### PR TITLE
Fix several issues in System.Json

### DIFF
--- a/mcs/class/System.Json/System.Json/JsonPrimitive.cs
+++ b/mcs/class/System.Json/System.Json/JsonPrimitive.cs
@@ -163,7 +163,16 @@ namespace System.Json
 					return (string) value;
 				throw new NotImplementedException ("GetFormattedString from value type " + value.GetType ());
 			case JsonType.Number:
-				return ((IFormattable) value).ToString ("G", NumberFormatInfo.InvariantInfo);
+				string s;
+				if (value is float || value is double)
+					// Use "round-trip" format
+					s = ((IFormattable) value).ToString ("R", NumberFormatInfo.InvariantInfo);
+				else
+					s = ((IFormattable) value).ToString ("G", NumberFormatInfo.InvariantInfo);
+				if (s == "NaN" || s == "Infinity" || s == "-Infinity")
+					return "\"" + s + "\"";
+				else
+					return s;
 			default:
 				throw new InvalidOperationException ();
 			}

--- a/mcs/class/System.Json/System.Json/JsonValue.cs
+++ b/mcs/class/System.Json/System.Json/JsonValue.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;
@@ -328,70 +329,70 @@ namespace System.Json
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToBoolean (((JsonPrimitive) value).Value);
+			return Convert.ToBoolean (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator byte (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToByte (((JsonPrimitive) value).Value);
+			return Convert.ToByte (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator char (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToChar (((JsonPrimitive) value).Value);
+			return Convert.ToChar (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator decimal (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToDecimal (((JsonPrimitive) value).Value);
+			return Convert.ToDecimal (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator double (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToDouble (((JsonPrimitive) value).Value);
+			return Convert.ToDouble (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator float (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToSingle (((JsonPrimitive) value).Value);
+			return Convert.ToSingle (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator int (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToInt32 (((JsonPrimitive) value).Value);
+			return Convert.ToInt32 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator long (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToInt64 (((JsonPrimitive) value).Value);
+			return Convert.ToInt64 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator sbyte (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToSByte (((JsonPrimitive) value).Value);
+			return Convert.ToSByte (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator short (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToInt16 (((JsonPrimitive) value).Value);
+			return Convert.ToInt16 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator string (JsonValue value)
@@ -405,21 +406,21 @@ namespace System.Json
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToUInt16 (((JsonPrimitive) value).Value);
+			return Convert.ToUInt16 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator ulong (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToUInt64(((JsonPrimitive) value).Value);
+			return Convert.ToUInt64(((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator ushort (JsonValue value)
 		{
 			if (value == null)
 				throw new ArgumentNullException ("value");
-			return Convert.ToUInt16 (((JsonPrimitive) value).Value);
+			return Convert.ToUInt16 (((JsonPrimitive) value).Value, NumberFormatInfo.InvariantInfo);
 		}
 
 		public static implicit operator DateTime (JsonValue value)

--- a/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
+++ b/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
@@ -11,6 +11,8 @@ using System;
 using System.IO;
 using System.Text;
 using System.Json;
+using System.Globalization;
+using System.Threading;
 
 namespace MonoTests.System
 {
@@ -24,6 +26,14 @@ namespace MonoTests.System
 			Assert.AreEqual (1, j.Count, "itemcount");
 			Assert.AreEqual (JsonType.String, j ["a"].JsonType, "type");
 			Assert.AreEqual ("b", (string) j ["a"], "value");
+
+			JsonValue.Parse ("[{ \"a\": \"b\",}]");
+		}
+
+		[Test]
+		public void LoadWithTrailingComma2 ()
+		{
+			JsonValue.Parse ("[{ \"a\": \"b\",}]");
 		}
 
 		// Test that we correctly serialize JsonArray with null elements.
@@ -40,6 +50,136 @@ namespace MonoTests.System
 		public void QuoteEscapeBug_20869 () 
 		{
 			Assert.AreEqual ((new JsonPrimitive ("\"\"")).ToString (), "\"\\\"\\\"\"");
+		}
+
+		void ExpectError (string s)
+		{
+			try {
+				JsonValue.Parse (s);
+				Assert.Fail ("Expected ArgumentException for `" + s + "'");
+			} catch (ArgumentException) {
+			}
+		}
+
+		// Test whether an exception is thrown for invalid JSON
+		[Test]
+		public void CheckErrors () 
+		{
+			ExpectError (@"-");
+			ExpectError (@"- ");
+			ExpectError (@"1.");
+			ExpectError (@"1. ");
+			ExpectError (@"1e+");
+			ExpectError (@"1 2");
+			ExpectError (@"077");
+
+			ExpectError (@"[1,]");
+
+			//ExpectError (@"{""a"":1,}"); // Not valid JSON, allowed anyway
+		}
+
+		// Parse a json string and compare to the expected value
+		void CheckDouble (double expected, string json)
+		{
+			double jvalue = (double) JsonValue.Parse (json);
+			Assert.AreEqual (expected, jvalue);
+		}
+
+		// Convert a number to json and parse the string, then compare the result to the original value
+		void CheckDouble (double number)
+		{
+			double jvalue = (double) JsonValue.Parse (new JsonPrimitive (number).ToString ());
+			Assert.AreEqual (number, jvalue); // should be exactly the same
+		}
+
+		[Test]
+		public void CheckNumbers () 
+		{
+			CheckDouble (0, "0");
+			CheckDouble (0, "-0");
+			CheckDouble (0, "0.00");
+			CheckDouble (0, "-0.00");
+			CheckDouble (1, "1");
+			CheckDouble (1.1, "1.1");
+			CheckDouble (-1, "-1");
+			CheckDouble (-1.1, "-1.1");
+			CheckDouble (1e-10, "1e-10");
+			CheckDouble (1e+10, "1e+10");
+			CheckDouble (1e-30, "1e-30");
+			CheckDouble (1e+30, "1e+30");
+
+			CheckDouble (1, "\"1\"");
+			CheckDouble (1.1, "\"1.1\"");
+			CheckDouble (-1, "\"-1\"");
+			CheckDouble (-1.1, "\"-1.1\"");
+
+			CheckDouble (double.NaN, "\"NaN\"");
+			CheckDouble (double.PositiveInfinity, "\"Infinity\"");
+			CheckDouble (double.NegativeInfinity, "\"-Infinity\"");
+
+			ExpectError ("NaN");
+			ExpectError ("Infinity");
+			ExpectError ("-Infinity");
+
+			Assert.AreEqual ("1.1", new JsonPrimitive (1.1).ToString ());
+			Assert.AreEqual ("-1.1", new JsonPrimitive (-1.1).ToString ());
+			Assert.AreEqual ("1E-20", new JsonPrimitive (1e-20).ToString ());
+			Assert.AreEqual ("1E+20", new JsonPrimitive (1e+20).ToString ());
+			Assert.AreEqual ("1E-30", new JsonPrimitive (1e-30).ToString ());
+			Assert.AreEqual ("1E+30", new JsonPrimitive (1e+30).ToString ());
+			Assert.AreEqual ("\"NaN\"", new JsonPrimitive (double.NaN).ToString ());
+			Assert.AreEqual ("\"Infinity\"", new JsonPrimitive (double.PositiveInfinity).ToString ());
+			Assert.AreEqual ("\"-Infinity\"", new JsonPrimitive (double.NegativeInfinity).ToString ());
+
+			Assert.AreEqual ("1E-30", JsonValue.Parse ("1e-30").ToString ());
+			Assert.AreEqual ("1E+30", JsonValue.Parse ("1e+30").ToString ());
+
+			CheckDouble (1);
+			CheckDouble (1.1);
+			CheckDouble (1.25);
+			CheckDouble (-1);
+			CheckDouble (-1.1);
+			CheckDouble (-1.25);
+			CheckDouble (1e-20);
+			CheckDouble (1e+20);
+			CheckDouble (1e-30);
+			CheckDouble (1e+30);
+			CheckDouble (3.1415926535897932384626433);
+			CheckDouble (3.1415926535897932384626433e-20);
+			CheckDouble (3.1415926535897932384626433e+20);
+			CheckDouble (double.NaN);
+			CheckDouble (double.PositiveInfinity);
+			CheckDouble (double.NegativeInfinity);
+			CheckDouble (double.MinValue);
+			CheckDouble (double.MaxValue);
+
+			// A number which needs 17 digits (see http://stackoverflow.com/questions/6118231/why-do-i-need-17-significant-digits-and-not-16-to-represent-a-double)
+			CheckDouble (18014398509481982.0);
+
+			// Values around the smallest positive decimal value
+			CheckDouble (1.123456789e-29);
+			CheckDouble (1.123456789e-28);
+
+			CheckDouble (1.1E-29, "0.000000000000000000000000000011");
+			// This is being parsed as a decimal and rounded to 1e-28, even though it can be more accurately be represented by a double
+			//CheckDouble (1.1E-28, "0.00000000000000000000000000011");
+		}
+
+		// Retry the test with different locales
+		[Test]
+		public void CheckNumbersCulture () 
+		{
+			CultureInfo old = Thread.CurrentThread.CurrentCulture;
+			try {
+				Thread.CurrentThread.CurrentCulture = new CultureInfo ("en");
+				CheckNumbers ();
+				Thread.CurrentThread.CurrentCulture = new CultureInfo ("fr");
+				CheckNumbers ();
+				Thread.CurrentThread.CurrentCulture = new CultureInfo ("de");
+				CheckNumbers ();
+			} finally {
+				Thread.CurrentThread.CurrentCulture = old;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This commit fixes several issues in System.Json
- Fix detection of extra characters in JSON input (e.g. reject "1 1")
- Fix detection of invalid negative numeric literals (e.g. reject "- ")
- Disallow leading zeros. Leading zeros are a bad idea because JavaScript will parse them as octal values.
- Use "round-trip" format for floating point numbers. This should ensure that writing a double to a json file and reading it back will yield exactly the same value.
- Serialize NaN and Infinity as strings. Currently NaN gets serialized as "NaN" (with quotes) but Infinity as Infinity or -Infinity (without quotes). The forms without quotes are not valid JSON. This commit also makes sure that the forms with quotes can be converted back to double.
- Use NumberFormatInfo.InvariantInfo for Convert.To*(). These conversions shouldn't depend on the locale. (I.e. (double)JsonValue.Parse("\"0.5\"") should always work and return 0.5)
- Use standard number parsing methods in ReadNumericLiteral(). This fixes lots of problems with parsing large / small exponents. Parsing values as decimals and then converting it to double will causes rounding problems in many cases.
- Add test cases. I've added test cases for basically all the stuff that was changed / fixed.
