### PR TITLE
Do not fail on empty or too short AppDomainSetup.ConfigurationFile

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6397,12 +6397,12 @@ get_bundled_app_config (void)
 	MonoDomain *domain;
 	MonoString *file;
 	gchar *config_file_name, *config_file_path;
-	gsize len;
+	gsize len, config_file_path_length, config_ext_length;
 	gchar *module;
 
 	domain = mono_domain_get ();
 	file = domain->setup->configuration_file;
-	if (!file)
+	if (!file || file->length == 0)
 		return NULL;
 
 	// Retrieve config file and remove the extension
@@ -6410,7 +6410,13 @@ get_bundled_app_config (void)
 	config_file_path = mono_portability_find_file (config_file_name, TRUE);
 	if (!config_file_path)
 		config_file_path = config_file_name;
-	len = strlen (config_file_path) - strlen (".config");
+
+	config_file_path_length = strlen (config_file_path);
+	config_ext_length = strlen (".config");
+	if (config_file_path_length <= config_ext_length)
+		return NULL;
+
+	len = config_file_path_length - config_ext_length;
 	module = g_malloc0 (len + 1);
 	memcpy (module, config_file_path, len);
 	// Get the config file from the module name


### PR DESCRIPTION
Currently mono runtime fails with the next exception if AppDomain was initialized with empty ConfigurationFile:

 Could not allocate -6 bytes
 Stacktrace:
   at <unknown> <0xffffffff>
   at (wrapper managed-to-native) System.Configuration.InternalConfigurationHost.get_bundled_app_config () <0xffffffff>
   at System.Configuration.InternalConfigurationHost.OpenStreamForRead (string) <0x000fb>
   at System.Configuration.Configuration.Load () <0x00073>
   at System.Configuration.Configuration.Init (System.Configuration.Internal.IConfigSystem,string,System.Configuration.Configuration) <0x00233>
   at System.Configuration.Configuration..ctor (System.Configuration.InternalConfigurationSystem,string) <0x001c7>
   at System.Configuration.InternalConfigurationFactory.Create (System.Type,object[]) <0x000a7>
   at System.Configuration.ConfigurationManager.OpenExeConfigurationInternal (System.Configuration.ConfigurationUserLevel,System.Reflection.Assembly,string) <0x00375>
   at System.Configuration.ClientConfigurationSystem.get_Configuration () <0x00053>
   at System.Configuration.ClientConfigurationSystem.System.Configuration.Internal.IInternalConfigSystem.GetSection (string) <0x0001f>
   at System.Configuration.ConfigurationManager.GetSection (string) <0x00038>
   at System.Configuration.PrivilegedConfigurationManager.GetSection (string) <0x00017>
   at System.Diagnostics.DiagnosticsConfiguration.GetConfigSection () <0x00023>
   at System.Diagnostics.DiagnosticsConfiguration.Initialize () <0x00087>
   at System.Diagnostics.DiagnosticsConfiguration.get_IndentSize () <0x0000f>
   at System.Diagnostics.TraceInternal.InitializeSettings () <0x000c7>
   at System.Diagnostics.TraceInternal.get_Listeners () <0x0001f>
   at System.Diagnostics.Debug.get_Listeners () <0x0000b>
<0x00093>