### PR TITLE
Cause MenuDeactivate event to be delivered when appropriate

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/MenuStrip.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/MenuStrip.cs
@@ -173,6 +173,8 @@ namespace System.Windows.Forms
 			this.MenuDroppedDown = false;
 			
 			base.Dismiss (reason);
+
+			this.FireMenuDeactivate ();
 		}
 		
 		internal void FireMenuActivate ()

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -892,7 +892,7 @@ namespace System.Windows.Forms
 				if (this is MenuStrip && mouse_currently_over is ToolStripMenuItem && !(mouse_currently_over as ToolStripMenuItem).HasDropDownItems)
 					return;
 			} else {
-				this.HideMenus (true, ToolStripDropDownCloseReason.AppClicked);
+				this.Dismiss (ToolStripDropDownCloseReason.AppClicked);
 			}
 			
 			if (this is MenuStrip)
@@ -1501,17 +1501,6 @@ namespace System.Windows.Forms
 			this.GetTopLevelToolStrip ().Dismiss (ToolStripDropDownCloseReason.ItemClicked);
 		}
 		
-		internal void HideMenus (bool release, ToolStripDropDownCloseReason reason)
-		{
-			if (this is MenuStrip && release && menu_selected)
-				(this as MenuStrip).FireMenuDeactivate ();
-				
-			if (release)
-				menu_selected = false;
-				
-			NotifySelectedChanged (null);
-		}
-
 		internal void NotifySelectedChanged (ToolStripItem tsi)
 		{
 			foreach (ToolStripItem tsi2 in this.DisplayedItems)

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripMenuItem.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripMenuItem.cs
@@ -315,12 +315,9 @@ namespace System.Windows.Forms
 		protected override void OnMouseUp (MouseEventArgs e)
 		{
 			if (this.close_on_mouse_release) {
-				this.DropDown.Dismiss (ToolStripDropDownCloseReason.ItemClicked);
+				this.Parent.Dismiss (ToolStripDropDownCloseReason.ItemClicked);
 				this.Invalidate ();
 				this.close_on_mouse_release = false;
-				
-				if (!this.IsOnDropDown && this.Parent is MenuStrip)
-					(this.Parent as MenuStrip).MenuDroppedDown = false;
 			}
 				
 			if (!this.HasDropDownItems && Enabled)


### PR DESCRIPTION
This is achieved by moving the FireMenuDeactivate call to
MenuStrip.Dismiss and causing it to be called in a couple of places
where it ought to be.
