### PR TITLE
re #18763: After the chained handler executes, it may return to allow th...

### DIFF
--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -6767,8 +6767,10 @@ SIG_HANDLER_FUNC (, mono_sigfpe_signal_handler)
 			return;
 
 		mono_handle_native_sigsegv (SIGSEGV, ctx);
-		if (mono_do_crash_chaining)
+		if (mono_do_crash_chaining) {
 			mono_chain_signal (SIG_HANDLER_PARAMS);
+			return;
+		}
 	}
 	
 	mono_arch_handle_exception (ctx, exc);
@@ -6819,8 +6821,10 @@ SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 		if (!mono_do_crash_chaining && mono_chain_signal (SIG_HANDLER_PARAMS))
 			return;
 		mono_handle_native_sigsegv (SIGSEGV, ctx);
-		if (mono_do_crash_chaining)
+		if (mono_do_crash_chaining) {
 			mono_chain_signal (SIG_HANDLER_PARAMS);
+			return;
+		}
 	}
 
 	ji = mono_jit_info_table_find (mono_domain_get (), mono_arch_ip_from_context (ctx));
@@ -6864,8 +6868,10 @@ SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 
 		mono_handle_native_sigsegv (SIGSEGV, ctx);
 
-		if (mono_do_crash_chaining)
+		if (mono_do_crash_chaining) {
 			mono_chain_signal (SIG_HANDLER_PARAMS);
+			return;
+		}
 	}
 			
 	mono_arch_handle_exception (ctx, NULL);


### PR DESCRIPTION
...e crashed instruction to be restarted or it may have taken corrective action so the instruction can be resumed successfully.   For example, bionic resets the signal handler for SIGSEGV to default expecting that the kernel will restart the offending instruction and cause the kernel to abort the process.  Don't do mono exception handling after chaining to support these types of signal management.
