### PR TITLE
Bug 15373: Return Local DateTime instead of Unspecified for >net_4_0

### DIFF
--- a/mcs/class/System.Core/System/TimeZoneInfo.cs
+++ b/mcs/class/System.Core/System/TimeZoneInfo.cs
@@ -1,3 +1,4 @@
+
 /*
  * System.TimeZoneInfo
  *
@@ -285,10 +286,17 @@ namespace System
 
 			if (this == TimeZoneInfo.Utc)
 				return DateTime.SpecifyKind (dateTime, DateTimeKind.Utc);
-
+			
 			//FIXME: do not rely on DateTime implementation !
-			if (this == TimeZoneInfo.Local)
+			if (this == TimeZoneInfo.Local) 
+			{
+#if NET_4_0
+				return dateTime.ToLocalTime ();
+#else
 				return DateTime.SpecifyKind (dateTime.ToLocalTime (), DateTimeKind.Unspecified);
+#endif
+			}
+
 
 			AdjustmentRule rule = GetApplicableRule (dateTime);
 		

--- a/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
@@ -387,6 +387,23 @@ namespace MonoTests.System
 		
 			}
 
+
+			[Test]
+			public void ConvertFromToLocal ()
+			{
+				DateTime utc = DateTime.UtcNow;
+				Assert.AreEqual(utc.Kind, DateTimeKind.Utc);
+				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc(utc, TimeZoneInfo.Local);
+			#if NET_4_0
+				Assert.AreEqual(DateTimeKind.Local, converted.Kind);
+			#else
+				Assert.AreEqual(DateTimeKind.Unspecified, converted.Kind);
+			#endif
+				DateTime back = TimeZoneInfo.ConvertTimeToUtc(converted, TimeZoneInfo.Local);
+				Assert.AreEqual(back.Kind, DateTimeKind.Utc);
+				Assert.AreEqual(utc, back);
+			}
+
 			[Test]
 			public void ConvertToTimeZone ()
 			{


### PR DESCRIPTION
Currently the documentation on MSDN located at http://msdn.microsoft.com/en-us/library/system.timezoneinfo.converttimefromutc(v=vs.110).aspx does not match the behaviour of .NET 4 ( or 4.5)

While the documentation says that calling TimeZoneInfoFromUtc will return a Unspecified DateTime this is not the case. Calls like the following will actually return a DateTime with Kind=Local.

TimeZoneInfo.ConvertTimeFromUtc(utc, TimeZoneInfo.Local).

This patch brings mono in line with the Microsoft implementation.
