### PR TITLE
Fixing inconsistency in XmlSchemaValidatingReader between Mono and MS.NET

### DIFF
--- a/mcs/class/System.XML/Mono.Xml.Schema/XmlSchemaValidatingReader.cs
+++ b/mcs/class/System.XML/Mono.Xml.Schema/XmlSchemaValidatingReader.cs
@@ -125,7 +125,7 @@ namespace Mono.Xml.Schema
 				schemas,
 				nsResolver,
 				options);
-			if (reader.BaseURI != String.Empty)
+			if (reader.BaseURI != String.Empty && Uri.IsWellFormedUriString(reader.BaseURI, UriKind.Absolute))
 				v.SourceUri = new Uri (reader.BaseURI);
 
 			readerLineInfo = reader as IXmlLineInfo;

--- a/mcs/class/System.XML/Test/System.Xml.Schema/XmlSchemaValidatorTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Schema/XmlSchemaValidatorTests.cs
@@ -441,6 +441,16 @@ namespace MonoTests.System.Xml
 				}
 			}
 		}
+		
+		[Test]
+		public void IgnoresInvalidBaseUri ()
+		{
+			var source = new StringReader (@"<?xml version='1.0' encoding='utf-8'?><Test></Test>");
+			var readerSettings = new XmlReaderSettings { ValidationType = ValidationType.Schema };
+			var reader = XmlReader.Create (source, readerSettings, "invalidBaseUri");
+
+			Assert.IsNotNull (reader);
+		}
 	}
 }
 


### PR DESCRIPTION
While working on getting EF6 code-first to work on Mono, I discovered an inconsistency in how Mono handles an invalid (i.e. non-absolute) baseUri parameter passed to XmlReader.Create() when using schema validation compared to .NET.

Logically, I would expect that an invalid Uri would throw an exception, but .NET doesn't do it (though there's very little documentation on MSDN what the correct behavior is).
This PR fixes the inconsistency, however I'm not 100% sure this is the correct approach. Any feedback would be greatly appreciated.

Changes released under MIT/X11.

Note: I've opened a bug on EF, so they stop passing an invalid baseUri to XmlReader: [EF#1632](https://entityframework.codeplex.com/workitem/1632)
