### PR TITLE
[Fix] ReusableHashAlgorithm doesn't set the Key of the ValidationAlgorit...

### DIFF
--- a/mcs/class/System.Web/System.Web.Handlers/AssemblyResourceLoader.cs
+++ b/mcs/class/System.Web/System.Web.Handlers/AssemblyResourceLoader.cs
@@ -79,7 +79,9 @@ namespace System.Web.Handlers
 					if (!hashAlg.CanReuseTransform) {
 						canReuseHashAlg = false;
 						hashAlg = null;
+						return null;
 					}
+					hashAlg.Key = MachineKeySectionUtils.GetValidationKey (mks);
 				}
 
 				if (hashAlg != null)


### PR DESCRIPTION
...hm

Without this patch you can't use "WebResource.axd" ressources
in a cluster (each mono instance will get a different link for the same ressource)

Signed-off-by: Etienne CHAMPETIER <etienne.champetier@fiducial.net>