### PR TITLE
[XBuild) Make RemoveDir task able to recursively delete the content of a directory

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/RemoveDir.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/RemoveDir.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Tasks {
 			
 			foreach (ITaskItem directory in directories) {
 				try {
-					Directory.Delete (directory.GetMetadata ("FullPath"));
+					Directory.Delete (directory.GetMetadata ("FullPath"), true);
 					temporaryRemovedDirectories.Add (directory);
 				}
 				catch (DirectoryNotFoundException ex) {


### PR DESCRIPTION
According to [MSDN](http://msdn.microsoft.com/en-us/library/xyfz6ddb.aspx), RemoveDir task "Removes the specified directories and all of its files and subdirectories."
