### PR TITLE
initialize ReaderQuotas, fixes bugzilla #15153

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel/NetTcpBinding.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/NetTcpBinding.cs
@@ -43,7 +43,8 @@ namespace System.ServiceModel
 		int max_conn;
 		OptionalReliableSession reliable_session;
 		NetTcpSecurity security;
-		XmlDictionaryReaderQuotas reader_quotas;
+		XmlDictionaryReaderQuotas reader_quotas
+			= new XmlDictionaryReaderQuotas ();
 		bool transaction_flow;
 		TransactionProtocol transaction_protocol;
 		TcpTransportBindingElement transport;


### PR DESCRIPTION
Fixes [Bug 15153](https://bugzilla.xamarin.com/show_bug.cgi?id=15153) "`System.ServiceModel.NetTcpBinding` properties are not pre-initialized while they are in .NET causing interoperability problems."

Specifically the `reader_quotas` member of `System.ServiceModel.NetTcpBinding` is not initialized to a new `XmlDictionaryReaderQuotas` object which causes a "`NullReferenceException`: Object reference not set to an instance of an object." whenever an attempt is made to set any attributes of that property.

For example:

    using System.ServiceModel;
    NetTcpBinding binding = new NetTcpBinding(SecurityMode.None);
    binding.ReaderQuotas.MaxStringContentLength = 8192;

raises "`NullReferenceException`: Object reference not set to an instance of an object."

OP: [Eddy Hahn](mailto:eddyhahn@hotmail.com)
>Description of Problem:
Properties of System.ServiceModel.NetTcpBinding should be pre-created just like
.Net.  Specifically ReaderQuotas and ReliableSession properties should have the
objects precreated and initialized.

>Steps to reproduce the problem:
1. Create NetTcpBinding and try to set a property of ReaderQuotas or
ReliableSession.  Both will throw a NullObject exception.  In .Net (Microsoft)
when a NetTCPBiniding is created thoese two properties are point to a
pre-created instance.
2. NetTcpBinding binding = new NetTcpBinding();

>binding.ReaderQuotas.MaxDepth = 64;   //will cause an error in Mono
ReaderQuotas are not initialized with an object.  .Net will work
binding.ReliableSession.Enabled = false;   //same here. But worst because
ReliableSession is read only so there is no way to fix it by creating the
object for ReliableSession


>Actual Results:
Assembly moved from Windows (it works on Windows) will break because
un-initialized properties in Mono

>Expected Results:
These properties are pre-initialized just like in .Net and assembly work when
copied from Windows.

>How often does this happen? 
Always

>Additional Information: