### PR TITLE
[eval] Capture local variables

### DIFF
--- a/mcs/class/Mono.CSharp/Test/Evaluator/ExpressionsTest.cs
+++ b/mcs/class/Mono.CSharp/Test/Evaluator/ExpressionsTest.cs
@@ -166,5 +166,14 @@ namespace MonoTests.EvaluatorTest
 			Assert.AreEqual (3, res, "#1");
 		}
 #endif
+		
+		[Test]
+		public void CaptureLocalVariableTest()
+		{
+			Evaluator.Run ("using System;");
+
+			var res = Evaluator.Evaluate("var x = 123;Action a = () => x++;a();x;");
+			Assert.AreEqual (124, res);	
+		}
 	}
 }

--- a/mcs/mcs/anonymous.cs
+++ b/mcs/mcs/anonymous.cs
@@ -352,6 +352,14 @@ namespace Mono.CSharp {
 				hoisted_locals.Add (hoisted);
 			}
 
+			//
+			// Variable is already hoisted but does not have a storey
+			// e.g. when a HoistedEvaluatorVariable 
+			//
+			if (hoisted.Storey == null) {
+				hoisted = new HoistedLocalVariable (this, hoisted.Field);
+			}
+
 			if (ec.CurrentBlock.Explicit != localVariable.Block.Explicit && !(hoisted.Storey is StateMachine))
 				hoisted.Storey.AddReferenceFromChildrenBlock (ec.CurrentBlock.Explicit);
 		}
@@ -905,6 +913,11 @@ namespace Mono.CSharp {
 	{
 		public HoistedLocalVariable (AnonymousMethodStorey storey, LocalVariable local, string name)
 			: base (storey, name, local.Type)
+		{
+		}
+
+		public HoistedLocalVariable (AnonymousMethodStorey storey, Field field)
+			: base (storey, field)
 		{
 		}
 	}


### PR DESCRIPTION
Evaluated variables are hoisted by never assigned to a storey (as it's not available at the time), so they can't be captured.  So the compiler crashes because the storey is null for the hoisted variable.

This fix will assign a storey to a HoistedEvaluatorVariable.

**Before**
![capture_before](https://cloud.githubusercontent.com/assets/3028306/5044968/cd25455a-6bee-11e4-8875-03d7299eea10.png)

**After**
![capture_after](https://cloud.githubusercontent.com/assets/3028306/5044992/110c2554-6bef-11e4-959c-631790f28914.png)
