### PR TITLE
[jit] Portably decompose power-of-two OP_[IL]REM_IMM.

### DIFF
--- a/mono/mini/basic-long.cs
+++ b/mono/mini/basic-long.cs
@@ -1212,6 +1212,16 @@ class Tests
 		return (int)res;
 	}
 
+	public static int test_0_lrem_imm_1 () {
+		long b = 12L;
+		return (int)(b % 1L);
+	}
+
+	public static int test_0_lrem_imm_1_neg () {
+		long b = -2L;
+		return (int)(b % 1L);
+	}
+
 	public static int test_0_lrem_imm_2 ()
 	{
 		long x = 245345634L;

--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -98,7 +98,6 @@ long_conv_to_u1: dest:i src1:i len:4
 zext_i4: dest:i src1:i len:4
 
 long_mul_imm: dest:i src1:i clob:1 len:12
-long_rem_imm: dest:a src1:a len:32 clob:d
 long_min: dest:i src1:i src2:i len:16 clob:1
 long_min_un: dest:i src1:i src2:i len:16 clob:1
 long_max: dest:i src1:i src2:i len:16 clob:1
@@ -354,7 +353,6 @@ int_sub_imm: dest:i src1:i clob:1 len:8 nacl:10
 int_mul_imm: dest:i src1:i clob:1 len:32
 int_div_imm: dest:a src1:i clob:d len:32
 int_div_un_imm: dest:a src1:i clob:d len:32
-int_rem_imm: dest:a src1:a len:32 clob:d
 int_rem_un_imm: dest:d src1:i clob:a len:32
 int_and_imm: dest:i src1:i clob:1 len:8
 int_or_imm: dest:i src1:i clob:1 len:8

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -476,6 +476,43 @@ mono_decompose_opcode (MonoCompile *cfg, MonoInst *ins)
 		break;
 #endif
 
+#if SIZEOF_REGISTER == 8
+	case OP_LREM_IMM:
+#endif
+	case OP_IREM_IMM: {
+		int power = mono_is_power_of_two (ins->inst_imm);
+		if (ins->inst_imm == 1) {
+			ins->opcode = OP_ICONST;
+			MONO_INST_NULLIFY_SREGS (ins);
+			ins->inst_c0 = 0;
+		} else if ((ins->inst_imm > 0) && (ins->inst_imm < (1L << 32)) && (power != -1)) {
+			gboolean is_long = ins->opcode == OP_LREM_IMM;
+			int compensator_reg = alloc_ireg (cfg);
+			int intermediate_reg;
+
+			/* Based on gcc code */
+
+			/* Add compensation for negative numerators */
+
+			if (power > 1) {
+				intermediate_reg = compensator_reg;
+				MONO_EMIT_NEW_BIALU_IMM (cfg, is_long ? OP_LSHR_IMM : OP_SHR_IMM, intermediate_reg, ins->sreg1, is_long ? 63 : 31);
+			} else {
+				intermediate_reg = ins->sreg1;
+			}
+
+			MONO_EMIT_NEW_BIALU_IMM (cfg, is_long ? OP_LSHR_UN_IMM : OP_SHR_UN_IMM, compensator_reg, intermediate_reg, (is_long ? 64 : 32) - power);
+			MONO_EMIT_NEW_BIALU (cfg, is_long ? OP_LADD : OP_IADD, ins->dreg, ins->sreg1, compensator_reg);
+			/* Compute remainder */
+			MONO_EMIT_NEW_BIALU_IMM (cfg, is_long ? OP_LAND_IMM : OP_AND_IMM, ins->dreg, ins->dreg, (1 << power) - 1);
+			/* Remove compensation */
+			MONO_EMIT_NEW_BIALU (cfg, is_long ? OP_LSUB : OP_ISUB, ins->dreg, ins->dreg, compensator_reg);
+
+			NULLIFY_INS (ins);
+		}
+		break;
+	}
+
 	default:
 		emulate = TRUE;
 		break;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12365,7 +12365,7 @@ mono_op_to_op_imm (int opcode)
 		return OP_LSHR_IMM;
 	case OP_LSHR_UN:
 		return OP_LSHR_UN_IMM;
-#ifdef MONO_ARCH_HAVE_OP_LREM_IMM
+#if SIZEOF_REGISTER == 8
 	case OP_LREM:
 		return OP_LREM_IMM;
 #endif


### PR DESCRIPTION
Instead of generating a sequence of AMD64 instructions for
power-of-two OP_[IL]REM_IMM, portably decompose them to intermediate
code.

OP_IREM_IMM is decomposed on 32 and 64 bit archs, OP_LREM_IMM only on
64 bit archs.
