### PR TITLE
[amd64] Fast OP_LREM_IMM for power of two operands.

### DIFF
--- a/mono/mini/basic-long.cs
+++ b/mono/mini/basic-long.cs
@@ -1211,5 +1211,47 @@ class Tests
 
 		return (int)res;
 	}
+
+	public static int test_0_lrem_imm_2 ()
+	{
+		long x = 245345634L;
+		return (int)(x % 2L);
+	}
+
+	public static int test_1_lrem_imm_2 ()
+	{
+		long x = 24534553245L;
+		return (int)(x % 2L);
+	}
+
+	public static int test_1_lrem_imm_2_neg ()
+	{
+		long x = -24534553245L;
+		return -(int)(x % 2L);
+	}
+
+	public static int test_13_lrem_imm_32 ()
+	{
+		long x = 17389L;
+		return (int)(x % 32L);
+	}
+
+	public static int test_27_lrem_imm_32_neg ()
+	{
+		long x = -2435323L;
+		return -(int)(x % 32L);
+	}
+
+	public static int test_5_lrem_imm_large ()
+	{
+		long x = 0x1000000005L;
+		return (int)(x % 0x40000000L);
+	}
+
+	public static int test_5_lrem_imm_too_large ()
+	{
+		long x = 0x1000000005L;
+		return (int)(x % 0x80000000L);
+	}
 }
 

--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -98,6 +98,7 @@ long_conv_to_u1: dest:i src1:i len:4
 zext_i4: dest:i src1:i len:4
 
 long_mul_imm: dest:i src1:i clob:1 len:12
+long_rem_imm: dest:a src1:a len:32 clob:d
 long_min: dest:i src1:i src2:i len:16 clob:1
 long_min_un: dest:i src1:i src2:i len:16 clob:1
 long_max: dest:i src1:i src2:i len:16 clob:1

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12364,7 +12364,11 @@ mono_op_to_op_imm (int opcode)
 	case OP_LSHR:
 		return OP_LSHR_IMM;
 	case OP_LSHR_UN:
-		return OP_LSHR_UN_IMM;		
+		return OP_LSHR_UN_IMM;
+#ifdef TARGET_AMD64
+	case OP_LREM:
+		return OP_LREM_IMM;
+#endif
 
 	case OP_COMPARE:
 		return OP_COMPARE_IMM;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1135,6 +1135,8 @@ mono_op_imm_to_op (int opcode)
 		return OP_IREM_UN;
 	case OP_IREM_IMM:
 		return OP_IREM;
+	case OP_LREM_IMM:
+		return OP_LREM;
 	case OP_DIV_IMM:
 #if SIZEOF_REGISTER == 4
 		return OP_IDIV;


### PR DESCRIPTION
This was the reason for one of our bad performance results in the
paper "Clash of the Lambdas" by Biboudis, Palladinos, Smaragdakis:

http://cgi.di.uoa.gr/~biboudis/clashofthelambdas.pdf

There's clearly way more we could do in this regard.  More specifically
with other number types (unsigned longs, unsigned ints, ...), more
generally for more immediate operands to the division (integer divisions
with constant divisor can always be implemented via multiplication - the
CLR does this for the few cases I tested) and for more architectures.
How deep down the rabbit hole do we want to go?
