### PR TITLE
Fixes UdpClient.Receive with IPv6 endpoint

### DIFF
--- a/mcs/class/System/System.Net.Sockets/UdpClient.cs
+++ b/mcs/class/System/System.Net.Sockets/UdpClient.cs
@@ -298,7 +298,7 @@ namespace System.Net.Sockets
 			CheckDisposed ();
 
 			byte [] recBuffer = new byte [65536]; // Max. size
-			EndPoint endPoint = new IPEndPoint (IPAddress.Any, 0);
+			EndPoint endPoint = (EndPoint) remoteEP;
 			int dataRead = socket.ReceiveFrom (recBuffer, ref endPoint);
 			if (dataRead < recBuffer.Length)
 				recBuffer = CutArray (recBuffer, dataRead);

--- a/mcs/class/System/Test/System.Net.Sockets/UdpClientTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/UdpClientTest.cs
@@ -1057,6 +1057,23 @@ namespace MonoTests.System.Net.Sockets {
 
 			client.Close ();
 		}
+
+		[Test] // #6057
+		public void ReceiveIPv6 ()
+		{
+			int PORT = 9997;
+			using(var udpClient = new UdpClient (PORT, AddressFamily.InterNetworkV6))
+			using(var udpClient2 = new UdpClient (PORT+1, AddressFamily.InterNetworkV6))
+			{
+				var dataSent = new byte [] {1,2,3};
+				udpClient2.SendAsync (dataSent, dataSent.Length, "::1", PORT);
+
+				IPEndPoint endPoint = new IPEndPoint (IPAddress.IPv6Any, 0);
+				var data = udpClient.Receive (ref endPoint);
+
+				Assert.AreEqual (dataSent.Length, data.Length);
+			}
+		}
 		
 		/* No test for Ttl default as it is platform dependent */
 


### PR DESCRIPTION
Tests and fixes UdpClient.Receive with IPv6 endpoint

Fixes [#6057](https://bugzilla.xamarin.com/show_bug.cgi?id=6057)

Partially reverts 838b6c5