### PR TITLE
Null Exception in System.Security.Claims

### DIFF
--- a/mcs/class/corlib/System.Security.Claims/ClaimsIdentity.cs
+++ b/mcs/class/corlib/System.Security.Claims/ClaimsIdentity.cs
@@ -97,8 +97,10 @@ namespace System.Security.Claims {
 				foreach (var c in ci.Claims)
 					this.claims.Add (c);
 				
-				foreach (var c in claims)
-					this.claims.Add (c);
+				if (claims != null) {
+					foreach (var c in claims)
+						this.claims.Add (c);
+				}
 				Label = ci.Label;
 				NameClaimType = ci.NameClaimType;
 				RoleClaimType = ci.RoleClaimType;

--- a/mcs/class/corlib/System.Security.Claims/ClaimsPrincipal.cs
+++ b/mcs/class/corlib/System.Security.Claims/ClaimsPrincipal.cs
@@ -66,7 +66,9 @@ namespace System.Security.Claims {
 		{
 			if (identity == null)
 				throw new ArgumentNullException ("identity");
-			// TODO
+
+			identities = new List<ClaimsIdentity> ();
+			identities.Add (new ClaimsIdentity (identity))
 		}
 
 		public ClaimsPrincipal (IPrincipal principal)


### PR DESCRIPTION
This fixed a runtime exception when trying to get a ClaimsPrincipal from an IIdentity. Noticed this work working with aspnet Identity in a Web Api 2 controller. Exception fired when running User.Identity.IsAuthenticated.

Exception detail:
http://falk.pw:7777/tocehuhemo.xml
