### PR TITLE
[runtime] Optimizations fixes for OP_IL_SEQ_POINT compatibility.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -657,6 +657,7 @@ checktests: $(regtests)
 	for i in $(regtests); do $(RUNTIME) $$i; done
 
 rcheck: mono $(regtests)
+	for i in $(regtests); do ./test_op_il_seq_point.sh $$i || exit 1; done
 if NACL_CODEGEN
 	for i in $(regtests); do echo "running test $$i"; $(RUNTIME) $$i --exclude 'NaClDisable' || exit 1; done
 else

--- a/mono/mini/branch-opts.c
+++ b/mono/mini/branch-opts.c
@@ -278,6 +278,7 @@ mono_if_conversion (MonoCompile *cfg)
 #ifdef MONO_ARCH_HAVE_CMOV_OPS
 	MonoBasicBlock *bb;
 	gboolean changed = FALSE;
+	int filter = FILTER_NOP | FILTER_IL_SEQ_POINT;
 
 	if (!(cfg->opt & MONO_OPT_CMOV))
 		return;
@@ -317,14 +318,15 @@ mono_if_conversion (MonoCompile *cfg)
 			int dreg, tmp_reg;
 			CompType comp_type;
 
-			if (bb->last_ins && (bb->last_ins->opcode == OP_BR_REG || bb->last_ins->opcode == OP_BR))
+			branch = mono_bb_last_inst (bb, filter);
+
+			if (!branch || branch->opcode == OP_BR_REG || branch->opcode == OP_BR)
 				continue;
 
 			/* Find the compare instruction */
-			if (!bb->last_ins || !bb->last_ins->prev)
+			compare = mono_inst_prev (branch, filter);
+			if (!compare)
 				continue;
-			branch = bb->last_ins;
-			compare = branch->prev;
 
 			if (!MONO_IS_COND_BRANCH_OP (branch))
 				/* This can happen if a cond branch is optimized away */
@@ -338,22 +340,19 @@ mono_if_conversion (MonoCompile *cfg)
 			 * variable.
 			 */
 			/* FIXME: Get rid of the nops earlier */
-			ins1 = true_bb->code;
-			while (ins1 && ins1->opcode == OP_NOP)
-				ins1 = ins1->next;
-			ins2 = false_bb->code;
-			while (ins2 && ins2->opcode == OP_NOP)
-				ins2 = ins2->next;
+			ins1 = mono_bb_first_inst (true_bb, filter);
+			ins2 = mono_bb_first_inst (false_bb, filter);
+
 			if (!(ins1 && ins2 && ins1->dreg == ins2->dreg && ins1->dreg != -1))
 				continue;
 
 			simple = TRUE;
 			for (tmp = ins1->next; tmp; tmp = tmp->next)
-				if (!((tmp->opcode == OP_NOP) || (tmp->opcode == OP_BR)))
+				if (!((tmp->opcode == OP_NOP) || (tmp->opcode == OP_IL_SEQ_POINT) || (tmp->opcode == OP_BR)))
 					simple = FALSE;
 					
 			for (tmp = ins2->next; tmp; tmp = tmp->next)
-				if (!((tmp->opcode == OP_NOP) || (tmp->opcode == OP_BR)))
+				if (!((tmp->opcode == OP_NOP) || (tmp->opcode == OP_IL_SEQ_POINT) || (tmp->opcode == OP_BR)))
 					simple = FALSE;
 
 			if (!simple)
@@ -381,7 +380,7 @@ mono_if_conversion (MonoCompile *cfg)
 			if (cfg->verbose_level > 2) {
 				printf ("\tBranch -> CMove optimization in BB%d on\n", bb->block_num);
 				printf ("\t\t"); mono_print_ins (compare);
-				printf ("\t\t"); mono_print_ins (compare->next);
+				printf ("\t\t"); mono_print_ins (mono_inst_next (compare, filter));
 				printf ("\t\t"); mono_print_ins (ins1);
 				printf ("\t\t"); mono_print_ins (ins2);
 			}
@@ -489,15 +488,15 @@ mono_if_conversion (MonoCompile *cfg)
 				next_bb = bb2;
 			}
 
