### PR TITLE
[MWF] Improve ellipsis handling

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TextRenderer.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TextRenderer.cs
@@ -492,9 +492,6 @@ namespace System.Windows.Forms
 				r.X += 2;
 				r.Width -= 2;
 			}
-			if ((flags & TextFormatFlags.WordEllipsis) == TextFormatFlags.WordEllipsis || (flags & TextFormatFlags.EndEllipsis) == TextFormatFlags.EndEllipsis || (flags & TextFormatFlags.WordBreak) == TextFormatFlags.WordBreak) {
-				r.Width -= 4;
-			}
 			if ((flags & TextFormatFlags.VerticalCenter) == TextFormatFlags.VerticalCenter && XplatUI.RunningOnUnix) {
 				r.Y -= 1;
 			}

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
@@ -375,14 +375,16 @@ namespace System.Windows.Forms
 			textRectangle = Rectangle.Inflate (content_rect, -4, -4);
 			imageRectangle = Rectangle.Empty;
 			
+			bool displayEllipsis = (button.TextFormatFlags & (TextFormatFlags.EndEllipsis | TextFormatFlags.PathEllipsis | TextFormatFlags.WordEllipsis)) != 0;
+
 			switch (button.TextImageRelation) {
 				case TextImageRelation.Overlay:
 					// Overlay is easy, text always goes here
 
 					// Image is dependent on ImageAlign
 					if (image == null) {
-					if (button.Pressed)
-						textRectangle.Offset (1, 1);
+						if (button.Pressed)
+							textRectangle.Offset (1, 1);
 						return;
 					}
 						
@@ -437,10 +439,10 @@ namespace System.Windows.Forms
 					imageRectangle = new Rectangle (image_x, image_y, image_width, image_height);
 					break;
 				case TextImageRelation.ImageAboveText:
-					LayoutTextAboveOrBelowImage (textRectangle, false, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
+					LayoutTextAboveOrBelowImage (textRectangle, false, text_size, image_size, button.TextAlign, button.ImageAlign, displayEllipsis, out textRectangle, out imageRectangle);
 					break;
 				case TextImageRelation.TextAboveImage:
-					LayoutTextAboveOrBelowImage (textRectangle, true, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
+					LayoutTextAboveOrBelowImage (textRectangle, true, text_size, image_size, button.TextAlign, button.ImageAlign, displayEllipsis, out textRectangle, out imageRectangle);
 					break;
 				case TextImageRelation.ImageBeforeText:
 					LayoutTextBeforeOrAfterImage (textRectangle, false, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
@@ -498,7 +500,7 @@ namespace System.Windows.Forms
 			imageRect = final_image_rect;
 		}
 
-		private void LayoutTextAboveOrBelowImage (Rectangle totalArea, bool textFirst, Size textSize, Size imageSize, System.Drawing.ContentAlignment textAlign, System.Drawing.ContentAlignment imageAlign, out Rectangle textRect, out Rectangle imageRect)
+		private void LayoutTextAboveOrBelowImage (Rectangle totalArea, bool textFirst, Size textSize, Size imageSize, System.Drawing.ContentAlignment textAlign, System.Drawing.ContentAlignment imageAlign, bool displayEllipsis, out Rectangle textRect, out Rectangle imageRect)
 		{
 			int element_spacing = 0;	// Spacing between the Text and the Image
 			int total_height = textSize.Height + element_spacing + imageSize.Height;
@@ -545,6 +547,12 @@ namespace System.Windows.Forms
 				
 				if (final_text_rect.Bottom > totalArea.Bottom)
 					final_text_rect.Y = totalArea.Top;
+			}
+
+			if (displayEllipsis) {
+				// Don't use more space than is available otherwise ellipsis won't show
+				if (final_text_rect.Height > totalArea.Bottom)
+					final_text_rect.Height = totalArea.Bottom - final_text_rect.Top;
 			}
 
 			textRect = final_text_rect;
@@ -1094,11 +1102,11 @@ namespace System.Windows.Forms
 					break;
 				case TextImageRelation.ImageAboveText:
 					content_rect.Inflate (-4, -4);
-					LayoutTextAboveOrBelowImage (content_rect, false, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
+					LayoutTextAboveOrBelowImage (content_rect, false, text_size, image_size, button.TextAlign, button.ImageAlign, false, out textRectangle, out imageRectangle);
 					break;
 				case TextImageRelation.TextAboveImage:
 					content_rect.Inflate (-4, -4);
-					LayoutTextAboveOrBelowImage (content_rect, true, text_size, image_size, button.TextAlign, button.ImageAlign, out textRectangle, out imageRectangle);
+					LayoutTextAboveOrBelowImage (content_rect, true, text_size, image_size, button.TextAlign, button.ImageAlign, false, out textRectangle, out imageRectangle);
 					break;
 				case TextImageRelation.ImageBeforeText:
 					content_rect.Inflate (-4, -4);


### PR DESCRIPTION
- Don't subtract room for ellipsis. Ellipsis should be
  handled by the renderer so we shouldn't reserve space for it.
  Otherwise we end up not getting ellipsis (because the renderer
  thinks there is enough space available), or we don't use up the
  available space.
- Don't allow text to go below button if we want to show ellipsis.

(There will probably be not difference visible when using the Cairo renderer, but it will improve things when using the experimental Pango renderer)
