### PR TITLE
Bug 27529 Tool Tip appears behind menu

### DIFF
--- a/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolTip.cs
+++ b/mcs/class/Managed.Windows.Forms/System.Windows.Forms/ToolTip.cs
@@ -256,6 +256,7 @@ namespace System.Windows.Forms {
 				
 				Location = loc;
 				Visible = true;
+				BringToFront ();
 			}
 
 


### PR DESCRIPTION
In certain cases, hovering over a ToolStripMenuItem
that has a tool tip defined will result in the tool
tip appearing behind, and hidden by, the context
menu containing the item.  The change is to cause
the tool tip to be pushed to the front when it is
displayed.