### PR TITLE
Matched FileStream behaviour with MS.NET

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
@@ -1603,5 +1603,39 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (false, File.Exists (path), "DOC#2");
 			
 		}
+
+		[Test]
+		public void WriteWithExposedHandle ()
+		{
+			string path = TempFolder + DSC + "exposed-handle.txt";
+			FileStream fs1 = null;
+			FileStream fs2 = null;
+			DeleteFile (path);
+			
+			try {
+				fs1 = new FileStream (path, FileMode.Create);
+				fs2 = new FileStream (fs1.SafeFileHandle, FileAccess.ReadWrite);
+				fs1.WriteByte (Convert.ToByte ('H'));
+				fs1.WriteByte (Convert.ToByte ('E'));
+				fs1.WriteByte (Convert.ToByte ('L'));
+				fs2.WriteByte (Convert.ToByte ('L'));
+				fs2.WriteByte (Convert.ToByte ('O'));
+				long fs1Pos = fs1.Position;
+				fs1.Flush ();
+				fs2.Flush (); 
+				fs1.Close ();
+				fs2.Close ();
+
+				var check = Encoding.ASCII.GetString (File.ReadAllBytes (path));
+				Assert.AreEqual ("HELLO", check, "EXPOSED#1");
+				Assert.AreEqual (5, fs1Pos, "EXPOSED#2");
+			} finally {
+				if (fs1 != null)
+					fs1.Close ();
+				if (fs2 != null)
+					fs2.Close ();
+				DeleteFile (path);
+			}
+		}
 	}
 }


### PR DESCRIPTION
FileStream in MS.NET behaves differently from it's normal buffering strategy once the Handle/SafeFileHandle has been retrieved.

The buffering should be turned off, and retrieving the Position should always go through the Handle/OS.

The provided test should write to a temp file the ASCII string HELLO, but writes LOL on the current implementation of Mono.

The test also checks that the position is correct once the string has been written using the two FileStream instances sharing a handle.
