### PR TITLE
[msvc] Bump winconfig.h VERSION to match configure.ac

### DIFF
--- a/winconfig.h
+++ b/winconfig.h
@@ -629,4 +629,4 @@
 /* #undef USE_MONO_MUTEX */
 
 /* Version number of package */
-#define VERSION "2.11"
+#define VERSION "3.12.1"


### PR DESCRIPTION
Unhelpfully, winconfig.h is used for building eglib, and it includes a hardcoded VERSION definition which needs to match configure.ac - otherwise msvc builds identify themselves as 2.11

It would be lovely to regenerate the line automatically in some sane manner, but that's a job for another day
