### PR TITLE
Added public API visibility macros

### DIFF
--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -26,190 +26,190 @@ typedef struct _MonoJitInfo MonoJitInfo;
 
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
 
-MonoDomain*
+MONO_API MonoDomain*
 mono_init                  (const char *filename);
 
-MonoDomain *
+MONO_API MonoDomain *
 mono_init_from_assembly    (const char *domain_name, const char *filename);
 
-MonoDomain *
+MONO_API MonoDomain *
 mono_init_version          (const char *domain_name, const char *version);
 
-MonoDomain*
+MONO_API MonoDomain*
 mono_get_root_domain       (void);
 
-void
+MONO_API void
 mono_runtime_init          (MonoDomain *domain, MonoThreadStartCB start_cb,
 			    MonoThreadAttachCB attach_cb);
 
-void
+MONO_API void
 mono_runtime_cleanup       (MonoDomain *domain);
 
-void
+MONO_API void
 mono_install_runtime_cleanup (MonoDomainFunc func);
 
-void
+MONO_API void
 mono_runtime_quit (void);
 
-void
+MONO_API void
 mono_runtime_set_shutting_down (void);
 
-mono_bool
+MONO_API mono_bool
 mono_runtime_is_shutting_down (void);
 
-const char*
+MONO_API const char*
 mono_check_corlib_version (void);
 
-MonoDomain *
+MONO_API MonoDomain *
 mono_domain_create         (void);
 
-MonoDomain *
+MONO_API MonoDomain *
 mono_domain_create_appdomain (char *friendly_name, char *configuration_file);
 
-MonoDomain *
+MONO_API MonoDomain *
 mono_domain_get            (void);
 
-MonoDomain *
+MONO_API MonoDomain *
 mono_domain_get_by_id      (int32_t domainid);
 
-int32_t
+MONO_API int32_t
 mono_domain_get_id         (MonoDomain *domain);
 
-mono_bool
+MONO_API mono_bool
 mono_domain_set            (MonoDomain *domain, mono_bool force);
 
-void
+MONO_API void
 mono_domain_set_internal   (MonoDomain *domain);
 
-void
+MONO_API void
 mono_domain_unload (MonoDomain *domain);
 
-void
+MONO_API void
 mono_domain_try_unload (MonoDomain *domain, MonoObject **exc);
 
-mono_bool
+MONO_API mono_bool
 mono_domain_is_unloading   (MonoDomain *domain);
 
-MonoDomain *
+MONO_API MonoDomain *
 mono_domain_from_appdomain (MonoAppDomain *appdomain);
 
-void
+MONO_API void
 mono_domain_foreach        (MonoDomainFunc func, void* user_data);
 
-MonoAssembly *
+MONO_API MonoAssembly *
 mono_domain_assembly_open  (MonoDomain *domain, const char *name);
 
-mono_bool
+MONO_API mono_bool
 mono_domain_finalize       (MonoDomain *domain, uint32_t timeout);
 
-void
+MONO_API void
 mono_domain_free           (MonoDomain *domain, mono_bool force);
 
-mono_bool
+MONO_API mono_bool
 mono_domain_has_type_resolve (MonoDomain *domain);
 
-MonoReflectionAssembly *
+MONO_API MonoReflectionAssembly *
 mono_domain_try_type_resolve (MonoDomain *domain, char *name, MonoObject *tb);
 
-mono_bool
+MONO_API mono_bool
 mono_domain_owns_vtable_slot (MonoDomain *domain, void* vtable_slot);
 
-void
+MONO_API void
 mono_context_init 				   (MonoDomain *domain);
 
-void 
+MONO_API void 
 mono_context_set				   (MonoAppContext *new_context);
 
-MonoAppContext * 
+MONO_API MonoAppContext * 
 mono_context_get				   (void);
 
-MonoJitInfo *
+MONO_API MonoJitInfo *
 mono_jit_info_table_find   (MonoDomain *domain, char *addr);
 
 /* MonoJitInfo accessors */
 
-void*
+MONO_API void*
 mono_jit_info_get_code_start (MonoJitInfo* ji);
 
-int
+MONO_API int
 mono_jit_info_get_code_size (MonoJitInfo* ji);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_jit_info_get_method (MonoJitInfo* ji);
 
 
