### PR TITLE
Bug 17838 - IDictionary item property implemention for ConcurrentDiction...

### DIFF
--- a/mcs/class/System/System.Collections.Generic/SortedList.cs
+++ b/mcs/class/System/System.Collections.Generic/SortedList.cs
@@ -169,10 +169,10 @@ namespace System.Collections.Generic
 
 		object IDictionary.this [object key] {
 			get {
-				if (!(key is TKey))
-					return null;
-				else
-					return this [(TKey)key];
+				TValue obj;
+				if (key is TKey && TryGetValue ((TKey)key, out obj))
+					return obj;
+				return null;
 			}
 
 			set {

--- a/mcs/class/System/Test/System.Collections.Generic/SortedListTest.cs
+++ b/mcs/class/System/Test/System.Collections.Generic/SortedListTest.cs
@@ -516,6 +516,14 @@ namespace MonoTests.System.Collections.Generic
 				Assert.That (ex.InnerException, Is.TypeOf (typeof (DivideByZeroException)), "UC #8");
 			}
 		}
+
+		[Test]
+		public void IDictionaryNullOnNonExistingKey ()
+		{
+			System.Collections.IDictionary list = new SortedList<long, string> ();
+			object val = list [1234L];
+			Assert.IsNull (val);
+		}
 	}
 }
 

--- a/mcs/class/corlib/System.Collections.Concurrent/ConcurrentDictionary.cs
+++ b/mcs/class/corlib/System.Collections.Concurrent/ConcurrentDictionary.cs
@@ -239,10 +239,10 @@ namespace System.Collections.Concurrent
 		object IDictionary.this [object key]
 		{
 			get {
-				if (!(key is TKey))
-					throw new ArgumentException ("key isn't of correct type", "key");
-
-				return this[(TKey)key];
+				TValue obj;
+				if (key is TKey && TryGetValue ((TKey) key, out obj))
+					return obj;
+				return null;
 			}
 			set {
 				if (!(key is TKey) || !(value is TValue))

--- a/mcs/class/corlib/System.Collections.Generic/Dictionary.cs
+++ b/mcs/class/corlib/System.Collections.Generic/Dictionary.cs
@@ -710,8 +710,9 @@ namespace System.Collections.Generic {
 
 		object IDictionary.this [object key] {
 			get {
-				if (key is TKey && ContainsKey((TKey) key))
-					return this [ToTKey (key)];
+				TValue obj;
+				if (key is TKey && TryGetValue ((TKey) key, out obj))
+					return obj;
 				return null;
 			}
 			set { this [ToTKey (key)] = ToTValue (value); }

--- a/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentDictionaryTests.cs
+++ b/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentDictionaryTests.cs
@@ -334,7 +334,15 @@ namespace MonoTests.System.Collections.Concurrent
 			AssertThrowsArgumentNullException (() => map.TryGetValue (null, out value));
 			AssertThrowsArgumentNullException (() => map.TryRemove (null, out value));
 			AssertThrowsArgumentNullException (() => map.TryUpdate (null, 0, 0));
-		} 
+		}
+
+		[Test]
+		public void IDictionaryNullOnNonExistingKey ()
+		{
+			System.Collections.IDictionary dict = new ConcurrentDictionary<long, string> ();
+			object val = dict [1234L];
+			Assert.IsNull (val);
+		}
 
 		void AssertThrowsArgumentNullException (Action action)
 		{


### PR DESCRIPTION
...ary throws exception on non-existing key

https://bugzilla.xamarin.com/show_bug.cgi?id=17838
