### PR TITLE
[System] Fix bug #31209 - HttpConnection infinite loop

### DIFF
--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -306,18 +306,25 @@ namespace System.Net {
 			int used = 0;
 			string line;
 
-			try {
-				line = ReadLine (buffer, position, len - position, ref used);
-				position += used;
-			} catch {
-				context.ErrorMessage = "Bad request";
-				context.ErrorStatus = 400;
-				return true;
-			}
+			while (true) {
+				if (context.HaveError)
+					return true;
 
-			do {
+				if (position >= len)
+					break;
+
+				try {
+					line = ReadLine (buffer, position, len - position, ref used);
+					position += used;
+				} catch {
+					context.ErrorMessage = "Bad request";
+					context.ErrorStatus = 400;
+					return true;
+				}
+
 				if (line == null)
 					break;
+
 				if (line == "") {
 					if (input_state == InputState.RequestLine)
 						continue;
@@ -338,21 +345,7 @@ namespace System.Net {
 						return true;
 					}
 				}
-
-				if (context.HaveError)
-					return true;
-
-				if (position >= len)
-					break;
-				try {
-					line = ReadLine (buffer, position, len - position, ref used);
-					position += used;
-				} catch {
-					context.ErrorMessage = "Bad request";
-					context.ErrorStatus = 400;
-					return true;
-				}
-			} while (line != null);
+			}
 
 			if (used == len) {
 				ms.SetLength (0);

--- a/mcs/class/System/Test/System.Net/HttpListener2Test.cs
+++ b/mcs/class/System/Test/System.Net/HttpListener2Test.cs
@@ -774,5 +774,23 @@ namespace MonoTests.System.Net {
 			var c = new TcpClient ("localhost", port);
 			h.Stop ();
 		}
+
+		// Test case for bug #31209
+		[Test]
+		public void Test_EmptyLineAtStart ()
+		{
+			var listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:9124/");
+			var ns = HttpListener2Test.CreateNS (9124);
+
+			HttpListener2Test.Send (ns, "\r\nGET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+			bool timedout;
+			HttpListener2Test.GetContextWithTimeout (listener, 1000, out timedout);
+
+			Assert.IsFalse (timedout, "timed out");
+
+			ns.Close ();
+			listener.Close ();
+		}
 	}
 }


### PR DESCRIPTION
```
A continue statement in a do...while loop was skipping code to read the next line in a connection, causing an infinite loop.
Fixed by refactoring the loop, removing duplicated code.
````

Since bretternst hadn't made any progress in #1961, I decided to write this up as the bug is somewhat severe in my opinion, affecting all HttpListeners since commit f512a21c in 2009

Included is fix + test case. I've tested it on my local machine, build and tests pass.
I wasn't 100% sure where to put the test though - MonoTests.System.Net.HttpListenerBugs in HttpListener2Tests.cs seemed like a good place.