### PR TITLE
Add [ConditionalAttribute("CONTRACTS_FULL")] to generic Contract.Requires<>() overloads..

### DIFF
--- a/mcs/class/corlib/System.Diagnostics.Contracts/Contract.cs
+++ b/mcs/class/corlib/System.Diagnostics.Contracts/Contract.cs
@@ -251,12 +251,14 @@ namespace System.Diagnostics.Contracts
 			AssertMustUseRewriter (ContractFailureKind.Precondition, "Contract.Requires");
 		}
 
+		[ConditionalAttribute("CONTRACTS_FULL")]
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.MayFail)]
 		public static void Requires<TException> (bool condition) where TException : Exception
 		{
 			AssertMustUseRewriter (ContractFailureKind.Precondition, "Contract.Requires<TException>");
 		}
 
+		[ConditionalAttribute("CONTRACTS_FULL")]
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.MayFail)]
 		public static void Requires<TException> (bool condition, string userMessage) where TException : Exception
 		{


### PR DESCRIPTION
Otherwise code using these will have to use ccrewrite. With this change, the rewriter isn't needed unless the symbol is defined.
