### PR TITLE
any BSD's sendfile has 6 arguments

### DIFF
--- a/support/sys-sendfile.c
+++ b/support/sys-sendfile.c
@@ -31,7 +31,7 @@ Mono_Posix_Syscall_sendfile (int out_fd, int in_fd, mph_off_t *offset, mph_size_
 
 	_offset = *offset;
 
-#ifdef PLATFORM_MACOSX
+#if defined(PLATFORM_MACOSX) || defined(PLATFORM_BSD)
 	/* The BSD version has 6 arguments */
 	g_assert_not_reached ();
 #else


### PR DESCRIPTION
any BSD's sendfile has 6 arguments
