### PR TITLE
[System.Numerics] BigInteger.GCD(0,x) must return abs(x) instead of x

### DIFF
--- a/mcs/class/System.Numerics/System.Numerics/BigInteger.cs
+++ b/mcs/class/System.Numerics/System.Numerics/BigInteger.cs
@@ -1725,9 +1725,9 @@ namespace System.Numerics {
 			if (right.sign != 0 && right.data.Length == 1 && right.data [0] == 1)
 				return new BigInteger (1, ONE);
 			if (left.IsZero)
-				return right;
+				return Abs(right);
 			if (right.IsZero)
-				return left;
+				return Abs(left);
 
 			BigInteger x = new BigInteger (1, left.data);
 			BigInteger y = new BigInteger (1, right.data);

--- a/mcs/class/System.Numerics/System.Numerics/ChangeLog
+++ b/mcs/class/System.Numerics/System.Numerics/ChangeLog
@@ -1,3 +1,8 @@
+2013-06-12 Christoph Ruegg <git@cdrnet.ch>
+
+	* BigInteger.cs: Fix GreatestCommonDivisor to
+	return absolute value if one of the args is zero.
+
 2013-06-09 Christoph Ruegg <git@cdrnet.ch>
 
 	* Complex.cs: Fix IFormattable.ToString to pass custom

--- a/mcs/class/System.Numerics/Test/System.Numerics/BigIntegerTest.cs
+++ b/mcs/class/System.Numerics/Test/System.Numerics/BigIntegerTest.cs
@@ -150,6 +150,9 @@ namespace MonoTests.System.Numerics
 			Assert.AreEqual (2, (int)BigInteger.GreatestCommonDivisor (-12345678, -8765432), "#14");
 
 			Assert.AreEqual (40, (int)BigInteger.GreatestCommonDivisor (5581 * 40, 6671 * 40), "#15");
+
+			Assert.AreEqual (5, (int)BigInteger.GreatestCommonDivisor (-5, 0), "#16");
+			Assert.AreEqual (5, (int)BigInteger.GreatestCommonDivisor (0, -5), "#17");
 		}
 
 		[Test]

--- a/mcs/class/System.Numerics/Test/System.Numerics/ChangeLog
+++ b/mcs/class/System.Numerics/Test/System.Numerics/ChangeLog
@@ -1,3 +1,8 @@
+2013-06-13 Christoph Ruegg <git@cdrnet.ch>
+
+	* BigIntegerTest.cs: Extended tests for
+	GreatestCommonDivisor to cover zero-args.
+
 2013-06-09 Christoph Ruegg <git@cdrnet.ch>
 
 	* ComplexTest.cs: Created; Tests ToString


### PR DESCRIPTION
According to the docs and matching the behavior in .Net, BigInteger's
GreatestCommonDivisor must return the absolute value of the non-zero
parameter if one of the parameters is zero.

Previously it just returned the other non-zero value, even if negative.

Contains a fix and extended unit tests to cover the case.
