### PR TITLE
Fixed clearing of the ImageList

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ImageList.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ImageList.cs
@@ -705,7 +705,7 @@ namespace System.Windows.Forms
 			public void Clear()
 			{
 				list.Clear();
-				if (this.handleCreated)
+				if (!this.handleCreated)
 					this.count = 0;
 				keys.Clear();
 			}


### PR DESCRIPTION
`CreateHandle` in the `ImageList` class resets the `count` variable to 0. Therefore if not handle has been created, the counter has to be reset when `Clear` is called. Otherwise, when adding again images, an `ArgumentOutOfRangeException` is thrown in the `GetImage` method when accessing `list`. 
