### PR TITLE
[test] sgen tests should behave nicer on slower machines.

### DIFF
--- a/mono/tests/sgen-domain-unload-2.cs
+++ b/mono/tests/sgen-domain-unload-2.cs
@@ -9,7 +9,6 @@ This is a regression test for a crash in the domain object cleaner code that did
 stop-the-world before walking the heap.
 */
 class Driver {
-
 	static void AllocStuff ()
 	{
 		var x = new object ();
@@ -24,6 +23,8 @@ class Driver {
 	}
 
 	static void Main () {
+		var testTimeout = new TestTimeout ();
+		testTimeout.Start ();
 		for (int i = 0; i < Math.Max (1, Environment.ProcessorCount / 2); ++i) {
 		// for (int i = 0; i < 4; ++i) {
 			var t = new Thread (BackgroundNoise);
@@ -31,12 +32,20 @@ class Driver {
 			t.Start ();
 		}
 		
-		for (int i = 0; i < 100; ++i) {
+		const int TOTAL_ITERATIONS = 100;
+		for (int i = 0; i < TOTAL_ITERATIONS; ++i) {
 			var ad = AppDomain.CreateDomain ("domain_" + i);
 			ad.DoCallBack (new CrossAppDomainDelegate (AllocStuff));
 			AppDomain.Unload (ad);
+
 			Console.Write (".");
 			if (i > 0 && i % 20 == 0) Console.WriteLine ();
+
+			if (!testTimeout.HaveTimeLeft ()) {
+				var finishTime = DateTime.UtcNow;
+				var ranFor = finishTime - testTimeout.StartTime;
+				Console.WriteLine ("Will run out of time soon. ran for {0}, finished {1}/{2} iterations", ranFor, i+1, TOTAL_ITERATIONS);
+			}
 		}
 		Console.WriteLine ("\ndone");
 	}

--- a/mono/tests/sgen-new-threads-dont-join-stw.cs
+++ b/mono/tests/sgen-new-threads-dont-join-stw.cs
@@ -44,8 +44,11 @@ class T {
     }
 
     static void Main (string[] args) {
-        
-        for (int j = 0; j < 2; j++)
+        var testTimeout = new TestTimeout ();
+        testTimeout.Start ();
+
+        const int TOTAL_ITERATIONS = 2;
+        for (int j = 0; j < TOTAL_ITERATIONS; j++)
         {
             count = 0;
 
@@ -82,6 +85,7 @@ class T {
             {
                 while (count < num_threads)
                 {
+                    Console.Write (".");
                     Monitor.Wait(count_lock);
                 }
             }
@@ -90,6 +94,15 @@ class T {
             {
                 t.Join();
             }
+
+            Console.WriteLine ();
+            if (!testTimeout.HaveTimeLeft ()) {
+                    var finishTime = DateTime.UtcNow;
+                    var ranFor = finishTime - testTimeout.StartTime;
+                    Console.WriteLine ("Will run out of time soon.  ran for {0}, finished {1}/{2} iterations", ranFor, j+1, TOTAL_ITERATIONS);
+            }
         }
+
+	Console.WriteLine ("done");
     }
 }

--- a/mono/tests/test-driver
+++ b/mono/tests/test-driver
@@ -29,6 +29,7 @@ if ($test =~ /.*\|.*/) {
 	#This is a silly workaround, but all tests that use extra parameters need a larger timeout.
 	$timeout_in_minutes = 5;
 }
+$ENV{'TEST_DRIVER_TIMEOUT_SEC'} = $timeout_in_minutes * 60;
 
 $| = 0;
 print "Testing $test... ";

--- a/mono/tests/test-driver
+++ b/mono/tests/test-driver
@@ -27,7 +27,7 @@ if ($test =~ /.*\|.*/) {
 	$output = $test;
 
 	#This is a silly workaround, but all tests that use extra parameters need a larger timeout.
-	$timeout_in_minutes = 5;
+	$timeout_in_minutes = 9;
 }
 $ENV{'TEST_DRIVER_TIMEOUT_SEC'} = $timeout_in_minutes * 60;
 

--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -41,6 +41,7 @@ using System.Text.RegularExpressions;
 public class TestRunner
 {
 	const string TEST_TIME_FORMAT = "mm\\:ss\\.fff";
+	const string ENV_TIMEOUT = "TEST_DRIVER_TIMEOUT_SEC";
 
 	class ProcessData {
 		public string test;
@@ -220,6 +221,7 @@ public class TestRunner
 					info.UseShellExecute = false;
 					info.RedirectStandardOutput = true;
 					info.RedirectStandardError = true;
+					info.EnvironmentVariables[ENV_TIMEOUT] = timeout.ToString();
 					Process p = new Process ();
 					p.StartInfo = info;
 


### PR DESCRIPTION
  *  `sgen-domain-unload-2.cs` stop before timeout.
  *  `sgen-new-threads-dont-join-stw.cs` print progress dots.