### PR TITLE
Print diagnostic messages for platform detection

### DIFF
--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -80,9 +80,12 @@ include $(topdir)/build/config-default.make
 # Default PLATFORM and PROFILE if they're not already defined.
 
 ifndef PLATFORM
+$(info *** PLATFORM is not defined.)
 ifeq ($(OS),Windows_NT)
+$(info *** Assuming PLATFORM is 'win32'.)
 PLATFORM = win32
 else
+$(info *** Assuming PLATFORM is 'linux'.)
 PLATFORM = linux
 endif
 endif


### PR DESCRIPTION
Print some diagnostic messages when running 'make' on this file, so it's clear when a platform has not been explicitly specified and we're going to compile with a platform value which has been automatically selected.
