### PR TITLE
Change the submodules to use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "external/aspnetwebstack"]
 	path = external/aspnetwebstack
-	url = git://github.com/mono/aspnetwebstack.git
+	url = https://github.com/mono/aspnetwebstack.git
 [submodule "external/Newtonsoft.Json"]
 	path = external/Newtonsoft.Json
-	url = git://github.com/mono/Newtonsoft.Json.git
+	url = https://github.com/mono/Newtonsoft.Json.git
 [submodule "external/cecil"]
 	path = external/cecil
-	url = git://github.com/mono/cecil.git
+	url = https://github.com/mono/cecil.git
 [submodule "external/debian-snapshot"]
 	path = external/debian-snapshot
-	url = git://github.com/directhex/mono-snapshot.git
+	url = https://github.com/directhex/mono-snapshot.git
 [submodule "external/entityframework"]
 	path = external/entityframework
-	url = git://github.com/mono/entityframework.git
+	url = https://github.com/mono/entityframework.git
 [submodule "external/rx"]
 	path = external/rx
-	url = git://github.com/mono/rx.git
+	url = https://github.com/mono/rx.git
 [submodule "external/ikvm"]
 	path = external/ikvm
-	url = git://github.com/mono/ikvm-fork.git
+	url = https://github.com/mono/ikvm-fork.git
 [submodule "external/Lucene.Net"]
 	path = external/Lucene.Net
-	url = git://github.com/apache/lucene.net.git
+	url = https://github.com/apache/lucene.net.git


### PR DESCRIPTION
The only reason to do this is to allow setup and compilation from behind a strict firewall
