### PR TITLE
SqlDbType missing values.

### DIFF
--- a/mcs/class/System.Data/System.Data/SqlDbType.cs
+++ b/mcs/class/System.Data/System.Data/SqlDbType.cs
@@ -69,6 +69,7 @@ namespace System.Data
 #if NET_2_0
 		Xml = 25,
 		Udt = 29,
+		Structured = 30,
 		Date = 31,
 		Time = 32,
 		DateTime2 = 33,


### PR DESCRIPTION
Enum SqlDbType (FW3.5, FW4.0) has two more values DateTime2 and DateTimeOffset.
