### PR TITLE
[DO NOT MERGE] [4.2.0][IO] Dump handle when we run out of them

### DIFF
--- a/mcs/class/corlib/System.IO/MonoIO.cs
+++ b/mcs/class/corlib/System.IO/MonoIO.cs
@@ -51,6 +51,8 @@ namespace System.IO
 		public static readonly IntPtr
 			InvalidHandle = (IntPtr)(-1L);
 
+		static bool dump_handles = Environment.GetEnvironmentVariable ("MONO_DUMP_HANDLES_ON_ERROR_TOO_MANY_OPEN_FILES") != null;
+
 		// error methods
 		public static Exception GetException (MonoIOError error)
 		{
@@ -89,6 +91,8 @@ namespace System.IO
 				return new FileNotFoundException (message, path);
 
 			case MonoIOError.ERROR_TOO_MANY_OPEN_FILES:
+				if (dump_handles)
+					DumpHandles ();
 				return new IOException ("Too many open files", unchecked((int)0x80070000) | (int)error);
 				
 			case MonoIOError.ERROR_PATH_NOT_FOUND:
@@ -602,6 +606,9 @@ namespace System.IO
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		public extern static int GetTempPath(out string path);
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		extern static void DumpHandles ();
 	}
 }
 

--- a/mono/metadata/file-io.c
+++ b/mono/metadata/file-io.c
@@ -1283,3 +1283,12 @@ mono_filesize_from_fd (int fd)
 }
 
 #endif
+
+void _wapi_handle_dump (void);
+
+void ves_icall_System_IO_MonoIO_DumpHandles (void)
+{
+#ifndef HOST_WIN32
+	_wapi_handle_dump ();
+#endif
+}

--- a/mono/metadata/file-io.h
+++ b/mono/metadata/file-io.h
@@ -257,6 +257,9 @@ mono_filesize_from_path (MonoString *path);
 extern gint64
 mono_filesize_from_fd (int fd);
 
+void
+ves_icall_System_IO_MonoIO_DumpHandles (void);
+
 G_END_DECLS
 
 #endif /* _MONO_METADATA_FILEIO_H_ */

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -327,6 +327,7 @@ ICALL(MONOIO_3, "CreateDirectory(string,System.IO.MonoIOError&)", ves_icall_Syst
 ICALL(MONOIO_4, "CreatePipe(intptr&,intptr&)", ves_icall_System_IO_MonoIO_CreatePipe)
 ICALL(MONOIO_5, "DeleteFile(string,System.IO.MonoIOError&)", ves_icall_System_IO_MonoIO_DeleteFile)
 #endif /* !PLATFORM_RO_FS */
+ICALL(MONOIO_38, "DumpHandles", ves_icall_System_IO_MonoIO_DumpHandles)
 ICALL(MONOIO_34, "DuplicateHandle", ves_icall_System_IO_MonoIO_DuplicateHandle)
 ICALL(MONOIO_37, "FindClose", ves_icall_System_IO_MonoIO_FindClose)
 ICALL(MONOIO_35, "FindFirst", ves_icall_System_IO_MonoIO_FindFirst)


### PR DESCRIPTION
When running out of handle, it's hard to know exactly why. Dumping them
will help troubleshoot handle leaks.