### PR TITLE
[runtime] Rename DISABLE_AOT_COMPILER back to DISABLE_AOT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -743,7 +743,8 @@ AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsy
 AC_DEFINE_UNQUOTED(DISABLED_FEATURES, "$DISABLED_FEATURES", [String of disabled features])
 
 if test "x$mono_feature_disable_aot" = "xyes"; then
-	AC_DEFINE(DISABLE_AOT_COMPILER, 1, [Disable AOT Compiler])
+	AC_DEFINE(DISABLE_AOT, 1, [Disable AOT Compiler])
+	enable_system_aot=no
 	AC_MSG_NOTICE([Disabled AOT compiler])
 fi
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5434,6 +5434,33 @@ mono_aot_init (void)
 {
 }
 
+void
+mono_aot_cleanup (void)
+{
+}
+
+guint32
+mono_aot_find_method_index (MonoMethod *method)
+{
+	g_assert_not_reached ();
+	return 0;
+}
+
+void
+mono_aot_init_llvm_method (gpointer aot_module, guint32 method_index)
+{
+}
+
+void
+mono_aot_init_gshared_method_this (gpointer aot_module, guint32 method_index, MonoObject *this)
+{
+}
+
+void
+mono_aot_init_gshared_method_rgctx  (gpointer aot_module, guint32 method_index, MonoMethodRuntimeGenericContext *rgctx)
+{
+}
+
 gpointer
 mono_aot_get_method (MonoDomain *domain, MonoMethod *method)
 {
@@ -5516,6 +5543,13 @@ mono_aot_get_static_rgctx_trampoline (gpointer ctx, gpointer addr)
 }
 
 gpointer
+mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
 mono_aot_get_trampoline (const char *name)
 {
 	g_assert_not_reached ();
@@ -5542,6 +5576,29 @@ mono_aot_get_imt_thunk (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem
 	g_assert_not_reached ();
 	return NULL;
 }	
+
+gpointer
+mono_aot_get_gsharedvt_arg_trampoline (gpointer arg, gpointer addr)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+void
+mono_aot_set_make_unreadable (gboolean unreadable)
+{
+}
+
+gboolean
+mono_aot_is_pagefault (void *ptr)
+{
+	return FALSE;
+}
+
+void
+mono_aot_handle_pagefault (void *ptr)
+{
+}
 
 guint8*
 mono_aot_get_unwind_info (MonoJitInfo *ji, guint32 *unwind_info_len)


### PR DESCRIPTION
The original rename in c4aa103e486ac7116d78be3f3efecf49bfd29335 was done by accident,
the rest of the codebase still used the old name so disabling AOT didn't actually work.

Renaming this back to the original name and fix a few instances where methods weren't added
in the DISABLE_AOT case.

This allows a `--enable-minmal=aot` build to succeed and actually work.