### PR TITLE
[Bug 16186] SqlCommand.BeginExecuteInternal fix

### DIFF
--- a/mcs/class/System.Data/System.Data.SqlClient/SqlCommand.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlCommand.cs
@@ -846,7 +846,7 @@ namespace System.Data.SqlClient {
 					if (keyInfo || schemaOnly)
 						epilog = sql2.ToString ();
 					try {
-						Connection.Tds.BeginExecuteProcedure (prolog,
+						ar = Connection.Tds.BeginExecuteProcedure (prolog,
 										      epilog,
 										      CommandText,
 										      !wantResults,


### PR DESCRIPTION
If you use a stored procedure or a prepared statement, with
CommantType.StoredProcedure the ar variable is not set as the result of
onnection.Tds.BeginExecuteProcedure().

See https://bugzilla.xamarin.com/show_bug.cgi?id=16186
