### PR TITLE
Fix bug in BlockingCollection<T>.TryTake

### DIFF
--- a/mcs/class/System/System.Collections.Concurrent/BlockingCollection.cs
+++ b/mcs/class/System/System.Collections.Concurrent/BlockingCollection.cs
@@ -269,6 +269,7 @@ namespace System.Collections.Concurrent
 
 				if (!mreRemove.IsSet)
 					mreRemove.Set ();
+				return true;
 			} while (contFunc ());
 
 			return false;

--- a/mcs/class/System/Test/System.Collections.Concurrent/BlockingCollectionTests.cs
+++ b/mcs/class/System/Test/System.Collections.Concurrent/BlockingCollectionTests.cs
@@ -166,6 +166,22 @@ namespace MonoTests.System.Collections.Concurrent
 			}
 			Assert.AreEqual(0, defaultCollection.Count, "#" + i);
 		}
+
+		[TestAttribute]
+		public void TryTakeTestCase ()
+		{
+			defaultCollection.Add (1);
+
+			int value = default (int);
+			bool firstTake = defaultCollection.TryTake (out value);
+			int value2 = default (int);
+			bool secondTake = defaultCollection.TryTake (out value2);
+
+			Assert.AreEqual (1, value);
+			Assert.IsTrue (firstTake);
+			Assert.AreEqual (default (int), value2);
+			Assert.IsFalse (secondTake);
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Hi,

I've fixed a problem in BlockingCollection<T>.TryTake which was always returning false.
I've added a small unit test to verify that behavior.

It's my first time with git and github and contribution to OSS, please advise me of any mistake I've done for this pull request.

Best regards,
Guillaume Pouillet
