### PR TITLE
Prevent multiple threads to populate the keyword table

### DIFF
--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
@@ -1597,9 +1597,13 @@ namespace Mono.CSharp
 
 		static void FillKeywordTable ()
 		{
-			keywordsTable = new Hashtable ();
-			foreach (string keyword in keywords) {
-				keywordsTable.Add (keyword, keyword);
+			lock (keywords) {
+				if (keywordsTable == null) {
+					keywordsTable = new Hashtable ();
+					foreach (string keyword in keywords) {
+						keywordsTable.Add (keyword, keyword);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Ran into an exception while generating C# code using CodeDom.
