### PR TITLE
[System.Configuration/Test] Try to track down failure in buildbot

### DIFF
--- a/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationManagerTest.cs
+++ b/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationManagerTest.cs
@@ -37,6 +37,7 @@ using System.IO;
 using NUnit.Framework;
 using SysConfig = System.Configuration.Configuration;
 using System.Runtime.InteropServices;
+using System.Reflection;
 
 namespace MonoTests.System.Configuration {
 	using Util;
@@ -616,6 +617,11 @@ namespace MonoTests.System.Configuration {
 		[Test]
 		public void TestConnectionStringRetrieval ()
 		{
+			var currentAssembly = Assembly.GetExecutingAssembly().Location;
+			Assert.IsTrue (File.Exists (currentAssembly + ".config"),
+			               String.Format ("This test cannot succeed without the .config file being in the same place as the assembly ({0})",
+			                              currentAssembly));
+
 			var connStringObj = ConfigurationManager.ConnectionStrings ["test-connstring"];
 			Assert.IsNotNull (connStringObj);
 			var connString = connStringObj.ConnectionString;


### PR DESCRIPTION
This TestConnectionStringRetrieval unit test (committed by me some months
ago) succeeds for me in a clean checkout, but I don't understand why it
fails in the buildbot, so let's place some sanity check in it.
