### PR TITLE
Fixed process model reference on FreeBSD 10.1

### DIFF
--- a/eglib/src/gunicode.c
+++ b/eglib/src/gunicode.c
@@ -217,8 +217,17 @@ g_get_charset (G_CONST_RETURN char **charset)
 		sprintf (buf, "CP%u", GetACP ());
 		my_charset = buf;
 		is_utf8 = FALSE;
+#elif defined(__FreeBSD__)
+
+#if defined(HAVE_LANGINFO_H)
+                my_charset = nl_langinfo (CODESET);
+#elif defined(HAVE_LOCALCHARSET_H)
+		my_charset = locale_charset ();
 #else
+                my_charset = "UTF-8";
+#endif
 		/* These shouldn't be heap allocated */
+#else
 #if HAVE_LOCALCHARSET_H
 		my_charset = locale_charset ();
 #elif defined(HAVE_LANGINFO_H)

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -309,7 +309,13 @@ mono_process_get_times (gpointer pid, gint64 *start_time, gint64 *user_time, gin
 			KINFO_PROC processi;
 
 			if (sysctl_kinfo_proc (pid, &processi))
+			#if defined(__FreeBSD__)
+				/* BSD process model: */
+				*start_time = mono_100ns_datetime_from_timeval (processi.ki_start);
+			#else
+				/* Mach process model: */
 				*start_time = mono_100ns_datetime_from_timeval (processi.kp_proc.p_starttime);
+			#endif
 		}
 #endif
 


### PR DESCRIPTION
Build on FreeBSD 10.1 yields the following error:

mono-proclib.c:312:61: error: 'struct kinfo_proc' has no member named 'kp_proc'
*start_time = mono_100ns_datetime_from_timeval (processi.kp_proc.p_starttime);

kp_proc is from the Mach kernel and does not work for the FreeBSD kernel.
