### PR TITLE
[aot] Add gshared types from the local&args too (bxc#17572)

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4,10 +4,12 @@
  * Author:
  *   Dietmar Maurer (dietmar@ximian.com)
  *   Zoltan Varga (vargaz@gmail.com)
+ *   Andrés G. Aragoneses (aaragon@sinenomine.net)
  *
  * (C) 2002 Ximian, Inc.
  * Copyright 2003-2011 Novell, Inc 
  * Copyright 2011 Xamarin Inc (http://www.xamarin.com)
+ * Copyright 2014 Sine Nomine Associates (http://www.sinenomine.net)
  */
 
 /* Remaining AOT-only work:
@@ -297,6 +299,9 @@ get_patch_name (int info)
 
 static char*
 get_plt_entry_debug_sym (MonoAotCompile *acfg, MonoJumpInfo *ji, GHashTable *cache);
+
+static void
+add_types_from_method_header (MonoAotCompile *acfg, MonoMethod *method);
 
 /* Wrappers around the image writer functions */
 
@@ -3876,8 +3881,10 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		}
 		
 		if (mono_method_is_generic_sharable_full (method, FALSE, FALSE, use_gsharedvt))
-			/* Already added */
+		{
+			add_types_from_method_header (acfg, method);
 			continue;
+		}
 
 		if (method->is_generic)
 			/* FIXME: */


### PR DESCRIPTION
The following example was generating an error when compiled an
ran with Full AOT.

```
    public class Foo<T1>
    {
        public Foo() {
            var c = new Bar<T1, bool> ();
            Console.WriteLine ("Foo ctor ", c);
        }
    }
    public class Bar<T1, T2>
    {
        public Bar()
        {
            Console.WriteLine ("T1:{0},T2:{1}", typeof(T1).FullName, typeof(T2).FullName);
        }
    }
    public class Baz
    {
    }

    class MainClass
    {
        public static void Main (string[] args)
        {
            var c = new Foo<Baz>();
            Console.WriteLine ("end");
        }
    }
```

This is actually not a value-type generic sharing limitation
because the same example, with a field instead of a local
variable in Foo's constructor, works:

```
    public class Foo<T1>
    {
        Bar <T1, bool> c;
        public Foo() {
            Console.WriteLine ("Foo ctor ", c);
        }
    }
    public class Bar<T1, T2>
    {
        public Bar()
        {
            Console.WriteLine ("T1:{0},T2:{1}", typeof(T1).FullName, typeof(T2).FullName);
        }
    }
    public class Baz
    {
    }

    class MainClass
    {
        public static void Main (string[] args)
        {
            var c = new Foo<Baz>();
            Console.WriteLine ("end");
        }
    }
```

The difference between the class Foo in each case can be better
visualized this way:

```
#if BUG
        public Foo() {
            var c = new Bar<T1, bool> ();
            Console.WriteLine ("Foo ctor ", c);
        }
#else
        Bar <T1, bool> c;
        public Foo() {
            Console.WriteLine ("Foo ctor ", c);
        }
#endif
```

By inspecting the types of local variables and arguments of methods
(besides fields), this bug is fixed. It's the first part for bug 17572.
https://bugzilla.xamarin.com/show_bug.cgi?id=17572

This commit is provided under the terms of the X11/MIT licence.
