### PR TITLE
Don't redeclare desc in mini_create_ftnptr on ppc64

### DIFF
--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -6807,7 +6807,6 @@ mini_create_ftnptr (MonoDomain *domain, gpointer addr)
 	desc [0] = addr;
 	desc [1] = NULL;
 #	elif defined(__ppc64__) || defined(__powerpc64__)
-	gpointer *desc;
 
 	desc = mono_domain_alloc0 (domain, 3 * sizeof (gpointer));
 


### PR DESCRIPTION
mini.c: In function 'mini_create_ftnptr':
mini.c:6734:12: error: redeclaration of 'desc' with no linkage
mini.c:6724:12: note: previous definition of 'desc' was here
mini.c:6734:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]

(line numbers are slightly out as this was from a 3.2.1 tarball, but the bug remains)
