### PR TITLE
Minimal fix for sporadic Mono.Unix.UnixSignalTest.TestWaitAny crashes (bug #35936)

### DIFF
--- a/mcs/nunit24/ConsoleRunner/nunit-console/ConsoleUi.cs
+++ b/mcs/nunit24/ConsoleRunner/nunit-console/ConsoleUi.cs
@@ -158,7 +158,7 @@ namespace NUnit.ConsoleRunner
 				//if ( testRunner != null )
 				//    testRunner.Unload();
 
-				if ( collector.HasExceptions )
+				if ( result == null || collector.HasExceptions )
 				{
 					collector.WriteExceptions();
 					return UNEXPECTED_ERROR;

--- a/support/signal.c
+++ b/support/signal.c
@@ -184,7 +184,6 @@ default_handler (int signum)
 			for (j = 0; j < pipecounter; ++j) {
 				int r;
 				do { r = write (fd, &c, 1); } while (keep_trying (r));
-				fsync (fd); /* force */
 			}
 		}
 	}


### PR DESCRIPTION
PR #2260 contained several things mixed together and the discussion is taking some time. Splitting out two minimal patches which directly address the main crash: