### PR TITLE
fixed some warnings in mono-proclib.c

### DIFF
--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -561,7 +561,7 @@ get_cpu_times (int cpu_id, gint64 *user, gint64 *systemt, gint64 *irq, gint64 *s
 	char buf [256];
 	char *s;
 	int hz = get_user_hz ();
-	guint64	user_ticks, nice_ticks, system_ticks, idle_ticks, iowait_ticks, irq_ticks, sirq_ticks;
+	guint64	user_ticks = 0, nice_ticks = 0, system_ticks = 0, idle_ticks = 0, iowait_ticks, irq_ticks = 0, sirq_ticks = 0;
 	FILE *f = fopen ("/proc/stat", "r");
 	if (!f)
 		return;


### PR DESCRIPTION
mono-proclib.c: In function ‘get_cpu_times’:
mono-proclib.c:600:24: warning: ‘sirq_ticks’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   *sirq = (sirq_ticks) \* 10000000 / hz;
                        ^
mono-proclib.c:598:22: warning: ‘irq_ticks’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   *irq = (irq_ticks) \* 10000000 / hz;
                      ^
mono-proclib.c:602:24: warning: ‘idle_ticks’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   *idle = (idle_ticks) \* 10000000 / hz;
                        ^
mono-proclib.c:596:29: warning: ‘system_ticks’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   *systemt = (system_ticks) \* 10000000 / hz;
                             ^
mono-proclib.c:594:23: warning: ‘nice_ticks’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   *user = (user_ticks + nice_ticks) \* 10000000 / hz;
                       ^
mono-proclib.c:594:23: warning: ‘user_ticks’ may be used uninitialized in this function [-Wmaybe-uninitialized]
