### PR TITLE
[System.Security] Fix SignedXml bug #7716 with tests

### DIFF
--- a/mcs/class/System.Security/Mono.Xml/XmlCanonicalizer.cs
+++ b/mcs/class/System.Security/Mono.Xml/XmlCanonicalizer.cs
@@ -637,7 +637,7 @@ namespace Mono.Xml {
 			else if (n2 == null) 
 				return 1;
 	    		else if (n1.Prefix == n2.Prefix) 
-				return string.Compare (n1.LocalName, n2.LocalName);
+				return string.CompareOrdinal (n1.LocalName, n2.LocalName);
 	
     			// Attributes in the default namespace are first
 			// because the default namespace is not applied to

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigC14NTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigC14NTransformTest.cs
@@ -494,6 +494,19 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 			Assert.AreEqual (new StreamReader (s, Encoding.UTF8).ReadToEnd (), expected);
 		}
 
+		[Test]
+		public void OrdinalSortForAttributes ()
+		{
+			XmlDocument doc = new XmlDocument ();
+			string xml = "<foo Aa=\"one\" Bb=\"two\" aa=\"three\" bb=\"four\"><bar></bar></foo>";
+			doc.LoadXml (xml);
+
+			transform.LoadInput (doc);
+			Stream s = (Stream) transform.GetOutput ();
+			string output = Stream2String (s);
+			Assert.AreEqual (xml, output);
+		}
+
 #if NET_2_0
 		[Test]
 		public void PrefixlessNamespaceOutput ()


### PR DESCRIPTION
The underlying problem for bug 7716 [1] was that the Mono C14N XML
canonicalizer was not sorting the XML attributes in the same order as
Microsoft .NET's canonicalizer.

The C14N specification [2] states: "the attributes are sorted
lexicographically by attribute name (based on Unicode character code
points)." This wording suggests that the order of attributes should be
strictly ascending based on Unicode byte value. This commit changes the
attribute sort order to match the specification.

The new tests pass on Windows, fail on Mono before this change, and
succeed on Mono after this change.

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=7716
[2] http://www.w3.org/TR/2000/WD-xml-c14n-20000119.html
