### PR TITLE
Skip unrecognized #pragma directive

### DIFF
--- a/mcs/mcs/cs-tokenizer.cs
+++ b/mcs/mcs/cs-tokenizer.cs
@@ -2629,6 +2629,9 @@ namespace Mono.CSharp
 			}
 
 			Report.Warning (1633, 1, Location, "Unrecognized #pragma directive");
+
+			// Eat any remaining characters on the line
+			ReadToEndOfLine ();
 		}
 
 		bool eval_val (string s)

--- a/mcs/tests/test-pragma-unrecognized.cs
+++ b/mcs/tests/test-pragma-unrecognized.cs
@@ -1,0 +1,9 @@
+// Compiler options: -warn:4
+// This test should print only: warning CS1633: Unrecognized #pragma directive
+
+#pragma xxx some unrecognized text
+
+public class C
+{
+  public static void Main () {}
+}

--- a/mcs/tests/ver-il-net_4_5.xml
+++ b/mcs/tests/ver-il-net_4_5.xml
@@ -69806,4 +69806,14 @@
       </method>
     </type>
   </test>
+  <test name="test-pragma-unrecognized.cs">
+    <type name="C">
+      <method name="Void Main()" attrs="150">
+        <size>2</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
 </tests>


### PR DESCRIPTION
mcs should skip contents of unrecognized #pragma directive (as csc does)

So directive like this "#pragma xxx some text" will issue a warning, but no errors about "some text".

Test attached