### PR TITLE
tasklets.c: update used stack size

### DIFF
--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -106,8 +106,8 @@ continuation_store (MonoContinuation *cont, int state, MonoException **e)
 		/* clear to avoid GC retention */
 		if (num_bytes < cont->stack_used_size) {
 			memset ((char*)cont->saved_stack + num_bytes, 0, cont->stack_used_size - num_bytes);
-			cont->stack_used_size = num_bytes;
 		}
+		cont->stack_used_size = num_bytes;
 	} else {
 		tasklets_lock ();
 		internal_init ();


### PR DESCRIPTION
was allowing case of stack_used_size < num_bytes to
slip by so restore function wasn't restoring all bytes
