### PR TITLE
[profiler] Emit NUnit xml report of test result in ptestrunner.pl

### DIFF
--- a/mono/profiler/ptestrunner.pl
+++ b/mono/profiler/ptestrunner.pl
@@ -104,6 +104,8 @@ check_alloc_traces ($report,
 );
 report_errors ();
 
+emit_nunit_report();
+
 exit ($total_errors? 1: 0);
 
 # utility functions
@@ -157,6 +159,61 @@ sub report_errors
 	}
 	print "Total errors: $total_errors\n" if $total_errors;
 	#print $report;
+}
+
+sub emit_nunit_report
+{
+	use Cwd;
+	use POSIX qw(strftime uname locale_h);
+	use Net::Domain qw(hostname hostfqdn);
+	use locale;
+
+	my $failed = $total_errors ? 1 : 0;
+	my $successbool;
+	my $total = 1;
+	my $mylocale = setlocale (LC_CTYPE);
+	$mylocale = substr($mylocale, 0, index($mylocale, '.'));
+	$mylocale =~ s/_/-/;
+
+	if ($failed > 0) {
+		$successbool = "False";
+	} else {
+		$successbool = "True";
+	}
+	open (my $nunitxml, '>', 'TestResults_profiler.xml') or die "Could not write to 'TestResults_profiler.xml' $!";
+	print $nunitxml "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n";
+	print $nunitxml "<!--This file represents the results of running a test suite-->\n";
+	print $nunitxml "<test-results name=\"profiler-tests.dummy\" total=\"$total\" failures=\"$failed\" not-run=\"0\" date=\"" . strftime ("%F", localtime) . "\" time=\"" . strftime ("%T", localtime) . "\">\n";
+	print $nunitxml "  <environment nunit-version=\"2.4.8.0\" clr-version=\"4.0.30319.17020\" os-version=\"Unix " . (uname ())[2]  . "\" platform=\"Unix\" cwd=\"" . getcwd . "\" machine-name=\"" . hostname . "\" user=\"" . getpwuid ($<) . "\" user-domain=\"" . hostfqdn  . "\" />\n";
+	print $nunitxml "  <culture-info current-culture=\"$mylocale\" current-uiculture=\"$mylocale\" />\n";
+	print $nunitxml "  <test-suite name=\"profiler-tests.dummy\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
+	print $nunitxml "    <results>\n";
+	print $nunitxml "      <test-suite name=\"MonoTests\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
+	print $nunitxml "        <results>\n";
+	print $nunitxml "          <test-suite name=\"profiler\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
+	print $nunitxml "            <results>\n";
+	print $nunitxml "              <test-case name=\"MonoTests.profiler.100percentsuccess\" executed=\"True\" success=\"$successbool\" time=\"0\" asserts=\"0\"";
+	if ( $failed > 0) {
+	print $nunitxml ">\n";
+	print $nunitxml "                <failure>\n";
+	print $nunitxml "                  <message><![CDATA[";
+	print $nunitxml "The profiler tests returned an error. Check the log for more details.";
+	print $nunitxml "]]></message>\n";
+	print $nunitxml "                  <stack-trace>\n";
+	print $nunitxml "                  </stack-trace>\n";
+	print $nunitxml "                </failure>\n";
+	print $nunitxml "              </test-case>\n";
+	} else {
+	print $nunitxml " />\n";
+	}
+	print $nunitxml "            </results>\n";
+	print $nunitxml "          </test-suite>\n";
+	print $nunitxml "        </results>\n";
+	print $nunitxml "      </test-suite>\n";
+	print $nunitxml "    </results>\n";
+	print $nunitxml "  </test-suite>\n";
+	print $nunitxml "</test-results>\n";
+	close $nunitxml;
 }
 
 sub get_delim_data


### PR DESCRIPTION
Currently only emits a single pass/fail testcase as capturing the individual errors
and test counts would be much more invasive to the script.

The bulk of the logic is copied from [mono/mini/emitnunit.pl](https://github.com/mono/mono/blob/b3fa096e5eceea1c3b289b3655244a42c2884274/mono/mini/emitnunit.pl).

This makes it possible for Jenkins to pick up profiler test failures instead of silently ignoring them (as right now).