### PR TITLE
Fixed StackOverflow exception in Attribute.GetHashCode()

### DIFF
--- a/mcs/class/corlib/System/Attribute.cs
+++ b/mcs/class/corlib/System/Attribute.cs
@@ -258,7 +258,7 @@ namespace System
 
 		public override int GetHashCode ()
 		{
-			int result = TypeId.GetHashCode ();
+			int result = GetType ().GetHashCode ();
 
 			FieldInfo[] fields = GetType ().GetFields (BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
 			foreach (FieldInfo field in fields) {

--- a/mcs/class/corlib/Test/System/AttributeTest.cs
+++ b/mcs/class/corlib/Test/System/AttributeTest.cs
@@ -88,6 +88,13 @@ namespace MonoTests.System
 		class MyDerivedClassNoAttribute : MyClass
 		{
 		}
+
+		internal class AttributeWithTypeId : Attribute
+		{
+			public override object TypeId {
+				get { return this; }
+			}
+		}
 	}
 
 	[TestFixture]
@@ -997,6 +1004,14 @@ namespace MonoTests.System
 
 			MyOwnCustomAttribute b1 = new MyOwnCustomAttribute (null);
 			Assert.AreNotEqual (a1.GetHashCode (), b1.GetHashCode (), "non-identical-types");
+		}
+
+		[Test]
+		public void GetHashCodeWithOverriddenTypeId ()
+		{
+			//check for not throwing stack overflow exception
+			AttributeWithTypeId a = new AttributeWithTypeId ();
+			a.GetHashCode ();
 		}
 	}
 


### PR DESCRIPTION
MS implementation of Attribute.GetHashCode does not depend on TypeId property you can return any value in TypeId and hashcode in MS.NET will be same all the time. HashCode for Attribute in MS.NET depends on Type and attribute field values so mono implementation changed to be depended on such parameters. 
