### PR TITLE
Unbreak build-mingw32.sh... with this patch, it builds on Debian 6 no trouble. (corrected)

### DIFF
--- a/build-mingw32.sh
+++ b/build-mingw32.sh
@@ -4,7 +4,7 @@ MINGW=i386-mingw32msvc
 CROSS_DIR=/opt/cross/$MINGW
 EXTRA_CROSS_DIR=
 INSTALL_DESTDIR="$CURDIR/mono-win32"
-PROFILES="default net_2_0 net_3_5 net_4_0 moonlight"
+PROFILES="default net_2_0 net_3_5 net_4_0 net_4_5 moonlight"
 TEMPORARY_PKG_CONFIG_DIR=/tmp/$RANDOM-pkg-config-$RANDOM
 ORIGINAL_PATH="$PATH"
 
@@ -57,7 +57,7 @@ function setup ()
     CROSS_DLL_DIR="$CROSS_DIR/bin"
     PATH=$CROSS_BIN_DIR:$PATH
 
-    MONO_VERSION=`grep AM_INIT_AUTOMAKE configure.in | cut -d ',' -f 2|tr -d '\)'|tr -d '\('`
+    MONO_VERSION=`grep AC_INIT configure.in | cut -d ',' -f 2|tr -d '\[ \]'`
     
     if [ -d ./.git ]; then
 	MONO_GIT_COMMIT="`git log -1 --format=format:%t`"

--- a/configure.in
+++ b/configure.in
@@ -93,6 +93,7 @@ case "$host" in
 		AC_DEFINE(DISABLE_PORTABILITY,1,[Disable the io-portability layer])
 		AC_DEFINE(PLATFORM_NO_SYMLINKS,1,[This platform does not support symlinks])
 		host_win32=yes
+		mono_cv_clang=no
 		if test "x$cross_compiling" = "xno"; then
 			target_win32=yes
 			if test "x$host" == "x$build" -a "x$host" == "x$target"; then


### PR DESCRIPTION
(1) Made build-mingw32.sh build .NET 4.5 as well.
(2) Fixed the version extraction for build-mingw32.sh. It extracted from the wrong line for current configure.in.
(3) configure.in added a line for Clang for the Windows cross-compile just like the Android cross-compile has.
It can't do the automatic check due to being a cross-compile so manually adding the line makes it possible
to build at all. Like Android, if you want to use Clang for the cross-compile, you have to manually set the
variable to 'yes'.

Summary:
With these changes, build-mingw32.sh works nicely and I've successfully built Windows Mono on Debian 6, using the command line "./build-mingw32.sh -d /usr/i586-mingw32msvc -m i586-mingw32msvc".
Changelog suggests the script may not have been touched/used in a while, so this is an un-break patch.
ave been touched/used in a while, so this is an un-break patch.
