### PR TITLE
Fix for Xamarin's bug #4108 (BrowserCaps compatibility problem with MS.NET)

### DIFF
--- a/mcs/class/System.Web/System.Web.Configuration_2.0/nBrowser/Build.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/nBrowser/Build.cs
@@ -316,7 +316,7 @@ namespace System.Web.Configuration.nBrowser
 		public override System.Web.Configuration.CapabilitiesResult Process(System.Collections.Specialized.NameValueCollection header, System.Collections.IDictionary initialCapabilities)
 		{
 			if (initialCapabilities == null)
-				initialCapabilities = new System.Collections.Generic.Dictionary<string, string>(StringComparer.CurrentCultureIgnoreCase);
+				initialCapabilities = new System.Collections.Generic.Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 			System.Web.Configuration.nBrowser.Result r = new System.Web.Configuration.nBrowser.Result(initialCapabilities);
 
 #if trace

--- a/mcs/class/System.Web/System.Web.Configuration_2.0/nBrowser/Node.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/nBrowser/Node.cs
@@ -262,7 +262,7 @@ namespace System.Web.Configuration.nBrowser
 		/// <param name="node"></param>
 		private void ProcessCapabilities(System.Xml.XmlNode node)
 		{
-			Capabilities = new System.Collections.Specialized.NameValueCollection(node.ChildNodes.Count);
+			Capabilities = new System.Collections.Specialized.NameValueCollection(node.ChildNodes.Count, StringComparer.OrdinalIgnoreCase);
 
 			for (int a = 0;a <= node.ChildNodes.Count - 1;a++)
 			{
@@ -1005,7 +1005,7 @@ namespace System.Web.Configuration.nBrowser
 			if (n.Capabilities != null)
 			{
 				if (Capabilities == null)
-					Capabilities =  new System.Collections.Specialized.NameValueCollection(n.Capabilities.Count);
+					Capabilities =  new System.Collections.Specialized.NameValueCollection(n.Capabilities.Count, StringComparer.OrdinalIgnoreCase);
 				foreach (string capName in n.Capabilities)
 					Capabilities[capName] = n.Capabilities[capName];
 			}

--- a/mcs/class/System.Web/System.Web/BrowserCapabilities.cs
+++ b/mcs/class/System.Web/System.Web/BrowserCapabilities.cs
@@ -355,7 +355,12 @@ namespace System.Web.Configuration
 		public int MajorVersion {
 			get {
 				if (!Get (HaveMajorVersion)) {
-					majorVersion = ReadInt32 ("majorver");
+					// Try with MS.NET's property name.
+					// See: https://bugzilla.xamarin.com/show_bug.cgi?id=4108
+					if (this["majorversion"] != null)
+						majorVersion = ReadInt32 ("majorversion");
+					else 
+						majorVersion = ReadInt32 ("majorver");
 					Set (HaveMajorVersion);
 				}
 
@@ -366,7 +371,12 @@ namespace System.Web.Configuration
 		public double MinorVersion {
 			get {
 				if (!Get (HaveMinorVersion)) {
-					minorVersion = ReadDouble ("minorver");
+					// Try with MS.NET's property name.
+					// See: https://bugzilla.xamarin.com/show_bug.cgi?id=4108
+					if (this["minorversion"] != null)
+						minorVersion = ReadDouble ("minorversion");
+					else
+						minorVersion = ReadDouble ("minorver");
 					Set (HaveMinorVersion);
 				}
 

--- a/mcs/class/System.Web/System.Web/CapabilitiesLoader.cs
+++ b/mcs/class/System.Web/System.Web/CapabilitiesLoader.cs
@@ -218,7 +218,7 @@ namespace System.Web
 
 		static CapabilitiesLoader ()
 		{
-			defaultCaps = new Hashtable ();
+			defaultCaps = new Hashtable (StringComparer.OrdinalIgnoreCase);
 			defaultCaps.Add ("activexcontrols", "False");
 			defaultCaps.Add ("alpha", "False");
 			defaultCaps.Add ("aol", "False");
@@ -355,7 +355,7 @@ namespace System.Web
 				foreach (BrowserData bd in alldata) {
 					if (bd.IsMatch (userAgent)) {
 						Hashtable tbl;
-						tbl = new Hashtable (defaultCaps);
+						tbl = new Hashtable (defaultCaps, StringComparer.OrdinalIgnoreCase);
 						userBrowserCaps = bd.GetProperties (tbl);
 						break;
 					}
@@ -442,7 +442,7 @@ namespace System.Web
 #endif
 			using (input) {
 			string str;
-			Hashtable allhash = new Hashtable ();
+			Hashtable allhash = new Hashtable (StringComparer.OrdinalIgnoreCase);
 			int aux = 0;
 			ArrayList browserData = new ArrayList ();
 			while ((str = input.ReadLine ()) != null) {


### PR DESCRIPTION
Fix browser capabilities compatibility with ms.net by 1) Avoid issues with capabilities defined with same name, but diferent case. and 2) favor majorversion/minorversion capabilities, but fallback to majorver/minorver if not found, to preserve compatibility with previous versions.
