### PR TITLE
[mcs] xml doc: return correct signature for nested array

### DIFF
--- a/mcs/mcs/typespec.cs
+++ b/mcs/mcs/typespec.cs
@@ -541,7 +541,10 @@ namespace Mono.CSharp
 					if (i > 0)
 						sb.Append (",");
 
-					sb.Append (TypeArguments[i].GetExplicitNameSignatureForDocumentation ());
+					if (TypeArguments[i].IsArray)
+						sb.Append (TypeArguments[i].ToString ());
+					else
+						sb.Append (TypeArguments[i].GetExplicitNameSignatureForDocumentation ());
 				}
 				sb.Append ("}");
 			}

--- a/mcs/tests/test-xml-071-ref.xml
+++ b/mcs/tests/test-xml-071-ref.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>test-xml-071</name>
+    </assembly>
+    <members>
+        <member name="M:Test`1.X{T[]}#Consume(Y{`0[]})">
+            <summary>This is the consume method.</summary></member>
+    </members>
+</doc>

--- a/mcs/tests/test-xml-071.cs
+++ b/mcs/tests/test-xml-071.cs
@@ -1,0 +1,30 @@
+// Compiler options: -doc:xml-071.xml
+
+interface X<out TOutput>
+{
+	TOutput Consume (Y<TOutput> a);
+}
+
+interface Y<in TInput>
+{
+}
+
+interface Z<in TInput, out TOutput> : Y<TInput>, X<TOutput>
+{
+}
+
+class Test<T> : Z<T, T[]>
+{
+	/// <summary>This is the consume method.</summary>
+	T[] X<T[]>.Consume (Y<T[]> target)
+	{
+		return null;
+	}
+}
+
+class Program
+{
+	static void Main ()
+	{
+	}
+}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=25544

Note: I have no idea if this is the correct fix (relying on `ToString ()` sounds less than ideal), but it does fix the test case in the bug report :smile: 