### PR TITLE
[mdoc] Improved error handling for multiassembly.

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -195,6 +195,24 @@ check-monodocer-dropns-multi: $(PROGRAM)
 	
 	diff --exclude=.svn -rup Test/en.expected-dropns-multi Test/en.actual
 
+
+check-monodocer-dropns-multi-withexisting: $(PROGRAM)
+	-rm -Rf Test/en.actual
+	$(MAKE) Test/DocTest-DropNS-classic.dll
+	$(MAKE) Test/DocTest-DropNS-unified.dll
+	$(MAKE) Test/DocTest-DropNS-classic-multitest.dll
+	$(MAKE) Test/DocTest-DropNS-unified-multitest.dll
+
+	# mdoc update to show a pre-existing set of documents
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-DropNS-classic.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-DropNS-unified.dll --dropns Test/DocTest-DropNS-unified.dll=MyFramework 
+	
+	# mdoc update for both classic and unified
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) -multiassembly
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework -multiassembly
+	
+	diff --exclude=.svn -rup Test/en.expected-dropns-multi-withexisting Test/en.actual
+
 check-monodocer-dropns-delete: $(PROGRAM)
 	-rm -Rf Test/en.actual
 	rm -Rf Test/DocTest-DropNS-classic-deletetest.dll
@@ -399,7 +417,8 @@ check-doc-tools: check-monodocer-since \
 	check-monodocer-dropns-delete \
 	check-monodocer-internal-interface \
 	check-monodocer-enumerations \
-	check-monodocer-dropns-multi
+	check-monodocer-dropns-multi \
+	check-monodocer-dropns-multi-withexisting
 
 check-doc-tools-update: check-monodocer-since-update \
 	check-monodocer-importecmadoc-update \

--- a/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
+++ b/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
@@ -1663,7 +1663,11 @@ class MDocUpdater : MDocCommand
 	/// <returns>The assembly that was either added, or was already present</returns>
 	static XmlElement AddAssemblyNameToNode (XmlElement root, ModuleDefinition module)
 	{
-		Func<XmlElement, bool> assemblyFilter = x => x.SelectSingleNode ("AssemblyName").InnerText == module.Assembly.Name.Name;
+		Func<XmlElement, bool> assemblyFilter = x => {
+			var existingName = x.SelectSingleNode ("AssemblyName");
+			return existingName != null && existingName.InnerText == module.Assembly.Name.Name;
+		};
+		
 		return AddAssemblyXmlNode (
 			root.SelectNodes ("AssemblyInfo").Cast<XmlElement> ().ToArray (), 
 			assemblyFilter, x => WriteElementText (x, "AssemblyName", module.Assembly.Name.Name), 

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/MyClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/MyClass.xml
@@ -1,0 +1,136 @@
+<Type Name="MyClass" FullName="MyFramework.MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Hello">
+      <MemberSignature Language="C#" Value="public float Hello (int value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MyProperty">
+      <MemberSignature Language="C#" Value="public string MyProperty { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/OnlyInMulti.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/OnlyInMulti.xml
@@ -1,0 +1,40 @@
+<Type Name="OnlyInMulti" FullName="MyFramework.MyNamespace.OnlyInMulti">
+  <TypeSignature Language="C#" Value="public class OnlyInMulti" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit OnlyInMulti extends System.Object" />
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public OnlyInMulti ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/index.xml
@@ -1,0 +1,53 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-DropNS-classic-multitest" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-DropNS-unified" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-DropNS-unified-multitest" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="MyFramework.MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+      <Type Name="OnlyInMulti" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>DocTest-DropNS-classic</Title>
+</Overview>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/ns-MyFramework.MyNamespace.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/ns-MyFramework.MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyFramework.MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>


### PR DESCRIPTION
While there were tests included for the [multiassembly option](https://github.com/mono/mono/pull/2127), unfortunately
the tests did not consider starting from an existing repository. So this patch
rectifies the issue by improving a small function to consider the possibility
of a null result. Test that reproduced, and subsequently proves the resolution
is included here.