### PR TITLE
Added support for ARM v5 CPU info

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -948,6 +948,9 @@ mono_arch_init (void)
 	   have a way to properly detect CPU features on it. */
 	thumb_supported = TRUE;
 	iphone_abi = TRUE;
+#elif 1
+	thumb_supported = TRUE;
+	v5_supported = TRUE;
 #else
 	thumb_supported = mono_hwcap_arm_has_thumb;
 	thumb2_supported = mono_hwcap_arm_has_thumb2;


### PR DESCRIPTION
Yet another undocumented patch from https://build.opensuse.org/package/show/Mono:Factory/mono-core. I can only guess what it does. Uploaded it here for review.
