### PR TITLE
Add conditions to "CopyNonResxEmbeddedResources" target so it doesn't fail

### DIFF
--- a/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/xbuild/4.0/Microsoft.Common.targets
@@ -486,14 +486,14 @@
 		Condition = "'@(NonResxWithCulture)' != '' or '@(NonResxWithNoCulture)' != '' or '@(ManifestNonResxWithCulture)' != '' or '@(ManifestNonResxWithNoCulture)' != ''">
 
 		<MakeDir Directories="$(IntermediateOutputPath)%(ManifestNonResxWithCulture.Culture)"/>
-		<Copy SourceFiles = "@(NonResxWithCulture)"
+		<Copy Condition = "'@(NonResxWithCulture)' != '' and '@(ManifestNonResxWithCulture)' != ''" SourceFiles = "@(NonResxWithCulture)"
 			DestinationFiles = "@(ManifestNonResxWithCulture->'$(IntermediateOutputPath)%(Identity)')"
 			SkipUnchangedFiles="$(SkipCopyUnchangedFiles)">
 			<Output TaskParameter = "DestinationFiles" ItemName = "ManifestNonResxWithCultureOnDisk"/>
 			<Output TaskParameter = "DestinationFiles" ItemName = "FileWrites"/>
 		</Copy>
 
-		<Copy SourceFiles = "@(NonResxWithNoCulture)"
+		<Copy Condition = "'@(NonResxWithNoCulture)' != '' and '@(ManifestNonResxWithNoCulture)' != ''" SourceFiles = "@(NonResxWithNoCulture)"
 			DestinationFiles = "@(ManifestNonResxWithNoCulture->'$(IntermediateOutputPath)%(Identity)')"
 			SkipUnchangedFiles="$(SkipCopyUnchangedFiles)">
 			<Output TaskParameter = "DestinationFiles" ItemName = "ManifestNonResxWithNoCultureOnDisk"/>


### PR DESCRIPTION
The "CopyNonResxEmbeddedResources" target has conditions for two separate resource types, but the copy tasks within don't check for the files they're trying to copy. If you only have one of the two in your project, the other will fail with "error : You must specify DestinationFolder or DestinationFiles attribute.".
