### PR TITLE
[tools] Fixed mono-shlib-cop test

### DIFF
--- a/mcs/tools/mono-shlib-cop/Makefile
+++ b/mcs/tools/mono-shlib-cop/Makefile
@@ -20,7 +20,7 @@ cleanup:
 run-test-local: run-mono-shlib-cop-test
 
 run-mono-shlib-cop-test: $(the_lib) $(TEST_INPUT)
-	$(RUNTIME) $(the_lib) $(TEST_INPUT) | diff - test.dll.out
+	MONO_PATH="$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(the_lib) $(TEST_INPUT) | diff - test.dll.out
 
 $(TEST_INPUT) : test.cs
 	$(CSCOMPILE) -target:library $< -out:$@

--- a/mcs/tools/mono-shlib-cop/test.cs
+++ b/mcs/tools/mono-shlib-cop/test.cs
@@ -42,8 +42,8 @@ namespace Mono.Unmanaged.Check {
 		private static extern int g_module_close (IntPtr handle);
 
 		// Warning
-		[DllImport ("libglib-2.0.so")]
-		private static extern void g_free (IntPtr mem);
+		[DllImport ("libMonoPosixHelper.so")]
+		private static extern int Mono_Posix_Stdlib_TMP_MAX ();
 
 		// Error: no such library
 		[DllImport ("does-not-exist")]
@@ -60,7 +60,7 @@ namespace Mono.Unmanaged.Check {
 		Test ()
 		{
 			g_module_close (IntPtr.Zero);
-			g_free (IntPtr.Zero);
+			Mono_Posix_Stdlib_TMP_MAX ();
 			Foo ();
 			RenameMe ();
 			DoesNotExist ();

--- a/mcs/tools/mono-shlib-cop/test.dll.config
+++ b/mcs/tools/mono-shlib-cop/test.dll.config
@@ -1,4 +1,5 @@
 <configuration>
+	<dllmap dll="libMonoPosixHelper.so" target="../../../support/.libs/libMonoPosixHelper.so" />
 	<dllmap dll="libgmodule-2.0.so" target="libgmodule-2.0.so.0"/>
 	<dllmap dll="renamed-lib" target="libc.so.6"/>
 </configuration>

--- a/mcs/tools/mono-shlib-cop/test.dll.out
+++ b/mcs/tools/mono-shlib-cop/test.dll.out
@@ -1,4 +1,4 @@
 error: in Mono.Unmanaged.Check.Test.Foo: Could not load library `does-not-exist': ./libdoes-not-exist.so: cannot open shared object file: No such file or directory
 error: in Mono.Unmanaged.Check.Test.RenameMe: library `libc.so.6' is missing symbol `RenameMe'
 error: in Mono.Unmanaged.Check.Test.DoesNotExist: library `libc.so.6' is missing symbol `DoesNotExist'
-warning: in Mono.Unmanaged.Check.Test.g_free: Library `libglib-2.0.so' might be a development library
+warning: in Mono.Unmanaged.Check.Test.Mono_Posix_Stdlib_TMP_MAX: Library `../../../support/.libs/libMonoPosixHelper.so' might be a development library


### PR DESCRIPTION
MONO_PATH was missing when running the tests.

Use "libMonoPosixHelper.so" in local directory when checking if DllImport of a development library generates a warning (libglib2.0-dev might not be installed, but libMonoPosixHelper is always built with mono)
