### PR TITLE
Disable bug-18026.exe when running tests in the CI environment

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -556,6 +556,7 @@ DISABLED_TESTS=			\
 DISABLED_TESTS_WRENCH=	\
 	$(DISABLED_TESTS)	\
 	$(PLATFORM_DISABLED_TESTS_WRENCH)	\
+	bug-18026.exe	\
 	main-returns-background-resetabort.exe \
 	main-returns-background-abort-resetabort.exe	\
 	thread6.exe	\


### PR DESCRIPTION
The test performed in bug-18026.exe can sometimes fail if the hazard
table gets full. Disabling it in CI testing avoids unwanted noise.

See https://bugzilla.xamarin.com/show_bug.cgi?id=19235
