### PR TITLE
String.Join() calls List(IEnum) instead of looping

### DIFF
--- a/mcs/class/corlib/System/String.cs
+++ b/mcs/class/corlib/System/String.cs
@@ -2710,9 +2710,7 @@ namespace System
 			if (values == null)
 				throw new ArgumentNullException ("values");
 			
-			var stringList = new List<string> ();
-			foreach (var v in values)
-				stringList.Add (v);
+			var stringList = new List<string> (values);
 
 			return JoinUnchecked (separator, stringList.ToArray (), 0, stringList.Count);
 		}


### PR DESCRIPTION
`String.Join()` instead of looping over `IEnumerable<T>` calls the constructor of `List<T>` accepting `IEnumerable<T>`.
According to [List.cs](https://github.com/mono/mono/blob/master/mcs/class/corlib/System.Collections.Generic/List.cs#L67) it should be more efficient.

Because `JoinUnchecked()` accepts `string[]` the option #2 is to call [ToArray()](https://github.com/mono/mono/blob/master/mcs/class/System.Core/System.Linq/Enumerable.cs#L2886) extension method 
