### PR TITLE
Add default behavior to certificate selection callback.

### DIFF
--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -71,6 +71,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Security.Cryptography;
 
+
 #if NET_4_5
 using System.Threading.Tasks;
 #endif
@@ -102,7 +103,7 @@ namespace System.Net.Security
 
 		[MonoTODO ("userCertificateValidationCallback is not passed X509Chain and SslPolicyErrors correctly")]
 		public SslStream (Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback)
-			: this (innerStream, leaveInnerStreamOpen, userCertificateValidationCallback, null)
+			: this (innerStream, leaveInnerStreamOpen, userCertificateValidationCallback, LocalCertificateSelectionCallbackDefault)
 		{
 		}
 
@@ -596,6 +597,24 @@ namespace System.Net.Security
 			if (!IsAuthenticated)
 				throw new InvalidOperationException ("This operation is invalid until it is successfully authenticated");
 		}
+
+		private static X509Certificate LocalCertificateSelectionCallbackDefault (
+			object sender,
+			string targetHost,
+			X509CertificateCollection localCertificates,
+			X509Certificate remoteCertificate,
+			string [] acceptableIssuers)
+		{
+			if (localCertificates.Count == 0) {
+				return null;
+			}
+
+			else {
+				// Default implementation to return the first certificate out of the given collection.
+				return localCertificates[0];
+			}
+		}
+
 
 #if NET_4_5
 		public virtual Task AuthenticateAsClientAsync (string targetHost)


### PR DESCRIPTION
The current state:
In case of creation of an SslStream object using the constructor with 3
parameters (without explicitly providing the
LocalCertificateSelectionClassbackDelegate) no certificate is ever
selected.
A problomatic scenario:
1. Server and Client are using SslStream class in order to perform 2-way
ssl. The client calls AutheticateAsClient with exactly one client
certificate in the X509CertificateCollection.
2. The client initialize the SslStream class using the constructor with
3 parameters.
The operation will be failed for sure.

In fact the problem is not that easy to detect\debug - because in case
the certificate selection callback is null there is no "Fail-First"
exception - and simply the client returns a certificate with 0 bytes to
the server; then the server hit an exception.

The fix is quite simple - just add a defualt behavior of certificate
selection method (which simply selects the first certificate in the
collection).

I also tested it in .Net enviornment and it also provide a similar
default behavior.