### PR TITLE
DataGridView: Fixed an ArgumentOutOfRangeException when adding rows to a DataGridView

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -6342,7 +6342,7 @@ namespace System.Windows.Forms {
 				
 					horizontalScrollBar.SafeValueSet (horizontalScrollBar.Value - delta_x);
 					OnHScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, horizontalScrollBar.Value));
-				} else if (disp_x > first_col_index + displayedColumnsCount - 1) {
+				} else if (disp_x > first_col_index + displayedColumnsCount - 1 && disp_x != 0) {
 					RefreshScrollBars ();
 					scrollbarsRefreshed = true;
 					
@@ -6376,7 +6376,7 @@ namespace System.Windows.Forms {
 
 					verticalScrollBar.SafeValueSet (verticalScrollBar.Value - delta_y);
 					OnVScrollBarScroll (this, new ScrollEventArgs (ScrollEventType.ThumbPosition, verticalScrollBar.Value));
-				} else if (disp_y > first_row_index + displayedRowsCount - 1) {
+				} else if (disp_y > first_row_index + displayedRowsCount - 1 && disp_y != 0) {
 					if (!scrollbarsRefreshed)
 						RefreshScrollBars ();
 


### PR DESCRIPTION
In the `MoveCurrentCell` method, `disp_x` and `disp_y` are not allowed to be 0 if `disp_x > first_col_index + displayedColumnsCount - 1` and `first_col_index + displayedColumnsCount - 1` evaluates to -1 as this would mean that the subsequent `for` loop would start at -1 and accessing the `Columns` with this value results in an `ArgumentOutOfRangeException`. 
