### PR TITLE
[runtime] Avoid allocating interface offsets multiple times. Fixes #28398

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3621,8 +3621,9 @@ setup_interface_offsets (MonoClass *class, int cur_slot, gboolean overwrite)
 	 * mono_class_setup_interface_offsets () passes 0 as CUR_SLOT, so the computed interface offsets will be invalid. This
 	 * means we have to overwrite those when called from other places (#4440).
 	 */
-	if (class->interfaces_packed && !overwrite) {
-		g_assert (class->interface_offsets_count == interface_offsets_count);
+	if (class->interfaces_packed) {
+		if (!overwrite)
+			g_assert (class->interface_offsets_count == interface_offsets_count);
 	} else {
 		uint8_t *bitmap;
 		int bsize;


### PR DESCRIPTION
setup_interface_offsets will be called multiple times. The code was originally
designed to avoid setting up this multiple times but a change to avoid making it assert
when used from SRE made it so that the check to avoid multiple initialization would
effectively make it be initialized multiple times.

See 628e025476f1e8781502eb9ee44bc94911229c36 for the original change.