### PR TITLE
Crazy idea: Unsafe C# extensions

### DIFF
--- a/man/mcs.1
+++ b/man/mcs.1
@@ -185,6 +185,14 @@ specification.
 .TP
 .I "experimental"
 Enables unstable features from upcoming versions of the language.
+.TP
+.I "unsafe"
+Enables Mono-specific unsafe extensions to the C# language. In particular,
+allows pointer types in generic arguments and allows all unsafe operations
+on managed objects. This implies -langversion:experimental and -unsafe+.
+\fBNote that this feature will produce CIL code that is not guaranteed to
+be portable to other virtual machines than Mono!\fB
+.PP
 .PP
 Notice that this flag only restricts the language features available to
 the programmer. A version of produced assemblies can be controlled using
@@ -346,7 +354,7 @@ Another debugging flag.  Used to display the times at various points
 in the compilation process.
 .TP
 .I \-unsafe, -unsafe+
-Enables compilation of unsafe code.
+Enables compilation of unsafe code.  Always on if using -langversion:unsafe.
 .TP
 .I \-v 
 Debugging. Turns on verbose yacc parsing.

--- a/mcs/mcs/generic.cs
+++ b/mcs/mcs/generic.cs
@@ -2247,7 +2247,8 @@ namespace Mono.CSharp {
 					ok = false;
 				}
 
