### PR TITLE
TimeZoneInfo fix

### DIFF
--- a/mcs/class/System.Core/System/TimeZoneInfo.cs
+++ b/mcs/class/System.Core/System/TimeZoneInfo.cs
@@ -232,7 +232,7 @@ namespace System
 
 			AdjustmentRule rule = GetApplicableRule (dateTime);
 		
-			if (IsDaylightSavingTime (DateTime.SpecifyKind (dateTime, DateTimeKind.Utc)))
+			if (rule != null && IsDaylightSavingTime (DateTime.SpecifyKind (dateTime, DateTimeKind.Utc)))
 				return DateTime.SpecifyKind (dateTime + BaseUtcOffset + rule.DaylightDelta , DateTimeKind.Unspecified);
 			else
 				return DateTime.SpecifyKind (dateTime + BaseUtcOffset, DateTimeKind.Unspecified);
@@ -282,7 +282,10 @@ namespace System
 				return DateTime.SpecifyKind (dateTime - sourceTimeZone.BaseUtcOffset, DateTimeKind.Utc);
 			else {
 				AdjustmentRule rule = sourceTimeZone.GetApplicableRule (dateTime);
-				return DateTime.SpecifyKind (dateTime - sourceTimeZone.BaseUtcOffset - rule.DaylightDelta, DateTimeKind.Utc);
+				if (rule != null)
+					return DateTime.SpecifyKind (dateTime - sourceTimeZone.BaseUtcOffset - rule.DaylightDelta, DateTimeKind.Utc);
+				else
+					return DateTime.SpecifyKind (dateTime - sourceTimeZone.BaseUtcOffset, DateTimeKind.Utc);
 			}
 		}
 
@@ -482,7 +485,10 @@ namespace System
 				throw new ArgumentException ("dateTime is not an ambiguous time");
 
 			AdjustmentRule rule = GetApplicableRule (dateTime);
-			return new TimeSpan[] {baseUtcOffset, baseUtcOffset + rule.DaylightDelta};
+			if (rule != null)
+				return new TimeSpan[] {baseUtcOffset, baseUtcOffset + rule.DaylightDelta};
+			else
+				return new TimeSpan[] {baseUtcOffset, baseUtcOffset};
 		}
 
 		public TimeSpan [] GetAmbiguousTimeOffsets (DateTimeOffset dateTimeOffset)
@@ -559,7 +565,8 @@ namespace System
 		{
 			if (IsDaylightSavingTime (dateTime)) {
 				AdjustmentRule rule = GetApplicableRule (dateTime);
-				return BaseUtcOffset + rule.DaylightDelta;
+				if (rule != null)
+					return BaseUtcOffset + rule.DaylightDelta;
 			}
 			
 			return BaseUtcOffset;
@@ -610,9 +617,11 @@ namespace System
 				dateTime = ConvertTime (dateTime, TimeZoneInfo.Local, this);
 
 			AdjustmentRule rule = GetApplicableRule (dateTime);
-			DateTime tpoint = TransitionPoint (rule.DaylightTransitionEnd, dateTime.Year);
-			if (dateTime > tpoint - rule.DaylightDelta  && dateTime <= tpoint)
-				return true;
+			if (rule != null) {
+				DateTime tpoint = TransitionPoint (rule.DaylightTransitionEnd, dateTime.Year);
+				if (dateTime > tpoint - rule.DaylightDelta  && dateTime <= tpoint)
+					return true;
+			}
 				
 			return false;
 		}
@@ -667,9 +676,11 @@ namespace System
 				return false;
 
 			AdjustmentRule rule = GetApplicableRule (dateTime);
-			DateTime tpoint = TransitionPoint (rule.DaylightTransitionStart, dateTime.Year);
-			if (dateTime >= tpoint && dateTime < tpoint + rule.DaylightDelta)
-				return true;
+			if (rule != null) {
+				DateTime tpoint = TransitionPoint (rule.DaylightTransitionStart, dateTime.Year);
+				if (dateTime >= tpoint && dateTime < tpoint + rule.DaylightDelta)
+					return true;
+			}
 				
 			return false;
 		}


### PR DESCRIPTION
This code:
   TimeZoneInfo pstTimeZone = TimeZoneInfo.FindSystemTimeZoneById(tzName);
   TimezoneOffset = TimeZoneInfo.Local.GetUtcOffset(now) - pstTimeZone.GetUtcOffset(now);

Would fail with this stack trace:
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object
at System.TimeZoneInfo.IsInvalidTime (System.DateTime) <0x000ad>
at System.TimeZoneInfo.IsDaylightSavingTime (System.DateTime) <0x000ba>
at System.TimeZoneInfo.GetUtcOffset (System.DateTime) <0x00023>

Because GetApplicableRule returns NULL yet the code does not handle a NULL return.  I fixed all cases in TimeZoneInfo.cs that failed this check.
