### PR TITLE
Bug fix: reading of infinite web response can lead to connection loss

### DIFF
--- a/mcs/class/System/System.Net/WebConnectionStream.cs
+++ b/mcs/class/System/System.Net/WebConnectionStream.cs
@@ -67,6 +67,7 @@ namespace System.Net
 		int write_timeout;
 		AsyncCallback cb_wrapper; // Calls to ReadCallbackWrapper or WriteCallbacWrapper
 		internal bool IgnoreIOErrors;
+		bool isContinuousContent;
 
 		public WebConnectionStream (WebConnection cnc, WebConnectionData data)
 		{          
@@ -97,6 +98,7 @@ namespace System.Net
 				}
 			} else {
 				contentLength = Int32.MaxValue;
+				isContinuousContent = true;
 			}
 
 			// Negative numbers?
@@ -372,7 +374,10 @@ namespace System.Net
 				readBufferOffset += copy;
 				offset += copy;
 				size -= copy;
-				totalRead += copy;
+
+				if (!isContinuousContent)
+					totalRead += copy;
+				
 				if (size == 0 || totalRead >= contentLength) {
 					result.SetCompleted (true, copy);
 					result.DoCallback ();
@@ -429,7 +434,9 @@ namespace System.Net
 					read_eof = true;
 				}
 
-				totalRead += nbytes;
+				if (!isContinuousContent)
+					totalRead += nbytes;
+
 				result.SetCompleted (false, nbytes + result.NBytes);
 				result.DoCallback ();
 				if (nbytes == 0)

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -6,6 +6,7 @@
 //   Martin Willemoes Hansen (mwh@sysrq.dk)
 //   Gonzalo Paniagua Javier (gonzalo@ximian.com)
 //   Andres G. Aragoneses (andres@7digital.com)
+//   Bogdanov Kirill (bogdanov@macroscop.com)
 //
 // (C) 2003 Martin Willemoes Hansen
 // Copyright (c) 2005 Novell, Inc. (http://www.novell.com
@@ -2301,6 +2302,88 @@ namespace MonoTests.System.Net
 
 			return;
 		}
+		
+		[Test]
+		public void TestLargeDataReading ()
+		{
+			const int internalBufferSize = 16 * 1024 * 1024;
+			AutoResetEvent readyGetLastPortionEvent = new AutoResetEvent (false);
+			AssertionException testException = null;
+
+			DoRequest (
+			(request, waitHandle) =>
+			{
+				try
+				{
+					const int timeoutMs = 5000;
+
+					request.Timeout = timeoutMs;
+					request.ReadWriteTimeout = timeoutMs;
+
+					if (Type.GetType ("Mono.Runtime") == null)
+						//significantly increases speed of test on MS .NET, because default value	
+						//of receive buffer is about 8192 bytes. doesn't implemented now on Mono.
+						request.ServicePoint.ReceiveBufferSize = internalBufferSize;
+
+					WebResponse webResponse = request.GetResponse ();
+					Stream webResponseStream = webResponse.GetResponseStream ();
+					Assert.IsNotNull (webResponseStream, null, "#1");
+
+					int totalRead = 0;
+					byte[] readBuffer = new byte[internalBufferSize];
+
+					while (totalRead < int.MaxValue) {
+						int read = webResponseStream.Read (readBuffer, 0, readBuffer.Length);
+						Assert.Greater (read, 0, "#2");
+						totalRead += read;
+						Assert.Greater (totalRead, 0, "#3");
+					}
+
+					Assert.AreEqual (totalRead, int.MaxValue, "#4");
+					readyGetLastPortionEvent.Set ();
+					Assert.Greater (webResponseStream.Read (readBuffer, 0, readBuffer.Length), 0, "#5");
+				}
+				catch (AssertionException e)
+				{
+					testException = e;
+				}
+				finally
+				{
+					waitHandle.Set ();
+				}
+			},
+			processor =>
+			{
+				processor.Request.InputStream.Close ();
+
+				HttpListenerResponse response = processor.Response;
+				response.SendChunked = true;
+
+				Stream outputStream = response.OutputStream;
+
+				long totalWritten = 0;
+				byte[] writeBuffer = new byte[internalBufferSize];
+
+				while (totalWritten < int.MaxValue) {
+					int size;
+
+					if (totalWritten + writeBuffer.Length < int.MaxValue)
+						size = writeBuffer.Length;
+					else
+						size = (int) (int.MaxValue - totalWritten);
+
+					outputStream.Write (writeBuffer, 0, size);
+					totalWritten += size;
+				}
+
+				readyGetLastPortionEvent.WaitOne ();
+				outputStream.Write (writeBuffer, 0, writeBuffer.Length);
+				response.Close ();
+			}, 60 * 1000);
+
+			if (testException != null)
+				throw testException;
+		}
 
 		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request)
 		{
@@ -2316,7 +2399,7 @@ namespace MonoTests.System.Net
 				Assert.Fail ("Test hung");
 		}
 
-		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request, Action<HttpListenerContext> processor)
+		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request, Action<HttpListenerContext> processor, int timeoutMs = 10000)
 		{
 			int port = NetworkHelpers.FindFreePort ();
 
@@ -2331,7 +2414,7 @@ namespace MonoTests.System.Net
 
 				ThreadPool.QueueUserWorkItem ((o) => request (client, completed [1]));
 
-				if (!WaitHandle.WaitAll (completed, 10000))
+				if (!WaitHandle.WaitAll (completed, timeoutMs))
 					Assert.Fail ("Test hung.");
 			}
 		}


### PR DESCRIPTION
When HttpWebRequest is used to download infinite (ContentLength not set) response from web server, we can see that after reading about 2 GB (Int32.MaxValue) of data, totalRead variable can be equal to contentLength (which is int32.MaxValue). Then WebConnectionStream thinks that all data is received (see soft condition totalRead >= contentLength), but this is not correct. Seems to me the easiest way to fix that is to forbid increment of totalRead variable. Check it please.