### PR TITLE
Fixed an error in xbuild_targets.make when using --with-profile2=no or --with-profile4=no

### DIFF
--- a/mcs/tools/xbuild/xbuild_targets.make
+++ b/mcs/tools/xbuild/xbuild_targets.make
@@ -2,13 +2,15 @@ test-local: copy-targets
 
 copy-targets:
 	for p in net_2_0 net_3_5 net_4_0; do \
-		cp $(XBUILD_DIR)/xbuild/Microsoft.CSharp.targets $(topdir)/class/lib/$$p; \
-		cp $(XBUILD_DIR)/xbuild/Microsoft.VisualBasic.targets $(topdir)/class/lib/$$p; \
-		cp $(XBUILD_DIR)/xbuild/Microsoft.Silverlight*.targets $(topdir)/class/lib/$$p; \
+		if [ -d $(topdir)/class/lib/$$p ]; then \
+			cp $(XBUILD_DIR)/xbuild/Microsoft.CSharp.targets $(topdir)/class/lib/$$p; \
+			cp $(XBUILD_DIR)/xbuild/Microsoft.VisualBasic.targets $(topdir)/class/lib/$$p; \
+			cp $(XBUILD_DIR)/xbuild/Microsoft.Silverlight*.targets $(topdir)/class/lib/$$p; \
+		fi \
 	done
-	cp $(XBUILD_DIR)/xbuild/2.0/Microsoft.Common.* $(topdir)/class/lib/net_2_0
-	cp $(XBUILD_DIR)/xbuild/3.5/Microsoft.Common.* $(topdir)/class/lib/net_3_5
-	cp $(XBUILD_DIR)/xbuild/4.0/Microsoft.Common.* $(topdir)/class/lib/net_4_0
+	if [ -d $(topdir)/class/lib/net_2_0 ]; then cp $(XBUILD_DIR)/xbuild/2.0/Microsoft.Common.* $(topdir)/class/lib/net_2_0; fi
+	if [ -d $(topdir)/class/lib/net_3_5 ]; then cp $(XBUILD_DIR)/xbuild/3.5/Microsoft.Common.* $(topdir)/class/lib/net_3_5; fi
+	if [ -d $(topdir)/class/lib/net_4_0 ]; then cp $(XBUILD_DIR)/xbuild/4.0/Microsoft.Common.* $(topdir)/class/lib/net_4_0; fi
 
 clean-local: clean-target-files
 


### PR DESCRIPTION
When turning off the net_2_0 or net_4_0 profile the respective folder in mcs/class/lib/ doesn't exist,
which results in an error when trying to copy a file to it in xbuild_targets.make

This occurs for example when running unit tests in `mcs/class/Microsoft.Build.Framework`
