### PR TITLE
[HttpConfigurationSystem] Proxy to previous system if section is empty

### DIFF
--- a/mcs/class/System.Web/System.Web.Configuration_2.0/HttpConfigurationSystem.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/HttpConfigurationSystem.cs
@@ -3,6 +3,7 @@
 //
 // Authors:
 //  Chris Toshok (toshok@ximian.com)
+//  Andres G. Aragoneses (andres@7digital.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,19 +25,31 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 // Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+// Copyright (C) 2013 7digital Media, Ltd (http://www.7digital.com)
 //
 
 using System;
 using System.Reflection;
 using System.Configuration.Internal;
+using System.Collections.Specialized;
 
 namespace System.Web.Configuration {
 
 	internal class HttpConfigurationSystem : IInternalConfigSystem
 	{
+		internal IInternalConfigSystem fallback;
+
 		object IInternalConfigSystem.GetSection (string configKey)
 		{
-			return WebConfigurationManager.GetSection (configKey);
+			var section = WebConfigurationManager.GetSection (configKey);
+
+			if (fallback != null) {
+				var col = section as NameValueCollection;
+
+				if (section == null || (col != null && col.Count == 0))
+					return fallback.GetSection (configKey);
+			}
+			return section;
 		}
 
 		void IInternalConfigSystem.RefreshConfig (string sectionName)

--- a/mcs/class/System.Web/System.Web.Configuration_2.0/HttpConfigurationSystem.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/HttpConfigurationSystem.cs
@@ -26,8 +26,6 @@
 // Copyright (C) 2006 Novell, Inc (http://www.novell.com)
 //
 
-#if NET_2_0
-
 using System;
 using System.Reflection;
 using System.Configuration.Internal;
@@ -50,5 +48,3 @@ namespace System.Web.Configuration {
 		}
 	}
 }
-
-#endif

--- a/mcs/class/System.Web/System.Web.Configuration_2.0/WebConfigurationManager.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/WebConfigurationManager.cs
@@ -790,7 +790,7 @@ namespace System.Web.Configuration {
 						throw new ConfigurationException ("Cannot find method CCS");
 
 					object [] args = new object [] {system};
-					changeConfig.Invoke (null, args);
+					system.fallback = (IInternalConfigSystem)changeConfig.Invoke (null, args);
 					//configSystem = system;
 				}
 			}

--- a/mcs/class/System.Web/System.Web_test.dll.sources
+++ b/mcs/class/System.Web/System.Web_test.dll.sources
@@ -560,3 +560,4 @@ System.Web.Util/TransactionsCas.cs
 System.Web.Util/UrlUtilsTest.cs
 System.Web.Util/WorkItemCas.cs
 System.Web/XmlSiteMapProviderTest.cs
+SysConfigInteroperabilityTest.cs

--- a/mcs/class/System.Web/System.Web_test_net_2_0.dll.config
+++ b/mcs/class/System.Web/System.Web_test_net_2_0.dll.config
@@ -1,0 +1,1 @@
+Test/App.config

--- a/mcs/class/System.Web/System.Web_test_net_4_0.dll.config
+++ b/mcs/class/System.Web/System.Web_test_net_4_0.dll.config
@@ -1,0 +1,1 @@
+Test/App.config

--- a/mcs/class/System.Web/System.Web_test_net_4_5.dll.config
+++ b/mcs/class/System.Web/System.Web_test_net_4_5.dll.config
@@ -1,0 +1,1 @@
+Test/App.config

--- a/mcs/class/System.Web/Test/App.config
+++ b/mcs/class/System.Web/Test/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<appSettings>
+		<add key="BXC11972" value="value" />
+	</appSettings>
+</configuration>

--- a/mcs/class/System.Web/Test/SysConfigInteroperabilityTest.cs
+++ b/mcs/class/System.Web/Test/SysConfigInteroperabilityTest.cs
@@ -34,23 +34,20 @@ using System.Web;
 
 using NUnit.Framework;
 
-// this single test has this AAAAAA prefix in its namespace to make sure
-// it is the very first to run within this test suite,
-// otherwise BXC#11972 cannot be reproduced within this test suite
-namespace AAAAAAA_MonoTests.System.Web {
+namespace MonoTests.System.Web {
 
 	[TestFixture]
 	public class SystemConfigurationConfigurationManagerAppSettingsTest
 	{
 		[Test]
-		public void UsageOfSystemWebApiShouldNotBreakAccessToAppSettings()
+		public void UsageOfSystemWebApiShouldNotBreakAccessToAppSettings ()
 		{
-			Assert.IsNotNull (ConfigurationManager.AppSettings ["BXC11972"], "Null on first try");
-
-			// any API in System.Web seems to expose the bug, i.e. this too: VirtualPathUtility.Combine ("/hi", "there");
+			// any API in System.Web makes the ConfigurationManager replace its configSystem with the HttpConfigurationSystem,
+			// which causes BXC#11972
 			HttpUtility.HtmlEncode ("foo");
 
-			Assert.IsNotNull (ConfigurationManager.AppSettings ["BXC11972"], "Null on second try");
+			Assert.IsNotNull (ConfigurationManager.AppSettings ["BXC11972"],
+			                  "Should still be able to access <appSettings> when System.Web.WebConfigurationManager is used");
 		}
 	}
 }

--- a/mcs/class/System.Web/Test/SysConfigInteroperabilityTest.cs
+++ b/mcs/class/System.Web/Test/SysConfigInteroperabilityTest.cs
@@ -1,0 +1,56 @@
+//
+// System.Web.SysConfigInteroperability.cs - 
+//   Unit tests for interoperability between System.Web and ConfigurationManager
+//
+// Authors:
+//	Darrell Mozingo <darrell.mozingo@7digital.com>
+//	Andres G. Aragoneses <andres@7digital.com>
+//
+// Copyright (C) 2013 7digital Media, Ltd (http://www.7digital.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Configuration;
+using System.Web;
+
+using NUnit.Framework;
+
+// this single test has this AAAAAA prefix in its namespace to make sure
+// it is the very first to run within this test suite,
+// otherwise BXC#11972 cannot be reproduced within this test suite
+namespace AAAAAAA_MonoTests.System.Web {
+
+	[TestFixture]
+	public class SystemConfigurationConfigurationManagerAppSettingsTest
+	{
+		[Test]
+		public void UsageOfSystemWebApiShouldNotBreakAccessToAppSettings()
+		{
+			Assert.IsNotNull (ConfigurationManager.AppSettings ["BXC11972"], "Null on first try");
+
+			// any API in System.Web seems to expose the bug, i.e. this too: VirtualPathUtility.Combine ("/hi", "there");
+			HttpUtility.HtmlEncode ("foo");
+
+			Assert.IsNotNull (ConfigurationManager.AppSettings ["BXC11972"], "Null on second try");
+		}
+	}
+}


### PR DESCRIPTION
If the new HttpConfigurationSystem was put in place, there was no way to
access the old system for accessing non-System.Web settings, even though
the ChangeConfigurationSystem method was providing it as a return value.

Proxying to previous system fixes bxc#11972:
https://bugzilla.xamarin.com/show_bug.cgi?id=11972

(A unit test is added as well.)
