### PR TITLE
Noted that the fullname attribute is not the same as Type.FullName.

### DIFF
--- a/mcs/tools/linker/README
+++ b/mcs/tools/linker/README
@@ -105,6 +105,10 @@ Here is an example that shows all the possibilities of this format:
 
 In this example, the linker will link the types Foo, Bar, Baz and Gazonk.
 
+The fullname attribute specifies the fullname of the type in the format
+specified by ECMA-335. This is in Mono and certain cases not the same
+as the one reported by Type.FullName (nested classes e.g.).
+
 The preserve attribute ensures that all the fields of the type Baz will be
 always be linked, not matter if they are used or not, but that neither the
 fields or the methods of Bar will be linked if they are not used. Not


### PR DESCRIPTION
Because of Cecil the fullname attribute does expect the fullname attribute to be in the format of ECMA-335. This is in certain cases not the same as the name reported by Type.FullName.

See jbevain/cecil#150 for some details on this.
