### PR TITLE
Suppression of negative Elapsed in Stopwatch

### DIFF
--- a/mcs/class/System/System.Diagnostics/Stopwatch.cs
+++ b/mcs/class/System/System.Diagnostics/Stopwatch.cs
@@ -113,6 +113,10 @@ namespace System.Diagnostics
 			if (!is_running)
 				return;
 			elapsed += GetTimestamp () - started;
+#if NET_4_0
+			if (elapsed < 0)
+				elapsed = 0;
+#endif
 			is_running = false;
 		}
 


### PR DESCRIPTION
There was a bug in the old Microsoft .NET versions: the Stopwatch.Elapsed property could return negative value for a small time period. It was be fixed in .NET 4.0, but it can be still reproduced by the current Mono version.

More information:
Official bug in .NET: https://connect.microsoft.com/VisualStudio/feedbackdetail/view/94083/stopwatch-returns-negative-elapsed-time
Useful comment in the official source of .NET 4.5.1: http://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/Stopwatch.cs#92
Discussion on StackOverflow: http://stackoverflow.com/questions/1008345/system-diagnostics-stopwatch-returns-negative-numbers-in-elapsed-properties
