### PR TITLE
Fix broken XML writer tests.

### DIFF
--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializationWriterTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializationWriterTests.cs
@@ -331,7 +331,7 @@ namespace MonoTests.System.XmlSerialization
 			WriteStartElement("x");
 			WriteAttribute("a", "b\nc");
 			WriteEndElement();
-			Assert.AreEqual ("<x a='b&#xA;c' />", Content);
+			Assert.AreEqual ("<x a='b\nc' />", Content);
 
 			Reset();
 			WriteStartElement("x");

--- a/mcs/class/System.XML/Test/System.Xml/XmlTextWriterTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlTextWriterTests.cs
@@ -387,10 +387,10 @@ namespace MonoTests.System.Xml
 			Assert.AreEqual ("<foo foo='bar' bar='' baz=''", StringWriterText);
 
 			xtw.WriteAttributeString ("hoge", "a\nb");
-			Assert.AreEqual ("<foo foo='bar' bar='' baz='' hoge='a&#xA;b'", StringWriterText);
+			Assert.AreEqual ("<foo foo='bar' bar='' baz='' hoge='a\nb'", StringWriterText);
 
 			xtw.WriteAttributeString ("fuga", " a\t\r\nb\t");
-			Assert.AreEqual ("<foo foo='bar' bar='' baz='' hoge='a&#xA;b' fuga=' a\t&#xD;&#xA;b\t'", StringWriterText);
+			Assert.AreEqual ("<foo foo='bar' bar='' baz='' hoge='a\nb' fuga=' a\t\r\nb\t'", StringWriterText);
 		}
 
 		[Test]


### PR DESCRIPTION
Default treatment for attributes is not to transform any of the
newline characters or \t.
