### PR TITLE
Setting ReceiveBufferSize & SendBufferSize on Socket (Bug 16021 & Bug 12754)

### DIFF
--- a/mono/io-layer/sockets.c
+++ b/mono/io-layer/sockets.c
@@ -778,6 +778,7 @@ int _wapi_setsockopt(guint32 fd, int level, int optname,
 	gpointer handle = GUINT_TO_POINTER (fd);
 	int ret;
 	const void *tmp_val;
+	int bufsize = 0;
 	struct timeval tv;
 	
 	if (startup_count == 0) {
@@ -805,7 +806,7 @@ int _wapi_setsockopt(guint32 fd, int level, int optname,
 		 * buffer sizes "to allow space for bookkeeping
 		 * overhead."
 		 */
-		int bufsize = *((int *) optval);
+		bufsize = *((int *) optval);
 
 		bufsize /= 2;
 		tmp_val = &bufsize;


### PR DESCRIPTION
Setting ReceiveBufferSize & SendBufferSize on Socket (Bug 16021 & Bug 12754) sets the properties to random values.

Fixes :

https://bugzilla.xamarin.com/show_bug.cgi?id=16021
https://bugzilla.xamarin.com/show_bug.cgi?id=12754

Resolves:

http://lists.ximian.com/pipermail/mono-list/2013-June/050008.html

A reference to the variable bufsize, local to the else-if block was being passed to the function setsockopt hence
the properties ReceiveBufferSize & SendBufferSize were being set to garbage on the Socket class. This could and did have a SERIOUS performance hit on socket communication. It is not inconceivable that people would try to increase the
buffer sizes and inadvertently shrink them considerably with a consequence of drastically degrade performance.

Narinder Claire
narinder.claire <<at>> gmail.com
