### PR TITLE
HttpRequestMessage should accept URI string beginning with '/'.

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpRequestMessage.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpRequestMessage.cs
@@ -48,8 +48,18 @@ namespace System.Net.Http
 		}
 
 		public HttpRequestMessage (HttpMethod method, string requestUri)
-			: this (method, string.IsNullOrEmpty (requestUri) ? (Uri) null : new Uri (requestUri, System.UriKind.RelativeOrAbsolute))
+			: this (method, null as Uri)
 		{
+			if (!string.IsNullOrEmpty (requestUri)) {
+				UriKind kind = IsHttpUriString (requestUri) ? UriKind.Absolute : UriKind.Relative;
+				RequestUri = new Uri (requestUri, kind);
+			}
+		}
+
+		internal static bool IsHttpUriString (string uri)
+		{
+			StringComparison option = StringComparison.OrdinalIgnoreCase;
+			return uri.StartsWith ("http://", option) || uri.StartsWith ("https://", option);
 		}
 
 		public HttpRequestMessage (HttpMethod method, Uri requestUri)

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpRequestMessageTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpRequestMessageTest.cs
@@ -107,6 +107,9 @@ namespace MonoTests.System.Net.Http
 			var req = new HttpRequestMessage (HttpMethod.Get, "Computer");
 			// HttpRequestMessage does not rewrite it here.
 			Assert.IsFalse (req.RequestUri.IsAbsoluteUri);
+
+			req = new HttpRequestMessage (HttpMethod.Get, "/");
+			Assert.IsFalse (req.RequestUri.IsAbsoluteUri);
 		}
 
 		[Test]


### PR DESCRIPTION
This PR will solve an issue described below.

``` csharp
var client = new HttpClient() { BaseAddress = new Uri("http://github.com") };
var content = async client.GetStringAsync("/");
```

`GetStringAsync("/")` on the code snippet above throws on Mono, due to the following reasons.
- The parser of Mono's Uri class interprets uri strings beginning with '/' as UNIX file paths and mark them absolute (`uri.IsAbsoluteUri == true`) unless specified as relative.
- HttpRequestMessage.RequestUri rejects absolute and non-http(s) Uris.

Such a behaviour of Uri class is incompatible with the original .NET. However, changing the Uri behaviour can be painful, so changing that of HttpRequestMessage would be better.
