### PR TITLE
Tests and fixes for OP_IL_SEQ_POINT

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -663,8 +663,9 @@ else
 	$(RUNTIME) --regression $(regtests)
 endif
 
-check-seq-points:
+check-seq-points: mono $(regtests)
 	for i in $(regtests); do ./test_op_il_seq_point.sh $$i || exit 1; done
+	for i in $(regtests); do ./test_op_il_seq_point.sh $$i --aot || exit 1; done
 
 gctest: mono gc-test.exe
 	MONO_DEBUG_OPTIONS=clear-nursery-at-gc $(RUNTIME) --regression gc-test.exe
@@ -723,7 +724,7 @@ stat3: mono bench.exe
 docu: mini.sgm
 	docbook2txt mini.sgm
 
-check-local: rcheck
+check-local: rcheck check-seq-points
 
 clean-local:
 	rm -f mono a.out gmon.out *.o buildver-boehm.h buildver-sgen.h test.exe

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -629,14 +629,13 @@ mono_decompose_long_opts (MonoCompile *cfg)
 	first_bb = cfg->cbb;
 
 	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
-		MonoInst *tree = bb->code;	
+		MonoInst *tree = mono_bb_first_inst(bb, FILTER_IL_SEQ_POINT);
 		MonoInst *prev = NULL;
 
 		   /*
 		mono_print_bb (bb, "BEFORE LOWER_LONG_OPTS");
 		*/
 
-		tree = bb->code;
 		cfg->cbb->code = cfg->cbb->last_ins = NULL;
 
 		while (tree) {
@@ -967,7 +966,7 @@ mono_decompose_long_opts (MonoCompile *cfg)
 				break;
 
 			case OP_LCOMPARE: {
-				MonoInst *next = tree->next;
+				MonoInst *next = mono_inst_next (tree, FILTER_IL_SEQ_POINT);
 
 				g_assert (next);
 
@@ -1049,7 +1048,7 @@ mono_decompose_long_opts (MonoCompile *cfg)
 
 			/* Not yet used, since lcompare is decomposed before local cprop */
 			case OP_LCOMPARE_IMM: {
-				MonoInst *next = tree->next;
+				MonoInst *next = mono_inst_next (tree, FILTER_IL_SEQ_POINT);
 				guint32 low_imm = tree->inst_ls_word;
 				guint32 high_imm = tree->inst_ms_word;
 				int low_reg = tree->sreg1 + 1;
@@ -1149,9 +1148,9 @@ mono_decompose_long_opts (MonoCompile *cfg)
 
 				/* Process the newly added ops again since they can be long ops too */
 				if (prev)
-					tree = prev->next;
+					tree = mono_inst_next (prev, FILTER_IL_SEQ_POINT);
 				else
-					tree = bb->code;
+					tree = mono_bb_first_inst (bb, FILTER_IL_SEQ_POINT);
 
 				first_bb->code = first_bb->last_ins = NULL;
 				first_bb->in_count = first_bb->out_count = 0;
@@ -1159,7 +1158,7 @@ mono_decompose_long_opts (MonoCompile *cfg)
 			}
 			else {
 				prev = tree;
-				tree = tree->next;
+				tree = mono_inst_next (tree, FILTER_IL_SEQ_POINT);
 			}
 		}
 	}

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -2,35 +2,62 @@
 
  TESTFILE=$1
 
