### PR TITLE
Fixed issue where XmlReflectionImporter unable to handle XmlEnums with full names

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlReflectionImporter.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlReflectionImporter.cs
@@ -1042,11 +1042,14 @@ namespace System.Xml.Serialization {
 				if (choiceEnumMap != null) {
 					string cname = choiceEnumMap.GetEnumName (choiceEnumType.FullName, elem.ElementName);
 					if (cname == null)
-						throw new InvalidOperationException (string.Format (
-							CultureInfo.InvariantCulture, "Type {0} is missing"
-							+ " enumeration value '{1}' for element '{1} from"
-							+ " namespace '{2}'.", choiceEnumType, elem.ElementName,
-							elem.Namespace));
+						cname = choiceEnumMap.GetEnumName(choiceEnumType.FullName,elem.Namespace.ToString() + ":" +elem.ElementName);
+						if (cname == null)
+							throw new InvalidOperationException (string.Format (
+								CultureInfo.InvariantCulture, "Type {0} is missing"
+								+ " enumeration value '{1}' for element '{1} from"
+								+ " namespace '{2}'.", choiceEnumType, elem.ElementName,
+								elem.Namespace));
+
 					elem.ChoiceValue = Enum.Parse (choiceEnumType, cname, false);
 				}
 					


### PR DESCRIPTION
XmlReflectionImporter would fail to call ImportElementInfo on elements with an enumeration that was fully qualified.  In this scenario: "urn:oasis:names:tc:SAML:2.0:assertion:AuthnContextClassRef" and "urn:oasis:names:tc:SAML:2.0:assertion:AuthnContextDeclRef" when going against the saml 2.0 schema at urn:oasis:names:tc:SAML:2.0:protocol.   

Simple fix to add the namespace to the EnumMap lookup if the first simple check fails.

The business logic works on .Net 4.0 under Visual Studio 2010 and the classes were imported using xsd.exe. This patch is to allow mono to support the same feature. Tested and working with the latest commit.
