### PR TITLE
[System.ServiceModel] Fix flaky Bug652331_2 test

### DIFF
--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
@@ -57,6 +57,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 			serviceHost.AddServiceEndpoint (typeof (IMetadataExchange), MetadataExchangeBindings.CreateMexHttpBinding (), "mex");
 
 			serviceHost.Open ();
+			Thread.Sleep (2000);  // let WCF spin up
 
 			try {
 				// client


### PR DESCRIPTION
The test sometimes failed on Jenkins with the timeout assert. Running only this single test locally with `make check TESTNAME=System.ServiceModel.Dispatcher.Bug652331Test.Bug652331_2` however reproduced this almost every single time.

It seems that WCF takes a bit to initialize until it accepts connections, so putting a little sleep fixed this for me locally and running it in a loop for half an hour didn't assert even once.

If someone has a better idea how to avoid the sleep I'm all ears, otherwise this should be a harmless fix.