### PR TITLE
[runtime] Emit the necessary left shift anding in the LambdaCompiler

### DIFF
--- a/mcs/class/dlr/Runtime/Microsoft.Scripting.Core/Compiler/LambdaCompiler.Binary.cs
+++ b/mcs/class/dlr/Runtime/Microsoft.Scripting.Core/Compiler/LambdaCompiler.Binary.cs
@@ -275,6 +275,12 @@ namespace System.Linq.Expressions.Compiler {
                     if (rightType != typeof(int)) {
                         throw ContractUtils.Unreachable;
                     }
+                    // Note: If this code is made to handle unsigned
+                    // rightType types, emit the following when rightType:
+                    // is unsigned
+                    //_ilg.EmitInt(0x3f);
+                    _ilg.EmitInt(0x1f);
+                    _ilg.Emit(OpCodes.And);
                     _ilg.Emit(OpCodes.Shl);
                     break;
                 case ExpressionType.RightShift:

--- a/mcs/tests/dtest-061.cs
+++ b/mcs/tests/dtest-061.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Test
+{
+	public class Program
+	{
+		static int[] testValues = {0, -1, 200, -200, 32, -32, 64, -128, 333, 5};
+
+		dynamic dynBase;
+		dynamic dynAmt;
+
+		int? optBase;
+		int? optAmt;
+
+		int normBase;
+		int normAmt;
+
+		dynamic uDynBase;
+
+		public static void Main ()
+		{
+			var tester = new Program ();
+
+			foreach (int baseVal in testValues)
+				foreach (int amt in testValues)
+					tester.ShiftTest (baseVal, amt);
+		}
+
+		public static void AreEqual<A, B> (A a, B b)
+		{
+			if (!a.Equals (b))
+				throw new Exception (
+					String.Format (
+						"Shift Equality Assertion Failed: Had {0} and expected {1}", a, b));
+		}
+
+		public void ShiftTest (int shiftBase, int shiftAmt)
+		{
+			optBase = dynBase = normBase = shiftBase;
+			optAmt = dynAmt = normAmt = shiftAmt;
+			int immediate = shiftBase << shiftAmt;
+
+			AreEqual<int?, int?> (dynBase << dynAmt, immediate);
+			AreEqual<int?, int?> (dynBase << optAmt, immediate);
+			AreEqual<int?, int?> (dynBase << normAmt, immediate);
+
+			AreEqual<int?, int?> (optBase << dynAmt, immediate);
+			AreEqual<int?, int?> (optBase << optAmt, immediate);
+			AreEqual<int?, int?> (optBase << normAmt, immediate);
+
+			AreEqual<int?, int?> (normBase << dynAmt, immediate);
+			AreEqual<int?, int?> (normBase << optAmt, immediate);
+			AreEqual<int?, int?> (normBase << normAmt, immediate);
+
+			uint uShiftBase = (uint)shiftBase;
+			uDynBase = uShiftBase;
+
+			AreEqual<uint?, uint?> (uShiftBase << dynAmt, uDynBase << dynAmt);
+			AreEqual<uint?, uint?> (uShiftBase << optAmt, uDynBase << optAmt);
+			AreEqual<uint?, uint?> (uShiftBase << normAmt, uDynBase << normAmt);
+		}
+	}
+}


### PR DESCRIPTION
We were failing dtest-006.exe, which checks that a right shift with
a negative shift amount and a dynamic base is shifted by the right
amount.

We were failing it because we were excluding the step that we
do in regular code generation, which is to do a binary and of the shift
amount so it behaves like we are shifting by the original shift
amount modulo 32. The C# spec defines left shift like so.

This commit adds that to the LambdaCompiler.