### PR TITLE
Fix HttpContextWrapper.Session when Session State is disabled

### DIFF
--- a/mcs/class/System.Web.Abstractions/System.Web/HttpContextWrapper.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpContextWrapper.cs
@@ -127,7 +127,7 @@ namespace System.Web
 		}
 
 		public override HttpSessionStateBase Session {
-			get { return new HttpSessionStateWrapper (w.Session); }
+			get { return w.Session == null ? null : new HttpSessionStateWrapper (w.Session); }
 		}
 
 		public override bool SkipAuthorization {


### PR DESCRIPTION
When `<sessionState mode="Off" />` is present in Web.config, `HttpContextWrapper.Session` throws an ArgumentNullException.

I fixed it to return null instead.
