### PR TITLE
Translate errno for EHOSTDOWN to WSAEHOSTDOWN

### DIFF
--- a/mono/io-layer/error.c
+++ b/mono/io-layer/error.c
@@ -177,6 +177,9 @@ errno_to_WSA (guint32 code, const gchar *function_name)
 #ifdef EDESTADDRREQ
 	case EDESTADDRREQ: result = WSAEDESTADDRREQ; break;
 #endif
+#ifdef EHOSTDOWN
+	case EHOSTDOWN: result = WSAEHOSTDOWN; break;
+#endif
 	case ENODEV: result = WSAENETDOWN; break;
 	default:
 		sys_error = strerror (code);


### PR DESCRIPTION
This fixes a trace from Mono like this:

_wapi_sendto: Need to translate 64 [Host is down] into winsock error

when one tries to write to a host that is down.
