### PR TITLE
[corlib] Implement MonoEvent Module property

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoEvent.cs
+++ b/mcs/class/corlib/System.Reflection/MonoEvent.cs
@@ -69,10 +69,26 @@ namespace System.Reflection {
 			}
 		}
 
+		public override Module Module {
+			get {
+				return GetRuntimeModule ();
+			}
+		}
+
+		internal RuntimeType GetDeclaringTypeInternal ()
+		{
+			return (RuntimeType) DeclaringType;
+		}
+
 		RuntimeType ReflectedTypeInternal {
 			get {
 				return (RuntimeType) ReflectedType;
 			}
+		}
+
+		internal RuntimeModule GetRuntimeModule ()
+		{
+			return GetDeclaringTypeInternal ().GetRuntimeModule ();
 		}
 
         #region ISerializable

--- a/mcs/class/corlib/Test/System.Reflection/ConstructorInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ConstructorInfoTest.cs
@@ -140,5 +140,14 @@ namespace MonoTests.System.Reflection
 			var ctor = typeof (Gen<>).GetConstructor (Type.EmptyTypes);
 			Assert.IsTrue (ctor.ContainsGenericParameters);
 		}
+
+		[Test]
+		public void ConstructorInfoModule ()
+		{
+			Type type = typeof (Foo);
+			ConstructorInfo co = type.GetConstructors ()[0];
+
+			Assert.AreEqual (type.Module, co.Module);
+		}
 	}
 }

--- a/mcs/class/corlib/Test/System.Reflection/EventInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/EventInfoTest.cs
@@ -114,6 +114,15 @@ namespace MonoTests.System.Reflection
 			} catch (InvalidOperationException) {}			
 		}
 
+		[Test]
+		public void EventInfoModule ()
+		{
+			Type type = typeof (TestClass);
+			EventInfo ev = type.GetEvent ("pub");
+
+			Assert.AreEqual (type.Module, ev.Module);
+		}
+
 #pragma warning disable 67
 		public class PrivateEvent
 		{

--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -401,6 +401,15 @@ namespace MonoTests.System.Reflection
 		}
 
 		[Test]
+		public void MethodInfoModule ()
+		{
+			Type type = typeof (MethodInfoTest);
+			MethodInfo me = type.GetMethod ("return_parameter_test");
+
+			Assert.AreEqual (type.Module, me.Module);
+		}
+
+		[Test]
 			public void InvokeOnRefOnlyAssembly ()
 		{
 			Assembly a = Assembly.ReflectionOnlyLoad (typeof (MethodInfoTest).Assembly.FullName);


### PR DESCRIPTION
Add tests for Event-, Method- and ConstructorInfo to verify accessing .Module works (the latter two already worked before this change).

This follows the lead of https://github.com/mono/mono/commit/1304fc1546f031be7a91a0663e00308fc5cbbbae and https://github.com/mono/mono/pull/1794 and should be the last of the \*Info classes that didn't properly override Module.

/cc @marek-safar 

Please cherry-pick into 4.2 as this is a regression from 4.0.