### PR TITLE
Darwin/static build fixes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2886,7 +2886,7 @@ fi
 # When --disable-shared is used, libtool transforms libmono-2.0.la into libmono-2.0.so
 # instead of libmono-static.a
 if test "x$enable_shared" = "xno"; then
-   LIBMONO_LA=.libs/libmono-static.a
+   LIBMONO_LA=libmini-static.la
 else
    LIBMONO_LA=libmono-$API_VER.la
 fi

--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -5,7 +5,18 @@ export HOST_CC
 endif
 
 if JIT_SUPPORTED
+if !SHARED_MONO
+static_libs=	\
+	$(top_builddir)/mono/metadata/libmonoruntime-static.la	\
+	$(top_builddir)/mono/io-layer/libwapi.la	\
+	$(top_builddir)/mono/utils/libmonoutils.la \
+	$(GLIB_LIBS) $(LIBICONV) \
+	$(LIBGC_STATIC_LIBS)
+
+runtime_lib=../mini/$(LIBMONO_LA) $(static_libs)
+else
 runtime_lib=../mini/$(LIBMONO_LA)
+endif
 else
 runtime_lib=../interpreter/libmint.la
 endif

--- a/mono/monograph/Makefile.am
+++ b/mono/monograph/Makefile.am
@@ -4,7 +4,18 @@ export HOST_CC
 endif
 
 if JIT_SUPPORTED
+if !SHARED_MONO
+static_libs=	\
+	$(top_builddir)/mono/metadata/libmonoruntime-static.la	\
+	$(top_builddir)/mono/io-layer/libwapi.la	\
+	$(top_builddir)/mono/utils/libmonoutils.la \
+	$(GLIB_LIBS) $(LIBICONV) \
+	$(LIBGC_STATIC_LIBS)
+
+runtime_lib=../mini/$(LIBMONO_LA) $(static_libs)
+else
 runtime_lib=../mini/$(LIBMONO_LA)
+endif
 else
 runtime_lib=../interpreter/libmint.la
 endif

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -24,7 +24,18 @@ if HAVE_OPROFILE
 endif
 
 if SUPPORT_BOEHM
-LIBMONO=$(top_builddir)/mono/mini/libmono-$(API_VER).la
+if !SHARED_MONO
+static_libs=	\
+	$(top_builddir)/mono/metadata/libmonoruntime-static.la	\
+	$(top_builddir)/mono/io-layer/libwapi.la	\
+	$(top_builddir)/mono/utils/libmonoutils.la \
+	$(GLIB_LIBS) $(LIBICONV) \
+	$(LIBGC_STATIC_LIBS)
+
+LIBMONO=$(top_builddir)/mono/mini/$(LIBMONO_LA) $(static_libs)
+else
+LIBMONO=$(top_builddir)/mono/mini/$(LIBMONO_LA)
+endif
 else
 LIBMONO=$(top_builddir)/mono/mini/libmonosgen-$(API_VER).la
 endif


### PR DESCRIPTION
Hi,

Without these, `./configure --enable-static --disable-shared … && make` fails on Mac OS X (but I believe the second fix is not OS-specific).

I cargo-culted the solutions from other `Makefile.am`s.

Cheers, -D
