### PR TITLE
Avoid references to pthread_t when building for win32.

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -173,7 +173,9 @@ mono_gc_base_init (void)
 	memset (&cb, 0, sizeof (cb));
 	cb.thread_register = boehm_thread_register;
 	cb.mono_method_is_critical = (gpointer)mono_runtime_is_critical_method;
+#ifndef HOST_WIN32
 	cb.mono_gc_pthread_create = (gpointer)mono_gc_pthread_create;
+#endif
 	
 	mono_threads_init (&cb, sizeof (MonoThreadInfo));
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -97,7 +97,9 @@ typedef struct {
 	void (*thread_unregister)(THREAD_INFO_TYPE *info);
 	void (*thread_attach)(THREAD_INFO_TYPE *info);
 	gboolean (*mono_method_is_critical) (void *method);
+#ifndef HOST_WIN32
 	int (*mono_gc_pthread_create) (pthread_t *new_thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg);
+#endif
 } MonoThreadInfoCallbacks;
 
 typedef struct {


### PR DESCRIPTION
Just a small fix I needed for my mingw build.
