### PR TITLE
Updated the Mono website links in the man pages

### DIFF
--- a/man/csharp.1
+++ b/man/csharp.1
@@ -358,9 +358,9 @@ gmcs(1), mcs(1), mdb(1), mono(1), pkg-config(1)
 .SH BUGS
 To report bugs in the compiler, you must file them on our bug tracking
 system, at:
-http://www.mono-project.com/Bugs 
+http://www.mono-project.com/community/bugs/
 .SH MAILING LIST
-The Mono Mailing lists are listed at http://www.mono-project.com/Mailing_Lists
+The Mono Mailing lists are listed at http://www.mono-project.com/community/help/mailing-lists/
 .SH MORE INFORMATION
 The Mono C# compiler was developed by Novell, Inc
 (http://www.novell.com, http) and is based on the
@@ -368,5 +368,5 @@ ECMA C# language standard available here:
 http://www.ecma.ch/ecma1/STAND/ecma-334.htm
 .PP
 The home page for the Mono C# compiler is at
-http://www.mono-project.com/CSharp_Compiler  information about the
-interactive mode for C# is available in http://mono-project.com/CsharpRepl
+http://www.mono-project.com/docs/about-mono/languages/csharp/ information about the
+interactive mode for C# is available in http://mono-project.com/docs/tools+libraries/tools/repl/

--- a/man/httpcfg.1
+++ b/man/httpcfg.1
@@ -54,7 +54,7 @@ httpcfg -add -port 8081 -pvk myfile.pvk -cert MyCert
 For more details on creating the certificate file and the private key,
 see the following web page:
 .PP
-http://www.mono-project.com/UsingClientCertificatesWithXSP
+http://www.mono-project.com/docs/web/using-clientcertificates-with-xsp/
 .SH FILES
 The certificates are stored in the ~/.mono/httplistener directory
 .SH AUTHOR

--- a/man/lc.1
+++ b/man/lc.1
@@ -78,7 +78,7 @@ version and publickeytoken.
 
 .SH MAILING LISTS
 Mailing lists are listed at the
-http://www.mono-project.com/Mailing_Lists
+http://www.mono-project.com/community/help/mailing-lists/
 .SH WEB SITE
 http://www.mono-project.com
 .SH SEE ALSO

--- a/man/mcs.1
+++ b/man/mcs.1
@@ -538,13 +538,13 @@ csharp(1), mdb(1), mono(1), mopen(1), pkg-config(1), sn(1)
 .SH BUGS
 To report bugs in the compiler, you must file them on our bug tracking
 system, at:
-http://www.mono-project.com/Bugs 
+http://www.mono-project.com/community/bugs/
 .SH MAILING LIST
-The Mono Mailing lists are listed at http://www.mono-project.com/Mailing_Lists
+The Mono Mailing lists are listed at http://www.mono-project.com/community/help/mailing-lists/
 .SH MORE INFORMATION
 The Mono C# compiler was developed by Novell, Inc
 (http://www.novell.com) and Xamarin Inc (http://www.xamarin.com) is based on the
 ECMA C# language standard available here:
 http://www.ecma.ch/ecma1/STAND/ecma-334.htm
 .PP
-The home page for the Mono C# compiler is at http://www.mono-project.com/CSharp_Compiler
+The home page for the Mono C# compiler is at http://www.mono-project.com/docs/about-mono/languages/csharp/

--- a/man/mdassembler.1
+++ b/man/mdassembler.1
@@ -198,7 +198,7 @@ file for a list of PATH values
 .I //node/@name
 values).
 .sp
-See also: http://www.mono-project.com/Generating_Documentation
+See also: http://www.mono-project.com/docs/tools+libraries/tools/monodoc/generating-documentation/
 .TP
 .I Create your documentation
 See also the
@@ -256,4 +256,4 @@ Visit http://lists.ximian.com/mailman/listinfo/mono-docs-list for details.
 .SH WEB SITE
 See also: http://www.mono-project.com
 and
-http://www.mono-project.com/Assembler
+http://www.mono-project.com/docs/tools+libraries/tools/mdassembler/

--- a/man/mdoc-assemble.1
+++ b/man/mdoc-assemble.1
@@ -207,4 +207,4 @@ file and looks for referenced documents to create the help source.
 .TP
 Visit http://lists.ximian.com/mailman/listinfo/mono-docs-list for details.
 .SH WEB SITE
-See also: http://www.mono-project.com/mdoc
+See also: http://www.mono-project.com/docs/tools+libraries/tools/mdoc/

--- a/man/mdoc-export-html.1
+++ b/man/mdoc-export-html.1
@@ -148,4 +148,4 @@ See the \fICREF FORMAT\fR section of \fBmdoc\fR(5) for more information.
 .TP
 Visit http://lists.ximian.com/mailman/listinfo/mono-docs-list for details.
 .SH WEB SITE
-Visit http://www.mono-project.com/mdoc for details
+Visit http://www.mono-project.com/docs/tools+libraries/tools/mdoc/ for details

--- a/man/mdoc-export-msxdoc.1
+++ b/man/mdoc-export-msxdoc.1
@@ -34,4 +34,4 @@ Display a help message and exit.
 .TP
 Visit http://lists.ximian.com/mailman/listinfo/mono-docs-list for details.
 .SH WEB SITE
-Visit http://www.mono-project.com/mdoc for details
+Visit http://www.mono-project.com/docs/tools+libraries/tools/mdoc/ for details

--- a/man/mdoc-validate.1
+++ b/man/mdoc-validate.1
@@ -51,4 +51,4 @@ documentation within that directory, recursively), use:
 .TP
 Visit http://lists.ximian.com/mailman/listinfo/mono-docs-list for details.
 .SH WEB SITE
