### PR TITLE
Fix bug 290

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/ServiceEndpoint.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/ServiceEndpoint.cs
@@ -121,6 +121,9 @@ namespace System.ServiceModel.Description
 
 		internal void Validate ()
 		{
+			if (Contract.Operations.Count == 0)
+				throw new InvalidOperationException (String.Format ("ContractDescription '{0}' has zero operations; a contract must have at least one operation.", Contract.ContractType.Name));
+
 			foreach (IContractBehavior b in Contract.Behaviors)
 				b.Validate (Contract, this);
 			foreach (IEndpointBehavior b in Behaviors)

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
@@ -204,6 +204,26 @@ namespace MonoTests.System.ServiceModel
 		}
 
 		[Test]
+		public void Open ()
+		{
+			ServiceHost host = new ServiceHost (typeof (ZeroOperationsImpl));
+			host.AddServiceEndpoint (typeof (IHaveZeroOperarationsContract), new BasicHttpBinding (), "http://localhost/echo");
+
+			try {
+				host.Open ();
+				Assert.Fail ("InvalidOperationException expected");
+			} 
+			catch (InvalidOperationException e) {
+				//"ContractDescription 'IHaveZeroOperarationsContract' has zero operations; a contract must have at least one operation."
+				StringAssert.Contains ("IHaveZeroOperarationsContract", e.Message);
+			}
+			finally {
+				if (host.State == CommunicationState.Opened)
+					host.Close (); // It is to make sure to close unexpectedly opened host if the test fail.
+			}
+		}
+
+		[Test]
 		public void AddServiceEndpoint4 ()
 		{
 			ServiceHost host = new ServiceHost (typeof (Baz), new Uri ("http://localhost/echo"));
@@ -345,7 +365,21 @@ namespace MonoTests.System.ServiceModel
 			[OperationContract]
 			void DoY ();
 		}
-		
+
+		[ServiceContract]
+		interface IHaveZeroOperarationsContract
+		{
+			string Echo (string source);
+		}
+
+		class ZeroOperationsImpl : IHaveZeroOperarationsContract
+		{
+			public string Echo(string source)
+			{
+				return null;
+			}
+		}
+
 		class HogeFuga : IHoge, IFuga
 		{
 			public void DoX () {}


### PR DESCRIPTION
ServiceHost.Open should throw InvalidOperationException if service contract has zero operations

Fix bug https://bugzilla.xamarin.com/show_bug.cgi?id=290
