### PR TITLE
Needed to add more precise checking of dimensions on array initializers

### DIFF
--- a/mcs/errors/cs0847-2.cs
+++ b/mcs/errors/cs0847-2.cs
@@ -1,0 +1,11 @@
+// CS0847: An array initializer of length `2' was expected
+// Line: 9
+
+class M
+{
+	public static void Main ()
+	{
+		int[,] i = { {0, 0},
+			{ 1 } };
+	}
+}

--- a/mcs/errors/cs0847-3.cs
+++ b/mcs/errors/cs0847-3.cs
@@ -1,0 +1,11 @@
+// CS0847: An array initializer of length `2' was expected
+// Line: 9
+
+class M
+{
+	public static void Main ()
+	{
+		int[,,] i = { { { 0, 0 }, { 1, 1} },
+			{ { 2, 2 } } };
+	}
+}

--- a/mcs/errors/cs0847-4.cs
+++ b/mcs/errors/cs0847-4.cs
@@ -1,0 +1,11 @@
+// CS0847: An array initializer of length `3' was expected
+// Line: 9
+
+class M
+{
+	public static void Main ()
+	{
+		int[,,] i = { { { 0, 0, 0 }, { 1, 1, 1 } },
+			{ { 2 }, { 3, 3, 3 } } };
+	}
+}

--- a/mcs/mcs/expression.cs
+++ b/mcs/mcs/expression.cs
@@ -6133,7 +6133,7 @@ namespace Mono.CSharp
 		{
 			if (initializers != null && bounds == null) {
 				//
-				// We use this to store all the date values in the order in which we
+				// We use this to store all the data values in the order in which we
 				// will need to store them in the byte blob later
 				//
 				array_data = new List<Expression> ();
@@ -6191,7 +6191,16 @@ namespace Mono.CSharp
 						ec.Report.Error (623, loc, "Array initializers can only be used in a variable or field initializer. Try using a new expression instead");
 						return false;
 					}
-					
+
+					// When we don't have explicitly specified dimensions, record whatever dimension we first encounter at each level
+					if (!bounds.ContainsKey(idx + 1))
+						bounds[idx + 1] = sub_probe.Count;
+
+					if (bounds[idx + 1] != sub_probe.Count) {
+						ec.Report.Error(847, sub_probe.Location, "An array initializer of length `{0}' was expected", bounds[idx + 1].ToString());
+						return false;
+					}
+
 					bool ret = CheckIndices (ec, sub_probe, idx + 1, specified_dims, child_bounds - 1);
 					if (!ret)
 						return false;


### PR DESCRIPTION
One of my co-workers discovered one day that mcs.exe was happy to accept

``` c#
int[,] a = { { 0, 1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10} };
```

despite that [§12.6 of the C# standard](http://msdn.microsoft.com/en-us/library/aa664573%28v=VS.71%29.aspx) says "For each nested array initializer, the number of elements must be the same as the other array initializers at the same level."

This change includes test cases that should trigger the error, as well as the fairly straightforward fix for the error.
