### PR TITLE
[verifier] Fix the verifiers to handle Roslyn style fixed blocks.

### DIFF
--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -2515,6 +2515,12 @@ verify_stack_type_compatibility_full (VerifyContext *ctx, MonoType *type, ILStac
 	if (drop_byref)
 		return verify_type_compatibility_full (ctx, type, mono_type_get_type_byval (candidate), FALSE);
 
+	/* Handle how Roslyn emit fixed statements by encoding it as byref */
+	if (type->byref && candidate->byref && (type->type == MONO_TYPE_I) && !mono_type_is_reference (candidate)) {
+		if (!IS_STRICT_MODE (ctx))
+			return TRUE;
+	}
+
 	return verify_type_compatibility_full (ctx, type, candidate, FALSE);
 }
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2184,7 +2184,7 @@ target_type_is_incompatible (MonoCompile *cfg, MonoType *target, MonoInst *arg)
 	if (target->byref) {
 		/* FIXME: check that the pointed to types match */
 		if (arg->type == STACK_MP)
-			return arg->klass != mono_class_from_mono_type (target);
+			return target->type != MONO_TYPE_I && arg->klass != mono_class_from_mono_type (target);
 		if (arg->type == STACK_PTR)
 			return 0;
 		return 1;


### PR DESCRIPTION
Roslyn used byref vars whenever possible to store fixed statements. This leads to confusion in
both the full verifier and the JIT built-in one.

Now we skip it in the JIT one and allow it when not in strict mode for the full verifier.