### PR TITLE
Fix Xamarin bug #9116

### DIFF
--- a/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
@@ -437,7 +437,8 @@ namespace System.Web.Routing
 						if (defaultValue is string && parameterValue is string) {
 							if (String.Compare ((string)defaultValue, (string)parameterValue, StringComparison.Ordinal) != 0)
 								return null; // different value => no match
-						} else if (defaultValue != parameterValue)
+						// Parameter may be a boxed value type, need to use .Equals() for comparison
+						} else if (!object.Equals (parameterValue, defaultValue))
 							return null; // different value => no match
 					}
 				}

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/ChangeLog
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/ChangeLog
@@ -1,3 +1,8 @@
+2012-12-23  Daniel Lo Nigro  <daniel@dan.cx>
+
+	* RouteTest.cs: added tests for value types in route default values
+	(Xamarin bug #9116)
+
 2009-09-09  Marek Habersack  <mhabersack@novell.com>
 
 	* RouteTest.cs: added two tests for empty and null route URLs (bug

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
@@ -1351,6 +1351,106 @@ namespace MonoTests.System.Web.Routing
 		}
 #endif
 
+		[Test (Description="Xamarin Bug #9116")]
+		public void GetVirtualPath16 ()
+		{
+			var context = new HttpContextWrapper (
+				new HttpContext (new HttpRequest ("filename", "http://localhost/filename", String.Empty),
+						 new HttpResponse (new StringWriter())
+				)
+			);
+			var rc = new RequestContext (context, new RouteData ());
+
+			var route = new Route ("Hello", new MyRouteHandler ()) {
+					Defaults = new RouteValueDictionary (new {controller = "Home", action = "Hello", page = 1})
+			};
+
+			var routeValues = new RouteValueDictionary
+			{
+				{"controller", "Home"},
+				{"action", "Hello"},
+				{"page", 1}
+			};
+
+			var result = route.GetVirtualPath(rc, routeValues);
+			Assert.IsNotNull(result, "#A1");
+			Assert.AreEqual("Hello", result.VirtualPath, "#A2");
+		}
+
+		[Test (Description="Xamarin Bug #9116")]
+		public void GetVirtualPath17 () 
+		{
+			var context = new HttpContextWrapper (
+				new HttpContext (new HttpRequest ("filename", "http://localhost/filename", String.Empty),
+						 new HttpResponse (new StringWriter())
+				)
+			);
+			var rc = new RequestContext (context, new RouteData ());
+
+			RouteTable.Routes.Add("FirstPage", new Route ("Hello/FirstPage", new MyRouteHandler ()) {
+					Defaults = new RouteValueDictionary (new {controller = "Home", action = "Hello", page = 1})
+			});
+			RouteTable.Routes.Add("OtherPages", new Route ("Hello/Page-{page}", new MyRouteHandler ()) {
+					Defaults = new RouteValueDictionary (new {controller = "Home", action = "Hello"})
+			});
+
+			var firstPageRouteValues = new RouteValueDictionary
+			{
+				{"controller", "Home"},
+				{"action", "Hello"},
+				{"page", 1}
+			};
+			var secondPageRouteValues = new RouteValueDictionary
+			{
+				{"controller", "Home"},
+				{"action", "Hello"},
+				{"page", 2}
+			};
+
+			var firstPageResult = RouteTable.Routes.GetVirtualPath (rc, firstPageRouteValues);
+			var secondPageResult = RouteTable.Routes.GetVirtualPath (rc, secondPageRouteValues);
+
+			Assert.AreEqual ("/Hello/FirstPage", firstPageResult.VirtualPath, "#A1");
+			Assert.AreEqual ("/Hello/Page-2", secondPageResult.VirtualPath, "#A2");
+		}
+
+		[Test (Description="Xamarin Bug #9116")]
+		public void GetVirtualPath18 () 
+		{
+			var context = new HttpContextWrapper (
+				new HttpContext (new HttpRequest ("filename", "http://localhost/filename", String.Empty),
+						 new HttpResponse (new StringWriter())
+				)
+			);
+			var rc = new RequestContext (context, new RouteData ());
+
+			RouteTable.Routes.Add("Published", new Route ("Posts/Published", new MyRouteHandler ()) {
+					Defaults = new RouteValueDictionary (new {controller = "Home", action = "Posts", published = true})
+			});
+			RouteTable.Routes.Add("Unpublished", new Route ("Posts/Unpublished", new MyRouteHandler ()) {
+					Defaults = new RouteValueDictionary (new {controller = "Home", action = "Posts", published = false})
+			});
+
+			var publishedRouteValues = new RouteValueDictionary
+			{
+				{"controller", "Home"},
+				{"action", "Posts"},
+				{"published", true}
+			};
+			var unpublishedRouteValues = new RouteValueDictionary
+			{
+				{"controller", "Home"},
+				{"action", "Posts"},
+				{"published", false}
+			};
+
+			var publishedResult = RouteTable.Routes.GetVirtualPath (rc, publishedRouteValues);
+			var unpublishedResult = RouteTable.Routes.GetVirtualPath (rc, unpublishedRouteValues);
+
+			Assert.AreEqual ("/Posts/Published", publishedResult.VirtualPath, "#A1");
+			Assert.AreEqual ("/Posts/Unpublished", unpublishedResult.VirtualPath, "#A2");
+		}
+
 		// Bug #500739
 		[Test]
 		public void RouteGetRequiredStringWithDefaults ()


### PR DESCRIPTION
Need to use .Equals() for comparison instead of the "!=" operator, as != will do a reference comparison in the case of boxed value types.
