### PR TITLE
[jit] Add support for widening of Array.UnsafeMov intrisic. Fixes #35310

### DIFF
--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -3189,6 +3189,19 @@ namespace System
 		//
 		// Moved value from instance into target of different type with no checks (JIT intristics)
 		//
+		// Restrictions:
+		//
+		// S and R must either:
+		// 	 both be blitable valuetypes
+		// 	 both be reference types (IOW, an unsafe cast)
+		// S and R cannot be float or double
+		// S and R must either:
+		//	 both be a struct
+		// 	 both be a scalar
+		// S and R must either:
+		// 	 be of same size
+		// 	 both be a scalar of size <= 4
+		//
 		internal static R UnsafeMov<S,R> (S instance) {
 			return (R)(object) instance;
 		}

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5694,11 +5694,17 @@ is_unsafe_mov_compatible (MonoCompile *cfg, MonoClass *param_klass, MonoClass *r
 	if (cfg->verbose_level > 3)
 		printf ("[UNSAFE-MOV-INTRISIC] %s <- %s\n", return_klass->name, param_klass->name);
 
-	//Only allow for valuetypes
-	if (!param_klass->valuetype || !return_klass->valuetype) {
+	//Don't allow mixing reference types with value types
+	if (param_klass->valuetype != return_klass->valuetype) {
 		if (cfg->verbose_level > 3)
-			printf ("[UNSAFE-MOV-INTRISIC]\tone of the args is not a valuetype\n");
+			printf ("[UNSAFE-MOV-INTRISIC]\tone of the args is a valuetype and the other is not\n");
 		return FALSE;
+	}
+
+	if (!param_klass->valuetype) {
+		if (cfg->verbose_level > 3)
+			printf ("[UNSAFE-MOV-INTRISIC]\targs are reference types\n");
+		return TRUE;
 	}
 
 	//That are blitable

--- a/mono/tests/enum.cs
+++ b/mono/tests/enum.cs
@@ -1,38 +1,151 @@
+using System;
+using System.Collections.Generic;
+
 namespace Test {
 
-public enum YaddaYadda {
-	buba,
-	birba,
-	dadoom,
-};
-
-public enum byteenum : byte {
-	zero,
-	one,
-	two,
-	three
-}
-
-public enum longenum: long {
-	s0 = 0,
-	s1 = 1
-}
-
-public enum sbyteenum : sbyte {
-	d0,
-	d1
-}
-
-public class test {
-	public static int Main () {
-		YaddaYadda val = YaddaYadda.dadoom;
-		byteenum be = byteenum.one;
-		if (val != YaddaYadda.dadoom)
-			return 1;
-		if (be != (byteenum)1)
-			return 2;
-		return 0;
+	enum ByteEnum : byte {
+		A = 10
 	}
-}
+
+	enum SByteEnum : sbyte {
+		A = -11
+	}
+
+	enum ShortEnum : short {
+		A = -12
+	}
+
+	enum UShortEnum : ushort {
+		A = 13
+	}
+
+	enum IntEnum : int {
+		A = -15
+	}
+
+	enum UIntEnum : uint {
+		A = 16
+	}
+
+	enum LongEnum : long {
+		A = -153453525432334L
+	}
+
+	enum ULongEnum : ulong {
+		A = 164923797563459L
+	}
+
+	public enum YaddaYadda {
+		buba,
+		birba,
+		dadoom,
+	};
+
+	public enum byteenum : byte {
+		zero,
+		one,
+		two,
+		three
+	}
+
+	public enum longenum: long {
+		s0 = 0,
+		s1 = 1
+	}
+
+	public enum sbyteenum : sbyte {
+		d0,
+		d1
+	}
+
+	public class Tests {
+		public static int test_0_basic_enum_vals ()
+		{
+			YaddaYadda val = YaddaYadda.dadoom;
+			byteenum be = byteenum.one;
+			if (val != YaddaYadda.dadoom)
+				return 1;
+			if (be != (byteenum)1)
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_byte_enum_hashcode ()
+		{
+			if (ByteEnum.A.GetHashCode () != EqualityComparer<ByteEnum>.Default.GetHashCode (ByteEnum.A))
+				return 1;
+			if (ByteEnum.A.GetHashCode () != ((byte)ByteEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_sbyte_enum_hashcode ()
+		{
+			if (SByteEnum.A.GetHashCode () != EqualityComparer<SByteEnum>.Default.GetHashCode (SByteEnum.A))
+				return 1;
+			if (SByteEnum.A.GetHashCode () != ((sbyte)SByteEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_short_enum_hashcode ()
+		{
+			if (ShortEnum.A.GetHashCode () != EqualityComparer<ShortEnum>.Default.GetHashCode (ShortEnum.A))
+				return 1;
+			if (ShortEnum.A.GetHashCode () != ((short)ShortEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_ushort_enum_hashcode ()
+		{
+			if (UShortEnum.A.GetHashCode () != EqualityComparer<UShortEnum>.Default.GetHashCode (UShortEnum.A))
+				return 1;
+			if (UShortEnum.A.GetHashCode () != ((ushort)UShortEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_int_enum_hashcode ()
+		{
+			if (IntEnum.A.GetHashCode () != EqualityComparer<IntEnum>.Default.GetHashCode (IntEnum.A))
+				return 1;
+			if (IntEnum.A.GetHashCode () != ((int)IntEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_uint_enum_hashcode ()
+		{
+			if (UIntEnum.A.GetHashCode () != EqualityComparer<UIntEnum>.Default.GetHashCode (UIntEnum.A))
+				return 1;
+			if (UIntEnum.A.GetHashCode () != ((uint)UIntEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_long_enum_hashcode ()
+		{
+			if (LongEnum.A.GetHashCode () != EqualityComparer<LongEnum>.Default.GetHashCode (LongEnum.A))
+				return 1;
+			if (LongEnum.A.GetHashCode () != ((long)LongEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int test_0_ulong_enum_hashcode ()
+		{
+			if (ULongEnum.A.GetHashCode () != EqualityComparer<ULongEnum>.Default.GetHashCode (ULongEnum.A))
+				return 1;
+			if (ULongEnum.A.GetHashCode () != ((ulong)ULongEnum.A).GetHashCode () )
+				return 2;
+			return 0;
+		}
+
+		public static int Main (String[] args) {
+			return TestDriver.RunTests (typeof (Tests), args);
+		}
+
+	}
 
 }


### PR DESCRIPTION
This enables usage of JitHelper.UnsafeEnumCast<> with enums smaller than int.