### PR TITLE
Null reference check before calling delegate

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
@@ -404,13 +404,15 @@ namespace System.Net.NetworkInformation {
 		void OnAvailabilityChanged (object unused)
 		{
 			NetworkAvailabilityChangedEventHandler d = AvailabilityChanged;
-			d (null, new NetworkAvailabilityEventArgs (GetAvailability ()));
+			if (d != null)
+				d (null, new NetworkAvailabilityEventArgs (GetAvailability ()));
 		}
 
 		void OnAddressChanged (object unused)
 		{
 			NetworkAddressChangedEventHandler d = AddressChanged;
-			d (null, EventArgs.Empty);
+			if (d != null)
+				d (null, EventArgs.Empty);
 		}
 
 		void OnEventDue (object unused)


### PR DESCRIPTION
We see a crash in LinuxNetworkChange.OnAvailabilityChanged when dereferencing the AvailabilityChanged delegate (NullReferenceException). There is a race here: the OnAvailabilityChanged is fired by deferring to the ThreadPool, which allows an unregister to come in between, removing the potential registration before we get called back.