### PR TITLE
Fix for #14077. HashSet no longer grows in capacity on deserialize

### DIFF
--- a/mcs/class/System.Core/System.Collections.Generic/HashSet.cs
+++ b/mcs/class/System.Core/System.Collections.Generic/HashSet.cs
@@ -566,8 +566,7 @@ namespace System.Collections.Generic {
 
 				empty_slot = NO_SLOT;
 				if (capacity > 0) {
-					table = new int[capacity];
-					slots = new T[capacity];
+					InitArrays(capacity);
 
 					T[] tableArray = (T[]) si.GetValue("Elements", typeof(T[]));
 					if (tableArray == null) 


### PR DESCRIPTION
Not all necessary members were being initialized during deserialization
