### PR TITLE
[Dataflow] Fix flaky tests by bumping timeouts

### DIFF
--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ActionBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ActionBlockTest.cs
@@ -46,7 +46,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			for (int i = 0; i < array.Length; ++i)
 				Assert.IsTrue (block.Post (i), "Not accepted");
 
-			Assert.IsTrue (evt.Wait (500));
+			Assert.IsTrue (evt.Wait (1000));
 			
 			Assert.IsTrue (array.All (b => b), "Some false");
 		}
@@ -82,7 +82,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			block.Complete ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BatchBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BatchBlockTest.cs
@@ -340,7 +340,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			scheduler.ExecuteAll ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -355,9 +355,9 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			block.Complete ();
 
 			CollectionAssert.AreEqual (new[] { 1 },
-				block.Receive (TimeSpan.FromMilliseconds (200)));
+				block.Receive (TimeSpan.FromMilliseconds (2000)));
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -371,9 +371,9 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			block.Complete ();
 
 			CollectionAssert.AreEqual (new[] { 1, 2 },
-				block.Receive (TimeSpan.FromMilliseconds (200)));
+				block.Receive (TimeSpan.FromMilliseconds (2000)));
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -386,9 +386,9 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			block.Complete ();
 
 			CollectionAssert.AreEqual (new[] { 1 },
-				block.Receive (TimeSpan.FromMilliseconds (200)));
+				block.Receive (TimeSpan.FromMilliseconds (2000)));
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -410,7 +410,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			int[] batch;
 			Assert.IsFalse (block.TryReceive (out batch));
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -446,7 +446,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (block.TryReceive (out batch));
 			CollectionAssert.AreEquivalent (new[] { 11, 21 }, batch);
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 	}
 }

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BatchedJoinBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BatchedJoinBlockTest.cs
@@ -52,7 +52,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue (block.Target2.Post (2));
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsNotNull (result);
 			CollectionAssert.AreEqual (new[] { 1 }, result.Item1);
@@ -68,7 +68,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsNull (result);
 
 			Assert.IsTrue (block.Target1.Post (4));
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsNotNull (result);
 			CollectionAssert.AreEqual (new[] { 3, 4 }, result.Item1);
@@ -84,7 +84,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsNull (result);
 
 			Assert.IsTrue (block.Target2.Post (6));
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsNotNull (result);
 			CollectionAssert.IsEmpty (result.Item1);
@@ -114,7 +114,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			CollectionAssert.AreEqual (new[] { 1 }, batch.Item1);
 			CollectionAssert.IsEmpty (batch.Item2);
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -143,7 +143,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			scheduler.ExecuteAll ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 	}
 }

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BatchedJoinBlock`3Test.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BatchedJoinBlock`3Test.cs
@@ -54,7 +54,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue (block.Target3.Post ("foo"));
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsNotNull (result);
 			CollectionAssert.AreEqual (new[] { 1 }, result.Item1);
@@ -86,7 +86,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			CollectionAssert.IsEmpty (batch.Item2);
 			CollectionAssert.IsEmpty (batch.Item3);
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -125,7 +125,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			scheduler.ExecuteAll ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 	}
 }

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BoundedCapacityTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BoundedCapacityTest.cs
@@ -77,13 +77,13 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.AreEqual (DataflowMessageStatus.Postponed,
 				target.OfferMessage (header, 43, source, false));
 
-			Assert.AreEqual (42, block.Receive (TimeSpan.FromMilliseconds (100)));
+			Assert.AreEqual (42, block.Receive (TimeSpan.FromMilliseconds (1000)));
 
 			Assert.IsFalse (block.Completion.Wait (100));
 
 			Assert.IsTrue (source.WasConsumed (header));
 
-			Assert.AreEqual (43, block.Receive (TimeSpan.FromMilliseconds (100)));
+			Assert.AreEqual (43, block.Receive (TimeSpan.FromMilliseconds (1000)));
 
 			Assert.AreEqual (DataflowMessageStatus.Accepted,
 				target.OfferMessage (new DataflowMessageHeader (3), 44, source, false));

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BroadcastBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BroadcastBlockTest.cs
@@ -58,7 +58,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue (broadcast.Post (42));
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsTrue (act1);
 			Assert.IsTrue (act2);
@@ -81,7 +81,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			broadcast.LinkTo (action);
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsTrue (act);
 		}
