### PR TITLE
Fixes xamarin-bug #8646: Inconsistencies with MS.NET on Sys.Web.Routing logic

### DIFF
--- a/mcs/class/System.Web.Routing/System.Web.Routing/HttpMethodConstraint.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/HttpMethodConstraint.cs
@@ -68,24 +68,23 @@ namespace System.Web.Routing
 			if (values == null)
 				throw new ArgumentNullException ("values");
 
-			switch (routeDirection)
-			{
-				case RouteDirection.IncomingRequest:
-					// LAMESPEC: .NET allows case-insensitive comparison, which violates RFC 2616
-					return AllowedMethods.Contains(httpContext.Request.HttpMethod);
+			switch (routeDirection) {
+			case RouteDirection.IncomingRequest:
+				// LAMESPEC: .NET allows case-insensitive comparison, which violates RFC 2616
+				return AllowedMethods.Contains (httpContext.Request.HttpMethod);
 
-				case RouteDirection.UrlGeneration:
-					// See: aspnetwebstack's WebAPI equivalent for details.
-					object method;
+			case RouteDirection.UrlGeneration:
+				// See: aspnetwebstack's WebAPI equivalent for details.
+				object method;
 
-					if (!values.TryGetValue(parameterName, out method))
-						return true;
+				if (!values.TryGetValue (parameterName, out method))
+					return true;
 
-					// LAMESPEC: .NET allows case-insensitive comparison, which violates RFC 2616
-					return AllowedMethods.Contains(Convert.ToString(method));
+				// LAMESPEC: .NET allows case-insensitive comparison, which violates RFC 2616
+				return AllowedMethods.Contains (Convert.ToString (method));
 
-				default:
-					throw new ArgumentException("Invalid routeDirection: " + routeDirection);
+			default:
+				throw new ArgumentException ("Invalid routeDirection: " + routeDirection);
 			}
 		}
 	}

--- a/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
@@ -445,7 +445,7 @@ namespace System.Web.Routing
 
 			// We're a match, generate the URL
 			var ret = new StringBuilder ();
-			usedValues = new RouteValueDictionary();
+			usedValues = new RouteValueDictionary ();
 			bool canTrim = true;
 			
 			// Going in reverse order, so that we can trim without much ado
@@ -469,7 +469,7 @@ namespace System.Web.Routing
 #if SYSTEMCORE_DEP
 				if (userValues.GetValue (parameterName, out tokenValue)) {
 					if (tokenValue != null)
-						usedValues.Add(parameterName, tokenValue.ToString());
+						usedValues.Add (parameterName, tokenValue.ToString ());
 
 					if (!defaultValues.Has (parameterName, tokenValue)) {
 						canTrim = false;
@@ -479,7 +479,7 @@ namespace System.Web.Routing
 					}
 
 					if (!canTrim && tokenValue != null)
-						ret.Insert(0, tokenValue.ToString());
+						ret.Insert (0, tokenValue.ToString ());
 
 					continue;
 				}
@@ -492,7 +492,7 @@ namespace System.Web.Routing
 					if (!canTrim && tokenValue != null)
 						ret.Insert (0, tokenValue.ToString ());
 
-					usedValues.Add (parameterName, tokenValue.ToString());
+					usedValues.Add (parameterName, tokenValue.ToString ());
 					continue;
 				}
 
@@ -500,8 +500,8 @@ namespace System.Web.Routing
 				if (ambientValues.GetValue (parameterName, out tokenValue)) {
 					if (tokenValue != null)
 					{
-						ret.Insert (0, tokenValue.ToString());
-						usedValues.Add (parameterName, tokenValue.ToString());
+						ret.Insert (0, tokenValue.ToString ());
+						usedValues.Add (parameterName, tokenValue.ToString ());
 					}
 					continue;
 				}
@@ -541,7 +541,7 @@ namespace System.Web.Routing
 					if (parameterValue != null)
 						ret.Append (Uri.EscapeDataString (de.Value.ToString ()));
 
-					usedValues.Add (parameterName, de.Value.ToString());
+					usedValues.Add (parameterName, de.Value.ToString ());
 				}
 			}
 			

