### PR TITLE
Make use of runtime version 4.0 by default for Cairo and NUnit

### DIFF
--- a/data/mono-nunit.pc.in
+++ b/data/mono-nunit.pc.in
@@ -6,4 +6,4 @@ libdir=${exec_prefix}/lib
 Name: Mono NUnit
 Description: Mono's version of NUnit
 Version: @VERSION@
-Libs: -r:${libdir}/mono/2.0/nunit.core.dll -r:${libdir}/mono/2.0/nunit.core.interfaces.dll -r:${libdir}/mono/2.0/nunit.core.extensions.dll -r:${libdir}/mono/2.0/nunit.framework.dll -r:${libdir}/mono/2.0/nunit.framework.extensions.dll -r:${libdir}/mono/2.0/nunit.mocks.dll -r:${libdir}/mono/2.0/nunit.util.dll -r:${libdir}/mono/2.0/nunit-console-runner.dll 
+Libs: -r:${libdir}/mono/4.0/nunit.core.dll -r:${libdir}/mono/4.0/nunit.core.interfaces.dll -r:${libdir}/mono/4.0/nunit.core.extensions.dll -r:${libdir}/mono/4.0/nunit.framework.dll -r:${libdir}/mono/4.0/nunit.framework.extensions.dll -r:${libdir}/mono/4.0/nunit.mocks.dll -r:${libdir}/mono/4.0/nunit.util.dll -r:${libdir}/mono/4.0/nunit-console-runner.dll 


### PR DESCRIPTION
Marked as `PATCH-FIX-UPSTREAM` by @DimStar77 at https://build.opensuse.org/package/view_file/Mono:Factory/mono-core/mono-core.spec?expand=1 but I think it was never submitted.
