### PR TITLE
[Managed.Windows.Forms] Fix 'minimum' default value of NumericUpDown

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/NumericUpDown.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/NumericUpDown.cs
@@ -109,7 +109,7 @@ namespace System.Windows.Forms {
 			hexadecimal = false;
 			increment = 1M;
 			maximum = 100M;
-			minimum = 0.0M;
+			minimum = 0M;
 			thousands_separator = false;
 
 			Text = "0";


### PR DESCRIPTION
The 'minimum' default value of NumericUpDown was set to 0.0M, which caused the ToString() to format it as "0.0" instead of "0" as it does on .NET.
A similar change was done for the 'maximum' default value already in f6c8d48a3aed377b8a11e38c96c0d4c774664279.
