### PR TITLE
Double <-> Int64 conversion is much faster now.

### DIFF
--- a/mcs/class/corlib/System/BitConverter.cs
+++ b/mcs/class/corlib/System/BitConverter.cs
@@ -60,14 +60,14 @@ namespace System
 			return b [2] == 0xf0;
 		}
 
-		public static long DoubleToInt64Bits (double value)
+		public unsafe static long DoubleToInt64Bits (double value)
 		{
-			return ToInt64 (GetBytes (value), 0);
+			return *(long *) &value;
 		}
 
-		public static double Int64BitsToDouble (long value)
+		public unsafe static double Int64BitsToDouble (long value)
 		{
-			return ToDouble (GetBytes (value), 0);
+			return *(double *) &value;
 		}
 
 		internal static double InternalInt64BitsToDouble (long value)


### PR DESCRIPTION
Instead of using GetBytes and converting bytes to long, which involves allocation and deallocation of small temporary array, the simple cpu register load is in fact done now. This results in a much faster operation.

With this sample program:

``` csharp
var stopwatch = Stopwatch.StartNew();
var sum = 0L;
for(var i = 0; i < 100000000; i++)
{
    sum += BitConverter.DoubleToInt64Bits(99.9);
}
stopwatch.Stop();
Console.WriteLine(stopwatch.Elapsed);
```

my results are:
- **00:00:00.6614282** with my patch;
- **00:00:19.8135516** without my patch and Boehm GC;
- **00:00:10.2296766** without my patch and SGEN GC.

I'm doing a lot of this operations in my serialization framework, so it is quite essential to be fast ;) The performance improvement is due to no-allocation nature of the patch vs the old code, which allocated a temporary array (difference between Boehm and SGEN is explained the same way).
