### PR TITLE
TimeSpan.TryParseExact should not try to parse null input.

### DIFF
--- a/mcs/class/corlib/System/TimeSpan.cs
+++ b/mcs/class/corlib/System/TimeSpan.cs
@@ -439,7 +439,7 @@ namespace System
 		{
 			result = TimeSpan.Zero;
 
-			if (formats == null || formats.Length == 0)
+			if (input == null || formats == null || formats.Length == 0)
 				return false;
 
 			Parser p = new Parser (input, formatProvider);

--- a/mcs/class/corlib/Test/System/TimeSpanTest.cs
+++ b/mcs/class/corlib/Test/System/TimeSpanTest.cs
@@ -1322,6 +1322,8 @@ public class TimeSpanTest {
 		TryParseExactHelper ("10:12", new string [0], true, "dontcare");
 		TryParseExactHelper ("10:12", new string [] { String.Empty }, true, "dontcare");
 		TryParseExactHelper ("10:12", new string [] { null }, true, "dontcare");
+
+		TryParseExactHelper (null, new string [] { null }, true, "dontcare");
 	}
 
 	void TryParseExactHelper (string input, string [] formats, bool error, string expected, IFormatProvider formatProvider = null,


### PR DESCRIPTION
TimeSpan.TryParseExact would previously throw a NullReferenceException constructing the Parser when it accesses the Length property of the input string. Microsoft's implementation returns false when null is passed as the input string to parse.
