### PR TITLE
Fix reading back a HTTP Request's Host header

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http-tests-net_4_5.csproj
+++ b/mcs/class/System.Net.Http/System.Net.Http-tests-net_4_5.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Test\System.Net.Http.Headers\EntityTagHeaderValueTest.cs" />
     <Compile Include="Test\System.Net.Http.Headers\HttpHeadersTest.cs" />
     <Compile Include="Test\System.Net.Http.Headers\HttpHeaderValueCollection.cs" />
+    <Compile Include="Test\System.Net.Http.Headers\HttpRequestHeadersTest.cs" />
     <Compile Include="Test\System.Net.Http.Headers\MediaTypeHeaderValueTest.cs" />
     <Compile Include="Test\System.Net.Http.Headers\MediaTypeWithQualityHeaderValueTest.cs" />
     <Compile Include="Test\System.Net.Http.Headers\NameValueHeaderValueTest.cs" />

--- a/mcs/class/System.Net.Http/System.Net.Http.Headers/HttpHeaders.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http.Headers/HttpHeaders.cs
@@ -109,7 +109,7 @@ namespace System.Net.Http.Headers
 				HeaderInfo.CreateMulti<NameValueWithParametersHeaderValue> ("Expect", NameValueWithParametersHeaderValue.TryParse, HttpHeaderKind.Request),
 				HeaderInfo.CreateSingle<DateTimeOffset> ("Expires", Parser.DateTime.TryParse, HttpHeaderKind.Content),
 				HeaderInfo.CreateSingle<string> ("From", Parser.EmailAddress.TryParse, HttpHeaderKind.Request),
-				HeaderInfo.CreateSingle<Uri> ("Host", Parser.Uri.TryParse, HttpHeaderKind.Request),
+				HeaderInfo.CreateSingle<string> ("Host", Parser.Host.TryParse, HttpHeaderKind.Request),
 				HeaderInfo.CreateMulti<EntityTagHeaderValue> ("If-Match", EntityTagHeaderValue.TryParse, HttpHeaderKind.Request),
 				HeaderInfo.CreateSingle<DateTimeOffset> ("If-Modified-Since", Parser.DateTime.TryParse, HttpHeaderKind.Request),
 				HeaderInfo.CreateMulti<EntityTagHeaderValue> ("If-None-Match", EntityTagHeaderValue.TryParse, HttpHeaderKind.Request),

--- a/mcs/class/System.Net.Http/System.Net.Http.Headers/Parser.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http.Headers/Parser.cs
@@ -125,6 +125,17 @@ namespace System.Net.Http.Headers
 			}
 		}
 
+		public static class Host
+		{
+			public static bool TryParse (string input, out string result)
+			{
+				result = input;
+
+				System.Uri dummy;
+				return System.Uri.TryCreate ("http://u@" + input + "/", UriKind.Absolute, out dummy);
+			}
+		}
+
 		public static class Int
 		{
 			public static bool TryParse (string input, out int result)

--- a/mcs/class/System.Net.Http/System.Net.Http_test.dll.sources
+++ b/mcs/class/System.Net.Http/System.Net.Http_test.dll.sources
@@ -17,6 +17,7 @@ System.Net.Http.Headers/ContentRangeHeaderValueTest.cs
 System.Net.Http.Headers/EntityTagHeaderValueTest.cs
 System.Net.Http.Headers/HttpHeadersTest.cs
 System.Net.Http.Headers/HttpHeaderValueCollection.cs
+System.Net.Http.Headers/HttpRequestHeadersTest.cs
 System.Net.Http.Headers/MediaTypeHeaderValueTest.cs
 System.Net.Http.Headers/MediaTypeWithQualityHeaderValueTest.cs
 System.Net.Http.Headers/NameValueHeaderValueTest.cs

--- a/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpRequestHeadersTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/HttpRequestHeadersTest.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using System.Net.Http;
+
+namespace MonoTests.System.Net.Http.Headers
+{
+	[TestFixture]
+	public class HttpRequestHeadersTest
+	{
+		[Test]
+		public void AccessHostAfterAdding()
+		{
+			var requestMessage = new HttpRequestMessage ();
+			requestMessage.Headers.TryAddWithoutValidation ("Host", "MyHost:90");
+
+			Assert.AreEqual ("MyHost:90", requestMessage.Headers.Host);
+		}
+	}
+}


### PR DESCRIPTION
In tests for [aspnet/Hosting](https://github.com/aspnet/Hosting/blob/dev/src/Microsoft.AspNet.TestHost/RequestBuilder.cs#L53), the headers  of a HTTP request are set up manually using `TryAddWithoutValidation`. For `Host`, this header is internally stored as `System.Uri`, so on retrieval, the property's cast to string fails.