### PR TITLE
[eglib] Fix broken g_int_hash/g_int_equal semantics

### DIFF
--- a/eglib/src/ghashtable.c
+++ b/eglib/src/ghashtable.c
@@ -579,13 +579,13 @@ g_direct_hash (gconstpointer v1)
 gboolean
 g_int_equal (gconstpointer v1, gconstpointer v2)
 {
-	return GPOINTER_TO_INT (v1) == GPOINTER_TO_INT (v2);
+	return *(gint *)v1 == *(gint *)v2;
 }
 
 guint
 g_int_hash (gconstpointer v1)
 {
-	return GPOINTER_TO_UINT(v1);
+	return *(guint *)v1;
 }
 
 gboolean


### PR DESCRIPTION
Ran into this today when my hash tables weren't working.
