### PR TITLE
Fix checking when libgdi is configured as "sibling"

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -170,7 +170,7 @@ etc/mono/config: ../data/config Makefile $(symlinks)
 	d=`cd ../support && pwd`; \
 	sed 's,target="libMonoPosixHelper[^"]*",target="'$$d/libMonoPosixHelper.la'",' ../data/config > $@t
 	if test -z "$(libgdiplus_loc)"; then :; else \
-	  sed 's,<configuration>,& <dllmap dll="gdiplus.dll" target="$(libgdiplus_loc)" os="!windows"/>,' $@t > $@tt; \
+	  sed 's,target="[^"]*libgdiplus[^"]*",target="$(libgdiplus_loc)",' $@t > $@tt; \
 	  mv -f $@tt $@t; fi
 	mv -f $@t $@
 


### PR DESCRIPTION
When libgdiplus is configured as sibling, it is available in the
libgdiplus_loc path. This path was added to runtime/mono/config, but
it was later overridden by the prefix-based path.

Using the same approach as for libMonoPosixHelper fixed the lookup of
the library (performed, for example, when testing
MonoTests.System.Drawing without installing libgdiplus).

This change is released under the MIT license.
