### PR TITLE
Add NoData as valid return state for Statements with params

### DIFF
--- a/mcs/class/System.Data/System.Data.Odbc/OdbcCommand.cs
+++ b/mcs/class/System.Data/System.Data.Odbc/OdbcCommand.cs
@@ -337,7 +337,7 @@ namespace System.Data.Odbc
 
 			BindParameters ();
 			ret = libodbc.SQLExecute (hstmt);
-			if (ret != OdbcReturn.Success && ret != OdbcReturn.SuccessWithInfo)
+			if (ret != OdbcReturn.Success && ret != OdbcReturn.SuccessWithInfo && ret != OdbcReturn.NoData)
 				throw connection.CreateOdbcException (OdbcHandleType.Stmt, hstmt);
 		}
 


### PR DESCRIPTION
When using stements with parameters, the OdbcCommand would throw an exception
on ExecSQL when no row was returned. The commit adapts the change done in
5264613b6d63ecb44502746321b97c4a304dedb0 which was the same fix for the case of unprepared statements without parameters.