@@ -99,7 +99,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (broadcast.Post (2));
 
 			Assert.AreEqual (1, target.Receive (TimeSpan.FromMilliseconds (0)));
-			Assert.AreEqual (2, target.Receive (TimeSpan.FromMilliseconds (100)));
+			Assert.AreEqual (2, target.Receive (TimeSpan.FromMilliseconds (1000)));
 		}
 
 		[Test]
@@ -200,7 +200,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (broadcast.Post (2));
 
 			AssertEx.Throws<TimeoutException> (
-				() => target.Receive (TimeSpan.FromMilliseconds (100)));
+				() => target.Receive (TimeSpan.FromMilliseconds (1000)));
 
 			scheduler.ExecuteAll ();
 
@@ -269,7 +269,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue (broadcast.Post (source));
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsNotNull (act1);
 			Assert.IsNotNull (act2);

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ChooseTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ChooseTest.cs
@@ -46,7 +46,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			source1.Post (42);
 
-			Assert.IsTrue (completion.Wait (500));
+			Assert.IsTrue (completion.Wait (1000));
 			Assert.AreEqual (0, completion.Result);
 			Assert.IsTrue (action1);
 			Assert.IsFalse (action2);
@@ -67,7 +67,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			source1.Post (42);
 			source1.Post (43);
 
-			Assert.IsTrue (completion.Wait (500));
+			Assert.IsTrue (completion.Wait (1000));
 			Assert.AreEqual (0, completion.Result);
 			Assert.AreEqual (1, action1);
 			Assert.AreEqual (0, action2);
@@ -104,7 +104,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Task.WaitAll (t1, t2);
 
-			Assert.IsTrue (completion.Wait (500));
+			Assert.IsTrue (completion.Wait (1000));
 			Assert.AreEqual (1, action1 + action2);
 
 			int item;
@@ -166,7 +166,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			source1.Post (10);
 
-			Assert.IsTrue (completion.Wait (500));
+			Assert.IsTrue (completion.Wait (1000));
 			Assert.AreEqual (0, completion.Result);
 			Assert.AreEqual (42, action1);
 			Assert.AreEqual (0, action2);
@@ -185,7 +185,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			source1.Post (42);
 
-			var ae = AssertEx.Throws<AggregateException> (() => completion.Wait (500));
+			var ae = AssertEx.Throws<AggregateException> (() => completion.Wait (1000));
 			Assert.AreEqual (1, ae.InnerExceptions.Count);
 			Assert.AreSame (exception, ae.InnerException);
 		}
@@ -207,7 +207,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			source3.Post (new object ());
 
-			Assert.IsTrue (completion.Wait (500));
+			Assert.IsTrue (completion.Wait (1000));
 			Assert.AreEqual (2, completion.Result);
 			Assert.IsFalse (action1);
 			Assert.IsFalse (action2);

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/CompletionTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/CompletionTest.cs
@@ -50,7 +50,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.AreEqual (42, block.Receive ());
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 			Assert.IsTrue (block.Completion.IsCompleted);
 			Assert.AreEqual (TaskStatus.RanToCompletion, block.Completion.Status);
 		}
@@ -62,7 +62,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (block.Post (42));
 			((IDataflowBlock)block).Fault (new Exception ());
 
-			AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+			AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 			Assert.IsTrue (block.Completion.IsCompleted);
 			Assert.AreEqual (TaskStatus.Faulted, block.Completion.Status);
 			Assert.IsFalse (block.Post (43));
@@ -78,7 +78,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			tokenSource.Cancel ();
 
 			var ae = AssertEx.Throws<AggregateException> (
-				() => block.Completion.Wait (100));
+				() => block.Completion.Wait (1000));
 			Assert.AreEqual (1, ae.InnerExceptions.Count);
 			Assert.AreEqual (typeof(TaskCanceledException), ae.InnerException.GetType ());
 
@@ -208,7 +208,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			((IDataflowBlock)block).Fault (new Exception ("fault"));
 
 			var exception =
-				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 
 			Assert.AreEqual (1, exception.InnerExceptions.Count);
 			Assert.AreEqual ("action", exception.InnerException.Message);
@@ -259,7 +259,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			tokenSource.Cancel ();
 
 			var exception =
-				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 
 			Assert.AreEqual (1, exception.InnerExceptions.Count);
 			Assert.AreEqual ("action", exception.InnerException.Message);
@@ -289,7 +289,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			evt.Set ();
 
 			var exception =
