### PR TITLE
Fix build on Linux and Windows

### DIFF
--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -21,13 +21,15 @@
 #include <Winbase.h>
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(_POSIX_VERSION)
 #include <sys/errno.h>
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>
-#include <sys/proc.h>
 #include <sys/resource.h>
+#endif
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#include <sys/proc.h>
 #if defined(__APPLE__)
 #include <mach/mach.h>
 #endif

--- a/mono/utils/mono-rand.c
+++ b/mono/utils/mono-rand.c
@@ -80,7 +80,7 @@ mono_rand_try_get_bytes (gpointer *handle, guchar *buffer, gint buffer_size)
 {
 	HCRYPTPROV provider;
 
-	g_assert (handle)
+	g_assert (handle);
 	provider = (HCRYPTPROV) *handle;
 
 	if (!CryptGenRandom (provider, buffer_size, buffer)) {


### PR DESCRIPTION
This PR does two fixes:

1. Include all necessary POSIX headers in `mono-proclib.c` (not just for Mac / *BSD). This shall fix the build for Linux.
2. Add a missing semicolon in `mono-rand.c`. This shall fix the build for Windows.
