### PR TITLE
[runtime] Use _SC_NPROCESSORS_CONF not _SC_NPROCESSORS_ONLN

### DIFF
--- a/mono/io-layer/system.c
+++ b/mono/io-layer/system.c
@@ -20,8 +20,8 @@ void GetSystemInfo(WapiSystemInfo *info)
 	info->dwPageSize=getpagesize();
 
 	/* Fill in the rest of this junk. Maybe with libgtop */
-#ifdef _SC_NPROCESSORS_ONLN
-	info->dwNumberOfProcessors = sysconf (_SC_NPROCESSORS_ONLN);
+#ifdef _SC_NPROCESSORS_CONF
+	info->dwNumberOfProcessors = sysconf (_SC_NPROCESSORS_CONF);
 	if (info->dwNumberOfProcessors <= 0)
 		info->dwNumberOfProcessors = 1;
 #else

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -1868,8 +1868,8 @@ mono_cpu_count (void)
 	if (count > 0)
 		return count + 1;
 #endif
-#ifdef _SC_NPROCESSORS_ONLN
-	count = sysconf (_SC_NPROCESSORS_ONLN);
+#ifdef _SC_NPROCESSORS_CONF
+	count = sysconf (_SC_NPROCESSORS_CONF);
 	if (count > 0)
 		return count;
 #endif

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -581,8 +581,8 @@ mono_cpu_count (void)
 	if (count > 0)
 		return count + 1;
 #endif
-#ifdef _SC_NPROCESSORS_ONLN
-	count = sysconf (_SC_NPROCESSORS_ONLN);
+#ifdef _SC_NPROCESSORS_CONF
+	count = sysconf (_SC_NPROCESSORS_CONF);
 	if (count > 0)
 		return count;
 #endif


### PR DESCRIPTION
We had a failing arm test which exposed that our caching of the
number of processors was leading to some inconsistencies when the number
of processors increased. TODO: Use the actual number of online processors when
rebalancing threadpool.