### PR TITLE
[system.transactions] Throw exception when an invalid TimeSpan is provided

### DIFF
--- a/mcs/class/System.Transactions/System.Transactions/TransactionScope.cs
+++ b/mcs/class/System.Transactions/System.Transactions/TransactionScope.cs
@@ -62,7 +62,6 @@ namespace System.Transactions
 		{
 		}
 
-		[MonoTODO ("No TimeoutException is thrown")]
 		public TransactionScope (TransactionScopeOption option,
 			TimeSpan timeout)
 		{
@@ -92,6 +91,10 @@ namespace System.Transactions
 			completed = false;
 			isRoot = false;
 			nested = 0;
+
+			if (timeout < TimeSpan.Zero)
+				throw new ArgumentOutOfRangeException ("timeout");
+
 			this.timeout = timeout;
 
 			oldTransaction = Transaction.CurrentInternal;

--- a/mcs/class/System.Transactions/Test/TransactionScopeTest.cs
+++ b/mcs/class/System.Transactions/Test/TransactionScopeTest.cs
@@ -19,6 +19,24 @@ namespace MonoTests.System.Transactions
 	{
 
 		[Test]
+		public void TransactionScopeWithInvalidTimeSpanThrows ()
+		{
+			try {
+				TransactionScope scope = new TransactionScope (TransactionScopeOption.Required, TimeSpan.FromSeconds (-1));
+				Assert.Fail ("Expected exception when passing TransactionScopeOption and an invalid TimeSpan.");
+			} catch (ArgumentOutOfRangeException ex) {
+				Assert.AreEqual (ex.ParamName, "timeout");
+			}
+
+			try {
+				TransactionScope scope = new TransactionScope (null, TimeSpan.FromSeconds (-1));
+				Assert.Fail ("Expected exception when passing TransactionScopeOption and an invalid TimeSpan.");
+			} catch (ArgumentOutOfRangeException ex) {
+				Assert.AreEqual (ex.ParamName, "timeout");
+			}
+		}
+
+		[Test]
 		public void TransactionScopeCommit ()
 		{
 			Assert.IsNull (Transaction.Current, "Ambient transaction exists (before)");


### PR DESCRIPTION
MS.NET throws and prevents construction when an invalid (negative) timeout is provided.

This is invalid: `new TransactionScope (null, TimeSpan.FromSeconds (-1))`, and should throw an `ArgumentOutOfRangeException`
