### PR TITLE
[MWF] DataGridViewRowCollection Clear() speed up

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridViewRowCollection.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridViewRowCollection.cs
@@ -268,9 +268,9 @@ namespace System.Windows.Forms
 
 				row.SetDataGridView (null);
 				list.Remove (row);
-				ReIndex ();
 			}
 
+			ReIndex ();
 			DataGridView.OnRowsPostRemovedInternal (new DataGridViewRowsRemovedEventArgs (0, total));
 			OnCollectionChanged (new CollectionChangeEventArgs (CollectionChangeAction.Refresh, null));
 		}


### PR DESCRIPTION
When issuing a Clear() to remove all rows, a ReIndex() was being called for
each row that was being removed.  This is extremely inefficient, instead
do a single ReIndex() after all rows have been removed.

Before doing a Clear() of 30k rows was taking 5.8 seconds.  With this patch
it now takes 670ms.
