### PR TITLE
Fix Windows build by including wstcpip.h before winsock.h is included

### DIFF
--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -20,12 +20,6 @@
 #include <glib.h>
 #include <string.h>
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#include <errno.h>
-
-#include <sys/types.h>
 #ifdef HOST_WIN32
 #include <ws2tcpip.h>
 #else
@@ -36,6 +30,12 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <errno.h>
+
+#include <sys/types.h>
 
 #include <mono/metadata/object.h>
 #include <mono/io-layer/io-layer.h>


### PR DESCRIPTION
Error generated by socket-io.c was:

/usr/i686-pc-mingw32/sys-root/mingw/include/ws2tcpip.h:38:2:
error: #error "ws2tcpip.h is not compatible with winsock.h.
Include winsock2.h instead."

Tested this builds on Windows Cygwin and Linux Ubuntu/x64

Signed-off-by: Alex J Lennon ajlennon@dynamicdevices.co.uk
