### PR TITLE
[system] Add IsIPv6Teredo to System.Net.IpAddress

### DIFF
--- a/mcs/class/System/Documentation/en/System.Net/IPAddress.xml
+++ b/mcs/class/System/Documentation/en/System.Net/IPAddress.xml
@@ -541,6 +541,21 @@ in network-byte-order.</para>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="IsIPv6Teredo">
+      <MemberSignature Language="C#" Value="public bool IsIPv6Teredo { get; }" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="IsLoopback">
       <MemberSignature Language="ILASM" Value=".method public hidebysig static bool IsLoopback(class System.Net.IPAddress address)" />
       <MemberSignature Language="C#" Value="public static bool IsLoopback (System.Net.IPAddress addr);" />

--- a/mcs/class/System/System.Net/IPAddress.cs
+++ b/mcs/class/System/System.Net/IPAddress.cs
@@ -333,6 +333,16 @@ namespace System.Net {
 			}
 		}
 
+#if NET_4_0
+		public bool IsIPv6Teredo {
+			get {
+				return m_Family != AddressFamily.InterNetwork &&
+					m_Numbers[0] == 0x2001 &&
+					m_Numbers[1] == 0;
+			}
+		}
+#endif
+
 		public long ScopeId {
 			get {
 				if (m_Family != AddressFamily.InterNetworkV6)

--- a/mcs/class/System/Test/System.Net/IPAddressTest.cs
+++ b/mcs/class/System/Test/System.Net/IPAddressTest.cs
@@ -545,6 +545,15 @@ public class IPAddressTest
 		Assert.IsTrue (IPAddress.Parse ("FF01::1").IsIPv6Multicast, "#2");
 		Assert.IsFalse (IPAddress.Parse ("FE00::1").IsIPv6Multicast, "#3");
 	}
+
+#if NET_4_0
+	[Test]
+	public void IsIPv6Teredo ()
+	{
+		Assert.IsTrue (IPAddress.Parse ("2001::1").IsIPv6Teredo, "#1");
+		Assert.IsFalse (IPAddress.Parse ("2002::1").IsIPv6Teredo, "#2");
+	}
+#endif
 }
 }
 


### PR DESCRIPTION
Adds support for checking for an IPv6 Teredo address, introduced in
.NET Framework 4.

[System.Net.IPAddress.IsIPv6Teredo](http://msdn.microsoft.com/en-us/library/system.net.ipaddress.isipv6teredo.aspx)
