### PR TITLE
Use random port numbers for ServiceModel tests.

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel_test.dll.sources
+++ b/mcs/class/System.ServiceModel/System.ServiceModel_test.dll.sources
@@ -211,3 +211,5 @@ MetadataTests/MetadataSamples.cs
 MetadataTests/TestContext.cs
 MetadataTests/TestLabel.cs
 MetadataTests/ExportTests.cs
+../../test-helpers/NetworkHelpers.cs
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/AsymmetricSecurityBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/AsymmetricSecurityBindingElementTest.cs
@@ -43,6 +43,8 @@ using System.Threading;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Channels
 {
 	[TestFixture]
@@ -131,7 +133,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			CustomBinding binding = new CustomBinding (sbe,
 				new HttpTransportBindingElement ());
 			IChannelListener<IReplyChannel> l =
-				binding.BuildChannelListener<IReplyChannel> (new Uri ("http://localhost:37564"), new BindingParameterCollection ());
+				binding.BuildChannelListener<IReplyChannel> (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()), new BindingParameterCollection ());
 			try {
 				l.Open ();
 			} finally {
@@ -171,11 +173,11 @@ namespace MonoTests.System.ServiceModel.Channels
 			b_res.ReceiveTimeout = b_res.SendTimeout = TimeSpan.FromSeconds (10);
 
 			EndpointAddress remaddr = new EndpointAddress (
-				new Uri ("http://localhost:37564"),
+				new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()),
 				new X509CertificateEndpointIdentity (cert2));
 			CalcProxy proxy = null;
 			ServiceHost host = new ServiceHost (typeof (CalcService));
-			host.AddServiceEndpoint (typeof (ICalc), b_res, "http://localhost:37564");
+			host.AddServiceEndpoint (typeof (ICalc), b_res, "http://localhost:" + NetworkHelpers.FindFreePort ());
 
 			ServiceCredentials cred = new ServiceCredentials ();
 			cred.ServiceCertificate.Certificate = cert;
@@ -240,7 +242,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				new HttpTransportBindingElement ();
 			CustomBinding binding = new CustomBinding (sbe, hbe);
 			host.AddServiceEndpoint (typeof (IFoo),
-				binding, new Uri ("http://localhost:37564"));
+				binding, new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			ServiceCredentials cred = new ServiceCredentials ();
 			cred.ServiceCertificate.Certificate =
 				new X509Certificate2 ("Test/Resources/test.pfx", "mono");

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/BinaryMessageEncodingBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/BinaryMessageEncodingBindingElementTest.cs
@@ -36,6 +36,8 @@ using System.Text;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 using Element = System.ServiceModel.Channels.BinaryMessageEncodingBindingElement;
 
 namespace MonoTests.System.ServiceModel.Channels
@@ -191,14 +193,15 @@ namespace MonoTests.System.ServiceModel.Channels
 			var bindingsvc = new CustomBinding (new BindingElement [] {
 				new BinaryMessageEncodingBindingElement (),
 				new TcpTransportBindingElement () });
-			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "net.tcp://localhost:37564/");
+			int port = NetworkHelpers.FindFreePort ();
+			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "net.tcp://localhost:" + port + "/");
 			host.Description.Behaviors.Find<ServiceBehaviorAttribute> ().IncludeExceptionDetailInFaults = true;
 			host.Open (TimeSpan.FromSeconds (5));
 			try {
 				for (int i = 0; i < 2; i++) {
 					var bindingcli = new NetTcpBinding ();
 					bindingcli.Security.Mode = SecurityMode.None;
-					var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("net.tcp://localhost:37564/")).CreateChannel ();
+					var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("net.tcp://localhost:" + port + "/")).CreateChannel ();
 					Assert.AreEqual ("test for echo", cli.Echo ("TEST FOR ECHO"), "#1");
 					var sid = cli.SessionId;
 					Assert.AreEqual (3000, cli.Add (1000, 2000), "#2");
@@ -207,7 +210,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				}
 			} finally {
 				host.Close (TimeSpan.FromSeconds (5));
-				var t = new TcpListener (37564);
+				var t = new TcpListener (port);
 				t.Start ();
 				t.Stop ();
 			}
@@ -220,7 +223,8 @@ namespace MonoTests.System.ServiceModel.Channels
 			var bindingsvc = new CustomBinding (new BindingElement [] {
 				new BinaryMessageEncodingBindingElement (),
 				new HttpTransportBindingElement () });
-			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "http://localhost:37564/");
+			int port = NetworkHelpers.FindFreePort ();
+			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "http://localhost:" + port + "/");
 			host.Description.Behaviors.Find<ServiceBehaviorAttribute> ().IncludeExceptionDetailInFaults = true;
 			host.Open (TimeSpan.FromSeconds (5));
 			try {
@@ -228,7 +232,7 @@ namespace MonoTests.System.ServiceModel.Channels
 					var bindingcli = new CustomBinding (new BindingElement [] {
 						new BinaryMessageEncodingBindingElement (),
 						new HttpTransportBindingElement () });
-					var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("http://localhost:37564/")).CreateChannel ();
+					var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("http://localhost:" + port + "/")).CreateChannel ();
 					Assert.AreEqual ("test for echo", cli.Echo ("TEST FOR ECHO"), "#1");
 					var sid = cli.SessionId;
 					Assert.AreEqual (3000, cli.Add (1000, 2000), "#2");
@@ -237,7 +241,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				}
 			} finally {
 				host.Close (TimeSpan.FromSeconds (5));
-				var t = new TcpListener (37564);
+				var t = new TcpListener (port);
 				t.Start ();
 				t.Stop ();
 			}

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CustomBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CustomBindingTest.cs
@@ -40,6 +40,8 @@ using System.Text;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Channels
 {
 	[TestFixture]
@@ -211,7 +213,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				new HandlerTransportBindingElement (sender));
 
 			EndpointAddress address = new EndpointAddress (
-				new Uri ("http://localhost:37564"),
+				new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()),
 				new X509CertificateEndpointIdentity (new X509Certificate2 ("Test/Resources/test.pfx", "mono")));
 
 			ChannelFactory<IRequestChannel> cf =
