### PR TITLE
[xbuild] Only execute PCL target "ImplicitlyExpandTargetFramework" when corresponding property is true

### DIFF
--- a/mcs/tools/xbuild/targets/Microsoft.Portable.Core.targets
+++ b/mcs/tools/xbuild/targets/Microsoft.Portable.Core.targets
@@ -12,6 +12,7 @@
 	</PropertyGroup>
 
 	<Target Name="ImplicitlyExpandTargetFramework"
+		Condition="'$(ImplicitlyExpandTargetFramework)' == 'true'"
 		DependsOnTargets="$(ImplicitlyExpandTargetFrameworkDependsOn)">
 
 		<ItemGroup>


### PR DESCRIPTION
This aligns xbuild with the MS.NET behavior.

/cc @mhutch 