### PR TITLE
Fix unreliable async_read.exe test

### DIFF
--- a/mono/tests/async_read.cs
+++ b/mono/tests/async_read.cs
@@ -28,6 +28,7 @@ class Test {
 		s.Position = 0;
 		
 		do {
+			buf = new byte [1];
 			ar = s.BeginRead (buf, 0, 1, ac, buf);
 		} while (s.EndRead (ar) == 1);
 		sum -= buf [0];


### PR DESCRIPTION
The async_read.exe test sometimes fails on [Jenkins](https://jenkins.mono-project.com/job/test-mono-mainline/label=debian-i386/665/consoleFull#-761061049fae71707-658d-4eb8-a859-cc8a41492d83) (from the looks of it more often on i386) and on Wrench [1](http://wrench.mono-project.com/Wrench/WebServices/Download.aspx?work_id=6561760&filename=runtime.log), [2](http://wrench.mono-project.com/Wrench/WebServices/Download.aspx?work_id=6559699&filename=runtime.log).

I decided to try it out on MS.NET and it failed pretty much everytime there, so I knew something was fishy with the test. I *think* the issue has something to do with the buffer being passed through the IAsyncResult, but I'm not really sure.

This is before this patch:
```
C:\>async_read.exe
CSUM: 147627 147650

C:\>async_read.exe
CSUM: 147487 147650

C:\>async_read.exe
CSUM: 147339 147650

C:\>async_read.exe
CSUM: 147339 147650
```

and this after:
```
C:\>async_read.exe
CSUM: 148289 148289

C:\>async_read.exe
CSUM: 148289 148289

C:\>async_read.exe
CSUM: 148289 148289

C:\>async_read.exe
CSUM: 148289 148289
```

... so this fixes it on .NET at least and I hope on Mono too :)