### PR TITLE
[ppc] Basic changes to allow mono to build and run on power BE

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1002,7 +1002,10 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 				}
 			}
 		}
-	} else {
+	// If "delegate->method_ptr" is null mono_get_addr_from_ftnptr will fail if
+	// ftnptrs are being used.  "method" would end up null on archtitectures without
+	// ftnptrs so we can just skip this.
+	} else if (delegate->method_ptr) {
 		ji = mono_jit_info_table_find (domain, mono_get_addr_from_ftnptr (delegate->method_ptr));
 		if (ji)
 			method = jinfo_get_method (ji);

--- a/mono/sgen/sgen-archdep.h
+++ b/mono/sgen/sgen-archdep.h
@@ -88,8 +88,8 @@
 	} while (0)
 
 /* MS_BLOCK_SIZE must be a multiple of the system pagesize, which for some
-   archs is 64k.  */
-#if defined(TARGET_POWERPC64) && _CALL_ELF == 2
+   architectures is 64k.  */
+#if defined(TARGET_POWERPC64)
 #define ARCH_MIN_MS_BLOCK_SIZE	(64*1024)
 #define ARCH_MIN_MS_BLOCK_SIZE_SHIFT	16
 #endif


### PR DESCRIPTION
These are the basic changes necessary to get mono to build and run on power 64 bit BE.  With these changes all the test cases except 2 run fine.  The 2 that fail (block_guard_restore_aligment_on_exit and delegate-async-exit) will be addressed in further patches.