### PR TITLE
System.Text.Decoder throws ArgumentOutOfRangeException when it should no...

### DIFF
--- a/mcs/class/corlib/System.Text/Decoder.cs
+++ b/mcs/class/corlib/System.Text/Decoder.cs
@@ -149,7 +149,10 @@ public abstract class Decoder
 		out int bytesUsed, out int charsUsed, out bool completed)
 	{
 		CheckArguments (bytes, byteIndex, byteCount);
-		CheckArguments (chars, charIndex);
+		if (chars == null)
+			throw new ArgumentNullException ("chars");
+		if (charIndex < 0)
+			throw new ArgumentOutOfRangeException ("charIndex");
 		if (charCount < 0 || chars.Length < charIndex + charCount)
 			throw new ArgumentOutOfRangeException ("charCount");
 
@@ -169,7 +172,7 @@ public abstract class Decoder
 	{
 		if (chars == null)
 			throw new ArgumentNullException ("chars");
-		if (charIndex < 0 || chars.Length <= charIndex)
+		if (charIndex < 0 || chars.Length < charIndex)
 			throw new ArgumentOutOfRangeException ("charIndex");
 	}
 
@@ -177,7 +180,7 @@ public abstract class Decoder
 	{
 		if (bytes == null)
 			throw new ArgumentNullException ("bytes");
-		if (byteIndex < 0 || bytes.Length <= byteIndex)
+		if (byteIndex < 0)
 			throw new ArgumentOutOfRangeException ("byteIndex");
 		if (byteCount < 0 || bytes.Length < byteIndex + byteCount)
 			throw new ArgumentOutOfRangeException ("byteCount");

--- a/mcs/class/corlib/System.Text/UTF8Encoding.cs
+++ b/mcs/class/corlib/System.Text/UTF8Encoding.cs
@@ -663,7 +663,7 @@ fail_no_space:
 			throw new ArgumentOutOfRangeException ("charIndex", _("ArgRange_Array"));
 		}
 
-		if (charIndex == chars.Length)
+		if (charIndex == chars.Length && byteCount == 0)
 			return 0;
 
 		fixed (char* cptr = chars) {

--- a/mcs/class/corlib/Test/System.Text/DecoderTest.cs
+++ b/mcs/class/corlib/Test/System.Text/DecoderTest.cs
@@ -98,5 +98,22 @@ namespace MonoTests.System.Text
 			}
 		}
 #endif
+
+		[Test]
+		public void Bug10789 ()
+		{
+			byte[] bytes = new byte[100];
+			char[] chars = new char[100];  
+
+			Decoder conv = Encoding.UTF8.GetDecoder ();
+			int charsUsed, bytesUsed;
+			bool completed;
+			
+			conv.Convert (bytes, 0, 0, chars, 100, 0, false, out bytesUsed, out charsUsed, out completed);
+
+			Assert.IsTrue (completed, "#1");
+			Assert.AreEqual (0, charsUsed, "#2");
+			Assert.AreEqual (0, bytesUsed, "#3");
+		}
 	}
 }

--- a/mcs/class/corlib/Test/System.Text/UTF8EncodingTest.cs
+++ b/mcs/class/corlib/Test/System.Text/UTF8EncodingTest.cs
@@ -1174,5 +1174,27 @@ namespace MonoTests.System.Text
 
 			Encoding.UTF8.GetDecoder ().GetChars (bytes, 0, 4096, chars, 9, false);
 		}
+
+		[Test]
+		public void Bug10789()
+		{
+			byte[] bytes = new byte[4096];
+			char[] chars = new char[10];
+
+			try {
+				Encoding.UTF8.GetDecoder ().GetChars (bytes, 0, 1, chars, 10, false);
+				Assert.Fail ("ArgumentException is expected #1");
+			} catch (ArgumentException) {
+			}
+
+			try {
+				Encoding.UTF8.GetDecoder ().GetChars (bytes, 0, 1, chars, 11, false);
+				Assert.Fail ("ArgumentOutOfRangeException is expected #2");
+			} catch (ArgumentOutOfRangeException) {
+			}
+
+			int charactersWritten = Encoding.UTF8.GetDecoder ().GetChars (bytes, 0, 0, chars, 10, false);
+			Assert.AreEqual (0, charactersWritten, "#3");
+		}
 	}
 }


### PR DESCRIPTION
...t. Fixes Bug #10789

Similar to previously reported bug #6404, according to the documentation at http://msdn.microsoft.com/en-us/library/h6w985hz.aspx, System.Text.Encoder throws ArgumentOutOfRangeExceptions when it should not. From the documentation, an ArgumentOutOfRangeException should be thrown when:

charIndex, charCount, byteIndex, or byteCount is less than zero.
-or-
The length of chars - charIndex is less than charCount.
-or-
The length of bytes - byteIndex is less than byteCount.

To reproduce, run the following code:

int charsUsed, bytesUsed;
bool completed;
byte[] bytes = new byte[4096];
char[] chars = new char[4096];
System.Text.Encoding.UTF8.GetDecoder().Convert(bytes, 0, 0, chars, 4096, 0, false, out bytesUsed, out charsUsed, out completed);

Expected:

The code runs, charsUsed equals zero, bytesUsed equals zero and completed is true.

Actual:

Mono throws an ArgumentOutOfRangeException for charIndex.

There are also other behavioral differences between Mono and Microsoft's implementation for the GetChars(Byte[], Int32, Int32, Char[], Int32, Boolean) method, such as:

byte[] bytes = new byte[4096];
char[] chars = new char[10];
int charactersWritten = System.Text.Encoding.UTF8.GetDecoder().GetChars(bytes, 0, 0, chars, 10, false);

On Mono, this results in an ArgumentOutOfRangeException for charIndex, where for Microsoft charactersWritten = 0.

Similarly:

byte[] bytes = new byte[4096];
char[] chars = new char[10];
int charactersWritten = System.Text.Encoding.UTF8.GetDecoder().GetChars(bytes, 0, 4096, chars, 10, false);

On Mono, this results in the same ArgumentOutOfRangeException for charIndex, where Microsoft throws and ArgumentException. since "chars does not have enough capacity from charIndex to the end of the array to accommodate the resulting characters."
