### PR TITLE
Prevent right click from triggering ToolStripItem.HandleClick

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripItem.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripItem.cs
@@ -1775,7 +1775,8 @@ namespace System.Windows.Forms
 				
 			switch (met) {
 				case ToolStripItemEventType.MouseUp:
-					this.HandleClick (((MouseEventArgs)e).Clicks, e);
+					if (((MouseEventArgs)e).Button == MouseButtons.Left)
+						this.HandleClick (((MouseEventArgs)e).Clicks, e);
 					this.OnMouseUp ((MouseEventArgs)e);
 					break;
 				case ToolStripItemEventType.MouseDown:


### PR DESCRIPTION
This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=26887.