### PR TITLE
Add mono_threads_core_set_name() on Mac.

### DIFF
--- a/mono/utils/mono-threads-mach.c
+++ b/mono/utils/mono-threads-mach.c
@@ -138,4 +138,10 @@ mono_native_thread_create (MonoNativeThreadId *tid, gpointer func, gpointer arg)
 	return pthread_create (tid, NULL, func, arg) == 0;
 }
 
+void
+mono_threads_core_set_name (MonoNativeThreadId tid, const char *name)
+{
+	/* pthread_setnmae_np() on Mac is not documented and doesn't receive thread id. */
+}
+
 #endif


### PR DESCRIPTION
5e0579782e13c8093ff9b58307ea8a3f3fa09726 breaks build on Mac.
