### PR TITLE
Identities not being set in ClaimsPrincipal Ctor

### DIFF
--- a/mcs/class/corlib/System.Security.Claims/ClaimsPrincipal.cs
+++ b/mcs/class/corlib/System.Security.Claims/ClaimsPrincipal.cs
@@ -59,7 +59,7 @@ namespace System.Security.Claims {
 			if (identities == null)
 				throw new ArgumentNullException ("identities");
 			
-			identities = new List<ClaimsIdentity> (identities);
+			this.identities = new List<ClaimsIdentity> (identities);
 		}
 
 		public ClaimsPrincipal (IIdentity identity)


### PR DESCRIPTION
Class' identities member is not set in constructor ClaimsPrincipal
(IEnumerable<ClaimsIdentity> identities)
