### PR TITLE
[mcs] Make xbuild resolver prefer specific version if available

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/AssemblyResolver.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/AssemblyResolver.cs
@@ -257,9 +257,9 @@ namespace Microsoft.Build.Tasks {
 		{
 			PackageAssemblyInfo pkg = null;
 
-			if (specific_version) {
-				pkg = PcCache.GetAssemblyLocation (reference.ItemSpec);
-			} else {
+			pkg = PcCache.GetAssemblyLocation (reference.ItemSpec);
+
+			if (pkg == null && !specific_version) {
 				// if not specific version, then just match simple name
 				string name = reference.ItemSpec;
 				if (name.IndexOf (',') > 0)


### PR DESCRIPTION
When two or more versions of an assembly are available and
"specific_version" is set to false the resolver picks the first
available assembly with a matching name. Sometimes this result in
an uncompatible set of assemblies (depending on how the different
assemblies are sorted in the pkgconfig cache). This fix makes the
resolver to always prefer the specific version if available, and only
fall back to "first assembly with a matching name" if no specific
version is available. If "specific_version" is set to null the old
behaviour is preserved.