### PR TITLE
Create on demand up to min_threads to avoid startup penalty

### DIFF
--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -1053,8 +1053,8 @@ threadpool_append_jobs (ThreadPool *tp, MonoObject **jobs, gint njobs)
 		}
 		/* Create on demand up to min_threads to avoid startup penalty for apps that don't use
 		 * the threadpool that much
-		* mono_thread_create_internal (mono_get_root_domain (), threadpool_start_idle_threads, tp, TRUE, FALSE, SMALL_STACK);
-		*/
+                 */
+		mono_thread_create_internal (mono_get_root_domain (), threadpool_start_idle_threads, tp, TRUE, FALSE, SMALL_STACK);
 	}
 
 	for (i = 0; i < njobs; i++) {


### PR DESCRIPTION
When this code was originally added, it seems it was commented out. Uncommenting it out avoids throttling of threadpool worker thread creation. With the throttling, operations such as parallel https requests are slowed down significantly due to all of the threads created in order to complete the SSL operations.
