### PR TITLE
WebClient delay file creation until a response is obtained

### DIFF
--- a/mcs/class/System/System.Net/WebClient.cs
+++ b/mcs/class/System/System.Net/WebClient.cs
@@ -315,10 +315,10 @@ namespace System.Net
 		{
 			WebRequest request = null;
 			
-			using (FileStream f = new FileStream (fileName, FileMode.Create)) {
-				try {
-					request = SetupRequest (address);
-					WebResponse response = GetWebResponse (request);
+			try {
+				request = SetupRequest (address);
+				WebResponse response = GetWebResponse (request);
+			    using (FileStream f = new FileStream (fileName, FileMode.Create)) {
 					Stream st = response.GetResponseStream ();
 					
 					int cLength = (int) response.ContentLength;
@@ -337,11 +337,11 @@ namespace System.Net
 
 					if (cLength > 0 && notify_total < cLength)
 						throw new WebException ("Download aborted prematurely.", WebExceptionStatus.ReceiveFailure);
-				} catch (ThreadInterruptedException){
-					if (request != null)
-						request.Abort ();
-					throw;
-				}
+			    }
+			} catch (ThreadInterruptedException){
+				if (request != null)
+					request.Abort ();
+				throw;
 			}
 		}
 
@@ -1713,8 +1713,8 @@ namespace System.Net
 		async Task DownloadFileTaskAsyncCore (WebRequest request, WebResponse response,
 		                                      string fileName, CancellationToken token)
 		{
+			Stream st = response.GetResponseStream ();
 			using (FileStream f = new FileStream (fileName, FileMode.Create)) {
-				Stream st = response.GetResponseStream ();
 					
 				int cLength = (int)response.ContentLength;
 				int length = (cLength <= -1 || cLength > 32 * 1024) ? 32 * 1024 : cLength;


### PR DESCRIPTION
[Fix] When using WebClient/DownloadFile, I found that on mono, it was creating files even before failing for the most obvious reasons and leaving the 0 byte file behind. This is a fix.
