### PR TITLE
Make the class thread-safe

### DIFF
--- a/mcs/class/System.Configuration/System.Configuration/ConfigurationSectionCollection.cs
+++ b/mcs/class/System.Configuration/System.Configuration/ConfigurationSectionCollection.cs
@@ -39,7 +39,8 @@ namespace System.Configuration
 	{
 		SectionGroupInfo group;
 		Configuration config;
-		
+		static readonly object lockObject = new object();
+		 
 		internal ConfigurationSectionCollection (Configuration config, SectionGroupInfo group)
 			: base (StringComparer.Ordinal)
 		{
@@ -60,15 +61,17 @@ namespace System.Configuration
 		public ConfigurationSection this [string name]
 		{
 			get {
-				ConfigurationSection sec = BaseGet (name) as ConfigurationSection;
-				if (sec == null) {
-					SectionInfo secData = group.Sections [name] as SectionInfo;
-					if (secData == null) return null;
-					sec = config.GetSectionInstance (secData, true);
-					if (sec == null) return null;
-					BaseSet (name, sec);
+				lock(lockObject) {
+					ConfigurationSection sec = BaseGet (name) as ConfigurationSection;
+					if (sec == null) {
+						SectionInfo secData = group.Sections [name] as SectionInfo;
+						if (secData == null) return null;
+						sec = config.GetSectionInstance (secData, true);
+						if (sec == null) return null;
+						BaseSet (name, sec);
+					}
+					return sec;
 				}
-				return sec;
 			}
 		}
 	


### PR DESCRIPTION
If two threads request the same section, which isn't yet cached, both try to insert it into the cache, causing a "Key duplication when adding...". It's neccesary to lock the getter. This solves bugs #5263, #7785, #18303