### PR TITLE
[corlib] Tweak the fix for the reference sources' inability to support sub-minute DST offsets.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1298,8 +1298,10 @@ namespace System
 					if (dstDelta.TotalSeconds != ttype.Offset - baseUtcOffset.TotalSeconds) {
 						// Round to nearest minute, since it's not possible to create an adjustment rule
 						// with sub-minute precision ("The TimeSpan parameter cannot be specified more precisely than whole minutes.")
-						// This happens with Europe/Dublin, which had an offset of 34 minutes and 39 seconds in 1916.
-						dstDelta = new TimeSpan (0, 0, ttype.Offset - ttype.Offset % 60) - baseUtcOffset;
+						// This happens for instance with Europe/Dublin, which had an offset of 34 minutes and 39 seconds in 1916.
+						dstDelta = new TimeSpan (0, 0, ttype.Offset) - baseUtcOffset;
+						if (dstDelta.Ticks % TimeSpan.TicksPerMinute != 0)
+							dstDelta = TimeSpan.FromMinutes ((long) (dstDelta.TotalMinutes + 0.5f));
 					}
 
 					dst_start = ttime;

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -804,14 +804,30 @@ namespace MonoTests.System
 		#endif
 
 			[Test]
-			public void Dublin ()
+			public void SubminuteDSTOffsets ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)
 					Assert.Ignore ();
-				// Europe/Dublin has a DST offset of 34 minutes and 39 seconds in 1916.
-				TimeZoneInfo.FindSystemTimeZoneById ("Europe/Dublin");
-			}
 
+				var subMinuteDSTs = new string [] {
+					"Europe/Dublin", // Europe/Dublin has a DST offset of 34 minutes and 39 seconds in 1916.
+					"Europe/Amsterdam",
+					"America/St_Johns",
+					"Canada/Newfoundland",
+					"Europe/Moscow",
+					"Europe/Riga",
+					"N/A", // testing that the test doesn't fail with inexistent TZs
+				};
+				foreach (var tz in subMinuteDSTs) {
+					try {
+						TimeZoneInfo.FindSystemTimeZoneById (tz);
+					} catch (TimeZoneNotFoundException) {
+						// ok;
+					} catch (Exception ex) {
+						Assert.Fail (string.Format ("Failed to load TZ {0}: {1}", tz, ex.ToString ()));
+					}
+				}
+			}
 		}
 		
 		[TestFixture]


### PR DESCRIPTION
It seems the base utc offset can also have a sub-minute resolution
in Unix, which means we need to apply the whole-minute rounding to
the final result (dstDelta) instead of the intermediate ttype.Offset
value.

We need to try to fetch the exact timezone id to expose this bug,
since fetching all system timezones will just not return any
problematic timezones (and there is thus no way to distinguish
inexistent timezones from timezones that failed to load).