-			ins1 = code_bb->code;
+			ins1 = mono_bb_first_inst (code_bb, filter);
 
 			if (!ins1)
 				continue;
 
 			/* Check that code_bb is simple */
 			simple = TRUE;
-			for (tmp = ins1->next; tmp; tmp = tmp->next)
-				if (!((tmp->opcode == OP_NOP) || (tmp->opcode == OP_BR)))
+			for (tmp = ins1; tmp; tmp = tmp->next)
+				if (!((tmp->opcode == OP_NOP) || (tmp->opcode == OP_IL_SEQ_POINT) || (tmp->opcode == OP_BR)))
 					simple = FALSE;
 
 			if (!simple)
@@ -507,15 +506,15 @@ mono_if_conversion (MonoCompile *cfg)
 			if (!MONO_INS_HAS_NO_SIDE_EFFECT (ins1))
 				continue;
 
-			if (bb->last_ins && bb->last_ins->opcode == OP_BR_REG)
+			branch = mono_bb_last_inst (bb, filter);
+
+			if (!branch || branch->opcode == OP_BR_REG)
 				continue;
 
 			/* Find the compare instruction */
-
-			if (!bb->last_ins || !bb->last_ins->prev)
+			compare = mono_inst_prev (branch, filter);
+			if (!compare)
 				continue;
-			branch = bb->last_ins;
-			compare = branch->prev;
 
 			if (!MONO_IS_COND_BRANCH_OP (branch))
 				/* This can happen if a cond branch is optimized away */
@@ -545,7 +544,7 @@ mono_if_conversion (MonoCompile *cfg)
 			if (cfg->verbose_level > 2) {
 				printf ("\tBranch -> CMove optimization (2) in BB%d on\n", bb->block_num);
 				printf ("\t\t"); mono_print_ins (compare);
-				printf ("\t\t"); mono_print_ins (compare->next);
+				printf ("\t\t"); mono_print_ins (mono_inst_next (compare, filter));
 				printf ("\t\t"); mono_print_ins (ins1);
 			}
 
@@ -628,7 +627,7 @@ mono_if_conversion (MonoCompile *cfg)
 	 */
 	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
 		MonoBasicBlock *bb1, *bb2, *true_bb, *false_bb, *next_bb;
-		MonoInst *branch1, *branch2, *compare1, *ins;
+		MonoInst *branch1, *branch2, *compare1, *ins, *next;
 
 		/* Look for the IR code generated from if (<var> < 0 || v > <limit>)
 		 * after branch opts which is:
@@ -654,14 +653,14 @@ mono_if_conversion (MonoCompile *cfg)
 		next_bb = bb2;
 
 		/* Check first branch */
-		branch1 = bb->last_ins;
+		branch1 = mono_bb_last_inst (bb, filter);
 		if (!(branch1 && ((branch1->opcode == OP_IBLT) || (branch1->opcode == OP_LBLT)) && (branch1->inst_false_bb == next_bb)))
 			continue;
 
 		true_bb = branch1->inst_true_bb;
 
 		/* Check second branch */
-		branch2 = next_bb->last_ins;
+		branch2 = mono_bb_last_inst (next_bb, filter);
 		if (!branch2)
 			continue;
 
@@ -674,19 +673,20 @@ mono_if_conversion (MonoCompile *cfg)
 			continue;
 
 		/* Check first compare */
-		compare1 = bb->last_ins->prev;
+		compare1 = mono_inst_prev (mono_bb_last_inst (bb, filter), filter);
 		if (!(compare1 && ((compare1->opcode == OP_ICOMPARE_IMM) || (compare1->opcode == OP_LCOMPARE_IMM)) && compare1->inst_imm == 0))
 			continue;
 
 		/* Check second bblock */
-		ins = next_bb->code;
+		ins = mono_bb_first_inst (next_bb, filter);
 		if (!ins)
 			continue;
