### PR TITLE
While resolving assemblies, populate the RequestingAssembly property of ResolveEventArgs

### DIFF
--- a/mcs/class/corlib/System/AppDomain.cs
+++ b/mcs/class/corlib/System/AppDomain.cs
@@ -1195,7 +1195,7 @@ namespace System {
 			AssemblyLoad (this, new AssemblyLoadEventArgs (assembly));
 		}
 
-		private Assembly DoAssemblyResolve (string name, bool refonly)
+		private Assembly DoAssemblyResolve (string name, Assembly requestingAssembly, bool refonly)
 		{
 			ResolveEventHandler del;
 #if !NET_2_1
@@ -1234,7 +1234,7 @@ namespace System {
 
 				foreach (Delegate eh in invocation_list) {
 					ResolveEventHandler handler = (ResolveEventHandler) eh;
-					Assembly assembly = handler (this, new ResolveEventArgs (name));
+					Assembly assembly = handler (this, new ResolveEventArgs (name, requestingAssembly));
 					if (assembly != null)
 						return assembly;
 				}

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -183,7 +183,9 @@ static mono_mutex_t assembly_binding_mutex;
 static GSList *loaded_assembly_bindings = NULL;
 
 static MonoAssembly*
-mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, gboolean refonly, gboolean postload);
+mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload);
+static MonoAssembly*
+mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *requesting, const char *basedir, MonoImageOpenStatus *status, gboolean refonly);
 static MonoBoolean
 mono_assembly_is_in_gac (const gchar *filanem);
 
@@ -1090,12 +1092,12 @@ mono_assembly_load_reference (MonoImage *image, int index)
 	if (image->assembly && image->assembly->ref_only) {
 		/* We use the loaded corlib */
 		if (!strcmp (aname.name, "mscorlib"))
-			reference = mono_assembly_load_full (&aname, image->assembly->basedir, &status, FALSE);
+			reference = mono_assembly_load_full_internal (&aname, image->assembly, image->assembly->basedir, &status, FALSE);
 		else {
 			reference = mono_assembly_loaded_full (&aname, TRUE);
 			if (!reference)
 				/* Try a postload search hook */
-				reference = mono_assembly_invoke_search_hook_internal (&aname, TRUE, TRUE);
+				reference = mono_assembly_invoke_search_hook_internal (&aname, image->assembly, TRUE, TRUE);
 		}
 
 		/*
@@ -1111,9 +1113,9 @@ mono_assembly_load_reference (MonoImage *image, int index)
 		 * The second load attempt has the basedir set to keep compatibility with the old mono behavior, for
 		 * example bug-349190.2.cs and who knows how much more code in the wild.
 		 */
-		reference = mono_assembly_load (&aname, NULL, &status);
+		reference = mono_assembly_load_full_internal (&aname, image->assembly, NULL, &status, FALSE);
 		if (!reference && image->assembly)
-			reference = mono_assembly_load (&aname, image->assembly->basedir, &status);
+			reference = mono_assembly_load_full_internal (&aname, image->assembly, image->assembly->basedir, &status, FALSE);
 	}
 
 	if (reference == NULL){
@@ -1232,7 +1234,7 @@ struct AssemblySearchHook {
 AssemblySearchHook *assembly_search_hook = NULL;
 
 static MonoAssembly*
-mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, gboolean refonly, gboolean postload)
+mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload)
 {
 	AssemblySearchHook *hook;
 
@@ -1244,13 +1246,16 @@ mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, gboolean ref
 		}
 	}
 
+	if (postload)
+		return mono_domain_assembly_postload_search(aname, requesting, refonly);
+
 	return NULL;
 }
 
 MonoAssembly*
 mono_assembly_invoke_search_hook (MonoAssemblyName *aname)
 {
-	return mono_assembly_invoke_search_hook_internal (aname, FALSE, FALSE);
+	return mono_assembly_invoke_search_hook_internal (aname, NULL, FALSE, FALSE);
 }
 
 static void
