### PR TITLE
[System.Threading] Be proactive avoiding possible ArgumentNullException

### DIFF
--- a/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
+++ b/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
@@ -64,6 +64,14 @@ namespace System.Threading
 
 		internal void Wait (object state)
 		{
+			if (_waitObject != null) {
+				WaitLoop (state);
+			}
+			WaitEnd ();
+		}
+
+		void WaitLoop (object state)
+		{
 			try
 			{
 				WaitHandle[] waits = new WaitHandle[] {_waitObject, _cancelEvent};
@@ -79,7 +87,10 @@ namespace System.Threading
 				while (!_unregistered && !_executeOnlyOnce);
 			}
 			catch {}
+		}
 
+		void WaitEnd ()
+		{
 			lock (this) {
 				_unregistered = true;
 				if (_callsInProcess == 0 && _finalEvent != null)


### PR DESCRIPTION
This way the exception is not generated for every WebRequest in the server,
which should imply better performance.

For the record, the stacktrace I was getting by using --trace=E:all, is:

[0x7fc6a6de1700:] EXCEPTION handling: System.ArgumentNullException: null handle
Parameter name: waitHandles

"Threadpool worker" tid=0x0x7fc6a6de1700 this=0x0x7fc6a62573c0 thread handle 0x4d6 state : not waiting owns ()
  at System.Threading.WaitHandle.CheckArray (System.Threading.WaitHandle[],bool) [0x00085] in /home/andres1304/Code/system_mono/mono/mcs/class/corlib/System.Threading/WaitHandle.cs:78
  at System.Threading.WaitHandle.WaitAny (System.Threading.WaitHandle[],System.TimeSpan,bool) [0x00000] in /home/andres1304/Code/system_mono/mono/mcs/class/corlib/System.Threading/WaitHandle.cs:211
  at System.Threading.RegisteredWaitHandle.Wait (object) [0x00019] in /home/andres1304/Code/system_mono/mono/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs:72
  at (wrapper runtime-invoke) <Module>.runtime_invoke_void__this___object (object,intptr,intptr,intptr) <IL 0x00052, 0xffffffff>
