### PR TITLE
corlib: String.Split() now returns empty array too for Empty when splitting chars

### DIFF
--- a/mcs/class/corlib/System/String.cs
+++ b/mcs/class/corlib/System/String.cs
@@ -222,6 +222,9 @@ namespace System
 			if ((options != StringSplitOptions.None) && (options != StringSplitOptions.RemoveEmptyEntries))
 				throw new ArgumentException ("Illegal enum value: " + options + ".");
 
+			if (Length == 0)
+				return new String[0];
+
 			if (count <= 1) {
 				return count == 0 ?
 					new String[0] :

--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -4024,6 +4024,10 @@ public class StringTest
 	{
 		String[] res;
 
+		// empty and RemoveEmpty
+		res = string.Empty.Split (new Char [] { 'A' }, StringSplitOptions.RemoveEmptyEntries);
+		Assert.AreEqual (0, res.Length);
+
 		// count == 0
 		res = "..A..B..".Split (new Char[] { '.' }, 0, StringSplitOptions.None);
 		Assert.AreEqual (0, res.Length, "#01-01");


### PR DESCRIPTION
String.Empty.Split(char[], StringSplitOptions.RemoveEmptyEntries) didn't have the same behaviour as String.Empty.Split(string[], StringSplitOptions.RemoveEmptyEntries), which was incorrect.
