### PR TITLE
TimeZoneInfo.ConvertTimeFromUtc should always return Kind.Local

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -413,7 +413,7 @@ namespace System
 				throw new ArgumentException ("Kind property of dateTime is Local");
 
 			if (this == TimeZoneInfo.Utc)
-				return DateTime.SpecifyKind (dateTime, DateTimeKind.Utc);
+				return DateTime.SpecifyKind (dateTime, DateTimeKind.Local);
 
 			var utcOffset = GetUtcOffset (dateTime);
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -39,6 +39,17 @@ namespace MonoTests.System
 {
 	public class TimeZoneInfoTest
 	{
+		static FieldInfo localField;
+
+		public static void SetLocal (TimeZoneInfo val)
+		{
+			if (localField == null)
+				localField = typeof (TimeZoneInfo).GetField ("local",
+					BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+
+			localField.SetValue (null, val);
+		}
+
 		[TestFixture]
 		public class PropertiesTests
 		{
@@ -467,15 +478,34 @@ namespace MonoTests.System
 			}
 
 			[Test]
+			public void ConvertFromToUtc_LocalAsUtc ()
+			{
+				var oldLocal = TimeZoneInfo.Local;
+				TimeZoneInfoTest.SetLocal (TimeZoneInfo.Utc);
+
+				try {
+					DateTime utc = DateTime.UtcNow;
+					Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
+					DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Local);
+					Assert.AreEqual (DateTimeKind.Local, converted.Kind);
+					DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Local);
+					Assert.AreEqual (back.Kind, DateTimeKind.Utc);
+					Assert.AreEqual (utc, back);
+				} finally {
+					TimeZoneInfoTest.SetLocal (oldLocal);
+				}
+			}
+
+			[Test]
 			public void ConvertFromToLocal ()
 			{
 				DateTime utc = DateTime.UtcNow;
-				Assert.AreEqual(utc.Kind, DateTimeKind.Utc);
-				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc(utc, TimeZoneInfo.Local);
-				Assert.AreEqual(DateTimeKind.Local, converted.Kind);
-				DateTime back = TimeZoneInfo.ConvertTimeToUtc(converted, TimeZoneInfo.Local);
-				Assert.AreEqual(back.Kind, DateTimeKind.Utc);
-				Assert.AreEqual(utc, back);
+				Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
+				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Local);
+				Assert.AreEqual (DateTimeKind.Local, converted.Kind);
+				DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Local);
+				Assert.AreEqual (back.Kind, DateTimeKind.Utc);
+				Assert.AreEqual (utc, back);
 			}
 
 			[Test]


### PR DESCRIPTION
Fixes #34711