### PR TITLE
Exception serializes the InnerException as System.Exception

### DIFF
--- a/mcs/class/corlib/System/Exception.cs
+++ b/mcs/class/corlib/System/Exception.cs
@@ -248,7 +248,7 @@ namespace System
 
 			info.AddValue ("ClassName", ClassName);
 			info.AddValue ("Message", _message);
-			info.AddValue ("InnerException", inner_exception);
+			info.AddValue ("InnerException", inner_exception, typeof (Exception));
 			info.AddValue ("HelpURL", help_link);
 			info.AddValue ("StackTraceString", StackTrace);
 			info.AddValue ("RemoteStackTraceString", _remoteStackTraceString);


### PR DESCRIPTION
... not as it's run-time type.

This makes serialization consistent with deserialization (where the InnerException is already retrieved as System.Exception explicitly).
Additionally it may allow serializers more options in serializing inner exceptions (i.e. fall back to System.Exception if the specific exception is not serializable itself).