### PR TITLE
[runtime] Make thread abort synchronous

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -452,6 +452,7 @@ suspend_signal_handler (int _dummy, siginfo_t *info, void *context)
 	if (current->syscall_break_signal) {
 		current->syscall_break_signal = FALSE;
 		THREADS_SUSPEND_DEBUG ("\tsyscall break for %p\n", current);
+		mono_threads_notify_initiator_of_abort (current);
 		goto done;
 	}
 
@@ -582,7 +583,8 @@ mono_threads_core_abort_syscall (MonoThreadInfo *info)
 	This signal should not be interpreted as a suspend request.
 	*/
 	info->syscall_break_signal = TRUE;
-	mono_threads_pthread_kill (info, abort_signal_num);
+	if (!mono_threads_pthread_kill (info, abort_signal_num))
+		mono_threads_add_to_pending_operation_set (info);
 }
 
 gboolean

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -556,6 +556,11 @@ This tells the resume initiator that we completed resume duties and will return 
 */
 void mono_threads_notify_initiator_of_resume (THREAD_INFO_TYPE* info);
 
+/*
+This tells the resume initiator that we completed abort duties and will return to previous state.
+*/
+void mono_threads_notify_initiator_of_abort (THREAD_INFO_TYPE* info);
+
 /* Thread state machine functions */
 
 typedef enum {


### PR DESCRIPTION
Due to asynchronous abortion a crash is being seen on
posix systems where the abort signal handler is having a
data race and not exiting the suspend signal handler early.

When it tries to make a state transition because of this, it
cannot and it crashes.

This fixes it by making is synchronous