### PR TITLE
Stop UnixStream.Dispose() throwing if the stream is already closed.

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixStream.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixStream.cs
@@ -417,8 +417,7 @@ namespace Mono.Unix {
 		
 		void IDisposable.Dispose ()
 		{
-			AssertNotDisposed ();
-			if (owner) {
+			if (fileDescriptor != InvalidFileDescriptor && owner) {
 				Close ();
 			}
 			GC.SuppressFinalize (this);


### PR DESCRIPTION
This (re-)establishes the invariant that once the object has been
constructed it can be disposed, making it suitable for use in 'using'
statements; and allows it to be used with a StreamReader in the same
way as other stream classes.

```
$ cat urt.cs 
// gmcs /r:Mono.Posix.dll urt.cs
class Test {
  public static void Main() {
    using (Mono.Unix.UnixStream fs = new Mono.Unix.UnixStream(0))
      using (System.IO.StreamReader sr = new System.IO.StreamReader(fs))
        while (sr.Peek() >= 0)
          System.Console.WriteLine(sr.ReadLine());
  }
}
$ gmcs /r:Mono.Posix.dll urt.cs
$ echo some input | mono urt.exe
some input

Unhandled Exception: System.ObjectDisposedException: The object was used after being disposed.
  at Mono.Unix.UnixStream.AssertNotDisposed () [0x00000] in <filename unknown>:0 
  at Mono.Unix.UnixStream.System.IDisposable.Dispose () [0x00000] in <filename unknown>:0 
  at Test.Main () [0x00000] in <filename unknown>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.ObjectDisposedException: The object was used after being disposed.
  at Mono.Unix.UnixStream.AssertNotDisposed () [0x00000] in <filename unknown>:0 
  at Mono.Unix.UnixStream.System.IDisposable.Dispose () [0x00000] in <filename unknown>:0 
  at Test.Main () [0x00000] in <filename unknown>:0 

# ...after applying patch...

$ echo some input | mono urt.exe
some input
$
```
