### PR TITLE
[MWF] Fix focus issue when removing last item in ListView

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -1031,6 +1031,7 @@ namespace System.Windows.Forms
 
 				virtual_list_size = value;
 				if (virtual_mode) {
+					focused_item_index = -1;
 					selected_indices.Reset ();
 					Redraw (true);
 				}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=24587

When the VirtualListSize changes, the focus_item_index should
be reset (similar to how it currently resets the selected indices).

If the last item in a ListView has focus and it is removed by
an another action on the form (i.e. push a button to remove the
current item), then the focused_item_index is not updated when
the VirtualListSize changes, even though that item doesn't exist
anymore.  When the ListView receives focus again, it tries to
invalidate the current focused item which causes an
ArgumentOutOfRangeException.
