### PR TITLE
[sgen] Fix Windows build

### DIFF
--- a/mono/metadata/sgen-os-win32.c
+++ b/mono/metadata/sgen-os-win32.c
@@ -59,57 +59,57 @@ sgen_suspend_thread (SgenThreadInfo *info)
 
 #if !defined(MONO_CROSS_COMPILE)
 #ifdef USE_MONO_CTX
-	memset (&info->ctx, 0, sizeof (MonoContext));
+	memset (&info->client_info.ctx, 0, sizeof (MonoContext));
 #ifdef TARGET_AMD64
-	info->ctx.rip = context.Rip;
-	info->ctx.rax = context.Rax;
-	info->ctx.rcx = context.Rcx;
-	info->ctx.rdx = context.Rdx;
-	info->ctx.rbx = context.Rbx;
-	info->ctx.rsp = context.Rsp;
-	info->ctx.rbp = context.Rbp;
-	info->ctx.rsi = context.Rsi;
-	info->ctx.rdi = context.Rdi;
-	info->ctx.r8 = context.R8;
-	info->ctx.r9 = context.R9;
-	info->ctx.r10 = context.R10;
-	info->ctx.r11 = context.R11;
-	info->ctx.r12 = context.R12;
-	info->ctx.r13 = context.R13;
-	info->ctx.r14 = context.R14;
-	info->ctx.r15 = context.R15;
-	info->stopped_ip = info->ctx.rip;
-	info->stack_start = (char*)info->ctx.rsp - REDZONE_SIZE;
+	info->client_info.ctx.rip = context.Rip;
+	info->client_info.ctx.rax = context.Rax;
+	info->client_info.ctx.rcx = context.Rcx;
+	info->client_info.ctx.rdx = context.Rdx;
+	info->client_info.ctx.rbx = context.Rbx;
+	info->client_info.ctx.rsp = context.Rsp;
+	info->client_info.ctx.rbp = context.Rbp;
+	info->client_info.ctx.rsi = context.Rsi;
+	info->client_info.ctx.rdi = context.Rdi;
+	info->client_info.ctx.r8 = context.R8;
+	info->client_info.ctx.r9 = context.R9;
+	info->client_info.ctx.r10 = context.R10;
+	info->client_info.ctx.r11 = context.R11;
+	info->client_info.ctx.r12 = context.R12;
+	info->client_info.ctx.r13 = context.R13;
+	info->client_info.ctx.r14 = context.R14;
+	info->client_info.ctx.r15 = context.R15;
+	info->client_info.stopped_ip = info->client_info.ctx.rip;
+	info->client_info.stack_start = (char*)info->client_info.ctx.rsp - REDZONE_SIZE;
 #else
-	info->ctx.edi = context.Edi;
-	info->ctx.esi = context.Esi;
-	info->ctx.ebx = context.Ebx;
-	info->ctx.edx = context.Edx;
-	info->ctx.ecx = context.Ecx;
-	info->ctx.eax = context.Eax;
-	info->ctx.ebp = context.Ebp;
-	info->ctx.esp = context.Esp;
-	info->stopped_ip = (gpointer)context.Eip;
-	info->stack_start = (char*)context.Esp - REDZONE_SIZE;
+	info->client_info.ctx.edi = context.Edi;
+	info->client_info.ctx.esi = context.Esi;
+	info->client_info.ctx.ebx = context.Ebx;
+	info->client_info.ctx.edx = context.Edx;
+	info->client_info.ctx.ecx = context.Ecx;
+	info->client_info.ctx.eax = context.Eax;
+	info->client_info.ctx.ebp = context.Ebp;
+	info->client_info.ctx.esp = context.Esp;
+	info->client_info.stopped_ip = (gpointer)context.Eip;
+	info->client_info.stack_start = (char*)context.Esp - REDZONE_SIZE;
 #endif
 
 #else
-	info->regs [0] = context.Edi;
-	info->regs [1] = context.Esi;
-	info->regs [2] = context.Ebx;
-	info->regs [3] = context.Edx;
-	info->regs [4] = context.Ecx;
-	info->regs [5] = context.Eax;
-	info->regs [6] = context.Ebp;
-	info->regs [7] = context.Esp;
-	info->stopped_ip = (gpointer)context.Eip;
-	info->stack_start = (char*)context.Esp - REDZONE_SIZE;
+	info->client_info.regs [0] = context.Edi;
+	info->client_info.regs [1] = context.Esi;
+	info->client_info.regs [2] = context.Ebx;
+	info->client_info.regs [3] = context.Edx;
+	info->client_info.regs [4] = context.Ecx;
+	info->client_info.regs [5] = context.Eax;
+	info->client_info.regs [6] = context.Ebp;
+	info->client_info.regs [7] = context.Esp;
+	info->client_info.stopped_ip = (gpointer)context.Eip;
+	info->client_info.stack_start = (char*)context.Esp - REDZONE_SIZE;
 #endif
 #endif
 
 	/* Notify the JIT */
 	if (mono_gc_get_gc_callbacks ()->thread_suspend_func)
-		mono_gc_get_gc_callbacks ()->thread_suspend_func (info->runtime_data, NULL, NULL);
+		mono_gc_get_gc_callbacks ()->thread_suspend_func (info->client_info.runtime_data, NULL, NULL);
 
 	return TRUE;
 }


### PR DESCRIPTION
There were some changes in the recent sgen overhaul (https://github.com/mono/mono/pull/1648) that weren't applied to Windows.

/cc @schani 