### PR TITLE
Use IPPROTO_TCP instead of SOL_TCP for cross-platform compatibility.

### DIFF
--- a/mono/io-layer/sockets.c
+++ b/mono/io-layer/sockets.c
@@ -1291,13 +1291,13 @@ WSAIoctl (guint32 fd, gint32 command,
 			keepalivetime /= 1000;
 			if (keepalivetime == 0 || rem >= 500)
 				keepalivetime++;
-			ret = setsockopt (fd, SOL_TCP, TCP_KEEPIDLE, &keepalivetime, sizeof (uint32_t));
+			ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepalivetime, sizeof (uint32_t));
 			if (ret == 0) {
 				rem = keepaliveinterval % 1000;
 				keepaliveinterval /= 1000;
 				if (keepaliveinterval == 0 || rem >= 500)
 					keepaliveinterval++;
-				ret = setsockopt (fd, SOL_TCP, TCP_KEEPINTVL, &keepaliveinterval, sizeof (uint32_t));
+				ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepaliveinterval, sizeof (uint32_t));
 			}
 			if (ret != 0) {
 				gint errnum = errno;


### PR DESCRIPTION
According to the Linux `tcp(7)` [man page](http://linux.die.net/man/7/tcp), the `IPPROTO_TCP` constant should be passed as the _level_ value when calling `setsockopt` to set an option value on a TCP socket (see the "Socket Options" section).

This compiles on Linux and should work (since that's what the manual specifies), though I don't know of a way to test this.

These fixes remove the need for a BSD-specific patch to this file -- BSD does not define the SOL_TCP constant, so compiling Mono currently requires a patch to replace the uses of SOL_TCP with IPPROTO_TCP.
