### PR TITLE
[System.Reflection.Emit] fix typo in ModuleBuilder.DefineType

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -288,7 +288,7 @@ namespace System.Reflection.Emit {
 		}
 
 		public TypeBuilder DefineType (string name, TypeAttributes attr, Type parent, int typesize) {
-			return DefineType (name, attr, parent, null, PackingSize.Unspecified, TypeBuilder.UnspecifiedTypeSize);
+			return DefineType (name, attr, parent, null, PackingSize.Unspecified, typesize);
 		}
 
 		public TypeBuilder DefineType (string name, TypeAttributes attr, Type parent, PackingSize packsize) {

--- a/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
@@ -241,6 +241,17 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
+		public void DefineType_TypeSize ()
+		{
+			AssemblyBuilder ab = genAssembly ();
+			ModuleBuilder mb = ab.DefineDynamicModule ("foo.dll", "foo.dll", true);
+
+			TypeBuilder tb = mb.DefineType ("Foo", TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.SequentialLayout,
+				typeof (ValueType), 1);
+			Assert.AreEqual (1, tb.Size);
+		}
+
+		[Test]
 		[ExpectedException (typeof (ArgumentException))]
 		public void DuplicateTypeName () {
 			AssemblyBuilder ab = genAssembly ();


### PR DESCRIPTION
Using TypeBuilder.UnspecifiedTypeSize instead of passed  typesize look like a copy-past typo.
I checked that in .NET it use typesize.