### PR TITLE
[threads] Avoid using same signals as sgen-os-posix.c

### DIFF
--- a/mono/utils/mono-threads-posix-signals.c
+++ b/mono/utils/mono-threads-posix-signals.c
@@ -44,6 +44,8 @@ signal_search_alternative (int min_signal)
 	/* we try to avoid SIGRTMIN and any one that might have been set already, see bug #75387 */
 	for (i = MAX (min_signal, SIGRTMIN) + 1; i < SIGRTMAX; ++i) {
 		struct sigaction sinfo;
+		if (i == DEFAULT_SUSPEND_SIGNAL || i == DEFAULT_RESTART_SIGNAL)
+			continue;
 		sigaction (i, NULL, &sinfo);
 		if (sinfo.sa_handler == SIG_DFL && (void*)sinfo.sa_sigaction == (void*)SIG_DFL) {
 			return i;


### PR DESCRIPTION
This would trigger a hang with finalizer-threads.cs, because sgen-stw
would send a signal, but it would be the mono-threads-posix-signal.c
suspend_signal_handler which would be run for the signal. That would
trigger a deadlock, because sgen_wait_for_suspend_ack would wait
indefinitely for the suspend_ack_semaphore_ptr which would never be
posted.