### PR TITLE
Fix several bugs relating to ToolStrips with Flow layout

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms.Layout/FlowLayout.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms.Layout/FlowLayout.cs
@@ -358,13 +358,9 @@ namespace System.Windows.Forms.Layout
 				// Only apply layout to visible controls.
 				if (!c.Available) { continue; }
 
-				// Resize any AutoSize controls to their preferred width
-				// (the height should fill the ToolStrip)
-				if (c.AutoSize == true) {
-					Size preferred_size = c.GetPreferredSize (c.Size);
-					preferred_size.Height = parentDisplayRectangle.Height;
-					c.SetBounds (new Rectangle (c.Location, preferred_size));
-				}
+				// Resize any AutoSize controls to their preferred size
+				if (c.AutoSize == true)
+					c.SetBounds (new Rectangle (c.Location, c.GetPreferredSize (c.Size)));
 
 				switch (settings.FlowDirection) {
 					case FlowDirection.BottomUp:

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -1429,25 +1429,28 @@ namespace System.Windows.Forms
 				Point currentLocation = Point.Empty;
 				int tallest = 0;
 				
-				foreach (ToolStripItem tsi in items) {
-					if ((DisplayRectangle.Width - currentLocation.X) < (tsi.Width + tsi.Margin.Horizontal)) {
+				foreach (ToolStripItem tsi in items)
+					if (tsi.Available) {
+						Size tsi_preferred = tsi.GetPreferredSize (Size.Empty);
 
-						currentLocation.Y += tallest;
-						tallest = 0;
+						if ((DisplayRectangle.Width - currentLocation.X) < (tsi_preferred.Width + tsi.Margin.Horizontal)) {
+
+							currentLocation.Y += tallest;
+							tallest = 0;
+							
+							currentLocation.X = DisplayRectangle.Left;
+						}
+
+						// Offset the left margin and set the control to our point
+						currentLocation.Offset (tsi.Margin.Left, 0);
+						tallest = Math.Max (tallest, tsi_preferred.Height + tsi.Margin.Vertical);
 						
-						currentLocation.X = DisplayRectangle.Left;
+						// Update our location pointer
+						currentLocation.X += tsi_preferred.Width + tsi.Margin.Right;
 					}
 
-					// Offset the left margin and set the control to our point
-					currentLocation.Offset (tsi.Margin.Left, 0);
-					tallest = Math.Max (tallest, tsi.Height + tsi.Margin.Vertical);
-					
-					// Update our location pointer
-					currentLocation.X += tsi.Width + tsi.Margin.Right;
-				}
-
 				currentLocation.Y += tallest;
-				return new Size (currentLocation.X, currentLocation.Y);
+				return new Size (currentLocation.X + this.Padding.Horizontal, currentLocation.Y + this.Padding.Vertical);
 			}
 				
 			if (this.orientation == Orientation.Vertical) {

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripSeparator.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripSeparator.cs
@@ -37,6 +37,7 @@ namespace System.Windows.Forms
 	{
 		public ToolStripSeparator () : base ()
 		{
+			Dock = DockStyle.Fill;
 		}
 
 		#region Public Properties


### PR DESCRIPTION
Specifically:
- Do not take into account unavailable ToolStripItems.
- Use preferred size of ToolStripItems instead of current size.
- Take into account the ToolStrip's padding.
- Do not fill the ToolStrip height during layout, which is wrong
  for multi-row ToolStrips.  This reverts commit f124ea39, which
  fixed Novell bug #469196.  As an alternative fix for that issue,
  set ToolStripSeparator's Dock to Fill in its constructor.
