### PR TITLE
[mcs] Loosing properties in CallTarget

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/CallTarget.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/CallTarget.cs
@@ -54,8 +54,7 @@ namespace Microsoft.Build.Tasks {
 			Hashtable targets_table = new Hashtable ();
 
 			if (!RunEachTargetSeparately) {
-				bool ret = BuildEngine.BuildProjectFile (BuildEngine.ProjectFileOfTaskNode,
-						targets, null, targets_table);
+				bool ret = BuildEngine.BuildProjectFile (null, targets, null, targets_table);
 				foreach (ITaskItem[] items in targets_table.Values) {
 					if (items != null)
 						targetOutputs_list.AddRange (items);


### PR DESCRIPTION
Msbuild keep the properties in CallTarget. Fix xbuild for having the same behavior.