### PR TITLE
[mono.data.sqlite] Using sqlite_close_v2 when available:

### DIFF
--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteBase.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteBase.cs
@@ -206,8 +206,13 @@ namespace Mono.Data.Sqlite
 #if !SQLITE_STANDARD
         int n = UnsafeNativeMethods.sqlite3_close_interop(db);
 #else
-      ResetConnection(db);
-      int n = UnsafeNativeMethods.sqlite3_close(db);
+        ResetConnection(db);
+        int n;
+        try {
+          n = UnsafeNativeMethods.sqlite3_close_v2(db);
+        } catch (EntryPointNotFoundException) {
+          n = UnsafeNativeMethods.sqlite3_close(db);
+        }
 #endif
         if (n > 0) throw new SqliteException(n, SQLiteLastError(db));
       }

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
@@ -133,6 +133,13 @@ namespace Mono.Data.Sqlite
     [DllImport(SQLITE_DLL)]
 #endif
     internal static extern int sqlite3_close(IntPtr db);
+		
+#if !PLATFORM_COMPACTFRAMEWORK
+    [DllImport(SQLITE_DLL, CallingConvention = CallingConvention.Cdecl)]
+#else
+    [DllImport(SQLITE_DLL)]
+#endif
+    internal static extern int sqlite3_close_v2(IntPtr db);
 
 #if !PLATFORM_COMPACTFRAMEWORK
     [DllImport(SQLITE_DLL, CallingConvention = CallingConvention.Cdecl)]

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteConnectionTest.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteConnectionTest.cs
@@ -44,6 +44,26 @@ namespace MonoTests.Mono.Data.Sqlite
                 readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
                 SqliteConnection _conn = new SqliteConnection ();
 
+				[Test]
+				public void ReleaseDatabaseFileHandles ()
+				{
+					_conn.ConnectionString = _connectionString;
+					_conn.Open ();
+
+					SqliteCommand cmd = _conn.CreateCommand ();
+					cmd.CommandText = "PRAGMA legacy_file_format;";
+					cmd.ExecuteScalar ();
+
+					// close connection before the command
+					_conn.Dispose ();
+
+					// then close the command
+					cmd.Dispose ();
+
+					// the locks should be released, and we should be able to delete the database
+					File.Delete (_uri);
+				}
+
 #if NET_2_0
                 [Test]
                 [ExpectedException (typeof (ArgumentNullException))]


### PR DESCRIPTION
 - This is the recommended function for garbage collected languages.  
   http://sqlite.org/c3ref/close.html  
   The sqlite3_close_v2() interface is intended for use with host languages that are garbage collected, and where the order in which destructors are called is arbitrary.
 - Falls back to old sqlite3_close if we are on an old system
 - Useful for ADO.NET where the connection os often closed, but the commands are re-usable
 - Mostly visible on Windows operating systems

This snippet should fail with a System.IO.IOException using the current build of Mono on Windows:

    string filename = "test_" + Guid.NewGuid ().ToString ("N") + ".db";
    SqliteConnection conn = new SqliteConnection ("Data Source=" + filename);
    conn.Open (); 
    SqliteCommand cmd = conn.CreateCommand (); 
    cmd.CommandText = "PRAGMA legacy_file_format;"; 
    cmd.ExecuteScalar (); 
    // close connection before the command 
    conn.Dispose (); 
    // then close the command 
    cmd.Dispose (); 
    // the locks should be released, and we should be able to delete the database 
    File.Delete (filename); 
