### PR TITLE
Improve Visual Basic build support

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Vbc.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Vbc.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Build.Tasks {
 			commandLine.AppendSwitchIfNotNull ("/main:", MainEntryPoint);
 
 			// NoStandardLib
+			if (Bag ["NoStandardLib"] != null && NoStandardLib)
+				commandLine.AppendSwitch ("/nostdlib");
 			
 			if (NoWarnings)
 				commandLine.AppendSwitch ("/nowarn");

--- a/mcs/tools/xbuild/Makefile
+++ b/mcs/tools/xbuild/Makefile
@@ -58,9 +58,11 @@ install-pcl-targets:
 	$(MKINSTALLDIRS) $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.0
 	$(INSTALL_DATA) targets/Microsoft.Portable.Common.targets $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.0/Microsoft.Portable.Common.targets
 	$(INSTALL_DATA) targets/Microsoft.Portable.CSharp_4.0.targets $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.0/Microsoft.Portable.CSharp.targets
+	$(INSTALL_DATA) targets/Microsoft.Portable.VisualBasic_4.0.targets $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.0/Microsoft.Portable.VisualBasic.targets
 	$(MKINSTALLDIRS) $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.5
 	$(INSTALL_DATA) targets/Microsoft.Portable.Common.targets $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.5/Microsoft.Portable.Common.targets
 	$(INSTALL_DATA) targets/Microsoft.Portable.CSharp_4.5.targets $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.5/Microsoft.Portable.CSharp.targets
+	$(INSTALL_DATA) targets/Microsoft.Portable.VisualBasic_4.5.targets $(DESTDIR)$(PORTABLE_TARGETS_DIR)/v4.5/Microsoft.Portable.VisualBasic.targets
 	$(INSTALL_DATA) targets/Microsoft.Portable.Core.targets $(DESTDIR)$(PORTABLE_TARGETS_DIR)/Microsoft.Portable.Core.targets
 	$(INSTALL_DATA) targets/Microsoft.Portable.Core.props $(DESTDIR)$(PORTABLE_TARGETS_DIR)/Microsoft.Portable.Core.props
 

--- a/mcs/tools/xbuild/data/12.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/12.0/Microsoft.Common.tasks
@@ -8,6 +8,7 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.CombinePath"		AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Copy"		AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateCSharpManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.CreateVisualBasicManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateItem"		AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateProperty"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Csc"			AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/mcs/tools/xbuild/data/14.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/14.0/Microsoft.Common.tasks
@@ -7,6 +7,7 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.CombinePath"		AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Copy"		AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateCSharpManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.CreateVisualBasicManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateItem"		AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateProperty"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Csc"			AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/mcs/tools/xbuild/data/2.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/2.0/Microsoft.Common.tasks
@@ -7,6 +7,7 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.CombinePath"		AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Copy"		AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateCSharpManifestResourceName"	AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.CreateVisualBasicManifestResourceName"	AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateItem"		AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateProperty"	AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Csc"			AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/mcs/tools/xbuild/data/3.5/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/3.5/Microsoft.Common.tasks
@@ -8,6 +8,7 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.CombinePath"		AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Copy"		AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateCSharpManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.CreateVisualBasicManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateItem"		AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateProperty"	AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Csc"			AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/mcs/tools/xbuild/data/4.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/4.0/Microsoft.Common.tasks
@@ -8,6 +8,7 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.CombinePath"		AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Copy"		AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateCSharpManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+	<UsingTask TaskName="Microsoft.Build.Tasks.CreateVisualBasicManifestResourceName"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateItem"		AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CreateProperty"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.Csc"			AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/mcs/tools/xbuild/data/Microsoft.VisualBasic.targets
+++ b/mcs/tools/xbuild/data/Microsoft.VisualBasic.targets
@@ -1,5 +1,4 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Microsoft.Build.Tasks.CreateVisualBasicManifestResourceName" AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<PropertyGroup>
 		<DefaultLanguageSourceExtension>.vb</DefaultLanguageSourceExtension>
 		<Language>VB</Language>
@@ -68,7 +67,7 @@
 			OptionInfer="$(OptionInfer)"
 			OutputAssembly="@(IntermediateAssembly)"
 			Platform="$(PlatformTarget)"
-			References="@(ResolvedFiles)"
+			References="@(ReferencePath)"
 			RemoveIntegerChecks="$(RemoveIntegerChecks)"
 			Resources="@(ManifestResourceWithNoCulture);@(ManifestNonResxWithNoCultureOnDisk);@(CompiledLicenseFile)"
 			ResponseFiles="$(CompilerResponseFile)"

--- a/mcs/tools/xbuild/targets/Microsoft.Portable.VisualBasic_4.0.targets
+++ b/mcs/tools/xbuild/targets/Microsoft.Portable.VisualBasic_4.0.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="..\Microsoft.Portable.Core.props" />
+	<Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+	<Import Project="..\Microsoft.Portable.Core.targets" />
+</Project>

--- a/mcs/tools/xbuild/targets/Microsoft.Portable.VisualBasic_4.5.targets
+++ b/mcs/tools/xbuild/targets/Microsoft.Portable.VisualBasic_4.5.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="..\Microsoft.Portable.Core.props" />
+	<Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+	<Import Project="..\Microsoft.Portable.Core.targets" />
+</Project>


### PR DESCRIPTION
This fixes a couple of small issues with the Visual Basic build support:

- The VBC task now respects the $(NoStdLib) MSBuild option.
- The field @(ReferencePath) should be used for References in the VBC
target as it is for the CSC target.
- The CreateVisualBasicManifestResourceNames task is compiled and used
in the same manner as CreateCSharpManifestResourceNames hence it should
be loaded via UsingTask in the same manner as well.
- Include the VisualBasic Portable targets files.