### PR TITLE
Workaround for X509Certificate.RSA throwing an unhandled exception

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/X509Certificate.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X509Certificate.cs
@@ -68,6 +68,10 @@ namespace Mono.Security.X509 {
 		private byte[] certhash;
 		private RSA _rsa;
 		private DSA _dsa;
+
+		// from http://msdn.microsoft.com/en-gb/library/ff635835.aspx
+		private const string OID_DSA = "1.2.840.10040.4.1";
+		private const string OID_RSA = "1.2.840.113549.1.1.1";
 		
 		// from http://www.ietf.org/rfc/rfc2459.txt
 		//
@@ -247,7 +251,7 @@ namespace Mono.Security.X509 {
 				if (m_keyalgoparams == null)
 					throw new CryptographicException ("Missing key algorithm parameters.");
 
-				if (_dsa == null) {
+				if (_dsa == null && m_keyalgo == OID_DSA) {
 					DSAParameters dsaParams = new DSAParameters ();
 					// for DSA m_publickey contains 1 ASN.1 integer - Y
 					ASN1 pubkey = new ASN1 (m_publickey);
@@ -327,7 +331,7 @@ namespace Mono.Security.X509 {
 
 		public virtual RSA RSA {
 			get {
-				if (_rsa == null) {
+				if (_rsa == null && m_keyalgo == OID_RSA) {
 					RSAParameters rsaParams = new RSAParameters ();
 					// for RSA m_publickey contains 2 ASN.1 integers
 					// the modulus and the public exponent


### PR DESCRIPTION
As per https://bugzilla.xamarin.com/show_bug.cgi?id=23013, our ASN1 parser does very Wrong Things when it tries to parse an ECC public key. Real-world examples here include VeriSign_Class_3_Public_Primary_Certification_Authority_-_G4.pem and thawte_Primary_Root_CA_-_G2.pem where it tries to allocate gigabytes of memory and/or negative memory.

This tweak ensures the ASN1 parser will only be called inside the RSA getter when the OID for the key algo says it's RSA, and the DSA getter when the key algo says DSA. These values are correct as per http://msdn.microsoft.com/en-gb/library/ff635835.aspx and analysis of 164 certificates on an up-to-date Linux system.

By forcing this check, ECC certs will safely show a null RSA/DSA value, rather than throwing an unhandled exception and stopping certificate processing (which prevents SSL from working on any sites whose CA cert would be processed sequentially after an ECC cert, when Mono parses the entire cert store sequentially)