### PR TITLE
mdbrebase: fix prefix replacement, add regex & filename modes

### DIFF
--- a/mcs/tools/mdbrebase/mdbrebase.cs
+++ b/mcs/tools/mdbrebase/mdbrebase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.IO;
 
 using Mono.CompilerServices.SymbolWriter;
@@ -15,6 +16,11 @@ class Settings
 	public string OutputDirectory { get; set; }
 	public string InputPattern { get; set; }
 	public string OutputPattern { get; set; }
+	public bool InputPatternIsRegex { get; set; }
+	public bool FileNamesOnly { get; set; }
+	public bool Verbose { get; set; }
+
+	Regex inputPatternRegex;
 
 	public bool Validate ()
 	{
@@ -23,8 +29,15 @@ class Settings
 
 	public string Replace (string input)
 	{
-		if (input.StartsWith (InputPattern))
-			return input.Replace (InputPattern, OutputPattern);
+		if (InputPatternIsRegex) {
+			if (inputPatternRegex == null)
+				inputPatternRegex = new Regex (InputPattern);
+			return inputPatternRegex.Replace (input, OutputPattern);
+		} else {
+			if (input.StartsWith (InputPattern))
+				return OutputPattern + input.Substring (InputPattern.Length);
+		}
+
 		return input;
 	}
 }
@@ -46,7 +59,14 @@ class MdbRebase
 		var output = new MonoSymbolFile ();
 
 		foreach (var s in input.Sources) {
-			s.FileName = settings.Replace (s.FileName);
+			var newFileName = settings.FileNamesOnly
+				? Path.Combine (Path.GetDirectoryName (s.FileName), settings.Replace (Path.GetFileName (s.FileName)))
+				: settings.Replace (s.FileName);
+
+			if (settings.Verbose)
+				Console.WriteLine ("{0} -> {1}", s.FileName, newFileName);
+
+			s.FileName = newFileName;
 			output.AddSource (s);
 		}
 
@@ -97,6 +117,9 @@ class Driver {
 
 		var p = new OptionSet () {
 			{ "d=|output=",  "Output directory to the mdb file, replace existing one if ommited", v => s.OutputDirectory = v },
+			{ "v|verbose", "Be verbose with output (show individual path rewrites)", v => s.Verbose = true },
+			{ "f|filenames", "Only operate on file names, not full absolute paths", v => s.FileNamesOnly = true },
+			{ "r|regex", "Input pattern is a regular expression", v => s.InputPatternIsRegex = true },
 			{ "i=|input-pattern=", "Input pattern to replace (must not be a prefix to output-pattern)(required)", v => s.InputPattern = v },
 			{ "o=|output-pattern=", "Output pattern to replace (required)", v => s.OutputPattern = v },
 			{ "h|?|help", v => showHelp = true },


### PR DESCRIPTION
Existing prefix replacement was incorrect as
it tested for a prefix but performed a multi
search and replace instead of just a prefix
replace. Fix that.

Add -r|--regex mode to indicate that path
replacement should be performed with regular
expressions.

Add -f|--filename mode to indicate that
replacements should be performed only on
a file name and not the full absolute path.

Add -v|--verbose mode to print the replacements
that are performed.
