### PR TITLE
[RFC] Added MSVC Premake build support.

### DIFF
--- a/premake/README.md
+++ b/premake/README.md
@@ -1,0 +1,4 @@
+mono-premake
+============
+
+MSVC Premake build scripts for Mono

--- a/premake/classlibs.lua
+++ b/premake/classlibs.lua
@@ -1,0 +1,11 @@
+MCS_CLASS_LIBS_ROOT = MONO_ROOT .. "mcs/class/"
+
+if false then
+
+local dirs = os.matchdirs(MCS_CLASS_LIBS_ROOT .. "**")
+
+for k,v in ipairs(dirs) do
+	print(v)
+end
+
+end

--- a/premake/eglib.lua
+++ b/premake/eglib.lua
@@ -1,0 +1,48 @@
+EGLIB_ROOT = MONO_ROOT .. 'eglib/'
+
+project "eglib"
+	
+	kind "StaticLib"
+	language "C"
+	
+	includedirs
+	{
+		gendir,
+		EGLIB_ROOT,
+		EGLIB_ROOT .. "src",
+		EGLIB_ROOT .. ".."
+	}
+	
+	files
+	{
+		EGLIB_ROOT .. "src/*.c",
+		EGLIB_ROOT .. "src/*.h",
+	}
+
+	excludes
+	{	
+		-- Platform-specific files
+		EGLIB_ROOT .. "src/*-unix.c",
+		EGLIB_ROOT .. "src/*-win32.c",
+	}
+
+	filter "system:windows"
+		SetupWindowsDefines()
+		files
+		{
+			EGLIB_ROOT .. "src/*-win32.c"
+		}
+
+	filter "system:not windows"
+		files { EGLIB_ROOT .. "src/*-unix.c" }
+
+	filter "action:vs*"
+		SetupMSVCWarnings()
+		buildoptions
+		{
+			"/wd4018", -- signed/unsigned mismatch
+			"/wd4133", -- incompatible types - from 'x *' to 'y *'
+			"/wd4267", -- conversion from 'size_t' to 'glong', possible loss of data
+			"/wd4273", -- inconsistent dll linkage
+			"/wd4996"
+		}

--- a/premake/helpers.lua
+++ b/premake/helpers.lua
@@ -1,0 +1,84 @@
+-- This module checks for the all the project dependencies.
+
+function SetupManagedProject()
+  language "C#"
+  location (path.join(builddir, "projects"))
+end
+
+function SetupWindowsDefines()
+    defines
+    {
+      "WIN32_THREADS",
+      "UNICODE",
+      "_UNICODE",
+      "FD_SETSIZE=1024",
+      "HOST_WIN32",
+      "WIN32_LEAN_AND_MEAN"
+    }
+end
+
+function SetupMSVCWarnings()
+  buildoptions
+  {
+    "/wd4018", -- signed/unsigned mismatch
+    "/wd4244", -- conversion from 'x' to 'y', possible loss of data
+    "/wd4133", -- incompatible types - from 'x *' to 'y *'
+    "/wd4715", -- not all control paths return a value
+    "/wd4047", -- 'x' differs in levels of indirection from 'y'
+    "/wd4116", -- unnamed type definition in parentheses
+  }
+
+  -- clang-cl specific warnings
+  -- filter { "toolset:clang", "action:vs*" }
+  if useClangCl then
+    buildoptions
+    {      
+      "-Wno-implicit-int",
+      "-Wno-implicit-function-declaration",
+      "-Wno-return-type",
+      "-Wno-unused-variable",
+      "-Wno-deprecated-declarations",
+      "-Wno-parentheses",
+      "-Wno-incompatible-pointer-types",
+      "-Wno-missing-braces",
+      "-Wno-unused-function",
+    }
+  end
+end
+
+function IncludeDir(dir)
+  local files = os.matchfiles(path.join(dir, "**.lua"))
+  
+  for i,file in pairs(files) do
+    print(string.format(" including %s", file))
+    include(file)
+  end
+end
+
+function WriteToFile(path, content)
+  file = io.open(path, "w")
+  file:write(content)
+  file:close()
+end
+
+function GenerateBuildVersion(file)
+  print("Generating build version file: " .. file)
+  local contents = "const char *build_date = \"\";"
+  WriteToFile(gendir .. '/' .. file, contents)
+end
+
+-- Premake hacks
+
+local p = premake
+local m = p.vstudio.vc2010
+
+premake.override(premake.vstudio.vc2010, "platformToolset", function(base, cfg)
+    local tool, version = p.config.toolset(cfg)
+    if version then
+      version = "v" .. version
+    else
+      local action = p.action.current()
+      version = action.vstudio.platformToolset
+    end
+    m.element("PlatformToolset", nil, version)
+end)

