### PR TITLE
Delete assemblies from external/ when building "make dist" tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,8 @@ dist-hook:
 	test -d $(distdir)/mcs || mkdir $(distdir)/mcs
 	d=`cd $(distdir)/mcs && pwd`; cd $(mcs_topdir) && $(MAKE) distdir=$$d dist-recursive
 	rm -rf `find $(top_distdir)/external -path '*\.git'`
+	rm -f `find $(top_distdir)/external -path '*\.exe'`
+	rm -f `find $(top_distdir)/external -path '*\.dll'`
 	cp mcs/class/lib/basic/System.Configuration.dll mcs/class/lib/monolite/
 	cp mcs/class/lib/basic/System.Security.dll mcs/class/lib/monolite/
 # Disable this for now because it is very slow and causes wrench to timeout:


### PR DESCRIPTION
Debian needs to ship a modified mono tarball, as packages may not contain binary compiler output in their tarball in the Debian archive.

This change removes the need for that moving forwards.
