### PR TITLE
Call mono_thread_exit rather than Sleep. Embedders may be unloading the ...

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -4582,8 +4582,7 @@ self_suspend_internal (MonoInternalThread *thread)
 
 		if (shutting_down) {
 			/* After we left the lock, the runtime might shut down so everything becomes invalid */
-			for (;;)
-				Sleep (1000);
+			mono_thread_exit ();
 		}
 		
 		WaitForSingleObject (thread->suspend_event, INFINITE);


### PR DESCRIPTION
...runtime, and the Sleep loop will crash since it keeps executing even though the library has been unloaded from memory.

Contributed under MIT/X11 license.
