### PR TITLE
Turn off exception callback filtering on WoW64.

### DIFF
--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -41,6 +41,10 @@ static MonoW32ExceptionHandler segv_handler;
 
 static LPTOP_LEVEL_EXCEPTION_FILTER old_handler;
 
+#ifndef PROCESS_CALLBACK_FILTER_ENABLED
+#	define PROCESS_CALLBACK_FILTER_ENABLED 1
+#endif
+
 #define W32_SEH_HANDLE_EX(_ex) \
 	if (_ex##_handler) _ex##_handler(0, er, sctx)
 
@@ -833,6 +837,27 @@ mono_arch_get_throw_corlib_exception (void)
 void
 mono_arch_exceptions_init (void)
 {
+/* 
+ * If we're running WoW64, we need to set the usermode exception policy 
+ * for SEHs to behave. This requires hotfix http://support.microsoft.com/kb/976038
+ * or (eventually) Windows 7 SP1.
+ */
+#ifdef PLATFORM_WIN32
+	DWORD flags;
+	FARPROC getter;
+	FARPROC setter;
+	HMODULE kernel32 = LoadLibraryW (L"kernel32.dll");
+
+	if (kernel32) {
+		getter = GetProcAddress (kernel32, "GetProcessUserModeExceptionPolicy");
+		setter = GetProcAddress (kernel32, "SetProcessUserModeExceptionPolicy");
+		if (getter && setter) {
+			if (getter (&flags))
+				setter (flags & ~PROCESS_CALLBACK_FILTER_ENABLED);
+		}
+	}
+#endif
+
 	if (mono_aot_only) {
 		signal_exception_trampoline = mono_aot_get_named_code ("x86_signal_exception_trampoline");
 		return;


### PR DESCRIPTION
The LoadLibrary business is necessary because those are supposedly new API points that are created in the hotfix (and eventually in the service pack(s)).
