### PR TITLE
[FileSystemWatcher] Kill race condition (fixes BXC#10205)

### DIFF
--- a/mcs/class/System/System.IO/DefaultWatcher.cs
+++ b/mcs/class/System/System.IO/DefaultWatcher.cs
@@ -43,6 +43,8 @@ namespace System.IO {
 		public bool Enabled;
 		public bool NoWildcards;
 		public DateTime DisabledTime;
+
+		public object FilesLock = new object ();
 		public Hashtable Files;
 	}
 
@@ -211,6 +213,13 @@ namespace System.IO {
 					files = NoStringsArray;
 			}
 
+			lock (data.FilesLock) {
+				IterateAndModifyFilesData (data, directory, dispatch, files);
+			}
+		}
+
+		void IterateAndModifyFilesData (DefaultWatcherData data, string directory, bool dispatch, string[] files)
+		{
 			/* Set all as untested */
 			foreach (string filename in data.Files.Keys) {
 				FileData fd = (FileData) data.Files [filename];


### PR DESCRIPTION
As seen in the stacktraces provided in [1],
a thread could modify the Files hashtable
while other thread is enumerating it, so this
can be prevented by using a lock{} in the parts
of the code that access and modify this field.

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=10205