### PR TITLE
Feature arm fast tls

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1010,7 +1010,7 @@ static gboolean use_managed_allocator = TRUE;
 
 #else
 
-#if defined(__APPLE__) || defined (HOST_WIN32)
+#if defined(TARGET_OSX) || defined(TARGET_WIN32)
 #define EMIT_TLS_ACCESS_NEXT_ADDR(mb)	do {	\
 	mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX);	\
 	mono_mb_emit_byte ((mb), CEE_MONO_TLS);		\
@@ -2750,7 +2750,7 @@ sgen_client_init (void)
 
 #ifndef HAVE_KW_THREAD
 	mono_native_tls_alloc (&thread_info_key, NULL);
-#if defined(__APPLE__) || defined (HOST_WIN32)
+#if defined(TARGET_OSX) || defined(TARGET_WIN32)
 	/* 
 	 * CEE_MONO_TLS requires the tls offset, not the key, so the code below only works on darwin,
 	 * where the two are the same.

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1010,7 +1010,7 @@ static gboolean use_managed_allocator = TRUE;
 
 #else
 
-#if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID)
+#if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID) || defined(TARGET_IOS)
 #define EMIT_TLS_ACCESS_NEXT_ADDR(mb)	do {	\
 	mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX);	\
 	mono_mb_emit_byte ((mb), CEE_MONO_TLS);		\
@@ -2752,7 +2752,7 @@ sgen_client_init (void)
 
 #ifndef HAVE_KW_THREAD
 	mono_native_tls_alloc (&thread_info_key, NULL);
-#if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID)
+#if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID) || defined(TARGET_IOS)
 	/* 
 	 * CEE_MONO_TLS requires the tls offset, not the key, so the code below only works on darwin,
 	 * where the two are the same.

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1381,7 +1381,9 @@ create_allocator (int atype, gboolean slowpath)
 
 	res = mono_mb_create_method (mb, csig, 8);
 	mono_mb_free (mb);
+#ifndef DISABLE_JIT
 	mono_method_get_header (res)->init_locals = FALSE;
+#endif
 
 	info = mono_image_alloc0 (mono_defaults.corlib, sizeof (AllocatorWrapperInfo));
 	info->gc_name = "sgen";

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1010,7 +1010,7 @@ static gboolean use_managed_allocator = TRUE;
 
 #else
 
-#if defined(TARGET_OSX) || defined(TARGET_WIN32)
+#if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID)
 #define EMIT_TLS_ACCESS_NEXT_ADDR(mb)	do {	\
 	mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX);	\
 	mono_mb_emit_byte ((mb), CEE_MONO_TLS);		\
@@ -2750,7 +2750,7 @@ sgen_client_init (void)
 
 #ifndef HAVE_KW_THREAD
 	mono_native_tls_alloc (&thread_info_key, NULL);
-#if defined(TARGET_OSX) || defined(TARGET_WIN32)
+#if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID)
 	/* 
 	 * CEE_MONO_TLS requires the tls offset, not the key, so the code below only works on darwin,
 	 * where the two are the same.

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -309,7 +309,9 @@ ppc_sources = \
 
 arm_sources = \
 	mini-arm.c		\
+	mini-arm-tls.S		\
 	mini-arm.h		\
+	mini-arm-tls.h		\
 	exceptions-arm.c	\
 	tramp-arm.c
 

--- a/mono/mini/cpu-arm.md
+++ b/mono/mini/cpu-arm.md
@@ -243,6 +243,9 @@ br_reg: src1:i len:8
 bigmul: len:8 dest:l src1:i src2:i
 bigmul_un: len:8 dest:l src1:i src2:i
 tls_get: len:24 dest:i clob:c
+tls_get_reg: len:28 dest:i src1:i clob:c
+tls_set: len:24 src1:i clob:c
+tls_set_reg: len:28 src1:i src2:i clob:c
 
 # 32 bit opcodes
 int_add: dest:i src1:i src2:i len:4

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4142,9 +4142,7 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 			return NULL;
 		}
 
-#ifndef MONO_CROSS_COMPILE
 		managed_alloc = mono_gc_get_managed_allocator (klass, for_box, TRUE);
-#endif
 
 		if (managed_alloc) {
 			int size = mono_class_instance_size (klass);

--- a/mono/mini/mini-arm-tls.S
+++ b/mono/mini/mini-arm-tls.S
@@ -1,0 +1,114 @@
+/*
+ * mini-arm-tls.S: tls getters and setters for arm platforms
+ *
+ * Copyright 2015 Xamarin, Inc.
+ */
+
+#include <config.h>
+
+#ifndef MONO_CROSS_COMPILE
+
+	/*
+	 * The following thunks fetch the value corresponding to the key/offset
+	 * passed in R0. These thunks don't do jumps to external code so execution
+	 * within can be tracked. The tls value is returned in R0.
+	 */
+
+	.text
+/* no .arch on clang. it only supports armv6+ anyway */
+#ifndef TARGET_MACH
+	.arch armv5
+#endif
+	.arm
+	.align 4
+#ifdef TARGET_MACH
+	.global _mono_fast_get_tls_key
+_mono_fast_get_tls_key :
+#else
+	.global mono_fast_get_tls_key
+mono_fast_get_tls_key :
+#endif
+#if defined(HAVE_KW_THREAD) && defined(__linux__)
+	mrc	p15, 0, r1, c13, c0, 3
+	ldr	r0, [r1, r0]
+	bx	lr
+#else
+	nop
+#endif
+
+	/*
+	 * The following thunks fetch the value corresponding to the key/offset
+	 * passed in R0. These thunks are used in the unlikely cases where we determine
+	 * at runtime that the current implementation is not accounted for.
+	 */
+
+	.align 4
+#ifdef TARGET_MACH
+	.global _mono_fallback_get_tls_key
+_mono_fallback_get_tls_key :
+#else
+	.global mono_fallback_get_tls_key
+mono_fallback_get_tls_key :
+#endif
+#if defined(HAVE_KW_THREAD) && defined(__linux__)
+	mov	r1, r0
+	mvn	r0, #0xf000
+	sub	r0, r0, #31
+	push	{lr}
+	blx	r0
+	ldr	r0, [r0, r1]
+	pop	{pc}
+#else
+	nop
+#endif
+
+	/*
+	 * The following thunks set the value corresponding to the key/offset
+	 * passed in R0. These thunks don't do jumps to external code so execution
+	 * within can be tracked. The tls value is passed in R1.
+	 */
+
+	.align 4
+#ifdef TARGET_MACH
+	.global _mono_fast_set_tls_key
+_mono_fast_set_tls_key :
+#else
+	.global mono_fast_set_tls_key
+mono_fast_set_tls_key :
+#endif
+#if defined(HAVE_KW_THREAD) && defined(__linux__)
+	mrc	p15, 0, r2, c13, c0, 3
+	str	r1, [r2, r0]
+	bx	lr
+#else
+	nop
+#endif
+
+	/*
+	 * The following thunks set the value corresponding to the key/offset
+	 * passed in R0. These thunks are used in the unlikely cases where we determine
+	 * at runtime that the current implementation is not accounted for.
+	 */
+
+	.align 4
+#ifdef TARGET_MACH
+	.global _mono_fallback_set_tls_key
+_mono_fallback_set_tls_key :
+#else
+	.global mono_fallback_set_tls_key
+mono_fallback_set_tls_key :
+#endif
+#if defined(HAVE_KW_THREAD) && defined(__linux__)
+	mov	r2, r0
+	mvn	r0, #0xf000
+	sub	r0, r0, #31
+	push	{lr}
+	blx	r0
+	str	r1, [r0, r2]
+	pop	{pc}
+#else
+	nop
+#endif
+
+#endif
+

