### PR TITLE
[corlib] Fix implementation of Tuple hash generator

### DIFF
--- a/mcs/class/corlib/System/Tuples.cs
+++ b/mcs/class/corlib/System/Tuples.cs
@@ -1050,7 +1050,7 @@ public class TupleGen
 			Console.WriteLine ("\t\t\th{0} = comparer.GetHashCode ({1});", destVar, GetItemName (start));
 		} else {
 			int subCount = 1 << IntLog2 (count - 1);
-			computeHash (destVar, start, subCount);
+			WriteHash (destVar, start, subCount);
 			start += subCount;
 			count -= subCount;
 			if (count == 1) {
@@ -1060,13 +1060,6 @@ public class TupleGen
 				Console.WriteLine ("\t\t\th{0} = (h{0} << 5) + h{0} ^ h{1};", destVar, destVar + 1);
 			}
 		}
-	}
-
-	static void computeHash (int destVar, int start, int count)
-	{
-		Console.WriteLine ("\t\t\th{0} = comparer.GetHashCode (item{1});", destVar, start);
-		if (--count > 0)
-			throw new NotImplementedException ();
 	}
 
 	static string GetTypeName (int arity)


### PR DESCRIPTION
The Tuples.cs code generator dies with:

Unhandled Exception:
System.NotImplementedException: The requested feature is not implemented.
  at TupleGen.computeHash (Int32 destVar, Int32 start, Int32 count) [0x00000] in <filename unknown>:0
  at TupleGen.WriteHash (Int32 destVar, Int32 start, Int32 count) [0x00000] in <filename unknown>:0
  at TupleGen.Main () [0x00000] in <filename unknown>:0

This is caused by the incorrect definition of WriteHash(), which
instead of recursively calling itself is calling computeHash().

Thanks to Marek Safar for reporting the issue in
https://github.com/fsharp/fsharp/issues/188#issuecomment-34351850
