### PR TITLE
Remove duplicated definition of mini_gc_enable_gc_maps_for_aot

### DIFF
--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -2551,11 +2551,6 @@ mini_gc_set_slot_type_from_cfa (MonoCompile *cfg, int slot_offset, GCSlotType ty
 
 #endif /* DISABLE_JIT */
 
-void
-mini_gc_enable_gc_maps_for_aot (void)
-{
-}
-
 #endif
 
 #ifndef DISABLE_JIT


### PR DESCRIPTION
It seems two people fixed the same bug, in the same way, a week apart - which ended up introducing a build failure on some architectures.

8b3f25b841abc803d62af28424f22cd3383e688f was committed on Feb 8th, introducing an empty mini_gc_enable_gc_maps_for_aot on architectures without MONO_ARCH_GC_MAPS_SUPPORTED

Then cf0bc265c48a03d37c01e6f1fb118626a1faa234 was commited a week later, with exactly the same code change - resulting in the following build failure:

  CC     libmini_la-mini-gc.lo
mini-gc.c:2551:1: error: redefinition of 'mini_gc_enable_gc_maps_for_aot'
mini-gc.c:2517:1: note: previous definition of 'mini_gc_enable_gc_maps_for_aot' was here
make[3]: **\* [libmini_la-mini-gc.lo] Error 1

I'm submitting this pull request which removes vargaz's version of the change, since his is poorly placed in the file compared to deplinenoise's (i.e. easier to overlook)
