### PR TITLE
Fix a small typo in mono-core.spec.in breaking the build

### DIFF
--- a/mono-core.spec.in
+++ b/mono-core.spec.in
@@ -1122,7 +1122,7 @@ desktop-specific features.
 %_prefix/lib/mono/gac/System.Reactive.Experimental
 %_prefix/lib/mono/gac/System.Reactive.Interfaces
 %_prefix/lib/mono/gac/System.Reactive.Linq
-%_prefix/lib/mono/gac/System.Reactive.Observable.Aliases.dll
+%_prefix/lib/mono/gac/System.Reactive.Observable.Aliases
 %_prefix/lib/mono/gac/System.Reactive.PlatformServices
 %_prefix/lib/mono/gac/System.Reactive.Providers
 %_prefix/lib/mono/gac/System.Reactive.Runtime.Remoting


### PR DESCRIPTION
Signed-off-by: Etienne CHAMPETIER etienne.champetier@fiducial.net
