### PR TITLE
DependencyObject default value

### DIFF
--- a/mcs/class/WindowsBase/System.Windows/DependencyObject.cs
+++ b/mcs/class/WindowsBase/System.Windows/DependencyObject.cs
@@ -83,7 +83,7 @@ namespace System.Windows {
 		
 		public object GetValue(DependencyProperty dp)
 		{
-			object val = properties[dp];
+			object val = properties.ContainsKey (dp) ? properties [dp] : null;
 			return val == null ? dp.DefaultMetadata.DefaultValue : val;
 		}
 		
@@ -102,7 +102,7 @@ namespace System.Windows {
 		
 		public object ReadLocalValue(DependencyProperty dp)
 		{
-			object val = properties[dp];
+			object val = properties.ContainsKey (dp) ? properties [dp] : null;
 			return val == null ? DependencyProperty.UnsetValue : val;
 		}
 		

--- a/mcs/class/WindowsBase/Test/System.Windows/DependencyObjectTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/DependencyObjectTest.cs
@@ -59,6 +59,10 @@ namespace MonoTests.System.Windows {
 	class Y : DependencyObject {
 	}
 
+	class DefaultValueTest : DependencyObject {
+		public static readonly DependencyProperty AProperty = DependencyProperty.Register("A", typeof(string), typeof(DefaultValueTest), new PropertyMetadata("defaultValueTest"));
+	}
+
 	[TestFixture]
 	public class DependencyObjectTest {
 		[Test]
@@ -103,6 +107,13 @@ namespace MonoTests.System.Windows {
 			}
 
 			Assert.AreEqual(2, count);
+		}
+
+		[Test]
+		public void TestDefaultValue()
+		{
+			DefaultValueTest obj = new DefaultValueTest ();
+			Assert.AreEqual (obj.GetValue(DefaultValueTest.AProperty), "defaultValueTest");
 		}
 
 	}


### PR DESCRIPTION
DependencyProperty of DependencyObject was throwing KeyNotFound exception instead of default value defined in PropertyMetadata.

I'm planning to use DependencyProperty to animate properties(mostly double and floats) of UI objects for example X or Y from 0 to 500. But this has nothing to do with WPF. i.e:
Tweener.fromTo(button, Button.PropertyX,0,500,TimeSpan.FromSeconds(2));

Sample code of bug:

``` csharp
using System;
using System.Windows; 
namespace ConsoleApplication1
{
  class MainClass
  {
    public static void Main(string[] args)
    {
      DependencyPropertyTest g = new DependencyPropertyTest();
      Console.WriteLine("Hello World!" + g.State);
      //Mono throws KeyNotFound(underlying Dictionary)
      //.Net prints "Hello World!True"
    }
  }

   class DependencyPropertyTest : DependencyObject
   {
     public Boolean State
     {
       get { return (Boolean)this.GetValue(StateProperty); }
       set { this.SetValue(StateProperty, value); }
     }
     public static readonly DependencyProperty StateProperty = DependencyProperty.Register(
                        "State", typeof(Boolean), typeof(DependencyPropertyTest), new PropertyMetadata(true));
   }
}
```
