### PR TITLE
add LogicalCallContext to ExecutionContext

### DIFF
--- a/mcs/class/corlib/System.Threading/ExecutionContext.cs
+++ b/mcs/class/corlib/System.Threading/ExecutionContext.cs
@@ -170,16 +170,12 @@ namespace System.Threading {
 
 			// FIXME: supporting more than one context should be done with executionContextSwitcher
 			// and will requires a rewrite of this method
-			var callContextCallBack = new ContextCallback (new Action<object> ((ostate) =>
-			{
+			var callContextCallBack = new ContextCallback (new Action<object> ((ostate) => {
 				var originalCallContext = CallContext.CreateLogicalCallContext (true);
-				try
-				{
+				try {
 					CallContext.SetCurrentCallContext (executionContext.LogicalCallContext);
 					callback (ostate);
-				}
-				finally
-				{
+				} finally {
 					CallContext.SetCurrentCallContext (originalCallContext);
 				}
 			}));

--- a/mcs/class/corlib/Test/System.Threading/ExecutionContextTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ExecutionContextTest.cs
@@ -47,11 +47,10 @@ namespace MonoTests.System.Threading {
 			success = (bool)o;
 		}
 
-		public class CallContextValue : ILogicalThreadAffinative
-		{
+		public class CallContextValue : ILogicalThreadAffinative {
 			public object Value { get; set; }
 
-			public CallContextValue(object value)
+			public CallContextValue (object value)
 			{
 				this.Value = value;
 			}
@@ -73,22 +72,22 @@ namespace MonoTests.System.Threading {
 		[Test]
 		public void CaptureCallContext ()
 		{
-			var value = new CallContextValue(true);
+			var value = new CallContextValue (true);
 			object capturedValue = null;
 
-			CallContext.SetData("testlc", value);
+			CallContext.SetData ("testlc", value);
 
 			ExecutionContext ec = ExecutionContext.Capture ();
 			Assert.IsNotNull (ec, "Capture");
-			Assert.AreEqual(value, CallContext.GetData("testlc")); 
-			CallContext.SetData("testlc", null);
+			Assert.AreEqual (value, CallContext.GetData ("testlc")); 
+			CallContext.SetData ("testlc", null);
 
-			ExecutionContext.Run(ec, new ContextCallback(new Action<object>((data) => {
-				capturedValue = CallContext.GetData("testlc");
+			ExecutionContext.Run (ec, new ContextCallback (new Action<object> ((data) => {
+				capturedValue = CallContext.GetData ("testlc");
 			})), null);
 
-			Assert.AreEqual(value, capturedValue); 
-			Assert.AreNotEqual(value, CallContext.GetData("testlc"));
+			Assert.AreEqual (value, capturedValue); 
+			Assert.AreNotEqual (value, CallContext.GetData ("testlc"));
 		}
 
 		[Test]


### PR DESCRIPTION
Save LogicalCallContext when Capture is called

Restore LogicalCallContext on Run.

see msdn for behavior of ExecutionContext http://msdn.microsoft.com/en-us/library/h84136b2.aspx

Added necessary tests.

See bugzilla ticket : https://bugzilla.xamarin.com/show_bug.cgi?id=8838
