### PR TITLE
[System.Net.Http] Fix custom Host header not being set on requests

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -272,6 +272,11 @@ namespace System.Net.Http
 				wr.Proxy = proxy;
 			}
 
+			//Host must be explicitly set for HttpWebRequest
+			if (request.Headers.Host != null) {
+				wr.Host = request.Headers.Host;
+			}
+
 			// Add request headers
 			var headers = wr.Headers;
 			foreach (var header in request.Headers) {

--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -607,6 +607,39 @@ namespace MonoTests.System.Net.Http
 		}
 
 		[Test]
+		public void Send_Complete_CustomHeaders_Host ()
+		{
+			bool? failed = null;
+			var listener = CreateListener (l => {
+				var request = l.Request;
+
+				try {
+					Assert.AreEqual ("customhost", request.Headers["Host"], "#1");
+					failed = false;
+				} catch {
+					failed = true;
+				}
+			});
+
+			try {
+				var client = new HttpClient ();
+
+				client.DefaultRequestHeaders.Add("Host", "customhost");
+
+				var request = new HttpRequestMessage (HttpMethod.Get, LocalServer);
+
+				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
+
+				Assert.AreEqual ("", response.Content.ReadAsStringAsync ().Result, "#100");
+				Assert.AreEqual (HttpStatusCode.OK, response.StatusCode, "#101");
+				Assert.AreEqual (false, failed, "#102");
+			} finally {
+				listener.Abort ();
+				listener.Close ();
+			}
+		}
+
+		[Test]
 		public void Send_Transfer_Encoding_Chunked ()
 		{
 			bool? failed = null;


### PR DESCRIPTION
Fixes #34044.

This is necessary because HttpWebRequest overwrites the Host header, unless it is set by using the Host property: [HttpWebRequest.GetHeaders](https://github.com/mono/mono/blob/88d2b9da2a87b4e5c82abaea4e5110188d49601d/mcs/class/System/System.Net/HttpWebRequest.cs#L1175)