### PR TITLE
Fix config paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -649,18 +649,6 @@ if test "x$USE_NLS" = "xyes"; then
    fi
 fi
 
-AC_ARG_WITH([libgdiplus], 
-	[  --with-libgdiplus=installed|sibling|<path>	Override the libgdiplus used for System.Drawing tests (defaults to installed)], 
-	[], [with_libgdiplus=installed])
-
-case $with_libgdiplus in
-no|installed) libgdiplus_loc= ;;
-yes|sibling) libgdiplus_loc=`cd ../libgdiplus && pwd`/src/libgdiplus.la ;;
-/*) libgdiplus_loc=$with_libgdiplus ;;
-*) libgdiplus_loc=`pwd`/$with_libgdiplus ;;
-esac
-AC_SUBST([libgdiplus_loc])
-
 AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
 
 pkg_config_path=
@@ -3005,6 +2993,33 @@ esac
 
 
 AC_SUBST(libsuffix)
+
+AC_ARG_WITH([libgdiplus],
+	[  --with-libgdiplus=installed|sibling|<path>	Override the libgdiplus used for System.Drawing tests (defaults to installed)],
+	[], [with_libgdiplus=installed])
+
+# default install location
+libgdiplus_install_loc=libgdiplus${libsuffix}
+case $with_libgdiplus in
+    no|installed)
+    libgdiplus_loc=
+    ;;
+
+    yes|sibling)
+    libgdiplus_loc=`cd ../libgdiplus && pwd`/src/libgdiplus.la
+    ;;
+
+    /*) # absolute path, assume it is an install location
+    libgdiplus_loc=$with_libgdiplus
+    libgdiplus_install_loc=$with_libgdiplus
+    ;;
+
+    *)
+    libgdiplus_loc=`pwd`/$with_libgdiplus
+    ;;
+esac
+AC_SUBST([libgdiplus_loc])
+AC_SUBST([libgdiplus_install_loc])
 
 AC_ARG_ENABLE(icall-symbol-map,[  --enable-icall-symbol-map Generate tables which map icall functions to their C symbols], icall_symbol_map=$enableval, icall_symbol_map=no)
 if test "x$icall_symbol_map" = "xyes"; then

--- a/data/config.in
+++ b/data/config.in
@@ -29,8 +29,8 @@
 		<dllentry dll="__Internal" name="MoveMemory" target="mono_win32_compat_MoveMemory"/>
 		<dllentry dll="__Internal" name="ZeroMemory" target="mono_win32_compat_ZeroMemory"/>
 	</dllmap>
-	<dllmap dll="gdiplus" target="@prefix@/lib/libgdiplus@libsuffix@" os="!windows"/>
-	<dllmap dll="gdiplus.dll" target="@prefix@/lib/libgdiplus@libsuffix@"  os="!windows"/>
-	<dllmap dll="gdi32" target="@prefix@/lib/libgdiplus@libsuffix@" os="!windows"/>
-	<dllmap dll="gdi32.dll" target="@prefix@/lib/libgdiplus@libsuffix@" os="!windows"/>
+	<dllmap dll="gdiplus" target="@libgdiplus_install_loc@" os="!windows"/>
+	<dllmap dll="gdiplus.dll" target="@libgdiplus_install_loc@"  os="!windows"/>
+	<dllmap dll="gdi32" target="@libgdiplus_install_loc@" os="!windows"/>
+	<dllmap dll="gdi32.dll" target="@libgdiplus_install_loc@" os="!windows"/>
 </configuration>

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -170,7 +170,7 @@ etc/mono/config: ../data/config Makefile $(symlinks)
 	d=`cd ../support && pwd`; \
 	sed 's,target="$(prefix)/lib/libMonoPosixHelper$(libsuffix)",target="'$$d'/libMonoPosixHelper.la",' ../data/config > $@t
 	if test -z "$(libgdiplus_loc)"; then :; else \
-	  sed 's,target="[^"]*libgdiplus[^"]*",target="$(libgdiplus_loc)",' $@t > $@tt; \
+	  sed 's,target="$(libgdiplus_install_loc)",target="$(libgdiplus_loc)",' $@t > $@tt; \
 	  mv -f $@tt $@t; fi
 	mv -f $@t $@
 


### PR DESCRIPTION
This patchset should improve the handling of the paths for libgdiplus (by making it more consistent with that of other external libraries, yet preserving the possibility of building & testing Mono with a sibling non-installed libgdiplus) and for libMonoPosixHelper (in particular, fixing https://bugzilla.xamarin.com/show_bug.cgi?id=18555 )
