### PR TITLE
Fixed: send/recv race in tpool-epoll and tpool-kqueue implementations 

### DIFF
--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -89,7 +89,7 @@ typedef struct {
 
 	gint event_system;
 	gpointer event_data;
-	void (*modify) (gpointer event_data, int fd, int operation, int events, gboolean is_new);
+	void (*modify) (gpointer p, int fd, int operation, int events, gboolean is_new);
 	void (*wait) (gpointer sock_data);
 	void (*shutdown) (gpointer event_data);
 } SocketIOData;
@@ -557,8 +557,7 @@ socket_io_add (MonoAsyncResult *ares, MonoSocketAsyncResult *state)
 
 	mono_g_hash_table_replace (data->sock_to_state, state->handle, list);
 	ievt = get_events_from_list (list);
-	LeaveCriticalSection (&data->io_lock);
-	data->modify (data->event_data, fd, state->operation, ievt, is_new);
+	data->modify (data, fd, state->operation, ievt, is_new);
 }
 
 #ifndef DISABLE_SOCKETS

--- a/mono/metadata/tpool-epoll.c
+++ b/mono/metadata/tpool-epoll.c
@@ -15,7 +15,7 @@ struct _tp_epoll_data {
 };
 
 typedef struct _tp_epoll_data tp_epoll_data;
-static void tp_epoll_modify (gpointer event_data, int fd, int operation, int events, gboolean is_new);
+static void tp_epoll_modify (gpointer p, int fd, int operation, int events, gboolean is_new);
 static void tp_epoll_shutdown (gpointer event_data);
 static void tp_epoll_wait (gpointer event_data);
 
@@ -51,9 +51,11 @@ tp_epoll_init (SocketIOData *data)
 }
 
 static void
-tp_epoll_modify (gpointer event_data, int fd, int operation, int events, gboolean is_new)
+tp_epoll_modify (gpointer p, int fd, int operation, int events, gboolean is_new)
 {
-	tp_epoll_data *data = event_data;
+	SocketIOData *socket_io_data;
+	socket_io_data = p;
+	tp_epoll_data *data = socket_io_data->event_data;
 	struct epoll_event evt;
 	int epoll_op;
 
@@ -74,6 +76,7 @@ tp_epoll_modify (gpointer event_data, int fd, int operation, int events, gboolea
 			}
 		}
 	}
+	LeaveCriticalSection (&socket_io_data->io_lock);
 }
 
 static void

--- a/mono/metadata/tpool-kqueue.c
+++ b/mono/metadata/tpool-kqueue.c
@@ -12,7 +12,7 @@ struct _tp_kqueue_data {
 };
 
 typedef struct _tp_kqueue_data tp_kqueue_data;
-static void tp_kqueue_modify (gpointer event_data, int fd, int operation, int events, gboolean is_new);
+static void tp_kqueue_modify (gpointer p, int fd, int operation, int events, gboolean is_new);
 static void tp_kqueue_shutdown (gpointer event_data);
 static void tp_kqueue_wait (gpointer event_data);
 
@@ -42,9 +42,11 @@ kevent_change (int kfd, struct kevent *evt, const char *error_str)
 }
 
 static void
-tp_kqueue_modify (gpointer event_data, int fd, int operation, int events, gboolean is_new)
+tp_kqueue_modify (gpointer p, int fd, int operation, int events, gboolean is_new)
 {
-	tp_kqueue_data *data = event_data;
+	SocketIOData *socket_io_data;
+	socket_io_data = p;
+	tp_kqueue_data *data = socket_io_data->event_data;
 	struct kevent evt;
 
 	memset (&evt, 0, sizeof (evt));
@@ -57,6 +59,7 @@ tp_kqueue_modify (gpointer event_data, int fd, int operation, int events, gboole
 		EV_SET (&evt, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, 0);
 		kevent_change (data->fd, &evt, "ADD write");
 	}
+	LeaveCriticalSection (&socket_io_data->io_lock);
 }
 
 static void

