### PR TITLE
Return correctly-sized ProcessThreadCollection to enable Threads.Count.

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -685,11 +685,13 @@ namespace System.Diagnostics {
 		}
 
 		[MonoTODO]
-		[DesignerSerializationVisibility (DesignerSerializationVisibility.Hidden), Browsable (false)]
+		[DesignerSerializationVisibility (DesignerSerializationVisibility.Hidden)]
 		[MonitoringDescription ("The number of threads of this process.")]
 		public ProcessThreadCollection Threads {
 			get {
-				return ProcessThreadCollection.GetEmpty ();
+				// This'll return a correctly-sized array of empty ProcessThreads for now.
+				int error;
+				return new ProcessThreadCollection(new ProcessThread[GetProcessData (pid, 0, out error)]);
 			}
 		}
 


### PR DESCRIPTION
I wrote this to provide a fix for [a question on Stack Overflow](http://stackoverflow.com/a/11713554/63225). It certainly didn't get rid of any <code>MonoTODO</code>s, but it at least plumbs through one thing we already had the native infrastructure for, but didn't have exposed in the class libraries.

Do you consider this incremental improvement useful enough to pull? Does someone want to work with me on getting the rest of the <code>ProcessThread</code> info wired up before this goes in?
