### PR TITLE
This is a small batch of MonoError cleanups.

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -1322,13 +1322,13 @@ get_type (MonoImage *m, const char *ptr, char **result, gboolean is_def, MonoGen
 	}
 
 	default:
-		t = mono_metadata_parse_type_full (m, container, MONO_PARSE_TYPE, 0, start, &ptr);
+		t = mono_metadata_parse_type_full (m, container, 0, start, &ptr);
 		if (t) {
 			*result = dis_stringify_type (m, t, is_def);
 		} else {
 			GString *err = g_string_new ("@!#$<InvalidType>$#!@");
 			if (container)
-				t = mono_metadata_parse_type_full (m, NULL, MONO_PARSE_TYPE, 0, start, &ptr);
+				t = mono_metadata_parse_type_full (m, NULL, 0, start, &ptr);
 			if (t) {
 				char *name = dis_stringify_type (m, t, is_def);
 				g_warning ("Encountered a generic type inappropriate for its context");

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -980,7 +980,7 @@ dis_property_signature (MonoImage *m, guint32 prop_idx, MonoGenericContainer *co
 		g_string_append (res, "instance ");
 	ptr++;
 	pcount = mono_metadata_decode_value (ptr, &ptr);
-	type = mono_metadata_parse_type_full (m, container, MONO_PARSE_TYPE, 0, ptr, &ptr);
+	type = mono_metadata_parse_type_full (m, container, 0, ptr, &ptr);
 	blurb = dis_stringify_type (m, type, TRUE);
 	if (prop_flags & 0x0200)
 		g_string_append (res, "specialname ");
@@ -993,7 +993,7 @@ dis_property_signature (MonoImage *m, guint32 prop_idx, MonoGenericContainer *co
 	for (i = 0; i < pcount; i++) {
 		if (i)
 			g_string_append (res, ", ");
-		param = mono_metadata_parse_type_full (m, container, MONO_PARSE_PARAM, 0, ptr, &ptr);
+		param = mono_metadata_parse_type_full (m, container, 0, ptr, &ptr);
 		blurb = dis_stringify_param (m, param);
 		g_string_append (res, blurb);
 		g_free (blurb);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1340,7 +1340,7 @@ mono_class_find_enum_basetype (MonoClass *class, MonoError *error)
 			goto fail;
 		}
 
-		ftype = mono_metadata_parse_type_full (m, container, MONO_PARSE_FIELD, cols [MONO_FIELD_FLAGS], sig + 1, &sig);
+		ftype = mono_metadata_parse_type_full (m, container, cols [MONO_FIELD_FLAGS], sig + 1, &sig);
 		if (!ftype) {
 			if (mono_loader_get_last_error ()) /*FIXME plug the above to not leak errors*/
 				mono_error_set_from_loader_error (error);
@@ -10548,7 +10548,7 @@ mono_field_resolve_type (MonoClassField *field, MonoError *error)
 		mono_metadata_decode_value (sig, &sig);
 		/* FIELD signature == 0x06 */
 		g_assert (*sig == 0x06);
-		field->type = mono_metadata_parse_type_full (image, container, MONO_PARSE_FIELD, cols [MONO_FIELD_FLAGS], sig + 1, &sig);
+		field->type = mono_metadata_parse_type_full (image, container, cols [MONO_FIELD_FLAGS], sig + 1, &sig);
 		if (!field->type)
 			mono_class_set_failure_from_loader_error (class, error, g_strdup_printf ("Could not load field %s type", field->name));
 	}

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -895,5 +895,8 @@ mono_method_get_wrapper_cache (MonoMethod *method);
 MonoWrapperCaches*
 mono_method_get_wrapper_cache (MonoMethod *method);
 
+MonoType*
+mono_metadata_parse_type_checked (MonoImage *m, MonoGenericContainer *container, short opt_attrs, gboolean transient, const char *ptr, const char **rptr, MonoError *error);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -724,7 +724,6 @@ mono_metadata_parse_array_full              (MonoImage             *image,
 MONO_API MonoType *
 mono_metadata_parse_type_full               (MonoImage             *image,
 					     MonoGenericContainer  *container,
-					     MonoParseTypeMode      mode,
 					     short                  opt_attrs,
 					     const char            *ptr,
 					     const char           **rptr);

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1329,7 +1329,7 @@ mono_metadata_parse_array_internal (MonoImage *m, MonoGenericContainer *containe
 	MonoType *etype;
 	
 	array = transient ? g_malloc0 (sizeof (MonoArrayType)) : mono_image_alloc0 (m, sizeof (MonoArrayType));
-	etype = mono_metadata_parse_type_full (m, container, MONO_PARSE_TYPE, 0, ptr, &ptr);
+	etype = mono_metadata_parse_type_full (m, container, 0, ptr, &ptr);
 	if (!etype)
 		return NULL;
 	array->eklass = mono_class_from_mono_type (etype);
@@ -1595,7 +1595,7 @@ mono_metadata_cleanup (void)
  * Returns: a #MonoType structure representing the decoded type.
  */
 static MonoType*
-mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container, MonoParseTypeMode mode,
+mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container,
 								   short opt_attrs, gboolean transient, const char *ptr, const char **rptr)
 {
 	MonoType *type, *cached;
@@ -1727,10 +1727,10 @@ mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container
 }
 
 MonoType*
-mono_metadata_parse_type_full (MonoImage *m, MonoGenericContainer *container, MonoParseTypeMode mode,
+mono_metadata_parse_type_full (MonoImage *m, MonoGenericContainer *container,
 							   short opt_attrs, const char *ptr, const char **rptr)
 {
-	return mono_metadata_parse_type_internal (m, container, mode, opt_attrs, FALSE, ptr, rptr);
+	return mono_metadata_parse_type_internal (m, container, opt_attrs, FALSE, ptr, rptr);
 }
 
 /*
@@ -1740,7 +1740,7 @@ MonoType*
 mono_metadata_parse_type (MonoImage *m, MonoParseTypeMode mode, short opt_attrs,
 			  const char *ptr, const char **rptr)
 {
-	return mono_metadata_parse_type_full (m, NULL, mode, opt_attrs, ptr, rptr);
+	return mono_metadata_parse_type_full (m, NULL, opt_attrs, ptr, rptr);
 }
 
 gboolean
@@ -2022,7 +2022,7 @@ mono_metadata_parse_method_signature_full (MonoImage *m, MonoGenericContainer *c
 	method->generic_param_count = gen_param_count;
 
 	if (call_convention != 0xa) {
-		method->ret = mono_metadata_parse_type_full (m, container, MONO_PARSE_RET, pattrs ? pattrs [0] : 0, ptr, &ptr);
+		method->ret = mono_metadata_parse_type_full (m, container, pattrs ? pattrs [0] : 0, ptr, &ptr);
 		if (!method->ret) {
 			mono_metadata_free_method_signature (method);
 			g_free (pattrs);
@@ -2052,7 +2052,7 @@ mono_metadata_parse_method_signature_full (MonoImage *m, MonoGenericContainer *c
 			method->sentinelpos = i;
 			ptr++;
 		}
-		method->params [i] = mono_metadata_parse_type_full (m, container, MONO_PARSE_PARAM, pattrs ? pattrs [i+1] : 0, ptr, &ptr);
+		method->params [i] = mono_metadata_parse_type_full (m, container, pattrs ? pattrs [i+1] : 0, ptr, &ptr);
 		if (!method->params [i]) {
 			if (mono_loader_get_last_error ())
 				mono_error_set_from_loader_error (error);
@@ -3091,7 +3091,7 @@ mono_metadata_parse_generic_inst (MonoImage *m, MonoGenericContainer *container,
 	type_argv = g_new0 (MonoType*, count);
 
 	for (i = 0; i < count; i++) {
-		MonoType *t = mono_metadata_parse_type_full (m, container, MONO_PARSE_TYPE, 0, ptr, &ptr);
+		MonoType *t = mono_metadata_parse_type_full (m, container, 0, ptr, &ptr);
 		if (!t) {
 			g_free (type_argv);
 			return NULL;
@@ -3339,7 +3339,7 @@ do_mono_metadata_parse_type (MonoType *type, MonoImage *m, MonoGenericContainer 
 		break;
 	}
 	case MONO_TYPE_SZARRAY: {
-		MonoType *etype = mono_metadata_parse_type_full (m, container, MONO_PARSE_MOD_TYPE, 0, ptr, &ptr);
+		MonoType *etype = mono_metadata_parse_type_full (m, container, 0, ptr, &ptr);
 		if (!etype)
 			return FALSE;
 		type->data.klass = mono_class_from_mono_type (etype);
@@ -3348,7 +3348,7 @@ do_mono_metadata_parse_type (MonoType *type, MonoImage *m, MonoGenericContainer 
 		break;
 	}
 	case MONO_TYPE_PTR:
-		type->data.type = mono_metadata_parse_type_internal (m, container, MONO_PARSE_MOD_TYPE, 0, transient, ptr, &ptr);
+		type->data.type = mono_metadata_parse_type_internal (m, container, 0, transient, ptr, &ptr);
 		if (!type->data.type)
 			return FALSE;
 		break;
@@ -3694,7 +3694,7 @@ mono_metadata_parse_mh_full (MonoImage *m, MonoGenericContainer *container, cons
 		mh->num_locals = len;
 		for (i = 0; i < len; ++i) {
 			mh->locals [i] = mono_metadata_parse_type_internal (m, container,
-																MONO_PARSE_LOCAL, 0, TRUE, locals_ptr, &locals_ptr);
+																0, TRUE, locals_ptr, &locals_ptr);
 			if (!mh->locals [i])
 				goto fail;
 		}
@@ -5528,7 +5528,7 @@ mono_type_create_from_typespec_checked (MonoImage *image, guint32 type_spec, Mon
 
 	mono_metadata_decode_value (ptr, &ptr);
 
-	type = mono_metadata_parse_type_internal (image, NULL, MONO_PARSE_TYPE, 0, TRUE, ptr, &ptr);
+	type = mono_metadata_parse_type_internal (image, NULL, 0, TRUE, ptr, &ptr);
 	if (!type) {
 		if (mono_loader_get_last_error ())
 			mono_error_set_from_loader_error (error);

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2104,13 +2104,16 @@ mono_metadata_parse_method_signature_full (MonoImage *m, MonoGenericContainer *c
 MonoMethodSignature *
 mono_metadata_parse_method_signature (MonoImage *m, int def, const char *ptr, const char **rptr)
 {
+	/*
+	 * This function MUST NOT be called by runtime code as it does error handling incorrectly.
+	 * Use mono_metadata_parse_method_signature_full instead.
+	 * It's ok to asser on failure as we no longer use it.
+	 */
 	MonoError error;
 	MonoMethodSignature *ret;
 	ret = mono_metadata_parse_method_signature_full (m, NULL, def, ptr, rptr, &error);
-	if (!ret) {
-		mono_loader_set_error_from_mono_error (&error);
-		mono_error_cleanup (&error); /*FIXME don't swallow the error message*/
-	}
+	g_assert (mono_error_ok (&error));
+
 	return ret;
 }
 


### PR DESCRIPTION
This makes 3 more cases in do_mono_metadata_parse_type rely on MonoError.

mono_metadata_parse_type_checked looks funky but eventually it will pass
the MonoError through it. This is just an intermediate step until
the rest of the parsing functions are adjusted.