### PR TITLE
[System.Web.Extension] Fixes JavaScriptSerializer.Deserialize.

### DIFF
--- a/mcs/class/System.Web.Extensions/System.Web.Script.Serialization/JsonDeserializer.cs
+++ b/mcs/class/System.Web.Extensions/System.Web.Script.Serialization/JsonDeserializer.cs
@@ -495,21 +495,21 @@ namespace System.Web.Script.Serialization
 					break;
 
 				case JsonType.TRUE:
-					if (String.Compare (s, "true", StringComparison.Ordinal) == 0)
+					if (String.Compare (s.Trim (), "true", StringComparison.Ordinal) == 0)
 						result = true;
 					else
 						converted = false;
 					break;
 
 				case JsonType.FALSE:
-					if (String.Compare (s, "false", StringComparison.Ordinal) == 0)
+					if (String.Compare (s.Trim (), "false", StringComparison.Ordinal) == 0)
 						result = false;
 					else
 						converted = false;
 					break;
 
 				case JsonType.NULL:
-					if (String.Compare (s, "null", StringComparison.Ordinal) != 0)
+					if (String.Compare (s.Trim (), "null", StringComparison.Ordinal) != 0)
 						converted = false;
 					break;
 

--- a/mcs/class/System.Web.Extensions/Test/System.Web.Script.Serialization/JavaScriptSerializerTest.cs
+++ b/mcs/class/System.Web.Extensions/Test/System.Web.Script.Serialization/JavaScriptSerializerTest.cs
@@ -1416,5 +1416,30 @@ namespace MonoTests.System.Web.Script.Serialization
     ";
 			serializer.DeserializeObject (json_with_newline);
 		}
+
+		class Dummy
+		{
+			public bool t;
+			public bool f;
+			public string s;
+			public int i;
+			public double d;
+			public object o;
+		}
+		
+		[Test]
+		public void DeserializeWhiteSpaces ()
+		{
+			string json = "{\"t\" : true , \"f\" : false , \"s\" : \"s\" , \"i\" : 1337 , \"d\" : 1337.0 , \"o\" : null }";
+			
+			var obj = (new JavaScriptSerializer ()).Deserialize<Dummy>(json);
+			
+			Assert.IsTrue (obj.t);
+			Assert.IsFalse (obj.f);
+			Assert.AreEqual ("s", obj.s);
+			Assert.AreEqual (1337, obj.i);
+			Assert.AreEqual (1337.0, obj.d);
+			Assert.AreEqual (null, obj.o);
+		}
 	}
 }


### PR DESCRIPTION
Fixes JavaScriptSerializer.Deserialize of values with trailing spaces.
**Fixes** [#4148](https://bugzilla.xamarin.com/show_bug.cgi?id=4148).