### PR TITLE
[corlib] Fix Array.Sort throwing when fewer keys than items are provided

### DIFF
--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -1689,10 +1689,10 @@ namespace System
 		
 			if (keys == null)
 				throw new ArgumentNullException ("keys");
-				
-			if (keys.Length != items.Length)
-				throw new ArgumentException ("Length of keys and items does not match.");
-			
+
+			if (keys.Length > items.Length)
+				throw new ArgumentException ("Length of keys is larger than length of items.");
+
 			SortImpl<TKey, TValue> (keys, items, 0, keys.Length, comparer);
 		}
 

--- a/mcs/class/corlib/Test/System/ArrayTest.cs
+++ b/mcs/class/corlib/Test/System/ArrayTest.cs
@@ -2549,6 +2549,33 @@ public class ArrayTest
 	}
 
 	[Test]
+	public void TestSortComparable()
+	{
+		int[] source = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+		int[] expected = { 6, 5, 4, 3, 2, 1, 7, 8, 9 };
+		Comp[] c = { new Comp (100), new Comp (16), new Comp (11), new Comp (9), new Comp (0), new Comp (-100) };
+		IComparer<Comp> comp = null;
+		Array.Sort<Comp, int> (c, source, comp);
+
+		Assert.AreEqual (expected, source);
+	}
+
+	class Comp : IComparable
+	{
+		readonly int val;
+
+		public Comp (int a)
+		{
+			val = a;
+		}
+
+		int IComparable.CompareTo (object obj)
+		{
+			return val.CompareTo ((obj as Comp).val);
+		}
+	}
+
+	[Test]
 	public void TestInitializeEmpty()
 	{
 		bool catched=false;


### PR DESCRIPTION
The `Sort<TKey, TValue> (TKey [] keys, TValue [] items, IComparer<TKey> comparer)` overload in Array throwed when `keys.Length != items.Length`.

However, on .NET you can pass in a keys array with fewer elements than in items and it'd sort the elements in items up to that point.

Fixed our implementation by only throwing when `keys.Length > items.Length`.

This was revealed by the `coreclr/tests/src/CoreMangLib/cti/system/array/arraysort12.exe` test.
I decided to port the test into our testsuite so we catch regressions earlier.