-MonoImage*
+MONO_API MonoImage*
 mono_get_corlib            (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_object_class      (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_byte_class        (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_void_class        (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_boolean_class     (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_sbyte_class       (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_int16_class       (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_uint16_class      (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_int32_class       (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_uint32_class      (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_intptr_class         (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_uintptr_class        (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_int64_class       (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_uint64_class      (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_single_class      (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_double_class      (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_char_class        (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_string_class      (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_enum_class        (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_array_class       (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_thread_class       (void);
 
-MonoClass*
+MONO_API MonoClass*
 mono_get_exception_class    (void);
 
-void
+MONO_API void
 mono_security_enable_core_clr (void);
 
 typedef mono_bool (*MonoCoreClrPlatformCB) (const char *image_name);
 
-void
+MONO_API void
 mono_security_set_core_clr_platform_callback (MonoCoreClrPlatformCB callback);
 
 MONO_END_DECLS

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -5,67 +5,67 @@
 
 MONO_BEGIN_DECLS
 
-void          mono_assemblies_init     (void);
-void          mono_assemblies_cleanup  (void);
-MonoAssembly *mono_assembly_open       (const char *filename,
+MONO_API void          mono_assemblies_init     (void);
+MONO_API void          mono_assemblies_cleanup  (void);
+MONO_API MonoAssembly *mono_assembly_open       (const char *filename,
 				       	MonoImageOpenStatus *status);
-MonoAssembly *mono_assembly_open_full (const char *filename,
+MONO_API MonoAssembly *mono_assembly_open_full (const char *filename,
 				       	MonoImageOpenStatus *status,
 					mono_bool refonly);
-MonoAssembly* mono_assembly_load       (MonoAssemblyName *aname, 
+MONO_API MonoAssembly* mono_assembly_load       (MonoAssemblyName *aname, 
                                        	const char       *basedir, 
 				     	MonoImageOpenStatus *status);
-MonoAssembly* mono_assembly_load_full (MonoAssemblyName *aname, 
+MONO_API MonoAssembly* mono_assembly_load_full (MonoAssemblyName *aname, 
                                        	const char       *basedir, 
 				     	MonoImageOpenStatus *status,
 					mono_bool refonly);
-MonoAssembly* mono_assembly_load_from  (MonoImage *image, const char *fname,
+MONO_API MonoAssembly* mono_assembly_load_from  (MonoImage *image, const char *fname,
 					MonoImageOpenStatus *status);
-MonoAssembly* mono_assembly_load_from_full  (MonoImage *image, const char *fname,
+MONO_API MonoAssembly* mono_assembly_load_from_full  (MonoImage *image, const char *fname,
 					MonoImageOpenStatus *status,
 					mono_bool refonly);
 
-MonoAssembly* mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *status);
+MONO_API MonoAssembly* mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *status);
 
-MonoAssembly* mono_assembly_loaded     (MonoAssemblyName *aname);
-MonoAssembly* mono_assembly_loaded_full (MonoAssemblyName *aname, mono_bool refonly);
-void          mono_assembly_get_assemblyref (MonoImage *image, int index, MonoAssemblyName *aname);
-void          mono_assembly_load_reference (MonoImage *image, int index);
-void          mono_assembly_load_references (MonoImage *image, MonoImageOpenStatus *status);
-MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32_t idx);
-void          mono_assembly_close      (MonoAssembly *assembly);
-void          mono_assembly_setrootdir (const char *root_dir);
-MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
-void	      mono_assembly_foreach    (MonoFunc func, void* user_data);
-void          mono_assembly_set_main   (MonoAssembly *assembly);
-MonoAssembly *mono_assembly_get_main   (void);
-MonoImage    *mono_assembly_get_image  (MonoAssembly *assembly);
-mono_bool      mono_assembly_fill_assembly_name (MonoImage *image, MonoAssemblyName *aname);
-mono_bool      mono_assembly_names_equal (MonoAssemblyName *l, MonoAssemblyName *r);
-char*         mono_stringify_assembly_name (MonoAssemblyName *aname);
+MONO_API MonoAssembly* mono_assembly_loaded     (MonoAssemblyName *aname);
+MONO_API MonoAssembly* mono_assembly_loaded_full (MonoAssemblyName *aname, mono_bool refonly);
+MONO_API void          mono_assembly_get_assemblyref (MonoImage *image, int index, MonoAssemblyName *aname);
+MONO_API void          mono_assembly_load_reference (MonoImage *image, int index);
+MONO_API void          mono_assembly_load_references (MonoImage *image, MonoImageOpenStatus *status);
+MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32_t idx);
+MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
+MONO_API void          mono_assembly_setrootdir (const char *root_dir);
+MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
+MONO_API void	      mono_assembly_foreach    (MonoFunc func, void* user_data);
+MONO_API void          mono_assembly_set_main   (MonoAssembly *assembly);
+MONO_API MonoAssembly *mono_assembly_get_main   (void);
+MONO_API MonoImage    *mono_assembly_get_image  (MonoAssembly *assembly);
+MONO_API mono_bool      mono_assembly_fill_assembly_name (MonoImage *image, MonoAssemblyName *aname);
+MONO_API mono_bool      mono_assembly_names_equal (MonoAssemblyName *l, MonoAssemblyName *r);
+MONO_API char*         mono_stringify_assembly_name (MonoAssemblyName *aname);
 
 /* Installs a function which is called each time a new assembly is loaded. */
 typedef void  (*MonoAssemblyLoadFunc)         (MonoAssembly *assembly, void* user_data);
-void          mono_install_assembly_load_hook (MonoAssemblyLoadFunc func, void* user_data);
+MONO_API void          mono_install_assembly_load_hook (MonoAssemblyLoadFunc func, void* user_data);
 
 /* 
  * Installs a new function which is used to search the list of loaded 
  * assemblies for a given assembly name.
  */
 typedef MonoAssembly *(*MonoAssemblySearchFunc)         (MonoAssemblyName *aname, void* user_data);
-void          mono_install_assembly_search_hook (MonoAssemblySearchFunc func, void* user_data);
-void 	      mono_install_assembly_refonly_search_hook (MonoAssemblySearchFunc func, void* user_data);
+MONO_API void          mono_install_assembly_search_hook (MonoAssemblySearchFunc func, void* user_data);
+MONO_API void 	      mono_install_assembly_refonly_search_hook (MonoAssemblySearchFunc func, void* user_data);
 
-MonoAssembly* mono_assembly_invoke_search_hook (MonoAssemblyName *aname);
+MONO_API MonoAssembly* mono_assembly_invoke_search_hook (MonoAssemblyName *aname);
 
 /*
  * Installs a new search function which is used as a last resort when loading 
  * an assembly fails. This could invoke AssemblyResolve events.
  */
-void          
+MONO_API void          
 mono_install_assembly_postload_search_hook (MonoAssemblySearchFunc func, void* user_data);
 
-void          
+MONO_API void          
 mono_install_assembly_postload_refonly_search_hook (MonoAssemblySearchFunc func, void* user_data);
 
 
@@ -76,20 +76,20 @@ typedef MonoAssembly * (*MonoAssemblyPreLoadFunc) (MonoAssemblyName *aname,
 						   char **assemblies_path,
 						   void* user_data);
 
-void          mono_install_assembly_preload_hook (MonoAssemblyPreLoadFunc func,
+MONO_API void          mono_install_assembly_preload_hook (MonoAssemblyPreLoadFunc func,
 						  void* user_data);
-void          mono_install_assembly_refonly_preload_hook (MonoAssemblyPreLoadFunc func,
+MONO_API void          mono_install_assembly_refonly_preload_hook (MonoAssemblyPreLoadFunc func,
 						  void* user_data);
 
-void          mono_assembly_invoke_load_hook (MonoAssembly *ass);
+MONO_API void          mono_assembly_invoke_load_hook (MonoAssembly *ass);
 
-MonoAssemblyName* mono_assembly_name_new             (const char *name);
-const char*       mono_assembly_name_get_name        (MonoAssemblyName *aname);
-const char*       mono_assembly_name_get_culture     (MonoAssemblyName *aname);
-uint16_t          mono_assembly_name_get_version     (MonoAssemblyName *aname,
+MONO_API MonoAssemblyName* mono_assembly_name_new             (const char *name);
+MONO_API const char*       mono_assembly_name_get_name        (MonoAssemblyName *aname);
+MONO_API const char*       mono_assembly_name_get_culture     (MonoAssemblyName *aname);
+MONO_API uint16_t          mono_assembly_name_get_version     (MonoAssemblyName *aname,
 						      uint16_t *minor, uint16_t *build, uint16_t *revision);
-mono_byte*        mono_assembly_name_get_pubkeytoken (MonoAssemblyName *aname);
-void              mono_assembly_name_free            (MonoAssemblyName *aname);
+MONO_API mono_byte*        mono_assembly_name_get_pubkeytoken (MonoAssemblyName *aname);
+MONO_API void              mono_assembly_name_free            (MonoAssemblyName *aname);
 
 typedef struct {
 	const char *name;
@@ -97,14 +97,14 @@ typedef struct {
 	const unsigned int size;
 } MonoBundledAssembly;
 
-void          mono_register_bundled_assemblies (const MonoBundledAssembly **assemblies);
-void          mono_register_config_for_assembly (const char* assembly_name, const char* config_xml);
-void          mono_register_symfile_for_assembly (const char* assembly_name, const mono_byte *raw_contents, int size);
-void	      mono_register_machine_config (const char *config_xml);
+MONO_API void          mono_register_bundled_assemblies (const MonoBundledAssembly **assemblies);
+MONO_API void          mono_register_config_for_assembly (const char* assembly_name, const char* config_xml);
+MONO_API void          mono_register_symfile_for_assembly (const char* assembly_name, const mono_byte *raw_contents, int size);
+MONO_API void	      mono_register_machine_config (const char *config_xml);
 
-void          mono_set_rootdir (void);
-void          mono_set_dirs (const char *assembly_dir, const char *config_dir);
-void          mono_set_assemblies_path (const char* path);
+MONO_API void          mono_set_rootdir (void);
+MONO_API void          mono_set_dirs (const char *assembly_dir, const char *config_dir);
+MONO_API void          mono_set_assemblies_path (const char* path);
 MONO_END_DECLS
 
 #endif

--- a/mono/metadata/cil-coff.h
+++ b/mono/metadata/cil-coff.h
@@ -320,6 +320,6 @@ typedef struct {
 	MonoCLIHeader     cli_cli_header;
 } MonoCLIImageInfo;
 
-guint32       mono_cli_rva_image_map (MonoImage *image, guint32 rva);
+MONO_API guint32       mono_cli_rva_image_map (MonoImage *image, guint32 rva);
 
 #endif /* __MONO_CIL_COFF_H__ */

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -439,7 +439,7 @@ int mono_class_interface_match (const uint8_t *bitmap, int id) MONO_INTERNAL;
 #endif
 
 
-int mono_class_interface_offset (MonoClass *klass, MonoClass *itf);
+MONO_API int mono_class_interface_offset (MonoClass *klass, MonoClass *itf);
 int mono_class_interface_offset_with_variance (MonoClass *klass, MonoClass *itf, gboolean *non_exact_match) MONO_INTERNAL;
 
 typedef gpointer MonoRuntimeGenericContext;
@@ -835,7 +835,7 @@ typedef struct {
 
 extern MonoPerfCounters *mono_perfcounters MONO_INTERNAL;
 
-void mono_perfcounters_init (void);
+MONO_API void mono_perfcounters_init (void);
 
 /*
  * The definition of the first field in SafeHandle,
@@ -1001,7 +1001,7 @@ MonoGenericContext*
 mono_method_get_context (MonoMethod *method) MONO_INTERNAL;
 
 /* Used by monodis, thus cannot be MONO_INTERNAL */
-MonoGenericContainer*
+MONO_API MonoGenericContainer*
 mono_method_get_generic_container (MonoMethod *method);
 
 MonoGenericContext*
@@ -1022,7 +1022,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 MonoMethodInflated*
 mono_method_inflated_lookup (MonoMethodInflated* method, gboolean cache) MONO_INTERNAL;
 
-MonoMethodSignature *
+MONO_API MonoMethodSignature *
 mono_metadata_get_inflated_signature (MonoMethodSignature *sig, MonoGenericContext *context);
 
 MonoType*
@@ -1034,7 +1034,7 @@ mono_class_inflate_generic_class (MonoClass *gklass, MonoGenericContext *context
 MonoType*
 mono_class_inflate_generic_type_checked (MonoType *type, MonoGenericContext *context, MonoError *error) MONO_INTERNAL;
 
-void
+MONO_API void
 mono_metadata_free_inflated_signature (MonoMethodSignature *sig);
 
 MonoMethodSignature*
@@ -1218,11 +1218,11 @@ mono_method_get_wrapper_data (MonoMethod *method, guint32 id) MONO_INTERNAL;
 gboolean
 mono_metadata_has_generic_params (MonoImage *image, guint32 token) MONO_INTERNAL;
 
-MonoGenericContainer *
+MONO_API MonoGenericContainer *
 mono_metadata_load_generic_params (MonoImage *image, guint32 token,
 				   MonoGenericContainer *parent_container);
 
-void
+MONO_API void
 mono_metadata_load_generic_param_constraints (MonoImage *image, guint32 token,
 					      MonoGenericContainer *container);
 
@@ -1272,23 +1272,23 @@ mono_type_get_full_name (MonoClass *class) MONO_INTERNAL;
 MonoArrayType *mono_dup_array_type (MonoImage *image, MonoArrayType *a) MONO_INTERNAL;
 MonoMethodSignature *mono_metadata_signature_deep_dup (MonoImage *image, MonoMethodSignature *sig) MONO_INTERNAL;
 
-void
+MONO_API void
 mono_image_init_name_cache (MonoImage *image);
 
 gboolean mono_class_is_nullable (MonoClass *klass) MONO_INTERNAL;
 MonoClass *mono_class_get_nullable_param (MonoClass *klass) MONO_INTERNAL;
 
 /* object debugging functions, for use inside gdb */
-void mono_object_describe        (MonoObject *obj);
-void mono_object_describe_fields (MonoObject *obj);
-void mono_value_describe_fields  (MonoClass* klass, const char* addr);
-void mono_class_describe_statics (MonoClass* klass);
+MONO_API void mono_object_describe        (MonoObject *obj);
+MONO_API void mono_object_describe_fields (MonoObject *obj);
+MONO_API void mono_value_describe_fields  (MonoClass* klass, const char* addr);
+MONO_API void mono_class_describe_statics (MonoClass* klass);
 
 /*Enum validation related functions*/
-gboolean
+MONO_API gboolean
 mono_type_is_valid_enum_basetype (MonoType * type);
 
-gboolean
+MONO_API gboolean
 mono_class_is_valid_enum (MonoClass *klass);
 
 MonoType *

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -13,249 +13,249 @@ typedef struct _MonoClassField MonoClassField;
 typedef struct _MonoProperty MonoProperty;
 typedef struct _MonoEvent MonoEvent;
 
-MonoClass *
+MONO_API MonoClass *
 mono_class_get             (MonoImage *image, uint32_t type_token);
 
-MonoClass *
+MONO_API MonoClass *
 mono_class_get_full        (MonoImage *image, uint32_t type_token, MonoGenericContext *context);
 
-mono_bool
+MONO_API mono_bool
 mono_class_init            (MonoClass *klass);
 
-MonoVTable *
+MONO_API MonoVTable *
 mono_class_vtable          (MonoDomain *domain, MonoClass *klass);
 
-MonoClass *
+MONO_API MonoClass *
 mono_class_from_name       (MonoImage *image, const char* name_space, const char *name);
 
-MonoClass *
+MONO_API MonoClass *
 mono_class_from_name_case  (MonoImage *image, const char* name_space, const char *name);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_class_get_method_from_name_flags (MonoClass *klass, const char *name, int param_count, int flags);
 
-MonoClass * 
+MONO_API MonoClass * 
 mono_class_from_typeref    (MonoImage *image, uint32_t type_token);
 
-MonoClass *
+MONO_API MonoClass *
 mono_class_from_generic_parameter (MonoGenericParam *param, MonoImage *image, mono_bool is_mvar);
 
-MonoType*
+MONO_API MonoType*
 mono_class_inflate_generic_type (MonoType *type, MonoGenericContext *context) /* MONO_DEPRECATED */;
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_class_inflate_generic_method (MonoMethod *method, MonoGenericContext *context);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_get_inflated_method (MonoMethod *method);
 
-MonoClassField*
+MONO_API MonoClassField*
 mono_field_from_token      (MonoImage *image, uint32_t token, MonoClass **retklass, MonoGenericContext *context);
 
-MonoClass *
+MONO_API MonoClass *
 mono_bounded_array_class_get (MonoClass *element_class, uint32_t rank, mono_bool bounded);
 
-MonoClass *
+MONO_API MonoClass *
 mono_array_class_get       (MonoClass *element_class, uint32_t rank);
 
-MonoClass *
+MONO_API MonoClass *
 mono_ptr_class_get         (MonoType *type);
 
-MonoClassField *
+MONO_API MonoClassField *
 mono_class_get_field       (MonoClass *klass, uint32_t field_token);
 
-MonoClassField *
+MONO_API MonoClassField *
 mono_class_get_field_from_name (MonoClass *klass, const char *name);
 
-uint32_t
+MONO_API uint32_t
 mono_class_get_field_token (MonoClassField *field);
 
-uint32_t
+MONO_API uint32_t
 mono_class_get_event_token (MonoEvent *event);
 
-MonoProperty*
+MONO_API MonoProperty*
 mono_class_get_property_from_name (MonoClass *klass, const char *name);
 
-uint32_t
+MONO_API uint32_t
 mono_class_get_property_token (MonoProperty *prop);
 
-int32_t
+MONO_API int32_t
 mono_array_element_size    (MonoClass *ac);
 
-int32_t
+MONO_API int32_t
 mono_class_instance_size   (MonoClass *klass);
 
-int32_t
+MONO_API int32_t
 mono_class_array_element_size (MonoClass *klass);
 
-int32_t
+MONO_API int32_t
 mono_class_data_size       (MonoClass *klass);
 
-int32_t
+MONO_API int32_t
 mono_class_value_size      (MonoClass *klass, uint32_t *align);
 
-int32_t
+MONO_API int32_t
 mono_class_min_align       (MonoClass *klass);
 
-MonoClass *
+MONO_API MonoClass *
 mono_class_from_mono_type  (MonoType *type);
 
-mono_bool
+MONO_API mono_bool
 mono_class_is_subclass_of (MonoClass *klass, MonoClass *klassc, 
 						   mono_bool check_interfaces);
 
-mono_bool
+MONO_API mono_bool
 mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass);
 
-void*
+MONO_API void*
 mono_ldtoken               (MonoImage *image, uint32_t token, MonoClass **retclass, MonoGenericContext *context);
 
-char*         
+MONO_API char*         
 mono_type_get_name         (MonoType *type);
 
-MonoType*
+MONO_API MonoType*
 mono_type_get_underlying_type (MonoType *type);
 
 /* MonoClass accessors */
-MonoImage*
+MONO_API MonoImage*
 mono_class_get_image         (MonoClass *klass);
 
-MonoClass*
+MONO_API MonoClass*
 mono_class_get_element_class (MonoClass *klass);
 
-mono_bool
+MONO_API mono_bool
 mono_class_is_valuetype      (MonoClass *klass);
 
-mono_bool
+MONO_API mono_bool
 mono_class_is_enum          (MonoClass *klass);
 
-MonoType*
+MONO_API MonoType*
 mono_class_enum_basetype    (MonoClass *klass);
 
-MonoClass*
+MONO_API MonoClass*
 mono_class_get_parent        (MonoClass *klass);
 
-MonoClass*
+MONO_API MonoClass*
 mono_class_get_nesting_type  (MonoClass *klass);
 
-int
+MONO_API int
 mono_class_get_rank          (MonoClass *klass);
 
-uint32_t
+MONO_API uint32_t
 mono_class_get_flags         (MonoClass *klass);
 
-const char*
+MONO_API const char*
 mono_class_get_name          (MonoClass *klass);
 
-const char*
+MONO_API const char*
 mono_class_get_namespace     (MonoClass *klass);
 
-MonoType*
+MONO_API MonoType*
 mono_class_get_type          (MonoClass *klass);
 
-uint32_t
+MONO_API uint32_t
 mono_class_get_type_token    (MonoClass *klass);
 
-MonoType*
+MONO_API MonoType*
 mono_class_get_byref_type    (MonoClass *klass);
 
-int
+MONO_API int
 mono_class_num_fields        (MonoClass *klass);
 
-int
+MONO_API int
 mono_class_num_methods       (MonoClass *klass);
 
-int
+MONO_API int
 mono_class_num_properties    (MonoClass *klass);
 
-int
+MONO_API int
 mono_class_num_events        (MonoClass *klass);
 
-MonoClassField*
+MONO_API MonoClassField*
 mono_class_get_fields        (MonoClass* klass, void **iter);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_class_get_methods       (MonoClass* klass, void **iter);
 
-MonoProperty*
+MONO_API MonoProperty*
 mono_class_get_properties    (MonoClass* klass, void **iter);
 
-MonoEvent*
+MONO_API MonoEvent*
 mono_class_get_events        (MonoClass* klass, void **iter);
 
-MonoClass*
+MONO_API MonoClass*
 mono_class_get_interfaces    (MonoClass* klass, void **iter);
 
-MonoClass*
+MONO_API MonoClass*
 mono_class_get_nested_types  (MonoClass* klass, void **iter);
 
 /* MonoClassField accessors */
-const char*
+MONO_API const char*
 mono_field_get_name   (MonoClassField *field);
 
-MonoType*
+MONO_API MonoType*
 mono_field_get_type   (MonoClassField *field);
 
-MonoClass*
+MONO_API MonoClass*
 mono_field_get_parent (MonoClassField *field);
 
-uint32_t
+MONO_API uint32_t
 mono_field_get_flags  (MonoClassField *field);
 
-uint32_t
+MONO_API uint32_t
 mono_field_get_offset  (MonoClassField *field);
 
-const char *
+MONO_API const char *
 mono_field_get_data  (MonoClassField *field);
 
 /* MonoProperty acessors */
-const char*
+MONO_API const char*
 mono_property_get_name       (MonoProperty *prop);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_property_get_set_method (MonoProperty *prop);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_property_get_get_method (MonoProperty *prop);
 
-MonoClass*
+MONO_API MonoClass*
 mono_property_get_parent     (MonoProperty *prop);
 
-uint32_t
+MONO_API uint32_t
 mono_property_get_flags      (MonoProperty *prop);
 
 /* MonoEvent accessors */
-const char*
+MONO_API const char*
 mono_event_get_name          (MonoEvent *event);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_event_get_add_method    (MonoEvent *event);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_event_get_remove_method (MonoEvent *event);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_event_get_remove_method (MonoEvent *event);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_event_get_raise_method  (MonoEvent *event);
 
-MonoClass*
+MONO_API MonoClass*
 mono_event_get_parent        (MonoEvent *event);
 
-uint32_t
+MONO_API uint32_t
 mono_event_get_flags         (MonoEvent *event);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_class_get_method_from_name (MonoClass *klass, const char *name, int param_count);
 
-char *
+MONO_API char *
 mono_class_name_from_token (MonoImage *image, uint32_t type_token);
 
-mono_bool
+MONO_API mono_bool
 mono_method_can_access_field (MonoMethod *method, MonoClassField *field);
 
-mono_bool
+MONO_API mono_bool
 mono_method_can_access_method (MonoMethod *method, MonoMethod *called);
 
 MONO_END_DECLS

--- a/mono/metadata/cominterop.h
+++ b/mono/metadata/cominterop.h
@@ -47,10 +47,10 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum,
 										int conv_arg, MonoType **conv_arg_type,
 										MarshalAction action) MONO_INTERNAL;
 
-MonoString * 
+MONO_API MonoString * 
 mono_string_from_bstr (gpointer bstr);
 
-void 
+MONO_API void 
 mono_free_bstr (gpointer bstr);
 
 #endif /* __MONO_COMINTEROP_H__ */

--- a/mono/metadata/debug-helpers.h
+++ b/mono/metadata/debug-helpers.h
@@ -19,28 +19,28 @@ struct MonoDisHelper {
 	void* user_data;
 };
 
-char* mono_disasm_code_one (MonoDisHelper *dh, MonoMethod *method, const mono_byte *ip, const mono_byte** endp);
-char* mono_disasm_code     (MonoDisHelper *dh, MonoMethod *method, const mono_byte *ip, const mono_byte* end);
+MONO_API char* mono_disasm_code_one (MonoDisHelper *dh, MonoMethod *method, const mono_byte *ip, const mono_byte** endp);
+MONO_API char* mono_disasm_code     (MonoDisHelper *dh, MonoMethod *method, const mono_byte *ip, const mono_byte* end);
 
 typedef struct MonoMethodDesc MonoMethodDesc;
 
-char*           mono_type_full_name (MonoType *type);
+MONO_API char*           mono_type_full_name (MonoType *type);
 
-char*           mono_signature_get_desc (MonoMethodSignature *sig, mono_bool include_namespace);
+MONO_API char*           mono_signature_get_desc (MonoMethodSignature *sig, mono_bool include_namespace);
 
-char*           mono_context_get_desc (MonoGenericContext *context);
+MONO_API char*           mono_context_get_desc (MonoGenericContext *context);
 
-MonoMethodDesc* mono_method_desc_new (const char *name, mono_bool include_namespace);
-MonoMethodDesc* mono_method_desc_from_method (MonoMethod *method);
-void            mono_method_desc_free (MonoMethodDesc *desc);
-mono_bool       mono_method_desc_match (MonoMethodDesc *desc, MonoMethod *method);
-mono_bool       mono_method_desc_full_match (MonoMethodDesc *desc, MonoMethod *method);
-MonoMethod*     mono_method_desc_search_in_class (MonoMethodDesc *desc, MonoClass *klass);
-MonoMethod*     mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image);
+MONO_API MonoMethodDesc* mono_method_desc_new (const char *name, mono_bool include_namespace);
+MONO_API MonoMethodDesc* mono_method_desc_from_method (MonoMethod *method);
+MONO_API void            mono_method_desc_free (MonoMethodDesc *desc);
+MONO_API mono_bool       mono_method_desc_match (MonoMethodDesc *desc, MonoMethod *method);
+MONO_API mono_bool       mono_method_desc_full_match (MonoMethodDesc *desc, MonoMethod *method);
+MONO_API MonoMethod*     mono_method_desc_search_in_class (MonoMethodDesc *desc, MonoClass *klass);
+MONO_API MonoMethod*     mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image);
 
-char*           mono_method_full_name (MonoMethod *method, mono_bool signature);
+MONO_API char*           mono_method_full_name (MonoMethod *method, mono_bool signature);
 
-char*           mono_field_full_name (MonoClassField *field);
+MONO_API char*           mono_field_full_name (MonoClassField *field);
 
 MONO_END_DECLS
 

--- a/mono/metadata/debug-mono-symfile.h
+++ b/mono/metadata/debug-mono-symfile.h
@@ -122,43 +122,43 @@ typedef struct {
 
 MONO_BEGIN_DECLS
 
-MonoSymbolFile *
+MONO_API MonoSymbolFile *
 mono_debug_open_mono_symbols       (MonoDebugHandle          *handle,
 				    const uint8_t            *raw_contents,
 				    int                       size,
 				    mono_bool                 in_the_debugger);
 
-void
+MONO_API void
 mono_debug_close_mono_symbol_file  (MonoSymbolFile           *symfile);
 
-mono_bool
+MONO_API mono_bool
 mono_debug_symfile_is_loaded       (MonoSymbolFile           *symfile);
 
-MonoDebugSourceLocation *
+MONO_API MonoDebugSourceLocation *
 mono_debug_symfile_lookup_location (MonoDebugMethodInfo      *minfo,
 				    uint32_t                  offset);
 
-void
+MONO_API void
 mono_debug_symfile_free_location   (MonoDebugSourceLocation  *location);
 
 int32_t
 _mono_debug_address_from_il_offset (MonoDebugMethodJitInfo   *jit,
 				    uint32_t                  il_offset);
 
-MonoDebugMethodInfo *
+MONO_API MonoDebugMethodInfo *
 mono_debug_symfile_lookup_method   (MonoDebugHandle          *handle,
 				    MonoMethod               *method);
 
-MonoDebugLocalsInfo*
+MONO_API MonoDebugLocalsInfo*
 mono_debug_symfile_lookup_locals (MonoDebugMethodInfo *minfo);
 
-void
+MONO_API void
 mono_debug_symfile_free_locals (MonoDebugLocalsInfo *info);
 
-void
+MONO_API void
 mono_debug_symfile_get_line_numbers (MonoDebugMethodInfo *minfo, char **source_file, int *n_il_offsets, int **il_offsets, int **line_numbers);
 
-void
+MONO_API void
 mono_debug_symfile_get_line_numbers_full (MonoDebugMethodInfo *minfo, char **source_file, GPtrArray **source_file_list, int *n_il_offsets, int **il_offsets, int **line_numbers, int **column_numbers, int **source_files);
 
 MONO_END_DECLS

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -608,7 +608,7 @@ MonoImage *mono_assembly_open_from_bundle (const char *filename,
 					   MonoImageOpenStatus *status,
 					   gboolean refonly) MONO_INTERNAL;
 
-void
+MONO_API void
 mono_domain_add_class_static_data (MonoDomain *domain, MonoClass *klass, gpointer data, guint32 *bitmap);
 
 MonoReflectionAssembly *

--- a/mono/metadata/environment.h
+++ b/mono/metadata/environment.h
@@ -14,8 +14,8 @@
 
 MONO_BEGIN_DECLS
 
-extern int32_t mono_environment_exitcode_get (void);
-extern void mono_environment_exitcode_set (int32_t value);
+MONO_API extern int32_t mono_environment_exitcode_get (void);
+MONO_API extern void mono_environment_exitcode_set (int32_t value);
 
 MONO_END_DECLS
 

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -9,140 +9,140 @@
 
 MONO_BEGIN_DECLS
 
-extern MonoException *
+extern MONO_API MonoException *
 mono_exception_from_name               (MonoImage *image, 
 					const char* name_space, 
 					const char *name);
 
-MonoException *
+MONO_API MonoException *
 mono_exception_from_token              (MonoImage *image, uint32_t token);
 
-MonoException *
+MONO_API MonoException *
 mono_exception_from_name_two_strings (MonoImage *image, const char *name_space,
 				      const char *name, MonoString *a1, MonoString *a2);
 
-MonoException *
+MONO_API MonoException *
 mono_exception_from_name_msg	       (MonoImage *image, const char *name_space,
 					const char *name, const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_exception_from_token_two_strings (MonoImage *image, uint32_t token,
 						   MonoString *a1, MonoString *a2);
 
-extern MonoException *
+extern MONO_API MonoException *
 mono_exception_from_name_domain        (MonoDomain *domain, MonoImage *image, 
 					const char* name_space, 
 					const char *name);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_divide_by_zero      (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_security            (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_arithmetic          (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_overflow            (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_null_reference      (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_execution_engine    (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_thread_abort        (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_thread_state        (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_thread_interrupted  (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_serialization       (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_invalid_cast        (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_invalid_operation (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_index_out_of_range  (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_array_type_mismatch (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_type_load           (MonoString *class_name, char *assembly_name);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_missing_method      (const char *class_name, const char *member_name);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_missing_field       (const char *class_name, const char *member_name);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_not_implemented     (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_not_supported       (const char *msg);
 
-MonoException*
+MONO_API MonoException*
 mono_get_exception_argument_null       (const char *arg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_argument            (const char *arg, const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_argument_out_of_range (const char *arg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_io                    (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_file_not_found        (MonoString *fname);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_file_not_found2       (const char *msg, MonoString *fname);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_type_initialization (const char *type_name, MonoException *inner);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_synchronization_lock (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_cannot_unload_appdomain (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_appdomain_unloaded (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_bad_image_format (const char *msg);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_bad_image_format2 (const char *msg, MonoString *fname);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_stack_overflow (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_out_of_memory (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_field_access (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_method_access (void);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_reflection_type_load (MonoArray *types, MonoArray *exceptions);
 
-MonoException *
+MONO_API MonoException *
 mono_get_exception_runtime_wrapped (MonoObject *wrapped_exception);
 
 MONO_END_DECLS

--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -112,10 +112,10 @@ extern void mono_gc_set_stack_end (void *stack_end) MONO_INTERNAL;
 /* only valid after the RECLAIM_START GC event and before RECLAIM_END
  * Not exported in public headers, but can be linked to (unsupported).
  */
-extern gboolean mono_object_is_alive (MonoObject* obj);
-extern gboolean mono_gc_is_finalizer_thread (MonoThread *thread);
-extern gpointer mono_gc_out_of_memory (size_t size);
-extern void     mono_gc_enable_events (void);
+extern MONO_API gboolean mono_object_is_alive (MonoObject* obj);
+extern MONO_API gboolean mono_gc_is_finalizer_thread (MonoThread *thread);
+extern MONO_API gpointer mono_gc_out_of_memory (size_t size);
+extern MONO_API void     mono_gc_enable_events (void);
 
 /* disappearing link functionality */
 void        mono_gc_weak_link_add    (void **link_addr, MonoObject *obj, gboolean track) MONO_INTERNAL;
@@ -146,7 +146,7 @@ typedef void (*MonoGCMarkFunc)     (void **addr);
 typedef void (*MonoGCRootMarkFunc) (void *addr, MonoGCMarkFunc mark_func);
 
 /* Create a descriptor with a user defined marking function */
-void *mono_gc_make_root_descr_user (MonoGCRootMarkFunc marker);
+MONO_API void *mono_gc_make_root_descr_user (MonoGCRootMarkFunc marker);
 
 /* Return whenever user defined marking functions are supported */
 gboolean mono_gc_user_markers_supported (void) MONO_INTERNAL;

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -18,65 +18,65 @@ typedef enum {
 	MONO_IMAGE_IMAGE_INVALID
 } MonoImageOpenStatus;
 
-void          mono_images_init    (void);
-void          mono_images_cleanup (void);
+MONO_API void          mono_images_init    (void);
+MONO_API void          mono_images_cleanup (void);
 
-MonoImage    *mono_image_open     (const char *fname,
+MONO_API MonoImage    *mono_image_open     (const char *fname,
 				   MonoImageOpenStatus *status);
-MonoImage    *mono_image_open_full (const char *fname,
+MONO_API MonoImage    *mono_image_open_full (const char *fname,
 				   MonoImageOpenStatus *status, mono_bool refonly);
-MonoImage    *mono_pe_file_open     (const char *fname,
+MONO_API MonoImage    *mono_pe_file_open     (const char *fname,
 				     MonoImageOpenStatus *status);
-MonoImage    *mono_image_open_from_data (char *data, uint32_t data_len, mono_bool need_copy,
+MONO_API MonoImage    *mono_image_open_from_data (char *data, uint32_t data_len, mono_bool need_copy,
                                          MonoImageOpenStatus *status);
-MonoImage    *mono_image_open_from_data_full (char *data, uint32_t data_len, mono_bool need_copy,
+MONO_API MonoImage    *mono_image_open_from_data_full (char *data, uint32_t data_len, mono_bool need_copy,
                                          MonoImageOpenStatus *status, mono_bool refonly);
-MonoImage    *mono_image_open_from_data_with_name (char *data, uint32_t data_len, mono_bool need_copy,
+MONO_API MonoImage    *mono_image_open_from_data_with_name (char *data, uint32_t data_len, mono_bool need_copy,
                                                    MonoImageOpenStatus *status, mono_bool refonly, const char *name);
-void          mono_image_fixup_vtable (MonoImage *image);
-MonoImage    *mono_image_loaded   (const char *name);
-MonoImage    *mono_image_loaded_full   (const char *name, mono_bool refonly);
-MonoImage    *mono_image_loaded_by_guid (const char *guid);
-MonoImage    *mono_image_loaded_by_guid_full (const char *guid, mono_bool refonly);
-void          mono_image_init     (MonoImage *image);
-void          mono_image_close    (MonoImage *image);
-void          mono_image_addref   (MonoImage *image);
-const char   *mono_image_strerror (MonoImageOpenStatus status);
+MONO_API void          mono_image_fixup_vtable (MonoImage *image);
+MONO_API MonoImage    *mono_image_loaded   (const char *name);
+MONO_API MonoImage    *mono_image_loaded_full   (const char *name, mono_bool refonly);
+MONO_API MonoImage    *mono_image_loaded_by_guid (const char *guid);
+MONO_API MonoImage    *mono_image_loaded_by_guid_full (const char *guid, mono_bool refonly);
+MONO_API void          mono_image_init     (MonoImage *image);
+MONO_API void          mono_image_close    (MonoImage *image);
+MONO_API void          mono_image_addref   (MonoImage *image);
+MONO_API const char   *mono_image_strerror (MonoImageOpenStatus status);
 
-int           mono_image_ensure_section     (MonoImage *image,
+MONO_API int           mono_image_ensure_section     (MonoImage *image,
 					     const char *section);
-int           mono_image_ensure_section_idx (MonoImage *image,
+MONO_API int           mono_image_ensure_section_idx (MonoImage *image,
 					     int section);
 
-uint32_t       mono_image_get_entry_point    (MonoImage *image);
-const char   *mono_image_get_resource       (MonoImage *image, uint32_t offset, uint32_t *size);
-MonoImage*    mono_image_load_file_for_image (MonoImage *image, int fileidx);
+MONO_API uint32_t       mono_image_get_entry_point    (MonoImage *image);
+MONO_API const char   *mono_image_get_resource       (MonoImage *image, uint32_t offset, uint32_t *size);
+MONO_API MonoImage*    mono_image_load_file_for_image (MonoImage *image, int fileidx);
 
-MonoImage*    mono_image_load_module (MonoImage *image, int idx);
+MONO_API MonoImage*    mono_image_load_module (MonoImage *image, int idx);
 
-const char*   mono_image_get_name       (MonoImage *image);
-const char*   mono_image_get_filename   (MonoImage *image);
-const char *  mono_image_get_guid       (MonoImage *image);
-MonoAssembly* mono_image_get_assembly   (MonoImage *image);
-mono_bool     mono_image_is_dynamic     (MonoImage *image);
-char*         mono_image_rva_map        (MonoImage *image, uint32_t rva);
+MONO_API const char*   mono_image_get_name       (MonoImage *image);
+MONO_API const char*   mono_image_get_filename   (MonoImage *image);
+MONO_API const char *  mono_image_get_guid       (MonoImage *image);
+MONO_API MonoAssembly* mono_image_get_assembly   (MonoImage *image);
+MONO_API mono_bool     mono_image_is_dynamic     (MonoImage *image);
+MONO_API char*         mono_image_rva_map        (MonoImage *image, uint32_t rva);
 
-const MonoTableInfo *mono_image_get_table_info (MonoImage *image, int table_id);
-int                  mono_image_get_table_rows (MonoImage *image, int table_id);
-int                  mono_table_info_get_rows  (const MonoTableInfo *table);
+MONO_API const MonoTableInfo *mono_image_get_table_info (MonoImage *image, int table_id);
+MONO_API int                  mono_image_get_table_rows (MonoImage *image, int table_id);
+MONO_API int                  mono_table_info_get_rows  (const MonoTableInfo *table);
 
 /* This actually returns a MonoPEResourceDataEntry *, but declaring it
  * causes an include file loop.
  */
-void*      mono_image_lookup_resource (MonoImage *image, uint32_t res_id,
+MONO_API void*      mono_image_lookup_resource (MonoImage *image, uint32_t res_id,
 					  uint32_t lang_id, mono_unichar2 *name);
 
-const char*   mono_image_get_public_key  (MonoImage *image, uint32_t *size);
-const char*   mono_image_get_strong_name (MonoImage *image, uint32_t *size);
-uint32_t       mono_image_strong_name_position (MonoImage *image, uint32_t *size);
-void          mono_image_add_to_name_cache (MonoImage *image, 
+MONO_API const char*   mono_image_get_public_key  (MonoImage *image, uint32_t *size);
+MONO_API const char*   mono_image_get_strong_name (MonoImage *image, uint32_t *size);
+MONO_API uint32_t       mono_image_strong_name_position (MonoImage *image, uint32_t *size);
+MONO_API void          mono_image_add_to_name_cache (MonoImage *image, 
 			const char *nspace, const char *name, uint32_t idx);
-mono_bool     mono_image_has_authenticode_entry (MonoImage *image);
+MONO_API mono_bool     mono_image_has_authenticode_entry (MonoImage *image);
 
 MONO_END_DECLS
 

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -8,86 +8,86 @@ MONO_BEGIN_DECLS
 
 typedef mono_bool (*MonoStackWalk)     (MonoMethod *method, int32_t native_offset, int32_t il_offset, mono_bool managed, void* data);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_get_method             (MonoImage *image, uint32_t token, MonoClass *klass);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_get_method_full        (MonoImage *image, uint32_t token, MonoClass *klass,
 			     MonoGenericContext *context);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_get_method_constrained (MonoImage *image, uint32_t token, MonoClass *constrained_class,
 			     MonoGenericContext *context, MonoMethod **cil_method);
 
-void               
+MONO_API void               
 mono_free_method           (MonoMethod *method);
 
-MonoMethodSignature*
+MONO_API MonoMethodSignature*
 mono_method_get_signature_full (MonoMethod *method, MonoImage *image, uint32_t token,
 				MonoGenericContext *context);
 
-MonoMethodSignature* 
+MONO_API MonoMethodSignature* 
 mono_method_get_signature  (MonoMethod *method, MonoImage *image, uint32_t token);
 
-MonoMethodSignature* 
+MONO_API MonoMethodSignature* 
 mono_method_signature      (MonoMethod *method);
 
-MonoMethodHeader* 
+MONO_API MonoMethodHeader* 
 mono_method_get_header     (MonoMethod *method);
 
-const char*
+MONO_API const char*
 mono_method_get_name       (MonoMethod *method);
 
-MonoClass*
+MONO_API MonoClass*
 mono_method_get_class      (MonoMethod *method);
 
-uint32_t
+MONO_API uint32_t
 mono_method_get_token      (MonoMethod *method);
 
-uint32_t
+MONO_API uint32_t
 mono_method_get_flags      (MonoMethod *method, uint32_t *iflags);
 
-uint32_t
+MONO_API uint32_t
 mono_method_get_index      (MonoMethod *method);
 
-MonoImage *
+MONO_API MonoImage *
 mono_load_image            (const char *fname, MonoImageOpenStatus *status);
 
-void
+MONO_API void
 mono_add_internal_call     (const char *name, const void* method);
 
-void*
+MONO_API void*
 mono_lookup_internal_call (MonoMethod *method);
 
-const char*
+MONO_API const char*
 mono_lookup_icall_symbol (MonoMethod *m);
 
-void
+MONO_API void
 mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc);
 
-void*
+MONO_API void*
 mono_lookup_pinvoke_call (MonoMethod *method, const char **exc_class, const char **exc_arg);
 
-void
+MONO_API void
 mono_method_get_param_names (MonoMethod *method, const char **names);
 
-uint32_t
+MONO_API uint32_t
 mono_method_get_param_token (MonoMethod *method, int idx);
 
-void
+MONO_API void
 mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs);
 
-mono_bool
+MONO_API mono_bool
 mono_method_has_marshal_info (MonoMethod *method);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_method_get_last_managed  (void);
 
-void
+MONO_API void
 mono_stack_walk         (MonoStackWalk func, void* user_data);
 
 /* Use this if the IL offset is not needed: it's faster */
-void
+MONO_API void
 mono_stack_walk_no_il   (MonoStackWalk func, void* user_data);
 
 MONO_END_DECLS

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -98,7 +98,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 static void 
 mono_struct_delete_old (MonoClass *klass, char *ptr);
 
-void *
+MONO_API void *
 mono_marshal_string_to_utf16 (MonoString *s);
 
 static void *
@@ -145,7 +145,7 @@ mono_marshal_check_domain_image (gint32 domain_id, MonoImage *image);
 static MonoObject *
 mono_remoting_wrapper (MonoMethod *method, gpointer *params);
 
-void
+MONO_API void
 mono_upgrade_remote_class_wrapper (MonoReflectionType *rtype, MonoTransparentProxy *tproxy);
 
 #endif

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -514,16 +514,16 @@ ves_icall_Mono_Interop_ComInteropProxy_AddProxy (gpointer pUnk, MonoComInteropPr
 MonoComInteropProxy*
 ves_icall_Mono_Interop_ComInteropProxy_FindProxy (gpointer pUnk) MONO_INTERNAL;
 
-void
+MONO_API void
 mono_win32_compat_CopyMemory (gpointer dest, gconstpointer source, gsize length);
 
-void
+MONO_API void
 mono_win32_compat_FillMemory (gpointer dest, gsize length, guchar fill);
 
-void
+MONO_API void
 mono_win32_compat_MoveMemory (gpointer dest, gconstpointer source, gsize length);
 
-void
+MONO_API void
 mono_win32_compat_ZeroMemory (gpointer dest, gsize length);
 
 void

--- a/mono/metadata/mempool.h
+++ b/mono/metadata/mempool.h
@@ -7,37 +7,37 @@ MONO_BEGIN_DECLS
 
 typedef struct _MonoMemPool MonoMemPool;
 
-MonoMemPool *
+MONO_API MonoMemPool *
 mono_mempool_new           (void);
 
-MonoMemPool *
+MONO_API MonoMemPool *
 mono_mempool_new_size      (int initial_size);
 
-void
+MONO_API void
 mono_mempool_destroy       (MonoMemPool *pool);
 
-void
+MONO_API void
 mono_mempool_invalidate    (MonoMemPool *pool);
 
-void
+MONO_API void
 mono_mempool_empty         (MonoMemPool *pool);
 
-void
+MONO_API void
 mono_mempool_stats         (MonoMemPool *pool);
 
-void*
+MONO_API void*
 mono_mempool_alloc         (MonoMemPool *pool, unsigned int size);
 
-void*
+MONO_API void*
 mono_mempool_alloc0        (MonoMemPool *pool, unsigned int size);
 
-mono_bool
+MONO_API mono_bool
 mono_mempool_contains_addr (MonoMemPool *pool, void* addr);
 
-char*
+MONO_API char*
 mono_mempool_strdup        (MonoMemPool *pool, const char *s);
 
-uint32_t
+MONO_API uint32_t
 mono_mempool_get_allocated (MonoMemPool *pool);
 
 MONO_END_DECLS

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -588,7 +588,7 @@ mono_metadata_clean_for_image (MonoImage *image) MONO_INTERNAL;
 void
 mono_metadata_clean_generic_classes_for_image (MonoImage *image) MONO_INTERNAL;
 
-void
+MONO_API void
 mono_metadata_cleanup (void);
 
 const char *   mono_meta_table_name              (int table) MONO_INTERNAL;
@@ -608,7 +608,7 @@ mono_metadata_parse_array_full              (MonoImage             *image,
 					     const char            *ptr,
 					     const char           **rptr) MONO_INTERNAL;
 
-MonoType *
+MONO_API MonoType *
 mono_metadata_parse_type_full               (MonoImage             *image,
 					     MonoGenericContainer  *container,
 					     MonoParseTypeMode      mode,
@@ -621,14 +621,14 @@ mono_metadata_parse_signature_full          (MonoImage             *image,
 					     MonoGenericContainer  *generic_container,
 					     guint32                token) MONO_INTERNAL;
 
-MonoMethodSignature *
+MONO_API MonoMethodSignature *
 mono_metadata_parse_method_signature_full   (MonoImage             *image,
 					     MonoGenericContainer  *generic_container,
 					     int                     def,
 					     const char             *ptr,
 					     const char            **rptr);
 
-MonoMethodHeader *
+MONO_API MonoMethodHeader *
 mono_metadata_parse_mh_full                 (MonoImage             *image,
 					     MonoGenericContainer  *container,
 					     const char            *ptr);
@@ -687,7 +687,7 @@ mono_assembly_name_parse_full 		     (const char	   *name,
 					      gboolean *is_version_defined,
 						  gboolean *is_token_defined) MONO_INTERNAL;
 
-guint32 mono_metadata_get_generic_param_row (MonoImage *image, guint32 token, guint32 *owner);
+MONO_API guint32 mono_metadata_get_generic_param_row (MonoImage *image, guint32 token, guint32 *owner);
 
 void mono_unload_interface_ids (MonoBitSet *bitset) MONO_INTERNAL;
 
@@ -702,7 +702,7 @@ mono_get_shared_generic_inst (MonoGenericContainer *container) MONO_INTERNAL;
 int
 mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open) MONO_INTERNAL;
 
-void            mono_type_get_desc (GString *res, MonoType *type, mono_bool include_namespace);
+MONO_API void            mono_type_get_desc (GString *res, MonoType *type, mono_bool include_namespace);
 
 gboolean
 mono_metadata_type_equal_full (MonoType *t1, MonoType *t2, gboolean signature_only) MONO_INTERNAL;
@@ -713,7 +713,7 @@ mono_metadata_parse_marshal_spec_full (MonoImage *image, const char *ptr) MONO_I
 guint	       mono_metadata_generic_inst_hash (gconstpointer data) MONO_INTERNAL;
 gboolean       mono_metadata_generic_inst_equal (gconstpointer ka, gconstpointer kb) MONO_INTERNAL;
 
-void
+MONO_API void
 mono_metadata_field_info_with_mempool (
 					  MonoImage *meta, 
 				      guint32       table_index,

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -198,14 +198,14 @@ typedef struct {
 	} data;
 } MonoMarshalSpec;
 
-void         mono_metadata_init (void);
+MONO_API void         mono_metadata_init (void);
 
-void         mono_metadata_decode_row (const MonoTableInfo   *t,
+MONO_API void         mono_metadata_decode_row (const MonoTableInfo   *t,
 				       int                    idx,
 				       uint32_t               *res,
 				       int                    res_size);
 
-uint32_t      mono_metadata_decode_row_col (const MonoTableInfo *t, 
+MONO_API uint32_t      mono_metadata_decode_row_col (const MonoTableInfo *t, 
 					   int            idx, 
 					   unsigned int          col);
 
@@ -216,61 +216,61 @@ uint32_t      mono_metadata_decode_row_col (const MonoTableInfo *t,
 #define mono_metadata_table_size(bitfield,table) ((((bitfield) >> ((table)*2)) & 0x3) + 1)
 #define mono_metadata_table_count(bitfield) ((bitfield) >> 24)
 
-int mono_metadata_compute_size (MonoImage   *meta,
+MONO_API int mono_metadata_compute_size (MonoImage   *meta,
                                 int             tableindex,
                                 uint32_t        *result_bitfield);
 
 /*
  *
  */
-const char    *mono_metadata_locate        (MonoImage *meta, int table, int idx);
-const char    *mono_metadata_locate_token  (MonoImage *meta, uint32_t token);
+MONO_API const char    *mono_metadata_locate        (MonoImage *meta, int table, int idx);
+MONO_API const char    *mono_metadata_locate_token  (MonoImage *meta, uint32_t token);
 					   
-const char    *mono_metadata_string_heap   (MonoImage *meta, uint32_t table_index);
-const char    *mono_metadata_blob_heap     (MonoImage *meta, uint32_t table_index);
-const char    *mono_metadata_user_string   (MonoImage *meta, uint32_t table_index);
-const char    *mono_metadata_guid_heap     (MonoImage *meta, uint32_t table_index);
+MONO_API const char    *mono_metadata_string_heap   (MonoImage *meta, uint32_t table_index);
+MONO_API const char    *mono_metadata_blob_heap     (MonoImage *meta, uint32_t table_index);
+MONO_API const char    *mono_metadata_user_string   (MonoImage *meta, uint32_t table_index);
+MONO_API const char    *mono_metadata_guid_heap     (MonoImage *meta, uint32_t table_index);
 
-uint32_t mono_metadata_typedef_from_field  (MonoImage *meta, uint32_t table_index);
-uint32_t mono_metadata_typedef_from_method (MonoImage *meta, uint32_t table_index);
-uint32_t mono_metadata_nested_in_typedef   (MonoImage *meta, uint32_t table_index);
-uint32_t mono_metadata_nesting_typedef     (MonoImage *meta, uint32_t table_index, uint32_t start_index);
+MONO_API uint32_t mono_metadata_typedef_from_field  (MonoImage *meta, uint32_t table_index);
+MONO_API uint32_t mono_metadata_typedef_from_method (MonoImage *meta, uint32_t table_index);
+MONO_API uint32_t mono_metadata_nested_in_typedef   (MonoImage *meta, uint32_t table_index);
+MONO_API uint32_t mono_metadata_nesting_typedef     (MonoImage *meta, uint32_t table_index, uint32_t start_index);
 
-MonoClass** mono_metadata_interfaces_from_typedef (MonoImage *meta, uint32_t table_index, unsigned int *count);
+MONO_API MonoClass** mono_metadata_interfaces_from_typedef (MonoImage *meta, uint32_t table_index, unsigned int *count);
 
-uint32_t     mono_metadata_events_from_typedef     (MonoImage *meta, uint32_t table_index, unsigned int *end_idx);
-uint32_t     mono_metadata_methods_from_event      (MonoImage *meta, uint32_t table_index, unsigned int *end);
-uint32_t     mono_metadata_properties_from_typedef (MonoImage *meta, uint32_t table_index, unsigned int *end);
-uint32_t     mono_metadata_methods_from_property   (MonoImage *meta, uint32_t table_index, unsigned int *end);
-uint32_t     mono_metadata_packing_from_typedef    (MonoImage *meta, uint32_t table_index, uint32_t *packing, uint32_t *size);
-const char* mono_metadata_get_marshal_info        (MonoImage *meta, uint32_t idx, mono_bool is_field);
-uint32_t     mono_metadata_custom_attrs_from_index (MonoImage *meta, uint32_t cattr_index);
+MONO_API uint32_t     mono_metadata_events_from_typedef     (MonoImage *meta, uint32_t table_index, unsigned int *end_idx);
+MONO_API uint32_t     mono_metadata_methods_from_event      (MonoImage *meta, uint32_t table_index, unsigned int *end);
+MONO_API uint32_t     mono_metadata_properties_from_typedef (MonoImage *meta, uint32_t table_index, unsigned int *end);
+MONO_API uint32_t     mono_metadata_methods_from_property   (MonoImage *meta, uint32_t table_index, unsigned int *end);
+MONO_API uint32_t     mono_metadata_packing_from_typedef    (MonoImage *meta, uint32_t table_index, uint32_t *packing, uint32_t *size);
+MONO_API const char* mono_metadata_get_marshal_info        (MonoImage *meta, uint32_t idx, mono_bool is_field);
+MONO_API uint32_t     mono_metadata_custom_attrs_from_index (MonoImage *meta, uint32_t cattr_index);
 
-MonoMarshalSpec *mono_metadata_parse_marshal_spec (MonoImage *image, const char *ptr);
+MONO_API MonoMarshalSpec *mono_metadata_parse_marshal_spec (MonoImage *image, const char *ptr);
 
-void mono_metadata_free_marshal_spec (MonoMarshalSpec *spec);
+MONO_API void mono_metadata_free_marshal_spec (MonoMarshalSpec *spec);
 
-uint32_t     mono_metadata_implmap_from_method     (MonoImage *meta, uint32_t method_idx);
+MONO_API uint32_t     mono_metadata_implmap_from_method     (MonoImage *meta, uint32_t method_idx);
 
-void        mono_metadata_field_info (MonoImage *meta, 
+MONO_API void        mono_metadata_field_info (MonoImage *meta, 
 				      uint32_t       table_index,
 				      uint32_t      *offset,
 				      uint32_t      *rva,
 				      MonoMarshalSpec **marshal_spec);
 
-uint32_t     mono_metadata_get_constant_index (MonoImage *meta, uint32_t token, uint32_t hint);
+MONO_API uint32_t     mono_metadata_get_constant_index (MonoImage *meta, uint32_t token, uint32_t hint);
 
 /*
  * Functions to extract information from the Blobs
  */
-uint32_t mono_metadata_decode_value     (const char            *ptr,
+MONO_API uint32_t mono_metadata_decode_value     (const char            *ptr,
                                         const char           **rptr);
-int32_t mono_metadata_decode_signed_value (const char *ptr, const char **rptr);
+MONO_API int32_t mono_metadata_decode_signed_value (const char *ptr, const char **rptr);
 
-uint32_t mono_metadata_decode_blob_size (const char            *ptr,
+MONO_API uint32_t mono_metadata_decode_blob_size (const char            *ptr,
                                         const char           **rptr);
 
-void mono_metadata_encode_value (uint32_t value, char *bug, char **endbuf);
+MONO_API void mono_metadata_encode_value (uint32_t value, char *bug, char **endbuf);
 
 #define MONO_OFFSET_IN_CLAUSE(clause,offset) \
 	((clause)->try_offset <= (offset) && (offset) < ((clause)->try_offset + (clause)->try_len))
@@ -329,133 +329,133 @@ typedef enum {
 	MONO_PARSE_FIELD
 } MonoParseTypeMode;
 
-mono_bool
+MONO_API mono_bool
 mono_type_is_byref       (MonoType *type);
 
-int
+MONO_API int
 mono_type_get_type       (MonoType *type);
 
 /* For MONO_TYPE_FNPTR */
-MonoMethodSignature*
+MONO_API MonoMethodSignature*
 mono_type_get_signature  (MonoType *type);
 
 /* For MONO_TYPE_CLASS, VALUETYPE */
-MonoClass*
+MONO_API MonoClass*
 mono_type_get_class      (MonoType *type);
 
-MonoArrayType*
+MONO_API MonoArrayType*
 mono_type_get_array_type (MonoType *type);
 
 /* For MONO_TYPE_PTR */
-MonoType*
+MONO_API MonoType*
 mono_type_get_ptr_type (MonoType *type);
 
-MonoClass*
+MONO_API MonoClass*
 mono_type_get_modifiers  (MonoType *type, mono_bool *is_required, void **iter);
 
-mono_bool mono_type_is_struct    (MonoType *type);
-mono_bool mono_type_is_void      (MonoType *type);
-mono_bool mono_type_is_pointer   (MonoType *type);
-mono_bool mono_type_is_reference (MonoType *type);
+MONO_API mono_bool mono_type_is_struct    (MonoType *type);
+MONO_API mono_bool mono_type_is_void      (MonoType *type);
+MONO_API mono_bool mono_type_is_pointer   (MonoType *type);
+MONO_API mono_bool mono_type_is_reference (MonoType *type);
 
-MonoType*
+MONO_API MonoType*
 mono_signature_get_return_type (MonoMethodSignature *sig);
 
-MonoType*
+MONO_API MonoType*
 mono_signature_get_params      (MonoMethodSignature *sig, void **iter);
 
-uint32_t
+MONO_API uint32_t
 mono_signature_get_param_count (MonoMethodSignature *sig);
 
-uint32_t
+MONO_API uint32_t
 mono_signature_get_call_conv   (MonoMethodSignature *sig);
 
-int
+MONO_API int
 mono_signature_vararg_start    (MonoMethodSignature *sig);
 
-mono_bool
+MONO_API mono_bool
 mono_signature_is_instance     (MonoMethodSignature *sig);
 
-mono_bool
+MONO_API mono_bool
 mono_signature_explicit_this   (MonoMethodSignature *sig);
 
-uint32_t     mono_metadata_parse_typedef_or_ref (MonoImage      *m,
+MONO_API uint32_t     mono_metadata_parse_typedef_or_ref (MonoImage      *m,
                                                 const char      *ptr,
                                                 const char     **rptr);
-int            mono_metadata_parse_custom_mod  (MonoImage      *m,
+MONO_API int            mono_metadata_parse_custom_mod  (MonoImage      *m,
 						MonoCustomMod   *dest,
 						const char      *ptr,
 						const char     **rptr);
-MonoArrayType *mono_metadata_parse_array       (MonoImage      *m,
+MONO_API MonoArrayType *mono_metadata_parse_array       (MonoImage      *m,
 						const char      *ptr,
 						const char     **rptr);
-void           mono_metadata_free_array        (MonoArrayType     *array);
-MonoType      *mono_metadata_parse_type        (MonoImage      *m,
+MONO_API void           mono_metadata_free_array        (MonoArrayType     *array);
+MONO_API MonoType      *mono_metadata_parse_type        (MonoImage      *m,
 						MonoParseTypeMode  mode,
 						short              opt_attrs,
 						const char        *ptr,
 						const char       **rptr);
-MonoType      *mono_metadata_parse_param       (MonoImage      *m,
+MONO_API MonoType      *mono_metadata_parse_param       (MonoImage      *m,
 						const char      *ptr,
 						const char      **rptr);
-MonoType      *mono_metadata_parse_ret_type    (MonoImage      *m,
+MONO_API MonoType      *mono_metadata_parse_ret_type    (MonoImage      *m,
 						const char      *ptr,
 						const char      **rptr);
-MonoType      *mono_metadata_parse_field_type  (MonoImage      *m,
+MONO_API MonoType      *mono_metadata_parse_field_type  (MonoImage      *m,
 		                                short            field_flags,
 						const char      *ptr,
 						const char      **rptr);
-MonoType      *mono_type_create_from_typespec  (MonoImage        *image, 
+MONO_API MonoType      *mono_type_create_from_typespec  (MonoImage        *image, 
 					        uint32_t           type_spec);
-void           mono_metadata_free_type         (MonoType        *type);
-int            mono_type_size                  (MonoType        *type, 
+MONO_API void           mono_metadata_free_type         (MonoType        *type);
+MONO_API int            mono_type_size                  (MonoType        *type, 
 						int             *alignment);
-int            mono_type_stack_size            (MonoType        *type, 
+MONO_API int            mono_type_stack_size            (MonoType        *type, 
 						int             *alignment);
 
-mono_bool       mono_type_generic_inst_is_valuetype      (MonoType *type);
-mono_bool       mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass);
-unsigned int          mono_metadata_generic_class_hash  (MonoGenericClass *gclass);
-mono_bool       mono_metadata_generic_class_equal (MonoGenericClass *g1, MonoGenericClass *g2);
+MONO_API mono_bool       mono_type_generic_inst_is_valuetype      (MonoType *type);
+MONO_API mono_bool       mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass);
+MONO_API unsigned int          mono_metadata_generic_class_hash  (MonoGenericClass *gclass);
+MONO_API mono_bool       mono_metadata_generic_class_equal (MonoGenericClass *g1, MonoGenericClass *g2);
 
-unsigned int          mono_metadata_type_hash         (MonoType *t1);
-mono_bool       mono_metadata_type_equal        (MonoType *t1, MonoType *t2);
+MONO_API unsigned int          mono_metadata_type_hash         (MonoType *t1);
+MONO_API mono_bool       mono_metadata_type_equal        (MonoType *t1, MonoType *t2);
 
-MonoMethodSignature  *mono_metadata_signature_alloc (MonoImage *image, uint32_t nparams);
+MONO_API MonoMethodSignature  *mono_metadata_signature_alloc (MonoImage *image, uint32_t nparams);
 
-MonoMethodSignature  *mono_metadata_signature_dup (MonoMethodSignature *sig);
+MONO_API MonoMethodSignature  *mono_metadata_signature_dup (MonoMethodSignature *sig);
 
-MonoMethodSignature  *mono_metadata_parse_signature (MonoImage *image, 
+MONO_API MonoMethodSignature  *mono_metadata_parse_signature (MonoImage *image, 
 						     uint32_t    token);
 
-MonoMethodSignature  *mono_metadata_parse_method_signature (MonoImage            *m,
+MONO_API MonoMethodSignature  *mono_metadata_parse_method_signature (MonoImage            *m,
                                                             int                    def,
                                                             const char            *ptr,
                                                             const char           **rptr);
-void                  mono_metadata_free_method_signature  (MonoMethodSignature   *method);
+MONO_API void                  mono_metadata_free_method_signature  (MonoMethodSignature   *method);
 
-mono_bool          mono_metadata_signature_equal (MonoMethodSignature *sig1, 
+MONO_API mono_bool          mono_metadata_signature_equal (MonoMethodSignature *sig1, 
 						 MonoMethodSignature *sig2);
 
-unsigned int             mono_signature_hash (MonoMethodSignature *sig);
+MONO_API unsigned int             mono_signature_hash (MonoMethodSignature *sig);
 
-MonoMethodHeader *mono_metadata_parse_mh (MonoImage *m, const char *ptr);
-void              mono_metadata_free_mh  (MonoMethodHeader *mh);
+MONO_API MonoMethodHeader *mono_metadata_parse_mh (MonoImage *m, const char *ptr);
+MONO_API void              mono_metadata_free_mh  (MonoMethodHeader *mh);
 
 /* MonoMethodHeader acccessors */
-const unsigned char*
+MONO_API const unsigned char*
 mono_method_header_get_code (MonoMethodHeader *header, uint32_t* code_size, uint32_t* max_stack);
 
-MonoType**
+MONO_API MonoType**
 mono_method_header_get_locals (MonoMethodHeader *header, uint32_t* num_locals, mono_bool *init_locals);
 
-int
+MONO_API int
 mono_method_header_get_num_clauses (MonoMethodHeader *header);
 
-int
+MONO_API int
 mono_method_header_get_clauses (MonoMethodHeader *header, MonoMethod *method, void **iter, MonoExceptionClause *clause);
 
-uint32_t 
+MONO_API uint32_t 
 mono_type_to_unmanaged (MonoType *type, MonoMarshalSpec *mspec, 
 			mono_bool as_field, mono_bool unicode, MonoMarshalConv *conv);
 
@@ -477,20 +477,20 @@ mono_type_to_unmanaged (MonoType *type, MonoMarshalSpec *mspec,
 
 #define mono_metadata_token_code(token) ((token & 0xff000000))
 
-uint32_t mono_metadata_token_from_dor (uint32_t dor_index);
+MONO_API uint32_t mono_metadata_token_from_dor (uint32_t dor_index);
 
-char *mono_guid_to_string (const uint8_t *guid);
+MONO_API char *mono_guid_to_string (const uint8_t *guid);
 
-uint32_t mono_metadata_declsec_from_index (MonoImage *meta, uint32_t idx);
+MONO_API uint32_t mono_metadata_declsec_from_index (MonoImage *meta, uint32_t idx);
 
-uint32_t mono_metadata_translate_token_index (MonoImage *image, int table, uint32_t idx);
+MONO_API uint32_t mono_metadata_translate_token_index (MonoImage *image, int table, uint32_t idx);
 
-void    mono_metadata_decode_table_row (MonoImage *image, int table,
+MONO_API void    mono_metadata_decode_table_row (MonoImage *image, int table,
 				       int                    idx,
 				       uint32_t               *res,
 				       int                    res_size);
 
-uint32_t      mono_metadata_decode_table_row_col (MonoImage *image, int table,
+MONO_API uint32_t      mono_metadata_decode_table_row_col (MonoImage *image, int table,
 					   int            idx, 
 					   unsigned int          col);
 

--- a/mono/metadata/monitor.h
+++ b/mono/metadata/monitor.h
@@ -16,7 +16,7 @@
 
 G_BEGIN_DECLS
 
-void mono_locks_dump (gboolean include_untaken);
+MONO_API void mono_locks_dump (gboolean include_untaken);
 
 void mono_monitor_init (void) MONO_INTERNAL;
 void mono_monitor_cleanup (void) MONO_INTERNAL;

--- a/mono/metadata/mono-config.h
+++ b/mono/metadata/mono-config.h
@@ -13,17 +13,17 @@
 
 MONO_BEGIN_DECLS
 
-const char* mono_get_config_dir (void);
-void        mono_set_config_dir (const char *dir);
+MONO_API const char* mono_get_config_dir (void);
+MONO_API void        mono_set_config_dir (const char *dir);
 
-const char* mono_get_machine_config (void);
+MONO_API const char* mono_get_machine_config (void);
 
-void mono_config_cleanup      (void);
-void mono_config_parse        (const char *filename);
-void mono_config_for_assembly (MonoImage *assembly);
-void mono_config_parse_memory (const char *buffer);
+MONO_API void mono_config_cleanup      (void);
+MONO_API void mono_config_parse        (const char *filename);
+MONO_API void mono_config_for_assembly (MonoImage *assembly);
+MONO_API void mono_config_parse_memory (const char *buffer);
 
-const char* mono_config_string_for_assembly_file (const char *filename);
+MONO_API const char* mono_config_string_for_assembly_file (const char *filename);
 
 MONO_END_DECLS
 

--- a/mono/metadata/mono-debug-debugger.h
+++ b/mono/metadata/mono-debug-debugger.h
@@ -50,42 +50,42 @@ extern volatile gint32 _mono_debugger_interruption_request;
 
 extern void (*mono_debugger_event_handler) (MonoDebuggerEvent event, guint64 data, guint64 arg);
 
-void            mono_debugger_initialize                    (gboolean use_debugger);
-void            mono_debugger_cleanup                       (void);
+MONO_API void            mono_debugger_initialize                    (gboolean use_debugger);
+MONO_API void            mono_debugger_cleanup                       (void);
 
-void            mono_debugger_lock                          (void);
-void            mono_debugger_unlock                        (void);
-void            mono_debugger_event                         (MonoDebuggerEvent event, guint64 data, guint64 arg);
+MONO_API void            mono_debugger_lock                          (void);
+MONO_API void            mono_debugger_unlock                        (void);
+MONO_API void            mono_debugger_event                         (MonoDebuggerEvent event, guint64 data, guint64 arg);
 
-gchar *
+MONO_API gchar *
 mono_debugger_check_runtime_version (const char *filename);
 
-void
+MONO_API void
 mono_debugger_class_initialized (MonoClass *klass);
 
-void
+MONO_API void
 mono_debugger_check_interruption (void);
 
-void
+MONO_API void
 mono_debugger_event_create_appdomain (MonoDomain *domain, gchar *shadow_path);
 
-void
+MONO_API void
 mono_debugger_event_unload_appdomain (MonoDomain *domain);
 
-MonoDebugMethodAddressList *
+MONO_API MonoDebugMethodAddressList *
 mono_debugger_insert_method_breakpoint (MonoMethod *method, guint64 idx);
 
-int
+MONO_API int
 mono_debugger_remove_method_breakpoint (guint64 index);
 
-void
+MONO_API void
 mono_debugger_check_breakpoints (MonoMethod *method, MonoDebugMethodAddress *debug_info);
 
-MonoClass *
+MONO_API MonoClass *
 mono_debugger_register_class_init_callback (MonoImage *image, const gchar *full_name,
 					    guint32 token, guint32 index);
 
-void
+MONO_API void
 mono_debugger_remove_class_init_callback (int index);
 
 #endif /* __MONO_DEBUG_DEBUGGER_H__ */

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -148,59 +148,59 @@ extern MonoDebugFormat mono_debug_format;
 extern int32_t mono_debug_debugger_version;
 extern int32_t _mono_debug_using_mono_debugger;
 
-void mono_debug_list_add (MonoDebugList **list, const void* data);
-void mono_debug_list_remove (MonoDebugList **list, const void* data);
+MONO_API void mono_debug_list_add (MonoDebugList **list, const void* data);
+MONO_API void mono_debug_list_remove (MonoDebugList **list, const void* data);
 
-void mono_debug_init (MonoDebugFormat format);
-void mono_debug_open_image_from_memory (MonoImage *image, const mono_byte *raw_contents, int size);
-void mono_debug_cleanup (void);
+MONO_API void mono_debug_init (MonoDebugFormat format);
+MONO_API void mono_debug_open_image_from_memory (MonoImage *image, const mono_byte *raw_contents, int size);
+MONO_API void mono_debug_cleanup (void);
 
-void mono_debug_close_image (MonoImage *image);
+MONO_API void mono_debug_close_image (MonoImage *image);
 
-void mono_debug_domain_unload (MonoDomain *domain);
-void mono_debug_domain_create (MonoDomain *domain);
+MONO_API void mono_debug_domain_unload (MonoDomain *domain);
+MONO_API void mono_debug_domain_create (MonoDomain *domain);
 
-mono_bool mono_debug_using_mono_debugger (void);
+MONO_API mono_bool mono_debug_using_mono_debugger (void);
 
-MonoDebugMethodAddress *
+MONO_API MonoDebugMethodAddress *
 mono_debug_add_method (MonoMethod *method, MonoDebugMethodJitInfo *jit, MonoDomain *domain);
 
-void
+MONO_API void
 mono_debug_remove_method (MonoMethod *method, MonoDomain *domain);
 
-MonoDebugMethodInfo *
+MONO_API MonoDebugMethodInfo *
 mono_debug_lookup_method (MonoMethod *method);
 
-MonoDebugMethodAddressList *
+MONO_API MonoDebugMethodAddressList *
 mono_debug_lookup_method_addresses (MonoMethod *method);
 
-MonoDebugMethodJitInfo*
+MONO_API MonoDebugMethodJitInfo*
 mono_debug_find_method (MonoMethod *method, MonoDomain *domain);
 
-void
+MONO_API void
 mono_debug_free_method_jit_info (MonoDebugMethodJitInfo *jit);
 
 
-void
+MONO_API void
 mono_debug_add_delegate_trampoline (void* code, int size);
 
-MonoDebugLocalsInfo*
+MONO_API MonoDebugLocalsInfo*
 mono_debug_lookup_locals (MonoMethod *method);
 
 /*
  * Line number support.
  */
 
-MonoDebugSourceLocation *
+MONO_API MonoDebugSourceLocation *
 mono_debug_lookup_source_location (MonoMethod *method, uint32_t address, MonoDomain *domain);
 
-int32_t
+MONO_API int32_t
 mono_debug_il_offset_from_address (MonoMethod *method, MonoDomain *domain, uint32_t native_offset);
 
-void
+MONO_API void
 mono_debug_free_source_location (MonoDebugSourceLocation *location);
 
-char *
+MONO_API char *
 mono_debug_print_stack_frame (MonoMethod *method, uint32_t native_offset, MonoDomain *domain);
 
 /*
@@ -209,11 +209,11 @@ mono_debug_print_stack_frame (MonoMethod *method, uint32_t native_offset, MonoDo
  * These methods are used by the JIT while running inside the Mono Debugger.
  */
 
-int             mono_debugger_method_has_breakpoint       (MonoMethod *method);
-int             mono_debugger_insert_breakpoint           (const char *method_name, mono_bool include_namespace);
+MONO_API int             mono_debugger_method_has_breakpoint       (MonoMethod *method);
+MONO_API int             mono_debugger_insert_breakpoint           (const char *method_name, mono_bool include_namespace);
 
-void mono_set_is_debugger_attached (mono_bool attached);
-mono_bool mono_is_debugger_attached (void);
+MONO_API void mono_set_is_debugger_attached (mono_bool attached);
+MONO_API mono_bool mono_is_debugger_attached (void);
 
 MONO_END_DECLS
 

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -11,15 +11,15 @@ MONO_BEGIN_DECLS
 
 typedef int (*MonoGCReferences) (MonoObject *obj, MonoClass *klass, uintptr_t size, uintptr_t num, MonoObject **refs, uintptr_t *offsets, void *data);
 
-void   mono_gc_collect         (int generation);
-int    mono_gc_max_generation  (void);
-int    mono_gc_get_generation  (MonoObject *object);
-int    mono_gc_collection_count (int generation);
-int64_t mono_gc_get_used_size   (void);
-int64_t mono_gc_get_heap_size   (void);
-int    mono_gc_invoke_finalizers (void);
+MONO_API void   mono_gc_collect         (int generation);
+MONO_API int    mono_gc_max_generation  (void);
+MONO_API int    mono_gc_get_generation  (MonoObject *object);
+MONO_API int    mono_gc_collection_count (int generation);
+MONO_API int64_t mono_gc_get_used_size   (void);
+MONO_API int64_t mono_gc_get_heap_size   (void);
+MONO_API int    mono_gc_invoke_finalizers (void);
 /* heap walking is only valid in the pre-stop-world event callback */
-int    mono_gc_walk_heap        (int flags, MonoGCReferences callback, void *data);
+MONO_API int    mono_gc_walk_heap        (int flags, MonoGCReferences callback, void *data);
 
 MONO_END_DECLS
 

--- a/mono/metadata/mono-hash.h
+++ b/mono/metadata/mono-hash.h
@@ -34,6 +34,7 @@
  */
 
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
 G_BEGIN_DECLS
 
@@ -52,51 +53,51 @@ typedef enum {
 
 /* Hash tables
  */
-MonoGHashTable* mono_g_hash_table_new		   (GHashFunc	    hash_func,
+MONO_API MonoGHashTable* mono_g_hash_table_new		   (GHashFunc	    hash_func,
 					    GEqualFunc	    key_equal_func);
-MonoGHashTable* mono_g_hash_table_new_type		   (GHashFunc	    hash_func,
+MONO_API MonoGHashTable* mono_g_hash_table_new_type		   (GHashFunc	    hash_func,
 					    GEqualFunc	    key_equal_func,
 					    MonoGHashGCType type);
-MonoGHashTable* mono_g_hash_table_new_full      	   (GHashFunc	    hash_func,
+MONO_API MonoGHashTable* mono_g_hash_table_new_full      	   (GHashFunc	    hash_func,
 					    GEqualFunc	    key_equal_func,
 					    GDestroyNotify  key_destroy_func,
 					    GDestroyNotify  value_destroy_func);
-void	    mono_g_hash_table_destroy	   (MonoGHashTable	   *hash_table);
-void	    mono_g_hash_table_insert		   (MonoGHashTable	   *hash_table,
+MONO_API void	    mono_g_hash_table_destroy	   (MonoGHashTable	   *hash_table);
+MONO_API void	    mono_g_hash_table_insert		   (MonoGHashTable	   *hash_table,
 					    gpointer	    key,
 					    gpointer	    value);
-void        mono_g_hash_table_replace           (MonoGHashTable     *hash_table,
+MONO_API void        mono_g_hash_table_replace           (MonoGHashTable     *hash_table,
 					    gpointer	    key,
 					    gpointer	    value);
-gboolean    mono_g_hash_table_remove		   (MonoGHashTable	   *hash_table,
+MONO_API gboolean    mono_g_hash_table_remove		   (MonoGHashTable	   *hash_table,
 					    gconstpointer   key);
-gboolean    mono_g_hash_table_steal             (MonoGHashTable     *hash_table,
+MONO_API gboolean    mono_g_hash_table_steal             (MonoGHashTable     *hash_table,
 					    gconstpointer   key);
-gpointer    mono_g_hash_table_lookup		   (MonoGHashTable	   *hash_table,
+MONO_API gpointer    mono_g_hash_table_lookup		   (MonoGHashTable	   *hash_table,
 					    gconstpointer   key);
-gboolean    mono_g_hash_table_lookup_extended   (MonoGHashTable	   *hash_table,
+MONO_API gboolean    mono_g_hash_table_lookup_extended   (MonoGHashTable	   *hash_table,
 					    gconstpointer   lookup_key,
 					    gpointer	   *orig_key,
 					    gpointer	   *value);
-void	    mono_g_hash_table_foreach	   (MonoGHashTable	   *hash_table,
+MONO_API void	    mono_g_hash_table_foreach	   (MonoGHashTable	   *hash_table,
 					    GHFunc	    func,
 					    gpointer	    user_data);
-guint	    mono_g_hash_table_foreach_remove	   (MonoGHashTable	   *hash_table,
+MONO_API guint	    mono_g_hash_table_foreach_remove	   (MonoGHashTable	   *hash_table,
 					    GHRFunc	    func,
 					    gpointer	    user_data);
-guint	    mono_g_hash_table_foreach_steal	   (MonoGHashTable	   *hash_table,
+MONO_API guint	    mono_g_hash_table_foreach_steal	   (MonoGHashTable	   *hash_table,
 					    GHRFunc	    func,
 					    gpointer	    user_data);
-gpointer    mono_g_hash_table_find (MonoGHashTable *hash_table,
+MONO_API gpointer    mono_g_hash_table_find (MonoGHashTable *hash_table,
 									GHRFunc predicate,
 									gpointer user_data);
-guint	    mono_g_hash_table_size		   (MonoGHashTable	   *hash_table);
+MONO_API guint	    mono_g_hash_table_size		   (MonoGHashTable	   *hash_table);
 
-void        mono_g_hash_table_remap (MonoGHashTable *hash_table,
+MONO_API void        mono_g_hash_table_remap (MonoGHashTable *hash_table,
 									 MonoGRemapperFunc func,
 									 gpointer user_data);
 
-void        mono_g_hash_table_print_stats (MonoGHashTable *table);
+MONO_API void        mono_g_hash_table_print_stats (MonoGHashTable *table);
 
 G_END_DECLS
 

--- a/mono/metadata/mono-mlist.h
+++ b/mono/metadata/mono-mlist.h
@@ -8,16 +8,16 @@
 #include <mono/metadata/object.h>
 
 typedef struct _MonoMList MonoMList;
-MonoMList*  mono_mlist_alloc       (MonoObject *data);
-MonoObject* mono_mlist_get_data    (MonoMList* list);
-void        mono_mlist_set_data    (MonoMList* list, MonoObject *data);
-MonoMList*  mono_mlist_set_next    (MonoMList* list, MonoMList *next);
-int         mono_mlist_length      (MonoMList* list);
-MonoMList*  mono_mlist_next        (MonoMList* list);
-MonoMList*  mono_mlist_last        (MonoMList* list);
-MonoMList*  mono_mlist_prepend     (MonoMList* list, MonoObject *data);
-MonoMList*  mono_mlist_append      (MonoMList* list, MonoObject *data);
-MonoMList*  mono_mlist_remove_item (MonoMList* list, MonoMList *item);
+MONO_API MonoMList*  mono_mlist_alloc       (MonoObject *data);
+MONO_API MonoObject* mono_mlist_get_data    (MonoMList* list);
+MONO_API void        mono_mlist_set_data    (MonoMList* list, MonoObject *data);
+MONO_API MonoMList*  mono_mlist_set_next    (MonoMList* list, MonoMList *next);
+MONO_API int         mono_mlist_length      (MonoMList* list);
+MONO_API MonoMList*  mono_mlist_next        (MonoMList* list);
+MONO_API MonoMList*  mono_mlist_last        (MonoMList* list);
+MONO_API MonoMList*  mono_mlist_prepend     (MonoMList* list, MonoObject *data);
+MONO_API MonoMList*  mono_mlist_append      (MonoMList* list, MonoObject *data);
+MONO_API MonoMList*  mono_mlist_remove_item (MonoMList* list, MonoMList *item);
 
 #endif /* __MONO_METADATA_MONO_MLIST_H__ */
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1584,7 +1584,7 @@ void
 mono_field_static_get_value_for_thread (MonoInternalThread *thread, MonoVTable *vt, MonoClassField *field, void *value) MONO_INTERNAL;
 
 /* exported, used by the debugger */
-void *
+MONO_API void *
 mono_vtable_get_static_field_data (MonoVTable *vt);
 
 char *

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -65,231 +65,231 @@ typedef void	    (*MonoMainThreadFunc)    (void* user_data);
 		mono_gc_wbarrier_arrayref_copy (__p, __s, (count));	\
 	} while (0)
 
-mono_unichar2 *mono_string_chars  (MonoString *s);
-int            mono_string_length (MonoString *s);
+MONO_API mono_unichar2 *mono_string_chars  (MonoString *s);
+MONO_API int            mono_string_length (MonoString *s);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_new		    (MonoDomain *domain, MonoClass *klass);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_new_specific    (MonoVTable *vtable);
 
 /* can be used for classes without finalizer in non-profiling mode */
-MonoObject *
+MONO_API MonoObject *
 mono_object_new_fast	    (MonoVTable *vtable);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_new_alloc_specific (MonoVTable *vtable);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, uint32_t token);
 
-MonoArray*
+MONO_API MonoArray*
 mono_array_new		    (MonoDomain *domain, MonoClass *eclass, uintptr_t n);
 
-MonoArray*
+MONO_API MonoArray*
 mono_array_new_full	    (MonoDomain *domain, MonoClass *array_class,
 			     uintptr_t *lengths, intptr_t *lower_bounds);
 
-MonoArray *
+MONO_API MonoArray *
 mono_array_new_specific	    (MonoVTable *vtable, uintptr_t n);
 
-MonoArray*
+MONO_API MonoArray*
 mono_array_clone	    (MonoArray *array);
 
-char*
+MONO_API char*
 mono_array_addr_with_size   (MonoArray *array, int size, uintptr_t idx);
 
-uintptr_t
+MONO_API uintptr_t
 mono_array_length           (MonoArray *array);
 
-MonoString*
+MONO_API MonoString*
 mono_string_new_utf16	    (MonoDomain *domain, const mono_unichar2 *text, int32_t len);
 
-MonoString*
+MONO_API MonoString*
 mono_string_new_size	    (MonoDomain *domain, int32_t len);
 
-MonoString*
+MONO_API MonoString*
 mono_ldstr		    (MonoDomain *domain, MonoImage *image, uint32_t str_index);
 
-MonoString*
+MONO_API MonoString*
 mono_string_is_interned	    (MonoString *str);
 
-MonoString*
+MONO_API MonoString*
 mono_string_intern	    (MonoString *str);
 
-MonoString*
+MONO_API MonoString*
 mono_string_new		    (MonoDomain *domain, const char *text);
 
-MonoString*
+MONO_API MonoString*
 mono_string_new_wrapper	    (const char *text);
 
-MonoString*
+MONO_API MonoString*
 mono_string_new_len	    (MonoDomain *domain, const char *text, unsigned int length);
 
-char *
+MONO_API char *
 mono_string_to_utf8	    (MonoString *string_obj);
 
-char *
+MONO_API char *
 mono_string_to_utf8_checked (MonoString *string_obj, MonoError *error);
 
-mono_unichar2 *
+MONO_API mono_unichar2 *
 mono_string_to_utf16	    (MonoString *string_obj);
 
-MonoString *
+MONO_API MonoString *
 mono_string_from_utf16	    (mono_unichar2 *data);
 
-mono_bool
+MONO_API mono_bool
 mono_string_equal           (MonoString *s1, MonoString *s2);
 
-unsigned int
+MONO_API unsigned int
 mono_string_hash            (MonoString *s);
 
-int
+MONO_API int
 mono_object_hash            (MonoObject* obj);
 
-MonoString *
+MONO_API MonoString *
 mono_object_to_string (MonoObject *obj, MonoObject **exc);
 
-MonoObject *
+MONO_API MonoObject *
 mono_value_box		    (MonoDomain *domain, MonoClass *klass, void* val);
 
-void
+MONO_API void
 mono_value_copy             (void* dest, void* src, MonoClass *klass);
 
-void
+MONO_API void
 mono_value_copy_array       (MonoArray *dest, int dest_idx, void* src, int count);
 
-MonoDomain*
+MONO_API MonoDomain*
 mono_object_get_domain      (MonoObject *obj);
 
-MonoClass*
+MONO_API MonoClass*
 mono_object_get_class       (MonoObject *obj);
 
-void*
+MONO_API void*
 mono_object_unbox	    (MonoObject *obj);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_clone	    (MonoObject *obj);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_isinst	    (MonoObject *obj, MonoClass *klass);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_isinst_mbyref   (MonoObject *obj, MonoClass *klass);
 
-MonoObject *
+MONO_API MonoObject *
 mono_object_castclass_mbyref (MonoObject *obj, MonoClass *klass);
 
-mono_bool 
+MONO_API mono_bool 
 mono_monitor_try_enter       (MonoObject *obj, uint32_t ms);
 
-mono_bool
+MONO_API mono_bool
 mono_monitor_enter           (MonoObject *obj);
 
-unsigned int
+MONO_API unsigned int
 mono_object_get_size         (MonoObject *o);
 
-void 
+MONO_API void 
 mono_monitor_exit            (MonoObject *obj);
 
-void
+MONO_API void
 mono_raise_exception	    (MonoException *ex);
 
-void
+MONO_API void
 mono_runtime_object_init    (MonoObject *this_obj);
 
-void
+MONO_API void
 mono_runtime_class_init	    (MonoVTable *vtable);
 
-MonoMethod*
+MONO_API MonoMethod*
 mono_object_get_virtual_method (MonoObject *obj, MonoMethod *method);
 
-MonoObject*
+MONO_API MonoObject*
 mono_runtime_invoke	    (MonoMethod *method, void *obj, void **params,
 			     MonoObject **exc);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_get_delegate_invoke    (MonoClass *klass);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_get_delegate_begin_invoke (MonoClass *klass);
 
-MonoMethod *
+MONO_API MonoMethod *
 mono_get_delegate_end_invoke (MonoClass *klass);
 
-MonoObject*
+MONO_API MonoObject*
 mono_runtime_delegate_invoke (MonoObject *delegate, void **params, 
 			      MonoObject **exc);
 
-MonoObject*
+MONO_API MonoObject*
 mono_runtime_invoke_array   (MonoMethod *method, void *obj, MonoArray *params,
 			     MonoObject **exc);
 
-void*
+MONO_API void*
 mono_method_get_unmanaged_thunk (MonoMethod *method);
 
-MonoArray*
+MONO_API MonoArray*
 mono_runtime_get_main_args  (void);
 
-void
+MONO_API void
 mono_runtime_exec_managed_code (MonoDomain *domain,
 				MonoMainThreadFunc main_func,
 				void* main_args);
 
-int
+MONO_API int
 mono_runtime_run_main	    (MonoMethod *method, int argc, char* argv[], 
 			     MonoObject **exc);
 
-int
+MONO_API int
 mono_runtime_exec_main	    (MonoMethod *method, MonoArray *args,
 			     MonoObject **exc);
 
 /* The following functions won't be available with mono was configured with remoting disabled. */
 /*#ifndef DISABLE_REMOTING */
-void*
+MONO_API void*
 mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void **res);
 
-MonoObject *
+MONO_API MonoObject *
 mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field);
 
-void
+MONO_API void
 mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void* val);
 
-void
+MONO_API void
 mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg);
 
 /* #endif */
 
-void
+MONO_API void
 mono_unhandled_exception    (MonoObject *exc);
 
-void
+MONO_API void
 mono_print_unhandled_exception (MonoObject *exc);
 
-void* 
+MONO_API void* 
 mono_compile_method	   (MonoMethod *method);
 
 /* accessors for fields and properties */
-void
+MONO_API void
 mono_field_set_value (MonoObject *obj, MonoClassField *field, void *value);
 
-void
+MONO_API void
 mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value);
 
-void
+MONO_API void
 mono_field_get_value (MonoObject *obj, MonoClassField *field, void *value);
 
-void
+MONO_API void
 mono_field_static_get_value (MonoVTable *vt, MonoClassField *field, void *value);
 
-MonoObject *
+MONO_API MonoObject *
 mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObject *obj);
 
-void
+MONO_API void
 mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 
-MonoObject*
+MONO_API MonoObject*
 mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 
 /* GC handles support 
@@ -306,19 +306,19 @@ mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObjec
  * mono_gchandle_get_target () can be used to get the object referenced by both kinds
  * of handle: for a weakref handle, if an object has been collected, it will return NULL.
  */
-uint32_t      mono_gchandle_new         (MonoObject *obj, mono_bool pinned);
-uint32_t      mono_gchandle_new_weakref (MonoObject *obj, mono_bool track_resurrection);
-MonoObject*  mono_gchandle_get_target  (uint32_t gchandle);
-void         mono_gchandle_free        (uint32_t gchandle);
+MONO_API uint32_t      mono_gchandle_new         (MonoObject *obj, mono_bool pinned);
+MONO_API uint32_t      mono_gchandle_new_weakref (MonoObject *obj, mono_bool track_resurrection);
+MONO_API MonoObject*  mono_gchandle_get_target  (uint32_t gchandle);
+MONO_API void         mono_gchandle_free        (uint32_t gchandle);
 
 /* GC write barriers support */
-void mono_gc_wbarrier_set_field     (MonoObject *obj, void* field_ptr, MonoObject* value);
-void mono_gc_wbarrier_set_arrayref  (MonoArray *arr, void* slot_ptr, MonoObject* value);
-void mono_gc_wbarrier_arrayref_copy (void* dest_ptr, void* src_ptr, int count);
-void mono_gc_wbarrier_generic_store (void* ptr, MonoObject* value);
-void mono_gc_wbarrier_generic_nostore (void* ptr);
-void mono_gc_wbarrier_value_copy    (void* dest, void* src, int count, MonoClass *klass);
-void mono_gc_wbarrier_object_copy   (MonoObject* obj, MonoObject *src);
+MONO_API void mono_gc_wbarrier_set_field     (MonoObject *obj, void* field_ptr, MonoObject* value);
+MONO_API void mono_gc_wbarrier_set_arrayref  (MonoArray *arr, void* slot_ptr, MonoObject* value);
+MONO_API void mono_gc_wbarrier_arrayref_copy (void* dest_ptr, void* src_ptr, int count);
+MONO_API void mono_gc_wbarrier_generic_store (void* ptr, MonoObject* value);
+MONO_API void mono_gc_wbarrier_generic_nostore (void* ptr);
+MONO_API void mono_gc_wbarrier_value_copy    (void* dest, void* src, int count, MonoClass *klass);
+MONO_API void mono_gc_wbarrier_object_copy   (MonoObject* obj, MonoObject *src);
 
 MONO_END_DECLS
 

--- a/mono/metadata/opcodes.h
+++ b/mono/metadata/opcodes.h
@@ -64,10 +64,10 @@ typedef struct {
 
 extern const MonoOpcode mono_opcodes [];
 
-const char*
+MONO_API const char*
 mono_opcode_name (int opcode);
 
-MonoOpcodeEnum
+MONO_API MonoOpcodeEnum
 mono_opcode_value (const mono_byte **ip, const mono_byte *end);
 
 MONO_END_DECLS

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -151,47 +151,47 @@ typedef void (*MonoProfilerCodeBufferNew) (MonoProfiler *prof, void* buffer, int
 /*
  * Function the profiler may call.
  */
-void mono_profiler_install       (MonoProfiler *prof, MonoProfileFunc shutdown_callback);
-void mono_profiler_set_events    (MonoProfileFlags events);
+MONO_API void mono_profiler_install       (MonoProfiler *prof, MonoProfileFunc shutdown_callback);
+MONO_API void mono_profiler_set_events    (MonoProfileFlags events);
 
-MonoProfileFlags mono_profiler_get_events (void);
+MONO_API MonoProfileFlags mono_profiler_get_events (void);
 
-void mono_profiler_install_appdomain   (MonoProfileAppDomainFunc start_load, MonoProfileAppDomainResult end_load,
+MONO_API void mono_profiler_install_appdomain   (MonoProfileAppDomainFunc start_load, MonoProfileAppDomainResult end_load,
                                         MonoProfileAppDomainFunc start_unload, MonoProfileAppDomainFunc end_unload);
-void mono_profiler_install_assembly    (MonoProfileAssemblyFunc start_load, MonoProfileAssemblyResult end_load,
+MONO_API void mono_profiler_install_assembly    (MonoProfileAssemblyFunc start_load, MonoProfileAssemblyResult end_load,
                                         MonoProfileAssemblyFunc start_unload, MonoProfileAssemblyFunc end_unload);
-void mono_profiler_install_module      (MonoProfileModuleFunc start_load, MonoProfileModuleResult end_load,
+MONO_API void mono_profiler_install_module      (MonoProfileModuleFunc start_load, MonoProfileModuleResult end_load,
                                         MonoProfileModuleFunc start_unload, MonoProfileModuleFunc end_unload);
-void mono_profiler_install_class       (MonoProfileClassFunc start_load, MonoProfileClassResult end_load,
+MONO_API void mono_profiler_install_class       (MonoProfileClassFunc start_load, MonoProfileClassResult end_load,
                                         MonoProfileClassFunc start_unload, MonoProfileClassFunc end_unload);
 
-void mono_profiler_install_jit_compile (MonoProfileMethodFunc start, MonoProfileMethodResult end);
-void mono_profiler_install_jit_end (MonoProfileJitResult end);
-void mono_profiler_install_method_free (MonoProfileMethodFunc callback);
-void mono_profiler_install_method_invoke (MonoProfileMethodFunc start, MonoProfileMethodFunc end);
-void mono_profiler_install_enter_leave (MonoProfileMethodFunc enter, MonoProfileMethodFunc fleave);
-void mono_profiler_install_thread      (MonoProfileThreadFunc start, MonoProfileThreadFunc end);
-void mono_profiler_install_thread_name (MonoProfileThreadNameFunc thread_name_cb);
-void mono_profiler_install_transition  (MonoProfileMethodResult callback);
-void mono_profiler_install_allocation  (MonoProfileAllocFunc callback);
-void mono_profiler_install_monitor     (MonoProfileMonitorFunc callback);
-void mono_profiler_install_statistical (MonoProfileStatFunc callback);
-void mono_profiler_install_statistical_call_chain (MonoProfileStatCallChainFunc callback, int call_chain_depth, MonoProfilerCallChainStrategy call_chain_strategy);
-void mono_profiler_install_exception   (MonoProfileExceptionFunc throw_callback, MonoProfileMethodFunc exc_method_leave, MonoProfileExceptionClauseFunc clause_callback);
-void mono_profiler_install_coverage_filter (MonoProfileCoverageFilterFunc callback);
-void mono_profiler_coverage_get  (MonoProfiler *prof, MonoMethod *method, MonoProfileCoverageFunc func);
-void mono_profiler_install_gc    (MonoProfileGCFunc callback, MonoProfileGCResizeFunc heap_resize_callback);
-void mono_profiler_install_gc_moves    (MonoProfileGCMoveFunc callback);
-void mono_profiler_install_gc_roots    (MonoProfileGCHandleFunc handle_callback, MonoProfileGCRootFunc roots_callback);
-void mono_profiler_install_runtime_initialized (MonoProfileFunc runtime_initialized_callback);
+MONO_API void mono_profiler_install_jit_compile (MonoProfileMethodFunc start, MonoProfileMethodResult end);
+MONO_API void mono_profiler_install_jit_end (MonoProfileJitResult end);
+MONO_API void mono_profiler_install_method_free (MonoProfileMethodFunc callback);
+MONO_API void mono_profiler_install_method_invoke (MonoProfileMethodFunc start, MonoProfileMethodFunc end);
+MONO_API void mono_profiler_install_enter_leave (MonoProfileMethodFunc enter, MonoProfileMethodFunc fleave);
+MONO_API void mono_profiler_install_thread      (MonoProfileThreadFunc start, MonoProfileThreadFunc end);
+MONO_API void mono_profiler_install_thread_name (MonoProfileThreadNameFunc thread_name_cb);
+MONO_API void mono_profiler_install_transition  (MonoProfileMethodResult callback);
+MONO_API void mono_profiler_install_allocation  (MonoProfileAllocFunc callback);
+MONO_API void mono_profiler_install_monitor     (MonoProfileMonitorFunc callback);
+MONO_API void mono_profiler_install_statistical (MonoProfileStatFunc callback);
+MONO_API void mono_profiler_install_statistical_call_chain (MonoProfileStatCallChainFunc callback, int call_chain_depth, MonoProfilerCallChainStrategy call_chain_strategy);
+MONO_API void mono_profiler_install_exception   (MonoProfileExceptionFunc throw_callback, MonoProfileMethodFunc exc_method_leave, MonoProfileExceptionClauseFunc clause_callback);
+MONO_API void mono_profiler_install_coverage_filter (MonoProfileCoverageFilterFunc callback);
+MONO_API void mono_profiler_coverage_get  (MonoProfiler *prof, MonoMethod *method, MonoProfileCoverageFunc func);
+MONO_API void mono_profiler_install_gc    (MonoProfileGCFunc callback, MonoProfileGCResizeFunc heap_resize_callback);
+MONO_API void mono_profiler_install_gc_moves    (MonoProfileGCMoveFunc callback);
+MONO_API void mono_profiler_install_gc_roots    (MonoProfileGCHandleFunc handle_callback, MonoProfileGCRootFunc roots_callback);
+MONO_API void mono_profiler_install_runtime_initialized (MonoProfileFunc runtime_initialized_callback);
 
-void mono_profiler_install_code_chunk_new (MonoProfilerCodeChunkNew callback);
-void mono_profiler_install_code_chunk_destroy (MonoProfilerCodeChunkDestroy callback);
-void mono_profiler_install_code_buffer_new (MonoProfilerCodeBufferNew callback);
+MONO_API void mono_profiler_install_code_chunk_new (MonoProfilerCodeChunkNew callback);
+MONO_API void mono_profiler_install_code_chunk_destroy (MonoProfilerCodeChunkDestroy callback);
+MONO_API void mono_profiler_install_code_buffer_new (MonoProfilerCodeBufferNew callback);
 
-void mono_profiler_install_iomap (MonoProfileIomapFunc callback);
+MONO_API void mono_profiler_install_iomap (MonoProfileIomapFunc callback);
 
-void mono_profiler_load             (const char *desc);
+MONO_API void mono_profiler_load             (const char *desc);
 
 MONO_END_DECLS
 

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -41,44 +41,44 @@ typedef enum {
 	ResolveTokenError_Other
 } MonoResolveTokenError;
 
-int           mono_reflection_parse_type (char *name, MonoTypeNameParse *info);
-MonoType*     mono_reflection_get_type   (MonoImage* image, MonoTypeNameParse *info, mono_bool ignorecase, mono_bool *type_resolve);
-void          mono_reflection_free_type_info (MonoTypeNameParse *info);
-MonoType*     mono_reflection_type_from_name (char *name, MonoImage *image);
-uint32_t      mono_reflection_get_token (MonoObject *obj);
+MONO_API int           mono_reflection_parse_type (char *name, MonoTypeNameParse *info);
+MONO_API MonoType*     mono_reflection_get_type   (MonoImage* image, MonoTypeNameParse *info, mono_bool ignorecase, mono_bool *type_resolve);
+MONO_API void          mono_reflection_free_type_info (MonoTypeNameParse *info);
+MONO_API MonoType*     mono_reflection_type_from_name (char *name, MonoImage *image);
+MONO_API uint32_t      mono_reflection_get_token (MonoObject *obj);
 
-MonoReflectionAssembly* mono_assembly_get_object (MonoDomain *domain, MonoAssembly *assembly);
-MonoReflectionModule*   mono_module_get_object   (MonoDomain *domain, MonoImage *image);
-MonoReflectionModule*   mono_module_file_get_object (MonoDomain *domain, MonoImage *image, int table_index);
-MonoReflectionType*     mono_type_get_object     (MonoDomain *domain, MonoType *type);
-MonoReflectionMethod*   mono_method_get_object   (MonoDomain *domain, MonoMethod *method, MonoClass *refclass);
-MonoReflectionField*    mono_field_get_object    (MonoDomain *domain, MonoClass *klass, MonoClassField *field);
-MonoReflectionProperty* mono_property_get_object (MonoDomain *domain, MonoClass *klass, MonoProperty *property);
-MonoReflectionEvent*    mono_event_get_object    (MonoDomain *domain, MonoClass *klass, MonoEvent *event);
+MONO_API MonoReflectionAssembly* mono_assembly_get_object (MonoDomain *domain, MonoAssembly *assembly);
+MONO_API MonoReflectionModule*   mono_module_get_object   (MonoDomain *domain, MonoImage *image);
+MONO_API MonoReflectionModule*   mono_module_file_get_object (MonoDomain *domain, MonoImage *image, int table_index);
+MONO_API MonoReflectionType*     mono_type_get_object     (MonoDomain *domain, MonoType *type);
+MONO_API MonoReflectionMethod*   mono_method_get_object   (MonoDomain *domain, MonoMethod *method, MonoClass *refclass);
+MONO_API MonoReflectionField*    mono_field_get_object    (MonoDomain *domain, MonoClass *klass, MonoClassField *field);
+MONO_API MonoReflectionProperty* mono_property_get_object (MonoDomain *domain, MonoClass *klass, MonoProperty *property);
+MONO_API MonoReflectionEvent*    mono_event_get_object    (MonoDomain *domain, MonoClass *klass, MonoEvent *event);
 /* note: this one is slightly different: we keep the whole array of params in the cache */
-MonoArray* mono_param_get_objects  (MonoDomain *domain, MonoMethod *method);
-MonoReflectionMethodBody* mono_method_body_get_object (MonoDomain *domain, MonoMethod *method);
+MONO_API MonoArray* mono_param_get_objects  (MonoDomain *domain, MonoMethod *method);
+MONO_API MonoReflectionMethodBody* mono_method_body_get_object (MonoDomain *domain, MonoMethod *method);
 
-MonoObject *mono_get_dbnull_object (MonoDomain *domain);
+MONO_API MonoObject *mono_get_dbnull_object (MonoDomain *domain);
 
-MonoArray*  mono_reflection_get_custom_attrs_by_type (MonoObject *obj, MonoClass *attr_klass, MonoError *error);
-MonoArray*  mono_reflection_get_custom_attrs (MonoObject *obj);
-MonoArray*  mono_reflection_get_custom_attrs_data (MonoObject *obj);
-MonoArray*  mono_reflection_get_custom_attrs_blob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *porpValues, MonoArray *fields, MonoArray* fieldValues);
+MONO_API MonoArray*  mono_reflection_get_custom_attrs_by_type (MonoObject *obj, MonoClass *attr_klass, MonoError *error);
+MONO_API MonoArray*  mono_reflection_get_custom_attrs (MonoObject *obj);
+MONO_API MonoArray*  mono_reflection_get_custom_attrs_data (MonoObject *obj);
+MONO_API MonoArray*  mono_reflection_get_custom_attrs_blob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *porpValues, MonoArray *fields, MonoArray* fieldValues);
 
-MonoCustomAttrInfo* mono_reflection_get_custom_attrs_info (MonoObject *obj);
-MonoArray*  mono_custom_attrs_construct (MonoCustomAttrInfo *cinfo);
-MonoCustomAttrInfo* mono_custom_attrs_from_index    (MonoImage *image, uint32_t idx);
-MonoCustomAttrInfo* mono_custom_attrs_from_method   (MonoMethod *method);
-MonoCustomAttrInfo* mono_custom_attrs_from_class    (MonoClass *klass);
-MonoCustomAttrInfo* mono_custom_attrs_from_assembly (MonoAssembly *assembly);
-MonoCustomAttrInfo* mono_custom_attrs_from_property (MonoClass *klass, MonoProperty *property);
-MonoCustomAttrInfo* mono_custom_attrs_from_event    (MonoClass *klass, MonoEvent *event);
-MonoCustomAttrInfo* mono_custom_attrs_from_field    (MonoClass *klass, MonoClassField *field);
-MonoCustomAttrInfo* mono_custom_attrs_from_param    (MonoMethod *method, uint32_t param);
-mono_bool           mono_custom_attrs_has_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
-MonoObject*         mono_custom_attrs_get_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
-void                mono_custom_attrs_free          (MonoCustomAttrInfo *ainfo);
+MONO_API MonoCustomAttrInfo* mono_reflection_get_custom_attrs_info (MonoObject *obj);
+MONO_API MonoArray*  mono_custom_attrs_construct (MonoCustomAttrInfo *cinfo);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_index    (MonoImage *image, uint32_t idx);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_method   (MonoMethod *method);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_class    (MonoClass *klass);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_assembly (MonoAssembly *assembly);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_property (MonoClass *klass, MonoProperty *property);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_event    (MonoClass *klass, MonoEvent *event);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_field    (MonoClass *klass, MonoClassField *field);
+MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_param    (MonoMethod *method, uint32_t param);
+MONO_API mono_bool           mono_custom_attrs_has_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
+MONO_API MonoObject*         mono_custom_attrs_get_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
+MONO_API void                mono_custom_attrs_free          (MonoCustomAttrInfo *ainfo);
 
 
 #define MONO_DECLSEC_ACTION_MIN		0x1
@@ -105,9 +105,9 @@ enum {
 	MONO_DECLSEC_FLAG_DEMAND_CHOICE			= 0x00020000
 };
 
-uint32_t mono_declsec_flags_from_method (MonoMethod *method);
-uint32_t mono_declsec_flags_from_class (MonoClass *klass);
-uint32_t mono_declsec_flags_from_assembly (MonoAssembly *assembly);
+MONO_API uint32_t mono_declsec_flags_from_method (MonoMethod *method);
+MONO_API uint32_t mono_declsec_flags_from_class (MonoClass *klass);
+MONO_API uint32_t mono_declsec_flags_from_assembly (MonoAssembly *assembly);
 
 /* this structure MUST be kept in synch with RuntimeDeclSecurityEntry
  * located in /mcs/class/corlib/System.Security/SecurityFrame.cs */
@@ -123,16 +123,16 @@ typedef struct {
 	MonoDeclSecurityEntry demandchoice;
 } MonoDeclSecurityActions;
 
-MonoBoolean mono_declsec_get_demands (MonoMethod *callee, MonoDeclSecurityActions* demands);
-MonoBoolean mono_declsec_get_linkdemands (MonoMethod *callee, MonoDeclSecurityActions* klass, MonoDeclSecurityActions* cmethod);
-MonoBoolean mono_declsec_get_inheritdemands_class (MonoClass *klass, MonoDeclSecurityActions* demands);
-MonoBoolean mono_declsec_get_inheritdemands_method (MonoMethod *callee, MonoDeclSecurityActions* demands);
+MONO_API MonoBoolean mono_declsec_get_demands (MonoMethod *callee, MonoDeclSecurityActions* demands);
+MONO_API MonoBoolean mono_declsec_get_linkdemands (MonoMethod *callee, MonoDeclSecurityActions* klass, MonoDeclSecurityActions* cmethod);
+MONO_API MonoBoolean mono_declsec_get_inheritdemands_class (MonoClass *klass, MonoDeclSecurityActions* demands);
+MONO_API MonoBoolean mono_declsec_get_inheritdemands_method (MonoMethod *callee, MonoDeclSecurityActions* demands);
 
-MonoBoolean mono_declsec_get_method_action (MonoMethod *method, uint32_t action, MonoDeclSecurityEntry *entry);
-MonoBoolean mono_declsec_get_class_action (MonoClass *klass, uint32_t action, MonoDeclSecurityEntry *entry);
-MonoBoolean mono_declsec_get_assembly_action (MonoAssembly *assembly, uint32_t action, MonoDeclSecurityEntry *entry);
+MONO_API MonoBoolean mono_declsec_get_method_action (MonoMethod *method, uint32_t action, MonoDeclSecurityEntry *entry);
+MONO_API MonoBoolean mono_declsec_get_class_action (MonoClass *klass, uint32_t action, MonoDeclSecurityEntry *entry);
+MONO_API MonoBoolean mono_declsec_get_assembly_action (MonoAssembly *assembly, uint32_t action, MonoDeclSecurityEntry *entry);
 
-MonoType* mono_reflection_type_get_type (MonoReflectionType *reftype);
+MONO_API MonoType* mono_reflection_type_get_type (MonoReflectionType *reftype);
 
 MONO_END_DECLS
 

--- a/mono/metadata/security-core-clr.h
+++ b/mono/metadata/security-core-clr.h
@@ -56,9 +56,9 @@ extern MonoSecurityCoreCLRLevel mono_security_core_clr_method_level (MonoMethod 
 extern gboolean mono_security_core_clr_is_platform_image (MonoImage *image) MONO_INTERNAL;
 extern gboolean mono_security_core_clr_determine_platform_image (MonoImage *image) MONO_INTERNAL;
 
-extern gboolean mono_security_core_clr_require_elevated_permissions (void);
+extern MONO_API gboolean mono_security_core_clr_require_elevated_permissions (void);
 
-extern void mono_security_core_clr_set_options (MonoSecurityCoreCLROptions options);
-extern MonoSecurityCoreCLROptions mono_security_core_clr_get_options (void);
+extern MONO_API void mono_security_core_clr_set_options (MonoSecurityCoreCLROptions options);
+extern MONO_API MonoSecurityCoreCLROptions mono_security_core_clr_get_options (void);
 
 #endif	/* _MONO_METADATA_SECURITY_CORE_CLR_H_ */

--- a/mono/metadata/threadpool.h
+++ b/mono/metadata/threadpool.h
@@ -47,10 +47,10 @@ ves_icall_System_Threading_ThreadPool_SetMaxThreads (gint workerThreads,
 								gint completionPortThreads) MONO_INTERNAL;
 
 typedef void  (*MonoThreadPoolFunc) (gpointer user_data);
-void mono_install_threadpool_thread_hooks (MonoThreadPoolFunc start_func, MonoThreadPoolFunc finish_func, gpointer user_data);
+MONO_API void mono_install_threadpool_thread_hooks (MonoThreadPoolFunc start_func, MonoThreadPoolFunc finish_func, gpointer user_data);
 
 typedef void  (*MonoThreadPoolItemFunc) (gpointer user_data);
-void mono_install_threadpool_item_hooks (MonoThreadPoolItemFunc begin_func, MonoThreadPoolItemFunc end_func, gpointer user_data);
+MONO_API void mono_install_threadpool_item_hooks (MonoThreadPoolItemFunc begin_func, MonoThreadPoolItemFunc end_func, gpointer user_data);
 
 #endif
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -187,7 +187,7 @@ void mono_threads_set_shutting_down (void) MONO_INTERNAL;
 
 gunichar2* mono_thread_get_name (MonoInternalThread *this_obj, guint32 *name_len) MONO_INTERNAL;
 
-MonoException* mono_thread_get_undeniable_exception (void);
+MONO_API MonoException* mono_thread_get_undeniable_exception (void);
 
 MonoException* mono_thread_get_and_clear_pending_exception (void) MONO_INTERNAL;
 

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -20,33 +20,33 @@ MONO_BEGIN_DECLS
 /* This callback should return TRUE if the runtime must wait for the thread, FALSE otherwise */
 typedef mono_bool (*MonoThreadManageCallback) (MonoThread* thread);
 
-extern void mono_thread_init (MonoThreadStartCB start_cb,
+extern MONO_API void mono_thread_init (MonoThreadStartCB start_cb,
 			      MonoThreadAttachCB attach_cb);
-extern void mono_thread_cleanup (void);
-extern void mono_thread_manage(void);
+extern MONO_API void mono_thread_cleanup (void);
+extern MONO_API void mono_thread_manage(void);
 
-extern MonoThread *mono_thread_current (void);
+extern MONO_API MonoThread *mono_thread_current (void);
 
-extern void        mono_thread_set_main (MonoThread *thread);
-extern MonoThread *mono_thread_get_main (void);
+extern MONO_API void        mono_thread_set_main (MonoThread *thread);
+extern MONO_API MonoThread *mono_thread_get_main (void);
 
-extern void mono_thread_stop (MonoThread *thread);
+extern MONO_API void mono_thread_stop (MonoThread *thread);
 
-extern void mono_thread_new_init (intptr_t tid, void* stack_start,
+extern MONO_API void mono_thread_new_init (intptr_t tid, void* stack_start,
 				  void* func);
-extern void mono_thread_create (MonoDomain *domain, void* func, void* arg);
-extern MonoThread *mono_thread_attach (MonoDomain *domain);
-extern void mono_thread_detach (MonoThread *thread);
-extern void mono_thread_exit (void);
+extern MONO_API void mono_thread_create (MonoDomain *domain, void* func, void* arg);
+extern MONO_API MonoThread *mono_thread_attach (MonoDomain *domain);
+extern MONO_API void mono_thread_detach (MonoThread *thread);
+extern MONO_API void mono_thread_exit (void);
 
-void     mono_thread_set_manage_callback (MonoThread *thread, MonoThreadManageCallback func);
+MONO_API void     mono_thread_set_manage_callback (MonoThread *thread, MonoThreadManageCallback func);
 
-extern void mono_threads_set_default_stacksize (uint32_t stacksize);
-extern uint32_t mono_threads_get_default_stacksize (void);
+extern MONO_API void mono_threads_set_default_stacksize (uint32_t stacksize);
+extern MONO_API uint32_t mono_threads_get_default_stacksize (void);
 
-void mono_threads_request_thread_dump (void);
+MONO_API void mono_threads_request_thread_dump (void);
 
-mono_bool mono_thread_is_foreign (MonoThread *thread);
+MONO_API mono_bool mono_thread_is_foreign (MonoThread *thread);
 
 MONO_END_DECLS
 

--- a/mono/metadata/verify.h
+++ b/mono/metadata/verify.h
@@ -52,9 +52,9 @@ typedef struct {
 } MonoVerifyInfoExtended;
 
 
-GSList* mono_method_verify       (MonoMethod *method, int level);
-void    mono_free_verify_list    (GSList *list);
-char*   mono_verify_corlib       (void);
+MONO_API GSList* mono_method_verify       (MonoMethod *method, int level);
+MONO_API void    mono_free_verify_list    (GSList *list);
+MONO_API char*   mono_verify_corlib       (void);
 
 MONO_END_DECLS
 

--- a/mono/mini/debug-mini.h
+++ b/mono/mini/debug-mini.h
@@ -9,28 +9,28 @@
 typedef struct _MonoDebuggerThreadInfo MonoDebuggerThreadInfo;
 extern MonoDebuggerThreadInfo *mono_debugger_thread_table;
 
-void
+MONO_API void
 mono_debugger_thread_created (gsize tid, MonoThread *thread, MonoJitTlsData *jit_tls, gpointer func);
 
-void
+MONO_API void
 mono_debugger_thread_cleanup (MonoJitTlsData *jit_tls);
 
-void
+MONO_API void
 mono_debugger_extended_notification (MonoDebuggerEvent event, guint64 data, guint64 arg);
 
-void
+MONO_API void
 mono_debugger_trampoline_compiled (const guint8 *trampoline, MonoMethod *method, const guint8 *code);
 
-void
+MONO_API void
 mono_debugger_call_exception_handler (gpointer addr, gpointer stack, MonoObject *exc);
 
-gboolean
+MONO_API gboolean
 mono_debugger_handle_exception (MonoContext *ctx, MonoObject *obj);
 
-MonoObject *
+MONO_API MonoObject *
 mono_debugger_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc);
 
-gboolean
+MONO_API gboolean
 mono_debugger_abort_runtime_invoke (void);
 
 /*

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -17,7 +17,7 @@
 #ifndef DISABLE_JIT
 
 /* FIXME: This conflicts with the definition in mini.c, so it cannot be moved to mini.h */
-MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
+MONO_API MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
 void mini_emit_stobj (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, gboolean native);
 void mini_emit_initobj (MonoCompile *cfg, MonoInst *dest, const guchar *ip, MonoClass *klass);
 

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -12,25 +12,25 @@
 
 MONO_BEGIN_DECLS
 
-MonoDomain * 
+MONO_API MonoDomain * 
 mono_jit_init              (const char *file);
 
-MonoDomain * 
+MONO_API MonoDomain * 
 mono_jit_init_version      (const char *root_domain_name, const char *runtime_version);
 
-int
+MONO_API int
 mono_jit_exec              (MonoDomain *domain, MonoAssembly *assembly, 
 			    int argc, char *argv[]);
-void        
+MONO_API void        
 mono_jit_cleanup           (MonoDomain *domain);
 
-mono_bool
+MONO_API mono_bool
 mono_jit_set_trace_options (const char* options);
 
-void
+MONO_API void
 mono_set_signal_chaining   (mono_bool chain_signals);
 
-void
+MONO_API void
 mono_jit_set_aot_only      (mono_bool aot_only);
 
 /* Allow embedders to decide wherther to actually obey breakpoint instructions
@@ -50,12 +50,12 @@ typedef enum {
 } MonoBreakPolicy;
 
 typedef MonoBreakPolicy (*MonoBreakPolicyFunc) (MonoMethod *method);
-void mono_set_break_policy (MonoBreakPolicyFunc policy_callback);
+MONO_API void mono_set_break_policy (MonoBreakPolicyFunc policy_callback);
 
-void
+MONO_API void
 mono_jit_parse_options     (int argc, char * argv[]);
 
-char*       mono_get_runtime_build_info    (void);
+MONO_API char*       mono_get_runtime_build_info    (void);
 
 MONO_END_DECLS
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -130,7 +130,7 @@ static int stind_to_store_membase (int opcode);
 int mono_op_to_op_imm (int opcode);
 int mono_op_to_op_imm_noemul (int opcode);
 
-MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
+MONO_API MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
 
 /* helper methods signatures */
 static MonoMethodSignature *helper_sig_class_init_trampoline = NULL;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1875,8 +1875,8 @@ enum {
 typedef void (*MonoInstFunc) (MonoInst *tree, gpointer data);
 
 /* main function */
-int         mono_main                      (int argc, char* argv[]);
-void        mono_set_defaults              (int verbose_level, guint32 opts);
+MONO_API int         mono_main                      (int argc, char* argv[]);
+MONO_API void        mono_set_defaults              (int verbose_level, guint32 opts);
 MonoDomain* mini_init                      (const char *filename, const char *runtime_version) MONO_INTERNAL;
 void        mini_cleanup                   (MonoDomain *domain) MONO_INTERNAL;
 MonoDebugOptions *mini_get_debug_options   (void) MONO_INTERNAL;
@@ -1892,7 +1892,7 @@ MonoInst* mono_find_exvar_for_offset        (MonoCompile *cfg, int offset) MONO_
 int       mono_get_block_region_notry       (MonoCompile *cfg, int region) MONO_LLVM_INTERNAL;
 
 void      mono_precompile_assemblies        (void) MONO_INTERNAL;
-int       mono_parse_default_optimizations  (const char* p);
+MONO_API int       mono_parse_default_optimizations  (const char* p);
 void      mono_bblock_add_inst              (MonoBasicBlock *bb, MonoInst *inst) MONO_LLVM_INTERNAL;
 void      mono_bblock_insert_after_ins      (MonoBasicBlock *bb, MonoInst *ins, MonoInst *ins_to_insert) MONO_INTERNAL;
 void      mono_bblock_insert_before_ins     (MonoBasicBlock *bb, MonoInst *ins, MonoInst *ins_to_insert) MONO_INTERNAL;
@@ -1933,10 +1933,10 @@ void      mono_print_ins_index              (int i, MonoInst *ins) MONO_INTERNAL
 void      mono_print_ins                    (MonoInst *ins) MONO_INTERNAL;
 void      mono_print_bb                     (MonoBasicBlock *bb, const char *msg) MONO_INTERNAL;
 void      mono_print_code                   (MonoCompile *cfg, const char *msg) MONO_INTERNAL;
-void      mono_print_method_from_ip         (void *ip);
-char     *mono_pmip                         (void *ip);
+MONO_API void      mono_print_method_from_ip         (void *ip);
+MONO_API char     *mono_pmip                         (void *ip);
 gboolean  mono_debug_count                  (void) MONO_INTERNAL;
-const char* mono_inst_name                  (int op);
+MONO_API const char* mono_inst_name                  (int op);
 void      mono_inst_set_src_registers       (MonoInst *ins, int *regs) MONO_INTERNAL;
 int       mono_op_to_op_imm                 (int opcode) MONO_INTERNAL;
 int       mono_op_imm_to_op                 (int opcode) MONO_INTERNAL;
@@ -1959,8 +1959,8 @@ gpointer  mono_jit_compile_method           (MonoMethod *method) MONO_INTERNAL;
 MonoLMF * mono_get_lmf                      (void) MONO_INTERNAL;
 MonoLMF** mono_get_lmf_addr                 (void) MONO_INTERNAL;
 void      mono_set_lmf                      (MonoLMF *lmf) MONO_INTERNAL;
-MonoDomain *mono_jit_thread_attach          (MonoDomain *domain);
-void      mono_jit_set_domain               (MonoDomain *domain);
+MONO_API MonoDomain *mono_jit_thread_attach          (MonoDomain *domain);
+MONO_API void      mono_jit_set_domain               (MonoDomain *domain);
 MonoNativeTlsKey mono_get_jit_tls_key       (void) MONO_INTERNAL;
 gint32    mono_get_jit_tls_offset           (void) MONO_INTERNAL;
 gint32    mono_get_lmf_tls_offset           (void) MONO_INTERNAL;
@@ -2081,9 +2081,9 @@ void     mono_aot_register_jit_icall        (const char *name, gpointer addr) MO
 void*    mono_aot_readonly_field_override   (MonoClassField *field) MONO_INTERNAL;
 
 /* This is an exported function */
-void     mono_aot_register_globals          (gpointer *globals);
+MONO_API void     mono_aot_register_globals          (gpointer *globals);
 /* This too */
-void     mono_aot_register_module           (gpointer *aot_info);
+MONO_API void     mono_aot_register_module           (gpointer *aot_info);
 
 void     mono_xdebug_init                   (char *xdebug_opts) MONO_INTERNAL;
 void     mono_save_xdebug_info              (MonoCompile *cfg) MONO_INTERNAL;
@@ -2108,7 +2108,7 @@ void      mono_draw_graph                   (MonoCompile *cfg, MonoGraphOptions 
 void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst) MONO_INTERNAL;
 gpointer  mono_create_ftnptr                (MonoDomain *domain, gpointer addr) MONO_INTERNAL;
 
-void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
+MONO_API void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
 
 int               mono_find_method_opcode      (MonoMethod *method) MONO_INTERNAL;
 MonoJitICallInfo *mono_register_jit_icall      (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean is_save) MONO_INTERNAL;
@@ -2367,8 +2367,8 @@ typedef gboolean (*MonoJitStackWalk)            (StackFrameInfo *frame, MonoCont
 void     mono_exceptions_init                   (void) MONO_INTERNAL;
 gboolean mono_handle_exception                  (MonoContext *ctx, gpointer obj) MONO_INTERNAL;
 void     mono_handle_native_sigsegv             (int signal, void *sigctx) MONO_INTERNAL;
-void     mono_print_thread_dump                 (void *sigctx);
-void     mono_print_thread_dump_from_ctx        (MonoContext *ctx);
+MONO_API void     mono_print_thread_dump                 (void *sigctx);
+MONO_API void     mono_print_thread_dump_from_ctx        (MonoContext *ctx);
 void     mono_walk_stack_with_ctx               (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnwindOptions unwind_options, void *user_data) MONO_INTERNAL;
 void     mono_walk_stack_with_state             (MonoJitStackWalk func, MonoThreadUnwindState *state, MonoUnwindOptions unwind_options, void *user_data) MONO_INTERNAL;
 void     mono_walk_stack                        (MonoJitStackWalk func, MonoUnwindOptions options, void *user_data) MONO_INTERNAL;
@@ -2446,12 +2446,12 @@ void      mono_debug_add_aot_method             (MonoDomain *domain,
 						 MonoMethod *method, guint8 *code_start, 
 						 guint8 *debug_info, guint32 debug_info_len) MONO_INTERNAL;
 void      mono_debug_add_icall_wrapper          (MonoMethod *method, MonoJitICallInfo* info) MONO_INTERNAL;
-void      mono_debug_print_vars                 (gpointer ip, gboolean only_arguments);
-void      mono_debugger_run_finally             (MonoContext *start_ctx);
+MONO_API void      mono_debug_print_vars                 (gpointer ip, gboolean only_arguments);
+MONO_API void      mono_debugger_run_finally             (MonoContext *start_ctx);
 
 extern gssize mono_breakpoint_info_index [MONO_BREAKPOINT_ARRAY_SIZE];
 
-gboolean mono_breakpoint_clean_code (guint8 *method_start, guint8 *code, int offset, guint8 *buf, int size);
+MONO_API gboolean mono_breakpoint_clean_code (guint8 *method_start, guint8 *code, int offset, guint8 *buf, int size);
 
 #ifdef MONO_DEBUGGER_SUPPORTED
 

--- a/mono/utils/mono-codeman.h
+++ b/mono/utils/mono-codeman.h
@@ -1,21 +1,23 @@
 #ifndef __MONO_CODEMAN_H__
 #define __MONO_CODEMAN_H__
 
+#include <mono/utils/mono-publib.h>
+
 typedef struct _MonoCodeManager MonoCodeManager;
 
-MonoCodeManager* mono_code_manager_new     (void);
-MonoCodeManager* mono_code_manager_new_dynamic (void);
-void             mono_code_manager_destroy (MonoCodeManager *cman);
-void             mono_code_manager_invalidate (MonoCodeManager *cman);
-void             mono_code_manager_set_read_only (MonoCodeManager *cman);
+MONO_API MonoCodeManager* mono_code_manager_new     (void);
+MONO_API MonoCodeManager* mono_code_manager_new_dynamic (void);
+MONO_API void             mono_code_manager_destroy (MonoCodeManager *cman);
+MONO_API void             mono_code_manager_invalidate (MonoCodeManager *cman);
+MONO_API void             mono_code_manager_set_read_only (MonoCodeManager *cman);
 
-void*            mono_code_manager_reserve_align (MonoCodeManager *cman, int size, int alignment);
+MONO_API void*            mono_code_manager_reserve_align (MonoCodeManager *cman, int size, int alignment);
 
-void*            mono_code_manager_reserve (MonoCodeManager *cman, int size);
-void             mono_code_manager_commit  (MonoCodeManager *cman, void *data, int size, int newsize);
-int              mono_code_manager_size    (MonoCodeManager *cman, int *used_size);
-void             mono_code_manager_init (void);
-void             mono_code_manager_cleanup (void);
+MONO_API void*            mono_code_manager_reserve (MonoCodeManager *cman, int size);
+MONO_API void             mono_code_manager_commit  (MonoCodeManager *cman, void *data, int size, int newsize);
+MONO_API int              mono_code_manager_size    (MonoCodeManager *cman, int *used_size);
+MONO_API void             mono_code_manager_init (void);
+MONO_API void             mono_code_manager_cleanup (void);
 
 /* find the extra block allocated to resolve branches close to code */
 typedef int    (*MonoCodeManagerFunc)      (void *data, int csize, int size, void *user_data);

--- a/mono/utils/mono-counters.h
+++ b/mono/utils/mono-counters.h
@@ -25,21 +25,21 @@ enum {
 	MONO_COUNTER_LAST_SECTION
 };
 
-void mono_counters_enable (int section_mask);
+MONO_API void mono_counters_enable (int section_mask);
 
 /* 
  * register addr as the address of a counter of type type.
  * It may be a function pointer if MONO_COUNTER_CALLBACK is specified:
  * the function should return the value and take no arguments.
  */
-void mono_counters_register (const char* descr, int type, void *addr);
+MONO_API void mono_counters_register (const char* descr, int type, void *addr);
 
 /* 
  * Create a readable dump of the counters for section_mask sections (ORed section values)
  */
-void mono_counters_dump (int section_mask, FILE *outfile);
+MONO_API void mono_counters_dump (int section_mask, FILE *outfile);
 
-void mono_counters_cleanup (void);
+MONO_API void mono_counters_cleanup (void);
 
 typedef enum {
 	MONO_RESOURCE_JIT_CODE, /* bytes */
@@ -50,9 +50,9 @@ typedef enum {
 
 typedef void (*MonoResourceCallback) (int resource_type, uintptr_t value, int is_soft);
 
-int  mono_runtime_resource_limit        (int resource_type, uintptr_t soft_limit, uintptr_t hard_limit);
-void mono_runtime_resource_set_callback (MonoResourceCallback callback);
-void mono_runtime_resource_check_limit  (int resource_type, uintptr_t value);
+MONO_API int  mono_runtime_resource_limit        (int resource_type, uintptr_t soft_limit, uintptr_t hard_limit);
+MONO_API void mono_runtime_resource_set_callback (MonoResourceCallback callback);
+MONO_API void mono_runtime_resource_check_limit  (int resource_type, uintptr_t value);
 
 #endif /* __MONO_COUNTERS_H__ */
 

--- a/mono/utils/mono-digest.h
+++ b/mono/utils/mono-digest.h
@@ -28,6 +28,7 @@
 
 #include <config.h>
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
 G_BEGIN_DECLS
 
@@ -49,16 +50,16 @@ typedef struct {
 
 #endif
 
-void mono_md5_get_digest (const guchar *buffer, gint buffer_size, guchar digest[16]);
+MONO_API void mono_md5_get_digest (const guchar *buffer, gint buffer_size, guchar digest[16]);
 
 /* use this one when speed is needed */
 /* for use in provider code only */
-void mono_md5_get_digest_from_file (const gchar *filename, guchar digest[16]);
+MONO_API void mono_md5_get_digest_from_file (const gchar *filename, guchar digest[16]);
 
 /* raw routines */
-void mono_md5_init   (MonoMD5Context *ctx);
-void mono_md5_update (MonoMD5Context *ctx, const guchar *buf, guint32 len);
-void mono_md5_final  (MonoMD5Context *ctx, guchar digest[16]);
+MONO_API void mono_md5_init   (MonoMD5Context *ctx);
+MONO_API void mono_md5_update (MonoMD5Context *ctx, const guchar *buf, guint32 len);
+MONO_API void mono_md5_final  (MonoMD5Context *ctx, guchar digest[16]);
 
 #if !HAVE_COMMONCRYPTO_COMMONDIGEST_H
 
@@ -70,14 +71,14 @@ typedef struct {
 
 #endif
 
-void mono_sha1_get_digest (const guchar *buffer, gint buffer_size, guchar digest [20]);
-void mono_sha1_get_digest_from_file (const gchar *filename, guchar digest [20]);
+MONO_API void mono_sha1_get_digest (const guchar *buffer, gint buffer_size, guchar digest [20]);
+MONO_API void mono_sha1_get_digest_from_file (const gchar *filename, guchar digest [20]);
 
-void mono_sha1_init   (MonoSHA1Context* context);
-void mono_sha1_update (MonoSHA1Context* context, const guchar* data, guint32 len);
-void mono_sha1_final  (MonoSHA1Context* context, unsigned char digest[20]);
+MONO_API void mono_sha1_init   (MonoSHA1Context* context);
+MONO_API void mono_sha1_update (MonoSHA1Context* context, const guchar* data, guint32 len);
+MONO_API void mono_sha1_final  (MonoSHA1Context* context, unsigned char digest[20]);
 
-void mono_digest_get_public_token (guchar* token, const guchar *pubkey, guint32 len);
+MONO_API void mono_digest_get_public_token (guchar* token, const guchar *pubkey, guint32 len);
 
 G_END_DECLS
 #endif	/* __MONO_DIGEST_H__ */

--- a/mono/utils/mono-dl-fallback.h
+++ b/mono/utils/mono-dl-fallback.h
@@ -23,10 +23,10 @@ typedef void* (*MonoDlFallbackLoad) (const char *name, int flags, char **err, vo
 typedef void* (*MonoDlFallbackSymbol) (void *handle, const char *name, char **err, void *user_data);
 typedef void* (*MonoDlFallbackClose) (void *handle, void *user_data);
 
-MonoDlFallbackHandler *mono_dl_fallback_register (MonoDlFallbackLoad load_func, MonoDlFallbackSymbol symbol_func,
+MONO_API MonoDlFallbackHandler *mono_dl_fallback_register (MonoDlFallbackLoad load_func, MonoDlFallbackSymbol symbol_func,
 						  MonoDlFallbackClose close_func, void *user_data);
 
-void                   mono_dl_fallback_unregister (MonoDlFallbackHandler *handler);
+MONO_API void                   mono_dl_fallback_unregister (MonoDlFallbackHandler *handler);
 
 MONO_END_DECLS
 

--- a/mono/utils/mono-embed.h
+++ b/mono/utils/mono-embed.h
@@ -13,7 +13,7 @@ typedef struct {
 	void *addr;
 } MonoDlMapping;
 
-void mono_dl_register_library (const char *name, MonoDlMapping *mappings);
+MONO_API void mono_dl_register_library (const char *name, MonoDlMapping *mappings);
 
 MONO_END_DECLS
 

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -43,22 +43,22 @@ typedef struct {
 
 MONO_BEGIN_DECLS
 
-void
+MONO_API void
 mono_error_init (MonoError *error);
 
-void
+MONO_API void
 mono_error_init_flags (MonoError *error, unsigned short flags);
 
-void
+MONO_API void
 mono_error_cleanup (MonoError *error);
 
-mono_bool
+MONO_API mono_bool
 mono_error_ok (MonoError *error);
 
-unsigned short
+MONO_API unsigned short
 mono_error_get_error_code (MonoError *error);
 
-const char*
+MONO_API const char*
 mono_error_get_message (MonoError *error);
 
 MONO_END_DECLS

--- a/mono/utils/mono-logger.h
+++ b/mono/utils/mono-logger.h
@@ -4,10 +4,10 @@
 #include <mono/utils/mono-publib.h>
 MONO_BEGIN_DECLS
 
-void 
+MONO_API void 
 mono_trace_set_level_string (const char *value);
 
-void 
+MONO_API void 
 mono_trace_set_mask_string (const char *value);
 
 MONO_END_DECLS

--- a/mono/utils/mono-math.h
+++ b/mono/utils/mono-math.h
@@ -3,16 +3,17 @@
 #define __MONO_SIGNBIT_H__
 
 #include <math.h>
+#include <mono/utils/mono-publib.h>
 
 #ifdef HAVE_SIGNBIT
 #define mono_signbit signbit
 #else
 #define mono_signbit(x) (sizeof (x) == sizeof (float) ? mono_signbit_float (x) : mono_signbit_double (x))
 
-int
+MONO_API int
 mono_signbit_double (double x);
 
-int
+MONO_API int
 mono_signbit_float (float x);
 
 #endif

--- a/mono/utils/mono-mmap.h
+++ b/mono/utils/mono-mmap.h
@@ -2,6 +2,7 @@
 #define __MONO_UTILS_MMAP_H__
 
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
 enum {
 	/* protection */
@@ -24,28 +25,28 @@ enum {
  */
 typedef struct _MonoFileMap MonoFileMap;
 
-MonoFileMap *mono_file_map_open  (const char* name);
-guint64      mono_file_map_size  (MonoFileMap *fmap);
-int          mono_file_map_fd    (MonoFileMap *fmap);
-int          mono_file_map_close (MonoFileMap *fmap);
+MONO_API MonoFileMap *mono_file_map_open  (const char* name);
+MONO_API guint64      mono_file_map_size  (MonoFileMap *fmap);
+MONO_API int          mono_file_map_fd    (MonoFileMap *fmap);
+MONO_API int          mono_file_map_close (MonoFileMap *fmap);
 
-int   mono_pagesize   (void);
-void* mono_valloc     (void *addr, size_t length, int flags);
-void* mono_valloc_aligned (size_t length, size_t alignment, int flags);
-int   mono_vfree      (void *addr, size_t length);
-void* mono_file_map   (size_t length, int flags, int fd, guint64 offset, void **ret_handle);
-int   mono_file_unmap (void *addr, void *handle);
+MONO_API int   mono_pagesize   (void);
+MONO_API void* mono_valloc     (void *addr, size_t length, int flags);
+MONO_API void* mono_valloc_aligned (size_t length, size_t alignment, int flags);
+MONO_API int   mono_vfree      (void *addr, size_t length);
+MONO_API void* mono_file_map   (size_t length, int flags, int fd, guint64 offset, void **ret_handle);
+MONO_API int   mono_file_unmap (void *addr, void *handle);
 #ifndef HOST_WIN32
-void* mono_file_map_fileio   (size_t length, int flags, int fd, guint64 offset, void **ret_handle);
-int   mono_file_unmap_fileio (void *addr, void *handle);
+MONO_API void* mono_file_map_fileio   (size_t length, int flags, int fd, guint64 offset, void **ret_handle);
+MONO_API int   mono_file_unmap_fileio (void *addr, void *handle);
 #endif
-int   mono_mprotect   (void *addr, size_t length, int flags);
+MONO_API int   mono_mprotect   (void *addr, size_t length, int flags);
 
-void* mono_shared_area         (void);
-void  mono_shared_area_remove  (void);
-void* mono_shared_area_for_pid (void *pid);
-void  mono_shared_area_unload  (void *area);
-int   mono_shared_area_instances (void **array, int count);
+MONO_API void* mono_shared_area         (void);
+MONO_API void  mono_shared_area_remove  (void);
+MONO_API void* mono_shared_area_for_pid (void *pid);
+MONO_API void  mono_shared_area_unload  (void *area);
+MONO_API int   mono_shared_area_instances (void **array, int count);
 
 /*
  * On systems where we have to load code into memory instead of mmaping
@@ -55,7 +56,7 @@ int   mono_shared_area_instances (void **array, int count);
 typedef void *(*mono_file_map_alloc_fn)   (size_t length);
 typedef void  (*mono_file_map_release_fn) (void *addr);
 
-void mono_file_map_set_allocator (mono_file_map_alloc_fn alloc, mono_file_map_release_fn release);
+MONO_API void mono_file_map_set_allocator (mono_file_map_alloc_fn alloc, mono_file_map_release_fn release);
 				  
 #endif /* __MONO_UTILS_MMAP_H__ */
 

--- a/mono/utils/mono-path.h
+++ b/mono/utils/mono-path.h
@@ -2,9 +2,10 @@
 #define __MONO_PATH_H
 
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
-gchar *mono_path_resolve_symlinks (const char *path);
-gchar *mono_path_canonicalize (const char *path);
+MONO_API gchar *mono_path_resolve_symlinks (const char *path);
+MONO_API gchar *mono_path_canonicalize (const char *path);
 
 #endif /* __MONO_PATH_H */
 

--- a/mono/utils/mono-poll.h
+++ b/mono/utils/mono-poll.h
@@ -1,6 +1,8 @@
 #ifndef MONO_POLL_H
 #define MONO_POLL_H
 
+#include <mono/utils/mono-publib.h>
+
 #include <config.h>
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
@@ -42,7 +44,7 @@ typedef struct {
 
 #endif
 
-int mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout);
+MONO_API int mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout);
 
 #endif /* MONO_POLL_H */
 

--- a/mono/utils/mono-property-hash.h
+++ b/mono/utils/mono-property-hash.h
@@ -18,22 +18,23 @@
 #define _MONO_PROPERTY_HASH_H_
 
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
 G_BEGIN_DECLS
 
 typedef struct _MonoPropertyHash MonoPropertyHash;
 
-MonoPropertyHash* mono_property_hash_new (void);
+MONO_API MonoPropertyHash* mono_property_hash_new (void);
 
-void mono_property_hash_destroy (MonoPropertyHash *hash);
+MONO_API void mono_property_hash_destroy (MonoPropertyHash *hash);
 
-void mono_property_hash_insert (MonoPropertyHash *hash, gpointer object, guint32 property,
+MONO_API void mono_property_hash_insert (MonoPropertyHash *hash, gpointer object, guint32 property,
 								gpointer value);
 
 /* Remove all properties of OBJECT */
-void mono_property_hash_remove_object (MonoPropertyHash *hash, gpointer object);
+MONO_API void mono_property_hash_remove_object (MonoPropertyHash *hash, gpointer object);
 
-gpointer mono_property_hash_lookup (MonoPropertyHash *hash, gpointer object, guint32 property);
+MONO_API gpointer mono_property_hash_lookup (MonoPropertyHash *hash, gpointer object, guint32 property);
 
 G_END_DECLS
 

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -18,7 +18,9 @@
 MONO_BEGIN_DECLS
 
 /* VS 2010 and later have stdint.h */
-#if defined(_MSC_VER) && _MSC_VER < 1600
+#if defined(_MSC_VER)
+
+#if _MSC_VER < 1600
 
 typedef __int8			int8_t;
 typedef unsigned __int8		uint8_t;
@@ -33,7 +35,25 @@ typedef unsigned __int64	uint64_t;
 
 #include <stdint.h>
 
+#endif
+
+#define MONO_API_EXPORT __declspec(dllexport)
+#define MONO_API_IMPORT __declspec(dllimport)
+
+#else
+
+#define MONO_API_EXPORT
+#define MONO_API_IMPORT
+
 #endif /* end of compiler-specific stuff */
+
+#if !defined(MONO_STATIC_BUILD) && defined(MONO_DLL_EXPORT)
+	#define MONO_API MONO_API_EXPORT
+#elif !defined(MONO_STATIC_BUILD)
+	#define MONO_API MONO_API_IMPORT
+#else
+	#define MONO_API
+#endif
 
 typedef int32_t		mono_bool;
 typedef uint8_t		mono_byte;
@@ -42,7 +62,7 @@ typedef uint16_t	mono_unichar2;
 typedef void	(*MonoFunc)	(void* data, void* user_data);
 typedef void	(*MonoHFunc)	(void* key, void* value, void* user_data);
 
-void mono_free (void *);
+MONO_API void mono_free (void *);
 
 #define MONO_CONST_RETURN const
 

--- a/mono/utils/mono-semaphore.h
+++ b/mono/utils/mono-semaphore.h
@@ -17,6 +17,7 @@
 #include <semaphore.h>
 #endif
 #include <mono/io-layer/io-layer.h>
+#include <mono/utils/mono-publib.h>
 
 #if (defined (HAVE_SEMAPHORE_H) || defined (USE_MACH_SEMA)) && !defined(HOST_WIN32)
 #  define MONO_HAS_SEMAPHORES
@@ -54,9 +55,9 @@ typedef HANDLE MonoSemType;
 
 G_BEGIN_DECLS
 
-int mono_sem_wait (MonoSemType *sem, gboolean alertable);
-int mono_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, gboolean alertable);
-int mono_sem_post (MonoSemType *sem);
+MONO_API int mono_sem_wait (MonoSemType *sem, gboolean alertable);
+MONO_API int mono_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, gboolean alertable);
+MONO_API int mono_sem_post (MonoSemType *sem);
 
 G_END_DECLS
 #endif /* _MONO_SEMAPHORE_H_ */

--- a/mono/utils/mono-uri.h
+++ b/mono/utils/mono-uri.h
@@ -1,8 +1,9 @@
 #ifndef __MONO_URI_H
 #define __MONO_URI_H
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
-gchar * mono_escape_uri_string (const gchar *string);
+MONO_API gchar * mono_escape_uri_string (const gchar *string);
 
 #endif /* __MONO_URI_H */
 

--- a/mono/utils/monobitset.h
+++ b/mono/utils/monobitset.h
@@ -2,6 +2,7 @@
 #define __MONO_BITSET_H__
 
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
 /*
  * When embedding, you have to define MONO_ZERO_LEN_ARRAY before including any
@@ -62,56 +63,56 @@ enum {
  * Interface documentation by Dennis Haney.
  */
 
-guint32     mono_bitset_alloc_size   (guint32 max_size, guint32 flags);
+MONO_API guint32     mono_bitset_alloc_size   (guint32 max_size, guint32 flags);
 
-MonoBitSet* mono_bitset_new          (guint32 max_size, guint32 flags);
+MONO_API MonoBitSet* mono_bitset_new          (guint32 max_size, guint32 flags);
 
-MonoBitSet* mono_bitset_mem_new      (gpointer mem, guint32 max_size, guint32 flags);
+MONO_API MonoBitSet* mono_bitset_mem_new      (gpointer mem, guint32 max_size, guint32 flags);
 
-void        mono_bitset_free         (MonoBitSet *set); 
+MONO_API void        mono_bitset_free         (MonoBitSet *set); 
 
-void        mono_bitset_set          (MonoBitSet *set, guint32 pos);
+MONO_API void        mono_bitset_set          (MonoBitSet *set, guint32 pos);
 
-void        mono_bitset_set_all      (MonoBitSet *set);
+MONO_API void        mono_bitset_set_all      (MonoBitSet *set);
 
-int         mono_bitset_test         (const MonoBitSet *set, guint32 pos);
+MONO_API int         mono_bitset_test         (const MonoBitSet *set, guint32 pos);
 
-gsize       mono_bitset_test_bulk    (const MonoBitSet *set, guint32 pos);
+MONO_API gsize       mono_bitset_test_bulk    (const MonoBitSet *set, guint32 pos);
 
-void        mono_bitset_clear        (MonoBitSet *set, guint32 pos);
+MONO_API void        mono_bitset_clear        (MonoBitSet *set, guint32 pos);
 
-void        mono_bitset_clear_all    (MonoBitSet *set);
+MONO_API void        mono_bitset_clear_all    (MonoBitSet *set);
 
-void        mono_bitset_invert       (MonoBitSet *set);
+MONO_API void        mono_bitset_invert       (MonoBitSet *set);
 
-guint32     mono_bitset_size         (const MonoBitSet *set);
+MONO_API guint32     mono_bitset_size         (const MonoBitSet *set);
 
-guint32     mono_bitset_count        (const MonoBitSet *set);
+MONO_API guint32     mono_bitset_count        (const MonoBitSet *set);
 
-void        mono_bitset_low_high     (const MonoBitSet *set, guint32 *low, guint32 *high);
+MONO_API void        mono_bitset_low_high     (const MonoBitSet *set, guint32 *low, guint32 *high);
 
-int         mono_bitset_find_start   (const MonoBitSet *set);
+MONO_API int         mono_bitset_find_start   (const MonoBitSet *set);
 
-int         mono_bitset_find_first   (const MonoBitSet *set, gint pos);
+MONO_API int         mono_bitset_find_first   (const MonoBitSet *set, gint pos);
 
-int         mono_bitset_find_last    (const MonoBitSet *set, gint pos);
+MONO_API int         mono_bitset_find_last    (const MonoBitSet *set, gint pos);
 
-int         mono_bitset_find_first_unset (const MonoBitSet *set, gint pos);
+MONO_API int         mono_bitset_find_first_unset (const MonoBitSet *set, gint pos);
 
-MonoBitSet* mono_bitset_clone        (const MonoBitSet *set, guint32 new_size);
+MONO_API MonoBitSet* mono_bitset_clone        (const MonoBitSet *set, guint32 new_size);
 
-void        mono_bitset_copyto       (const MonoBitSet *src, MonoBitSet *dest);
+MONO_API void        mono_bitset_copyto       (const MonoBitSet *src, MonoBitSet *dest);
 
-void        mono_bitset_union        (MonoBitSet *dest, const MonoBitSet *src);
+MONO_API void        mono_bitset_union        (MonoBitSet *dest, const MonoBitSet *src);
 
-void        mono_bitset_intersection (MonoBitSet *dest, const MonoBitSet *src);
+MONO_API void        mono_bitset_intersection (MonoBitSet *dest, const MonoBitSet *src);
 
-void        mono_bitset_sub          (MonoBitSet *dest, const MonoBitSet *src);
+MONO_API void        mono_bitset_sub          (MonoBitSet *dest, const MonoBitSet *src);
 
-gboolean    mono_bitset_equal        (const MonoBitSet *src, const MonoBitSet *src1);
+MONO_API gboolean    mono_bitset_equal        (const MonoBitSet *src, const MonoBitSet *src1);
 
-void        mono_bitset_foreach      (MonoBitSet *set, MonoBitSetFunc func, gpointer data);
+MONO_API void        mono_bitset_foreach      (MonoBitSet *set, MonoBitSetFunc func, gpointer data);
 
-void        mono_bitset_intersection_2 (MonoBitSet *dest, const MonoBitSet *src1, const MonoBitSet *src2);
+MONO_API void        mono_bitset_intersection_2 (MonoBitSet *dest, const MonoBitSet *src1, const MonoBitSet *src2);
 
 #endif /* __MONO_BITSET_H__ */

--- a/mono/utils/strenc.h
+++ b/mono/utils/strenc.h
@@ -11,11 +11,12 @@
 #define _MONO_STRENC_H_ 1
 
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
-extern gunichar2 *mono_unicode_from_external (const gchar *in, gsize *bytes);
-extern gchar *mono_utf8_from_external (const gchar *in);
-extern gchar *mono_unicode_to_external (const gunichar2 *uni);
-extern gboolean mono_utf8_validate_and_len (const gchar *source, glong* oLength, const gchar** oEnd);
-extern gboolean mono_utf8_validate_and_len_with_bounds (const gchar *source, glong max_bytes, glong* oLength, const gchar** oEnd);
+extern MONO_API gunichar2 *mono_unicode_from_external (const gchar *in, gsize *bytes);
+extern MONO_API gchar *mono_utf8_from_external (const gchar *in);
+extern MONO_API gchar *mono_unicode_to_external (const gunichar2 *uni);
+extern MONO_API gboolean mono_utf8_validate_and_len (const gchar *source, glong* oLength, const gchar** oEnd);
+extern MONO_API gboolean mono_utf8_validate_and_len_with_bounds (const gchar *source, glong max_bytes, glong* oLength, const gchar** oEnd);
 
 #endif /* _MONO_STRENC_H_ */


### PR DESCRIPTION
As the title says, this adds public API visibility macros, which should help the Windows build to be more straightforward, namely no need to maintain the separate .def file with exports which is usually out-of-sync with the latest revisions. 

In the future, this could also be used to control visibility with GCC/Clang so there would be no need for MONO_INTERNAL (while changing the default visibility to hidden).

I verified all of the symbols of the compiled DLL in Windows vs. the .def file listing and it exports all the APIs that were previously exported (plus a handful new ones that have been introduced).

If no one objects, I will send another pull in the future removing the .def and related files and re-doing a bit of the Windows build scripts.
