### PR TITLE
Remove --enable-nunit-tests option from build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2299,9 +2299,6 @@ fi
 
 AC_ARG_ENABLE(bcl-opt, [  --disable-bcl-opt	BCL is compiled with no optimizations (allows accurate BCL debugging)], test_bcl_opt=$enableval, test_bcl_opt=yes)
 
-AC_ARG_ENABLE(nunit-tests, [  --enable-nunit-tests	Run the nunit tests of the class library on 'make check'])
-AM_CONDITIONAL(ENABLE_NUNIT_TESTS, [test x$enable_nunit_tests = xyes])
-
 AC_MSG_CHECKING([if big-arrays are to be enabled])
 AC_ARG_ENABLE(big-arrays,  [  --enable-big-arrays	Enable the allocation and indexing of arrays greater than Int32.MaxValue], enable_big_arrays=$enableval, enable_big_arrays=no)
 if test "x$enable_big_arrays" = "xyes" ; then

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -94,13 +94,6 @@ endif BUILD_MCS
 
 TEST_SUPPORT_FILES = $(tmpinst)/bin/mono $(tmpinst)/bin/ilasm $(tmpinst)/bin/mcs $(tmpinst)/bin/gmcs $(tmpinst)/bin/dmcs $(tmpinst)/bin/al2 $(tmpinst)/bin/al
 
-# now a misnomer, but it'll go away soon enough.
-if ENABLE_NUNIT_TESTS
-test_select =
-else
-test_select = ONLY_CENTUM_TESTS=yes
-endif
-
 mcs-do-test-profiles:
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' test-profiles
 
@@ -152,7 +145,7 @@ if NACL_CODEGEN
 check-local:
 else
 check-local: mcs-compileall mcs-do-test-profiles
-	$(MAKE) $(test_select) mcs-do-run-test-profiles
+	$(MAKE) ONLY_CENTUM_TESTS=yes mcs-do-run-test-profiles
 endif
 
 # Compile all mcs tests


### PR DESCRIPTION
It isn't used anymore as the classlib tests are always enabled now during 'make check'.
