### PR TITLE
[corlib] Fixes DST without AdjustmentRules

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -592,7 +592,7 @@ namespace System
 
 		public AdjustmentRule [] GetAdjustmentRules ()
 		{
-			if (!supportsDaylightSavingTime)
+			if (!supportsDaylightSavingTime || adjustmentRules == null)
 				return new AdjustmentRule [0];
 			else
 				return (AdjustmentRule []) adjustmentRules.Clone ();
@@ -1254,8 +1254,10 @@ namespace System
 				tz = CreateCustomTimeZone (id, baseUtcOffset, id, standardDisplayName, daylightDisplayName, ValidateRules (adjustmentRules).ToArray ());
 			}
 
-			if (storeTransition)
+			if (storeTransition && transitions.Count > 0) {
 				tz.transitions = transitions;
+				tz.supportsDaylightSavingTime = true;
+			}
 
 			return tz;
 		}


### PR DESCRIPTION
Fixes IsDaylightSavingTime returning false when
SupportsDaylightSavingTime was set to false because TimeZoneInfo was
create with no AdjustmentRules.

Now if TimeZoneInfo uses transitions SupportsDaylightSavingTime will be
set to true regardless of AdjustmentRules.

Fixes [24086](https://bugzilla.xamarin.com/show_bug.cgi?id=24086)