### PR TITLE
Fix CreateErrorFromString: match.Result("${column}") may contain a '+', ...

### DIFF
--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
@@ -432,7 +432,7 @@ namespace Mono.CSharp
 			if (String.Empty != match.Result("${line}"))
 				error.Line=Int32.Parse(match.Result("${line}"));
 			if (String.Empty != match.Result("${column}"))
-				error.Column=Int32.Parse(match.Result("${column}"));
+				error.Column=Int32.Parse(match.Result("${column}").Trim('+'));
 
 			string level = match.Result ("${level}");
 			if (level == "warning")


### PR DESCRIPTION
...trim it

Signed-off-by: Etienne CHAMPETIER etienne.champetier@fiducial.net
