### PR TITLE
Complex.ToString must not pass format string to string.Format

### DIFF
--- a/mcs/class/System.Numerics/System.Numerics-tests-net_4_0.csproj
+++ b/mcs/class/System.Numerics/System.Numerics-tests-net_4_0.csproj
@@ -44,7 +44,8 @@
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Compile Include="Test\System.Numerics\BigIntegerTest.cs" />  </ItemGroup>
+    <Compile Include="Test\System.Numerics\BigIntegerTest.cs" />
+    <Compile Include="Test\System.Numerics\ComplexTest.cs" />  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/mcs/class/System.Numerics/System.Numerics-tests-net_4_5.csproj
+++ b/mcs/class/System.Numerics/System.Numerics-tests-net_4_5.csproj
@@ -44,7 +44,8 @@
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Compile Include="Test\System.Numerics\BigIntegerTest.cs" />  </ItemGroup>
+    <Compile Include="Test\System.Numerics\BigIntegerTest.cs" />
+    <Compile Include="Test\System.Numerics\ComplexTest.cs" />  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/mcs/class/System.Numerics/System.Numerics/ChangeLog
+++ b/mcs/class/System.Numerics/System.Numerics/ChangeLog
@@ -1,3 +1,8 @@
+2013-06-09 Christoph Ruegg <git@cdrnet.ch>
+
+	* Complex.cs: Fix IFormattable.ToString to pass custom
+	format strings to double.ToString instead of string.Format.
+
 2010-07-12  Jb Evain  <jbevain@novell.com>
 
 	* Complex.cs: implement IFormattable.

--- a/mcs/class/System.Numerics/System.Numerics/Complex.cs
+++ b/mcs/class/System.Numerics/System.Numerics/Complex.cs
@@ -338,12 +338,12 @@ namespace System.Numerics {
 
 		public string ToString (string format)
 		{
-			return string.Format ("({0}, {1})", string.Format (format, real), string.Format (format, imaginary));
+			return string.Format ("({0}, {1})", real.ToString (format), imaginary.ToString (format));
 		}
 
 		public string ToString (string format, IFormatProvider provider)
 		{
-			return string.Format ("({0}, {1})", string.Format (provider, format, real), string.Format (provider, format, imaginary));
+			return string.Format ("({0}, {1})", real.ToString (format, provider), imaginary.ToString (format, provider));
 		}
 	}
 }

--- a/mcs/class/System.Numerics/System.Numerics_test.dll.sources
+++ b/mcs/class/System.Numerics/System.Numerics_test.dll.sources
@@ -1,1 +1,2 @@
 System.Numerics/BigIntegerTest.cs
+System.Numerics/ComplexTest.cs

--- a/mcs/class/System.Numerics/Test/System.Numerics/ChangeLog
+++ b/mcs/class/System.Numerics/Test/System.Numerics/ChangeLog
@@ -1,3 +1,8 @@
+2013-06-09 Christoph Ruegg <git@cdrnet.ch>
+
+	* ComplexTest.cs: Created; Tests ToString
+	with special format strings.
+
 2010-03-06 Rodrigo Kumpera  <rkumpera@novell.com>
 
 	* BigIntegerTest.cs: Tests for decimal stuff.

--- a/mcs/class/System.Numerics/Test/System.Numerics/ComplexTest.cs
+++ b/mcs/class/System.Numerics/Test/System.Numerics/ComplexTest.cs
@@ -1,0 +1,32 @@
+// ComplexTest.cs
+//
+// Authors:
+//   Christoph Ruegg <git@cdrnet.ch>
+//
+// Copyright (C) 2013 Novell, Inc (http://www.novell.com)
+//
+
+using System;
+using System.Numerics;
+using System.Globalization;
+using NUnit.Framework;
+
+namespace MonoTests.System.Numerics
+{
+	[TestFixture]
+	public class ComplexTest
+	{
+		[Test]
+		public void TestToStringFormats ()
+		{
+			Assert.AreEqual ("(1, 2)", new Complex (1, 2).ToString (), "#1");
+			Assert.AreEqual ("(1, 2)", new Complex (1, 2).ToString ("G"), "#2");
+			Assert.AreEqual ("(1, 2)", new Complex (1, 2).ToString ((string)null), "#3");
+
+			IFormatProvider provider = CultureInfo.InvariantCulture;
+			Assert.AreEqual ("(1, 2)", new Complex (1, 2).ToString (provider), "#4");
+			Assert.AreEqual ("(1, 2)", new Complex (1, 2).ToString ("G", provider), "#5");
+			Assert.AreEqual ("(1, 2)", new Complex (1, 2).ToString ((string)null, provider), "#6");
+		}
+	}
+}


### PR DESCRIPTION
IFormattable format strings and string.Format formats are different and incompatible. For example, `x.ToString("G")` and `x.ToString((string)null)` must be equivalent to `x.ToString()`, but they behave very differently with string.Format, where the former just returns "G" and the latter throws an ArgumentNullException.

Changes System.Numerics.Complex.ToString to pass the format string to real/imag.ToString instead of using string.Format.
