### PR TITLE
[corlib] Fix Parallel.ForEach overload that hardcoded -1 for the item index

### DIFF
--- a/mcs/class/corlib/System.Threading.Tasks/Parallel.cs
+++ b/mcs/class/corlib/System.Threading.Tasks/Parallel.cs
@@ -448,7 +448,7 @@ namespace System.Threading.Tasks
 			return ForEach<TSource, object> (Partitioner.Create (source),
 			                                 ParallelOptions.Default,
 			                                 () => null,
-			                                 (e, s, l) => { body (e, s, -1); return null; },
+			                                 (e, s, i, l) => { body (e, s, i); return null; },
 			                                 _ => {});
 		}
 

--- a/mcs/class/corlib/Test/System.Threading.Tasks/ParallelTests.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/ParallelTests.cs
@@ -115,6 +115,16 @@ namespace MonoTests.System.Threading.Tasks
 			});
 		}
 
+		[Test]
+		public void ParallelForEachTestCaseWithIndex ()
+		{
+			var list = new List<int> { 0, 1, 2, 3, 4 };
+
+			Parallel.ForEach (list, (l, s, i) => {
+				Assert.AreEqual (l, i, "#1");
+			});
+		}
+
 		class ValueAndSquare
 		{ 
 			public float Value { get; set; }


### PR DESCRIPTION
Xamarin bug [#24891](https://bugzilla.xamarin.com/show_bug.cgi?id=24891)
