### PR TITLE
Add ClientDisconnectedToken property to HttpResponseBase and Wrapper as ...

### DIFF
--- a/mcs/class/System.Web.Abstractions/System.Web/HttpResponseBase.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpResponseBase.cs
@@ -39,6 +39,7 @@ using System.Security.Permissions;
 using System.Security.Principal;
 using System.Text;
 using System.Web.Caching;
+using System.Threading;
 
 #if NET_4_0
 using System.Web.Routing;
@@ -68,6 +69,10 @@ namespace System.Web
 		public virtual string CacheControl { get { NotImplemented (); return null; } set { NotImplemented (); } }
 
 		public virtual string Charset { get { NotImplemented (); return null; } set { NotImplemented (); } }
+
+#if NET_4_5
+		public virtual CancellationToken ClientDisconnectedToken { get { NotImplemented (); return CancellationToken.None; } }
+#endif
 
 		public virtual Encoding ContentEncoding { get { NotImplemented (); return null; } set { NotImplemented (); } }
 

--- a/mcs/class/System.Web.Abstractions/System.Web/HttpResponseWrapper.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpResponseWrapper.cs
@@ -39,6 +39,7 @@ using System.Security.Permissions;
 using System.Security.Principal;
 using System.Text;
 using System.Web.Caching;
+using System.Threading;
 
 namespace System.Web
 {
@@ -81,6 +82,12 @@ namespace System.Web
 			get { return w.Charset; }
 			set { w.Charset = value; }
 		}
+
+#if NET_4_5
+		public override CancellationToken ClientDisconnectedToken {
+			get { return CancellationToken.None; }
+		}
+#endif
 
 		public override Encoding ContentEncoding {
 			get { return w.ContentEncoding; }


### PR DESCRIPTION
...default None.

I don't profess to know what it does, however, I've looked at the usage of this in the aspnetwebstack, and under a few scenarios, it defaults it's own helper method to CancellationToken.None.  Therefore I'm assuming this is ok as a default in the code.
