### PR TITLE
Fixed handling of modifier keys in KeyEventArgs constructor (bug #6707)

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Control.cs
@@ -4413,7 +4413,7 @@ namespace System.Windows.Forms
 			switch (m.Msg) {
 				case (int)Msg.WM_SYSKEYDOWN:
 				case (int)Msg.WM_KEYDOWN: {
-					key_event = new KeyEventArgs ((Keys) m.WParam.ToInt32 ());
+					key_event = new KeyEventArgs (((Keys) m.WParam.ToInt32 ()) | XplatUI.State.ModifierKeys);
 					OnKeyDown (key_event);
 					suppressing_key_press = key_event.SuppressKeyPress;
 					return key_event.Handled;
@@ -4421,7 +4421,7 @@ namespace System.Windows.Forms
 
 				case (int)Msg.WM_SYSKEYUP:
 				case (int)Msg.WM_KEYUP: {
-					key_event = new KeyEventArgs ((Keys) m.WParam.ToInt32 ());
+					key_event = new KeyEventArgs (((Keys) m.WParam.ToInt32 ()) | XplatUI.State.ModifierKeys);
 					OnKeyUp (key_event);
 					return key_event.Handled;
 				}

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGrid.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGrid.cs
@@ -2063,7 +2063,7 @@ namespace System.Windows.Forms
 		{
 			if ((Msg) m.Msg == Msg.WM_KEYDOWN) {
 				Keys key = (Keys) m.WParam.ToInt32 ();
-				KeyEventArgs ke = new KeyEventArgs (key);
+				KeyEventArgs ke = new KeyEventArgs (key | XplatUI.State.ModifierKeys);
 				if (ProcessGridKey (ke))
 					return true;
 

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -5467,7 +5467,7 @@ namespace System.Windows.Forms {
 			DataGridViewCell cell = CurrentCell;
 			
 			if (cell != null) {
-				if (cell.KeyEntersEditMode (new KeyEventArgs ((Keys)m.WParam.ToInt32 ())))
+				if (cell.KeyEntersEditMode (new KeyEventArgs (((Keys)m.WParam.ToInt32 ()) | XplatUI.State.ModifierKeys)))
 					BeginEdit (true);
 				if (EditingControl != null && ((Msg)m.Msg == Msg.WM_KEYDOWN || (Msg)m.Msg == Msg.WM_CHAR))
 					XplatUI.SendMessage (EditingControl.Handle, (Msg)m.Msg, m.WParam, m.LParam);
@@ -5479,7 +5479,7 @@ namespace System.Windows.Forms {
 		protected override bool ProcessKeyPreview (ref Message m)
 		{
 			if ((Msg)m.Msg == Msg.WM_KEYDOWN && (IsCurrentCellInEditMode || m.HWnd == horizontalScrollBar.Handle || m.HWnd == verticalScrollBar.Handle)) {
-				KeyEventArgs e = new KeyEventArgs ((Keys)m.WParam.ToInt32 ());
+				KeyEventArgs e = new KeyEventArgs (((Keys)m.WParam.ToInt32 ()) | XplatUI.State.ModifierKeys);
 			
 				IDataGridViewEditingControl ctrl = (IDataGridViewEditingControl)EditingControlInternal;
 				

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/KeyEventArgs.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/KeyEventArgs.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Forms {
 
 		#region Public Constructors
 		public KeyEventArgs(Keys keyData) {
-			this.key_data=keyData | XplatUI.State.ModifierKeys;
+			this.key_data=keyData;
 			this.event_handled=false;
 		}
 		#endregion	// Public Constructors


### PR DESCRIPTION
Bug https://bugzilla.xamarin.com/show_bug.cgi?id=6707
The current state of the modifier keys was used added to the given keyData in the KeyEventArgs constructor. This makes the KeyEventArgs class dependent on availability of XplatUI, causing exceptions when the KeyEventArgs class is used in a non-desktop environment.

The Microsoft documentation for the constructor at http://msdn.microsoft.com/en-us/library/system.windows.forms.keyeventargs.keyeventargs.aspx also implies this behaviour is wrong: A Keys representing the key that was pressed, combined with any modifier flags that indicate which CTRL, SHIFT, and ALT keys were pressed at the same time."

The patch moves the code that retrieves the state of the modifier keys from the constructor to the call sites.
