### PR TITLE
[ThreadPool] Allow heavier initialization when using --server flag

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -417,7 +417,7 @@ the global assembly cache is always trusted.
 .TP
 \fB--server\fR
 Configures the virtual machine to be better suited for server
-operations (currently, a no-op).
+operations (currently, allows a heavier threadpool initialization).
 .TP
 \fB--verify-all\fR 
 Verifies mscorlib and assemblies in the global

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -790,3 +790,17 @@ mono_config_parse_assembly_bindings (const char *filename, int amajor, int amino
 	mono_config_parse_file_with_context (&state, filename);
 }
 
+static gboolean mono_server_mode = FALSE;
+
+void
+mono_config_set_server_mode (gboolean server_mode)
+{
+	mono_server_mode = server_mode;
+}
+
+gboolean
+mono_config_is_server_mode (void)
+{
+	return mono_server_mode;
+}
+

--- a/mono/metadata/mono-config.h
+++ b/mono/metadata/mono-config.h
@@ -25,6 +25,9 @@ void mono_config_parse_memory (const char *buffer);
 
 const char* mono_config_string_for_assembly_file (const char *filename);
 
+void mono_config_set_server_mode (gboolean server_mode);
+gboolean mono_config_is_server_mode (void);
+
 MONO_END_DECLS
 
 #endif /* __MONO_METADATA_CONFIG_H__ */

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -19,6 +19,7 @@
 #include <mono/metadata/threadpool-internals.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/environment.h>
+#include <mono/metadata/mono-config.h>
 #include <mono/metadata/mono-mlist.h>
 #include <mono/metadata/mono-perfcounters.h>
 #include <mono/metadata/socket-io.h>
@@ -1064,8 +1065,10 @@ threadpool_append_jobs (ThreadPool *tp, MonoObject **jobs, gint njobs)
 		}
 		/* Create on demand up to min_threads to avoid startup penalty for apps that don't use
 		 * the threadpool that much
-		* mono_thread_create_internal (mono_get_root_domain (), threadpool_start_idle_threads, tp, TRUE, FALSE, SMALL_STACK);
-		*/
+		 */
+		if (mono_config_is_server_mode ()) {
+			mono_thread_create_internal (mono_get_root_domain (), threadpool_start_idle_threads, tp, TRUE, FALSE, SMALL_STACK);
+		}
 	}
 
 	for (i = 0; i < njobs; i++) {

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1715,9 +1715,10 @@ mono_main (int argc, char* argv[])
 			}
 		} else if (strcmp (argv [i], "--desktop") == 0) {
 			mono_gc_set_desktop_mode ();
-			/* Put desktop-specific optimizations here */
+			/* Put more desktop-specific optimizations here */
 		} else if (strcmp (argv [i], "--server") == 0){
-			/* Put server-specific optimizations here */
+			mono_config_set_server_mode (TRUE);
+			/* Put more server-specific optimizations here */
 		} else if (strcmp (argv [i], "--inside-mdb") == 0) {
 			action = DO_DEBUGGER;
 		} else if (strncmp (argv [i], "--wapi=", 7) == 0) {


### PR DESCRIPTION
Create on demand up to min_threads to avoid startup penalty, avoiding
throttling of threadpool worker thread creation (for now, using
a --server flag) at initialization.

When throttling happens, operations such as parallel https requests were
slowed down significantly due to all of the threads created in order
to complete the SSL operations.

Based on @kamalaboulhosn's pull request (https://github.com/mono/mono/pull/640), addressing Miguel's comment.

(Tried putting the gboolean variable in mini.c/mini.h, but this didn't work, as it would cause this compilation error:
make[3]: Entering directory `/home/knocte/Documents/Code/mymono/mono/metadata'
  CC     libmonoruntime_la-mono-config.lo
  CC     libmonoruntime_la-threadpool.lo
In file included from threadpool.c:22:0:
../../mono/mini/mini.h:52:2: error: #error "The code in mini/ should not depend on these defines."
make[3]: *** [libmonoruntime_la-threadpool.lo] Error 1
make[3]: Leaving directory`/home/knocte/Documents/Code/mymono/mono/metadata'
make[2]: **\* [all-recursive] Error 1
make[2]: Leaving directory `/home/knocte/Documents/Code/mymono/mono'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory`/home/knocte/Documents/Code/mymono'
make: **\* [all] Error 2

So I moved it to mono-config.)
