### PR TITLE
AppSettings 'file' attribute supports a relative path to the target of a...

### DIFF
--- a/mcs/class/Mono.Posix/Makefile
+++ b/mcs/class/Mono.Posix/Makefile
@@ -3,6 +3,7 @@ SUBDIRS =
 include ../../build/rules.make
 
 LIBRARY = Mono.Posix.dll
+LOCAL_MCS_FLAGS = -lib:$(bare_libdir)
 # Don't warn about [Obsolete] members, as there are now *lots* of [Obsolete]
 # members, generating volumes of output.
 LIB_MCS_FLAGS = /unsafe /r:$(corlib) /r:System.dll /nowarn:0618,612

--- a/mcs/class/System.Configuration/Makefile
+++ b/mcs/class/System.Configuration/Makefile
@@ -7,14 +7,15 @@ LIBRARY = System.Configuration.dll
 
 LOCAL_MCS_FLAGS = -lib:$(secxml_libdir) -lib:$(bare_libdir)
 test_remove = $(LOCAL_MCS_FLAGS)
-LIB_MCS_FLAGS = -r:$(corlib) -r:System.dll -r:System.Xml.dll -r:System.Security.dll -nowarn:618 
-TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) 
+LIB_MCS_FLAGS = -r:$(corlib) -r:System.dll -r:System.Xml.dll -r:System.Security.dll -r:Mono.Posix.dll -nowarn:618
+TEST_MCS_FLAGS = $(LIB_MCS_FLAGS)
 
 include ../../build/library.make
 
 configuration_library_deps = \
 	$(secxml_libdir)/System.dll 	\
 	$(the_libdir_base)System.Security.dll 	\
+	$(the_libdir_base)Mono.Posix.dll 	\
 	$(bare_libdir)/System.Xml.dll
 
 $(build_lib): $(configuration_library_deps)
@@ -27,6 +28,9 @@ $(secxml_libdir)/System.dll:
 
 $(the_libdir_base)System.Security.dll:
 	(cd ../System.Security; $(MAKE) $@)
+
+$(the_libdir_base)Mono.Posix.dll:
+	(cd ../Mono.Posix; $(MAKE) $@)
 
 $(bare_libdir)/System.Xml.dll:
 	(cd ../System.XML; $(MAKE) $@)

--- a/mcs/class/System.Configuration/System.Configuration/AppSettingsSection.cs
+++ b/mcs/class/System.Configuration/System.Configuration/AppSettingsSection.cs
@@ -4,6 +4,7 @@
 // Authors:
 //	Duncan Mak (duncan@ximian.com)
 //	Chris Toshok (toshok@ximian.com)
