### PR TITLE
[sdb] Fixed .mdb parsing when line equals 0

### DIFF
--- a/mono/metadata/debug-mono-symfile.c
+++ b/mono/metadata/debug-mono-symfile.c
@@ -413,12 +413,10 @@ mono_debug_symfile_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset)
 static void
 add_line (StatementMachine *stm, GPtrArray *il_offset_array, GPtrArray *line_number_array, GPtrArray *source_file_array, GPtrArray *hidden_array)
 {
-	if (stm->line > 0) {
-		g_ptr_array_add (il_offset_array, GUINT_TO_POINTER (stm->offset));
-		g_ptr_array_add (line_number_array, GUINT_TO_POINTER (stm->line));
-		g_ptr_array_add (source_file_array, GUINT_TO_POINTER (stm->file));
-		g_ptr_array_add (hidden_array, GUINT_TO_POINTER (stm->is_hidden));
-	}
+	g_ptr_array_add (il_offset_array, GUINT_TO_POINTER (stm->offset));
+	g_ptr_array_add (line_number_array, GUINT_TO_POINTER (stm->line));
+	g_ptr_array_add (source_file_array, GUINT_TO_POINTER (stm->file));
+	g_ptr_array_add (hidden_array, GUINT_TO_POINTER (stm->is_hidden || stm->line <= 0));
 
 	if (!stm->is_hidden && !stm->first_file)
 		stm->first_file = stm->file;


### PR DESCRIPTION
Current logic was skipping sequence points with line 0 or lower. Resulting in misaligned reading of rest of data like ILOffsets, columns...
This is what I got from runtime 3.3 on IDE side(I was in mood for painting :D):
![image](https://cloud.githubusercontent.com/assets/774791/5754453/5618381a-9c99-11e4-9a64-63728e392a7a.png)
I'm guessing this wasn't discovered before mostly because row="0" is .pdb only(I think(hidden seq)) and IDEs didn't pay attention to columns...