### PR TITLE
tolerate /nowarn:"1234, 5678" arguments - improve csc compatibility

### DIFF
--- a/mcs/mcs/settings.cs
+++ b/mcs/mcs/settings.cs
@@ -572,13 +572,13 @@ namespace Mono.CSharp {
 				int id;
 				if(!String.IsNullOrEmpty(wid))
 				{
-				    if (!int.TryParse (wid, NumberStyles.AllowLeadingWhite, CultureInfo.InvariantCulture, out id)) {
-					   report.Error (1904, "`{0}' is not a valid warning number", wid);
-					    valid = false;
-					    continue;
-				    }
+					if (!int.TryParse (wid, NumberStyles.AllowLeadingWhite, CultureInfo.InvariantCulture, out id)) {
+						report.Error (1904, "`{0}' is not a valid warning number", wid);
+						valid = false;
+						continue;
+					}
 
-				    if (report.CheckWarningCode (id, Location.Null))
+					if (report.CheckWarningCode (id, Location.Null))
 						action (id);
 				}
 			}


### PR DESCRIPTION
We have many .csproj files that have:
 <NoWarn>1234, 5678</NoWarn> tags (comma plus space) 

These are converted into:
 /nowarn:"1234, 5678" 

arguments by xbuild, which isn't accepted by mcs, but are accepted by csc.  Change mcs to match.
