### PR TITLE
[xbuild] Add missing property 'StandardOutputImportance' to ToolTask

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
@@ -533,6 +533,7 @@ namespace Microsoft.Build.Utilities
 		}
 
 		public bool LogStandardErrorAsError { get; set; }
+		public string StandardOutputImportance { get; set; }
 #endif
 	}
 }


### PR DESCRIPTION
It's a stub and is currently not used by xbuild.
