### PR TITLE
Print the correct GC type if compiling using --with-gc=none.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1087,6 +1087,7 @@ case "x$gc" in
 		AC_MSG_WARN("Compiling mono without GC.")
 		AC_DEFINE_UNQUOTED(DEFAULT_GC_NAME, "none", [GC description])
 		AC_DEFINE(HAVE_NULL_GC,1,[No GC support.])
+		gc_msg="none"
 		;;
 	*)
 		AC_MSG_ERROR([Invalid argument to --with-gc.])


### PR DESCRIPTION
If --with-gc=none is specified tell the user that in the printed GC message instead of confusingly saying that the GC is "included Boehm".
