### PR TITLE
[Fix] #635971 Fixed throwing exception in case of using zero timeout. Now

### DIFF
--- a/mcs/class/System/System.IO.Ports/SerialPort.cs
+++ b/mcs/class/System/System.IO.Ports/SerialPort.cs
@@ -388,7 +388,7 @@ namespace System.IO.Ports
 				return read_timeout;
 			}
 			set {
-				if (value <= 0 && value != InfiniteTimeout)
+				if (value < 0 && value != InfiniteTimeout)
 					throw new ArgumentOutOfRangeException ("value");
 
 				if (is_open)
@@ -476,7 +476,7 @@ namespace System.IO.Ports
 				return write_timeout;
 			}
 			set {
-				if (value <= 0 && value != InfiniteTimeout)
+				if (value < 0 && value != InfiniteTimeout)
 					throw new ArgumentOutOfRangeException ("value");
 
 				if (is_open)

--- a/mcs/class/System/Test/System.IO.Ports/SerialPortTest.cs
+++ b/mcs/class/System/Test/System.IO.Ports/SerialPortTest.cs
@@ -70,6 +70,24 @@ namespace MonoTests.System.IO.Ports
 			Assert.IsTrue(exceptionCatched,
 				"Exception not thrown despite wrong baud rate");
 		}
+
+		/// <summary>
+		/// This test is related to bug #635971
+		/// </summary>
+		[Test]
+		public void ZeroTimeout ()
+		{
+			var sp = new SerialPort ();
+			var exceptionThrown = false;
+			try {
+				sp.ReadTimeout = 0;
+			} catch(ArgumentOutOfRangeException) {
+				exceptionThrown = true;
+			}
+			Assert.IsFalse(exceptionThrown,
+				"Exception thrown despite proper timeout (0)");
+		}
+
 	}
 }
 


### PR DESCRIPTION
[Fix] #635971 Fixed throwing exception in case of using zero timeout. Now it is legal.

For details, please see bug description and comments on bugzilla.
