### PR TITLE
Fix mono_mutex_trylock on Windows

### DIFF
--- a/mono/utils/mono-mutex.h
+++ b/mono/utils/mono-mutex.h
@@ -86,7 +86,7 @@ typedef HANDLE mono_cond_t;
 #define mono_mutex_init(mutex) (InitializeCriticalSection((mutex)), 0)
 #define mono_mutex_init_recursive(mutex) (InitializeCriticalSection((mutex)), 0)
 #define mono_mutex_lock(mutex) EnterCriticalSection((mutex))
-#define mono_mutex_trylock(mutex) TryEnterCriticalSection((mutex))
+#define mono_mutex_trylock(mutex) (!TryEnterCriticalSection((mutex)))
 #define mono_mutex_unlock(mutex)  LeaveCriticalSection((mutex))
 #define mono_mutex_destroy(mutex) DeleteCriticalSection((mutex))
 


### PR DESCRIPTION
mono_mutex_trylock is expected to return nonzero on failure, while
TryEnterCriticalSection returns nonzero on success.
