### PR TITLE
NullReferenceException when reading a schema xml fix

### DIFF
--- a/mcs/class/System.XML/System.Xml.Schema/XmlSchemaXPath.cs
+++ b/mcs/class/System.XML/System.Xml.Schema/XmlSchemaXPath.cs
@@ -301,7 +301,8 @@ namespace System.Xml.Schema
 			path.LinePosition = reader.LinePosition;
 			path.SourceUri = reader.BaseURI;
 
-			XmlNamespaceManager currentMgr = XmlSchemaUtil.GetParserContext (reader.Reader).NamespaceManager;
+			XmlParserContext parserCtx = XmlSchemaUtil.GetParserContext (reader.Reader);
+			XmlNamespaceManager currentMgr = parserCtx != null ? parserCtx.NamespaceManager : null;
 			if (currentMgr != null) {
 				path.nsmgr = new XmlNamespaceManager (reader.NameTable);
 				IEnumerator e = currentMgr.GetEnumerator ();


### PR DESCRIPTION
In some cases reading a valid schema xml (which worked in MS.Net) would cause null reference exceptions. Here is a simple program that reproduces the problem: https://gist.github.com/pingec/336f087d4e820c4f72cc