### PR TITLE
UriParser.IsBaseOf now explicitly throws ArgumentNullException.

### DIFF
--- a/mcs/class/System/System/UriParser.cs
+++ b/mcs/class/System/System/UriParser.cs
@@ -189,6 +189,11 @@ namespace System {
 
 		protected internal virtual bool IsBaseOf (Uri baseUri, Uri relativeUri)
 		{
+			if (baseUri == null)
+				throw new ArgumentNullException ("baseUri");
+			if (relativeUri == null)
+				throw new ArgumentNullException ("relativeUri");
+
 			// compare, not case sensitive, the scheme, host and port (+ user informations)
 			if (Uri.Compare (baseUri, relativeUri, UriComponents.SchemeAndServer | UriComponents.UserInfo, UriFormat.Unescaped, StringComparison.InvariantCultureIgnoreCase) != 0)
 				return false;

--- a/mcs/class/System/Test/System/UriParserTest.cs
+++ b/mcs/class/System/Test/System/UriParserTest.cs
@@ -357,7 +357,7 @@ namespace MonoTests.System {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
+		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsBaseOf_UriNull ()
 		{
 			UnitTestUriParser p = new UnitTestUriParser ();
@@ -365,7 +365,7 @@ namespace MonoTests.System {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
+		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsBaseOf_NullUri ()
 		{
 			UnitTestUriParser p = new UnitTestUriParser ();

--- a/mcs/class/System/Test/System/UriTest3.cs
+++ b/mcs/class/System/Test/System/UriTest3.cs
@@ -425,13 +425,8 @@ namespace MonoTests.System
 				http.IsBaseOf (null);
 				Assert.Fail ();
 			}
-#if NET_4_0
 			catch (ArgumentNullException) {
 			}
-#else
-			catch (NullReferenceException) {
-			}
-#endif
 		}
 
 		[Test] 


### PR DESCRIPTION
A change in Uri.Compare was making IsBaseOf to return false when arguments were null.
NullReferenceException is thrown by .NET, nonetheless the correct behavior is to throw a ArgumentNullException.
