### PR TITLE
Binding socket with specified IP address if possible.

### DIFF
--- a/mcs/class/System/System.Net/EndPointManager.cs
+++ b/mcs/class/System/System.Net/EndPointManager.cs
@@ -74,13 +74,17 @@ namespace System.Net {
 			if (lp.Path.IndexOf ("//", StringComparison.Ordinal) != -1) // TODO: Code?
 				throw new HttpListenerException (400, "Invalid path.");
 
-			// Always listens on all the interfaces, no matter the host name/ip used.
-			EndPointListener epl = GetEPListener (IPAddress.Any, lp.Port, listener, lp.Secure);
+			// listens on all the interfaces if host name cannot be parsed by IPAddress.
+			EndPointListener epl = GetEPListener (lp.Host, lp.Port, listener, lp.Secure);
 			epl.AddPrefix (lp, listener);
 		}
 
-		static EndPointListener GetEPListener (IPAddress addr, int port, HttpListener listener, bool secure)
+		static EndPointListener GetEPListener (string host, int port, HttpListener listener, bool secure)
 		{
+			IPAddress addr;
+			if (IPAddress.TryParse(host, out addr) == false)
+				addr = IPAddress.Any;
+
 			Hashtable p = null;  // Dictionary<int, EndPointListener>
 			if (ip_to_endpoints.ContainsKey (addr)) {
 				p = (Hashtable) ip_to_endpoints [addr];
@@ -139,7 +143,7 @@ namespace System.Net {
 			if (lp.Path.IndexOf ("//", StringComparison.Ordinal) != -1)
 				return;
 
-			EndPointListener epl = GetEPListener (IPAddress.Any, lp.Port, listener, lp.Secure);
+			EndPointListener epl = GetEPListener (lp.Host, lp.Port, listener, lp.Secure);
 			epl.RemovePrefix (lp, listener);
 		}
 	}


### PR DESCRIPTION
HttpListener uses this class to manage endpoint listener. URI prefix usually looks like 'http://address:port/', with the specified URI, EndPointListener should bind IP address and port. But, without this change, EndPointManager passes IPAddress.Any instead of IP address given by URI prefix. This behavior is not only different with .NET class lib, but also could be security hole on server, which machine has multiple network interfaces combined public/private IP addresses. It always opens both public/private even if it is not intended.
