### PR TITLE
Improved Process.Exited

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -1256,7 +1256,13 @@ namespace System.Diagnostics {
 						return false;
 				}
 			}
-			return WaitForExit_internal (process_handle, ms);
+
+			bool exited = WaitForExit_internal (process_handle, ms);
+
+			if (exited)
+				OnExited ();
+
+			return exited;
 		}
 
 		/* Waits up to ms milliseconds for process 'handle' to 

--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -773,6 +773,23 @@ namespace MonoTests.System.Diagnostics
 		{
 			return RunningOnUnix ? new ProcessStartInfo ("/bin/ls", "/") : new ProcessStartInfo ("help", "");
 		}
+
+		[Test] // Covers #26362
+		public void TestExitedEvent ()
+		{
+			var falseExitedEvents = 0;
+			var cp = Process.GetCurrentProcess ();
+			foreach (var p in Process.GetProcesses ()) {
+				if (p.Id != cp.Id && !p.HasExited) {
+					p.EnableRaisingEvents = true;
+					p.Exited += (s, e) => {
+						if (!p.HasExited)
+							falseExitedEvents++;
+					};
+				}
+			}
+			Assert.AreEqual (0, falseExitedEvents);
+		}
 		
 		[Test]
 		public void ProcessName_NotStarted ()

--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -768,6 +768,65 @@ namespace MonoTests.System.Diagnostics
 
 			Assert.AreEqual (true, r, "Null Argument Events Raised");
 		}
+
+		[Test]
+		[NUnit.Framework.Category ("MobileNotWorking")]
+		public void TestEnableEventsAfterExitedEvent ()
+		{
+			Process p = new Process ();
+			
+			p.StartInfo = GetCrossPlatformStartInfo ();
+			p.StartInfo.UseShellExecute = false;
+			p.StartInfo.RedirectStandardOutput = true;
+			p.StartInfo.RedirectStandardError = true;
+
+			var exitedCalledCounter = 0;
+			p.Exited += (object sender, EventArgs e) => {
+				exitedCalledCounter++;
+				Assert.IsTrue (p.HasExited);
+			};
+
+			p.EnableRaisingEvents = true;
+
+			p.Start ();
+			p.BeginErrorReadLine ();
+			p.BeginOutputReadLine ();
+			p.WaitForExit ();
+
+			Assert.AreEqual (1, exitedCalledCounter);
+			Thread.Sleep (50);
+			Assert.AreEqual (1, exitedCalledCounter);
+		}
+
+		[Test]
+		[NUnit.Framework.Category ("MobileNotWorking")]
+		public void TestEnableEventsBeforeExitedEvent ()
+		{
+			Process p = new Process ();
+			
+			p.StartInfo = GetCrossPlatformStartInfo ();
+			p.StartInfo.UseShellExecute = false;
+			p.StartInfo.RedirectStandardOutput = true;
+			p.StartInfo.RedirectStandardError = true;
+
+			p.EnableRaisingEvents = true;
+
+			var exitedCalledCounter = 0;
+			p.Exited += (object sender, EventArgs e) => {
+				exitedCalledCounter++;
+				Assert.IsTrue (p.HasExited);
+			};
+
+			p.Start ();
+			p.BeginErrorReadLine ();
+			p.BeginOutputReadLine ();
+			p.WaitForExit ();
+
+			Assert.AreEqual (1, exitedCalledCounter);
+			Thread.Sleep (50);
+			Assert.AreEqual (1, exitedCalledCounter);
+		}
+
 		
 		private ProcessStartInfo GetCrossPlatformStartInfo ()
 		{


### PR DESCRIPTION
Process no longer calls OnExit if HasExited is false.
Process.WaitForExit now triggers event Exited.
**Fixes:** [#26362](https://bugzilla.xamarin.com/show_bug.cgi?id=26362)