### PR TITLE
[profiler] Add GC handle events with backtraces.

### DIFF
--- a/mono/profiler/proflog.h
+++ b/mono/profiler/proflog.h
@@ -24,6 +24,7 @@
                    load/unload for contexts
                    load/unload/name for assemblies
                removed TYPE_LOAD_ERR flag (profiler never generated it, now removed from the format itself)
+               added TYPE_GC_HANDLE_{CREATED,DESTROYED}_BT
  */
 
 enum {
@@ -56,8 +57,10 @@ enum {
 	TYPE_GC_EVENT  = 1 << 4,
 	TYPE_GC_RESIZE = 2 << 4,
 	TYPE_GC_MOVE   = 3 << 4,
-	TYPE_GC_HANDLE_CREATED   = 4 << 4,
-	TYPE_GC_HANDLE_DESTROYED = 5 << 4,
+	TYPE_GC_HANDLE_CREATED      = 4 << 4,
+	TYPE_GC_HANDLE_DESTROYED    = 5 << 4,
+	TYPE_GC_HANDLE_CREATED_BT   = 6 << 4,
+	TYPE_GC_HANDLE_DESTROYED_BT = 7 << 4,
 	/* extended type for TYPE_METHOD */
 	TYPE_LEAVE     = 1 << 4,
 	TYPE_ENTER     = 2 << 4,


### PR DESCRIPTION
This includes backtraces in GC handle events such that consumers of the format can present useful backtraces for them when enter/leave profiling is disabled (i.e. in 99% of cases). Basically mirrors the logic for regular object allocation events.

Sample output:

```bash
$ cat test.cs
using System.Runtime.InteropServices;
class Program {
        static void Foo () {
                GCHandle.Alloc (new int ());
                GCHandle.Alloc (new decimal ());
        }
        static void Main () {
                GCHandle.Alloc (new object ());
                var gch = GCHandle.Alloc (new string (new char [0]));
                Foo ();
                gch.Free ();
        }
}
$ mcs test.cs
$ mono '--profile=log:sample,alloc,nocalls,output=|mprof-report --traces --reports=gc -' test.exe

GC summary
        GC resizes: 0
        Max heap size: 0
        Object moves: 14
        Gen1 collections: 1, max time: 395us, total time: 395us, average: 395us
        GC handles weak: created: 1, destroyed: 0, max: 1
        GC handles normal: created: 4, destroyed: 1, max: 4
        2 created from:
                (wrapper runtime-invoke) object:runtime_invoke_void (object,intptr,intptr,intptr)
                Program:Main ()
                System.Runtime.InteropServices.GCHandle:Alloc (object)
                System.Runtime.InteropServices.GCHandle:.ctor (object)
                System.Runtime.InteropServices.GCHandle:.ctor (object,System.Runtime.InteropServices.GCHandleType)
                (wrapper managed-to-native) System.Runtime.InteropServices.GCHandle:GetTargetHandle (object,int,System.Runtime.InteropServices.GCHandleType)
        2 created from:
                (wrapper runtime-invoke) object:runtime_invoke_void (object,intptr,intptr,intptr)
                Program:Main ()
                Program:Foo ()
                System.Runtime.InteropServices.GCHandle:Alloc (object)
                System.Runtime.InteropServices.GCHandle:.ctor (object)
                System.Runtime.InteropServices.GCHandle:.ctor (object,System.Runtime.InteropServices.GCHandleType)
        1 destroyed from:
                (wrapper runtime-invoke) object:runtime_invoke_void (object,intptr,intptr,intptr)
                Program:Main ()
                System.Runtime.InteropServices.GCHandle:Free ()
                (wrapper managed-to-native) System.Runtime.InteropServices.GCHandle:FreeHandle (int)
```

You can track an object that has a handle as you would any other object and get useful backtraces when doing so:

```bash
$ mono '--profile=log:sample,alloc,nocalls,output=|mprof-report --traces --find=T:System.Decimal -' test.exe
Object 0x7f8077c004a8 created (System.Decimal, 32 bytes) at 0.006 secs.
        (wrapper runtime-invoke) object:runtime_invoke_void (object,intptr,intptr,intptr)
        Program:Main ()
        Program:Foo ()
        (wrapper managed-to-native) object:__icall_wrapper_mono_object_new_specific (intptr)
Object 0x7f8077c004a8 referenced from handle 27 at 0.006 secs.
        (wrapper runtime-invoke) object:runtime_invoke_void (object,intptr,intptr,intptr)
        Program:Main ()
        Program:Foo ()
        System.Runtime.InteropServices.GCHandle:Alloc (object)
        System.Runtime.InteropServices.GCHandle:.ctor (object)
        System.Runtime.InteropServices.GCHandle:.ctor (object,System.Runtime.InteropServices.GCHandleType)
Object 0x7f8077c004a8 moved to 0x7f8080eb4150
```

The only missing piece is tracking (i.e. `--track=0x...`) support for GC handle destruction events. This is a bit difficult to do in the current `mprof-report` code as we don't track the objects that handles are associated with.