### PR TITLE
mdoc no longer documents private interfaces

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -104,6 +104,9 @@ Test/DocTest-DropNS-unified.dll:
 Test/DocTest.dll: 
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -debug -unsafe -target:library -out:$@ Test/DocTest.cs
 
+Test/DocTest-InternalInterface.dll: 
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -debug -unsafe -target:library -out:$@ Test/DocTest-InternalInterface.cs
+
 Test/DocTest.dll-v1: 
 	-rm -f Test/DocTest.cs
 	cp Test/DocTest-v1.cs Test/DocTest.cs
@@ -145,7 +148,13 @@ update-monodocer-dropns-unified-withsecondary: $(PROGRAM)
 update-monodocer-dropns-classic-secondary: $(PROGRAM)
 	$(MAKE) Test/DocTest-DropNS-classic-secondary.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-DropNS-classic-secondary.dll
-		
+
+check-monodocer-internal-interface: $(PROGRAM)
+	# Tests to make sure internal interfaces that are explicitly implemented are not documented
+	-rm -Rf Test/en.actual
+	$(MAKE) Test/DocTest-InternalInterface.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-InternalInterface.dll
+	diff --exclude=.svn -rup Test/en.expected-internal-interface Test/en.actual
 
 check-monodocer-update: $(PROGRAM)
 	find Test/en.expected -name \*.xml -exec rm "{}" \;
@@ -305,6 +314,7 @@ check-doc-tools-update: check-monodocer-since-update \
 	check-monodocer-update \
 	check-monodocer-dropns-classic \
 	check-monodocer-dropns-classic-withsecondary \
+	check-monodocer-internal-interface \
 	check-monodocer-delete-update \
 	check-mdoc-export-html-update \
 	check-mdoc-export-msxdoc-update \

--- a/mcs/tools/mdoc/Test/DocTest-InternalInterface.cs
+++ b/mcs/tools/mdoc/Test/DocTest-InternalInterface.cs
@@ -1,0 +1,17 @@
+namespace MyNamespace {
+	internal interface MyInternalInterface {
+		bool Foo {get;set;}
+		string FooSet {set;}
+		void FooMeth ();
+		void BarMeth ();
+	}
+
+	public class MyClass : MyInternalInterface {
+		public string Bar {get;set;}
+		public void BarMeth () {} // part of the interface, but publicly implemented
+
+		string MyInternalInterface.FooSet {set {}}
+		bool MyInternalInterface.Foo {get;set;}
+		void MyInternalInterface.FooMeth () {}
+	}
+}

--- a/mcs/tools/mdoc/Test/en.expected-internal-interface/MyNamespace/MyClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-internal-interface/MyNamespace/MyClass.xml
@@ -1,0 +1,63 @@
+<Type Name="MyClass" FullName="MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-InternalInterface</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Bar">
+      <MemberSignature Language="C#" Value="public string Bar { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Bar" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="BarMeth">
+      <MemberSignature Language="C#" Value="public void BarMeth ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void BarMeth() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-internal-interface/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-internal-interface/index.xml
@@ -1,0 +1,22 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-InternalInterface" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>DocTest-InternalInterface</Title>
+</Overview>

--- a/mcs/tools/mdoc/Test/en.expected-internal-interface/ns-MyNamespace.xml
+++ b/mcs/tools/mdoc/Test/en.expected-internal-interface/ns-MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>


### PR DESCRIPTION
Resolves this reported bug: https://bugzilla.xamarin.com/show_bug.cgi?id=18411

If a class explicitly implements an internal interface, those members will no longer be documented, nor will the interface show up in the class' signature. This allows for a library to hide internal implementation details that an end user would not be able to take advantage of (ie. can't cast to internal interface to call methods).
