### PR TITLE
Fixes build when running `make -k check`

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Test/Microsoft.Build.BuildEngine/TargetTest.cs
+++ b/mcs/class/Microsoft.Build.Engine/Test/Microsoft.Build.BuildEngine/TargetTest.cs
@@ -366,7 +366,7 @@ namespace MonoTests.Microsoft.Build.BuildEngine {
 			var type = Type.GetType ("Microsoft.Build.Evaluation.ProjectCollection, Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
 
 			var prop = type.GetProperty ("GlobalProjectCollection");
-			var coll = prop.GetValue (null);
+			var coll = prop.GetValue (null, null);
 				
 			var loadProject = coll.GetType ().GetMethod (
 					"LoadProject", new Type[] { typeof (XmlReader), typeof (string) });

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -554,7 +554,9 @@ public class Tests : TestsBase
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+#if NET_4_5
 	[StateMachine (typeof (int))]
+#endif
 	public static void locals2<T> (string[] args, int arg, T t, ref string rs) {
 		long i = 42;
 		string s = "AB";
@@ -567,6 +569,7 @@ public class Tests : TestsBase
 		}
 		rs = "A";
 	}
+
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void locals3 () {

--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -299,21 +299,25 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (0, p.GetCustomAttributes (typeof (FlagsAttribute), false).Length, "#3");
 			Assert.AreEqual (0, p.GetOptionalCustomModifiers ().Length, "#4");
 			Assert.AreEqual (0, p.GetRequiredCustomModifiers ().Length, "#5");
+#if NET_4_5
 			try {
 				var ign = p.HasDefaultValue;
 				Assert.Fail ("#6");
 			} catch (NotImplementedException) {
 			}
+#endif
 			Assert.IsFalse (p.IsIn, "#7");
 			Assert.IsFalse (p.IsLcid, "#8");
 			Assert.IsFalse (p.IsOptional, "#9");
 			Assert.IsFalse (p.IsOut, "#10");
 			Assert.IsFalse (p.IsRetval, "#10");
+#if NET_4_5
 			try {
 				var ign = p.CustomAttributes;
 				Assert.Fail ("#11");
 			} catch (NotImplementedException) {
 			}
+#endif
 			try {
 				p.GetCustomAttributesData ();
 				Assert.Fail ("#12");
@@ -395,7 +399,9 @@ namespace MonoTests.System.Reflection
 			Assert.IsFalse (p2.IsIn, "#1");
 			p2.MyAttrsImpl = ParameterAttributes.In;
 			Assert.IsTrue (p2.IsIn, "#2");
+#if NET_4_5
 			Assert.AreEqual (p2.myList, p2.CustomAttributes, "#3");
+#endif
 		}
 #endif
 	}


### PR DESCRIPTION
- Fixes StateMachineAttribute in BuildEngine for 4.0 and 3.5
- Fixes build for Mono.Debugger.Soft not in 4_5 profile
- Fixes build for NET_4_0 profile (CustomAttributes and HasDefaultValue)
