### PR TITLE
Allow cross-compilation on Mac OS X host to Windows target.

### DIFF
--- a/libgc/include/gc.h
+++ b/libgc/include/gc.h
@@ -61,6 +61,7 @@
   /* Win64 isn't really supported yet, but this is the first step. And	*/
   /* it might cause error messages to show up in more plausible places.	*/
   /* This needs basetsd.h, which is included by windows.h.	 	*/
+  #include <stdint.h>
   typedef unsigned __int64 GC_word;
   typedef __int64 GC_signed_word;
 #endif

--- a/mono/tests/mixed-mode/MixedModeLibrary/NativeApp.cpp
+++ b/mono/tests/mixed-mode/MixedModeLibrary/NativeApp.cpp
@@ -7,6 +7,7 @@ typedef HRESULT (STDAPICALLTYPE *MONOFIXUPCOREE) (HMODULE);
 typedef void (__stdcall *WRITESTRING) (const wchar_t*);
 
 #ifdef _WIN64
+#include <stdint.h>
 extern "C" void __security_check_cookie(unsigned __int64 value)
 {
 }


### PR DESCRIPTION
Cross-compiling mono on an OS X host for a Windows target using
mingw-w64 fails because of undefined __int64 types in a couple of places.

Including <stdint.h> fixes this and allows the OS X host to cross-compile
a Windows mono.

It probably sounds like an obscure use-case, but the wine-mono
project does just this, so ability to cross-compile for Windows on OS X
is crucial to being able to build wine-mono on a Mac.
