### PR TITLE
Return at least MinimumWidth instead of 0 in GetPreferredWidth

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridViewColumn.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridViewColumn.cs
@@ -467,6 +467,7 @@ Example */
 			*/
 		}
 
+		[MonoTODO("Actually calculate width")]
 		public virtual int GetPreferredWidth (DataGridViewAutoSizeColumnMode autoSizeColumnMode, bool fixedHeight) {
 			switch (autoSizeColumnMode) {
 			case DataGridViewAutoSizeColumnMode.NotSet:
@@ -475,10 +476,10 @@ Example */
 				throw new ArgumentException("AutoSizeColumnMode is invalid");
 			}
 			if (fixedHeight) {
-				return 0;
+				return MinimumWidth;
 			}
 			else {
-				return 0;
+				return MinimumWidth;
 			}
 		}
 


### PR DESCRIPTION
Otherwise we cannot use GetPreferredWidth as new Width, since this will
throw an Exception (ArgumentOutOfRange).
It's not a real fix, but it avoids crashes when using this method to
assign a new width for columns. Attached a MonoTODO to make this clear.

Signed-off-by: Daniel Knittl-Frank <knittl89+git@googlemail.com>
