### PR TITLE
Feature concurrent evacuation

### DIFF
--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -59,7 +59,10 @@ namespace Mono {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern string GetNativeStackTrace (Exception exception);
 
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		public static extern bool SetGCAllowSynchronousMajor (bool flag);
+		public static bool SetGCAllowSynchronousMajor (bool flag)
+		{
+			// No longer used
+			return true;
+		}
 	}
 }

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1420,11 +1420,6 @@ mono_gc_make_root_descr_user (MonoGCRootMarkFunc marker)
 	return NULL;
 }
 
-gboolean
-mono_gc_set_allow_synchronous_major (gboolean flag)
-{
-	return flag;
-}
 /* Toggleref support */
 
 void

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -80,7 +80,6 @@ gpointer    ves_icall_System_GCHandle_GetAddrOfPinnedObject (guint32 handle);
 void        ves_icall_System_GC_register_ephemeron_array (MonoObject *array);
 MonoObject  *ves_icall_System_GC_get_ephemeron_tombstone (void);
 
-MonoBoolean ves_icall_Mono_Runtime_SetGCAllowSynchronousMajor (MonoBoolean flag);
 
 extern void mono_gc_init (void);
 extern void mono_gc_base_init (void);
@@ -110,9 +109,6 @@ void mono_gchandle_set_target (guint32 gchandle, MonoObject *obj);
 
 /*Ephemeron functionality. Sgen only*/
 gboolean    mono_gc_ephemeron_array_add (MonoObject *obj);
-
-/* To disable synchronous, evacuating collections - concurrent SGen only */
-gboolean    mono_gc_set_allow_synchronous_major (gboolean flag);
 
 MonoBoolean
 mono_gc_GCHandle_CheckCurrentDomain (guint32 gchandle);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -608,12 +608,6 @@ ves_icall_System_GCHandle_GetAddrOfPinnedObject (guint32 handle)
 }
 
 MonoBoolean
-ves_icall_Mono_Runtime_SetGCAllowSynchronousMajor (MonoBoolean flag)
-{
-	return mono_gc_set_allow_synchronous_major (flag);
-}
-
-MonoBoolean
 mono_gc_GCHandle_CheckCurrentDomain (guint32 gchandle)
 {
 	return mono_gchandle_is_in_domain (gchandle, mono_domain_get ());

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -46,7 +46,6 @@ ICALL(COMPROX_2, "FindProxy", ves_icall_Mono_Interop_ComInteropProxy_FindProxy)
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
 ICALL(RUNTIME_1, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName)
 ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace)
-ICALL(RUNTIME_13, "SetGCAllowSynchronousMajor", ves_icall_Mono_Runtime_SetGCAllowSynchronousMajor)
 
 #ifndef PLATFORM_RO_FS
 ICALL_TYPE(KPAIR, "Mono.Security.Cryptography.KeyPairPersistence", KPAIR_1)

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -529,12 +529,6 @@ mono_gc_register_altstack (gpointer stack, gint32 stack_size, gpointer altstack,
 }
 
 gboolean
