### PR TITLE
Maximum large object size should be limited by SSIZE_MAX not SIZE_MAX.

### DIFF
--- a/mono/metadata/sgen-los.c
+++ b/mono/metadata/sgen-los.c
@@ -336,13 +336,13 @@ sgen_los_alloc_large_inner (MonoVTable *vtable, size_t size)
 	g_assert ((size & 1) == 0);
 
 	/*
-	 * size + sizeof (LOSObject) <= SIZE_MAX - (mono_pagesize () - 1)
+	 * size + sizeof (LOSObject) <= SSIZE_MAX - (mono_pagesize () - 1)
 	 *
 	 * therefore:
 	 *
-	 * size <= SIZE_MAX - (mono_pagesize () - 1) - sizeof (LOSObject)
+	 * size <= SSIZE_MAX - (mono_pagesize () - 1) - sizeof (LOSObject)
 	 */
-	if (size > SIZE_MAX - (mono_pagesize () - 1) - sizeof (LOSObject))
+	if (size > SSIZE_MAX - (mono_pagesize () - 1) - sizeof (LOSObject))
 		return NULL;
 
 #ifdef LOS_DUMMY


### PR DESCRIPTION
The latter appears to be a hangover from 32-bit systems.
