### PR TITLE
Fix for bug 22954 - Domain-rooted relative URI is reported as absolute

### DIFF
--- a/mcs/class/System/System/UriParseComponents.cs
+++ b/mcs/class/System/System/UriParseComponents.cs
@@ -200,13 +200,13 @@ namespace System {
 		{
 			string part = state.remaining;
 
-			if (part.Length < 1 || part [0] != '/' || Path.DirectorySeparatorChar != '/')
+			if (part.Length < 1 || part [0] != '/' || Path.DirectorySeparatorChar != '/' || state.kind != UriKind.Absolute)
 				return state.remaining.Length > 0;
 
 			state.elements.scheme = Uri.UriSchemeFile;
 			state.elements.delimiter = "://";
 			state.elements.isUnixFilePath = true;
-			state.elements.isAbsoluteUri = (state.kind == UriKind.Relative)? false : true;
+			state.elements.isAbsoluteUri = true;
 
 			if (part.Length >= 2 && part [0] == '/' && part [1] == '/') {
 				part = part.TrimStart (new char [] {'/'});


### PR DESCRIPTION
This is an alternate fix for bug 22954. The original fix was reverted (see https://github.com/mono/mono/pull/1302). My justification for still fixing this is:
-The code in master as-is gives precedence to UNIX file paths over relative web paths. This is counter-intuitive and it conflicts with the documentation. For example, in the remarks section of the documentation for System.Uri, an example relative URI is given as "/new/index.htm". However Mono treats this as an absolute UNIX file path.
-The workaround requires all applications to add logic for detecting relative vs. absolute URIs if the kind of a web URI is not known (ex. a URI from a hypermedia REST response). This means URI parsing is not encapsulated by the Uri class anymore.

The difference between the original pull request and this one is that specifying "new Uri("/abc/123", UriKind.Absolute)" will still parse the URI as an absolute UNIX file path.

This is a critical issue for our application and requires us to patch Mono ourselves. Please reconsider accepting this change.