### PR TITLE
revises GZipStream ctor parameter names

### DIFF
--- a/mcs/class/System/System.IO.Compression/GZipStream.cs
+++ b/mcs/class/System/System.IO.Compression/GZipStream.cs
@@ -40,12 +40,12 @@ namespace System.IO.Compression {
 	{
 		private DeflateStream deflateStream;
 
-		public GZipStream (Stream compressedStream, CompressionMode mode) :
-			this (compressedStream, mode, false) {
+		public GZipStream (Stream stream, CompressionMode mode) :
+			this (stream, mode, false) {
 		}
 
-		public GZipStream (Stream compressedStream, CompressionMode mode, bool leaveOpen) {
-			this.deflateStream = new DeflateStream (compressedStream, mode, leaveOpen, true);
+		public GZipStream (Stream stream, CompressionMode mode, bool leaveOpen) {
+			this.deflateStream = new DeflateStream (stream, mode, leaveOpen, true);
 		}
 		
 		


### PR DESCRIPTION
By changing the names of the parameters, code that uses .NET GZipStream constructors[1][2] with named parameters can use this GZipStream without change. I made a mistake when submitting #1574, so I'm resubmitting with the mistake corrected.

[1]: https://msdn.microsoft.com/en-us/library/as1ff51s(v=vs.110).aspx
[2]: https://msdn.microsoft.com/en-us/library/27ck2z1y(v=vs.110).aspx