### PR TITLE
[mdoc] Adds custom formatting for the `ObjCRuntime.Platform` enum.

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -127,6 +127,9 @@ Test/DocTest.dll-v2:
 	-rm -f Test/DocTest.dll
 	$(MAKE) TEST_CSCFLAGS=$(TEST_CSCFLAGS) Test/DocTest.dll
 
+Test/DocTest-enumerations.dll: 
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -debug -unsafe -target:library -out:$@ Test/DocTest-enumerations.cs
+
 check-monodocer-addNonGeneric: $(PROGRAM)
 	-rm -Rf Test/en.actual
 	# first, make a docset with the generic method
@@ -175,6 +178,12 @@ check-monodocer-internal-interface: $(PROGRAM)
 	$(MAKE) Test/DocTest-InternalInterface.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-InternalInterface.dll
 	diff --exclude=.svn -rup Test/en.expected-internal-interface Test/en.actual
+
+check-monodocer-enumerations: $(PROGRAM)
+	-rm -Rf Test/en.actual
+	$(MAKE) Test/DocTest-enumerations.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-enumerations.dll
+	diff --exclude=.svn -rup Test/en.expected-enumerations Test/en.actual
 
 check-monodocer-update: $(PROGRAM)
 	find Test/en.expected -name \*.xml -exec rm "{}" \;
@@ -335,6 +344,7 @@ check-doc-tools-update: check-monodocer-since-update \
 	check-monodocer-dropns-classic \
 	check-monodocer-dropns-classic-withsecondary \
 	check-monodocer-internal-interface \
+	check-monodocer-enumerations \
 	check-monodocer-delete-update \
 	check-mdoc-export-html-update \
 	check-mdoc-export-msxdoc-update \

