### PR TITLE
Check for __readfsdword at configure-time

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2146,6 +2146,7 @@ else
 	AC_CHECK_DECLS(InterlockedIncrement64, [], [], [[#include <windows.h>]])
 	AC_CHECK_DECLS(InterlockedAdd, [], [], [[#include <windows.h>]])
 	AC_CHECK_DECLS(InterlockedAdd64, [], [], [[#include <windows.h>]])
+	AC_CHECK_DECLS(__readfsdword, [], [], [[#include <windows.h>]])
 fi
 
 dnl socklen_t check

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -811,9 +811,8 @@ mono_thread_create (MonoDomain *domain, gpointer func, gpointer arg)
 	mono_thread_create_internal (domain, func, arg, FALSE, FALSE, 0);
 }
 
-#if defined(HOST_WIN32) && defined(__GNUC__)
+#if defined(HOST_WIN32) && HAVE_DECL___READFSDWORD==0
 static __inline__ __attribute__((always_inline))
-/* This is not defined by gcc */
 unsigned long long
 __readfsdword (unsigned long offset)
 {

--- a/winconfig.h
+++ b/winconfig.h
@@ -96,6 +96,10 @@
    and to 0 if you don't. */
 #define HAVE_DECL_INTERLOCKEDCOMPAREEXCHANGE64 1
 
+/* Define to 1 if you have the declaration of `__readfsdword',
+   and to 0 if you don't. */
+#define HAVE_DECL___READFSDWORD 1
+
 /* Define to 1 if you have the <dirent.h> header file. */
 /* #define HAVE_DIRENT_H 1 */
 


### PR DESCRIPTION
Recent versions of mingw-w64 have moved this definition to a header
included by this file, so checking simply for GCC would cause a multiple
definition error. We should instead check for this function's
availability at configure-time.

These changes are released under MIT/X11 license.
