### PR TITLE
[WinForms] Update tests to match recent changes to Control Foreground+Background

### DIFF
--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/TextBoxTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/TextBoxTest.cs
@@ -206,7 +206,7 @@ namespace MonoTests.System.Windows.Forms
 		[Test]
 		public void BackColorTest ()
 		{
-			Assert.AreEqual (SystemColors.Window, textBox.BackColor, "#A1");
+			Assert.AreEqual (SystemColors.Control, textBox.BackColor, "#A1");
 			textBox.BackColor = Color.Red;
 			Assert.AreEqual (Color.Red, textBox.BackColor, "#A2");
 			textBox.BackColor = Color.White;

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ToolStripControlHostTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ToolStripControlHostTest.cs
@@ -108,7 +108,7 @@ namespace MonoTests.System.Windows.Forms
 			Assert.AreEqual (SystemColors.Control, tsi.BackColor, "B4");
 
 			tsi = new ToolStripControlHost (new TextBox ());
-			Assert.AreEqual (SystemColors.Window, tsi.BackColor, "B5");
+			Assert.AreEqual (SystemColors.Control, tsi.BackColor, "B5");
 
 			tsi = new ToolStripControlHost (new ProgressBar ());
 			Assert.AreEqual (SystemColors.Control, tsi.BackColor, "B6");
@@ -239,7 +239,7 @@ namespace MonoTests.System.Windows.Forms
 			Assert.AreEqual (SystemColors.ControlText, tsi.ForeColor, "B4");
 
 			tsi = new ToolStripControlHost (new TextBox ());
-			Assert.AreEqual (SystemColors.WindowText, tsi.ForeColor, "B5");
+			Assert.AreEqual (SystemColors.ControlText, tsi.ForeColor, "B5");
 		}
 
 		[Test]


### PR DESCRIPTION
The colors were updated in https://github.com/mono/mono/commit/f412b5529e560bca594e0c29a47f32dcfb252820, but the tests weren't. This fixes them.