### PR TITLE
CSharpCodeCompiler should treat multi-line warning messages as warnings

### DIFF
--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
@@ -387,6 +387,12 @@ namespace Mono.CSharp
 			\s*
 			(?<message>.*)$";
 
+		static readonly Regex RelatedSymbolsRegex = new Regex(
+			@"
+            \(Location\ of\ the\ symbol\ related\ to\ previous\ (warning|error)\)
+			",
+			RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
+
 		private static CompilerError CreateErrorFromString(string error_string)
 		{
 			if (error_string.StartsWith ("BETA"))
@@ -399,11 +405,17 @@ namespace Mono.CSharp
 			Regex reg = new Regex (ErrorRegexPattern, RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
 			Match match=reg.Match(error_string);
 			if (!match.Success) {
-				// We had some sort of runtime crash
-				error.ErrorText = error_string;
-				error.IsWarning = false;
-				error.ErrorNumber = "";
-				return error;
+				match = RelatedSymbolsRegex.Match (error_string);
+				if (!match.Success) {
+					// We had some sort of runtime crash
+					error.ErrorText = error_string;
+					error.IsWarning = false;
+					error.ErrorNumber = "";
+					return error;
+				} else {
+					// This line is a continuation of previous warning of error
+					return null;
+				}
 			}
 			if (String.Empty != match.Result("${file}"))
 				error.FileName=match.Result("${file}");

--- a/mcs/class/System/Test/Microsoft.CSharp/CSharpCodeProviderTest.cs
+++ b/mcs/class/System/Test/Microsoft.CSharp/CSharpCodeProviderTest.cs
@@ -27,6 +27,9 @@ namespace MonoTests.Microsoft.CSharp
 
 		private static readonly string _sourceLibrary1 = "public class Test1 {}";
 		private static readonly string _sourceLibrary2 = "public class Test2 {}";
+		private static readonly string _sourceLibrary3 =
+			@"public class Test3 { public void F() { } }
+			public class Test4 : Test3 { public void F() { } }";
 		private static readonly string _sourceExecutable = "public class Program { static void Main () { } }";
 
 		[SetUp]
@@ -545,6 +548,22 @@ namespace MonoTests.Microsoft.CSharp
 			string[] tempFiles = Directory.GetFiles (_tempDir);
 			Assert.AreEqual (1, tempFiles.Length, "#3");
 			Assert.AreEqual (tempFile, tempFiles[0], "#4");
+		}
+
+		[Test]
+		public void MultiLineWarningIsReportedAsOneWarning()
+		{
+			CompilerParameters options = new CompilerParameters ();
+			options.GenerateExecutable = false;
+			options.GenerateInMemory = true;
+			options.TempFiles = new TempFileCollection (_tempDir);
+
+			ICodeCompiler compiler = _codeProvider.CreateCompiler ();
+			CompilerResults results = compiler.CompileAssemblyFromSource (options,
+				_sourceLibrary3);
+
+			// verify compilation was successful
+			AssertCompileResults (results, true);
 		}
 
 		private static string CreateTempDirectory ()


### PR DESCRIPTION
Most errors and warnings from c# compiler are reported in one line in format "FILE(LINE, COL): warning CS1234: Text".
But some warning span multiple lines:

```
/tmp/3fb23cc0/634d2022.0.cs(22,29): warning CS0114: `NS.B.F()' hides inherited member `NS.A.F()' ..
/tmp/3fb23cc0/634d2022.0.cs(16,29): (Location of the symbol related to previous warning)
```

Previously the second line was considered to be an internal compiler error since it doesn't match the error regex.

This seems to be only type of messages that span multiple lines.

This fixes #35980