### PR TITLE
Correct spelling DEFAULT_ACCESS_MODIFER -> DEFAULT_ACCESS_MODIFIER

### DIFF
--- a/mcs/mcs/class.cs
+++ b/mcs/mcs/class.cs
@@ -144,8 +144,8 @@ namespace Mono.CSharp
 			}
 
 			if ((existing.ModFlags & Modifiers.AccessibilityMask) != (next_part.ModFlags & Modifiers.AccessibilityMask) &&
-				((existing.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFER) == 0 &&
-				 (next_part.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFER) == 0)) {
+				((existing.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFIER) == 0 &&
+				 (next_part.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFIER) == 0)) {
 					 Report.SymbolRelatedToPreviousError (existing);
 				Report.Error (262, next_part.Location,
 					"Partial declarations of `{0}' have conflicting accessibility modifiers",
@@ -172,10 +172,10 @@ namespace Mono.CSharp
 				}
 			}
 
-			if ((next_part.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFER) != 0) {
-				existing.ModFlags |= next_part.ModFlags & ~(Modifiers.DEFAULT_ACCESS_MODIFER | Modifiers.AccessibilityMask);
-			} else if ((existing.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFER) != 0) {
-				existing.ModFlags &= ~(Modifiers.DEFAULT_ACCESS_MODIFER | Modifiers.AccessibilityMask);
+			if ((next_part.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFIER) != 0) {
+				existing.ModFlags |= next_part.ModFlags & ~(Modifiers.DEFAULT_ACCESS_MODIFIER | Modifiers.AccessibilityMask);
+			} else if ((existing.ModFlags & Modifiers.DEFAULT_ACCESS_MODIFIER) != 0) {
+				existing.ModFlags &= ~(Modifiers.DEFAULT_ACCESS_MODIFIER | Modifiers.AccessibilityMask);
 				existing.ModFlags |= next_part.ModFlags;
 			} else {
 				existing.ModFlags |= next_part.ModFlags;

--- a/mcs/mcs/modifiers.cs
+++ b/mcs/mcs/modifiers.cs
@@ -46,7 +46,7 @@ namespace Mono.CSharp
 		PROPERTY_CUSTOM 		= 0x10000,
 
 		PARTIAL					= 0x20000,
-		DEFAULT_ACCESS_MODIFER	= 0x40000,
+		DEFAULT_ACCESS_MODIFIER	= 0x40000,
 		METHOD_EXTENSION		= 0x80000,
 		COMPILER_GENERATED		= 0x100000,
 		BACKING_FIELD			= 0x200000,
@@ -256,7 +256,7 @@ namespace Mono.CSharp
 				if ((mod & Modifiers.AccessibilityMask) == 0) {
 					mod |= def_access;
 					if (def_access != 0)
-						mod |= Modifiers.DEFAULT_ACCESS_MODIFER;
+						mod |= Modifiers.DEFAULT_ACCESS_MODIFIER;
 					return mod;
 				}
 

--- a/mcs/mcs/property.cs
+++ b/mcs/mcs/property.cs
@@ -1109,8 +1109,8 @@ namespace Mono.CSharp
 				return false;
 
 			if (declarators != null) {
-				if ((mod_flags_src & Modifiers.DEFAULT_ACCESS_MODIFER) != 0)
-					mod_flags_src &= ~(Modifiers.AccessibilityMask | Modifiers.DEFAULT_ACCESS_MODIFER);
+				if ((mod_flags_src & Modifiers.DEFAULT_ACCESS_MODIFIER) != 0)
+					mod_flags_src &= ~(Modifiers.AccessibilityMask | Modifiers.DEFAULT_ACCESS_MODIFIER);
 
 				var t = new TypeExpression (MemberType, TypeExpression.Location);
 				foreach (var d in declarators) {


### PR DESCRIPTION
Corrects spelling of Modifiers.DEFAULT_ACCESS_MODIFER to Modifiers.DEFAULT_ACCESS_MODIFIERS. I have run all compiler tests to verify that this doesn't introduce regressions.
