### PR TITLE
[corlib] Fixed TimeZoneInfo.TryGetTransitionOffset.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1016,7 +1016,7 @@ namespace System
 
 		private AdjustmentRule GetApplicableRule (DateTime dateTime)
 		{
-			//Transitions are always in standard time
+			//Applicable rules are in standard time
 			DateTime date = dateTime;
 
 			if (dateTime.Kind == DateTimeKind.Local && this != TimeZoneInfo.Local)
@@ -1047,14 +1047,17 @@ namespace System
 			if (transitions == null)
 				return false;
 
-			//Transitions are always in standard time
+			//Transitions are in UTC
 			DateTime date = dateTime;
 
 			if (dateTime.Kind == DateTimeKind.Local && this != TimeZoneInfo.Local)
 				date = date.ToUniversalTime () + BaseUtcOffset;
 
-			if (dateTime.Kind == DateTimeKind.Utc && this != TimeZoneInfo.Utc)
-				date = date + BaseUtcOffset;
+			if (dateTime.Kind != DateTimeKind.Utc) {
+				if (date.Ticks < BaseUtcOffset.Ticks)
+					return false;
+				date = date - BaseUtcOffset;
+			}
 
 			for (var i =  transitions.Count - 1; i >= 0; i--) {
 				var pair = transitions [i];

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -300,6 +300,15 @@ namespace MonoTests.System
 				// If it is DST, then the runtime has the bug that we are looking for.
 				Assert.IsFalse (timeZone.IsDaylightSavingTime (new DateTime (2014, 3, 7, 12, 0, 0, DateTimeKind.Unspecified)));
 			}
+
+			[Test] //Covers #25050
+			public void TestAthensDST ()
+			{
+				TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById ("Europe/Athens");
+				var date = new DateTime (2014, 3, 30 , 2, 0, 0);
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
+				Assert.AreEqual (new TimeSpan (2,0,0), tzi.GetUtcOffset (date));
+			}
 		}
 		
 		[TestFixture]


### PR DESCRIPTION
Olson TZ transitions are in UTC, and TryGetTransitionOffset used the TZ standard time.
TryGetTransitionOffset was comparing UTC with TZ standard times thus DST transitions could be obtained some hours before their start.
TryGetTransitionOffset is now changing provided times to UTC before comparing them with the transition times.
Fixes [#25050](https://bugzilla.xamarin.com/show_bug.cgi?id=25050).