### PR TITLE
Mempool reference-auditing feature in checked builds (prep work only, PR 2)

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2947,7 +2947,7 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 		return corlib;
 
 	// This unusual directory layout can occur if mono is being built and run out of its own source repo
-	if (assemblies_path) { // MONO_PATH has been set
+	if (assemblies_path) { // Custom assemblies path set via MONO_PATH or mono_set_assemblies_path
 		corlib = load_in_path ("mscorlib.dll", (const char**)assemblies_path, status, FALSE);
 		if (corlib)
 			return corlib;
@@ -2955,7 +2955,7 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 
 	/* Normal case: Load corlib from mono/<version> */
 	corlib_file = g_build_filename ("mono", runtime->framework_version, "mscorlib.dll", NULL);
-	if (assemblies_path) { // MONO_PATH has been set
+	if (assemblies_path) { // Custom assemblies path
 		corlib = load_in_path (corlib_file, (const char**)assemblies_path, status, FALSE);
 		if (corlib) {
 			g_free (corlib_file);

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1588,6 +1588,7 @@ mono_assembly_open_full (const char *filename, MonoImageOpenStatus *status, gboo
 	
 	image = NULL;
 
+	// If VM built with mkbundle
 	loaded_from_bundle = FALSE;
 	if (bundles != NULL) {
 		image = mono_assembly_open_from_bundle (fname, status, refonly);
@@ -2920,6 +2921,7 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 		return corlib;
 	}
 
+	// In native client, Corlib is embedded in the executable as static variable corlibData
 #if defined(__native_client__)
 	if (corlibData != NULL && corlibSize != 0) {
 		int status = 0;
@@ -2936,6 +2938,7 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 	}
 #endif
 
+	// A nonstandard preload hook may provide a special mscorlib assembly
 	aname = mono_assembly_name_new ("mscorlib.dll");
 	corlib = invoke_assembly_preload_hook (aname, assemblies_path);
 	mono_assembly_name_free (aname);
@@ -2943,16 +2946,16 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 	if (corlib != NULL)
 		return corlib;
 
-	if (assemblies_path) {
+	// This unusual directory layout can occur if mono is being built and run out of its own source repo
+	if (assemblies_path) { // MONO_PATH has been set
 		corlib = load_in_path ("mscorlib.dll", (const char**)assemblies_path, status, FALSE);
 		if (corlib)
 			return corlib;
 	}
 
-	/* Load corlib from mono/<version> */
-	
+	/* Normal case: Load corlib from mono/<version> */
 	corlib_file = g_build_filename ("mono", runtime->framework_version, "mscorlib.dll", NULL);
-	if (assemblies_path) {
+	if (assemblies_path) { // MONO_PATH has been set
 		corlib = load_in_path (corlib_file, (const char**)assemblies_path, status, FALSE);
 		if (corlib) {
 			g_free (corlib_file);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -583,8 +583,13 @@ struct _MonoGenericParam {
 typedef struct {
 	MonoClass *pklass;		/* The corresponding `MonoClass'. */
 	const char *name;
+
+	// See GenericParameterAttributes
 	guint16 flags;
+
 	guint32 token;
+
+	// Constraints on type parameters
 	MonoClass** constraints; /* NULL means end of list */
 } MonoGenericParamInfo;
 

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -19,10 +19,6 @@
 #include "mempool.h"
 #include "mempool-internals.h"
 
-#if USE_MALLOC_FOR_MEMPOOLS
-#define MALLOC_ALLOCATION
-#endif
-
 /*
  * MonoMemPool is for fast allocation of memory. We free
  * all memory when the pool is destroyed.
@@ -30,6 +26,8 @@
 
 #define MEM_ALIGN 8
 #define ALIGN_SIZE(s)	(((s) + MEM_ALIGN - 1) & ~(MEM_ALIGN - 1))
+
+// Size of memory at start of mempool reserved for header
 #define SIZEOF_MEM_POOL	(ALIGN_SIZE (sizeof (MonoMemPool)))
 
 #if MONO_SMALL_CONFIG
@@ -40,33 +38,42 @@
 #define MONO_MEMPOOL_MINSIZE 512
 #endif
 
+// The --with-malloc-mempools debug-build flag causes mempools to be allocated in single-element blocks, so tools like Valgrind can run better.
+#if USE_MALLOC_FOR_MEMPOOLS
+#define INDIVIDUAL_ALLOCATIONS
+#define MONO_MEMPOOL_PREFER_INDIVIDUAL_ALLOCATION_SIZE 0
+#else
+#define MONO_MEMPOOL_PREFER_INDIVIDUAL_ALLOCATION_SIZE MONO_MEMPOOL_PAGESIZE
+#endif
+
 #ifndef G_LIKELY
 #define G_LIKELY(a) (a)
 #define G_UNLIKELY(a) (a)
 #endif
 
-#ifdef MALLOC_ALLOCATION
-typedef struct _Chunk {
-	struct _Chunk *next;
-	guint32 size;
-} Chunk;
-
+// A mempool is a linked list of memory blocks, each of which begins with this header structure.
+// The initial block in the linked list is special, and tracks additional information.
 struct _MonoMemPool {
-	Chunk *chunks;
-	guint32 allocated;
-};
-#else
-struct _MonoMemPool {
+	// Next block after this one in linked list
 	MonoMemPool *next;
-	gint rest;
-	guint8 *pos, *end;
+
+	// Size of this memory block only
 	guint32 size;
+
+	// Used in "initial block" only: Beginning of current free space in mempool (may be in some block other than the first one)
+	guint8 *pos;
+
+	// Used in "initial block" only: End of current free space in mempool (ie, the first byte following the end of usable space)
+	guint8 *end;
+
 	union {
-		double pad; /* to assure proper alignment */
+		// Unused: Imposing floating point memory rules on _MonoMemPool's final field ensures proper alignment of whole header struct
+		double pad;
+
+		// Used in "initial block" only: Number of bytes so far allocated (whether used or not) in the whole mempool
 		guint32 allocated;
 	} d;
 };
-#endif
 
 static long total_bytes_allocated = 0;
 
@@ -81,24 +88,33 @@ mono_mempool_new (void)
 	return mono_mempool_new_size (MONO_MEMPOOL_PAGESIZE);
 }
 
+/**
+ * mono_mempool_new_size:
+ * @initial_size: the amount of memory to initially reserve for the memory pool.
+ *
+ * Returns: a new memory pool with a specific initial memory reservation.
+ */
 MonoMemPool *
 mono_mempool_new_size (int initial_size)
 {
-#ifdef MALLOC_ALLOCATION
-	return g_new0 (MonoMemPool, 1);
-#else
 	MonoMemPool *pool;
+
+#ifdef INDIVIDUAL_ALLOCATIONS
+	// In individual allocation mode, create initial block with zero storage space.
+	initial_size = SIZEOF_MEM_POOL;
+#else
 	if (initial_size < MONO_MEMPOOL_MINSIZE)
 		initial_size = MONO_MEMPOOL_MINSIZE;
+#endif
+
 	pool = g_malloc (initial_size);
 
 	pool->next = NULL;
-	pool->pos = (guint8*)pool + SIZEOF_MEM_POOL;
-	pool->end = pool->pos + initial_size - SIZEOF_MEM_POOL;
+	pool->pos = (guint8*)pool + SIZEOF_MEM_POOL; // Start after header
+	pool->end = (guint8*)pool + initial_size;    // End at end of allocated space 
 	pool->d.allocated = pool->size = initial_size;
 	total_bytes_allocated += initial_size;
 	return pool;
-#endif
 }
 
 /**
@@ -110,11 +126,6 @@ mono_mempool_new_size (int initial_size)
 void
 mono_mempool_destroy (MonoMemPool *pool)
 {
-#ifdef MALLOC_ALLOCATION
-	mono_mempool_empty (pool);
-
-	g_free (pool);
-#else
 	MonoMemPool *p, *n;
 
 	total_bytes_allocated -= pool->d.allocated;
@@ -125,7 +136,6 @@ mono_mempool_destroy (MonoMemPool *pool)
 		g_free (p);
 		p = n;
 	}
-#endif
 }
 
 /**
@@ -137,7 +147,7 @@ mono_mempool_destroy (MonoMemPool *pool)
 void
 mono_mempool_invalidate (MonoMemPool *pool)
 {
-#ifdef MALLOC_ALLOCATION
+#ifdef INDIVIDUAL_ALLOCATIONS
 	g_assert_not_reached ();
 #else
 	MonoMemPool *p, *n;
@@ -151,46 +161,27 @@ mono_mempool_invalidate (MonoMemPool *pool)
 #endif
 }
 
-void
-mono_mempool_empty (MonoMemPool *pool)
-{
-#ifdef MALLOC_ALLOCATION
-	Chunk *p, *n;
-
-	p = pool->chunks;
-	pool->chunks = NULL;
-	while (p) {
-		n = p->next;
-		g_free (p);
-		p = n;
-	}
-
-	pool->allocated = 0;
-#else
-	pool->pos = (guint8*)pool + SIZEOF_MEM_POOL;
-	pool->end = pool->pos + pool->size - SIZEOF_MEM_POOL;
-#endif
-}
-
 /**
  * mono_mempool_stats:
  * @pool: the momory pool we need stats for
  *
- * Print a few stats about the mempool
+ * Print a few stats about the mempool:
+ * - Total memory allocated (malloced) by mem pool
+ * - Number of chunks/blocks memory is allocated in
+ * - How much memory is available to dispense before a new malloc must occur?
  */
 void
 mono_mempool_stats (MonoMemPool *pool)
 {
-#ifdef MALLOC_ALLOCATION
+#ifdef INDIVIDUAL_ALLOCATIONS
 	g_assert_not_reached ();
 #else
 	MonoMemPool *p;
 	int count = 0;
-	guint32 still_free = 0;
+	guint32 still_free = pool->end - pool->pos;
 
 	p = pool;
 	while (p) {
-		still_free += p->end - p->pos;
 		p = p->next;
 		count++;
 	}
@@ -203,7 +194,7 @@ mono_mempool_stats (MonoMemPool *pool)
 #endif
 }
 
-#ifndef MALLOC_ALLOCATION
+#ifndef INDIVIDUAL_ALLOCATIONS
 #ifdef TRACE_ALLOCATIONS
 #include <execinfo.h>
 #include "metadata/appdomain.h"
@@ -236,8 +227,20 @@ mono_backtrace (int size)
 }
 
 #endif
+#endif
 
-static int
+/**
+ * mono_mempool_alloc:
+ * @pool: the memory pool to use
+ * @size: size of the memory entity we are trying to allocate
+ *
+ * A mempool is growing; give a recommended size for the next block.
+ * Each block in a mempool should be about 150% bigger than the previous one,
+ * or bigger if it is necessary to include the new entity.
+ *
+ * Returns: the recommended size.
+ */
+static guint
 get_next_size (MonoMemPool *pool, int size)
 {
 	int target = pool->next? pool->next->size: pool->size;
@@ -251,12 +254,11 @@ get_next_size (MonoMemPool *pool, int size)
 		target = MONO_MEMPOOL_PAGESIZE;
 	return target;
 }
-#endif
 
 /**
  * mono_mempool_alloc:
- * @pool: the momory pool to use
- * @size: size of the momory block
+ * @pool: the memory pool to use
+ * @size: size of the memory block
  *
  * Allocates a new block of memory in @pool.
  *
@@ -265,24 +267,10 @@ get_next_size (MonoMemPool *pool, int size)
 gpointer
 mono_mempool_alloc (MonoMemPool *pool, guint size)
 {
-	gpointer rval;
+	gpointer rval = pool->pos; // Return value
 
+	// Normal case: Just bump up pos pointer and we are done
 	size = ALIGN_SIZE (size);
-
-#ifdef MALLOC_ALLOCATION
-	{
-		Chunk *c = g_malloc (size + sizeof (Chunk));
-
-		c->next = pool->chunks;
-		pool->chunks = c;
-		c->size = size - sizeof(Chunk);
-
-		pool->allocated += size;
-
-		rval = ((guint8*)c) + sizeof (Chunk);
-	}
-#else
-	rval = pool->pos;
 	pool->pos = (guint8*)rval + size;
 
 #ifdef TRACE_ALLOCATIONS
@@ -290,28 +278,34 @@ mono_mempool_alloc (MonoMemPool *pool, guint size)
 		mono_backtrace (size);
 	}
 #endif
+
+	// If we have just overflowed the current block, we need to back up and try again.
 	if (G_UNLIKELY (pool->pos >= pool->end)) {
-		pool->pos -= size;
-		if (size >= 4096) {
-			MonoMemPool *np = g_malloc (SIZEOF_MEM_POOL + size);
-			np->next = pool->next;
-			pool->next = np;
-			np->pos = (guint8*)np + SIZEOF_MEM_POOL;
-			np->size = SIZEOF_MEM_POOL + size;
-			np->end = np->pos + np->size - SIZEOF_MEM_POOL;
-			pool->d.allocated += SIZEOF_MEM_POOL + size;
-			total_bytes_allocated += SIZEOF_MEM_POOL + size;
-			return (guint8*)np + SIZEOF_MEM_POOL;
-		} else {
-			int new_size = get_next_size (pool, size);
+		pool->pos -= size;  // Back out
+
+		// For large objects, allocate the object into its own block.
+		// (In individual allocation mode, the constant will be 0 and this path will always be taken)
+		if (size >= MONO_MEMPOOL_PREFER_INDIVIDUAL_ALLOCATION_SIZE) {
+			guint new_size = SIZEOF_MEM_POOL + size;
 			MonoMemPool *np = g_malloc (new_size);
+
 			np->next = pool->next;
+			np->size = new_size;
+			pool->next = np;
+			pool->d.allocated += new_size;
+			total_bytes_allocated += new_size;
+
+			rval = (guint8*)np + SIZEOF_MEM_POOL;
+		} else {
+			// Notice: any unused memory at the end of the old head becomes simply abandoned in this case until the mempool is freed (see Bugzilla #35136)
+			guint new_size = get_next_size (pool, size);
+			MonoMemPool *np = g_malloc (new_size);
+
+			np->next = pool->next;
+			np->size = new_size;
 			pool->next = np;
 			pool->pos = (guint8*)np + SIZEOF_MEM_POOL;
-			np->pos = (guint8*)np + SIZEOF_MEM_POOL;
-			np->size = new_size;
-			np->end = np->pos;
-			pool->end = pool->pos + new_size - SIZEOF_MEM_POOL;
+			pool->end = (guint8*)np + new_size;
 			pool->d.allocated += new_size;
 			total_bytes_allocated += new_size;
 
@@ -319,7 +313,6 @@ mono_mempool_alloc (MonoMemPool *pool, guint size)
 			pool->pos += size;
 		}
 	}
-#endif
 
 	return rval;
 }
@@ -334,14 +327,12 @@ mono_mempool_alloc0 (MonoMemPool *pool, guint size)
 {
 	gpointer rval;
 
-#ifdef MALLOC_ALLOCATION
-	rval = mono_mempool_alloc (pool, size);
-#else
+	// For the fast path, repeat the first few lines of mono_mempool_alloc
 	size = ALIGN_SIZE (size);
-
 	rval = pool->pos;
 	pool->pos = (guint8*)rval + size;
 
+	// If that doesn't work fall back on mono_mempool_alloc to handle new chunk allocation
 	if (G_UNLIKELY (pool->pos >= pool->end)) {
 		rval = mono_mempool_alloc (pool, size);
 	}
@@ -349,7 +340,6 @@ mono_mempool_alloc0 (MonoMemPool *pool, guint size)
 	else if (pool == mono_get_corlib ()->mempool) {
 		mono_backtrace (size);
 	}
-#endif
 #endif
 
 	memset (rval, 0, size);
@@ -365,28 +355,13 @@ gboolean
 mono_mempool_contains_addr (MonoMemPool *pool,
 							gpointer addr)
 {
-#ifdef MALLOC_ALLOCATION
-	Chunk *c;
+	MonoMemPool *p = pool;
 
-	c = pool->chunks;
-	while (c) {
-		guint8 *p = ((guint8*)c) + sizeof (Chunk);
-
-		if (addr >= (gpointer)p && addr < (gpointer)(p + c->size))
-			return TRUE;
-
-		c = c->next;
-	}
-#else
-	MonoMemPool *p;
-
-	p = pool;
 	while (p) {
-		if (addr > (gpointer)p && addr <= (gpointer)((guint8*)p + p->size))
+		if (addr >= (gpointer)p && addr < (gpointer)((guint8*)p + p->size))
 			return TRUE;
 		p = p->next;
 	}
-#endif
 
 	return FALSE;
 }
@@ -422,11 +397,7 @@ mono_mempool_strdup (MonoMemPool *pool,
 guint32
 mono_mempool_get_allocated (MonoMemPool *pool)
 {
-#ifdef MALLOC_ALLOCATION
-	return pool->allocated;
-#else
 	return pool->d.allocated;
-#endif
 }
 
 /**

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -147,9 +147,6 @@ mono_mempool_destroy (MonoMemPool *pool)
 void
 mono_mempool_invalidate (MonoMemPool *pool)
 {
-#ifdef INDIVIDUAL_ALLOCATIONS
-	g_assert_not_reached ();
-#else
 	MonoMemPool *p, *n;
 
 	p = pool;
@@ -158,7 +155,6 @@ mono_mempool_invalidate (MonoMemPool *pool)
 		memset (p, 42, p->size);
 		p = n;
 	}
-#endif
 }
 
 /**
@@ -173,9 +169,6 @@ mono_mempool_invalidate (MonoMemPool *pool)
 void
 mono_mempool_stats (MonoMemPool *pool)
 {
-#ifdef INDIVIDUAL_ALLOCATIONS
-	g_assert_not_reached ();
-#else
 	MonoMemPool *p;
 	int count = 0;
 	guint32 still_free = pool->end - pool->pos;
@@ -191,10 +184,8 @@ mono_mempool_stats (MonoMemPool *pool)
 		g_print ("Num chunks: %d\n", count);
 		g_print ("Free memory: %d\n", still_free);
 	}
-#endif
 }
 
-#ifndef INDIVIDUAL_ALLOCATIONS
 #ifdef TRACE_ALLOCATIONS
 #include <execinfo.h>
 #include "metadata/appdomain.h"
@@ -226,7 +217,6 @@ mono_backtrace (int size)
         mono_mutex_unlock (&mempool_tracing_lock);
 }
 
-#endif
 #endif
 
 /**

--- a/mono/metadata/mempool.h
+++ b/mono/metadata/mempool.h
@@ -20,9 +20,6 @@ MONO_API void
 mono_mempool_invalidate    (MonoMemPool *pool);
 
 MONO_API void
-mono_mempool_empty         (MonoMemPool *pool);
-
-MONO_API void
 mono_mempool_stats         (MonoMemPool *pool);
 
 MONO_API void*

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -217,10 +217,16 @@ struct _MonoImage {
 
 	/* Whenever this image is considered as platform code for the CoreCLR security model */
 	guint8 core_clr_platform_code : 1;
-			    
+
+	/* The path to the file for this image. */
 	char *name;
+
+	/* The assembly name reported in the file for this image (expected to be NULL for a netmodule) */
 	const char *assembly_name;
+
+	/* The module name reported in the file for this image (could be NULL for a malformed file) */
 	const char *module_name;
+
 	char *version;
 	gint16 md_version_major, md_version_minor;
 	char *guid;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -484,6 +484,10 @@ mono_tables_names [] = {
 
 #endif
 
+// Amount initially reserved in each imageset's mempool.
+// FIXME: This number is arbitrary, a more practical number should be found
+#define INITIAL_IMAGE_SET_SIZE    1024
+
 /**
  * mono_meta_table_name:
  * @table: table index
@@ -2437,7 +2441,7 @@ mono_image_set_alloc (MonoImageSet *set, guint size)
 
 	mono_image_set_lock (set);
 	if (!set->mempool)
-		set->mempool = mono_mempool_new_size (1024);
+		set->mempool = mono_mempool_new_size (INITIAL_IMAGE_SET_SIZE);
 	res = mono_mempool_alloc (set->mempool, size);
 	mono_image_set_unlock (set);
 
@@ -2451,7 +2455,7 @@ mono_image_set_alloc0 (MonoImageSet *set, guint size)
 
 	mono_image_set_lock (set);
 	if (!set->mempool)
-		set->mempool = mono_mempool_new_size (1024);
+		set->mempool = mono_mempool_new_size (INITIAL_IMAGE_SET_SIZE);
 	res = mono_mempool_alloc0 (set->mempool, size);
 	mono_image_set_unlock (set);
 
@@ -2465,7 +2469,7 @@ mono_image_set_strdup (MonoImageSet *set, const char *s)
 
 	mono_image_set_lock (set);
 	if (!set->mempool)
-		set->mempool = mono_mempool_new_size (1024);
+		set->mempool = mono_mempool_new_size (INITIAL_IMAGE_SET_SIZE);
 	res = mono_mempool_strdup (set->mempool, s);
 	mono_image_set_unlock (set);
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -470,18 +470,16 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf)
 		break;
 	}
 	case MONO_AOT_TYPEREF_VAR: {
-		MonoType *t;
+		MonoType *t = NULL;
 		MonoGenericContainer *container = NULL;
 		int type = decode_value (p, &p);
 		int num = decode_value (p, &p);
 		gboolean has_container = decode_value (p, &p);
 		MonoType *gshared_constraint = NULL;
-		char *par_name = NULL;
 
-		t = NULL;
 		if (has_container) {
 			gboolean is_method = decode_value (p, &p);
-			
+
 			if (is_method) {
 				MonoMethod *method_def;
 				g_assert (type == MONO_TYPE_MVAR);
@@ -531,8 +529,6 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf)
 				par->gshared_constraint = gshared_constraint;
 				par->image = module->assembly->image;
 				t->data.generic_param = par;
-				if (par_name)
-					((MonoGenericParamFull*)par)->info.name = par_name;
 			}
 			// FIXME: Maybe use types directly to avoid
 			// the overhead of creating MonoClass-es

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -529,8 +529,7 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf)
 				MonoGenericParam *par = (MonoGenericParam*)mono_image_alloc0 (module->assembly->image, sizeof (MonoGenericParamFull));
 				par->num = num;
 				par->gshared_constraint = gshared_constraint;
-				// FIXME:
-				par->image = mono_defaults.corlib;
+				par->image = module->assembly->image;
 				t->data.generic_param = par;
 				if (par_name)
 					((MonoGenericParamFull*)par)->info.name = par_name;
@@ -4403,7 +4402,7 @@ mono_aot_plt_resolve (gpointer aot_module, guint32 plt_info_offset, guint8 *code
 
 	ji.type = decode_value (p, &p);
 
-	mp = mono_mempool_new_size (512);
+	mp = mono_mempool_new ();
 	res = decode_patch (module, mp, &ji, p, &p);
 
 	if (!res) {


### PR DESCRIPTION
At Rodrigo's advice I am splitting out separable parts of pull request #2163 into their own PRs. This one refactors the image caches in image.c, so that lookups by name and lookups by path are out of two separate hashes, so that iterating over "all open images" can be done in a more sensible way.