### PR TITLE
Fix for incorrect behavior of Guid.TryParse and Guid.TryParseExact. Bug Id: 6402

### DIFF
--- a/mcs/class/corlib/System/Guid.cs
+++ b/mcs/class/corlib/System/Guid.cs
@@ -693,6 +693,9 @@ namespace System {
 #if NET_4_0 || MOONLIGHT || MOBILE
 		public static Guid Parse (string input)
 		{
+			if (input == null)
+				throw new ArgumentNullException ("input");
+
 			Guid guid;
 			if (!TryParse (input, out guid))
 				throw CreateFormatException (input);
@@ -702,6 +705,11 @@ namespace System {
 
 		public static Guid ParseExact (string input, string format)
 		{
+			if (input == null)
+				throw new ArgumentNullException ("input");
+			if (format == null)
+				throw new ArgumentNullException ("format");
+
 			Guid guid;
 			if (!TryParseExact (input, format, out guid))
 				throw CreateFormatException (input);
@@ -711,8 +719,10 @@ namespace System {
 
 		public static bool TryParse (string input, out Guid result)
 		{
-			if (input == null)
-				throw new ArgumentNullException ("input");
+			if (input == null) {
+				result = Empty;
+				return false;
+			}
 
 			var parser = new GuidParser (input);
 			return parser.Parse (out result);
@@ -720,10 +730,10 @@ namespace System {
 
 		public static bool TryParseExact (string input, string format, out Guid result)
 		{
-			if (input == null)
-				throw new ArgumentNullException ("input");
-			if (format == null)
-				throw new ArgumentNullException ("format");
+			if (input == null || format == null) {
+				result = Empty;
+				return false;
+			}
 
 			var parser = new GuidParser (input);
 			return parser.Parse (ParseFormat (format), out result);

--- a/mcs/class/corlib/Test/System/GuidTest.cs
+++ b/mcs/class/corlib/Test/System/GuidTest.cs
@@ -392,6 +392,30 @@ namespace MonoTests.System {
 		{
 			Guid.ParseExact ("{0x00010203,0x0405,0x0607,{0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f}}", "D");
 		}
+
+		[Test]
+		public void TryParse()
+		{
+			Guid guid;
+			Assert.IsFalse (Guid.TryParse(null, out guid), "A1");
+			Assert.AreEqual (Guid.Empty, guid, "A2");
+			Assert.IsFalse (Guid.TryParse("", out guid), "A3");
+			Assert.AreEqual (Guid.Empty, guid, "A4");
+			Assert.IsFalse (Guid.TryParse("foobar", out guid), "A5");
+			Assert.AreEqual (Guid.Empty, guid, "A6");
+		}
+
+		[Test]
+		public void TryParseExact()
+		{
+			Guid guid;
+			Assert.IsFalse (Guid.TryParseExact(null, null, out guid), "A1");
+			Assert.AreEqual (Guid.Empty, guid, "A2");
+			Assert.IsFalse (Guid.TryParseExact("", null, out guid), "A3");
+			Assert.AreEqual (Guid.Empty, guid, "A4");
+			Assert.IsFalse (Guid.TryParseExact("foobar", null, out guid), "A5");
+			Assert.AreEqual (Guid.Empty, guid, "A6");
+		}
 #endif
 	}
 }


### PR DESCRIPTION
According to the MSDN documentation, http://msdn.microsoft.com/en-us/library/system.guid.tryparse.aspx and http://msdn.microsoft.com/en-us/library/system.guid.tryparseexact.aspx, Guid.TryParse and Guid.TryParseExact should "return false if input is null or not in a recognized format, and does not throw an exception."