+//	Dave Curylo (curylod@asme.org)
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -71,14 +72,24 @@ namespace System.Configuration {
 
 			if (File != "") {
 				try {
-					string filePath = File;
-					if (!Path.IsPathRooted (filePath))
-						filePath = Path.Combine (Path.GetDirectoryName (Configuration.FilePath), filePath);
-
-					Stream s = System.IO.File.OpenRead (filePath);
-					XmlReader subreader = new ConfigXmlTextReader (s, filePath);
-					base.DeserializeElement (subreader, serializeCollectionKey);
-					s.Close ();
+					string filePath;
+					if (!Path.IsPathRooted (File)) {
+						// Relative path, we should ensure check relative to the configuration file, which may be a symlink on *nix
+						string directory;
+						var p = Environment.OSVersion.Platform;
+						if ((p == PlatformID.Unix) || (p == PlatformID.MacOSX) || ((int)p == 128)) {
+							directory = Mono.Unix.UnixPath.GetRealPath (Path.GetDirectoryName (Configuration.FilePath));
+						} else {
+							directory = Path.GetDirectoryName (Configuration.FilePath);
+						}
+						filePath = Path.Combine (directory, File);
+					} else {
+						filePath = File;
+					}
+					using (Stream s = System.IO.File.OpenRead (filePath)) {
+						XmlReader subreader = new ConfigXmlTextReader (s, filePath);
+						base.DeserializeElement (subreader, serializeCollectionKey);
+					}
 				}
 				catch {
 					// nada, we just ignore a missing/unreadble file

--- a/mcs/class/System.Configuration/Test/System.Configuration/AppSettingsSectionTest.cs
+++ b/mcs/class/System.Configuration/Test/System.Configuration/AppSettingsSectionTest.cs
@@ -4,6 +4,7 @@
 //
 // Author:
 //	Tom Philpot  <tom.philpot@logos.com>
+//	Dave Curylo  <curylod@asme.org>
 //
 // Copyright (C) 2014 Logos Bible Software
 //
@@ -28,9 +29,12 @@
 //
 
 using System;
+using System.CodeDom.Compiler;
 using System.Configuration;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using Microsoft.CSharp;
 using NUnit.Framework;
 
 namespace MonoTests.System.Configuration
@@ -58,6 +62,11 @@ namespace MonoTests.System.Configuration
 			Directory.SetCurrentDirectory (originalCurrentDir);
 			if (Directory.Exists (tempFolder))
 				Directory.Delete (tempFolder, true);
+			File.Delete ("TestLoadsFromFileAttribute.exe");
+			File.Delete ("TestLoadsFromFileAttribute.exe.config");
+			File.Delete ("extra.config");
+			if (Directory.Exists ("a"))
+				Directory.Delete ("a", true);
 		}
 		
 		[Test]
@@ -70,6 +79,40 @@ namespace MonoTests.System.Configuration
 			Assert.AreEqual ("Test/appSettings.config", config.AppSettings.File, "#A01");
 			Assert.AreEqual ("foo", ConfigurationSettings.AppSettings["TestKey1"], "#A02");
 			Assert.AreEqual ("bar", ConfigurationSettings.AppSettings["TestKey2"], "#A03");
+		}
+
+		[Test]
+		public void TestLoadsFileAttributeSymlinkPath () {
+			// Compile a test executable with codedom that returns a string from the file
+			// Create an app.config file.
+			// Create an extra.config file at a relative path.
+			// Create a symlink to the extra.config that is referenced by the app.config file.
+			// Process.Start the executable from a different directory (up one).
+			// Should not find the setting from extra.config before the fix
+			// Should find it after the fix.
+			var code = "using System; using System.Configuration; namespace Testing { class LoadsFromFileAttribute { public static void Main(string[] args) { if (ConfigurationManager.AppSettings[\"foo\"] == \"bar\") Environment.Exit (100); }  } }";
+			var codeProvider = new CSharpCodeProvider ();
+			var icc = codeProvider.CreateCompiler ();
+			var parameters = new CompilerParameters ();
+			parameters.GenerateExecutable = true;
+			parameters.OutputAssembly = "TestLoadsFromFileAttribute.exe";
+			parameters.ReferencedAssemblies.Add ("System.Configuration");
+			CompilerResults results = icc.CompileAssemblyFromSource (parameters, code);
+			if (results.Errors.Count > 0) {
+				Assert.Fail (String.Format ("Test assembly failed to build. Errors : {0}", results.Errors [0]));
+			}
+			File.WriteAllText ("TestLoadsFromFileAttribute.exe.config", "<configuration><appSettings file=\"extra.config\"/></configuration>");
+			Directory.CreateDirectory ("a/b/c");
+			File.WriteAllText ("a/b/c/extra.config", "<appSettings><add key=\"foo\" value=\"bar\" /></appSettings>");
+			var f = new Mono.Unix.UnixFileInfo ("a/b/c/extra.config");
+			f.CreateSymbolicLink ("extra.config");
+			var pwd = Environment.CurrentDirectory;
+			var p = Process.Start (new ProcessStartInfo {
+				FileName = "mono",
+				Arguments = "TestLoadsFromFileAttribute.exe"
+			});
+			p.WaitForExit ();
+			Assert.AreEqual (100, p.ExitCode, "Couldn't find setting from extra.config file when loaded by symlink.");
 		}
 	}
 }


### PR DESCRIPTION
... symlink to the .config on *nix systems.

Added unit test to check that the 'file' attribute in App.config resolves to a .config file at a relative path to the symlink target .config.

This change is released under the MIT license.