### PR TITLE
Report XDG Documents directory for SpecialFolder.MyDocuments

### DIFF
--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -653,6 +653,9 @@ namespace System {
 			case SpecialFolder.LocalApplicationData:
 				return data;
 
+			case SpecialFolder.MyDocuments:
+				return ReadXdgUserDir (config, home, "XDG_DOCUMENTS_DIR", "Documents");
+
 			case SpecialFolder.Desktop:
 			case SpecialFolder.DesktopDirectory:
 				return ReadXdgUserDir (config, home, "XDG_DESKTOP_DIR", "Desktop");


### PR DESCRIPTION
http://freedesktop.org/wiki/Software/xdg-user-dirs sets the (de facto) standard for translatable directory name locations for Linux desktops. Mono already honors many of the xdg-user-dirs, eg. Music, while ignoring Documents.