### PR TITLE
Get do_mono_metadata_parse_type to use MonoError

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1196,12 +1196,9 @@ method_from_methodspec (MonoImage *image, MonoGenericContext *context, guint32 i
 	ptr++;
 	param_count = mono_metadata_decode_value (ptr, &ptr);
 
-	inst = mono_metadata_parse_generic_inst (image, NULL, param_count, ptr, &ptr);
-	if (!inst) {
-		mono_loader_assert_no_error ();
-		mono_error_set_bad_image (error, image, "Cannot parse generic instance for methodspec 0x%08x", idx);
+	inst = mono_metadata_parse_generic_inst (image, NULL, param_count, ptr, &ptr, error);
+	if (!inst)
 		return NULL;
-	}
 
 	if (context && inst->is_open) {
 		inst = mono_metadata_inflate_generic_inst (inst, context, error);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -759,7 +759,8 @@ mono_metadata_parse_generic_inst            (MonoImage             *image,
 					     MonoGenericContainer  *container,
 					     int                    count,
 					     const char            *ptr,
-					     const char           **rptr);
+					     const char           **rptr,
+						 MonoError *error);
 
 MonoGenericInst *
 mono_metadata_get_generic_inst              (int 		    type_argc,


### PR DESCRIPTION
This refactors enough of the loading code to the point that it gets do_mono_metadata_parse_type to use MonoError.

Still far from done, but the score here is -3 loader error occurrences.