### PR TITLE
[API] Fixes bug 648888 (DataTypeAttributes.IsValid(object) should return true)

### DIFF
--- a/mcs/class/System.ComponentModel.DataAnnotations/System.ComponentModel.DataAnnotations/DataTypeAttribute.cs
+++ b/mcs/class/System.ComponentModel.DataAnnotations/System.ComponentModel.DataAnnotations/DataTypeAttribute.cs
@@ -74,10 +74,11 @@ namespace System.ComponentModel.DataAnnotations
 			return dt.ToString ();
 		}
 
-		[MonoTODO]
 		public override bool IsValid (object value)
 		{
-			throw new NotImplementedException ();
+			// Returns alwasy true 	
+			// See: http://msdn.microsoft.com/en-us/library/cc679235.aspx
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
Small fix (nearly one-liner) for https://bugzilla.novell.com/show_bug.cgi?id=648888.

This allows sample MVC projects to run out of the box, as they use DataTypeAttribute extensively.

PD: My last pull request attemp was messed with non-related (and already merged) comits.
