### PR TITLE
Fix error in ToolStripItem finalization

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripItem.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripItem.cs
@@ -958,7 +958,7 @@ namespace System.Windows.Forms
 				image = null;
 			}
 
-			if (owner != null)
+			if (owner != null && disposing)
 				owner.Items.Remove (this);
 			
 			base.Dispose (disposing);


### PR DESCRIPTION
The Dispose function in ToolStripItem should not remove itself from its owner during finalization. Finalization implies that the owner has also been garbage collected, and accessing it may result in undesirable behaviour. More specifically, the call to owner.Items.Remove ultimately may boil down to a call to GDI+ throwing an Exception like the following:

Program.UnhandledException: System.ArgumentException: A null reference or invalid value was found [GDI+ status: InvalidParameter]
  at System.Drawing.GDIPlus.CheckStatus (Status status) [0x00000] in <filename unknown>:0 
  at System.Drawing.Graphics.GdipMeasureString (IntPtr graphics, System.String text, System.Drawing.Font font, System.Drawing.RectangleF& layoutRect, IntPtr stringFormat) [0x00000] in <filename unknown>:0 
  at System.Drawing.Graphics.MeasureString (System.String text, System.Drawing.Font font, Int32 width, System.Drawing.StringFormat format) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.Drawing.Graphics:MeasureString (string,System.Drawing.Font,int,System.Drawing.StringFormat)
  at System.Windows.Forms.TextRenderer.MeasureTextInternal (IDeviceContext dc, System.String text, System.Drawing.Font font, Size proposedSize, TextFormatFlags flags, Boolean useMeasureString) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.TextRenderer.MeasureText (System.String text, System.Drawing.Font font, Size proposedSize, TextFormatFlags flags) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.ToolStripItem.CalculateAutoSize () [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.ToolStripItem.set_InternalOwner (System.Windows.Forms.ToolStrip value) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.ToolStripItem:set_InternalOwner (System.Windows.Forms.ToolStrip)
  at System.Windows.Forms.ToolStripItemCollection.Remove (System.Windows.Forms.ToolStripItem value) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.ToolStripItem.Dispose (Boolean disposing) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.ToolStripDropDownItem.Dispose (Boolean disposing) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.ToolStripMenuItem.Dispose (Boolean disposing) [0x00000] in <filename unknown>:0 
  at System.ComponentModel.Component.Finalize () [0x00000] in <filename unknown>:0
