### PR TITLE
Fixed HashAlgorithm not enforcing State and cases where the hash is re-Initialized before return

### DIFF
--- a/mcs/class/corlib/System.Security.Cryptography/HMAC.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HMAC.cs
@@ -148,6 +148,8 @@ namespace System.Security.Cryptography {
 		{
 			if (_disposed)
 				throw new ObjectDisposedException ("HMAC");
+			if (!_isKeySetupCompleted)
+				InitialKeySetup ();
 
 			Block.Final ();
 			byte[] intermediate = _algo.Hash;

--- a/mcs/class/corlib/System.Security.Cryptography/HMAC.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HMAC.cs
@@ -57,12 +57,12 @@ namespace System.Security.Cryptography {
 		private HashAlgorithm _algo;
 		private BlockProcessor _block;
 		private int _blockSizeValue; 
+		private bool _isKeySetupCompleted;
 
 		// constructors
 
 		protected HMAC () 
 		{
-			_disposed = false;
 			_blockSizeValue = 64;
 		}
 
@@ -101,6 +101,16 @@ namespace System.Security.Cryptography {
 
 		// methods
 
+		private void InitialKeySetup ()
+		{
+			Block.Initialize ();
+			byte[] buf = KeySetup (Key, 0x36);
+			Block.Core (buf);
+			// zeroize key
+			Array.Clear (buf, 0, buf.Length);
+			_isKeySetupCompleted = true;
+		}
+
 		private byte[] KeySetup (byte[] key, byte padding) 
 		{
 			byte[] buf = new byte [BlockSizeValue];
@@ -126,11 +136,11 @@ namespace System.Security.Cryptography {
 		{
 			if (_disposed)
 				throw new ObjectDisposedException ("HMACSHA1");
-
 			if (State == 0) {
-				Initialize ();
 				State = 1;
 			}
+			if (!_isKeySetupCompleted)
+				InitialKeySetup ();
 			Block.Core (rgb, ib, cb);
 		}
 
@@ -163,12 +173,9 @@ namespace System.Security.Cryptography {
 				throw new ObjectDisposedException ("HMAC");
 
 			State = 0;
-			Block.Initialize ();
-			byte[] buf = KeySetup (Key, 0x36);
+			_block = null;
 			_algo.Initialize ();
-			Block.Core (buf);
-			// zeroize key
-			Array.Clear (buf, 0, buf.Length);
+			_isKeySetupCompleted = false;
 		}
 
 #if FULL_AOT_RUNTIME

--- a/mcs/class/corlib/System.Security.Cryptography/HMAC.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HMAC.cs
@@ -138,7 +138,6 @@ namespace System.Security.Cryptography {
 		{
 			if (_disposed)
 				throw new ObjectDisposedException ("HMAC");
-			State = 0;
 
 			Block.Final ();
 			byte[] intermediate = _algo.Hash;
@@ -148,10 +147,13 @@ namespace System.Security.Cryptography {
 			_algo.TransformBlock (buf, 0, buf.Length, buf, 0);
 			_algo.TransformFinalBlock (intermediate, 0, intermediate.Length);
 			byte[] hash = _algo.Hash;
-			_algo.Initialize ();
+			State = 0;
+
 			// zeroize sensitive data
+			_algo.Initialize ();
 			Array.Clear (buf, 0, buf.Length);	
 			Array.Clear (intermediate, 0, intermediate.Length);
+
 			return hash;
 		}
 

--- a/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
@@ -129,7 +129,7 @@ namespace System.Security.Cryptography {
 	
 		public virtual byte[] Hash {
 			get { 
-				if (HashValue == null) {
+				if (State != 0 || HashValue == null) {
 					throw new CryptographicUnexpectedOperationException (
 						Locale.GetText ("No hash value computed."));
 				}

--- a/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography {
 
 			HashCore (buffer, offset, count);
 			HashValue = HashFinal ();
-			byte[] dataToReturn = (byte[])this.HashValue.Clone ();
+			byte[] dataToReturn = (byte[])HashValue.Clone ();
 			Initialize ();
 			
 			return dataToReturn;
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography {
 				len = inputStream.Read (buffer, 0, 4096);
 			}
 			HashValue = HashFinal ();
-			byte[] dataToReturn = (byte[])this.HashValue.Clone ();
+			byte[] dataToReturn = (byte[])HashValue.Clone ();
 			Initialize ();
 
 			return dataToReturn;
@@ -135,7 +135,7 @@ namespace System.Security.Cryptography {
 					throw new CryptographicUnexpectedOperationException (
 						Locale.GetText ("No hash value computed."));
 				}
-				return (byte[])this.HashValue.Clone ();
+				return (byte[])HashValue.Clone ();
 			}
 		}
 	

--- a/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
@@ -129,6 +129,8 @@ namespace System.Security.Cryptography {
 	
 		public virtual byte[] Hash {
 			get { 
+				if (disposed)
+					throw new ObjectDisposedException ("HashAlgorithm");
 				if (State != 0 || HashValue == null) {
 					throw new CryptographicUnexpectedOperationException (
 						Locale.GetText ("No hash value computed."));

--- a/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
@@ -133,7 +133,7 @@ namespace System.Security.Cryptography {
 					throw new CryptographicUnexpectedOperationException (
 						Locale.GetText ("No hash value computed."));
 				}
-				return HashValue; 
+				return (byte[])this.HashValue.Clone ();
 			}
 		}
 	

--- a/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
@@ -226,7 +226,6 @@ namespace System.Security.Cryptography {
 			
 			HashCore (inputBuffer, inputOffset, inputCount);
 			HashValue = HashFinal ();
-			Initialize ();
 			
 			return outputBuffer;
 		}

--- a/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
@@ -199,6 +199,7 @@ namespace System.Security.Cryptography {
 				}
 			}
 
+			State = 1;
 			HashCore (inputBuffer, inputOffset, inputCount);
 
 			if (outputBuffer != null)
@@ -226,6 +227,7 @@ namespace System.Security.Cryptography {
 			
 			HashCore (inputBuffer, inputOffset, inputCount);
 			HashValue = HashFinal ();
+			State = 0;
 			
 			return outputBuffer;
 		}

--- a/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/HashAlgorithm.cs
@@ -88,9 +88,10 @@ namespace System.Security.Cryptography {
 
 			HashCore (buffer, offset, count);
 			HashValue = HashFinal ();
+			byte[] dataToReturn = (byte[])this.HashValue.Clone ();
 			Initialize ();
 			
-			return HashValue;
+			return dataToReturn;
 		}
 
 		public byte[] ComputeHash (Stream inputStream) 
@@ -106,8 +107,10 @@ namespace System.Security.Cryptography {
 				len = inputStream.Read (buffer, 0, 4096);
 			}
 			HashValue = HashFinal ();
+			byte[] dataToReturn = (byte[])this.HashValue.Clone ();
 			Initialize ();
-			return HashValue;
+
+			return dataToReturn;
 		}
 	
 		public static HashAlgorithm Create () 

--- a/mcs/class/corlib/System.Security.Cryptography/MACTripleDES.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/MACTripleDES.cs
@@ -144,6 +144,10 @@ namespace System.Security.Cryptography {
 		{
 			if (m_disposed)
 				throw new ObjectDisposedException ("MACTripleDES");
+			if (!_isKeySetupCompleted) {
+				mac.Initialize (KeyValue);
+				_isKeySetupCompleted = true;
+			}
 			State = 0;
 			return mac.Final ();
 		}

--- a/mcs/class/corlib/System.Security.Cryptography/MACTripleDES.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/MACTripleDES.cs
@@ -46,6 +46,7 @@ namespace System.Security.Cryptography {
 		private TripleDES tdes;
 		private MACAlgorithm mac;
 		private bool m_disposed;
+		private bool _isKeySetupCompleted;
 	
 		public MACTripleDES ()
 		{
@@ -130,8 +131,11 @@ namespace System.Security.Cryptography {
 			if (m_disposed)
 				throw new ObjectDisposedException ("MACTripleDES");
 			if (State == 0) {
-				Initialize ();
 				State = 1;
+			}
+			if (!_isKeySetupCompleted) {
+				mac.Initialize (KeyValue);
+				_isKeySetupCompleted = true;
 			}
 			mac.Core (rgbData, ibStart, cbSize);
 		}

--- a/mcs/class/corlib/System.Security.Cryptography/MD5CryptoServiceProvider.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/MD5CryptoServiceProvider.cs
@@ -114,6 +114,7 @@ namespace System.Security.Cryptography {
 					hash[i*4+j] = (byte)(_H[i] >> j*8);
 				}
 			}
+			State = 0;
 
 			return hash;
 		}

--- a/mcs/class/corlib/System.Security.Cryptography/MD5CryptoServiceProvider.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/MD5CryptoServiceProvider.cs
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography {
 			buff = new uint[16];
 			_ProcessingBuffer = new byte [BLOCK_SIZE_BYTES];
 
-			Initialize();
+			HInit ();
 		}
 
 		~MD5CryptoServiceProvider () 
@@ -123,7 +123,11 @@ namespace System.Security.Cryptography {
 		{
 			count = 0;
 			_ProcessingBufferCount = 0;
-
+			HInit ();
+		}
+		
+		private void HInit ()
+		{
 			_H[0] = 0x67452301;
 			_H[1] = 0xefcdab89;
 			_H[2] = 0x98badcfe;

--- a/mcs/class/corlib/System.Security.Cryptography/RIPEMD160Managed.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/RIPEMD160Managed.cs
@@ -116,6 +116,7 @@ namespace System.Security.Cryptography {
 			} else {
 				Buffer.BlockCopy (_HashValue, 0, hash, 0, 20);
 			}
+			State = 0;
 			return hash;
 		}
 

--- a/mcs/class/corlib/System.Security.Cryptography/SHA256Managed.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/SHA256Managed.cs
@@ -46,7 +46,7 @@ namespace System.Security.Cryptography {
 			_H = new uint [8];
 			_ProcessingBuffer = new byte [BLOCK_SIZE_BYTES];
 			buff = new uint[64];
-			Initialize ();
+			HInit ();
 		}
 
 		protected override void HashCore (byte[] rgb, int ibStart, int cbSize) 
@@ -102,7 +102,11 @@ namespace System.Security.Cryptography {
 			State = 0;
 			count = 0;
 			_ProcessingBufferCount = 0;
+			HInit ();
+		}
 		
+		private void HInit()
+		{
 			_H[0] = 0x6A09E667;
 			_H[1] = 0xBB67AE85;
 			_H[2] = 0x3C6EF372;

--- a/mcs/class/corlib/System.Security.Cryptography/SHA256Managed.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/SHA256Managed.cs
@@ -99,6 +99,7 @@ namespace System.Security.Cryptography {
 
 		public override void Initialize () 
 		{
+			State = 0;
 			count = 0;
 			_ProcessingBufferCount = 0;
 		

--- a/mcs/class/corlib/System.Security.Cryptography/SHA384Managed.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/SHA384Managed.cs
@@ -56,6 +56,8 @@ public class SHA384Managed : SHA384 {
 
 	private void Initialize (bool reuse) 
 	{
+		State = 0;
+		
 		// SHA-384 initial hash value
 		// The first 64 bits of the fractional parts of the square roots
 		// of the 9th through 16th prime numbers

--- a/mcs/class/corlib/System.Security.Cryptography/SHA384Managed.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/SHA384Managed.cs
@@ -51,10 +51,10 @@ public class SHA384Managed : SHA384 {
 	{
 		xBuf = new byte [8];
 		W = new ulong [80];
-		Initialize (false); // limited initialization
+		InternalInitialize (false); // limited initialization
 	}
 
-	private void Initialize (bool reuse) 
+	private void InternalInitialize (bool reuse) 
 	{
 		State = 0;
 		
@@ -86,7 +86,7 @@ public class SHA384Managed : SHA384 {
 
 	public override void Initialize () 
 	{
-		Initialize (true); // reuse instance
+		InternalInitialize (true); // reuse instance
 	}
 
 	// protected
@@ -139,7 +139,6 @@ public class SHA384Managed : SHA384 {
 		unpackWord(H5, output, 32);
 		unpackWord(H6, output, 40);
 
-		Initialize ();
 		return output;
 	}
 

--- a/mcs/class/corlib/System.Security.Cryptography/SHA512Managed.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/SHA512Managed.cs
@@ -52,10 +52,10 @@ public class SHA512Managed : SHA512 {
 	{
 		xBuf = new byte [8];
 		W = new ulong [80];
-		Initialize (false); // limited initialization
+		InternalInitialize (false); // limited initialization
 	}
 
-	private void Initialize (bool reuse) 
+	private void InternalInitialize (bool reuse) 
 	{
 		State = 0;
 		
@@ -87,7 +87,7 @@ public class SHA512Managed : SHA512 {
 
 	public override void Initialize () 
 	{
-		Initialize (true); // reuse instance
+		InternalInitialize (true); // reuse instance
 	}
 
 	// protected
@@ -139,10 +139,9 @@ public class SHA512Managed : SHA512 {
 		unpackWord(H4, output, 24);
 		unpackWord(H5, output, 32);
 		unpackWord(H6, output, 40);
-	        unpackWord(H7, output, 48);
+		unpackWord(H7, output, 48);
 		unpackWord(H8, output, 56);
 
-		Initialize ();
 		return output;
 	}
 

--- a/mcs/class/corlib/System.Security.Cryptography/SHA512Managed.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/SHA512Managed.cs
@@ -57,6 +57,8 @@ public class SHA512Managed : SHA512 {
 
 	private void Initialize (bool reuse) 
 	{
+		State = 0;
+		
 		// SHA-512 initial hash value
 		// The first 64 bits of the fractional parts of the square roots
 		// of the first eight prime numbers

--- a/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
@@ -210,22 +210,6 @@ public class HashAlgorithmTest {
 		byte[] array = new byte [1];
 		hash.ComputeHash (array, 1, Int32.MaxValue);
 	}
-	
-	[Test]
-	[ExpectedException (typeof (CryptographicUnexpectedOperationException))]
-	public void GetHash_StateExeception ()
-	{
-		hash.Initialize ();
-		byte[] input = new byte [8];
-		byte[] output = new byte [8];
-		hash.TransformBlock (input, 0, input.Length, output, 0);
-		
-		//Should fail with CryptographicUnexpectedOperationException as TransformFinalBlock was not called.
-		byte[] result = hash.Hash;
-		
-		//Use var so no warning is shown when compiling.
-		result.GetType ();
-	}
 
 	[Test]
 // not checked in Fx 1.1
@@ -516,6 +500,21 @@ public class HashAlgorithmTest {
 		hash.Dispose();
 		//Should fail since the hash object is disposed.
 		Assert.IsNull(hash.Hash);
+	}
+
+	[Test]
+	[ExpectedException (typeof (CryptographicUnexpectedOperationException))]
+	public void Hash_StateExeception ()
+	{
+		hash.Initialize ();
+		byte[] input = new byte [8];
+		byte[] output = new byte [8];
+		hash.TransformBlock (input, 0, input.Length, output, 0);
+
+		//Should fail with CryptographicUnexpectedOperationException as TransformFinalBlock was not called.
+		byte[] result = hash.Hash;
+		//Use var so no warning is shown when compiling.
+		Assert.IsNull(result);
 	}
 }
 

--- a/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
@@ -508,6 +508,15 @@ public class HashAlgorithmTest {
 		//If the byte array is returned as a ref, both instance will be cleared.
 		Assert.AreNotEqual(hash.Hash, brokenHash, "ExternalChanges");
 	}
+
+	[Test]
+	[ExpectedException (typeof (ObjectDisposedException))]
+	public void Hash_DisposedException ()
+	{
+		hash.Dispose();
+		//Should fail since the hash object is disposed.
+		Assert.IsNull(hash.Hash);
+	}
 }
 
 }

--- a/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
@@ -210,6 +210,22 @@ public class HashAlgorithmTest {
 		byte[] array = new byte [1];
 		hash.ComputeHash (array, 1, Int32.MaxValue);
 	}
+	
+	[Test]
+	[ExpectedException (typeof (CryptographicUnexpectedOperationException))]
+	public void GetHash_StateExeception ()
+	{
+		hash.Initialize ();
+		byte[] input = new byte [8];
+		byte[] output = new byte [8];
+		hash.TransformBlock (input, 0, input.Length, output, 0);
+		
+		//Should fail with CryptographicUnexpectedOperationException as TransformFinalBlock was not called.
+		byte[] result = hash.Hash;
+		
+		//Use var so no warning is shown when compiling.
+		result.GetType ();
+	}
 
 	[Test]
 // not checked in Fx 1.1

--- a/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
@@ -493,6 +493,21 @@ public class HashAlgorithmTest {
 		hash.TransformFinalBlock (input, 0, input.Length);
 		Assert.IsNotNull (hash.Hash);
 	}
+
+	[Test]
+	public void Hash_NoExternalChanges ()
+	{
+		byte[] input = new byte [512];
+		for (int i=0;i<input.Length;i++)
+			input[i] = (byte)(i % 0xFF);
+		hash.TransformFinalBlock (input, 0, input.Length);
+
+		byte[] brokenHash = hash.Hash;
+		Array.Clear(brokenHash, 0, brokenHash.Length);
+
+		//If the byte array is returned as a ref, both instance will be cleared.
+		Assert.AreNotEqual(hash.Hash, brokenHash, "ExternalChanges");
+	}
 }
 
 }

--- a/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTest.cs
@@ -512,9 +512,7 @@ public class HashAlgorithmTest {
 		hash.TransformBlock (input, 0, input.Length, output, 0);
 
 		//Should fail with CryptographicUnexpectedOperationException as TransformFinalBlock was not called.
-		byte[] result = hash.Hash;
-		//Use var so no warning is shown when compiling.
-		Assert.IsNull(result);
+		Assert.IsNull(hash.Hash);
 	}
 }
 

--- a/mcs/class/corlib/Test/System.Security.Cryptography/RSAPKCS1SignatureDeformatterTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/RSAPKCS1SignatureDeformatterTest.cs
@@ -363,7 +363,7 @@ namespace MonoTests.System.Security.Cryptography {
 			badSignature[0] = (byte) ~md5Signature [0];
 			HashAlgorithm hash = MD5.Create ();
 			try {
-				fmt.VerifySignature (hash, md5Signature);
+				fmt.VerifySignature (hash, badSignature);
 				Assert.Fail ("VerifyBadSignatureMD5Hash - Expected CryptographicUnexpectedOperationException but none");
 			}
 			catch (CryptographicUnexpectedOperationException) {
@@ -385,7 +385,7 @@ namespace MonoTests.System.Security.Cryptography {
 			byte[] badSignature = new byte [md5Signature.Length-1];
 			HashAlgorithm hash = MD5.Create ();
 			try {
-				fmt.VerifySignature (hash, md5Signature);
+				fmt.VerifySignature (hash, badSignature);
 				Assert.Fail ("VerifySignatureMD5HashBadSignatureLength - Expected CryptographicUnexpectedOperationException but none");
 			}
 			catch (CryptographicUnexpectedOperationException) {


### PR DESCRIPTION
Fixed HashAlgorithm not enforcing State when reading HashValue.
     in TransformBlock State is != 0 and a call to TransformFinalBlock is required before the hash is valid and readable.
There were also 2 places where Initialize was called before the HashValue was read.
It now copy the hash instead of returning a pointer to it.
Removed call to Initialize in TransformFinalBlock since HashValue was reset to 0 before it could be retrieved.
      Tested in a console application in VS2013 with Ms.Net and Initialize is not called.

This change is released under the MIT license.
