### PR TITLE
[Test] Cleaned up how a bunch of tests were ignored

### DIFF
--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildManagerTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildManagerTest.cs
@@ -140,7 +140,8 @@ namespace MonoTests.Microsoft.Build.Execution
 			case PlatformID.Unix:
 				break;
 			default:
-				return; // ignore, cannot run it
+				Assert.Ignore (); // ignore, cannot run it
+				break;
 			}
 			
 			var xml = XmlReader.Create (new StringReader (project_xml));

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/ReadlinkTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/ReadlinkTest.cs
@@ -122,7 +122,7 @@ namespace MonoTests.Mono.Unix
 		public void ReadLinkAt ()
 		{
 			if (!HaveReadlinkAt)
-				return;
+				Assert.Ignore ("No ReadlinkAt.");
 
 			foreach (string s in Targets) {
 				CreateLink (s);
@@ -149,7 +149,7 @@ namespace MonoTests.Mono.Unix
 		public void TryReadLinkAt ()
 		{
 			if (!HaveReadlinkAt)
-				return;
+				Assert.Ignore ("No ReadlinkAt.");
 
 			foreach (string s in Targets) {
 				CreateLink (s);
@@ -188,7 +188,7 @@ namespace MonoTests.Mono.Unix
 		public void readlinkat_byte ()
 		{
 			if (!HaveReadlinkAt)
-				return;
+				Assert.Ignore ("No ReadlinkAt.");
 
 			foreach (string s in Targets) {
 				CreateLink (s);
@@ -242,7 +242,7 @@ namespace MonoTests.Mono.Unix
 		public void readlinkat_char ()
 		{
 			if (!HaveReadlinkAt)
-				return;
+				Assert.Ignore ("No ReadlinkAt.");
 
 			foreach (string s in Targets) {
 				CreateLink (s);

--- a/mcs/class/System.Core/Test/System.IO.Pipes/PipeSecurityTest.cs
+++ b/mcs/class/System.Core/Test/System.IO.Pipes/PipeSecurityTest.cs
@@ -23,7 +23,7 @@ namespace MonoTests.System.IO.Pipes
 		public void NamedPipeDefaultPermissionsWork ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			string name = @"Local\MonoTestPipeNPNPW";
@@ -40,7 +40,7 @@ namespace MonoTests.System.IO.Pipes
 		public void NamedPipeSetAccessControlFailsWithoutChangePermissionRight ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			string name = @"Local\MonoTestPipeNPSACFWCPR";
@@ -71,7 +71,7 @@ namespace MonoTests.System.IO.Pipes
 		void NamedPipePermissionsActuallyWorkSync (string name, bool addDenyEveryone)
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			PipeSecurity security = new PipeSecurity ();
@@ -116,7 +116,7 @@ namespace MonoTests.System.IO.Pipes
 		public void NamedPipePermissionsActuallyWorkAsync ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			IAsyncResult waitForConnection;

--- a/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
@@ -44,7 +44,7 @@ namespace MonoTests.System
 			public void GetLocal ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo local = TimeZoneInfo.Local;
 				Assert.IsNotNull (local);
 				Assert.IsTrue (true);
@@ -214,7 +214,7 @@ namespace MonoTests.System
 			public void DSTInLondon ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				DateTime june01 = new DateTime (2007, 06, 01);
 				DateTime xmas = new DateTime (2007, 12, 25);
 				Assert.IsTrue (london.IsDaylightSavingTime (june01), "June 01 is DST in London");
@@ -225,7 +225,7 @@ namespace MonoTests.System
 			public void DSTTransisions ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				DateTime beforeDST = new DateTime (2007, 03, 25, 0, 59, 59, DateTimeKind.Unspecified);
 				DateTime startDST = new DateTime (2007, 03, 25, 2, 0, 0, DateTimeKind.Unspecified);
 				DateTime endDST = new DateTime (2007, 10, 28, 1, 59, 59, DateTimeKind.Unspecified);
@@ -307,7 +307,7 @@ namespace MonoTests.System
 			public void ConvertFromUTC_ConvertInWinter ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				DateTime utc = new DateTime (2007, 12, 25, 12, 0, 0);
 				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, london);
 				Assert.AreEqual (utc, converted);
@@ -317,7 +317,7 @@ namespace MonoTests.System
 			public void ConvertFromUtc_ConvertInSummer ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				DateTime utc = new DateTime (2007, 06, 01, 12, 0, 0);
 				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, london);
 				Assert.AreEqual (utc + new TimeSpan (1,0,0), converted);
@@ -376,7 +376,7 @@ namespace MonoTests.System
 			public void ConvertFromToUtc ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				DateTime utc = DateTime.UtcNow;
 				Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
 				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, london);
@@ -408,7 +408,7 @@ namespace MonoTests.System
 			public void ConvertToTimeZone ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 
 				TimeZoneInfo.ConvertTime (DateTime.Now, TimeZoneInfo.FindSystemTimeZoneById("Pacific/Auckland"));
 			}
@@ -466,7 +466,7 @@ namespace MonoTests.System
 			public void AmbiguousDates ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				Assert.IsFalse (london.IsAmbiguousTime (new DateTime (2007, 10, 28, 1, 0, 0)));
 				Assert.IsTrue (london.IsAmbiguousTime (new DateTime (2007, 10, 28, 1, 0, 1)));
 				Assert.IsTrue (london.IsAmbiguousTime (new DateTime (2007, 10, 28, 2, 0, 0)));
@@ -477,7 +477,7 @@ namespace MonoTests.System
 			public void AmbiguousUTCDates ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				Assert.IsFalse (london.IsAmbiguousTime (new DateTime (2007, 10, 28, 0, 0, 0, DateTimeKind.Utc)));
 				Assert.IsTrue (london.IsAmbiguousTime (new DateTime (2007, 10, 28, 0, 0, 1, DateTimeKind.Utc)));
 				Assert.IsTrue (london.IsAmbiguousTime (new DateTime (2007, 10, 28, 0, 59, 59, DateTimeKind.Utc)));
@@ -502,7 +502,7 @@ namespace MonoTests.System
 			public void NotEmpty ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				global::System.Collections.ObjectModel.ReadOnlyCollection<TimeZoneInfo> systemTZ = TimeZoneInfo.GetSystemTimeZones ();
 				Assert.IsNotNull(systemTZ, "SystemTZ is null");
 				Assert.IsFalse (systemTZ.Count == 0, "SystemTZ is empty");
@@ -512,7 +512,7 @@ namespace MonoTests.System
 			public void ContainsBrussels ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				global::System.Collections.ObjectModel.ReadOnlyCollection<TimeZoneInfo> systemTZ = TimeZoneInfo.GetSystemTimeZones ();
 				foreach (TimeZoneInfo tz in systemTZ) {
 					if (tz.Id == "Europe/Brussels")
@@ -545,7 +545,7 @@ namespace MonoTests.System
 			public void FindBrusselsTZ ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo brussels = TimeZoneInfo.FindSystemTimeZoneById ("Europe/Brussels");
 				Assert.IsNotNull (brussels);
 			}
@@ -554,7 +554,7 @@ namespace MonoTests.System
 			public void OffsetIsCorrectInKinshasa ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo kin = TimeZoneInfo.FindSystemTimeZoneById ("Africa/Kinshasa");
 				Assert.AreEqual (new TimeSpan (1,0,0), kin.BaseUtcOffset, "BaseUtcOffset in Kinshasa is not +1h");
 			}
@@ -563,7 +563,7 @@ namespace MonoTests.System
 			public void OffsetIsCorrectInBrussels ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo brussels = TimeZoneInfo.FindSystemTimeZoneById ("Europe/Brussels");
 				Assert.AreEqual (new TimeSpan (1,0,0), brussels.BaseUtcOffset, "BaseUtcOffset for Brussels is not +1h");
 			}
@@ -572,7 +572,7 @@ namespace MonoTests.System
 			public void NoDSTInKinshasa ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo kin = TimeZoneInfo.FindSystemTimeZoneById ("Africa/Kinshasa");
 				Assert.IsFalse (kin.SupportsDaylightSavingTime);
 			}
@@ -581,7 +581,7 @@ namespace MonoTests.System
 			public void BrusselsSupportsDST ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo brussels = TimeZoneInfo.FindSystemTimeZoneById ("Europe/Brussels");
 				Assert.IsTrue (brussels.SupportsDaylightSavingTime);
 			}
