### PR TITLE
[corlib] Assume UTC if no $TZ set. Fixes #30698.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -116,11 +116,11 @@ namespace System
 
 			try {
 				return FindSystemTimeZoneByFileName ("Local", "/etc/localtime");	
-			} catch {
+			} catch (TimeZoneNotFoundException) {
 				try {
 					return FindSystemTimeZoneByFileName ("Local", Path.Combine (TimeZoneDirectory, "localtime"));	
-				} catch {
-					return null;
+				} catch (TimeZoneNotFoundException) {
+					return Utc;
 				}
 			}
 		}


### PR DESCRIPTION
Don't throw System.TimeZoneNotFoundException
if no $TZ is set and there is no /etc/localtime
or similar file.