### PR TITLE
[System.IO.Compression] Fixed handling of empty Zip archives in Update mode

### DIFF
--- a/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
+++ b/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
@@ -251,5 +251,16 @@ namespace MonoTests.System.IO.Compression
 
 			File.Delete ("test.zip");
 		}
+
+		[Test]
+		public void ZipUpdateEmptyArchive()
+		{
+			File.WriteAllText("empty.zip", string.Empty);
+			using (var archive = new ZipArchive(File.Open("empty.zip", FileMode.Open),
+				ZipArchiveMode.Update))
+			{
+			}
+			File.Delete ("empty.zip");
+		}
 	}
 }

--- a/mcs/class/System.IO.Compression/ZipArchive.cs
+++ b/mcs/class/System.IO.Compression/ZipArchive.cs
@@ -103,9 +103,9 @@ namespace System.IO.Compression
 				throw new ArgumentException("Stream must support reading, writing and seeking for Update archive mode");
 
 			try {
-				zipFile = mode == ZipArchiveMode.Create ? 
-					SharpCompress.Archive.Zip.ZipArchive.Create() :
-					SharpCompress.Archive.Zip.ZipArchive.Open(stream);
+				zipFile = mode != ZipArchiveMode.Create && stream.Length != 0
+					? SharpCompress.Archive.Zip.ZipArchive.Open(stream)
+					: SharpCompress.Archive.Zip.ZipArchive.Create();
 			} catch (Exception e) {
 				throw new InvalidDataException("The contents of the stream are not in the zip archive format.", e);
 			}


### PR DESCRIPTION
Fixes bug #32725.

https://bugzilla.xamarin.com/show_bug.cgi?id=32725