### PR TITLE
Xamarin Bug 10879: Use of mono-sgen causes mono path detection fallback (2.10 backport)

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -562,7 +562,7 @@ compute_base (char *path)
 		return NULL;
 
 	/* Not a well known Mono executable, we are embedded, cant guess the base  */
-	if (strcmp (p, "/mono") && strcmp (p, "/monodis") && strcmp (p, "/mint") && strcmp (p, "/monodiet"))
+	if (strcmp (p, "/mono") && strcmp (p, "/mono-sgen") && strcmp (p, "/pedump") && strcmp (p, "/monodis") && strcmp (p, "/mint") && strcmp (p, "/monodiet"))
 		return NULL;
 	    
 	*p = 0;


### PR DESCRIPTION
Fix for [Xamarin bug 10879](https://bugzilla.xamarin.com/show_bug.cgi?id=10879), backported to 2.10 branch.

This small change allows mono-sgen and pedump to exhibit the same behavior when searching for mscorlib. Without this change, these binaries will use the "fallback" method, which causes probing only at the original install location.

Contribution is submitted under MIT X11 license.
