### PR TITLE
Unambiguous ownership of generic param objects

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -626,16 +626,63 @@ struct _MonoGenericContainer {
 	MonoGenericParamFull *type_params;
 };
 
-#define mono_generic_container_get_param(gc, i) ((MonoGenericParam *) ((gc)->type_params + (i)))
-#define mono_generic_container_get_param_info(gc, i) (&((gc)->type_params + (i))->info)
+static inline MonoGenericParam *
+mono_generic_container_get_param (MonoGenericContainer *gc, int i)
+{
+	return (MonoGenericParam *) &gc->type_params [i];
+}
 
-#define mono_generic_param_owner(p)		((p)->owner)
-#define mono_generic_param_num(p)		((p)->num)
-#define mono_generic_param_is_fullsize(p) ( !mono_generic_param_owner (p)->is_small_param )
-#define mono_generic_param_info(p)		(mono_generic_param_is_fullsize (p) ? &((MonoGenericParamFull *) p)->info : NULL)
-#define mono_generic_param_name(p)		(((mono_generic_param_is_fullsize (p) || (p)->gshared_constraint)) ? ((MonoGenericParamFull *) p)->info.name : NULL)
-#define mono_type_get_generic_param_owner(t)	(mono_generic_param_owner ((t)->data.generic_param))
-#define mono_type_get_generic_param_num(t)	(mono_generic_param_num   ((t)->data.generic_param))
+static inline MonoGenericParamInfo *
+mono_generic_container_get_param_info (MonoGenericContainer *gc, int i)
+{
+	return &gc->type_params [i].info;
+}
+
+static inline MonoGenericContainer *
+mono_generic_param_owner (MonoGenericParam *p)
+{
+	return p->owner;
+}
+
+static inline int
+mono_generic_param_num (MonoGenericParam *p)
+{
+	return p->num;
+}
+
+static inline gboolean
+mono_generic_param_is_fullsize (MonoGenericParam *p)
+{
+	return !mono_generic_param_owner (p)->is_small_param;
+}
+
+static inline MonoGenericParamInfo *
+mono_generic_param_info (MonoGenericParam *p)
+{
+	if (mono_generic_param_is_fullsize (p))
+		return &((MonoGenericParamFull *) p)->info;
+	return NULL;
+}
+
+static inline const char *
+mono_generic_param_name (MonoGenericParam *p)
+{
+	if (mono_generic_param_is_fullsize (p))
+		return ((MonoGenericParamFull *) p)->info.name;
+	return NULL;
+}
+
+static inline MonoGenericContainer *
+mono_type_get_generic_param_owner (MonoType *t)
+{
+	return mono_generic_param_owner (t->data.generic_param);
+}
+
+static inline int
+mono_type_get_generic_param_num (MonoType *t)
+{
+	return mono_generic_param_num (t->data.generic_param);
+}
 
 /*
  * Class information which might be cached by the runtime in the AOT file for

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -570,13 +570,6 @@ struct _MonoGenericParam {
 	 * sharing.
 	 */
 	MonoType *gshared_constraint;
-	/* 
-	 * If owner is NULL, or owner is 'owned' by this gparam,
-	 * then this is the image whose mempool this struct was allocated from.
-	 * The second case happens for gparams created in
-	 * mono_reflection_initialize_generic_parameter ().
-	 */
-	MonoImage *image;
 };
 
 /* Additional details about a MonoGenericParam */
@@ -609,22 +602,28 @@ struct _MonoGenericContainer {
 	   the generic container of the containing class. */
 	MonoGenericContainer *parent;
 	/* the generic type definition or the generic method definition corresponding to this container */
+	/* Union rules: If is_anonymous, image field is valid; else if is_method, method field is valid; else klass is valid. */
 	union {
 		MonoClass *klass;
 		MonoMethod *method;
+		MonoImage *image;
 	} owner;
-	int type_argc    : 31;
+	int type_argc    : 29; // Per the ECMA spec, this value is capped at 16 bits
 	/* If true, we're a generic method, otherwise a generic type definition. */
 	/* Invariant: parent != NULL => is_method */
-	int is_method    : 1;
+	int is_method     : 1;
+	/* If true, this container has no associated class/method and only the image is known. This can happen:
+	   1. For the special anonymous containers kept by MonoImage.
+	   2. During container creation via the mono_metadata_load_generic_params path-- in this case the caller
+	      sets the owner, so temporarily while load_generic_params is completing the container is anonymous.
+	   3. When user code creates a generic parameter via SRE, but has not yet set an owner. */
+	int is_anonymous : 1;
+	/* If false, all params in this container are full-size. If true, all params are just param structs. */
+	/* This field is always == to the is_anonymous field, except in "temporary" cases (2) and (3) above. */
+	/* TODO: Merge GenericParam and GenericParamFull, remove this field. Benefit is marginal. */
+	int is_small_param : 1;
 	/* Our type parameters. */
 	MonoGenericParamFull *type_params;
-
-	/* 
-	 * For owner-less containers created by SRE, the image the container was
-	 * allocated from.
-	 */
-	MonoImage *image;
 };
 
 #define mono_generic_container_get_param(gc, i) ((MonoGenericParam *) ((gc)->type_params + (i)))
