### PR TITLE
Encoded mail headers fix (RCF2047 compliance)

### DIFF
--- a/mcs/class/System/System.Net.Mime/ContentType.cs
+++ b/mcs/class/System/System.Net.Mime/ContentType.cs
@@ -208,7 +208,7 @@ namespace System.Net.Mime {
 		{
 			System.IO.StringWriter writer = new System.IO.StringWriter ();
 			foreach (byte i in bytes) {
-				if (i > 127 || i == '\t') {
+				if (i < 0x21 || i > 0x7E || i == '?' || i == '=' || i == '_') {
 					writer.Write ("=");
 					writer.Write (Convert.ToString (i, 16).ToUpper ());
 				} else


### PR DESCRIPTION
Hello,
 after some emails generated by mono were marked as spam by SpamAssassin I've noticed that the RCF2047 encoding was not compliant, as it was keeping spaces unencoded.

I've now fixed this and made sure that every non-printable ASCII value is escaped.

Thank you!
