### PR TITLE
[MWF] Use Ctrl+PageUp/PageDown for Tab Navigation

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TabControl.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/TabControl.cs
@@ -817,6 +817,12 @@ namespace System.Windows.Forms {
 				else
 					SelectedIndex = (SelectedIndex + TabCount - 1) % TabCount;
 				ke.Handled = true;
+			} else if (ke.KeyCode == Keys.PageUp && (ke.KeyData & Keys.Control) != 0) {
+				SelectedIndex = (SelectedIndex + TabCount - 1) % TabCount;
+				ke.Handled = true;
+			} else if (ke.KeyCode == Keys.PageDown && (ke.KeyData & Keys.Control) != 0) {
+				SelectedIndex = (SelectedIndex + 1) % TabCount;
+				ke.Handled = true;
 			} else if (ke.KeyCode == Keys.Home) {
 				SelectedIndex = 0;
 				ke.Handled = true;


### PR DESCRIPTION
In the Windows implementation of the TabControl, Ctrl+PageUp
navigates to the previous tab and Ctrl+PageDown navigates to the
next tab (with both wrapping around).  This change implements this
feature in the Mono implementation.

Change-Id: Ib940bd08d5ba641f05ed91c0e789e356e68f72bb
