### PR TITLE
Include hard-coded strings (SR.cs-style) rather than using AppliCationServicesStrings.Designer.cs

### DIFF
--- a/mcs/class/System.Web.ApplicationServices/ReferenceSources/ApplicationServicesStrings.cs
+++ b/mcs/class/System.Web.ApplicationServices/ReferenceSources/ApplicationServicesStrings.cs
@@ -1,0 +1,51 @@
+//
+// ApplicationServicesStrings.cs: Manually collected resource strings for ReferenceSources
+//
+// Authors:
+//	Alexander Köplinger  <alex.koeplinger@outlook.com>
+//	Jo Shields <jo.shields@xamarin.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal class ApplicationServicesStrings
+{
+	public const string Can_not_use_encrypted_passwords_with_autogen_keys = "Can_not_use_encrypted_passwords_with_autogen_keys";
+	public const string CustomLoader_ForbiddenByHost = "CustomLoader_ForbiddenByHost";
+	public const string CustomLoader_NoAttributeFound = "CustomLoader_NoAttributeFound";
+	public const string CustomLoader_NotInFullTrust = "CustomLoader_NotInFullTrust";
+	public const string CustomLoader_MustImplementICustomLoader = "CustomLoader_MustImplementICustomLoader";
+	public const string Membership_DuplicateEmail = "Membership_DuplicateEmail";
+	public const string Membership_DuplicateProviderUserKey = "Membership_DuplicateProviderUserKey";
+	public const string Membership_DuplicateUserName = "Membership_DuplicateUserName";
+	public const string Membership_InvalidAnswer = "Membership_InvalidAnswer";
+	public const string Membership_InvalidEmail = "Membership_InvalidEmail";
+	public const string Membership_InvalidPassword = "Membership_InvalidPassword";
+	public const string Membership_InvalidProviderUserKey = "Membership_InvalidProviderUserKey";
+	public const string Membership_InvalidQuestion = "Membership_InvalidQuestion";
+	public const string Membership_InvalidUserName = "Membership_InvalidUserName";
+	public const string Membership_no_error = "Membership_no_error";
+	public const string Membership_provider_name_invalid = "Membership_provider_name_invalid";
+	public const string Membership_UserRejected = "Membership_UserRejected";
+	public const string Parameter_can_not_be_empty = "Parameter_can_not_be_empty";
+	public const string Platform_not_supported = "Platform_not_supported";
+	public const string Provider_Error = "Provider_Error";
+	public const string Provider_must_implement_type = "Provider_must_implement_type";
+}

--- a/mcs/class/System.Web.ApplicationServices/net_4_0_System.Web.ApplicationServices.dll.sources
+++ b/mcs/class/System.Web.ApplicationServices/net_4_0_System.Web.ApplicationServices.dll.sources
@@ -7,6 +7,7 @@ Assembly/AssemblyInfo.cs
 ../../build/common/SR.cs
 
 System.Web.Security/IMembershipHelper.cs
+ReferenceSources/ApplicationServicesStrings.cs
 
 ../../../external/referencesource/System.Web.ApplicationServices/Hosting/CustomLoaderAttribute.cs
 ../../../external/referencesource/System.Web.ApplicationServices/Hosting/ICustomLoaderHelperFunctions.cs
@@ -28,5 +29,4 @@ System.Web.Security/IMembershipHelper.cs
 ../../../external/referencesource/System.Web.ApplicationServices/Security/MembershipUserCollection.cs
 ../../../external/referencesource/System.Web.ApplicationServices/Security/MembershipUser.cs
 ../../../external/referencesource/System.Web.ApplicationServices/Properties/AssemblyInfo.cs
-../../../external/referencesource/System.Web.ApplicationServices/ApplicationServicesStrings.Designer.cs
 


### PR DESCRIPTION
This avoids depending on a missing .resources file with string translations in it