### PR TITLE
[delegate] Fix Equals on Delegate to virtual method

### DIFF
--- a/mcs/class/corlib/System/Delegate.cs
+++ b/mcs/class/corlib/System/Delegate.cs
@@ -475,13 +475,15 @@ namespace System
 			return MemberwiseClone ();
 		}
 
-		internal bool Compare (Delegate d)
+		public override bool Equals (object obj)
 		{
+			Delegate d = obj as Delegate;
+
 			if (d == null)
 				return false;
-			
+
 			// Do not compare method_ptr, since it can point to a trampoline
-			if (d.m_target == m_target && d.method == method) {
+			if (d.m_target == m_target && d.Method == Method) {
 				if (d.data != null || data != null) {
 					/* Uncommon case */
 					if (d.data != null && data != null)
@@ -500,14 +502,9 @@ namespace System
 			return false;
 		}
 
-		public override bool Equals (object obj)
-		{
-			return Compare (obj as Delegate);
-		}
-
 		public override int GetHashCode ()
 		{
-			return method.GetHashCode () ^ (m_target != null ? m_target.GetHashCode () : 0);
+			return Method.GetHashCode () ^ (m_target != null ? m_target.GetHashCode () : 0);
 		}
 
 		protected virtual MethodInfo GetMethodImpl ()

--- a/mono/tests/delegate12.cs
+++ b/mono/tests/delegate12.cs
@@ -32,6 +32,11 @@ class MainClass
 		if (del2 () != "Derived method")
 			return 22;
 
+		if (!del1.Equals (del2))
+			return 30;
+		if (!del2.Equals (del1))
+			return 31;
+
 		return 0;
 	}
 


### PR DESCRIPTION
The comparison was failing because we were still using the method field (instead of the Method property), which would then return, in the case of a delegate to a virtual function, the method on the base class, instead of the method on the derived class. Updated the test cases to check that too.