### PR TITLE
xbuild: do not stop BuildNodeManager after one build

### DIFF
--- a/mcs/class/Microsoft.Build/Microsoft.Build.Execution/BuildManager.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Execution/BuildManager.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Build.Execution
 				throw new InvalidOperationException ("Build has not started");
 			if (submissions.Count > 0)
 				WaitHandle.WaitAll (submissions.Select (s => s.WaitHandle).ToArray ());
-			BuildNodeManager.Stop ();
 			ongoing_build_parameters = null;
 		}
 		


### PR DESCRIPTION
It prevents subsequent builds from executing