### PR TITLE
[Mono.Debugger.Soft] Caching Assemblies and Types

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AppDomainMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AppDomainMirror.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Mono.Debugger.Soft
 {
@@ -6,6 +7,9 @@ namespace Mono.Debugger.Soft
 	{
 		string friendly_name;
 		AssemblyMirror entry_assembly, corlib;
+		AssemblyMirror[] assemblies;
+		bool assembliesCacheIsInvalid = true;
+		object assembliesCacheLocker = new object ();
 
 		internal AppDomainMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
@@ -19,15 +23,27 @@ namespace Mono.Debugger.Soft
 			}
 	    }
 
-		// Not cached
+		internal void InvalidateAssembliesCache ()
+		{
+			assembliesCacheIsInvalid = true;
+		}
+
 		public AssemblyMirror[] GetAssemblies () {
-			long[] ids = vm.conn.Domain_GetAssemblies (id);
-			AssemblyMirror[] assemblies = new AssemblyMirror [ids.Length];
-			// FIXME: Uniqueness
-			for (int i = 0; i < ids.Length; ++i)
-				assemblies [i] = vm.GetAssembly (ids [i]);
+			if (assembliesCacheIsInvalid) {
+				lock (assembliesCacheLocker) {
+					if (assembliesCacheIsInvalid) {
+						long[] ids = vm.conn.Domain_GetAssemblies (id);
+						assemblies = new AssemblyMirror [ids.Length];
+						// FIXME: Uniqueness
+						for (int i = 0; i < ids.Length; ++i)
+							assemblies [i] = vm.GetAssembly (ids [i]);
+						Thread.MemoryBarrier ();
+						assembliesCacheIsInvalid = false;
+					}
+				}
+			}
 			return assemblies;
-	    }
+		}
 
 		// This returns null when called before the first AssemblyLoad event
 		public AssemblyMirror GetEntryAssembly () {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -655,9 +655,11 @@ namespace Mono.Debugger.Soft
 					break;
 				case EventType.AssemblyLoad:
 					l.Add (new AssemblyLoadEvent (vm, req_id, thread_id, id));
+					vm.GetThread (thread_id).Domain.InvalidateAssembliesCache ();
 					break;
 				case EventType.AssemblyUnload:
 					l.Add (new AssemblyUnloadEvent (vm, req_id, thread_id, id));
+					vm.GetThread (thread_id).Domain.InvalidateAssembliesCache ();
 					break;
 				case EventType.TypeLoad:
 					l.Add (new TypeLoadEvent (vm, req_id, thread_id, id));


### PR DESCRIPTION
I could make single Dictionary<Tuple<string,bool>,TypeMirro> but having two Dictionaries feels better to me...
