### PR TITLE
Fixed a possible deadlock in WebConnectionStream

### DIFF
--- a/mcs/class/System/System.Net/WebConnectionStream.cs
+++ b/mcs/class/System/System.Net/WebConnectionStream.cs
@@ -234,7 +234,8 @@ namespace System.Net
 				return;
 			}
 
-			pending.WaitOne ();
+			if (!pending.WaitOne (ReadTimeout))
+				throw new WebException ("The operation has timed out.", WebExceptionStatus.Timeout);
 			lock (locker) {
 				if (totalRead >= contentLength)
 					return;
@@ -592,6 +593,14 @@ namespace System.Net
 			if (result.EndCalled)
 				return;
 
+			if (sendChunked) {
+				lock (locker) {
+					pendingWrites--;
+					if (pendingWrites <= 0)
+						pending.Set ();
+				}
+			}
+
 			result.EndCalled = true;
 			if (result.AsyncWriteAll) {
 				result.WaitUntilComplete ();
@@ -605,14 +614,6 @@ namespace System.Net
 
 			if (result.GotException)
 				throw result.Exception;
-
-			if (sendChunked) {
-				lock (locker) {
-					pendingWrites--;
-					if (pendingWrites == 0)
-						pending.Set ();
-				}
-			}
 		}
 		
 		public override void Write (byte [] buffer, int offset, int size)
@@ -761,7 +762,9 @@ namespace System.Net
 				if (disposed)
 					return;
 				disposed = true;
-				pending.WaitOne ();
+				if (!pending.WaitOne (WriteTimeout)) {
+					throw new WebException ("The operation has timed out.", WebExceptionStatus.Timeout);
+				}
 				byte [] chunk = Encoding.ASCII.GetBytes ("0\r\n\r\n");
 				string err_msg = null;
 				cnc.Write (request, chunk, 0, chunk.Length, ref err_msg);


### PR DESCRIPTION
This patch fixes a possible deadlock that happens in WebConnectionStream.Close() when using a writeStream together with chunked transfer encoding under heavy system load.

Just in case this falls under the dual-licensed part:
I'd like to contribute this under the MIT X11 license.
