### PR TITLE
[sdb] Fixed GetThreads deadlock if thread was started or stopped during GetThread

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -1638,13 +1638,14 @@ namespace Mono.Debugger.Soft
 			SendReceive (CommandSet.VM, (int)CmdVM.SET_PROTOCOL_VERSION, new PacketWriter ().WriteInt (major).WriteInt (minor));
 		}
 
-		internal long[] VM_GetThreads () {
-			var res = SendReceive (CommandSet.VM, (int)CmdVM.ALL_THREADS, null);
-			int len = res.ReadInt ();
-			long[] arr = new long [len];
-			for (int i = 0; i < len; ++i)
-				arr [i] = res.ReadId ();
-			return arr;
+		internal void VM_GetThreads (Action<long[]> resultCallaback) {
+			Send (CommandSet.VM, (int)CmdVM.ALL_THREADS, null, (res) => {
+				int len = res.ReadInt ();
+				long[] arr = new long [len];
+				for (int i = 0; i < len; ++i)
+					arr [i] = res.ReadId ();
+				resultCallaback(arr);
+			}, 1);
 		}
 
 		internal void VM_Suspend () {


### PR DESCRIPTION
This hang regression was introduced with https://github.com/mono/mono/commit/52b168e3366344fa426fabb121df79a156a424c9.

What happens here IDE hangs if during GetThreads call thread is started or stopped, below is stack trace of 2 threads when hanged:
```
Thread	SDB Receiver:
Mono.Debugger.Soft.dll!Mono.Debugger.Soft.VirtualMachine.InvalidateThreadCache()	 
Mono.Debugger.Soft.dll!Mono.Debugger.Soft.EventHandler.Events(Mono.Debugger.Soft.SuspendPolicy suspend_policy = All, Mono.Debugger.Soft.EventInfo[] events = {Mono.Debugger.Soft.EventInfo[1]})	 
Mono.Debugger.Soft.dll!Mono.Debugger.Soft.Connection.ReceivePacket()	 
Mono.Debugger.Soft.dll!Mono.Debugger.Soft.Connection.receiver_thread_main()	 
mscorlib.dll!System.Threading.ThreadHelper.ThreadStart_Context(object state)	 
mscorlib.dll!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx)	 
mscorlib.dll!System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx)	 
mscorlib.dll!System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state)	 
mscorlib.dll!System.Threading.ThreadHelper.ThreadStart()

Thread	Main:
WindowsBase.dll!System.Windows.Threading.DispatcherSynchronizationContext.Wait(System.IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)	 
mscorlib.dll!System.Threading.SynchronizationContext.InvokeWaitMethodHelper(System.Threading.SynchronizationContext syncContext, System.IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)	 
[Native to Managed Transition]	 
mscorlib.dll!System.Threading.Monitor.Wait(object obj, int millisecondsTimeout, bool exitContext)	 
Mono.Debugger.Soft.dll!Mono.Debugger.Soft.Connection.SendReceive(Mono.Debugger.Soft.Connection.CommandSet command_set, int command, Mono.Debugger.Soft.Connection.PacketWriter packet)	 
Mono.Debugger.Soft.dll!Mono.Debugger.Soft.Connection.VM_GetThreads()	 
Mono.Debugger.Soft.dll!Mono.Debugger.Soft.VirtualMachine.GetThreads()	 
Mono.Debugging.Soft.dll!Mono.Debugging.Soft.SoftDebuggerSession.OnGetThreads(long processId = 0)	 
Mono.Debugging.dll!Mono.Debugging.Client.DebuggerSession.GetThreads(long processId)	 	 
```

What happens is GetThreads is waiting for SendReceive response which is done by SdbRecieve thread but this one is waiting for release of threadCacheLocker to invalidate threads...

Problem was that I thought GetThreads is only called when runtime is stopped and threads are not started/stopped while runtime is stopped... One of this assumptions is obviously wrong...

Explanation of fix:
I made VM_GetThreads work with callback so
```csharp
ids = threadsIds;
threadCache = threads = new ThreadMirror [threadsIds.Length];
fetchingEvent.Set ();
```
is called from SDBRecevier thread(where callback is executed) so invalidating and setting threadCache is in synchronized by always using same thread(SDBRecevier), hence no need for threadCacheLocker.

Rest of code is just to make callback logic work...

About commented code:"if (threadCache != threads)"...
This is possibility for future if someone wants to have really up to date response from GetThreads to check if threads were started/stopped during fetch and re-fetch newer threads... This scenario also wasn't handled before https://github.com/mono/mono/commit/52b168e3366344fa426fabb121df79a156a424c9.