### PR TITLE
[delegate] Replace multicast delegate implementation

### DIFF
--- a/mcs/class/corlib/System/Delegate.cs
+++ b/mcs/class/corlib/System/Delegate.cs
@@ -123,9 +123,6 @@ namespace System
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern Delegate CreateDelegate_internal (Type type, object target, MethodInfo info, bool throwOnBindFailure);
 
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		internal extern void SetMulticastInvoke ();
-
 		private static bool arg_type_match (Type delArgType, Type argType) {
 			bool match = delArgType == argType;
 
@@ -186,11 +183,12 @@ namespace System
 
 			MethodInfo invoke = type.GetMethod ("Invoke");
 
-			if (!return_type_match (invoke.ReturnType, method.ReturnType))
+			if (!return_type_match (invoke.ReturnType, method.ReturnType)) {
 				if (throwOnBindFailure)
 					throw new ArgumentException ("method return type is incompatible");
 				else
 					return null;
+			}
 
 			ParameterInfo[] delargs = invoke.GetParametersInternal ();
 			ParameterInfo[] args = method.GetParametersInternal ();
@@ -224,11 +222,12 @@ namespace System
 						argLengthMatch = args.Length == delargs.Length + 1;
 				}
 			}
-			if (!argLengthMatch)
+			if (!argLengthMatch) {
 				if (throwOnBindFailure)
 					throw new ArgumentException ("method argument length mismatch");
 				else
 					return null;
+			}
 
 			bool argsMatch;
 			DelegateData delegate_data = new DelegateData ();
@@ -274,11 +273,12 @@ namespace System
 				}
 			}
 
-			if (!argsMatch)
+			if (!argsMatch) {
 				if (throwOnBindFailure)
 					throw new ArgumentException ("method arguments are incompatible");
 				else
 					return null;
+			}
 
 			Delegate d = CreateDelegate_internal (type, target, method, throwOnBindFailure);
 			if (d != null)
@@ -614,5 +614,9 @@ namespace System
 		{
 			return CreateDelegate_internal (type, firstArgument, method, true);
 		}
+
+		/* Internal call largely inspired from MS Delegate.InternalAllocLike */
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal extern static MulticastDelegate AllocDelegateLike_internal (Delegate d);
 	}
 }

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 130;
+		private const int mono_corlib_version = 131;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -78,7 +78,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 130
+#define MONO_CORLIB_VERSION 131
 
 typedef struct
 {

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1299,6 +1299,9 @@ MONO_API void mono_object_describe_fields (MonoObject *obj);
 MONO_API void mono_value_describe_fields  (MonoClass* klass, const char* addr);
 MONO_API void mono_class_describe_statics (MonoClass* klass);
 
+/* method debugging functions, for use inside gdb */
+MONO_API void mono_method_print_code (MonoMethod *method);
+
 /*Enum validation related functions*/
 MONO_API gboolean
 mono_type_is_valid_enum_basetype (MonoType * type);

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1022,3 +1022,25 @@ mono_class_describe_statics (MonoClass* klass)
 		}
 	}
 }
+
+/**
+ * mono_print_method_code
+ * @MonoMethod: a pointer to the method
+ *
+ * This method is used from a debugger to print the code of the method.
+ *
+ * This prints the IL code of the method in the standard output.
+ */
+void
+mono_method_print_code (MonoMethod *method)
+{
+	char *code;
+	MonoMethodHeader *header = mono_method_get_header (method);
+	if (!header) {
+		printf ("METHOD HEADER NOT FOUND\n");
+		return;
+	}
+	code = mono_disasm_code (0, method, header->code, header->code + header->code_size);
+	printf ("CODE FOR %s:\n%s\n", mono_method_full_name (method, TRUE), code);
+	g_free (code);
+}

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -150,8 +150,8 @@ ICALL(DECIMAL_13, "ToSingle", mono_decimal_to_float)
 #endif
 
 ICALL_TYPE(DELEGATE, "System.Delegate", DELEGATE_1)
-ICALL(DELEGATE_1, "CreateDelegate_internal", ves_icall_System_Delegate_CreateDelegate_internal)
-ICALL(DELEGATE_2, "SetMulticastInvoke", ves_icall_System_Delegate_SetMulticastInvoke)
+ICALL(DELEGATE_1, "AllocDelegateLike_internal", ves_icall_System_Delegate_AllocDelegateLike_internal)
+ICALL(DELEGATE_2, "CreateDelegate_internal", ves_icall_System_Delegate_CreateDelegate_internal)
 
 ICALL_TYPE(DEBUGR, "System.Diagnostics.Debugger", DEBUGR_1)
 ICALL(DEBUGR_1, "IsAttached_internal", ves_icall_System_Diagnostics_Debugger_IsAttached_internal)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5612,11 +5612,17 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionType *type, Mon
 	return delegate;
 }
 
