### PR TITLE
use await GetRequestStreamAsync on System.Net.Http.HttpClientHandler SendAsync to avoid blocking

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -308,7 +308,7 @@ namespace System.Net.Http
 					}
 				}
 
-				var stream = wrequest.GetRequestStream ();
+				var stream = await wrequest.GetRequestStreamAsync ();
 				await request.Content.CopyToAsync (stream).ConfigureAwait (false);
 			}
 


### PR DESCRIPTION
I've been using the System.Net.Http Async methods with the monotouch 6.3.1 preview release, and when a server is down (in our case an aws ec2 spot instance with an elastic ip terminates) the  async request completely blocks the UI... after a little investigation (using a custom httpclienthandler), the problem lies in the var stream = wrequest.GetRequestStream() call that blocks execution... changing it to var stream = await wrequest.GetRequestStreamAsync (); resolves the problem.

Hope it helps!
