### PR TITLE
[Microsoft.Build.Engine] Fix bug with escaped semicolon and spaces

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildItem.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildItem.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Build.BuildEngine {
 
 			BuildItemGroup big;			
 			BuildItem bi = new BuildItem (this);
-			bi.finalItemSpec = taskitem.ItemSpec;
+			bi.finalItemSpec = ((ITaskItem2)taskitem).EvaluatedIncludeEscaped;
 
 			foreach (DictionaryEntry de in taskitem.CloneCustomMetadata ()) {
 				bi.unevaluatedMetadata.Add ((string) de.Key, (string) de.Value);

--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Expression.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Expression.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Build.BuildEngine {
 			for (int i = 0; i < lists.Count; i++) {
 				foreach (object o in lists [i]) {
 					if (o is string)
-						expressionCollection.Add (MSBuildUtils.Unescape ((string) o));
+						expressionCollection.Add ((string) o);
 					else if (!allowItems && o is ItemReference)
 						expressionCollection.Add (((ItemReference) o).OriginalString);
 					else if (!allowMd && o is MetadataReference) {

--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ExpressionCollection.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ExpressionCollection.cs
@@ -233,11 +233,11 @@ namespace Microsoft.Build.BuildEngine {
 			// Trim and Remove empty items
 			List<ITaskItem> toRemove = new List<ITaskItem> ();
 			for (int i = 0; i < finalItems.Count; i ++) {
-				string s = finalItems [i].ItemSpec.Trim ();
+				string s = ((ITaskItem2)finalItems [i]).EvaluatedIncludeEscaped.Trim ();
 				if (s.Length == 0)
 					toRemove.Add (finalItems [i]);
 				else
-					finalItems [i].ItemSpec = s;
+					((ITaskItem2)finalItems [i]).EvaluatedIncludeEscaped = s;
 			}
 			foreach (ITaskItem ti in toRemove)
 				finalItems.Remove (ti);

--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/WriteLinesToFileTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/WriteLinesToFileTest.cs
@@ -91,6 +91,26 @@ namespace MonoTests.Microsoft.Build.Tasks {
 		}
 
 		[Test]
+		public void TestLineWithEscapedSemicolon ()
+		{
+			string[] lines = new string[] { "abc%3Btest%3B%3B", "%3Bdef" };
+			CreateProjectAndCheck (full_filepath, lines, false, true, delegate () {
+				CheckFileExists (full_filepath, true);
+				CheckLines (full_filepath, new string [] {"abc;test;;", ";def"});
+			});
+		}
+
+		[Test]
+		public void TestLineWithEscapedSpace ()
+		{
+			string[] lines = new string[] { "  %20%20abc%20test  ", "  def%20%20" };
+			CreateProjectAndCheck (full_filepath, lines, false, true, delegate () {
+				CheckFileExists (full_filepath, true);
+				CheckLines (full_filepath, new string [] {"  abc test", "def  "});
+			});
+		}
+
+		[Test]
 		public void TestNoOverwrite ()
 		{
 			string[] lines = new string[] { "abc", "def" };

--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/WriteLinesToFileTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/WriteLinesToFileTest.cs
@@ -210,7 +210,7 @@ namespace MonoTests.Microsoft.Build.Tasks {
 			string[] actual = File.ReadAllLines (full_filepath);
 			Assert.AreEqual (expected != null ? expected.Length : 0, actual.Length, "Number of lines written don't match");
 
-			if (expected != null)
+			if (expected == null)
 				return;
 			int i = 0;
 			foreach (string line in actual)

--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskItem.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskItem.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Build.Utilities
 		}
 		public override string ToString ()
 		{
-			return escapedItemSpec;
+			return ItemSpec;
 		}
 		
 		public string ItemSpec {


### PR DESCRIPTION
This fixes a bug where escaped spaces and semicolons wouldn't be written to a file with WriteLinesToFileTest.

Note: This is an intricate piece of code and I'm not really sure it's the correct fix or whether this breaks any corner case usages (it at least builds dotnet/corefx as a sanity check). Would love to get some more :eyes: on it. If anyone knows a better way to make the included tests pass, please show me.

/cc @radical