### PR TITLE
Added missing properties available in .Net 4.5

### DIFF
--- a/mcs/class/corlib/System.Reflection/PropertyInfo.cs
+++ b/mcs/class/corlib/System.Reflection/PropertyInfo.cs
@@ -46,11 +46,11 @@ namespace System.Reflection {
 		
 #if NET_4_5
 		public virtual MethodInfo GetMethod {
-			get{return GetGetMethod(true);}
+			get { return GetGetMethod(true); }
 		}
 
 		public virtual MethodInfo SetMethod {
-			get{return GetSetMethod(true);}
+			get { return GetSetMethod(true); }
 		}
 #endif
 


### PR DESCRIPTION
Solves this issue when migrating from .Net 4.5 to Mono
System.MissingMethodException: Method not found: 'System.Reflection.PropertyInfo.get_GetMethod'.

System.MissingMethodException: Method not found: 'System.Reflection.PropertyInfo.get_SetMethod'.
