### PR TITLE
Using the fully qualified assembly name in dependencies

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -582,7 +582,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			Assembly a = universe.LoadFile (new Uri(codebase).LocalPath);
 
 			foreach (AssemblyName an in a.GetReferencedAssemblies ()) {
-				a = universe.Load (an.Name);
+				a = universe.Load (an.FullName);
 				QueueAssembly (files, a.CodeBase);
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
mkbundle fails to load dependencies in certain cases because it doesn't use the full assembly name when computing dependencies. The assembly name is eventually provided to 'System.AppDomain.Load()' which expects a fully qualified assembly name.

The problem can be reproduced by running mkbundle on an GTK# application

```
$ mkbundle test.exe test.dll -o test --deps -z --static --config config
OS is: Linux
Note that statically linking the LGPL Mono runtime has more licensing restrictions than dynamically linking.
See http://www.mono-project.com/Licensing for details on licensing.
Sources: 2 Auto-dependencies: True

Unhandled Exception:
System.IO.FileNotFoundException: Could not load file or assembly 'gtk-sharp' or one of its dependencies. The system cannot find the file specified.
File name: 'gtk-sharp'
  at System.AppDomain.Load (System.String assemblyString, System.Security.Policy.Evidence assemblySecurity, Boolean refonly) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.AppDomain:Load (string,System.Security.Policy.Evidence,bool)
  at System.Reflection.Assembly.ReflectionOnlyLoad (System.String assemblyString) [0x00000] in <filename unknown>:0 
  at IKVM.Reflection.Universe.DefaultResolver (System.String refname, Boolean throwOnError) [0x00000] in <filename unknown>:0 
  at IKVM.Reflection.Universe.Load (System.String refname, IKVM.Reflection.Module requestingModule, Boolean throwOnError) [0x00000] in <filename unknown>:0 
  at IKVM.Reflection.Universe.Load (System.String refname) [0x00000] in <filename unknown>:0 
  at MakeBundle.QueueAssembly (System.Collections.Generic.List`1 files, System.String codebase) [0x00000] in <filename unknown>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.IO.FileNotFoundException: Could not load file or assembly 'gtk-sharp' or one of its dependencies. The system cannot find the file specified.
File name: 'gtk-sharp'
  at System.AppDomain.Load (System.String assemblyString, System.Security.Policy.Evidence assemblySecurity, Boolean refonly) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.AppDomain:Load (string,System.Security.Policy.Evidence,bool)
  at System.Reflection.Assembly.ReflectionOnlyLoad (System.String assemblyString) [0x00000] in <filename unknown>:0 
  at IKVM.Reflection.Universe.DefaultResolver (System.String refname, Boolean throwOnError) [0x00000] in <filename unknown>:0 
  at IKVM.Reflection.Universe.Load (System.String refname, IKVM.Reflection.Module requestingModule, Boolean throwOnError) [0x00000] in <filename unknown>:0 
  at IKVM.Reflection.Universe.Load (System.String refname) [0x00000] in <filename unknown>:0 
  at MakeBundle.QueueAssembly (System.Collections.Generic.List`1 files, System.String codebase) [0x00000] in <filename unknown>:0 
```

This patch simply changes the assembly qualifier to be its full name, causing System.AppDomain.Load() to succeed even for GTK# apps.
