### PR TITLE
[System] Remove C#6 expression bodied property to fix bootstrapping with older mcs

### DIFF
--- a/mcs/class/corlib/System/MulticastDelegate.cs
+++ b/mcs/class/corlib/System/MulticastDelegate.cs
@@ -83,7 +83,9 @@ namespace System
 		// https://gist.github.com/migueldeicaza/cd99938c2a4372e7e5d5
 		//
 		// Do not remove this API
-		internal bool HasSingleTarget => delegates == null;
+		internal bool HasSingleTarget {
+			get { return delegates == null; }
+		}
 
 		// <remarks>
 		//   Equals: two multicast delegates are equal if their base is equal


### PR DESCRIPTION
See https://github.com/mono/mono/pull/2012#issuecomment-142336361.