### PR TITLE
If Mono's configure script cannot determine the soname of libX11, assume libX11.so.6

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2585,7 +2585,8 @@ case "$host" in
 	done
 	
 	if test "x$X11" = "xlibX11.so"; then
-		AC_MSG_WARN([Could not find X development libs. Do you have the -devel package installed? WinForms may not work...]);
+		AC_MSG_WARN([Could not find X development libs. Do you have the -devel package installed? Assuming libX11.so.6...]);
+		X11=libX11.so.6
 	fi
 	;;
 esac


### PR DESCRIPTION
The old behaviour is to try a couple of folders to find libX11.so.4, 5, and 6, and if it can't find any of those, assume no soname at all (i.e. libX11.so). It is reasonable to assume that users will be running at least XFree86 3.0, so reasonable to assume libX11.so.6 will be the soname in use.

The edge case "user compiles Mono without X.org installed" is much more common than "user has X386 1.0 -> XFree86 2.1.1 installed in a non-standard library folder, and expects a valid dllmap in /etc/mono/config"