@@ -259,7 +261,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				new HandlerTransportBindingElement (sender));
 
 			EndpointAddress address = new EndpointAddress (
-				new Uri ("http://localhost:37564"),
+				new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()),
 				new X509CertificateEndpointIdentity (new X509Certificate2 ("Test/Resources/test.pfx", "mono")));
 
 			ChannelProtectionRequirements reqs =
@@ -322,7 +324,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				new HttpTransportBindingElement ());
 			BindingContext ctx = new BindingContext (
 				cb, new BindingParameterCollection (),
-				new Uri ("http://localhost:37564"), String.Empty, ListenUriMode.Unique);
+				new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()), String.Empty, ListenUriMode.Unique);
 			new TextMessageEncodingBindingElement ().BuildChannelListener<IReplyChannel> (ctx);
 		}
 
@@ -336,7 +338,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			ServiceHost host = new ServiceHost (typeof (FooService));
 			host.AddServiceEndpoint (typeof (IFooService),
 				new CustomBinding (new MyBindingElement (false), new HttpTransportBindingElement ()),
-				"http://localhost:37564");
+				"http://localhost:" + NetworkHelpers.FindFreePort ());
 			host.Open ();
 		}
 
@@ -349,7 +351,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			ServiceHost host = new ServiceHost (typeof (FooService));
 			host.AddServiceEndpoint (typeof (IFooService),
 				new CustomBinding (new MyBindingElement (true), new HttpTransportBindingElement ()),
-				"http://localhost:37564");
+				"http://localhost:" + NetworkHelpers.FindFreePort ());
 			host.Open ();
 			host.Close ();
 		}
@@ -363,7 +365,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			ServiceHost host = new ServiceHost (typeof (FooService));
 			host.AddServiceEndpoint (typeof (IFooService),
 				new CustomBinding (new MyBindingElement (true), new HttpTransportBindingElement ()),
-				"http://localhost:37564", new Uri ("foobar", UriKind.Relative));
+				"http://localhost:" + NetworkHelpers.FindFreePort (), new Uri ("foobar", UriKind.Relative));
 		}
 
 		[Test]
@@ -372,10 +374,10 @@ namespace MonoTests.System.ServiceModel.Channels
 		{
 			// MyBindingElement overrides GetProperty<T>() to call GetInnerProperty<T>() (default implementation).
 			// HttpTransportBindingElement should return Soap11.
-			ServiceHost host = new ServiceHost (typeof (FooService), new Uri ("http://localhost:37564"));
+			ServiceHost host = new ServiceHost (typeof (FooService), new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			host.AddServiceEndpoint (typeof (IFooService),
 				new CustomBinding (new MyBindingElement (true), new HttpTransportBindingElement ()),
-				"http://localhost:37564", new Uri ("foobar", UriKind.Relative));
+				"http://localhost:" + NetworkHelpers.FindFreePort (), new Uri ("foobar", UriKind.Relative));
 			host.Open ();
 			host.Close ();
 		}

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HttpTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HttpTransportBindingElementTest.cs
@@ -38,6 +38,8 @@ using System.Threading;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 #if NET_4_0
 using System.Security.Authentication.ExtendedProtection;
 #endif
@@ -203,7 +205,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			var cf = new HttpTransportBindingElement ().BuildChannelFactory<IRequestChannel> (ctx);
 			Assert.IsTrue (cf is ChannelFactoryBase<IRequestChannel>, "#1");
 			cf.Open ();
-			cf.CreateChannel (new EndpointAddress ("http://localhost:8080"), null);
+			cf.CreateChannel (new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()), null);
 		}
 
 		[Test]
@@ -228,7 +230,7 @@ namespace MonoTests.System.ServiceModel.Channels
 		public void EndpointAddressAndViaMustMatchOnAddressingNone ()
 		{
 			try {
-				var ch = ChannelFactory<IFoo>.CreateChannel (new BasicHttpBinding (), new EndpointAddress ("http://localhost:37564/"), new Uri ("http://localhost:8080/HogeService"));
+				var ch = ChannelFactory<IFoo>.CreateChannel (new BasicHttpBinding (), new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort () + "/"), new Uri ("http://localhost:" + NetworkHelpers.FindFreePort () + "/HogeService"));
 				((ICommunicationObject) ch).Close ();
 			} catch (TargetInvocationException) {
 				// we throw this exception so far. Since it is
@@ -338,7 +340,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			BindingContext lbc = new BindingContext (
 				new CustomBinding (),
 				new BindingParameterCollection (),
-				new Uri ("http://localhost:37564"),
+				new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()),
 				String.Empty, ListenUriMode.Explicit);
 			listener = lel.BuildChannelListener<IReplyChannel> (lbc);
 
@@ -370,7 +372,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			factory.Open ();
 
 			IRequestChannel request = factory.CreateChannel (
-				new EndpointAddress ("http://localhost:37564"));
+				new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 
 			request.Open ();
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SecurityBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SecurityBindingElementTest.cs
@@ -41,6 +41,8 @@ using System.ServiceModel.Security.Tokens;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Channels
 {
 	[TestFixture]
@@ -428,7 +430,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			ClientCredentials cred = new ClientCredentials ();
 			cred.ClientCertificate.Certificate =
 				new X509Certificate2 ("Test/Resources/test.pfx", "mono");
-			IChannelFactory<IReplyChannel> ch = b.BuildChannelFactory<IReplyChannel> (new Uri ("http://localhost:37564"), cred);
+			IChannelFactory<IReplyChannel> ch = b.BuildChannelFactory<IReplyChannel> (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()), cred);
 			try {
 				ch.Open ();
 			} finally {
@@ -456,7 +458,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			ServiceCredentials cred = new ServiceCredentials ();
 			cred.ServiceCertificate.Certificate =
 				new X509Certificate2 ("Test/Resources/test.pfx", "mono");
-			IChannelListener<IReplyChannel> ch = b.BuildChannelListener<IReplyChannel> (new Uri ("http://localhost:37564"), cred);
+			IChannelListener<IReplyChannel> ch = b.BuildChannelListener<IReplyChannel> (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()), cred);
 			try {
 				ch.Open ();
 			} finally {
@@ -478,7 +480,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				new UserNameSecurityTokenParameters ());
 			Binding b = new CustomBinding (be, new HttpTransportBindingElement ());
 			X509Certificate2 cert = new X509Certificate2 ("Test/Resources/test.pfx", "mono");
