### PR TITLE
Fix unit test for OverwriteReadOnlyFiles

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Copy.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Copy.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Build.Tasks {
 			}
 		}
 
-#if NET_3_5 || NET_4_0
+#if NET_3_5 
 		public bool OverwriteReadOnlyFiles {
 			get {
 				return overwriteReadOnlyFiles;

--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/CopyTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/CopyTest.cs
@@ -286,7 +286,7 @@ namespace MonoTests.Microsoft.Build.Tasks {
 			Assert.AreEqual (FileAttributes.Normal, File.GetAttributes (target_file), "A3");					
 		}
 
-#if NET_3_5 || NET_4_0
+#if NET_3_5
 		[Test]
 		public void TestCopy_OverwriteReadOnlyTrue ()
 		{
@@ -302,7 +302,7 @@ namespace MonoTests.Microsoft.Build.Tasks {
 			Assert.AreEqual (FileAttributes.ReadOnly, File.GetAttributes (target_file), "A1");
 			
 			string documentString = @"
-				<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+				<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""3.5"">
 					<PropertyGroup><DestFile>" + target_file + @"</DestFile></PropertyGroup>
 					<ItemGroup>
 						<SFiles Include='" + file_path + @"'><Md>1</Md></SFiles>


### PR DESCRIPTION
The ToolsVersion defaults to 2.0, which doesn't include the OverwriteReadOnlyFiles property. Manually setting the ToolsVersion to 3.5 so that the OverwriteReadOnlyFiles property is available. Also, cleaned up the check for preprocessor profiles (NET_3_5 is minimum needed).
