### PR TITLE
AppSettings 'file' attribute now refers to a path relative to the config...

### DIFF
--- a/mcs/class/System.Configuration/Makefile
+++ b/mcs/class/System.Configuration/Makefile
@@ -7,8 +7,8 @@ LIBRARY = System.Configuration.dll
 
 LOCAL_MCS_FLAGS = -lib:$(secxml_libdir) -lib:$(bare_libdir)
 test_remove = $(LOCAL_MCS_FLAGS)
-LIB_MCS_FLAGS = -r:$(corlib) -r:System.dll -r:System.Xml.dll -r:System.Security.dll -nowarn:618 
-TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) 
+LIB_MCS_FLAGS = -r:$(corlib) -r:System.dll -r:System.Xml.dll -r:System.Security.dll -r:Mono.Posix.dll -nowarn:618
+TEST_MCS_FLAGS = $(LIB_MCS_FLAGS)
 
 include ../../build/library.make
 


### PR DESCRIPTION
...uration file.

Per the '<appSettings>' documentation at http://msdn.microsoft.com/en-us/library/aa903313(v=vs.71).aspx, the 'file' attribute "specifies a relative path to an external file containing custom application configuration settings."

Previous to this commit, the file attribute attempts to load a file based on the current working directory, which is incorrect.  It should be a file path relative to the application's configuration file.  Since on *nix systems this may be a symlink to the .config file, we need to ensure the symlinks are followed on those platforms.
Also, the reading of the file is moved to a using { } block so it will be disposed properly in the event there is an error reading the file.

Since some users may be counting on the ability to specify an absolute path, this behavior continues to be supported.

This change is released under the MIT license.