### PR TITLE
Fixes mono-symbolicate in Mono 4.2 

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -170,21 +170,14 @@ namespace System.Diagnostics {
 			return frames;
 		}
 
-		bool AddFrames (StringBuilder sb, bool isException = false)
+		bool AddFrames (StringBuilder sb)
 		{
 			bool printOffset;
 			string debugInfo, indentation;
 			string unknown = Locale.GetText ("<unknown method>");
 
-			if (isException) {
-				printOffset = true;
-				indentation = "  ";
-				debugInfo = Locale.GetText (" in {0}:{1} ");
-			} else {
-				printOffset = false;
-				indentation = "   ";
-				debugInfo = Locale.GetText (" in {0}:line {1}");
-			}
+			indentation = "  ";
+			debugInfo = Locale.GetText (" in {0}:{1} ");
 
 			var newline = String.Format ("{0}{1}{2} ", Environment.NewLine, indentation,
 					Locale.GetText ("at"));
@@ -201,21 +194,17 @@ namespace System.Diagnostics {
 					string internal_name = frame.GetInternalMethodName ();
 					if (internal_name != null)
 						sb.Append (internal_name);
-					else if (printOffset)
-						sb.AppendFormat ("<0x{0:x5} + 0x{1:x5}> {2}", frame.GetMethodAddress (), frame.GetNativeOffset (), unknown);
 					else
-						sb.AppendFormat (unknown);
+						sb.AppendFormat ("<0x{0:x5} + 0x{1:x5}> {2}", frame.GetMethodAddress (), frame.GetNativeOffset (), unknown);
 				} else {
 					GetFullNameForStackTrace (sb, frame.GetMethod ());
 
-					if (printOffset) {
-						if (frame.GetILOffset () == -1) {
-							sb.AppendFormat (" <0x{0:x5} + 0x{1:x5}>", frame.GetMethodAddress (), frame.GetNativeOffset ());
-							if (frame.GetMethodIndex () != 0xffffff)
-								sb.AppendFormat (" {0}", frame.GetMethodIndex ());
-						} else {
-							sb.AppendFormat (" [0x{0:x5}]", frame.GetILOffset ());
-						}
+					if (frame.GetILOffset () == -1) {
+						sb.AppendFormat (" <0x{0:x5} + 0x{1:x5}>", frame.GetMethodAddress (), frame.GetNativeOffset ());
+						if (frame.GetMethodIndex () != 0xffffff)
+							sb.AppendFormat (" {0}", frame.GetMethodIndex ());
+					} else {
+						sb.AppendFormat (" [0x{0:x5}]", frame.GetILOffset ());
 					}
 
 					sb.AppendFormat (debugInfo, frame.GetSecureFileName (),
@@ -293,7 +282,7 @@ namespace System.Diagnostics {
 			//
 			if (captured_traces != null) {
 				foreach (var t in captured_traces) {
-					if (!t.AddFrames (sb, true))
+					if (!t.AddFrames (sb))
 						continue;
 
 					sb.Append (Environment.NewLine);

--- a/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
+++ b/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
@@ -9,86 +9,54 @@ class StackTraceDumper {
 			throw new Exception ("Stacktrace with 1 frame");
 		} catch (Exception e) {
 			Console.WriteLine (e);
+			Console.WriteLine ("Stacktrace:");
+			Console.WriteLine (new System.Diagnostics.StackTrace(e));
 		}
 
-		try {
-			ThrowException ("Stacktrace with 2 frames");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => {throw new Exception ("Stacktrace with 2 frames");});
 
-		try {
-			ThrowException ("Stacktrace with 3 frames", 2);
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => ThrowException ("Stacktrace with 3 frames", 1));
 
-		try {
+		Catch (() => ThrowException ("Stacktrace with 4 frames", 2));
+
+		Catch (() => {
 			var message = "Stack frame with method overload using ref parameter";
 			ThrowException (ref message);
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		});
 
-		try {
+		Catch (() => {
 			int i;
 			ThrowException ("Stack frame with method overload using out parameter", out i);
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		});
 
-		try {
-			ThrowExceptionGeneric<double> ("Stack frame with 1 generic parameter");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => ThrowExceptionGeneric<double> ("Stack frame with 1 generic parameter"));
 
-		try {
-			ThrowExceptionGeneric<double,string> ("Stack frame with 2 generic parameters");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => ThrowExceptionGeneric<double,string> ("Stack frame with 2 generic parameters"));
 
-		try {
-			ThrowExceptionGeneric (12);
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => ThrowExceptionGeneric (12));
 
-		try {
-			InnerClass.ThrowException ("Stack trace with inner class");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => InnerClass.ThrowException ("Stack trace with inner class"));
 
-		try {
-			InnerGenericClass<string>.ThrowException ("Stack trace with inner generic class");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => InnerGenericClass<string>.ThrowException ("Stack trace with inner generic class"));
 
-		try {
-			InnerGenericClass<string>.ThrowException ("Stack trace with inner generic class and method generic parameter", "string");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => InnerGenericClass<string>.ThrowException ("Stack trace with inner generic class and method generic parameter", "string"));
 
-		try {
-			InnerGenericClass<string>.ThrowException<string> ("Stack trace with inner generic class and generic overload", "string");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => InnerGenericClass<string>.ThrowException<string> ("Stack trace with inner generic class and generic overload", "string"));
 
-		try {
-			InnerGenericClass<string>.InnerInnerGenericClass<int>.ThrowException ("Stack trace with 2 inner generic class and generic overload");
-		} catch (Exception e) {
-			Console.WriteLine (e);
-		}
+		Catch (() => InnerGenericClass<string>.InnerInnerGenericClass<int>.ThrowException ("Stack trace with 2 inner generic class and generic overload"));
 
+		Catch (() => InnerGenericClass<int>.InnerInnerGenericClass<string>.ThrowException ("Stack trace with 2 inner generic class and generic overload"));
+	}
+
+	public static void Catch (Action action)
+	{
 		try {
-			InnerGenericClass<int>.InnerInnerGenericClass<string>.ThrowException ("Stack trace with 2 inner generic class and generic overload");
+			action ();
 		} catch (Exception e) {
+			Console.WriteLine();
 			Console.WriteLine (e);
+			Console.WriteLine ("Stacktrace:");
+			Console.WriteLine (new System.Diagnostics.StackTrace (e));
 		}
 	}
 

--- a/mcs/tools/mono-symbolicate/Test/symbolicate.expected
+++ b/mcs/tools/mono-symbolicate/Test/symbolicate.expected
@@ -1,43 +1,131 @@
 System.Exception: Stacktrace with 1 frame
   at StackTraceDumper.Main () in StackTraceDumper.cs:9 
+Stacktrace:
+  at StackTraceDumper.Main () in StackTraceDumper.cs:9 
+
 System.Exception: Stacktrace with 2 frames
-  at StackTraceDumper.ThrowException (System.String message) in StackTraceDumper.cs:97 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:15 
+  at StackTraceDumper.<Main>m__0 () in StackTraceDumper.cs:16 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.<Main>m__0 () in StackTraceDumper.cs:16 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stacktrace with 3 frames
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:110 
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:108 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:21 
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.<Main>m__1 () in StackTraceDumper.cs:18 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.<Main>m__1 () in StackTraceDumper.cs:18 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
+System.Exception: Stacktrace with 4 frames
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:76 
+  at StackTraceDumper.<Main>m__2 () in StackTraceDumper.cs:20 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:76 
+  at StackTraceDumper.<Main>m__2 () in StackTraceDumper.cs:20 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack frame with method overload using ref parameter
-  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:102 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:28 
+  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:70 
+  at StackTraceDumper.<Main>m__3 () in StackTraceDumper.cs:24 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:70 
+  at StackTraceDumper.<Main>m__3 () in StackTraceDumper.cs:24 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack frame with method overload using out parameter
-  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:115 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:35 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:83 
+  at StackTraceDumper.<Main>m__4 () in StackTraceDumper.cs:29 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:83 
+  at StackTraceDumper.<Main>m__4 () in StackTraceDumper.cs:29 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack frame with 1 generic parameter
-  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:120 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:41 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:88 
+  at StackTraceDumper.<Main>m__5 () in StackTraceDumper.cs:32 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:88 
+  at StackTraceDumper.<Main>m__5 () in StackTraceDumper.cs:32 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack frame with 2 generic parameters
-  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:140 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:47 
+  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:108 
+  at StackTraceDumper.<Main>m__6 () in StackTraceDumper.cs:34 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:108 
+  at StackTraceDumper.<Main>m__6 () in StackTraceDumper.cs:34 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack frame with generic method overload
-  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:125 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:53 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:93 
+  at StackTraceDumper.<Main>m__7 () in StackTraceDumper.cs:36 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:93 
+  at StackTraceDumper.<Main>m__7 () in StackTraceDumper.cs:36 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack trace with inner class
-  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:146 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:59 
+  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:114 
+  at StackTraceDumper.<Main>m__8 () in StackTraceDumper.cs:38 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:114 
+  at StackTraceDumper.<Main>m__8 () in StackTraceDumper.cs:38 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack trace with inner generic class
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:153 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:65 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:121 
+  at StackTraceDumper.<Main>m__9 () in StackTraceDumper.cs:40 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:121 
+  at StackTraceDumper.<Main>m__9 () in StackTraceDumper.cs:40 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
 Generic to string:string
+
 System.Exception: Stack trace with inner generic class and method generic parameter
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:159 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:71 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:127 
+  at StackTraceDumper.<Main>m__A () in StackTraceDumper.cs:42 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:127 
+  at StackTraceDumper.<Main>m__A () in StackTraceDumper.cs:42 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack trace with inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:164 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:77 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:132 
+  at StackTraceDumper.<Main>m__B () in StackTraceDumper.cs:44 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:132 
+  at StackTraceDumper.<Main>m__B () in StackTraceDumper.cs:44 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack trace with 2 inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:170 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:83 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:138 
+  at StackTraceDumper.<Main>m__C () in StackTraceDumper.cs:46 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:138 
+  at StackTraceDumper.<Main>m__C () in StackTraceDumper.cs:46 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+
 System.Exception: Stack trace with 2 inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:175 
-  at StackTraceDumper.Main () in StackTraceDumper.cs:89 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:143 
+  at StackTraceDumper.<Main>m__D () in StackTraceDumper.cs:48 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+Stacktrace:
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:143 
+  at StackTraceDumper.<Main>m__D () in StackTraceDumper.cs:48 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 


### PR DESCRIPTION
Mono 4.2 branch is missing changes that are required for mono-symbolicate tool to work.