### PR TITLE
Remove ReadOnlyDictionary reference from xbuild_12's Microsoft.Build.dll

### DIFF
--- a/mcs/class/Microsoft.Build/Microsoft.Build.Evaluation/ProjectCollection.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Evaluation/ProjectCollection.cs
@@ -67,11 +67,7 @@ namespace Microsoft.Build.Evaluation
 
 		static ProjectCollection ()
 		{
-			#if NET_4_5
-			global_project_collection = new ProjectCollection (new ReadOnlyDictionary<string, string> (new Dictionary<string, string> ()));
-			#else
 			global_project_collection = new ProjectCollection (new Dictionary<string, string> ());
-			#endif
 		}
 
 		public static string Escape (string unescapedString)


### PR DESCRIPTION
Same thing was done for 221184f74786145fcea1bd9014c2958f7de78417.
I'm thinking the RODictionary is more trouble than it's worth.

Causes an invalid assembly to be built. Here's the message from
make check:

Missing method .ctor in assembly mono-3.2.7/mcs/class/lib/xbuild_12/Microsoft.Build.dll, type Typespec 0x1b00007f
Compilation of Microsoft.Build.Evaluation.ProjectCollection:.cctor () failed with exception 'Error verifying Microsoft.Build.Evaluation.ProjectCollection:.cctor (): Cannot load method from token 0x0a0001f6 for newobj at 0x0030':

The disassembly shows a BROKEN CLASS:

```
    IL_002b:  newobj instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string, string>::'.ctor'()
    IL_0030:  newobj Missing method .ctor in assembly mono-3.2.7/mcs/class/lib/xbuild_12/Microsoft.Build.dll, type Typespec 0x1b00007f instance void <BROKEN CLASS token_ 100009b><string,string>::.ctor(class [mscorlib]System.Collections.Generic.IDictionary`2<!0,!1>)
    IL_0035:  newobj instance void class Microsoft.Build.Evaluation.ProjectCollection::'.ctor'(class [mscorlib]System.Collections.Generic.IDictionary`2<string,string>)
    IL_003a:  stsfld class Microsoft.Build.Evaluation.ProjectCollection Microsoft.Build.Evaluation.ProjectCollection::global_project_collection
```
