### PR TITLE
[counters] Fix file handle leak in cpu_load ()

### DIFF
--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -360,6 +360,7 @@ cpu_load (int kind)
 	FILE *f = fopen ("/proc/loadavg", "r");
 	if (f) {
 		len = fread (buffer, 1, sizeof (buffer) - 1, f);
+		fclose (f);
 		if (len > 0) {
 			buffer [len < 511 ? len : 511] = 0;
 			b = buffer;
@@ -374,7 +375,6 @@ cpu_load (int kind)
 				}
 			}
 		}
-		fclose (f);
 	}
 #endif
 	return 0;


### PR DESCRIPTION
If a premature return is taken, the FILE pointer f is not fclose()-ed.

Report and fix provided by Markus Beth on the mailing list: http://lists.ximian.com/pipermail/mono-devel-list/2014-December/042459.html
