### PR TITLE
Fixed a test issue where net45 methods were used in net40 profile

### DIFF
--- a/mcs/class/System/Test/System.Collections.Concurrent/BlockingCollectionTests.cs
+++ b/mcs/class/System/Test/System.Collections.Concurrent/BlockingCollectionTests.cs
@@ -202,12 +202,12 @@ namespace MonoTests.System.Collections.Concurrent
 			var arr = new [] { a, b };
 			string res = null;
 
-			Task<int> t = Task.Run (() => BlockingCollection<string>.TakeFromAny (arr, out res));
+			Task<int> t = Task.Factory.StartNew (() => BlockingCollection<string>.TakeFromAny (arr, out res));
 			a.Add ("foo");
 			Assert.AreEqual (0, t.Result, "#1");
 			Assert.AreEqual ("foo", res, "#2");
 
-			t = Task.Run (() => BlockingCollection<string>.TakeFromAny (arr, out res));
+			t = Task.Factory.StartNew (() => BlockingCollection<string>.TakeFromAny (arr, out res));
 			b.Add ("bar");
 			Assert.AreEqual (1, t.Result, "#3");
 			Assert.AreEqual ("bar", res, "#4");
@@ -222,19 +222,19 @@ namespace MonoTests.System.Collections.Concurrent
 			var cts = new CancellationTokenSource ();
 			string res = null;
 
-			Task<int> t = Task.Run (() => BlockingCollection<string>.TakeFromAny (arr, out res, cts.Token));
+			Task<int> t = Task.Factory.StartNew (() => BlockingCollection<string>.TakeFromAny (arr, out res, cts.Token));
 			Thread.Sleep (100);
 			a.Add ("foo");
 			Assert.AreEqual (0, t.Result, "#1");
 			Assert.AreEqual ("foo", res, "#2");
 
-			t = Task.Run (() => BlockingCollection<string>.TakeFromAny (arr, out res, cts.Token));
+			t = Task.Factory.StartNew (() => BlockingCollection<string>.TakeFromAny (arr, out res, cts.Token));
 			Thread.Sleep (100);
 			b.Add ("bar");
 			Assert.AreEqual (1, t.Result, "#3");
 			Assert.AreEqual ("bar", res, "#4");
 
-			t = Task.Run (() => {
+			t = Task.Factory.StartNew (() => {
 				try {
 					return BlockingCollection<string>.TakeFromAny (arr, out res, cts.Token);
 				} catch (OperationCanceledException WE_GOT_CANCELED) {

--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskFactoryTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskFactoryTest.cs
@@ -284,7 +284,9 @@ namespace MonoTests.System.Threading.Tasks
 		[Test]
 		public void ContinueWhenAny_WithResult ()
 		{
-			Task[] tasks = new[] { Task.FromResult (1) };
+			var tcs = new TaskCompletionSource<int>();
+			tcs.SetResult(1);
+			Task[] tasks = new[] { tcs.Task };
 			var res = Task.Factory.ContinueWhenAny (tasks, l => 4);
 			Assert.AreEqual (4, res.Result);
 		}


### PR DESCRIPTION
I found some tests that used methods added in .NET 4.5, despite the test being compiled under .NET 4.0, so I replaced them with equivalent methods.
