### PR TITLE
Disabling WCF log activity when logging is disabled by configuration

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel/Logger.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/Logger.cs
@@ -142,7 +142,7 @@ namespace System.ServiceModel
 
 		static void Log (TraceEventType eventType, string message, params object [] args)
 		{
-			if (log_writer){
+			if (log_writer != null) {
 				lock (log_writer){
 					event_id++;
 #if NET_2_1
@@ -168,7 +168,7 @@ namespace System.ServiceModel
 		
 		public static void LogMessage (MessageLogSourceKind sourceKind, ref Message msg, long maxMessageSize)
 		{
-			if (log_writer){
+			if (log_writer != null) {
 				if (maxMessageSize > int.MaxValue)
 					throw new ArgumentOutOfRangeException ("maxMessageSize");
 				var mb = msg.CreateBufferedCopy ((int) maxMessageSize);
@@ -179,7 +179,7 @@ namespace System.ServiceModel
 		
 		public static void LogMessage (MessageLogTraceRecord log)
 		{
-			if (log_writer){
+			if (log_writer != null) {
 				var sw = new StringWriter ();
 #if NET_2_1
 				var xw = XmlWriter.Create (sw, xws);


### PR DESCRIPTION
The System.ServiceModel.Logger static methods are used by all of the various channel classes throughout WCF.

Until they previous commit they were not thread-safe at all.  Basic usage of WCF would bring down the entire process because access to the single XmlWriter wasn't synchronized.

The last commit synchronized access, but across the entire AppDomain, which is not desirable from a performance perspective.

Under default behavior the Logger is performing a lot of activity, then writing to TextWriter.Null.  I changed the default behavior to not instantiate a text writer at all if logging isn't configured and to not even enter blocks where previously a lot of intensive logging activity was performed
