### PR TITLE
corlib: List's enumerator should not mutate after being disposed

### DIFF
--- a/mcs/class/corlib/System.Collections.Generic/List.cs
+++ b/mcs/class/corlib/System.Collections.Generic/List.cs
@@ -779,13 +779,10 @@ namespace System.Collections.Generic {
 			
 			public void Dispose ()
 			{
-				l = null;
 			}
 
 			void VerifyState ()
 			{
-				if (l == null)
-					throw new ObjectDisposedException (GetType ().FullName);
 				if (ver != l._version)
 					throw new InvalidOperationException (
 						"Collection was modified; enumeration operation may not execute.");

--- a/mcs/class/corlib/Test/System.Collections.Generic/ListTest.cs
+++ b/mcs/class/corlib/Test/System.Collections.Generic/ListTest.cs
@@ -1,12 +1,14 @@
 //
-// MonoTests.System.Collections.Generic.Test.DictionaryTest
+// MonoTests.System.Collections.Generic.Test.ListTest
 //
 // Authors:
 //      David Waite (mass@akuma.org)
+//      Andres G. Aragoneses (andres.aragoneses@7digital.com)
 //
 // Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
 // Copyright (C) 2005 David Waite (mass@akuma.org)
 // Copyright 2011 Xamarin Inc (http://www.xamarin.com).
+// Copyright 2012 7digital Ltd (http://www.7digital.com).
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -1325,6 +1327,141 @@ namespace MonoTests.System.Collections.Generic {
 			var l = new List<int> ();
 			Assert.AreEqual (-1, l.IndexOf (-1));
 		}
+
+
+#region Enumerator mutability
+
+		class Bar
+		{
+		}
+
+		class Foo : IEnumerable<Bar>
+		{
+			Baz enumerator;
+
+			public Foo ()
+			{
+				enumerator = new Baz ();
+			}
+
+			public IEnumerator<Bar> GetEnumerator ()
+			{
+				return enumerator;
+			}
+
+			IEnumerator IEnumerable.GetEnumerator ()
+			{
+				return enumerator;
+			}
+		}
+
+		class Baz : IEnumerator<Bar>
+		{
+			public bool DisposeWasCalled = false;
+
+			public void Dispose ()
+			{
+				DisposeWasCalled = true;
+			}
+
+			public bool MoveNext ()
+			{
+				return false; //assume empty collection
+			}
+
+			public void Reset ()
+			{
+			}
+
+			public Bar Current
+			{
+				get { return null; }
+			}
+
+			object IEnumerator.Current
+			{
+				get { return Current; }
+			}
+		}
+
+		[Test]
+		public void PremiseAboutDisposeBeingCalledWhenLooping ()
+		{
+			Foo enumerable = new Foo ();
+			Baz enumerator = enumerable.GetEnumerator () as Baz;
+			Assert.IsNotNull (enumerator);
+			Assert.AreEqual (false, enumerator.DisposeWasCalled);
+			foreach (var element in enumerable) ; //sic
+			Assert.AreEqual (true, enumerator.DisposeWasCalled);
+		}
+
+		[Test]
+		public void TwoEnumeratorsOfTwoDifferentListsAreDifferent ()
+		{
+			var twoThree = new List<int> { 2, 3 };
+			var oneTwo = new List<int> { 2, 4 };
+			Assert.IsFalse (oneTwo.GetEnumerator ().Equals (twoThree.GetEnumerator ()));
+		}
+
+		[Test]
+		public void TwoEnumeratorsOfTwoDifferentListsWithSameElementsAreDifferent ()
+		{
+			var twoThree = new List<int> { 2, 3 };
+			var anotherTwoThree = new List<int> { 2, 3 };
+			Assert.IsFalse(twoThree.GetEnumerator ().Equals (anotherTwoThree.GetEnumerator ()));
+		}
+
+		[Test]
+		public void EnumeratorIsSameInSameListAfterSubsequentCalls ()
+		{
+			var enumerable = new List<Bar> ();
+			var enumerator = enumerable.GetEnumerator ();
+			var enumerator2 = enumerable.GetEnumerator ();
+
+			Assert.IsFalse (ReferenceEquals (enumerator2, enumerator)); //because they are value-types
+
+			Assert.IsTrue (enumerator2.Equals (enumerator));
+		}
+
+
+		[Test] // was bug in Mono 2.10.9
+		public void EnumeratorIsStillSameInSubsequentCallsEvenHavingADisposalInBetween ()
+		{
+			var enumerable = new List<Bar> ();
+			var enumerator = enumerable.GetEnumerator ();
+			enumerator.Dispose ();
+			var enumerator2 = enumerable.GetEnumerator ();
+
+			Assert.IsFalse (ReferenceEquals (enumerator2, enumerator)); //because they are value-types
+
+			Assert.IsTrue (enumerator2.Equals (enumerator));
+		}
+
+		[Test]
+		public void EnumeratorIsObviouslyDifferentAfterListChanges ()
+		{
+			var enumerable = new List<Bar> ();
+			var enumerator = enumerable.GetEnumerator ();
+			enumerable.Add (new Bar ());
+			var enumerator2 = enumerable.GetEnumerator ();
+
+			Assert.IsFalse (ReferenceEquals (enumerator2, enumerator)); //because they are value-types
+
+			Assert.IsFalse (enumerator2.Equals (enumerator));
+		}
+
+		[Test] // was bug in Mono 2.10.9
+		public void DotNetDoesntThrowObjectDisposedExceptionAfterSubsequentDisposes()
+		{
+			var enumerable = new List<Bar> ();
+			var enumerator = enumerable.GetEnumerator ();
+			Assert.AreEqual (false, enumerator.MoveNext ());
+			enumerator.Dispose();
+			Assert.AreEqual (false, enumerator.MoveNext ());
+		}
+#endregion
+
+
 	}
 }
 #endif


### PR DESCRIPTION
List<T>.Enumerator is a struct so current Dispose() implementation was causing mutability on it.
Depending on this behaviour may seem overkill but some codebases may implement IEnumerator<T> themselves by caching the enumerator of their initial readonly list.

Making Dispose() not do anything may seem incorrect, but it is not. For a good read about this, take a look at Stephen Cleary's first comment in:
http://social.msdn.microsoft.com/Forums/en/netfxbcl/thread/f5a59eac-4a3e-4417-99a8-83d4a6a9e41d

(Added NUnit tests that demonstrate the issue too.)

For a good example: this fix makes a simple HelloWorld System.Web.IHttpHandler work in Mono within the OpenRasta framework (at least tested with the stable branch).
