### PR TITLE
Remove dead weak link API.

### DIFF
--- a/mono/metadata/gc-internal.h
+++ b/mono/metadata/gc-internal.h
@@ -106,11 +106,6 @@ gpointer mono_gc_out_of_memory (size_t size);
 void     mono_gc_enable_events (void);
 void     mono_gc_enable_alloc_events (void);
 
-/* disappearing link functionality */
-void mono_gc_weak_link_register (volatile gpointer *link_addr, MonoObject *obj, gboolean track);
-void mono_gc_weak_link_unregister (volatile gpointer *link_addr, gboolean track);
-void mono_gc_ensure_weak_links_accessible (void);
-
 void mono_gchandle_set_target (guint32 gchandle, MonoObject *obj);
 
 /*Ephemeron functionality. Sgen only*/

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2565,35 +2565,6 @@ mono_gc_get_los_limit (void)
 	return SGEN_MAX_SMALL_OBJ_SIZE;
 }
 
-void
-mono_gc_weak_link_register (volatile gpointer *link_addr, MonoObject *obj, gboolean track)
-{
-	binary_protocol_dislink_add ((gpointer)link_addr, obj, track);
-}
-
-void
-mono_gc_weak_link_unregister (volatile gpointer *link_addr, gboolean track)
-{
-	binary_protocol_dislink_remove ((gpointer)link_addr, track);
-}
-
-void
-mono_gc_ensure_weak_links_accessible (void)
-{
-	/*
-	 * During the second bridge processing step the world is
-	 * running again.  That step processes all weak links once
-	 * more to null those that refer to dead objects.  Before that
-	 * is completed, those links must not be followed, so we
-	 * conservatively wait for bridge processing when any weak
-	 * link is dereferenced.
-	 */
-	/* FIXME: A GC can occur after this check fails, in which case we
-	 * should wait for bridge processing but would fail to do so.
-	 */
-	mono_gc_wait_for_bridge_processing ();
-}
-
 gpointer
 sgen_client_default_metadata (void)
 {


### PR DESCRIPTION
These are leftovers from #1457. Weak links no longer exist, and `mono_gc_ensure_weak_links_accessible` is a duplicate of `sgen_client_ensure_weak_gchandles_accessible`.