### PR TITLE
Use /etc/mono/ (or equivalent MONO_CFG_DIR) for cert store, on Unix

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Cryptography/KeyPairPersistence.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Cryptography/KeyPairPersistence.cs
@@ -248,7 +248,18 @@ namespace Mono.Security.Cryptography {
 							Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData),
 							".mono");
 						_machinePath = Path.Combine (_machinePath, "keypairs");
-
+						if (Environment.OSVersion.Platform == PlatformID.Unix) {
+							string newMachinePath = Path.Combine (Directory.GetParent (Path.GetDirectoryName (System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile)).FullName, "keypairs");
+							if (Directory.Exists (_machinePath)) {
+								try {
+									Directory.Move (_machinePath, newMachinePath);
+								}
+								catch {
+									// migration failed
+								}
+							}
+							_machinePath = newMachinePath;
+						}
 						_machinePathExists = Directory.Exists (_machinePath);
 						if (!_machinePathExists) {
 							try {

--- a/mcs/class/Mono.Security/Mono.Security.X509/X509StoreManager.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X509StoreManager.cs
@@ -71,6 +71,18 @@ namespace Mono.Security.X509 {
 						Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData),
 						".mono");
 					_localMachinePath = Path.Combine (_localMachinePath, "certs");
+					if (Environment.OSVersion.Platform == PlatformID.Unix) {
+						string newLocalMachinePath = Path.Combine (Directory.GetParent (Path.GetDirectoryName (System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile)).FullName, "certs");
+						if (Directory.Exists (_localMachinePath)) {
+							try {
+								Directory.Move (_localMachinePath, newLocalMachinePath);
+							}
+							catch {
+								// migration failed
+							}
+						}
+						_localMachinePath = newLocalMachinePath;
+					}
 				}
 				return _localMachinePath;
 			}


### PR DESCRIPTION
On every major Linux distribution, the system cert store lives in /etc, and the Java cert store lives in /etc - it certainly doesn't belong in /usr/share, which should only be for static app-provided data. Mono's /usr/share/.mono/ is a major FHS violation, albeit it's much easier to retrieve as a location than the alternative I'm using here.

This patch includes a simple migration behaviour to move any old system certs to the new location.