### PR TITLE
[sgen] Use memcpy to copy object

### DIFF
--- a/mono/metadata/sgen-copy-object.h
+++ b/mono/metadata/sgen-copy-object.h
@@ -49,24 +49,8 @@ par_copy_object_no_checks (char *destination, MonoVTable *vt, void *obj, mword o
 	}
 #endif
 
-#ifdef __GNUC__
-	if (objsize <= sizeof (gpointer) * 8) {
-		mword *dest = (mword*)destination;
-		switch (objsize / sizeof (gpointer)) {
-		case 8: (dest) [7] = ((mword*)obj) [7];
-		case 7: (dest) [6] = ((mword*)obj) [6];
-		case 6: (dest) [5] = ((mword*)obj) [5];
-		case 5: (dest) [4] = ((mword*)obj) [4];
-		case 4: (dest) [3] = ((mword*)obj) [3];
-		case 3: (dest) [2] = ((mword*)obj) [2];
-		case 2: (dest) [1] = ((mword*)obj) [1];
-		}
-	} else
-#endif
-	{
-		/*can't trust memcpy doing word copies */
-		mono_gc_memmove_aligned (destination + sizeof (mword), (char*)obj + sizeof (mword), objsize - sizeof (mword));
-	}
+	memcpy (destination + sizeof (mword), (char*)obj + sizeof (mword), objsize - sizeof (mword));
+
 	/* adjust array->bounds */
 	SGEN_ASSERT (9, vt->gc_descr, "vtable %p for class %s:%s has no gc descriptor", vt, vt->klass->name_space, vt->klass->name);
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -43,6 +43,7 @@ STRESS_TESTS_SRC=	\
 	monitor-stress.cs	\
 	thread-stress.cs	\
 	gc-stress.cs		\
+	gc-copy-stress.cs	\
 	gc-graystack-stress.cs		\
 	exit-stress.cs		\
 	process-stress.cs	\

--- a/mono/tests/gc-copy-stress.cs
+++ b/mono/tests/gc-copy-stress.cs
@@ -1,0 +1,35 @@
+using System;
+
+class T {
+	
+	static int count = 1000000;
+	static int loops = 20;
+	static int persist_factor = 10;
+
+	static object obj;
+
+	static object[] persist;
+	static int persist_idx;
+
+	static void work () {
+		persist = new object[count / persist_factor + 1];
+		persist_idx = 0;
+		for (int i = 0; i < count; ++i) {
+			obj = new object ();
+			if (i % persist_factor == 0)
+				persist[persist_idx++] = obj;
+		}
+	}
+
+	static void Main (string[] args) {
+		if (args.Length > 0)
+			loops = int.Parse (args [0]);
+		if (args.Length > 1)
+			count = int.Parse (args [1]);
+		if (args.Length > 2)
+			persist_factor = int.Parse (args [2]);
+		for (int i = 0; i < loops; ++i) {
+			work ();
+		}
+	}
+}

--- a/mono/tests/stress-runner.pl
+++ b/mono/tests/stress-runner.pl
@@ -72,6 +72,13 @@ my %tests = (
 		'arg-knob' => 2, # loops
 		'ratio' => 10,
 	},
+	'gc-copy-stress' => {
+		'program' => 'gc-copy-stress.exe',
+		# loops, count, persist_factor
+		'args' => [250, 500000, 10],
+		'arg-knob' => 1, # count
+		'ratio' => 4,
+	},
 	'thread-stress' => {
 		'program' => 'thread-stress.exe',
 		# loops


### PR DESCRIPTION
It is faster by around 5-6% on copy heavy gc stress tests.
