### PR TITLE
Align behaviour of Type.IsAssignableFrom type loading to that which is similar to MS.NET

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1554,9 +1554,6 @@ ves_icall_type_is_assignable_from (MonoReflectionType *type, MonoReflectionType 
 	klass = mono_class_from_mono_type (type->type);
 	klassc = mono_class_from_mono_type (c->type);
 
-	mono_class_init_or_throw (klass);
-	mono_class_init_or_throw (klassc);
-
 	if (type->type->byref ^ c->type->byref)
 		return FALSE;
 
@@ -1582,7 +1579,15 @@ ves_icall_type_is_assignable_from (MonoReflectionType *type, MonoReflectionType 
 			return klass->valuetype == klassc->valuetype;
 		}
 	}
-	return mono_class_is_assignable_from (klass, klassc);
+
+	/*
+	 * If the klass hasn't been inited yet then there is
+	 * no guarentee that the dll is loadable therefore
+	 * use the slow version
+	 */
+	if (klass->inited && klassc->inited)
+		return mono_class_is_assignable_from (klass, klassc);
+	return mono_class_is_assignable_from_slow (klass, klassc);
 }
 
 ICALL_EXPORT guint32


### PR DESCRIPTION
Currently mono is more aggressive at fully resolving class information than MS.NET.  

In this particular case this means that using Type.IsAssignableFrom will error with missing type information ( or shadow copy CopyFile ) errors if you attempt to determine whether a type (A) is assignable from another type (B) and either of those types has private instance variables with unresolvable types.

The FubuMVC project has a command-line application for running web applications with a Katana web app.  This cli app does so by copying itself + dependencies it knows will be required (but not all its dependencies) and then iterating over the Types loaded within a appdomain containing itself + the webapplication looking for an interface of the type expected by the FubuMVC framework.  ( IApplicationSource )

I have created a replication of the issue, as a simplified implementation of fubu.exe approach, which demonstrates this is.  It is located at https://github.com/alistair/mono_appdomain_investigation/tree/master  Sadly I am unsure of the best approach in creating a unit test for this fix within the mono repository.

I have attempted to compromise on performance + correctness so than when both types MonoClass's have been initialized the faster method of comparison will be used.   I have not profiled either method nor there frequency of calls within a 'normal' application so can not say what the performance implication are.

I have tested this code by running monodevelop with no issues, but that is a rather limited coverage.

ps.  Changing the AppDomain.ShadowCopyFiles property to "false"  in my replication project of will show more type information than then it is "true".  Please ensure you compile the solution first.

pss.  I have also raised a bug about this issue at https://bugzilla.xamarin.com/show_bug.cgi?id=17010
