### PR TITLE
Send Content-Length header when it's set to 0

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -1178,7 +1178,7 @@ namespace System.Net
 					if (contentLength > 0)
 						continue100 = true;
 
-					if (haveContentLength || gotRequestStream || contentLength > 0)
+					if (haveContentLength || gotRequestStream || contentLength >= 0)
 						webHeaders.SetInternal ("Content-Length", contentLength.ToString ());
 				}
 				webHeaders.RemoveInternal ("Transfer-Encoding");


### PR DESCRIPTION
Right now when you set `ContentLength` to `0` it's not sent as part of the request. That's not how .NET Framework works (see [sourceof.net](http://referencesource.microsoft.com/#System/net/System/Net/HttpWebRequest.cs,4911)). Also, there are valid cases when server expects Content-Length header to be set to 0 when there is no request body (I run into one of them today :()