### PR TITLE
[monop] Set MONO_PATH when running tests so class libs are found

### DIFF
--- a/mcs/tools/monop/Makefile
+++ b/mcs/tools/monop/Makefile
@@ -13,4 +13,4 @@ run-test-local : basic-tests
 
 basic-tests:
 	for type in System.Array System.String 'System.Collections.Generic.List`1'; do \
-	echo $$type; $(RUNTIME) $(build_lib) $$type >/dev/null || exit 1; done
+	echo $$type; MONO_PATH="$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(build_lib) $$type >/dev/null || exit 1; done


### PR DESCRIPTION
When the monop tests were added in 6c9ad41d85a668550d0d6077cd3f7d504fe6b6eb the `MONO_PATH` variable wasn't included.
This means that the tests actually ran against the system-provided Mono class libs instead of the in-tree versions (or failed in case of CI with only monolite).
