### PR TITLE
fix the x86 build

### DIFF
--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -5465,7 +5465,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 		gboolean supported = FALSE;
 
 		if (cfg->compile_aot) {
-#if MONO_HAVE_FAST_TLS
+#if defined(MONO_HAVE_FAST_TLS)
 			supported = TRUE;
 #endif
 		} else if (mono_get_jit_tls_offset () != -1) {


### PR DESCRIPTION
A recent change has broken the x86 build and is in the way of my .NET 4.6 PR work. Can the fix be merged please?