### PR TITLE
File URI's without a host are not UNC paths on Windows.

### DIFF
--- a/mcs/class/System/System/UriParseComponents.cs
+++ b/mcs/class/System/System/UriParseComponents.cs
@@ -269,15 +269,6 @@ namespace System {
 				return state.remaining.Length > 0;
 			}
 
-			if (state.elements.scheme == Uri.UriSchemeFile) {
-				// under Windows all file:// URI are considered UNC, which is not the case other MacOS (e.g. Silverlight)
-#if BOOTSTRAP_BASIC
-				state.elements.isUnc = (Path.DirectorySeparatorChar == '\\');
-#else
-				state.elements.isUnc = Environment.IsRunningOnWindows;
-#endif
-			}
-
 			return ParseDelimiter (state);
 		}
 
@@ -430,7 +421,17 @@ namespace System {
 			state.elements.host = state.elements.host.ToLowerInvariant ();
 
 			state.remaining = part.Substring (state.elements.host.Length);
-				
+
+			if (state.elements.scheme == Uri.UriSchemeFile &&
+				state.elements.host != "") {
+				// under Windows all file://host URI are considered UNC, which is not the case other MacOS (e.g. Silverlight)
+#if BOOTSTRAP_BASIC
+				state.elements.isUnc = (Path.DirectorySeparatorChar == '\\');
+#else
+				state.elements.isUnc = Environment.IsRunningOnWindows;
+#endif
+			}
+
 			return state.remaining.Length > 0;
 		}
 		

--- a/mcs/class/System/Test/System/UriTest2.cs
+++ b/mcs/class/System/Test/System/UriTest2.cs
@@ -920,6 +920,102 @@ TextWriter sw = Console.Out;
 		}
 
 		[Test]
