### PR TITLE
Don't define _XOPEN_SOURCE on OpenBSD.

### DIFF
--- a/support/sys-mman.c
+++ b/support/sys-mman.c
@@ -9,7 +9,9 @@
 
 #include <config.h>
 
+#ifndef __OpenBSD__
 #define _XOPEN_SOURCE 600
+#endif
 
 #ifdef PLATFORM_MACOSX
 /* For mincore () */


### PR DESCRIPTION
mincore() is defined in <sys/mman.h> as a __BSD_VISIBLE API and if _XOPEN_SOURCE is defined this turns off __BSD_VISIBLE APIs.

Not defining _XOPEN_SOURCE turns on __BSD_VISIBLE by default so __BSD_VISIBLE doesn't need to be defined.
