### PR TITLE
Fix NullReferenceException in timer thread

### DIFF
--- a/mcs/class/corlib/System.Runtime.Remoting.Lifetime/LeaseManager.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting.Lifetime/LeaseManager.cs
@@ -78,7 +78,7 @@ namespace System.Runtime.Remoting.Lifetime
 		{
 			Timer t = _timer;
 			_timer = null;
-			t.Dispose();
+			if (t != null) t.Dispose();
 		}
 
 		public void ManageLeases(object state)


### PR DESCRIPTION
Every once in a while, we run into a NullReferenceException attempting to dispose a null timer. It's very rare and we can't reproduce reliably. However, reading this code, it seems possible that two timer callbacks could pile up, and if they did, the first one might dispose the timer, and then the second one would attempt to dispose null. This null check should fix it.