### PR TITLE
Don't run net_4_0 tests during "make check"

### DIFF
--- a/mcs/build/profiles/net_4_0.make
+++ b/mcs/build/profiles/net_4_0.make
@@ -17,3 +17,6 @@ FRAMEWORK_VERSION = 4.0
 XBUILD_VERSION = 4.0
 
 LIBRARY_INSTALL_DIR = $(mono_libdir)/mono/$(FRAMEWORK_VERSION)
+
+# Ignore tests on net_4_0 as the 4.0 IL code is never used for running (just for metadata), so it doesn't make sense to execute tests there
+NO_TEST = yes

--- a/mcs/class/corlib/Makefile
+++ b/mcs/class/corlib/Makefile
@@ -147,8 +147,10 @@ run-test-vts: test-vts
 	@echo Running vts tests...
 	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(TEST_HARNESS) -noshadow \
 		$(vtsdir)/$(PROFILE)_TestLib/BinarySerializationOverVersions.exe
+ifndef NO_TEST
 test: test-vts
 run-test: run-test-vts
+endif
 
 EXTRA_DISTFILES += \
 	$(vtsdir)/VersionTolerantSerializationTestLib/1.0/Address.cs \


### PR DESCRIPTION
The IL code for the 4.0 profile is never used for running (they are just built for having metadata), so it makes no sense to execute 4.0 tests during "make check"

As discussed with @marek-safar on #monodev.
