### PR TITLE
Do not build libeglib-static.a

### DIFF
--- a/eglib/src/Makefile.am
+++ b/eglib/src/Makefile.am
@@ -1,4 +1,4 @@
-noinst_LTLIBRARIES = libeglib.la libeglib-static.la
+noinst_LTLIBRARIES = libeglib.la
 
 AM_CFLAGS = $(WERROR_CFLAGS)
 
@@ -59,8 +59,6 @@ libeglib_la_SOURCES = \
 	$(vasprintf_files)
 
 libeglib_la_CFLAGS = -g -Wall -D_FORTIFY_SOURCE=2
-libeglib_static_la_SOURCES=$(libeglib_la_SOURCES)
-libeglib_static_la_CFLAGS = $(libeglib_la_CFLAGS)
 
 AM_CPPFLAGS = -I$(srcdir)
 
@@ -71,9 +69,6 @@ if PLATFORM_ANDROID
 libeglib_la_LIBADD = -llog
 endif
 endif
-
-libeglib_static_la_LIBADD = $(libeglib_la_LIBADD) $(LIBICONV)
-libeglib_static_la_LDFLAGS = -static
 
 MAINTAINERCLEANFILES = Makefile.in
 


### PR DESCRIPTION
1) libeglib.a is already a static library
2) It is not used anywhere, unlike other lib*-static.a
   libraries in the Mono runtime