### PR TITLE
[dist] Do not include .git link files in dist tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,7 @@ GIT_DIR ?= $(srcdir)/.git
 dist-hook:
 	test -d $(distdir)/mcs || mkdir $(distdir)/mcs
 	d=`cd $(distdir)/mcs && pwd`; cd $(mcs_topdir) && $(MAKE) distdir=$$d dist-recursive
-	rm -rf `find $(top_distdir)/external -path '*\.git' -and -type d`
+	rm -rf `find $(top_distdir)/external -path '*\.git'`
 	cp mcs/class/lib/basic/System.Configuration.dll mcs/class/lib/monolite/
 	cp mcs/class/lib/basic/System.Security.dll mcs/class/lib/monolite/
 # Disable this for now because it is very slow and causes wrench to timeout:


### PR DESCRIPTION
Recent versions of Git co-host submodule `GIT_DIR`s in `<root-project>/.git/`
by default, and write their relative path into `<subproject>/.git`,
which is a regular file:

```
$ ls -l external/cecil/.git
-rw-r--r-- 1 foo  bar  42 Jun 16 12:50 external/cecil/.git
$ cat external/cecil/.git
gitdir: ../../.git/modules/external/cecil
```

Relax the expression in `Makefile.am` to also delete these (broken)
"symlinks" when preparing a distribution tarball.
