### PR TITLE
Added DataProtector and DpapiDataProtector classes. fixes #22336

### DIFF
--- a/mcs/class/System.Security/System.Security.Cryptography/DataProtector.cs
+++ b/mcs/class/System.Security/System.Security.Cryptography/DataProtector.cs
@@ -1,0 +1,183 @@
+//
+// DataProtector.cs: Provides the base class for simple data protectors
+//
+// Author:
+//	Robert J. van der Boon  <rjvdboon@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace System.Security.Cryptography {
+	/// <summary>Provides the base class for simple data protectors.</summary>
+	public abstract class DataProtector {
+		byte [] hashed_purpose;
+
+		/// <summary>Gets the name of the application.</summary>
+		/// <returns>The name of the application.</returns>
+		protected string ApplicationName {
+			get; private set;
+		}
+
+		/// <summary>Gets the primary purpose for the protected data.</summary>
+		/// <returns>The primary purpose for the protected data.</returns>
+		protected string PrimaryPurpose {
+			get; private set;
+		}
+
+		/// <summary>Gets the specific purposes for the protected data.</summary>
+		/// <returns>A collection of the specific purposes for the protected data.</returns>
+		protected IEnumerable<string> SpecificPurposes {
+			get; private set;
+		}
+		
+		/// <summary>Gets whether the hash is prepended to the byte array before encryption.</summary>
+		/// <returns>Always true, unless overridden in a derived type.</returns>
+		protected virtual bool PrependHashedPurposeToPlaintext {
+			get {
+				return true;
+			}
+		}
+
+		/// <summary>Creates a new instance of the <see cref="DataProtector" /> class by using the provided application
+		/// name, primary purpose, and (optional) specific purposes.</summary>
+		/// <param name="applicationName">The name of the application.</param>
+		/// <param name="primaryPurpose">The primary purpose.</param>
+		/// <param name="specificPurposes">The specific purposes.</param>
+		/// <exception cref="ArgumentException">
+		///      <paramref name="applicationName" /> is an empty string, a string containing only whitespace, or null.
+		/// -or- <paramref name="primaryPurpose" /> is an empty string, a string containing only whitespace, or null.
+		/// -or- <paramref name="specificPurposes" /> contains an empty string, a string containing only whitespace, or null.</exception>
+		protected DataProtector (string applicationName, string primaryPurpose, params string [] specificPurposes)
+		{
+			// The .Net documentation states "empty", but testing on .Net shows that whitespace is not allowed either
+			if (string.IsNullOrWhiteSpace (applicationName))
+				throw new ArgumentException ("The applicationName is missing", "applicationName");
+			// The .Net documentation states "empty", but testing on .Net shows that whitespace is not allowed either
+			if (string.IsNullOrWhiteSpace (primaryPurpose))
+				throw new ArgumentException ("The primaryPurpose is missing", "primaryPurpose");
+			if (specificPurposes != null) {
+				foreach (string specificPurpose in specificPurposes)
+					// The .Net documentation states "empty", but testing on .Net shows that whitespace is not allowed either
+					if (string.IsNullOrWhiteSpace (specificPurpose))
+						throw new ArgumentException ("A specificPurpose is null or empty", "specificPurposes");
+			}
+			ApplicationName = applicationName;
+			PrimaryPurpose = primaryPurpose;
+			SpecificPurposes = specificPurposes == null ? new List<string>(0) : new List<string>(specificPurposes);
+		}
+
+		/// <summary>Creates an instance of a data protector implementation by using the specified class name
+		/// of the data protector, the application name, the primary purpose, and the (optional) specific purposes.</summary>
+		/// <param name="providerClass">The class name for the data protector.</param>
+		/// <param name="applicationName">The name of the application.</param>
+		/// <param name="primaryPurpose">The primary purpose.</param>
+		/// <param name="specificPurposes">The specific purposes.</param>
+		/// <returns>A data protector implementation object.</returns>
+		/// <exception cref="ArgumentNullException">
+		///   <paramref name="providerClass" /> is null.</exception>
+		public static DataProtector Create (string providerClass, string applicationName, string primaryPurpose, params string [] specificPurposes)
+		{
+			if (providerClass == null)
+				throw new ArgumentNullException ("providerClass");
+			return (DataProtector)CryptoConfig.CreateFromName (providerClass, new object [] { applicationName, primaryPurpose, specificPurposes });
+		}
+
+		/// <summary>Creates a hash of the property values specified by the constructor.</summary>
+		/// <returns>the hash of the <see cref="ApplicationName" />, <see cref="PrimaryPurpose" />, and <see cref="SpecificPurposes" /> properties.</returns>
+		public byte [] GetHashedPurpose ()
+		{
+			if (hashed_purpose != null)
+				return hashed_purpose;
+			using (var memoryStream = new MemoryStream ()) {
+				using (var binaryWriter = new BinaryWriter (memoryStream)) {
+					binaryWriter.Write (ApplicationName);
+					binaryWriter.Write (PrimaryPurpose);
+					foreach (string specificPurpose in SpecificPurposes)
+						binaryWriter.Write (specificPurpose);
+				}
+				using (var hashAlgorithm = HashAlgorithm.Create ("SHA256")) {
+					hashed_purpose = hashAlgorithm.ComputeHash (memoryStream.ToArray());
+				}
+			}
+			return hashed_purpose;
+		}
+
+		/// <summary>Determines if re-encryption is required for the specified encrypted data.</summary>
+		/// <param name="encryptedData">The encrypted data to be evaluated.</param>
+		/// <returns>true if the data must be re-encrypted; otherwise, false.</returns>
+		public abstract bool IsReprotectRequired (byte [] encryptedData);
+
+		/// <summary>Protects the specified data.</summary>
+		/// <param name="userData">The user data to be protected.</param>
+		/// <returns>A byte array with the encrypted data.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="userData" /> is null.</exception>
+		public byte [] Protect (byte [] userData)
+		{
+			if (userData == null)
+				throw new ArgumentNullException ("userData");
+			if (!PrependHashedPurposeToPlaintext)
+				return ProviderProtect (userData);
+
+			byte [] userDataToProtect;
+			var prepend = GetHashedPurpose ();
+			userDataToProtect = new byte [prepend.Length + userData.Length];
+			Array.Copy (prepend, 0, userDataToProtect, 0, prepend.Length);
+			Array.Copy (userData, 0, userDataToProtect, prepend.Length, userData.Length);
+			return ProviderProtect (userDataToProtect);
+		}
+
+		/// <summary>Specifies the delegate method in the derived class that <see cref="Protect(byte[])" /> calls.</summary>
+		/// <param name="userData">The user data.</param>
+		/// <returns>A byte array with the encrypted data.</returns>
+		protected abstract byte [] ProviderProtect (byte [] userData);
+
+		/// <summary>Specifies the delegate method in the derived class that <see cref="Unprotect(byte[])" /> calls.</summary>
+		/// <param name="encryptedData">The encrypted data.</param>
+		/// <returns>A byte array with the clear text user data.</returns>
+		protected abstract byte [] ProviderUnprotect (byte [] encryptedData);
+
+		/// <summary>Unprotects the specified data.</summary>
+		/// <param name="encryptedData">The encrypted data.</param>
+		/// <returns>A byte array with the clear text user data.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="encryptedData" /> is null.</exception>
+		/// <exception cref="CryptographicException"><paramref name="encryptedData" /> contained an invalid purpose.</exception>
+		public byte [] Unprotect (byte [] encryptedData)
+		{
+			if (encryptedData == null)
+				throw new ArgumentNullException ("encryptedData");
+			byte [] unprotectedData = ProviderUnprotect (encryptedData);
+			if (!PrependHashedPurposeToPlaintext)
+				return unprotectedData;
+
+			byte [] hashedToCheck = GetHashedPurpose ();
+			if (unprotectedData.Length < hashedToCheck.Length)
+				throw new CryptographicException ("The purpose of the protected blob does not match the expected purpose value of this data protector instance.");
+			for (int i = 0; i < hashedToCheck.Length; i++)
+				if (hashedToCheck [i] != unprotectedData [i])
+					throw new CryptographicException ("The purpose of the protected blob does not match the expected purpose value of this data protector instance.");
+
+			byte [] clearTextData = new byte [unprotectedData.Length - hashedToCheck.Length];
+			Array.Copy (unprotectedData, hashedToCheck.Length, clearTextData, 0, clearTextData.Length);
+			return clearTextData;
+		}
+	}
+}

