### PR TITLE
[MWF] Fix hang if clipboard source application closes down

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -2727,9 +2727,14 @@ namespace System.Windows.Forms {
 			while (f != null) {
 				XConvertSelection(DisplayHandle, CLIPBOARD, (IntPtr)f.Id, (IntPtr)f.Id, FosterParent, IntPtr.Zero);
 
+				var timeToWaitForSelectionFormats = TimeSpan.FromSeconds(4);
+				var startTime = DateTime.Now;
 				Clipboard.Enumerating = true;
 				while (Clipboard.Enumerating) {
 					UpdateMessageQueue(null, false);
+
+					if (DateTime.Now - startTime > timeToWaitForSelectionFormats)
+						break;
 				}
 				f = f.Next;
 			}


### PR DESCRIPTION
This change adds a timeout to the Clipboard.Enumerating loop, making a
hang less likely. This fixes Novell bug #674098
(https://bugzilla.novell.com/show_bug.cgi?id=674098).
