### PR TITLE
Specify path to Mono.Security.dll when building System.dll.

### DIFF
--- a/mcs/class/Mono.Security/Makefile
+++ b/mcs/class/Mono.Security/Makefile
@@ -3,9 +3,9 @@ SUBDIRS =
 include ../../build/rules.make
 
 LIBRARY = Mono.Security.dll
-LOCAL_MCS_FLAGS = -lib:$(the_libdir_base)bare
-LIB_MCS_FLAGS = -r:System.dll -unsafe -nowarn:1030 
-TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) -nowarn:169,219,618,672
+LIB_MCS_FLAGS = -r:$(the_libdir_base)bare/System.dll
+LOCAL_MCS_FLAGS = -r:$(corlib) -unsafe -nowarn:1030 
+TEST_MCS_FLAGS = -r:System.dll -nowarn:169,219,618,672
 
 include ../../build/library.make
 

--- a/mcs/class/System.Configuration/Makefile
+++ b/mcs/class/System.Configuration/Makefile
@@ -5,10 +5,9 @@ include ../../build/rules.make
 
 LIBRARY = System.Configuration.dll
 
-LOCAL_MCS_FLAGS = -lib:$(secxml_libdir) -lib:$(bare_libdir)
-test_remove = $(LOCAL_MCS_FLAGS)
-LIB_MCS_FLAGS = -r:$(corlib) -r:System.dll -r:System.Xml.dll -r:System.Security.dll -nowarn:618 
-TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) 
+LIB_MCS_FLAGS = -r:$(bare_libdir)/System.Xml.dll -r:$(secxml_libdir)/System.dll
+LOCAL_MCS_FLAGS = -r:$(corlib) -r:$(the_libdir_base)System.Security.dll -nowarn:618 
+TEST_MCS_FLAGS = -r:System.dll -r:System.Xml.dll
 
 include ../../build/library.make
 

--- a/mcs/class/System.Core/Makefile
+++ b/mcs/class/System.Core/Makefile
@@ -4,7 +4,7 @@ include ../../build/rules.make
 
 LIBRARY = System.Core.dll
 
-LIB_MCS_FLAGS = -d:INSIDE_SYSCORE -d:LIBC /r:System.dll -unsafe
+LIB_MCS_FLAGS = -d:INSIDE_SYSCORE -d:LIBC -r:$(corlib) -r:$(the_libdir_base)System.dll -unsafe
 
 ifneq (2.1, $(FRAMEWORK_VERSION))
 LIB_MCS_FLAGS += -d:NET_3_5 -nowarn:1720

--- a/mcs/class/System.Security/Makefile
+++ b/mcs/class/System.Security/Makefile
@@ -3,14 +3,14 @@ SUBDIRS =
 include ../../build/rules.make
 
 LIBRARY = System.Security.dll
-LIB_MCS_FLAGS = -nowarn:618 \
+LOCAL_MCS_FLAGS = -nowarn:618 \
 	-d:SECURITY_DEP \
-	-r:$(corlib) -r:System.dll -r:System.Xml.dll \
-	-r:Mono.Security.dll -nowarn:414
+	-r:$(corlib) \
+	-r:$(the_libdir_base)Mono.Security.dll -nowarn:414
 
-LOCAL_MCS_FLAGS = -lib:$(secxml_libdir) -lib:$(bare_libdir)
+LIB_MCS_FLAGS = -r:$(secxml_libdir)/System.dll -r:$(bare_libdir)/System.Xml.dll
 
-TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) -nowarn:168,169,183,219,414,1595
+TEST_MCS_FLAGS = -r:System.dll -r:System.Xml.dll -nowarn:168,169,183,219,414,1595
 
 VALID_PROFILE := $(filter net_1_1 net_2_0 moonlight_raw net_4_0 net_4_5, $(PROFILE))
 

--- a/mcs/class/System.XML/Makefile
+++ b/mcs/class/System.XML/Makefile
@@ -15,11 +15,11 @@ endif
 
 PROFILE_ANY_MOBILE := $(filter monotouch monotouch_runtime monodroid xammac, $(PROFILE))
 
-LIB_MCS_FLAGS = -r:$(corlib) -r:System.dll -nowarn:0618,0612,0642
+LOCAL_MCS_FLAGS = -r:$(corlib) -nowarn:0618,0612,0642
 ifeq (2.1, $(FRAMEWORK_VERSION))
-LIB_MCS_FLAGS += -unsafe -d:AGCLR -d:NET_2_1_HACK
+LOCAL_MCS_FLAGS += -unsafe -d:AGCLR -d:NET_2_1_HACK
 endif
-TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) -nowarn:0618 -nowarn:219 -nowarn:169 -r:System.Data.dll -r:System.Core.dll
+TEST_MCS_FLAGS = -r:System.dll -nowarn:0618 -nowarn:219 -nowarn:169 -r:System.Data.dll -r:System.Core.dll
 
 ifndef PROFILE_ANY_MOBILE
 FINAL_MCS_FLAGS = -r:System.Configuration.dll -d:CONFIGURATION_DEP
@@ -29,7 +29,7 @@ ifneq (bare/,$(intermediate))
 LIB_MCS_FLAGS += $(FINAL_MCS_FLAGS)
 endif
 
-LOCAL_MCS_FLAGS += -lib:$(bare_libdir)
+LIB_MCS_FLAGS += -r:$(bare_libdir)/System.dll
 
 nist_dom_files = \
 	ChangeLog ITest.cs readme.txt util.cs \

--- a/mcs/class/System/Makefile
+++ b/mcs/class/System/Makefile
@@ -48,15 +48,17 @@ endif
 #
 ifeq (secxml/, $(intermediate))
 LOCAL_MCS_FLAGS = -lib:$(bare_libdir) 
-LIB_MCS_FLAGS += -d:SECURITY_DEP -d:XML_DEP -r:PrebuiltSystem=$(bare_libdir)/System.dll -r:System.Xml.dll -r:MonoSecurity=Mono.Security.dll
+LIB_MCS_FLAGS += -d:SECURITY_DEP -d:XML_DEP -r:PrebuiltSystem=$(bare_libdir)/System.dll -r:$(bare_libdir)/System.Xml.dll -r:MonoSecurity=$(the_libdir_base)Mono.Security.dll
 endif
 
 #
 # Flags used to build the final version of System (when intermediate is not defined)
 #
 ifndef intermediate
-LIB_MCS_FLAGS += -d:SECURITY_DEP -d:XML_DEP -r:PrebuiltSystem=$(secxml_libdir)/System.dll -r:System.Xml.dll -r:MonoSecurity=Mono.Security.dll $(FINAL_MCS_FLAGS)
+LIB_MCS_FLAGS += -d:SECURITY_DEP -d:XML_DEP -r:PrebuiltSystem=$(secxml_libdir)/System.dll -r:$(the_libdir_base)System.Xml.dll -r:MonoSecurity=$(the_libdir_base)Mono.Security.dll $(FINAL_MCS_FLAGS)
 endif
+
+LIB_MCS_FLAGS += -r:$(corlib)
 
 EXTRA_DISTFILES = \
 	System.Text.RegularExpressions/notes.txt	\


### PR DESCRIPTION
This fixes build errors caused by having an old Mono.Security.dll in the GAC.