### PR TITLE
[Mono.Security] Added Encode to AuthorityKeyIdentifierExtension and Subj...

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security-tests-net_2_0.csproj
+++ b/mcs/class/Mono.Security/Mono.Security-tests-net_2_0.csproj
@@ -75,10 +75,12 @@
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type1MessageTest.cs" />
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type2MessageTest.cs" />
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type3MessageTest.cs" />
+    <Compile Include="Test\Mono.Security.X509.Extensions\AuthorityKeyIdentifierExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\BasicConstraintsExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\ExtendedKeyUsageExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\KeyUsageExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\SubjectAltNameExtensionTest.cs" />
+    <Compile Include="Test\Mono.Security.X509.Extensions\SubjectKeyIdentifierExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509\PKCS12Test.cs" />
     <Compile Include="Test\Mono.Security.X509\X501NameTest.cs" />
     <Compile Include="Test\Mono.Security.X509\X509CertificateTest.cs" />

--- a/mcs/class/Mono.Security/Mono.Security-tests-net_4_0.csproj
+++ b/mcs/class/Mono.Security/Mono.Security-tests-net_4_0.csproj
@@ -75,10 +75,12 @@
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type1MessageTest.cs" />
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type2MessageTest.cs" />
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type3MessageTest.cs" />
+    <Compile Include="Test\Mono.Security.X509.Extensions\AuthorityKeyIdentifierExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\BasicConstraintsExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\ExtendedKeyUsageExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\KeyUsageExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\SubjectAltNameExtensionTest.cs" />
+    <Compile Include="Test\Mono.Security.X509.Extensions\SubjectKeyIdentifierExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509\PKCS12Test.cs" />
     <Compile Include="Test\Mono.Security.X509\X501NameTest.cs" />
     <Compile Include="Test\Mono.Security.X509\X509CertificateTest.cs" />

--- a/mcs/class/Mono.Security/Mono.Security-tests-net_4_5.csproj
+++ b/mcs/class/Mono.Security/Mono.Security-tests-net_4_5.csproj
@@ -75,10 +75,12 @@
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type1MessageTest.cs" />
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type2MessageTest.cs" />
     <Compile Include="Test\Mono.Security.Protocol.Ntlm\Type3MessageTest.cs" />
+    <Compile Include="Test\Mono.Security.X509.Extensions\AuthorityKeyIdentifierExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\BasicConstraintsExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\ExtendedKeyUsageExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\KeyUsageExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509.Extensions\SubjectAltNameExtensionTest.cs" />
+    <Compile Include="Test\Mono.Security.X509.Extensions\SubjectKeyIdentifierExtensionTest.cs" />
     <Compile Include="Test\Mono.Security.X509\PKCS12Test.cs" />
     <Compile Include="Test\Mono.Security.X509\X501NameTest.cs" />
     <Compile Include="Test\Mono.Security.X509\X509CertificateTest.cs" />

