### PR TITLE
System.Web.SessionState: simplify sessions retrival polling

### DIFF
--- a/mcs/class/System.Web/System.Web.SessionState_2.0/SessionStateModule.cs
+++ b/mcs/class/System.Web/System.Web.SessionState_2.0/SessionStateModule.cs
@@ -47,21 +47,6 @@ namespace System.Web.SessionState
 	[AspNetHostingPermission (SecurityAction.LinkDemand, Level = AspNetHostingPermissionLevel.Minimal)]
 	public sealed class SessionStateModule : IHttpModule
 	{
-		class CallbackState
-		{
-			public readonly HttpContext Context;
-			public readonly AutoResetEvent AutoEvent;
-			public readonly string SessionId;
-			public readonly bool IsReadOnly;
-
-			public CallbackState (HttpContext context, AutoResetEvent e, string sessionId, bool isReadOnly) {
-				this.Context = context;
-				this.AutoEvent = e;
-				this.SessionId = sessionId;
-				this.IsReadOnly = isReadOnly;
-			}
-		}
-
 		internal const string HeaderName = "AspFilterSessionId";
 		internal const string CookielessFlagName = "_SessionIDManager_IsCookieLess";
 
@@ -358,33 +343,19 @@ namespace System.Web.SessionState
 			return item;
 		}
 
-		void WaitForStoreUnlock (HttpContext context, string sessionId, bool isReadonly) {
-			AutoResetEvent are = new AutoResetEvent (false);
-			TimerCallback tc = new TimerCallback (StoreUnlockWaitCallback);
-			CallbackState cs = new CallbackState (context, are, sessionId, isReadonly);
-			using (Timer timer = new Timer (tc, cs, 500, 500)) {
-				try {
-					are.WaitOne (executionTimeout, false);
+		void WaitForStoreUnlock (HttpContext context, string sessionId, bool isReadOnly) {
+			DateTime dt = DateTime.Now;
+			while ((DateTime.Now - dt) < executionTimeout) {
+				Thread.Sleep(500);
+				storeData = GetStoreData (context, sessionId, isReadOnly);
+				if (storeData == null && storeLocked && (storeLockAge > executionTimeout)) {
+					handler.ReleaseItemExclusive (context, sessionId, storeLockId);
+					return;
 				}
-				catch {
-					storeData = null;
+				else if (storeData != null && !storeLocked) {
+					//we have the session
+					return;
 				}
-			}
-		}
-
-		void StoreUnlockWaitCallback (object s) {
-			CallbackState state = (CallbackState) s;
-
-			SessionStateStoreData item = GetStoreData (state.Context, state.SessionId, state.IsReadOnly);
-
-			if (item == null && storeLocked && (storeLockAge > executionTimeout)) {
-				handler.ReleaseItemExclusive (state.Context, state.SessionId, storeLockId);
-				storeData = null; // Create new state
-				state.AutoEvent.Set ();
-			}
-			else if (item != null && !storeLocked) {
-				storeData = item;
-				state.AutoEvent.Set ();
 			}
 		}
 


### PR DESCRIPTION
When using "fat" session (~2MB) and multiple (~20) simultaneous calls
the retrieval sometimes fails and lock the session.
The original code blocks on the calling thread (AutoResetEvent.WaitOne())
and uses another thread with the timer to do the polling.
If the polling succeeds, the TimerCallback AutoResetEvent.Set(),
with no guarantes that it will wake up the thread.
(see Remarks in http://msdn.microsoft.com/en-us/system.threading.eventwaithandle.set%28v=vs.110%29)

In this patch we simply replace all this code with an equivalent
loop + sleep, which give us the same behaviour
(we still block the calling thread with the sleep, but we didn't use another one)

Signed-off-by: Etienne CHAMPETIER etienne.champetier@fiducial.net
