### PR TITLE
Fix thread stack initialization on BSD platforms.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -173,10 +173,6 @@ case "$host" in
 		libgc_threads=pthreads
 		# This doesn't seem to work as of 7.0 on amd64
 		with_sigaltstack=no
-# TLS is only partially implemented on -CURRENT (compiler support
-# but NOT library support)
-#
-		with_tls=pthread
 		use_sigposix=yes
 		;;
 	*-*-*openbsd*)
@@ -1444,6 +1440,7 @@ if test x$target_win32 = xno; then
 		;;
 	esac
 	AC_CHECK_HEADERS(pthread.h)
+	AC_CHECK_HEADERS(pthread_np.h)
 	AC_CHECK_FUNCS(pthread_mutex_timedlock)
 	AC_CHECK_FUNCS(pthread_getattr_np pthread_attr_get_np)
 	AC_CHECK_FUNCS(pthread_kill)

--- a/mono/metadata/sgen-gc.c
+++ b/mono/metadata/sgen-gc.c
@@ -179,6 +179,9 @@
 #ifdef HAVE_PTHREAD_H
 #include <pthread.h>
 #endif
+#ifdef HAVE_PTHREAD_NP_H
+#include <pthread_np.h>
+#endif
 #ifdef HAVE_SEMAPHORE_H
 #include <semaphore.h>
 #endif
@@ -4124,17 +4127,28 @@ sgen_thread_register (SgenThreadInfo* info, void *addr)
 #endif
 
 	/* try to get it with attributes first */
-#if defined(HAVE_PTHREAD_GETATTR_NP) && defined(HAVE_PTHREAD_ATTR_GETSTACK)
-	{
-		size_t size;
-		void *sstart;
-		pthread_attr_t attr;
-		pthread_getattr_np (pthread_self (), &attr);
-		pthread_attr_getstack (&attr, &sstart, &size);
-		info->stack_start_limit = sstart;
-		info->stack_end = (char*)sstart + size;
-		pthread_attr_destroy (&attr);
-	}
+#if (defined(HAVE_PTHREAD_GETATTR_NP) || defined(HAVE_PTHREAD_ATTR_GET_NP)) && defined(HAVE_PTHREAD_ATTR_GETSTACK)
+  {
+     size_t size;
+     void *sstart;
+     pthread_attr_t attr;
+
+#if defined(HAVE_PTHREAD_GETATTR_NP)
+    /* Linux */
+    pthread_getattr_np (pthread_self (), &attr);
+#elif defined(HAVE_PTHREAD_ATTR_GET_NP)
+    /* BSD */
+    pthread_attr_init (&attr);
+    pthread_attr_get_np (pthread_self (), &attr);
+#else
+#error Cannot determine which API is needed to retrieve pthread attributes.
+#endif
+
+     pthread_attr_getstack (&attr, &sstart, &size);
+     info->stack_start_limit = sstart;
+     info->stack_end = (char*)sstart + size;
+     pthread_attr_destroy (&attr);
+  }
 #elif defined(HAVE_PTHREAD_GET_STACKSIZE_NP) && defined(HAVE_PTHREAD_GET_STACKADDR_NP)
 		 info->stack_end = (char*)pthread_get_stackaddr_np (pthread_self ());
 		 info->stack_start_limit = (char*)info->stack_end - pthread_get_stacksize_np (pthread_self ());


### PR DESCRIPTION
This is a fix for bug #9732 reported on the Xamarin Bugzilla. BSD uses `pthread_attr_get_np` instead of Linux's `pthread_getattr_np`. Without this, sgen compiles on FreeBSD 9.1 and sometimes runs but certain programs cause it to crash. Using the BSD-specific API call to initialize the thread's stack fixes this problem and allows sgen to work as it should.
