### PR TITLE
WebRequest.GetSystemWebProxy() does not work in Windows

### DIFF
--- a/mcs/class/System/System.Net/WebRequest.cs
+++ b/mcs/class/System/System.Net/WebRequest.cs
@@ -356,7 +356,7 @@ namespace System.Net
 							else bBypassOnLocal = true;
 					}
 					
-					return new WebProxy (strProxyServer, bBypassOnLocal, al.ToArray (typeof(string)) as string[]);
+					return new WebProxy (strHttpProxy, bBypassOnLocal, al.ToArray (typeof(string)) as string[]);
 				}
 			} else {
 				string address = Environment.GetEnvironmentVariable ("http_proxy");


### PR DESCRIPTION
The current implementation of WebRequest.GetSystemWebProxy() is working in Linux environments only. It is impossible to use these features in Windows.

This functionality has never been implemented in Mono. It is clearly a missing feature. So don't delete my pull request without even commenting.
