### PR TITLE
Prevent exception in finalization of Form class

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Form.cs
@@ -1978,10 +1978,12 @@ namespace System.Windows.Forms {
 
 		protected override void Dispose(bool disposing)
 		{
-			for (int i = 0; i < owned_forms.Count; i++)
-				((Form)owned_forms[i]).Owner = null;
+			if (owned_forms != null) {
+				for (int i = 0; i < owned_forms.Count; i++)
+					((Form)owned_forms[i]).Owner = null;
 
-			owned_forms.Clear ();
+				owned_forms.Clear ();
+			}
 			Owner = null;
 			base.Dispose (disposing);
 			


### PR DESCRIPTION
If initialization of the Form class or one of its base classes fails, possibly because X11 is not available and the constructor of the parent Control class throws an exception, the owned_forms member is not initialized. This results in a NullReferenceException during finalization, if the error that occurs during construction is handled.

Stack traces:
Unhandled Exception:
System.TypeInitializationException: An exception was thrown by the type initializer for System.Windows.Forms.WindowsFormsSynchronizationContext ---> System.TypeInitializationException: An exception was thrown by the type initializer for System.Windows.Forms.XplatUI ---> System.ArgumentNullException: Could not open display (X-Server required. Check you DISPLAY environment variable)
Parameter name: Display
  at System.Windows.Forms.XplatUIX11.SetDisplay (IntPtr display_handle) [0x00000] in <filename unknown>:0
  at System.Windows.Forms.XplatUIX11..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.XplatUIX11.GetInstance () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.XplatUI..cctor () [0x00000] in <filename unknown>:0
  --- End of inner exception stack trace ---
  at System.Windows.Forms.Theme.get_MenuAccessKeysUnderlined () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.SystemInformation.get_MenuAccessKeysUnderlined () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.Control..ctor () [0x00000] in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control:.ctor ()
  at System.Windows.Forms.WindowsFormsSynchronizationContext..cctor () [0x00000] in <filename unknown>:0
  --- End of inner exception stack trace ---
  at System.Windows.Forms.Control..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.ScrollableControl..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.ContainerControl..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.Form..ctor () [0x00000] in <filename unknown>:0
  at AutoCRCheck.frmOptions..ctor () [0x00000] in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) AutoCRCheck.frmOptions:.ctor ()
  at AutoCRCheck.Program.Main (System.String[] args) [0x00000] in <filename unknown>:0
[ERROR] FATAL UNHANDLED EXCEPTION: System.TypeInitializationException: An exception was thrown by the type initializer for System.Windows.Forms.WindowsFormsSynchronizationContext ---> System.TypeInitializationException: An exception was thrown by the type initializer for System.Windows.Forms.XplatUI ---> System.ArgumentNullException: Could not open display (X-Server required. Check you DISPLAY environment variable)
Parameter name: Display
  at System.Windows.Forms.XplatUIX11.SetDisplay (IntPtr display_handle) [0x00000] in <filename unknown>:0
  at System.Windows.Forms.XplatUIX11..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.XplatUIX11.GetInstance () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.XplatUI..cctor () [0x00000] in <filename unknown>:0
  --- End of inner exception stack trace ---
  at System.Windows.Forms.Theme.get_MenuAccessKeysUnderlined () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.SystemInformation.get_MenuAccessKeysUnderlined () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.Control..ctor () [0x00000] in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control:.ctor ()
  at System.Windows.Forms.WindowsFormsSynchronizationContext..cctor () [0x00000] in <filename unknown>:0
  --- End of inner exception stack trace ---
  at System.Windows.Forms.Control..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.ScrollableControl..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.ContainerControl..ctor () [0x00000] in <filename unknown>:0
  at System.Windows.Forms.Form..ctor () [0x00000] in <filename unknown>:0
  at AutoCRCheck.frmOptions..ctor () [0x00000] in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) AutoCRCheck.frmOptions:.ctor ()
  at AutoCRCheck.Program.Main (System.String[] args) [0x00000] in <filename unknown>:0

---

Handling the previous exception results in the following exception:

System.NullReferenceException: Object reference not set to an instance of an object
  at System.Windows.Forms.Form.Dispose (Boolean disposing) [0x00000] in <filename unknown>:0
  at AutoCRCheck.frmOptions.Dispose (Boolean disposing) [0x00000] in <filename unknown>:0
  at System.ComponentModel.Component.Finalize () [0x00000] in <filename unknown>:0