-get_code_length () {
-    ./mono -v $1 | grep 'code length' | sed 's/0x[0-9a-f]*/0x/g' | sed -E 's/Method (\(.*\) )?//g' | sort
+get_methods () {
+    ./mono -v -v $1 | grep '^Method \|^000' | sed 's/emitted[^()]*//' | sed 's/0x[0-9a-fA-F]*/0x0/g' | awk -v RS='' '{gsub(/\n000/, "000"); print}' | sort
 }
 
-sdiff_code_length () {
-    sdiff -s -w 1000 <(echo "$(get_code_length $1)") <(echo "$(MONO_DEBUG=gen-compact-seq-points  get_code_length $1)")
+get_method () {
+	MONO_VERBOSE_METHOD="$2" ./mono $1 | grep '^Method \|^000' | sed 's/emitted[^()]*//' | sed 's/0x[0-9a-fA-F]*/0x0/g'
+}
+
+sdiff_methods () {
+    sdiff -s -w 1000 <(echo "$(get_methods $1)") <(echo "$(MONO_DEBUG=gen-compact-seq-points  get_methods $1)")
+}
+
+diff_method () {
+	diff <(echo "$(get_method $1 $2)") <(echo "$(MONO_DEBUG=gen-compact-seq-points  get_method $1 $2)")
+}
+
+get_method_name () {
+	echo $1 | sed -E 's/Method (\([^)]*\) )?([^ ]*).*/\2/g'
+}
+
+get_method_length () {
+	echo $1 | sed 's/.*code length \([0-9]*\).*/\1/'
 }
 
 DIFF_FILE=mktemp
 
-echo "$(sdiff_code_length $TESTFILE)" > $DIFF_FILE
+echo "$(sdiff_methods $TESTFILE)" > $DIFF_FILE
 
 CHANGES=0
+METHOD=""
+MIN_SIZE=10000
 
 while read line; do
 	if [ "$line" != "" ]; then
+		echo $line | sed 's/000.*//g'
 		CHANGES=$((CHANGES+1))
-	    echo $line
+		SIZE=$(get_method_length "$line")
+		if [[ SIZE -lt MIN_SIZE ]]; then
+			MIN_SIZE=$SIZE
+			METHOD="$line"
+		fi
 	fi
 done < $DIFF_FILE
 
 if [ $CHANGES != 0 ]
 then
+	METHOD_NAME=$(get_method_name "$METHOD")
+
+	echo "$(diff_method $TESTFILE $METHOD_NAME)"
+
 	echo ''
 	echo "Detected OP_IL_SEQ_POINT incompatibility on $TESTFILE"
-	echo "  $CHANGES methods differ in size when sequence points are enabled."
+	echo "  $CHANGES methods differ when sequence points are enabled."
 	echo '  This is probably caused by a runtime optimization that is not handling OP_IL_SEQ_POINT'
-	echo '  More details can be obtained by comparing the output of the following commands:'
-	echo "    MONO_VERBOSE_METHOD=testname mono/mini/mono $TESTFILE"
-	echo "    MONO_DEBUG=gen-compact-seq-points #MONO_VERBOSE_METHOD=testname mono/mini/mono $TESTFILE"
+	echo '  Differences can be obtained by comparing the output of the following commands:'
+	echo "    MONO_VERBOSE_METHOD=\"$METHOD_NAME\" mono/mini/mono mono/mini/$TESTFILE"
+	echo "    MONO_DEBUG=gen-compact-seq-points MONO_VERBOSE_METHOD=\"$METHOD_NAME\" mono/mini/mono mono/mini/$TESTFILE"
 	exit 1
 fi

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -24,7 +24,7 @@ get_methods () {
 		MONO_PATH=$1 $2 -v $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
 	else
 		clean_aot
-		MONO_PATH=$1 $2 --aot -v -v $3 | grep '^Method .*code length\|^000' | sed 's/emitted[^()]*//' | sed 's/0x[0-9a-fA-F]*/0x0/g' | awk -v RS='' '{gsub(/\n000/, "000"); print}' | sort
+		MONO_PATH=$1 $2 -v $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
 	fi
 }
 
@@ -33,7 +33,7 @@ get_method () {
 		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
 	else
 		clean_aot
-		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 --aot $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
+		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
 	fi
 }
 

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -40,7 +40,7 @@ get_method () {
 diff_methods () {
 	TMP_FILE=tmp_file
 	echo "$(get_methods $1 $2 $3 $4)" >$TMP_FILE
-	sdiff -s -w 1000 <(cat $TMP_FILE) <(echo "$(MONO_DEBUG=gen-compact-seq-points get_methods $1 $2 $3 $4)")
+	diff <(cat $TMP_FILE) <(echo "$(MONO_DEBUG=gen-compact-seq-points get_methods $1 $2 $3 $4)")
 }
 
 diff_method () {
@@ -50,7 +50,7 @@ diff_method () {
 }
 
 get_method_name () {
-	echo $1 | sed -E 's/Method (\([^)]*\) )?([^ ]*).*/\2/g'
+	echo $1 | sed -E 's/.*Method (\([^)]*\) )?([^ ]*).*/\2/g'
 }
 
 get_method_length () {
@@ -73,9 +73,10 @@ MIN_SIZE=10000
 
 while read line; do
 	if [ "$line" != "" ]; then
-		echo $line | sed 's/000.*//g'
+		METHOD_INFO=$(echo $line | sed 's/000.*//g')
+		echo $METHOD_INFO
 		CHANGES=$((CHANGES+1))
-		SIZE=$(get_method_length "$line")
+		SIZE=$(get_method_length "$METHOD_INFO")
 		if [[ SIZE -lt MIN_SIZE ]]; then
 			MIN_SIZE=$SIZE
 			METHOD="$line"


### PR DESCRIPTION
test_op_il_seq_point.sh now also checks that AOT compiled methods native code size is not changed by OP_IL_SEQ_POINT.

test_op_il_seq_point.sh now shows a sdiff of the smallest method with unintended changes.

Fixed regressions found by test_op_il_seq_point.sh with AOT compilation enabled.