### PR TITLE
Fixed deadlock in WebConnectionGroup.Close()

### DIFF
--- a/mcs/class/System/System.Net/ServicePoint.cs
+++ b/mcs/class/System/System.Net/ServicePoint.cs
@@ -401,13 +401,19 @@ namespace System.Net
 		}
 		public bool CloseConnectionGroup (string connectionGroupName)
 		{
+			WebConnectionGroup cncGroup = null;
+
 			lock (this) {
-				WebConnectionGroup cncGroup = GetConnectionGroup (connectionGroupName);
+				cncGroup = GetConnectionGroup (connectionGroupName);
 				if (cncGroup != null) {
-					cncGroup.Close ();
 					RemoveConnectionGroup (cncGroup);
-					return true;
 				}
+			}
+
+			// WebConnectionGroup.Close() must *not* be called inside the lock
+			if (cncGroup != null) {
+				cncGroup.Close ();
+				return true;
 			}
 
 			return false;


### PR DESCRIPTION
The fix is similar to the one used in the TryRecycle() method: we defer connection closing until after we've left the lock. The original bug: https://bugzilla.xamarin.com/show_bug.cgi?id=27348