### PR TITLE
[utils] Extract Windows-specific networking fallback into networking-windows.c

### DIFF
--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -124,6 +124,7 @@ monoutils_sources = \
 	networking-posix.c	\
 	networking-fallback.c	\
 	networking-missing.c	\
+	networking-windows.c	\
 	networking.h
 
 arch_sources = 

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -302,15 +302,6 @@ mono_get_local_interfaces (int family, int *interface_count)
 	return result;
 }
 
-#else
-
-void *
-mono_get_local_interfaces (int family, int *interface_count)
-{
-	*interface_count = 0;
-	return NULL;
-}
-
 #endif
 
 #ifdef HAVE_GETNAMEINFO

--- a/mono/utils/networking-windows.c
+++ b/mono/utils/networking-windows.c
@@ -1,0 +1,19 @@
+/*
+ * networking-windows.c: Windows-specific networking implementations
+ *
+ * Author:
+ *	Alexander Köplinger (alex.koeplinger@outlook.com)
+ */
+
+#include <mono/utils/networking.h>
+
+#if defined(HOST_WIN32)
+
+void *
+mono_get_local_interfaces (int family, int *interface_count)
+{
+	*interface_count = 0;
+	return NULL;
+}
+
+#endif /* defined(HOST_WIN32) */

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -48,6 +48,7 @@
     <ClCompile Include="..\mono\utils\networking.c" />
     <ClCompile Include="..\mono\utils\networking-posix.c" />
     <ClCompile Include="..\mono\utils\networking-missing.c" />
+    <ClCompile Include="..\mono\utils\networking-windows.c" />
     <ClCompile Include="..\mono\utils\mono-path.c" />
     <ClCompile Include="..\mono\utils\mono-poll.c" />
     <ClCompile Include="..\mono\utils\mono-proclib.c" />


### PR DESCRIPTION
This patch is licensed under MIT/X11.

/cc @kumpera 