### PR TITLE
Bug 27010 - Difference in Assembly.GetExportedTypes with .NET

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/MonoGenericClassTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MonoGenericClassTest.cs
@@ -204,6 +204,23 @@ namespace MonoTests.System.Reflection.Emit
 			Assert.AreSame (expected, t.BaseType, "#1");
 			
 		}
+
+		class Nested
+		{
+			public class Inner {}
+		}
+
+		public class Nested2
+		{
+			public class Inner {}
+		}
+
+		[Test]
+		public void TestsClassInnerStuff ()
+		{
+			CollectionAssert.Contains(typeof(Nested).Assembly.GetExportedTypes (), typeof(Nested.Inner));
+			CollectionAssert.Contains(typeof(Nested).Assembly.GetExportedTypes (), typeof(Nested2.Inner));
+		}
 	}
 }
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5156,6 +5156,20 @@ ves_icall_System_Reflection_Assembly_LoadPermissions (MonoReflectionAssembly *as
 	return result;	
 }
 
+int
+mono_type_is_visible (MonoTableInfo *tdef, MonoImage *image, int type)
+{
+	guint32 attrs, visibility;
+	do {
+		attrs = mono_metadata_decode_row_col (tdef, type, MONO_TYPEDEF_FLAGS);
+		visibility = attrs & TYPE_ATTRIBUTE_VISIBILITY_MASK;
+		if (visibility != TYPE_ATTRIBUTE_PUBLIC && visibility != TYPE_ATTRIBUTE_NESTED_PUBLIC)
+			return 0;
+	} while (mono_metadata_nested_in_typedef (image, type++));
+
+	return 1;
+}
+
 static MonoArray*
 mono_module_get_types (MonoDomain *domain, MonoImage *image, MonoArray **exceptions, MonoBoolean exportedOnly)
 {
@@ -5163,15 +5177,12 @@ mono_module_get_types (MonoDomain *domain, MonoImage *image, MonoArray **excepti
 	MonoClass *klass;
 	MonoTableInfo *tdef = &image->tables [MONO_TABLE_TYPEDEF];
 	int i, count;
-	guint32 attrs, visibility;
 
 	/* we start the count from 1 because we skip the special type <Module> */
 	if (exportedOnly) {
 		count = 0;
 		for (i = 1; i < tdef->rows; ++i) {
-			attrs = mono_metadata_decode_row_col (tdef, i, MONO_TYPEDEF_FLAGS);
-			visibility = attrs & TYPE_ATTRIBUTE_VISIBILITY_MASK;
-			if (visibility == TYPE_ATTRIBUTE_PUBLIC || visibility == TYPE_ATTRIBUTE_NESTED_PUBLIC)
+			if (mono_type_is_visible (tdef, image, i))
 				count++;
 		}
 	} else {
@@ -5181,9 +5192,7 @@ mono_module_get_types (MonoDomain *domain, MonoImage *image, MonoArray **excepti
 	*exceptions = mono_array_new (domain, mono_defaults.exception_class, count);
 	count = 0;
 	for (i = 1; i < tdef->rows; ++i) {
-		attrs = mono_metadata_decode_row_col (tdef, i, MONO_TYPEDEF_FLAGS);
-		visibility = attrs & TYPE_ATTRIBUTE_VISIBILITY_MASK;
-		if (!exportedOnly || (visibility == TYPE_ATTRIBUTE_PUBLIC || visibility == TYPE_ATTRIBUTE_NESTED_PUBLIC)) {
+		if (!exportedOnly || mono_type_is_visible (tdef, image, i)) {
 			MonoError error;
 			klass = mono_class_get_checked (image, (i + 1) | MONO_TOKEN_TYPE_DEF, &error);
 			g_assert (!mono_loader_get_last_error ()); /* Plug any leaks */


### PR DESCRIPTION
While this appears to fix the issue, I'm sure there are issues with the PR:
 1. Tests location is probably totally wrong.
 2. I'm not sure I understood `mono_metadata_nested_in_typedef` correctly.
 3. Caused by `2.` I'm not sure whether it's the _real_ fix.