### PR TITLE
[System.Reflection.Emit] Store dynamic assemblies after the static ones

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -5327,7 +5327,7 @@ mono_image_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 	}
 
 	mono_domain_assemblies_lock (domain);
-	domain->domain_assemblies = g_slist_prepend (domain->domain_assemblies, assembly);
+	domain->domain_assemblies = g_slist_append (domain->domain_assemblies, assembly);
 	mono_domain_assemblies_unlock (domain);
 
 	register_assembly (mono_object_domain (assemblyb), &assemblyb->assembly, &assembly->assembly);


### PR DESCRIPTION
AssemblyBuilder class was adding generated dynamic assemblies at the
beginning of the list of the assemblies of the current domain, instead
of at the end.

This not only is not the behaviour of MS.NET but was inconsistent to
previous calls to the CurrentDomain.GetAssemblies() method, which would
return assemblies in different positions.

If code was relying on the order of these assemblies being returned (i.e.
to find the first type in the loaded assemblies that conforms to certain
requirements), it would result in unexpected behaviour if used along with
frameworks that mock/stub types on the fly, such as RhinoMocks, FakeItEasy
or other Castle.DynamicProxy-based ones.

This fixes BXC#10004:
https://bugzilla.xamarin.com/show_bug.cgi?id=10004

Patch contributed under the terms of MIT/X11 licence.
