### PR TITLE
Better type conversion for Char in Mono.Data.Sqlite

### DIFF
--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteConvert.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteConvert.cs
@@ -402,7 +402,7 @@ namespace Mono.Data.Sqlite
       DbType.Binary,
       DbType.Object,
       DbType.Boolean,
-      DbType.SByte,
+      DbType.String,
       DbType.SByte,
       DbType.Byte,
       DbType.Int16, // 7


### PR DESCRIPTION
Right now SQLiteConvert maps Char to DbType.SByte. This has two
problems:

1) The database column gets assigned a numeric value representing the
   char that, when read back, shows up as an integer: nor the type or
   the "semantic" value survive the round-trip.
2) SByte is 8 bits while Char is 16 (SQLite doesn't bother because it
   doesn't really check type sizes but it is an error neverthless).

Given that SQLite doesn't have a real CHAR type making a single char
to round-trip is impossible but mapping it to DbType.String at least
keeps the semantic value intact, i.e., if you look at the database
after the insert you at least see the inserted char and if you read
it back from code you get a string of length 1 with the correct char
at position 0.
