### PR TITLE
[xbuild] Fix Microsoft.VisualBasic.targets to contain correct VbcToolExe

### DIFF
--- a/mcs/tools/xbuild/data/Microsoft.VisualBasic.targets
+++ b/mcs/tools/xbuild/data/Microsoft.VisualBasic.targets
@@ -114,11 +114,7 @@
 	<Import Project="Microsoft.Common.targets" />
 
 	<PropertyGroup>
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' != 'v4.0' and '$(OS)' != 'Windows_NT'">vbnc2</VbcToolExe>
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' != 'v4.0' and '$(OS)' == 'Windows_NT'">vbnc2.bat</VbcToolExe>
-
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' == 'v4.0' and '$(OS)' != 'Windows_NT'">vbnc</VbcToolExe>
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' == 'v4.0' and '$(OS)' == 'Windows_NT'">vbnc.bat</VbcToolExe>
+		<VbcToolExe Condition="'$(VbcToolExe)' == ''">vbnc.exe</VbcToolExe>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Compiling VB projects was broken since a few releases but apparently went unnoticed.
The VbcToolExe path needs to be set to "vbnc.exe" because vbnc2 and vbnc shell scripts
don't work in this case and we only support building against the reference assemblies anyway
now for different targets.

I tested this on Windows and Linux. Fixes [29362](https://bugzilla.xamarin.com/show_bug.cgi?id=29362). I think this should go into 4.2-pre as well.

@rolfbjarne fyi