### PR TITLE
[delegate] Improve allocation patterns for MulticastDelegate

### DIFF
--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 138;
+		private const int mono_corlib_version = 139;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -79,7 +79,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 138
+#define MONO_CORLIB_VERSION 139
 
 typedef struct
 {

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -792,10 +792,18 @@ struct _MonoDelegate {
 	MonoBoolean method_is_virtual;
 };
 
+typedef struct _MonoMulticastDelegateData MonoMulticastDelegateData;
+struct _MonoMulticastDelegateData {
+	MonoObject object;
+	MonoArray *delegates;
+	gint32 offset;
+	gint32 count;
+};
+
 typedef struct _MonoMulticastDelegate MonoMulticastDelegate;
 struct _MonoMulticastDelegate {
 	MonoDelegate delegate;
-	MonoArray *delegates;
+	MonoObject *multicast;
 };
 
 struct _MonoReflectionField {

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -77,7 +77,11 @@ DECL_OFFSET(MonoInternalThread, tid)
 DECL_OFFSET(MonoInternalThread, small_id)
 DECL_OFFSET(MonoInternalThread, static_data)
 
-DECL_OFFSET(MonoMulticastDelegate, delegates)
+DECL_OFFSET(MonoMulticastDelegate, multicast)
+
+DECL_OFFSET(MonoMulticastDelegateData, delegates)
+DECL_OFFSET(MonoMulticastDelegateData, offset)
+DECL_OFFSET(MonoMulticastDelegateData, count)
 
 DECL_OFFSET(MonoTransparentProxy, rp)
 DECL_OFFSET(MonoTransparentProxy, remote_class)

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1080,7 +1080,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	/* Necessary for !code condition to fallback to slow path */
 	code = NULL;
 
-	multicast = ((MonoMulticastDelegate*)delegate)->delegates != NULL;
+	multicast = ((MonoMulticastDelegate*)delegate)->multicast != NULL;
 	if (!multicast && !callvirt) {
 		if (method && (method->flags & METHOD_ATTRIBUTE_STATIC) && mono_method_signature (method)->param_count == mono_method_signature (invoke)->param_count + 1)
 			/* Closed static delegate */


### PR DESCRIPTION
We try to reuse the underlying delegates array, to avoid reallocating a new array for every combine/remove.