### PR TITLE
Fix a couple bugs in TaskScheduler and Task

### DIFF
--- a/mcs/class/corlib/System.Threading.Tasks/Task.cs
+++ b/mcs/class/corlib/System.Threading.Tasks/Task.cs
@@ -356,7 +356,8 @@ namespace System.Threading.Tasks
 			status = TaskStatus.WaitingToRun;
 			
 			// If worker is null it means it is a local one, revert to the old behavior
-			if (childWorkAdder == null || CheckTaskOptions (taskCreationOptions, TaskCreationOptions.PreferFairness)) {
+			// If TaskScheduler.Current is not being used, the scheduler was explicitly provided, so we must use that
+			if (scheduler != TaskScheduler.Current || childWorkAdder == null || CheckTaskOptions (taskCreationOptions, TaskCreationOptions.PreferFairness)) {
 				scheduler.QueueTask (this);
 			} else {
 				/* Like the semantic of the ABP paper describe it, we add ourselves to the bottom 

--- a/mcs/class/corlib/System.Threading.Tasks/TaskScheduler.cs
+++ b/mcs/class/corlib/System.Threading.Tasks/TaskScheduler.cs
@@ -113,7 +113,15 @@ namespace System.Threading.Tasks
 
 		internal protected bool TryExecuteTask (Task task)
 		{
-			return TryExecuteTaskInline (task, false);
+			if (task.IsCompleted)
+				return false;
+
+			if (task.Status == TaskStatus.WaitingToRun) {
+				task.Execute (null);
+				return true;
+			}
+
+			return false;
 		}
 
 		protected abstract bool TryExecuteTaskInline (Task task, bool taskWasPreviouslyQueued);

--- a/mcs/class/corlib/System.Threading.Tasks/TpScheduler.cs
+++ b/mcs/class/corlib/System.Threading.Tasks/TpScheduler.cs
@@ -57,15 +57,7 @@ namespace System.Threading.Tasks
 
 		protected override bool TryExecuteTaskInline (Task task, bool taskWasPreviouslyQueued)
 		{
-			if (task.IsCompleted)
-				return false;
-
-			if (task.Status == TaskStatus.WaitingToRun) {
-				task.Execute (null);
-				return true;
-			}
-
-			return false;
+		    return TryExecuteTask(task);
 		}
 
 		public override int MaximumConcurrencyLevel {


### PR DESCRIPTION
submitted under MIT license.

I did NOT run tests, as for some reason my Mono checkout just SIGSEGV's quite beautifully when calling make run-test.
