### PR TITLE
added Quit method to csharp eval

### DIFF
--- a/mcs/mcs/eval.cs
+++ b/mcs/mcs/eval.cs
@@ -988,6 +988,13 @@ namespace Mono.CSharp
 			}
 		}
 
+		/// <summary>
+		///   Same as quit - useful in script scenerios
+		/// </summary>
+		static public void Quit () {
+			QuitRequested = true;
+		}
+
 #if !NET_2_1
 		/// <summary>
 		///   Describes an object or a type.


### PR DESCRIPTION
this could be useful in scripting scenarios e.g. consider following csharp script:
# !/usr/bin/csharp

if(someCondition)
    doSomething()
else
    Quit(); // ... yes i can use: var o = quit; but this generates warning
