### PR TITLE
[docs] Removed DoesNotExist from toc.xml

### DIFF
--- a/docs/toc.xml
+++ b/docs/toc.xml
@@ -6,12 +6,6 @@
       <param name="Auto Generated" value="No"/>
 	</object>
     <ul>
-      <li>
-        <object type="text/sitemap">
-          <param name="Name" value="Mono Runtime API"/>
-          <param name="Local" value="DoesNotExist"/>
-        </object>
-      </li>
 	  <li>
 		<object type="text/sitemap">
 	      <param name="Name" value="Assemblies"/>


### PR DESCRIPTION
This raised an error on the first build of a clean checkout:

> MDOC    [net_4_5] mono-tools.tree
> File `DoesNotExist' referenced in TOC but it doesn't exist.
