### PR TITLE
[threadpool-ms-io] Fix some crashy mono_trace () calls.

### DIFF
--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -284,8 +284,8 @@ wait_callback (gint fd, gint events, gpointer user_data)
 
 			operations = get_operations_for_jobs (list);
 
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_THREADPOOL, "io threadpool: res fd %3d, events = %2s | %2s | %2s",
-				fd, (operations & EVENT_IN) ? "RD" : "..", (operations & EVENT_OUT) ? "WR" : "..");
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_THREADPOOL, "io threadpool: res fd %3d, events = %2s | %2s | %3s",
+				fd, (operations & EVENT_IN) ? "RD" : "..", (operations & EVENT_OUT) ? "WR" : "..", (operations & EVENT_ERR) ? "ERR" : "...");
 
 			threadpool_io->backend.register_fd (fd, operations, FALSE);
 		} else {
@@ -344,8 +344,8 @@ selector_thread (gpointer data)
 
 				operations = get_operations_for_jobs (list);
 
-				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_THREADPOOL, "io threadpool: %3s fd %3d, operations = %2s | %2s | %2s",
-					exists ? "mod" : "add", fd, (operations & EVENT_IN) ? "RD" : "..", (operations & EVENT_OUT) ? "WR" : "..");
+				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_THREADPOOL, "io threadpool: %3s fd %3d, operations = %2s | %2s | %3s",
+					exists ? "mod" : "add", fd, (operations & EVENT_IN) ? "RD" : "..", (operations & EVENT_OUT) ? "WR" : "..", (operations & EVENT_ERR) ? "ERR" : "...");
 
 				threadpool_io->backend.register_fd (fd, operations, !exists);
 


### PR DESCRIPTION
The format strings declared a string argument that wasn't being passed so the underlying format function crashed when trying to retrieve it.

cc @ludovic-henry