### PR TITLE
[Microsoft.Build.Utilities] Make properties in ToolTask available in 4.0 xbuild

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
@@ -512,7 +512,6 @@ namespace Microsoft.Build.Utilities
 			canceled.Set ();
 		}
 
-#if XBUILD_12
 		protected MessageImportance StandardErrorImportanceToUse {
 			get {
 				return MessageImportance.Normal;
@@ -527,6 +526,5 @@ namespace Microsoft.Build.Utilities
 
 		public bool LogStandardErrorAsError { get; set; }
 		public string StandardOutputImportance { get; set; }
-#endif
 	}
 }


### PR DESCRIPTION
The properties were introduced with MSBuild 4.0 (e.g. https://msdn.microsoft.com/en-us/library/microsoft.build.utilities.tooltask.logstandarderroraserror(v=vs.100).aspx) and shouldn't be inside a XBUILD_12 ifdef.