### PR TITLE
Fix dot stuffing in SmtpClient

### DIFF
--- a/mcs/class/System/System.Net.Mail/SmtpClient.cs
+++ b/mcs/class/System/System.Net.Mail/SmtpClient.cs
@@ -781,13 +781,8 @@ namespace System.Net.Mail {
 				CheckCancellation ();
 
 				if (escapeDots) {
-					int i;
-					for (i = 0; i < line.Length; i++) {
-						if (line[i] != '.')
-							break;
-					}
-					if (i > 0 && i == line.Length) {
-						line += ".";
+					if (line.Length > 0 && line[0] == '.') {
+						line = "." + line;
 					}
 				}
 				writer.Write (line);


### PR DESCRIPTION
As per RFC2821 section 4.5.2:
   -  Before sending a line of mail text, the SMTP client checks the
      first character of the line.  If it is a period, one additional
      period is inserted at the beginning of the line.