### PR TITLE
Avoid outputting nulls in serialised json when EmitDefaultValue is false

### DIFF
--- a/mcs/class/System.ServiceModel.Web/System.Runtime.Serialization.Json/TypeMap.cs
+++ b/mcs/class/System.ServiceModel.Web/System.Runtime.Serialization.Json/TypeMap.cs
@@ -195,7 +195,7 @@ namespace System.Runtime.Serialization.Json
 			foreach (TypeMapMember member in members) {
 				object memberObj = member.GetMemberOf (graph);
 				shouldWrite = true;
-				if (memberObj == null && member.EmitDefaultValue == false) {
+				if (memberObj == null && member.EmitDefaultValue == false) { // FIXME: Won't handle defaults for non-nullables like ints or bools atm.
 					shouldWrite = false;
 				}
 				if (shouldWrite) {

--- a/mcs/class/System.ServiceModel.Web/System.Runtime.Serialization.Json/TypeMap.cs
+++ b/mcs/class/System.ServiceModel.Web/System.Runtime.Serialization.Json/TypeMap.cs
@@ -191,12 +191,18 @@ namespace System.Runtime.Serialization.Json
 				OnSerializing.Invoke (graph, new object [] {new StreamingContext (StreamingContextStates.All)});
 
 			outputter.Writer.WriteAttributeString ("type", type);
+			bool shouldWrite;
 			foreach (TypeMapMember member in members) {
 				object memberObj = member.GetMemberOf (graph);
-				// FIXME: consider EmitDefaultValue
-				outputter.Writer.WriteStartElement (member.Name);
-				outputter.WriteObjectContent (memberObj, false, false);
-				outputter.Writer.WriteEndElement ();
+				shouldWrite = true;
+				if (memberObj == null && member.EmitDefaultValue == false) {
+					shouldWrite = false;
+				}
+				if (shouldWrite) {
+					outputter.Writer.WriteStartElement(member.Name);
+					outputter.WriteObjectContent(memberObj, false, false);
+					outputter.Writer.WriteEndElement();
+				}
 			}
 
 			if (OnSerialized != null)


### PR DESCRIPTION
This should in theory avoid serialising any DataMembers that are null and marked as having EmitDefaultValue as false. Sorry, I've been unable to test this because I don't have time to setup things up fully, but badly in need for this fix as soon as possible. As far as I can tell the logic is sound, the only caveat is , it won't cover defaults for things like integers or bools etc.

I can look up the bug report if needed.
