### PR TITLE
Bundle modified masm.props with fully qualified ml.exe call.

### DIFF
--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -185,7 +185,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+    <Import Project=".\masm.fixed.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/msvc/masm.fixed.props
+++ b/msvc/masm.fixed.props
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup
+    Condition="'$(MASMBeforeTargets)' == '' and '$(MASMAfterTargets)' == '' and '$(ConfigurationType)' != 'Makefile'">
+    <MASMBeforeTargets>Midl</MASMBeforeTargets>
+    <MASMAfterTargets>CustomBuild</MASMAfterTargets>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <MASM>
+      <NoLogo>true</NoLogo>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ObjectFileName>$(IntDir)%(FileName).obj</ObjectFileName>
+      <PreserveIdentifierCase>0</PreserveIdentifierCase>
+      <WarningLevel>3</WarningLevel>
+      <PackAlignmentBoundary>0</PackAlignmentBoundary>
+      <CallingConvention>0</CallingConvention>
+      <ErrorReporting>0</ErrorReporting>
+      <CommandLineTemplate Condition="'$(Platform)' == 'Win32'">"$(VCInstallDir)bin\ml.exe" /c [AllOptions] [AdditionalOptions] /Ta[Inputs]</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' == 'X64'">"$(VCInstallDir)bin\ml64.exe" /c [AllOptions] [AdditionalOptions] /Ta[Inputs]</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' != 'Win32' and '$(Platform)' != 'X64'">echo MASM not supported on this platform</CommandLineTemplate>
+      <ExecutionDescription>Assembling %(Identity)...</ExecutionDescription>
+    </MASM>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
In some more esoteric environments (say bash.exe spawned by jenkins-slave.exe), the _MASM target's attempts to call ml.exe fail due to ml.exe missing from $PATH (even when it appears to be fine).

The ClCompile target doesn't suffer this issue, since it uses the full path to CL.exe rather than assuming CL.exe is in $PATH. Bundle a lightly patched masm.props to duplicate the ClCompile target behaviour.

This should have no impact on you unless for some reason you're using a different MASM to the one provided with MSVC.