-				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 
 			Assert.AreEqual (1, exception.InnerExceptions.Count);
 			Assert.AreEqual ("action", exception.InnerException.Message);
@@ -309,7 +309,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			((IDataflowBlock)block).Fault (new Exception ("fault"));
 
 			var exception =
-				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 
 			Assert.AreEqual (1, exception.InnerExceptions.Count);
 			Assert.AreEqual (typeof(TaskCanceledException),
@@ -341,7 +341,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Thread.Sleep (100);
 
 			var exception =
-				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 
 			Assert.AreEqual (1, exception.InnerExceptions.Count);
 			Assert.AreEqual (typeof(TaskCanceledException),
@@ -373,7 +373,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Thread.Sleep (100);
 
 			var exception =
-				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 
 			Assert.AreEqual (1, exception.InnerExceptions.Count);
 			Assert.AreEqual ("fault", exception.InnerException.Message);

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/DataflowBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/DataflowBlockTest.cs
@@ -60,7 +60,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			var block = new BufferBlock<int> ();
 			block.Complete ();
 			AssertEx.Throws<InvalidOperationException> (
-				() => block.Receive (TimeSpan.FromMilliseconds (100)));
+				() => block.Receive (TimeSpan.FromMilliseconds (1000)));
 		}
 
 		[Test]
@@ -68,7 +68,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 		{
 			var block = new BufferBlock<int> ();
 			AssertEx.Throws<TimeoutException> (
-				() => block.Receive (TimeSpan.FromMilliseconds (100)));
+				() => block.Receive (TimeSpan.FromMilliseconds (1000)));
 		}
 
 		[Test]
@@ -169,7 +169,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.AreEqual (1, target.Receive ());
 
-			Assert.IsTrue (task.Wait (100));
+			Assert.IsTrue (task.Wait (1000));
 			Assert.IsTrue (task.Result);
 		}
 
@@ -187,7 +187,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			target.Complete ();
 
-			Assert.IsTrue (task.Wait (100));
+			Assert.IsTrue (task.Wait (1000));
 			Assert.IsFalse (task.Result);
 		}
 

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ExecutionBlocksTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ExecutionBlocksTest.cs
@@ -77,7 +77,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 				block.Post (1);
 
 				var ae =
-					AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+					AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 				Assert.AreEqual (1, ae.InnerExceptions.Count);
 				Assert.AreSame (exception, ae.InnerException);
 			}
@@ -118,7 +118,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 				shouldRun = 0;
 				evt.Set ();
 
-				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 
 				Thread.Sleep (100);
 
@@ -188,7 +188,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 				scheduler.ExecuteAll ();
 
 				var ae =
-					AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100)).
+					AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000)).
 						Flatten ();
 
 				Assert.AreEqual (1, ae.InnerExceptions.Count);

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/JoinBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/JoinBlockTest.cs
@@ -79,7 +79,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Task.Factory.StartNew (() => block.Target1.Post (42));
 			Task.Factory.StartNew (() => block.Target2.Post (24));
 
-			Assert.IsTrue (evt.Wait (500));
+			Assert.IsTrue (evt.Wait (1000));
 			Assert.IsNotNull (tuple);
 			Assert.AreEqual (42, tuple.Item1);
 			Assert.AreEqual (24, tuple.Item2);
@@ -113,7 +113,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Tuple<int, int> tuple;
 			Assert.IsFalse (block.TryReceive (out tuple));
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -140,7 +140,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			scheduler.ExecuteAll ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -175,7 +175,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (block.TryReceive (out tuple));
 			Assert.AreEqual (Tuple.Create (11, 21), tuple);
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 	}
 }

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/JoinBlock`3Test.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/JoinBlock`3Test.cs
@@ -50,12 +50,12 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			block.Target1.Post (42);
 
-			evt.Wait (500);
+			evt.Wait (1000);
 			Assert.IsNull (tuple);
 
 			block.Target2.Post (24);
 
-			evt.Wait (500);
+			evt.Wait (1000);
 			Assert.IsNull (tuple);
 
 			block.Target3.Post (44);
