### PR TITLE
F#-compatible tuple hashing

### DIFF
--- a/mcs/class/corlib/System/Tuples.cs
+++ b/mcs/class/corlib/System/Tuples.cs
@@ -183,9 +183,10 @@ namespace System
 
 		int IStructuralEquatable.GetHashCode (IEqualityComparer comparer)
 		{
-			int h = comparer.GetHashCode (item1);
-			h = (h << 5) - h + comparer.GetHashCode (item2);
-			return h;
+			int h0;
+			h0 = comparer.GetHashCode (item1);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item2);
+			return h0;
 		}
 
 		public override string ToString ()
@@ -263,10 +264,11 @@ namespace System
 
 		int IStructuralEquatable.GetHashCode (IEqualityComparer comparer)
 		{
-			int h = comparer.GetHashCode (item1);
-			h = (h << 5) - h + comparer.GetHashCode (item2);
-			h = (h << 5) - h + comparer.GetHashCode (item3);
-			return h;
+			int h0;
+			h0 = comparer.GetHashCode (item1);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item2);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item3);
+			return h0;
 		}
 
 		public override string ToString ()
@@ -353,11 +355,13 @@ namespace System
 
 		int IStructuralEquatable.GetHashCode (IEqualityComparer comparer)
 		{
-			int h = comparer.GetHashCode (item1);
-			h = (h << 5) - h + comparer.GetHashCode (item2);
-			h = (h << 5) - h + comparer.GetHashCode (item3);
-			h = (h << 5) - h + comparer.GetHashCode (item4);
-			return h;
+			int h0, h1;
+			h0 = comparer.GetHashCode (item1);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item2);
+			h1 = comparer.GetHashCode (item3);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item4);
+			h0 = (h0 << 5) + h0 ^ h1;
+			return h0;
 		}
 
 		public override string ToString ()
@@ -453,12 +457,14 @@ namespace System
 
 		int IStructuralEquatable.GetHashCode (IEqualityComparer comparer)
 		{
-			int h = comparer.GetHashCode (item1);
-			h = (h << 5) - h + comparer.GetHashCode (item2);
-			h = (h << 5) - h + comparer.GetHashCode (item3);
-			h = (h << 5) - h + comparer.GetHashCode (item4);
-			h = (h << 5) - h + comparer.GetHashCode (item5);
-			return h;
+			int h0, h1;
+			h0 = comparer.GetHashCode (item1);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item2);
+			h1 = comparer.GetHashCode (item3);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item4);
+			h0 = (h0 << 5) + h0 ^ h1;
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item5);
+			return h0;
 		}
 
 		public override string ToString ()
@@ -563,13 +569,16 @@ namespace System
 
 		int IStructuralEquatable.GetHashCode (IEqualityComparer comparer)
 		{
-			int h = comparer.GetHashCode (item1);
-			h = (h << 5) - h + comparer.GetHashCode (item2);
-			h = (h << 5) - h + comparer.GetHashCode (item3);
-			h = (h << 5) - h + comparer.GetHashCode (item4);
-			h = (h << 5) - h + comparer.GetHashCode (item5);
-			h = (h << 5) - h + comparer.GetHashCode (item6);
-			return h;
+			int h0, h1;
+			h0 = comparer.GetHashCode (item1);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item2);
+			h1 = comparer.GetHashCode (item3);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item4);
+			h0 = (h0 << 5) + h0 ^ h1;
+			h1 = comparer.GetHashCode (item5);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item6);
+			h0 = (h0 << 5) + h0 ^ h1;
+			return h0;
 		}
 
 		public override string ToString ()
@@ -683,14 +692,17 @@ namespace System
 
 		int IStructuralEquatable.GetHashCode (IEqualityComparer comparer)
 		{
-			int h = comparer.GetHashCode (item1);
-			h = (h << 5) - h + comparer.GetHashCode (item2);
-			h = (h << 5) - h + comparer.GetHashCode (item3);
-			h = (h << 5) - h + comparer.GetHashCode (item4);
-			h = (h << 5) - h + comparer.GetHashCode (item5);
-			h = (h << 5) - h + comparer.GetHashCode (item6);
-			h = (h << 5) - h + comparer.GetHashCode (item7);
-			return h;
+			int h0, h1;
+			h0 = comparer.GetHashCode (item1);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item2);
+			h1 = comparer.GetHashCode (item3);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item4);
+			h0 = (h0 << 5) + h0 ^ h1;
+			h1 = comparer.GetHashCode (item5);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item6);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item7);
+			h0 = (h0 << 5) + h0 ^ h1;
+			return h0;
 		}
 
 		public override string ToString ()
