### PR TITLE
Prioritize gray queue to improve GC locality.

### DIFF
--- a/mono/metadata/sgen-marksweep-drain-gray-stack.h
+++ b/mono/metadata/sgen-marksweep-drain-gray-stack.h
@@ -208,12 +208,6 @@ SCAN_OBJECT_FUNCTION_NAME (char *obj, mword desc, SgenGrayQueue *queue)
 	add_scanned_object (start);
 #endif
 
-	char *block_begin = NULL, *block_end = NULL;
-	if (!sgen_ptr_in_nursery (obj) && sgen_safe_object_get_size ((MonoObject *)obj) <= SGEN_MAX_SMALL_OBJ_SIZE) {
-		block_begin = (char *)MS_BLOCK_FOR_OBJ (obj);
-		block_end = (char *)block_begin + MS_BLOCK_SIZE;
-	}
-
 	/* Now scan the object. */
 
 #undef HANDLE_PTR
@@ -221,8 +215,9 @@ SCAN_OBJECT_FUNCTION_NAME (char *obj, mword desc, SgenGrayQueue *queue)
 		void *__old = *(ptr); \
 		binary_protocol_scan_process_reference ((obj), (ptr), __old); \
 		if (__old) { \
-			gboolean __still_in_nursery = COPY_OR_MARK_FUNCTION_NAME ((ptr), __old, queue, (char *)__old >= block_begin && (char *)__old < block_end); \
-			HEAVY_STAT ((char *)__old >= block_begin && (char *)__old < block_end ? ++stat_optimized_major_scan_local : ++stat_optimized_major_scan_nonlocal); \
+			gboolean __local = ((size_t)(__old) ^ (size_t)obj) > (MS_BLOCK_SIZE * CHAR_BIT); \
+			gboolean __still_in_nursery = COPY_OR_MARK_FUNCTION_NAME ((ptr), __old, queue, __local); \
+			HEAVY_STAT (__local ? ++stat_optimized_major_scan_local : ++stat_optimized_major_scan_nonlocal); \
 			if (G_UNLIKELY (__still_in_nursery && !sgen_ptr_in_nursery ((ptr)) && !SGEN_OBJECT_IS_CEMENTED (*(ptr)))) { \
 				void *__copy = *(ptr); \
 				sgen_add_to_global_remset ((ptr), __copy); \

--- a/mono/metadata/sgen-workers.c
+++ b/mono/metadata/sgen-workers.c
@@ -356,7 +356,8 @@ workers_steal (WorkerData *data, WorkerData *victim_data, gboolean lock)
 		int m = MIN (SGEN_GRAY_QUEUE_SECTION_SIZE, n);
 		n -= m;
 
-		sgen_gray_object_alloc_queue_section (queue);
+		/* FIXME: Which priority should be used here? */
+		sgen_gray_object_alloc_queue_section (queue, &queue->cursor, &queue->first);
 		memcpy (queue->first->entries,
 				victim_data->stealable_stack + victim_data->stealable_stack_fill - num + n,
 				sizeof (GrayQueueEntry) * m);


### PR DESCRIPTION
I observed that many references are between objects within the same block. In an effort to improve memory locality during scanning, this splits the gray queue into two sections: high-priority and low-priority. References into the same block are enqueued with high priority; into other blocks, with low priority. High-priority objects are dequeued first.

[Benchmark results](https://drive.google.com/a/xamarin.com/file/d/0B9vUy441CSjgYW9lZUVqQmxKTms/view?usp=sharing) show speedups of 1–39% on ~12 benchmarks and slowdowns of 1–5% on ~6. Notably and unfortunately, Roslyn was one that experienced a slowdown, but F# got faster. :)
