### PR TITLE
Fix SQL Server 2012 bulk insert issues

### DIFF
--- a/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/TdsComm.cs
+++ b/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/TdsComm.cs
@@ -219,6 +219,9 @@ namespace Mono.Data.Tds.Protocol {
 			case TypeCode.Object :
 				if (o is byte[])
 					Append ((byte[]) o);
+				else if (o is Guid)
+					Append (((Guid) o).ToByteArray ());
+				else break;
 				return;
 			case TypeCode.Int16 :
 				Append ((short) o);

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.cs
@@ -191,7 +191,7 @@ namespace System.Data.SqlClient {
 				  } else if (i == 2) {
 					SqlDataAdapter adapter = new SqlDataAdapter ();
 					adapter.MissingSchemaAction = MissingSchemaAction.AddWithKey;
-					columnMetaDataTables [i - 1] = new DataTable ();
+					columnMetaDataTables [i - 1] = new DataTable (DestinationTableName);
 					adapter.FillInternal (columnMetaDataTables [i - 1], reader);
 				}
 				i++;

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.cs
@@ -179,6 +179,10 @@ namespace System.Data.SqlClient {
 							 "exec sp_tablecollations_90 '" +
 							 DestinationTableName + "'",
 							 connection);
+
+			if (externalTransaction != null)
+				cmd.Transaction = externalTransaction;
+
 			SqlDataReader reader = cmd.ExecuteReader ();
 			int i = 0; // Skipping 1st result
 			do {

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlParameter.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlParameter.cs
@@ -177,6 +177,7 @@ namespace System.Data.SqlClient {
 			type_mapping.Add (typeof (SqlTypes.SqlXml), SqlDbType.Xml);
 
 			type_mapping.Add (typeof (object), SqlDbType.Variant);
+			type_mapping.Add (typeof (DateTimeOffset), SqlDbType.DateTimeOffset);
 		}
 		
 		public SqlParameter () 
@@ -1067,6 +1068,13 @@ namespace System.Data.SqlClient {
 
 		object ConvertToFrameworkType (object value, Type frameworkType)
 		{
+			if (frameworkType == typeof (string)) {
+				if (value is DateTime)
+					return ((DateTime) value).ToString ("yyyy-MM-dd'T'HH':'mm':'ss.fffffff");
+				if (value is DateTimeOffset)
+					return ((DateTimeOffset) value).ToString ("yyyy-MM-dd'T'HH':'mm':'ss.fffffffzzz");
+			}
+
 			object sqlvalue = Convert.ChangeType (value, frameworkType);
 			switch (sqlDbType) {
 			case SqlDbType.Money:


### PR DESCRIPTION
These patches enable the bulk insertion of the following types, and their null values, in an instance of SQL Server 2012.

    string           "@@@"
    int              0x40
    long             0x40deadbeef
    byte             (byte)0x40
    double           0.3333
    float            10.5f
    boolean          true
    guid             Guid.NewGuid()
    datetime2        DateTime.Now
    datetimeoffset   DateTimeOffset.Now

(Full processing of datetime2/datetimeoffset require additional patches, cf. PR https://github.com/mono/mono/pull/1773.)
