### PR TITLE
Fix bug #10872 (Expires and Last-Modified headers should use two-digit days)

### DIFF
--- a/mcs/class/System.Web/System.Web.Util/TimeUtil.cs
+++ b/mcs/class/System.Web/System.Web.Util/TimeUtil.cs
@@ -39,8 +39,7 @@ namespace System.Web.Util {
 		
 		internal static string ToUtcTimeString (DateTime dt)
 		{
-			return dt.ToUniversalTime ().ToString ("ddd, d MMM yyyy HH:mm:ss ",
-				Helpers.InvariantCulture) + "GMT";
+			return dt.ToUniversalTime ().ToString ("R", DateTimeFormatInfo.InvariantInfo);
 		}
 	}
 }


### PR DESCRIPTION
While RFC 822 and RFC 1123 both allow either one- or two-digit days in dates, [HTTP only allows two-digit days](http://tools.ietf.org/html/rfc2616#section-3.3.1). Mono currently outputs dates in this format:
Sun, 3 Mar 2014 13:22:27 GMT

When they should be in this format:
Sun, **0**3 Mar 2014 13:22:27 GMT

The [standard RFC1123 ("R") format specifier](http://msdn.microsoft.com/en-us/library/az4se3k1.aspx#RFC1123) uses the correct format so I've changed the code to use this instead of a custom format.

Also see http://trac.nginx.org/nginx/ticket/310 (which is how I originally found this issue).
