### PR TITLE
Do a dynamic link relative to the bin folder.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -118,7 +118,7 @@ mono: mono-$(mono_bin_suffix)
 	ln -sf $< $@
 
 install-exec-hook:
-	ln -sf $(DESTDIR)$(bindir)/mono-$(libmono_suffix) $(DESTDIR)$(bindir)/mono
+	ln -sf mono-$(libmono_suffix) $(DESTDIR)$(bindir)/mono
 	(cd $(DESTDIR)$(libdir); for i in libmono$(libmono_suffix)*; do ln -sf $$i `echo $$i | sed s/$(libmono_suffix)//` ; done)
 endif
 


### PR DESCRIPTION
Instead of doing a global link to the position of the mono binaries use the relative position as they are both in the same folder.

Using a root based link is superfluous and creates issues with packaging systems not using fakeroot (like archlinux mono-git packages with makepkg), so this will generate a link mono -> mono-boehm instead of mono -> /usr/bin/mono-boehm (which would become the packaging folder in case of makepkg breaking the link)
