### PR TITLE
Disable -Werror=format-security on GCC as the input is already validated...

### DIFF
--- a/support/syslog.c
+++ b/support/syslog.c
@@ -34,7 +34,16 @@ Mono_Posix_Syscall_closelog (void)
 int
 Mono_Posix_Syscall_syslog (int priority, const char* message)
 {
+#ifdef __GNUC__
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
+
 	syslog (priority, message);
+
+#ifdef __GNUC__
+	#pragma GCC diagnostic pop
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
... by the caller

Jonathan Pryor (jonpryor) commented on f49164b:

The message parameter is validated in managed code:
https://github.com/mono/mono/blob/master/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs#L3200
https://github.com/mono/mono/blob/master/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs#L366

This change means that '%m' isn't useful in format strings to Syscall.syslog(),
as it'll be escaped instead of "passed through" unchanged.
