### PR TITLE
[System] Fixed dots trimmed from segments.

### DIFF
--- a/mcs/class/System/System/Uri.cs
+++ b/mcs/class/System/System/Uri.cs
@@ -371,7 +371,7 @@ namespace System {
 			if ((path.Length == 0 || path [0] != '/') && baseEl.delimiter == SchemeDelimiter)
 				path = "/" + path;
 
-			source += UriHelper.Reduce (path, true);
+			source += UriHelper.Reduce (path, !IriParsing);
 
 			if (relativeEl.query != null) {
 				canUseBase = false;

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -2030,6 +2030,19 @@ namespace MonoTests.System
 				Assert.Fail (string.Format ("Unexpected {0} while building URI with username {1}", e.GetType ().Name, userinfo));
 			}
 		}
+
+		// Covers #29864
+		[Test]
+		public void PathDotTrim ()
+		{
+			var baseUri = new Uri ("http://test.com", UriKind.Absolute);
+			var relUri = new Uri ("path/dot./", UriKind.Relative);
+			var uri = new Uri (baseUri, relUri);
+			if (IriParsing)
+				Assert.AreEqual ("http://test.com/path/dot./", uri.ToString ());
+			else
+				Assert.AreEqual ("http://test.com/path/dot/", uri.ToString ());
+		}
 	}
 
 	// Tests non default IriParsing


### PR DESCRIPTION
Before .NET 4.5 dots were trimmed from the end of uri path segments.

In .NET 4.5 IRI parsing is enabled by default and dot are no longer
trimmed from the end of path segments.

This commit disables dot trimming when Uri.IriParsing is true.

Fixes [#29864](https://bugzilla.xamarin.com/show_bug.cgi?id=29864).