### PR TITLE
[mcs] Fix compiling "string"+object if corlib don't have nullable types

### DIFF
--- a/mcs/mcs/expression.cs
+++ b/mcs/mcs/expression.cs
@@ -3172,10 +3172,14 @@ namespace Mono.CSharp
 		public static PredefinedOperator[] CreateStandardLiftedOperatorsTable (ModuleContainer module)
 		{
 			var nullable = module.PredefinedTypes.Nullable.TypeSpec;
-			if (nullable == null)
-				return new PredefinedOperator [0];
-
 			var types = module.Compiler.BuiltinTypes;
+			if (nullable == null) {
+				return new [] {
+					new PredefinedStringOperator (types.String, types.Object, Operator.AdditionMask, types.String),
+					new PredefinedStringOperator (types.Object, types.String, Operator.AdditionMask, types.String)
+				};
+			}
+
 			var bool_type = types.Bool;
 
 			var nullable_bool = nullable.MakeGenericType (module, new[] { bool_type });


### PR DESCRIPTION
With commit 09ca788b4b0c7c1fc3e84cf96dda1440001a79c3 when string+(object, int, double...) addition operator was moved into lifted group with nullables in case nullables are not defined in corlib(e.g. MicroFramework corlib doesn't have nullables) mcs didn't compile this statment: string newStringValue="someString"+1; but instead generate error: CS0019: Operator '+' cannot be applied to operands of type 'string' and 'int'
