### PR TITLE
HttpListenerRequest Uri is now unescaped.

### DIFF
--- a/mcs/class/System/ReferenceSources/HttpSysSettings.cs
+++ b/mcs/class/System/ReferenceSources/HttpSysSettings.cs
@@ -1,0 +1,8 @@
+namespace System.Net
+{
+	static class HttpSysSettings
+	{
+		public const bool EnableNonUtf8 = true;
+		public const bool FavorUtf8 = true;
+	}
+}

--- a/mcs/class/System/ReferenceSources/Logging.cs
+++ b/mcs/class/System/ReferenceSources/Logging.cs
@@ -14,12 +14,21 @@ namespace System.Net {
 			}
 		}
 
+		internal static TraceSource HttpListener {
+			get {
+				return null;
+			}
+		}
+
 		[Conditional ("TRACE")]
  		internal static void Enter(TraceSource traceSource, object obj, string method, object paramObject) {
  		}
 
 		[Conditional ("TRACE")]
 		internal static void Exit(TraceSource traceSource, object obj, string method, object retObject) {
+		}
+
+		internal static void PrintWarning(TraceSource traceSource, object obj, string method, string msg) {
 		}
 	}
 

--- a/mcs/class/System/ReferenceSources/SettingsSectionInternal.cs
+++ b/mcs/class/System/ReferenceSources/SettingsSectionInternal.cs
@@ -9,7 +9,11 @@ namespace System.Net.Configuration {
 			}
 		}
 
+#if !MOBILE
 		internal UnicodeEncodingConformance WebUtilityUnicodeEncodingConformance = UnicodeEncodingConformance.Auto;
 		internal UnicodeDecodingConformance WebUtilityUnicodeDecodingConformance = UnicodeDecodingConformance.Auto;
+#endif
+
+		internal bool HttpListenerUnescapeRequestUrl = true;
 	}
 }

--- a/mcs/class/System/System.Net/HttpListenerRequest.cs
+++ b/mcs/class/System/System.Net/HttpListenerRequest.cs
@@ -188,6 +188,11 @@ namespace System.Net {
 
 			CreateQueryString (url.Query);
 
+			// Use reference source HttpListenerRequestUriBuilder to process url.
+			// Fixes #29927
+			url = HttpListenerRequestUriBuilder.GetRequestUri (raw_url, url.Scheme,
+								url.Authority, url.LocalPath, url.Query);
+
 			if (version >= HttpVersion.Version11) {
 				string t_encoding = Headers ["Transfer-Encoding"];
 				is_chunked = (t_encoding != null && String.Compare (t_encoding, "chunked", StringComparison.OrdinalIgnoreCase) == 0);

--- a/mcs/class/System/System.dll.sources
+++ b/mcs/class/System/System.dll.sources
@@ -616,6 +616,7 @@ System.Windows.Input/ICommand.cs
 ReferenceSources/AssertWrapper.cs
 ReferenceSources/BinaryCompatibility.cs
 ReferenceSources/ConfigurationManagerInternalFactory.cs
+ReferenceSources/HttpSysSettings.cs
 ReferenceSources/Logging.cs
 ReferenceSources/NativeMethods.cs
 ReferenceSources/SettingsSectionInternal.cs
@@ -999,6 +1000,7 @@ ReferenceSources/Win32Exception.cs
 ../../../external/referencesource/System/net/System/Net/cookiecollection.cs
 ../../../external/referencesource/System/net/System/Net/cookiecontainer.cs
 ../../../external/referencesource/System/net/System/Net/cookieexception.cs
+../../../external/referencesource/System/net/System/Net/HttpListenerRequestUriBuilder.cs
 ../../../external/referencesource/System/net/System/Net/Internal.cs
 ../../../external/referencesource/System/net/System/Net/UnicodeDecodingConformance.cs
 ../../../external/referencesource/System/net/System/Net/UnicodeEncodingConformance.cs
@@ -1121,4 +1123,3 @@ ReferenceSources/Win32Exception.cs
 ../../../external/referencesource/System/compmod/system/codedom/compiler/ICodeParser.cs
 ../../../external/referencesource/System/compmod/system/codedom/compiler/IndentTextWriter.cs
 ../../../external/referencesource/System/compmod/system/codedom/compiler/LanguageOptions.cs
-

--- a/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
@@ -184,5 +184,31 @@ namespace MonoTests.System.Net
 			Assert.AreEqual ("/RequestUriDecodeTest/?a=b&c=d%26e", request.Url.PathAndQuery);
 			listener.Close ();
 		}
+
+		[Test] // #29927
+		public void HttpRequestUriUnescape ()
+		{
+			var prefix = "http://localhost:12345/";
+			var key = "Product/1";
+
+			var expectedUrl = prefix + key + "/";
+			var rawUrl = prefix + Uri.EscapeDataString (key) + "/";
+
+			HttpListener listener = new HttpListener ();
+			listener.Prefixes.Add (prefix);
+			listener.Start ();
+
+			var contextTask = listener.GetContextAsync ();
+
+			var request = (HttpWebRequest) WebRequest.Create (rawUrl);
+			request.GetResponseAsync ();
+
+			if(!contextTask.Wait (1000))
+				Assert.Fail ("Timeout");
+
+			Assert.AreEqual (expectedUrl, contextTask.Result.Request.Url.AbsoluteUri);
+
+			listener.Close ();
+		}
 	}
 }

--- a/mcs/class/System/mobile_System.dll.sources
+++ b/mcs/class/System/mobile_System.dll.sources
@@ -350,8 +350,10 @@ System.Runtime.InteropServices/HandleCollector.cs
 System.Windows.Input/ICommand.cs
 
 ReferenceSources/AssertWrapper.cs
+ReferenceSource/HttpSysSettings.cs
 ReferenceSources/Logging.cs
 ReferenceSources/NativeMethods.cs
+ReferenceSources/SettingsSectionInternal.cs
 ReferenceSources/SR.cs
 ReferenceSources/SRCategoryAttribute.cs
 ReferenceSources/SystemNetworkCredential.cs
@@ -717,6 +719,7 @@ ReferenceSources/Win32Exception.cs
 ../../../external/referencesource/System/net/System/Net/cookiecollection.cs
 ../../../external/referencesource/System/net/System/Net/cookiecontainer.cs
 ../../../external/referencesource/System/net/System/Net/cookieexception.cs
+../../../external/referencesource/System/net/System/Net/HttpListenerRequestUriBuilder.cs
 ../../../external/referencesource/System/net/System/Net/Internal.cs
 ../../../external/referencesource/System/net/System/Net/webclient.cs
 ../../../external/referencesource/System/net/System/Net/WebPermission.cs


### PR DESCRIPTION
**Fixes:** [#29927](https://bugzilla.xamarin.com/show_bug.cgi?id=29927)