### PR TITLE
fix bug 31209, prevent infinite loop in HttpConnection.cs

### DIFF
--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -320,21 +320,21 @@ namespace System.Net {
 					break;
 				if (line != "") {
 					if (input_state == InputState.RequestLine) {
-                        context.Request.SetRequestLine (line);
-                        input_state = InputState.Headers;
-                    } else {
-                        try {
-                            context.Request.AddHeader (line);
-                        } catch (Exception e) {
-                            context.ErrorMessage = e.Message;
-                            context.ErrorStatus = 400;
-                            return true;
-                        }
-                    }
+						context.Request.SetRequestLine (line);
+						input_state = InputState.Headers;
+					} else {
+						try {
+							context.Request.AddHeader (line);
+						} catch (Exception e) {
+							context.ErrorMessage = e.Message;
+							context.ErrorStatus = 400;
+							return true;
+						}
+					}
 
-                    if (context.HaveError)
-                        return true;
-                }
+					if (context.HaveError)
+						return true;
+				}
 				else if (input_state != InputState.RequestLine) {
 					current_line = null;
 					ms = null;

--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -318,29 +318,28 @@ namespace System.Net {
 			do {
 				if (line == null)
 					break;
-				if (line == "") {
-					if (input_state == InputState.RequestLine)
-						continue;
+				if (line != "") {
+					if (input_state == InputState.RequestLine) {
+                        context.Request.SetRequestLine (line);
+                        input_state = InputState.Headers;
+                    } else {
+                        try {
+                            context.Request.AddHeader (line);
+                        } catch (Exception e) {
+                            context.ErrorMessage = e.Message;
+                            context.ErrorStatus = 400;
+                            return true;
+                        }
+                    }
+
+                    if (context.HaveError)
+                        return true;
+                }
+				else if (input_state != InputState.RequestLine) {
 					current_line = null;
 					ms = null;
 					return true;
 				}
-
-				if (input_state == InputState.RequestLine) {
-					context.Request.SetRequestLine (line);
-					input_state = InputState.Headers;
-				} else {
-					try {
-						context.Request.AddHeader (line);
-					} catch (Exception e) {
-						context.ErrorMessage = e.Message;
-						context.ErrorStatus = 400;
-						return true;
-					}
-				}
-
-				if (context.HaveError)
-					return true;
 
 				if (position >= len)
 					break;


### PR DESCRIPTION
This patch fixes an infinite loop in HttpConnection.cs causing 100% CPU utilization when the first line of an HTTP request is empty. This bug has been triggered randomly by some browsers, especially when using HTTP Keepalive. This change simply ignores a blank first line and continues reading the request, instead of hanging. This behavior is consistent with other web servers (e.g., http://www.google.com).

I release this patch under the MIT license.