### PR TITLE
Content-Disposition filename param should be quoted

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http.Headers/ContentDispositionHeaderValue.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http.Headers/ContentDispositionHeaderValue.cs
@@ -213,7 +213,7 @@ namespace System.Net.Http.Headers
 		string GetQuotedStringValue (string name)
 		{
 			var value = FindParameter (name);
-			if (value == null || value == null)
+			if (value == null)
 				return null;
 
 			if (value[0] == '\"')

--- a/mcs/class/System.Net.Http/System.Net.Http.Headers/ContentDispositionHeaderValue.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http.Headers/ContentDispositionHeaderValue.cs
@@ -79,17 +79,10 @@ namespace System.Net.Http.Headers
 
 		public string FileName {
 			get {
-				var value = FindParameter ("filename");
-				if (value == null)
-					return null;
-
-				return DecodeValue (value, false);
+				return GetQuotedStringValue (value, false);
 			}
 			set {
-				if (value != null)
-					value = EncodeBase64Value (value);
-
-				SetValue ("filename", value);
+				SetQuotedStringValue ("filename", value);
 			}
 		}
 
@@ -215,6 +208,18 @@ namespace System.Net.Http.Headers
 				return offset;
 
 			return null;
+		}
+
+		string GetQuotedStringValue (string name)
+		{
+			var value = FindParameter (name);
+			if (value == null || value == null)
+				return null;
+
+			if (value[0] == '\"')
+				value = value.Substring (1, value.Length - 2);
+
+			return value;
 		}
 
 		static string EncodeBase64Value (string value)
@@ -381,6 +386,14 @@ namespace System.Net.Http.Headers
 		{
 			SetValue (key, value == null ? null : ("\"" + value.Value.ToString ("r", CultureInfo.InvariantCulture)) + "\"");
 		}
+
+                void SetQuotedStringValue (string key, string value) 
+                {
+                	if (value != null)
+				value = EncodeBase64Value (value);
+                	
+			SetValue (key, value == null ? null : ("\"" + value.Value.ToString ("r", CultureInfo.InvariantCulture)) + "\"");
+                }
 
 		void SetValue (string key, string value)
 		{

--- a/mcs/class/System.Net.Http/System.Net.Http.Headers/ContentDispositionHeaderValue.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http.Headers/ContentDispositionHeaderValue.cs
@@ -392,7 +392,7 @@ namespace System.Net.Http.Headers
                 	if (value != null)
 				value = EncodeBase64Value (value);
                 	
-			SetValue (key, value == null ? null : ("\"" + value.Value.ToString ("r", CultureInfo.InvariantCulture)) + "\"");
+			SetValue (key, value == null ? null : ("\"" + value + "\"");
                 }
 
 		void SetValue (string key, string value)


### PR DESCRIPTION
This is a fix for Content-Disposition that makes sure the filename parameter is always a quoted-string as defined in the spec.  http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1 This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=28569