### PR TITLE
Fixes Uri.UserInfo with spaces.

### DIFF
--- a/mcs/class/System/System/UriParseComponents.cs
+++ b/mcs/class/System/System/UriParseComponents.cs
@@ -326,6 +326,14 @@ namespace System {
 				bool isEscapedChar = false;
 				var oldIndex = index;
 
+				// Spaces should be percentage encoded #31172
+				if (ch == ' ') {
+					if (sb == null)
+						sb = new StringBuilder ();
+					sb.Append ("%20");
+					continue;
+				}
+
 				if (ch == '%'){
 					if (!Uri.IsHexEncoding (part, index))
 						return false;

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -1984,6 +1984,20 @@ namespace MonoTests.System
 				}
 			}
 		}
+
+		[Test]
+		public void UserInfo_Spaces ()
+		{
+			const string userinfo = "test 1:pass 1";
+			const string expected = "test%201:pass%201";
+
+			try {
+				var uri = new Uri (string.Format ("rtmp://{0}@test.com:333/live", userinfo));
+				Assert.AreEqual (expected, uri.UserInfo);
+			} catch (Exception e) {
+				Assert.Fail (string.Format ("Unexpected {0} while building URI with username {1}", e.GetType ().Name, userinfo));
+			}
+		}
 	}
 
 	// Tests non default IriParsing


### PR DESCRIPTION
Fixes [#31172](https://bugzilla.xamarin.com/show_bug.cgi?id=31172)