### PR TITLE
Fixed exception in ASP.NET WebApi due to missing method

### DIFF
--- a/mcs/class/System.Web/System.Web/HttpRequest.cs
+++ b/mcs/class/System.Web/System.Web/HttpRequest.cs
@@ -1364,6 +1364,13 @@ namespace System.Web
 			return result;
 		}
 
+#if NET_4_0
+		public Stream GetBufferlessInputStream ()
+		{
+			throw new NotImplementedException ();
+		}
+#endif
+
 		public string MapPath (string virtualPath)
 		{
 			if (worker_request == null)


### PR DESCRIPTION
This fix enables the latest ASP.NET WebApi from NuGet to work on Mono 3.x.

All I did was adding a method stub for `GetBufferlessInputStream()` in System.Web.HttpRequest (which is new in .NET 4.0).

It currently just throws a NotImplementedException as WebApi doesn't use this method by default (you'd need to explicitly enable bufferless input in config), but an exception occured when instantiating an Api-Controller even though the method wasn't used.

Before applying the fix (using curl to query the api):
![before.png](https://f.cloud.github.com/assets/1376924/140331/22a9c600-721c-11e2-801a-462ba72cec21.png)

After:
![after.png](https://f.cloud.github.com/assets/1376924/140332/28e57a6e-721c-11e2-9756-b36f950e5b82.png)
