### PR TITLE
[sgen] Solving problem with handling ephemerons arrays

### DIFF
--- a/mono/metadata/sgen-gc.c
+++ b/mono/metadata/sgen-gc.c
@@ -4410,8 +4410,9 @@ mark_ephemerons_in_range (CopyOrMarkObjectFunc copy_func, char *start, char *end
 		DEBUG (5, fprintf (gc_debug_file, "Ephemeron array at %p\n", object));
 
 		/*We ignore arrays in old gen during minor collections since all objects are promoted by the remset machinery.*/
-		if (object < start || object >= end)
+		/*if (object < start || object >= end)
 			continue;
+                */
 
 		/*It has to be alive*/
 		if (!object_is_reachable (object, start, end)) {


### PR DESCRIPTION
Doesn't allow GC to skip scanning all ephemerons arrays basing only on
an array address. Such skips are big mistake because even if an array
allocated in different region it still can contain references to the
region we scanning. So it's necessary to scan all available arrays.

Signed-off-by: Gleb Golubitsky sectoid@gnolltech.org
