### PR TITLE
[sgen] Fix memory use of the concurrent collector

### DIFF
--- a/mono/sgen/sgen-conf.h
+++ b/mono/sgen/sgen-conf.h
@@ -186,6 +186,11 @@ typedef mword SgenDescriptor;
 #define SGEN_MAX_ALLOWANCE_NURSERY_SIZE_RATIO 10.0
 
 /*
+ * How much more we allow the heap to grow before triggering another major collection
+ */
+#define SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO 0.33
+
+/*
  * Default ratio of memory we want to release in a major collection in relation to the the current heap size.
  *
  * A major collection target is to free a given amount of memory. This amount is a ratio of the major heap size.

--- a/mono/sgen/sgen-conf.h
+++ b/mono/sgen/sgen-conf.h
@@ -191,6 +191,12 @@ typedef mword SgenDescriptor;
 #define SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO 0.33
 
 /*
+ * How much more we allow the heap to grow, relative to the allowance, while doing
+ * a concurrent collection, before forcing its finish.
+ */
+#define SGEN_DEFAULT_CONCURRENT_HEAP_ALLOWANCE_RATIO 0.25
+
+/*
  * Default ratio of memory we want to release in a major collection in relation to the the current heap size.
  *
  * A major collection target is to free a given amount of memory. This amount is a ratio of the major heap size.

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -86,7 +86,7 @@ sgen_memgov_calculate_minor_collection_allowance (void)
 	 * We allow the heap to grow by one third its current size before we start the next
 	 * major collection.
 	 */
-	allowance_target = new_heap_size / 3;
+	allowance_target = new_heap_size * SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO;
 
 	allowance = MAX (allowance_target, MIN_MINOR_COLLECTION_ALLOWANCE);
 

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -112,13 +112,32 @@ sgen_memgov_calculate_minor_collection_allowance (void)
 	}
 }
 
+static inline size_t
+get_heap_size (void)
+{
+	return major_collector.get_num_major_sections () * major_collector.section_size + los_memory_usage;
+}
+
 gboolean
 sgen_need_major_collection (mword space_needed)
 {
 	size_t heap_size;
 
-	if (sgen_concurrent_collection_in_progress ())
+	if (sgen_concurrent_collection_in_progress ()) {
+		heap_size = get_heap_size ();
+
+		if (heap_size <= major_collection_trigger_size)
+			return FALSE; 
+
+		/* We allow the heap to grow an additional third of the allowance during a concurrent collection */
+		if ((heap_size - major_collection_trigger_size) >
+				(major_collection_trigger_size
+				* (SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO / (SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO + 1))
+				* SGEN_DEFAULT_CONCURRENT_HEAP_ALLOWANCE_RATIO)) {
+			return TRUE;
+		}
 		return FALSE;
+	}
 
 	/* FIXME: This is a cop-out.  We should have some way of figuring this out. */
 	if (!major_collector.have_swept ())
@@ -129,7 +148,7 @@ sgen_need_major_collection (mword space_needed)
 
 	sgen_memgov_calculate_minor_collection_allowance ();
 
-	heap_size = major_collector.get_num_major_sections () * major_collector.section_size + los_memory_usage;
+	heap_size = get_heap_size ();
 
 	return heap_size > major_collection_trigger_size;
 }
@@ -150,7 +169,7 @@ sgen_memgov_major_collection_start (void)
 	need_calculate_minor_collection_allowance = TRUE;
 
 	if (debug_print_allowance) {
-		SGEN_LOG (0, "Starting collection with heap size %ld bytes", (long)(major_collector.get_num_major_sections () * major_collector.section_size + los_memory_usage));
+		SGEN_LOG (0, "Starting collection with heap size %ld bytes", (long)get_heap_size ());
 	}
 }
 

--- a/mono/sgen/sgen-workers.h
+++ b/mono/sgen/sgen-workers.h
@@ -29,6 +29,7 @@ struct _WorkerData {
 };
 
 void sgen_workers_init (int num_workers);
+void sgen_workers_stop_all_workers (void);
 void sgen_workers_start_all_workers (SgenObjectOperations *object_ops);
 void sgen_workers_ensure_awake (void);
 void sgen_workers_init_distribute_gray_queue (void);
@@ -37,9 +38,9 @@ void sgen_workers_wait_for_jobs_finished (void);
 void sgen_workers_distribute_gray_queue_sections (void);
 void sgen_workers_reset_data (void);
 void sgen_workers_join (void);
+gboolean sgen_workers_have_idle_work (void);
 gboolean sgen_workers_all_done (void);
 gboolean sgen_workers_are_working (void);
-void sgen_workers_wait (void);
 SgenSectionGrayQueue* sgen_workers_get_distribute_section_gray_queue (void);
 
 #endif


### PR DESCRIPTION
If the concurrent mark takes too long to finish and the mutator allocates a lot of memory in the meantime, we end up with increased memory use due to lack of collections. We handle this scenario by putting a limit on the heap increase during the concurrent collection.

Before (MB/s)

![before](https://cloud.githubusercontent.com/assets/4720621/10921417/2f325926-827e-11e5-8c1e-ded1c74305a0.jpg)

After (MB/s)

![after](https://cloud.githubusercontent.com/assets/4720621/10921452/55b2bdde-827e-11e5-8db4-d1ff46e33998.jpg)
