### PR TITLE
Add support for thiscall pinvkes

### DIFF
--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -49,7 +49,8 @@ typedef enum {
 	MONO_CALL_STDCALL,
 	MONO_CALL_THISCALL,
 	MONO_CALL_FASTCALL,
-	MONO_CALL_VARARG
+	MONO_CALL_VARARG,
+	MONO_CALL_GCCTHISCALL = 0x10
 } MonoCallConvention;
 
 /* ECMA lamespec: the old spec had more info... */

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -244,6 +244,7 @@ static const guint32 *callconv_param_regs(MonoMethodSignature *sig)
 
 	switch (sig->call_convention) {
 	case MONO_CALL_THISCALL:
+	case MONO_CALL_GCCTHISCALL:
 		 return thiscall_param_regs;
 	default:
 		 return NULL;

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -5378,3 +5378,47 @@ mono_test_has_thiscall (void)
 
 #endif
 
+
+#if !defined(TARGET_X86) || defined(__GNUC__)
+
+#if defined(__GNUC__) && defined(TARGET_X86)
+# define GCCTHISCALL __attribute__((thiscall))
+#else
+# define GCCTHISCALL
+#endif
+
+LIBTEST_API int STDCALL
+mono_test_has_gccthiscall (void)
+{
+	return 1;
+}
+
+LIBTEST_API int GCCTHISCALL
+_mono_test_native_gccthiscall1 (int arg)
+{
+	return arg;
+}
+
+LIBTEST_API int GCCTHISCALL
+_mono_test_native_gccthiscall2 (int arg, int arg2)
+{
+	return arg + (arg2^1);
+}
+
+LIBTEST_API int GCCTHISCALL
+_mono_test_native_gccthiscall3 (int arg, int arg2, int arg3)
+{
+	return arg + (arg2^1) + (arg3^2);
+}
+
+#else
+
+LIBTEST_API int STDCALL
+mono_test_has_gccthiscall (void)
+{
+	return 0;
+}
+
+#endif
+
+

--- a/mono/tests/pinvoke2.cs
+++ b/mono/tests/pinvoke2.cs
@@ -8,6 +8,8 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Reflection.Emit;
 
+internal class MonoGccThisCallAttribute : Attribute { }
+
 public class Tests {
 
 	public int int_field;
@@ -1777,6 +1779,38 @@ public class Tests {
 
 		if (mono_test_native_thiscall (new TinyStruct(1288082683), -421187449, -1733670329) != -866775098)
 			return 6;
+
+		return 0;
+	}
+
+	[DllImport ("libtest")]
+	static extern int mono_test_has_gccthiscall ();
+
+	[MonoGccThisCallAttribute]
+	[DllImport ("libtest", EntryPoint = "_mono_test_native_gccthiscall1", CallingConvention=CallingConvention.FastCall)]
+	static extern int mono_test_native_gccthiscall (int a);
+
+	[MonoGccThisCallAttribute]
+	[DllImport ("libtest", EntryPoint = "_mono_test_native_gccthiscall2", CallingConvention=CallingConvention.FastCall)]
+	static extern int mono_test_native_gccthiscall (int a, int b);
+
+	[MonoGccThisCallAttribute]
+	[DllImport ("libtest", EntryPoint = "_mono_test_native_gccthiscall3", CallingConvention=CallingConvention.FastCall)]
+	static extern int mono_test_native_gccthiscall (int a, int b, int c);
+
+	public static int test_0_native_gccthiscall ()
+	{
+		if (mono_test_has_gccthiscall () == 0)
+			return 0;
+
+		if (mono_test_native_gccthiscall (1968329802) != 1968329802)
+			return 1;
+
+		if (mono_test_native_gccthiscall (268894549, 1212675791) != 1481570339)
+			return 2;
+
+		if (mono_test_native_gccthiscall (1288082683, -421187449, -1733670329) != -866775098)
+			return 3;
 
 		return 0;
 	}


### PR DESCRIPTION
This is used extensively by Managed C++, and may also be useful for cxxi.
