### PR TITLE
Add icalls to Mono.Runtime for getting the arch/OS.

### DIFF
--- a/docs/current-api
+++ b/docs/current-api
@@ -135,6 +135,8 @@ mono_code_manager_set_read_only
 mono_code_manager_size
 mono_compile_method
 mono_config_for_assembly
+mono_config_get_cpu
+mono_config_get_os
 mono_config_parse
 mono_config_parse_memory
 mono_config_string_for_assembly_file

--- a/docs/public-api
+++ b/docs/public-api
@@ -135,6 +135,8 @@ mono_code_manager_set_read_only
 mono_code_manager_size
 mono_compile_method
 mono_config_for_assembly
+mono_config_get_cpu
+mono_config_get_os
 mono_config_parse
 mono_config_parse_memory
 mono_config_string_for_assembly_file

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -45,6 +45,10 @@ namespace Mono {
 			mono_runtime_install_handlers ();
 		}
 
+		// see mono-config.c
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		public static extern string GetArchitectureName ();
+
 		// Should not be removed intended for external use
 		// Safe to be called using reflection
 		// Format is undefined only for use as a string for reporting
@@ -58,6 +62,10 @@ namespace Mono {
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern string GetNativeStackTrace (Exception exception);
+
+		// see mono-config.c
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		public static extern string GetOperatingSystemName ();
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		public static extern bool SetGCAllowSynchronousMajor (bool flag);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -46,8 +46,10 @@ ICALL(COMPROX_2, "FindProxy", ves_icall_Mono_Interop_ComInteropProxy_FindProxy)
 #endif
 
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
+ICALL(RUNTIME_14, "GetArchitectureName", ves_icall_Mono_Runtime_GetArchitectureName)
 ICALL(RUNTIME_1, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName)
 ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace)
+ICALL(RUNTIME_15, "GetOperatingSystemName", ves_icall_Mono_Runtime_GetOperatingSystemName)
 ICALL(RUNTIME_13, "SetGCAllowSynchronousMajor", ves_icall_Mono_Runtime_SetGCAllowSynchronousMajor)
 
 #ifndef PLATFORM_RO_FS

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7579,6 +7579,18 @@ ves_icall_Mono_Runtime_GetDisplayName (void)
 }
 
 ICALL_EXPORT MonoString*
+ves_icall_Mono_Runtime_GetArchitectureName (void)
+{
+	return mono_string_new (mono_domain_get (), mono_config_get_cpu ());
+}
+
+ICALL_EXPORT MonoString*
+ves_icall_Mono_Runtime_GetOperatingSystemName (void)
+{
+	return mono_string_new (mono_domain_get (), mono_config_get_os ());
+}
+
+ICALL_EXPORT MonoString*
 ves_icall_System_ComponentModel_Win32Exception_W32ErrorMessage (guint32 code)
 {
 	MonoString *message;

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -87,6 +87,16 @@
 #endif
 #endif
 
+const char *mono_config_get_cpu (void)
+{
+	return CONFIG_CPU;
+}
+
+const char *mono_config_get_os (void)
+{
+	return CONFIG_OS;
+}
+
 static void start_element (GMarkupParseContext *context, 
                            const gchar         *element_name,
 			   const gchar        **attribute_names,

--- a/mono/metadata/mono-config.h
+++ b/mono/metadata/mono-config.h
@@ -28,6 +28,9 @@ MONO_API const char* mono_config_string_for_assembly_file (const char *filename)
 MONO_API void mono_config_set_server_mode (mono_bool server_mode);
 MONO_API mono_bool mono_config_is_server_mode (void);
 
+MONO_API const char *mono_config_get_cpu (void);
+MONO_API const char *mono_config_get_os (void);
+
 MONO_END_DECLS
 
 #endif /* __MONO_METADATA_CONFIG_H__ */

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -141,6 +141,8 @@ mono_code_manager_size
 mono_compile_method
 mono_config_cleanup
 mono_config_for_assembly
+mono_config_get_cpu
+mono_config_get_os
 mono_config_parse
 mono_config_parse_memory
 mono_config_string_for_assembly_file

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -141,6 +141,8 @@ mono_code_manager_size
 mono_compile_method
 mono_config_cleanup
 mono_config_for_assembly
+mono_config_get_cpu
+mono_config_get_os
 mono_config_parse
 mono_config_parse_memory
 mono_config_string_for_assembly_file


### PR DESCRIPTION
I need this for a C# library I'm working on which attempts to implement the C11/C++11 atomic memory model. I cannot use things like `Environment.Is64BitProcess` because I need to know the actual architecture - it's not a matter of word size. For example, on x86, barriers are usually not needed for an atomic load, while on ARM, they are. And so on.

Whether the `mono-config` APIs should be public is debatable and I don't particularly care myself. I just marked them public in case anyone thought they would be useful.
