### PR TITLE
Revert "Uri made from UNIX path and RelativeOrAbsolute is now relative."

### DIFF
--- a/mcs/class/System/System/UriParseComponents.cs
+++ b/mcs/class/System/System/UriParseComponents.cs
@@ -206,7 +206,7 @@ namespace System {
 			state.elements.scheme = Uri.UriSchemeFile;
 			state.elements.delimiter = "://";
 			state.elements.isUnixFilePath = true;
-			state.elements.isAbsoluteUri = state.kind == UriKind.Absolute;
+			state.elements.isAbsoluteUri = (state.kind == UriKind.Relative)? false : true;
 
 			if (part.Length >= 2 && part [0] == '/' && part [1] == '/') {
 				part = part.TrimStart (new char [] {'/'});

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -1941,13 +1941,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		public void RelativeOrAbsoluteUnixPath ()
-		{
-			var uri = new Uri ("/abc", UriKind.RelativeOrAbsolute);
-			Assert.IsFalse (uri.IsAbsoluteUri);
-		}
-
-		[Test]
 		// Bug #12631
 		public void LocalPathWithBaseUrl ()
 		{


### PR DESCRIPTION
Reverts mono/mono#1300

This change has been debated exhaustively over the past decade and changing this to behave like windows
will bring more pain that it's worth.
