### PR TITLE
[System] Fix parsing of URI schemes with digits

### DIFF
--- a/mcs/class/System/System/UriParseComponents.cs
+++ b/mcs/class/System/System/UriParseComponents.cs
@@ -228,7 +228,7 @@ namespace System {
 			int index;
 			for (index = 1; index < part.Length; index++ ) {
 				char ch = part [index];
-				if (ch != '.' && ch != '-' && ch != '+' && !IsAlpha (ch))
+				if (ch != '.' && ch != '-' && ch != '+' && !IsAlpha (ch) && !Char.IsDigit (ch))
 					break;
 				
 				sb.Append (ch);

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -1434,6 +1434,13 @@ namespace MonoTests.System
 			new Uri ("hey");
 		}
 
+		[Test]
+		public void SchemeWithDigits ()
+		{
+			Uri uri = new Uri ("net.p2p://foobar");
+			Assert.AreEqual ("net.p2p", uri.Scheme);
+		}
+
 		// on .NET 2.0 a port number is limited to UInt16.MaxValue
 		[ExpectedException (typeof (UriFormatException))]
 		[Test]


### PR DESCRIPTION
Initializing an Uri previously throwed an exception when the URI scheme contained a digit (e.g. net.p2p).
The loop was missing a digit check, similar to https://github.com/mono/mono/blob/1f1dc988ad7b165603a1175bf0a92156c4372c43/mcs/class/System/System/Uri.cs#L767

I noticed this after PR #1168 by @esdrubal was merged.
