### PR TITLE
Use mktemp instead of $RANDOM to generate unique names

### DIFF
--- a/mcs/class/monodoc/jay.sh
+++ b/mcs/class/monodoc/jay.sh
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 TOPDIR=$1
 INPUT=$2
 OUTPUT=$3
 FLAGS=$4
 
-TEMPFILE=jay-tmp-$RANDOM.out
+TEMPFILE=`mktemp jay-tmp.XXXXXX` || exit 1
 
 $TOPDIR/jay/jay $FLAGS < $TOPDIR/jay/skeleton.cs $INPUT > $TEMPFILE && mv $TEMPFILE $OUTPUT


### PR DESCRIPTION
Using $RANDOM is not safe because collisions can occur. An example of
such a failure is available here:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/23572639/log.txt

Using mktemp avoids this issue and removes the dependency on bash.
