### PR TITLE
Tarball: include System.Security.dll and System.Configuration.dll in monolite directory, branch 3.6.0

### DIFF
--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -285,7 +285,7 @@ all-local $(STD_TARGETS:=-local):
 	@:
 
 # Files needed to bootstrap C# compiler
-basic_files = basic.exe mscorlib.dll System.dll System.Xml.dll Mono.Security.dll System.Core.dll
+basic_files = basic.exe mscorlib.dll System.dll System.Xml.dll Mono.Security.dll System.Core.dll System.Security.dll System.Configuration.dll
 monolite_files = $(basic_files:%=lib/monolite/%)
 
 lib/monolite:


### PR DESCRIPTION
same as pull request https://github.com/mono/mono/pull/1104, but now for branch 3.6.0