--- a/mono/mini/mini-arm-tls.S
+++ b/mono/mini/mini-arm-tls.S
@@ -36,8 +36,11 @@ mono_fast_get_tls_key :
 	ldr	r0, [r1, r0, lsl #2]
 #endif
 	bx	lr
-#else
-	nop
+#elif defined(TARGET_IOS)
+	mrc	p15, 0, r1, c13, c0, 3
+	bic	r1, r1, #3
+	ldr	r0, [r1, r0, lsl #2]
+	bx	lr
 #endif
 
 	/*
@@ -66,8 +69,10 @@ mono_fallback_get_tls_key :
 	ldr	r0, [r0, r1, lsl #2]
 #endif
 	pop	{pc}
-#else
-	nop
+#elif defined(TARGET_IOS)
+	push	{lr}
+	bl	_pthread_getspecific
+	pop	{pc}
 #endif
 
 	/*
@@ -92,8 +97,11 @@ mono_fast_set_tls_key :
 	str	r1, [r2, r0, lsl #2]
 #endif
 	bx	lr
-#else
-	nop
+#elif defined(TARGET_IOS)
+	mrc	p15, 0, r2, c13, c0, 3
+	bic	r2, r2, #3
+	str	r1, [r2, r0, lsl #2]
+	bx	lr
 #endif
 
 	/*
@@ -122,8 +130,10 @@ mono_fallback_set_tls_key :
 	str	r1, [r0, r2, lsl #2]
 #endif
 	pop	{pc}
-#else
-	nop
+#elif defined(TARGET_IOS)
+	push	{lr}
+	bl	_pthread_setspecific
+	pop	{pc}
 #endif
 
 #endif

--- a/mono/mini/mini-arm-tls.S
+++ b/mono/mini/mini-arm-tls.S
@@ -28,9 +28,13 @@ _mono_fast_get_tls_key :
 	.global mono_fast_get_tls_key
 mono_fast_get_tls_key :
 #endif
-#if defined(HAVE_KW_THREAD) && defined(__linux__)
+#if defined(__linux__)
 	mrc	p15, 0, r1, c13, c0, 3
+#if defined(HAVE_KW_THREAD)
 	ldr	r0, [r1, r0]
+#elif defined(TARGET_ANDROID)
+	ldr	r0, [r1, r0, lsl #2]
+#endif
 	bx	lr
 #else
 	nop
@@ -50,13 +54,17 @@ _mono_fallback_get_tls_key :
 	.global mono_fallback_get_tls_key
 mono_fallback_get_tls_key :
 #endif
-#if defined(HAVE_KW_THREAD) && defined(__linux__)
+#if defined(__linux__)
 	mov	r1, r0
 	mvn	r0, #0xf000
 	sub	r0, r0, #31
 	push	{lr}
 	blx	r0
+#if defined(HAVE_KW_THREAD)
 	ldr	r0, [r0, r1]
+#elif defined(TARGET_ANDROID)
+	ldr	r0, [r0, r1, lsl #2]
+#endif
 	pop	{pc}
 #else
 	nop
@@ -76,9 +84,13 @@ _mono_fast_set_tls_key :
 	.global mono_fast_set_tls_key
 mono_fast_set_tls_key :
 #endif
-#if defined(HAVE_KW_THREAD) && defined(__linux__)
+#if defined(__linux__)
 	mrc	p15, 0, r2, c13, c0, 3
+#if defined(HAVE_KW_THREAD)
 	str	r1, [r2, r0]
+#elif defined(TARGET_ANDROID)
+	str	r1, [r2, r0, lsl #2]
+#endif
 	bx	lr
 #else
 	nop
@@ -98,13 +110,17 @@ _mono_fallback_set_tls_key :
 	.global mono_fallback_set_tls_key
 mono_fallback_set_tls_key :
 #endif
-#if defined(HAVE_KW_THREAD) && defined(__linux__)
+#if defined(__linux__)
 	mov	r2, r0
 	mvn	r0, #0xf000
 	sub	r0, r0, #31
 	push	{lr}
 	blx	r0
+#if defined(HAVE_KW_THREAD)
 	str	r1, [r0, r2]
+#elif defined(TARGET_ANDROID)
+	str	r1, [r0, r2, lsl #2]
+#endif
 	pop	{pc}
 #else
 	nop

--- a/mono/mini/mini-arm-tls.h
+++ b/mono/mini/mini-arm-tls.h
@@ -1,0 +1,14 @@
+#ifndef __MONO_MINI_ARM_TLS_H__
+#define __MONO_MINI_ARM_TLS_H__
+
+/* Fast inlined tls getters/setters */
+
+int mono_fast_get_tls_key (int);
+void mono_fast_set_tls_key (int, int);
+
+/* Fallback tls getters/setters */
+
+int mono_fallback_get_tls_key (int);
+void mono_fallback_set_tls_key (int, int);
+
+#endif

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -650,6 +650,8 @@ emit_restore_lmf (MonoCompile *cfg, guint8 *code, gint32 lmf_offset)
 static gboolean
 mono_arm_have_fast_tls (void)
 {
+	if (mini_get_debug_options ()->arm_use_fallback_tls)
+		return FALSE;
 #if (defined(HAVE_KW_THREAD) && defined(__linux__)) \
 	|| defined(TARGET_ANDROID)
 	guint32* kuser_get_tls = (void*)0xffff0fe0;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -21,12 +21,17 @@
 #include <mono/utils/mono-memory-model.h>
 
 #include "mini-arm.h"
+#include "mini-arm-tls.h"
 #include "cpu-arm.h"
 #include "trace.h"
 #include "ir-emit.h"
 #include "debugger-agent.h"
 #include "mini-gc.h"
 #include "mono/arch/arm/arm-vfp-codegen.h"
+
+#if defined(HAVE_KW_THREAD) && defined(__linux__)
+#define HAVE_FAST_TLS
+#endif
 
 /* Sanity check: This makes no sense */
 #if defined(ARM_FPU_NONE) && (defined(ARM_FPU_VFP) || defined(ARM_FPU_VFP_HARD))
@@ -54,10 +59,6 @@
 #define IS_SOFT_FLOAT (FALSE)
 #define IS_HARD_FLOAT (FALSE)
 #define IS_VFP (TRUE)
-#endif
-
-#if defined(__ARM_EABI__) && defined(__linux__) && !defined(PLATFORM_ANDROID) && !defined(__native_client__)
-#define HAVE_AEABI_READ_TP 1
 #endif
 
 #define THUNK_SIZE (3 * 4)
@@ -385,6 +386,86 @@ mono_arm_load_jumptable_entry (guint8 *code, gpointer* jte, ARMReg reg)
 }
 #endif
 
+static guint8*
+mono_arm_emit_tls_get (MonoCompile *cfg, guint8* code, int dreg, int tls_offset)
+{
+#ifdef HAVE_FAST_TLS
+	code = mono_arm_emit_load_imm (code, ARMREG_R0, tls_offset);
+	mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_INTERNAL_METHOD,
+			"mono_get_tls_key");
+	code = emit_call_seq (cfg, code);
+	if (dreg != ARMREG_R0)
+		ARM_MOV_REG_REG (code, dreg, ARMREG_R0);
+#else
+	g_assert_not_reached ();
+#endif
+	return code;
+}
+
+static guint8*
+mono_arm_emit_tls_get_reg (MonoCompile *cfg, guint8* code, int dreg, int tls_offset_reg)
+{
+#ifdef HAVE_FAST_TLS
+	if (tls_offset_reg != ARMREG_R0)
+		ARM_MOV_REG_REG (code, ARMREG_R0, tls_offset_reg);
+	mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_INTERNAL_METHOD,
+			"mono_get_tls_key");
+	code = emit_call_seq (cfg, code);
+	if (dreg != ARMREG_R0)
+		ARM_MOV_REG_REG (code, dreg, ARMREG_R0);
+#else
+	g_assert_not_reached ();
+#endif
+	return code;
+}
+
+static guint8*
+mono_arm_emit_tls_set (MonoCompile *cfg, guint8* code, int sreg, int tls_offset)
+{
+#ifdef HAVE_FAST_TLS
+	if (sreg != ARMREG_R1)
+		ARM_MOV_REG_REG (code, ARMREG_R1, sreg);
+	code = mono_arm_emit_load_imm (code, ARMREG_R0, tls_offset);
+	mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_INTERNAL_METHOD,
+			"mono_set_tls_key");
+	code = emit_call_seq (cfg, code);
+#else
+	g_assert_not_reached ();
+#endif
+	return code;
+}
+
+static guint8*
+mono_arm_emit_tls_set_reg (MonoCompile *cfg, guint8* code, int sreg, int tls_offset_reg)
+{
+#ifdef HAVE_FAST_TLS
+	/* Get sreg in R1 and tls_offset_reg in R0 */
+	if (tls_offset_reg == ARMREG_R1) {
+		if (sreg == ARMREG_R0) {
+			/* swap sreg and tls_offset_reg */
+			ARM_EOR_REG_REG (code, sreg, sreg, tls_offset_reg);
+			ARM_EOR_REG_REG (code, tls_offset_reg, sreg, tls_offset_reg);
+			ARM_EOR_REG_REG (code, sreg, sreg, tls_offset_reg);
+		} else {
+			ARM_MOV_REG_REG (code, ARMREG_R0, tls_offset_reg);
+			if (sreg != ARMREG_R1)
+				ARM_MOV_REG_REG (code, ARMREG_R1, sreg);
+		}
+	} else {
+		if (sreg != ARMREG_R1)
+			ARM_MOV_REG_REG (code, ARMREG_R1, sreg);
+		if (tls_offset_reg != ARMREG_R0)
+			ARM_MOV_REG_REG (code, ARMREG_R0, tls_offset_reg);
+	}
+	mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_INTERNAL_METHOD,
+			"mono_set_tls_key");
+	code = emit_call_seq (cfg, code);
+#else
+	g_assert_not_reached ();
+#endif
+	return code;
+}
+
 /*
  * emit_save_lmf:
  *
@@ -397,21 +478,24 @@ emit_save_lmf (MonoCompile *cfg, guint8 *code, gint32 lmf_offset)
 	gboolean get_lmf_fast = FALSE;
 	int i;
 
-#ifdef HAVE_AEABI_READ_TP
-	gint32 lmf_addr_tls_offset = mono_get_lmf_addr_tls_offset ();
-
-	if (lmf_addr_tls_offset != -1) {
+	if (mono_arm_have_tls_get ()) {
 		get_lmf_fast = TRUE;
-
-		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_INTERNAL_METHOD,
-							 (gpointer)"__aeabi_read_tp");
-		code = emit_call_seq (cfg, code);
-
-		ARM_LDR_IMM (code, ARMREG_R0, ARMREG_R0, lmf_addr_tls_offset);
-		get_lmf_fast = TRUE;
+		if (cfg->compile_aot) {
+			/* OP_AOTCONST */
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_TLS_OFFSET, (gpointer)TLS_KEY_LMF_ADDR);
+			ARM_LDR_IMM (code, ARMREG_R1, ARMREG_PC, 0);
+			ARM_B (code, 0);
+			*(gpointer*)code = NULL;
+			code += 4;
+			/* Load the value from the GOT */
+			ARM_LDR_REG_REG (code, ARMREG_R1, ARMREG_PC, ARMREG_R1);
+			code = mono_arm_emit_tls_get_reg (cfg, code, ARMREG_R0, ARMREG_R1);
+		} else {
+			gint32 lmf_addr_tls_offset = mono_get_lmf_addr_tls_offset ();
+			g_assert (lmf_addr_tls_offset != -1);
+			code = mono_arm_emit_tls_get (cfg, code, ARMREG_R0, lmf_addr_tls_offset);
+		}
 	}
