### PR TITLE
[pdb2mdb] Skip unknown pdb metadata

### DIFF
--- a/mcs/tools/pdb2mdb/PdbFunction.cs
+++ b/mcs/tools/pdb2mdb/PdbFunction.cs
@@ -325,7 +325,6 @@ namespace Microsoft.Cci.Pdb {
         case 2: this.ReadForwardedToModuleInfo(bits); break;
         case 3: this.ReadIteratorLocals(bits); break;
         case 4: this.ReadForwardIterator(bits); break;
-        default: throw new PdbDebugException("Unknown custom metadata item kind: {0}", kind);
       }
       bits.Position = savedPosition+(int)numberOfBytesInItem;
     }


### PR DESCRIPTION
This patch allows pdb2mdb to convert pdb files containing
metadata items emitted by the Roslyn compiler.