-		if (((ins->opcode == OP_ICOMPARE_IMM) || (ins->opcode == OP_LCOMPARE_IMM)) && ins->sreg1 == compare1->sreg1 && ins->next == branch2) {
+		next = mono_inst_next (ins, filter);
+		if (((ins->opcode == OP_ICOMPARE_IMM) || (ins->opcode == OP_LCOMPARE_IMM)) && ins->sreg1 == compare1->sreg1 && next == branch2) {
 			/* The second arg must be positive */
 			if (ins->inst_imm < 0)
 				continue;
-		} else if (((ins->opcode == OP_LDLEN) || (ins->opcode == OP_STRLEN)) && ins->dreg != compare1->sreg1 && ins->next && ins->next->opcode == OP_ICOMPARE && ins->next->sreg1 == compare1->sreg1 && ins->next->sreg2 == ins->dreg && ins->next->next == branch2) {
+		} else if (((ins->opcode == OP_LDLEN) || (ins->opcode == OP_STRLEN)) && ins->dreg != compare1->sreg1 && next && next->opcode == OP_ICOMPARE && next->sreg1 == compare1->sreg1 && next->sreg2 == ins->dreg && mono_inst_next (next, filter) == branch2) {
 			/* Another common case: if (index < 0 || index > arr.Length) */
 		} else {
 			continue;
@@ -695,7 +695,7 @@ mono_if_conversion (MonoCompile *cfg)
 		if (cfg->verbose_level > 2) {
 			printf ("\tSigned->unsigned compare optimization in BB%d on\n", bb->block_num);
 			printf ("\t\t"); mono_print_ins (compare1);
-			printf ("\t\t"); mono_print_ins (compare1->next);
+			printf ("\t\t"); mono_print_ins (mono_inst_next (compare1, filter));
 			printf ("\t\t"); mono_print_ins (ins);
 		}
 

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -168,7 +168,7 @@ restart:
 					!vreg_is_volatile (cfg, def->sreg1) &&
 					/* This avoids propagating local vregs across calls */
 					((get_vreg_to_inst (cfg, def->sreg1) || !defs [def->sreg1] || (def_index [def->sreg1] >= last_call_index) || (def->opcode == OP_VMOVE))) &&
-					!(defs [def->sreg1] && defs [def->sreg1]->next == def) &&
+					!(defs [def->sreg1] && mono_inst_next (defs [def->sreg1], FILTER_IL_SEQ_POINT) == def) &&
 					(!MONO_ARCH_USE_FPSTACK || (def->opcode != OP_FMOVE)) &&
 					(def->opcode != OP_FMOVE)) {
 					int vreg = def->sreg1;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12332,7 +12332,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	}
 
 	/* Add a sequence point for method entry/exit events */
-	if (seq_points) {
+	if (cfg->gen_seq_points_debug_data) {
 		NEW_SEQ_POINT (cfg, ins, METHOD_ENTRY_IL_OFFSET, FALSE);
 		MONO_ADD_INS (init_localsbb, ins);
 		NEW_SEQ_POINT (cfg, ins, METHOD_EXIT_IL_OFFSET, FALSE);

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3055,7 +3055,7 @@ mono_arch_peephole_pass_1 (MonoCompile *cfg, MonoBasicBlock *bb)
 	MonoInst *ins, *n;
 
 	MONO_BB_FOR_EACH_INS_SAFE (bb, n, ins) {
-		MonoInst *last_ins = ins->prev;
+		MonoInst *last_ins = mono_inst_prev (ins, FILTER_IL_SEQ_POINT);
 
 		switch (ins->opcode) {
 		case OP_ADD_IMM:
@@ -3090,6 +3090,8 @@ mono_arch_peephole_pass_1 (MonoCompile *cfg, MonoBasicBlock *bb)
 						/* Continue */
 					} else if (((ins2->opcode == OP_ICONST) || (ins2->opcode == OP_I8CONST)) && (ins2->dreg == ins->dreg) && (ins2->inst_c0 == 0)) {
 						NULLIFY_INS (ins2);
+						/* Continue */
+					} else if (ins2->opcode == OP_IL_SEQ_POINT) {
 						/* Continue */
 					} else {
 						break;
@@ -3147,9 +3149,10 @@ mono_arch_peephole_pass_2 (MonoCompile *cfg, MonoBasicBlock *bb)
 		switch (ins->opcode) {
 		case OP_ICONST:
 		case OP_I8CONST: {
+			MonoInst *next = mono_inst_next (ins, FILTER_IL_SEQ_POINT);
 			/* reg = 0 -> XOR (reg, reg) */
 			/* XOR sets cflags on x86, so we cant do it always */
-			if (ins->inst_c0 == 0 && (!ins->next || (ins->next && INST_IGNORES_CFLAGS (ins->next->opcode)))) {
+			if (ins->inst_c0 == 0 && (!next || (next && INST_IGNORES_CFLAGS (next->opcode)))) {
 				ins->opcode = OP_LXOR;
 				ins->sreg1 = ins->dreg;
 				ins->sreg2 = ins->dreg;
@@ -3185,6 +3188,8 @@ mono_arch_peephole_pass_2 (MonoCompile *cfg, MonoBasicBlock *bb)
 						/* Continue */
 					} else if (((ins2->opcode == OP_ICONST) || (ins2->opcode == OP_I8CONST)) && (ins2->dreg == ins->dreg) && (ins2->inst_c0 == 0)) {
 						NULLIFY_INS (ins2);
+						/* Continue */
+					} else if (ins2->opcode == OP_IL_SEQ_POINT) {
 						/* Continue */
 					} else {
 						break;
@@ -6920,11 +6925,12 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	if (!args_clobbered) {
 		MonoBasicBlock *first_bb = cfg->bb_entry;
 		MonoInst *next;
+		int filter = FILTER_IL_SEQ_POINT;
 
-		next = mono_bb_first_ins (first_bb);
+		next = mono_bb_first_inst (first_bb, filter);
 		if (!next && first_bb->next_bb) {
 			first_bb = first_bb->next_bb;
-			next = mono_bb_first_ins (first_bb);
+			next = mono_bb_first_inst (first_bb, filter);
 		}
 
 		if (first_bb->in_count > 1)
@@ -6934,11 +6940,6 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 			ArgInfo *ainfo = cinfo->args + i;
 			gboolean match = FALSE;
 
-			while (next && next->opcode == OP_IL_SEQ_POINT)
-				next = next->next;
-			if (!next)
-				break;
-			
 			ins = cfg->args [i];
 			if (ins->opcode != OP_REGVAR) {
 				switch (ainfo->storage) {
@@ -6975,7 +6976,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 			}
 
 			if (match) {
-				next = next->next;
+				next = mono_inst_next (next, filter);
 				//next = mono_inst_list_next (&next->node, &first_bb->ins_list);
 				if (!next)
 					break;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -2123,7 +2123,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 		}
 	}
 
-	if (cfg->gen_seq_points) {
+	if (cfg->gen_seq_points_debug_data) {
 		if (cfg->soft_breakpoints) {
 			MonoInst *ins = mono_compile_create_var (cfg, &mono_defaults.int_class->byval_arg, OP_LOCAL);
 			ins->flags |= MONO_INST_VOLATILE;

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -2574,7 +2574,8 @@ mono_is_regsize_var (MonoType *t)
 void
 mono_peephole_ins (MonoBasicBlock *bb, MonoInst *ins)
 {
-	MonoInst *last_ins = ins->prev;
+	int filter = FILTER_IL_SEQ_POINT;
+	MonoInst *last_ins = mono_inst_prev (ins, filter);
 
 	switch (ins->opcode) {
 	case OP_MUL_IMM: 
@@ -2598,7 +2599,7 @@ mono_peephole_ins (MonoBasicBlock *bb, MonoInst *ins)
 		 * OP_MOVE reg1, reg2
 		 */
 		if (last_ins && last_ins->opcode == OP_GC_LIVENESS_DEF)
-			last_ins = last_ins->prev;
+			last_ins = mono_inst_prev (ins, filter);
 		if (last_ins &&
 			(((ins->opcode == OP_LOADI4_MEMBASE) && (last_ins->opcode == OP_STOREI4_MEMBASE_REG)) ||
 			 ((ins->opcode == OP_LOAD_MEMBASE) && (last_ins->opcode == OP_STORE_MEMBASE_REG))) &&

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1942,6 +1942,66 @@ enum {
 
 typedef void (*MonoInstFunc) (MonoInst *tree, gpointer data);
 
+enum {
+	FILTER_IL_SEQ_POINT = 1 << 0,
+	FILTER_NOP          = 1 << 1,
+};
+
+static inline gboolean
+mono_inst_filter (MonoInst *ins, int filter)
+{
+	if (!ins || !filter)
+		return FALSE;
+
+	if ((filter & FILTER_IL_SEQ_POINT) && ins->opcode == OP_IL_SEQ_POINT)
+		return TRUE;
+
+	if ((filter & FILTER_NOP) && ins->opcode == OP_NOP)
+		return TRUE;
+
+	return FALSE;
+}
+
+static inline MonoInst*
+mono_inst_next (MonoInst *ins, int filter)
+{
+	do {
+		ins = ins->next;
+	} while (mono_inst_filter (ins, filter));
+
+	return ins;
+}
+
+static inline MonoInst*
+mono_inst_prev (MonoInst *ins, int filter)
+{
+	do {
+		ins = ins->prev;
+	} while (mono_inst_filter (ins, filter));
+
+	return ins;
+}
+
+static inline MonoInst*
+mono_bb_first_inst (MonoBasicBlock *bb, int filter)
+{
+	MonoInst *ins = bb->code;
+	if (mono_inst_filter (ins, filter))
+		ins = mono_inst_next (ins, filter);
+
+	return ins;
+}
+
+static inline MonoInst*
+mono_bb_last_inst (MonoBasicBlock *bb, int filter)
+{
+	MonoInst *ins = bb->last_ins;
+	if (mono_inst_filter (ins, filter))
+		ins = mono_inst_prev (ins, filter);
+
+	return ins;
+}
+
 /* main function */
 MONO_API int         mono_main                      (int argc, char* argv[]);
 MONO_API void        mono_set_defaults              (int verbose_level, guint32 opts);

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+ TESTFILE=$1
+
+get_code_length () {
+    ./mono -v $1 | grep 'code length' | sed 's/0x[0-9a-f]*/0x/g' | sed -E 's/Method (\(.*\) )?//g' | sort
+}
+
+sdiff_code_length () {
+    sdiff -s -w 1000 <(echo "$(get_code_length $1)") <(echo "$(MONO_DEBUG=gen-compact-seq-points  get_code_length $1)")
+}
+
+DIFF_FILE=mktemp
+
+echo "$(sdiff_code_length $TESTFILE)" > $DIFF_FILE
+
+CHANGES=0
+
+while read line; do
+	if [ "$line" != "" ]; then
+		CHANGES=$((CHANGES+1))
+	    echo $line
+	fi
+done < $DIFF_FILE
+
+if [ $CHANGES != 0 ]
+then
+	echo ''
+	echo "Detected OP_IL_SEQ_POINT incompatibility on $TESTFILE"
+	echo "  $CHANGES methods differ in size when sequence points are enabled."
+	echo '  This is probably caused by a runtime optimization that is not handling OP_IL_SEQ_POINT'
+	echo '  More details can be obtained by comparing the output of the following commands:'
+	echo "    MONO_VERBOSE_METHOD=testname mono/mini/mono $TESTFILE"
+	echo "    MONO_DEBUG=gen-compact-seq-points #MONO_VERBOSE_METHOD=testname mono/mini/mono $TESTFILE"
+	exit 1
+fi


### PR DESCRIPTION
JIT optimizations were broken by the introduction of OP_IL_SEQ_POINT in the middle of the IR code.

The issues were fixed by modifying some `MonoInst *ins` and  `MonoBasicBlock *bb ` field usages to ignore OP_IL_SEQ_POINT. This was done with new helper methods:
 - `mono_inst_next (ins, FILTER_IL_SEQ_POINT)` replaces `ins->next` 
 - `mono_inst_prev (ins, FILTER_IL_SEQ_POINT)` replaces `ins->prev`
 - `mono_bb_first_inst (bb, FILTER_IL_SEQ_POINT)` replaces `bb->code`
 - `mono_bb_last_inst (bb, FILTER_IL_SEQ_POINT)` replaces `bb->last_ins`

Added test_op_il_seq_point.sh, it checks that each method of tested assemblies is equal with and without sequence points enabled. 
For now the test just compare methods size, which can be problem when an optimization does not change the size of the method. 
test_op_il_seq_point.sh will updated to compare the generated native code in an upcoming commit.