--- a/premake/mcs.lua
+++ b/premake/mcs.lua
@@ -1,0 +1,73 @@
+MCS_ROOT = MONO_ROOT .. 'mcs/'
+
+function GenerateConsts()
+  print('Generating Consts.cs')
+
+  local consts = 'build/common/Consts.cs.in'
+  local src = MCS_ROOT .. consts
+  local dest = gendir .. '/Consts.cs'
+
+  local file = io.open(path.getabsolute(src))
+  if not file then
+    error(consts .. " was not found")
+  end
+
+  local contents = file:read("*all")
+  file:close()
+
+  local token = '@MONO_VERSION@'
+  local version = '3.12'
+
+  local contents, matches = string.gsub(contents, token, version)
+  if matches == 0 then
+    print("Error replacing token " .. token .. ' with version')
+    return
+  end
+
+  file = io.open(path.getabsolute(dest), "w+")
+  file:write(contents)
+  file:close()
+end
+
+GenerateConsts()
+
+project "mcs-gen"
+
+  kind "ConsoleApp"
+  dependson { "jay" }
+
+  files { MCS_ROOT .. "mcs/*.jay" }
+
+  filter 'files:**.jay'
+    -- A message to display while this build step is running (optional)
+    buildmessage 'Generating %{file.relpath}'
+
+    -- One or more commands to run (required)
+    local prj = premake.api.scope.project.location
+    local input = path.getrelative(prj, path.getabsolute(MCS_ROOT .. 'jay/skeleton.cs'))
+    local out = 'gen/%{file.basename}.cs'
+    buildcommands { '"lib\\jay" -cv < "' .. input .. '" "%{file.relpath}" > ' .. out }
+
+   -- One or more outputs resulting from the build (required)
+   buildoutputs { out }
+
+project "mcs"
+  SetupManagedProject()
+
+  kind "ConsoleApp"
+  dependson { "mcs-gen" }
+
+  defines { 'NET_4_5' }
+  files
+  {
+    MCS_ROOT .. "mcs/*.cs",
+    MCS_ROOT .. "mcs/*.jay",
+    MCS_ROOT .. "class/Mono.CompilerServices.SymbolWriter/*.cs",
+    MCS_ROOT .. "class/Mono.Security/Mono.Security.Cryptography/CryptoConvert.cs",
+    MCS_ROOT .. "tools/monop/outline.cs",
+    gendir .. "/cs-parser.cs",
+    gendir .. "/Consts.cs"
+  }
+
+  excludes { MCS_ROOT .. "mcs/ikvm.cs" }
+  links { "System", "System.Xml" }

