### PR TITLE
[Mono.Debugger.Soft] Added methods EndInvokeMethodWithResult to all mirrors

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
@@ -165,6 +165,10 @@ namespace Mono.Debugger.Soft
 			return EndInvokeMethodInternal (asyncResult);
 		}
 
+		public InvokeResult EndInvokeMethodWithResult (IAsyncResult asyncResult) {
+			return  ObjectMirror.EndInvokeMethodInternalWithResult (asyncResult);
+		}
+
 #if NET_4_5
 		public Task<Value> InvokeMethodAsync (ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options = InvokeOptions.None) {
 			var tcs = new TaskCompletionSource<Value> ();

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PrimitiveValue.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PrimitiveValue.cs
@@ -55,5 +55,9 @@ namespace Mono.Debugger.Soft
 		public Value EndInvokeMethod (IAsyncResult asyncResult) {
 			return ObjectMirror.EndInvokeMethodInternal (asyncResult);
 		}
+
+		public InvokeResult EndInvokeMethodWithResult (IAsyncResult asyncResult) {
+			return  ObjectMirror.EndInvokeMethodInternalWithResult (asyncResult);
+		}
 	}
 }

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/StructMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/StructMirror.cs
@@ -86,7 +86,21 @@ namespace Mono.Debugger.Soft
 		}
 
 		public Value EndInvokeMethod (IAsyncResult asyncResult) {
-			return ObjectMirror.EndInvokeMethodInternal (asyncResult);
+			var result = ObjectMirror.EndInvokeMethodInternalWithResult (asyncResult);
+			var outThis = result.OutThis as StructMirror;
+			if (outThis != null) {
+				SetFields (outThis.Fields);
+			}
+			return result.Result;
+		}
+
+		public InvokeResult EndInvokeMethodWithResult (IAsyncResult asyncResult) {
+			var result = ObjectMirror.EndInvokeMethodInternalWithResult (asyncResult);
+			var outThis = result.OutThis as StructMirror;
+			if (outThis != null) {
+				SetFields (outThis.Fields);
+			}
+			return result;
 		}
 
 #if NET_4_5

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -806,6 +806,10 @@ namespace Mono.Debugger.Soft
 			return ObjectMirror.EndInvokeMethodInternal (asyncResult);
 		}
 
+		public InvokeResult EndInvokeMethodWithResult (IAsyncResult asyncResult) {
+			return  ObjectMirror.EndInvokeMethodInternalWithResult (asyncResult);
+		}
+
 #if NET_4_5
 		public Task<Value> InvokeMethodAsync (ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options = InvokeOptions.None) {
 			var tcs = new TaskCompletionSource<Value> ();


### PR DESCRIPTION
StructMirror also overrides fields of structure in case InvokeMethod was called with InvokeOptions.ReturnOutThis option set

@vargaz We already talked on IRC about this solution last week... Can you please review this? Tnx.
