### PR TITLE
[System] Fixed an error in the implementation of System.Net.IPAddress.IsIPv6Teredo

### DIFF
--- a/mcs/class/System/System.Net/IPAddress.cs
+++ b/mcs/class/System/System.Net/IPAddress.cs
@@ -337,7 +337,7 @@ namespace System.Net {
 		public bool IsIPv6Teredo {
 			get {
 				return m_Family != AddressFamily.InterNetwork &&
-					m_Numbers[0] == 0x2001 &&
+					NetworkToHostOrder ((short) m_Numbers [0]) == 0x2001 &&
 					m_Numbers[1] == 0;
 			}
 		}


### PR DESCRIPTION
Original commit: daf2340d47d6983a627949ff96054b6f7b392fb5
This fixes MonoTests.System.Net.IPAddressTest.IsIPv6Teredo.
