### PR TITLE
support nanoseconds

### DIFF
--- a/mcs/class/corlib/System/DateTime.cs
+++ b/mcs/class/corlib/System/DateTime.cs
@@ -93,6 +93,8 @@ namespace System
 		private static readonly string[] ParseTimeFormats = new string [] {
 			"H:m:s.fff zzz",
 			"H:m:s.fffffffzzz",
+			"H:m:s.fffffffff",
+			"H:m:s.ffffffff",
 			"H:m:s.fffffff",
 			"H:m:s.ffffff",
 			"H:m:s.ffffffzzz",


### PR DESCRIPTION
Golang:
```go
time.Now() // output: 2014-09-11T16:21:45.324661311Z
```
For supporting also nanoseconds. Actually why 7? It's not mili/micro or neither nano?!