### PR TITLE
Fix for sgen on PPC Linux

### DIFF
--- a/mono/metadata/sgen-archdep.h
+++ b/mono/metadata/sgen-archdep.h
@@ -107,12 +107,21 @@
 #define REDZONE_SIZE	224
 
 #define ARCH_NUM_REGS 32
+#ifdef __APPLE__
 #define ARCH_STORE_REGS(ptr)	\
 	__asm__ __volatile__(	\
 		"stmw r0, 0(%0)\n"	\
 		:			\
 		: "b" (ptr)		\
 	)
+#else
+#define ARCH_STORE_REGS(ptr)	\
+	__asm__ __volatile__(	\
+		"stmw 0, 0(%0)\n"	\
+		:			\
+		: "b" (ptr)		\
+	)
+#endif
 #define ARCH_SIGCTX_SP(ctx)	(UCONTEXT_REG_Rn((ctx), 1))
 #define ARCH_SIGCTX_IP(ctx)	(UCONTEXT_REG_NIP((ctx)))
 #define ARCH_COPY_SIGCTX_REGS(a,ctx) do {	\


### PR DESCRIPTION
This is a follow-up to 4a812850f8af46161953

sgen fails to build on PPC Linux, because the assembler code included from mono/metadata/sgen-archdep.h assumes OSX register naming conventions. On Linux, the register r0 should be named 0, unless building with -Xassembler -mregnames as flags to gcc.

The style of checking for **APPLE** is taken from mono/mini/mini-ppc.h, which picks between using assembler with "r1" and "1" on that basis.
