### PR TITLE
[System.ServiceModel] Changed test port from 8080 to 30158

### DIFF
--- a/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebServiceHostTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebServiceHostTest.cs
@@ -45,7 +45,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Category("NotWorking")]
 		public void ServiceDebugBehaviorTest () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:8080/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
 			ServiceEndpoint webHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new WebHttpBinding (), "WebHttpBinding");
 
 			Assert.AreEqual (true, host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageEnabled, "HttpHelpPageEnabled #1");
@@ -63,7 +63,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Category ("NotWorking")]
 		public void WebHttpBehaviorTest1 () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:8080/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
 			ServiceEndpoint webHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new WebHttpBinding (), "WebHttpBinding");
 			ServiceEndpoint basicHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new BasicHttpBinding (), "BasicHttpBinding");
 
@@ -83,7 +83,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Category("NotWorking")]
 		public void WebHttpBehaviorTest2 () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:8080/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
 			ServiceEndpoint webHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new WebHttpBinding (), "WebHttpBinding");
 			MyWebHttpBehavior behavior = new MyWebHttpBehavior ();
 			behavior.ApplyDispatchBehaviorBegin += delegate {
@@ -103,7 +103,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Test]
 		public void ServiceBaseUriTest () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:8080/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
 			Assert.AreEqual (0, host.Description.Endpoints.Count, "no endpoints yet");
 			host.Open ();
 			Assert.AreEqual (1, host.Description.Endpoints.Count, "default endpoint after open");

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataExchangeBindingsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataExchangeBindingsTest.cs
@@ -69,7 +69,7 @@ namespace MonoTests.System.ServiceModel.Description
 			Assert.AreEqual (MessageVersion.Soap12WSAddressing10, b.GetProperty<MessageVersion> (new BindingParameterCollection ()), "#6");
 
 			var host = new ServiceHost (typeof (MetadataExchange));
-			host.AddServiceEndpoint (typeof (IMetadataExchange), MetadataExchangeBindings.CreateMexHttpBinding (), CreateUri ("http://localhost:8080"));
+			host.AddServiceEndpoint (typeof (IMetadataExchange), MetadataExchangeBindings.CreateMexHttpBinding (), CreateUri ("http://localhost:30158"));
 			host.Open ();
 			try {
 				// it still does not rewrite MessageVersion.None. It's rather likely ServiceMetadataExtension which does overwriting.
@@ -96,7 +96,7 @@ namespace MonoTests.System.ServiceModel.Description
 			Assert.AreEqual(Uri.UriSchemeHttps, b.Scheme, "#8");
 
 			var host = new ServiceHost(typeof(MetadataExchange));
-			host.AddServiceEndpoint(typeof(IMetadataExchange), MetadataExchangeBindings.CreateMexHttpsBinding(), CreateUri("https://localhost:8080"));
+			host.AddServiceEndpoint(typeof(IMetadataExchange), MetadataExchangeBindings.CreateMexHttpsBinding(), CreateUri("https://localhost:30158"));
 			host.Open();
 			try
 			{

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataBehaviorTest.cs
@@ -56,7 +56,7 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime1 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:8080"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "e1");
 				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true });
 
@@ -93,10 +93,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime2 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:8080"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:8080/mex_and_help") });
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:8080/mex_and_help");
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex_and_help") });
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:30158/mex_and_help");
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
 
@@ -125,10 +125,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime3 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:8080"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:8080/mex") });
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:8080/help");
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:30158/help");
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
 
@@ -176,9 +176,9 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime4 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:8080"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:8080/mex") });
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
@@ -204,7 +204,7 @@ namespace MonoTests.System.ServiceModel.Description
 				Assert.AreEqual (0, ed.FilterPriority, "FilterPriority");
 
 				EndpointAddress ea = ed.EndpointAddress;
-				Assert.AreEqual (new Uri ("http://localhost:8080/mex"), ea.Uri, "Uri");
+				Assert.AreEqual (new Uri ("http://localhost:30158/mex"), ea.Uri, "Uri");
 
 				DispatchRuntime dr = ed.DispatchRuntime;
 				Assert.AreEqual (1, dr.Operations.Count, "Operations.Count");
@@ -221,9 +221,9 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void ServiceMetadataExtension1 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:8080"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:8080/mex") });
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
 				host.Open ();
