### PR TITLE
UTF8Decoder.GetChars(Byte[], Int32, Int32, Char[], Int32, Boolean) can w...

### DIFF
--- a/mcs/class/corlib/System.Text/UTF8Encoding.cs
+++ b/mcs/class/corlib/System.Text/UTF8Encoding.cs
@@ -688,10 +688,14 @@ fail_no_space:
 		if (leftOverCount == 0) {
 			int end = byteIndex + byteCount;
 			for (; byteIndex < end; posn++, byteIndex++, byteCount--) {
-				if (bytes [byteIndex] < 0x80)
+				if (bytes [byteIndex] < 0x80) {
+					if (posn >= length) {
+						throw new ArgumentException (_("Arg_InsufficientSpace"), "chars");
+					}
 					chars [posn] = (char) bytes [byteIndex];
-				else
+				} else {
 					break;
+				}
 			}
 		}
 

--- a/mcs/class/corlib/Test/System.Text/UTF8EncodingTest.cs
+++ b/mcs/class/corlib/Test/System.Text/UTF8EncodingTest.cs
@@ -1164,5 +1164,15 @@ namespace MonoTests.System.Text
 			}
 		}
 #endif
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void Bug10788()
+		{
+			byte[] bytes = new byte[4096];
+			char[] chars = new char[10];
+
+			Encoding.UTF8.GetDecoder ().GetChars (bytes, 0, 4096, chars, 9, false);
+		}
 	}
 }


### PR DESCRIPTION
...rite past end of char[]. Fixes Bug#10788

UTF8Decoder.GetChars(Byte[], Int32, Int32, Char[], Int32, Boolean) eventually calls into UTF8Encoding.InternalGetChars, which does not perform any bounds checking on the passed in char\* until after the first byte > 0x80 is encountered. For instance:

byte[] bytes = new byte[4096];
char[] chars = new char[10];
int charactersWritten = System.Text.Encoding.UTF8.GetDecoder().GetChars(bytes,
0, 4096, chars, 9, false);

will result in no errors and charactersWritten = 4096.
