### PR TITLE
[runtime] Fix casting error in InternalCodePage.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6168,7 +6168,7 @@ ves_icall_System_Text_EncodingHelper_InternalCodePage (gint32 *int_code_page)
 	p = encodings [0];
 	code = 0;
 	for (i = 0; p != 0; ){
-		if ((gssize) p < 7){
+		if ((gsize) p < 7){
 			code = (gssize) p;
 			p = encodings [++i];
 			continue;


### PR DESCRIPTION
Use gsize instead of gssize when checking the encodings array for
codepage numbers. When a char* is pointing to the upper half of the
address space, it will be otherwise converted to a negative number.

I encountered this (https://github.com/fsharp/emacs-fsharp-mode/pull/16) on some of my system, where the default encoding of the console Output/Error was not set correctly to UTF-8 (without BOM).

In the Debugger I found the cause of this issue:  

    (gdb) print p
    $10 = 0xb7ec201a "us_ascii"

    (gdb) print (gssize) p
    $11 = -1209262054