-#endif
-
 #ifdef TARGET_IOS
 	if (cfg->method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
 		int lmf_offset;
@@ -586,6 +670,38 @@ emit_restore_lmf (MonoCompile *cfg, guint8 *code, gint32 lmf_offset)
 }
 
 #endif /* #ifndef DISABLE_JIT */
+
+#ifndef MONO_CROSS_COMPILE
+static gboolean
+mono_arm_have_fast_tls (void)
+{
+#if defined(HAVE_KW_THREAD) && defined(__linux__)
+	guint32* kuser_get_tls = (void*)0xffff0fe0;
+	guint32 expected [] = {0xee1d0f70, 0xe12fff1e};
+
+	/* Expecting mrc + bx lr in the kuser_get_tls kernel helper */
+	return memcmp (kuser_get_tls, expected, 8) == 0;
+#else
+	return FALSE;
+#endif
+}
+#endif
+
+/*
+ * mono_arm_have_tls_get:
+ *
+ * Returns whether we have tls access implemented on the current
+ * platform
+ */
+gboolean
+mono_arm_have_tls_get (void)
+{
+#ifdef HAVE_FAST_TLS
+	return TRUE;
+#else
+	return FALSE;
+#endif
+}
 
 /*
  * mono_arch_get_argument_info:
@@ -4184,15 +4300,16 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			}
 			break;
 		case OP_TLS_GET:
-#ifdef HAVE_AEABI_READ_TP
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_INTERNAL_METHOD, 
-								 (gpointer)"__aeabi_read_tp");
-			code = emit_call_seq (cfg, code);
-
-			ARM_LDR_IMM (code, ins->dreg, ARMREG_R0, ins->inst_offset);
-#else
-			g_assert_not_reached ();
-#endif
+			code = mono_arm_emit_tls_get (cfg, code, ins->dreg, ins->inst_offset);
+			break;
+		case OP_TLS_GET_REG:
+			code = mono_arm_emit_tls_get_reg (cfg, code, ins->dreg, ins->sreg1);
+			break;
+		case OP_TLS_SET:
+			code = mono_arm_emit_tls_set (cfg, code, ins->sreg1, ins->inst_offset);
+			break;
+		case OP_TLS_SET_REG:
+			code = mono_arm_emit_tls_set_reg (cfg, code, ins->sreg1, ins->sreg2);
 			break;
 		case OP_ATOMIC_EXCHANGE_I4:
 		case OP_ATOMIC_CAS_I4:
@@ -5854,10 +5971,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 #endif /* DISABLE_JIT */
 
