### PR TITLE
Fixed Bug 9576. Corrects the way System.Uri handles slashs in the path.

### DIFF
--- a/mcs/class/System/System/Uri.cs
+++ b/mcs/class/System/System/Uri.cs
@@ -570,7 +570,7 @@ namespace System {
 					return cachedLocalPath;
 
 				if (IsLocalIdenticalToAbsolutePath ()) {
-					cachedLocalPath = Unescape (AbsolutePath);
+					cachedLocalPath = Unescape (AbsolutePath, true);
 					return cachedLocalPath;
 				}
 
@@ -939,7 +939,7 @@ namespace System {
 					if (scheme == "mailto" || scheme == "news")
 						sb.Append (path);
 					else 
-						sb.Append (Reduce (path, CompactEscaped (scheme)));
+						sb.Append (Reduce (path, CompactEscaped (scheme), NormalizeForwardSlashes (scheme)));
 				}
 				return sb.ToString ();
 			}
@@ -1227,7 +1227,7 @@ namespace System {
 			return Unescape (str, excludeSpecial, excludeSpecial);
 		}
 		
-		internal static string Unescape (string str, bool excludeSpecial, bool excludeBackslash) 
+		internal static string Unescape (string str, bool excludeSpecial, bool excludeSlash) 
 		{
 			if (String.IsNullOrEmpty (str))
 				return String.Empty;
@@ -1245,8 +1245,12 @@ namespace System {
 						s.Append ("%25");
 					else if (excludeSpecial && x == '?')
 						s.Append ("%3F");
-					else if (excludeBackslash && x == '\\')
+					else if (excludeSlash && x == '\\')
 						s.Append ("%5C");
+#if NET_4_5
+					else if (excludeSlash && x == '/')
+						s.Append ("%2F");
+#endif
 					else {
 						s.Append (x);
 						if (surrogate != char.MinValue)
@@ -1580,7 +1584,7 @@ namespace System {
 			host = uriString;
 
 			if (unixAbsPath) {
-				path = Reduce ('/' + uriString, true);
+				path = Reduce ('/' + uriString, true, true);
 				host = String.Empty;
 			} else if (host.Length == 2 && host [1] == ':') {
 				if (scheme != UriSchemeFile) {
@@ -1632,7 +1636,7 @@ namespace System {
 				return ex.Message;
 
 			if ((scheme != Uri.UriSchemeMailto) && (scheme != Uri.UriSchemeFile)) {
-				path = Reduce (path, CompactEscaped (scheme));
+				path = Reduce (path, CompactEscaped (scheme), NormalizeForwardSlashes (scheme));
 			}
 
 			return null;
@@ -1664,9 +1668,25 @@ namespace System {
 			return false;
 		}
 
+		private static bool NormalizeForwardSlashes(string scheme)
+		{
+#if NET_4_5
+			if (scheme == null || scheme.Length < 4)
+				return true;
+			
+			char first = scheme [0];
+
+			if (first == 'h') {
+				return !(scheme == "http" || scheme == "https");
+			}
+
+#endif			
+			return true;
+		}
+
 		// replace '\', %5C ('\') and %2f ('/') into '/'
 		// replace %2e ('.') into '.'
-		private static string NormalizePath (string path)
+		private static string NormalizePath (string path, bool normalizeForwardSlashes)
 		{
 			StringBuilder res = new StringBuilder ();
 			for (int i = 0; i < path.Length; i++) {
@@ -1679,10 +1699,11 @@ namespace System {
 					if (i < path.Length - 2) {
 						char c1 = path [i + 1];
 						char c2 = Char.ToUpper (path [i + 2]);
+						
 						if ((c1 == '2') && (c2 == 'E')) {
 							c = '.';
 							i += 2;
-						} else if (((c1 == '2') && (c2 == 'F')) || ((c1 == '5') && (c2 == 'C'))) {
+						} else if ((normalizeForwardSlashes && (c1 == '2') && (c2 == 'F')) || ((c1 == '5') && (c2 == 'C'))) {
 							c = '/';
 							i += 2;
 						}
@@ -1695,7 +1716,7 @@ namespace System {
 		}
 
 		// This is called "compacting" in the MSDN documentation
-		private static string Reduce (string path, bool compact_escaped)
+		private static string Reduce (string path, bool compact_escaped, bool normalizeForwardSlashes)
 		{
 			// quick out, allocation-free, for a common case
 			if (path == "/")
@@ -1704,7 +1725,7 @@ namespace System {
 			if (compact_escaped && (path.IndexOf ('%') != -1)) {
 				// replace '\', %2f, %5c with '/' and replace %2e with '.'
 				// other escaped values seems to survive this step
-				path = NormalizePath (path);
+				path = NormalizePath (path, normalizeForwardSlashes);
 			} else {
 				// (always) replace '\' with '/'
 				path = path.Replace ('\\', '/');

--- a/mcs/class/System/Test/System/UriTest2.cs
+++ b/mcs/class/System/Test/System/UriTest2.cs
@@ -381,7 +381,7 @@ TextWriter sw = Console.Out;
 		[Test]
 		public void HttpsWithoutPort ()
 		{
-			string s = "Https://host.DOMAIN.com/dir%2fapp.xap#";
+			string s = "Https://host.DOMAIN.com/dir/app.xap#";
 			Uri uri = new Uri (s);
 			Assert.AreEqual ("/dir/app.xap", uri.AbsolutePath, "AbsolutePath");
 			Assert.AreEqual ("https://host.domain.com/dir/app.xap#", uri.AbsoluteUri, "AbsoluteUri");
@@ -1036,6 +1036,20 @@ TextWriter sw = Console.Out;
 			Assert.AreEqual (2121, uri.Port, "Port");
 			Assert.AreEqual ("ftp", uri.Scheme, "Scheme");
 			Assert.AreEqual ("/", uri.Segments [0], "Segments [0]");
+		}
+		
+		[Test]
+		public void PreserveSlashsOnPath ()
+		{
+			Uri uri = new Uri ("http://host.com/%2Fcontent", UriKind.Absolute);
+#if NET_4_5
+			Assert.AreEqual ("/%2Fcontent", uri.AbsolutePath, "AbsolutePath");
+			Assert.AreEqual ("/%2Fcontent", uri.LocalPath, "LocalPath");
+#else
+			Assert.AreEqual ("//content", uri.AbsolutePath, "AbsolutePath");
+			Assert.AreEqual ("//content", uri.LocalPath, "LocalPath");
+#endif
+			Assert.AreEqual (uri.AbsoluteUri, uri.ToString(), "ToString");
 		}
 	}
 }


### PR DESCRIPTION
Makes more compliant to RFC 3986 and fixes the Bug 9576 (https://bugzilla.xamarin.com/show_bug.cgi?id=9576). 

Tests weren't changed, they need to be reviewed by someone who really understands the original purpose of the tests, since they were written specifically to assert the unencoding of slash -- despite the RFC 3986 stating otherwise. Also .NET 4.5 has fixed the same bug recently. Apparently there's a work in progress to make the System.Uri compliant to RFC 3986, under Bug 5887 (https://bugzilla.xamarin.com/show_bug.cgi?id=5887).

Patch granted under the current MIT X11 licence.