### PR TITLE
Match ext libgc api

### DIFF
--- a/libgc/alloc.c
+++ b/libgc/alloc.c
@@ -644,8 +644,16 @@ GC_stop_func stop_func;
    }
 }
 
-void (*GC_notify_event) GC_PROTO((GCEventType e));
+void (*GC_notify_event) GC_PROTO((GC_EventType e));
 void (*GC_on_heap_resize) GC_PROTO((size_t new_size));
+
+GC_API void GC_set_on_collection_event (void (*fn) (GC_EventType))
+{
+	DCL_LOCK_STATE;
+	LOCK();
+	GC_notify_event = fn;
+	UNLOCK();
+}
 
 /* Finish up a collection.  Assumes lock is held, signals are disabled,	*/
 /* but the world is otherwise running.					*/

--- a/libgc/include/private/gc_priv.h
+++ b/libgc/include/private/gc_priv.h
@@ -1214,6 +1214,8 @@ extern long GC_large_alloc_warn_suppressed;
   extern GC_bool GC_world_stopped;
 #endif
 
+extern void (*GC_notify_event) GC_PROTO((GC_EventType));
+
 /* Operations */
 # ifndef abs
 #   define abs(x)  ((x) < 0? (-(x)) : (x))

--- a/libgc/misc.c
+++ b/libgc/misc.c
@@ -480,7 +480,7 @@ int GC_get_suspend_signal GC_PROTO(())
 #endif
 }
 
-int GC_get_restart_signal GC_PROTO(())
+int GC_get_thr_restart_signal GC_PROTO(())
 {
 #if defined(SIG_THR_RESTART) && defined(GC_PTHREADS) && !defined(GC_MACOSX_THREADS) && !defined(GC_OPENBSD_THREADS)
 	return SIG_THR_RESTART;

--- a/libgc/pthread_support.c
+++ b/libgc/pthread_support.c
@@ -294,17 +294,17 @@ void GC_init_thread_local(GC_thread p)
 	ABORT("Failed to set thread specific allocation pointers");
     }
     for (i = 1; i < NFREELISTS; ++i) {
-	p -> ptrfree_freelists[i] = (ptr_t)1;
-	p -> normal_freelists[i] = (ptr_t)1;
+	p -> tlfs.ptrfree_freelists[i] = (ptr_t)1;
+	p -> tlfs.normal_freelists[i] = (ptr_t)1;
 #	ifdef GC_GCJ_SUPPORT
-	  p -> gcj_freelists[i] = (ptr_t)1;
+	  p -> tlfs.gcj_freelists[i] = (ptr_t)1;
 #	endif
     }   
     /* Set up the size 0 free lists.	*/
-    p -> ptrfree_freelists[0] = (ptr_t)(&size_zero_object);
-    p -> normal_freelists[0] = (ptr_t)(&size_zero_object);
+    p -> tlfs.ptrfree_freelists[0] = (ptr_t)(&size_zero_object);
+    p -> tlfs.normal_freelists[0] = (ptr_t)(&size_zero_object);
 #   ifdef GC_GCJ_SUPPORT
-        p -> gcj_freelists[0] = (ptr_t)(-1);
+	p -> tlfs.gcj_freelists[0] = (ptr_t)(-1);
 #   endif
 }
 
@@ -320,10 +320,10 @@ void GC_destroy_thread_local(GC_thread p)
 #   ifndef HANDLE_FORK
       GC_ASSERT(GC_getspecific(GC_thread_key) == (void *)p);
 #   endif
-    return_freelists(p -> ptrfree_freelists, GC_aobjfreelist);
-    return_freelists(p -> normal_freelists, GC_objfreelist);
+    return_freelists(p -> tlfs.ptrfree_freelists, GC_aobjfreelist);
+    return_freelists(p -> tlfs.normal_freelists, GC_objfreelist);
 #   ifdef GC_GCJ_SUPPORT
-   	return_freelists(p -> gcj_freelists, GC_gcjobjfreelist);
+	return_freelists(p -> tlfs.gcj_freelists, GC_gcjobjfreelist);
 #   endif
 }
 
@@ -357,7 +357,7 @@ GC_PTR GC_local_malloc(size_t bytes)
 	  GC_ASSERT(tsd == (void *)GC_lookup_thread(pthread_self()));
 	  UNLOCK();
 #	endif
