### PR TITLE
xml type parameters have no size specifier

### DIFF
--- a/mcs/class/Mono.Data.Tds/Mono.Data.Tds/TdsMetaParameter.cs
+++ b/mcs/class/Mono.Data.Tds/Mono.Data.Tds/TdsMetaParameter.cs
@@ -322,7 +322,6 @@ namespace Mono.Data.Tds {
 				result.Append (size > 8000 ? "(max)" : String.Format ("({0})", size));
 				break;
 			case "nvarchar":
-			case "xml":
 				int paramSize = Size < 0 ? GetActualSize () / 2 : Size;
 				result.Append (paramSize > 0 ? (paramSize > 4000 ? "(max)" : String.Format ("({0})", paramSize)) : "(4000)");
 				break;


### PR DESCRIPTION
generate "@p1 xml" instead of "@p1 xml(123)"
