### PR TITLE
Revert "If HTTP charset header is empty, do not append content encoding ...

### DIFF
--- a/mcs/class/System.Web/System.Web/HttpResponse.cs
+++ b/mcs/class/System.Web/System.Web/HttpResponse.cs
@@ -724,7 +724,9 @@ namespace System.Web
 				string header = content_type;
 
 				if (charset_set || header == "text/plain" || header == "text/html") {
-					if (header.IndexOf ("charset=") == -1 && !string.IsNullOrEmpty (charset)) {
+					if (header.IndexOf ("charset=") == -1) {
+						if (charset == null || charset == "")
+							charset = ContentEncoding.HeaderName;
 						header += "; charset=" + charset;
 					}
 				}


### PR DESCRIPTION
...to Content-Type header"

This reverts commit 3cc0e3fe3d33bb9dbd8357dd3430db7d507f4487.
This commit break globalization responseEncoding setting
see bug 23810 in xamarin bugzilla

Signed-off-by: Etienne CHAMPETIER <etienne.champetier@fiducial.net>