### PR TITLE
Add g_getdtablesize to list of acceptable g_* symbols in mono, for test-eglib-remap

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -700,7 +700,7 @@ tests: $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la $(PREREQSI_IL) $(PREREQSI_
 #
 # Test that no symbols are missed in eglib-remap.h
 #
-OK_G_SYMBOLS='g_list\|g_slist\|g_concat_dir_and_file\|g_Ctoc'
+OK_G_SYMBOLS='g_list\|g_slist\|g_concat_dir_and_file\|g_Ctoc\|g_getdtablesize'
 if NACL_CODEGEN
 test-eglib-remap:
 else


### PR DESCRIPTION
The method was added in cd9f3b5859bce24cc00f3620544bde581054a8dd and caused the test to fail.

I'm wondering why the test-eglib-remap is only executed on X86 ([Makefile.am#L690](https://github.com/mono/mono/blob/master/mono/tests/Makefile.am#L690))?