--- a/mcs/class/System.Web.Routing/System.Web.Routing/Route.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/Route.cs
@@ -102,7 +102,7 @@ namespace System.Web.Routing
 			if (values == null)
 				return null;
 
-			if (!ProcessConstraints(httpContext, values, RouteDirection.IncomingRequest))
+			if (!ProcessConstraints (httpContext, values, RouteDirection.IncomingRequest))
 				return null;
 			
 			var rd = new RouteData (this, RouteHandler);
@@ -138,7 +138,7 @@ namespace System.Web.Routing
 			if (resultUrl == null)
 				return null;
 
-			if (!ProcessConstraints(requestContext.HttpContext, usedValues, RouteDirection.UrlGeneration))
+			if (!ProcessConstraints (requestContext.HttpContext, usedValues, RouteDirection.UrlGeneration))
 				return null;
 
 			var result = new VirtualPathData (this, resultUrl);
@@ -249,8 +249,7 @@ namespace System.Web.Routing
 		{
 			var constraints = Constraints;
 
-			if (Constraints != null)
-			{
+			if (Constraints != null) {
 				foreach (var p in constraints)
 					if (!ProcessConstraint (httpContext, p.Value, p.Key, values, routeDirection))
 						return false;

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/HttpMethodConstraintTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/HttpMethodConstraintTest.cs
@@ -125,14 +125,14 @@ namespace MonoTests.System.Web.Routing
 		[Test]
 		public void UrlGeneration ()
 		{
-			var c = new HttpMethodConstraint(new string[] { "GET" }) as IRouteConstraint;
-			var req = new HttpContextStub("", "", "HEAD");
+			var c = new HttpMethodConstraint (new string[] { "GET" }) as IRouteConstraint;
+			var req = new HttpContextStub ("", "", "HEAD");
 
-			var values = new RouteValueDictionary() { { "httpMethod", "GET" } };
-			Assert.IsTrue(c.Match(req, new Route(null, null), "httpMethod", values, RouteDirection.UrlGeneration), "#1");
+			var values = new RouteValueDictionary () { { "httpMethod", "GET" } };
+			Assert.IsTrue (c.Match (req, new Route (null, null), "httpMethod", values, RouteDirection.UrlGeneration), "#1");
 
 			values = new RouteValueDictionary() { { "httpMethod", "POST" } };
-			Assert.IsFalse(c.Match(req, new Route(null, null), "httpMethod", values, RouteDirection.UrlGeneration), "#2");
+			Assert.IsFalse (c.Match (req, new Route (null, null), "httpMethod", values, RouteDirection.UrlGeneration), "#2");
 		}
 	}
 }

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteCollectionTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteCollectionTest.cs
@@ -538,67 +538,60 @@ namespace MonoTests.System.Web.Routing
 		}
 
 		[Test]
