### PR TITLE
Read tzfile values as unsigned int

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1170,7 +1170,7 @@ namespace System
 			return true;
 		}
 
-		static int SwapInt32 (int i)
+		static uint SwapUInt32 (uint i)
 		{
 			return (((i >> 24) & 0xff)
 				| ((i >> 8) & 0xff00)
@@ -1178,30 +1178,35 @@ namespace System
 				| ((i << 24)));
 		}
 
-		static int ReadBigEndianInt32 (byte [] buffer, int start)
+		static uint ReadBigEndianUInt32 (byte [] buffer, uint start)
 		{
-			int i = BitConverter.ToInt32 (buffer, start);
+			uint i = BitConverter.ToUInt32 (buffer, (int)start);
 			if (!BitConverter.IsLittleEndian)
 				return i;
 
-			return SwapInt32 (i);
+			return SwapUInt32 (i);
+		}
+
+		static int ReadBigEndianSignedInt32 (byte [] buffer, uint start)
+		{
+			return (int)ReadBigEndianUInt32(buffer, start);
 		}
 
 		private static TimeZoneInfo ParseTZBuffer (string id, byte [] buffer, int length)
 		{
 			//Reading the header. 4 bytes for magic, 16 are reserved
-			int ttisgmtcnt = ReadBigEndianInt32 (buffer, 20);
-			int ttisstdcnt = ReadBigEndianInt32 (buffer, 24);
-			int leapcnt = ReadBigEndianInt32 (buffer, 28);
-			int timecnt = ReadBigEndianInt32 (buffer, 32);
-			int typecnt = ReadBigEndianInt32 (buffer, 36);
-			int charcnt = ReadBigEndianInt32 (buffer, 40);
+			uint ttisgmtcnt = ReadBigEndianUInt32 (buffer, 20);
+			uint ttisstdcnt = ReadBigEndianUInt32 (buffer, 24);
+			uint leapcnt = ReadBigEndianUInt32 (buffer, 28);
+			uint timecnt = ReadBigEndianUInt32 (buffer, 32);
+			uint typecnt = ReadBigEndianUInt32 (buffer, 36);
+			uint charcnt = ReadBigEndianUInt32 (buffer, 40);
 
 			if (length < 44 + timecnt * 5 + typecnt * 6 + charcnt + leapcnt * 8 + ttisstdcnt + ttisgmtcnt)
 				throw new InvalidTimeZoneException ();
 
-			Dictionary<int, string> abbreviations = ParseAbbreviations (buffer, 44 + 4 * timecnt + timecnt + 6 * typecnt, charcnt);
-			Dictionary<int, TimeType> time_types = ParseTimesTypes (buffer, 44 + 4 * timecnt + timecnt, typecnt, abbreviations);
+			Dictionary<uint, string> abbreviations = ParseAbbreviations (buffer, 44 + 4 * timecnt + timecnt + 6 * typecnt, charcnt);
+			Dictionary<uint, TimeType> time_types = ParseTimesTypes (buffer, 44 + 4 * timecnt + timecnt, typecnt, abbreviations);
 			List<KeyValuePair<DateTime, TimeType>> transitions = ParseTransitions (buffer, 44, timecnt, time_types);
 
 			if (time_types.Count == 0)
@@ -1219,7 +1224,7 @@ namespace System
 			List<AdjustmentRule> adjustmentRules = new List<AdjustmentRule> ();
 			bool storeTransition = false;
 
-			for (int i = 0; i < transitions.Count; i++) {
+			for (int i = 0; i < (int)transitions.Count; i++) {
 				var pair = transitions [i];
 				DateTime ttime = pair.Key;
 				TimeType ttype = pair.Value;
@@ -1306,20 +1311,20 @@ namespace System
 			return tz;
 		}
 
-		static Dictionary<int, string> ParseAbbreviations (byte [] buffer, int index, int count)
+		static Dictionary<uint, string> ParseAbbreviations (byte [] buffer, uint index, uint count)
 		{
-			var abbrevs = new Dictionary<int, string> ();
-			int abbrev_index = 0;
+			var abbrevs = new Dictionary<uint, string> ();
+			uint abbrev_index = 0;
 			var sb = new StringBuilder ();
-			for (int i = 0; i < count; i++) {
+			for (uint i = 0; i < count; i++) {
 				char c = (char) buffer [index + i];
 				if (c != '\0')
 					sb.Append (c);
 				else {
 					abbrevs.Add (abbrev_index, sb.ToString ());
 					//Adding all the substrings too, as it seems to be used, at least for Africa/Windhoek
-					for (int j = 1; j < sb.Length; j++)
-						abbrevs.Add (abbrev_index + j, sb.ToString (j, sb.Length - j));
+					for (uint j = 1; j < sb.Length; j++)
+						abbrevs.Add (abbrev_index + j, sb.ToString ((int)j, sb.Length - (int)j));
 					abbrev_index = i + 1;
 					sb = new StringBuilder ();
 				}
@@ -1327,26 +1332,26 @@ namespace System
 			return abbrevs;
 		}
 
-		static Dictionary<int, TimeType> ParseTimesTypes (byte [] buffer, int index, int count, Dictionary<int, string> abbreviations)
+		static Dictionary<uint, TimeType> ParseTimesTypes (byte [] buffer, uint index, uint count, Dictionary<uint, string> abbreviations)
 		{
-			var types = new Dictionary<int, TimeType> (count);
-			for (int i = 0; i < count; i++) {
-				int offset = ReadBigEndianInt32 (buffer, index + 6 * i);
+			var types = new Dictionary<uint, TimeType> ((int)count);
+			for (uint i = 0; i < count; i++) {
+				int offset = ReadBigEndianSignedInt32 (buffer, index + 6 * i);
 				byte is_dst = buffer [index + 6 * i + 4];
 				byte abbrev = buffer [index + 6 * i + 5];
-				types.Add (i, new TimeType (offset, (is_dst != 0), abbreviations [(int)abbrev]));
+				types.Add (i, new TimeType (offset, (is_dst != 0), abbreviations [(uint)abbrev]));
 			}
 			return types;
 		}
 
-		static List<KeyValuePair<DateTime, TimeType>> ParseTransitions (byte [] buffer, int index, int count, Dictionary<int, TimeType> time_types)
+		static List<KeyValuePair<DateTime, TimeType>> ParseTransitions (byte [] buffer, uint index, uint count, Dictionary<uint, TimeType> time_types)
 		{
-			var list = new List<KeyValuePair<DateTime, TimeType>> (count);
-			for (int i = 0; i < count; i++) {
-				int unixtime = ReadBigEndianInt32 (buffer, index + 4 * i);
+			var list = new List<KeyValuePair<DateTime, TimeType>> ((int)count);
+			for (uint i = 0; i < count; i++) {
+				long unixtime = (long)ReadBigEndianUInt32 (buffer, index + 4 * i);
 				DateTime ttime = DateTimeFromUnixTime (unixtime);
 				byte ttype = buffer [index + 4 * count + i];
-				list.Add (new KeyValuePair<DateTime, TimeType> (ttime, time_types [(int)ttype]));
+				list.Add (new KeyValuePair<DateTime, TimeType> (ttime, time_types [(uint)ttype]));
 			}
 			return list;
 		}


### PR DESCRIPTION
Almost all fields in the UNIX timezone
file are unsigned integers (mostly offsets).
Only struct ttinfo field tt_mgmtoff is
of type (long) and may indicate positive
or negative offset west or east of GMT.

Reading values on PPC64 caused issues
with imported values (e.g. 0xeb000000)
to be sign-extended (to 0xffeb000000000000)
which lead to incorred value after
byte-swapping (0xffeb0000000000eb instead
of just 0xeb).

Might-fix: https://bugzilla.xamarin.com/show_bug.cgi?id=30360