### PR TITLE
Fixed xamarin bug #13708: ASP.NET routing constraints should be treated as 'convertible to string' in order to be compat with MS.NET

### DIFF
--- a/mcs/class/System.Web.Routing/System.Web.Routing/Route.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/Route.cs
@@ -32,6 +32,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Permissions;
 using System.Text.RegularExpressions;
 using System.Web;
+using System.Globalization;
 
 namespace System.Web.Routing
 {
@@ -163,13 +164,15 @@ namespace System.Web.Routing
 
 			string s = constraint as string;
 			if (s != null) {
-				string v;
+				string v = null;
 				object o;
 
+				// NOTE: If constraint was not an IRouteConstraint, is is asumed
+				// to be an object 'convertible' to string, or at least this is how
+				// ASP.NET seems to work by the tests i've done latelly. (pruiz)
+
 				if (values != null && values.TryGetValue (parameterName, out o))
-					v = o as string;
-				else
-					v = null;
+					v = Convert.ToString (o, CultureInfo.InvariantCulture);
 
 				if (!String.IsNullOrEmpty (v))
 					return MatchConstraintRegex (v, s);
@@ -184,7 +187,7 @@ namespace System.Web.Routing
 					if (!rdValues.TryGetValue (parameterName, out o))
 						return false;
 
-					v = o as string;
+					v = Convert.ToString (o, CultureInfo.InvariantCulture);
 					if (String.IsNullOrEmpty (v))
 						return false;
 

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
@@ -1699,6 +1699,30 @@ namespace MonoTests.System.Web.Routing
 			Assert.IsNull(vp, "#3");
 		}
 
+		[Test (Description="Xamarin Bug #13708")]
+		public void GetVirtualPath25()
+		{
+			var r = new MyRoute("{year}/{month}/{slug}", new MyRouteHandler())
+			{
+				Defaults = new RouteValueDictionary(new { controller = "Blog", action = "View" }),
+				Constraints = new RouteValueDictionary(new { year = @"\d{4}", month = @"\d{2}" }),
+			};
+			var hc = new HttpContextStub2("~/", String.Empty);
+			var values = new RouteValueDictionary()
+			{
+				{ "area", string.Empty },
+				{ "controller", "Blog" },
+				{ "action", "View" },
+				{ "year", 2013 }, // Year as an int, not a string
+				{ "month", "08" },
+				{ "slug", "hello-world" },
+			};
+			var vp = r.GetVirtualPath(new RequestContext(hc, new RouteData()), values);
+
+			Assert.IsNotNull(vp, "#1");
+			Assert.AreEqual("2013/08/hello-world", vp.VirtualPath, "#2");
+		}
+
 		// Bug #500739
 		[Test]
 		public void RouteGetRequiredStringWithDefaults ()


### PR DESCRIPTION
Daniel Lo Nigro (@Daniel15) found a problem with ASP.NET routing logic by which route values when matched against constraints where not being converted into strings, resulting in an incompatibility with MS.NET's routing implementation.

This pull-req fixes this issue (reported by @Daniel15 as xamarin's #13708).
