### PR TITLE
[System] handle arguments whose ToString returns null in String.Format

### DIFF
--- a/mcs/class/corlib/System/String.cs
+++ b/mcs/class/corlib/System/String.cs
@@ -2046,7 +2046,7 @@ namespace System
 						if (arg is IFormattable)
 							str = ((IFormattable)arg).ToString (arg_format, provider);
 						else
-							str = arg.ToString ();
+							str = arg.ToString () ?? Empty;
 					}
 
 					// pad formatted string and append to result

--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -37,6 +37,13 @@ public class StringTest
 		}
 	}
 
+	class ToNullStringer
+	{
+		public override string ToString()
+		{
+			return null;
+		}
+	}
 
 	private CultureInfo orgCulture;
 
@@ -1207,6 +1214,13 @@ public class StringTest
 	{
 		var s = String.Format (new NullFormatter (), "{0:}", "test");
 		Assert.AreEqual ("test", s);
+	}
+
+	[Test]
+	public void Format_Arg_ToNullStringer ()
+	{
+		var s = String.Format ("{0}", new ToNullStringer ());
+		Assert.AreEqual ("", s);
 	}
 
 	[Test]


### PR DESCRIPTION
When an argument to String.Format has no formatter, its ToString method
is called. This change takes care that the FormatHelper can handle
arguments whose ToString() method returns null.
