### PR TITLE
[COV] Set the correct link flags for OS X

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -21,6 +21,7 @@ lib_LTLIBRARIES = libmono-profiler-cov.la libmono-profiler-aot.la libmono-profil
 
 if PLATFORM_DARWIN
 libmono_profiler_log_la_LDFLAGS = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
+libmono_profiler_cov_la_LDFLAGS = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
 endif
 if PLATFORM_ANDROID
 libmono_profiler_log_la_LDFLAGS = -avoid-version


### PR DESCRIPTION
Cov needs to be linked using the flat namespace on OS X, the same way that proflog is linked or else it won't do anything.