### PR TITLE
[runtime] Add thread-local runtime profiling counters.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5267,8 +5267,11 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 			vtable = mono_class_vtable (cfg->domain, method->klass);
 			if (!vtable)
 				return FALSE;
-			if (!cfg->compile_aot)
+			if (!cfg->compile_aot) {
+				mono_change_perf_state_from_to (MONO_PERF_STATE_COMPILE, MONO_PERF_STATE_EXEC);
 				mono_runtime_class_init (vtable);
+				mono_change_perf_state_from_to (MONO_PERF_STATE_EXEC, MONO_PERF_STATE_COMPILE);
+			}
 		} else if (method->klass->flags & TYPE_ATTRIBUTE_BEFORE_FIELD_INIT) {
 			if (cfg->run_cctors && method->klass->has_cctor) {
 				/*FIXME it would easier and lazier to just use mono_class_try_get_vtable */
@@ -11356,7 +11359,11 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 							g_assert (vtable);
 							if (! vtable->initialized)
 								INLINE_FAILURE ("class init");
+
+							mono_change_perf_state_from_to (MONO_PERF_STATE_COMPILE, MONO_PERF_STATE_EXEC);
 							ex = mono_runtime_class_init_full (vtable, FALSE);
+							mono_change_perf_state_from_to (MONO_PERF_STATE_EXEC, MONO_PERF_STATE_COMPILE);
+
 							if (ex) {
 								set_exception_object (cfg, ex);
 								goto exception_exit;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -954,6 +954,12 @@ mono_setup_perf_counters (MonoJitTlsData *jit_tls)
 {
 	jit_tls->perf_segment_start = mono_thread_cpu_time ();
 	jit_tls->state = MONO_PERF_STATE_EXEC;
+	mono_counters_register ("Total compilation CPU time",
+				MONO_COUNTER_RUNTIME | MONO_COUNTER_LONG | MONO_COUNTER_TIME,
+				&mono_jit_stats.perf_counters [MONO_PERF_STATE_COMPILE]);
+	mono_counters_register ("Total execution CPU time",
+				MONO_COUNTER_RUNTIME | MONO_COUNTER_LONG | MONO_COUNTER_TIME,
+				&mono_jit_stats.perf_counters [MONO_PERF_STATE_EXEC]);
 }
 
 static void
@@ -3639,8 +3645,6 @@ mini_cleanup (MonoDomain *domain)
 
 	mono_trace_cleanup ();
 
-	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
-
 	if (mono_inject_async_exc_method)
 		mono_method_desc_free (mono_inject_async_exc_method);
 
@@ -3654,7 +3658,7 @@ mini_cleanup (MonoDomain *domain)
 	mono_jumptable_cleanup ();
 #endif
 
-	print_jit_counters ();
+	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 }
 
 void

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -57,6 +57,7 @@
 #include <mono/utils/mono-hwcap.h>
 #include <mono/utils/dtrace.h>
 #include <mono/utils/mono-threads.h>
+#include <mono/utils/mono-time.h>
 #include <mono/io-layer/io-layer.h>
 
 #include "mini.h"
@@ -4254,7 +4255,10 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 
 	jit_timer = g_timer_new ();
 
+	mono_change_perf_state_from_to (MONO_PERF_STATE_EXEC, MONO_PERF_STATE_COMPILE);
 	cfg = mini_method_compile (method, opt, target_domain, JIT_FLAG_RUN_CCTORS, 0, -1);
+	mono_change_perf_state_from_to (MONO_PERF_STATE_COMPILE, MONO_PERF_STATE_EXEC);
+
 	prof_method = cfg->method;
 
 	g_timer_stop (jit_timer);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1080,6 +1080,16 @@ typedef struct {
 	int first_filter_idx, filter_idx;
 } ResumeState;
 
+/*
+ * Lists all states in which a thread can be. Used for performance profiling.
+ */
+typedef enum {
+	MONO_PERF_STATE_COMPILE,
+	MONO_PERF_STATE_EXEC,
+	MONO_PERF_STATE_UNKNOWN,
+	MONO_PERF_STATE_NUM = MONO_PERF_STATE_UNKNOWN
+} MonoThreadPerfState;
+
 typedef struct {
 	gpointer          end_of_stack;
 	guint32           stack_size;
@@ -1127,6 +1137,13 @@ typedef struct {
 	 * The current exception in flight
 	 */
 	guint32 thrown_exc;
+
+	/*
+	 * Thread-local state and time tracking.
+	 */
+	gint64 perf_segment_start;
+	gint64 perf_counters [MONO_PERF_STATE_NUM];
+	MonoThreadPerfState state;
 } MonoJitTlsData;
 
 /*
@@ -1831,6 +1848,7 @@ typedef struct {
 	char *biggest_method;
 	double jit_time;
 	gboolean enabled;
+	gint64 perf_counters [MONO_PERF_STATE_NUM];
 } MonoJitStats;
 
 extern MonoJitStats mono_jit_stats;
@@ -3032,4 +3050,29 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 #define ARCH_VARARG_ICALLS 0
 #endif
 
+<<<<<<< HEAD
+=======
+#ifdef MONO_ARCH_HAVE_DUMMY_INIT
+#define ARCH_HAVE_DUMMY_INIT 1
+#else
+#define ARCH_HAVE_DUMMY_INIT 0
+#endif
+
+#ifdef MONO_CROSS_COMPILE
+#define MONO_IS_CROSS_COMPILE 1
+#else
+#define MONO_IS_CROSS_COMPILE 0
+#endif
+
+#if defined(__mono_ilp32__)
+#define MONO_IS_ILP32 1
+#else
+#define MONO_IS_ILP32 0
+#endif
+
+void mono_change_perf_state (MonoThreadPerfState state);
+void mono_change_perf_state_from_to (MonoThreadPerfState old_state, MonoThreadPerfState new_state);
+void mono_update_perf_counter (MonoJitTlsData *jit_tls);
+
+>>>>>>> [runtime] Add thread-local performance counters to precisely measure compilation and execution time.
 #endif /* __MONO_MINI_H__ */

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -14,6 +14,9 @@ guint32 mono_msec_ticks      (void);
 /* Returns the number of 100ns ticks from unspecified time: this should be monotonic */
 gint64  mono_100ns_ticks     (void);
 
+/* Returns user & system time for a thread in 100ns units. */
+gint64  mono_thread_cpu_time (void);
+
 /* Returns the number of 100ns ticks since 1/1/1601, UTC timezone */
 gint64  mono_100ns_datetime  (void);
 


### PR DESCRIPTION
Add thread-local performance profiling counters to precisely measure CPU time spent on compilation and execution.

The counters work by tracking the type of activity that each runtime thread is doing, and increasing the corresponding thread-local performance counter whenever the type activity changes. Whenever a thread is terminated, its thread-local counter values are added to the global counters.

In this commit, the only two types of activity are compilation and "execution" (i.e. everything other than compilation), but additional counters can be added later, if higher granularity is needed.

@schani Could you take a look at this?
