### PR TITLE
Mono.Tasklets: Suppress Continuation finalization when explicitly disposed.

### DIFF
--- a/mcs/class/Mono.Tasklets/Mono.Tasklets/Continuation.cs
+++ b/mcs/class/Mono.Tasklets/Mono.Tasklets/Continuation.cs
@@ -48,6 +48,7 @@ namespace Mono.Tasklets {
 			if (cont != IntPtr.Zero){
 				free (cont);
 				cont = IntPtr.Zero;
+				GC.SuppressFinalize (this);
 			}
 		}
 


### PR DESCRIPTION
Mono.Tasklets: Suppress Continuation finalization when explicitly disposed.
