### PR TITLE
Wcf fix

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs
@@ -314,7 +314,7 @@ namespace System.ServiceModel.Description
 				{
 					var occa = serviceMethod.GetCustomAttribute<OperationContractAttribute>(false);
                     if (occa != null)
-                        od.Behaviors.Add(new DataContractSerializerOperationBehavior(od, occa));
+                        od.Behaviors.Add(new DataContractSerializerOperationBehavior(od));
 				}
 
 				od.Messages.Add (GetMessage (od, mi, oca, true, isCallback, null));

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs
@@ -308,6 +308,14 @@ namespace System.ServiceModel.Description
 				var dfa = serviceMethod.GetCustomAttribute<DataContractFormatAttribute> (false);
 				if (dfa != null)
 					od.Behaviors.Add (new DataContractSerializerOperationBehavior (od, dfa));
+				
+				// check if method has OperationContractAttribute then add DataContractSerializerOperationBehavior 	
+				else
+				{
+					var occa = serviceMethod.GetCustomAttribute<OperationContractAttribute>(false);
+                    if (occa != null)
+                        od.Behaviors.Add(new DataContractSerializerOperationBehavior(od, occa));
+				}
 
 				od.Messages.Add (GetMessage (od, mi, oca, true, isCallback, null));
 				if (!od.IsOneWay) {

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/DataContractSerializerOperationBehavior.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/DataContractSerializerOperationBehavior.cs
@@ -70,22 +70,21 @@ namespace System.ServiceModel.Description
 #if !NET_2_1
 		public IDataContractSurrogate DataContractSurrogate { get; set; }
 #endif
-
 		public virtual XmlObjectSerializer CreateSerializer (Type type, string name, string ns, IList<Type> knownTypes)
 		{
 #if NET_2_1
-			return new DataContractSerializer (type, name, ns, knownTypes);
+			return new DataContractSerializer (type, name, ns, operation.KnownTypes);
 #else
-			return new DataContractSerializer (type, name, ns, knownTypes, MaxItemsInObjectGraph, IgnoreExtensionDataObject, false, DataContractSurrogate);
+			return new DataContractSerializer (type, name, ns, operation.KnownTypes, MaxItemsInObjectGraph, IgnoreExtensionDataObject, false, DataContractSurrogate);
 #endif
 		}
 
 		public virtual XmlObjectSerializer CreateSerializer (Type type, XmlDictionaryString name, XmlDictionaryString ns, IList<Type> knownTypes)
 		{
 #if NET_2_1
-			return new DataContractSerializer (type, name, ns, knownTypes);
+			return new DataContractSerializer (type, name, ns, operation.KnownTypes);
 #else
-			return new DataContractSerializer (type, name, ns, knownTypes, MaxItemsInObjectGraph, IgnoreExtensionDataObject, false, DataContractSurrogate);
+			return new DataContractSerializer (type, name, ns, operation.KnownTypes, MaxItemsInObjectGraph, IgnoreExtensionDataObject, false, DataContractSurrogate);
 #endif
 		}
 


### PR DESCRIPTION
Suggestion to fix Bug #14473 - WCF SerializationException. 

In case using interface and Inheritance in service method was thrown System.Runtime.Serialization.SerializationException: Type
'Dante.Contracts.Authentication.PinAuthenticationCommand' is unexpected. The
type should either be registered as a known type, or DataContractResolver
should be used. Known types was registred, but not used in Serialization.

