### PR TITLE
HttpListener now listens on default ports if not specified instead of random

### DIFF
--- a/mcs/class/System/System.Net/ListenerPrefix.cs
+++ b/mcs/class/System/System.Net/ListenerPrefix.cs
@@ -88,9 +88,9 @@ namespace System.Net {
 
 		void Parse (string uri)
 		{
-			int default_port = (uri.StartsWith ("http://")) ? 80 : -1;
-			if (default_port == -1) {
-				default_port = (uri.StartsWith ("https://")) ? 443 : -1;
+			ushort default_port = 80;
+			if (uri.StartsWith ("https://")) {
+				default_port = 443;
 				secure = true;
 			}
 
@@ -109,6 +109,7 @@ namespace System.Net {
 			} else {
 				root = uri.IndexOf ('/', start_host, length - start_host);
 				host = uri.Substring (start_host, root - start_host);
+				port = default_port;
 				path = uri.Substring (root);
 			}
 			if (path.Length != 1)
@@ -120,10 +121,7 @@ namespace System.Net {
 			if (uri == null)
 				throw new ArgumentNullException ("uriPrefix");
 
-			int default_port = (uri.StartsWith ("http://")) ? 80 : -1;
-			if (default_port == -1)
-				default_port = (uri.StartsWith ("https://")) ? 443 : -1;
-			if (default_port == -1)
+			if(!uri.StartsWith ("http://") && !uri.StartsWith ("https://"))
 				throw new ArgumentException ("Only 'http' and 'https' schemes are supported.");
 
 			int length = uri.Length;


### PR DESCRIPTION
In method public static void CheckUri I just made code a bit nicer.

In method Parse I fixed bug where default_port variable was set but never used in case if URI did not have port specified. Since port was set by default 0 HttpListener would listen on random port instead 80 or 443. Also notice that this class is private and only used by Mono so CheckUri is always called before Parse() which means only "http://" and "https://" schemas are possible so I changed beginning of Parse method a bit. "optimization" :)

This is also behaviour of .Net(no port specified results in port 80 on http schema).

I ran into this problem using Nancy because there self hosting accepts Uri objects which is later sent to HttpListener prefixes by using .ToString() which omits port number(see Uri.cs).

Seems like some other guys ran into same problem here: http://stackoverflow.com/questions/19741880/nancy-mono-self-host-wont-start-on-port-80
