### PR TITLE
Improve detecting if a handle is a console on Windows.

### DIFF
--- a/mono/metadata/console-win32.c
+++ b/mono/metadata/console-win32.c
@@ -46,7 +46,8 @@ ves_icall_System_ConsoleDriver_Isatty (HANDLE handle)
 {
 	MONO_ARCH_SAVE_REGS;
 
-	return (GetFileType (handle) == FILE_TYPE_CHAR);
+	DWORD mode;
+	return GetConsoleMode (handle, &mode) != 0;
 }
 
 MonoBoolean


### PR DESCRIPTION
Use GetConsoleMode to detect if a handle is a console on Windows. If it succeeds (returns non-zero) then the handle is a console. If it fails (returns zero) then the handle is not a console.

The old check, (GetFileType (handle) == FILE_TYPE_CHAR) assumes that a handle of type FILE_TYPE_CHAR is a console. This falsely reports a handle directed to NUL as a console.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=12752

The Windows build is currently broken but I tested it applied against e0f26cc2, the last commit that built successfully on Windows according to MonkeyWrench. Using the test program in the bug report:

C:\Users\Greg\Documents\Visual Studio 2012\Projects\IsRedirectedTest\IsRedirecte
dTest\bin\Debug>C:\Users\Greg\Documents\Programs\cygwin\usr\local\bin\mono IsRed
irectedTest.exe
Input redirected: False
Output redirected: False
Error redirected: False

C:\Users\Greg\Documents\Visual Studio 2012\Projects\IsRedirectedTest\IsRedirecte
dTest\bin\Debug>C:\Users\Greg\Documents\Programs\cygwin\usr\local\bin\mono IsRed
irectedTest.exe < NUL
Input redirected: True
Output redirected: False
Error redirected: False

C:\Users\Greg\Documents\Visual Studio 2012\Projects\IsRedirectedTest\IsRedirecte
dTest\bin\Debug>C:\Users\Greg\Documents\Programs\cygwin\usr\local\bin\mono IsRed
irectedTest.exe > NUL

(output.txt contents)
Input redirected: False
Output redirected: True
Error redirected: False

C:\Users\Greg\Documents\Visual Studio 2012\Projects\IsRedirectedTest\IsRedirecte
dTest\bin\Debug>C:\Users\Greg\Documents\Programs\cygwin\usr\local\bin\mono IsRed
irectedTest.exe 2> NUL
Input redirected: False
Output redirected: False
Error redirected: True

C:\Users\Greg\Documents\Visual Studio 2012\Projects\IsRedirectedTest\IsRedirecte
dTest\bin\Debug>C:\Users\Greg\Documents\Programs\cygwin\usr\local\bin\mono IsRed
irectedTest.exe > outputx.txt

(output.txt contents)
Input redirected: False
Output redirected: True
Error redirected: False
