### PR TITLE
Fix NullReferenceException when reader fails in SqlDataSourceView

### DIFF
--- a/mcs/class/System.Web/System.Web.UI.WebControls/SqlDataSourceView.cs
+++ b/mcs/class/System.Web/System.Web.UI.WebControls/SqlDataSourceView.cs
@@ -293,8 +293,8 @@ namespace System.Web.UI.WebControls {
 				catch (Exception e) {
 					exception = e;
 				}
-				SqlDataSourceStatusEventArgs selectedArgs =
-					new SqlDataSourceStatusEventArgs (command, reader.RecordsAffected, exception);
+				int rows = reader == null ? 0 : reader.RecordsAffected;
+				SqlDataSourceStatusEventArgs selectedArgs = new SqlDataSourceStatusEventArgs (command, rows, exception);
 				OnSelected (selectedArgs);
 				if (exception != null && !selectedArgs.ExceptionHandled)
 					throw exception;


### PR DESCRIPTION
If the reader execution in the try block fails, reader will stay null, but we later try to access `reader.RecordsAffected`. This raises a null reference exception which hides the original exception, making this particularly hard to detect.