### PR TITLE
Fix getting current system locale

### DIFF
--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -478,6 +478,9 @@ get_current_locale_name (void)
 	p = strchr (locale, '@');
 	if (p != NULL)
 		*p = 0;
+	p = strchr (locale, '_');
+	if (p != NULL)
+		*p = '-';
 
 	ret = g_ascii_strdown (locale, -1);
 	g_free (locale);


### PR DESCRIPTION
Ultimately this fixes the invariant locale being set as System.Globalization.CultureInfo.CurrentCulture on systems with LANG=xx_YY and in wine-mono. See commit messages for more details.
