### PR TITLE
Fail cleanly when MonoPosixHelper.dll version is wrong (bug #35655)

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixSignal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixSignal.cs
@@ -39,6 +39,11 @@ namespace Mono.Unix {
 		private int signum;
 		private IntPtr signal_info;
 
+		static UnixSignal ()
+		{
+			Stdlib.VersionCheck ();
+		}
+
 		public UnixSignal (Signum signum)
 		{
 			this.signum = NativeConvert.FromSignum (signum);

--- a/support/map.h
+++ b/support/map.h
@@ -2049,6 +2049,7 @@ int Mono_Posix_Stdlib_clearerr (void* stream);
 void* Mono_Posix_Stdlib_CreateFilePosition (void);
 int Mono_Posix_Stdlib_DumpFilePosition (char* buf, void* handle, int len);
 int Mono_Posix_Stdlib_EOF (void);
+const char* Mono_Unix_VersionString (void);
 int Mono_Posix_Stdlib_EXIT_FAILURE (void);
 int Mono_Posix_Stdlib_EXIT_SUCCESS (void);
 int Mono_Posix_Stdlib_fgetpos (void* stream, void* pos);

--- a/support/stdlib.c
+++ b/support/stdlib.c
@@ -14,6 +14,13 @@
 
 G_BEGIN_DECLS
 
+// See Stdlib.cs
+const char *
+Mono_Unix_VersionString ()
+{
+	return "MonoProject-2015-12-1";
+}
+
 gint32
 Mono_Posix_Stdlib_EXIT_FAILURE (void)
 {


### PR DESCRIPTION
Add version keys to the C and C# versions of Mono.Posix and add static constructors which fail early if the version keys differ.