### PR TITLE
Limit the lock to the writing operation

### DIFF
--- a/mcs/class/System.Configuration/System.Configuration/ConfigurationSectionCollection.cs
+++ b/mcs/class/System.Configuration/System.Configuration/ConfigurationSectionCollection.cs
@@ -61,17 +61,17 @@ namespace System.Configuration
 		public ConfigurationSection this [string name]
 		{
 			get {
-				lock(lockObject) {
-					ConfigurationSection sec = BaseGet (name) as ConfigurationSection;
-					if (sec == null) {
-						SectionInfo secData = group.Sections [name] as SectionInfo;
-						if (secData == null) return null;
-						sec = config.GetSectionInstance (secData, true);
-						if (sec == null) return null;
+				ConfigurationSection sec = BaseGet (name) as ConfigurationSection;
+				if (sec == null) {
+					SectionInfo secData = group.Sections [name] as SectionInfo;
+					if (secData == null) return null;
+					sec = config.GetSectionInstance (secData, true);
+					if (sec == null) return null;
+					lock(lockObject) {
 						BaseSet (name, sec);
 					}
-					return sec;
 				}
+				return sec;
 			}
 		}
 	


### PR DESCRIPTION
I initially discarded this change, because locking BaseSet (name, sec), didn't prevent the threads from trying to add the same key. That said, following the code, the point at which it actually fails is in NameObjectCollectionBase.BaseAdd, lines 331 and 332. The threads were arriving the second line at the same time:
```c#
   if (_entriesTable[name] == null)
          _entriesTable.Add(name, entry);
```
In brief, it's safe to call BaseSet twice with the same key, so it's safe to lock only the call to BaseSet