### PR TITLE
"make dist" do not work in branch mono-2-10

### DIFF
--- a/mcs/class/System/System_test.dll.sources
+++ b/mcs/class/System/System_test.dll.sources
@@ -26,7 +26,6 @@ System/LdapStyleUriParserTest.cs
 System/NetPipeStyleUriParserTest.cs
 System/NetTcpStyleUriParserTest.cs
 System/NewsStyleUriParserTest.cs
-System/Platform.cs
 System/UriBuilderTest.cs
 System/UriParserTest.cs
 System/UriTest.cs


### PR DESCRIPTION
The line "System/Platform.cs" prevent "make dist" to work on the mono-2-10 branch (the platform.cs file is searched in Test/System directory).
