### PR TITLE
Serilaization TimeZoneInfo class

### DIFF
--- a/mcs/class/System.Core/System/TimeZoneInfo.cs
+++ b/mcs/class/System.Core/System/TimeZoneInfo.cs
@@ -598,7 +598,15 @@ namespace System
 		public void GetObjectData (SerializationInfo info, StreamingContext context)
 #endif
 		{
-			throw new NotImplementedException ();
+			if (info == null)
+				throw new ArgumentNullException ("info");
+			info.AddValue ("Id", id);
+			info.AddValue ("DisplayName", displayName);
+			info.AddValue ("StandardName", standardDisplayName);
+			info.AddValue ("DaylightName", daylightDisplayName);
+			info.AddValue ("BaseUtcOffset", baseUtcOffset);
+			info.AddValue ("AdjustmentRules", adjustmentRules);
+			info.AddValue ("SupportsDaylightSavingTime", SupportsDaylightSavingTime);
 		}
 
 		//FIXME: change this to a generic Dictionary and allow caching for FindSystemTimeZoneById
@@ -786,7 +794,54 @@ namespace System
 		public void OnDeserialization (object sender)
 #endif
 		{
-			throw new NotImplementedException ();
+			try {
+					TimeZoneInfo.Validate (id, baseUtcOffset, adjustmentRules);
+				} catch (ArgumentException ex) {
+					throw new SerializationException ("invalid serialization data", ex);
+				}
+ 		}
+
+		private static void Validate (string id, TimeSpan baseUtcOffset, AdjustmentRule [] adjustmentRules)
+		{
+			if (id == null)
+				throw new ArgumentNullException ("id");
+
+			if (id == String.Empty)
+				throw new ArgumentException ("id parameter is an empty string");
+
+			if (baseUtcOffset.Ticks % TimeSpan.TicksPerMinute != 0)
+				throw new ArgumentException ("baseUtcOffset parameter does not represent a whole number of minutes");
+
+			if (baseUtcOffset > new TimeSpan (14, 0, 0) || baseUtcOffset < new TimeSpan (-14, 0, 0))
+				throw new ArgumentOutOfRangeException ("baseUtcOffset parameter is greater than 14 hours or less than -14 hours");
+
+#if STRICT
+			if (id.Length > 32)
+				throw new ArgumentException ("id parameter shouldn't be longer than 32 characters");
+#endif
+
+			if (adjustmentRules != null && adjustmentRules.Length != 0) {
+				AdjustmentRule prev = null;
+				foreach (AdjustmentRule current in adjustmentRules) {
+					if (current == null)
+						throw new InvalidTimeZoneException ("one or more elements in adjustmentRules are null");
+
+					if ((baseUtcOffset + current.DaylightDelta < new TimeSpan (-14, 0, 0)) ||
+							(baseUtcOffset + current.DaylightDelta > new TimeSpan (14, 0, 0)))
+						throw new InvalidTimeZoneException ("Sum of baseUtcOffset and DaylightDelta of one or more object in adjustmentRules array is greater than 14 or less than -14 hours;");
+
+					if (prev != null && prev.DateStart > current.DateStart)
+						throw new InvalidTimeZoneException ("adjustment rules specified in adjustmentRules parameter are not in chronological order");
+					
+					if (prev != null && prev.DateEnd > current.DateStart)
+						throw new InvalidTimeZoneException ("some adjustment rules in the adjustmentRules parameter overlap");
+
+					if (prev != null && prev.DateEnd == current.DateStart)
+						throw new InvalidTimeZoneException ("a date can have multiple adjustment rules applied to it");
+
+					prev = current;
+				}
+			}
 		}
 		
 		public string ToSerializedString ()
@@ -797,6 +852,19 @@ namespace System
 		public override string ToString ()
 		{
 			return DisplayName;
+		}
+
+		private TimeZoneInfo (SerializationInfo info, StreamingContext context)
+		{
+			if (info == null)
+				throw new ArgumentNullException ("info");
+			id = (string) info.GetValue ("Id", typeof (string));
+			displayName = (string) info.GetValue ("DisplayName", typeof (string));
+			standardDisplayName = (string) info.GetValue ("StandardName", typeof (string));
+			daylightDisplayName = (string) info.GetValue ("DaylightName", typeof (string));
+			baseUtcOffset = (TimeSpan) info.GetValue ("BaseUtcOffset", typeof (TimeSpan));
+			adjustmentRules = (TimeZoneInfo.AdjustmentRule []) info.GetValue ("AdjustmentRules", typeof (TimeZoneInfo.AdjustmentRule []));
+			supportsDaylightSavingTime = (bool) info.GetValue ("SupportsDaylightSavingTime", typeof (bool));
 		}
 
 		private TimeZoneInfo (string id, TimeSpan baseUtcOffset, string displayName, string standardDisplayName, string daylightDisplayName, TimeZoneInfo.AdjustmentRule [] adjustmentRules, bool disableDaylightSavingTime)

--- a/mcs/class/System.Core/Test/System/TimeZoneInfo.AdjustmentRuleTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfo.AdjustmentRuleTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using NUnit.Framework;
 
 #if NET_2_0
@@ -89,7 +91,27 @@ namespace MonoTests.System
 				TimeZoneInfo.TransitionTime daylightTransitionEnd = TimeZoneInfo.TransitionTime.CreateFixedDateRule (new DateTime (1,1,1,2,0,0), 10, 11);
 				TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule (dateStart, dateEnd, new TimeSpan (55), daylightTransitionStart, daylightTransitionEnd);
 			}
