### PR TITLE
Generic inflating: support for pointer types.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -579,6 +579,15 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		mono_metadata_free_type (inflated);
 		return nt;
 	}
+	case MONO_TYPE_PTR: {
+		MonoType *nt, *inflated = inflate_generic_type(NULL, type->data.type, context, error);
+		if (!inflated || !mono_error_ok (error))
+			return NULL;
+
+		nt = mono_metadata_type_dup (image, type);
+		nt->data.type = inflated;
+		return nt;
+	}
 	case MONO_TYPE_GENERICINST: {
 		MonoGenericClass *gclass = type->data.generic_class;
 		MonoGenericInst *inst;


### PR DESCRIPTION
Mono was generating runtime exception when JITing any method referencing this IL function:

```
.method public hidebysig static !!T* Cast<T>(void* ptr) cil managed
{
    ldarg.0
    ret
}
```
- Assertion at method-to-ir.c:5873, condition `!sig->has_type_parameters' not met
  It was because inflating pointer type (such as !!T*) was not implemented.

Somebody should probably double check if what I did is good (esp. not totally sure if there is something I'm suppose to free, but since I directly use "inflated" I thought that was not necessary).
