### PR TITLE
[Processes] Memory leak fix in EnumProcessModules function

### DIFF
--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -1780,7 +1780,7 @@ gboolean EnumProcessModules (gpointer process, gpointer *modules,
 			return FALSE;
 		}
 		pid = process_handle->id;
-		proc_name = process_handle->proc_name;
+		proc_name = g_strdup (process_handle->proc_name);
 	}
 	
 #if defined(PLATFORM_MACOSX) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__HAIKU__)
@@ -1798,6 +1798,7 @@ gboolean EnumProcessModules (gpointer process, gpointer *modules,
 		 */
 		modules[0] = NULL;
 		*needed = sizeof(gpointer);
+		g_free (proc_name);
 		return TRUE;
 	}
 	mods = load_modules (fp);
@@ -1831,7 +1832,8 @@ gboolean EnumProcessModules (gpointer process, gpointer *modules,
 		free_procmodule (g_slist_nth_data (mods, i));
 	}
 	g_slist_free (mods);
-
+	g_free (proc_name);
+	
 	return TRUE;
 }
 


### PR DESCRIPTION
The main point is that get_process_name_from_proc's result string is never released.