### PR TITLE
GetSystemTimeZones() not returning Australia zones

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -150,7 +150,7 @@ namespace System
 #endif
 
 #if LIBC
-			string[] continents = new string [] {"Africa", "America", "Antarctica", "Arctic", "Asia", "Atlantic", "Brazil", "Canada", "Chile", "Europe", "Indian", "Mexico", "Mideast", "Pacific", "US"};
+			string[] continents = new string [] {"Africa", "America", "Antarctica", "Arctic", "Asia", "Atlantic", "Australia", "Brazil", "Canada", "Chile", "Europe", "Indian", "Mexico", "Mideast", "Pacific", "US"};
 			foreach (string continent in continents) {
 				try {
 					foreach (string zonepath in Directory.GetFiles (Path.Combine (TimeZoneDirectory, continent))) {


### PR DESCRIPTION
A call to TimeZoneInfo.GetSystemTimeZones() is not returning any of the timezones for Australia due to the "Australia" string being missing from the array of continents used to look up the zoneinfo data at /usr/share/zoneinfo. This patch adds the "Australia" value to the array.