### PR TITLE
[ilasm] Add stubs for the "legacy library" and "auto" keywords in .assembly 

### DIFF
--- a/mcs/ilasm/parser/ILParser.jay
+++ b/mcs/ilasm/parser/ILParser.jay
@@ -480,6 +480,8 @@ namespace Mono.ILASM {
 %token K_OFF
 %token K_FORWARDER
 %token K_CHARMAPERROR
+%token K_LEGACY
+%token K_LIBRARY
 
 /* end generated */
 
@@ -3149,9 +3151,9 @@ assembly_all		: assembly_head OPEN_BRACE assembly_decls CLOSE_BRACE
 			  }
 			;
 
-assembly_head		: D_ASSEMBLY asm_attr slashed_name
+assembly_head		: D_ASSEMBLY legacylibrary_opt asm_attr slashed_name
                           {
-                                codegen.SetThisAssembly ((string) $3, (PEAPI.AssemAttr) $2);
+                                codegen.SetThisAssembly ((string) $4, (PEAPI.AssemAttr) $3);
                                 codegen.CurrentCustomAttrTarget = codegen.ThisAssembly;
 				codegen.CurrentDeclSecurityTarget = codegen.ThisAssembly;
                           }
@@ -3211,19 +3213,19 @@ asm_or_ref_decl		: D_PUBLICKEY ASSIGN bytes_list
 assemblyref_all		: assemblyref_head OPEN_BRACE assemblyref_decls CLOSE_BRACE
 			;
 
-assemblyref_head	: D_ASSEMBLY K_EXTERN asm_attr slashed_name
+assemblyref_head	: D_ASSEMBLY K_EXTERN legacylibrary_opt asm_attr slashed_name
                           {
                                 System.Reflection.AssemblyName asmb_name = 
 					new System.Reflection.AssemblyName ();
-				asmb_name.Name = (string) $4;
-				codegen.BeginAssemblyRef ((string) $4, asmb_name, (PEAPI.AssemAttr) $3);
+				asmb_name.Name = (string) $5;
+				codegen.BeginAssemblyRef ((string) $5, asmb_name, (PEAPI.AssemAttr) $4);
                           }
-			| D_ASSEMBLY K_EXTERN asm_attr slashed_name K_AS slashed_name
+			| D_ASSEMBLY K_EXTERN legacylibrary_opt asm_attr slashed_name K_AS slashed_name
                           {
                                 System.Reflection.AssemblyName asmb_name = 
 					new System.Reflection.AssemblyName ();
-				asmb_name.Name = (string) $4;
-				codegen.BeginAssemblyRef ((string) $6, asmb_name, (PEAPI.AssemAttr) $3);
+				asmb_name.Name = (string) $5;
+				codegen.BeginAssemblyRef ((string) $7, asmb_name, (PEAPI.AssemAttr) $4);
                           }
 			;
 
@@ -3423,6 +3425,10 @@ semicolon_opt
 			: /* empty */
 			| SEMICOLON
 			;
+
+legacylibrary_opt	: /* empty */
+					| K_LEGACY K_LIBRARY  /* MS ilasm has these keywords for backwards compatibility, we just ignore them */
+					;
 
 %%
 

--- a/mcs/ilasm/parser/ILParser.jay
+++ b/mcs/ilasm/parser/ILParser.jay
@@ -482,6 +482,7 @@ namespace Mono.ILASM {
 %token K_CHARMAPERROR
 %token K_LEGACY
 %token K_LIBRARY
+%token K_AUTO
 
 /* end generated */
 
@@ -3260,6 +3261,7 @@ assemblyref_decl	: D_VER int32 COLON int32 COLON int32 COLON int32
                                 if (codegen.CurrentCustomAttrTarget != null)
                                         codegen.CurrentCustomAttrTarget.AddCustomAttribute ((CustomAttr) $1);
                           }
+            | K_AUTO  /* MS ilasm uses this keyword to lookup the specified assembly in the GAC and embeds its attributes, we just ignore it */
 			;
 
 exptype_all		: exptype_head OPEN_BRACE exptype_decls CLOSE_BRACE

--- a/mcs/ilasm/scanner/ILTables.cs
+++ b/mcs/ilasm/scanner/ILTables.cs
@@ -319,6 +319,7 @@ namespace Mono.ILASM {
 				keywords ["forwarder"] = new ILToken (Token.K_FORWARDER, "forwarder");
                                 keywords ["legacy"] = new ILToken (Token.K_LEGACY, "legacy");
                                 keywords ["library"] = new ILToken (Token.K_LIBRARY, "library");
+                                keywords ["auto"] = new ILToken (Token.K_AUTO, "auto");
 
                                 return keywords;
                         }

--- a/mcs/ilasm/scanner/ILTables.cs
+++ b/mcs/ilasm/scanner/ILTables.cs
@@ -317,6 +317,8 @@ namespace Mono.ILASM {
                                 keywords ["off"] = new ILToken (Token.K_OFF, "off");
 				keywords ["strict"] = new ILToken (Token.K_STRICT, "strict");
 				keywords ["forwarder"] = new ILToken (Token.K_FORWARDER, "forwarder");
+                                keywords ["legacy"] = new ILToken (Token.K_LEGACY, "legacy");
+                                keywords ["library"] = new ILToken (Token.K_LIBRARY, "library");
 
                                 return keywords;
                         }


### PR DESCRIPTION
They are present in some of the IL tests in dotnet/coreclr and otherwise ilasm can't process such files.
The keywords aren't documented in ECMA335, I opened https://github.com/dotnet/coreclr/issues/1401 for more clarification. I think we can just ignore them for now.