### PR TITLE
Remove a reference to the file AvoidCDataTextReaderTests.cs so that tarballs can be built again

### DIFF
--- a/mcs/class/monodoc/monodoc_test.dll.sources
+++ b/mcs/class/monodoc/monodoc_test.dll.sources
@@ -6,4 +6,3 @@ Monodoc/SettingsTest.cs
 Monodoc.Generators/RawGeneratorTests.cs
 Monodoc/NodeTest.cs
 Monodoc/RootTreeTest.cs
-Monodoc.Generators/AvoidCDataTextReaderTests.cs


### PR DESCRIPTION
The file AvoidCDataTextReaderTests.cs was removed from master in https://github.com/mono/mono/commit/d8d1b0be6baf6f8881871592b040d85be790926c

Currently when running make dist, I get:

```
[01892] mkdir -p -- /root/lbs-mono/mono-opt-nightly/work/mono-3.6.1/mcs/class/monodoc/Test/Monodoc.Generators
[01892] cp: cannot stat 'Test/Monodoc.Generators/AvoidCDataTextReaderTests.cs': No such file or directory
[01892] make[5]: *** [dist-local] Error 1
[01892] make[5]: Leaving directory `/root/lbs-mono/mono-opt-nightly/work/mcs/class/monodoc'
```
