### PR TITLE
Fix for bug #2907 XML "choice" not correclty processed during deserialization

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlSerializationReaderInterpreter.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlSerializationReaderInterpreter.cs
@@ -329,12 +329,12 @@ namespace System.Xml.Serialization
 			object[] flatLists = null;
 			object[] flatListsChoices = null;
 			Fixup fixup = null;
-			int ind = 0;
+			int ind = -1;
 			int maxInd;
 
 			if (readBySoapOrder) {
 				if (map.ElementMembers != null) maxInd = map.ElementMembers.Count;
-				else maxInd = 0;
+				else maxInd = -1;
 			}
 			else
 				maxInd = int.MaxValue;
@@ -373,14 +373,15 @@ namespace System.Xml.Serialization
 				AddFixup (fixup);
 			}
 
-			while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && (ind < maxInd)) 
+			XmlTypeMapMember previousMember = null;
+			while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && (ind < maxInd - 1))
 			{
 				if (Reader.NodeType == System.Xml.XmlNodeType.Element) 
 				{
 					XmlTypeMapElementInfo info;
 					
 					if (readBySoapOrder) {
-						info = map.GetElement (ind++);
+						info = map.GetElement (Reader.LocalName, Reader.NamespaceURI, ind);
 					}
 					else if (hasAnyReturnMember) {
 						info = (XmlTypeMapElementInfo) ((XmlTypeMapMemberElement)map.ReturnMember).ElementInfo[0];
@@ -388,16 +389,20 @@ namespace System.Xml.Serialization
 					}
 					else {
 						if (map.IsOrderDependentMap) {
-							while ((info = map.GetElement (ind++)) != null)
-								if (info.ElementName == Reader.LocalName && info.Namespace == Reader.NamespaceURI)
-									break;
+							info = map.GetElement (Reader.LocalName, Reader.NamespaceURI, ind);
 						}
 						else
-							info = map.GetElement (Reader.LocalName, Reader.NamespaceURI, -1);
+							info = map.GetElement (Reader.LocalName, Reader.NamespaceURI);
 					}
 
 					if (info != null && !readFlag[info.Member.Index] )
 					{
+						if (info.Member != previousMember)
+						{
+							ind = info.ExplicitOrder + 1;
+							previousMember = info.Member;
+						}
+
 						if (info.Member.GetType() == typeof (XmlTypeMapMemberList))
 						{
 							if (_format == SerializationFormat.Encoded && info.MultiReferenceType)

--- a/mcs/class/System.XML/System.Xml.Serialization/XmlTypeMapping.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlTypeMapping.cs
@@ -400,10 +400,26 @@ namespace System.Xml.Serialization
 			return (XmlTypeMapMemberAttribute)_attributeMembers [BuildKey (name,ns, -1)];
 		}
 
-		public XmlTypeMapElementInfo GetElement (string name, string ns, int order)
+		public XmlTypeMapElementInfo GetElement(string name, string ns, int minimalOrder)
 		{
 			if (_elements == null) return null;
-			return (XmlTypeMapElementInfo)_elements [BuildKey (name,ns, order)];
+
+			foreach (XmlTypeMapElementInfo info in _elements.Values)
+				if (info.ElementName == name && info.Namespace == ns && info.ExplicitOrder >= minimalOrder)
+					return info;
+
+			return null;
+		}
+
+		public XmlTypeMapElementInfo GetElement(string name, string ns)
+		{
+			if (_elements == null) return null;
+
+			foreach (XmlTypeMapElementInfo info in _elements.Values)
+				if (info.ElementName == name && info.Namespace == ns)
+					return info;
+
+			return null;
 		}
 		
 		public XmlTypeMapElementInfo GetElement (int index)


### PR DESCRIPTION
Have fixed an issue with processing of xs:choice with ordered read.
Failed tests (as mentioned here https://github.com/mono/mono/pull/495) are fixed too.
