### PR TITLE
Bump nunit from mono/2.0 to mono/4.5.

### DIFF
--- a/data/mono-nunit.pc.in
+++ b/data/mono-nunit.pc.in
@@ -6,4 +6,4 @@ libdir=${exec_prefix}/lib
 Name: Mono NUnit
 Description: Mono's version of NUnit
 Version: @VERSION@
-Libs: -r:${libdir}/mono/2.0/nunit.core.dll -r:${libdir}/mono/2.0/nunit.core.interfaces.dll -r:${libdir}/mono/2.0/nunit.core.extensions.dll -r:${libdir}/mono/2.0/nunit.framework.dll -r:${libdir}/mono/2.0/nunit.framework.extensions.dll -r:${libdir}/mono/2.0/nunit.mocks.dll -r:${libdir}/mono/2.0/nunit.util.dll -r:${libdir}/mono/2.0/nunit-console-runner.dll 
+Libs: -r:${libdir}/mono/4.5/nunit.core.dll -r:${libdir}/mono/4.5/nunit.core.interfaces.dll -r:${libdir}/mono/4.5/nunit.core.extensions.dll -r:${libdir}/mono/4.5/nunit.framework.dll -r:${libdir}/mono/4.5/nunit.framework.extensions.dll -r:${libdir}/mono/4.5/nunit.mocks.dll -r:${libdir}/mono/4.5/nunit.util.dll -r:${libdir}/mono/4.5/nunit-console-runner.dll 


### PR DESCRIPTION
A mono-xsp build was observed to fail with many messages of the form

error CS0006: Metadata file `/ssd/rtollert/nioefeeds-objects/x64_feeds/linuxU/x64/gcc-4.7-oe/release/build/tmp-glibc/sysroots/x64/usr/lib/pkgconfig/../../lib/mono/2.0/nunit.core.dll' could not be found

Some digging indicated that nunit.core.dll exists under lib/mono/4.5 but not lib/mono/2.0 and this version is hardcoded in the .pc.in file. Applying this patch fixed the build issue.

EDIT: MIT License.