### PR TITLE
mono_string_new_len should handle UTF8 with nuls

### DIFF
--- a/mono/tests/custom-attr.cs
+++ b/mono/tests/custom-attr.cs
@@ -49,7 +49,11 @@ namespace Test {
 	[X, Z, Serializable]
 	class Y {
 	}
-			
+
+	[My("arg\0string\0with\0nuls")]
+	class NulTests {
+	}
+
 	[My("testclass")]
 	[My2("testclass", 22)]
 	[My3(Prop = new char [] { 'A', 'B', 'C', 'D' }, Prop2 = new char [] { 'A', 'D' })]
@@ -105,6 +109,12 @@ namespace Test {
 			// Test that synthetic methods have no attributes
 			if (typeof(int[,]).GetConstructor (new Type [] { typeof (int), typeof (int) }).GetCustomAttributes (true).Length != 0)
 				return 7;
+
+			// Test that nuls are preserved (see Xamarin bug 5732)
+			if (((MyAttribute)typeof (NulTests).GetCustomAttributes (true)[0]).val != "arg\0string\0with\0nuls")
+			{
+				return 8;
+			}
 
 			return 0;
 		}


### PR DESCRIPTION
Fix for bug 5732. Attribute parameter strings can contain unicode
nuls. This fixes the attribute loading code to preserve those
nuls.

License: MIT/X11
