### PR TITLE
[System] Added icall SupportsPortReuse.

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -3120,6 +3120,9 @@ namespace System.Net.Sockets
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal static extern void socket_pool_queue (SocketAsyncCallback d, SocketAsyncResult r);
+
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern bool SupportsPortReuse ();
 	}
 }
 

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -440,6 +440,7 @@ ICALL(SOCK_17, "Send_internal(intptr,byte[],int,int,System.Net.Sockets.SocketFla
 ICALL(SOCK_18, "SetSocketOption_internal(intptr,System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName,object,byte[],int,int&)", ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal)
 ICALL(SOCK_19, "Shutdown_internal(intptr,System.Net.Sockets.SocketShutdown,int&)", ves_icall_System_Net_Sockets_Socket_Shutdown_internal)
 ICALL(SOCK_20, "Socket_internal(System.Net.Sockets.AddressFamily,System.Net.Sockets.SocketType,System.Net.Sockets.ProtocolType,int&)", ves_icall_System_Net_Sockets_Socket_Socket_internal)
+ICALL(SOCK_20a, "SupportsPortReuse", ves_icall_System_Net_Sockets_Socket_SupportPortReuse)
 ICALL(SOCK_21a, "cancel_blocking_socket_operation", icall_cancel_blocking_socket_operation)
 ICALL(SOCK_22, "socket_pool_queue", icall_append_io_job)
 

--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -2540,6 +2540,16 @@ ves_icall_System_Net_Sockets_Socket_SendFile_internal (SOCKET sock, MonoString *
 	return ret;
 }
 
+gboolean
+ves_icall_System_Net_Sockets_Socket_SupportPortReuse (void)
+{
+#if defined (SO_REUSEPORT) || defined (HOST_WIN32)
+    return TRUE;
+#else
+    return FALSE;
+#endif
+}
+
 void
 mono_network_init(void)
 {

--- a/mono/metadata/socket-io.h
+++ b/mono/metadata/socket-io.h
@@ -223,6 +223,7 @@ extern MonoBoolean ves_icall_System_Net_Sockets_Socket_Poll_internal (SOCKET soc
 extern void ves_icall_System_Net_Sockets_Socket_Disconnect_internal(SOCKET sock, MonoBoolean reuse, gint32 *error);
 extern gboolean ves_icall_System_Net_Sockets_Socket_SendFile_internal (SOCKET sock, MonoString *filename, MonoArray *pre_buffer, MonoArray *post_buffer, gint flags);
 void icall_cancel_blocking_socket_operation (MonoThread *thread);
+extern gboolean ves_icall_System_Net_Sockets_Socket_SupportPortReuse (void);
 
 extern void mono_network_init(void);
 extern void mono_network_cleanup(void);


### PR DESCRIPTION
Linux kernels before 3.9 did not support port reuse.
Added private method System.Net.Sockets.Socket.SupportsPortReuse,
which returns true when the runtime is able to bind to the same address
and port multiple times.