### PR TITLE
Fix for bug #641821 - Version tolerant serialization fails with primitive typed members

### DIFF
--- a/mcs/class/corlib/Makefile
+++ b/mcs/class/corlib/Makefile
@@ -90,6 +90,8 @@ test-vts:
 		$(vtsdir)/$(vts)TestLib/4.0/Address.cs
 	$(MCS) -target:library \
 		$(vtsdir)/$(vts)TestLib/5.0/Address.cs
+	$(MCS) -target:library \
+		$(vtsdir)/$(vts)TestLib/6.0/Address.cs
 run-test-vts: test-vts
 	$(TEST_RUNTIME) $(RUNTIME_FLAGS) $(TEST_HARNESS) -noshadow \
 		$(vtsdir)/BinarySerializationOverVersions.exe 

--- a/mcs/class/corlib/System.Runtime.Serialization.Formatters.Binary/ObjectReader.cs
+++ b/mcs/class/corlib/System.Runtime.Serialization.Formatters.Binary/ObjectReader.cs
@@ -294,13 +294,22 @@ namespace System.Runtime.Serialization.Formatters.Binary
 				
 			info = metadata.NeedsSerializationInfo ? new SerializationInfo(metadata.Type, new FormatterConverter()) : null;
 
-   			if (metadata.MemberNames != null)
+			if (metadata.MemberNames != null) {
 				for (int n=0; n<metadata.FieldCount; n++)
 					ReadValue (reader, objectInstance, objectId, info, metadata.MemberTypes[n], metadata.MemberNames[n], null, null);
-			else
-				for (int n=0; n<metadata.FieldCount; n++)
+			} else
+				for (int n=0; n<metadata.FieldCount; n++) {
 					if (metadata.MemberInfos [n] != null)
-					ReadValue (reader, objectInstance, objectId, info, metadata.MemberTypes[n], metadata.MemberInfos[n].Name, metadata.MemberInfos[n], null);
+						ReadValue (reader, objectInstance, objectId, info, metadata.MemberTypes[n], metadata.MemberInfos[n].Name, metadata.MemberInfos[n], null);
+					else if (BinaryCommon.IsPrimitive(metadata.MemberTypes[n])) {
+						// Since the member info is null, the type in this
+						// domain does not have this type. Even though we
+						// are not going to store the value, we will read
+						// it from the stream so that we can advance to the
+						// next block.
+						ReadPrimitiveTypeValue (reader,	metadata.MemberTypes[n]);
+					}
+				}
 		}
 
 		private void RegisterObject (long objectId, object objectInstance, SerializationInfo info, long parentObjectId, MemberInfo parentObjectMemeber, int[] indices)

--- a/mcs/class/corlib/Test/System.Runtime.Serialization.Formatters.Binary/VersionTolerantSerialization/BinarySerializationOverVersions.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Serialization.Formatters.Binary/VersionTolerantSerialization/BinarySerializationOverVersions.cs
@@ -124,6 +124,18 @@ namespace MonoTests.System.Runtime.Serialization.Formatters.Binary
 			Deserialize ("4.0", Serialize ("5.0"));
 		}
 
+		[Test]
+		public void TestDroppedPrimitiveTypeField() //eliminate Id (int)
+		{
+			Deserialize ("5.0", Serialize ("6.0"));
+		}
+
+		[Test]
+		public void TestAddedPrimitiveTypeField () //add Id (int)
+		{
+			Deserialize ("6.0", Serialize ("5.0"));
+		}
+
 		private static string Serialize (string assemblyVersion)
 		{
 			return SerializeOOP (SetEnvironment (assemblyVersion)); ;

--- a/mcs/class/corlib/Test/System.Runtime.Serialization.Formatters.Binary/VersionTolerantSerialization/VersionTolerantSerializationTestLib/6.0/Address.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Serialization.Formatters.Binary/VersionTolerantSerialization/VersionTolerantSerializationTestLib/6.0/Address.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace VersionTolerantSerializationTestLib
+{
+	[Serializable]
+	public class Address
+	{
+		private string Street;
+		private string City;
+		private string CountryCode;
+
+		[OptionalField (VersionAdded = 4)]
+		private string PostCode;
+
+		[OptionalField (VersionAdded = 5)]
+		private string AreaCode = "0";
+
+		[OptionalField (VersionAdded = 6)]
+		private int Id = 0;
+	}
+}


### PR DESCRIPTION
https://bugzilla.novell.com/show_bug.cgi?id=641821

Details are in the bug report. 168f1ac3ff13b0514e2123e35b7debe9f966d670 provides a test that reproduces the issue as well as a proposed fix.

P.S. Sorry if sending a pull request is bad form, I'm new to hacking on mono and the GitFAQ page on the wiki suggested sending one.
