### PR TITLE
When dynamically compiling script with a class with a nested class defin...

### DIFF
--- a/mcs/mcs/eval.cs
+++ b/mcs/mcs/eval.cs
@@ -1233,10 +1233,13 @@ namespace Mono.CSharp
 			if (undo_actions == null)
 				undo_actions = new List<Action> ();
 
-			var existing = current_container.Containers.FirstOrDefault (l => l.Basename == tc.Basename);
-			if (existing != null) {
-				current_container.RemoveContainer (existing);
-				undo_actions.Add (() => current_container.AddTypeContainer (existing));
+			if (current_container.Containers != null)
+			{
+				var existing = current_container.Containers.FirstOrDefault (l => l.Basename == tc.Basename);
+				if (existing != null) {
+					current_container.RemoveContainer (existing);
+					undo_actions.Add (() => current_container.AddTypeContainer (existing));
+				}
 			}
 
 			undo_actions.Add (() => current_container.RemoveContainer (tc));


### PR DESCRIPTION
When dynamically compiling script with a class with a nested class, the collection would be null.

Example:
class test
{
 class asd
 {
 }
}

If I removed class asd from class test, no error.
I looked trough the code and I noticed that the Containers list can be null so a null check seems ok.
