### PR TITLE
[ChunkStream] CPU and memory leak fix when writing and reading infinitely

### DIFF
--- a/mcs/class/System/System.Net/ChunkStream.cs
+++ b/mcs/class/System/System.Net/ChunkStream.cs
@@ -29,6 +29,7 @@
 //
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -114,13 +115,13 @@ namespace System.Net
 		{
 			int count = chunks.Count;
 			int nread = 0;
+
+			var chunksForRemoving = new List<Chunk>(count);
 			for (int i = 0; i < count; i++) {
 				Chunk chunk = (Chunk) chunks [i];
-				if (chunk == null)
-					continue;
 
 				if (chunk.Offset == chunk.Bytes.Length) {
-					chunks [i] = null;
+					chunksForRemoving.Add(chunk);
 					continue;
 				}
 				
@@ -128,6 +129,9 @@ namespace System.Net
 				if (nread == size)
 					break;
 			}
+
+			foreach (var chunk in chunksForRemoving)
+				chunks.Remove(chunk);
 
 			return nread;
 		}


### PR DESCRIPTION
The problem is connected with "chunks" field in ChunkStream class. As you can see in "ReadFromChunks" method, the number of elements of this array continuously grows, because array's elements are not removed but just set to null. So, every subsequent call of this method will be slower than previous and will use additional memory more and more infinitely. Yes, we have "ResetBuffer" method than could clear "chunks" array, but nobody call it when the connection is infinite.

The typical case when we need infinite connection is getting video stream from web server through HttpWebRequest.

In our server application we are getting 100% CPU usage after 6 hours of work. Server application must work for months.