### PR TITLE
[tests] gc-descriptors: Only copy file in case of VPATH build

### DIFF
--- a/mono/tests/gc-descriptors/Makefile.am
+++ b/mono/tests/gc-descriptors/Makefile.am
@@ -10,7 +10,7 @@ descriptor-tests.exe : descriptor-tests.cs
 	$(MCS) -Warn:0 descriptor-tests.cs
 
 descriptor-tests.cs : descriptor-tests-driver.cs descriptor-tests-prefix.cs gen-descriptor-tests.py
-	-cp $^ .
+	if [ "$(srcdir)" != "$(builddir)" ]; then cp $^ .; fi
 	$(srcdir)/gen-descriptor-tests.py >descriptor-tests.cs
 
 EXTRA_DIST = descriptor-tests-driver.cs descriptor-tests-prefix.cs gen-descriptor-tests.py


### PR DESCRIPTION
Instead of ignoring the cp error when copying over the same file in non-VPATH builds.

This is purely a convenience fix for one of my scripts that processes the log, without this the log shows the following:

> cp: ‘descriptor-tests-driver.cs’ and ‘./descriptor-tests-driver.cs’ are the same file
> cp: ‘descriptor-tests-prefix.cs’ and ‘./descriptor-tests-prefix.cs’ are the same file
> cp: ‘gen-descriptor-tests.py’ and ‘./gen-descriptor-tests.py’ are the same file
> make[4]: [descriptor-tests.cs] Error 1 (ignored)
