### PR TITLE
[runtime] GetProcessTimes now works with all processes. 

### DIFF
--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -52,6 +52,15 @@ namespace MonoTests.System.Diagnostics
 			}
 		}
 
+		[Test] // Covers #26363
+		public void GetProcesses_StartTime ()
+		{
+			foreach (var p in Process.GetProcesses ()) {
+				if (!p.HasExited && p.StartTime.Year < 1800)
+					Assert.Fail ("Process should not be started since the 18th century.");
+			}
+		}
+
 		[Test]
 		public void PriorityClass_NotStarted ()
 		{

--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -90,6 +90,7 @@
 #include <mono/utils/mono-membar.h>
 #include <mono/utils/mono-mutex.h>
 #include <mono/utils/mono-signal-handler.h>
+#include <mono/utils/mono-proclib.h>
 
 /* The process' environment strings */
 #if defined(__APPLE__) && !defined (__arm__) && !defined (__aarch64__)
@@ -1310,11 +1311,19 @@ GetProcessTimes (gpointer process, WapiFileTime *create_time,
 		/* Not sure if w32 allows NULLs here or not */
 		return FALSE;
 	
-	if (WAPI_IS_PSEUDO_PROCESS_HANDLE (process))
-		/* This is a pseudo handle, so just fail for now
-		 */
-		return FALSE;
-	
+	if (WAPI_IS_PSEUDO_PROCESS_HANDLE (process)) {
+		gpointer pid = GINT_TO_POINTER (WAPI_HANDLE_TO_PID(process));
+		gint64 start_ticks, user_ticks, kernel_ticks;
+
+		mono_process_get_times (pid, &start_ticks, &user_ticks, &kernel_ticks);
+
+		_wapi_guint64_to_filetime (start_ticks, create_time);
+		_wapi_guint64_to_filetime (user_ticks, kernel_time);
+		_wapi_guint64_to_filetime (kernel_ticks, user_time);
+
+		return TRUE;
+	}
+
 	process_handle = lookup_process_handle (process);
 	if (!process_handle) {
 		DEBUG ("%s: Can't find process %p", __func__, process);

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -320,7 +320,7 @@ mono_process_get_times (gpointer pid, gint64 *start_time, gint64 *user_time, gin
  * /proc/pid/stat format:
  * pid (cmdname) S 
  * 	[0] ppid pgid sid tty_nr tty_pgrp flags min_flt cmin_flt maj_flt cmaj_flt
- * 	[10] utime stime cutime cstime prio nice threads 0 start_time vsize rss
+ * 	[10] utime stime cutime cstime prio nice threads 0 start_time vsize
  * 	[20] rss rsslim start_code end_code start_stack esp eip pending blocked sigign
  * 	[30] sigcatch wchan 0 0 exit_signal cpu rt_prio policy
  */

--- a/mono/utils/mono-proclib.h
+++ b/mono/utils/mono-proclib.h
@@ -43,6 +43,8 @@ typedef enum {
 
 gpointer* mono_process_list     (int *size);
 
+void      mono_process_get_times (gpointer pid, gint64 *start_time, gint64 *user_time, gint64 *kernel_time);
+
 char*     mono_process_get_name (gpointer pid, char *buf, int len);
 
 gint64    mono_process_get_data (gpointer pid, MonoProcessData data);

--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -168,8 +168,14 @@ mono_100ns_datetime (void)
 {
 	struct timeval tv;
 	if (gettimeofday (&tv, NULL) == 0)
-		return (((gint64)tv.tv_sec + EPOCH_ADJUST) * 1000000 + tv.tv_usec) * 10;
+		return mono_100ns_datetime_from_timeval (tv);
 	return 0;
+}
+
+gint64
+mono_100ns_datetime_from_timeval (struct timeval tv)
+{
+	return (((gint64)tv.tv_sec + EPOCH_ADJUST) * 1000000 + tv.tv_usec) * 10;
 }
 
 #endif

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -13,6 +13,11 @@ gint64  mono_100ns_ticks     (void);
 /* Returns the number of 100ns ticks since 1/1/1, UTC timezone */
 gint64  mono_100ns_datetime  (void);
 
+#ifndef HOST_WIN32
+gint64 mono_100ns_datetime_from_timeval (struct timeval tv);
+#endif
+
+
 /* Stopwatch class for internal runtime use */
 typedef struct {
 	gint64 start, stop;

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -10,13 +10,12 @@ guint32 mono_msec_ticks      (void);
 /* Returns the number of 100ns ticks from unspecified time: this should be monotonic */
 gint64  mono_100ns_ticks     (void);
 
-/* Returns the number of 100ns ticks since 1/1/1, UTC timezone */
+/* Returns the number of 100ns ticks since 1/1/1601, UTC timezone */
 gint64  mono_100ns_datetime  (void);
 
 #ifndef HOST_WIN32
 gint64 mono_100ns_datetime_from_timeval (struct timeval tv);
 #endif
-
 
 /* Stopwatch class for internal runtime use */
 typedef struct {


### PR DESCRIPTION
Fixes: [26363](https://bugzilla.xamarin.com/show_bug.cgi?id=26363).