### PR TITLE
Take shared file lock before collecting file share_info.

### DIFF
--- a/mono/io-layer/collection.c
+++ b/mono/io-layer/collection.c
@@ -92,6 +92,9 @@ void _wapi_handle_collect (void)
 	thr_ret = _wapi_handle_lock_shared_handles ();
 	g_assert (thr_ret == 0);
 	
+	thr_ret = _wapi_shm_sem_lock (_WAPI_SHARED_SEM_FILESHARE);
+	g_assert (thr_ret == 0);
+	
 	DEBUG ("%s: (%d) Master set", __func__, _wapi_getpid ());
 	
 	/* If count has changed, someone else jumped in as master */
@@ -120,6 +123,9 @@ void _wapi_handle_collect (void)
 		InterlockedIncrement ((gint32 *)&_wapi_shared_layout->collection_count);
 	}
 	
+	thr_ret = _wapi_shm_sem_unlock (_WAPI_SHARED_SEM_FILESHARE);
+	g_assert (thr_ret == 0);
+        
 	_wapi_handle_unlock_shared_handles ();
 
 	DEBUG ("%s: (%d) Collection done", __func__, _wapi_getpid ());


### PR DESCRIPTION
I realize that shared handles are basically deprecated since Mono 2.8, but we still use them to emulate the Windows behavior under Mono.

In trying to track down a crash in one of our applications which uses shared handles, I noticed that _wapi_handle_collect() in collection.c does not lock _WAPI_SHARED_SEM_FILESHARE before performing a collection. I could not reproduce the crash I was investigating or induce any other race condition related to not taking the lock, but it does seem like an oversight, since every other mutation of share_info is protected by _WAPI_SHARED_SEM_FILESHARE.
