### PR TITLE
Fix building mono with icc

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -222,7 +222,8 @@ typedef struct {
 		"movq %%r13, 0x68(%0)\n"	\
 		"movq %%r14, 0x70(%0)\n"	\
 		"movq %%r15, 0x78(%0)\n"	\
-		"leaq (%%rip), %%rdx\n"	\
+		/* "leaq (%%rip), %%rdx\n" is not understood by icc */	\
+		".byte 0x48, 0x8d, 0x15, 0x00, 0x00, 0x00, 0x00\n" \
 		"movq %%rdx, 0x80(%0)\n"	\
 		: 	\
 		: "a" (&(ctx))	\


### PR DESCRIPTION
When compiling mono with icc (ICC) 14.0.0 20130728 the build fails on

  CC     libmonoruntimesgen_la-sgen-stw.lo

with the following error:

Assembler messages:
Error: suffix or operands invalid for `lea'

Apparently icc (or the assembler) dislikes the rip-based LEA
operation. This can be worked around by manually assembling the
instruction and replacing it with the corresponding byte sequence.
