### PR TITLE
Fully resolve ContractHelper (broke build on my machine)

### DIFF
--- a/mcs/class/Mono.CodeContracts/Mono.CodeContracts.Rewrite/ContractsRuntime.cs
+++ b/mcs/class/Mono.CodeContracts/Mono.CodeContracts.Rewrite/ContractsRuntime.cs
@@ -196,7 +196,7 @@ namespace Mono.CodeContracts.Rewrite {
 				TypeReference typeContractFailureKind = this.module.Import (typeof (ContractFailureKind));
 				TypeReference typeString = this.module.Import (typeof (string));
 				TypeReference typeException = this.module.Import (typeof (Exception));
-				MethodReference mRaiseContractFailedEvent = this.module.Import (typeof (ContractHelper).GetMethod ("RaiseContractFailedEvent"));
+				MethodReference mRaiseContractFailedEvent = this.module.Import (typeof (System.Runtime.CompilerServices.ContractHelper).GetMethod ("RaiseContractFailedEvent"));
 				// Create method
 				MethodDefinition method = new MethodDefinition ("ReportFailure",
 					MethodAttributes.Assembly | MethodAttributes.Static, typeVoid);


### PR DESCRIPTION
Build error (only tested 235a41e76d59f5021bfc2b895e5571f20d6d87e0):

```
Mono.CodeContracts.Rewrite/ContractsRuntime.cs(199,105): error CS0104: `ContractHelper' is an ambiguous reference between `System.Diagnostics.Contracts.Internal.ContractHelper' and `System.Runtime.CompilerServices.ContractHelper'
```

Unsure if this is affecting anyone else... but it's "good" practice anyways (or at least used elsewhere in the file).
