### PR TITLE
[MWF] Fix TableLayoutPanel layout bug (#8907)

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TableLayoutSettings.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TableLayoutSettings.cs
@@ -163,9 +163,15 @@ namespace System.Windows.Forms
 			int row;
 
 			if (!columns.TryGetValue (control, out column))
-				column = -1;
+			{
+				if (!(control is Control) || !columns.TryGetValue ((control as Control).Name, out column))
+					column = -1;
+			}
 			if (!rows.TryGetValue (control, out row))
-				row = -1;
+			{
+				if (!(control is Control) || !rows.TryGetValue ((control as Control).Name, out row))
+					row = -1;
+			}
 
 			return new TableLayoutPanelCellPosition (column, row);
 		}
@@ -180,6 +186,8 @@ namespace System.Windows.Forms
 
 			if (columns.TryGetValue (control, out retval))
 				return retval;
+			if ((control is Control) && columns.TryGetValue ((control as Control).Name, out retval))
+				return retval;
 
 			return -1;
 		}
@@ -192,6 +200,8 @@ namespace System.Windows.Forms
 			int retval;
 
 			if (column_spans.TryGetValue (control, out retval))
+				return retval;
+			if ((control is Control) && column_spans.TryGetValue ((control as Control).Name, out retval))
 				return retval;
 
 			return 1;
@@ -207,6 +217,8 @@ namespace System.Windows.Forms
 
 			if (rows.TryGetValue (control, out retval))
 				return retval;
+			if ((control is Control) && rows.TryGetValue ((control as Control).Name, out retval))
+				return retval;
 
 			return -1;
 		}
@@ -219,6 +231,8 @@ namespace System.Windows.Forms
 			int retval;
 
 			if (row_spans.TryGetValue (control, out retval))
+				return retval;
+			if ((control is Control) && row_spans.TryGetValue ((control as Control).Name, out retval))
 				return retval;
 
 			return 1;


### PR DESCRIPTION
This fixes the TableLayoutPanel implementation to check for control names
as well as the the controls themselves in looking up the row and column
values.
