### PR TITLE
Added handling of 'targetFramework' attribute to HttpRuntime

### DIFF
--- a/mcs/class/System.Web/System.Web.Configuration_2.0/HttpRuntimeSection.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/HttpRuntimeSection.cs
@@ -65,6 +65,9 @@ namespace System.Web.Configuration
 		static ConfigurationProperty encoderTypeProp;
 		static ConfigurationProperty relaxedUrlToFileSystemMappingProp;
 #endif
+#if NET_4_5
+		static ConfigurationProperty targetFrameworkProp;
+#endif
 		static ConfigurationPropertyCollection properties;
 
 		static HttpRuntimeSection ()
@@ -141,6 +144,12 @@ namespace System.Web.Configuration
 								     ConfigurationPropertyOptions.None);
 			relaxedUrlToFileSystemMappingProp = new ConfigurationProperty ("relaxedUrlToFileSystemMapping", typeof (bool), false);
 #endif
+#if NET_4_5
+			targetFrameworkProp = new ConfigurationProperty ("targetFramework", typeof (Version), new Version (4, 0),
+										PropertyHelper.VersionConverter,
+										PropertyHelper.DefaultValidator,
+										ConfigurationPropertyOptions.None);
+#endif
 			
 			properties = new ConfigurationPropertyCollection();
 			properties.Add (apartmentThreadingProp);
@@ -169,6 +178,9 @@ namespace System.Web.Configuration
 			properties.Add (maxUrlLengthProp);
 			properties.Add (encoderTypeProp);
 			properties.Add (relaxedUrlToFileSystemMappingProp);
+#endif
+#if NET_4_5
+			properties.Add (targetFrameworkProp);
 #endif
 		}
 
@@ -341,6 +353,14 @@ namespace System.Web.Configuration
 		public bool RelaxedUrlToFileSystemMapping {
 			get { return (bool) base [relaxedUrlToFileSystemMappingProp]; }
 			set { base [relaxedUrlToFileSystemMappingProp] = value; }
+		}
+#endif
+#if NET_4_5
+		[ConfigurationProperty ("targetFramework", DefaultValue = "4.0")]
+		[TypeConverter ("System.Web.Configuration.VersionConverter")]
+		public Version TargetFramework {
+			get { return (Version) base [targetFrameworkProp]; }
+			set { base [targetFrameworkProp] = value; }
 		}
 #endif
 		protected internal override ConfigurationPropertyCollection Properties {

--- a/mcs/class/System.Web/System.Web/HttpRuntime.cs
+++ b/mcs/class/System.Web/System.Web/HttpRuntime.cs
@@ -337,6 +337,12 @@ namespace System.Web
 				return null;
 			}
 		}
+		
+		public static Version TargetFramework {
+			get {
+				return runtime_section.TargetFramework;
+			}
+		}
 #endif
 		
 		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]


### PR DESCRIPTION
The 'targetFramework' attribute of the `<httpRuntime>` section in Web.config was added in .NET 4.5 (see blog post in [1]) and is automatically set to "4.5" by newer Visual Studio web templates. Up until now, this resulted in a crash when running on Mono, because the element was not recognized when the config file was deserialized.

This PR fixes the crash by introducing the element in HttpRuntime and HttpRuntimeSection. Note that this does not implement any of the "quirks mode" / fallback behavior mentioned in the blog post and is currently not used in any such way inside Mono.

Changes released under MIT/X11.

[1] http://blogs.msdn.com/b/webdev/archive/2012/11/19/all-about-httpruntime-targetframework.aspx
