### PR TITLE
[utils] Export concurrent hash table and lock free queue functions

### DIFF
--- a/mono/utils/lock-free-queue.h
+++ b/mono/utils/lock-free-queue.h
@@ -29,6 +29,7 @@
 #define __MONO_LOCKFREEQUEUE_H__
 
 #include <glib.h>
+#include <mono/utils/mono-publib.h>
 
 //#define QUEUE_DEBUG	1
 
@@ -55,13 +56,13 @@ typedef struct {
 	volatile gint32 has_dummy;
 } MonoLockFreeQueue;
 
-void mono_lock_free_queue_init (MonoLockFreeQueue *q);
+MONO_API void mono_lock_free_queue_init (MonoLockFreeQueue *q);
 
-void mono_lock_free_queue_node_init (MonoLockFreeQueueNode *node, gboolean to_be_freed);
-void mono_lock_free_queue_node_free (MonoLockFreeQueueNode *node);
+MONO_API void mono_lock_free_queue_node_init (MonoLockFreeQueueNode *node, gboolean to_be_freed);
+MONO_API void mono_lock_free_queue_node_free (MonoLockFreeQueueNode *node);
 
-void mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node);
+MONO_API void mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node);
 
-MonoLockFreeQueueNode* mono_lock_free_queue_dequeue (MonoLockFreeQueue *q);
+MONO_API MonoLockFreeQueueNode* mono_lock_free_queue_dequeue (MonoLockFreeQueue *q);
 
 #endif

--- a/mono/utils/mono-conc-hashtable.h
+++ b/mono/utils/mono-conc-hashtable.h
@@ -10,18 +10,19 @@
 #ifndef __MONO_CONCURRENT_HASHTABLE_H__
 #define __MONO_CONCURRENT_HASHTABLE_H__
 
+#include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-mutex.h>
 #include <glib.h>
 
 typedef struct _MonoConcurrentHashTable MonoConcurrentHashTable;
 
-MonoConcurrentHashTable* mono_conc_hashtable_new (mono_mutex_t *mutex, GHashFunc hash_func, GEqualFunc key_equal_func);
-MonoConcurrentHashTable* mono_conc_hashtable_new_full (mono_mutex_t *mutex, GHashFunc hash_func, GEqualFunc key_equal_func, GDestroyNotify key_destroy_func, GDestroyNotify value_destroy_func);
-void mono_conc_hashtable_destroy (MonoConcurrentHashTable *hash_table);
-gpointer mono_conc_hashtable_lookup (MonoConcurrentHashTable *hash_table, gpointer key);
-gpointer mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, gpointer value);
-gpointer mono_conc_hashtable_remove (MonoConcurrentHashTable *hash_table, gpointer key);
+MONO_API MonoConcurrentHashTable* mono_conc_hashtable_new (mono_mutex_t *mutex, GHashFunc hash_func, GEqualFunc key_equal_func);
+MONO_API MonoConcurrentHashTable* mono_conc_hashtable_new_full (mono_mutex_t *mutex, GHashFunc hash_func, GEqualFunc key_equal_func, GDestroyNotify key_destroy_func, GDestroyNotify value_destroy_func);
+MONO_API void mono_conc_hashtable_destroy (MonoConcurrentHashTable *hash_table);
+MONO_API gpointer mono_conc_hashtable_lookup (MonoConcurrentHashTable *hash_table, gpointer key);
+MONO_API gpointer mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, gpointer value);
+MONO_API gpointer mono_conc_hashtable_remove (MonoConcurrentHashTable *hash_table, gpointer key);
 
 #endif
 


### PR DESCRIPTION
These are needed by the log profiler. Since we now actually use `-fvisibility=hidden` by default, this problem [surfaced](https://jenkins.mono-project.com/job/test-mono-mainline/label=debian-amd64/1672/consoleFull#-70129138231f6a1ff-0c33-4e56-82df-c01aeecabdde).

Please let this run through on Jenkins before merging.