### PR TITLE
Prevent call to OwnerLostFocusHandler for disposed object

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ComboBox.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ComboBox.cs
@@ -2315,7 +2315,16 @@ namespace System.Windows.Forms
 					return owner.Focused;
 				}
 			}
-			
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing ) {
+					// Prevents corruption of combobox text by disposed object
+					owner.EnabledChanged -= OwnerEnabledChangedHandler;
+					owner.LostFocus -= OwnerLostFocusHandler;
+				}
+				base.Dispose(disposing);
+			}
+
 			internal override bool ActivateOnShow { get { return false; } }
 		}
 


### PR DESCRIPTION
bugzilla.xamarin.com bug reference: Bug 19304
ComboBox reverts to original selection when it loses focus.
The LostFocus handler for the internal ComboTextBox class
was being called after it had been disposed.  The dispose
was correctly called when the ComboBoxStyle changed from
it's initial default value to DropDownList.  However, when
the ComboBox control lost focus later on, the LostFocus event handler
was called, which resulted in the Text value for the ComboBox
being overwritten by the value in the disposed object.

Could not see how to write a unit test within the ComboBoxTest.cs
that would simulate losing focus so only providing fix.

Change-Id: I9ca4cc75da5711a7d7c1dd166d5f52d580f44df1
