### PR TITLE
Patch for bug #6718 - incorrect release of XPCOM object causing segmention fault

### DIFF
--- a/mcs/class/corlib/Mono.Interop/ComInteropProxy.cs
+++ b/mcs/class/corlib/Mono.Interop/ComInteropProxy.cs
@@ -94,11 +94,11 @@ namespace Mono.Interop
 			Marshal.ThrowExceptionForHR (hr);
 			ComInteropProxy obj = FindProxy (ppv);
 			if (obj == null) {
-				Marshal.Release (pItf);
+				Marshal.Release (ppv);
 				return new ComInteropProxy (ppv);
 			}
 			else {
-				Marshal.Release (pItf);
+				Marshal.Release (ppv);
 				System.Threading.Interlocked.Increment (ref obj.ref_count);
 				return obj;
 			}


### PR DESCRIPTION
Bug report is at https://bugzilla.xamarin.com/show_bug.cgi?id=6718
