### PR TITLE
Update mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/XsdDatatypeProv...

### DIFF
--- a/mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/XsdDatatypeProvider.cs
+++ b/mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/XsdDatatypeProvider.cs
@@ -212,6 +212,8 @@ namespace Commons.Xml.Relaxng.XmlSchema
 			// simple-type based validation (since there is no
 			// other way, because of sucky XmlSchemaSimpleType
 			// design).
+			if (value != null)
+				value = value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
 			XmlValidatingReader v = new XmlValidatingReader (
 				new XmlTextReader (
 					String.Concat ("<root>", value, "</root>"),


### PR DESCRIPTION
...ider.cs

The text, which arrives decoded, must be escaped when manually concatenating strings aimed to be consumed by an XML reader.

For instance, if the original document to be validated contains
[a href="http://example.org/?a=1&amp;b=2"]fail[/a]
then the "value" parameter will contain "http://example.org/?a=1&b=2"
and before the patch, that would have generated an exception.
I am not sure however, if the whole Parse() function works correctly.
In addition, the function is using XmlValidatingReader, which is deprecated.

Cordially,
Alexandre
http://alexandre.alapetite.fr
