### PR TITLE
[System] Check SocketOptionName.ReuseAddress support.

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -3163,27 +3163,24 @@ namespace System.Net.Sockets
 
 		public void SetSocketOption (SocketOptionLevel optionLevel, SocketOptionName optionName, bool optionValue)
 		{
-			ThrowIfDisposedAndClosed ();
-
-			int error;
 			int int_val = optionValue ? 1 : 0;
-			SetSocketOption_internal (safe_handle, optionLevel, optionName, null, null, int_val, out error);
 
-			if (error != 0) {
-				if (error == (int) SocketError.InvalidArgument)
-					throw new ArgumentException ();
-				throw new SocketException (error);
-			}
+			SetSocketOption (optionLevel, optionName, int_val);
 		}
 
 		public void SetSocketOption (SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue)
 		{
 			ThrowIfDisposedAndClosed ();
 
+			if (optionName == SocketOptionName.ReuseAddress && optionValue != 0 && !SupportsPortReuse ())
+				throw new SocketException ((int) SocketError.OperationNotSupported, "Operating system sockets do not support ReuseAddress.\nIf your socket is not intended to bind to the same address and port multiple times remove this option, otherwise you should ignore this exception inside a try catch and check that ReuseAddress is true before binding to the same address and port multiple times.");
+
 			int error;
 			SetSocketOption_internal (safe_handle, optionLevel, optionName, null, null, optionValue, out error);
 
 			if (error != 0) {
+				if (error == (int) SocketError.InvalidArgument)
+					throw new ArgumentException ();
 				throw new SocketException (error);
 			}
 		}

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -3492,6 +3492,8 @@ namespace MonoTests.System.Net.Sockets
 					s.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 				} catch (SocketException e) {
 					// Exception is thrown when ReuseAddress is not supported
+					Assert.AreEqual ((int) SocketError.OperationNotSupported, e.NativeErrorCode,
+							"Expected SocketError.OperationNotSupported");
 					supportsReuseAddress = false;
 				}
 
@@ -3523,6 +3525,8 @@ namespace MonoTests.System.Net.Sockets
 					s.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 				} catch (SocketException e) {
 					// Exception is thrown when ReuseAddress is not supported
+					Assert.AreEqual ((int) SocketError.OperationNotSupported, e.NativeErrorCode,
+							"Expected SocketError.OperationNotSupported");
 					supportsReuseAddress = false;
 				}
 


### PR DESCRIPTION
Operating systems that use linux kernels before 3.9 do not support
binding multiple socket to the same address and port.

In those systems even if it was possible to set
SocketOptionName.ReuseAddress an exception was thrown on the second
bind.

These changes introduce a SocketException that is thrown when
SocketOptionName.ReuseAddress is set on a system that will fail to bind
multiple times to the same address.