### PR TITLE
[system.data] DataRows with a NULL RowError incorrectly indicated HasError

### DIFF
--- a/mcs/class/System.Data/System.Data/DataRow.cs
+++ b/mcs/class/System.Data/System.Data/DataRow.cs
@@ -118,11 +118,11 @@ namespace System.Data {
 		/// </summary>
 		public bool HasErrors {
 			get {
-				if (RowError != string.Empty)
+				if (!string.IsNullOrEmpty (RowError))
 					return true;
 
 				foreach (String columnError in ColumnErrors) {
-					if (columnError != null && columnError != string.Empty)
+					if (!string.IsNullOrEmpty (columnError))
 						return true;
 				}
 				return false;
@@ -509,7 +509,7 @@ namespace System.Data {
 		/// </summary>
 		public string RowError {
 			get { return rowError; }
-			set { rowError = value; }
+			set { rowError = value ?? string.Empty; }
 		}
 
 		internal int IndexFromVersion (DataRowVersion version)

--- a/mcs/class/System.Data/Test/System.Data/DataRowTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataRowTest2.cs
@@ -739,6 +739,21 @@ namespace MonoTests.System.Data
 			Assert.AreEqual(true , dr.HasErrors , "DRW48");
 		}
 
+		[Test] public void HasErrorsWithNullError()
+		{
+			DataTable dt = new DataTable("myTable"); 
+			DataRow dr = dt.NewRow();
+
+			// HasErrors (default)
+			Assert.AreEqual(false, dr.HasErrors, "DRW47.2");
+
+			dr.RowError = null;
+
+			// HasErrors (set/get)
+			Assert.AreEqual(string.Empty , dr.RowError , "DRW48.2");
+			Assert.AreEqual(false , dr.HasErrors , "DRW49.2");
+		}
+
 		[Test] public void HasVersion_ByDataRowVersion()
 		{
 			DataTable t = new DataTable("atable");


### PR DESCRIPTION
MS.NET allows RowError to be set to NULL, but will convert it to string.Empty
