### PR TITLE
Bug #6404: System.Text.Encoder only throws ArgumentOutOfRangeException when appropriate

### DIFF
--- a/mcs/class/corlib/System.Text/Encoder.cs
+++ b/mcs/class/corlib/System.Text/Encoder.cs
@@ -133,11 +133,11 @@ public abstract class Encoder
 			throw new ArgumentNullException ("chars");
 		if (bytes == null)
 			throw new ArgumentNullException ("bytes");
-		if (charIndex < 0 || chars.Length <= charIndex)
+		if (charIndex < 0)
 			throw new ArgumentOutOfRangeException ("charIndex");
 		if (charCount < 0 || chars.Length < charIndex + charCount)
 			throw new ArgumentOutOfRangeException ("charCount");
-		if (byteIndex < 0 || bytes.Length <= byteIndex)
+		if (byteIndex < 0)
 			throw new ArgumentOutOfRangeException ("byteIndex");
 		if (byteCount < 0 || bytes.Length < byteIndex + byteCount)
 			throw new ArgumentOutOfRangeException ("byteCount");

--- a/mcs/class/corlib/Test/System.Text/EncoderTest.cs
+++ b/mcs/class/corlib/Test/System.Text/EncoderTest.cs
@@ -64,6 +64,22 @@ namespace MonoTests.System.Text
 			Assert.IsNotNull (encoder);
 		}
 
+		[Test]
+		public void ConvertZeroCharacters ()
+		{
+			int charsUsed, bytesUsed;
+			bool completed;
+			byte [] bytes = new byte [0];
+
+			Encoding.UTF8.GetEncoder ().Convert (
+				new char[0], 0, 0, bytes, 0, bytes.Length, true,
+				out charsUsed, out bytesUsed, out completed);
+
+			Assert.IsTrue (completed, "#1");
+			Assert.AreEqual (0, charsUsed, "#2");
+			Assert.AreEqual (0, bytesUsed, "#3");
+		}
+
 		class CustomEncoding : Encoding {
 
 			public override int GetByteCount (char [] chars, int index, int count)


### PR DESCRIPTION
This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=6404
