### PR TITLE
Remove MONO_API from some internal GC APIs

### DIFF
--- a/docs/current-api
+++ b/docs/current-api
@@ -292,7 +292,6 @@ mono_free_method
 mono_free_verify_list
 mono_gc_collect
 mono_gc_collection_count
-mono_gc_enable_events
 mono_gc_get_generation
 mono_gc_get_heap_size
 mono_gc_get_used_size
@@ -301,9 +300,7 @@ mono_gchandle_get_target
 mono_gchandle_new
 mono_gchandle_new_weakref
 mono_gc_invoke_finalizers
-mono_gc_is_finalizer_thread
 mono_gc_max_generation
-mono_gc_out_of_memory
 mono_gc_wbarrier_arrayref_copy
 mono_gc_wbarrier_generic_nostore
 mono_gc_wbarrier_generic_store
@@ -604,7 +601,6 @@ mono_object_get_class
 mono_object_get_domain
 mono_object_get_size
 mono_object_get_virtual_method
-mono_object_is_alive
 mono_object_isinst
 mono_object_isinst_mbyref
 mono_object_new

--- a/docs/documented
+++ b/docs/documented
@@ -269,12 +269,9 @@ mono_gc_weak_link_get
 mono_gc_weak_link_remove
 mono_gc_disable
 mono_gc_enable
-mono_gc_is_finalizer_thread
-mono_gc_out_of_memory
 mono_gc_start_world
 mono_gc_stop_world
 mono_gc_alloc_fixed
-mono_gc_enable_events
 mono_gc_free_fixed
 mono_gc_make_descr_from_bitmap
 mono_gc_base_init
@@ -526,7 +523,6 @@ mono_object_isinst
 mono_object_register_finalizer
 mono_object_unbox
 mono_object_castclass_mbyref
-mono_object_is_alive
 mono_object_get_size
 mono_value_box
 mono_value_copy

--- a/docs/public-api
+++ b/docs/public-api
@@ -292,7 +292,6 @@ mono_free_method
 mono_free_verify_list
 mono_gc_collect
 mono_gc_collection_count
-mono_gc_enable_events
 mono_gc_get_generation
 mono_gc_get_heap_size
 mono_gc_get_used_size
@@ -301,9 +300,7 @@ mono_gchandle_get_target
 mono_gchandle_new
 mono_gchandle_new_weakref
 mono_gc_invoke_finalizers
-mono_gc_is_finalizer_thread
 mono_gc_max_generation
-mono_gc_out_of_memory
 mono_gc_wbarrier_arrayref_copy
 mono_gc_wbarrier_generic_nostore
 mono_gc_wbarrier_generic_store
@@ -604,7 +601,6 @@ mono_object_get_class
 mono_object_get_domain
 mono_object_get_size
 mono_object_get_virtual_method
-mono_object_is_alive
 mono_object_isinst
 mono_object_isinst_mbyref
 mono_object_new

--- a/docs/sources/mono-api-internal.html
+++ b/docs/sources/mono-api-internal.html
@@ -93,12 +93,9 @@
 	
 <h4><a name="api:mono_gc_disable">mono_gc_disable</a></h4>
 <h4><a name="api:mono_gc_enable">mono_gc_enable</a></h4>
-<h4><a name="api:mono_gc_is_finalizer_thread">mono_gc_is_finalizer_thread</a></h4>
-<h4><a name="api:mono_gc_out_of_memory">mono_gc_out_of_memory</a></h4>
 <h4><a name="api:mono_gc_start_world">mono_gc_start_world</a></h4>
 <h4><a name="api:mono_gc_stop_world">mono_gc_stop_world</a></h4>
 <h4><a name="api:mono_gc_alloc_fixed">mono_gc_alloc_fixed</a></h4> 
-<h4><a name="api:mono_gc_enable_events">mono_gc_enable_events</a></h4> 
 <h4><a name="api:mono_gc_free_fixed">mono_gc_free_fixed</a></h4> 
 <h4><a name="api:mono_gc_make_descr_from_bitmap">mono_gc_make_descr_from_bitmap</a></h4> 
 

--- a/docs/sources/mono-api-object.html
+++ b/docs/sources/mono-api-object.html
@@ -93,7 +93,6 @@ result = mono_object_new (mono_domain_get (), version_class);
 <h4><a name="api:mono_object_isinst">mono_object_isinst</a></h4>
 <h4><a name="api:mono_object_unbox">mono_object_unbox</a></h4>
 <h4><a name="api:mono_object_castclass_mbyref">mono_object_castclass_mbyref</a></h4>