@@ -79,7 +79,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Tuple<int, int, int> tuple;
 			Assert.IsFalse (block.TryReceive (out tuple));
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -108,7 +108,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			scheduler.ExecuteAll ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -148,7 +148,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (block.TryReceive (out tuple));
 			Assert.AreEqual (Tuple.Create (11, 21, 31), tuple);
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 	}
 }

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/OptionsTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/OptionsTest.cs
@@ -59,7 +59,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			foreach (var block in blocks) {
 				var ae =
-					AssertEx.Throws<AggregateException> (() => block.Completion.Wait (100));
+					AssertEx.Throws<AggregateException> (() => block.Completion.Wait (1000));
 				Assert.AreEqual (1, ae.InnerExceptions.Count);
 				Assert.IsInstanceOfType (typeof(TaskCanceledException), ae.InnerExceptions [0]);
 				Assert.IsTrue (block.Completion.IsCanceled);
@@ -103,7 +103,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 					source.LinkTo (new BufferBlock<int> ());
 				}
-				Assert.IsTrue (block.Completion.Wait (500));
+				Assert.IsTrue (block.Completion.Wait (1000));
 
 				CollectionAssert.AreEquivalent (
 					Enumerable.Range (0, 100), queue.Select (t => t.Item1));
@@ -243,7 +243,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsNotNull (action);
 
-			Assert.IsTrue (action.Completion.Wait (100));
+			Assert.IsTrue (action.Completion.Wait (1000));
 			Assert.IsTrue (task.Wait (0));
 		}
 
@@ -405,7 +405,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			evt.Set ();
 
-			Assert.IsTrue (Task.WaitAll (new Task[] { task1, task2 }, 100));
+			Assert.IsTrue (Task.WaitAll (new Task[] { task1, task2 }, 1000));
 
 			CollectionAssert.AreEquivalent (
 				new[]

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/OutputAvailableTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/OutputAvailableTest.cs
@@ -56,7 +56,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue(source.Post(1));
 
-			Assert.IsTrue(task.Wait(100));
+			Assert.IsTrue(task.Wait(1000));
 			Assert.IsTrue(task.Result);
 		}
 
@@ -68,7 +68,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			var task = source.OutputAvailableAsync();
 
-			Assert.IsTrue(task.Wait(100));
+			Assert.IsTrue(task.Wait(1000));
 			Assert.IsFalse(task.Result);
 		}
 
@@ -83,7 +83,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			source.Complete();
 
-			Assert.IsTrue(task.Wait(100));
+			Assert.IsTrue(task.Wait(1000));
 			Assert.IsFalse(task.Result);
 		}
 
@@ -95,7 +95,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			var task = source.OutputAvailableAsync();
 
-			Assert.IsTrue(task.Wait(100));
+			Assert.IsTrue(task.Wait(1000));
 			Assert.IsFalse(task.Result);
 		}
 
@@ -110,7 +110,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			((IDataflowBlock)source).Fault(new Exception());
 
-			Assert.IsTrue(task.Wait(100));
+			Assert.IsTrue(task.Wait(1000));
 			Assert.IsFalse(task.Result);
 		}
 
@@ -139,7 +139,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue(source.Post(1));
 
-			Assert.IsTrue(task.Wait(100));
+			Assert.IsTrue(task.Wait(1000));
 			Assert.IsTrue(task.Result);
 		}
 
@@ -153,7 +153,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			tokenSource.Cancel();
 
-			AssertEx.Throws<AggregateException>(() => task.Wait(100));
+			AssertEx.Throws<AggregateException>(() => task.Wait(1000));
 			Assert.IsTrue(task.IsCanceled);
 		}
 	}

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/PropagateCompletionTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/PropagateCompletionTest.cs
@@ -39,7 +39,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsFalse (target.Completion.Wait (100));
 			source.Complete ();
-			Assert.IsTrue (target.Completion.Wait (100));
+			Assert.IsTrue (target.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -55,10 +55,10 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			source.Fault (exception);
 
 			var ae =
-				AssertEx.Throws<AggregateException> (() => source.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => source.Completion.Wait (1000));
 			Assert.AreEqual (exception, ae.Flatten ().InnerException);
 
-			ae = AssertEx.Throws<AggregateException> (() => target.Completion.Wait (100));
+			ae = AssertEx.Throws<AggregateException> (() => target.Completion.Wait (1000));
 			Assert.AreEqual (exception, ae.Flatten ().InnerException);
 		}
 
@@ -76,11 +76,11 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			tokenSource.Cancel ();
 
 			var ae =
-				AssertEx.Throws<AggregateException> (() => source.Completion.Wait (100));
+				AssertEx.Throws<AggregateException> (() => source.Completion.Wait (1000));
 			Assert.IsInstanceOfType (
 				typeof(TaskCanceledException), ae.Flatten ().InnerException);
 
