### PR TITLE
[System.Web] Added missing HttpRequestBase, HttpRequestWrapper and HttpRequest methods + properties:

### DIFF
--- a/mcs/class/System.Web.Abstractions/System.Web/HttpRequestBase.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpRequestBase.cs
@@ -38,6 +38,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 using System.Security.Principal;
 using System.Text;
+using System.Threading;
 using System.Web.Caching;
 
 using System.Security.Authentication.ExtendedProtection;
@@ -76,6 +77,8 @@ namespace System.Web
 		public virtual HttpCookieCollection Cookies { get { NotImplemented (); return null; } }
 
 		public virtual string CurrentExecutionFilePath { get { NotImplemented (); return null; } }
+
+		public virtual string CurrentExecutionFilePathExtension { get { NotImplemented (); return null; } }
 
 		public virtual string FilePath { get { NotImplemented (); return null; } }
 
@@ -126,6 +129,8 @@ namespace System.Web
 		}
 		public virtual NameValueCollection ServerVariables { get { NotImplemented (); return null; } }
 
+		public virtual CancellationToken TimedOutToken { get { NotImplemented (); return default(CancellationToken); } }
+
 		public virtual int TotalBytes { get { NotImplemented (); return 0; } }
 
 		public virtual ReadEntityBodyMode ReadEntityBodyMode { get { NotImplemented(); return ReadEntityBodyMode.Classic; } }
@@ -150,6 +155,40 @@ namespace System.Web
 		}
 
 		public virtual byte [] BinaryRead (int count)
+		{
+			NotImplemented ();
+			return null;
+		}
+
+		public virtual Stream GetBufferedInputStream ()
+		{
+			NotImplemented ();
+			return null;
+		}
+
+		public virtual Stream GetBufferlessInputStream ()
+		{
+			NotImplemented ();
+			return null;
+		}
+
+		public virtual Stream GetBufferlessInputStream (bool disableMaxRequestLength)
+		{
+			NotImplemented ();
+			return null;
+		}
+
+		public virtual void InsertEntityBody()
+		{
+			NotImplemented ();
+		}
+
+		public virtual void InsertEntityBody(byte[] buffer, int offset, int count)
+		{
+			NotImplemented ();
+		}
+
+		public virtual double [] MapRawImageCoordinates (string imageFieldName)
 		{
 			NotImplemented ();
 			return null;

--- a/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
+++ b/mcs/class/System.Web.Abstractions/System.Web/HttpRequestWrapper.cs
@@ -38,6 +38,7 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 using System.Security.Principal;
 using System.Text;
+using System.Threading;
 using System.Web.Caching;
 
 using System.Security.Authentication.ExtendedProtection;
@@ -126,6 +127,21 @@ namespace System.Web
 			get { return w.Headers; }
 		}
 
+		public override Stream GetBufferedInputStream ()
+		{
+			return w.GetBufferedInputStream ();
+		}
+
+		public override Stream GetBufferlessInputStream ()
+		{
+			return w.GetBufferlessInputStream ();
+		}
+
+		public override Stream GetBufferlessInputStream (System.Boolean disableMaxRequestLength)
+		{
+			return w.GetBufferlessInputStream (disableMaxRequestLength);
+		}
+
 		public override string HttpMethod {
 			get { return w.HttpMethod; }
 		}
@@ -196,6 +212,10 @@ namespace System.Web
 			get { return w.ServerVariables; }
 		}
 
+		public virtual CancellationToken TimedOutToken {
+			get { return w.TimedOutToken; }
+		}
+
 		public override int TotalBytes {
 			get { return w.TotalBytes; }
 		}
@@ -247,14 +267,19 @@ namespace System.Web
 			return w.MapImageCoordinates (imageFieldName);
 		}
 
-		public override string MapPath (string overridePath)
+		public override string MapPath (string virtualPath)
 		{
-			return w.MapPath (overridePath);
+			return w.MapPath (virtualPath);
 		}
 
-		public override string MapPath (string overridePath, string baseVirtualDir, bool allowCrossAppMapping)
+		public override string MapPath (string virtualPath, string baseVirtualDir, bool allowCrossAppMapping)
 		{
-			return w.MapPath (overridePath, baseVirtualDir, allowCrossAppMapping);
+			return w.MapPath (virtualPath, baseVirtualDir, allowCrossAppMapping);
+		}
+
+		public override double [] MapRawImageCoordinates (System.String imageFieldName)
+		{
+			return w.MapRawImageCoordinates (imageFieldName);
 		}
 
 		public override void SaveAs (string filename, bool includeHeaders)

