### PR TITLE
Allow .NET 4.0 + users to use the ConnectSocket property

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
@@ -82,7 +82,7 @@ namespace System.Net.Sockets
 		public SocketFlags SocketFlags { get; set; }
 		public object UserToken { get; set; }
 		internal Socket curSocket;
-#if NET_2_1
+#if (NET_2_1 || NET_4_0)
 		public Socket ConnectSocket {
 			get {
 				switch (SocketError) {


### PR DESCRIPTION
Should close bug: https://bugzilla.xamarin.com/show_bug.cgi?id=12211

I've a client program that use this property and it is compiling and working with the change
