### PR TITLE
Propose a different implementation of AggregateException.GetBaseExceptio...

### DIFF
--- a/mcs/class/corlib/System/AggregateException.cs
+++ b/mcs/class/corlib/System/AggregateException.cs
@@ -163,9 +163,12 @@ namespace System
 
 		public override Exception GetBaseException ()
 		{
-			if (innerExceptions == null || innerExceptions.Count != 1)
-				return this;
-			return innerExceptions[0].GetBaseException ();
+			var ret = (Exception)this;
+
+			while ((ret is AggregateException) && ((AggregateException)ret).InnerExceptions.Count == 1)
+				ret = ret.InnerException;
+
+			return ret;
 		}
 	}
 }

--- a/mcs/class/corlib/Test/System/AggregateExceptionTests.cs
+++ b/mcs/class/corlib/Test/System/AggregateExceptionTests.cs
@@ -120,7 +120,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorking")]
 		public void GetBaseException_stops_at_first_inner_exception_that_is_not_AggregateException()
 		{
 			var inner = new ArgumentNullException();


### PR DESCRIPTION
...n that makes the failing test pass. Does it precisely capture the .net semantics?
