### PR TITLE
Ctor tests for SqlBulkCopy class

### DIFF
--- a/mcs/class/System.Data/Test/System.Data.SqlClient/SqlBulkCopyTest.cs
+++ b/mcs/class/System.Data/Test/System.Data.SqlClient/SqlBulkCopyTest.cs
@@ -1,0 +1,77 @@
+//
+// SqlBulkCopyTest.cs - NUnit Test Cases for testing the
+//                      SqlBulkCopy class
+// Author:
+//      Oleg Petrov (ch5oh@qip.ru)
+//
+// Copyright (c) 2004 Novell Inc., and the individuals listed
+// on the ChangeLog entries.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Data;
+using System.Data.SqlClient;
+
+using NUnit.Framework;
+
+namespace MonoTests.System.Data.SqlClient {
+	[TestFixture]
+	public class SqlBulkCopyTest {
+		[Test] // .ctor(SqlConnection connection)
+		[ExpectedException (typeof(ArgumentNullException))]
+		public void ConstructorNotNull1 ()
+		{
+			new SqlBulkCopy ((SqlConnection)null);
+		}
+		
+		[Test] // .ctor(string connectionString)
+		[ExpectedException (typeof(ArgumentNullException))]
+		public void ConstructorNotNull2 ()
+		{
+			new SqlBulkCopy ((string)null);
+		}
+		
+		[Test] // .ctor(SqlConnection connection)
+		[ExpectedException (typeof(ArgumentNullException))]
+		public void ConstructorNotNull3 ()
+		{
+			try {
+				new SqlBulkCopy ((SqlConnection)null);
+			} catch (ArgumentNullException ane) {
+				Assert.AreEqual ("connection", ane.ParamName, "#001 - We have to provide the same parameter name as in original .NET");
+				throw;
+			}
+		}
+		
+		[Test] // .ctor(string connectionString)
+		[ExpectedException (typeof(ArgumentNullException))]
+		public void ConstructorNotNull4 ()
+		{
+			try {
+				new SqlBulkCopy ((string)null);
+			} catch (ArgumentNullException ane) {
+				Assert.AreEqual ("connectionString", ane.ParamName, "#002 - We have to provide the same parameter name as in original .NET");
+				throw;
+			}
+		}
+	}
+}


### PR DESCRIPTION
I have some interest to finish System.Data.SqlClient.SqlBulkCopy class. Tests in this commit clearly show difference between original .NET and current Mono implementation.

I did not include them in any assembly (project) yet, because I would like to do very small, very safe steps. But at the same time I'd like you to check my code style and to try Pull Request mechanism in practice.

Disclaimer: this is my first commit to git...
