### PR TITLE
Correct 2 properties missing on System.Web.Routing.RouteCollection & 1 on Route for Net 4.5

### DIFF
--- a/mcs/class/System.Web.Routing/System.Web.Routing/RouteBase.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/RouteBase.cs
@@ -41,6 +41,9 @@ namespace System.Web.Routing
 	[AspNetHostingPermission (SecurityAction.LinkDemand, Level = AspNetHostingPermissionLevel.Minimal)]
 	public abstract class RouteBase
 	{
+#if NET_4_5
+		public bool RouteExistingFiles { get; set; }
+#endif
 		public abstract RouteData GetRouteData (HttpContextBase httpContext);
 		public abstract VirtualPathData GetVirtualPath (RequestContext requestContext, RouteValueDictionary values);
 	}

--- a/mcs/class/System.Web.Routing/System.Web.Routing/RouteCollection.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/RouteCollection.cs
@@ -95,6 +95,10 @@ namespace System.Web.Routing
 		}
 
 		public bool RouteExistingFiles { get; set; }
+#if NET_4_5
+		public bool AppendTrailingSlash { get; set; }
+		public bool LowercaseUrls { get; set; }
+#endif
 
 		public void Add (string name, RouteBase item)
 		{

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteCollectionTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteCollectionTest.cs
@@ -595,7 +595,6 @@ namespace MonoTests.System.Web.Routing
 		}
 
 		[Test]
-		[Ignore ("looks like RouteExistingFiles ( = false) does not affect... so this test needs more investigation")]
 		public void GetVirtualPathToExistingFile ()
 		{
 			var c = new RouteCollection ();
@@ -926,6 +925,27 @@ namespace MonoTests.System.Web.Routing
 			Assert.AreEqual (typeof (PageRouteHandler), rd.RouteHandler.GetType (), "#A4-3");
 			Assert.IsFalse (((PageRouteHandler) rd.RouteHandler).CheckPhysicalUrlAccess, "#A4-4");
 		}
+
+#if NET_4_5
+		[Test]
+		public void AppendTrailingSlash ()
+		{
+			var c = new RouteCollection ();
+			c.AppendTrailingSlash = true;
+			Assert.IsTrue (c.AppendTrailingSlash);
+			c.AppendTrailingSlash = false;
+			Assert.IsFalse (c.AppendTrailingSlash);
+		}
+		[Test]
+		public void LowercaseUrls ()
+		{
+			var c = new RouteCollection ();
+			c.LowercaseUrls = true;
+			Assert.IsTrue (c.LowercaseUrls);
+			c.LowercaseUrls = false;
+			Assert.IsFalse (c.LowercaseUrls);
+		}
+#endif
 #endif
 	}
 }

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
@@ -1775,5 +1775,17 @@ namespace MonoTests.System.Web.Routing
 				"#6"
 			);
 		}
+
+#if NET_4_5
+		[Test]
+		public void RouteExistingFiles ()
+		{
+			var route = new Route ("foo", null);
+			route.RouteExistingFiles = true;
+			Assert.IsTrue (route.RouteExistingFiles);
+			route.RouteExistingFiles = false;
+			Assert.IsFalse (route.RouteExistingFiles);
+		}
+#endif
 	}
 }


### PR DESCRIPTION
Addresses 3 of the crosses on 
http://go-mono.com/status/status.aspx?reference=4.5&profile=4.5&assembly=System.Web