-				if (te.IsPointer || te.IsSpecialRuntimeType) {
+				if ((ec.Module.Compiler.Settings.Version < LanguageVersion.Unsafe && te.IsPointer) ||
+				    te.IsSpecialRuntimeType) {
 					ec.Module.Compiler.Report.Error (306, args[i].Location,
 						"The type `{0}' may not be used as a type argument",
 						te.GetSignatureForError ());

--- a/mcs/mcs/settings.cs
+++ b/mcs/mcs/settings.cs
@@ -30,6 +30,7 @@ namespace Mono.CSharp {
 		V_5 = 5,
 		V_6 = 6,
 		Experimental = 100,
+		Unsafe = 101,
 
 		Default = LanguageVersion.V_6,
 	}
@@ -232,6 +233,12 @@ namespace Mono.CSharp {
 		}
 
 		#endregion
+
+		public void SetUnsafe (bool value)
+		{
+			// If we're using unsafe extensions, unsafe code is always allowed.
+			Unsafe = Version >= LanguageVersion.Unsafe ? true : value;
+		}
 
 		public void AddConditionalSymbol (string symbol)
 		{
@@ -969,11 +976,11 @@ namespace Mono.CSharp {
 
 			case "/unsafe":
 			case "/unsafe+":
-				settings.Unsafe = true;
+				settings.SetUnsafe (true);
 				return ParseResult.Success;
 
 			case "/unsafe-":
-				settings.Unsafe = false;
+				settings.SetUnsafe (false);
 				return ParseResult.Success;
 
 			case "/warnaserror":
@@ -1164,6 +1171,10 @@ namespace Mono.CSharp {
 				case "experimental":
 					settings.Version = LanguageVersion.Experimental;
 					return ParseResult.Success;
+				case "unsafe":
+					settings.SetUnsafe (true);
+					settings.Version = LanguageVersion.Unsafe;
+					return ParseResult.Success;
 				case "future":
 					report.Warning (8000, 1, "Language version `future' is no longer supported");
 					goto case "6";
@@ -1240,7 +1251,7 @@ namespace Mono.CSharp {
 				
 			case "--unsafe":
 				report.Warning (-29, 1, "Compatibility: Use -unsafe instead of --unsafe");
-				settings.Unsafe = true;
+				settings.SetUnsafe (true);
 				return ParseResult.Success;
 				
 			case "/?": case "/h": case "/help":
@@ -1561,7 +1572,7 @@ namespace Mono.CSharp {
 				"   -help                Lists all compiler options (short: -?)\n" +
 				"   -keycontainer:NAME   The key pair container used to sign the output assembly\n" +
 				"   -keyfile:FILE        The key file used to strongname the ouput assembly\n" +
-				"   -langversion:TEXT    Specifies language version: ISO-1, ISO-2, 3, 4, 5, Default or Experimental\n" +
+				"   -langversion:TEXT    Specifies language version: ISO-1, ISO-2, 3, 4, 5, Default, Experimental or Unsafe\n" +
 				"   -lib:PATH1[,PATHn]   Specifies the location of referenced assemblies\n" +
 				"   -main:CLASS          Specifies the class with the Main method (short: -m)\n" +
 				"   -noconfig            Disables implicitly referenced assemblies\n" +
@@ -1580,7 +1591,7 @@ namespace Mono.CSharp {
 				"                        VERSION can be one of: 2, 4, 4.5 (default) or a custom value\n" +
 				"   -target:KIND         Specifies the format of the output assembly (short: -t)\n" +
 				"                        KIND can be one of: exe, winexe, library, module\n" +
-				"   -unsafe[+|-]         Allows to compile code which uses unsafe keyword\n" +
+				"   -unsafe[+|-]         Allows to compile code which uses unsafe keyword (always on if using -langversion:Unsafe)\n" +
 				"   -warnaserror[+|-]    Treats all warnings as errors\n" +
 				"   -warnaserror[+|-]:W1[,Wn] Treats one or more compiler warnings as errors\n" +
 				"   -warn:0-4            Sets warning level, the default is 4 (short -w:)\n" +

--- a/mcs/mcs/typemanager.cs
+++ b/mcs/mcs/typemanager.cs
@@ -1109,6 +1109,10 @@ namespace Mono.CSharp
 	/// </summary>
 	public static bool VerifyUnmanaged (ModuleContainer rc, TypeSpec t, Location loc)
 	{
+		// If we're using unsafe extensions, anything goes.
+		if (rc.Compiler.Settings.Version >= LanguageVersion.Unsafe)
+			return true;
+
 		if (t.IsUnmanaged)
 			return true;
 


### PR DESCRIPTION
This is a quite possibly insane idea that came to mind over the weekend and was fairly easy to hack into `mcs`. This patch adds a new `unsafe` language version (i.e. `-langversion:unsafe`) to `mcs` which implies `experimental` and enables the following extensions:

* Pointers can be used in generic type arguments. (`int i = 42; List<int*> list; list.Add (&i);`)
* Pointers to managed objects are allowed. (`string s = "..."; string* p = &s;`)
* Managed types can be used in `stackalloc` declarations. (`string* strings = stackalloc string [16];`)
* The size of managed references can be computed. (`var sz = sizeof (string); /* 4 or 8 */`)

All of these still require `unsafe` context. Also, there is no guarantee that the generated code will work with any other VM.

# Pointers in generic type arguments

This one is interesting because it adds type safety that C# doesn't currently have when dealing with pointers in collections. Today, you have to maintain a `List<IntPtr>` which is not really any better than `List<object>` in terms of type safety.

Today, you do:

```csharp
List<IntPtr> ptrs = new List<IntPtr> ();
int i = 42;
ptrs.Add ((IntPtr) &i);
```

If the type of `i` ever changes, you likely won't notice that you're now putting mistyped pointers into `ptrs`.

With the extension:

```csharp
List<int*> ptrs = new List<int*> ();
int i = 42;
ptrs.Add (&i); // OK
short j = 21;
ptrs.Add (&j); // Not OK
```

# Pointers to managed objects

This is a simple but surprisingly useful feature. It's as unsafe as any other kind of pointer, but when used with care can allow some patterns that are currently impossible in C# due to the restrictive nature of `ref` and `out`.

LLVM's instruction matching framework is one example of where this feature can be really useful. They have this code in `lib/Transforms/InstCombine/InstCombineAddSub.cpp`:

```cpp
    Value *A = 0, *B = 0;
    if (match(RHS, m_Xor(m_Value(A), m_Value(B))) &&
        (match(LHS, m_And(m_Specific(A), m_Specific(B))) ||
         match(LHS, m_And(m_Specific(B), m_Specific(A)))))
      return BinaryOperator::CreateOr(A, B);
```

What happens here is that `A` and `B` are stored into temporary structures by reference via the `m_...` calls which set up match specifications. They are then set once the `match` call goes through the matching tree and calls `match` on each node. If the whole match passes, `A` and `B` have been set to the desired values from the instruction tree.

This can't really be done reasonably in C# with `ref`/`out` as these references can't be stored into fields. It can't be done with pointers currently, either, as pointers can only point to things that don't contain managed references, which is highly restrictive and impractical.

This change enables the above.

# Managed types in `stackalloc` declarations

This quite simply allows the following:

```csharp
struct ManagedData
{
    string SomeString;
}

object* objectArr = stackalloc object [16];
ManagedData* dataArr = stackalloc ManagedData [16];
```

That is, managed references can be stored in `stackalloc`'d memory, as can structures containing managed references. I suspect the latter case will be the most useful one in practice.

Note that this relies entirely on Mono doing stack scanning conservatively for managed stack frames. If that ever changes, this won't work, and for that reason I'm not really convinced this is as worthwhile an idea as the other features. On the other hand, even a stack-precise Mono could scan `stackalloc`'d memory conservatively to enable this feature. Who knows.

# Size of managed references

This is a small feature that makes the above features really come together. `Marshal.SizeOf` has all sorts of special cases and only sometimes does what the user wants. `sizeof` will now simply do what you'd expect for any type: Return the size of storing that type in memory. For structures, this means the size of all its fields as the runtime sees it, while for references, this means the size of a managed reference. No special cases where certain types are not allowed.

This means that unsafe code that computes sizes of types will be clearer and more maintainable.

# TL;DR

This off-by-default extension enables more practical and 'safe' unsafe programming in C# but generates code that won't necessarily work in other VMs. Useful enough to merge? I don't know. But I could see myself using these features in some tools that aren't intended to run anywhere but on Mono.