### PR TITLE
Loop support for Mono.CSharp.Evaluator Terse Mode

### DIFF
--- a/mcs/mcs/eval.cs
+++ b/mcs/mcs/eval.cs
@@ -20,6 +20,7 @@ using System.Reflection.Emit;
 using System.IO;
 using System.Text;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Mono.CSharp
 {
@@ -226,7 +227,8 @@ namespace Mono.CSharp
 
 				bool partial_input;
 				CSharpParser parser = ParseString (ParseMode.Silent, input, out partial_input);
-				if (parser == null && Terse && partial_input){
+
+				if (parser == null && Terse && partial_input && !(Regex.IsMatch(input,@"^\s*for\s*\(") || Regex.IsMatch(input,@"^\s*while\s*\(") || Regex.IsMatch(input,@"^\s*foreach\s*\("))){
 					bool ignore;
 					parser = ParseString (ParseMode.Silent, input + ";", out ignore);
 				}


### PR DESCRIPTION
When Terse mode automatically adds a semi-colon to partial inputs it causes inputs like "for (int ii = 0; ii < 3; ii++)", or "while (ii < 3)" to execute immediately with no body in the loop, rather than waiting for further input. 

This pull request fixes that problem by detecting loop expressions using a Regex, and not attempting to complete them by adding a semi-colon.
