### PR TITLE
Allow disabling the mono-find-provides/requires RPM processing scripts

### DIFF
--- a/scripts/mono-find-provides.in
+++ b/scripts/mono-find-provides.in
@@ -8,6 +8,8 @@
 # (C) 2005 Novell (http://www.novell.com)
 #
 
+if [ -n "$DISABLE_MONO_RPM_AUTO_DEPS" ]; then exit 0; fi
+
 IFS=$'\n'
 filelist=($(grep -Ev '/usr/doc/|/usr/share/doc/'))
 monolist=($(printf "%s\n" "${filelist[@]}" | egrep "\\.(exe|dll)\$"))

--- a/scripts/mono-find-requires.in
+++ b/scripts/mono-find-requires.in
@@ -9,6 +9,8 @@
 # (C) 2008 Novell (http://www.novell.com)
 #
 
+if [ -n "$DISABLE_MONO_RPM_AUTO_DEPS" ]; then exit 0; fi
+
 IFS=$'\n'
 filelist=($(grep -Ev '/usr/doc/|/usr/share/doc/'))
 monolist=($(printf "%s\n" "${filelist[@]}" | egrep "\\.(exe|dll)\$"))


### PR DESCRIPTION
The mono-find-provides and mono-find-requires scripts, that are using when creating RPM packages to auto generate the set of required and provided package dependencies, can generate incorrect information for some packages. This patch allows disabling the scripts when the DISABLE_MONO_RPM_AUTO_DEPS environmental variable is set.