### PR TITLE
[unit-tests] Fix "parallel-tests" AUTOMAKE_OPTIONS not recognized by old automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,11 @@ AC_CANONICAL_HOST
 # The extra brackets are to foil regex-based scans.
 m4_ifdef([_A][M_PROG_TAR],[_A][M_SET_OPTION([tar-ustar])])
 
-AM_INIT_AUTOMAKE([1.9 dist-bzip2 tar-ustar no-dist-gzip foreign subdir-objects])
+AM_INIT_AUTOMAKE([1.9 dist-bzip2 tar-ustar no-dist-gzip foreign subdir-objects]
+                 m4_esyscmd([case `automake --version | head -n 1` in    # parallel-tests is default in automake 1.13+, we need to explicitly enable it
+                             *1.11*|*1.12*) echo parallel-tests;;        # for 1.11 and 1.12 but not below as those versions don't recognize the flag
+                             esac]))                                     # TODO: remove this hack once we require automake 1.11+
+
 AC_CONFIG_HEADERS([config.h])
 AM_MAINTAINER_MODE
 

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -7,8 +7,6 @@ if PLATFORM_DARWIN
 test_ldflags = -framework CoreFoundation -framework Foundation
 endif
 
-AUTOMAKE_OPTIONS = parallel-tests
-
 if !CROSS_COMPILE
 if !HOST_WIN32
 if SUPPORT_BOEHM
@@ -44,10 +42,12 @@ TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashta
 .NOTPARALLEL:
 
 check-local:
-	if grep -q "# FAIL:  0\|tests passed" test-suite.log; then successbool=True && failures=0; else successbool=False && failures=1; fi; \
-	echo "<?xml version='1.0' encoding='utf-8'?><test-results failures='$$failures' total='1' not-run='0' name='unit-tests.dummy' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='MonoTests.unit-tests' success='$$successbool' time='0'><results><test-case name='MonoTests.unit-tests.100percentsuccess' executed='True' success='$$successbool' time='0'>" > TestResult-unit-tests.xml; \
-	if [ $$failures -ne 0 ]; then echo "<failure><message>"'<![CDATA[' >> TestResult-unit-tests.xml && cat test-suite.log >> TestResult-unit-tests.xml && echo "]]></message><stack-trace></stack-trace></failure>" >> TestResult-unit-tests.xml; fi; \
-	echo "</test-case></results></test-suite></test-results>" >> TestResult-unit-tests.xml
+	if [ -e test-suite.log ]; then \
+		if grep -q "# FAIL:  0\|tests passed" test-suite.log; then successbool=True && failures=0; else successbool=False && failures=1; fi; \
+		echo "<?xml version='1.0' encoding='utf-8'?><test-results failures='$$failures' total='1' not-run='0' name='unit-tests.dummy' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='MonoTests.unit-tests' success='$$successbool' time='0'><results><test-case name='MonoTests.unit-tests.100percentsuccess' executed='True' success='$$successbool' time='0'>" > TestResult-unit-tests.xml; \
+		if [ $$failures -ne 0 ]; then echo "<failure><message>"'<![CDATA[' >> TestResult-unit-tests.xml && cat test-suite.log >> TestResult-unit-tests.xml && echo "]]></message><stack-trace></stack-trace></failure>" >> TestResult-unit-tests.xml; fi; \
+		echo "</test-case></results></test-suite></test-results>" >> TestResult-unit-tests.xml; \
+	fi;
 
 endif SUPPORT_BOEHM
 endif !HOST_WIN32


### PR DESCRIPTION
automake 1.13 introduced the flag as default, in 5ad2890c I explicitly set it via AUTOMAKE_OPTIONS to ensure Jenkins (which is on automake 1.11 on some builders) has the same behavior.

Turns out that the flag isn't recognized by automake versions below 1.11 and so the build fails there.

To fix the problem, remove AUTOMAKE_OPTIONS from the Makefile.am in unit-tests and introduce some clever code in configure.ac instead to set the flag only on the automake versions that need it.

--
This fixes the build on SLES11, thanks to @nealef for catching this.