--- a/mcs/class/System.Security/System.Security.Cryptography/DpapiDataProtector.cs
+++ b/mcs/class/System.Security/System.Security.Cryptography/DpapiDataProtector.cs
@@ -1,0 +1,84 @@
+﻿//
+// DpapiDataProtector.cs: Protect (encrypt) data without (user involved) key management
+//
+// Author:
+//	Robert J. van der Boon  <rjvdboon@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace System.Security.Cryptography {
+	/// <summary>Provides Data Protection through the <see cref="ProtectedData"/> class.</summary>
+	public sealed class DpapiDataProtector : DataProtector {
+		/// <summary>Gets or sets the scope of the data protection. The default is <see cref="DataProtectionScope.CurrentUser" />.</summary>
+		public DataProtectionScope Scope {
+			get; set;
+		}
+
+		/// <summary>Specifies whether the hash is prepended to the byte array before encryption.</summary>
+		/// <returns>Always false, as the hash is used as additional entropy in the <see cref="ProtectedData"/> calls.</returns>
+		protected override bool PrependHashedPurposeToPlaintext {
+			get {
+				return false;
+			}
+		}
+
+		/// <summary>Creates a new instance of the <see cref="DpapiDataProtector" /> class by using the specified
+		/// application name, primary purpose, and specific purposes.</summary>
+		/// <param name="applicationName">The name of the application.</param>
+		/// <param name="primaryPurpose">The primary purpose for the data protector.</param>
+		/// <param name="specificPurposes">The specific purpose(s) for the data protector.</param>
+		/// <exception cref="ArgumentException">
+		///      <paramref name="applicationName" /> is an empty string, a string constisting of only whitespace, or null.
+		/// -or- <paramref name="primaryPurpose" /> is an empty string, a string constisting of only whitespace, or null.
+		/// -or- <paramref name="specificPurposes" /> contains an empty string, a string constisting of only whitespace, or null.</exception>
+		public DpapiDataProtector (string applicationName, string primaryPurpose, params string [] specificPurposes)
+			: base (applicationName, primaryPurpose, specificPurposes)
+		{
+			Scope = DataProtectionScope.CurrentUser;
+		}
+		/// <summary>Determines if the data must be re-encrypted.</summary>
+		/// <param name="encryptedData">The encrypted data to be checked.</param>
+		/// <returns>Always true.</returns>
+		public override bool IsReprotectRequired (byte [] encryptedData)
+		{
+			return true;
+		}
+
+		/// <summary>Specifies the delegate method in the derived class that the <see cref="DataProtector.Protect(byte[])" />
+		/// method in the base class calls back into.
+		/// This calls directly into <see cref="ProtectedData.Protect(byte[],byte[],DataProtectionScope)"/>.</summary>
+		/// <param name="userData">The user data.</param>
+		/// <returns>A byte array with the encrypted data.</returns>
+		protected override byte [] ProviderProtect (byte [] userData)
+		{
+			return ProtectedData.Protect (userData, GetHashedPurpose (), Scope);
+		}
+
+		/// <summary>Specifies the delegate method in the derived class that the <see cref="DataProtector.Unprotect(byte[])" />
+		///  method in the base class calls back into.
+		/// This calls directly into <see cref="ProtectedData.Unprotect(byte[],byte[],DataProtectionScope)"/>.</summary>
+		/// <param name="encryptedData">The data to be unencrypted.</param>
+		/// <returns>A byte array with the clear text data.</returns>
+		protected override byte [] ProviderUnprotect (byte [] encryptedData)
+		{
+			return ProtectedData.Unprotect (encryptedData, GetHashedPurpose (), Scope);
+		}
+	}
+}

