### PR TITLE
[threadpool-ms-io] Remove unnecessary asserts. Fixes #32947.

### DIFF
--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -533,7 +533,6 @@ is_socket_async_callback (MonoImage *system_image, MonoClass *class)
 	MonoClass *socket_async_callback_class = NULL;
 
 	socket_async_callback_class = mono_class_from_name (system_image, "System.Net.Sockets", "SocketAsyncCallback");
-	g_assert (socket_async_callback_class);
 
 	return class == socket_async_callback_class;
 }
@@ -544,7 +543,6 @@ is_async_read_handler (MonoImage *system_image, MonoClass *class)
 	MonoClass *async_read_handler_class = NULL;
 
 	async_read_handler_class = mono_class_from_name (system_image, "System.Diagnostics", "Process/AsyncReadHandler");
-	g_assert (async_read_handler_class);
 
 	return class == async_read_handler_class;
 }


### PR DESCRIPTION
Neither is_socket_async_callback nor is_async_read_handler need to
actually successfully load the classes they're comparing against;
if the classes can't be loaded, then the input class is obviously
not of that class.

This occurs when mscorlib is linked, the classes to compare against
might be linked away.

https://bugzilla.xamarin.com/show_bug.cgi?id=32947