### PR TITLE
[System] Make tests more descriptive on failure

### DIFF
--- a/mcs/class/System/Test/System.Net/HttpListener2Test.cs
+++ b/mcs/class/System/Test/System.Net/HttpListener2Test.cs
@@ -144,7 +144,7 @@ namespace MonoTests.System.Net {
 			Send (ns, "GET / HTTP/1.1\r\n\r\n"); // No host
 			string response = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 400"));
+			StringAssert.StartsWith ("HTTP/1.1 400", response);
 		}
 
 		[Test]
@@ -155,7 +155,7 @@ namespace MonoTests.System.Net {
 			Send (ns, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"); // no prefix
 			string response = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 400"));
+			StringAssert.StartsWith ("HTTP/1.1 400", response);
 		}
 
 		[Test]
@@ -192,7 +192,7 @@ namespace MonoTests.System.Net {
 				string response = Receive (ns, 512);
 				ns.Close ();
 				listener.Close ();
-				Assert.AreEqual (true, response.StartsWith ("HTTP/1.1 400"), String.Format ("Failed on {0}", (int) b));
+				StringAssert.StartsWith ("HTTP/1.1 400", response, String.Format ("Failed on {0}", (int) b));
 			}
 		}
 
@@ -204,7 +204,7 @@ namespace MonoTests.System.Net {
 			Send (ns, "POST /test4/ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"); // length required
 			string response = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 411"));
+			StringAssert.StartsWith ("HTTP/1.1 411", response);
 		}
 
 		[Test]
@@ -215,7 +215,7 @@ namespace MonoTests.System.Net {
 			Send (ns, "POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: pepe\r\n\r\n"); // not implemented
 			string response = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 501"));
+			StringAssert.StartsWith ("HTTP/1.1 501", response);
 		}
 
 		[Test]
@@ -227,7 +227,7 @@ namespace MonoTests.System.Net {
 			Send (ns, "POST /test6/ HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: identity\r\n\r\n");
 			string response = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 501"));
+			StringAssert.StartsWith ("HTTP/1.1 501", response);
 		}
 
 		[Test]
@@ -241,8 +241,8 @@ namespace MonoTests.System.Net {
 			ctx.Response.Close ();
 			string response = Receive (ns, 1024);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 200"));
-			Assert.IsTrue (-1 != response.IndexOf ("Transfer-Encoding: chunked"));
+			StringAssert.StartsWith ("HTTP/1.1 200", response);
+			StringAssert.Contains ("Transfer-Encoding: chunked", response);
 		}
 
 		[Test]
@@ -257,7 +257,7 @@ namespace MonoTests.System.Net {
 			ctx.Response.Close ();
 			string response = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 200"));
+			StringAssert.StartsWith ("HTTP/1.1 200", response);
 			Assert.IsTrue (-1 == response.IndexOf ("Transfer-Encoding: chunked"));
 		}
 
@@ -272,7 +272,7 @@ namespace MonoTests.System.Net {
 			string response = ReceiveWithTimeout (ns, 512, 1000, out timeout);
 			ns.Close ();
 			Assert.IsFalse (timeout);
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 411"));
+			StringAssert.StartsWith ("HTTP/1.1 411", response);
 		}
 
 		[Test]
@@ -287,7 +287,7 @@ namespace MonoTests.System.Net {
 			string response = ReceiveWithTimeout (ns, 512, 1000, out timeout);
 			ns.Close ();
 			Assert.IsFalse (timeout);
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 411"));
+			StringAssert.StartsWith ("HTTP/1.1 411", response);
 		}
 
 		[Test]
@@ -300,7 +300,7 @@ namespace MonoTests.System.Net {
 			ns.GetSocket ().Shutdown (SocketShutdown.Send);
 			string input = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (input.StartsWith ("HTTP/1.1 400"));
+			StringAssert.StartsWith ("HTTP/1.1 400", input);
 		}
 
 		[Test]
@@ -313,7 +313,7 @@ namespace MonoTests.System.Net {
 			ns.GetSocket ().Shutdown (SocketShutdown.Send);
 			string input = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (input.StartsWith ("HTTP/1.1 400"));
+			StringAssert.StartsWith ("HTTP/1.1 400", input);
 		}
 
 		[Test]
@@ -326,7 +326,7 @@ namespace MonoTests.System.Net {
 			ns.GetSocket ().Shutdown (SocketShutdown.Send);
 			string input = Receive (ns, 512);
 			ns.Close ();
-			Assert.IsTrue (input.StartsWith ("HTTP/1.1 400"));
+			StringAssert.StartsWith ("HTTP/1.1 400", input);
 		}
 
 		HttpListenerRequest test14_request;
@@ -418,8 +418,8 @@ namespace MonoTests.System.Net {
 			ctx.Response.Close ();
 			string response = Receive (ns, 1024);
 			ns.Close ();
-			Assert.IsTrue (response.StartsWith ("HTTP/1.1 200"));
-			Assert.IsTrue (-1 != response.IndexOf ("Transfer-Encoding: chunked"));
+			StringAssert.StartsWith ("HTTP/1.1 200", response);
+			StringAssert.Contains ("Transfer-Encoding: chunked", response);
 		}
 
 		[Test]


### PR DESCRIPTION
By using StringAssert we get a more descriptive error message when the test fails, i.e. the expected vs. the actual string value instead of just true/false.
