### PR TITLE
[docs] Fixed XML syntax issue with CipherSuitesCallback, and ServicePointManager xml files.

### DIFF
--- a/mcs/class/System/Documentation/en/System.Net/CipherSuitesCallback.xml
+++ b/mcs/class/System/Documentation/en/System.Net/CipherSuitesCallback.xml
@@ -22,7 +22,7 @@
     <returns>The ordered list of all cipher suites you wish to support.</returns>
     <remarks>
       <para>This type is only available in Mono and Xamarin products.</para>
-      <para>See the <see cref="P:System.Net.ServicePointManager.ClientCipherSuitesCallback"/> property for examples of how this is used.
+      <para>See the <see cref="P:System.Net.ServicePointManager.ClientCipherSuitesCallback"/> property for examples of how this is used.</para>
     </remarks>
   </Docs>
 </Type>

--- a/mcs/class/System/Documentation/en/System.Net/ServicePointManager.xml
+++ b/mcs/class/System/Documentation/en/System.Net/ServicePointManager.xml
@@ -109,7 +109,7 @@ instance. </para>
 	  <example>
 	    <para>The following example removes weak (export) ciphers from the list that will be offered to the server.</para>
 	    <code lang="C#">
-ServicePointManager.ClientCipherSuitesCallback += (SecurityProtocolType p, IEnumerable&lt;string&gt; allCiphers) => {
+ServicePointManager.ClientCipherSuitesCallback += (SecurityProtocolType p, IEnumerable&lt;string&gt; allCiphers) =&gt; {
     return from cipher in allCiphers where !cipher.Contains ("EXPORT")
     select cipher;
 };
@@ -119,10 +119,11 @@ ServicePointManager.ClientCipherSuitesCallback += (SecurityProtocolType p, IEnum
 	  <para>Example: Use AES128 (preference) or AES256 (allowed) but no other ciphers.</para>
 
 	  <code lang="C#">
-ServicePointManager.ClientCipherSuitesCallback += (SecurityProtocolType p, IEnumerable<string> allCiphers) => {
+ServicePointManager.ClientCipherSuitesCallback += (SecurityProtocolType p, IEnumerable&lt;string&gt; allCiphers) =&gt; {
     string prefix = p == SecurityProtocolType.Tls ? "TLS_" : "SSL_";
-    return new List<string> { prefix + "RSA_WITH_AES_128_CBC_SHA", prefix + "RSA_WITH_AES_256_CBC_SHA" };
+    return new List&lt;string&gt; { prefix + "RSA_WITH_AES_128_CBC_SHA", prefix + "RSA_WITH_AES_256_CBC_SHA" };
 };
+    </code>
 	</example>
       </remarks>
       </Docs>


### PR DESCRIPTION
Just a quick fix for some of the documentation XML
