### PR TITLE
[MSBuild] Fixed a test that failed when the GAC wasn't available

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/ResolveAssemblyReferenceTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/ResolveAssemblyReferenceTest.cs
@@ -230,6 +230,11 @@ namespace MonoTests.Microsoft.Build.Tasks {
 		[Test]
 		public void TestSystemDll ()
 		{
+			var gacDir = GetGacDir ();
+
+			if (gacDir == null || !System.IO.Directory.Exists (gacDir))
+				Assert.Ignore ("GAC not found.");
+
 			string documentString = @"
                                 <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
 					<ItemGroup>


### PR DESCRIPTION
PR #1229 added a test that relies on the GAC and fails when it isn't available, like when building on a clean machine with monolite. Skip the test in that case.

This should fix the test failure on [jenkins.mono-project.com](http://jenkins.mono-project.com/job/test-mono-mainline/63/label=debian-amd64/testReport/MonoTests.Microsoft.Build.Tasks/ResolveAssemblyReferenceTest/TestSystemDll/)
