### PR TITLE
Move monolite URL to Jenkins, not Boston NAS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ DISTCLEANFILES= mono-uninstalled.pc
 mcslib = $(mcs_topdir)/class/lib
 monolite = $(mcslib)/monolite
 mono_corlib_version = $(shell sed -n "s/\#define MONO_CORLIB_VERSION //p" $(srcdir)/mono/metadata/appdomain.c)
-monolite_url = http://storage.bos.xamarin.com/mono-dist-master/latest/monolite-$(mono_corlib_version)-latest.tar.gz
+monolite_url = http://download.mono-project.com/monolite/monolite-$(mono_corlib_version)-latest.tar.gz
 .PHONY: get-monolite-latest 
 get-monolite-latest:
 	-rm -fr $(mcslib)/monolite-*


### PR DESCRIPTION
This is the first step for replacing public Wrench with Jenkins, since it's the only part of public Wrench which is used in important places