### PR TITLE
[x86] Arguments to calls are passed via moves, instead of pushes.

### DIFF
--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -849,6 +849,7 @@ mono_arch_find_jit_info (MonoDomain *domain, MonoJitTlsData *jit_tls,
 				*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~3);
 		}
 
+#ifndef MONO_X86_NO_PUSHES
 		/* Pop arguments off the stack */
 		if (ji->has_arch_eh_info) {
 			int stack_size;
@@ -868,6 +869,7 @@ mono_arch_find_jit_info (MonoDomain *domain, MonoJitTlsData *jit_tls,
 #endif
 			}
 		}
+#endif
 
 		return TRUE;
 	} else if (*lmf) {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7787,6 +7787,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					EMIT_NEW_ARGLOAD (cfg, call->args [i], i);
 
 				mono_arch_emit_call (cfg, call);
+				cfg->param_area = MAX(cfg->param_area, call->stack_usage);
 				MONO_ADD_INS (bblock, (MonoInst*)call);
 			} else {
 				for (i = 0; i < num_args; ++i)

--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -1869,7 +1869,11 @@ sp_offset_to_fp_offset (MonoCompile *cfg, int sp_offset)
 #elif defined(TARGET_X86)
 	/* The offset is computed from the sp at the start of the call sequence */
 	g_assert (cfg->frame_reg == X86_EBP);
+#ifdef MONO_X86_NO_PUSHES
+	return (- cfg->arch.sp_fp_offset + sp_offset);
+#else
 	return (- cfg->arch.sp_fp_offset - sp_offset);	
+#endif
 #else
 	NOT_IMPLEMENTED;
 	return -1;
@@ -2056,7 +2060,11 @@ compute_frame_size (MonoCompile *cfg)
 #ifdef TARGET_AMD64
 	min_offset = MIN (min_offset, -cfg->arch.sp_fp_offset);
 #elif defined(TARGET_X86)
+#ifdef MONO_X86_NO_PUSHES
+	min_offset = MIN (min_offset, -cfg->arch.sp_fp_offset);
+#else
 	min_offset = MIN (min_offset, - (cfg->arch.sp_fp_offset + cfg->arch.param_area_size));
+#endif
 #elif defined(TARGET_ARM)
 	// FIXME:
 #elif defined(TARGET_s390X)

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -74,6 +74,8 @@ struct sigcontext {
 #endif /* HAVE_WORKING_SIGALTSTACK */
 #endif /* !HOST_WIN32 */
 
+#define MONO_X86_NO_PUSHES
+
 #define MONO_ARCH_SUPPORT_TASKLETS 1
 
 #ifndef DISABLE_SIMD
@@ -167,6 +169,7 @@ struct MonoLMF {
 typedef struct {
 	gboolean need_stack_frame_inited;
 	gboolean need_stack_frame;
+	gboolean no_pushes;
 	int sp_fp_offset, param_area_size;
 } MonoCompileArch;
 


### PR DESCRIPTION
I release these changes under the MIT license.
