### PR TITLE
Allow CLR binaries to be passed to Process.Start

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -400,7 +400,8 @@ BASE_TEST_CS_SRC=		\
 	unload-appdomain-on-shutdown.cs	\
 	block_guard_restore_aligment_on_exit.cs	\
 	thread_static_gc_layout.cs \
-	sleep.cs
+	sleep.cs \
+	bug-17537.cs
 
 TEST_CS_SRC_DIST=	\
 	$(BASE_TEST_CS_SRC)	\
@@ -1187,6 +1188,14 @@ bug-382986-lib.dll: bug-382986-lib.cs
 	$(MCS) -target:library -out:$@ $(srcdir)/bug-382986-lib.cs
 bug-382986.exe: bug-382986.cs bug-382986-lib.dll
 	$(MCS) -out:$@ -r:bug-382986-lib.dll $(srcdir)/bug-382986.cs
+
+EXTRA_DIST += bug-17537-helper.cs
+bug-17537-helper.exe: bug-17537-helper.cs
+	$(MCS) -out:$@ $(srcdir)/bug-17537-helper.cs
+	chmod -x $@
+
+bug-17537.exe: bug-17537.cs bug-17537-helper.exe
+	$(MCS) -out:$@ $(srcdir)/bug-17537.cs
 
 EXTRA_DIST += coreclr-security.cs
 

--- a/mono/tests/bug-17537-helper.cs
+++ b/mono/tests/bug-17537-helper.cs
@@ -1,0 +1,10 @@
+using System;
+using System.IO;
+
+public class Test {
+	public static int Main(string[] args)
+	{
+		Console.WriteLine ("Hello from bug-17537-helper!");
+		return 0;
+	}
+}

--- a/mono/tests/bug-17537.cs
+++ b/mono/tests/bug-17537.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Diagnostics;
+
+public class Test {
+	public static int Main(string[] args)
+	{
+		// Only run this test on Unix
+		int pl = (int) Environment.OSVersion.Platform;
+		if ((pl != 4) && (pl != 6) && (pl != 128)) {
+			return 0;
+		}
+
+		// Try to invoke the helper assembly
+		// Return 0 only if it is successful
+		try
+		{
+			var name = "bug-17537-helper.exe";
+			Console.WriteLine ("Launching subprocess: {0}", name);
+			var p = new Process();
+			p.StartInfo.FileName = Path.Combine (AppDomain.CurrentDomain.BaseDirectory + name);
+			p.StartInfo.UseShellExecute = false;
+
+			var result = p.Start();
+			p.WaitForExit(1000);
+			if (result) {
+				Console.WriteLine ("Subprocess started successfully");
+				return 0;
+			} else {
+				Console.WriteLine ("Subprocess failure");
+				return 1;
+			}
+		}
+		catch (Exception e)
+		{
+			Console.WriteLine ("Subprocess exception");
+			Console.WriteLine (e.Message);
+			return 1;
+		}
+	}
+}


### PR DESCRIPTION
Even if they are not executable
