### PR TITLE
For module handles, only check that rva's are within the image size.

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -151,7 +151,16 @@ mono_image_rva_map (MonoImage *image, guint32 addr)
 	const int top = iinfo->cli_section_count;
 	MonoSectionTable *tables = iinfo->cli_section_tables;
 	int i;
-	
+
+#ifdef HOST_WIN32
+	if (image->is_module_handle) {
+		if (addr && addr < image->raw_data_len)
+			return image->raw_data + addr;
+		else
+			return NULL;
+	}
+#endif
+
 	for (i = 0; i < top; i++){
 		if ((addr >= tables->st_virtual_address) &&
 		    (addr < tables->st_virtual_address + tables->st_raw_data_size)){
@@ -159,10 +168,6 @@ mono_image_rva_map (MonoImage *image, guint32 addr)
 				if (!mono_image_ensure_section_idx (image, i))
 					return NULL;
 			}
-#ifdef HOST_WIN32
-			if (image->is_module_handle)
-				return image->raw_data + addr;
-#endif
 			return (char*)iinfo->cli_sections [i] +
 				(addr - tables->st_virtual_address);
 		}


### PR DESCRIPTION
This is only really relevant for Managed C++ dll's. It's possible for managed code to reference an RVA that is within a mapped section of the library but does not exist within the image file. Currently Mono will reject those addresses, even though for module handles they can be accessed. This becomes a problem if the library contains native code that accesses the same location directly.

In theory, we could still check to see whether the RVA is within a section, but PE images will typically make use of their entire range of memory when mapped by the Windows loader. I don't think it's worth the extra work to reject addresses that must be mapped because the loader can only map entire pages but technically aren't supposed to be in use.

It may be possible for pure managed code to also rely on this behavior, but to support this, Mono would have to map individual sections of images like the Windows loader instead of mapping the image file as-is. I can't see it being worth it, when any code that does this is probably using many other things that don't or can't work.
