### PR TITLE
Initialize icalls before exceptions.

### DIFF
--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -7266,10 +7266,10 @@ mini_init (const char *filename, const char *runtime_version)
 	/*Init arch tls information only after the metadata side is inited to make sure we see dynamic appdomain tls keys*/
 	mono_arch_finish_init ();
 
+	mono_icall_init ();
+
 	/* This must come after mono_init () in the aot-only case */
 	mono_exceptions_init ();
-
-	mono_icall_init ();
 
 	/* This should come after mono_init () too */
 	mini_gc_init ();


### PR DESCRIPTION
Since the icall mutex was added (720c9f42c7a1d5b11b30c19232ab0b9b58cb10c1), I'm seeing hangs in mono_jit_init in my win32 build. What happens is that mini_init calls mono_exceptions_init, which calls mono_arch_exceptions_init, which on x86 adds some icalls, which grabs the icall mutex. However, the grab cannot work because mono_icall_init, which initializes the mutex, isn't called until after mono_exceptions_init.

From reading the icall_init code I can't see any reason why it would need exceptions to be initialized first, so I think we can swap the order of those two calls. But a review from someone more familiar with this code would be nice.
