### PR TITLE
Fix an unlock without a corresponding lock.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -7510,6 +7510,8 @@ mono_image_init_name_cache (MonoImage *image)
 	}
 
 	g_hash_table_destroy (name_cache2);
+
+	mono_image_lock (image);
 	if (image->name_cache) {
 		/* Somebody initialized it before us */
 		g_hash_table_destroy (the_name_cache);


### PR DESCRIPTION
8eeb2cef introduced this by moving the lock into an if statement.

The intent of 8eeb2cef seemed to be to hold the image lock as little as possible, so I only added it around where we update image->name_cache. We had been holding the lock while building the table, but afaict that wasn't really necessary (it'd be nice if someone more familiar with this code could double-check that).