### PR TITLE
Renamed target AssignProjectConfigurations to AssignProjectConfiguration...

### DIFF
--- a/mcs/tools/xbuild/xbuild/2.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/2.0/Microsoft.Common.targets
@@ -187,7 +187,7 @@
 	</Target>
 
 	<Target
-		Name="AssignProjectConfigurations"
+		Name="AssignProjectConfiguration"
 		Condition="'@(ProjectReference)' != ''">
 
 		<!-- assign configs if building a solution file -->
@@ -211,7 +211,7 @@
 		ProjectReferenceWithConfigurationNonExistent: Projects non-existent on disk -->
 
 	<Target Name="SplitProjectReferencesByExistent"
-		DependsOnTargets="AssignProjectConfigurations">
+		DependsOnTargets="AssignProjectConfiguration">
 
 		<CreateItem Include="@(ProjectReferenceWithConfiguration)" Condition="'@(ProjectReferenceWithConfiguration)' != ''">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfigurationExistent"
@@ -737,7 +737,7 @@
 	</Target>
 
 	<Target Name="CleanReferencedProjects"
-		DependsOnTargets="AssignProjectConfigurations">
+		DependsOnTargets="AssignProjectConfiguration">
 
 		<!-- If building from .sln.proj or from IDE, clean will get handled by them,
 		     else we are building a project directly, from the command line, so

--- a/mcs/tools/xbuild/xbuild/3.5/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/3.5/Microsoft.Common.targets
@@ -196,7 +196,7 @@
 	</Target>
 
 	<Target
-		Name="AssignProjectConfigurations"
+		Name="AssignProjectConfiguration"
 		Condition="'@(ProjectReference)' != ''">
 
 		<!-- assign configs if building a solution file -->
@@ -220,7 +220,7 @@
 		ProjectReferenceWithConfigurationNonExistent: Projects non-existent on disk -->
 
 	<Target Name="SplitProjectReferencesByExistent"
-		DependsOnTargets="AssignProjectConfigurations">
+		DependsOnTargets="AssignProjectConfiguration">
 
 		<CreateItem Include="@(ProjectReferenceWithConfiguration)" Condition="'@(ProjectReferenceWithConfiguration)' != ''">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfigurationExistent"
@@ -744,7 +744,7 @@
 	</Target>
 
 	<Target Name="CleanReferencedProjects"
-		DependsOnTargets="AssignProjectConfigurations">
+		DependsOnTargets="AssignProjectConfiguration">
 
 		<!-- If building from .sln.proj or from IDE, clean will get handled by them,
 		     else we are building a project directly, from the command line, so

--- a/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
@@ -291,7 +291,7 @@
 	</Target>
 
 	<Target
-		Name="AssignProjectConfigurations"
+		Name="AssignProjectConfiguration"
 		Condition="'@(ProjectReference)' != ''">
 
 		<!-- assign configs if building a solution file -->
@@ -315,7 +315,7 @@
 		ProjectReferenceWithConfigurationNonExistent: Projects non-existent on disk -->
 
 	<Target Name="SplitProjectReferencesByExistent"
-		DependsOnTargets="AssignProjectConfigurations">
+		DependsOnTargets="AssignProjectConfiguration">
 
 		<CreateItem Include="@(ProjectReferenceWithConfiguration)" Condition="'@(ProjectReferenceWithConfiguration)' != ''">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfigurationExistent"
@@ -842,7 +842,7 @@
 	</Target>
 
 	<Target Name="CleanReferencedProjects"
-		DependsOnTargets="AssignProjectConfigurations">
+		DependsOnTargets="AssignProjectConfiguration">
 
 		<!-- If building from .sln.proj or from IDE, clean will get handled by them,
 		     else we are building a project directly, from the command line, so


### PR DESCRIPTION
... (without the s) to better match .NET and other target files that call this target directly by name
