### PR TITLE
Move architecture detection to new mono-arch.h in utils.

### DIFF
--- a/mcs/class/corlib/System/Console.cs
+++ b/mcs/class/corlib/System/Console.cs
@@ -93,6 +93,12 @@ namespace System
 		private static TextWriter stderr;
 		private static TextReader stdin;
 
+#if NET_4_5
+		static TextWriter console_stdout;
+		static TextWriter console_stderr;
+		static TextReader console_stdin;
+#endif
+
 		static Console ()
 		{
 #if NET_2_1
@@ -159,6 +165,12 @@ namespace System
 			}
 #endif
 
+#if NET_4_5
+			console_stderr = stderr;
+			console_stdout = stdout;
+			console_stdin = stdin;
+#endif
+
 			GC.SuppressFinalize (stdout);
 			GC.SuppressFinalize (stderr);
 			GC.SuppressFinalize (stdin);
@@ -181,6 +193,26 @@ namespace System
 				return stdin;
 			}
 		}
+
+#if NET_4_5
+		public static bool IsErrorRedirected {
+			get {
+				return stderr != console_stderr;
+			}
+		}
+
+		public static bool IsOutputRedirected {
+			get {
+				return stdout != console_stdout;
+			}
+		}
+
+		public static bool IsInputRedirected {
+			get {
+				return stdin != console_stdin;
+			}
+		}
+#endif
 
 		private static Stream Open (IntPtr handle, FileAccess access, int bufferSize)
 		{


### PR DESCRIPTION
This moves compile-time architecture detection to a central header.

You generally consume the header by checking the MONO_ARCH constant against the MONO_ARCH_\* defines. Alternatively, you can check for MONO_ARCH_IS_\* when you need to check for two architectures; e.g. if you want to use an x86 feature which is available on both x86 and x86-64, you can just check if MONO_ARCH_IS_X86 is defined.

The commit includes one example conversion from the "old-style" checks to mono-arch.h. A lot of work still needs to be put into converting the rest of the runtime code.

Code contributed under the BSD license.
