### PR TITLE
[HttpWebRequestTest] New test to check that after reading 2 GB of data from web server HttpWebRequest still works

### DIFF
--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -6,6 +6,7 @@
 //   Martin Willemoes Hansen (mwh@sysrq.dk)
 //   Gonzalo Paniagua Javier (gonzalo@ximian.com)
 //   Andres G. Aragoneses (andres@7digital.com)
+//   Bogdanov Kirill (bogdanov@macroscop.com)
 //
 // (C) 2003 Martin Willemoes Hansen
 // Copyright (c) 2005 Novell, Inc. (http://www.novell.com
@@ -24,6 +25,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
+using System.Reflection;
 using Mono.Security.Authenticode;
 #if !MOBILE
 using Mono.Security.Protocol.Tls;
@@ -2300,6 +2302,70 @@ namespace MonoTests.System.Net
 			});
 
 			return;
+		}
+		
+		[Test]
+		public void TestLargeDataReading ()
+		{
+			int near2GBStartPosition = rand.Next (int.MaxValue - 500, int.MaxValue);
+			AutoResetEvent readyGetLastPortionEvent = new AutoResetEvent (false);
+			Exception testException = null;
+
+			DoRequest (
+			(request, waitHandle) =>
+			{
+				try
+				{
+					const int timeoutMs = 5000;
+
+					request.Timeout = timeoutMs;
+					request.ReadWriteTimeout = timeoutMs;
+
+					WebResponse webResponse = request.GetResponse ();
+					Stream webResponseStream = webResponse.GetResponseStream ();
+					Assert.IsNotNull (webResponseStream, null, "#1");
+					
+					Type webConnectionStreamType = webResponseStream.GetType ();
+					FieldInfo totalReadField = webConnectionStreamType.GetField ("totalRead", BindingFlags.NonPublic | BindingFlags.Instance);
+					Assert.IsNotNull (totalReadField, "#2");
+					totalReadField.SetValue (webResponseStream, near2GBStartPosition);
+					
+					byte[] readBuffer = new byte[int.MaxValue - near2GBStartPosition];
+					Assert.AreEqual (webResponseStream.Read (readBuffer, 0, readBuffer.Length), readBuffer.Length, "#3");
+					readyGetLastPortionEvent.Set ();
+					Assert.Greater (webResponseStream.Read (readBuffer, 0, readBuffer.Length), 0, "#4");
+					readyGetLastPortionEvent.Set ();
+					
+					webResponse.Close();
+				}
+				catch (Exception e)
+				{
+					testException = e;
+				}
+				finally
+				{
+					waitHandle.Set ();
+				}
+			},
+			processor =>
+			{
+				processor.Request.InputStream.Close ();
+				
+				HttpListenerResponse response = processor.Response;
+				response.SendChunked = true;
+				
+				Stream outputStream = response.OutputStream;
+				var writeBuffer = new byte[int.MaxValue - near2GBStartPosition];
+				outputStream.Write (writeBuffer, 0, writeBuffer.Length);
+				readyGetLastPortionEvent.WaitOne ();
+				outputStream.Write (writeBuffer, 0, writeBuffer.Length);
+				readyGetLastPortionEvent.WaitOne ();
+				
+				response.Close();
+			});
+
+			if (testException != null)
+				throw testException;
 		}
 
 		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request)


### PR DESCRIPTION
When HttpWebRequest is used to download infinite (ContentLength is not set) response from web server, we must be sure that after reading 2 GB (Int32.MaxValue) of data our internal classes are still working correctly. This test was discussed here: https://github.com/mono/mono/pull/2000