### PR TITLE
[corlib] MyDocuments maps to /home/foo/Documents, not $HOME

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
@@ -4906,7 +4906,7 @@ namespace System.Windows.Forms
 			static MWFConfigInstance ()
 			{
 				string b = "mwf_config";
-				string dir = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				string dir = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 
 				if (XplatUI.RunningOnUnix) {
 					dir = Path.Combine (dir, ".mono");

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Mime.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Mime.cs
@@ -677,8 +677,8 @@ namespace System.Windows.Forms
 			if (Directory.Exists ("/usr/local/share/mime"))
 				shared_mime_paths.Add ("/usr/local/share/mime/");
 			
-			if (Directory.Exists (System.Environment.GetFolderPath (Environment.SpecialFolder.Personal) + "/.local/share/mime"))
-				shared_mime_paths.Add (System.Environment.GetFolderPath (Environment.SpecialFolder.Personal) + "/.local/share/mime/");
+			if (Directory.Exists (System.Environment.GetFolderPath (Environment.SpecialFolder.UserProfile) + "/.local/share/mime"))
+				shared_mime_paths.Add (System.Environment.GetFolderPath (Environment.SpecialFolder.UserProfile) + "/.local/share/mime/");
 			
 			if (shared_mime_paths.Count == 0)
 				return;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Theme.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Theme.cs
@@ -581,7 +581,7 @@ namespace System.Windows.Forms
 
 				case UIIcon.PlacesPersonal: {
 					// Default = "My Documents"
-					return Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+					return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 				}
 
 				case UIIcon.PlacesMyComputer: {

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11DesktopColors.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11DesktopColors.cs
@@ -190,7 +190,7 @@ namespace System.Windows.Forms {
 		}
 		
 		private static bool ReadKDEColorsheme() {
-			string full_kdegloabals_filename = Environment.GetFolderPath(Environment.SpecialFolder.Personal)
+			string full_kdegloabals_filename = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
 				+ "/"
 				+ ".kde/share/config/kdeglobals";
 			

--- a/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
+++ b/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
@@ -805,7 +805,7 @@ namespace Microsoft.Win32 {
 		private static string UserStore {
 			get {
 				if (user_store == null)
-					user_store = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal),
+					user_store = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile),
 					".mono/registry");
 
 				return user_store;

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -641,9 +641,10 @@ namespace System {
 			case SpecialFolder.MyComputer:
 				return String.Empty;
 
-			// personal == ~
-			case SpecialFolder.Personal:
-				return home;
+			// SpecialFolder.Personal==SpecialFolder.MyDocuments
+			// case SpecialFolder.Personal:
+			case SpecialFolder.MyDocuments:
+				return ReadXdgUserDir (config, home, "XDG_DOCUMENTS_DIR", "Documents");
 
 			// use FDO's CONFIG_HOME. This data will be synced across a network like the windows counterpart.
 			case SpecialFolder.ApplicationData:

--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -47,7 +47,7 @@ namespace MonoTests.System.IO
 		[TestFixtureSetUp]
 		public void FixtureSetUp ()
 		{
-			path = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+			path = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 			testfile = Path.Combine (path, "FileStreamTest.dat");
 			File.WriteAllText (testfile, "1");
 		}

--- a/mcs/class/monodoc/Monodoc/cache.cs
+++ b/mcs/class/monodoc/Monodoc/cache.cs
@@ -39,7 +39,7 @@ namespace Monodoc
 				if (cacheConfig == null) return;
 				var cacheValues = cacheConfig.Split (',');
 				if (cacheValues.Length == 2 && cacheValues[0].Equals ("file", StringComparison.Ordinal))
-					cacheBaseDirectory = cacheValues[1].Replace ("~", Environment.GetFolderPath (Environment.SpecialFolder.Personal));
+					cacheBaseDirectory = cacheValues[1].Replace ("~", Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 			} catch {}
 		}
 

--- a/mcs/tools/monop/monop.cs
+++ b/mcs/tools/monop/monop.cs
@@ -169,7 +169,7 @@ class MonoP {
 
 		// if -r:~/foo.dll syntax is used the shell misses it
 		if (assembly.StartsWith ("~/"))
-			assembly = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), assembly.Substring (2));
+			assembly = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), assembly.Substring (2));
 
 		try {
 			// if it exists try to use LoadFrom


### PR DESCRIPTION
In Windows, SpecialFolder.MyDocuments maps to
"C:\Documents and Settings\foo\My Documents".

The equivalent to this in Linux should be
"/home/foo/Documents", not "/home/foo".

In fact, there's already another SpecialFolder enum member
that already maps to "/home/foo" and
"C:\Documents and Settings\foo", respectively, it is
the SpecialFolder.UserProfile member.