### PR TITLE
[HttpConnection] Bug fix: HttpListener's "IgnoreWriteExceptions" property value is always ignored

### DIFF
--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -132,6 +132,7 @@ namespace System.Net {
 			input_state = InputState.RequestLine;
 			line_state = LineState.None;
 			context = new HttpListenerContext (this);
+			context.Listener = epl.Listener;
 		}
 
 		public bool IsClosed {


### PR DESCRIPTION
The problem is connected with "Listener" property of "context" object. It is always null, because nobody sets it. That's why "Write" method of the "ResponseStream" never throws any exceptions and caller's side thinks that network client is always connected.