### PR TITLE
Locked ASP.NET InProc Session Items return null, losing session data during concurrent access.

### DIFF
--- a/mcs/class/System.Web/System.Web.SessionState_2.0/SessionInProcHandler.cs
+++ b/mcs/class/System.Web/System.Web.SessionState_2.0/SessionInProcHandler.cs
@@ -180,7 +180,8 @@ namespace System.Web.SessionState
 					locked = true;
 					lockAge = DateTime.UtcNow.Subtract (item.lockedTime);
 					lockId = item.lockId;
-					return null;
+					// HACK: Don't return null. TODO: Block thread until resource is released?
+					// return null;
 				}
 				
 				if (exclusive) {


### PR DESCRIPTION
It seems like mod_mono/XSP doesn't block concurrent requests associated with a same ASP.NET SessionId (like IIS), at least not for images generated through scripts which may want to check the session first.

Thus, when a second request tries to access an InProc ASP.NET Session, SessionItems may be locked by the first request and NULL values are returned.
This produces Phalanger to lose sessions.

Mono's InProc ASP.NET Session handler is implemented in file:
./mcs/class/System.Web/System.Web.SessionState_2.0/SessionInProcHandler.cs

In function GetItemInternal() we have this code:

```
            if (item.locked) {
                locked = true;
                lockAge = DateTime.UtcNow.Subtract (item.lockedTime);
                lockId = item.lockId;
                return null; <------- Just return null!!??
            }
```

Regardless the fact that the WebServer should block or not a request associated with the same SessionID (locking by SessionItems may be more efficient),
this function should not just return null, but wait until the SessionItem is released.
