### PR TITLE
Fixed NullReferenceExcepton in Socket.Connect for non-IP endpoints

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
@@ -1253,7 +1253,7 @@ namespace System.Net.Sockets {
 				throw new SocketException (error);
 			}
 
-			if (socket_type == SocketType.Dgram && (ep.Address.Equals (IPAddress.Any) || ep.Address.Equals (IPAddress.IPv6Any)))
+			if (socket_type == SocketType.Dgram && ep != null && (ep.Address.Equals (IPAddress.Any) || ep.Address.Equals (IPAddress.IPv6Any)))
 				connected = false;
 			else
 				connected = true;


### PR DESCRIPTION
Socket.Connect(EndPoint) throws a NullReferenceException when connecting to non-IP (eg Unix) endpoints in Dgram mode.