+		public void LocalFile ()
+		{
+			Uri uri = new Uri ("file:///c:/subdir/file");
+
+			Assert.AreEqual ("c:/subdir/file", uri.AbsolutePath, "AbsolutePath");
+			Assert.AreEqual ("file:///c:/subdir/file", uri.AbsoluteUri, "AbsoluteUri");
+			Assert.AreEqual ("c:\\subdir\\file", uri.LocalPath, "LocalPath");
+			Assert.AreEqual ("c:/subdir/file", uri.PathAndQuery, "PathAndQuery");
+			Assert.AreEqual (String.Empty, uri.Query, "Query");
+			Assert.AreEqual ("file", uri.Segments [3], "Segments [3]");
+
+			Assert.AreEqual (String.Empty, uri.Authority, "Authority");
+			Assert.AreEqual (String.Empty, uri.DnsSafeHost, "DnsSafeHost");
+			Assert.AreEqual (String.Empty, uri.Fragment, "Fragment");
+			Assert.AreEqual (String.Empty, uri.Host, "Host");
+			Assert.AreEqual (UriHostNameType.Basic, uri.HostNameType, "HostNameType");
+			Assert.IsTrue (uri.IsAbsoluteUri, "IsAbsoluteUri");
+			Assert.IsTrue (uri.IsDefaultPort, "IsDefaultPort");
+			Assert.IsTrue (uri.IsFile, "IsFile");
+			Assert.IsTrue (uri.IsLoopback, "IsLoopback");
+			Assert.IsFalse (uri.IsUnc, "IsUnc");
+			Assert.AreEqual ("file:///c:/subdir/file", uri.OriginalString, "OriginalString");
+			Assert.AreEqual (-1, uri.Port, "Port");
+			Assert.AreEqual ("file", uri.Scheme, "Scheme");
+			Assert.AreEqual ("/", uri.Segments [0], "Segments [0]");
+			Assert.AreEqual ("c:/", uri.Segments [1], "Segments [1]");
+			Assert.AreEqual ("subdir/", uri.Segments [2], "Segments [2]");
+			Assert.IsFalse (uri.UserEscaped, "UserEscaped");
+			Assert.AreEqual (String.Empty, uri.UserInfo, "UserInfo");
+		}
+
+		[Test]
+		public void LocalhostWinFile ()
+		{
+			Uri uri = new Uri ("file://localhost/c:/subdir/file");
+
+			Assert.AreEqual ("/c:/subdir/file", uri.AbsolutePath, "AbsolutePath");
+			Assert.AreEqual ("file://localhost/c:/subdir/file", uri.AbsoluteUri, "AbsoluteUri");
+			Assert.AreEqual (isWin32 ? "\\\\localhost\\c:\\subdir\\file" : "/c:/subdir/file", uri.LocalPath, "LocalPath");
+			Assert.AreEqual ("/c:/subdir/file", uri.PathAndQuery, "PathAndQuery");
+			Assert.AreEqual (String.Empty, uri.Query, "Query");
+			Assert.AreEqual ("file", uri.Segments [3], "Segments [3]");
+
+			Assert.AreEqual ("localhost", uri.Authority, "Authority");
+			Assert.AreEqual ("localhost", uri.DnsSafeHost, "DnsSafeHost");
+			Assert.AreEqual (String.Empty, uri.Fragment, "Fragment");
+			Assert.AreEqual ("localhost", uri.Host, "Host");
+			Assert.AreEqual (UriHostNameType.Dns, uri.HostNameType, "HostNameType");
+			Assert.IsTrue (uri.IsAbsoluteUri, "IsAbsoluteUri");
+			Assert.IsTrue (uri.IsDefaultPort, "IsDefaultPort");
+			Assert.IsTrue (uri.IsFile, "IsFile");
+			Assert.IsTrue (uri.IsLoopback, "IsLoopback");
+			Assert.AreEqual (isWin32, uri.IsUnc, "IsUnc");
+			Assert.AreEqual ("file://localhost/c:/subdir/file", uri.OriginalString, "OriginalString");
+			Assert.AreEqual (-1, uri.Port, "Port");
+			Assert.AreEqual ("file", uri.Scheme, "Scheme");
+			Assert.AreEqual ("/", uri.Segments [0], "Segments [0]");
+			Assert.AreEqual ("c:/", uri.Segments [1], "Segments [1]");
+			Assert.AreEqual ("subdir/", uri.Segments [2], "Segments [2]");
+			Assert.IsFalse (uri.UserEscaped, "UserEscaped");
+			Assert.AreEqual (String.Empty, uri.UserInfo, "UserInfo");
+		}
+
+		[Test]
+		public void LocalhostFile ()
+		{
+			Uri uri = new Uri ("file://localhost/dir/subdir/file");
+
+			Assert.AreEqual ("/dir/subdir/file", uri.AbsolutePath, "AbsolutePath");
+			Assert.AreEqual ("file://localhost/dir/subdir/file", uri.AbsoluteUri, "AbsoluteUri");
+			Assert.AreEqual (isWin32 ? "\\\\localhost\\dir\\subdir\\file" : "/dir/subdir/file", uri.LocalPath, "LocalPath");
+			Assert.AreEqual ("/dir/subdir/file", uri.PathAndQuery, "PathAndQuery");
+			Assert.AreEqual (String.Empty, uri.Query, "Query");
+			Assert.AreEqual ("file", uri.Segments [3], "Segments [3]");
+
+			Assert.AreEqual ("localhost", uri.Authority, "Authority");
+			Assert.AreEqual ("localhost", uri.DnsSafeHost, "DnsSafeHost");
+			Assert.AreEqual (String.Empty, uri.Fragment, "Fragment");
+			Assert.AreEqual ("localhost", uri.Host, "Host");
+			Assert.AreEqual (UriHostNameType.Dns, uri.HostNameType, "HostNameType");
+			Assert.IsTrue (uri.IsAbsoluteUri, "IsAbsoluteUri");
+			Assert.IsTrue (uri.IsDefaultPort, "IsDefaultPort");
+			Assert.IsTrue (uri.IsFile, "IsFile");
+			Assert.IsTrue (uri.IsLoopback, "IsLoopback");
+			Assert.AreEqual (isWin32, uri.IsUnc, "IsUnc");
+			Assert.AreEqual ("file://localhost/dir/subdir/file", uri.OriginalString, "OriginalString");
+			Assert.AreEqual (-1, uri.Port, "Port");
+			Assert.AreEqual ("file", uri.Scheme, "Scheme");
+			Assert.AreEqual ("/", uri.Segments [0], "Segments [0]");
+			Assert.AreEqual ("dir/", uri.Segments [1], "Segments [1]");
+			Assert.AreEqual ("subdir/", uri.Segments [2], "Segments [2]");
+			Assert.IsFalse (uri.UserEscaped, "UserEscaped");
+			Assert.AreEqual (String.Empty, uri.UserInfo, "UserInfo");
+		}
+
+		[Test]
 		public void PathReduction_2e ()
 		{
 			Uri uri = new Uri ("http://host/dir/%2e%2E/file");


### PR DESCRIPTION
NUnit breaks when these URI's are treated as UNC paths, so I have no way of
running the tests on Windows without this change to see if it broke anything.
Not all URI tests pass, but the ones that fail seem unrelated to my change.

On Unix, the tests all work, but of course on Unix this is a no-op.

I have not been able to run tests in a Windows build of Mono since https://github.com/mono/mono/pull/1168
