### PR TITLE
[MWF] Fix finding of X11 shared library on Ubuntu (#708856)

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2948,8 +2948,9 @@ case "$host" in
 	;;
     *-*-*linux*)
 	AC_PATH_X
+	dlsearch_path=`(libtool --config ; echo eval echo \\$sys_lib_dlsearch_path_spec) | sh`
 	AC_MSG_CHECKING(for the soname of libX11.so)
-	for i in $x_libraries /usr/lib /usr/lib64; do
+	for i in $x_libraries $dlsearch_path; do
 		for r in 4 5 6; do
 			if test -f $i/libX11.so.$r; then
 				X11=libX11.so.$r


### PR DESCRIPTION
When libX11-dev is not installed on an end-user's machine MWF apps
will crash in XCreateFontSet. This change uses dynamic search path
when building instead of hard coded directories when
searching for libX11.so.*. This fixes bug 708856
(https://bugzilla.novell.com/show_bug.cgi?id=708856).
