### PR TITLE
Check for null item in BindingList<T>.InsertItem

### DIFF
--- a/mcs/class/System/System.ComponentModel/BindingList.cs
+++ b/mcs/class/System/System.ComponentModel/BindingList.cs
@@ -242,7 +242,7 @@ namespace System.ComponentModel {
 			if (raise_list_changed_events)
 				OnListChanged (new ListChangedEventArgs (ListChangedType.ItemAdded, index));
 
-			if (item!=null && type_raises_item_changed_events)
+			if (item != null && type_raises_item_changed_events)
 				(item as INotifyPropertyChanged).PropertyChanged += Item_PropertyChanged;
 		}
 


### PR DESCRIPTION
Fix for [bug 16902](https://bugzilla.xamarin.com/show_bug.cgi?id=16902).
Prevents `NullReferenceException` when a class implementing `INotifyPropertyChanged` is used as `T` in `System.ComponentModel.BindingList<T>`, and a `null` object is added to the collection.
