### PR TITLE
[runtime] Implement wait interrupt in thread info, instead of in the io-layer

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -800,15 +800,17 @@ namespace MonoTests.System.Threading
 		[Test]
 		public void Test_Interrupt ()
 		{
+			ManualResetEvent mre = new ManualResetEvent (false);
 			bool interruptedExceptionThrown = false;
+
 			ThreadPool.QueueUserWorkItem (Test_Interrupt_Worker, Thread.CurrentThread);
 
 			try {
 				try {
-					Thread.Sleep (3000);
+					mre.WaitOne (3000);
 				} finally {
 					try {
-						Thread.Sleep (0);
+						mre.WaitOne (0);
 					} catch (ThreadInterruptedException) {
 						Assert.Fail ("ThreadInterruptedException thrown twice");
 					}
@@ -838,11 +840,12 @@ namespace MonoTests.System.Threading
 		[Category ("NotDotNet")] // it crashes nunit.
 		public void Test_InterruptCurrentThread ()
 		{
+			ManualResetEvent mre = new ManualResetEvent (false);
 			bool interruptedExceptionThrown = false;
 
 			Thread.CurrentThread.Interrupt ();
 			try {
-				Thread.Sleep (0);
+				mre.WaitOne (0);
 				Assert.Fail ();
 			} catch (ThreadInterruptedException) {
 			}

--- a/mono/io-layer/handles-private.h
+++ b/mono/io-layer/handles-private.h
@@ -79,9 +79,7 @@ extern gboolean _wapi_handle_count_signalled_handles (guint32 numhandles,
 						      guint32 *lowest);
 extern void _wapi_handle_unlock_handles (guint32 numhandles,
 					 gpointer *handles);
-extern int _wapi_handle_wait_signal (gboolean poll);
 extern int _wapi_handle_timedwait_signal (struct timespec *timeout, gboolean poll);
-extern int _wapi_handle_wait_signal_handle (gpointer handle, gboolean alertable);
 extern int _wapi_handle_timedwait_signal_handle (gpointer handle,
 												 struct timespec *timeout, gboolean alertable, gboolean poll);
 extern gboolean _wapi_handle_get_or_set_share (guint64 device, guint64 inode,

--- a/mono/io-layer/handles-private.h
+++ b/mono/io-layer/handles-private.h
@@ -79,9 +79,8 @@ extern gboolean _wapi_handle_count_signalled_handles (guint32 numhandles,
 						      guint32 *lowest);
 extern void _wapi_handle_unlock_handles (guint32 numhandles,
 					 gpointer *handles);
-extern int _wapi_handle_timedwait_signal (struct timespec *timeout, gboolean poll);
-extern int _wapi_handle_timedwait_signal_handle (gpointer handle,
-												 struct timespec *timeout, gboolean alertable, gboolean poll);
+extern int _wapi_handle_timedwait_signal (struct timespec *timeout, gboolean poll, gboolean *alerted);
+extern int _wapi_handle_timedwait_signal_handle (gpointer handle, struct timespec *timeout, gboolean alertable, gboolean poll, gboolean *alerted);
 extern gboolean _wapi_handle_get_or_set_share (guint64 device, guint64 inode,
 					       guint32 new_sharemode,
 					       guint32 new_access,

--- a/mono/io-layer/handles.c
+++ b/mono/io-layer/handles.c
@@ -1537,21 +1537,9 @@ static int timedwait_signal_poll_cond (pthread_cond_t *cond, mono_mutex_t *mutex
 	return(ret);
 }
 
-int _wapi_handle_wait_signal (gboolean poll)
-{
-	return _wapi_handle_timedwait_signal_handle (_wapi_global_signal_handle, NULL, TRUE, poll);
-}
-
 int _wapi_handle_timedwait_signal (struct timespec *timeout, gboolean poll)
 {
 	return _wapi_handle_timedwait_signal_handle (_wapi_global_signal_handle, timeout, TRUE, poll);
-}
-
-int _wapi_handle_wait_signal_handle (gpointer handle, gboolean alertable)
-{
-	DEBUG ("%s: waiting for %p", __func__, handle);
-	
-	return _wapi_handle_timedwait_signal_handle (handle, NULL, alertable, FALSE);
 }
 
 int _wapi_handle_timedwait_signal_handle (gpointer handle,

--- a/mono/io-layer/thread-private.h
+++ b/mono/io-layer/thread-private.h
@@ -20,19 +20,10 @@
 
 extern struct _WapiHandleOps _wapi_thread_ops;
 
-#define INTERRUPTION_REQUESTED_HANDLE (gpointer)0xFFFFFFFE
-
 struct _WapiHandle_thread
 {
 	pthread_t id;
 	GPtrArray *owned_mutexes;
-	/* 
-     * Handle this thread waits on. If this is INTERRUPTION_REQUESTED_HANDLE,
-	 * it means the thread is interrupted by another thread, and shouldn't enter
-	 * a wait.
-	 * This also acts as a reference for the handle.
-	 */
-	gpointer wait_handle;
 };
 
 typedef struct _WapiHandle_thread WapiHandle_thread;

--- a/mono/io-layer/thread-private.h
+++ b/mono/io-layer/thread-private.h
@@ -37,7 +37,6 @@ struct _WapiHandle_thread
 
 typedef struct _WapiHandle_thread WapiHandle_thread;
 
-extern gboolean _wapi_thread_apc_pending (gpointer handle);
 extern gboolean _wapi_thread_cur_apc_pending (void);
 extern void _wapi_thread_own_mutex (gpointer mutex);
 extern void _wapi_thread_disown_mutex (gpointer mutex);

--- a/mono/io-layer/threads.h
+++ b/mono/io-layer/threads.h
@@ -30,14 +30,6 @@ extern gsize GetCurrentThreadId(void); /* NB return is 32bit in MS API */
 extern void Sleep(guint32 ms);
 extern guint32 SleepEx(guint32 ms, gboolean alertable);
 
-void wapi_clear_interruption (void);
-gboolean wapi_thread_set_wait_handle (gpointer handle);
-void wapi_thread_clear_wait_handle (gpointer handle);
-void wapi_self_interrupt (void);
-
-gpointer wapi_prepare_interrupt_thread (gpointer thread_handle);
-void wapi_finish_interrupt_thread (gpointer wait_handle);
-
 gpointer wapi_create_thread_handle (void);
 void wapi_thread_handle_set_exited (gpointer handle, guint32 exitstatus);
 void wapi_ref_thread_handle (gpointer handle);

--- a/mono/io-layer/wait.c
+++ b/mono/io-layer/wait.c
@@ -130,7 +130,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 
 		ret = _wapi_handle_ops_special_wait (handle, timeout, alertable);
 	
-		if (alertable && _wapi_thread_apc_pending (current_thread)) {
+		if (alertable && _wapi_thread_cur_apc_pending ()) {
 			apc_pending = TRUE;
 			ret = WAIT_IO_COMPLETION;
 		}
@@ -154,7 +154,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 		}
 	}
 	
-	if (alertable && _wapi_thread_apc_pending (current_thread)) {
+	if (alertable && _wapi_thread_cur_apc_pending ()) {
 		apc_pending = TRUE;
 		ret = WAIT_IO_COMPLETION;
 		goto done;
@@ -197,7 +197,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 		}
 	
 		if (alertable)
-			apc_pending = _wapi_thread_apc_pending (current_thread);
+			apc_pending = _wapi_thread_cur_apc_pending ();
 
 		if(waited==0 && !apc_pending) {
 			/* Condition was signalled, so hopefully
@@ -352,7 +352,7 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 		}
 	}
 	
-	if (alertable && _wapi_thread_apc_pending (current_thread)) {
+	if (alertable && _wapi_thread_cur_apc_pending ()) {
 		apc_pending = TRUE;
 		ret = WAIT_IO_COMPLETION;
 		goto done;
@@ -389,7 +389,7 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 		}
 
 		if (alertable) {
-			apc_pending = _wapi_thread_apc_pending (current_thread);
+			apc_pending = _wapi_thread_cur_apc_pending ();
 		}
 
 		if (waited==0 && !apc_pending) {
@@ -590,7 +590,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 		_wapi_calc_timeout (&abstime, timeout);
 	}
 
-	if (alertable && _wapi_thread_apc_pending (current_thread))
+	if (alertable && _wapi_thread_cur_apc_pending ())
 		return WAIT_IO_COMPLETION;
 	
 	for (i = 0; i < numobjects; i++) {
@@ -648,7 +648,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 		thr_ret = _wapi_handle_unlock_signal_mutex (NULL);
 		g_assert (thr_ret == 0);
 		
-		if (alertable && _wapi_thread_apc_pending (current_thread)) {
+		if (alertable && _wapi_thread_cur_apc_pending ()) {
 			retval = WAIT_IO_COMPLETION;
 			break;
 		}

--- a/mono/io-layer/wait.c
+++ b/mono/io-layer/wait.c
@@ -190,12 +190,8 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 			goto done;
 		}
 			
-		if (timeout == INFINITE) {
-			waited = _wapi_handle_wait_signal_handle (handle, alertable);
-		} else {
-			waited = _wapi_handle_timedwait_signal_handle (handle, &abstime, alertable, FALSE);
-		}
-	
+		waited = _wapi_handle_timedwait_signal_handle (handle, timeout == INFINITE ? NULL : &abstime, alertable, FALSE);
+
 		if (alertable)
 			apc_pending = _wapi_thread_cur_apc_pending ();
 
@@ -381,12 +377,8 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 			ret = WAIT_OBJECT_0;
 			goto done;
 		}
-		
-		if (timeout == INFINITE) {
-			waited = _wapi_handle_wait_signal_handle (wait, alertable);
-		} else {
-			waited = _wapi_handle_timedwait_signal_handle (wait, &abstime, alertable, FALSE);
-		}
+
+		waited = _wapi_handle_timedwait_signal_handle (wait, timeout == INFINITE ? NULL : &abstime, alertable, FALSE);
 
 		if (alertable) {
 			apc_pending = _wapi_thread_cur_apc_pending ();
@@ -633,11 +625,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 		
 		if (!done) {
 			/* Enter the wait */
-			if (timeout == INFINITE) {
-				ret = _wapi_handle_wait_signal (poll);
-			} else {
-				ret = _wapi_handle_timedwait_signal (&abstime, poll);
-			}
+			ret = _wapi_handle_timedwait_signal (timeout == INFINITE ? NULL : &abstime, poll);
 		} else {
 			/* No need to wait */
 			ret = 0;

--- a/mono/io-layer/wthreads.c
+++ b/mono/io-layer/wthreads.c
@@ -243,7 +243,7 @@ SleepEx (guint32 ms, gboolean alertable)
 	if (alertable) {
 		current_thread = get_current_thread_handle ();
 		
-		if (_wapi_thread_apc_pending (current_thread))
+		if (_wapi_thread_cur_apc_pending ())
 			return WAIT_IO_COMPLETION;
 	}
 	
@@ -271,7 +271,7 @@ SleepEx (guint32 ms, gboolean alertable)
 	while (TRUE) {
 		ret = clock_nanosleep (CLOCK_MONOTONIC, TIMER_ABSTIME, &target, NULL);
 
-		if (alertable && _wapi_thread_apc_pending (current_thread))
+		if (alertable && _wapi_thread_cur_apc_pending ())
 			return WAIT_IO_COMPLETION;
 
 		if (ret == 0)
@@ -288,7 +288,7 @@ again:
 	memset (&rem, 0, sizeof (rem));
 	ret=nanosleep(&req, &rem);
 
-	if (alertable && _wapi_thread_apc_pending (current_thread))
+	if (alertable && _wapi_thread_cur_apc_pending ())
 		return WAIT_IO_COMPLETION;
 	
 	if(ret==-1) {
@@ -316,16 +316,9 @@ Sleep(guint32 ms)
 gboolean
 _wapi_thread_cur_apc_pending (void)
 {
-	return _wapi_thread_apc_pending (get_current_thread_handle ());
-}
-
-gboolean
-_wapi_thread_apc_pending (gpointer handle)
-{
 	WapiHandle_thread *thread;
 
-	thread = lookup_thread (handle);
-	
+	thread = lookup_thread (get_current_thread_handle ());
 	return thread->wait_handle == INTERRUPTION_REQUESTED_HANDLE;
 }
 

--- a/mono/io-layer/wthreads.c
+++ b/mono/io-layer/wthreads.c
@@ -316,175 +316,7 @@ Sleep(guint32 ms)
 gboolean
 _wapi_thread_cur_apc_pending (void)
 {
-	WapiHandle_thread *thread;
-
-	thread = lookup_thread (get_current_thread_handle ());
-	return thread->wait_handle == INTERRUPTION_REQUESTED_HANDLE;
-}
-
-/*
- * wapi_interrupt_thread:
- *
- * The state of the thread handle HANDLE is set to 'interrupted' which means that
- * if the thread calls one of the WaitFor functions, the function will return with 
- * WAIT_IO_COMPLETION instead of waiting. Also, if the thread was waiting when
- * this function was called, the wait will be broken.
- * It is possible that the wait functions return WAIT_IO_COMPLETION, but the
- * target thread didn't receive the interrupt signal yet, in this case it should
- * call the wait function again. This essentially means that the target thread will
- * busy wait until it is ready to process the interruption.
- */
-gpointer
-wapi_prepare_interrupt_thread (gpointer thread_handle)
-{
-	WapiHandle_thread *thread;
-	gpointer prev_handle, wait_handle;
-
-	thread = lookup_thread (thread_handle); /* FIXME this is wrong, move this whole thing to MonoThreads where it can be done lockfree */
-
-	while (TRUE) {
-		wait_handle = thread->wait_handle;
-
-		/* 
-		 * Atomically obtain the handle the thread is waiting on, and
-		 * change it to a flag value.
-		 */
-		prev_handle = InterlockedCompareExchangePointer (&thread->wait_handle,
-														 INTERRUPTION_REQUESTED_HANDLE, wait_handle);
-		if (prev_handle == INTERRUPTION_REQUESTED_HANDLE)
-			/* Already interrupted */
-			return 0;
-		if (prev_handle == wait_handle)
-			break;
-
-		/* Try again */
-	}
-
-	WAIT_DEBUG (printf ("%p: state -> INTERRUPTED.\n", thread->id););
-
-	return wait_handle;
-}
-
-void
-wapi_finish_interrupt_thread (gpointer wait_handle)
-{
-	pthread_cond_t *cond;
-	mono_mutex_t *mutex;
-	guint32 idx;
-
-	if (!wait_handle)
-		/* Not waiting */
-		return;
-
-	/* If we reach here, then wait_handle is set to the flag value, 
-	 * which means that the target thread is either
-	 * - before the first CAS in timedwait, which means it won't enter the
-	 * wait.
-	 * - it is after the first CAS, so it is already waiting, or it will 
-	 * enter the wait, and it will be interrupted by the broadcast.
-	 */
-	idx = GPOINTER_TO_UINT(wait_handle);
-	cond = &_WAPI_PRIVATE_HANDLES(idx).signal_cond;
-	mutex = &_WAPI_PRIVATE_HANDLES(idx).signal_mutex;
-
-	mono_mutex_lock (mutex);
-	mono_cond_broadcast (cond);
-	mono_mutex_unlock (mutex);
-
-	/* ref added by set_wait_handle */
-	_wapi_handle_unref (wait_handle);
-}
-
-/*
- * wapi_self_interrupt:
- *
- *   This is not part of the WIN32 API.
- * Set the 'interrupted' state of the calling thread if it's NULL.
- */
-void
-wapi_self_interrupt (void)
-{
-	gpointer wait_handle;
-
-	wait_handle = wapi_prepare_interrupt_thread (get_current_thread_handle ());
-	if (wait_handle)
-		/* ref added by set_wait_handle */
-		_wapi_handle_unref (wait_handle);
-}
-
-/*
- * wapi_clear_interruption:
- *
- *   This is not part of the WIN32 API. 
- * Clear the 'interrupted' state of the calling thread.
- * This function is signal safe
- */
-void
-wapi_clear_interruption (void)
-{
-	WapiHandle_thread *thread;
-	gpointer prev_handle;
-
-	thread = get_current_thread ();
-
-	prev_handle = InterlockedCompareExchangePointer (&thread->wait_handle,
-													 NULL, INTERRUPTION_REQUESTED_HANDLE);
-	if (prev_handle == INTERRUPTION_REQUESTED_HANDLE)
-		WAIT_DEBUG (printf ("%p: state -> NORMAL.\n", GetCurrentThreadId ()););
-}
-
-/**
- * wapi_thread_set_wait_handle:
- *
- *   Set the wait handle for the current thread to HANDLE. Return TRUE on success, FALSE
- * if the thread is in interrupted state, and cannot start waiting.
- */
-gboolean
-wapi_thread_set_wait_handle (gpointer handle)
-{
-	WapiHandle_thread *thread;
-	gpointer prev_handle;
-
-	thread = get_current_thread ();
-
-	prev_handle = InterlockedCompareExchangePointer (&thread->wait_handle,
-													 handle, NULL);
-	if (prev_handle == NULL) {
-		/* thread->wait_handle acts as an additional reference to the handle */
-		_wapi_handle_ref (handle);
-
-		WAIT_DEBUG (printf ("%p: state -> WAITING.\n", GetCurrentThreadId ()););
-	} else {
-		g_assert (prev_handle == INTERRUPTION_REQUESTED_HANDLE);
-		WAIT_DEBUG (printf ("%p: unable to set state to WAITING.\n", GetCurrentThreadId ()););
-	}
-
-	return prev_handle == NULL;
-}
-
-/**
- * wapi_thread_clear_wait_handle:
- *
- *   Clear the wait handle of the current thread.
- */
-void
-wapi_thread_clear_wait_handle (gpointer handle)
-{
-	WapiHandle_thread *thread;
-	gpointer prev_handle;
-
-	thread = get_current_thread ();
-
-	prev_handle = InterlockedCompareExchangePointer (&thread->wait_handle,
-													 NULL, handle);
-	if (prev_handle == handle) {
-		_wapi_handle_unref (handle);
-		WAIT_DEBUG (printf ("%p: state -> NORMAL.\n", GetCurrentThreadId ()););
-	} else {
-		/*It can be NULL if it was asynchronously cleared*/
-		g_assert (prev_handle == INTERRUPTION_REQUESTED_HANDLE || prev_handle == NULL);
-		WAIT_DEBUG (printf ("%p: finished waiting.\n", GetCurrentThreadId ()););
-	}
+	return mono_thread_info_is_interrupt_state (mono_thread_info_current ());
 }
 
 void
@@ -517,31 +349,20 @@ wapi_current_thread_desc (void)
 	WapiHandle_thread *thread;
 	gpointer thread_handle;
 	int i;
-	gpointer handle;
 	GString* text;
 	char *res;
 
 	thread_handle = get_current_thread_handle ();
 	thread = lookup_thread (thread_handle);
 
-	handle = thread->wait_handle;
 	text = g_string_new (0);
 	g_string_append_printf (text, "thread handle %p state : ", thread_handle);
 
-	if (!handle)
-		g_string_append_printf (text, "not waiting");
-	else if (handle == INTERRUPTION_REQUESTED_HANDLE)
-		g_string_append_printf (text, "interrupted state");
-	else
-		g_string_append_printf (text, "waiting on %p : %s ", handle, _wapi_handle_typename[_wapi_handle_type (handle)]);
+	mono_thread_info_describe_interrupt_token (mono_thread_info_current (), text);
+
 	g_string_append_printf (text, " owns (");
-	for (i = 0; i < thread->owned_mutexes->len; i++) {
-		gpointer mutex = g_ptr_array_index (thread->owned_mutexes, i);
-		if (i > 0)
-			g_string_append_printf (text, ", %p", mutex);
-		else
-			g_string_append_printf (text, "%p", mutex);
-	}
+	for (i = 0; i < thread->owned_mutexes->len; i++)
+		g_string_append_printf (text, i > 0 ? ", %p" : "%p", g_ptr_array_index (thread->owned_mutexes, i));
 	g_string_append_printf (text, ")");
 
 	res = text->str;

--- a/mono/utils/mono-threads-mach.c
+++ b/mono/utils/mono-threads-mach.c
@@ -32,12 +32,6 @@ mono_threads_init_platform (void)
 }
 
 void
-mono_threads_core_interrupt (MonoThreadInfo *info)
-{
-	thread_abort (info->native_handle);
-}
-
-void
 mono_threads_core_abort_syscall (MonoThreadInfo *info)
 {
 	kern_return_t ret;

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -236,30 +236,6 @@ mono_threads_core_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
 	return handle;
 }
 
-gpointer
-mono_threads_core_prepare_interrupt (HANDLE thread_handle)
-{
-	return wapi_prepare_interrupt_thread (thread_handle);
-}
-
-void
-mono_threads_core_finish_interrupt (gpointer wait_handle)
-{
-	wapi_finish_interrupt_thread (wait_handle);
-}
-
-void
-mono_threads_core_self_interrupt (void)
-{
-	wapi_self_interrupt ();
-}
-
-void
-mono_threads_core_clear_interruption (void)
-{
-	wapi_clear_interruption ();
-}
-
 int
 mono_threads_pthread_kill (MonoThreadInfo *info, int signum)
 {

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -395,26 +395,4 @@ mono_threads_core_set_name (MonoNativeThreadId tid, const char *name)
 #endif
 }
 
-
-gpointer
-mono_threads_core_prepare_interrupt (HANDLE thread_handle)
-{
-	return NULL;
-}
-
-void
-mono_threads_core_finish_interrupt (gpointer wait_handle)
-{
-}
-
-void
-mono_threads_core_self_interrupt (void)
-{
-}
-
-void
-mono_threads_core_clear_interruption (void)
-{
-}
-
 #endif

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -457,7 +457,6 @@ gboolean mono_threads_core_suspend (THREAD_INFO_TYPE *info, gboolean interrupt_k
 gboolean mono_threads_core_resume (THREAD_INFO_TYPE *info);
 void mono_threads_platform_register (THREAD_INFO_TYPE *info); //ok
 void mono_threads_platform_free (THREAD_INFO_TYPE *info);
-void mono_threads_core_interrupt (THREAD_INFO_TYPE *info);
 void mono_threads_core_abort_syscall (THREAD_INFO_TYPE *info);
 gboolean mono_threads_core_needs_abort_syscall (void);
 HANDLE mono_threads_core_create_thread (LPTHREAD_START_ROUTINE start, gpointer arg, guint32 stack_size, guint32 creation_flags, MonoNativeThreadId *out_tid);


### PR DESCRIPTION
This lets us take one more thing out of io-layer, to hopefully reduce it to a bare minimum some day.