### PR TITLE
[System] Fixes TimeZoneInfo.ConvertTimeFromUtc.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -412,11 +412,8 @@ namespace System
 			if (dateTime.Kind == DateTimeKind.Local)
 				throw new ArgumentException ("Kind property of dateTime is Local");
 
-			if (this == TimeZoneInfo.Utc) {
-				// TimeZoneInfo.Local can be equal to TimeZoneInfo.Utc, fixes #33471
-				var k = (this == TimeZoneInfo.Local)? DateTimeKind.Local : DateTimeKind.Utc;
-				return DateTime.SpecifyKind (dateTime, k);
-			}
+			if (this == TimeZoneInfo.Utc)
+				return DateTime.SpecifyKind (dateTime, DateTimeKind.Utc);
 
 			var utcOffset = GetUtcOffset (dateTime);
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -360,6 +360,27 @@ namespace MonoTests.System
 		}
 		
 		[TestFixture]
+		public class ConvertTimeTests_LocalUtc : ConvertTimeTests
+		{
+			static TimeZoneInfo oldLocal;
+
+			[SetUp]
+			public void SetLocal ()
+			{
+				base.CreateTimeZones ();
+
+				oldLocal = TimeZoneInfo.Local;
+				TimeZoneInfoTest.SetLocal (TimeZoneInfo.Utc);
+			}
+
+			[TearDown]
+			public void RestoreLocal ()
+			{
+				TimeZoneInfoTest.SetLocal (oldLocal);
+			}
+		}
+
+		[TestFixture]
 		public class ConvertTimeTests
 		{
 			TimeZoneInfo london;
@@ -501,25 +522,6 @@ namespace MonoTests.System
 				DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Utc);
 				Assert.AreEqual (back.Kind, DateTimeKind.Utc);
 				Assert.AreEqual (utc, back);
-			}
-
-			[Test]
-			public void ConvertFromToUtc_LocalAsUtc ()
-			{
-				var oldLocal = TimeZoneInfo.Local;
-				TimeZoneInfoTest.SetLocal (TimeZoneInfo.Utc);
-
-				try {
-					DateTime utc = DateTime.UtcNow;
-					Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
-					DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Local);
-					Assert.AreEqual (DateTimeKind.Utc, converted.Kind);
-					DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Local);
-					Assert.AreEqual (back.Kind, DateTimeKind.Utc);
-					Assert.AreEqual (utc, back);
-				} finally {
-					TimeZoneInfoTest.SetLocal (oldLocal);
-				}
 			}
 
 			[Test]

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -40,14 +40,28 @@ namespace MonoTests.System
 	public class TimeZoneInfoTest
 	{
 		static FieldInfo localField;
+		static FieldInfo cachedDataField;
+		static object localFieldObj;
 
 		public static void SetLocal (TimeZoneInfo val)
 		{
-			if (localField == null)
-				localField = typeof (TimeZoneInfo).GetField ("local",
-					BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+			if (localField == null) {
+				if (Type.GetType ("Mono.Runtime") != null) {
+					localField = typeof (TimeZoneInfo).GetField ("local",
+							BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+				} else {
+					cachedDataField = typeof (TimeZoneInfo).GetField ("s_cachedData",
+							BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
 
-			localField.SetValue (null, val);
+					localField = cachedDataField.FieldType.GetField ("m_localTimeZone",
+						BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic);
+				}
+			}
+
+			if (cachedDataField != null)
+				localFieldObj = cachedDataField.GetValue (null);
+
+			localField.SetValue (localFieldObj, val);
 		}
 
 		[TestFixture]
@@ -499,7 +513,7 @@ namespace MonoTests.System
 					DateTime utc = DateTime.UtcNow;
 					Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
 					DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Local);
-					Assert.AreEqual (DateTimeKind.Local, converted.Kind);
+					Assert.AreEqual (DateTimeKind.Utc, converted.Kind);
 					DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Local);
 					Assert.AreEqual (back.Kind, DateTimeKind.Utc);
 					Assert.AreEqual (utc, back);
@@ -514,7 +528,8 @@ namespace MonoTests.System
 				DateTime utc = DateTime.UtcNow;
 				Assert.AreEqual (utc.Kind, DateTimeKind.Utc);
 				DateTime converted = TimeZoneInfo.ConvertTimeFromUtc (utc, TimeZoneInfo.Local);
-				Assert.AreEqual (DateTimeKind.Local, converted.Kind);
+				var expectedKind = (TimeZoneInfo.Local == TimeZoneInfo.Utc)? DateTimeKind.Utc : DateTimeKind.Local;
+				Assert.AreEqual (expectedKind, converted.Kind);
 				DateTime back = TimeZoneInfo.ConvertTimeToUtc (converted, TimeZoneInfo.Local);
 				Assert.AreEqual (back.Kind, DateTimeKind.Utc);
 				Assert.AreEqual (utc, back);
@@ -551,8 +566,9 @@ namespace MonoTests.System
 
 				sdt = new DateTime (2014, 1, 9, 23, 0, 0);
 				ddt = TimeZoneInfo.ConvertTime (sdt, TimeZoneInfo.Local);
-				Assert.AreEqual (ddt.Kind, sdt.Kind, "#3.1");
-				Assert.AreEqual (ddt.Kind, DateTimeKind.Unspecified, "#3.2");
+				var expectedKind = (TimeZoneInfo.Local == TimeZoneInfo.Utc)? DateTimeKind.Utc : sdt.Kind;
+				Assert.AreEqual (expectedKind,  ddt.Kind, "#3.1");
+				Assert.AreEqual (DateTimeKind.Unspecified, sdt.Kind, "#3.2");
 			}
 
 			[Test]


### PR DESCRIPTION
Fixes TimeZoneInfo.ConvertTimeFromUtc and related tests when
TimeZoneInfo.Local is equal to TimeZoneInfo.Utc.

In .NET if we set TimeZoneInfo.Local to TimeZoneInfo.Utc by using
reflection.

```
var cachedDataField = typeof (TimeZoneInfo).GetField ("s_cachedData",
BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);

var localField = cachedDataField.FieldType.GetField ("m_localTimeZone",
BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic);

var localFieldObj = cachedDataField.GetValue (null);

localField.SetValue (localFieldObj, DateTimeKind.Utc);
```

We can observe that `TimeZoneInfo.ConvertTimeFromUtc (DateTime.UtcNow,
TimeZoneInfo.Local).Kind` is DateTimeKind.Utc.

By looking at reference source [code](http://referencesource.microsoft.com/#mscorlib/system/timezoneinfo.cs,211)
we can also confirm that while getting a time zone corresponding kind,
Utc is prioritized over Local.

This commit reverts changes introduced by 60d5b39 that were prioritizing Local
over Utc and changes tests to expect Utc kinds instead of Local when
TimeZoneInfo.Local is equal to TimeZoneInfo.Utc.