### PR TITLE
mdoc: display property getters before setters

### DIFF
--- a/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
+++ b/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
@@ -1893,6 +1893,8 @@ class MDocUpdater : MDocCommand
 		"System.Runtime.CompilerServices.ExtensionAttribute",
 		// Used to differentiate 'object' from C#4 'dynamic'
 		"System.Runtime.CompilerServices.DynamicAttribute",
+		// Used in code contracts' object invariants (should not be accessed directly)
+		"System.Diagnostics.Contracts.ContractInvariantMethodAttribute",
 	};
 
 	private void MakeAttributes (XmlElement root, IEnumerable<string> attributes)


### PR DESCRIPTION
I believe this is the more 'standard' way to display property accessors.
