### PR TITLE
[System.Core] Fixed wrong DST of TimeZoneInfo with floating date rules.

### DIFF
--- a/mcs/class/System.Core/System/TimeZoneInfo.cs
+++ b/mcs/class/System.Core/System/TimeZoneInfo.cs
@@ -1086,7 +1086,7 @@ namespace System
 				return new DateTime (year, transition.Month, transition.Day) + transition.TimeOfDay.TimeOfDay;
 
 			DayOfWeek first = (new DateTime (year, transition.Month, 1)).DayOfWeek;
-			int day = 1 + (transition.Week - 1) * 7 + (transition.DayOfWeek - first) % 7;
+			int day = 1 + (transition.Week - 1) * 7 + (transition.DayOfWeek - first + 7) % 7;
 			if (day >  DateTime.DaysInMonth (year, transition.Month))
 				day -= 7;
 			if (day < 1)

--- a/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/System.Core/Test/System/TimeZoneInfoTest.cs
@@ -287,6 +287,20 @@ namespace MonoTests.System
 				dt = new DateTime (2014, 10, 9, 23, 0, 0, DateTimeKind.Utc);
 				Assert.IsTrue (tz.IsDaylightSavingTime (dt), "#3.1");
 			}
+
+			[Test] //Covers #26008
+			public void DSTWithFloatingDateRule ()
+			{
+				// Construct a custom time zone where daylight saving time starts on the
+				// 2nd Sunday in March.
+				var transitionToDaylight = TimeZoneInfo.TransitionTime.CreateFloatingDateRule (new DateTime (1, 1, 1, 2, 0, 0), 3, 2, DayOfWeek.Sunday);
+				var transitionToStandard = TimeZoneInfo.TransitionTime.CreateFloatingDateRule (new DateTime (1, 1, 1, 2, 0, 0), 11, 1, DayOfWeek.Sunday);
+				var adjustment = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule (DateTime.MinValue.Date, DateTime.MaxValue.Date, new TimeSpan (1, 0, 0), transitionToDaylight, transitionToStandard);
+				var timeZone = TimeZoneInfo.CreateCustomTimeZone ("BugCheck", new TimeSpan (-8, 0, 0), "Testing", "Testing Standard", "Testing Daylight", new TimeZoneInfo.AdjustmentRule [] { adjustment });
+				// See if March 7, 2014 is listed as being during daylight saving time.
+				// If it is DST, then the runtime has the bug that we are looking for.
+				Assert.IsFalse (timeZone.IsDaylightSavingTime (new DateTime (2014, 3, 7, 12, 0, 0, DateTimeKind.Unspecified)));
+			}
 		}
 		
 		[TestFixture]


### PR DESCRIPTION
**Fixes:** [#26008](https://bugzilla.xamarin.com/show_bug.cgi?id=26008)
We do not want (transition.DayOfWeek - first) % 7 to be negative.
As (transition.DayOfWeek - first) cannot be lower than -7, adding 7 to it solves the issue.