### PR TITLE
Fix error handling for case of invalid host name

### DIFF
--- a/mcs/class/System/System.Net/HttpListenerRequest.cs
+++ b/mcs/class/System/System.Net/HttpListenerRequest.cs
@@ -182,7 +182,7 @@ namespace System.Net {
 								host, LocalEndPoint.Port);
 
 			if (!Uri.TryCreate (base_uri + path, UriKind.Absolute, out url)){
-				context.ErrorMessage = "Invalid url: " + base_uri + path;
+				context.ErrorMessage = HttpUtility.HtmlEncode ("Invalid url: " + base_uri + path);
 				return;
 			}
 


### PR DESCRIPTION
If a attacker injects invalid content into the "host" header field like
"><script>alert(123)</script>
this content is now html encoded.
This prevents XSS attacks.

see [Xamarin bug 19238](https://bugzilla.xamarin.com/show_bug.cgi?id=19238)