### PR TITLE
Fixes nasty issue with callbacks not happening.

### DIFF
--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -574,8 +574,8 @@ socket_io_add (MonoAsyncResult *ares, MonoSocketAsyncResult *state)
 
 	mono_g_hash_table_replace (data->sock_to_state, state->handle, list);
 	ievt = get_events_from_list (list);
-	LeaveCriticalSection (&data->io_lock);
 	data->modify (data->event_data, fd, state->operation, ievt, is_new);
+        LeaveCriticalSection (&data->io_lock);
 }
 
 #ifndef DISABLE_SOCKETS


### PR DESCRIPTION
async callabacks (TCP) occasionally do not happen under load. This causes the async loop
to break in the calling TCP code. EX you call beginsend but never get endsend

We have put examples of this on mailing list. With this patch (and previous patch to object pool) we can not reproduce the problem.
