### PR TITLE
fix PackagePart.GetRelationships for readonly files

### DIFF
--- a/mcs/class/WindowsBase/System.IO.Packaging/PackagePart.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/PackagePart.cs
@@ -125,7 +125,8 @@ namespace System.IO.Packaging {
 
 		private PackageRelationship CreateRelationship (Uri targetUri, TargetMode targetMode, string relationshipType, string id, bool loading)
 		{
-			Package.CheckIsReadOnly ();
+			if (!loading)
+				Package.CheckIsReadOnly ();
 			Check.TargetUri (targetUri);
 			Check.RelationshipTypeIsValid (relationshipType);
 			Check.IdIsValid (id);

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
@@ -377,8 +377,8 @@ namespace System.IO.Packaging.Tests {
                 part.CreateRelationship (part.Uri, TargetMode.Internal, "self");
                 package.Close ();
                 package = Package.Open (new MemoryStream (stream.ToArray ()), FileMode.Open, FileAccess.Read);
-                part  = package.GetPart(uris[0]);
-                part.GetRelationships();
+                part = package.GetPart (uris [0]);
+                part.GetRelationships ();
             }
         }
     }

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
@@ -367,5 +367,19 @@ namespace System.IO.Packaging.Tests {
         {
 	        Assert.IsFalse (package.PartExists(new Uri ("[Content_Types].xml", UriKind.Relative)));
         }
+
+        [Test]
+        public void CheckCanGetRelationshipsIfReadOnly ()
+        {
+            using (var stream = new MemoryStream ()) {
+                var package = Package.Open (stream, FileMode.OpenOrCreate);
+                var part = package.CreatePart (uris [0], contentType);
+                part.CreateRelationship (part.Uri, TargetMode.Internal, "self");
+                package.Close ();
+                package = Package.Open (new MemoryStream (stream.ToArray ()), FileMode.Open, FileAccess.Read);
+                part  = package.GetPart(uris[0]);
+                part.GetRelationships();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes this bug: https://bugzilla.novell.com/show_bug.cgi?id=675379

'PackagePart.GetRelationships throws an "Operation not valid when package is read-only" exception when package is open with only read presmissions'