### PR TITLE
Xamarin Bug 10884: Additional abstract members on MethodBase breaks F# build

### DIFF
--- a/mcs/class/corlib/System.Reflection/MethodBase.cs
+++ b/mcs/class/corlib/System.Reflection/MethodBase.cs
@@ -91,8 +91,13 @@ namespace System.Reflection {
 		// This is a quick version for our own use. We should override
 		// it where possible so that it does not allocate an array.
 		//
-		internal abstract ParameterInfo[] GetParametersInternal ();
-		internal abstract int GetParametersCount ();
+		internal virtual ParameterInfo[] GetParametersInternal () {
+			return GetParameters ();
+		}
+
+		internal virtual int GetParametersCount () {
+			return GetParameters ().Length;
+		}
 
 		internal virtual Type GetParameterType (int pos) {
 			throw new NotImplementedException ();


### PR DESCRIPTION
A recent commit [(Optimize parameters handling to do much less allocation)](https://github.com/mono/mono/commit/feb5080d23ca3b0d53a13a77ae39c68734907b6a) added "internal abstract" methods to System.Reflection.MethodBase, which prevents them from being implemented by other libraries. This change converts the methods to "internal virtual" with a simple implementation suggested by [Jb Evain](https://github.com/jbevain). This fixes a build failure for F# 3.0 against Mono introduced in Mono 3.0.5.

Contribution is submitted under MIT X11 license.
