### PR TITLE
[mdoc] Removed extraneous directory creation.

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -169,6 +169,8 @@ check-monodocer-dropns-classic: $(PROGRAM)
 
 check-monodocer-dropns-delete: $(PROGRAM)
 	-rm -Rf Test/en.actual
+	rm -Rf Test/DocTest-DropNS-classic-deletetest.dll
+	rm -Rf Test/DocTest-DropNS-unified-deletetest.dll
 	$(MAKE) Test/DocTest-DropNS-classic-deletetest.dll
 	$(MONO) $(PROGRAM) update --delete --exceptions=all -o Test/en.actual Test/DocTest-DropNS-classic-deletetest.dll
 	$(MAKE) Test/DocTest-DropNS-unified-deletetest.dll
@@ -363,22 +365,21 @@ check-doc-tools: check-monodocer-since \
 	check-mdoc-export-html \
 	check-mdoc-export-html-with-version \
 	check-mdoc-export-msxdoc \
-	check-mdoc-validate
+	check-mdoc-validate \
+	check-monodocer-dropns-classic \
+	check-monodocer-dropns-classic-withsecondary \
+	check-monodocer-dropns-delete \
+	check-monodocer-internal-interface \
+	check-monodocer-enumerations
 
 check-doc-tools-update: check-monodocer-since-update \
 	check-monodocer-importecmadoc-update \
 	check-monodocer-importslashdoc-update \
 	check-monodocer-update \
-	check-monodocer-dropns-classic \
-	check-monodocer-dropns-classic-withsecondary \
-	check-monodocer-dropns-delete \
-	check-monodocer-internal-interface \
-	check-monodocer-enumerations \
 	check-monodocer-delete-update \
 	check-mdoc-export-html-update \
 	check-mdoc-export-msxdoc-update \
 	check-mdoc-validate-update 
 
-check: check-doc-tools \
-	check-doc-tools-update
+check: check-doc-tools 
 

--- a/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
+++ b/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
@@ -678,12 +678,6 @@ class MDocUpdater : MDocCommand
 			XmlElement td = StubType(type, output);
 			if (td == null)
 				return null;
-			
-			System.IO.DirectoryInfo dir = new System.IO.DirectoryInfo (DocUtils.PathCombine (dest, type.Namespace));
-			if (!dir.Exists) {
-				dir.Create();
-				Console.WriteLine("Namespace Directory Created: " + type.Namespace);
-			}
 		}
 		return reltypefile;
 	}


### PR DESCRIPTION
This was in response to a test failure noticed after this pull request was accepted: https://github.com/mono/mono/pull/2012#commitcomment-13325966

The solution was two-fold, the code removed was unecessary as this directory is created elsewhere right before the file is written (and with the correct name in the case of a unified type). Also a small change was made to the makefile to clean up some files which was causing some targets to be skipped.

@akoeplinger ... I didn't make any changes to the makefile targets that you mentioned weren't being run in CI. I wonder if we shouldn't just change CI to run `make check`? this would ensure that all tests get run every time, or is there some other reason that some of these tests aren't run on CI?