### PR TITLE
[mdoc] Marking `MDocPreserve` Obsolete.

### DIFF
--- a/mcs/tools/mdoc/Mono.Documentation/preserver.cs
+++ b/mcs/tools/mdoc/Mono.Documentation/preserver.cs
@@ -7,6 +7,7 @@ using Mono.Options;
 
 namespace Mono.Documentation
 {
+	[Obsolete ("This functionality is no longer supported.")]
 	public class MDocPreserve : MDocCommand
 	{
 		MDocUpdater updater;
@@ -18,6 +19,8 @@ namespace Mono.Documentation
 
 		public override void Run (IEnumerable<string> args)
 		{
+			Message (System.Diagnostics.TraceLevel.Warning, "This functionality is no longer supported, and will be removed in a future release.");
+
 			string preserveName = string.Empty;
 			var p = new OptionSet () { { "name=",
 					"Root {DIRECTORY} to generate/update documentation.",


### PR DESCRIPTION
This was functionality that changed mid-way through an implementation, and
was never removed. The underlying functionality changed direction and is now
a part of the `mdoc update`, and doesn't work in any way as originally planned ...
so I'm marking it as obsolete, and will completely remove it in a future release.