### PR TITLE
add BinaryFormatter.DefaultSurrogateselector

### DIFF
--- a/mcs/class/corlib/System.Runtime.Serialization.Formatters.Binary/BinaryFormatter.cs
+++ b/mcs/class/corlib/System.Runtime.Serialization.Formatters.Binary/BinaryFormatter.cs
@@ -48,7 +48,7 @@ namespace System.Runtime.Serialization.Formatters.Binary {
 		
 		public BinaryFormatter()
 		{
-			surrogate_selector=null;
+			surrogate_selector=DefaultSurrogateSelector;
 			context=new StreamingContext(StreamingContextStates.All);
 		}
 		
@@ -57,7 +57,9 @@ namespace System.Runtime.Serialization.Formatters.Binary {
 			surrogate_selector=selector;
 			this.context=context;
 		}
-
+		
+		static ISurrogateSelector DefaultSurrogateSelector { get; set; }
+		
 		public FormatterAssemblyStyle AssemblyFormat
 		{
 			get {


### PR DESCRIPTION
Implement a private BinaryFormatter.DefaultSurrogateSelector, which enables embedders who want to make a sandbox, to specify a default surrogate selector, which is required to get the BinaryFormatter be able to operate within a CoreCLR environment.

Usecase: webgame powered by mono talking to a server powered by mono, that want to exchange serialized objects over a socket connection.  Deserializing a List<T> is not possible within the CoreCLR limitations, However a custom surrogateselector can be set by a sandboxing app that implements deserialization of List<T> and other specific types in a different way that does fit within the coreclr sandbox.

It is private so we dont add public api that we do not want to expose. Embedders that want to use this can set the DefaultSurrogateSelector using reflection.
