### PR TITLE
Causes deserialization to work even with some broken assembly loaded.

### DIFF
--- a/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization/XmlFormatterDeserializer.cs
+++ b/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization/XmlFormatterDeserializer.cs
@@ -282,7 +282,16 @@ namespace System.Runtime.Serialization
 					types = rtle.Types;
 				}
 #else
-				types = ass.GetTypes ();
+				try
+				{
+					types = ass.GetTypes ();
+				}
+				catch (ReflectionTypeLoadException rtle)
+				{
+					Console.Error.WriteLine(rtle);
+					Console.Error.WriteLine("Assembly: " + ass);
+					continue;
+				}
 #endif
 				if (types == null)
 					continue;


### PR DESCRIPTION
...mbly throws the exception

"The classes in the module cannot be loaded."
