### PR TITLE
Corrected mono-gdb.py use of "\u%X".format (val)

### DIFF
--- a/data/gdb/mono-gdb.py
+++ b/data/gdb/mono-gdb.py
@@ -31,7 +31,7 @@ class StringPrinter:
         while i < len:
             val = (chars.cast(gdb.lookup_type ("gint64")) + (i * 2)).cast(gdb.lookup_type ("gunichar2").pointer ()).dereference ()
             if val >= 256:
-                c = "\u%X".format (val)
+                c = unichr (val)
             else:
                 c = chr (val)
             res.append (c)


### PR DESCRIPTION
This line of code would cause an error to pop up in gdb when starting. This issue appeared in the Ubuntu 7.7-0ubuntu3 release of gdb.

```
Reading symbols from mono...done.
  File "/usr/local/bin/mono-sgen-gdb.py", line 34
    c = "\u%X".format (val)
                       ^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 0-1: truncated \uXXXX escape
```