### PR TITLE
[System] UriKind.RelativeOrAbsolute workaround.

### DIFF
--- a/mcs/class/System/System/Uri.cs
+++ b/mcs/class/System/System/Uri.cs
@@ -170,9 +170,16 @@ namespace System {
 			}
 		}
 
+		// When used instead of UriKind.RelativeOrAbsolute paths such as "/foo" are assumed relative.
+		const UriKind DotNetRelativeOrAbsolute = (UriKind) 300;
+
 		public Uri (string uriString, UriKind uriKind)
 		{
 			source = uriString;
+
+			if (uriString != null && uriKind == DotNetRelativeOrAbsolute)
+				uriKind = (uriString.StartsWith ("/", StringComparison.Ordinal))? UriKind.Relative : UriKind.RelativeOrAbsolute;
+
 			ParseUri (uriKind);
 
 			switch (uriKind) {
@@ -204,6 +211,9 @@ namespace System {
 				success = false;
 				return;
 			}
+
+			if (uriKind == DotNetRelativeOrAbsolute)
+				uriKind = (uriString.StartsWith ("/", StringComparison.Ordinal))? UriKind.Relative : UriKind.RelativeOrAbsolute;
 
 			if (uriKind != UriKind.RelativeOrAbsolute &&
 				uriKind != UriKind.Absolute &&

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -1940,6 +1940,20 @@ namespace MonoTests.System
 			Assert.AreEqual ("id=1%262&sort=asc", escaped, "UriEscaped");
 		}
 
+		// When used, paths such as "/foo" are assumed relative.
+		static UriKind DotNetRelativeOrAbsolute = (Type.GetType ("Mono.Runtime") == null)? UriKind.RelativeOrAbsolute : (UriKind) 300;
+
+		[Test]
+		public void DotNetRelativeOrAbsoluteTest ()
+		{
+			var uri1 = new Uri ("/foo", DotNetRelativeOrAbsolute);
+			Assert.IsFalse (uri1.IsAbsoluteUri);
+			
+			Uri uri2;
+			Uri.TryCreate("/foo", DotNetRelativeOrAbsolute, out uri2);
+			Assert.IsFalse (uri2.IsAbsoluteUri);
+		}
+
 		[Test]
 		// Bug #12631
 		public void LocalPathWithBaseUrl ()


### PR DESCRIPTION
In .NET an URI constructor from "/foo" and UriKind.RelativeOrAbsolute is
relative whereas in mono it is assumed as an absolute file path.

This provides supports for an easy workaround to make mono behave as
.NET.

The workaround consists in defining DotNetRelativeOrAbsolute and using
it instead of UriKind.RelativeOrAbsolute.

DotNetRelativeOrAbsolute should be defined as follows:

static UriKind DotNetRelativeOrAbsolute = (Type.GetType ("Mono.Runtime")
== null)? UriKind.RelativeOrAbsolute : (UriKind) 300;