### PR TITLE
TimeZoneInfo.Local shall not throw a TimeZoneNotFoundException.

### DIFF
--- a/mcs/class/System.Core/System/TimeZoneInfo.cs
+++ b/mcs/class/System.Core/System/TimeZoneInfo.cs
@@ -93,7 +93,7 @@ namespace System
 				if (l == null) {
 					l = CreateLocal ();
 					if (l == null)
-						throw new TimeZoneNotFoundException ();
+						return null;
 
 					if (Interlocked.CompareExchange (ref local, l, null) != null)
 						l = local;


### PR DESCRIPTION
Before commit 0c35602a172610e427d2a893199e053f62bf2ff9 the property TimeZoneInfo.Local simply did return null, if there was no time zone information available. Now it throws a TimeZoneNotFoundException. The proposed change restores the old behaviour. Throwing a TimeZoneNotFoundException in TimeZoneInfo.Local breaks any compatibility with platforms that do not have the expected time zone database, i.e. the Android environment on all BlackBerry 10 device. Before commit 0c35602a172610e427d2a893199e053f62bf2ff9 Xamarin.Android did work perfectly on the BlackBerry 10 Android environment. This change restores that compatibility.
