### PR TITLE
Use HashSet.Comparer for set methods with IEnumerable collection

### DIFF
--- a/mcs/class/System.Core/System.Collections.Generic/HashSet.cs
+++ b/mcs/class/System.Core/System.Collections.Generic/HashSet.cs
@@ -438,7 +438,7 @@ namespace System.Collections.Generic {
 		{
 			var set = enumerable as HashSet<T>;
 			if (set == null || !Comparer.Equals (set.Comparer))
-				set = new HashSet<T> (enumerable);
+				set = new HashSet<T> (enumerable, Comparer);
 
 			return set;
 		}

--- a/mcs/class/System.Core/Test/System.Collections.Generic/HashSetTest.cs
+++ b/mcs/class/System.Core/Test/System.Collections.Generic/HashSetTest.cs
@@ -173,6 +173,20 @@ namespace MonoTests.System.Collections.Generic {
 		}
 
 		[Test]
+		public void TestIntersectWithComparer ()
+		{
+			var data = new[] {"a", "b", "C", "d", "E"};
+			var other = new[] {"a", "B", "e"};
+			var result = new[] {"a", "b", "E"};
+
+			var set = new HashSet<string> (data, StringComparer.OrdinalIgnoreCase);
+
+			set.IntersectWith (other);
+
+			AssertContainsOnly (result, set);
+		}
+
+		[Test]
 		public void TestExceptWith ()
 		{
 			var data = new [] {1, 2, 3, 4, 5, 6};
@@ -236,6 +250,18 @@ namespace MonoTests.System.Collections.Generic {
 		}
 
 		[Test]
+		public void TestSubsetOfComparer ()
+		{
+			var data = new[] { "abc", "DF", "gHIl" };
+
+			var other1 = new[] { "pqR", "ABC", "ghil", "dF", "lmn" };
+
+			var set = new HashSet<string> (data, StringComparer.OrdinalIgnoreCase);
+
+			Assert.IsTrue (set.IsSubsetOf (other1));
+		}
+
+		[Test]
 		public void TestProperSubsetOf ()
 		{
 			var data = new [] {1, 2, 3};
@@ -248,6 +274,18 @@ namespace MonoTests.System.Collections.Generic {
 			Assert.IsTrue (set.IsProperSubsetOf (other));
 			Assert.IsFalse (set.IsProperSubsetOf (other2));
 			Assert.IsFalse (set.IsProperSubsetOf (other3));
+		}
+
+		[Test]
+		public void TestProperSubsetOfComparer ()
+		{
+			var data = new[] { "abc", "DF", "gHIl" };
+
+			var other1 = new[] { "pqR", "ABC", "ghil", "dF", "lmn" };
+
+			var set = new HashSet<string> (data, StringComparer.OrdinalIgnoreCase);
+
+			Assert.IsTrue (set.IsProperSubsetOf (other1));
 		}
 
 		[Test]
@@ -266,6 +304,20 @@ namespace MonoTests.System.Collections.Generic {
 		}
 
 		[Test]
+		public void TestSupersetOfComparer ()
+		{
+			var data = new[] {"a", "B", "c", "D"};
+
+			var other1 = new[] {"A", "a", "C", "c"};
+			var other2 = new[] {"A", "a", "B", "D", "C", "c"};
+
+			var set = new HashSet<string> (data, StringComparer.OrdinalIgnoreCase);
+
+			Assert.IsTrue (set.IsSupersetOf (other1));
+			Assert.IsTrue (set.IsSupersetOf (other2));
+		}
+
+		[Test]
 		public void TestProperSupersetOf ()
 		{
 			var data = new [] {1, 2, 3, 4, 5};
@@ -278,6 +330,20 @@ namespace MonoTests.System.Collections.Generic {
 			Assert.IsTrue (set.IsProperSupersetOf (other));
 			Assert.IsFalse (set.IsProperSupersetOf (other2));
 			Assert.IsFalse (set.IsProperSupersetOf (other3));
+		}
+
+		[Test]
+		public void TestProperSupersetOfComparer ()
+		{
+			var data = new[] { "a", "B", "c", "D" };
+
+			var other1 = new[] { "A", "a", "d", "D" };
+			var other2 = new[] { "A", "a", "B", "D", "C", "c" };
+
+			var set = new HashSet<string> (data, StringComparer.OrdinalIgnoreCase);
+
+			Assert.IsTrue (set.IsProperSupersetOf (other1));
+			Assert.IsFalse (set.IsProperSupersetOf (other2));
 		}
 
 		[Test]
@@ -298,6 +364,20 @@ namespace MonoTests.System.Collections.Generic {
 			Assert.IsFalse (set.SetEquals (other3));
 			Assert.IsFalse (set.SetEquals (other4));
 			Assert.IsFalse (set.SetEquals (other5));
+		}
+
+		[Test]
+		public void TestSetEqualsComparer ()
+		{
+			var data = new[] { "abc", "DF", "gHIl" };
+
+			var other1 = new[] { "ABC", "DF", "GHIL" };
+			var other2 = new[] { "ABC", "aBc", "DF", "GHIL", "ghil" };
+
+			var set = new HashSet<string>(data, StringComparer.OrdinalIgnoreCase);
+
+			Assert.IsTrue (set.SetEquals (other1));
+			Assert.IsTrue (set.SetEquals (other2));
 		}
 
 		[Test]


### PR DESCRIPTION
fix bug 6373 ( https://bugzilla.xamarin.com/show_bug.cgi?id=6373 )

i checked the behaviour with .NET 3.5, .NET 4.0