-Visit http://www.mono-project.com/mdoc for details
+Visit http://www.mono-project.com/docs/tools+libraries/tools/mdoc/ for details

--- a/man/mdoc.1
+++ b/man/mdoc.1
@@ -195,4 +195,4 @@ mdoc-validate(1)
 .TP
 Visit http://lists.ximian.com/mailman/listinfo/mono-docs-list for details.
 .SH WEB SITE
-Visit http://www.mono-project.com/mdoc for details
+Visit http://www.mono-project.com/docs/tools+libraries/tools/mdoc/ for details

--- a/man/mono-cil-strip.1
+++ b/man/mono-cil-strip.1
@@ -11,7 +11,7 @@ longer necessary, but the metadata still is.
 .SH COPYRIGHT
 Copyright (C) 2008 Novell, Inc (http://www.novell.com)
 .SH MAILING LISTS
-Mailing lists are listed at http://www.mono-project.com/Mailing_Lists
+Mailing lists are listed at http://www.mono-project.com/community/help/mailing-lists/
 .SH LICENSE
 mono-cil-strip is licensed under the MIT/X11 license. Please read the accompayning
 MIT.X11 file for details.

--- a/man/mono-xmltool.1
+++ b/man/mono-xmltool.1
@@ -78,7 +78,7 @@ specified it reads the standard input.   If
 is not specified, the output is sent to the standard output.
 .SH MAILING LISTS
 Mailing lists are listed at the
-http://www.mono-project.com/Mailing_Lists
+http://www.mono-project.com/community/help/mailing-lists/
 .SH WEB SITE
 http://www.mono-project.com
 .SH SEE ALSO

--- a/man/mono.1
+++ b/man/mono.1
@@ -222,7 +222,7 @@ example, --tool=prefix=arm-linux-gnueabi- will make the AOT compiler run
 .I write-symbols
 Instructs the AOT compiler to emit debug symbol information.
 .PP
-For more information about AOT, see: http://www.mono-project.com/AOT
+For more information about AOT, see: http://www.mono-project.com/docs/advanced/aot/
 .RE
 .TP
 \fB--attach=[options]\fR
@@ -318,7 +318,7 @@ If the Mono runtime has been compiled with LLVM support (not available
 in all configurations), Mono will use the LLVM optimization and code
 generation engine to JIT or AOT compile.     
 .Sp
-For more information, consult: http://www.mono-project.com/Mono_LLVM
+For more information, consult: http://www.mono-project.com/docs/advanced/mono-llvm/
 .TP
 \fB--nollvm\fR
 When using a Mono that has been compiled with LLVM support, it forces
@@ -401,7 +401,7 @@ e.g. execution of Code Access Security (CAS) or non-CAS demands.
 .I core-clr
 Enables the core-clr security system, typically used for
 Moonlight/Silverlight applications.  It provides a much simpler
-security system than CAS, see http://www.mono-project.com/Moonlight
+security system than CAS, see http://www.mono-project.com/docs/web/moonlight/
 for more details and links to the descriptions of this new system. 
 .TP
 .I validil
@@ -737,7 +737,7 @@ shared library `mono-profiler-custom.so'.  This profiler module must
 be on your dynamic linker library path.
 .PP 
 A list of other third party profilers is available from Mono's web
-site (www.mono-project.com/Performance_Tips)
+site (www.mono-project.com/docs/advanced/performance-tips/)
 .PP
 Custom profiles are written as shared libraries.  The shared library
 must be called `mono-profiler-NAME.so' where `NAME' is the name of
@@ -1372,7 +1372,7 @@ libraries side-by-side with the main executable.
 .Sp
 For a complete description of recommended practices for application
 deployment, see
-http://www.mono-project.com/Guidelines:Application_Deployment
+http://www.mono-project.com/docs/getting-started/application-deployment/
 .TP
 \fBMONO_RTC\fR
 Experimental RTC support in the statistical profiler: if the user has
@@ -1756,7 +1756,7 @@ on this subject see the http://www.mono-project.com/Config_system.web
 page. 
 .SH MAILING LISTS
 Mailing lists are listed at the
-http://www.mono-project.com/Mailing_Lists
+http://www.mono-project.com/community/help/mailing-lists/
 .SH WEB SITE
 http://www.mono-project.com
 .SH SEE ALSO
@@ -1765,6 +1765,6 @@ certmgr(1), csharp(1), mcs(1), mdb(1), monocov(1), monodis(1),
 mono-config(5), mozroots(1), mprof-report(1), pdb2mdb(1), xsp(1), mod_mono(8).
 .PP
 For more information on AOT:
-http://www.mono-project.com/AOT
+http://www.mono-project.com/docs/advanced/aot/
 .PP
 For ASP.NET-related documentation, see the xsp(1) manual page

--- a/man/monolinker.1
+++ b/man/monolinker.1
@@ -202,13 +202,13 @@ Specify a parameter for a custom step.
 .SH COPYRIGHT
 Copyright (C) 2007 Novell, Inc (http://www.novell.com)
 .SH BUGS
-Bugs report are welcome at http://bugzilla.ximian.com
+Bugs report are welcome at http://bugzilla.xamarin.com
 .PP
 Product Mono Tools, Component linker.
 .SH MAILING LISTS
-Mailing lists are listed at http://www.mono-project.com/Mailing_Lists
+Mailing lists are listed at http://www.mono-project.com/community/help/mailing-lists/
 .SH WEB SITE
-http://www.mono-project.com/Linker
+http://www.mono-project.com/docs/tools+libraries/tools/linker/
 .SH AUTHORS
 The linker has been written by Jb Evain, and have been partially founded by
 the Google Summer of Code.

--- a/man/mozroots.1
+++ b/man/mozroots.1
@@ -170,7 +170,7 @@ manual page for more information on managing certificate stores.
 Copyright (C) 2005 Novell. 
 .SH MAILING LISTS
 Mailing lists are listed at the
-http://www.mono-project.com/Mailing_Lists
+http://www.mono-project.com/community/help/mailing-lists/
 .SH WEB SITE
 http://www.mono-project.com
 .SH SEE ALSO

--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -536,7 +536,7 @@ information, you could use it like this:
 .PP
 \f[B]output=|mprof-report\ --reports=monitor\ --traces\ -\f[]
 .SH WEB SITE
-http://www.mono-project.com/Profiler
+http://www.mono-project.com/docs/debug+profile/profile/profiler/
 .SH SEE ALSO
 .PP
 mono(1)

--- a/man/sqlsharp.1
+++ b/man/sqlsharp.1
@@ -518,7 +518,7 @@ licenses are available from Novell or Daniel Morgan.
 To report bugs in the compiler, you can use `bug-buddy', or you can
 file bug reports in our bug tracking system:
 .nf
-http://bugzilla.ximian.com.
+http://bugzilla.xamarin.com.
 .fi
 .PP
 .SH MAILING LISTS


### PR DESCRIPTION
Even though the old links still work, we can save everyone an unnecessary redirect by using the new links.
