### PR TITLE
Bug-833 - Path.GetFullPath returns double DirectorySeparatorChar if cwd == DirectorySeparatorChar

### DIFF
--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -356,10 +356,10 @@ namespace System.IO {
 					canonicalize = start > 0;
 					
 					var cwd = Directory.GetCurrentDirectory();
-                    if (cwd.EndsWith(DirectorySeparatorStr))
-                        path = cwd + path;
-                    else
-                        path = cwd + DirectorySeparatorChar + path;
+					if (cwd.EndsWith(DirectorySeparatorStr))
+						path = cwd + path;
+					else
+						path = cwd + DirectorySeparatorChar + path;
 				} else if (DirectorySeparatorChar == '\\' &&
 					path.Length >= 2 &&
 					IsDsc (path [0]) &&


### PR DESCRIPTION
Check if ending of Directory.GetCurrentDirectory() ends in DirectorySeparatorChar and don't append if it does.

Was concerned about UNC paths, but '\\\' is invalid. This means that even if GetCurrentDirectory() happened to return a '\' an extra DirectorySeparatorChar is invalid.
