### PR TITLE
Generate ServerProtocolViolation If WebConnection.GetResponse() returns -1 in ReadDone() 

### DIFF
--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -458,7 +458,7 @@ namespace System.Net
 					exc = e;
 				}
 
-				if (exc != null) {
+				if (exc != null || pos == -1) {
 					cnc.HandleError (WebExceptionStatus.ServerProtocolViolation, exc, "ReadDone4");
 					return;
 				}


### PR DESCRIPTION
If WebConnection.GetResponse() returns -1 in ReadDone() then also treat this as a ServerProtocolViolation rather than failing with an exception later on.

We occasionally see this happen in the OpenSimulator project when web requests are made (the project makes a lot of these).
I'm reasoning that a -1 from GetResponse() also indicates that the response is badly formatted (wrong number of parts or not properly terminated) as well as catching an Exception.
Making this change removes the issues that we see.
