### PR TITLE
Backport fix for #31635 ([Mono.Posix] Special-case UTF-32 in PtrToString) to Mono 4.2

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -176,6 +176,10 @@ namespace Mono.Unix {
 			else if (typeof(UnicodeEncoding).IsAssignableFrom (encodingType)) {
 				len = GetInt16BufferLength (p);
 			}
+			// Encodings that will always end with a 0x00000000 32-bit word
+			else if (typeof(UTF32Encoding).IsAssignableFrom (encodingType)) {
+				len = GetInt32BufferLength (p);
+			}
 			// Some non-public encoding, such as Latin1 or a DBCS charset.
 			// Look for a sequence of encoding.GetMaxByteCount() bytes that are all
 			// 0, which should be the terminating null.

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixMarshalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixMarshalTest.cs
@@ -8,6 +8,7 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -86,6 +87,69 @@ namespace MonoTests.Mono.Unix {
 			Marshal.WriteByte (p, 0);
 			string s = UnixMarshal.PtrToString (p);
 			UnixMarshal.FreeHeap (p);
+		}
+
+		[Test]
+		public void TestUtf32PtrToString ()
+		{
+			var utf32NativeEndianNoBom = new UTF32Encoding(
+				bigEndian: !BitConverter.IsLittleEndian,
+				byteOrderMark: false,
+				throwOnInvalidCharacters: true
+			);
+
+			// assemble a buffer that contains:
+			// 1. eight garbage bytes
+			// 2. the native-endian UTF-32 string "Hello, World" without BOM
+			// 3. four 0 bytes (as a C wide string terminator)
+			// 4. the native-endian UTF-32 string "broken" without BOM
+			// 5. eight 0 bytes
+			// 6. four garbage bytes
+			var buf = new List<byte>();
+			for (int i = 0; i < 2; ++i) {
+				buf.Add((byte)0x12);
+				buf.Add((byte)0x34);
+				buf.Add((byte)0x56);
+				buf.Add((byte)0x78);
+			}
+
+			buf.AddRange(utf32NativeEndianNoBom.GetBytes("Hello, World"));
+
+			for (int i = 0; i < 4; ++i) {
+				buf.Add((byte)0x00);
+			}
+
+			buf.AddRange(utf32NativeEndianNoBom.GetBytes("broken"));
+
+			for (int i = 0; i < 8; ++i) {
+				buf.Add((byte)0x00);
+			}
+
+			buf.Add((byte)0x12);
+			buf.Add((byte)0x34);
+			buf.Add((byte)0x56);
+			buf.Add((byte)0x78);
+
+			// get the array version of this
+			var bufArr = buf.ToArray();
+
+			// allocate a buffer that will contain this string
+			IntPtr bufPtr = UnixMarshal.AllocHeap(bufArr.Length);
+			string returned;
+			try
+			{
+				// copy it in
+				Marshal.Copy(bufArr, 0, bufPtr, bufArr.Length);
+
+				// try getting it back
+				returned = UnixMarshal.PtrToString(bufPtr + 8, utf32NativeEndianNoBom);
+			}
+			finally
+			{
+				UnixMarshal.FreeHeap(bufPtr);
+			}
+
+			Assert.AreEqual("Hello, World", returned);
 		}
 	}
 }


### PR DESCRIPTION
Since this bugfix is important for one of the [Smuxi](http://smuxi.im/) frontends (which P/Invokes using wide characters on Unix), I would like to request that the fix be merged into the 4.2 branch too.

The original pull request (to master) was #1913.

Thanks!