### PR TITLE
[Mono.Debugger.Soft] Adding caching of ThreadInfo in ThreadMirror

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
@@ -7,6 +7,7 @@ namespace Mono.Debugger.Soft
 	public class ThreadMirror : ObjectMirror
 	{
 		string name;
+		ThreadInfo info;
 
 		internal ThreadMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
@@ -53,8 +54,8 @@ namespace Mono.Debugger.Soft
 
 		public bool IsThreadPoolThread {
 			get {
-				ThreadInfo info = vm.conn.Thread_GetInfo (id);
-
+				if (info == null)
+					info = vm.conn.Thread_GetInfo (id);
 				return info.is_thread_pool;
 			}
 		}


### PR DESCRIPTION
This is part of ongoing optimizations in [Mono.Debugger.Soft] to reduce number of calls during stepping which slow down debugging. I will be making smaller pulls to simplify reviewing.

ThreadInfo currently only has 1 property(IsThreadPool) which doesn't change so there is no need to invalidate it.
