### PR TITLE
Call 'awk' instead of 'gawk' for cross-platform compatibility.

### DIFF
--- a/mcs/class/Managed.Windows.Forms/build-csproj
+++ b/mcs/class/Managed.Windows.Forms/build-csproj
@@ -177,7 +177,7 @@ SWFresourcelist()
 {
 cat $Resource | while read SRC; do
 SRC=`echo $SRC | $tr '/' '\\\\'`
-SRC=`echo $SRC | sed 's/-resource://' | gawk -F , '{print "                    RelPath = \"" $1 "\"\n                    CustomToolNameSpace = \"" $2 "\""}' | fgrep -v \"\"`
+SRC=`echo $SRC | sed 's/-resource://' | awk -F , '{print "                    RelPath = \"" $1 "\"\n                    CustomToolNameSpace = \"" $2 "\""}' | fgrep -v \"\"`
 
 cat << EOT
                 <File


### PR DESCRIPTION
Call `awk` instead of `gawk` for cross-platform compatibility. Linux systems normally have a symbolic link from `awk` to `gawk`, so there should be no difference in the functionality on those systems.
