### PR TITLE
Improve handling of custom versions of mscorlib

### DIFF
--- a/mcs/mcs/assembly.cs
+++ b/mcs/mcs/assembly.cs
@@ -1122,7 +1122,8 @@ namespace Mono.CSharp
 			compiler.TimeReporter.Start (TimeReporter.TimerType.ReferencesLoading);
 
 			loaded = new List<Tuple<RootNamespace, T>> ();
-
+			bool isDefault = false;
+			
 			//
 			// Load mscorlib.dll as the first
 			//
@@ -1130,6 +1131,7 @@ namespace Mono.CSharp
 				corlib_assembly = LoadAssemblyDefault ("mscorlib.dll");
 			} else {
 				corlib_assembly = default (T);
+				isDefault = true;
 			}
 
 			T a;
@@ -1143,12 +1145,17 @@ namespace Mono.CSharp
 					continue;
 
 				// A corlib assembly is the first assembly which contains System.Object
-				if (corlib_assembly == null && HasObjectType (a)) {
+				if ((corlib_assembly == null || isDefault) && HasObjectType (a)) {
 					corlib_assembly = a;
+					isDefault = false;
 					continue;
 				}
 
 				loaded.Add (key);
+			}
+			
+			if (! isDefault) {
+				module.Compiler.Settings.StdLib = true;
 			}
 
 			foreach (var entry in module.Compiler.Settings.AssemblyReferencesAliases) {


### PR DESCRIPTION
If /nostdlib is specified on the command line, but an assembly is referenced that defines System.Object then:
1. That assembly will be used as the mscorlib assembly.
2. The compiler will behave as if /nostdlib is not specified.

This makes building assemblies that references custom versions of mscorlib with csc.exe or mcs much easier. 
