### PR TITLE
Make libmono and dependencies compilables with the VC++ compiler

### DIFF
--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -413,11 +413,12 @@ mono_counters_foreach (CountersEnumCallback cb, gpointer user_data)
 	}
 }
 
-#define COPY_COUNTER(type,functype) do {	\
+#define COPY_COUNTER(type,functype) do { \
+		type __var; \
 		size = sizeof (type);	\
 		if (buffer_size < size)	\
-			return -1;	\
-		type __var = cb ? ((functype)counter->addr) () : *(type*)counter->addr;	\
+		return -1;	\
+		__var = cb ? ((functype)counter->addr) () : *(type*)counter->addr;	\
 		memcpy (buffer, &__var, size);	\
 	} while (0);
 


### PR DESCRIPTION
__var needs to be declared at the beginning of the code block, at least for typedef types, otherwise error C2275: 'guint' : illegal use of this type as an expression. Looks like a MSVC bug.

After this change, I can compile the libmono.vcxproj project and its 5 dependencies.
