### PR TITLE
Fix PrepareEmit error when evaluating delegates

### DIFF
--- a/mcs/class/Mono.CSharp/Test/Evaluator/TypesTest.cs
+++ b/mcs/class/Mono.CSharp/Test/Evaluator/TypesTest.cs
@@ -104,7 +104,15 @@ namespace MonoTests.EvaluatorTest
 		{
 			Evaluator.Run ("class A { class B { } }");
 			Evaluator.Run ("var x = new A ();");
+		}
 
+		[Test]
+		public void DelegateType ()
+		{
+			Evaluator.Run ("public delegate int D();");
+			Evaluator.Run ("D d = delegate () { return 7; };");
+			object res = Evaluator.Evaluate ("d();");
+			Assert.AreEqual (7, res);
 		}
 	}
 }

--- a/mcs/mcs/delegate.cs
+++ b/mcs/mcs/delegate.cs
@@ -294,6 +294,9 @@ namespace Mono.CSharp {
 
 		public override void PrepareEmit ()
 		{
+			if ((caching_flags & Flags.CloseTypeCreated) != 0)
+				return;
+
 			if (!Parameters.IsEmpty) {
 				parameters.ResolveDefaultValues (this);
 			}


### PR DESCRIPTION
The delegate class did not use the internal cache flag as other type definitions which caused the next evaluation to fail.

Before
![delegate_before](https://cloud.githubusercontent.com/assets/3028306/4603895/d240c6e4-517d-11e4-975b-6630ca7a513d.png)

After
![delegate](https://cloud.githubusercontent.com/assets/3028306/4603896/da6561f4-517d-11e4-9dc9-c24eae084adc.png)
