### PR TITLE
Fix serialization of DateTime struct for MS compatibility

### DIFF
--- a/mcs/class/corlib/System/DateTime.cs
+++ b/mcs/class/corlib/System/DateTime.cs
@@ -376,7 +376,7 @@ namespace System
 		DateTime (SerializationInfo info, StreamingContext context)
 		{
 			if (info.HasKey ("dateData")){
-				encoded = info.GetInt64 ("dateData");
+				encoded = (Int64)info.GetUInt64 ("dateData");
 			} else if (info.HasKey ("ticks")){
 				encoded = info.GetInt64 ("ticks") & TicksMask;
 			} else {
@@ -2186,7 +2186,7 @@ namespace System
 			info.AddValue ("ticks", t);
 
 			// This is the new .NET format, encodes the kind on the top bits
-			info.AddValue ("dateData", encoded);
+			info.AddValue ("dateData", (UInt64)encoded);
 		}
 		
 #if MONOTOUCH


### PR DESCRIPTION
Microsoft uses the UInt64 for the serialized dateData field.
Microsoft also uses Convert.ToUInt64 to convert the serialized
value to UInt64, which results in an overflow exception when
deserializing a DateTime serialized by mono.

Suggested change may break compatibility with previous versions
of mono, but should work with the Microsoft implementation.
