### PR TITLE
[corlib] Fixes TimeZoneInfo.ConvertTimeFromUtc.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -412,8 +412,11 @@ namespace System
 			if (dateTime.Kind == DateTimeKind.Local)
 				throw new ArgumentException ("Kind property of dateTime is Local");
 
-			if (this == TimeZoneInfo.Utc)
-				return DateTime.SpecifyKind (dateTime, DateTimeKind.Utc);
+			if (this == TimeZoneInfo.Utc) {
+				// TimeZoneInfo.Local can be equal to TimeZoneInfo.Utc, fixes #33471
+				var k = (this == TimeZoneInfo.Local)? DateTimeKind.Local : DateTimeKind.Utc;
+				return DateTime.SpecifyKind (dateTime, k);
+			}
 
 			var utcOffset = GetUtcOffset (dateTime);
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -39,6 +39,17 @@ namespace MonoTests.System
 {
 	public class TimeZoneInfoTest
 	{
+		static FieldInfo localField;
+
+		public static void SetLocal (TimeZoneInfo val)
+		{
+			if (localField == null)
+				localField = typeof (TimeZoneInfo).GetField ("local",
+					BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+
+			localField.SetValue (null, val);
+		}
+
 		[TestFixture]
 		public class PropertiesTests
 		{
@@ -467,15 +478,46 @@ namespace MonoTests.System
 			}
 
 			[Test]
+			public void ConvertFromToUtc_Utc ()
+			{
+				DateTime utc = DateTime.UtcNow;
+				Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
+				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Utc);
+				Assert.AreEqual (DateTimeKind.Utc, converted.Kind);
+				DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Utc);
+				Assert.AreEqual (back.Kind, DateTimeKind.Utc);
+				Assert.AreEqual (utc, back);
+			}
+
+			[Test]
+			public void ConvertFromToUtc_LocalAsUtc ()
+			{
+				var oldLocal = TimeZoneInfo.Local;
+				TimeZoneInfoTest.SetLocal (TimeZoneInfo.Utc);
+
+				try {
+					DateTime utc = DateTime.UtcNow;
+					Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
+					DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Local);
+					Assert.AreEqual (DateTimeKind.Local, converted.Kind);
+					DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Local);
+					Assert.AreEqual (back.Kind, DateTimeKind.Utc);
+					Assert.AreEqual (utc, back);
+				} finally {
+					TimeZoneInfoTest.SetLocal (oldLocal);
+				}
+			}
+
+			[Test]
 			public void ConvertFromToLocal ()
 			{
 				DateTime utc = DateTime.UtcNow;
-				Assert.AreEqual(utc.Kind, DateTimeKind.Utc);
-				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc(utc, TimeZoneInfo.Local);
-				Assert.AreEqual(DateTimeKind.Local, converted.Kind);
-				DateTime back = TimeZoneInfo.ConvertTimeToUtc(converted, TimeZoneInfo.Local);
-				Assert.AreEqual(back.Kind, DateTimeKind.Utc);
-				Assert.AreEqual(utc, back);
+				Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
+				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Local);
+				Assert.AreEqual (DateTimeKind.Local, converted.Kind);
+				DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Local);
+				Assert.AreEqual (back.Kind, DateTimeKind.Utc);
+				Assert.AreEqual (utc, back);
 			}
 
 			[Test]


### PR DESCRIPTION
TimeZoneInfo.ConvertTimeFromUtc(utcDate, TimeZoneInfo.Local) now returns a date of kind
DateTimeKind.Local when TimeZoneInfo.Local is equal to TimeZoneInfo.Utc.

Fixes [#33471](https://bugzilla.xamarin.com/show_bug.cgi?id=33471).