### PR TITLE
AssignProjectConfigurtion task fix

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/AssignProjectConfiguration.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/AssignProjectConfiguration.cs
@@ -87,14 +87,15 @@ namespace Microsoft.Build.Tasks {
 				string config;
 
 				string guid_str = item.GetMetadata ("Project");
-				Guid guid;
-				if (!TryParseGuid (guid_str, out guid)) {
+
+				Guid guid = Guid.Empty;
+				if (!string.IsNullOrEmpty(guid_str) && !TryParseGuid (guid_str, out guid)) {
 					Log.LogError ("Project reference '{0}' has invalid or missing guid for metadata 'Project'.",
 							item.ItemSpec);
 					return false;
 				}
 
-				if (guidToConfigPlatform.TryGetValue (guid, out config)) {
+				if (guid != Guid.Empty && guidToConfigPlatform.TryGetValue (guid, out config)) {
 					string [] parts = config.Split (new char [] {'|'}, 2);
 
 					ITaskItem new_item = new TaskItem (item);

--- a/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets
@@ -328,13 +328,13 @@
 		<AssignProjectConfiguration
 			ProjectReferences = "@(ProjectReference)"
 			SolutionConfigurationContents = "$(CurrentSolutionConfigurationContents)"
-			Condition="'$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true'">
+			Condition="$(CurrentSolutionConfigurationContents) != '' and ('$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true')">
 
 			<Output TaskParameter = "AssignedProjects" ItemName = "ProjectReferenceWithConfiguration"/>
 		</AssignProjectConfiguration>
 
 		<!-- Else, just -->
-		<CreateItem Include="@(ProjectReference)" Condition="'$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">
+		<CreateItem Include="@(ProjectReference)" Condition="$(CurrentSolutionConfigurationContents) == '' or ('$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true')">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfiguration"/>
 		</CreateItem>
 

--- a/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets
@@ -314,13 +314,13 @@
 		<AssignProjectConfiguration
 			ProjectReferences = "@(ProjectReference)"
 			SolutionConfigurationContents = "$(CurrentSolutionConfigurationContents)"
-			Condition="'$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true'">
+			Condition="$(CurrentSolutionConfigurationContents) != '' and ('$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true')">
 
 			<Output TaskParameter = "AssignedProjects" ItemName = "ProjectReferenceWithConfiguration"/>
 		</AssignProjectConfiguration>
 
 		<!-- Else, just -->
-		<CreateItem Include="@(ProjectReference)" Condition="'$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">
+		<CreateItem Include="@(ProjectReference)" Condition="$(CurrentSolutionConfigurationContents) == '' or ('$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true')">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfiguration"/>
 		</CreateItem>
 

--- a/mcs/tools/xbuild/data/2.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/2.0/Microsoft.Common.targets
@@ -194,13 +194,13 @@
 		<AssignProjectConfiguration
 			ProjectReferences = "@(ProjectReference)"
 			SolutionConfigurationContents = "$(CurrentSolutionConfigurationContents)"
-			Condition="'$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true'">
+			Condition="$(CurrentSolutionConfigurationContents) != '' and ('$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true')">
 
 			<Output TaskParameter = "AssignedProjects" ItemName = "ProjectReferenceWithConfiguration"/>
 		</AssignProjectConfiguration>
 
 		<!-- Else, just -->
-		<CreateItem Include="@(ProjectReference)" Condition="'$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">
+		<CreateItem Include="@(ProjectReference)" Condition="$(CurrentSolutionConfigurationContents) == '' or ('$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true')">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfiguration"/>
 		</CreateItem>
 

--- a/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/3.5/Microsoft.Common.targets
@@ -224,13 +224,13 @@
 		<AssignProjectConfiguration
 			ProjectReferences = "@(ProjectReference)"
 			SolutionConfigurationContents = "$(CurrentSolutionConfigurationContents)"
-			Condition="'$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true'">
+			Condition="$(CurrentSolutionConfigurationContents) != '' and ('$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true')">
 
 			<Output TaskParameter = "AssignedProjects" ItemName = "ProjectReferenceWithConfiguration"/>
 		</AssignProjectConfiguration>
 
 		<!-- Else, just -->
-		<CreateItem Include="@(ProjectReference)" Condition="'$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">
+		<CreateItem Include="@(ProjectReference)" Condition="$(CurrentSolutionConfigurationContents) == '' or ('$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true')">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfiguration"/>
 		</CreateItem>
 

--- a/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets
@@ -328,13 +328,13 @@
 		<AssignProjectConfiguration
 			ProjectReferences = "@(ProjectReference)"
 			SolutionConfigurationContents = "$(CurrentSolutionConfigurationContents)"
-			Condition="'$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true'">
+			Condition="$(CurrentSolutionConfigurationContents) != '' and ('$(BuildingSolutionFile)' == 'true' or '$(BuildingInsideVisualStudio)' == 'true')">
 
 			<Output TaskParameter = "AssignedProjects" ItemName = "ProjectReferenceWithConfiguration"/>
 		</AssignProjectConfiguration>
 
 		<!-- Else, just -->
-		<CreateItem Include="@(ProjectReference)" Condition="'$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true'">
+		<CreateItem Include="@(ProjectReference)" Condition="$(CurrentSolutionConfigurationContents) == '' or ('$(BuildingSolutionFile)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true')">
 			<Output TaskParameter="Include" ItemName="ProjectReferenceWithConfiguration"/>
 		</CreateItem>
 


### PR DESCRIPTION
More then month ago I fixed https://bugzilla.xamarin.com/show_bug.cgi?id=25480 via https://github.com/mono/mono/commit/76c6a08e730393927b6851709cdae1d397cbcc3a
But last week we discovered this fixed caused 2 new bugs in Cycle 6:
https://bugzilla.xamarin.com/show_bug.cgi?id=35548 (Android)
https://bugzilla.xamarin.com/show_bug.cgi?id=35579 (F#)
for Cycle 6 we reverted this fix...

With this PR I'm fixing this 2 bugs...
Android bug is fixed by changes in AssignProjectConfiguration.cs which doesn't throw error anymore if ProjectReference Guid is not set, same as MSBuild. What is interesting about this bug... ProjectReferences that don't have Guid set can't be built via "xbuild SolutionName.sln" even on stable...

F# bug is fixed by ignoring AssignProjectConfiguration if CurrentSolutionConfigurationContents is not set... FSharp.Compiler.Service is calling MSBuild to resolve project references but doesn't set CurrentSolutionConfigurationContents which causes AssignProjectConfiguration to fail to resolve, fix is to take old logic, same as before https://github.com/mono/mono/commit/76c6a08e730393927b6851709cdae1d397cbcc3a which means just copy same ProjectReference without configuration/platform set...