### PR TITLE
[corlib] Fixed TimeZoneInfo.GetDaylightChanges.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -892,24 +892,17 @@ namespace System
 					DateTime ttime = pair.Key;
 					TimeType ttype = pair.Value;
 
+					if (ttime.Year > year)
+						continue;
+					if (ttime.Year < year)
+						break;
+
 					if (ttype.IsDst) {
 						// DaylightTime.Delta is relative to the current BaseUtcOffset.
-						var d =  new TimeSpan (0, 0, ttype.Offset) - BaseUtcOffset;
-						// Handle DST gradients
-						if (start != DateTime.MinValue && delta != d)
-							end = start;
-
+						delta =  new TimeSpan (0, 0, ttype.Offset) - BaseUtcOffset;
 						start = ttime;
-						delta = d;
-
-						if (ttime.Year <= year)
-							break;
 					} else {
-						if (ttime.Year < year)
-							break;
-
 						end = ttime;
-						start = DateTime.MinValue;
 					}
 				}
 
@@ -918,22 +911,26 @@ namespace System
 					start += BaseUtcOffset;
 
 				// DaylightTime.End is relative to the DST time.
-				if (end != DateTime.MaxValue)
+				if (end != DateTime.MinValue)
 					end += BaseUtcOffset + delta;
 			} else {
-				AdjustmentRule rule = null;
-				foreach (var r in GetAdjustmentRules ()) {
-					if (r.DateEnd.Year < year)
+				AdjustmentRule first = null, last = null;
+
+				foreach (var rule in GetAdjustmentRules ()) {
+					if (rule.DateStart.Year != year && rule.DateEnd.Year != year)
 						continue;
-					if (r.DateStart.Year > year)
-						break;
-					rule = r;
+					if (rule.DateStart.Year == year)
+						first = rule;
+					if (rule.DateEnd.Year == year)
+						last = rule;
 				}
-				if (rule != null) {
-					start = TransitionPoint (rule.DaylightTransitionStart, year);
-					end = TransitionPoint (rule.DaylightTransitionEnd, year);
-					delta = rule.DaylightDelta;
-				}
+
+				if (first == null || last == null)
+					return new DaylightTime (new DateTime (), new DateTime (), new TimeSpan ());
+
+				start = TransitionPoint (first.DaylightTransitionStart, year);
+				end = TransitionPoint (last.DaylightTransitionEnd, year);
+				delta = first.DaylightDelta;
 			}
 
 			if (start == DateTime.MinValue || end == DateTime.MinValue)

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -30,6 +30,8 @@ using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Collections;
+using System.Reflection;
+using System.Globalization;
 
 using NUnit.Framework;
 namespace MonoTests.System
@@ -1024,6 +1026,35 @@ namespace MonoTests.System
 				Assert.AreEqual(dstUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,0,0,-1))));
 				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d));
 				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,0,0, 1))));
+			}
+		}
+
+		[TestFixture]
+		public class GetDaylightChanges
+		{
+			MethodInfo getChanges;
+
+			[SetUp]
+			public void Setup ()
+			{
+				var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+				getChanges = typeof (TimeZoneInfo).GetMethod ("GetDaylightChanges", flags);
+			}
+
+			[Test]
+			public void TestSydneyDaylightChanges ()
+			{
+				TimeZoneInfo tz;
+				if (Environment.OSVersion.Platform == PlatformID.Unix)
+					tz = TimeZoneInfo.FindSystemTimeZoneById ("Australia/Sydney");
+				else
+					tz = TimeZoneInfo.FindSystemTimeZoneById ("W. Australia Standard Time");
+
+				var changes = (DaylightTime) getChanges.Invoke (tz, new object [] {2014});
+
+				Assert.AreEqual (new TimeSpan (1, 0, 0), changes.Delta);
+				Assert.AreEqual (new DateTime (2014, 10, 5, 2, 0, 0), changes.Start);
+				Assert.AreEqual (new DateTime (2014, 4, 6, 3, 0, 0), changes.End);
 			}
 		}
 	}


### PR DESCRIPTION
Changed GetDaylightChanges to match .NET behaviour.

GetDaylightChanges now only returns DaylightTime.Start and
DaylightTime.End in the given year.

DaylightTime.Start and DaylightTime.End may not belong to the same DST
period.