### PR TITLE
Update mcs/class/System/System.Media/AudioData.cs

### DIFF
--- a/mcs/class/System/System.Media/AudioData.cs
+++ b/mcs/class/System/System.Media/AudioData.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -101,6 +100,7 @@ namespace Mono.Audio {
 					byte_rate |= buffer [idx++] << 16;
 					byte_rate |= buffer [idx++] << 24;
 //					int block_align = buffer [idx++] | (buffer [idx++] << 8);
+					idx += 2; //because, the above line is commented out
 					int sign_bits = buffer [idx++] | (buffer [idx++] << 8);
 
 					switch (sign_bits) {


### PR DESCRIPTION
Since this line is commented out:
int block_align = buffer [idx++] | (buffer [idx++] << 8);
you will ran into a "bits per sample" exception.
Adding the two increpements (idx+=2) will solve it.
