### PR TITLE
Fix non-sgen builds.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3217,7 +3217,11 @@ fi
 if test "x$enable_shared" = "xno" -a "x$enable_executables" = "xyes"; then
    LIBMONO_LA=libmini-static.la
 else
-   LIBMONO_LA=libmonosgen-$API_VER.la
+   if test x$buildsgen = xyes; then
+      LIBMONO_LA=libmonosgen-$API_VER.la
+   else
+      LIBMONO_LA=libmonoboehm-$API_VER.la
+   fi
 fi
 AC_SUBST(LIBMONO_LA)
 

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -106,14 +106,15 @@ boehm_binaries  = mono-boehm
 endif
 
 #The mono uses sgen, while libmono remains boehm
+if SUPPORT_SGEN
 mono_bin_suffix = sgen
+else
+mono_bin_suffix = boehm
+endif
 libmono_suffix = boehm
 
 if DISABLE_EXECUTABLES
 else
-bin_SCRIPTS = mono
-noinst_SCRIPTS = mono
-
 mono: mono-$(mono_bin_suffix)
 	ln -sf $< $@
 


### PR DESCRIPTION
We have a few hard-coded assumptions that sgen will be built.

Also, mono does not need to be in bin_SCRIPTS/noinst_SCRIPTS as it's already in noinst_PROGRAMS and the symlink will be installed to bin by install-exec-hook. Having mono in SCRIPTS means it'll try to build mono instead of mono.exe on Windows, which will depend on mono-boehm instead of mono-boehm.exe.
