### PR TITLE
Added fix for Bug 11630

### DIFF
--- a/mcs/class/corlib/System/DateTime.cs
+++ b/mcs/class/corlib/System/DateTime.cs
@@ -214,6 +214,10 @@ namespace System
 			"yyyy/MMMM",
 		};
 
+		private static readonly string[] ExoticAndNonStandardFormats = new string[] {
+			"ddMMMyyyy"
+		};
+
 		private enum Which 
 		{
 			Day,
@@ -925,6 +929,9 @@ namespace System
 
 			// Try as a last resort all the patterns
 			if (ParseExact (s, dfi.GetAllDateTimePatternsInternal (), dfi, styles, out result, false, ref longYear, setExceptionOnError, ref exception))
+				return true;
+
+			if (ParseExact (s, ExoticAndNonStandardFormats, dfi, styles, out result, false, ref longYear, setExceptionOnError, ref exception))
 				return true;
 
 			if (!setExceptionOnError)

--- a/mcs/class/corlib/Test/System/DateTimeTest.cs
+++ b/mcs/class/corlib/Test/System/DateTimeTest.cs
@@ -1217,6 +1217,15 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		public void TryParse_Bug11630 ()
+		{
+			DateTime parsed;
+
+			Assert.IsTrue (DateTime.TryParse ("10Feb2013", out parsed));
+			Assert.AreEqual (new DateTime (2013, 2, 10), parsed);
+		}
+
+		[Test]
 		[ExpectedException (typeof (FormatException))]
 		public void Parse_CommaAfterHours ()
 		{


### PR DESCRIPTION
Added the additional formats such that the behavior of TryParse matches MS.NET (all versions).
