### PR TITLE
Prevent DataGridViewTextBoxCell from using Disposed editor object

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewTextBoxCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewTextBoxCell.cs
@@ -90,7 +90,7 @@ namespace System.Windows.Forms {
 				throw new InvalidOperationException("There is no associated DataGridView.");
 			}
 
-			if (editingControl == null)
+			if (editingControl == null || editingControl.IsDisposed)
 				CreateEditingControl ();
 
 			DataGridView.EditingControlInternal = editingControl;


### PR DESCRIPTION
This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=30325.