### PR TITLE
Implemented async methods in System.Data.Common

### DIFF
--- a/mcs/class/System.Data/System.Data-net_4_5.csproj
+++ b/mcs/class/System.Data/System.Data-net_4_5.csproj
@@ -127,6 +127,7 @@
     <Compile Include="System.Data.Common\SchemaTableColumn.cs" />
     <Compile Include="System.Data.Common\SchemaTableOptionalColumn.cs" />
     <Compile Include="System.Data.Common\SupportedJoinOperators.cs" />
+    <Compile Include="System.Data.Common\TaskHelper.cs" />
     <Compile Include="System.Data.Odbc\libodbc.cs" />
     <Compile Include="System.Data.Odbc\NativeBuffer.cs" />
     <Compile Include="System.Data.Odbc\OdbcCategoryAttribute.cs" />

--- a/mcs/class/System.Data/System.Data.Common/DbCommand.cs
+++ b/mcs/class/System.Data/System.Data.Common/DbCommand.cs
@@ -151,10 +151,17 @@ namespace System.Data.Common {
 		public abstract void Prepare ();
 		
 #if NET_4_5
-		[MonoTODO]
 		protected virtual Task<DbDataReader> ExecuteDbDataReaderAsync (CommandBehavior behavior, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<DbDataReader> ();
+			}
+			
+			try {
+				return Task.FromResult (ExecuteDbDataReader (behavior));
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<DbDataReader> (e);
+			}
 		}
 		
 		public Task<int> ExecuteNonQueryAsync ()
@@ -162,10 +169,17 @@ namespace System.Data.Common {
 			return ExecuteNonQueryAsync (CancellationToken.None);
 		}
 		
-		[MonoTODO]
 		public virtual Task<int> ExecuteNonQueryAsync (CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<int> ();
+			}
+			
+			try {
+				return Task.FromResult (ExecuteNonQuery ());
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<int> (e);
+			}
 		}
 		
 		public Task<Object> ExecuteScalarAsync ()
@@ -173,10 +187,17 @@ namespace System.Data.Common {
 			return ExecuteScalarAsync (CancellationToken.None);
 		}
 		
-		[MonoTODO]
 		public virtual Task<Object> ExecuteScalarAsync (CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<Object> ();
+			}
+			
+			try {
+				return Task.FromResult (ExecuteScalar ());
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<Object> (e);
+			}
 		}
 		
 		public Task<DbDataReader> ExecuteReaderAsync ()
@@ -184,10 +205,17 @@ namespace System.Data.Common {
 			return ExecuteReaderAsync (CancellationToken.None);
 		}
 		
-		[MonoTODO]
 		public Task<DbDataReader> ExecuteReaderAsync (CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<DbDataReader> ();
+			}
+			
+			try {
+				return Task.FromResult (ExecuteReader ());
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<DbDataReader> (e);
+			}
 		}
 		
 		public Task<DbDataReader> ExecuteReaderAsync (CommandBehavior behavior)
@@ -195,10 +223,17 @@ namespace System.Data.Common {
 			return ExecuteReaderAsync (behavior, CancellationToken.None);
 		}
 		
-		[MonoTODO]
 		public Task<DbDataReader> ExecuteReaderAsync (CommandBehavior behavior, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<DbDataReader> ();
+			}
+			
+			try {
+				return Task.FromResult (ExecuteReader (behavior));
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<DbDataReader> (e);
+			}
 		}
 
 #endif

--- a/mcs/class/System.Data/System.Data.Common/DbConnection.cs
+++ b/mcs/class/System.Data/System.Data.Common/DbConnection.cs
@@ -754,10 +754,18 @@ namespace System.Data.Common {
 			return OpenAsync (CancellationToken.None);
 		}
 		
-		[MonoTODO]
 		public virtual Task OpenAsync (CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask ();
+			}
+			
+			try {
+				Open ();
+				return TaskHelper.CreateVoidTask ();
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask (e);
+			}
 		}
 #endif
 

--- a/mcs/class/System.Data/System.Data.Common/DbDataReader.cs
+++ b/mcs/class/System.Data/System.Data.Common/DbDataReader.cs
@@ -200,10 +200,17 @@ namespace System.Data.Common {
 			return GetFieldValueAsync<T> (ordinal, CancellationToken.None);
 		}
 		
-		[MonoTODO]
 		public virtual Task<T> GetFieldValueAsync<T> (int ordinal, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<T> ();
+			}
+			
+			try {
+				return Task.FromResult<T> (GetFieldValue<T> (ordinal));
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<T> (e);
+			}
 		}
 		
 		public Task<bool> NextResultAsync ()
