### PR TITLE
[System.Drawing] Fix Point constructor with single int parameter to correctly handle negative locations.

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/Point.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Point.cs
@@ -226,7 +226,7 @@ namespace System.Drawing
 		public Point (int dw)
 		{
 			y = dw >> 16;
-			x = dw & 0xffff;
+			x = unchecked ((short) (dw & 0xffff));
 		}
 
 		/// <summary>

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestPoint.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestPoint.cs
@@ -155,6 +155,15 @@ namespace MonoTests.System.Drawing{
 			Assert.AreEqual (pt_i, pt1_1, "#2");
 			Assert.AreEqual (pt_sz, pt1_1, "#3");
 		}
+
+		[Test]
+		public void ConstructorNegativeLocationTest ()
+		{
+			var pt = new Point (unchecked ((int) 0xffe0fc00));
+
+			Assert.AreEqual (-32, pt.Y, "#1"); // (short) 0xffe0
+			Assert.AreEqual (-1024, pt.X, "#2"); // (short) 0xfc00
+		}
 		
 		[Test]
 		public void PropertyTest () 


### PR DESCRIPTION
Point(Int32) constructor should be able to handle negative location because some WndProc message (eg. WM_MOUSEMOVE) brings it in lParams when mouse pointer locates at left or top of primary display in multi-display environment.

Before:
``` c#
var pos = new Point ((int) 0xffe0fc00);
Console.WriteLine(pos); // {X=64512,Y=-32}
```

After:
``` c#
var pos = new Point ((int) 0xffe0fc00);
Console.WriteLine(pos); // {X=-1024,Y=-32}
```