### PR TITLE
Fixed Type.GetEnumNames sort order (it's specified on MSDN). Previously ...

### DIFF
--- a/mcs/class/corlib/System/Enum.cs
+++ b/mcs/class/corlib/System/Enum.cs
@@ -167,7 +167,7 @@ namespace System
 			names = other.names;
 			name_hash = other.name_hash;
 		}
-
+		
 		internal static void GetInfo (Type enumType, out MonoEnumInfo info)
 		{
 			/* First check the thread-local cache without locking */
@@ -187,18 +187,9 @@ namespace System
 
 			get_enum_info (enumType, out info);
 
-			IComparer ic = null;
 			Type et = Enum.GetUnderlyingType (enumType);
-			if (et == typeof (int))
-				ic = int_comparer;
-			else if (et == typeof (short))
-				ic = short_comparer;
-			else if (et == typeof (sbyte))
-				ic = sbyte_comparer;
-			else if (et == typeof (long))
-				ic = long_comparer;
+			SortEnums (et, info.values, info.names);
 			
-			Array.Sort (info.values, info.names, ic);
 			if (info.names.Length > 50) {
 				info.name_hash = new Hashtable (info.names.Length);
 				for (int i = 0; i <  info.names.Length; ++i)
@@ -208,6 +199,21 @@ namespace System
 			lock (global_cache_monitor) {
 				global_cache [enumType] = cached;
 			}
+		}
+		
+		internal static void SortEnums (Type et, Array values, Array names)
+		{
+			IComparer ic = null;
+			if (et == typeof (int))
+				ic = int_comparer;
+			else if (et == typeof (short))
+				ic = short_comparer;
+			else if (et == typeof (sbyte))
+				ic = sbyte_comparer;
+			else if (et == typeof (long))
+				ic = long_comparer;
+			
+			Array.Sort (values, names, ic);
 		}
 	};
 

--- a/mcs/class/corlib/System/Type.cs
+++ b/mcs/class/corlib/System/Type.cs
@@ -511,11 +511,19 @@ namespace System {
 
 			var fields = GetFields (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
 
-			string [] result = new string [fields.Length];
-			for (int i = 0; i < fields.Length; ++i)
-				result [i] = fields [i].Name;
+			string [] names = new string [fields.Length];
+			if (0 != names.Length) {
+				for (int i = 0; i < fields.Length; ++i)
+					names [i] = fields [i].Name;
+					
+				var et = GetEnumUnderlyingType ();
+				var values = Array.CreateInstance (et, names.Length);
+				for (int i = 0; i < fields.Length; ++i)
+					values.SetValue (fields [i].GetValue (null), i);
+				MonoEnumInfo.SortEnums (et, values, names);
+			}
 
-			return result;
+			return names;
 		}
 
 		static NotImplementedException CreateNIE () {

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3489,6 +3489,22 @@ PublicKeyToken=b77a5c561934e089"));
 			Assert.AreEqual ("C", res [2], "#7");
 		}
 
+		public enum OutOfOrderEnum : sbyte
+		{
+			D = -1, C = 2, B = 1, A = 0
+		}
+				
+		[Test]
+		public void GetEnumNamesSortsByUnsignedValue ()
+		{
+			string[] names = typeof (OutOfOrderEnum).GetEnumNames ();
+			Assert.AreEqual (4, names.Length);
+			Assert.AreEqual ("A", names [0]);
+			Assert.AreEqual ("B", names [1]);
+			Assert.AreEqual ("C", names [2]);
+			Assert.AreEqual ("D", names [3]);
+		}
+		
 		[Test]
 		public void GetEnumValues () {
 			try {


### PR DESCRIPTION
...this method was returning in GetFields (declaration) order. It now returns sorted by the unsigned value of the enum as is correct.

Ran into this while calling Type.GetEnumNames and Type.GetEnumValues.
To my surprise the pairs didn't match up. Anyway, here's a fix.