@@ -590,7 +590,7 @@ namespace MonoTests.System
 			public void MelbourneSupportsDST ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo melbourne = TimeZoneInfo.FindSystemTimeZoneById ("Australia/Melbourne");
 				Assert.IsTrue (melbourne.SupportsDaylightSavingTime);
 			}
@@ -599,7 +599,7 @@ namespace MonoTests.System
 			public void RomeAndVaticanSharesTime ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo rome = TimeZoneInfo.FindSystemTimeZoneById ("Europe/Rome");
 				TimeZoneInfo vatican = TimeZoneInfo.FindSystemTimeZoneById ("Europe/Vatican");
 				Assert.IsTrue (rome.HasSameRules (vatican));
@@ -656,7 +656,7 @@ namespace MonoTests.System
 			public void AmbiguousOffsets ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
-					return;
+					Assert.Ignore ("Not running on Unix.");
 				TimeZoneInfo brussels = TimeZoneInfo.FindSystemTimeZoneById ("Europe/Brussels");
 				DateTime date = new DateTime (2007, 10, 28, 2, 30, 00);
 				Assert.IsTrue (brussels.IsAmbiguousTime (date));

--- a/mcs/class/System.Drawing/Test/System.Drawing.Printing/PageSettingsTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Printing/PageSettingsTest.cs
@@ -40,7 +40,7 @@ namespace MonoTests.System.Drawing.Printing
 			// Check for installed printers, because we need
 			// to have at least one to test
 			if (PrinterSettings.InstalledPrinters.Count == 0)
-				return;
+				Assert.Ignore ("No printers found.");
 
 			PageSettings ps = new PageSettings ();
 			ps.Color = false;

