### PR TITLE
[System.ServiceModel] Fixed Bug652331_2 test that failed on Jenkins by increasing timeout

### DIFF
--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
@@ -70,7 +70,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 				};
 
 				client.GetDataAsync ();
-				if (!wait.WaitOne (TimeSpan.FromSeconds (10)))
+				if (!wait.WaitOne (TimeSpan.FromSeconds (20)))
 					Assert.Fail ("timeout");
 			} finally {
 				serviceHost.Close ();


### PR DESCRIPTION
Any exception in the eventhandler is swallowed, so we couldn't see why the test fails.

This should let us see why the test fails on Jenkins.
