### PR TITLE
Fix routing of CatchAll tokens (Bug #17960) - on master

### DIFF
--- a/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/PatternParser.cs
@@ -606,7 +606,7 @@ namespace System.Web.Routing
 							pendingPartsAreAllSafe = true;
 							pendingParts.Append (token.Name);
 						} else {
-							if (token.Type == PatternTokenType.Standard) {
+							if (token.Type == PatternTokenType.Standard || token.Type == PatternTokenType.CatchAll) {
 								if (pendingPartsAreAllSafe) {
 									// Accept
 									if (pendingParts.Length > 0) {

--- a/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
+++ b/mcs/class/System.Web.Routing/Test/System.Web.Routing/RouteTest.cs
@@ -1723,6 +1723,36 @@ namespace MonoTests.System.Web.Routing
 			Assert.AreEqual("2013/08/hello-world", vp.VirtualPath, "#2");
 		}
 
+		[Test (Description = "Xamarin Bug #17960")]
+		public void GetVirtualPathWithCatchall1()
+		{
+			var r = new MyRoute("HelloWorld/{*path}", new MyRouteHandler());
+			var hc = new HttpContextStub2("~/", String.Empty);
+			var values = new RouteValueDictionary()
+			{
+				{ "path", "foobar" },
+			};
+			var vp = r.GetVirtualPath(new RequestContext(hc, new RouteData()), values);
+
+			Assert.IsNotNull(vp, "#1");
+			Assert.AreEqual("HelloWorld/foobar", vp.VirtualPath, "#2");
+		}
+
+		[Test (Description = "Xamarin Bug #17960")]
+		public void GetVirtualPathWithCatchall2()
+		{
+			var r = new MyRoute("HelloWorld/{*path}", new MyRouteHandler());
+			var hc = new HttpContextStub2("~/", String.Empty);
+			var values = new RouteValueDictionary()
+			{
+				{ "path", "foo/bar/baz" },
+			};
+			var vp = r.GetVirtualPath(new RequestContext(hc, new RouteData()), values);
+
+			Assert.IsNotNull(vp, "#1");
+			Assert.AreEqual("HelloWorld/foo/bar/baz", vp.VirtualPath, "#2");
+		}
+
 		// Bug #500739
 		[Test]
 		public void RouteGetRequiredStringWithDefaults ()


### PR DESCRIPTION
This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=17960, where catchall URL parameters were not being handled correctly. This is the same change as #911 except on `master` rather than `mono-3.2.8-branch`.
