### PR TITLE
[FreeBSD] fix build with libiconv

### DIFF
--- a/eglib/test/Makefile.am
+++ b/eglib/test/Makefile.am
@@ -32,7 +32,9 @@ SOURCES = \
 test_eglib_SOURCES = $(SOURCES)
 
 test_eglib_CFLAGS = -Wall -D_FORTIFY_SOURCE=2 -I$(srcdir)/../src -I../src -DDRIVER_NAME=\"EGlib\"
-test_eglib_LDADD = ../src/libeglib.la
+test_eglib_LDADD = \
+	../src/libeglib.la \
+	$(LIBICONV)
 
 run-eglib: all
 	srcdir=`readlink -f $(srcdir)` ./test-eglib

--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -34,7 +34,8 @@ monodis_LDADD = 			\
 	libmonodis.a			\
 	$(runtime_lib)			\
 	$(LLVM_LIBS)			\
-	$(GLIB_LIBS) 
+	$(GLIB_LIBS)            \
+	$(LIBICONV)
 
 if PLATFORM_DARWIN
 monodis_LDFLAGS=-framework CoreFoundation

--- a/mono/monograph/Makefile.am
+++ b/mono/monograph/Makefile.am
@@ -19,6 +19,7 @@ monograph_LDADD = \
 	$(runtime_lib)			\
 	$(GLIB_LIBS)			\
 	$(LLVM_LIBS)			\
+	$(LIBICONV)			\
 	-lm
 
 GRAPHS=System.Object System.Enum System.Attribute System.ValueType System.Reflection.MemberInfo


### PR DESCRIPTION
Hello,

I'm building a mono git pulled from time to time (as a hobby...).
Recently, mono has stopped building at some places, asking for libiconv and a few of its methods.
It seems this commit could fix that.
I'm not sure that could be the best way to fix it, but at least I can build Mono from a fresh git pull with these changes.
