### PR TITLE
Revert "Fix build errors in mono-context.c on ppc64el"

### DIFF
--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -4,7 +4,6 @@
 #include <mono/arch/ppc/ppc-codegen.h>
 #include <mono/utils/mono-sigcontext.h>
 #include <mono/utils/mono-context.h>
-#include <mono/metadata/object.h>
 #include <glib.h>
 
 #ifdef __mono_ppc64__

--- a/mono/utils/mono-context.c
+++ b/mono/utils/mono-context.c
@@ -424,7 +424,6 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 #elif (((defined(__ppc__) || defined(__powerpc__) || defined(__ppc64__)) && !defined(MONO_CROSS_COMPILE))) || (defined(TARGET_POWERPC))
 
 #include <mono/utils/mono-context.h>
-#include <mono/mini/mini-ppc.h>
 
 void
 mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)


### PR DESCRIPTION
Reverts mono/mono#1475

The pull request needs to be explicitly licensed as MIT to be accepted.
