### PR TITLE
[runtime] Fix profiler reporting of object allocations

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -47,17 +47,18 @@
 
 #ifdef HAVE_BOEHM_GC
 #define NEED_TO_ZERO_PTRFREE 1
-#define ALLOC_PTRFREE(obj,vt,size) do { (obj) = GC_MALLOC_ATOMIC ((size)); (obj)->vtable = (vt); (obj)->synchronisation = NULL;} while (0)
-#define ALLOC_OBJECT(obj,vt,size) do { (obj) = GC_MALLOC ((size)); (obj)->vtable = (vt);} while (0)
+#define ALLOC_PTRFREE(obj,vt,size) do { (obj) = GC_MALLOC_ATOMIC ((size)); (obj)->vtable = (vt); (obj)->synchronisation = NULL; mono_profiler_allocation ((obj)); } while (0)
+#define ALLOC_OBJECT(obj,vt,size) do { (obj) = GC_MALLOC ((size)); (obj)->vtable = (vt); mono_profiler_allocation ((obj)); } while (0)
 #ifdef HAVE_GC_GCJ_MALLOC
 #define GC_NO_DESCRIPTOR ((gpointer)(0 | GC_DS_LENGTH))
-#define ALLOC_TYPED(dest,size,type) do { (dest) = GC_GCJ_MALLOC ((size),(type)); } while (0)
+#define ALLOC_TYPED(dest,size,type) do { (dest) = GC_GCJ_MALLOC ((size),(type)); mono_profiler_allocation ((dest)); } while (0)
 #else
 #define GC_NO_DESCRIPTOR (NULL)
-#define ALLOC_TYPED(dest,size,type) do { (dest) = GC_MALLOC ((size)); *(gpointer*)dest = (type);} while (0)
+#define ALLOC_TYPED(dest,size,type) do { (dest) = GC_MALLOC ((size)); *(gpointer*)dest = (type); mono_profiler_allocation ((dest)); } while (0)
 #endif
 #else
 #ifdef HAVE_SGEN_GC
+/* allocations are reported to the profiler in the GC functions */
 #define GC_NO_DESCRIPTOR (NULL)
 #define ALLOC_PTRFREE(obj,vt,size) do { (obj) = mono_gc_alloc_obj (vt, size);} while (0)
 #define ALLOC_OBJECT(obj,vt,size) do { (obj) = mono_gc_alloc_obj (vt, size);} while (0)
@@ -90,8 +91,6 @@ mono_string_to_utf8_internal (MonoMemPool *mp, MonoImage *image, MonoString *s, 
 #define ldstr_lock() mono_mutex_lock (&ldstr_section)
 #define ldstr_unlock() mono_mutex_unlock (&ldstr_section)
 static mono_mutex_t ldstr_section;
-
-static gboolean profile_allocs = TRUE;
 
 void
 mono_runtime_object_init (MonoObject *this)
@@ -4387,7 +4386,7 @@ mono_object_allocate_ptrfree (size_t size, MonoVTable *vtable)
 static inline void *
 mono_object_allocate_spec (size_t size, MonoVTable *vtable)
 {
-	void *o;
+	MonoObject *o;
 	ALLOC_TYPED (o, size, vtable);
 
 	return o;
@@ -4491,8 +4490,6 @@ mono_object_new_alloc_specific (MonoVTable *vtable)
 	if (G_UNLIKELY (vtable->klass->has_finalize))
 		mono_object_register_finalizer (o);
 	
-	if (G_UNLIKELY (profile_allocs))
-		mono_profiler_allocation (o, vtable->klass);
 	return o;
 }
 
@@ -4550,9 +4547,6 @@ void*
 mono_class_get_allocation_ftn (MonoVTable *vtable, gboolean for_box, gboolean *pass_size_in_words)
 {
 	*pass_size_in_words = FALSE;
-
-	if (!(mono_profiler_get_events () & MONO_PROFILE_ALLOCATIONS))
-		profile_allocs = FALSE;
 
 	if (mono_class_has_finalizer (vtable->klass) || mono_class_is_marshalbyref (vtable->klass) || (mono_profiler_get_events () & MONO_PROFILE_ALLOCATIONS))
 		return mono_object_new_specific;
@@ -4630,8 +4624,6 @@ mono_object_clone (MonoObject *obj)
 		/* do not copy the sync state */
 		mono_gc_memmove_atomic ((char*)o + sizeof (MonoObject), (char*)obj + sizeof (MonoObject), size - sizeof (MonoObject));
 	}
-	if (G_UNLIKELY (profile_allocs))
-		mono_profiler_allocation (o, obj->vtable->klass);
 
 	if (obj->vtable->klass->has_finalize)
 		mono_object_register_finalizer (o);
@@ -4876,9 +4868,6 @@ mono_array_new_full (MonoDomain *domain, MonoClass *array_class, uintptr_t *leng
 		}
 	}
 
