### PR TITLE
AuthorizationRule now accepts NTAccount like it should. Provided a unit test.

### DIFF
--- a/mcs/class/corlib/System.Security.AccessControl/AuthorizationRule.cs
+++ b/mcs/class/corlib/System.Security.AccessControl/AuthorizationRule.cs
@@ -48,16 +48,19 @@ namespace System.Security.AccessControl {
 						      InheritanceFlags inheritanceFlags,
 						      PropagationFlags propagationFlags)
 		{
-			if (!(identity is SecurityIdentifier)) {
+			if (!(identity is SecurityIdentifier) && !(identity is NTAccount))
 				throw new ArgumentException ("identity");
-			}
-			
-			if (accessMask == 0) {
-				/* FIXME: check inheritance and
-				 * propagation flags too
-				 */
+
+			// Unit testing showed that MS.NET 4.0 actually throws ArgumentException
+			// for accessMask == 0, not the ArgumentOutOfRangeException specified.			
+			if (accessMask == 0)
+				throw new ArgumentException ("accessMask");
+
+			if (0 != (inheritanceFlags & ~(InheritanceFlags.ContainerInherit|InheritanceFlags.ObjectInherit)))
 				throw new ArgumentOutOfRangeException ();
-			}
+
+			if (0 != (propagationFlags & ~(PropagationFlags.NoPropagateInherit|PropagationFlags.InheritOnly)))
+				throw new ArgumentOutOfRangeException ();
 			
 			this.identity = identity;
 			this.accessMask = accessMask;

--- a/mcs/class/corlib/Test/System.Security.AccessControl/AuthorizationRuleTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/AuthorizationRuleTest.cs
@@ -1,0 +1,78 @@
+// AuthorizationRuleTest.cs - NUnit Test Cases for AuthorizationRule
+//
+// Authors:
+//	James Bellinger (jfb@zer7.com)
+
+#if NET_4_0
+
+using System;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using NUnit.Framework;
+
+namespace MonoTests.System.Security.AccessControl
+{
+	[TestFixture]
+	public class AuthorizationRuleTest
+	{
+		class TestRule : AuthorizationRule
+		{
+			public TestRule (IdentityReference identity,
+					int accessMask, bool isInherited,
+					InheritanceFlags inheritanceFlags,
+					PropagationFlags propagationFlags)
+				: base (identity, accessMask, isInherited, inheritanceFlags, propagationFlags)
+			{
+
+			}
+		}
+
+		[Test, ExpectedException (typeof (ArgumentException))]
+		public void ThrowOnZeroAccessMask ()
+		{
+			new TestRule (new SecurityIdentifier (WellKnownSidType.WorldSid, null),
+				0, false, InheritanceFlags.None, PropagationFlags.None);
+		}
+
+		[Test, ExpectedException (typeof (ArgumentOutOfRangeException))]
+		public void ThrowOnBadInheritanceFlags ()
+		{
+			new TestRule (new SecurityIdentifier (WellKnownSidType.WorldSid, null),
+				1, false, (InheritanceFlags)(-1), PropagationFlags.None);
+		}
+
+		// While InheritanceFlags.None makes PropagationFlags not *significant*,
+		// my tests with MS.NET show that it is still *validated*. So, we'll use
+		// that case with this test to make sure.
+		[Test, ExpectedException (typeof (ArgumentOutOfRangeException))]
+		public void ThrowOnBadPropagationFlags ()
+		{
+			new TestRule (new SecurityIdentifier (WellKnownSidType.WorldSid, null),
+				1, false, InheritanceFlags.None, (PropagationFlags)(-1));
+		}
+
+		[Test]
+		public void AcceptNTAccount ()
+		{
+			new TestRule (new NTAccount ("Test"), 1, false, InheritanceFlags.None, PropagationFlags.None);				
+		}
+
+		[Test]
+		public void AcceptSecurityIdentifier ()
+		{
+			new TestRule (new SecurityIdentifier (WellKnownSidType.WorldSid, null),
+				1, false, InheritanceFlags.None, PropagationFlags.None);
+		}
+
+		[Test]
+		public void AcceptValidFlags ()
+		{
+			SecurityIdentifier id = new SecurityIdentifier (WellKnownSidType.WorldSid, null);
+			new TestRule (id, 1, false, InheritanceFlags.ContainerInherit, PropagationFlags.NoPropagateInherit);				
+			new TestRule (id, 1, false, InheritanceFlags.ObjectInherit, PropagationFlags.InheritOnly);				
+		}
+	}
+}
+
+#endif
+

--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -204,6 +204,7 @@ System.Runtime.Versioning/TargetFrameworkAttributeTest.cs
 System.Runtime.Versioning/VersioningHelperTest.cs
 System/SByteTest.cs
 System.Security/CodeAccessPermissionTest.cs
+System.Security.AccessControl/AuthorizationRuleTest.cs
 System.Security.AccessControl/CommonAceTest.cs
 System.Security.AccessControl/RawAclTest.cs
 System.Security.AccessControl/RawSecurityDescriptorTest.cs


### PR DESCRIPTION
Many derived classes of AuthorizationRule have string overloads which pass
'new NTAccount (identity)'. The exception docs state "can be cast as a
SecurityIdentifier" not "is a SecurityIdentifier". Anyway, this fixes all the
string constructors in System.Security.AccessControl that derive from AuthorizationRule...

Also, I added checking for inheritanceFlags and propagationFlags parameters.

While building the unit test, I found accessMask == 0 throws ArgumentException,
not ArgumentOutOfRangeException, on MS.NET 4.0 (contrary to docs). So,
I've made this match.
