### PR TITLE
[runtime] Fixed flags for VirtualAlloc in mono_valloc (Windows)

### DIFF
--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -107,7 +107,7 @@ void*
 mono_valloc (void *addr, size_t length, int flags)
 {
 	void *ptr;
-	int mflags = MEM_COMMIT;
+	int mflags = MEM_RESERVE|MEM_COMMIT;
 	int prot = prot_from_flags (flags);
 	/* translate the flags */
 


### PR DESCRIPTION
If `VirtualAlloc` gets non-null address and MEM_COMMIT flag (without MEM_RESERVE), it assumes you want to commit memory which is already reserved. What we want here is to reserve AND commit the memory.

This fixes random crashes occuring on Windows after commit https://github.com/mono/mono/commit/2fed14d6ef5e0f0f5fe71f0f5a18a1146cb1113d. Before this commit `mono_valloc` was not used with `addr` argument (at least on Windows).
