### PR TITLE
Fixed issue where XmlReflectionImporter unable to handle XmlEnums with colons

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlReflectionImporter.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlReflectionImporter.cs
@@ -1041,6 +1041,9 @@ namespace System.Xml.Serialization {
 
 				if (choiceEnumMap != null) {
 					string cname = choiceEnumMap.GetEnumName (choiceEnumType.FullName, elem.ElementName);
+					if (cname == null && elem.Namespace != null)
+						cname = choiceEnumMap.GetEnumName (choiceEnumType.FullName,
+							elem.Namespace.ToString () + ":" + elem.ElementName);
 					if (cname == null)
 						throw new InvalidOperationException (string.Format (
 							CultureInfo.InvariantCulture, "Type {0} is missing"

--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlReflectionImporterTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlReflectionImporterTests.cs
@@ -2303,6 +2303,53 @@ namespace MonoTests.System.XmlSerialization
 					"Novell bug #594490 (https://bugzilla.novell.com/show_bug.cgi?id=594490) not fixed.");
 			}
 		}
+
+		/*
+		 * The following code was generated from Microsoft's xsd.exe with the /classes switch.
+		 * It only includes the relevent details but was based on the following namespaces:
+		 *   urn:oasis:names:tc:SAML:2.0:protocol
+		 *   urn:oasis:names:tc:SAML:2.0:assertion
+		 *   http://www.w3.org/2000/09/xmldsig#
+		 *   http://www.w3.org/2001/04/xmlenc
+		 */
+
+		[XmlTypeAttribute (Namespace = "urn:oasis:names:tc:SAML:2.0:protocol")]
+		[XmlRootAttribute ("RequestedAuthnContext", Namespace = "urn:oasis:names:tc:SAML:2.0:protocol", IsNullable = false)]
+		public class RequestedAuthnContext
+		{
+			string[] items;
+			ItemsChoice7[] itemsElementName;
+
+			[XmlElementAttribute ("AuthnContextClassRef", typeof (string), Namespace = "urn:oasis:names:tc:SAML:2.0:assertion", DataType = "anyURI")]
+			[XmlElementAttribute ("AuthnContextDeclRef", typeof (string), Namespace = "urn:oasis:names:tc:SAML:2.0:assertion", DataType = "anyURI")]
+			[XmlChoiceIdentifierAttribute ("ItemsElementName")]
+			public string[] Items {
+				get { return this.items; }
+				set { this.items = value; }
+			}
+
+			[XmlElementAttribute ("ItemsElementName")]
+			[XmlIgnoreAttribute ()]
+			public ItemsChoice7[] ItemsElementName {
+				get { return this.itemsElementName; }
+				set { this.itemsElementName = value; }
+			}
+		}
+
+		[XmlTypeAttribute (Namespace = "urn:oasis:names:tc:SAML:2.0:protocol", IncludeInSchema = false)]
+		public enum ItemsChoice7 {
+			[XmlEnumAttribute ("urn:oasis:names:tc:SAML:2.0:assertion:AuthnContextClassRef")]
+			AuthnContextClassRef,
+			[XmlEnumAttribute ("urn:oasis:names:tc:SAML:2.0:assertion:AuthnContextDeclRef")]
+			AuthnContextDeclRef,
+		}
+		// End snippet from xsd.exe
+	
+		[Test]
+		public void FullyQualifiedName_XmlEnumAttribute ()
+		{
+			var serializer = new XmlSerializer (typeof (RequestedAuthnContext)); 
+		}
 	}
 }
 


### PR DESCRIPTION
XmlReflectionImporter would fail to call ImportElementInfo on elements with an enumeration that was fully qualified. In this scenario: "urn:oasis:names:tc:SAML:2.0:assertion:AuthnContextClassRef" and "urn:oasis:names:tc:SAML:2.0:assertion:AuthnContextDeclRef" when going against the saml 2.0 schema at urn:oasis:names:tc:SAML:2.0:assertion.  Simple fix to add the namespace to the EnumMap lookup if the first simple check fails.  The business logic works on .Net 4.0 under Visual Studio 2010 and the classes were imported using xsd.exe. This patch is to allow mono to support the same feature. Tested and working with the latest commit.

As per [previous PR](https://github.com/mono/mono/pull/1194) Fixed potential null reference error, checked coding styles, and added a unit test to MonoTests.System.XmlSerialization.XmlReflectionImporterTests.

Tested as working on windows and patch. Not working in current build of master.
