### PR TITLE
[runtime] Add root type and human-readable description for all GC roots.

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -475,7 +475,7 @@ mono_gc_enable_alloc_events (void)
 }
 
 int
-mono_gc_register_root (char *start, size_t size, void *descr)
+mono_gc_register_root (char *start, size_t size, void *descr, MonoGCRootSource source, const char *msg)
 {
 	/* for some strange reason, they want one extra byte on the end */
 	GC_add_roots (start, start + size + 1);
@@ -566,7 +566,7 @@ mono_gc_make_root_descr_all_refs (int numbits)
 }
 
 void*
-mono_gc_alloc_fixed (size_t size, void *descr)
+mono_gc_alloc_fixed (size_t size, void *descr, MonoGCRootSource source, const char *msg)
 {
 	/* To help track down typed allocation bugs */
 	/*

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3222,7 +3222,7 @@ ves_icall_Type_GetFields_internal (MonoReflectionType *type, MonoString *name, g
 	klass = startklass = mono_class_from_mono_type (type->type);
 	refklass = mono_class_from_mono_type (reftype->type);
 
-	mono_ptr_array_init (tmp_array, 2);
+	mono_ptr_array_init (tmp_array, 2, MONO_ROOT_SOURCE_REFLECTION, "temporary reflection fields list");
 	
 handle_parent:	
 	if (klass->exception_type != MONO_EXCEPTION_NONE) {
@@ -3478,7 +3478,7 @@ ves_icall_Type_GetConstructors_internal (MonoReflectionType *type, guint32 bflag
 	gpointer iter = NULL;
 	MonoPtrArray tmp_array;
 	
-	mono_ptr_array_init (tmp_array, 4); /*FIXME, guestimating*/
+	mono_ptr_array_init (tmp_array, 4, MONO_ROOT_SOURCE_REFLECTION, "temporary reflection constructors list"); /*FIXME, guestimating*/
 
 	domain = ((MonoObject *)type)->vtable->domain;
 	if (type->type->byref)
@@ -3586,7 +3586,7 @@ ves_icall_Type_GetPropertiesByName (MonoReflectionType *type, MonoString *name, 
 	GHashTable *properties = NULL;
 	MonoPtrArray tmp_array;
 
-	mono_ptr_array_init (tmp_array, 8); /*This the average for ASP.NET types*/
+	mono_ptr_array_init (tmp_array, 8, MONO_ROOT_SOURCE_REFLECTION, "temporary reflection properties list"); /*This the average for ASP.NET types*/
 
 	if (!System_Reflection_PropertyInfo)
 		System_Reflection_PropertyInfo = mono_class_from_name (
@@ -3720,7 +3720,7 @@ ves_icall_Type_GetEvents_internal (MonoReflectionType *type, MonoString *name, g
 	GHashTable *events = NULL;
 	MonoPtrArray tmp_array;
 
-	mono_ptr_array_init (tmp_array, 4);
+	mono_ptr_array_init (tmp_array, 4, MONO_ROOT_SOURCE_REFLECTION, "temporary reflection events list");
 
 	if (!System_Reflection_EventInfo)
 		System_Reflection_EventInfo = mono_class_from_name (
@@ -3853,7 +3853,7 @@ ves_icall_Type_GetNestedTypes (MonoReflectionType *type, MonoString *name, guint
 	if (klass->generic_class)
 		klass = klass->generic_class->container_class;
 
-	mono_ptr_array_init (tmp_array, 1);
+	mono_ptr_array_init (tmp_array, 1, MONO_ROOT_SOURCE_REFLECTION, "temporary reflection nested types list");
 	iter = NULL;
 	while ((nested = mono_class_get_nested_types (klass, &iter))) {
 		match = 0;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3524,7 +3524,7 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 
 	/* to make it work with our special string constructors */
 	if (!string_dummy) {
-		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy);
+		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, "dummy marshal string");
 		string_dummy = mono_string_new_wrapper ("dummy");
 	}
 

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -11,6 +11,37 @@ MONO_BEGIN_DECLS
 
 typedef int (*MonoGCReferences) (MonoObject *obj, MonoClass *klass, uintptr_t size, uintptr_t num, MonoObject **refs, uintptr_t *offsets, void *data);
 
+typedef enum {
+	// Roots external to Mono.  Embedders may only use this value.
+	MONO_ROOT_SOURCE_EXTERNAL = 0,
+	// Thread stack.  Must not be used to register roots.
+	MONO_ROOT_SOURCE_STACK = 1,
+	// Roots in the finalizer queue.  Must not be used to register roots.
+	MONO_ROOT_SOURCE_FINALIZER_QUEUE = 2,
+	// Managed static variables.
+	MONO_ROOT_SOURCE_STATIC = 3,
+	// Static variables with ThreadStaticAttribute.
+	MONO_ROOT_SOURCE_THREAD_STATIC = 4,
+	// Static variables with ContextStaticAttribute.
+	MONO_ROOT_SOURCE_CONTEXT_STATIC = 5,
+	// GCHandle structures.
+	MONO_ROOT_SOURCE_GC_HANDLE = 6,
+	// Roots in the just-in-time compiler.
+	MONO_ROOT_SOURCE_JIT = 7,
+	// Roots in the threading subsystem.
+	MONO_ROOT_SOURCE_THREADING = 8,
+	// Roots in application domains.
+	MONO_ROOT_SOURCE_DOMAIN = 9,
+	// Roots in reflection code.
+	MONO_ROOT_SOURCE_REFLECTION = 10,
+	// Roots from P/Invoke or other marshaling.
+	MONO_ROOT_SOURCE_MARSHAL = 11,
+	// Roots in the thread pool data structures.
+	MONO_ROOT_SOURCE_THREAD_POOL = 12,
+	// Roots in the debugger agent.
+	MONO_ROOT_SOURCE_DEBUGGER = 13,
+} MonoGCRootSource;
+
 MONO_API void   mono_gc_collect         (int generation);
 MONO_API int    mono_gc_max_generation  (void);
 MONO_API int    mono_gc_get_generation  (MonoObject *object);

--- a/mono/metadata/mono-hash.h
+++ b/mono/metadata/mono-hash.h
@@ -6,10 +6,11 @@
  *
  * Copyright 2013 Xamarin Inc (http://www.xamarin.com)
  */
-#include <glib.h>
-#include <mono/utils/mono-publib.h>
+
 #ifndef __MONO_G_HASH_H__
 #define __MONO_G_HASH_H__
+
+#include <mono/metadata/mono-gc.h>
 
 MONO_BEGIN_DECLS
 /* do not change the values of this enum */
@@ -22,7 +23,7 @@ typedef enum {
 
 typedef struct _MonoGHashTable MonoGHashTable;
 
-MONO_API MonoGHashTable *mono_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type);
+MONO_API MonoGHashTable *mono_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, const char *msg);
 MONO_API guint    mono_g_hash_table_size            (MonoGHashTable *hash);
 MONO_API gpointer mono_g_hash_table_lookup          (MonoGHashTable *hash, gconstpointer key);
 MONO_API gboolean mono_g_hash_table_lookup_extended (MonoGHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value);

--- a/mono/metadata/mono-ptr-array.h
+++ b/mono/metadata/mono-ptr-array.h
@@ -23,14 +23,18 @@ typedef struct {
 	void **data;
 	int size;
 	int capacity;
+	MonoGCRootSource source;
+	const char *msg;
 } MonoPtrArray;
 
 #define MONO_PTR_ARRAY_MAX_ON_STACK (16)
 
-#define mono_ptr_array_init(ARRAY, INITIAL_SIZE) do {\
+#define mono_ptr_array_init(ARRAY, INITIAL_SIZE, SOURCE, MSG) do {\
 	(ARRAY).size = 0; \
 	(ARRAY).capacity = MAX (INITIAL_SIZE, MONO_PTR_ARRAY_MAX_ON_STACK); \
-	(ARRAY).data = INITIAL_SIZE > MONO_PTR_ARRAY_MAX_ON_STACK ? mono_gc_alloc_fixed (sizeof (void*) * INITIAL_SIZE, mono_gc_make_root_descr_all_refs (INITIAL_SIZE)) : g_newa (void*, MONO_PTR_ARRAY_MAX_ON_STACK); \
+	(ARRAY).source = SOURCE; \
+	(ARRAY).msg = MSG; \
+	(ARRAY).data = INITIAL_SIZE > MONO_PTR_ARRAY_MAX_ON_STACK ? mono_gc_alloc_fixed (sizeof (void*) * INITIAL_SIZE, mono_gc_make_root_descr_all_refs (INITIAL_SIZE), SOURCE, MSG) : g_newa (void*, MONO_PTR_ARRAY_MAX_ON_STACK); \
 } while (0)
 
 #define mono_ptr_array_destroy(ARRAY) do {\
@@ -40,7 +44,7 @@ typedef struct {
 
 #define mono_ptr_array_append(ARRAY, VALUE) do { \
 	if ((ARRAY).size >= (ARRAY).capacity) {\
-	void *__tmp = mono_gc_alloc_fixed (sizeof (void*) * (ARRAY).capacity * 2, mono_gc_make_root_descr_all_refs ((ARRAY).capacity * 2)); \
+	void *__tmp = mono_gc_alloc_fixed (sizeof (void*) * (ARRAY).capacity * 2, mono_gc_make_root_descr_all_refs ((ARRAY).capacity * 2), (ARRAY).source, (ARRAY).msg); \
 		mono_gc_memmove_aligned (__tmp, (ARRAY).data, (ARRAY).capacity * sizeof (void*)); \
 		if ((ARRAY).capacity > MONO_PTR_ARRAY_MAX_ON_STACK)	\
 			mono_gc_free_fixed ((ARRAY).data);	\

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -117,7 +117,7 @@ mono_gc_enable_alloc_events (void)
 }
 
 int
-mono_gc_register_root (char *start, size_t size, void *descr)
+mono_gc_register_root (char *start, size_t size, void *descr, MonoGCRootSource source, const char *msg)
 {
 	return TRUE;
 }
@@ -176,7 +176,7 @@ mono_gc_make_root_descr_all_refs (int numbits)
 }
 
 void*
-mono_gc_alloc_fixed (size_t size, void *descr)
+mono_gc_alloc_fixed (size_t size, void *descr, MonoGCRootSource source, const char *msg)
 {
 	return g_malloc0 (size);
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -964,13 +964,13 @@ mono_gc_alloc_mature (MonoVTable *vtable)
 }
 
 void*
-mono_gc_alloc_fixed (size_t size, MonoGCDescriptor descr)
+mono_gc_alloc_fixed (size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg)
 {
 	/* FIXME: do a single allocation */
 	void *res = calloc (1, size);
 	if (!res)
 		return NULL;
-	if (!mono_gc_register_root (res, size, descr)) {
+	if (!mono_gc_register_root (res, size, descr, source, msg)) {
 		free (res);
 		res = NULL;
 	}
@@ -2406,15 +2406,15 @@ mono_gc_set_stack_end (void *stack_end)
  */
 
 int
-mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr)
+mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg)
 {
-	return sgen_register_root (start, size, descr, descr ? ROOT_TYPE_NORMAL : ROOT_TYPE_PINNED);
+	return sgen_register_root (start, size, descr, descr ? ROOT_TYPE_NORMAL : ROOT_TYPE_PINNED, source, msg);
 }
 
 int
-mono_gc_register_root_wbarrier (char *start, size_t size, MonoGCDescriptor descr)
+mono_gc_register_root_wbarrier (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg)
 {
-	return sgen_register_root (start, size, descr, ROOT_TYPE_WBARRIER);
+	return sgen_register_root (start, size, descr, ROOT_TYPE_WBARRIER, source, msg);
 }
 
 void

--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -333,7 +333,7 @@ selector_thread (gpointer data)
 		return;
 	}
 
-	states = mono_g_hash_table_new_type (g_direct_hash, g_direct_equal, MONO_HASH_VALUE_GC);
+	states = mono_g_hash_table_new_type (g_direct_hash, g_direct_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_THREAD_POOL, "i/o thread pool states table");
 
 	for (;;) {
 		gint i, j;
@@ -531,7 +531,7 @@ initialize (void)
 
 	mono_mutex_init_recursive (&threadpool_io->updates_lock);
 	mono_cond_init (&threadpool_io->updates_cond, NULL);
-	mono_gc_register_root ((void*)&threadpool_io->updates [0], sizeof (threadpool_io->updates), MONO_GC_DESCRIPTOR_NULL);
+	mono_gc_register_root ((void*)&threadpool_io->updates [0], sizeof (threadpool_io->updates), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_THREAD_POOL, "i/o thread pool updates list");
 
 	threadpool_io->updates_size = 0;
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -988,14 +988,14 @@ mono_debugger_agent_init (void)
 	/* Needed by the hash_table_new_type () call below */
 	mono_gc_base_init ();
 
-	thread_to_tls = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_KEY_GC);
-	MONO_GC_REGISTER_ROOT_FIXED (thread_to_tls);
+	thread_to_tls = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, "thread-to-tls table");
+	MONO_GC_REGISTER_ROOT_FIXED (thread_to_tls, MONO_ROOT_SOURCE_DEBUGGER, "thread-to-tls table");
 
-	tid_to_thread = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC);
-	MONO_GC_REGISTER_ROOT_FIXED (tid_to_thread);
+	tid_to_thread = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread table");
+	MONO_GC_REGISTER_ROOT_FIXED (tid_to_thread, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread table");
 
-	tid_to_thread_obj = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC);
-	MONO_GC_REGISTER_ROOT_FIXED (tid_to_thread_obj);
+	tid_to_thread_obj = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread object table");
+	MONO_GC_REGISTER_ROOT_FIXED (tid_to_thread_obj, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread object table");
 
 	pending_assembly_loads = g_ptr_array_new ();
 	domains = g_hash_table_new (mono_aligned_addr_hash, NULL);
@@ -1928,8 +1928,8 @@ objrefs_init (void)
 {
 	objrefs = g_hash_table_new_full (NULL, NULL, NULL, free_objref);
 	obj_to_objref = g_hash_table_new (NULL, NULL);
-	suspended_objs = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_KEY_GC);
-	MONO_GC_REGISTER_ROOT_FIXED (suspended_objs);
+	suspended_objs = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, "suspended objects table");
+	MONO_GC_REGISTER_ROOT_FIXED (suspended_objs, MONO_ROOT_SOURCE_DEBUGGER, "suspended objects table");
 }
 
 static void
