### PR TITLE
[MWF] Fix PropertyGridTest.PropertyGrid_ArrayParentTest by returning the correct value of PropertyCategoryDefault

### DIFF
--- a/mcs/class/System/ReferenceSources/SR.cs
+++ b/mcs/class/System/ReferenceSources/SR.cs
@@ -7,6 +7,12 @@ partial class SR
 {
 	public static object GetObject (string name)
 	{
+		// The PropertyGrid code in WinForms and the corresponding tests
+		// rely on PropertyCategoryDefault returning the correct value.
+		// Handle this special case until we have proper resource lookup. 
+		if (name == "PropertyCategoryDefault")
+			return "Misc";
+
 		return name;
 	}
 


### PR DESCRIPTION
[This code](https://github.com/mono/referencesource/blob/7dc4e513eafd3fb30d34111948ef14c981264463/System/compmod/system/componentmodel/CategoryAttribute.cs#L276) in ComponentModel looks up the category name by string concatenation, which means it wasn't captured in our SR.cs.
We also can't add the correct value for PropertyCategoryDefault as a string constant to SR.cs since the value is retrieved via GetObject () and we currently just return the parameter name there.

A short-term workaround is to just special case PropertyCategoryDefault in GetObject ().