--- a/mcs/tools/mdoc/Test/DocTest-enumerations.cs
+++ b/mcs/tools/mdoc/Test/DocTest-enumerations.cs
@@ -1,0 +1,79 @@
+using System;
+using ObjCRuntime;
+namespace ObjCRuntime {
+	[Flags]
+	public enum Platform : ulong {
+		None = 0,
+		iOS_2_0 = 		0x0000000000020000,
+		iOS_2_2 = 		0x0000000000020200,
+		iOS_3_0 = 		0x0000000000030000,
+		iOS_3_1 = 		0x0000000000030100,
+		iOS_3_2 = 		0x0000000000030200,
+		iOS_4_0 = 		0x0000000000040000,
+		iOS_4_1 = 		0x0000000000040100,
+		iOS_4_2 = 		0x0000000000040200,
+		iOS_4_3 = 		0x0000000000040300,
+		iOS_5_0 = 		0x0000000000050000,
+		iOS_5_1 = 		0x0000000000050100,
+		iOS_6_0 = 		0x0000000000060000,
+		iOS_6_1 = 		0x0000000000060100,
+		iOS_7_0 = 		0x0000000000070000,
+		iOS_7_1 = 		0x0000000000070100,
+		iOS_8_0 = 		0x0000000000080000,
+		iOS_8_1 = 		0x0000000000080100,
+		iOS_8_2 = 		0x0000000000080200,
+		iOS_8_3 = 		0x0000000000080300,
+		Mac_10_0 = 		0x000A000000000000,
+		Mac_10_1 = 		0x000A010000000000,
+		Mac_10_2 = 		0x000A020000000000,
+		Mac_10_3 = 		0x000A030000000000,
+		Mac_10_4 = 		0x000A040000000000,
+		Mac_10_5 = 		0x000A050000000000,
+		Mac_10_6 = 		0x000A060000000000,
+		Mac_10_7 = 		0x000A070000000000,
+		Mac_10_8 = 		0x000A080000000000,
+		Mac_10_9 = 		0x000A090000000000,
+		Mac_10_10 = 	0x000A0A0000000000,
+		iOS_Version = 	0x0000000000FFFFFF,
+		Mac_Version = 	0x00FFFFFF00000000,
+		Mac_Arch32 = 	0x0100000000000000,
+		Mac_Arch64 = 	0x0200000000000000,
+		Mac_Arch = 		0xFF00000000000000,
+		iOS_Arch32 = 	0x0000000001000000,
+		iOS_Arch64 = 	0x0000000002000000,
+		iOS_Arch = 		0x00000000FF000000
+	}
+}
+namespace MyNamespace {
+	public enum MyEnum {
+		One,
+		Two,
+		Three
+	}
+	public class MyFlagEnumAttribute : Attribute {
+		public Platform Enum {get;set;}
+		public MyFlagEnumAttribute(){}
+		public MyFlagEnumAttribute (Platform value) {
+			this.Enum = value;
+		}
+	}
+	public class MyEnumAttribute : Attribute {
+		public MyEnum Enum {get;set;}
+		public MyEnumAttribute(){}
+		public MyEnumAttribute (MyEnum value) {
+			this.Enum = value;
+		}
+	}
+	public class MyClass {
+		[MyFlagEnum(value: Platform.None)]
+		public string None() { return string.Empty; }
+		[MyFlagEnum(value: Platform.Mac_10_8 | Platform.Mac_Arch64)]
+		public string MacMethod() { return string.Empty; }
+		[MyFlagEnum(value: Platform.iOS_Arch32 | Platform.iOS_4_2)]
+		public string iOSMethod() { return string.Empty; }
+		[MyEnum(value: MyEnum.One)]
+		public string RegularEnum() { return string.Empty; }
+		[MyEnum(value: (MyEnum)234234)]
+		public string UnknownEnumValue() { return string.Empty; }
+	}
+}

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyClass.xml
@@ -1,0 +1,141 @@
+<Type Name="MyClass" FullName="MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-enumerations</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="iOSMethod">
+      <MemberSignature Language="C#" Value="public string iOSMethod ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string iOSMethod() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>MyNamespace.MyFlagEnum(Platform.iOS_4_2 | Platform.iOS_Arch32)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MacMethod">
+      <MemberSignature Language="C#" Value="public string MacMethod ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string MacMethod() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>MyNamespace.MyFlagEnum(Platform.Mac_10_8 | Platform.Mac_Arch64)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="None">
+      <MemberSignature Language="C#" Value="public string None ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string None() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>MyNamespace.MyFlagEnum(ObjCRuntime.Platform.None)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RegularEnum">
+      <MemberSignature Language="C#" Value="public string RegularEnum ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string RegularEnum() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>MyNamespace.MyEnum(MyNamespace.MyEnum.One)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UnknownEnumValue">
+      <MemberSignature Language="C#" Value="public string UnknownEnumValue ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string UnknownEnumValue() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>MyNamespace.MyEnum((MyNamespace.MyEnum) 234234)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyEnum.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyEnum.xml
@@ -1,0 +1,59 @@
+<Type Name="MyEnum" FullName="MyNamespace.MyEnum">
+  <TypeSignature Language="C#" Value="public enum MyEnum" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed MyEnum extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-enumerations</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="One">
+      <MemberSignature Language="C#" Value="One" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype MyNamespace.MyEnum One = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Three">
+      <MemberSignature Language="C#" Value="Three" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype MyNamespace.MyEnum Three = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Two">
+      <MemberSignature Language="C#" Value="Two" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype MyNamespace.MyEnum Two = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyEnumAttribute.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyEnumAttribute.xml
@@ -1,0 +1,63 @@
+<Type Name="MyEnumAttribute" FullName="MyNamespace.MyEnumAttribute">
+  <TypeSignature Language="C#" Value="public class MyEnumAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyEnumAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-enumerations</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyEnumAttribute ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyEnumAttribute (MyNamespace.MyEnum value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(valuetype MyNamespace.MyEnum value) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="value" Type="MyNamespace.MyEnum" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Enum">
+      <MemberSignature Language="C#" Value="public MyNamespace.MyEnum Enum { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype MyNamespace.MyEnum Enum" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyFlagEnumAttribute.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/MyNamespace/MyFlagEnumAttribute.xml
@@ -1,0 +1,63 @@
+<Type Name="MyFlagEnumAttribute" FullName="MyNamespace.MyFlagEnumAttribute">
+  <TypeSignature Language="C#" Value="public class MyFlagEnumAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyFlagEnumAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-enumerations</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyFlagEnumAttribute ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyFlagEnumAttribute (ObjCRuntime.Platform value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(valuetype ObjCRuntime.Platform value) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="value" Type="ObjCRuntime.Platform" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Enum">
+      <MemberSignature Language="C#" Value="public ObjCRuntime.Platform Enum { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype ObjCRuntime.Platform Enum" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/ObjCRuntime/Platform.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/ObjCRuntime/Platform.xml
@@ -1,0 +1,568 @@
+<Type Name="Platform" FullName="ObjCRuntime.Platform">
+  <TypeSignature Language="C#" Value="public enum Platform" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed Platform extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-enumerations</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.Flags</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="iOS_2_0">
+      <MemberSignature Language="C#" Value="iOS_2_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_2_0 = unsigned int64(131072)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_2_2">
+      <MemberSignature Language="C#" Value="iOS_2_2" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_2_2 = unsigned int64(131584)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_3_0">
+      <MemberSignature Language="C#" Value="iOS_3_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_3_0 = unsigned int64(196608)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_3_1">
+      <MemberSignature Language="C#" Value="iOS_3_1" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_3_1 = unsigned int64(196864)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_3_2">
+      <MemberSignature Language="C#" Value="iOS_3_2" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_3_2 = unsigned int64(197120)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_4_0">
+      <MemberSignature Language="C#" Value="iOS_4_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_4_0 = unsigned int64(262144)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_4_1">
+      <MemberSignature Language="C#" Value="iOS_4_1" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_4_1 = unsigned int64(262400)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_4_2">
+      <MemberSignature Language="C#" Value="iOS_4_2" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_4_2 = unsigned int64(262656)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_4_3">
+      <MemberSignature Language="C#" Value="iOS_4_3" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_4_3 = unsigned int64(262912)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_5_0">
+      <MemberSignature Language="C#" Value="iOS_5_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_5_0 = unsigned int64(327680)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_5_1">
+      <MemberSignature Language="C#" Value="iOS_5_1" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_5_1 = unsigned int64(327936)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_6_0">
+      <MemberSignature Language="C#" Value="iOS_6_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_6_0 = unsigned int64(393216)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_6_1">
+      <MemberSignature Language="C#" Value="iOS_6_1" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_6_1 = unsigned int64(393472)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_7_0">
+      <MemberSignature Language="C#" Value="iOS_7_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_7_0 = unsigned int64(458752)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_7_1">
+      <MemberSignature Language="C#" Value="iOS_7_1" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_7_1 = unsigned int64(459008)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_8_0">
+      <MemberSignature Language="C#" Value="iOS_8_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_8_0 = unsigned int64(524288)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_8_1">
+      <MemberSignature Language="C#" Value="iOS_8_1" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_8_1 = unsigned int64(524544)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_8_2">
+      <MemberSignature Language="C#" Value="iOS_8_2" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_8_2 = unsigned int64(524800)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_8_3">
+      <MemberSignature Language="C#" Value="iOS_8_3" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_8_3 = unsigned int64(525056)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_Arch">
+      <MemberSignature Language="C#" Value="iOS_Arch" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_Arch = unsigned int64(4278190080)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_Arch32">
+      <MemberSignature Language="C#" Value="iOS_Arch32" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_Arch32 = unsigned int64(16777216)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_Arch64">
+      <MemberSignature Language="C#" Value="iOS_Arch64" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_Arch64 = unsigned int64(33554432)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="iOS_Version">
+      <MemberSignature Language="C#" Value="iOS_Version" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform iOS_Version = unsigned int64(16777215)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_0">
+      <MemberSignature Language="C#" Value="Mac_10_0" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_0 = unsigned int64(2814749767106560)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_1">
+      <MemberSignature Language="C#" Value="Mac_10_1" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_1 = unsigned int64(2815849278734336)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_10">
+      <MemberSignature Language="C#" Value="Mac_10_10" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_10 = unsigned int64(2825744883384320)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_2">
+      <MemberSignature Language="C#" Value="Mac_10_2" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_2 = unsigned int64(2816948790362112)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_3">
+      <MemberSignature Language="C#" Value="Mac_10_3" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_3 = unsigned int64(2818048301989888)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_4">
+      <MemberSignature Language="C#" Value="Mac_10_4" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_4 = unsigned int64(2819147813617664)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_5">
+      <MemberSignature Language="C#" Value="Mac_10_5" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_5 = unsigned int64(2820247325245440)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_6">
+      <MemberSignature Language="C#" Value="Mac_10_6" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_6 = unsigned int64(2821346836873216)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_7">
+      <MemberSignature Language="C#" Value="Mac_10_7" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_7 = unsigned int64(2822446348500992)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_8">
+      <MemberSignature Language="C#" Value="Mac_10_8" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_8 = unsigned int64(2823545860128768)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_10_9">
+      <MemberSignature Language="C#" Value="Mac_10_9" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_10_9 = unsigned int64(2824645371756544)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_Arch">
+      <MemberSignature Language="C#" Value="Mac_Arch" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_Arch = unsigned int64(18374686479671623680)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_Arch32">
+      <MemberSignature Language="C#" Value="Mac_Arch32" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_Arch32 = unsigned int64(72057594037927936)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_Arch64">
+      <MemberSignature Language="C#" Value="Mac_Arch64" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_Arch64 = unsigned int64(144115188075855872)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Mac_Version">
+      <MemberSignature Language="C#" Value="Mac_Version" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform Mac_Version = unsigned int64(72057589742960640)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="None">
+      <MemberSignature Language="C#" Value="None" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype ObjCRuntime.Platform None = unsigned int64(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>ObjCRuntime.Platform</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/index.xml
@@ -1,0 +1,28 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-enumerations" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyEnum" Kind="Enumeration" />
+      <Type Name="MyEnumAttribute" Kind="Class" />
+      <Type Name="MyFlagEnumAttribute" Kind="Class" />
+    </Namespace>
+    <Namespace Name="ObjCRuntime">
+      <Type Name="Platform" Kind="Enumeration" />
+    </Namespace>
+  </Types>
+  <Title>DocTest-enumerations</Title>
+</Overview>

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/ns-MyNamespace.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/ns-MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mcs/tools/mdoc/Test/en.expected-enumerations/ns-ObjCRuntime.xml
+++ b/mcs/tools/mdoc/Test/en.expected-enumerations/ns-ObjCRuntime.xml
@@ -1,0 +1,6 @@
+<Namespace Name="ObjCRuntime">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>


### PR DESCRIPTION
This enum, which can be found in Xamarin's iOS and Mac products use a custom encoding
scheme which resulted in invalid values being shown when processed with mdoc. This patch
adds a special case to watch for this particular enumeration value, and decodes the data
correctly.

Additionally, the code that formats the values for flags enumerations was refactored. Future extensibility of this feature can now be done by simply implementing a new `FlagsFormatter`, and applying the proper logic in the `MakeAttributesValueString` function.