### PR TITLE
[Linq] Return a clearer exception message for Enumerable<T>.First()'s IOE

### DIFF
--- a/mcs/class/System.Core/System.Linq/Enumerable.cs
+++ b/mcs/class/System.Core/System.Linq/Enumerable.cs
@@ -813,7 +813,7 @@ namespace System.Linq
 					return element;
 
 			if (fallback == Fallback.Throw)
-				throw new InvalidOperationException ();
+				throw new InvalidOperationException (Locale.GetText ("Sequence contains no matching element"));
 
 			return default (TSource);
 		}


### PR DESCRIPTION
This method was using the empty constructor (no message) of
InvalidOperationException if no element matched the predicate.
This meant that the message bubbled up would be a bit confusing:
"Operation is not valid due to the current state of the object".

This commit makes Mono match MS.NET by throwing "Sequence contains
no matching element"
