### PR TITLE
[corlib] Fix timezone dependent DateTimeOffset test

### DIFF
--- a/mcs/class/corlib/Test/System/DateTimeOffsetTest.cs
+++ b/mcs/class/corlib/Test/System/DateTimeOffsetTest.cs
@@ -261,8 +261,8 @@ namespace MonoTests.System {
 		[Test]
 		public void ParseExactCustomFormat ()
 		{
-			var dt = DateTimeOffset.ParseExact ("Sunday, 06-Nov-94 08:49:37 GMT", "dddd, dd'-'MMM'-'yy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture);
-			Assert.AreEqual (new DateTimeOffset (1994, 11, 6, 8, 49, 37, TimeZone.CurrentTimeZone.GetUtcOffset (DateTime.Now)), dt);
+			var dt = DateTimeOffset.ParseExact ("Sunday, 06-Nov-94 08:49:37 GMT", "dddd, dd'-'MMM'-'yy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+			Assert.AreEqual (new DateTimeOffset (1994, 11, 6, 8, 49, 37, TimeSpan.Zero), dt);
 		}
 		
 		[Test]


### PR DESCRIPTION
Instead of trying to recreate the date with the current timezone, we should make the date assume UTC and compare against that.