### PR TITLE
Stub implementation of EndGetRequestStream overload in HttpWebRequest.cs

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -36,6 +36,7 @@ using System.Collections;
 using System.Configuration;
 using System.Globalization;
 using System.IO;
+using System.Net;
 using System.Net.Cache;
 using System.Net.Sockets;
 using System.Runtime.Remoting.Messaging;
@@ -951,8 +952,8 @@ namespace System.Net
 			return result.Response;
 		}
 		
-#if NET_4_0
-		public Stream EndGetRequestStream (IAsyncResult asyncResult, out System.Net.TransportContext transportContext)
+#if NET_3_5
+		public Stream EndGetRequestStream (IAsyncResult asyncResult, out TransportContext transportContext)
 		{
 			transportContext = null;
 			return EndGetRequestStream (asyncResult);


### PR DESCRIPTION
I am not sure if a "do-nothing" implementation like this is acceptable in the Mono code base, but it does solve the problem described in https://bugzilla.xamarin.com/show_bug.cgi?id=12875 (successfully executing simple API requests using the Google API .NET client library).

According to the Microsoft documentation (http://msdn.microsoft.com/en-us/library/dd383932.aspx), the TransportContext out parameter in this overload is primarily intended for callers that use integrated Windows authentication, while also implementing their own authentication. (The explanation is a bit hard to follow, but it does seem to indicate that the parameter is rarely needed.)

I believe EndGetRequestStream is not called directly by the Google API .NET client library but by one of its dependencies installed by NuGet. This makes the problem hard to fix at the Google API library end.

After applying this patch, compiling Mono, and installing root certificates, I was able to get the expected response from the API to a request for Analytics data.

The changes are licensed under the MIT X11 license. (This is correct for the class libraries, right?)
