### PR TITLE
[System] Fix TCP socket reuse.

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -9,8 +9,10 @@
 //
 
 using System;
+using System.Linq;
 using System.Collections;
 using System.Threading;
+using System.Text.RegularExpressions;
 using System.Net;
 using System.Net.Sockets;
 using NUnit.Framework;
@@ -3477,6 +3479,37 @@ namespace MonoTests.System.Net.Sockets
 			s.Close ();
 		}
 
+		static bool supportsTcpReuse = false;
+		static bool supportsTcpReuseSet = false;
+
+		static bool SupportsTcpReuse ()
+		{
+			if (supportsTcpReuseSet)
+				return supportsTcpReuse;
+
+			if (Path.DirectorySeparatorChar == '/') {
+				/*
+				 * On UNIX OS
+				 * Multiple threads listening to the same address and port are not possible
+				 * before linux 3.9 kernel, where the socket option SO_REUSEPORT was introduced.
+				 */
+				Regex reg = new Regex(@"^#define\s*SO_REUSEPORT");
+				foreach (string directory in Directory.GetDirectories ("/usr/include")) {
+					var f = Directory.GetFiles (directory, "socket.h").SingleOrDefault ();
+					if (f != null && File.ReadLines (f).Any (l => reg.Match (l).Success)) {
+						supportsTcpReuse = true;
+						break;
+					}
+				}
+			} else {
+				supportsTcpReuse = true;
+			}
+
+			supportsTcpReuseSet = true;
+
+			return supportsTcpReuse;
+		}
+
 		// Test case for bug #31557
 		[Test]
 		public void TcpDoubleBind ()
@@ -3492,10 +3525,15 @@ namespace MonoTests.System.Net.Sockets
 
 				ss.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 
-				ss.Bind (new IPEndPoint (IPAddress.Any, 12345));
-				ss.Listen(1);
+				Exception ex = null;
+				try {
+					ss.Bind (new IPEndPoint (IPAddress.Any, 12345));
+					ss.Listen(1);
+				} catch (SocketException e) {
+					ex = e;
+				}
 
-				// If we make it this far, we succeeded.
+				Assert.AreEqual (SupportsTcpReuse (), ex == null);
 			}
 		}
 

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -3476,7 +3476,29 @@ namespace MonoTests.System.Net.Sockets
 			ss.Close ();
 			s.Close ();
 		}
-		
+
+		// Test case for bug #31557
+		[Test]
+		public void TcpDoubleBind ()
+		{
+			using (Socket s = new Socket (AddressFamily.InterNetwork,
+						SocketType.Stream, ProtocolType.Tcp))
+			using (Socket ss = new Socket (AddressFamily.InterNetwork,
+						SocketType.Stream, ProtocolType.Tcp)) {
+				s.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+
+				s.Bind (new IPEndPoint (IPAddress.Any, 12345));
+				s.Listen(1);
+
+				ss.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+
+				ss.Bind (new IPEndPoint (IPAddress.Any, 12345));
+				ss.Listen(1);
+
+				// If we make it this far, we succeeded.
+			}
+		}
+
 		[Test]
 		[Category ("NotOnMac")]
                 public void ConnectedProperty ()

--- a/mono/io-layer/sockets.c
+++ b/mono/io-layer/sockets.c
@@ -733,7 +733,7 @@ int _wapi_setsockopt(guint32 fd, int level, int optname,
 		socklen_t type_len = sizeof (type);
 
 		if (!getsockopt (fd, level, SO_TYPE, &type, &type_len)) {
-			if (type == SOCK_DGRAM)
+			if (type == SOCK_DGRAM || type == SOCK_STREAM)
 				setsockopt (fd, level, SO_REUSEPORT, tmp_val, optlen);
 		}
 	}


### PR DESCRIPTION
TCP sockets with option SocketOptionName.ReuseAddress were not working on Linux.

Fixes [#31557](https://bugzilla.xamarin.com/show_bug.cgi?id=31557).