### PR TITLE
Header names should be compared binary but not linguistic.

### DIFF
--- a/mcs/class/System.Web/System.Web/HttpHeaderCollection.cs
+++ b/mcs/class/System.Web/System.Web/HttpHeaderCollection.cs
@@ -34,6 +34,10 @@ namespace System.Web
 	{
 		bool? headerCheckingEnabled;
 
+		public HttpHeaderCollection () : base (StringComparer.OrdinalIgnoreCase)
+		{
+		}
+
 		bool HeaderCheckingEnabled {
 			get {
 				if (headerCheckingEnabled == null)

--- a/mcs/class/System.Web/System.Web/HttpResponse.cs
+++ b/mcs/class/System.Web/System.Web/HttpResponse.cs
@@ -510,27 +510,27 @@ namespace System.Web
 			if (headers_sent)
 				throw new HttpException ("Headers have been already sent");
 #if !TARGET_J2EE
-			if (String.Compare (name, "content-length", true, Helpers.InvariantCulture) == 0){
+			if (String.Compare (name, "content-length", StringComparison.OrdinalIgnoreCase) == 0){
 				content_length = (long) UInt64.Parse (value);
 				use_chunked = false;
 				return;
 			}
 #endif
 
-			if (String.Compare (name, "content-type", true, Helpers.InvariantCulture) == 0){
+			if (String.Compare (name, "content-type", StringComparison.OrdinalIgnoreCase) == 0){
 				ContentType = value;
 				return;
 			}
 
 #if !TARGET_J2EE
-			if (String.Compare (name, "transfer-encoding", true, Helpers.InvariantCulture) == 0){
+			if (String.Compare (name, "transfer-encoding", StringComparison.OrdinalIgnoreCase) == 0){
 				transfer_encoding = value;
 				use_chunked = false;
 				return;
 			}
 #endif
 
-			if (String.Compare (name, "cache-control", true, Helpers.InvariantCulture) == 0){
+			if (String.Compare (name, "cache-control", StringComparison.OrdinalIgnoreCase) == 0){
 				user_cache_control = value;
 				return;
 			}


### PR DESCRIPTION
Moreover according to RFC2616 header names are subset of ASCII chars [0-127],
so culture-aware comparison is useless and eats too many processor time
(My benchmarks show that getting an item from Hashtable with OrdinalIgnoreCase
comparers more than 20x times faster compared to Hashtable with InvariantCultureIgnoreCase
comparer)
