### PR TITLE
Fixed parallel build for MCS dir-check

### DIFF
--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -82,7 +82,7 @@ all-local $(STD_TARGETS:=-local):
 	@:
 
 dir-check:
-	@if [ "$(NO_DIR_CHECK)" = "" -a "$(PROFILE)" != "basic" ]; then make -C ../runtime; fi
+	@if [ "$(NO_DIR_CHECK)" = "" -a "$(PROFILE)" != "basic" ]; then $(MAKE) -C ../runtime; fi
 
 # fun specialty targets
 


### PR DESCRIPTION
Created by @bugfinder for https://build.opensuse.org/package/show/Mono:Factory/mono-core but never upstreamed. Not really sure why this helps, but it adds consistency to the Makefile.
