### PR TITLE
[eglib] Fixed g_path_get_basename and g_path_get_dirname  when working with Windows paths on *nix

### DIFF
--- a/eglib/src/gpath.c
+++ b/eglib/src/gpath.c
@@ -91,17 +91,14 @@ g_build_path (const gchar *separator, const gchar *first_element, ...)
 static gchar*
 strrchr_seperator (const gchar* filename)
 {
-#ifdef G_OS_WIN32
-	char *p2;
-#endif
 	char *p;
+	char *p2;
 
-	p = strrchr (filename, G_DIR_SEPARATOR);
-#ifdef G_OS_WIN32
-	p2 = strrchr (filename, '/');
+	p = strrchr (filename, '/');
+	p2 = strrchr (filename, '\\');
+
 	if (p2 > p)
 		p = p2;
-#endif
 
 	return p;
 }

--- a/eglib/test/path.c
+++ b/eglib/test/path.c
@@ -152,7 +152,7 @@ test_dirname ()
 {
 	char *s;
 
-#ifdef G_OS_WIN32
+
 	s = g_path_get_dirname ("c:\\home\\miguel");
 	if (strcmp (s, "c:\\home") != 0)
 		return FAILED ("Expected c:\\home, got %s", s);
@@ -176,7 +176,7 @@ test_dirname ()
 	s = g_path_get_dirname ("c:\\index.html");
 	if (strcmp (s, "c:") != 0)
 		return FAILED ("Expected [c:], got [%s]", s);
-#else
+
 	s = g_path_get_dirname ("/home/miguel");
 	if (strcmp (s, "/home") != 0)
 		return FAILED ("Expected /home, got %s", s);
@@ -195,7 +195,7 @@ test_dirname ()
 	s = g_path_get_dirname ("/index.html");
 	if (strcmp (s, "/") != 0)
 		return FAILED ("Expected [/], got [%s]", s);
-#endif	
+
 	return OK;
 }
 
@@ -204,7 +204,6 @@ test_basename ()
 {
 	char *s;
 
-#ifdef G_OS_WIN32
 	s = g_path_get_basename ("");
 	if (strcmp (s, ".") != 0)
 		return FAILED ("Expected `.', got %s", s);
@@ -229,7 +228,7 @@ test_basename ()
 	if (strcmp (s, "dingus") != 0)
 		return FAILED ("2 Expected dingus, got %s", s);
 	g_free (s);
-#else
+
 	s = g_path_get_basename ("");
 	if (strcmp (s, ".") != 0)
 		return FAILED ("Expected `.', got %s", s);
@@ -244,7 +243,6 @@ test_basename ()
 	if (strcmp (s, "dingus") != 0)
 		return FAILED ("2 Expected dingus, got %s", s);
 	g_free (s);
-#endif
 	return OK;
 }
 


### PR DESCRIPTION
This is primary for g_path_get_basename method. Because if some path is generated
on Windows and later used on *nix g_path_get_basename was returning full path instead of
filename as it should. This caused bug when working with .mdb files created on
Windows and used on *nix. I also disabled platform specific unit tests so now all tests are ran on all platforms. For both g_path_get_dirname and g_path_get_basename.