### PR TITLE
[MWF] Pass graphics when calculating button text and image

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Button.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Button.cs
@@ -175,7 +175,7 @@ namespace System.Windows.Forms {
 			Rectangle text_rectangle;
 			Rectangle image_rectangle;
 
-			ThemeEngine.Current.CalculateButtonTextAndImageLayout (this, out text_rectangle, out image_rectangle);
+			ThemeEngine.Current.CalculateButtonTextAndImageLayout (pevent.Graphics, this, out text_rectangle, out image_rectangle);
 
 			// Draw our button
 			if (this.FlatStyle == FlatStyle.Standard)

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Theme.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/Theme.cs
@@ -698,7 +698,7 @@ namespace System.Windows.Forms
 
 		#region Button
 		public abstract Size CalculateButtonAutoSize (Button button);
-		public abstract void CalculateButtonTextAndImageLayout (ButtonBase b, out Rectangle textRectangle, out Rectangle imageRectangle);
+		public abstract void CalculateButtonTextAndImageLayout (Graphics g, ButtonBase b, out Rectangle textRectangle, out Rectangle imageRectangle);
 		public abstract void DrawButton (Graphics g, Button b, Rectangle textBounds, Rectangle imageBounds, Rectangle clipRectangle);
 		public abstract void DrawFlatButton (Graphics g, ButtonBase b, Rectangle textBounds, Rectangle imageBounds, Rectangle clipRectangle);
 		public abstract void DrawPopupButton (Graphics g, Button b, Rectangle textBounds, Rectangle imageBounds, Rectangle clipRectangle);

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
@@ -364,12 +364,14 @@ namespace System.Windows.Forms
 			return ret_size;
 		}
 
-		public override void CalculateButtonTextAndImageLayout (ButtonBase button, out Rectangle textRectangle, out Rectangle imageRectangle)
+		public override void CalculateButtonTextAndImageLayout (Graphics g, ButtonBase button, out Rectangle textRectangle, out Rectangle imageRectangle)
 		{
 			Image image = button.Image;
 			string text = button.Text;
 			Rectangle content_rect = button.PaddingClientRectangle;
-			Size text_size = TextRenderer.MeasureTextInternal (text, button.Font, content_rect.Size, button.TextFormatFlags, button.UseCompatibleTextRendering);
+			if (button.TextImageRelation != TextImageRelation.Overlay)
+				content_rect.Inflate(-4, -4);
+			Size text_size = TextRenderer.MeasureTextInternal (g, text, button.Font, content_rect.Size, button.TextFormatFlags, button.UseCompatibleTextRendering);
 			Size image_size = image == null ? Size.Empty : image.Size;
 
 			textRectangle = Rectangle.Empty;
@@ -438,19 +440,15 @@ namespace System.Windows.Forms
 					imageRectangle = new Rectangle (image_x, image_y, image_width, image_height);
 					break;
 				case TextImageRelation.ImageAboveText:
-					content_rect.Inflate (-4, -4);
 					LayoutTextAboveOrBelowImage (content_rect, false, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
 					break;
 				case TextImageRelation.TextAboveImage:
-					content_rect.Inflate (-4, -4);
 					LayoutTextAboveOrBelowImage (content_rect, true, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
 					break;
 				case TextImageRelation.ImageBeforeText:
-					content_rect.Inflate (-4, -4);
 					LayoutTextBeforeOrAfterImage (content_rect, false, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
 					break;
 				case TextImageRelation.TextBeforeImage:
-					content_rect.Inflate (-4, -4);
 					LayoutTextBeforeOrAfterImage (content_rect, true, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
 					break;
 			}


### PR DESCRIPTION
This fixes a problem with calculating the text width of a button which caused the text to get truncated under certain circumstances instead of being wrapped. This fixes Xamarin-23168.
