### PR TITLE
[runtime] Remove the last bits of mono_dont_free_global_codeman

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -522,7 +522,6 @@ extern int mono_break_at_bb_bb_num;
 extern gboolean check_for_pending_exc;
 extern gboolean disable_vtypes_in_regs;
 extern gboolean mono_verify_all;
-extern gboolean mono_dont_free_global_codeman;
 extern gboolean mono_do_x86_stack_align;
 extern const char *mono_build_date;
 extern gboolean mono_do_signal_chaining;


### PR DESCRIPTION
All uses of the mono_dont_free_global_codeman variable (including its
definition) have been removed in
4a1ae4694a2d4fc06bd1cb02b88dfeeeb8c90630.

Its declaration should be removed as well to keep the codebase clean.
