### PR TITLE
Improve ABCREM

### DIFF
--- a/mono/mini/abcremoval.c
+++ b/mono/mini/abcremoval.c
@@ -275,6 +275,12 @@ get_relation_from_ins (MonoVariableRelationsEvaluationArea *area, MonoInst *ins,
 		value->value.variable.variable = ins->sreg1;
 		value->value.variable.delta = 0;
 		break;
+	case OP_SEXT_I4:
+		value->type = MONO_VARIABLE_SUMMARIZED_VALUE;
+		value->value.variable.variable = ins->sreg1;
+		value->value.variable.delta = 0;
+		value_kind = MONO_INTEGER_VALUE_SIZE_8;
+		break;
 	case OP_PHI:
 		value->type = MONO_PHI_SUMMARIZED_VALUE;
 		value->value.phi.number_of_alternatives = *(ins->inst_phi_args);


### PR DESCRIPTION
While working on some performance-related measurements in F# I found out that Mono was not performing ABCREM as expected. It looks like it's currently unable to propagate the value constraint across sign-extension, which on 64-bits archs is used basically every time a bound-check is added (see https://github.com/mono/mono/blob/master/mono/mini/method-to-ir.c#L4668 ).

While working on this code I noticed that both OP_IADD_IMM and OP_ISUB_IMM result in the very same constraint.
I would have expected OP_ISUB_IMM to have a value->value.variable.delta = -ins->inst_imm.
If this is correct and expected, could somebody add a comment about it?
