### PR TITLE
[System] Fixed an error in the implementation of System.Net.IPAddress.IsIPv6Teredo

### DIFF
--- a/mcs/class/System/System.Net/IPAddress.cs
+++ b/mcs/class/System/System.Net/IPAddress.cs
@@ -337,7 +337,7 @@ namespace System.Net {
 		public bool IsIPv6Teredo {
 			get {
 				return m_Family != AddressFamily.InterNetwork &&
-					m_Numbers[0] == 0x2001 &&
+					NetworkToHostOrder ((short) m_Numbers [0]) == 0x2001 &&
 					m_Numbers[1] == 0;
 			}
 		}

--- a/mcs/class/System/Test/System.Net/IPAddressTest.cs
+++ b/mcs/class/System/Test/System.Net/IPAddressTest.cs
@@ -550,7 +550,7 @@ public class IPAddressTest
 	[Test]
 	public void IsIPv6Teredo ()
 	{
-		Assert.IsFalse (IPAddress.Parse ("2001::1").IsIPv6Teredo, "#1");
+		Assert.IsTrue (IPAddress.Parse ("2001::1").IsIPv6Teredo, "#1");
 		Assert.IsFalse (IPAddress.Parse ("2002::1").IsIPv6Teredo, "#2");
 	}
 #endif


### PR DESCRIPTION
The property was introduced with PR #870 but it missed to convert network byte order to host byte order, so the comparison wasn't working correctly and the corresponding unit test failed. @marek-safar erroneously "fixed" the test in 27e07c7.

This is the corrected implementation and the original test now works as intended.

Changes released under MIT/X11.
