### PR TITLE
[System.Net.Http] Fix CancelRequestViaProxy() test that intermittently fails on Jenkins

### DIFF
--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -249,7 +249,7 @@ namespace MonoTests.System.Net.Http
 
 			var httpClient = new HttpClient (handler) {
 				BaseAddress = new Uri ("https://google.com"),
-				Timeout = TimeSpan.FromSeconds (1)
+				Timeout = TimeSpan.FromMilliseconds (1)
 			};
 
 			try {


### PR DESCRIPTION
Seems that on Jenkins, the request to the (non-existing) IP address used in the test returns before the 1s timeout, causing the test to fail because the cancellation didn't fire.

Lowering the timeout to 1 millisecond should fix this.

I also verified that the test still correctly fails when the commit that fixed the original issue is reverted.

**don't merge yet, I'd like to schedule a few builds on jenkins to make sure this fixes it**