### PR TITLE
[winforms] DataGridView row height resize handles added for bug #490247

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -4417,7 +4417,9 @@ namespace System.Windows.Forms {
 				return;
 			}
 
-			if (hitTest.Type == DataGridViewHitTestType.RowHeader && MouseOverRowResize (hitTest.RowIndex, e.Y)) {
+			if ((hitTest.Type == DataGridViewHitTestType.RowHeader ||
+			     (hitTest.Type == DataGridViewHitTestType.Cell && !RowHeadersVisible))
+			    && MouseOverRowResize (hitTest.RowIndex, e.Y)) {
 				if (e.Clicks == 2) {
 					AutoResizeRow (hitTest.RowIndex);
 					return;
@@ -4512,6 +4514,9 @@ namespace System.Windows.Forms {
 				EnteredHeaderCell = Columns [hit.ColumnIndex].HeaderCell;
 				if (MouseOverColumnResize (hit.ColumnIndex, e.X))
 					new_cursor = Cursors.VSplit;
+			} else if (!RowHeadersVisible && hit.Type == DataGridViewHitTestType.Cell && MouseOverRowResize (hit.RowIndex, e.Y)) {
+				EnteredHeaderCell = Rows[hit.RowIndex].HeaderCell;
+				new_cursor = Cursors.HSplit;
 			} else if (hit.Type == DataGridViewHitTestType.Cell) {
 				EnteredHeaderCell = null;
 


### PR DESCRIPTION
As shown in the sample attached to the bug report, https://bugzilla.novell.com/show_bug.cgi?id=490247, mono's DataGridView is missing some resize handle cases compared to the .Net DataGridView. This patch adds the row height resizing handles to the cells when the row headers are hidden.
