### PR TITLE
Bug fix caused by Dispose failing because 'Initialize' method throws exception

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Cryptography/DiffieHellmanManaged.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Cryptography/DiffieHellmanManaged.cs
@@ -156,9 +156,9 @@ namespace Mono.Security.Cryptography {
 		// clear keys
 		protected override void Dispose(bool disposing) {
 			if (!m_Disposed) {
-				m_P.Clear();
-				m_G.Clear();
-				m_X.Clear();
+				if (m_P != null) m_P.Clear();
+				if (m_G != null) m_G.Clear();
+				if (m_X != null) m_X.Clear();
 			}
 			m_Disposed = true;
 		}


### PR DESCRIPTION
Fixing a bug that causes Dispose to fail because the `Initialize` method had earlier thrown a `CryptographicException` before the private variables `m_p, m_G, m_X` could be set. This causes the GC to fail to properly finalize an instance of DiffieHellmanManaged.

Exception thrown:

System.NullReferenceException: Object reference not set to an instance of an object.
   at Mono.Security.Cryptography.DiffieHellmanManaged.Dispose(Boolean disposing)
   at Mono.Security.Cryptography.DiffieHellmanManaged.Finalize()
