### PR TITLE
s390x fixes/enhancements

### DIFF
--- a/mono/metadata/mono-endian.h
+++ b/mono/metadata/mono-endian.h
@@ -14,7 +14,49 @@ typedef union {
 	unsigned char cval [8];
 } mono_rdouble;
 
-#if NO_UNALIGNED_ACCESS
+#if defined(__s390x__)
+
+#define read16(x)	s390x_read16(*(guint16 *)(x))
+#define read32(x)	s390x_read32(*(guint32 *)(x))
+#define read64(x)	s390x_read64(*(guint64 *)(x))
+
+static __inline__ guint16
+s390x_read16(guint16 x)
+{
+	guint16 ret;
+
+	__asm__ ("	lrvr	%0,%1\n"
+		 "	sra	%0,16\n"
+		 : "=r" (ret) : "r" (x));
+
+	return(ret);
+}
+
+static __inline__ guint32
+s390x_read32(guint32 x)
+{
+	guint32 ret;
+
+	__asm__ ("	lrvr	%0,%1\n"
+		 : "=r" (ret) : "r" (x));
+
+	return(ret);
+}
+
+static __inline__ guint64
+s390x_read64(guint64 x)
+{
+	guint64 ret;
+
+	__asm__ ("	lrvgr	%0,%1\n"
+		 : "=r" (ret) : "r" (x));
+
+	return(ret);
+}
+
+#else
+
+# if NO_UNALIGNED_ACCESS
 
 guint16 mono_read16 (const unsigned char *x);
 guint32 mono_read32 (const unsigned char *x);
@@ -24,11 +66,13 @@ guint64 mono_read64 (const unsigned char *x);
 #define read32(x) (mono_read32 ((const unsigned char *)(x)))
 #define read64(x) (mono_read64 ((const unsigned char *)(x)))
 
-#else
+# else
 
 #define read16(x) GUINT16_FROM_LE (*((const guint16 *) (x)))
 #define read32(x) GUINT32_FROM_LE (*((const guint32 *) (x)))
 #define read64(x) GUINT64_FROM_LE (*((const guint64 *) (x)))
+
+# endif
 
 #endif
 

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -210,6 +210,9 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 
 	g_assert ((code - start) < SZ_THROW); 
 
+	mono_arch_flush_icache(start, code - start);
+	mono_profiler_code_buffer_new (start, code - start, MONO_PROFILER_CODE_BUFFER_EXCEPTION_HANDLING, NULL);
+
 	if (info)
 		*info = mono_tramp_info_create ("call_filter",
 						start, code - start, ji,
@@ -356,6 +359,9 @@ mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info,
 	/* we should never reach this breakpoint */
 	s390_break (code);
 	g_assert ((code - start) < size);
+
+	mono_arch_flush_icache (start, code - start);
+	mono_profiler_code_buffer_new (start, code - start, MONO_PROFILER_CODE_BUFFER_EXCEPTION_HANDLING, NULL);
 
 	if (info)
 		*info = mono_tramp_info_create (corlib ? "throw_corlib_exception" 


### PR DESCRIPTION
decimal-ms.c:
- Fix handling of lo64 on big endian systems (fixes 28672)

mono-endian.h:
- Add optimization on s390x for read64/read32/read16

exceptions-s390x.c:
- Add profiling support for exception handler