### PR TITLE
Implement a VirtualMachine.IsSuspended property for the soft debugger

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -376,7 +376,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 17;
+		internal const int MINOR_VERSION = 18;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -443,7 +443,8 @@ namespace Mono.Debugger.Soft
 			ABORT_INVOKE = 9,
 			SET_KEEPALIVE = 10,
 			GET_TYPES_FOR_SOURCE_FILE = 11,
-			GET_TYPES = 12
+			GET_TYPES = 12,
+			IS_SUSPENDED = 13,
 		}
 
 		enum CmdEvent {
@@ -1590,6 +1591,10 @@ namespace Mono.Debugger.Soft
 			for (int i = 0; i < count; ++i)
 				types [i] = res.ReadId ();
 			return types;
+		}
+
+		internal bool VM_IsSuspended () {
+			return SendReceive (CommandSet.VM, (int)CmdVM.IS_SUSPENDED, null).ReadByte () != 0;
 		}
 
 		/*

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -130,6 +130,13 @@ namespace Mono.Debugger.Soft
 			}
 	    }
 
+		public bool IsSuspended {
+			get {
+				CheckProtocolVersion (2, 18);
+				return conn.VM_IsSuspended ();
+			}
+		}
+
 		public void Exit (int exitCode) {
 			conn.VM_Exit (exitCode);
 		}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -270,7 +270,7 @@ typedef struct {
 #define HEADER_LENGTH 11
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 17
+#define MINOR_VERSION 18
 
 typedef enum {
 	CMD_SET_VM = 1,
@@ -395,7 +395,8 @@ typedef enum {
 	CMD_VM_ABORT_INVOKE = 9,
 	CMD_VM_SET_KEEPALIVE = 10,
 	CMD_VM_GET_TYPES_FOR_SOURCE_FILE = 11,
-	CMD_VM_GET_TYPES = 12
+	CMD_VM_GET_TYPES = 12,
+	CMD_VM_IS_SUSPENDED = 13,
 } CmdVM;
 
 typedef enum {
@@ -6414,6 +6415,10 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		g_ptr_array_free (res_domains, TRUE);
 		break;
 	}
+	case CMD_VM_IS_SUSPENDED: {
+		buffer_add_byte (buf, suspend_count > 0 ? 1 : 0);
+		break;
+	}
 
 	default:
 		return ERR_NOT_IMPLEMENTED;
@@ -8278,6 +8283,8 @@ cmd_to_string (CommandSet set, int command)
 			return "SET_PROTOCOL_VERSION";
 		case CMD_VM_ABORT_INVOKE:
 			return "ABORT_INVOKE";
+		case CMD_VM_IS_SUSPENDED:
+			return "IS_SUSPENDED";
 		default:
 			break;
 		}


### PR DESCRIPTION
We currently have no indication whether a VM is suspended or not. The pattern used in MD to safely resume is:

``` csharp
try {
    vm.Resume ();
} catch (InvalidOperationException) {
}
```

This new command allows for a simpler pattern, at least for vm that support the new call.
