### PR TITLE
Python 3 compatibility in gen-descriptor-tests.py 

### DIFF
--- a/mono/tests/gc-descriptors/gen-descriptor-tests.py
+++ b/mono/tests/gc-descriptors/gen-descriptor-tests.py
@@ -75,7 +75,7 @@ def gen_binary_search (left, right):
     if left + 1 >= right:
         gen_new (names [left])
     else:
-        mid = (left + right) / 2
+        mid = (left + right) // 2
         print ("if (which < %d) {" % mid)
         print ("return %s (which, refs, wrap);" % search_method_name (left, mid))
         print ("} else {")


### PR DESCRIPTION
This file is using `#!/usr/bin/env python` so it cause build fault for people who use python3 by default, this request fixes it.

Works well on python2 also.

`print X` -> `print (X)`

floor division -> `//`