--- a/mcs/class/System.Drawing/Test/System.Drawing.Printing/PrintingServicesUnixTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Printing/PrintingServicesUnixTest.cs
@@ -45,7 +45,7 @@ namespace MonoTests.System.Drawing.Printing {
 		{
 			// ensure libgdiplus is built with printing support enabled
 			if (GDIPlus.RunningOnWindows ())
-				return;
+				Assert.Ignore ("Running on Windows.");
 
 			Assert.AreEqual (Status.InvalidParameter, GdipGetPostScriptSavePage (IntPtr.Zero), "Missing printing support");
 		}

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetPeerTcpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetPeerTcpBindingTest.cs
@@ -43,7 +43,7 @@ namespace MonoTests.System.ServiceModel
 		public void DefaultValues ()
 		{
 			if (!NetPeerTcpBinding.IsPnrpAvailable)
-				return; // yes, we actually don't test it.
+				Assert.Ignore ("PNRP is not available."); // yes, we actually don't test it.
 
 			var n = new NetPeerTcpBinding ();
 			Assert.AreEqual (EnvelopeVersion.Soap12, n.EnvelopeVersion, "#1");

--- a/mcs/class/System.ServiceProcess/Test/System.ServiceProcess/ServiceControllerTest.cs
+++ b/mcs/class/System.ServiceProcess/Test/System.ServiceProcess/ServiceControllerTest.cs
@@ -46,7 +46,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Constructor1 ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 
@@ -162,7 +162,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Constructor2 ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("lanmanworkstation");
 
@@ -217,7 +217,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Constructor2_Name_DisplayName ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("workstation");
 
@@ -247,7 +247,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Constructor2_Name_ServiceName ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("lanmanworkstation");
 
@@ -260,7 +260,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Constructor3 ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("lanmanworkstation",
 				Environment.MachineName);
@@ -367,7 +367,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.IsTrue (sc.CanPauseAndContinue, "#1");
@@ -401,7 +401,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -430,7 +430,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("NetDDE", ".");
 			Assert.IsFalse (sc1.CanPauseAndContinue);
@@ -440,7 +440,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -468,7 +468,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue_Service_OperationNotValid ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("SamSs", ".");
 			Assert.IsFalse (sc1.CanPauseAndContinue);
@@ -478,7 +478,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue_Service_Running ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#1");
@@ -489,7 +489,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue_Service_Paused ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -526,7 +526,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanPauseAndContinue_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -582,7 +582,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.IsTrue (sc.CanShutdown, "#1");
@@ -616,7 +616,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -645,7 +645,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("NetDDE", ".");
 			Assert.IsFalse (sc1.CanShutdown);
@@ -655,7 +655,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -683,7 +683,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown_Service_OperationNotValid ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("SamSs", ".");
 			Assert.IsFalse (sc1.CanShutdown);
@@ -693,7 +693,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown_Service_Running ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#1");
@@ -704,7 +704,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown_Service_Paused ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -741,7 +741,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanShutdown_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -797,7 +797,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.IsTrue (sc.CanStop, "#1");
@@ -831,7 +831,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -860,7 +860,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("NetDDE", ".");
 			Assert.IsFalse (sc1.CanStop);
@@ -870,7 +870,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -898,7 +898,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop_Service_OperationNotValid ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("SamSs", ".");
 			Assert.IsFalse (sc1.CanStop);
@@ -908,7 +908,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop_Service_Running ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#1");
@@ -919,7 +919,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop_Service_Paused ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -956,7 +956,7 @@ namespace MonoTests.System.ServiceProcess
 		public void CanStop_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -1012,7 +1012,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Continue ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -1050,7 +1050,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Continue_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -1079,7 +1079,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Continue_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("NetDDE", ".");
 			ServiceController sc2 = new ServiceController ("NetDDE", ".");
@@ -1115,7 +1115,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Continue_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -1143,7 +1143,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Continue_Service_OperationNotValid ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("SamSs", ".");
 			ServiceController sc2 = new ServiceController ("SamSs", ".");
@@ -1179,7 +1179,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Continue_Service_Running ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -1197,7 +1197,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Continue_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -1265,7 +1265,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DependentServices ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = null;
 			ServiceController [] dependentServices = null;
@@ -1368,7 +1368,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DependentServices_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("dmserver",
 				"doesnotexist");
@@ -1397,7 +1397,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DependentServices_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("NetDDE", ".");
 			ServiceController [] dependentServices = sc.DependentServices;
@@ -1410,7 +1410,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DependentServices_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -1457,7 +1457,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.DisplayName = "workstation";
@@ -1495,7 +1495,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("dmserver",
 				"doesnotexist");
@@ -1524,7 +1524,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("NetDDE", ".");
 			Assert.AreEqual ("Network DDE", sc.DisplayName);
@@ -1534,7 +1534,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -1562,7 +1562,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_ServiceName_Empty ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.DisplayName = "workstation";
@@ -1574,7 +1574,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_Value_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.DisplayName = "doesnotexist";
@@ -1605,7 +1605,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_Value_Empty ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			Assert.AreEqual (string.Empty, sc.DisplayName, "#A1");
@@ -1626,7 +1626,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_Value_Null ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.DisplayName = "Alerter";
@@ -1647,7 +1647,7 @@ namespace MonoTests.System.ServiceProcess
 		public void DisplayName_Value_ServiceName ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.DisplayName = "lanmanworkstation";
@@ -1660,7 +1660,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Device_ControlCodes ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Disk", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -1956,7 +1956,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -1985,7 +1985,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Parameter_Incorrect ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2044,7 +2044,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_ContinuePending ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2089,7 +2089,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_ControlCodes ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2385,7 +2385,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -2413,7 +2413,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_Paused ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2438,7 +2438,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_PausePending ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2478,7 +2478,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_StartPending ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2541,7 +2541,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2602,7 +2602,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ExecuteCommand_Service_StopPending ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule", ".");
 			Assert.AreEqual (ServiceControllerStatus.Running, sc.Status, "#A");
@@ -2679,7 +2679,7 @@ namespace MonoTests.System.ServiceProcess
 		public void GetDevices ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController [] devices = null;
 
@@ -2732,7 +2732,7 @@ namespace MonoTests.System.ServiceProcess
 		public void GetDevices_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			try {
 				ServiceController [] devices = ServiceController.GetDevices ("doesnotexist");
@@ -2793,7 +2793,7 @@ namespace MonoTests.System.ServiceProcess
 		public void GetServices ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController [] services = null;
 
@@ -2844,7 +2844,7 @@ namespace MonoTests.System.ServiceProcess
 		public void GetServices_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			try {
 				ServiceController [] services = ServiceController.GetServices ("doesnotexist");
@@ -2905,7 +2905,7 @@ namespace MonoTests.System.ServiceProcess
 		public void MachineName ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.ServiceName = "alerter";
@@ -2933,7 +2933,7 @@ namespace MonoTests.System.ServiceProcess
 		public void MachineName_Empty ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.MachineName = Environment.MachineName;
@@ -2956,7 +2956,7 @@ namespace MonoTests.System.ServiceProcess
 		public void MachineName_Null ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.MachineName = Environment.MachineName;
@@ -2979,7 +2979,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Pause ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -3010,7 +3010,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Pause_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -3039,7 +3039,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Pause_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("NetDDE", ".");
 			ServiceController sc2 = new ServiceController ("NetDDE", ".");
@@ -3075,7 +3075,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Pause_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -3103,7 +3103,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Pause_Service_OperationNotValid ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("SamSs", ".");
 			ServiceController sc2 = new ServiceController ("SamSs", ".");
@@ -3139,7 +3139,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Pause_Service_Paused ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -3175,7 +3175,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Pause_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -3243,7 +3243,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Refresh ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = null;
 			ServiceController [] dependentServices = null;
@@ -3288,7 +3288,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Refresh_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -3299,7 +3299,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Refresh_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			sc.Refresh ();
@@ -3309,7 +3309,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Refresh_Service_Paused ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -3350,7 +3350,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Refresh_Service_Running ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -3402,7 +3402,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Refresh_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -3438,7 +3438,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Refresh_ServiceName_Empty ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.Refresh ();
@@ -3448,7 +3448,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.ServiceName = "lanmanworkstation";
@@ -3486,7 +3486,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("dmserver",
 				"doesnotexist");
@@ -3515,7 +3515,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("NetDDE", ".");
 			Assert.AreEqual ("NetDDE", sc.ServiceName);
@@ -3525,7 +3525,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -3553,7 +3553,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_DisplayName_Empty ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.ServiceName = "lanmanworkstation";
@@ -3565,7 +3565,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_Value_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.ServiceName = "doesnotexist";
@@ -3595,7 +3595,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_Value_Empty ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			Assert.AreEqual (string.Empty, sc.DisplayName, "#A1");
@@ -3625,7 +3625,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_Value_Null ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.ServiceName = "lanmanworkstation";
@@ -3647,7 +3647,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceName_Value_DisplayName ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ();
 			sc.ServiceName = "workstation";
@@ -3678,7 +3678,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServicesDependedOn ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = null;
 			ServiceController [] servicesDependedOn = null;
@@ -3789,7 +3789,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServicesDependedOn_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("dmserver",
 				"doesnotexist");
@@ -3818,7 +3818,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServicesDependedOn_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("ClipSrv", ".");
 			ServiceController [] servicesDependedOn = sc.ServicesDependedOn;
@@ -3831,7 +3831,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServicesDependedOn_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -3878,7 +3878,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceTypeTest ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = null;
 			
@@ -3923,7 +3923,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceType_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("dmserver",
 				"doesnotexist");
@@ -3952,7 +3952,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceType_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("NetDDE", ".");
 			Assert.AreEqual (ServiceType.Win32ShareProcess, sc.ServiceType);
@@ -3962,7 +3962,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceType_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -3990,7 +3990,7 @@ namespace MonoTests.System.ServiceProcess
 		public void ServiceType_ServiceName_Empty ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = null;
 
@@ -4021,7 +4021,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Stop ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -4052,7 +4052,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Stop_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -4081,7 +4081,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Stop_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("NetDDE", ".");
 			ServiceController sc2 = new ServiceController ("NetDDE", ".");
@@ -4117,7 +4117,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Stop_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -4145,7 +4145,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Stop_Service_OperationNotValid ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("SamSs", ".");
 			ServiceController sc2 = new ServiceController ("SamSs", ".");
@@ -4181,7 +4181,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Stop_Service_Paused ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -4222,7 +4222,7 @@ namespace MonoTests.System.ServiceProcess
 		public void Stop_Service_Stopped ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -4290,7 +4290,7 @@ namespace MonoTests.System.ServiceProcess
 		public void WaitForStatus ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");
@@ -4336,7 +4336,7 @@ namespace MonoTests.System.ServiceProcess
 		public void WaitForStatus_Machine_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("Schedule",
 				"doesnotexist");
@@ -4366,7 +4366,7 @@ namespace MonoTests.System.ServiceProcess
 		public void WaitForStatus_Service_Disabled ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("NetDDE", ".");
 			ServiceController sc2 = new ServiceController ("NetDDE", ".");
@@ -4398,7 +4398,7 @@ namespace MonoTests.System.ServiceProcess
 		public void WaitForStatus_Service_DoesNotExist ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc = new ServiceController ("doesnotexist", ".");
 			try {
@@ -4426,7 +4426,7 @@ namespace MonoTests.System.ServiceProcess
 		public void WaitForStatus_Service_OperationNotValid ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("SamSs", ".");
 			ServiceController sc2 = new ServiceController ("SamSs", ".");
@@ -4478,7 +4478,7 @@ namespace MonoTests.System.ServiceProcess
 		public void WaitForStatus_Timeout ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			ServiceController sc1 = new ServiceController ("Schedule", ".");
 			ServiceController sc2 = new ServiceController ("Schedule", ".");

--- a/mcs/class/System/Test/System.Diagnostics/EventLogTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/EventLogTest.cs
@@ -111,7 +111,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -219,7 +219,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.Exists ("monologtemp", "."))
 				Assert.Ignore ("Event log 'monologtemp' should not exist.");
@@ -245,7 +245,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -308,7 +308,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -344,7 +344,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -375,7 +375,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -406,7 +406,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			EventLog eventLog = new EventLog ();
 			Assert.IsFalse (eventLog.EnableRaisingEvents, "#1");
@@ -450,7 +450,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -482,7 +482,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.Exists ("monologtemp", "."))
 				Assert.Ignore ("Event log 'monologtemp' should not exist.");
@@ -526,7 +526,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			EventLog eventLog = new EventLog (string.Empty);
 			Assert.IsFalse (eventLog.EnableRaisingEvents, "#A1");
@@ -577,7 +577,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -609,7 +609,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.Exists ("monologtemp", "."))
 				Assert.Ignore ("Event log 'monologtemp' should not exist.");
@@ -653,7 +653,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			EventLog eventLog = new EventLog (string.Empty, ".");
 			Assert.IsFalse (eventLog.EnableRaisingEvents, "#A1");
@@ -768,7 +768,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -805,7 +805,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.Exists ("monologtemp", "."))
 				Assert.Ignore ("Event log 'monologtemp' should not exist.");
