### PR TITLE
El Capitan fix : system integrity protection compatibility

### DIFF
--- a/mcs/tools/macpack/LOADER
+++ b/mcs/tools/macpack/LOADER
@@ -35,6 +35,14 @@ cd "$APP_PATH/Contents/Resources"
 
 if [ "$X11_MODE" -eq "1" ]; then
 	open-x11 "$APP_NAME"
+
+# rcruzs00
+# El Capitan FIX: `which` wont work (system-integrity-protection)
+# elif: Keep compatibility with previous code
+elif [ -f /usr/local/bin/mono ]; then
+        DIR=$(cd "$(dirname "$0")"; pwd)
+        /usr/local/bin/mono $DIR/../Resources/"$ASSEMBLY"
+
 else
 	if [ ! -d "./bin" ]; then mkdir bin ; fi
 	if [ -f "./bin/$APP_NAME" ]; then rm -f "./bin/$APP_NAME" ; fi


### PR DESCRIPTION
system integrity protection wont let you run /usr/bin/which.
last mono versions already have a symlink located at /usr/local/bin/mono
If symlink exists we should use it.