### PR TITLE
[WinForms] Make ResXResourceReader enumerator return values in same order as resx

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Resources/ResXResourceReader.cs
+++ b/mcs/class/System.Windows.Forms/System.Resources/ResXResourceReader.cs
@@ -55,13 +55,13 @@ namespace System.Resources
 		private string fileName;
 		private Stream stream;
 		private TextReader reader;
-		private Hashtable hasht;
+		private OrderedDictionary hasht;
 		private ITypeResolutionService typeresolver;
 		private XmlTextReader xmlReader;
 		private string basepath;
 		private bool useResXDataNodes;
 		private AssemblyName [] assemblyNames;
-		private Hashtable hashtm;
+		private OrderedDictionary hashtm;
 		#endregion	// Local Variables
 
 		#region Constructors & Destructor
@@ -145,8 +145,8 @@ namespace System.Resources
 		#region Private Methods
 		private void LoadData ()
 		{
-			hasht = new Hashtable ();
-			hashtm = new Hashtable ();
+			hasht = new OrderedDictionary ();
+			hashtm = new OrderedDictionary ();
 			if (fileName != null) {
 				stream = File.OpenRead (fileName);
 			}
@@ -278,7 +278,7 @@ namespace System.Resources
 
 		private void ParseDataNode (bool meta)
 		{
-			Hashtable hashtable = ((meta && ! useResXDataNodes) ? hashtm : hasht);
+			OrderedDictionary hashtable = ((meta && ! useResXDataNodes) ? hashtm : hasht);
 			Point pos = new Point (xmlReader.LineNumber, xmlReader.LinePosition);
 			string name = GetAttribute ("name");
 			string type_name = GetAttribute ("type");

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXResourceReaderTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXResourceReaderTest.cs
@@ -1420,6 +1420,57 @@ namespace MonoTests.System.Resources {
 		}
 
 		[Test]
+		public void EnumeratorOrderSameAsResx ()
+		{
+			string resXContent = string.Format (CultureInfo.CurrentCulture,
+				"<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+				"<root>" +
+				"	<resheader name=\"resmimetype\">" +
+				"		<value>{0}</value>" +
+				"	</resheader>" +
+				"	<resheader name=\"reader\">" +
+				"		<value>System.Resources.ResXResourceReader, {1}</value>" +
+				"	</resheader>" +
+				"	<resheader name=\"writer\">" +
+				"		<value>System.Resources.ResXResourceWriter, {1}</value>" +
+				"	</resheader>" +
+				"	<data name=\"name2\">" +
+				"		<value> value5 </value>" +
+				"	</data>" +
+				"	<data name=\"name1\">" +
+				"		<value> value4 </value>" +
+				"	</data>" +
+				"	<data name=\"aaa\">" +
+				"		<value> value3 </value>" +
+				"	</data>" +
+				"	<data name=\"zzzz\">" +
+				"		<value> value2 </value>" +
+				"	</data>" +
+				"	<data name=\"bbbbbb\">" +
+				"		<value> value1 </value>" +
+				"	</data>" +
+				"</root>",
+				ResXResourceWriter.ResMimeType, Consts.AssemblySystem_Windows_Forms);
+
+			using (StringReader sr = new StringReader (resXContent)) {
+				using (ResXResourceReader r = new ResXResourceReader (sr)) {
+
+					IDictionaryEnumerator enumerator = r.GetEnumerator ();
+					enumerator.MoveNext ();
+					Assert.AreEqual ("name2", enumerator.Key, "#1");
+					enumerator.MoveNext ();
+					Assert.AreEqual ("name1", enumerator.Key, "#2");
+					enumerator.MoveNext ();
+					Assert.AreEqual ("aaa", enumerator.Key, "#3");
+					enumerator.MoveNext ();
+					Assert.AreEqual ("zzzz", enumerator.Key, "#4");
+					enumerator.MoveNext ();
+					Assert.AreEqual ("bbbbbb", enumerator.Key, "#5");
+				}
+			}
+		}
+
+		[Test]
 		public void UseResXDataNodes ()
 		{
 			string refFile = Path.Combine (_tempDirectory, "32x32.ico");


### PR DESCRIPTION
This fixes an issue when building dotnet/corefx and all the SR.cs files are modified
because Mono used a HashTable internally in ResXResourceReader and it returned the
elements in a different order than MS.NET.

Even though this isn't explicitly mentioned in the docs, the MS.NET implementation returns
the elements in the same order as they appear in the resx and we should do the same.