### PR TITLE
Throw AbandonedMutexException when waiting on an abandoned mutex.

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/MutexTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/MutexTest.cs
@@ -20,6 +20,7 @@ namespace MonoTests.System.Threading
 		{
 			public int id;
 			public Mutex mut;
+			public bool abandoned_exception;
 			public ConcClass(int id,Mutex mut)
 			{
 				this.id = id;
@@ -63,7 +64,12 @@ namespace MonoTests.System.Threading
 
 			public void WaitAndForget()
 			{
-				this.Wait();
+				try {
+					this.Wait();
+				} catch (AbandonedMutexException) {
+					this.abandoned_exception = true;
+				}
+
 				this.marker = id;
 			}
 			public void WaitAndWait()
@@ -148,9 +154,11 @@ namespace MonoTests.System.Threading
 			try {
 				thread1.Start();
 				TestUtil.WaitForNotAlive (thread1, "t1");
+				Assert.IsFalse (class1.abandoned_exception, "e1");
 	
 				thread2.Start();
 				TestUtil.WaitForNotAlive (thread2, "t2");
+				Assert.IsTrue (class2.abandoned_exception, "e2");
 			
 				Assert.AreEqual (class2.id, class2.marker);
 			} finally {

--- a/mono/io-layer/events.c
+++ b/mono/io-layer/events.c
@@ -21,10 +21,10 @@
 #include <mono/utils/mono-logger-internals.h>
 
 static void event_signal(gpointer handle);
-static gboolean event_own (gpointer handle);
+static gboolean event_own (gpointer handle, guint32 *statuscode);
 
 static void namedevent_signal (gpointer handle);
-static gboolean namedevent_own (gpointer handle);
+static gboolean namedevent_own (gpointer handle, guint32 *statuscode);
 
 struct _WapiHandleOps _wapi_event_ops = {
 	NULL,			/* close */
@@ -94,11 +94,13 @@ static void event_signal(gpointer handle)
 	SetEvent(handle);
 }
 
-static gboolean event_own (gpointer handle)
+static gboolean event_own (gpointer handle, guint32 *statuscode)
 {
 	struct _WapiHandle_event *event_handle;
 	gboolean ok;
-	
+
+	*statuscode = WAIT_OBJECT_0;
+
 	ok=_wapi_lookup_handle (handle, WAPI_HANDLE_EVENT,
 				(gpointer *)&event_handle);
 	if(ok==FALSE) {
@@ -126,10 +128,12 @@ static void namedevent_signal (gpointer handle)
 }
 
 /* NB, always called with the shared handle lock held */
-static gboolean namedevent_own (gpointer handle)
+static gboolean namedevent_own (gpointer handle, guint32 *statuscode)
 {
 	struct _WapiHandle_namedevent *namedevent_handle;
 	gboolean ok;
+
+	*statuscode = WAIT_OBJECT_0;
 	
 	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: owning named event handle %p", __func__, handle);
 

--- a/mono/io-layer/handles-private.h
+++ b/mono/io-layer/handles-private.h
@@ -62,7 +62,7 @@ extern gboolean _wapi_handle_test_capabilities (gpointer handle,
 						WapiHandleCapability caps);
 extern void _wapi_handle_ops_close (gpointer handle, gpointer data);
 extern void _wapi_handle_ops_signal (gpointer handle);
-extern gboolean _wapi_handle_ops_own (gpointer handle);
+extern gboolean _wapi_handle_ops_own (gpointer handle, guint32 *statuscode);
 extern gboolean _wapi_handle_ops_isowned (gpointer handle);
 extern guint32 _wapi_handle_ops_special_wait (gpointer handle,
 					      guint32 timeout,

--- a/mono/io-layer/handles.c
+++ b/mono/io-layer/handles.c
@@ -1212,7 +1212,7 @@ void _wapi_handle_ops_signal (gpointer handle)
 	}
 }
 
-gboolean _wapi_handle_ops_own (gpointer handle)
+gboolean _wapi_handle_ops_own (gpointer handle, guint32 *statuscode)
 {
 	guint32 idx = GPOINTER_TO_UINT(handle);
 	WapiHandleType type;
@@ -1224,7 +1224,7 @@ gboolean _wapi_handle_ops_own (gpointer handle)
 	type = _WAPI_PRIVATE_HANDLES(idx).type;
 
 	if (handle_ops[type] != NULL && handle_ops[type]->own_handle != NULL) {
-		return(handle_ops[type]->own_handle (handle));
+		return(handle_ops[type]->own_handle (handle, statuscode));
 	} else {
 		return(FALSE);
 	}

--- a/mono/io-layer/mutex-private.h
+++ b/mono/io-layer/mutex-private.h
@@ -25,6 +25,7 @@ struct _WapiHandle_mutex
 	pid_t pid;
 	pthread_t tid;
 	guint32 recursion;
+	gboolean abandoned;
 };
 
 struct _WapiHandle_namedmutex 
@@ -33,6 +34,7 @@ struct _WapiHandle_namedmutex
 	pid_t pid;
 	pthread_t tid;
 	guint32 recursion;
+	gboolean abandoned;
 };
 
 extern void _wapi_mutex_abandon (gpointer data, pid_t pid, pthread_t tid);

--- a/mono/io-layer/semaphores.c
+++ b/mono/io-layer/semaphores.c
@@ -26,10 +26,10 @@
 #include <mono/utils/mono-logger-internals.h>
 
 static void sema_signal(gpointer handle);
-static gboolean sema_own (gpointer handle);
+static gboolean sema_own (gpointer handle, guint32 *statuscode);
 
 static void namedsema_signal (gpointer handle);
-static gboolean namedsema_own (gpointer handle);
+static gboolean namedsema_own (gpointer handle, guint32 *statuscode);
 
 struct _WapiHandleOps _wapi_sem_ops = {
 	NULL,			/* close */
@@ -93,10 +93,12 @@ static void sema_signal(gpointer handle)
 	ReleaseSemaphore(handle, 1, NULL);
 }
 
-static gboolean sema_own (gpointer handle)
+static gboolean sema_own (gpointer handle, guint32 *statuscode)
 {
 	struct _WapiHandle_sem *sem_handle;
 	gboolean ok;
+	
+	*statuscode = WAIT_OBJECT_0;
 	
 	ok=_wapi_lookup_handle (handle, WAPI_HANDLE_SEM,
 				(gpointer *)&sem_handle);
@@ -125,11 +127,13 @@ static void namedsema_signal (gpointer handle)
 }
 
 /* NB, always called with the shared handle lock held */
-static gboolean namedsema_own (gpointer handle)
+static gboolean namedsema_own (gpointer handle, guint32 *statuscode)
 {
 	struct _WapiHandle_namedsem *namedsem_handle;
 	gboolean ok;
 	
+	*statuscode = WAIT_OBJECT_0;
+
 	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: owning named sem handle %p", __func__, handle);
 
 	ok = _wapi_lookup_handle (handle, WAPI_HANDLE_NAMEDSEM,

--- a/mono/io-layer/wapi-private.h
+++ b/mono/io-layer/wapi-private.h
@@ -80,8 +80,10 @@ struct _WapiHandleOps
 	/* Called by WaitForSingleObject and WaitForMultipleObjects,
 	 * with the handle locked (shared handles aren't locked.)
 	 * Returns TRUE if ownership was established, false otherwise.
+	 * If TRUE, *statuscode contains a status to which a handle
+	 * number can be added (typically WAIT_STATUS_0 or WAIT_ABANDONED_0).
 	 */
-	gboolean (*own_handle)(gpointer handle);
+	gboolean (*own_handle)(gpointer handle, guint32 *statuscode);
 
 	/* Called by WaitForSingleObject and WaitForMultipleObjects, if the
 	 * handle in question is "ownable" (ie mutexes), to see if the current

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1653,18 +1653,7 @@ gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_ha
 
 	THREAD_WAIT_DEBUG (g_message ("%s: (%"G_GSIZE_FORMAT") returning %d", __func__, mono_native_thread_id_get (), ret));
 
-	/*
-	 * These need to be here.  See MSDN dos on WaitForMultipleObjects.
-	 */
-	if (ret >= WAIT_OBJECT_0 && ret <= WAIT_OBJECT_0 + numhandles - 1) {
-		return ret - WAIT_OBJECT_0;
-	}
-	else if (ret >= WAIT_ABANDONED_0 && ret <= WAIT_ABANDONED_0 + numhandles - 1) {
-		return ret - WAIT_ABANDONED_0;
-	}
-	else {
-		return ret;
-	}
+	return ret;
 }
 
 /* FIXME: exitContext isnt documented */


### PR DESCRIPTION
.NET 2.0 and later throws this exception. The current tests fail in .NET,
and the modified tests pass there.

This commit licensed as MIT/X11.