### PR TITLE
Nunit25/2011 04 11

### DIFF
--- a/mcs/class/System.Data/Test/System.Data/ConstraintCollectionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/ConstraintCollectionTest.cs
@@ -31,8 +31,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
-
 using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
 using System;
@@ -41,73 +39,71 @@ using System.Data;
 namespace MonoTests.System.Data
 {
 	[TestFixture]
-	public class ConstraintCollectionTest {
+	public class ConstraintCollectionTest
+	{
 		private DataTable _table;
 		private DataTable _table2;
 		private Constraint _constraint1;
 		private Constraint _constraint2;
 
 		[SetUp]
-		public void GetReady() 
+		public void GetReady ()
 		{
 			//Setup DataTable
-			_table = new DataTable("TestTable");
-			_table.Columns.Add("Col1",typeof(int));
-			_table.Columns.Add("Col2",typeof(int));
-			_table.Columns.Add("Col3",typeof(int));
+			_table = new DataTable ("TestTable");
+			_table.Columns.Add ("Col1", typeof(int));
+			_table.Columns.Add ("Col2", typeof(int));
+			_table.Columns.Add ("Col3", typeof(int));
 
-			_table2 = new DataTable("TestTable");
-			_table2.Columns.Add("Col1",typeof(int));
-			_table2.Columns.Add("Col2",typeof(int));
+			_table2 = new DataTable ("TestTable");
+			_table2.Columns.Add ("Col1", typeof(int));
+			_table2.Columns.Add ("Col2", typeof(int));
 
 			//Use UniqueConstraint to test Constraint Base Class
-			_constraint1 = new UniqueConstraint(_table.Columns[0],false); 
-			_constraint2 = new UniqueConstraint(_table.Columns[1],false); 
+			_constraint1 = new UniqueConstraint (_table.Columns [0], false); 
+			_constraint2 = new UniqueConstraint (_table.Columns [1], false); 
 
 			// not sure why this is needed since a new _table was just created
 			// for us, but this Clear() keeps the tests from throwing
 			// an exception when the Add() is called.
-			_table.Constraints.Clear();
+			_table.Constraints.Clear ();
 		}
 
 		[Test]
-		public void Add()
+		public void Add ()
 		{
 			ConstraintCollection col = _table.Constraints;
-			col.Add(_constraint1);
-			col.Add(_constraint2);
+			col.Add (_constraint1);
+			col.Add (_constraint2);
 
-			Assert.That(col.Count, Is.EqualTo(2), "Count doesn't equal added.");
+			Assert.That (col.Count, Is.EqualTo (2), "Count doesn't equal added.");
 		}
 
 		[Test]
-		public void AddExceptions()
+		public void AddExceptions ()
 		{
 			ConstraintCollection col = _table.Constraints;
 			
 			//null
-			try 
-			{
-				col.Add(null);
-				Assert.Fail("B1: Failed to throw ArgumentNullException.");
-			}
-			catch (ArgumentNullException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch 
-			{
-				Assert.Fail("A1: Wrong exception type");
+			try {
+				col.Add (null);
+				Assert.Fail ("B1: Failed to throw ArgumentNullException.");
+			} catch (ArgumentNullException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch {
+				Assert.Fail ("A1: Wrong exception type");
 			}
 
 			//duplicate name
-			try 
-			{
+			try {
 				_constraint1.ConstraintName = "Dog";
 				_constraint2.ConstraintName = "dog"; //case insensitive
-				col.Add(_constraint1);
-				col.Add(_constraint2);
+				col.Add (_constraint1);
+				col.Add (_constraint2);
 #if NET_1_1
 #else
-				Assert.Fail("Failed to throw Duplicate name exception.");
+				Assert.Fail ("Failed to throw Duplicate name exception.");
 #endif
 				col.Remove (_constraint2); // only for !1.0
 				col.Remove (_constraint1);
@@ -116,7 +112,9 @@ namespace MonoTests.System.Data
 			catch (DuplicateNameException) {
 			}
 #endif
-			catch (AssertionException exc) {throw exc;}
+			catch (AssertionException exc) {
+				throw exc;
+			}
 /* Don't use such catch. They cover our eyes from the exact exception location.
 			catch (Exception exc)
 			{
@@ -124,316 +122,292 @@ namespace MonoTests.System.Data
 			}
 */
 			//Constraint Already exists
-			try 
-			{
-				col.Add(_constraint1);
+			try {
+				col.Add (_constraint1);
 #if NET_1_1
 #else
-				Assert.Fail("B2: Failed to throw ArgumentException.");
+				Assert.Fail ("B2: Failed to throw ArgumentException.");
 #endif
 				col.Remove (_constraint1);
-			}
-			catch (ArgumentException) {
+			} catch (ArgumentException) {
 #if NET_1_1
 #else
 				throw;
 #endif
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch {
+				Assert.Fail ("A3: Wrong exception type");
 			}
-			catch (AssertionException exc) {throw exc;}
-			catch 
-			{
-				Assert.Fail("A3: Wrong exception type");
-			}
 		}
 
 		[Test]
-		public void Indexer()
+		public void Indexer ()
 		{
-			Constraint c1 = new UniqueConstraint(_table.Columns[0]);
-			Constraint c2 = new UniqueConstraint(_table.Columns[1]);
+			Constraint c1 = new UniqueConstraint (_table.Columns [0]);
+			Constraint c2 = new UniqueConstraint (_table.Columns [1]);
 
 			c1.ConstraintName = "first";
 			c2.ConstraintName = "second";
 
 
-			_table.Constraints.Add(c1);
-			_table.Constraints.Add(c2);
+			_table.Constraints.Add (c1);
+			_table.Constraints.Add (c2);
 
-			Assert.AreSame(c1, _table.Constraints[0], "A1"); 
-			Assert.AreSame(c2, _table.Constraints[1], "A2");
+			Assert.AreSame (c1, _table.Constraints [0], "A1"); 
+			Assert.AreSame (c2, _table.Constraints [1], "A2");
 
-			Assert.AreSame(c1, _table.Constraints["first"], "A3");
-			Assert.AreSame(c2, _table.Constraints["sEcond"], "A4"); //case insensitive
+			Assert.AreSame (c1, _table.Constraints ["first"], "A3");
+			Assert.AreSame (c2, _table.Constraints ["sEcond"], "A4"); //case insensitive
 
 		}
 
 		[Test]
-		public void IndexOf()
+		public void IndexOf ()
 		{
-			Constraint c1 = new UniqueConstraint(_table.Columns[0]);
-			Constraint c2 = new UniqueConstraint(_table.Columns[1]);
+			Constraint c1 = new UniqueConstraint (_table.Columns [0]);
+			Constraint c2 = new UniqueConstraint (_table.Columns [1]);
 
 			c1.ConstraintName = "first";
 			c2.ConstraintName = "second";
 
-			_table.Constraints.Add(c1);
-			_table.Constraints.Add(c2);
+			_table.Constraints.Add (c1);
+			_table.Constraints.Add (c2);
 
-			Assert.AreEqual(0, _table.Constraints.IndexOf(c1), "A1");
-			Assert.AreEqual(1, _table.Constraints.IndexOf(c2), "A2");
-			Assert.AreEqual(0, _table.Constraints.IndexOf("first"), "A3");
-			Assert.AreEqual(1, _table.Constraints.IndexOf("second"), "A4");
+			Assert.AreEqual (0, _table.Constraints.IndexOf (c1), "A1");
+			Assert.AreEqual (1, _table.Constraints.IndexOf (c2), "A2");
+			Assert.AreEqual (0, _table.Constraints.IndexOf ("first"), "A3");
+			Assert.AreEqual (1, _table.Constraints.IndexOf ("second"), "A4");
 		}
 
 		[Test]
-		public void Contains()
+		public void Contains ()
 		{
-			Constraint c1 = new UniqueConstraint(_table.Columns[0]);
-			Constraint c2 = new UniqueConstraint(_table.Columns[1]);
+			Constraint c1 = new UniqueConstraint (_table.Columns [0]);
+			Constraint c2 = new UniqueConstraint (_table.Columns [1]);
 
 			c1.ConstraintName = "first";
 			c2.ConstraintName = "second";
 
-			_table.Constraints.Add(c1);
+			_table.Constraints.Add (c1);
 
-			Assert.That(_table.Constraints.Contains(c1.ConstraintName), Is.True);
-			Assert.That(_table.Constraints.Contains(c2.ConstraintName), Is.False);
+			Assert.That (_table.Constraints.Contains (c1.ConstraintName), Is.True);
+			Assert.That (_table.Constraints.Contains (c2.ConstraintName), Is.False);
 		}
 
 		[Test]
-		public void IndexerFailures()
+		public void IndexerFailures ()
 		{
-			_table.Constraints.Add(new UniqueConstraint(_table.Columns[0]));
+			_table.Constraints.Add (new UniqueConstraint (_table.Columns [0]));
 
 			//This doesn't throw
-			Assert.That(_table.Constraints["notInCollection"], Is.Null);
+			Assert.That (_table.Constraints ["notInCollection"], Is.Null);
 			
 			//Index too high
-			try 
-			{
-				Constraint c = _table.Constraints[_table.Constraints.Count];
-				Assert.Fail("B1: Failed to throw IndexOutOfRangeException.");
-			}
-			catch (IndexOutOfRangeException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch 
-			{
-				Assert.Fail("A1: Wrong exception type");
+			try {
+				Constraint c = _table.Constraints [_table.Constraints.Count];
+				Assert.Fail ("B1: Failed to throw IndexOutOfRangeException.");
+			} catch (IndexOutOfRangeException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch {
+				Assert.Fail ("A1: Wrong exception type");
 			}
 
 			//Index too low
-			try 
-			{
-				Constraint c = _table.Constraints[-1];
-				Assert.Fail("B2: Failed to throw IndexOutOfRangeException.");
-			}
-			catch (IndexOutOfRangeException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch 
-			{
-				Assert.Fail("A2: Wrong exception type");
+			try {
+				Constraint c = _table.Constraints [-1];
+				Assert.Fail ("B2: Failed to throw IndexOutOfRangeException.");
+			} catch (IndexOutOfRangeException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch {
+				Assert.Fail ("A2: Wrong exception type");
 			}	
-
 		}
 
 		[Test]
-		public void AddFkException1()
+		public void AddFkException1 ()
 		{
-			DataSet ds = new DataSet();
-			ds.Tables.Add(_table);
+			DataSet ds = new DataSet ();
+			ds.Tables.Add (_table);
 			_table2.TableName = "TestTable2";
-			ds.Tables.Add(_table2);
+			ds.Tables.Add (_table2);
 
-			_table.Rows.Add(new object [] {1});
-			_table.Rows.Add(new object [] {1});
+			_table.Rows.Add (new object [] {1});
+			_table.Rows.Add (new object [] {1});
 
 			//FKC: can't create unique constraint because duplicate values already exist
-			try
-			{
-				ForeignKeyConstraint fkc = new ForeignKeyConstraint( _table.Columns[0],
-											_table2.Columns[0]);
+			try {
+				ForeignKeyConstraint fkc = new ForeignKeyConstraint (_table.Columns [0],
+											_table2.Columns [0]);
 				
-				_table2.Constraints.Add(fkc);	//should throw			
-				Assert.Fail("B1: Failed to throw ArgumentException.");
+				_table2.Constraints.Add (fkc);	//should throw			
+				Assert.Fail ("B1: Failed to throw ArgumentException.");
+			} catch (ArgumentException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch (Exception exc) {
+				Assert.Fail ("A1: Wrong Exception type. " + exc.ToString ());
 			}
-			catch (ArgumentException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch (Exception exc)
-			{
-				Assert.Fail("A1: Wrong Exception type. " + exc.ToString());
-			}
-
-
 		}
 
-
 		[Test]
-		public void AddFkException2()
+		public void AddFkException2 ()
 		{
 			//Foreign key rules only work when the tables
 			//are apart of the dataset
-			DataSet ds = new DataSet();
-			ds.Tables.Add(_table);
+			DataSet ds = new DataSet ();
+			ds.Tables.Add (_table);
 			_table2.TableName = "TestTable2";
-			ds.Tables.Add(_table2);
+			ds.Tables.Add (_table2);
 
-			_table.Rows.Add(new object [] {1});
+			_table.Rows.Add (new object [] {1});
 			
 			// will need a matching parent value in 
 			// _table
-			_table2.Rows.Add(new object [] {3}); 
+			_table2.Rows.Add (new object [] {3}); 
 								
 
 			//FKC: no matching parent value
-			try
-			{
-				ForeignKeyConstraint fkc = new ForeignKeyConstraint( _table.Columns[0],
-					_table2.Columns[0]);
+			try {
+				ForeignKeyConstraint fkc = new ForeignKeyConstraint (_table.Columns [0],
+					_table2.Columns [0]);
 				
-				_table2.Constraints.Add(fkc);	//should throw			
-				Assert.Fail("B1: Failed to throw ArgumentException.");
+				_table2.Constraints.Add (fkc);	//should throw			
+				Assert.Fail ("B1: Failed to throw ArgumentException.");
+			} catch (ArgumentException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch (Exception exc) {
+				Assert.Fail ("A1: Wrong Exception type. " + exc.ToString ());
 			}
-			catch (ArgumentException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch (Exception exc)
-			{
-				Assert.Fail("A1: Wrong Exception type. " + exc.ToString());
-			}
-
-
 		}
 
-
 		[Test]
-		public void AddUniqueExceptions()
+		public void AddUniqueExceptions ()
 		{
 			
 
 			//UC: can't create unique constraint because duplicate values already exist
-			try
-			{
-				_table.Rows.Add(new object [] {1});
-				_table.Rows.Add(new object [] {1});
-				UniqueConstraint uc = new UniqueConstraint( _table.Columns[0]);
+			try {
+				_table.Rows.Add (new object [] {1});
+				_table.Rows.Add (new object [] {1});
+				UniqueConstraint uc = new UniqueConstraint (_table.Columns [0]);
 				
-				_table.Constraints.Add(uc);	//should throw			
-				Assert.Fail("B1: Failed to throw ArgumentException.");
-			}
-			catch (ArgumentException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch (Exception exc)
-			{
-				Assert.Fail("A1: Wrong Exception type. " + exc.ToString());
+				_table.Constraints.Add (uc);	//should throw			
+				Assert.Fail ("B1: Failed to throw ArgumentException.");
+			} catch (ArgumentException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch (Exception exc) {
+				Assert.Fail ("A1: Wrong Exception type. " + exc.ToString ());
 			}
 		}
 
 		[Test]
-                //Tests AddRange (), CanRemove (), RemoveAt (), Remove (), Exceptions of  Remove(), and Clear ()
-                public void AddRemoveTest ()
-                {
-                        AddRange ();
-//                      CanRemove (); This test is ignored
-                        Remove ();
-//                      RemoveAt (); This test is ignored
+		//Tests AddRange (), CanRemove (), RemoveAt (), Remove (), Exceptions of  Remove(), and Clear ()
+		public void AddRemoveTest ()
+		{
+			AddRange ();
+			//CanRemove (); This test is ignored
+			Remove ();
+			//RemoveAt (); This test is ignored
 
 			// This test is expected to be failed, so don't reuse it.
-//                        RemoveExceptions ();
-                        _table.Constraints.Remove (_table.Constraints [0]);
+			//RemoveExceptions ();
+			_table.Constraints.Remove (_table.Constraints [0]);
 
 			Clear ();
-                }
+		}
 
 		[Test]
-		public void AddRange()
+		public void AddRange ()
 		{
 			_constraint1.ConstraintName = "UK1";
-                        _constraint2.ConstraintName = "UK12";
+			_constraint2.ConstraintName = "UK12";
                                                                                                     
-                        ForeignKeyConstraint _constraint3 = new ForeignKeyConstraint ("FK2", _table.Columns [0],
+			ForeignKeyConstraint _constraint3 = new ForeignKeyConstraint ("FK2", _table.Columns [0],
                                         _table2.Columns [0]);
-                        UniqueConstraint _constraint4=new UniqueConstraint("UK2", _table2.Columns [1]);
+			UniqueConstraint _constraint4 = new UniqueConstraint ("UK2", _table2.Columns [1]);
                                                                                                     
-                        // Add the constraints.
-                        Constraint [] constraints = {_constraint1, _constraint2};
-                        _table.Constraints.AddRange (constraints);
+			// Add the constraints.
+			Constraint [] constraints = {_constraint1, _constraint2};
+			_table.Constraints.AddRange (constraints);
                                                                                                                                                                                                          
-                        Constraint [] constraints1 = {_constraint3, _constraint4};
-                        _table2.Constraints.AddRange (constraints1);
+			Constraint [] constraints1 = {_constraint3, _constraint4};
+			_table2.Constraints.AddRange (constraints1);
                                                                                                     
-                        Assert.AreEqual ("UK1", _table.Constraints [0].ConstraintName, "A1");
-                        Assert.AreEqual ("UK12", _table.Constraints [1].ConstraintName, "A2");
+			Assert.AreEqual ("UK1", _table.Constraints [0].ConstraintName, "A1");
+			Assert.AreEqual ("UK12", _table.Constraints [1].ConstraintName, "A2");
                                                                                               
-                        Assert.AreEqual ("FK2", _table2.Constraints [0].ConstraintName, "A3");
-                        Assert.AreEqual ("UK2", _table2.Constraints [1].ConstraintName, "A4");
-
+			Assert.AreEqual ("FK2", _table2.Constraints [0].ConstraintName, "A3");
+			Assert.AreEqual ("UK2", _table2.Constraints [1].ConstraintName, "A4");
 		}
 		
 		[Test]
 		[Category ("NotDotNet")]
 		// Even after EndInit(), MS.NET does not fill Table property
 		// on UniqueConstraint.
- 		public void TestAddRange2()
-                {
-                        DataTable table = new DataTable ("Table");
-                        DataColumn column1 = new DataColumn ("col1");
-                        DataColumn column2 = new DataColumn ("col2");
-                        DataColumn column3 = new DataColumn ("col3");
-                        table.Columns.Add (column1);
-                        table.Columns.Add (column2);
-                        table.Columns.Add (column3);
-                        string []columnNames = {"col1", "col2", "col3"};
+		public void TestAddRange2 ()
+		{
+			DataTable table = new DataTable ("Table");
+			DataColumn column1 = new DataColumn ("col1");
+			DataColumn column2 = new DataColumn ("col2");
+			DataColumn column3 = new DataColumn ("col3");
+			table.Columns.Add (column1);
+			table.Columns.Add (column2);
+			table.Columns.Add (column3);
+			string [] columnNames = {"col1", "col2", "col3"};
                                                                                                     
-                        Constraint []constraints = new Constraint[3];
-                        constraints [0] = new UniqueConstraint ("Unique1",column1);
-                        constraints [1] = new UniqueConstraint ("Unique2",column2);
-                        constraints [2] = new UniqueConstraint ("Unique3", columnNames, true);
+			Constraint [] constraints = new Constraint[3];
+			constraints [0] = new UniqueConstraint ("Unique1", column1);
+			constraints [1] = new UniqueConstraint ("Unique2", column2);
+			constraints [2] = new UniqueConstraint ("Unique3", columnNames, true);
                                                                                                     
-                        table.BeginInit();
-                        //Console.WriteLine(table.InitStatus == DataTable.initStatus.BeginInit);
-                        table.Constraints.AddRange (constraints);
+			table.BeginInit ();
+			//Console.WriteLine(table.InitStatus == DataTable.initStatus.BeginInit);
+			table.Constraints.AddRange (constraints);
                                                                                                     
-                        //Check the table property of UniqueConstraint Object
-                        try{
-                                Assert.That (constraints [2].Table, Is.Null, "#A01");
-                        }
-                        catch (Exception e) {
-                                Assert.That (e, Is.TypeOf(typeof(NullReferenceException)), "#A02");
-                        }
+			//Check the table property of UniqueConstraint Object
+			try {
+				Assert.That (constraints [2].Table, Is.Null, "#A01");
+			} catch (Exception e) {
+				Assert.That (e, Is.TypeOf (typeof(NullReferenceException)), "#A02");
+			}
 
-			table.EndInit();
+			table.EndInit ();
 
 			// After EndInit is called the constraints associated with most recent call to AddRange() must be
 			// added to the ConstraintCollection
-                        Assert.That (constraints [2].Table.ToString(), Is.EqualTo ("Table"), "#A03");
-                        Assert.That (table.Constraints.Contains ("Unique1"), Is.True, "#A04");
-                        Assert.That (table.Constraints.Contains ("Unique3"), Is.True, "#A06");
-                        Assert.That (table.Constraints.Contains ("Unique2"), Is.True, "#A05");
-                }
+			Assert.That (constraints [2].Table.ToString (), Is.EqualTo ("Table"), "#A03");
+			Assert.That (table.Constraints.Contains ("Unique1"), Is.True, "#A04");
+			Assert.That (table.Constraints.Contains ("Unique3"), Is.True, "#A06");
+			Assert.That (table.Constraints.Contains ("Unique2"), Is.True, "#A05");
+		}
 
 		[Test]
-		public void Clear()
+		public void Clear ()
 		{
- 			try {
-                               _table.Constraints.Clear (); //Clear all constraints
-                                Assert.That (_table.Constraints.Count, Is.EqualTo(0), "A1"); //No constraints should remain
-                                _table2.Constraints.Clear ();
-                                Assert.That (_table2.Constraints.Count, Is.EqualTo(0), "A2"); //No constraints should remain
-                        }
-                        catch (Exception e) {
-                                Console.WriteLine (e);
-                        }
-
+			try {
+				_table.Constraints.Clear (); //Clear all constraints
+				Assert.That (_table.Constraints.Count, Is.EqualTo (0), "A1"); //No constraints should remain
+				_table2.Constraints.Clear ();
+				Assert.That (_table2.Constraints.Count, Is.EqualTo (0), "A2"); //No constraints should remain
+			} catch (Exception e) {
+				Console.WriteLine (e);
+			}
 		}
 
 		[Test]
 		[Ignore ("This never works on MS.NET (and it should not)")]
-		public void CanRemove()
+		public void CanRemove ()
 		{
 			Assert.That (_table.Constraints.CanRemove (_table.Constraints [0]), Is.False, "A1");
 		}
 
 		[Test]
-		public void CollectionChanged()
+		public void CollectionChanged ()
 		{
 		}
 #if false
@@ -455,28 +429,26 @@ namespace MonoTests.System.Data
 
 		//[Test]
 		[Ignore ("MS.NET fails this test (and it should fail)")]
-		public void Remove()
+		public void Remove ()
 		{
 			_table2.Constraints.Remove (_table2.Constraints [1]); //Remove constraint and again add it
-                        Assert.That (_table2.Constraints.Count, Is.EqualTo(1), "A1");
-                        UniqueConstraint _constraint4 = new UniqueConstraint ("UK2", _table2.Columns [1]);                                                                               
-                        // Add the constraints.
-                        Constraint [] constraints = {_constraint4};
-                        _table2.Constraints.AddRange (constraints);
+			Assert.That (_table2.Constraints.Count, Is.EqualTo (1), "A1");
+			UniqueConstraint _constraint4 = new UniqueConstraint ("UK2", _table2.Columns [1]);                                                                               
+			// Add the constraints.
+			Constraint [] constraints = {_constraint4};
+			_table2.Constraints.AddRange (constraints);
 		}
 
 		[Test]
-		public void RemoveExceptions()
+		public void RemoveExceptions ()
 		{
 			try {
-                                //Remove constraint that cannot be removed
-                                _table.Constraints.Remove (_table.Constraints [0]);
+				//Remove constraint that cannot be removed
+				_table.Constraints.Remove (_table.Constraints [0]);
 				Assert.Fail ("A1");
 			} catch (Exception e) {
-				Assert.That (e, Is.TypeOf (typeof (IndexOutOfRangeException)), "A2");
-                        }
-                }
-
+				Assert.That (e, Is.TypeOf (typeof(IndexOutOfRangeException)), "A2");
+			}
+		}
 	}
-	
 }

--- a/mcs/class/System.Data/Test/System.Data/ConstraintTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/ConstraintTest.cs
@@ -31,7 +31,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
 using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
 using System;
@@ -63,26 +62,28 @@ namespace MonoTests.System.Data
 		private Constraint _constraint2;
 
 		[SetUp]
-		public void GetReady() {
+		public void GetReady ()
+		{
 
 			//Setup DataTable
-			_table = new DataTable("TestTable");
+			_table = new DataTable ("TestTable");
 
-			_table.Columns.Add("Col1",typeof(int));
-			_table.Columns.Add("Col2",typeof(int));
+			_table.Columns.Add ("Col1", typeof(int));
+			_table.Columns.Add ("Col2", typeof(int));
 
 			//Use UniqueConstraint to test Constraint Base Class
-			_constraint1 = new UniqueConstraint(_table.Columns[0],false); 
-			_constraint2 = new UniqueConstraint(_table.Columns[1],false); 
+			_constraint1 = new UniqueConstraint (_table.Columns [0], false); 
+			_constraint2 = new UniqueConstraint (_table.Columns [1], false); 
 
 			// not sure why this is needed since a new _table was just created
 			// for us, but this Clear() keeps the tests from throwing
 			// an exception when the Add() is called.
-			_table.Constraints.Clear();
+			_table.Constraints.Clear ();
 		}  
-		
+
 		[Test]
-		public void SetConstraintNameNullOrEmptyExceptions() {
+		public void SetConstraintNameNullOrEmptyExceptions ()
+		{
 			bool exceptionCaught = false;
 			string name = null;
 
@@ -90,8 +91,10 @@ namespace MonoTests.System.Data
 
 			for (int i = 0; i <= 1; i++) {
 				exceptionCaught = false;
-				if (0 == i) name = null;
-				if (1 == i) name = String.Empty;
+				if (0 == i)
+					name = null;
+				if (1 == i)
+					name = String.Empty;
 	
 				try {
 				
@@ -100,15 +103,13 @@ namespace MonoTests.System.Data
 					//or empty while the constraint is part of the
 					//collection
 					_constraint1.ConstraintName = name; 
-				}
-				catch (ArgumentException){ 
+				} catch (ArgumentException) { 
 					exceptionCaught = true;
-				}
-				catch {
-					Assert.Fail("Wrong exception type thrown.");
+				} catch {
+					Assert.Fail ("Wrong exception type thrown.");
 				}
 				
-				Assert.That(exceptionCaught, Is.True, "Failed to throw exception.");
+				Assert.That (exceptionCaught, Is.True, "Failed to throw exception.");
 			}	
 		}
 
@@ -119,29 +120,31 @@ namespace MonoTests.System.Data
 			_constraint1.ConstraintName = "Dog";
 			_constraint2.ConstraintName = "Cat";
 
-			_table.Constraints.Add(_constraint1);
-			_table.Constraints.Add(_constraint2);
+			_table.Constraints.Add (_constraint1);
+			_table.Constraints.Add (_constraint2);
 
 			//Should throw DuplicateNameException
 			_constraint2.ConstraintName = "Dog";
 		}
 
 		[Test]
-		public void ToStringTest() {
+		public void ToStringTest ()
+		{
 			_constraint1.ConstraintName = "Test";
-			Assert.That(_constraint1.ConstraintName, Is.EqualTo(_constraint1.ToString()),
+			Assert.That (_constraint1.ConstraintName, Is.EqualTo (_constraint1.ToString ()),
 				"ToString is the same as constraint name.");
 			
 			_constraint1.ConstraintName = null;
-			Assert.That(_constraint1.ToString(), Is.Not.Null, "ToString should return empty.");
+			Assert.That (_constraint1.ToString (), Is.Not.Null, "ToString should return empty.");
 		}
 
 		[Test]
-		public void GetExtendedProperties() {
+		public void GetExtendedProperties ()
+		{
 			PropertyCollection col = _constraint1.ExtendedProperties as
 				PropertyCollection;
 
-			Assert.That(col, Is.Not.Null, "ExtendedProperties returned null or didn't " +
+			Assert.That (col, Is.Not.Null, "ExtendedProperties returned null or didn't " +
 				"return the correct type");
 		}
 	}

--- a/mcs/class/System.Data/Test/System.Data/DataRelationCollectionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataRelationCollectionTest.cs
@@ -27,8 +27,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
-
 using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
 using System;
@@ -41,337 +39,324 @@ namespace MonoTests.System.Data
 	public class DataRelationCollectionTest
 	{
 		DataSet _dataset;
-		DataTable _tblparent,_tblchild;
+		DataTable _tblparent, _tblchild;
 		DataRelation _relation;
+
 		[SetUp]
-		public void GetReady() 
+		public void GetReady ()
 		{
-			_dataset = new DataSet();
-			_tblparent = new DataTable("Customer");
-			_tblchild = new DataTable("Order");
-			_dataset.Tables.Add(_tblchild);
-			_dataset.Tables.Add(_tblparent);
-			_dataset.Tables.Add("Item");
-			_dataset.Tables["Customer"].Columns.Add("custid");
-			_dataset.Tables["Customer"].Columns.Add("custname");
-			_dataset.Tables["Order"].Columns.Add("oid");
-			_dataset.Tables["Order"].Columns.Add("custid");
-			_dataset.Tables["Order"].Columns.Add("itemid");
-			_dataset.Tables["Order"].Columns.Add("desc");
-			_dataset.Tables["Item"].Columns.Add("itemid");
-			_dataset.Tables["Item"].Columns.Add("desc");
+			_dataset = new DataSet ();
+			_tblparent = new DataTable ("Customer");
+			_tblchild = new DataTable ("Order");
+			_dataset.Tables.Add (_tblchild);
+			_dataset.Tables.Add (_tblparent);
+			_dataset.Tables.Add ("Item");
+			_dataset.Tables ["Customer"].Columns.Add ("custid");
+			_dataset.Tables ["Customer"].Columns.Add ("custname");
+			_dataset.Tables ["Order"].Columns.Add ("oid");
+			_dataset.Tables ["Order"].Columns.Add ("custid");
+			_dataset.Tables ["Order"].Columns.Add ("itemid");
+			_dataset.Tables ["Order"].Columns.Add ("desc");
+			_dataset.Tables ["Item"].Columns.Add ("itemid");
+			_dataset.Tables ["Item"].Columns.Add ("desc");
 			
 		}
-	
+
 		[TearDown]
-		public void Clean() 
+		public void Clean ()
 		{
-			_dataset.Relations.Clear();
+			_dataset.Relations.Clear ();
 		}
-	
+
 		[Test]
-		public void Add()
+		public void Add ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataColumn parentCol = _dataset.Tables["Customer"].Columns["custid"];
-			DataColumn childCol = _dataset.Tables["Order"].Columns["custid"];
-			DataRelation dr = new DataRelation("CustOrder",parentCol,childCol);
+			DataColumn parentCol = _dataset.Tables ["Customer"].Columns ["custid"];
+			DataColumn childCol = _dataset.Tables ["Order"].Columns ["custid"];
+			DataRelation dr = new DataRelation ("CustOrder", parentCol, childCol);
 			
-			drcol.Add(dr);
-			Assert.That (drcol[0].RelationName, Is.EqualTo ("CustOrder"), "test#1");
-			drcol.Clear();
+			drcol.Add (dr);
+			Assert.That (drcol [0].RelationName, Is.EqualTo ("CustOrder"), "test#1");
+			drcol.Clear ();
 			
-			drcol.Add(parentCol,childCol);
+			drcol.Add (parentCol, childCol);
 			Assert.That (drcol.Count, Is.EqualTo (1), "test#2");
-			drcol.Clear();
+			drcol.Clear ();
 			
-			drcol.Add("NewRelation",parentCol,childCol);
-			Assert.That (drcol[0].RelationName, Is.EqualTo ("NewRelation"), "test#3");
-			drcol.Clear();
+			drcol.Add ("NewRelation", parentCol, childCol);
+			Assert.That (drcol [0].RelationName, Is.EqualTo ("NewRelation"), "test#3");
+			drcol.Clear ();
 			
-			drcol.Add("NewRelation",parentCol,childCol,false);
+			drcol.Add ("NewRelation", parentCol, childCol, false);
 			Assert.That (drcol.Count, Is.EqualTo (1), "test#4");
-			drcol.Clear();
+			drcol.Clear ();
 			
-			drcol.Add("NewRelation",parentCol,childCol,true);
+			drcol.Add ("NewRelation", parentCol, childCol, true);
 			Assert.That (drcol.Count, Is.EqualTo (1), "test#5");
-			drcol.Clear();
+			drcol.Clear ();
 		}
-		
+
 		[Test]		
 		[ExpectedException(typeof(ArgumentNullException))]
 		[Ignore ("It does not pass under MS.NET")]
-		public void AddException1()
+		public void AddException1 ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
 			DataRelation drnull = null;
-			drcol.Add(drnull);
+			drcol.Add (drnull);
 		}
-		
+
 		[Test]
 		[ExpectedException(typeof(ArgumentException))]
-		public void AddException2()
+		public void AddException2 ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataRelation dr1= new DataRelation("CustOrder"
-							,_dataset.Tables["Customer"].Columns["custid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.Add(dr1);			
-			drcol.Add(dr1);
+			DataRelation dr1 = new DataRelation ("CustOrder"
+							, _dataset.Tables ["Customer"].Columns ["custid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.Add (dr1);			
+			drcol.Add (dr1);
 		}
-		
+
 		[Test]
 		[ExpectedException(typeof(DuplicateNameException))]
-		public void AddException3()
+		public void AddException3 ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataRelation dr1= new DataRelation("DuplicateName"
-							,_dataset.Tables["Customer"].Columns["custid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			DataRelation dr2 = new DataRelation("DuplicateName"
-							,_dataset.Tables["Item"].Columns["itemid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
+			DataRelation dr1 = new DataRelation ("DuplicateName"
+							, _dataset.Tables ["Customer"].Columns ["custid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			DataRelation dr2 = new DataRelation ("DuplicateName"
+							, _dataset.Tables ["Item"].Columns ["itemid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
 			
-			drcol.Add(dr1);			
-			drcol.Add(dr2);
+			drcol.Add (dr1);			
+			drcol.Add (dr2);
 		}
-		
-		
+
 		[Test]
-		public void AddRange()
+		public void AddRange ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataRelation dr1= new DataRelation("CustOrder"
-							,_dataset.Tables["Customer"].Columns["custid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			DataRelation dr2 = new DataRelation("ItemOrder"
-							,_dataset.Tables["Item"].Columns["itemid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.AddRange(new DataRelation[] {dr1,dr2});
+			DataRelation dr1 = new DataRelation ("CustOrder"
+							, _dataset.Tables ["Customer"].Columns ["custid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			DataRelation dr2 = new DataRelation ("ItemOrder"
+							, _dataset.Tables ["Item"].Columns ["itemid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.AddRange (new DataRelation[] {dr1,dr2});
 			
-			Assert.That (drcol[0].RelationName, Is.EqualTo ("CustOrder"), "test#1");
-			Assert.That (drcol[1].RelationName, Is.EqualTo ("ItemOrder"), "test#2");
+			Assert.That (drcol [0].RelationName, Is.EqualTo ("CustOrder"), "test#1");
+			Assert.That (drcol [1].RelationName, Is.EqualTo ("ItemOrder"), "test#2");
 		}
-		
+
 		[Test]
-		public void CanRemove()
+		public void CanRemove ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataColumn parentCol = _dataset.Tables["Customer"].Columns["custid"];
-			DataColumn childCol = _dataset.Tables["Order"].Columns["custid"];
-			DataRelation dr = new DataRelation("CustOrder",parentCol,childCol);
+			DataColumn parentCol = _dataset.Tables ["Customer"].Columns ["custid"];
+			DataColumn childCol = _dataset.Tables ["Order"].Columns ["custid"];
+			DataRelation dr = new DataRelation ("CustOrder", parentCol, childCol);
 			
-			drcol.Add(dr);
-			Assert.That (drcol.CanRemove(dr), Is.True, "test#1");
-			Assert.That (drcol.CanRemove(null), Is.False, "test#2");
-			DataRelation dr2 = new DataRelation("ItemOrder"
-						,_dataset.Tables["Item"].Columns["itemid"]
-						,_dataset.Tables["Order"].Columns["custid"]);
-			Assert.That (drcol.CanRemove(dr2), Is.False, "test#3");
+			drcol.Add (dr);
+			Assert.That (drcol.CanRemove (dr), Is.True, "test#1");
+			Assert.That (drcol.CanRemove (null), Is.False, "test#2");
+			DataRelation dr2 = new DataRelation ("ItemOrder"
+						, _dataset.Tables ["Item"].Columns ["itemid"]
+						, _dataset.Tables ["Order"].Columns ["custid"]);
+			Assert.That (drcol.CanRemove (dr2), Is.False, "test#3");
 		}
-		
+
 		[Test]
-		public void Clear()
+		public void Clear ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataColumn parentCol = _dataset.Tables["Customer"].Columns["custid"];
-			DataColumn childCol = _dataset.Tables["Order"].Columns["custid"];
-			drcol.Add(new DataRelation("CustOrder",parentCol,childCol));
-			drcol.Add("ItemOrder",_dataset.Tables["Item"].Columns["itemid"]
-								 ,_dataset.Tables["Order"].Columns["itemid"]);
-			drcol.Clear();
+			DataColumn parentCol = _dataset.Tables ["Customer"].Columns ["custid"];
+			DataColumn childCol = _dataset.Tables ["Order"].Columns ["custid"];
+			drcol.Add (new DataRelation ("CustOrder", parentCol, childCol));
+			drcol.Add ("ItemOrder", _dataset.Tables ["Item"].Columns ["itemid"]
+								 , _dataset.Tables ["Order"].Columns ["itemid"]);
+			drcol.Clear ();
 			Assert.That (drcol.Count, Is.EqualTo (0), "test#1");
 		}
-		
+
 		[Test]
-		public void Contains()
+		public void Contains ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataColumn parentCol = _dataset.Tables["Customer"].Columns["custid"];
-			DataColumn childCol = _dataset.Tables["Order"].Columns["custid"];
-			DataRelation dr = new DataRelation("CustOrder",parentCol,childCol);
+			DataColumn parentCol = _dataset.Tables ["Customer"].Columns ["custid"];
+			DataColumn childCol = _dataset.Tables ["Order"].Columns ["custid"];
+			DataRelation dr = new DataRelation ("CustOrder", parentCol, childCol);
 			
-			drcol.Add(dr);
-			Assert.That(drcol.Contains(dr.RelationName), Is.True, "test#1");
+			drcol.Add (dr);
+			Assert.That (drcol.Contains (dr.RelationName), Is.True, "test#1");
 			string drnull = "";
-			Assert.That(drcol.Contains(drnull), Is.False, "test#2");
-			dr = new DataRelation("newRelation",childCol,parentCol);
-			Assert.That(drcol.Contains("NoSuchRelation"), Is.False, "test#3");
+			Assert.That (drcol.Contains (drnull), Is.False, "test#2");
+			dr = new DataRelation ("newRelation", childCol, parentCol);
+			Assert.That (drcol.Contains ("NoSuchRelation"), Is.False, "test#3");
 		}
-		
+
 		[Test]
-		public void CopyTo()
+		public void CopyTo ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			drcol.Add("CustOrder"
-					,_dataset.Tables["Customer"].Columns["custid"]
-					,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.Add("ItemOrder"
-					,_dataset.Tables["Item"].Columns["itemid"]
-					,_dataset.Tables["Order"].Columns["custid"]);
+			drcol.Add ("CustOrder"
+					, _dataset.Tables ["Customer"].Columns ["custid"]
+					, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.Add ("ItemOrder"
+					, _dataset.Tables ["Item"].Columns ["itemid"]
+					, _dataset.Tables ["Order"].Columns ["custid"]);
 			
 			DataRelation [] array = new DataRelation[2];
-			drcol.CopyTo(array,0);
-			Assert.That(array.Length, Is.EqualTo(2), "test#1");
-			Assert.That(array[0].RelationName, Is.EqualTo("CustOrder"), "test#2");
-			Assert.That(array[1].RelationName, Is.EqualTo("ItemOrder"), "test#3");
+			drcol.CopyTo (array, 0);
+			Assert.That (array.Length, Is.EqualTo (2), "test#1");
+			Assert.That (array [0].RelationName, Is.EqualTo ("CustOrder"), "test#2");
+			Assert.That (array [1].RelationName, Is.EqualTo ("ItemOrder"), "test#3");
 			
 			DataRelation [] array1 = new DataRelation[4];
-			drcol.CopyTo(array1,2);
-			Assert.That(array1[0], Is.Null,"test#4");
-			Assert.That(array1[1], Is.Null,"test#5" );
-			Assert.That(array1[2].RelationName, Is.EqualTo("CustOrder"),"test#6");
-			Assert.That(array1[3].RelationName, Is.EqualTo("ItemOrder"),"test#7");
+			drcol.CopyTo (array1, 2);
+			Assert.That (array1 [0], Is.Null, "test#4");
+			Assert.That (array1 [1], Is.Null, "test#5");
+			Assert.That (array1 [2].RelationName, Is.EqualTo ("CustOrder"), "test#6");
+			Assert.That (array1 [3].RelationName, Is.EqualTo ("ItemOrder"), "test#7");
 		}
-		
+
 		[Test]
-		public void Equals()
+		public void Equals ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			drcol.Add("CustOrder"
-					,_dataset.Tables["Customer"].Columns["custid"]
-					,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.Add("ItemOrder"
-					,_dataset.Tables["Item"].Columns["itemid"]
-					,_dataset.Tables["Order"].Columns["custid"]);
-			DataSet newds = new DataSet();
+			drcol.Add ("CustOrder"
+					, _dataset.Tables ["Customer"].Columns ["custid"]
+					, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.Add ("ItemOrder"
+					, _dataset.Tables ["Item"].Columns ["itemid"]
+					, _dataset.Tables ["Order"].Columns ["custid"]);
+			DataSet newds = new DataSet ();
 			DataRelationCollection drcol1 = newds.Relations;
 			DataRelationCollection drcol2 = _dataset.Relations;
 
-			Assert.That(drcol.Equals(drcol), Is.True,"test#1");
-			Assert.That(drcol.Equals(drcol2), Is.True,"test#2");
+			Assert.That (drcol.Equals (drcol), Is.True, "test#1");
+			Assert.That (drcol.Equals (drcol2), Is.True, "test#2");
 			
-			Assert.That(drcol1.Equals(drcol), Is.False,"test#3");
-			Assert.That(drcol.Equals(drcol1), Is.False,"test#4");
+			Assert.That (drcol1.Equals (drcol), Is.False, "test#3");
+			Assert.That (drcol.Equals (drcol1), Is.False, "test#4");
 			
-			Assert.That(Object.Equals(drcol,drcol2), Is.True,"test#5");
-			Assert.That(Object.Equals(drcol,drcol1), Is.False,"test#6");
+			Assert.That (Object.Equals (drcol, drcol2), Is.True, "test#5");
+			Assert.That (Object.Equals (drcol, drcol1), Is.False, "test#6");
 			
-		}
-		[Test]
-		public void IndexOf()
-		{
-			DataRelationCollection drcol = _dataset.Relations;
-			DataRelation dr1= new DataRelation("CustOrder"
-							,_dataset.Tables["Customer"].Columns["custid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			DataRelation dr2 = new DataRelation("ItemOrder"
-							,_dataset.Tables["Item"].Columns["itemid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.Add(dr1);
-			drcol.Add(dr2);
-			
-			Assert.That(drcol.IndexOf(dr1), Is.EqualTo(0), "test#1");
-			Assert.That(drcol.IndexOf(dr2), Is.EqualTo(1), "test#2");
-			
-			Assert.That(drcol.IndexOf("CustOrder"), Is.EqualTo(0), "test#3");
-			Assert.That(drcol.IndexOf("ItemOrder"), Is.EqualTo(1), "test#4");
-			
-			Assert.That(drcol.IndexOf(drcol[0]), Is.EqualTo(0), "test#5");
-			Assert.That(drcol.IndexOf(drcol[1]), Is.EqualTo(1), "test#6");
-			
-			Assert.That(drcol.IndexOf("_noRelation_"), Is.EqualTo(-1), "test#7");
-			DataRelation newdr = new DataRelation("newdr"
-										,_dataset.Tables["Customer"].Columns["custid"]
-										,_dataset.Tables["Order"].Columns["custid"]);
-			
-			Assert.That(drcol.IndexOf(newdr), Is.EqualTo(-1), "test#8");
 		}
 
 		[Test]
-		public void Remove()
+		public void IndexOf ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataRelation dr1= new DataRelation("CustOrder"
-							,_dataset.Tables["Customer"].Columns["custid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			DataRelation dr2 = new DataRelation("ItemOrder"
-							,_dataset.Tables["Item"].Columns["itemid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.Add(dr1);
-			drcol.Add(dr2);
+			DataRelation dr1 = new DataRelation ("CustOrder"
+							, _dataset.Tables ["Customer"].Columns ["custid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			DataRelation dr2 = new DataRelation ("ItemOrder"
+							, _dataset.Tables ["Item"].Columns ["itemid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.Add (dr1);
+			drcol.Add (dr2);
 			
-			drcol.Remove(dr1);
-			Assert.That(drcol.Contains(dr1.RelationName), Is.False, "test#1");
-			drcol.Add(dr1);
+			Assert.That (drcol.IndexOf (dr1), Is.EqualTo (0), "test#1");
+			Assert.That (drcol.IndexOf (dr2), Is.EqualTo (1), "test#2");
 			
-			drcol.Remove("CustOrder");
-			Assert.That(drcol.Contains("CustOrder"), Is.False, "test#2");
-			drcol.Add(dr1);
+			Assert.That (drcol.IndexOf ("CustOrder"), Is.EqualTo (0), "test#3");
+			Assert.That (drcol.IndexOf ("ItemOrder"), Is.EqualTo (1), "test#4");
+			
+			Assert.That (drcol.IndexOf (drcol [0]), Is.EqualTo (0), "test#5");
+			Assert.That (drcol.IndexOf (drcol [1]), Is.EqualTo (1), "test#6");
+			
+			Assert.That (drcol.IndexOf ("_noRelation_"), Is.EqualTo (-1), "test#7");
+			DataRelation newdr = new DataRelation ("newdr"
+					, _dataset.Tables ["Customer"].Columns ["custid"]
+					, _dataset.Tables ["Order"].Columns ["custid"]);
+			
+			Assert.That (drcol.IndexOf (newdr), Is.EqualTo (-1), "test#8");
+		}
+
+		[Test]
+		public void Remove ()
+		{
+			DataRelationCollection drcol = _dataset.Relations;
+			DataRelation dr1 = new DataRelation ("CustOrder"
+							, _dataset.Tables ["Customer"].Columns ["custid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			DataRelation dr2 = new DataRelation ("ItemOrder"
+							, _dataset.Tables ["Item"].Columns ["itemid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.Add (dr1);
+			drcol.Add (dr2);
+			
+			drcol.Remove (dr1);
+			Assert.That (drcol.Contains (dr1.RelationName), Is.False, "test#1");
+			drcol.Add (dr1);
+			
+			drcol.Remove ("CustOrder");
+			Assert.That (drcol.Contains ("CustOrder"), Is.False, "test#2");
+			drcol.Add (dr1);
 			
 			DataRelation drnull = null;
-			drcol.Remove(drnull);
+			drcol.Remove (drnull);
 			
-			DataRelation newdr = new DataRelation("newdr"
-										,_dataset.Tables["Customer"].Columns["custid"]
-										,_dataset.Tables["Order"].Columns["custid"]);
-			try
-			{
-				drcol.Remove(newdr);
-				Assert.Fail("Err: removed relation which not part of collection");
+			DataRelation newdr = new DataRelation ("newdr"
+								, _dataset.Tables ["Customer"].Columns ["custid"]
+								, _dataset.Tables ["Order"].Columns ["custid"]);
+			try {
+				drcol.Remove (newdr);
+				Assert.Fail ("Err: removed relation which not part of collection");
+			} catch (Exception e) {
+				Assert.That (e, Is.TypeOf (typeof(ArgumentException)), "test#4");
 			}
-			catch (Exception e)
-			{
-				Assert.That (e, Is.TypeOf(typeof(ArgumentException)), "test#4");
+			try {
+				drcol.Remove ("newdr");
+				Assert.Fail ("Err: removed relation which not part of collection");
+			} catch (ArgumentException e) {
 			}
-			try
-			{
-				drcol.Remove("newdr");
-				Assert.Fail("Err: removed relation which not part of collection");
-			}
-			catch (ArgumentException e)
-			{
-			}
-
-			
 		}
-		
+
 		[Test]
-		public void RemoveAt()
+		public void RemoveAt ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataRelation dr1= new DataRelation("CustOrder"
-							,_dataset.Tables["Customer"].Columns["custid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			DataRelation dr2 = new DataRelation("ItemOrder"
-							,_dataset.Tables["Item"].Columns["itemid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.Add(dr1);
-			drcol.Add(dr2);
+			DataRelation dr1 = new DataRelation ("CustOrder"
+							, _dataset.Tables ["Customer"].Columns ["custid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			DataRelation dr2 = new DataRelation ("ItemOrder"
+							, _dataset.Tables ["Item"].Columns ["itemid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.Add (dr1);
+			drcol.Add (dr2);
 
-			try
-			{
-				drcol.RemoveAt(-1);
-				Assert.Fail("the index was out of bound: must have failed");
+			try {
+				drcol.RemoveAt (-1);
+				Assert.Fail ("the index was out of bound: must have failed");
+			} catch (IndexOutOfRangeException e) {
 			}
-			catch(IndexOutOfRangeException e)
-			{
-			}
-			try
-			{
-				drcol.RemoveAt(101);
-				Assert.Fail("the index was out of bound: must have failed");
-			}
-			catch(IndexOutOfRangeException e)
-			{
+			try {
+				drcol.RemoveAt (101);
+				Assert.Fail ("the index was out of bound: must have failed");
+			} catch (IndexOutOfRangeException e) {
 			}
 			
 			drcol.RemoveAt (1);
-			Assert.That (drcol.Contains(dr2.RelationName), Is.False, "test#5");
+			Assert.That (drcol.Contains (dr2.RelationName), Is.False, "test#5");
 			drcol.RemoveAt (0);
-			Assert.That (drcol.Contains(dr1.RelationName), Is.False, "test#6");
+			Assert.That (drcol.Contains (dr1.RelationName), Is.False, "test#6");
 		}
 		
 		//[Test]
-		public void ToStringTest()
+		public void ToStringTest ()
 		{
 			DataRelationCollection drcol = _dataset.Relations;
-			DataRelation dr1= new DataRelation("CustOrder"
-							,_dataset.Tables["Customer"].Columns["custid"]
-							,_dataset.Tables["Order"].Columns["custid"]);
-			drcol.Add(dr1);	
-			Assert.That (drcol.ToString(), Is.EqualTo("System.Data.DataRelationCollection"), "test#1");
-			Console.WriteLine(drcol.ToString());
+			DataRelation dr1 = new DataRelation ("CustOrder"
+							, _dataset.Tables ["Customer"].Columns ["custid"]
+							, _dataset.Tables ["Order"].Columns ["custid"]);
+			drcol.Add (dr1);	
+			Assert.That (drcol.ToString (), Is.EqualTo ("System.Data.DataRelationCollection"), "test#1");
+			Console.WriteLine (drcol.ToString ());
 		}
 	}
 }

--- a/mcs/class/System.Data/Test/System.Data/DataRelationTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataRelationTest.cs
@@ -31,7 +31,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
 using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
 using System;
@@ -40,14 +39,14 @@ using System.Data;
 namespace MonoTests.System.Data
 {
 	[TestFixture]
-        public class DataRelationTest
-        {
+	public class DataRelationTest
+	{
 		private DataSet Set = null;
-        	private DataTable Mom = null;
-        	private DataTable Child = null;        	
+		private DataTable Mom = null;
+		private DataTable Child = null;        	
 
 		[SetUp]
-                public void GetReady() 
+		public void GetReady ()
 		{
 			Set = new DataSet ();
 			Mom = new DataTable ("Mom");
@@ -66,77 +65,74 @@ namespace MonoTests.System.Data
 			Child.Columns.Add (Col3);
 			Child.Columns.Add (Col4);
 		}  
-                
+
 		[Test]
-                public void Foreign ()
-                {
+		public void Foreign ()
+		{
 			DataRelation Relation = new DataRelation ("Rel", Mom.Columns [1], Child.Columns [0]);
 			Set.Relations.Add (Relation);
 
-                	DataRow Row = Mom.NewRow ();
-                	Row [0] = "Teresa";
-                	Row [1] = "Jack";
-                	Mom.Rows.Add (Row);
+			DataRow Row = Mom.NewRow ();
+			Row [0] = "Teresa";
+			Row [1] = "Jack";
+			Mom.Rows.Add (Row);
                 	
-                	Row = Mom.NewRow ();
-                	Row [0] = "Teresa";
-                	Row [1] = "Dick";
-                	Mom.Rows.Add (Row);
+			Row = Mom.NewRow ();
+			Row [0] = "Teresa";
+			Row [1] = "Dick";
+			Mom.Rows.Add (Row);
                 	
-                	Row = Mom.NewRow ();
-                	Row [0] = "Mary";
-                	Row [1] = "Harry";
+			Row = Mom.NewRow ();
+			Row [0] = "Mary";
+			Row [1] = "Harry";
                 	
-                	Row = Child.NewRow ();
-                	Row [0] = "Jack";
-                	Row [1] = 16;
-                	Child.Rows.Add (Row);
+			Row = Child.NewRow ();
+			Row [0] = "Jack";
+			Row [1] = 16;
+			Child.Rows.Add (Row);
                 	
-                	Row = Child.NewRow ();
-                	Row [0] = "Dick";
-                	Row [1] = 56;
-                	Child.Rows.Add (Row);
+			Row = Child.NewRow ();
+			Row [0] = "Dick";
+			Row [1] = 56;
+			Child.Rows.Add (Row);
                 	
 			Assert.That (Child.Rows.Count, Is.EqualTo (2), "test#01");
                 	
-                	Row = Mom.Rows [0];
-                	Row.Delete ();
+			Row = Mom.Rows [0];
+			Row.Delete ();
                 	
 			Assert.That (Child.Rows.Count, Is.EqualTo (1), "test#02");
                 	
-                	Row = Mom.NewRow ();
-                	Row [0] = "Teresa";
-                	Row [1] = "Dick";
+			Row = Mom.NewRow ();
+			Row [0] = "Teresa";
+			Row [1] = "Dick";
                 	
-                	try {
-                		Mom.Rows.Add (Row);
+			try {
+				Mom.Rows.Add (Row);
 				Assert.Fail ("test#03");
-                	} catch (Exception e) {
-				Assert.That (e, Is.TypeOf (typeof (ConstraintException)), "test#04");
+			} catch (Exception e) {
+				Assert.That (e, Is.TypeOf (typeof(ConstraintException)), "test#04");
 				// Never premise English.
-                		//Assert.That (e.Message, Is.EqualTo("Column 'ChildName' is constrained to be unique.  Value 'Dick' is already present."), "test#05");
-                	}                	
+				//Assert.That (e.Message, Is.EqualTo("Column 'ChildName' is constrained to be unique.  Value 'Dick' is already present."), "test#05");
+			}                	
 
 			Row = Mom.NewRow ();                                 
-                        Row [0] = "Teresa";                                  
-                        Row [1] = "Mich";                                    
-                        Mom.Rows.Add (Row);                                  
-                        Assert.That (Child.Rows.Count, Is.EqualTo (1), "test#06");
+			Row [0] = "Teresa";                                  
+			Row [1] = "Mich";                                    
+			Mom.Rows.Add (Row);                                  
+			Assert.That (Child.Rows.Count, Is.EqualTo (1), "test#06");
 			
-                        Row = Child.NewRow ();                               
-                        Row [0] = "Jack";                                    
-                        Row [1] = 16;                                        
+			Row = Child.NewRow ();                               
+			Row [0] = "Jack";                                    
+			Row [1] = 16;                                        
 			
-                        try {                                                
-                                Child.Rows.Add (Row);                               
-                                Assert.Fail ("test#07");
-                        } catch (Exception e) {                              
-                                Assert.That (e, Is.TypeOf (typeof (InvalidConstraintException)), "test#08");
-				// Never premise English.
-                                //Assert.That (e.Message, Is.EqualTo("ForeignKeyConstraint Rel requires the child key values (Jack) to exist in the parent table."), "test#09");                                                                      
-                        }                                                    
-
-                }
+			try {                                                
+				Child.Rows.Add (Row);                               
+				Assert.Fail ("test#07");
+			} catch (Exception e) {                              
+				Assert.That (e, Is.TypeOf (typeof(InvalidConstraintException)), "test#08");
+			}                                                    
+		}
 
 		[Test]
 		[ExpectedException (typeof(InvalidConstraintException))]
@@ -159,7 +155,7 @@ namespace MonoTests.System.Data
 			
 			Child.Columns [1].DataType = Type.GetType ("System.Double");
 		}
-		
+
 		[Test]
 		public void DataSetRelations ()
 		{
@@ -185,11 +181,10 @@ namespace MonoTests.System.Data
 			Assert.That (Relation.ChildKeyConstraint.ConstraintName, Is.EqualTo ("Rel"), "test#13");
 			Assert.That (Relation.ParentKeyConstraint.ConstraintName, Is.EqualTo ("Constraint1"), "test#14");
 		}
-		
+
 		[Test]
 		public void Constraints ()
 		{
-				
 			Assert.That (Mom.Constraints.Count, Is.EqualTo (0), "test#01");
 			Assert.That (Child.Constraints.Count, Is.EqualTo (0), "test#02");
 
@@ -198,15 +193,13 @@ namespace MonoTests.System.Data
 			
 			Assert.That (Mom.Constraints.Count, Is.EqualTo (1), "test#03");
 			Assert.That (Child.Constraints.Count, Is.EqualTo (1), "test#04");
-			Assert.That (Child.Constraints [0], Is.TypeOf (typeof (ForeignKeyConstraint)), "test#05");
-			Assert.That (Mom.Constraints [0], Is.TypeOf (typeof (UniqueConstraint)), "test#06");
-			
+			Assert.That (Child.Constraints [0], Is.TypeOf (typeof(ForeignKeyConstraint)), "test#05");
+			Assert.That (Mom.Constraints [0], Is.TypeOf (typeof(UniqueConstraint)), "test#06");
 		}
 
 		[Test]
 		public void Creation ()
 		{
-			
 			DataRelation Relation = new DataRelation ("Rel", Mom.Columns [1], Child.Columns [0]);
 			Set.Relations.Add (Relation);
 			DataRelation Test = null;
@@ -224,11 +217,11 @@ namespace MonoTests.System.Data
 			Assert.That (Test.ParentColumns.Length, Is.EqualTo (1), "test#10");
 			Assert.That (Test.Nested, Is.False, "test#11");
 			Assert.That (Test.ExtendedProperties.Count, Is.EqualTo (0), "test#12");
-			Assert.That (Test.ChildTable.TableName, Is.EqualTo ("Child"), "test#13" );
+			Assert.That (Test.ChildTable.TableName, Is.EqualTo ("Child"), "test#13");
 			Assert.That (Test.ChildKeyConstraint.ConstraintName, Is.EqualTo ("Rel"), "test#14");
 			Assert.That (Test.ChildColumns.Length, Is.EqualTo (1), "test#15");
 		}
-		
+
 		[Test]
 		public void Creation2 ()
 		{
@@ -259,7 +252,6 @@ namespace MonoTests.System.Data
 			DataColumn Col8 = new DataColumn ("Age");
 			Hubby.Columns.Add (Col7);
 			Hubby.Columns.Add (Col8);
-			
 			
 			DataColumn [] Parents = new DataColumn [2];
 			Parents [0] = Col2;
@@ -305,11 +297,10 @@ namespace MonoTests.System.Data
 			Assert.That (Child2.Constraints.Count, Is.EqualTo (1), "test#18");
 			Assert.That (Hubby.Constraints.Count, Is.EqualTo (0), "test#19");
 		}
-		
+
 		[Test]
 		public void Creation3 ()
 		{
-
 			DataRelation Relation = new DataRelation ("Rel", Mom.Columns [1], Child.Columns [0], false);
 			Set.Relations.Add (Relation);
 			DataRelation Test = null;
@@ -339,13 +330,11 @@ namespace MonoTests.System.Data
 			Assert.That (Test.ChildColumns.Length, Is.EqualTo (1), "test#15");
 			Assert.That (Mom.Constraints.Count, Is.EqualTo (0), "test#16");
 			Assert.That (Child.Constraints.Count, Is.EqualTo (0), "test#17");
-
 		}
 
 		[Test]
 		public void Creation4 ()
 		{
-			
 			DataRelation Relation = new DataRelation ("Rel", "Mom", "Child", 
 			                                          new string [] {"ChildName"},
 			                                          new string [] {"Name"}, true);
@@ -354,14 +343,14 @@ namespace MonoTests.System.Data
 				Set.Relations.Add (Relation);
 				Assert.Fail ("test#01");
 			} catch (Exception e) {
-				Assert.That (e, Is.TypeOf (typeof (NullReferenceException)), "test#02");
+				Assert.That (e, Is.TypeOf (typeof(NullReferenceException)), "test#02");
 			}
 			
 			try {
 				Set.Relations.AddRange (new DataRelation [] {Relation});
 				Assert.Fail ("test#03");
 			} catch (Exception e) {
-				Assert.That (e, Is.TypeOf (typeof (NullReferenceException)), "test#04");
+				Assert.That (e, Is.TypeOf (typeof(NullReferenceException)), "test#04");
 			}
 			
 			Set.BeginInit ();
@@ -369,24 +358,24 @@ namespace MonoTests.System.Data
 			Set.EndInit ();
 			
 			DataRelation Test = null;
-			Assert.That (Mom.ChildRelations.Count, Is.EqualTo(1), "test#01");
-			Assert.That (Child.ChildRelations.Count, Is.EqualTo(0), "test#02");
-			Assert.That (Mom.ParentRelations.Count, Is.EqualTo(0), "test#03");
-			Assert.That (Child.ParentRelations.Count, Is.EqualTo(1), "test#04");
+			Assert.That (Mom.ChildRelations.Count, Is.EqualTo (1), "test#01");
+			Assert.That (Child.ChildRelations.Count, Is.EqualTo (0), "test#02");
+			Assert.That (Mom.ParentRelations.Count, Is.EqualTo (0), "test#03");
+			Assert.That (Child.ParentRelations.Count, Is.EqualTo (1), "test#04");
 				
 			Test = Child.ParentRelations [0];
-			Assert.That (Test.ToString (), Is.EqualTo("Rel"), "test#05");
-			Assert.That (Test.RelationName, Is.EqualTo("Rel"), "test#06");
-			Assert.That (Test.ParentTable.TableName, Is.EqualTo("Mom"), "test#07");
+			Assert.That (Test.ToString (), Is.EqualTo ("Rel"), "test#05");
+			Assert.That (Test.RelationName, Is.EqualTo ("Rel"), "test#06");
+			Assert.That (Test.ParentTable.TableName, Is.EqualTo ("Mom"), "test#07");
 			
 			Assert.That (Test.ParentKeyConstraint, Is.Null, "test#08");
 						
-			Assert.That (Test.ParentColumns.Length, Is.EqualTo(1), "test#10");
+			Assert.That (Test.ParentColumns.Length, Is.EqualTo (1), "test#10");
 			Assert.That (Test.Nested, Is.True, "test#11");
-			Assert.That (Test.ExtendedProperties.Count, Is.EqualTo(0), "test#12");
-			Assert.That (Test.ChildTable.TableName, Is.EqualTo("Child"), "test#13");
+			Assert.That (Test.ExtendedProperties.Count, Is.EqualTo (0), "test#12");
+			Assert.That (Test.ChildTable.TableName, Is.EqualTo ("Child"), "test#13");
 			Assert.That (Test.ChildKeyConstraint, Is.Null, "test#14");
-			Assert.That (Test.ChildColumns.Length, Is.EqualTo(1), "test#15");
+			Assert.That (Test.ChildColumns.Length, Is.EqualTo (1), "test#15");
 			
 		}
 
@@ -398,66 +387,65 @@ namespace MonoTests.System.Data
 			DataTable Table = Set.Tables [0];
 			
 			Assert.That (Table.CaseSensitive, Is.False, "test#01");
-			Assert.That (Table.ChildRelations.Count, Is.EqualTo(1), "test#02");
-			Assert.That (Table.ParentRelations.Count, Is.EqualTo(0), "test#03");
-			Assert.That (Table.Constraints.Count, Is.EqualTo(1), "test#04");
-			Assert.That (Table.PrimaryKey.Length, Is.EqualTo(1), "test#05");
-			Assert.That (Table.Rows.Count, Is.EqualTo(0), "test#06");
-			Assert.That (Table.TableName, Is.EqualTo("bookstore"), "test#07");
-			Assert.That (Table.Columns.Count, Is.EqualTo(1), "test#08");
+			Assert.That (Table.ChildRelations.Count, Is.EqualTo (1), "test#02");
+			Assert.That (Table.ParentRelations.Count, Is.EqualTo (0), "test#03");
+			Assert.That (Table.Constraints.Count, Is.EqualTo (1), "test#04");
+			Assert.That (Table.PrimaryKey.Length, Is.EqualTo (1), "test#05");
+			Assert.That (Table.Rows.Count, Is.EqualTo (0), "test#06");
+			Assert.That (Table.TableName, Is.EqualTo ("bookstore"), "test#07");
+			Assert.That (Table.Columns.Count, Is.EqualTo (1), "test#08");
 						
 			DataRelation Relation = Table.ChildRelations [0];
-			Assert.That (Relation.ChildColumns.Length, Is.EqualTo(1), "test#09");
-			Assert.That (Relation.ChildKeyConstraint.ConstraintName, Is.EqualTo("bookstore_book"), "test#10");
-			Assert.That (Relation.ChildKeyConstraint.Columns.Length, Is.EqualTo(1), "test#11");
-			Assert.That (Relation.ChildTable.TableName, Is.EqualTo("book"), "test#12");
-			Assert.That (Relation.DataSet.DataSetName, Is.EqualTo("NewDataSet"), "test#13");
-			Assert.That (Relation.ExtendedProperties.Count, Is.EqualTo(0), "test#14");
+			Assert.That (Relation.ChildColumns.Length, Is.EqualTo (1), "test#09");
+			Assert.That (Relation.ChildKeyConstraint.ConstraintName, Is.EqualTo ("bookstore_book"), "test#10");
+			Assert.That (Relation.ChildKeyConstraint.Columns.Length, Is.EqualTo (1), "test#11");
+			Assert.That (Relation.ChildTable.TableName, Is.EqualTo ("book"), "test#12");
+			Assert.That (Relation.DataSet.DataSetName, Is.EqualTo ("NewDataSet"), "test#13");
+			Assert.That (Relation.ExtendedProperties.Count, Is.EqualTo (0), "test#14");
 			Assert.That (Relation.Nested, Is.True, "test#15");
-			Assert.That (Relation.ParentColumns.Length, Is.EqualTo(1), "test#16");
-			Assert.That (Relation.ParentKeyConstraint.ConstraintName, Is.EqualTo("Constraint1"), "test#17");
-			Assert.That (Relation.ParentTable.TableName, Is.EqualTo("bookstore"), "test#18");
-			Assert.That (Relation.RelationName, Is.EqualTo("bookstore_book"), "test#19");
+			Assert.That (Relation.ParentColumns.Length, Is.EqualTo (1), "test#16");
+			Assert.That (Relation.ParentKeyConstraint.ConstraintName, Is.EqualTo ("Constraint1"), "test#17");
+			Assert.That (Relation.ParentTable.TableName, Is.EqualTo ("bookstore"), "test#18");
+			Assert.That (Relation.RelationName, Is.EqualTo ("bookstore_book"), "test#19");
 
 			Table = Set.Tables [1];
 			
 			Assert.That (Table.CaseSensitive, Is.False, "test#20");
-			Assert.That (Table.ChildRelations.Count, Is.EqualTo(1), "test#21");
-			Assert.That (Table.ParentRelations.Count, Is.EqualTo(1), "test#22");
-			Assert.That (Table.Constraints.Count, Is.EqualTo(2), "test#23");
-			Assert.That (Table.PrimaryKey.Length, Is.EqualTo(1), "test#24");
-			Assert.That (Table.Rows.Count, Is.EqualTo(0), "test#25");
-			Assert.That (Table.TableName, Is.EqualTo("book"), "test#26");
-			Assert.That (Table.Columns.Count, Is.EqualTo(5), "test#27");
+			Assert.That (Table.ChildRelations.Count, Is.EqualTo (1), "test#21");
+			Assert.That (Table.ParentRelations.Count, Is.EqualTo (1), "test#22");
+			Assert.That (Table.Constraints.Count, Is.EqualTo (2), "test#23");
+			Assert.That (Table.PrimaryKey.Length, Is.EqualTo (1), "test#24");
+			Assert.That (Table.Rows.Count, Is.EqualTo (0), "test#25");
+			Assert.That (Table.TableName, Is.EqualTo ("book"), "test#26");
+			Assert.That (Table.Columns.Count, Is.EqualTo (5), "test#27");
 		
 			Relation = Table.ChildRelations [0];
-			Assert.That (Relation.ChildColumns.Length, Is.EqualTo(1), "test#28");
-			Assert.That (Relation.ChildKeyConstraint.ConstraintName, Is.EqualTo("book_author"), "test#29");
-			Assert.That (Relation.ChildKeyConstraint.Columns.Length, Is.EqualTo(1), "test#30");
-			Assert.That (Relation.ChildTable.TableName, Is.EqualTo("author"), "test#31");
-			Assert.That (Relation.DataSet.DataSetName, Is.EqualTo("NewDataSet"), "test#32");
-			Assert.That (Relation.ExtendedProperties.Count, Is.EqualTo(0), "test#33");
+			Assert.That (Relation.ChildColumns.Length, Is.EqualTo (1), "test#28");
+			Assert.That (Relation.ChildKeyConstraint.ConstraintName, Is.EqualTo ("book_author"), "test#29");
+			Assert.That (Relation.ChildKeyConstraint.Columns.Length, Is.EqualTo (1), "test#30");
+			Assert.That (Relation.ChildTable.TableName, Is.EqualTo ("author"), "test#31");
+			Assert.That (Relation.DataSet.DataSetName, Is.EqualTo ("NewDataSet"), "test#32");
+			Assert.That (Relation.ExtendedProperties.Count, Is.EqualTo (0), "test#33");
 			Assert.That (Relation.Nested, Is.True, "test#34");
-			Assert.That (Relation.ParentColumns.Length, Is.EqualTo(1), "test#35");
-			Assert.That (Relation.ParentKeyConstraint.ConstraintName, Is.EqualTo("Constraint1"), "test#36");
-			Assert.That (Relation.ParentTable.TableName, Is.EqualTo("book"), "test#37");
-			Assert.That (Relation.RelationName, Is.EqualTo("book_author"), "test#38");
+			Assert.That (Relation.ParentColumns.Length, Is.EqualTo (1), "test#35");
+			Assert.That (Relation.ParentKeyConstraint.ConstraintName, Is.EqualTo ("Constraint1"), "test#36");
+			Assert.That (Relation.ParentTable.TableName, Is.EqualTo ("book"), "test#37");
+			Assert.That (Relation.RelationName, Is.EqualTo ("book_author"), "test#38");
 			
 			Table = Set.Tables [2];
 			Assert.That (Table.CaseSensitive, Is.False, "test#39");
-			Assert.That (Table.ChildRelations.Count, Is.EqualTo(0), "test#40");
-			Assert.That (Table.ParentRelations.Count, Is.EqualTo(1), "test#41");
-			Assert.That (Table.Constraints.Count, Is.EqualTo(1), "test#42");
-			Assert.That (Table.PrimaryKey.Length, Is.EqualTo(0), "test#43");
-			Assert.That (Table.Rows.Count, Is.EqualTo(0), "test#44");
-			Assert.That (Table.TableName, Is.EqualTo("author"), "test#45");
-			Assert.That (Table.Columns.Count, Is.EqualTo(3), "test#46");
+			Assert.That (Table.ChildRelations.Count, Is.EqualTo (0), "test#40");
+			Assert.That (Table.ParentRelations.Count, Is.EqualTo (1), "test#41");
+			Assert.That (Table.Constraints.Count, Is.EqualTo (1), "test#42");
+			Assert.That (Table.PrimaryKey.Length, Is.EqualTo (0), "test#43");
+			Assert.That (Table.Rows.Count, Is.EqualTo (0), "test#44");
+			Assert.That (Table.TableName, Is.EqualTo ("author"), "test#45");
+			Assert.That (Table.Columns.Count, Is.EqualTo (3), "test#46");
 		}
-		
+
 		[Test]
 		public void ChildRows ()
 		{
-			
 			DataRelation Relation = new DataRelation ("Rel", Mom.Columns [1], Child.Columns [0]);
 			Set.Relations.Add (Relation);
 			
@@ -483,17 +471,16 @@ namespace MonoTests.System.Data
 			
 			DataRow Row = Mom.Rows [1];			
 			TempRow = Row.GetChildRows ("Rel") [0];
-			Assert.That (TempRow [0], Is.EqualTo("Dick"), "test#01");
-			Assert.That (TempRow [1].ToString (), Is.EqualTo("10"), "test#02");
+			Assert.That (TempRow [0], Is.EqualTo ("Dick"), "test#01");
+			Assert.That (TempRow [1].ToString (), Is.EqualTo ("10"), "test#02");
 			TempRow = TempRow.GetParentRow ("Rel");
-			Assert.That (TempRow [0], Is.EqualTo("teresa"), "test#03");
-			Assert.That (TempRow [1], Is.EqualTo("Dick"), "test#04");
+			Assert.That (TempRow [0], Is.EqualTo ("teresa"), "test#03");
+			Assert.That (TempRow [1], Is.EqualTo ("Dick"), "test#04");
 			
 			Row = Child.Rows [0];
 			TempRow = Row.GetParentRows ("Rel") [0];
-			Assert.That (TempRow [0], Is.EqualTo("teresa"), "test#05");
-			Assert.That (TempRow [1], Is.EqualTo("john"), "test#06");						
+			Assert.That (TempRow [0], Is.EqualTo ("teresa"), "test#05");
+			Assert.That (TempRow [1], Is.EqualTo ("john"), "test#06");						
 		}
-
-        }
+	}
 }

--- a/mcs/class/System.Data/Test/System.Data/UniqueConstraintTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/UniqueConstraintTest.cs
@@ -30,7 +30,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
 using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
 using System;
@@ -44,180 +43,169 @@ namespace MonoTests.System.Data
 		private DataTable _table;
 
 		[SetUp]
-		public void GetReady() {
+		public void GetReady ()
+		{
 
 			//Setup DataTable
-			_table = new DataTable("TestTable");
-			_table.Columns.Add("Col1",typeof(int));
-			_table.Columns.Add("Col2",typeof(int));
-			_table.Columns.Add("Col3",typeof(int));
+			_table = new DataTable ("TestTable");
+			_table.Columns.Add ("Col1", typeof(int));
+			_table.Columns.Add ("Col2", typeof(int));
+			_table.Columns.Add ("Col3", typeof(int));
 
 		}  
 
 		[Test]
-		public void CtorExceptions() {
+		public void CtorExceptions ()
+		{
 			//UniqueConstraint(string name, DataColumn column, bool isPrimaryKey)
 
 			UniqueConstraint cst;
 			
 			//must have DataTable exception
-			try{
+			try {
 				//Should throw an ArgumentException
 				//Can only add DataColumns that are attached
 				//to a DataTable
-				cst = new UniqueConstraint(new DataColumn(""));
+				cst = new UniqueConstraint (new DataColumn (""));
 
-				Assert.Fail("Failed to throw ArgumentException.");
-			} 
-			catch (Exception e) {
-				Assert.That (e, Is.TypeOf (typeof (ArgumentException)), "test#02");
-				// Never premise English.
-                        	// AssertEquals ("test#03", "Column must belong to a table.", e.Message);
-                        }        
+				Assert.Fail ("Failed to throw ArgumentException.");
+			} catch (Exception e) {
+				Assert.That (e, Is.TypeOf (typeof(ArgumentException)), "test#02");
+			}        
 
 			//Null exception
 			try {
 				//Should throw argument null exception
-				cst = new UniqueConstraint((DataColumn)null);
+				cst = new UniqueConstraint ((DataColumn)null);
+			} catch (Exception e) {
+				Assert.That (e, Is.TypeOf (typeof(NullReferenceException)), "test#05");
 			}
-                        catch (Exception e) {
-                                Assert.That (e, Is.TypeOf (typeof (NullReferenceException)), "test#05");
-				// Never premise English.
-                                //AssertEquals ("test#06", "Object reference not set to an instance of an object.", e.Message);
-                        }
 			
 			try {
 				//Should throw exception
 				//must have at least one valid column
 				//InvalidConstraintException is thrown by msft ver
-				cst = new UniqueConstraint(new DataColumn [] {});
+				cst = new UniqueConstraint (new DataColumn [] {});
 
-				Assert.Fail("B1: Failed to throw InvalidConstraintException.");
+				Assert.Fail ("B1: Failed to throw InvalidConstraintException.");
+			} catch (InvalidConstraintException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch {
+				Assert.Fail ("A3: Wrong Exception type.");
 			}
-			catch (InvalidConstraintException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch {
-				Assert.Fail("A3: Wrong Exception type.");
-			}
 
-			DataTable dt = new DataTable("Table1");
-			dt.Columns.Add("Col1",typeof(int));
-			DataTable dt2 = new DataTable("Table2");
-			dt2.Columns.Add("Col1",typeof(int));
+			DataTable dt = new DataTable ("Table1");
+			dt.Columns.Add ("Col1", typeof(int));
+			DataTable dt2 = new DataTable ("Table2");
+			dt2.Columns.Add ("Col1", typeof(int));
 
-			DataSet ds = new DataSet();
-			ds.Tables.Add(dt);
-			ds.Tables.Add(dt2);
+			DataSet ds = new DataSet ();
+			ds.Tables.Add (dt);
+			ds.Tables.Add (dt2);
 
 			//columns from two different tables.
 			try {
 				//next line should throw
 				//can't have columns from two different tables
-				cst = new UniqueConstraint(new DataColumn [] { 
+				cst = new UniqueConstraint (new DataColumn [] { 
 						 dt.Columns[0], dt2.Columns[0]});
 
-				Assert.Fail("B2: Failed to throw InvalidConstraintException");
+				Assert.Fail ("B2: Failed to throw InvalidConstraintException");
+			} catch (InvalidConstraintException) {
+			} catch (AssertionException exc) {
+				throw exc;
+			} catch {
+				Assert.Fail ("A4: Wrong Exception type.");
 			}
-			catch (InvalidConstraintException) {}
-			catch (AssertionException exc) {throw exc;}
-			catch {
-				Assert.Fail("A4: Wrong Exception type.");
-			}
-			
-
-			
 		}
 
 		[Test]
-		public void Ctor() {
-			
+		public void Ctor ()
+		{
 			UniqueConstraint cst;
 		
 			//Success case
 			try {
-				cst = new UniqueConstraint(_table.Columns[0]);
-			}
-			catch (Exception exc) {
-				Assert.Fail("A1: Failed to ctor. " + exc.ToString());
+				cst = new UniqueConstraint (_table.Columns [0]);
+			} catch (Exception exc) {
+				Assert.Fail ("A1: Failed to ctor. " + exc.ToString ());
 			}
 
-			
 			try {
-				cst = new UniqueConstraint( new DataColumn [] {
+				cst = new UniqueConstraint (new DataColumn [] {
 						_table.Columns[0], _table.Columns[1]});
-			}
-			catch (Exception exc) {
-				Assert.Fail("A2: Failed to ctor. " + exc.ToString());
+			} catch (Exception exc) {
+				Assert.Fail ("A2: Failed to ctor. " + exc.ToString ());
 			}
 
-			
 			//table is set on ctor
-			cst = new UniqueConstraint(_table.Columns[0]);
+			cst = new UniqueConstraint (_table.Columns [0]);
 			
-			Assert.That (cst.Table, Is.SameAs(_table), "B1");
+			Assert.That (cst.Table, Is.SameAs (_table), "B1");
 
 			//table is set on ctor
-			cst = new UniqueConstraint( new DataColumn [] {
+			cst = new UniqueConstraint (new DataColumn [] {
 				      _table.Columns[0], _table.Columns[1]});
-			Assert.That (cst.Table, Is.SameAs(_table), "B2");
+			Assert.That (cst.Table, Is.SameAs (_table), "B2");
 
-			cst = new UniqueConstraint("MyName",_table.Columns[0],true);
+			cst = new UniqueConstraint ("MyName", _table.Columns [0], true);
 
 			//Test ctor parm set for ConstraintName & IsPrimaryKey
-			Assert.That (cst.ConstraintName, Is.EqualTo("MyName"), "ConstraintName not set in ctor.");
-                        Assert.That (cst.IsPrimaryKey, Is.False, "IsPrimaryKey already set.");
+			Assert.That (cst.ConstraintName, Is.EqualTo ("MyName"), "ConstraintName not set in ctor.");
+			Assert.That (cst.IsPrimaryKey, Is.False, "IsPrimaryKey already set.");
                 
 			_table.Constraints.Add (cst);
 
-                        Assert.That (cst.IsPrimaryKey, Is.True, "IsPrimaryKey not set set.");
+			Assert.That (cst.IsPrimaryKey, Is.True, "IsPrimaryKey not set set.");
                 	
-                	Assert.That (_table.PrimaryKey.Length, Is.EqualTo(1), "PrimaryKey not set.");
-                	Assert.That (_table.PrimaryKey [0].Unique, Is.True, "Not unigue.");
-
+			Assert.That (_table.PrimaryKey.Length, Is.EqualTo (1), "PrimaryKey not set.");
+			Assert.That (_table.PrimaryKey [0].Unique, Is.True, "Not unigue.");
 		}
 
 		[Test]
-		public void Unique ()                             
+		public void Unique ()
 		{                                                     
 			UniqueConstraint U = new UniqueConstraint (_table.Columns [0]);
 			Assert.That (_table.Columns [0].Unique, Is.False, "test#01"); 
 			
-                        U = new UniqueConstraint (new DataColumn [] {_table.Columns [0],_table.Columns [1]});     
+			U = new UniqueConstraint (new DataColumn [] {_table.Columns [0],_table.Columns [1]});     
 			
 			Assert.That (_table.Columns [0].Unique, Is.False, "test#02");
-                        Assert.That (_table.Columns [1].Unique, Is.False, "test#03");
-                        Assert.That (_table.Columns [2].Unique, Is.False, "test#04");
+			Assert.That (_table.Columns [1].Unique, Is.False, "test#03");
+			Assert.That (_table.Columns [2].Unique, Is.False, "test#04");
 			
-                        _table.Constraints.Add (U);
-                        Assert.That (_table.Columns [0].Unique, Is.False, "test#05");
-                        Assert.That (_table.Columns [1].Unique, Is.False, "test#06");
-                        Assert.That (_table.Columns [2].Unique, Is.False, "test#07");
-                }                                                     
-		
+			_table.Constraints.Add (U);
+			Assert.That (_table.Columns [0].Unique, Is.False, "test#05");
+			Assert.That (_table.Columns [1].Unique, Is.False, "test#06");
+			Assert.That (_table.Columns [2].Unique, Is.False, "test#07");
+		}                                                     
+
 		[Test]
-		public void EqualsAndHashCode() {
-			UniqueConstraint cst = new UniqueConstraint( new DataColumn [] {
+		public void EqualsAndHashCode ()
+		{
+			UniqueConstraint cst = new UniqueConstraint (new DataColumn [] {
 					_table.Columns[0], _table.Columns[1]});
-			UniqueConstraint cst2 = new UniqueConstraint( new DataColumn [] {
+			UniqueConstraint cst2 = new UniqueConstraint (new DataColumn [] {
 					 _table.Columns[1], _table.Columns[0]});
 
-			UniqueConstraint cst3 = new UniqueConstraint(_table.Columns[0]);
-			UniqueConstraint cst4 = new UniqueConstraint(_table.Columns[2]);
+			UniqueConstraint cst3 = new UniqueConstraint (_table.Columns [0]);
+			UniqueConstraint cst4 = new UniqueConstraint (_table.Columns [2]);
 			
 			//true
-			Assert.That (cst.Equals(cst2), Is.True, "A0");
+			Assert.That (cst.Equals (cst2), Is.True, "A0");
 			
 			//false
-			Assert.That (cst.Equals(23), Is.False, "A1");
-			Assert.That (cst.Equals(cst3), Is.False, "A2");
-			Assert.That (cst3.Equals(cst), Is.False, "A3");
-			Assert.That (cst.Equals(cst4), Is.False, "A4");
+			Assert.That (cst.Equals (23), Is.False, "A1");
+			Assert.That (cst.Equals (cst3), Is.False, "A2");
+			Assert.That (cst3.Equals (cst), Is.False, "A3");
+			Assert.That (cst.Equals (cst4), Is.False, "A4");
 
 			//true
-			Assert.That (cst.GetHashCode(), Is.EqualTo(cst2.GetHashCode()), "HashEquals");
+			Assert.That (cst.GetHashCode (), Is.EqualTo (cst2.GetHashCode ()), "HashEquals");
 
 			//false
-			Assert.That (cst.GetHashCode(), Is.Not.EqualTo(cst3.GetHashCode()), "Hash Not Equals");
+			Assert.That (cst.GetHashCode (), Is.Not.EqualTo (cst3.GetHashCode ()), "Hash Not Equals");
 		}
 
 		[Test]


### PR DESCRIPTION
This is a follow-up to https://bugzilla.novell.com/show_bug.cgi?id=686503 : "Migrate MonoTests.System.Data.ConstraintCollectionTest to NUnit 2.4+ syntax", now with a few more files.
