### PR TITLE
Fix for issues 9653, 22297 

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -1368,7 +1368,6 @@ namespace System.Windows.Forms {
 					} else {
 						Controls.Remove (editingControl);
 					}
-					editingControl.Dispose();
 				}
 				
 				


### PR DESCRIPTION
This is a fix for the System.ObjectDisposedException caused by editing a text cell in a DataGridView control a second time.
The issue was caused by calling dispose on a static DataGridViewTextBoxEditingControl object after it has been set as the editingControl for the DataGridView

The full explanation of the cause of this issue is located in this comment https://bugzilla.xamarin.com/show_bug.cgi?id=9653#c5