### PR TITLE
[System] Allow Uri.GetComponents on relative Uri for SerializationInfoString 

### DIFF
--- a/mcs/class/System/System/Uri.cs
+++ b/mcs/class/System/System/Uri.cs
@@ -2029,6 +2029,11 @@ namespace System {
 
 		public string GetComponents (UriComponents components, UriFormat format)
 		{
+			if (!IsAbsoluteUri && components == UriComponents.SerializationInfoString)
+			{
+				return UriParser.Format (OriginalString, format);
+			}
+
 			return Parser.GetComponents (this, components, format);
 		}
 

--- a/mcs/class/System/System/UriParser.cs
+++ b/mcs/class/System/System/UriParser.cs
@@ -226,7 +226,7 @@ namespace System {
 			return s;
 		}
 
-		private string Format (string s, UriFormat format)
+		internal static string Format (string s, UriFormat format)
 		{
 			if (s.Length == 0)
 				return String.Empty;

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -1896,5 +1896,15 @@ namespace MonoTests.System
 			Assert.IsTrue (Uri.TryCreate (mainUri, uriPath, out result), "#1");
 			Assert.AreEqual ("http://www.imdb.com/title/tt0106521", result.ToString (), "#2");
 		}
+
+		[Test]
+		public void GetSerializationInfoStringOnRelativeUri ()
+		{
+			var uri = new Uri ("/relative/path", UriKind.Relative);
+
+			var result = uri.GetComponents (UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+
+			Assert.AreEqual (uri.OriginalString, result);
+		}
 	}
 }


### PR DESCRIPTION
Fixes [#21571](https://bugzilla.xamarin.com/show_bug.cgi?id=21571).

First I went down the path of changing `Uri.get_Parser()` to create a default parser instance
when the uri is relative, but thought that may break behavior in other methods that access
the parser instance.

I ended up putting a special case directly into `Uri.GetComponents()` and changed `UriParser.Format()`
from private to internal static so I could reuse it. This code is a bit circular: Uri calls UriParser.Format wich calls methods on Uri to do the actual work.

There is probably a cleaner solution.

I think the only potential side effect outside of the intended change in behavior would be any evil code using reflection to invoke UriParser.Format and I think this is unlikely and not worth worrying about since any code doing this is inherently dangerous.

This change in released under the MIT license.
