### PR TITLE
[utils] Fix array index out of bounds in lock-free-queue

### DIFF
--- a/mono/utils/lock-free-queue.c
+++ b/mono/utils/lock-free-queue.c
@@ -183,7 +183,7 @@ get_dummy (MonoLockFreeQueue *q)
 static gboolean
 is_dummy (MonoLockFreeQueue *q, MonoLockFreeQueueNode *n)
 {
-	return n >= &q->dummies [0].node && n < &q->dummies [MONO_LOCK_FREE_QUEUE_NUM_DUMMIES].node;
+	return n >= &q->dummies [0].node && n < &q->dummies [MONO_LOCK_FREE_QUEUE_NUM_DUMMIES - 1].node;
 }
 
 static gboolean


### PR DESCRIPTION
#define MONO_LOCK_FREE_QUEUE_NUM_DUMMIES 2
q->dummies => MonoLockFreeQueueDummy dummies [MONO_LOCK_FREE_QUEUE_NUM_DUMMIES];