### PR TITLE
[Fix] Bugzilla #18182 - ConcurrentQueue<T>.TryPeek() is not thread safe

### DIFF
--- a/mcs/class/corlib/System.Collections.Concurrent/ConcurrentQueue.cs
+++ b/mcs/class/corlib/System.Collections.Concurrent/ConcurrentQueue.cs
@@ -128,15 +128,15 @@ namespace System.Collections.Concurrent
 		}
 		
 		public bool TryPeek (out T result)
-		{		
+		{
 			Node first = head.Next;	
-			
-			if (IsEmpty || first == null) {
+
+			if (first == null) {
 				result = default (T);
 				return false;
 			}
-							
-			result = first.Value;			
+
+			result = first.Value;
 			return true;
 		}
 		


### PR DESCRIPTION
- in the previous version the IsEmpty could be false, but by the time we get
  to head.Next.Value we get an exception since Value is now null
- passes existing test cases, although these are not definitive since
  they don't show threading issue
- would need to adapt System.Threading.Tasks.ParallelTestHelper to allow
  TryPeek() to be called during Enqueue/Dequeue operations to truly
  test this change out
