### PR TITLE
[System] Change S.N.S.NetworkStream's param name on ctor

### DIFF
--- a/mcs/class/System/System.Net.Sockets/NetworkStream.cs
+++ b/mcs/class/System/System.Net.Sockets/NetworkStream.cs
@@ -51,8 +51,8 @@ namespace System.Net.Sockets
 		{
 		}
 
-		public NetworkStream (Socket socket, bool owns_socket)
-			: this (socket, FileAccess.ReadWrite, owns_socket)
+		public NetworkStream (Socket socket, bool ownsSocket)
+			: this (socket, FileAccess.ReadWrite, ownsSocket)
 		{
 		}
 
@@ -61,7 +61,7 @@ namespace System.Net.Sockets
 		{
 		}
 		
-		public NetworkStream (Socket socket, FileAccess access, bool owns_socket)
+		public NetworkStream (Socket socket, FileAccess access, bool ownsSocket)
 		{
 			if (socket == null)
 				throw new ArgumentNullException ("socket is null");
@@ -73,7 +73,7 @@ namespace System.Net.Sockets
 				throw new IOException ("Operation not allowed on a non-blocking socket.");
 			
 			this.socket = socket;
-			this.owns_socket = owns_socket;
+			this.owns_socket = ownsSocket;
 			this.access = access;
 
 			readable = CanRead;


### PR DESCRIPTION
Changed to the name that is used in MS.NET:
http://msdn.microsoft.com/en-us/library/te7e60bx%28v=vs.110%29.aspx

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=16832