@@ -849,7 +849,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -978,7 +978,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monoothersource", "."))
 				Assert.Ignore ("Event log source 'monoothersource' should not exist.");
@@ -1019,7 +1019,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1055,7 +1055,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1090,7 +1090,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1188,7 +1188,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1216,7 +1216,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1263,7 +1263,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType != NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1400,7 +1400,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType != NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1460,7 +1460,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1487,7 +1487,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1545,7 +1545,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1584,7 +1584,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1642,7 +1642,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1725,7 +1725,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1769,7 +1769,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1814,7 +1814,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1922,7 +1922,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -1970,7 +1970,7 @@ namespace MonoTests.System.Diagnostics
 
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -2178,7 +2178,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.Exists ("monologtemp", "."))
 				Assert.Ignore ("Event log 'monologtemp' should not exist.");
@@ -2247,7 +2247,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -2412,7 +2412,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -2603,7 +2603,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -2779,7 +2779,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -2967,7 +2967,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType != WIN32_IMPL)
 				// test can only pass with win32 implementation
-				return;
+				Assert.Ignore ("Wrong EventLogImplType.");
 
 			using (RegistryKey logKey = FindLogKeyByName ("monotempsource")) {
 				if (logKey != null)
@@ -3035,7 +3035,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType != WIN32_IMPL)
 				// test can only pass with win32 implementation
-				return;
+				Assert.Ignore ("Wrong EventLogImplType.");
 
 			using (RegistryKey logKey = FindLogKeyByName ("monotempsource")) {
 				if (logKey != null)
@@ -3242,7 +3242,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3332,7 +3332,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3347,7 +3347,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			string logName = EventLog.LogNameFromSourceName (string.Empty, ".");
 			Assert.IsNotNull (logName, "#1");
@@ -3359,7 +3359,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			string logName = EventLog.LogNameFromSourceName (null, ".");
 			Assert.IsNotNull (logName, "#1");
@@ -3438,7 +3438,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3489,7 +3489,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType != WIN32_IMPL)
 				// test can only pass with win32 implementation
-				return;
+				Assert.Ignore ("Wrong EventLogImplType.");
 
 			using (RegistryKey logKey = FindLogKeyByName ("monotempsource")) {
 				if (logKey != null)
@@ -3562,7 +3562,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType != WIN32_IMPL)
 				// test can only pass with win32 implementation