-<h4><a name="api:mono_object_is_alive">mono_object_is_alive</a></h4> 
 <h4><a name="api:mono_object_get_size">mono_object_get_size</a></h4>
 
 <a name="valuetypes"></a>

--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -113,10 +113,10 @@ extern void mono_gc_set_stack_end (void *stack_end);
 /* only valid after the RECLAIM_START GC event and before RECLAIM_END
  * Not exported in public headers, but can be linked to (unsupported).
  */
-extern MONO_API gboolean mono_object_is_alive (MonoObject* obj);
-extern MONO_API gboolean mono_gc_is_finalizer_thread (MonoThread *thread);
-extern MONO_API gpointer mono_gc_out_of_memory (size_t size);
-extern MONO_API void     mono_gc_enable_events (void);
+gboolean mono_object_is_alive (MonoObject* obj);
+gboolean mono_gc_is_finalizer_thread (MonoThread *thread);
+gpointer mono_gc_out_of_memory (size_t size);
+void     mono_gc_enable_events (void);
 
 /* disappearing link functionality */
 void        mono_gc_weak_link_add    (void **link_addr, MonoObject *obj, gboolean track);
@@ -147,7 +147,7 @@ typedef void (*MonoGCMarkFunc)     (void **addr, void *gc_data);
 typedef void (*MonoGCRootMarkFunc) (void *addr, MonoGCMarkFunc mark_func, void *gc_data);
 
 /* Create a descriptor with a user defined marking function */
-MONO_API void *mono_gc_make_root_descr_user (MonoGCRootMarkFunc marker);
+void *mono_gc_make_root_descr_user (MonoGCRootMarkFunc marker);
 
 /* Return whenever user defined marking functions are supported */
 gboolean mono_gc_user_markers_supported (void);

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -329,15 +329,11 @@ mono_g_hash_table_replace
 mono_g_hash_table_size
 mono_gc_collect
 mono_gc_collection_count
-mono_gc_enable_events
 mono_gc_get_generation
 mono_gc_get_heap_size
 mono_gc_get_used_size
 mono_gc_invoke_finalizers
-mono_gc_is_finalizer_thread
-mono_gc_make_root_descr_user
 mono_gc_max_generation
-mono_gc_out_of_memory
 mono_gc_reference_queue_add
 mono_gc_reference_queue_free
 mono_gc_reference_queue_new
@@ -651,7 +647,6 @@ mono_object_get_domain
 mono_object_get_size
 mono_object_get_virtual_method
 mono_object_hash
-mono_object_is_alive
 mono_object_isinst
 mono_object_isinst_mbyref
 mono_object_isinst_with_cache

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -329,15 +329,11 @@ mono_g_hash_table_replace
 mono_g_hash_table_size
 mono_gc_collect
 mono_gc_collection_count
-mono_gc_enable_events
 mono_gc_get_generation
 mono_gc_get_heap_size
 mono_gc_get_used_size
 mono_gc_invoke_finalizers
-mono_gc_is_finalizer_thread
-mono_gc_make_root_descr_user
 mono_gc_max_generation
-mono_gc_out_of_memory
 mono_gc_reference_queue_add
 mono_gc_reference_queue_free
 mono_gc_reference_queue_new
@@ -653,7 +649,6 @@ mono_object_get_domain
 mono_object_get_size
 mono_object_get_virtual_method
 mono_object_hash
-mono_object_is_alive
 mono_object_isinst
 mono_object_isinst_mbyref
 mono_object_isinst_with_cache

--- a/msvc/monosgen64.def
+++ b/msvc/monosgen64.def
@@ -313,15 +313,11 @@ mono_g_hash_table_replace
 mono_g_hash_table_size
 mono_gc_collect
 mono_gc_collection_count
-mono_gc_enable_events
 mono_gc_get_generation
 mono_gc_get_heap_size
 mono_gc_get_used_size
 mono_gc_invoke_finalizers
-mono_gc_is_finalizer_thread
-mono_gc_make_root_descr_user
 mono_gc_max_generation
-mono_gc_out_of_memory
 mono_gc_reference_queue_add
 mono_gc_reference_queue_free
 mono_gc_reference_queue_new
@@ -633,7 +629,6 @@ mono_object_get_domain
 mono_object_get_size
 mono_object_get_virtual_method
 mono_object_hash
-mono_object_is_alive
 mono_object_isinst
 mono_object_isinst_mbyref
 mono_object_isinst_with_cache


### PR DESCRIPTION
I was going over `gc-internal.h` and wasn't sure which of these really should be exposed. (Per @kumpera, `mono_gc_make_root_descr_user` is one that shouldn't be.)

For the record, none of these are used by XA/XI/XM.