### PR TITLE
Remove throws in public getters

### DIFF
--- a/mcs/class/corlib/System.Reflection/FieldInfo.cs
+++ b/mcs/class/corlib/System.Reflection/FieldInfo.cs
@@ -278,19 +278,19 @@ namespace System.Reflection {
 		
 		public virtual bool IsSecurityCritical {
 			get {
-				throw new NotImplementedException ();
+				return false;
 			}
 		}
 		
 		public virtual bool IsSecuritySafeCritical {
 			get {
-				throw new NotImplementedException ();
+				return false;
 			}
 		}
 
 		public virtual bool IsSecurityTransparent {
 			get {
-				throw new NotImplementedException ();
+				return false;
 			}
 		}
 #endif


### PR DESCRIPTION
Getters with throws can cause serialization problems.