### PR TITLE
Change Mono manpage to correct effect of MONO_THREADS_PER_CPU env var

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1417,9 +1417,9 @@ small embedded systems.
 The default is 180 seconds.
 .TP
 \fBMONO_THREADS_PER_CPU\fR
-The maximum number of threads in the general threadpool will be
-20 + (MONO_THREADS_PER_CPU * number of CPUs). The default value for this
-variable is 10.
+The minimum number of threads in the general threadpool will be 
+MONO_THREADS_PER_CPU * number of CPUs. The default value for this
+variable is 1.
 .TP
 \fBMONO_XMLSERIALIZER_THS\fR
 Controls the threshold for the XmlSerializer to produce a custom


### PR DESCRIPTION
1.  MONO_THREADS_PER_CPU affects ThreadPool min threads rather than max threads
2.  Effect is MONO_THREADS_PER_CPU \* cpu_cores, there is no +20
3.  Default is 1, not 10
