### PR TITLE
Fix bugs in sizing TableLayoutPanel (Xamarin bug 18638)

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms.Layout/TableLayout.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms.Layout/TableLayout.cs
@@ -368,7 +368,20 @@ namespace System.Windows.Forms.Layout
 			}
 
 			if (total_width > 0)
-				panel.column_widths[col_styles.Count - 1] += total_width;
+			{
+				// Find the last column that isn't an Absolute SizeType, and give it
+				// all this free space.  (Absolute sized columns need to retain their
+				// absolute width if at all possible!)
+				int col = col_styles.Count - 1;
+				for (; col >= 0; --col)
+				{
+					if (col_styles[col].SizeType != SizeType.Absolute)
+						break;
+				}
+				if (col < 0)
+					col = col_styles.Count - 1;
+				panel.column_widths[col] += total_width;
+			}
 
 			// Figure up all the row heights
 			int total_height = parentDisplayRectangle.Height - (border_width * (rows + 1));
@@ -464,7 +477,20 @@ namespace System.Windows.Forms.Layout
 			}
 
 			if (total_height > 0)
-				panel.row_heights[row_styles.Count - 1] += total_height;
+			{
+				// Find the last row that isn't an Absolute SizeType, and give it
+				// all this free space.  (Absolute sized rows need to retain their
+				// absolute height if at all possible!)
+				int row = row_styles.Count - 1;
+				for (; row >= 0; --row)
+				{
+					if (row_styles[row].SizeType != SizeType.Absolute)
+						break;
+				}
+				if (row < 0)
+					row = row_styles.Count - 1;
+				panel.row_heights[row] += total_height;
+			}
 		}
 		
 		private void LayoutControls (TableLayoutPanel panel)

--- a/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/.gitattributes
+++ b/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/.gitattributes
@@ -16,7 +16,7 @@
 /SendKeysTest.cs -crlf
 /SplitContainerTests.cs -crlf
 /StatusStripTest.cs -crlf
-/TableLayoutTest.cs -crlf
+/TableLayoutTest.cs -crlf -whitespace
 /TimerTest.cs -crlf
 /ToolStripContainerTest.cs -crlf
 /ToolStripContentPanelTest.cs -crlf

--- a/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/TableLayoutTest.cs
+++ b/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/TableLayoutTest.cs
@@ -1672,6 +1672,55 @@ namespace MonoTests.System.Windows.Forms
 				tlp.LayoutSettings = tls; // Should not throw an exception
 			}
 		}
+
+		[Test]
+		public void XamarinBug18638 ()
+		{
+			// Spanning items should not have their entire width assigned to the first column in the span.
+			TableLayoutPanel tlp = new TableLayoutPanel ();
+			tlp.SuspendLayout ();
+			tlp.Size = new Size(291, 100);
+			tlp.AutoSize = true;
+			tlp.ColumnStyles.Add (new ColumnStyle (SizeType.Absolute, 60));
+			tlp.ColumnStyles.Add (new ColumnStyle (SizeType.Percent, 100));
+			tlp.ColumnStyles.Add (new ColumnStyle (SizeType.Absolute, 45));
+			tlp.ColumnCount = 3;
+			tlp.RowStyles.Add (new RowStyle (SizeType.AutoSize));
+			var label1 = new Label {AutoSize = true, Text = @"This line spans all three columns in the table!"};
+			tlp.Controls.Add (label1, 0, 0);
+			tlp.SetColumnSpan (label1, 3);
+			tlp.RowStyles.Add (new RowStyle (SizeType.AutoSize));
+			tlp.RowCount = 1;
+			var label2 = new Label {AutoSize = true, Text = @"This line spans columns two and three."};
+			tlp.Controls.Add (label2, 1, 1);
+			tlp.SetColumnSpan (label2, 2);
+			tlp.RowCount = 2;
+			AddTableRow (tlp, "First Row", "This is a test");
+			AddTableRow (tlp, "Row 2", "This is another test");
+			tlp.ResumeLayout ();
+
+			var widths = tlp.GetColumnWidths ();
+			Assert.AreEqual (4, tlp.RowCount, "X18638-1");
+			Assert.AreEqual (3, tlp.ColumnCount, "X18638-2");
+			Assert.AreEqual (60, widths[0], "X18638-3");
+			Assert.Greater (label2.Width, widths[1], "X18638-5");
+			Assert.AreEqual (45, widths[2], "X18638-4");
+		}
+
+		private void AddTableRow(TableLayoutPanel tlp, string label, string text)
+		{
+			tlp.SuspendLayout ();
+			int row = tlp.RowCount;
+			tlp.RowStyles.Add (new RowStyle (SizeType.AutoSize));
+			var first = new Label {AutoSize = true, Dock = DockStyle.Fill, Text = label};
+			tlp.Controls.Add (first, 0, row);
+			var second = new TextBox {AutoSize = true, Text = text, Dock = DockStyle.Fill, Multiline = true};
+			tlp.Controls.Add (second, 1, row);
+			var third = new Button {Text = @"DEL", Dock = DockStyle.Fill};
+			tlp.Controls.Add (third, 2, row);
+			tlp.RowCount = row + 1;
+			tlp.ResumeLayout ();
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Consider spans and absolute sizes in computing PreferredSize for
TableLayoutPanel.
Also fix bug in allocating unused width to SizeType.Absolute columns.

Change-Id: Ic5065b83ced8195d1c5be39087f33b0d632fc9a6
