### PR TITLE
Fix System.Json string handling and make order of JsonObject entries deterministic

### DIFF
--- a/mcs/class/System.Json/System.Json/JsonObject.cs
+++ b/mcs/class/System.Json/System.Json/JsonObject.cs
@@ -12,11 +12,12 @@ namespace System.Json
 {
 	public class JsonObject : JsonValue, IDictionary<string, JsonValue>, ICollection<JsonPair>
 	{
-		Dictionary<string, JsonValue> map;
+		// Use SortedDictionary to make result of ToString() deterministic
+		SortedDictionary<string, JsonValue> map;
 
 		public JsonObject (params JsonPair [] items)
 		{
-			map = new Dictionary<string, JsonValue> ();
+			map = new SortedDictionary<string, JsonValue> (StringComparer.Ordinal);
 
 			if (items != null)
 				AddRange (items);
@@ -27,7 +28,7 @@ namespace System.Json
 			if (items == null)
 				throw new ArgumentNullException ("items");
 
-			map = new Dictionary<string, JsonValue> ();
+			map = new SortedDictionary<string, JsonValue> (StringComparer.Ordinal);
 			AddRange (items);
 		}
 

--- a/mcs/class/System.Json/System.Json/JsonPrimitive.cs
+++ b/mcs/class/System.Json/System.Json/JsonPrimitive.cs
@@ -161,6 +161,8 @@ namespace System.Json
 			case JsonType.String:
 				if (value is string || value == null)
 					return (string) value;
+				if (value is char)
+					return value.ToString ();
 				throw new NotImplementedException ("GetFormattedString from value type " + value.GetType ());
 			case JsonType.Number:
 				string s;

--- a/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
+++ b/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
@@ -181,5 +181,64 @@ namespace MonoTests.System
 				Thread.CurrentThread.CurrentCulture = old;
 			}
 		}
+
+		// Convert a string to json and parse the string, then compare the result to the original value
+		void CheckString (string str)
+		{
+			var json = new JsonPrimitive (str).ToString ();
+			// Check whether the string is valid Unicode (will throw for broken surrogate pairs)
+			new UTF8Encoding (false, true).GetBytes (json);
+			string jvalue = (string) JsonValue.Parse (json);
+			Assert.AreEqual (str, jvalue);
+		}
+		
+		// String handling: http://tools.ietf.org/html/rfc7159#section-7
+		[Test]
+		public void CheckStrings () 
+		{
+			Assert.AreEqual ("\"test\"", new JsonPrimitive ("test").ToString ());
+			// Handling of characters
+			Assert.AreEqual ("\"f\"", new JsonPrimitive ('f').ToString ());
+			Assert.AreEqual ('f', (char) JsonValue.Parse ("\"f\""));
+
+			// Control characters with special escape sequence
+			Assert.AreEqual ("\"\\b\\f\\n\\r\\t\"", new JsonPrimitive ("\b\f\n\r\t").ToString ());
+			// Other characters which must be escaped
+			Assert.AreEqual (@"""\""\\""", new JsonPrimitive ("\"\\").ToString ());
+			// Control characters without special escape sequence
+			for (int i = 0; i < 32; i++)
+				if (i != '\b' && i != '\f' && i != '\n' && i != '\r' && i != '\t')
+					Assert.AreEqual ("\"\\u" + i.ToString ("x04") + "\"", new JsonPrimitive ("" + (char) i).ToString ());
+
+			// JSON does not require U+2028 and U+2029 to be escaped, but
+			// JavaScript does require this:
+			// http://stackoverflow.com/questions/2965293/javascript-parse-error-on-u2028-unicode-character/9168133#9168133
+			Assert.AreEqual ("\"\\u2028\\u2029\"", new JsonPrimitive ("\u2028\u2029").ToString ());
+
+			// '/' also does not have to be escaped, but escaping it when
+			// preceeded by a '<' avoids problems with JSON in HTML <script> tags
+			Assert.AreEqual ("\"<\\/\"", new JsonPrimitive ("</").ToString ());
+			// Don't escape '/' in other cases as this makes the JSON hard to read
+			Assert.AreEqual ("\"/bar\"", new JsonPrimitive ("/bar").ToString ());
+			Assert.AreEqual ("\"foo/bar\"", new JsonPrimitive ("foo/bar").ToString ());
+
+			CheckString ("test\b\f\n\r\t\"\\/</\0x");
+			for (int i = 0; i < 65536; i++)
+				CheckString ("x" + ((char) i));
+
+			// Check broken surrogate pairs
+			CheckString ("\ud800");
+			CheckString ("x\ud800");
+			CheckString ("\udfff\ud800");
+			CheckString ("\ude03\ud912");
+			CheckString ("\uc000\ubfff");
+			CheckString ("\udfffx");
+			// Valid strings should not be escaped:
+			Assert.AreEqual ("\"\ud7ff\"", new JsonPrimitive ("\ud7ff").ToString ());
+			Assert.AreEqual ("\"\ue000\"", new JsonPrimitive ("\ue000").ToString ());
+			Assert.AreEqual ("\"\ud800\udc00\"", new JsonPrimitive ("\ud800\udc00").ToString ());
+			Assert.AreEqual ("\"\ud912\ude03\"", new JsonPrimitive ("\ud912\ude03").ToString ());
+			Assert.AreEqual ("\"\udbff\udfff\"", new JsonPrimitive ("\udbff\udfff").ToString ());
+		}
 	}
 }

