### PR TITLE
[MWF] Release capture when clicking LinkLabel (Fixes #2787)

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/LinkLabel.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/LinkLabel.cs
@@ -459,6 +459,14 @@ namespace System.Windows.Forms
 				OnLinkClicked (new LinkLabelLinkClickedEventArgs (clicked_link, e.Button));
 		}
 
+		protected override void OnClick (EventArgs e)
+		{
+			if (active_link != null && this.Capture) {
+				this.Capture = false;
+			}
+			base.OnClick (e);
+		}
+
 		protected override void OnPaint (PaintEventArgs e)
 		{
 			// We need to invoke paintbackground because control is opaque


### PR DESCRIPTION
When clicking on a LinkLabel we need to release the mouse capture otherwise the UI might lock up. This helps especially when running in the debugger, but probably in other cases as well.

This fixes Xamarin bug #2787.
