### PR TITLE
[System.Web] Added missing methods for default VS2013 MVC template

### DIFF
--- a/mcs/class/System.Web.Routing/System.Web.Routing/RouteCollection.cs
+++ b/mcs/class/System.Web.Routing/System.Web.Routing/RouteCollection.cs
@@ -92,6 +92,8 @@ namespace System.Web.Routing
 			}
 		}
 
+		public bool LowercaseUrls { get; set; }
+		public bool AppendTrailingSlash { get; set; }
 		public bool RouteExistingFiles { get; set; }
 
 		public void Add (string name, RouteBase item)

--- a/mcs/class/System.Web/System.Web.Configuration_2.0/HttpRuntimeSection.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/HttpRuntimeSection.cs
@@ -63,6 +63,7 @@ namespace System.Web.Configuration
 		static ConfigurationProperty encoderTypeProp;
 		static ConfigurationProperty relaxedUrlToFileSystemMappingProp;
 		static ConfigurationProperty targetFrameworkProp;
+		static ConfigurationProperty allowDynamicModuleRegistrationProp;
 		static ConfigurationPropertyCollection properties;
 
 		static HttpRuntimeSection ()
@@ -141,6 +142,8 @@ namespace System.Web.Configuration
 										PropertyHelper.VersionConverter,
 										PropertyHelper.DefaultValidator,
 										ConfigurationPropertyOptions.None);
+			allowDynamicModuleRegistrationProp = new ConfigurationProperty ("allowDynamicModuleRegistration", typeof(bool), true,
+										ConfigurationPropertyOptions.None);
 			
 			properties = new ConfigurationPropertyCollection();
 			properties.Add (apartmentThreadingProp);
@@ -169,6 +172,7 @@ namespace System.Web.Configuration
 			properties.Add (encoderTypeProp);
 			properties.Add (relaxedUrlToFileSystemMappingProp);
 			properties.Add (targetFrameworkProp);
+			properties.Add (allowDynamicModuleRegistrationProp);
 		}
 
 		public HttpRuntimeSection()
@@ -348,6 +352,11 @@ namespace System.Web.Configuration
 		}
 		protected internal override ConfigurationPropertyCollection Properties {
 			get { return properties; }
+		}
+		[ConfigurationProperty ("allowDynamicModuleRegistration", DefaultValue = "True")]
+		public bool AllowDynamicModuleRegistration {
+			get { return (bool) base [allowDynamicModuleRegistrationProp]; }
+			set { base [allowDynamicModuleRegistrationProp] = value; }
 		}
 	}
 }

--- a/mcs/class/System.Web/System.Web.Hosting/HostingEnvironment.cs
+++ b/mcs/class/System.Web/System.Web.Hosting/HostingEnvironment.cs
@@ -104,6 +104,13 @@ namespace System.Web.Hosting {
 			get { return vpath_provider; }
 		}
 
+		public static bool InClientBuildManager {
+			get {
+				// Mono doesn't have a ClientBuildManager, so we can't be in it. Simple as that.
+				return false;
+			}
+		}
+
 		public static void DecrementBusyCount ()
 		{
 			Interlocked.Decrement (ref busy_count);

--- a/mcs/class/System.Web/System.Web/DynamicModuleManager.cs
+++ b/mcs/class/System.Web/System.Web/DynamicModuleManager.cs
@@ -1,0 +1,57 @@
+//
+// DynamicModuleManager.cs: Manager for dynamic Http Modules.
+//
+// Author:
+//   Matthias Bogad (bogad@cs.tum.edu)
+//
+// (C) 2015
+//
+
+using System;
+using System.Collections.Generic;
+
+namespace System.Web {
+	sealed class DynamicModuleManager {
+		const string moduleNameFormat = "__Module__{0}_{1}";
+	
+		readonly List<DynamicModuleInfo> entries = new List<DynamicModuleInfo> ();
+		bool entriesAreReadOnly = false;
+		readonly object mutex = new object ();
+		
+		public void Add (Type moduleType) 
+		{
+			if (moduleType == null)
+				throw new ArgumentException ("moduleType");
+			
+			if (!typeof (IHttpModule).IsAssignableFrom (moduleType))
+				throw new ArgumentException ("Given object does not implement IHttpModule.", "moduleType");
+			
+			lock (mutex) {
+				if (entriesAreReadOnly)
+					throw new InvalidOperationException ("A module was to be added to the dynamic module list, but the list was already initialized. The dynamic module list can only be initialized once.");
+
+				entries.Add (new DynamicModuleInfo (moduleType,
+							string.Format (moduleNameFormat, moduleType.AssemblyQualifiedName, Guid.NewGuid ())));
+			}
+		}
+		
+		public ICollection<DynamicModuleInfo> LockAndGetModules ()
+		{
+			lock (mutex) {
+				entriesAreReadOnly = true;
+				return entries;
+			}
+		}
+	}
+
+	struct DynamicModuleInfo {
+		public readonly string Name;
+		public readonly Type Type;
+
+		public DynamicModuleInfo (Type type, string name)
+		{
+			Name = name;
+			Type = type;
+		}
+	}
+}

--- a/mcs/class/System.Web/net_4_5_System.Web.dll.sources
+++ b/mcs/class/System.Web/net_4_5_System.Web.dll.sources
@@ -10,3 +10,4 @@ System.Web/UnvalidatedRequestValuesWrapper.cs
 System.Web/TaskAsyncResult.cs
 System.Web/TaskEventHandler.cs
 System.Web.Security/MembershipPasswordAttribute.cs
+System.Web/DynamicModuleManager.cs


### PR DESCRIPTION
I have added System.HttpApplication.RegisterModule(), the missing two properties of the System.Web.Routing.RouteCollection as well as the corresponding property in the HttpRuntimeSection to completely turn this off. Microsofts MIT-Licensed counterparts of the official System.Web assembly from github [0] were used as a reference. It is kind-of bolted on, but should be good enough until the whole open-sourced System.Web is incorporated. This enables the default asp.net mvc template from Visual Studio 2013 to be executed with mono.

[0]: http://github.com/Microsoft/referencesource/