### PR TITLE
Fixes TimeZoneInfo.GetDaylightChanges #32722.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -930,12 +930,12 @@ namespace System
 				}
 
 				// DaylightTime.Start is relative to the Standard time.
-				if (start != DateTime.MinValue)
-					start += BaseUtcOffset;
+				if (!TryAddTicks (start, BaseUtcOffset.Ticks, out start))
+					start = DateTime.MinValue;
 
 				// DaylightTime.End is relative to the DST time.
-				if (end != DateTime.MinValue)
-					end += BaseUtcOffset + delta;
+				if (!TryAddTicks (end, BaseUtcOffset.Ticks + delta.Ticks, out end))
+					end = DateTime.MinValue;
 			} else {
 				AdjustmentRule first = null, last = null;
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -1088,6 +1088,19 @@ namespace MonoTests.System
 				Assert.AreEqual (new DateTime (2014, 10, 5, 2, 0, 0), changes.Start);
 				Assert.AreEqual (new DateTime (2014, 4, 6, 3, 0, 0), changes.End);
 			}
+
+			[Test]
+			public void AllTimeZonesDaylightChanges ()
+			{
+				foreach (var tz in TimeZoneInfo.GetSystemTimeZones ()) {
+					try {
+						for (var year = 1950; year <= DateTime.Now.Year; year++)
+							getChanges.Invoke (tz, new object [] {year} );
+					} catch (Exception e) {
+						Assert.Fail ("TimeZone " + tz.Id + " exception: " + e.ToString ()); 
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds Suite that tests all TimeZones.

The purpose of TimeZoneInfoSuite is run the set of tests in
TimeZoneInfoSuiteTests against all TimeZoneInfo.

Fixes TimeZoneInfo.GetDaylightChanges [#32722](https://bugzilla.xamarin.com/show_bug.cgi?id=32722).