--- a/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
+++ b/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
@@ -46,6 +46,26 @@ namespace MonoTests.System
 			Assert.AreEqual (str, "[1, 2, 3, null]");
 		}
 
+		// Test that we correctly serialize JsonObject with null elements.
+		[Test]
+		public void ToStringOnJsonObjectWithNulls () {
+			var j = JsonValue.Load (new StringReader ("{\"a\":null,\"b\":2}"));
+			Assert.AreEqual (2, j.Count, "itemcount");
+			Assert.AreEqual (JsonType.Object, j.JsonType, "type");
+			var str = j.ToString ();
+			Assert.AreEqual (str, "{\"a\": null, \"b\": 2}");
+		}
+
+		[Test]
+		public void JsonObjectOrder () {
+			var obj = new JsonObject ();
+			obj["a"] = 1;
+			obj["c"] = 3;
+			obj["b"] = 2;
+			var str = obj.ToString ();
+			Assert.AreEqual (str, "{\"a\": 1, \"b\": 2, \"c\": 3}");
+		}
+
 		[Test]
 		public void QuoteEscapeBug_20869 () 
 		{

--- a/mcs/class/System.ServiceModel.Web/System.Runtime.Serialization.Json/JavaScriptReader.cs
+++ b/mcs/class/System.ServiceModel.Web/System.Runtime.Serialization.Json/JavaScriptReader.cs
@@ -164,9 +164,7 @@ namespace System.Runtime.Serialization.Json
 		{
 			var sb = new StringBuilder ();
 			
-			bool negative = false;
 			if (PeekChar () == '-') {
-				negative = true;
 				sb.Append ((char) ReadChar ());
 			}
 


### PR DESCRIPTION
Fix handling of strings in System.Json:
- Escape control characters, as required by JSON spec (i.e. ASCII 0-31)
- Escape invalid surrogate pairs (so we get valid Unicode even for invalid strings)
- Escape characters invalid in JavaScript strings (not needed to get valid JSON, get generally useful)
- Escape "&lt;/" for HTML script tags (not needed to get valid JSON, get generally useful as "&lt;/" is not a valid sequence in HTML &lt;script> tags)
- Fix serialization of chars
- Remove unused variable in JavaScriptReader.cs
- Add tests

Use SortedDictionary in System.Json.JsonObject:
Currently JsonObject uses a Dictionary and JsonValue does not sort the keys in SaveInternal(). As iterating over a Dictionary returns the values in random order, this causes the JSON string to be non-deterministic.
Switching to SortedDictionary makes sure that the same object always will produce the same JSON string.
The keys are sorted using StringComparer.Ordinal to produce the same order in all locales.
