### PR TITLE
Tarball: include System.Security.dll and System.Configuration.dll in monolite directory

### DIFF
--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -285,7 +285,7 @@ all-local $(STD_TARGETS:=-local):
 	@:
 
 # Files needed to bootstrap C# compiler
-basic_files = basic.exe mscorlib.dll System.dll System.Xml.dll Mono.Security.dll System.Core.dll
+basic_files = basic.exe mscorlib.dll System.dll System.Xml.dll Mono.Security.dll System.Core.dll System.Security.dll System.Configuration.dll
 monolite_files = $(basic_files:%=lib/monolite/%)
 
 lib/monolite:


### PR DESCRIPTION
this is related to commit https://github.com/mono/mono/commit/993f4773638bcb36abf8b9660ee737d6445c5200

We need System.Security.dll and System.Configuration.dll in the monolite directory of the tarball.
