### PR TITLE
HttpClientHandler shouldn't buffer request streams

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -232,6 +232,8 @@ namespace System.Net.Http
 		{
 			var wr = new HttpWebRequest (request.RequestUri);
 			wr.ThrowOnError = false;
+			wr.AllowReadStreamBuffering = false;
+			wr.AllowWriteStreamBuffering = false;
 
 			wr.ConnectionGroupName = connectionGroupName;
 			wr.Method = request.Method.Method;


### PR DESCRIPTION
Turned off Allow(Read/Write)StreamBuffering to bring this inline with the .NET version of the HttpClientHandler which doesn't buffer request streams.  This took my team quite some time to track down where the problem was, when we were trying to upload larges files of 1GB or more.  We verified this fix with a custom build.

We have been working with Code Beyer of Xamarin to track down the memory leak in our application in regards to very large uploads.  These two lines changed int he HttpClientHandler make all the difference.