### PR TITLE
Change the ExpressionVisitor abstract class from private to public

### DIFF
--- a/mcs/class/System.Core/System.Linq.Expressions/ExpressionVisitor.cs
+++ b/mcs/class/System.Core/System.Linq.Expressions/ExpressionVisitor.cs
@@ -31,7 +31,7 @@ using System.Collections.ObjectModel;
 
 namespace System.Linq.Expressions {
 
-	abstract class ExpressionVisitor {
+	public abstract class ExpressionVisitor {
 
 		protected virtual void Visit (Expression expression)
 		{


### PR DESCRIPTION
I changed only the ExpressionVisitor abstract class from private to public because in desktop .NET and in MonoForAndroid it is public and I have classes that inherits from this class and I want to use them in MonoTouch.
