### PR TITLE
[monodoc] removed erroneous instance of 'FOO' string.

### DIFF
--- a/mcs/class/monodoc/Resources/mono-ecma-impl.xsl
+++ b/mcs/class/monodoc/Resources/mono-ecma-impl.xsl
@@ -176,7 +176,7 @@
 
 					<xsl:when test="$show='namespace'">
 						<xsl:value-of select="$namespace"/>
-						<xsl:text> FOO Namespace</xsl:text>
+						<xsl:text> Namespace</xsl:text>
 					</xsl:when>
 					
 					<xsl:when test="$show='overloads'">


### PR DESCRIPTION
This change somehow made it into the repository, but unnecessarily adds a static "FOO Namespace" to every namespace page generated by monodoc.
