### PR TITLE
Use the NI_MAXHOST constant to initialize the size of the hostname buffer.

### DIFF
--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -26,7 +26,9 @@
 #include <errno.h>
 
 #include <sys/types.h>
-#ifndef HOST_WIN32 
+#ifdef HOST_WIN32
+#include <ws2tcpip.h>
+#else
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
@@ -3137,7 +3139,7 @@ extern MonoBoolean ves_icall_System_Net_Dns_GetHostByAddr_internal(MonoString *a
 	struct sockaddr_in6 saddr6;
 	struct addrinfo *info = NULL, hints;
 	gint32 family;
-	char hostname[1024] = {0};
+	char hostname[NI_MAXHOST] = {0};
 	int flags = 0;
 #else
 	struct in_addr inaddr;


### PR DESCRIPTION
The NI_MAXHOST constant should be used when creating the hostname buffer to adhere to the behavior defined in [RFC2553](https://www.ietf.org/rfc/rfc2553.txt) (and also to avoid potential buffer overflows).

References:
- [getnameinfo(3)](http://linux.die.net/man/3/getnameinfo)
- [getnameinfo function (Windows)](http://msdn.microsoft.com/en-us/library/windows/desktop/ms738532%28v=vs.85%29.aspx)
