### PR TITLE
Add a third AOT location, alongside ~/.mono/aot-cache and the assembly dir

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1779,6 +1779,14 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 			if (!sofile) {
 				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_AOT, "AOT module '%s' not found: %s\n", aot_name, err);
 				g_free (err);
+
+				aot_name = g_strdup_printf ("%s/mono/aot-cache/%s/%s%s", mono_assembly_getrootdir(), ARCHITECTURE, basename (assembly->image->name), SHARED_EXT);
+				sofile = mono_dl_open (aot_name, MONO_DL_LAZY, &err);
+				if (!sofile) {
+					mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_AOT, "AOT module '%s' not found: %s\n", aot_name, err);
+					g_free (err);
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
Unless running in on-demand AOT mode, the AOT runtime will look for an AOT cache alongside the assembly (e.g. /usr/lib/mono/4.5/mscorlib.dll.so).

This patch adds a second search path to the non-on-demand AOT loader, /usr/lib/mono/aot-cache/ARCHITECTURE/path/to/assembly.dll.so

This new structure makes it possible to have more than one Mono architecture on a system, sharing assemblies but not sharing AOT caches (for example, i386 and amd64 Mono on the same system, for different needs)
