### PR TITLE
Fixes process names trimmed to 15 chars.

### DIFF
--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -1864,7 +1864,31 @@ get_process_name_from_proc (pid_t pid)
 	/* No proc name on OSX < 10.5 nor ppc nor iOS */
 	memset (buf, '\0', sizeof(buf));
 	proc_name (pid, buf, sizeof(buf));
-	if (strlen (buf) > 0)
+
+	// Fixes proc_name triming values to 15 characters #32539
+	if (strlen (buf) >= MAXCOMLEN - 1) {
+		char path_buf [PROC_PIDPATHINFO_MAXSIZE];
+		char *name_buf;
+		int path_len;
+
+		memset (path_buf, '\0', sizeof(path_buf));
+		path_len = proc_pidpath (pid, path_buf, sizeof(path_buf));
+
+		if (path_len > 0 && path_len < sizeof(path_buf)) {
+			name_buf = path_buf + path_len;
+			for(;name_buf > path_buf; name_buf--) {
+				if (name_buf [0] == '/') {
+					name_buf++;
+					break;
+				}
+			}
+
+			if (memcmp (buf, name_buf, MAXCOMLEN - 1) == 0)
+				ret = g_strdup (name_buf);
+		}
+	}
+
+	if (ret == NULL && strlen (buf) > 0)
 		ret = g_strdup (buf);
 #else
 	if (sysctl(mib, 4, NULL, &size, NULL, 0) < 0)


### PR DESCRIPTION
Process names were trimmed to 15 characters. proc_name was used to
retrieve the process name, by looking at its implementation we can see
that it returns a buffer which the size is MAXCOMLEN defined as 16.

When the proc_name result length is equal to 15 (MAXCOMLEN - 1) we now check if
proc_pidpath is able to return a longer process name.

Fixes [#32539](https://bugzilla.xamarin.com/show_bug.cgi?id=32539).