### PR TITLE
System.Configuration: Matched `configSource` behavior with MS.NET

### DIFF
--- a/mcs/class/System.Configuration/System.Configuration/ConfigurationSection.cs
+++ b/mcs/class/System.Configuration/System.Configuration/ConfigurationSection.cs
@@ -206,7 +206,7 @@ namespace System.Configuration
 			if (!File.Exists (path)) {
 				RawXml = null;
 				SectionInformation.SetRawXml (null);
-				return;
+				throw new ConfigurationErrorsException (string.Format ("Unable to open configSource file '{0}'.", path));
 			}
 			
 			RawXml = File.ReadAllText (path);


### PR DESCRIPTION
In MS.NET, it throws '`ConfigurationErrorsException` when "configSource" points to file that does not exist. In Mono (tested with 2.11,) nothing happens. For example, the .exe.config:

```
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
  <appSettings configSource="FileThatDoesNotExist.config" />
</configuration>
```

When app calls `var settings = ConfigurationManager.AppSettings;`exception is thrown in MS.NET.

```
System.Configuration.ConfigurationErrorsException was unhandled
  Message=Unable to open configSource file '...'. (C:\Users\...\ConfigSourceTest.vshost.exe.Config line 3)
```
