### PR TITLE
[threadpool-ms-io] Remove socket synchronously from backend when closing socket

### DIFF
--- a/mono/metadata/threadpool-ms-io-kqueue.c
+++ b/mono/metadata/threadpool-ms-io-kqueue.c
@@ -46,9 +46,12 @@ kqueue_cleanup (void)
 }
 
 static void
-kqueue_update_add (gint fd, gint events, gboolean is_new)
+kqueue_register_fd (gint fd, gint events, gboolean is_new)
 {
 	struct kevent event;
+
+	if (events == 0)
+		return;
 
 	if ((events & MONO_POLLIN) != 0)
 		EV_SET (&event, fd, EVFILT_READ, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, 0);
@@ -56,7 +59,7 @@ kqueue_update_add (gint fd, gint events, gboolean is_new)
 		EV_SET (&event, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, 0);
 
 	if (kevent (kqueue_fd, &event, 1, NULL, 0, NULL) == -1)
-		g_warning ("kqueue_update_add: kevent(update) failed, error (%d) %s", errno, g_strerror (errno));
+		g_warning ("kqueue_register_fd: kevent(update) failed, error (%d) %s", errno, g_strerror (errno));
 }
 
 static gint
@@ -97,31 +100,13 @@ kqueue_event_get_fd_max (void)
 	return KQUEUE_NEVENTS;
 }
 
-static void
-kqueue_event_reset_fd_at (gint i, gint events)
-{
-	if (kqueue_events [i].filter == EVFILT_READ && (events & MONO_POLLIN) != 0) {
-		EV_SET (&kqueue_events [i], kqueue_events [i].ident, EVFILT_READ, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, 0);
-		if (kevent (kqueue_fd, &kqueue_events [i], 1, NULL, 0, NULL) == -1) {
-			g_warning ("kqueue_event_reset_fd_at: kevent (read) failed, error (%d) %s", errno, g_strerror (errno));
-		}
-	}
-	if (kqueue_events [i].filter == EVFILT_WRITE && (events & MONO_POLLOUT) != 0) {
-		EV_SET (&kqueue_events [i], kqueue_events [i].ident, EVFILT_WRITE, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, 0);
-		if (kevent (kqueue_fd, &kqueue_events [i], 1, NULL, 0, NULL) == -1) {
-			g_warning ("kqueue_event_reset_fd_at: kevent (write) failed, error (%d) %s", errno, g_strerror (errno));
-		}
-	}
-}
-
 static ThreadPoolIOBackend backend_kqueue = {
 	.init = kqueue_init,
 	.cleanup = kqueue_cleanup,
-	.update_add = kqueue_update_add,
+	.register_fd = kqueue_register_fd,
 	.event_wait = kqueue_event_wait,
 	.event_get_fd_max = kqueue_event_get_fd_max,
 	.event_get_fd_at = kqueue_event_get_fd_at,
-	.event_reset_fd_at = kqueue_event_reset_fd_at,
 };
 
 #endif


### PR DESCRIPTION
To achieve this, we need to wait for the update to be applied to the backend.

This is mainly for the epoll backend, as we do not need to remove the fd from the backend when using kqueue.