### PR TITLE
re #22724: don't store an instance variable pointer to last web request ...

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -50,7 +50,6 @@ namespace System.Net.Http
 		bool useProxy;
 		ClientCertificateOption certificate;
 		bool sentRequest;
-		HttpWebRequest wrequest;
 		string connectionGroupName;
 		bool disposed;
 
@@ -222,11 +221,7 @@ namespace System.Net.Http
 		protected override void Dispose (bool disposing)
 		{
 			if (disposing) {
-				if (wrequest != null) {
-					wrequest.ServicePoint.CloseConnectionGroup (wrequest.ConnectionGroupName);
-					Volatile.Write (ref wrequest, null);
-				}
-				Volatile.Write (ref disposed, true);
+				ServicePointManager.CloseConnectionGroupForAllServicePoints(connectionGroupName);
 			}
 
 			base.Dispose (disposing);
@@ -317,7 +312,7 @@ namespace System.Net.Http
 				throw new ObjectDisposedException (GetType ().ToString ());
 
 			Volatile.Write (ref sentRequest, true);
-			wrequest = CreateWebRequest (request);
+			var wrequest = CreateWebRequest (request);
 
 			if (request.Content != null) {
 				var headers = wrequest.Headers;

--- a/mcs/class/System/System.Net/ServicePointManager.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.cs
@@ -369,6 +369,22 @@ namespace System.Net
 			
 			return sp;
 		}
+		public static void CloseConnectionGroupForAllServicePoints(string group)
+		{
+			if (group == null)
+				throw new ArgumentNullException("group");
+
+			lock (servicePoints) {
+				foreach (var key in servicePoints.Keys)
+				{
+					var sp = servicePoints[key] as ServicePoint;
+					if (sp == null)
+						continue;
+
+					sp.CloseConnectionGroup(group);
+				}
+			}
+		}
 		
 #if SECURITY_DEP
 		internal class ChainValidationHelper {


### PR DESCRIPTION
...initiated by HttpClientHandler or it breaks the ability to do multiple concurrent requests with a single handler.  clean up the connection groups by adding a method in the ServicePointManager that iterates over all known ServicePoint's to perform the cleanup more cleanly.
