### PR TITLE
[FIX] mono-xmltool can't write to a file when prettyprinting, and corrupts the input file.

### DIFF
--- a/mcs/tools/mono-xmltool/xmltool.cs
+++ b/mcs/tools/mono-xmltool/xmltool.cs
@@ -235,7 +235,7 @@ environment variable that affects behavior:
 			r.WhitespaceHandling = WhitespaceHandling.Significant;
 			XmlTextWriter w = null;
 			if (args.Length > 2)
-				w = new XmlTextWriter (args [1], Encoding.UTF8);
+				w = new XmlTextWriter (args [2], Encoding.UTF8);
 			else
 				w = new XmlTextWriter (Console.Out);
 			w.Formatting = Formatting.Indented;


### PR DESCRIPTION
A bug in xmltool's argument handling meant that it opens the source file as the destination file, so
`mono-xmltool --prettyprint source.xml dest.xml`
- erases the contents of source.xml
- fails to save to dest.xml
