### PR TITLE
mcs: Don't use an array for the interfaces collection as a call to Add results in a NotSupportedException

### DIFF
--- a/mcs/mcs/generic.cs
+++ b/mcs/mcs/generic.cs
@@ -790,7 +790,7 @@ namespace Mono.CSharp {
 			set {
 				ifaces_defined = value;
 				if (value != null && value.Length != 0)
-					ifaces = value;
+					ifaces = value.ToList();
 			}
 		}
 


### PR DESCRIPTION
The class `TypeParameterSpec` has a property `InterfacesDefined` that sets `ifaces` to an array. This can lead to a "NotSupportedException: Collection is of a fixed size" when the `AddInterface` method of the base class `TypeSpec` is called as the `Add` method is not supported for arrays. 

This error occurs when compiling AutoDiff from http://autodiff.codeplex.com/.

The compiler error was: 
CompiledDifferentiator.Compiler.cs(21,65): error CS0584: Internal compiler error: Collection is of a fixed size
CompiledDifferentiator.cs(28,31): error CS0584: Internal compiler error: Collection is of a fixed size
CompiledDifferentiator.cs(29,30): error CS0019: Operator == cannot be applied to operands of type int and method group
CompiledDifferentiator.cs(38,35): error CS0428: Cannot convert method group Count to non-delegate type int. Consider using parentheses to invoke the method 
CompiledDifferentiator.cs(39,25): error CS0584: Internal compiler error: Collection is of a fixed size
