### PR TITLE
Lower-case the host in Uri.TryCreate to match behavior of constructors

### DIFF
--- a/mcs/class/System/System/Uri.cs
+++ b/mcs/class/System/System/Uri.cs
@@ -235,6 +235,11 @@ namespace System {
 					success = false;
 					break;
 				}
+
+				if (success && host.Length > 1 && host [0] != '[' && host [host.Length - 1] != ']') {
+					// host name present (but not an IPv6 address)
+					host = host.ToLower (CultureInfo.InvariantCulture);
+				}
 			}
 		}
 
@@ -1141,9 +1146,6 @@ namespace System {
 		private void ParseUri (UriKind kind)
 		{
 			Parse (kind, source);
-
-			if (userEscaped)
-				return;
 
 			if (host.Length > 1 && host [0] != '[' && host [host.Length - 1] != ']') {
 				// host name present (but not an IPv6 address)

--- a/mcs/class/System/Test/System/UriTest3.cs
+++ b/mcs/class/System/Test/System/UriTest3.cs
@@ -184,6 +184,12 @@ namespace MonoTests.System
 
 			Assert.IsTrue (Uri.TryCreate ("http://mono-project.com/☕", UriKind.Absolute, out uri), "highunicode-Absolute");
 			Assert.AreEqual("http://mono-project.com/%E2%98%95", uri.AbsoluteUri, "highunicode-Absolute-AbsoluteUri");
+
+			string mixedCaseUri = "http://mOnO-proJECT.com";
+			uri = new Uri (mixedCaseUri);
+			Uri uri2;
+			Assert.IsTrue (Uri.TryCreate (mixedCaseUri, UriKind.Absolute, out uri2), "mixedcasehost-absolute");
+			Assert.AreEqual (uri.AbsoluteUri, uri2.AbsoluteUri, "mixedcasehost-absoluteuri-absoluteuri");
 		}
 
 		[Test] // TryCreate (String, UriKind, Uri)


### PR DESCRIPTION
On Microsoft's implementation of the Uri class, the contructors and TryCreate method both lower-case the host. This commit fixes the issue where the constructors lower-cased the host but the TryCreate method did not.