### PR TITLE
Allows CustomErrors redirect attribute to specify paths w/QueryStrings.

### DIFF
--- a/mcs/class/System.Web/System.Web/HttpApplication.cs
+++ b/mcs/class/System.Web/System.Web/HttpApplication.cs
@@ -1722,7 +1722,7 @@ namespace System.Web
 			if (context.Request.QueryString ["aspxerrorpath"] != null)
 				return false;
 
-			if(error_page.IndexOf('?') < 0)
+			if (error_page.IndexOf ('?') < 0)
 				error_page += "?aspxerrorpath=" + Request.Path;
 
 			Response.Redirect (error_page, false);

--- a/mcs/class/System.Web/System.Web/HttpApplication.cs
+++ b/mcs/class/System.Web/System.Web/HttpApplication.cs
@@ -1722,7 +1722,10 @@ namespace System.Web
 			if (context.Request.QueryString ["aspxerrorpath"] != null)
 				return false;
 
-			Response.Redirect (error_page + "?aspxerrorpath=" + Request.Path, false);
+			if(error_page.IndexOf('?') < 0)
+				error_page += "?aspxerrorpath=" + Request.Path;
+
+			Response.Redirect (error_page, false);
 			return true;
 		}
 							

--- a/mcs/class/System.Web/System.Web/HttpApplication.jvm.cs
+++ b/mcs/class/System.Web/System.Web/HttpApplication.jvm.cs
@@ -1586,7 +1586,7 @@ yield_19:
 			if (context.Request.QueryString ["aspxerrorpath"] != null)
 				return false;
 
-			if(error_page.IndexOf('?') < 0)
+			if (error_page.IndexOf ('?') < 0)
 				error_page += "?aspxerrorpath=" + Request.Path;
 
 			Response.Redirect (error_page, false);

--- a/mcs/class/System.Web/System.Web/HttpApplication.jvm.cs
+++ b/mcs/class/System.Web/System.Web/HttpApplication.jvm.cs
@@ -1586,7 +1586,10 @@ yield_19:
 			if (context.Request.QueryString ["aspxerrorpath"] != null)
 				return false;
 
-			Response.Redirect (error_page + "?aspxerrorpath=" + Request.Path, false);
+			if(error_page.IndexOf('?') < 0)
+				error_page += "?aspxerrorpath=" + Request.Path;
+
+			Response.Redirect (error_page, false);
 			return true;
 		}
 							


### PR DESCRIPTION
Currently, with the following configuration, `error_page` is generated as `~/error.aspx?type=404?aspxerrorpath={REQUEST_PATH}`:

```
<customErrors mode="RemoteOnly" defaultRedirect="~/error.htm">
    <error statusCode="404" redirect="~/error.aspx?type=404" />
    <error statusCode="500" redirect="~/error.aspx?type=500" />
</customErrors>
```

The proposed fix will only append `aspxerrorpath` to the QueryString when a custom QueryString isn't provided.