@@ -237,9 +237,9 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void ServiceMetadataExtension2 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:8080"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:8080/mex") });
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
 				ServiceMetadataExtension extension = new ServiceMetadataExtension ();

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchRuntimeTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchRuntimeTest.cs
@@ -53,7 +53,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 			// free to change if MS implementation does not make 
 			// sense.
 			DispatchRuntime r = new EndpointDispatcher (
-				new EndpointAddress ("http://localhost:8080"), "IFoo", "urn:foo").DispatchRuntime;
+				new EndpointAddress ("http://localhost:30158"), "IFoo", "urn:foo").DispatchRuntime;
 			Assert.AreEqual (AuditLogLocation.Default,
 					 r.SecurityAuditLogLocation, "#1");
 
@@ -153,7 +153,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 
 		void TestInstanceBehavior (MessageInspectBehavior b, string expected, Result actual, int invocations)
 		{
-			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:8080"));
+			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:30158"));
 			try {
 				h.AddServiceEndpoint (typeof (IAllActions).FullName, new BasicHttpBinding (), "AllActions");
 				h.Description.Behaviors.Add (b);
@@ -167,7 +167,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 						Assert.AreEqual (typeof (AllActions), ed.DispatchRuntime.Type, "Type property: " + ed.ContractName);
 					}
 				}
-				AllActionsProxy p = new AllActionsProxy (new BasicHttpBinding () { SendTimeout = TimeSpan.FromSeconds (5), ReceiveTimeout = TimeSpan.FromSeconds (5) }, new EndpointAddress ("http://localhost:8080/AllActions"));
+				AllActionsProxy p = new AllActionsProxy (new BasicHttpBinding () { SendTimeout = TimeSpan.FromSeconds (5), ReceiveTimeout = TimeSpan.FromSeconds (5) }, new EndpointAddress ("http://localhost:30158/AllActions"));
 
 				for (int i = 0; i < invocations; ++i)
 					p.Get (10);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactory_1Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactory_1Test.cs
