### PR TITLE
Bug fix to get rid of reference to Microsoft.VisualBasic.dll when compiling a C# XSL script.

### DIFF
--- a/mcs/class/System.XML/Mono.Xml.Xsl/ScriptCompilerInfo.cs
+++ b/mcs/class/System.XML/Mono.Xml.Xsl/ScriptCompilerInfo.cs
@@ -167,7 +167,7 @@ namespace Mono.Xml.Xsl
 #if MS_NET
 			this.CompilerCommand = "csc.exe";
 #endif
-			this.DefaultCompilerOptions = "/t:library /r:System.dll /r:System.Xml.dll /r:Microsoft.VisualBasic.dll";
+			this.DefaultCompilerOptions = "/t:library /r:System.dll /r:System.Xml.dll";
 		}
 
 		public override CodeDomProvider CodeDomProvider {
@@ -271,7 +271,7 @@ end namespace
 #if MS_NET
 			this.CompilerCommand = "jsc.exe";
 #endif
-			this.DefaultCompilerOptions = "/t:library /r:Microsoft.VisualBasic.dll";
+			this.DefaultCompilerOptions = "/t:library";
 		}
 
 		public override CodeDomProvider CodeDomProvider {


### PR DESCRIPTION
We had to create an "empty" Microsoft.VisualBasic.dll file for a C# script inside our XSL to compile.  This fixes that.
