### PR TITLE
Fixed ZipFile.CreateFromDirectory overload to use compressionLevel

### DIFF
--- a/mcs/class/System.IO.Compression.FileSystem/ZipFile.cs
+++ b/mcs/class/System.IO.Compression.FileSystem/ZipFile.cs
@@ -43,7 +43,7 @@ namespace System.IO.Compression
 			CompressionLevel compressionLevel, bool includeBaseDirectory)
 		{
 			CreateFromDirectory (sourceDirectoryName, destinationArchiveFileName,
-				CompressionLevel.Fastest, includeBaseDirectory, Encoding.UTF8);
+				compressionLevel, includeBaseDirectory, Encoding.UTF8);
 		}
 
 		public static void CreateFromDirectory (


### PR DESCRIPTION
One of the `ZipFile.CreateFromDirectory` overloads that have a `compressionLevel` parameter ignores it and passes `CompressionLevel.Fastest` anyway.
