### PR TITLE
[xbuild] handle <NoWarn> tags of the form <NoWarn>1234, 5678</NoWarn>

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Csc.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Csc.cs
@@ -70,7 +70,12 @@ namespace Microsoft.Build.Tasks {
 							String.Join (";", defines));
 			}
 
-			commandLine.AppendSwitchIfNotNull ("/nowarn:", DisabledWarnings);
+			if (!String.IsNullOrEmpty (DisabledWarnings)) {
+				string [] defines = DisabledWarnings.Split (new char [] {';', ' ', ','},
+						StringSplitOptions.RemoveEmptyEntries);
+				if (defines.Length > 0)
+				    commandLine.AppendSwitchIfNotNull ("/nowarn:", defines, ";");
+			}
 
 			commandLine.AppendSwitchIfNotNull ("/doc:", DocumentationFile);
 

--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/CscTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/CscTest.cs
@@ -190,6 +190,18 @@ namespace MonoTests.Microsoft.Build.Tasks {
 		}
 
 		[Test]
+		public void TestDisabledWarningsComma ()
+		{
+			CscExtended csc = new CscExtended ();
+			CommandLineBuilderExtension clbe = new CommandLineBuilderExtension ();
+
+			csc.DisabledWarnings = "A, B";
+			csc.ARFC (clbe);
+
+			Assert.AreEqual ("/nowarn:A;B", clbe.ToString (), "A1");
+		}
+
+		[Test]
 		public void TestDocumentationFile ()
 		{
 			CscExtended csc = new CscExtended ();


### PR DESCRIPTION
Improves compatibility with msbuild.  This format is legal in csproj files in .NET.
