### PR TITLE
Fixes https://github.com/OfficeDev/Open-XML-SDK/issues/7 by allow absolute urls in relationships

### DIFF
--- a/mcs/class/WindowsBase/System.IO.Packaging/PackagePart.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/PackagePart.cs
@@ -165,7 +165,7 @@ namespace System.IO.Packaging {
 				if (node.Attributes["TargetMode"] != null)
 					mode = (TargetMode) Enum.Parse (typeof(TargetMode), node.Attributes ["TargetMode"].Value);
 				
-				CreateRelationship (new Uri (node.Attributes["Target"].Value.ToString(), UriKind.Relative),
+				CreateRelationship (new Uri (node.Attributes["Target"].Value.ToString(), UriKind.RelativeOrAbsolute),
 				                    mode,
 				                    node.Attributes["Type"].Value.ToString (),
 				                    node.Attributes["Id"].Value.ToString (),


### PR DESCRIPTION
Right now the OfficeDev Open-Xml-SDK depends on being able to parse absolute URLs (such as those from embedded hyperlinks in word documents)
