### PR TITLE
Fix possible NRE if idleTimer is null

### DIFF
--- a/mcs/class/System/System.Net/ServicePoint.cs
+++ b/mcs/class/System/System.Net/ServicePoint.cs
@@ -353,8 +353,11 @@ namespace System.Net
 					groups = null;
 
 				if (firstGroup == null) {
-					idleTimer.Dispose ();
-					idleTimer = null;
+					if (idleTimer != null) {
+						idleTimer.Dispose ();
+						idleTimer = null;
+					}
+
 					return true;
 				}
 


### PR DESCRIPTION
Fixes a possible NRE in ServicePoint if idleTimer is null.

NRE was possibly introduced in commit c6a70a9586971d9d2561933fab47e30cca997e76
