### PR TITLE
Fix the build on Visual C++

### DIFF
--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -417,8 +417,7 @@ mono_counters_foreach (CountersEnumCallback cb, gpointer user_data)
 		size = sizeof (type);	\
 		if (buffer_size < size)	\
 			return -1;	\
-		type __var = cb ? ((functype)counter->addr) () : *(type*)counter->addr;	\
-		memcpy (buffer, &__var, size);	\
+		*(type*)buffer = cb ? ((functype)counter->addr) () : *(type*)counter->addr; \
 	} while (0);
 
 int


### PR DESCRIPTION
Visual C++ does not support intermixed declarations and code and
errors out with:
error C2275: 'guint' : illegal use of this type as an expression

This also silences gcc/clang warnings such as:
mono-counters.c:xxx:3: warning: ISO C90 forbids mixing declarations
and code

In this case this can be fixed easily by skipping the intermediate
variable.

Based on pull request #1043 by J-M jean-michel.perraud@csiro.au

This change is released under the MIT license.
