### PR TITLE
[sgen] Record object provenances in binary protocol.

### DIFF
--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -248,6 +248,11 @@ typedef struct {
 	 *   using precise marking by calling mono_gc_scan_object ().
 	 */
 	void (*thread_mark_func) (gpointer user_data, guint8 *stack_start, guint8 *stack_end, gboolean precise, void *gc_data);
+	/*
+	 * Function called for debugging to get the current managed method for
+	 * tracking the provenances of objects.
+	 */
+	gpointer (*get_provenance_func) (void);
 } MonoGCCallbacks;
 
 /* Set the callback functions callable by the GC */

--- a/mono/metadata/sgen-alloc.c
+++ b/mono/metadata/sgen-alloc.c
@@ -111,7 +111,7 @@ alloc_degraded (GCVTable *vtable, size_t size, gboolean for_mature)
 	p = major_collector.alloc_degraded (vtable, size);
 
 	if (!for_mature)
-		binary_protocol_alloc_degraded (p, vtable, size);
+		binary_protocol_alloc_degraded (p, vtable, size, sgen_client_get_provenance ());
 
 	return p;
 }
@@ -215,7 +215,7 @@ sgen_alloc_obj_nolock (GCVTable *vtable, size_t size)
 
 			CANARIFY_ALLOC(p,real_size);
 			SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-			binary_protocol_alloc (p , vtable, size);
+			binary_protocol_alloc (p , vtable, size, sgen_client_get_provenance ());
 			g_assert (*p == NULL);
 			mono_atomic_store_seq (p, vtable);
 
@@ -322,7 +322,7 @@ sgen_alloc_obj_nolock (GCVTable *vtable, size_t size)
 
 	if (G_LIKELY (p)) {
 		SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-		binary_protocol_alloc (p, vtable, size);
+		binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
 		mono_atomic_store_seq (p, vtable);
 	}
 
@@ -409,7 +409,7 @@ sgen_try_alloc_obj_nolock (GCVTable *vtable, size_t size)
 
 	CANARIFY_ALLOC(p,real_size);
 	SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-	binary_protocol_alloc (p, vtable, size);
+	binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
 	g_assert (*p == NULL); /* FIXME disable this in non debug builds */
 
 	mono_atomic_store_seq (p, vtable);
@@ -485,7 +485,7 @@ sgen_alloc_obj_pinned (GCVTable *vtable, size_t size)
 	}
 	if (G_LIKELY (p)) {
 		SGEN_LOG (6, "Allocated pinned object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-		binary_protocol_alloc_pinned (p, vtable, size);
+		binary_protocol_alloc_pinned (p, vtable, size, sgen_client_get_provenance ());
 	}
 	UNLOCK_GC;
 	return p;

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -444,19 +444,19 @@ mono_binary_protocol_alloc_generic (gpointer obj, gpointer vtable, size_t size, 
 }
 
 static void G_GNUC_UNUSED
-sgen_client_binary_protocol_alloc (gpointer obj, gpointer vtable, size_t size)
+sgen_client_binary_protocol_alloc (gpointer obj, gpointer vtable, size_t size, gpointer provenance)
 {
 	mono_binary_protocol_alloc_generic (obj, vtable, size, FALSE);
 }
 
 static void G_GNUC_UNUSED
-sgen_client_binary_protocol_alloc_pinned (gpointer obj, gpointer vtable, size_t size)
+sgen_client_binary_protocol_alloc_pinned (gpointer obj, gpointer vtable, size_t size, gpointer provenance)
 {
 	mono_binary_protocol_alloc_generic (obj, vtable, size, TRUE);
 }
 
 static void G_GNUC_UNUSED
-sgen_client_binary_protocol_alloc_degraded (gpointer obj, gpointer vtable, size_t size)
+sgen_client_binary_protocol_alloc_degraded (gpointer obj, gpointer vtable, size_t size, gpointer provenance)
 {
 	MONO_GC_MAJOR_OBJ_ALLOC_DEGRADED ((mword)obj, size, sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable));
 }

