### PR TITLE
Update SynchronizedCollection.cs

### DIFF
--- a/mcs/class/System.ServiceModel/System.Collections.Generic/SynchronizedCollection.cs
+++ b/mcs/class/System.ServiceModel/System.Collections.Generic/SynchronizedCollection.cs
@@ -147,14 +147,15 @@ namespace System.Collections.Generic
 			InsertItem (index, item);
 		}
 
-		[MonoTODO ("should we lock and remove item without invoking RemoveItem() instead?")]
 		public bool Remove (T item)
 		{
-			int index = IndexOf (item);
-			if (index < 0)
-				return false;
-			RemoveAt (index);
-			return true;
+			lock (root) {
+				int index = list.IndexOf (item);
+				if (index < 0)
+					return false;
+				list.RemoveAt (index);
+				return true;
+			}
 		}
 
 		public void RemoveAt (int index)


### PR DESCRIPTION
Change is to fix following exception. Which suspect is cause by two threads, both call remove at same time.

System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
  at System.ThrowHelper.ThrowArgumentOutOfRangeException () [0x00000] in <filename unknown>:0
  at System.Collections.Generic.List`1[System.ServiceModel.Channels.IDuplexSessionChannel].RemoveAt (Int32 index) [0x00000] in <filename unknown>:0
  at System.Collections.Generic.SynchronizedCollection`1[System.ServiceModel.Channels.IDuplexSessionChannel].RemoveItem (Int32 index) [0x00000] in <filename unknown>:0
  at System.Collections.Generic.SynchronizedCollection`1[System.ServiceModel.Channels.IDuplexSessionChannel].RemoveAt (Int32 index) [0x00000] in <filename unknown>:0
  at System.Collections.Generic.SynchronizedCollection`1[System.ServiceModel.Channels.IDuplexSessionChannel].Remove (IDuplexSessionChannel item) [0x00000] in <filename unknown>:0