### PR TITLE
[class libs] Implemented DnsRefreshTimeout for ServicePointManager

### DIFF
--- a/mcs/class/System/System.Net/ServicePoint.cs
+++ b/mcs/class/System/System.Net/ServicePoint.cs
@@ -47,6 +47,7 @@ namespace System.Net
 		int maxIdleTime;
 		int currentConnections;
 		DateTime idleSince;
+		DateTime lastDnsResolve;
 		Version protocolVersion;
 		X509Certificate certificate;
 		X509Certificate clientCertificate;
@@ -339,37 +340,30 @@ namespace System.Net
 			CheckAvailableForRecycling (out dummy);
 		}
 
+		private bool HasTimedOut
+		{
+			get {
+				int timeout = ServicePointManager.DnsRefreshTimeout;
+				return timeout != Timeout.Infinite &&
+					(lastDnsResolve + TimeSpan.FromMilliseconds (timeout)) < DateTime.UtcNow;
+			}
+		}
+
 		internal IPHostEntry HostEntry
 		{
 			get {
 				lock (hostE) {
-					if (host != null)
-						return host;
-
 					string uriHost = uri.Host;
 
-					// There is no need to do DNS resolution on literal IP addresses
-					if (uri.HostNameType == UriHostNameType.IPv6 ||
-						uri.HostNameType == UriHostNameType.IPv4) {
+					if (host == null || HasTimedOut) {
+						lastDnsResolve = DateTime.UtcNow;
 
-						if (uri.HostNameType == UriHostNameType.IPv6) {
-							// Remove square brackets
-							uriHost = uriHost.Substring(1,uriHost.Length-2);
+						try {
+							host = Dns.GetHostEntry (uriHost);
 						}
-
-						// Creates IPHostEntry
-						host = new IPHostEntry();
-						host.AddressList = new IPAddress[] { IPAddress.Parse(uriHost) };
-
-						return host;
-					}
-
-					// Try DNS resolution on host names
-					try  {
-						host = Dns.GetHostByName (uriHost);
-					} 
-					catch {
-						return null;
+						catch (Exception) {
+							return null;
+						}
 					}
 				}
 

--- a/mcs/class/System/System.Net/ServicePointManager.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.cs
@@ -134,6 +134,7 @@ namespace System.Net
 		private static int defaultConnectionLimit = DefaultPersistentConnectionLimit;
 		private static int maxServicePointIdleTime = 100000; // 100 seconds
 		private static int maxServicePoints = 0;
+		private static int dnsRefreshTimeout = 2 * 60 * 1000;
 		private static bool _checkCRL = false;
 		private static SecurityProtocolType _securityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls;
 
@@ -218,14 +219,13 @@ namespace System.Net
 			return new NotImplementedException ();
 		}
 		
-		[MonoTODO]
 		public static int DnsRefreshTimeout
 		{
 			get {
-				throw GetMustImplement ();
+				return dnsRefreshTimeout;
 			}
 			set {
-				throw GetMustImplement ();
+				dnsRefreshTimeout = Math.Max (-1, value);
 			}
 		}
 		


### PR DESCRIPTION
Hey,

this commit adds the DnsRefreshTimeout (previously not implemented in mono) to the ServicePointManager and applys it in the ServicePoint HostEntry property. When HostEntry gets called after the timeout has been reached a new dns lookup gets triggered (via Dns.GetHostEntry).
The default value is set to 2 minutes - like MS does it.

We hit an issue in production were the missing refresh made some trouble - I thought thats a good starting point to contriubte something again :)

Cheers,
Simon

