### PR TITLE
Don't include pthread.h when it's not needed.

### DIFF
--- a/mono/utils/atomic.c
+++ b/mono/utils/atomic.c
@@ -10,11 +10,12 @@
 
 #include <config.h>
 #include <glib.h>
-#include <pthread.h>
 
 #include <mono/utils/atomic.h>
 
 #ifdef WAPI_NO_ATOMIC_ASM
+
+#include <pthread.h>
 
 static pthread_mutex_t spin = PTHREAD_MUTEX_INITIALIZER;
 static mono_once_t spin_once=MONO_ONCE_INIT;


### PR DESCRIPTION
Fixes mingw-w64 build.

This commit is licensed under MIT/X11.
