### PR TITLE
When doing a compile time check for large file support there is no need ...

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1106,11 +1106,7 @@ if test x$target_win32 = xno; then
 			#define COMPILE_TIME_ASSERT(pred) \
 				switch(0){case 0:case pred:;}
 
-			int main(void)
-			{
-				COMPILE_TIME_ASSERT(sizeof(off_t) * CHAR_BIT == 64);
-				return 0;
-			}
+			COMPILE_TIME_ASSERT(sizeof(off_t) * CHAR_BIT == 64);
 		], [
 			AC_MSG_RESULT(ok)
 			AC_DEFINE(HAVE_LARGE_FILE_SUPPORT, 1, [Have large file support])


### PR DESCRIPTION
...for wrapping in a main function.  In fact is can cause failures in some cases
