### PR TITLE
Added HasClaim, FindFirst, FindAll into ClaimsPrincipal

### DIFF
--- a/mcs/class/corlib/System.Security.Claims/ClaimsPrincipal.cs
+++ b/mcs/class/corlib/System.Security.Claims/ClaimsPrincipal.cs
@@ -187,7 +187,7 @@ namespace System.Security.Claims {
 			return false;
 		}
 
-		public virtual bool HasClaim(string type, string value)
+		public virtual bool HasClaim (string type, string value)
 		{
 			foreach(var claim in Claims){
 				if (claim.Type == type && claim.Value == value)
@@ -196,14 +196,14 @@ namespace System.Security.Claims {
 			return false;
 		}
 
-		public virtual Claim FindFirst(string type)
+		public virtual Claim FindFirst (string type)
 		{
 			if (type == null)
 				throw new ArgumentNullException ("type");
 			return FindFirst(x => x.Type == type);
 		}
 
-		public virtual IEnumerable<Claim> FindAll(string type)
+		public virtual IEnumerable<Claim> FindAll (string type)
 		{
 			if (type == null)
 				throw new ArgumentNullException ("type");


### PR DESCRIPTION
Added HasClaim, FindFirst, FindAll System.Security.Claims.ClaimsPrincipal method overloads - This change in released under the MIT license.

This addresses [Bug 22065](https://bugzilla.xamarin.com/show_bug.cgi?id=22065)
