### PR TITLE
Fix build break compiling with DISABLE_JIT

### DIFF
--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -409,7 +409,7 @@ typedef struct {
 	regmask_t preferred_mask; /* the hreg where the register should be allocated, or 0 */
 } RegTrack;
 
-#ifndef DISABLE_LOGGING
+#if !defined(DISABLE_LOGGING) && !defined(DISABLE_JIT)
 
 static const char* const patch_info_str[] = {
 #define PATCH_INFO(a,b) "" #a,
@@ -716,7 +716,7 @@ void
 mono_print_ins_index (int i, MonoInst *ins)
 {
 }
-#endif /* DISABLE_LOGGING */
+#endif /* !defined(DISABLE_LOGGING) && !defined(DISABLE_JIT) */
 
 void
 mono_print_ins (MonoInst *ins)


### PR DESCRIPTION
When building with DISABLE_JIT, mono_inst_name which is normally defined in helpers.c is not. But, mini-codegen.c tries to use it anyway. This fix updates mini-codegen.c to not rely on this logging feature.
