### PR TITLE
Makes AppendTextUnquoted public.

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/CommandLineBuilder.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/CommandLineBuilder.cs
@@ -328,8 +328,13 @@ namespace Microsoft.Build.Utilities
 				}
 			}
 		}
-		
-		public void AppendTextUnquoted (string textToAppend)
+
+#if NET_4_0
+		public
+#else
+		protected
+#endif
+		void AppendTextUnquoted (string textToAppend)
 		{
 			commandLine.Append (textToAppend);
 		}


### PR DESCRIPTION
The Microsoft version is public, so should this be.
NuGet.MSBuild.Tools.CommandLineBuilderExtensions:AppendTextUnquotedIfNotNullOrEmpty attempts to call this method in NuGet for MSBuild NuGet package.
