### PR TITLE
[MWF] Fix text position on buttons (#463149)

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TextRenderer.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TextRenderer.cs
@@ -487,8 +487,8 @@ namespace System.Windows.Forms
 			if ((flags & TextFormatFlags.WordEllipsis) == TextFormatFlags.WordEllipsis || (flags & TextFormatFlags.EndEllipsis) == TextFormatFlags.EndEllipsis || (flags & TextFormatFlags.WordBreak) == TextFormatFlags.WordBreak) {
 				r.Width -= 4;
 			}
-			if ((flags & TextFormatFlags.VerticalCenter) == TextFormatFlags.VerticalCenter) {
-				r.Y += 1;
+			if ((flags & TextFormatFlags.VerticalCenter) == TextFormatFlags.VerticalCenter && XplatUI.RunningOnUnix) {
+				r.Y -= 1;
 			}
 
 			return r;


### PR DESCRIPTION
Vertically centered text on buttons didn't show up centered. The
referenced bug reports it on Windows. Matters were worse on Linux.
This patch tries to fix the problem on both Windows and Linux. On Linux
the positioning is improved although probably still not perfect.

This fixes Novell bug #463149
(https://bugzilla.novell.com/show_bug.cgi?id=463149).
