### PR TITLE
Bug 27010 - Difference in Assembly.GetExportedTypes with .NET

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/VisibilityTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/VisibilityTest.cs
@@ -1,0 +1,98 @@
+// VisibilityTest.cs
+//
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if !MONOTOUCH
+
+using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace MonoTests.System.Reflection.VisibilityTypes
+{
+	[TestFixture]
+	public class VisibilityTests
+	{
+		[Test]
+		public void TestsExportedTypes ()
+		{
+			var types = typeof (VisibilityTests).Assembly.GetExportedTypes ();
+
+			// Test visibility means that the class is public by applying and on the 'public' visibility of the nested items.
+			CollectionAssert.DoesNotContain (types, typeof (InternalClass));
+			CollectionAssert.Contains (types, typeof (PublicClass));
+
+			CollectionAssert.DoesNotContain (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+InternalNested", true));
+			CollectionAssert.DoesNotContain (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+PrivateNested", true));
+			CollectionAssert.DoesNotContain (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+ProtectedNested", true));
+			CollectionAssert.DoesNotContain (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+PublicNested", true));
+
+			CollectionAssert.DoesNotContain (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+InternalNested", true));
+			CollectionAssert.DoesNotContain (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+PrivateNested", true));
+			CollectionAssert.DoesNotContain (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+ProtectedNested", true));
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+PublicNested", true));
+		}
+
+		[Test]
+		public void TestsModuleTypes ()
+		{
+			var types = typeof (VisibilityTests).Module.GetTypes ();
+
+			// Test that all the types defined exist.
+			CollectionAssert.Contains (types, typeof (InternalClass));
+			CollectionAssert.Contains (types, typeof (PublicClass));
+
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+InternalNested", true));
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+PrivateNested", true));
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+ProtectedNested", true));
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+InternalClass+PublicNested", true));
+
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+InternalNested", true));
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+PrivateNested", true));
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+ProtectedNested", true));
+			CollectionAssert.Contains (types, Type.GetType ("MonoTests.System.Reflection.VisibilityTypes.VisibilityTests+PublicClass+PublicNested", true));
+		}
+
+		class InternalClass
+		{
+			internal class InternalNested {}
+			private class PrivateNested {}
+			protected class ProtectedNested {}
+			public class PublicNested {}
+		}
+
+		public class PublicClass
+		{
+			internal class InternalNested {}
+			private class PrivateNested {}
+			protected class ProtectedNested {}
+			public class PublicNested {}
+		}
+	}
+}
+
+#endif
+

--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -148,6 +148,7 @@ System.Reflection/ParameterInfoTest.cs
 System.Reflection/PropertyInfoTest.cs
 System.Reflection/ReflectedTypeTest.cs
 System.Reflection/TypeDelegatorTest.cs
+System.Reflection/VisibilityTest.cs
 System.Reflection.Emit/AssemblyBuilderTest.cs
 System.Reflection.Emit/AssemblyBuilderAccessTest.cs
 System.Reflection.Emit/ConstructorBuilderTest.cs

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5018,6 +5018,21 @@ ves_icall_System_Reflection_Assembly_LoadPermissions (MonoReflectionAssembly *as
 	return result;	
 }
 
+static gboolean
+mono_module_type_is_visible (MonoTableInfo *tdef, MonoImage *image, int type)
+{
+	guint32 attrs, visibility;
+	do {
+		attrs = mono_metadata_decode_row_col (tdef, type - 1, MONO_TYPEDEF_FLAGS);
+		visibility = attrs & TYPE_ATTRIBUTE_VISIBILITY_MASK;
+		if (visibility != TYPE_ATTRIBUTE_PUBLIC && visibility != TYPE_ATTRIBUTE_NESTED_PUBLIC)
+			return FALSE;
+
+	} while ((type = mono_metadata_token_index (mono_metadata_nested_in_typedef (image, type))));
+
+	return TRUE;
+}
+
 static MonoArray*
 mono_module_get_types (MonoDomain *domain, MonoImage *image, MonoArray **exceptions, MonoBoolean exportedOnly)
 {
@@ -5025,15 +5040,12 @@ mono_module_get_types (MonoDomain *domain, MonoImage *image, MonoArray **excepti
 	MonoClass *klass;
 	MonoTableInfo *tdef = &image->tables [MONO_TABLE_TYPEDEF];
 	int i, count;
-	guint32 attrs, visibility;
 
 	/* we start the count from 1 because we skip the special type <Module> */
 	if (exportedOnly) {
 		count = 0;
 		for (i = 1; i < tdef->rows; ++i) {
-			attrs = mono_metadata_decode_row_col (tdef, i, MONO_TYPEDEF_FLAGS);
-			visibility = attrs & TYPE_ATTRIBUTE_VISIBILITY_MASK;
-			if (visibility == TYPE_ATTRIBUTE_PUBLIC || visibility == TYPE_ATTRIBUTE_NESTED_PUBLIC)
+			if (mono_module_type_is_visible (tdef, image, i + 1))
 				count++;
 		}
 	} else {
@@ -5043,9 +5055,7 @@ mono_module_get_types (MonoDomain *domain, MonoImage *image, MonoArray **excepti
 	*exceptions = mono_array_new (domain, mono_defaults.exception_class, count);
 	count = 0;
 	for (i = 1; i < tdef->rows; ++i) {
-		attrs = mono_metadata_decode_row_col (tdef, i, MONO_TYPEDEF_FLAGS);
-		visibility = attrs & TYPE_ATTRIBUTE_VISIBILITY_MASK;
-		if (!exportedOnly || (visibility == TYPE_ATTRIBUTE_PUBLIC || visibility == TYPE_ATTRIBUTE_NESTED_PUBLIC)) {
+		if (!exportedOnly || mono_module_type_is_visible (tdef, image, i + 1)) {
 			MonoError error;
 			klass = mono_class_get_checked (image, (i + 1) | MONO_TOKEN_TYPE_DEF, &error);
 			g_assert (!mono_loader_get_last_error ()); /* Plug any leaks */


### PR DESCRIPTION
While this appears to fix the issue, I'm sure there are issues with the PR:
1. Tests location is probably totally wrong.
2. I'm not sure I understood `mono_metadata_nested_in_typedef` correctly.
3. Caused by `2.` I'm not sure whether it's the _real_ fix.
4. While it has some unit tests, they're really small tests. Probably testing an assembly with various definitions would be better. Thoughts?