### PR TITLE
[WCF] Fixed stack overflow issue in DuplexClientRuntimeChannel

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel/DuplexClientRuntimeChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/DuplexClientRuntimeChannel.cs
@@ -192,10 +192,6 @@ namespace System.ServiceModel.MonoInternal
 			} catch (Exception ex) {
 				// FIXME: log it.
 				Console.WriteLine (ex);
-			} finally {
-				// unless it is closed by session/call manager, move it back to the loop to receive the next message.
-				if (loop && input.State != CommunicationState.Closed)
-					ProcessRequestOrInput (input);
 			}
 		}
 


### PR DESCRIPTION
ProcessRequestOrInput has its own while true already. No need to call it again after finished receiving. It will case stack overflow after a few thousand requests are sent.