### PR TITLE
Add IE9 and newer to Up level navigator

### DIFF
--- a/mcs/class/System.Web/UplevelHelperDefinitions.xml
+++ b/mcs/class/System.Web/UplevelHelperDefinitions.xml
@@ -93,7 +93,11 @@ definition correctly.
       <!-- MSIE, Netscape 4.0, Opera -->
       <except positions="13-28" match="ActiveTouristBot"/>
     </group>
-
+    <!-- IE9 or newer -->
+    <group positions="7-10" match="/5.0" javascript="true">
+      <!-- MSIE 10, MSIE 11 -->
+	    <except positions="13-28" match="ActiveTouristBot"/>
+    </group>
     <group scanfrom="12" skip="4" match=") Gecko/" javascript="true">
       <!-- All the Gecko-based browsers -->
     </group>


### PR DESCRIPTION
This line enable the ASP Javascript validators in IE9 and upper. the user agent the IE10 is "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)".
