### PR TITLE
dllmap for BitBlt in gdi32.dll

### DIFF
--- a/data/config.in
+++ b/data/config.in
@@ -28,6 +28,6 @@
 	</dllmap>
 	<dllmap dll="gdiplus" target="@prefix@/lib/libgdiplus@libsuffix@" os="!windows"/>
 	<dllmap dll="gdiplus.dll" target="@prefix@/lib/libgdiplus@libsuffix@"  os="!windows"/>
-	<dllmap dll="gdi32" target="@prefix@/lib/libgdiplus@libsuffix@" />
-	<dllmap dll="gdi32.dll" target="@prefix@/lib/libgdiplus@libsuffix@" />
+	<dllmap dll="gdi32" target="@prefix@/lib/libgdiplus@libsuffix@" os="!windows"/>
+	<dllmap dll="gdi32.dll" target="@prefix@/lib/libgdiplus@libsuffix@" os="!windows"/>
 </configuration>


### PR DESCRIPTION
This pull request goes hand in hand with a change to libgdiplus that partially implements BitBlt from gdi32.dll: https://github.com/mono/libgdiplus/pull/9
