### PR TITLE
[System] Added missing ctor to Socket for initializing dual-mode socket

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
@@ -952,6 +952,14 @@ namespace System.Net.Sockets {
 #endif
 		}
 
+#if NET_4_5
+		[MonoTODO ("Currently hardcoded to IPv4. Ideally, support v4/v6 dual-stack.")]
+		public Socket (SocketType socketType, ProtocolType protocolType)
+			: this (AddressFamily.InterNetwork, socketType, protocolType)
+		{
+		}
+#endif
+
 		~Socket ()
 		{
 			Dispose (false);


### PR DESCRIPTION
- Ref: https://bugzilla.xamarin.com/show_bug.cgi?id=20048
- It's new one added in .NET 4.5
- Absence of this ctor prevents KestrelHttpServer (web server for ASP.NET vNext: https://github.com/aspnet/KestrelHttpServer ) test code from working
- I hesitated to put IPv4 only implementation, but whole dual stack (IPv4/v6) support would need bunch of works to be done. So, I pinned supported protocol of new ctor to IPv4
