### PR TITLE
[jit] Optimize the managed allocator fastpath for small objects

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -747,9 +747,10 @@ create_allocator (int atype, int tls_key)
 		csig->params [0] = &mono_defaults.int_class->byval_arg;
 		csig->params [1] = &mono_defaults.int32_class->byval_arg;
 	} else {
-		csig = mono_metadata_signature_alloc (mono_defaults.corlib, 1);
+		csig = mono_metadata_signature_alloc (mono_defaults.corlib, 2);
 		csig->ret = &mono_defaults.object_class->byval_arg;
 		csig->params [0] = &mono_defaults.int_class->byval_arg;
+		csig->params [1] = &mono_defaults.int32_class->byval_arg;
 	}
 
 	mb = mono_mb_new (mono_defaults.object_class, "Alloc", MONO_WRAPPER_ALLOC);
@@ -767,15 +768,7 @@ create_allocator (int atype, int tls_key)
 		mono_mb_emit_byte (mb, MONO_CEE_ADD);
 		mono_mb_emit_stloc (mb, bytes_var);
 	} else {
-		/* bytes = vtable->klass->instance_size */
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (MonoVTable, klass));
-		mono_mb_emit_byte (mb, MONO_CEE_ADD);
-		mono_mb_emit_byte (mb, MONO_CEE_LDIND_I);
-		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (MonoClass, instance_size));
-		mono_mb_emit_byte (mb, MONO_CEE_ADD);
-		/* FIXME: assert instance_size stays a 4 byte integer */
-		mono_mb_emit_byte (mb, MONO_CEE_LDIND_U4);
+		mono_mb_emit_ldarg (mb, 1);
 		mono_mb_emit_stloc (mb, bytes_var);
 	}
 
@@ -961,7 +954,7 @@ mono_gc_is_critical_method (MonoMethod *method)
  */
 
 MonoMethod*
-mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box)
+mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size)
 {
 	int offset = -1;
 	int atype;
@@ -1058,7 +1051,7 @@ mono_gc_is_critical_method (MonoMethod *method)
 }
 
 MonoMethod*
-mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box)
+mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size)
 {
 	return NULL;
 }

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1083,6 +1083,12 @@ mono_gc_get_write_barrier (void)
 
 #endif
 
+int
+mono_gc_get_aligned_size_for_allocator (int size)
+{
+	return size;
+}
+
 const char *
 mono_gc_get_gc_name (void)
 {

--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -220,7 +220,7 @@ typedef struct {
 	int alloc_type;
 } AllocatorWrapperInfo;
 
-MonoMethod* mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box) MONO_INTERNAL;
+MonoMethod* mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size) MONO_INTERNAL;
 MonoMethod* mono_gc_get_managed_array_allocator (MonoClass *klass) MONO_INTERNAL;
 MonoMethod *mono_gc_get_managed_allocator_by_type (int atype) MONO_INTERNAL;
 

--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -220,6 +220,7 @@ typedef struct {
 	int alloc_type;
 } AllocatorWrapperInfo;
 
+int mono_gc_get_aligned_size_for_allocator (int size) MONO_INTERNAL;
 MonoMethod* mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size) MONO_INTERNAL;
 MonoMethod* mono_gc_get_managed_array_allocator (MonoClass *klass) MONO_INTERNAL;
 MonoMethod *mono_gc_get_managed_allocator_by_type (int atype) MONO_INTERNAL;

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -234,6 +234,12 @@ mono_gc_is_critical_method (MonoMethod *method)
 	return FALSE;
 }
 
+int
+mono_gc_get_aligned_size_for_allocator (int size)
+{
+	return size;
+}
+
 MonoMethod*
 mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size)
 {

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -235,7 +235,7 @@ mono_gc_is_critical_method (MonoMethod *method)
 }
 
 MonoMethod*
-mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box)
+mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size)
 {
 	return NULL;
 }

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3908,7 +3908,7 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 
 		if (managed_alloc && !(cfg->opt & MONO_OPT_SHARED)) {
 			if (known_instance_size)
-				EMIT_NEW_ICONST (cfg, iargs [1], klass->instance_size);
+				EMIT_NEW_ICONST (cfg, iargs [1], mono_gc_get_aligned_size_for_allocator (klass->instance_size));
 			return mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 		}
 
@@ -3942,7 +3942,7 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 
 		if (managed_alloc) {
 			EMIT_NEW_VTABLECONST (cfg, iargs [0], vtable);
-			EMIT_NEW_ICONST (cfg, iargs [1], klass->instance_size);
+			EMIT_NEW_ICONST (cfg, iargs [1], mono_gc_get_aligned_size_for_allocator (klass->instance_size));
 			return mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 		}
 		alloc_ftn = mono_class_get_allocation_ftn (vtable, for_box, &pass_lw);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3887,8 +3887,9 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 		MonoInst *data;
 		int rgctx_info;
 		MonoInst *iargs [2];
+		gboolean known_instance_size = !mini_is_gsharedvt_klass (cfg, klass);
 
-		MonoMethod *managed_alloc = mono_gc_get_managed_allocator (klass, for_box);
+		MonoMethod *managed_alloc = mono_gc_get_managed_allocator (klass, for_box, known_instance_size);
 
 		if (cfg->opt & MONO_OPT_SHARED)
 			rgctx_info = MONO_RGCTX_INFO_KLASS;
@@ -3905,8 +3906,11 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 			alloc_ftn = mono_object_new_specific;
 		}
 
-		if (managed_alloc && !(cfg->opt & MONO_OPT_SHARED))
+		if (managed_alloc && !(cfg->opt & MONO_OPT_SHARED)) {
+			if (known_instance_size)
+				EMIT_NEW_ICONST (cfg, iargs [1], klass->instance_size);
 			return mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
+		}
 
 		return mono_emit_jit_icall (cfg, alloc_ftn, iargs);
 	}
@@ -3933,11 +3937,12 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 		}
 
 #ifndef MONO_CROSS_COMPILE
-		managed_alloc = mono_gc_get_managed_allocator (klass, for_box);
+		managed_alloc = mono_gc_get_managed_allocator (klass, for_box, TRUE);
 #endif
 
 		if (managed_alloc) {
 			EMIT_NEW_VTABLECONST (cfg, iargs [0], vtable);
+			EMIT_NEW_ICONST (cfg, iargs [1], klass->instance_size);
 			return mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 		}
 		alloc_ftn = mono_class_get_allocation_ftn (vtable, for_box, &pass_lw);
@@ -5912,7 +5917,7 @@ mini_redirect_call (MonoCompile *cfg, MonoMethod *method,
 
 			g_assert (vtable); /*Should not fail since it System.String*/
 #ifndef MONO_CROSS_COMPILE
-			managed_alloc = mono_gc_get_managed_allocator (method->klass, FALSE);
+			managed_alloc = mono_gc_get_managed_allocator (method->klass, FALSE, FALSE);
 #endif
 			if (!managed_alloc)
 				return NULL;


### PR DESCRIPTION
Send the instance_size as an argument to the managed object allocator to reduce memory dereferences from the vtable in the generated code.