### PR TITLE
XmlReader.ReadToNextSibling(string) doesn't match .net behaviour

### DIFF
--- a/mcs/class/System.XML/Test/System.Xml/XmlReaderCommonTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlReaderCommonTests.cs
@@ -1753,6 +1753,19 @@ namespace MonoTests.System.Xml
 			Assert.AreEqual (3, count, "#3");
 		}
 
+		[Test, Category("NotWorking")]
+		public void ReadToNextSiblingInInitialReadState ()
+		{
+			var xml = "<Text name=\"hello\"><Something></Something></Text>";
+			var ms = new MemoryStream(Encoding.Default.GetBytes(xml));
+			var xtr = XmlReader.Create(ms);
+
+			Assert.AreEqual(xtr.ReadState, ReadState.Initial);
+			xtr.ReadToNextSibling("Text");
+
+			Assert.AreEqual("hello", xtr.GetAttribute("name"));
+		}
+
 		[Test]
 		public void ReadSubtree ()
 		{


### PR DESCRIPTION
[MSDN](https://msdn.microsoft.com/en-us/library/yf7w4zx9(v=vs.110).aspx) states that you should not use ReadToNextSibling when the XmlReader is in the Initial State,  instead you should Read first.

While the documentation is lovely and all, this unit test demonstrates that fundamental rule of all documentation,  "All documentation of any size is wrong".

I realise that there is ( or will be ) a effort to start using the referencesources and therefore I have not yet attempted to fix this issue and instead would like to submit it to the unit test suite only.

What is the best approach with this?   I'm happy to mark the test as Ignore or Explicit if required.  I also see there is a branch for the xml reference sources which could have this merged immediately.

Thanks