### PR TITLE
Fix SQL Server 2012 variant parameters and return values

### DIFF
--- a/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/Tds.cs
+++ b/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/Tds.cs
@@ -932,6 +932,11 @@ namespace Mono.Data.Tds.Protocol
 					element = new Guid (guidBytes);
 				}
 				break;
+			case TdsColumnType.Variant :
+				if (outParam)
+					comm.Skip (4);
+				element = GetVariantValue();
+				break;
 			default :
 				return DBNull.Value;
 			}
@@ -954,6 +959,40 @@ namespace Mono.Data.Tds.Protocol
 			}
 
 			return result;
+		}
+
+		private object GetVariantValue ()
+		{
+			uint len = (uint)comm.GetTdsInt ();
+			if (len == 0)
+				return DBNull.Value;
+
+			// VARIANT_BASETYPE
+			TdsColumnType colType = (TdsColumnType)comm.GetByte ();
+			// VARIANT_PROPBYTES
+			byte propbytes = comm.GetByte ();
+			if (propbytes != 0)
+				// VARIANT_PROPERTIES
+				comm.Skip (propbytes);
+
+			len -= (uint)propbytes + 2;
+
+			switch (colType)
+			{
+			case TdsColumnType.Int1 :
+			case TdsColumnType.Int2 :
+			case TdsColumnType.Int4 :
+			case TdsColumnType.BigInt :
+				return GetIntValue (colType);
+			default:
+				// The old code was ignoring variants
+				// and returning null.  Should we
+				// throw an exception?
+				comm.Skip (len);
+				break;
+			}
+
+			return DBNull.Value;
 		}
 
 		private object GetDateTimeValue (

--- a/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/Tds.cs
+++ b/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/Tds.cs
@@ -1291,7 +1291,7 @@ namespace Mono.Data.Tds.Protocol
 		
 		internal bool IsBlobType (TdsColumnType columnType)
 		{
-			return (columnType == TdsColumnType.Text || columnType == TdsColumnType.Image || columnType == TdsColumnType.NText);
+			return (columnType == TdsColumnType.Text || columnType == TdsColumnType.Image || columnType == TdsColumnType.NText || columnType == TdsColumnType.Variant);
 		}
 
 		internal bool IsLargeType (TdsColumnType columnType)

--- a/mcs/class/Mono.Data.Tds/Mono.Data.Tds/TdsMetaParameter.cs
+++ b/mcs/class/Mono.Data.Tds/Mono.Data.Tds/TdsMetaParameter.cs
@@ -480,6 +480,8 @@ namespace Mono.Data.Tds {
 				return TdsColumnType.BigVarBinary;
 			case "varchar":
 				return TdsColumnType.BigVarChar;
+			case "sql_variant":
+				return TdsColumnType.Variant;
 			default:
 				throw new NotSupportedException ("Unknown Type : " + TypeName);
 			}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlParameter.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlParameter.cs
@@ -221,8 +221,7 @@ namespace System.Data.SqlClient {
 							      scale,
 							      GetFrameworkValue);
 			metaParameter.RawValue =  value;
-			if (dbType != SqlDbType.Variant) 
-				SqlDbType = dbType;
+			SqlDbType = dbType;
 			Direction = direction;
 			SourceColumn = sourceColumn;
 			SourceVersion = sourceVersion;


### PR DESCRIPTION
These patches enable passing and receiving variant parameters to/from stored procedures.  Example code:

    command.CommandText = "sys.sp_sequence_get_range";
    command.CommandType = CommandType.StoredProcedure;
    
    SqlParameterCollection parameters = (SqlParameterCollection)command.Parameters;
    
    parameters.AddWithValue("@sequence_name", "my_sequence");
    parameters.AddWithValue("@range_size", 3);
    
    SqlParameter parameter = parameters.Add("@range_first_value", SqlDbType.Variant);
    parameter.Direction = ParameterDirection.Output;
    
    command.ExecuteNonQuery();
    
    Console.WriteLine("@range_first_value: {0}", parameter.Value);