### PR TITLE
Fix bug in System.Json ToString implementation

### DIFF
--- a/mcs/class/System.Json/System.Json/JsonValue.cs
+++ b/mcs/class/System.Json/System.Json/JsonValue.cs
@@ -162,7 +162,10 @@ namespace System.Json
 				foreach (JsonValue v in ((JsonArray) this)) {
 					if (following)
 						w.Write (", ");
-					v.SaveInternal (w);
+					if (v != null) 
+						v.SaveInternal (w);
+					else
+						w.Write ("null");
 					following = true;
 				}
 				w.Write (']');

--- a/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
+++ b/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
@@ -25,5 +25,15 @@ namespace MonoTests.System
 			Assert.AreEqual (JsonType.String, j ["a"].JsonType, "type");
 			Assert.AreEqual ("b", (string) j ["a"], "value");
 		}
+
+		// Test that we correctly serialize JsonArray with null elements.
+		[Test]
+		public void ToStringOnJsonArrayWithNulls () {
+			var j = JsonValue.Load (new StringReader ("[1,2,3,null]"));
+			Assert.AreEqual (4, j.Count, "itemcount");
+			Assert.AreEqual (JsonType.Array, j.JsonType, "type");
+			var str = j.ToString ();
+			Assert.AreEqual (str, "[1, 2, 3, null]");
+		}
 	}
 }


### PR DESCRIPTION
JsonValue.ToString() was failing in cases involving a JsonArray with one or more array elements which had the value null, for example [1,2,3,null].

This fix includes a unit test which failed before and passes after.