--- a/mcs/class/System.Security/System.Security.dll.sources
+++ b/mcs/class/System.Security/System.Security.dll.sources
@@ -11,6 +11,8 @@ System.Security.Cryptography/DataProtectionScope.cs
 System.Security.Cryptography/MemoryProtectionScope.cs
 System.Security.Cryptography/ProtectedData.cs
 System.Security.Cryptography/ProtectedMemory.cs
+System.Security.Cryptography/DataProtector.cs
+System.Security.Cryptography/DpapiDataProtector.cs
 System.Security.Cryptography.Pkcs/AlgorithmIdentifier.cs
 System.Security.Cryptography.Pkcs/ContentInfo.cs
 System.Security.Cryptography.Pkcs/EnvelopedCms.cs

--- a/mcs/class/System.Security/System.Security_test.dll.sources
+++ b/mcs/class/System.Security/System.Security_test.dll.sources
@@ -1,6 +1,8 @@
 System.Security.Cryptography/CryptographicAttributeObjectCollectionTest.cs
 System.Security.Cryptography/CryptographicAttributeObjectEnumeratorTest.cs
 System.Security.Cryptography/CryptographicAttributeTest.cs
+System.Security.Cryptography/DataProtectorTest.cs
+System.Security.Cryptography/DpapiDataProtectorTest.cs
 System.Security.Cryptography/ProtectedDataTest.cs
 System.Security.Cryptography/ProtectedMemoryTest.cs
 System.Security.Cryptography.Pkcs/AlgorithmIdentifierTest.cs

