### PR TITLE
Bug 15574. XML deserialization recursion: add array type to known_types?

### DIFF
--- a/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization/DataContractSerializer.cs
+++ b/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization/DataContractSerializer.cs
@@ -248,8 +248,10 @@ namespace System.Runtime.Serialization
 				return;
 
 			Type elementType = type;
-			if (type.HasElementType)
+			if (type.HasElementType) {
+				known_types.Add (type);
 				elementType = type.GetElementType ();
+			}
 
 			known_types.Add (elementType);
 


### PR DESCRIPTION
One way to prevent https://bugzilla.xamarin.com/show_bug.cgi?id=15574 is to add the problematic array type to the `known_types`.

On the other hand, this might not be the intended use of `known_types`. In that case, perhaps a better fix would be to guard against recursion in the `foreach` loop:

```
foreach (var t in kt.GetTypes (elementType))
    if (t != type)
        RegisterTypeAsKnown (t);
```
