### PR TITLE
X509Store bug fixed related to "Certificates" property.

### DIFF
--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Store.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Store.cs
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography.X509Certificates {
 
 		// properties
 
-		public X509Certificate2Collection Certificates {
+		private X509Certificate2Collection CertList {
 			get {
 				if (list == null)
 					list = new X509Certificate2Collection ();
@@ -117,6 +117,17 @@ namespace System.Security.Cryptography.X509Certificates {
 					list.Clear ();
 
 				return list;
+			}
+		}
+
+		public X509Certificate2Collection Certificates {
+			get {
+				X509Certificate2Collection certificates = this.CertList;
+				X509Certificate2Collection collection = new X509Certificate2Collection ();
+				for (int i = 0; i < certificates.Count; i++)
+					collection.Add (new X509Certificate2 (certificates [i].RawData));
+
+				return collection;
 			}
 		} 
 
@@ -170,7 +181,7 @@ namespace System.Security.Cryptography.X509Certificates {
 					store.Import (new MX.X509Certificate (certificate.RawData));
 				}
 				finally {
-					Certificates.Add (certificate);
+					CertList.Add (certificate);
 				}
 			}
 		}
@@ -195,7 +206,7 @@ namespace System.Security.Cryptography.X509Certificates {
 						store.Import (new MX.X509Certificate (certificate.RawData));
 					}
 					finally {
-						Certificates.Add (certificate);
+						CertList.Add (certificate);
 					}
 				}
 			}
@@ -233,7 +244,7 @@ namespace System.Security.Cryptography.X509Certificates {
 			foreach (MX.X509Certificate x in store.Certificates) {
 				var cert2 = new X509Certificate2 (x.RawData);
 				cert2.PrivateKey = x.RSA;
-				Certificates.Add (cert2);
+				CertList.Add (cert2);
 			}
 		}
 
@@ -254,7 +265,7 @@ namespace System.Security.Cryptography.X509Certificates {
 				store.Remove (new MX.X509Certificate (certificate.RawData));
 			}
 			finally {
-				Certificates.Remove (certificate);
+				CertList.Remove (certificate);
 			}
 		}
 
@@ -286,7 +297,7 @@ namespace System.Security.Cryptography.X509Certificates {
 					store.Remove (new MX.X509Certificate (certificate.RawData));
 			}
 			finally {
-				Certificates.RemoveRange (certificates);
+				CertList.RemoveRange (certificates);
 			}
 		}
 

--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509StoreTest.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509StoreTest.cs
@@ -525,6 +525,18 @@ namespace MonoTests.System.Security.Cryptography.X509Certificates {
 		}
 
 		[Test]
+		public void Remove_Certificate_OK ()
+		{
+			X509Store xs = new X509Store ("ReadWriteStore");
+			xs.Open (OpenFlags.ReadWrite);
+			xs.Add (cert1);
+			xs.Add (cert2);
+			int countBeforeRemove = xs.Certificates.Count;
+			xs.Remove (cert1);
+			Assert.AreEqual (countBeforeRemove - 1, xs.Certificates.Count);
+		}
+
+		[Test]
 		[ExpectedException (typeof (ArgumentNullException))]
 		public void RemoveRange_Null ()
 		{
@@ -579,6 +591,17 @@ namespace MonoTests.System.Security.Cryptography.X509Certificates {
 		}
 
 		[Test]
+		public void RemoveRange_Certificate_OK ()
+		{
+			X509Store xs = new X509Store ("ReadWriteStore");
+			xs.Open (OpenFlags.ReadWrite);
+			xs.AddRange (coll);
+			int countBeforeRemove = xs.Certificates.Count;
+			xs.RemoveRange (coll);
+			Assert.AreEqual (countBeforeRemove - coll.Count, xs.Certificates.Count);
+		}
+
+		[Test]
 		public void Collection_Add ()
 		{
 			X509Store xs = new X509Store ("ReadWriteStore");
@@ -586,6 +609,28 @@ namespace MonoTests.System.Security.Cryptography.X509Certificates {
 			Assert.AreEqual (0, xs.Certificates.Count, "Not Open");
 			xs.Close ();
 			Assert.AreEqual (0, xs.Certificates.Count, "Close");
+		}
+
+		[Test]
+		public void CertificatesNewCollection ()
+		{
+			X509Store xs = new X509Store ("ReadWriteStore");
+			xs.Open (OpenFlags.ReadWrite);
+			xs.Add (cert1);
+			var coll1 = xs.Certificates;
+			var coll2 = xs.Certificates;
+			Assert.AreEqual (1, coll1.Count);
+			Assert.AreEqual (1, coll2.Count);
+
+			xs.Close ();
+			Assert.AreEqual (1, coll1.Count);
+			Assert.AreEqual (1, coll2.Count);
+			Assert.AreNotSame (coll1[0], coll2[0]);
+
+			coll1.Clear ();
+			Assert.AreEqual (0, coll1.Count);
+			Assert.AreEqual (1, coll2.Count);
+
 		}
 	}
 }


### PR DESCRIPTION
The X509Store.Certificates property behaviour was different in mono (returning a reference) and .NET (returning a copy) and caused side effects. With these changes, the behaviour of the "Certificates" property is now the same as in the .NET.
