### PR TITLE
2013-11-12 Ryan Williams <ryan@ryanwilliams.id.au>

### DIFF
--- a/mcs/class/corlib/System/ConsoleKeyInfo.cs
+++ b/mcs/class/corlib/System/ConsoleKeyInfo.cs
@@ -31,80 +31,83 @@ namespace System {
 	[Serializable]
 	public struct ConsoleKeyInfo {
 		internal static ConsoleKeyInfo Empty = new ConsoleKeyInfo ('\0', 0, false, false, false);
-		ConsoleKey key;
-		char keychar;
-		ConsoleModifiers modifiers;
+		ConsoleKey _key;
+		char _keyChar;
+		ConsoleModifiers _mods;
 
 		public ConsoleKeyInfo (char keyChar, ConsoleKey key, bool shift, bool alt, bool control)
 		{
-			this.key = key;
-			this.keychar = keyChar;
-			modifiers = 0;
+			_key = key;
+			_keyChar = keyChar;
+			_mods = 0;
 			SetModifiers (shift, alt, control);
 		}
 
 		internal ConsoleKeyInfo (ConsoleKeyInfo other)
 		{
-			this.key = other.key;
-			this.keychar = other.keychar;
-			this.modifiers = other.modifiers;
+			_key = other._key;
+			_keyChar = other._keyChar;
+			_mods = other._mods;
 		}
 
 		internal void SetKey (ConsoleKey key)
 		{
-			this.key = key;
+			_key = key;
 		}
 
 		internal void SetKeyChar (char keyChar)
 		{
-			this.keychar = keyChar;
+			_keyChar = keyChar;
 		}
 
 		internal void SetModifiers (bool shift, bool alt, bool control)
 		{
-			this.modifiers = (shift) ? ConsoleModifiers.Shift : 0;
-			this.modifiers |= (alt) ? ConsoleModifiers.Alt : 0;
-			this.modifiers |= (control) ? ConsoleModifiers.Control : 0;
+			_mods = (shift) ? ConsoleModifiers.Shift : 0;
+			_mods |= (alt) ? ConsoleModifiers.Alt : 0;
+			_mods |= (control) ? ConsoleModifiers.Control : 0;
 		}
 
-		public ConsoleKey Key {
-			get { return key; }
+		public ConsoleKey Key 
+		{
+			get { return _key; }
 		}
 
-		public char KeyChar {
-			get { return keychar; }
+		public char KeyChar 
+		{
+			get { return _keyChar; }
 		}
 
-		public ConsoleModifiers Modifiers {
-			get { return modifiers; }
+		public ConsoleModifiers Modifiers 
+		{
+			get { return _mods; }
 		}
-		
+
 		public override bool Equals (object value)
 		{
 			if (!(value is ConsoleKeyInfo))
 				return false;
+
 			return Equals ((ConsoleKeyInfo) value);
 		}
-		
+
 		public static bool operator == (ConsoleKeyInfo a, ConsoleKeyInfo b)
 		{
 			return a.Equals (b);
 		}
-		
+
 		public static bool operator != (ConsoleKeyInfo a, ConsoleKeyInfo b)
 		{
 			return !a.Equals (b);
 		}
-		
+
 		public bool Equals (ConsoleKeyInfo obj)
 		{
-			return key == obj.key && obj.keychar == keychar && obj.modifiers == modifiers;
+			return _key == obj._key && _keyChar == obj._keyChar && _mods == obj._mods;
 		}
-		
+
 		public override int GetHashCode ()
 		{
-			return key.GetHashCode () ^ keychar.GetHashCode () ^ modifiers.GetHashCode ();
+			return _key.GetHashCode () ^ _keyChar.GetHashCode () ^ _mods.GetHashCode ();
 		}
 	}
 }
-


### PR DESCRIPTION
Renamed member variables to be compatible with Microsoft for serialization.

Slight change to Equals method for consistency.
