### PR TITLE
Allow building with null-gc and sgen.

### DIFF
--- a/mono/metadata/Makefile.am.in
+++ b/mono/metadata/Makefile.am.in
@@ -86,6 +86,9 @@ libmonoruntime_static_la_LIBADD = $(bundle_obj) $(libmonoruntime_la_LIBADD)
 null_sources = \
 	console-null.c
 
+null_gc_sources = \
+	null-gc.c
+
 common_sources = \
 	$(platform_sources)	\
 	assembly.c		\
@@ -159,7 +162,6 @@ common_sources = \
 	monitor.h		\
 	nacl-stub.c		\
 	normalization-tables.h	\
-	null-gc.c		\
 	number-formatter.h	\
 	object-internals.h	\
 	opcodes.c		\
@@ -262,7 +264,7 @@ sgen_sources = \
 	sgen-qsort.c	\
 	sgen-qsort.h
 
-libmonoruntime_la_SOURCES = $(common_sources) $(gc_dependent_sources) $(boehm_sources)
+libmonoruntime_la_SOURCES = $(common_sources) $(gc_dependent_sources) $(null_gc_sources) $(boehm_sources)
 libmonoruntime_la_CFLAGS = $(BOEHM_DEFINES)
 
 libmonoruntimesgen_la_SOURCES = $(common_sources) $(gc_dependent_sources) $(sgen_sources)


### PR DESCRIPTION
Previously if --with-gc=none --with-sgen=yes was specified the sgen runtime
would include the null GC and the sgen GC which would confuse the linker.
