### PR TITLE
GetCallingAssembly() skip past reflection. Fix #29108 - part 1

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4627,7 +4627,7 @@ ves_icall_System_Reflection_Assembly_GetCallingAssembly (void)
 	dest = NULL;
 	mono_stack_walk_no_il (get_executing, &dest);
 	m = dest;
-	mono_stack_walk_no_il (get_caller, &dest);
+	mono_stack_walk_no_il (get_caller_no_reflection, &dest);
 	if (!dest)
 		dest = m;
 	return mono_assembly_get_object (mono_domain_get (), dest->klass->image->assembly);


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=29108#c6