### PR TITLE
[Managed.Windows.Forms] Verify that DataMember is valid when setting DataSource

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/BindingSource.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/BindingSource.cs
@@ -207,6 +207,7 @@ namespace System.Windows.Forms {
 		private void OnParentCurrencyManagerChanged (object sender, EventArgs args)
 		{
 			// Essentially handles chained data sources (e.g. chained BindingSource)
+			ResetDataMemberIfInvalid ();
 			ResetList ();
 		}
 
@@ -349,6 +350,7 @@ namespace System.Windows.Forms {
 
 					DisconnectDataSourceEvents (datasource);
 					datasource = value;
+					ResetDataMemberIfInvalid ();
 					ConnectDataSourceEvents (datasource);
 					ResetList ();
 
@@ -451,6 +453,19 @@ namespace System.Windows.Forms {
 
 				ProcessSortString (value);
 				sort = value;
+			}
+		}
+
+		void ResetDataMemberIfInvalid ()
+		{
+			if (datamember == String.Empty)
+				return;
+
+			// if dataMember doesn't refer to a valid property of dataSource, we need to reset it
+			var property = ListBindingHelper.GetListItemProperties (datasource).Find (datamember, true);
+			if (property == null) {
+				datamember = String.Empty;
+				OnDataMemberChanged (EventArgs.Empty);
 			}
 		}
 


### PR DESCRIPTION
When DataMember is already set before DataSource we need to verify that it refers to a valid property in the DataSource setter, otherwise we'd get an exception in ResetList ().
This fixes the following failing tests: BindingSourceTest.DataMemberBeforeDataSource and BindingSourceTest.DataSourceAssignToDefaultType.
