### PR TITLE
Missing <ucontext.h> for x86

### DIFF
--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -12,6 +12,9 @@
 #include <glib.h>
 #include <signal.h>
 #include <string.h>
+#ifdef HAVE_UCONTEXT_H
+#include <ucontext.h>
+#endif
 
 #include <mono/metadata/abi-details.h>
 #include <mono/arch/x86/x86-codegen.h>


### PR DESCRIPTION
Obtained from: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198404