### PR TITLE
Making dmcs and gmcs execute mcs using a fully qualified PATH.

### DIFF
--- a/scripts/dmcs.in
+++ b/scripts/dmcs.in
@@ -1,3 +1,3 @@
 #!/bin/sh
-BINDIR=$(dirname $0)
+BINDIR=`dirname $0`
 exec ${BINDIR}/mcs -sdk:4 "$@"

--- a/scripts/gmcs.in
+++ b/scripts/gmcs.in
@@ -1,3 +1,3 @@
 #!/bin/sh
-BINDIR=$(dirname $0)
+BINDIR=`dirname $0`
 exec ${BINDIR}/mcs -sdk:2 "$@"


### PR DESCRIPTION
I'm installing mono into a custom location which is not in PATH and when executing /opt/blah/bin/mcs it doesn't work. However with this patch it does - other stuff in the scripts/ directory are doing the right thing.

Signed-off-by: Alfred Hall ahall@ahall.org
