### PR TITLE
[mcs] Fix wrong case for error CS0177 (squashed)

### DIFF
--- a/mcs/mcs/delegate.cs
+++ b/mcs/mcs/delegate.cs
@@ -581,6 +581,11 @@ namespace Mono.CSharp {
 			ec.Emit (OpCodes.Newobj, constructor_method);
 		}
 
+		public override void FlowAnalysis (FlowAnalysisContext fc) {
+			base.FlowAnalysis (fc);
+			method_group.FlowAnalysis (fc);
+		}
+
 		void Error_ConversionFailed (ResolveContext ec, MethodSpec method, Expression return_type)
 		{
 			var invoke_method = Delegate.GetInvokeMethod (type);

--- a/mcs/tests/gtest-607.cs
+++ b/mcs/tests/gtest-607.cs
@@ -1,0 +1,25 @@
+using System;
+
+public class C
+{
+	public C (out string b)
+	{
+		b = "";
+	}
+	public string D () {
+		return "";
+	}
+}
+public class A
+{
+	public Func<String> E (out string b)
+	{
+		return new C (out b).D;
+	}
+	public Func<String> F (out string b)
+	{
+		return new Func<String> (new C (out b).D);
+	}
+	static void Main () {
+	}
+}

--- a/mcs/tests/ver-il-net_4_5.xml
+++ b/mcs/tests/ver-il-net_4_5.xml
@@ -18962,6 +18962,30 @@
       </method>
     </type>
   </test>
+  <test name="gtest-607.cs">
+    <type name="A">
+      <method name="System.Func`1[System.String] E(System.String ByRef)" attrs="134">
+        <size>26</size>
+      </method>
+      <method name="System.Func`1[System.String] F(System.String ByRef)" attrs="134">
+        <size>26</size>
+      </method>
+      <method name="Void Main()" attrs="145">
+        <size>2</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="C">
+      <method name="Void .ctor(String&amp;)" attrs="6278">
+        <size>15</size>
+      </method>
+      <method name="System.String D()" attrs="134">
+        <size>14</size>
+      </method>
+    </type>
+  </test>
   <test name="gtest-anontype-01.cs">
     <type name="Test">
       <method name="Int32 Main()" attrs="150">


### PR DESCRIPTION
This is a squashed version of #967

While trying to compile with mono a project I had in Visual Studio I found a case where the compiler emits a CS0177 _The out parameter `b' must be assigned to before control leaves the current method_

This error is not emitted by .net's compiler so I started to look at the code. The code is similar to what follows:

```
using System;

public class C
{
    public C (out string b)
    {
        b = "";
    }
    public string D () {
        return "";
    }
}
public class A
{
    public Func<String> E (out string b)
    {
        return new C (out b).D;
    }
    static void Main () {
    }
}
```

As you can see, `A.E` returns Func<String>, so this `new C(out b).D` in the code is called an `ImplicitDelegateCreation`.
The problem I saw is that `DelegateCreation` class didn't implement `FlowAnalysis` method so it wasn't checking it's `method_group` property and validating that `out b` parameter was being filled before returning control.

This commit implements FlowAnalysis in DelegateCreation covering the following cases:

```
return new C (out b).D;
```

This is ImplicitDelegateCreation class

and

```
return new Func<String> (new C (out b).D);
```

This is NewDelegate class.
Both cases were throwing a wrong error and at this point it's fixed.

I hope I didn't miss anything.

Regards,
