### PR TITLE
mono-context.h: fix build on MIPS

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -464,6 +464,8 @@ mono_ia64_context_get_fp (MonoContext *ctx)
 
 #elif ((defined(__mips__) && !defined(MONO_CROSS_COMPILE)) || (defined(TARGET_MIPS))) && SIZEOF_REGISTER == 4 /* defined(__ia64__) */
 
+#include <mono/arch/mips/mips-codegen.h>
+
 typedef struct {
 	mgreg_t	    sc_pc;
 	mgreg_t		sc_regs [32];


### PR DESCRIPTION
The mono-context.h file uses definitions such as mips_fp and mips_sp,
which are defined in <mono/arch/mips/mips-codegen.h>, but this file is
not included, leading to build failures.

This fix is similar to 4437ecea91bab3fe68ba1c30521acf75052662cd (for
ARM).

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>