### PR TITLE
[Managed.Windows.Forms] Fixed System.Resources tests that relied on DummyAssembly

### DIFF
--- a/mcs/class/Managed.Windows.Forms/.gitignore
+++ b/mcs/class/Managed.Windows.Forms/.gitignore
@@ -1,0 +1,3 @@
+DummyAssembly.dll
+DummyAssembly.mdb
+test_file

--- a/mcs/class/Managed.Windows.Forms/Makefile
+++ b/mcs/class/Managed.Windows.Forms/Makefile
@@ -93,7 +93,10 @@ TEST_DISTFILES = \
 	Test/resources/32x32.ico \
 	Test/System.Resources/compat_1_1.resx \
 	Test/System.Resources/compat_2_0.resx \
-	Test/System.Windows.Forms/bitmaps/a.png
+	Test/System.Windows.Forms/bitmaps/a.png \
+	Test/DummyAssembly/AnotherSerializable.cs \
+	Test/DummyAssembly/Convertable.cs \
+	Test/DummyAssembly/Properties/AssemblyInfo.cs \
 
 EXTRA_DISTFILES = \
 	README System.Windows.Forms.dll.resources \
@@ -105,6 +108,11 @@ TEST_MCS_FLAGS = /r:System.Data.dll /r:System.Drawing.dll /r:Accessibility.dll -
 	-resource:Test/resources/a.cur,a.cur \
 	-resource:Test/resources/32x32.ico,32x32.ico \
 	-nowarn:618,612
+
+DummyAssembly.dll:
+	$(CSCOMPILE) /target:library /out:$@ Test/DummyAssembly/AnotherSerializable.cs Test/DummyAssembly/Convertable.cs Test/DummyAssembly/Properties/AssemblyInfo.cs
+
+test-local: DummyAssembly.dll
 
 include ../../build/library.make
 

--- a/mcs/class/Managed.Windows.Forms/Test/DummyAssembly/AnotherSerializable.cs
+++ b/mcs/class/Managed.Windows.Forms/Test/DummyAssembly/AnotherSerializable.cs
@@ -1,0 +1,88 @@
+//
+// AnotherSerializable.cs : Serializable Class used to test types from other
+// assemblies for resources tests
+//
+// Author:
+//	Gary Barnett (gary.barnett.mono@gmail.com)
+// 
+// Copyright (C) Gary Barnett (2012)
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Runtime.Serialization;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace DummyAssembly {
+	[SerializableAttribute]
+	public class AnotherSerializable : ISerializable {
+		public string name;
+		public string value;
+
+		public AnotherSerializable ()
+		{
+		}
+
+		public AnotherSerializable (string name, string value)
+		{
+			this.name = name;
+			this.value = value;
+		}
+
+		public AnotherSerializable (SerializationInfo info, StreamingContext ctxt)
+		{
+			name = (string) info.GetValue ("sername", typeof (string));
+			value = (String) info.GetValue ("servalue", typeof (string));
+		}
+
+		public AnotherSerializable (Stream stream)
+		{
+			BinaryFormatter bFormatter = new BinaryFormatter ();
+			AnotherSerializable deser = (AnotherSerializable) bFormatter.Deserialize (stream);
+			stream.Close ();
+
+			name = deser.name;
+			value = deser.value;
+		}
+
+		public void GetObjectData (SerializationInfo info, StreamingContext ctxt)
+		{
+			info.AddValue ("sername", name);
+			info.AddValue ("servalue", value);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("name={0};value={1}", this.name, this.value);
+		}
+
+		public override bool Equals (object obj)
+		{
+			AnotherSerializable o = obj as AnotherSerializable;
+			if (o == null)
+				return false;
+			return this.name.Equals (o.name) && this.value.Equals (o.value);
+		}
+	}
+}
+

--- a/mcs/class/Managed.Windows.Forms/Test/DummyAssembly/Convertable.cs
+++ b/mcs/class/Managed.Windows.Forms/Test/DummyAssembly/Convertable.cs
@@ -1,0 +1,119 @@
+//
+// Convertable.cs : Class with type converter used to test types from other
+// assemblies for resources tests
+//
+// Author:
+//	Gary Barnett (gary.barnett.mono@gmail.com)
+// 
+// Copyright (C) Gary Barnett (2012)
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.IO;
+using System.Runtime.Serialization;
+using System.ComponentModel;
+
+namespace DummyAssembly {
+
+    [SerializableAttribute]
+    [TypeConverter (typeof (ConvertableConverter))]
+    public class Convertable {
+        protected string name;
+        protected string value;
+
+        public Convertable ()
+        {
+        }
+
+        public Convertable (string name, string value)
+        {
+            this.name = name;
+            this.value = value;
+        }
+        
+        public void GetObjectData (SerializationInfo info, StreamingContext ctxt)
+        {
+            info.AddValue ("sername", name);
+            info.AddValue ("servalue", value);
+        }
+
+        public override string ToString ()
+        {
+            return String.Format ("{0}\t{1}",name, value);
+        }
+
+        public override bool Equals (object obj)
+        {
+            Convertable o = obj as Convertable;
+            if (o == null)
+                return false;
+            return this.name.Equals (o.name) && this.value.Equals (o.value);
+        }
+    }
+
+    class ConvertableConverter : TypeConverter {
+        public ConvertableConverter ()
+        {
+        }
+
+        public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof (string);
+        }
+
+        public override bool CanConvertTo (ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof (string);
+        }
+
+        public override object ConvertFrom (ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value.GetType() != typeof (string))
+                throw new Exception ("value not string");
+
+            string serialised = (string) value;
+
+            string [] parts = serialised.Split ('\t');
+
+            if (parts.Length != 2)
+                throw new Exception ("string in incorrect format");
+
+            Convertable convertable = new Convertable (parts [0], parts [1]);
+            return convertable;
+        }
+
+        public override object ConvertTo (ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType != typeof (String)) {
+                return base.ConvertTo (context, culture, value, destinationType);
+            }
+
+            return ((Convertable) value).ToString ();
+        }
+    }
+
+}
+

--- a/mcs/class/Managed.Windows.Forms/Test/DummyAssembly/Properties/AssemblyInfo.cs
+++ b/mcs/class/Managed.Windows.Forms/Test/DummyAssembly/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle ("DummyAssembly")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("DummyAssembly")]
+[assembly: AssemblyCopyright ("")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible (false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid ("c80e062b-a918-4aa5-b62c-7455ca2c56d5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
+[assembly: AssemblyFileVersion ("1.0.0.0")]


### PR DESCRIPTION
Several System.Resources tests rely on a DummyAssembly.dll, which was removed in 016b0b5170fca72b977f952ee817fe06e32890a9 (possibly by accident?).

This commit adds the assembly back.
