### PR TITLE
Fix for Chunked transfer

### DIFF
--- a/mcs/class/System/System.Net/ChunkStream.cs
+++ b/mcs/class/System/System.Net/ChunkStream.cs
@@ -178,7 +178,7 @@ namespace System.Net
 		}
 
 		public int ChunkLeft {
-			get { return chunkSize - chunkRead; }
+			get { return Math.Max( chunkSize - chunkRead, 0 ); }
 		}
 		
 		State ReadBody (byte [] buffer, ref int offset, int size)


### PR DESCRIPTION
In some cases the ChunkLeft will return a negative value, causing an OutOfBoundsException to be thrown, followed by a HttpListenerException (400, "I/O operation aborted.");

This tiny fix seems to work for the Chunked transfers we're receiving (using Mono 2.6).
