### PR TITLE
Encoding constants should be in lower case.

### DIFF
--- a/mcs/class/corlib/System.Text/Encoding.cs
+++ b/mcs/class/corlib/System.Text/Encoding.cs
@@ -621,7 +621,7 @@ public abstract class Encoding : ICloneable
 			return GetEncoding (UTF8Encoding.UTF8_CODE_PAGE);
 		
 		case "utf_16":
-		case "UTF_16LE":
+		case "utf_16le":
 		case "ucs_2":
 		case "unicode":
 		case "iso_10646_ucs2":
@@ -632,11 +632,11 @@ public abstract class Encoding : ICloneable
 			return GetEncoding (UnicodeEncoding.BIG_UNICODE_CODE_PAGE);
 		
 		case "utf_32":
-		case "UTF_32LE":
+		case "utf_32le":
 		case "ucs_4":
 			return GetEncoding (UTF32Encoding.UTF32_CODE_PAGE);
 
-		case "UTF_32BE":
+		case "utf_32be":
 			return GetEncoding (UTF32Encoding.BIG_UTF32_CODE_PAGE);
 
 #if !MOONLIGHT


### PR DESCRIPTION
name.ToLowerInvariant ().Replace ('-', '_') should ensure that they
are all lowercase.

https://github.com/mono/mono/commit/145d6be351c20de3855f003d24719eba6b713db5#mcs/class/corlib/System.Text/Encoding.cs-P110
