### PR TITLE
Minor fix to avoid ArgumentOutOfRangeException

### DIFF
--- a/mcs/tools/security/sn.cs
+++ b/mcs/tools/security/sn.cs
@@ -126,7 +126,7 @@ namespace Mono.Tools {
 				return new StrongName (data).RSA;
 			}
 			catch {
-				if (data [0] != 0x30)
+				if (data.Length == 0 || data [0] != 0x30)
 					throw;
 				// this could be a PFX file
 				Console.Write ("Enter password for private key (will be visible when typed): ");


### PR DESCRIPTION
When the file is empty, data[0] would throw and swallow the original exception.
