### PR TITLE
mono-threads-linux.c also applies to other OSes with GNU userland

### DIFF
--- a/mono/utils/mono-threads-linux.c
+++ b/mono/utils/mono-threads-linux.c
@@ -1,6 +1,6 @@
 #include <config.h>
 
-#if defined(__linux__) && !defined(PLATFORM_ANDROID)
+#if (defined(__linux__) && !defined(PLATFORM_ANDROID)) || defined(__FreeBSD_kernel__)
 
 #include <mono/utils/mono-threads.h>
 #include <pthread.h>


### PR DESCRIPTION
Fixes a build failure for GNU/kFreeBSD (which doesn't use mono-threads-freebsd.c, since GNU/kFreeBSD doesn't have pthread_np.h)