### PR TITLE
[msvc] Define SSIZE_MAX if not already defined (i.e. on Windows)

### DIFF
--- a/mono/metadata/sgen-los.c
+++ b/mono/metadata/sgen-los.c
@@ -38,6 +38,7 @@
 #include "metadata/sgen-cardtable.h"
 #include "metadata/sgen-memory-governor.h"
 #include "utils/mono-mmap.h"
+#include "utils/mono-compiler.h"
 
 #define LOS_SECTION_SIZE	(1024 * 1024)
 

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -219,6 +219,20 @@
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 
+/*
+ * SSIZE_MAX is not defined in MSVC, so define it here.
+ *
+ * These values come from MinGW64, and are public domain.
+ *
+ */
+#ifndef SSIZE_MAX
+#ifdef _WIN64
+#define SSIZE_MAX _I64_MAX
+#else
+#define SSIZE_MAX INT_MAX
+#endif
+#endif
+
 #endif /* _MSC_VER */
 
 #if !defined(_MSC_VER) && !defined(PLATFORM_SOLARIS) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(MONOTOUCH) && HAVE_VISIBILITY_HIDDEN


### PR DESCRIPTION
limits.h from MSVC does not include SIZE_MAX or SSIZE_MAX. We need the latter to build sgen, so define it.
