### PR TITLE
[MWF] Partially implement Help.ShowHelp

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Help.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Help.cs
@@ -28,9 +28,14 @@
 
 using System;
 using System.Drawing;
+using System.Diagnostics;
+using System.IO;
 
 namespace System.Windows.Forms
 {
+	/// <summary>
+	/// http://msdn.microsoft.com/en-us/library/System.Windows.Forms.Help(v=vs.110).aspx
+	/// </summary>
 	public class Help
 	{
 		#region Constructor
@@ -42,7 +47,7 @@ namespace System.Windows.Forms
 		#region Public Static Methods
 		public static void ShowHelp (Control parent, string url)
 		{
-			ShowHelp(parent, url, HelpNavigator.TableOfContents, null);
+			ShowHelp (parent, url, null);
 		}
 
 		public static void ShowHelp (Control parent, string url, HelpNavigator navigator)
@@ -57,9 +62,7 @@ namespace System.Windows.Forms
 
 		public static void ShowHelp (Control parent, string url, string keyword)
 		{
-			if (keyword == null || keyword == String.Empty)
-				ShowHelp (parent, url, HelpNavigator.TableOfContents, null);
-			ShowHelp (parent, url, HelpNavigator.Topic, keyword);
+			ShowHelpTopic (url, keyword);
 		}
 
 		public static void ShowHelpIndex (Control parent, string url)
@@ -72,5 +75,55 @@ namespace System.Windows.Forms
 		{
 		}
 		#endregion	// Public Static Methods
+
+		/// <summary>
+		/// Show a help file and topic using a help viewer
+		/// </summary>
+		/// <param name="helpFile">path to a .chm help file</param>
+		/// <param name="helpTopic">path to a topic in helpFile, or null</param>
+		private static void ShowHelpTopic (string helpFile, string helpTopic)
+		{
+			if (helpFile == null)
+				throw new ArgumentNullException ();
+			if (helpFile == String.Empty)
+				throw new ArgumentException ();
+
+			// Use forward slashes in helpFile path if needed
+			helpFile = helpFile.Replace (@"\", Path.DirectorySeparatorChar.ToString ());
+
+			string helpViewer = Environment.GetEnvironmentVariable ("MONO_HELP_VIEWER") ?? "chmsee";
+			string arguments = String.Format ("\"{0}\"", helpFile);
+			if (!String.IsNullOrEmpty (helpTopic)) {
+				if (!helpTopic.StartsWith ("/"))
+					helpTopic = "/" + helpTopic;
+				helpTopic = helpTopic.TrimEnd (' ');
+				arguments = String.Format ("\"{0}::{1}\"", helpFile, helpTopic);
+			}
+
+			try {
+				RunNonblockingProcess (helpViewer, arguments);
+			} catch (Exception e) {
+				// Don't crash if the help viewer couldn't be launched. There
+				// won't be an exception thrown if the help viewer can't find
+				// the help file; it's up to the help viewer to display such an error.
+				string message = String.Format ("The help viewer could not load. Maybe you don't have {0} installed or haven't set MONO_HELP_VIEWER. The specific error message was: {1}", helpViewer, e.Message);
+				Console.Error.WriteLine (message);
+				MessageBox.Show (message);
+			}
+		}
+
+		/// <remarks>
+		/// throws exception from Process.Start() if there was a problem starting
+		/// </remarks>
+		private static void RunNonblockingProcess (string command, string arguments)
+		{
+			using (Process process = new Process ()) {
+				process.StartInfo.FileName = command;
+				process.StartInfo.Arguments = arguments;
+				process.StartInfo.UseShellExecute = false;
+
+				process.Start ();
+			}
+		}
 	}
 }


### PR DESCRIPTION
This change partially implements the ability to show a help file by calling chmsee or whatever the environment variable MONO_HELP_VIEWER is set to.