-		public void GetVirtualPath8()
+		public void GetVirtualPath8 ()
 		{
 			var routes = new RouteCollection();
 
-			routes.Add(new MyRoute("login", new MyRouteHandler())
-			{
-				Defaults = new RouteValueDictionary(new { controller = "Home", action = "LogOn" }),
-				//new { Url = new UrlMatchConstraint("~/login", true) }
+			routes.Add (new MyRoute ("login", new MyRouteHandler ()) {
+				Defaults = new RouteValueDictionary (new { controller = "Home", action = "LogOn" })
 			});
 
-			routes.Add(new MyRoute("{site}/{controller}/{action}", new MyRouteHandler())
-			{
-				Defaults = new RouteValueDictionary(new { site = "_", controller = "Home", action = "Index" }),
-				Constraints = new RouteValueDictionary( new { site = "_?[0-9A-Za-z-]*" })
+			routes.Add (new MyRoute ("{site}/{controller}/{action}", new MyRouteHandler ())	{
+				Defaults = new RouteValueDictionary (new { site = "_", controller = "Home", action = "Index" }),
+				Constraints = new RouteValueDictionary ( new { site = "_?[0-9A-Za-z-]*" })
 			});
 
-			routes.Add(new MyRoute("{*path}", new MyRouteHandler())
-			{
-				Defaults = new RouteValueDictionary(new { controller = "Error", action = "NotFound" }),
+			routes.Add (new MyRoute ("{*path}", new MyRouteHandler ()) {
+				Defaults = new RouteValueDictionary (new { controller = "Error", action = "NotFound" }),
 			});
 
-			var hc = new HttpContextStub2("~/login", String.Empty, String.Empty);
-			hc.SetResponse(new HttpResponseStub(3));
-			var rd = routes.GetRouteData(hc);
-			var rvs = new RouteValueDictionary()
-			{
+			var hc = new HttpContextStub2 ("~/login", String.Empty, String.Empty);
+			hc.SetResponse (new HttpResponseStub (3));
+			var rd = routes.GetRouteData (hc);
+			var rvs = new RouteValueDictionary () {
 				{ "controller", "Home" },
 				{ "action" , "Index" }
 			};
-			var vpd = routes.GetVirtualPath(new RequestContext(hc, rd), rvs);
-			Assert.IsNotNull(vpd, "#A1");
-			Assert.AreEqual("/", vpd.VirtualPath, "#A2");
-			Assert.AreEqual(0, vpd.DataTokens.Count, "#A3");
+			var vpd = routes.GetVirtualPath (new RequestContext (hc, rd), rvs);
+			Assert.IsNotNull (vpd, "#A1");
+			Assert.AreEqual ("/", vpd.VirtualPath, "#A2");
+			Assert.AreEqual (0, vpd.DataTokens.Count, "#A3");
 
-			hc = new HttpContextStub2("~/login", String.Empty, String.Empty);
-			hc.SetResponse(new HttpResponseStub(3));
-			rd = routes.GetRouteData(hc);
-			rvs = new RouteValueDictionary()
-			{
+			hc = new HttpContextStub2 ("~/login", String.Empty, String.Empty);
+			hc.SetResponse (new HttpResponseStub (3));
+			rd = routes.GetRouteData (hc);
+			rvs = new RouteValueDictionary () {
 				{ "controller", "Home" }
 			};
-			vpd = routes.GetVirtualPath(new RequestContext(hc, rd), rvs);
-			Assert.IsNotNull(vpd, "#B1");
-			Assert.AreEqual("/login", vpd.VirtualPath, "#B2");
-			Assert.AreEqual(0, vpd.DataTokens.Count, "#B3");
+			vpd = routes.GetVirtualPath (new RequestContext (hc, rd), rvs);
+			Assert.IsNotNull (vpd, "#B1");
+			Assert.AreEqual ("/login", vpd.VirtualPath, "#B2");
+			Assert.AreEqual (0, vpd.DataTokens.Count, "#B3");
 
-			hc = new HttpContextStub2("~/login", String.Empty, String.Empty);
-			hc.SetResponse(new HttpResponseStub(3));
-			rd = routes.GetRouteData(hc);
-			rvs = new RouteValueDictionary()
-			{
+			hc = new HttpContextStub2 ("~/login", String.Empty, String.Empty);
+			hc.SetResponse (new HttpResponseStub (3));
+			rd = routes.GetRouteData (hc);
+			rvs = new RouteValueDictionary () {
 				{ "action" , "Index" }
 			};
-			vpd = routes.GetVirtualPath(new RequestContext(hc, rd), rvs);
-			Assert.IsNotNull(vpd, "#C1");
-			Assert.AreEqual("/", vpd.VirtualPath, "#C2");
-			Assert.AreEqual(0, vpd.DataTokens.Count, "#C3");
+			vpd = routes.GetVirtualPath (new RequestContext (hc, rd), rvs);
+			Assert.IsNotNull (vpd, "#C1");
+			Assert.AreEqual ("/", vpd.VirtualPath, "#C2");
+			Assert.AreEqual (0, vpd.DataTokens.Count, "#C3");
 
-			hc = new HttpContextStub2("~/", String.Empty, String.Empty);
-			rd = routes.GetRouteData(hc);
-			Assert.IsNotNull(rd, "#D1");
+			hc = new HttpContextStub2 ("~/", String.Empty, String.Empty);
+			rd = routes.GetRouteData (hc);
+			Assert.IsNotNull (rd, "#D1");
 		}
 
 		[Test]

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
@@ -981,62 +981,58 @@ namespace MonoTests.System.Web.Routing
 		}
 
 		[Test]
-		public void GetRouteDataWithCatchAll()
+		public void GetRouteDataWithCatchAll ()
 		{
-			var r = new Route("{*path}", new StopRoutingHandler())
-			{
-				Defaults = new RouteValueDictionary(new
-				{
+			var r = new Route ("{*path}", new StopRoutingHandler ()) {
+				Defaults = new RouteValueDictionary (new {
 					controller = "Error",
 					action = "NotFound"
 				})
 			};
 
-			var hc = new HttpContextStub("~/", String.Empty);
-			var rd = r.GetRouteData(hc);
+			var hc = new HttpContextStub ("~/", String.Empty);
+			var rd = r.GetRouteData (hc);
 
-			Assert.IsNotNull(rd, "#1");
+			Assert.IsNotNull (rd, "#1");
 
-			hc = new HttpContextStub("~/Foo/x123", String.Empty);
-			rd = r.GetRouteData(hc);
+			hc = new HttpContextStub ("~/Foo/x123", String.Empty);
+			rd = r.GetRouteData (hc);
 
-			Assert.IsNotNull(rd, "#2");
+			Assert.IsNotNull (rd, "#2");
 		}
 
 		[Test]
-		public void GetRouteDataWithCatchAll2()
+		public void GetRouteDataWithCatchAll2 ()
 		{
-			var r = new Route("something/{*path}", new StopRoutingHandler())
-			{
-				Defaults = new RouteValueDictionary(new
-				{
+			var r = new Route ("something/{*path}", new StopRoutingHandler ()) {
+				Defaults = new RouteValueDictionary (new {
 					controller = "Error",
 					action = "NotFound"
 				})
 			};
 
-			var hc = new HttpContextStub("~/", String.Empty);
-			var rd = r.GetRouteData(hc);
+			var hc = new HttpContextStub ("~/", String.Empty);
+			var rd = r.GetRouteData (hc);
 
-			Assert.IsNull(rd, "#1");
+			Assert.IsNull (rd, "#1");
 
-			hc = new HttpContextStub("~/something", String.Empty);
-			rd = r.GetRouteData(hc);
+			hc = new HttpContextStub ("~/something", String.Empty);
+			rd = r.GetRouteData (hc);
 
-			Assert.IsNotNull(rd, "#2");
-			Assert.IsNull(rd.Values["path"], "#2.1");
+			Assert.IsNotNull (rd, "#2");
+			Assert.IsNull (rd.Values["path"], "#2.1");
 
-			hc = new HttpContextStub("~/something/", String.Empty);
-			rd = r.GetRouteData(hc);
+			hc = new HttpContextStub ("~/something/", String.Empty);
+			rd = r.GetRouteData (hc);
 
-			Assert.IsNotNull(rd, "#3");
-			Assert.IsNull(rd.Values["path"], "#3.1");
+			Assert.IsNotNull (rd, "#3");
+			Assert.IsNull (rd.Values["path"], "#3.1");
 
-			hc = new HttpContextStub("~/something/algo", String.Empty);
-			rd = r.GetRouteData(hc);
+			hc = new HttpContextStub ("~/something/algo", String.Empty);
+			rd = r.GetRouteData (hc);
 
-			Assert.IsNotNull(rd, "#4");
-			Assert.AreEqual("algo", rd.Values["path"], "#4.1");
+			Assert.IsNotNull (rd, "#4");
+			Assert.AreEqual ("algo", rd.Values["path"], "#4.1");
 
 		}
 


### PR DESCRIPTION
This patch fixes some inconsistencies on Sys.Web.Routing between our implementation
and the one found on MS.NET.. Both relating to URL Generation code inside of
Route.GetVirtualPath().

1) When defining a route with a parameter with both a default value and some
constraint, Route.GetVirtualPath() fails to match if no parameter values is specified.

2) HttpMethodConstraint, does not take into account RouteDirection.UrlGeneration.

See: https://bugzilla.xamarin.com/show_bug.cgi?id=8646
License: This patch is under MIT/X11 license.
