### PR TITLE
[System] UriKind.RelativeOrAbsolute workaround.

### DIFF
--- a/mcs/class/System/System/Uri.cs
+++ b/mcs/class/System/System/Uri.cs
@@ -96,6 +96,12 @@ namespace System {
 			set { s_IriParsing = value; }
 		}
 
+		// Do not rename this.
+		// User code might set this to true with reflection.
+		// When set to true an Uri constructed with UriKind.RelativeOrAbsolute 
+		// and paths such as "/foo" is assumed relative.
+		private static bool useDotNetRelativeOrAbsolute;
+
 #if BOOTSTRAP_BASIC
 		private static readonly string hexUpperChars = "0123456789ABCDEF";
 		private static readonly string [] Empty = new string [0];
@@ -147,6 +153,8 @@ namespace System {
 				IriParsing = true;
 			else if (iriparsingVar == "false")
 				IriParsing = false;
+
+			useDotNetRelativeOrAbsolute = Environment.GetEnvironmentVariable ("MONO_URI_DOTNETRELATIVEORABSOLUTE") == "true";
 		}
 
 		public Uri (string uriString) : this (uriString, false) 
@@ -173,12 +181,21 @@ namespace System {
 		// When used instead of UriKind.RelativeOrAbsolute paths such as "/foo" are assumed relative.
 		const UriKind DotNetRelativeOrAbsolute = (UriKind) 300;
 
+		private void ProcessUriKind (string uriString, ref UriKind uriKind)
+		{
+			if (uriString == null)
+			   return;
+		
+			if (uriKind == DotNetRelativeOrAbsolute ||
+				(uriKind == UriKind.RelativeOrAbsolute && useDotNetRelativeOrAbsolute))
+				uriKind = (uriString.StartsWith ("/", StringComparison.Ordinal))? UriKind.Relative : UriKind.RelativeOrAbsolute;
+		}
+
 		public Uri (string uriString, UriKind uriKind)
 		{
 			source = uriString;
 
-			if (uriString != null && uriKind == DotNetRelativeOrAbsolute)
-				uriKind = (uriString.StartsWith ("/", StringComparison.Ordinal))? UriKind.Relative : UriKind.RelativeOrAbsolute;
+			ProcessUriKind (uriString, ref uriKind);
 
 			ParseUri (uriKind);
 
@@ -212,8 +229,7 @@ namespace System {
 				return;
 			}
 
-			if (uriKind == DotNetRelativeOrAbsolute)
-				uriKind = (uriString.StartsWith ("/", StringComparison.Ordinal))? UriKind.Relative : UriKind.RelativeOrAbsolute;
+			ProcessUriKind (uriString, ref uriKind);
 
 			if (uriKind != UriKind.RelativeOrAbsolute &&
 				uriKind != UriKind.Absolute &&

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -1920,12 +1920,32 @@ namespace MonoTests.System
 		[Test]
 		public void DotNetRelativeOrAbsoluteTest ()
 		{
-			var uri1 = new Uri ("/foo", DotNetRelativeOrAbsolute);
-			Assert.IsFalse (uri1.IsAbsoluteUri);
+			Uri uri;
+
+			uri = new Uri ("/foo", DotNetRelativeOrAbsolute);
+			Assert.IsFalse (uri.IsAbsoluteUri);
 			
-			Uri uri2;
-			Uri.TryCreate("/foo", DotNetRelativeOrAbsolute, out uri2);
-			Assert.IsFalse (uri2.IsAbsoluteUri);
+			Uri.TryCreate("/foo", DotNetRelativeOrAbsolute, out uri);
+			Assert.IsFalse (uri.IsAbsoluteUri);
+
+			if (Type.GetType ("Mono.Runtime") != null) {
+				uri = new Uri ("/foo", UriKind.RelativeOrAbsolute);
+				Assert.IsTrue (uri.IsAbsoluteUri);
+
+				Uri.TryCreate("/foo", UriKind.RelativeOrAbsolute, out uri);
+				Assert.IsTrue (uri.IsAbsoluteUri);
+
+				var useDotNetRelativeOrAbsoluteField = typeof (Uri).GetField ("useDotNetRelativeOrAbsolute",
+					BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+
+				useDotNetRelativeOrAbsoluteField.SetValue (null, true);
+			}
+
+			uri = new Uri ("/foo", UriKind.RelativeOrAbsolute);
+			Assert.IsFalse (uri.IsAbsoluteUri);
+
+			Uri.TryCreate("/foo", DotNetRelativeOrAbsolute, out uri);
+			Assert.IsFalse (uri.IsAbsoluteUri);
 		}
 
 		[Test]


### PR DESCRIPTION
In .NET an URI constructor from "/foo" and UriKind.RelativeOrAbsolute is
relative whereas in mono it is assumed as an absolute file path.

This adds another workaround that changes all Uri constructor calls to
behave like .NET when receiving UriKind.RelativeOrAbsolute.

The environment variable workaround consists in setting
MONO_URI_DOTNETRELATIVEORABSOLUTE=true before starting the application.

Reflection workaround:
```
if (Type.GetType ("Mono.Runtime") != null)
    typeof (Uri).GetField ("useDotNetRelativeOrAbsolute",
        BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic).
        SetValue (null, true);
```

WARNING: The workarounds change the behavior of all Uri constructor calls.
Unexpected problems can occur if an used library relies on
UriKind.RelativeOrAbsolute to parse absolute file paths.