### PR TITLE
Expose mono_class_is_generic and mono_class_is_inflated to embedders.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -667,6 +667,20 @@ mono_class_get_generic_class (MonoClass *klass)
 	return klass->generic_class;
 }
 
+gboolean
+mono_class_is_generic (MonoClass *klass)
+{
+	g_assert (klass);
+	return (klass->is_generic);
+}
+
+gboolean
+mono_class_is_inflated (MonoClass *klass)
+{
+	g_assert (klass);
+	return (klass->is_inflated);
+}
+
 /*
  * mono_class_inflate_generic_type_with_mempool:
  * @mempool: a mempool

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -107,6 +107,12 @@ mono_class_is_subclass_of (MonoClass *klass, MonoClass *klassc,
 mono_bool
 mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass);
 
+mono_bool
+mono_class_is_generic (MonoClass *klass);
+
+mono_bool
+mono_class_is_inflated (MonoClass *klass);
+
 void*
 mono_ldtoken               (MonoImage *image, uint32_t token, MonoClass **retclass, MonoGenericContext *context);
 


### PR DESCRIPTION
- class.c:
- class.h: Expose mono_class_is_generic and mono_class_is_inflated.

License: MIT/X11
