### PR TITLE
[runtime] Refactor AsyncResult.Invoke icall and swallow exception on AsyncCallback

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -634,10 +634,7 @@ mono_async_result_new	    (MonoDomain *domain, HANDLE handle,
 			     MonoObject *state, gpointer data, MonoObject *object_data);
 
 MonoObject *
-mono_async_result_invoke    (MonoAsyncResult *ares, MonoObject **exc);
-
-MonoObject *
-ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult *this_obj);
+ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult *ares);
 
 MonoWaitHandle *
 mono_wait_handle_new	    (MonoDomain *domain, HANDLE handle);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5783,29 +5783,23 @@ mono_async_result_new (MonoDomain *domain, HANDLE handle, MonoObject *state, gpo
 }
 
 MonoObject *
-mono_async_result_invoke (MonoAsyncResult *ares, MonoObject **exc)
+ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult *ares)
 {
 	MonoAsyncCall *ac;
 	MonoObject *res;
-	MonoInternalThread *thread;
 
 	g_assert (ares);
 	g_assert (ares->async_delegate);
 
-	thread = mono_thread_internal_current ();
-
 	ac = (MonoAsyncCall*) ares->object_data;
 	if (!ac) {
-		res = mono_runtime_delegate_invoke (ares->async_delegate, (void**) &ares->async_state, exc);
+		res = mono_runtime_delegate_invoke (ares->async_delegate, (void**) &ares->async_state, NULL);
 	} else {
-		MonoArray *out_args = NULL;
 		gpointer wait_event = NULL;
 
 		ac->msg->exc = NULL;
-		res = mono_message_invoke (ares->async_delegate, ac->msg, exc, &out_args);
-		MONO_OBJECT_SETREF (ac->msg, exc, *exc);
+		res = mono_message_invoke (ares->async_delegate, ac->msg, &ac->msg->exc, &ac->out_args);
 		MONO_OBJECT_SETREF (ac, res, res);
-		MONO_OBJECT_SETREF (ac, out_args, out_args);
 
 		mono_monitor_enter ((MonoObject*) ares);
 		ares->completed = 1;
@@ -5816,23 +5810,13 @@ mono_async_result_invoke (MonoAsyncResult *ares, MonoObject **exc)
 		if (wait_event != NULL)
 			SetEvent (wait_event);
 
-		if (!ac->cb_method) {
-			*exc = NULL;
-		} else {
-			mono_runtime_invoke (ac->cb_method, ac->cb_target, (gpointer*) &ares, exc);
+		if (ac->cb_method) {
+			/* we swallow the excepton as it is the behavior on .NET */
+			MonoObject *exc = NULL;
+			mono_runtime_invoke (ac->cb_method, ac->cb_target, (gpointer*) &ares, &exc);
 		}
 	}
 
-	return res;
-}
-
-MonoObject *
-ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult *this_obj)
-{
-	MonoObject *exc = NULL;
-	MonoObject *res = mono_async_result_invoke (this_obj, &exc);
-	if (exc)
-		mono_raise_exception ((MonoException*) exc);
 	return res;
 }
 
@@ -5984,8 +5968,7 @@ mono_message_invoke (MonoObject *target, MonoMethodMessage *msg,
 		object_array_klass = klass;
 	}
 
-	/* FIXME: GC ensure we insert a write barrier for out_args, maybe in the caller? */
-	*out_args = mono_array_new_specific (mono_class_vtable (domain, object_array_klass), outarg_count);
+	mono_gc_wbarrier_generic_store (out_args, (MonoObject*) mono_array_new_specific (mono_class_vtable (domain, object_array_klass), outarg_count));
 	*exc = NULL;
 
 	ret = mono_runtime_invoke_array (method, method->klass->valuetype? mono_object_unbox (target): target, msg->args, exc);


### PR DESCRIPTION
The swallowed exception is the behavior we can observe on .NET and Mono 4.0