### PR TITLE
xbuild: use the AdditionalReferencePath items to locate assemblies

### DIFF
--- a/mcs/tools/xbuild/xbuild/2.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/2.0/Microsoft.Common.targets
@@ -138,6 +138,7 @@
 		<AssemblySearchPaths Condition="'$(AssemblySearchPaths)' == ''">
 			{CandidateAssemblyFiles};
 			$(ReferencePath);
+			@(AdditionalReferencePath);
 			{HintPathFromItem};
 			{TargetFrameworkDirectory};
 			{PkgConfig};

--- a/mcs/tools/xbuild/xbuild/3.5/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/3.5/Microsoft.Common.targets
@@ -145,6 +145,7 @@
 		<AssemblySearchPaths Condition="'$(AssemblySearchPaths)' == ''">
 			{CandidateAssemblyFiles};
 			$(ReferencePath);
+			@(AdditionalReferencePath);
 			{HintPathFromItem};
 			{TargetFrameworkDirectory};
 			{PkgConfig};

--- a/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
@@ -197,6 +197,7 @@
 		<AssemblySearchPaths Condition="'$(AssemblySearchPaths)' == ''">
 			{CandidateAssemblyFiles};
 			$(ReferencePath);
+			@(AdditionalReferencePath);
 			{HintPathFromItem};
 			{TargetFrameworkDirectory};
 			{PkgConfig};


### PR DESCRIPTION
This is a little underdocumented feature of MSBuild. Items with the name
"AdditionalReferencePath" get searched for referenced assemblies. This helps
with some scenarios, e.g. when the assembly has to be references from a central
location.
