### PR TITLE
Implemented AssemblyName.ReferenceMatchesDefinition ()

### DIFF
--- a/mcs/class/corlib/System.Reflection/AssemblyName.cs
+++ b/mcs/class/corlib/System.Reflection/AssemblyName.cs
@@ -323,16 +323,16 @@ namespace System.Reflection {
 			return token;
 		}
 
-		[MonoTODO]
 		public static bool ReferenceMatchesDefinition (AssemblyName reference, AssemblyName definition)
 		{
 			if (reference == null)
 				throw new ArgumentNullException ("reference");
 			if (definition == null)
 				throw new ArgumentNullException ("definition");
-			if (reference.Name != definition.Name)
-				return false;
-			throw new NotImplementedException ();
+			
+			// we only compare the simple assembly name to be consistent with MS .NET,
+			// which is the result of a bug in their implementation (see https://connect.microsoft.com/VisualStudio/feedback/details/752902)
+			return string.Equals (reference.Name, definition.Name, StringComparison.OrdinalIgnoreCase);
 		}
 
 		public void SetPublicKey (byte[] publicKey) 

--- a/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
@@ -2016,6 +2016,23 @@ public class AssemblyNameTest {
 
 		Assert.AreEqual (fullName, an.FullName);
 	}
+
+	[Test]
+	public void ReferenceMatchesDefinition_Compares_Only_SimpleName ()
+	{
+		var an1 = new AssemblyName ("TestDll, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089");
+		var an2 = new AssemblyName ("TestDll, Version=2.0.0.2001, Culture=en-US, PublicKeyToken=ab7a5c561934e089");
+
+		var an3 = new AssemblyName ("TestDll");
+		var an4 = new AssemblyName ("tesTDlL");
+
+		var an5 = new AssemblyName ("TestDll");
+		var an6 = new AssemblyName ("TestDll2");
+		
+		Assert.IsTrue (AssemblyName.ReferenceMatchesDefinition (an1, an2));
+		Assert.IsTrue (AssemblyName.ReferenceMatchesDefinition (an3, an4));
+		Assert.IsFalse (AssemblyName.ReferenceMatchesDefinition (an5, an6));
+	}
 #endif
 }
 


### PR DESCRIPTION
I implemented this method by comparing the simple assembly names. This is the current behavior in MS.NET because of a bug in their implementation (see [Connect](https://connect.microsoft.com/VisualStudio/feedback/details/752902) bug report).

I added tests to verify the implementation and checked the results are the same on .NET 2.0 -> .NET 4.5.

Changes released under MIT/X11.
