### PR TITLE
[utils] Change mono_conc_hashtable write operations to rely on external locking.

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -679,7 +679,7 @@ mono_image_init (MonoImage *image)
 				       g_direct_hash,
 				       class_key_extract,
 				       class_next_value);
-	image->field_cache = mono_conc_hashtable_new (&image->lock, NULL, NULL);
+	image->field_cache = mono_conc_hashtable_new (NULL, NULL);
 
 	image->typespec_cache = g_hash_table_new (NULL, NULL);
 	image->memberref_signatures = g_hash_table_new (NULL, NULL);

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -600,8 +600,11 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 		}
 	}
 
-	if (field && field->parent && !field->parent->generic_class && !field->parent->generic_container)
+	if (field && field->parent && !field->parent->generic_class && !field->parent->generic_container) {
+		mono_image_lock (image);
 		mono_conc_hashtable_insert (image->field_cache, GUINT_TO_POINTER (token), field);
+		mono_image_unlock (image);
+	}
 
 	mono_loader_assert_no_error ();
 	return field;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1971,6 +1971,8 @@ mono_jit_free_method (MonoDomain *domain, MonoMethod *method)
 	mono_internal_hash_table_remove (&domain->jit_code_hash, method);
 	mono_domain_jit_code_hash_unlock (domain);
 	g_hash_table_remove (domain_jit_info (domain)->jump_trampoline_hash, method);
+
+	/* requires the domain lock - took above */
 	mono_conc_hashtable_remove (domain_jit_info (domain)->runtime_invoke_hash, method);
 
 	/* Remove jump targets in this method */
@@ -2254,7 +2256,9 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		if (!info->dyn_call_info)
 			info->runtime_invoke = mono_jit_compile_method (invoke);
 
+		mono_domain_lock (domain);
 		info2 = mono_conc_hashtable_insert (domain_info->runtime_invoke_hash, method, info);
+		mono_domain_unlock (domain);
 		if (info2) {
 			g_free (info);
 			info = info2;
@@ -2788,7 +2792,7 @@ mini_create_jit_domain_info (MonoDomain *domain)
 	info->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	info->delegate_trampoline_hash = g_hash_table_new (class_method_pair_hash, class_method_pair_equal);
 	info->llvm_vcall_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
-	info->runtime_invoke_hash = mono_conc_hashtable_new_full (&domain->lock, mono_aligned_addr_hash, NULL, NULL, runtime_invoke_info_free);
+	info->runtime_invoke_hash = mono_conc_hashtable_new_full (mono_aligned_addr_hash, NULL, NULL, runtime_invoke_info_free);
 	info->seq_points = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_seq_point_info_free);
 	info->arch_seq_points = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	info->jump_target_hash = g_hash_table_new (NULL, NULL);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -307,7 +307,7 @@ typedef struct
 	/* maps MonoMethod -> MonoJitDynamicMethodInfo */
 	GHashTable *dynamic_code_hash;
 	GHashTable *method_code_hash;
-	/* Maps methods to a RuntimeInvokeInfo structure */
+	/* Maps methods to a RuntimeInvokeInfo structure, protected by the associated MonoDomain lock */
 	MonoConcurrentHashTable *runtime_invoke_hash;
 	/* Maps MonoMethod to a GPtrArray containing sequence point locations */
 	GHashTable *seq_points;

--- a/mono/utils/mono-conc-hashtable.h
+++ b/mono/utils/mono-conc-hashtable.h
@@ -17,8 +17,8 @@
 
 typedef struct _MonoConcurrentHashTable MonoConcurrentHashTable;
 
-MONO_API MonoConcurrentHashTable* mono_conc_hashtable_new (mono_mutex_t *mutex, GHashFunc hash_func, GEqualFunc key_equal_func);
-MONO_API MonoConcurrentHashTable* mono_conc_hashtable_new_full (mono_mutex_t *mutex, GHashFunc hash_func, GEqualFunc key_equal_func, GDestroyNotify key_destroy_func, GDestroyNotify value_destroy_func);
+MONO_API MonoConcurrentHashTable* mono_conc_hashtable_new (GHashFunc hash_func, GEqualFunc key_equal_func);
+MONO_API MonoConcurrentHashTable* mono_conc_hashtable_new_full (GHashFunc hash_func, GEqualFunc key_equal_func, GDestroyNotify key_destroy_func, GDestroyNotify value_destroy_func);
 MONO_API void mono_conc_hashtable_destroy (MonoConcurrentHashTable *hash_table);
 MONO_API gpointer mono_conc_hashtable_lookup (MonoConcurrentHashTable *hash_table, gpointer key);
 MONO_API gpointer mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, gpointer value);


### PR DESCRIPTION
The original design was to pass a lock to the mono_conc_hashtable constructor and
then the write operations would do locking themselves.

That turned out to be a problem for two reasons:

First, it hidden the fact that locking was happening. Every other data structure in
the runtime rely on the caller to perform locking - thus that design ended up been
a lie.

Second, under coop, taking the lock became a problem as leak locks should be taken
in GC Safe mode and other locks should be taken under GC Unsafe mode. Taking a lock
in the wrong GC mode makes the suspend watchdog bark really loudly.

The runtime, funny enough has 2 usages of the conc hashtable, one with the image lock
and one with the domain lock - and each must be taken in a different GC mode. That
meant that either overcomplicating the design, or just removing locking from it.

This commit does that. It removes the mutex from mono_conc_hashtable and hoist locking
around the calls that used to do it.