### PR TITLE
Fix for transactions hanging and timing out if PreparingEnlistment.Done() is called

### DIFF
--- a/mcs/class/System.Transactions/System.Transactions/Enlistment.cs
+++ b/mcs/class/System.Transactions/System.Transactions/Enlistment.cs
@@ -25,6 +25,12 @@ namespace System.Transactions
 		public void Done ()
 		{
 			done = true;
+
+			InternalOnDone();
+		}
+
+		internal virtual void InternalOnDone ()
+		{
 		}
 	}
 }

--- a/mcs/class/System.Transactions/System.Transactions/PreparingEnlistment.cs
+++ b/mcs/class/System.Transactions/System.Transactions/PreparingEnlistment.cs
@@ -35,6 +35,11 @@ namespace System.Transactions
 			ForceRollback (null);
 		}
 
+		internal override void InternalOnDone ()
+		{
+			this.Prepared();			
+		}
+
 		[MonoTODO]
 		public void ForceRollback (Exception ex)
 		{


### PR DESCRIPTION
According to MSDN it is valid to call PreparingEnlistment.Done() without calling PreparingEnlistment.Prepared(). http://msdn.microsoft.com/en-us/library/system.transactions.preparingenlistment(v=vs.110).aspx

This is a quick fix for the above situation. PreparingEnlistment should also throw if both Done and Prepared are called but that's a bigger change....
