### PR TITLE
WebConnectionStream.Length now consistently throws a NotSupportedException.

### DIFF
--- a/mcs/class/System/System.Net/WebConnectionStream.cs
+++ b/mcs/class/System/System.Net/WebConnectionStream.cs
@@ -44,7 +44,6 @@ namespace System.Net
 		byte [] readBuffer;
 		int readBufferOffset;
 		int readBufferSize;
-		int stream_length; // -1 when CL not present
 		int contentLength;
 		int totalRead;
 		internal long totalWritten;
@@ -98,10 +97,6 @@ namespace System.Net
 			} else {
 				contentLength = Int32.MaxValue;
 			}
-
-			// Negative numbers?
-			if (!Int32.TryParse (clength, out stream_length))
-				stream_length = -1;
 		}
 
 		public WebConnectionStream (WebConnection cnc, HttpWebRequest request)
@@ -810,11 +805,7 @@ namespace System.Net
 		}
 
 		public override long Length {
-			get {
-				if (!isRead)
-					throw new NotSupportedException ();
-				return stream_length;
-			}
+			get { throw new NotSupportedException (); }
 		}
 
 		public override long Position {


### PR DESCRIPTION
The behaviour of the Length implementation was not consistent with the expected and documented behaviour of this property:
    CanSeek always returns false, so Length should always throw an exception.
    In all cases, it should _never_ return -1, as it was the case when the Content-Length header could not be parsed.

See this bug on the Xamarin bug tracker for the discussion and an example of why the previous behaviour was a problem. https://bugzilla.xamarin.com/show_bug.cgi?id=15671
