### PR TITLE
[FIX][v2] Do not use chunked encoding with CGI/FastCGI

### DIFF
--- a/mcs/class/System.Web/System.Web/HttpResponse.cs
+++ b/mcs/class/System.Web/System.Web/HttpResponse.cs
@@ -127,8 +127,13 @@ namespace System.Web
 			this.context = context;
 
 #if !TARGET_J2EE
-			if (worker_request != null)
-				use_chunked = (worker_request.GetHttpVersion () == "HTTP/1.1");
+			if (worker_request != null && worker_request.GetHttpVersion () == "HTTP/1.1") {
+				string gi = worker_request.GetServerVariable ("GATEWAY_INTERFACE");
+				use_chunked = (String.IsNullOrEmpty (gi) ||
+					!gi.StartsWith ("cgi", StringComparison.OrdinalIgnoreCase));
+			} else {
+				use_chunked = false;
+			}
 #endif
 			writer = new HttpWriter (this);
 		}


### PR DESCRIPTION
Hi

make run-test PROFILE=net_2_0 OK
make run-test PROFILE=net_4_0 OK
make run-test PROFILE=net_4_5 OK

make run-test PROFILE=net_3_5 don't run on my box with unrelated errors
http://pastebin.com/0EwAf3um

https://bugzilla.xamarin.com/show_bug.cgi?id=10001
