### PR TITLE
Use the action in the HTTP header if possible.

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TextMessageEncoder.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TextMessageEncoder.cs
@@ -60,13 +60,28 @@ namespace System.ServiceModel.Channels
 			get { return version; }
 		}
 
+		private static System.Text.RegularExpressions.Regex getAction = new Text.RegularExpressions.Regex("action=\"(.*)\"");
+
+		private static string GetActionFromContentType(string contentType)
+		{
+			if (contentType == null)
+				return string.Empty;
+			System.Text.RegularExpressions.Match match = getAction.Match(contentType);
+
+			if (match.Success)
+				return match.Groups[1].Value;
+			else
+				return string.Empty;
+
+		}
+
 		[MonoTODO]
 		public override Message ReadMessage (ArraySegment<byte> buffer,
 			BufferManager bufferManager, string contentType)
 		{
 			if (bufferManager == null)
 				throw new ArgumentNullException ("bufferManager");
-			return Message.CreateMessage (
+			var ret = Message.CreateMessage (
 				XmlDictionaryReader.CreateDictionaryReader (
 					XmlReader.Create (new StreamReader (
 						new MemoryStream (
@@ -75,6 +90,12 @@ namespace System.ServiceModel.Channels
 				// FIXME: supply max header size
 				int.MaxValue,
 				version);
+
+			string action = GetActionFromContentType(contentType);
+			if (!string.IsNullOrEmpty(action))
+				ret.Headers.Action = action;
+
+			return ret;
 		}
 
 		public override Message ReadMessage (Stream stream,
@@ -88,6 +109,11 @@ namespace System.ServiceModel.Channels
 				maxSizeOfHeaders,
 				version);
 			ret.Properties.Encoder = this;
+
+			string action = GetActionFromContentType(contentType);
+			if (!string.IsNullOrEmpty(action))
+				ret.Headers.Action = action;
+
 			return ret;
 		}
 


### PR DESCRIPTION
I have to communicate with a Soap 1.2 webservice based on GSoap. 
It do not send an header in the soap envelop with the action. But it send the action in the content-type http header.

Exemple :

``` xml
   POST / HTTP/1.1
   Host: 172.16.5.7:1415
   User-Agent: gSOAP/2.8
   Content-Type: application/soap+xml; charset=utf-8; action="http://localhost/notifications/StatusNotify"
   Content-Length: 49432
   Connection: keep-alive
   Authorization: Basic xxxxxxxxx
   SOAPAction: "http://localhost/notifications/StatusNotify"

   <?xml version="1.0" encoding="UTF-8"?>
   <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:vmx="http://www.exemple.com/VMX/ver10/schema" xmlns:vmxen="http://www.exemple.com/VMX/ver10/enumeration/wsdl" xmlns:vmxnfmgr="http://www.exemple.com/VMX/ver10/notifications/wsdl/StatusNotificationManagerBinding" xmlns:vmxnfscbr="http://www.exemple.com/VMX/ver10/notifications/wsdl/StatusSubscriberBinding" xmlns:vmxnf="http://www.exemple.com/VMX/ver10/notifications/wsdl">
   <SOAP-ENV:Body><vmxnf:StatusNofity><vmxnf:SubscriptionId>623</vmxnf:SubscriptionId> ...
   </vmxnf:StatusNofity></SOAP-ENV:Body>
```

.Net support it but not mono. I  make a change to add the action from the http header after decoding.
But I am not sure this is the right way.
