### PR TITLE
Include inner exception when BeginWrite fails due to exception from Sock...

### DIFF
--- a/mcs/class/System/System.Net.Sockets/NetworkStream.cs
+++ b/mcs/class/System/System.Net.Sockets/NetworkStream.cs
@@ -254,8 +254,8 @@ namespace System.Net.Sockets
 
 			try {
 				retval = s.BeginSend (buffer, offset, size, 0, callback, state);
-			} catch {
-				throw new IOException ("BeginWrite failure");
+			} catch (Exception e) {
+				throw new IOException ("BeginWrite failure", e);
 			}
 
 			return retval;


### PR DESCRIPTION
...et.BeginSend.

Unlike BeginRead, BeginWrite does not include the inner exception. This PR adds the inner exception which may help diagnose bugs like https://bugzilla.xamarin.com/show_bug.cgi?id=19334.
