### PR TITLE
[xbuild] Actually delete common files (CopyLocal) during Clean.

### DIFF
--- a/mcs/tools/xbuild/xbuild/2.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/2.0/Microsoft.Common.targets
@@ -689,10 +689,6 @@
 			<Output TaskParameter="Lines" ItemName="PreviousFileWrites"/>
 		</ReadLinesFromFile>
 
-		<RemoveDuplicates Inputs="@(PreviousFileWrites);@(FileWrites->'%(FullPath)')">
-			<Output TaskParameter="Filtered" ItemName="CombinedFileWrites"/>
-		</RemoveDuplicates>
-
 		<!-- CopyLocal files: In case all the projects build to common output
 		     directory, then other projects might depend on some of these
 		     CopyLocal files, so delete only the ones under *this* project
@@ -700,6 +696,10 @@
 		<FindUnderPath Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)">
 			<Output TaskParameter="InPath" ItemName="FileWrites"/>
 		</FindUnderPath>
+
+		<RemoveDuplicates Inputs="@(PreviousFileWrites);@(FileWrites->'%(FullPath)')">
+			<Output TaskParameter="Filtered" ItemName="CombinedFileWrites"/>
+		</RemoveDuplicates>
 
 		<WriteLinesToFile
 			File="$(IntermediateOutputPath)$(CleanFile)"

--- a/mcs/tools/xbuild/xbuild/3.5/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/3.5/Microsoft.Common.targets
@@ -696,10 +696,6 @@
 			<Output TaskParameter="Lines" ItemName="PreviousFileWrites"/>
 		</ReadLinesFromFile>
 
-		<RemoveDuplicates Inputs="@(PreviousFileWrites);@(FileWrites->'%(FullPath)')">
-			<Output TaskParameter="Filtered" ItemName="CombinedFileWrites"/>
-		</RemoveDuplicates>
-
 		<!-- CopyLocal files: In case all the projects build to common output
 		     directory, then other projects might depend on some of these
 		     CopyLocal files, so delete only the ones under *this* project
@@ -707,6 +703,10 @@
 		<FindUnderPath Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)">
 			<Output TaskParameter="InPath" ItemName="FileWrites"/>
 		</FindUnderPath>
+
+		<RemoveDuplicates Inputs="@(PreviousFileWrites);@(FileWrites->'%(FullPath)')">
+			<Output TaskParameter="Filtered" ItemName="CombinedFileWrites"/>
+		</RemoveDuplicates>
 
 		<WriteLinesToFile
 			File="$(IntermediateOutputPath)$(CleanFile)"

--- a/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
@@ -747,10 +747,6 @@
 			<Output TaskParameter="Lines" ItemName="PreviousFileWrites"/>
 		</ReadLinesFromFile>
 
-		<RemoveDuplicates Inputs="@(PreviousFileWrites);@(FileWrites->'%(FullPath)')">
-			<Output TaskParameter="Filtered" ItemName="CombinedFileWrites"/>
-		</RemoveDuplicates>
-
 		<!-- CopyLocal files: In case all the projects build to common output
 		     directory, then other projects might depend on some of these
 		     CopyLocal files, so delete only the ones under *this* project
@@ -758,6 +754,10 @@
 		<FindUnderPath Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)">
 			<Output TaskParameter="InPath" ItemName="FileWrites"/>
 		</FindUnderPath>
+
+		<RemoveDuplicates Inputs="@(PreviousFileWrites);@(FileWrites->'%(FullPath)')">
+			<Output TaskParameter="Filtered" ItemName="CombinedFileWrites"/>
+		</RemoveDuplicates>
 
 		<WriteLinesToFile
 			File="$(IntermediateOutputPath)$(CleanFile)"


### PR DESCRIPTION
The common files that should be deleted during Clean (see 4c37deb) weren't actually written to the CleanFile, as they were stored in FileWrites after it was already used to create CombinedFileWrites. Thus, after running xbuild /t:Clean, there would be some binary files left over in the output.
