### PR TITLE
Fix for Xamarin bug 6148

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1777,6 +1777,7 @@ mono_class_layout_fields (MonoClass *class)
 				continue;
 
 			size = mono_type_size (field->type, &align);
+			align = class->packing_size ? MIN (class->packing_size, align): align;
 			class->min_align = MAX (align, class->min_align);
 
 			/*
@@ -1800,6 +1801,10 @@ mono_class_layout_fields (MonoClass *class)
 			real_size = MAX (real_size, size + field->offset);
 		}
 		class->instance_size = MAX (real_size, class->instance_size);
+		if (class->instance_size & (class->min_align - 1)) {
+			class->instance_size += class->min_align - 1;
+			class->instance_size &= ~(class->min_align - 1);
+		}
 		break;
 	}
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -383,7 +383,8 @@ BASE_TEST_CS_SRC=		\
 	mono-path.cs	\
 	bug-bxc-795.cs	\
 	bug-3903.cs	\
-	async-with-cb-throws.cs
+	async-with-cb-throws.cs \
+	bug-6148.cs
 
 TEST_CS_SRC_DIST=	\
 	$(BASE_TEST_CS_SRC)	\

--- a/mono/tests/bug-6148.cs
+++ b/mono/tests/bug-6148.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Runtime.InteropServices;
+
+
+[StructLayout(LayoutKind.Explicit)]
+struct DefaultPack
+{
+	[FieldOffset(0)]
+		public int A;
+	[FieldOffset(4)]
+		public int A1;
+	[FieldOffset(8)]
+		public byte A2;
+	
+	[FieldOffset(9)]
+		public int A3;
+	[FieldOffset(13)]
+		public int A4;
+}
+[StructLayout(LayoutKind.Explicit, Pack=2)]
+struct ExplicitPack
+{
+	[FieldOffset(0)]
+		public int A;
+	[FieldOffset(4)]
+		public int A1;
+	[FieldOffset(8)]
+		public byte A2;
+	
+	[FieldOffset(9)]
+		public int A3;
+	[FieldOffset(13)]
+		public int A4;
+}
+
+
+
+
+public class Program {
+	public static unsafe int Main(string[] args)
+	{
+		if (sizeof(DefaultPack) != 20)
+			return 1;
+
+		if (sizeof(ExplicitPack) != 18)
+			return 2;
+		return 0;
+	}
+}
+


### PR DESCRIPTION
- fixes https://bugzilla.xamarin.com/show_bug.cgi?id=6148
  - explicit layout classes use the right packing
    when determining the class size
