### PR TITLE
[System] Fix Uri.MakeRelativeUri on paths to higher level dir

### DIFF
--- a/mcs/class/System/System/Uri.cs
+++ b/mcs/class/System/System/Uri.cs
@@ -1038,6 +1038,13 @@ namespace System {
 				for (int i = k; i < segments2.Length; i++)
 					result += segments2 [i];
 				
+				// if there is more than 1 segment and if the last segment of segments
+				// ends with separator char, assume its a directory and prepend "../"
+				if (segments.Length > 1) {
+					var lastSegment = segments [segments.Length - 1];
+					if (lastSegment.EndsWith ("/"))
+						result = "../" + result;
+				}
 			}
 			uri.AppendQueryAndFragment (ref result);
 

--- a/mcs/class/System/Test/System/UriTest3.cs
+++ b/mcs/class/System/Test/System/UriTest3.cs
@@ -439,6 +439,8 @@ namespace MonoTests.System
 			Uri uri11 = new Uri ("mailto:xxx@xxx.com?subject=hola");
 			Uri uri12 = new Uri ("mailto:xxx@mail.xxx.com?subject=hola");
 			Uri uri13 = new Uri ("mailto:xxx@xxx.com/foo/bar");
+			Uri uri14 = new Uri ("http://www.contoso.com/test1/");
+			Uri uri15 = new Uri ("http://www.contoso.com/");
 
 			AssertRelativeUri ("foo/bar/index.htm#fragment", uri1, uri2, "#A");
 			AssertRelativeUri ("../../index.htm?x=2", uri2, uri1, "#B");
@@ -470,6 +472,8 @@ namespace MonoTests.System
 			Assert.IsTrue (relativeUri.IsAbsoluteUri, "#N1");
 			Assert.AreEqual (uri5.ToString (), relativeUri.ToString (), "#N2");
 			Assert.AreEqual (uri5.OriginalString, relativeUri.OriginalString, "#N3");
+
+			AssertRelativeUri ("../", uri14, uri15, "#O");
 		}
 
 		[Test]


### PR DESCRIPTION
Problem description:
Given the test case when a relative path should be built from a lower
level dir to a higher level dir, the last bit from the "From-Path" is always
considered to be a file - even if it ends with "/". In contrast, .NET
considers paths ending with "/" as directories and therefore the
resulting path goes one level further up than the resulting path of the
mono implementation. This patch aims to fix that.

I've successfully run the unit-tests on mono on Ubuntu amd64 and on
.NET on Windows x86 - both on profile 4.0.
