### PR TITLE
[xbuild] Fix BuildItem.GetMetadata() and TaskItem.GetMetadata ()

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Test/Microsoft.Build.BuildEngine/BuildItemTest.cs
+++ b/mcs/class/Microsoft.Build.Engine/Test/Microsoft.Build.BuildEngine/BuildItemTest.cs
@@ -319,6 +319,40 @@ namespace MonoTests.Microsoft.Build.BuildEngine {
 		}
 
 		[Test]
+		public void GetMetadata_UnescapedItemSpec_BuildItemCreatedWithITaskItem ()
+		{
+			string itemInclude = "a;b;c";
+			string escapedItemInclude = Utilities.Escape (itemInclude);
+
+			item = new BuildItem ("name", new TaskItem (itemInclude));
+			Assert.IsTrue (item.GetMetadata ("FullPath").EndsWith (escapedItemInclude), "#1a");
+			Assert.IsTrue (item.GetEvaluatedMetadata ("FullPath").EndsWith (itemInclude), "#1b");
+
+			Assert.AreEqual (escapedItemInclude, item.GetMetadata ("FileName"), "#2b");
+			Assert.AreEqual (itemInclude, item.GetEvaluatedMetadata ("FileName"), "#2b");
+
+			Assert.AreEqual (escapedItemInclude, item.GetMetadata ("Identity"), "#3a");
+			Assert.AreEqual (itemInclude, item.GetEvaluatedMetadata ("Identity"), "#3b");
+		}
+
+		[Test]
+		public void GetMetadata_EscapedItemSpec_BuildItemCreatedWithITaskItem ()
+		{
+			string itemInclude = "a;b;c";
+			string escapedItemInclude = Utilities.Escape (itemInclude);
+
+			item = new BuildItem ("name", new TaskItem (escapedItemInclude));
+			Assert.IsTrue (item.GetMetadata ("FullPath").EndsWith (escapedItemInclude), "#1a");
+			Assert.IsTrue (item.GetEvaluatedMetadata ("FullPath").EndsWith (itemInclude), "#1b");
+
+			Assert.AreEqual (escapedItemInclude, item.GetMetadata ("FileName"), "#2b");
+			Assert.AreEqual (itemInclude, item.GetEvaluatedMetadata ("FileName"), "#2b");
+
+			Assert.AreEqual (escapedItemInclude, item.GetMetadata ("Identity"), "#3a");
+			Assert.AreEqual (itemInclude, item.GetEvaluatedMetadata ("Identity"), "#3b");
+		}
+
+		[Test]
 		[ExpectedException (typeof (ArgumentNullException))]
 		public void TestGetMetadata2 ()
 		{

--- a/mcs/class/Microsoft.Build.Utilities/Mono.XBuild.Utilities/ReservedNameUtils.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Mono.XBuild.Utilities/ReservedNameUtils.cs
@@ -75,10 +75,10 @@ namespace Mono.XBuild.Utilities {
 			if (String.IsNullOrEmpty (itemSpec))
 				return String.Empty;
 		
+			itemSpec = MSBuildUtils.Unescape (itemSpec);
 			switch (metadataName.ToLowerInvariant ()) {
 			case "fullpath":
-				var unescapedItemSpec = MSBuildUtils.Unescape (itemSpec);
-				return MSBuildUtils.Escape (Path.GetFullPath (unescapedItemSpec));
+				return Path.GetFullPath (itemSpec);
 			case "rootdir":
 				if (Path.IsPathRooted (itemSpec))
 					return Path.GetPathRoot (itemSpec);

--- a/mcs/class/Microsoft.Build.Utilities/Test/Microsoft.Build.Utilities/TaskItemTest.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Test/Microsoft.Build.Utilities/TaskItemTest.cs
@@ -240,5 +240,25 @@ namespace MonoTests.Microsoft.Build.Utilities {
 			item = new TaskItem ("lalala");
 			item.SetMetadata ("Identity", "some value");
 		}
+
+		[Test]
+		public void GetFullPathOfItemWithUnescapedSpecialChar ()
+		{
+			var taskItem = new TaskItem ("my@file");
+			Assert.IsTrue (taskItem.GetMetadata ("FullPath").EndsWith (
+				"my@file", StringComparison.InvariantCulture), "A1");
+			Assert.AreEqual ("my@file", taskItem.GetMetadata ("FileName"), "A2");
+			Assert.AreEqual ("my@file", taskItem.GetMetadata ("Identity"), "A3");
+		}
+
+		[Test]
+		public void GetFullPathOfItemWithEscapedSpecialChar ()
+		{
+			var taskItem = new TaskItem ("my%40file");
+			Assert.IsTrue (taskItem.GetMetadata ("FullPath").EndsWith (
+				"my@file", StringComparison.InvariantCulture), "A1");
+			Assert.AreEqual ("my@file", taskItem.GetMetadata ("FileName"), "A2");
+			Assert.AreEqual ("my@file", taskItem.GetMetadata ("Identity"), "A3");
+		}
 	}
 }


### PR DESCRIPTION
This change makes those functions behave like their equivalents in .NET.
All tests related with the affected code have passed on my machine.

The attached image illustrate the results from test runs of these functions
with various inputs on .NET.

![builditemmetadatamatrix](https://f.cloud.github.com/assets/759436/1969096/8d3f4d54-82ed-11e3-80b3-5670b15faeb7.png)

This PR replaces https://github.com/mono/mono/pull/877
