### PR TITLE
Fixed a test failure that occurs when the specified font is not installed

### DIFF
--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
@@ -635,8 +635,8 @@ namespace MonoTests.System.Drawing{
         [Test]
         public void GetHashCode_UnitDiffers_HashesNotEqual()
         {
-            Font f1 = new Font("DejaVu Sans", 8.25F, GraphicsUnit.Point);
-            Font f2 = new Font("DejaVu Sans", 8.25F, GraphicsUnit.Pixel);
+            Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
+            Font f2 = new Font("Arial", 8.25F, GraphicsUnit.Pixel);
 
             Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
                 "Hashcodes should differ if _unit member differs");
@@ -645,8 +645,8 @@ namespace MonoTests.System.Drawing{
         [Test]
         public void GetHashCode_NameDiffers_HashesNotEqual()
         {
-            Font f1 = new Font("DejaVu Sans", 8.25F, GraphicsUnit.Point);
-            Font f2 = new Font("Liberation Sans", 8.25F, GraphicsUnit.Point);
+            Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
+            Font f2 = new Font("Courier New", 8.25F, GraphicsUnit.Point);
 
             Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
                 "Hashcodes should differ if _name member differs");
@@ -655,8 +655,8 @@ namespace MonoTests.System.Drawing{
         [Test]
         public void GetHashCode_StyleEqualsGdiCharSet_HashesNotEqual()
         {
-            Font f1 = new Font("DejaVu Sans", 8.25F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
-            Font f2 = new Font("DejaVu Sans", 8.25F, FontStyle.Bold, GraphicsUnit.Point, ((byte)(1)));
+            Font f1 = new Font("Arial", 8.25F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
+            Font f2 = new Font("Arial", 8.25F, FontStyle.Bold, GraphicsUnit.Point, ((byte)(1)));
 
             Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
                 "Hashcodes should differ if _style member differs");


### PR DESCRIPTION
On systems where 'Liberation Sans' is not installed out-of-the-box (e.g. Ubuntu Server, OpenSuse Server) it falls back to 'DejaVu Sans', which makes the GetHashCode_NameDiffers_HashesNotEqual() test fail as the two font names are now equal. Instead we use 'Arial' and 'Courier New' which resolve to different fonts on most systems.

Note: I changed the other two tests that used 'Liberation Sans' too, so they are consistent with the rest of the font test suite which uses 'Arial'.
