### PR TITLE
[build] library.make: Avoid collisions in response file name for facades on Windows

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -58,7 +58,7 @@ endif
 endif
 
 ifndef response
-response = $(depsdir)/$(PROFILE)_$(LIBRARY).response
+response = $(depsdir)/$(PROFILE)_$(LIBRARY_SUBDIR)_$(LIBRARY).response
 library_CLEAN_FILES += $(response)
 endif
 
@@ -306,7 +306,7 @@ all-local: $(the_lib)$(PLATFORM_AOT_SUFFIX)
 endif
 endif
 
-makefrag = $(depsdir)/$(PROFILE)_$(LIBRARY).makefrag
+makefrag = $(depsdir)/$(PROFILE)_$(LIBRARY_SUBDIR)_$(LIBRARY).makefrag
 library_CLEAN_FILES += $(makefrag)
 $(makefrag): $(sourcefile)
 #	@echo Creating $@ ...


### PR DESCRIPTION
When additional facades were added in 04114a5e9d141a4f424564fea95ac4480cb0a16a, the Windows Cygwin build broke.
Turns out, when building the System.IO.Comporession facade assembly it wanted to use the SharpCompress sources of the real assembly and couldn't find it (which made no sense since the facade doesn't even list them in its .sources file), see [this failed build](https://ci.appveyor.com/project/ajlennon/mono-817/build/1.0.2467).

After inspecting library.make what happens is this: the response file is defined as `$(PROFILE)_$(LIBRARY).response`, but this results in the same value for both the real assembly and the facade assembly.
This means that since the real assembly was compiled first, the response file contained the source list of the real assembly - which was then used to compile the facade (make happily reused the response file since it already existed).

The fix is to put `$(LIBRARY_SUBDIR)` into the filename so the facade assembly gets a different response file. Same for the makefrag.

This didn't show up on Unix since there `$(sourcefile)` is used directly as the response file.
I'm a bit surprised this didn't blow up earlier :smile:

**Question:** should something similar be done to [executable.make#L17](
https://github.com/mono/mono/blob/2f763d7e697191d1741cbb7e9fb33254c7d8ca5a/mcs/build/executable.make#L17)? It doesn't even include profile there !?

/cc @marek-safar 