### PR TITLE
[unit-tests] Emit NUnit xml report of test result

### DIFF
--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -7,6 +7,7 @@ if PLATFORM_DARWIN
 test_ldflags = -framework CoreFoundation -framework Foundation
 endif
 
+AUTOMAKE_OPTIONS = parallel-tests
 
 if !CROSS_COMPILE
 if !HOST_WIN32
@@ -39,6 +40,14 @@ test_conc_hashtable_LDFLAGS = $(test_ldflags)
 noinst_PROGRAMS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable
 
 TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable
+
+.NOTPARALLEL:
+
+check-local:
+	if grep -q "# FAIL:  0\|tests passed" test-suite.log; then successbool=True && failures=0; else successbool=False && failures=1; fi; \
+	echo "<?xml version='1.0' encoding='utf-8'?><test-results failures='$$failures' total='1' not-run='0' name='unit-tests.dummy' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='MonoTests.unit-tests' success='$$successbool' time='0'><results><test-case name='MonoTests.unit-tests.100percentsuccess' executed='True' success='$$successbool' time='0'>" > TestResult-unit-tests.xml; \
+	if [ $$failures -ne 0 ]; then echo "<failure><message>"'<![CDATA[' >> TestResult-unit-tests.xml && cat test-suite.log >> TestResult-unit-tests.xml && echo "]]></message><stack-trace></stack-trace></failure>" >> TestResult-unit-tests.xml; fi; \
+	echo "</test-case></results></test-suite></test-results>" >> TestResult-unit-tests.xml
 
 endif SUPPORT_BOEHM
 endif !HOST_WIN32


### PR DESCRIPTION
Overrides check-local to output an NUnit report of the test results.

It currently creates a single pass/fail test case as this is the easiest solution, but the test log is included in the report which should be enough to diagnose errors.

Parallelism is disabled here since we need to ensure check-local happens after check so we can parse test-suite.log. The tests are quite fast so it doesn't hurt much. If anyone has a better idea how to achieve this please shout.

We need AUTOMAKE_OPTIONS=parallel-tests so the test-suite.log gets created on automake 1.11.

---
This allows Jenkins to catch failures in unit-tests like the following which happened a few days ago:

```
================================================
   mono 4.3.0: mono/unit-tests/test-suite.log
================================================

# TOTAL: 4
# PASS:  2
# SKIP:  0
# XFAIL: 0
# FAIL:  2
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: test-mono-linked-list-set
===============================

* Assertion at mono-threads.c:577, condition `thread_info_key' not met


FAIL: test-conc-hashtable
=========================

* Assertion at mono-threads.c:577, condition `thread_info_key' not met
```