### PR TITLE
[corlib] Remove the DebuggerDisplay attribute from KeyValuePair

### DIFF
--- a/mcs/class/corlib/System.Collections.Generic/KeyValuePair.cs
+++ b/mcs/class/corlib/System.Collections.Generic/KeyValuePair.cs
@@ -35,7 +35,6 @@ using System.Diagnostics;
 
 namespace System.Collections.Generic {
 	[Serializable]
-	[DebuggerDisplay ("{value}", Name="[{key}]")]	
 	public struct KeyValuePair<TKey,TValue> {
 		private TKey key;
 		private TValue value;

--- a/mcs/class/corlib/System.Collections/DictionaryEntry.cs
+++ b/mcs/class/corlib/System.Collections/DictionaryEntry.cs
@@ -37,7 +37,6 @@ using System.Runtime.InteropServices;
 namespace System.Collections {
 
 	[ComVisible(true)]
-	[System.Diagnostics.DebuggerDisplay ("{_value}", Name="[{_key}]")]
 	[Serializable]
 	public struct DictionaryEntry {
 		private object _key;


### PR DESCRIPTION
This attribute gives us a horrible debugging experience when the
'Value' of the KeyValuePair is null. By using this attribute, the
user is told that the KeyValuePair itself is null when they inspect
something like 'new KeyValuePair<string, string> (null, null)'.
This is very confusing.

We should just let the ToString method be invoked, which returns a
nicely formatted string. This is also the behaviour observed when
debugging using Visual Studio.