--- a/premake/mono.lua
+++ b/premake/mono.lua
@@ -1,0 +1,399 @@
+MONO_RUNTIME_ROOT = MONO_ROOT .. "mono/"
+
+function SetupSGen()
+	local f = filter()
+
+	defines
+	{
+		"HAVE_SGEN_GC",
+		"HAVE_MOVING_COLLECTOR",
+		"HAVE_WRITE_BARRIERS",
+		"MONO_DLL_EXPORT"
+	}
+
+	files
+	{
+		MONO_RUNTIME_ROOT .. "metadata/sgen-*.*"
+	}
+
+	filter "system:windows"
+		files { MONO_RUNTIME_ROOT .. "metadata/sgen-os-win*.c" }
+
+	filter "system:not windows"
+		files { MONO_RUNTIME_ROOT .. "metadata/sgen-os-posix.c" }
+
+	filter "system:macosx"
+		files { MONO_RUNTIME_ROOT .. "metadata/sgen-os-mach.c" }
+
+	filter(f)
+end
+
+function SetupConfigDefines()
+	defines
+	{
+		"HAVE_DECL_INTERLOCKEDCOMPAREEXCHANGE64=1",
+		"HAVE_DECL_INTERLOCKEDEXCHANGE64=1",
+		"HAVE_DECL_INTERLOCKEDINCREMENT64=1",
+		"HAVE_DECL_INTERLOCKEDDECREMENT64=1",
+		"HAVE_DECL_INTERLOCKEDADD=1",
+		"HAVE_DECL_INTERLOCKEDADD64=1",
+		"HAVE_DECL_INTERLOCKEDCOMPAREEXCHANGE64=1",
+		"HAVE_DECL___READFSDWORD=1",
+	}
+end
+
+function GenerateConfig()
+	if not os.is("windows") then
+		return
+	end
+
+	print('Generating Windows config.h')
+	os.copyfile(MONO_ROOT .. "winconfig.h", gendir .. "/config.h")
+end
+
+function GenerateVersion()
+	print('Generating version.h')
+
+	local contents
+	if os.isdir(MONO_ROOT .. ".git") then
+		local branches = os.outputof("set LANG=C && git branch")
+		local branch = string.gmatch(branches, "^\* (%w+)")()
+		local version = os.outputof("set LANG=C && git log --no-color --first-parent -n1 --pretty=format:%h")
+		contents = string.format("#define FULL_VERSION \"%s/%s\"", branch, version)
+	else
+		contents = "#define FULL_VERSION \"tarball\""
+	end
+
+	file = io.open(path.getabsolute(gendir .. "/version.h"), "w+")
+	file:write(contents)
+	file:close()
+end
+
+function SetupMonoIncludes(monoRuntimeRoot)
+	includedirs
+	{
+		gendir,
+		monoRuntimeRoot,
+		monoRuntimeRoot .. "..",
+		monoRuntimeRoot .. "../eglib/src",
+		monoRuntimeRoot .. "utils/",
+	}
+	print(monoRuntimeRoot .. "../eglib/src")
+end
+
+function SetupMonoLinks()
+	local f = filter()
+
+	links
+	{
+		"eglib",
+		"libmonoruntime",
+		"libmonoutils"
+	}
+
+	filter "system:windows"
+
+		links
+		{
+			"Mswsock",
+			"ws2_32",
+			"psapi",
+			"version",
+			"winmm",
+		}
+
+	filter()
+end
+
+function GenerateMachineDescription(arch)
+	local prj = premake.api.scope.project.location
+	local abs = path.getabsolute(MONO_RUNTIME_ROOT .. 'mini/cpu-' .. arch .. '.md')
+	local input = path.getrelative(prj, abs)	
+	local out = gendir .. '/cpu-' .. arch .. '.h'
+	local desc = arch .. '_desc'
+
+	prebuildcommands
+	{
+		'"%{cfg.targetdir}/genmdesc" ' .. out .. ' ' .. desc .. ' ' .. input
+	}
+end
+
+GenerateConfig()
+GenerateVersion()
+
+project "mono"
+	
+	kind "ConsoleApp"
+	language "C"
+
+	files
+	{
+		MONO_RUNTIME_ROOT .. "mini/main.c",
+	}
+
+	includedirs
+	{
+		gendir,
+		MONO_RUNTIME_ROOT .. "../",
+		MONO_RUNTIME_ROOT .. "../eglib/src/"
+	}	
+	
+	links
+	{
+		"eglib",
+		"libmono",
+		"libmonoruntime",
+		"libmonoutils"
+	}
+
+	filter "action:vs*"
+		defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+		SetupConfigDefines()
+
+
+project "libmono"
+
+	kind "SharedLib"
+	language "C"
+
+	defines
+	{
+		"__default_codegen__",
+		"HAVE_CONFIG_H",
+		"MONO_DLL_EXPORT"
+	}
+	
+	SetupMonoIncludes(MONO_RUNTIME_ROOT)
+	SetupMonoLinks()
+
+	files
+	{
+		MONO_RUNTIME_ROOT .. "mini/*.c",
+		MONO_RUNTIME_ROOT .. "mini/*.h",
+	}
+
+	excludes
+	{
+		-- Archicture-specific files
+		MONO_RUNTIME_ROOT .. "mini/*-alpha.*",
+		MONO_RUNTIME_ROOT .. "mini/*-amd64.*",
+		MONO_RUNTIME_ROOT .. "mini/*-arm.*",
+		MONO_RUNTIME_ROOT .. "mini/*-arm64.*",
+		MONO_RUNTIME_ROOT .. "mini/*-hppa.*",
+		MONO_RUNTIME_ROOT .. "mini/*-ia64.*",
+		MONO_RUNTIME_ROOT .. "mini/*-llvm.*",
+		MONO_RUNTIME_ROOT .. "mini/*-mips.*",
+		MONO_RUNTIME_ROOT .. "mini/*-ppc.*",
+		MONO_RUNTIME_ROOT .. "mini/*-s390*.*",
+		MONO_RUNTIME_ROOT .. "mini/*-sparc.*",
+		MONO_RUNTIME_ROOT .. "mini/*-x86.*",
+
+		-- Platform-specific files
+		MONO_RUNTIME_ROOT .. "mini/*-windows.*",
+		MONO_RUNTIME_ROOT .. "mini/*-darwin.*",
+		MONO_RUNTIME_ROOT .. "mini/*-posix.*",
+
+		-- Tools
+		MONO_RUNTIME_ROOT .. "mini/fsacheck.c",
+		MONO_RUNTIME_ROOT .. "mini/genmdesc.c",
+		MONO_RUNTIME_ROOT .. "mini/main.c",
+	}
+
+	dependson { "genmdesc" }
+	
+	filter "platforms:x32"
+		GenerateMachineDescription('x86')
+		files
+		{
+			MONO_RUNTIME_ROOT .. "mini/*-x86.c",
+		}
+
+	filter "platforms:x64"
+		GenerateMachineDescription('amd64')
+		files
+		{
+			MONO_RUNTIME_ROOT .. "mini/*-amd64.c",
+		}	
+
+	filter "system:windows"
+		SetupWindowsDefines()
+		files
+		{
+			MONO_RUNTIME_ROOT .. "mini/*-windows.c"
+		}
+
+	filter "system:not windows"
+		files
+		{
+			MONO_RUNTIME_ROOT .. "mini/*-posix.c"
+		}
+
+	filter "system:macosx"
+		files
+		{
+			MONO_RUNTIME_ROOT .. "mini/*-darwin.c"
+		}
+
+	filter "action:vs*"
+		defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+		SetupConfigDefines()
+		SetupMSVCWarnings()
+		buildoptions
+		{
+			"/wd4018", -- signed/unsigned mismatch
+			"/wd4244", -- conversion from 'x' to 'y', possible loss of data
+			"/wd4133", -- incompatible types - from 'x *' to 'y *'
+			"/wd4715", -- not all control paths return a value
+			"/wd4047", -- 'x' differs in levels of indirection from 'y'
+		}
+		linkoptions
+		{
+			"/ignore:4049", -- locally defined symbol imported
+			"/ignore:4217", -- locally defined symbol imported in function
+		}
+
+project "libmonoruntime"
+
+	kind "StaticLib"
+	language "C"
+	
+	defines
+	{
+		"HAVE_CONFIG_H",
+	}
+
+	SetupMonoIncludes(MONO_RUNTIME_ROOT)
+	
+	files
+	{
+		MONO_RUNTIME_ROOT .. "metadata/*.c",
+		MONO_RUNTIME_ROOT .. "metadata/*.h",
+		MONO_RUNTIME_ROOT .. "sgen/*.c",
+		MONO_RUNTIME_ROOT .. "sgen/*.h",
+	}
+
+	excludes
+	{
+		MONO_RUNTIME_ROOT .. "metadata/threadpool-ms-io-*",
+
+		-- GC-specific files
+		MONO_RUNTIME_ROOT .. "metadata/boehm-gc.c",
+		MONO_RUNTIME_ROOT .. "metadata/null-gc.c",
+		MONO_RUNTIME_ROOT .. "metadata/sgen-*.*",
+		MONO_RUNTIME_ROOT .. "metadata/sgen-os-*.*",
+		
+		-- Platform-specific files
+		MONO_RUNTIME_ROOT .. "metadata/console-unix.c",
+		MONO_RUNTIME_ROOT .. "metadata/console-win32.c",
+		MONO_RUNTIME_ROOT .. "metadata/coree.c",
+
+		-- Tools
+		MONO_RUNTIME_ROOT .. "metadata/monodiet.c",
+		MONO_RUNTIME_ROOT .. "metadata/monosn.c",
+		MONO_RUNTIME_ROOT .. "metadata/pedump.c",
+		MONO_RUNTIME_ROOT .. "metadata/tpool-*.c",
+		MONO_RUNTIME_ROOT .. "metadata/test-*.c",
+	}
+
+	SetupSGen()
+
+	filter "system:windows"
+		SetupWindowsDefines()
+		defines { "_WINSOCK_DEPRECATED_NO_WARNINGS" }
+		files
+		{
+			MONO_RUNTIME_ROOT .. "metadata/coree.c",
+		}
+
+	filter "system:linux"
+		files
+		{
+			MONO_RUNTIME_ROOT .. "metadata/tpool-epoll.c"
+		}
+		
+	filter "system:macosx or freebsd"
+		files
+		{
+			MONO_RUNTIME_ROOT .. "metadata/tpool-kqueue.c"
+		}
+
+	filter "action:vs*"
+		defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+		SetupConfigDefines()
+		SetupMSVCWarnings()
+
+
+project "libmonoutils"
+
+	kind "StaticLib"
+	language "C"
+	
+	defines
+	{
+		"HAVE_CONFIG_H",
+	}
+
+	SetupMonoIncludes(MONO_RUNTIME_ROOT)
+	
+	files
+	{
+		MONO_RUNTIME_ROOT .. "utils/*.c",
+		MONO_RUNTIME_ROOT .. "utils/*.h",
+	}
+
+	excludes
+	{
+		MONO_RUNTIME_ROOT .. "utils/sha1.c",
+
+		-- Platform-specific files
+		MONO_RUNTIME_ROOT .. "utils/atomic.c",
+		MONO_RUNTIME_ROOT .. "utils/mono-hwcap-*.*",
+		MONO_RUNTIME_ROOT .. "utils/mono-threads-*.c",
+
+		-- Tools
+		MONO_RUNTIME_ROOT .. "utils/mono-embed.c",
+	}
+
+	files { MONO_RUNTIME_ROOT .. "utils/mono-threads-state-machine.c" }
+
+	filter "architecture:arm*"
+		files { MONO_RUNTIME_ROOT .. "utils/mono-hwcap-arm.*" }
+
+	filter "architecture:x32 or x64"
+		files { MONO_RUNTIME_ROOT .. "utils/mono-hwcap-x86.*" }
+
+	filter "system:windows"
+		SetupWindowsDefines()
+		files
+		{
+			MONO_RUNTIME_ROOT .. "metadata/coree.c",
+			MONO_RUNTIME_ROOT .. "utils/mono-threads-windows.c",
+		}
+		links
+		{
+			"Mswsock",
+			"ws2_32",
+			"psapi",
+			"version",
+			"winmm",
+			"eglib",
+		}
+
+	filter "system:not windows"
+		files
+		{
+			MONO_RUNTIME_ROOT .. "utils/mono-threads-posix.c",
+		}
+
+	filter "system:macosx"
+		files
+		{
+			MONO_RUNTIME_ROOT .. "utils/mono-threads-mach.c",
+		}
+
+	filter "action:vs*"
+		defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+		SetupConfigDefines()
+		SetupMSVCWarnings()
+		buildoptions { "/wd4273", "/wd4197" }
+

