### PR TITLE
[MWF] Display visual feedback on pressed button (#23869)

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
@@ -379,12 +379,12 @@ namespace System.Windows.Forms
 				case TextImageRelation.Overlay:
 					// Overlay is easy, text always goes here
 
-						if (button.Pressed)
-							textRectangle.Offset (1, 1);
-						
 					// Image is dependent on ImageAlign
-					if (image == null)
+					if (image == null) {
+					if (button.Pressed)
+						textRectangle.Offset (1, 1);
 						return;
+					}
 						
 					int image_x = 0;
 					int image_y = 0;
@@ -449,6 +449,8 @@ namespace System.Windows.Forms
 					LayoutTextBeforeOrAfterImage (textRectangle, true, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
 					break;
 			}
+			if (button.Pressed)
+				textRectangle.Offset (1, 1);
 		}
 
 		private void LayoutTextBeforeOrAfterImage (Rectangle totalArea, bool textFirst, Size textSize, Size imageSize, System.Drawing.ContentAlignment textAlign, System.Drawing.ContentAlignment imageAlign, out Rectangle textRect, out Rectangle imageRect)


### PR DESCRIPTION
When a button is pressed the image and the text needs to be rendered one
pixel to the right and to the bottom so that there is some visual
feedback of the button press. Previously this was only the case if
TextImageRelation was set to Overlay.
