### PR TITLE
Make the new profiler build on Darwin

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -14,6 +14,8 @@ if JIT_SUPPORTED
 if PLATFORM_LINUX
 bin_PROGRAMS = mprof-report
 lib_LTLIBRARIES = libmono-profiler-cov.la libmono-profiler-aot.la libmono-profiler-iomap.la libmono-profiler-log.la
+else if PLATFORM_DARWIN
+libmono_profiler_log_la_LDFLAGS = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
 else
 bin_PROGRAMS = mprof-report
 lib_LTLIBRARIES = libmono-profiler-cov.la libmono-profiler-aot.la libmono-profiler-iomap.la libmono-profiler-log.la


### PR DESCRIPTION
This patches the Makefile.am in the profiler subdirectory to get the profiler to run correctly on Darwin platforms. This is the same patch as described in the following mailing list thread: http://lists.ximian.com/pipermail/mono-devel-list/2010-December/036469.html.
