### PR TITLE
Add exception handlers to MethodBodyMirror

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft.dll.sources
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft.dll.sources
@@ -12,6 +12,7 @@ Mono.Debugger.Soft/StackFrame.cs
 Mono.Debugger.Soft/CustomAttributeDataMirror.cs
 Mono.Debugger.Soft/ThreadStartEvent.cs
 Mono.Debugger.Soft/ILInstruction.cs
+Mono.Debugger.Soft/ILExceptionHandler.cs
 Mono.Debugger.Soft/InterfaceMappingMirror.cs
 Mono.Debugger.Soft/PrimitiveValue.cs
 Mono.Debugger.Soft/PointerValue.cs

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILExceptionHandler.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILExceptionHandler.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+
+namespace Mono.Debugger.Soft
+{
+	public enum ILExceptionHandlerType
+	{
+		Catch = ExceptionClauseFlags.None,
+		Filter = ExceptionClauseFlags.Filter,
+		Finally = ExceptionClauseFlags.Finally,
+		Fault = ExceptionClauseFlags.Fault,
+	}
+
+	public class ILExceptionHandler
+	{
+		public int TryOffset { get; internal set; }
+		public int TryLength { get; internal set; }
+		public ILExceptionHandlerType HandlerType { get; internal set; }
+		public int HandlerOffset { get; internal set; }
+		public int HandlerLength { get; internal set;}
+		public int FilterOffset { get; internal set; }
+		public TypeMirror CatchType { get; internal set; }
+
+		internal ILExceptionHandler (int try_offset, int try_length, ILExceptionHandlerType handler_type, int handler_offset, int handler_length)
+		{
+			TryOffset = try_offset;
+			TryLength = try_length;
+			HandlerType = handler_type;
+			HandlerOffset = handler_offset;
+			HandlerLength = handler_length;
+		}
+	}
+}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodBodyMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodBodyMirror.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Metadata;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Mono.Debugger.Soft
@@ -11,11 +12,11 @@ namespace Mono.Debugger.Soft
 	public class MethodBodyMirror : Mirror
 	{
 		MethodMirror method;
-		byte[] il;
+		MethodBodyInfo info;
 
-		internal MethodBodyMirror (VirtualMachine vm, MethodMirror method, byte[] il) : base (vm, 0) {
+		internal MethodBodyMirror (VirtualMachine vm, MethodMirror method, MethodBodyInfo info) : base (vm, 0) {
 			this.method = method;
-			this.il = il;
+			this.info = info;
 		}
 
 		public MethodMirror Method {
@@ -24,13 +25,29 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
+		public List<ILExceptionHandler> ExceptionHandlers {
+			get {
+				vm.CheckProtocolVersion (2, 18);
+				return info.clauses.Select (c =>
+				{
+					var handler = new ILExceptionHandler (c.try_offset, c.try_length, (ILExceptionHandlerType) c.flags, c.handler_offset, c.handler_length);
+					if (c.flags == ExceptionClauseFlags.None)
+						handler.CatchType = vm.GetType (c.catch_type_id);
+					else if (c.flags == ExceptionClauseFlags.Filter)
+						handler.FilterOffset = c.filter_offset;
+
+					return handler;
+				}).ToList ();
+			}
+		}
+
 		public byte[] GetILAsByteArray () {
-			return il;
+			return info.il;
 		}
 
 		public List<ILInstruction> Instructions {
 			get {
-				return ReadCilBody (new BinaryReader (new MemoryStream (il)), il.Length);
+				return ReadCilBody (new BinaryReader (new MemoryStream (info.il)), info.il.Length);
 			}
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -249,7 +249,7 @@ namespace Mono.Debugger.Soft
 			if (body == null) {
 				MethodBodyInfo info = vm.conn.Method_GetBody (id);
 
-				body = new MethodBodyMirror (vm, this, info.il);
+				body = new MethodBodyMirror (vm, this, info);
 			}
 			return body;
 		}


### PR DESCRIPTION
This branch adds support for exception handlers in MethodBodyMirror.

For symmetry with ILInstruction and Cecil, they're named ILExceptionHandler and are exposed alike.
