### PR TITLE
Please review! thanks

### DIFF
--- a/mcs/class/System.Data.Linq/src/DbLinq/Data/Linq/DataContext.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Data/Linq/DataContext.cs
@@ -987,7 +987,7 @@ namespace DbLinq.Data.Linq
         /// <summary>
         /// Execute raw SQL query and return object
         /// </summary>
-        public IEnumerable<TResult> ExecuteQuery<TResult>(string query, params object[] parameters) where TResult : class, new()
+        public IEnumerable<TResult> ExecuteQuery<TResult>(string query, params object[] parameters) where TResult : new()
         {
             if (query == null)
                 throw new ArgumentNullException("query");


### PR DESCRIPTION
System.Data.Linq: Fix DataContext.ExecuteQuery<T>(..) to allow primitive types for T

This should fix https://bugzilla.novell.com/show_bug.cgi?id=699803
