### PR TITLE
This is a patch to fix bug 34123. System.Drawing.Printing.PrintingSer…

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.Printing/PrintingServicesUnix.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Printing/PrintingServicesUnix.cs
@@ -843,7 +843,7 @@ namespace System.Drawing.Printing
 			if (!settings.PrintToFile) {
 				StringBuilder sb = new StringBuilder (1024);
 				int length = sb.Capacity;
-				cupsTempFile (sb, length);
+				cupsTempFd (sb, length);
 				name = sb.ToString ();
 				tmpfile = name;
 			}
@@ -889,7 +889,7 @@ namespace System.Drawing.Printing
 		static extern void cupsFreeDests (int num_dests, IntPtr dests);
 
 		[DllImport("libcups", CharSet=CharSet.Ansi)]
-		static extern IntPtr cupsTempFile (StringBuilder sb, int len);
+		static extern IntPtr cupsTempFd (StringBuilder sb, int len);
 
 		[DllImport("libcups", CharSet=CharSet.Ansi)]
 		static extern IntPtr cupsGetDefault ();


### PR DESCRIPTION
…vicesUnix is failing to print on Mac OSX Yosemite because the CUPS function cupsTempFile now always returns an empty string. This function was deprecated. Now replacing cupsTempFile call with call to cupsTempFd to fix printing. I do not see a clear way to unit test this, and there appear to be no prior unit tests covering this. Essentially we are swapping a function call for another that returns the same type of result. This was tested on my copy of net_4_x master. The same fix could be applied to mono version 3 also. This change is released under the MIT license.