### PR TITLE
[System] Fixed HttpWebRequest test that sometimes failed

### DIFF
--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -1499,7 +1499,7 @@ namespace MonoTests.System.Net
 			Assert.IsNotNull (webEx, "Exception thrown should be WebException, but was: " +
 			                  timeoutWorker.Exception.GetType ().FullName);
 
-			Assert.AreEqual (webEx.Status, WebExceptionStatus.Timeout,
+			Assert.AreEqual (WebExceptionStatus.Timeout, webEx.Status,
 			                 "WebException was thrown, but with a wrong status (should be timeout): " + webEx.Status);
 
 			Assert.IsFalse (timeoutWorker.End > (timeoutWorker.Start + TimeSpan.FromMilliseconds (three_seconds_in_milliseconds + 500)),
@@ -1525,7 +1525,7 @@ namespace MonoTests.System.Net
 		[Test] // 2nd possible case of https://bugzilla.novell.com/show_bug.cgi?id=MONO74177
 		public void TestTimeoutPropertyWithServerThatDoesntExist ()
 		{
-			string url = "http://10.128.200.100:8271/"; // some endpoint that is unlikely to exist
+			string url = "http://8.8.8.8:8271/"; // some endpoint that is unlikely to exist
 
 			TestTimeOut (url);
 		}


### PR DESCRIPTION
The TestTimeoutPropertyWithServerThatDoesntExist test sometimes failed with a 'ConnectFailure' instead
of a 'Timeout', presumably because connecting to the non-existing IP failed earlier than the timeout was reached.
Using a public, existing IP (but still with a port where no service listens) made this test reliable for me.

Additionally, the assert which checks for the correct exception switched the 'expected' and 'actual' parameter, which resulted in the wrong output.

I'm actually not sure if this test is even testing the right thing (i.e. it sounds plausible that the connection fails before the timeout if the IP doesn't exist).
@knocte: you added this test, do you remember some context about this? The linked bug doesn't seem to go into much detail about why this would be the correct behavior.
