### PR TITLE
[Scripts] Fix a Shebang in mono-test-install for freeBSD

### DIFF
--- a/scripts/mono-test-install
+++ b/scripts/mono-test-install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Does various checks for people that we can use to diagnose
 # an end user installation


### PR DESCRIPTION
On some UNIX OS bash is not alway in /bin/bash (Free BSD for instance).
Using "/usr/bin/env bash" will found the correct location of bash.
