### PR TITLE
[Mono.Data.Tds] Stop using Obsoleted NTLM APIs (partial fix for BXC#11122)

### DIFF
--- a/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/Tds.cs
+++ b/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/Tds.cs
@@ -1463,8 +1463,7 @@ namespace Mono.Data.Tds.Protocol
 			// 0x0200	Negotiate NTLM
 			// 0x8000	Negotiate Always Sign
 
-			Type3Message t3 = new Type3Message ();
-			t3.Challenge = t2.Nonce;
+			Type3Message t3 = new Type3Message (t2);
 			
 			t3.Domain = this.connectionParms.DefaultDomain;
 			t3.Host = this.connectionParms.Hostname;


### PR DESCRIPTION
New NTLM APIs have been pushed recently[1], which made Mono.Data.Tds break
with IOE: Refusing to use legacy-mode LM/NTLM authentication unless
explicitly enabled using DefaultAuthLevel.

This doesn't fix the bug completely, but at least reverts the situation
to the same exception being thrown before the NTLM changes took place.

[1] https://github.com/mono/mono/commit/45745e5123267e8530b87b8dada9a89c6269b383
