### PR TITLE
SafeHandle.Close or Dispose should never throw.

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/SafeHandleTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/SafeHandleTest.cs
@@ -96,17 +96,8 @@ namespace MonoTests.System.Runtime.InteropServices
 
 			sf.DangerousRelease ();
 
-			try {
-				sf.Close ();
-				Assert.Fail ("#1");
-			} catch (ObjectDisposedException) {
-			}
-
-			try {
-				sf.Dispose ();
-				Assert.Fail ("#2");
-			} catch (ObjectDisposedException) {
-			}
+			sf.Close ();
+			sf.Dispose ();
 
 			//In Ms.Net SafeHandle does not change the value of the handle after being SetInvalid or Disposed.
 			Assert.AreEqual ((int)sf.DangerousGetHandle(), dummyHandle, "handle");


### PR DESCRIPTION
Closing a handle or Disposing a handle should not result in an ObjectDisposedException.

Dispose should be safe to call more than once and never throw in finalization.
Right now Ms.Net will only throw on Dipose in a very specific cases.
An it will also happen in the GC Thread...

We should not try to copy this undocumented behavior. That is most likely a bug in the Ms.Net implementation.

If last call to DangerousRelease caused the resource to be released, the next call to Close or Dipose under Ms.Net will throw. Even if called by the GC in a finalizer.

Unhandled Exception: System.ObjectDisposedException: Safe handle has been closed
at System.Runtime.InteropServices.SafeHandle.InternalFinalize()
at System.Runtime.InteropServices.SafeHandle.Dispose(Boolean disposing)
at ConsoleApplication1.TestHandle.Dispose(Boolean disposing)
at System.Runtime.InteropServices.SafeHandle.Finalize()
at ConsoleApplication1.TestHandle.Finalize()