### PR TITLE
Removing excess line with debug Console.WriteLine

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
@@ -810,7 +810,6 @@ namespace System.Reflection.Emit
 				throw new TypeLoadException ("Could not load type '" + FullName + "' from assembly '" + Assembly + "' because it is an enum with methods.");
 			if (interfaces != null) {
 				foreach (var iface in interfaces) {
-					Console.WriteLine (iface.Attributes);
 					if (iface.IsNestedPrivate && iface.Assembly != Assembly)
 						throw new TypeLoadException ("Could not load type '" + FullName + "' from assembly '" + Assembly + "' because it is implements the inaccessible interface '" + iface.FullName + "'.");
 				}


### PR DESCRIPTION
I reported about a bug 22059 (https://bugzilla.xamarin.com/show_bug.cgi?id=22059). It was fixed in 68e5cc395fd19366ed8e421f2f329fcf91d2b0b0, but a excess line with debug Console.WriteLine

```
Console.WriteLine (iface.Attributes);
```

was added. I removed it.
