### PR TITLE
Fix Render problem when the Multiline TextBox, is in a UpdatePanel or an...

### DIFF
--- a/mcs/class/System.Web/System.Web.UI.WebControls/TextBox.cs
+++ b/mcs/class/System.Web/System.Web.UI.WebControls/TextBox.cs
@@ -209,13 +209,8 @@ namespace System.Web.UI.WebControls {
 		{
 			// Why didn't msft just override RenderContents!?
 			RenderBeginTag (w);
-			if (TextMode == TextBoxMode.MultiLine) {
-#if NET_4_0
-				w.WriteLine ();
-#endif
+			if (TextMode == TextBoxMode.MultiLine) 
 				HttpUtility.HtmlEncode (Text, w);
-			}
-			
 			RenderEndTag (w);
 		}
 		


### PR DESCRIPTION
...other container

In the next example you can See, the problem the TextBox appends to begin a tab ('\t') character

&lt;%@ Page Language=&quot;C#&quot; AutoEventWireup=&quot;true&quot; %&gt;
&lt;!DOCTYPE html&gt;
&lt;html xmlns=&quot;http://www.w3.org/1999/xhtml&quot;&gt;
&lt;head runat=&quot;server&quot;&gt;
    &lt;title&gt;&lt;/title&gt;
&lt;/head&gt;
&lt;body&gt;
    &lt;form id=&quot;form1&quot; runat=&quot;server&quot;&gt;
    &lt;div&gt;
        &lt;asp:ScriptManager runat=&quot;server&quot; ID=&quot;S&quot;&gt;&lt;/asp:ScriptManager&gt;
        &lt;asp:UpdatePanel runat=&quot;server&quot; ID=&quot;U&quot; Visible=&quot;true&quot; UpdateMode=&quot;Conditional&quot;&gt;
        &lt;ContentTemplate&gt;
            &lt;asp:TextBox runat=&quot;server&quot; ID=&quot;T&quot; TextMode=&quot;MultiLine&quot; Text=&quot;Text&quot;&gt;&lt;/asp:TextBox&gt;
        &lt;/ContentTemplate&gt;
        &lt;/asp:UpdatePanel&gt;
        &lt;asp:TextBox runat=&quot;server&quot; ID=&quot;E&quot; TextMode=&quot;MultiLine&quot; Text=&quot;Text&quot;&gt;&lt;/asp:TextBox&gt;
    &lt;/div&gt;
    &lt;/form&gt;
&lt;/body&gt;
&lt;/html&gt;
