### PR TITLE
[System.Web] Tests: Fix deadlock when ThreadAbortException is thrown

### DIFF
--- a/mcs/class/System.Web/Test/System.Web.Compilation/AppResourcesCompilerTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.Compilation/AppResourcesCompilerTest.cs
@@ -48,7 +48,6 @@ namespace MonoTests.System.Web.Compilation
 		}
 
 		[Test (Description="Bug #548768")]
-		[Category ("NotWorking")]
 		public void GlobalResourcesLocalization ()
 		{
 			string pageHtml = new WebTest ("GlobalResourcesLocalization.aspx").Run ();


### PR DESCRIPTION
This reverts commit ed11296c511d670391374fbb68e2988a9c1e8789.

When a ThreadAbortException is thrown during request processing in AsyncRun () the _done.Set () call is not executed.
This then results in a deadlock because _done.WaitOne () doesn't get signaled and waits forever.
One solution would be enclosing the _done.Set () in a finally clause, but even then we'd need to relaunch the AsyncRun () loop to be in a usable state.

A simpler solution is to revert the commit that introduced the AsyncRun () in the first place, as it doesn't seem necessary now (the tests pass just fine without it).

The test that was disabled in 429cdf17cf3a4887d9882380beebbf0d119e65ab is reenabled too, as it wasn't the culprit of the problem.
