### PR TITLE
[runtime] Remove a test that leads to excessive heap thrashing and interferes with other tests.

### DIFF
--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -842,23 +842,6 @@ namespace MonoTests.System.Diagnostics
 			return RunningOnUnix ? new ProcessStartInfo ("/bin/ls", "/") : new ProcessStartInfo ("help", "");
 		}
 
-		[Test] // Covers #26362
-		public void TestExitedEvent ()
-		{
-			var falseExitedEvents = 0;
-			var cp = Process.GetCurrentProcess ();
-			foreach (var p in Process.GetProcesses ()) {
-				if (p.Id != cp.Id && !p.HasExited) {
-					p.EnableRaisingEvents = true;
-					p.Exited += (s, e) => {
-						if (!p.HasExited)
-							falseExitedEvents++;
-					};
-				}
-			}
-			Assert.AreEqual (0, falseExitedEvents);
-		}
-		
 		[Test]
 		public void ProcessName_NotStarted ()
 		{


### PR DESCRIPTION
This test was the bug reproduction for bug #26362 https://github.com/mono/mono/commit/e097a98f3bd9082c7d03fa580b604c0228b4ad67.

The problem with this test is that
* It sets a callback on the exit of on `every` process on the running OS. Don't run this on big iron.
* It doesn't wait around to ensure that any of the callbacks are actually run, meaning that it's check is basically a NOP

This is being removed because it causes such heap thrashing that sgen's signals are starving out our system calls on public jenkins tests. 

If you need to re-enable this test for some reason, rewrite it.