### PR TITLE
Fix Xamarin bug #9133 - Routes should be case insensitive

### DIFF
--- a/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
@@ -435,7 +435,7 @@ namespace System.Web.Routing
 					if (userValues != null && userValues.TryGetValue (parameterName, out parameterValue)) {
 						object defaultValue = de.Value;
 						if (defaultValue is string && parameterValue is string) {
-							if (String.Compare ((string)defaultValue, (string)parameterValue, StringComparison.Ordinal) != 0)
+							if (String.Compare ((string)defaultValue, (string)parameterValue, StringComparison.OrdinalIgnoreCase) != 0)
 								return null; // different value => no match
 						// Parameter may be a boxed value type, need to use .Equals() for comparison
 						} else if (!object.Equals (parameterValue, defaultValue))

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
@@ -1451,6 +1451,46 @@ namespace MonoTests.System.Web.Routing
 			Assert.AreEqual ("/Posts/Unpublished", unpublishedResult.VirtualPath, "#A2");
 		}
 
+		[Test (Description="Routes should be case insensitive - Xamarin bug #9133")]
+		public void GetVirtualPath19 ()
+		{
+			var context = new HttpContextWrapper (
+				new HttpContext (new HttpRequest ("filename", "http://localhost/filename", String.Empty),
+						 new HttpResponse (new StringWriter())
+				)
+			);
+			var rc = new RequestContext (context, new RouteData ());
+
+			var route = new Route ("HelloWorld", new MyRouteHandler ()) {
+					Defaults = new RouteValueDictionary (new {controller = "Home", action = "HelloWorld"})
+			};
+
+			var lowercase = route.GetVirtualPath (rc, new RouteValueDictionary
+			{
+				{"controller", "home"},
+				{"action", "helloworld"}
+			});
+			var standardCase = route.GetVirtualPath (rc, new RouteValueDictionary
+			{
+				{"controller", "Home"},
+				{"action", "HelloWorld"}
+			});
+			var uppercase = route.GetVirtualPath (rc, new RouteValueDictionary
+			{
+				{"controller", "HOME"},
+				{"action", "HELLOWORLD"}
+			});
+
+			Assert.IsNotNull(lowercase, "#A1");
+			Assert.AreEqual ("HelloWorld", lowercase.VirtualPath, "#A2");
+
+			Assert.IsNotNull(standardCase, "#A3");
+			Assert.AreEqual ("HelloWorld", standardCase.VirtualPath, "#A4");
+
+			Assert.IsNotNull(uppercase, "#A5");
+			Assert.AreEqual ("HelloWorld", uppercase.VirtualPath, "#A6");
+		}
+
 		// Bug #500739
 		[Test]
 		public void RouteGetRequiredStringWithDefaults ()


### PR DESCRIPTION
Microsoft .NET uses case-insensitive routes.

References:
- http://msdn.microsoft.com/en-us/magazine/dd347546.aspx ("One additional note—the routing engine performs the pattern matching in a case-insensitive manner")
- http://msdn.microsoft.com/en-us/library/system.web.routing.routevaluedictionary(v=vs.110).aspx ("Represents a case-insensitive collection of key/value pairs ... The RouteValueDictionary class uses case-insensitive ordinal comparison")
