### PR TITLE
[Fix] Bugzilla #17897 - MemoryCacheEntryPriorityQueue throws out of boun...

### DIFF
--- a/mcs/class/System.Runtime.Caching/System.Runtime.Caching/MemoryCacheEntryPriorityQueue.cs
+++ b/mcs/class/System.Runtime.Caching/System.Runtime.Caching/MemoryCacheEntryPriorityQueue.cs
@@ -88,8 +88,10 @@ namespace System.Runtime.Caching
 					newSize = halfTheSize + (heapCount / 3);
 				}
 
-				if ((heapCount < halfTheSize) && newSize > -1)
+				if ((heapCount < halfTheSize) && newSize > -1) {
 					Array.Resize <MemoryCacheEntry> (ref heap, newSize);
+					heapSize = newSize;
+				}
 			}
 			
 			return heap;


### PR DESCRIPTION
...ds after shrink
- when MemoryCacheEntryPriorityQueue grows the timed items after a shrink
  the value of the member variable heapSize is wrong allowing an out-of-
  bounds exception which would normally be prevented by bounds tests
- A test case was added for the out-of-bounds exception
