### PR TITLE
System.Web.dll : NullReferenceException on GetItemInternal() after a Session.Abandon()

### DIFF
--- a/mcs/class/System.Web/System.Web.SessionState_2.0/SessionInProcHandler.cs
+++ b/mcs/class/System.Web/System.Web.SessionState_2.0/SessionInProcHandler.cs
@@ -435,8 +435,15 @@ namespace System.Web.SessionState
 					item.Dispose ();
 				} else
 					expireCallback (key, null);
-			} else if (value is InProcSessionItem)
-				((InProcSessionItem)value).Dispose ();
+			} else if (value is InProcSessionItem) {
+				InProcSessionItem item = (InProcSessionItem)value;
+				if (item.resettingTimeout) {
+					item.resettingTimeout = false;
+					return;
+				}
+				
+				item.Dispose ();
+			}
                 }
 	}
 }


### PR DESCRIPTION
See the bug on 
https://bugzilla.novell.com/show_bug.cgi?id=669807 or
https://bugzilla.xamarin.com/show_bug.cgi?id=925

When Session.Abandon() is called, all the next calls to GetItemInternal()  in SessionInProcHandler.cs crash because item.rwlock is null.

In OnSessionRemoved(), I just copy the code what is made in the case (expireCallback != null) for a InProcSessionItem in
the case (expireCallback == null)

It seems to be good after that

To reproduce : 

Default.aspx:

```
<%@ Page Language="C#" Inherits="mono2101.Default" %>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html>
<head runat="server">
    <title>Default</title>
</head>
<body>
    <form id="form1" runat="server">
        <asp:Button id="button1" runat="server" Text="Click me!"
OnClick="button1Clicked" Enabled="false" />
        <asp:Button id="button2" runat="server" Text="Abandon !!!"
OnClick="button2Clicked" />
    </form>
</body>
</html>
```

Default.aspx.cs:

```
using System;
using System.Web;
using System.Web.UI;

namespace mono2101
{

    public partial class Default : System.Web.UI.Page
    {    


        public virtual void button1Clicked (object sender, EventArgs args)
        {
            button1.Text = "Clicked me one more time";
        }

        public virtual void button2Clicked (object sender, EventArgs args)
        {
            button1.Enabled=true;
            button1.Text= "Click me twice!!!";
            Session.Abandon();
        }
    }
}
```
