### PR TITLE
Fixed the build of System.Windows.Forms on 64-bit Linux

### DIFF
--- a/mcs/class/System.Windows.Forms/Makefile
+++ b/mcs/class/System.Windows.Forms/Makefile
@@ -118,11 +118,11 @@ TEST_HARNESS_EXCLUDES_ONDOTNET = -exclude=Interactive,NotDotNet,CAS
 $(the_lib): $(RESOURCES)
 
 $(RESX_RESOURCES): %.resources: %.resx
-	$(RESGEN) $< || cp $@.prebuilt $@
+	$(RESGEN) $< || cp -r $@.prebuilt $@
 
 $(LIBRARY): $(CUR_RESOURCES)
 
 $(PREBUILT): %.prebuilt: %
-	cp $* $@
+	cp -r $* $@
 
 dist-default: $(PREBUILT)


### PR DESCRIPTION
This patch was marked as `PATCH-FIX-UPSTREAM` by @marguerite but apparently never submitted here. We include it in @openSUSE Factory since October 2014.