### PR TITLE
[xbuild] Implement GetDirectoryNameOfFileAbove ()

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/PredefinedPropertyFunctions.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/PredefinedPropertyFunctions.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Build.BuildEngine
 				filePath = Path.Combine (path, file);
 
 				if (File.Exists (filePath))
-					return Path.GetDirectoryName (filePath);
+					return path;
 
 				path = Path.GetDirectoryName (path);
 


### PR DESCRIPTION
The method looks for the given file starting at the given path and traverses the directory tree up until the file is found or root is reached.
