### PR TITLE
Fixed execution of parallel PageAsyncTasks

### DIFF
--- a/mcs/class/System.Web/System.Web.UI/Page.cs
+++ b/mcs/class/System.Web/System.Web.UI/Page.cs
@@ -2269,7 +2269,7 @@ public partial class Page : TemplateControl, IHttpHandler
 			parallelTasks = null; // Shouldn't execute tasks twice
 			List<IAsyncResult> asyncResults = new List<IAsyncResult>();
 			foreach (PageAsyncTask parallelTask in localParallelTasks) {
-				IAsyncResult result = parallelTask.BeginHandler (this, EventArgs.Empty, new AsyncCallback (EndAsyncTaskCallback), parallelTask.State);
+				IAsyncResult result = parallelTask.BeginHandler (this, EventArgs.Empty, new AsyncCallback (EndAsyncTaskCallback), parallelTask);
 				if (result.CompletedSynchronously)
 					parallelTask.EndHandler (result);
 				else


### PR DESCRIPTION
Execution of parallel PageAsyncTasks was broken.

compare line 2272 of Page.cs with line 2330.  Both are executing and using the same callback, but they provide different state.  For serially-registered tasks it worked, for parallel it did not, because the callback casted the state to a PageAsyncTask, which was wrong.  I changed line 2272 to be consistent with 2330, and now it works.
