### PR TITLE
[Microsoft.Build.Engine] Ignore import with empty project attribute when condition is false

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Import.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Import.cs
@@ -152,6 +152,15 @@ namespace Microsoft.Build.BuildEngine {
 						project_attribute.IndexOf ("$(MSBuildExtensionsPath32)") >= 0 ||
 						project_attribute.IndexOf ("$(MSBuildExtensionsPath64)") >= 0;
 
+			bool condn_has_extn_ref = condition_attribute.IndexOf ("$(MSBuildExtensionsPath)") >= 0 ||
+						condition_attribute.IndexOf ("$(MSBuildExtensionsPath32)") >= 0 ||
+						condition_attribute.IndexOf ("$(MSBuildExtensionsPath64)") >= 0;
+
+			// we can skip the following logic in case the condition doesn't reference any extension paths
+			// and it evaluates to false since nothing would change anyway
+			if (!condn_has_extn_ref && !ConditionParser.ParseAndEvaluate (condition_attribute, project))
+				return;
+
 			string importingFile = importingProject != null ? importingProject.FullFileName : project.FullFileName;
 			DirectoryInfo base_dir_info = null;
 			if (!String.IsNullOrEmpty (importingFile))

--- a/mcs/class/Microsoft.Build.Engine/Test/Microsoft.Build.BuildEngine/ImportTest.cs
+++ b/mcs/class/Microsoft.Build.Engine/Test/Microsoft.Build.BuildEngine/ImportTest.cs
@@ -209,7 +209,38 @@ namespace MonoTests.Microsoft.Build.BuildEngine {
 			project.LoadXml (documentString);
 		}
 
-#if NET_4_0
+		[Test]
+		public void TestImportEmptyVariableWithConditionFalse ()
+		{
+			string documentString = @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+				<Import Project='$(ImportPath)' Condition='false' />
+				<Target Name='Build' />
+			</Project>";
+
+			engine = new Engine (Consts.BinPath);
+
+			project = engine.CreateNewProject ();
+			project.LoadXml (documentString);
+
+			Assert.IsTrue (project.Build ("Build"), "Build failed");
+		}
+
+		[Test]
+		public void TestImportProjectWithConditionReferencingExtensionPath ()
+		{
+			string documentString = @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+				<Import Project='$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets' Condition=""Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets')""  />
+				<Target Name='Build' />
+			</Project>";
+
+			engine = new Engine (Consts.BinPath);
+
+			project = engine.CreateNewProject ();
+			project.LoadXml (documentString);
+
+			Assert.IsTrue (project.Build ("Build"), "Build failed");
+		}
+
 		[Test]
 		public void TestImportWildcard ()
 		{
@@ -264,7 +295,6 @@ namespace MonoTests.Microsoft.Build.BuildEngine {
 				File.Delete (second_project);
 			}
 		}
-#endif
 
 	}
 }


### PR DESCRIPTION
`<Import Project="$(Variable)" Condition="false" />` causes an exception otherwise when Variable is not set.
Also added a test for condition referencing extension path after discussion in f13d9cb

Note: this is part of the patches that enable dotnet/corefx to be built with Mono.