### PR TITLE
Fix for bz6389 - Absolute paths to project files cause error: 'MSBUILD00...

### DIFF
--- a/mcs/tools/xbuild/Parameters.cs
+++ b/mcs/tools/xbuild/Parameters.cs
@@ -102,10 +102,8 @@ namespace Mono.XBuild.CommandLine {
 				LoadResponseFile (responseFile);
 			}
 			foreach (string s in flatArguments) {
-				if (s [0] != '/')
+				if (s [0] != '/' || !ParseFlatArgument (s))
 					remainingArguments.Add (s);
-				else if (!ParseFlatArgument (s))
-					ReportError (1, "Unknown switch: " + s);
 			}
 			if (remainingArguments.Count == 0) {
 				string[] sln_files = Directory.GetFiles (Directory.GetCurrentDirectory (), "*.sln");


### PR DESCRIPTION
This is to address bug [bz6389](https://bugzilla.xamarin.com/show_bug.cgi?id=6389). 

Issue originates from a [previous commit (54a6896)](https://github.com/mono/mono/commit/54a689690afc44fe6a7c837cc73f142009fc4631) with a subsequent [failed attempt at fixing it in commit (667eb08)](https://github.com/mono/mono/commit/667eb08736701f413d42d4362875702114b5a760). 

Unfortunately I don't see how the original intent is workable given the current command-line structure (use of slashes '/') and can see little benefit of it remaining. Worth noting that automated build tools (such as [FAKE - F# Make](https://github.com/forki/FAKE)) currently fail due to this issue.

This pull-request effectively backs out the original change.
