### PR TITLE
[xbuild] Fix Microsoft.VisualBasic.targets to contain correct VbcToolExe (4.2 branch)

### DIFF
--- a/mcs/tools/xbuild/data/Microsoft.VisualBasic.targets
+++ b/mcs/tools/xbuild/data/Microsoft.VisualBasic.targets
@@ -114,11 +114,7 @@
 	<Import Project="Microsoft.Common.targets" />
 
 	<PropertyGroup>
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' != 'v4.0' and '$(OS)' != 'Windows_NT'">vbnc2</VbcToolExe>
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' != 'v4.0' and '$(OS)' == 'Windows_NT'">vbnc2.bat</VbcToolExe>
-
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' == 'v4.0' and '$(OS)' != 'Windows_NT'">vbnc</VbcToolExe>
-		<VbcToolExe Condition="'$(VbcToolExe)' == '' and '$(TargetFrameworkVersion)' == 'v4.0' and '$(OS)' == 'Windows_NT'">vbnc.bat</VbcToolExe>
+		<VbcToolExe Condition="'$(VbcToolExe)' == ''">vbnc.exe</VbcToolExe>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Like https://github.com/mono/mono/pull/1884, but for the 4.2 branch