### PR TITLE
Make System.Xaml reference depend on NET_4_0

### DIFF
--- a/mcs/class/WindowsBase/Makefile
+++ b/mcs/class/WindowsBase/Makefile
@@ -4,13 +4,14 @@ include ../../build/rules.make
 LIBRARY = WindowsBase.dll
 
 LIB_MCS_FLAGS = -unsafe -r:System -r:System.Xml
-TEST_MCS_FLAGS = -unsafe -r:WindowsBase.dll -r:System.Xaml.dll
+TEST_MCS_FLAGS = -unsafe -r:WindowsBase.dll
 
 ifeq (2.0, $(FRAMEWORK_VERSION))
 LIB_MCS_FLAGS += -d:NET_3_0
 endif
 ifeq (4.0, $(FRAMEWORK_VERSION))
 LIB_MCS_FLAGS += -d:NET_4_0 -r:System.Xaml.dll
+TEST_MCS_FLAGS += -r:System.Xaml.dll
 endif
 
 include ../../build/library.make


### PR DESCRIPTION
This assembly is 4.0 only and confuses the compiler when used in the 2.0 profile
