### PR TITLE
Fix Bug #658, allowing uri templates with no text preceding a wildcard.

### DIFF
--- a/mcs/class/System.ServiceModel.Web/System/UriTemplate.cs
+++ b/mcs/class/System.ServiceModel.Web/System/UriTemplate.cs
@@ -303,7 +303,7 @@ namespace System
 			if (tEnd < 0)
 				tEnd = template.Length;
 			if (wild)
-				tEnd = wildIdx - 1;
+				tEnd = Math.Max (wildIdx - 1, 0);
 			if (!wild && (cp.Length - c) != (tEnd - i) ||
 			    String.CompareOrdinal (cp, c, template, i, tEnd - i) != 0)
 				return null; // suffix doesn't match

--- a/mcs/class/System.ServiceModel.Web/Test/System/UriTemplateTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System/UriTemplateTest.cs
@@ -426,6 +426,32 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		public void MatchWildcard2 ()
+		{
+			var t = new UriTemplate ("*");
+			var m = t.Match (new Uri ("http://localhost"), new Uri ("http://localhost/hoge/ppp"));
+			Assert.IsNotNull (m, "#0");
+			Assert.IsEmpty (m.QueryParameters, "#1.0");
+			Assert.AreEqual ("hoge", m.WildcardPathSegments [0], "#2");
+			Assert.AreEqual ("ppp", m.WildcardPathSegments [1], "#3");
+		}
+
+		[Test]
+		public void MatchWildcard3 ()
+		{
+			var t = new UriTemplate ("*?p1={foo}");
+			var m = t.Match (new Uri ("http://localhost"), new Uri ("http://localhost/hoge/ppp/qqq?p1=v1"));
+			Assert.IsNotNull (m, "#0");
+			Assert.IsNotNull (m.QueryParameters, "#1.0");
+			Assert.AreEqual ("v1", m.QueryParameters ["p1"], "#1");
+			Assert.IsNotNull (m.WildcardPathSegments, "#2.0");
+			Assert.AreEqual (3, m.WildcardPathSegments.Count, "#2");
+			Assert.AreEqual ("hoge", m.WildcardPathSegments [0], "#3");
+			Assert.AreEqual ("ppp", m.WildcardPathSegments [1], "#4");
+			Assert.AreEqual ("qqq", m.WildcardPathSegments [2], "#5");
+		}
+
+		[Test]
 		public void IgnoreTrailingSlash ()
 		{
 			var t = new UriTemplate ("/{foo}/{bar}", true);


### PR DESCRIPTION
This fix addresses https://bugzilla.xamarin.com/show_bug.cgi?id=658

The proposed fix there does not properly fix the issue. I added two test cases to reproduce the problem, which fundamentally had to do with URI templates with no text before the wildcard, which "*" is just a pathological case of.

Fixed by clamping the tEnd variable to not be negative in that case.