@@ -1764,7 +1769,7 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 	 * assemblies lock.
 	 */
 	if (ass->aname.name) {
-		ass2 = mono_assembly_invoke_search_hook_internal (&ass->aname, refonly, FALSE);
+		ass2 = mono_assembly_invoke_search_hook_internal (&ass->aname, NULL, refonly, FALSE);
 		if (ass2) {
 			g_free (ass);
 			g_free (base_dir);
@@ -2367,7 +2372,7 @@ mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *sta
 		res->in_gac = TRUE;
 	else {
 		MonoDomain *domain = mono_domain_get ();
-		MonoReflectionAssembly *refasm = mono_try_assembly_resolve (domain, mono_string_new (domain, name), FALSE);
+		MonoReflectionAssembly *refasm = mono_try_assembly_resolve (domain, mono_string_new (domain, name), NULL, FALSE);
 		if (refasm)
 			res = refasm->assembly;
 	}
@@ -2947,6 +2952,17 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 	return result;
 }
 
+MonoAssembly*
+mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *requesting, const char *basedir, MonoImageOpenStatus *status, gboolean refonly)
+{
+	MonoAssembly *result = mono_assembly_load_full_nosearch (aname, basedir, status, refonly);
+
+	if (!result)
+		/* Try a postload search hook */
+		result = mono_assembly_invoke_search_hook_internal (aname, requesting, refonly, TRUE);
+	return result;
+}
+
 /**
  * mono_assembly_load_full:
  * @aname: A MonoAssemblyName with the assembly name to load.
@@ -2966,12 +2982,7 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 MonoAssembly*
 mono_assembly_load_full (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, gboolean refonly)
 {
-	MonoAssembly *result = mono_assembly_load_full_nosearch (aname, basedir, status, refonly);
-	
-	if (!result)
-		/* Try a postload search hook */
-		result = mono_assembly_invoke_search_hook_internal (aname, refonly, TRUE);
-	return result;
+	return mono_assembly_load_full_internal (aname, NULL, basedir, status, refonly);
 }
 
 /**
@@ -2989,9 +3000,9 @@ mono_assembly_load_full (MonoAssemblyName *aname, const char *basedir, MonoImage
 MonoAssembly*
 mono_assembly_load (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status)
 {
-	return mono_assembly_load_full (aname, basedir, status, FALSE);
+	return mono_assembly_load_full_internal (aname, NULL, basedir, status, FALSE);
 }
-	
+
 MonoAssembly*
 mono_assembly_loaded_full (MonoAssemblyName *aname, gboolean refonly)
 {
@@ -3000,7 +3011,7 @@ mono_assembly_loaded_full (MonoAssemblyName *aname, gboolean refonly)
 
 	aname = mono_assembly_remap_version (aname, &maped_aname);
 
-	res = mono_assembly_invoke_search_hook_internal (aname, refonly, FALSE);
+	res = mono_assembly_invoke_search_hook_internal (aname, NULL, refonly, FALSE);
 
 	return res;
 }

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -661,7 +661,10 @@ MONO_API void
 mono_domain_add_class_static_data (MonoDomain *domain, MonoClass *klass, gpointer data, guint32 *bitmap);
 
 MonoReflectionAssembly *
-mono_try_assembly_resolve (MonoDomain *domain, MonoString *fname, gboolean refonly) MONO_INTERNAL;
+mono_try_assembly_resolve (MonoDomain *domain, MonoString *fname, MonoAssembly *requesting, gboolean refonly) MONO_INTERNAL;
+
+MonoAssembly *
+mono_domain_assembly_postload_search (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly);
 
 MonoAssembly* mono_assembly_load_full_nosearch (MonoAssemblyName *aname, 
 						const char       *basedir, 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -57,6 +57,7 @@ BASE_TEST_CS_SRC=		\
 	arraylist.cs		\
 	assemblyresolve_event.cs	\
 	assemblyresolve_event3.cs	\
+	assemblyresolve_event4.cs	\
 	checked.cs		\
 	char-isnumber.cs	\
 	create-instance.cs	\

--- a/mono/tests/assemblyresolve_event4.cs
+++ b/mono/tests/assemblyresolve_event4.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+class App
+{
+	public static int Main ()
+	{
+		AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler (MyResolveEventHandler);
+
+		try {
+			var a = Assembly.Load ("test");
+			foreach (Type t in a.GetTypes ()) {
+				Console.WriteLine ("pp: " + t + " " + t.BaseType);
+			}
+		} catch (Exception ex) {
+			Console.WriteLine ("Caught exception: {0}", ex);
+			return 1;
+		}
+
+		return 0;
+	}
+
+	static Assembly MyResolveEventHandler (object sender, ResolveEventArgs args)
+	{
+		var path = Path.Combine (Directory.GetCurrentDirectory (), "assemblyresolve", "deps");
+		if (args.Name == "test" && args.RequestingAssembly == null)
+			return Assembly.LoadFile (Path.Combine (path, "test.dll"));
+		if (args.Name == "TestBase, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" && args.RequestingAssembly.GetName ().Name == "test")
+			return Assembly.LoadFile (Path.Combine (path, "TestBase.dll"));
+
+		throw new InvalidOperationException (String.Format ("Unexpected parameter combination {0} {1}", args.Name, args.RequestingAssembly));
+	}
+}

--- a/mono/utils/mono-dl-posix.c
+++ b/mono/utils/mono-dl-posix.c
@@ -45,7 +45,7 @@ mono_dl_get_so_suffixes (void)
 int
 mono_dl_get_executable_path (char *buf, int buflen)
 {
-	return readlink ("/proc/self/exe", buf, buflen - 1;
+	return readlink ("/proc/self/exe", buf, buflen - 1);
 }
 #endif
 


### PR DESCRIPTION
Currently, the RequestingAssembly property of ResolveEventArgs [is not populated](https://github.com/mono/mono/blob/master/mcs/class/corlib/System/AppDomain.cs#L1237) when resolving assemblies.
This PR adds the necessary plumbing to transport the requesting assembly through the hooks.

This fixes [a problem in ASP.NET 5](https://github.com/aspnet/XRE/issues/1048) and fixes the behavioral differences as observed [here](https://github.com/davidfowl/Mono-Assembly-Resolve-Issue)