### PR TITLE
Process.cs: adding a handler to Exited will make the program wait for the process to exit

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -1584,7 +1584,7 @@ namespace System.Diagnostics {
 			if (background_wait_for_exit_thread != null)
 				return;
 
-			Thread t = new Thread (_ => WaitForExit ());
+			Thread t = new Thread (_ => WaitForExit ()) { IsBackground = true };
 
 			if (Interlocked.CompareExchange (ref background_wait_for_exit_thread, t, null) == null)
 				t.Start ();


### PR DESCRIPTION
When a handler is added, a thread is created to call handler when process exits. The problem is that this thread is not a background thread, so it effectively makes our program living at least as long as the child process. This patch resolves this.

I do, however, wonder why you did not make use of a `Task` instead of `Thread`.