### PR TITLE
Fix GetUsing to output the using name instead of -> using Mono.CSharp.Na...

### DIFF
--- a/mcs/mcs/ecore.cs
+++ b/mcs/mcs/ecore.cs
@@ -3208,6 +3208,11 @@ namespace Mono.CSharp {
 		{
 			return ns.LookupTypeOrNamespace (ctx, name, arity, mode, loc);
 		}
+
+        public override string ToString ()
+        {
+            return Namespace.Name;
+        }
     }
 
 	/// <summary>

--- a/mcs/mcs/eval.cs
+++ b/mcs/mcs/eval.cs
@@ -861,34 +861,44 @@ namespace Mono.CSharp
 			return "\"" + s + "\"";
 		}
 
-		public string GetUsing ()
-		{
-			StringBuilder sb = new StringBuilder ();
-			// TODO:
-			//foreach (object x in ns.using_alias_list)
-			//    sb.AppendFormat ("using {0};\n", x);
+        public string GetUsing ()
+        {
+            if (source_file == null || source_file.Usings == null)
+                return string.Empty;
 
-			foreach (var ue in source_file.Usings) {
-				sb.AppendFormat ("using {0};", ue.ToString ());
-				sb.Append (Environment.NewLine);
-			}
+            StringBuilder sb = new StringBuilder ();
 
-			return sb.ToString ();
-		}
+            // TODO:
+            //foreach (object x in ns.using_alias_list)
+            //    sb.AppendFormat ("using {0};\n", x);
 
-		internal List<string> GetUsingList ()
-		{
-			var res = new List<string> ();
+            foreach (var ue in source_file.Usings) {
+                if (ue.Alias != null || ue.ResolvedExpression == null)
+                    continue;
 
-			foreach (var ue in source_file.Usings) {
-				if (ue.Alias != null || ue.ResolvedExpression == null)
-					continue;
+                sb.AppendFormat ("using {0};", ue.ToString());
+                sb.Append (Environment.NewLine);
+            }
 
-				res.Add (ue.NamespaceExpression.Name);
-			}
+            return sb.ToString ();
+        }
 
-			return res;
-		}
+        internal List<string> GetUsingList ()
+        {
+            var res = new List<string> ();
+
+            if (source_file == null || source_file.Usings == null)
+                return res;
+
+            foreach (var ue in source_file.Usings) {
+                if (ue.Alias != null || ue.ResolvedExpression == null)
+                    continue;
+
+                res.Add (ue.NamespaceExpression.Name);
+            }
+
+            return res;
+        }
 		
 		internal string [] GetVarNames ()
 		{


### PR DESCRIPTION
...mespaceExpression; <- for every using statement that was set
- Fix NRE when source_file or source_file.Usings is null.  This will now return back an empty string or empty List<string>
- **Note** that we are returning the ToString() value of NamespaceExpression which is the full resolved namespace of "System.Drawing" instead of "Drawing".
- Add ToString override for NamespaceExpression to return the full resolved name of the namespace.
