### PR TITLE
When detecting drive type it is possible that a path might be mounted mo...

### DIFF
--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -3954,8 +3954,12 @@ GetDriveTypeFromPath (const gchar *utf8_root_path_name)
 		if (strcmp (*(splitted + 1), utf8_root_path_name) == 0 ||
 		    (strcmp (*(splitted + 1), "/") == 0 && strlen (utf8_root_path_name) == 0)) {
 			drive_type = _wapi_get_drive_type (*(splitted + 2));
-			g_strfreev (splitted);
-			break;
+			/* it is possible this path might be mounted again with
+			   a known type...keep looking */
+			if (drive_type != DRIVE_UNKNOWN) {
+				g_strfreev (splitted);
+				break;
+			}
 		}
 
 		g_strfreev (splitted);


### PR DESCRIPTION
...re than once and later mounts may have a known type.

This will allow the check to keep looking in case it can a known type.
This happens with a default redhat system which uses lvm and the first entry for the main drive is unknown even though a later entry is a known type.
