### PR TITLE
[mdoc] Follow up fix for member and type removal.

### DIFF
--- a/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/WillDelete.xml.remove
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/WillDelete.xml.remove
@@ -14,9 +14,6 @@
       <MemberSignature Language="C#" Value="public WillDelete ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
-      <AssemblyInfo apistyle="classic">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
@@ -30,9 +27,6 @@
       <MemberSignature Language="C#" Value="public string Name { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Name" />
       <MemberType>Property</MemberType>
-      <AssemblyInfo apistyle="classic">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>


### PR DESCRIPTION
In supplement of the changes submitted in 09b97cba2e7c2d9c68830d55ff3d99c5f36eb439, there were
some additional edge cases that were not originally considered, and so this patch resolves these
additional issues. In particular, there was a bug in the `RemoveApiStyle` method that wasn't
checking the value of the `apistyle` attribute before removing it. This caused members to be
stripped of apistyle inadvertently.

There was an issue in the type removal code that caused
too many files to be removed. This patch adds additional checks to make sure that a file isn't
going to be removed if it contains members in the other style that shoulnd't be removed

Finally, there was an issue that arose after the aforementioned changes in the `OrderTypeAttributes`
method. It was somewhat counterintuitive, but it wasn't allowing the reordering of attributes
with the `.Remove` method (throwing an exception). Not entirely sure why this was happening,
but using the `.RemoveNamedItem` method worked around the issue.