### PR TITLE
To use thread local alloc in FreeBSD

### DIFF
--- a/libgc/configure.in
+++ b/libgc/configure.in
@@ -122,6 +122,7 @@ case "$THREADS" in
 	else
 		THREADDLLIBS="$PTHREAD_LIBS"
 	fi
+	AC_DEFINE(THREAD_LOCAL_ALLOC)
 	;;
      *-*-solaris*)
 	AC_DEFINE(GC_SOLARIS_THREADS)

--- a/libgc/pthread_support.c
+++ b/libgc/pthread_support.c
@@ -69,6 +69,7 @@
 # if (defined(GC_DGUX386_THREADS) || defined(GC_OSF1_THREADS) || \
       defined(GC_DARWIN_THREADS) || defined(GC_AIX_THREADS)) || \
       defined(GC_NETBSD_THREADS) && !defined(USE_PTHREAD_SPECIFIC) || \
+      defined(GC_FREEBSD_THREADS) && !defined(USE_PTHREAD_SPECIFIC) || \
       defined(GC_OPENBSD_THREADS)
 #   define USE_PTHREAD_SPECIFIC
 # endif

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -17,7 +17,7 @@
 #include <signal.h>
 #include <string.h>
 
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
 #include <pthread.h>
 #include <pthread_np.h>
 #endif


### PR DESCRIPTION
To use thread local alloc in FreeBSD
(Without this modify, Mono cannot build in FreeBSD)