-mono_gc_set_allow_synchronous_major (gboolean flag)
-{
-	return TRUE;
-}
-
-gboolean
 mono_gc_is_null (void)
 {
 	return TRUE;

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -561,6 +561,11 @@ sgen_client_binary_protocol_global_remset (gpointer ptr, gpointer value, gpointe
 }
 
 static void G_GNUC_UNUSED
+sgen_client_binary_protocol_mod_union_remset (gpointer obj, gpointer ptr, gpointer value, gpointer value_vtable)
+{
+}
+
+static void G_GNUC_UNUSED
 sgen_client_binary_protocol_ptr_update (gpointer ptr, gpointer old_value, gpointer new_value, gpointer vtable, size_t size)
 {
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2687,12 +2687,6 @@ sgen_client_ensure_weak_gchandles_accessible (void)
 		mono_gc_wait_for_bridge_processing ();
 }
 
-gboolean
-mono_gc_set_allow_synchronous_major (gboolean flag)
-{
-	return sgen_set_allow_synchronous_major (flag);
-}
-
 void*
 mono_gc_invoke_with_gc_lock (MonoGCLockedCallbackFunc func, void *data)
 {

--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -292,8 +292,11 @@ static void
 update_mod_union (guint8 *dest, guint8 *start_card, size_t num_cards)
 {
 	int i;
-	for (i = 0; i < num_cards; ++i)
-		dest [i] |= start_card [i];
+	/* Marking from another thread can happen while we mark here */
+	for (i = 0; i < num_cards; ++i) {
+		if (start_card [i])
+			dest [i] = 1;
+	}
 }
 
 guint8*

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -239,12 +239,6 @@ static gboolean do_concurrent_checks = FALSE;
    each collection */
 static gboolean do_scan_starts_check = FALSE;
 
-/*
- * If the major collector is concurrent and this is FALSE, we will
- * never initiate a synchronous major collection, unless requested via
- * GC.Collect().
- */
-static gboolean allow_synchronous_major = TRUE;
 static gboolean disable_minor_collections = FALSE;
 static gboolean disable_major_collections = FALSE;
 static gboolean do_verify_nursery = FALSE;
@@ -2244,17 +2238,6 @@ sgen_perform_collection (size_t requested_size, int generation_to_collect, const
 		goto done;
 	}
 
-	/*
-	 * If we've been asked to do a major collection, and the major collector wants to
-	 * run synchronously (to evacuate), we set the flag to do that.
-	 */
-	if (generation_to_collect == GENERATION_OLD &&
-			allow_synchronous_major &&
-			major_collector.want_synchronous_collection &&
-			*major_collector.want_synchronous_collection) {
-		wait_to_finish = TRUE;
-	}
-
 	SGEN_ASSERT (0, !concurrent_collection_in_progress, "Why did this not get handled above?");
 
 	/*
@@ -2726,16 +2709,6 @@ sgen_gc_get_used_size (void)
 	return tot;
 }
 
-gboolean
-sgen_set_allow_synchronous_major (gboolean flag)
-{
-	if (!major_collector.is_concurrent)
-		return flag;
-
-	allow_synchronous_major = flag;
-	return TRUE;
-}
-
 void
 sgen_env_var_error (const char *env_var, const char *fallback, const char *description_format, ...)
 {
@@ -2952,23 +2925,6 @@ sgen_gc_init (void)
 				}
 				continue;
 			}
-			if (g_str_has_prefix (opt, "allow-synchronous-major=")) {
-				if (!major_collector.is_concurrent) {
-					sgen_env_var_error (MONO_GC_PARAMS_NAME, "Ignoring.", "`allow-synchronous-major` is only valid for the concurrent major collector.");
-					continue;
-				}
-
-				opt = strchr (opt, '=') + 1;
-
-				if (!strcmp (opt, "yes")) {
-					allow_synchronous_major = TRUE;
-				} else if (!strcmp (opt, "no")) {
-					allow_synchronous_major = FALSE;
-				} else {
-					sgen_env_var_error (MONO_GC_PARAMS_NAME, "Using default value.", "`allow-synchronous-major` must be either `yes' or `no'.");
-					continue;
-				}
-			}
 
 			if (!strcmp (opt, "cementing")) {
 				cement_enabled = TRUE;
@@ -3001,8 +2957,6 @@ sgen_gc_init (void)
 			fprintf (stderr, "  minor=COLLECTOR (where COLLECTOR is `simple' or `split')\n");
 			fprintf (stderr, "  wbarrier=WBARRIER (where WBARRIER is `remset' or `cardtable')\n");
 			fprintf (stderr, "  [no-]cementing\n");
-			if (major_collector.is_concurrent)
-				fprintf (stderr, "  allow-synchronous-major=FLAG (where FLAG is `yes' or `no')\n");
 			if (major_collector.print_gc_param_usage)
 				major_collector.print_gc_param_usage ();
 			if (sgen_minor_collector.print_gc_param_usage)

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -607,13 +607,6 @@ struct _SgenMajorCollector {
 	gboolean supports_cardtable;
 	gboolean sweeps_lazily;
 
-	/*
-	 * This is set to TRUE by the sweep if the next major
-	 * collection should be synchronous (for evacuation).  For
-	 * non-concurrent collectors, this should be NULL.
-	 */
-	gboolean *want_synchronous_collection;
-
 	void* (*alloc_heap) (mword nursery_size, mword nursery_align, int nursery_bits);
 	gboolean (*is_object_live) (GCObject *obj);
 	GCObject* (*alloc_small_pinned_obj) (GCVTable vtable, size_t size, gboolean has_references);

--- a/mono/sgen/sgen-marksweep-drain-gray-stack.h
+++ b/mono/sgen/sgen-marksweep-drain-gray-stack.h
@@ -223,7 +223,7 @@ SCAN_OBJECT_FUNCTION_NAME (GCObject *full_object, SgenDescriptor desc, SgenGrayQ
 #ifdef COPY_OR_MARK_CONCURRENT
 #define HANDLE_PTR(ptr,obj)	do {					\
 		GCObject *__old = *(ptr);				\
-		binary_protocol_scan_process_reference ((obj), (ptr), __old); \
+		binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
 		if (__old && !sgen_ptr_in_nursery (__old)) {            \
 			MSBlockInfo *block = MS_BLOCK_FOR_OBJ (__old);	\
 			if (G_UNLIKELY (!sgen_ptr_in_nursery (ptr) &&	\
@@ -242,7 +242,7 @@ SCAN_OBJECT_FUNCTION_NAME (GCObject *full_object, SgenDescriptor desc, SgenGrayQ
 #else
 #define HANDLE_PTR(ptr,obj)	do {					\
 		void *__old = *(ptr);					\
-		binary_protocol_scan_process_reference ((obj), (ptr), __old); \
+		binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
 		if (__old) {						\
 			gboolean __still_in_nursery = COPY_OR_MARK_FUNCTION_NAME ((ptr), __old, queue); \
 			if (G_UNLIKELY (__still_in_nursery && !sgen_ptr_in_nursery ((ptr)) && !SGEN_OBJECT_IS_CEMENTED (*(ptr)))) { \

--- a/mono/sgen/sgen-marksweep-drain-gray-stack.h
+++ b/mono/sgen/sgen-marksweep-drain-gray-stack.h
@@ -229,14 +229,14 @@ SCAN_OBJECT_FUNCTION_NAME (GCObject *full_object, SgenDescriptor desc, SgenGrayQ
 			if (G_UNLIKELY (!sgen_ptr_in_nursery (ptr) &&	\
 					sgen_safe_object_is_small (__old, sgen_obj_get_descriptor (__old) & DESC_TYPE_MASK) && \
 					major_block_is_evacuating (block))) { \
-				mark_mod_union_card ((full_object), (void**)(ptr)); \
+				mark_mod_union_card ((full_object), (void**)(ptr), __old); \
 			} else {					\
 				PREFETCH_READ (__old);			\
 				COPY_OR_MARK_FUNCTION_NAME ((ptr), __old, queue); \
 			}						\
 		} else {                                                \
 			if (G_UNLIKELY (sgen_ptr_in_nursery (__old) && !sgen_ptr_in_nursery ((ptr)))) \
-				mark_mod_union_card ((full_object), (void**)(ptr)); \
+				mark_mod_union_card ((full_object), (void**)(ptr), __old); \
 			}						\
 		} while (0)
 #else

--- a/mono/sgen/sgen-marksweep-scan-object-concurrent.h
+++ b/mono/sgen/sgen-marksweep-scan-object-concurrent.h
@@ -33,7 +33,7 @@
 #undef HANDLE_PTR
 #define HANDLE_PTR(ptr,obj)     do {                                    \
                 void *__old = *(ptr);                                   \
-                binary_protocol_scan_process_reference ((obj), (ptr), __old); \
+                binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
                 if (__old) {                                            \
                         gboolean __still_in_nursery = major_copy_or_mark_object_with_evacuation ((ptr), __old, queue); \
                         if (G_UNLIKELY (__still_in_nursery && !sgen_ptr_in_nursery ((ptr)) && !SGEN_OBJECT_IS_CEMENTED (*(ptr)))) { \

--- a/mono/sgen/sgen-marksweep-scan-object-concurrent.h
+++ b/mono/sgen/sgen-marksweep-scan-object-concurrent.h
@@ -35,7 +35,7 @@
                 void *__old = *(ptr);                                   \
                 binary_protocol_scan_process_reference ((obj), (ptr), __old); \
                 if (__old) {                                            \
-                        gboolean __still_in_nursery = major_copy_or_mark_object_no_evacuation ((ptr), __old, queue); \
+                        gboolean __still_in_nursery = major_copy_or_mark_object_with_evacuation ((ptr), __old, queue); \
                         if (G_UNLIKELY (__still_in_nursery && !sgen_ptr_in_nursery ((ptr)) && !SGEN_OBJECT_IS_CEMENTED (*(ptr)))) { \
                                 void *__copy = *(ptr);                  \
                                 sgen_add_to_global_remset ((ptr), __copy); \

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -2492,6 +2492,7 @@ sgen_marksweep_init_internal (SgenMajorCollector *collector, gboolean is_concurr
 	mono_counters_register ("Optimized copy major", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_optimized_copy_major);
 	mono_counters_register ("Optimized copy major small fast", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_optimized_copy_major_small_fast);
 	mono_counters_register ("Optimized copy major small slow", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_optimized_copy_major_small_slow);
+	mono_counters_register ("Optimized copy major small evacuate", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_optimized_copy_major_small_evacuate);
 	mono_counters_register ("Optimized copy major large", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_optimized_copy_major_large);
 	mono_counters_register ("Optimized major scan", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_optimized_major_scan);
 	mono_counters_register ("Optimized major scan no refs", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_optimized_major_scan_no_refs);

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -245,7 +245,6 @@ static MSBlockInfo * volatile *free_block_lists [MS_BLOCK_TYPE_MAX];
 static guint64 stat_major_blocks_alloced = 0;
 static guint64 stat_major_blocks_freed = 0;
 static guint64 stat_major_blocks_lazy_swept = 0;
-static guint64 stat_major_objects_evacuated = 0;
 
 #if SIZEOF_VOID_P != 8
 static guint64 stat_major_blocks_freed_ideal = 0;
@@ -2411,7 +2410,6 @@ sgen_marksweep_init_internal (SgenMajorCollector *collector, gboolean is_concurr
 	mono_counters_register ("# major blocks allocated", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_major_blocks_alloced);
 	mono_counters_register ("# major blocks freed", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_major_blocks_freed);
 	mono_counters_register ("# major blocks lazy swept", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_major_blocks_lazy_swept);
-	mono_counters_register ("# major objects evacuated", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_major_objects_evacuated);
 #if SIZEOF_VOID_P != 8
 	mono_counters_register ("# major blocks freed ideally", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_major_blocks_freed_ideal);
 	mono_counters_register ("# major blocks freed less ideally", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_major_blocks_freed_less_ideal);

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -1174,8 +1174,6 @@ static guint64 stat_drain_prefetch_fill_failures;
 static guint64 stat_drain_loops;
 #endif
 
-static void major_scan_object_with_evacuation (GCObject *start, mword desc, SgenGrayQueue *queue);
-
 #define COPY_OR_MARK_FUNCTION_NAME	major_copy_or_mark_object_no_evacuation
 #define SCAN_OBJECT_FUNCTION_NAME	major_scan_object_no_evacuation
 #define DRAIN_GRAY_STACK_FUNCTION_NAME	drain_gray_stack_no_evacuation

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -1065,7 +1065,7 @@ major_get_cardtable_mod_union_for_reference (char *ptr)
  * Mark the mod-union card for `ptr`, which must be a reference within the object `obj`.
  */
 static void
-mark_mod_union_card (GCObject *obj, void **ptr)
+mark_mod_union_card (GCObject *obj, void **ptr, GCObject *value_obj)
 {
 	int type = sgen_obj_get_descriptor (obj) & DESC_TYPE_MASK;
 	if (sgen_safe_object_is_small (obj, type)) {
@@ -1075,6 +1075,8 @@ mark_mod_union_card (GCObject *obj, void **ptr)
 	} else {
 		sgen_los_mark_mod_union_card (obj, ptr);
 	}
+
+	binary_protocol_mod_union_remset (obj, ptr, value_obj, SGEN_LOAD_VTABLE (value_obj));
 }
 
 static inline gboolean

--- a/mono/sgen/sgen-minor-scan-object.h
+++ b/mono/sgen/sgen-minor-scan-object.h
@@ -38,7 +38,7 @@ extern guint64 stat_scan_object_called_nursery;
 #define HANDLE_PTR(ptr,obj)	do {	\
 		void *__old = *(ptr);	\
 		SGEN_OBJECT_LAYOUT_STATISTICS_MARK_BITMAP ((obj), (ptr)); \
-		binary_protocol_scan_process_reference ((obj), (ptr), __old); \
+		binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
 		if (__old) {	\
 			SERIAL_COPY_OBJECT_FROM_OBJ ((ptr), queue);	\
 			SGEN_COND_LOG (9, __old != *(ptr), "Overwrote field at %p with %p (was: %p)", (ptr), *(ptr), __old); \
@@ -46,9 +46,9 @@ extern guint64 stat_scan_object_called_nursery;
 	} while (0)
 
 static void
-SERIAL_SCAN_OBJECT (GCObject *object, SgenDescriptor desc, SgenGrayQueue *queue)
+SERIAL_SCAN_OBJECT (GCObject *full_object, SgenDescriptor desc, SgenGrayQueue *queue)
 {
-	char *start = (char*)object;
+	char *start = (char*)full_object;
 
 	SGEN_OBJECT_LAYOUT_STATISTICS_DECLARE_BITMAP;
 

--- a/mono/sgen/sgen-protocol-def.h
+++ b/mono/sgen/sgen-protocol-def.h
@@ -372,6 +372,13 @@ MATCH_INDEX (ptr == entry->cursor ? 1 : ptr == entry->value ? 2 : BINARY_PROTOCO
 IS_VTABLE_MATCH (FALSE)
 END_PROTOCOL_ENTRY_HEAVY
 
+BEGIN_PROTOCOL_ENTRY_HEAVY4 (binary_protocol_mod_union_remset, TYPE_POINTER, obj, TYPE_POINTER, ptr, TYPE_POINTER, value, TYPE_POINTER, value_vtable)
+DEFAULT_PRINT ()
+IS_ALWAYS_MATCH (FALSE)
+MATCH_INDEX (ptr == entry->obj ? 0 : ptr == entry->ptr ? 1 : ptr == entry->value ? 2 : BINARY_PROTOCOL_NO_MATCH)
+IS_VTABLE_MATCH (ptr == entry->value_vtable)
+END_PROTOCOL_ENTRY_HEAVY
+
 #undef BEGIN_PROTOCOL_ENTRY0
 #undef BEGIN_PROTOCOL_ENTRY1
 #undef BEGIN_PROTOCOL_ENTRY2


### PR DESCRIPTION
The purpose of this commit is to unify evacuation between the normal and the concurrent collector. Before, for the concurrent collector, there was a different heuristic (less aggressive) for the case when we needed evacuation and this only happened by doing an explicit synchronous collection. Now we follow the same heuristic for evacuation that is on the normal collector, doing all the evacuation in the finishing pause.

As an example, on fsharp we had 5K objects evacuated with the concurrent collector. After this patch the number goes up to around 3.5M which is fairly close to what the normal collector does. This translates in a memory reduction, as seen in the image below. The price we pay for this added compaction is 1% increase in execution time (but the concurrent case is still about 5% faster than the non-concurrent) and a 2.5x increase in pause times (but the concurrent case pause times are, on average, still 5 times lower than the non-concurrent ones)

MB/s
![fsc0](https://cloud.githubusercontent.com/assets/4720621/11250099/78fd0306-8e33-11e5-820f-2ad0c70554b0.jpg)
