### PR TITLE
PowerPC Garbage Collector build fixes

### DIFF
--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -436,6 +436,8 @@ static int callee_saved_regs [] = { ARMREG_V1, ARMREG_V2, ARMREG_V3, ARMREG_V4, 
 static int callee_saved_regs [] = { };
 #elif defined(TARGET_S390X)
 static int callee_saved_regs [] = { s390_r6, s390_r7, s390_r8, s390_r9, s390_r10, s390_r11, s390_r12, s390_r13, s390_r14 };
+#elif defined(TARGET_POWERPC)
+static int callee_saved_regs [] = { ppc_r6, ppc_r7, ppc_r8, ppc_r9, ppc_r10, ppc_r11, ppc_r12, ppc_r13, ppc_r14 };
 #endif
 
 static guint32

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -94,6 +94,7 @@ typedef struct MonoCompileArch {
 #define MONO_ARCH_EMULATE_LCONV_TO_R8_UN 1
 #define MONO_ARCH_EMULATE_FREM 1
 #define MONO_ARCH_BIGMUL_INTRINS 1
+#define MONO_ARCH_GC_MAPS_SUPPORTED 1
 
 /* Parameters used by the register allocator */
 #define MONO_ARCH_CALLEE_REGS ((0xff << ppc_r3) | (1 << ppc_r11) | (1 << ppc_r12))


### PR DESCRIPTION
This patch was created by @k0da and never upstreamed. Not sure why. I have to rebase this anyway for 3.6.0 because all patches fail for https://build.opensuse.org/package/show/Mono:Factory/mono-core at the moment.