--- a/mono/metadata/tpool-poll.c
+++ b/mono/metadata/tpool-poll.c
@@ -19,7 +19,7 @@ struct _tp_poll_data {
 typedef struct _tp_poll_data tp_poll_data;
 
 static void tp_poll_shutdown (gpointer event_data);
-static void tp_poll_modify (gpointer event_data, int fd, int operation, int events, gboolean is_new);
+static void tp_poll_modify (gpointer p, int fd, int operation, int events, gboolean is_new);
 static void tp_poll_wait (gpointer p);
 
 static gpointer
@@ -74,12 +74,16 @@ tp_poll_init (SocketIOData *data)
 }
 
 static void
-tp_poll_modify (gpointer event_data, int fd, int operation, int events, gboolean is_new)
+tp_poll_modify (gpointer p, int fd, int operation, int events, gboolean is_new)
 {
-	tp_poll_data *data = event_data;
+	SocketIOData *socket_io_data;
+	socket_io_data = p;
+	tp_poll_data *data = socket_io_data->event_data;
 	char msg [1];
 	int unused;
 
+	LeaveCriticalSection (&socket_io_data->io_lock);
+	
 	MONO_SEM_WAIT (&data->new_sem);
 	INIT_POLLFD (&data->newpfd, GPOINTER_TO_INT (fd), events);
 	*msg = (char) operation;


### PR DESCRIPTION
There was a long discussion on a mailing list about the async-socket problem

in mono. We have previously submitted a patch fixing the problem, however it
was later reverted back as causing deadlocks in some cases.

This patch is very close to the original one, but it takes into account how
tpool-thread operates and avoids deadlocks in this code. (Unfortunately, it
probably makes the code a little less readable, but it works).

So, this patch aims to fix several races in the mono code. These problems are
not relevant for a lot of applications as they can appear only if both read
and write operations are active on the socket. (I.e. RPC style communications
do not trigger the problem).

So, there are two major problems with existing mono code:

a) threadpool.c :: socket_io_add

LeaveCriticalSection (&data->io_lock);
data->modify (data->event_data, fd, state->operation, ievt, is_new);

the problem is that data modify receives ievt and is_new arguments which
may be already outdated due to the concurrent operation on the same socket
(read vs. write).

(If you look at the other part of the operation in
tpool_epoll.c :: tp_epoll_wait updates the epoll settigs under the lock.)

b) The epoll implementation uses the following code to change the epoll
settings in the data->modify handler.

if (epoll_ctl (data->epollfd, epoll_op, fd, &evt) == -1) {
  int err = errno;
  if (epoll_op == EPOLL_CTL_ADD && err == EEXIST) {
    epoll_op = EPOLL_CTL_MOD;
    if (epoll_ctl (data->epollfd, epoll_op, fd, &evt) == -1) {
      g_message ("epoll_ctl(MOD): %d %s", err, g_strerror (err));
    }
  }
}

Here we have the same problem. If concurrent operation updates epoll between
first epoll_ctl and the second epoll_ctl the second will override concurrent
update.

These problems result in missing callbacks on async socket send or receive
completion

The original idea was as simple as just move the data->modify under the lock.
(NOTE: both internal associated list and epoll are updated under the lock in
case of data->wait (see tp_epoll_wait).

As i already noted it causes a problem for tpool_poll.c implementation as it
uses different approach than epoll/kqueue.

This patch still invokes data->modify under the lock, but allow implementation
to release lock at the point where it is appropriate for the given
implementation.

The tpool-poll.c releases lock immediately and thus its behavior remains
unchanged (and it still has a problem of missing send/receive callbacks)

The tpool-epoll/kqueue implementations update their internal structures and
corresponding OS level structures under the locks (as _wait does). This change
makes them reliable in simultaneous socket read/write scenarios.

The following code demonstrates the problem. See readme inside.

https://github.com/ysw/mono-socket-problem/tree/master/SocketTest

NOTE: you need at least 4 coresto reliably reproduce the problem.

It is quite hard to reproduce on OSX, but it is easy reproducible in LINUX.

This commit is licensed under MIT/X11.
