### PR TITLE
[WIP] Only allocate MonoReflectionType when necessary.

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -453,7 +453,7 @@ struct MonoVTable {
 	 */
 	MonoGCDescriptor gc_descr;
 	MonoDomain *domain;  /* each object/vtable belongs to exactly one domain */
-        gpointer    type; /* System.Type type for klass */
+	guint32     type_handle; /* System.Type type for klass */
 	guint8     *interface_bitmap;
 	guint16     max_interface_id;
 	guint8      rank;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1091,10 +1091,7 @@ mono_domain_assembly_open (MonoDomain *domain, const char *name)
 static void
 unregister_vtable_reflection_type (MonoVTable *vtable)
 {
-	MonoObject *type = vtable->type;
-
-	if (type->vtable->klass != mono_defaults.monotype_class)
-		MONO_GC_UNREGISTER_ROOT_IF_MOVING (vtable->type);
+	mono_gchandle_free (vtable->type_handle);
 }
 
 void

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1610,6 +1610,9 @@ mono_field_static_get_value_for_thread (MonoInternalThread *thread, MonoVTable *
 MONO_API void *
 mono_vtable_get_static_field_data (MonoVTable *vt);
 
+MonoReflectionType *
+mono_vtable_get_reflection_type (MonoVTable *vt);
+
 char *
 mono_string_to_utf8_ignore (MonoString *s);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -6648,8 +6648,8 @@ mono_type_get_object (MonoDomain *domain, MonoType *type)
 	 */
 	if (type == &klass->byval_arg && !image_is_dynamic (klass->image)) {
 		MonoVTable *vtable = mono_class_try_get_vtable (domain, klass);
-		if (vtable && vtable->type)
-			return vtable->type;
+		if (vtable && vtable->type_handle)
+			return mono_vtable_get_reflection_type (vtable);
 	}
 
 	mono_loader_lock (); /*FIXME mono_class_init and mono_class_vtable acquire it*/

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9204,7 +9204,7 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	switch (command) {
 	case CMD_OBJECT_REF_GET_TYPE:
 		/* This handles transparent proxies too */
-		buffer_add_typeid (buf, obj->vtable->domain, mono_class_from_mono_type (((MonoReflectionType*)obj->vtable->type)->type));
+		buffer_add_typeid (buf, obj->vtable->domain, mono_class_from_mono_type (mono_vtable_get_reflection_type (obj->vtable)->type));
 		break;
 	case CMD_OBJECT_REF_GET_VALUES:
 		len = decode_int (p, &p, end);
@@ -9294,7 +9294,7 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		buffer_add_domainid (buf, obj->vtable->domain);
 		break;
 	case CMD_OBJECT_REF_GET_INFO:
-		buffer_add_typeid (buf, obj->vtable->domain, mono_class_from_mono_type (((MonoReflectionType*)obj->vtable->type)->type));
+		buffer_add_typeid (buf, obj->vtable->domain, mono_class_from_mono_type (mono_vtable_get_reflection_type (obj->vtable)->type));
 		buffer_add_domainid (buf, obj->vtable->domain);
 		break;
 	default:

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5886,12 +5886,12 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	} else if (cmethod->klass == mono_defaults.object_class) {
 
 		if (strcmp (cmethod->name, "GetType") == 0 && fsig->param_count + fsig->hasthis == 1) {
-			int dreg = alloc_ireg_ref (cfg);
+			MonoInst *iargs [1];
 			int vt_reg = alloc_preg (cfg);
-			MONO_EMIT_NEW_LOAD_MEMBASE_FAULT (cfg, vt_reg, args [0]->dreg, MONO_STRUCT_OFFSET (MonoObject, vtable));
-			EMIT_NEW_LOAD_MEMBASE (cfg, ins, OP_LOAD_MEMBASE, dreg, vt_reg, MONO_STRUCT_OFFSET (MonoVTable, type));
-			type_from_op (cfg, ins, NULL, NULL);
-
+			EMIT_NEW_LOAD_MEMBASE (cfg, ins, OP_LOAD_MEMBASE, vt_reg, args [0]->dreg, MONO_STRUCT_OFFSET (MonoObject, vtable));
+			iargs [0] = ins;
+			/* FIXME: This could be inlined by one level. */
+			ins = mono_emit_jit_icall (cfg, mono_vtable_get_reflection_type, iargs);
 			return ins;
 		} else if (!cfg->backend->emulate_mul_div && strcmp (cmethod->name, "InternalGetHashCode") == 0 && fsig->param_count == 1 && !mono_gc_is_moving ()) {
 			int dreg = alloc_ireg (cfg);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3480,6 +3480,9 @@ register_icalls (void)
 #ifdef TARGET_IOS
 	register_icall (pthread_getspecific, "pthread_getspecific", "ptr ptr", TRUE);
 #endif
+
+	register_icall (mono_vtable_get_reflection_type, "mono_vtable_get_reflection_type", "object ptr", FALSE);
+
 }
 
 MonoJitStats mono_jit_stats = {0};


### PR DESCRIPTION
This removes the `type` field of `MonoVTable`, currently a GC root pointing to an object that’s always allocated. It adds a `type_handle` field, denoting a GC handle pointing to a `MonoReflectionType` instance that is allocated only as needed.

PR’ing for critique and having a central place for perf numbers. The `mono_vtable_get_reflection_type` icall isn’t strictly necessary, and there are some test failures that I’m not sure are related to these changes.
