### PR TITLE
Fixes a problem in Mono's ASP.NET Menu Control

### DIFF
--- a/mcs/class/System.Web/System.Web.UI.WebControls/Menu.js
+++ b/mcs/class/System.Web/System.Web.UI.WebControls/Menu.js
@@ -1,4 +1,3 @@
-
 function Menu_OverItem (menuId, itemId, parentId) {
 	var menu = getMenu (menuId);
 	if (menu == null)
@@ -177,8 +176,8 @@ function Menu_Resize (subm, menuId, itemId)
 	 */
 	var newWidth = box.offsetWidth;
 	
-	if (bottom > parent.clientHeight /* && parent.scrollHeight > parent.clientHeight*/) {
-		var overflow = bottom - parent.clientHeight;
+	if (bottom > window.innerHeight) {
+		var overflow = bottom - window.innerHeight;
 		var freeTop = subm.offsetTop - parent.scrollTop;
 		if (overflow <= freeTop) {
 			subm.style.top = (subm.offsetTop - overflow) + "px";
@@ -186,7 +185,7 @@ function Menu_Resize (subm, menuId, itemId)
 			box.style.height = subm.initialContentHeight + "px";
 		} else {
 			subm.style.top = (subm.offsetTop - freeTop) + "px";
-			var bh = (parent.clientHeight - subm.offsetTop + parent.scrollTop) - subm.scrollButtonsHeight;
+			var bh = (window.innerHeight - subm.offsetTop + parent.scrollTop) - subm.scrollButtonsHeight;
 			box.style.overflow = "hidden";
 			box.style.height = bh + "px";
 			displayScroll = "block";


### PR DESCRIPTION
Mono's implementation of the ASP.NET Menu Control is still different compared to the .NET implementation. One annoying thing is that submenus sometimes show scroll buttons when there is still enough space in the window. This happens because parent.clientHeight is used as a reference to detect an overflow condition. Using window.innerHeight solves this strange behaviour.
