### PR TITLE
Escape the output files when running AOT to support paths with spaces li...

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8215,7 +8215,7 @@ compile_asm (MonoAotCompile *acfg)
 	} else {
 		objfile = g_strdup_printf ("%s.o", acfg->tmpfname);
 	}
-	command = g_strdup_printf ("%s%s %s %s -o %s %s", tool_prefix, AS_NAME, AS_OPTIONS, acfg->as_args ? acfg->as_args->str : "", objfile, acfg->tmpfname);
+	command = g_strdup_printf ("%s%s %s %s -o '%s' '%s'", tool_prefix, AS_NAME, AS_OPTIONS, acfg->as_args ? acfg->as_args->str : "", objfile, acfg->tmpfname);
 	printf ("Executing the native assembler: %s\n", command);
 	if (system (command) != 0) {
 		g_free (command);
@@ -8240,17 +8240,17 @@ compile_asm (MonoAotCompile *acfg)
 	tmp_outfile_name = g_strdup_printf ("%s.tmp", outfile_name);
 
 #if defined(sparc)
-	command = g_strdup_printf ("ld -shared -G -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
+	command = g_strdup_printf ("ld -shared -G -o '%s' '%s.o'", tmp_outfile_name, acfg->tmpfname);
 #elif defined(__ppc__) && defined(TARGET_MACH)
-	command = g_strdup_printf ("gcc -dynamiclib -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
+	command = g_strdup_printf ("gcc -dynamiclib -o '%s' '%s.o'", tmp_outfile_name, acfg->tmpfname);
 #elif defined(TARGET_AMD64) && defined(TARGET_MACH)
-	command = g_strdup_printf ("gcc --shared -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
+	command = g_strdup_printf ("gcc --shared -o '%s' '%s.o'", tmp_outfile_name, acfg->tmpfname);
 #elif defined(HOST_WIN32)
-	command = g_strdup_printf ("gcc -shared --dll -mno-cygwin -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
+	command = g_strdup_printf ("gcc -shared --dll -mno-cygwin -o '%s' '%s.o'", tmp_outfile_name, acfg->tmpfname);
 #elif defined(TARGET_X86) && defined(TARGET_MACH) && !defined(__native_client_codegen__)
-	command = g_strdup_printf ("gcc -m32 -dynamiclib -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
+	command = g_strdup_printf ("gcc -m32 -dynamiclib -o '%s' '%s.o'", tmp_outfile_name, acfg->tmpfname);
 #else
-	command = g_strdup_printf ("%sld %s %s -shared -o %s %s.o", tool_prefix, EH_LD_OPTIONS, LD_OPTIONS, tmp_outfile_name, acfg->tmpfname);
+	command = g_strdup_printf ("%sld %s %s -shared -o '%s' '%s.o'", tool_prefix, EH_LD_OPTIONS, LD_OPTIONS, tmp_outfile_name, acfg->tmpfname);
 #endif
 	printf ("Executing the native linker: %s\n", command);
 	if (system (command) != 0) {
@@ -8263,7 +8263,7 @@ compile_asm (MonoAotCompile *acfg)
 
 	g_free (command);
 
-	/*com = g_strdup_printf ("strip --strip-unneeded %s%s", acfg->image->name, SHARED_EXT);
+	/*com = g_strdup_printf ("strip --strip-unneeded '%s%s'", acfg->image->name, SHARED_EXT);
 	printf ("Stripping the binary: %s\n", com);
 	system (com);
 	g_free (com);*/
@@ -8273,7 +8273,7 @@ compile_asm (MonoAotCompile *acfg)
 	 * gas generates 'mapping symbols' each time code and data is mixed, which 
 	 * happens a lot in emit_and_reloc_code (), so we need to get rid of them.
 	 */
-	command = g_strdup_printf ("%sstrip --strip-symbol=\\$a --strip-symbol=\\$d %s", tool_prefix, tmp_outfile_name);
+	command = g_strdup_printf ("%sstrip --strip-symbol=\\$a --strip-symbol=\\$d '%s'", tool_prefix, tmp_outfile_name);
 	printf ("Stripping the binary: %s\n", command);
 	if (system (command) != 0) {
 		g_free (tmp_outfile_name);
@@ -8287,7 +8287,7 @@ compile_asm (MonoAotCompile *acfg)
 	rename (tmp_outfile_name, outfile_name);
 
 #if defined(TARGET_MACH)
-	command = g_strdup_printf ("dsymutil %s", outfile_name);
+	command = g_strdup_printf ("dsymutil '%s'", outfile_name);
 	printf ("Generating debug symbols: %s\n", command);
 	if (system (command) != 0) {
 		return 1;


### PR DESCRIPTION
...ke /Library/Application\ Support on the Mac. This one against master.