### PR TITLE
Put KeyPairPersistence load into a try{}catch{} block.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/X509Store.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X509Store.cs
@@ -236,8 +236,13 @@ namespace Mono.Security.X509 {
 				cspParams.Flags = CspProviderFlags.UseMachineKeyStore;
 			KeyPairPersistence kpp = new KeyPairPersistence (cspParams);
 
-			if (!kpp.Load ())
+			try {
+				if (!kpp.Load ())
+					return cert;
+			}
+			catch {
 				return cert;
+			}
 
 			if (cert.RSA != null)
 				cert.RSA = new RSACryptoServiceProvider (cspParams);


### PR DESCRIPTION
Kpp.Load() will throw an unhandled exception if _filename (a folder to use as the key store) does not exist and it cannot be created.

This is an entirely valid thing to have happen - cert importing into the machine store (mozroots --import --machine --sync) as root will create a /usr/share/.mono/certs/ folder, but will not create /usr/share/.mono/keypairs - and since the root user owns /usr/share/.mono/, if the user tries to enumerate the certificates in /usr/share/.mono/certs/, they get 0 certificates returned due to the unhandled exception dropping each loaded certificate on the floor.

Closes: Xamarin bug 23015
