### PR TITLE
Add g_Ctoc to list of acceptable g_* symbols in mono, for test-eglib-remap

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -695,7 +695,7 @@ tests: $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la $(PREREQSI_IL) $(PREREQSI_
 #
 # Test that no symbols are missed in eglib-remap.h
 #
-OK_G_SYMBOLS='g_list\|g_slist\|g_concat_dir_and_file'
+OK_G_SYMBOLS='g_list\|g_slist\|g_concat_dir_and_file\|g_Ctoc'
 if NACL_CODEGEN
 test-eglib-remap:
 else


### PR DESCRIPTION
In theory, this test is used to verify that no unknown glib symbols exist
in eglib. However, it's tripping on g_Ctoc which is not a glib (or eglib)
symbol, instead it comes from the IO layer - and glib symbols never use
uppercase characters anyway
