### PR TITLE
Set ReadEntityBodyMode default to Classic to force clients to use the ol...

### DIFF
--- a/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
@@ -208,6 +208,12 @@ namespace System.Web
 			get { return w.TotalBytes; }
 		}
 
+#if NET_4_5
+		public override ReadEntityBodyMode ReadEntityBodyMode {
+			get { return ReadEntityBodyMode.Classic; }
+		}
+#endif
+
 		public override Uri Url {
 			get { return w.Url; }
 		}


### PR DESCRIPTION
...d method for reading the input stream.

According to the MSDN docs, if ReadEntityBodyMode returns "Classic" the code should use the old method to read the input stream (HttpRequestBase.InputStream) which is fully implemented in mono.