@@ -801,15 +813,19 @@ namespace System
 
 		int IStructuralEquatable.GetHashCode (IEqualityComparer comparer)
 		{
-			int h = comparer.GetHashCode (item1);
-			h = (h << 5) - h + comparer.GetHashCode (item2);
-			h = (h << 5) - h + comparer.GetHashCode (item3);
-			h = (h << 5) - h + comparer.GetHashCode (item4);
-			h = (h << 5) - h + comparer.GetHashCode (item5);
-			h = (h << 5) - h + comparer.GetHashCode (item6);
-			h = (h << 5) - h + comparer.GetHashCode (item7);
-			h = (h << 5) - h + comparer.GetHashCode (rest);
-			return h;
+			int h0, h1, h2;
+			h0 = comparer.GetHashCode (item1);
+			h0 = (h0 << 5) + h0 ^ comparer.GetHashCode (item2);
+			h1 = comparer.GetHashCode (item3);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item4);
+			h0 = (h0 << 5) + h0 ^ h1;
+			h1 = comparer.GetHashCode (item5);
+			h1 = (h1 << 5) + h1 ^ comparer.GetHashCode (item6);
+			h2 = comparer.GetHashCode (item7);
+			h2 = (h2 << 5) + h2 ^ comparer.GetHashCode (rest);
+			h1 = (h1 << 5) + h1 ^ h2;
+			h0 = (h0 << 5) + h0 ^ h1;
+			return h0;
 		}
 
 		public override string ToString ()
@@ -937,10 +953,15 @@ public class TupleGen
 			if (arity == 1) {
 				Console.WriteLine ("\t\t\treturn comparer.GetHashCode ({0});", GetItemName (arity));
 			} else {
-				Console.WriteLine ("\t\t\tint h = comparer.GetHashCode ({0});", GetItemName (1));
-				for (int i = 2; i <= arity; ++i)
-					Console.WriteLine ("\t\t\th = (h << 5) - h + comparer.GetHashCode ({0});", GetItemName (i));
-				Console.WriteLine ("\t\t\treturn h;");
+				int varnum = IntLog2(arity);
+				Console.Write ("\t\t\tint h0");
+				for (int i = 1; i < varnum; ++i)
+					Console.Write (", h{0}", i);
+				Console.WriteLine (";");
+
+				WriteHash(0, 1, arity);
+
+				Console.WriteLine ("\t\t\treturn h0;");
 			}
 
 			Console.WriteLine ("\t\t}");
@@ -964,6 +985,36 @@ public class TupleGen
 			Console.WriteLine ("\t\t}");
 
 			Console.WriteLine ("\t}\n");
+		}
+	}
+
+	static int IntLog2 (int n)
+	{
+		int r = -1;
+
+		while (n != 0) {
+			n >>= 1;
+			r++;
+		}
+
+		return r;
+	}
+
+	static void WriteHash (int destVar, int start, int count)
+	{
+		if (count == 1) {
+			Console.WriteLine ("\t\t\th{0} = comparer.GetHashCode ({1});", destVar, GetItemName (start));
+		} else {
+			int subCount = 1 << IntLog2(count-1);
+			computeHash(destVar, start, subCount);
+			start += subCount;
+			count -= subCount;
+			if (count == 1) {
+				Console.WriteLine ("\t\t\th{0} = (h{0} << 5) + h{0} ^ comparer.GetHashCode ({1});", destVar, GetItemName (start));
+			} else {
+				WriteHash(destVar+1, start, count);
+				Console.WriteLine ("\t\t\th{0} = (h{0} << 5) + h{0} ^ h{1};", destVar, destVar+1);
+			}
 		}
 	}
 


### PR DESCRIPTION
As pointed out in https://github.com/fsharp/fsharp/issues/188 , currently the F# compiler makes very strong assumptions about the algorithm used for hashing tuples. These assumptions hold on the .NET runtime, but not on Mono, which can result in incorrect behaviour.

This patchset restores the functionality of the Tuples.cs code generator and replaces the current algorithm (h = h_31 + data) with DJB2-XOR (h=h_33 ^ data), using the same parenthesization as in the F# compiler (somewhat like in a balanced binary tree). The original F# implementation is available here: https://github.com/fsharp/fsharp/blob/fsharp_31/src/fsharp/FSharp.Core/prim-types.fs#L488 

Some additional thoughts:
Neither the old nor the new hash algorithm are particularly robust, but they are not supposed to be strong hashes. In fact, DJB2 is known to be quite poor with respect to collisions. In my opinion a better (and still reasonably cheap) choice would have been some variant of MurmurHash, but this would break compatibility with .NET.

For future reference it might be worth pointing out that the new hash
requires an amount of memory (in the current implementation,
variables) which is O(log n) with respect to the size of the tuple,
while the previous one used O(1) space. Right now this is probably not much of a problem, but if in future tuples were allowed to have very big sizes, it might be inappropriate to have the temporary variables explicitly and it might be a good idea to store them in an array.
