### PR TITLE
More accurate xbuild cmdline error reporting

### DIFF
--- a/mcs/tools/xbuild/Parameters.cs
+++ b/mcs/tools/xbuild/Parameters.cs
@@ -102,8 +102,10 @@ namespace Mono.XBuild.CommandLine {
 				LoadResponseFile (responseFile);
 			}
 			foreach (string s in flatArguments) {
-				if (s [0] != '/' || !ParseFlatArgument (s))
+				if (s [0] != '/')
 					remainingArguments.Add (s);
+				if (!ParseFlatArgument (s))
+					ReportError (1, "Unknown switch: " + s);
 			}
 			if (remainingArguments.Count == 0) {
 				string[] sln_files = Directory.GetFiles (Directory.GetCurrentDirectory (), "*.sln");


### PR DESCRIPTION
When an unknown switch is passed to xbuild, an explicit "unknown switch" error is reported. Previously, the switch was interpreted as an additional argument and resulted in a "Too many project files specified" error.