--- a/mcs/class/System.Security/Test/System.Security.Cryptography/DataProtectorTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography/DataProtectorTest.cs
@@ -1,0 +1,275 @@
+﻿//
+// DataProtectorTest.cs: Test the DataProtector base class for simple data protectors
+//
+// Author:
+//	Robert J. van der Boon  <rjvdboon@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Security.Cryptography;
+using System.Reflection;
+
+using NUnit.Framework;
+
+namespace MonoTests.System.Security.Cryptography {
+	[TestFixture]
+	public class DataProtectorTest {
+		#region Dummy Data Protector to help test DataProtector base class
+		public class DummyDataProtector : DataProtector {
+			internal bool prepend_hash;
+			public DummyDataProtector (string appName, string primPurp, params string [] specPurp)
+				: base (appName, primPurp, specPurp)
+			{
+			}
+			public override bool IsReprotectRequired (byte [] encryptedData)
+			{
+				return true;
+			}
+
+			protected override byte [] ProviderProtect (byte [] userData)
+			{
+				byte[] protectedData = new byte [userData.Length];
+				for (int i = 0; i < userData.Length; i++)
+					protectedData [i] = userData [userData.Length - 1 - i];
+				return protectedData;
+			}
+
+			protected override byte [] ProviderUnprotect (byte [] encryptedData)
+			{
+				byte[] unprotectedData = new byte [encryptedData.Length];
+				for (int i = 0; i < encryptedData.Length; i++)
+					unprotectedData [i] = encryptedData [encryptedData.Length - 1 - i];
+				return unprotectedData;
+			}
+			protected override bool PrependHashedPurposeToPlaintext {
+				get {
+					return prepend_hash;
+				}
+			}
+		}
+		#endregion
+
+		#region Tests DataProtector.Create
+		[Test]
+		public void TestCreate ()
+		{
+			string protectorType = typeof (DummyDataProtector).AssemblyQualifiedName;
+			var specificPurposes = new string [] { "spec1", "spec2" };
+			var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+			Assert.IsNotNull (protector, "DummyDataProtector");
+
+			protectorType = "System.Security.Cryptography.NonExistingDataProtector";
+			protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+			Assert.IsNull (protector, "NonExistingDataProtector");
+		}
+
+		[Test]
+		public void TestCreateConstructorRequiredArgumentsWithDummyDataProtector ()
+		{
+			string protectorType = typeof (DummyDataProtector).AssemblyQualifiedName;
+			try {
+				var specificPurposes = new string [] { "spec1", "spec2" };
+				var protector = DataProtector.Create (protectorType, "", "prim", specificPurposes);
+				Assert.Fail ("should have failed on empty app name");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("applicationName", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "spec1", "spec2" };
+				var protector = DataProtector.Create (protectorType, (string)null, "prim", specificPurposes);
+				Assert.Fail ("should have failed on null app name");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("applicationName", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "spec1", "spec2" };
+				var protector = DataProtector.Create (protectorType, "  ", "prim", specificPurposes);
+				Assert.Fail ("should have failed on whitespace app name");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("applicationName", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", "", specificPurposes);
+				Assert.Fail ("should have failed on empty primaryPurpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("primaryPurpose", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", null, specificPurposes);
+				Assert.Fail ("should have failed on null primaryPurpose ");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("primaryPurpose", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", "\t", specificPurposes);
+				Assert.Fail ("should have failed on whitespace primaryPurpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("primaryPurpose", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on null specific purposes");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "\r\n", "spec2" };
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on null specific purpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { null, "spec2" };
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on null specific purpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "spec1", "" };
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on empty specific purpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof(ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+		}
+		#endregion
+
+		[Test]
+		public void TestDataIsPrependedWithHashBeforeProtectingWhenPrependHashedPurposeToPlaintextIsTrue ()
+		{
+			var protector = new DummyDataProtector ("app", "prim");
+			protector.prepend_hash = true;
+			byte [] userData = new byte [] { 1, 2, 3, 4 };
+			byte[] encryptedData = protector.Protect (userData);
+			// SHA256 hash size is 32 bytes
+			Assert.AreEqual (userData.Length + 32, encryptedData.Length, "hash length");
+			for (int i = 0; i < userData.Length; i++) {
+				Assert.AreEqual (userData [i], encryptedData [userData.Length - 1 - i], "encrypted data #" + i.ToString());
+			}
+
+			// Protect again, now with differnt primary purpose should result in different protected data
+			var protectorWithDifferentPrimaryPurpose = new DummyDataProtector ("app", "prim2");
+			protectorWithDifferentPrimaryPurpose.prepend_hash = true;
+			byte [] encryptedData1 = protectorWithDifferentPrimaryPurpose.Protect (userData);
+			bool allBytesEqual = true;
+			for (int i = 4; i < encryptedData.Length; i++) {
+				if (encryptedData [i] != encryptedData1 [i]) {
+					allBytesEqual = false;
+					break;
+				}
+			}
+			Assert.IsFalse (allBytesEqual, "different primary purpose must result in different encrypted data");
+
+			// Protect again, now with specific purpose should result in different protected data
+			var protectorWithSpecificPurpose = new DummyDataProtector ("app", "prim", "spec1", "spec2");
+			protectorWithSpecificPurpose.prepend_hash = true;
+			byte [] encryptedData2 = protectorWithSpecificPurpose.Protect (userData);
+			allBytesEqual = true;
+			for (int i = 4; i < encryptedData.Length; i++) {
+				if (encryptedData [i] != encryptedData2 [i]) {
+					allBytesEqual = false;
+					break;
+				}
+			}
+			Assert.IsFalse(allBytesEqual, "with specific purpose must result in different encrypted data");
+
+			// Protect again, now with different app name should result in different protected data
+			var protectorWithDifferentAppName = new DummyDataProtector ("app2", "prim");
+			protectorWithDifferentAppName.prepend_hash = true;
+			byte [] encryptedData3 = protectorWithDifferentAppName.Protect (userData);
+			allBytesEqual = true;
+			for (int i = 4; i < encryptedData.Length; i++) {
+				if (encryptedData [i] != encryptedData3 [i]) {
+					allBytesEqual = false;
+					break;
+				}
+			}
+			Assert.IsFalse (allBytesEqual, "different applicationName must result in different encrypted data");
+		}
+		[Test]
+		public void TestDataIsNotPrependedWithHashBeforeProtectingWhenPrependHashedPurposeToPlaintextIsFalse ()
+		{
+			var protector = new DummyDataProtector ("app", "prim");
+			protector.prepend_hash = false;
+			byte [] userData = new byte [] { 1, 2, 3, 4 };
+			byte [] encryptedData = protector.Protect (userData);
+			Assert.AreEqual(encryptedData.Length, userData.Length, "length");
+			for (int i = 0; i < userData.Length; i++)
+				Assert.AreEqual (userData [i], encryptedData [userData.Length - 1 - i], "#" + i.ToString());
+		}
+		[Test]
+		public void TestProtectUnprotect ()
+		{
+			var protector = new DummyDataProtector ("app", "prim", "spec1");
+			protector.prepend_hash = false;
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+
+			var roundTrip = protector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundTrip, "#1");
+		}
+		[Test]
+		public void TestProtectUnprotectWithPrependedHash ()
+		{
+			var protector = new DummyDataProtector ("app", "prim", "spec1");
+			protector.prepend_hash = true;
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+
+			var roundTrip = protector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundTrip, "#1");
+
+			// Should fail on tampered hash
+			var protectedData = protector.Protect (userData);
+			protectedData [protectedData.Length - 5] = (byte)(protectedData [protectedData.Length - 5] ^ 0x12);
+			try {
+				protector.Unprotect (protectedData);
+				Assert.Fail ("Should have failed on invalid hash");
+			} catch (CryptographicException cryptoEx) {
+				Assert.AreEqual("The purpose of the protected blob does not match the expected purpose value of this data protector instance.", cryptoEx.Message, "#2");
+			}
+
+		}
+	}
+}

