### PR TITLE
Removed obsolete flag '-no-cpp-precomp' from darwin $CPPFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,7 +291,7 @@ case "$host" in
 		host_win32=no
 		platform_darwin=yes
 		target_mach=yes
-		CPPFLAGS="$CPPFLAGS -no-cpp-precomp -D_THREAD_SAFE -DGC_MACOSX_THREADS -DPLATFORM_MACOSX -DUSE_MMAP -DUSE_MUNMAP"
+		CPPFLAGS="$CPPFLAGS -D_THREAD_SAFE -DGC_MACOSX_THREADS -DPLATFORM_MACOSX -DUSE_MMAP -DUSE_MUNMAP"
 		libmono_cflags="-D_THREAD_SAFE"
 		need_link_unlink=yes
 		AC_DEFINE(PTHREAD_POINTER_ID)


### PR DESCRIPTION
Removed obsolete flag '-no-cpp-precomp' from darwin $CPPFLAGS, so that build is possible on osx