### PR TITLE
- ADDED: Support to read out Interface flags on OS X

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/MacOsNetworkInterfaceMarshal.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/MacOsNetworkInterfaceMarshal.cs
@@ -79,4 +79,23 @@ namespace System.Net.NetworkInformation {
 		LOOPBACK = 0x18,
 		FDDI = 0xf
 	}
+
+	internal enum MacOsInterfaceFlags {
+		IFF_UP = 0x1,				/* interface is up */
+		IFF_BROADCAST = 0x2,		/* broadcast address valid */
+		IFF_DEBUG = 0x4,			/* turn on debugging */
+		IFF_LOOPBACK = 0x8,			/* is a loopback net */
+		IFF_POINTOPOINT = 0x10,		/* interface is point-to-point link */
+		IFF_NOTRAILERS = 0x20,		/* avoid use of trailers */
+		IFF_RUNNING = 0x40,			/* resources allocated */
+		IFF_NOARP = 0x80,			/* no address resolution protocol */
+		IFF_PROMISC = 0x100,		/* receive all packets */
+		IFF_ALLMULTI = 0x200,		/* receive all multicast packets */
+		IFF_OACTIVE = 0x400,		/* transmission in progress */
+		IFF_SIMPLEX = 0x800,		/* can't hear own transmissions */
+		IFF_LINK0 = 0x1000,			/* per link layer defined bit */
+		IFF_LINK1 = 0x2000,			/* per link layer defined bit */
+		IFF_LINK2 = 0x4000,			/* per link layer defined bit */
+		IFF_MULTICAST = 0x8000		/* supports multicast */
+	}
 }

--- a/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
@@ -446,6 +446,8 @@ namespace System.Net.NetworkInformation {
 		const int AF_INET  = 2;
 		const int AF_INET6 = 30;
 		const int AF_LINK  = 18;
+
+		private uint _ifa_flags;
 		
 		public static NetworkInterface [] ImplGetAllNetworkInterfaces ()
 		{
@@ -465,6 +467,7 @@ namespace System.Net.NetworkInformation {
 					NetworkInterfaceType type = NetworkInterfaceType.Unknown;
 
 					if (addr.ifa_addr != IntPtr.Zero) {
+						// optain IPAddress
 						MacOsStructs.sockaddr sockaddr = (MacOsStructs.sockaddr) Marshal.PtrToStructure (addr.ifa_addr, typeof (MacOsStructs.sockaddr));
 
 						if (sockaddr.sa_family == AF_INET6) {
@@ -478,7 +481,10 @@ namespace System.Net.NetworkInformation {
 							sockaddrdl.Read (addr.ifa_addr);
 
 							macAddress = new byte [(int) sockaddrdl.sdl_alen];
+							// copy mac address from sdl_data field starting at last index pos of interface name into array macaddress, starting
+							// at index 0
 							Array.Copy (sockaddrdl.sdl_data, sockaddrdl.sdl_nlen, macAddress, 0, Math.Min (macAddress.Length, sockaddrdl.sdl_data.Length - sockaddrdl.sdl_nlen));
+
 							index = sockaddrdl.sdl_index;
 
 							int hwtype = (int) sockaddrdl.sdl_type;
@@ -515,14 +521,17 @@ namespace System.Net.NetworkInformation {
 
 					MacOsNetworkInterface iface = null;
 
+					// create interface if not already present
 					if (!interfaces.TryGetValue (name, out iface)) {
-						iface = new MacOsNetworkInterface (name);
+						iface = new MacOsNetworkInterface (name, addr.ifa_flags);
 						interfaces.Add (name, iface);
 					}
 
+					// if a new address has been found, add it
 					if (!address.Equals (IPAddress.None))
 						iface.AddAddress (address);
 
+					// set link layer info, if iface has macaddress or is loopback device
 					if (macAddress != null || type == NetworkInterfaceType.Loopback)
 						iface.SetLinkLayerInfo (index, macAddress, type);
 
@@ -541,9 +550,10 @@ namespace System.Net.NetworkInformation {
 			return result;
 		}
 		
-		MacOsNetworkInterface (string name)
+		MacOsNetworkInterface (string name, uint ifa_flags)
 			: base (name)
 		{
+			_ifa_flags = ifa_flags;
 		}
 
 		public override IPInterfaceProperties GetIPProperties ()
@@ -562,13 +572,16 @@ namespace System.Net.NetworkInformation {
 
 		public override OperationalStatus OperationalStatus {
 			get {
+				if(((MacOsInterfaceFlags)_ifa_flags & MacOsInterfaceFlags.IFF_UP) == MacOsInterfaceFlags.IFF_UP){
+					return OperationalStatus.Up;
+				}
 				return OperationalStatus.Unknown;
 			}
 		}
 
 		public override bool SupportsMulticast {
 			get {
-				return false;
+				return ((MacOsInterfaceFlags)_ifa_flags & MacOsInterfaceFlags.IFF_MULTICAST) == MacOsInterfaceFlags.IFF_MULTICAST;
 			}
 		}
 	}


### PR DESCRIPTION
Prior to these changes the NetworkInterface class provided very little information about the capabilities of the available network interfaces, especially not about their multicast capabilities and / or their OperationalStatus.
- ADDED: Implemented NetworkInterface property "OperationalStatus" to be UP, in case the IFF_UP flag is set
- ADDED: Implemented NetworkInterface property "SupportsMulticast" to be true, in case the IFF_MULTICAST flag is set

This change is released under the MIT license.
