### PR TITLE
Strip extra null characters in socketAddress

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
+++ b/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
@@ -1,7 +1,9 @@
 Mono.Unix/ReadlinkTest.cs
 Mono.Unix/StdioFileStreamTest.cs
 Mono.Unix/UnixEncodingTest.cs
+Mono.Unix/UnixEndPointTest.cs
 Mono.Unix/UnixGroupTest.cs
+Mono.Unix/UnixListenerTest.cs
 Mono.Unix/UnixMarshalTest.cs
 Mono.Unix/UnixPathTest.cs
 Mono.Unix/UnixSignalTest.cs

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixEndPoint.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixEndPoint.cs
@@ -82,12 +82,18 @@ namespace Mono.Unix
 				uep.filename = "";
 				return uep;
 			}
-			byte [] bytes = new byte [socketAddress.Size - 2 - 1];
+			int size = socketAddress.Size - 2;
+			byte [] bytes = new byte [size];
 			for (int i = 0; i < bytes.Length; i++) {
 				bytes [i] = socketAddress [i + 2];
+				// There may be junk after the null terminator, so ignore it all.
+				if (bytes [i] == 0) {
+					size = i;
+					break;
+				}
 			}
 
-			string name = Encoding.Default.GetString (bytes);
+			string name = Encoding.Default.GetString (bytes, 0, size);
 			return new UnixEndPoint (name);
 		}
 

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixEndPointTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixEndPointTest.cs
@@ -1,0 +1,45 @@
+// UnixEndPointTest.cs: Unit tests for Mono.Unix.UnixListener
+//
+// Authors:
+//  David Lechner (david@lechnology.com)
+//
+// (c) 2015 David Lechner
+//
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+using NUnit.Framework;
+using Mono.Unix;
+
+namespace MonoTests.Mono.Unix {
+
+    [TestFixture]
+    public class UnixEndPointTest {
+
+        // Regression test for https://bugzilla.xamarin.com/show_bug.cgi?id=35004
+        [Test]
+        public void TestCreate ()
+        {
+            const string socketFile = "test";
+            // mangledSocketFile simulates the socket file name with a null
+            // terminator and junk after the null terminator. This can be present
+            // in a SocketAddress when marshaled from native code.
+            const string mangledSocketFile = socketFile + "\0junk";
+
+            var bytes = Encoding.Default.GetBytes (mangledSocketFile);
+            var socketAddress = new SocketAddress (AddressFamily.Unix, bytes.Length + 2);
+            for (int i = 0; i < bytes.Length; i++) {
+                socketAddress [i + 2] = bytes [i];
+            }
+            var dummyEndPoint = new UnixEndPoint (socketFile);
+
+            // testing that the Create() method strips off the null terminator and the junk
+            var endPoint = (UnixEndPoint)dummyEndPoint.Create (socketAddress);
+            Assert.AreEqual (socketFile, endPoint.Filename, "#A01");
+        }
+    }
+}

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixListenerTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixListenerTest.cs
@@ -1,0 +1,36 @@
+// UnixListenerTest.cs: Unit tests for Mono.Unix.UnixListener
+//
+// Authors:
+//  David Lechner (david@lechnology.com)
+//
+// (c) 2015 David Lechner
+//
+
+using System;
+using System.IO;
+
+using NUnit.Framework;
+using Mono.Unix;
+
+namespace MonoTests.Mono.Unix {
+
+    [TestFixture]
+    public class UnixListenerTest {
+
+        // test that a socket file is created and deleted by the UnixListener
+        [Test]
+        public void TestSocketFileCreateDelete ()
+        {
+            var socketFile = Path.GetTempFileName ();
+            // we just want the file name, not the file
+            File.Delete (socketFile);
+
+            using (var listener = new UnixListener (socketFile)) {
+                // creating an instance of UnixListener should create the file
+                Assert.IsTrue (File.Exists (socketFile), "#A01");
+            }
+            // and disposing the UnixListener should delete the file
+            Assert.IsFalse (File.Exists (socketFile), "#A02");
+        }
+    }
+}


### PR DESCRIPTION
Fixes <https://bugzilla.xamarin.com/show_bug.cgi?id=35004>.

Also remove unnecessary copying of array.