### PR TITLE
Implemented IDisposable on System.Security.Cryptography.DeriveBytes

### DIFF
--- a/mcs/class/corlib/System.Security.Cryptography/DeriveBytes.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/DeriveBytes.cs
@@ -31,8 +31,9 @@ using System.Runtime.InteropServices;
 namespace System.Security.Cryptography {
 
 	[ComVisible (true)]
-	public abstract class DeriveBytes {
-	
+	public abstract class DeriveBytes : IDisposable {
+		private bool m_disposed;
+
 		protected DeriveBytes ()
 		{
 		}
@@ -40,5 +41,20 @@ namespace System.Security.Cryptography {
 		public abstract byte[] GetBytes (int cb);
 
 		public abstract void Reset ();
+
+		void IDisposable.Dispose()
+		{
+			Dispose(true);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if (!m_disposed) {
+				if (disposing) {
+					// dispose managed objects
+				}
+				m_disposed = true;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Implemented IDisposable on System.Security.Cryptography.DeriveBytes to match the .Net 4.0 implementation.

Followed the same pattern as is in the SymmetricAlgorithm class (minus the finalizer).  Dispose method doesn't do anything, just there to allow instances to be used in a using statement at this point.

Noticed the difference when the Nancy build failed on Mono.  This fixed the build failure.
