### PR TITLE
 [Mono.Posix] Add support for sending and receiving socket control messages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2090,6 +2090,8 @@ if test x$host_win32 = xno; then
 		 #include <unistd.h>])
 	AC_CHECK_TYPES([suseconds_t], [AC_DEFINE(HAVE_SUSECONDS_T)], ,
 		[#include <sys/time.h>])
+	AC_CHECK_TYPES([struct cmsghdr], [AC_DEFINE(HAVE_STRUCT_CMSGHDR)], ,
+		[#include <sys/socket.h>])
 	AC_CHECK_TYPES([struct flock], [AC_DEFINE(HAVE_STRUCT_FLOCK)], ,
 		[#include <unistd.h>
 		 #include <fcntl.h>])

--- a/mcs/class/Mono.Posix/Mono.Unix.Native/NativeConvert.generated.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix.Native/NativeConvert.generated.cs
@@ -86,6 +86,22 @@ namespace Mono.Unix.Native {
 			return rval;
 		}
 
+		[DllImport (LIB, EntryPoint="Mono_Posix_FromCmsghdr")]
+		private static extern int FromCmsghdr (ref Cmsghdr source, IntPtr destination);
+
+		public static bool TryCopy (ref Cmsghdr source, IntPtr destination)
+		{
+			return FromCmsghdr (ref source, destination) == 0;
+		}
+
+		[DllImport (LIB, EntryPoint="Mono_Posix_ToCmsghdr")]
+		private static extern int ToCmsghdr (IntPtr source, out Cmsghdr destination);
+
+		public static bool TryCopy (IntPtr source, out Cmsghdr destination)
+		{
+			return ToCmsghdr (source, out destination) == 0;
+		}
+
 		[DllImport (LIB, EntryPoint="Mono_Posix_FromConfstrName")]
 		private static extern int FromConfstrName (ConfstrName value, out Int32 rval);
 
@@ -1186,6 +1202,38 @@ namespace Mono.Unix.Native {
 		{
 			UnixAddressFamily rval;
 			if (ToUnixAddressFamily (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
+		[DllImport (LIB, EntryPoint="Mono_Posix_FromUnixSocketControlMessage")]
+		private static extern int FromUnixSocketControlMessage (UnixSocketControlMessage value, out Int32 rval);
+
+		public static bool TryFromUnixSocketControlMessage (UnixSocketControlMessage value, out Int32 rval)
+		{
+			return FromUnixSocketControlMessage (value, out rval) == 0;
+		}
+
+		public static Int32 FromUnixSocketControlMessage (UnixSocketControlMessage value)
+		{
+			Int32 rval;
+			if (FromUnixSocketControlMessage (value, out rval) == -1)
+				ThrowArgumentException (value);
+			return rval;
+		}
+
+		[DllImport (LIB, EntryPoint="Mono_Posix_ToUnixSocketControlMessage")]
+		private static extern int ToUnixSocketControlMessage (Int32 value, out UnixSocketControlMessage rval);
+
+		public static bool TryToUnixSocketControlMessage (Int32 value, out UnixSocketControlMessage rval)
+		{
+			return ToUnixSocketControlMessage (value, out rval) == 0;
+		}
+
+		public static UnixSocketControlMessage ToUnixSocketControlMessage (Int32 value)
+		{
+			UnixSocketControlMessage rval;
+			if (ToUnixSocketControlMessage (value, out rval) == -1)
 				ThrowArgumentException (value);
 			return rval;
 		}

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -44,6 +44,7 @@ MPH_UNIX_SOURCE =				\
 	sys-statvfs.c				\
 	sys-time.c				\
 	sys-uio.c				\
+	sys-uio.h				\
 	sys-utsname.c   \
 	sys-wait.c				\
 	sys-xattr.c				\

--- a/support/stdlib.c
+++ b/support/stdlib.c
@@ -15,7 +15,7 @@
 G_BEGIN_DECLS
 
 // See Stdlib.cs
-const char *
+void*
 Mono_Unix_VersionString ()
 {
 	return "MonoProject-2015-12-1";

--- a/support/sys-uio.c
+++ b/support/sys-uio.c
@@ -11,6 +11,8 @@
 #define _GNU_SOURCE
 #endif /* ndef _GNU_SOURCE */
 
+#include "sys-uio.h"
+
 #include <sys/uio.h>
 
 #include "map.h"
@@ -18,8 +20,8 @@
 
 G_BEGIN_DECLS
 
-static struct iovec*
-from_iovec (struct Mono_Posix_Iovec *iov, gint32 iovcnt)
+struct iovec*
+_mph_from_iovec_array (struct Mono_Posix_Iovec *iov, gint32 iovcnt)
 {
 	struct iovec* v;
 	gint32 i;
@@ -51,7 +53,7 @@ Mono_Posix_Syscall_readv (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcnt
 	struct iovec* v;
 	gint64 res;
 
-	v = from_iovec (iov, iovcnt);
+	v = _mph_from_iovec_array (iov, iovcnt);
 	if (!v) {
 		return -1;
 	}
@@ -69,7 +71,7 @@ Mono_Posix_Syscall_writev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcn
 	struct iovec* v;
 	gint64 res;
 
-	v = from_iovec (iov, iovcnt);
+	v = _mph_from_iovec_array (iov, iovcnt);
 	if (!v) {
 		return -1;
 	}
@@ -89,7 +91,7 @@ Mono_Posix_Syscall_preadv (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcn
 
 	mph_return_if_off_t_overflow (off);
 
-	v = from_iovec (iov, iovcnt);
+	v = _mph_from_iovec_array (iov, iovcnt);
 	if (!v) {
 		return -1;
 	}
@@ -109,7 +111,7 @@ Mono_Posix_Syscall_pwritev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovc
 
 	mph_return_if_off_t_overflow (off);
 
-	v = from_iovec (iov, iovcnt);
+	v = _mph_from_iovec_array (iov, iovcnt);
 	if (!v) {
 		return -1;
 	}

--- a/support/sys-uio.h
+++ b/support/sys-uio.h
@@ -1,0 +1,18 @@
+#ifndef SYS_UIO_H
+#define SYS_UIO_H
+
+#include <glib.h>
+
+#include <sys/uio.h>
+
+#include "map.h"
+#include "mph.h"
+
+G_BEGIN_DECLS
+
+MPH_INTERNAL struct iovec*
+_mph_from_iovec_array (struct Mono_Posix_Iovec *iov, gint32 iovcnt);
+
+G_END_DECLS
+
+#endif /* SYS_UIO_H */


### PR DESCRIPTION
Add wrappers for struct cmsghdr, the macros for manipulating control messages (CMSG_*) and recvmsg() and sendmsg().

This commit is the third and last part of #1977

This pull request depends on #2006