### PR TITLE
[io-layer] Fix Windows build on mingw

### DIFF
--- a/mono/io-layer/io-layer.h
+++ b/mono/io-layer/io-layer.h
@@ -14,13 +14,6 @@
 #if defined(__WIN32__) || defined(_WIN32)
 /* Native win32 */
 #define __USE_W32_SOCKETS
-#if (_WIN32_WINNT < 0x0502)
-/* GetProcessId is available on Windows XP SP1 and later.
- * Windows SDK declares it unconditionally.
- * MinGW declares for Windows XP and later.
- * Declare as __GetProcessId for unsupported targets. */
-#define GetProcessId __GetProcessId
-#endif
 #include <windows.h>
 #include <winbase.h>
 #include <winsock2.h>
@@ -33,10 +26,18 @@
 #endif
 #include <psapi.h>
 #include <shlobj.h>
-#include <mswsock.h>
-#if (_WIN32_WINNT < 0x0502)
-#undef GetProcessId
+/*
+ * Workaround for missing WSAPOLLFD typedef in mingw's winsock2.h that is required for mswsock.h below.
+ * Remove once http://sourceforge.net/p/mingw/bugs/1980/ is fixed.
+ */
+#if defined(__MINGW_MAJOR_VERSION) && __MINGW_MAJOR_VERSION == 4 
+typedef struct pollfd {
+  SOCKET fd;
+  short  events;
+  short  revents;
+} WSAPOLLFD, *PWSAPOLLFD, *LPWSAPOLLFD;
 #endif
+#include <mswsock.h>
 #else	/* EVERYONE ELSE */
 #include "mono/io-layer/wapi.h"
 #include "mono/io-layer/uglify.h"


### PR DESCRIPTION
When we moved to Vista as the minimum build target, the mingw build broke.
The reason is that mingw's mswsock.h has the following code:

    #if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
    int WSAAPI WSAPoll(WSAPOLLFD, ULONG, INT);
    #endif

Unfortunately, due to a bug mingw 4.0 doesn't define WSAPOLLFD and the compiler
raises an error. See http://sourceforge.net/p/mingw/bugs/1980 for more details.

As a workaround, inline the typedef for WSAPOLLFD from the mentioned bug report.

Also removed an unecessary check for _WIN32_WINNT < 0x0502 from the file.