### PR TITLE
Fix bug (457120 from novell's bugzilla)

### DIFF
--- a/mcs/class/System/Test/ChangeLog
+++ b/mcs/class/System/Test/ChangeLog
@@ -1,7 +1,3 @@
-2012-06-21  Maciej Paszta <maciej.paszta@gmail.com>
-
-	* System.Net.Security: New test directory.
-
 2010-02-23  Carlos Alberto Cortez <calberto.cortez@gmail.com>
 
 	* System.IO.Ports: New test directory.

--- a/mcs/class/System/Test/System.Net.Security/ChangeLog
+++ b/mcs/class/System/Test/System.Net.Security/ChangeLog
@@ -1,3 +1,0 @@
-2012-06-21  Maciej Paszta <maciej.paszta@gmail.com>
-
-	* SslStreamTest.cs: Added tests for SslStream.

--- a/mcs/class/System/Test/System.Net.Security/SslStreamTest.cs
+++ b/mcs/class/System/Test/System.Net.Security/SslStreamTest.cs
@@ -5,7 +5,7 @@
 // Author:
 //      Maciej Paszta (maciej.paszta@gmail.com)
 //
-// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+// Copyright (C) Maciej Paszta, 2012
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the


### PR DESCRIPTION
When authenticating server via SslStream, method blocks until client sends any data. This can be a problem in protocols where the server side sends initial packets. Moreover it's incompatible with with the .NET implementation of the SslStream. The following patch fixes the problem. More details on the bug: https://bugzilla.novell.com/show_bug.cgi?id=457120
