### PR TITLE
[runtime] Prioritize loading a profiler library from the installation dir.

### DIFF
--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -1196,17 +1196,15 @@ mono_profiler_load (const char *desc)
 		}
 		if (!load_embedded_profiler (desc, mname)) {
 			libname = g_strdup_printf ("mono-profiler-%s", mname);
-			if (!load_profiler_from_directory (NULL, libname, desc)) {
-				res = FALSE;
 #if defined (MONO_ASSEMBLIES)
-				res = load_profiler_from_directory (mono_assembly_getrootdir (), libname, desc);
+			res = load_profiler_from_directory (mono_assembly_getrootdir (), libname, desc);
 #endif
-				if (!res)
-					res = load_profiler_from_mono_instalation (libname, desc);
-
-				if (!res)
-					g_warning ("The '%s' profiler wasn't found in the main executable nor could it be loaded from '%s'.", mname, libname);
-			}
+			if (!res)
+				res = load_profiler_from_directory (NULL, libname, desc);
+			if (!res)
+				res = load_profiler_from_mono_instalation (libname, desc);
+			if (!res)
+				g_warning ("The '%s' profiler wasn't found in the main executable nor could it be loaded from '%s'.", mname, libname);
 			g_free (libname);
 		}
 		g_free (mname);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1875,6 +1875,9 @@ mono_main (int argc, char* argv[])
 
 	mono_counters_init ();
 
+	/* Set rootdir before loading config */
+	mono_set_rootdir ();
+
 	if (enable_profile)
 		mono_profiler_load (profile_options);
 
@@ -1908,9 +1911,6 @@ mono_main (int argc, char* argv[])
 	if (mixed_mode)
 		mono_load_coree (argv [i]);
 #endif
-
-	/* Set rootdir before loading config */
-	mono_set_rootdir ();
 
 	/* Parse gac loading options before loading assemblies. */
 	if (mono_compile_aot || action == DO_EXEC || action == DO_DEBUGGER) {


### PR DESCRIPTION
Prioritize loading a profiler library from the installation dir over loading ti from the standard system libarary paths.
The current behaviour unintuitive, since custom installations of Mono would still try to use profiler libraries from the system-default mono installation (possibly causing incompatibility problems as well). 