### PR TITLE
[corlib] Rename private method in TimeZoneInfo to avoid conflict with public one via reflection

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.Android.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.Android.cs
@@ -266,7 +266,7 @@ namespace System {
 			return timeZoneInfo;
 		}
 
-		static void GetSystemTimeZones (List<TimeZoneInfo> systemTimeZones)
+		static void GetSystemTimeZonesCore (List<TimeZoneInfo> systemTimeZones)
 		{
 			foreach (string id in AndroidTimeZones.GetAvailableIds ()) {
 				var tz = AndroidTimeZones.GetTimeZone (id, id);

--- a/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
@@ -58,7 +58,7 @@ namespace System {
 			}
 		}
 
-		static void GetSystemTimeZones (List<TimeZoneInfo> systemTimeZones)
+		static void GetSystemTimeZonesCore (List<TimeZoneInfo> systemTimeZones)
 		{
 			foreach (string name in GetMonoTouchNames ()) {
 				using (Stream stream = GetMonoTouchData (name, false)) {

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -135,7 +135,7 @@ namespace System
 #endif
 		}
 
-		static void GetSystemTimeZones (List<TimeZoneInfo> systemTimeZones)
+		static void GetSystemTimeZonesCore (List<TimeZoneInfo> systemTimeZones)
 		{
 #if !MOBILE_STATIC
 			if (TimeZoneKey != null) {
@@ -651,7 +651,7 @@ namespace System
 		{
 			if (systemTimeZones == null) {
 				var tz = new List<TimeZoneInfo> ();
-				GetSystemTimeZones (tz);
+				GetSystemTimeZonesCore (tz);
 				Interlocked.CompareExchange (ref systemTimeZones, new ReadOnlyCollection<TimeZoneInfo> (tz), null);
 			}
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -690,6 +690,15 @@ namespace MonoTests.System
 				}
 				Assert.Fail ("Europe/Brussels not found in SystemTZ");
 			}
+
+			[Test]
+			public void ReflectionReturnsTheCorrectMethod ()
+			{
+				var method = (MethodInfo) typeof (TimeZoneInfo).GetMember ("GetSystemTimeZones", MemberTypes.Method, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)[0];
+
+				var timeZones = (global::System.Collections.ObjectModel.ReadOnlyCollection<TimeZoneInfo>) method.Invoke (null, null);
+				Assert.IsNotEmpty (timeZones);
+			}
 		}
 		
 		[TestFixture]


### PR DESCRIPTION
A private overload of the public GetSystemTimeZones() method was added in 4dc9a90d7f23f0f5a7a31f7357ea782408d3d9b5.
This broke code that tried to access that method via reflection and expected that there be only one.

Fixing this by renaming the private method to GetSystemTimeZonesCore (which is also more aligned with FindSystemTimeZoneByIdCore).

--
Found out as it indirectly affected the nodatime tests: https://github.com/nodatime/nodatime/commit/8959fdb230d024563fafe9d1edf85d0e129d1ed8

This is technically a regression from 4.0, but reflection code is always dangerous :dragon: 