### PR TITLE
Revert "Fix XAttribute.ToString method (Xamarin-29935)"

### DIFF
--- a/mcs/class/System.Xml.Linq/Test/System.Xml.Linq/XAttributeTest.cs
+++ b/mcs/class/System.Xml.Linq/Test/System.Xml.Linq/XAttributeTest.cs
@@ -206,14 +206,6 @@ namespace MonoTests.System.Xml.Linq
 		}
 
 		[Test]
-		public void ToString_Xamarin29935 ()
-		{
-			var doc = XDocument.Parse ("<?xml version='1.0' encoding='utf-8'?><lift xmlns:test='http://test.example.com'></lift>");
-			Assert.AreEqual ("xmlns:test=\"http://test.example.com\"",
-				doc.Root.Attributes ().Select (s => s.ToString ()).First ());
-		}
-
-		[Test]
 		public void DateTimeAttribute ()
 		{
 			var date = DateTime.Now;


### PR DESCRIPTION
Reverts mono/mono#1787

There was some communication problems between us. We're close from shipping 4.0.1 and this came too late to be included. We'll apply it again on 4.0.2.