### PR TITLE
[corlib] ModuleBuilder.GetMethodToken no longer has a module check.

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -574,8 +574,7 @@ namespace System.Reflection.Emit {
 		{
 			if (entryPoint == null)
 				throw new ArgumentNullException ("entryPoint");
-			if (entryPoint.DeclaringType.Module != this)
-				throw new InvalidOperationException ("entryPoint is not contained in this module");
+
 			throw new NotImplementedException ();
 		}
 


### PR DESCRIPTION
.NET implementation is able to get method tokens from other modules [source](http://referencesource.microsoft.com/#mscorlib/system/reflection/emit/modulebuilder.cs,1824).
This was causing a regression on a System.Xml.Xsl.XslTransformTests.Bug487065 while using referencesource's System.Xml implementation.

GetMethodToken calls [ves_icall_ModuleBuilder_getToken](https://github.com/mono/mono/blob/5937d3a70c818ca54b18671b32bdbb5b3263cea3/mono/metadata/icall.c#L1153) which calls [mono_image_create_token](https://github.com/mono/mono/blob/5937d3a70c818ca54b18671b32bdbb5b3263cea3/mono/metadata/reflection.c#L4916)