### PR TITLE
Let Mono live with Xcode on EL Capitan. 

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3579,6 +3579,35 @@ mono_amd64_have_tls_get (void)
 
 	tls_gs_offset = ins[5];
 
+    /*
+     * Apple now loads a different version of pthread_getspecific when launched from Xcode
+     * For that version we're looking for these instructions:
+     *
+     * pushq  %rbp
+     * movq   %rsp, %rbp
+     * mov    %gs:[offset](,%rdi,8),%rax
+     * popq   %rbp
+     * retq
+     */
+    if (!have_tls_get) {
+        have_tls_get = ins [0] == 0x55 &&
+        ins [1] == 0x48 &&
+        ins [2] == 0x89 &&
+        ins [3] == 0xe5 &&
+        ins [4] == 0x65 &&
+        ins [5] == 0x48 &&
+        ins [6] == 0x8b &&
+        ins [7] == 0x04 &&
+        ins [8] == 0xfd &&
+        ins [10] == 0x00 &&
+        ins [11] == 0x00 &&
+        ins [12] == 0x00 &&
+        ins [13] == 0x5d &&
+        ins [14] == 0xc3;
+        
+        tls_gs_offset = ins[9];
+    }
+    
 	return have_tls_get;
 #elif defined(TARGET_ANDROID)
 	return FALSE;


### PR DESCRIPTION
This was merged into master as 3adcd34f783a870cc07ab8d9c3b2782328b0938f. Without it Xcode kills Mono due to a changed pthread_getspecific(). Mono 4.2 will likely need the same tls TLC.