### PR TITLE
anonymous: move counters to TypeContainer

### DIFF
--- a/mcs/mcs/anonymous.cs
+++ b/mcs/mcs/anonymous.cs
@@ -244,11 +244,11 @@ namespace Mono.CSharp {
 		AnonymousMethodStorey hoisted_this_parent;
 
 		public AnonymousMethodStorey (ExplicitBlock block, TypeDefinition parent, MemberBase host, TypeParameters tparams, string name, MemberKind kind)
-			: base (parent, MakeMemberName (host, name, parent.Module.CounterAnonymousContainers, tparams, block.StartLocation),
+			: base (parent, MakeMemberName (host, name, parent.PartialContainer.CounterAnonymousContainers, tparams, block.StartLocation),
 				tparams, 0, kind)
 		{
 			OriginalSourceBlock = block;
-			ID = parent.Module.CounterAnonymousContainers++;
+			ID = parent.PartialContainer.CounterAnonymousContainers++;
 		}
 
 		public void AddCapturedThisField (EmitContext ec, AnonymousMethodStorey parent)
@@ -1714,7 +1714,7 @@ namespace Mono.CSharp {
 				parent = ec.CurrentTypeDefinition.Parent.PartialContainer;
 
 			string name = CompilerGeneratedContainer.MakeName (parent != storey ? block_name : null,
-				"m", null, ec.Module.CounterAnonymousMethods++);
+				"m", null, parent.PartialContainer.CounterAnonymousMethods++);
 
 			MemberName member_name;
 			if (storey == null && ec.CurrentTypeParameters != null) {
@@ -1902,7 +1902,7 @@ namespace Mono.CSharp {
 
 		public static AnonymousTypeClass Create (TypeContainer parent, IList<AnonymousTypeParameter> parameters, Location loc)
 		{
-			string name = ClassNamePrefix + parent.Module.CounterAnonymousTypes++;
+			string name = ClassNamePrefix + parent.PartialContainer.CounterAnonymousTypes++;
 
 			ParametersCompiled all_parameters;
 			TypeParameters tparams = null;

--- a/mcs/mcs/class.cs
+++ b/mcs/mcs/class.cs
@@ -53,6 +53,11 @@ namespace Mono.CSharp
 
 		protected bool is_defined;
 
+		public int CounterAnonymousTypes { get; set; }
+		public int CounterAnonymousMethods { get; set; }
+		public int CounterAnonymousContainers { get; set; }
+		public int CounterSwitchTypes { get; set; }
+
 		protected TypeContainer (TypeContainer parent, MemberName name, Attributes attrs, MemberKind kind)
 			: base (parent, name, attrs)
 		{

--- a/mcs/mcs/module.cs
+++ b/mcs/mcs/module.cs
@@ -186,11 +186,6 @@ namespace Mono.CSharp
 			}
 		}
 
-		public int CounterAnonymousTypes { get; set; }
-		public int CounterAnonymousMethods { get; set; }
-		public int CounterAnonymousContainers { get; set; }
-		public int CounterSwitchTypes { get; set; }
-
 		public AssemblyDefinition DeclaringAssembly {
 			get {
 				return assembly;


### PR DESCRIPTION
With the anonymous counters on ModuleContainer,
anonymous method and type names will be generated
in a way that depends on the order of the sources
passed to mcs. This can cause undesirable API
and IL differences.

Moving the counters to TypeContainer instead
avoids this issue.
