### PR TITLE
Fix memory leak.

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -430,6 +430,8 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, guint8* tram
 		} else {
 			gboolean lookup_aot;
 
+			mono_class_interface_offset_with_variance (vt->klass, m->klass, &variance_used);
+
 			if (m->is_inflated && ((MonoMethodInflated*)m)->context.method_inst) {
 				/* Generic virtual method */
 				generic_virtual = m;


### PR DESCRIPTION
Introduced in b322a6e41038f7bf35f8a433b34c3b18e4a6d169. variance_used
was not being set before use, resulting in leaked trampolines when
calling methods on variant interfaces.

Test case:

``` csharp
using System;
using System.Collections;
using System.Collections.Generic;

public interface I<out T> {
    T Current { get; }
}

public struct X<T>: I<T> {
    public T Current { get { return default(T); } } 
}

public class TestCase {
    static object Dummy;

    private void BusyWork(I<object> i) {
        Dummy = i.Current;
    }    

    public void Run() {
        var x = new X<string>();

        for (var i = 0; i < 100000000; ++i) {
            BusyWork(x);
        }   

        Console.WriteLine("Dummy: {0}", Dummy);
    }   

    public static void Main() { new TestCase().Run(); }
}
```