-			EndpointAddress ea = new EndpointAddress (new Uri ("http://localhost:37564"), new X509CertificateEndpointIdentity (cert));
+			EndpointAddress ea = new EndpointAddress (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()), new X509CertificateEndpointIdentity (cert));
 			CalcProxy client = new CalcProxy (b, ea);
 			client.ClientCredentials.UserName.UserName = "rupert";
 			client.Sum (1, 2);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TcpTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TcpTransportBindingElementTest.cs
@@ -37,6 +37,8 @@ using System.Threading;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Channels
 {
 	[TestFixture]
@@ -173,8 +175,9 @@ namespace MonoTests.System.ServiceModel.Channels
 				new TcpTransportBindingElement () });
 			bindingS.ReceiveTimeout = TimeSpan.FromSeconds (5);
 			bindingS.OpenTimeout = TimeSpan.FromSeconds (20);
+			int port = NetworkHelpers.FindFreePort ();
 			host.AddServiceEndpoint (typeof (IFoo),
-				bindingS, new Uri ("net.tcp://localhost:37564"));
+				bindingS, new Uri ("net.tcp://localhost:" + port));
 			host.Description.Behaviors.Find<ServiceBehaviorAttribute> ().IncludeExceptionDetailInFaults = true;
 			host.Open ();
 
