### PR TITLE
Use netstat to get routes if no /proc/net/route

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/IPInterfaceProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/IPInterfaceProperties.cs
@@ -78,8 +78,8 @@ namespace System.Net.NetworkInformation {
 		void ParseRouteInfo (string iface)
 		{
 			try {
+				gateways = new IPAddressCollection ();
 				if (File.Exists ("/proc/net/route")) {
-					gateways = new IPAddressCollection ();
 					using (StreamReader reader = new StreamReader ("/proc/net/route")) {
 						string line;
 						reader.ReadLine (); // Ignore first line


### PR DESCRIPTION
If /proc/net/route is not available on the system (i.e. non-Linux
systems), then fallback to using the netstat command to get routing
information
