### PR TITLE
[System] Fixed Diagnostics.Switch ctor behavior for null parameters

### DIFF
--- a/mcs/class/System/System.Diagnostics/Switch.cs
+++ b/mcs/class/System/System.Diagnostics/Switch.cs
@@ -64,8 +64,8 @@ namespace System.Diagnostics
 
 		protected Switch(string displayName, string description)
 		{
-			this.name = displayName;
-			this.description = description;
+			this.name = displayName ?? string.Empty;
+			this.description = description ?? string.Empty;
 		}
 
 		protected Switch(string displayName, string description, string defaultSwitchValue)

--- a/mcs/class/System/Test/System.Diagnostics/SourceSwitchTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/SourceSwitchTest.cs
@@ -51,7 +51,7 @@ namespace MonoTests.System.Diagnostics
 		public void ConstructorNullName ()
 		{
 			SourceSwitch s = new SourceSwitch (null);
-			Assert.IsNull (s.DisplayName);
+			Assert.IsEmpty (s.DisplayName);
 		}
 
 		[Test]

--- a/mcs/class/System/Test/System.Diagnostics/SwitchesTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/SwitchesTest.cs
@@ -80,6 +80,12 @@ namespace MonoTests.System.Diagnostics {
 		}
 	}
 
+	class TestNullSwitch : Switch {
+		public TestNullSwitch () : base (null, null)
+		{
+		}
+	}
+
 	[TestFixture]
 	public class SwitchesTest {
     
@@ -183,6 +189,14 @@ namespace MonoTests.System.Diagnostics {
 		{
 			BooleanSwitch s = new BooleanSwitch ("test", "", "hoge");
 			Assert.IsTrue (!s.Enabled);
+		}
+
+		[Test]
+		public void NullSwitchHasEmptyDisplayNameAndDescription ()
+		{
+			var s = new TestNullSwitch ();
+			Assert.IsEmpty (s.DisplayName);
+			Assert.IsEmpty (s.Description);
 		}
 #endif
 	}


### PR DESCRIPTION
Passing null to the displayName or description ctor parameter on MS.NET makes them equal to an empty string.

Fixed the Mono behavior to match .NET.
