### PR TITLE
[#13604] Eliminating sgen assert info-doing_handshake check

### DIFF
--- a/mono/metadata/sgen-os-posix.c
+++ b/mono/metadata/sgen-os-posix.c
@@ -57,8 +57,6 @@ suspend_thread (SgenThreadInfo *info, void *context)
 #endif
 	gpointer stack_start;
 
-	g_assert (info->doing_handshake);
-
 	info->stopped_domain = mono_domain_get ();
 	info->stopped_ip = context ? (gpointer) ARCH_SIGCTX_IP (context) : NULL;
 	stop_count = sgen_global_stop_count;


### PR DESCRIPTION
This is related to the issue I've described here https://bugzilla.xamarin.com/show_bug.cgi?id=13604

This doesn't fix the entire problem, but it does prevent the process from crashing. My question is, what state would cause the handshake check to be in a state where doing_handshake is false?