--- a/mcs/class/Mono.Security/Mono.Security.X509.Extensions/AuthorityKeyIdentifierExtension.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509.Extensions/AuthorityKeyIdentifierExtension.cs
@@ -85,8 +85,8 @@ namespace Mono.Security.X509.Extensions {
 		protected override void Encode ()
 		{
 			ASN1 seq = new ASN1 (0x30);
-			if (Identifier == null) {
-				throw new ArgumentException ("Invalid AuthorityKeyIdentifier extension");
+			if (aki == null) {
+				throw new InvalidOperationException ("Invalid AuthorityKeyIdentifier extension");
 			}
 
 			seq.Add (new ASN1 (0x80, aki));

--- a/mcs/class/Mono.Security/Mono.Security.X509.Extensions/SubjectKeyIdentifierExtension.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509.Extensions/SubjectKeyIdentifierExtension.cs
@@ -77,8 +77,8 @@ namespace Mono.Security.X509.Extensions {
 
 		protected override void Encode ()
 		{
-			if (Identifier == null) {
-				throw new ArgumentException ("Invalid SubjectKeyIdentifier extension");
+			if (ski == null) {
+				throw new InvalidOperationException ("Invalid SubjectKeyIdentifier extension");
 			}
 
 			var seq = new ASN1 (0x04, ski);

--- a/mcs/class/Mono.Security/Test/Mono.Security.X509.Extensions/AuthorityKeyIdentifierExtensionTest.cs
+++ b/mcs/class/Mono.Security/Test/Mono.Security.X509.Extensions/AuthorityKeyIdentifierExtensionTest.cs
@@ -1,0 +1,122 @@
+﻿//
+// AuthorityKeyIdentifierExtensionTest.cs - NUnit Test Cases for 
+//	Mono.Security.X509.Extensions.AuthorityKeyIdentifierExtension
+//
+// Authors:
+//	Lex Li  <support@lextm.com>
+//
+// Copyright (C) 2014 Lex Li
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using Mono.Security.X509.Extensions;
+using NUnit.Framework;
+
+namespace MonoTests.Mono.Security.X509.Extensions
+{
+	[TestFixture]
+	public class AuthorityKeyIdentifierExtensionTest
+	{
+		private void Empty (AuthorityKeyIdentifierExtension aki)
+		{
+			Assert.IsFalse (aki.Critical, "Critical");
+			Assert.AreEqual ("2.5.29.35", aki.Oid, "Oid");
+			Assert.IsNotNull (aki.Name, "Name");
+			Assert.IsFalse (aki.Name == aki.Oid, "Name!=Oid");
+			Assert.AreEqual (new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			}, aki.Identifier, "Identifier");
+		}
+
+		[Test]
+		public void Constructor_Empty ()
+		{
+			AuthorityKeyIdentifierExtension aki = new AuthorityKeyIdentifierExtension ();
+			aki.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			Empty (aki);
+		}
+
+		[Test]
+		public void Constructor_Extension ()
+		{
+			AuthorityKeyIdentifierExtension ext = new AuthorityKeyIdentifierExtension ();
+			ext.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			AuthorityKeyIdentifierExtension aki = new AuthorityKeyIdentifierExtension (ext);
+			Empty (aki);
+		}
+
+		[Test]
+		public void Constructor_ASN1 ()
+		{
+			AuthorityKeyIdentifierExtension ext = new AuthorityKeyIdentifierExtension ();
+			ext.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			AuthorityKeyIdentifierExtension aki = new AuthorityKeyIdentifierExtension (ext.ASN1);
+			Empty (aki);
+		}
+
+		[Test]
+		public void AuthorityKeyIdentifier_Critical ()
+		{
+			AuthorityKeyIdentifierExtension aki = new AuthorityKeyIdentifierExtension ();
+			aki.Critical = true;
+			aki.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			Assert.AreEqual ("30-22-06-03-55-1D-23-01-01-FF-04-18-30-16-80-14-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", BitConverter.ToString (aki.GetBytes ()), "GetBytes");
+
+			AuthorityKeyIdentifierExtension aki2 = new AuthorityKeyIdentifierExtension (aki.ASN1);
+			Assert.IsTrue (aki2.Critical, "Critical");
+			Assert.AreEqual (new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			}, aki2.Identifier, "Identifier");
+		}
+
+		[Test]
+		[ExpectedException (typeof(InvalidOperationException))]
+		public void EmptyIdentifier ()
+		{
+			AuthorityKeyIdentifierExtension ext = new AuthorityKeyIdentifierExtension ();
+			AuthorityKeyIdentifierExtension aki = new AuthorityKeyIdentifierExtension (ext);
+			Empty (aki);
+		}
+	}
+}

--- a/mcs/class/Mono.Security/Test/Mono.Security.X509.Extensions/SubjectKeyIdentifierExtensionTest.cs
+++ b/mcs/class/Mono.Security/Test/Mono.Security.X509.Extensions/SubjectKeyIdentifierExtensionTest.cs
@@ -1,0 +1,122 @@
+﻿//
+// SubjectKeyIdentifierExtensionTest.cs - NUnit Test Cases for 
+//	Mono.Security.X509.Extensions.SubjectKeyIdentifierExtension
+//
+// Authors:
+//	Lex Li  <support@lextm.com>
+//
+// Copyright (C) 2014 Lex Li
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using Mono.Security.X509.Extensions;
+using NUnit.Framework;
+
+namespace MonoTests.Mono.Security.X509.Extensions
+{
+	[TestFixture]
+	public class SubjectKeyIdentifierExtensionTest
+	{
+		private void Empty (SubjectKeyIdentifierExtension ski)
+		{
+			Assert.IsFalse (ski.Critical, "Critical");
+			Assert.AreEqual ("2.5.29.14", ski.Oid, "Oid");
+			Assert.IsNotNull (ski.Name, "Name");
+			Assert.IsFalse (ski.Name == ski.Oid, "Name!=Oid");
+			Assert.AreEqual (new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			}, ski.Identifier, "Identifier");
+		}
+
+		[Test]
+		public void Constructor_Empty ()
+		{
+			SubjectKeyIdentifierExtension ski = new SubjectKeyIdentifierExtension ();
+			ski.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			Empty (ski);
+		}
+
+		[Test]
+		public void Constructor_Extension ()
+		{
+			SubjectKeyIdentifierExtension ext = new SubjectKeyIdentifierExtension ();
+			ext.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			SubjectKeyIdentifierExtension ski = new SubjectKeyIdentifierExtension (ext);
+			Empty (ski);
+		}
+
+		[Test]
+		public void Constructor_ASN1 ()
+		{
+			SubjectKeyIdentifierExtension ext = new SubjectKeyIdentifierExtension ();
+			ext.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			SubjectKeyIdentifierExtension ski = new SubjectKeyIdentifierExtension (ext.ASN1);
+			Empty (ski);
+		}
+
+		[Test]
+		public void AuthorityKeyIdentifier_Critical ()
+		{
+			SubjectKeyIdentifierExtension ski = new SubjectKeyIdentifierExtension ();
+			ski.Critical = true;
+			ski.Identifier = new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			};
+			Assert.AreEqual ("30-20-06-03-55-1D-0E-01-01-FF-04-16-04-14-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", BitConverter.ToString (ski.GetBytes ()), "GetBytes");
+
+			SubjectKeyIdentifierExtension ski2 = new SubjectKeyIdentifierExtension (ski.ASN1);
+			Assert.IsTrue (ski2.Critical, "Critical");
+			Assert.AreEqual (new byte[] {
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00
+			}, ski2.Identifier, "Identifier");
+		}
+
+		[Test]
+		[ExpectedException (typeof(InvalidOperationException))]
+		public void EmptyIdentifier ()
+		{
+			SubjectKeyIdentifierExtension ext = new SubjectKeyIdentifierExtension ();
+			SubjectKeyIdentifierExtension ski = new SubjectKeyIdentifierExtension (ext);
+			Empty (ski);
+		}
+	}
+}


### PR DESCRIPTION
When trying to create new certificates via `X509CertificateBuilder` it is very important to have AuthorityKeyIdentifier and SubjectKeyIdentifier extensions configurable.

This pull request implements the required `Encode` methods of two classes and have been verified to be working.

I cannot build the .Tests project and that's why no unit test case is attached.
