### PR TITLE
Added "put certificate" support to export certificate from cert store to a file

### DIFF
--- a/mcs/tools/security/certmgr.cs
+++ b/mcs/tools/security/certmgr.cs
@@ -41,13 +41,14 @@ namespace Mono.Tools {
 			Console.WriteLine ("   or: certmgr -list object-type [options] store");
 			Console.WriteLine ("   or: certmgr -del object-type [options] store certhash");
 			Console.WriteLine ("   or: certmgr -ssl [options] url");
+			Console.WriteLine ("   or: certmgr -put object-type [options] store certfile");
 			Console.WriteLine ("   or: certmgr -importKey [options] store pkcs12file");
 			Console.WriteLine ();
 			Console.WriteLine ("actions");
 			Console.WriteLine ("\t-add\t\tAdd a certificate, CRL or CTL to specified store");
 			Console.WriteLine ("\t-del\t\tRemove a certificate, CRL or CTL to specified store");
 			Console.WriteLine ("\t-put\t\tCopy a certificate, CRL or CTL from a store to a file");
-			Console.WriteLine ("\t-list\t\tList certificates, CRL ot CTL in the specified store.");
+			Console.WriteLine ("\t-list\t\tList certificates, CRL or CTL in the specified store.");
 			Console.WriteLine ("\t-ssl\t\tDownload and add certificates from an SSL session");
 			Console.WriteLine ("\t-importKey\tImport PKCS12 privateKey to keypair store.");
 			Console.WriteLine ("object types");
@@ -58,6 +59,7 @@ namespace Mono.Tools {
 			Console.WriteLine ("\t-m\t\tuse the machine certificate store (default to user)");
 			Console.WriteLine ("\t-v\t\tverbose mode (display status for every steps)");
 			Console.WriteLine ("\t-p [password]\tPassword used to decrypt PKCS12");
+			Console.WriteLine ("\t-pem\t\tPut certificate in Base-64 encoded format (default DER encoded)");
 			Console.WriteLine ("\t-?\t\th[elp]\tDisplay this help message");
 			Console.WriteLine ();
 		}
@@ -174,6 +176,30 @@ namespace Mono.Tools {
 			int end = pem.IndexOf (footer, start);
 			string base64 = pem.Substring (start, (end - start));
 			return Convert.FromBase64String (base64);
+		}
+		
+		static byte[] ToPEM(string type, byte[] data)
+		{
+			string header = String.Format ("-----BEGIN {0}-----", type);
+			string footer = String.Format ("-----END {0}-----", type);
+			
+			Encoding encoding = new System.Text.ASCIIEncoding();           
+			string encodedString = Convert.ToBase64String(data);
+
+			StringBuilder sb = new StringBuilder();
+			int remaining = encodedString.Length;
+			sb.AppendLine(header);
+			for (int i = 0; i <= encodedString.Length; i += 64)	{
+				if (remaining >= 64) {
+					sb.AppendLine(encodedString.Substring(i, 64));
+				}
+				else {
+					sb.AppendLine(encodedString.Substring(i, remaining));
+				}
+				remaining -= 64;
+			}
+			sb.AppendLine(footer);
+			return encoding.GetBytes(sb.ToString());
 		}
 
 		static X509CertificateCollection LoadCertificates (string filename, string password, bool verbose) 
@@ -308,18 +334,49 @@ namespace Mono.Tools {
 			}
 		}
 
-		static void Put (ObjectType type, X509Store store, string file, string password, bool verbose) 
+		static void Put (ObjectType type, X509Store store, string file, bool machine, bool pem, bool verbose) 
 		{
-			throw new NotImplementedException ("Put not yet supported");
-/*			switch (type) {
+			if(string.IsNullOrEmpty(file))
+			{
+				Console.Error.WriteLine("error: no filename provided to put the certificate.");
+				Help();
+				return;
+			}
+			switch (type) {
 				case ObjectType.Certificate:
-					break;
-				case ObjectType.CRL:
-					// TODO
+					for(int i = 0; i < store.Certificates.Count; i++)
+					{
+						Console.WriteLine("==============Certificate # {0} ==========", i + 1);
+						DisplayCertificate(store.Certificates[i], machine, verbose);
+					}
+					int selection;
+					Console.Write("Enter cert # from the above list to put-->");
+					if(!int.TryParse(Console.ReadLine(), out selection)
+				   		|| selection > store.Certificates.Count)
+					{
+						Console.Error.WriteLine("error: invalid selection.");
+						return;
+					}
+				
+					SSCX.X509Certificate2 cert = new SSCX.X509Certificate2(store.Certificates[selection-1].RawData);
+					byte[] data = null;
+					if(pem) {
+						data = ToPEM("CERTIFICATE", cert.Export(SSCX.X509ContentType.Cert));
+					}
+					else {
+						data = cert.Export(SSCX.X509ContentType.Cert);
+					}
+					
+					using (FileStream fs = File.Create(file))
+					{
+						fs.Write(data, 0, data.Length);
+					}
+					
+					Console.WriteLine ("Certificate put to {0}.", file);
 					break;
 				default:
-					throw new NotSupportedException (type.ToString ());
-			}*/
+					throw new NotSupportedException ("Put " + type + " not supported yet");
+			}
 		}
 
 		static void DisplayCertificate (X509Certificate x509, bool machine, bool verbose)
@@ -563,6 +620,9 @@ namespace Mono.Tools {
 		static void Main (string[] args)
 		{
 			string password = null;
+			bool verbose = false;
+			bool pem = false;
+			bool machine = false;
 
 			Header ();
 			if (args.Length < 2) {
@@ -580,19 +640,29 @@ namespace Mono.Tools {
 					n++;
 			}
 			
-			bool verbose = (GetCommand (args [n]) == "V");
-			if (verbose)
-				n++;
-			bool machine = (GetCommand (args [n]) == "M");
-			if (machine)
-				n++;
-
-			if (GetCommand (args [n]) == "P")
+			for (int i = n; i < args.Length; i++)
 			{
-				n++;
-				password = args[n++];
+				switch(GetCommand(args[i]))
+				{
+					case "V":
+						verbose = true;
+						n++;
+						break;
+					case "M":
+						machine = true;
+						n++;
+						break;
+					case "P":
+						password = args[++n];
+						n++;
+						break;
+					case "PEM":
+						pem = true;
+						n++;
+						break;
+				}
 			}
-
+			
 			X509Store store = null;
 			string storeName = null;
 			if (action != Action.Ssl) {
@@ -631,7 +701,7 @@ namespace Mono.Tools {
 					Delete (type, store, file, verbose);
 					break;
 				case Action.Put:
-					Put (type, store, file, password, verbose);
+					Put (type, store, file, machine, pem, verbose);
 					break;
 				case Action.List:
 					List (type, store, machine, file, verbose);


### PR DESCRIPTION
I've tried to replicate the behavior of microsoft certmgr tool (displaying list of certificates in the store and choosing a number from that list to put it to a file). I also added ability to export certificate to base-64 encoded format (saving an extra step and hassle -- of using openssl to convert -- for people who need the cert in that format) by specifying -pem option. Also re-factored the option parsing code to be able to parse options regardless of their order.
