### PR TITLE
ExecuteReaderAsync should invoke ExecuteDbDataReaderAsync

### DIFF
--- a/mcs/class/System.Data/System.Data.Common/DbCommand.cs
+++ b/mcs/class/System.Data/System.Data.Common/DbCommand.cs
@@ -204,15 +204,7 @@ namespace System.Data.Common {
 		
 		public Task<DbDataReader> ExecuteReaderAsync (CancellationToken cancellationToken)
 		{
-			if (cancellationToken.IsCancellationRequested) {
-				return TaskHelper.CreateCanceledTask<DbDataReader> ();
-			}
-			
-			try {
-				return Task.FromResult (ExecuteReader ());
-			} catch (Exception e) {
-				return TaskHelper.CreateExceptionTask<DbDataReader> (e);
-			}
+			return ExecuteDbDataReaderAsync (CommandBehavior.Default, cancellationToken);
 		}
 		
 		public Task<DbDataReader> ExecuteReaderAsync (CommandBehavior behavior)
@@ -222,15 +214,7 @@ namespace System.Data.Common {
 		
 		public Task<DbDataReader> ExecuteReaderAsync (CommandBehavior behavior, CancellationToken cancellationToken)
 		{
-			if (cancellationToken.IsCancellationRequested) {
-				return TaskHelper.CreateCanceledTask<DbDataReader> ();
-			}
-			
-			try {
-				return Task.FromResult (ExecuteReader (behavior));
-			} catch (Exception e) {
-				return TaskHelper.CreateExceptionTask<DbDataReader> (e);
-			}
+			return ExecuteDbDataReaderAsync (behavior, cancellationToken);
 		}
 
 		


### PR DESCRIPTION
The documentation for DbCommand.ExecuteReaderAsync clearly states that ExecuteDbDataReaderAsync should be invoked.