### PR TITLE
[reflection] Fix for  35375 - explicit interface implementation using a generic type instance

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/MonoGenericClassTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MonoGenericClassTest.cs
@@ -201,6 +201,88 @@ namespace MonoTests.System.Reflection.Emit
 			Assert.AreSame (expected, t.BaseType, "#1");
 			
 		}
+
+		[Test]
+		public void GenericClassFromStaleTypeBuilderDoesNotClassInit ()
+		{
+			// interface JJJ<T> {
+			//   abstract void W (x : T)
+			// }
+			MethodInfo winfo = null;
+			TypeBuilder ib = null;
+			Type ic = null;
+			Type icreated = null;
+			{
+				ib = module.DefineType ("Foo.JJJ`1",
+							 TypeAttributes.Public
+							 | TypeAttributes.Interface
+							 | TypeAttributes.Abstract);
+				String[] gens = { "T" };
+				GenericTypeParameterBuilder[] gbs = ib.DefineGenericParameters (gens);
+				var gb = gbs[0];
+				winfo = ib.DefineMethod ("W",
+							 MethodAttributes.Public |
+							 MethodAttributes.Abstract |
+							 MethodAttributes.Virtual,
+							 CallingConventions.HasThis,
+							 typeof(void),
+					 new Type[] { gb });
+				icreated = ib.CreateType();
+
+			}
+
+			// class SSS : JJJ<char> {
+			//   bool wasCalled;
+			//   void JJJ.W (x : T) { wasCalled = true; return; }
+		        // }
+			TypeBuilder tb = null;
+			MethodBuilder mb = null;
+			{
+				tb = module.DefineType ("Foo.SSS",
+							TypeAttributes.Public,
+							null,
+							new Type[]{ icreated.MakeGenericType(typeof(char)) });
+				var wasCalledField = tb.DefineField ("wasCalled",
+								     typeof(bool),
+								     FieldAttributes.Public);
+				mb = tb.DefineMethod ("W_impl",
+						      MethodAttributes.Public | MethodAttributes.Virtual,
+						      CallingConventions.HasThis,
+						      typeof (void),
+						      new Type[] { typeof (char) });
+				{
+					var il = mb.GetILGenerator ();
+					il.Emit (OpCodes.Ldarg_0); // this
+					il.Emit (OpCodes.Ldc_I4_1);
+					il.Emit (OpCodes.Stfld, wasCalledField); // this.wasCalled = true
+					il.Emit (OpCodes.Ret);
+				}
+			}
+
+			ic = ib.MakeGenericType(typeof (char)); // this is a MonoGenericMethod
+			var mintf = TypeBuilder.GetMethod(ic, winfo);
+			// the next line causes mono_class_init() to
+			// be called on JJJ<char> when we try to setup
+			// the vtable for SSS
+			tb.DefineMethodOverride(mb, mintf);
+
+			var result = tb.CreateType();
+
+			// o = new SSS()
+			object o = Activator.CreateInstance(result);
+			Assert.IsNotNull(o, "#1");
+
+			// ((JJJ<char>)o).W('a');
+			var m = icreated.MakeGenericType(typeof(char)).GetMethod("W", BindingFlags.Public | BindingFlags.Instance);
+			Assert.IsNotNull(m, "#2");
+			m.Invoke(o, new object[] {'a'});
+
+			var f = result.GetField("wasCalled", BindingFlags.Public | BindingFlags.Instance);
+			Assert.IsNotNull(f, "#3");
+			var wasCalledVal = f.GetValue(o);
+			Assert.IsInstanceOfType (typeof(Boolean), wasCalledVal, "#4");
+			Assert.AreEqual (wasCalledVal, true, "#5");
+		}
 	}
 }
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5267,7 +5267,7 @@ mono_class_init (MonoClass *klass)
 		if (!MONO_CLASS_IS_INTERFACE (klass) || klass->image != mono_defaults.corlib) {
 			MonoMethod *cmethod = NULL;
 
-			if (klass->type_token) {
+			if (klass->type_token && !image_is_dynamic(klass->image)) {
 				cmethod = find_method_in_metadata (klass, ".cctor", 0, METHOD_ATTRIBUTE_SPECIAL_NAME);
 				/* The find_method function ignores the 'flags' argument */
 				if (cmethod && (cmethod->flags & METHOD_ATTRIBUTE_SPECIAL_NAME))


### PR DESCRIPTION
It's worth looking at this commit by commit.  There are two ways to fix the bug and I'm not sure which is right.

* In b503b87a03571680e1142354fe1c2a1d3f6865ef we have the bad test case (the F# interactive shell interacts with reflection in this way).
* In 9450821daea5a03d145b534a10e0efa5e07b66fa one fix of the particular symptom - crash in `mono_class_init` when we go looking for `.cctor` using metadata in an image without tables.
* In dc9397aa52369a6c9fc38cb8333ec65904f51bd9 is a different fix: `TypeBuilder.MakeGenericType()` shoudl check if the type was already created and in that case, kick out the generic type from the created type, without constructing a new `MonoGenericClass` (which won't get registered with the runtime since its generic type definition is already created).

I think dc9397aa52369a6c9fc38cb8333ec65904f51bd9 is better, but I had to go and change `MonoGenericClassTest.ClassMustNotBeRegisteredAfterTypeBuilderIsFinishe()` which is testing something important but in a way that's incompatible with my changes.