### PR TITLE
[RFC] Improve unit test reporting when test runner crashes

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -85,6 +85,7 @@ endif
 run-test-lib: test-local
 	ok=:; \
 	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(TEST_HARNESS) $(test_assemblies) -noshadow $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) -xml=TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
+	if [ ! -f "TestResult-$(PROFILE).xml" ]; then echo "<?xml version='1.0' encoding='utf8'?><test-results failures='1' total='1' not-run='0'><test-suite name=\"$(test_assemblies)\" success='False' time='0'><results><test-case name='crash'><failure><message>The test runner didn't produce a test result XML, probably due to a crash of the runtime. Check the log for more details.</message></failure></test-case></results></test-suite></test-results>" > TestResult-$(PROFILE).xml; fi; \
 	$(TEST_HARNESS_POSTPROC) ; $$ok
 
 ## Instructs compiler to compile to target .net execution, it can be usefull in rare cases when runtime detection is not possible


### PR DESCRIPTION
Right now, when the unit test runner crashes, no test result XML is produced and Jenkins doesn't pick up an error (since we ignore the exit code). This is bad as it is easy to miss, e.g. right now the System
testsuite crashes on Linux.

As an RFC, this PR checks if the XML is missing and write a dummy one in that case so Jenkins can pick it up (we have a few similar scripts already that @directhex added for the runtime tests that we should probably unify if we go forward with this).

What do you think?