@@ -483,12 +483,12 @@ namespace MonoTests.System.ServiceModel
 			var host = new ServiceHost (typeof (OneWayService));
 			host.AddServiceEndpoint (typeof (IOneWayService),
 				new BasicHttpBinding (),
-				new Uri ("http://localhost:8080"));
+				new Uri ("http://localhost:30158"));
 			host.Open ();
 			try {
 				var cf = new ChannelFactory<IOneWayService> (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:8080"));
+					new EndpointAddress ("http://localhost:30158"));
 				var ch = cf.CreateChannel ();
 				ch.GiveMessage ("test");
 				

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
@@ -159,7 +159,7 @@ namespace MonoTests.System.ServiceModel
 
 		[Test]
 		public void ChannelDispatchers_NoDebug () {
-			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:8080"));
+			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:30158"));
 			h.AddServiceEndpoint (typeof (AllActions).FullName, new BasicHttpBinding (), "address");
 
 			ServiceDebugBehavior b = h.Description.Behaviors.Find<ServiceDebugBehavior> ();
@@ -183,11 +183,11 @@ namespace MonoTests.System.ServiceModel
 
 		[Test]
 		public void ChannelDispatchers_WithDebug () {
-			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:8080"));
+			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:30158"));
 			h.AddServiceEndpoint (typeof (AllActions).FullName, new BasicHttpBinding (), "address");
 			ServiceMetadataBehavior b = new ServiceMetadataBehavior ();
 			b.HttpGetEnabled = true;
-			b.HttpGetUrl = new Uri( "http://localhost:8080" );
+			b.HttpGetUrl = new Uri( "http://localhost:30158" );
 			h.Description.Behaviors.Add (b);
 			h.Open ();
 
@@ -197,7 +197,7 @@ namespace MonoTests.System.ServiceModel
 			Assert.IsTrue (channelDispatcher.Endpoints.Count == 1, "#3");
 			EndpointAddressMessageFilter filter = channelDispatcher.Endpoints [0].AddressFilter as EndpointAddressMessageFilter;
 			Assert.IsNotNull (filter, "#4");
-			Assert.IsTrue (filter.Address.Equals (new EndpointAddress ("http://localhost:8080")), "#5");
+			Assert.IsTrue (filter.Address.Equals (new EndpointAddress ("http://localhost:30158")), "#5");
 			Assert.IsFalse (filter.IncludeHostNameInComparison, "#6");
 			Assert.IsTrue (channelDispatcher.Endpoints [0].ContractFilter is MatchAllMessageFilter, "#7");
 			h.Close ();
@@ -207,7 +207,7 @@ namespace MonoTests.System.ServiceModel
 		public void SpecificActionTest ()
 		{
 			//EndpointDispatcher d = new EndpointDispatcher(
-			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://localhost:8080"));
+			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://localhost:30158"));
 			h.AddServiceEndpoint (typeof (Action1Interface), new BasicHttpBinding (), "address");
 						
 			h.Open ();
@@ -222,7 +222,7 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void InitializeRuntimeBehaviors1 () {
 			HostState st = new HostState ();
-			ServiceHost h = new ServiceHost (typeof (SpecificAction2), new Uri ("http://localhost:8080"));
+			ServiceHost h = new ServiceHost (typeof (SpecificAction2), new Uri ("http://localhost:30158"));
 			h.AddServiceEndpoint (typeof (SpecificAction2), new BasicHttpBinding (), "temp");			
 
 			h.Description.Behaviors.Add (new MyServiceBehavior (st, h));
@@ -241,7 +241,7 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void InitializeRuntimeBehaviors2 () {
 			HostState st = new HostState ();
-			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://localhost:8080"));
+			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://localhost:30158"));
 			h.AddServiceEndpoint (typeof (Action1Interface), new BasicHttpBinding (), "temp");
 			h.AddServiceEndpoint (typeof (Action2Interface), new BasicHttpBinding (), "temp2");
 
@@ -368,7 +368,7 @@ namespace MonoTests.System.ServiceModel
 		public void AddServiceEndpoint_Directly ()
 		{
 			var host = new ServiceHost (typeof (DummyService));
-			var address = new EndpointAddress ("http://localhost:8080");
+			var address = new EndpointAddress ("http://localhost:30158");
 			var binding = new BasicHttpBinding ();
 			var contract = ContractDescription.GetContract (typeof (IDummyService));
 			host.AddServiceEndpoint (new ServiceEndpoint (contract, binding, address));
@@ -389,7 +389,7 @@ namespace MonoTests.System.ServiceModel
 		public void AddServiceEndpoint_Directly_NullBinding ()
 		{
 			var host = new ServiceHost (typeof (DummyService));
-			var address = new EndpointAddress ("http://localhost:8080");
+			var address = new EndpointAddress ("http://localhost:30158");
 			var contract = ContractDescription.GetContract (typeof (IDummyService));
 			host.AddServiceEndpoint (new ServiceEndpoint (contract, null, address));
 		}
@@ -407,7 +407,7 @@ namespace MonoTests.System.ServiceModel
 		public void AddServiceEndpoint_Directly_ContractMismatch ()
 		{
 			var host = new ServiceHost (typeof (DummyService));
-			var address = new EndpointAddress ("http://localhost:8080");
+			var address = new EndpointAddress ("http://localhost:30158");
 			var binding = new BasicHttpBinding ();
 			var contract = ContractDescription.GetContract (typeof (INotImplementedService));
 			host.AddServiceEndpoint (new ServiceEndpoint (contract, binding, address));

--- a/mcs/class/System/Test/System.Net/HttpListener2Test.cs
+++ b/mcs/class/System/Test/System.Net/HttpListener2Test.cs
@@ -723,11 +723,11 @@ namespace MonoTests.System.Net {
 		public void ClosePort ()
 		{
 			var h = new HttpListener ();
-			h.Prefixes.Add ("http://127.0.0.1:8080/");
+			h.Prefixes.Add ("http://127.0.0.1:30158/");
 			h.Start ();
 			h.BeginGetContext (null, null);
 			h.Stop ();
-			TcpListener t = new TcpListener (IPAddress.Parse ("127.0.0.1"), 8080);
+			TcpListener t = new TcpListener (IPAddress.Parse ("127.0.0.1"), 30158);
 			t.Start ();
 			t.Stop ();
 		}


### PR DESCRIPTION
Port 8080 is widely used and resulted in address conflicts on monojenkins, so we use a different port instead.
