### PR TITLE
Fix for Null reference exception in Int.ToString()

### DIFF
--- a/mcs/class/corlib/System/EmptyArray.cs
+++ b/mcs/class/corlib/System/EmptyArray.cs
@@ -3,6 +3,7 @@
 //
 // Authors:
 //	Marek Safar  <marek.safar@gmail.com>
+//	Mikhail Filimonov <mfilimonov@gmail.com>
 //
 // Copyright (C) 2012 Xamarin, Inc (http://www.xamarin.com)
 //
@@ -30,6 +31,11 @@ namespace System
 {
 	static class EmptyArray<T>
 	{
-		public static readonly T[] Value = new T [0];
+                static EmptyArray()
+                {
+                        Value = new T [0];
+                }
+
+		public static readonly T[] Value;
 	}
 }


### PR DESCRIPTION
This is the fix for the issue "Null reference exception occurs after the call to Int.ToString() from multiple threads" https://bugzilla.xamarin.com/show_bug.cgi?id=23242
