### PR TITLE
Another round of mono error cleanups.

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -20,6 +20,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/metadata/class.h>
 #include <mono/metadata/marshal.h>
+#include <mono/metadata/metadata-internals.h>
 
 extern gboolean substitute_with_mscorlib_p;
 
@@ -1900,6 +1901,7 @@ get_memberref_parent (MonoImage *m, guint32 mrp_token, MonoGenericContainer *con
 static char *
 get_method_core (MonoImage *m, guint32 token, gboolean fullsig, MonoGenericContainer *container)
 {
+	MonoError error;
 	int idx = mono_metadata_token_index (token);
 	guint32 member_cols [MONO_MEMBERREF_SIZE], method_cols [MONO_METHOD_SIZE];
 	char *sig = NULL, *esname;
@@ -1908,7 +1910,7 @@ get_method_core (MonoImage *m, guint32 token, gboolean fullsig, MonoGenericConta
 	MonoMethod *mh;
 	MonoGenericContainer *type_container = container;
 
-	mh = mono_get_method_full (m, token, NULL, (MonoGenericContext *) container);
+	mh = mono_get_method_checked (m, token, NULL, (MonoGenericContext *) container, &error);
 	if (mh) {
 		if (mono_method_signature (mh)->is_inflated)
 			container = mono_method_get_generic_container (((MonoMethodInflated *) mh)->declaring);
@@ -1920,8 +1922,10 @@ get_method_core (MonoImage *m, guint32 token, gboolean fullsig, MonoGenericConta
 			name = g_strdup_printf ("%s%s%s", sig ? sig : "", sig ? "::" : "", esname);
 		g_free (sig);
 		g_free (esname);
-	} else
+	} else {
 		name = NULL;
+		mono_error_cleanup (&error);
+	}
 
 	switch (mono_metadata_token_code (token)){
 	case MONO_TOKEN_METHOD_DEF:
@@ -2005,13 +2009,14 @@ get_method (MonoImage *m, guint32 token, MonoGenericContainer *container)
 char *
 get_methoddef (MonoImage *m, guint32 idx)
 {
-        guint32 cols [MONO_METHOD_SIZE];
+	MonoError error;
+	guint32 cols [MONO_METHOD_SIZE];
 	char *sig;
 	const char *name;
 
 	MonoMethod *mh;
 
-	mh = mono_get_method (m, MONO_TOKEN_METHOD_DEF | idx, NULL);
+	mh = mono_get_method_checked (m, MONO_TOKEN_METHOD_DEF | idx, NULL, NULL, &error);
 	if (mh) {
 		sig = dis_stringify_type (m, &mh->klass->byval_arg, FALSE);
 		name = g_strdup_printf ("%s%s%s", 
@@ -2019,13 +2024,15 @@ get_methoddef (MonoImage *m, guint32 idx)
 				sig ? "::" : "",
 				mh->name);
 		g_free (sig);
-	} else
-		name = NULL;
-        mono_metadata_decode_row (&m->tables [MONO_TABLE_METHOD], 
-                        idx - 1, cols, MONO_METHOD_SIZE);
-        sig = get_methodref_signature (m, cols [MONO_METHOD_SIGNATURE], name);
+	} else {
+		name = g_strdup_printf ("!bad-method-name!");
+		mono_error_cleanup (&error);
+	}
+    mono_metadata_decode_row (&m->tables [MONO_TABLE_METHOD], 
+                    idx - 1, cols, MONO_METHOD_SIZE);
+    sig = get_methodref_signature (m, cols [MONO_METHOD_SIGNATURE], name);
         
-        return sig;
+	return sig;
 }
 
 char *
@@ -2068,7 +2075,8 @@ get_method_type_param (MonoImage *m, guint32 blob_signature, MonoGenericContaine
 char *
 get_methodspec (MonoImage *m, int idx, guint32 token, const char *fancy_name, MonoGenericContainer *type_container)
 {
-        GString *res = g_string_new ("");
+	MonoError error;
+	GString *res = g_string_new ("");
 	guint32 member_cols [MONO_MEMBERREF_SIZE], method_cols [MONO_METHOD_SIZE];
         char *s, *type_param;
         const char *ptr;
@@ -2097,8 +2105,13 @@ get_methodspec (MonoImage *m, int idx, guint32 token, const char *fancy_name, Mo
 	ptr = mono_metadata_blob_heap (m, sig);
 	mono_metadata_decode_value (ptr, &ptr);
 	
-	mh = mono_get_method_full (m, method_dor_to_token (token), NULL, (MonoGenericContext *) type_container);
-	g_assert (mh);
+	mh = mono_get_method_checked (m, method_dor_to_token (token), NULL, (MonoGenericContext *) type_container, &error);
+	if (!mh) {
+		g_string_append_printf (res, "Could not decode method token 0x%x due to %s", token, mono_error_get_message (&error));
+		mono_error_cleanup (&error);
+		return g_string_free (res, FALSE);
+	}
+
 	container = mono_method_get_generic_container (mh);
 	if (!container)
 		container = type_container;
@@ -3098,8 +3111,9 @@ get_method_override (MonoImage *m, guint32 token, MonoGenericContainer *containe
 		decl = method_dor_to_token (cols [MONO_METHODIMPL_DECLARATION]);
 
 		if (token == impl) {
+			MonoError error;
 			MonoMethod *mh = NULL;
-			mh = mono_get_method_full (m, decl, NULL, (MonoGenericContext *) container);
+			mh = mono_get_method_checked (m, decl, NULL, (MonoGenericContext *) container, &error);
 
 			if (mh && (mh->klass && (mh->klass->generic_class || mh->klass->generic_container))) {
 				char *meth_str;
@@ -3110,7 +3124,12 @@ get_method_override (MonoImage *m, guint32 token, MonoGenericContainer *containe
 				g_free (meth_str);
 				return ret;
 			} else {
-				return get_method_core (m, decl, FALSE, container);
+				char *meth_str = get_method_core (m, decl, FALSE, container);
+				char *ret = g_strdup_printf ("Could not decode method override %s due to %s", meth_str, mono_error_get_message (&error));
+
+				mono_error_cleanup (&error);
+				g_free (meth_str);
+				return ret;
 			}
 		}
 	}

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -271,6 +271,7 @@ mono_attach_cleanup (void)
 static int
 mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject **exc)
 {
+	MonoError error;
 	MonoAssembly *agent_assembly;
 	MonoImage *image;
 	MonoMethod *method;
@@ -298,9 +299,10 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 		return 1;
 	}
 
-	method = mono_get_method (image, entry, NULL);
+	method = mono_get_method_checked (image, entry, NULL, NULL, &error);
 	if (method == NULL){
-		g_print ("The entry point method of assembly '%s' could not be loaded\n", agent);
+		g_print ("The entry point method of assembly '%s' could not be loaded due to %s\n", agent, mono_error_get_message (&error));
+		mono_error_cleanup (&error);
 		g_free (agent);
 		return 1;
 	}

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -136,6 +136,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 /* Called by ntdll.dll reagardless of entry point after _CorValidateImage. */
 __int32 STDMETHODCALLTYPE _CorExeMain(void)
 {
+	MonoError error;
 	MonoDomain* domain;
 	MonoAssembly* assembly;
 	MonoImage* image;
@@ -179,9 +180,10 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		ExitProcess (1);
 	}
 
-	method = mono_get_method (image, entry, NULL);
+	method = mono_get_method_checked (image, entry, NULL, NULL, &error);
 	if (method == NULL) {
 		g_free (file_name);
+		mono_error_cleanup (&error); /* FIXME don't swallow the error */
 		MessageBox (NULL, L"The entry point method could not be loaded.", NULL, MB_ICONERROR);
 		mono_runtime_quit ();
 		ExitProcess (1);

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -516,12 +516,17 @@ mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image)
 	mono_image_get_table_info (image, MONO_TABLE_TYPEDEF);
 	methods = mono_image_get_table_info (image, MONO_TABLE_METHOD);
 	for (i = 0; i < mono_table_info_get_rows (methods); ++i) {
+		MonoError error;
 		guint32 token = mono_metadata_decode_row_col (methods, i, MONO_METHOD_NAME);
 		const char *n = mono_metadata_string_heap (image, token);
 
 		if (strcmp (n, desc->name))
 			continue;
-		method = mono_get_method (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL);
+		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
+		if (!method) {
+			mono_error_cleanup (&error);
+			continue;
+		}
 		if (mono_method_desc_full_match (desc, method))
 			return method;
 	}

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -533,17 +533,14 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 /*
  * mono_field_from_token:
  * @deprecated use the _checked variant
+ * Notes: runtime code MUST not use this function
 */
 MonoClassField*
 mono_field_from_token (MonoImage *image, guint32 token, MonoClass **retklass, MonoGenericContext *context)
 {
 	MonoError error;
 	MonoClassField *res = mono_field_from_token_checked (image, token, retklass, context, &error);
-	mono_loader_assert_no_error ();
-	if (!mono_error_ok (&error)) {
-		mono_loader_set_error_from_mono_error (&error);
-		mono_error_cleanup (&error);
-	}
+	g_assert (mono_error_ok (&error));
 	return res;
 }
 
@@ -898,20 +895,15 @@ inflate_generic_header (MonoMethodHeader *header, MonoGenericContext *context)
 
 /*
  * token is the method_ref/def/spec token used in a call IL instruction.
+ * @deprecated use the _checked variant
+ * Notes: runtime code MUST not use this function
  */
 MonoMethodSignature*
 mono_method_get_signature_full (MonoMethod *method, MonoImage *image, guint32 token, MonoGenericContext *context)
 {
 	MonoError error;
 	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, context, &error);
-
-	mono_loader_assert_no_error ();
-
-	if (!res) {
-		g_assert (!mono_error_ok (&error));
-		mono_loader_set_error_from_mono_error (&error);
-		mono_error_cleanup (&error); /* FIXME Don't swallow the error */
-	}
+	g_assert (mono_error_ok (&error));
 	return res;
 }
 
@@ -1000,19 +992,17 @@ mono_method_get_signature_checked (MonoMethod *method, MonoImage *image, guint32
 	return sig;
 }
 
+/*
+ * token is the method_ref/def/spec token used in a call IL instruction.
+ * @deprecated use the _checked variant
+ * Notes: runtime code MUST not use this function
+ */
 MonoMethodSignature*
 mono_method_get_signature (MonoMethod *method, MonoImage *image, guint32 token)
 {
 	MonoError error;
 	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, NULL, &error);
-
-	mono_loader_assert_no_error ();
-
-	if (!res) {
-		g_assert (!mono_error_ok (&error));
-		mono_loader_set_error_from_mono_error (&error);
-		mono_error_cleanup (&error); /* FIXME Don't swallow the error */
-	}
+	g_assert (mono_error_ok (&error));
 	return res;
 }
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -8106,6 +8106,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 gpointer
 mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 {
+	MonoError error;
 	MonoMethod *method;
 	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
@@ -8113,7 +8114,9 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 
 	g_assert (token);
 
-	method = mono_get_method (image, token, NULL);
+	method = mono_get_method_checked (image, token, NULL, NULL, &error);
+	if (!method)
+		g_error ("Could not load vtfixup token 0x%x due to %s", token, mono_error_get_message (&error));
 	g_assert (method);
 
 	if (type & (VTFIXUP_TYPE_FROM_UNMANAGED | VTFIXUP_TYPE_FROM_UNMANAGED_RETAIN_APPDOMAIN)) {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -9007,6 +9007,7 @@ mono_custom_attrs_from_index (MonoImage *image, guint32 idx)
 	ainfo->num_attrs = len;
 	ainfo->image = image;
 	for (i = len, tmp = list; i != 0; --i, tmp = tmp->next) {
+		MonoError error;
 		mono_metadata_decode_row (ca, GPOINTER_TO_UINT (tmp->data), cols, MONO_CUSTOM_ATTR_SIZE);
 		mtoken = cols [MONO_CUSTOM_ATTR_TYPE] >> MONO_CUSTOM_ATTR_TYPE_BITS;
 		switch (cols [MONO_CUSTOM_ATTR_TYPE] & MONO_CUSTOM_ATTR_TYPE_MASK) {
@@ -9021,9 +9022,10 @@ mono_custom_attrs_from_index (MonoImage *image, guint32 idx)
 			break;
 		}
 		attr = &ainfo->attrs [i - 1];
-		attr->ctor = mono_get_method (image, mtoken, NULL);
+		attr->ctor = mono_get_method_checked (image, mtoken, NULL, NULL, &error);
 		if (!attr->ctor) {
-			g_warning ("Can't find custom attr constructor image: %s mtoken: 0x%08x", image->name, mtoken);
+			g_warning ("Can't find custom attr constructor image: %s mtoken: 0x%08x due to %s", image->name, mtoken, mono_error_get_message (&error));
+			mono_error_cleanup (&error); /* FIXME don't swallow the error */
 			g_list_free (list);
 			g_free (ainfo);
 			return NULL;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3613,10 +3613,12 @@ add_wrappers (MonoAotCompile *acfg)
 #if 0
 	/* remoting-invoke wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
+		MonoError error;
 		MonoMethodSignature *sig;
 		
 		token = MONO_TOKEN_METHOD_DEF | (i + 1);
-		method = mono_get_method (acfg->image, token, NULL);
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
+		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 
 		sig = mono_method_signature (method);
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1204,9 +1204,11 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 		if (!image)
 			return FALSE;
 
-		ref->method = mono_get_method_full (image, ref->token, NULL, NULL);
-		if (!ref->method)
+		ref->method = mono_get_method_checked (image, ref->token, NULL, NULL, &error);
+		if (!ref->method) {
+			mono_error_cleanup (&error); /* FIXME don't swallow the error */
 			return FALSE;
+		}
 
 		memset (&ctx, 0, sizeof (ctx));
 
@@ -1215,7 +1217,8 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 			ctx.method_inst = NULL;
  
 			ref->method = mono_class_inflate_generic_method_full_checked (ref->method, klass, &ctx, &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			if (!ref->method)
+				g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
 		}			
 
 		memset (&ctx, 0, sizeof (ctx));
@@ -1224,7 +1227,9 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 			return FALSE;
 
 		ref->method = mono_class_inflate_generic_method_full_checked (ref->method, klass, &ctx, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		if (!ref->method)
+			g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
+
 	} else if (image_index == MONO_AOT_METHODREF_ARRAY) {
 		MonoClass *klass;
 		int method_type;
@@ -1286,8 +1291,10 @@ decode_method_ref (MonoAotModule *module, MethodRef *ref, guint8 *buf, guint8 **
 static MonoMethod*
 decode_resolve_method_ref_with_target (MonoAotModule *module, MonoMethod *target, guint8 *buf, guint8 **endbuf)
 {
+	MonoError error;
 	MethodRef ref;
 	gboolean res;
+	MonoMethod *result;
 
 	res = decode_method_ref_with_target (module, &ref, target, buf, endbuf);
 	if (!res)
@@ -1296,7 +1303,10 @@ decode_resolve_method_ref_with_target (MonoAotModule *module, MonoMethod *target
 		return ref.method;
 	if (!ref.image)
 		return NULL;
-	return mono_get_method (ref.image, ref.token, NULL);
+	result = mono_get_method_checked (ref.image, ref.token, NULL, NULL, &error);
+	if (!result)
+		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+	return result;
 }
 
 static MonoMethod*
@@ -3230,8 +3240,11 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 					/* Happens when a random address is passed in which matches a not-yey called wrapper encoded using its name */
 					return NULL;
 			} else {
+				MonoError error;
 				token = mono_metadata_make_token (MONO_TABLE_METHOD, method_index + 1);
-				method = mono_get_method (image, token, NULL);
+				method = mono_get_method_checked (image, token, NULL, NULL, &error);
+				if (!method)
+					g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
 			}
 		}
 		/* FIXME: */
@@ -3308,10 +3321,14 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 			ji->type = MONO_PATCH_INFO_ABS;
 		}
 		else {
-			if (ref.method)
+			if (ref.method) {
 				ji->data.method = ref.method;
-			else
-				ji->data.method = mono_get_method (ref.image, ref.token, NULL);
+			}else {
+				MonoError error;
+				ji->data.method = mono_get_method_checked (ref.image, ref.token, NULL, NULL, &error);
+				if (!ji->data.method)
+					g_error ("AOT Runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
+			}
 			g_assert (ji->data.method);
 			mono_class_init (ji->data.method->klass);
 		}
@@ -3698,8 +3715,11 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 			if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT)) {
 				char *full_name;
 
-				if (!method)
-					method = mono_get_method (image, token, NULL);
+				if (!method) {
+					MonoError error;
+					method = mono_get_method_checked (image, token, NULL, NULL, &error);
+					g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+				}
 				full_name = mono_method_full_name (method, TRUE);
 				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "AOT: NOT FOUND: %s.", full_name);
 				g_free (full_name);
@@ -3730,8 +3750,12 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 		if (mono_jit_stats.methods_aot >= mono_last_aot_method)
 				return NULL;
 		else if (mono_jit_stats.methods_aot == mono_last_aot_method - 1) {
-			if (!method)
-				method = mono_get_method (image, token, NULL);
+			if (!method) {
+				MonoError error;
+				method = mono_get_method_checked (image, token, NULL, NULL, &error);
+				if (!method)
+					mono_error_cleanup (&error);/* FIXME don't swallow the error */
+			}
 			if (method) {
 				char *name = mono_method_full_name (method, TRUE);
 				g_print ("LAST AOT METHOD: %s.\n", name);
@@ -3751,8 +3775,12 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 	if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT)) {
 		char *full_name;
 
-		if (!method)
-			method = mono_get_method (image, token, NULL);
+		if (!method) {
+			MonoError error;
+			method = mono_get_method_checked (image, token, NULL, NULL, &error);
+			if (!method)
+				g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
+		}
 
 		full_name = mono_method_full_name (method, TRUE);
 
@@ -3780,8 +3808,10 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 		MonoJitInfo *jinfo;
 
 		if (!method) {
-			method = mono_get_method (amodule->assembly->image, token, NULL);
-			g_assert (method);
+			MonoError error;
+			method = mono_get_method_checked (amodule->assembly->image, token, NULL, NULL, &error);
+			if (!method)
+				g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
 		}
 		mono_profiler_method_jit (method);
 		jinfo = mono_jit_info_table_find (domain, (char*)code);
@@ -4210,7 +4240,8 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method)
 			ctx.method_inst = mono_metadata_get_generic_inst (1, args);
 
 			m = mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (m, &ctx, &error), TRUE, TRUE);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			if (!m)
+				g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
 
 			/* 
 			 * Get the code for the <object> instantiation which should be emitted into
@@ -4244,7 +4275,8 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method)
 			ctx.method_inst = mono_metadata_get_generic_inst (1, args);
 
 			m = mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (m, &ctx, &error), TRUE, TRUE);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			if (!m)
+				g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
 
 			/* Avoid recursion */
 			if (method == m)

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7626,7 +7626,10 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (token == 0) {
 				buffer_add_id (buf, 0);
 			} else {
-				m = mono_get_method (ass->image, token, NULL);
+				MonoError error;
+				m = mono_get_method_checked (ass->image, token, NULL, NULL, &error);
+				if (!m)
+					mono_error_cleanup (&error); /* FIXME don't swallow the error */
 				buffer_add_methodid (buf, domain, m);
 			}
 		}

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -1396,10 +1396,14 @@ token_handler (MonoDisHelper *dh, MonoMethod *method, guint32 token)
 	case CEE_NEWOBJ:
 	case CEE_CALL:
 	case CEE_CALLVIRT:
-		if (method->wrapper_type)
+		if (method->wrapper_type) {
 			cmethod = data;
-		else
-			cmethod = mono_get_method_full (method->klass->image, token, NULL, NULL);
+		} else {
+			MonoError error;
+			cmethod = mono_get_method_checked (method->klass->image, token, NULL, NULL, &error);
+			if (!cmethod)
+				g_error ("Could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
+		}
 		desc = mono_method_full_name (cmethod, TRUE);
 		res = g_strdup_printf ("<%s>", desc);
 		g_free (desc);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7260,20 +7260,21 @@ exception_exit:
 }
 
 static inline MonoMethod *
-mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context)
+mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context, MonoError *error)
 {
-	MonoError error;
 	MonoMethod *method;
+
+	mono_error_init (error);
 
 	if (m->wrapper_type != MONO_WRAPPER_NONE) {
 		method = mono_method_get_wrapper_data (m, token);
 		if (context) {
-			method = mono_class_inflate_generic_method_checked (method, context, &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			method = mono_class_inflate_generic_method_checked (method, context, error);
+			printf ("11) %d\n", mono_error_ok (error));
 		}
 	} else {
-		method = mono_get_method_checked (m->klass->image, token, klass, context, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		method = mono_get_method_checked (m->klass->image, token, klass, context, error);
+		printf ("22) %d\n", mono_error_ok (error));
 	}
 
 	return method;
@@ -7282,8 +7283,13 @@ mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, Mono
 static inline MonoMethod *
 mini_get_method (MonoCompile *cfg, MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context)
 {
-	MonoMethod *method = mini_get_method_allow_open (m, token, klass, context);
+	MonoError error;
+	MonoMethod *method = mini_get_method_allow_open (m, token, klass, context, &error);
 
+	if (!method) {
+		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		return NULL;
+	}
 	if (method && cfg && !cfg->gshared && mono_class_is_open_constructed_type (&method->klass->byval_arg))
 		return NULL;
 
@@ -8913,7 +8919,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (!dont_verify && !cfg->skip_visibility) {
 				MonoMethod *target_method = cil_method;
 				if (method->is_inflated) {
-					target_method = mini_get_method_allow_open (method, token, NULL, &(mono_method_get_generic_container (method_definition)->context));
+					target_method = mini_get_method_allow_open (method, token, NULL, &(mono_method_get_generic_container (method_definition)->context), &cfg->error);
+					CHECK_CFG_ERROR;
 				}
 				if (!mono_method_can_access_method (method_definition, target_method) &&
 					!mono_method_can_access_method (method, cil_method))

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7262,17 +7262,18 @@ exception_exit:
 static inline MonoMethod *
 mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context)
 {
+	MonoError error;
 	MonoMethod *method;
 
 	if (m->wrapper_type != MONO_WRAPPER_NONE) {
 		method = mono_method_get_wrapper_data (m, token);
 		if (context) {
-			MonoError error;
 			method = mono_class_inflate_generic_method_checked (method, context, &error);
 			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 		}
 	} else {
-		method = mono_get_method_full (m->klass->image, token, klass, context);
+		method = mono_get_method_checked (m->klass->image, token, klass, context, &error);
+		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 	}
 
 	return method;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3681,7 +3681,13 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 		printf ("PRECOMPILE: %s.\n", mono_image_get_filename (image));
 
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
-		method = mono_get_method (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL);
+		MonoError error;
+
+		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
+		if (!method) {
+			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			continue;
+		}
 		if (method->flags & METHOD_ATTRIBUTE_ABSTRACT)
 			continue;
 		if (method->is_generic || method->klass->generic_container)

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -829,8 +829,10 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
 
 	addr = mono_aot_get_method_from_token (mono_domain_get (), image, token);
 	if (!addr) {
-		method = mono_get_method (image, token, NULL);
-		g_assert (method);
+		MonoError error;
+		method = mono_get_method_checked (image, token, NULL, NULL, &error);
+		if (!method)
+			g_error ("Could not load AOT trampoline due to %s", mono_error_get_message (&error));
 
 		/* Use the generic code */
 		return mono_magic_trampoline (regs, code, method, tramp);


### PR DESCRIPTION
This removes usage of a few legacy functions and remove loader-error
handling from them since it's no longer needed.