### PR TITLE
wrong behaviour in ClaimsIdentity's constructor

### DIFF
--- a/mcs/class/corlib/System.Security.Claims/ClaimsIdentity.cs
+++ b/mcs/class/corlib/System.Security.Claims/ClaimsIdentity.cs
@@ -97,14 +97,15 @@ namespace System.Security.Claims {
 				foreach (var c in ci.Claims)
 					this.claims.Add (c);
 				
-				if (claims != null) {
-					foreach (var c in claims)
-						this.claims.Add (c);
-				}
 				Label = ci.Label;
 				NameClaimType = ci.NameClaimType;
 				RoleClaimType = ci.RoleClaimType;
 				auth_type = ci.AuthenticationType;
+			}
+
+			if (claims != null) {
+				foreach (var c in claims)
+					this.claims.Add (c);
 			}
 		}
 


### PR DESCRIPTION
claims must be added regardless of identity parameter
Since constructors are chained in that class,  this wrong behaviour causes chained trouble of claims to be never added
