### PR TITLE
Changed Socket to used SafeHandle instead of IntPtr.

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
@@ -365,7 +365,9 @@ namespace System.Net.NetworkInformation {
 				if (fd.ToInt64 () == -1)
 					return false;
 
-				nl_sock = new Socket (0, SocketType.Raw, ProtocolType.Udp, fd);
+				var safeHandle = new SafeSocketHandle (fd, true);
+
+				nl_sock = new Socket (0, SocketType.Raw, ProtocolType.Udp, safeHandle);
 				nl_args = new SocketAsyncEventArgs ();
 				nl_args.SetBuffer (new byte [8192], 0, 8192);
 				nl_args.Completed += OnDataAvailable;

--- a/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
+++ b/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
@@ -1,0 +1,36 @@
+﻿//
+// System.Net.Sockets.SafeSocketHandle
+//
+// Authors:
+//	Marcos Henrich  <marcos.henrich@xamarin.com>
+//
+
+using System;
+using System.IO;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Net.Sockets {
+
+	sealed class SafeSocketHandle : SafeHandleZeroOrMinusOneIsInvalid {
+		public SafeSocketHandle (IntPtr preexistingHandle, bool ownsHandle) : base (ownsHandle)
+		{
+			SetHandle (preexistingHandle);
+		}
+
+		// This is just for marshalling
+		internal SafeSocketHandle () : base (true)
+		{
+		}
+
+		protected override bool ReleaseHandle ()
+		{
+			int error;
+			
+			Socket.Close_internal (handle, out error);
+
+			return error == 0;
+		}
+
+	}
+}
+

--- a/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
+++ b/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
@@ -7,11 +7,17 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Collections.Generic;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.Sockets {
 
 	sealed class SafeSocketHandle : SafeHandleZeroOrMinusOneIsInvalid {
+
+		List<Thread> blocking_threads;
+		const int ABORT_RETRIES = 10;
+
 		public SafeSocketHandle (IntPtr preexistingHandle, bool ownsHandle) : base (ownsHandle)
 		{
 			SetHandle (preexistingHandle);
@@ -24,13 +30,74 @@ namespace System.Net.Sockets {
 
 		protected override bool ReleaseHandle ()
 		{
-			int error;
+			int error = 0;
 			
+			Socket.Blocking_internal (handle, false, out error);
+	
+			if (blocking_threads != null) {
+				int abort_attempts = 0;
+				while (blocking_threads.Count > 0) {
+					if (abort_attempts++ >= ABORT_RETRIES) {
+#if DEBUG
+						throw new Exception ("Could not abort registered blocking threads before closing socket.");
+#else
+						// Attempts to close the socket safely failed.
+						// We give up, and close the socket with pending blocking system calls.
+						// This should not occur, nonetheless if it does this avoids an endless loop.
+						break;
+#endif
+					}
+
+					AbortRegisteredThreads ();
+					// Sleep so other threads can resume
+					Thread.Sleep (1);
+				}
+			}
+
 			Socket.Close_internal (handle, out error);
 
 			return error == 0;
 		}
 
+		public void RegisterForBlockingSyscall ()
+		{
+			while (blocking_threads == null) {
+				//In the rare event this CAS fail, there's a good chance other thread won, so we're kosher.
+				//In the VERY rare event of all CAS fail together, we pay the full price of of failure.
+				Interlocked.CompareExchange (ref blocking_threads, new List<Thread> (), null);
+			}
+			
+			bool release = false;
+			try {
+				DangerousAddRef (ref release);
+			} finally {
+				/* We must use a finally block here to make this atomic. */
+				lock (blocking_threads) {
+					blocking_threads.Add (Thread.CurrentThread);
+				}
+				if (release)
+					DangerousRelease ();
+			}
+		}
+
+		/* This must be called from a finally block! */
+		public void UnRegisterForBlockingSyscall ()
+		{
+			//If this NRE, we're in deep problems because Register Must have
+			lock (blocking_threads) {
+				blocking_threads.Remove (Thread.CurrentThread);
+			}
+		}
+
+		void AbortRegisteredThreads () {
+			if (blocking_threads == null)
+				return;
+
+			lock (blocking_threads) {
+				foreach (var t in blocking_threads)
+					Socket.cancel_blocking_socket_operation (t);
+			}
+		}
 	}
 }
 

--- a/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
+++ b/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
@@ -61,11 +61,8 @@ namespace System.Net.Sockets {
 
 		public void RegisterForBlockingSyscall ()
 		{
-			while (blocking_threads == null) {
-				//In the rare event this CAS fail, there's a good chance other thread won, so we're kosher.
-				//In the VERY rare event of all CAS fail together, we pay the full price of of failure.
+			if (blocking_threads == null)
 				Interlocked.CompareExchange (ref blocking_threads, new List<Thread> (), null);
-			}
 			
 			bool release = false;
 			try {

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -555,14 +555,12 @@ namespace System.Net.Sockets
 
 		private static SafeSocketHandle Accept_internal(SafeSocketHandle safeHandle, out int error, bool blocking)
 		{
-			bool release = false;
 			try {
-				safeHandle.DangerousAddRef (ref release);
+				safeHandle.RegisterForBlockingSyscall ();
 				var ret = Accept_internal (safeHandle.DangerousGetHandle (), out error, blocking);
 				return new SafeSocketHandle (ret, true);
 			} finally {
-				if (release)
-					safeHandle.DangerousRelease ();
+				safeHandle.UnRegisterForBlockingSyscall ();
 			}
 		}
 
@@ -571,13 +569,7 @@ namespace System.Net.Sockets
 				throw new ObjectDisposedException (GetType ().ToString ());
 
 			int error = 0;
-			SafeSocketHandle sock = null;
-			try {
-				RegisterForBlockingSyscall ();
-				sock = Accept_internal(socket, out error, blocking);
-			} finally {
-				UnRegisterForBlockingSyscall ();
-			}
+			var sock = Accept_internal(socket, out error, blocking);
 
 			if (error != 0) {
 				if (closed)
@@ -599,14 +591,7 @@ namespace System.Net.Sockets
 				throw new ObjectDisposedException (GetType ().ToString ());
 			
 			int error = 0;
-			SafeSocketHandle sock = null;
-			
-			try {
-				RegisterForBlockingSyscall ();
-				sock = Accept_internal (socket, out error, blocking);
-			} finally {
-				UnRegisterForBlockingSyscall ();
-			}
+			var sock = Accept_internal (socket, out error, blocking);
 			
 			if (error != 0) {
 				if (closed)
@@ -1766,13 +1751,11 @@ namespace System.Net.Sockets
 							    ref SocketAddress sockaddr,
 							    out int error)
 		{
-			bool release = false;
 			try {
-				safeHandle.DangerousAddRef (ref release);
+				safeHandle.RegisterForBlockingSyscall ();
 				return RecvFrom_internal (safeHandle.DangerousGetHandle (), buffer, offset, count, flags, ref sockaddr, out error);
 			} finally {
-				if (release)
-					safeHandle.DangerousRelease ();
+				safeHandle.UnRegisterForBlockingSyscall ();
 			}
 		}
 
@@ -1979,13 +1962,11 @@ namespace System.Net.Sockets
 
 		private static bool SendFile (SafeSocketHandle safeHandle, string filename, byte [] pre_buffer, byte [] post_buffer, TransmitFileOptions flags)
 		{
-			bool release = false;
 			try {
-				safeHandle.DangerousAddRef (ref release);
+				safeHandle.RegisterForBlockingSyscall ();
 				return SendFile (safeHandle.DangerousGetHandle (), filename, pre_buffer, post_buffer, flags);
 			} finally {
-				if (release)
-					safeHandle.DangerousRelease ();
+				safeHandle.UnRegisterForBlockingSyscall ();
 			}
 		}
 
@@ -2112,13 +2093,11 @@ namespace System.Net.Sockets
 							  SocketAddress sa,
 							  out int error)
 		{
-			bool release = false;
 			try {
-				safeHandle.DangerousAddRef (ref release);
+				safeHandle.RegisterForBlockingSyscall ();
 				return SendTo_internal (safeHandle.DangerousGetHandle (), buffer, offset, count, flags, sa, out error);
 			} finally {
-				if (release)
-					safeHandle.DangerousRelease ();
+				safeHandle.UnRegisterForBlockingSyscall ();
 			}
 		}
 

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -202,6 +202,18 @@ namespace System.Net.Sockets
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static int Available_internal(IntPtr socket, out int error);
 
+		private static int Available_internal (SafeSocketHandle safeHandle, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return Available_internal (safeHandle.DangerousGetHandle (), out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public int Available {
 			get {
 				if (disposed && closed)
@@ -404,6 +416,18 @@ namespace System.Net.Sockets
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static SocketAddress LocalEndPoint_internal(IntPtr socket, int family, out int error);
 
+		private static SocketAddress LocalEndPoint_internal(SafeSocketHandle safeHandle, int family, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return LocalEndPoint_internal (safeHandle.DangerousGetHandle (), family, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		// Wish:  support non-IP endpoints.
 		public EndPoint LocalEndPoint {
 			get {
@@ -528,6 +552,19 @@ namespace System.Net.Sockets
 		// Creates a new system socket, returning the handle
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static IntPtr Accept_internal(IntPtr sock, out int error, bool blocking);
+
+		private static SafeSocketHandle Accept_internal(SafeSocketHandle safeHandle, out int error, bool blocking)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				var ret = Accept_internal (safeHandle.DangerousGetHandle (), out error, blocking);
+				return new SafeSocketHandle (ret, true);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		public Socket Accept() {
 			if (disposed && closed)
@@ -1091,6 +1128,20 @@ namespace System.Net.Sockets
 							 SocketAddress sa,
 							 out int error);
 
+		private static void Bind_internal (SafeSocketHandle safeHandle,
+							 SocketAddress sa,
+							 out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				Bind_internal (safeHandle.DangerousGetHandle (), sa, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public void Bind(EndPoint local_end) {
 			if (disposed && closed)
 				throw new ObjectDisposedException (GetType ().ToString ());
@@ -1181,6 +1232,18 @@ namespace System.Net.Sockets
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern static void Disconnect_internal(IntPtr sock, bool reuse, out int error);
+
+		private static void Disconnect_internal(SafeSocketHandle safeHandle, bool reuse, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				Disconnect_internal (safeHandle.DangerousGetHandle (), reuse, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		/* According to the docs, the MS runtime will throw
 		 * PlatformNotSupportedException if the platform is
@@ -1373,6 +1436,20 @@ namespace System.Net.Sockets
 			SocketOptionLevel level, SocketOptionName name, ref byte[] byte_val,
 			out int error);
 
+		private static void GetSocketOption_arr_internal (SafeSocketHandle safeHandle,
+			SocketOptionLevel level, SocketOptionName name, ref byte[] byte_val,
+			out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				GetSocketOption_arr_internal (safeHandle.DangerousGetHandle (), level, name, ref byte_val, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public void GetSocketOption (SocketOptionLevel optionLevel, SocketOptionName optionName, byte [] optionValue)
 		{
 			if (disposed && closed)
@@ -1415,6 +1492,19 @@ namespace System.Net.Sockets
 		extern static int WSAIoctl (IntPtr sock, int ioctl_code, byte [] input,
 			byte [] output, out int error);
 
+		private static int WSAIoctl (SafeSocketHandle safeHandle, int ioctl_code, byte [] input,
+			byte [] output, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return WSAIoctl (safeHandle.DangerousGetHandle (), ioctl_code, input, output, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public int IOControl (int ioctl_code, byte [] in_value, byte [] out_value)
 		{
 			if (disposed)
@@ -1440,6 +1530,18 @@ namespace System.Net.Sockets
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static void Listen_internal(IntPtr sock, int backlog, out int error);
+
+		private static void Listen_internal (SafeSocketHandle safeHandle, int backlog, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				Listen_internal (safeHandle.DangerousGetHandle (), backlog, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		public void Listen (int backlog)
 		{
@@ -1656,6 +1758,24 @@ namespace System.Net.Sockets
 							    ref SocketAddress sockaddr,
 							    out int error);
 
+		private static int RecvFrom_internal (SafeSocketHandle safeHandle,
+							    byte[] buffer,
+							    int offset,
+							    int count,
+							    SocketFlags flags,
+							    ref SocketAddress sockaddr,
+							    out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return RecvFrom_internal (safeHandle.DangerousGetHandle (), buffer, offset, count, flags, ref sockaddr, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public int ReceiveFrom (byte [] buffer, int offset, int size, SocketFlags flags,
 					ref EndPoint remoteEP)
 		{
@@ -1857,6 +1977,18 @@ namespace System.Net.Sockets
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static bool SendFile (IntPtr sock, string filename, byte [] pre_buffer, byte [] post_buffer, TransmitFileOptions flags);
 
+		private static bool SendFile (SafeSocketHandle safeHandle, string filename, byte [] pre_buffer, byte [] post_buffer, TransmitFileOptions flags)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return SendFile (safeHandle.DangerousGetHandle (), filename, pre_buffer, post_buffer, flags);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public void SendFile (string fileName)
 		{
 			if (disposed && closed)
@@ -1971,6 +2103,24 @@ namespace System.Net.Sockets
 							  SocketFlags flags,
 							  SocketAddress sa,
 							  out int error);
+
+		private static int SendTo_internal (SafeSocketHandle safeHandle,
+							  byte[] buffer,
+							  int offset,
+							  int count,
+							  SocketFlags flags,
+							  SocketAddress sa,
+							  out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return SendTo_internal (safeHandle.DangerousGetHandle (), buffer, offset, count, flags, sa, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		public int SendTo (byte [] buffer, int offset, int size, SocketFlags flags,
 				   EndPoint remote_end)

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -142,7 +142,7 @@ namespace System.Net.Sockets
 		// private constructor used by Accept, which already
 		// has a socket handle to use
 		internal Socket(AddressFamily family, SocketType type,
-			       ProtocolType proto, IntPtr sock)
+			       ProtocolType proto, SafeSocketHandle sock)
 		{
 			address_family=family;
 			socket_type=type;
@@ -193,7 +193,7 @@ namespace System.Net.Sockets
 			socket_type = (SocketType) (int) result [1];
 			protocol_type = (ProtocolType) (int) result [2];
 			isbound = (ProtocolType) (int) result [3] != 0;
-			socket = (IntPtr) (long) result [4];
+			socket = new SafeSocketHandle ((IntPtr) (long) result [4], true);
 			SocketDefaults ();
 		}
 #endif
@@ -408,7 +408,7 @@ namespace System.Net.Sockets
 
 		public IntPtr Handle {
 			get {
-				return(socket);
+				return(socket.DangerousGetHandle ());
 			}
 		}
 
@@ -571,7 +571,7 @@ namespace System.Net.Sockets
 				throw new ObjectDisposedException (GetType ().ToString ());
 
 			int error = 0;
-			IntPtr sock = (IntPtr) (-1);
+			SafeSocketHandle sock = null;
 			try {
 				RegisterForBlockingSyscall ();
 				sock = Accept_internal(socket, out error, blocking);
@@ -599,7 +599,7 @@ namespace System.Net.Sockets
 				throw new ObjectDisposedException (GetType ().ToString ());
 			
 			int error = 0;
-			IntPtr sock = (IntPtr)(-1);
+			SafeSocketHandle sock = null;
 			
 			try {
 				RegisterForBlockingSyscall ();
@@ -1285,8 +1285,8 @@ namespace System.Net.Sockets
 				(blocking ? 0 : SocketInformationOptions.NonBlocking) |
 				(useoverlappedIO ? SocketInformationOptions.UseOnlyOverlappedIO : 0);
 
-			si.ProtocolInformation = Mono.DataConverter.Pack ("iiiil", (int)address_family, (int)socket_type, (int)protocol_type, isbound ? 1 : 0, (long)socket);
-			socket = (IntPtr) (-1);
+			si.ProtocolInformation = Mono.DataConverter.Pack ("iiiil", (int)address_family, (int)socket_type, (int)protocol_type, isbound ? 1 : 0, (long)Handle);
+			socket = null;
 
 			return si;
 		}

--- a/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
@@ -286,7 +286,7 @@ namespace System.Net.Sockets
 				SocketError = SocketError.OperationAborted;
 			} finally {
 				if (AcceptSocket == null)
-					AcceptSocket = new Socket (curSocket.AddressFamily, curSocket.SocketType, curSocket.ProtocolType, (IntPtr)(-1));
+					AcceptSocket = new Socket (curSocket.AddressFamily, curSocket.SocketType, curSocket.ProtocolType, null);
 				OnCompleted (this);
 			}
 		}

--- a/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
@@ -973,6 +973,20 @@ namespace System.Net.Sockets {
 							     bool block,
 							     out int error);
 
+		internal static void Blocking_internal (SafeSocketHandle safeHandle,
+							     bool block,
+							     out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				Blocking_internal (safeHandle.DangerousGetHandle (), block, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public bool Blocking {
 			get {
 				return(blocking);
@@ -1105,6 +1119,18 @@ namespace System.Net.Sockets {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static SocketAddress RemoteEndPoint_internal(IntPtr socket, int family, out int error);
 
+		private static SocketAddress RemoteEndPoint_internal (SafeSocketHandle safeHandle, int family, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return RemoteEndPoint_internal (safeHandle.DangerousGetHandle (), family, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public EndPoint RemoteEndPoint {
 			get {
 				if (disposed && closed)
@@ -1213,6 +1239,20 @@ namespace System.Net.Sockets {
 		private extern static void Connect_internal(IntPtr sock,
 							    SocketAddress sa,
 							    out int error);
+		
+		private static void Connect_internal (SafeSocketHandle safeHandle,
+							    SocketAddress sa,
+							    out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				Connect_internal (safeHandle.DangerousGetHandle (), sa, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		public void Connect (EndPoint remoteEP)
 		{
@@ -1330,6 +1370,18 @@ namespace System.Net.Sockets {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern static bool Poll_internal (IntPtr socket, SelectMode mode, int timeout, out int error);
 
+		private static bool Poll_internal (SafeSocketHandle safeHandle, SelectMode mode, int timeout, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return Poll_internal (safeHandle.DangerousGetHandle (), mode, timeout, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static int Receive_internal(IntPtr sock,
 							   byte[] buffer,
@@ -1337,6 +1389,23 @@ namespace System.Net.Sockets {
 							   int count,
 							   SocketFlags flags,
 							   out int error);
+
+		private static int Receive_internal (SafeSocketHandle safeHandle,
+							   byte[] buffer,
+							   int offset,
+							   int count,
+							   SocketFlags flags,
+							   out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return Receive_internal (safeHandle.DangerousGetHandle (), buffer, offset, count, flags, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		internal int Receive_nochecks (byte [] buf, int offset, int size, SocketFlags flags, out SocketError error)
 		{
@@ -1358,12 +1427,42 @@ namespace System.Net.Sockets {
 			SocketOptionLevel level, SocketOptionName name, out object obj_val,
 			out int error);
 
+		private static void GetSocketOption_obj_internal (SafeSocketHandle safeHandle,
+			SocketOptionLevel level, SocketOptionName name, out object obj_val,
+			out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				GetSocketOption_obj_internal (safeHandle.DangerousGetHandle (), level, name, out obj_val, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static int Send_internal(IntPtr sock,
 							byte[] buf, int offset,
 							int count,
 							SocketFlags flags,
 							out int error);
+
+		private static int Send_internal (SafeSocketHandle safeHandle,
+							byte[] buf, int offset,
+							int count,
+							SocketFlags flags,
+							out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return Send_internal (safeHandle.DangerousGetHandle (), buf, offset, count, flags, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		internal int Send_nochecks (byte [] buf, int offset, int size, SocketFlags flags, out SocketError error)
 		{
@@ -1416,6 +1515,18 @@ namespace System.Net.Sockets {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static void Shutdown_internal (IntPtr socket, SocketShutdown how, out int error);
 		
+		private static void Shutdown_internal (SafeSocketHandle safeHandle, SocketShutdown how, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				Shutdown_internal (safeHandle.DangerousGetHandle (), how, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public void Shutdown (SocketShutdown how)
 		{
 			if (disposed && closed)
@@ -1436,6 +1547,21 @@ namespace System.Net.Sockets {
 								     SocketOptionName name, object obj_val,
 								     byte [] byte_val, int int_val,
 								     out int error);
+
+		private static void SetSocketOption_internal (SafeSocketHandle safeHandle, SocketOptionLevel level,
+								     SocketOptionName name, object obj_val,
+								     byte [] byte_val, int int_val,
+								     out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				SetSocketOption_internal (safeHandle.DangerousGetHandle (), level, name, obj_val, byte_val, int_val, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
 
 		public void SetSocketOption (SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue)
 		{
@@ -1645,6 +1771,19 @@ namespace System.Net.Sockets {
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static int Receive_internal (IntPtr sock, WSABUF[] bufarray, SocketFlags flags, out int error);
+
+		private static int Receive_internal (SafeSocketHandle safeHandle, WSABUF[] bufarray, SocketFlags flags, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return Receive_internal (safeHandle.DangerousGetHandle (), bufarray, flags, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public
 		int Receive (IList<ArraySegment<byte>> buffers)
 		{
@@ -1725,6 +1864,19 @@ namespace System.Net.Sockets {
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static int Send_internal (IntPtr sock, WSABUF[] bufarray, SocketFlags flags, out int error);
+
+		private static int Send_internal (SafeSocketHandle safeHandle, WSABUF[] bufarray, SocketFlags flags, out int error)
+		{
+			bool release = false;
+			try {
+				safeHandle.DangerousAddRef (ref release);
+				return Send_internal (safeHandle.DangerousGetHandle (), bufarray, flags, out error);
+			} finally {
+				if (release)
+					safeHandle.DangerousRelease ();
+			}
+		}
+
 		public
 		int Send (IList<ArraySegment<byte>> buffers)
 		{

--- a/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
@@ -1194,7 +1194,7 @@ namespace System.Net.Sockets {
 
 		// Closes the socket
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		private extern static void Close_internal(IntPtr socket, out int error);
+		internal extern static void Close_internal(IntPtr socket, out int error);
 
 		public void Close ()
 		{

--- a/mcs/class/System/System.dll.sources
+++ b/mcs/class/System/System.dll.sources
@@ -553,6 +553,7 @@ System.Net.Sockets/MulticastOption.cs
 System.Net.Sockets/NetworkStream.cs
 System.Net.Sockets/ProtocolFamily.cs
 System.Net.Sockets/ProtocolType.cs
+System.Net.Sockets/SafeSocketHandle.cs
 System.Net.Sockets/SelectMode.cs
 System.Net.Sockets/SendPacketsElement.cs
 System.Net.Sockets/Socket.cs

--- a/mono/utils/mono-threads-mach.c
+++ b/mono/utils/mono-threads-mach.c
@@ -36,12 +36,13 @@ mono_threads_core_interrupt (MonoThreadInfo *info)
 void
 mono_threads_core_abort_syscall (MonoThreadInfo *info)
 {
+	mono_threads_core_interrupt (info);
 }
 
 gboolean
 mono_threads_core_needs_abort_syscall (void)
 {
-	return FALSE;
+	return TRUE;
 }
 
 gboolean

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -43,12 +43,13 @@ mono_threads_core_interrupt (MonoThreadInfo *info)
 void
 mono_threads_core_abort_syscall (MonoThreadInfo *info)
 {
+	mono_threads_core_interrupt (info);
 }
 
 gboolean
 mono_threads_core_needs_abort_syscall (void)
 {
-	return FALSE;
+	return TRUE;
 }
 
 void


### PR DESCRIPTION
Changed Socket to use SafeHandle with the purpose of fixing the problem of a thread using an handle released by another thread.
The solution to this issue is to release the socket only when all system call that use the handle have returned.
Non blocking system calls are now wrapped around DangerousAddRef/DangerousRelease threads that block on a system call are kept on list so we can call cancel_blocking_socket_operation to make them return before the socket is closed.

This was only tested on mach.