### PR TITLE
Update eglib gmarkup implementation to skip high-ASCII chars at start of XML file

### DIFF
--- a/eglib/src/gmarkup.c
+++ b/eglib/src/gmarkup.c
@@ -276,7 +276,7 @@ g_markup_parse_context_parse (GMarkupParseContext *context,
 
 		switch (context->state){
 		case START:
-			if (c == ' ' || c == '\t' || c == '\f' || c == '\n')
+			if (c == ' ' || c == '\t' || c == '\f' || c == '\n' || (c & 0x80))
 				continue;
 			if (c == '<'){
 				if (p+1 < end && p [1] == '?'){


### PR DESCRIPTION
I have been having problems with Mono not honoring *.exe.config files (it seemed to ignore them completely), and then I noticed that the files it was ignoring all had a [Unicode BOM](http://en.wikipedia.org/wiki/Byte_order_mark) at the beginning of the file.

In this change, I add high-ASCII characters to the set of "white space" that gmarkup ignores before the first XML open tag.
