### PR TITLE
UInt32 is too large for Int32

### DIFF
--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteStatement.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteStatement.cs
@@ -181,6 +181,7 @@ namespace Mono.Data.Sqlite
         case DbType.DateTime:
           _sql.Bind_DateTime(this, index, Convert.ToDateTime(obj, CultureInfo.CurrentCulture));
           break;
+        case DbType.UInt32:
         case DbType.Int64:
         case DbType.UInt64:
           _sql.Bind_Int64(this, index, Convert.ToInt64(obj, CultureInfo.CurrentCulture));
@@ -189,7 +190,6 @@ namespace Mono.Data.Sqlite
         case DbType.Int16:
         case DbType.Int32:
         case DbType.UInt16:
-        case DbType.UInt32:
         case DbType.SByte:
         case DbType.Byte:
           _sql.Bind_Int32(this, index, Convert.ToInt32(obj, CultureInfo.CurrentCulture));


### PR DESCRIPTION
Fix for overflow exception as mapping a UInt32 to Int32 fails.
Changed mapping of UInt32 to Int64 instead.

Line 192 was moved to 184:
case `DbType.UInt32:` was moved to make it map to `_sql.Bind_Int64(...)`

This can be reproduced by saving an `UInt32.Max`.
