### PR TITLE
Fixes MSBuild behavior difference with ToolPath.

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Build.Utilities
 			if (SkipTaskExecution ())
 				return true;
 
-			exitCode = ExecuteTool (GenerateFullPathToTool (), GenerateResponseFileCommands (),
+			exitCode = ExecuteTool (ToolPath ?? GenerateFullPathToTool (), GenerateResponseFileCommands (),
 				GenerateCommandLineCommands ());
 
 			// HandleTaskExecutionErrors is called only if exitCode != 0


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=22981

I don't have an environment setup to verify this fix, but I believe it should work.