--- a/premake/premake5.lua
+++ b/premake/premake5.lua
@@ -1,0 +1,62 @@
+builddir = path.getabsolute("./" .. _ACTION or "")
+libdir = path.join(builddir, "lib")
+gendir = path.join(builddir, "gen")
+
+MONO_ROOT = "../"
+MONO_TOOLS_ROOT = MONO_ROOT .. "tools/"
+
+include("helpers.lua")
+
+GenerateBuildVersion("buildver-sgen.h")
+os.mkdir(gendir)
+
+workspace "Mono"
+
+	configurations
+	{
+		"Debug_SGen",
+		"Release_SGen",
+		"Debug_Boehm",
+		"Release_Boehm"
+	}
+
+	platforms { "x32", "x64" }
+
+  	filter "configurations:Release"
+    	defines { "NDEBUG" }	
+
+	filter "platforms:x32"
+		architecture "x86"
+
+	filter "platforms:x64"
+		architecture "x86_64"
+
+	filter { "system:windows", "language:C or C++" }
+		defines { "WIN32", "_WINDOWS" }
+		defines { "WINVER=0x0600", "_WIN32_WINNT=0x0600" }	
+
+	filter {}
+	
+	location (builddir)
+	objdir (builddir .. "/obj/")
+	targetdir (libdir)
+	libdirs { libdir }
+
+	framework "4.5"
+	flags { "Unicode", "Symbols" }
+
+	group "Compiler"
+		include("mcs.lua")
+
+	group "Class Libraries"
+		include("classlibs.lua")
+
+	group "Profilers"
+		include("profilers.lua")
+
+	group "Runtime"
+		include("eglib.lua")
+		include("mono.lua")
+
+	group "Tools"
+		include("tools.lua")

