### PR TITLE
Fix typo in OldValue/NewValue for mono-2-10

### DIFF
--- a/mcs/class/System/System.ComponentModel.Design/ComponentChangedEventArgs.cs
+++ b/mcs/class/System/System.ComponentModel.Design/ComponentChangedEventArgs.cs
@@ -61,11 +61,11 @@ namespace System.ComponentModel.Design
 		}
 
 		public object NewValue {
-			get { return oldValue; }
+			get { return newValue; }
 		}
 
 		public object OldValue {
-			get { return newValue; }
+			get { return olVdalue; }
 		}
 	}
 }


### PR DESCRIPTION
Fix typo in OldValue/NewValue in System.ComponentModel.Design/ComponentChangedEventArgs.cs
