### PR TITLE
[System.Net.Http] Replace google.com with example.org in a test

### DIFF
--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -997,8 +997,8 @@ namespace MonoTests.System.Net.Http
 		public void GetString_Many ()
 		{
 			var client = new HttpClient ();
-			var t1 = client.GetStringAsync ("http://www.google.com");
-			var t2 = client.GetStringAsync ("http://www.google.com");
+			var t1 = client.GetStringAsync ("http://example.org");
+			var t2 = client.GetStringAsync ("http://example.org");
 			Assert.IsTrue (Task.WaitAll (new [] { t1, t2 }, WaitTimeout));		
 		}
 


### PR DESCRIPTION
It sometimes fails on Jenkins and google might be doing unwanted things (like redirecting to https),
so we just use example.org instead which hopefully is more stable in that regard.