### PR TITLE
Work around bad native code

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -36,6 +36,7 @@
 #include "mono/utils/atomic.h"
 #include <string.h>
 #include <errno.h>
+#include <signal.h>
 
 /*
 Code shared between the DISABLE_COM and !DISABLE_COM
@@ -1665,6 +1666,11 @@ cominterop_rcw_finalizer (gpointer key, gpointer value, gpointer user_data)
 	return TRUE;
 }
 
+void justexit(int sig)
+{
+	_exit(0);
+}
+
 void
 cominterop_release_all_rcws (void)
 {
@@ -1672,10 +1678,17 @@ cominterop_release_all_rcws (void)
 		return;
 
 	mono_cominterop_lock ();
+	sighandler_t oldAbrt = signal(SIGABRT, justexit);
+	sighandler_t oldSegv = signal(SIGSEGV, justexit);
+	sighandler_t oldFpe = signal(SIGFPE, justexit);
 
 	g_hash_table_foreach_remove (rcw_hash, cominterop_rcw_finalizer, NULL);
 	g_hash_table_destroy (rcw_hash);
 	rcw_hash = NULL;
+
+	signal(SIGABRT, oldAbrt);
+	signal(SIGABRT, oldSegv);
+	signal(SIGFPE, oldFpe);
 
 	mono_cominterop_unlock ();
 }


### PR DESCRIPTION
Don't crash managed app when native code crashes during cleanup.
