### PR TITLE
[Tools] Add user option to cert-sync, fix a few string formatting errors

### DIFF
--- a/mcs/tools/security/cert-sync.cs
+++ b/mcs/tools/security/cert-sync.cs
@@ -124,10 +124,11 @@ namespace Mono.Tools
 					try {
 						stores.TrustedRoot.Import (root);
 						WriteLine ("Certificate added: {0}", root.SubjectName);
-					} catch {
-						WriteLine ("Warning: Could not import {0}");
+						additions++;
+					} catch (Exception e) {
+						WriteLine ("Warning: Could not import {0}", root.SubjectName);
+						WriteLine (e.ToString ());
 					}
-					additions++;
 				}
 			}
 			if (additions > 0)
@@ -169,13 +170,13 @@ namespace Mono.Tools
 					quiet = true;
 					break;
 				default:
-					WriteLine ("Unknown option '{0}'.");
+					WriteLine ("Unknown option '{0}'.", args[i]);
 					return false;
 				}
 			}
 			inputFile = args [args.Length - 1];
 			if (!File.Exists (inputFile)) {
-				WriteLine ("Unknown option or file not found '{0}'.");
+				WriteLine ("Unknown option or file not found '{0}'.", inputFile);
 				return false;
 			}
 			return true;

--- a/mcs/tools/security/cert-sync.cs
+++ b/mcs/tools/security/cert-sync.cs
@@ -49,6 +49,7 @@ namespace Mono.Tools
 	
 		static string inputFile;
 		static bool quiet;
+		static bool userStore;
 
 		static X509Certificate DecodeCertificate (string s)
 		{
@@ -115,7 +116,7 @@ namespace Mono.Tools
 				return 0;
 			}
 				
-			X509Stores stores = (X509StoreManager.LocalMachine);
+			X509Stores stores = userStore ? X509StoreManager.CurrentUser : X509StoreManager.LocalMachine;
 			X509CertificateCollection trusted = stores.TrustedRoot.Certificates;
 			int additions = 0;
 			WriteLine ("I already trust {0}, your new list has {1}", trusted.Count, roots.Count);
@@ -169,6 +170,9 @@ namespace Mono.Tools
 				case "--quiet":
 					quiet = true;
 					break;
+				case "--user":
+					userStore = true;
+					break;
 				default:
 					WriteLine ("Unknown option '{0}'.", args[i]);
 					return false;
@@ -189,7 +193,7 @@ namespace Mono.Tools
 
 		static void Help ()
 		{
-			Console.WriteLine ("Usage: cert-sync [--quiet] system-ca-bundle.crt");
+			Console.WriteLine ("Usage: cert-sync [--quiet] [--user] system-ca-bundle.crt");
 			Console.WriteLine ("Where system-ca-bundle.crt is in PEM format");
 		}
 


### PR DESCRIPTION
First commit adds in missing parameters to WriteLine, which caused it to simply print "{0}" to console...not very helpful
It also prints out the exception if a cert fails to import, and for those it doesn't increment the additions value.

Second commit adds a 'user' option. This uses the current user's certificate store (~/.config/.mono/certs) instead of the machine's certificate store (/usr/share/.mono/certs).
I've been using it for [Heroku](//github.com/AdamBurgess/heroku-buildpack-mono), where root is not available.