### PR TITLE
- Use the correct absolute path for relative paths within a rooted path

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/DirectoryScanner.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/DirectoryScanner.cs
@@ -98,7 +98,9 @@ namespace Microsoft.Build.BuildEngine {
 				int offset = 0;
 				string full_path;
 				if (Path.IsPathRooted (name)) {
-					full_path = name;
+					// The path may start with a root indicator, but at the same time can
+					// contain relative paths inbetween
+					full_path = Path.GetFullPath (name);
 					baseDirectory = new DirectoryInfo (Path.GetPathRoot (name));
 					if (IsRunningOnWindows)
 						// skip the "drive:"


### PR DESCRIPTION
 Use the correct absolute path for relative paths within a rooted path to avoid issues with the FileInfo items, which may be shorter than the original full_path, since they use absolute path information:

/foo/bar/baz/../../\* being a full_path item with a wildcard and a matching FileInfo item
/foo/Item.cs
