### PR TITLE
fix for bug 708178 that would fail if the type wasnt IEnumerable, should check if it implement IEnumerable rather than is IEnumerable

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/TypeData.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/TypeData.cs
@@ -450,7 +450,7 @@ namespace System.Xml.Serialization
 #if NET_2_0
 		internal static Type GetGenericListItemType (Type type)
 		{
-			if (type.IsGenericType && type.GetGenericTypeDefinition () == typeof (IEnumerable<>)) {
+			if (type.IsGenericType && typeof(IEnumerable).IsAssignableFrom(type.GetGenericTypeDefinition ())) {
 				Type [] gatypes = type.GetGenericArguments ();
 				if (type.GetMethod ("Add", gatypes) != null)
 					return gatypes [0];

--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlReflectionImporterTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlReflectionImporterTests.cs
@@ -1635,6 +1635,27 @@ namespace MonoTests.System.XmlSerialization
 			var xs = new XmlSerializer (typeof (Bug704813Type));
 			xs.Serialize (TextWriter.Null, new Bug704813Type ());
 		}
+
+		[Test]
+		public void Bug708178Type()
+		{
+			XmlSerializer xmlSerializer = new XmlSerializer (typeof(Bug708178Type));
+			Bug708178Type bugType = new Bug708178Type ();
+			bugType.Foo.Add ("test");
+			Assert.AreEqual (1, bugType.Foo.Count);
+		 
+			//xml Serialize
+			TextWriter WriteFileStream = new StreamWriter (@"Bug708178Type.xml", false);
+			xmlSerializer.Serialize (WriteFileStream, bugType);
+			WriteFileStream.Close ();
+		 
+			//xml Deserialize
+			FileStream ReadFileStream = new FileStream (@"Bug708178Type.xml", FileMode.Open, FileAccess.Read, FileShare.Read);
+			Bug708178Type bugTypeReload = (Bug708178Type)xmlSerializer.Deserialize (ReadFileStream);
+		 
+			//should have deserialized the relationship
+			Assert.AreEqual(1, bugTypeReload.Foo.Count);
+	       }
 #endif
 
 		public class Employee : IXmlSerializable

--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTestClasses.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTestClasses.cs
@@ -968,6 +968,16 @@ namespace MonoTests.System.Xml.TestClasses
 		}
 	}
 
+	public class Bug708178Type
+	{
+		List<string> foo = new List<string> ();
+
+		[XmlArray("Foo"), XmlArrayItem("Foo", typeof(string))]
+		public List<string> Foo {
+			get { return foo; }
+		}                
+	}
+
 	[XmlRoot("root")]
 	public class ExplicitlyOrderedMembersType1
 	{


### PR DESCRIPTION
[708178] - Type check invalid and breaks XmlSerialization if serializing ICollection<> types
