### PR TITLE
Make XmlCustomFormatter.cs more liberal about the date formats it accept...

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlCustomFormatter.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlCustomFormatter.cs
@@ -272,11 +272,11 @@ namespace System.Xml.Serialization {
 				case "char": return (char)XmlConvert.ToInt32 (value);
 #if NET_2_0
 				case "dateTime": return XmlConvert.ToDateTime (value, XmlDateTimeSerializationMode.RoundtripKind);
-				case "date": return DateTime.ParseExact (value, "yyyy-MM-dd", null);
+				case "date": return DateTime.Parse (value).Date;
 				case "time": return DateTime.ParseExact (value, "HH:mm:ss.FFFFFFF", null);
 #else
 				case "dateTime": return XmlConvert.ToDateTime (value);
-				case "date": return DateTime.ParseExact (value, "yyyy-MM-dd", null);
+				case "date": return DateTime.Parse (value).Date;
 				case "time": return DateTime.ParseExact (value, "HH:mm:ss.fffffffzzz", null);
 #endif
 				case "decimal": return XmlConvert.ToDecimal (value);


### PR DESCRIPTION
...s. Many third party web services do not format date exactly at 'yyyy-mm-dd'. The Microsoft implementation is more liberal about accepting other formats and so the current Mono implementation breaks projects that consume third party web services when they are ported to Mono.

I hit this porting a web service project to Mono that consumed a web service written in Java couple years back, worked fine with stock .Net but failed with Mono because of this strict date format requirement. At the time I gave up rather than make a custom build of Mono, but a colleague hit the same thing today with the latest Mono and I saw that it is still causing problems for other people so I thought to raise it.

http://stackoverflow.com/questions/10198386/system-datetime-parseexact-error-in-soap-response-in-monotouch-ios
