### PR TITLE
Clean up preprocessor ifdefs in mono_thread_get_stack_bounds and fix the way thread stack information is retrieved on BSD

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -831,16 +831,8 @@ __readfsdword (unsigned long long offset)
 void
 mono_thread_get_stack_bounds (guint8 **staddr, size_t *stsize)
 {
-#if defined(HAVE_PTHREAD_GET_STACKSIZE_NP) && defined(HAVE_PTHREAD_GET_STACKADDR_NP)
-	*staddr = (guint8*)pthread_get_stackaddr_np (pthread_self ());
-	*stsize = pthread_get_stacksize_np (pthread_self ());
-
-	/* staddr points to the start of the stack, not the end */
-	*staddr -= *stsize;
-	*staddr = (guint8*)((gssize)*staddr & ~(mono_pagesize () - 1));
-	return;
-	/* FIXME: simplify the mess below */
-#elif defined(HOST_WIN32)
+#if defined(HOST_WIN32)
+	/* Windows */
 	/* http://en.wikipedia.org/wiki/Win32_Thread_Information_Block */
 	void* tib = (void*)__readfsdword(0x18);
 	guint8 *stackTop = (guint8*)*(int*)((char*)tib + 4);
@@ -849,7 +841,22 @@ mono_thread_get_stack_bounds (guint8 **staddr, size_t *stsize)
 	*staddr = stackBottom;
 	*stsize = stackTop - stackBottom;
 	return;
-#else
+
+#elif defined(HAVE_PTHREAD_GET_STACKSIZE_NP) && defined(HAVE_PTHREAD_GET_STACKADDR_NP)
+	/* Mac OS X */
+	*staddr = (guint8*)pthread_get_stackaddr_np (pthread_self());
+	*stsize = pthread_get_stacksize_np (pthread_self());
+
+	/* staddr points to the start of the stack, not the end */
+	*staddr -= *stsize;
+
+	/* When running under emacs, sometimes staddr is not aligned to a page size */
+	*staddr = (guint8*)((gssize)*staddr & ~(mono_pagesize() - 1));
+	return;
+
+#elif (defined(HAVE_PTHREAD_GETATTR_NP) || defined(HAVE_PTHREAD_ATTR_GET_NP)) && defined(HAVE_PTHREAD_ATTR_GETSTACK)
+	/* Linux, BSD */
+
 	pthread_attr_t attr;
 	guint8 *current = (guint8*)&attr;
 
@@ -857,15 +864,41 @@ mono_thread_get_stack_bounds (guint8 **staddr, size_t *stsize)
 	*stsize = (size_t)-1;
 
 	pthread_attr_init (&attr);
-#  ifdef HAVE_PTHREAD_GETATTR_NP
+
+#if     defined(HAVE_PTHREAD_GETATTR_NP)
+	/* Linux */
 	pthread_getattr_np (pthread_self(), &attr);
-#  else
-#    ifdef HAVE_PTHREAD_ATTR_GET_NP
+
+#elif   defined(HAVE_PTHREAD_ATTR_GET_NP)
+	/* BSD */
 	pthread_attr_get_np (pthread_self(), &attr);
-#    elif defined(sun)
+
+#else
+#error 	Cannot determine which API is needed to retrieve pthread attributes.
+#endif
+
+	pthread_attr_getstack (&attr, (void**)staddr, stsize);
+	pthread_attr_destroy (&attr);
+
+	if (*staddr)
+		g_assert ((current > *staddr) && (current < *staddr + *stsize));
+
+	/* When running under emacs, sometimes staddr is not aligned to a page size */
+	*staddr = (guint8*)((gssize)*staddr & ~(mono_pagesize () - 1));
+	return;
+
+#elif defined(__OpenBSD__)
+	/* OpenBSD */
+	/* TODO :   Determine if this code is actually still needed. It may already be covered by the case above. */
+
+	pthread_attr_t attr;
+	guint8 *current = (guint8*)&attr;
+
 	*staddr = NULL;
-	pthread_attr_getstacksize (&attr, &stsize);
-#    elif defined(__OpenBSD__)
+	*stsize = (size_t)-1;
+
+	pthread_attr_init (&attr);
+
 	stack_t ss;
 	int rslt;
 
@@ -874,29 +907,33 @@ mono_thread_get_stack_bounds (guint8 **staddr, size_t *stsize)
 
 	*staddr = (guint8*)((size_t)ss.ss_sp - ss.ss_size);
 	*stsize = ss.ss_size;
-#    else
-	*staddr = NULL;
-	*stsize = 0;
-	return;
-#    endif
-#  endif
-
-#  if !defined(sun)
-#    if defined(__native_client__)
-	*staddr = NULL;
-	pthread_attr_getstacksize (&attr, &stsize);
-#    elif !defined(__OpenBSD__)
-	pthread_attr_getstack (&attr, (void**)staddr, stsize);
-#    endif
-	if (*staddr)
-		g_assert ((current > *staddr) && (current < *staddr + *stsize));
-#  endif
 
 	pthread_attr_destroy (&attr);
-#endif
+
+	if (*staddr)
+		g_assert ((current > *staddr) && (current < *staddr + *stsize));
 
 	/* When running under emacs, sometimes staddr is not aligned to a page size */
 	*staddr = (guint8*)((gssize)*staddr & ~(mono_pagesize () - 1));
+	return;
+
+#elif defined(sun) || defined(__native_client__)
+	/* Solaris/Illumos, NaCl */
+	pthread_attr_t attr;
+	pthread_attr_init (&attr);
+	pthread_attr_getstacksize (&attr, &stsize);
+	pthread_attr_destroy (&attr);
+	*staddr = NULL;
+	return;
+
+#else
+	/* FIXME:   It'd be better to use the 'error' preprocessor macro here so we know
+		    at compile-time if the target platform isn't supported. */
+#warning Unable to determine how to retrieve a thread's stack-bounds for this platform in 'mono_thread_get_stack_bounds()'.
+	*staddr = NULL;
+	*stsize = 0;
+	return;
+#endif
 }
 
 MonoThread *


### PR DESCRIPTION
Cleaned up the heavily-nested preprocessor ifdefs. The code within the function was extremely difficult to understand because of the nested preprocessor directives, which has led to a number of avoidable configuration-related bugs. I've de-nested the ifdefs into a mostly-flat style, where we check for each platform just once and the entirety of the code for that platform falls under that single check. This improves the readability of the code and should fix the configuration-related issues on some platforms.

This code also fixes an issue where thread-stack information wasn't retrieved correctly on BSD-based systems; now the platform is detected correctly and the `pthread_attr_get_np` function used to retrieve the information.

This subsumes pull-request #553, which couldn't be merged with the current master branch due to several changes which were made to the `mono_thread_get_stack_bounds` function since that pull request was submitted. This commit also keeps the OpenBSD-related code for auditing purposes, though it may be removed later if testing shows the "generic" BSD handler works for OpenBSD.

The code in this commit is hereby released under the terms of the MIT/X11 license.
