### PR TITLE
[corlib] Use same Console and Environment logic in monotouch_runtime

### DIFF
--- a/mcs/class/corlib/System/Console.cs
+++ b/mcs/class/corlib/System/Console.cs
@@ -152,10 +152,7 @@ namespace System
 				stdin = new CStreamReader (OpenStandardInput (0), inputEncoding);
 			} else {
 #endif
-// FULL_AOT_RUNTIME is used (instead of MONOTOUCH) since we only want this code when running on 
-// iOS (simulator or devices) and *not* when running tools (e.g. btouch #12179) that needs to use 
-// the mscorlib.dll shipped with Xamarin.iOS
-#if MONOTOUCH && FULL_AOT_RUNTIME
+#if MONOTOUCH
 				stdout = new NSLogWriter ();
 #else
 				stdout = new UnexceptionalStreamWriter (OpenStandardOutput (0), outputEncoding);
@@ -163,7 +160,7 @@ namespace System
 #endif
 				stdout = TextWriter.Synchronized (stdout);
 
-#if MONOTOUCH && FULL_AOT_RUNTIME
+#if MONOTOUCH
 				stderr = new NSLogWriter ();
 #else
 				stderr = new UnexceptionalStreamWriter (OpenStandardError (0), outputEncoding); 

--- a/mcs/class/corlib/System/Console.iOS.cs
+++ b/mcs/class/corlib/System/Console.iOS.cs
@@ -7,7 +7,7 @@
 // Copyright 2012-2014 Xamarin Inc. All rights reserved.
 //
 
-#if FULL_AOT_RUNTIME
+#if MONOTOUCH
 
 using System;
 using System.IO;

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -549,8 +549,7 @@ namespace System {
 			return GetFolderPath (folder, SpecialFolderOption.None);
 		}
 
-// for monotouch, not monotouch_runtime
-#if !(MONOTOUCH && FULL_AOT_RUNTIME)
+#if !MONOTOUCH
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static string GetWindowsFolderPath (int folder);
 


### PR DESCRIPTION
The `monotouch_runtime` profile is exclusively used for the monotouch
REPL assemblies used by Xamarin Sketches and Inspector. In those cases,
Console and Environment should behave just the same as in the
`monotouch` profile.

The only real difference between the two profiles should be the presence
of SRE in `monotouch_runtime`.