### PR TITLE
[runtime] Use libtool convenience library for unit tests. Fixes #21520.

### DIFF
--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\"
 
 test_cflags = $(AM_CFLAGS) $(SGEN_DEFINES)
-test_ldadd = ../metadata/libmonoruntimesgen.la ../sgen/libmonosgen.la ../io-layer/libwapi.la ../utils/libmonoutils.la \
+test_ldadd = libtestlib.la \
 	$(LIBGC_LIBS) $(GLIB_LIBS) -lm $(LIBICONV)
 if PLATFORM_DARWIN
 test_ldflags = -framework CoreFoundation -framework Foundation
@@ -11,7 +11,10 @@ endif
 if !CROSS_COMPILE
 if !HOST_WIN32
 if SUPPORT_BOEHM
-if !PLATFORM_GNU
+
+noinst_LTLIBRARIES = libtestlib.la
+libtestlib_la_SOURCES =
+libtestlib_la_LIBADD = ../metadata/libmonoruntimesgen.la ../sgen/libmonosgen.la ../utils/libmonoutils.la ../io-layer/libwapi.la 
 
 test_sgen_qsort_SOURCES = test-sgen-qsort.c
 test_sgen_qsort_CFLAGS = $(test_cflags)
@@ -37,7 +40,6 @@ noinst_PROGRAMS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-c
 
 TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable
 
-endif !PLATFORM_GNU
 endif SUPPORT_BOEHM
 endif !HOST_WIN32
 endif !CROSS_COMPILE


### PR DESCRIPTION
In order to resolve interdependencies between
static libraries we should create a temporary
throw-away ("convenience") library via libtool.

Should unbreak unit tests on Linux