### PR TITLE
System.Web: Fixed bugs in HttpRequest.GetBufferlessInputStream()

### DIFF
--- a/mcs/class/System.Web/System.Web/HttpWorkerRequest.cs
+++ b/mcs/class/System.Web/System.Web/HttpWorkerRequest.cs
@@ -298,7 +298,13 @@ namespace System.Web
 
 		public virtual int ReadEntityBody (byte [] buffer, int offset, int size)
 		{
-			return 0;
+			byte[] temp = new byte [size];
+			int n = ReadEntityBody (temp, size);
+
+			if(n > 0)
+				Array.Copy (temp, 0, buffer, offset, n);
+
+			return n;
 		}
 
 		public virtual void SendCalculatedContentLength (long contentLength)


### PR DESCRIPTION
This PR fixes some issues with the implementation of GetBufferlessInputStream() from ae25155bdf7d3f0cbab6ca9b664aa5eb3005c4f6 .
1. In the original implementation, the position was never updated
2. The check for maxRequestLength was done when creating the stream. This is not exactly in line with the MS implementation (see remarks in http://msdn.microsoft.com/en-us/library/ff406798.aspx). I now check it directly in the Read() method of the stream.
3. `ReadEntityBody(byte[] buffer, int offset, int size)` of HttpWorkerRequest is not overidden in any of the deriving classes, which means it returned 0 all the time. I implemented it by using `ReadEntityBody(byte[] buffer, int size)` and shuffling the bytes according to the offset parameter.

With these fixes, the implementation works as intended according to my tests.
Let me know if there's something that can be improved.

Changes released under MIT/X11 license.
