### PR TITLE
Fix BinaryReader.ReadChars() To Match .NET Behavior

### DIFF
--- a/mcs/class/corlib/System.IO/BinaryReader.cs
+++ b/mcs/class/corlib/System.IO/BinaryReader.cs
@@ -369,6 +369,15 @@ namespace System.IO {
 		}
 
 		public virtual char[] ReadChars(int count) {
+			if (m_stream == null)
+			{
+
+				if (m_disposed)
+					throw new ObjectDisposedException("BinaryReader", "Cannot read from a closed BinaryReader.");
+
+				throw new IOException("Stream is invalid");
+			}
+
 			if (count < 0) {
 				throw new ArgumentOutOfRangeException("count is less than 0");
 			}
@@ -376,8 +385,9 @@ namespace System.IO {
 			if (count == 0)
 				return new char [0];
 					
-			char[] full = new char[count];
-			int chars = Read(full, 0, count);
+			char[] full = new char[count];			
+			int bytes_read;
+			int chars = ReadCharBytes(full, 0, count, out bytes_read);
 			
 			if (chars == 0) {
 				throw new EndOfStreamException();


### PR DESCRIPTION
In Mono BinaryReader.ReadChars() recursively calls BinaryReader.Read().

This causes trouble if you are doing something like this...

```
    public class CheckedBinaryWriter : BinaryWriter
    {
        public override void Write(char[] chars)
        {
            WriteType<char[]>();
            base.Write(chars); // DOES NOT CALL Write()
        }

        public override void Write(char[] chars, int index, int count)
        {
            WriteType<char[]>();
            base.Write(chars, index, count);
        }
    }

    public class CheckedBinaryReader : BinaryReader
    {   
        public override int Read(char[] buffer, int index, int count)
        {
            ReadTypeAndCheck<char[]>(); // FAIL!
            return base.Read(buffer, index, count);
        }

        public override char[] ReadChars(int count)
        {
            ReadTypeAndCheck<char[]>();
            return base.ReadChars(count); // CALLS Read()
        }
    }
```

... because the writer and the reader do not make balanced calls.

This same code works in .NET because BinaryReader.ReadChars() does not recursively call BinaryReader.Read().

As a side effect the removal of recursion saves some more stack space and removes some unnecessary argument checks.

(This is my first commit to Mono...  let me know if I have done something stupid!)