-			Assert.IsTrue (target.Completion.Wait (100));
+			Assert.IsTrue (target.Completion.Wait (1000));
 		}
 
 		[Test]
@@ -109,7 +109,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsFalse (target.Completion.Wait (100));
 
 			Assert.AreEqual (42, target.Receive ());
-			Assert.IsTrue (target.Completion.Wait (100));
+			Assert.IsTrue (target.Completion.Wait (1000));
 		}
 
 		[Test]

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ReceivingTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/ReceivingTest.cs
@@ -113,7 +113,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			scheduler.ExecuteAll ();
 			Assert.AreEqual (default(int), target.DirectlyAccepted);
 
-			Assert.AreEqual (42, source.Receive (TimeSpan.FromMilliseconds (100)));
+			Assert.AreEqual (42, source.Receive (TimeSpan.FromMilliseconds (1000)));
 			scheduler.ExecuteAll ();
 			Assert.AreEqual (43, target.DirectlyAccepted);
 		}
@@ -347,7 +347,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 				new BufferBlock<int> (new DataflowBlockOptions { TaskScheduler = scheduler });
 
 			AssertEx.Throws<TimeoutException> (
-				() => block.Receive (TimeSpan.FromMilliseconds (100)));
+				() => block.Receive (TimeSpan.FromMilliseconds (1000)));
 
 			block.Post (1);
 

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/TransformBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/TransformBlockTest.cs
@@ -91,7 +91,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			block.Complete ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/TransformManyBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/TransformManyBlockTest.cs
@@ -88,7 +88,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (transformMany.Post (1), "#1");
 
 			transformMany.Complete ();
-			Assert.IsTrue (transformMany.Completion.Wait (100), "#2");
+			Assert.IsTrue (transformMany.Completion.Wait (1000), "#2");
 			Assert.IsFalse (received, "#3");
 		}
 
@@ -108,7 +108,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			block.Complete ();
 
-			Assert.IsTrue (block.Completion.Wait (100));
+			Assert.IsTrue (block.Completion.Wait (1000));
 		}
 
 		[Test]

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/WriteOnceBlockTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/WriteOnceBlockTest.cs
@@ -58,7 +58,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (block.Post (42), "#1");
 			Assert.IsFalse (block.Post (43), "#2");
 
-			Assert.IsTrue (evt.Wait (100), "#3");
+			Assert.IsTrue (evt.Wait (1000), "#3");
 
 			Assert.IsTrue (act1, "#4");
 			Assert.IsTrue (act2, "#5");
@@ -81,7 +81,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			block.LinkTo (action);
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsTrue (act);
 		}
@@ -98,8 +98,8 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue (block.Post (2));
 
-			Assert.AreEqual (1, target.Receive (TimeSpan.FromMilliseconds (100)));
-			Assert.AreEqual (2, target.Receive (TimeSpan.FromMilliseconds (100)));
+			Assert.AreEqual (1, target.Receive (TimeSpan.FromMilliseconds (1000)));
+			Assert.AreEqual (2, target.Receive (TimeSpan.FromMilliseconds (1000)));
 		}
 
 		[Test]
@@ -114,7 +114,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (block.Post (1));
 
 			AssertEx.Throws<TimeoutException> (
-				() => target.Receive (TimeSpan.FromMilliseconds (100)));
+				() => target.Receive (TimeSpan.FromMilliseconds (1000)));
 
 			scheduler.ExecuteAll ();
 
@@ -147,7 +147,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue (block.Post (source));
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsNotNull (act1);
 			Assert.IsNotNull (act2);
@@ -180,7 +180,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsTrue (broadcast.Post (42));
 
-			Assert.IsTrue (evt.Wait (100));
+			Assert.IsTrue (evt.Wait (1000));
 
 			Assert.IsTrue (act1);
 			Assert.IsTrue (act2);


### PR DESCRIPTION
We were seeing random Dataflow tests fail on Jenkins from time to time.
I managed to reproduce the BroadcastBlockTest.CloningTest and WriteOnceBlockTest.CloningTest fail on my machine by generating CPU load and running those test in a while(true).

Bumping the timeouts from 100ms -> 1s fixed the flakiness for me, so I went ahead and opportunistically bumped all such small timeouts throughout the testsuite.