### PR TITLE
Making the behavior of substring versions of string.CompareOrdinal and s...

### DIFF
--- a/mcs/class/corlib/System/String.cs
+++ b/mcs/class/corlib/System/String.cs
@@ -769,16 +769,30 @@ namespace System
 
 		public static int CompareOrdinal (String strA, int indexA, String strB, int indexB, int length)
 		{
-			if ((indexA > strA.Length) || (indexB > strB.Length) || (indexA < 0) || (indexB < 0) || (length < 0))
-				throw new ArgumentOutOfRangeException ();
+			if (strA != null && strB != null)
+			{
+				if (indexA > strA.Length || indexA < 0)
+					throw new ArgumentOutOfRangeException ("indexA");
+				if (indexB > strB.Length || indexB < 0)
+					throw new ArgumentOutOfRangeException ("indexB");
+				if (length < 0)
+					throw new ArgumentOutOfRangeException ("length");
+			}
 
 			return CompareOrdinalUnchecked (strA, indexA, length, strB, indexB, length);
 		}
 
 		internal static int CompareOrdinalCaseInsensitive (String strA, int indexA, String strB, int indexB, int length)
 		{
-			if ((indexA > strA.Length) || (indexB > strB.Length) || (indexA < 0) || (indexB < 0) || (length < 0))
-				throw new ArgumentOutOfRangeException ();
+			if (strA != null && strB != null)
+			{
+				if (indexA > strA.Length || indexA < 0)
+					throw new ArgumentOutOfRangeException ("indexA");
+				if (indexB > strB.Length || indexB < 0)
+					throw new ArgumentOutOfRangeException ("indexB");
+				if (length < 0)
+					throw new ArgumentOutOfRangeException ("length");
+			}
 
 			return CompareOrdinalCaseInsensitiveUnchecked (strA, indexA, length, strB, indexB, length);
 		}
@@ -815,11 +829,9 @@ namespace System
 		{
 			// Same as above, but checks versus uppercase characters
 			if (strA == null) {
-				if (strB == null)
-					return 0;
-				else
-					return -1;
-			} else if (strB == null) {
+				return strB == null ? 0 : -1;
+			}
+			if (strB == null) {
 				return 1;
 			}
 			int lengthA = Math.Min (lenA, strA.Length - indexA);

--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -659,6 +659,23 @@ public class StringTest
 	}
 
 	[Test]
+	public void CompareOrdinalSubstringWithNull ()
+	{
+		string lesser = "abc";
+		string greater = "xyz";
+
+		Assert.AreEqual (0, string.CompareOrdinal (null, 0, null, 0, 0), "substring both null");
+		Assert.AreEqual (-1, string.CompareOrdinal (null, 0, greater, 0, 0), "substring strA null");
+		Assert.AreEqual (-1, string.CompareOrdinal (null, 4, greater, 0, 0), "substring strA null; indexA greater than strA.Length");
+		Assert.AreEqual (-1, string.CompareOrdinal (null, 0, greater, 4, 0), "substring strA null; indexB greater than strB.Length");
+		Assert.AreEqual (-1, string.CompareOrdinal (null, -1, greater, -1, -1), "substring strA null; indexA, indexB, length negative");
+		Assert.AreEqual (1, string.CompareOrdinal (lesser, 0, null, 0, 0), "substring strB null");
+		Assert.AreEqual (1, string.CompareOrdinal (lesser, 4, null, 0, 0), "substring strB null; indexA greater than strA.Length");
+		Assert.AreEqual (1, string.CompareOrdinal (lesser, 0, null, 4, 0), "substring strB null; indexB greater than strB.Length");
+		Assert.AreEqual (1, string.CompareOrdinal (lesser, -1, null, -1, -1), "substring strB null; indexA, indexB, length negative");
+	}
+
+	[Test]
 	public void CompareTo ()
 	{
 		string lower = "abc";


### PR DESCRIPTION
...tring.CompareOrdinalCaseInsensitive match Microsoft's implementation.

The MSDN documentation states "Because CompareOrdinal is a static method, strA and strB can be null. If both values are null, the method returns 0 (zero), which indicates that strA and strB are equal. If only one of the values is null, the method considers the non-null value to be greater." Previously, CompareOrdinal and CompareOrdinalCaseInsensitive would throw a NullReferenceException if strA or strB was null.
