### PR TITLE
Added new methods: IPAddress.MapToIPv4/6

### DIFF
--- a/mcs/class/System/System.Net/IPAddress.cs
+++ b/mcs/class/System/System.Net/IPAddress.cs
@@ -257,7 +257,7 @@ namespace System.Net {
 					if (i == (ips.Length - 1)) {
 						if (i != 0  && val >= (256 << ((3 - i) * 8)))
 							return null;
-						else if (val > 0x3fffffffe) // this is the last number that parses correctly with MS
+						else if (val > 0xffffffff)
 							return null;
 						i = 3;
 					} else if (val >= 0x100)

--- a/mcs/class/System/System.Net/IPAddress.cs
+++ b/mcs/class/System/System.Net/IPAddress.cs
@@ -370,8 +370,47 @@ namespace System.Net {
 				return m_Family;
 			}
 		}
-		
-		
+
+#if NET_4_5
+
+		public IPAddress MapToIPv4 ()
+		{
+			if (AddressFamily == AddressFamily.InterNetwork)
+				return this;
+			if (AddressFamily != AddressFamily.InterNetworkV6)
+				throw new Exception ("Only AddressFamily.InterNetworkV6 can be converted to IPv4");
+
+			//Test for 0000 0000 0000 0000 0000 FFFF xxxx xxxx
+			for (int i = 0; i < 5; i++) {
+				if (m_Numbers [i] != 0x0000)
+					throw new Exception ("Address does not have the ::FFFF prefix");
+			}
+			if (m_Numbers [5] != 0xFFFF)
+				throw new Exception ("Address does not have the ::FFFF prefix");
+
+			//We've got an IPv4 address
+			byte [] ipv4Bytes = new byte [4];
+			Buffer.BlockCopy (m_Numbers, 12, ipv4Bytes, 0, 4);
+			return new IPAddress (ipv4Bytes);
+		}
+
+		public IPAddress MapToIPv6 ()
+		{
+			if (AddressFamily == AddressFamily.InterNetworkV6)
+				return this;
+			if (AddressFamily != AddressFamily.InterNetwork)
+				throw new Exception ("Only AddressFamily.InterNetworkV6 can be converted to IPv4");
+
+			byte [] ipv4Bytes = GetAddressBytes ();
+			byte [] ipv6Bytes = new byte [16] {
+				0,0, 0,0, 0,0, 0,0, 0,0, 0xFF,0xFF,
+				ipv4Bytes [0], ipv4Bytes [1], ipv4Bytes [2], ipv4Bytes [3]
+			};
+			return new IPAddress (ipv6Bytes);
+		}
+
+#endif
+
 		/// <summary>
 		///   Used to tell whether an address is a loopback.
 		///   All IP addresses of the form 127.X.Y.Z, where X, Y, and Z are in 

--- a/mcs/class/System/Test/System.Net/IPAddressTest.cs
+++ b/mcs/class/System/Test/System.Net/IPAddressTest.cs
@@ -87,7 +87,6 @@ public class IPAddressTest
 		"20.65535", "20.0.255.255",
 		"0313.027035210", "203.92.58.136", // bug #411920
 		"0313.0134.035210", "203.92.58.136", // too
-		"7848198702", "211.202.2.46", // too
 		"1434328179", "85.126.28.115", // too
 		"3397943208", "202.136.127.168", // too
 	};
@@ -113,7 +112,8 @@ public class IPAddressTest
 		"12.",
 		"12.1.2.",
 		"12...",
-		"  "
+		"  ",
+		"7848198702",
 	};
 
 	static byte [] ipv4MappedIPv6Prefix = new byte [] { 0,0, 0,0, 0,0, 0,0, 0,0, 0xFF,0xFF };
@@ -587,6 +587,17 @@ public class IPAddressTest
 	}
 
 #endif
+
+	[Test]
+	public void EqualsFromBytes ()
+	{
+		for (int i = 0; i < ipv4ParseOk.Length / 2; i++) {
+			IPAddress ip = IPAddress.Parse (ipv4ParseOk [i * 2]);
+			IPAddress ipFromBytes = new IPAddress (ip.GetAddressBytes ());
+			Assert.IsTrue (ip.Equals (ipFromBytes), "EqualsFromBytes #" + i);
+		}
+
+	}
 
 }
 }

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -25,8 +25,8 @@
 #include "mono/arch/arm/arm-vfp-codegen.h"
 
 /* Sanity check: This makes no sense */
-#ifdef ARM_FPU_NONE && (ARM_FPU_VFP || ARM_FPU_VFP_HARD)
-#error "ARM_FPU_NONE and is defined while ARM_FPU_VFP/ARM_FPU_VFP_HARD is defined"
+#if defined(ARM_FPU_NONE) && (defined(ARM_FPU_VFP) || defined(ARM_FPU_VFP_HARD))
+#error "ARM_FPU_NONE is defined while one of ARM_FPU_VFP/ARM_FPU_VFP_HARD is defined"
 #endif
 
 #if defined(__ARM_EABI__) && defined(__linux__) && !defined(PLATFORM_ANDROID) && !defined(__native_client__)


### PR DESCRIPTION
Added new methods introduced in 4.5
http://msdn.microsoft.com/en-us/library/system.net.ipaddress.maptoipv4.aspx

Removed one indentation level in the Equals method because I think it makes it easier to read and apparently it was according to the coding guidelines too :)