### PR TITLE
Fix assertion in test-mono-linked-list-set

### DIFF
--- a/mono/unit-tests/test-mono-linked-list-set.c
+++ b/mono/unit-tests/test-mono-linked-list-set.c
@@ -126,7 +126,6 @@ main (int argc, char *argv [])
 
 	mono_threads_init (&thread_callbacks, 0);
 
-	mono_thread_smr_init ();
 	mono_lls_init (&lls, free_node);
 
 	for (i = 0; i < N; ++i) {


### PR DESCRIPTION
When running 'make check', test-mono-linked-list-set fails with:
- Assertion at hazard-pointer.c:353, condition `small_id == i' not met

This happens since 71ad74dc11c5fa4bc8c178a5457d2cab732fdb01, because
that commit changes the behaviour of mono_thread_smr_init() so that
invoking it should not be invoked more than once.
