### PR TITLE
[corlib] AssemblyName.CultureName now matches .NET

### DIFF
--- a/mcs/class/corlib/System.Reflection/AssemblyName.cs
+++ b/mcs/class/corlib/System.Reflection/AssemblyName.cs
@@ -431,11 +431,7 @@ namespace System.Reflection {
 
 		public string CultureName {
 			get {
-				if (cultureinfo == null)
-					return null;
-				if (cultureinfo.LCID == CultureInfo.InvariantCulture.LCID)
-					return "neutral";
-				return cultureinfo.Name;
+				return (cultureinfo == null)? null : cultureinfo.Name;
 			}
 		}
 

--- a/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
@@ -1845,6 +1845,15 @@ public class AssemblyNameTest {
 		Assert.IsTrue (AssemblyName.ReferenceMatchesDefinition (an3, an4));
 		Assert.IsFalse (AssemblyName.ReferenceMatchesDefinition (an5, an6));
 	}
+
+	[Test]
+	public void CultureNameInvariant ()
+	{
+		var an = new AssemblyName ("TestDll");
+		an.CultureInfo = new CultureInfo (CultureInfo.InvariantCulture.LCID);
+
+		Assert.AreEqual ("", an.CultureName);
+	}
 }
 
 }


### PR DESCRIPTION
AssemblyName.CultureName was returning "neutral" for invariant culture
info whereas .NET returns "".

This was causing problems in Roslyn while comparing assemblies with
an empty culture name against references that would have culture name
set to "neutral".

Fixes [#30502](https://bugzilla.xamarin.com/show_bug.cgi?id=30502).