### PR TITLE
Prevent right click from triggering ToolStrip.OnItemClicked

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -962,8 +962,9 @@ namespace System.Windows.Forms
 		{
 			// If we're currently over an item (set in MouseMove)
 			if (mouse_currently_over != null && !(mouse_currently_over is ToolStripControlHost) && mouse_currently_over.Enabled) {
-				// Fire our ItemClicked event
-				OnItemClicked (new ToolStripItemClickedEventArgs (mouse_currently_over));
+				// Fire our ItemClicked event, but only for a left mouse click.
+				if (mea.Button == MouseButtons.Left)
+					OnItemClicked (new ToolStripItemClickedEventArgs (mouse_currently_over));
 					
 				// Fire the item's MouseUp event
 				if (mouse_currently_over != null)


### PR DESCRIPTION
This addresses https://bugzilla.xamarin.com/show_bug.cgi?id=26887
(along with a previous fix).