### PR TITLE
[Sdb] Ignore hidden sequence points

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8385,7 +8385,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 				MonoDebugSourceInfo *sinfo = g_ptr_array_index (source_file_list, source_files [i]);
 				srcfile = sinfo->source_file;
 			}
-			DEBUG (10, fprintf (log_file, "IL%x -> %s:%d %d\n", il_offsets [i], srcfile, line_numbers [i], column_numbers ? column_numbers [i] : -1));
+			DEBUG (10, fprintf (log_file, "IL%x -> %s:%d %d %d %d\n", il_offsets [i], srcfile, line_numbers [i], column_numbers ? column_numbers [i] : -1, end_line_numbers ? end_line_numbers [i] : -1, end_column_numbers ? end_column_numbers [i] : -1));
 			buffer_add_int (buf, il_offsets [i]);
 			buffer_add_int (buf, line_numbers [i]);
 			if (CHECK_PROTOCOL_VERSION (2, 13))


### PR DESCRIPTION
Hidden sequence points are created by Roslyn or csc.exe + pdb2mdb...
We could stop emitting them in pdb2mdb and Roslyn but prefer to do this in runtime for two reasons:
* We would need to worry about syncing modified pdb2mdb with runtime
* Maybe we will want to use this hidden sequence points in future inside Runtime and we will have to modify pdb2mdb again...