### PR TITLE
Fix 'make check' when mono is not installed

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -136,6 +136,8 @@ mcs-compileall: mono-wrapper etc/mono/config
       fi; \
 	  if [ "net_3_5" = "$$profile" ]; then \
 		  MONO_PATH="$$mcs_topdir/class/lib/$$profile$(PLATFORM_PATH_SEPARATOR)$$mcs_topdir/class/lib/net_2_0$(PLATFORM_PATH_SEPARATOR)$$save_MONO_PATH"; \
+	  elif [ "xbuild_12" = "$$profile" ]; then \
+		  MONO_PATH="$$mcs_topdir/class/lib/$$profile$(PLATFORM_PATH_SEPARATOR)$$mcs_topdir/class/lib/net_4_5$(PLATFORM_PATH_SEPARATOR)$$save_MONO_PATH"; \
 	  else \
 		  MONO_PATH="$$mcs_topdir/class/lib/$$profile$(PLATFORM_PATH_SEPARATOR)$$save_MONO_PATH"; \
 	  fi; \


### PR DESCRIPTION
When the xbuild_12 profile is verified, the corlib from the net_4_5
profile should be in the MONO_PATH, otherwise the verification will
fail with:

The assembly mscorlib.dll was not found or could not be loaded.
It should have been installed in the `.../mono/4.5/mscorlib.dll' directory.
