### PR TITLE
Fix XAttribute.ToString method (Xamarin-29935)

### DIFF
--- a/mcs/class/System.Xml.Linq/System.Xml.Linq/XAttribute.cs
+++ b/mcs/class/System.Xml.Linq/System.Xml.Linq/XAttribute.cs
@@ -26,6 +26,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Text;
 using System.Xml;
 
@@ -334,34 +336,29 @@ namespace System.Xml.Linq
 
 		static readonly char [] escapeChars = new char [] {'<', '>', '&', '"', '\r', '\n', '\t'};
 
+		private static string GetPrefixOfNamespace (XNamespace ns)
+		{
+			string namespaceName = ns.NamespaceName;
+			if (namespaceName.Length == 0)
+				return string.Empty;
+			if (namespaceName == XNamespace.Xml.NamespaceName)
+				return "xml";
+			if (namespaceName == XNamespace.Xmlns.NamespaceName)
+				return "xmlns";
+			return null;
+		}
+
 		public override string ToString ()
 		{
-			StringBuilder sb = new StringBuilder ();
-			sb.Append (name.ToString ());
-			sb.Append ("=\"");
-			int start = 0;
-			do {
-				int idx = value.IndexOfAny (escapeChars, start);
-				if (idx < 0) {
-					if (start > 0)
-						sb.Append (value, start, value.Length - start);
-					else
-						sb.Append (value);
-					sb.Append ("\"");
-					return sb.ToString ();
+			using (StringWriter sw = new StringWriter (CultureInfo.InvariantCulture)) {
+				XmlWriterSettings ws = new XmlWriterSettings ();
+				ws.ConformanceLevel = ConformanceLevel.Fragment;
+				using (XmlWriter w = XmlWriter.Create (sw, ws)) {
+					w.WriteAttributeString (GetPrefixOfNamespace (Name.Namespace), Name.LocalName,
+						Name.NamespaceName, Value);
 				}
-				sb.Append (value, start, idx - start);
-				switch (value [idx]) {
-				case '&': sb.Append ("&amp;"); break;
-				case '<': sb.Append ("&lt;"); break;
-				case '>': sb.Append ("&gt;"); break;
-				case '"': sb.Append ("&quot;"); break;
-				case '\r': sb.Append ("&#xD;"); break;
-				case '\n': sb.Append ("&#xA;"); break;
-				case '\t': sb.Append ("&#x9;"); break;
-				}
-				start = idx + 1;
-			} while (true);
+				return sw.ToString ().Trim ();
+			}
 		}
 	}
 }

--- a/mcs/class/System.Xml.Linq/Test/System.Xml.Linq/XAttributeTest.cs
+++ b/mcs/class/System.Xml.Linq/Test/System.Xml.Linq/XAttributeTest.cs
@@ -206,6 +206,14 @@ namespace MonoTests.System.Xml.Linq
 		}
 
 		[Test]
+		public void ToString_Xamarin29935 ()
+		{
+			var doc = XDocument.Parse ("<?xml version='1.0' encoding='utf-8'?><lift xmlns:test='http://test.example.com'></lift>");
+			Assert.AreEqual ("xmlns:test=\"http://test.example.com\"",
+				doc.Root.Attributes ().Select (s => s.ToString ()).First ());
+		}
+
+		[Test]
 		public void DateTimeAttribute ()
 		{
 			var date = DateTime.Now;


### PR DESCRIPTION
Of course this fix will be obsolete in the future when System.Xml.Linq gets replaced by the referencesource implementation, but in light of what Miguel wrote for a different bug [1] it might be worth fixing it in the 4.0 branch.


[1] http://lists.ximian.com/pipermail/mono-devel-list/2015-May/042947.html