### PR TITLE
[System.Configuration] IntegerValidator's maxValue was 0 even if not used

### DIFF
--- a/mcs/class/System.Configuration/System.Configuration/IntegerValidator.cs
+++ b/mcs/class/System.Configuration/System.Configuration/IntegerValidator.cs
@@ -3,6 +3,7 @@
 //
 // Authors:
 //	Chris Toshok (toshok@ximian.com)
+//	Andres G. Aragoneses ( andres@7digital.com )
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -35,13 +36,15 @@ namespace System.Configuration {
 	{
 		bool rangeIsExclusive;
 		int minValue;
-		int maxValue;
+		int maxValue = int.MaxValue;
 		int resolution;
 
 		public IntegerValidator (int minValue, int maxValue, bool rangeIsExclusive, int resolution)
 		{
-			this.minValue = minValue;
-			this.maxValue = maxValue;
+			if (minValue != default (int))
+				this.minValue = minValue;
+			if (maxValue != default (int))
+				this.maxValue = maxValue;
 			this.rangeIsExclusive = rangeIsExclusive;
 			this.resolution = resolution;
 		}


### PR DESCRIPTION
When using IntegerValidator, if only MinValue is used, max value should
not be set by default to 0. Fix and unit tests included.

This fixes BNC#654721 (https://bugzilla.novell.com/show_bug.cgi?id=654721)
and therefore allows Enyim.Memcached to be used with Mono.
