### PR TITLE
Implement SqlDataReader.GetFieldValue<T> in order to fix EF's UpdateException

### DIFF
--- a/mcs/class/System.Data/System.Data.SqlClient/SqlDataReader.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlDataReader.cs
@@ -1406,10 +1406,9 @@ namespace System.Data.SqlClient
 			return (sb);
 		}
 
-		[MonoTODO]
 		public override T GetFieldValue<T> (int i)
 		{
-			throw new NotImplementedException ();
+			return (T)GetValue(i);
 		}
 
 		[MonoTODO]


### PR DESCRIPTION
Fixes the issue I get from EF6 while updating my entities. 

Platform: OS X

I could give more stack trace in case of need. Because of I am using async methods of EF, stack trace really does not have any useful information. But I could create a new project to reproduce helpful stack trace of this issue.

```
An unhandled exception occurred while processing the request.

NotImplementedException: The method or operation is not implemented.
System.Data.SqlClient.SqlDataReader.GetFieldValue[T] (Int32 i) <0x114d1cbb0 + 0x0002e> in <filename unknown>, line 0

UpdateException: An error occurred while updating the entries. See the inner exception for details.
System.Data.Entity.Core.Mapping.Update.Internal.UpdateTranslator+<UpdateAsync>d__0.MoveNext () <0x1145f07e0 + 0x00725> in <filename unknown>, line 0

DbUpdateException: An error occurred while updating the entries. See the inner exception for details.
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () <0x10887d610 + 0x00029> in <filename unknown>, line 0
```

<img width="895" alt="screen shot 2015-08-30 at 15 50 14 1" src="https://cloud.githubusercontent.com/assets/3593288/9567386/b6dfd4f0-4f31-11e5-9096-09a2d37886d7.png">
