### PR TITLE
#35635 Don't trim TimeZone names ending in parenthesys.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -288,7 +288,9 @@ namespace System
 			var Istart = 0;
 			while (Istart < str.Length && !char.IsLetterOrDigit(str[Istart])) Istart++;
 			var Iend = str.Length - 1;
-			while (Iend > Istart && !char.IsLetterOrDigit(str[Iend])) Iend--;
+			while (Iend > Istart &&
+			       !char.IsLetterOrDigit(str[Iend]) && !(str[Iend] == ")"))
+				Iend--;
 			
 			return str.Substring (Istart, Iend-Istart+1);
 		}


### PR DESCRIPTION
Such as "Central Standard Time (Mexico)"

References https://bugzilla.xamarin.com/show_bug.cgi?id=35635