### PR TITLE
[Microsoft.Build.Tasks] Rework CodeTaskFactory to use CodeDom and implement parameter support

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/CodeTaskFactory.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/CodeTaskFactory.cs
@@ -110,31 +110,85 @@ namespace Microsoft.Build.Tasks
 					break;
 				}
 			}
-			if (language == "vb")
-				throw new NotImplementedException (string.Format ("{0} is not supported language for inline task", language));
-			if (language != "cs")
+
+			if (language != "cs" && language != "vb")
 				throw new InvalidProjectFileException (null, string.Format ("{0} is not supported language for inline task", language), "MSB", "4175", null);
-			string gen = null;
-			// The documentation says "ITask", but the very first example shows "Log" which is not in ITask! It is likely that the generated code uses Task or TaskExtension.
-			string classTemplate = @"public class " + taskName + " : Microsoft.Build.Utilities.Task { @@EXECUTE@@ }";
-			foreach (var ns in namespace_uses)
-				gen += "using " + ns + ";\n";
-			switch (type) {
-			case "Class":
-				gen += code;
-				break;
-			case "Method":
-				gen += classTemplate.Replace ("@@EXECUTE@@", code);
-				break;
-			case "Fragment":
-				gen += classTemplate.Replace ("@@EXECUTE@@", "public override bool Execute () { " + code + " return true; }");
-				break;
+
+			CodeCompileUnit ccu;
+
+			if (type == "Class") {  // 'code' contains the whole class that implements the task
+				ccu = new CodeSnippetCompileUnit (code);
+			}
+			else {  // 'code' contains parts of the class that implements the task
+				ccu = new CodeCompileUnit ();
+				var nsp = new CodeNamespace ();
+				nsp.Imports.AddRange (namespace_uses.Select (x => new CodeNamespaceImport (x)).ToArray ());
+				ccu.Namespaces.Add (nsp);
+
+				var taskClass = new CodeTypeDeclaration {
+					IsClass = true,
+					Name = taskName,
+					TypeAttributes = TypeAttributes.Public
+				};
+
+				var parameters = new List<CodeMemberProperty> ();
+				var parametersBackingFields = new List<CodeMemberField> ();
+
+				// add a public property + backing field for each parameter
+				foreach (var param in parameter_group) {
+					var prop = new CodeMemberProperty {
+						Attributes = MemberAttributes.Public | MemberAttributes.Final,
+						Name = param.Value.Name,
+						Type = new CodeTypeReference (param.Value.PropertyType)
+					};
+
+					var propBf = new CodeMemberField {
+						Attributes = MemberAttributes.Private,
+						Name = "_" + prop.Name,
+						Type = prop.Type
+					};
+
+					// add getter and setter to the property
+					prop.GetStatements.Add (new CodeMethodReturnStatement (new CodeFieldReferenceExpression (new CodeThisReferenceExpression (), propBf.Name)));
+					prop.SetStatements.Add (new CodeAssignStatement (new CodeFieldReferenceExpression (new CodeThisReferenceExpression (), propBf.Name), new CodePropertySetValueReferenceExpression ()));
+
+					parameters.Add (prop);
+					parametersBackingFields.Add (propBf);
+				}
+
+				taskClass.Members.AddRange (parameters.ToArray ());
+				taskClass.Members.AddRange (parametersBackingFields.ToArray ());
+				taskClass.BaseTypes.Add ("Microsoft.Build.Utilities.Task");  // The documentation says "ITask", but the very first example shows "Log" which is not in ITask! It is likely that the generated code uses Task or TaskExtension.
+
+				if (type == "Method") {  // 'code' contains the 'Execute' method directly
+					taskClass.Members.Add (new CodeSnippetTypeMember (code));
+				}
+				else if (type == "Fragment") {  // 'code' contains the body of the 'Execute' method
+					var method = new CodeMemberMethod {
+						Attributes = MemberAttributes.Public | MemberAttributes.Override,
+						Name = "Execute",
+						ReturnType = new CodeTypeReference (typeof (bool))
+					};
+
+					// add the code and a 'return true' at the end of the method
+					method.Statements.Add (new CodeSnippetStatement (code));
+					method.Statements.Add (new CodeMethodReturnStatement (new CodePrimitiveExpression (true)));
+
+					taskClass.Members.Add (method);
+				}
+				else {
+					throw new ArgumentException ("Invalid type: " + type);
+				}
+
+				nsp.Types.Add (taskClass);
 			}
 
 			var cscParams = new CompilerParameters ();
 			cscParams.ReferencedAssemblies.Add ("Microsoft.Build.Framework.dll");
 			cscParams.ReferencedAssemblies.Add ("Microsoft.Build.Utilities.v4.0.dll"); // since we use Task, it depends on this dll.
-			var results = new CSharpCodeProvider ().CompileAssemblyFromSource (cscParams, gen);
+			cscParams.ReferencedAssemblies.AddRange (references.ToArray ());
+			cscParams.GenerateInMemory = true;
+			var results = CodeDomProvider.CreateProvider (language).CompileAssemblyFromDom (cscParams, ccu);
 			var errors = new CompilerError [results.Errors.Count];
 			results.Errors.CopyTo (errors, 0);
 			if (errors.Any (e => !e.IsWarning)) {

--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/CodeTaskFactoryTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/CodeTaskFactoryTest.cs
@@ -79,6 +79,61 @@ Log.LogWarning(""Hello, world!"");
 		}
 
 		[Test]
+		public void HelloWithParameter ()
+		{
+			string project_xml = @"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <UsingTask
+    TaskName='DoNothing'
+    TaskFactory='CodeTaskFactory'
+    AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll' >
+    <ParameterGroup>
+      <Message ParameterType='System.String' Required='true' />
+    </ParameterGroup>
+    <Task>
+      <Code Type='Fragment' Language='cs'>
+<![CDATA[
+Log.LogWarning(""Message: "" + Message);
+]]>      </Code>
+    </Task>
+  </UsingTask>
+  <Target Name='default'>
+    <DoNothing Message='Hello, world!'/>
+  </Target>
+</Project>";
+			var root = ProjectRootElement.Create (XmlReader.Create (new StringReader (project_xml))); 
+			root.FullPath = "CodeTaskFactoryTest.HelloWithParameter.proj";
+			var project = new Project (root);
+			Assert.IsTrue (project.Build (new ConsoleLogger (LoggerVerbosity.Diagnostic)), "Build");
+		}
+
+		[Test]
+		public void Reference ()
+		{
+			string project_xml = @"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <UsingTask
+    TaskName='DoNothing'
+    TaskFactory='CodeTaskFactory'
+    AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll' >
+    <ParameterGroup />
+    <Task>
+      <Reference Include='System.Drawing' />
+      <Code Type='Fragment' Language='cs'>
+<![CDATA[
+Log.LogWarning(""Color: "" + System.Drawing.Color.CornflowerBlue);
+]]>      </Code>
+    </Task>
+  </UsingTask>
+  <Target Name='default'>
+    <DoNothing />
+  </Target>
+</Project>";
+			var root = ProjectRootElement.Create (XmlReader.Create (new StringReader (project_xml))); 
+			root.FullPath = "CodeTaskFactoryTest.Reference.proj";
+			var project = new Project (root);
+			Assert.IsTrue (project.Build (new ConsoleLogger (LoggerVerbosity.Diagnostic)), "Build");
+		}
+
+		[Test]
 		public void MultipleCodeElements ()
 		{
 			string project_xml = @"<Project ToolsVersion='4.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>


### PR DESCRIPTION
Removed the old string-based code and use CodeDom APIs for everything.
Implemented parameter support by adding the necessary properties to the generated class.
Fixed bug where the task references weren't passed to the compiler.
This should now work with VB code as well (assuming the compiler is installed).