--- a/premake/tools.lua
+++ b/premake/tools.lua
@@ -1,0 +1,1 @@
+IncludeDir("tools")

--- a/premake/tools/genmdesc.lua
+++ b/premake/tools/genmdesc.lua
@@ -1,0 +1,39 @@
+project "genmdesc"
+
+  kind "ConsoleApp"
+  language "C"
+
+  files
+  {
+    MONO_ROOT .. "../mono/mini/genmdesc.c",
+    MONO_ROOT .. "../mono/mini/helpers.c",
+    MONO_ROOT .. "../mono/utils/monobitset.c",
+    MONO_ROOT .. "../mono/metadata/opcodes.c"
+  }
+
+  removedefines { "DEBUG" }
+
+  SetupMonoIncludes(MONO_ROOT)
+
+  links
+  {
+    "eglib",
+  }
+
+  filter "action:vs*"
+
+    defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+    SetupConfigDefines()
+    SetupMSVCWarnings()
+
+    buildoptions
+    {
+      "/wd4273", -- 'function' : inconsistent DLL linkage
+      "/wd4197"
+    }
+
+    linkoptions
+    {
+      "/ignore:4049", -- locally defined symbol imported
+      "/ignore:4217", -- locally defined symbol imported in function
+    }

--- a/premake/tools/jay.lua
+++ b/premake/tools/jay.lua
@@ -1,0 +1,27 @@
+JAY_ROOT = MONO_ROOT .. '../mcs/jay/'
+
+project "jay"
+
+  kind "ConsoleApp"
+  language "C"
+
+  files { JAY_ROOT .. "*.c" }
+
+  defines { "SKEL_DIRECTORY=\".\""}
+  removedefines { "DEBUG" }
+
+  filter "action:vs*"
+
+    SetupMSVCWarnings()
+    buildoptions
+    {
+        "/wd4033",
+        "/wd4013",
+        "/wd4996",
+        "/wd4267",
+        "/wd4273",
+        "/wd4113",
+        "/wd4244",
+        "/wd4715",
+        "/wd4716"
+    }