@@ -3835,7 +3835,7 @@ thread_startup (MonoProfiler *prof, uintptr_t tid)
 	g_assert (!tls);
 	// FIXME: Free this somewhere
 	tls = g_new0 (DebuggerTlsData, 1);
-	MONO_GC_REGISTER_ROOT_SINGLE (tls->thread);
+	MONO_GC_REGISTER_ROOT_SINGLE (tls->thread, MONO_ROOT_SOURCE_DEBUGGER, "debugger thread reference");
 	tls->thread = thread;
 	mono_native_tls_set_value (debugger_tls_id, tls);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7365,7 +7365,7 @@ static void
 set_exception_object (MonoCompile *cfg, MonoException *exception)
 {
 	mono_cfg_set_exception (cfg, MONO_EXCEPTION_OBJECT_SUPPLIED);
-	MONO_GC_REGISTER_ROOT_SINGLE (cfg->exception_ptr);
+	MONO_GC_REGISTER_ROOT_SINGLE (cfg->exception_ptr, MONO_ROOT_SOURCE_JIT, "jit exception");
 	cfg->exception_ptr = exception;
 }
 

--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -19,8 +19,8 @@ internal_init (void)
 {
 	if (keepalive_stacks)
 		return;
-	MONO_GC_REGISTER_ROOT_PINNING (keepalive_stacks);
-	keepalive_stacks = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_CONSERVATIVE_GC);
+	MONO_GC_REGISTER_ROOT_PINNING (keepalive_stacks, MONO_ROOT_SOURCE_THREADING, "tasklet stacks table");
+	keepalive_stacks = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_CONSERVATIVE_GC, MONO_ROOT_SOURCE_THREADING, "tasklet stacks table");
 }
 
 static void*
