### PR TITLE
Fix for bug 22307 - Intermittent IndexOutOfRangeException on closing connection

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
@@ -452,8 +452,11 @@ namespace System.ServiceModel.Dispatcher
 			public void CloseInput ()
 			{
 				foreach (var ch in channels.ToArray ()) {
-					if (ch.State == CommunicationState.Closed)
-						RemoveChannel (ch);
+					if (ch.State == CommunicationState.Closed) {
+						lock (channels) {
+							RemoveChannel (ch);
+						}
+					}
 					else {
 						try {
 							ch.Close (close_timeout - (DateTime.Now - close_started));


### PR DESCRIPTION
This fixes Xamarin bug 22307 (https://bugzilla.xamarin.com/show_bug.cgi?id=22307). When adding/removing channels in other areas of this class a lock is taken on the 'channels' variable. In one case the lock was missed, and this caused intermittent failures when removing a channel.