### PR TITLE
[System] Fix SmtpClient.SendMailAsync never completing

### DIFF
--- a/mcs/class/System/System.Net.Mail/SmtpClient.cs
+++ b/mcs/class/System/System.Net.Mail/SmtpClient.cs
@@ -742,7 +742,7 @@ namespace System.Net.Mail {
 
 		static void SendMailAsyncCompletedHandler (TaskCompletionSource<object> source, AsyncCompletedEventArgs e, SendCompletedEventHandler handler, SmtpClient client)
 		{
-			if ((object) handler != e.UserState)
+			if (source != e.UserState)
 				return;
 
 			client.SendCompleted -= handler;

--- a/mcs/class/System/Test/System.Net.Mail/SmtpClientTest.cs
+++ b/mcs/class/System/Test/System.Net.Mail/SmtpClientTest.cs
@@ -389,5 +389,23 @@ namespace MonoTests.System.Net.Mail
 			Assert.AreEqual ("<bar@example.com>", server.rcpt_to);
 		}
 
+		[Test]
+		public void Deliver_Async ()
+		{
+			var server = new SmtpServer ();
+			var client = new SmtpClient ("localhost", server.EndPoint.Port);
+			var msg = new MailMessage ("foo@example.com", "bar@example.com", "hello", "howdydoo\r\n");
+
+			Thread t = new Thread (server.Run);
+			t.Start ();
+			var task = client.SendMailAsync (msg);
+			t.Join ();
+
+			Assert.AreEqual ("<foo@example.com>", server.mail_from);
+			Assert.AreEqual ("<bar@example.com>", server.rcpt_to);
+
+			Assert.IsTrue (task.IsCompleted, "task");
+		}
+
 	}
 }


### PR DESCRIPTION
The user object passed to the callback is the task completion source, not the handler
This bug causes SendMailAsync to never complete
A simple test is included which just checks if the task does in fact complete