### PR TITLE
[MWF] Use overload of Marshal.PtrToStringUni that reads up until ...

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -1296,7 +1296,7 @@ namespace System.Windows.Forms {
 						buffer [i] = Marshal.ReadByte (prop, i);
 					Clipboard.Item = Encoding.UTF8.GetString (buffer);
 				} else if (property == UTF16_STRING) {
-					Clipboard.Item = Marshal.PtrToStringUni (prop, Encoding.Unicode.GetMaxCharCount ((int)nitems));
+					Clipboard.Item = Marshal.PtrToStringUni (prop);
 				} else if (property == RICHTEXTFORMAT)
 					Clipboard.Item = Marshal.PtrToStringAnsi(prop);
 				else if (DataFormats.ContainsFormat (property.ToInt32 ())) {


### PR DESCRIPTION
...the first null instead of explicitly specifying length

This fixes the two tests broken by 0ac61b03fcd9baf75739d3c567b36647bde08025
