### PR TITLE
fix DateTimeFormatInfo era names

### DIFF
--- a/mcs/class/corlib/System.Globalization/DateTimeFormatInfo.cs
+++ b/mcs/class/corlib/System.Globalization/DateTimeFormatInfo.cs
@@ -193,9 +193,11 @@ namespace System.Globalization
 
 		public string GetAbbreviatedEraName (int era)
 		{
-			if (era < 0 || era >= Calendar.AbbreviatedEraNames.Length)
+			if (era < 0 || era > Calendar.AbbreviatedEraNames.Length)
 				throw new ArgumentOutOfRangeException ("era", era.ToString ());
-			return Calendar.AbbreviatedEraNames [era];
+			if (era == Calendar.CurrentEra)
+			    era = Calendar.EraNames.Length;				
+			return Calendar.AbbreviatedEraNames [era - 1];
 		}
 
 		public string GetAbbreviatedMonthName(int month)
@@ -229,6 +231,8 @@ namespace System.Globalization
 		{
 			if (era < 0 || era > Calendar.EraNames.Length)
 				throw new ArgumentOutOfRangeException ("era", era.ToString ());
+			if (era == Calendar.CurrentEra)
+			    era = Calendar.EraNames.Length;
 			return Calendar.EraNames [era - 1];
 		}
 

--- a/mcs/class/corlib/Test/System.Globalization/DateTimeFormatInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/DateTimeFormatInfoTest.cs
@@ -55,6 +55,8 @@ namespace MonoTests.System.Globalization
 			CultureInfo en_US = new CultureInfo ("en-US");
 			DateTimeFormatInfo dtfi = en_US.DateTimeFormat;
 			Assert.AreEqual ("AD", dtfi.GetAbbreviatedEraName (0), "#1");
+			Assert.AreEqual ("AD", dtfi.GetAbbreviatedEraName (1), "#7");
+			Assert.AreEqual ("A.D.", dtfi.GetEraName (0), "#8");
 			Assert.AreEqual ("A.D.", dtfi.GetEraName (1), "#2");
 			Assert.AreEqual (1, dtfi.GetEra ("A.D."), "#3");
 			Assert.AreEqual (1, dtfi.GetEra ("AD"), "#4");


### PR DESCRIPTION
Calendar.Eras values start from 1 (1 = oldest)
As parameter of GetEraName or GetAbbreviatedEraName, era 0 mean current
era
