### PR TITLE
Fixed SKEL_DIRECTORY definition in Release build of jay2010.vcxproj

### DIFF
--- a/mcs/jay/jay2010.vcxproj
+++ b/mcs/jay/jay2010.vcxproj
@@ -76,7 +76,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>SKEL_DIRECTORY=.;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SKEL_DIRECTORY=".";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>


### PR DESCRIPTION
Previously, compiling jay2010 in Release mode caused the compiler to give the following error:
error C2059: syntax error : '.'
