### PR TITLE
Added GetBufferless and GetBufferedInputStream to HttpRequest*

### DIFF
--- a/mcs/class/System.Web.Abstractions/System.Web/HttpRequestBase.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpRequestBase.cs
@@ -164,6 +164,20 @@ namespace System.Web
 			return null;
 		}
 
+#if NET_4_5
+		public virtual Stream GetBufferlessInputStream ()
+		{
+			NotImplemented ();
+			return null;
+		}
+
+		public virtual Stream GetBufferedInputStream ()
+		{
+			NotImplemented ();
+			return null;
+		}
+#endif
+
 		public virtual int [] MapImageCoordinates (string imageFieldName)
 		{
 			NotImplemented ();

--- a/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
@@ -244,6 +244,18 @@ namespace System.Web
 			return w.BinaryRead (count);
 		}
 
+#if NET_4_5
+		public override Stream GetBufferedInputStream()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override Stream GetBufferlessInputStream()
+		{
+			return w.GetBufferlessInputStream ();
+		}
+#endif
+
 		public override int [] MapImageCoordinates (string imageFieldName)
 		{
 			return w.MapImageCoordinates (imageFieldName);


### PR DESCRIPTION
These methods are required for the aspnetwebstack to compile.  We don't have the GetBufferedInputStream on the HttpRequest, but it shouldn't actually be used due to the setting of the ReadEntityBodyMode in a previous pull.
