### PR TITLE
Revert "[Microsoft.Build.Engine] Fix bug with escaped semicolon and spaces"

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildItem.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildItem.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Build.BuildEngine {
 
 			BuildItemGroup big;			
 			BuildItem bi = new BuildItem (this);
-			bi.finalItemSpec = ((ITaskItem2)taskitem).EvaluatedIncludeEscaped;
+			bi.finalItemSpec = taskitem.ItemSpec;
 
 			foreach (DictionaryEntry de in taskitem.CloneCustomMetadata ()) {
 				bi.unevaluatedMetadata.Add ((string) de.Key, (string) de.Value);

--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Expression.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Expression.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Build.BuildEngine {
 			for (int i = 0; i < lists.Count; i++) {
 				foreach (object o in lists [i]) {
 					if (o is string)
-						expressionCollection.Add ((string) o);
+						expressionCollection.Add (MSBuildUtils.Unescape ((string) o));
 					else if (!allowItems && o is ItemReference)
 						expressionCollection.Add (((ItemReference) o).OriginalString);
 					else if (!allowMd && o is MetadataReference) {

--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ExpressionCollection.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ExpressionCollection.cs
@@ -233,11 +233,11 @@ namespace Microsoft.Build.BuildEngine {
 			// Trim and Remove empty items
 			List<ITaskItem> toRemove = new List<ITaskItem> ();
 			for (int i = 0; i < finalItems.Count; i ++) {
-				string s = ((ITaskItem2)finalItems [i]).EvaluatedIncludeEscaped.Trim ();
+				string s = finalItems [i].ItemSpec.Trim ();
 				if (s.Length == 0)
 					toRemove.Add (finalItems [i]);
 				else
-					((ITaskItem2)finalItems [i]).EvaluatedIncludeEscaped = s;
+					finalItems [i].ItemSpec = s;
 			}
 			foreach (ITaskItem ti in toRemove)
 				finalItems.Remove (ti);

--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/MessageTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/MessageTest.cs
@@ -79,6 +79,7 @@ namespace MonoTests.Microsoft.Build.Tasks {
 						<Message Text='Text5' Importance='normal'/>
 						<Message Text='Text6' Importance='high'/>
 						<Message Text='Text7' />
+						<Message Text='%22abc test%22 123 %22def%22' />
 						<Message Text='Text8' Importance='weird_importance'/>
 					</Target>
 				</Project>
@@ -102,7 +103,8 @@ namespace MonoTests.Microsoft.Build.Tasks {
 			Assert.AreEqual (0, testLogger.CheckAny ("Text5", MessageImportance.Normal), "A5");
 			Assert.AreEqual (0, testLogger.CheckAny ("Text6", MessageImportance.High), "A6");
 			Assert.AreEqual (0, testLogger.CheckAny ("Text7", MessageImportance.Normal), "A7");
-			Assert.AreEqual (1, testLogger.CheckAny ("Text8", MessageImportance.Normal), "A8");
+			Assert.AreEqual (0, testLogger.CheckAny ("\"abc test\" 123 \"def\"", MessageImportance.Normal), "A8");
+			Assert.AreEqual (1, testLogger.CheckAny ("Text8", MessageImportance.Normal), "A9");
 		}
 	}
 }	

--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/WriteLinesToFileTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/WriteLinesToFileTest.cs
@@ -91,6 +91,7 @@ namespace MonoTests.Microsoft.Build.Tasks {
 		}
 
 		[Test]
+		[Category("NotWorking")] // this fails due to an xbuild bug, it works on MS.NET
 		public void TestLineWithEscapedSemicolon ()
 		{
 			string[] lines = new string[] { "abc%3Btest%3B%3B", "%3Bdef" };
@@ -101,12 +102,23 @@ namespace MonoTests.Microsoft.Build.Tasks {
 		}
 
 		[Test]
+		[Category("NotWorking")] // this fails due to an xbuild bug, it works on MS.NET
 		public void TestLineWithEscapedSpace ()
 		{
 			string[] lines = new string[] { "  %20%20abc%20test  ", "  def%20%20" };
 			CreateProjectAndCheck (full_filepath, lines, false, true, delegate () {
 				CheckFileExists (full_filepath, true);
 				CheckLines (full_filepath, new string [] {"  abc test", "def  "});
+			});
+		}
+
+		[Test]
+		public void TestLineWithEscapedQuote ()
+		{
+			string[] lines = new string[] { "%22abc test%22 123 %22def%22" };
+			CreateProjectAndCheck (full_filepath, lines, false, true, delegate () {
+				CheckFileExists (full_filepath, true);
+				CheckLines (full_filepath, new string [] {"\"abc test\" 123 \"def\""});
 			});
 		}
 

--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskItem.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskItem.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Build.Utilities
 		}
 		public override string ToString ()
 		{
-			return ItemSpec;
+			return escapedItemSpec;
 		}
 		
 		public string ItemSpec {


### PR DESCRIPTION
This reverts commit 51297ed7ab06480df84520c758639b6cef0790d9.

It caused a regression for escaped quotes (%22) in msbuild properties. See https://github.com/mono/mono/commit/51297ed7ab06480df84520c758639b6cef0790d9#commitcomment-11827605.

Disable test that now fails again after the revert. Add new test that verifies the behavior originally broken by the change.

--

As I said in the original PR https://github.com/mono/mono/pull/1580, this part of xbuild is quite intricate and I currently lack enough familiarity with xbuild to fix the bug that triggered my initial change without regressing some other scenarios (plus my main motivator of getting CoreFx to build with xbuild has vanished now that the open-sourced MSBuild is available).

Reverting this seems safer to avoid breaking someone by the change in the upcoming release. I'm sorry for the regression.

@kumpera This should go into the 4.2 branch, hopefully it's not too late in the release process for that?