### PR TITLE
Fixed Evaluator' GetUsing method by implementing ToString overrides.

### DIFF
--- a/mcs/mcs/namespace.cs
+++ b/mcs/mcs/namespace.cs
@@ -648,6 +648,11 @@ namespace Mono.CSharp {
 					"Identifier `{0}' differing only in case is not CLS-compliant", compiled.GetSignatureForError ());
 			}
 		}
+
+		public override string ToString ()
+		{
+			return Name;
+		}
 	}
 
 	public class CompilationSourceFile : NamespaceContainer
@@ -1384,6 +1389,11 @@ namespace Mono.CSharp {
 						GetSignatureForError ());
 				}
 			}
+		}
+
+		public override string ToString()
+		{
+			return resolved.ToString();
 		}
 	}
 


### PR DESCRIPTION
Implemented ToString for UsingNamespace and Namespace classes.

The GetUsing Evaluator method was attempting to build string by calling ToString, which was returning default values.
