### PR TITLE
Make Type.GetProperty() work for indexers returning primitive types

### DIFF
--- a/mcs/class/corlib/ReferenceSources/DefaultBinder.cs
+++ b/mcs/class/corlib/ReferenceSources/DefaultBinder.cs
@@ -36,7 +36,10 @@ namespace System
 				return false;
 
 			var from = Type.GetTypeCode (source);
-			switch (Type.GetTypeCode (target)) {
+			var to = Type.GetTypeCode (target);
+			if (from == to && source.IsPrimitive)
+				return true;
+			switch (to) {
 			case TypeCode.Char:
 				switch (from) {
 				case TypeCode.Byte:

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -1527,6 +1527,27 @@ namespace MonoTests.System
 							    typeof (long), new Type[0], null), "#2");
 		}
 
+		[Test]
+		public void GetProperty9_Indexers ()
+		{
+
+			var bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+
+			Type type1 = typeof (List<byte>);
+			var p1 = type1.GetProperty ("Item", bindingFlags, null, typeof (byte), new Type[] { typeof (int) }, null);
+			Assert.IsNotNull (p1, "#1");
+
+			Type type2 = typeof (List<string>);
+			var p2 = type2.GetProperty ("Item", bindingFlags, null, typeof (string), new Type[] { typeof (int) }, null);
+			Assert.IsNotNull (p2, "#2");
+
+			Type type3 = typeof (List<Type>);
+			// result type not convertible, make sure we fail.
+			var p3 = type3.GetProperty ("Item", bindingFlags, null, typeof (string) /*!*/,
+						    new Type[] { typeof (int) }, null);
+			Assert.IsNull (p3, "#3");
+		}
+
 		[StructLayout(LayoutKind.Explicit, Pack = 4, Size = 64)]
 		public class Class1
 		{


### PR DESCRIPTION
`Type.GetProperty(..., Type returnType, Type[] indexes, ...)` did the wrong when `returnType` was a primitive type and the giventype had precisely the same property type: for example `typeof(List<byte>).GetProperty("Item", ..., typeof(byte), ...)` would return `null`.

The fix is to make `DefaultBinder.CanConvertPrimitive(source, target)` return true if `source` and `target` are the same primitive type.