### PR TITLE
Improve Soundplayer stability

### DIFF
--- a/mcs/class/System/System.Media/AudioData.cs
+++ b/mcs/class/System/System.Media/AudioData.cs
@@ -61,10 +61,8 @@ namespace Mono.Audio {
 		int data_len;
 		long data_offset;
 		AudioFormat format;
-		Mutex mutex;
 		
 		public WavData (Stream data) {
-			mutex = new Mutex();
 			stream = data;
 			byte[] buffer = new byte [12 + 32];
 			int idx;
@@ -166,11 +164,9 @@ namespace Mono.Audio {
 			byte[] buffer            = new byte [data_len];
 			byte[] chunk_to_play     = new byte [chunk_size];
 
-			mutex.WaitOne();
 			// Read only wave data, don't care about file header here !
 			stream.Position = data_offset;
 			stream.Read (buffer, 0, data_len); 
-			mutex.ReleaseMutex();
 			
 			while (!IsStopped && count >= 0){
 				// Copy one chunk from buffer

--- a/mcs/class/System/System.Media/AudioData.cs
+++ b/mcs/class/System/System.Media/AudioData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Mono.Audio {
  
@@ -60,8 +61,10 @@ namespace Mono.Audio {
 		int data_len;
 		long data_offset;
 		AudioFormat format;
-
+		Mutex mutex;
+		
 		public WavData (Stream data) {
+			mutex = new Mutex();
 			stream = data;
 			byte[] buffer = new byte [12 + 32];
 			int idx;
@@ -163,10 +166,12 @@ namespace Mono.Audio {
 			byte[] buffer            = new byte [data_len];
 			byte[] chunk_to_play     = new byte [chunk_size];
 
+			mutex.WaitOne();
 			// Read only wave data, don't care about file header here !
 			stream.Position = data_offset;
 			stream.Read (buffer, 0, data_len); 
-
+			mutex.ReleaseMutex();
+			
 			while (!IsStopped && count >= 0){
 				// Copy one chunk from buffer
 				Buffer.BlockCopy(buffer, total_data_played, chunk_to_play, 0, chunk_size);

--- a/mcs/class/System/System.Media/AudioDevice.cs
+++ b/mcs/class/System/System.Media/AudioDevice.cs
@@ -174,6 +174,10 @@ namespace Mono.Audio {
 		static extern int snd_pcm_sw_params_set_start_threshold(IntPtr handle, IntPtr param, uint StartThreshold);
 
 		public AlsaDevice (string name) {
+			handle = IntPtr.Zero;
+			hw_param = IntPtr.Zero;
+			sw_param = IntPtr.Zero;
+			
 			if (name == null)
 				name = "default";
 			int err = snd_pcm_open (ref handle, name, 0, 0);
@@ -194,15 +198,18 @@ namespace Mono.Audio {
 			if (disposing) {
 				
 			}
-			if (sw_param != IntPtr.Zero)
+			if (sw_param != IntPtr.Zero) {
 				snd_pcm_sw_params_free (sw_param);
-			if (hw_param != IntPtr.Zero)
+				sw_param = IntPtr.Zero;
+			}
+			if (hw_param != IntPtr.Zero) {
 				snd_pcm_hw_params_free (hw_param);
-			if (handle != IntPtr.Zero)
+				hw_param = IntPtr.Zero;
+			}
+			if (handle != IntPtr.Zero) {
 				snd_pcm_close (handle);
-			sw_param = IntPtr.Zero;
-			hw_param = IntPtr.Zero;
-			handle = IntPtr.Zero;
+				handle = IntPtr.Zero;
+			}
 		}
 
 		public override bool SetFormat (AudioFormat format, int channels, int rate) {
@@ -261,6 +268,7 @@ namespace Mono.Audio {
 
 
 			} else {
+				hw_param = IntPtr.Zero;
 				Console.WriteLine ("failed to alloc Alsa hw param struct");
 			}
 
@@ -277,6 +285,7 @@ namespace Mono.Audio {
 				// apply software param
 				snd_pcm_sw_params(handle, sw_param);
 			} else {
+				sw_param = IntPtr.Zero;
 				Console.WriteLine ("failed to alloc Alsa sw param struct");
 			}
 

--- a/mcs/class/System/System.Media/SoundPlayer.cs
+++ b/mcs/class/System/System.Media/SoundPlayer.cs
@@ -46,7 +46,6 @@ namespace System.Media {
 		int load_timeout = 10000;
 
 		#region Only used for Alsa implementation
-		AudioDevice adev;
 		AudioData adata;
 		bool stopped;
 		#endregion
@@ -126,7 +125,6 @@ namespace System.Media {
 
 			// force recreate for new stream
 			adata = null;
-			adev = null;
 
 			load_completed = true;
 			AsyncCompletedEventArgs e = new AsyncCompletedEventArgs (null, false, this);
@@ -239,9 +237,8 @@ namespace System.Media {
 				try {
 					if (adata == null)
 						adata = new WavData (mstream);
-					if (adev == null)
-						adev = AudioDevice.CreateDevice (null);
 					if (adata != null) {
+						AudioDevice adev = AudioDevice.CreateDevice (null);
 						adata.Setup (adev);
 						adata.Play (adev);
 					}


### PR DESCRIPTION
This series of patches fixes several issues with the SoundPlayer on Linux (via Alsa), including:
- Better pointer initialization and release;
- Remove useless class attributes;
- Add Mutex for thread-safety;
- Handle Alsa error codes after calling snd_pcm_writei(). The absence of error checking here could cause an infinite loop playing the same sample _ad vitam eternam_. The patch adds handling of common errors Alsa returns (-EAGAIN, -ESTRPIPE), and discards and stops the sound if other errors appear.
  This is inspired by **aplay** -> https://github.com/bear24rw/alsa-utils/blob/2d105e0f18a82783ea69e2dbe9da7aeb7d3c1346/aplay/aplay.c#L1700.
