### PR TITLE
Improved generics in exception's stack traces and mono-symbolicate.

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackFrame.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackFrame.cs
@@ -50,6 +50,7 @@ namespace System.Diagnostics {
 		private int ilOffset = OFFSET_UNKNOWN;
 		private int nativeOffset = OFFSET_UNKNOWN;
 		private long methodAddress;
+		private uint methodIndex;
 		private MethodBase methodBase;
 		private string fileName;
 		private int lineNumber;
@@ -60,7 +61,7 @@ namespace System.Diagnostics {
 		#endregion
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		extern static int GetILOffsetFromFile (string path, int methodToken, int nativeOffset);
+		extern static int GetILOffsetFromFile (string path, int methodToken, uint methodIndex, int nativeOffset);
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern static bool get_frame_info (int skip, bool needFileInfo, out MethodBase method,
@@ -172,6 +173,11 @@ namespace System.Diagnostics {
 		internal long GetMethodAddress ()
 		{
 			return methodAddress;
+		}
+
+		internal uint GetMethodIndex ()
+		{
+			return methodIndex;
 		}
 
 		internal string GetInternalMethodName ()

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 123;
+		private const int mono_corlib_version = 124;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mcs/class/corlib/System/Exception.cs
+++ b/mcs/class/corlib/System/Exception.cs
@@ -209,10 +209,13 @@ namespace System
 				} else {
 					GetFullNameForStackTrace (sb, frame.GetMethod ());
 
-					if (frame.GetILOffset () == -1)
-						sb.AppendFormat ("<0x{0:x5} + 0x{1:x5}> ", frame.GetMethodAddress (), frame.GetNativeOffset ());
-					else
+					if (frame.GetILOffset () == -1) {
+						sb.AppendFormat (" <0x{0:x5} + 0x{1:x5}> ", frame.GetMethodAddress (), frame.GetNativeOffset ());
+						if (frame.GetMethodIndex () != 0xffffff)
+							sb.AppendFormat ("{0} ", frame.GetMethodIndex ());
+					} else {
 						sb.AppendFormat (" [0x{0:x5}] ", frame.GetILOffset ());
+					}
 
 					sb.AppendFormat ("in {0}:{1} ", frame.GetSecureFileName (),
 									 frame.GetFileLineNumber ());

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -13,7 +13,7 @@ include ../../build/executable.make
 
 LIB_PATH = $(topdir)/class/lib/$(PROFILE)
 
-MONO = MONO_PATH=$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH $(RUNTIME)
+MONO = MONO_PATH=$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH $(RUNTIME) -O=-inline
 
 OUT_DIR = Test/out
 TEST_CS = Test/StackTraceDumper.cs

--- a/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
+++ b/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
@@ -1,34 +1,179 @@
 using System;
+using System.Collections.Generic;
 
 class StackTraceDumper {
-	public static void Main () {
-		// Stacktrace with no depth
+
+	public static void Main ()
+	{
 		try {
-			throw new Exception ();
+			throw new Exception ("Stacktrace with 1 frame");
 		} catch (Exception e) {
 			Console.WriteLine (e);
 		}
-		// Stacktrace with depth of 1
+
 		try {
-			ThrowException ();
+			ThrowException ("Stacktrace with 2 frames");
 		} catch (Exception e) {
 			Console.WriteLine (e);
 		}
-		// Stacktrace with depth of 2
+
 		try {
-			ThrowException2 ();
+			ThrowException ("Stacktrace with 3 frames", 2);
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			var message = "Stack frame with method overload using ref parameter";
+			ThrowException (ref message);
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			int i;
+			ThrowException ("Stack frame with method overload using out parameter", out i);
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			ThrowExceptionGeneric<double> ("Stack frame with 1 generic parameter");
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			ThrowExceptionGeneric<double,string> ("Stack frame with 2 generic parameters");
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			ThrowExceptionGeneric (12);
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			InnerClass.ThrowException ("Stack trace with inner class");
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			InnerGenericClass<string>.ThrowException ("Stack trace with inner generic class");
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			InnerGenericClass<string>.ThrowException ("Stack trace with inner generic class and method generic parameter", "string");
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			InnerGenericClass<string>.ThrowException<string> ("Stack trace with inner generic class and generic overload", "string");
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			InnerGenericClass<string>.InnerInnerGenericClass<int>.ThrowException ("Stack trace with 2 inner generic class and generic overload");
+		} catch (Exception e) {
+			Console.WriteLine (e);
+		}
+
+		try {
+			InnerGenericClass<int>.InnerInnerGenericClass<string>.ThrowException ("Stack trace with 2 inner generic class and generic overload");
 		} catch (Exception e) {
 			Console.WriteLine (e);
 		}
 	}
 
-	public static void ThrowException () {
-		Console.WriteLine ("Exception is not in the first line!");
-		throw new Exception ();
+	public static void ThrowException (string message)
+	{
+		throw new Exception (message);
 	}
 
-	public static void ThrowException2 () {
-		ThrowException ();
+	public static void ThrowException (ref string message)
+	{
+		throw new Exception (message);
 	}
 
+	public static void ThrowException (string message, int i)
+	{
+		if (i > 1)
+			ThrowException (message, --i);
+
+		throw new Exception (message);
+	}
+
+	public static void ThrowException (string message, out int o)
+	{
+		throw new Exception (message);
+	}
+
+	public static void ThrowExceptionGeneric<T> (string message)
+	{
+		throw new Exception (message);
+	}
+
+	public static void ThrowExceptionGeneric<T> (T a1)
+	{
+		throw new Exception ("Stack frame with generic method overload");
+	}
+
+	public static void ThrowExceptionGeneric<T> (List<string> a1)
+	{
+		throw new Exception ("Stack frame with generic method overload");
+	}
+
+	public static void ThrowExceptionGeneric<T> (List<T> a1)
+	{
+		throw new Exception ("Stack frame with generic method overload");
+	}
+
+	public static void ThrowExceptionGeneric<T1,T2> (string message)
+	{
+		throw new Exception (message);
+	}
+
+	class InnerClass {
+		public static void ThrowException (string message)
+		{
+			throw new Exception (message);
+		}
+	}
+
+	class InnerGenericClass<T> {
+		public static void ThrowException (string message)
+		{
+			throw new Exception (message);
+		}
+
+		public static void ThrowException (string message, T arg)
+		{
+			Console.WriteLine ("Generic to string:" + arg.ToString());
+			throw new Exception (message);
+		}
+
+		public static void ThrowException<T1> (string message, T1 arg)
+		{
+			throw new Exception (message);
+		}
+
+		public class InnerInnerGenericClass<T2> {
+			public static void ThrowException (T message)
+			{
+				throw new Exception (message as string);
+			}
+
+			public static void ThrowException (T2 message)
+			{
+				throw new Exception (message as string);
+			}
+		}
+	}
 }

--- a/mcs/tools/mono-symbolicate/Test/symbolicate.expected
+++ b/mcs/tools/mono-symbolicate/Test/symbolicate.expected
@@ -1,11 +1,43 @@
-System.Exception: Exception of type 'System.Exception' was thrown.
-  at StackTraceDumper.Main () in StackTraceDumper.cs:7 
-Exception is not in the first line!
-System.Exception: Exception of type 'System.Exception' was thrown.
-  at StackTraceDumper.ThrowException () in StackTraceDumper.cs:27 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:13 
-Exception is not in the first line!
-System.Exception: Exception of type 'System.Exception' was thrown.
-  at StackTraceDumper.ThrowException () in StackTraceDumper.cs:27 
-  at StackTraceDumper.ThrowException2 () in StackTraceDumper.cs:31 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:19 
+System.Exception: Stacktrace with 1 frame
+  at StackTraceDumper.Main () in StackTraceDumper.cs:9 
+System.Exception: Stacktrace with 2 frames
+  at StackTraceDumper.ThrowException (System.String message) in StackTraceDumper.cs:97 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:15 
+System.Exception: Stacktrace with 3 frames
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:110 
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:108 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:21 
+System.Exception: Stack frame with method overload using ref parameter
+  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:102 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:28 
+System.Exception: Stack frame with method overload using out parameter
+  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:115 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:35 
+System.Exception: Stack frame with 1 generic parameter
+  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:120 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:41 
+System.Exception: Stack frame with 2 generic parameters
+  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:140 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:47 
+System.Exception: Stack frame with generic method overload
+  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:125 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:53 
+System.Exception: Stack trace with inner class
+  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:146 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:59 
+System.Exception: Stack trace with inner generic class
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:153 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:65 
+Generic to string:string
+System.Exception: Stack trace with inner generic class and method generic parameter
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:159 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:71 
+System.Exception: Stack trace with inner generic class and generic overload
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:164 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:77 
+System.Exception: Stack trace with 2 inner generic class and generic overload
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:170 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:83 
+System.Exception: Stack trace with 2 inner generic class and generic overload
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:175 
+  at StackTraceDumper.Main () in StackTraceDumper.cs:89 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -78,7 +78,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 123
+#define MONO_CORLIB_VERSION 124
 
 typedef struct
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7309,12 +7309,12 @@ ves_icall_System_ComponentModel_Win32Exception_W32ErrorMessage (guint32 code)
 }
 
 ICALL_EXPORT int
-ves_icall_System_StackFrame_GetILOffsetFromFile (MonoString *path, int methodToken, int nativeOffset)
+ves_icall_System_StackFrame_GetILOffsetFromFile (MonoString *path, guint32 method_token, guint32 method_index, int native_offset)
 {
 	guint32 il_offset;
 	char *path_str = mono_string_to_utf8 (path);
 
-	if (!seq_point_data_get_il_offset (path_str, methodToken, nativeOffset, &il_offset))
+	if (!seq_point_data_get_il_offset (path_str, method_token, method_index, native_offset, &il_offset))
 		il_offset = -1;
 
 	g_free (path_str);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -363,6 +363,7 @@ typedef struct {
 	gint32 il_offset;
 	gint32 native_offset;
 	gint64 method_address;
+	gint32 method_index;
 	MonoReflectionMethod *method;
 	MonoString *filename;
 	gint32 line;

--- a/mono/metadata/seq-points-data.h
+++ b/mono/metadata/seq-points-data.h
@@ -81,7 +81,8 @@ seq_point_find_by_il_offset (MonoSeqPointInfo* info, int il_offset, SeqPoint* se
  */
 
 typedef struct {
-	guint32 token;
+	guint32 method_token;
+	guint32 method_index;
 	MonoSeqPointInfo* seq_points;
 	gboolean free_seq_points;
 } SeqPointDataEntry;
@@ -105,12 +106,12 @@ gboolean
 seq_point_data_write (SeqPointData *data, char *path);
 
 void
-seq_point_data_add (SeqPointData *data, guint32 token, MonoSeqPointInfo* info);
+seq_point_data_add (SeqPointData *data, guint32 methodToken, guint32 methodIndex, MonoSeqPointInfo* info);
 
 gboolean
-seq_point_data_get (SeqPointData *data, guint32 token, MonoSeqPointInfo** info);
+seq_point_data_get (SeqPointData *data, guint32 methodToken, guint32 methodIndex, MonoSeqPointInfo** info);
 
 gboolean
-seq_point_data_get_il_offset (char *path, guint32 token, guint32 native_offset, guint32 *il_offset);
+seq_point_data_get_il_offset (char *path, guint32 methodToken, guint32 methodIndex, guint32 native_offset, guint32 *il_offset);
 
 #endif /* __MONO_SEQ_POINTS_DATA_H__ */

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7894,7 +7894,7 @@ emit_exception_info (MonoAotCompile *acfg)
 					seq_point_data_init (&sp_data, acfg->nmethods);
 					seq_points_to_file = TRUE;
 				}
-				seq_point_data_add (&sp_data, cfg->method->token, cfg->seq_point_info);
+				seq_point_data_add (&sp_data, cfg->method->token, cfg->method_index, cfg->seq_point_info);
 			}
 		} else {
 			offsets [i] = 0;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3868,6 +3868,13 @@ find_aot_method (MonoMethod *method, MonoAotModule **out_amodule)
 	return index;
 }
 
+guint32
+mono_aot_find_method_index (MonoMethod *method)
+{
+	MonoAotModule *out_amodule;
+	return find_aot_method (method, &out_amodule);
+}
+
 /*
  * mono_aot_get_method:
  *

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -700,6 +700,8 @@ ves_icall_get_trace (MonoException *exc, gint32 skip, MonoBoolean need_file_info
 		}
 		else
 			MONO_OBJECT_SETREF (sf, method, mono_method_get_object (domain, method, NULL));
+
+		sf->method_index = ji->from_aot ? mono_aot_find_method_index (method) : 0xffffff;
 		sf->method_address = (gsize) ji->code_start;
 		sf->native_offset = (char *)ip - (char *)ji->code_start;
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2277,6 +2277,7 @@ gboolean mono_aot_is_pagefault              (void *ptr);
 void     mono_aot_handle_pagefault          (void *ptr);
 void     mono_aot_register_jit_icall        (const char *name, gpointer addr);
 void*    mono_aot_readonly_field_override   (MonoClassField *field);
+guint32  mono_aot_find_method_index         (MonoMethod *method);
 
 /* This is an exported function */
 MONO_API void     mono_aot_register_globals          (gpointer *globals);


### PR DESCRIPTION
mono-symbolicate tool is now capable of finding a filename and line for generic methods.

When an assembly is compiled AOT, and the sequence point data is stored in a separated .msym file, we now need a method token and a method index to retrieve the sequence point table that maps native offsets into il offsets.
The method index was added to the .msym file because while a generic method has a single metadata token it can have different native code and sequence point data for different type specializations.

With the method index we are now able to disambiguate between generic methods that share the same metadata token.

Exception stack traces now show a method index after a native offset when the method metadata token is ambiguous.

Exception stack traces were also changed to display the name of generic argument name instead of the used type. This is the same behavior as .NET. 