### PR TITLE
Fix MonoTests.System.Windows.Forms.TrackBarBaseTest on Windows.

### DIFF
--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/TrackBarTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/TrackBarTest.cs
@@ -145,7 +145,7 @@ namespace MonoTests.System.Windows.Forms
 				myTrackBar.Height = 250;
 				myTrackBar.Orientation = Orientation.Vertical;
 				Assert.AreEqual(200, myTrackBar.Width, "#SIZE03");
-				AreEqual(default_height, default_height2, myTrackBar.Height, "#SIZE04");
+				Assert.AreEqual(250, myTrackBar.Height, "#SIZE04");
 			}
 
 			using (TrackBar myTrackBar = new TrackBar()) {
@@ -163,7 +163,7 @@ namespace MonoTests.System.Windows.Forms
 				myTrackBar.AutoSize = false;
 				myTrackBar.Orientation = Orientation.Vertical;
 				Assert.AreEqual(200, myTrackBar.Width, "#SIZE11");
-				AreEqual(default_height, default_height2, myTrackBar.Height, "#SIZE12");
+				Assert.AreEqual(250, myTrackBar.Height, "#SIZE12");
 			}
 
 			using (TrackBar myTrackBar = new TrackBar()) {
@@ -175,7 +175,7 @@ namespace MonoTests.System.Windows.Forms
 					handle = myTrackBar.Handle;
 					
 					AreEqual(default_height, default_height2, myTrackBar.Width, "#SIZE17");
-					AreEqual(default_height, default_height2, myTrackBar.Height, "#SIZE18");
+					Assert.AreEqual(250, myTrackBar.Height, "#SIZE18");
 				}
 			}
 
@@ -188,7 +188,7 @@ namespace MonoTests.System.Windows.Forms
 					handle = myTrackBar.Handle;
 					
 					AreEqual(default_height, default_height2, myTrackBar.Width, "#SIZE19");
-					AreEqual(default_height, default_height2, myTrackBar.Height, "#SIZE20");
+					Assert.AreEqual(250, myTrackBar.Height, "#SIZE20");
 				}
 			}
 
@@ -202,7 +202,7 @@ namespace MonoTests.System.Windows.Forms
 					
 					myTrackBar.Orientation = Orientation.Horizontal;
 					
-					AreEqual(default_height, default_height2, myTrackBar.Width, "#SIZE23");
+					Assert.AreEqual(250, myTrackBar.Width, "#SIZE23");
 					AreEqual(default_height, default_height2, myTrackBar.Height, "#SIZE24");
 				}
 			}


### PR DESCRIPTION
This is based on Windows 10 + .NET 4. I'm assuming until told otherwise that
the test was written based on an earlier .NET and the behavior has changed.