### PR TITLE
Allow clang to compile sgen

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2960,11 +2960,6 @@ if test "x$icall_tables" = "xno"; then
    AC_DEFINE(DISABLE_ICALL_TABLES, 1, [Icall tables disabled])
 fi
 
-if test "x$mono_cv_clang" = "xyes"; then
-   # FIXME: This causes many compilation errors
-   with_tls=pthread
-fi
-
 if test "x$with_tls" = "x__thread"; then
 	AC_DEFINE(HAVE_KW_THREAD, 1, [Have __thread keyword])
 	# Pass the information to libgc
@@ -2973,10 +2968,7 @@ if test "x$with_tls" = "x__thread"; then
 	AC_TRY_COMPILE([static __thread int foo __attribute__((tls_model("initial-exec")));], [
 		], [
 			AC_MSG_RESULT(yes)
-			# CLANG doesn't support this yet, and it prints warnings about it
-			if test "x$mono_cv_clang" = "xno"; then
-				AC_DEFINE(HAVE_TLS_MODEL_ATTR, 1, [tld_model available])
-			fi
+			AC_DEFINE(HAVE_TLS_MODEL_ATTR, 1, [tls_model available])
 		], [
 			AC_MSG_RESULT(no)
 	])


### PR DESCRIPTION
Clang has supported both the `__thread` and `tls_model` attributes (needed to compile the sgen GC) since Clang/LLVM 3.2.

When compiling Mono with clang, the check which sets `with_tls=pthread` causes `mono-sgen` to be compiled anyway, although with some improper configuration which causes it to crash immediately when run.

I also removed the check for clang which was causing the `HAVE_TLS_MODEL_ATTR` symbol not to be defined, as Clang has in fact supported `tls_model` for some time now.

I cloned the Mono repository today, applied these changes, and compiled Mono using the LLVM/Clang 3.4 nightly builds on both the 32- and 64-bit versions of Ubuntu 12.04 LTS. In both cases, Mono compiled without any problems at all. Running `make check` on both boxes yielded no errors, except that the `finalizer-exception.exe` test hung on the x64 build; it's unclear whether or not this is a bug which manifests itself when Mono is built with clang, or if it's just a general bug in Mono. Either way, it doesn't seem to affect anything else.

If there are any issues compiling Mono with clang on other platforms, these "global" checks for clang should still be removed, and new platform-specific checks added where necessary.