-		}	
+		}
+	
+		[TestFixture]
+		public class NonExceptional
+		{
+			[Test]
+			public void Serialization_Deserialization ()
+			{
+				TimeZoneInfo.TransitionTime start = TimeZoneInfo.TransitionTime.CreateFloatingDateRule (new DateTime (1,1,1,1,0,0), 3, 5, DayOfWeek.Sunday);
+				TimeZoneInfo.TransitionTime end = TimeZoneInfo.TransitionTime.CreateFloatingDateRule (new DateTime (1,1,1,2,0,0), 10, 5, DayOfWeek.Sunday);
+				TimeZoneInfo.AdjustmentRule rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule (DateTime.MinValue.Date, DateTime.MaxValue.Date, new TimeSpan (1,0,0), start, end);
+				MemoryStream stream = new MemoryStream ();
+				BinaryFormatter formatter = new BinaryFormatter ();
+				formatter.Serialize (stream, rule);
+				stream.Position = 0;
+				TimeZoneInfo.AdjustmentRule deserialized = (TimeZoneInfo.AdjustmentRule) formatter.Deserialize (stream);
+				stream.Close ();
+				stream.Dispose ();
+				Assert.AreEqual (rule, deserialized);
+			}
+		}
 	}	
 }
 #endif

--- a/mcs/class/System.Core/Test/System/TimeZoneInfo.TransitionTimeTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfo.TransitionTimeTest.cs
@@ -1,5 +1,7 @@
 
 using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using NUnit.Framework;
 
 #if NET_2_0
@@ -105,6 +107,34 @@ namespace MonoTests.System
 				TimeZoneInfo.TransitionTime tt2 = TimeZoneInfo.TransitionTime.CreateFixedDateRule (dt, 2, 12);
 				Assert.IsFalse (tt2.Equals (tt1), "1!=2");
 				Assert.IsFalse (tt1.Equals (tt2), "2!=1");
+			}
+			
+			[Test]
+			public void Serialize_Deserialize_FloatingDateRule ()
+			{
+				TimeZoneInfo.TransitionTime floatingDateRule = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(new DateTime(1, 1, 1, 1, 0, 0), 3, 5, DayOfWeek.Sunday);
+				MemoryStream stream = new MemoryStream ();
+				BinaryFormatter formatter = new BinaryFormatter ();
+				formatter.Serialize (stream, floatingDateRule);
+				stream.Position = 0;
+				TimeZoneInfo.TransitionTime deserialized = (TimeZoneInfo.TransitionTime) formatter.Deserialize (stream);
+				stream.Close ();
+				stream.Dispose ();
+				Assert.AreEqual (floatingDateRule, deserialized);
+			}
+
+			[Test]
+			public void Serialize_Deserialize_FixedDateRule ()
+			{
+				TimeZoneInfo.TransitionTime fixedDateRule = TimeZoneInfo.TransitionTime.CreateFixedDateRule(new DateTime(1, 1, 1, 1, 0, 0), 3, 12);
+				MemoryStream stream = new MemoryStream ();
+				BinaryFormatter formatter = new BinaryFormatter ();
+				formatter.Serialize (stream, fixedDateRule);
+				stream.Position = 0;
+				TimeZoneInfo.TransitionTime deserialized = (TimeZoneInfo.TransitionTime) formatter.Deserialize (stream);
+				stream.Close ();
+				stream.Dispose ();
+				Assert.AreEqual (fixedDateRule, deserialized);
 			}
 		}
 	}

--- a/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
@@ -27,6 +27,8 @@
  */
 
 using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Collections;
 
 using NUnit.Framework;
@@ -655,6 +657,27 @@ namespace MonoTests.System
 				TimeZoneInfo utc = TimeZoneInfo.Utc;
 				TimeZoneInfo custom = TimeZoneInfo.CreateCustomTimeZone ("Custom", new TimeSpan (0), "Custom", "Custom");
 				Assert.IsTrue (utc.HasSameRules (custom));
+			}
+		}
+
+		[TestFixture]
+		public class SerializationTests
+		{
+			[Test]
+			public void Serialization_Deserialization ()
+			{
+				TimeZoneInfo.TransitionTime start = TimeZoneInfo.TransitionTime.CreateFloatingDateRule (new DateTime (1,1,1,1,0,0), 3, 5, DayOfWeek.Sunday);
+				TimeZoneInfo.TransitionTime end = TimeZoneInfo.TransitionTime.CreateFloatingDateRule (new DateTime (1,1,1,2,0,0), 10, 5, DayOfWeek.Sunday);
+				TimeZoneInfo.AdjustmentRule rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule (DateTime.MinValue.Date, DateTime.MaxValue.Date, new TimeSpan (1,0,0), start, end);
+				TimeZoneInfo london = TimeZoneInfo.CreateCustomTimeZone ("Europe/London", new TimeSpan (0), "Europe/London", "British Standard Time", "British Summer Time", new TimeZoneInfo.AdjustmentRule [] {rule});
+				MemoryStream stream = new MemoryStream ();
+				BinaryFormatter formatter = new BinaryFormatter ();
+				formatter.Serialize (stream, london);
+				stream.Position = 0;
+				TimeZoneInfo deserialized = (TimeZoneInfo) formatter.Deserialize (stream);
+				stream.Close ();
+				stream.Dispose ();
+				Assert.AreEqual (london, deserialized);
 			}
 		}
 	}


### PR DESCRIPTION
Add serialization for the TimeZoneInfo, TimeZoneInfo.AdjustmentRule and TimeZoneInfo.TransitionTime class. It is compatible with the serialization in .Net for cross serialization/deserialization from Mono to .Net and vice versa.
