### PR TITLE
[Jay] Fix memory corruptions: out-of-bounds and uninitialized value.

### DIFF
--- a/mcs/jay/reader.c
+++ b/mcs/jay/reader.c
@@ -874,6 +874,7 @@ expand_items()
     maxitems += 300;
     pitem = (bucket **) REALLOC(pitem, maxitems*sizeof(bucket *));
     if (pitem == 0) no_space();
+    memset(pitem+maxitems-300, 0, 300*sizeof(bucket *));
 }
 
 
@@ -958,6 +959,8 @@ end_rule()
 {
     register int i;
 
+    if (nitems >= maxitems) expand_items();
+
     if (!last_was_action && plhs[nrules]->tag)
     {
 	for (i = nitems - 1; pitem[i]; --i) continue;
@@ -966,7 +969,6 @@ end_rule()
     }					/** bug: could be superclass... **/
 
     last_was_action = 0;
-    if (nitems >= maxitems) expand_items();
     pitem[nitems] = 0;
     ++nitems;
     ++nrules;


### PR DESCRIPTION
Found two memory corruptions in Jay - an out-of-bounds access in end_rule(), and use of uninitialized values in the same function. The uninitialized memory should have been set to 0 when reallocating pitem in expand_items.
The bugs can be triggered by testing with low realloc sizes. First encountered this issue on windows, when using mingw, even with the large realloc sizes.

Here are the error logs from Valgrind and Clang's ASan:
https://gist.github.com/miguelzf/130aef65b65b12d3cf63
https://gist.github.com/miguelzf/c6d0d2dcd47c821eaf6d
