### PR TITLE
[runtime] Don't allocate domain-level static slots for special static fields.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2066,6 +2066,9 @@ mono_class_layout_fields (MonoClass *class)
 			continue;
 		if (mono_field_is_deleted (field))
 			continue;
+		// Special static fields do not need a domain-level static slot
+		if (mono_class_field_is_special_static (field))
+			continue;
 
 		if (mono_type_has_exceptions (field->type)) {
 			mono_class_set_failure (class, MONO_EXCEPTION_TYPE_LOAD, NULL);

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1040,6 +1040,9 @@ mono_class_describe_statics (MonoClass* klass)
 				continue;
 			if (!(field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA)))
 				continue;
+			// Special static fields don't have a domain-level static slot
+			if (mono_class_field_is_special_static (field))
+				continue;
 
 			field_ptr = (const char*)addr + field->offset;
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2419,6 +2419,8 @@ mono_class_field_is_special_static (MonoClassField *field)
 	if (mono_field_is_deleted (field))
 		return FALSE;
 	if (!(field->type->attrs & FIELD_ATTRIBUTE_LITERAL)) {
+		if (field->offset == -1)
+			return TRUE;
 		if (field_is_special_static (field->parent, field) != SPECIAL_STATIC_NONE)
 			return TRUE;
 	}

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -725,8 +725,8 @@ compute_class_bitmap (MonoClass *class, gsize *bitmap, int size, int offset, int
 			if (field->type->byref)
 				break;
 
-			if (static_fields && field->offset == -1)
-				/* special static */
+			// Special static fields do not have a domain-level static slot
+			if (static_fields && mono_class_field_is_special_static (field))
 				continue;
 
 			pos = field->offset / sizeof (gpointer);


### PR DESCRIPTION
Let's see how much stuff this breaks.