### PR TITLE
[xbuild] Fixed a typo in MSBuildUtils.cs

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Mono.XBuild.Utilities/MSBuildUtils.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Mono.XBuild.Utilities/MSBuildUtils.cs
@@ -112,7 +112,7 @@ namespace Mono.XBuild.Utilities {
 						sb.Append ('"');
 						break;
 					default:
-						throw new FormatException ("Unrecogised XML entity '&" + entity + ";'.");
+						throw new FormatException ("Unrecognized XML entity '&" + entity + ";'.");
 					}
 					i = end;
 				} else


### PR DESCRIPTION
This just fixing a spelling typo in one of the exceptions.