--- a/mcs/class/System.Security/Test/System.Security.Cryptography/DpapiDataProtectorTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography/DpapiDataProtectorTest.cs
@@ -1,0 +1,224 @@
+﻿//
+// DataProtectorTest.cs: Test the DataProtector base class for simple data protectors
+//
+// Author:
+//	Robert J. van der Boon  <rjvdboon@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Security.Cryptography;
+using System.Reflection;
+
+using NUnit.Framework;
+
+namespace MonoTests.System.Security.Cryptography {
+	[TestFixture]
+	public class DpapiDataProtectorTest {
+		#region Tests DataProtector.Create
+		[Test]
+		public void TestCreate ()
+		{
+			string protectorType = typeof (DpapiDataProtector).AssemblyQualifiedName;
+			var specificPurposes = new string [] { "spec1", "spec2" };
+			var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+			Assert.IsNotNull (protector, "DpapiDataProtector by AssemblyQualifiedName");
+
+			protectorType = typeof (DpapiDataProtector).FullName;
+			protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+			Assert.IsNotNull (protector, "DpapiDataProtector by Namespace.TypeName");
+		}
+
+		[Test]
+		public void TestCreateConstructorRequiredArgumentsWithDpapiDataProtector ()
+		{
+			string protectorType = "System.Security.Cryptography.DpapiDataProtector";
+			try {
+				var specificPurposes = new string [] { "spec1", "spec2" };
+				var protector = DataProtector.Create (protectorType, "", "prim", specificPurposes);
+				Assert.Fail ("should have failed on empty app name");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("applicationName", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "spec1", "spec2" };
+				var protector = DataProtector.Create (protectorType, (string)null, "prim", specificPurposes);
+				Assert.Fail ("should have failed on null app name");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("applicationName", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "spec1", "spec2" };
+				var protector = DataProtector.Create (protectorType, "  ", "prim", specificPurposes);
+				Assert.Fail ("should have failed on whitespace app name");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("applicationName", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", "", specificPurposes);
+				Assert.Fail ("should have failed on empty primaryPurpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("primaryPurpose", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", null, specificPurposes);
+				Assert.Fail ("should have failed on null primaryPurpose ");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("primaryPurpose", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", "\t", specificPurposes);
+				Assert.Fail ("should have failed on whitespace primaryPurpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("primaryPurpose", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = (string [])null;
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on null specific purposes");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "\r\n", "spec2" };
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on null specific purpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { null, "spec2" };
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on null specific purpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+
+			try {
+				var specificPurposes = new string [] { "spec1", "" };
+				var protector = DataProtector.Create (protectorType, "app", "prim", specificPurposes);
+				Assert.Fail ("should have failed on empty specific purpose");
+			} catch (TargetInvocationException tie) {
+				Assert.IsInstanceOfType (typeof (ArgumentException), tie.InnerException);
+				Assert.AreEqual ("specificPurposes", ((ArgumentException)tie.InnerException).ParamName);
+			}
+		}
+		#endregion
+
+		[Test]
+		public void TestProtectUnprotectWithDefaultScope ()
+		{
+			var protector = new DpapiDataProtector ("app", "prim", "spec1");
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+
+			var roundTrip = protector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundTrip, "#1");
+		}
+
+		[Test]
+		public void TestDefaultScopeIsCurrentUserScope ()
+		{
+			var protector = new DpapiDataProtector ("app", "prim", "spec1");
+			Assert.AreEqual (DataProtectionScope.CurrentUser, protector.Scope);
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+
+			var unprotector = new DpapiDataProtector ("app", "prim", "spec1") {
+				Scope = DataProtectionScope.CurrentUser
+			};
+			var roundTrip = unprotector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundTrip, "#1");
+		}
+
+		[Test]
+		public void TestProtectUnprotectWithExplicitUserScope ()
+		{
+			var protector = new DpapiDataProtector ("app", "prim", "spec1") {
+				Scope = DataProtectionScope.CurrentUser
+			};
+			Assert.AreEqual (DataProtectionScope.CurrentUser, protector.Scope);
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+
+			var roundTrip = protector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundTrip, "#1");
+		}
+		[Test]
+		public void TestProtectUnprotectWithExplicitMachineScope ()
+		{
+			var protector = new DpapiDataProtector ("app", "prim", "spec1") {
+				Scope = DataProtectionScope.LocalMachine
+			};
+			Assert.AreEqual (DataProtectionScope.LocalMachine, protector.Scope);
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+
+			var roundTrip = protector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundTrip, "#1");
+		}
+
+		[Test]
+		[Ignore("MONO's ProtectedData implementation does not detect the scope during Unprotect")]
+		public void TestProtectWithUserScopeUnprotectWithMachineScopeIgnoresScopeOnUnprotect ()
+		{
+			var protector = new DpapiDataProtector ("app", "prim", "spec1") {
+				Scope = DataProtectionScope.CurrentUser
+			};
+			var unprotector = new DpapiDataProtector ("app", "prim", "spec1") {
+				Scope = DataProtectionScope.LocalMachine
+			};
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+			var roundtrip = unprotector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundtrip);
+		}
+
+		[Test]
+		[Ignore("MONO's ProtectedData implementation does not detect the scope during Unprotect")]
+		public void TestProtectWithMachineScopeUnprotectWithUserScopeIgnoresScopeOnUnprotect ()
+		{
+			var protector = new DpapiDataProtector ("app", "prim", "spec1") {
+				Scope = DataProtectionScope.LocalMachine
+			};
+			var unprotector = new DpapiDataProtector ("app", "prim", "spec1") {
+				Scope = DataProtectionScope.CurrentUser
+			};
+			var userData = new byte [] { 9, 1, 5, 1, 55, 23, 12 };
+			var roundtrip = unprotector.Unprotect (protector.Protect (userData));
+			Assert.AreEqual (userData, roundtrip);
+		}
+	}
+}

