### PR TITLE
[MWF] Don't truncate text on ToolStripButton

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripItem.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripItem.cs
@@ -1632,14 +1632,14 @@ namespace System.Windows.Forms
 								image_rect = AlignInRectangle (contentRectangle, GetImageSize (), this.image_align);
 								break;
 							case TextImageRelation.ImageAboveText:
-								text_area = new Rectangle (contentRectangle.Left, contentRectangle.Bottom - (text_size.Height - 4), contentRectangle.Width, text_size.Height - 4);
+								text_area = new Rectangle (contentRectangle.Left, contentRectangle.Bottom - text_size.Height, contentRectangle.Width, text_size.Height);
 								image_area = new Rectangle (contentRectangle.Left, contentRectangle.Top, contentRectangle.Width, contentRectangle.Height - text_area.Height);
 
 								text_rect = AlignInRectangle (text_area, this.text_size, this.text_align);
 								image_rect = AlignInRectangle (image_area, GetImageSize (), this.image_align);
 								break;
 							case TextImageRelation.TextAboveImage:
-								text_area = new Rectangle (contentRectangle.Left, contentRectangle.Top, contentRectangle.Width, text_size.Height - 4);
+								text_area = new Rectangle (contentRectangle.Left, contentRectangle.Top, contentRectangle.Width, text_size.Height);
 								image_area = new Rectangle (contentRectangle.Left, text_area.Bottom, contentRectangle.Width, contentRectangle.Height - text_area.Height);
 
 								text_rect = AlignInRectangle (text_area, this.text_size, this.text_align);


### PR DESCRIPTION
Previous code subtracted 4 pixels of the height of the text of a
toolstrip button, presumably to leave a margin. However, margins
are handled elsewhere, so we ended up with truncated text.
