### PR TITLE
Implement Request.Abort()

### DIFF
--- a/mcs/class/System.Web.Abstractions/System.Web/HttpRequestBase.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpRequestBase.cs
@@ -148,6 +148,12 @@ namespace System.Web
 
 		public virtual string [] UserLanguages { get { NotImplemented (); return null; } }
 
+#if NET_4_5
+		public virtual void Abort ()
+		{
+			NotImplemented();
+		}
+#endif
 
 		public virtual byte [] BinaryRead (int count)
 		{

--- a/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
@@ -232,6 +232,13 @@ namespace System.Web
 			get { return w.UserLanguages; }
 		}
 
+#if NET_4_5
+		public void Abort ()
+		{
+			w.WorkerRequest.CloseConnection();
+		}
+#endif
+
 		public override byte [] BinaryRead (int count)
 		{
 			return w.BinaryRead (count);


### PR DESCRIPTION
Implements a basic RequestAbort that calls close connection on the worker request.  I can't see a place to add tests but would love some help if there is a test that can be added for this.
