### PR TITLE
Fix to UriTemplate.Match to properly handle query parameters without a v...

### DIFF
--- a/mcs/class/System.ServiceModel.Web/System/UriTemplate.cs
+++ b/mcs/class/System.ServiceModel.Web/System/UriTemplate.cs
@@ -321,11 +321,15 @@ namespace System
 			string [] parameters = Uri.UnescapeDataString (candidate.Query.Substring (1)).Split ('&'); // chop first '?'
 			foreach (string parameter in parameters) {
 				string [] pair = parameter.Split ('=');
-				m.QueryParameters.Add (pair [0], pair [1]);
-				if (!query_params.ContainsKey (pair [0]))
-					continue;
-				string templateName = query_params [pair [0]];
-				vc.Add (templateName, pair [1]);
+				if (pair.Length > 0) {
+					m.QueryParameters.Add (pair [0], pair.Length == 2 ? pair [1] : null);
+					if (!query_params.ContainsKey (pair [0]))
+						continue;
+					if (pair.Length > 1) {
+						string templateName = query_params [pair [0]];
+						vc.Add (templateName, pair [1]);
+					}
+				}
 			}
 
 			return m;

--- a/mcs/class/System.ServiceModel.Web/Test/System/UriTemplateTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System/UriTemplateTest.cs
@@ -462,6 +462,14 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		public void MatchIgnoreQueryParamNoValue ()
+		{
+			var t = new UriTemplate ("/{a}/*", true);
+			var m = t.Match (new Uri ("http://s"), new Uri ("http://s/a/b?foo"));
+			Assert.AreEqual (1, m.QueryParameters.Keys.Count, "#1");
+		}
+
+		[Test]
 		public void IgnoreTrailingSlash ()
 		{
 			var t = new UriTemplate ("/{foo}/{bar}", true);


### PR DESCRIPTION
...alue.  No longer throws IndexOutOfRangeException and the parameter is added to the resulting UriTemplateMatch.QueryParameters field with a null value, same as in .NET.

This change is released under the MIT license.