### PR TITLE
[sgen-parallel-collector] Replace worker stealable stack with section gray queue

### DIFF
--- a/mono/metadata/sgen-workers.c
+++ b/mono/metadata/sgen-workers.c
@@ -225,55 +225,28 @@ static gboolean
 workers_steal (WorkerData *data, WorkerData *victim_data, gboolean lock)
 {
 	SgenGrayQueue *queue = &data->private_gray_queue;
-	int num, n;
+	GrayQueueSection *section;
 
-	g_assert (!queue->first);
+	g_assert (sgen_gray_object_queue_is_empty (queue));
 
-	if (!victim_data->stealable_stack_fill)
+	/* We're stealing 1 section */
+	section = sgen_section_gray_queue_dequeue (&victim_data->stealable_gray_queue);
+
+	if (!section)
 		return FALSE;
 
-	if (lock && mono_mutex_trylock (&victim_data->stealable_stack_mutex))
-		return FALSE;
-
-	n = num = (victim_data->stealable_stack_fill + 1) / 2;
-	/* We're stealing num entries. */
-
-	while (n > 0) {
-		int m = MIN (SGEN_GRAY_QUEUE_SECTION_SIZE, n);
-		n -= m;
-
-		sgen_gray_object_alloc_queue_section (queue);
-		memcpy (queue->first->objects,
-				victim_data->stealable_stack + victim_data->stealable_stack_fill - num + n,
-				sizeof (char*) * m);
-		queue->first->size = m;
-
-		/*
-		 * DO NOT move outside this loop
-		 * Doing so trigger "assert not reached" in sgen-scan-object.h : we use the queue->cursor
-		 * to compute the size of the first section during section allocation (via alloc_prepare_func
-		 * -> workers_gray_queue_share_redirect -> sgen_gray_object_dequeue_section) which will be then
-		 * set to 0, because queue->cursor is still pointing to queue->first->objects [-1], thus
-		 * losing objects in the gray queue.
-		 */
-		queue->cursor = (char**)queue->first->objects + queue->first->size - 1;
-	}
-
-	victim_data->stealable_stack_fill -= num;
-
-	if (lock)
-		mono_mutex_unlock (&victim_data->stealable_stack_mutex);
+	sgen_gray_object_enqueue_section (&data->private_gray_queue, section);
 
 	if (data == victim_data) {
 		if (lock)
-			stat_workers_stolen_from_self_lock += num;
+			stat_workers_stolen_from_self_lock += data->private_gray_queue.first->size;
 		else
-			stat_workers_stolen_from_self_no_lock += num;
+			stat_workers_stolen_from_self_no_lock += data->private_gray_queue.first->size;
 	} else {
-		stat_workers_stolen_from_others += num;
+		stat_workers_stolen_from_others += data->private_gray_queue.first->size;
 	}
 
-	return num != 0;
+	return TRUE;
 }
 
 static gboolean
@@ -320,7 +293,7 @@ workers_gray_queue_share_redirect (SgenGrayQueue *queue)
 	GrayQueueSection *section;
 	WorkerData *data = queue->alloc_prepare_data;
 
-	if (data->stealable_stack_fill) {
+	if (!sgen_section_gray_queue_is_empty (&data->stealable_gray_queue)) {
 		/*
 		 * There are still objects in the stealable stack, so
 		 * wake up any workers that might be sleeping
@@ -330,30 +303,8 @@ workers_gray_queue_share_redirect (SgenGrayQueue *queue)
 		return;
 	}
 
-	/* The stealable stack is empty, so fill it. */
-	mono_mutex_lock (&data->stealable_stack_mutex);
-
-	while (data->stealable_stack_fill < STEALABLE_STACK_SIZE &&
-			(section = sgen_gray_object_dequeue_section (queue))) {
-		int num = MIN (section->size, STEALABLE_STACK_SIZE - data->stealable_stack_fill);
-
-		memcpy (data->stealable_stack + data->stealable_stack_fill,
-				section->objects + section->size - num,
-				sizeof (char*) * num);
-
-		section->size -= num;
-		data->stealable_stack_fill += num;
-
-		if (section->size)
-			sgen_gray_object_enqueue_section (queue, section);
-		else
-			sgen_gray_object_free_queue_section (section);
-	}
-
-	if (sgen_gray_object_queue_is_empty (queue))
-		workers_steal (data, data, FALSE);
-
-	mono_mutex_unlock (&data->stealable_stack_mutex);
+	while (queue->first && queue->first->next && (section = sgen_gray_object_dequeue_section (queue)))
+		sgen_section_gray_queue_enqueue (&data->stealable_gray_queue, section);
 
 	if (workers_state.data.gc_in_progress)
 		workers_wake_up_all ();
@@ -470,9 +421,7 @@ sgen_workers_init (int num_workers)
 	for (i = 0; i < workers_num; ++i) {
 		workers_data [i].index = i;
 
-		/* private gray queue is inited by the thread itself */
-		mono_mutex_init (&workers_data [i].stealable_stack_mutex);
-		workers_data [i].stealable_stack_fill = 0;
+		sgen_section_gray_queue_init (&workers_data [i].stealable_gray_queue, TRUE, NULL);
 
 		if (sgen_get_major_collector ()->alloc_worker_data)
 			workers_data [i].major_collector_data = sgen_get_major_collector ()->alloc_worker_data ();
@@ -637,7 +586,7 @@ sgen_workers_join (void)
 	g_assert (workers_job_queue_num_entries == 0);
 	g_assert (sgen_section_gray_queue_is_empty (&workers_distribute_gray_queue));
 	for (i = 0; i < workers_num; ++i) {
-		g_assert (!workers_data [i].stealable_stack_fill);
+		g_assert (sgen_section_gray_queue_is_empty (&workers_data [i].stealable_gray_queue));
 		g_assert (sgen_gray_object_queue_is_empty (&workers_data [i].private_gray_queue));
 	}
 }

--- a/mono/metadata/sgen-workers.h
+++ b/mono/metadata/sgen-workers.h
@@ -31,10 +31,7 @@ struct _WorkerData {
 	void *major_collector_data;
 
 	SgenGrayQueue private_gray_queue; /* only read/written by worker thread */
-
-	mono_mutex_t stealable_stack_mutex;
-	volatile int stealable_stack_fill;
-	char *stealable_stack [STEALABLE_STACK_SIZE];
+	SgenSectionGrayQueue stealable_gray_queue; /* read/written by any worker thread */
 };
 
 typedef void (*JobFunc) (WorkerData *worker_data, void *job_data);


### PR DESCRIPTION
This approach presents two main advantages :
- remove copying of data around memory with memcpy, it is replaced by dequeuing/enqueuing sections which does not imply copying large amounts of memory, but only passing pointers
- greatly simplify the code because we do not allocate section which then does not recursively call back workers_gray_queue_share_redirect
