### PR TITLE
Fix .NET incompatibility in UpDownBase

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/UpDownBase.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/UpDownBase.cs
@@ -369,8 +369,8 @@ namespace System.Windows.Forms
 			txtView.Dock = DockStyle.Fill;
 			
 			SuspendLayout ();
-            Controls.Add(spnSpinner);
-			Controls.Add (txtView);		
+			Controls.Add (spnSpinner);
+			Controls.Add (txtView);	
 			ResumeLayout ();
 
 			Height = PreferredHeight;


### PR DESCRIPTION
In mono list of controls is in the wrong order which results in an null reference exception with code like this.

TextBoxBase tbb = domainUpDownFiles.Controls[1] as TextBoxBase;

In .NET everything is fine.
