### PR TITLE
Add DateTimeOffsetConverter to the default converters list

### DIFF
--- a/mcs/class/System/System.ComponentModel/TypeDescriptor.cs
+++ b/mcs/class/System/System.ComponentModel/TypeDescriptor.cs
@@ -409,6 +409,7 @@ public sealed class TypeDescriptor
 				defaultConverters.Add (new DictionaryEntry (typeof (Array), typeof (ArrayConverter)));
 				defaultConverters.Add (new DictionaryEntry (typeof (CultureInfo), typeof (CultureInfoConverter)));
 				defaultConverters.Add (new DictionaryEntry (typeof (DateTime), typeof (DateTimeConverter)));
+				defaultConverters.Add (new DictionaryEntry (typeof (DateTimeOffset), typeof (DateTimeOffsetConverter)));
 				defaultConverters.Add (new DictionaryEntry (typeof (Guid), typeof (GuidConverter)));
 				defaultConverters.Add (new DictionaryEntry (typeof (TimeSpan), typeof (TimeSpanConverter)));
 				defaultConverters.Add (new DictionaryEntry (typeof (ICollection), typeof (CollectionConverter)));

--- a/mcs/class/System/Test/System.ComponentModel/TypeDescriptorTests.cs
+++ b/mcs/class/System/Test/System.ComponentModel/TypeDescriptorTests.cs
@@ -1244,6 +1244,7 @@ namespace MonoTests.System.ComponentModel
 			Assert.IsTrue (TypeDescriptor.GetConverter (new Component()) is ComponentConverter, "#30");
 #endif
 			Assert.AreEqual (typeof (NullableConverter), TypeDescriptor.GetConverter (typeof (int?)).GetType (), "#31");
+			Assert.AreEqual (typeof (DateTimeOffsetConverter), TypeDescriptor.GetConverter (typeof (DateTimeOffset)).GetType (), "#32");
 		}
 		
 		[Test]


### PR DESCRIPTION
This PR solves the https://bugzilla.xamarin.com/show_bug.cgi?id=25158 bug. 

`TypeDescriptor.GetConverter(typeof(DateTimeOffset))` does not return `DateTimeOffsetConverter` instance. Instead, it returns the default converter. The following test will fail on Mono, but will pass on .NET Framework:

``` csharp
Assert.AreEqual (typeof (DateTimeOffsetConverter), TypeDescriptor.GetConverter (typeof (DateTimeOffset)).GetType ());
```

The problem is that the `DateTimeOffsetConverter` class is not being registered in the [list of default converters](https://github.com/mono/mono/blob/master/mcs/class/System/System.ComponentModel/TypeDescriptor.cs#L411). But it is registered in such a list in .NET Framework as we can see [from ReferenceSource site](http://referencesource.microsoft.com/#System/compmod/system/componentmodel/ReflectTypeDescriptionProvider.cs,136). The problem causes `NotSupportedException` to be thrown when trying to serialize/deserialize `DateTimeOffset` values to/from string.