-	my_fl = ((GC_thread)tsd) -> normal_freelists + index;
+	my_fl = ((GC_thread)tsd) -> tlfs.normal_freelists + index;
 	my_entry = *my_fl;
 	if (EXPECT((word)my_entry >= HBLKSIZE, 1)) {
 	    ptr_t next = obj_link(my_entry);
@@ -384,7 +384,7 @@ GC_PTR GC_local_malloc_atomic(size_t bytes)
     } else {
 	int index = INDEX_FROM_BYTES(bytes);
 	ptr_t * my_fl = ((GC_thread)GC_getspecific(GC_thread_key))
-		        -> ptrfree_freelists + index;
+		        -> tlfs.ptrfree_freelists + index;
 	ptr_t my_entry = *my_fl;
     
 	if (EXPECT((word)my_entry >= HBLKSIZE, 1)) {
@@ -424,7 +424,7 @@ GC_PTR GC_local_gcj_malloc(size_t bytes,
     } else {
 	int index = INDEX_FROM_BYTES(bytes);
 	ptr_t * my_fl = ((GC_thread)GC_getspecific(GC_thread_key))
-	                -> gcj_freelists + index;
+	                -> tlfs.gcj_freelists + index;
 	ptr_t my_entry = *my_fl;
 	if (EXPECT((word)my_entry >= HBLKSIZE, 1)) {
 	    GC_PTR result = (GC_PTR)my_entry;
@@ -463,7 +463,7 @@ GC_PTR GC_local_gcj_malloc(size_t bytes,
 void * GC_local_gcj_fast_malloc(size_t lw, void * ptr_to_struct_containing_descr)
 {
 	ptr_t * my_fl = ((GC_thread)GC_getspecific(GC_thread_key))
-		-> gcj_freelists + lw;
+		-> tlfs.gcj_freelists + lw;
 	ptr_t my_entry = *my_fl;
 
     GC_ASSERT(GC_gcj_malloc_initialized);
@@ -666,12 +666,12 @@ void GC_mark_thread_local_free_lists(void)
     for (i = 0; i < THREAD_TABLE_SZ; ++i) {
       for (p = GC_threads[i]; 0 != p; p = p -> next) {
 	for (j = 1; j < NFREELISTS; ++j) {
-	  q = p -> ptrfree_freelists[j];
+	  q = p -> tlfs.ptrfree_freelists[j];
 	  if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
-	  q = p -> normal_freelists[j];
+	  q = p -> tlfs.normal_freelists[j];
 	  if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
 #	  ifdef GC_GCJ_SUPPORT
-	    q = p -> gcj_freelists[j];
+	    q = p -> tlfs.gcj_freelists[j];
 	    if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
 #	  endif /* GC_GCJ_SUPPORT */
 	}

--- a/libgc/solaris_threads.c
+++ b/libgc/solaris_threads.c
@@ -642,10 +642,15 @@ int GC_thread_is_registered (void)
 	return ptr ? 1 : 0;
 }
 
-int GC_thread_register_foreign (void *base_addr)
+void GC_allow_register_threads (void)
+{
+	/* No-op for GC pre-v7. */
+}
+
+int GC_register_my_thread (struct GC_stack_base *sb)
 {
 	/* FIXME: */
-	return 0;
+	return GC_UNIMPLEMENTED;
 }
 
 void GC_register_altstack (void *stack, int stack_size, void *altstack, int altstack_size)

--- a/libgc/win32_threads.c
+++ b/libgc/win32_threads.c
@@ -85,6 +85,22 @@ int GC_thread_is_registered (void)
 #endif
 }
 
+void GC_allow_register_threads (void)
+{
+    /* No-op for GC pre-v7. */
+}
+
+int GC_register_my_thread (struct GC_stack_base *sb)
+{
+#   if defined(GC_DLL) || defined(GC_INSIDE_DLL)
+	/* Registered by DllMain. */
+	return GC_DUPLICATE;
+#   else
+	/* TODO: Implement. */
+	return GC_UNIMPLEMENTED;
+#   endif
+}
+
 void GC_register_altstack (void *stack, int stack_size, void *altstack, int altstack_size)
 {
 }

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -925,11 +925,17 @@ create_allocator (int atype, int tls_key, gboolean slowpath)
 	mono_mb_emit_byte (mb, 0x0D); /* CEE_MONO_TLS */
 	mono_mb_emit_i4 (mb, tls_key);
 	if (atype == ATYPE_FREEPTR || atype == ATYPE_FREEPTR_FOR_BOX || atype == ATYPE_STRING)
-		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (struct GC_Thread_Rep, ptrfree_freelists));
+		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (struct GC_Thread_Rep, tlfs)
+					+ G_STRUCT_OFFSET (struct thread_local_freelists,
+							   ptrfree_freelists));
 	else if (atype == ATYPE_NORMAL)
-		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (struct GC_Thread_Rep, normal_freelists));
+		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (struct GC_Thread_Rep, tlfs)
+					+ G_STRUCT_OFFSET (struct thread_local_freelists,
+							   normal_freelists));
 	else if (atype == ATYPE_GCJ)
-		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (struct GC_Thread_Rep, gcj_freelists));
+		mono_mb_emit_icon (mb, G_STRUCT_OFFSET (struct GC_Thread_Rep, tlfs)
+					+ G_STRUCT_OFFSET (struct thread_local_freelists,
+							   gcj_freelists));
 	else
 		g_assert_not_reached ();
 	mono_mb_emit_byte (mb, MONO_CEE_ADD);

--- a/mono/utils/gc_wrapper.h
+++ b/mono/utils/gc_wrapper.h
@@ -37,6 +37,7 @@
 #       endif
 #	endif
 
+#	define GC_INSIDE_DLL
 #	include <gc.h>
 #	include <gc_typed.h>
 #	include <gc_mark.h>


### PR DESCRIPTION
Proposed 2 commits are code refactoring of libgc (and mono/metadata/boehm-gc.c, accordingly) to match API (semi-private part of libgc used by mono) of recent BDWGC master (https://github.com/ivmai/bdwgc). This should simplify optional replacement of internal libgc with the external one without any mono functionality loss.