@@ -228,16 +235,30 @@ namespace System.Data.Common {
 			throw new NotImplementedException ();	
 		}
 
-		[MonoTODO]
 		public virtual Task<bool> IsDBNullAsync (int ordinal, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<bool> ();
+			}
+			
+			try {
+				return Task.FromResult (IsDBNull (ordinal));
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<bool> (e);
+			}
 		}
 		
-		[MonoTODO]
 		public virtual Task<bool> NextResultAsync (CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<bool> ();
+			}
+			
+			try {
+				return Task.FromResult (NextResult ());
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<bool> (e);
+			}
 		}
 		
 		public Task<bool> ReadAsync ()
@@ -245,10 +266,17 @@ namespace System.Data.Common {
 			return ReadAsync (CancellationToken.None);
 		}
 		
-		[MonoTODO]
 		public virtual Task<bool> ReadAsync (CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			if (cancellationToken.IsCancellationRequested) {
+				return TaskHelper.CreateCanceledTask<bool> ();
+			}
+			
+			try {
+				return Task.FromResult (Read ());
+			} catch (Exception e) {
+				return TaskHelper.CreateExceptionTask<bool> (e);
+			}
 		}
 #endif
 

--- a/mcs/class/System.Data/System.Data.Common/TaskHelper.cs
+++ b/mcs/class/System.Data/System.Data.Common/TaskHelper.cs
@@ -1,0 +1,71 @@
+//
+// System.Data.Common.TaskHelper.cs
+//
+// Copyright (C) 2013 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if NET_4_5
+
+using System;
+using System.Threading.Tasks;
+
+namespace System.Data.Common {
+	internal sealed class TaskHelper
+	{
+		internal static Task CreateCanceledTask ()
+		{
+			TaskCompletionSource<object> tsc = new TaskCompletionSource<object> ();
+			tsc.SetCanceled ();
+			return tsc.Task;
+		}
+		
+		internal static Task<T> CreateCanceledTask<T> ()
+		{
+			TaskCompletionSource<T> tsc = new TaskCompletionSource<T> ();
+			tsc.SetCanceled ();
+			return tsc.Task;
+		}
+		
+		internal static Task CreateExceptionTask (Exception e)
+		{
+			TaskCompletionSource<object> tsc = new TaskCompletionSource<object> ();
+			tsc.SetException (e);
+			return tsc.Task;
+		}
+		
+		internal static Task<T> CreateExceptionTask<T> (Exception e)
+		{
+			TaskCompletionSource<T> tsc = new TaskCompletionSource<T> ();
+			tsc.SetException (e);
+			return tsc.Task;
+		}
+		
+		internal static Task CreateVoidTask ()
+		{
+			TaskCompletionSource<object> tsc = new TaskCompletionSource<object> ();
+			tsc.SetResult (null);
+			return tsc.Task;
+		}
+	}
+}
+
+#endif

--- a/mcs/class/System.Data/System.Data.dll.sources
+++ b/mcs/class/System.Data/System.Data.dll.sources
@@ -176,6 +176,7 @@ System.Data.Common/SchemaInfo.cs
 System.Data.Common/SchemaTableColumn.cs
 System.Data.Common/SchemaTableOptionalColumn.cs
 System.Data.Common/SupportedJoinOperators.cs
+System.Data.Common/TaskHelper.cs
 System.Data.OleDb/libgda.cs
 System.Data.OleDb/OleDbParameterConverter.cs
 System.Data.OleDb/OleDbCommand.cs


### PR DESCRIPTION
Previously these methods were marked with a `MonoTODO` attribute and threw a `NotImplementedException`.

These methods are implemented like in .NET. For example, `DbConnection.OpenAsync`:

> This is the asynchronous version of Open. Providers should override with an appropriate implementation. The cancellation token can optionally be honored.The default implementation invokes the synchronous Open call and returns a completed task. The default implementation will return a cancelled task if passed an already cancelled cancellationToken. Exceptions thrown by Open will be communicated via the returned Task Exception property.Do not invoke other methods and properties of the DbConnection object until the returned Task is complete.

These non-existing async methods didn't magically become asynchronous, they run synchronously, but now it's possible to use them even though providers haven't implemented them yet.

Consider this piece of code:

```
using (var db = new MySqlConnection()) {
    await db.OpenAsync();
}
```

This code will be executed synchronously but if the provider implements it in the future, we can use that feature without changing any code.
