### PR TITLE
revises GZipStream ctor parameter names

### DIFF
--- a/mcs/class/System/System.IO.Compression/GZipStream.cs
+++ b/mcs/class/System/System.IO.Compression/GZipStream.cs
@@ -40,11 +40,11 @@ namespace System.IO.Compression {
 	{
 		private DeflateStream deflateStream;
 
-		public GZipStream (Stream compressedStream, CompressionMode mode) :
+		public GZipStream (Stream stream, CompressionMode mode) :
 			this (compressedStream, mode, false) {
 		}
 
-		public GZipStream (Stream compressedStream, CompressionMode mode, bool leaveOpen) {
+		public GZipStream (Stream stream, CompressionMode mode, bool leaveOpen) {
 			this.deflateStream = new DeflateStream (compressedStream, mode, leaveOpen, true);
 		}
 		


### PR DESCRIPTION
By changing the names of the parameters, code that uses .NET GZipStream constructors ([1], [2]) with named parameters can use this GZipStream without any changes to code.

[1]: https://msdn.microsoft.com/en-us/library/as1ff51s(v=vs.110).aspx
[2]: https://msdn.microsoft.com/en-us/library/27ck2z1y(v=vs.110).aspx