-#ifdef HAVE_AEABI_READ_TP
-void __aeabi_read_tp (void);
-#endif
-
 void
 mono_arch_register_lowlevel_calls (void)
 {
@@ -5866,9 +5979,16 @@ mono_arch_register_lowlevel_calls (void)
 	mono_register_jit_icall (mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
 
 #ifndef MONO_CROSS_COMPILE
-#ifdef HAVE_AEABI_READ_TP
-	mono_register_jit_icall (__aeabi_read_tp, "__aeabi_read_tp", mono_create_icall_signature ("void"), TRUE);
-#endif
+	if (mono_arm_have_tls_get ()) {
+		if (mono_arm_have_fast_tls ()) {
+			mono_register_jit_icall (mono_fast_get_tls_key, "mono_get_tls_key", mono_create_icall_signature ("ptr ptr"), TRUE);
+			mono_register_jit_icall (mono_fast_set_tls_key, "mono_set_tls_key", mono_create_icall_signature ("void ptr ptr"), TRUE);
+		} else {
+			g_warning ("No fast tls on device. Using fallbacks.");
+			mono_register_jit_icall (mono_fallback_get_tls_key, "mono_get_tls_key", mono_create_icall_signature ("ptr ptr"), TRUE);
+			mono_register_jit_icall (mono_fallback_set_tls_key, "mono_set_tls_key", mono_create_icall_signature ("void ptr ptr"), TRUE);
+		}
+	}
 #endif
 }
 

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -29,7 +29,8 @@
 #include "mini-gc.h"
 #include "mono/arch/arm/arm-vfp-codegen.h"
 
-#if defined(HAVE_KW_THREAD) && defined(__linux__)
+#if defined(HAVE_KW_THREAD) && defined(__linux__) \
+	|| defined(TARGET_ANDROID)
 #define HAVE_FAST_TLS
 #endif
 
@@ -675,7 +676,8 @@ emit_restore_lmf (MonoCompile *cfg, guint8 *code, gint32 lmf_offset)
 static gboolean
 mono_arm_have_fast_tls (void)
 {
-#if defined(HAVE_KW_THREAD) && defined(__linux__)
+#if (defined(HAVE_KW_THREAD) && defined(__linux__)) \
+	|| defined(TARGET_ANDROID)
 	guint32* kuser_get_tls = (void*)0xffff0fe0;
 	guint32 expected [] = {0xee1d0f70, 0xe12fff1e};
 

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -301,10 +301,8 @@ typedef struct MonoCompileArch {
 #undef MONO_ARCH_HAVE_CONTEXT_SET_INT_REG
 #endif
 
-/* Matches the HAVE_AEABI_READ_TP define in mini-arm.c */
-#if defined(__ARM_EABI__) && defined(__linux__) && !defined(TARGET_ANDROID) && !defined(__native_client__)
-#define MONO_ARCH_HAVE_TLS_GET 1
-#endif
+#define MONO_ARCH_HAVE_TLS_GET (mono_arm_have_tls_get ())
+#define MONO_ARCH_HAVE_TLS_GET_REG 1
 
 /* ARM doesn't have too many registers, so we have to use a callee saved one */
 #define MONO_ARCH_RGCTX_REG ARMREG_V5
@@ -357,5 +355,8 @@ mono_arm_load_jumptable_entry (guint8 *code, gpointer *jte, ARMReg reg);
 
 gboolean
 mono_arm_is_hard_float (void);
+
+gboolean
+mono_arm_have_tls_get (void);
 
 #endif /* __MONO_MINI_ARM_H__ */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2675,6 +2675,8 @@ mini_parse_debug_options (void)
 			debug_options.soft_breakpoints = TRUE;
 		else if (!strcmp (arg, "check-pinvoke-callconv"))
 			debug_options.check_pinvoke_callconv = TRUE;
+		else if (!strcmp (arg, "arm-use-fallback-tls"))
+			debug_options.arm_use_fallback_tls = TRUE;
 		else if (!strcmp (arg, "debug-domain-unload"))
 			mono_enable_debug_domain_unload (TRUE);
 		else if (!strcmp (arg, "partial-sharing"))
@@ -2683,7 +2685,7 @@ mini_parse_debug_options (void)
 			mono_align_small_structs = TRUE;
 		else {
 			fprintf (stderr, "Invalid option for the MONO_DEBUG env variable: %s\n", arg);
-			fprintf (stderr, "Available options: 'handle-sigint', 'keep-delegates', 'reverse-pinvoke-exceptions', 'collect-pagefault-stats', 'break-on-unverified', 'no-gdb-backtrace', 'dont-free-domains', 'suspend-on-sigsegv', 'suspend-on-exception', 'suspend-on-unhandled', 'dyn-runtime-invoke', 'gdb', 'explicit-null-checks', 'init-stacks', 'check-pinvoke-callconv', 'debug-domain-unload', 'partial-sharing', 'align-small-structs'\n");
+			fprintf (stderr, "Available options: 'handle-sigint', 'keep-delegates', 'reverse-pinvoke-exceptions', 'collect-pagefault-stats', 'break-on-unverified', 'no-gdb-backtrace', 'dont-free-domains', 'suspend-on-sigsegv', 'suspend-on-exception', 'suspend-on-unhandled', 'dyn-runtime-invoke', 'gdb', 'explicit-null-checks', 'init-stacks', 'check-pinvoke-callconv', 'arm-use-fallback-tls', 'debug-domain-unload', 'partial-sharing', 'align-small-structs'\n");
 			exit (1);
 		}
 	}

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1923,6 +1923,7 @@ typedef struct {
 	gboolean suspend_on_unhandled;
 	gboolean dyn_runtime_invoke;
 	gboolean gdb;
+	gboolean arm_use_fallback_tls;
 	/*
 	 * Whenever data such as next sequence points and flags is required.
 	 * Next sequence points and flags are required by the debugger agent.

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -140,6 +140,7 @@ BASE_TEST_CS_SRC=		\
 	many-locals.cs		\
 	string-compare.cs	\
 	test-prime.cs		\
+	test-tls.cs		\
 	params.cs		\
 	reflection.cs		\
 	interface.cs		\

--- a/mono/tests/test-tls.cs
+++ b/mono/tests/test-tls.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+
+public class Program
+{
+	public const int nr_threads = 4;
+	public const int reps = 10000;
+	public static int[] allocs = new int[nr_threads];
+
+	public Program (int index)
+	{
+		allocs [index] += 1;
+	}
+
+	public static void Work (object oindex)
+	{
+		int index = (int)oindex;
+		for (int i = 0; i < reps; i++) {
+			Thread thread = Thread.CurrentThread;
+			if (string.Compare (thread.Name, "t" + index) == 0)
+				new Program (index);
+		}
+	}
+
+	public static int Main (string[] args)
+	{
+		Thread[] threads = new Thread[nr_threads];
+
+		for (int i = 0; i < nr_threads; i++) {
+			threads [i] = new Thread (Work);
+			threads [i].Name = "t" + i;
+			threads [i].Start (i);
+		}
+
+		for (int i = 0; i < nr_threads; i++) {
+			threads [i].Join ();
+			if (allocs [i] != reps)
+				return 1;
+		}
+
+		return 0;
+	}
+}

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -194,6 +194,17 @@
 	pthread_key_t _y;	\
 	(void) (&_x == &_y);		\
 	y = (gint32) x; })
+
+#elif defined(TARGET_ANDROID) && defined(TARGET_ARM)
+
+#define MONO_HAVE_FAST_TLS
+#define MONO_FAST_TLS_SET(x,y) pthread_setspecific(x, y)
+#define MONO_FAST_TLS_GET(x) pthread_getspecific(x)
+#define MONO_FAST_TLS_INIT(x) pthread_key_create(&x, NULL)
+#define MONO_FAST_TLS_DECLARE(x) static pthread_key_t x;
+
+#define MONO_THREAD_VAR_OFFSET(var, offset) do { offset = (int)var; } while (0)
+
 #else /* no HAVE_KW_THREAD */
 
 #define MONO_THREAD_VAR_OFFSET(var,offset) (offset) = -1

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -195,7 +195,7 @@
 	(void) (&_x == &_y);		\
 	y = (gint32) x; })
 
-#elif defined(TARGET_ANDROID) && defined(TARGET_ARM)
+#elif (defined(TARGET_ANDROID) || defined(TARGET_IOS)) && defined(TARGET_ARM)
 
 #define MONO_HAVE_FAST_TLS
 #define MONO_FAST_TLS_SET(x,y) pthread_setspecific(x, y)


### PR DESCRIPTION
Add support for OP_TLS operations on arm. The code that implements this is comprised of getter and setter asm thunks, which is either inlined, or it uses external code. At runtime we check the implementation on the system, using the inlined thunks if we can.

This also enables the sgen allocator fastpath.