### PR TITLE
Remove deprecated -mno-cygwin flag.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -114,8 +114,8 @@ case "$host" in
 		# Windows 2000 is required that includes Internet Explorer 5.01
 		CPPFLAGS="$CPPFLAGS -DWINVER=0x0500 -D_WIN32_WINNT=0x0500 -D_WIN32_IE=0x0501 -D_UNICODE -DUNICODE -DWIN32_THREADS -DFD_SETSIZE=1024"
 		LDFLAGS="$LDFLAGS -lmswsock -lws2_32 -lole32 -loleaut32 -lpsapi -lversion -ladvapi32 -lwinmm -lkernel32"
-		libmono_cflags="-mno-cygwin -mms-bitfields -mwindows"
-		libmono_ldflags="-mno-cygwin -mms-bitfields -mwindows"
+		libmono_cflags="-mms-bitfields -mwindows"
+		libmono_ldflags="-mms-bitfields -mwindows"
 		libdl=
 		libgc_threads=win32
 		gc_default=included

--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -124,7 +124,7 @@ gcc-mingw and as packages.
 Assembler command. The default is "as".
 .TP
 .I "CC"
-C compiler command. The default is "cc" under Linux and "gcc -mno-cygwin"
+C compiler command. The default is "cc" under Linux and "gcc"
 under Windows.
 .TP
 .I "MONO_BUNDLED_OPTIONS"

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -476,7 +476,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 
 			string zlib = (compress ? "-lz" : "");
 			string debugging = "-g";
-			string cc = GetEnv ("CC", IsUnix ? "cc" : "gcc -mno-cygwin");
+			string cc = GetEnv ("CC", IsUnix ? "cc" : "gcc");
 
 			if (style == "linux")
 				debugging = "-ggdb";

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8328,7 +8328,7 @@ compile_asm (MonoAotCompile *acfg)
 #elif defined(TARGET_AMD64) && defined(TARGET_MACH)
 	command = g_strdup_printf ("gcc --shared -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
 #elif defined(HOST_WIN32)
-	command = g_strdup_printf ("gcc -shared --dll -mno-cygwin -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
+	command = g_strdup_printf ("gcc -shared --dll -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
 #elif defined(TARGET_X86) && defined(TARGET_MACH) && !defined(__native_client_codegen__)
 	command = g_strdup_printf ("gcc -m32 -dynamiclib -o %s %s.o", tmp_outfile_name, acfg->tmpfname);
 #else


### PR DESCRIPTION
-mno-cygwin flag is deprecated since gcc4 and was finally removed from cygwin since mingw 4.7.
