### PR TITLE
Faster compiles

### DIFF
--- a/mono/Makefile.am
+++ b/mono/Makefile.am
@@ -30,7 +30,38 @@ monotouch-do-clean:
 	  (cd $$subdir && $(MAKE) $(AM_MAKEFLAGS) $$target); \
     done;
 else
-SUBDIRS = arch utils io-layer cil metadata $(sgen_dirs) mini dis tests unit-tests benchmark profiler
+
+mono_subdirs = arch utils io-layer cil metadata $(sgen_dirs) mini dis tests unit-tests benchmark profiler
+
+SUBDIR_PREFIX = subdir
+
+define SUBDIR_RULE
+.PHONY: $(SUBDIR_PREFIX)-$2-$1
+
+$(SUBDIR_PREFIX)-$2-$1:
+	@echo "Making $2 in $1"; \
+	(cd $1 && $(MAKE) $(AM_MAKEFLAGS) $2)
+endef
+
+define S
+$(addprefix $(SUBDIR_PREFIX)-all-,$1)
+endef
+
+all-local: $(call S,$(mono_subdirs))
+
+$(foreach SUBDIR,$(mono_subdirs),$(eval $(call SUBDIR_RULE,$(SUBDIR),all)))
+
+$(call S,mini): $(call S,metadata utils)
+$(call S,mini): $(call S,arch dis io-layer metadata sgen utils)
+$(call S,profiler): $(call S,mini)
+$(call S,tests): $(call S,io-layer metadata sgen utils)
+$(call S,unit-tests): $(call S,io-layer metadata sgen utils)
+$(call S,dis): $(call S,io-layer metadata sgen utils)
+
+clean-local: $(addprefix $(SUBDIR_PREFIX)-clean-,$(mono_subdirs))
+
+$(foreach SUBDIR,$(mono_subdirs),$(eval $(call SUBDIR_RULE,$(SUBDIR),clean)))
+
 endif
 endif
 DIST_SUBDIRS = arch utils io-layer cil metadata $(sgen_dirs) mini dis tests unit-tests benchmark profiler

--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -20,6 +20,7 @@
 #include "mono/metadata/class.h"
 #include "mono/metadata/class-internals.h"
 #include "mono/utils/mono-compiler.h"
+#include "mono/utils/mono-error.h"
 
 #if defined(__native_client__) && defined(__GLIBC__)
 volatile int __nacl_thread_suspension_needed = 0;

--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -21,6 +21,7 @@
 #include <mono/utils/mono-error.h>
 #include <mono/metadata/class.h>
 #include <mono/metadata/marshal.h>
+#include <mono/metadata/object-internals.h>
 
 extern gboolean substitute_with_mscorlib_p;
 

--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -18,6 +18,7 @@
 #include "util.h"
 #include "get.h"
 #include <mono/utils/mono-compiler.h>
+#include <mono/utils/mono-error.h>
 #include <mono/metadata/class.h>
 #include <mono/metadata/marshal.h>
 

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -31,6 +31,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/utils/bsearch.h>
+#include <mono/utils/mono-error.h>
 
 static void     setup_filter          (MonoImage *image);
 static gboolean should_include_type   (int idx);

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -107,6 +107,7 @@ common_sources = \
 	cil-coff.h		\
 	class.c			\
 	class-internals.h	\
+	class-internals-forward.h	\
 	cominterop.c		\
 	cominterop.h		\
 	console-io.h		\
@@ -290,6 +291,7 @@ libmonoruntimeinclude_HEADERS = \
 	image.h			\
 	loader.h		\
 	metadata.h		\
+	metadata-forward.h		\
 	mono-config.h		\
 	mono-debug.h		\
 	mono-gc.h		\

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -122,6 +122,7 @@ common_sources = \
 	decimal-ms.c		\
 	decimal-ms.h		\
 	domain-internals.h	\
+	domain-internals-forward.h	\
 	environment.c		\
 	environment.h		\
 	exception.c		\
@@ -148,6 +149,7 @@ common_sources = \
 	metadata.c		\
 	metadata-verify.c	\
 	metadata-internals.h	\
+	metadata-internals-forward.h	\
 	method-builder.h 	\
 	method-builder.c 	\
 	mono-basic-block.c	\
@@ -176,6 +178,7 @@ common_sources = \
 	normalization-tables.h	\
 	number-formatter.h	\
 	object-internals.h	\
+	object-internals-forward.h	\
 	opcodes.c		\
 	socket-io.c		\
 	socket-io.h		\
@@ -292,6 +295,7 @@ libmonoruntimeinclude_HEADERS = \
 	mono-gc.h		\
 	sgen-bridge.h		\
 	object.h		\
+	object-forward.h		\
 	opcodes.h		\
 	profiler.h		\
 	reflection.h		\

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -59,6 +59,7 @@
 #include <mono/utils/mono-path.h>
 #include <mono/utils/mono-stdlib.h>
 #include <mono/utils/mono-io-portability.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-memory-model.h>

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -12,6 +12,7 @@
 
 #include <mono/utils/mono-publib.h>
 
+#include <mono/metadata/domain-internals-forward.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/reflection.h>
 

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -13,7 +13,7 @@
 #include <mono/utils/mono-publib.h>
 
 #include <mono/metadata/domain-internals-forward.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/reflection.h>
 
 MONO_BEGIN_DECLS

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -22,6 +22,7 @@
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/runtime.h>
 #include <mono/metadata/sgen-toggleref.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-logger-internal.h>
 #include <mono/utils/mono-memory-model.h>

--- a/mono/metadata/class-internals-forward.h
+++ b/mono/metadata/class-internals-forward.h
@@ -17,6 +17,7 @@ struct _MonoMethodInflated;
 struct _MonoMethodPInvoke;
 struct _MonoMethodWrapper;
 struct _MonoProperty;
+struct _MonoVTable;
 
 typedef struct _MonoClass MonoClass;
 typedef struct _MonoClassField MonoClassField;
@@ -33,5 +34,6 @@ typedef struct _MonoMethodInflated MonoMethodInflated;
 typedef struct _MonoMethodPInvoke MonoMethodPInvoke;
 typedef struct _MonoMethodWrapper MonoMethodWrapper;
 typedef struct _MonoProperty MonoProperty;
+typedef struct _MonoVTable MonoVTable;
 
 #endif /* __MONO_CLASS_INTERNALS_FORWARD_H__ */

--- a/mono/metadata/class-internals-forward.h
+++ b/mono/metadata/class-internals-forward.h
@@ -1,0 +1,37 @@
+#ifndef __MONO_CLASS_INTERNALS_FORWARD_H__
+#define __MONO_CLASS_INTERNALS_FORWARD_H__
+
+struct _MonoClass;
+struct _MonoClassField;
+struct _MonoDynamicGenericClass;
+struct _MonoEvent;
+struct _MonoFieldDefaultValue;
+struct _MonoGenericClass;
+struct _MonoGenericContainer;
+struct _MonoGenericContext;
+struct _MonoGenericContext;
+struct _MonoGenericInst;
+struct _MonoGenericParam;
+struct _MonoMethod;
+struct _MonoMethodInflated;
+struct _MonoMethodPInvoke;
+struct _MonoMethodWrapper;
+struct _MonoProperty;
+
+typedef struct _MonoClass MonoClass;
+typedef struct _MonoClassField MonoClassField;
+typedef struct _MonoDynamicGenericClass MonoDynamicGenericClass;
+typedef struct _MonoEvent MonoEvent;
+typedef struct _MonoFieldDefaultValue MonoFieldDefaultValue;
+typedef struct _MonoGenericClass MonoGenericClass;
+typedef struct _MonoGenericContainer MonoGenericContainer;
+typedef struct _MonoGenericContext MonoGenericContext;
+typedef struct _MonoGenericInst MonoGenericInst;
+typedef struct _MonoGenericParam MonoGenericParam;
+typedef struct _MonoMethod MonoMethod;
+typedef struct _MonoMethodInflated MonoMethodInflated;
+typedef struct _MonoMethodPInvoke MonoMethodPInvoke;
+typedef struct _MonoMethodWrapper MonoMethodWrapper;
+typedef struct _MonoProperty MonoProperty;
+
+#endif /* __MONO_CLASS_INTERNALS_FORWARD_H__ */

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -21,10 +21,6 @@
 extern gboolean mono_print_vtable;
 extern gboolean mono_align_small_structs;
 
-typedef struct _MonoMethodWrapper MonoMethodWrapper;
-typedef struct _MonoMethodInflated MonoMethodInflated;
-typedef struct _MonoMethodPInvoke MonoMethodPInvoke;
-
 /* Properties that applies to a group of structs should better use a higher number
  * to avoid colision with type specific properties.
  * 
@@ -110,7 +106,7 @@ struct _MonoMethodPInvoke {
  * This information is rarely needed, so it is stored separately from 
  * MonoClassField.
  */
-typedef struct MonoFieldDefaultValue {
+struct _MonoFieldDefaultValue {
 	/*
 	 * If the field is constant, pointer to the metadata constant
 	 * value.
@@ -121,7 +117,7 @@ typedef struct MonoFieldDefaultValue {
 
 	/* If the field is constant, the type of the constant. */
 	MonoTypeEnum     def_type;
-} MonoFieldDefaultValue;
+};
 
 /*
  * MonoClassField is just a runtime representation of the metadata for

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -10,7 +10,7 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/io-layer/io-layer.h>
 #include "mono/utils/mono-compiler.h"
-#include "mono/utils/mono-error.h"
+#include <mono/utils/mono-error-forward.h>
 
 #define MONO_CLASS_IS_ARRAY(c) ((c)->rank)
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -5,7 +5,7 @@
 #define __MONO_METADATA_CLASS_INTERBALS_H__
 
 #include <mono/metadata/class.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/mempool.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/io-layer/io-layer.h>
@@ -442,7 +442,7 @@ int mono_class_interface_offset_with_variance (MonoClass *klass, MonoClass *itf,
 typedef gpointer MonoRuntimeGenericContext;
 
 /* the interface_offsets array is stored in memory before this struct */
