### PR TITLE
[corlib] Don't strip @ char in Mono.Security.Uri for absolute path

### DIFF
--- a/mcs/class/corlib/Mono.Security/Uri.cs
+++ b/mcs/class/corlib/Mono.Security/Uri.cs
@@ -1030,6 +1030,8 @@ namespace Mono.Security {
 
 			// 4.a user info
 			pos = uriString.IndexOf ("@");
+			if (unixAbsPath)
+				pos = -1;
 			if (pos != -1) {
 				userinfo = uriString.Substring (0, pos);
 				uriString = uriString.Remove (0, pos + 1);


### PR DESCRIPTION
When creating a Mono.Security.Uri with the string `file:///var/lib/jenkins/workspace/test-mono-mainline@2/...` (happens sometimes in System.Security.Policy.Zone-related unit tests on Jenkins) the current implementation strips everything up until the @ sign.

Zone thinks the file doesn't exist locally as the Uri.LocalPath doesn't refer to a valid file on disk anymore and this results in an incorrect zone value, making the tests fail.

Fixing this by treating the @ char differently when it is in an absolute path (as is done for other chars).