### PR TITLE
Fixed typo causing all attributes in the namespace System.Runtime.CompilerServices to be treated as DynamicAttribute

### DIFF
--- a/mcs/mcs/import.cs
+++ b/mcs/mcs/import.cs
@@ -90,7 +90,7 @@ namespace Mono.CSharp
 				if (cad.Count > 0) {
 					foreach (var ca in cad) {
 						var dt = ca.Constructor.DeclaringType;
-						if (dt.Name != "DynamicAttribute" && dt.Namespace != CompilerServicesNamespace)
+						if (dt.Name != "DynamicAttribute" || dt.Namespace != CompilerServicesNamespace)
 							continue;
 
 						if (ca.ConstructorArguments.Count == 0) {


### PR DESCRIPTION
This must have been a typo. I guess it doesn't cause any problems as long as System.Object doesn't have any attributes from the System.Runtime.CompilerServices namespace, but it just has to be wrong.
