### PR TITLE
Update mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/RelaxngPattern....

### DIFF
--- a/mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/RelaxngPattern.cs
+++ b/mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/RelaxngPattern.cs
@@ -83,8 +83,8 @@ namespace Commons.Xml.Relaxng
 			RelaxngGrammar g = null;
 			RelaxngPattern p;
 			try {
-				if (grammar.IsSourceCompactSyntax) {
-					p = RncParser.ParseRnc (new StreamReader ((Stream) grammar.Resolver.GetEntity (uri, null, typeof (Stream))), null, BaseUri, nsContext);
+				if (uri.AbsolutePath.EndsWith(".rnc", StringComparison.InvariantCultureIgnoreCase)) {
+					p = RncParser.ParseRnc (new StreamReader ((Stream) grammar.Resolver.GetEntity (uri, null, typeof (Stream))), null, uri.AbsoluteUri, nsContext);
 				} else {
 					xtr = new XmlTextReader (uri.AbsoluteUri, (Stream) grammar.Resolver.GetEntity (uri, null, typeof (Stream)));
 					RelaxngReader r = new RelaxngReader (xtr, nsContext, grammar.Resolver);


### PR DESCRIPTION
...cs
- Choice of using the parser for compact syntax or not based on the file extension,
  in order to allow mixed grammars (e.g. including RNG from RNC).
- Correction in base URI for compact syntax in order to allow including grammar files located in different directories.
