### PR TITLE
FIx for problem with MRES.Wait(timeout, token) with not immediate Set

### DIFF
--- a/mcs/class/corlib/System.Threading/ManualResetEventSlim.cs
+++ b/mcs/class/corlib/System.Threading/ManualResetEventSlim.cs
@@ -180,8 +180,11 @@ namespace System.Threading
 				WaitHandle handle = WaitHandle;
 
 				if (cancellationToken.CanBeCanceled) {
-					if (WaitHandle.WaitAny (new[] { handle, cancellationToken.WaitHandle }, millisecondsTimeout, false) == 1)
+					var result = WaitHandle.WaitAny (new[] { handle, cancellationToken.WaitHandle }, millisecondsTimeout, false);
+					if (result == 1)
 						throw new OperationCanceledException (cancellationToken);
+					if (result == WaitHandle.WaitTimeout)
+						return false;
 				} else {
 					if (!handle.WaitOne (millisecondsTimeout, false))
 						return false;

--- a/mcs/class/corlib/Test/System.Threading/ManualResetEventSlimTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/ManualResetEventSlimTests.cs
@@ -262,6 +262,14 @@ namespace MonoTests.System.Threading
 		}
 
 		[Test]
+		public void WaitWithCancellationTokenAndTimeout ()
+		{
+			var mres = new ManualResetEventSlim ();
+			var cts = new CancellationTokenSource ();
+			Assert.IsFalse (mres.Wait (TimeSpan.FromSeconds (1), cts.Token), "Wait returned true despite timeout.");
+		}
+
+		[Test]
 		public void Dispose ()
 		{
 			var mre = new ManualResetEventSlim (false);


### PR DESCRIPTION
The problem occured when one waited for an event with the
cancellation token and the wait was successful but not
immediate. In that case Wait returned false instead of true,
because of wait handle number mismatch. Also the unit test was
added.
