### PR TITLE
Support for setting a pretty mono process title on OSX and Linux

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -400,6 +400,8 @@ common_sources = \
 	ssapre.h		\
 	local-propagation.c	\
 	driver.c		\
+	proctitle.c  \
+	proctitle-darwin.c \
 	debug-mini.c		\
 	debug-mini.h		\
 	linear-scan.c		\
@@ -549,7 +551,7 @@ endif
 if PLATFORM_DARWIN
 os_sources = $(darwin_sources) $(posix_sources)
 #monobin_platform_ldflags=-sectcreate __TEXT __info_plist $(top_srcdir)/mono/mini/Info.plist -framework CoreFoundation
-monobin_platform_ldflags=-framework CoreFoundation
+monobin_platform_ldflags=-framework CoreFoundation -framework ApplicationServices
 endif
 
 libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(arch_sources) $(os_sources)

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -54,6 +54,7 @@
 #include <ctype.h>
 #include <locale.h>
 #include "version.h"
+#include "proctitle.h"
 #include "debugger-agent.h"
 
 static FILE *mini_stats_fd = NULL;
@@ -1158,6 +1159,8 @@ mini_usage (void)
 #ifdef HOST_WIN32
 	        "    --mixed-mode           Enable mixed-mode image support.\n"
 #endif
+        "    --process-title=NAME   Sets the process title to NAME. Currently supported on\n"
+		"                           Linux and Mac OSX platforms.\n"
 	  );
 }
 
@@ -1528,6 +1531,8 @@ mono_main (int argc, char* argv[])
 			mini_stats_fd = fopen (argv [++i], "w+");
 		} else if (strncmp (argv [i], "--optimize=", 11) == 0) {
 			opt = parse_optimizations (argv [i] + 11);
+		} else if (strncmp (argv [i], "--process-title=", 16) == 0) {
+			mono_proctitle_set (argv [i] + 16);
 		} else if (strncmp (argv [i], "-O=", 3) == 0) {
 			opt = parse_optimizations (argv [i] + 3);
 		} else if (strcmp (argv [i], "--gc=sgen") == 0) {

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -6,6 +6,8 @@
 #endif
 #endif
 
+#include "proctitle.h"
+
 /*
  * If the MONO_ENV_OPTIONS environment variable is set, it uses this as a
  * source of command line arguments that are passed to Mono before the
@@ -15,6 +17,11 @@ static int
 mono_main_with_options (int argc, char *argv [])
 {
 	const char *env_options = getenv ("MONO_ENV_OPTIONS");
+    int ret;
+
+    /* setup the arguments to support setting the process title */
+    argv = mono_proctitle_start(argc, argv);
+
 	if (env_options != NULL){
 		GPtrArray *array = g_ptr_array_new ();
 		GString *buffer = g_string_new ("");
@@ -88,7 +95,11 @@ mono_main_with_options (int argc, char *argv [])
 		g_ptr_array_free (array, TRUE);
 	}
 
-	return mono_main (argc, argv);
+	ret = mono_main (argc, argv);
+	
+	mono_proctitle_shutdown();
+	
+	return ret;
 }
 
 #ifdef HOST_WIN32