@@ -632,8 +631,9 @@ struct _MonoGenericContainer {
 
 #define mono_generic_param_owner(p)		((p)->owner)
 #define mono_generic_param_num(p)		((p)->num)
-#define mono_generic_param_info(p)		(mono_generic_param_owner (p) ? &((MonoGenericParamFull *) p)->info : NULL)
-#define mono_generic_param_name(p)		(((mono_generic_param_owner (p) || (p)->gshared_constraint)) ? ((MonoGenericParamFull *) p)->info.name : NULL)
+#define mono_generic_param_is_fullsize(p) ( !mono_generic_param_owner (p)->is_small_param )
+#define mono_generic_param_info(p)		(mono_generic_param_is_fullsize (p) ? &((MonoGenericParamFull *) p)->info : NULL)
+#define mono_generic_param_name(p)		(((mono_generic_param_is_fullsize (p) || (p)->gshared_constraint)) ? ((MonoGenericParamFull *) p)->info.name : NULL)
 #define mono_type_get_generic_param_owner(t)	(mono_generic_param_owner ((t)->data.generic_param))
 #define mono_type_get_generic_param_num(t)	(mono_generic_param_num   ((t)->data.generic_param))
 
@@ -1415,5 +1415,14 @@ mono_field_from_token_checked (MonoImage *image, uint32_t token, MonoClass **ret
 
 gpointer
 mono_ldtoken_checked (MonoImage *image, guint32 token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
+
+MonoClass *
+mono_class_from_generic_parameter_internal (MonoGenericParam *param);
+
+MonoImage *
+get_image_for_generic_param (MonoGenericParam *param);
+
+char *
+make_generic_name_string (MonoImage *image, int num);
 
 #endif /* __MONO_METADATA_CLASS_INTERNALS_H__ */

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -66,7 +66,7 @@ struct _MonoMethod {
 	guint16 flags;  /* method flags */
 	guint16 iflags; /* method implementation flags */
 	guint32 token;
-	MonoClass *klass;
+	MonoClass *klass; /* To what class does this method belong */
 	MonoMethodSignature *signature;
 	/* name is useful mostly for debugging */
 	const char *name;
@@ -528,7 +528,7 @@ struct _MonoMethodInflated {
  */
 struct _MonoGenericClass {
 	MonoClass *container_class;	/* the generic type definition */
-	MonoGenericContext context;	/* a context that contains the type instantiation doesn't contain any method instantiation */
+	MonoGenericContext context;	/* a context that contains the type instantiation doesn't contain any method instantiation */ /* FIXME: Only the class_inst member of "context" is ever used, so this field could be replaced with just a monogenericinst */
 	guint is_dynamic  : 1;		/* We're a MonoDynamicGenericClass */
 	guint is_tb_open  : 1;		/* This is the fully open instantiation for a type_builder. Quite ugly, but it's temporary.*/
 	MonoClass *cached_class;	/* if present, the MonoClass corresponding to the instantiation.  */

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4269,7 +4269,7 @@ verify_class_overrides (MonoClass *klass, MonoMethod **overrides, int onum)
 		}
 
 		if (!mono_class_is_assignable_from_slow (decl->klass, klass)) {
-			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, g_strdup ("Method overrides a class or interface that extended or implemented by this type"));
+			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, g_strdup ("Method overrides a class or interface that is not extended or implemented by this type"));
 			return FALSE;
 		}
 
@@ -5982,7 +5982,7 @@ parent_failure:
 	return NULL;
 }
 
-/** is klass Nullable<T>? */
+/** Is klass a Nullable<T> ginst? */
 gboolean
 mono_class_is_nullable (MonoClass *klass)
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2324,7 +2324,7 @@ ves_icall_MonoType_GetGenericArguments (MonoReflectionType *type, MonoBoolean ru
 		MonoGenericContainer *container = klass->generic_container;
 		res = create_type_array (domain, runtimeTypeArray, container->type_argc);
 		for (i = 0; i < container->type_argc; ++i) {
-			pklass = mono_class_from_generic_parameter (mono_generic_container_get_param (container, i), klass->image, FALSE);
+			pklass = mono_class_from_generic_parameter_internal (mono_generic_container_get_param (container, i));
 			mono_array_setref (res, i, mono_type_get_object (domain, &pklass->byval_arg));
 		}
 	} else if (klass->generic_class) {
@@ -2678,8 +2678,7 @@ ves_icall_MonoMethod_GetGenericArguments (MonoReflectionMethod *method)
 	for (i = 0; i < count; i++) {
 		MonoGenericContainer *container = mono_method_get_generic_container (method->method);
 		MonoGenericParam *param = mono_generic_container_get_param (container, i);
-		MonoClass *pklass = mono_class_from_generic_parameter (
-			param, method->method->klass->image, TRUE);
+		MonoClass *pklass = mono_class_from_generic_parameter_internal (param);
 		mono_array_setref (res, i,
 				mono_type_get_object (domain, &pklass->byval_arg));
 	}

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -4,28 +4,9 @@
 #ifndef __MONO_METADATA_IMAGE_INTERNALS_H__
 #define __MONO_METADATA_IMAGE_INTERNALS_H__
 
-#ifdef CHECKED_BUILD
-
 #include <mono/metadata/image.h>
-#include <mono/metadata/metadata-internals.h>
 
-typedef struct
-{
-	MonoImage *image;
-	MonoImageSet *image_set;
-} MonoMemPoolOwner;
-
-static MonoMemPoolOwner mono_mempool_no_owner = {NULL,NULL};
-
-static gboolean
-check_mempool_owner_eq (MonoMemPoolOwner a, MonoMemPoolOwner b)
-{
-	return a.image == b.image && a.image_set == b.image_set;
-}
-
-MonoMemPoolOwner
-mono_find_mempool_owner (void *ptr);
-
-#endif /* CHECKED_BUILD */
+MonoImage *
+mono_find_image_owner (void *ptr);
 
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2538,51 +2538,24 @@ mono_image_append_class_to_reflection_info_set (MonoClass *klass)
 	mono_image_unlock (image);
 }
 
-#if CHECKED_BUILD
-
-// These are support for the mempool reference tracking feature in checked-build, but live in image.c due to use of static variables of this file.
-
-// Given an image and a pointer, return the mempool owner if it is either this image or one of its imagesets.
-static MonoMemPoolOwner
-check_for_mempool_owner (void *ptr, MonoImage *image)
-{
-	if (mono_mempool_contains_addr (image->mempool, ptr))
-	{
-		MonoMemPoolOwner owner = {image, NULL};
-		return owner;
-	}
-
-	GSList *l;
-	for (l = image->image_sets; l; l = l->next) {
-		MonoImageSet *set = l->data;
-
-		if (mono_mempool_contains_addr (set->mempool, ptr))
-		{
-			MonoMemPoolOwner owner = {NULL, set};
-			return owner;
-		}
-	}
-
-	return mono_mempool_no_owner;
-}
+// This is support for the mempool reference tracking feature in checked-build, but lives in image.c due to use of static variables of this file.
 
 /**
- * mono_find_mempool_owner:
+ * mono_find_image_owner:
  *
- * Find the image or imageset, if any, which a given pointer is located in the memory of.
+ * Find the image, if any, which a given pointer is located in the memory of.
  */
-MonoMemPoolOwner
-mono_find_mempool_owner (void *ptr)
+MonoImage *
+mono_find_image_owner (void *ptr)
 {
 	mono_images_lock ();
 
-	MonoMemPoolOwner owner = mono_mempool_no_owner;
-	gboolean searching = TRUE;
+	MonoImage *owner = NULL;
 
 	// Iterate over both by-path image hashes
 	const int hash_candidates[] = {IMAGES_HASH_PATH, IMAGES_HASH_PATH_REFONLY};
 	int hash_idx;
-	for (hash_idx = 0; searching && hash_idx < G_N_ELEMENTS (hash_candidates); hash_idx++)
+	for (hash_idx = 0; !owner && hash_idx < G_N_ELEMENTS (hash_candidates); hash_idx++)
 	{
 		GHashTable *target = loaded_images_hashes [hash_candidates [hash_idx]];
 		GHashTableIter iter;
@@ -2590,14 +2563,12 @@ mono_find_mempool_owner (void *ptr)
 
 		// Iterate over images within a hash
 		g_hash_table_iter_init (&iter, target);
-		while (searching && g_hash_table_iter_next(&iter, NULL, (gpointer *)&image))
+		while (!owner && g_hash_table_iter_next(&iter, NULL, (gpointer *)&image))
 		{
 			mono_image_lock (image);
-			owner = check_for_mempool_owner (ptr, image);
+			if (mono_mempool_contains_addr (image->mempool, ptr))
+				owner = image;
 			mono_image_unlock (image);
-
-			// Continue searching if null owner returned
-			searching = check_mempool_owner_eq (owner, mono_mempool_no_owner);
 		}
 	}
 
@@ -2605,5 +2576,3 @@ mono_find_mempool_owner (void *ptr)
 
 	return owner;
 }
-
-#endif

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1942,6 +1942,7 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 	if (generic_container) {
 		result->is_generic = TRUE;
 		generic_container->owner.method = result;
+		generic_container->is_anonymous = FALSE; // Method is now known, container is no longer anonymous
 		/*FIXME put this before the image alloc*/
 		if (!mono_metadata_load_generic_param_constraints_checked (image, token, generic_container, error))
 			return NULL;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -899,5 +899,11 @@ mono_method_get_wrapper_cache (MonoMethod *method);
 MonoType*
 mono_metadata_parse_type_checked (MonoImage *m, MonoGenericContainer *container, short opt_attrs, gboolean transient, const char *ptr, const char **rptr, MonoError *error);
 
+char *
+mono_image_set_description (MonoImageSet *);
+
+MonoImageSet *
+mono_find_image_set_owner (void *ptr);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -389,6 +389,11 @@ struct _MonoImage {
 	/* The loader used to load this image */
 	MonoImageLoader *loader;
 
+	// Containers for MonoGenericParams associated with this image but not with any specific class or method. Created on demand.
+	// This could happen, for example, for MonoTypes associated with TypeSpec table entries.
+	MonoGenericContainer *anonymous_generic_class_container;
+	MonoGenericContainer *anonymous_generic_method_container;
+
 	/*
 	 * No other runtime locks must be taken while holding this lock.
 	 * It's meant to be used only to mutate and query structures part of this image.
@@ -898,6 +903,9 @@ mono_method_get_wrapper_cache (MonoMethod *method);
 
 MonoType*
 mono_metadata_parse_type_checked (MonoImage *m, MonoGenericContainer *container, short opt_attrs, gboolean transient, const char *ptr, const char **rptr, MonoError *error);
+
+MonoGenericContainer *
+get_anonymous_container_for_image (MonoImage *image, gboolean is_mvar);
 
 char *
 mono_image_set_description (MonoImageSet *);

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -14,4 +14,7 @@ mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_k
 char*
 mono_identifier_unescape_type_name_chars (char* identifier);
 
+MonoImage *
+mono_find_dynamic_image_owner (void *ptr);
+
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -215,6 +215,48 @@ static void init_type_builder_generics (MonoObject *type);
 #define ADDP_IS_GREATER_OR_OVF(a, b, c) (((a) + (b) > (c)) || CHECK_ADDP_OVERFLOW_UN (a, b))
 #define ADD_IS_GREATER_OR_OVF(a, b, c) (((a) + (b) > (c)) || CHECK_ADD4_OVERFLOW_UN (a, b))
 
+// The dynamic images list is only needed to support the mempool reference tracking feature in checked-build.
+static GPtrArray *dynamic_images;
+static mono_mutex_t dynamic_images_mutex;
+
+static inline void
+dynamic_images_lock (void)
+{
+	mono_mutex_lock (&dynamic_images_mutex);
+}
+
+static inline void
+dynamic_images_unlock (void)
+{
+	mono_mutex_unlock (&dynamic_images_mutex);
+}
+
+/**
+ * mono_find_dynamic_image_owner:
+ *
+ * Find the dynamic image, if any, which a given pointer is located in the memory of.
+ */
+MonoImage *
+mono_find_dynamic_image_owner (void *ptr)
+{
+	MonoImage *owner = NULL;
+	int i;
+
+	dynamic_images_lock ();
+
+	if (dynamic_images)
+	{
+		for (i = 0; !owner && i < dynamic_images->len; ++i) {
+			MonoImage *image = g_ptr_array_index (dynamic_images, i);
+			if (mono_mempool_contains_addr (image->mempool, ptr))
+				owner = image;
+		}
+	}
+
+	dynamic_images_unlock ();
+
+	return owner;
+}
 
 void
 mono_reflection_init (void)
@@ -5338,6 +5380,15 @@ create_dynamic_mono_image (MonoDynamicAssembly *assembly, char *assembly_name, c
 	
 	mono_profiler_module_loaded (&image->image, MONO_PROFILE_OK);
 
+	dynamic_images_lock ();
+
+	if (!dynamic_images)
+		dynamic_images = g_ptr_array_new ();
+
+	g_ptr_array_add (dynamic_images, image);
+
+	dynamic_images_unlock ();
+
 	return image;
 }
 #endif
@@ -5438,7 +5489,14 @@ mono_dynamic_image_free (MonoDynamicImage *image)
 	for (i = 0; i < MONO_TABLE_NUM; ++i) {
 		g_free (di->tables [i].values);
 	}
-}	
+
+	dynamic_images_lock ();
+
+	if (dynamic_images)
+		g_ptr_array_remove (dynamic_images, di);
+
+	dynamic_images_unlock ();
+}
 
 void
 mono_dynamic_image_free_image (MonoDynamicImage *image)

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -5419,6 +5419,7 @@ mono_dynamic_image_release_gc_roots (MonoDynamicImage *image)
 	release_hashtable (&image->methodspec);
 }
 
+// Free dynamic image pass one: Free resources but not image itself
 void
 mono_dynamic_image_free (MonoDynamicImage *image)
 {
@@ -5498,6 +5499,7 @@ mono_dynamic_image_free (MonoDynamicImage *image)
 	dynamic_images_unlock ();
 }
 
+// Free dynamic image pass two: Free image itself (might never get called in some debug modes)
 void
 mono_dynamic_image_free_image (MonoDynamicImage *image)
 {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -10746,6 +10746,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 		container->type_argc = count;
 		container->type_params = image_g_new0 (image, MonoGenericParamFull, count);
 		container->owner.method = m;
+		container->is_anonymous = FALSE; // Method is now known, container is no longer anonymous
 
 		m->is_generic = TRUE;
 		mono_method_set_generic_container (m, container);
@@ -11946,7 +11947,8 @@ mono_reflection_initialize_generic_parameter (MonoReflectionGenericParam *gparam
 			 * Cannot set owner.method, since the MonoMethod is not created yet.
 			 * Set the image field instead, so type_in_image () works.
 			 */
-			gparam->mbuilder->generic_container->image = klass->image;
+			gparam->mbuilder->generic_container->is_anonymous = TRUE;
+			gparam->mbuilder->generic_container->owner.image = klass->image;
 		}
 		param->param.owner = gparam->mbuilder->generic_container;
 	} else if (gparam->tbuilder) {
@@ -11958,7 +11960,7 @@ mono_reflection_initialize_generic_parameter (MonoReflectionGenericParam *gparam
 		param->param.owner = gparam->tbuilder->generic_container;
 	}
 
-	pklass = mono_class_from_generic_parameter ((MonoGenericParam *) param, image, gparam->mbuilder != NULL);
+	pklass = mono_class_from_generic_parameter_internal ((MonoGenericParam *) param);
 
 	gparam->type.type = &pklass->byval_arg;
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -2508,10 +2508,9 @@ encode_klass_ref_inner (MonoAotCompile *acfg, MonoClass *klass, guint8 *buf, gui
 		encode_value (klass->byval_arg.type, p, &p);
 		encode_value (mono_type_get_generic_param_num (&klass->byval_arg), p, &p);
 
-		encode_value (container ? 1 : 0, p, &p);
-		if (container) {
+		encode_value (container->is_anonymous ? 0 : 1, p, &p);
+		if (!container->is_anonymous) {
 			encode_value (container->is_method, p, &p);
-			g_assert (!par->gshared_constraint);
 			if (container->is_method)
 				encode_method_ref (acfg, container->owner.method, p, &p);
 			else

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7932,7 +7932,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 				count = container->type_argc;
 				buffer_add_int (buf, count);
 				for (i = 0; i < count; i++) {
-					pklass = mono_class_from_generic_parameter (mono_generic_container_get_param (container, i), klass->image, FALSE);
+					pklass = mono_class_from_generic_parameter_internal (mono_generic_container_get_param (container, i));
 					buffer_add_typeid (buf, domain, pklass);
 				}
 			} else {
@@ -8544,7 +8544,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 						buffer_add_int (buf, count);
 						for (i = 0; i < count; i++) {
 							MonoGenericParam *param = mono_generic_container_get_param (container, i);
-							MonoClass *pklass = mono_class_from_generic_parameter (param, method->klass->image, TRUE);
+							MonoClass *pklass = mono_class_from_generic_parameter_internal (param);
 							buffer_add_typeid (buf, domain, pklass);
 						}
 					} else {

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -20,6 +20,8 @@
 
 #ifdef CHECKED_BUILD
 
+#define g_assert_checked g_assert
+
 /*
 GC runtime modes rules:
 
@@ -88,6 +90,12 @@ Functions that can be called from both coop or preept modes.
     (ptr) = (val);    \
 } while (0);
 
+// Use when writing a pointer from one image or imageset to another (atomic version).
+#define CHECKED_METADATA_WRITE_PTR_ATOMIC(ptr, val) do {    \
+    check_metadata_store (&(ptr), (val));    \
+    mono_atomic_store_release (&(ptr), (val));    \
+} while (0);
+
 /*
 This can be called by embedders
 */
@@ -116,6 +124,8 @@ void check_metadata_store_local(void *from, void *to);
 
 #else
 
+#define g_assert_checked(...)
+
 #define MONO_REQ_GC_SAFE_MODE
 #define MONO_REQ_GC_UNSAFE_MODE
 #define MONO_REQ_GC_NEUTRAL_MODE
@@ -127,6 +137,7 @@ void check_metadata_store_local(void *from, void *to);
 
 #define CHECKED_METADATA_WRITE_PTR(ptr, val) do { (ptr) = (val); } while (0)
 #define CHECKED_METADATA_WRITE_PTR_LOCAL(ptr, val) do { (ptr) = (val); } while (0)
+#define CHECKED_METADATA_WRITE_PTR_ATOMIC(ptr, val) do { mono_atomic_store_release (&(ptr), (val)); } while (0)
 
 #endif /* CHECKED_BUILD */
 


### PR DESCRIPTION
This patch adds a small number of mempool-reference audit points to functions in class.c and then performs a large refactor without which those audit points would fail on the standard tests. The goal of the refactor is to remove ambiguities in what image owns or should own any particular generic parameter object. Previously, there were four options for specifying a MonoGenericParam’s image:
	1. klass/method union in MonoGenericContainer.
	2. image field in MonoGenericContainer.
	3. image field in MonoGenericParam.
	4. No field; “image” passed in to methods in at time of usage.
This patch removes 3 and 4; it preserves the image field from (2), but merges it into the union from (1). It adds a new field, “is_anonymous”, to indicate when the image member of the union should be used. The single source of the “owner" union now always points to the generic param’s image, directly or indirectly.

A further change is made to support this: Previously, containers were optional, and the presence or absence of container was incidentally used to determine whether an object was a MonoGenericParam or a MonoGenericParamFull. Now, containers are mandatory for all MonoGenericParams, so a new “is_small_size” bit in the container tracks this information.

Some changes were made to checked builds to support all this: there's a g_assert_checked now which asserts but only on checked builds, and a bunch of little changes to the mempool audit feature (see commit #1)

This change opens some sources of risk:
	⁃ Code which creates MonoGenericParams now must make sure to allocate a container early.
	⁃ Code that accesses the MonoGenericContainer::owner field must all be correctly updated to look for is_anonymous or there will be a crash. (Much of this code would have previously used a NULL container as the flag for “anonymous”).
	⁃ Code that casts MonoGenericParams to MonoGenericParamFull must use the is_small_size field.
	⁃ Some generic containers will now exist with NULL type_params and 0 type_argc. Code which reads the type param array must either not receive objects from these containers, or must handle it.
	⁃ If code by users of the embedding API exists which somehow depends on particular behavior related to the now-unused image argument of mono_class_from_generic_parameter, it will break.
I have audited code around, at least, the first three of these cases and fixed what problems I found.

Monodis is probably completely broken now.