### PR TITLE
Performance fix for TimeZoneInfo.GetApplicableRule(), addresses #25442

### DIFF
--- a/mcs/class/System.Core/System/TimeZoneInfo.cs
+++ b/mcs/class/System.Core/System/TimeZoneInfo.cs
@@ -1028,15 +1028,17 @@ namespace System
 
 			if (dateTime.Kind == DateTimeKind.Local && this != TimeZoneInfo.Local)
 				date = date.ToUniversalTime () + BaseUtcOffset;
-
-			if (dateTime.Kind == DateTimeKind.Utc && this != TimeZoneInfo.Utc)
+			else if (dateTime.Kind == DateTimeKind.Utc && this != TimeZoneInfo.Utc)
 				date = date + BaseUtcOffset;
+
+			// get the date component of the datetime
+			date = date.Date;
 
 			if (adjustmentRules != null) {
 				foreach (AdjustmentRule rule in adjustmentRules) {
-					if (rule.DateStart > date.Date)
+					if (rule.DateStart > date)
 						return null;
-					if (rule.DateEnd < date.Date)
+					if (rule.DateEnd < date)
 						continue;
 					return rule;
 				}


### PR DESCRIPTION
- Main use case - JSON.NET serialization of CLR objects containing DateTime fields, GetUtcOffset()=>GetApplicableRule() are the highest Mono methods in the profiler
- The property DateTime.Date access in the foreach is very expensive, this has been moved outside the foreach
- Performance for DateTime.Now passed as a parameter is 10x better than before
- This is the simplest possible change to yield an improvement, it would be better to replace the O(N) loop logic with a binary search - this yields a further 2-3x performance improvement, when master is building I may submit later