--- a/mono/mini/proctitle-darwin.c
+++ b/mono/mini/proctitle-darwin.c
@@ -1,0 +1,86 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifdef PLATFORM_MACOSX
+
+/* undefine MonoGetCurrentProcess */
+#undef GetCurrentProcess
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <ApplicationServices/ApplicationServices.h>
+#include "proctitle.h"
+
+int mono_proctitle_set_macosx(const char* title) {
+
+  typedef CFTypeRef (*LSGetCurrentApplicationASNType)(void);
+  typedef OSStatus (*LSSetApplicationInformationItemType)(int,
+                                                          CFTypeRef,
+                                                          CFStringRef,
+                                                          CFStringRef,
+                                                          CFDictionaryRef*);
+  CFBundleRef launch_services_bundle;
+  LSGetCurrentApplicationASNType ls_get_current_application_asn;
+  LSSetApplicationInformationItemType ls_set_application_information_item;
+  CFStringRef* display_name_key;
+  ProcessSerialNumber psn;
+  CFTypeRef asn;
+  CFStringRef display_name;
+  OSStatus err;
+
+  launch_services_bundle =
+      CFBundleGetBundleWithIdentifier(CFSTR("com.apple.LaunchServices"));
+
+  if (launch_services_bundle == NULL)
+    return -1;
+
+  ls_get_current_application_asn = (LSGetCurrentApplicationASNType)
+      CFBundleGetFunctionPointerForName(launch_services_bundle,
+                                        CFSTR("_LSGetCurrentApplicationASN"));
+
+  if (ls_get_current_application_asn == NULL)
+    return -1;
+
+  ls_set_application_information_item = (LSSetApplicationInformationItemType)
+      CFBundleGetFunctionPointerForName(launch_services_bundle,
+                                        CFSTR("_LSSetApplicationInformationItem"));
+
+  if (ls_set_application_information_item == NULL)
+    return -1;
+
+  display_name_key = CFBundleGetDataPointerForName(launch_services_bundle,
+                                                   CFSTR("_kLSDisplayNameKey"));
+
+  if (display_name_key == NULL || *display_name_key == NULL)
+    return -1;
+
+  /* Force the process manager to initialize. */
+  GetCurrentProcess(&psn);
+
+  display_name = CFStringCreateWithCString(NULL, title, kCFStringEncodingUTF8);
+  asn = ls_get_current_application_asn();
+  err = ls_set_application_information_item(-2,  /* Magic value. */
+                                            asn,
+                                            *display_name_key,
+                                            display_name,
+                                            NULL);
+
+  return (err == noErr) ? 0 : -1;
+}
+#endif

--- a/mono/mini/proctitle-darwin.c
+++ b/mono/mini/proctitle-darwin.c
@@ -18,69 +18,188 @@
  * IN THE SOFTWARE.
  */
 
-#ifdef PLATFORM_MACOSX
+#if defined(PLATFORM_MACOSX)
 
-/* undefine MonoGetCurrentProcess */
-#undef GetCurrentProcess
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
 
-#include <CoreFoundation/CoreFoundation.h>
-#include <ApplicationServices/ApplicationServices.h>
+#if !TARGET_OS_IPHONE
+# include <CoreFoundation/CoreFoundation.h>
+# include <ApplicationServices/ApplicationServices.h>
+#endif
+
 #include "proctitle.h"
 
