### PR TITLE
When generating resources, it intends to add the .resources file to the ...

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/GenerateResource.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/GenerateResource.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Tasks {
 						result &= CompileResourceFile (sourceFile, outputFile);
 
 					ITaskItem newItem = new TaskItem (source);
-					source.ItemSpec = outputFile;
+					newItem.ItemSpec = outputFile;
 
 					temporaryFilesWritten.Add (newItem);
 				}


### PR DESCRIPTION
...FilesWritten list. However, it sets the ItemSpec on the wrong item, and a 'Clean' ends up deleting the .resx file.
