### PR TITLE
System.Xml.Serialization: fix xml serializers generation for Web Services

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlSerializer.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlSerializer.cs
@@ -769,6 +769,8 @@ namespace System.Xml.Serialization
 				cp.ReferencedAssemblies.Add ("System.Xml");
 			if (!cp.ReferencedAssemblies.Contains ("System.Data"))
 				cp.ReferencedAssemblies.Add ("System.Data");
+			if (!cp.ReferencedAssemblies.Contains ("System.Web.Services"))
+				cp.ReferencedAssemblies.Add ("System.Web.Services");
 			
 			CompilerResults res = comp.CompileAssemblyFromFile (cp, file);
 			if (res.Errors.HasErrors || res.CompiledAssembly == null) {


### PR DESCRIPTION
(add a reference to System.Web.Services)

Without this patch we get the following exception after multiple call
to a soap web services:
Error while compiling generated serializer
/tmp/24ee1170/4996ddb2.cs(2519,27) : warning CS1522: Empty switch block
/tmp/24ee1170/4996ddb2.cs(969,29) : error CS0012: The type `System.Web.Services.Protocols.SoapHeader' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System.Web.Services, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'

Signed-off-by: Frederic Mestayer <f.mestayer@fiducial.net>
Signed-off-by: Etienne CHAMPETIER <etienne.champetier@fiducial.net>