### PR TITLE
[System] Fixed RemoveConnectionGroup concurrent issue.

### DIFF
--- a/mcs/class/System/System.Net/ServicePoint.cs
+++ b/mcs/class/System/System.Net/ServicePoint.cs
@@ -314,7 +314,8 @@ namespace System.Net
 
 				if (removeList != null) {
 					foreach (var group in removeList)
-						RemoveConnectionGroup (group);
+						if (groups.ContainsKey (group.Name))
+							RemoveConnectionGroup (group);
 				}
 
 				if (groups != null && groups.Count == 0)

--- a/mcs/class/System/System.Net/ServicePoint.cs
+++ b/mcs/class/System/System.Net/ServicePoint.cs
@@ -275,7 +275,7 @@ namespace System.Net
 			groups.Remove (group.Name);
 		}
 
-		internal bool CheckAvailableForRecycling (out DateTime outIdleSince)
+		bool CheckAvailableForRecycling (out DateTime outIdleSince)
 		{
 			outIdleSince = DateTime.MinValue;
 

--- a/mcs/class/System/Test/System.Net/ServicePointTest.cs
+++ b/mcs/class/System/Test/System.Net/ServicePointTest.cs
@@ -177,6 +177,28 @@ public class ServicePointTest
 		Assert.IsTrue (called);
 	}
 
+	public static void GetRequestStreamCallback (IAsyncResult asynchronousResult)
+	{
+	}
+
+	[Test] //Covers #19823
+	public void CloseConnectionGroupConcurency ()
+	{
+		// Try with multiple service points
+		for (var i = 0; i < 10; i++) {
+			Uri targetUri = new Uri ("http://" + i + ".mono-project.com");
+			var req = (HttpWebRequest) HttpWebRequest.Create (targetUri);
+			req.ContentType = "application/x-www-form-urlencoded";
+			req.Method = "POST";
+			req.ConnectionGroupName = "" + i;
+			req.ServicePoint.MaxIdleTime = 1;
+
+			req.BeginGetRequestStream (new AsyncCallback (GetRequestStreamCallback), req);
+			Thread.Sleep (1);
+			req.ServicePoint.CloseConnectionGroup (req.ConnectionGroupName);
+		}
+	}
+
 // Debug code not used now, but could be useful later
 /*
 	private void WriteServicePoint (string label, ServicePoint sp)


### PR DESCRIPTION
CloseConnectionGroup can concurrently call RemoveConnectionGroup and remove a group that has added to removeList.
We now check that the group still exists before removing it.
Fixes:** [#19823](https://bugzilla.xamarin.com/show_bug.cgi?id=19823).

**Workaround:** 
The crashes should not occur for a period of at least ServicePointManager.MaxServicePointIdleTime which by default is 100 secs.

``` csharp
ServicePointManager.MaxServicePointIdleTime = 1000 * 3600 * 24;
```

This workaround gives the app at least one day without crashes.

**Note about the test:** There is no way the added test can fail while running on nunit because the exception is thrown by a 
Timer callback and nunit does not seem to check those. I will look into it in another pull request.