### PR TITLE
DataGridView: Auto resizing of the width of row headers fails when no rows are displayed

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -2240,10 +2240,20 @@ namespace System.Windows.Forms {
 			int new_width = 0;
 			
 			if (rowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.AutoSizeToDisplayedHeaders) {
-				foreach (DataGridViewRow row in Rows)
-					if (row.Displayed)
+				bool anyRowsDisplayed = false;
+				foreach(DataGridViewRow row in Rows)
+					if(row.Displayed) {
+						anyRowsDisplayed = true;
 						new_width = Math.Max (new_width, row.HeaderCell.PreferredSize.Width);
-						
+					}
+	
+			        // if there are no rows which are displayed, we still have to set new_width
+				// to a value >= 4 as RowHeadersWidth will throw an exception otherwise	
+				if(!anyRowsDisplayed) {
+					foreach (DataGridViewRow row in Rows)
+							new_width = Math.Max (new_width, row.HeaderCell.PreferredSize.Width);
+			        }		
+				
 				if (RowHeadersWidth != new_width)
 					RowHeadersWidth = new_width;
 					


### PR DESCRIPTION
The `DataGridView` has a method `AutoResizeRowHeadersWidth` that resizes the header cells of the rows based on their preferred size. If the sizing mode is `DataGridViewRowHeadersWidthSizeMode.AutoSizeToDisplayedHeaders`, only the row header cells that are displayed are taken into account for calculating the `new_width`. This can lead to a problem if no rows are displayed as `new_width` is then 0 and setting the `RowsHeadersWidth` property with a value less than 4 results in an exception.
