### PR TITLE
Update mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/RelaxngValidati...

### DIFF
--- a/mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/RelaxngValidatingReader.cs
+++ b/mcs/class/Commons.Xml.Relaxng/Commons.Xml.Relaxng/RelaxngValidatingReader.cs
@@ -3,7 +3,7 @@
 //
 // Author:
 //	Atsushi Enomoto <ginga@kit.hi-ho.ne.jp>
-//	Alexandre Alapetite <http://alexandre.alapetite.net/cv/>
+//	Alexandre Alapetite <http://alexandre.alapetite.fr/cv/>
 //
 // 2003 Atsushi Enomoto. "No rights reserved."
 //
@@ -629,12 +629,12 @@ namespace Commons.Xml.Relaxng
 				if (!Util.IsWhitespace (cachedValue)) {
 					// HandleError() is not really useful here since it involves else condition...
 					ts = memo.MixedTextDeriv (ts);
-					if (InvalidNodeFound != null) {
+					/*if (InvalidNodeFound != null) {
 						InvalidNodeFound (reader, "Not allowed text node was found.");
 						ts = vState;
 						cachedValue = null;
 					}
-					else
+					else*/
 						ts = TextDeriv (ts, cachedValue, reader);
 				}
 				break;


### PR DESCRIPTION
...ngReader.cs

There should not be such a big difference in behaviour when the application listens to the InvalidNodeFound event or not.
Furthermore, before the patch, the following document would fail (tests done with http://syntax.whattf.org/relaxng/xhtml5.rnc ):

[!DOCTYPE html]
[html xmlns="http://www.w3.org/1999/xhtml"]
[head][title]XHTML5 test[/title][/head]
[body][p]This is a [span]simple[/span] test.[/p][/body]
[/html]

because "cachedValue" contains "This is a".

However, I have a suspicion that there is a problem in the logic of this function.

Cordially,
Alexandre
http://alexandre.alapetite.fr
