### PR TITLE
Randomize tcp ports in tests

### DIFF
--- a/mcs/class/System/System_test.dll.sources
+++ b/mcs/class/System/System_test.dll.sources
@@ -508,3 +508,4 @@ System.Collections.Concurrent/ConcurrentBagTests.cs
 System.Collections.Concurrent/CollectionStressTestHelper.cs
 System.Collections.Concurrent/ParallelTestHelper.cs
 System.Net.WebSockets/ClientWebSocketTest.cs
+../../test-helpers/NetworkHelpers.cs

--- a/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
+++ b/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
@@ -10,6 +10,7 @@ using System.Text;
 
 using NUnit.Framework;
 
+using MonoTests.Helpers;
 
 namespace MonoTests.System.Net.WebSockets
 {
@@ -17,7 +18,7 @@ namespace MonoTests.System.Net.WebSockets
 	public class ClientWebSocketTest
 	{
 		const string EchoServerUrl = "ws://echo.websocket.org";
-		const int Port = 42123;
+		int Port = NetworkHelpers.FindFreePort ();
 		HttpListener listener;
 		ClientWebSocket socket;
 		MethodInfo headerSetMethod;

--- a/mcs/class/System/Test/System.Net/HttpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerTest.cs
@@ -31,6 +31,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using NUnit.Framework;
+using MonoTests.Helpers;
 
 namespace MonoTests.System.Net {
 	[TestFixture]
@@ -40,7 +41,7 @@ namespace MonoTests.System.Net {
 
 		[SetUp]
 		public void SetUp () {
-			port = new Random ().Next (7777, 8000);
+			port = NetworkHelpers.FindFreePort ();
 		}
 
 		[Test]
@@ -477,7 +478,7 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void ConnectionReuse ()
 		{
-			var uri = "http://localhost:1338/";
+			var uri = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
 
 			HttpListener listener = new HttpListener ();
 			listener.Prefixes.Add (uri);

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace MonoTests.Helpers {
+
+	public static class NetworkHelpers
+	{
+		public static int FindFreePort ()
+		{
+			TcpListener l = new TcpListener(IPAddress.Loopback, 0);
+			l.Start();
+			int port = ((IPEndPoint)l.LocalEndpoint).Port;
+			l.Stop();
+			return port;
+		}
+	}
+}


### PR DESCRIPTION
Static port numbers in tests break if the test suite runs more than once on the same machine simultaneously (as is the case for our ARM builders, where soft-float is done in a chroot on a hard-float host, sharing port-space)

This helper method enumerates current ports in use, then tries random port numbers within a range to find a non-match. This is open to a possible race condition (a port seems clear, but is opened by another process after being chosen by the tests) but it's a hell of a lot less likely to fail than with a hard-coded port number.