### PR TITLE
Use libc.so.7 for FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3239,7 +3239,7 @@ case "$host" in
 	X11="libX11.so.6"
 	;;
     *-*-*freebsd*)
-    	LIBC="libc.so"
+    	LIBC="libc.so.7"
 	INTL="libintl.so"
 	SQLITE="libsqlite.so"
 	SQLITE3="libsqlite3.so"


### PR DESCRIPTION
/usr/lib/libc.so is now an ld script
and to a symbolic link to the
libc.so.7 library.

Obtained from: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=179899