-ICALL_EXPORT void
-ves_icall_System_Delegate_SetMulticastInvoke (MonoDelegate *this)
+ICALL_EXPORT MonoMulticastDelegate *
+ves_icall_System_Delegate_AllocDelegateLike_internal (MonoDelegate *delegate)
 {
-	/* Reset the invoke impl to the default one */
-	this->invoke_impl = mono_runtime_create_delegate_trampoline (this->object.vtable->klass);
+	MonoMulticastDelegate *ret;
+
+	g_assert (mono_class_has_parent (mono_object_class (delegate), mono_defaults.multicastdelegate_class));
+
+	ret = (MonoMulticastDelegate*) mono_object_new (mono_object_domain (delegate), mono_object_class (delegate));
+	ret->delegate.invoke_impl = mono_runtime_create_delegate_trampoline (mono_object_class (delegate));
+
+	return ret;
 }
 
 /* System.Buffer */

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -796,7 +796,7 @@ struct _MonoDelegate {
 typedef struct _MonoMulticastDelegate MonoMulticastDelegate;
 struct _MonoMulticastDelegate {
 	MonoDelegate delegate;
-	MonoMulticastDelegate *prev;
+	MonoArray *delegates;
 };
 
 struct _MonoReflectionField {

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -76,7 +76,7 @@ DECL_OFFSET(MonoInternalThread, tid)
 DECL_OFFSET(MonoInternalThread, small_id)
 DECL_OFFSET(MonoInternalThread, static_data)
 
-DECL_OFFSET(MonoMulticastDelegate, prev)
+DECL_OFFSET(MonoMulticastDelegate, delegates)
 
 DECL_OFFSET(MonoTransparentProxy, rp)
 DECL_OFFSET(MonoTransparentProxy, remote_class)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6335,6 +6335,8 @@ mono_delegate_ctor_with_method (MonoObject *this, MonoObject *target, gpointer a
 	g_assert (this);
 	g_assert (addr);
 
+	g_assert (mono_class_has_parent (mono_object_class (this), mono_defaults.multicastdelegate_class));
+
 	if (method)
 		delegate->method = method;
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4794,10 +4794,6 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	MonoInst *obj, *method_ins, *tramp_ins;
 	MonoDomain *domain;
 	guint8 **code_slot;
-	
-	// FIXME reenable optimisation for virtual case
-	if (virtual)
-		return NULL;
 
 	if (virtual) {
 		MonoMethod *invoke = mono_get_delegate_invoke (klass);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1048,6 +1048,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 
 	/* Obtain the delegate object according to the calling convention */
 	delegate = mono_arch_get_this_arg_from_call (regs, code);
+	g_assert (mono_class_has_parent (mono_object_class (delegate), mono_defaults.multicastdelegate_class));
 
 	if (delegate->method) {
 		method = delegate->method;
@@ -1167,7 +1168,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	/* Necessary for !code condition to fallback to slow path */
 	code = NULL;
 
-	multicast = ((MonoMulticastDelegate*)delegate)->prev != NULL;
+	multicast = ((MonoMulticastDelegate*)delegate)->delegates != NULL;
 	if (!multicast && !callvirt) {
 		if (method && (method->flags & METHOD_ATTRIBUTE_STATIC) && mono_method_signature (method)->param_count == mono_method_signature (invoke)->param_count + 1)
 			/* Closed static delegate */

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -179,6 +179,7 @@ BASE_TEST_CS_SRC=		\
 	delegate8.cs		\
 	delegate9.cs		\
 	delegate10.cs		\
+	delegate11.cs		\
 	remoting1.cs		\
 	remoting2.cs		\
 	remoting3.cs		\

--- a/mono/tests/delegate11.cs
+++ b/mono/tests/delegate11.cs
@@ -1,0 +1,57 @@
+using System;
+
+public static class Driver
+{
+	delegate void SimpleDelegate ();
+
+	static int error = 0;
+
+	class VirtualDelegate0
+	{
+		public virtual void OnEvent ()
+		{
+			Console.WriteLine ("VirtualDelegate0.OnEvent (error!)");
+			error = 1;
+		}
+	}
+
+	class VirtualDelegate1 : VirtualDelegate0
+	{
+		public override void OnEvent ()
+		{
+			Console.WriteLine ("VirtualDelegate1.OnEvent");
+		}
+	}
+
+	class NonVirtualDelegate
+	{
+		public void OnEvent ()
+		{
+			Console.WriteLine ("NonVirtualDelegate.OnEvent");
+		}
+	}
+
+	static bool check (SimpleDelegate d)
+	{
+		error = 0;
+		d ();
+		return error == 0;
+	}
+
+	public static int Main ()
+	{
+		SimpleDelegate dv = new SimpleDelegate (new VirtualDelegate1 ().OnEvent);
+		SimpleDelegate dnv = new SimpleDelegate (new NonVirtualDelegate ().OnEvent);
+
+		if (!check (dv + dv))
+			return 1;
+		if (!check (dnv + dv))
+			return 2;
+		if (!check (dv + dnv))
+			return 3;
+		if (!check (dnv + dnv))
+			return 4;
+
+		return 0;
+	}
+}

--- a/mono/tests/delegate7.cs
+++ b/mono/tests/delegate7.cs
@@ -4,8 +4,6 @@ using System.Runtime.InteropServices;
 class Tests {
 	delegate void SimpleDelegate ();
 
-	public static int v = 0;
-	
 	static void F1 () {
 		v += 1;
 		Console.WriteLine ("Test.F1");
@@ -14,45 +12,114 @@ class Tests {
 		v += 2;
 		Console.WriteLine ("Test.F2");
 	}
-	static void F3 () {
+	static void F4 () {
 		v += 4;
-		Console.WriteLine ("Test.F3");
+		Console.WriteLine ("Test.F4");
 	}
 
 	public static int Main () {
 		return TestDriver.RunTests (typeof (Tests));
 	}
 
+	static int v = 0;
+	static bool check_is_expected_v (SimpleDelegate d, int expected_v)
+	{
+		v = 0;
+		d ();
+		return v == expected_v;
+	}
+
 	static public int test_0_test () {
-		SimpleDelegate t;
 		SimpleDelegate d1 = new SimpleDelegate (F1);
 		SimpleDelegate d2 = new SimpleDelegate (F2);
-		SimpleDelegate d3 = new SimpleDelegate (F3);
+		SimpleDelegate d4 = new SimpleDelegate (F4);
+
+		if (d1 - d1 != null)
+			return 1;
+		if (!check_is_expected_v (d1 - d2, 1))
+			return 2;
+		if (!check_is_expected_v (d1 - d4, 1))
+			return 3;
+
+		if (!check_is_expected_v (d2 - d1, 2))
+			return 4;
+		if (d2 - d2 != null)
+			return 5;
+		if (!check_is_expected_v (d2 - d4, 2))
+			return 6;
+
+		if (!check_is_expected_v (d4 - d1, 4))
+			return 7;
+		if (!check_is_expected_v (d4 - d2, 4))
+			return 8;
+		if (d4 - d4 != null)
+			return 9;
 
 		SimpleDelegate d12 = d1 + d2;
-		SimpleDelegate d13 = d1 + d3;
-		SimpleDelegate d23 = d2 + d3;
-		SimpleDelegate d123 = d1 + d2 + d3;
+		SimpleDelegate d14 = d1 + d4;
+		SimpleDelegate d24 = d2 + d4;
 
-		v = 0;
-		t = d123 - d13;
-		t ();
-		if (v != 7)
-			return 1;
-		
-		v = 0;
-		t = d123 - d12;
-		t ();
-		if (v != 4)
-			return 1;
-		
-		v = 0;
-		t = d123 - d23;
-		t ();
-		if (v != 1)
-			return 1;
-		
-		
+		if (!check_is_expected_v (d12 - d1, 2))
+			return 11;
+		if (!check_is_expected_v (d12 - d2, 1))
+			return 12;
+		if (!check_is_expected_v (d12 - d4, 3))
+			return 13;
+
+		if (!check_is_expected_v (d14 - d1, 4))
+			return 14;
+		if (!check_is_expected_v (d14 - d2, 5))
+			return 15;
+		if (!check_is_expected_v (d14 - d4, 1))
+			return 16;
+
+		if (!check_is_expected_v (d14 - d1, 4))
+			return 17;
+		if (!check_is_expected_v (d14 - d2, 5))
+			return 18;
+		if (!check_is_expected_v (d14 - d4, 1))
+			return 19;
+
+		if (d12 - d12 != null)
+			return 21;
+		if (!check_is_expected_v (d12 - d14, 2))
+			return 22;
+		if (!check_is_expected_v (d12 - d24, 1))
+			return 23;
+
+		if (!check_is_expected_v (d14 - d12, 4))
+			return 24;
+		if (d14 - d14 != null)
+			return 25;
+		if (!check_is_expected_v (d14 - d24, 1))
+			return 26;
+
+		if (!check_is_expected_v (d24 - d12, 4))
+			return 27;
+		if (!check_is_expected_v (d24 - d14, 2))
+			return 28;
+		if (d24 - d24 != null)
+			return 29;
+
+		SimpleDelegate d124 = d1 + d2 + d4;
+
+		if (!check_is_expected_v (d124 - d1, 6))
+			return 31;
+		if (!check_is_expected_v (d124 - d2, 5))
+			return 32;
+		if (!check_is_expected_v (d124 - d4, 3))
+			return 33;
+
+		if (!check_is_expected_v (d124 - d12, 4))
+			return 34;
+		if (!check_is_expected_v (d124 - d14, 2))
+			return 35;
+		if (!check_is_expected_v (d124 - d24, 1))
+			return 36;
+
+		if (d124 - d124 != null)
+			return 37;
+
 		return 0;
 	}
 


### PR DESCRIPTION
Replace the reversed linked implementation by an array based implementation. This improve Combine performance, as well as ease delegate to virtual function optimization.