### PR TITLE
[docs] monodoc style update for blockquote attribution.

### DIFF
--- a/mcs/class/monodoc/Resources/base.css
+++ b/mcs/class/monodoc/Resources/base.css
@@ -39,7 +39,7 @@ div.title {
 	float:right;
 }
 
-div:hover > .attributionlogo,p:hover > .attributionlogo,td:hover > .attributionlogo { 
+div:hover > .attributionlogo,p:hover > .attributionlogo,td:hover > .attributionlogo,blockquote:hover > .attributionlogo { 
 	display:inline; 
 	float:right;
 }


### PR DESCRIPTION
Handles the case for method lists, which are contained in blockquotes. This is a follow up to pull request #1006 after further testing.
