### PR TITLE
[Facades] fix exclusion from "make dist"

### DIFF
--- a/mcs/class/Facades/Makefile
+++ b/mcs/class/Facades/Makefile
@@ -66,7 +66,7 @@ include $(MCS_BUILD_DIR)/rules.make
 
 dist-local: dist-default
 
-#SUBDIRS = $(net_4_5_SUBDIRS)
+SUBDIRS = $(net_4_5_PARALLEL_SUBDIRS)
 
 doc-update-local:
 	@echo "not doing docs"


### PR DESCRIPTION
If SUBDIRS is not set, then no files which aren't explicit Makefile targets will get included - which in this case means the only file in Facades/ in tarballs is the Makefile itself.