### PR TITLE
Fix ArgumentOutOfRangeException in HttpListenerManager.TryDequeueRequest when timeout is less than 0

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpListenerManager.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpListenerManager.cs
@@ -96,6 +96,7 @@ namespace System.ServiceModel.Channels.Http
 			lock (ce.RetrieverLock) {
 				var q = ce.ContextQueue;
 				if (q.Count == 0) {
+					if (timeout.TotalMilliseconds < 0) return false;
 					TimeSpan waitTimeout = timeout;
 					if (timeout == TimeSpan.MaxValue)
 						waitTimeout = TimeSpan.FromMilliseconds (int.MaxValue);


### PR DESCRIPTION
In rare situations timeout passed to TryDequeueRequest can be negative. This can happen if previous recurrent call to this method (from line 103) was called after waiting almost for "waitTimeout" value, in such case (DateTime.Now - start) can be greater than "waitTimeout" and,  as a result, ArgumentOutOfRangeException is thrown from line 102. The patch makes sure that this doesn't happen.
