### PR TITLE
[bcl] Fix System.Net.HttpWebRequestTest.GetRequestStream hang

### DIFF
--- a/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SocketResponder.cs
+++ b/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SocketResponder.cs
@@ -96,6 +96,9 @@ namespace MonoTests.System.Web.Services.Protocols
 				if (tcpListener != null) {
 					tcpListener.Stop ();
 					tcpListener = null;
+					listenThread.Abort ();
+					listenThread.Join ();
+					listenThread = null;
 				}
 			}
 		}

--- a/mcs/class/System/Test/System.Net/SocketResponder.cs
+++ b/mcs/class/System/Test/System.Net/SocketResponder.cs
@@ -98,6 +98,9 @@ namespace MonoTests.System.Net
 				if (tcpListener != null) {
 					tcpListener.Stop ();
 					tcpListener = null;
+					listenThread.Abort ();
+					listenThread.Join ();
+					listenThread = null;
 					Thread.Sleep (50);
 				}
 			}


### PR DESCRIPTION
This hang would manifest when running the System test suite, with a thread waiting on a `recv'. This syscall would never be interrupted because the socket it would listen on would never close, as there would still be references to its SafeSocketHandle, so that it would never release the native handle.

The issue came from the fact that, when closing the SocketResponder (via the Dispose and the using), the listening thread would never be aborted/stopped, and it would consequently never be collected, thus never releasing the current socket on which _requestHandler is called, thus never aborting the above `recv' syscall.

The issue would arise with the cooperative GC as well as the premptive one.