### PR TITLE
[Mono.CodeContracts] Always build debug file for the test assembly

### DIFF
--- a/mcs/class/Mono.CodeContracts/Makefile
+++ b/mcs/class/Mono.CodeContracts/Makefile
@@ -7,6 +7,6 @@ LIBRARY = Mono.CodeContracts.dll
 LIB_MCS_FLAGS = -r:System.dll -r:System.Core.dll -r:Mono.Cecil.dll -r:Mono.Cecil.Mdb.dll 
 #-r:Mono.Cecil.Pdb.dll
 
-TEST_MCS_FLAGS = -r:System.Core.dll
+TEST_MCS_FLAGS = -r:System.Core.dll -debug
 
 include ../../build/library.make


### PR DESCRIPTION
The tests require that the debug file is available, however in the net_4_0 profile this file isn't generated by default.
We now ensure the debug file is always generated for the test assembly.

As discussed on #monodev with @marek-safar