-int mono_proctitle_set_macosx(const char* title) {
+static int mono__pthread_setname_np(const char* name) {
+  int (*dynamic_pthread_setname_np)(const char* name);
+  char namebuf[64];  /* MAXTHREADNAMESIZE */
+  int err;
 
-  typedef CFTypeRef (*LSGetCurrentApplicationASNType)(void);
-  typedef OSStatus (*LSSetApplicationInformationItemType)(int,
-                                                          CFTypeRef,
-                                                          CFStringRef,
-                                                          CFStringRef,
-                                                          CFDictionaryRef*);
+  /* pthread_setname_np() first appeared in OS X 10.6 and iOS 3.2. */
+  dynamic_pthread_setname_np = dlsym(RTLD_DEFAULT, "pthread_setname_np");
+  if (dynamic_pthread_setname_np == NULL)
+    return -ENOSYS;
+
+  strncpy(namebuf, name, sizeof(namebuf) - 1);
+  namebuf[sizeof(namebuf) - 1] = '\0';
+
+  err = dynamic_pthread_setname_np(namebuf);
+  if (err)
+    return -err;
+
+  return 0;
+}
+
+
+int mono_proctitle_set_darwin(const char* title) {
+#if TARGET_OS_IPHONE
+  return mono__pthread_setname_np(title);
+#else
+  CFStringRef (*pCFStringCreateWithCString)(CFAllocatorRef,
+                                            const char*,
+                                            CFStringEncoding);
+  CFBundleRef (*pCFBundleGetBundleWithIdentifier)(CFStringRef);
+  void *(*pCFBundleGetDataPointerForName)(CFBundleRef, CFStringRef);
+  void *(*pCFBundleGetFunctionPointerForName)(CFBundleRef, CFStringRef);
+  CFTypeRef (*pLSGetCurrentApplicationASN)(void);
+  OSStatus (*pLSSetApplicationInformationItem)(int,
+                                               CFTypeRef,
+                                               CFStringRef,
+                                               CFStringRef,
+                                               CFDictionaryRef*);
+  void* application_services_handle;
+  void* core_foundation_handle;
   CFBundleRef launch_services_bundle;
-  LSGetCurrentApplicationASNType ls_get_current_application_asn;
-  LSSetApplicationInformationItemType ls_set_application_information_item;
   CFStringRef* display_name_key;
-  ProcessSerialNumber psn;
+  CFDictionaryRef (*pCFBundleGetInfoDictionary)(CFBundleRef);
+  CFBundleRef (*pCFBundleGetMainBundle)(void);
+  CFBundleRef hi_services_bundle;
+  OSStatus (*pSetApplicationIsDaemon)(int);
+  CFDictionaryRef (*pLSApplicationCheckIn)(int, CFDictionaryRef);
+  void (*pLSSetApplicationLaunchServicesServerConnectionStatus)(uint64_t,
+                                                                void*);
   CFTypeRef asn;
-  CFStringRef display_name;
-  OSStatus err;
+  int err;
+
+  err = -ENOENT;
+  application_services_handle = dlopen("/System/Library/Frameworks/"
+                                       "ApplicationServices.framework/"
+                                       "Versions/A/ApplicationServices",
+                                       RTLD_LAZY | RTLD_LOCAL);
+  core_foundation_handle = dlopen("/System/Library/Frameworks/"
+                                  "CoreFoundation.framework/"
+                                  "Versions/A/CoreFoundation",
+                                  RTLD_LAZY | RTLD_LOCAL);
+
+  if (application_services_handle == NULL || core_foundation_handle == NULL)
+    goto out;
+
+  pCFStringCreateWithCString =
+      dlsym(core_foundation_handle, "CFStringCreateWithCString");
+  pCFBundleGetBundleWithIdentifier =
+      dlsym(core_foundation_handle, "CFBundleGetBundleWithIdentifier");
+  pCFBundleGetDataPointerForName =
+      dlsym(core_foundation_handle, "CFBundleGetDataPointerForName");
+  pCFBundleGetFunctionPointerForName =
+      dlsym(core_foundation_handle, "CFBundleGetFunctionPointerForName");
+
+  if (pCFStringCreateWithCString == NULL ||
+      pCFBundleGetBundleWithIdentifier == NULL ||
+      pCFBundleGetDataPointerForName == NULL ||
+      pCFBundleGetFunctionPointerForName == NULL) {
+    goto out;
+  }
+
+#define S(s) pCFStringCreateWithCString(NULL, (s), kCFStringEncodingUTF8)
 
   launch_services_bundle =
-      CFBundleGetBundleWithIdentifier(CFSTR("com.apple.LaunchServices"));
+      pCFBundleGetBundleWithIdentifier(S("com.apple.LaunchServices"));
 
   if (launch_services_bundle == NULL)
-    return -1;
+    goto out;
 
-  ls_get_current_application_asn = (LSGetCurrentApplicationASNType)
-      CFBundleGetFunctionPointerForName(launch_services_bundle,
-                                        CFSTR("_LSGetCurrentApplicationASN"));
+  pLSGetCurrentApplicationASN =
+      pCFBundleGetFunctionPointerForName(launch_services_bundle,
+                                         S("_LSGetCurrentApplicationASN"));
 
-  if (ls_get_current_application_asn == NULL)
-    return -1;
+  if (pLSGetCurrentApplicationASN == NULL)
+    goto out;
 
-  ls_set_application_information_item = (LSSetApplicationInformationItemType)
-      CFBundleGetFunctionPointerForName(launch_services_bundle,
-                                        CFSTR("_LSSetApplicationInformationItem"));
+  pLSSetApplicationInformationItem =
+      pCFBundleGetFunctionPointerForName(launch_services_bundle,
+                                         S("_LSSetApplicationInformationItem"));
 
-  if (ls_set_application_information_item == NULL)
-    return -1;
+  if (pLSSetApplicationInformationItem == NULL)
+    goto out;
 
-  display_name_key = CFBundleGetDataPointerForName(launch_services_bundle,
-                                                   CFSTR("_kLSDisplayNameKey"));
+  display_name_key = pCFBundleGetDataPointerForName(launch_services_bundle,
+                                                    S("_kLSDisplayNameKey"));
 
   if (display_name_key == NULL || *display_name_key == NULL)
-    return -1;
+    goto out;
 
-  /* Force the process manager to initialize. */
-  GetCurrentProcess(&psn);
+  pCFBundleGetInfoDictionary = dlsym(core_foundation_handle,
+                                     "CFBundleGetInfoDictionary");
+  pCFBundleGetMainBundle = dlsym(core_foundation_handle,
+                                 "CFBundleGetMainBundle");
+  if (pCFBundleGetInfoDictionary == NULL || pCFBundleGetMainBundle == NULL)
+    goto out;
 
-  display_name = CFStringCreateWithCString(NULL, title, kCFStringEncodingUTF8);
-  asn = ls_get_current_application_asn();
-  err = ls_set_application_information_item(-2,  /* Magic value. */
-                                            asn,
-                                            *display_name_key,
-                                            display_name,
-                                            NULL);
+  /* Black 10.9 magic, to remove (Not responding) mark in Activity Monitor */
+  hi_services_bundle =
+      pCFBundleGetBundleWithIdentifier(S("com.apple.HIServices"));
+  err = -ENOENT;
+  if (hi_services_bundle == NULL)
+    goto out;
 
-  return (err == noErr) ? 0 : -1;
+  pSetApplicationIsDaemon = pCFBundleGetFunctionPointerForName(
+      hi_services_bundle,
+      S("SetApplicationIsDaemon"));
+  pLSApplicationCheckIn = pCFBundleGetFunctionPointerForName(
+      launch_services_bundle,
+      S("_LSApplicationCheckIn"));
+  pLSSetApplicationLaunchServicesServerConnectionStatus =
+      pCFBundleGetFunctionPointerForName(
+          launch_services_bundle,
+          S("_LSSetApplicationLaunchServicesServerConnectionStatus"));
+  if (pSetApplicationIsDaemon == NULL ||
+      pLSApplicationCheckIn == NULL ||
+      pLSSetApplicationLaunchServicesServerConnectionStatus == NULL) {
+    goto out;
+  }
+
+  if (pSetApplicationIsDaemon(1) != noErr)
+    goto out;
+
+  pLSSetApplicationLaunchServicesServerConnectionStatus(0, NULL);
+
+  /* Check into process manager?! */
+  pLSApplicationCheckIn(-2,
+                        pCFBundleGetInfoDictionary(pCFBundleGetMainBundle()));
+
+  asn = pLSGetCurrentApplicationASN();
+
+  err = -EINVAL;
+  if (pLSSetApplicationInformationItem(-2,  /* Magic value. */
+                                       asn,
+                                       *display_name_key,
+                                       S(title),
+                                       NULL) != noErr) {
+    goto out;
+  }
+
+  mono__pthread_setname_np(title);  /* Don't care if it fails. */
+  err = 0;
+
+out:
+  if (core_foundation_handle != NULL)
+    dlclose(core_foundation_handle);
+
+  if (application_services_handle != NULL)
+    dlclose(application_services_handle);
+
+  return err;
+#endif  /* !TARGET_OS_IPHONE */
 }
 #endif

--- a/mono/mini/proctitle.c
+++ b/mono/mini/proctitle.c
@@ -21,14 +21,14 @@
 #include "mini.h"
 #include "proctitle.h"
 
-#if defined(PLATFORM_MACOSX) || defined(PLATFORM_LINUX)
+#if defined(PLATFORM_MACOSX) || defined(__linux__)
 
-static void* args_mem;
+static void* args_mem = NULL;
 
 static struct {
   char* str;
   size_t len;
-} mono_process_title;
+} mono_process_title = { NULL, 0 };
 
 char** mono_proctitle_start (int argc, char** argv) {
   char** new_argv;

--- a/mono/mini/proctitle.c
+++ b/mono/mini/proctitle.c
@@ -1,0 +1,109 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+ 
+#include "mini.h"
+#include "proctitle.h"
+
+#if defined(PLATFORM_MACOSX) || defined(PLATFORM_LINUX)
+
+static void* args_mem;
+
+static struct {
+  char* str;
+  size_t len;
+} mono_process_title;
+
+char** mono_proctitle_start (int argc, char** argv) {
+  char** new_argv;
+  size_t size;
+  char* s;
+  int i;
+
+  if (argc <= 0)
+    return argv;
+
+  /* Calculate how much memory we need for the argv strings. */
+  size = 0;
+  for (i = 0; i < argc; i++)
+    size += strlen(argv[i]) + 1;
+
+  mono_process_title.str = argv[0];
+  mono_process_title.len = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
+  assert(mono_process_title.len + 1 == size);  /* argv memory should be adjacent. */
+
+  /* Add space for the argv pointers. */
+  size += (argc + 1) * sizeof(char*);
+
+  new_argv = malloc(size);
+  if (new_argv == NULL)
+    return argv;
+  args_mem = new_argv;
+
+  /* Copy over the strings and set up the pointer table. */
+  s = (char*) &new_argv[argc + 1];
+  for (i = 0; i < argc; i++) {
+    size = strlen(argv[i]) + 1;
+    memcpy(s, argv[i], size);
+    new_argv[i] = s;
+    s += size;
+  }
+  new_argv[i] = NULL;
+
+  return new_argv;
+}
+
+int mono_proctitle_set(const char* title) 
+{
+  if (mono_process_title.len == 0)
+    return 0;
+
+  /* No need to terminate, byte after is always '\0'. */
+  strncpy(mono_process_title.str, title, mono_process_title.len);
+  
+#ifdef PLATFORM_MACOSX  
+  mono_proctitle_set_macosx(title);
+#endif
+
+  return 0;
+}
+
+void mono_proctitle_shutdown()
+{
+  free(args_mem);
+  args_mem = NULL;
+}
+
+#else
+
+char** mono_proctitle_start (int argc, char **argv)
+{
+    return argv;
+}
+
+int mono_proctitle_set(const char* title)
+{
+    return 0;
+}
+
+void mono_proctitle_shutdown()
+{
+}
+
+#endif

--- a/mono/mini/proctitle.c
+++ b/mono/mini/proctitle.c
@@ -77,8 +77,8 @@ int mono_proctitle_set(const char* title)
   /* No need to terminate, byte after is always '\0'. */
   strncpy(mono_process_title.str, title, mono_process_title.len);
   
-#ifdef PLATFORM_MACOSX  
-  mono_proctitle_set_macosx(title);
+#if defined(PLATFORM_MACOSX)
+  mono_proctitle_set_darwin(title);
 #endif
 
   return 0;

--- a/mono/mini/proctitle.h
+++ b/mono/mini/proctitle.h
@@ -1,0 +1,18 @@
+/* Sets up the arguments to support renaming the process title through rewriting argv 
+   Must be called with the argv pointer on process entry. Will potentially return 
+   a copy of argv.
+*/
+char** mono_proctitle_start (int argc, char **argv);
+
+/* Sets the process title. Can be called at anytime */
+int mono_proctitle_set(const char* title);
+
+/* Called to cleanup after proc title */
+void mono_proctitle_shutdown(void);
+
+/* private */
+
+#ifdef PLATFORM_MACOSX
+int mono_proctitle_set_macosx(const char* title);
+#endif
+

--- a/mono/mini/proctitle.h
+++ b/mono/mini/proctitle.h
@@ -12,7 +12,7 @@ void mono_proctitle_shutdown(void);
 
 /* private */
 
-#ifdef PLATFORM_MACOSX
-int mono_proctitle_set_macosx(const char* title);
+#if defined(PLATFORM_MACOSX)
+int mono_proctitle_set_darwin(const char* title);
 #endif
 


### PR DESCRIPTION
When running multiple mono processes on a machine its really hard to tell them apart. This adds support to give each process a pretty process name. Works well on Linux and OSX, could probably support other platforms but I've not been able to test this on any more. Windows does not have support for changing the process title.