### PR TITLE
Ignore the gdiplus dllmap on Windows.

### DIFF
--- a/data/config.in
+++ b/data/config.in
@@ -26,6 +26,6 @@
 		<dllentry dll="__Internal" name="MoveMemory" target="mono_win32_compat_MoveMemory"/>
 		<dllentry dll="__Internal" name="ZeroMemory" target="mono_win32_compat_ZeroMemory"/>
 	</dllmap>
-	<dllmap dll="gdiplus" target="@prefix@/lib/libgdiplus@libsuffix@" />
-	<dllmap dll="gdiplus.dll" target="@prefix@/lib/libgdiplus@libsuffix@" />
+	<dllmap dll="gdiplus" target="@prefix@/lib/libgdiplus@libsuffix@" os="!windows"/>
+	<dllmap dll="gdiplus.dll" target="@prefix@/lib/libgdiplus@libsuffix@"  os="!windows"/>
 </configuration>

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -182,7 +182,7 @@ etc/mono/config: ../data/config Makefile $(symlinks)
 	d=`cd ../support && pwd`; \
 	sed 's,target="libMonoPosixHelper[^"]*",target="'$$d/libMonoPosixHelper.la'",' ../data/config > $@t
 	if test -z "$(libgdiplus_loc)"; then :; else \
-	  sed 's,<configuration>,& <dllmap dll="gdiplus.dll" target="$(libgdiplus_loc)" />,' $@t > $@tt; \
+	  sed 's,<configuration>,& <dllmap dll="gdiplus.dll" target="$(libgdiplus_loc)" os="!windows"/>,' $@t > $@tt; \
 	  mv -f $@tt $@t; fi
 	mv -f $@t $@
 


### PR DESCRIPTION
This makes System.Drawing work again for me on Windows.

It could be that some of what's already in place is wrong and should be reverted instead. It seems suspicious to me that the dllmap now exists in two places, and one of them is only used if libgdiplus exists. But I don't feel qualified to review the situation.
