### PR TITLE
[corlib] MonoAssembly.LoadWithPartialNameInternal.

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoAssembly.cs
+++ b/mcs/class/corlib/System.Reflection/MonoAssembly.cs
@@ -139,14 +139,16 @@ namespace System.Reflection {
 
 		internal static RuntimeAssembly LoadWithPartialNameInternal (String partialName, Evidence securityEvidence, ref StackCrawlMark stackMark)
 		{
-			AssemblyName an = new AssemblyName(partialName);
-			return LoadWithPartialNameInternal (an, securityEvidence, ref stackMark);
+			// Mono runtime does not support StackCrawlMark
+			//FIXME stackMark should probably change method behavior in some cases.
+			return (RuntimeAssembly) Assembly.LoadWithPartialName (partialName, securityEvidence);
 		}
 
 		internal static RuntimeAssembly LoadWithPartialNameInternal (AssemblyName an, Evidence securityEvidence, ref StackCrawlMark stackMark)
 		{
-			throw new NotImplementedException ("LoadWithPartialNameInternal");
+			return LoadWithPartialNameInternal (an.ToString (), securityEvidence, ref stackMark);
 		}
+
 	}
 
 	[ComVisible (true)]


### PR DESCRIPTION
Implemented MonoAssembly.LoadWithPartialNameInternal.
Implementation is not 100% correct without handling stackMark properly.
Improving this would require the generous amount of work of adding
StackCrawlMark support to the runtime.

Fixes #27103. NotImplementedException crashes