### PR TITLE
System.Data.Linq: Fix DataContext.CreateExecuteQueryEnumerable<T>(..) to allow primitive types for T

### DIFF
--- a/mcs/class/System.Data.Linq/src/DbLinq/Data/Linq/DataContext.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Data/Linq/DataContext.cs
@@ -996,7 +996,7 @@ namespace DbLinq.Data.Linq
         }
 
         private IEnumerable<TResult> CreateExecuteQueryEnumerable<TResult>(string query, object[] parameters)
-            where TResult : class, new()
+            where TResult : new()
         {
             foreach (TResult result in ExecuteQuery(typeof(TResult), query, parameters))
                 yield return result;


### PR DESCRIPTION
System.Data.Linq: Fix DataContext.CreateExecuteQueryEnumerable<T>(..) to allow primitive types for T
