### PR TITLE
Use the sourceLevels parameter to the TraceSource constructor to initialize the trace source

### DIFF
--- a/mcs/class/System/System.Diagnostics/TraceSource.cs
+++ b/mcs/class/System/System.Diagnostics/TraceSource.cs
@@ -54,6 +54,7 @@ namespace System.Diagnostics
 			Hashtable sources = DiagnosticsConfiguration.Settings ["sources"] as Hashtable;
 			TraceSourceInfo info = sources != null ? sources [name] as TraceSourceInfo : null;
 			source_switch = new SourceSwitch (name);
+			source_switch.Level = sourceLevels
 
 			if (info == null)
 				listeners = new TraceListenerCollection ();


### PR DESCRIPTION
Consider the following test program:

```
using System;
using System.Diagnostics;

public class Foo
{
public static void Main()
{
    var t = new TraceSource("Test", SourceLevels.All);
    Console.WriteLine(t.Switch.Level.ToString());
}
}
```

If you run this using Microsoft.NET, it prints "All".  If you run it with mono, mono prints "Off".
