### PR TITLE
Fix ISerializable implementation in mcs/class/corlib/System/OperatingSystem.cs

### DIFF
--- a/mcs/class/corlib/System/OperatingSystem.cs
+++ b/mcs/class/corlib/System/OperatingSystem.cs
@@ -56,6 +56,13 @@ namespace System {
 			}
 		}
 
+		private OperatingSystem (SerializationInfo information, StreamingContext context)
+		{
+			_platform = (System.PlatformID)information.GetValue("_platform", typeof(System.PlatformID));
+			_version = (Version)information.GetValue("_version", typeof(Version));
+			_servicePack = information.GetString("_servicePack");
+		}
+		
 		public PlatformID Platform {
 			get {
 				return _platform;


### PR DESCRIPTION
"The ISerializable interface implies a constructor with the signature constructor (SerializationInfo information, StreamingContext context)."
from http://msdn.microsoft.com/en-us/library/system.runtime.serialization.iserializable.aspx