--- a/premake/tools/monodis.lua
+++ b/premake/tools/monodis.lua
@@ -1,0 +1,30 @@
+project "monodis"
+
+	kind "ConsoleApp"
+	language "C"
+
+	files
+	{
+		MONO_ROOT .. "../mono/dis/*.c",
+		MONO_ROOT .. "../mono/dis/*.h",
+		MONO_ROOT .. "../metadata/opcodes.c"
+	}
+
+	SetupMonoIncludes(MONO_ROOT)
+	SetupMonoLinks()
+	defines { "MONO_STATIC_BUILD" }
+
+	filter "action:vs*"
+	
+		defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+		SetupConfigDefines()
+		buildoptions
+		{
+			"/wd4018", -- signed/unsigned mismatch
+			"/wd4273", -- inconsistent dll linkage
+		}
+		linkoptions
+		{
+			"/ignore:4049", -- locally defined symbol imported
+			"/ignore:4217", -- locally defined symbol imported in function
+		}

--- a/premake/tools/monograph.lua
+++ b/premake/tools/monograph.lua
@@ -1,0 +1,30 @@
+project "monograph"
+
+	kind "ConsoleApp"
+	language "C"
+
+	files
+	{
+		MONO_ROOT .. "../tools/monograph/*.c",
+		MONO_ROOT .. "../tools/monograph/*.h",
+		MONO_ROOT .. "../mono/metadata/opcodes.c"
+	}
+
+	SetupMonoIncludes(MONO_ROOT)
+	SetupMonoLinks()
+	defines { "MONO_STATIC_BUILD" }
+
+	filter "action:vs*"
+	
+		defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+		SetupConfigDefines()
+		buildoptions
+		{
+			"/wd4018", -- signed/unsigned mismatch
+			"/wd4273", -- inconsistent dll linkage
+		}
+		linkoptions
+		{
+			"/ignore:4049", -- locally defined symbol imported
+			"/ignore:4217", -- locally defined symbol imported in function
+		}

