### PR TITLE
Add TLS offset for pre-release OS X 10.11 on amd64

### DIFF
--- a/mono/utils/mach-support-amd64.c
+++ b/mono/utils/mach-support-amd64.c
@@ -23,6 +23,7 @@
 /* All OSX versions up to 10.8 */
 #define TLS_VECTOR_OFFSET_CATS 0x60
 #define TLS_VECTOR_OFFSET_10_9 0xe0
+#define TLS_VECTOR_OFFSET_10_11 0x100
 
 static int tls_vector_offset;
 
@@ -127,6 +128,10 @@ mono_mach_init (pthread_key_t key)
 		goto ok;
 
 	tls_vector_offset = TLS_VECTOR_OFFSET_10_9;
+	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
+		goto ok;
+
+	tls_vector_offset = TLS_VECTOR_OFFSET_10_11;
 	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
 		goto ok;
 


### PR DESCRIPTION
This pull request may be premature, but I found it necessary to make this patch in order to get mono working on prerelease versions of OS X 10.11 (as of DP3, at least). 