### PR TITLE
[Critical] [runtime] don't declare already declared suspend_semaphore

### DIFF
--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -108,7 +108,6 @@ typedef struct {
 
 	/* only needed by the posix backend */ 
 #if (defined(_POSIX_VERSION) || defined(__native_client__)) && !defined (__MACH__)
-	MonoSemType suspend_semaphore;
 	gboolean syscall_break_signal;
 	gboolean suspend_can_continue;
 #endif


### PR DESCRIPTION
Fix for:

```
utils/mono-threads.h:111:14: error: duplicate member 'suspend_semaphore'
```
