### PR TITLE
[mcs tests] Add tests/dlls/*.il to DISTFILES

### DIFF
--- a/mcs/tests/Makefile
+++ b/mcs/tests/Makefile
@@ -6,7 +6,7 @@ thisdir = tests
 SUBDIRS =
 include ../build/rules.make
 
-DISTFILES = $(wildcard dlls/**/*.cs) $(wildcard dlls/*.cs) $(wildcard dlls/*.inc)
+DISTFILES = $(wildcard dlls/**/*.cs) $(wildcard dlls/*.cs) $(wildcard dlls/*.inc) $(wildcard dlls/*.il)
 DISTFILES += $(wildcard *.cs) $(wildcard *.il) $(wildcard *.xml) $(wildcard *.inc) $(wildcard known-issues-*) $(wildcard *.snk)
 
 with_mono_path = MONO_PATH="$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH"


### PR DESCRIPTION
Without this,

```
cd mcs/tests && make run-test
```

fails when run from a distribution tarball.
