### PR TITLE
Adding the mutex header file dependency

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -9,11 +9,13 @@
 #include <mono/metadata/mempool.h>
 #include <mono/metadata/lock-tracer.h>
 #include <mono/utils/mono-codeman.h>
+#include <mono/utils/mono-mutex.h>
 #include <mono/metadata/mono-hash.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-internal-hash.h>
 #include <mono/io-layer/io-layer.h>
 #include <mono/metadata/mempool-internals.h>
+
 
 extern mono_mutex_t mono_delegate_section;
 extern mono_mutex_t mono_strtod_mutex;

--- a/mono/utils/mono-codeman.c
+++ b/mono/utils/mono-codeman.c
@@ -26,6 +26,8 @@
 #include <nacl/nacl_dyncode.h>
 #include <mono/mini/mini.h>
 #endif
+#include <mono/utils/mono-mutex.h>
+
 
 static uintptr_t code_memory_used = 0;
 static size_t dynamic_code_alloc_count;


### PR DESCRIPTION
Fix the error "unknown type name 'mono_mutex_t'" during make command.
