### PR TITLE
Correct duplicate X509CertificateValidationMode definition error

### DIFF
--- a/mcs/class/System.IdentityModel/System.ServiceModel.Security/X509CertificateValidationMode.cs
+++ b/mcs/class/System.IdentityModel/System.ServiceModel.Security/X509CertificateValidationMode.cs
@@ -25,6 +25,8 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if NET_4_5
+
 namespace System.ServiceModel.Security
 {
 	public enum X509CertificateValidationMode
@@ -36,3 +38,4 @@ namespace System.ServiceModel.Security
 		Custom = 4,
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/System.ServiceModel/AllEnums.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/AllEnums.cs
@@ -411,6 +411,8 @@ namespace System.ServiceModel.Security
 		Custom,
 	}
 
+#if !NET_4_5
+
 	public enum X509CertificateValidationMode
 	{
 		None,
@@ -419,6 +421,7 @@ namespace System.ServiceModel.Security
 		PeerOrChainTrust,
 		Custom,
 	}
+#endif
 }
 
 namespace System.ServiceModel.Security.Tokens


### PR DESCRIPTION
Correct duplicate X509CertificateValidationMode definition error caused by enum changing assemblies between .NET 4.0 and 4.5 (introduced in previous pull request https://github.com/mono/mono/pull/1236/files)
