### PR TITLE
XmlSerializer should set *non* readonly {V}Specified fields

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlTypeMapMember.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlTypeMapMember.cs
@@ -221,7 +221,7 @@ namespace System.Xml.Serialization
 				return ((PropertyInfo) _specifiedMember).CanWrite;
 
 			if (_specifiedMember is FieldInfo)
-				return ((FieldInfo) _specifiedMember).IsInitOnly;
+				return ! ((FieldInfo) _specifiedMember).IsInitOnly;
 
 			return false;
 		}

--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTests.cs
@@ -1006,7 +1006,26 @@ namespace MonoTests.System.XmlSerialization
 				XmlSchema.Namespace, XmlSchema.InstanceNamespace, AnotherNamespace,
 				ANamespace), sw.ToString (), "#3");
 		}
-
+		
+		[Test]
+		public void TestRoundTripSerializeOptionalValueTypeContainer ()
+		{
+			var source = new OptionalValueTypeContainer ();
+			source.IsEmpty = true;
+			source.IsEmptySpecified = true;
+			var ser = new XmlSerializer (typeof (OptionalValueTypeContainer));
+			string xml;
+			using (var t = new StringWriter ()) {
+				ser.Serialize (t, source);
+				xml = t.ToString();
+			}
+			using (var s = new StringReader (xml)) {
+				var obj = (ClassWithOptionalField) ser.Deserialize(s);
+				Assert.AreEqual (source.X, obj.X, "#1");
+				Assert.AreEqual (source.XSpecified, obj.XSpecified, "#2");
+			}
+		}
+		
 		[Test]
 		public void TestSerializePlainContainer ()
 		{


### PR DESCRIPTION
Addresses an oversight in PR 1257 that caused {V}Specified fields to not be set during XML deserialization in some circumstances.