### PR TITLE
[mkbundle] Fix check for dos2unix

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -715,9 +715,14 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 		if (use_dos2unix == null) {
 			use_dos2unix = false;
 			try {
-				var dos2unix = Process.Start ("dos2unix");
+				var info = new ProcessStartInfo ("dos2unix");
+				info.CreateNoWindow = true;
+				info.RedirectStandardInput = true;
+				info.UseShellExecute = false;
+				var dos2unix = Process.Start (info);
 				dos2unix.StandardInput.WriteLine ("aaa");
 				dos2unix.StandardInput.WriteLine ("\u0004");
+				dos2unix.StandardInput.Close ();
 				dos2unix.WaitForExit ();
 				if (dos2unix.ExitCode == 0)
 					use_dos2unix = true;


### PR DESCRIPTION
This fixes the command to check for dos2unix and makes mkbundle usable again with mingw.
We need first to redirect the standard input, otherwise the check always fails with an InvalidOperationException and set CreateNoWindow=false to avoid spawning a new window.