--- a/mcs/class/corlib/System.Security.Cryptography/CryptoConfig.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/CryptoConfig.cs
@@ -273,6 +273,12 @@ public partial class CryptoConfig {
 	// SHA512 provider
 	const string nameSHA512Provider = "System.Security.Cryptography.SHA512CryptoServiceProvider";
 	const string defaultSHA512Provider = "System.Security.Cryptography.SHA512CryptoServiceProvider" + system_core_assembly;
+	
+	// LAMESPEC: directly from Reference Source
+	const string defaultDpapiDataProtector = defaultNamespace + "DpapiDataProtector, " + Consts.AssemblySystem_Security;
+	const string nameDpapiDataProtector_1 = defaultNamespace + "DpapiDataProtector";
+	const string nameDpapiDataProtector_2 = "DpapiDataProtector";
+	
 	static CryptoConfig () 
 	{
 		// lock(this) is bad
@@ -413,6 +419,9 @@ public partial class CryptoConfig {
 		unresolved_algorithms.Add (nameSHA384Provider, defaultSHA384Provider);
 		unresolved_algorithms.Add (nameSHA512Cng, defaultSHA512Cng);
 		unresolved_algorithms.Add (nameSHA512Provider, defaultSHA512Provider);
+		unresolved_algorithms.Add (nameDpapiDataProtector_1, defaultDpapiDataProtector);
+		unresolved_algorithms.Add (nameDpapiDataProtector_2, defaultDpapiDataProtector);
+		
 		Dictionary<string,string> oid = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
 		// comments here are to match with MS implementation (but not with doc)
@@ -492,24 +501,18 @@ public partial class CryptoConfig {
 				Initialize ();
 			}
 		}
-	
-		try {
-			Type algoClass = null;
-			if (!algorithms.TryGetValue (name, out algoClass)) {
-				string algo = null;
-				if (!unresolved_algorithms.TryGetValue (name, out algo))
-						algo = name;
-				algoClass = Type.GetType (algo);
-			}
-			if (algoClass == null)
-				return null;
-			// call the constructor for the type
-			return Activator.CreateInstance (algoClass, args);
+
+		Type algoClass = null;
+		if (!algorithms.TryGetValue (name, out algoClass)) {
+			string algo = null;
+			if (!unresolved_algorithms.TryGetValue (name, out algo))
+					algo = name;
+			algoClass = Type.GetType (algo);
 		}
-		catch {
-			// method doesn't throw any exception
+		if (algoClass == null)
 			return null;
-		}
+		// call the constructor for the type
+		return Activator.CreateInstance (algoClass, args);
 	}
 
 	internal static string MapNameToOID (string name, OidGroup oidGroup)


### PR DESCRIPTION
These were introduced in .Net 4.5 and are used by Owin 3 security components.
Also changed CryptoConfig.CreateFromName to not swallow exceptions.

This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=22336