### PR TITLE
Make CustomAttributeData.AttributeType virtual

### DIFF
--- a/mcs/class/corlib/System.Reflection/CustomAttributeData.cs
+++ b/mcs/class/corlib/System.Reflection/CustomAttributeData.cs
@@ -131,7 +131,7 @@ namespace System.Reflection {
 			return MonoCustomAttrs.GetCustomAttributesData (target);
 		}
 
-		public Type AttributeType {
+		public virtual Type AttributeType {
 			get { return ctorInfo.DeclaringType; }
 		}
 


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/system.reflection.customattributedata.attributetype%28v=vs.110%29.aspx, System.Reflection.CustomAttributeData.AttributeType is a virtual property.