### PR TITLE
[system.data] BUGFIX: fixes issue with expression columns and IsNull:

### DIFF
--- a/mcs/class/System.Data/System.Data/DataColumn.cs
+++ b/mcs/class/System.Data/System.Data/DataColumn.cs
@@ -474,7 +474,7 @@ namespace System.Data {
 		public string Expression {
 			get { return _expression; }
 			set {
-				if (value == null)
+				if (value == null || value.Trim () == string.Empty)
 					value = String.Empty;
 
 				CompileExpression (value);

--- a/mcs/class/System.Data/System.Data/DataRow.cs
+++ b/mcs/class/System.Data/System.Data/DataRow.cs
@@ -134,10 +134,7 @@ namespace System.Data {
 		public object this [string columnName] {
 			get { return this [columnName, DataRowVersion.Default]; }
 			set {
-				DataColumn column = _table.Columns [columnName];
-				if (column == null)
-					throw new ArgumentException ("The column '" + columnName +
-						"' does not belong to the table : " + _table.TableName);
+				DataColumn column = GetColumn (columnName);
 				this [column.Ordinal] = value;
 			}
 		}
@@ -202,10 +199,7 @@ namespace System.Data {
 		/// </summary>
 		public object this [string columnName, DataRowVersion version] {
 			get {
-				DataColumn column = _table.Columns [columnName];
-				if (column == null)
-					throw new ArgumentException ("The column '" + columnName +
-						"' does not belong to the table : " + _table.TableName);
+				DataColumn column = GetColumn (columnName);
 				return this [column.Ordinal, version];
 			}
 		}
@@ -1248,7 +1242,7 @@ namespace System.Data {
 		/// </summary>
 		public bool IsNull (string columnName)
 		{
-			return IsNull (Table.Columns [columnName]);
+			return IsNull (GetColumn (columnName));
 		}
 
 		/// <summary>
@@ -1257,6 +1251,9 @@ namespace System.Data {
 		/// </summary>
 		public bool IsNull (DataColumn column, DataRowVersion version)
 		{
+			if (column == null)
+				throw new ArgumentNullException ("column");
+
 			// use the expresion if there is one
 			if (column.Expression != String.Empty) {
 				// FIXME: how does this handle 'version'?
@@ -1700,5 +1697,15 @@ namespace System.Data {
 			}
 		}
 #endif // NET_2_0
+
+		DataColumn GetColumn (string columnName)
+		{
+			DataColumn column = _table.Columns [columnName];
+
+			if (column == null)
+				throw new ArgumentException ("The column '" + columnName + "' does not belong to the table " + _table.TableName);
+
+			return column;
+		}
 	}
 }

--- a/mcs/class/System.Data/Test/System.Data/DataColumnTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataColumnTest2.cs
@@ -543,6 +543,23 @@ namespace MonoTests.System.Data
 		}
 
 		[Test]
+		public void Expression_Whitespace ()
+		{
+			DataColumn dc = new DataColumn ("ColName", typeof(string));
+
+			string plainWhitespace = "    ";
+			string surroundWhitespace = "  'abc'  ";
+
+			Assert.AreEqual (string.Empty, dc.Expression, "dce#1");
+
+			dc.Expression = plainWhitespace;
+			Assert.AreEqual (string.Empty, dc.Expression, "dce#2");
+
+			dc.Expression = surroundWhitespace;
+			Assert.AreEqual (surroundWhitespace, dc.Expression, "dce#3");
+		}
+
+		[Test]
 		public void Expression_Exceptions()
 		{
 			DataTable dt = DataProvider.CreateParentDataTable();

--- a/mcs/class/System.Data/Test/System.Data/DataRowTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataRowTest2.cs
@@ -2147,6 +2147,37 @@ namespace MonoTests.System.Data
 			Assert.AreEqual ("the value", row ["second"], "second level value check failed");
 		}
 
+		[Test]
+		public void IsNull_NullValueArguments ()
+		{
+			DataTable table = new DataTable ();
+
+			// add the row, with the value in the column
+			DataColumn staticColumn = table.Columns.Add ("static", typeof(string), null);
+			DataRow row = table.Rows.Add ("the value");
+
+			try {
+				row.IsNull ((string)null);
+				Assert.Fail ("expected an arg null exception for passing a null string");
+			} catch (ArgumentNullException) {
+				// do nothing as null columns aren't allowed
+			}
+
+			try {
+				row.IsNull ("");
+				Assert.Fail ("expected an arg exception for passing an empty string");
+			} catch (ArgumentException) {
+				// do nothing as we can't find a col with no name
+			}
+
+			try {
+				row.IsNull (null, DataRowVersion.Default);
+				Assert.Fail ("null column with version check failed");
+			} catch (ArgumentNullException) {
+				// do nothing as null columns aren't allowed
+			}
+		}
+
 		[Test] public void Item()
 		{
 			// init table with columns


### PR DESCRIPTION
- bugzilla.xamarin.com issue 20925 (https://bugzilla.xamarin.com/show_bug.cgi?id=20925)
- if an expression column was added after there were rows, and then IsNull is called, the result is incorrect (it will always be true)
