### PR TITLE
Added null check in constructor of BlockProcessor in CryptoTools.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Cryptography/CryptoTools.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Cryptography/CryptoTools.cs
@@ -88,6 +88,10 @@ namespace Mono.Security.Cryptography {
 		// block size (which isn't their real internal block size)
 		public BlockProcessor (ICryptoTransform transform, int blockSize)
 		{
+			if (transform == null)
+				throw new ArgumentNullException ("transform");
+			if (blockSize <= 0)
+				throw new ArgumentOutOfRangeException ("blockSize");
 			this.transform = transform;
 			this.blockSize = blockSize;
 			block = new byte [blockSize];


### PR DESCRIPTION
Avoid throwing NRE later while using the class.