### PR TITLE
Added missing awaits to StreamWriter

### DIFF
--- a/mcs/class/corlib/System.IO/StreamWriter.cs
+++ b/mcs/class/corlib/System.IO/StreamWriter.cs
@@ -239,7 +239,7 @@ namespace System.IO {
 		{
 			await DecodeAsync ().ConfigureAwait (false);
 			if (byte_pos > 0) {
-				FlushBytesAsync ().ConfigureAwait (false);
+				await FlushBytesAsync ().ConfigureAwait (false);
 				await internalStream.FlushAsync ().ConfigureAwait (false);
 			}
 		}
@@ -254,7 +254,7 @@ namespace System.IO {
 				preamble_done = true;
 			}
 
-			internalStream.WriteAsync (byte_buf, 0, byte_pos).ConfigureAwait (false);
+			await internalStream.WriteAsync (byte_buf, 0, byte_pos).ConfigureAwait (false);
 			byte_pos = 0;
 		}
 


### PR DESCRIPTION
The modified methods were added by @marek-safar in 185743cacd6f0f54caff73a87609bf603706e5ff, but it seems the code is missing `await`s in two places. The result would be that the returned `Task` would be completed too early.

In the case these two lines really shouldn't have `await`s, then I believe it doesn't make sense to use `ConfigureAwait()` on them and I think a comment about that should be added.

I didn't actually encounter any problem because of this, I just noticed warnings this caused in VS.
