### PR TITLE
Mono.Debugger.Soft: Really fix parameter types in MethodMirror.FullName.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -61,7 +61,7 @@ namespace Mono.Debugger.Soft
 				sb.Append(" ");
 				sb.Append("(");
 				for (var i = 0; i < param_info.Length; i++) {
-					sb.Append(param_info[i].Name);
+					sb.Append(param_info[i].ParameterType.Name);
 					if (i != param_info.Length - 1)
 						sb.Append(", ");
 				}


### PR DESCRIPTION
Mono.Debugger.Soft: Really fix parameter types in MethodMirror.FullName.
