### PR TITLE
[System.Web] Tests: Add a timeout for WaitOne () calls

### DIFF
--- a/mcs/class/System.Web/Test/System.Web.Compilation/AppResourcesCompilerTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.Compilation/AppResourcesCompilerTest.cs
@@ -48,7 +48,6 @@ namespace MonoTests.System.Web.Compilation
 		}
 
 		[Test (Description="Bug #548768")]
-		[Category ("NotWorking")]
 		public void GlobalResourcesLocalization ()
 		{
 			string pageHtml = new WebTest ("GlobalResourcesLocalization.aspx").Run ();

--- a/mcs/class/System.Web/Test/mainsoft/NunitWeb/NunitWeb/MyHost.cs
+++ b/mcs/class/System.Web/Test/mainsoft/NunitWeb/NunitWeb/MyHost.cs
@@ -49,7 +49,8 @@ namespace MonoTests.SystemWeb.Framework
 		{
 			_currentTest = t;
 			_doNext.Set ();
-			_done.WaitOne ();
+			if (!_done.WaitOne (TimeSpan.FromSeconds (20)))
+				throw new TimeoutException ("No signal received for _done.");
 			if (_e != null) {
 				Exception e = _e;
 				_e = null;
@@ -61,7 +62,8 @@ namespace MonoTests.SystemWeb.Framework
 		void AsyncRun (object param)
 		{
 			for (;;) {
-			_doNext.WaitOne ();
+			if (!_doNext.WaitOne (TimeSpan.FromSeconds (20)))
+				throw new TimeoutException ("No signal received for _doNext.");
 			try {
 			WebTest t = _currentTest;
 			HttpWorkerRequest wr = t.Request.CreateWorkerRequest ();


### PR DESCRIPTION
This should get rid of the test hangs we're seeing on monojenkins (although it doesn't yet fix the underlying problem).

Note: before this fix, I could reproduce the hang once with the following GDB output: http://pastebin.com/pUnzQcJ3

@alexrp: does it make sense that the hangs are caused by the WaitOne calls or am I misinterpreting the GDB output?
