### PR TITLE
Suppression of negative Elapsed in Stopwatch

### DIFF
--- a/mcs/class/System/System.Diagnostics/Stopwatch.cs
+++ b/mcs/class/System/System.Diagnostics/Stopwatch.cs
@@ -113,10 +113,8 @@ namespace System.Diagnostics
 			if (!is_running)
 				return;
 			elapsed += GetTimestamp () - started;
-#if NET_4_0
 			if (elapsed < 0)
 				elapsed = 0;
-#endif
 			is_running = false;
 		}
 

--- a/mcs/class/System/System.Diagnostics/Stopwatch.cs
+++ b/mcs/class/System/System.Diagnostics/Stopwatch.cs
@@ -113,6 +113,10 @@ namespace System.Diagnostics
 			if (!is_running)
 				return;
 			elapsed += GetTimestamp () - started;
+#if NET_4_0
+			if (elapsed < 0)
+				elapsed = 0;
+#endif
 			is_running = false;
 		}
 


### PR DESCRIPTION
There was a bug (https://connect.microsoft.com/VisualStudio/feedbackdetail/view/94083/stopwatch-returns-negative-elapsed-time) in the old Microsoft .NET versions: the Stopwatch.Elapsed property could return negative value for a small time period. It was be fixed in .NET 4.0, but it can be still reproduced by the current Mono version.
For example, this can be reproduced during dynamic processor frequency scaling (see http://en.wikipedia.org/wiki/SpeedStep).