### PR TITLE
Fix ServicePointManager.DefaultConnectionLimit to work as specified.

### DIFF
--- a/mcs/class/System/System.Net/ServicePointManager.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.cs
@@ -187,6 +187,8 @@ namespace System.Net
 					throw new ArgumentOutOfRangeException ("value");
 
 				defaultConnectionLimit = value; 
+                if (manager != null)
+					manager.Add ("*", defaultConnectionLimit);
 			}
 		}
 


### PR DESCRIPTION
Fix ServicePointManager to accept the DefaultConnectionLimit property being
set as per the .NET spec.
