### PR TITLE
icall: Use mono_strtod on non-Android ARM platforms

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -127,7 +127,7 @@ mono_double_ParseImpl (char *ptr, double *result)
 
 	MONO_ARCH_SAVE_REGS;
 
-#ifdef __arm__
+#if defined(__arm__) && defined(PLATFORM_ANDROID)
 	if (*ptr)
 		*result = strtod (ptr, &endptr);
 #else


### PR DESCRIPTION
Mono's `Double.Parse` uses `mono_strtod` (a non-locale-aware version of
`strtod`) on most platforms, except on ARM, where it directly calls the
platform's `strtod`—which incidentally is the same implementation.

This changes the compile-time conditional to `__arm__ && ANDROID`, to
avoid issues on other ARM operating systems, notably Tizen, where the
`strtod` implementation is more complete.

For example, on Tizen, `LANG=de_DE.UTF-8` results in internal compiler
errors when C# source contains floating-point numbers:

```
MCS     [net_4_5] corlib_test_net_4_5.dll
Test/Mono/DataConvertTest.cs(64,77): error CS0589: Internal \
compiler error during parsingSystem.FormatException: Input  \
string was not in the correct format
  at System.Double.Parse (System.String s, NumberStyles     \
  style, IFormatProvider provider) ...
```

because the German decimal separator is the comma, and successfully
tokenized input cannot be converted to a double.
