### PR TITLE
tarball is missing file vasprintf.h

### DIFF
--- a/eglib/src/Makefile.am
+++ b/eglib/src/Makefile.am
@@ -32,6 +32,7 @@ libeglib_la_SOURCES = \
 	garray.c	\
 	gbytearray.c	\
 	gerror.c	\
+	vasprintf.h     \
 	ghashtable.c 	\
 	giconv.c	\
 	gmem.c       	\


### PR DESCRIPTION
since https://github.com/mono/mono/commit/975bf0a37966e55e5544660f3f5089a8a90f4567#diff-0, gerror.c requires vasprintf.h

But this file is currently missing in the tarball, and when building from the tarball, you get:

```
[01175] make[4]: Entering directory `/root/rpmbuild/BUILD/mono-3.6.1/eglib/src'
[01175]   CC     libeglib_la-garray.lo
[01175]   CC     libeglib_la-gbytearray.lo
[01176]   CC     libeglib_la-gerror.lo
[01176] gerror.c:33:23: error: vasprintf.h: No such file or directory
```

This pull request adds the file to the tarball.
I have tested building from the fixed tarball, and it works.
