### PR TITLE
[monodoc] Updated how generators load resource streams.

### DIFF
--- a/mcs/class/monodoc/Monodoc/generators/html/Ecma2Html.cs
+++ b/mcs/class/monodoc/Monodoc/generators/html/Ecma2Html.cs
@@ -101,7 +101,7 @@ namespace Monodoc.Generators.Html
 		{
 			if (ecma_transform == null) {
 				ecma_transform = new XslCompiledTransform ();
-				var assembly = System.Reflection.Assembly.GetCallingAssembly ();
+				var assembly = System.Reflection.Assembly.GetAssembly (typeof (Ecma2Html));
 			
 				Stream stream = assembly.GetManifestResourceStream ("mono-ecma-css.xsl");
 				XmlReader xml_reader = new XmlTextReader (stream);

--- a/mcs/class/monodoc/Monodoc/generators/html/Ecmaspec2Html.cs
+++ b/mcs/class/monodoc/Monodoc/generators/html/Ecmaspec2Html.cs
@@ -17,7 +17,7 @@ namespace Monodoc.Generators.Html
 			get {
 				if (css_ecmaspec != null)
 					return css_ecmaspec;
-				System.Reflection.Assembly assembly = System.Reflection.Assembly.GetCallingAssembly ();
+				System.Reflection.Assembly assembly = System.Reflection.Assembly.GetAssembly (typeof (Ecmaspec2Html));
 				Stream str_css = assembly.GetManifestResourceStream ("ecmaspec.css");
 				css_ecmaspec = (new StreamReader (str_css)).ReadToEnd ();
 				return css_ecmaspec;
@@ -46,7 +46,7 @@ namespace Monodoc.Generators.Html
 		{
 			if (ecma_transform == null){
 				ecma_transform = new XslTransform ();
-				System.Reflection.Assembly assembly = System.Reflection.Assembly.GetCallingAssembly ();
+				System.Reflection.Assembly assembly = System.Reflection.Assembly.GetAssembly (typeof (Ecmaspec2Html));
 				Stream stream;
 				stream = assembly.GetManifestResourceStream ("ecmaspec-html-css.xsl");
 

--- a/mcs/class/monodoc/Monodoc/generators/html/Toc2Html.cs
+++ b/mcs/class/monodoc/Monodoc/generators/html/Toc2Html.cs
@@ -15,7 +15,7 @@ namespace Monodoc.Generators.Html
 		public Toc2Html ()
 		{
 			transform = new XslTransform ();
-			var assembly = Assembly.GetCallingAssembly ();
+			var assembly = Assembly.GetAssembly (typeof (Toc2Html));
 			var stream = assembly.GetManifestResourceStream ("toc-html.xsl");
 			XmlReader xml_reader = new XmlTextReader (stream);
 			transform.Load (xml_reader, null, null);


### PR DESCRIPTION
The issue was discovered when using monodoc in an asp.net application; while the code was developed and worked successfully in the local Visual Studio web server, it failed when deployed and executed in IIS. The reason it seems is because of the use of `.GetCallingAssembly()`, which was returning an unexpected assembly reference. This resulted in the `.GetManifestResourceStream` returning null for resources that are definitely a part of monodoc.dll.

Once the code was changed to get the assembly using a type reference of a type that's definitely in monodoc.dll ... the code resumed working as expected.