### PR TITLE
[libgc] Eliminate warning about redefinition of GC_WIN32_THREADS

### DIFF
--- a/libgc/include/gc_config_macros.h
+++ b/libgc/include/gc_config_macros.h
@@ -32,7 +32,7 @@
 # define GC_LINUX_THREADS
 #endif
 #if defined(WIN32_THREADS)
-# define GC_WIN32_THREADS
+# define GC_WIN32_THREADS 1
 #endif
 #if defined(USE_LD_WRAP)
 # define GC_USE_LD_WRAP


### PR DESCRIPTION
Makefile defines GC_WIN32_THREADS as 1 but gc_config_macros was
redefining as defined but with no value.

Signed-off-by: Alex J Lennon ajlennon@dynamicdevices.co.uk