--- a/premake/tools/pedump.lua
+++ b/premake/tools/pedump.lua
@@ -1,0 +1,28 @@
+project "pedump"
+
+	kind "ConsoleApp"
+	language "C"
+
+	files
+	{
+		MONO_ROOT .. "../mono/metadata/pedump.c"
+	}
+
+	SetupMonoIncludes(MONO_ROOT)
+	SetupMonoLinks()
+	defines { "MONO_STATIC_BUILD" }
+
+	filter "action:vs*"
+	
+		defines { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE" }
+		SetupConfigDefines()
+		buildoptions
+		{
+			"/wd4018", -- signed/unsigned mismatch
+			"/wd4273", -- inconsistent dll linkage
+		}
+		linkoptions
+		{
+			"/ignore:4049", -- locally defined symbol imported
+			"/ignore:4217", -- locally defined symbol imported in function
+		}


### PR DESCRIPTION
This pull provides some work-in-progress build scripts for MSVC using Premake.

It provides some nice benefits over our current MSVC projects.

The biggest one is that we can automatically generate the projects. Our current MSVC projects are almost always broken because of trivial things like moved, renamed or new files so this should ease some of the maintenance burden. It also allow us to trivially support different toolsets like Clang on VS or Emscripten.

I've also left some hooks where we can include the class libraries projects to be able to finally get a unified Mono build in Windows.

If there's positive support for moving to these declarative auto-generated projects then I'll put some effort into making sure all we need from this is properly supported and kill the undermantained VS projects.
