### PR TITLE
Standardize on lower-case names for Windows include files.

### DIFF
--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -27,7 +27,7 @@
 #include "environment.h"
 #include "coree.h"
 
-#include <Shellapi.h>
+#include <shellapi.h>
 
 HMODULE coree_module_handle = NULL;
 

--- a/mono/metadata/process.c
+++ b/mono/metadata/process.c
@@ -31,7 +31,7 @@
 /* define LOGDEBUG(...) g_message(__VA_ARGS__)  */
 
 #ifdef _WIN32
-#include <Shellapi.h>
+#include <shellapi.h>
 #endif
 
 HANDLE ves_icall_System_Diagnostics_Process_GetProcess_internal (guint32 pid)

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -93,7 +93,7 @@ mono_main_with_options (int argc, char *argv [])
 
 #ifdef HOST_WIN32
 
-#include <Shellapi.h>
+#include <shellapi.h>
 
 int
 main (void)

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -51,7 +51,7 @@
 #include "jit-icalls.h"
 
 #ifdef _WIN32
-#include <Mmsystem.h>
+#include <mmsystem.h>
 #endif
 
 void


### PR DESCRIPTION
This is needed for mingw builds on Linux.