### PR TITLE
Add missing .resources files in aspnetwebstack projects

### DIFF
--- a/mcs/class/System.Net.Http.Formatting/Makefile
+++ b/mcs/class/System.Net.Http.Formatting/Makefile
@@ -13,7 +13,8 @@ System.Net.Http.Properties.Resources.resources: ../../../external/aspnetwebstack
 
 LIB_MCS_FLAGS = -r:System.Core.dll -r:System.dll -r:System.Net.Http.dll -r:System.Xml.dll -r:System.Runtime.Serialization.dll -r:System.Xml.Linq.dll -r:System.Data.dll -r:System.Configuration.dll \
 		-d:ASPNETMVC -keyfile:../winfx.pub -delaysign \
-		-resource:System.Net.Http.Properties.CommonWebApiResources.resources
+		-resource:System.Net.Http.Properties.CommonWebApiResources.resources \
+		-resource:System.Net.Http.Properties.Resources.resources
 
 include ../../build/library.make
 

--- a/mcs/class/System.Web.Http/Makefile
+++ b/mcs/class/System.Web.Http/Makefile
@@ -13,7 +13,9 @@ System.Web.Http.Properties.SRResources.resources: ../../../external/aspnetwebsta
 
 LIB_MCS_FLAGS = -r:System.Core.dll -r:System.dll -r:System.Xml.dll -r:System.Net.Http.dll -r:System.ComponentModel.DataAnnotations.dll \
 		-r:System.Net.Http.Formatting.dll -r:System.Runtime.Caching.dll -r:System.Runtime.Serialization.dll -r:System.Data.Linq.dll \
-		-d:ASPNETMVC -keyfile:../winfx.pub -delaysign
+		-d:ASPNETMVC -keyfile:../winfx.pub -delaysign \
+		-resource:System.Web.Http.Properties.CommonWebApiResources.resources \
+		-resource:System.Web.Http.Properties.SRResources.resources
 
 include ../../build/library.make
 


### PR DESCRIPTION
The System.Net.Http.Formatting and System.Web.Http make files were missing some lines for embedding the string resources into the assemblies. This caused MissingManifestResourceExceptions at runtime.
