### PR TITLE
Correctly set Count after call to ConcurrentStack.PushRange()

### DIFF
--- a/mcs/class/corlib/System.Collections.Concurrent/ConcurrentStack.cs
+++ b/mcs/class/corlib/System.Collections.Concurrent/ConcurrentStack.cs
@@ -111,7 +111,7 @@ namespace System.Collections.Concurrent
 				first.Next = head;
 			} while (Interlocked.CompareExchange (ref head, insert, first.Next) != first.Next);
 			
-			Interlocked.Add (ref count, count);
+			Interlocked.Add (ref this.count, count);
 		}
 		
 		public bool TryPop (out T result)
@@ -280,3 +280,4 @@ namespace System.Collections.Concurrent
 	}
 }
 #endif
+

--- a/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentStackTests.cs
+++ b/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentStackTests.cs
@@ -290,6 +290,17 @@ namespace MonoTests.System.Collections.Concurrent
 		{
 			stack.TryPopRange (null);
 		}
+		
+		[Test]
+		public void PushRangeTestCase()
+		{
+			var testStack = new ConcurrentStack<int>();
+			
+			var testData = new int[] { 1, 2, 3, 4, 5 };			
+			testStack.PushRange (testData);
+			
+			Assert.AreEqual (testData.Length, testStack.Count);
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Fixes Bugzilla issue 18097: https://bugzilla.xamarin.com/show_bug.cgi?id=18097
