### PR TITLE
parser improvements for Type.GetType() and Assembly.GetType() 

### DIFF
--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -32,7 +32,10 @@ using System.IO;
 using System.Reflection;
 
 namespace System {
-	internal class ArraySpec
+	internal abstract class ModifierSpec {
+		internal abstract Type Resolve (Type type);
+	}
+        internal class ArraySpec : ModifierSpec
 	{
 		int dimensions;
 		bool bound;
@@ -43,7 +46,7 @@ namespace System {
 			this.bound = bound;
 		}
 
-		internal Type Resolve (Type type)
+		internal override Type Resolve (Type type)
 		{
 			if (bound)
 				return type.MakeArrayType (1);
@@ -65,17 +68,40 @@ namespace System {
 #endif
 	}
 
+	internal class PointerSpec : ModifierSpec
+	{
+		int pointer_level;
+
+		internal PointerSpec (int pointer_level) {
+			this.pointer_level = pointer_level;
+		}
+
+		internal override Type Resolve (Type type) {
+			for (int i = 0; i < pointer_level; ++i)
+				type = type.MakePointerType ();
+			return type;
+		}
+#if DEBUG
+		public override string ToString () {
+			string s = "";
+			for (int i = 0; i < pointer_level; ++i)
+				s += "*";
+			return s;
+		}
+#endif
+
+	}
+
 	internal class TypeSpec
 	{
 		string name, assembly_name;
 		List<string> nested;
 		List<TypeSpec> generic_params;
-		List<ArraySpec> array_spec;
-		int pointer_level;
+		List<ModifierSpec> modifier_spec;
 		bool is_byref;
 
-		bool IsArray {
-			get { return array_spec != null; }
+		bool HasModifiers {
+			get { return modifier_spec != null; }
 		}
 
 #if DEBUG
@@ -99,13 +125,10 @@ namespace System {
 				str += "]";
 			}
 
-			if (array_spec != null) {
-				foreach (var ar in array_spec)
-					str += ar;
+			if (modifier_spec != null) {
+				foreach (var md in modifier_spec)
+					str += md;
 			}
-
-			for (int i = 0; i < pointer_level; ++i)
-				str += "*";
 
 			if (is_byref)
 				str += "&";
@@ -185,13 +208,10 @@ namespace System {
 				type = type.MakeGenericType (args);
 			}
 
-			if (array_spec != null) {
-				foreach (var arr in array_spec)
-					type = arr.Resolve (type);
+			if (modifier_spec != null) {
+				foreach (var md in modifier_spec)
+					type = md.Resolve (type);
 			}
-
-			for (int i = 0; i < pointer_level; ++i)
-				type = type.MakePointerType ();
 
 			if (is_byref)
 				type = type.MakeByRefType ();
@@ -210,11 +230,11 @@ namespace System {
 			}
 		}
 
-		void AddArray (ArraySpec array)
+		void AddModifier (ModifierSpec md)
 		{
-			if (array_spec == null)
-				array_spec = new List<ArraySpec> ();
-			array_spec.Add (array);
+			if (modifier_spec == null)
+				modifier_spec = new List<ModifierSpec> ();
+			modifier_spec.Add (md);
 		}
 
 		static void SkipSpace (string name, ref int pos)
@@ -282,7 +302,13 @@ namespace System {
 					case '*':
 						if (data.is_byref)
 							throw new ArgumentException ("Can't have a pointer to a byref type", "typeName");
-						++data.pointer_level;
+						// take subsequent '*'s too
+						int pointer_level = 1;
+						while (pos+1 < name.Length && name[pos+1] == '*') {
+							++pos;
+							++pointer_level;
+						}
+						data.AddModifier (new PointerSpec(pointer_level));
 						break;
 					case ',':
 						if (is_recurse) {
@@ -308,8 +334,8 @@ namespace System {
 
 						if (name [pos] != ',' && name [pos] != '*' && name [pos]  != ']') {//generic args
 							List<TypeSpec> args = new List <TypeSpec> ();
-							if (data.IsArray)
-								throw new ArgumentException ("generic args after array spec", "typeName");
+							if (data.HasModifiers)
+								throw new ArgumentException ("generic args after array spec or pointer type", "typeName");
 
 							while (pos < name.Length) {
 								SkipSpace (name, ref pos);
@@ -352,7 +378,7 @@ namespace System {
 								throw new ArgumentException ("Error parsing array spec", "typeName");
 							if (dimensions > 1 && bound)
 								throw new ArgumentException ("Invalid array spec, multi-dimensional array cannot be bound", "typeName");
-							data.AddArray (new ArraySpec (dimensions, bound));
+							data.AddModifier (new ArraySpec (dimensions, bound));
 						}
 
 						break;

--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -32,8 +32,8 @@ using System.IO;
 using System.Reflection;
 
 namespace System {
-	internal abstract class ModifierSpec {
-		internal abstract Type Resolve (Type type);
+	internal interface ModifierSpec {
+		Type Resolve (Type type);
 	}
         internal class ArraySpec : ModifierSpec
 	{
@@ -46,7 +46,7 @@ namespace System {
 			this.bound = bound;
 		}
 
-		internal override Type Resolve (Type type)
+		public Type Resolve (Type type)
 		{
 			if (bound)
 				return type.MakeArrayType (1);
@@ -76,7 +76,7 @@ namespace System {
 			this.pointer_level = pointer_level;
 		}
 
-		internal override Type Resolve (Type type) {
+		public Type Resolve (Type type) {
 			for (int i = 0; i < pointer_level; ++i)
 				type = type.MakePointerType ();
 			return type;

--- a/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
@@ -5,9 +5,11 @@
 // 	Gonzalo Paniagua Javier (gonzalo@ximian.com)
 //	Philippe Lavoie (philippe.lavoie@cactus.ca)
 //	Sebastien Pouliot (sebastien@ximian.com)
+//      Aleksey Kliger (aleksey@xamarin.com)
 //
 // (c) 2003 Ximian, Inc. (http://www.ximian.com)
 // Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
+// Copyright (C) 2015, Xamarin, Inc. (http://www.xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -89,13 +91,58 @@ namespace MonoTests.System.Reflection
 		}
 
 		[Test] // bug #49114
-		[Category ("NotWorking")]
 		[ExpectedException (typeof (ArgumentException))]
 		public void GetType_TypeName_Invalid () 
 		{
 			typeof (int).Assembly.GetType ("&blabla", true, true);
 		}
 
+		[Test] // bug #17571
+		[ExpectedException (typeof (ArgumentException))]
+		public void GetType_Invalid_RefPtr () {
+			typeof (int).Assembly.GetType ("System.Int32&*", true, true);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void GetType_Invalid_RefArray () {
+			typeof (int).Assembly.GetType ("System.Int32&[]", true, true);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void GetType_Invalid_RefGeneric () {
+			typeof (int).Assembly.GetType ("System.Tuple`1&[System.Int32]", true, true);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void GetType_Invalid_PtrGeneric () {
+			typeof (int).Assembly.GetType ("System.Tuple`1*[System.Int32]", true, true);
+		}
+
+		[Test]
+		public void GetType_ComposeModifiers () {
+			var a = typeof(int).Assembly;
+
+			var e1 = typeof (Int32).MakePointerType().MakeByRefType();
+			var t1 = a.GetType ("System.Int32*&", true, true);
+			Assert.AreEqual (e1, t1, "#1");
+
+			var e2 = typeof (Int32).MakeArrayType(2).MakeByRefType();
+			var t2 = a.GetType ("System.Int32[,]&", true, true);
+			Assert.AreEqual (e2, t2, "#2");
+
+			var e3 = typeof (Int32).MakePointerType().MakeArrayType();
+			var t3 = a.GetType ("System.Int32*[]", true, true);
+			Assert.AreEqual (e3, t3, "#3");
+
+			var e4 = typeof (Int32).MakeArrayType().MakePointerType().MakePointerType().MakeArrayType().MakePointerType().MakeByRefType();
+			var t4 = a.GetType ("System.Int32[]**[]*&", true, true);
+			Assert.AreEqual (e4, t4, "#4");
+				
+		}
+		
 		[Test] // bug #334203
 		public void GetType_TypeName_AssemblyName ()
 		{

--- a/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
@@ -9,7 +9,7 @@
 //
 // (c) 2003 Ximian, Inc. (http://www.ximian.com)
 // Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
-// Copyright (C) 2015, Xamarin, Inc. (http://www.xamarin.com)
+// Copyright (C) 2015 Xamarin, Inc. (http://www.xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3,8 +3,10 @@
 // Authors:
 // 	Zoltan Varga (vargaz@freemail.hu)
 //  Patrik Torstensson
+//  Aleksey Kliger (aleksey@xamarin.com)
 //
 // (C) 2003 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2015 Xamarin, Inc. (http://www.xamarin.com)
 // 
 
 using NUnit.Framework;
@@ -3901,6 +3903,43 @@ namespace MonoTests.System
 				}, false, false);
 			Assert.AreEqual (typeof (MyRealEnum).MakePointerType (), res, "#12");
 
+			tname = typeof (MyRealEnum).FullName + "*&";
+			res = Type.GetType (tname, name => {
+					return Assembly.Load (name);
+				},(asm,name,ignore) => {
+					return asm == null ? Type.GetType (name, false, ignore) : asm.GetType (name, false, ignore);
+				}, false, false);
+			Assert.AreEqual (typeof (MyRealEnum).MakePointerType ().MakeByRefType(),
+					 res, "#13");
+
+			tname = typeof (MyRealEnum).FullName + "[,]&";
+			res = Type.GetType (tname, name => {
+					return Assembly.Load (name);
+				},(asm,name,ignore) => {
+					return asm == null ? Type.GetType (name, false, ignore) : asm.GetType (name, false, ignore);
+				}, false, false);
+			Assert.AreEqual (typeof (MyRealEnum).MakeArrayType (2).MakeByRefType (),
+					 res, "#14");
+
+			tname = typeof (MyRealEnum).FullName + "*[]";
+			res = Type.GetType (tname, name => {
+					return Assembly.Load (name);
+				},(asm,name,ignore) => {
+					return asm == null ? Type.GetType (name, false, ignore) : asm.GetType (name, false, ignore);
+				}, false, false);
+			Assert.AreEqual (typeof (MyRealEnum).MakePointerType().MakeArrayType(),
+					 res, "#15");
+
+			// not a very useful type, but ought to be parsed correctly
+			tname = typeof (MyRealEnum).FullName + "[]**[]*&";
+			res = Type.GetType (tname, name => {
+					return Assembly.Load (name);
+				},(asm,name,ignore) => {
+					return asm == null ? Type.GetType (name, false, ignore) : asm.GetType (name, false, ignore);
+				}, false, false);
+			Assert.AreEqual (typeof (MyRealEnum).MakeArrayType().MakePointerType().MakePointerType().MakeArrayType().MakePointerType().MakeByRefType(),
+					 res, "#16");
+
 			// assembly resolve without type resolve
 			res = Type.GetType ("System.String,mscorlib", delegate (AssemblyName aname) { return typeof (int).Assembly; }, null);
 			Assert.AreEqual (typeof (string), res);
@@ -3997,6 +4036,7 @@ namespace MonoTests.System
 		[Test]
 		public void NewGetTypeErrors () {
 			MustANE (null);
+			MustAE ("!@#$%^&*");
 			MustAE (string.Format ("{0}[{1}&]", typeof (Foo<>).FullName, typeof (MyRealEnum).FullName));
 			MustAE (string.Format ("{0}[{1}*]", typeof (Foo<>).FullName, typeof (MyRealEnum).FullName));
 			MustAE (string.Format ("{0}&&", typeof (MyRealEnum).FullName));


### PR DESCRIPTION
Throw ArgumentException (instead of TypeLoadException) when unable to parse types, as in .NET documentation.

Parse certain bizarre but legal type specifications such as "Foo\*[]\*[]*".