### PR TITLE
Inflate calli generic method signature even if not a wrapper

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7182,16 +7182,15 @@ mini_get_signature (MonoMethod *method, guint32 token, MonoGenericContext *conte
 	MonoMethodSignature *fsig;
 
 	if (method->wrapper_type != MONO_WRAPPER_NONE) {
-		MonoError error;
-
 		fsig = (MonoMethodSignature *)mono_method_get_wrapper_data (method, token);
-		if (context) {
-			fsig = mono_inflate_generic_signature (fsig, context, &error);
-			// FIXME:
-			g_assert (mono_error_ok (&error));
-		}
 	} else {
 		fsig = mono_metadata_parse_signature (method->klass->image, token);
+	}
+	if (context) {
+		MonoError error;
+		fsig = mono_inflate_generic_signature(fsig, context, &error);
+		// FIXME:
+		g_assert(mono_error_ok(&error));
 	}
 	return fsig;
 }

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -611,6 +611,7 @@ TEST_IL_SRC=			\
 	cpblkTest.il		\
 	vbinterface.il		\
 	calliTest.il		\
+	calliGenericTest.il		\
 	ckfiniteTest.il		\
 	fault-handler.il		\
 	locallocTest.il		\

--- a/mono/tests/calliGenericTest.il
+++ b/mono/tests/calliGenericTest.il
@@ -1,0 +1,32 @@
+//Tests ldftn and calli with generic return signature
+
+.assembly extern mscorlib{}
+.assembly someTest{}
+.module someTest
+
+.class public auto ansi beforefieldinit Test`1<T>
+  extends [mscorlib]System.Object
+{
+    // method line 1
+    .method public hidebysig
+           static default void test (native int ptr)  cil managed 
+    {
+	.maxstack 8
+	ldarg ptr
+	calli !T()
+	call void class [mscorlib]System.Console::WriteLine(int32)
+	ret 
+    }
+}
+	
+.class private auto ansi someTest
+       extends [mscorlib]System.Object {
+	   
+  .method public static void  go() cil managed {
+    .entrypoint
+
+	ldftn int32 [mscorlib]System.Environment::get_ProcessorCount()
+	call void class Test`1<int32>::test(native int)
+	ret
+  }
+} 


### PR DESCRIPTION
This fixes use of calli with generics.
Ideally should be backported to 4.0, 4.2 and 4.3 (would like to use this on Xamarin Android/iOS).