### PR TITLE
[monodoc] Clarified message when a backing file isn't found

### DIFF
--- a/mcs/class/monodoc/Monodoc/providers/xhtml-provider.cs
+++ b/mcs/class/monodoc/Monodoc/providers/xhtml-provider.cs
@@ -49,7 +49,7 @@ namespace Monodoc.Providers
 				ObjectEntryToParams (inner, out caption, out element);
 				// Don't add if the backing file doesn't exist
 				if (!File.Exists (element)) {
-					Console.Error.WriteLine ("File `{0}' referenced in TOC but it doesn't exist.", element);
+					Console.Error.WriteLine ("Warning: File `{0}' referenced in TOC but it doesn't exist. It will be ignored.", element);
 					continue;
 				}
 				using (var file = File.OpenRead (element))


### PR DESCRIPTION
If the backing file doesn't exist, it will be ignored.

The previous message made it sound like this is a serious problem, which confused people as it is the last message that is printed when building Mono (because of a reference to 'DoesNotExist' in docs/toc.xml) while in reality everything is fine.
