### PR TITLE
fixed case-sensitive file name for cross compilation

### DIFF
--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -18,7 +18,7 @@
 #ifdef HOST_WIN32
 #include <windows.h>
 #include <process.h>
-#include <Winbase.h>
+#include <winbase.h>
 #endif
 
 #if defined(_POSIX_VERSION)


### PR DESCRIPTION
The included "Winbase.h" does not exist on my mingw package. Instead it's called "winbase.h" starting with lowercase.
This is a problem if one wants to cross compile mono on Linux for Windows.

I'm using the mingw-w64-i686-dev package version 3.1.0-4 on Ubuntu 14.10.