### PR TITLE
monodoc/mdoc patches

### DIFF
--- a/mcs/class/monodoc/Monodoc.Ecma/EcmaDesc.cs
+++ b/mcs/class/monodoc/Monodoc.Ecma/EcmaDesc.cs
@@ -234,7 +234,9 @@ namespace Monodoc.Ecma
 
 			sb.Append ('.');
 			sb.Append (TypeName);
-			if (GenericTypeArguments != null) {
+			if (GenericTypeArguments != null && GenericTypeArgumentsIsNumeric) {
+				sb.AppendFormat ("`{0}", GenericTypeArgumentsCount);
+			} else if (GenericTypeArguments != null) {
 				sb.Append ('<');
 				int i=0;
 				foreach (var t in GenericTypeArguments) {

--- a/mcs/class/monodoc/Resources/mdoc-html-utils.xsl
+++ b/mcs/class/monodoc/Resources/mdoc-html-utils.xsl
@@ -840,6 +840,10 @@
 			<xsl:with-param name="content">
 			  <div class="related">
 				<xsl:call-template name="CreateRelatedSection">
+				  <xsl:with-param name="section" select="'Platform Docs'" />
+				  <xsl:with-param name="type" select="'PlatformDocAPI'" />
+				</xsl:call-template>
+				<xsl:call-template name="CreateRelatedSection">
 				  <xsl:with-param name="section" select="'Articles'" />
 				  <xsl:with-param name="type" select="'article'" />
 				</xsl:call-template>

--- a/mcs/class/monodoc/Test/Monodoc.Ecma/EcmaUrlTests.cs
+++ b/mcs/class/monodoc/Test/Monodoc.Ecma/EcmaUrlTests.cs
@@ -193,6 +193,17 @@ namespace MonoTests.Monodoc.Ecma
 		}
 
 		[Test]
+		public void GenericTypeArgsNumericToStringTest ()
+		{
+			string stringCref = "T:System.Collections.Generic.Dictionary`2";
+			var desc = parser.Parse (stringCref);
+			Assert.IsTrue (desc.GenericTypeArgumentsIsNumeric);
+			Assert.AreEqual (2, desc.GenericTypeArguments.Count);
+			string generatedEcmaCref = desc.ToEcmaCref ();
+			Assert.AreEqual (stringCref, generatedEcmaCref);
+		}
+
+		[Test]
 		public void MetaEtcNodeTest ()
 		{
 			var ast = new EcmaDesc () { DescKind = EcmaDesc.Kind.Type,

--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -91,6 +91,12 @@ cleanup:
 	-rm -Rf Test/en.actual Test/html.actual
 	-rm -f monodocer1.exe*
 
+Test/DocTest-addNonGeneric.dll:
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -debug -unsafe -target:library -out:$@ Test/DocTest-addNonGeneric.cs
+
+Test/DocTest-addNonGeneric-v2.dll:
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -debug -unsafe -target:library -out:$@ Test/DocTest-addNonGeneric.cs /define:V2
+
 Test/DocTest-DropNS-classic-secondary.dll:
 	@echo $(value @)
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -debug -unsafe -target:library -out:$@ Test/DocTest-DropNS-classic-secondary.cs
@@ -120,6 +126,19 @@ Test/DocTest.dll-v2:
 	cd Test && patch -p0 < DocTest-v2.patch
 	-rm -f Test/DocTest.dll
 	$(MAKE) TEST_CSCFLAGS=$(TEST_CSCFLAGS) Test/DocTest.dll
+
+check-monodocer-addNonGeneric: $(PROGRAM)
+	-rm -Rf Test/en.actual
+	# first, make a docset with the generic method
+	$(MAKE) Test/DocTest-addNonGeneric.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric.dll
+
+	# now add a non-generic version of the method and update several times
+	$(MAKE) Test/DocTest-addNonGeneric-v2.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
+	diff --exclude=.svn -rup Test/en.expected-addNonGeneric Test/en.actual
 
 check-monodocer-dropns-classic: $(PROGRAM)
 	# tests the simplest --dropns case, a single class where the root namespace was dropped.
@@ -321,4 +340,6 @@ check-doc-tools-update: check-monodocer-since-update \
 	check-mdoc-export-msxdoc-update \
 	check-mdoc-validate-update 
 
+check: check-doc-tools \
+	check-doc-tools-update
 

--- a/mcs/tools/mdoc/Test/DocTest-addNonGeneric.cs
+++ b/mcs/tools/mdoc/Test/DocTest-addNonGeneric.cs
@@ -1,0 +1,9 @@
+namespace MyNamespace {
+	public class MyClass {
+		public string SomeMethod<T>() { return string.Empty; }
+
+		#if V2
+		public string SomeMethod() { return string.Empty; }
+		#endif
+	}
+}

--- a/mcs/tools/mdoc/mdoc.csproj
+++ b/mcs/tools/mdoc/mdoc.csproj
@@ -9,13 +9,14 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>mdoc</RootNamespace>
     <AssemblyName>mdoc</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;NET_4_0</DefineConstants>
+    <DefineConstants>DEBUG;NET_4_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
@@ -38,7 +39,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Cecil, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="monodoc">
-      <HintPath>..\..\class\lib\net_4_0\monodoc.dll</HintPath>
+      <HintPath>..\..\class\lib\net_4_5\monodoc.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
- Updates mdoc's project file to target .net 4.5.
- Fixes an issue with mdoc duplicating members that have both generic and non-generic variants.
- Fixes an issue with monodoc generating EcmaCref URLs with numeric type parameters.
- Adds `PlatformDocApi` to the list of valid related related sections.

The bug fixes contain related unit tests in their respective projects.