### PR TITLE
Fix Service Model Xml Serialization and XMLAttributes

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs
@@ -65,6 +65,7 @@ namespace System.ServiceModel.Dispatcher
 			m.IsReturnValue = isReturnValue;
 			m.MemberName = partDesc.Name;
 			m.MemberType = partDesc.Type;
+			m.XmlAttributes = new XmlAttributes(partDesc.MemberInfo);
 			return m;
 		}
 


### PR DESCRIPTION
TypedMessageConverter do not take into account the xml attributes which modify the serialization. 
I got this problem with data sent by a gSoap webservice  which work on .Net and not on Mono. 

Correction and Unit Test.
