### PR TITLE
[corlib] Take daylight change info for the current year in TimeZoneTest.cs

### DIFF
--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -303,11 +303,12 @@ public class TimeZoneTest {
 
 
 			TimeZone tz = TimeZone.CurrentTimeZone;
-			DaylightTime daylightChanges = tz.GetDaylightChanges(2007);
+			int year = DateTime.Now.Year;
+			DaylightTime daylightChanges = tz.GetDaylightChanges(year);
 			DateTime dst_end = daylightChanges.End;
 
 			if (dst_end == DateTime.MinValue)
-				Assert.Ignore (tz.StandardName + " did not observe daylight saving time during 2007.");
+				Assert.Ignore (tz.StandardName + " did not observe daylight saving time during " + year + ".");
 
 			var standardOffset = tz.GetUtcOffset(daylightChanges.Start.AddMinutes(-1));
 


### PR DESCRIPTION
In GetUtcOffsetAtDSTBoundary() from the time zone test suite, UtcOffset is taken for the current year, so take DaylightChanges for the current year as well.

The existing discrepancy in years can cause a test failure in some time zones that recently abolished (or adopted) daylight saving, e.g. Russia that doesn't have DST since 2011.

It can be reproduced by running the following on Linux (and probably Mac):
$ TZ=/usr/share/zoneinfo/Europe/Moscow make run-test FIXTURE=System.TimeZoneTest
