### PR TITLE
In Type.FullName, escape ,+&@*[]\ with blackslash. Closes #26384

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -67,7 +67,8 @@ namespace System.Reflection.Emit {
 		
 		private TypeBuilder global_type;
 		private Type global_type_created;
-		Hashtable name_cache;
+		// name_cache keys are display names
+		Dictionary<TypeName, TypeBuilder> name_cache;
 		Dictionary<string, int> us_string_cache;
 		private int[] table_indexes;
 		bool transient;
@@ -90,7 +91,7 @@ namespace System.Reflection.Emit {
 			guid = Guid.FastNewGuidArray ();
 			// guid = Guid.NewGuid().ToByteArray ();
 			table_idx = get_next_table_index (this, 0x00, true);
-			name_cache = new Hashtable ();
+			name_cache = new Dictionary<TypeName, TypeBuilder> ();
 			us_string_cache = new Dictionary<string, int> (512);
 
 			basic_init (this);
@@ -262,24 +263,27 @@ namespace System.Reflection.Emit {
 		private TypeBuilder DefineType (string name, TypeAttributes attr, Type parent, Type[] interfaces, PackingSize packingSize, int typesize) {
 			if (name == null)
 				throw new ArgumentNullException ("fullname");
-			if (name_cache.ContainsKey (name))
+			TypeIdentifier ident = TypeIdentifiers.FromInternal (name);
+			if (name_cache.ContainsKey (ident))
 				throw new ArgumentException ("Duplicate type name within an assembly.");
 			TypeBuilder res = new TypeBuilder (this, name, attr, parent, interfaces, packingSize, typesize, null);
 			AddType (res);
 
-			name_cache.Add (name, res);
+			name_cache.Add (ident, res);
 			
 			return res;
 		}
 
-		internal void RegisterTypeName (TypeBuilder tb, string name)
+		internal void RegisterTypeName (TypeBuilder tb, TypeName name)
 		{
 			name_cache.Add (name, tb);
 		}
 		
-		internal TypeBuilder GetRegisteredType (string name)
+		internal TypeBuilder GetRegisteredType (TypeName name)
 		{
-			return (TypeBuilder) name_cache [name];
+			TypeBuilder result = null;
+			name_cache.TryGetValue (name, out result);
+			return result;
 		}
 
 		[ComVisible (true)]
@@ -304,13 +308,14 @@ namespace System.Reflection.Emit {
 		}
 
 		public EnumBuilder DefineEnum( string name, TypeAttributes visibility, Type underlyingType) {
-			if (name_cache.Contains (name))
+			TypeIdentifier ident = TypeIdentifiers.FromInternal (name);
+			if (name_cache.ContainsKey (ident))
 				throw new ArgumentException ("Duplicate type name within an assembly.");
 
 			EnumBuilder eb = new EnumBuilder (this, name, visibility, underlyingType);
 			TypeBuilder res = eb.GetTypeBuilder ();
 			AddType (res);
-			name_cache.Add (name, res);
+			name_cache.Add (ident, res);
 			return eb;
 		}
 
@@ -324,20 +329,20 @@ namespace System.Reflection.Emit {
 			return GetType (className, false, ignoreCase);
 		}
 
-		private TypeBuilder search_in_array (TypeBuilder[] arr, int validElementsInArray, string className) {
+		private TypeBuilder search_in_array (TypeBuilder[] arr, int validElementsInArray, TypeName className) {
 			int i;
 			for (i = 0; i < validElementsInArray; ++i) {
-				if (String.Compare (className, arr [i].FullName, true, CultureInfo.InvariantCulture) == 0) {
+				if (String.Compare (className.DisplayName, arr [i].FullName, true, CultureInfo.InvariantCulture) == 0) {
 					return arr [i];
 				}
 			}
 			return null;
 		}
 
-		private TypeBuilder search_nested_in_array (TypeBuilder[] arr, int validElementsInArray, string className) {
+		private TypeBuilder search_nested_in_array (TypeBuilder[] arr, int validElementsInArray, TypeName className) {
 			int i;
 			for (i = 0; i < validElementsInArray; ++i) {
-				if (String.Compare (className, arr [i].Name, true, CultureInfo.InvariantCulture) == 0)
+				if (String.Compare (className.DisplayName, arr [i].Name, true, CultureInfo.InvariantCulture) == 0)
 					return arr [i];
 			}
 			return null;
@@ -346,26 +351,17 @@ namespace System.Reflection.Emit {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private static extern Type create_modified_type (TypeBuilder tb, string modifiers);
 
-		static readonly char [] type_modifiers = {'&', '[', '*'};
+		private TypeBuilder GetMaybeNested (TypeBuilder t, IEnumerable<TypeName> nested) {
+			TypeBuilder result = t;
 
-		private TypeBuilder GetMaybeNested (TypeBuilder t, string className) {
-			int subt;
-			string pname, rname;
-
-			subt = className.IndexOf ('+');
-			if (subt < 0) {
-				if (t.subtypes != null)
-					return search_nested_in_array (t.subtypes, t.subtypes.Length, className);
-				return null;
+			foreach (TypeName pname in nested) {
+				if (result.subtypes == null)
+					return null;
+				result = search_nested_in_array(result.subtypes, result.subtypes.Length, pname);
+				if (result == null)
+					return null;
 			}
-			if (t.subtypes != null) {
-				pname = className.Substring (0, subt);
-				rname = className.Substring (subt + 1);
-				TypeBuilder result = search_nested_in_array (t.subtypes, t.subtypes.Length, pname);
-				if (result != null)
-					return GetMaybeNested (result, rname);
-			}
-			return null;
+			return result;
 		}
 
 		[ComVisible (true)]
@@ -376,40 +372,27 @@ namespace System.Reflection.Emit {
 			if (className.Length == 0)
 				throw new ArgumentException ("className");
 
-			int subt;
-			string orig = className;
-			string modifiers;
 			TypeBuilder result = null;
 
 			if (types == null && throwOnError)
 				throw new TypeLoadException (className);
 
-			subt = className.IndexOfAny (type_modifiers);
-			if (subt >= 0) {
-				modifiers = className.Substring (subt);
-				className = className.Substring (0, subt);
-			} else
-				modifiers = null;
+			TypeSpec ts = TypeSpec.Parse (className);
 
 			if (!ignoreCase) {
-				result =  name_cache [className] as TypeBuilder;
+				var displayNestedName = ts.TypeNameWithoutModifiers();
+				name_cache.TryGetValue (displayNestedName, out result);
 			} else {
-				subt = className.IndexOf ('+');
-				if (subt < 0) {
-					if (types != null)
-						result = search_in_array (types, num_types,  className);
-				} else {
-					string pname, rname;
-					pname = className.Substring (0, subt);
-					rname = className.Substring (subt + 1);
-					result = search_in_array (types, num_types, pname);
-					if (result != null)
-						result = GetMaybeNested (result, rname);
+				if (types != null)
+					result = search_in_array (types, num_types,  ts.Name);
+				if (!ts.IsNested && result != null) {
+					result = GetMaybeNested (result, ts.Nested);
 				}
 			}
 			if ((result == null) && throwOnError)
-				throw new TypeLoadException (orig);
-			if (result != null && (modifiers != null)) {
+				throw new TypeLoadException (className);
+			if (result != null && (ts.HasModifiers || ts.IsByRef)) {
+				string modifiers = ts.ModifierString ();
 				Type mt = create_modified_type (result, modifiers);
 				result = mt as TypeBuilder;
 				if (result == null)

--- a/mcs/class/corlib/System/MonoType.cs
+++ b/mcs/class/corlib/System/MonoType.cs
@@ -51,6 +51,9 @@ namespace System
 	// Contains information about the type which is expensive to compute
 	[StructLayout (LayoutKind.Sequential)]
 	internal class MonoTypeInfo {
+		// this is the displayed form: special characters
+		// ,+*&*[]\ in the identifier portions of the names
+		// have been escaped with a leading backslash (\)
 		public string full_name;
 		public MonoCMethod default_ctor;
 	}

--- a/mcs/class/corlib/System/TypeIdentifier.cs
+++ b/mcs/class/corlib/System/TypeIdentifier.cs
@@ -1,0 +1,234 @@
+//
+// System.TypeIdentifier.cs
+//
+// Author:
+//   Aleksey Kliger <aleksey@xamarin.com>
+//
+//
+// Copyright (C) 2015 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace System {
+
+	// A TypeName is wrapper around type names in display form
+	// (that is, with special characters escaped).
+	//
+	// Note that in general if you unescape a type name, you will
+	// lose information: If the type name's DisplayName is
+	// Foo\+Bar+Baz (outer class ``Foo+Bar``, inner class Baz)
+	// unescaping the first plus will give you (outer class Foo,
+	// inner class Bar, innermost class Baz).
+	//
+	// The correct way to take a TypeName apart is to feed its
+	// DisplayName to TypeSpec.Parse()
+	//
+	internal interface TypeName : System.IEquatable<TypeName> {
+		string DisplayName {
+			get;
+		}
+
+		// add a nested name under this one.
+		TypeName NestedName (TypeIdentifier innerName);
+	}
+
+	// A type identifier is a single component of a type name.
+	// Unlike a general typename, a type identifier can be be
+	// converted to internal form without loss of information.
+	internal interface TypeIdentifier : TypeName {
+
+		string InternalName {
+			get;
+		}
+
+	}
+
+	internal class TypeNames {
+		internal static TypeName FromDisplay (string displayName)
+		{
+			return new Display (displayName);
+		}
+
+		internal abstract class ATypeName : TypeName {
+			public abstract string DisplayName { get; }
+
+			public abstract TypeName NestedName (TypeIdentifier innerName);
+
+			public bool Equals(TypeName other)
+			{
+				return other != null && DisplayName == other.DisplayName;
+			}
+
+			public override int GetHashCode ()
+			{
+				return DisplayName.GetHashCode();
+			}
+
+			public override bool Equals(object other)
+			{
+				return Equals(other as TypeName);
+			}
+		}
+
+
+		private class Display : ATypeName {
+			string displayName;
+
+			internal Display (string displayName)
+			{
+				this.displayName = displayName;
+			}
+
+			public override string DisplayName { get { return displayName; } }
+
+			public override TypeName NestedName (TypeIdentifier innerName)
+			{
+				return new Display (DisplayName + "+" + innerName.DisplayName);
+			}
+
+		}
+	}
+
+	internal class TypeIdentifiers {
+
+		internal static TypeIdentifier FromDisplay (string displayName)
+		{
+			return new Display (displayName);
+		}
+
+		internal static TypeIdentifier FromInternal (string internalName)
+		{
+			return new Internal (internalName);
+		}
+
+		internal static TypeIdentifier FromInternal (string internalNameSpace, TypeIdentifier typeName)
+		{
+			return new Internal (internalNameSpace, typeName);
+		}
+
+		// Only use if simpleName is certain not to contain
+		// unexpected characters that ordinarily require
+		// escaping: ,+*&[]\
+		internal static TypeIdentifier WithoutEscape (string simpleName)
+		{
+			return new NoEscape (simpleName);
+		}
+
+		private class Display : TypeNames.ATypeName, TypeIdentifier {
+			string displayName;
+			string internal_name; //cached
+
+			internal Display (string displayName)
+			{
+				this.displayName = displayName;
+				internal_name = null;
+			}
+
+			public override string DisplayName {
+				get { return displayName; }
+			}
+
+			public string InternalName {
+				get {
+					if (internal_name == null)
+						internal_name = GetInternalName ();
+					return internal_name;
+				}
+			}
+
+			private string GetInternalName ()
+			{
+				return TypeSpec.UnescapeInternalName(displayName);
+			}
+
+			public override TypeName NestedName (TypeIdentifier innerName) {
+				return TypeNames.FromDisplay (DisplayName + "+" + innerName.DisplayName);
+			}
+		}
+
+
+		private class Internal : TypeNames.ATypeName, TypeIdentifier {
+			string internalName;
+			string display_name; //cached
+
+			internal Internal (string internalName)
+			{
+				this.internalName = internalName;
+				this.display_name = null;
+			}
+
+			internal Internal (string nameSpaceInternal, TypeIdentifier typeName)
+			{
+				this.internalName = nameSpaceInternal + "." + typeName.InternalName;
+				this.display_name = null;
+			}
+
+			public override string DisplayName {
+				get {
+					if (display_name == null)
+						display_name = GetDisplayName ();
+					return display_name;
+				}
+			}
+
+			public string InternalName {
+				get { return internalName; }
+			}
+
+			private string GetDisplayName ()
+			{
+				return TypeSpec.EscapeDisplayName (internalName);
+			}
+
+			public override TypeName NestedName (TypeIdentifier innerName)
+			{
+				return TypeNames.FromDisplay (DisplayName + "+" + innerName.DisplayName);
+			}
+
+		}
+
+		private class NoEscape : TypeNames.ATypeName, TypeIdentifier {
+			string simpleName;
+			internal NoEscape (string simpleName)
+			{
+				this.simpleName = simpleName;
+#if DEBUG
+				checkNoBadChars(simpleName);
+#endif
+			}
+
+			public override string DisplayName { get { return simpleName; } }
+			public string InternalName { get { return simpleName; } }
+
+#if DEBUG
+			static private void checkNoBadChars (string s)
+			{
+				if (TypeSpec.NeedsEscaping (s))
+				    throw new ArgumentException ("simpleName");
+			}
+#endif
+
+			public override TypeName NestedName (TypeIdentifier innerName) {
+				return TypeNames.FromDisplay (DisplayName + "+" + innerName.DisplayName);
+			}
+		}
+	}
+}

--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -281,6 +281,9 @@ namespace System {
 					name_start = pos + 1;
 					in_modifiers = true;
 					break;
+				case '\\':
+					pos++;
+					break;
 				}
 				if (in_modifiers)
 					break;

--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -34,9 +34,11 @@ using System.Reflection;
 namespace System {
 	internal interface ModifierSpec {
 		Type Resolve (Type type);
+		Text.StringBuilder Append (Text.StringBuilder sb);
 	}
         internal class ArraySpec : ModifierSpec
 	{
+		// dimensions == 1 and bound, or dimensions > 1 and !bound
 		int dimensions;
 		bool bound;
 
@@ -55,17 +57,19 @@ namespace System {
 			return type.MakeArrayType (dimensions);
 		}
 
-#if DEBUG
-		public override string ToString ()
+		public Text.StringBuilder Append (Text.StringBuilder sb)
 		{
 			if (bound)
-				return "[*]";
-			string str = "[";
-			for (int i = 1; i < dimensions; ++i)
-				str += ",";
-			return str + "]";
+				return sb.Append ("[*]");
+			return sb.Append ('[')
+				.Append (',', dimensions - 1)
+				.Append (']');
+			
 		}
-#endif
+		public override string ToString ()
+		{
+			return Append (new Text.StringBuilder ()).ToString ();
+		}
 	}
 
 	internal class PointerSpec : ModifierSpec
@@ -81,64 +85,132 @@ namespace System {
 				type = type.MakePointerType ();
 			return type;
 		}
-#if DEBUG
-		public override string ToString () {
-			string s = "";
-			for (int i = 0; i < pointer_level; ++i)
-				s += "*";
-			return s;
+
+		public Text.StringBuilder Append (Text.StringBuilder sb)
+		{
+			return sb.Append ('*', pointer_level);
 		}
-#endif
+		
+		public override string ToString () {
+			return Append (new Text.StringBuilder ()).ToString ();
+		}
 
 	}
 
 	internal class TypeSpec
 	{
-		string name, assembly_name;
-		List<string> nested;
+		TypeIdentifier name;
+		string assembly_name;
+		List<TypeIdentifier> nested;
 		List<TypeSpec> generic_params;
 		List<ModifierSpec> modifier_spec;
 		bool is_byref;
 
-		bool HasModifiers {
+		string display_fullname; // cache
+
+		internal bool HasModifiers {
 			get { return modifier_spec != null; }
 		}
 
+		internal bool IsNested {
+			get { return nested != null && nested.Count > 0; }
+		}
+
+		internal bool IsByRef {
+			get { return is_byref; }
+		}
+
+		internal TypeName Name {
+			get { return name; }
+		}
+
+		internal IEnumerable<TypeName> Nested {
+			get {
+				if (nested != null)
+					return nested;
+				else
+					return EmptyArray<TypeName>.Value;
+			}
+		}
+
+		internal IEnumerable<ModifierSpec> Modifiers {
+			get {
+				if (modifier_spec != null)
+					return modifier_spec;
+				else
+					return EmptyArray<ModifierSpec>.Value;
+			}
+		}
+
+		[Flags]
+		internal enum DisplayNameFormat {
+			Default = 0x0,
+			WANT_ASSEMBLY = 0x1,
+			NO_MODIFIERS = 0x2,
+		}
 #if DEBUG
 		public override string ToString () {
-			string str = name;
+			return GetDisplayFullName (DisplayNameFormat.WANT_ASSEMBLY);
+		}
+#endif
+
+		string GetDisplayFullName (DisplayNameFormat flags)
+		{
+			bool wantAssembly = (flags & DisplayNameFormat.WANT_ASSEMBLY) != 0;
+			bool wantModifiers = (flags & DisplayNameFormat.NO_MODIFIERS) == 0;
+			var sb = new Text.StringBuilder(name.DisplayName);
 			if (nested != null) {
 				foreach (var n in nested)
-					str += "+" + n;
+					sb.Append ('+').Append (n.DisplayName);
 			}
 
 			if (generic_params != null) {
-				str += "[";
+				sb.Append ('[');
 				for (int i = 0; i < generic_params.Count; ++i) {
 					if (i > 0)
-						str += ", ";
+						sb.Append (", ");
 					if (generic_params [i].assembly_name != null)
-						str += "[" + generic_params [i] + "]";
+						sb.Append ('[').Append (generic_params [i].DisplayFullName).Append (']');
 					else
-						str += generic_params [i];
+						sb.Append (generic_params [i].DisplayFullName);
 				}
-				str += "]";
+				sb.Append (']');
 			}
 
+			if (wantModifiers)
+				GetModifierString (sb);
+
+			if (assembly_name != null && wantAssembly)
+				sb.Append (", ").Append (assembly_name);
+
+			return sb.ToString();
+		}
+
+		internal string ModifierString ()
+		{
+			return GetModifierString (new Text.StringBuilder ()).ToString ();
+		}
+
+		private Text.StringBuilder GetModifierString (Text.StringBuilder sb)
+		{
 			if (modifier_spec != null) {
 				foreach (var md in modifier_spec)
-					str += md;
+					md.Append (sb);
 			}
 
 			if (is_byref)
-				str += "&";
+				sb.Append ('&');
 
-			if (assembly_name != null)
-				str += ", " + assembly_name;
-
-			return str;
+			return sb;
 		}
-#endif
+
+		internal string DisplayFullName {
+			get {
+				if (display_fullname == null)
+					display_fullname = GetDisplayFullName (DisplayNameFormat.Default);
+				return display_fullname;
+			}
+		}
 
 		internal static TypeSpec Parse (string typeName)
 		{
@@ -152,11 +224,70 @@ namespace System {
 			return res;
 		}
 
+		internal static string EscapeDisplayName(string internalName)
+		{
+			// initial capacity = length of internalName.
+			// Maybe we won't have to escape anything.
+			var res = new Text.StringBuilder (internalName.Length);
+			foreach (char c in internalName)
+			{
+				switch (c) {
+					case '+':
+					case ',':
+					case '[':
+					case ']':
+					case '*':
+					case '&':
+					case '\\':
+						res.Append ('\\').Append (c);
+						break;
+					default:
+						res.Append (c);
+						break;
+				}
+			}
+			return res.ToString ();
+		}
+
+		internal static string UnescapeInternalName(string displayName)
+		{
+			var res = new Text.StringBuilder (displayName.Length);
+			for (int i = 0; i < displayName.Length; ++i)
+			{
+				char c = displayName[i];
+				if (c == '\\')
+					if (++i < displayName.Length)
+						c = displayName[i];
+				res.Append (c);
+			}
+			return res.ToString ();
+		}
+
+		internal static bool NeedsEscaping (string internalName)
+		{
+			foreach (char c in internalName)
+			{
+				switch (c) {
+					case ',':
+					case '+':
+					case '*':
+					case '&':
+					case '[':
+					case ']':
+					case '\\':
+						return true;
+					default:
+						break;
+				}
+			}
+			return false;
+		}
+
 		internal Type Resolve (Func<AssemblyName,Assembly> assemblyResolver, Func<Assembly,string,bool,Type> typeResolver, bool throwOnError, bool ignoreCase)
 		{
 			Assembly asm = null;
 			if (assemblyResolver == null && typeResolver == null)
-				return Type.GetType (name, throwOnError, ignoreCase);
+				return Type.GetType (name.DisplayName, throwOnError, ignoreCase);
 
 			if (assembly_name != null) {
 				if (assemblyResolver != null)
@@ -173,9 +304,9 @@ namespace System {
 
 			Type type = null;
 			if (typeResolver != null)
-				type = typeResolver (asm, name, ignoreCase);
+				type = typeResolver (asm, name.DisplayName, ignoreCase);
 			else
-				type = asm.GetType (name, false, ignoreCase);
+				type = asm.GetType (name.DisplayName, false, ignoreCase);
 			if (type == null) {
 				if (throwOnError)
 					throw new TypeLoadException ("Could not resolve type '" + name + "'");
@@ -184,7 +315,7 @@ namespace System {
 
 			if (nested != null) {
 				foreach (var n in nested) {
-					var tmp = type.GetNestedType (n, BindingFlags.Public | BindingFlags.NonPublic);
+					var tmp = type.GetNestedType (n.DisplayName, BindingFlags.Public | BindingFlags.NonPublic);
 					if (tmp == null) {
 						if (throwOnError)
 							throw new TypeLoadException ("Could not resolve type '" + n + "'");
@@ -222,11 +353,11 @@ namespace System {
 		void AddName (string type_name)
 		{
 			if (name == null) {
-				name = type_name;
+				name = ParsedTypeIdentifier(type_name);
 			} else {
 				if (nested == null)
-					nested = new List <string> ();
-				nested.Add (type_name);
+					nested = new List <TypeIdentifier> ();
+				nested.Add (ParsedTypeIdentifier(type_name));
 			}
 		}
 
@@ -243,6 +374,11 @@ namespace System {
 			while (p < name.Length && Char.IsWhiteSpace (name [p]))
 				++p;
 			pos = p;
+		}
+
+		static TypeIdentifier ParsedTypeIdentifier (string displayName)
+		{
+			return TypeIdentifiers.FromDisplay(displayName);
 		}
 
 		static TypeSpec Parse (string name, ref int p, bool is_recurse, bool allow_aqn)
@@ -400,6 +536,41 @@ namespace System {
 			p = pos;
 			return data;
 		}
+
+		internal TypeName TypeNameWithoutModifiers ()
+		{
+			return new TypeSpecTypeName (this, false);
+		}
+		
+		internal TypeName TypeName {
+			get { return new TypeSpecTypeName (this, true); }
+		}
+
+		private class TypeSpecTypeName : TypeNames.ATypeName, TypeName {
+			TypeSpec ts;
+			bool want_modifiers;
+
+			internal TypeSpecTypeName (TypeSpec ts, bool wantModifiers)
+			{
+				this.ts = ts;
+				this.want_modifiers = wantModifiers;
+			}
+
+			public override string DisplayName {
+				get {
+					if (want_modifiers)
+						return ts.DisplayFullName;
+					else
+						return ts.GetDisplayFullName (DisplayNameFormat.NO_MODIFIERS);
+				}
+			}
+
+			public override TypeName NestedName (TypeIdentifier innerName)
+			{
+				return TypeNames.FromDisplay(DisplayName + "+" + innerName.DisplayName);
+			}
+		}
+
 	}
 }
 

--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -377,7 +377,7 @@ namespace System {
 								++pos;
 								SkipSpace (name, ref pos);
 							}
-							if (name [pos] != ']')
+							if (pos >= name.Length || name [pos] != ']')
 								throw new ArgumentException ("Error parsing array spec", "typeName");
 							if (dimensions > 1 && bound)
 								throw new ArgumentException ("Invalid array spec, multi-dimensional array cannot be bound", "typeName");

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -4042,7 +4042,8 @@ namespace MonoTests.System
 			MustAE (string.Format ("{0}&&", typeof (MyRealEnum).FullName));
 			MustAE (string.Format ("{0}&*", typeof (MyRealEnum).FullName));
 			MustAE (string.Format ("{0}&[{1}]", typeof (Foo<>).FullName, typeof (MyRealEnum).FullName));
-
+			MustAE (string.Format ("{0}[,", typeof (MyRealEnum).FullName));
+			MustAE (string.Format ("{0}[*", typeof (MyRealEnum).FullName));
 
 			MustAE (string.Format ("{0}[[{1},", typeof (Foo<>).FullName, typeof (MyRealEnum).FullName));
 			MustAE (string.Format ("{0}[[{1}]", typeof (Foo<>).FullName, typeof (MyRealEnum).FullName));

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -4104,6 +4104,51 @@ namespace MonoTests.System
 			Assert.AreEqual (Type.GetType ("MonoTests.System.Foo`1[System.Int32"), null, "#15");
 		}
 
+#if !MONOTOUCH
+		[Test]
+		public void FullNameGetTypeParseEscapeRoundtrip () // bug #26384
+		{
+			var nm = new AssemblyName ("asm");
+			var ab = AssemblyBuilder.DefineDynamicAssembly (nm,
+									AssemblyBuilderAccess.Run);
+			var mb = ab.DefineDynamicModule("m", true);
+			var tb = mb.DefineType ("NameSpace,+*&[]\\.Type,+*&[]\\",
+						TypeAttributes.Class | TypeAttributes.Public);
+
+			var nestedTb = tb.DefineNestedType("Nested,+*&[]\\",
+							  TypeAttributes.Class | TypeAttributes.NestedPublic);
+
+			var ty = tb.CreateType();
+
+			var nestedTy = nestedTb.CreateType();
+
+			var escapedNestedName =
+				"NameSpace\\,\\+\\*\\&\\[\\]\\\\"
+				+ "."
+				+ "Type\\,\\+\\*\\&\\[\\]\\\\"
+				+ "+"
+				+ "Nested\\,\\+\\*\\&\\[\\]\\\\";
+
+			Assert.AreEqual(escapedNestedName, nestedTy.FullName);
+
+			var lookupNestedTy =
+				Type.GetType(escapedNestedName + "," + nm.FullName,
+					     asmName => {
+						     if (asmName.FullName.Equals(nm.FullName)) return ab;
+						     else return Assembly.Load (asmName);
+					     },
+					     (asm,name,ignore) => {
+						     if (asm == null)
+							     return Type.GetType(name, true, ignore);
+						     else return asm.GetType(name, true, ignore);
+					     },
+					     true,
+					     false);
+			Assert.AreEqual(nestedTy, lookupNestedTy);
+
+		}
+#endif
+
 		public abstract class Stream : IDisposable
 		{
 			public void Dispose ()

--- a/mcs/class/corlib/corlib-basic.csproj
+++ b/mcs/class/corlib/corlib-basic.csproj
@@ -1691,6 +1691,7 @@
     <Compile Include="System\TypedReference.cs" />
     <Compile Include="System\TypeInitializationException.cs" />
     <Compile Include="System\TypeLoadException.cs" />
+    <Compile Include="System\TypeIdentifier.cs" />
     <Compile Include="System\TypeSpec.cs" />
     <Compile Include="System\TypeUnloadedException.cs" />
     <Compile Include="System\UInt16.cs" />

--- a/mcs/class/corlib/corlib-build.csproj
+++ b/mcs/class/corlib/corlib-build.csproj
@@ -1691,6 +1691,7 @@
     <Compile Include="System\TypedReference.cs" />
     <Compile Include="System\TypeInitializationException.cs" />
     <Compile Include="System\TypeLoadException.cs" />
+    <Compile Include="System\TypeIdentifier.cs" />
     <Compile Include="System\TypeSpec.cs" />
     <Compile Include="System\TypeUnloadedException.cs" />
     <Compile Include="System\UInt16.cs" />

--- a/mcs/class/corlib/corlib-net_4_5.csproj
+++ b/mcs/class/corlib/corlib-net_4_5.csproj
@@ -1579,6 +1579,7 @@
     <Compile Include="System\TimeZoneInfo.MonoTouch.cs" />
     <Compile Include="System\TimeZoneInfo.Serialization.cs" />
     <Compile Include="System\TypeCode.cs" />
+    <Compile Include="System\TypeIdentifier.cs" />
     <Compile Include="System\TypeSpec.cs" />
     <Compile Include="System\UIntPtr.cs" />
     <Compile Include="System\ValueType.cs" />

--- a/mcs/class/corlib/corlib-net_4_x.csproj
+++ b/mcs/class/corlib/corlib-net_4_x.csproj
@@ -1586,6 +1586,7 @@
     <Compile Include="System\TimeZoneInfo.MonoTouch.cs" />
     <Compile Include="System\TimeZoneInfo.Serialization.cs" />
     <Compile Include="System\TypeCode.cs" />
+    <Compile Include="System\TypeIdentifier.cs" />
     <Compile Include="System\TypeSpec.cs" />
     <Compile Include="System\UIntPtr.cs" />
     <Compile Include="System\ValueType.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -142,6 +142,7 @@ System/TimeZoneInfo.Android.cs
 System/TimeZoneInfo.MonoTouch.cs
 System/TimeZoneInfo.Serialization.cs
 ../../build/common/MonoTODOAttribute.cs
+System/TypeIdentifier.cs
 System/TypeSpec.cs
 System/TypeCode.cs
 System/UIntPtr.cs

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -53,6 +53,7 @@
 #include <mono/metadata/domain-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/class-internals.h>
+#include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/gc-internal.h>
 #include <mono/metadata/mono-gc.h>
@@ -3885,8 +3886,10 @@ ves_icall_Type_GetNestedTypes (MonoReflectionType *type, MonoString *name, guint
 			continue;
 
 		if (name != NULL) {
-			if (str == NULL)
+			if (str == NULL) {
 				str = mono_string_to_utf8 (name);
+				mono_identifier_unescape_type_name_chars (str);
+			}
 
 			if (strcmp (nested->name, str))
 				continue;

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -11,4 +11,7 @@
 MonoObject*
 mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass, MonoError *error);
 
+char*
+mono_identifier_unescape_type_name_chars (char* identifier);
+
 #endif

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -7637,7 +7637,6 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
  *
  *  The string is modified in place!
  */
-static
 char*
 mono_identifier_unescape_type_name_chars(char* identifier)
 {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -7627,10 +7627,93 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
 	return 1;
 }
 
+
+/**
+ * mono_identifier_unescape_type_name_chars:
+ * @identifier: the display name of a mono type
+ *
+ * Returns:
+ *  The name in internal form, that is without escaping backslashes.
+ *
+ *  The string is modified in place!
+ */
+static
+char*
+mono_identifier_unescape_type_name_chars(char* identifier)
+{
+	char *w, *r;
+	if (!identifier)
+		return NULL;
+	for (w = r = identifier; *r != 0; r++)
+	{
+		char c = *r;
+		if (c == '\\') {
+			r++;
+			if (*r == 0)
+				break;
+			c = *r;
+		}
+		*w = c;
+		w++;
+	}
+	if (w != r)
+		*w = 0;
+	return identifier;
+}
+
+void
+mono_identifier_unescape_info (MonoTypeNameParse* info);
+
+static void
+unescape_each_type_argument(void* data, void* user_data)
+{
+	MonoTypeNameParse* info = (MonoTypeNameParse*)data;
+	mono_identifier_unescape_info (info);
+}
+
+static void
+unescape_each_nested_name (void* data, void* user_data)
+{
+	char* nested_name = (char*) data;
+	mono_identifier_unescape_type_name_chars(nested_name);
+}
+
+/**
+ * mono_identifier_unescape_info:
+ *
+ * @info: a parsed display form of an (optionally assembly qualified) full type name.
+ *
+ * Returns: nothing.
+ *
+ * Destructively updates the info by unescaping the identifiers that
+ * comprise the type namespace, name, nested types (if any) and
+ * generic type arguments (if any).
+ *
+ * The resulting info has the names in internal form.
+ *
+ */
+void
+mono_identifier_unescape_info (MonoTypeNameParse *info)
+{
+	if (!info)
+		return;
+	mono_identifier_unescape_type_name_chars(info->name_space);
+	mono_identifier_unescape_type_name_chars(info->name);
+	// but don't escape info->assembly
+	if (info->type_arguments)
+		g_ptr_array_foreach(info->type_arguments, &unescape_each_type_argument, NULL);
+	if (info->nested)
+		g_list_foreach(info->nested, &unescape_each_nested_name, NULL);
+}
+
 int
 mono_reflection_parse_type (char *name, MonoTypeNameParse *info)
 {
-	return _mono_reflection_parse_type (name, NULL, FALSE, info);
+	int ok = _mono_reflection_parse_type (name, NULL, FALSE, info);
+	if (ok) {
+		mono_identifier_unescape_info (info);
+	}
+	return ok;
 }
 
 static MonoType*


### PR DESCRIPTION
 - [x] Enable roundtrip between `Type.FullName` and `Type.GetType(String)`.
 - [x] Git rid of ad-hoc parser in `ModuleBuilder.GetType(String)` use `TypeSpec.Parse`
 - [x] Return display (escaped) name for `TypeBuilder.FullName`
 - [x] Added a wrapper `TypeIdentifier` interface that has a `DisplayName` and an `InternalName` property and use that in `TypeSpec`,  `ModuleBuilder` and `TypeBuilder` instead of bare `string`s.
 - [x] ~~Maybe reflect `TypeSpec` into the native side and get rid of the parser in `mono_reflection_parse_type()`~~

    ~~(Though there's a tricky bit because the native parser is also called from `mini/debugger-agent.c` ... maybe it's not worth it)~~ (Seems like a bigger project. Better to approach is separately.)