### PR TITLE
Fix implementation of System.IO.Packaging::GetRelativeUri(Uri,Uri) [fixes xamarin's bug #2727]

### DIFF
--- a/mcs/class/WindowsBase/System.IO.Packaging/Check.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/Check.cs
@@ -135,6 +135,12 @@ namespace System.IO.Packaging
 		{
 			NotNull(sourcePartUri, "sourcePartUri");
 		}
+
+		public static void TargetPartUri (Uri targetPartUri)
+		{
+			NotNull(targetPartUri, "targetPartUri");
+		}
+
 		public static void SourceUri (Uri sourceUri)
 		{
 			if (sourceUri == null)

--- a/mcs/class/WindowsBase/System.IO.Packaging/PackUriHelper.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/PackUriHelper.cs
@@ -139,10 +139,14 @@ namespace System.IO.Packaging {
 
 		public static Uri GetRelativeUri (Uri sourcePartUri, Uri targetPartUri)
 		{
-			//Check.SourcePartUri (sourcePartUri);
-			//Check.TargetPartUri (targetPartUri);
+			Check.SourcePartUri (sourcePartUri);
+			Check.TargetPartUri (targetPartUri);
 
-			return sourcePartUri;
+			Uri uri = new Uri ("http://fake.com");
+			Uri a = new Uri (uri, sourcePartUri.AbsolutePath);
+			Uri b = new Uri (uri, targetPartUri.AbsolutePath);
+
+			return a.MakeRelativeUri(b);
 		}
 
 		public static Uri GetSourcePartUriFromRelationshipPartUri (Uri relationshipPartUri)

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackUriHelperTests.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackUriHelperTests.cs
@@ -230,6 +230,21 @@ namespace System.IO.Packaging.Tests {
 
             dest = new Uri ("/1/2/", UriKind.Relative);
             Assert.AreEqual (new Uri ("", UriKind.Relative), PackUriHelper.GetRelativeUri (src, src), "#4");
+
+            // See: http://msdn.microsoft.com/en-us/library/system.io.packaging.packurihelper.getrelativeuri.aspx
+
+            src = new Uri("/mydoc/markup/page.xml", UriKind.Relative);
+            dest = new Uri("/mydoc/markup/picture.jpg", UriKind.Relative);
+            Assert.AreEqual (new Uri ("picture.jpg", UriKind.Relative), PackUriHelper.GetRelativeUri (src, dest), "#5");
+
+            src = new Uri("/mydoc/markup/page.xml", UriKind.Relative);
+            dest = new Uri("/mydoc/picture.jpg", UriKind.Relative);
+            Assert.AreEqual (new Uri ("../picture.jpg", UriKind.Relative), PackUriHelper.GetRelativeUri (src, dest), "#6");
+
+            src = new Uri("/mydoc/markup/page.xml", UriKind.Relative);
+            dest = new Uri("/mydoc/images/picture.jpg", UriKind.Relative);
+            Assert.AreEqual (new Uri ("../images/picture.jpg", UriKind.Relative), PackUriHelper.GetRelativeUri (src, dest), "#7");
+
         }
 
         [Test]


### PR DESCRIPTION
Fix for: https://bugzilla.xamarin.com/show_bug.cgi?id=2527