-	if (G_UNLIKELY (profile_allocs))
-		mono_profiler_allocation (o, array_class);
-
 	return array;
 }
 
@@ -4945,9 +4934,6 @@ mono_array_new_specific (MonoVTable *vtable, uintptr_t n)
 	o = mono_gc_alloc_vector (vtable, byte_len, n);
 	ao = (MonoArray*)o;
 #endif
-
-	if (G_UNLIKELY (profile_allocs))
-		mono_profiler_allocation (o, vtable->klass);
 
 	return ao;
 }
@@ -5039,8 +5025,6 @@ mono_string_new_size (MonoDomain *domain, gint32 len)
 #if NEED_TO_ZERO_PTRFREE
 	s->chars [len] = 0;
 #endif
-	if (G_UNLIKELY (profile_allocs))
-		mono_profiler_allocation ((MonoObject*)s, mono_defaults.string_class);
 
 	return s;
 }
@@ -5159,8 +5143,6 @@ mono_value_box (MonoDomain *domain, MonoClass *class, gpointer value)
 		return NULL;
 	size = mono_class_instance_size (class);
 	res = mono_object_new_alloc_specific (vtable);
-	if (G_UNLIKELY (profile_allocs))
-		mono_profiler_allocation (res, class);
 
 	size = size - sizeof (MonoObject);
 

--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -34,7 +34,7 @@ void mono_profiler_method_start_invoke (MonoMethod *method);
 void mono_profiler_method_end_invoke   (MonoMethod *method);
 
 void mono_profiler_code_transition (MonoMethod *method, int result);
-void mono_profiler_allocation      (MonoObject *obj, MonoClass *klass);
+void mono_profiler_allocation      (MonoObject *obj);
 void mono_profiler_monitor_event   (MonoObject *obj, MonoProfilerMonitorEvent event);
 void mono_profiler_stat_hit        (guchar *ip, void *context);
 void mono_profiler_stat_call_chain (int call_chain_depth, guchar **ips, void *context);

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -500,12 +500,12 @@ mono_profiler_code_transition (MonoMethod *method, int result)
 }
 
 void 
-mono_profiler_allocation (MonoObject *obj, MonoClass *klass)
+mono_profiler_allocation (MonoObject *obj)
 {
 	ProfilerDesc *prof;
 	for (prof = prof_list; prof; prof = prof->next) {
 		if ((prof->events & MONO_PROFILE_ALLOCATIONS) && prof->allocation_cb)
-			prof->allocation_cb (prof->profiler, obj, klass);
+			prof->allocation_cb (prof->profiler, obj, obj->vtable->klass);
 	}
 }
 


### PR DESCRIPTION
Previously, not all allocations would be reported. For example, when using managed allocators, we would go through `mono_gc_alloc_obj ()` and friends which did not call `mono_profiler_allocation ()`. There were also some functions in `object.c` which did not call it.

For SGen, we now report allocations in the client code, which is where all object allocations ultimately end up going whether or not we're using managed allocators. For Boehm, we call `mono_profiler_allocation ()` in the `object.c` macros. (This is not pretty, but will go away when Boehm does.)