@@ -117,7 +117,7 @@ continuation_store (MonoContinuation *cont, int state, MonoException **e)
 		}
 		cont->stack_used_size = num_bytes;
 		cont->stack_alloc_size = num_bytes * 1.1;
-		cont->saved_stack = mono_gc_alloc_fixed (cont->stack_alloc_size, NULL);
+		cont->saved_stack = mono_gc_alloc_fixed (cont->stack_alloc_size, NULL, MONO_ROOT_SOURCE_THREADING, "saved tasklet stack");
 		mono_g_hash_table_insert (keepalive_stacks, cont->saved_stack, cont->saved_stack);
 		tasklets_unlock ();
 	}

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -2520,7 +2520,7 @@ sgen_have_pending_finalizers (void)
  * We do not coalesce roots.
  */
 int
-sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type)
+sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type, int source, const char *msg)
 {
 	RootRecord new_root;
 	int i;
@@ -2532,6 +2532,8 @@ sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_typ
 			size_t old_size = root->end_root - start;
 			root->end_root = start + size;
 			SGEN_ASSERT (0, !!root->root_desc == !!descr, "Can't change whether a root is precise or conservative.");
+			SGEN_ASSERT (0, root->source == source, "Can't change a root's source identifier.");
+			SGEN_ASSERT (0, !!root->msg == !!msg, "Can't change a root's message.");
 			root->root_desc = descr;
 			roots_size += size;
 			roots_size -= old_size;
@@ -2542,6 +2544,8 @@ sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_typ
 
 	new_root.end_root = start + size;
 	new_root.root_desc = descr;
+	new_root.source = source;
+	new_root.msg = msg;
 
 	sgen_hash_table_replace (&roots_hash [root_type], start, &new_root, NULL);
 	roots_size += size;

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -373,6 +373,8 @@ typedef struct _RootRecord RootRecord;
 struct _RootRecord {
 	char *end_root;
 	SgenDescriptor root_desc;
+	int source;
+	const char *msg;
 };
 
 enum {
@@ -384,7 +386,7 @@ enum {
 
 extern SgenHashTable roots_hash [ROOT_TYPE_NUM];
 
-int sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type);
+int sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type, int source, const char *msg);
 void sgen_deregister_root (char* addr);
 
 typedef void (*IterateObjectCallbackFunc) (GCObject*, size_t, void*);


### PR DESCRIPTION
This is the first part of the improved GC root profiling. This contains the changes to the GC API so that more detailed descriptions of roots can be given to the GC. This information will be passed onto the profiler (in upcoming PRs).

(Doing these changes incrementally to reduce the amount of rebasing that I waste time on.)