--- a/mono/metadata/sgen-client.h
+++ b/mono/metadata/sgen-client.h
@@ -219,6 +219,12 @@ gboolean sgen_client_handle_gc_debug (const char *opt);
 void sgen_client_print_gc_debug_usage (void);
 
 /*
+ * Called to obtain an identifier for the current location, such as a method pointer. This
+ * is used for logging the provenances of allocations with the heavy binary protocol.
+ */
+gpointer sgen_client_get_provenance (void);
+
+/*
  * These client binary protocol functions are called from the respective binary protocol
  * functions.  No action is necessary.  We suggest implementing them as inline functions in
  * the client header file so that no overhead is incurred if they don't actually do

--- a/mono/metadata/sgen-conf.h
+++ b/mono/metadata/sgen-conf.h
@@ -61,6 +61,12 @@ typedef guint64 mword;
 //#define SGEN_HEAVY_BINARY_PROTOCOL
 
 /*
+ * This extends the heavy binary protocol to record the provenance of an object
+ * for every allocation.
+ */
+//#define SGEN_OBJECT_PROVENANCE
+
+/*
  * This enables checks whenever objects are enqueued in gray queues.
  * Right now the only check done is that we never enqueue nursery
  * pointers in the concurrent collector.

--- a/mono/metadata/sgen-los.c
+++ b/mono/metadata/sgen-los.c
@@ -393,7 +393,7 @@ sgen_los_alloc_large_inner (GCVTable *vtable, size_t size)
 	los_memory_usage += size;
 	los_num_objects++;
 	SGEN_LOG (4, "Allocated large object %p, vtable: %p (%s), size: %zd", obj->data, vtable, sgen_client_vtable_get_name (vtable), size);
-	binary_protocol_alloc (obj->data, vtable, size);
+	binary_protocol_alloc (obj->data, vtable, size, sgen_client_get_provenance ());
 
 #ifdef LOS_CONSISTENCY_CHECK
 	los_consistency_check ();

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2794,6 +2794,24 @@ sgen_client_print_gc_debug_usage (void)
 	sgen_bridge_print_gc_debug_usage ();
 }
 
+
+gpointer
+sgen_client_get_provenance (void)
+{
+#ifdef SGEN_OBJECT_PROVENANCE
+	MonoGCCallbacks *cb = mono_gc_get_gc_callbacks ();
+	gpointer (*get_provenance_func) (void);
+	if (!cb)
+		return NULL;
+	get_provenance_func = cb->get_provenance_func;
+	if (get_provenance_func)
+		return get_provenance_func ();
+	return NULL;
+#else
+	return NULL;
+#endif
+}
+
 void
 mono_gc_base_init (void)
 {

--- a/mono/metadata/sgen-protocol-def.h
+++ b/mono/metadata/sgen-protocol-def.h
@@ -135,7 +135,7 @@ MATCH_INDEX (BINARY_PROTOCOL_MATCH)
 IS_VTABLE_MATCH (FALSE)
 END_PROTOCOL_ENTRY
 
-BEGIN_PROTOCOL_ENTRY_HEAVY3 (binary_protocol_alloc, TYPE_POINTER, obj, TYPE_POINTER, vtable, TYPE_SIZE, size)
+BEGIN_PROTOCOL_ENTRY_HEAVY4 (binary_protocol_alloc, TYPE_POINTER, obj, TYPE_POINTER, vtable, TYPE_SIZE, size, TYPE_POINTER, provenance)
 DEFAULT_PRINT ()
 IS_ALWAYS_MATCH (FALSE)
 MATCH_INDEX (matches_interval (ptr, entry->obj, entry->size) ? 0 : BINARY_PROTOCOL_NO_MATCH)
@@ -275,14 +275,14 @@ MATCH_INDEX (ptr == entry->obj ? 0 : ptr == entry->value ? 3 : ptr == (char*)ent
 IS_VTABLE_MATCH (ptr == entry->obj_vtable || ptr == entry->value_vtable)
 END_PROTOCOL_ENTRY
 
-BEGIN_PROTOCOL_ENTRY_HEAVY3 (binary_protocol_alloc_pinned, TYPE_POINTER, obj, TYPE_POINTER, vtable, TYPE_SIZE, size)
+BEGIN_PROTOCOL_ENTRY_HEAVY4 (binary_protocol_alloc_pinned, TYPE_POINTER, obj, TYPE_POINTER, vtable, TYPE_SIZE, size, TYPE_POINTER, provenance)
 DEFAULT_PRINT ()
 IS_ALWAYS_MATCH (FALSE)
 MATCH_INDEX (matches_interval (ptr, entry->obj, entry->size) ? 0 : BINARY_PROTOCOL_NO_MATCH)
 IS_VTABLE_MATCH (ptr == entry->vtable)
 END_PROTOCOL_ENTRY_HEAVY
 
-BEGIN_PROTOCOL_ENTRY_HEAVY3 (binary_protocol_alloc_degraded, TYPE_POINTER, obj, TYPE_POINTER, vtable, TYPE_SIZE, size)
+BEGIN_PROTOCOL_ENTRY_HEAVY4 (binary_protocol_alloc_degraded, TYPE_POINTER, obj, TYPE_POINTER, vtable, TYPE_SIZE, size, TYPE_POINTER, provenance)
 DEFAULT_PRINT ()
 IS_ALWAYS_MATCH (FALSE)
 MATCH_INDEX (matches_interval (ptr, entry->obj, entry->size) ? 0 : BINARY_PROTOCOL_NO_MATCH)

--- a/tools/sgen/sgen-grep-binprot.c
+++ b/tools/sgen/sgen-grep-binprot.c
@@ -619,6 +619,29 @@ main (int argc, char *argv[])
 		} else if (!strcmp (arg, "-i") || !strcmp (arg, "--input")) {
 			input_path = next_arg;
 			++i;
+		} else if (!strcmp (arg, "--help")) {
+			printf (
+				"\n"
+				"Usage:\n"
+				"\n"
+				"\tsgen-grep-binprot [options] [pointer...]\n"
+				"\n"
+				"Examples:\n"
+				"\n"
+				"\tsgen-grep-binprot --all </tmp/binprot\n"
+				"\tsgen-grep-binprot --input /tmp/binprot --color 0xdeadbeef\n"
+				"\n"
+				"Options:\n"
+				"\n"
+				"\t--all                    Print all entries.\n"
+				"\t--color, -c              Highlight matches in color.\n"
+				"\t--help                   You're looking at it.\n"
+				"\t--input FILE, -i FILE    Read input from FILE instead of standard input.\n"
+				"\t--pause-times            Print GC pause times.\n"
+				"\t--start-at N, -s N       Begin filtering at the Nth entry.\n"
+				"\t--vtable PTR, -v PTR     Search for vtable pointer PTR.\n"
+				"\n");
+			return 0;
 		} else {
 			nums [num_nums++] = strtoul (arg, NULL, 16);
 		}

--- a/tools/sgen/sgen-grep-binprot.c
+++ b/tools/sgen/sgen-grep-binprot.c
@@ -207,6 +207,7 @@ typedef struct {
 #define TYPE_LONGLONG 1
 #define TYPE_SIZE 2
 #define TYPE_POINTER 3
+#define TYPE_BOOL 4
 
 static void
 print_entry_content (int entries_size, PrintEntry *entries, gboolean color_output)
@@ -229,6 +230,9 @@ print_entry_content (int entries_size, PrintEntry *entries, gboolean color_outpu
 			break;
 		case TYPE_POINTER:
 			printf ("%p", *(gpointer*) entries [i].data);
+			break;
+		case TYPE_BOOL:
+			printf ("%s", *(gboolean*) entries [i].data ? "true" : "false");
 			break;
 		default:
 			assert (0);


### PR DESCRIPTION
When compiling with `SGEN_OBJECT_PROVENANCE` and `SGEN_HEAVY_BINARY_PROTOCOL` defined in `sgen-conf.h`, the binary protocol entry for every allocation will include a pointer to the nearest managed (non-wrapper) method where the object was allocated, if such a method is available. This also includes small fixes to `sgen-grep-binprot`.
