### PR TITLE
Fix preprocessor/compiler warning due to unbalanced apostophe (') character

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -929,7 +929,7 @@ mono_thread_get_stack_bounds (guint8 **staddr, size_t *stsize)
 #else
 	/* FIXME:   It'd be better to use the 'error' preprocessor macro here so we know
 		    at compile-time if the target platform isn't supported. */
-#warning Unable to determine how to retrieve a thread's stack-bounds for this platform in 'mono_thread_get_stack_bounds()'.
+#warning Unable to determine how to retrieve the stack-bounds for a thread on this platform (mono_thread_get_stack_bounds).
 	*staddr = NULL;
 	*stsize = 0;
 	return;


### PR DESCRIPTION
Reworded the warning message to be displayed when the fall-through case is taken by the preprocessor in `mono_thread_get_stack_bounds()`.
