### PR TITLE
[eval] Allow class attributes

### DIFF
--- a/mcs/class/Mono.CSharp/Test/Evaluator/TypesTest.cs
+++ b/mcs/class/Mono.CSharp/Test/Evaluator/TypesTest.cs
@@ -114,5 +114,16 @@ namespace MonoTests.EvaluatorTest
 			object res = Evaluator.Evaluate ("d();");
 			Assert.AreEqual (7, res);
 		}
+
+		[Test]
+		public void ClassWithAttribute ()
+		{
+			Evaluator.Run ("public class A : System.Attribute { }");
+			Evaluator.Run ("[A] public class B {}");
+			Evaluator.Run ("var attr = new B().GetType().GetCustomAttributes(false)[0];");
+
+			object res = Evaluator.Evaluate ("attr.GetType().Name;");
+			Assert.AreEqual ("A", res);
+		}
 	}
 }

--- a/mcs/mcs/eval.cs
+++ b/mcs/mcs/eval.cs
@@ -521,6 +521,7 @@ namespace Mono.CSharp
 			// These are toplevels
 			case Token.EXTERN:
 			case Token.OPEN_BRACKET:
+			case Token.OPEN_BRACKET_EXPR:
 			case Token.ABSTRACT:
 			case Token.CLASS:
 			case Token.ENUM:


### PR DESCRIPTION
Fix for scriptcs/scriptcs/issues/971 and https://bugzilla.xamarin.com/show_bug.cgi?id=28126

Top level brackets <code>[</code> defaulted to statement or expression instead of compilation unit.