### PR TITLE
Fix warning for a probable bug.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1581,7 +1581,7 @@ transport_handshake (void)
 
 	/* Read answer */
 	res = transport_recv (buf, strlen (handshake_msg));
-	if ((res != strlen (handshake_msg)) || (memcmp (buf, handshake_msg, strlen (handshake_msg) != 0))) {
+	if ((res != strlen (handshake_msg)) || (memcmp (buf, handshake_msg, strlen (handshake_msg)) != 0)) {
 		fprintf (stderr, "debugger-agent: DWP handshake failed.\n");
 		return FALSE;
 	}


### PR DESCRIPTION
It looks like the intent was to compare the result of `memcmp`, but the code was comparing the result of `strlen`.
