### PR TITLE
PerformanceCounter support on OS X

### DIFF
--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -18,7 +18,9 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/proc.h>
+#if defined(__APPLE__)
 #include <mach/mach.h>
+#endif
 #ifdef HAVE_SYS_USER_H
 #include <sys/user.h>
 #endif


### PR DESCRIPTION
This patch adds support for:
PerformanceCounter("Process", "% Processor Time", "<process id>")
