### PR TITLE
Bug fix: reading of infinite web response can lead to connection loss

### DIFF
--- a/mcs/class/System/System.Net/WebConnectionStream.cs
+++ b/mcs/class/System/System.Net/WebConnectionStream.cs
@@ -45,8 +45,8 @@ namespace System.Net
 		int readBufferOffset;
 		int readBufferSize;
 		int stream_length; // -1 when CL not present
-		int contentLength;
-		int totalRead;
+		long contentLength;
+		long totalRead;
 		internal long totalWritten;
 		bool nextReadCalled;
 		int pendingReads;
@@ -93,10 +93,10 @@ namespace System.Net
 						ReadAll ();
 					}
 				} catch {
-					contentLength = Int32.MaxValue;
+					contentLength = Int64.MaxValue;
 				}
 			} else {
-				contentLength = Int32.MaxValue;
+				contentLength = Int64.MaxValue;
 			}
 
 			// Negative numbers?
@@ -208,7 +208,7 @@ namespace System.Net
 		internal void ForceCompletion ()
 		{
 			if (!nextReadCalled) {
-				if (contentLength == Int32.MaxValue)
+				if (contentLength == Int64.MaxValue)
 					contentLength = 0;
 				nextReadCalled = true;
 				cnc.NextRead ();
@@ -244,7 +244,7 @@ namespace System.Net
 				int diff = readBufferSize - readBufferOffset;
 				int new_size;
 
-				if (contentLength == Int32.MaxValue) {
+				if (contentLength == Int64.MaxValue) {
 					MemoryStream ms = new MemoryStream ();
 					byte [] buffer = null;
 					if (readBuffer != null && diff > 0) {
@@ -264,7 +264,7 @@ namespace System.Net
 					new_size = (int) ms.Length;
 					contentLength = new_size;
 				} else {
-					new_size = contentLength - totalRead;
+					new_size = (int) (contentLength - totalRead);
 					b = new byte [new_size];
 					if (readBuffer != null && diff > 0) {
 						if (diff > new_size)
@@ -384,8 +384,8 @@ namespace System.Net
 			if (cb != null)
 				cb = cb_wrapper;
 
-			if (contentLength != Int32.MaxValue && contentLength - totalRead < size)
-				size = contentLength - totalRead;
+			if (contentLength != Int64.MaxValue && contentLength - totalRead < size)
+				size = (int)(contentLength - totalRead);
 
 			if (!read_eof) {
 				result.InnerAsyncResult = cnc.BeginRead (request, buffer, offset, size, cb, result);

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -6,6 +6,7 @@
 //   Martin Willemoes Hansen (mwh@sysrq.dk)
 //   Gonzalo Paniagua Javier (gonzalo@ximian.com)
 //   Andres G. Aragoneses (andres@7digital.com)
+//   Bogdanov Kirill (bogdanov@macroscop.com)
 //
 // (C) 2003 Martin Willemoes Hansen
 // Copyright (c) 2005 Novell, Inc. (http://www.novell.com
@@ -2301,6 +2302,88 @@ namespace MonoTests.System.Net
 
 			return;
 		}
+		
+		[Test]
+		public void TestLargeDataReading ()
+		{
+			const int internalBufferSize = 16 * 1024 * 1024;
+			AutoResetEvent readyGetLastPortionEvent = new AutoResetEvent (false);
+			AssertionException testException = null;
+
+			DoRequest (
+			(request, waitHandle) =>
+			{
+				try
+				{
+					const int timeoutMs = 5000;
+
+					request.Timeout = timeoutMs;
+					request.ReadWriteTimeout = timeoutMs;
+
+					if (Type.GetType ("Mono.Runtime") == null)
+						//significantly increases speed of test on MS .NET, because default value	
+						//of receive buffer is about 8192 bytes. doesn't implemented now on Mono.
+						request.ServicePoint.ReceiveBufferSize = internalBufferSize;
+
+					WebResponse webResponse = request.GetResponse ();
+					Stream webResponseStream = webResponse.GetResponseStream ();
+					Assert.IsNotNull (webResponseStream, null, "#1");
+
+					int totalRead = 0;
+					byte[] readBuffer = new byte[internalBufferSize];
+
+					while (totalRead < int.MaxValue) {
+						int read = webResponseStream.Read (readBuffer, 0, readBuffer.Length);
+						Assert.Greater (read, 0, "#2");
+						totalRead += read;
+						Assert.Greater (totalRead, 0, "#3");
+					}
+
+					Assert.AreEqual (totalRead, int.MaxValue, "#4");
+					readyGetLastPortionEvent.Set ();
+					Assert.Greater (webResponseStream.Read (readBuffer, 0, readBuffer.Length), 0, "#5");
+				}
+				catch (AssertionException e)
+				{
+					testException = e;
+				}
+				finally
+				{
+					waitHandle.Set ();
+				}
+			},
+			processor =>
+			{
+				processor.Request.InputStream.Close ();
+
+				HttpListenerResponse response = processor.Response;
+				response.SendChunked = true;
+
+				Stream outputStream = response.OutputStream;
+
+				long totalWritten = 0;
+				byte[] writeBuffer = new byte[internalBufferSize];
+
+				while (totalWritten < int.MaxValue) {
+					int size;
+
+					if (totalWritten + writeBuffer.Length < int.MaxValue)
+						size = writeBuffer.Length;
+					else
+						size = (int) (int.MaxValue - totalWritten);
+
+					outputStream.Write (writeBuffer, 0, size);
+					totalWritten += size;
+				}
+
+				readyGetLastPortionEvent.WaitOne ();
+				outputStream.Write (writeBuffer, 0, writeBuffer.Length);
+				response.Close ();
+			}, 60 * 1000);
+
+			if (testException != null)
+				throw testException;
+		}
 
 		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request)
 		{
@@ -2316,7 +2399,7 @@ namespace MonoTests.System.Net
 				Assert.Fail ("Test hung");
 		}
 
-		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request, Action<HttpListenerContext> processor)
+		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request, Action<HttpListenerContext> processor, int timeoutMs = 10000)
 		{
 			int port = NetworkHelpers.FindFreePort ();
 
@@ -2331,7 +2414,7 @@ namespace MonoTests.System.Net
 
 				ThreadPool.QueueUserWorkItem ((o) => request (client, completed [1]));
 
-				if (!WaitHandle.WaitAll (completed, 10000))
+				if (!WaitHandle.WaitAll (completed, timeoutMs))
 					Assert.Fail ("Test hung.");
 			}
 		}


### PR DESCRIPTION
When HttpWebRequest is used to download infinite (ContentLength not set) response from web server, we can see that after reading about 2 GB (Int32.MaxValue) of data, totalRead variable can be equal to contentLength (which is int32.MaxValue). Then WebConnectionStream thinks that all data is received (see soft condition totalRead >= contentLength), but this is not correct. Previously this problem was discussed here: https://github.com/mono/mono/pull/1987. Currently, the solution is to change the type of `totalRead` and `contentLength` variables from int to long.