### PR TITLE
Don't raise an exception if we can't find the src assembly on a shadow copy appdomain

### DIFF
--- a/mcs/class/corlib/Test/System/AppDomainTest.cs
+++ b/mcs/class/corlib/Test/System/AppDomainTest.cs
@@ -3308,11 +3308,28 @@ namespace MonoTests.System
 			TestSerialization (tester, typeof (StuffToPick<int>).GetMethod ("GenericMethod").MakeGenericMethod (typeof (int)));
 		}
 
+		[Test]
+		public void ShadowCopyTypeGetTypeMissingAssemblyTest ()
+		{
+			ad = CreateShadowCopyAppDomain (tempDir, true);
+			CrossDomainTester tester = CreateCrossDomainTester (ad);
+			tester.AssertLoadMissingAssemblyType ();
+		}
+
 		private static AppDomain CreateTestDomain (string baseDirectory, bool assemblyResolver)
 		{
 			AppDomainSetup setup = new AppDomainSetup ();
 			setup.ApplicationBase = baseDirectory;
 			setup.ApplicationName = "testdomain";
+			return CreateTestDomain (setup, assemblyResolver);
+		}
+
+		private static AppDomain CreateShadowCopyAppDomain (string baseDirectory, bool assemblyResolver)
+		{
+			AppDomainSetup setup = new AppDomainSetup ();
+			setup.ApplicationBase = baseDirectory;
+			setup.ApplicationName = "testdomain";
+			setup.ShadowCopyFiles = "true";
 			return CreateTestDomain (setup, assemblyResolver);
 		}
 
@@ -3423,22 +3440,17 @@ namespace MonoTests.System
 				}
 			}
 
+			public void AssertLoadMissingAssemblyType ()
+			{
+				Assert.IsNull (Type.GetType ("A.B.C, MissingAssembly"));
+			}
+
 			public bool AssertFileLoadException (AssemblyName assemblyRef)
 			{
 				try {
 					AppDomain.CurrentDomain.Load (assemblyRef);
 					return false;
 				} catch (FileLoadException) {
-					return true;
-				}
-			}
-
-			public bool AssertFileNotFoundException (AssemblyName assemblyRef)
-			{
-				try {
-					AppDomain.CurrentDomain.Load (assemblyRef);
-					return false;
-				} catch (FileNotFoundException) {
 					return true;
 				}
 			}


### PR DESCRIPTION
This is all related to https://bugzilla.xamarin.com/show_bug.cgi?id=17066

But to summarise.

Currently, attempting to call Type.GetType("A.B.T, NonExistantAssembly") will normally return null.  BUT if you attempt to do this within an appdomain with ShadowCopyFile="true" you will instead get a RuntimeException.

This patch calls GetFileAttributes in an attempt to ensure that the src file is readable by caller and if not just return the existing filename.
