### PR TITLE
[System] Add performanceCounters element to System.Diagnostics app.config configuration section

### DIFF
--- a/mcs/class/System/System.Diagnostics/DiagnosticsConfigurationHandler.cs
+++ b/mcs/class/System/System.Diagnostics/DiagnosticsConfigurationHandler.cs
@@ -94,6 +94,7 @@ namespace System.Diagnostics
 		public DiagnosticsConfigurationHandler ()
 		{
 			elementHandlers ["assert"] = new ElementHandler (AddAssertNode);
+			elementHandlers ["performanceCounters"] = new ElementHandler (AddPerformanceCountersNode);
 			elementHandlers ["switches"] = new ElementHandler (AddSwitchesNode);
 			elementHandlers ["trace"] = new ElementHandler (AddTraceNode);
 			elementHandlers ["sources"] = new ElementHandler (AddSourcesNode);
@@ -175,6 +176,25 @@ namespace System.Diagnostics
 					dtl.AssertUiEnabled = (bool) d ["assertuienabled"];
 				if (logfilename != null)
 					dtl.LogFileName = logfilename;
+			}
+
+			if (node.ChildNodes.Count > 0)
+				ThrowUnrecognizedElement (node.ChildNodes[0]);
+		}
+
+		private void AddPerformanceCountersNode (IDictionary d, XmlNode node)
+		{
+			XmlAttributeCollection c = node.Attributes;
+			string filemappingsize = GetAttribute (c, "filemappingsize", false, node);
+			ValidateInvalidAttributes (c, node);
+			if (filemappingsize != null) {
+				try {
+					d ["filemappingsize"] = int.Parse (filemappingsize);
+				}
+				catch (Exception e) {
+					throw new ConfigurationException ("The `filemappingsize' attribute must be an integral value.",
+							e, node);
+				}
 			}
 
 			if (node.ChildNodes.Count > 0)

--- a/mcs/class/System/Test/System.Diagnostics/DiagnosticsConfigurationHandlerTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/DiagnosticsConfigurationHandlerTest.cs
@@ -161,6 +161,30 @@ namespace MonoTests.System.Diagnostics
 
 		[Test]
 		[Category ("NotDotNet")]
+		public void PerformanceCountersTag ()
+		{
+			string[] goodAttributes = {
+				"",
+				"filemappingsize=\"1048576\"",
+				"filemappingsize=\"0\""
+			};
+			ValidateSuccess ("#PCT:Good", "<performanceCounters {0}/>", goodAttributes);
+
+			string[] badAttributes = {
+				"FileMappingSize=\"1048576\"",
+				"filemappingsize=\"\"",
+				"filemappingsize=\"non-int-value\""
+			};
+			ValidateExceptions ("#PCT:BadAttrs", "<performanceCounters {0}/>", badAttributes);
+
+			string[] badChildren = {
+				"<any element=\"here\"/>"
+			};
+			ValidateExceptions ("#PCT:BadChildren", "<performanceCounters>{0}</performanceCounters>", badChildren);
+		}
+
+		[Test]
+		[Category ("NotDotNet")]
 		public void TraceTag_Attributes ()
 		{
 			string[] good = {


### PR DESCRIPTION
See [MSDN](http://msdn.microsoft.com/en-us/library/ms229387%28v=vs.110%29.aspx) for details about the element.
The value that is set by the element isn't currently used in Mono, but applications using it in their app.config crash otherwise (e.g. http://stackoverflow.com/questions/25741651).
