### PR TITLE
eglib: checking locale_charset function availability

### DIFF
--- a/eglib/configure.ac
+++ b/eglib/configure.ac
@@ -182,6 +182,7 @@ fi
 AC_SUBST(G_HAVE_ISO_VARARGS)
 
 AC_CHECK_HEADERS(getopt.h sys/select.h sys/time.h sys/wait.h pwd.h langinfo.h iconv.h localcharset.h sys/types.h sys/resource.h)
+AC_CHECK_LIB([iconv], [locale_charset],[],[AC_CHECK_LIB([charset], [locale_charset],[LIBS+="-liconv -lcharset"])])
 AC_CHECK_HEADER(alloca.h, [HAVE_ALLOCA_H=1], [HAVE_ALLOCA_H=0])
 AC_SUBST(HAVE_ALLOCA_H)
 


### PR DESCRIPTION
This patch checks if locale_charset function is availabe in
libiconv of libcharset and chenges the linking options accordingly.