### PR TITLE
FilledIn, Required and Editable should all be locked if the character is...

### DIFF
--- a/mcs/class/System/System.ComponentModel/MaskedTextProvider.cs
+++ b/mcs/class/System/System.ComponentModel/MaskedTextProvider.cs
@@ -266,12 +266,19 @@ namespace System.ComponentModel {
 			
 			public bool FilledIn {
 				get {
-					return Input != char.MinValue;
+					if (Type == EditType.Literal) {
+						return true;
+					} else {
+						return Input != char.MinValue;
+					}
 				}
 			}
 			
 			public bool Required {
 				get {
+					if (Type == EditType.Literal) {
+						return false;
+					}
 					switch (MaskCharacter) {
 					case '0':
 					case 'L':
@@ -286,6 +293,9 @@ namespace System.ComponentModel {
 			
 			public bool Editable {
 				get {
+					if (Type == EditType.Literal) {
+						return false;
+					}
 					switch (MaskCharacter) {
 					case '0':
 					case '9':


### PR DESCRIPTION
... a Literal. Otherwise user entry is expected, but not provided, causing MaskFull and MaskCompleted to always return false.
