### PR TITLE
[RFC] Add timeout feature for test suite

### DIFF
--- a/mcs/build/config-default.make
+++ b/mcs/build/config-default.make
@@ -23,7 +23,7 @@ mono_libdir = $(exec_prefix)/lib
 sysconfdir = $(prefix)/etc
 #RUNTIME = mono
 RUNTIME = false
-TEST_RUNTIME = MONO_PATH="$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$(TEST_MONO_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) --debug
+TEST_RUNTIME = MONO_PATH="$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$(TEST_MONO_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(TEST_RUNTIME_PRECOMMAND) $(RUNTIME) --debug
 
 # In case you want to add MCS_FLAGS, this lets you not have to
 # keep track of the default value

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -81,11 +81,15 @@ ifdef TESTNAME
 TESTNAME_ARG = -run=MonoTests.$(TESTNAME)
 endif
 
+ifdef TEST_TIMEOUT
+TEST_RUNTIME_PRECOMMAND = timeout --foreground $(TEST_TIMEOUT)
+endif
+
 ## FIXME: i18n problem in the 'sed' command below
 run-test-lib: test-local
 	ok=:; \
-	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(TEST_HARNESS) $(test_assemblies) -noshadow $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) -xml=TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
-	if [ ! -f "TestResult-$(PROFILE).xml" ]; then echo "<?xml version='1.0' encoding='utf8'?><test-results failures='1' total='1' not-run='0' name='bcl-tests' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='$(strip $(test_assemblies))' success='False' time='0'><results><test-case name='crash' executed='True' success='False' time='0'><failure><message>The test runner didn't produce a test result XML, probably due to a crash of the runtime. Check the log for more details.</message><stack-trace></stack-trace></failure></test-case></results></test-suite></test-results>" > TestResult-$(PROFILE).xml; fi; \
+	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(TEST_HARNESS) $(test_assemblies) -noshadow $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) -xml=TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| echo "Command failed with error $$?"; ok=false; \
+	if [ ! -f "TestResult-$(PROFILE).xml" ]; then echo "<?xml version='1.0' encoding='utf8'?><test-results failures='1' total='1' not-run='0' name='bcl-tests' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='$(strip $(test_assemblies))' success='False' time='0'><results><test-case name='crash' executed='True' success='False' time='0'><failure><message>The test runner didn't produce a test result XML, probably due to a crash of the runtime or a timeout. Check the log for more details.</message><stack-trace></stack-trace></failure></test-case></results></test-suite></test-results>" > TestResult-$(PROFILE).xml; fi; \
 	$(TEST_HARNESS_POSTPROC) ; $$ok
 
 ## Instructs compiler to compile to target .net execution, it can be usefull in rare cases when runtime detection is not possible


### PR DESCRIPTION
If TEST_TIMEOUT is set to a value (e.g. 300s), the test suite will be aborted when a timeout occurs.

Right now, the System testsuite hangs on Linux / Jenkins. Since this testsuite runs pretty early on, we get very limited test results as Jenkins aborts the whole job after a while.

With this feature we could set TEST_TIMEOUT on Jenkins to an appropriate value and get results from  the other testsuites as only the problematic one would be aborted.

RFC: what do you think?