### PR TITLE
[tests] Avoid "Address already in use"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ Ankh.NoLoad
 _ReSharper*/
 *.resharper
 [Tt]est[Rr]esult*
+*.orig
+*.rej
 
 # NuGet packages
 !.nuget/*

--- a/mcs/class/System.ServiceModel.Web/System.ServiceModel.Web_test.dll.sources
+++ b/mcs/class/System.ServiceModel.Web/System.ServiceModel.Web_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NetworkHelpers.cs
 System.Runtime.Serialization.Json/DataContractJsonSerializerTest.cs
 System.Runtime.Serialization.Json/JsonReaderTest.cs
 System.Runtime.Serialization.Json/JsonWriterTest.cs

--- a/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebServiceHostTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebServiceHostTest.cs
@@ -37,6 +37,8 @@ using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using System.Net;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Web
 {
 	[TestFixture]
@@ -46,7 +48,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Category("NotWorking")]
 		public void ServiceDebugBehaviorTest () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://" + NetworkHelpers.LocalEphemeralEndPoint().ToString()));
 			ServiceEndpoint webHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new WebHttpBinding (), "WebHttpBinding");
 
 			Assert.AreEqual (true, host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageEnabled, "HttpHelpPageEnabled #1");
@@ -64,7 +66,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Category ("NotWorking")]
 		public void WebHttpBehaviorTest1 () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://" + NetworkHelpers.LocalEphemeralEndPoint().ToString()));
 			ServiceEndpoint webHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new WebHttpBinding (), "WebHttpBinding");
 			ServiceEndpoint basicHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new BasicHttpBinding (), "BasicHttpBinding");
 
@@ -84,7 +86,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Category("NotWorking")]
 		public void WebHttpBehaviorTest2 () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://" + NetworkHelpers.LocalEphemeralEndPoint().ToString()));
 			ServiceEndpoint webHttp = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.Web.WebServiceHostTest+MyService", new WebHttpBinding (), "WebHttpBinding");
 			MyWebHttpBehavior behavior = new MyWebHttpBehavior ();
 			behavior.ApplyDispatchBehaviorBegin += delegate {
@@ -104,7 +106,7 @@ namespace MonoTests.System.ServiceModel.Web
 		[Test]
 		public void ServiceBaseUriTest () {
 
-			var host = new WebServiceHost (typeof (MyService), new Uri ("http://localhost:30158/"));
+			var host = new WebServiceHost (typeof (MyService), new Uri ("http://" + NetworkHelpers.LocalEphemeralEndPoint().ToString()));
 			Assert.AreEqual (0, host.Description.Endpoints.Count, "no endpoints yet");
 			host.Open ();
 			Assert.AreEqual (1, host.Description.Endpoints.Count, "default endpoint after open");
@@ -138,12 +140,13 @@ namespace MonoTests.System.ServiceModel.Web
 		[Test]
 		public void Connect ()
 		{
+			var url = "http://" + NetworkHelpers.LocalEphemeralEndPoint().ToString();
 			var host = new WebServiceHost (typeof (DemoService), new Uri
-						       ("http://localhost:30158/"));
+						       (url));
 			try {
 				host.Open ();
 				var wc = new WebClient();
-				wc.DownloadString("http://localhost:30158/testData");
+				wc.DownloadString(url + "/testData");
 				Console.WriteLine();
 			} finally {
 				host.Close();

--- a/mcs/class/System.ServiceModel/System.ServiceModel_test.dll.sources
+++ b/mcs/class/System.ServiceModel/System.ServiceModel_test.dll.sources
@@ -1,4 +1,5 @@
 NUnitMoonHelper.cs
+../../test-helpers/NetworkHelpers.cs
 FeatureBased/Features.Client/AsyncCallTesterProxy.cs
 FeatureBased/Features.Client/AsyncPatternServer.cs
 FeatureBased/Features.Client/DataContractTesterProxy.cs

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
@@ -36,6 +36,8 @@ using System.ServiceModel.Dispatcher;
 using SMMessage = System.ServiceModel.Channels.Message;
 using System.ServiceModel.Channels;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -159,7 +161,8 @@ namespace MonoTests.System.ServiceModel
 
 		[Test]
 		public void ChannelDispatchers_NoDebug () {
-			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:30158"));
+			var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
+			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://" + ep));
 			h.AddServiceEndpoint (typeof (AllActions).FullName, new BasicHttpBinding (), "address");
 
 			ServiceDebugBehavior b = h.Description.Behaviors.Find<ServiceDebugBehavior> ();
@@ -173,7 +176,7 @@ namespace MonoTests.System.ServiceModel
 			Assert.IsTrue (channelDispatcher.Endpoints.Count == 1, "#2");
 			EndpointAddressMessageFilter filter = channelDispatcher.Endpoints [0].AddressFilter as EndpointAddressMessageFilter;
 			Assert.IsNotNull (filter, "#3");
-			Assert.IsTrue (filter.Address.Equals (new EndpointAddress ("http://localhost:30158/address")), "#4");
+			Assert.IsTrue (filter.Address.Equals (new EndpointAddress ("http://" + ep + "/address")), "#4");
 			Assert.IsFalse (filter.IncludeHostNameInComparison, "#5");
 			Assert.IsTrue (channelDispatcher.Endpoints [0].ContractFilter is MatchAllMessageFilter, "#6");
 			} finally {
@@ -183,11 +186,12 @@ namespace MonoTests.System.ServiceModel
 
 		[Test]
 		public void ChannelDispatchers_WithDebug () {
-			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:30158"));
+			var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
+			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://" + ep));
 			h.AddServiceEndpoint (typeof (AllActions).FullName, new BasicHttpBinding (), "address");
 			ServiceMetadataBehavior b = new ServiceMetadataBehavior ();
 			b.HttpGetEnabled = true;
-			b.HttpGetUrl = new Uri( "http://localhost:30158" );
+			b.HttpGetUrl = new Uri( ep );
 			h.Description.Behaviors.Add (b);
 			h.Open ();
 
@@ -197,7 +201,7 @@ namespace MonoTests.System.ServiceModel
 			Assert.IsTrue (channelDispatcher.Endpoints.Count == 1, "#3");
 			EndpointAddressMessageFilter filter = channelDispatcher.Endpoints [0].AddressFilter as EndpointAddressMessageFilter;
 			Assert.IsNotNull (filter, "#4");
-			Assert.IsTrue (filter.Address.Equals (new EndpointAddress ("http://localhost:30158")), "#5");
+			Assert.IsTrue (filter.Address.Equals (new EndpointAddress ("http://" + ep)), "#5");
 			Assert.IsFalse (filter.IncludeHostNameInComparison, "#6");
 			Assert.IsTrue (channelDispatcher.Endpoints [0].ContractFilter is MatchAllMessageFilter, "#7");
 			h.Close ();
@@ -207,7 +211,8 @@ namespace MonoTests.System.ServiceModel
 		public void SpecificActionTest ()
 		{
 			//EndpointDispatcher d = new EndpointDispatcher(
-			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://localhost:30158"));
+			var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
+			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://" + ep));
 			h.AddServiceEndpoint (typeof (Action1Interface), new BasicHttpBinding (), "address");
 						
 			h.Open ();
@@ -222,7 +227,8 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void InitializeRuntimeBehaviors1 () {
 			HostState st = new HostState ();
-			ServiceHost h = new ServiceHost (typeof (SpecificAction2), new Uri ("http://localhost:30158"));
+			var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
+			ServiceHost h = new ServiceHost (typeof (SpecificAction2), new Uri ("http://" + ep));
 			h.AddServiceEndpoint (typeof (SpecificAction2), new BasicHttpBinding (), "temp");			
 
 			h.Description.Behaviors.Add (new MyServiceBehavior (st, h));
@@ -241,7 +247,8 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void InitializeRuntimeBehaviors2 () {
 			HostState st = new HostState ();
-			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://localhost:30158"));
+			var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
+			ServiceHost h = new ServiceHost (typeof (SpecificAction), new Uri ("http://" + ep));
 			h.AddServiceEndpoint (typeof (Action1Interface), new BasicHttpBinding (), "temp");
 			h.AddServiceEndpoint (typeof (Action2Interface), new BasicHttpBinding (), "temp2");
 
@@ -309,8 +316,9 @@ namespace MonoTests.System.ServiceModel
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void AddServiceEndpointOnlyMex ()
 		{
+            var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
 			var host = new ServiceHost (typeof (AllActions),
-				new Uri ("http://localhost:37564"));
+				new Uri ("http://" + ep));
 			host.Description.Behaviors.Add (new ServiceMetadataBehavior ());
 			host.AddServiceEndpoint ("IMetadataExchange",
 				new BasicHttpBinding (), "/wsdl");
@@ -339,7 +347,7 @@ namespace MonoTests.System.ServiceModel
 
 		void RunDestinationUnreachableTest (string label, Binding binding)
 		{
-			string address = "http://localhost:37564/";
+			string address = "http://" + NetworkHelpers.LocalEphemeralEndPoint().ToString();
 			var host = OpenHost (address, binding);
 			
 			try {

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
@@ -34,6 +34,8 @@ using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -172,10 +174,11 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void AddServiceEndpoint2_4 ()
 		{
-			ServiceHost host = new ServiceHost (typeof (HogeFuga), new Uri ("http://localhost:37564"));
+			var ep = "http://" + NetworkHelpers.LocalEphemeralEndPoint().ToString();
+			ServiceHost host = new ServiceHost (typeof (HogeFuga), new Uri (ep));
 			var binding = new BasicHttpBinding ();
-			host.AddServiceEndpoint (typeof (IHoge), binding, new Uri ("http://localhost:37564"));
-			host.AddServiceEndpoint (typeof (IFuga), binding, new Uri ("http://localhost:37564"));
+			host.AddServiceEndpoint (typeof (IHoge), binding, new Uri (ep));
+			host.AddServiceEndpoint (typeof (IFuga), binding, new Uri (ep));
 
 			// Use the same binding, results in one ChannelDispatcher (actually two, for metadata/debug behavior).
 			host.Open ();
@@ -296,13 +299,14 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void InstanceWithNonSingletonMode ()
 		{
+			var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
 			ServiceHost host = new ServiceHost (
 				new NonSingletonService ());
 			Assert.IsNotNull (host.Description.Behaviors.Find<ServiceBehaviorAttribute> ().GetWellKnownSingleton (), "premise1");
 			host.AddServiceEndpoint (
 				typeof (NonSingletonService),
 				new BasicHttpBinding (),
-				new Uri ("http://localhost:37564/s1"));
+				new Uri ("http://" + ep + "/s1"));
 
 			// in case Open() didn't fail, we need to close the host.
 			// And even if Close() caused the expected exception,
@@ -323,13 +327,14 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void InstanceWithSingletonMode ()
 		{
+            var ep = NetworkHelpers.LocalEphemeralEndPoint().ToString();
 			SingletonService instance = new SingletonService ();
 			ServiceHost host = new ServiceHost (instance);
 			Assert.IsNotNull (host.Description.Behaviors.Find<ServiceBehaviorAttribute> ().GetWellKnownSingleton (), "#1");
 			host.AddServiceEndpoint (
 				typeof (SingletonService),
 				new BasicHttpBinding (),
-				new Uri ("http://localhost:37564/s2"));
+				new Uri ("http://" + ep + "/s2"));
 
 			// in case Open() didn't fail, we need to close the host.
 			// And even if Close() caused the expected exception,

--- a/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
@@ -14,6 +14,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
+using MonoTests.Helpers;
+
 using NUnit.Framework;
 
 namespace MonoTests.System.Net
@@ -24,7 +26,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void CharacterSet_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -54,7 +56,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Close_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -75,7 +77,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void ContentEncoding_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -105,7 +107,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void ContentLength_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -127,7 +129,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void ContentType_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -157,7 +159,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Cookies_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -197,7 +199,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void GetResponseHeader_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -227,7 +229,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void GetResponseStream_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -257,7 +259,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Headers_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -286,7 +288,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void LastModified_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -316,7 +318,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Method_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -346,7 +348,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void ProtocolVersion_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -376,7 +378,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void ResponseUri_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -406,7 +408,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Server_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -436,7 +438,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void StatusCode_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -458,7 +460,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void StatusDescription_Disposed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (FullResponseHandler))) {
@@ -511,7 +513,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void BeginRead_Buffer_Null ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -562,7 +564,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void BeginWrite ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -597,7 +599,7 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void CanRead ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -626,7 +628,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void CanSeek ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -655,7 +657,7 @@ namespace MonoTests.System.Net
 		[Test] // bug #324182
 		public void CanTimeout ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -684,7 +686,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void CanWrite ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -713,7 +715,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Read ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -752,7 +754,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Read_Buffer_Null ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -803,7 +805,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Read_Count_Negative ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -855,7 +857,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Read_Count_Overflow ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -907,7 +909,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Read_Offset_Negative ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -959,7 +961,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Read_Offset_Overflow ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -1012,7 +1014,7 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void Read_Stream_Closed ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -1077,7 +1079,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void ReadTimeout ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -1106,7 +1108,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void Write ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {
@@ -1140,7 +1142,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void WriteTimeout ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
 			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (HttpWebResponseTest.FullResponseHandler))) {

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -16,6 +16,8 @@ using System.Text;
 using System.Threading;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.Net
 {
 	[TestFixture]
@@ -1417,8 +1419,8 @@ namespace MonoTests.System.Net
 		[Test]
 		public void UploadValues1 ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 8000);
-			string url = "http://" + IPAddress.Loopback.ToString () + ":8000/test/";
+			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
+			string url = "http://" + ep.ToString () + "/test/";
 
 			using (SocketResponder responder = new SocketResponder (ep, new SocketRequestHandler (EchoRequestHandler))) {
 				responder.Start ();
@@ -1783,7 +1785,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void UploadStringAsyncCancelEvent ()
 		{
-			UploadAsyncCancelEventTest ((webClient, uri, cancelEvent) =>
+			UploadAsyncCancelEventTest (9301, (webClient, uri, cancelEvent) =>
 			{
 
 				webClient.UploadStringCompleted += (sender, args) =>
@@ -1799,7 +1801,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void UploadDataAsyncCancelEvent ()
 		{
-			UploadAsyncCancelEventTest ((webClient, uri, cancelEvent) =>
+			UploadAsyncCancelEventTest (9302, (webClient, uri, cancelEvent) =>
 			{
 				webClient.UploadDataCompleted += (sender, args) =>
 				{
@@ -1814,7 +1816,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void UploadValuesAsyncCancelEvent ()
 		{
-			UploadAsyncCancelEventTest ((webClient, uri, cancelEvent) =>
+			UploadAsyncCancelEventTest (9303, (webClient, uri, cancelEvent) =>
 			{
 				webClient.UploadValuesCompleted += (sender, args) =>
 				{
@@ -1829,7 +1831,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void UploadFileAsyncCancelEvent ()
 		{
-			UploadAsyncCancelEventTest ((webClient, uri, cancelEvent) =>
+			UploadAsyncCancelEventTest (9304,(webClient, uri, cancelEvent) =>
 			{
 				string tempFile = Path.Combine (_tempFolder, "upload.tmp");
 				File.Create (tempFile).Close ();
@@ -1868,10 +1870,10 @@ namespace MonoTests.System.Net
 #endif
 
 #if NET_4_0
-		public void UploadAsyncCancelEventTest (Action<WebClient, Uri, EventWaitHandle> uploadAction)
+		public void UploadAsyncCancelEventTest (int port, Action<WebClient, Uri, EventWaitHandle> uploadAction)
 		{
-			var ep = new IPEndPoint (IPAddress.Loopback, 8000);
-			string url = "http://" + IPAddress.Loopback + ":8000/test/";
+			var ep = NetworkHelpers.LocalEphemeralEndPoint ();
+			string url = "http://" + ep.ToString() + "/test/";
 
 			using (var responder = new SocketResponder (ep, EchoRequestHandler))
 			{

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -14,5 +14,9 @@ namespace MonoTests.Helpers {
 			l.Stop();
 			return port;
 		}
+		public static IPEndPoint LocalEphemeralEndPoint ()
+		{
+			return new IPEndPoint (IPAddress.Loopback, FindFreePort());
+		}
 	}
 }


### PR DESCRIPTION
MonoTests.System.Net.HttpResponseStreamTest
MonoTests.System.Net.HttpWebResponseTest
MonoTests.System.Net.WebClientTest

seem to fail due to "Address already in use"
error that may be caused by opening listening
port too fast while in the 2MSL wait state.