### PR TITLE
Add missing header file to s390x_sources

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -348,6 +348,7 @@ sparc_sources = \
 s390x_sources = \
 	mini-s390x.c		\
 	mini-s390x.h		\
+	support-s390x.h		\
 	exceptions-s390x.c	\
 	tramp-s390x.c
 


### PR DESCRIPTION
Otherwise a required header file for s390x builds is missing from tarball builds.
