### PR TITLE
Bug 15572. Lookup KnownTypeCollection element types in MSSimpleNamespace

### DIFF
--- a/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization/XmlFormatterDeserializer.cs
+++ b/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization/XmlFormatterDeserializer.cs
@@ -261,7 +261,7 @@ namespace System.Runtime.Serialization
 			if (name.StartsWith ("ArrayOf", StringComparison.Ordinal)) {
 				name = name.Substring (7); // strip "ArrayOf"
 				if (ns == KnownTypeCollection.MSArraysNamespace)
-					return GetTypeFromNamePair (name, String.Empty).MakeArrayType ();
+					return GetTypeFromNamePair (name, KnownTypeCollection.MSSimpleNamespace).MakeArrayType ();
 				makeArray = true;
 			}
 


### PR DESCRIPTION
This patch prevents the problem in https://bugzilla.xamarin.com/show_bug.cgi?id=15572. This change allows the DataContractSerializer to deserialize DataMembers that use an array KnownType, at least for the test case in the bug report.
