### PR TITLE
Bug 2761 - BigInteger constructed with zero-filled byte array raises IndexOutOfRangeException

### DIFF
--- a/mcs/class/System.Numerics/System.Numerics/BigInteger.cs
+++ b/mcs/class/System.Numerics/System.Numerics/BigInteger.cs
@@ -251,8 +251,13 @@ namespace System.Numerics {
 				sign = 1;
 
 			if (sign == 1) {
-				while (value [len - 1] == 0)
-					--len;
+				while (value [len - 1] == 0) {
+					if (--len == 0) {
+						sign = 0;
+						data = ZERO;
+						return;
+					}
+				}
 
 				int full_words, size;
 				full_words = size = len / 4;

--- a/mcs/class/System.Numerics/Test/System.Numerics/BigIntegerTest.cs
+++ b/mcs/class/System.Numerics/Test/System.Numerics/BigIntegerTest.cs
@@ -497,6 +497,10 @@ namespace MonoTests.System.Numerics
 			} catch (ArgumentNullException) {}
 
 			Assert.AreEqual (0, (int)new BigInteger (new byte [0]), "#2");
+
+			Assert.AreEqual (0, (int)new BigInteger (new byte [1]), "#3");
+
+			Assert.AreEqual (0, (int)new BigInteger (new byte [2]), "#4");
 		}
 
 		[Test]


### PR DESCRIPTION
http://bugzilla.xamarin.com/show_bug.cgi?id=2761