-				return;
+				Assert.Ignore ("Wrong EventLogImplType.");
 
 			using (RegistryKey logKey = FindLogKeyByName ("monotempsource")) {
 				if (logKey != null)
@@ -3697,7 +3697,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3772,7 +3772,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3806,7 +3806,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3848,7 +3848,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3899,7 +3899,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -3950,7 +3950,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4012,7 +4012,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4087,7 +4087,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4121,7 +4121,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4176,7 +4176,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4227,7 +4227,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4278,7 +4278,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4348,7 +4348,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4424,7 +4424,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4469,7 +4469,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4514,7 +4514,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4584,7 +4584,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4681,7 +4681,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4747,7 +4747,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4781,7 +4781,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4858,7 +4858,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4909,7 +4909,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -4960,7 +4960,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5035,7 +5035,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5112,7 +5112,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5157,7 +5157,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5202,7 +5202,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5279,7 +5279,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5379,7 +5379,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5445,7 +5445,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5479,7 +5479,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5556,7 +5556,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5607,7 +5607,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5658,7 +5658,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5728,7 +5728,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5830,7 +5830,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5906,7 +5906,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5952,7 +5952,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -5998,7 +5998,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6076,7 +6076,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6178,7 +6178,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6246,7 +6246,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6280,7 +6280,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6357,7 +6357,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6408,7 +6408,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6459,7 +6459,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6529,7 +6529,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6632,7 +6632,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6708,7 +6708,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6754,7 +6754,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6800,7 +6800,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6879,7 +6879,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -6984,7 +6984,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -7060,7 +7060,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -7106,7 +7106,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -7152,7 +7152,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -7326,7 +7326,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -7576,7 +7576,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -7772,7 +7772,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");
@@ -8019,7 +8019,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (EventLogImplType == NULL_IMPL)
 				// test cannot pass with NULL implementation
-				return;
+				Assert.Ignore ("No EventLogImplType.");
 
 			if (EventLog.SourceExists ("monotempsource", "."))
 				Assert.Ignore ("Event log source 'monotempsource' should not exist.");

--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -132,7 +132,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			if (RunningOnUnix)
 				// on unix, all characters are allowed
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			string systemDir = Environment.GetFolderPath (Environment.SpecialFolder.System);
 			string exe = "\"" + Path.Combine (systemDir, "calc.exe") + "\"";
@@ -680,7 +680,7 @@ namespace MonoTests.System.Diagnostics
 		{
 			// Test requires cygwin, so we just bail out for now.
 			if (Path.DirectorySeparatorChar == '\\')
-				return;
+				Assert.Ignore ("Test requires cygwin.");
 			
 			Process p = new Process ();
 			p.StartInfo = new ProcessStartInfo ("/bin/sh", "-c \"sleep 2; echo hello\"");

--- a/mcs/class/System/Test/System.IO.Ports/SerialPortTest.cs
+++ b/mcs/class/System/Test/System.IO.Ports/SerialPortTest.cs
@@ -59,7 +59,7 @@ namespace MonoTests.System.IO.Ports
 		{
 			int platform = (int) Environment.OSVersion.Platform;
 			// we are testing on Unix only
-			if ((platform != 4) && (platform != 128)) return;
+			if ((platform != 4) && (platform != 128)) Assert.Ignore ("Not running on Unix.");
 			SerialPort sp = new SerialPort ();
 			sp.BaudRate = 1234;
 			var exceptionCatched = false;

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -1810,7 +1810,7 @@ namespace MonoTests.System.Net.Sockets
 			// Need at least two addresses.
 			var ips = Dns.GetHostAddresses (string.Empty);
 			if (ips.Length < 1)
-				return;
+				Assert.Ignore ("This test needs at least two IP addresses.");
 
 			var allIps = new IPAddress [ips.Length + 1];
 			allIps [0] = IPAddress.Loopback;
@@ -2304,7 +2304,7 @@ namespace MonoTests.System.Net.Sockets
 			// Need at least two addresses.
 			var ips = Dns.GetHostAddresses (string.Empty);
 			if (ips.Length < 1)
-				return;
+				Assert.Ignore ("This test needs at least two IP addresses.");
 
 			var allIps = new IPAddress [ips.Length + 1];
 			allIps [0] = IPAddress.Loopback;

--- a/mcs/class/System/Test/System.Net/HttpListener2Test.cs
+++ b/mcs/class/System/Test/System.Net/HttpListener2Test.cs
@@ -750,7 +750,7 @@ namespace MonoTests.System.Net {
 				machineAddress = Dns.GetHostAddresses (Dns.GetHostName ());
 			} catch (SocketException){
 				// The build hosts sometimes can not resolve the hostname
-				return;
+				Assert.Ignore ("Hostname couldn't be resolved.");
 			}
 			
 			int port = 61234;

--- a/mcs/class/System/Test/System.Net/WebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/WebRequestTest.cs
@@ -362,7 +362,7 @@ namespace MonoTests.System.Net {
 			 * instead of reporting an error.
 			 */
 			if (req.ResponseUri.DnsSafeHost.Equals ("navigationshilfe1.t-online.de"))
-				return;
+				Assert.Ignore ("Misbehaving DNS server.");
 
 			Assert.Fail ("Should have raised an exception");
 		} catch (Exception e) {

--- a/mcs/class/System/Test/System.Security.AccessControl/SemaphoreSecurityTest.cs
+++ b/mcs/class/System/Test/System.Security.AccessControl/SemaphoreSecurityTest.cs
@@ -22,7 +22,7 @@ namespace MonoTests.System.Security.AccessControl
 		public void PermissionsActuallyWork ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			bool createdNew; SemaphoreSecurity security;

--- a/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
+++ b/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
@@ -44,7 +44,7 @@ namespace MonoTests.Microsoft.Win32
 		{
 			// this test is for Windows only
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			// this regpath always exists under windows
 			RegistryKey k = Registry.CurrentUser
@@ -301,7 +301,7 @@ namespace MonoTests.Microsoft.Win32
 		{
 			// access to registry of remote machines is not implemented on unix
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			RegistryKey hive = RegistryKey.OpenRemoteBaseKey (
 				RegistryHive.CurrentUser, Environment.MachineName);
@@ -391,7 +391,7 @@ namespace MonoTests.Microsoft.Win32
 		{
 			// access to registry of remote machines is not implemented on unix
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			RegistryKey hive = RegistryKey.OpenRemoteBaseKey (
 				RegistryHive.CurrentUser, Environment.MachineName);
@@ -1677,7 +1677,7 @@ namespace MonoTests.Microsoft.Win32
 		{
 			// Not supported on Unix
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			string subKeyName = Guid.NewGuid ().ToString ();
 			try {
@@ -1705,7 +1705,7 @@ namespace MonoTests.Microsoft.Win32
 		{
 			// Not supported on Unix
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			string subKeyName = Guid.NewGuid ().ToString ();
 			try {
@@ -1731,7 +1731,7 @@ namespace MonoTests.Microsoft.Win32
 		public void Handle ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			string subKeyName = Guid.NewGuid ().ToString ();
 			RegistryKey subkey = null;
@@ -2173,7 +2173,7 @@ namespace MonoTests.Microsoft.Win32
 		{
 			// access to registry of remote machines is not implemented on unix
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			RegistryKey hive = RegistryKey.OpenRemoteBaseKey (
 				RegistryHive.CurrentUser, Environment.MachineName);
@@ -2207,7 +2207,7 @@ namespace MonoTests.Microsoft.Win32
 		{
 			// access to registry of remote machines is not implemented on unix
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			try {
 				RegistryKey.OpenRemoteBaseKey (RegistryHive.CurrentUser,

--- a/mcs/class/corlib/Test/System.Globalization/CompareInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CompareInfoTest.cs
@@ -252,7 +252,7 @@ public class CompareInfoTest
 	public void GetSortKey ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// AE == \u00C6
 		AssertSortKey ("#1", new byte [] {0xE, 2, 0xE, 0x21, 1, 1,
@@ -288,7 +288,7 @@ public class CompareInfoTest
 	public void GetSortKeyIgnoreWidth ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#i1", new byte [] {
 			0xE, 2, 1, 1, 0x13, 1, 1, 0}, "\uFF21");
@@ -304,7 +304,7 @@ public class CompareInfoTest
 	public void GetSortKeyDiacritical ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#i1", new byte [] {
 			0xE, 0x21, 1, 0xE, 1, 1, 1, 0}, "e\u0301");
@@ -357,7 +357,7 @@ public class CompareInfoTest
 	public void GetSortKeyIgnoreNonSpaceKana ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#i1", new byte [] {
 			0x22, 0x1A, 1, 1, 1, 0xFF, 2, 0xFF, 0xFF, 1, 0},
@@ -377,7 +377,7 @@ public class CompareInfoTest
 	public void GetSortKeySpecialWeight ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#i1", new byte [] {
 			0x22, 0xA, 0x22, 2, 1, 1, 1, 0xFF, 2, 0xFF, 0xFF, 1, 0},
@@ -468,7 +468,7 @@ public class CompareInfoTest
 	public void GetSortKeyLevel5 ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// shift weight
 		AssertSortKeyLevel5 ("#8", new byte [] {
@@ -530,7 +530,7 @@ public class CompareInfoTest
 	public void FrenchSort ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// invariant
 		AssertSortKey ("#inv-1", new byte [] {0xE, 0xA, 0xE, 0x7C, 0xE, 0x99, 0xE, 0x21, 1, 2, 0x12, 1, 1, 1, 0}, "c\u00F4te");
@@ -558,7 +558,7 @@ public class CompareInfoTest
 	public void GetSortKeyThai ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#i1", new byte [] {
 			0x1E, 7, 0x1F, 0x28, 1, 3, 3, 1, 1, 1, 0},
@@ -623,7 +623,7 @@ public class CompareInfoTest
 	public void GetSortKeyCzechTailoring ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#i1", new byte [] {
 			0xE, 0xA, 0xE, 0x2C, 1, 1, 1, 1, 0},
@@ -643,7 +643,7 @@ public class CompareInfoTest
 	public void GetSortKeyHungarianTailoring ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#1", new byte [] {
 			0xE, 0xE, 1, 1, 0x1A, 1, 1, 0},
@@ -695,7 +695,7 @@ public class CompareInfoTest
 	public void CustomCJKTable ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertSortKey ("#1", new byte [] {
 			0x9E, 9, 0x9E, 0x11, 1, 1, 1, 1, 0},
@@ -712,7 +712,7 @@ public class CompareInfoTest
 	public void CultureSensitiveCompare ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertCompare ("#1", -1, "1", "2");
 		AssertCompare ("#2", 1, "A", "a");
@@ -766,7 +766,7 @@ public class CompareInfoTest
 	public void CompareSpecialWeight ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// Japanese (in invariant)
 // BUG in .NET 2.0 : half-width kana should be bigger.
@@ -793,7 +793,7 @@ public class CompareInfoTest
 	public void IndexOfChar ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertIndexOf ("#1", -1, "ABC", '1');
 		AssertIndexOf ("#2", 2, "ABCABC", 'c', CompareOptions.IgnoreCase);
@@ -813,7 +813,7 @@ public class CompareInfoTest
 	public void IndexOfCharMSBug ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertIndexOf ("#1", 0, "\u00E6", 'a');
 	}
@@ -822,7 +822,7 @@ public class CompareInfoTest
 	public void LastIndexOfChar ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertLastIndexOf ("#1", -1, "ABC", '1');
 		AssertLastIndexOf ("#2", 5, "ABCABC", 'c', CompareOptions.IgnoreCase);
@@ -847,7 +847,7 @@ public class CompareInfoTest
 	public void LastIndexOfCharMSBug ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertIndexOf ("#1", 0, "\u00E6", 'a');
 	}
@@ -859,7 +859,7 @@ public class CompareInfoTest
 	public void IsPrefix ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertIsPrefix ("#1", false, "ABC", "c", CompareOptions.IgnoreCase);
 		AssertIsPrefix ("#2", false, "BC", "c", CompareOptions.IgnoreCase);
@@ -891,7 +891,7 @@ public class CompareInfoTest
 	public void IsPrefixSpecialWeight ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// Japanese (in invariant)
 		AssertIsPrefix ("#1", false, "\u30D1\u30FC\u30B9", "\uFF8A\uFF9F\uFF70\uFF7D");
@@ -928,7 +928,7 @@ public class CompareInfoTest
 	public void IsSuffix ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertIsSuffix ("#1", true, "ABC", "c", CompareOptions.IgnoreCase);
 		AssertIsSuffix ("#2", true, "BC", "c", CompareOptions.IgnoreCase);
@@ -970,7 +970,7 @@ public class CompareInfoTest
 	public void IsSuffixMSBug ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertIsSuffix ("#1", true, "\u00E6", "e", CompareOptions.None);
 	}
@@ -979,7 +979,7 @@ public class CompareInfoTest
 	public void IndexOfString ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertIndexOf ("#0", 0, "", "", CompareOptions.None);
 		AssertIndexOf ("#1", -1, "ABC", "1", CompareOptions.None);
@@ -1029,7 +1029,7 @@ public class CompareInfoTest
 	public void IndexOfSpecialWeight ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// Japanese (in invariant)
 		AssertIndexOf ("#1", -1, "\u30D1\u30FC\u30B9", "\uFF8A\uFF9F\uFF70\uFF7D");
@@ -1054,7 +1054,7 @@ public class CompareInfoTest
 	public void LastIndexOfString ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertLastIndexOf ("#1", -1, "ABC", "1", CompareOptions.None);
 		AssertLastIndexOf ("#2", 5, "ABCABC", "c", CompareOptions.IgnoreCase);
@@ -1090,7 +1090,7 @@ public class CompareInfoTest
 	public void LastIndexOfStringDotnetWeird ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 // BUG in .NET 2.0 : see GetSortKey() test (mentioned above).
 		AssertLastIndexOf ("#8", 0, "\u00E6", "ae", CompareOptions.None);
@@ -1106,7 +1106,7 @@ public class CompareInfoTest
 	public void LastIndexOfSpecialWeight ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// Japanese (in invariant)
 		AssertLastIndexOf ("#1", -1, "\u30D1\u30FC\u30B9", "\uFF8A\uFF9F\uFF70\uFF7D");
@@ -1135,7 +1135,7 @@ public class CompareInfoTest
 	public void LastIndexOfOrdinalString ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		AssertLastIndexOf ("#1", -1, "ABC", "1", CompareOptions.Ordinal);
 		AssertLastIndexOf ("#2", 5, "ABCABC", "C", CompareOptions.Ordinal);
@@ -1176,7 +1176,7 @@ public class CompareInfoTest
 	public void OrdinalIgnoreCaseCompare ()
 	{
 		if (!doTest)
-			return;
+			Assert.Ignore ("Test is disabled.");
 
 		// matches
 // BUG in .NET 2.0 : see GetSortKey() test (mentioned above).

--- a/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
@@ -650,7 +650,7 @@ namespace MonoTests.System.Globalization
 
 			// The test doesn't work if the current culture is already set
 			if (orig_culture != CultureInfo.InvariantCulture)
-				return;
+				Assert.Ignore ("The test doesn't work if the current culture is already set.");
 
 			/* Phase 0 - warm up */
 			new Thread (ThreadWithoutChange).Start ();

--- a/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
@@ -1030,7 +1030,7 @@ namespace MonoTests.System.IO
 		public void WindowsSystem32_76191 ()
 		{
 			if (RunningOnUnix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			Directory.SetCurrentDirectory (@"C:\WINDOWS\system32");
 			WindowsParentFullName ("C:", "C:\\WINDOWS");
@@ -1134,7 +1134,7 @@ namespace MonoTests.System.IO
 			// Linux-like platforms but mono-on-windows
 			// doesn't set the NotDotNet category
 			if (!RunningOnUnix) {
-				return;
+				Assert.Ignore ("Not running on Unix.");
 			}
 
 			Symlink_helper ();

--- a/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
@@ -52,7 +52,7 @@ public class DirectoryTest
 	public void EnumerateFilesListSymlinks ()
 	{
 		if (!RunningOnUnix)
-			return;
+			Assert.Ignore ("Not running on Unix.");
 
 		var afile = Path.Combine (TempFolder, "afile.src");
 		var bfile = Path.Combine (TempFolder, "bfile.src");
@@ -369,7 +369,7 @@ public class DirectoryTest
 	public void ExistsAccessDenied ()
 	{
 		if (!RunningOnUnix)
-			return; // this test does not work on Windows.
+			Assert.Ignore ("Not running on Unix."); // this test does not work on Windows.
 
 		string path = TempFolder + DSC + "ExistsAccessDenied";
 
@@ -1577,7 +1577,7 @@ public class DirectoryTest
 	{
 		if (!RunningOnUnix)
 			// on Windows, backslash is used as directory separator
-			return;
+			Assert.Ignore ("Not running on Unix.");
 
 		string dir = Path.Combine (TempFolder, @"sub\dir");
 		Directory.CreateDirectory (dir);
@@ -1628,7 +1628,7 @@ public class DirectoryTest
 	{
 		if (!RunningOnUnix)
 			// on Windows, backslash is used as directory separator
-			return;
+			Assert.Ignore ("Not running on Unix.");
 
 		string file = Path.Combine (TempFolder, @"doc\temp1.file");
 		File.Create (file).Close ();

--- a/mcs/class/corlib/Test/System.IO/PathTest.cs
+++ b/mcs/class/corlib/Test/System.IO/PathTest.cs
@@ -502,7 +502,7 @@ namespace MonoTests.System.IO
 		public void GetFullPath_Unix ()
 		{
 			if (Windows)
-				return;
+				Assert.Ignore ("Running on Windows.");
 
 			string root =  "/";
 			string [,] test = new string [,] {
@@ -551,7 +551,7 @@ namespace MonoTests.System.IO
 		public void GetFullPath_Windows ()
 		{
 			if (!Windows)
-				return;
+				Assert.Ignore ("Not running on Windows.");
 
 			string root =  "C:\\";
 			string [,] test = new string [,] {
@@ -1033,7 +1033,7 @@ namespace MonoTests.System.IO
 			// http://www.mono-project.com/FAQ:_Technical#How_to_detect_the_execution_platform_.3F
 			int platform = (int) Environment.OSVersion.Platform;
 			if ((platform == 4) || (platform == 128) || (platform == 6))
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			string curdir = Directory.GetCurrentDirectory ();
 			try {
@@ -1058,7 +1058,7 @@ namespace MonoTests.System.IO
 			// http://www.mono-project.com/FAQ:_Technical#How_to_detect_the_execution_platform_.3F
 			int platform = (int) Environment.OSVersion.Platform;
 			if ((platform == 4) || (platform == 128) || (platform == 6))
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			string curdir = Directory.GetCurrentDirectory ();
 			try {
@@ -1087,7 +1087,7 @@ namespace MonoTests.System.IO
 			// http://www.mono-project.com/FAQ:_Technical#How_to_detect_the_execution_platform_.3F
 			int platform = (int) Environment.OSVersion.Platform;
 			if ((platform == 4) || (platform == 128) || (platform == 6))
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			Assert.AreEqual (@"C:\Windows\dir", Path.GetFullPath (@"C:\Windows\System32\..\dir"), "1");
 			Assert.AreEqual (@"C:\dir", Path.GetFullPath (@"C:\Windows\System32\..\..\dir"), "2");

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/ConditionalWeakTableTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/ConditionalWeakTableTest.cs
@@ -194,7 +194,7 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Test]
 	public void Reachability () {
 		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			return;
+			Assert.Ignore ("Not working on Boehm.");
 		var cwt = new ConditionalWeakTable <object,object> ();
 		List<object> keepAlive;
 		List<WeakReference> keys;
@@ -241,7 +241,7 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Test]
 	public void InsertStress () {
 		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			return;
+			Assert.Ignore ("Not working on Boehm.");
 		var cwt = new ConditionalWeakTable <object,object> ();
 
 		var a = new object ();
@@ -292,7 +292,7 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Test]
 	public void OldGenStress () {
 		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			return;
+			Assert.Ignore ("Not working on Boehm.");
 		var cwt = new ConditionalWeakTable <object,object>[1];
 		List<object> k = null;
 		List<WeakReference> res, res2;
@@ -436,7 +436,7 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	public void FinalizableObjectsThatRetainDeadKeys ()
 	{
 		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			return;
+			Assert.Ignore ("Not working on Boehm.");
 		lock (_lock1) { 
 			var cwt = new ConditionalWeakTable <object,object> ();
 			ThreadStart dele = () => { FillWithFinalizable (cwt); };
@@ -460,7 +460,7 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	public void OldGenKeysMakeNewGenObjectsReachable ()
 	{
 		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			return;
+			Assert.Ignore ("Not working on Boehm.");
 		ConditionalWeakTable<object, Val> table = new ConditionalWeakTable<object, Val>();
 		List<Key> keys = new List<Key>();
 

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/TaskAwaiterTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/TaskAwaiterTest.cs
@@ -124,7 +124,7 @@ namespace MonoTests.System.Runtime.CompilerServices
 		{
 			// some test runners (e.g. Touch.Unit) will execute this on the main thread and that would lock them
 			if (!Thread.CurrentThread.IsBackground)
-				return;
+				Assert.Ignore ("Current thread is not running in the background.");
 
 			var a = new Scheduler ("a");
 			var b = new Scheduler ("b");

--- a/mcs/class/corlib/Test/System.Security.AccessControl/DirectorySecurityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/DirectorySecurityTest.cs
@@ -27,7 +27,7 @@ namespace MonoTests.System.Security.AccessControl
 				 AccessControlType.Allow);
 
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			string dirpath = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());

--- a/mcs/class/corlib/Test/System.Security.AccessControl/EventWaitHandleSecurityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/EventWaitHandleSecurityTest.cs
@@ -22,7 +22,7 @@ namespace MonoTests.System.Security.AccessControl
 		public void PermissionsActuallyWork ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			bool createdNew; EventWaitHandleSecurity security;

--- a/mcs/class/corlib/Test/System.Security.AccessControl/FileSecurityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/FileSecurityTest.cs
@@ -19,7 +19,7 @@ namespace MonoTests.System.Security.AccessControl
 		{
 			FileSecurity security;
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			string path = Path.GetTempFileName ();
@@ -42,7 +42,7 @@ namespace MonoTests.System.Security.AccessControl
 		{
 			FileSecurity security;
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			string path = Path.GetTempFileName ();
@@ -90,7 +90,7 @@ namespace MonoTests.System.Security.AccessControl
 		{
 			FileSecurity security;
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			string path = Path.GetTempFileName ();

--- a/mcs/class/corlib/Test/System.Security.AccessControl/MutexSecurityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/MutexSecurityTest.cs
@@ -23,7 +23,7 @@ namespace MonoTests.System.Security.AccessControl
 		public void FailsForNonexistantMutex ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			new MutexSecurity (@"Local\NonexistantMutex", AccessControlSections.Access);
@@ -33,7 +33,7 @@ namespace MonoTests.System.Security.AccessControl
 		public void SucceedsForExistingMutex ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			bool createdNew;
@@ -56,7 +56,7 @@ namespace MonoTests.System.Security.AccessControl
 		public void CanSetAndGetMutexSecurity ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			MutexAccessRule rule; SecurityIdentifier sid;
@@ -99,7 +99,7 @@ namespace MonoTests.System.Security.AccessControl
 		public void PermissionsActuallyWork ()
 		{
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			bool createdNew; MutexSecurity security;

--- a/mcs/class/corlib/Test/System.Security.AccessControl/RegistrySecurityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/RegistrySecurityTest.cs
@@ -24,7 +24,7 @@ namespace MonoTests.System.Security.AccessControl
 
 			RegistrySecurity security;
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			try {
@@ -55,7 +55,7 @@ namespace MonoTests.System.Security.AccessControl
 
 			RegistrySecurity security;
 			if (PlatformID.Win32NT != Environment.OSVersion.Platform) {
-				Assert.Ignore (); return;
+				Assert.Ignore ();
 			}
 
 			try {

--- a/mcs/class/corlib/Test/System.Security.Principal/WindowsIdentityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Principal/WindowsIdentityTest.cs
@@ -200,7 +200,7 @@ namespace MonoTests.System.Security.Principal {
 		{
 			// remove g_warning from being show during unit tests
 			if (IsPosix)
-				return;
+				Assert.Ignore ("Running on Unix.");
 
 			WindowsIdentity wi = WindowsIdentity.GetCurrent ();
 			WindowsPrincipal wp = new WindowsPrincipal (wi);

--- a/mcs/class/corlib/Test/System/ConsoleTest.cs
+++ b/mcs/class/corlib/Test/System/ConsoleTest.cs
@@ -337,8 +337,7 @@ public class ConsoleTest
 	public void RedirectedTest ()
 	{
 		if (Console.IsErrorRedirected) {
-			// Assert.Inconclusive ();
-			return;
+			Assert.Ignore ("The error output stream of the console is redirected.");
 		}
 
 		Console.SetError (TextWriter.Null);

--- a/mcs/class/corlib/Test/System/DateTimeTest.cs
+++ b/mcs/class/corlib/Test/System/DateTimeTest.cs
@@ -2194,10 +2194,10 @@ namespace MonoTests.System
 		public void Kind ()
 		{
 			if (DateTime.Now == DateTime.UtcNow)
-				return; // This test does not make sense.
+				Assert.Ignore (); // This test does not make sense.
 			if (TimeZone.CurrentTimeZone.GetUtcOffset (DateTime.UtcNow)
 				!= TimeZone.CurrentTimeZone.GetUtcOffset (DateTime.Now))
-				return; // In this case it does not satisfy the test premises.
+				Assert.Ignore (); // In this case it does not satisfy the test premises.
 
 			Assert.AreEqual (DateTimeKind.Local, DateTime.Now.Kind, "#A1");
 			Assert.AreEqual (DateTimeKind.Local, DateTime.Today.Kind, "#A2");

--- a/mcs/class/corlib/Test/System/RandomTest.cs
+++ b/mcs/class/corlib/Test/System/RandomTest.cs
@@ -198,7 +198,7 @@ namespace MonoTests.System {
 
 			// if the method is not present, e.g. on MS.NET, skip this test
 			if (next == null)
-				return;
+				Assert.Ignore ("The JKiss method is not present, e.g. on MS.NET.");
 
 			// ensure we match the original JKISS random stream
 			// first 64KB but without checking every value (one each KB)

--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -272,7 +272,7 @@ public class TimeZoneTest {
 		DateTime dst_start_utc = tz.GetDaylightChanges(2007).Start.ToUniversalTime ();
 
 		if (dst_start_utc == DateTime.MinValue)
-			return;
+			Assert.Ignore ("Couldn't get beginning of daylight saving time in 2007.");
 		Assert.IsTrue (tz.ToLocalTime (dst_start_utc.Subtract (new TimeSpan (0, 1, 0))) < tz.ToLocalTime (dst_start_utc), "0:1:59 < 0:3:00");
 		Assert.IsTrue (tz.ToLocalTime (dst_start_utc) < tz.ToLocalTime (dst_start_utc.Add (new TimeSpan (0, 1, 0))), "0:3:00 < 0:3:01");
 		Assert.IsTrue (tz.ToLocalTime (dst_start_utc.Add (new TimeSpan (0, 1, 0))) < tz.ToLocalTime (dst_start_utc.Add (new TimeSpan (0, 59, 0))), "0:3:01 < 0:3:59");


### PR DESCRIPTION
Previously, many tests just had a return statement when the test shouldn't be executed (e.g. Unix-only).
This made it look like the test was successful when in fact it wasn't executed at all.
Assert.Ignore() is now used instead to correctly exclude those tests.

Changes released under MIT/X11.

I know this looks like a large changeset, but it is effectively a no-op.
Let me know if you prefer multiple commits or anything else :smile: 
