### PR TITLE
[System] Fix a race in two ProcessTest tests

### DIFF
--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -791,9 +791,11 @@ namespace MonoTests.System.Diagnostics
 			p.StartInfo.RedirectStandardError = true;
 
 			var exitedCalledCounter = 0;
+			var exited = new ManualResetEventSlim ();
 			p.Exited += (object sender, EventArgs e) => {
 				exitedCalledCounter++;
 				Assert.IsTrue (p.HasExited);
+				exited.Set ();
 			};
 
 			p.EnableRaisingEvents = true;
@@ -803,6 +805,7 @@ namespace MonoTests.System.Diagnostics
 			p.BeginOutputReadLine ();
 			p.WaitForExit ();
 
+			exited.Wait (10000);
 			Assert.AreEqual (1, exitedCalledCounter);
 			Thread.Sleep (50);
 			Assert.AreEqual (1, exitedCalledCounter);
@@ -822,9 +825,11 @@ namespace MonoTests.System.Diagnostics
 			p.EnableRaisingEvents = true;
 
 			var exitedCalledCounter = 0;
+			var exited = new ManualResetEventSlim ();
 			p.Exited += (object sender, EventArgs e) => {
 				exitedCalledCounter++;
 				Assert.IsTrue (p.HasExited);
+				exited.Set ();
 			};
 
 			p.Start ();
@@ -832,6 +837,7 @@ namespace MonoTests.System.Diagnostics
 			p.BeginOutputReadLine ();
 			p.WaitForExit ();
 
+			exited.Wait (10000);
 			Assert.AreEqual (1, exitedCalledCounter);
 			Thread.Sleep (50);
 			Assert.AreEqual (1, exitedCalledCounter);


### PR DESCRIPTION
The tests sometimes failed in CI, due to a race condition between the Exited event and our assertion of whether it was called.

@esdrubal I don't think this changes the logic you wanted to test when you added the tests in https://github.com/mono/mono/commit/287ba33275b3ef684bc639806a4bb0e5de92fbae, but can you please confirm?