### PR TITLE
[interpreter] Implement comparing string values in (Not)EqualInstruction

### DIFF
--- a/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Equal.cs
+++ b/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Equal.cs
@@ -91,6 +91,18 @@ namespace MonoTests.System.Linq.Expressions
 		}
 
 		[Test]
+		public void StringWithNull ()
+		{
+			BinaryExpression expr = Expression.Equal (Expression.Constant ("a"), Expression.Constant (null));
+			Assert.AreEqual (ExpressionType.Equal, expr.NodeType);
+			Assert.AreEqual (typeof (bool), expr.Type);
+			Assert.IsNull (expr.Method);
+
+			var eq = Expression.Lambda<Func<bool>> (expr).Compile ();
+			Assert.IsFalse (eq ());
+		}
+
+		[Test]
 		public void Nullable_LiftToNull_SetToFalse ()
 		{
 			int? a = 1;

--- a/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_NotEqual.cs
+++ b/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_NotEqual.cs
@@ -80,6 +80,30 @@ namespace MonoTests.System.Linq.Expressions
 		}
 
 		[Test]
+		public void PrimitiveNonNumeric ()
+		{
+			BinaryExpression expr = Expression.NotEqual (Expression.Constant ('a'), Expression.Constant ('b'));
+			Assert.AreEqual (ExpressionType.NotEqual, expr.NodeType);
+			Assert.AreEqual (typeof (bool), expr.Type);
+			Assert.IsNull (expr.Method);
+
+			var eq = Expression.Lambda<Func<bool>> (expr).Compile ();
+			Assert.IsTrue (eq ());
+		}
+
+		[Test]
+		public void StringWithNull ()
+		{
+			BinaryExpression expr = Expression.NotEqual (Expression.Constant ("a"), Expression.Constant (null));
+			Assert.AreEqual (ExpressionType.NotEqual, expr.NodeType);
+			Assert.AreEqual (typeof (bool), expr.Type);
+			Assert.IsNull (expr.Method);
+
+			var eq = Expression.Lambda<Func<bool>> (expr).Compile ();
+			Assert.IsTrue (eq ());
+		}
+
+		[Test]
 		public void Nullable_LiftToNull_SetToFalse ()
 		{
 			int? a = 1;

--- a/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/Instructions/EqualInstruction.cs
+++ b/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/Instructions/EqualInstruction.cs
@@ -24,7 +24,7 @@ using Microsoft.Scripting.Utils;
 namespace Microsoft.Scripting.Interpreter {
     internal abstract class EqualInstruction : ComparisonInstruction {
         // Perf: EqualityComparer<T> but is 3/2 to 2 times slower.
-        private static Instruction _Reference, _Boolean, _SByte, _Int16, _Char, _Int32, _Int64, _Byte, _UInt16, _UInt32, _UInt64, _Single, _Double;
+        private static Instruction _Reference, _Boolean, _SByte, _Int16, _Char, _String, _Int32, _Int64, _Byte, _UInt16, _UInt32, _UInt64, _Single, _Double;
         private static Instruction _BooleanLifted, _SByteLifted, _Int16Lifted, _CharLifted, _Int32Lifted, _Int64Lifted,
             _ByteLifted, _UInt16Lifted, _UInt32Lifted, _UInt64Lifted, _SingleLifted, _DoubleLifted;
 
@@ -61,6 +61,13 @@ namespace Microsoft.Scripting.Interpreter {
             protected override object DoCalculate (object l, object r)
             {
                 return (Char)l == (Char)r;
+            }
+        }
+
+        internal sealed class EqualString : EqualInstruction {
+            protected override object DoCalculate (object l, object r)
+            {
+                return (String)l == (String)r;
             }
         }
 
@@ -140,6 +147,7 @@ namespace Microsoft.Scripting.Interpreter {
                 case TypeCode.SByte: return _SByte ?? (_SByte = new EqualSByte());
                 case TypeCode.Byte: return _Byte ?? (_Byte = new EqualByte());
                 case TypeCode.Char: return _Char ?? (_Char = new EqualChar());
+                case TypeCode.String: return _String ?? (_String = new EqualString());
                 case TypeCode.Int16: return _Int16 ?? (_Int16 = new EqualInt16());
                 case TypeCode.Int32: return _Int32 ?? (_Int32 = new EqualInt32());
                 case TypeCode.Int64: return _Int64 ?? (_Int64 = new EqualInt64());

--- a/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/Instructions/NotEqualInstruction.cs
+++ b/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/Instructions/NotEqualInstruction.cs
@@ -24,7 +24,7 @@ using Microsoft.Scripting.Utils;
 namespace Microsoft.Scripting.Interpreter {
     internal abstract class NotEqualInstruction : ComparisonInstruction {
         // Perf: EqualityComparer<T> but is 3/2 to 2 times slower.
-        private static Instruction _Reference, _Boolean, _SByte, _Int16, _Char, _Int32, _Int64, _Byte, _UInt16, _UInt32, _UInt64, _Single, _Double;
+        private static Instruction _Reference, _Boolean, _SByte, _Int16, _Char, _String, _Int32, _Int64, _Byte, _UInt16, _UInt32, _UInt64, _Single, _Double;
         private static Instruction _BooleanLifted, _SByteLifted, _Int16Lifted, _CharLifted, _Int32Lifted, _Int64Lifted,
             _ByteLifted, _UInt16Lifted, _UInt32Lifted, _UInt64Lifted, _SingleLifted, _DoubleLifted;
 
@@ -61,6 +61,13 @@ namespace Microsoft.Scripting.Interpreter {
             protected override object DoCalculate (object l, object r)
             {
                 return (Char)l != (Char)r;
+            }
+        }
+
+        internal sealed class NotEqualString : NotEqualInstruction {
+            protected override object DoCalculate (object l, object r)
+            {
+                return (String)l != (String)r;
             }
         }
 
@@ -140,6 +147,7 @@ namespace Microsoft.Scripting.Interpreter {
                 case TypeCode.SByte: return _SByte ?? (_SByte = new NotEqualSByte());
                 case TypeCode.Byte: return _Byte ?? (_Byte = new NotEqualByte());
                 case TypeCode.Char: return _Char ?? (_Char = new NotEqualChar());
+                case TypeCode.String: return _String ?? (_String = new NotEqualString());
                 case TypeCode.Int16: return _Int16 ?? (_Int16 = new NotEqualInt16());
                 case TypeCode.Int32: return _Int32 ?? (_Int32 = new NotEqualInt32());
                 case TypeCode.Int64: return _Int64 ?? (_Int64 = new NotEqualInt64());


### PR DESCRIPTION
When comparing a string with null the other checks in the interpreter for type equality didn't catch this case and this ultimately resulted in a NotImplementedException in EqualInstruction and NotEqualInstruction.

The fix is to handle the TypeCode.String case in those instructions.
We don't need to do it for CreateLifted() as that method only applies for `Nullable<T>` types which doesn't make sense for string.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=34334 (part 1)