### PR TITLE
Fix for bug 349053 (unable to serialize SortedDictionary)

### DIFF
--- a/mcs/class/System/System.Collections.Generic/SortedDictionary.cs
+++ b/mcs/class/System/System.Collections.Generic/SortedDictionary.cs
@@ -35,13 +35,15 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
 
 namespace System.Collections.Generic
 {
 	[Serializable]
 	[DebuggerDisplay ("Count={Count}")]
 	[DebuggerTypeProxy (typeof (CollectionDebuggerView<,>))]
-	public class SortedDictionary<TKey,TValue> : IDictionary<TKey,TValue>, ICollection<KeyValuePair<TKey,TValue>>, IEnumerable<KeyValuePair<TKey,TValue>>, IDictionary, ICollection, IEnumerable
+	public class SortedDictionary<TKey,TValue> : IDictionary<TKey,TValue>, ICollection<KeyValuePair<TKey,TValue>>, IEnumerable<KeyValuePair<TKey,TValue>>, IDictionary, ICollection, IEnumerable, ISerializable
 	{
 		class Node : RBTree.Node {
 			public TKey key;
@@ -76,6 +78,7 @@ namespace System.Collections.Generic
 			}
 		}
 
+		[Serializable]
 		class NodeHelper : RBTree.INodeHelper<TKey> {
 			public IComparer<TKey> cmp;
 
@@ -127,6 +130,17 @@ namespace System.Collections.Generic
 			foreach (KeyValuePair<TKey, TValue> entry in dic)
 				Add (entry.Key, entry.Value);
 		}
+
+		protected SortedDictionary (SerializationInfo info, StreamingContext context)
+		{
+			hlp = (NodeHelper)info.GetValue("Helper", typeof(NodeHelper));
+			tree = new RBTree (hlp);
+
+			KeyValuePair<TKey, TValue> [] data = (KeyValuePair<TKey, TValue>[])info.GetValue("KeyValuePairs", typeof(KeyValuePair<TKey, TValue>[]));
+			foreach (KeyValuePair<TKey, TValue> entry in data)
+				Add(entry.Key, entry.Value);
+		}
+
 		#endregion
 
 		#region PublicProperty
@@ -226,6 +240,18 @@ namespace System.Collections.Generic
 			return n != null;
 		}
 
+		[SecurityPermission (SecurityAction.LinkDemand, Flags=SecurityPermissionFlag.SerializationFormatter)]
+		public virtual void GetObjectData (SerializationInfo info, StreamingContext context)
+		{
+			if (info == null)
+				throw new ArgumentNullException ("info");
+
+			KeyValuePair<TKey, TValue> [] data = new KeyValuePair<TKey,TValue> [Count];
+			CopyTo (data, 0);
+			info.AddValue ("KeyValuePairs", data);
+			info.AddValue ("Helper", hlp);
+		}
+
 		#endregion
 
 		#region PrivateMethod
@@ -280,7 +306,7 @@ namespace System.Collections.Generic
 		{
 			TValue value;
 			return TryGetValue (item.Key, out value) &&
- 				EqualityComparer<TValue>.Default.Equals (item.Value, value) &&
+				EqualityComparer<TValue>.Default.Equals (item.Value, value) &&
 				Remove (item.Key);
 		}
 
@@ -466,7 +492,7 @@ namespace System.Collections.Generic
 
 			IEnumerator IEnumerable.GetEnumerator ()
 			{
- 				return new Enumerator (_dic);
+				return new Enumerator (_dic);
 			}
 
 			public struct Enumerator : IEnumerator<TValue>,IEnumerator, IDisposable
@@ -601,7 +627,7 @@ namespace System.Collections.Generic
 
 			IEnumerator IEnumerable.GetEnumerator ()
 			{
- 				return new Enumerator (_dic);
+				return new Enumerator (_dic);
 			}
 
 			public struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable


### PR DESCRIPTION
Just needed to implement ISerializable on the SortedDictionary (RBTree stuff isn't serializable so the attribute-based method would have been much more work).

My first time with Git, so I made this more complicated than it should have been:
1st commit here fixes it
2nd one undoes that (oops!)
3rd one redoes it

:)
