### PR TITLE
Add msvc/mono.props to EXTRA_DIST so make dist will find it.

### DIFF
--- a/msvc/Makefile.am
+++ b/msvc/Makefile.am
@@ -6,6 +6,7 @@ EXTRA_DIST = \
 	     README \
 	     create-windef.pl \
 	     mono.def \
+	     mono.props \
 	     mono.sln \
 	     monoposixhelper.def \
 	     runmdesc.bat \


### PR DESCRIPTION
mono.props is needed to build with visual studio but has been missing from source drops for a while.
