### PR TITLE
[Fix] Bugzilla #17897 - MemoryCacheEntryPriorityQueue throws out of boun...

### DIFF
--- a/mcs/class/System.Runtime.Caching/System.Runtime.Caching/MemoryCacheEntry.cs
+++ b/mcs/class/System.Runtime.Caching/System.Runtime.Caching/MemoryCacheEntry.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Runtime.Caching
 {
-	sealed class MemoryCacheEntry
+	sealed class MemoryCacheEntry : IComparable<MemoryCacheEntry>
 	{
 		object value;
 		DateTimeOffset absoluteExpiration;
@@ -194,6 +194,22 @@ namespace System.Runtime.Caching
 			removedCallback = policy.RemovedCallback;
 			slidingExpiration = policy.SlidingExpiration;
 			updateCallback = policy.UpdateCallback;
+		}
+		
+		public int CompareTo(MemoryCacheEntry other)
+		{
+			if (IsExpirable && other.IsExpirable) {
+				return (int)(expiresAt - other.expiresAt);
+			}
+			else if (IsExpirable) {
+				return -1;
+			}
+			else if (other.IsExpirable) {
+				return 1;
+			}
+			else {
+				return 0;
+			}
 		}
 	}
 }

--- a/mcs/class/System.Runtime.Caching/Test/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/mcs/class/System.Runtime.Caching/Test/System.Runtime.Caching/MemoryCacheTest.cs
@@ -1232,5 +1232,56 @@ namespace MonoTests.System.Runtime.Caching
 				Assert.AreEqual ("key" + i.ToString (), removed [idx], "#A5-" + idx.ToString ());
 			}
 		}
+	
+		[Test]
+		public void TestCacheShrink ()
+		{
+			const int HEAP_RESIZE_THRESHOLD = 8192 + 2;
+			const int HEAP_RESIZE_SHORT_ENTRIES = 2048;
+			const int HEAP_RESIZE_LONG_ENTRIES = HEAP_RESIZE_THRESHOLD - HEAP_RESIZE_SHORT_ENTRIES;			
+			
+			var config = new NameValueCollection();
+            config["cacheMemoryLimitMegabytes"] = 0.ToString();
+            config["physicalMemoryLimitPercentage"] = 100.ToString();            
+            config["__MonoEmulateOneCPU"] = true.ToString();
+            
+            // TODO: it appears that pollingInterval does nothing, so we set the Mono timer as well
+            config["pollingInterval"] = new TimeSpan(0, 0, 1).ToString();
+            config["__MonoTimerPeriod"] = 1.ToString();
+			
+			using (var mc = new MemoryCache ("TestCacheShrink",  config))
+			{	
+				Assert.AreEqual (0, mc.GetCount(), "#CS1");
+							
+				// add some long duration entries				
+				for (int i = 0; i < HEAP_RESIZE_LONG_ENTRIES; i++)
+				{				
+					mc.Add("long-" + i, i.ToString(), DateTimeOffset.Now.AddSeconds(10));
+				}
+				
+				Assert.AreEqual (HEAP_RESIZE_LONG_ENTRIES, mc.GetCount(), "#CS2");
+				
+				// add some short duration entries
+				for (int i = 0; i < HEAP_RESIZE_SHORT_ENTRIES; i++)
+				{				
+					mc.Add("short-" + i, i.ToString(), DateTimeOffset.Now.AddSeconds(2));
+				}
+				
+				Assert.AreEqual (HEAP_RESIZE_LONG_ENTRIES + HEAP_RESIZE_SHORT_ENTRIES, mc.GetCount(), "#CS3");
+				
+				// wait for the cache thread to expire the short duration items, this will also shrink the size of the cache
+				global::System.Threading.Thread.Sleep(4 * 1000);
+				
+				Assert.AreEqual (HEAP_RESIZE_LONG_ENTRIES, mc.GetCount(), "#CS4");	
+				
+				// add some new items into the cache, this will grow the cache again
+				for (int i = 0; i < HEAP_RESIZE_LONG_ENTRIES; i++)
+				{				
+					mc.Add("final-" + i, i.ToString(), DateTimeOffset.Now.AddSeconds(2));
+				}			
+				
+				Assert.AreEqual (HEAP_RESIZE_LONG_ENTRIES + HEAP_RESIZE_LONG_ENTRIES, mc.GetCount(), "#CS4");	
+			}
+		}
 	}
 }


### PR DESCRIPTION
...ds after shrink
- when MemoryCacheEntryPriorityQueue grows the timed items after a shrink
  the size of the memory variable heapSize is wrong allowing an out-of-
  bounds exception which would normally be prevented by bounds tests
- in order to fix the exception the BubbleUp() method was modified
  to make it sort the timed item list, previously the logic did
  not result in sorted items which the cache did not flush in a timely
  manner
- BubbleDown() now just moves items down the array
- MemoryCacheEntry now implements IComparable<MemoryCacheEntry>
- A test case was added for the out-of-bounds exception
