### PR TITLE
[MWF] Fix crash in multi-selection list view

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -2669,12 +2669,13 @@ namespace System.Windows.Forms
 							owner.UpdateMultiSelection (clicked_item.DisplayIndex, reselect);
 					} else {
 						clicked_item.Selected = true;
-						// Side-effects to setting Selected can possibly result in ItemsMouseUp() being called
-						// and clicked_item being set to null.  (See Xamarin bug 23591.)  In such a case, assume
-						// that there's nothing more we can do here.
-						if (clicked_item == null)
-							return;
 					}
+
+					// Side-effects of changing the selection can possibly result in ItemsMouseUp() being called and
+					// and clicked_item being set to null.  (See Xamarin bug 23591.)  In such a case, assume
+					// that there's nothing more we can do here.
+					if (clicked_item == null)
+						return;
 
 					if (owner.VirtualMode && changed) {
 						// Broken event - It's not fired from Item.Selected also


### PR DESCRIPTION
Calling owner.UpdateMultiSelection can also change the selected item,
causing a crash.

This change improves the fix for Xamarin bug #23591.
