### PR TITLE
Try to fix an assertion failure triggered by calls to System.Environment...

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -847,6 +847,8 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 	gboolean async = mono_thread_info_is_async_context ();
 
 	g_assert (start_ctx);
+	if (!domain)
+		domain = mono_domain_get ();
 	g_assert (domain);
 	g_assert (jit_tls);
 	/*The LMF will be null if the target have no managed frames.*/


### PR DESCRIPTION
....Exit()

The comments and code for mono_walk_stack_full(...) seemed to be
inconsistent. The comments claimed that ``domain`` could be set to
NULL which would cause the current domain to be used. However the code
asserted that ``domain`` was never null which doesn't seem to be the
case.

Now if ``domain`` is set to NULL the value returned by mono_domain_get()
is used.

This seems to fix [bug 28187](https://bugzilla.xamarin.com/show_bug.cgi?id=28187)