@@ -182,7 +185,7 @@ namespace MonoTests.System.ServiceModel.Channels
 				for (int i = 0; i < 2; i++) {
 					var bindingC = new NetTcpBinding ();
 					bindingC.Security.Mode = SecurityMode.None;
-					IFooChannel proxy = new ChannelFactory<IFooChannel> (bindingC, new EndpointAddress ("net.tcp://localhost:37564/")).CreateChannel ();
+					IFooChannel proxy = new ChannelFactory<IFooChannel> (bindingC, new EndpointAddress ("net.tcp://localhost:" + port + "/")).CreateChannel ();
 					proxy.Open ();
 					try {
 						Assert.AreEqual ("TEST FOR ECHO", proxy.Echo ("TEST FOR ECHO"), "#1");
@@ -212,8 +215,9 @@ namespace MonoTests.System.ServiceModel.Channels
 			bindingS.Security.Mode = SecurityMode.None;
 			bindingS.ReceiveTimeout = TimeSpan.FromSeconds (5);
 			bindingS.OpenTimeout = TimeSpan.FromSeconds (20);
+			int port = NetworkHelpers.FindFreePort ();
 			host.AddServiceEndpoint (typeof (IFoo),
-				bindingS, new Uri ("net.tcp://localhost:37564"));
+				bindingS, new Uri ("net.tcp://localhost:" + port));
 			host.Description.Behaviors.Find<ServiceBehaviorAttribute> ().IncludeExceptionDetailInFaults = true;
 			host.Open ();
 
@@ -222,7 +226,7 @@ namespace MonoTests.System.ServiceModel.Channels
 					var bindingC = new NetTcpBinding ();
 					bindingS.TransferMode = TransferMode.Streamed;
 					bindingC.Security.Mode = SecurityMode.None;
-					IFooChannel proxy = new ChannelFactory<IFooChannel> (bindingC, new EndpointAddress ("net.tcp://localhost:37564/")).CreateChannel ();
+					IFooChannel proxy = new ChannelFactory<IFooChannel> (bindingC, new EndpointAddress ("net.tcp://localhost:" + port + "/")).CreateChannel ();
 					proxy.Open ();
 					try {
 						Assert.AreEqual ("TEST FOR ECHO", proxy.Echo ("TEST FOR ECHO"), "#1");

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataResolverTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataResolverTest.cs
@@ -38,17 +38,19 @@ using System.ServiceModel;
 
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Description
 {
 	[TestFixture]
 	public class MetadataResolverTest
 	{
-		string url = "http://localhost:37564/echo/mex";
+		string url;
 		//string url = "http://192.168.0.1:8080/echo/mex";
 
 		static HttpListener listener;
 		IAsyncResult current_request;
-		int remaining;
+		int remaining, port;
 
 		static readonly string mex = File.ReadAllText ("Test/System.ServiceModel.Description/dump.xml");
 
@@ -58,7 +60,9 @@ namespace MonoTests.System.ServiceModel.Description
 			if (listener != null)
 				listener.Stop ();
 			listener = new HttpListener ();
-			listener.Prefixes.Add ("http://*:37564/echo/");
+			port = NetworkHelpers.FindFreePort ();
+			url = "http://localhost:" + port + "/echo/mex";
+			listener.Prefixes.Add ("http://*:" + port + "/echo/");
 			listener.Start ();
 			current_request = listener.BeginGetContext (OnReceivedRequest, null);
 			remaining = 1;

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceAuthorizationBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceAuthorizationBehaviorTest.cs
@@ -34,6 +34,8 @@ using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Description
 {
 	[TestFixture]
@@ -73,7 +75,7 @@ namespace MonoTests.System.ServiceModel.Description
 			b.ImpersonateCallerForAllOperations = true;
 			b.PrincipalPermissionMode = PrincipalPermissionMode.None;
 
-			host.AddServiceEndpoint (typeof (TestService), new BasicHttpBinding (), new Uri ("http://localhost:37564"));
+			host.AddServiceEndpoint (typeof (TestService), new BasicHttpBinding (), new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 
 			host.Open ();
 		}
@@ -86,7 +88,7 @@ namespace MonoTests.System.ServiceModel.Description
 			b.ImpersonateCallerForAllOperations = false;
 			b.PrincipalPermissionMode = PrincipalPermissionMode.None;
 
-			host.AddServiceEndpoint (typeof (TestService2), new BasicHttpBinding (), new Uri ("http://localhost:37564"));
+			host.AddServiceEndpoint (typeof (TestService2), new BasicHttpBinding (), new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 
 			host.Open ();
 			var ed = ((ChannelDispatcher) host.ChannelDispatchers [0]).Endpoints [0];

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceDebugBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceDebugBehaviorTest.cs
@@ -36,6 +36,8 @@ using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Channels;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Description
 {
 	[TestFixture]
@@ -66,7 +68,7 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime1 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:37564"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "e1");
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
@@ -103,7 +105,7 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime2 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:37564"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
@@ -122,7 +124,7 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime3 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:37564"))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
 				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageEnabled = false;
 
@@ -140,9 +142,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime4 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:37564"))) {
+			int port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:37564/help");
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:" + port + "/help");
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
 
@@ -168,7 +171,7 @@ namespace MonoTests.System.ServiceModel.Description
 				Assert.AreEqual (0, ed.FilterPriority, "FilterPriority");
 
 				EndpointAddress ea = ed.EndpointAddress;
-				Assert.AreEqual (new Uri ("http://localhost:37564/help"), ea.Uri, "Uri");
+				Assert.AreEqual (new Uri ("http://localhost:" + port + "/help"), ea.Uri, "Uri");
 
 				DispatchRuntime dr = ed.DispatchRuntime;
 				Assert.AreEqual (1, dr.Operations.Count, "Operations.Count");
@@ -186,9 +189,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void ServiceMetadataExtension1 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:37564"))) {
+			int port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:37564/help");
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:" + port + "/help");
 				try {
 				host.Open ();
 
@@ -202,9 +206,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void ServiceMetadataExtension2 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:37564"))) {
+			int port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = CreateUri ("http://localhost:37564/help");
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = CreateUri ("http://localhost:" + port + "/help");
 
 				ServiceMetadataExtension extension = new ServiceMetadataExtension ();
 				host.Extensions.Add (extension);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceEndpointTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceEndpointTest.cs
@@ -35,6 +35,8 @@ using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Channels;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Description
 {
 	[TestFixture]
@@ -58,7 +60,7 @@ namespace MonoTests.System.ServiceModel.Description
 		[Test]
 		public void ListenUri ()
 		{
-			Uri uri = new Uri ("http://localhost:37564");
+			Uri uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			var se = new ServiceEndpoint (contract1, null, new EndpointAddress (uri));
 			Assert.AreEqual (uri, se.ListenUri, "#1");
 		}

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
@@ -35,6 +35,8 @@ using NUnit.Framework;
 
 using WebServiceMoonlightTest.ServiceReference1;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Dispatcher
 {
 	[TestFixture]
@@ -44,7 +46,8 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		public void Bug652331_2 () // test in one of the comment
 		{
 			// Init service
-			ServiceHost serviceHost = new ServiceHost (typeof (Service1), new Uri ("http://localhost:37564/Service1"));
+			int port = NetworkHelpers.FindFreePort ();
+			ServiceHost serviceHost = new ServiceHost (typeof (Service1), new Uri ("http://localhost:" + port + "/Service1"));
 			serviceHost.AddServiceEndpoint (typeof (IService1), new BasicHttpBinding (), string.Empty);
 
 			// Enable metadata exchange (WSDL publishing)
@@ -58,7 +61,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 			try {
 				// client
 				var binding = new BasicHttpBinding ();
-				var remoteAddress = new EndpointAddress ("http://localhost:37564/Service1");
+				var remoteAddress = new EndpointAddress ("http://localhost:" + port + "/Service1");
 				var client = new Service1Client (binding, remoteAddress);
 
 				var wait = new ManualResetEvent (false);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331_2Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331_2Test.cs
@@ -37,6 +37,8 @@ using NUnit.Framework;
 
 using WebServiceMoonlightTest.ServiceReference2;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Dispatcher
 {
 	[TestFixture]
@@ -47,7 +49,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		public void Bug652331_3 ()
 		{
 			// Init service
-			ServiceHost serviceHost = new ServiceHost(typeof(Service1), new Uri("http://localhost:37564/Service1"));
+			ServiceHost serviceHost = new ServiceHost(typeof(Service1), new Uri("http://localhost:" + NetworkHelpers.FindFreePort () + "/Service1"));
 			serviceHost.AddServiceEndpoint(typeof(IService1), new BasicHttpBinding(), string.Empty);
 
 			// Enable metadata exchange (WSDL publishing)
@@ -68,7 +70,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		void RunClient ()
 		{
 			var binding = new BasicHttpBinding ();
-			var remoteAddress = new EndpointAddress ("http://localhost:37564/Service1");
+			var remoteAddress = new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort () + "/Service1");
 
 			var normalClient      = new Service1Client (binding, remoteAddress);
 			var collectionClient  = new Service1Client (binding, remoteAddress);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ChannelDispatcherTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ChannelDispatcherTest.cs
@@ -10,6 +10,8 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Dispatcher
 {
 	[TestFixture]
@@ -42,7 +44,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 			var st = cd.ServiceThrottle;
 			Assert.IsNull (st, "#0");
 
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			h.AddServiceEndpoint (typeof (TestContract).FullName, new BasicHttpBinding (), "address");
 			h.ChannelDispatchers.Add (cd);
@@ -69,7 +71,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]			
 		public void Collection_Add_Remove () {
 			Console.WriteLine ("STart test Collection_Add_Remove");
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			h.AddServiceEndpoint (typeof (TestContract).FullName, new BasicHttpBinding (), "address");
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
@@ -87,7 +89,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]
 		public void EndpointDispatcherAddTest ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
 			d.Endpoints.Add (new EndpointDispatcher (new EndpointAddress (uri), "", ""));
 		}
@@ -95,7 +97,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]
 		[ExpectedException (typeof (InvalidOperationException))] 
 		public void EndpointDispatcherAddTest2 () {
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
 			d.Endpoints.Add (new EndpointDispatcher (new EndpointAddress (uri), "", ""));
 			d.Open (); // the dispatcher must be attached.
@@ -105,7 +107,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void EndpointDispatcherAddTest3 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
 			d.Endpoints.Add (new EndpointDispatcher (new EndpointAddress (uri), "", ""));
@@ -117,7 +119,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))] // i.e. it is thrown synchronously in current thread.
 		public void EndpointDispatcherAddTest4 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var listener = new MyChannelListener (uri);
 			MyChannelDispatcher d = new MyChannelDispatcher (listener);
@@ -149,7 +151,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))] // i.e. it is thrown synchronously in current thread.
 		public void EndpointDispatcherAddTest5 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var binding = new BasicHttpBinding ();
 			var listener = new MyChannelListener (uri);
@@ -171,7 +173,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]
 		public void EndpointDispatcherAddTest6 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var binding = new BasicHttpBinding ();
 			var listener = new MyChannelListener<IReplyChannel> (uri);
@@ -202,7 +204,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void EndpointDispatcherAddTest7 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var binding = new BasicHttpBinding ();
 			var listener = new MyChannelListener<IReplyChannel> (uri);
@@ -237,7 +239,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		// but it makes little sense especially for checking duplicate listen URIs. Duplicate listen URIs should be rejected anyways.
 		public void EndpointDispatcherAddTest8 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var listener = new MyChannelListener<IReplyChannel> (uri);
 			MyChannelDispatcher d = new MyChannelDispatcher (listener);
@@ -282,7 +284,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 //		[Test]
 		public void EndpointDispatcherAddTest9 () // test singleton service
 		{
-			var uri = CreateAvailableUri ("http://localhost:37564");
+			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (new TestContract (), uri);
 			h.Description.Behaviors.Find<ServiceBehaviorAttribute> ().InstanceContextMode = InstanceContextMode.Single;
 			var listener = new MyChannelListener<IReplyChannel> (uri);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchOperationTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchOperationTest.cs
@@ -37,6 +37,8 @@ using System.ServiceModel.Security;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Dispatcher
 {
 	[TestFixture]
@@ -88,11 +90,12 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		public void FaultContractInfos ()
 		{
 			var host = new ServiceHost (typeof (TestFaultContract));
+			int port = NetworkHelpers.FindFreePort ();
 			host.Description.Behaviors.Find<ServiceDebugBehavior> ().IncludeExceptionDetailInFaults = false;
-			host.AddServiceEndpoint (typeof (ITestFaultContract), new BasicHttpBinding (), new Uri ("http://localhost:37564"));
+			host.AddServiceEndpoint (typeof (ITestFaultContract), new BasicHttpBinding (), new Uri ("http://localhost:" + port));
 			host.Open ();
 			try {
-				var cf = new ChannelFactory<ITestFaultContract> (new BasicHttpBinding (), new EndpointAddress ("http://localhost:37564"));
+				var cf = new ChannelFactory<ITestFaultContract> (new BasicHttpBinding (), new EndpointAddress ("http://localhost:" + port));
 				var cli = cf.CreateChannel ();
 				try {
 					cli.Run ("default");

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityMessagePropertyTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityMessagePropertyTest.cs
@@ -42,6 +42,8 @@ using NUnit.Framework;
 
 using MonoTests.System.ServiceModel.Channels;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Security
 {
 	[TestFixture]
@@ -190,7 +192,7 @@ namespace MonoTests.System.ServiceModel.Security
 					sintercept,
 					transport);
 				b_res.ReceiveTimeout = b_res.SendTimeout = TimeSpan.FromSeconds (5);
-				host.AddServiceEndpoint (typeof (ICalc), b_res, "http://localhost:37564");
+				host.AddServiceEndpoint (typeof (ICalc), b_res, "http://localhost:" + NetworkHelpers.FindFreePort ());
 
 				ServiceCredentials cred = new ServiceCredentials ();
 				cred.ServiceCertificate.Certificate = cert;
@@ -223,7 +225,7 @@ namespace MonoTests.System.ServiceModel.Security
 
 			b_req.ReceiveTimeout = b_req.SendTimeout = TimeSpan.FromSeconds (5);
 			EndpointAddress remaddr = new EndpointAddress (
-				new Uri ("http://localhost:37564"),
+				new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()),
 				new X509CertificateEndpointIdentity (cert));
 			CalcProxy proxy = new CalcProxy (b_req, remaddr);
 			proxy.ClientCredentials.ClientCertificate.Certificate = cert2;

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/CallbackBehaviorAttributeTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/CallbackBehaviorAttributeTest.cs
@@ -39,6 +39,8 @@ using System.Transactions;
 using System.Threading;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -80,7 +82,7 @@ namespace MonoTests.System.ServiceModel
 			IEndpointBehavior eb = new CallbackBehaviorAttribute () { ConcurrencyMode = ConcurrencyMode.Multiple, ValidateMustUnderstand = false };
 			var cd = ContractDescription.GetContract (typeof (IFoo));
 			var se = new ServiceEndpoint (cd);
-			var ed = new EndpointDispatcher (new EndpointAddress ("http://localhost:37564"), "IFoo", "urn:foo");
+			var ed = new EndpointDispatcher (new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()), "IFoo", "urn:foo");
 			eb.ApplyDispatchBehavior (se, ed);
 		}
 
@@ -92,7 +94,7 @@ namespace MonoTests.System.ServiceModel
 			IEndpointBehavior eb = new CallbackBehaviorAttribute () { ConcurrencyMode = ConcurrencyMode.Multiple, ValidateMustUnderstand = false };
 			var cd = ContractDescription.GetContract (typeof (IFoo));
 			var se = new ServiceEndpoint (cd);
-			var ed = new EndpointDispatcher (new EndpointAddress ("http://localhost:37564"), "IFoo", "urn:foo");
+			var ed = new EndpointDispatcher (new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()), "IFoo", "urn:foo");
 			var cr = ed.DispatchRuntime.CallbackClientRuntime;
 			eb.ApplyClientBehavior (se, cr);
 		}
@@ -104,7 +106,7 @@ namespace MonoTests.System.ServiceModel
 			IEndpointBehavior eb = new CallbackBehaviorAttribute () { ConcurrencyMode = ConcurrencyMode.Multiple, ValidateMustUnderstand = false };
 			var cd = ContractDescription.GetContract (typeof (IDuplexFoo));
 			var se = new ServiceEndpoint (cd);
-			var ed = new EndpointDispatcher (new EndpointAddress ("http://localhost:37564"), "IDuplexFoo", "urn:foo");
+			var ed = new EndpointDispatcher (new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()), "IDuplexFoo", "urn:foo");
 			var cr = ed.DispatchRuntime.CallbackClientRuntime;
 			eb.ApplyClientBehavior (se, cr);
 			Assert.IsFalse (cr.ValidateMustUnderstand, "#2.1");

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactory_1Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactory_1Test.cs
@@ -38,6 +38,8 @@ using System.Xml.Serialization;
 using MonoTests.System.ServiceModel.Channels;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -63,14 +65,14 @@ namespace MonoTests.System.ServiceModel
 			//ChannelFactory<TestService> f =
 				new ChannelFactory<TestService> (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:37564"));
+					new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 		}
 
 		[Test]
 		public void EndpointAddressAfterCreateChannel ()
 		{
 			var f = new ChannelFactory<ITestService> (new BasicHttpBinding ());
-			f.CreateChannel (new EndpointAddress ("http://localhost:37564"), null);
+			f.CreateChannel (new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()), null);
 			Assert.IsNull (f.Endpoint.Address, "#1");
 		}
 
@@ -163,7 +165,7 @@ namespace MonoTests.System.ServiceModel
 			MyChannelFactory<ITestService> f =
 				new MyChannelFactory<ITestService> (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:37564"));
+					new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			Assert.AreEqual (CommunicationState.Created,
 				f.State, "#1");
 			f.OpenAnyways ();
@@ -179,7 +181,7 @@ namespace MonoTests.System.ServiceModel
 			ChannelFactory<ITestService> f =
 				new ChannelFactory<ITestService> (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:37564"));
+					new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			f.CreateChannel ();
 		}
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientBaseTest.cs
@@ -36,6 +36,8 @@ using System.ServiceModel.Description;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -217,22 +219,23 @@ namespace MonoTests.System.ServiceModel
 		[Ignore ("With Orcas it does not work fine")]
 		public void UseCase1Test ()
 		{
+			int port = NetworkHelpers.FindFreePort ();
 			// almost equivalent to samples/clientbase/samplesvc.cs
 			using (host = new ServiceHost (typeof (UseCase1))) {
 				Binding binding = new BasicHttpBinding ();
 				binding.ReceiveTimeout = TimeSpan.FromSeconds (15);
-				host.AddServiceEndpoint (typeof (IUseCase1).FullName, binding, new Uri ("http://localhost:37564"));
+				host.AddServiceEndpoint (typeof (IUseCase1).FullName, binding, new Uri ("http://localhost:" + port));
 
 				host.Open ();
 				// almost equivalent to samples/clientbase/samplecli.cs
 				using (UseCase1Proxy proxy = new UseCase1Proxy (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:37564"))) {
+					new EndpointAddress ("http://localhost:" + port))) {
 					proxy.Open ();
 					Assert.AreEqual ("TEST FOR ECHOTEST FOR ECHO", proxy.Echo ("TEST FOR ECHO"));
 				}
 			}
-			EnsurePortNonBlocking (37564);
+			EnsurePortNonBlocking (port);
 		}
 
 		void EnsurePortNonBlocking (int port)
@@ -357,8 +360,9 @@ namespace MonoTests.System.ServiceModel
 			ServiceHost host = new ServiceHost (typeof (UseCase2));
 			Binding binding = new BasicHttpBinding ();
 			binding.ReceiveTimeout = TimeSpan.FromSeconds (15);
+			int port = NetworkHelpers.FindFreePort ();
 			host.AddServiceEndpoint (typeof (IUseCase2).FullName,
-			binding, new Uri ("http://localhost:37564"));
+			binding, new Uri ("http://localhost:" + port));
 
 			try {
 				host.Open ();
@@ -368,7 +372,7 @@ namespace MonoTests.System.ServiceModel
 				b.ReceiveTimeout = TimeSpan.FromSeconds (15);
 				UseCase2Proxy proxy = new UseCase2Proxy (
 					b,
-					new EndpointAddress ("http://localhost:37564/"));
+					new EndpointAddress ("http://localhost:" + port + "/"));
 				proxy.Open ();
 				Message req = Message.CreateMessage (MessageVersion.Soap11, "http://tempuri.org/IUseCase2/Echo");
 				Message res = proxy.Echo (req);
@@ -378,7 +382,7 @@ namespace MonoTests.System.ServiceModel
 			} finally {
 				if (host.State == CommunicationState.Opened)
 					host.Close ();
-				EnsurePortNonBlocking (37564);
+				EnsurePortNonBlocking (port);
 			}
 		}
 
@@ -426,9 +430,10 @@ namespace MonoTests.System.ServiceModel
 			Binding bs = new BasicHttpBinding ();
 			bs.SendTimeout = TimeSpan.FromSeconds (5);
 			bs.ReceiveTimeout = TimeSpan.FromSeconds (5);
+			int port = NetworkHelpers.FindFreePort ();
 			// magic name that does not require fully qualified name ...
 			host.AddServiceEndpoint ("IMetadataExchange",
-			        bs, new Uri ("http://localhost:37564"));
+			        bs, new Uri ("http://localhost:" + port));
 			try {
 				host.Open ();
 				// almost equivalent to samples/clientbase/samplecli3.cs
@@ -437,7 +442,7 @@ namespace MonoTests.System.ServiceModel
 				bc.ReceiveTimeout = TimeSpan.FromSeconds (5);
 				MetadataExchangeProxy proxy = new MetadataExchangeProxy (
 					bc,
-					new EndpointAddress ("http://localhost:37564/"));
+					new EndpointAddress ("http://localhost:" + port + "/"));
 				proxy.Open ();
 
 				Message req = Message.CreateMessage (MessageVersion.Soap11, "http://schemas.xmlsoap.org/ws/2004/09/transfer/Get");
@@ -448,7 +453,7 @@ namespace MonoTests.System.ServiceModel
 			} finally {
 				if (host.State == CommunicationState.Opened)
 					host.Close ();
-				EnsurePortNonBlocking (37564);
+				EnsurePortNonBlocking (port);
 			}
 		}
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientBase_InteractiveChannelInitializerTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientBase_InteractiveChannelInitializerTest.cs
@@ -37,6 +37,8 @@ using System.ServiceModel.Dispatcher;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -48,7 +50,7 @@ namespace MonoTests.System.ServiceModel
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void NotAllowedInitializationUI ()
 		{
-			var f = new FooProxy (new BasicHttpBinding (), new EndpointAddress ("http://localhost:37564"));
+			var f = new FooProxy (new BasicHttpBinding (), new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			f.Endpoint.Contract.Behaviors.Add (new MyContractBehavior ());
 			f.InnerChannel.AllowInitializationUI = false;
 			f.DisplayInitializationUI ();
@@ -58,7 +60,7 @@ namespace MonoTests.System.ServiceModel
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void OpenBeforeDisplayInitializationUI ()
 		{
-			var f = new FooProxy (new BasicHttpBinding (), new EndpointAddress ("http://localhost:37564"));
+			var f = new FooProxy (new BasicHttpBinding (), new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			f.Endpoint.Contract.Behaviors.Add (new MyContractBehavior ());
 			f.Open ();
 		}

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientCredentialsSecurityTokenManagerTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientCredentialsSecurityTokenManagerTest.cs
@@ -42,6 +42,8 @@ using MonoTests.System.ServiceModel.Channels;
 
 using ReqType = System.ServiceModel.Security.Tokens.ServiceModelSecurityTokenRequirement;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -621,7 +623,7 @@ Assert.IsFalse (new MyManager (new MyClientCredentials ()).IsIssued (r), "premis
 			be.EndpointSupportingTokenParameters.Endorsing.Add (
 				new MyEndorsingTokenParameters ());
 			Binding b = new CustomBinding (be, new HttpTransportBindingElement ());
-			EndpointAddress ea = new EndpointAddress (new Uri ("http://localhost:37564"), new X509CertificateEndpointIdentity (cert));
+			EndpointAddress ea = new EndpointAddress (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()), new X509CertificateEndpointIdentity (cert));
 			CalcProxy client = new CalcProxy (b, ea);
 			client.Endpoint.Behaviors.RemoveAll<ClientCredentials> ();
 			client.Endpoint.Behaviors.Add (new MyClientCredentials ());

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/IntegratedConnectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/IntegratedConnectionTest.cs
@@ -39,6 +39,7 @@ using System.Threading;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
 
 namespace MonoTests.System.ServiceModel
 {
@@ -55,17 +56,18 @@ namespace MonoTests.System.ServiceModel
 		{
 			// Service
 			ServiceHost host = new ServiceHost (typeof (Foo));
+			int port = NetworkHelpers.FindFreePort ();
 			try {
 				Binding binding = new BasicHttpBinding ();
 				binding.SendTimeout = binding.ReceiveTimeout = TimeSpan.FromSeconds (5);
 				ServiceEndpoint se = host.AddServiceEndpoint ("MonoTests.System.ServiceModel.IFoo",
-					binding, new Uri ("http://localhost:37564"));
+					binding, new Uri ("http://localhost:" + port));
 				host.Open ();
 
 				// Client
 				ChannelFactory<IFoo> cf = new ChannelFactory<IFoo> (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:37564/"));
+					new EndpointAddress ("http://localhost:" + port + "/"));
 				IFoo foo  = cf.CreateChannel ();
 				Assert.AreEqual ("Test for EchoTest for Echo", foo.Echo ("Test for Echo"));
 			} finally {
@@ -80,17 +82,18 @@ namespace MonoTests.System.ServiceModel
 		{
 			// Service
 			ServiceHost host = new ServiceHost (typeof (Foo2));
+			int port = NetworkHelpers.FindFreePort ();
 			try {
 				Binding binding = new BasicHttpBinding ();
 				binding.SendTimeout = binding.ReceiveTimeout = TimeSpan.FromSeconds (5);
 				host.AddServiceEndpoint ("MonoTests.System.ServiceModel.IFoo2",
-				binding, new Uri ("http://localhost:37564"));
+				binding, new Uri ("http://localhost:" + port));
 				host.Open ();
 
 				// Client
 				Foo2Proxy proxy = new Foo2Proxy (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:37564/"));
+					new EndpointAddress ("http://localhost:" + port + "/"));
 				proxy.Open ();
 				try {
 					Assert.AreEqual ("TEST FOR ECHOTEST FOR ECHO",
@@ -111,17 +114,18 @@ namespace MonoTests.System.ServiceModel
 		{
 			// Service
 			ServiceHost host = new ServiceHost (typeof (MetadataExchange));
+			int port = NetworkHelpers.FindFreePort ();
 			try {
 				Binding binding = new BasicHttpBinding ();
 				binding.ReceiveTimeout = TimeSpan.FromSeconds (5);
 				host.AddServiceEndpoint ("IMetadataExchange",
-				binding, new Uri ("http://localhost:37564"));
+				binding, new Uri ("http://localhost:" + port));
 				host.Open ();
 				// Client
 
 				MetadataExchangeProxy proxy = new MetadataExchangeProxy (
 					new BasicHttpBinding (),
-					new EndpointAddress ("http://localhost:37564/"));
+					new EndpointAddress ("http://localhost:" + port + "/"));
 				proxy.Open ();
 
 				try {

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetTcpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetTcpBindingTest.cs
@@ -35,6 +35,8 @@ using System.ServiceModel.Security;
 using System.Threading;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -167,17 +169,18 @@ namespace MonoTests.System.ServiceModel
 		{
 			var host = new ServiceHost (typeof (Foo));
 			var bindingsvc = new CustomBinding (new BinaryMessageEncodingBindingElement (), new TcpTransportBindingElement ());
-			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "net.tcp://localhost:37564/");
+			int port = NetworkHelpers.FindFreePort ();
+			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "net.tcp://localhost:" + port + "/");
 			host.Open (TimeSpan.FromSeconds (5));
 			try {
 				var bindingcli = new NetTcpBinding () { TransactionFlow = false };
 				bindingcli.Security.Mode = SecurityMode.None;
-				var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("net.tcp://localhost:37564/")).CreateChannel ();
+				var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("net.tcp://localhost:" + port + "/")).CreateChannel ();
 				Assert.AreEqual (5, cli.Add (1, 4));
 				Assert.AreEqual ("monkey science", cli.Join ("monkey", "science"));
 			} finally {
 				host.Close (TimeSpan.FromSeconds (5));
-				var t = new TcpListener (37564);
+				var t = new TcpListener (port);
 				t.Start ();
 				t.Stop ();
 			}
@@ -190,18 +193,19 @@ namespace MonoTests.System.ServiceModel
 		{
 			var host = new ServiceHost (typeof (Foo));
 			var bindingsvc = new CustomBinding (new BinaryMessageEncodingBindingElement (), new TcpTransportBindingElement () { TransferMode = TransferMode.Streamed });
-			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "net.tcp://localhost:37564/");
+			int port = NetworkHelpers.FindFreePort ();
+			host.AddServiceEndpoint (typeof (IFoo), bindingsvc, "net.tcp://localhost:" + port + "/");
 			host.Open (TimeSpan.FromSeconds (5));
 			try {
 				var bindingcli = new NetTcpBinding () { TransactionFlow = false };
 				bindingcli.TransferMode = TransferMode.Streamed;
 				bindingcli.Security.Mode = SecurityMode.None;
-				var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("net.tcp://localhost:37564/")).CreateChannel ();
+				var cli = new ChannelFactory<IFooClient> (bindingcli, new EndpointAddress ("net.tcp://localhost:" + port + "/")).CreateChannel ();
 				Assert.AreEqual (5, cli.Add (1, 4));
 				Assert.AreEqual ("monkey science", cli.Join ("monkey", "science"));
 			} finally {
 				host.Close (TimeSpan.FromSeconds (5));
-				var t = new TcpListener (37564);
+				var t = new TcpListener (port);
 				t.Start ();
 				t.Stop ();
 			}

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/OperationContextTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/OperationContextTest.cs
@@ -35,6 +35,8 @@ using System.ServiceModel;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel
 {
 	[TestFixture]
@@ -50,7 +52,7 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void UserContextProperties ()
 		{
-			var ch = ChannelFactory<IFooChannel>.CreateChannel (new BasicHttpBinding (), new EndpointAddress ("http://localhost:37564"));
+			var ch = ChannelFactory<IFooChannel>.CreateChannel (new BasicHttpBinding (), new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			var o = new OperationContext (ch);
 
 			// FIXME: this is strange. It should return non-null value.
@@ -91,7 +93,7 @@ namespace MonoTests.System.ServiceModel
 			Assert.IsNull (OperationContext.Current, "Current-1");
 
 			try {
-				var ch = ChannelFactory<IFooChannel>.CreateChannel (new BasicHttpBinding (), new EndpointAddress ("http://localhost:37564"));
+				var ch = ChannelFactory<IFooChannel>.CreateChannel (new BasicHttpBinding (), new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 				OperationContext.Current = new OperationContext (ch);
 				Assert.IsNotNull (OperationContext.Current, "Current-2");
 			}

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
@@ -273,9 +273,9 @@ namespace MonoTests.System.ServiceModel
 		{
 			var host = new Poker ();
 			Assert.AreEqual (0, host.BaseAddresses.Count, "#1");
-			host.DoAddBaseAddress (new Uri ("http://localhost:37564"));
+			host.DoAddBaseAddress (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			Assert.AreEqual (1, host.BaseAddresses.Count, "#1");
-			host.DoAddBaseAddress (new Uri ("net.tcp://localhost:893"));
+			host.DoAddBaseAddress (new Uri ("net.tcp://localhost:" + NetworkHelpers.FindFreePort ()));
 			Assert.AreEqual (2, host.BaseAddresses.Count, "#1");
 		}
 
@@ -285,31 +285,33 @@ namespace MonoTests.System.ServiceModel
 		{
 			var host = new Poker ();
 			Assert.AreEqual (0, host.BaseAddresses.Count, "#1");
-			host.DoAddBaseAddress (new Uri ("http://localhost:37564"));
+			host.DoAddBaseAddress (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 			// http base address is already added.
-			host.DoAddBaseAddress (new Uri ("http://localhost:893"));
+			host.DoAddBaseAddress (new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()));
 		}
 
 		[Test]
 		public void AddServiceEndpointUri ()
 		{
+			int port = NetworkHelpers.FindFreePort ();
 			var host = new ServiceHost (typeof (AllActions),
-				new Uri ("http://localhost:37564"));
+				new Uri ("http://localhost:" + port));
 			var se = host.AddServiceEndpoint (typeof (AllActions),
 				new BasicHttpBinding (), "foobar");
-			Assert.AreEqual ("http://localhost:37564/foobar", se.Address.Uri.AbsoluteUri, "#1");
-			Assert.AreEqual ("http://localhost:37564/foobar", se.ListenUri.AbsoluteUri, "#2");
+			Assert.AreEqual ("http://localhost:" + port + "/foobar", se.Address.Uri.AbsoluteUri, "#1");
+			Assert.AreEqual ("http://localhost:" + port + "/foobar", se.ListenUri.AbsoluteUri, "#2");
 		}
 
 		[Test]
 		public void AddServiceEndpointUri2 ()
 		{
+			int port = NetworkHelpers.FindFreePort ();
 			var host = new ServiceHost (typeof (AllActions),
-				new Uri ("http://localhost:37564"));
+				new Uri ("http://localhost:" + port));
 			var se = host.AddServiceEndpoint (typeof (AllActions),
 				new BasicHttpBinding (), String.Empty);
-			Assert.AreEqual ("http://localhost:37564/", se.Address.Uri.AbsoluteUri, "#1");
-			Assert.AreEqual ("http://localhost:37564/", se.ListenUri.AbsoluteUri, "#2");
+			Assert.AreEqual ("http://localhost:" + port + "/", se.Address.Uri.AbsoluteUri, "#1");
+			Assert.AreEqual ("http://localhost:" + port + "/", se.ListenUri.AbsoluteUri, "#2");
 		}
 
 		[Test]


### PR DESCRIPTION
This prevents race conditions when running multiple test suites at once on the same computer, as happens on our ARM builders.