### PR TITLE
[eglib] Prefer <langinfo.h> to <localcharset.h>

### DIFF
--- a/eglib/src/gunicode.c
+++ b/eglib/src/gunicode.c
@@ -219,10 +219,10 @@ g_get_charset (G_CONST_RETURN char **charset)
 		is_utf8 = FALSE;
 #else
 		/* These shouldn't be heap allocated */
-#if HAVE_LOCALCHARSET_H
-		my_charset = locale_charset ();
-#elif defined(HAVE_LANGINFO_H)
+#if defined(HAVE_LANGINFO_H)
 		my_charset = nl_langinfo (CODESET);
+#elif defined(HAVE_LOCALCHARSET_H)
+		my_charset = locale_charset ();
 #else
 		my_charset = "UTF-8";
 #endif


### PR DESCRIPTION
(This is a followup to https://github.com/mono/mono/pull/1813)

For platforms that have external libiconv
located in some non-default directory (e.g. /usr/local/lib)
it is very difficult to force libtool to pick
up a static libiconv.a when needed.

We currently build eglib as a static library,
and then we continue to link eglib (with -leglib)
to other binaries and libraries.

As -leglib is a static library, we should either

1) incorporate the contents of libiconv.a into
   libeglib.a (therefore we would _require_
   libiconv.a to be installed).

2) prepare stub libiconv.la file and provide it
   to all libeglib.a consumers as a dependency.

We should not just detect HAVE_LOCALCHARSET_H,
add it to CPPFLAGS and then continue without
linking libiconv properly as a static library;
This manifests with the error message during
linking:

   gunicode.c:223: undefined reference to `locale_charset'

This workaround makes us look for <langinfo.h>
first, which - if available - will be there in
the standard C library. This fixes the gunicode.c
problem for FreeBSD and similar platforms, that
may install GNU iconv as an add-on library.