### PR TITLE
sgen marksweep-conc 64-bit pointer arithmetic fix for segfault

### DIFF
--- a/mono/metadata/sgen-los.c
+++ b/mono/metadata/sgen-los.c
@@ -579,7 +579,7 @@ sgen_los_object_size (LOSObject *obj)
 LOSObject*
 sgen_los_header_for_object (char *data)
 {
-	return (LOSObject*)(data - (sizeof (LOSObject*) + sizeof (mword)));
+	return (LOSObject*)(data - sizeof (LOSObject));
 }
 
 void


### PR DESCRIPTION
I turned on marksweep-conc on mono-3.0.6 on my 64-bit CentOS 6.2 system and got the following segfault when running some in-house software:

Thread 7 (Thread 0x7f604e580700 (LWP 12247)):
#0  0x00007f605cd6809d in __libc_waitpid (pid=<value optimized out>, stat_loc=<value optimized out>, options=<value optimized out>) at ../sysdeps/unix/sysv/linux/waitpid.c:41
#1  0x000000000049c935 in mono_handle_native_sigsegv (signal=<value optimized out>, ctx=<value optimized out>) at mini-exceptions.c:2331
#2  0x00000000004f5cdb in mono_arch_handle_altstack_exception (sigctx=0x7f604e37fc40, fault_addr=<value optimized out>, stack_ovf=0) at exceptions-amd64.c:884
#3  0x0000000000415239 in mono_sigsegv_signal_handler (_dummy=11, info=0x7f604e37fd70, context=0x7f604e37fc40) at mini.c:6371
#4  <signal handler called>
**#5  sgen_los_update_cardtable_mod_union () at sgen-los.c:569**
#6  0x00000000005c957b in major_update_or_finish_concurrent_collection (requested_size=8224, generation_to_collect=1, reason=0x6f49fa "Finish concurrent collection", wait_to_finish=0) at sgen-gc.c:3321
#7  sgen_perform_collection (requested_size=8224, generation_to_collect=1, reason=0x6f49fa "Finish concurrent collection", wait_to_finish=0) at sgen-gc.c:3415
#8  0x00000000005db3a3 in sgen_los_alloc_large_inner (vtable=vtable("System.Byte[]"), size=8224) at sgen-los.c:346
#9  0x00000000005e4383 in mono_gc_alloc_obj_nolock (vtable=vtable("System.Byte[]"), size=<value optimized out>) at sgen-alloc.c:204
#10 0x00000000005e48fc in mono_gc_alloc_vector (vtable=vtable("System.Byte[]"), size=8224, max_length=8192) at sgen-alloc.c:472

(gdb) up 5
#5  sgen_los_update_cardtable_mod_union () at sgen-los.c:569
569                 **obj->cardtable_mod_union** [i] |= start_card [i];
(gdb) p *obj
$1 = {next = 0x7f600ed01000, size = 839360, **cardtable_mod_union = 0x1 <Address 0x1 out of bounds>**, data = 0x7f600eb01000 ""}

Looks like cardtable_mod_union got set to 1 due to some bad pointer arithmetic.
