### PR TITLE
Mark hot functions in the runtime.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2517,7 +2517,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
  *       through @error
  * @error: error or caught exception object
  */
-static MonoObject*
+static MonoObject* MONO_HOT
 mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error)
 {
 	MonoMethod *invoke, *callee;

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -329,7 +329,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 	return (GCObject*)p;
 }
 
-GCObject*
+GCObject* MONO_HOT
 sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size)
 {
 	void **p;

--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -67,7 +67,7 @@ static guint64 last_los_scan_time;
 
 static void sgen_card_tables_collect_stats (gboolean begin);
 
-mword
+mword MONO_HOT
 sgen_card_table_number_of_cards_in_range (mword address, mword size)
 {
 	mword end = address + MAX (1, size) - 1;
@@ -387,7 +387,7 @@ move_cards_to_shadow_table (mword start, mword size)
 	}
 }
 
-static void
+static void MONO_HOT
 clear_cards (mword start, mword size)
 {
 	guint8 *addr = sgen_card_table_get_card_address (start);

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -536,7 +536,7 @@ sgen_add_to_global_remset (gpointer ptr, GCObject *obj)
  * usage.
  *
  */
-gboolean
+gboolean MONO_HOT
 sgen_drain_gray_stack (ScanCopyContext ctx)
 {
 	ScanObjectFunc scan_func = ctx.ops->scan_object;
@@ -1326,7 +1326,7 @@ typedef struct {
 	SgenObjectOperations *ops;
 } ScanJob;
 
-static void
+static void MONO_HOT
 job_remembered_set_scan (void *worker_data_untyped, SgenThreadPoolJob *job)
 {
 	WorkerData *worker_data = (WorkerData *)worker_data_untyped;
@@ -1477,7 +1477,7 @@ enqueue_scan_from_roots_jobs (char *heap_start, char *heap_end, SgenObjectOperat
  *
  * Return whether any objects were late-pinned due to being out of memory.
  */
-static gboolean
+static gboolean MONO_HOT
 collect_nursery (SgenGrayQueue *unpin_queue, gboolean finish_up_concurrent_mark)
 {
 	gboolean needs_major;
@@ -2224,7 +2224,7 @@ sgen_ensure_free_space (size_t size, int generation)
 /*
  * LOCKING: Assumes the GC lock is held.
  */
-void
+void MONO_HOT
 sgen_perform_collection (size_t requested_size, int generation_to_collect, const char *reason, gboolean wait_to_finish)
 {
 	TV_DECLARE (gc_start);

--- a/mono/sgen/sgen-marksweep-drain-gray-stack.h
+++ b/mono/sgen/sgen-marksweep-drain-gray-stack.h
@@ -32,7 +32,7 @@
  */
 
 /* Returns whether the object is still in the nursery. */
-static inline MONO_ALWAYS_INLINE gboolean
+static inline MONO_ALWAYS_INLINE MONO_HOT gboolean
 COPY_OR_MARK_FUNCTION_NAME (GCObject **ptr, GCObject *obj, SgenGrayQueue *queue)
 {
 	MSBlockInfo *block;

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -642,7 +642,7 @@ unlink_slot_from_free_list_uncontested (MSBlockInfo * volatile *free_blocks, int
 	return obj;
 }
 
-static GCObject*
+static GCObject* MONO_HOT
 alloc_obj (GCVTable vtable, size_t size, gboolean pinned, gboolean has_references)
 {
 	int size_index = MS_BLOCK_OBJ_SIZE_INDEX (size);
@@ -1233,13 +1233,13 @@ drain_gray_stack_concurrent (SgenGrayQueue *queue)
 		return drain_gray_stack_concurrent_no_evacuation (queue);
 }
 
-static void
+static void MONO_HOT
 major_copy_or_mark_object_canonical (GCObject **ptr, SgenGrayQueue *queue)
 {
 	major_copy_or_mark_object_with_evacuation (ptr, *ptr, queue);
 }
 
-static void
+static void MONO_HOT
 major_copy_or_mark_object_concurrent_canonical (GCObject **ptr, SgenGrayQueue *queue)
 {
 	major_copy_or_mark_object_concurrent_with_evacuation (ptr, *ptr, queue);
@@ -1330,7 +1330,7 @@ set_block_state (MSBlockInfo *block, gint32 new_state, gint32 expected_state)
  * Sweeping means iterating through the block's slots and building the free-list from the
  * unmarked ones.  They will also be zeroed.  The mark bits will be reset.
  */
-static gboolean
+static gboolean MONO_HOT
 sweep_block (MSBlockInfo *block)
 {
 	int count;
@@ -2121,7 +2121,7 @@ major_print_gc_param_usage (void)
 /*
  * This callback is used to clear cards, move cards to the shadow table and do counting.
  */
-static void
+static void MONO_HOT
 major_iterate_live_block_ranges (sgen_cardtable_block_callback callback)
 {
 	MSBlockInfo *block;
@@ -2147,7 +2147,7 @@ extern guint64 remarked_cards;
  * Cardtables are 4K aligned, at least.
  * This means that the cardtable of a given block is 32 bytes aligned.
  */
-static guint8*
+static guint8* MONO_HOT
 initial_skip_card (guint8 *card_data)
 {
 	mword *cards = (mword*)card_data;
@@ -2181,7 +2181,7 @@ initial_skip_card (guint8 *card_data)
 #define MS_BLOCK_OBJ_FAST(b,os,i)			((b) + MS_BLOCK_SKIP + (os) * (i))
 #define MS_OBJ_ALLOCED_FAST(o,b)		(*(void**)(o) && (*(char**)(o) < (b) || *(char**)(o) >= (b) + MS_BLOCK_SIZE))
 
-static void
+static void MONO_HOT
 scan_card_table_for_block (MSBlockInfo *block, CardTableScanType scan_type, ScanCopyContext ctx)
 {
 	SgenGrayQueue *queue = ctx.queue;

--- a/mono/sgen/sgen-minor-scan-object.h
+++ b/mono/sgen/sgen-minor-scan-object.h
@@ -45,7 +45,7 @@ extern guint64 stat_scan_object_called_nursery;
 		}	\
 	} while (0)
 
-static void
+static void MONO_HOT
 SERIAL_SCAN_OBJECT (GCObject *full_object, SgenDescriptor desc, SgenGrayQueue *queue)
 {
 	char *start = (char*)full_object;

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -299,8 +299,10 @@ typedef SSIZE_T ssize_t;
 
 #ifdef __GNUC__
 #define MONO_COLD __attribute__((cold))
+#define MONO_HOT __attribute__((hot))
 #else
 #define MONO_COLD
+#define MONO_HOT
 #endif
 
 #endif /* __UTILS_MONO_COMPILER_H__*/


### PR DESCRIPTION
This attribute is supposed to improve code locality and branch prediction for hot functions. It can be inferred by profile-guided optimisation, but I think it makes sense to encode in the source directly. All but `mono_jit_runtime_invoke` are in SGen.

I mainly wanted to solicit feedback about whether this seems worthwhile—running the benchmark suite, it improves performance on more complex workloads (lcscbench, raytracer3, sharpchess) but worsens microbenchmarks (onelist, lists).
