### PR TITLE
Seting custom InteractiveBase class in Mono.Csharp Evaluator should be allowed after Evaluator init

### DIFF
--- a/mcs/mcs/eval.cs
+++ b/mcs/mcs/eval.cs
@@ -191,6 +191,9 @@ namespace Mono.CSharp
 			if (type == null)
 				throw new ArgumentNullException ();
 
+			if (!inited)
+				throw new Exception ("Evaluator has to be initiated before seting custom InteractiveBase class");
+
 			lock (evaluator_lock)
 				interactive_base_class = loader.Importer.ImportType (type);
 		}


### PR DESCRIPTION
Otherwise not very helpful 'null reference exception' will happen in SetInteractiveBaseClass method (mono/mcs/mcs/eval.cs)
