### PR TITLE
Generate NUnit interpretation of whether "mono --regressions" passed

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -660,7 +660,8 @@ rcheck: mono $(regtests)
 if NACL_CODEGEN
 	for i in $(regtests); do echo "running test $$i"; $(RUNTIME) $$i --exclude 'NaClDisable' || exit 1; done
 else
-	$(RUNTIME) --regression $(regtests)
+	-($(RUNTIME) --regression $(regtests); echo $$? > regressionexitcode.out) | ./emitnunit.pl
+	exit $$(cat regressionexitcode.out)
 endif
 
 check-seq-points: mono $(regtests)
@@ -727,7 +728,7 @@ docu: mini.sgm
 check-local: rcheck check-seq-points
 
 clean-local:
-	rm -f mono a.out gmon.out *.o buildver-boehm.h buildver-sgen.h test.exe
+	rm -f mono a.out gmon.out *.o buildver-boehm.h buildver-sgen.h test.exe regressionexitcode.out
 
 pkgconfigdir = $(libdir)/pkgconfig
 

--- a/mono/mini/emitnunit.pl
+++ b/mono/mini/emitnunit.pl
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Cwd;
+use POSIX qw(strftime uname locale_h);
+use Net::Domain qw(hostname hostfqdn);
+use locale;
+
+my $line;
+foreach $line (<STDIN>) {
+    chomp ($line);
+    print "$line\n";
+    if ($line =~ /^Overall results:/) {
+        # do magic nunit emission here
+        # failures look like:
+        #    Overall results: tests: 19992, failed: 48, opt combinations: 24 (pass: 99.76%)
+        # passes look like:
+        #    Overall results: tests: 20928, 100% pass, opt combinations: 24
+        my @words = split (/ /, $line);
+        my $failed;
+        my $successbool;
+        my $total = $words[3];
+        my $mylocale = setlocale (LC_CTYPE);
+        $mylocale = substr($mylocale, 0, index($mylocale, '.'));
+        $mylocale =~ s/_/-/;
+        if ($line =~ /failed:/) {
+            $failed = $words[5];
+        } else {
+            $failed = "0,";
+        }
+        chop ($failed);
+        chop ($total);
+        if ($failed > 0) {
+            $successbool = "False";
+        } else {
+            $successbool = "True";
+        }
+        open (my $nunitxml, '>', 'TestResults_regression.xml') or die "Could not write to 'TestResults_regression.xml' $!";
+        print $nunitxml "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n";
+        print $nunitxml "<!--This file represents the results of running a test suite-->\n";
+        print $nunitxml "<test-results name=\"regression-tests.dummy\" total=\"$total\" failures=\"$failed\" not-run=\"0\" date=\"" . strftime ("%F", localtime) . "\" time=\"" . strftime ("%T", localtime) . "\">\n";
+        print $nunitxml "  <environment nunit-version=\"2.4.8.0\" clr-version=\"4.0.30319.17020\" os-version=\"Unix " . (uname ())[2]  . "\" platform=\"Unix\" cwd=\"" . getcwd . "\" machine-name=\"" . hostname . "\" user=\"" . getpwuid ($<) . "\" user-domain=\"" . hostfqdn  . "\" />\n";
+        print $nunitxml "  <culture-info current-culture=\"$mylocale\" current-uiculture=\"$mylocale\" />\n";
+        print $nunitxml "  <test-suite name=\"regression-tests.dummy\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
+        print $nunitxml "    <results>\n";
+        print $nunitxml "      <test-suite name=\"MonoTests\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
+        print $nunitxml "        <results>\n";
+        print $nunitxml "          <test-suite name=\"regressions\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
+        print $nunitxml "            <results>\n";
+        print $nunitxml "              <test-case name=\"MonoTests.regressions.100percentsuccess\" executed=\"True\" success=\"$successbool\" time=\"0\" asserts=\"0\"";
+        if ( $failed > 0) {
+        print $nunitxml ">\n";
+        print $nunitxml "                <failure>\n";
+        print $nunitxml "                  <message><![CDATA[";
+        foreach $line (<STDIN>) {
+            chomp ($line);
+            print "$line\n";
+        }
+        print $nunitxml "]]></message>\n";
+        print $nunitxml "                  <stack-trace>\n";
+        print $nunitxml "                  </stack-trace>\n";
+        print $nunitxml "                </failure>\n";
+        print $nunitxml "              </test-case>\n";
+        } else {
+        print $nunitxml " />\n";
+        }
+        print $nunitxml "            </results>\n";
+        print $nunitxml "          </test-suite>\n";
+        print $nunitxml "        </results>\n";
+        print $nunitxml "      </test-suite>\n";
+        print $nunitxml "    </results>\n";
+        print $nunitxml "  </test-suite>\n";
+        print $nunitxml "</test-results>\n";
+        close $nunitxml;
+    }
+}


### PR DESCRIPTION
This is another NUnitification of an existing test suite.

Sample output:

    <?xml version="1.0" encoding="utf-8" standalone="no"?>
    <!--This file represents the results of running a test suite-->
    <test-results name="regression-tests.dummy" total="23544" failures="0" not-run="0" date="2015-02-12" time="15:20:12">
      <environment nunit-version="2.4.8.0" clr-version="4.0.30319.17020" os-version="Unix 3.13.0-45-generic" platform="Unix" cwd="/home/directhex/Projects/mono/mono/mini" machine-name="marceline" user="directhex" user-domain="marceline" />
      <culture-info current-culture="en-GB" current-uiculture="en-GB" />
      <test-suite name="regression-tests.dummy" success="True" time="0" asserts="0">
        <results>
          <test-suite name="MonoTests" success="True" time="0" asserts="0">
            <results>
              <test-suite name="regressions" success="True" time="0" asserts="0">
                <results>
                  <test-case name="MonoTests.regressions.100percentsuccess" executed="True" success="True" time="0" asserts="0" />
                </results>
              </test-suite>
            </results>
          </test-suite>
        </results>
      </test-suite>
    </test-results>

Perl with only base-class support (i.e. nothing useful like an actual XML library) should be somewhat reliable as a choice, but this *needs* double-checking on OSX. We already depend on Perl in our test suite, for mono/profiler.

This does not make any effort to split up and parse the individual tests, just the summary. Any lines added after the summary are treated as an NUnit <message>