### PR TITLE
Avoid adjusting selection twice in TextControl.

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TextControl.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TextControl.cs
@@ -2444,6 +2444,8 @@ namespace System.Windows.Forms {
 
 				if (selection_visible == false) {
 					SetSelectionToCaret (true);
+					move_sel_start = false;
+					move_sel_end = false;
 				}
 			}
 


### PR DESCRIPTION
If we move the selection to the caret, the later adjustments (which assume the selection position did not account for the line splitting) will produce incorrect and possibly inconsistent values for selection position.
