### PR TITLE
[interpreter] Relax check for forcing compilation for built-in structs

### DIFF
--- a/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Call.cs
+++ b/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Call.cs
@@ -240,6 +240,17 @@ namespace MonoTests.System.Linq.Expressions {
 		}
 
 		[Test]
+		public void CallMethodOnDateTime ()
+		{
+			var left = Expression.Call (Expression.Constant (DateTime.Now), typeof(DateTime).GetMethod ("AddDays"), Expression.Constant (-5.0));
+			var right = Expression.Constant (DateTime.Today);
+			var expr = Expression.GreaterThan (left, right);
+
+			var eq = Expression.Lambda<Func<bool>> (expr).Compile ();
+			Assert.IsFalse (eq ());
+		}
+
+		[Test]
 		[Category ("NotDotNet")] // http://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=339351
 		[ExpectedException (typeof (ArgumentException))]
 		public void CallStaticMethodOnNonSenseInstanceExpression ()
@@ -382,7 +393,6 @@ namespace MonoTests.System.Linq.Expressions {
 		}
 
 		[Test]
-		[Category ("NotWorkingInterpreter")]
 		public void Connect282702 ()
 		{
 			var lambda = Expression.Lambda<Func<Func<int>>> (

--- a/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/LightCompiler.cs
+++ b/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/LightCompiler.cs
@@ -1278,7 +1278,7 @@ namespace Microsoft.Scripting.Interpreter {
             // also could be a mutable value type, Delegate.CreateDelegate and MethodInfo.Invoke both can't handle this, we
             // need to generate code.
             if (!CollectionUtils.TrueForAll(parameters, (p) => !p.ParameterType.IsByRef) ||
-                (!node.Method.IsStatic && node.Method.DeclaringType.IsValueType() && !node.Method.DeclaringType.IsPrimitive())) {
+                (!node.Method.IsStatic && node.Method.DeclaringType.IsValueType && node.Method.DeclaringType.Assembly != typeof (object).Assembly)) {
 #if MONO_INTERPRETER
                 throw new NotImplementedException ("Interpreter of ref types");
 #else


### PR DESCRIPTION
Method calls on structs like DateTime wouldn't work before, even though we know we don't have self mutating structs in mscorlib.

Fixes part 2 of https://bugzilla.xamarin.com/show_bug.cgi?id=34334