### PR TITLE
[runtime] Add a missing NOP to the OP_SEQ_POINT arm code

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -4627,6 +4627,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				for (i = 0; i < 4; ++i)
 					ARM_NOP (code);
 			}
+
+			/*
+			 * Add an additional nop so skipping the bp doesn't cause the ip to point
+			 * to another IL offset.
+			 */
+
+			ARM_NOP (code);
 			break;
 		}
 		case OP_ADDCC:


### PR DESCRIPTION
We were failing MonoTests.DebuggerTests.Locals and MonoTests.DebuggerTests.SingleStepping because we stepped forward too far as a side effect of this missing "padding" NOP.
