### PR TITLE
Fix build on s390

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -297,6 +297,9 @@ MONO_SIG_HANDLER_FUNC (static, sigusr1_signal_handler)
 #endif
 
 #ifdef SIGPROF
+
+static int profiling_signal_in_use;
+
 #if defined(__ia64__) || defined(__sparc__) || defined(sparc) || defined(__s390__) || defined(s390)
 
 MONO_SIG_HANDLER_FUNC (static, sigprof_signal_handler)
@@ -308,8 +311,6 @@ MONO_SIG_HANDLER_FUNC (static, sigprof_signal_handler)
 }
 
 #else
-
-static int profiling_signal_in_use;
 
 static void
 per_thread_profiler_hit (void *ctx)


### PR DESCRIPTION
This should fix the s390 built on Jenkins that currently fails with:

```
  CC     libmini_la-tramp-s390x.lo
  CC     libmini_la-mini-posix.lo
mini-posix.c: In function ‘mono_runtime_setup_stat_profiler’:
mini-posix.c:686: error: ‘profiling_signal_in_use’ undeclared (first use in this function)
mini-posix.c:686: error: (Each undeclared identifier is reported only once
mini-posix.c:686: error: for each function it appears in.)
make[4]: *** [libmini_la-mini-posix.lo] Error 1
```

Note: I know next to nothing about that code, so if moving the variable declaration causes problems, please let me know :smile: 