-struct MonoVTable {
+struct _MonoVTable {
 	MonoClass  *klass;
 	 /*
 	 * According to comments in gc_gcj.h, this should be the second word in

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -38,6 +38,7 @@
 #include <mono/metadata/mono-debug.h>
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-string.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-logger-internal.h>
 #include <mono/utils/mono-memory-model.h>

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -4,7 +4,7 @@
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/image.h>
 #include <mono/metadata/loader.h>
-#include <mono/utils/mono-error.h>
+#include <mono/utils/mono-error-forward.h>
 
 MONO_BEGIN_DECLS
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -4,11 +4,10 @@
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/image.h>
 #include <mono/metadata/loader.h>
+#include <mono/metadata/class-internals-forward.h>
 #include <mono/utils/mono-error-forward.h>
 
 MONO_BEGIN_DECLS
-
-typedef struct MonoVTable MonoVTable;
 
 MONO_API MonoClass *
 mono_class_get             (MonoImage *image, uint32_t type_token);

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -10,10 +10,6 @@ MONO_BEGIN_DECLS
 
 typedef struct MonoVTable MonoVTable;
 
-typedef struct _MonoClassField MonoClassField;
-typedef struct _MonoProperty MonoProperty;
-typedef struct _MonoEvent MonoEvent;
-
 MONO_API MonoClass *
 mono_class_get             (MonoImage *image, uint32_t type_token);
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -34,6 +34,7 @@
 #include "mono/metadata/attrdefs.h"
 #include "mono/metadata/gc-internal.h"
 #include "mono/utils/mono-counters.h"
+#include "mono/utils/mono-error.h"
 #include "mono/utils/strenc.h"
 #include "mono/utils/atomic.h"
 #include <string.h>

--- a/mono/metadata/console-io.h
+++ b/mono/metadata/console-io.h
@@ -13,7 +13,7 @@
 #include <config.h>
 #include <glib.h>
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/io-layer/io-layer.h>
 #include <mono/utils/mono-compiler.h>
 

--- a/mono/metadata/culture-info.h
+++ b/mono/metadata/culture-info.h
@@ -3,7 +3,7 @@
 #define _MONO_METADATA_CULTURE_INFO_H_ 1
 
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 
 #define NUM_DAYS 7
 #define NUM_MONTHS 13

--- a/mono/metadata/domain-internals-forward.h
+++ b/mono/metadata/domain-internals-forward.h
@@ -3,6 +3,7 @@
 
 struct _MonoAppContext;
 struct _MonoDomain;
+struct _MonoGenericSharingContext;
 struct _MonoJitExceptionInfo;
 struct _MonoJitInfo;
 struct _MonoJitInfoTable;
@@ -11,6 +12,8 @@ struct _MonoThunkFreeList;
 struct _MonoTlsDataRecord;
 
 typedef struct _MonoAppContext MonoAppContext;
+typedef struct _MonoDomain MonoDomain;
+typedef struct _MonoGenericSharingContext MonoGenericSharingContext;
 typedef struct _MonoJitCodeHash MonoJitCodeHash;
 typedef struct _MonoJitExceptionInfo MonoJitExceptionInfo;
 typedef struct _MonoJitInfoTable MonoJitInfoTable;

--- a/mono/metadata/domain-internals-forward.h
+++ b/mono/metadata/domain-internals-forward.h
@@ -1,0 +1,21 @@
+#ifndef __MONO_METADATA_DOMAIN_INTERNALS_FORWARD_H__
+#define __MONO_METADATA_DOMAIN_INTERNALS_FORWARD_H__
+
+struct _MonoAppContext;
+struct _MonoDomain;
+struct _MonoJitExceptionInfo;
+struct _MonoJitInfo;
+struct _MonoJitInfoTable;
+struct _MonoJitInfoTableChunk;
+struct _MonoThunkFreeList;
+struct _MonoTlsDataRecord;
+
+typedef struct _MonoAppContext MonoAppContext;
+typedef struct _MonoJitCodeHash MonoJitCodeHash;
+typedef struct _MonoJitExceptionInfo MonoJitExceptionInfo;
+typedef struct _MonoJitInfoTable MonoJitInfoTable;
+typedef struct _MonoJitInfoTableChunk MonoJitInfoTableChunk;
+typedef struct _MonoThunkFreeList MonoThunkFreeList;
+typedef struct _MonoTlsDataRecord MonoTlsDataRecord;
+
+#endif

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -98,7 +98,7 @@ struct _MonoJitExceptionInfo {
 /*
  * Contains information about the type arguments for generic shared methods.
  */
-typedef struct {
+struct _MonoGenericSharingContext {
 	/*
 	 * If not NULL, determines whenever the class type arguments of the gshared method are references or vtypes.
 	 * The array length is equal to class_inst->type_argv.
@@ -106,7 +106,7 @@ typedef struct {
 	gboolean *var_is_vt;
 	/* Same for method type parameters */
 	gboolean *mvar_is_vt;
-} MonoGenericSharingContext;
+};
 
 /* Simplified DWARF location list entry */
 typedef struct {

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -16,7 +16,7 @@
 #include <mono/utils/mono-internal-hash.h>
 #include <mono/io-layer/io-layer.h>
 #include <mono/metadata/mempool-internals.h>
-
+#include <mono/metadata/object.h>
 
 extern mono_mutex_t mono_delegate_section;
 extern mono_mutex_t mono_strtod_mutex;

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -5,6 +5,7 @@
 #ifndef __MONO_METADATA_DOMAIN_INTERNALS_H__
 #define __MONO_METADATA_DOMAIN_INTERNALS_H__
 
+#include <mono/metadata/domain-internals-forward.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/mempool.h>
 #include <mono/metadata/lock-tracer.h>
@@ -55,9 +56,6 @@ typedef struct {
 	MonoArray *serialized_non_primitives;
 } MonoAppDomainSetup;
 
-typedef struct _MonoJitInfoTable MonoJitInfoTable;
-typedef struct _MonoJitInfoTableChunk MonoJitInfoTableChunk;
-
 #define MONO_JIT_INFO_TABLE_CHUNK_SIZE		64
 
 struct _MonoJitInfoTableChunk
@@ -79,7 +77,7 @@ struct _MonoJitInfoTable
 
 typedef GArray MonoAotModuleInfoTable;
 
-typedef struct {
+struct _MonoJitExceptionInfo {
 	guint32  flags;
 	gint32   exvar_offset;
 	gpointer try_start;
@@ -95,7 +93,7 @@ typedef struct {
 		gpointer filter;
 		gpointer handler_end;
 	} data;
-} MonoJitExceptionInfo;
+};
 
 /*
  * Contains information about the type arguments for generic shared methods.
@@ -277,15 +275,12 @@ typedef enum {
 	MONO_APPDOMAIN_UNLOADED
 } MonoAppDomainState;
 
-typedef struct _MonoThunkFreeList {
+struct _MonoThunkFreeList {
 	guint32 size;
 	int length;		/* only valid for the wait list */
 	struct _MonoThunkFreeList *next;
-} MonoThunkFreeList;
+};
 
-typedef struct _MonoJitCodeHash MonoJitCodeHash;
-
-typedef struct _MonoTlsDataRecord MonoTlsDataRecord;
 struct _MonoTlsDataRecord {
 	MonoTlsDataRecord *next;
 	guint32 tls_offset;

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -16,6 +16,7 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/mono-debug.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <string.h>
 

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -2,6 +2,7 @@
 #define _MONO_METADATA_EXCEPTION_H_
 
 #include <mono/metadata/object.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/metadata/image.h>
 
 MONO_BEGIN_DECLS

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -1,7 +1,7 @@
 #ifndef _MONO_METADATA_EXCEPTION_H_
 #define _MONO_METADATA_EXCEPTION_H_
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/image.h>
 

--- a/mono/metadata/file-io.h
+++ b/mono/metadata/file-io.h
@@ -15,7 +15,6 @@
 #include <config.h>
 #include <glib.h>
 
-#include <mono/metadata/object-internals.h>
 #include <mono/io-layer/io-layer.h>
 #include <mono/utils/mono-compiler.h>
 

--- a/mono/metadata/file-mmap.h
+++ b/mono/metadata/file-mmap.h
@@ -13,7 +13,6 @@
 #include <config.h>
 #include <glib.h>
 
-#include <mono/metadata/object-internals.h>
 #include <mono/io-layer/io-layer.h>
 #include <mono/utils/mono-compiler.h>
 

--- a/mono/metadata/filewatcher.h
+++ b/mono/metadata/filewatcher.h
@@ -10,7 +10,7 @@
 #ifndef _MONO_METADATA_FILEWATCHER_H
 #define _MONO_METADATA_FILEWATCHER_H
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/io-layer/io-layer.h>
 #include "mono/utils/mono-compiler.h"
 #include <glib.h>

--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -12,6 +12,8 @@
 
 #include <glib.h>
 #include <mono/metadata/threads-types.h>
+#include <mono/metadata/class-internals-forward.h>
+#include <mono/metadata/object.h>
 #include <mono/sgen/gc-internal-agnostic.h>
 #include <mono/utils/gc_wrapper.h>
 

--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -11,7 +11,6 @@
 #define __MONO_METADATA_GC_INTERNAL_H__
 
 #include <glib.h>
-#include <mono/metadata/object-internals.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/sgen/gc-internal-agnostic.h>
 #include <mono/utils/gc_wrapper.h>

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -86,6 +86,7 @@
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-proclib.h>
 #include <mono/utils/mono-string.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-io-portability.h>

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -2,14 +2,10 @@
 #define _MONONET_METADATA_IMAGE_H_
 
 #include <stdio.h>
+#include <mono/metadata/metadata-internals-forward.h>
 #include <mono/utils/mono-publib.h>
 
 MONO_BEGIN_DECLS
-
-typedef struct _MonoImage MonoImage;
-typedef struct _MonoAssembly MonoAssembly;
-typedef struct _MonoAssemblyName MonoAssemblyName;
-typedef struct _MonoTableInfo MonoTableInfo;
 
 typedef enum {
 	MONO_IMAGE_OK,

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -43,6 +43,7 @@
 #include <mono/utils/mono-dl.h>
 #include <mono/utils/mono-membar.h>
 #include <mono/utils/mono-counters.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-tls.h>
 

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -12,8 +12,6 @@
 
 #include <glib.h>
 
-#include <mono/metadata/object-internals.h>
-
 /* This is a copy of System.Globalization.CompareOptions */
 typedef enum {
 	CompareOptions_None=0x00,

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -39,6 +39,7 @@
 #include "mono/metadata/remoting.h"
 #include "mono/metadata/reflection-internals.h"
 #include "mono/utils/mono-counters.h"
+#include "mono/utils/mono-error.h"
 #include "mono/utils/mono-tls.h"
 #include "mono/utils/mono-memory-model.h"
 #include "mono/utils/atomic.h"

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -13,7 +13,7 @@
 #define __MONO_MARSHAL_H__
 
 #include <mono/metadata/class.h>
-#include <mono/metadata/object-internals.h>
+#include <mono/metadata/object-internals-forward.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/opcodes.h>
 #include <mono/metadata/reflection.h>

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -14,7 +14,7 @@
 
 #include <mono/metadata/class.h>
 #include <mono/metadata/object-internals-forward.h>
-#include <mono/metadata/class-internals.h>
+#include <mono/metadata/class-internals-forward.h>
 #include <mono/metadata/opcodes.h>
 #include <mono/metadata/reflection.h>
 #include <mono/metadata/method-builder.h>

--- a/mono/metadata/metadata-forward.h
+++ b/mono/metadata/metadata-forward.h
@@ -2,7 +2,9 @@
 #define __MONO_METADATA_FORWARD_H__
 
 struct _MonoArrayType;
+struct _MonoMarshalSpec;
 
 typedef struct _MonoArrayType MonoArrayType;
+typedef struct _MonoMarshalSpec MonoMarshalSpec;
 
 #endif /* __MONO_METADATA_FORWARD_H__ */

--- a/mono/metadata/metadata-forward.h
+++ b/mono/metadata/metadata-forward.h
@@ -1,0 +1,8 @@
+#ifndef __MONO_METADATA_FORWARD_H__
+#define __MONO_METADATA_FORWARD_H__
+
+struct _MonoArrayType;
+
+typedef struct _MonoArrayType MonoArrayType;
+
+#endif /* __MONO_METADATA_FORWARD_H__ */

--- a/mono/metadata/metadata-internals-forward.h
+++ b/mono/metadata/metadata-internals-forward.h
@@ -1,0 +1,7 @@
+#ifndef __MONO_METADATA_INTERNALS_FORWARD_H__
+#define __MONO_METADATA_INTERNALS_FORWARD_H__
+
+typedef struct _MonoDynamicAssembly MonoDynamicAssembly;
+typedef struct _MonoDynamicImage MonoDynamicImage;
+
+#endif

--- a/mono/metadata/metadata-internals-forward.h
+++ b/mono/metadata/metadata-internals-forward.h
@@ -1,7 +1,28 @@
 #ifndef __MONO_METADATA_INTERNALS_FORWARD_H__
 #define __MONO_METADATA_INTERNALS_FORWARD_H__
 
+struct _MonoAssembly;
+struct _MonoAssemblyBindingInfo;
+struct _MonoAssemblyName;
+struct _MonoDllMap;
+struct _MonoDynamicAssembly;
+struct _MonoDynamicImage;
+struct _MonoImage;
+struct _MonoMethodHeader;
+struct _MonoMethodSignature;
+struct _MonoTableInfo;
+struct _MonoType;
+
+typedef struct _MonoAssembly MonoAssembly;
+typedef struct _MonoAssemblyBindingInfo MonoAssemblyBindingInfo;
+typedef struct _MonoAssemblyName MonoAssemblyName;
+typedef struct _MonoDllMap MonoDllMap;
 typedef struct _MonoDynamicAssembly MonoDynamicAssembly;
 typedef struct _MonoDynamicImage MonoDynamicImage;
+typedef struct _MonoImage MonoImage;
+typedef struct _MonoMethodHeader MonoMethodHeader;
+typedef struct _MonoMethodSignature MonoMethodSignature;
+typedef struct _MonoTableInfo MonoTableInfo;
+typedef struct _MonoType MonoType;
 
 #endif

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -2,6 +2,7 @@
 #ifndef __MONO_METADATA_INTERNALS_H__
 #define __MONO_METADATA_INTERNALS_H__
 
+#include "mono/metadata/metadata-internals-forward.h"
 #include "mono/metadata/image.h"
 #include "mono/metadata/blob.h"
 #include "mono/metadata/mempool.h"

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -126,8 +126,6 @@ struct _MonoTableInfo {
 
 #define REFERENCE_MISSING ((gpointer) -1)
 
-typedef struct _MonoDllMap MonoDllMap;
-
 struct _MonoImage {
 	/*
 	 * The number of assemblies which reference this MonoImage though their 'image'
@@ -472,7 +470,7 @@ struct _MonoDynamicImage {
 };
 
 /* Contains information about assembly binding */
-typedef struct _MonoAssemblyBindingInfo {
+struct _MonoAssemblyBindingInfo {
 	char *name;
 	char *culture;
 	guchar public_key_token [MONO_PUBLIC_KEY_TOKEN_LENGTH];
@@ -486,7 +484,7 @@ typedef struct _MonoAssemblyBindingInfo {
 	guint has_new_version : 1;
 	guint is_valid : 1;
 	gint32 domain_id; /*Needed to unload per-domain binding*/
-} MonoAssemblyBindingInfo;
+};
 
 struct _MonoMethodHeader {
 	const unsigned char  *code;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -12,7 +12,7 @@
 #include "mono/utils/monobitset.h"
 #include "mono/utils/mono-property-hash.h"
 #include "mono/utils/mono-value-hash.h"
-#include <mono/utils/mono-error.h>
+#include <mono/utils/mono-error-forward.h>
 #include "mono/utils/mono-conc-hashtable.h"
 
 struct _MonoType {

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -23,6 +23,7 @@
 #include <mono/metadata/cil-coff.h>
 #include <mono/metadata/attrdefs.h>
 #include <mono/utils/strenc.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/bsearch.h>
 #include <string.h>

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -26,6 +26,7 @@
 #include "marshal.h"
 #include "debug-helpers.h"
 #include "abi-details.h"
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/bsearch.h>
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -26,8 +26,10 @@
 #include "marshal.h"
 #include "debug-helpers.h"
 #include "abi-details.h"
+#include <mono/metadata/object-internals.h>
 #include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
+#include <mono/utils/mono-membar.h>
 #include <mono/utils/bsearch.h>
 
 /* Auxiliary structure used for caching inflated signatures */

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -12,20 +12,9 @@
 #include <mono/metadata/domain-internals-forward.h>
 #include <mono/metadata/metadata-internals-forward.h>
 
-MONO_BEGIN_DECLS
+#include <mono/utils/mono-publib.h>
 
-/*
- * When embedding, you have to define MONO_ZERO_LEN_ARRAY before including any
- * other Mono header file if you use a different compiler from the one used to
- * build Mono.
- */
-#ifndef MONO_ZERO_LEN_ARRAY
-#ifdef __GNUC__
-#define MONO_ZERO_LEN_ARRAY 0
-#else
-#define MONO_ZERO_LEN_ARRAY 1
-#endif
-#endif
+MONO_BEGIN_DECLS
 
 #define MONO_TYPE_ISSTRUCT(t) mono_type_is_struct (t)
 #define MONO_TYPE_IS_VOID(t) mono_type_is_void (t)
@@ -178,7 +167,7 @@ typedef enum {
 	MONO_MARSHAL_CONV_HANDLEREF
 } MonoMarshalConv;
 
-typedef struct {
+struct _MonoMarshalSpec {
 	MonoMarshalNative native;
 	union {
 		struct {
@@ -197,7 +186,7 @@ typedef struct {
 			int32_t num_elem;
 		} safearray_data;
 	} data;
-} MonoMarshalSpec;
+};
 
 MONO_API void         mono_metadata_init (void);
 

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -7,6 +7,10 @@
 #include <mono/metadata/blob.h>
 #include <mono/metadata/row-indexes.h>
 #include <mono/metadata/image.h>
+#include <mono/metadata/metadata-forward.h>
+#include <mono/metadata/class-internals-forward.h>
+#include <mono/metadata/domain-internals-forward.h>
+#include <mono/metadata/metadata-internals-forward.h>
 
 MONO_BEGIN_DECLS
 
@@ -31,10 +35,6 @@ MONO_BEGIN_DECLS
 #define MONO_CLASS_IS_INTERFACE(c) ((c->flags & TYPE_ATTRIBUTE_INTERFACE) || (c->byval_arg.type == MONO_TYPE_VAR) || (c->byval_arg.type == MONO_TYPE_MVAR))
 
 #define MONO_CLASS_IS_IMPORT(c) ((c->flags & TYPE_ATTRIBUTE_IMPORT))
-
-typedef struct _MonoClass MonoClass;
-typedef struct _MonoDomain MonoDomain;
-typedef struct _MonoMethod MonoMethod;
 
 typedef enum {
 	MONO_EXCEPTION_CLAUSE_NONE,
@@ -292,16 +292,6 @@ typedef struct {
 	} data;
 } MonoExceptionClause;
 
-typedef struct _MonoType MonoType;
-typedef struct _MonoGenericInst MonoGenericInst;
-typedef struct _MonoGenericClass MonoGenericClass;
-typedef struct _MonoDynamicGenericClass MonoDynamicGenericClass;
-typedef struct _MonoGenericContext MonoGenericContext;
-typedef struct _MonoGenericContainer MonoGenericContainer;
-typedef struct _MonoGenericParam MonoGenericParam;
-typedef struct _MonoArrayType MonoArrayType;
-typedef struct _MonoMethodSignature MonoMethodSignature;
-
 /* FIXME: Keeping this name alive for now, since it is part of the exposed API, even though no entrypoint uses it.  */
 typedef struct invalid_name MonoGenericMethod;
 
@@ -318,8 +308,6 @@ struct _MonoArrayType {
 	int *sizes;
 	int *lobounds;
 };
-
-typedef struct _MonoMethodHeader MonoMethodHeader;
 
 typedef enum {
 	MONO_PARSE_TYPE,

--- a/mono/metadata/method-builder.h
+++ b/mono/metadata/method-builder.h
@@ -13,7 +13,6 @@
 
 #include "config.h"
 #include <mono/metadata/class.h>
-#include <mono/metadata/object-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/opcodes.h>
 #include <mono/metadata/reflection.h>

--- a/mono/metadata/monitor.h
+++ b/mono/metadata/monitor.h
@@ -11,7 +11,7 @@
 #define _MONO_METADATA_MONITOR_H_
 
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/io-layer/io-layer.h>
 #include "mono/utils/mono-compiler.h"
 

--- a/mono/metadata/mono-basic-block.c
+++ b/mono/metadata/mono-basic-block.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/mono-basic-block.h>
 #include <mono/metadata/opcodes.h>
 
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-compiler.h>
 

--- a/mono/metadata/mono-basic-block.h
+++ b/mono/metadata/mono-basic-block.h
@@ -4,7 +4,7 @@
 #include <glib.h>
 #include <mono/metadata/metadata.h>
 #include <mono/utils/mono-compiler.h>
-#include <mono/utils/mono-error.h>
+#include <mono/utils/mono-error-forward.h>
 
 G_BEGIN_DECLS
 

--- a/mono/metadata/mono-cq.c
+++ b/mono/metadata/mono-cq.c
@@ -8,8 +8,10 @@
  * Copyright 2011 Xamarin Inc
  */
 
-#include <mono/metadata/object.h>
 #include <mono/metadata/mono-cq.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/object.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/metadata/mono-mlist.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/atomic.h>

--- a/mono/metadata/mono-cq.h
+++ b/mono/metadata/mono-cq.h
@@ -3,7 +3,7 @@
 
 #include <config.h>
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/gc-internal.h>
 
 G_BEGIN_DECLS

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -5,7 +5,8 @@
 #ifndef __METADATA_MONO_GC_H__
 #define __METADATA_MONO_GC_H__
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
+#include <mono/metadata/class-internals-forward.h>
 
 MONO_BEGIN_DECLS
 

--- a/mono/metadata/mono-mlist.h
+++ b/mono/metadata/mono-mlist.h
@@ -5,7 +5,7 @@
  * mono-mlist.h: Managed object list implementation
  */
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 
 typedef struct _MonoMList MonoMList;
 MONO_API MonoMList*  mono_mlist_alloc       (MonoObject *data);

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -42,6 +42,7 @@
 #include "utils/mono-mmap.h"
 #include "utils/mono-proclib.h"
 #include "utils/mono-networkinterfaces.h"
+#include "utils/mono-error.h"
 #include "utils/mono-error-internals.h"
 #include "utils/atomic.h"
 #include <mono/io-layer/io-layer.h>

--- a/mono/metadata/mono-perfcounters.h
+++ b/mono/metadata/mono-perfcounters.h
@@ -2,7 +2,8 @@
 #define __MONO_PERFCOUNTERS_H__
 
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
+#include <mono/metadata/object-internals-forward.h>
 #include <mono/utils/mono-compiler.h>
 
 typedef struct _MonoCounterSample MonoCounterSample;

--- a/mono/metadata/mono-route.c
+++ b/mono/metadata/mono-route.c
@@ -16,8 +16,10 @@
 #include <sys/sysctl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <mono/metadata/domain-internals.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/mono-route.h>
+#include <glib.h>
 
 extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfaceProperties_ParseRouteInfo_internal(MonoString *iface, MonoArray **gw_addr_list)
 {

--- a/mono/metadata/mono-route.h
+++ b/mono/metadata/mono-route.h
@@ -12,8 +12,6 @@
 #include <net/route.h>
 #endif
 
-#include <mono/metadata/object-internals.h>
-
 in_addr_t gateway_from_rtm (struct rt_msghdr *rtm);
 
 /* Category icalls */

--- a/mono/metadata/mono-wsq.c
+++ b/mono/metadata/mono-wsq.c
@@ -9,7 +9,9 @@
  */
 
 #include <string.h>
+#include <mono/metadata/class-internals.h>
 #include <mono/metadata/object.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/metadata/mono-wsq.h>
 #include <mono/utils/mono-semaphore.h>
 #include <mono/utils/mono-tls.h>

--- a/mono/metadata/mono-wsq.h
+++ b/mono/metadata/mono-wsq.h
@@ -3,7 +3,7 @@
 
 #include <config.h>
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/gc-internal.h>
 #include <mono/io-layer/io-layer.h>
 

--- a/mono/metadata/object-forward.h
+++ b/mono/metadata/object-forward.h
@@ -1,7 +1,11 @@
 #ifndef __MONO_OBJECT_FORWARD_H__
 #define __MONO_OBJECT_FORWARD_H__
 
+#include <mono/utils/mono-publib.h> /* for mono_byte */
+
 struct _MonoObject;
+
 typedef struct _MonoObject MonoObject;
+typedef mono_byte MonoBoolean;
 
 #endif

--- a/mono/metadata/object-forward.h
+++ b/mono/metadata/object-forward.h
@@ -1,0 +1,7 @@
+#ifndef __MONO_OBJECT_FORWARD_H__
+#define __MONO_OBJECT_FORWARD_H__
+
+struct _MonoObject;
+typedef struct _MonoObject MonoObject;
+
+#endif

--- a/mono/metadata/object-internals-forward.h
+++ b/mono/metadata/object-internals-forward.h
@@ -1,0 +1,49 @@
+#ifndef __MONO_OBJECT_INTERNALS_FORWARD_H__
+#define __MONO_OBJECT_INTERNALS_FORWARD_H__
+
+struct _MonoAppDomain;
+struct _MonoArray;
+struct _MonoDelegate;
+struct _MonoException;
+struct _MonoIMTCheckItem;
+struct _MonoImtBuilderEntry;
+struct _MonoInternalThread;
+struct _MonoMulticastDelegate;
+struct _MonoReflectionAssembly;
+struct _MonoReflectionEvent;
+struct _MonoReflectionField;
+struct _MonoReflectionGenericClass;
+struct _MonoReflectionGenericMethod;
+struct _MonoReflectionMethod;
+struct _MonoReflectionMethodBody;
+struct _MonoReflectionModule;
+struct _MonoReflectionProperty;
+struct _MonoReflectionType;
+struct _MonoString;
+struct _MonoStringBuilder;
+struct _MonoThread;
+struct _MonoThreadsSync;
+
+typedef struct _MonoArray MonoArray;
+typedef struct _MonoDelegate MonoDelegate;
+typedef struct _MonoException MonoException;
+typedef struct _MonoIMTCheckItem MonoIMTCheckItem;
+typedef struct _MonoImtBuilderEntry MonoImtBuilderEntry;
+typedef struct _MonoInternalThread MonoInternalThread;
+typedef struct _MonoMulticastDelegate MonoMulticastDelegate;
+typedef struct _MonoReflectionAssembly MonoReflectionAssembly;
+typedef struct _MonoReflectionEvent MonoReflectionEvent;
+typedef struct _MonoReflectionField MonoReflectionField;
+typedef struct _MonoReflectionGenericClass MonoReflectionGenericClass;
+typedef struct _MonoReflectionGenericMethod MonoReflectionGenericMethod;
+typedef struct _MonoReflectionMethod MonoReflectionMethod;
+typedef struct _MonoReflectionMethodBody MonoReflectionMethodBody;
+typedef struct _MonoReflectionModule MonoReflectionModule;
+typedef struct _MonoReflectionProperty MonoReflectionProperty;
+typedef struct _MonoReflectionType MonoReflectionType;
+typedef struct _MonoString MonoString;
+typedef struct _MonoStringBuilder MonoStringBuilder;
+typedef struct _MonoThread MonoThread;
+typedef struct _MonoThreadsSync MonoThreadsSync;
+
+#endif

--- a/mono/metadata/object-internals-forward.h
+++ b/mono/metadata/object-internals-forward.h
@@ -3,6 +3,9 @@
 
 struct _MonoAppDomain;
 struct _MonoArray;
+struct _MonoAsyncResult;
+struct _MonoComInteropProxy;
+struct _MonoComObject;
 struct _MonoDelegate;
 struct _MonoException;
 struct _MonoIMTCheckItem;
@@ -23,8 +26,13 @@ struct _MonoString;
 struct _MonoStringBuilder;
 struct _MonoThread;
 struct _MonoThreadsSync;
+struct _MonoTypedRef;
+struct _MonoWaitHandle;
 
 typedef struct _MonoArray MonoArray;
+typedef struct _MonoAsyncResult MonoAsyncResult;
+typedef struct _MonoComInteropProxy MonoComInteropProxy;
+typedef struct _MonoComObject MonoComObject;
 typedef struct _MonoDelegate MonoDelegate;
 typedef struct _MonoException MonoException;
 typedef struct _MonoIMTCheckItem MonoIMTCheckItem;
@@ -45,5 +53,7 @@ typedef struct _MonoString MonoString;
 typedef struct _MonoStringBuilder MonoStringBuilder;
 typedef struct _MonoThread MonoThread;
 typedef struct _MonoThreadsSync MonoThreadsSync;
+typedef struct _MonoTypedRef MonoTypedRef;
+typedef struct _MonoWaitHandle MonoWaitHandle;
 
 #endif

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -9,7 +9,7 @@
 #include <mono/metadata/threads-types.h>
 #include <mono/io-layer/io-layer.h>
 #include "mono/utils/mono-compiler.h"
-#include "mono/utils/mono-error.h"
+#include <mono/utils/mono-error-forward.h>
 #include "mono/utils/mono-stack-unwinding.h"
 #include "mono/utils/mono-tls.h"
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -220,11 +220,11 @@ struct _MonoStringBuilder {
 	int maxCapacity;
 };
 
-typedef struct {
+struct _MonoTypedRef {
 	MonoType *type;
 	gpointer  value;
 	MonoClass *klass;
-} MonoTypedRef;
+};
 
 typedef struct {
 	gpointer args;
@@ -265,7 +265,7 @@ typedef struct {
 	MonoString *param_name;
 } MonoArgumentException;
 
-typedef struct {
+struct _MonoAsyncResult {
 	MonoObject   object;
 	MonoObject  *async_state;
 	MonoObject  *handle;
@@ -279,13 +279,13 @@ typedef struct {
 	MonoObject  *execution_context;
 	MonoObject  *original_context;
 	gint64	     add_time;
-} MonoAsyncResult;
+};
 
-typedef struct {
+struct _MonoWaitHandle {
 	MonoMarshalByRefObject object;
 	gpointer     handle;
 	MonoBoolean  disposed;
-} MonoWaitHandle;
+};
 
 /* This is a copy of System.Runtime.Remoting.Messaging.CallType */
 typedef enum {
@@ -318,18 +318,18 @@ typedef struct {
 	MonoObject *stub_data;
 } MonoRealProxy;
 
-typedef struct {
+struct _MonoComObject {
 	MonoMarshalByRefObject object;
 	gpointer iunknown;
 	GHashTable* itf_hash;
 	MonoObject *synchronization_context;
-} MonoComObject;
+};
 
-typedef struct {
+struct _MonoComInteropProxy {
 	MonoRealProxy real_proxy;
 	MonoComObject *com_object;
 	gint32 ref_count;
-} MonoComInteropProxy;
+};
 
 typedef struct {
 	MonoObject	 object;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2,7 +2,7 @@
 #define __MONO_OBJECT_INTERNALS_H__
 
 #include <mono/metadata/object-internals-forward.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/threads.h>
 #include <mono/metadata/reflection.h>
 #include <mono/metadata/mempool.h>

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1,6 +1,7 @@
 #ifndef __MONO_OBJECT_INTERNALS_H__
 #define __MONO_OBJECT_INTERNALS_H__
 
+#include <mono/metadata/object-internals-forward.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/threads.h>
 #include <mono/metadata/reflection.h>
@@ -209,8 +210,6 @@ struct _MonoAppDomain {
 	MonoMarshalByRefObject mbr;
 	MonoDomain *data;
 };
-
-typedef struct _MonoStringBuilder MonoStringBuilder;
 
 struct _MonoStringBuilder {
 	MonoObject object;
@@ -769,7 +768,6 @@ struct _MonoReflectionMethod {
 	MonoReflectionType *reftype;
 };
 
-typedef struct _MonoReflectionGenericMethod MonoReflectionGenericMethod;
 struct _MonoReflectionGenericMethod {
 	MonoReflectionMethod method;
 };
@@ -793,7 +791,6 @@ struct _MonoDelegate {
 	MonoObject *data;
 };
 
-typedef struct _MonoMulticastDelegate MonoMulticastDelegate;
 struct _MonoMulticastDelegate {
 	MonoDelegate delegate;
 	MonoArray *delegates;
@@ -1217,7 +1214,6 @@ typedef struct {
 	guint32 attrs;
 } MonoReflectionGenericParam;
 
-typedef struct _MonoReflectionGenericClass MonoReflectionGenericClass;
 struct _MonoReflectionGenericClass {
 	MonoReflectionType type;
 	MonoReflectionType *generic_type; /*Can be either a MonoType or a TypeBuilder*/
@@ -1515,15 +1511,13 @@ typedef union {
 	gpointer target_code;
 } MonoImtItemValue;
 
-typedef struct _MonoImtBuilderEntry {
+struct _MonoImtBuilderEntry {
 	gpointer key;
 	struct _MonoImtBuilderEntry *next;
 	MonoImtItemValue value;
 	int children;
 	guint8 has_target_code : 1;
-} MonoImtBuilderEntry;
-
-typedef struct _MonoIMTCheckItem MonoIMTCheckItem;
+};
 
 struct _MonoIMTCheckItem {
 	gpointer          key;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -10,12 +10,6 @@
  * Copyright 2001 Xamarin Inc (http://www.xamarin.com)
  */
 #include <config.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/tokentype.h>
@@ -41,9 +35,17 @@
 #include <mono/metadata/verify-internals.h>
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-counters.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-memory-model.h>
 #include "cominterop.h"
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #ifdef HAVE_BOEHM_GC
 #define NEED_TO_ZERO_PTRFREE 1

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -33,6 +33,7 @@
 #include "mono/metadata/mono-debug-debugger.h"
 #include <mono/metadata/gc-internal.h>
 #include <mono/metadata/verify-internals.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-error.h>

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -2,7 +2,7 @@
 #define _MONO_CLI_OBJECT_H_
 
 #include <mono/metadata/class.h>
-#include <mono/utils/mono-error.h>
+#include <mono/utils/mono-error-forward.h>
 
 MONO_BEGIN_DECLS
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -1,6 +1,8 @@
 #ifndef _MONO_CLI_OBJECT_H_
 #define _MONO_CLI_OBJECT_H_
 
+#include <mono/metadata/object-forward.h>
+#include <mono/metadata/object-internals-forward.h>
 #include <mono/metadata/class.h>
 #include <mono/utils/mono-error-forward.h>
 
@@ -8,28 +10,10 @@ MONO_BEGIN_DECLS
 
 typedef mono_byte MonoBoolean;
 
-typedef struct _MonoString MonoString;
-typedef struct _MonoArray MonoArray;
-typedef struct _MonoReflectionMethod MonoReflectionMethod;
-typedef struct _MonoReflectionAssembly MonoReflectionAssembly;
-typedef struct _MonoReflectionModule MonoReflectionModule;
-typedef struct _MonoReflectionField MonoReflectionField;
-typedef struct _MonoReflectionProperty MonoReflectionProperty;
-typedef struct _MonoReflectionEvent MonoReflectionEvent;
-typedef struct _MonoReflectionType MonoReflectionType;
-typedef struct _MonoDelegate MonoDelegate;
-typedef struct _MonoException MonoException;
-typedef struct _MonoThreadsSync MonoThreadsSync;
-typedef struct _MonoThread MonoThread;
-typedef struct _MonoDynamicAssembly MonoDynamicAssembly;
-typedef struct _MonoDynamicImage MonoDynamicImage;
-typedef struct _MonoReflectionMethodBody MonoReflectionMethodBody;
-typedef struct _MonoAppContext MonoAppContext;
-
-typedef struct _MonoObject {
+struct _MonoObject {
 	MonoVTable *vtable;
 	MonoThreadsSync *synchronisation;
-} MonoObject;
+};
 
 typedef MonoObject* (*MonoInvokeFunc)	     (MonoMethod *method, void *obj, void **params, MonoObject **exc);
 typedef void*    (*MonoCompileFunc)	     (MonoMethod *method);

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -8,8 +8,6 @@
 
 MONO_BEGIN_DECLS
 
-typedef mono_byte MonoBoolean;
-
 struct _MonoObject {
 	MonoVTable *vtable;
 	MonoThreadsSync *synchronisation;

--- a/mono/metadata/pedump.c
+++ b/mono/metadata/pedump.c
@@ -26,6 +26,7 @@
 #include <mono/metadata/verify-internals.h>
 #include <mono/metadata/marshal.h>
 #include "mono/utils/mono-digest.h"
+#include "mono/utils/mono-error.h"
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-counters.h>
 #include <sys/types.h>

--- a/mono/metadata/process.h
+++ b/mono/metadata/process.h
@@ -13,7 +13,7 @@
 #include <config.h>
 #include <glib.h>
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/io-layer/io-layer.h>
 #include "mono/utils/mono-compiler.h"
 

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -1,7 +1,7 @@
 #ifndef __MONO_PROFILER_H__
 #define __MONO_PROFILER_H__
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/appdomain.h>
 
 MONO_BEGIN_DECLS

--- a/mono/metadata/rand.h
+++ b/mono/metadata/rand.h
@@ -13,7 +13,7 @@
 #define _MONO_METADATA_RAND_H_
 
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include "mono/utils/mono-compiler.h"
 
 MonoBoolean ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngOpen (void);

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -6,7 +6,7 @@
 
 #include <mono/metadata/reflection.h>
 #include <mono/utils/mono-compiler.h>
-#include <mono/utils/mono-error.h>
+#include <mono/utils/mono-error-forward.h>
 
 MonoObject*
 mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass, MonoError *error);

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -42,6 +42,7 @@
 #include <mono/metadata/verify-internals.h>
 #include <mono/metadata/mono-ptr-array.h>
 #include <mono/utils/mono-string.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-error-internals.h>
 
 static gboolean is_usertype (MonoReflectionType *ref);

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -1,7 +1,13 @@
 #ifndef __METADATA_REFLECTION_H__
 #define __METADATA_REFLECTION_H__
 
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
+#include <mono/metadata/class-internals-forward.h>
+#include <mono/metadata/domain-internals-forward.h>
+#include <mono/metadata/object-internals-forward.h>
+#include <mono/metadata/metadata-internals-forward.h>
+#include <mono/metadata/metadata-forward.h>
+#include <mono/utils/mono-error-forward.h>
 
 MONO_BEGIN_DECLS
 

--- a/mono/metadata/remoting.h
+++ b/mono/metadata/remoting.h
@@ -10,7 +10,6 @@
 
 #include "config.h"
 #include <mono/metadata/class.h>
-#include <mono/metadata/object-internals.h>
 #include <mono/metadata/class-internals.h>
 
 void mono_remoting_init (void);

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -16,6 +16,7 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-logger-internal.h>
 
 #include "security-core-clr.h"

--- a/mono/metadata/security.h
+++ b/mono/metadata/security.h
@@ -12,7 +12,7 @@
 #define _MONO_METADATA_SECURITY_H_
 
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-publib.h>
 

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -20,6 +20,7 @@
 #ifdef SGEN_DEFINE_OBJECT_VTABLE
 
 #include "sgen/sgen-archdep.h"
+#include "sgen/sgen-descriptor.h"
 #include "utils/mono-threads.h"
 #include "utils/mono-mmap.h"
 #include "metadata/object-internals.h"

--- a/mono/metadata/socket-io.h
+++ b/mono/metadata/socket-io.h
@@ -13,7 +13,6 @@
 #include <config.h>
 #include <glib.h>
 
-#include <mono/metadata/object-internals.h>
 #include <mono/io-layer/io-layer.h>
 
 /* This is a copy of System.Net.Sockets.SocketType */

--- a/mono/metadata/string-icalls.h
+++ b/mono/metadata/string-icalls.h
@@ -12,7 +12,8 @@
 
 #include <glib.h>
 #include <mono/metadata/class.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
+#include <mono/metadata/object-internals-forward.h>
 #include "mono/utils/mono-compiler.h"
 
 void

--- a/mono/metadata/threadpool-internals.h
+++ b/mono/metadata/threadpool-internals.h
@@ -2,7 +2,7 @@
 #define _MONO_THREADPOOL_INTERNALS_H_
 
 #include <glib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/mono-hash.h>
 #include <mono/metadata/mono-mlist.h>
 #include <mono/utils/mono-compiler.h>

--- a/mono/metadata/threadpool-ms-io.h
+++ b/mono/metadata/threadpool-ms-io.h
@@ -4,7 +4,6 @@
 #include <config.h>
 #include <glib.h>
 
-#include <mono/metadata/object-internals.h>
 #include <mono/metadata/socket-io.h>
 
 gboolean

--- a/mono/metadata/threadpool.h
+++ b/mono/metadata/threadpool.h
@@ -1,7 +1,6 @@
 #ifndef _MONO_THREADPOOL_H_
 #define _MONO_THREADPOOL_H_
 
-#include <mono/metadata/object-internals.h>
 #include <mono/metadata/reflection.h>
 #include <mono/metadata/socket-io.h>
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -58,8 +58,6 @@ typedef SECURITY_ATTRIBUTES WapiSecurityAttributes;
 typedef LPTHREAD_START_ROUTINE WapiThreadStart;
 #endif
 
-typedef struct _MonoInternalThread MonoInternalThread;
-
 typedef void (*MonoThreadCleanupFunc) (MonoNativeThreadId tid);
 /* INFO has type MonoThreadInfo* */
 typedef void (*MonoThreadNotifyPendingExcFunc) (gpointer info);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -15,7 +15,7 @@
 #include <glib.h>
 
 #include <mono/io-layer/io-layer.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include "mono/utils/mono-compiler.h"
 #include "mono/utils/mono-membar.h"
 #include "mono/utils/mono-threads.h"

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -12,7 +12,7 @@
 #define _MONO_METADATA_THREADS_H_
 
 #include <mono/utils/mono-publib.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/appdomain.h>
 
 MONO_BEGIN_DECLS

--- a/mono/metadata/verify-internals.h
+++ b/mono/metadata/verify-internals.h
@@ -4,7 +4,7 @@
 #include <glib.h>
 #include <mono/metadata/metadata.h>
 #include <mono/utils/mono-compiler.h>
-#include <mono/utils/mono-error.h>
+#include <mono/utils/mono-error-forward.h>
 
 G_BEGIN_DECLS
 

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -28,6 +28,7 @@
 #include <mono/metadata/attrdefs.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/utils/mono-counters.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/monobitset.h>
 #include <string.h>
 #include <ctype.h>

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -46,6 +46,8 @@
 #include <mono/metadata/mempool-internals.h>
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/threads-types.h>
+#include <mono/metadata/security-manager.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-logger-internal.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-time.h>

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -51,6 +51,8 @@
 #include <mono/metadata/monitor.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/mono-endian.h>
+#include <mono/metadata/exception.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-logger-internal.h>
 #include <mono/utils/mono-mmap.h>
 #include "mono/utils/mono-compiler.h"

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/threads-types.h>
+#include <mono/metadata/tabledefs.h>
 
 #include <mono/metadata/mono-debug-debugger.h>
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -62,6 +62,10 @@
 #include <mono/metadata/runtime.h>
 #include <mono/metadata/threadpool.h>
 #include <mono/metadata/verify-internals.h>
+#include <mono/metadata/marshal.h>
+#include <mono/metadata/tabledefs.h>
+#include <mono/metadata/tokentype.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-semaphore.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-stack-unwinding.h>

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -65,6 +65,7 @@
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/tokentype.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-semaphore.h>
 #include <mono/utils/mono-error-internals.h>

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -14,6 +14,7 @@
 
 #include <mono/metadata/gc-internal.h>
 #include <mono/metadata/abi-details.h>
+#include <mono/metadata/marshal.h>
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/gc-internal.h>
 #include <mono/metadata/abi-details.h>
 #include <mono/metadata/marshal.h>
+#include <mono/metadata/object-internals.h>
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -22,6 +22,8 @@
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/debug-mono-symfile.h>
 #include <mono/metadata/mono-debug-debugger.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/tabledefs.h>
 #include <mono/utils/mono-compiler.h>
 
 #ifndef HOST_WIN32

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -30,6 +30,7 @@
 #include <mono/metadata/exception.h>
 #include <mono/metadata/gc-internal.h>
 #include <mono/metadata/mono-debug.h>
+#include <mono/metadata/tokentype.h>
 #include <mono/utils/mono-mmap.h>
 
 #include "mini.h"

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -17,7 +17,12 @@
 #endif
 
 #include "jit-icalls.h"
+#include <mono/metadata/exception.h>
 #include <mono/utils/mono-error-internals.h>
+#include <mono/metadata/tokentype.h>
+#include <mono/metadata/marshal.h>
+#include <mono/metadata/tabledefs.h>
+
 void*
 mono_ldftn (MonoMethod *method)
 {

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -27,6 +27,10 @@
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/gc-internal.h>
+#include <mono/metadata/metadata.h>
+#include <mono/metadata/marshal.h>
+#include <mono/metadata/tokentype.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-memory-model.h>

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -30,6 +30,7 @@
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/tokentype.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-mmap.h>

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -2,6 +2,7 @@
 #define __MONO_MINI_AMD64_H__
 
 #include <mono/arch/amd64/amd64-codegen.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/utils/mono-sigcontext.h>
 #include <mono/utils/mono-context.h>
 #include <glib.h>

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/threads.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/mempool-internals.h>
+#include <mono/metadata/tabledefs.h>
 #include <mono/utils/mono-math.h>
 
 #include "mini.h"

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -11,7 +11,11 @@
 #include <config.h>
 
 #include <mono/metadata/class.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/marshal.h>
+#include <mono/metadata/tabledefs.h>
 #include <mono/utils/mono-counters.h>
+#include <mono/utils/mono-membar.h>
 
 #include "mini.h"
 

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -4,7 +4,7 @@
 #include <mono/arch/ppc/ppc-codegen.h>
 #include <mono/utils/mono-sigcontext.h>
 #include <mono/utils/mono-context.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <glib.h>
 
 #ifdef __mono_ppc64__

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -47,6 +47,9 @@
 #include <mono/metadata/mempool-internals.h>
 #include <mono/metadata/attach.h>
 #include <mono/metadata/runtime.h>
+#include <mono/metadata/marshal.h>
+#include <mono/metadata/exception.h>
+#include <mono/metadata/security-manager.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-counters.h>

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -10,6 +10,7 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/tabledefs.h>
+#include <mono/metadata/exception.h>
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-membar.h>

--- a/mono/mini/mini-unwind.h
+++ b/mono/mini/mini-unwind.h
@@ -11,6 +11,7 @@
 #define __MONO_UNWIND_H__
 
 #include "mini.h"
+#include <mono/metadata/domain-internals-forward.h>
 
 /*
  * This is a platform-independent interface for unwinding through stack frames 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -46,6 +46,9 @@
 #include <mono/metadata/mempool-internals.h>
 #include <mono/metadata/attach.h>
 #include <mono/metadata/runtime.h>
+#include <mono/metadata/marshal.h>
+#include <mono/metadata/exception.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-counters.h>

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -14,16 +14,17 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
+
 #include <mono/metadata/loader.h>
 #include <mono/metadata/mempool.h>
 #include <mono/utils/monobitset.h>
 #include <mono/metadata/class.h>
-#include <mono/metadata/object.h>
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/opcodes.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/domain-internals.h>
 #include "mono/metadata/class-internals.h"
-#include "mono/metadata/object-internals.h"
+#include "mono/metadata/object-internals-forward.h"
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/utils/mono-compiler.h>

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -27,6 +27,7 @@
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/utils/mono-compiler.h>
+#include <mono/utils/mono-error.h>
 #include <mono/utils/mono-machine.h>
 #include <mono/utils/mono-stack-unwinding.h>
 #include <mono/utils/mono-threads.h>

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -15,25 +15,17 @@
 #include <sys/types.h>
 #endif
 
-#include <mono/metadata/loader.h>
+#include <mono/metadata/metadata.h>
 #include <mono/metadata/mempool.h>
-#include <mono/utils/monobitset.h>
-#include <mono/metadata/class.h>
-#include <mono/metadata/object-forward.h>
+#include <mono/utils/monobitset-forward.h>
+#include <mono/metadata/class-internals.h>
 #include <mono/metadata/opcodes.h>
-#include <mono/metadata/tabledefs.h>
-#include <mono/metadata/domain-internals.h>
-#include "mono/metadata/class-internals.h"
-#include "mono/metadata/object-internals-forward.h"
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/debug-helpers.h>
-#include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-error.h>
-#include <mono/utils/mono-machine.h>
 #include <mono/utils/mono-stack-unwinding.h>
-#include <mono/utils/mono-threads.h>
+#include <mono/utils/mono-threads-forward.h>
 #include <mono/utils/mono-tls.h>
-#include <mono/utils/atomic.h>
 #include <mono/utils/mono-conc-hashtable.h>
 #include <mono/utils/mono-signal-handler.h>
 
@@ -44,14 +36,7 @@
 #include "mini-unwind.h"
 #include "jit.h"
 
-#include "mono/metadata/class-internals.h"
-#include "mono/metadata/domain-internals.h"
-#include "mono/metadata/object.h"
-#include "mono/metadata/tabledefs.h"
-#include "mono/metadata/marshal.h"
-#include "mono/metadata/security-manager.h"
-#include "mono/metadata/exception.h"
-#include "mono/utils/mono-compiler.h"
+#include "mono/utils/mono-codeman.h"
 
 #ifdef __native_client_codegen__
 #include <nacl/nacl_dyncode.h>

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -14,6 +14,8 @@
 #include "ir-emit.h"
 #include "mono/utils/bsearch.h"
 #include <mono/metadata/abi-details.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/tabledefs.h>
 
 /*
 General notes on SIMD intrinsics

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -18,6 +18,7 @@
 #endif
 #include <string.h>
 #include "mini.h"
+#include <mono/metadata/object-internals.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/assembly.h>
 #include <mono/utils/mono-time.h>

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -21,6 +21,7 @@
 #include <mono/metadata/monitor.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/gc-internal.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/arch/amd64/amd64-codegen.h>
 
 #include <mono/utils/atomic.h>

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -23,6 +23,7 @@
 #include <mono/metadata/gc-internal.h>
 #include <mono/arch/amd64/amd64-codegen.h>
 
+#include <mono/utils/atomic.h>
 #include <mono/utils/memcheck.h>
 
 #include "mini.h"

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -16,6 +16,7 @@
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/mono-perfcounters.h>
 #include <mono/metadata/appdomain.h>
+#include <mono/metadata/object.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-membar.h>
 #include <mono/utils/mono-counters.h>

--- a/mono/sgen/Makefile.am
+++ b/mono/sgen/Makefile.am
@@ -34,6 +34,7 @@ monosgen_sources = \
 	sgen-gc.h \
 	sgen-gray.c \
 	sgen-gray.h \
+	sgen-gray-forward.h \
 	sgen-hash-table.c \
 	sgen-hash-table.h \
 	sgen-internal.c \

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -45,6 +45,7 @@
 #include "mono/sgen/sgen-protocol.h"
 #include "mono/sgen/sgen-memory-governor.h"
 #include "mono/sgen/sgen-client.h"
+#include "mono/utils/atomic.h"
 #include "mono/utils/mono-memory-model.h"
 
 #define ALIGN_UP		SGEN_ALIGN_UP

--- a/mono/sgen/sgen-copy-object.h
+++ b/mono/sgen/sgen-copy-object.h
@@ -19,6 +19,8 @@
  * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include <mono/sgen/sgen-gray.h>
+
 extern guint64 stat_copy_object_called_nursery;
 extern guint64 stat_objects_copied_nursery;
 

--- a/mono/sgen/sgen-fin-weak-hash.c
+++ b/mono/sgen/sgen-fin-weak-hash.c
@@ -32,6 +32,7 @@
 #include "mono/sgen/sgen-protocol.h"
 #include "mono/sgen/sgen-pointer-queue.h"
 #include "mono/sgen/sgen-client.h"
+#include "mono/utils/atomic.h"
 #include "mono/utils/mono-membar.h"
 
 #define ptr_in_nursery sgen_ptr_in_nursery

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -189,6 +189,7 @@
 #include <stdlib.h>
 
 #include "mono/sgen/sgen-gc.h"
+#include "mono/sgen/sgen-gray.h"
 #include "mono/sgen/sgen-cardtable.h"
 #include "mono/sgen/sgen-protocol.h"
 #include "mono/sgen/sgen-memory-governor.h"
@@ -199,6 +200,7 @@
 #include "mono/sgen/sgen-client.h"
 #include "mono/sgen/sgen-pointer-queue.h"
 #include "mono/sgen/gc-internal-agnostic.h"
+#include "mono/utils/atomic.h"
 #include "mono/utils/mono-proclib.h"
 #include "mono/utils/mono-memory-model.h"
 #include "mono/utils/hazard-pointer.h"

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -27,6 +27,12 @@
 
 #ifdef HAVE_SGEN_GC
 
+#include "mono/sgen/sgen-conf.h"
+#include "mono/sgen/sgen-gray-forward.h"
+#include "mono/sgen/sgen-hash-table.h"
+#include "mono/utils/mono-compiler.h"
+#include "mono/utils/mono-mutex.h"
+
 typedef struct _SgenThreadInfo SgenThreadInfo;
 #undef THREAD_INFO_TYPE
 #define THREAD_INFO_TYPE SgenThreadInfo
@@ -37,14 +43,6 @@ typedef struct _SgenThreadInfo SgenThreadInfo;
 #include <pthread.h>
 #endif
 #include <stdint.h>
-#include "mono/utils/mono-compiler.h"
-#include "mono/utils/atomic.h"
-#include "mono/utils/mono-mutex.h"
-#include "mono/sgen/sgen-conf.h"
-#include "mono/sgen/sgen-descriptor.h"
-#include "mono/sgen/sgen-gray.h"
-#include "mono/sgen/sgen-hash-table.h"
-#include "mono/sgen/sgen-protocol.h"
 
 /* The method used to clear the nursery */
 /* Clearing at nursery collections is the safest, but has bad interactions with caches.

--- a/mono/sgen/sgen-gray-forward.h
+++ b/mono/sgen/sgen-gray-forward.h
@@ -1,0 +1,16 @@
+#ifndef __MONO_SGEN_GRAY_FORWARD_H__
+#define __MONO_SGEN_GRAY_FORWARD_H__
+
+struct _GrayQueueEntry;
+typedef struct _GrayQueueEntry GrayQueueEntry;
+
+struct _GrayQueueSection;
+typedef struct _GrayQueueSection GrayQueueSection;
+
+struct _SgenGrayQueue;
+typedef struct _SgenGrayQueue SgenGrayQueue;
+
+struct _SgenSectionGrayQueue;
+typedef struct _SgenSectionGrayQueue SgenSectionGrayQueue;
+
+#endif /* __MONO_SGEN_GRAY_FORWARD_H__ */

--- a/mono/sgen/sgen-gray.c
+++ b/mono/sgen/sgen-gray.c
@@ -22,6 +22,7 @@
 #ifdef HAVE_SGEN_GC
 
 #include "mono/sgen/sgen-gc.h"
+#include "mono/sgen/sgen-gray.h"
 #include "mono/sgen/sgen-protocol.h"
 
 #ifdef HEAVY_STATISTICS

--- a/mono/sgen/sgen-gray.h
+++ b/mono/sgen/sgen-gray.h
@@ -20,6 +20,7 @@
 #ifndef __MONO_SGEN_GRAY_H__
 #define __MONO_SGEN_GRAY_H__
 
+#include "mono/sgen/sgen-gray-forward.h"
 #include "mono/sgen/sgen-protocol.h"
 
 /*
@@ -68,7 +69,6 @@ typedef enum {
 } GrayQueueSectionState;
 #endif
 
-typedef struct _GrayQueueEntry GrayQueueEntry;
 struct _GrayQueueEntry {
 	char *obj;
 	mword desc;
@@ -80,7 +80,6 @@ struct _GrayQueueEntry {
  * This is a stack now instead of a queue, so the most recently added items are removed
  * first, improving cache locality, and keeping the stack size manageable.
  */
-typedef struct _GrayQueueSection GrayQueueSection;
 struct _GrayQueueSection {
 #ifdef SGEN_CHECK_GRAY_OBJECT_SECTIONS
 	/*
@@ -95,8 +94,6 @@ struct _GrayQueueSection {
 	GrayQueueEntry entries [SGEN_GRAY_QUEUE_SECTION_SIZE];
 };
 
-typedef struct _SgenGrayQueue SgenGrayQueue;
-
 typedef void (*GrayQueueAllocPrepareFunc) (SgenGrayQueue*);
 typedef void (*GrayQueueEnqueueCheckFunc) (char*);
 
@@ -110,8 +107,6 @@ struct _SgenGrayQueue {
 #endif
 	void *alloc_prepare_data;
 };
-
-typedef struct _SgenSectionGrayQueue SgenSectionGrayQueue;
 
 struct _SgenSectionGrayQueue {
 	GrayQueueSection *first;

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -40,6 +40,7 @@
 #include "mono/sgen/sgen-cardtable.h"
 #include "mono/sgen/sgen-memory-governor.h"
 #include "mono/sgen/sgen-client.h"
+#include "mono/utils/atomic.h"
 
 #define LOS_SECTION_SIZE	(1024 * 1024)
 

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -25,12 +25,8 @@
 
 #ifdef HAVE_SGEN_GC
 
-#include <math.h>
-#include <errno.h>
-#include <string.h>
-#include <stdlib.h>
-
 #include "mono/sgen/sgen-gc.h"
+#include "mono/sgen/sgen-gray.h"
 #include "mono/sgen/sgen-protocol.h"
 #include "mono/sgen/sgen-cardtable.h"
 #include "mono/sgen/sgen-memory-governor.h"
@@ -40,7 +36,13 @@
 #include "mono/sgen/sgen-workers.h"
 #include "mono/sgen/sgen-thread-pool.h"
 #include "mono/sgen/sgen-client.h"
+#include "mono/utils/atomic.h"
 #include "mono/utils/mono-membar.h"
+
+#include <math.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
 
 #if defined(ARCH_MIN_MS_BLOCK_SIZE) && defined(ARCH_MIN_MS_BLOCK_SIZE_SHIFT)
 #define MS_BLOCK_SIZE	ARCH_MIN_MS_BLOCK_SIZE

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -33,6 +33,7 @@
 #include "mono/sgen/sgen-memory-governor.h"
 #include "mono/sgen/sgen-thread-pool.h"
 #include "mono/sgen/sgen-client.h"
+#include "mono/utils/atomic.h"
 
 #define MIN_MINOR_COLLECTION_ALLOWANCE	((mword)(DEFAULT_NURSERY_SIZE * default_allowance_nursery_size_ratio))
 

--- a/mono/sgen/sgen-nursery-allocator.c
+++ b/mono/sgen/sgen-nursery-allocator.c
@@ -60,11 +60,13 @@
 #endif
 
 #include "mono/sgen/sgen-gc.h"
+#include "mono/sgen/sgen-gray.h"
 #include "mono/sgen/sgen-cardtable.h"
 #include "mono/sgen/sgen-protocol.h"
 #include "mono/sgen/sgen-memory-governor.h"
 #include "mono/sgen/sgen-pinning.h"
 #include "mono/sgen/sgen-client.h"
+#include "mono/utils/atomic.h"
 #include "mono/utils/mono-membar.h"
 
 /* Enable it so nursery allocation diagnostic data is collected */

--- a/mono/sgen/sgen-protocol.c
+++ b/mono/sgen/sgen-protocol.c
@@ -29,6 +29,7 @@
 #include "sgen-memory-governor.h"
 #include "sgen-thread-pool.h"
 #include "sgen-client.h"
+#include "mono/utils/atomic.h"
 #include "mono/utils/mono-membar.h"
 
 #include <errno.h>

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -25,8 +25,10 @@
 #include <string.h>
 
 #include "mono/sgen/sgen-gc.h"
+#include "mono/sgen/sgen-gray.h"
 #include "mono/sgen/sgen-workers.h"
 #include "mono/sgen/sgen-thread-pool.h"
+#include "mono/utils/atomic.h"
 #include "mono/utils/mono-membar.h"
 #include "mono/sgen/sgen-client.h"
 

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -70,6 +70,7 @@ monoutils_sources = \
 	mono-error.c	\
 	mono-error-internals.h	\
 	monobitset.h	\
+	monobitset-forward.h	\
 	mono-codeman.h	\
 	mono-counters.h	\
 	mono-digest.h	\
@@ -110,6 +111,7 @@ monoutils_sources = \
 	mono-threads-openbsd.c	\
 	mono-threads-android.c	\
 	mono-threads.h	\
+	mono-threads-forward.h	\
 	mono-threads-coop.c	\
 	mono-threads-coop.h	\
 	mono-tls.h	\

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -74,6 +74,7 @@ monoutils_sources = \
 	mono-counters.h	\
 	mono-digest.h	\
 	mono-error.h	\
+	mono-error-forward.h	\
 	mono-machine.h	\
 	mono-math.h	\
 	mono-membar.h	\

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -279,5 +279,18 @@ typedef SSIZE_T ssize_t;
 #define MONO_COLD
 #endif
 
+/*
+ * When embedding, you have to define MONO_ZERO_LEN_ARRAY before including any
+ * other Mono header file if you use a different compiler from the one used to
+ * build Mono.
+ */
+#ifndef MONO_ZERO_LEN_ARRAY
+#ifdef __GNUC__
+#define MONO_ZERO_LEN_ARRAY 0
+#else
+#define MONO_ZERO_LEN_ARRAY 1
+#endif
+#endif
+
 #endif /* __UTILS_MONO_COMPILER_H__*/
 

--- a/mono/utils/mono-error-forward.h
+++ b/mono/utils/mono-error-forward.h
@@ -1,0 +1,7 @@
+#ifndef __MONO_ERROR_FORWARD_H__
+#define __MONO_ERROR_FORWARD_H__
+
+struct _MonoError;
+typedef struct _MonoError MonoError;
+
+#endif /* __MONO_ERROR_FORWARD_H__ */

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -2,7 +2,9 @@
 #define __MONO_ERROR_INTERNALS_H__
 
 #include "mono/utils/mono-compiler.h"
-#include "mono/metadata/object-internals.h"
+#include "mono/metadata/class-internals-forward.h"
+#include "mono/metadata/object-internals-forward.h"
+#include "mono/metadata/metadata-internals-forward.h"
 
 /*Keep in sync with MonoError*/
 typedef struct {

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -1,6 +1,7 @@
 #ifndef __MONO_ERROR_H__
 #define __MONO_ERROR_H__
 
+#include <mono/utils/mono-error-forward.h>
 #include <mono/utils/mono-publib.h>
 
 enum {
@@ -33,13 +34,13 @@ enum {
 };
 
 /*Keep in sync with MonoErrorInternal*/
-typedef struct _MonoError {
+struct _MonoError {
 	unsigned short error_code;
     unsigned short hidden_0; /*DON'T TOUCH */
 
 	void *hidden_1 [12]; /*DON'T TOUCH */
     char hidden_2 [128]; /*DON'T TOUCH */
-} MonoError;
+};
 
 MONO_BEGIN_DECLS
 

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -73,6 +73,19 @@ MONO_API void mono_free (void *);
 
 #define MONO_CONST_RETURN const
 
+/*
+ * When embedding, you have to define MONO_ZERO_LEN_ARRAY before including any
+ * other Mono header file if you use a different compiler from the one used to
+ * build Mono.
+ */
+#ifndef MONO_ZERO_LEN_ARRAY
+#ifdef __GNUC__
+#define MONO_ZERO_LEN_ARRAY 0
+#else
+#define MONO_ZERO_LEN_ARRAY 1
+#endif
+#endif
+
 MONO_END_DECLS
 
 #endif /* __MONO_PUBLIB_H__ */

--- a/mono/utils/mono-threads-forward.h
+++ b/mono/utils/mono-threads-forward.h
@@ -1,0 +1,8 @@
+#ifndef __MONO_THREADS_FORWARD_H__
+#define __MONO_THREADS_FORWARD_H__
+
+struct _MonoThreadInfo;
+
+typedef struct _MonoThreadInfo MonoThreadInfo;
+
+#endif /* __MONO_THREADS_FORWARD_H__ */

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -16,6 +16,7 @@
 #include <mono/utils/mono-mutex.h>
 #include <mono/utils/mono-tls.h>
 #include <mono/utils/mono-threads-coop.h>
+#include <mono/utils/mono-threads-forward.h>
 
 #include <glib.h>
 #include <config.h>
@@ -170,7 +171,7 @@ typedef enum {
 	MONO_SERVICE_REQUEST_SAMPLE = 1,
 } MonoAsyncJob;
 
-typedef struct {
+struct _MonoThreadInfo {
 	MonoLinkedListSetNode node;
 	guint32 small_id; /*Used by hazard pointers */
 	MonoNativeThreadHandle native_handle; /* Valid on mach and android */
@@ -243,7 +244,7 @@ typedef struct {
 	volatile gint32 service_requests;
 
 	void *jit_data;
-} MonoThreadInfo;
+};
 
 typedef struct {
 	void* (*thread_register)(THREAD_INFO_TYPE *info, void *baseaddr);

--- a/mono/utils/monobitset-forward.h
+++ b/mono/utils/monobitset-forward.h
@@ -1,0 +1,7 @@
+#ifndef __MONO_BITSET_FORWARD_H__
+#define __MONO_BITSET_FORWARD_H__
+
+struct _MonoBitSet;
+typedef struct _MonoBitSet MonoBitSet;
+
+#endif /* __MONO_BITSET_FORWARD_H__ */

--- a/mono/utils/monobitset.h
+++ b/mono/utils/monobitset.h
@@ -9,6 +9,8 @@
 #include <mono/utils/mono-publib.h>
 #endif
 
+#include <mono/utils/monobitset-forward.h>
+
 /*
  * When embedding, you have to define MONO_ZERO_LEN_ARRAY before including any
  * other Mono header file if you use a different compiler from the one used to
@@ -24,11 +26,11 @@
 
 #define MONO_BITSET_BITS_PER_CHUNK (8 * sizeof (gsize))
 
-typedef struct {
+struct _MonoBitSet {
 	gsize size;
 	gsize flags;
 	gsize data [MONO_ZERO_LEN_ARRAY];
-} MonoBitSet;
+};
 
 typedef void (*MonoBitSetFunc) (guint idx, gpointer data);
 

--- a/mono/utils/monobitset.h
+++ b/mono/utils/monobitset.h
@@ -11,19 +11,6 @@
 
 #include <mono/utils/monobitset-forward.h>
 
-/*
- * When embedding, you have to define MONO_ZERO_LEN_ARRAY before including any
- * other Mono header file if you use a different compiler from the one used to
- * build Mono.
- */
-#ifndef MONO_ZERO_LEN_ARRAY
-#ifdef __GNUC__
-#define MONO_ZERO_LEN_ARRAY 0
-#else
-#define MONO_ZERO_LEN_ARRAY 1
-#endif
-#endif
-
 #define MONO_BITSET_BITS_PER_CHUNK (8 * sizeof (gsize))
 
 struct _MonoBitSet {


### PR DESCRIPTION
WIP/RFC. This attempts to speed up compilations in a couple of ways:
- It introduces forward-declaration headers to avoid reincluding large headers, while also avoiding redeclaration of typedefs, a C11 feature. Doing this forces more source files to include what they use.
- It builds the subdirectories of `mono` concurrently, and makes the dependencies between those subdirectories explicit.
