### PR TITLE
Only call string.Format in Debug.Assert if really necessary

### DIFF
--- a/mcs/class/System/System.Diagnostics/Debug.cs
+++ b/mcs/class/System/System.Diagnostics/Debug.cs
@@ -80,6 +80,10 @@ namespace System.Diagnostics {
 		public static void Assert (bool condition, string message,
 			string detailMessageFormat, params object [] args)
 		{
+			if (condition)
+				// Return early to avoid the string formatting
+				return;
+
 			TraceImpl.Assert (condition,
 				message,
 				string.Format (detailMessageFormat, args));


### PR DESCRIPTION
Right now (without this change), `Debug.Assert` **always** formats its string parameters, even if doing so wouldn't be necessary because the condition is true. This has a huge impact on code that asserts frequently because it assumes that calling `Assert(true, ...)` is cheap.

The new behavior matches the [MSDN documentation](https://msdn.microsoft.com/en-us/library/cc190597(v=vs.110).aspx) which explicitly states:

>If the result is false, The String.Format(String, Object[]) method is called