### PR TITLE
[corlib] Fixed test that failed intermittently

### DIFF
--- a/mcs/class/corlib/Test/System/LazyTest.cs
+++ b/mcs/class/corlib/Test/System/LazyTest.cs
@@ -306,6 +306,8 @@ namespace MonoTests.System
 				e3 = ex;
 			}
 
+			Thread.Sleep (1000);
+
 			Assert.AreSame (e1, e2, "#2");
 			Assert.AreSame (e1, e3, "#3");
 		}


### PR DESCRIPTION
There is a race condition in the test, the "#2" Assert() can be reached before e1 is assigned if the thread
that handles e1 gets preempted by the scheduler (this is more likely on single-core systems). Adding a sleep before checking the values fixes this for now.

@marek-safar can you verify this doesn't change the behavior of the test (you added it in b787868fa8553095f2eceacde712768b69b645c4)?
