### PR TITLE
Fix SpinLock.TryEnter

### DIFF
--- a/mcs/class/corlib/System.Threading/SpinLock.cs
+++ b/mcs/class/corlib/System.Threading/SpinLock.cs
@@ -155,7 +155,7 @@ namespace System.Threading
 				long u = ticket.Users;
 				long totalValue = (u << 32) | u;
 				long newTotalValue
-					= BitConverter.IsLittleEndian ? (u << 32) | (u + 1) : ((u + 1) << 32) | u;
+					= BitConverter.IsLittleEndian ? ((u + 1) << 32) | u : (u << 32) | (u + 1);
 				
 				RuntimeHelpers.PrepareConstrainedRegions ();
 				try {}

--- a/mcs/class/corlib/Test/System.Threading/SpinLockTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/SpinLockTests.cs
@@ -85,6 +85,9 @@ namespace MonoTests.System.Threading
 
 			sl.TryEnter (ref taken2);
 			Assert.IsTrue (taken2, "#3");
+
+			sl.Exit ();
+			Assert.IsFalse (sl.IsHeld);
 		}
 
 		[Test, ExpectedException (typeof (ArgumentException))]


### PR DESCRIPTION
Little and big endian cases were inverted. It can be seen e.g. from the
reference http://locklessinc.com/articles/locks, where the ticket algorithm
is given for little-endian machines

As a consequence, without this patch, if TryEnter succeeds, it increments
ticket.Value instead of ticket.User, which puts the SpinLock in a corrupted
state, and makes it impossible to release afterwards.