### PR TITLE
cominterop: Don't rely on an inner IUnknown to reference the outer objec...

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2303,11 +2303,13 @@ cominterop_ccw_getfreethreadedmarshaler (MonoCCW* ccw, MonoObject* object, gpoin
 		/* remember to addref on QI */
 		cominterop_ccw_addref (tunk);
 		ret = CoCreateFreeThreadedMarshaler (tunk, (LPUNKNOWN*)&ccw->free_marshaler);
+		if (ccw->free_marshaler)
+			ret = ves_icall_System_Runtime_InteropServices_Marshal_QueryInterfaceInternal (ccw->free_marshaler, (IID*)&MONO_IID_IMarshal, ppv);
+		else
+			ret = MONO_E_NOINTERFACE;
 		cominterop_ccw_release(tunk);
+		return ret;
 	}
-		
-	if (!ccw->free_marshaler)
-		return MONO_E_NOINTERFACE;
 
 	return ves_icall_System_Runtime_InteropServices_Marshal_QueryInterfaceInternal (ccw->free_marshaler, (IID*)&MONO_IID_IMarshal, ppv);
 #else


### PR DESCRIPTION
Per COM aggregation rules (http://msdn.microsoft.com/en-us/library/windows/desktop/ms686558%28v=vs.85%29.aspx), the inner IUnknown interface is used by the outer object to control the lifetime of the inner object and access the interfaces it provides. Only the interfaces other than IUnknown maintain references to the outer object.

Since CoCreateFreeThreadedMarshaler only gives a reference to an IUnknown, the resulting object does not reference tunk. If tunk's reference count happens to be 0 when cominterop_ccw_getfreethreadedmarshaler begins, the release will actually free the FTMarshaler that was just created, causing a crash when we query for IMarshal. The solution is to query for IMarshal first, thus nailing down a reference to tunk.
