### PR TITLE
Fixing large file support compile-time check.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1132,12 +1132,7 @@ if test x$target_win32 = xno; then
 			/* Lifted this compile time assert method from: http://www.jaggersoft.com/pubs/CVu11_3.html */
 			#define COMPILE_TIME_ASSERT(pred) \
 				switch(0){case 0:case pred:;}
-
-			int main(void)
-			{
-				COMPILE_TIME_ASSERT(sizeof(off_t) * CHAR_BIT == 64);
-				return 0;
-			}
+			COMPILE_TIME_ASSERT(sizeof(off_t) * CHAR_BIT == 64);
 		], [
 			AC_MSG_RESULT(ok)
 			AC_DEFINE(HAVE_LARGE_FILE_SUPPORT, 1, [Have large file support])


### PR DESCRIPTION
Previous check did not follow the same conventions for the function body as other AC_TRY_COMPILE checks. This resulted in incorrectly reporting that the system did not have large file support due to the following errors reported in config.log:

conftest.c:88: warning: function declaration isn't a prototype
conftest.c: In function 'main':
conftest.c:94: error: nested functions are disabled, use -fnested-functions to re-enable
conftest.c:94: warning: 'main' is normally a non-static function
configure:21041: $? = 1
