### PR TITLE
Cleanup namespace names of class lib tests to follow convention

### DIFF
--- a/mcs/class/Commons.Xml.Relaxng/Test/NvdlValidatingReaderTests.cs
+++ b/mcs/class/Commons.Xml.Relaxng/Test/NvdlValidatingReaderTests.cs
@@ -13,7 +13,7 @@ using System.Xml;
 using Commons.Xml.Nvdl;
 using NUnit.Framework;
 
-namespace MonoTests.Commons.Xml.Nvdl
+namespace MonoTests.Commons.Xml.Relaxng
 {
 	[TestFixture]
 	public class NvdlValidatingReaderTests

--- a/mcs/class/Mono.Data.Tds/Test/bug-4786.cs
+++ b/mcs/class/Mono.Data.Tds/Test/bug-4786.cs
@@ -27,11 +27,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace bug4786test
+namespace MonoTests.Mono.Data.Tds
 {
 	
   using NUnit.Framework;
-  using Mono.Data.Tds.Protocol;
+  using global::Mono.Data.Tds.Protocol;
   using System;
   using System.Net;
   using System.Net.Sockets;

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionContextTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionContextTest.cs
@@ -39,7 +39,7 @@ using NUnit.Framework;
 #if NDESK_OPTIONS
 namespace Tests.NDesk.Options
 #else
-namespace Tests.Mono.Options
+namespace MonoTests.Mono.Options
 #endif
 {
 	[TestFixture]

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
@@ -46,7 +46,7 @@ using NUnit.Framework;
 #if NDESK_OPTIONS
 namespace Tests.NDesk.Options
 #else
-namespace Tests.Mono.Options
+namespace MonoTests.Mono.Options
 #endif
 {
 	class FooConverter : TypeConverter {

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionTest.cs
@@ -39,7 +39,7 @@ using NUnit.Framework;
 #if NDESK_OPTIONS
 namespace Tests.NDesk.Options
 #else
-namespace Tests.Mono.Options
+namespace MonoTests.Mono.Options
 #endif
 {
 	class DefaultOption : Option {

--- a/mcs/class/Mono.Options/Test/Mono.Options/Utils.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/Utils.cs
@@ -31,7 +31,7 @@ using System;
 #if NDESK_OPTIONS
 namespace Tests.NDesk.Options
 #else
-namespace Tests.Mono.Options
+namespace MonoTests.Mono.Options
 #endif
 {
 	static class Utils {

--- a/mcs/class/System.Data.Services/Test/ChangeInterceptorAttributeTests.cs
+++ b/mcs/class/System.Data.Services/Test/ChangeInterceptorAttributeTests.cs
@@ -26,9 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Data.Services;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class ChangeInterceptorAttributeTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/DataServiceExceptionTests.cs
+++ b/mcs/class/System.Data.Services/Test/DataServiceExceptionTests.cs
@@ -26,9 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Data.Services;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class DataServiceExceptionTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/DataServiceTests.cs
+++ b/mcs/class/System.Data.Services/Test/DataServiceTests.cs
@@ -26,9 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Data.Services;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class DataServiceTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/ETagAttributeTests.cs
+++ b/mcs/class/System.Data.Services/Test/ETagAttributeTests.cs
@@ -26,10 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Data.Services;
 using System.Linq;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class ETagAttributeTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/ExpandSegmentCollectionTests.cs
+++ b/mcs/class/System.Data.Services/Test/ExpandSegmentCollectionTests.cs
@@ -26,10 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Data.Services;
 using System.Linq.Expressions;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class ExpandSegmentCollectionTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/ExpandSegmentTests.cs
+++ b/mcs/class/System.Data.Services/Test/ExpandSegmentTests.cs
@@ -26,10 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Data.Services;
 using System.Linq.Expressions;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class ExpandSegmentTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/IgnorePropertiesAttributeTests.cs
+++ b/mcs/class/System.Data.Services/Test/IgnorePropertiesAttributeTests.cs
@@ -26,10 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Data.Services;
 using System.Linq;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class IgnorePropertiesAttributeTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/MimeTypeAttributeTests.cs
+++ b/mcs/class/System.Data.Services/Test/MimeTypeAttributeTests.cs
@@ -26,9 +26,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Data.Services;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class MimeTypeAttributeTests {
 		[Test]

--- a/mcs/class/System.Data.Services/Test/QueryInterceptorAttributeTests.cs
+++ b/mcs/class/System.Data.Services/Test/QueryInterceptorAttributeTests.cs
@@ -26,9 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Data.Services;
 using NUnit.Framework;
 
-namespace System.Data.Services.Tests {
+namespace MonoTests.System.Data.Services {
 	[TestFixture]
 	public class QueryInterceptorAttributeTests {
 		[Test]

--- a/mcs/class/System.Data/Test/System.Data.Common/DbDataReaderMock.cs
+++ b/mcs/class/System.Data/Test/System.Data.Common/DbDataReaderMock.cs
@@ -31,7 +31,7 @@ using System.Data;
 using System.Data.Common;
 using System.IO;
 
-namespace Test.System.Data.Common
+namespace MonoTests.System.Data.Common
 {
 	internal class DbDataReaderMock : DbDataReader
 	{

--- a/mcs/class/System.Data/Test/System.Data.Common/DbDataReaderTest.cs
+++ b/mcs/class/System.Data/Test/System.Data.Common/DbDataReaderTest.cs
@@ -32,7 +32,7 @@ using System.Data;
 using System.Data.Common;
 using System.IO;
 
-namespace Test.System.Data.Common
+namespace MonoTests.System.Data.Common
 {
 	[TestFixture]
 	public class DbDataReaderTest

--- a/mcs/class/System.Data/Test/System.Data/BinarySerializationTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/BinarySerializationTest.cs
@@ -12,6 +12,8 @@ using System.Threading;
 
 using NUnit.Framework;
 
+namespace MonoTests.System.Data
+{
 [TestFixture]
 public class BinarySerializationTest
 {
@@ -751,3 +753,4 @@ public class BinarySerializationTest
 }
 
 #endif
+}

--- a/mcs/class/System.Data/Test/System.Data/ConstraintExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/ConstraintExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class ConstraintExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/DBConcurrencyExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/DBConcurrencyExceptionTest.cs
@@ -31,7 +31,7 @@ using System.Data;
 
 using NUnit.Framework;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class DBConcurrencyExceptionTest

--- a/mcs/class/System.Data/Test/System.Data/DataSetTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataSetTest2.cs
@@ -39,7 +39,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Globalization;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class DataSetTest2
@@ -448,7 +448,7 @@ namespace MonoTests_System.Data
 			dt.Rows.Add(new object[] {2,"Value3","Value4"});
 			dt.Rows.Add(new object[] {3,"Value5","Value5"});
 
-			System.Text.StringBuilder resultXML = new System.Text.StringBuilder();
+			StringBuilder resultXML = new StringBuilder();
 
 			resultXML.Append("<" + ds.DataSetName  + "xmlns=\"namespace\">");
 
@@ -975,13 +975,13 @@ namespace MonoTests_System.Data
 		[Test] public void Locale()
 		{
 			DataSet ds = new DataSet("MyDataSet");
-			System.Globalization.CultureInfo culInfo = System.Globalization.CultureInfo.CurrentCulture ;
+			CultureInfo culInfo = CultureInfo.CurrentCulture ;
 
 			// Checking Locale default from system
 			Assert.AreEqual(culInfo, ds.Locale  , "DS156");
 
 			// Checking Locale get/set
-			culInfo = new System.Globalization.CultureInfo("fr"); // = french
+			culInfo = new CultureInfo("fr"); // = french
 			ds.Locale = culInfo ;
 			Assert.AreEqual(culInfo , ds.Locale , "DS157");
 		}
@@ -1998,11 +1998,11 @@ namespace MonoTests_System.Data
 			ds1.Tables.Add(DataProvider.CreateParentDataTable());
 			ds1.Tables.Add(DataProvider.CreateChildDataTable());
 
-			System.IO.MemoryStream ms = new System.IO.MemoryStream();
+			MemoryStream ms = new MemoryStream();
 			//write xml  schema only
 			ds1.WriteXmlSchema(ms);
 
-			System.IO.MemoryStream ms1 = new System.IO.MemoryStream(ms.GetBuffer());
+			MemoryStream ms1 = new MemoryStream(ms.GetBuffer());
 			//copy schema
 			DataSet ds2 = new DataSet();
 			ds2.ReadXmlSchema(ms1);
@@ -2073,7 +2073,7 @@ namespace MonoTests_System.Data
 			Assert.AreEqual(0, ds2.Tables[1].Rows.Count , "DS282");
 
 			//try to delete the file
-			System.IO.File.Delete(sTempFileName);
+			File.Delete(sTempFileName);
 		}
 
 		[Test] public void ReadXmlSchema_ByTextReader()
@@ -2082,11 +2082,11 @@ namespace MonoTests_System.Data
 			ds1.Tables.Add(DataProvider.CreateParentDataTable());
 			ds1.Tables.Add(DataProvider.CreateChildDataTable());
 
-			System.IO.StringWriter sw = new System.IO.StringWriter();
+			StringWriter sw = new StringWriter();
 			//write xml file, schema only
 			ds1.WriteXmlSchema(sw);
 
-			System.IO.StringReader sr = new System.IO.StringReader(sw.GetStringBuilder().ToString());
+			StringReader sr = new StringReader(sw.GetStringBuilder().ToString());
 			//copy both data and schema
 			DataSet ds2 = new DataSet();
 			ds2.ReadXmlSchema(sr);
@@ -2122,14 +2122,14 @@ namespace MonoTests_System.Data
 			ds1.Tables.Add(DataProvider.CreateParentDataTable());
 			ds1.Tables.Add(DataProvider.CreateChildDataTable());
 
-			System.IO.StringWriter sw = new System.IO.StringWriter();
-			System.Xml.XmlTextWriter xmlTW = new System.Xml.XmlTextWriter(sw);
+			StringWriter sw = new StringWriter();
+			XmlTextWriter xmlTW = new XmlTextWriter(sw);
 			//write xml file, schema only
 			ds1.WriteXmlSchema(xmlTW);
 			xmlTW.Flush();
 
-			System.IO.StringReader sr = new System.IO.StringReader(sw.ToString());
-			System.Xml.XmlTextReader xmlTR = new System.Xml.XmlTextReader(sr);
+			StringReader sr = new StringReader(sw.ToString());
+			XmlTextReader xmlTR = new XmlTextReader(sr);
 
 			//copy both data and schema
 			DataSet ds2 = new DataSet();
@@ -2196,7 +2196,7 @@ namespace MonoTests_System.Data
 			Assert.AreEqual(ds2.Tables[1].Rows.Count, ds1.Tables[1].Rows.Count , "DS299");
 
 			//try to delete the file
-			System.IO.File.Delete(sTempFileName);
+			File.Delete(sTempFileName);
 		}
 
 		[Test]
@@ -2212,7 +2212,7 @@ namespace MonoTests_System.Data
 			ds1.Tables[1].Rows.Add(new object[] {7,2," ","		",new DateTime(2000,1,1,0,0,0,0),35});
 			ds1.Tables[1].Rows.Add(new object[] {7,3,"","",new DateTime(2000,1,1,0,0,0,0),35});
 
-			System.IO.MemoryStream ms = new System.IO.MemoryStream();
+			MemoryStream ms = new MemoryStream();
 			//write xml file, data only
 			ds1.WriteXml(ms);
 
@@ -2241,7 +2241,7 @@ namespace MonoTests_System.Data
 		{
 			string input = string.Empty;
 
-			System.IO.StringReader sr;
+			StringReader sr;
 			DataSet ds = new DataSet();
 
 			input += "<?xml version=\"1.0\"?>";
@@ -2261,7 +2261,7 @@ namespace MonoTests_System.Data
 			input += "		</Price>";
 			input += "</Stock>";
 
-			sr = new System.IO.StringReader(input);
+			sr = new StringReader(input);
 
 			ds.ReadXml(sr);
 
@@ -2311,7 +2311,7 @@ namespace MonoTests_System.Data
 		{
 			DataSet ds = new DataSet("TestDataSet");
 			string input = string.Empty;
-			System.IO.StringReader sr;
+			StringReader sr;
 
 			input += "<?xml version=\"1.0\" standalone=\"yes\"?>";
 			input += "<Stocks><Stock name=\"MSFT\"><Company name=\"Microsoft Corp.\" /><Price type=\"high\"><Value>10.0</Value>";
@@ -2320,7 +2320,7 @@ namespace MonoTests_System.Data
 			input += "<Company name=\"General Electric\" /><Price type=\"high\"><Value>22.23</Value><Date>02/12/2001</Date></Price>";
 			input += "<Price type=\"low\"><Value>1.97</Value><Date>04/20/2003</Date></Price><Price type=\"current\"><Value>3.0</Value>";
 			input += "<Date>TODAY</Date></Price></Stock></Stocks>";
-			sr = new System.IO.StringReader(input);
+			sr = new StringReader(input);
 			ds.EnforceConstraints = false;
 			ds.ReadXml(sr);
 
@@ -2339,7 +2339,7 @@ namespace MonoTests_System.Data
 		{
 			m_ds = new DataSet("Stocks");
 			string input = string.Empty;
-			System.IO.StringReader sr;
+			StringReader sr;
 
 			input += "<?xml version=\"1.0\"?>";
 			input += "<Stocks>";
@@ -2408,7 +2408,7 @@ namespace MonoTests_System.Data
 			input += "		</Stock>";
 			input += "</Stocks>";
 
-			sr = new System.IO.StringReader(input);
+			sr = new StringReader(input);
 			m_ds.EnforceConstraints = true;
 			m_ds.ReadXml(sr);
 			this.privateTestCase("TestCase 1", "Company", "name='Microsoft Corp.'", "Stock", "name='MSFT'", "DS320");
@@ -2444,14 +2444,14 @@ namespace MonoTests_System.Data
 			#region "TestCase 1 - Empty string"
 			// Empty string
 			DataSet ds = new DataSet();
-			System.IO.StringReader sr = new System.IO.StringReader (string.Empty);
-			System.Xml.XmlTextReader xReader = new System.Xml.XmlTextReader(sr);
+			StringReader sr = new StringReader (string.Empty);
+			XmlTextReader xReader = new XmlTextReader(sr);
 			try
 			{
 				ds.ReadXml (xReader);
 				Assert.Fail("DS335: ReadXml Failed to throw XmlException");
 			}
-			catch (System.Xml.XmlException) {}
+			catch (XmlException) {}
 			catch (AssertionException exc) {throw  exc;}
 			catch (Exception exc)
 			{
@@ -2635,8 +2635,8 @@ namespace MonoTests_System.Data
 		private void PrivateTestCase(string a_name, string a_expected, string a_xmlData)
 		{
 			DataSet ds = new DataSet();
-			System.IO.StringReader sr = new System.IO.StringReader(a_xmlData) ;
-			System.Xml.XmlTextReader xReader = new System.Xml.XmlTextReader(sr) ;
+			StringReader sr = new StringReader(a_xmlData) ;
+			XmlTextReader xReader = new XmlTextReader(sr) ;
 			ds.ReadXml (xReader);
 			Assert.AreEqual(a_expected, this.dataSetDescription(ds), "DS337");
 		}
@@ -2681,8 +2681,8 @@ namespace MonoTests_System.Data
 			xmlData += 		"<c>3</c>";
 			xmlData +=    "</b>";
 			xmlData += 	"</a>";
-			System.IO.StringReader sr = new System.IO.StringReader(xmlData) ;
-			System.Xml.XmlTextReader xReader = new System.Xml.XmlTextReader(sr) ;
+			StringReader sr = new StringReader(xmlData) ;
+			XmlTextReader xReader = new XmlTextReader(sr) ;
 			ds.ReadXml (xReader);
 			Assert.AreEqual(3, ds.Tables["c"].Rows.Count, "DS338");
 		}
@@ -2738,7 +2738,7 @@ namespace MonoTests_System.Data
 			ds1.Tables[1].Rows.Add(new object[] {7,2," ","		",new DateTime(2000,1,1,0,0,0,0),35});
 			ds1.Tables[1].Rows.Add(new object[] {7,3,"","",new DateTime(2000,1,1,0,0,0,0),35});
 
-			System.IO.StringWriter sw = new System.IO.StringWriter();
+			StringWriter sw = new StringWriter();
 			//write xml file, data only
 			ds1.WriteXml(sw);
 
@@ -2747,7 +2747,7 @@ namespace MonoTests_System.Data
 			//clear the data
 			ds2.Clear();
 
-			System.IO.StringReader sr = new System.IO.StringReader(sw.GetStringBuilder().ToString());
+			StringReader sr = new StringReader(sw.GetStringBuilder().ToString());
 			ds2.ReadXml(sr);
 
 			//check xml data
@@ -2777,8 +2777,8 @@ namespace MonoTests_System.Data
 			ds1.Tables[1].Rows.Add(new object[] {7,2," ","		",new DateTime(2000,1,1,0,0,0,0),35});
 			ds1.Tables[1].Rows.Add(new object[] {7,3,"","",new DateTime(2000,1,1,0,0,0,0),35});
 
-			System.IO.StringWriter sw = new System.IO.StringWriter();
-			System.Xml.XmlTextWriter xmlTW = new System.Xml.XmlTextWriter(sw);
+			StringWriter sw = new StringWriter();
+			XmlTextWriter xmlTW = new XmlTextWriter(sw);
 
 			//write xml file, data only
 			ds1.WriteXml(xmlTW);
@@ -2788,8 +2788,8 @@ namespace MonoTests_System.Data
 			DataSet ds2 = ds1.Copy();
 			//clear the data
 			ds2.Clear();
-			System.IO.StringReader sr = new System.IO.StringReader(sw.ToString());
-			System.Xml.XmlTextReader xmlTR = new System.Xml.XmlTextReader(sr);
+			StringReader sr = new StringReader(sw.ToString());
+			XmlTextReader xmlTR = new XmlTextReader(sr);
 			ds2.ReadXml(xmlTR);
 
 			//check xml data
@@ -2847,8 +2847,8 @@ namespace MonoTests_System.Data
 
 		[Test] public void WriteXmlSchema_Relations_ForeignKeys ()
 		{
-			System.IO.MemoryStream ms = null;
-			System.IO.MemoryStream ms1 = null;
+			MemoryStream ms = null;
+			MemoryStream ms1 = null;
 
 			DataSet ds1 = new DataSet();
 
@@ -2884,10 +2884,10 @@ namespace MonoTests_System.Data
 				new DataColumn[] {col1_5, col1_6},
 				new DataColumn[] {col2_5, col2_6});
 
-			ms = new System.IO.MemoryStream();
+			ms = new MemoryStream();
 			ds1.WriteXmlSchema (ms);
 
-			ms1 = new System.IO.MemoryStream (ms.GetBuffer());
+			ms1 = new MemoryStream (ms.GetBuffer());
 			DataSet ds2 = new DataSet();
 			ds2.ReadXmlSchema(ms1);
 		
@@ -3096,18 +3096,18 @@ namespace MonoTests_System.Data
 
 		[Test] public void WriteXml_ByTextWriterXmlWriteMode()
 		{
-			System.IO.StringReader sr = null;
-			System.IO.StringWriter sw = null;
+			StringReader sr = null;
+			StringWriter sw = null;
 
 			try  // For real
 			{
 				// ReadXml - DataSetOut
 
 				DataSet oDataset = new DataSet("DataSetOut");
-				sw = new System.IO.StringWriter();
-				oDataset.WriteXml(sw,System.Data.XmlWriteMode.WriteSchema);
+				sw = new StringWriter();
+				oDataset.WriteXml(sw, XmlWriteMode.WriteSchema);
 
-				sr = new System.IO.StringReader(sw.GetStringBuilder().ToString());
+				sr = new StringReader(sw.GetStringBuilder().ToString());
 				oDataset = new DataSet("DataSetOut");
 
 				oDataset.ReadXml(sr);
@@ -3252,13 +3252,13 @@ namespace MonoTests_System.Data
 			{
 			DataSet ds = new DataSet();
 			string input = "<a><b><c>2</c></b></a>";
-			System.IO.StringReader sr = new System.IO.StringReader(input) ;
-			System.Xml.XmlTextReader xReader = new System.Xml.XmlTextReader(sr) ;
+			StringReader sr = new StringReader(input) ;
+			XmlTextReader xReader = new XmlTextReader(sr) ;
 			ds.ReadXml (xReader);
 
-			System.Text.StringBuilder sb = new System.Text.StringBuilder();
-			System.IO.StringWriter sw = new System.IO.StringWriter(sb);
-			System.Xml.XmlTextWriter xWriter = new System.Xml.XmlTextWriter(sw);
+			StringBuilder sb = new StringBuilder();
+			StringWriter sw = new StringWriter(sb);
+			XmlTextWriter xWriter = new XmlTextWriter(sw);
 			ds.WriteXml(xWriter);
 			string output = sb.ToString();
 			Assert.AreEqual(input,output, "DS76");
@@ -3267,20 +3267,20 @@ namespace MonoTests_System.Data
 			DataSet ds = new DataSet();
 			string input = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><a><b><c>2</c></b></a>";
 			string expectedOutput = "<a><b><c>2</c></b></a>";
-			System.IO.StringReader sr = new System.IO.StringReader(input) ;
-			System.Xml.XmlTextReader xReader = new System.Xml.XmlTextReader(sr) ;
+			StringReader sr = new StringReader(input) ;
+			XmlTextReader xReader = new XmlTextReader(sr) ;
 			ds.ReadXml (xReader);
 			
-			System.Text.StringBuilder sb = new System.Text.StringBuilder();
-			System.IO.StringWriter sw = new System.IO.StringWriter(sb);
-			System.Xml.XmlTextWriter xWriter = new System.Xml.XmlTextWriter(sw);
+			StringBuilder sb = new StringBuilder();
+			StringWriter sw = new StringWriter(sb);
+			XmlTextWriter xWriter = new XmlTextWriter(sw);
 			ds.WriteXml(xWriter);
 			string output = sb.ToString();
 			Assert.AreEqual(expectedOutput,output, "DS77");
 			}
 			{
 			DataSet ds = new DataSet("DSName"); 
-			System.IO.StringWriter sr = new System.IO.StringWriter();
+			StringWriter sr = new StringWriter();
 			ds.WriteXml(sr); 
 			Assert.AreEqual("<DSName />",sr.ToString(), "DS78");
 			}
@@ -3315,7 +3315,7 @@ namespace MonoTests_System.Data
 			ds.Tables.Remove("ChildTable");
 
 			//Get the xml representation of the dataset.
-			System.IO.StringWriter sr = new System.IO.StringWriter();
+			StringWriter sr = new StringWriter();
 			ds.WriteXml(sr); 
 			string xml = sr.ToString();
 

--- a/mcs/class/System.Data/Test/System.Data/DataTableCollectionTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataTableCollectionTest2.cs
@@ -28,10 +28,12 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections;
+using System.ComponentModel;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class DataTableCollectionTest2
 	{
@@ -143,7 +145,7 @@ namespace MonoTests_System.Data
 		{
 			counter = 0;
 			DataSet ds = new DataSet();
-			ds.Tables.CollectionChanged+=new System.ComponentModel.CollectionChangeEventHandler(Tables_CollectionChanged);
+			ds.Tables.CollectionChanged+=new CollectionChangeEventHandler(Tables_CollectionChanged);
 			ds.Tables.Add();
 			ds.Tables.Add();
 			Assert.AreEqual(2, counter, "DTC15");
@@ -153,7 +155,7 @@ namespace MonoTests_System.Data
 			Assert.AreEqual(4, counter, "DTC16");
 		}
 
-		private void Tables_CollectionChanged(object sender, System.ComponentModel.CollectionChangeEventArgs e)
+		private void Tables_CollectionChanged(object sender, CollectionChangeEventArgs e)
 		{
 			counter++;
 		}
@@ -163,7 +165,7 @@ namespace MonoTests_System.Data
 		{
 			counter = 0;
 			DataSet ds = new DataSet();
-			ds.Tables.CollectionChanging+=new System.ComponentModel.CollectionChangeEventHandler(Tables_CollectionChanging);
+			ds.Tables.CollectionChanging+=new CollectionChangeEventHandler(Tables_CollectionChanging);
 			ds.Tables.Add();
 			ds.Tables.Add();
 			Assert.AreEqual(2, counter, "DTC17");
@@ -173,7 +175,7 @@ namespace MonoTests_System.Data
 			Assert.AreEqual(4, counter, "DTC18");
 		}
 
-		private void Tables_CollectionChanging(object sender, System.ComponentModel.CollectionChangeEventArgs e)
+		private void Tables_CollectionChanging(object sender, CollectionChangeEventArgs e)
 		{
 			counter++;
 		}
@@ -233,7 +235,7 @@ namespace MonoTests_System.Data
 			ds.Tables.Add();
 			int count=0;
 
-			System.Collections.IEnumerator myEnumerator = ds.Tables.GetEnumerator();
+			IEnumerator myEnumerator = ds.Tables.GetEnumerator();
 
 			while (myEnumerator.MoveNext())
 			{

--- a/mcs/class/System.Data/Test/System.Data/DataTableTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataTableTest2.cs
@@ -36,7 +36,7 @@ using MonoTests.System.Data.Utils;
 
 using NUnit.Framework;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class DataTableTest2

--- a/mcs/class/System.Data/Test/System.Data/DataTableTest3.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataTableTest3.cs
@@ -31,7 +31,7 @@ using System.Xml;
 
 using NUnit.Framework;
 
-namespace Monotests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class DataTableTest3

--- a/mcs/class/System.Data/Test/System.Data/DataTableTest4.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataTableTest4.cs
@@ -31,7 +31,7 @@ using System.IO;
 using System.Xml;
 using NUnit.Framework;
 
-namespace Monotests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class DataTableTest4
@@ -1600,7 +1600,7 @@ namespace Monotests_System.Data
 			DataSet ds = new DataSet ();
 			DataTable table = new DataTable ("ParentTable");
 			XmlReadMode mode = XmlReadMode.Auto;
-			table.Columns.Add (new DataColumn ("id", System.Type.GetType ("System.Int32")));
+			table.Columns.Add (new DataColumn ("id", Type.GetType ("System.Int32")));
 			ds.Tables.Add (table);
 
 			using (FileStream stream = new FileStream (tempFile, FileMode.Open)) {
@@ -1638,7 +1638,7 @@ namespace Monotests_System.Data
 			using (FileStream stream = new FileStream (tempFile, FileMode.Open)) {
 				DataSet ds = new DataSet ();
 				DataTable table = new DataTable ("Table1");
-				table.Columns.Add (new DataColumn ("id", System.Type.GetType ("System.Int32")));
+				table.Columns.Add (new DataColumn ("id", Type.GetType ("System.Int32")));
 				ds.Tables.Add (table);
 
 				try {
@@ -1852,7 +1852,7 @@ namespace Monotests_System.Data
 			DataTable table = new DataTable ("DummyTable");
 			//define the table schame partially with a column name which does not match with any
 			//table columns in the diffgram
-			table.Columns.Add (new DataColumn ("WrongColumnName", System.Type.GetType ("System.String")));
+			table.Columns.Add (new DataColumn ("WrongColumnName", Type.GetType ("System.String")));
 
 			XmlReadMode mode = XmlReadMode.Auto;
 
@@ -2013,8 +2013,8 @@ namespace Monotests_System.Data
 			Assert.AreEqual ("NewDataSet", table.DataSet.DataSetName, "#2");
 			Assert.AreEqual (2, table.Columns.Count, "#3");
 			Assert.AreEqual (2, table.Rows.Count, "#4");
-			Assert.AreEqual (typeof (System.Int32), table.Columns [0].DataType, "#5");
-			Assert.AreEqual (typeof (System.String), table.Columns [1].DataType, "#6");
+			Assert.AreEqual (typeof (Int32), table.Columns [0].DataType, "#5");
+			Assert.AreEqual (typeof (String), table.Columns [1].DataType, "#6");
 			Assert.AreEqual (1, table.Constraints.Count, "#7");
 			Assert.AreEqual (typeof (UniqueConstraint), table.Constraints [0].GetType (), "#8");
 			Assert.AreEqual (1, table.ChildRelations.Count, "#9");
@@ -2027,9 +2027,9 @@ namespace Monotests_System.Data
 			Assert.AreEqual ("NewDataSet", table1.DataSet.DataSetName, "#14");
 			Assert.AreEqual (3, table1.Columns.Count, "#15");
 			Assert.AreEqual (4, table1.Rows.Count, "#16");
-			Assert.AreEqual (typeof (System.Int32), table1.Columns [0].DataType, "#17");
-			Assert.AreEqual (typeof (System.String), table1.Columns [1].DataType, "#18");
-			Assert.AreEqual (typeof (System.Int32), table1.Columns [2].DataType, "#19");
+			Assert.AreEqual (typeof (Int32), table1.Columns [0].DataType, "#17");
+			Assert.AreEqual (typeof (String), table1.Columns [1].DataType, "#18");
+			Assert.AreEqual (typeof (Int32), table1.Columns [2].DataType, "#19");
 			Assert.AreEqual (2, table1.Constraints.Count, "#20");
 			Assert.AreEqual (typeof (UniqueConstraint), table1.Constraints [0].GetType (), "#21");
 			Assert.AreEqual (typeof (ForeignKeyConstraint), table1.Constraints [1].GetType (), "#22");
@@ -2045,8 +2045,8 @@ namespace Monotests_System.Data
 			Assert.AreEqual ("NewDataSet", table1.DataSet.DataSetName, "#29");
 			Assert.AreEqual (2, table1.Columns.Count, "#30");
 			Assert.AreEqual (8, table1.Rows.Count, "#31");
-			Assert.AreEqual (typeof (System.Int32), table1.Columns [0].DataType, "#32");
-			Assert.AreEqual (typeof (System.String), table1.Columns [1].DataType, "#33");
+			Assert.AreEqual (typeof (Int32), table1.Columns [0].DataType, "#32");
+			Assert.AreEqual (typeof (String), table1.Columns [1].DataType, "#33");
 			Assert.AreEqual (1, table1.Constraints.Count, "#34");
 			Assert.AreEqual (typeof (ForeignKeyConstraint), table1.Constraints [0].GetType (), "#35");
 			Assert.AreEqual (1, table1.ParentRelations.Count, "#36");

--- a/mcs/class/System.Data/Test/System.Data/DataTableTest5.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataTableTest5.cs
@@ -34,7 +34,7 @@ using System.Xml.Serialization;
 
 using NUnit.Framework;
 
-namespace Monotests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class DataTableTest5

--- a/mcs/class/System.Data/Test/System.Data/DataViewTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataViewTest2.cs
@@ -28,12 +28,13 @@
 
 using NUnit.Framework;
 using System;
-using System.IO;
+using System.Collections;
 using System.ComponentModel;
+using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class DataViewTest2
 	{
@@ -41,7 +42,7 @@ namespace MonoTests_System.Data
 
 		class EventProperties  //hold the event properties to be checked
 		{
-			public System.ComponentModel.ListChangedType lstType ;
+			public ListChangedType lstType ;
 			public int NewIndex;
 			public int OldIndex;
 		}
@@ -508,7 +509,7 @@ namespace MonoTests_System.Data
 			//create the dataview for the table
 			DataView dv = new DataView(dt);
 
-			System.Collections.IEnumerator ienm = null;
+			IEnumerator ienm = null;
 
 			// GetEnumerator != null
 			ienm = dv.GetEnumerator();
@@ -549,7 +550,7 @@ namespace MonoTests_System.Data
 			DataView dv = new DataView(dt);
 
 			//add event handler
-			dv.ListChanged +=new System.ComponentModel.ListChangedEventHandler(dv_ListChanged);
+			dv.ListChanged +=new ListChangedEventHandler(dv_ListChanged);
 
 			// ----- Change Value ---------
 			evProp = null;
@@ -557,7 +558,7 @@ namespace MonoTests_System.Data
 			dv[1]["String1"] = "something";
 			Assert.AreEqual(true , evProp!=null , "DV58");
 			// change value - ListChangedType
-			Assert.AreEqual(System.ComponentModel.ListChangedType.ItemChanged, evProp.lstType , "DV59");
+			Assert.AreEqual(ListChangedType.ItemChanged, evProp.lstType , "DV59");
 			// change value - NewIndex
 			Assert.AreEqual(1, evProp.NewIndex, "DV60");
 			// change value - OldIndex
@@ -569,7 +570,7 @@ namespace MonoTests_System.Data
 			dv.AddNew();
 			Assert.AreEqual(true , evProp!=null , "DV62");
 			// Add New  - ListChangedType
-			Assert.AreEqual(System.ComponentModel.ListChangedType.ItemAdded , evProp.lstType , "DV63");
+			Assert.AreEqual(ListChangedType.ItemAdded , evProp.lstType , "DV63");
 			// Add New  - NewIndex
 			Assert.AreEqual(6, evProp.NewIndex, "DV64");
 			// Add New  - OldIndex
@@ -581,7 +582,7 @@ namespace MonoTests_System.Data
 			dv.Sort = "ParentId Desc";
 			Assert.AreEqual(true , evProp!=null , "DV66");
 			// sort - ListChangedType
-			Assert.AreEqual(System.ComponentModel.ListChangedType.Reset , evProp.lstType , "DV67");
+			Assert.AreEqual(ListChangedType.Reset , evProp.lstType , "DV67");
 			// sort - NewIndex
 			Assert.AreEqual(-1, evProp.NewIndex, "DV68");
 			// sort - OldIndex
@@ -627,12 +628,12 @@ namespace MonoTests_System.Data
 
                         Assert.AreEqual(true , evProp != null , "DV168");
                         // Clear DataTable - should emit ListChangedType.Reset
-                        Assert.AreEqual(System.ComponentModel.ListChangedType.Reset , evProp.lstType , "DV169");
+                        Assert.AreEqual(ListChangedType.Reset , evProp.lstType , "DV169");
                         // Clear DataTable - should clear view count
                         Assert.AreEqual(0, dt.DefaultView.Count , "DV169");
                 }
 
-		private void dv_ListChanged(object sender, System.ComponentModel.ListChangedEventArgs e)
+		private void dv_ListChanged(object sender, ListChangedEventArgs e)
 		{
 			evProp = new EventProperties();	
 			evProp.lstType = e.ListChangedType;
@@ -646,7 +647,7 @@ namespace MonoTests_System.Data
 			// this test also check DataView.Count property
 
 			DataRowView[] drvResult = null;
-			System.Collections.ArrayList al = new System.Collections.ArrayList();
+			ArrayList al = new ArrayList();
 
 			//create the source datatable
 			DataTable dt = DataProvider.CreateChildDataTable();
@@ -763,7 +764,7 @@ namespace MonoTests_System.Data
 			 */
 
 			//DataRowView[] drvResult = null;
-			System.Collections.ArrayList al = new System.Collections.ArrayList();
+			ArrayList al = new ArrayList();
 
 			DataTable dt = DataProvider.CreateParentDataTable();
 
@@ -821,7 +822,7 @@ namespace MonoTests_System.Data
 		private DataRow[] GetResultRows(DataTable dt,DataRowState State)
 		{
 			//get expected rows
-			System.Collections.ArrayList al = new System.Collections.ArrayList();
+			ArrayList al = new ArrayList();
 			DataRowVersion drVer = DataRowVersion.Current;
 
 			//From MSDN -	The row the default version for the current DataRowState.

--- a/mcs/class/System.Data/Test/System.Data/DeletedRowInaccessibleExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/DeletedRowInaccessibleExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class DeletedRowInaccessibleExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/DuplicateNameExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/DuplicateNameExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class DuplicateNameExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/EvaluateExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/EvaluateExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 //using GHTUtils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class EvaluateExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/ForeignKeyConstraintTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/ForeignKeyConstraintTest2.cs
@@ -31,7 +31,7 @@ using System;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class ForeignKeyConstraintTest2
 	{

--- a/mcs/class/System.Data/Test/System.Data/InRowChangingEventExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/InRowChangingEventExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class InRowChangingEventExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/InvalidConstraintExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/InvalidConstraintExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class InvalidConstraintExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/MissingPrimaryKeyExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/MissingPrimaryKeyExceptionTest.cs
@@ -32,7 +32,7 @@ using System.Data;
 using NUnit.Framework;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	class MissingPrimaryKeyExceptionTest

--- a/mcs/class/System.Data/Test/System.Data/NoNullAllowedExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/NoNullAllowedExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class NoNullAllowedExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/ReadOnlyExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/ReadOnlyExceptionTest.cs
@@ -33,7 +33,7 @@ using System.IO;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class ReadOnlyExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/RowNotInTableExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/RowNotInTableExceptionTest.cs
@@ -31,7 +31,7 @@ using System;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class RowNotInTableExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/SyntaxErrorExceptionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/SyntaxErrorExceptionTest.cs
@@ -32,7 +32,7 @@ using System.Text;
 using System.IO;
 using System.Data;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class SyntaxErrorExceptionTest
 	{

--- a/mcs/class/System.Data/Test/System.Data/TrailingSpaceTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/TrailingSpaceTest.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Data;
 
-namespace Monotests_Mono.Data.SqlExpressions
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class ComparisonTest {
@@ -10,7 +10,7 @@ namespace Monotests_Mono.Data.SqlExpressions
 		[Test]
 		public void TestStringTrailingSpaceHandling () {
 			// test for bug 79695 - does not ignore certain trailing whitespace chars when comparing strings
-			System.Data.DataTable dataTable = new System.Data.DataTable ("Person");
+			DataTable dataTable = new DataTable ("Person");
 			dataTable.Columns.Add ("Name", typeof (string));
 			dataTable.Rows.Add (new object[] {"Mike   "}); 
 			DataRow[] selectedRows = dataTable.Select ("Name = 'Mike'");

--- a/mcs/class/System.Data/Test/System.Data/UniqueConstraintTest2.cs
+++ b/mcs/class/System.Data/Test/System.Data/UniqueConstraintTest2.cs
@@ -31,7 +31,7 @@ using System;
 using System.Data;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture] public class UniqueConstraintTest2
 	{

--- a/mcs/class/System.Data/Test/System.Data/VersionNotFoundException.cs
+++ b/mcs/class/System.Data/Test/System.Data/VersionNotFoundException.cs
@@ -32,7 +32,7 @@ using System.Data;
 using NUnit.Framework;
 using MonoTests.System.Data.Utils;
 
-namespace MonoTests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	class VersionNotFoundExceptionTest

--- a/mcs/class/System.Data/Test/System.Data/XmlDataLoaderTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/XmlDataLoaderTest.cs
@@ -32,7 +32,7 @@ using System.Xml;
 
 using NUnit.Framework;
 
-namespace Monotests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]
 	public class XmlDataLoaderTest
@@ -74,7 +74,7 @@ namespace Monotests_System.Data
 			DataSet ds = new DataSet ("Set");
 			DataTable dt = new DataTable ("Test");
 			dt.Columns.Add ("CustName", typeof (String));
-			dt.Columns.Add ("Type", typeof (System.Type));
+			dt.Columns.Add ("Type", typeof (Type));
 			ds.Tables.Add (dt);
 			return ds;
 		}

--- a/mcs/class/System.Data/Test/System.Data/XmlDataReaderTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/XmlDataReaderTest.cs
@@ -33,7 +33,7 @@ using System.Xml.Serialization;
 using System.Xml.Schema;
 using NUnit.Framework;
 
-namespace Monotests_System.Data
+namespace MonoTests.System.Data
 {
 	[TestFixture]	
 	public class XmlDataReaderTest
@@ -103,7 +103,7 @@ namespace Monotests_System.Data
 			StringReader sr = new StringReader (xml);
 			XmlTextReader xr = new XmlTextReader (sr);
 			DataTable tbl = new DataTable("CustomTypesTable");
-			tbl.Columns.Add("Dummy", typeof(System.UInt32));
+			tbl.Columns.Add("Dummy", typeof(UInt32));
 			tbl.Columns.Add("FuncXml", typeof(CustomTypeXml));
 
 			DataSet ds = new DataSet("CustomTypesData");

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CommunicationObjectSyncTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CommunicationObjectSyncTest.cs
@@ -35,7 +35,7 @@ using System.ServiceModel.Channels;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Mono.Moonlight.UnitTesting;
 
-namespace MoonTest.ServiceModel {
+namespace MonoTests.System.ServiceModel.Channels {
 
 	[TestClass]
 	public class CommunicationObjectSyncTest {

--- a/mcs/class/System.ServiceProcess/Test/System.ServiceProcess/ServiceBaseTest.cs
+++ b/mcs/class/System.ServiceProcess/Test/System.ServiceProcess/ServiceBaseTest.cs
@@ -27,10 +27,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.ComponentModel;
 using System.ServiceProcess;
 using NUnit.Framework;
 
-namespace Test
+namespace MonoTests.System.ServiceProcess
 {
 	[TestFixture]
 	public class ServiceBaseTest
@@ -84,7 +85,7 @@ namespace Test
 			/// <summary>
 			/// Required designer variable.
 			/// </summary>
-			private System.ComponentModel.IContainer components = null;
+			private IContainer components = null;
 
 			/// <summary>
 			/// Clean up any resources being used.
@@ -107,7 +108,7 @@ namespace Test
 			/// </summary>
 			private void InitializeComponent()
 			{
-				components = new System.ComponentModel.Container();
+				components = new Container();
 				this.ServiceName = "ServiceFoo";
 			}
 

--- a/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/AnnotationPathPointTest.cs
+++ b/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/AnnotationPathPointTest.cs
@@ -27,7 +27,7 @@ using System;
 using System.Windows.Forms.DataVisualization.Charting;
 using NUnit.Framework;
 
-namespace ChartingTests
+namespace MonoTests.System.Windows.Forms.DataVisualization.Charting
 {
 	[TestFixture]
 	public class AnnotationPathPointTest

--- a/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/AnovaResultTest.cs
+++ b/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/AnovaResultTest.cs
@@ -27,7 +27,7 @@ using System;
 using System.Windows.Forms.DataVisualization.Charting;
 using NUnit.Framework;
 
-namespace ChartingTests
+namespace MonoTests.System.Windows.Forms.DataVisualization.Charting
 {
 	[TestFixture]
 	public class AnovaResultTest

--- a/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/ArrowAnnotationTest.cs
+++ b/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/ArrowAnnotationTest.cs
@@ -27,7 +27,7 @@ using System;
 using System.Windows.Forms.DataVisualization.Charting;
 using NUnit.Framework;
 
-namespace ChartingTests
+namespace MonoTests.System.Windows.Forms.DataVisualization.Charting
 {
 	[TestFixture]
 	public class ArrowAnnotationTest

--- a/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/AxisScaleBreakStyleTest.cs
+++ b/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/AxisScaleBreakStyleTest.cs
@@ -28,7 +28,7 @@ using System.Windows.Forms.DataVisualization.Charting;
 using NUnit.Framework;
 using System.Drawing;
 
-namespace ChartingTests
+namespace MonoTests.System.Windows.Forms.DataVisualization.Charting
 {
 	[TestFixture]
 	public class AxisScaleBreakStyleTest

--- a/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/ChartElementTest.cs
+++ b/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/ChartElementTest.cs
@@ -27,7 +27,7 @@ using System;
 using System.Windows.Forms.DataVisualization.Charting;
 using NUnit.Framework;
 
-namespace ChartingTests
+namespace MonoTests.System.Windows.Forms.DataVisualization.Charting
 {
 	[TestFixture]
 	public class ChartElementTest

--- a/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/DataPointTest.cs
+++ b/mcs/class/System.Windows.Forms.DataVisualization/Test/System.Windows.Forms.DataVisualization.Charting/DataPointTest.cs
@@ -27,7 +27,7 @@ using System;
 using System.Windows.Forms.DataVisualization.Charting;
 using NUnit.Framework;
 
-namespace ChartingTests
+namespace MonoTests.System.Windows.Forms.DataVisualization.Charting
 {
 	[TestFixture]
 	public class DataPointTest

--- a/mcs/class/System.XML/Test/System.Xml/XmlResolverTest.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlResolverTest.cs
@@ -33,7 +33,7 @@ using System.Xml;
 
 using NUnit.Framework;
 
-namespace MonoTest.System.Xml {
+namespace MonoTests.System.Xml {
 
 	[TestFixture]
 	public class XmlResolverTest {

--- a/mcs/class/System.XML/Test/System.Xml/XmlSecureResolverCas.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlSecureResolverCas.cs
@@ -38,7 +38,7 @@ using System.Security.Permissions;
 using System.Security.Policy;
 using System.Xml;
 
-using MonoTestsXml;
+using MonoTests.System.Xml;
 
 namespace MonoCasTests.System.Xml {
 

--- a/mcs/class/System.XML/Test/System.Xml/XmlSecureResolverTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlSecureResolverTests.cs
@@ -20,7 +20,7 @@ using System.Security.Permissions;
 using System.Xml;
 using NUnit.Framework;
 
-namespace MonoTestsXml
+namespace MonoTests.System.Xml
 {
 	[TestFixture]
 	public class XmlSecureResolverTests

--- a/mcs/class/System/Test/System.Net/NetworkCredentialTest.cs
+++ b/mcs/class/System/Test/System.Net/NetworkCredentialTest.cs
@@ -31,7 +31,7 @@ using System.Net;
 
 using NUnit.Framework;
 
-namespace MoonTest.System.Net {
+namespace MonoTests.System.Net {
 
 	[TestFixture]
 	public class NetworkCredentialTest {

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackage.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackage.cs
@@ -25,9 +25,11 @@
 
 
 using System;
+using System.IO;
+using System.IO.Packaging;
 using System.Collections.Generic;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
 	
     public class FakePackage : Package {
         Dictionary<Uri, PackagePart> Parts { get; set; }

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackagePart.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackagePart.cs
@@ -24,9 +24,11 @@
 //
 
 using System;
+using System.IO;
+using System.IO.Packaging;
 using System.Collections.Generic;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
     
     class FakePackagePart : PackagePart {
 

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackagePartTests.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackagePartTests.cs
@@ -26,9 +26,12 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
 
     [TestFixture]
     public class FakePackagePartTests : TestBase {
@@ -146,7 +149,7 @@ namespace System.IO.Packaging.Tests {
         }
 
         [Test]
-        [ExpectedException (typeof (Xml.XmlException))]
+        [ExpectedException (typeof (XmlException))]
         public void CreateDupeRelationship ()
         {
             part.CreateRelationship (uris [1], TargetMode.External, "blah", "asda");
@@ -154,7 +157,7 @@ namespace System.IO.Packaging.Tests {
         }
 
         [Test]
-        [ExpectedException (typeof (Xml.XmlException))]
+        [ExpectedException (typeof (XmlException))]
         public void CreateDupeRelationshipId ()
         {
             part.CreateRelationship (uris [1], TargetMode.External, "blah", "asda");

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackageTests.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/FakePackageTests.cs
@@ -26,11 +26,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests
+namespace MonoTests.System.IO.Packaging
 {
 
     [TestFixture]

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/FakeStream.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/FakeStream.cs
@@ -25,9 +25,10 @@
 
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
 
     public class FakeStream : MemoryStream {
         public bool canRead;

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackUriHelperTests.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackUriHelperTests.cs
@@ -8,7 +8,7 @@ using System;
 using System.IO.Packaging;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
     
     [TestFixture]
     public class PackUriHelperTests {

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartFileTests.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartFileTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.IO.Packaging;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests
+namespace MonoTests.System.IO.Packaging
 {
 	[TestFixture]
 	public class PackagePartFileTests

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartStreamTests.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartStreamTests.cs
@@ -26,11 +26,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
     
     [TestFixture]
     public class PackagePartStreamTests : TestBase {

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
@@ -26,12 +26,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using System.Xml;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
 
     [TestFixture]
     public class PackagePartTest : TestBase {

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackageRelationshipTests.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackageRelationshipTests.cs
@@ -28,12 +28,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using System.Xml;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
     
     [TestFixture]
     public class PackageRelationshipTests : TestBase {

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackageTest.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackageTest.cs
@@ -26,11 +26,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
 
     [TestFixture]
     public class PackageTest : TestBase {
@@ -411,7 +413,7 @@ namespace System.IO.Packaging.Tests {
         [ExpectedException (typeof (FileFormatException))]
         public void WriteOnlyAccessExists ()
         {
-            System.IO.File.Create (path).Close ();
+            File.Create (path).Close ();
             package = Package.Open (path, FileMode.OpenOrCreate, FileAccess.Write);
         }
     }

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/TestBase.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/TestBase.cs
@@ -26,11 +26,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
 
-namespace System.IO.Packaging.Tests {
+namespace MonoTests.System.IO.Packaging {
     public abstract class TestBase {
 
         protected string contentType = "mime/type";

--- a/mcs/class/corlib/Test/Mono/DataConvertTest.cs
+++ b/mcs/class/corlib/Test/Mono/DataConvertTest.cs
@@ -8,7 +8,7 @@ using Mono;
 using NUnit.Framework.SyntaxHelpers;
 #endif
 
-namespace MonoTests {
+namespace MonoTests.Mono {
 
 	[TestFixture]
 	public class DataConverterTest
@@ -50,9 +50,9 @@ namespace MonoTests {
 		[Test]
 		public void StringAlignment ()
 		{
-			byte[] packed = Mono.DataConverter.Pack ("bz8", 1, TEST_STRING);
+			byte[] packed = global::Mono.DataConverter.Pack ("bz8", 1, TEST_STRING);
 				
-			IList unpacked = Mono.DataConverter.Unpack ("bz8", packed, 0);
+			IList unpacked = global::Mono.DataConverter.Unpack ("bz8", packed, 0);
 			
 			Assert.AreEqual(1, (byte) unpacked[0]);
 			Assert.AreEqual(TEST_STRING, new string((char[]) unpacked[1]));

--- a/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
@@ -1111,7 +1111,7 @@ namespace MonoTests.System.IO
 			try {
 				Directory.CreateDirectory (path);
 				Directory.CreateDirectory (dir);
-				Mono.Unix.UnixSymbolicLinkInfo li = new Mono.Unix.UnixSymbolicLinkInfo (link);
+				global::Mono.Unix.UnixSymbolicLinkInfo li = new global::Mono.Unix.UnixSymbolicLinkInfo (link);
 				li.CreateSymbolicLinkTo (dir);
 
 				DirectoryInfo info = new DirectoryInfo (path);

--- a/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
@@ -374,11 +374,11 @@ public class DirectoryTest
 		string path = TempFolder + DSC + "ExistsAccessDenied";
 
 		Directory.CreateDirectory (path);
-		Mono.Posix.Syscall.chmod (path, 0);
+		global::Mono.Posix.Syscall.chmod (path, 0);
 		try {
 			Assert.IsFalse (Directory.Exists(path + DSC + "b"));
 		} finally {
-			Mono.Posix.Syscall.chmod (path, (Mono.Posix.FileMode) 755);
+			global::Mono.Posix.Syscall.chmod (path, (global::Mono.Posix.FileMode) 755);
 			Directory.Delete (path);
 		}
 	}


### PR DESCRIPTION
A couple of the test suites didn't follow the `MonoTests.<namespace of class under test>` naming convention for the namespace.

This should also make the test list on Jenkins a bit more useful.
