### PR TITLE
[xbuild] Return unescaped path from TaskItem.GetMetadata ("FullPath")

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskItem.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskItem.cs
@@ -107,9 +107,10 @@ namespace Microsoft.Build.Utilities
 
 		public string GetMetadata (string metadataName)
 		{
-			if (ReservedNameUtils.IsReservedMetadataName (metadataName))
-				return ReservedNameUtils.GetReservedMetadata (ItemSpec, metadataName, metadata);
-			else if (metadata.Contains (metadataName))
+			if (ReservedNameUtils.IsReservedMetadataName (metadataName)) {
+				var escapedMetadata = ReservedNameUtils.GetReservedMetadata (ItemSpec, metadataName, metadata);
+				return MSBuildUtils.Unescape (escapedMetadata);
+			} else if (metadata.Contains (metadataName))
 				return (string) metadata [metadataName];
 			else
 				return String.Empty;

--- a/mcs/class/Microsoft.Build.Utilities/Test/Microsoft.Build.Utilities/TaskItemTest.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Test/Microsoft.Build.Utilities/TaskItemTest.cs
@@ -240,5 +240,19 @@ namespace MonoTests.Microsoft.Build.Utilities {
 			item = new TaskItem ("lalala");
 			item.SetMetadata ("Identity", "some value");
 		}
+
+		[Test]
+		public void GetFullPathOfItemWithUnescapedSpecialChar ()
+		{
+			var item = new TaskItem ("my@file");
+			Assert.IsTrue (item.GetMetadata ("FullPath").EndsWith ("my@file"), "A1");
+		}
+
+		[Test]
+		public void GetFullPathOfItemWithEscapedSpecialChar ()
+		{
+			var item = new TaskItem ("my%40file");
+			Assert.IsTrue (item.GetMetadata ("FullPath").EndsWith ("my@file"), "A1");
+		}
 	}
 }


### PR DESCRIPTION
This is in accordance with the behavior in .NET. No matter what string you feed
the ctor (escaped or unescaped), GetMetadata("FullPath") always returns the
unescaped version.

This also fixes the monodevelop build of current master, which was broken on my
Ubuntu Trusty box since 6d7e812d709e182810d64c51a4e2d1af25d8adfa.
