### PR TITLE
Generate proper Link metadata for resources in imported projects

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildItem.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildItem.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Build.BuildEngine {
 					return;
 				}
 			}
-			
+
 			DirectoryScanner directoryScanner;
 			Expression includeExpr, excludeExpr;
 			ITaskItem[] includes, excludes;
@@ -341,8 +341,10 @@ namespace Microsoft.Build.BuildEngine {
 			directoryScanner.Includes = includes;
 			directoryScanner.Excludes = excludes;
 
-			if (project.FullFileName != String.Empty)
+			if (project.FullFileName != String.Empty) {
+				directoryScanner.ProjectFile = project.ThisFileFullPath;
 				directoryScanner.BaseDirectory = new DirectoryInfo (Path.GetDirectoryName (project.FullFileName));
+			}
 			else
 				directoryScanner.BaseDirectory = new DirectoryInfo (Directory.GetCurrentDirectory ());
 			

--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/DirectoryScanner.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/DirectoryScanner.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Build.BuildEngine {
 		DirectoryInfo	baseDirectory;
 		ITaskItem[]	includes, excludes;
 		ITaskItem[]	matchedItems;
+		string projectFile;
 
 		static bool _runningOnWindows;
 		
@@ -82,8 +83,11 @@ namespace Microsoft.Build.BuildEngine {
 
 			string name = include_item.ItemSpec;
 			if (!HasWildcard (name)) {
-				if (!excludedItems.ContainsKey (Path.GetFullPath(name)))
+				if (!excludedItems.ContainsKey (Path.GetFullPath (name))) {
 					includedItems.Add (include_item);
+					if (projectFile != null)
+						include_item.SetMetadata ("DefiningProjectFullPath", projectFile);
+				}
 			} else {
 				if (name.Split (Path.DirectorySeparatorChar).Length > name.Split (Path.AltDirectorySeparatorChar).Length) {
 					separatedPath = name.Split (new char [] {Path.DirectorySeparatorChar},
@@ -127,6 +131,8 @@ namespace Microsoft.Build.BuildEngine {
 								rec_dir += Path.DirectorySeparatorChar;
 							item.SetMetadata ("RecursiveDir", rec_dir);
 						}
+						if (projectFile != null)
+							item.SetMetadata ("DefiningProjectFullPath", projectFile);
 						includedItems.Add (item);
 					}
 				}
@@ -236,6 +242,11 @@ namespace Microsoft.Build.BuildEngine {
 			set { baseDirectory = value; }
 		}
 		
+		public string ProjectFile {
+			get { return projectFile; }
+			set { projectFile = value; }
+		}
+
 		public ITaskItem[] Includes {
 			get { return includes; }
 			set { includes = value; }

--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Project.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Project.cs
@@ -1429,6 +1429,10 @@ namespace Microsoft.Build.BuildEngine {
 			return default (T);
 		}
 
+		internal string ThisFileFullPath {
+			get { return this_file_property_stack.Peek (); }
+		}
+
 		// Used for MSBuild*This* set of properties
 		internal void PushThisFileProperty (string full_filename)
 		{

--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks-net_3_5.csproj
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks-net_3_5.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Microsoft.Build.Tasks\AspNetCompiler.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssemblyResolver.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssignCulture.cs" />
+    <Compile Include="Microsoft.Build.Tasks\AssignLinkMetadata.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssignProjectConfiguration.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssignTargetPath.cs" />
     <Compile Include="Microsoft.Build.Tasks\CallTarget.cs" />

--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks-net_4_5.csproj
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks-net_4_5.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Microsoft.Build.Tasks\AssignCulture.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssignProjectConfiguration.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssignTargetPath.cs" />
+    <Compile Include="Microsoft.Build.Tasks\AssignLinkMetadata.cs" />
     <Compile Include="Microsoft.Build.Tasks\CallTarget.cs" />
     <Compile Include="Microsoft.Build.Tasks\CodeTaskFactory.cs" />
     <Compile Include="Microsoft.Build.Tasks\CombinePath.cs" />

--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks-xbuild_12.csproj
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks-xbuild_12.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Microsoft.Build.Tasks\AssignCulture.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssignProjectConfiguration.cs" />
     <Compile Include="Microsoft.Build.Tasks\AssignTargetPath.cs" />
+    <Compile Include="Microsoft.Build.Tasks\AssignLinkMetadata.cs" />
     <Compile Include="Microsoft.Build.Tasks\CallTarget.cs" />
     <Compile Include="Microsoft.Build.Tasks\CombinePath.cs" />
     <Compile Include="Microsoft.Build.Tasks\CommandLineBuilderExtension.cs" />

--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks.dll.sources
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks.dll.sources
@@ -7,6 +7,7 @@ Microsoft.Build.Tasks/AppDomainIsolatedTaskExtension.cs
 Microsoft.Build.Tasks/AspNetCompiler.cs
 Microsoft.Build.Tasks/AssemblyResolver.cs
 Microsoft.Build.Tasks/AssignCulture.cs
+Microsoft.Build.Tasks/AssignLinkMetadata.cs
 Microsoft.Build.Tasks/AssignProjectConfiguration.cs
 Microsoft.Build.Tasks/AssignTargetPath.cs
 Microsoft.Build.Tasks/CallTarget.cs

--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/AssignLinkMetadata.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/AssignLinkMetadata.cs
@@ -1,0 +1,87 @@
+//
+// AssignLinkMetadata.cs
+//
+// Author:
+//   Lluis Sanchez (lluis@xamarin.com)
+//
+// Copyright 2015 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Tasks {
+	public class AssignLinkMetadata : TaskExtension {
+	
+		ITaskItem[]	assignedFiles;
+		ITaskItem[]	files;
+	
+		public AssignLinkMetadata ()
+		{
+		}
+		
+		public override bool Execute ()
+		{
+			if (files == null || files.Length == 0)
+				//nothing to do
+				return true;
+
+			List<ITaskItem> outFiles = new List<ITaskItem> ();
+
+			for (int i = 0; i < files.Length; i ++) {
+				string file = files [i].ItemSpec;
+				string link = files [i].GetMetadata ("Link");
+				string definingProjectPath = files [i].GetMetadata ("DefiningProjectFullPath");
+
+				if (String.IsNullOrEmpty (link) && Path.IsPathRooted (file) && !string.IsNullOrEmpty (definingProjectPath)) {
+					file = Path.GetFullPath (file);
+					var projectDir = Path.GetFullPath (Path.GetDirectoryName (definingProjectPath));
+					if (projectDir.Length == 0 || projectDir [projectDir.Length - 1] != Path.DirectorySeparatorChar)
+						projectDir += Path.DirectorySeparatorChar;
+					if (file.StartsWith (projectDir)) {
+						// The file is in the same folder or a subfolder of the project that contains it.
+						// Use the relative path wrt the containing project as link.
+						var outFile = new TaskItem (files [i]);
+						outFile.SetMetadata ("Link", file.Substring (projectDir.Length));
+						outFiles.Add (outFile);
+					}
+				}
+			}
+
+			assignedFiles = outFiles.ToArray ();
+
+			return true;
+		}
+		
+		[Output]
+		public ITaskItem[] OutputItems {
+			get { return assignedFiles; }
+		}
+		
+		public ITaskItem[] Items {
+			get { return files; }
+			set { files = value; }
+		}
+	}
+}

--- a/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets
@@ -105,7 +105,10 @@
 			Text="OutDir property must end with a slash."/>
 	</Target>
 
-	<Target Name="PrepareForBuild">
+	<PropertyGroup>
+		<PrepareForBuildDependsOn>AssignLinkMetadata</PrepareForBuildDependsOn>
+	</PropertyGroup>
+	<Target Name="PrepareForBuild" DependsOnTargets="$(PrepareForBuildDependsOn)">
 		<Message Importance="High" Text="Configuration: $(Configuration) Platform: $(Platform)"/>
 
 		<!-- Look for app.config, if $(AppConfig) is specified, then use that. Else look in
@@ -123,6 +126,18 @@
 		<MakeDir
 			Directories="$(OutDir);$(IntermediateOutputPath);@(DocFileItem->'%(RelativeDir)')"
 		/>
+	</Target>
+
+	<Target Name="AssignLinkMetadata">
+	    <AssignLinkMetadata Items="@(EmbeddedResource)" Condition="'@(EmbeddedResource)' != '' and '%(EmbeddedResource.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)'">
+	      <Output TaskParameter="OutputItems" ItemName="_EmbeddedResourceWithLinkAssigned" />
+	    </AssignLinkMetadata>
+
+	    <ItemGroup>
+		<EmbeddedResource Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+		<EmbeddedResource Include="@(_EmbeddedResourceWithLinkAssigned)" />
+		<_EmbeddedResourceWithLinkAssigned Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+	    </ItemGroup>
 	</Target>
 
 	<PropertyGroup>

--- a/mcs/tools/xbuild/data/12.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/12.0/Microsoft.Common.tasks
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
 	<UsingTask TaskName="Microsoft.Build.Tasks.AL"			AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignTargetPath"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.AssignLinkMetadata"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignCulture"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CallTarget"		AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets
@@ -85,7 +85,10 @@
 			Text="OutDir property must end with a slash."/>
 	</Target>
 
-	<Target Name="PrepareForBuild">
+	<PropertyGroup>
+		<PrepareForBuildDependsOn>AssignLinkMetadata</PrepareForBuildDependsOn>
+	</PropertyGroup>
+	<Target Name="PrepareForBuild" DependsOnTargets="$(PrepareForBuildDependsOn)">
 		<Message Importance="High" Text="Configuration: $(Configuration) Platform: $(Platform)"/>
 
 		<!-- Look for app.config, if $(AppConfig) is specified, then use that. Else look in
@@ -103,6 +106,18 @@
 		<MakeDir
 			Directories="$(OutDir);$(IntermediateOutputPath);@(DocFileItem->'%(RelativeDir)')"
 		/>
+	</Target>
+
+	<Target Name="AssignLinkMetadata">
+	    <AssignLinkMetadata Items="@(EmbeddedResource)" Condition="'@(EmbeddedResource)' != '' and '%(EmbeddedResource.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)'">
+	      <Output TaskParameter="OutputItems" ItemName="_EmbeddedResourceWithLinkAssigned" />
+	    </AssignLinkMetadata>
+
+	    <ItemGroup>
+			<EmbeddedResource Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+			<EmbeddedResource Include="@(_EmbeddedResourceWithLinkAssigned)" />
+			<_EmbeddedResourceWithLinkAssigned Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+	    </ItemGroup>
 	</Target>
 
 	<PropertyGroup>

--- a/mcs/tools/xbuild/data/3.5/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/3.5/Microsoft.Common.tasks
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
 	<UsingTask TaskName="Microsoft.Build.Tasks.AL"			AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignTargetPath"	AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.AssignLinkMetadata"	AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignCulture"	AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"	AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CallTarget"		AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets
@@ -105,7 +105,10 @@
 			Text="OutDir property must end with a slash."/>
 	</Target>
 
-	<Target Name="PrepareForBuild">
+	<PropertyGroup>
+		<PrepareForBuildDependsOn>AssignLinkMetadata</PrepareForBuildDependsOn>
+	</PropertyGroup>
+	<Target Name="PrepareForBuild" DependsOnTargets="$(PrepareForBuildDependsOn)">
 		<Message Importance="High" Text="Configuration: $(Configuration) Platform: $(Platform)"/>
 
 		<!-- Look for app.config, if $(AppConfig) is specified, then use that. Else look in
@@ -123,6 +126,18 @@
 		<MakeDir
 			Directories="$(OutDir);$(IntermediateOutputPath);@(DocFileItem->'%(RelativeDir)')"
 		/>
+	</Target>
+
+	<Target Name="AssignLinkMetadata">
+	    <AssignLinkMetadata Items="@(EmbeddedResource)" Condition="'@(EmbeddedResource)' != '' and '%(EmbeddedResource.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)'">
+	      <Output TaskParameter="OutputItems" ItemName="_EmbeddedResourceWithLinkAssigned" />
+	    </AssignLinkMetadata>
+
+	    <ItemGroup>
+			<EmbeddedResource Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+			<EmbeddedResource Include="@(_EmbeddedResourceWithLinkAssigned)" />
+			<_EmbeddedResourceWithLinkAssigned Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+	    </ItemGroup>
 	</Target>
 
 	<PropertyGroup>

--- a/mcs/tools/xbuild/data/4.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/4.0/Microsoft.Common.tasks
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
 	<UsingTask TaskName="Microsoft.Build.Tasks.AL"			AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignTargetPath"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.AssignLinkMetadata"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignCulture"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CallTarget"		AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />


### PR DESCRIPTION
When importing a project that contains embedded resources, the id of those resources must be generated using the path relative to the project file that includes them, not relative to the main project file. To fix this problem, we now generate a Link metadata property for those resources that has the correct relative path, and later this is used to generate the correct id for the resource. We also now store a new metadata value for all items (DefiningProjectFullPath) which contains the path to the project file that defines the element. This is used to check if an item was defined in an imported file, in which case the Link assignment may need to be made.

This fixes bug BXC 20966.