### PR TITLE
[corlib] Check for missing/empty Assembly.Location. Fixes #28876

### DIFF
--- a/mcs/class/corlib/System.Reflection/Assembly.cs
+++ b/mcs/class/corlib/System.Reflection/Assembly.cs
@@ -514,6 +514,9 @@ namespace System.Reflection {
 				// ignore
 			}
 
+			if (String.IsNullOrEmpty (Location))
+				return null;
+
 			// Try the assembly directory
 			string location = Path.GetDirectoryName (Location);
 			string fullName = Path.Combine (location, Path.Combine (culture.Name, an.Name + ".dll"));


### PR DESCRIPTION
I'm not sure if this is a sensible solution to the problem.

Test case: https://github.com/Garciat/dnx-mono-resources-bug

Bugzilla Bug: https://bugzilla.xamarin.com/show_bug.cgi?id=28876

Original discussion: https://github.com/aspnet/dnx/issues/1591