### PR TITLE
Fixing ToolStripManager.RevertMerge

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripManager.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripManager.cs
@@ -354,13 +354,16 @@ namespace System.Windows.Forms
 		
 		public static bool RevertMerge (ToolStrip targetToolStrip)
 		{
+            if (targetToolStrip == null)
+                return false;
+
 			return RevertMerge (targetToolStrip, targetToolStrip.CurrentlyMergedWith);			
 		}
 		
 		public static bool RevertMerge (ToolStrip targetToolStrip, ToolStrip sourceToolStrip)
 		{
 			if (sourceToolStrip == null)
-				throw new ArgumentNullException ("sourceToolStrip");
+                return false;
 				
 			List<ToolStripItem> items_to_move = new List<ToolStripItem> ();
 			

--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripManager.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolStripManager.cs
@@ -354,8 +354,8 @@ namespace System.Windows.Forms
 		
 		public static bool RevertMerge (ToolStrip targetToolStrip)
 		{
-            if (targetToolStrip == null)
-                return false;
+			if (targetToolStrip == null)
+				return false;
 
 			return RevertMerge (targetToolStrip, targetToolStrip.CurrentlyMergedWith);			
 		}
@@ -363,7 +363,7 @@ namespace System.Windows.Forms
 		public static bool RevertMerge (ToolStrip targetToolStrip, ToolStrip sourceToolStrip)
 		{
 			if (sourceToolStrip == null)
-                return false;
+				return false;
 				
 			List<ToolStripItem> items_to_move = new List<ToolStripItem> ();
 			

--- a/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/ToolStripManagerTest.cs
+++ b/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/ToolStripManagerTest.cs
@@ -578,12 +578,27 @@ namespace MonoTests.System.Windows.Forms
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
-		public void MethodRevertMergeANE ()
+		public void MethodRevertMergeNullArgument1 ()
+		{
+            String ts = null;
+
+			Assert.AreEqual (false, ToolStripManager.RevertMerge (ts), "C1");
+		}
+
+		[Test]
+		public void MethodRevertMergeNullArgument2 ()
+		{
+			ToolStrip ts = null;
+
+			Assert.AreEqual (false, ToolStripManager.RevertMerge (ts), "C2");
+		}
+
+		[Test]
+		public void MethodRevertMergeNullArgument3 ()
 		{
 			ToolStrip ts = new ToolStrip ();
 			
-			ToolStripManager.RevertMerge (ts, null);
+			Assert.AreEqual (false, ToolStripManager.RevertMerge (ts, null), "C3");
 		}
 		
 		[Test]

--- a/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/ToolStripManagerTest.cs
+++ b/mcs/class/Managed.Windows.Forms/Test/System.Windows.Forms/ToolStripManagerTest.cs
@@ -580,7 +580,7 @@ namespace MonoTests.System.Windows.Forms
 		[Test]
 		public void MethodRevertMergeNullArgument1 ()
 		{
-            String ts = null;
+			String ts = null;
 
 			Assert.AreEqual (false, ToolStripManager.RevertMerge (ts), "C1");
 		}


### PR DESCRIPTION
Hi, commit messages provide a detailed explanation of the change :).

I release this change under the MIT license.


Thanks!