### PR TITLE
Capturing more local variables in iterator/async context.

### DIFF
--- a/mcs/mcs/context.cs
+++ b/mcs/mcs/context.cs
@@ -475,14 +475,14 @@ namespace Mono.CSharp
 			// or it's a parameter
 			//
 			if (CurrentAnonymousMethod.IsIterator)
-				return local.IsParameter || CurrentBlock.Explicit.HasYield;
+				return local.IsParameter || local.Block.Explicit.HasYield || local.Block == CurrentAnonymousMethod.Block.Original;
 
 			//
 			// Capture only if this or any of child blocks contain await
 			// or it's a parameter
 			//
 			if (CurrentAnonymousMethod is AsyncInitializer)
-				return local.IsParameter || CurrentBlock.Explicit.HasAwait;
+				return local.IsParameter || local.Block.Explicit.HasAwait || local.Block == CurrentAnonymousMethod.Block.Original;
 
 			return local.Block.ParametersBlock != CurrentBlock.ParametersBlock.Original;
 		}


### PR DESCRIPTION
If the block in which the variable is declared contains a yield/await, capture the variable as it may be assigned and/or used in child block that do not contain yield/await. Previously, if the variable was assigned in a child block that did not contain a yield/await and subsequently used in a child block after a yield/await that also did not contain a yield/await, the variable would be treated as local to the MoveNext method, having it's value reset on each call to MoveNext. This fixes bug #6587.
