### PR TITLE
[System] Fix Interval_TooHigh_Enabled_Throw() test that failed on Linux

### DIFF
--- a/mcs/class/System/Test/System.Timers/TimerTest.cs
+++ b/mcs/class/System/Test/System.Timers/TimerTest.cs
@@ -179,7 +179,7 @@ namespace MonoTests.System.Timers
 		{
 			timer.Interval = 100;
 			timer.Enabled = true;
-			timer.Interval = double.MaxValue;
+			timer.Interval = (double)int.MaxValue + 1;
 		}
 
 		[Test]


### PR DESCRIPTION
When the System.Timers.Timer code from referencesource was integrated, this test started failing on Linux / amd64.

It turns out there is no explicit check for Interval > Int32.MaxValue like we had in the Mono
implementation, instead it relies on the result of `(int)Math.Ceiling(interval)` in [Timer.cs#L146](https://github.com/mono/referencesource/blob/cbec67c761ed7a6ccd994ee141718b3fd2f7a0e5/System/services/timers/system/timers/Timer.cs#L146)
being negative and throws the exception inside the System.Threading.Timers code.

On Linux, the result of the call is 0 and thus no exception occurs.

Changing the test code to some other value greater than Int32.MaxValue fixes this (although it feels like a crutch).