### PR TITLE
In WCF customBinding accept ContentType which contain extra parameter.

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageEncoder.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageEncoder.cs
@@ -55,7 +55,7 @@ namespace System.ServiceModel.Channels
 				throw new ArgumentNullException ("contentType");
 			int idx = contentType.IndexOf (';');
 			if (idx > 0)
-				return contentType == ContentType;
+				return contentType.StartsWith(ContentType);
 			return contentType == MediaType;
 		}
 


### PR DESCRIPTION
From http://www.ietf.org/rfc/rfc3902.txt the Content-Type header
for application/soap+xml can contain "action" optional parameter.

Exemple :
Content-Type: application/soap+xml; charset=utf-8; action="http://fabrikam123.com/Service/OneWay"
