### PR TITLE
[MWF] Fix problem when button text overlaps image

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
@@ -545,8 +545,11 @@ namespace System.Windows.Forms
 				var textHeight = excess_height >= 0 ? totalArea.Height - final_image_rect.Height : textSize.Height;
 				final_text_rect = new Rectangle (AlignInRectangle (totalArea, textSize, textAlign).Left, final_image_rect.Bottom + element_spacing, textSize.Width, textHeight);
 				
-				if (final_text_rect.Bottom > totalArea.Bottom)
-					final_text_rect.Y = totalArea.Top;
+				if (final_text_rect.Bottom > totalArea.Bottom) {
+					final_text_rect.Y -= (final_text_rect.Bottom - totalArea.Bottom);
+					if (final_text_rect.Y < totalArea.Top)
+						final_text_rect.Y = totalArea.Top;
+				}
 			}
 
 			if (displayEllipsis) {


### PR DESCRIPTION
When we draw a button with ImageAboveText.ImageAboveText and the
text is too big to fit below the image we have to draw the text over
the image. This should happen from the bottom, not from the top as
the previous implementation did. With the previous code we ended up
having the text at the top of the button under certain conditions.
