### PR TITLE
Fixed bug #1849

### DIFF
--- a/mcs/class/System.Core/System/TimeZoneInfo.cs
+++ b/mcs/class/System.Core/System/TimeZoneInfo.cs
@@ -267,7 +267,7 @@ namespace System
 			if (dateTime.Kind == DateTimeKind.Local && sourceTimeZone == TimeZoneInfo.Local && destinationTimeZone == TimeZoneInfo.Local)
 				return dateTime;
 
-			DateTime utc = ConvertTimeToUtc (dateTime);
+			DateTime utc = ConvertTimeToUtc (dateTime, sourceTimeZone);
 
 			if (destinationTimeZone != TimeZoneInfo.Utc) {
 				utc = ConvertTimeFromUtc (utc, destinationTimeZone);

--- a/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
@@ -521,7 +521,7 @@ namespace MonoTests.System
 			}
 
 			[Test (Description="Fix the bug https://bugzilla.xamarin.com/show_bug.cgi?id=1849")]
-			public void ConvertTime_AjustmentConvertTimeWithSourceTiemZone() {
+			public void ConvertTime_AjustmentConvertTimeWithSourceTimeZone () {
 				
 				TimeZoneInfo easternTimeZone;
 				TimeZoneInfo pacificTimeZone;
@@ -537,15 +537,15 @@ namespace MonoTests.System
 					pacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById ("Pacific Standard Time");
 				}
 
-				DateTime lastMidnight = new DateTime(new DateTime(2012, 06, 13).Ticks, DateTimeKind.Unspecified);
-				DateTime lastMidnightAsEST = TimeZoneInfo.ConvertTime(lastMidnight, pacificTimeZone, easternTimeZone);
-				DateTime lastMidnightAsPST = TimeZoneInfo.ConvertTime(lastMidnightAsEST, easternTimeZone, pacificTimeZone);
+				DateTime lastMidnight = new DateTime (new DateTime (2012, 06, 13).Ticks, DateTimeKind.Unspecified);
+				DateTime lastMidnightAsEST = TimeZoneInfo.ConvertTime (lastMidnight, pacificTimeZone, easternTimeZone);
+				DateTime lastMidnightAsPST = TimeZoneInfo.ConvertTime (lastMidnightAsEST, easternTimeZone, pacificTimeZone);
 			
 				// Last midnight in PST as EST should be 3AM
-				DateTime expectedDate = new DateTime(2012, 06, 13, 3, 0, 0);
+				DateTime expectedDate = new DateTime (2012, 06, 13, 3, 0, 0);
 
-				Assert.AreEqual(expectedDate, lastMidnightAsEST);
-				Assert.AreEqual(lastMidnight, lastMidnightAsPST);
+				Assert.AreEqual (expectedDate, lastMidnightAsEST);
+				Assert.AreEqual (lastMidnight, lastMidnightAsPST);
 			}
 		}
 		

--- a/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
@@ -519,6 +519,34 @@ namespace MonoTests.System
 				Assert.AreEqual (0, ddt.Minute, "#3.5");
 				Assert.AreEqual (0, ddt.Second, "#3.6");
 			}
+
+			[Test (Description="Fix the bug https://bugzilla.xamarin.com/show_bug.cgi?id=1849")]
+			public void ConvertTime_AjustmentConvertTimeWithSourceTiemZone() {
+				
+				TimeZoneInfo easternTimeZone;
+				TimeZoneInfo pacificTimeZone;
+
+				if (Environment.OSVersion.Platform == PlatformID.Unix) {
+					// *nix
+					easternTimeZone = TimeZoneInfo.FindSystemTimeZoneById ("US/Eastern");
+					pacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById ("US/Pacific");	
+				}
+				else {
+					// Windows
+					easternTimeZone = TimeZoneInfo.FindSystemTimeZoneById ("Eastern Standard Time");
+					pacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById ("Pacific Standard Time");
+				}
+
+				DateTime lastMidnight = new DateTime(new DateTime(2012, 06, 13).Ticks, DateTimeKind.Unspecified);
+				DateTime lastMidnightAsEST = TimeZoneInfo.ConvertTime(lastMidnight, pacificTimeZone, easternTimeZone);
+				DateTime lastMidnightAsPST = TimeZoneInfo.ConvertTime(lastMidnightAsEST, easternTimeZone, pacificTimeZone);
+			
+				// Last midnight in PST as EST should be 3AM
+				DateTime expectedDate = new DateTime(2012, 06, 13, 3, 0, 0);
+
+				Assert.AreEqual(expectedDate, lastMidnightAsEST);
+				Assert.AreEqual(lastMidnight, lastMidnightAsPST);
+			}
 		}
 		
 		[TestFixture]


### PR DESCRIPTION
Resolution:
- Add parameter sourceTimeZone in the method ConvertTimeToUtc();


https://bugzilla.xamarin.com/show_bug.cgi?id=1849