### PR TITLE
Shortcut open paren recognition for switch statements

### DIFF
--- a/mcs/mcs/cs-tokenizer.cs
+++ b/mcs/mcs/cs-tokenizer.cs
@@ -3180,6 +3180,7 @@ namespace Mono.CSharp
 						case Token.FOREACH:
 						case Token.TYPEOF:
 						case Token.WHILE:
+						case Token.SWITCH:
 						case Token.USING:
 						case Token.DEFAULT:
 						case Token.DELEGATE:


### PR DESCRIPTION
I was just having an issue where an incorrect amount of newlines are recognized (In NRefactory btw). Consider the following code, where newlines have been stripped for debugging purposes:

``` cs
class Test { public void Method() { int i = 0; switch(i)
{}}}
```

After the `switch` statement, two newlines are inserted, instead of just one. When `switch` is replaced by `if` or when `i` is replaced by e.g. a number, the problem disappears. It is fixed by short-circuiting the recognition of open params for `switch` statements as well.

Although this fixes the problem, there might be a problem in `TokenizeOpenParens` that causes the newline token to be read twice, causes this improper behavior. I will leave that to someone who actually knows the states of the parser, it would take me a lot more time to figure out myself.
