### PR TITLE
MembershipUser::UpdateUser method fix

### DIFF
--- a/mcs/class/System.Web/System.Web.Security/MembershipUser.cs
+++ b/mcs/class/System.Web/System.Web.Security/MembershipUser.cs
@@ -94,7 +94,7 @@ namespace System.Web.Security
 
 		internal void UpdateUser ()
 		{
-			MembershipUser newUser = Provider.GetUser (name, false);
+			MembershipUser newUser = Provider.GetUser (UserName, false);
 			UpdateSelf (newUser);
 		}
 


### PR DESCRIPTION
MembershipUser class uses private field name in the UpdateUser method. This causes an error when we  derive our class and override the UserName property.
