### PR TITLE
Fix mono tarball tests

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -864,6 +864,8 @@ test-generic-sharing-managed: test-runner.exe $(GSHARED_TESTS)
 test-generic-sharing:
 	@if test x$(M) != x; then $(MAKE) test-generic-sharing-managed; else $(MAKE) test-generic-sharing-normal; fi
 
+EXTRA_DIST += delegate2.exe.config
+
 EXTRA_DIST += async-exceptions.cs
 async-exceptions.exe : async-exceptions.cs
 	$(MCS) -out:async-exceptions.exe $(srcdir)/async-exceptions.cs


### PR DESCRIPTION
Include mono/tests/delegate2.exe.config in the source tarball so that the tests pass
