### PR TITLE
System.CompomentModel.Component.cs: Make disposedEvent key static

### DIFF
--- a/mcs/class/System/System.ComponentModel/Component.cs
+++ b/mcs/class/System/System.ComponentModel/Component.cs
@@ -44,7 +44,7 @@ namespace System.ComponentModel {
 
 		private EventHandlerList event_handlers;
 		private ISite mySite;
-		private object disposedEvent = new object ();
+		static readonly object disposedEvent = new object ();
 
 		public Component ()
 		{


### PR DESCRIPTION
There is no need for an instance of Component to create its own lookup key for the Disposed event. Use a shared static key instead.