--- a/mcs/class/System.Web/System.Web/HttpRequest.cs
+++ b/mcs/class/System.Web/System.Web/HttpRequest.cs
@@ -39,6 +39,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Permissions;
 using System.Security.Principal;
+using System.Threading;
 using System.Web.Configuration;
 using System.Web.Management;
 using System.Web.UI;
@@ -980,6 +981,11 @@ namespace System.Web
 			}
 		}
 
+		public Stream GetBufferedInputStream ()
+		{
+			return input_stream;
+		}
+
 		public Stream GetBufferlessInputStream ()
 		{
 			if (bufferlessInputStream == null) {
@@ -991,6 +997,11 @@ namespace System.Web
 			}
 
 			return bufferlessInputStream;
+		}
+
+		public Stream GetBufferlessInputStream (bool disableMaxRequestLength)
+		{
+			return GetBufferlessInputStream ();
 		}
 
 		//
@@ -1399,6 +1410,12 @@ namespace System.Web
 			}
 		}
 
+		public CancellationToken TimedOutToken {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+
 		public int TotalBytes {
 			get {
 				Stream ins = InputStream;
@@ -1509,6 +1526,38 @@ namespace System.Web
 
 		public int [] MapImageCoordinates (string imageFieldName)
 		{
+			string[] parameters = GetImageCoordinatesParameters (imageFieldName);
+			if (parameters == null)
+				return null;
+			int [] result = new int [2];
+			try {
+				result [0] = Int32.Parse (parameters [0]);
+				result [1] = Int32.Parse (parameters [1]);
+			} catch {
+				return null;
+			}
+
+			return result;
+		}
+
+		public double [] MapRawImageCoordinates (string imageFieldName)
+		{
+			string[] parameters = GetImageCoordinatesParameters (imageFieldName);
+			if (parameters == null)
+				return null;
+			double [] result = new double [2];
+			try {
+				result [0] = Double.Parse (parameters [0]);
+				result [1] = Double.Parse (parameters [1]);
+			} catch {
+				return null;
+			}
+
+			return result;
+		}
+
+		string [] GetImageCoordinatesParameters (string imageFieldName)
+		{
 			string method = HttpMethod;
 			NameValueCollection coll = null;
 			if (method == "HEAD" || method == "GET")
@@ -1526,14 +1575,7 @@ namespace System.Web
 			string y = coll [imageFieldName + ".y"];
 			if (y == null || y == "")
 				return null;
-
-			int [] result = new int [2];
-			try {
-				result [0] = Int32.Parse (x);
-				result [1] = Int32.Parse (y);
-			} catch {
-				return null;
-			}
+			string[] result = new string [] { x, y };
 
 			return result;
 		}


### PR DESCRIPTION
Changes:
* HttpRequestBase:GetBufferedInputStream, GetBufferlessInputStream,  InsertEntityBody, MapRawImageCoordinates, CurrentExecutionFilePathExtension, TimedOutToken.
	* [MSDN](https://msdn.microsoft.com/en-us/library/system.web.httprequestbase(v=vs.110).aspx)
	* [Reference Source](https://github.com/Microsoft/referencesource/blob/74706335e3b8c806f44fa0683dc1e18d3ed747c2/System.Web/Abstractions/HttpRequestBase.cs)
* HttpRequestWrapper: GetBufferedInputStream, GetBufferlessInputStream, MapRawImageCoordinates, TimedOutToken,
	* Fixed MapPath parameter name(overridePath -> virtualPath)
	* [MSDN](https://msdn.microsoft.com/en-us/library/system.web.httprequestwrapper(v=vs.110).aspx)
	* [Reference Source](https://github.com/Microsoft/referencesource/blob/74706335e3b8c806f44fa0683dc1e18d3ed747c2/System.Web/Abstractions/HttpRequestWrapper.cs)
* HttpRequest: GetBufferedInputStream, GetBufferlessInputStream(bool), MapRawImageCoordinates, TimedOutToken
	* [MSDN](https://msdn.microsoft.com/en-us/library/system.web.httprequest(v=vs.110).aspx)
	* [Reference Source](https://github.com/Microsoft/referencesource/blob/74706335e3b8c806f44fa0683dc1e18d3ed747c2/System.Web/HttpRequest.cs)

This commit allows to use OAuth authorization server from Microsoft.Owin.Security.OAuth (Fixes crash on code -> access token exchange).