### PR TITLE
[corlib] Fix needing write permission when reading registry values. Fixe...

### DIFF
--- a/mcs/class/corlib/Microsoft.Win32/Registry.cs
+++ b/mcs/class/corlib/Microsoft.Win32/Registry.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Win32
 			}
 
 			for (int i = 1; i < keys.Length; i++){
-				RegistryKey nkey = key.OpenSubKey (keys [i], true);
+				RegistryKey nkey = key.OpenSubKey (keys [i], setting);
 				if (nkey == null){
 					if (!setting)
 						return null;


### PR DESCRIPTION
...s #25106

ToKey() ignores the setting parameter when calling RegistryKey.OpenSubKey() and
thus always asks for write permission. If you try to read read-only keys (say
HKLM without admin rights) it will fail with a  SecurityException.
