### PR TITLE
Fixing initialization of have_vasprintf

### DIFF
--- a/eglib/configure.ac
+++ b/eglib/configure.ac
@@ -135,6 +135,7 @@ AC_CHECK_SIZEOF(void *)
 AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(long long)
 AC_CHECK_FUNCS(strlcpy stpcpy strtok_r rewinddir vasprintf)
+AC_CHECK_FUNC(vasprintf, have_vasprintf=yes)
 AC_CHECK_FUNCS(getrlimit)
 
 #


### PR DESCRIPTION
This patch initialize properly have_vasprintf in case vasprint function is found.
Solves multiple definition of `vasprintf' error in case vasprint is not properly detected.