### PR TITLE
Rewrote Font.GetHashCode() to improve uniqueness

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/Font.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Font.cs
@@ -548,10 +548,24 @@ namespace System.Drawing
 				return false;
 		}
 
+		private int _hashCode;
+
 		public override int GetHashCode ()
 		{
-			return _name.GetHashCode () ^ FontFamily.GetHashCode () ^ _size.GetHashCode () ^ _style.GetHashCode () ^
-				_gdiCharSet ^ _gdiVerticalFont.GetHashCode ();
+			if (_hashCode == 0) {
+				_hashCode = 17;
+				unchecked {
+					_hashCode = _hashCode * 23 + _name.GetHashCode();
+					_hashCode = _hashCode * 23 + FontFamily.GetHashCode();
+					_hashCode = _hashCode * 23 + _size.GetHashCode();
+					_hashCode = _hashCode * 23 + _unit.GetHashCode();
+					_hashCode = _hashCode * 23 + _style.GetHashCode();
+					_hashCode = _hashCode * 23 + _gdiCharSet;
+					_hashCode = _hashCode * 23 + _gdiVerticalFont.GetHashCode();
+				}
+			}
+
+			return _hashCode;
 		}
 
 		[MonoTODO ("The hdc parameter has no direct equivalent in libgdiplus.")]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
@@ -631,5 +631,35 @@ namespace MonoTests.System.Drawing{
 			Assert.IsFalse (f1.GetHashCode () == f2.GetHashCode (), "1) Fonts with different sizes should have different HashCodes");
 			Assert.IsFalse (f1.GetHashCode () == f3.GetHashCode (), "2) Fonts with different styles should have different HashCodes");
 		}
+
+        [Test]
+        public void GetHashCode_UnitDiffers_HashesNotEqual()
+        {
+            Font f1 = new Font("DejaVu Sans", 8.25F, GraphicsUnit.Point);
+            Font f2 = new Font("DejaVu Sans", 8.25F, GraphicsUnit.Pixel);
+
+            Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
+                "Hashcodes should differ if _unit member differs");
+        }
+
+        [Test]
+        public void GetHashCode_NameDiffers_HashesNotEqual()
+        {
+            Font f1 = new Font("DejaVu Sans", 8.25F, GraphicsUnit.Point);
+            Font f2 = new Font("Liberation Sans", 8.25F, GraphicsUnit.Point);
+
+            Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
+                "Hashcodes should differ if _name member differs");
+        }
+
+        [Test]
+        public void GetHashCode_StyleEqualsGdiCharSet_HashesNotEqual()
+        {
+            Font f1 = new Font("DejaVu Sans", 8.25F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
+            Font f2 = new Font("DejaVu Sans", 8.25F, FontStyle.Bold, GraphicsUnit.Point, ((byte)(1)));
+
+            Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
+                "Hashcodes should differ if _style member differs");
+        }
 	}
 }


### PR DESCRIPTION
Added test cases to prevent reintroduction of collision scenarios observed in Font.GetHashCode().

Changes are per request in bug #14016. (https://bugzilla.xamarin.com/show_bug.cgi?id=14016)
