### PR TITLE
[runtime] Compile cleanly with -Wc++-compat.

### DIFF
--- a/mono/dis/dis-cil.c
+++ b/mono/dis/dis-cil.c
@@ -56,7 +56,7 @@ disassemble_cil (MonoImage *m, MonoMethodHeader *mh, MonoGenericContainer *conta
 #endif
 
        if (mh->num_clauses) {
-	       trys = g_malloc0 (sizeof (gboolean) * mh->num_clauses);
+	       trys = (gboolean *)g_malloc0 (sizeof (gboolean) * mh->num_clauses);
 	       trys [0] = 1;
 	       for (i=1; i < mh->num_clauses; ++i) {
 #define jcl mh->clauses [j]	

--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -661,14 +661,14 @@ dump_table_methodimpl (MonoImage *m)
 
 	for (i = 1; i <= t->rows; i++){
 		guint32 cols [MONO_METHODIMPL_SIZE];
-		char *class, *impl, *decl;
+		char *klass, *impl, *decl;
 
 		mono_metadata_decode_row (t, i - 1, cols, MONO_METHODIMPL_SIZE);
-		class = get_typedef (m, cols [MONO_METHODIMPL_CLASS]);
+		klass = get_typedef (m, cols [MONO_METHODIMPL_CLASS]);
 		impl = get_method (m, method_dor_to_token (cols [MONO_METHODIMPL_BODY]), NULL);
 		decl = get_method (m, method_dor_to_token (cols [MONO_METHODIMPL_DECLARATION]), NULL);
-		fprintf (output, "%d: %s\n\tdecl: %s\n\timpl: %s\n", i, class, decl, impl);
-		g_free (class);
+		fprintf (output, "%d: %s\n\tdecl: %s\n\timpl: %s\n", i, klass, decl, impl);
+		g_free (klass);
 		g_free (impl);
 		g_free (decl);
 	}

--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -2222,7 +2222,7 @@ get_encoded_user_string_or_bytearray (const unsigned char *ptr, int len)
 	char *res, *eres, *result;
 	int i;
 
-	res = g_malloc ((len >> 1) + 1);
+	res = (char *)g_malloc ((len >> 1) + 1);
 
 	/*
 	 * I should really use some kind of libunicode here
@@ -3137,7 +3137,7 @@ check_ambiguous_genparams (MonoGenericContainer *container)
 	for (i = 0; i < container->type_argc; i++) {
 		MonoGenericParam *param = mono_generic_container_get_param (container, i);
 
-		if ((p = g_hash_table_lookup (table, mono_generic_param_info (param)->name)))
+		if ((p = (gpointer *)g_hash_table_lookup (table, mono_generic_param_info (param)->name)))
 			dup_list = g_slist_prepend (g_slist_prepend (dup_list, GUINT_TO_POINTER (i + 1)), p);
 		else
 			g_hash_table_insert (table, (char*)mono_generic_param_info (param)->name, GUINT_TO_POINTER (i + 1));

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -301,7 +301,7 @@ dis_directive_moduleref (MonoImage *m)
 static void
 dis_nt_header (MonoImage *m)
 {
-	MonoCLIImageInfo *image_info = m->image_info;
+	MonoCLIImageInfo *image_info = (MonoCLIImageInfo *)m->image_info;
 	if (image_info && image_info->cli_header.nt.pe_stack_reserve != 0x100000)
 		fprintf (output, ".stackreserve 0x%x\n", image_info->cli_header.nt.pe_stack_reserve);
 }
@@ -493,7 +493,7 @@ dis_field_list (MonoImage *m, guint32 start, guint32 end, MonoGenericContainer *
 			
 			if ((crow = mono_metadata_get_constant_index (m, MONO_TOKEN_FIELD_DEF | (i+1), 0))) {
 				mono_metadata_decode_row (&m->tables [MONO_TABLE_CONSTANT], crow-1, const_cols, MONO_CONSTANT_SIZE);
-				lit = get_constant (m, const_cols [MONO_CONSTANT_TYPE], const_cols [MONO_CONSTANT_VALUE]);
+				lit = get_constant (m, (MonoTypeEnum)const_cols [MONO_CONSTANT_TYPE], const_cols [MONO_CONSTANT_VALUE]);
 			} else {
 				lit = g_strdup ("not found");
 			}
@@ -800,7 +800,7 @@ dump_cattrs_for_method_params (MonoImage *m, guint32 midx, MonoMethodSignature *
 			if ((crow = mono_metadata_get_constant_index(m, MONO_TOKEN_PARAM_DEF | i, 0))) {
 				guint32 const_cols [MONO_CONSTANT_SIZE];
 				mono_metadata_decode_row( &m->tables[MONO_TABLE_CONSTANT], crow-1, const_cols, MONO_CONSTANT_SIZE);
-				lit = get_constant(m, const_cols [MONO_CONSTANT_TYPE], const_cols [MONO_CONSTANT_VALUE]);
+				lit = get_constant (m, (MonoTypeEnum)const_cols [MONO_CONSTANT_TYPE], const_cols [MONO_CONSTANT_VALUE]);
 			}
 			else {
 				lit = g_strdup ("not found");
@@ -1664,7 +1664,7 @@ setup_filter (MonoImage *image)
 	const char *name = mono_image_get_name (image);
 
 	for (item = filter_list; item; item = item->next) {
-		ifilter = item->data;
+		ifilter = (ImageFilter *)item->data;
 		if (strcmp (ifilter->name, name) == 0) {
 			cur_filter = ifilter;
 			return;
@@ -1676,8 +1676,8 @@ setup_filter (MonoImage *image)
 static int
 int_cmp (const void *e1, const void *e2)
 {
-	const int *i1 = e1;
-	const int *i2 = e2;
+	const int *i1 = (const int *)e1;
+	const int *i2 = (const int *)e2;
 	return *i1 - *i2;
 }
 
@@ -1720,7 +1720,7 @@ add_filter (const char *name)
 	GList *item;
 
 	for (item = filter_list; item; item = item->next) {
-		ifilter = item->data;
+		ifilter = (ImageFilter *)item->data;
 		if (strcmp (ifilter->name, name) == 0)
 			return ifilter;
 	}
@@ -1736,10 +1736,10 @@ add_item (TableFilter *tf, int val)
 	if (tf->count >= tf->size) {
 		if (!tf->size) {
 			tf->size = 8;
-			tf->elems = g_malloc (sizeof (int) * tf->size);
+			tf->elems = (int *)g_malloc (sizeof (int) * tf->size);
 		} else {
 			tf->size *= 2;
-			tf->elems = g_realloc (tf->elems, sizeof (int) * tf->size);
+			tf->elems = (int *)g_realloc (tf->elems, sizeof (int) * tf->size);
 		}
 	}
 	tf->elems [tf->count++] = val;
@@ -1752,7 +1752,7 @@ sort_filter_elems (void)
 	GList *item;
 
 	for (item = filter_list; item; item = item->next) {
-		ifilter = item->data;
+		ifilter = (ImageFilter *)item->data;
 		qsort (ifilter->types.elems, ifilter->types.count, sizeof (int), int_cmp);
 		qsort (ifilter->fields.elems, ifilter->fields.count, sizeof (int), int_cmp);
 		qsort (ifilter->methods.elems, ifilter->methods.count, sizeof (int), int_cmp);
@@ -1913,7 +1913,7 @@ monodis_assembly_search_hook (MonoAssemblyName *aname, gpointer user_data)
         GList *tmp;
 
        for (tmp = loaded_assemblies; tmp; tmp = tmp->next) {
-               MonoAssembly *ass = tmp->data;
+               MonoAssembly *ass = (MonoAssembly *)tmp->data;
                if (mono_assembly_names_equal (aname, &ass->aname))
 		       return ass;
        }
@@ -2000,7 +2000,7 @@ main (int argc, char *argv [])
 	 * If we just have one file, use the corlib version it requires.
 	 */
 	if (!input_files->next) {
-		char *filename = input_files->data;
+		char *filename = (char *)input_files->data;
 
 		mono_init_from_assembly (argv [0], filename);
 
@@ -2011,7 +2011,7 @@ main (int argc, char *argv [])
 		mono_init (argv [0]);
 
 		for (l = input_files; l; l = l->next)
-			disassemble_file (l->data);
+			disassemble_file ((const char *)l->data);
 	}
 
 	return 0;

--- a/mono/io-layer/events.c
+++ b/mono/io-layer/events.c
@@ -88,11 +88,9 @@ static mono_once_t event_ops_once=MONO_ONCE_INIT;
 static void event_ops_init (void)
 {
 	_wapi_handle_register_capabilities (WAPI_HANDLE_EVENT,
-					    WAPI_HANDLE_CAP_WAIT |
-					    WAPI_HANDLE_CAP_SIGNAL);
+		(WapiHandleCapability)(WAPI_HANDLE_CAP_WAIT | WAPI_HANDLE_CAP_SIGNAL));
 	_wapi_handle_register_capabilities (WAPI_HANDLE_NAMEDEVENT,
-					    WAPI_HANDLE_CAP_WAIT |
-					    WAPI_HANDLE_CAP_SIGNAL);
+		(WapiHandleCapability)(WAPI_HANDLE_CAP_WAIT | WAPI_HANDLE_CAP_SIGNAL));
 }
 
 static void event_signal(gpointer handle)

--- a/mono/io-layer/handles.c
+++ b/mono/io-layer/handles.c
@@ -56,7 +56,7 @@
 
 static void (*_wapi_handle_ops_get_close_func (WapiHandleType type))(gpointer, gpointer);
 
-static WapiHandleCapability handle_caps[WAPI_HANDLE_COUNT]={0};
+static WapiHandleCapability handle_caps[WAPI_HANDLE_COUNT] = { (WapiHandleCapability)0 };
 static struct _WapiHandleOps *handle_ops[WAPI_HANDLE_COUNT]={
 	NULL,
 	&_wapi_file_ops,
@@ -258,12 +258,12 @@ wapi_init (void)
 
 	_wapi_shm_semaphores_init ();
 	
-	_wapi_shared_layout = _wapi_shm_attach (WAPI_SHM_DATA);
+	_wapi_shared_layout = (_WapiHandleSharedLayout *)_wapi_shm_attach (WAPI_SHM_DATA);
 	g_assert (_wapi_shared_layout != NULL);
 	
 	if (_wapi_shm_enabled ()) {
 		/* This allocates a 4mb array, so do it only if SHM is enabled */
-		_wapi_fileshare_layout = _wapi_shm_attach (WAPI_SHM_FILESHARE);
+		_wapi_fileshare_layout = (_WapiFileShareLayout *)_wapi_shm_attach (WAPI_SHM_FILESHARE);
 		g_assert (_wapi_fileshare_layout != NULL);
 	}
 	
@@ -1636,8 +1636,8 @@ _wapi_free_share_info (_WapiFileShare *share_info)
 static gint
 wapi_share_info_equal (gconstpointer ka, gconstpointer kb)
 {
-	const _WapiFileShare *s1 = ka;
-	const _WapiFileShare *s2 = kb;
+	const _WapiFileShare *s1 = (const _WapiFileShare *)ka;
+	const _WapiFileShare *s2 = (const _WapiFileShare *)kb;
 
 	return (s1->device == s2->device && s1->inode == s2->inode) ? 1 : 0;
 }
@@ -1645,7 +1645,7 @@ wapi_share_info_equal (gconstpointer ka, gconstpointer kb)
 static guint
 wapi_share_info_hash (gconstpointer data)
 {
-	const _WapiFileShare *s = data;
+	const _WapiFileShare *s = (const _WapiFileShare *)data;
 
 	return s->inode;
 }
@@ -1689,7 +1689,7 @@ gboolean _wapi_handle_get_or_set_share (guint64 device, guint64 inode,
 
 		file_share_hash_lock ();
 
-		file_share = g_hash_table_lookup (file_share_hash, &tmp);
+		file_share = (_WapiFileShare *)g_hash_table_lookup (file_share_hash, &tmp);
 		if (file_share) {
 			*old_sharemode = file_share->sharemode;
 			*old_access = file_share->access;

--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -1494,7 +1494,7 @@ static gboolean share_check (struct stat *statbuf, guint32 sharemode,
 gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 		    guint32 sharemode, WapiSecurityAttributes *security,
 		    guint32 createmode, guint32 attrs,
-		    gpointer template G_GNUC_UNUSED)
+		    gpointer template_ G_GNUC_UNUSED)
 {
 	struct _WapiHandle_file file_handle = {0};
 	gpointer handle;
@@ -1508,7 +1508,7 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 	mode_t perms=0666;
 	gchar *filename;
 	int fd, ret;
-	int handle_type;
+	WapiHandleType handle_type;
 	struct stat statbuf;
 	
 	mono_once (&io_ops_once, io_ops_init);
@@ -3706,7 +3706,7 @@ append_to_mountpoint (LinuxMountInfoParseState *state)
 	if (state->mountpoint_allocated) {
 		if (state->mountpoint_index >= state->allocated_size) {
 			guint32 newsize = (state->allocated_size << 1) + 1;
-			gchar *newbuf = g_malloc0 (newsize * sizeof (gchar));
+			gchar *newbuf = (gchar *)g_malloc0 (newsize * sizeof (gchar));
 
 			memcpy (newbuf, state->mountpoint_allocated, state->mountpoint_index);
 			g_free (state->mountpoint_allocated);
@@ -3717,7 +3717,7 @@ append_to_mountpoint (LinuxMountInfoParseState *state)
 	} else {
 		if (state->mountpoint_index >= GET_LOGICAL_DRIVE_STRINGS_MOUNTPOINT_BUFFER) {
 			state->allocated_size = (state->mountpoint_index << 1) + 1;
-			state->mountpoint_allocated = g_malloc0 (state->allocated_size * sizeof (gchar));
+			state->mountpoint_allocated = (gchar *)g_malloc0 (state->allocated_size * sizeof (gchar));
 			memcpy (state->mountpoint_allocated, state->mountpoint, state->mountpoint_index);
 			state->mountpoint_allocated [state->mountpoint_index++] = ch;
 		} else

--- a/mono/io-layer/messages.c
+++ b/mono/io-layer/messages.c
@@ -1830,7 +1830,7 @@ find_msg (guint32 id, ErrorDesc *base, int n)
 	ErrorDesc d, *result;
 	d.id = id;
 	
-	result = mono_binary_search (&d, base, n, sizeof (ErrorDesc), msg_compare);
+	result = (ErrorDesc *)mono_binary_search (&d, base, n, sizeof (ErrorDesc), msg_compare);
 	if (result == NULL)
 		return NULL;
 	return result->txt;

--- a/mono/io-layer/mutexes.c
+++ b/mono/io-layer/mutexes.c
@@ -91,13 +91,9 @@ static mono_once_t mutex_ops_once=MONO_ONCE_INIT;
 static void mutex_ops_init (void)
 {
 	_wapi_handle_register_capabilities (WAPI_HANDLE_MUTEX,
-					    WAPI_HANDLE_CAP_WAIT |
-					    WAPI_HANDLE_CAP_SIGNAL |
-					    WAPI_HANDLE_CAP_OWN);
+		(WapiHandleCapability)(WAPI_HANDLE_CAP_WAIT | WAPI_HANDLE_CAP_SIGNAL | WAPI_HANDLE_CAP_OWN));
 	_wapi_handle_register_capabilities (WAPI_HANDLE_NAMEDMUTEX,
-					    WAPI_HANDLE_CAP_WAIT |
-					    WAPI_HANDLE_CAP_SIGNAL |
-					    WAPI_HANDLE_CAP_OWN);
+		(WapiHandleCapability)(WAPI_HANDLE_CAP_WAIT | WAPI_HANDLE_CAP_SIGNAL | WAPI_HANDLE_CAP_OWN));
 }
 
 static void mutex_signal(gpointer handle)

--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -1137,8 +1137,7 @@ wapi_processes_init (void)
 	WapiHandle_process process_handle = {0};
 
 	_wapi_handle_register_capabilities (WAPI_HANDLE_PROCESS,
-					    WAPI_HANDLE_CAP_WAIT |
-					    WAPI_HANDLE_CAP_SPECIAL_WAIT);
+		(WapiHandleCapability)(WAPI_HANDLE_CAP_WAIT | WAPI_HANDLE_CAP_SPECIAL_WAIT));
 	
 	process_handle.id = pid;
 
@@ -1831,7 +1830,7 @@ gboolean EnumProcessModules (gpointer process, gpointer *modules,
 	}
 		
 	for (i = 0; i < count; i++) {
-		free_procmodule (g_slist_nth_data (mods, i));
+		free_procmodule ((WapiProcModule *)g_slist_nth_data (mods, i));
 	}
 	g_slist_free (mods);
 	g_free (proc_name);
@@ -2633,7 +2632,7 @@ mono_processes_cleanup (void)
 		 * they have the 'finished' flag set, which means the sigchld handler is done
 		 * accessing them.
 		 */
-		mp = l->data;
+		mp = (MonoProcess *)l->data;
 		mono_os_sem_destroy (&mp->exit_sem);
 		g_free (mp);
 	}

--- a/mono/io-layer/semaphores.c
+++ b/mono/io-layer/semaphores.c
@@ -87,11 +87,9 @@ static mono_once_t sem_ops_once=MONO_ONCE_INIT;
 static void sem_ops_init (void)
 {
 	_wapi_handle_register_capabilities (WAPI_HANDLE_SEM,
-					    WAPI_HANDLE_CAP_WAIT |
-					    WAPI_HANDLE_CAP_SIGNAL);
+		(WapiHandleCapability)(WAPI_HANDLE_CAP_WAIT | WAPI_HANDLE_CAP_SIGNAL));
 	_wapi_handle_register_capabilities (WAPI_HANDLE_NAMEDSEM,
-					    WAPI_HANDLE_CAP_WAIT |
-					    WAPI_HANDLE_CAP_SIGNAL);
+		(WapiHandleCapability)(WAPI_HANDLE_CAP_WAIT | WAPI_HANDLE_CAP_SIGNAL));
 }
 
 static void sema_signal(gpointer handle)

--- a/mono/io-layer/sockets.c
+++ b/mono/io-layer/sockets.c
@@ -841,10 +841,10 @@ guint32 _wapi_socket(int domain, int type, int protocol, void *unused,
 	 * https://bugzilla.novell.com/show_bug.cgi?id=MONO53992
 	 */
 	{
-		int ret, true = 1;
+		int ret, true_ = 1;
 	
-		ret = setsockopt (fd, SOL_SOCKET, SO_REUSEADDR, &true,
-				  sizeof (true));
+		ret = setsockopt (fd, SOL_SOCKET, SO_REUSEADDR, &true_,
+				  sizeof (true_));
 		if (ret == -1) {
 			int errnum = errno;
 
@@ -1165,7 +1165,7 @@ WSAIoctl (guint32 fd, gint32 command,
 	}
 
 	if (i_len > 0) {
-		buffer = g_memdup (input, i_len);
+		buffer = (char *)g_memdup (input, i_len);
 	}
 
 	ret = ioctl (fd, command, buffer);

--- a/mono/io-layer/versioninfo.c
+++ b/mono/io-layer/versioninfo.c
@@ -901,7 +901,7 @@ VerQueryValue (gconstpointer datablock, const gunichar2 *subblock, gpointer *buf
 					    string_value != NULL &&
 					    string_value_len != 0) {
 						*buffer = string_value;
-						*len = unicode_chars (string_value) + 1; /* Include trailing null */
+						*len = unicode_chars ((const gunichar2 *)string_value) + 1; /* Include trailing null */
 						ret = TRUE;
 						goto done;
 					}

--- a/mono/io-layer/wapi-private.h
+++ b/mono/io-layer/wapi-private.h
@@ -173,6 +173,8 @@ struct _WapiHandleSharedLayout
 	struct _WapiHandleShared handles[_WAPI_HANDLE_INITIAL_COUNT];
 };
 
+typedef struct _WapiHandleSharedLayout _WapiHandleSharedLayout;
+
 #define _WAPI_FILESHARE_SIZE 102400
 
 struct _WapiFileShare
@@ -197,6 +199,8 @@ struct _WapiFileShareLayout
 	
 	struct _WapiFileShare share_info[_WAPI_FILESHARE_SIZE];
 };
+
+typedef struct _WapiFileShareLayout _WapiFileShareLayout;
 
 
 

--- a/mono/io-layer/wapi_glob.c
+++ b/mono/io-layer/wapi_glob.c
@@ -266,8 +266,9 @@ globextend(const gchar *path, wapi_glob_t *pglob, size_t *limitp)
 	const gchar *p;
 
 	newsize = sizeof(*pathv) * (2 + pglob->gl_pathc + pglob->gl_offs);
-	pathv = pglob->gl_pathv ? realloc((char *)pglob->gl_pathv, newsize) :
-	    malloc(newsize);
+	/* FIXME: Can just use realloc(). */
+	pathv = (char **)(pglob->gl_pathv ? realloc((char *)pglob->gl_pathv, newsize) :
+	    malloc(newsize));
 	if (pathv == NULL) {
 		if (pglob->gl_pathv) {
 			free(pglob->gl_pathv);
@@ -288,7 +289,7 @@ globextend(const gchar *path, wapi_glob_t *pglob, size_t *limitp)
 		;
 	len = (size_t)(p - path);
 	*limitp += len;
-	if ((copy = malloc(len)) != NULL) {
+	if ((copy = (char *)malloc(len)) != NULL) {
 		if (g_Ctoc(path, copy, len)) {
 			free(copy);
 			return(WAPI_GLOB_NOSPACE);

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -208,7 +208,7 @@ encode_public_tok (const guchar *token, gint32 len)
 	gchar *res;
 	int i;
 
-	res = g_malloc (len * 2 + 1);
+	res = (gchar *)g_malloc (len * 2 + 1);
 	for (i = 0; i < len; i++) {
 		res [i * 2] = allowed [token [i] >> 4];
 		res [i * 2 + 1] = allowed [token [i] & 0xF];
@@ -791,7 +791,7 @@ mono_assembly_fill_assembly_name (MonoImage *image, MonoAssemblyName *aname)
 	aname->revision = cols [MONO_ASSEMBLY_REV_NUMBER];
 	aname->hash_alg = cols [MONO_ASSEMBLY_HASH_ALG];
 	if (cols [MONO_ASSEMBLY_PUBLIC_KEY]) {
-		guchar* token = g_malloc (8);
+		guchar* token = (guchar *)g_malloc (8);
 		gchar* encoded;
 		const gchar* pkey;
 		int len;
@@ -1116,7 +1116,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 		 * a non loaded reference using the ReflectionOnly api
 		*/
 		if (!reference)
-			reference = REFERENCE_MISSING;
+			reference = (MonoAssembly *)REFERENCE_MISSING;
 	} else {
 		/* we first try without setting the basedir: this can eventually result in a ResolveAssembly
 		 * event which is the MS .net compatible behaviour (the assemblyresolve_event3.cs test has been fixed
@@ -1157,7 +1157,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 	mono_assemblies_lock ();
 	if (reference == NULL) {
 		/* Flag as not found */
-		reference = REFERENCE_MISSING;
+		reference = (MonoAssembly *)REFERENCE_MISSING;
 	}	
 
 	if (!image->references [index]) {
@@ -1937,10 +1937,10 @@ parse_public_key (const gchar *key, gchar** pubkey, gboolean *is_ecma)
 	/* Encode the size of the blob */
 	offset = 0;
 	if (keylen <= 127) {
-		arr = g_malloc (keylen + 1);
+		arr = (gchar *)g_malloc (keylen + 1);
 		arr [offset++] = keylen;
 	} else {
-		arr = g_malloc (keylen + 2);
+		arr = (gchar *)g_malloc (keylen + 2);
 		arr [offset++] = 0x80; /* 10bs */
 		arr [offset++] = keylen;
 	}
@@ -2547,7 +2547,7 @@ mono_assembly_load_publisher_policy (MonoAssemblyName *aname)
 
 	if (strstr (aname->name, ".dll")) {
 		len = strlen (aname->name) - 4;
-		name = g_malloc (len);
+		name = (gchar *)g_malloc (len);
 		strncpy (name, aname->name, len);
 	} else
 		name = g_strdup (aname->name);
@@ -2613,7 +2613,7 @@ search_binding_loaded (MonoAssemblyName *aname)
 	GSList *tmp;
 
 	for (tmp = loaded_assembly_bindings; tmp; tmp = tmp->next) {
-		MonoAssemblyBindingInfo *info = tmp->data;
+		MonoAssemblyBindingInfo *info = (MonoAssemblyBindingInfo *)tmp->data;
 		if (assembly_binding_maps_name (info, aname))
 			return info;
 	}
@@ -2668,12 +2668,12 @@ assembly_binding_info_parsed (MonoAssemblyBindingInfo *info, void *user_data)
 		return;
 
 	for (tmp = domain->assembly_bindings; tmp; tmp = tmp->next) {
-		info_tmp = tmp->data;
+		info_tmp = (MonoAssemblyBindingInfo *)tmp->data;
 		if (strcmp (info->name, info_tmp->name) == 0 && info_versions_equal (info, info_tmp))
 			return;
 	}
 
-	info_copy = mono_mempool_alloc0 (domain->mp, sizeof (MonoAssemblyBindingInfo));
+	info_copy = (MonoAssemblyBindingInfo *)mono_mempool_alloc0 (domain->mp, sizeof (MonoAssemblyBindingInfo));
 	memcpy (info_copy, info, sizeof (MonoAssemblyBindingInfo));
 	if (info->name)
 		info_copy->name = mono_mempool_strdup (domain->mp, info->name);
@@ -2721,7 +2721,7 @@ get_per_domain_assembly_binding_info (MonoDomain *domain, MonoAssemblyName *anam
 
 	info = NULL;
 	for (list = domain->assembly_bindings; list; list = list->next) {
-		info = list->data;
+		info = (MonoAssemblyBindingInfo *)list->data;
 		if (info && !strcmp (aname->name, info->name) && info_major_minor_in_range (info, aname))
 			break;
 		info = NULL;
@@ -2787,7 +2787,7 @@ mono_assembly_apply_binding (MonoAssemblyName *aname, MonoAssemblyName *dest_nam
 		info2 = get_per_domain_assembly_binding_info (domain, aname);
 
 		if (info2) {
-			info = g_memdup (info2, sizeof (MonoAssemblyBindingInfo));
+			info = (MonoAssemblyBindingInfo *)g_memdup (info2, sizeof (MonoAssemblyBindingInfo));
 			info->name = g_strdup (info2->name);
 			info->culture = g_strdup (info2->culture);
 			info->domain_id = domain->domain_id;
@@ -2858,7 +2858,7 @@ mono_assembly_load_from_gac (MonoAssemblyName *aname,  gchar *filename, MonoImag
 
 	if (strstr (aname->name, ".dll")) {
 		len = strlen (filename) - 4;
-		name = g_malloc (len);
+		name = (gchar *)g_malloc (len);
 		strncpy (name, aname->name, len);
 	} else {
 		name = g_strdup (aname->name);
@@ -3173,7 +3173,7 @@ mono_assembly_close_except_image_pools (MonoAssembly *assembly)
 		assembly->image = NULL;
 
 	for (tmp = assembly->friend_assembly_names; tmp; tmp = tmp->next) {
-		MonoAssemblyName *fname = tmp->data;
+		MonoAssemblyName *fname = (MonoAssemblyName *)tmp->data;
 		mono_assembly_name_free (fname);
 		g_free (fname);
 	}
@@ -3252,7 +3252,7 @@ mono_assemblies_cleanup (void)
 	mono_os_mutex_destroy (&assembly_binding_mutex);
 
 	for (l = loaded_assembly_bindings; l; l = l->next) {
-		MonoAssemblyBindingInfo *info = l->data;
+		MonoAssemblyBindingInfo *info = (MonoAssemblyBindingInfo *)l->data;
 
 		mono_assembly_binding_info_free (info);
 		g_free (info);
@@ -3274,7 +3274,7 @@ mono_assembly_cleanup_domain_bindings (guint32 domain_id)
 	iter = &loaded_assembly_bindings;
 	while (*iter) {
 		GSList *l = *iter;
-		MonoAssemblyBindingInfo *info = l->data;
+		MonoAssemblyBindingInfo *info = (MonoAssemblyBindingInfo *)l->data;
 
 		if (info->domain_id == domain_id) {
 			*iter = l->next;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -152,7 +152,7 @@ decode_string_value (guint8 *buf, guint8 **endbuf, guint8 *limit)
 
 	g_assert (length < (1 << 16));
 
-	s = g_malloc (length + 1);
+	s = (char *)g_malloc (length + 1);
 
 	g_assert (p + length <= limit);
 	memcpy (s, p, length);
@@ -524,7 +524,7 @@ receiver_thread (void *arg)
 			content_len = decode_int (p, &p, p_end);
 
 			/* Read message body */
-			body = g_malloc (content_len);
+			body = (guint8 *)g_malloc (content_len);
 			res = read (conn_fd, body, content_len);
 			
 			p = body;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -223,7 +223,7 @@ mono_class_from_typeref_checked (MonoImage *image, guint32 type_token, MonoError
 		if (enclosing->nested_classes_inited && enclosing->ext) {
 			/* Micro-optimization: don't scan the metadata tables if enclosing is already inited */
 			for (tmp = enclosing->ext->nested_classes; tmp; tmp = tmp->next) {
-				res = tmp->data;
+				res = (MonoClass *)tmp->data;
 				if (strcmp (res->name, name) == 0)
 					return res;
 			}
@@ -299,17 +299,17 @@ MonoArrayType *
 mono_dup_array_type (MonoImage *image, MonoArrayType *a)
 {
 	if (image) {
-		a = mono_image_memdup (image, a, sizeof (MonoArrayType));
+		a = (MonoArrayType *)mono_image_memdup (image, a, sizeof (MonoArrayType));
 		if (a->sizes)
-			a->sizes = mono_image_memdup (image, a->sizes, a->numsizes * sizeof (int));
+			a->sizes = (int *)mono_image_memdup (image, a->sizes, a->numsizes * sizeof (int));
 		if (a->lobounds)
-			a->lobounds = mono_image_memdup (image, a->lobounds, a->numlobounds * sizeof (int));
+			a->lobounds = (int *)mono_image_memdup (image, a->lobounds, a->numlobounds * sizeof (int));
 	} else {
-		a = g_memdup (a, sizeof (MonoArrayType));
+		a = (MonoArrayType *)g_memdup (a, sizeof (MonoArrayType));
 		if (a->sizes)
-			a->sizes = g_memdup (a->sizes, a->numsizes * sizeof (int));
+			a->sizes = (int *)g_memdup (a->sizes, a->numsizes * sizeof (int));
 		if (a->lobounds)
-			a->lobounds = g_memdup (a->lobounds, a->numlobounds * sizeof (int));
+			a->lobounds = (int *)g_memdup (a->lobounds, a->numlobounds * sizeof (int));
 	}
 	return a;
 }
@@ -1110,7 +1110,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 
 	// check cache
 	mono_image_set_lock (set);
-	cached = g_hash_table_lookup (set->gmethod_cache, iresult);
+	cached = (MonoMethodInflated *)g_hash_table_lookup (set->gmethod_cache, iresult);
 	mono_image_set_unlock (set);
 
 	if (cached) {
@@ -1185,7 +1185,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 
 	// check cache
 	mono_image_set_lock (set);
-	cached = g_hash_table_lookup (set->gmethod_cache, iresult);
+	cached = (MonoMethodInflated *)g_hash_table_lookup (set->gmethod_cache, iresult);
 	if (!cached) {
 		g_hash_table_insert (set->gmethod_cache, iresult, iresult);
 		iresult->owner = set;
@@ -1265,7 +1265,7 @@ mono_method_get_generic_container (MonoMethod *method)
 	if (!method->is_generic)
 		return NULL;
 
-	container = mono_image_property_lookup (method->klass->image, method, MONO_METHOD_PROP_GENERIC_CONTAINER);
+	container = (MonoGenericContainer *)mono_image_property_lookup (method->klass->image, method, MONO_METHOD_PROP_GENERIC_CONTAINER);
 	g_assert (container);
 
 	return container;
@@ -1454,7 +1454,7 @@ mono_class_setup_basic_field_info (MonoClass *klass)
 		klass->field.count = gtd->field.count;
 	}
 
-	klass->fields = mono_class_alloc0 (klass, sizeof (MonoClassField) * top);
+	klass->fields = (MonoClassField *)mono_class_alloc0 (klass, sizeof (MonoClassField) * top);
 
 	/*
 	 * Fetch all the field information.
@@ -2192,7 +2192,7 @@ mono_class_setup_methods (MonoClass *klass)
 
 		/* The + 1 makes this always non-NULL to pass the check in mono_class_setup_methods () */
 		count = gklass->method.count;
-		methods = mono_class_alloc0 (klass, sizeof (MonoMethod*) * (count + 1));
+		methods = (MonoMethod **)mono_class_alloc0 (klass, sizeof (MonoMethod*) * (count + 1));
 
 		for (i = 0; i < count; i++) {
 			methods [i] = mono_class_inflate_generic_method_full_checked (
@@ -2230,7 +2230,7 @@ mono_class_setup_methods (MonoClass *klass)
 			count += klass->interface_count * count_generic;
 		}
 
-		methods = mono_class_alloc0 (klass, sizeof (MonoMethod*) * count);
+		methods = (MonoMethod **)mono_class_alloc0 (klass, sizeof (MonoMethod*) * count);
 
 		sig = mono_metadata_signature_alloc (klass->image, klass->rank);
 		sig->ret = &mono_defaults.void_class->byval_arg;
@@ -2300,7 +2300,7 @@ mono_class_setup_methods (MonoClass *klass)
 		MonoError error;
 
 		count = klass->method.count;
-		methods = mono_class_alloc (klass, sizeof (MonoMethod*) * count);
+		methods = (MonoMethod **)mono_class_alloc (klass, sizeof (MonoMethod*) * count);
 		for (i = 0; i < count; ++i) {
 			int idx = mono_metadata_translate_token_index (klass->image, MONO_TABLE_METHOD, klass->method.first + i + 1);
 			methods [i] = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | idx, klass, NULL, &error);
@@ -2518,7 +2518,7 @@ mono_class_setup_properties (MonoClass *klass)
 				return;
 		}
 
-		properties = mono_class_alloc0 (klass, sizeof (MonoProperty) * count);
+		properties = (MonoProperty *)mono_class_alloc0 (klass, sizeof (MonoProperty) * count);
 		for (i = first; i < last; ++i) {
 			mono_metadata_decode_table_row (klass->image, MONO_TABLE_PROPERTY, i, cols, MONO_PROPERTY_SIZE);
 			properties [i - first].parent = klass;
@@ -2661,7 +2661,7 @@ mono_class_setup_events (MonoClass *klass)
 			}
 		}
 
-		events = mono_class_alloc0 (klass, sizeof (MonoEvent) * count);
+		events = (MonoEvent *)mono_class_alloc0 (klass, sizeof (MonoEvent) * count);
 		for (i = first; i < last; ++i) {
 			MonoEvent *event = &events [i - first];
 
@@ -2704,7 +2704,7 @@ mono_class_setup_events (MonoClass *klass)
 					} else {
 						while (event->other [n])
 							n++;
-						event->other = g_realloc (event->other, (n + 2) * sizeof (MonoMethod*));
+						event->other = (MonoMethod **)g_realloc (event->other, (n + 2) * sizeof (MonoMethod*));
 					}
 					event->other [n] = method;
 					/* NULL terminated */
@@ -2882,8 +2882,8 @@ mono_class_get_implemented_interfaces (MonoClass *klass, MonoError *error)
 
 static int
 compare_interface_ids (const void *p_key, const void *p_element) {
-	const MonoClass *key = p_key;
-	const MonoClass *element = *(MonoClass**) p_element;
+	const MonoClass *key = (const MonoClass *)p_key;
+	const MonoClass *element = *(const MonoClass **)p_element;
 	
 	return (key->interface_id - element->interface_id);
 }
@@ -2891,7 +2891,7 @@ compare_interface_ids (const void *p_key, const void *p_element) {
 /*FIXME verify all callers if they should switch to mono_class_interface_offset_with_variance*/
 int
 mono_class_interface_offset (MonoClass *klass, MonoClass *itf) {
-	MonoClass **result = mono_binary_search (
+	MonoClass **result = (MonoClass **)mono_binary_search (
 			itf,
 			klass->interfaces_packed,
 			klass->interface_offsets_count,
@@ -2984,7 +2984,7 @@ print_implemented_interfaces (MonoClass *klass) {
 			mono_error_cleanup (&error);
 		} else if (ifaces) {
 			for (i = 0; i < ifaces->len; i++) {
-				MonoClass *ic = g_ptr_array_index (ifaces, i);
+				MonoClass *ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 				printf ("  [UIID %d] interface %s\n", ic->interface_id, ic->name);
 				printf ("  [%03d][UUID %03d][SLOT %03d][SIZE  %03d] interface %s.%s\n", i,
 						ic->interface_id,
@@ -3136,7 +3136,7 @@ get_implicit_generic_array_interfaces (MonoClass *klass, int *num, int *is_enume
 				++real_count;
 		}
 
-		interfaces = g_malloc0 (sizeof (MonoClass*) * real_count);
+		interfaces = (MonoClass **)g_malloc0 (sizeof (MonoClass*) * real_count);
 		interfaces [0] = valuetype_types [0];
 		if (valuetype_types [1])
 			interfaces [nifaces] = valuetype_types [1];
@@ -3176,7 +3176,7 @@ get_implicit_generic_array_interfaces (MonoClass *klass, int *num, int *is_enume
 			if (valuetype_types [1])
 				++real_count;
 		}
-		interfaces = g_malloc0 (sizeof (MonoClass*) * real_count);
+		interfaces = (MonoClass **)g_malloc0 (sizeof (MonoClass*) * real_count);
 		if (MONO_CLASS_IS_INTERFACE (eclass)) {
 			interfaces [0] = mono_defaults.object_class;
 			j = nifaces;
@@ -3529,7 +3529,7 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 		if (ifaces) {
 			num_ifaces += ifaces->len;
 			for (i = 0; i < ifaces->len; ++i) {
-				ic = g_ptr_array_index (ifaces, i);
+				ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 				if (max_iid < ic->interface_id)
 					max_iid = ic->interface_id;
 			}
@@ -3551,8 +3551,8 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 	}
 	klass->max_interface_id = max_iid;
 	/* compute vtable offset for interfaces */
-	interfaces_full = g_malloc0 (sizeof (MonoClass*) * num_ifaces);
-	interface_offsets_full = g_malloc (sizeof (int) * num_ifaces);
+	interfaces_full = (MonoClass **)g_malloc0 (sizeof (MonoClass*) * num_ifaces);
+	interface_offsets_full = (int *)g_malloc (sizeof (int) * num_ifaces);
 
 	for (i = 0; i < num_ifaces; i++) {
 		interface_offsets_full [i] = -1;
@@ -3566,7 +3566,7 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 		if (ifaces) {
 			for (i = 0; i < ifaces->len; ++i) {
 				int io;
-				ic = g_ptr_array_index (ifaces, i);
+				ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 				
 				/*Force the sharing of interface offsets between parent and subtypes.*/
 				io = mono_class_interface_offset (k, ic);
@@ -3581,7 +3581,7 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 	if (ifaces) {
 		for (i = 0; i < ifaces->len; ++i) {
 			int count;
-			ic = g_ptr_array_index (ifaces, i);
+			ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 			if (set_interface_and_offset (num_ifaces, interfaces_full, interface_offsets_full, ic, cur_slot, FALSE))
 				continue;
 			count = count_virtual_methods (ic);
@@ -3669,13 +3669,13 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 		uint8_t *bitmap;
 		int bsize;
 		klass->interface_offsets_count = interface_offsets_count;
-		klass->interfaces_packed = mono_class_alloc (klass, sizeof (MonoClass*) * interface_offsets_count);
-		klass->interface_offsets_packed = mono_class_alloc (klass, sizeof (guint16) * interface_offsets_count);
+		klass->interfaces_packed = (MonoClass **)mono_class_alloc (klass, sizeof (MonoClass*) * interface_offsets_count);
+		klass->interface_offsets_packed = (guint16 *)mono_class_alloc (klass, sizeof (guint16) * interface_offsets_count);
 		bsize = (sizeof (guint8) * ((max_iid + 1) >> 3)) + (((max_iid + 1) & 7)? 1 :0);
 #ifdef COMPRESSED_INTERFACE_BITMAP
 		bitmap = g_malloc0 (bsize);
 #else
-		bitmap = mono_class_alloc0 (klass, bsize);
+		bitmap = (uint8_t *)mono_class_alloc0 (klass, bsize);
 #endif
 		for (i = 0; i < interface_offsets_count; i++) {
 			int id = interfaces_full [i]->interface_id;
@@ -4328,7 +4328,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		return;
 	} else if (ifaces) {
 		for (i = 0; i < ifaces->len; i++) {
-			MonoClass *ic = g_ptr_array_index (ifaces, i);
+			MonoClass *ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 			max_vtsize += ic->method.count;
 		}
 		g_ptr_array_free (ifaces, TRUE);
@@ -4359,7 +4359,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		++cur_slot;
 	}
 
-	vtable = alloca (sizeof (gpointer) * max_vtsize);
+	vtable = (MonoMethod **)alloca (sizeof (gpointer) * max_vtsize);
 	memset (vtable, 0, sizeof (gpointer) * max_vtsize);
 
 	/* printf ("METAINIT %s.%s\n", klass->name_space, klass->name); */
@@ -4383,7 +4383,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 			return;
 		}
 
-		tmp = mono_class_alloc0 (klass, sizeof (gpointer) * gklass->vtable_size);
+		tmp = (MonoMethod **)mono_class_alloc0 (klass, sizeof (gpointer) * gklass->vtable_size);
 		klass->vtable_size = gklass->vtable_size;
 		for (i = 0; i < gklass->vtable_size; ++i)
 			if (gklass->vtable [i]) {
@@ -4532,7 +4532,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		for (im_index = 0; im_index < ic->method.count; im_index++) {
 			MonoMethod *im = ic->methods [im_index];
 			int im_slot = ic_offset + im->slot;
-			MonoMethod *override_im = (override_map != NULL) ? g_hash_table_lookup (override_map, im) : NULL;
+			MonoMethod *override_im = (override_map != NULL) ? (MonoMethod *)g_hash_table_lookup (override_map, im) : NULL;
 			
 			if (im->flags & METHOD_ATTRIBUTE_STATIC)
 				continue;
@@ -4547,7 +4547,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 
 				// First look for a suitable method among the class methods
 				for (l = virt_methods; l; l = l->next) {
-					cm = l->data;
+					cm = (MonoMethod *)l->data;
 					TRACE_INTERFACE_VTABLE (printf ("    For slot %d ('%s'.'%s':'%s'), trying method '%s'.'%s':'%s'... [EXPLICIT IMPLEMENTATION = %d][SLOT IS NULL = %d]", im_slot, ic->name_space, ic->name, im->name, cm->klass->name_space, cm->klass->name, cm->name, interface_is_explicitly_implemented_by_class, (vtable [im_slot] == NULL)));
 					if (check_interface_method_override (klass, im, cm, TRUE, interface_is_explicitly_implemented_by_class, (vtable [im_slot] == NULL))) {
 						TRACE_INTERFACE_VTABLE (printf ("[check ok]: ASSIGNING"));
@@ -4622,7 +4622,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 
 	TRACE_INTERFACE_VTABLE (print_vtable_full (klass, vtable, cur_slot, first_non_interface_slot, "AFTER SETTING UP INTERFACE METHODS", FALSE));
 	for (l = virt_methods; l; l = l->next) {
-		cm = l->data;
+		cm = (MonoMethod *)l->data;
 		/*
 		 * If the method is REUSE_SLOT, we must check in the
 		 * base class for a method to override.
@@ -4725,7 +4725,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 			if (vtable [i]) {
 				TRACE_INTERFACE_VTABLE (printf ("checking slot %d method %s[%p] for overrides\n", i, mono_method_full_name (vtable [i], 1), vtable [i]));
 
-				cm = g_hash_table_lookup (override_map, vtable [i]);
+				cm = (MonoMethod *)g_hash_table_lookup (override_map, vtable [i]);
 				if (cm)
 					vtable [i] = cm;
 			}
@@ -4769,7 +4769,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		mono_memory_barrier ();
 		klass->vtable = klass->parent->vtable;
 	} else {
-		MonoMethod **tmp = mono_class_alloc0 (klass, sizeof (gpointer) * klass->vtable_size);
+		MonoMethod **tmp = (MonoMethod **)mono_class_alloc0 (klass, sizeof (gpointer) * klass->vtable_size);
 		memcpy (tmp, vtable,  sizeof (gpointer) * klass->vtable_size);
 		mono_memory_barrier ();
 		klass->vtable = tmp;
@@ -4954,12 +4954,12 @@ generic_array_methods (MonoClass *klass)
 		}
 	}
 	list = g_list_reverse (list);
-	generic_array_method_info = mono_image_alloc (mono_defaults.corlib, sizeof (GenericArrayMethodInfo) * count_generic);
+	generic_array_method_info = (GenericArrayMethodInfo *)mono_image_alloc (mono_defaults.corlib, sizeof (GenericArrayMethodInfo) * count_generic);
 	i = 0;
 	for (tmp = list; tmp; tmp = tmp->next) {
 		const char *mname, *iname;
 		gchar *name;
-		MonoMethod *m = tmp->data;
+		MonoMethod *m = (MonoMethod *)tmp->data;
 		const char *ireadonlylist_prefix = "InternalArray__IReadOnlyList_";
 		const char *ireadonlycollection_prefix = "InternalArray__IReadOnlyCollection_";
 
@@ -4983,7 +4983,7 @@ generic_array_methods (MonoClass *klass)
 			g_assert_not_reached ();
 		}
 
-		name = mono_image_alloc (mono_defaults.corlib, strlen (iname) + strlen (mname) + 1);
+		name = (gchar *)mono_image_alloc (mono_defaults.corlib, strlen (iname) + strlen (mname) + 1);
 		strcpy (name, iname);
 		strcpy (name + strlen (iname), mname);
 		generic_array_method_info [i].name = name;
@@ -5022,7 +5022,7 @@ concat_two_strings_with_zero (MonoImage *image, const char *s1, const char *s2)
 {
 	int null_length = strlen ("(null)");
 	int len = (s1 ? strlen (s1) : null_length) + (s2 ? strlen (s2) : null_length) + 2;
-	char *s = mono_image_alloc (image, len);
+	char *s = (char *)mono_image_alloc (image, len);
 	int result;
 
 	result = g_snprintf (s, len, "%s%c%s", s1 ? s1 : "(null)", '\0', s2 ? s2 : "(null)");
@@ -5450,11 +5450,14 @@ mono_class_setup_mono_type (MonoClass *klass)
 			klass->valuetype = 0;
 			klass->enumtype = 0;
 		} else if (!strcmp (name, "Object")) {
-			klass->this_arg.type = klass->byval_arg.type = MONO_TYPE_OBJECT;
+			klass->byval_arg.type = MONO_TYPE_OBJECT;
+			klass->this_arg.type = MONO_TYPE_OBJECT;
 		} else if (!strcmp (name, "String")) {
-			klass->this_arg.type = klass->byval_arg.type = MONO_TYPE_STRING;
+			klass->byval_arg.type = MONO_TYPE_STRING;
+			klass->this_arg.type = MONO_TYPE_STRING;
 		} else if (!strcmp (name, "TypedReference")) {
-			klass->this_arg.type = klass->byval_arg.type = MONO_TYPE_TYPEDBYREF;
+			klass->byval_arg.type = MONO_TYPE_TYPEDBYREF;
+			klass->this_arg.type = MONO_TYPE_TYPEDBYREF;
 		}
 	}
 
@@ -5536,7 +5539,8 @@ mono_class_setup_mono_type (MonoClass *klass)
 				break;
 			}
 		}
-		klass->this_arg.type = klass->byval_arg.type = t;
+		klass->byval_arg.type = (MonoTypeEnum)t;
+		klass->this_arg.type = (MonoTypeEnum)t;
 	}
 
 	if (MONO_CLASS_IS_INTERFACE (klass))
@@ -5678,7 +5682,7 @@ mono_class_setup_supertypes (MonoClass *klass)
 	int ms;
 	MonoClass **supertypes;
 
-	mono_atomic_load_acquire (supertypes, void*, &klass->supertypes);
+	mono_atomic_load_acquire (supertypes, MonoClass **, &klass->supertypes);
 	if (supertypes)
 		return;
 
@@ -5690,7 +5694,7 @@ mono_class_setup_supertypes (MonoClass *klass)
 		klass->idepth = 1;
 
 	ms = MAX (MONO_DEFAULT_SUPERTABLE_SIZE, klass->idepth);
-	supertypes = mono_class_alloc0 (klass, sizeof (MonoClass *) * ms);
+	supertypes = (MonoClass **)mono_class_alloc0 (klass, sizeof (MonoClass *) * ms);
 
 	if (klass->parent) {
 		CHECKED_METADATA_WRITE_PTR ( supertypes [klass->idepth - 1] , klass );
@@ -5779,7 +5783,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 
 	mono_loader_lock ();
 
-	if ((klass = mono_internal_hash_table_lookup (&image->class_cache, GUINT_TO_POINTER (type_token)))) {
+	if ((klass = (MonoClass *)mono_internal_hash_table_lookup (&image->class_cache, GUINT_TO_POINTER (type_token)))) {
 		mono_loader_unlock ();
 		mono_loader_assert_no_error ();
 		return klass;
@@ -5790,7 +5794,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 	name = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAME]);
 	nspace = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAMESPACE]);
 
-	klass = mono_image_alloc0 (image, sizeof (MonoClass));
+	klass = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClass));
 
 	klass->name = name;
 	klass->name_space = nspace;
@@ -6042,7 +6046,7 @@ mono_generic_class_get_class (MonoGenericClass *gclass)
 		return gclass->cached_class;
 	}
 
-	klass = mono_image_set_alloc0 (gclass->owner, sizeof (MonoClass));
+	klass = (MonoClass *)mono_image_set_alloc0 (gclass->owner, sizeof (MonoClass));
 
 	gklass = gclass->container_class;
 
@@ -6067,7 +6071,8 @@ mono_generic_class_get_class (MonoGenericClass *gclass)
 	klass->is_inflated = 1;
 	klass->generic_class = gclass;
 
-	klass->this_arg.type = klass->byval_arg.type = MONO_TYPE_GENERICINST;
+	klass->byval_arg.type = MONO_TYPE_GENERICINST;
+	klass->this_arg.type = klass->byval_arg.type;
 	klass->this_arg.data.generic_class = klass->byval_arg.data.generic_class = gclass;
 	klass->this_arg.byref = TRUE;
 	klass->enumtype = gklass->enumtype;
@@ -6157,7 +6162,7 @@ get_image_for_generic_param (MonoGenericParam *param)
 char *
 make_generic_name_string (MonoImage *image, int num)
 {
-	char *name = mono_image_alloc0 (image, INT_STRING_SIZE);
+	char *name = (char *)mono_image_alloc0 (image, INT_STRING_SIZE);
 	g_snprintf (name, INT_STRING_SIZE, "%d", num);
 	return name;
 }
@@ -6176,14 +6181,13 @@ make_generic_param_class (MonoGenericParam *param, MonoGenericParamInfo *pinfo)
 	gboolean is_mvar = container->is_method;
 	gboolean is_anonymous = container->is_anonymous;
 
-	klass = mono_image_alloc0 (image, sizeof (MonoClass));
+	klass = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClass));
 	classes_size += sizeof (MonoClass);
 
 	if (pinfo) {
 		CHECKED_METADATA_WRITE_PTR_EXEMPT ( klass->name , pinfo->name );
 	} else {
 		int n = mono_generic_param_num (param);
-
 		CHECKED_METADATA_WRITE_PTR_LOCAL ( klass->name , make_generic_name_string (image, n) );
 	}
 
@@ -6217,7 +6221,7 @@ make_generic_param_class (MonoGenericParam *param, MonoGenericParamInfo *pinfo)
 
 	if (count - pos > 0) {
 		klass->interface_count = count - pos;
-		CHECKED_METADATA_WRITE_PTR_LOCAL ( klass->interfaces , mono_image_alloc0 (image, sizeof (MonoClass *) * (count - pos)) );
+		CHECKED_METADATA_WRITE_PTR_LOCAL ( klass->interfaces , (MonoClass **)mono_image_alloc0 (image, sizeof (MonoClass *) * (count - pos)) );
 		klass->interfaces_inited = TRUE;
 		for (i = pos; i < count; i++)
 			CHECKED_METADATA_WRITE_PTR ( klass->interfaces [i - pos] , pinfo->constraints [i] );
@@ -6230,7 +6234,8 @@ make_generic_param_class (MonoGenericParam *param, MonoGenericParamInfo *pinfo)
 	CHECKED_METADATA_WRITE_PTR_LOCAL ( klass->element_class , klass );
 	klass->flags = TYPE_ATTRIBUTE_PUBLIC;
 
-	klass->this_arg.type = klass->byval_arg.type = is_mvar ? MONO_TYPE_MVAR : MONO_TYPE_VAR;
+	klass->byval_arg.type = is_mvar ? MONO_TYPE_MVAR : MONO_TYPE_VAR;
+	klass->this_arg.type = klass->byval_arg.type;
 	CHECKED_METADATA_WRITE_PTR ( klass->this_arg.data.generic_param ,  param );
 	CHECKED_METADATA_WRITE_PTR ( klass->byval_arg.data.generic_param , param );
 	klass->this_arg.byref = TRUE;
@@ -6289,7 +6294,7 @@ get_anon_gparam_class (MonoGenericParam *param, gboolean take_lock)
 		if (ht) {
 			if (take_lock)
 				mono_image_lock (image);
-			klass = g_hash_table_lookup (ht, param);
+			klass = (MonoClass *)g_hash_table_lookup (ht, param);
 			if (take_lock)
 				mono_image_unlock (image);
 		}
@@ -6306,7 +6311,7 @@ get_anon_gparam_class (MonoGenericParam *param, gboolean take_lock)
 		if (ht) {
 			if (take_lock)
 				mono_image_lock (image);
-			klass = g_hash_table_lookup (ht, GINT_TO_POINTER (n));
+			klass = (MonoClass *)g_hash_table_lookup (ht, GINT_TO_POINTER (n));
 			if (take_lock)
 				mono_image_unlock (image);
 		}
@@ -6341,11 +6346,11 @@ set_anon_gparam_class (MonoGenericParam *param, MonoClass *klass)
 		if (is_mvar) {
 			/* Requires locking to avoid droping an already published class */
 			if (!image->mvar_cache_fast)
-				image->mvar_cache_fast = mono_image_alloc0 (image, sizeof (MonoClass*) * FAST_CACHE_SIZE);
+				image->mvar_cache_fast = (MonoClass **)mono_image_alloc0 (image, sizeof (MonoClass*) * FAST_CACHE_SIZE);
 			image->mvar_cache_fast [n] = klass;
 		} else {
 			if (!image->var_cache_fast)
-				image->var_cache_fast = mono_image_alloc0 (image, sizeof (MonoClass*) * FAST_CACHE_SIZE);
+				image->var_cache_fast = (MonoClass **)mono_image_alloc0 (image, sizeof (MonoClass*) * FAST_CACHE_SIZE);
 			image->var_cache_fast [n] = klass;
 		}
 	} else {
@@ -6447,14 +6452,14 @@ mono_ptr_class_get (MonoType *type)
 
 	mono_image_lock (image);
 	if (image->ptr_cache) {
-		if ((result = g_hash_table_lookup (image->ptr_cache, el_class))) {
+		if ((result = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
 			mono_image_unlock (image);
 			return result;
 		}
 	}
 	mono_image_unlock (image);
 	
-	result = mono_image_alloc0 (image, sizeof (MonoClass));
+	result = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClass));
 
 	classes_size += sizeof (MonoClass);
 
@@ -6474,7 +6479,8 @@ mono_ptr_class_get (MonoType *type)
 	result->cast_class = result->element_class = el_class;
 	result->blittable = TRUE;
 
-	result->this_arg.type = result->byval_arg.type = MONO_TYPE_PTR;
+	result->byval_arg.type = MONO_TYPE_PTR;
+	result->this_arg.type = result->byval_arg.type;
 	result->this_arg.data.type = result->byval_arg.data.type = &result->element_class->byval_arg;
 	result->this_arg.byref = TRUE;
 
@@ -6483,7 +6489,7 @@ mono_ptr_class_get (MonoType *type)
 	mono_image_lock (image);
 	if (image->ptr_cache) {
 		MonoClass *result2;
-		if ((result2 = g_hash_table_lookup (image->ptr_cache, el_class))) {
+		if ((result2 = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
 			mono_image_unlock (image);
 			mono_profiler_class_loaded (result, MONO_PROFILE_FAILED);
 			return result2;
@@ -6512,7 +6518,7 @@ mono_fnptr_class_get (MonoMethodSignature *sig)
 	if (!ptr_hash)
 		ptr_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	
-	if ((result = g_hash_table_lookup (ptr_hash, sig))) {
+	if ((result = (MonoClass *)g_hash_table_lookup (ptr_hash, sig))) {
 		mono_loader_unlock ();
 		return result;
 	}
@@ -6532,7 +6538,8 @@ mono_fnptr_class_get (MonoMethodSignature *sig)
 	result->cast_class = result->element_class = result;
 	result->blittable = TRUE;
 
-	result->this_arg.type = result->byval_arg.type = MONO_TYPE_FNPTR;
+	result->byval_arg.type = MONO_TYPE_FNPTR;
+	result->this_arg.type = result->byval_arg.type;
 	result->this_arg.data.method = result->byval_arg.data.method = sig;
 	result->this_arg.byref = TRUE;
 	result->blittable = TRUE;
@@ -6701,7 +6708,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		mono_os_mutex_lock (&image->szarray_cache_lock);
 		if (!image->szarray_cache)
 			image->szarray_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
-		klass = g_hash_table_lookup (image->szarray_cache, eclass);
+		klass = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
 		mono_os_mutex_unlock (&image->szarray_cache_lock);
 		if (klass)
 			return klass;
@@ -6713,9 +6720,9 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		if (!image->array_cache)
 			image->array_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
 
-		if ((rootlist = list = g_hash_table_lookup (image->array_cache, eclass))) {
+		if ((rootlist = list = (GSList *)g_hash_table_lookup (image->array_cache, eclass))) {
 			for (; list; list = list->next) {
-				klass = list->data;
+				klass = (MonoClass *)list->data;
 				if ((klass->rank == rank) && (klass->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
 					mono_loader_unlock ();
 					return klass;
@@ -6734,12 +6741,12 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 			mono_class_init (parent);
 	}
 
-	klass = mono_image_alloc0 (image, sizeof (MonoClass));
+	klass = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClass));
 
 	klass->image = image;
 	klass->name_space = eclass->name_space;
 	nsize = strlen (eclass->name);
-	name = g_malloc (nsize + 2 + rank + 1);
+	name = (char *)g_malloc (nsize + 2 + rank + 1);
 	memcpy (name, eclass->name, nsize);
 	name [nsize] = '[';
 	if (rank > 1)
@@ -6820,7 +6827,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	klass->element_class = eclass;
 
 	if ((rank > 1) || bounded) {
-		MonoArrayType *at = mono_image_alloc0 (image, sizeof (MonoArrayType));
+		MonoArrayType *at = (MonoArrayType *)mono_image_alloc0 (image, sizeof (MonoArrayType));
 		klass->byval_arg.type = MONO_TYPE_ARRAY;
 		klass->byval_arg.data.array = at;
 		at->eklass = eclass;
@@ -6842,7 +6849,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		MonoClass *prev_class;
 
 		mono_os_mutex_lock (&image->szarray_cache_lock);
-		prev_class = g_hash_table_lookup (image->szarray_cache, eclass);
+		prev_class = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
 		if (prev_class)
 			/* Someone got in before us */
 			klass = prev_class;
@@ -7134,7 +7141,7 @@ mono_class_get_field_default_value (MonoClassField *field, MonoTypeEnum *def_typ
 
 		mono_class_alloc_ext (klass);
 
-		def_values = mono_class_alloc0 (klass, sizeof (MonoFieldDefaultValue) * klass->field.count);
+		def_values = (MonoFieldDefaultValue *)mono_class_alloc0 (klass, sizeof (MonoFieldDefaultValue) * klass->field.count);
 
 		mono_image_lock (klass->image);
 		mono_memory_barrier ();
@@ -7153,8 +7160,8 @@ mono_class_get_field_default_value (MonoClassField *field, MonoTypeEnum *def_typ
 		g_assert (!(field->type->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA));
 
 		mono_metadata_decode_row (&field->parent->image->tables [MONO_TABLE_CONSTANT], cindex - 1, constant_cols, MONO_CONSTANT_SIZE);
-		klass->ext->field_def_values [field_index].def_type = constant_cols [MONO_CONSTANT_TYPE];
-		klass->ext->field_def_values [field_index].data = (gpointer)mono_metadata_blob_heap (field->parent->image, constant_cols [MONO_CONSTANT_VALUE]);
+		klass->ext->field_def_values [field_index].def_type = (MonoTypeEnum)constant_cols [MONO_CONSTANT_TYPE];
+		klass->ext->field_def_values [field_index].data = (const char *)mono_metadata_blob_heap (field->parent->image, constant_cols [MONO_CONSTANT_VALUE]);
 	}
 
 	*def_type = klass->ext->field_def_values [field_index].def_type;
@@ -7203,8 +7210,8 @@ mono_class_get_property_default_value (MonoProperty *property, MonoTypeEnum *def
 		return NULL;
 
 	mono_metadata_decode_row (&klass->image->tables [MONO_TABLE_CONSTANT], cindex - 1, constant_cols, MONO_CONSTANT_SIZE);
-	*def_type = constant_cols [MONO_CONSTANT_TYPE];
-	return (gpointer)mono_metadata_blob_heap (klass->image, constant_cols [MONO_CONSTANT_VALUE]);
+	*def_type = (MonoTypeEnum)constant_cols [MONO_CONSTANT_TYPE];
+	return (const char *)mono_metadata_blob_heap (klass->image, constant_cols [MONO_CONSTANT_VALUE]);
 }
 
 guint32
@@ -7437,7 +7444,7 @@ mono_class_get_checked (MonoImage *image, guint32 type_token, MonoError *error)
 			mono_error_set_bad_image (error, image,"Bad token table for dynamic image: %x", table);
 			return NULL;
 		}
-		klass = mono_lookup_dynamic_token (image, type_token, NULL); /*FIXME proper error handling*/
+		klass = (MonoClass *)mono_lookup_dynamic_token (image, type_token, NULL); /*FIXME proper error handling*/
 		goto done;
 	}
 
@@ -7488,7 +7495,7 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 
 	//FIXME: this will not fix the very issue for which mono_type_get_full exists -but how to do it then?
 	if (image_is_dynamic (image))
-		return mono_class_get_type (mono_lookup_dynamic_token (image, type_token, context));
+		return mono_class_get_type ((MonoClass *)mono_lookup_dynamic_token (image, type_token, context));
 
 	if ((type_token & 0xff000000) != MONO_TOKEN_TYPE_SPEC) {
 		MonoClass *klass = mono_class_get_checked (image, type_token, error);
@@ -7583,7 +7590,7 @@ mono_image_init_name_cache (MonoImage *image)
 		nspace = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAMESPACE]);
 
 		nspace_index = cols [MONO_TYPEDEF_NAMESPACE];
-		nspace_table = g_hash_table_lookup (name_cache2, GUINT_TO_POINTER (nspace_index));
+		nspace_table = (GHashTable *)g_hash_table_lookup (name_cache2, GUINT_TO_POINTER (nspace_index));
 		if (!nspace_table) {
 			nspace_table = g_hash_table_new (g_str_hash, g_str_equal);
 			g_hash_table_insert (the_name_cache, (char*)nspace, nspace_table);
@@ -7611,7 +7618,7 @@ mono_image_init_name_cache (MonoImage *image)
 			nspace = mono_metadata_string_heap (image, cols [MONO_EXP_TYPE_NAMESPACE]);
 
 			nspace_index = cols [MONO_EXP_TYPE_NAMESPACE];
-			nspace_table = g_hash_table_lookup (name_cache2, GUINT_TO_POINTER (nspace_index));
+			nspace_table = (GHashTable *)g_hash_table_lookup (name_cache2, GUINT_TO_POINTER (nspace_index));
 			if (!nspace_table) {
 				nspace_table = g_hash_table_new (g_str_hash, g_str_equal);
 				g_hash_table_insert (the_name_cache, (char*)nspace, nspace_table);
@@ -7647,7 +7654,7 @@ mono_image_add_to_name_cache (MonoImage *image, const char *nspace,
 	mono_image_lock (image);
 
 	name_cache = image->name_cache;
-	if (!(nspace_table = g_hash_table_lookup (name_cache, nspace))) {
+	if (!(nspace_table = (GHashTable *)g_hash_table_lookup (name_cache, nspace))) {
 		nspace_table = g_hash_table_new (g_str_hash, g_str_equal);
 		g_hash_table_insert (name_cache, (char *)nspace, (char *)nspace_table);
 	}
@@ -7855,7 +7862,7 @@ mono_class_from_name_checked_aux (MonoImage *image, const char* name_space, cons
 	mono_image_init_name_cache (image);
 	mono_image_lock (image);
 
-	nspace_table = g_hash_table_lookup (image->name_cache, name_space);
+	nspace_table = (GHashTable *)g_hash_table_lookup (image->name_cache, name_space);
 
 	if (nspace_table)
 		token = GPOINTER_TO_UINT (g_hash_table_lookup (nspace_table, name));
@@ -8388,7 +8395,7 @@ mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 
 		/*A TypeBuilder can have more interfaces on tb->interfaces than on candidate->interfaces*/
 		if (image_is_dynamic (candidate->image) && !candidate->wastypebuilder) {
-			MonoReflectionTypeBuilder *tb = mono_class_get_ref_info (candidate);
+			MonoReflectionTypeBuilder *tb = (MonoReflectionTypeBuilder *)mono_class_get_ref_info (candidate);
 			int j;
 			if (tb && tb->interfaces) {
 				for (j = mono_array_length (tb->interfaces) - 1; j >= 0; --j) {
@@ -9049,16 +9056,18 @@ mono_class_get_fields (MonoClass* klass, gpointer *iter)
 			return NULL;
 		/* start from the first */
 		if (klass->field.count) {
-			return *iter = &klass->fields [0];
+			*iter = &klass->fields [0];
+			return &klass->fields [0];
 		} else {
 			/* no fields */
 			return NULL;
 		}
 	}
-	field = *iter;
+	field = (MonoClassField *)*iter;
 	field++;
 	if (field < &klass->fields [klass->field.count]) {
-		return *iter = field;
+		*iter = field;
+		return field;
 	}
 	return NULL;
 }
@@ -9099,7 +9108,7 @@ mono_class_get_methods (MonoClass* klass, gpointer *iter)
 			return NULL;
 		}
 	}
-	method = *iter;
+	method = (MonoMethod **)*iter;
 	method++;
 	if (method < &klass->methods [klass->method.count]) {
 		*iter = method;
@@ -9133,7 +9142,7 @@ mono_class_get_virtual_methods (MonoClass* klass, gpointer *iter)
 			/* start from the first */
 			method = &klass->methods [0];
 		} else {
-			method = *iter;
+			method = (MonoMethod **)*iter;
 			method++;
 		}
 		while (method < &klass->methods [klass->method.count]) {
@@ -9204,16 +9213,18 @@ mono_class_get_properties (MonoClass* klass, gpointer *iter)
 		mono_class_setup_properties (klass);
 		/* start from the first */
 		if (klass->ext->property.count) {
-			return *iter = &klass->ext->properties [0];
+			*iter = &klass->ext->properties [0];
+			return (MonoProperty *)*iter;
 		} else {
 			/* no fields */
 			return NULL;
 		}
 	}
-	property = *iter;
+	property = (MonoProperty *)*iter;
 	property++;
 	if (property < &klass->ext->properties [klass->ext->property.count]) {
-		return *iter = property;
+		*iter = property;
+		return (MonoProperty *)*iter;
 	}
 	return NULL;
 }
@@ -9240,16 +9251,18 @@ mono_class_get_events (MonoClass* klass, gpointer *iter)
 		mono_class_setup_events (klass);
 		/* start from the first */
 		if (klass->ext->event.count) {
-			return *iter = &klass->ext->events [0];
+			*iter = &klass->ext->events [0];
+			return (MonoEvent *)*iter;
 		} else {
 			/* no fields */
 			return NULL;
 		}
 	}
-	event = *iter;
+	event = (MonoEvent *)*iter;
 	event++;
 	if (event < &klass->ext->events [klass->ext->event.count]) {
-		return *iter = event;
+		*iter = event;
+		return (MonoEvent *)*iter;
 	}
 	return NULL;
 }
@@ -9292,7 +9305,7 @@ mono_class_get_interfaces (MonoClass* klass, gpointer *iter)
 			return NULL;
 		}
 	}
-	iface = *iter;
+	iface = (MonoClass **)*iter;
 	iface++;
 	if (iface < &klass->interfaces [klass->interface_count]) {
 		*iter = iface;
@@ -9380,17 +9393,17 @@ mono_class_get_nested_types (MonoClass* klass, gpointer *iter)
 		/* start from the first */
 		if (klass->ext && klass->ext->nested_classes) {
 			*iter = klass->ext->nested_classes;
-			return klass->ext->nested_classes->data;
+			return (MonoClass *)klass->ext->nested_classes->data;
 		} else {
 			/* no nested types */
 			return NULL;
 		}
 	}
-	item = *iter;
+	item = (GList *)*iter;
 	item = item->next;
 	if (item) {
 		*iter = item;
-		return item->data;
+		return (MonoClass *)item->data;
 	}
 	return NULL;
 }
@@ -9522,7 +9535,7 @@ mono_field_get_rva (MonoClassField *field)
 	if (!klass->ext || !klass->ext->field_def_values) {
 		mono_class_alloc_ext (klass);
 
-		field_def_values = mono_class_alloc0 (klass, sizeof (MonoFieldDefaultValue) * klass->field.count);
+		field_def_values = (MonoFieldDefaultValue *)mono_class_alloc0 (klass, sizeof (MonoFieldDefaultValue) * klass->field.count);
 
 		mono_image_lock (klass->image);
 		if (!klass->ext->field_def_values)
@@ -9915,19 +9928,19 @@ mono_class_get_exception_for_failure (MonoClass *klass)
 		return ex;
 	}
 	case MONO_EXCEPTION_MISSING_METHOD: {
-		char *class_name = exception_data;
+		char *class_name = (char *)exception_data;
 		char *assembly_name = class_name + strlen (class_name) + 1;
 
 		return mono_get_exception_missing_method (class_name, assembly_name);
 	}
 	case MONO_EXCEPTION_MISSING_FIELD: {
-		char *class_name = exception_data;
+		char *class_name = (char *)exception_data;
 		char *member_name = class_name + strlen (class_name) + 1;
 
 		return mono_get_exception_missing_field (class_name, member_name);
 	}
 	case MONO_EXCEPTION_FILE_NOT_FOUND: {
-		char *msg_format = exception_data;
+		char *msg_format = (char *)exception_data;
 		char *assembly_name = msg_format + strlen (msg_format) + 1;
 		char *msg = g_strdup_printf (msg_format, assembly_name);
 		MonoException *ex;
@@ -9939,7 +9952,7 @@ mono_class_get_exception_for_failure (MonoClass *klass)
 		return ex;
 	}
 	case MONO_EXCEPTION_BAD_IMAGE: {
-		return mono_get_exception_bad_image_format (exception_data);
+		return mono_get_exception_bad_image_format ((const char *)exception_data);
 	}
 	default: {
 		MonoLoaderError *error;
@@ -10044,16 +10057,16 @@ can_access_internals (MonoAssembly *accessing, MonoAssembly* accessed)
 
 	mono_assembly_load_friends (accessed);
 	for (tmp = accessed->friend_assembly_names; tmp; tmp = tmp->next) {
-		MonoAssemblyName *friend = tmp->data;
+		MonoAssemblyName *friend_ = (MonoAssemblyName *)tmp->data;
 		/* Be conservative with checks */
-		if (!friend->name)
+		if (!friend_->name)
 			continue;
-		if (strcmp (accessing->aname.name, friend->name))
+		if (strcmp (accessing->aname.name, friend_->name))
 			continue;
-		if (friend->public_key_token [0]) {
+		if (friend_->public_key_token [0]) {
 			if (!accessing->aname.public_key_token [0])
 				continue;
-			if (!mono_public_tokens_are_equal (friend->public_key_token, accessing->aname.public_key_token))
+			if (!mono_public_tokens_are_equal (friend_->public_key_token, accessing->aname.public_key_token))
 				continue;
 		}
 		return TRUE;
@@ -10485,7 +10498,7 @@ mono_class_alloc_ext (MonoClass *klass)
 	if (klass->ext)
 		return;
 
-	ext = mono_class_alloc0 (klass, sizeof (MonoClassExt));
+	ext = (MonoClassExt *)mono_class_alloc0 (klass, sizeof (MonoClassExt));
 	mono_image_lock (klass->image);
 	mono_memory_barrier ();
 	if (!klass->ext)
@@ -10517,7 +10530,7 @@ mono_class_setup_interfaces (MonoClass *klass, MonoError *error)
 
 		/* generic IList, ICollection, IEnumerable */
 		interface_count = mono_defaults.generic_ireadonlylist_class ? 2 : 1;
-		interfaces = mono_image_alloc0 (klass->image, sizeof (MonoClass*) * interface_count);
+		interfaces = (MonoClass **)mono_image_alloc0 (klass->image, sizeof (MonoClass*) * interface_count);
 
 		args [0] = &klass->element_class->byval_arg;
 		interfaces [0] = mono_class_bind_generic_parameters (
@@ -10686,16 +10699,18 @@ mono_class_get_fields_lazy (MonoClass* klass, gpointer *iter)
 			return NULL;
 		/* start from the first */
 		if (klass->field.count) {
-			return *iter = &klass->fields [0];
+			*iter = &klass->fields [0];
+			return (MonoClassField *)*iter;
 		} else {
 			/* no fields */
 			return NULL;
 		}
 	}
-	field = *iter;
+	field = (MonoClassField *)*iter;
 	field++;
 	if (field < &klass->fields [klass->field.count]) {
-		return *iter = field;
+		*iter = field;
+		return (MonoClassField *)*iter;
 	}
 	return NULL;
 }

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -322,7 +322,7 @@ cominterop_get_method_interface (MonoMethod* method)
 			for (i = 0; i < ifaces->len; ++i) {
 				int j, offset;
 				gboolean found = FALSE;
-				ic = g_ptr_array_index (ifaces, i);
+				ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 				offset = mono_class_interface_offset (method->klass, ic);
 				for (j = 0; j < ic->method.count; ++j) {
 					if (method->klass->vtable [j + offset] == method) {
@@ -443,7 +443,7 @@ cominterop_com_visible (MonoClass* klass)
 		int i;
 		for (i = 0; i < ifaces->len; ++i) {
 			MonoClass *ic = NULL;
-			ic = g_ptr_array_index (ifaces, i);
+			ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 			if (MONO_CLASS_IS_IMPORT (ic))
 				visible = TRUE;
 
@@ -1640,7 +1640,8 @@ ves_icall_System_ComObject_ReleaseInterfaces (MonoComObject* obj)
 		g_hash_table_foreach_remove (obj->itf_hash, cominterop_rcw_interface_finalizer, NULL);
 		g_hash_table_destroy (obj->itf_hash);
 		ves_icall_System_Runtime_InteropServices_Marshal_ReleaseInternal (obj->iunknown);
-		obj->itf_hash = obj->iunknown = NULL;
+		obj->iunknown = NULL;
+		obj->itf_hash = NULL;
 		mono_cominterop_unlock ();
 	}
 }
@@ -1661,7 +1662,8 @@ cominterop_rcw_finalizer (gpointer key, gpointer value, gpointer user_data)
 			}
 			if (proxy->com_object->iunknown)
 				ves_icall_System_Runtime_InteropServices_Marshal_ReleaseInternal (proxy->com_object->iunknown);
-			proxy->com_object->itf_hash = proxy->com_object->iunknown = NULL;
+			proxy->com_object->iunknown = NULL;
+			proxy->com_object->itf_hash = NULL;
 		}
 		
 		mono_gchandle_free (gchandle);
@@ -1764,7 +1766,7 @@ cominterop_get_ccw_object (MonoCCWInterface* ccw_entry, gboolean verify)
 		return NULL;
 
 	if (verify) {
-		ccw = g_hash_table_lookup (ccw_interface_hash, ccw_entry);
+		ccw = (MonoCCW *)g_hash_table_lookup (ccw_interface_hash, ccw_entry);
 	}
 	else {
 		ccw = ccw_entry->ccw;
@@ -1838,12 +1840,12 @@ cominterop_get_ccw (MonoObject* object, MonoClass* itf)
 	if (!ccw_interface_hash)
 		ccw_interface_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 
-	ccw_list = g_hash_table_lookup (ccw_hash, GINT_TO_POINTER (mono_object_hash (object)));
+	ccw_list = (GList *)g_hash_table_lookup (ccw_hash, GINT_TO_POINTER (mono_object_hash (object)));
 	mono_cominterop_unlock ();
 
 	ccw_list_item = ccw_list;
 	while (ccw_list_item) {
-		MonoCCW* ccw_iter = ccw_list_item->data;
+		MonoCCW* ccw_iter = (MonoCCW *)ccw_list_item->data;
 		if (mono_gchandle_get_target (ccw_iter->gc_handle) == object) {
 			ccw = ccw_iter;
 			break;
@@ -1913,11 +1915,11 @@ cominterop_get_ccw (MonoObject* object, MonoClass* itf)
 		iface = NULL;
 	}
 
-	ccw_entry = g_hash_table_lookup (ccw->vtable_hash, itf);
+	ccw_entry = (MonoCCWInterface *)g_hash_table_lookup (ccw->vtable_hash, itf);
 
 	if (!ccw_entry) {
 		int vtable_index = method_count-1+start_slot;
-		vtable = mono_image_alloc0 (klass->image, sizeof (gpointer)*(method_count+start_slot));
+		vtable = (void **)mono_image_alloc0 (klass->image, sizeof (gpointer)*(method_count+start_slot));
 		memcpy (vtable, iunknown, sizeof (iunknown));
 		if (start_slot == 7)
 			memcpy (vtable+3, idispatch, sizeof (idispatch));
@@ -2055,7 +2057,7 @@ mono_marshal_free_ccw (MonoObject* object)
 
 	/* need to cache orig list address to remove from hash_table if empty */
 	mono_cominterop_lock ();
-	ccw_list = ccw_list_orig = g_hash_table_lookup (ccw_hash, GINT_TO_POINTER (mono_object_hash (object)));
+	ccw_list = ccw_list_orig = (GList *)g_hash_table_lookup (ccw_hash, GINT_TO_POINTER (mono_object_hash (object)));
 	mono_cominterop_unlock ();
 
 	if (!ccw_list)
@@ -2063,7 +2065,7 @@ mono_marshal_free_ccw (MonoObject* object)
 
 	ccw_list_item = ccw_list;
 	while (ccw_list_item) {
-		MonoCCW* ccw_iter = ccw_list_item->data;
+		MonoCCW* ccw_iter = (MonoCCW *)ccw_list_item->data;
 		MonoObject* handle_target = mono_gchandle_get_target (ccw_iter->gc_handle);
 
 		/* Looks like the GC NULLs the weakref handle target before running the
@@ -2072,7 +2074,7 @@ mono_marshal_free_ccw (MonoObject* object)
 		*/
 		gboolean destroy_ccw = !handle_target || handle_target == object;
 		if (!handle_target) {
-			MonoCCWInterface* ccw_entry = g_hash_table_lookup (ccw_iter->vtable_hash, mono_class_get_iunknown_class ());
+			MonoCCWInterface* ccw_entry = (MonoCCWInterface *)g_hash_table_lookup (ccw_iter->vtable_hash, mono_class_get_iunknown_class ());
 			if (!(ccw_entry && object == cominterop_get_ccw_object (ccw_entry, FALSE)))
 				destroy_ccw = FALSE;
 		}
@@ -2350,7 +2352,7 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 	if (cominterop_class_guid_equal (riid, mono_class_get_iunknown_class ())) {
 		*ppv = cominterop_get_ccw (object, mono_class_get_iunknown_class ());
 		/* remember to addref on QI */
-		cominterop_ccw_addref (*ppv);
+		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
 	}
 
@@ -2361,7 +2363,7 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 		
 		*ppv = cominterop_get_ccw (object, mono_class_get_idispatch_class ());
 		/* remember to addref on QI */
-		cominterop_ccw_addref (*ppv);
+		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
 	}
 
@@ -2378,7 +2380,7 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 		if (ifaces) {
 			for (i = 0; i < ifaces->len; ++i) {
 				MonoClass *ic = NULL;
-				ic = g_ptr_array_index (ifaces, i);
+				ic = (MonoClass *)g_ptr_array_index (ifaces, i);
 				if (cominterop_class_guid_equal (riid, ic)) {
 					itf = ic;
 					break;
@@ -2395,7 +2397,7 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 	if (itf) {
 		*ppv = cominterop_get_ccw (object, itf);
 		/* remember to addref on QI */
-		cominterop_ccw_addref (*ppv);
+		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
 	}
 
@@ -2619,7 +2621,7 @@ mono_string_to_bstr (MonoString *string_obj)
 	if (com_provider == MONO_COM_DEFAULT) {
 		int slen = mono_string_length (string_obj);
 		/* allocate len + 1 utf16 characters plus 4 byte integer for length*/
-		char *ret = g_malloc ((slen + 1) * sizeof(gunichar2) + sizeof(guint32));
+		char *ret = (char *)g_malloc ((slen + 1) * sizeof(gunichar2) + sizeof(guint32));
 		if (ret == NULL)
 			return NULL;
 		memcpy (ret + sizeof(guint32), mono_string_chars (string_obj), slen * sizeof(gunichar2));
@@ -2653,13 +2655,13 @@ mono_string_from_bstr (gpointer bstr)
 	return mono_string_new_utf16 (mono_domain_get (), bstr, SysStringLen (bstr));
 #else
 	if (com_provider == MONO_COM_DEFAULT) {
-		return mono_string_new_utf16 (mono_domain_get (), bstr, *((guint32 *)bstr - 1) / sizeof(gunichar2));
+		return mono_string_new_utf16 (mono_domain_get (), (const mono_unichar2 *)bstr, *((guint32 *)bstr - 1) / sizeof(gunichar2));
 	} else if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
 		MonoString* str = NULL;
 		glong written = 0;
 		gunichar2* utf16 = NULL;
 
-		utf16 = g_ucs4_to_utf16 (bstr, sys_string_len_ms (bstr), NULL, &written, NULL);
+		utf16 = g_ucs4_to_utf16 ((const gunichar *)bstr, sys_string_len_ms (bstr), NULL, &written, NULL);
 		str = mono_string_new_utf16 (mono_domain_get (), utf16, written);
 		g_free (utf16);
 		return str;
@@ -2681,7 +2683,7 @@ mono_free_bstr (gpointer bstr)
 	if (com_provider == MONO_COM_DEFAULT) {
 		g_free (((char *)bstr) - 4);
 	} else if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
-		sys_free_string_ms (bstr);
+		sys_free_string_ms ((gunichar *)bstr);
 	} else {
 		g_assert_not_reached ();
 	}
@@ -3017,8 +3019,8 @@ mono_marshal_safearray_begin (gpointer safearray, MonoArray **result, gpointer *
 
 			*indices = g_malloc (dim * sizeof(int));
 
-			sizes = alloca (dim * sizeof(uintptr_t));
-			bounds = alloca (dim * sizeof(intptr_t));
+			sizes = (uintptr_t *)alloca (dim * sizeof(uintptr_t));
+			bounds = (intptr_t *)alloca (dim * sizeof(intptr_t));
 
 			for (i=0; i<dim; ++i) {
 				glong lbound, ubound;
@@ -3049,7 +3051,7 @@ mono_marshal_safearray_begin (gpointer safearray, MonoArray **result, gpointer *
 				aklass = mono_bounded_array_class_get (mono_defaults.object_class, dim, bounded);
 				*result = mono_array_new_full (mono_domain_get (), aklass, sizes, bounds);
 			} else {
-				*result = parameter;
+				*result = (MonoArray *)parameter;
 			}
 		}
 	}
@@ -3067,7 +3069,7 @@ gpointer mono_marshal_safearray_get_value (gpointer safearray, gpointer indices)
 	}
 #else
 	if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
-		int hr = safe_array_ptr_of_index_ms (safearray, indices, &result);
+		int hr = safe_array_ptr_of_index_ms (safearray, (glong *)indices, &result);
 		if (hr < 0) {
 			cominterop_raise_hr_exception (hr);
 		}
@@ -3151,7 +3153,7 @@ mono_marshal_safearray_create (MonoArray *input, gpointer *newsafearray, gpointe
 	dim = ((MonoObject *)input)->vtable->klass->rank;
 
 	*indices = g_malloc (dim * sizeof (int));
-	bounds = alloca (dim * sizeof (SAFEARRAYBOUND));
+	bounds = (SAFEARRAYBOUND *)alloca (dim * sizeof (SAFEARRAYBOUND));
 	(*(int*)empty) = (max_array_length == 0);
 
 	if (dim > 1) {
@@ -3183,7 +3185,7 @@ void mono_marshal_safearray_set_value (gpointer safearray, gpointer indices, gpo
 		cominterop_raise_hr_exception (hr);
 #else
 	if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
-		int hr = safe_array_put_element_ms (safearray, indices, value);
+		int hr = safe_array_put_element_ms (safearray, (glong *)indices, (void **)value);
 		if (hr < 0) {
 			cominterop_raise_hr_exception (hr);
 		}

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -344,19 +344,19 @@ console_set_signal_handlers ()
 	memset (&sigwinch, 0, sizeof (struct sigaction));
 	
 	// Continuing
-	sigcont.sa_handler = (void *) sigcont_handler;
+	sigcont.sa_handler = (void (*)(int)) sigcont_handler;
 	sigcont.sa_flags = 0;
 	sigemptyset (&sigcont.sa_mask);
 	sigaction (SIGCONT, &sigcont, &save_sigcont);
 	
 	// Interrupt handler
-	sigint.sa_handler = (void *) sigint_handler;
+	sigint.sa_handler = (void (*)(int)) sigint_handler;
 	sigint.sa_flags = 0;
 	sigemptyset (&sigint.sa_mask);
 	sigaction (SIGINT, &sigint, &save_sigint);
 
 	// Window size changed
-	sigwinch.sa_handler = (void *) sigwinch_handler;
+	sigwinch.sa_handler = (void (*)(int)) sigwinch_handler;
 	sigwinch.sa_flags = 0;
 	sigemptyset (&sigwinch.sa_mask);
 	sigaction (SIGWINCH, &sigwinch, &save_sigwinch);

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1031,7 +1031,7 @@ mono_class_describe_statics (MonoClass* klass)
 
 	if (!vtable)
 		return;
-	if (!(addr = mono_vtable_get_static_field_data (vtable)))
+	if (!(addr = (const char *)mono_vtable_get_static_field_data (vtable)))
 		return;
 
 	for (p = klass; p != NULL; p = p->parent) {

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -88,7 +88,7 @@ get_pe_debug_guid (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *
 static void
 doc_free (gpointer key)
 {
-	MonoDebugSourceInfo *info = key;
+	MonoDebugSourceInfo *info = (MonoDebugSourceInfo *)key;
 
 	g_free (info->source_file);
 	g_free (info);
@@ -176,7 +176,7 @@ mono_ppdb_lookup_method (MonoDebugHandle *handle, MonoMethod *method)
 
 	mono_debugger_lock ();
 
-	minfo = g_hash_table_lookup (ppdb->method_hash, method);
+	minfo = (MonoDebugMethodInfo *)g_hash_table_lookup (ppdb->method_hash, method);
 	if (minfo) {
 		mono_debugger_unlock ();
 		return minfo;
@@ -208,7 +208,7 @@ get_docinfo (MonoPPDBFile *ppdb, MonoImage *image, int docidx)
 	MonoDebugSourceInfo *res, *cached;
 
 	mono_debugger_lock ();
-	cached = g_hash_table_lookup (ppdb->doc_hash, GUINT_TO_POINTER (docidx));
+	cached = (MonoDebugSourceInfo *)g_hash_table_lookup (ppdb->doc_hash, GUINT_TO_POINTER (docidx));
 	mono_debugger_unlock ();
 	if (cached)
 		return cached;
@@ -246,7 +246,7 @@ get_docinfo (MonoPPDBFile *ppdb, MonoImage *image, int docidx)
 	res->hash = (guint8*)mono_metadata_blob_heap (image, cols [MONO_DOCUMENT_HASH]);
 
 	mono_debugger_lock ();
-	cached = g_hash_table_lookup (ppdb->doc_hash, GUINT_TO_POINTER (docidx));
+	cached = (MonoDebugSourceInfo *)g_hash_table_lookup (ppdb->doc_hash, GUINT_TO_POINTER (docidx));
 	if (!cached) {
 		g_hash_table_insert (ppdb->doc_hash, GUINT_TO_POINTER (docidx), res);
 	} else {

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -849,7 +849,7 @@ mono_exception_get_native_backtrace (MonoException *exc)
 
 	for (i = 0; i < len; ++i) {
 		gpointer ip = mono_array_get (arr, gpointer, i);
-		MonoJitInfo *ji = mono_jit_info_table_find (mono_domain_get (), ip);
+		MonoJitInfo *ji = mono_jit_info_table_find (mono_domain_get (), (char *)ip);
 		if (ji) {
 			char *msg = mono_debug_print_stack_frame (mono_jit_info_get_method (ji), (char*)ip - (char*)ji->code_start, domain);
 			g_string_append_printf (text, "%s\n", msg);

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -60,8 +60,8 @@ static const RegionInfoEntry* region_info_entry_from_lcid (int lcid);
 static int
 culture_lcid_locator (const void *a, const void *b)
 {
-	const int *lcid = a;
-	const CultureInfoEntry *bb = b;
+	const int *lcid = (const int *)a;
+	const CultureInfoEntry *bb = (const CultureInfoEntry *)b;
 
 	return *lcid - bb->lcid;
 }
@@ -69,8 +69,8 @@ culture_lcid_locator (const void *a, const void *b)
 static int
 culture_name_locator (const void *a, const void *b)
 {
-	const char *aa = a;
-	const CultureInfoNameEntry *bb = b;
+	const char *aa = (const char *)a;
+	const CultureInfoNameEntry *bb = (const CultureInfoNameEntry *)b;
 	int ret;
 	
 	ret = strcmp (aa, idx2string (bb->name));
@@ -81,8 +81,8 @@ culture_name_locator (const void *a, const void *b)
 static int
 region_name_locator (const void *a, const void *b)
 {
-	const char *aa = a;
-	const RegionInfoNameEntry *bb = b;
+	const char *aa = (const char *)a;
+	const RegionInfoNameEntry *bb = (const RegionInfoNameEntry *)b;
 	int ret;
 	
 	ret = strcmp (aa, idx2string (bb->name));
@@ -167,7 +167,7 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 	char *n;
 
 	n = mono_string_to_utf8 (name);
-	ne = mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
+	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
 			sizeof (CultureInfoNameEntry), culture_name_locator);
 	g_free (n);
 	if (ne == NULL) {
@@ -317,7 +317,7 @@ culture_info_entry_from_lcid (int lcid)
 {
 	const CultureInfoEntry *ci;
 
-	ci = mono_binary_search (&lcid, culture_entries, NUM_CULTURE_ENTRIES, sizeof (CultureInfoEntry), culture_lcid_locator);
+	ci = (const CultureInfoEntry *)mono_binary_search (&lcid, culture_entries, NUM_CULTURE_ENTRIES, sizeof (CultureInfoEntry), culture_lcid_locator);
 
 	return ci;
 }
@@ -328,7 +328,7 @@ region_info_entry_from_lcid (int lcid)
 	const RegionInfoEntry *entry;
 	const CultureInfoEntry *ne;
 
-	ne = mono_binary_search (&lcid, culture_entries, NUM_CULTURE_ENTRIES, sizeof (CultureInfoEntry), culture_lcid_locator);
+	ne = (const CultureInfoEntry *)mono_binary_search (&lcid, culture_entries, NUM_CULTURE_ENTRIES, sizeof (CultureInfoEntry), culture_lcid_locator);
 
 	if (ne == NULL)
 		return FALSE;
@@ -509,7 +509,7 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (
 	char *n;
 	
 	n = mono_string_to_utf8 (name);
-	ne = mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
+	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
 			sizeof (CultureInfoNameEntry), culture_name_locator);
 
 	if (ne == NULL) {
@@ -557,7 +557,7 @@ ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (M
 	char *n;
 	
 	n = mono_string_to_utf8 (name);
-	ne = mono_binary_search (n, region_name_entries, NUM_REGION_ENTRIES,
+	ne = (const RegionInfoNameEntry *)mono_binary_search (n, region_name_entries, NUM_REGION_ENTRIES,
 		sizeof (RegionInfoNameEntry), region_name_locator);
 
 	if (ne == NULL) {
@@ -666,12 +666,12 @@ int ves_icall_System_Threading_Thread_current_lcid (void)
 	return(0x007F);
 }
 
-MonoString *ves_icall_System_String_InternalReplace_Str_Comp (MonoString *this_obj, MonoString *old, MonoString *new, MonoCompareInfo *comp)
+MonoString *ves_icall_System_String_InternalReplace_Str_Comp (MonoString *this_obj, MonoString *old, MonoString *new_, MonoCompareInfo *comp)
 {
 	/* Do a normal ascii string compare and replace, as we only
 	 * know the invariant locale if we dont have ICU
 	 */
-	return(string_invariant_replace (this_obj, old, new));
+	return(string_invariant_replace (this_obj, old, new_));
 }
 
 static gint32 string_invariant_compare_char (gunichar2 c1, gunichar2 c2,

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -107,7 +107,7 @@ mono_mempool_new_size (int initial_size)
 		initial_size = MONO_MEMPOOL_MINSIZE;
 #endif
 
-	pool = g_malloc (initial_size);
+	pool = (MonoMemPool *)g_malloc (initial_size);
 
 	pool->next = NULL;
 	pool->pos = (guint8*)pool + SIZEOF_MEM_POOL; // Start after header
@@ -277,7 +277,7 @@ mono_mempool_alloc (MonoMemPool *pool, guint size)
 		// (In individual allocation mode, the constant will be 0 and this path will always be taken)
 		if (size >= MONO_MEMPOOL_PREFER_INDIVIDUAL_ALLOCATION_SIZE) {
 			guint new_size = SIZEOF_MEM_POOL + size;
-			MonoMemPool *np = g_malloc (new_size);
+			MonoMemPool *np = (MonoMemPool *)g_malloc (new_size);
 
 			np->next = pool->next;
 			np->size = new_size;
@@ -289,7 +289,7 @@ mono_mempool_alloc (MonoMemPool *pool, guint size)
 		} else {
 			// Notice: any unused memory at the end of the old head becomes simply abandoned in this case until the mempool is freed (see Bugzilla #35136)
 			guint new_size = get_next_size (pool, size);
-			MonoMemPool *np = g_malloc (new_size);
+			MonoMemPool *np = (MonoMemPool *)g_malloc (new_size);
 
 			np->next = pool->next;
 			np->size = new_size;
@@ -373,7 +373,7 @@ mono_mempool_strdup (MonoMemPool *pool,
 		return NULL;
 
 	l = strlen (s);
-	res = mono_mempool_alloc (pool, l + 1);
+	res = (char *)mono_mempool_alloc (pool, l + 1);
 	memcpy (res, s, l + 1);
 
 	return res;

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -332,7 +332,7 @@ bounds_check_virtual_address (VerifyContext *ctx, guint32 rva, guint32 size)
 		return FALSE;
 
 	if (ctx->stage > STAGE_PE) {
-		MonoCLIImageInfo *iinfo = ctx->image->image_info;
+		MonoCLIImageInfo *iinfo = (MonoCLIImageInfo *)ctx->image->image_info;
 		const int top = iinfo->cli_section_count;
 		MonoSectionTable *tables = iinfo->cli_section_tables;
 		int i;
@@ -689,7 +689,7 @@ verify_resources_table (VerifyContext *ctx)
 static DataDirectory
 get_data_dir (VerifyContext *ctx, int idx)
 {
-	MonoCLIImageInfo *iinfo = ctx->image->image_info;
+	MonoCLIImageInfo *iinfo = (MonoCLIImageInfo *)ctx->image->image_info;
 	MonoPEDirEntry *entry= &iinfo->cli_header.datadir.pe_export_table;
 	DataDirectory res;
 
@@ -1069,7 +1069,7 @@ search_sorted_table (VerifyContext *ctx, int table, int column, guint32 coded_to
 	base = tinfo->base;
 
 	VERIFIER_DEBUG ( printf ("looking token %x table %d col %d rsize %d roff %d\n", coded_token, table, column, locator.col_size, locator.col_offset) );
-	res = mono_binary_search (&locator, base, tinfo->rows, tinfo->row_size, token_locator);
+	res = (const char *)mono_binary_search (&locator, base, tinfo->rows, tinfo->row_size, token_locator);
 	if (!res)
 		return -1;
 
@@ -1787,7 +1787,7 @@ get_enum_by_encoded_name (VerifyContext *ctx, const char **_ptr, const char *end
 		return NULL;
 	}
 
-	enum_name = g_memdup (str_start, str_len + 1);
+	enum_name = (char *)g_memdup (str_start, str_len + 1);
 	enum_name [str_len] = 0;
 	type = mono_reflection_type_from_name (enum_name, ctx->image);
 	if (!type) {
@@ -1881,7 +1881,7 @@ handle_enum:
 			} else if (etype == 0x50 || etype == MONO_TYPE_CLASS) {
 				klass = mono_defaults.systemtype_class;
 			} else if ((etype >= MONO_TYPE_BOOLEAN && etype <= MONO_TYPE_STRING) || etype == 0x51) {
-				simple_type.type = etype == 0x51 ? MONO_TYPE_OBJECT : etype;
+				simple_type.type = etype == 0x51 ? MONO_TYPE_OBJECT : (MonoTypeEnum)etype;
 				klass = mono_class_from_mono_type (&simple_type);
 			} else
 				FAIL (ctx, g_strdup_printf ("CustomAttribute: Invalid array element type %x", etype));
@@ -1986,7 +1986,7 @@ is_valid_cattr_content (VerifyContext *ctx, MonoMethod *ctor, const char *ptr, g
 			FAIL (ctx, g_strdup_printf ("CustomAttribute: Not enough space for named parameter %d type", i));
 
 		if (kind >= MONO_TYPE_BOOLEAN && kind <= MONO_TYPE_STRING) {
-			simple_type.type = kind;
+			simple_type.type = (MonoTypeEnum)kind;
 			type = &simple_type;
 		} else if (kind == MONO_TYPE_ENUM) {
 			MonoClass *klass = get_enum_by_encoded_name (ctx, &ptr, end);
@@ -2010,7 +2010,7 @@ is_valid_cattr_content (VerifyContext *ctx, MonoMethod *ctor, const char *ptr, g
 			} else if (etype == 0x50 || etype == MONO_TYPE_CLASS) {
 				klass = mono_defaults.systemtype_class;
 			} else if ((etype >= MONO_TYPE_BOOLEAN && etype <= MONO_TYPE_STRING) || etype == 0x51) {
-				simple_type.type = etype == 0x51 ? MONO_TYPE_OBJECT : etype;
+				simple_type.type = etype == 0x51 ? MONO_TYPE_OBJECT : (MonoTypeEnum)etype;
 				klass = mono_class_from_mono_type (&simple_type);
 			} else
 				FAIL (ctx, g_strdup_printf ("CustomAttribute: Invalid array element type %x", etype));
@@ -3487,7 +3487,7 @@ verify_exportedtype_table (VerifyContext *ctx)
 static void
 verify_manifest_resource_table (VerifyContext *ctx)
 {
-	MonoCLIImageInfo *iinfo = ctx->image->image_info;
+	MonoCLIImageInfo *iinfo = (MonoCLIImageInfo *)ctx->image->image_info;
 	MonoCLIHeader *ch = &iinfo->cli_cli_header;
 	MonoTableInfo *table = &ctx->image->tables [MONO_TABLE_MANIFESTRESOURCE];
 	guint32 data [MONO_MANIFEST_SIZE], impl_table, token, resources_size;
@@ -3662,15 +3662,15 @@ typedef struct {
 static guint
 typedef_hash (gconstpointer _key)
 {
-	const TypeDefUniqueId *key = _key;
+	const TypeDefUniqueId *key = (const TypeDefUniqueId *)_key;
 	return g_str_hash (key->name) ^ g_str_hash (key->name_space) ^ key->resolution_scope; /*XXX better salt the int key*/
 }
 
 static gboolean
 typedef_equals (gconstpointer _a, gconstpointer _b)
 {
-	const TypeDefUniqueId *a = _a;
-	const TypeDefUniqueId *b = _b;
+	const TypeDefUniqueId *a = (const TypeDefUniqueId *)_a;
+	const TypeDefUniqueId *b = (const TypeDefUniqueId *)_b;
 	return !strcmp (a->name, b->name) && !strcmp (a->name_space, b->name_space) && a->resolution_scope == b->resolution_scope;
 }
 
@@ -3878,7 +3878,7 @@ cleanup_context_checked (VerifyContext *ctx, MonoError *error)
 {
 	g_free (ctx->sections);
 	if (ctx->errors) {
-		MonoVerifyInfo *info = ctx->errors->data;
+		MonoVerifyInfo *info = (MonoVerifyInfo *)ctx->errors->data;
 		mono_error_set_bad_image (error, ctx->image, "%s", info->message);
 		mono_free_verify_list (ctx->errors);
 	}

--- a/mono/metadata/method-builder.c
+++ b/mono/metadata/method-builder.c
@@ -67,7 +67,7 @@ mono_mb_new_base (MonoClass *klass, MonoWrapperType type)
 
 #ifndef DISABLE_JIT
 	mb->code_size = 40;
-	mb->code = g_malloc (mb->code_size);
+	mb->code = (unsigned char *)g_malloc (mb->code_size);
 #endif
 	/* placeholder for the wrapper always at index 1 */
 	mono_mb_add_data (mb, NULL);
@@ -155,7 +155,7 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 	{
 		/* Realloc the method info into a mempool */
 
-		method = mono_image_alloc0 (image, sizeof (MonoMethodWrapper));
+		method = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethodWrapper));
 		memcpy (method, mb->method, sizeof (MonoMethodWrapper));
 		mw = (MonoMethodWrapper*) method;
 
@@ -168,7 +168,7 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 		mw->header = header = (MonoMethodHeader *) 
 			mono_image_alloc0 (image, MONO_SIZEOF_METHOD_HEADER + mb->locals * sizeof (MonoType *));
 
-		header->code = mono_image_alloc (image, mb->pos);
+		header->code = (const unsigned char *)mono_image_alloc (image, mb->pos);
 		memcpy ((char*)header->code, mb->code, mb->pos);
 
 		for (i = 0, l = mb->locals_list; l; l = l->next, i++) {
@@ -197,15 +197,15 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 	method->skip_visibility = mb->skip_visibility;
 #endif
 
-	i = g_list_length (mw->method_data);
+	i = g_list_length ((GList *)mw->method_data);
 	if (i) {
 		GList *tmp;
 		void **data;
-		l = g_list_reverse (mw->method_data);
+		l = g_list_reverse ((GList *)mw->method_data);
 		if (method_is_dynamic (method))
-			data = g_malloc (sizeof (gpointer) * (i + 1));
+			data = (void **)g_malloc (sizeof (gpointer) * (i + 1));
 		else
-			data = mono_image_alloc (image, sizeof (gpointer) * (i + 1));
+			data = (void **)mono_image_alloc (image, sizeof (gpointer) * (i + 1));
 		/* store the size in the first element */
 		data [0] = GUINT_TO_POINTER (i);
 		i = 1;
@@ -232,7 +232,7 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 #endif
 
 	if (mb->param_names) {
-		char **param_names = mono_image_alloc0 (image, signature->param_count * sizeof (gpointer));
+		char **param_names = (char **)mono_image_alloc0 (image, signature->param_count * sizeof (gpointer));
 		for (i = 0; i < signature->param_count; ++i)
 			param_names [i] = mono_image_strdup (image, mb->param_names [i]);
 
@@ -257,9 +257,9 @@ mono_mb_add_data (MonoMethodBuilder *mb, gpointer data)
 	mw = (MonoMethodWrapper *)mb->method;
 
 	/* one O(n) is enough */
-	mw->method_data = g_list_prepend (mw->method_data, data);
+	mw->method_data = g_list_prepend ((GList *)mw->method_data, data);
 
-	return g_list_length (mw->method_data);
+	return g_list_length ((GList *)mw->method_data);
 }
 
 #ifndef DISABLE_JIT
@@ -299,7 +299,7 @@ mono_mb_emit_byte (MonoMethodBuilder *mb, guint8 op)
 {
 	if (mb->pos >= mb->code_size) {
 		mb->code_size += mb->code_size >> 1;
-		mb->code = g_realloc (mb->code, mb->code_size);
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
 	}
 
 	mb->code [mb->pos++] = op;
@@ -322,7 +322,7 @@ mono_mb_emit_i4 (MonoMethodBuilder *mb, gint32 data)
 {
 	if ((mb->pos + 4) >= mb->code_size) {
 		mb->code_size += mb->code_size >> 1;
-		mb->code = g_realloc (mb->code, mb->code_size);
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
 	}
 
 	mono_mb_patch_addr (mb, mb->pos, data);
@@ -334,7 +334,7 @@ mono_mb_emit_i8 (MonoMethodBuilder *mb, gint64 data)
 {
 	if ((mb->pos + 8) >= mb->code_size) {
 		mb->code_size += mb->code_size >> 1;
-		mb->code = g_realloc (mb->code, mb->code_size);
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
 	}
 
 	mono_mb_patch_addr (mb, mb->pos, data);
@@ -347,7 +347,7 @@ mono_mb_emit_i2 (MonoMethodBuilder *mb, gint16 data)
 {
 	if ((mb->pos + 2) >= mb->code_size) {
 		mb->code_size += mb->code_size >> 1;
-		mb->code = g_realloc (mb->code, mb->code_size);
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
 	}
 
 	mb->code [mb->pos] = data & 0xff;

--- a/mono/metadata/mono-basic-block.c
+++ b/mono/metadata/mono-basic-block.c
@@ -295,11 +295,11 @@ bb_liveness (MonoSimpleBasicBlock *bb)
 	}
 
 	while (mark_stack->len > 0) {
-		MonoSimpleBasicBlock *block = g_ptr_array_remove_index_fast (mark_stack, mark_stack->len - 1);
+		MonoSimpleBasicBlock *block = (MonoSimpleBasicBlock *)g_ptr_array_remove_index_fast (mark_stack, mark_stack->len - 1);
 		block->dead = FALSE;
 
 		for (tmp = block->out_bb; tmp; tmp = tmp->next) {
-			MonoSimpleBasicBlock *to = tmp->data;
+			MonoSimpleBasicBlock *to = (MonoSimpleBasicBlock *)tmp->data;
 			if (to->dead)
 				g_ptr_array_add (mark_stack, to);
 		}

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -166,9 +166,9 @@ static void start_element (GMarkupParseContext *context,
 			   gpointer             user_data,
 			   GError             **error)
 {
-	ParseState *state = user_data;
+	ParseState *state = (ParseState *)user_data;
 	if (!state->current) {
-		state->current = g_hash_table_lookup (config_handlers, element_name);
+		state->current = (MonoParseHandler *)g_hash_table_lookup (config_handlers, element_name);
 		if (state->current && state->current->init)
 			state->user_data = state->current->init (state->assembly);
 	}
@@ -181,7 +181,7 @@ static void end_element   (GMarkupParseContext *context,
 			   gpointer             user_data,
 			   GError             **error)
 {
-	ParseState *state = user_data;
+	ParseState *state = (ParseState *)user_data;
 	if (state->current) {
 		if (state->current->end)
 			state->current->end (state->user_data, element_name);
@@ -200,7 +200,7 @@ static void parse_text    (GMarkupParseContext *context,
 			   gpointer             user_data,
 			   GError             **error)
 {
-	ParseState *state = user_data;
+	ParseState *state = (ParseState *)user_data;
 	if (state->current && state->current->text)
 		state->current->text (state->user_data, text, text_len);
 }
@@ -218,7 +218,7 @@ static void parse_error   (GMarkupParseContext *context,
                            GError              *error,
 			   gpointer             user_data)
 {
-	ParseState *state = user_data;
+	ParseState *state = (ParseState *)user_data;
 	const gchar *msg;
 	const gchar *filename;
 
@@ -267,7 +267,7 @@ dllmap_start (gpointer user_data,
               const gchar        **attribute_values)
 {
 	int i;
-	DllInfo *info = user_data;
+	DllInfo *info = (DllInfo *)user_data;
 	
 	if (strcmp (element_name, "dllmap") == 0) {
 		g_free (info->dll);
@@ -284,7 +284,7 @@ dllmap_start (gpointer user_data,
 					size_t libdir_len = strlen (libdir);
 					char *result;
 					
-					result = g_malloc (libdir_len-strlen("$mono_libdir")+strlen(attribute_values[i])+1);
+					result = (char *)g_malloc (libdir_len-strlen("$mono_libdir")+strlen(attribute_values[i])+1);
 					strncpy (result, attribute_names[i], p-attribute_values[i]);
 					strcat (result, libdir);
 					strcat (result, p+strlen("$mono_libdir"));
@@ -327,7 +327,7 @@ dllmap_start (gpointer user_data,
 static void
 dllmap_finish (gpointer user_data)
 {
-	DllInfo *info = user_data;
+	DllInfo *info = (DllInfo *)user_data;
 
 	g_free (info->dll);
 	g_free (info->target);
@@ -448,7 +448,7 @@ mono_config_parse_xml_with_context (ParseState *state, const char *text, gsize l
 	if (!inited)
 		mono_config_init ();
 
-	context = g_markup_parse_context_new (&mono_parser, 0, state, NULL);
+	context = g_markup_parse_context_new (&mono_parser, (GMarkupParseFlags)0, state, NULL);
 	if (g_markup_parse_context_parse (context, text, len, NULL)) {
 		g_markup_parse_context_end_parse (context, NULL);
 	}
@@ -668,7 +668,7 @@ mono_get_machine_config (void)
 static void
 assembly_binding_end (gpointer user_data, const char *element_name)
 {
-	ParserUserData *pud = user_data;
+	ParserUserData *pud = (ParserUserData *)user_data;
 
 	if (!strcmp (element_name, "dependentAssembly")) {
 		if (pud->info_parsed && pud->info) {
@@ -689,7 +689,7 @@ publisher_policy_start (gpointer user_data,
 	MonoAssemblyBindingInfo *info;
 	int n;
 
-	pud = user_data;
+	pud = (ParserUserData *)user_data;
 	info = pud->info;
 	if (!strcmp (element_name, "dependentAssembly")) {
 		info->name = NULL;

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -100,7 +100,7 @@ lookup_data_table (MonoDomain *domain)
 {
 	MonoDebugDataTable *table;
 
-	table = g_hash_table_lookup (data_table_hash, domain);
+	table = (MonoDebugDataTable *)g_hash_table_lookup (data_table_hash, domain);
 	if (!table) {
 		g_error ("lookup_data_table () failed for %p\n", domain);
 		g_assert (table);
@@ -197,7 +197,7 @@ mono_debug_domain_unload (MonoDomain *domain)
 
 	mono_debugger_lock ();
 
-	table = g_hash_table_lookup (data_table_hash, domain);
+	table = (MonoDebugDataTable *)g_hash_table_lookup (data_table_hash, domain);
 	if (!table) {
 		g_warning (G_STRLOC ": unloading unknown domain %p / %d",
 			   domain, mono_domain_get_id (domain));
@@ -216,7 +216,7 @@ mono_debug_domain_unload (MonoDomain *domain)
 static MonoDebugHandle *
 mono_debug_get_image (MonoImage *image)
 {
-	return g_hash_table_lookup (mono_debug_handles, image);
+	return (MonoDebugHandle *)g_hash_table_lookup (mono_debug_handles, image);
 }
 
 void
@@ -444,7 +444,7 @@ mono_debug_add_method (MonoMethod *method, MonoDebugMethodJitInfo *jit, MonoDoma
 		(25 + sizeof (gpointer)) * (1 + jit->num_params + jit->num_locals);
 
 	if (max_size > BUFSIZ)
-		ptr = oldptr = g_malloc (max_size);
+		ptr = oldptr = (guint8 *)g_malloc (max_size);
 	else
 		ptr = oldptr = buffer;
 
@@ -482,9 +482,9 @@ mono_debug_add_method (MonoMethod *method, MonoDebugMethodJitInfo *jit, MonoDoma
 	total_size = size + sizeof (MonoDebugMethodAddress);
 
 	if (method_is_dynamic (method)) {
-		address = g_malloc0 (total_size);
+		address = (MonoDebugMethodAddress *)g_malloc0 (total_size);
 	} else {
-		address = mono_mempool_alloc (table->mp, total_size);
+		address = (MonoDebugMethodAddress *)mono_mempool_alloc (table->mp, total_size);
 	}
 
 	address->code_start = jit->code_start;
@@ -515,7 +515,7 @@ mono_debug_remove_method (MonoMethod *method, MonoDomain *domain)
 
 	table = lookup_data_table (domain);
 
-	address = g_hash_table_lookup (table->method_address_hash, method);
+	address = (MonoDebugMethodAddress *)g_hash_table_lookup (table->method_address_hash, method);
 	if (address)
 		g_free (address);
 
@@ -579,7 +579,7 @@ read_variable (MonoDebugVarInfo *var, guint8 *ptr, guint8 **rptr)
 	var->size = read_leb128 (ptr, &ptr);
 	var->begin_scope = read_leb128 (ptr, &ptr);
 	var->end_scope = read_leb128 (ptr, &ptr);
-	READ_UNALIGNED (gpointer, ptr, var->type);
+	READ_UNALIGNED (MonoType *, ptr, var->type);
 	ptr += sizeof (gpointer);
 	*rptr = ptr;
 }
@@ -655,7 +655,7 @@ find_method (MonoMethod *method, MonoDomain *domain)
 	MonoDebugMethodAddress *address;
 
 	table = lookup_data_table (domain);
-	address = g_hash_table_lookup (table->method_address_hash, method);
+	address = (MonoDebugMethodAddress *)g_hash_table_lookup (table->method_address_hash, method);
 
 	if (!address)
 		return NULL;

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -173,7 +173,7 @@ typedef struct {
 static void*
 do_rehash (void *_data)
 {
-	RehashData *data = _data;
+	RehashData *data = (RehashData *)_data;
 	MonoGHashTable *hash = data->hash;
 	int current_size, i;
 	Slot **table;
@@ -425,17 +425,17 @@ mono_g_hash_table_insert_replace (MonoGHashTable *hash, gpointer key, gpointer v
 			if (replace){
 				if (hash->key_destroy_func != NULL)
 					(*hash->key_destroy_func)(s->key);
-				s->key = key;
+				s->key = (MonoObject *)key;
 			}
 			if (hash->value_destroy_func != NULL)
 				(*hash->value_destroy_func) (s->value);
-			s->value = value;
+			s->value = (MonoObject *)value;
 			return;
 		}
 	}
 	s = new_slot (hash);
-	s->key = key;
-	s->value = value;
+	s->key = (MonoObject *)key;
+	s->value = (MonoObject *)value;
 	s->next = hash->table [hashcode];
 	hash->table [hashcode] = s;
 	hash->in_use++;

--- a/mono/metadata/mono-ptr-array.h
+++ b/mono/metadata/mono-ptr-array.h
@@ -34,7 +34,9 @@ typedef struct {
 	(ARRAY).capacity = MAX (INITIAL_SIZE, MONO_PTR_ARRAY_MAX_ON_STACK); \
 	(ARRAY).source = SOURCE; \
 	(ARRAY).msg = MSG; \
-	(ARRAY).data = INITIAL_SIZE > MONO_PTR_ARRAY_MAX_ON_STACK ? mono_gc_alloc_fixed (sizeof (void*) * INITIAL_SIZE, mono_gc_make_root_descr_all_refs (INITIAL_SIZE), SOURCE, MSG) : g_newa (void*, MONO_PTR_ARRAY_MAX_ON_STACK); \
+	(ARRAY).data = INITIAL_SIZE > MONO_PTR_ARRAY_MAX_ON_STACK \
+		? (void **)mono_gc_alloc_fixed (sizeof (void*) * INITIAL_SIZE, mono_gc_make_root_descr_all_refs (INITIAL_SIZE), SOURCE, MSG) \
+		: g_newa (void*, MONO_PTR_ARRAY_MAX_ON_STACK); \
 } while (0)
 
 #define mono_ptr_array_destroy(ARRAY) do {\
@@ -44,8 +46,8 @@ typedef struct {
 
 #define mono_ptr_array_append(ARRAY, VALUE) do { \
 	if ((ARRAY).size >= (ARRAY).capacity) {\
-	void *__tmp = mono_gc_alloc_fixed (sizeof (void*) * (ARRAY).capacity * 2, mono_gc_make_root_descr_all_refs ((ARRAY).capacity * 2), (ARRAY).source, (ARRAY).msg); \
-		mono_gc_memmove_aligned (__tmp, (ARRAY).data, (ARRAY).capacity * sizeof (void*)); \
+	void **__tmp = (void **)mono_gc_alloc_fixed (sizeof (void*) * (ARRAY).capacity * 2, mono_gc_make_root_descr_all_refs ((ARRAY).capacity * 2), (ARRAY).source, (ARRAY).msg); \
+		mono_gc_memmove_aligned ((void *)__tmp, (ARRAY).data, (ARRAY).capacity * sizeof (void*)); \
 		if ((ARRAY).capacity > MONO_PTR_ARRAY_MAX_ON_STACK)	\
 			mono_gc_free_fixed ((ARRAY).data);	\
 		(ARRAY).data = __tmp;	\

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -153,7 +153,7 @@ GetTokenName (uid_t uid)
 #else
 	fbufsize = MONO_SYSCONF_DEFAULT_SIZE;
 #endif
-	fbuf = g_malloc0 (fbufsize);
+	fbuf = (gchar *)g_malloc0 (fbufsize);
 	retval = getpwuid_r (uid, &pwd, fbuf, fbufsize, &p);
 	result = ((retval == 0) && (p == &pwd));
 #else
@@ -220,7 +220,7 @@ IsDefaultGroup (uid_t user, gid_t group)
 	fbufsize = MONO_SYSCONF_DEFAULT_SIZE;
 #endif
 
-	fbuf = g_malloc0 (fbufsize);
+	fbuf = (gchar *)g_malloc0 (fbufsize);
 	retval = getpwuid_r (user, &pwd, fbuf, fbufsize, &p);
 	result = ((retval == 0) && (p == &pwd));
 #else
@@ -359,7 +359,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetUserToken (MonoString *us
 	fbufsize = MONO_SYSCONF_DEFAULT_SIZE;
 #endif
 
-	fbuf = g_malloc0 (fbufsize);
+	fbuf = (gchar *)g_malloc0 (fbufsize);
 	retval = getpwnam_r (utf8_name, &pwd, fbuf, fbufsize, &p);
 	result = ((retval == 0) && (p == &pwd));
 #else
@@ -500,7 +500,7 @@ ves_icall_System_Security_Principal_WindowsPrincipal_IsMemberOfGroupId (gpointer
 #else
 	fbufsize = MONO_SYSCONF_DEFAULT_SIZE;
 #endif
-	fbuf = g_malloc0 (fbufsize);
+	fbuf = (gchar *)g_malloc0 (fbufsize);
 	retval = getgrgid_r ((gid_t) GPOINTER_TO_INT (group), &grp, fbuf, fbufsize, &g);
 	result = ((retval == 0) && (g == &grp));
 #else
@@ -547,7 +547,7 @@ ves_icall_System_Security_Principal_WindowsPrincipal_IsMemberOfGroupName (gpoint
 #else
 		size_t fbufsize = MONO_SYSCONF_DEFAULT_SIZE;
 #endif
-		fbuf = g_malloc0 (fbufsize);
+		fbuf = (gchar *)g_malloc0 (fbufsize);
 		retval = getgrnam_r (utf8_groupname, &grp, fbuf, fbufsize, &g);
 		result = ((retval == 0) && (g == &grp));
 #else

--- a/mono/metadata/opcodes.c
+++ b/mono/metadata/opcodes.c
@@ -72,19 +72,19 @@ mono_opcode_value (const mono_byte **ip, const mono_byte *end)
 	const mono_byte *p = *ip;
 
 	if (p >= end)
-		return -1;
+		return (MonoOpcodeEnum)-1;
 	if (*p == 0xfe) {
 		++p;
 		if (p >= end)
-			return -1;
-		res = *p + MONO_PREFIX1_OFFSET;
+			return (MonoOpcodeEnum)-1;
+		res = (MonoOpcodeEnum)(*p + MONO_PREFIX1_OFFSET);
 	} else if (*p == MONO_CUSTOM_PREFIX) {
 		++p;
 		if (p >= end)
-			return -1;
-		res = *p + MONO_CUSTOM_PREFIX_OFFSET;
+			return (MonoOpcodeEnum)-1;
+		res = (MonoOpcodeEnum)(*p + MONO_CUSTOM_PREFIX_OFFSET);
 	} else {
-		res = *p;
+		res = (MonoOpcodeEnum)*p;
 	}
 	*ip = p;
 	return res;

--- a/mono/metadata/pedump.c
+++ b/mono/metadata/pedump.c
@@ -333,7 +333,7 @@ dump_methoddef (MonoImage *metadata, guint32 token)
 static void
 dump_dotnet_iinfo (MonoImage *image)
 {
-	MonoCLIImageInfo *iinfo = image->image_info;
+	MonoCLIImageInfo *iinfo = (MonoCLIImageInfo *)image->image_info;
 
 	dump_dotnet_header (&iinfo->cli_header);
 	dump_sections (iinfo);
@@ -385,7 +385,7 @@ dump_verify_info (MonoImage *image, int flags)
 			}
 
 			for (tmp = errors; tmp; tmp = tmp->next) {
-				MonoVerifyInfo *info = tmp->data;
+				MonoVerifyInfo *info = (MonoVerifyInfo *)tmp->data;
 				g_print ("%s: %s\n", desc [info->status], info->message);
 				if (info->status == MONO_VERIFY_ERROR) {
 					count++;
@@ -504,7 +504,7 @@ verify_image_file (const char *fname)
 
 invalid_image:
 	for (tmp = errors; tmp; tmp = tmp->next) {
-		MonoVerifyInfo *info = tmp->data;
+		MonoVerifyInfo *info = (MonoVerifyInfo *)tmp->data;
 		g_print ("%s: %s\n", desc [info->status], info->message);
 		if (info->status == MONO_VERIFY_ERROR)
 			count++;
@@ -610,7 +610,7 @@ pedump_assembly_search_hook (MonoAssemblyName *aname, gpointer user_data)
         GList *tmp;
 
        for (tmp = loaded_assemblies; tmp; tmp = tmp->next) {
-               MonoAssembly *ass = tmp->data;
+               MonoAssembly *ass = (MonoAssembly *)tmp->data;
                if (mono_assembly_names_equal (aname, &ass->aname))
 		       return ass;
        }

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -159,11 +159,11 @@ void
 mono_profiler_set_events (MonoProfileFlags events)
 {
 	ProfilerDesc *prof;
-	MonoProfileFlags value = 0;
+	MonoProfileFlags value = (MonoProfileFlags)0;
 	if (prof_list)
 		prof_list->events = events;
 	for (prof = prof_list; prof; prof = prof->next)
-		value |= prof->events;
+		value = (MonoProfileFlags)(value | prof->events);
 	mono_profiler_events = value;
 }
 
@@ -813,7 +813,7 @@ mono_profiler_shutdown (void)
 			prof->shutdown_callback (prof->profiler);
 	}
 
-	mono_profiler_set_events (0);
+	mono_profiler_set_events ((MonoProfileFlags)0);
 }
 
 void
@@ -1018,7 +1018,7 @@ mono_profiler_coverage_alloc (MonoMethod *method, int entries)
 	if (!coverage_hash)
 		coverage_hash = g_hash_table_new (NULL, NULL);
 
-	res = g_malloc0 (sizeof (MonoProfileCoverageInfo) + sizeof (void*) * 2 * entries);
+	res = (MonoProfileCoverageInfo *)g_malloc0 (sizeof (MonoProfileCoverageInfo) + sizeof (void*) * 2 * entries);
 
 	res->entries = entries;
 
@@ -1040,7 +1040,7 @@ mono_profiler_coverage_free (MonoMethod *method)
 		return;
 	}
 
-	info = g_hash_table_lookup (coverage_hash, method);
+	info = (MonoProfileCoverageInfo *)g_hash_table_lookup (coverage_hash, method);
 	if (info) {
 		g_free (info);
 		g_hash_table_remove (coverage_hash, method);
@@ -1073,7 +1073,7 @@ mono_profiler_coverage_get (MonoProfiler *prof, MonoMethod *method, MonoProfileC
 
 	mono_profiler_coverage_lock ();
 	if (coverage_hash)
-		info = g_hash_table_lookup (coverage_hash, method);
+		info = (MonoProfileCoverageInfo *)g_hash_table_lookup (coverage_hash, method);
 	mono_profiler_coverage_unlock ();
 
 	if (!info)
@@ -1240,7 +1240,7 @@ mono_profiler_load (const char *desc)
 		gboolean res = FALSE;
 
 		if (col != NULL) {
-			mname = g_memdup (desc, col - desc + 1);
+			mname = (char *)g_memdup (desc, col - desc + 1);
 			mname [col - desc] = 0;
 		} else {
 			mname = g_strdup (desc);

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -332,7 +332,7 @@ mono_security_core_clr_check_override (MonoClass *klass, MonoMethod *override, M
 static gboolean
 get_caller_no_reflection_related (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed, gpointer data)
 {
-	MonoMethod **dest = data;
+	MonoMethod **dest = (MonoMethod **)data;
 	const char *ns;
 
 	/* skip unmanaged frames */
@@ -436,7 +436,7 @@ typedef struct {
 static gboolean
 get_caller_of_elevated_trust_code (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed, gpointer data)
 {
-	ElevatedTrustCookie *cookie = data;
+	ElevatedTrustCookie *cookie = (ElevatedTrustCookie *)data;
 
 	/* skip unmanaged frames and wrappers */
 	if (!managed || (m->wrapper_type != MONO_WRAPPER_NONE))
@@ -917,7 +917,7 @@ mono_security_core_clr_level_from_cinfo (MonoCustomAttrInfo *cinfo, MonoImage *i
 	if (cinfo && mono_custom_attrs_has_attr (cinfo, security_critical_attribute ()))
 		level = MONO_SECURITY_CORE_CLR_CRITICAL;
 
-	return level;
+	return (MonoSecurityCoreCLRLevel)level;
 }
 
 /*

--- a/mono/metadata/seq-points-data.c
+++ b/mono/metadata/seq-points-data.c
@@ -372,7 +372,7 @@ mono_seq_point_data_init (SeqPointData *data, int entry_capacity)
 {
 	data->entry_count = 0;
 	data->entry_capacity = entry_capacity;
-	data->entries = g_malloc (sizeof (SeqPointDataEntry) * entry_capacity);
+	data->entries = (SeqPointDataEntry *)g_malloc (sizeof (SeqPointDataEntry) * entry_capacity);
 }
 
 void
@@ -402,7 +402,7 @@ mono_seq_point_data_read (SeqPointData *data, char *path)
 	fsize = ftell(f);
 	fseek(f, 0, SEEK_SET);
 
-	buffer_orig = buffer = g_malloc(fsize + 1);
+	buffer_orig = buffer = (guint8 *)g_malloc (fsize + 1);
 	fread(buffer_orig, fsize, 1, f);
 	fclose(f);
 
@@ -438,7 +438,7 @@ mono_seq_point_data_write (SeqPointData *data, char *path)
 	// Add size of entry_count and native_base_offsets
 	size += 4 + data->entry_count * 4;
 
-	buffer_orig = buffer = g_malloc (size);
+	buffer_orig = buffer = (guint8 *)g_malloc (size);
 
 	encode_var_int (buffer, &buffer, data->entry_count);
 

--- a/mono/metadata/seq-points-data.h
+++ b/mono/metadata/seq-points-data.h
@@ -28,7 +28,7 @@ typedef struct {
 } SeqPoint;
 
 typedef struct MonoSeqPointInfo {
-	int dummy[0];
+	int dummy [1];
 } MonoSeqPointInfo;
 
 typedef struct {

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -151,8 +151,8 @@ sgen_bridge_processing_stw_step (void)
 static gboolean
 is_bridge_object_dead (GCObject *obj, void *data)
 {
-	SgenHashTable *table = data;
-	unsigned char *value = sgen_hash_table_lookup (table, obj);
+	SgenHashTable *table = (SgenHashTable *)data;
+	unsigned char *value = (unsigned char *)sgen_hash_table_lookup (table, obj);
 	if (!value)
 		return FALSE;
 	return !*value;
@@ -216,8 +216,8 @@ free_callback_data (SgenBridgeProcessor *processor)
 static int
 compare_xrefs (const void *a_ptr, const void *b_ptr)
 {
-	const MonoGCBridgeXRef *a = a_ptr;
-	const MonoGCBridgeXRef *b = b_ptr;
+	const MonoGCBridgeXRef *a = (const MonoGCBridgeXRef *)a_ptr;
+	const MonoGCBridgeXRef *b = (const MonoGCBridgeXRef *)b_ptr;
 
 	if (a->src_scc_index < b->src_scc_index)
 		return -1;
@@ -309,7 +309,7 @@ sgen_compare_bridge_processor_results (SgenBridgeProcessor *a, SgenBridgeProcess
 		gboolean new_entry;
 
 		g_assert (scc->num_objs > 0);
-		a_scc_index_ptr = sgen_hash_table_lookup (&obj_to_a_scc, scc->objs [0]);
+		a_scc_index_ptr = (int *)sgen_hash_table_lookup (&obj_to_a_scc, scc->objs [0]);
 		g_assert (a_scc_index_ptr);
 		a_scc_index = *a_scc_index_ptr;
 
@@ -319,7 +319,7 @@ sgen_compare_bridge_processor_results (SgenBridgeProcessor *a, SgenBridgeProcess
 		g_assert (a_scc->num_objs == scc->num_objs);
 
 		for (j = 1; j < scc->num_objs; ++j) {
-			a_scc_index_ptr = sgen_hash_table_lookup (&obj_to_a_scc, scc->objs [j]);
+			a_scc_index_ptr = (int *)sgen_hash_table_lookup (&obj_to_a_scc, scc->objs [j]);
 			g_assert (a_scc_index_ptr);
 			g_assert (*a_scc_index_ptr == a_scc_index);
 		}
@@ -339,8 +339,8 @@ sgen_compare_bridge_processor_results (SgenBridgeProcessor *a, SgenBridgeProcess
 	 */
 
 	xrefs_alloc_size = a->num_xrefs * sizeof (MonoGCBridgeXRef);
-	a_xrefs = sgen_alloc_internal_dynamic (xrefs_alloc_size, INTERNAL_MEM_BRIDGE_DEBUG, TRUE);
-	b_xrefs = sgen_alloc_internal_dynamic (xrefs_alloc_size, INTERNAL_MEM_BRIDGE_DEBUG, TRUE);
+	a_xrefs = (MonoGCBridgeXRef *)sgen_alloc_internal_dynamic (xrefs_alloc_size, INTERNAL_MEM_BRIDGE_DEBUG, TRUE);
+	b_xrefs = (MonoGCBridgeXRef *)sgen_alloc_internal_dynamic (xrefs_alloc_size, INTERNAL_MEM_BRIDGE_DEBUG, TRUE);
 
 	memcpy (a_xrefs, a->api_xrefs, xrefs_alloc_size);
 	for (i = 0; i < b->num_xrefs; ++i) {
@@ -349,11 +349,11 @@ sgen_compare_bridge_processor_results (SgenBridgeProcessor *a, SgenBridgeProcess
 
 		g_assert (xref->src_scc_index != xref->dst_scc_index);
 
-		scc_index_ptr = sgen_hash_table_lookup (&b_scc_to_a_scc, GINT_TO_POINTER (xref->src_scc_index));
+		scc_index_ptr = (int *)sgen_hash_table_lookup (&b_scc_to_a_scc, GINT_TO_POINTER (xref->src_scc_index));
 		g_assert (scc_index_ptr);
 		b_xrefs [i].src_scc_index = *scc_index_ptr;
 
-		scc_index_ptr = sgen_hash_table_lookup (&b_scc_to_a_scc, GINT_TO_POINTER (xref->dst_scc_index));
+		scc_index_ptr = (int *)sgen_hash_table_lookup (&b_scc_to_a_scc, GINT_TO_POINTER (xref->dst_scc_index));
 		g_assert (scc_index_ptr);
 		b_xrefs [i].dst_scc_index = *scc_index_ptr;
 	}

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -401,7 +401,7 @@ sgen_client_binary_protocol_block_free (gpointer addr, size_t size)
 }
 
 static void G_GNUC_UNUSED
-sgen_client_binary_protocol_block_set_state (gpointer addr, size_t size, int old, int new)
+sgen_client_binary_protocol_block_set_state (gpointer addr, size_t size, int old, int new_)
 {
 }
 

--- a/mono/metadata/sgen-os-posix.c
+++ b/mono/metadata/sgen-os-posix.c
@@ -246,7 +246,7 @@ sgen_os_init (void)
 		g_error ("failed sigaction");
 	}
 
-	sinfo.sa_handler = (void*) restart_handler;
+	sinfo.sa_handler = (void (*)(int))restart_handler;
 	if (sigaction (restart_signal_num, &sinfo, NULL) != 0) {
 		g_error ("failed sigaction");
 	}

--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -103,7 +103,7 @@ is_ip_in_managed_allocator (MonoDomain *domain, gpointer ip)
 	 * missing methods (#13951). To work around this, we disable the AOT fallback. For this to work, the JIT needs
 	 * to register the jit info for all GC critical methods after they are JITted/loaded.
 	 */
-	ji = mono_jit_info_table_find_internal (domain, ip, FALSE, FALSE);
+	ji = mono_jit_info_table_find_internal (domain, (char *)ip, FALSE, FALSE);
 	if (!ji)
 		return FALSE;
 
@@ -367,7 +367,7 @@ update_sgen_info (SgenThreadInfo *info)
 	char *stack_start;
 
 	/* Once we remove the old suspend code, we should move sgen to directly access the state in MonoThread */
-	info->client_info.stopped_domain = mono_thread_info_tls_get (info, TLS_KEY_DOMAIN);
+	info->client_info.stopped_domain = (MonoDomain *)mono_thread_info_tls_get (info, TLS_KEY_DOMAIN);
 	info->client_info.stopped_ip = (gpointer) MONO_CONTEXT_GET_IP (&mono_thread_info_get_suspend_state (info)->ctx);
 	stack_start = (char*)MONO_CONTEXT_GET_SP (&mono_thread_info_get_suspend_state (info)->ctx) - REDZONE_SIZE;
 

--- a/mono/metadata/sgen-tarjan-bridge.c
+++ b/mono/metadata/sgen-tarjan-bridge.c
@@ -88,7 +88,7 @@ dyn_array_ensure_capacity (DynArray *da, int capacity, int elem_size)
 	while (capacity > da->capacity)
 		da->capacity *= 2;
 
-	new_data = sgen_alloc_internal_dynamic (elem_size * da->capacity, INTERNAL_MEM_BRIDGE_DATA, TRUE);
+	new_data = (char *)sgen_alloc_internal_dynamic (elem_size * da->capacity, INTERNAL_MEM_BRIDGE_DATA, TRUE);
 	if (da->data) {
 		memcpy (new_data, da->data, elem_size * da->size);
 		sgen_free_internal_dynamic (da->data, elem_size * old_capacity, INTERNAL_MEM_BRIDGE_DATA);
@@ -137,7 +137,7 @@ dyn_array_ptr_get (DynPtrArray *da, int x)
 static void
 dyn_array_ptr_add (DynPtrArray *da, void *ptr)
 {
-	void **p = dyn_array_add (&da->array, sizeof (void*));
+	void **p = (void **)dyn_array_add (&da->array, sizeof (void*));
 	*p = ptr;
 }
 
@@ -276,7 +276,7 @@ static int object_data_count;
 static ObjectBucket*
 new_object_bucket (void)
 {
-	ObjectBucket *res = sgen_alloc_internal (INTERNAL_MEM_TARJAN_OBJ_BUCKET);
+	ObjectBucket *res = (ObjectBucket *)sgen_alloc_internal (INTERNAL_MEM_TARJAN_OBJ_BUCKET);
 	res->next_data = &res->data [0];
 	return res;
 }
@@ -340,7 +340,7 @@ static int color_data_count;
 static ColorBucket*
 new_color_bucket (void)
 {
-	ColorBucket *res = sgen_alloc_internal (INTERNAL_MEM_TARJAN_OBJ_BUCKET);
+	ColorBucket *res = (ColorBucket *)sgen_alloc_internal (INTERNAL_MEM_TARJAN_OBJ_BUCKET);
 	res->next_data = &res->data [0];
 	return res;
 }
@@ -724,7 +724,7 @@ reduce_color (void)
 	if (size == 0)
 		color = NULL;
 	else if (size == 1) {
-		color = dyn_array_ptr_get (&color_merge_array, 0);
+		color = (ColorData *)dyn_array_ptr_get (&color_merge_array, 0);
 	} else
 		color = new_color (FALSE);
 
@@ -740,7 +740,7 @@ create_scc (ScanData *data)
 	ColorData *color_data = NULL;
 
 	for (i = dyn_array_ptr_size (&loop_stack) - 1; i >= 0; --i) {
-		ScanData *other = dyn_array_ptr_get (&loop_stack, i);
+		ScanData *other = (ScanData *)dyn_array_ptr_get (&loop_stack, i);
 		found_bridge |= other->is_bridge;
 		if (found_bridge || other == data)
 			break;
@@ -769,7 +769,7 @@ create_scc (ScanData *data)
 	}
 
 	while (dyn_array_ptr_size (&loop_stack) > 0) {
-		ScanData *other = dyn_array_ptr_pop (&loop_stack);
+		ScanData *other = (ScanData *)dyn_array_ptr_pop (&loop_stack);
 
 #if DUMP_GRAPH
 		printf ("\tmember %s (%p) index %d low-index %d color %p state %d\n", safe_name_bridge (other->obj), other->obj, other->index, other->low_index, other->color, other->state);
@@ -797,7 +797,7 @@ create_scc (ScanData *data)
 	g_assert (found);
 
 	for (i = 0; i < dyn_array_ptr_size (&color_merge_array); ++i) {
-		ColorData *cd  = dyn_array_ptr_get (&color_merge_array, i);
+		ColorData *cd  = (ColorData *)dyn_array_ptr_get (&color_merge_array, i);
 		g_assert (cd->visited);
 		cd->visited = FALSE;
 	}
@@ -814,7 +814,7 @@ dfs (void)
 	dyn_array_ptr_set_size (&color_merge_array, 0);
 
 	while (dyn_array_ptr_size (&scan_stack) > 0) {
-		ScanData *data = dyn_array_ptr_pop (&scan_stack);
+		ScanData *data = (ScanData *)dyn_array_ptr_pop (&scan_stack);
 
 		/**
 		 * Ignore finished objects on stack, they happen due to loops. For example:
@@ -963,12 +963,12 @@ processing_stw_step (void)
 
 	bridge_count = dyn_array_ptr_size (&registered_bridges);
 	for (i = 0; i < bridge_count ; ++i)
-		register_bridge_object (dyn_array_ptr_get (&registered_bridges, i));
+		register_bridge_object ((GCObject *)dyn_array_ptr_get (&registered_bridges, i));
 
 	setup_time = step_timer (&curtime);
 
 	for (i = 0; i < bridge_count; ++i) {
-		ScanData *sd = find_data (dyn_array_ptr_get (&registered_bridges, i));
+		ScanData *sd = find_data ((GCObject *)dyn_array_ptr_get (&registered_bridges, i));
 		if (sd->state == INITIAL) {
 			dyn_array_ptr_push (&scan_stack, sd);
 			dfs ();
@@ -999,7 +999,7 @@ gather_xrefs (ColorData *color)
 {
 	int i;
 	for (i = 0; i < dyn_array_ptr_size (&color->other_colors); ++i) {
-		ColorData *src = dyn_array_ptr_get (&color->other_colors, i);
+		ColorData *src = (ColorData *)dyn_array_ptr_get (&color->other_colors, i);
 		if (src->visited)
 			continue;
 		src->visited = TRUE;
@@ -1015,7 +1015,7 @@ reset_xrefs (ColorData *color)
 {
 	int i;
 	for (i = 0; i < dyn_array_ptr_size (&color->other_colors); ++i) {
-		ColorData *src = dyn_array_ptr_get (&color->other_colors, i);
+		ColorData *src = (ColorData *)dyn_array_ptr_get (&color->other_colors, i);
 		if (!src->visited)
 			continue;
 		src->visited = FALSE;
@@ -1049,7 +1049,7 @@ processing_build_callback_data (int generation)
 #endif
 
 	/* This is a straightforward translation from colors to the bridge callback format. */
-	api_sccs = sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeSCC*) * num_colors_with_bridges, INTERNAL_MEM_BRIDGE_DATA, TRUE);
+	api_sccs = (MonoGCBridgeSCC **)sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeSCC*) * num_colors_with_bridges, INTERNAL_MEM_BRIDGE_DATA, TRUE);
 	api_index = xref_count = 0;
 
 	for (cur = root_color_bucket; cur; cur = cur->next) {
@@ -1059,14 +1059,14 @@ processing_build_callback_data (int generation)
 			if (!bridges)
 				continue;
 
-			api_sccs [api_index] = sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeSCC) + sizeof (MonoObject*) * bridges, INTERNAL_MEM_BRIDGE_DATA, TRUE);
+			api_sccs [api_index] = (MonoGCBridgeSCC *)sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeSCC) + sizeof (MonoObject*) * bridges, INTERNAL_MEM_BRIDGE_DATA, TRUE);
 			api_sccs [api_index]->is_alive = FALSE;
 			api_sccs [api_index]->num_objs = bridges;
 
 			cd->api_index = api_index;
 
 			for (j = 0; j < bridges; ++j)
-				api_sccs [api_index]->objs [j] = dyn_array_ptr_get (&cd->bridges, j);
+				api_sccs [api_index]->objs [j] = (MonoObject *)dyn_array_ptr_get (&cd->bridges, j);
 			api_index++;
 		}
 	}
@@ -1095,7 +1095,7 @@ processing_build_callback_data (int generation)
 	dump_color_table (" after xref pass", TRUE);
 #endif
 
-	api_xrefs = sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeXRef) * xref_count, INTERNAL_MEM_BRIDGE_DATA, TRUE);
+	api_xrefs = (MonoGCBridgeXRef *)sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeXRef) * xref_count, INTERNAL_MEM_BRIDGE_DATA, TRUE);
 	api_index = 0;
 	for (cur = root_color_bucket; cur; cur = cur->next) {
 		ColorData *src;
@@ -1105,7 +1105,7 @@ processing_build_callback_data (int generation)
 				continue;
 
 			for (j = 0; j < dyn_array_ptr_size (&src->other_colors); ++j) {
-				ColorData *dest = dyn_array_ptr_get (&src->other_colors, j);
+				ColorData *dest = (ColorData *)dyn_array_ptr_get (&src->other_colors, j);
 				g_assert (dyn_array_ptr_size (&dest->bridges)); /* We flattened the color graph, so this must never happen. */
 
 				api_xrefs [api_index].src_scc_index = src->api_index;

--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -142,7 +142,7 @@ ensure_toggleref_capacity (int capacity)
 {
 	if (!toggleref_array) {
 		toggleref_array_capacity = 32;
-		toggleref_array = sgen_alloc_internal_dynamic (
+		toggleref_array = (MonoGCToggleRef *)sgen_alloc_internal_dynamic (
 			toggleref_array_capacity * sizeof (MonoGCToggleRef),
 			INTERNAL_MEM_TOGGLEREF_DATA,
 			TRUE);
@@ -153,7 +153,7 @@ ensure_toggleref_capacity (int capacity)
 		while (toggleref_array_capacity < toggleref_array_size + capacity)
 			toggleref_array_capacity *= 2;
 
-		tmp = sgen_alloc_internal_dynamic (
+		tmp = (MonoGCToggleRef *)sgen_alloc_internal_dynamic (
 			toggleref_array_capacity * sizeof (MonoGCToggleRef),
 			INTERNAL_MEM_TOGGLEREF_DATA,
 			TRUE);
@@ -210,7 +210,7 @@ static MonoToggleRefStatus
 test_toggleref_callback (MonoObject *obj)
 {
 	static MonoClassField *mono_toggleref_test_field;
-	int status = MONO_TOGGLE_REF_DROP;
+	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
 	if (!mono_toggleref_test_field) {
 		mono_toggleref_test_field = mono_class_get_field_from_name (mono_object_get_class (obj), "__test");

--- a/mono/metadata/threadpool-ms-io-poll.c
+++ b/mono/metadata/threadpool-ms-io-poll.c
@@ -74,7 +74,7 @@ poll_register_fd (gint fd, gint events, gboolean is_new)
 		poll_fds_capacity *= 2;
 		g_assert (poll_fds_size <= poll_fds_capacity);
 
-		poll_fds = g_renew (mono_pollfd, poll_fds, poll_fds_capacity);
+		poll_fds = (mono_pollfd *)g_renew (mono_pollfd, poll_fds, poll_fds_capacity);
 	}
 
 	POLL_INIT_FD (&poll_fds [poll_fds_size - 1], fd, poll_event);

--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -203,12 +203,12 @@ static void
 filter_jobs_for_domain (gpointer key, gpointer value, gpointer user_data)
 {
 	FilterSockaresForDomainData *data;
-	MonoMList *list = value, *element;
+	MonoMList *list = (MonoMList *)value, *element;
 	MonoDomain *domain;
 	MonoGHashTable *states;
 
 	g_assert (user_data);
-	data = user_data;
+	data = (FilterSockaresForDomainData *)user_data;
 	domain = data->domain;
 	states = data->states;
 
@@ -259,7 +259,7 @@ wait_callback (gint fd, gint events, gpointer user_data)
 		gint operations;
 
 		g_assert (user_data);
-		states = user_data;
+		states = (MonoGHashTable *)user_data;
 
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_THREADPOOL, "io threadpool: cal fd %3d, events = %2s | %2s | %3s",
 			fd, (events & EVENT_IN) ? "RD" : "..", (events & EVENT_OUT) ? "WR" : "..", (events & EVENT_ERR) ? "ERR" : "...");
@@ -508,7 +508,7 @@ initialize (void)
 
 	mono_coop_mutex_init (&threadpool_io->updates_lock);
 	mono_coop_cond_init (&threadpool_io->updates_cond);
-	mono_gc_register_root ((void*)&threadpool_io->updates [0], sizeof (threadpool_io->updates), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_THREAD_POOL, "i/o thread pool updates list");
+	mono_gc_register_root ((char *)&threadpool_io->updates [0], sizeof (threadpool_io->updates), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_THREAD_POOL, "i/o thread pool updates list");
 
 	threadpool_io->updates_size = 0;
 

--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -40,7 +40,7 @@ is_long_stack_size (int type)
 static gboolean
 lower_load (MonoCompile *cfg, MonoInst *load, MonoInst *ldaddr)
 {
-	MonoInst *var = ldaddr->inst_p0;
+	MonoInst *var = (MonoInst *)ldaddr->inst_p0;
 	MonoType *type = &var->klass->byval_arg;
 	int replaced_op = mono_type_to_load_membase (cfg, type);
 
@@ -70,7 +70,7 @@ lower_load (MonoCompile *cfg, MonoInst *load, MonoInst *ldaddr)
 static gboolean
 lower_store (MonoCompile *cfg, MonoInst *store, MonoInst *ldaddr)
 {
-	MonoInst *var = ldaddr->inst_p0;
+	MonoInst *var = (MonoInst *)ldaddr->inst_p0;
 	MonoType *type = &var->klass->byval_arg;
 	int replaced_op = mono_type_to_store_membase (cfg, type);
 
@@ -101,7 +101,7 @@ lower_store (MonoCompile *cfg, MonoInst *store, MonoInst *ldaddr)
 static gboolean
 lower_store_imm (MonoCompile *cfg, MonoInst *store, MonoInst *ldaddr)
 {
-	MonoInst *var = ldaddr->inst_p0;
+	MonoInst *var = (MonoInst *)ldaddr->inst_p0;
 	MonoType *type = &var->klass->byval_arg;
 	int store_op = mono_type_to_store_membase (cfg, type);
 	if (store_op == OP_STOREV_MEMBASE || store_op == OP_STOREX_MEMBASE)
@@ -195,7 +195,7 @@ handle_instruction:
 			case OP_LOADR8_MEMBASE:
 				if (ins->inst_offset != 0)
 					continue;
-				tmp = g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->sreg1));
+				tmp = (MonoInst *)g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->sreg1));
 				if (tmp) {
 					if (cfg->verbose_level > 2) { printf ("Found candidate load:"); mono_print_ins (ins); }
 					if (lower_load (cfg, ins, tmp)) {
@@ -216,7 +216,7 @@ handle_instruction:
 			case OP_STOREV_MEMBASE:
 				if (ins->inst_offset != 0)
 					continue;
-				tmp = g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->dreg));
+				tmp = (MonoInst *)g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->dreg));
 				if (tmp) {
 					if (cfg->verbose_level > 2) { printf ("Found candidate store:"); mono_print_ins (ins); }
 					if (lower_store (cfg, ins, tmp)) {
@@ -232,7 +232,7 @@ handle_instruction:
 			case OP_STOREI8_MEMBASE_IMM:
 				if (ins->inst_offset != 0)
 					continue;
-				tmp = g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->dreg));
+				tmp = (MonoInst *)g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->dreg));
 				if (tmp) {
 					if (cfg->verbose_level > 2) { printf ("Found candidate store-imm:"); mono_print_ins (ins); }
 					needs_dce |= lower_store_imm (cfg, ins, tmp);
@@ -240,7 +240,7 @@ handle_instruction:
 				break;
 			case OP_CHECK_THIS:
 			case OP_NOT_NULL:
-				tmp = g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->sreg1));
+				tmp = (MonoInst *)g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->sreg1));
 				if (tmp) {
 					if (cfg->verbose_level > 2) { printf ("Found null check over local: "); mono_print_ins (ins); }
 					NULLIFY_INS (ins);

--- a/mono/mini/branch-opts.c
+++ b/mono/mini/branch-opts.c
@@ -85,7 +85,7 @@ mono_branch_optimize_exception_target (MonoCompile *cfg, MonoBasicBlock *bb, con
 						MONO_INST_NEW (cfg, jump, OP_BR);
 
 						/* Allocate memory for our branch target */
-						jump->inst_i1 = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst));
+						jump->inst_i1 = (MonoInst *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst));
 						jump->inst_true_bb = targetbb;
 
 						if (cfg->verbose_level > 2) 
@@ -851,7 +851,7 @@ replace_out_block_in_code (MonoBasicBlock *bb, MonoBasicBlock *orig, MonoBasicBl
 					ins->inst_false_bb = repl;
 			} else if (MONO_IS_JUMP_TABLE (ins)) {
 				int i;
-				MonoJumpInfoBBTable *table = MONO_JUMP_TABLE_FROM_INS (ins);
+				MonoJumpInfoBBTable *table = (MonoJumpInfoBBTable *)MONO_JUMP_TABLE_FROM_INS (ins);
 				for (i = 0; i < table->table_size; i++ ) {
 					if (table->table [i] == orig)
 						table->table [i] = repl;
@@ -995,7 +995,7 @@ mono_merge_basic_blocks (MonoCompile *cfg, MonoBasicBlock *bb, MonoBasicBlock *b
 		for (inst = bb->code; inst != NULL; inst = inst->next) {
 			if (MONO_IS_JUMP_TABLE (inst)) {
 				int i;
-				MonoJumpInfoBBTable *table = MONO_JUMP_TABLE_FROM_INS (inst);
+				MonoJumpInfoBBTable *table = (MonoJumpInfoBBTable *)MONO_JUMP_TABLE_FROM_INS (inst);
 				for (i = 0; i < table->table_size; i++ ) {
 					/* Might be already NULL from a previous merge */
 					if (table->table [i])
@@ -1137,7 +1137,7 @@ mono_remove_critical_edges (MonoCompile *cfg)
 				 * overwrite the sreg1 of the ins.
 				 */
 				if ((in_bb->out_count > 1) || (in_bb->out_count == 1 && in_bb->last_ins && in_bb->last_ins->opcode == OP_BR_REG)) {
-					MonoBasicBlock *new_bb = mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
+					MonoBasicBlock *new_bb = (MonoBasicBlock *)mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
 					new_bb->block_num = cfg->num_bblocks++;
 //					new_bb->real_offset = bb->real_offset;
 					new_bb->region = bb->region;
@@ -1161,7 +1161,7 @@ mono_remove_critical_edges (MonoCompile *cfg)
 							/* We cannot add any inst to the entry BB, so we must */
 							/* put a new BB in the middle to hold the OP_BR */
 							MonoInst *jump;
-							MonoBasicBlock *new_bb_after_entry = mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
+							MonoBasicBlock *new_bb_after_entry = (MonoBasicBlock *)mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
 							new_bb_after_entry->block_num = cfg->num_bblocks++;
 //							new_bb_after_entry->real_offset = bb->real_offset;
 							new_bb_after_entry->region = bb->region;
@@ -1190,10 +1190,10 @@ mono_remove_critical_edges (MonoCompile *cfg)
 					previous_bb = new_bb;
 					
 					/* Setup in_bb and out_bb */
-					new_bb->in_bb = mono_mempool_alloc ((cfg)->mempool, sizeof (MonoBasicBlock*));
+					new_bb->in_bb = (MonoBasicBlock **)mono_mempool_alloc ((cfg)->mempool, sizeof (MonoBasicBlock*));
 					new_bb->in_bb [0] = in_bb;
 					new_bb->in_count = 1;
-					new_bb->out_bb = mono_mempool_alloc ((cfg)->mempool, sizeof (MonoBasicBlock*));
+					new_bb->out_bb = (MonoBasicBlock **)mono_mempool_alloc ((cfg)->mempool, sizeof (MonoBasicBlock*));
 					new_bb->out_bb [0] = bb;
 					new_bb->out_count = 1;
 					

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -451,7 +451,7 @@ mono_debug_serialize_debug_info (MonoCompile *cfg, guint8 **out_buf, guint32 *bu
 	}
 
 	size = ((jit->num_params + jit->num_locals + 1) * 10) + (jit->num_line_numbers * 10) + 64;
-	p = buf = g_malloc (size);
+	p = buf = (guint8 *)g_malloc (size);
 	encode_value (jit->epilogue_begin, p, &p);
 	encode_value (jit->prologue_end, p, &p);
 	encode_value (jit->code_size, p, &p);
@@ -650,7 +650,7 @@ void
 mono_debug_print_vars (gpointer ip, gboolean only_arguments)
 {
 	MonoDomain *domain = mono_domain_get ();
-	MonoJitInfo *ji = mono_jit_info_table_find (domain, ip);
+	MonoJitInfo *ji = mono_jit_info_table_find (domain, (char *)ip);
 	MonoDebugMethodJitInfo *jit;
 	int i;
 
@@ -730,7 +730,7 @@ mono_debugger_method_has_breakpoint (MonoMethod *method)
 		return 0;
 
 	for (i = 0; i < breakpoints->len; i++) {
-		MiniDebugBreakpointInfo *info = g_ptr_array_index (breakpoints, i);
+		MiniDebugBreakpointInfo *info = (MiniDebugBreakpointInfo *)g_ptr_array_index (breakpoints, i);
 
 		if (!mono_method_desc_full_match (info->desc, method))
 			continue;

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -539,7 +539,7 @@ mono_decompose_opcode (MonoCompile *cfg, MonoInst *ins)
 			g_assert (!info->sig->hasthis);
 			g_assert (info->sig->param_count <= MONO_MAX_SRC_REGS);
 
-			args = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * info->sig->param_count);
+			args = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * info->sig->param_count);
 			if (info->sig->param_count > 0) {
 				int sregs [MONO_MAX_SRC_REGS];
 				int num_sregs, i;
@@ -1197,7 +1197,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 	 * Create a dummy bblock and emit code into it so we can use the normal 
 	 * code generation macros.
 	 */
-	cfg->cbb = mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
+	cfg->cbb = (MonoBasicBlock *)mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
 	first_bb = cfg->cbb;
 
 	/* For LLVM, decompose only the OP_STOREV_MEMBASE opcodes, which need write barriers and the gsharedvt opcodes */
@@ -1489,7 +1489,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 	 * Create a dummy bblock and emit code into it so we can use the normal 
 	 * code generation macros.
 	 */
-	cfg->cbb = mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
+	cfg->cbb = (MonoBasicBlock *)mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock));
 	first_bb = cfg->cbb;
 
 	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {

--- a/mono/mini/dominators.c
+++ b/mono/mini/dominators.c
@@ -117,7 +117,7 @@ compute_dominators (MonoCompile *cfg)
 		MonoBitSet *dominators;
 		char *mem;
 
-		mem = mono_mempool_alloc0 (cfg->mempool, bitsize);
+		mem = (char *)mono_mempool_alloc0 (cfg->mempool, bitsize);
 
 		bb->dominators = dominators = mono_bitset_mem_new (mem, cfg->num_bblocks, 0);
 		mem += bitsize;
@@ -199,7 +199,7 @@ compute_dominance_frontier (MonoCompile *cfg)
 		cfg->bblocks [i]->flags &= ~BB_VISITED;
 
 	bitsize = mono_bitset_alloc_size (cfg->num_bblocks, 0);
-	mem = mono_mempool_alloc0 (cfg->mempool, bitsize * cfg->num_bblocks);
+	mem = (char *)mono_mempool_alloc0 (cfg->mempool, bitsize * cfg->num_bblocks);
  
 	for (i = 0; i < cfg->num_bblocks; ++i) {
 		MonoBasicBlock *bb = cfg->bblocks [i];
@@ -332,7 +332,7 @@ mono_compute_natural_loops (MonoCompile *cfg)
 					GList *l;
 
 					for (l = h->loop_blocks; l; l = l->next) {
-						MonoBasicBlock *b = l->data;
+						MonoBasicBlock *b = (MonoBasicBlock *)l->data;
 						if (b->dfn)
 							mono_bitset_set_fast (in_loop_blocks, b->dfn);
 					}

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -392,7 +392,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 				if (verbose >= 2)
 					g_print ("Running '%s' ...\n", method->name);
 #ifdef MONO_USE_AOT_COMPILER
-				if ((func = mono_aot_get_method (mono_get_root_domain (), method)))
+				if ((func = (TestMethod)mono_aot_get_method (mono_get_root_domain (), method)))
 					;
 				else
 #endif
@@ -497,7 +497,7 @@ mini_regression (MonoImage *image, int verbose, int *total_run)
 		for (iter = mono_single_method_list; iter; iter = g_slist_next (iter)) {
 			char *method_name;
 
-			mono_current_single_method = iter->data;
+			mono_current_single_method = (MonoMethod *)iter->data;
 
 			method_name = mono_method_full_name (mono_current_single_method, TRUE);
 			g_print ("Current single method: %s\n", method_name);
@@ -934,7 +934,7 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 			g_print ("Compiling %d %s\n", count, desc);
 			g_free (desc);
 		}
-		cfg = mini_method_compile (method, mono_get_optimizations_for_method (method, args->opts), mono_get_root_domain (), 0, 0, -1);
+		cfg = mini_method_compile (method, mono_get_optimizations_for_method (method, args->opts), mono_get_root_domain (), (JitFlags)0, 0, -1);
 		if (cfg->exception_type != MONO_EXCEPTION_NONE) {
 			printf ("Compilation of %s failed with exception '%s':\n", mono_method_full_name (cfg->method, TRUE), cfg->exception_message);
 			fail_count ++;
@@ -1017,7 +1017,7 @@ typedef struct
 
 static void main_thread_handler (gpointer user_data)
 {
-	MainThreadArgs *main_args = user_data;
+	MainThreadArgs *main_args = (MainThreadArgs *)user_data;
 	MonoAssembly *assembly;
 
 	if (mono_compile_aot) {
@@ -1079,7 +1079,7 @@ load_agent (MonoDomain *domain, char *desc)
 	MonoImageOpenStatus open_status;
 
 	if (col) {
-		agent = g_memdup (desc, col - desc + 1);
+		agent = (char *)g_memdup (desc, col - desc + 1);
 		agent [col - desc] = '\0';
 		args = col + 1;
 	} else {
@@ -1435,7 +1435,7 @@ mono_set_use_smp (int use_smp)
 #ifdef GLIBC_BEFORE_2_3_4_SCHED_SETAFFINITY
 		sched_setaffinity (getpid(), (gpointer)&proc_mask);
 #else
-		sched_setaffinity (getpid(), sizeof (unsigned long), (gpointer)&proc_mask);
+		sched_setaffinity (getpid(), sizeof (unsigned long), (const cpu_set_t *)&proc_mask);
 #endif
 	}
 #endif
@@ -1520,7 +1520,7 @@ mono_main (int argc, char* argv[])
 	char *config_file = NULL;
 	int i, count = 1;
 	guint32 opt, action = DO_EXEC, recompilation_times = 1;
-	MonoGraphOptions mono_graph_options = 0;
+	MonoGraphOptions mono_graph_options = (MonoGraphOptions)0;
 	int mini_verbose = 0;
 	gboolean enable_profile = FALSE;
 	char *trace_options = NULL;
@@ -2113,10 +2113,10 @@ mono_main (int argc, char* argv[])
 			(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {
 			MonoMethod *nm;
 			nm = mono_marshal_get_native_wrapper (method, TRUE, FALSE);
-			cfg = mini_method_compile (nm, opt, mono_get_root_domain (), 0, part, -1);
+			cfg = mini_method_compile (nm, opt, mono_get_root_domain (), (JitFlags)0, part, -1);
 		}
 		else
-			cfg = mini_method_compile (method, opt, mono_get_root_domain (), 0, part, -1);
+			cfg = mini_method_compile (method, opt, mono_get_root_domain (), (JitFlags)0, part, -1);
 		if ((mono_graph_options & MONO_GRAPH_CFG_SSA) && !(cfg->comp_done & MONO_COMP_SSA)) {
 			g_warning ("no SSA info available (use -O=deadce)");
 			return 1;
@@ -2148,7 +2148,7 @@ mono_main (int argc, char* argv[])
 				opt = opt_sets [i];
 				g_timer_start (timer);
 				for (j = 0; j < count; ++j) {
-					cfg = mini_method_compile (method, opt, mono_get_root_domain (), 0, 0, -1);
+					cfg = mini_method_compile (method, opt, mono_get_root_domain (), (JitFlags)0, 0, -1);
 					mono_destroy_compile (cfg);
 				}
 				g_timer_stop (timer);
@@ -2171,12 +2171,12 @@ mono_main (int argc, char* argv[])
 					(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 					method = mono_marshal_get_native_wrapper (method, TRUE, FALSE);
 
-				cfg = mini_method_compile (method, opt, mono_get_root_domain (), 0, 0, -1);
+				cfg = mini_method_compile (method, opt, mono_get_root_domain (), (JitFlags)0, 0, -1);
 				mono_destroy_compile (cfg);
 			}
 		}
 	} else {
-		cfg = mini_method_compile (method, opt, mono_get_root_domain (), 0, 0, -1);
+		cfg = mini_method_compile (method, opt, mono_get_root_domain (), (JitFlags)0, 0, -1);
 		mono_destroy_compile (cfg);
 	}
 #endif
@@ -2357,7 +2357,7 @@ mono_parse_env_options (int *ref_argc, char **ref_argv [])
 			
 			/* First the environment variable settings, to allow the command line options to override */
 			for (i = 0; i < array->len; i++)
-				new_argv [i+1] = g_ptr_array_index (array, i);
+				new_argv [i+1] = (char *)g_ptr_array_index (array, i);
 			i++;
 			for (j = 1; j < argc; j++)
 				new_argv [i++] = argv [j];

--- a/mono/mini/genmdesc.c
+++ b/mono/mini/genmdesc.c
@@ -99,7 +99,7 @@ load_file (const char *name) {
 			is_template = TRUE;
 			desc = g_new0 (OpDesc, 1);
 		} else {
-			desc = g_hash_table_lookup (table, str);
+			desc = (OpDesc *)g_hash_table_lookup (table, str);
 			if (!desc)
 				g_error ("Invalid opcode '%s' at line %d in %s\n", str, line, name);
 			if (desc->desc)
@@ -165,7 +165,7 @@ load_file (const char *name) {
 				tname = p;
 				while (*p && isalnum (*p)) ++p;
 				*p++ = 0;
-				tdesc = g_hash_table_lookup (template_table, tname);
+				tdesc = (OpDesc *)g_hash_table_lookup (template_table, tname);
 				if (!tdesc)
 					g_error ("Invalid template name %s at '%s' at line %d in %s\n", tname, p, line, name);
 				for (i = 0; i < MONO_INST_MAX; ++i) {

--- a/mono/mini/graph.c
+++ b/mono/mini/graph.c
@@ -20,7 +20,7 @@ static char *
 convert_name (const char *str)
 {
 	int i, j, len = strlen (str);
-	char *res = g_malloc (len * 2);
+	char *res = (char *)g_malloc (len * 2);
 
 	j = 0;
 	for (i = 0; i < len; i++) {

--- a/mono/mini/image-writer.c
+++ b/mono/mini/image-writer.c
@@ -324,7 +324,7 @@ bin_writer_emit_ensure_buffer (BinSection *section, int size)
 		guint8 *data;
 		while (new_size <= new_offset)
 			new_size *= 2;
-		data = g_malloc0 (new_size);
+		data = (guint8 *)g_malloc0 (new_size);
 #ifdef __native_client_codegen__
 		/* for Native Client, fill empty space with HLT instruction */
 		/* instead of 00.                                           */
@@ -448,7 +448,7 @@ static BinReloc*
 create_reloc (MonoImageWriter *acfg, const char *end, const char* start, int offset)
 {
 	BinReloc *reloc;
-	reloc = mono_mempool_alloc0 (acfg->mempool, sizeof (BinReloc));
+	reloc = (BinReloc *)mono_mempool_alloc0 (acfg->mempool, sizeof (BinReloc));
 	reloc->val1 = mono_mempool_strdup (acfg->mempool, end);
 	if (strcmp (start, ".") == 0) {
 		reloc->val2_section = acfg->cur_section;
@@ -899,7 +899,7 @@ get_label_addr (MonoImageWriter *acfg, const char *name)
 	BinSection *section;
 	gsize value;
 
-	lab = g_hash_table_lookup (acfg->labels, name);
+	lab = (BinLabel *)g_hash_table_lookup (acfg->labels, name);
 	if (!lab)
 		g_error ("Undefined label: '%s'.\n", name);
 	section = lab->section;
@@ -982,7 +982,7 @@ collect_syms (MonoImageWriter *acfg, int *hash, ElfStrTable *strtab, ElfSectHead
 		/*g_print ("sym name %s tabled to %d\n", symbol->name, symbols [i].st_name);*/
 		section = symbol->section;
 		symbols [i].st_shndx = section->parent? section->parent->shidx: section->shidx;
-		lab = g_hash_table_lookup (acfg->labels, symbol->name);
+		lab = (BinLabel *)g_hash_table_lookup (acfg->labels, symbol->name);
 		offset = lab->offset;
 		if (section->parent) {
 			symbols [i].st_value = section->parent->virt_offset + section->cur_offset + offset;
@@ -991,7 +991,7 @@ collect_syms (MonoImageWriter *acfg, int *hash, ElfStrTable *strtab, ElfSectHead
 		}
 
 		if (symbol->end_label) {
-			BinLabel *elab = g_hash_table_lookup (acfg->labels, symbol->end_label);
+			BinLabel *elab = (BinLabel *)g_hash_table_lookup (acfg->labels, symbol->end_label);
 			g_assert (elab);
 			symbols [i].st_size = elab->offset - lab->offset;
 		}
@@ -1063,7 +1063,7 @@ reloc_symbols (MonoImageWriter *acfg, ElfSymbol *symbols, ElfSectHeader *sheader
 		if (dynamic && !symbol->is_global)
 			continue;
 		section = symbol->section;
-		lab = g_hash_table_lookup (acfg->labels, symbol->name);
+		lab = (BinLabel *)g_hash_table_lookup (acfg->labels, symbol->name);
 		offset = lab->offset;
 		if (section->parent) {
 			symbols [i].st_value = sheaders [section->parent->shidx].sh_addr + section->cur_offset + offset;
@@ -1615,7 +1615,7 @@ bin_writer_emit_writeout (MonoImageWriter *acfg)
 
 	if (!acfg->fp) {
 		acfg->out_buf_size = file_offset + sizeof (secth);
-		acfg->out_buf = g_malloc (acfg->out_buf_size);
+		acfg->out_buf = (guint8 *)g_malloc (acfg->out_buf_size);
 	}
 
 	bin_writer_fwrite (acfg, &header, sizeof (header), 1);

--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -106,7 +106,7 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
  * JIT code still uses the left and right fields, so it has to stay.
  */
 #define MONO_INST_NEW(cfg,dest,op) do {	\
-		(dest) = mono_mempool_alloc ((cfg)->mempool, sizeof (MonoInst));	\
+		(dest) = (MonoInst *)mono_mempool_alloc ((cfg)->mempool, sizeof (MonoInst));	\
 		(dest)->inst_c0 = (dest)->inst_c1 = 0; \
 		(dest)->next = (dest)->prev = NULL;    \
 		(dest)->opcode = (op);	\
@@ -230,7 +230,7 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 #define NEW_AOTCONST(cfg,dest,patch_type,cons) do {    \
         MONO_INST_NEW ((cfg), (dest), cfg->compile_aot ? OP_AOTCONST : OP_PCONST); \
 		(dest)->inst_p0 = (cons);	\
-		(dest)->inst_i1 = (gpointer)(patch_type); \
+		(dest)->inst_i1 = (MonoInst *)(patch_type); \
 		(dest)->type = STACK_PTR;	\
 		(dest)->dreg = alloc_dreg ((cfg), STACK_PTR);	\
     } while (0)
@@ -311,7 +311,7 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 		type_to_eval_stack_type ((cfg), (vartype), (dest));	\
 		(dest)->klass = var->klass;	\
 		(dest)->sreg1 = var->dreg;   \
-        (dest)->dreg = alloc_dreg ((cfg), (dest)->type); \
+        (dest)->dreg = alloc_dreg ((cfg), (MonoStackType)(dest)->type); \
         if ((dest)->opcode == OP_VMOVE) (dest)->klass = mono_class_from_mono_type ((vartype)); \
 	} while (0)
 
@@ -373,7 +373,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
         (dest)->type = STACK_MP; \
 	    (dest)->klass = cfg->ret->klass;	\
 	    (dest)->sreg1 = cfg->vret_addr->dreg;   \
-        (dest)->dreg = alloc_dreg ((cfg), (dest)->type); \
+        (dest)->dreg = alloc_dreg ((cfg), (MonoStackType)(dest)->type); \
 	} while (0)
 
 #define NEW_ARGLOADA(cfg,dest,num) NEW_VARLOADA ((cfg), (dest), arg_array [(num)], param_types [(num)])
@@ -395,7 +395,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
 #define NEW_LOAD_MEMBASE_TYPE(cfg,dest,ltype,base,offset) do { \
 	    NEW_LOAD_MEMBASE ((cfg), (dest), mono_type_to_load_membase ((cfg), (ltype)), 0, (base), (offset)); \
 	    type_to_eval_stack_type ((cfg), (ltype), (dest)); \
-	    (dest)->dreg = alloc_dreg ((cfg), (dest)->type); \
+	    (dest)->dreg = alloc_dreg ((cfg), (MonoStackType)(dest)->type); \
     } while (0)
 
 #define NEW_STORE_MEMBASE_TYPE(cfg,dest,ltype,base,offset,sr) do { \
@@ -743,7 +743,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
  * block_num: unique ID assigned at bblock creation
  */
 #define NEW_BBLOCK(cfg,bblock) do { \
-	(bblock) = mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock)); \
+	(bblock) = (MonoBasicBlock *)mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoBasicBlock)); \
 	(bblock)->block_num = cfg->num_bblocks++; \
     } while (0)
 
@@ -796,7 +796,7 @@ static int ccount = 0;
             MONO_ADD_INS ((cfg)->cbb, ins); \
             MONO_START_BB ((cfg), falsebb); \
         } else { \
-		    ins->inst_many_bb = mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);	\
+		    ins->inst_many_bb = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);	\
             ins->inst_true_bb = (truebb); \
             ins->inst_false_bb = NULL; \
             mono_link_bblock ((cfg), (cfg)->cbb, (truebb)); \
@@ -817,7 +817,7 @@ static int ccount = 0;
 #define	MONO_EMIT_NEW_BRANCH_BLOCK2(cfg,op,truebb,falsebb) do { \
         MonoInst *ins; \
         MONO_INST_NEW ((cfg), (ins), (op)); \
-		ins->inst_many_bb = mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);	\
+		ins->inst_many_bb = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);	\
         ins->inst_true_bb = (truebb); \
         ins->inst_false_bb = (falsebb); \
         mono_link_bblock ((cfg), (cfg)->cbb, (truebb)); \

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -671,14 +671,14 @@ mono_array_new_va (MonoMethod *cm, ...)
 
 	va_start (ap, cm);
 	
-	lengths = alloca (sizeof (uintptr_t) * pcount);
+	lengths = (uintptr_t *)alloca (sizeof (uintptr_t) * pcount);
 	for (i = 0; i < pcount; ++i)
 		lengths [i] = d = va_arg(ap, int);
 
 	if (rank == pcount) {
 		/* Only lengths provided. */
 		if (cm->klass->byval_arg.type == MONO_TYPE_ARRAY) {
-			lower_bounds = alloca (sizeof (intptr_t) * rank);
+			lower_bounds = (intptr_t *)alloca (sizeof (intptr_t) * rank);
 			memset (lower_bounds, 0, sizeof (intptr_t) * rank);
 		} else {
 			lower_bounds = NULL;
@@ -712,7 +712,7 @@ mono_array_new_1 (MonoMethod *cm, guint32 length)
 	g_assert (rank == pcount);
 
 	if (cm->klass->byval_arg.type == MONO_TYPE_ARRAY) {
-		lower_bounds = alloca (sizeof (intptr_t) * rank);
+		lower_bounds = (intptr_t *)alloca (sizeof (intptr_t) * rank);
 		memset (lower_bounds, 0, sizeof (intptr_t) * rank);
 	} else {
 		lower_bounds = NULL;
@@ -739,7 +739,7 @@ mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2)
 	g_assert (rank == pcount);
 
 	if (cm->klass->byval_arg.type == MONO_TYPE_ARRAY) {
-		lower_bounds = alloca (sizeof (intptr_t) * rank);
+		lower_bounds = (intptr_t *)alloca (sizeof (intptr_t) * rank);
 		memset (lower_bounds, 0, sizeof (intptr_t) * rank);
 	} else {
 		lower_bounds = NULL;
@@ -767,7 +767,7 @@ mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 	g_assert (rank == pcount);
 
 	if (cm->klass->byval_arg.type == MONO_TYPE_ARRAY) {
-		lower_bounds = alloca (sizeof (intptr_t) * rank);
+		lower_bounds = (intptr_t *)alloca (sizeof (intptr_t) * rank);
 		memset (lower_bounds, 0, sizeof (intptr_t) * rank);
 	} else {
 		lower_bounds = NULL;
@@ -796,7 +796,7 @@ mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 	g_assert (rank == pcount);
 
 	if (cm->klass->byval_arg.type == MONO_TYPE_ARRAY) {
-		lower_bounds = alloca (sizeof (intptr_t) * rank);
+		lower_bounds = (intptr_t *)alloca (sizeof (intptr_t) * rank);
 		memset (lower_bounds, 0, sizeof (intptr_t) * rank);
 	} else {
 		lower_bounds = NULL;
@@ -1119,7 +1119,7 @@ mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass)
 	MonoClass *oklass;
 
 	if (mini_get_debug_options ()->better_cast_details) {
-		jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+		jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 		jit_tls->class_cast_from = NULL;
 	}
 
@@ -1150,7 +1150,7 @@ mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *c
 	gpointer cached_vtable, obj_vtable;
 
 	if (mini_get_debug_options ()->better_cast_details) {
-		jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+		jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 		jit_tls->class_cast_from = NULL;
 	}
 
@@ -1388,7 +1388,7 @@ mono_resolve_iface_call (MonoObject *this_obj, int imt_slot, MonoMethod *imt_met
 		/*
 		 * The exact compiled method might not be shared so it doesn't have an rgctx arg.
 		 */
-		ji = mini_jit_info_table_find (mono_domain_get (), compiled_method, NULL);
+		ji = mini_jit_info_table_find (mono_domain_get (), (char *)compiled_method, NULL);
 		if (!ji || (ji && ji->has_generic_jit_info)) {
 			if (m->wrapper_type == MONO_WRAPPER_MANAGED_TO_MANAGED && m->klass->rank && strstr (m->name, "System.Collections.Generic"))
 				m = mono_aot_get_array_helper_from_wrapper (m);

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -195,9 +195,9 @@ gpointer mono_fill_class_rgctx (MonoVTable *vtable, int index);
 
 gpointer mono_fill_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, int index);
 
-gpointer mono_resolve_iface_call (MonoObject *this, int imt_slot, MonoMethod *imt_method, gpointer *out_rgctx_arg);
+gpointer mono_resolve_iface_call (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_rgctx_arg);
 
-gpointer mono_resolve_vcall (MonoObject *this, int slot, MonoMethod *imt_method);
+gpointer mono_resolve_vcall (MonoObject *this_obj, int slot, MonoMethod *imt_method);
 
 void mono_init_delegate (MonoDelegate *del, MonoObject *target, MonoMethod *method);
 

--- a/mono/mini/linear-scan.c
+++ b/mono/mini/linear-scan.c
@@ -23,7 +23,7 @@ mono_varlist_insert_sorted (MonoCompile *cfg, GList *list, MonoMethodVar *mv, in
 		return g_list_prepend (NULL, mv);
 
 	for (l = list; l; l = l->next) {
-		MonoMethodVar *v1 = l->data;
+		MonoMethodVar *v1 = (MonoMethodVar *)l->data;
 		
 		if (sort_type == 2) {
 			if (mv->spill_costs >= v1->spill_costs) {
@@ -108,7 +108,7 @@ mono_linear_scan (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_ma
 
 	/* linear scan */
 	for (l = vars; l; l = l->next) {
-		vmv = l->data;
+		vmv = (MonoMethodVar *)l->data;
 
 #ifdef DEBUG_LSCAN
 		printf ("START  %2d %08x %08x\n",  vmv->idx, vmv->range.first_use.abs_pos, 
@@ -199,7 +199,7 @@ mono_linear_scan (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_ma
 
 	n_regvars = 0;
 	for (l = vars; l; l = l->next) {
-		vmv = l->data;
+		vmv = (MonoMethodVar *)l->data;
 		
 		if (vmv->reg >= 0)  {
 			if ((gains [vmv->reg] > mono_arch_regalloc_cost (cfg, vmv)) && (cfg->varinfo [vmv->idx]->opcode != OP_REGVAR)) {
@@ -227,7 +227,7 @@ mono_linear_scan (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_ma
 	/* Compute used regs */
 	used_regs = 0;
 	for (l = vars; l; l = l->next) {
-		vmv = l->data;
+		vmv = (MonoMethodVar *)l->data;
 		
 		if (vmv->reg >= 0)
 			used_regs |= 1LL << vmv->reg;
@@ -288,7 +288,7 @@ mono_linear_scan2 (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_m
 	int n_regs, n_regvars, i;
 
 	for (l = vars; l; l = l->next) {
-		vmv = l->data;
+		vmv = (MonoMethodVar *)l->data;
 		LSCAN_DEBUG (printf ("VAR R%d %08x %08x C%d\n", cfg->varinfo [vmv->idx]->dreg, vmv->range.first_use.abs_pos, 
 							 vmv->range.last_use.abs_pos, vmv->spill_costs));
 	}
@@ -302,7 +302,7 @@ mono_linear_scan2 (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_m
 	inactive = NULL;
 
 	while (unhandled) {
-		MonoMethodVar *current = unhandled->data;
+		MonoMethodVar *current = (MonoMethodVar *)unhandled->data;
 		int pos, reg, max_free_pos;
 		gboolean changed;
 
@@ -470,7 +470,7 @@ mono_linear_scan2 (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_m
 	/* Do the actual register assignment */
 	n_regvars = 0;
 	for (l = vars; l; l = l->next) {
-		vmv = l->data;
+		vmv = (MonoMethodVar *)l->data;
 
 		if (vmv->reg >= 0) {
 			int reg_index = vmv->reg;
@@ -498,7 +498,7 @@ mono_linear_scan2 (MonoCompile *cfg, GList *vars, GList *regs, regmask_t *used_m
 	/* Compute used regs */
 	used_regs = 0;
 	for (l = vars; l; l = l->next) {
-		vmv = l->data;
+		vmv = (MonoMethodVar *)l->data;
 		
 		if (vmv->reg >= 0)
 			used_regs |= 1LL << vmv->reg;

--- a/mono/mini/liveness.c
+++ b/mono/mini/liveness.c
@@ -44,14 +44,14 @@ optimize_initlocals (MonoCompile *cfg);
 static inline MonoBitSet* 
 mono_bitset_mp_new (MonoMemPool *mp, guint32 size, guint32 max_size)
 {
-	guint8 *mem = mono_mempool_alloc0 (mp, size);
+	guint8 *mem = (guint8 *)mono_mempool_alloc0 (mp, size);
 	return mono_bitset_mem_new (mem, max_size, MONO_BITSET_DONT_FREE);
 }
 
 static inline MonoBitSet* 
 mono_bitset_mp_new_noinit (MonoMemPool *mp, guint32 size, guint32 max_size)
 {
-	guint8 *mem = mono_mempool_alloc (mp, size);
+	guint8 *mem = (guint8 *)mono_mempool_alloc (mp, size);
 	return mono_bitset_mem_new (mem, max_size, MONO_BITSET_DONT_FREE);
 }
 
@@ -154,7 +154,7 @@ mono_liveness_handle_exception_clauses (MonoCompile *cfg)
 	 * Determine which clauses are outer try clauses, i.e. they are not contained in any
 	 * other non-try clause.
 	 */
-	outer_try = mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * header->num_clauses);
+	outer_try = (gboolean *)mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * header->num_clauses);
 	for (i = 0; i < header->num_clauses; ++i)
 		outer_try [i] = TRUE;
 	/* Iterate over the clauses backward, so outer clauses come first */
@@ -238,7 +238,7 @@ analyze_liveness_bb (MonoCompile *cfg, MonoBasicBlock *bb)
 			continue;
 
 		if (ins->opcode == OP_LDADDR) {
-			MonoInst *var = ins->inst_p0;
+			MonoInst *var = (MonoInst *)ins->inst_p0;
 			int idx = var->inst_c0;
 			MonoMethodVar *vi = MONO_VARINFO (cfg, idx);
 
@@ -660,7 +660,7 @@ mono_linterval_add_range (MonoCompile *cfg, MonoLiveInterval *interval, int from
 		next_range->from = from;
 	} else {
 		/* Insert it */
-		new_range = mono_mempool_alloc (cfg->mempool, sizeof (MonoLiveRange2));
+		new_range = (MonoLiveRange2 *)mono_mempool_alloc (cfg->mempool, sizeof (MonoLiveRange2));
 		new_range->from = from;
 		new_range->to = to;
 		new_range->next = NULL;
@@ -753,8 +753,8 @@ mono_linterval_split (MonoCompile *cfg, MonoLiveInterval *interval, MonoLiveInte
 
 	g_assert (pos > interval->range->from && pos <= interval->last_range->to);
 
-	*i1 = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoLiveInterval));
-	*i2 = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoLiveInterval));
+	*i1 = (MonoLiveInterval *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoLiveInterval));
+	*i2 = (MonoLiveInterval *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoLiveInterval));
 
 	for (r = interval->range; r; r = r->next) {
 		if (pos > r->to) {
@@ -889,12 +889,12 @@ mono_analyze_liveness2 (MonoCompile *cfg)
 	last_use = g_new0 (gint32, max_vars);
 
 	reverse_len = 1024;
-	reverse = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * reverse_len);
+	reverse = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * reverse_len);
 
 	for (idx = 0; idx < max_vars; ++idx) {
 		MonoMethodVar *vi = MONO_VARINFO (cfg, idx);
 
-		vi->interval = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoLiveInterval));
+		vi->interval = (MonoLiveInterval *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoLiveInterval));
 	}
 
 	/*
@@ -941,7 +941,7 @@ mono_analyze_liveness2 (MonoCompile *cfg)
 		for (nins = 0, pos = block_from, ins = bb->code; ins; ins = ins->next, ++nins, ++pos) {
 			if (nins >= reverse_len) {
 				int new_reverse_len = reverse_len * 2;
-				MonoInst **new_reverse = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * new_reverse_len);
+				MonoInst **new_reverse = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * new_reverse_len);
 				memcpy (new_reverse, reverse, sizeof (MonoInst*) * reverse_len);
 				reverse = new_reverse;
 				reverse_len = new_reverse_len;
@@ -1025,17 +1025,17 @@ update_liveness_gc (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, gint32 
 
 		/* Add it to the last callsite */
 		g_assert (*callsites);
-		last = (*callsites)->data;
+		last = (GCCallSite *)(*callsites)->data;
 		last->param_slots = g_slist_prepend_mempool (cfg->mempool, last->param_slots, ins);
 	} else if (ins->flags & MONO_INST_GC_CALLSITE) {
-		GCCallSite *callsite = mono_mempool_alloc0 (cfg->mempool, sizeof (GCCallSite));
+		GCCallSite *callsite = (GCCallSite *)mono_mempool_alloc0 (cfg->mempool, sizeof (GCCallSite));
 		int i;
 
 		LIVENESS_DEBUG (printf ("\t%x: ", ins->backend.pc_offset); mono_print_ins (ins));
 		LIVENESS_DEBUG (printf ("\t\tlive: "));
 
 		callsite->bb = bb;
-		callsite->liveness = mono_mempool_alloc0 (cfg->mempool, ALIGN_TO (cfg->num_varinfo, 8) / 8);
+		callsite->liveness = (guint8 *)mono_mempool_alloc0 (cfg->mempool, ALIGN_TO (cfg->num_varinfo, 8) / 8);
 		callsite->pc_offset = ins->backend.pc_offset;
 		for (i = 0; i < cfg->num_varinfo; ++i) {
 			if (last_use [i] != 0) {
@@ -1091,7 +1091,7 @@ mono_analyze_liveness_gc (MonoCompile *cfg)
 	}
 
 	reverse_len = 1024;
-	reverse = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * reverse_len);
+	reverse = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * reverse_len);
 
 	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
 		MonoInst *ins;
@@ -1133,7 +1133,7 @@ mono_analyze_liveness_gc (MonoCompile *cfg)
 		for (nins = 0, pos = block_from, ins = bb->code; ins; ins = ins->next, ++nins, ++pos) {
 			if (nins >= reverse_len) {
 				int new_reverse_len = reverse_len * 2;
-				MonoInst **new_reverse = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * new_reverse_len);
+				MonoInst **new_reverse = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * new_reverse_len);
 				memcpy (new_reverse, reverse, sizeof (MonoInst*) * reverse_len);
 				reverse = new_reverse;
 				reverse_len = new_reverse_len;

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -58,8 +58,8 @@ mono_local_cprop (MonoCompile *cfg)
 restart:
 
 	max = cfg->next_vreg;
-	defs = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * (cfg->next_vreg + 1));
-	def_index = mono_mempool_alloc (cfg->mempool, sizeof (guint32) * (cfg->next_vreg + 1));
+	defs = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * (cfg->next_vreg + 1));
+	def_index = (gint32 *)mono_mempool_alloc (cfg->mempool, sizeof (guint32) * (cfg->next_vreg + 1));
 
 	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
 		MonoInst *ins;
@@ -107,7 +107,7 @@ restart:
 
 			/* FIXME: Optimize this */
 			if (ins->opcode == OP_LDADDR) {
-				MonoInst *var = ins->inst_p0;
+				MonoInst *var = (MonoInst *)ins->inst_p0;
 
 				defs [var->dreg] = NULL;
 				/*

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -499,7 +499,7 @@ add_widen_op (MonoCompile *cfg, MonoInst *ins, MonoInst **arg1_ref, MonoInst **a
 		CHECK_TYPE (ins);	\
 		/* Have to insert a widening op */		 \
         add_widen_op (cfg, ins, &sp [0], &sp [1]);		 \
-        ins->dreg = alloc_dreg ((cfg), (ins)->type); \
+        ins->dreg = alloc_dreg ((cfg), (MonoStackType)(ins)->type); \
         MONO_ADD_INS ((cfg)->cbb, (ins)); \
         *sp++ = mono_decompose_opcode ((cfg), (ins));	\
 	} while (0)
@@ -510,7 +510,7 @@ add_widen_op (MonoCompile *cfg, MonoInst *ins, MonoInst **arg1_ref, MonoInst **a
 		ins->sreg1 = sp [0]->dreg;	\
 		type_from_op (cfg, ins, sp [0], NULL);	\
 		CHECK_TYPE (ins);	\
-        (ins)->dreg = alloc_dreg ((cfg), (ins)->type); \
+        (ins)->dreg = alloc_dreg ((cfg), (MonoStackType)(ins)->type); \
         MONO_ADD_INS ((cfg)->cbb, (ins)); \
 		*sp++ = mono_decompose_opcode (cfg, ins);	\
 	} while (0)
@@ -525,7 +525,7 @@ add_widen_op (MonoCompile *cfg, MonoInst *ins, MonoInst **arg1_ref, MonoInst **a
 		CHECK_TYPE (cmp);	\
 		add_widen_op (cfg, cmp, &sp [0], &sp [1]);						\
 		type_from_op (cfg, ins, sp [0], sp [1]);							\
-		ins->inst_many_bb = mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);	\
+		ins->inst_many_bb = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);	\
 		GET_BBLOCK (cfg, tblock, target);		\
 		link_bblock (cfg, cfg->cbb, tblock);	\
 		ins->inst_true_bb = tblock;	\
@@ -582,7 +582,7 @@ link_bblock (MonoCompile *cfg, MonoBasicBlock *from, MonoBasicBlock* to)
 		}
 	}
 	if (!found) {
-		newa = mono_mempool_alloc (cfg->mempool, sizeof (gpointer) * (from->out_count + 1));
+		newa = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof (gpointer) * (from->out_count + 1));
 		for (i = 0; i < from->out_count; ++i) {
 			newa [i] = from->out_bb [i];
 		}
@@ -599,7 +599,7 @@ link_bblock (MonoCompile *cfg, MonoBasicBlock *from, MonoBasicBlock* to)
 		}
 	}
 	if (!found) {
-		newa = mono_mempool_alloc (cfg->mempool, sizeof (gpointer) * (to->in_count + 1));
+		newa = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof (gpointer) * (to->in_count + 1));
 		for (i = 0; i < to->in_count; ++i) {
 			newa [i] = to->in_bb [i];
 		}
@@ -685,7 +685,7 @@ mono_create_spvar_for_region (MonoCompile *cfg, int region)
 {
 	MonoInst *var;
 
-	var = g_hash_table_lookup (cfg->spvars, GINT_TO_POINTER (region));
+	var = (MonoInst *)g_hash_table_lookup (cfg->spvars, GINT_TO_POINTER (region));
 	if (var)
 		return;
 
@@ -699,7 +699,7 @@ mono_create_spvar_for_region (MonoCompile *cfg, int region)
 MonoInst *
 mono_find_exvar_for_offset (MonoCompile *cfg, int offset)
 {
-	return g_hash_table_lookup (cfg->exvars, GINT_TO_POINTER (offset));
+	return (MonoInst *)g_hash_table_lookup (cfg->exvars, GINT_TO_POINTER (offset));
 }
 
 static MonoInst*
@@ -707,7 +707,7 @@ mono_create_exvar_for_offset (MonoCompile *cfg, int offset)
 {
 	MonoInst *var;
 
-	var = g_hash_table_lookup (cfg->exvars, GINT_TO_POINTER (offset));
+	var = (MonoInst *)g_hash_table_lookup (cfg->exvars, GINT_TO_POINTER (offset));
 	if (var)
 		return var;
 
@@ -1397,7 +1397,7 @@ mono_save_token_info (MonoCompile *cfg, MonoImage *image, guint32 token, gpointe
 	 * table == 0 means this is a reference made from a wrapper.
 	 */
 	if (cfg->compile_aot && !cfg->generic_context && (mono_metadata_token_table (token) > 0)) {
-		MonoJumpInfoToken *jump_info_token = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfoToken));
+		MonoJumpInfoToken *jump_info_token = (MonoJumpInfoToken *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfoToken));
 		jump_info_token->image = image;
 		jump_info_token->token = token;
 		g_hash_table_insert (cfg->token_info_hash, key, jump_info_token);
@@ -1447,7 +1447,7 @@ handle_stack_args (MonoCompile *cfg, MonoInst **sp, int count)
 		}
 		//printf ("\n");
 		if (!found) {
-			bb->out_stack = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * count);
+			bb->out_stack = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * count);
 			for (i = 0; i < count; ++i) {
 				/* 
 				 * try to reuse temps already allocated for this purpouse, if they occupy the same
@@ -1950,7 +1950,7 @@ mini_emit_memcpy (MonoCompile *cfg, int destreg, int doffset, int srcreg, int so
 }
 
 static void
-emit_tls_set (MonoCompile *cfg, int sreg1, int tls_key)
+emit_tls_set (MonoCompile *cfg, int sreg1, MonoTlsKey tls_key)
 {
 	MonoInst *ins, *c;
 
@@ -2480,7 +2480,7 @@ emit_imt_argument (MonoCompile *cfg, MonoCallInst *call, MonoMethod *method, Mon
 static MonoJumpInfo *
 mono_patch_info_new (MonoMemPool *mp, int ip, MonoJumpInfoType type, gconstpointer target)
 {
-	MonoJumpInfo *ji = mono_mempool_alloc (mp, sizeof (MonoJumpInfo));
+	MonoJumpInfo *ji = (MonoJumpInfo *)mono_mempool_alloc (mp, sizeof (MonoJumpInfo));
 
 	ji->ip.i = ip;
 	ji->type = type;
@@ -2556,7 +2556,7 @@ check_method_sharing (MonoCompile *cfg, MonoMethod *cmethod, gboolean *out_pass_
 
 inline static MonoCallInst *
 mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig, 
-					 MonoInst **args, int calli, int virtual, int tail, int rgctx, int unbox_trampoline)
+					 MonoInst **args, int calli, int virtual_, int tail, int rgctx, int unbox_trampoline)
 {
 	MonoType *sig_ret;
 	MonoCallInst *call;
@@ -2572,7 +2572,7 @@ mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig,
 
 		MONO_INST_NEW_CALL (cfg, call, OP_TAILCALL);
 	} else
-		MONO_INST_NEW_CALL (cfg, call, ret_type_to_call_opcode (cfg, sig->ret, calli, virtual));
+		MONO_INST_NEW_CALL (cfg, call, ret_type_to_call_opcode (cfg, sig->ret, calli, virtual_));
 
 	call->args = args;
 	call->signature = sig;
@@ -2611,7 +2611,7 @@ mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig,
 
 		call->vret_var = loada;
 	} else if (!MONO_TYPE_IS_VOID (sig_ret))
-		call->inst.dreg = alloc_dreg (cfg, call->inst.type);
+		call->inst.dreg = alloc_dreg (cfg, (MonoStackType)call->inst.type);
 
 #ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
 	if (COMPILE_SOFT_FLOAT (cfg)) {
@@ -2749,7 +2749,7 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 #ifndef DISABLE_REMOTING
 	gboolean might_be_remote = FALSE;
 #endif
-	gboolean virtual = this_ins != NULL;
+	gboolean virtual_ = this_ins != NULL;
 	gboolean enable_for_aot = TRUE;
 	int context_used;
 	MonoCallInst *call;
@@ -2813,7 +2813,7 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 	}
 #endif
 
-	if (cfg->llvm_only && !call_target && virtual && (method->flags & METHOD_ATTRIBUTE_VIRTUAL)) {
+	if (cfg->llvm_only && !call_target && virtual_ && (method->flags & METHOD_ATTRIBUTE_VIRTUAL)) {
 		// FIXME: Vcall optimizations below
 		MonoInst *icall_args [16];
 		MonoInst *ins;
@@ -2843,7 +2843,7 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 
 	need_unbox_trampoline = method->klass == mono_defaults.object_class || (method->klass->flags & TYPE_ATTRIBUTE_INTERFACE);
 
-	call = mono_emit_call_args (cfg, sig, args, FALSE, virtual, tail, rgctx_arg ? TRUE : FALSE, need_unbox_trampoline);
+	call = mono_emit_call_args (cfg, sig, args, FALSE, virtual_, tail, rgctx_arg ? TRUE : FALSE, need_unbox_trampoline);
 
 #ifndef DISABLE_REMOTING
 	if (might_be_remote)
@@ -2855,7 +2855,7 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 	call->inst.inst_left = this_ins;
 	call->tail_call = tail;
 
-	if (virtual) {
+	if (virtual_) {
 		int vtable_reg, slot_reg, this_reg;
 		int offset;
 
@@ -3476,10 +3476,10 @@ emit_get_rgctx (MonoCompile *cfg, MonoMethod *method, int context_used)
 static MonoJumpInfoRgctxEntry *
 mono_patch_info_rgctx_entry_new (MonoMemPool *mp, MonoMethod *method, gboolean in_mrgctx, MonoJumpInfoType patch_type, gconstpointer patch_data, MonoRgctxInfoType info_type)
 {
-	MonoJumpInfoRgctxEntry *res = mono_mempool_alloc0 (mp, sizeof (MonoJumpInfoRgctxEntry));
+	MonoJumpInfoRgctxEntry *res = (MonoJumpInfoRgctxEntry *)mono_mempool_alloc0 (mp, sizeof (MonoJumpInfoRgctxEntry));
 	res->method = method;
 	res->in_mrgctx = in_mrgctx;
-	res->data = mono_mempool_alloc0 (mp, sizeof (MonoJumpInfo));
+	res->data = (MonoJumpInfo *)mono_mempool_alloc0 (mp, sizeof (MonoJumpInfo));
 	res->data->type = patch_type;
 	res->data->data.target = patch_data;
 	res->info_type = info_type;
@@ -3638,7 +3638,7 @@ emit_get_rgctx_gsharedvt_call (MonoCompile *cfg, int context_used,
 	MonoJumpInfoRgctxEntry *entry;
 	MonoInst *rgctx;
 
-	call_info = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfoGSharedVtCall));
+	call_info = (MonoJumpInfoGSharedVtCall *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfoGSharedVtCall));
 	call_info->sig = sig;
 	call_info->method = cmethod;
 
@@ -3661,7 +3661,7 @@ emit_get_rgctx_virt_method (MonoCompile *cfg, int context_used,
 	MonoJumpInfoRgctxEntry *entry;
 	MonoInst *rgctx;
 
-	info = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfoVirtMethod));
+	info = (MonoJumpInfoVirtMethod *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfoVirtMethod));
 	info->klass = klass;
 	info->method = virt_method;
 
@@ -3729,7 +3729,7 @@ static int
 get_gsharedvt_info_slot (MonoCompile *cfg, gpointer data, MonoRgctxInfoType rgctx_type)
 {
 	MonoGSharedVtMethodInfo *info = cfg->gsharedvt_info;
-	MonoRuntimeGenericContextInfoTemplate *template;
+	MonoRuntimeGenericContextInfoTemplate *template_;
 	int i, idx;
 
 	g_assert (info);
@@ -3745,7 +3745,7 @@ get_gsharedvt_info_slot (MonoCompile *cfg, gpointer data, MonoRgctxInfoType rgct
 		MonoRuntimeGenericContextInfoTemplate *new_entries;
 		int new_count_entries = info->count_entries ? info->count_entries * 2 : 16;
 
-		new_entries = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoRuntimeGenericContextInfoTemplate) * new_count_entries);
+		new_entries = (MonoRuntimeGenericContextInfoTemplate *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoRuntimeGenericContextInfoTemplate) * new_count_entries);
 
 		memcpy (new_entries, info->entries, sizeof (MonoRuntimeGenericContextInfoTemplate) * info->count_entries);
 		info->entries = new_entries;
@@ -3753,9 +3753,9 @@ get_gsharedvt_info_slot (MonoCompile *cfg, gpointer data, MonoRgctxInfoType rgct
 	}
 
 	idx = info->num_entries;
-	template = &info->entries [idx];
-	template->info_type = rgctx_type;
-	template->data = data;
+	template_ = &info->entries [idx];
+	template_->info_type = rgctx_type;
+	template_->data = data;
 
 	info->num_entries ++;
 
@@ -4114,7 +4114,7 @@ handle_unbox_gsharedvt (MonoCompile *cfg, MonoClass *klass, MonoInst *obj)
 		MonoInst *unbox_call;
 		MonoMethodSignature *unbox_sig;
 
-		unbox_sig = mono_mempool_alloc0 (cfg->mempool, MONO_SIZEOF_METHOD_SIGNATURE + (1 * sizeof (MonoType *)));
+		unbox_sig = (MonoMethodSignature *)mono_mempool_alloc0 (cfg->mempool, MONO_SIZEOF_METHOD_SIGNATURE + (1 * sizeof (MonoType *)));
 		unbox_sig->ret = &klass->byval_arg;
 		unbox_sig->param_count = 1;
 		unbox_sig->params [0] = &mono_defaults.object_class->byval_arg;
@@ -4146,7 +4146,7 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 
 	if (context_used) {
 		MonoInst *data;
-		int rgctx_info;
+		MonoRgctxInfoType rgctx_info;
 		MonoInst *iargs [2];
 		gboolean known_instance_size = !mini_is_gsharedvt_klass (klass);
 
@@ -4318,7 +4318,7 @@ handle_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used)
 			 * klass is Nullable<T>, need to call Nullable<T>.Box () using a gsharedvt signature, but we cannot
 			 * construct that method at JIT time, so have to do things by hand.
 			 */
-			box_sig = mono_mempool_alloc0 (cfg->mempool, MONO_SIZEOF_METHOD_SIGNATURE + (1 * sizeof (MonoType *)));
+			box_sig = (MonoMethodSignature *)mono_mempool_alloc0 (cfg->mempool, MONO_SIZEOF_METHOD_SIGNATURE + (1 * sizeof (MonoType *)));
 			box_sig->ret = &mono_defaults.object_class->byval_arg;
 			box_sig->param_count = 1;
 			box_sig->params [0] = &klass->byval_arg;
@@ -4926,13 +4926,13 @@ handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, M
 	}
 
 	{
-		MonoInst *load, *and, *cmp, *ceq;
+		MonoInst *load, *and_, *cmp, *ceq;
 		int enum_reg = is_i4 ? alloc_ireg (cfg) : alloc_lreg (cfg);
 		int and_reg = is_i4 ? alloc_ireg (cfg) : alloc_lreg (cfg);
 		int dest_reg = alloc_ireg (cfg);
 
 		EMIT_NEW_LOAD_MEMBASE (cfg, load, load_opc, enum_reg, enum_this->dreg, 0);
-		EMIT_NEW_BIALU (cfg, and, is_i4 ? OP_IAND : OP_LAND, and_reg, enum_reg, enum_flag->dreg);
+		EMIT_NEW_BIALU (cfg, and_, is_i4 ? OP_IAND : OP_LAND, and_reg, enum_reg, enum_flag->dreg);
 		EMIT_NEW_BIALU (cfg, cmp, is_i4 ? OP_ICOMPARE : OP_LCOMPARE, -1, and_reg, enum_flag->dreg);
 		EMIT_NEW_UNALU (cfg, ceq, is_i4 ? OP_ICEQ : OP_LCEQ, dest_reg, -1);
 
@@ -4940,7 +4940,7 @@ handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, M
 
 		if (!is_i4) {
 			load = mono_decompose_opcode (cfg, load);
-			and = mono_decompose_opcode (cfg, and);
+			and_ = mono_decompose_opcode (cfg, and_);
 			cmp = mono_decompose_opcode (cfg, cmp);
 			ceq = mono_decompose_opcode (cfg, ceq);
 		}
@@ -4953,7 +4953,7 @@ handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, M
  * Returns NULL and set the cfg exception on error.
  */
 static G_GNUC_UNUSED MonoInst*
-handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, MonoMethod *method, int context_used, gboolean virtual)
+handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, MonoMethod *method, int context_used, gboolean virtual_)
 {
 	MonoInst *ptr;
 	int dreg;
@@ -4962,7 +4962,7 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	MonoDomain *domain;
 	guint8 **code_slot;
 
-	if (virtual && !cfg->llvm_only) {
+	if (virtual_ && !cfg->llvm_only) {
 		MonoMethod *invoke = mono_get_delegate_invoke (klass);
 		g_assert (invoke);
 
@@ -4985,7 +4985,7 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 		args [0] = obj;
 		args [1] = target;
 		args [2] = emit_get_rgctx_method (cfg, context_used, method, MONO_RGCTX_INFO_METHOD);
-		mono_emit_jit_icall (cfg, virtual ? mono_init_delegate_virtual : mono_init_delegate, args);
+		mono_emit_jit_icall (cfg, virtual_ ? mono_init_delegate_virtual : mono_init_delegate, args);
 
 		return obj;
 	}
@@ -5022,9 +5022,9 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 			mono_domain_lock (domain);
 			if (!domain_jit_info (domain)->method_code_hash)
 				domain_jit_info (domain)->method_code_hash = g_hash_table_new (NULL, NULL);
-			code_slot = g_hash_table_lookup (domain_jit_info (domain)->method_code_hash, method);
+			code_slot = (guint8 **)g_hash_table_lookup (domain_jit_info (domain)->method_code_hash, method);
 			if (!code_slot) {
-				code_slot = mono_domain_alloc0 (domain, sizeof (gpointer));
+				code_slot = (guint8 **)mono_domain_alloc0 (domain, sizeof (gpointer));
 				g_hash_table_insert (domain_jit_info (domain)->method_code_hash, method, code_slot);
 			}
 			mono_domain_unlock (domain);
@@ -5037,13 +5037,13 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	if (cfg->compile_aot) {
 		MonoDelegateClassMethodPair *del_tramp;
 
-		del_tramp = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoDelegateClassMethodPair));
+		del_tramp = (MonoDelegateClassMethodPair *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoDelegateClassMethodPair));
 		del_tramp->klass = klass;
 		del_tramp->method = context_used ? NULL : method;
-		del_tramp->is_virtual = virtual;
+		del_tramp->is_virtual = virtual_;
 		EMIT_NEW_AOTCONST (cfg, tramp_ins, MONO_PATCH_INFO_DELEGATE_TRAMPOLINE, del_tramp);
 	} else {
-		if (virtual)
+		if (virtual_)
 			trampoline = mono_create_delegate_virtual_trampoline (cfg->domain, klass, context_used ? NULL : method);
 		else
 			trampoline = mono_create_delegate_trampoline_info (cfg->domain, klass, context_used ? NULL : method);
@@ -5051,7 +5051,7 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	}
 
 	/* Set invoke_impl field */
-	if (virtual) {
+	if (virtual_) {
 		MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, obj->dreg, MONO_STRUCT_OFFSET (MonoDelegate, invoke_impl), tramp_ins->dreg);
 	} else {
 		dreg = alloc_preg (cfg);
@@ -5064,7 +5064,7 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	}
 
 	dreg = alloc_preg (cfg);
-	MONO_EMIT_NEW_ICONST (cfg, dreg, virtual ? 1 : 0);
+	MONO_EMIT_NEW_ICONST (cfg, dreg, virtual_ ? 1 : 0);
 	MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STOREI1_MEMBASE_REG, obj->dreg, MONO_STRUCT_OFFSET (MonoDelegate, method_is_virtual), dreg);
 
 	/* All the checks which are in mono_delegate_ctor () are done by the delegate trampoline */
@@ -6692,13 +6692,13 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			cfg->disable_llvm = TRUE;
 
 			if (args [0]->opcode == OP_GOT_ENTRY) {
-				pi = args [0]->inst_p1;
+				pi = (MonoInst *)args [0]->inst_p1;
 				g_assert (pi->opcode == OP_PATCH_INFO);
 				g_assert (GPOINTER_TO_INT (pi->inst_p1) == MONO_PATCH_INFO_LDSTR);
-				ji = pi->inst_p0;
+				ji = (MonoJumpInfoToken *)pi->inst_p0;
 			} else {
 				g_assert (GPOINTER_TO_INT (args [0]->inst_p1) == MONO_PATCH_INFO_LDSTR);
-				ji = args [0]->inst_p0;
+				ji = (MonoJumpInfoToken *)args [0]->inst_p0;
 			}
 
 			NULLIFY_INS (args [0]);
@@ -6927,7 +6927,7 @@ emit_init_local (MonoCompile *cfg, int local, MonoType *type, gboolean init)
 	MonoInst *var = cfg->locals [local];
 	if (COMPILE_SOFT_FLOAT (cfg)) {
 		MonoInst *store;
-		int reg = alloc_dreg (cfg, var->type);
+		int reg = alloc_dreg (cfg, (MonoStackType)var->type);
 		emit_init_rvar (cfg, reg, type);
 		EMIT_NEW_LOCSTORE (cfg, store, local, cfg->cbb->last_ins);
 	} else {
@@ -6962,7 +6962,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 	guint32 prev_cil_offset_to_bb_len;
 	MonoMethod *prev_current_method;
 	MonoGenericContext *prev_generic_context;
-	gboolean ret_var_set, prev_ret_var_set, prev_disable_inline, virtual = FALSE;
+	gboolean ret_var_set, prev_ret_var_set, prev_disable_inline, virtual_ = FALSE;
 
 	g_assert (cfg->exception_type == MONO_EXCEPTION_NONE);
 
@@ -7013,7 +7013,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 	}
 
 	prev_locals = cfg->locals;
-	cfg->locals = mono_mempool_alloc0 (cfg->mempool, cheader->num_locals * sizeof (MonoInst*));	
+	cfg->locals = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, cheader->num_locals * sizeof (MonoInst*));
 	for (i = 0; i < cheader->num_locals; ++i)
 		cfg->locals [i] = mono_compile_create_var (cfg, cheader->locals [i], OP_LOCAL);
 
@@ -7044,9 +7044,9 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 	prev_disable_inline = cfg->disable_inline;
 
 	if (ip && *ip == CEE_CALLVIRT && !(cmethod->flags & METHOD_ATTRIBUTE_STATIC))
-		virtual = TRUE;
+		virtual_ = TRUE;
 
-	costs = mono_method_to_ir (cfg, cmethod, sbblock, ebblock, rvar, sp, real_offset, virtual);
+	costs = mono_method_to_ir (cfg, cmethod, sbblock, ebblock, rvar, sp, real_offset, virtual_);
 
 	ret_var_set = cfg->ret_var_set;
 
@@ -7286,7 +7286,7 @@ mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, Mono
 	MonoMethod *method;
 
 	if (m->wrapper_type != MONO_WRAPPER_NONE) {
-		method = mono_method_get_wrapper_data (m, token);
+		method = (MonoMethod *)mono_method_get_wrapper_data (m, token);
 		if (context) {
 			MonoError error;
 			method = mono_class_inflate_generic_method_checked (method, context, &error);
@@ -7317,7 +7317,7 @@ mini_get_class (MonoMethod *method, guint32 token, MonoGenericContext *context)
 	MonoClass *klass;
 
 	if (method->wrapper_type != MONO_WRAPPER_NONE) {
-		klass = mono_method_get_wrapper_data (method, token);
+		klass = (MonoClass *)mono_method_get_wrapper_data (method, token);
 		if (context)
 			klass = mono_class_inflate_generic_class (klass, context);
 	} else {
@@ -7480,7 +7480,7 @@ initialize_array_data (MonoMethod *method, gboolean aot, unsigned char *ip, Mono
 			/*g_print ("field: 0x%08x, rva: %d, rva_ptr: %p\n", read32 (ip + 2), rva, data_ptr);*/
 			/* for aot code we do the lookup on load */
 			if (aot && data_ptr)
-				return GUINT_TO_POINTER (rva);
+				return (const char *)GUINT_TO_POINTER (rva);
 		} else {
 			/*FIXME is it possible to AOT a SRE assembly not meant to be saved? */ 
 			g_assert (!aot);
@@ -7797,7 +7797,7 @@ sig_to_rgctx_sig (MonoMethodSignature *sig)
 	MonoMethodSignature *res;
 	int i;
 
-	res = g_malloc (MONO_SIZEOF_METHOD_SIGNATURE + (sig->param_count + 1) * sizeof (MonoType*));
+	res = (MonoMethodSignature *)g_malloc (MONO_SIZEOF_METHOD_SIGNATURE + (sig->param_count + 1) * sizeof (MonoType*));
 	memcpy (res, sig, MONO_SIZEOF_METHOD_SIGNATURE);
 	res->param_count = sig->param_count + 1;
 	for (i = 0; i < sig->param_count; ++i)
@@ -7957,7 +7957,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		cfg->real_offset = inline_offset;
 	}
 
-	cfg->cil_offset_to_bb = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoBasicBlock*) * header->code_size);
+	cfg->cil_offset_to_bb = (MonoBasicBlock **)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoBasicBlock*) * header->code_size);
 	cfg->cil_offset_to_bb_len = header->code_size;
 
 	cfg->current_method = method;
@@ -7965,7 +7965,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	if (cfg->verbose_level > 2)
 		printf ("method to IR %s\n", mono_method_full_name (method, TRUE));
 
-	param_types = mono_mempool_alloc (cfg->mempool, sizeof (MonoType*) * num_args);
+	param_types = (MonoType **)mono_mempool_alloc (cfg->mempool, sizeof (MonoType*) * num_args);
 	if (sig->hasthis)
 		param_types [0] = method->klass->valuetype?&method->klass->this_arg:&method->klass->byval_arg;
 	for (n = 0; n < sig->param_count; ++n)
@@ -8050,7 +8050,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				/* mostly like handle_stack_args (), but just sets the input args */
 				/* printf ("handling clause at IL_%04x\n", clause->handler_offset); */
 				tblock->in_scount = 1;
-				tblock->in_stack = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*));
+				tblock->in_stack = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*));
 				tblock->in_stack [0] = mono_create_exvar_for_offset (cfg, clause->handler_offset);
 
 				cfg->cbb = tblock;
@@ -8082,7 +8082,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					tblock->flags |= BB_EXCEPTION_HANDLER;
 					tblock->real_offset = clause->data.filter_offset;
 					tblock->in_scount = 1;
-					tblock->in_stack = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*));
+					tblock->in_stack = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*));
 					/* The filter block shares the exvar with the handler block */
 					tblock->in_stack [0] = mono_create_exvar_for_offset (cfg, clause->handler_offset);
 					MONO_INST_NEW (cfg, ins, OP_START_HANDLER);
@@ -8155,10 +8155,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		MonoInst *var, *locals_var;
 		int dreg;
 
-		info = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoGSharedVtMethodInfo));
+		info = (MonoGSharedVtMethodInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoGSharedVtMethodInfo));
 		info->method = cfg->method;
 		info->count_entries = 16;
-		info->entries = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoRuntimeGenericContextInfoTemplate) * info->count_entries);
+		info->entries = (MonoRuntimeGenericContextInfoTemplate *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoRuntimeGenericContextInfoTemplate) * info->count_entries);
 		cfg->gsharedvt_info = info;
 
 		var = mono_compile_create_var (cfg, &mono_defaults.int_class->byval_arg, OP_LOCAL);
@@ -8263,7 +8263,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	}
 
 	/* we use a spare stack slot in SWITCH and NEWOBJ and others */
-	stack_start = sp = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * (header->max_stack + 1));
+	stack_start = sp = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * (header->max_stack + 1));
 
 	ins_flag = 0;
 	start_new_bblock = 0;
@@ -8583,7 +8583,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 #endif
 
 			/* FIXME: we should really allocate this only late in the compilation process */
-			f = mono_domain_alloc (cfg->domain, sizeof (float));
+			f = (float *)mono_domain_alloc (cfg->domain, sizeof (float));
 			CHECK_OPSIZE (5);
 			CHECK_STACK_OVF (1);
 
@@ -8620,7 +8620,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 #endif
 
 			/* FIXME: we should really allocate this only late in the compilation process */
-			d = mono_domain_alloc (cfg->domain, sizeof (double));
+			d = (double *)mono_domain_alloc (cfg->domain, sizeof (double));
 			CHECK_OPSIZE (9);
 			CHECK_STACK_OVF (1);
 
@@ -8705,7 +8705,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (cfg->llvm_only) {
 				MonoInst **args;
 
-				args = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
+				args = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
 				for (i = 0; i < n; ++i)
 					EMIT_NEW_ARGLOAD (cfg, args [i], i);
 				ins = mono_emit_method_call_full (cfg, cmethod, fsig, TRUE, args, NULL, NULL, NULL);
@@ -8729,7 +8729,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				call->method = cmethod;
 				call->tail_call = TRUE;
 				call->signature = mono_method_signature (cmethod);
-				call->args = mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
+				call->args = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
 				call->inst.inst_p0 = cmethod;
 				for (i = 0; i < n; ++i)
 					EMIT_NEW_ARGLOAD (cfg, call->args [i], i);
@@ -8787,7 +8787,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			CHECK_STACK (n);
 
-			//g_assert (!virtual || fsig->hasthis);
+			//g_assert (!virtual_ || fsig->hasthis);
 
 			sp -= n;
 
@@ -8818,7 +8818,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			INLINE_FAILURE ("indirect call");
 
 			if (addr->opcode == OP_PCONST || addr->opcode == OP_AOTCONST || addr->opcode == OP_GOT_ENTRY) {
-				int info_type;
+				MonoJumpInfoType info_type;
 				gpointer info_data;
 
 				/*
@@ -8826,10 +8826,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				 * with the contents of the aotconst as the patch info.
 				 */
 				if (addr->opcode == OP_PCONST || addr->opcode == OP_AOTCONST) {
-					info_type = addr->inst_c1;
+					info_type = (MonoJumpInfoType)addr->inst_c1;
 					info_data = addr->inst_p0;
 				} else {
-					info_type = addr->inst_right->inst_c1;
+					info_type = (MonoJumpInfoType)addr->inst_right->inst_c1;
 					info_data = addr->inst_right->inst_left;
 				}
 
@@ -8862,7 +8862,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			MonoInst *addr = NULL;
 			MonoMethodSignature *fsig = NULL;
 			int array_rank = 0;
-			int virtual = *ip == CEE_CALLVIRT;
+			int virtual_ = *ip == CEE_CALLVIRT;
 			gboolean pass_imt_from_rgctx = FALSE;
 			MonoInst *imt_arg = NULL;
 			MonoInst *keep_this_alive = NULL;
@@ -8943,9 +8943,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (mono_security_core_clr_enabled ())
 				ensure_method_is_allowed_to_call_method (cfg, method, cil_method);
 
-			if (!virtual && (cmethod->flags & METHOD_ATTRIBUTE_ABSTRACT))
+			if (!virtual_ && (cmethod->flags & METHOD_ATTRIBUTE_ABSTRACT))
 				/* MS.NET seems to silently convert this to a callvirt */
-				virtual = 1;
+				virtual_ = 1;
 
 			{
 				/*
@@ -8956,8 +8956,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				 */
 				const int test_flags = METHOD_ATTRIBUTE_VIRTUAL | METHOD_ATTRIBUTE_FINAL | METHOD_ATTRIBUTE_STATIC;
 				const int expected_flags = METHOD_ATTRIBUTE_VIRTUAL | METHOD_ATTRIBUTE_FINAL;
-				if (!virtual && mono_class_is_marshalbyref (cmethod->klass) && (cmethod->flags & test_flags) == expected_flags && cfg->method->wrapper_type == MONO_WRAPPER_NONE)
-					virtual = 1;
+				if (!virtual_ && mono_class_is_marshalbyref (cmethod->klass) && (cmethod->flags & test_flags) == expected_flags && cfg->method->wrapper_type == MONO_WRAPPER_NONE)
+					virtual_ = 1;
 			}
 
 			if (!cmethod->klass->inited)
@@ -9021,7 +9021,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			CHECK_STACK (n);
 
-			//g_assert (!virtual || fsig->hasthis);
+			//g_assert (!virtual_ || fsig->hasthis);
 
 			sp -= n;
 
@@ -9157,7 +9157,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 							CHECK_CFG_EXCEPTION;
 						}
 					}
-					virtual = 0;
+					virtual_ = 0;
 				}
 				constrained_class = NULL;
 			}
@@ -9247,9 +9247,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				if ((!(cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL) ||
 					 MONO_METHOD_IS_FINAL (cmethod)) &&
 					!mono_class_is_marshalbyref (cmethod->klass)) {
-					if (virtual)
+					if (virtual_)
 						check_this = TRUE;
-					virtual = 0;
+					virtual_ = 0;
 				}
 			}
 
@@ -9264,7 +9264,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				MONO_EMIT_NEW_CHECK_THIS (cfg, sp [0]->dreg);
 
 			/* Calling virtual generic methods */
-			if (virtual && (cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL) && 
+			if (virtual_ && (cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL) &&
 		 	    !(MONO_METHOD_IS_FINAL (cmethod) && 
 			      cmethod->wrapper_type != MONO_WRAPPER_REMOTING_INVOKE_WITH_CHECK) &&
 			    fsig->generic_param_count && 
@@ -9349,7 +9349,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			/* Inlining */
 			if ((cfg->opt & MONO_OPT_INLINE) &&
-				(!virtual || !(cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL) || MONO_METHOD_IS_FINAL (cmethod)) &&
+				(!virtual_ || !(cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL) || MONO_METHOD_IS_FINAL (cmethod)) &&
 			    mono_method_check_inlining (cfg, cmethod)) {
 				int costs;
 				gboolean always = FALSE;
@@ -9421,7 +9421,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				!(cmethod->klass->rank && cmethod->klass->byval_arg.type != MONO_TYPE_SZARRAY)) {
 				MonoRgctxInfoType info_type;
 
-				if (virtual) {
+				if (virtual_) {
 					//if (cmethod->klass->flags & TYPE_ATTRIBUTE_INTERFACE)
 						//GSHAREDVT_FAILURE (*ip);
 					// disable for possible remoting calls
@@ -9446,7 +9446,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				if ((cmethod->klass->parent == mono_defaults.multicastdelegate_class) && (!strcmp (cmethod->name, "Invoke")))
 					keep_this_alive = sp [0];
 
-				if (virtual && (cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL))
+				if (virtual_ && (cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL))
 					info_type = MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE_VIRT;
 				else
 					info_type = MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE;
@@ -9466,7 +9466,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (context_used && !imt_arg && !array_rank && !delegate_invoke &&
 				(!mono_method_is_generic_sharable_full (cmethod, TRUE, FALSE, FALSE) ||
 				 !mono_class_generic_sharing_enabled (cmethod->klass)) &&
-				(!virtual || MONO_METHOD_IS_FINAL (cmethod) ||
+				(!virtual_ || MONO_METHOD_IS_FINAL (cmethod) ||
 				 !(cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL))) {
 				INLINE_FAILURE ("gshared");
 
@@ -9553,7 +9553,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				goto call_end;
 			}
 
-			ins = mini_redirect_call (cfg, cmethod, fsig, sp, virtual ? sp [0] : NULL);
+			ins = mini_redirect_call (cfg, cmethod, fsig, sp, virtual_ ? sp [0] : NULL);
 			if (ins)
 				goto call_end;
 
@@ -9636,7 +9636,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			 * So we make resolve_iface_call return the rgctx, and do two calls with different signatures
 			 * based on whenever there is an rgctx or not.
 			 */
-			if (cfg->llvm_only && virtual && cmethod && (cmethod->klass->flags & TYPE_ATTRIBUTE_INTERFACE)) {
+			if (cfg->llvm_only && virtual_ && cmethod && (cmethod->klass->flags & TYPE_ATTRIBUTE_INTERFACE)) {
 				MonoInst *args_buf [16], *icall_args [16];
 				MonoInst **args;
 				MonoBasicBlock *rgctx_bb, *end_bb;
@@ -9683,7 +9683,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				if (fsig->param_count + 2 < 16)
 					args = args_buf;
 				else
-					args = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * (fsig->param_count + 2));
+					args = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * (fsig->param_count + 2));
 				args [0] = sp [0];
 				for (i = 0; i < fsig->param_count; ++i)
 					args [i + 1] = sp [i + 1];
@@ -9701,7 +9701,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			/* Common call */
 			INLINE_FAILURE ("call");
-			ins = mono_emit_method_call_full (cfg, cmethod, fsig, tail_call, sp, virtual ? sp [0] : NULL,
+			ins = mono_emit_method_call_full (cfg, cmethod, fsig, tail_call, sp, virtual_ ? sp [0] : NULL,
 											  imt_arg, vtable_arg);
 
 			if (tail_call && !cfg->llvm_only) {
@@ -9927,7 +9927,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			MONO_INST_NEW (cfg, ins, is_true ? CEE_BNE_UN : CEE_BEQ);
 			type_from_op (cfg, ins, sp [0], NULL);
 			MONO_ADD_INS (cfg->cbb, ins);
-			ins->inst_many_bb = mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);
+			ins->inst_many_bb = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof(gpointer)*2);
 			GET_BBLOCK (cfg, tblock, target);
 			ins->inst_true_bb = tblock;
 			GET_BBLOCK (cfg, tblock, ip);
@@ -9986,7 +9986,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			GET_BBLOCK (cfg, default_bblock, target);
 			default_bblock->flags |= BB_INDIRECT_JUMP_TARGET;
 
-			targets = mono_mempool_alloc (cfg->mempool, sizeof (MonoBasicBlock*) * n);
+			targets = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof (MonoBasicBlock*) * n);
 			for (i = 0; i < n; ++i) {
 				GET_BBLOCK (cfg, tblock, target + (gint32)read32(ip));
 				targets [i] = tblock;
@@ -10019,7 +10019,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			for (i = 0; i < n; ++i)
 				link_bblock (cfg, cfg->cbb, targets [i]);
 
-			table = mono_mempool_alloc (cfg->mempool, sizeof (MonoJumpInfoBBTable));
+			table = (MonoJumpInfoBBTable *)mono_mempool_alloc (cfg->mempool, sizeof (MonoJumpInfoBBTable));
 			table->table = targets;
 			table->table_size = n;
 
@@ -10041,7 +10041,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				ins->sreg1 = src1->dreg;
 				ins->inst_p0 = table;
 				ins->inst_many_bb = targets;
-				ins->klass = GUINT_TO_POINTER (n);
+				ins->klass = (MonoClass *)GUINT_TO_POINTER (n);
 				MONO_ADD_INS (cfg->cbb, ins);
 			} else {
 				if (sizeof (gpointer) == 8)
@@ -10154,7 +10154,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			ins->sreg2 = sp [1]->dreg;
 			type_from_op (cfg, ins, sp [0], sp [1]);
 			CHECK_TYPE (ins);
-			ins->dreg = alloc_dreg ((cfg), (ins)->type);
+			ins->dreg = alloc_dreg ((cfg), (MonoStackType)(ins)->type);
 
 			/* Use the immediate opcodes if possible */
 			if ((sp [1]->opcode == OP_ICONST) && mono_arch_is_inst_imm (sp [1]->inst_c0)) {
@@ -10194,7 +10194,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			type_from_op (cfg, ins, sp [0], sp [1]);
 			CHECK_TYPE (ins);
 			add_widen_op (cfg, ins, &sp [0], &sp [1]);
-			ins->dreg = alloc_dreg ((cfg), (ins)->type);
+			ins->dreg = alloc_dreg ((cfg), (MonoStackType)(ins)->type);
 
 			/* FIXME: Pass opcode to is_inst_imm */
 
@@ -10442,7 +10442,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			}
 			else if (method->wrapper_type != MONO_WRAPPER_NONE) {
 				MonoInst *iargs [1];
-				char *str = mono_method_get_wrapper_data (method, n);
+				char *str = (char *)mono_method_get_wrapper_data (method, n);
 
 				if (cfg->compile_aot)
 					EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);
@@ -11007,7 +11007,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			CHECK_OPSIZE (5);
 			token = read32 (ip + 1);
 			if (method->wrapper_type != MONO_WRAPPER_NONE) {
-				field = mono_method_get_wrapper_data (method, token);
+				field = (MonoClassField *)mono_method_get_wrapper_data (method, token);
 				klass = field->parent;
 			}
 			else {
@@ -11904,7 +11904,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD ||
 					method->wrapper_type == MONO_WRAPPER_SYNCHRONIZED) {
 				handle = mono_method_get_wrapper_data (method, n);
-				handle_class = mono_method_get_wrapper_data (method, n + 1);
+				handle_class = (MonoClass *)mono_method_get_wrapper_data (method, n + 1);
 				if (handle_class == mono_defaults.typehandle_class)
 					handle = &((MonoClass*)handle)->byval_arg;
 			}
@@ -11923,11 +11923,11 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					   typeof(Gen<>). */
 					context_used = 0;
 				} else if (handle_class == mono_defaults.typehandle_class) {
-					context_used = mini_class_check_context_used (cfg, mono_class_from_mono_type (handle));
+					context_used = mini_class_check_context_used (cfg, mono_class_from_mono_type ((MonoType *)handle));
 				} else if (handle_class == mono_defaults.fieldhandle_class)
 					context_used = mini_class_check_context_used (cfg, ((MonoClassField*)handle)->parent);
 				else if (handle_class == mono_defaults.methodhandle_class)
-					context_used = mini_method_check_context_used (cfg, handle);
+					context_used = mini_method_check_context_used (cfg, (MonoMethod *)handle);
 				else
 					g_assert_not_reached ();
 			}
@@ -11963,7 +11963,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					(cmethod = mini_get_method (cfg, method, read32 (ip + 6), NULL, generic_context)) &&
 					(cmethod->klass == mono_defaults.systemtype_class) &&
 					(strcmp (cmethod->name, "GetTypeFromHandle") == 0)) {
-					MonoClass *tclass = mono_class_from_mono_type (handle);
+					MonoClass *tclass = mono_class_from_mono_type ((MonoType *)handle);
 
 					mono_class_init (tclass);
 					if (context_used) {
@@ -11985,7 +11985,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 							EMIT_NEW_TYPE_FROM_HANDLE_CONST (cfg, ins, image, n, generic_context);
 						}
 					} else {
-						EMIT_NEW_PCONST (cfg, ins, mono_type_get_object (cfg->domain, handle));
+						EMIT_NEW_PCONST (cfg, ins, mono_type_get_object (cfg->domain, (MonoType *)handle));
 					}
 					ins->type = STACK_OBJ;
 					ins->klass = cmethod->klass;
@@ -11998,14 +11998,14 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					if (context_used) {
 						if (handle_class == mono_defaults.typehandle_class) {
 							ins = emit_get_rgctx_klass (cfg, context_used,
-									mono_class_from_mono_type (handle),
+									mono_class_from_mono_type ((MonoType *)handle),
 									MONO_RGCTX_INFO_TYPE);
 						} else if (handle_class == mono_defaults.methodhandle_class) {
 							ins = emit_get_rgctx_method (cfg, context_used,
-									handle, MONO_RGCTX_INFO_METHOD);
+									(MonoMethod *)handle, MONO_RGCTX_INFO_METHOD);
 						} else if (handle_class == mono_defaults.fieldhandle_class) {
 							ins = emit_get_rgctx_field (cfg, context_used,
-									handle, MONO_RGCTX_INFO_CLASS_FIELD);
+									(MonoClassField *)handle, MONO_RGCTX_INFO_CLASS_FIELD);
 						} else {
 							g_assert_not_reached ();
 						}
@@ -12128,7 +12128,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				MonoExceptionClause *clause;
 
 				for (tmp = handlers; tmp; tmp = tmp->next) {
-					clause = tmp->data;
+					clause = (MonoExceptionClause *)tmp->data;
 					tblock = cfg->cil_offset_to_bb [clause->handler_offset];
 					g_assert (tblock);
 					link_bblock (cfg, cfg->cbb, tblock);
@@ -12267,7 +12267,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				CHECK_OPSIZE (6);
 				token = read32 (ip + 2);
 
-				cmethod = mono_method_get_wrapper_data (method, token);
+				cmethod = (MonoMethod *)mono_method_get_wrapper_data (method, token);
 
 				if (cfg->compile_aot) {
 					EMIT_NEW_AOTCONST (cfg, ins, MONO_PATCH_INFO_ICALL_ADDR, cmethod);
@@ -12330,7 +12330,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				CHECK_OPSIZE (6);
 				--sp;
 				token = read32 (ip + 2);
-				klass = mono_method_get_wrapper_data (method, token);
+				klass = (MonoClass *)mono_method_get_wrapper_data (method, token);
 				g_assert (klass->valuetype);
 				mono_class_init (klass);
 
@@ -12419,11 +12419,11 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				ip += 2;
 				break;
 			case CEE_MONO_TLS: {
-				int key;
+				MonoTlsKey key;
 
 				CHECK_STACK_OVF (1);
 				CHECK_OPSIZE (6);
-				key = (gint32)read32 (ip + 2);
+				key = (MonoTlsKey)read32 (ip + 2);
 				g_assert (key < TLS_KEY_NUM);
 
 				ins = mono_create_tls_get (cfg, key);
@@ -12601,7 +12601,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					cmp->opcode = OP_ICOMPARE;
 				MONO_ADD_INS (cfg->cbb, cmp);
 				ins->type = STACK_I4;
-				ins->dreg = alloc_dreg (cfg, ins->type);
+				ins->dreg = alloc_dreg (cfg, (MonoStackType)ins->type);
 				type_from_op (cfg, ins, arg1, arg2);
 
 				if (cmp->opcode == OP_FCOMPARE || cmp->opcode == OP_RCOMPARE) {
@@ -13720,7 +13720,7 @@ mono_handle_global_vregs (MonoCompile *cfg)
 	MonoBasicBlock *bb;
 	int i, pos;
 
-	vreg_to_bb = mono_mempool_alloc0 (cfg->mempool, sizeof (gint32*) * cfg->next_vreg + 1);
+	vreg_to_bb = (gint32 *)mono_mempool_alloc0 (cfg->mempool, sizeof (gint32*) * cfg->next_vreg + 1);
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
 	if (cfg->uses_simd_intrinsics)
@@ -13963,7 +13963,7 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 	guint32 *lvregs;
 	guint32 i, lvregs_len;
 	gboolean dest_has_lvreg = FALSE;
-	guint32 stacktypes [128];
+	MonoStackType stacktypes [128];
 	MonoInst **live_range_start, **live_range_end;
 	MonoBasicBlock **live_range_start_bb, **live_range_end_bb;
 	int *gsharedvt_vreg_to_idx = NULL;
@@ -14027,7 +14027,7 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 	}
 
 	if (cfg->gsharedvt) {
-		gsharedvt_vreg_to_idx = mono_mempool_alloc0 (cfg->mempool, sizeof (int) * cfg->next_vreg);
+		gsharedvt_vreg_to_idx = (int *)mono_mempool_alloc0 (cfg->mempool, sizeof (int) * cfg->next_vreg);
 
 		for (i = 0; i < cfg->num_varinfo; ++i) {
 			MonoInst *ins = cfg->varinfo [i];
@@ -14057,8 +14057,8 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 	 * the variable again.
 	 */
 	orig_next_vreg = cfg->next_vreg;
-	vreg_to_lvreg = mono_mempool_alloc0 (cfg->mempool, sizeof (guint32) * cfg->next_vreg);
-	lvregs = mono_mempool_alloc (cfg->mempool, sizeof (guint32) * 1024);
+	vreg_to_lvreg = (guint32 *)mono_mempool_alloc0 (cfg->mempool, sizeof (guint32) * cfg->next_vreg);
+	lvregs = (guint32 *)mono_mempool_alloc (cfg->mempool, sizeof (guint32) * 1024);
 	lvregs_len = 0;
 
 	/* 
@@ -14109,7 +14109,7 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 			 * when variable addresses are known.
 			 */
 			if (ins->opcode == OP_LDADDR) {
-				MonoInst *var = ins->inst_p0;
+				MonoInst *var = (MonoInst *)ins->inst_p0;
 
 				if (var->opcode == OP_VTARG_ADDR) {
 					/* Happens on SPARC/S390 where vtypes are passed by reference */

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1142,9 +1142,9 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 	gboolean is_pinvoke = sig->pinvoke;
 
 	if (mp)
-		cinfo = mono_mempool_alloc0 (mp, sizeof (CallInfo) + (sizeof (ArgInfo) * n));
+		cinfo = (CallInfo *)mono_mempool_alloc0 (mp, sizeof (CallInfo) + (sizeof (ArgInfo) * n));
 	else
-		cinfo = g_malloc0 (sizeof (CallInfo) + (sizeof (ArgInfo) * n));
+		cinfo = (CallInfo *)g_malloc0 (sizeof (CallInfo) + (sizeof (ArgInfo) * n));
 
 	cinfo->nargs = n;
 
@@ -1593,7 +1593,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
-	cinfo = cfg->arch.cinfo;
+	cinfo = (CallInfo *)cfg->arch.cinfo;
 
 	/*
 	 * FIXME: Remove some of the restrictions.
@@ -1776,7 +1776,7 @@ mono_arch_fill_argument_info (MonoCompile *cfg)
 
 	sig = mono_method_signature (cfg->method);
 
-	cinfo = cfg->arch.cinfo;
+	cinfo = (CallInfo *)cfg->arch.cinfo;
 	sig_ret = mini_get_underlying_type (sig->ret);
 
 	/*
@@ -1843,7 +1843,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 
 	sig = mono_method_signature (cfg->method);
 
-	cinfo = cfg->arch.cinfo;
+	cinfo = (CallInfo *)cfg->arch.cinfo;
 	sig_ret = mini_get_underlying_type (sig->ret);
 
 	mono_arch_compute_omit_fp (cfg);
@@ -2071,7 +2071,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
-	cinfo = cfg->arch.cinfo;
+	cinfo = (CallInfo *)cfg->arch.cinfo;
 
 	if (cinfo->ret.storage == ArgValuetypeInReg)
 		cfg->ret_var_is_local = TRUE;
@@ -2984,7 +2984,7 @@ mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 } while (0);
 
 static guint8*
-emit_call_body (MonoCompile *cfg, guint8 *code, guint32 patch_type, gconstpointer data)
+emit_call_body (MonoCompile *cfg, guint8 *code, MonoJumpInfoType patch_type, gconstpointer data)
 {
 	gboolean no_patch = FALSE;
 
@@ -3018,7 +3018,7 @@ emit_call_body (MonoCompile *cfg, guint8 *code, guint32 patch_type, gconstpointe
 				 * The call might go directly to a native function without
 				 * the wrapper.
 				 */
-				MonoJitICallInfo *mi = mono_find_jit_icall_by_name (data);
+				MonoJitICallInfo *mi = mono_find_jit_icall_by_name ((const char *)data);
 				if (mi) {
 					gconstpointer target = mono_icall_get_wrapper (mi);
 					if ((((guint64)target) >> 32) != 0)
@@ -3030,7 +3030,7 @@ emit_call_body (MonoCompile *cfg, guint8 *code, guint32 patch_type, gconstpointe
 			MonoJumpInfo *jinfo = NULL;
 
 			if (cfg->abs_patches)
-				jinfo = g_hash_table_lookup (cfg->abs_patches, data);
+				jinfo = (MonoJumpInfo *)g_hash_table_lookup (cfg->abs_patches, data);
 			if (jinfo) {
 				if (jinfo->type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 					MonoJitICallInfo *mi = mono_find_jit_icall_by_name (jinfo->data.name);
@@ -3109,7 +3109,7 @@ emit_call_body (MonoCompile *cfg, guint8 *code, guint32 patch_type, gconstpointe
 }
 
 static inline guint8*
-emit_call (MonoCompile *cfg, guint8 *code, guint32 patch_type, gconstpointer data, gboolean win64_adjust_stack)
+emit_call (MonoCompile *cfg, guint8 *code, MonoJumpInfoType patch_type, gconstpointer data, gboolean win64_adjust_stack)
 {
 #ifdef TARGET_WIN32
 	if (win64_adjust_stack)
@@ -3597,7 +3597,7 @@ emit_move_return_value (MonoCompile *cfg, MonoInst *ins, guint8 *code)
 	case OP_VCALL2_MEMBASE:
 		cinfo = get_call_info (cfg->mempool, ((MonoCallInst*)ins)->signature);
 		if (cinfo->ret.storage == ArgValuetypeInReg) {
-			MonoInst *loc = cfg->arch.vret_addr_loc;
+			MonoInst *loc = (MonoInst *)cfg->arch.vret_addr_loc;
 
 			/* Load the destination address */
 			g_assert (loc->opcode == OP_REGOFFSET);
@@ -3966,7 +3966,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 		if (G_UNLIKELY (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE))) {
 			cfg->code_size *= 2;
-			cfg->native_code = mono_realloc_native_code(cfg);
+			cfg->native_code = (unsigned char *)mono_realloc_native_code(cfg);
 			code = cfg->native_code + offset;
 			cfg->stat_code_reallocs++;
 		}
@@ -4314,7 +4314,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_SEQ_POINT: {
 			if (ins->flags & MONO_INST_SINGLE_STEP_LOC) {
-				MonoInst *var = cfg->arch.ss_tramp_var;
+				MonoInst *var = (MonoInst *)cfg->arch.ss_tramp_var;
 				guint8 *label;
 
 				/* Load ss_tramp_var */
@@ -4338,7 +4338,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			if (cfg->compile_aot) {
 				guint32 offset = code - cfg->native_code;
 				guint32 val;
-				MonoInst *info_var = cfg->arch.seq_point_info_var;
+				MonoInst *info_var = (MonoInst *)cfg->arch.seq_point_info_var;
 				guint8 *label;
 
 				/* Load info var */
@@ -4353,7 +4353,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				amd64_call_reg (code, AMD64_R11);
 				amd64_patch (label, code);
 			} else {
-				MonoInst *var = cfg->arch.bp_tramp_var;
+				MonoInst *var = (MonoInst *)cfg->arch.bp_tramp_var;
 				guint8 *label;
 
 				/*
@@ -5224,21 +5224,21 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_COND_EXC_IGE_UN:
 		case OP_COND_EXC_ILE:
 		case OP_COND_EXC_ILE_UN:
-			EMIT_COND_SYSTEM_EXCEPTION (cc_table [mono_opcode_to_cond (ins->opcode)], cc_signed_table [mono_opcode_to_cond (ins->opcode)], ins->inst_p1);
+			EMIT_COND_SYSTEM_EXCEPTION (cc_table [mono_opcode_to_cond (ins->opcode)], cc_signed_table [mono_opcode_to_cond (ins->opcode)], (const char *)ins->inst_p1);
 			break;
 		case OP_COND_EXC_OV:
 		case OP_COND_EXC_NO:
 		case OP_COND_EXC_C:
 		case OP_COND_EXC_NC:
 			EMIT_COND_SYSTEM_EXCEPTION (branch_cc_table [ins->opcode - OP_COND_EXC_EQ], 
-						    (ins->opcode < OP_COND_EXC_NE_UN), ins->inst_p1);
+						    (ins->opcode < OP_COND_EXC_NE_UN), (const char *)ins->inst_p1);
 			break;
 		case OP_COND_EXC_IOV:
 		case OP_COND_EXC_INO:
 		case OP_COND_EXC_IC:
 		case OP_COND_EXC_INC:
 			EMIT_COND_SYSTEM_EXCEPTION (branch_cc_table [ins->opcode - OP_COND_EXC_IEQ], 
-						    (ins->opcode < OP_COND_EXC_INE_UN), ins->inst_p1);
+						    (ins->opcode < OP_COND_EXC_INE_UN), (const char *)ins->inst_p1);
 			break;
 
 		/* floating point opcodes */
@@ -6857,7 +6857,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	cfg->code_size = MAX (cfg->header->code_size * 4, 1024);
 
 #if defined(__default_codegen__)
-	code = cfg->native_code = g_malloc (cfg->code_size);
+	code = cfg->native_code = (unsigned char *)g_malloc (cfg->code_size);
 #elif defined(__native_client_codegen__)
 	/* native_code_alloc is not 32-byte aligned, native_code is. */
 	cfg->native_code_alloc = g_malloc (cfg->code_size + kNaClAlignment);
@@ -6968,7 +6968,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		if (G_UNLIKELY (required_code_size >= (cfg->code_size - offset))) {
 			while (required_code_size >= (cfg->code_size - offset))
 				cfg->code_size *= 2;
-			cfg->native_code = mono_realloc_native_code (cfg);
+			cfg->native_code = (unsigned char *)mono_realloc_native_code (cfg);
 			code = cfg->native_code + offset;
 			cfg->stat_code_reallocs++;
 		}
@@ -7138,7 +7138,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	sig = mono_method_signature (method);
 	pos = 0;
 
-	cinfo = cfg->arch.cinfo;
+	cinfo = (CallInfo *)cfg->arch.cinfo;
 
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		/* Save volatile arguments to the stack */
@@ -7243,7 +7243,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 
 	if (trace) {
 		args_clobbered = TRUE;
-		code = mono_arch_instrument_prolog (cfg, mono_trace_enter_method, code, TRUE);
+		code = (guint8 *)mono_arch_instrument_prolog (cfg, mono_trace_enter_method, code, TRUE);
 	}
 
 	if (cfg->prof_options & MONO_PROFILE_ENTER_LEAVE)
@@ -7318,7 +7318,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	}
 
 	if (cfg->gen_sdb_seq_points) {
-		MonoInst *info_var = cfg->arch.seq_point_info_var;
+		MonoInst *info_var = (MonoInst *)cfg->arch.seq_point_info_var;
 
 		/* Initialize seq_point_info_var */
 		if (cfg->compile_aot) {
@@ -7332,7 +7332,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 
 		if (cfg->compile_aot) {
 			/* Initialize ss_tramp_var */
-			ins = cfg->arch.ss_tramp_var;
+			ins = (MonoInst *)cfg->arch.ss_tramp_var;
 			g_assert (ins->opcode == OP_REGOFFSET);
 
 			amd64_mov_reg_membase (code, AMD64_R11, info_var->inst_basereg, info_var->inst_offset, 8);
@@ -7340,14 +7340,14 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 			amd64_mov_membase_reg (code, ins->inst_basereg, ins->inst_offset, AMD64_R11, 8);
 		} else {
 			/* Initialize ss_tramp_var */
-			ins = cfg->arch.ss_tramp_var;
+			ins = (MonoInst *)cfg->arch.ss_tramp_var;
 			g_assert (ins->opcode == OP_REGOFFSET);
 
 			amd64_mov_reg_imm (code, AMD64_R11, (guint64)&ss_trampoline);
 			amd64_mov_membase_reg (code, ins->inst_basereg, ins->inst_offset, AMD64_R11, 8);
 
 			/* Initialize bp_tramp_var */
-			ins = cfg->arch.bp_tramp_var;
+			ins = (MonoInst *)cfg->arch.bp_tramp_var;
 			g_assert (ins->opcode == OP_REGOFFSET);
 
 			amd64_mov_reg_imm (code, AMD64_R11, (guint64)&bp_trampoline);
@@ -7377,7 +7377,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 
 	while (cfg->code_len + max_epilog_size > (cfg->code_size - 16)) {
 		cfg->code_size *= 2;
-		cfg->native_code = mono_realloc_native_code (cfg);
+		cfg->native_code = (unsigned char *)mono_realloc_native_code (cfg);
 		cfg->stat_code_reallocs++;
 	}
 	code = cfg->native_code + cfg->code_len;
@@ -7391,7 +7391,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 	mono_emit_unwind_op_remember_state (cfg, code);
 
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method))
-		code = mono_arch_instrument_epilog (cfg, mono_trace_leave_method, code, TRUE);
+		code = (guint8 *)mono_arch_instrument_epilog (cfg, mono_trace_leave_method, code, TRUE);
 
 	/* the code restoring the registers must be kept in sync with OP_TAILCALL */
 	
@@ -7432,7 +7432,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 	}
 
 	/* Load returned vtypes into registers if needed */
-	cinfo = cfg->arch.cinfo;
+	cinfo = (CallInfo *)cfg->arch.cinfo;
 	if (cinfo->ret.storage == ArgValuetypeInReg) {
 		ArgInfo *ainfo = &cinfo->ret;
 		MonoInst *inst = cfg->ret;
@@ -7507,7 +7507,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 
 	while (cfg->code_len + code_size > (cfg->code_size - 16)) {
 		cfg->code_size *= 2;
-		cfg->native_code = mono_realloc_native_code (cfg);
+		cfg->native_code = (unsigned char *)mono_realloc_native_code (cfg);
 		cfg->stat_code_reallocs++;
 	}
 
@@ -7699,7 +7699,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 void*
 mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean enable_arguments)
 {
-	guchar *code = p;
+	guchar *code = (guchar *)p;
 	MonoMethodSignature *sig;
 	MonoInst *inst;
 	int i, n, stack_area = 0;
@@ -7750,7 +7750,7 @@ enum {
 void*
 mono_arch_instrument_epilog_full (MonoCompile *cfg, void *func, void *p, gboolean enable_arguments, gboolean preserve_argument_registers)
 {
-	guchar *code = p;
+	guchar *code = (guchar *)p;
 	int save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
 	MonoType *ret_type = mini_get_underlying_type (mono_method_signature (method)->ret);
@@ -8009,7 +8009,7 @@ get_delegate_invoke_impl (MonoTrampInfo **info, gboolean has_target, guint32 par
 	unwind_ops = mono_arch_get_cie_program ();
 
 	if (has_target) {
-		start = code = mono_global_codeman_reserve (64);
+		start = code = (guint8 *)mono_global_codeman_reserve (64);
 
 		/* Replace the this argument with the target */
 		amd64_mov_reg_reg (code, AMD64_RAX, AMD64_ARG_REG1, 8);
@@ -8018,7 +8018,7 @@ get_delegate_invoke_impl (MonoTrampInfo **info, gboolean has_target, guint32 par
 
 		g_assert ((code - start) < 64);
 	} else {
-		start = code = mono_global_codeman_reserve (64);
+		start = code = (guint8 *)mono_global_codeman_reserve (64);
 
 		if (param_count == 0) {
 			amd64_jump_membase (code, AMD64_ARG_REG1, MONO_STRUCT_OFFSET (MonoDelegate, method_ptr));
@@ -8080,7 +8080,7 @@ get_delegate_virtual_invoke_impl (MonoTrampInfo **info, gboolean load_imt_reg, i
 	if (offset / (int)sizeof (gpointer) > MAX_VIRTUAL_DELEGATE_OFFSET)
 		return NULL;
 
-	start = code = mono_global_codeman_reserve (size);
+	start = code = (guint8 *)mono_global_codeman_reserve (size);
 
 	unwind_ops = mono_arch_get_cie_program ();
 
@@ -8160,10 +8160,10 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 			return cached;
 
 		if (mono_aot_only) {
-			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
+			start = (guint8 *)mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
-			start = get_delegate_invoke_impl (&info, TRUE, 0);
+			start = (guint8 *)get_delegate_invoke_impl (&info, TRUE, 0);
 			mono_tramp_info_register (info, NULL);
 		}
 
@@ -8184,11 +8184,11 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 
 		if (mono_aot_only) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
-			start = mono_aot_get_trampoline (name);
+			start = (guint8 *)mono_aot_get_trampoline (name);
 			g_free (name);
 		} else {
 			MonoTrampInfo *info;
-			start = get_delegate_invoke_impl (&info, FALSE, sig->param_count);
+			start = (guint8 *)get_delegate_invoke_impl (&info, FALSE, sig->param_count);
 			mono_tramp_info_register (info, NULL);
 		}
 
@@ -8326,9 +8326,9 @@ mono_arch_build_imt_thunk (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckI
 	code = mono_domain_code_reserve (domain, size);
 #else
 	if (fail_tramp)
-		code = mono_method_alloc_generic_virtual_thunk (domain, size);
+		code = (guint8 *)mono_method_alloc_generic_virtual_thunk (domain, size);
 	else
-		code = mono_domain_code_reserve (domain, size);
+		code = (guint8 *)mono_domain_code_reserve (domain, size);
 #endif
 	start = code;
 
@@ -8550,8 +8550,8 @@ mono_arch_install_handler_block_guard (MonoJitInfo *ji, MonoJitExceptionInfo *cl
 	char *bp;
 
 	/*Load the spvar*/
-	bp = MONO_CONTEXT_GET_BP (ctx);
-	sp = *(gpointer*)(bp + clause->exvar_offset);
+	bp = (char *)MONO_CONTEXT_GET_BP (ctx);
+	sp = (gpointer *)*(gpointer*)(bp + clause->exvar_offset);
 
 	old_value = *sp;
 	if (old_value < ji->code_start || (char*)old_value > ((char*)ji->code_start + ji->code_size))
@@ -8570,7 +8570,7 @@ mono_arch_install_handler_block_guard (MonoJitInfo *ji, MonoJitExceptionInfo *cl
  * On AMD64, the result is placed into R11.
  */
 guint8*
-mono_arch_emit_load_aotconst (guint8 *start, guint8 *code, MonoJumpInfo **ji, int tramp_type, gconstpointer target)
+mono_arch_emit_load_aotconst (guint8 *start, guint8 *code, MonoJumpInfo **ji, MonoJumpInfoType tramp_type, gconstpointer target)
 {
 	*ji = mono_patch_info_list_prepend (*ji, code - start, tramp_type, target);
 	amd64_mov_reg_membase (code, AMD64_R11, AMD64_RIP, 0, 8);
@@ -8606,7 +8606,7 @@ mono_arch_set_breakpoint (MonoJitInfo *ji, guint8 *ip)
 
 	if (ji->from_aot) {
 		guint32 native_offset = ip - (guint8*)ji->code_start;
-		SeqPointInfo *info = mono_arch_get_seq_point_info (mono_domain_get (), ji->code_start);
+		SeqPointInfo *info = (SeqPointInfo *)mono_arch_get_seq_point_info (mono_domain_get (), (guint8 *)ji->code_start);
 
 		g_assert (info->bp_addrs [native_offset] == 0);
 		info->bp_addrs [native_offset] = mini_get_breakpoint_trampoline ();
@@ -8630,7 +8630,7 @@ mono_arch_clear_breakpoint (MonoJitInfo *ji, guint8 *ip)
 
 	if (ji->from_aot) {
 		guint32 native_offset = ip - (guint8*)ji->code_start;
-		SeqPointInfo *info = mono_arch_get_seq_point_info (mono_domain_get (), ji->code_start);
+		SeqPointInfo *info = (SeqPointInfo *)mono_arch_get_seq_point_info (mono_domain_get (), (guint8 *)ji->code_start);
 
 		info->bp_addrs [native_offset] = NULL;
 	} else {
@@ -8719,7 +8719,7 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 	// FIXME: Add a free function
 
 	mono_domain_lock (domain);
-	info = g_hash_table_lookup (domain_jit_info (domain)->arch_seq_points,
+	info = (SeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->arch_seq_points,
 								code);
 	mono_domain_unlock (domain);
 
@@ -8728,7 +8728,7 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 		g_assert (ji);
 
 		// FIXME: Optimize the size
-		info = g_malloc0 (sizeof (SeqPointInfo) + (ji->code_size * sizeof (gpointer)));
+		info = (SeqPointInfo *)g_malloc0 (sizeof (SeqPointInfo) + (ji->code_size * sizeof (gpointer)));
 
 		info->ss_tramp_addr = &ss_trampoline;
 

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -144,7 +144,7 @@ mono_regstate_assign (MonoRegState *rs)
 	if (rs->next_vreg > rs->vassign_size) {
 		g_free (rs->vassign);
 		rs->vassign_size = MAX (rs->next_vreg, 256);
-		rs->vassign = g_malloc (rs->vassign_size * sizeof (gint32));
+		rs->vassign = (gint32 *)g_malloc (rs->vassign_size * sizeof (gint32));
 	}
 
 	memset (rs->isymbolic, 0, MONO_MAX_IREGS * sizeof (rs->isymbolic [0]));
@@ -295,7 +295,7 @@ resize_spill_info (MonoCompile *cfg, int bank)
 
 	g_assert (bank < MONO_NUM_REGBANKS);
 
-	new_info = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoSpillInfo) * new_len);
+	new_info = (MonoSpillInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoSpillInfo) * new_len);
 	if (orig_info)
 		memcpy (new_info, orig_info, sizeof (MonoSpillInfo) * orig_len);
 	for (i = orig_len; i < new_len; ++i)
@@ -1180,10 +1180,11 @@ mono_local_regalloc (MonoCompile *cfg, MonoBasicBlock *bb)
 	if (cfg->reginfo && cfg->reginfo_len < max)
 		cfg->reginfo = NULL;
 
-	reginfo = cfg->reginfo;
+	reginfo = (RegTrack *)cfg->reginfo;
 	if (!reginfo) {
 		cfg->reginfo_len = MAX (1024, max * 2);
-		reginfo = cfg->reginfo = mono_mempool_alloc (cfg->mempool, sizeof (RegTrack) * cfg->reginfo_len);
+		reginfo = (RegTrack *)mono_mempool_alloc (cfg->mempool, sizeof (RegTrack) * cfg->reginfo_len);
+		cfg->reginfo = reginfo;
 	} 
 	else
 		g_assert (cfg->reginfo_len >= rs->next_vreg);
@@ -2450,7 +2451,7 @@ mono_opcode_to_cond (int opcode)
 	default:
 		printf ("%s\n", mono_inst_name (opcode));
 		g_assert_not_reached ();
-		return 0;
+		return (CompRelation)0;
 	}
 }
 
@@ -2512,7 +2513,7 @@ mono_opcode_to_type (int opcode, int cmp_opcode)
 		}
 	} else {
 		g_error ("Unknown opcode '%s' in opcode_to_type", mono_inst_name (opcode));
-		return 0;
+		return (CompType)0;
 	}
 }
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -134,7 +134,7 @@ mono_exceptions_init (void)
 	if (mono_llvm_only)
 		cbs.mono_raise_exception = mono_llvm_raise_exception;
 	else
-		cbs.mono_raise_exception = mono_get_throw_exception ();
+		cbs.mono_raise_exception = (void (*)(MonoException *))mono_get_throw_exception ();
 	cbs.mono_raise_exception_with_ctx = mono_raise_exception_with_ctx;
 	cbs.mono_exception_walk_trace = mono_exception_walk_trace;
 	cbs.mono_install_handler_block_guard = mono_install_handler_block_guard;
@@ -238,21 +238,21 @@ find_jit_info (MonoDomain *domain, MonoJitTlsData *jit_tls, MonoJitInfo *res, Mo
 	if (prev_ji && (ip > prev_ji->code_start && ((guint8*)ip < ((guint8*)prev_ji->code_start) + prev_ji->code_size)))
 		ji = prev_ji;
 	else
-		ji = mini_jit_info_table_find (domain, ip, NULL);
+		ji = mini_jit_info_table_find (domain, (char *)ip, NULL);
 
 	if (managed)
 		*managed = FALSE;
 
 	err = mono_arch_unwind_frame (domain, jit_tls, ji, ctx, new_ctx, lmf, NULL, &frame);
 	if (!err)
-		return (gpointer)-1;
+		return (MonoJitInfo *)-1;
 
 	if (*lmf && ((*lmf) != jit_tls->first_lmf) && ((gpointer)MONO_CONTEXT_GET_SP (new_ctx) >= (gpointer)(*lmf))) {
 		/*
 		 * Remove any unused lmf.
 		 * Mask out the lower bits which might be used to hold additional information.
 		 */
-		*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~(SIZEOF_VOID_P -1));
+		*lmf = (MonoLMF *)(((gsize)(*lmf)->previous_lmf) & ~(SIZEOF_VOID_P -1));
 	}
 
 	/* Convert between the new and the old APIs */
@@ -397,7 +397,7 @@ mono_find_jit_info_ext (MonoDomain *domain, MonoJitTlsData *jit_tls,
 	if (prev_ji && (ip > prev_ji->code_start && ((guint8*)ip < ((guint8*)prev_ji->code_start) + prev_ji->code_size)))
 		ji = prev_ji;
 	else
-		ji = mini_jit_info_table_find (domain, ip, &target_domain);
+		ji = mini_jit_info_table_find (domain, (char *)ip, &target_domain);
 
 	if (!target_domain)
 		target_domain = domain;
@@ -414,7 +414,7 @@ mono_find_jit_info_ext (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		 * Remove any unused lmf.
 		 * Mask out the lower bits which might be used to hold additional information.
 		 */
-		*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~(SIZEOF_VOID_P -1));
+		*lmf = (MonoLMF *)(((gsize)(*lmf)->previous_lmf) & ~(SIZEOF_VOID_P -1));
 	}
 
 	if (frame->ji && !frame->ji->is_trampoline && !frame->ji->async)
@@ -524,7 +524,7 @@ get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 		return info;
 	} else {
 		/* Avoid returning a managed object */
-		MonoObject *this_obj = info;
+		MonoObject *this_obj = (MonoObject *)info;
 
 		return this_obj->vtable->klass;
 	}
@@ -542,17 +542,17 @@ get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_info)
 	method = jinfo_get_method (ji);
 	g_assert (method->is_inflated);
 	if (mono_method_get_context (method)->method_inst) {
-		MonoMethodRuntimeGenericContext *mrgctx = generic_info;
+		MonoMethodRuntimeGenericContext *mrgctx = (MonoMethodRuntimeGenericContext *)generic_info;
 
 		klass = mrgctx->class_vtable->klass;
 		context.method_inst = mrgctx->method_inst;
 		g_assert (context.method_inst);
 	} else if ((method->flags & METHOD_ATTRIBUTE_STATIC) || method->klass->valuetype) {
-		MonoVTable *vtable = generic_info;
+		MonoVTable *vtable = (MonoVTable *)generic_info;
 
 		klass = vtable->klass;
 	} else {
-		klass = generic_info;
+		klass = (MonoClass *)generic_info;
 	}
 
 	//g_assert (!method->klass->generic_container);
@@ -623,7 +623,7 @@ mono_exception_walk_trace (MonoException *ex, MonoExceptionFrameWalk func, gpoin
 	for (i = 0; i < len; i++) {
 		gpointer ip = mono_array_get (ta, gpointer, i * 2 + 0);
 		gpointer generic_info = mono_array_get (ta, gpointer, i * 2 + 1);
-		MonoJitInfo *ji = mono_jit_info_table_find (domain, ip);
+		MonoJitInfo *ji = mono_jit_info_table_find (domain, (char *)ip);
 
 		if (ji == NULL) {
 			if (func (NULL, ip, 0, FALSE, user_data))
@@ -663,7 +663,7 @@ ves_icall_get_trace (MonoException *exc, gint32 skip, MonoBoolean need_file_info
 		gpointer generic_info = mono_array_get (ta, gpointer, i * 2 + 1);
 		MonoMethod *method;
 
-		ji = mono_jit_info_table_find (domain, ip);
+		ji = mono_jit_info_table_find (domain, (char *)ip);
 		if (ji == NULL) {
 			/* Unmanaged frame */
 			mono_array_setref (res, i, sf);
@@ -726,7 +726,7 @@ static void
 mono_runtime_walk_stack_with_ctx (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnwindOptions unwind_options, void *user_data)
 {
 	if (!start_ctx) {
-		MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+		MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 		if (jit_tls && jit_tls->orig_ex_ctx_set)
 			start_ctx = &jit_tls->orig_ex_ctx;
 	}
@@ -760,7 +760,7 @@ mono_walk_stack_with_ctx (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnw
 		start_ctx = &extra_ctx;
 	}
 
-	mono_walk_stack_full (func, start_ctx, mono_domain_get (), thread->jit_data, mono_get_lmf (), unwind_options, user_data);
+	mono_walk_stack_full (func, start_ctx, mono_domain_get (), (MonoJitTlsData *)thread->jit_data, mono_get_lmf (), unwind_options, user_data);
 }
 
 /**
@@ -793,9 +793,9 @@ mono_walk_stack_with_state (MonoJitStackWalk func, MonoThreadUnwindState *state,
 
 	mono_walk_stack_full (func,
 		&state->ctx, 
-		state->unwind_data [MONO_UNWIND_DATA_DOMAIN],
-		state->unwind_data [MONO_UNWIND_DATA_JIT_TLS],
-		state->unwind_data [MONO_UNWIND_DATA_LMF],
+		(MonoDomain *)state->unwind_data [MONO_UNWIND_DATA_DOMAIN],
+		(MonoJitTlsData *)state->unwind_data [MONO_UNWIND_DATA_JIT_TLS],
+		(MonoLMF *)state->unwind_data [MONO_UNWIND_DATA_LMF],
 		unwind_options, user_data);
 }
 
@@ -901,7 +901,7 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 			  MonoString **file, gint32 *line, gint32 *column)
 {
 	MonoDomain *domain = mono_domain_get ();
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoLMF *lmf = mono_get_lmf ();
 	MonoJitInfo *ji = NULL;
 	MonoContext ctx, new_ctx;
@@ -1033,7 +1033,7 @@ mini_jit_info_table_find_ext (MonoDomain *domain, char *addr, gboolean allow_tra
 	if (!t)
 		return NULL;
 
-	refs = (t->appdomain_refs) ? *(gpointer *) t->appdomain_refs : NULL;
+	refs = (gpointer *)((t->appdomain_refs) ? *(gpointer *) t->appdomain_refs : NULL);
 	for (; refs && *refs; refs++) {
 		if (*refs != domain && *refs != mono_get_root_domain ()) {
 			ji = mono_jit_info_table_find_internal ((MonoDomain*) *refs, addr, TRUE, allow_trampolines);
@@ -1101,7 +1101,7 @@ wrap_non_exception_throws (MonoMethod *m)
 			if (named_type != 0x54)
 				continue;
 			name_len = mono_metadata_decode_blob_size (p, &p);
-			name = g_malloc (name_len + 1);
+			name = (char *)g_malloc (name_len + 1);
 			memcpy (name, p, name_len);
 			name [name_len] = 0;
 			p += name_len;
@@ -1193,12 +1193,12 @@ setup_stack_trace (MonoException *mono_ex, GSList *dynamic_methods, MonoArray *i
  * OUT_FILTER_IDX. Return TRUE if the exception is caught, FALSE otherwise.
  */
 static gboolean
-mono_handle_exception_internal_first_pass (MonoContext *ctx, gpointer obj, gint32 *out_filter_idx, MonoJitInfo **out_ji, MonoJitInfo **out_prev_ji, MonoObject *non_exception)
+mono_handle_exception_internal_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filter_idx, MonoJitInfo **out_ji, MonoJitInfo **out_prev_ji, MonoObject *non_exception)
 {
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitInfo *ji = NULL;
 	static int (*call_filter) (MonoContext *, gpointer) = NULL;
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoLMF *lmf = mono_get_lmf ();
 	MonoArray *initial_trace_ips = NULL;
 	GList *trace_ips = NULL;
@@ -1214,7 +1214,7 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, gpointer obj, gint3
 
 	g_assert (ctx != NULL);
 
-	if (obj == domain->stack_overflow_ex)
+	if (obj == (MonoObject *)domain->stack_overflow_ex)
 		stack_overflow = TRUE;
 
 	mono_ex = (MonoException*)obj;
@@ -1228,7 +1228,7 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, gpointer obj, gint3
 	}
 
 	if (!call_filter)
-		call_filter = mono_get_call_filter ();
+		call_filter = (int (*) (MonoContext *, void *))mono_get_call_filter ();
 
 	g_assert (jit_tls->end_of_stack);
 	g_assert (jit_tls->abort_func);
@@ -1413,12 +1413,12 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, gpointer obj, gint3
  * @resume: whenever to resume unwinding based on the state in MonoJitTlsData.
  */
 static gboolean
-mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gboolean resume, MonoJitInfo **out_ji)
+mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resume, MonoJitInfo **out_ji)
 {
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitInfo *ji, *prev_ji;
 	static int (*call_filter) (MonoContext *, gpointer) = NULL;
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoLMF *lmf = mono_get_lmf ();
 	MonoException *mono_ex;
 	gboolean stack_overflow = FALSE;
@@ -1440,20 +1440,20 @@ mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gboolean resume,
 	/*
 	 * Allocate a new exception object instead of the preconstructed ones.
 	 */
-	if (obj == domain->stack_overflow_ex) {
+	if (obj == (MonoObject *)domain->stack_overflow_ex) {
 		/*
 		 * It is not a good idea to try and put even more pressure on the little stack available.
 		 * obj = mono_get_exception_stack_overflow ();
 		 */
 		stack_overflow = TRUE;
 	}
-	else if (obj == domain->null_reference_ex) {
-		obj = mono_get_exception_null_reference ();
+	else if (obj == (MonoObject *)domain->null_reference_ex) {
+		obj = (MonoObject *)mono_get_exception_null_reference ();
 	}
 
 	if (!mono_object_isinst (obj, mono_defaults.exception_class)) {
 		non_exception = obj;
-		obj = mono_get_exception_runtime_wrapped (obj);
+		obj = (MonoObject *)mono_get_exception_runtime_wrapped (obj);
 	}
 
 	mono_ex = (MonoException*)obj;
@@ -1492,7 +1492,7 @@ mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gboolean resume,
 	}
 
 	if (!call_filter)
-		call_filter = mono_get_call_filter ();
+		call_filter = (int (*)(MonoContext *, void*))mono_get_call_filter ();
 
 	g_assert (jit_tls->end_of_stack);
 	g_assert (jit_tls->abort_func);
@@ -1540,7 +1540,7 @@ mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gboolean resume,
 		if (!res) {
 			if (mini_get_debug_options ()->break_on_exc)
 				G_BREAKPOINT ();
-			mono_debugger_agent_handle_exception (obj, ctx, NULL);
+			mono_debugger_agent_handle_exception ((MonoException *)obj, ctx, NULL);
 
 			if (mini_get_debug_options ()->suspend_on_unhandled) {
 				mono_runtime_printf_err ("Unhandled exception, suspending...");
@@ -1567,9 +1567,9 @@ mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gboolean resume,
 			}
 
 			if (unhandled)
-				mono_debugger_agent_handle_exception (obj, ctx, NULL);
+				mono_debugger_agent_handle_exception ((MonoException *)obj, ctx, NULL);
 			else
-				mono_debugger_agent_handle_exception (obj, ctx, &ctx_cp);
+				mono_debugger_agent_handle_exception ((MonoException *)obj, ctx, &ctx_cp);
 		}
 	}
 
@@ -1700,7 +1700,7 @@ mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gboolean resume,
 							 *	There aren't any further finally/fault handler blocks down the stack over this exception.
 							 *   This must be ensured by the code that installs the guard trampoline.
 							 */
-							g_assert (ji == mini_jit_info_table_find (domain, MONO_CONTEXT_GET_IP (&jit_tls->handler_block_context), NULL));
+							g_assert (ji == mini_jit_info_table_find (domain, (char *)MONO_CONTEXT_GET_IP (&jit_tls->handler_block_context), NULL));
 
 							if (!is_address_protected (ji, jit_tls->handler_block, ei->handler_start)) {
 								is_outside = TRUE;
@@ -1723,7 +1723,7 @@ mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gboolean resume,
 #ifndef DISABLE_PERFCOUNTERS
 					mono_perfcounters->exceptions_depth += frame_count;
 #endif
-					if (obj == domain->stack_overflow_ex)
+					if (obj == (MonoObject *)domain->stack_overflow_ex)
 						jit_tls->handling_stack_ovf = FALSE;
 
 					return 0;
@@ -1798,7 +1798,7 @@ mono_debugger_run_finally (MonoContext *start_ctx)
 {
 	static int (*call_filter) (MonoContext *, gpointer) = NULL;
 	MonoDomain *domain = mono_domain_get ();
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoLMF *lmf = mono_get_lmf ();
 	MonoContext ctx, new_ctx;
 	MonoJitInfo *ji, rji;
@@ -1811,7 +1811,7 @@ mono_debugger_run_finally (MonoContext *start_ctx)
 		return;
 
 	if (!call_filter)
-		call_filter = mono_get_call_filter ();
+		call_filter = (int (*)(MonoContext *, void *))mono_get_call_filter ();
 
 	for (i = 0; i < ji->num_clauses; i++) {
 		MonoJitExceptionInfo *ei = &ji->clauses [i];
@@ -1829,7 +1829,7 @@ mono_debugger_run_finally (MonoContext *start_ctx)
  * @obj: the exception object
  */
 gboolean
-mono_handle_exception (MonoContext *ctx, gpointer obj)
+mono_handle_exception (MonoContext *ctx, MonoObject *obj)
 {
 #ifndef DISABLE_PERFCOUNTERS
 	mono_perfcounters->exceptions_thrown++;
@@ -1944,7 +1944,7 @@ try_restore_stack_protection (MonoJitTlsData *jit_tls, int extra_bytes)
 static G_GNUC_UNUSED void
 try_more_restore (void)
 {
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	if (try_restore_stack_protection (jit_tls, 500))
 		jit_tls->restore_stack_prot = NULL;
 }
@@ -1952,7 +1952,7 @@ try_more_restore (void)
 static G_GNUC_UNUSED void
 restore_stack_protection (void)
 {
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoException *ex = mono_domain_get ()->stack_overflow_ex;
 	/* if we can't restore the stack protection, keep a callback installed so
 	 * we'll try to restore as much stack as we can at each return from unmanaged
@@ -1971,7 +1971,7 @@ restore_stack_protection (void)
 gpointer
 mono_altstack_restore_prot (mgreg_t *regs, guint8 *code, gpointer *tramp_data, guint8* tramp)
 {
-	void (*func)(void) = (gpointer)tramp_data;
+	void (*func)(void) = (void (*)(void))tramp_data;
 	func ();
 	return NULL;
 }
@@ -2039,7 +2039,7 @@ static gboolean
 print_overflow_stack_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 {
 	MonoMethod *method = NULL;
-	PrintOverflowUserData *user_data = data;
+	PrintOverflowUserData *user_data = (PrintOverflowUserData *)data;
 	gchar *location;
 
 	if (frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE)
@@ -2157,7 +2157,7 @@ mono_handle_native_sigsegv (int signal, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *i
 #ifdef MONO_ARCH_USE_SIGACTION
 	struct sigaction sa;
 #endif
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	const char *signal_str = (signal == SIGSEGV) ? "SIGSEGV" : "SIGABRT";
 
 	if (handling_sigsegv)
@@ -2182,7 +2182,8 @@ mono_handle_native_sigsegv (int signal, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *i
 	if (jit_tls && mono_thread_internal_current ()) {
 		mono_runtime_printf_err ("Stacktrace:\n");
 
-		mono_walk_stack (print_stack_frame_to_stderr, TRUE, NULL);
+		/* FIXME: Is MONO_UNWIND_LOOKUP_IL_OFFSET correct here? */
+		mono_walk_stack (print_stack_frame_to_stderr, MONO_UNWIND_LOOKUP_IL_OFFSET, NULL);
 	}
 
 #ifdef HAVE_BACKTRACE_SYMBOLS
@@ -2371,14 +2372,14 @@ mono_print_thread_dump_from_ctx (MonoContext *ctx)
 void
 mono_resume_unwind (MonoContext *ctx)
 {
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoContext new_ctx;
 
 	MONO_CONTEXT_SET_IP (ctx, MONO_CONTEXT_GET_IP (&jit_tls->resume_state.ctx));
 	MONO_CONTEXT_SET_SP (ctx, MONO_CONTEXT_GET_SP (&jit_tls->resume_state.ctx));
 	new_ctx = *ctx;
 
-	mono_handle_exception_internal (&new_ctx, jit_tls->resume_state.ex_obj, TRUE, NULL);
+	mono_handle_exception_internal (&new_ctx, (MonoObject *)jit_tls->resume_state.ex_obj, TRUE, NULL);
 
 	mono_restore_context (&new_ctx);
 }
@@ -2396,7 +2397,7 @@ find_last_handler_block (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 {
 	int i;
 	gpointer ip;
-	FindHandlerBlockData *pdata = data;
+	FindHandlerBlockData *pdata = (FindHandlerBlockData *)data;
 	MonoJitInfo *ji = frame->ji;
 
 	if (!ji)
@@ -2457,7 +2458,7 @@ gboolean
 mono_install_handler_block_guard (MonoThreadUnwindState *ctx)
 {
 	FindHandlerBlockData data = { 0 };
-	MonoJitTlsData *jit_tls = ctx->unwind_data [MONO_UNWIND_DATA_JIT_TLS];
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)ctx->unwind_data [MONO_UNWIND_DATA_JIT_TLS];
 	gpointer resume_ip;
 
 	/* FIXME */
@@ -2505,7 +2506,7 @@ mono_set_cast_details (MonoClass *from, MonoClass *to)
 	MonoJitTlsData *jit_tls = NULL;
 
 	if (mini_get_debug_options ()->better_cast_details) {
-		jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+		jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 		jit_tls->class_cast_from = from;
 		jit_tls->class_cast_to = to;
 	}
@@ -2612,7 +2613,7 @@ mono_thread_state_init_from_current (MonoThreadUnwindState *ctx)
 static void
 mono_raise_exception_with_ctx (MonoException *exc, MonoContext *ctx)
 {
-	mono_handle_exception (ctx, exc);
+	mono_handle_exception (ctx, (MonoObject *)exc);
 	mono_restore_context (ctx);
 }
 
@@ -2621,7 +2622,7 @@ void
 mono_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
 #ifdef MONO_ARCH_HAVE_SETUP_ASYNC_CALLBACK
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	jit_tls->ex_ctx = *ctx;
 
 	mono_arch_setup_async_callback (ctx, async_cb, user_data);
@@ -2684,7 +2685,7 @@ mono_restore_context (MonoContext *ctx)
 	static void (*restore_context) (MonoContext *);
 
 	if (!restore_context)
-		restore_context = mono_get_restore_context ();
+		restore_context = (void (*)(MonoContext *))mono_get_restore_context ();
 	restore_context (ctx);
 	g_assert_not_reached ();
 }

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -142,35 +142,35 @@ mono_class_check_context_used (MonoClass *klass)
  * LOCKING: loader lock
  */
 static MonoRuntimeGenericContextInfoTemplate*
-get_info_templates (MonoRuntimeGenericContextTemplate *template, int type_argc)
+get_info_templates (MonoRuntimeGenericContextTemplate *template_, int type_argc)
 {
 	g_assert (type_argc >= 0);
 	if (type_argc == 0)
-		return template->infos;
-	return g_slist_nth_data (template->method_templates, type_argc - 1);
+		return template_->infos;
+	return (MonoRuntimeGenericContextInfoTemplate *)g_slist_nth_data (template_->method_templates, type_argc - 1);
 }
 
 /*
  * LOCKING: loader lock
  */
 static void
-set_info_templates (MonoImage *image, MonoRuntimeGenericContextTemplate *template, int type_argc,
+set_info_templates (MonoImage *image, MonoRuntimeGenericContextTemplate *template_, int type_argc,
 	MonoRuntimeGenericContextInfoTemplate *oti)
 {
 	g_assert (type_argc >= 0);
 	if (type_argc == 0)
-		template->infos = oti;
+		template_->infos = oti;
 	else {
-		int length = g_slist_length (template->method_templates);
+		int length = g_slist_length (template_->method_templates);
 		GSList *list;
 
 		/* FIXME: quadratic! */
 		while (length < type_argc) {
-			template->method_templates = g_slist_append_image (image, template->method_templates, NULL);
+			template_->method_templates = g_slist_append_image (image, template_->method_templates, NULL);
 			length++;
 		}
 
-		list = g_slist_nth (template->method_templates, type_argc - 1);
+		list = g_slist_nth (template_->method_templates, type_argc - 1);
 		g_assert (list);
 		list->data = oti;
 	}
@@ -180,23 +180,23 @@ set_info_templates (MonoImage *image, MonoRuntimeGenericContextTemplate *templat
  * LOCKING: loader lock
  */
 static int
-template_get_max_argc (MonoRuntimeGenericContextTemplate *template)
+template_get_max_argc (MonoRuntimeGenericContextTemplate *template_)
 {
-	return g_slist_length (template->method_templates);
+	return g_slist_length (template_->method_templates);
 }
 
 /*
  * LOCKING: loader lock
  */
 static MonoRuntimeGenericContextInfoTemplate*
-rgctx_template_get_other_slot (MonoRuntimeGenericContextTemplate *template, int type_argc, int slot)
+rgctx_template_get_other_slot (MonoRuntimeGenericContextTemplate *template_, int type_argc, int slot)
 {
 	int i;
 	MonoRuntimeGenericContextInfoTemplate *oti;
 
 	g_assert (slot >= 0);
 
-	for (oti = get_info_templates (template, type_argc), i = 0; i < slot; oti = oti->next, ++i) {
+	for (oti = get_info_templates (template_, type_argc), i = 0; i < slot; oti = oti->next, ++i) {
 		if (!oti)
 			return NULL;
 	}
@@ -208,12 +208,12 @@ rgctx_template_get_other_slot (MonoRuntimeGenericContextTemplate *template, int 
  * LOCKING: loader lock
  */
 static int
-rgctx_template_num_infos (MonoRuntimeGenericContextTemplate *template, int type_argc)
+rgctx_template_num_infos (MonoRuntimeGenericContextTemplate *template_, int type_argc)
 {
 	MonoRuntimeGenericContextInfoTemplate *oti;
 	int i;
 
-	for (i = 0, oti = get_info_templates (template, type_argc); oti; ++i, oti = oti->next)
+	for (i = 0, oti = get_info_templates (template_, type_argc); oti; ++i, oti = oti->next)
 		;
 
 	return i;
@@ -245,14 +245,14 @@ class_set_rgctx_template (MonoClass *klass, MonoRuntimeGenericContextTemplate *r
 static MonoRuntimeGenericContextTemplate*
 class_lookup_rgctx_template (MonoClass *klass)
 {
-	MonoRuntimeGenericContextTemplate *template;
+	MonoRuntimeGenericContextTemplate *template_;
 
 	if (!klass->image->rgctx_template_hash)
 		return NULL;
 
-	template = g_hash_table_lookup (klass->image->rgctx_template_hash, klass);
+	template_ = (MonoRuntimeGenericContextTemplate *)g_hash_table_lookup (klass->image->rgctx_template_hash, klass);
 
-	return template;
+	return template_;
 }
 
 /*
@@ -273,7 +273,7 @@ register_generic_subclass (MonoClass *klass)
 	if (!generic_subclass_hash)
 		generic_subclass_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 
-	subclass = g_hash_table_lookup (generic_subclass_hash, parent);
+	subclass = (MonoClass *)g_hash_table_lookup (generic_subclass_hash, parent);
 	rgctx_template->next_subclass = subclass;
 	g_hash_table_insert (generic_subclass_hash, parent, klass);
 }
@@ -351,7 +351,7 @@ alloc_template (MonoClass *klass)
 	num_templates_allocted++;
 	num_templates_bytes += size;
 
-	return mono_image_alloc0 (klass->image, size);
+	return (MonoRuntimeGenericContextTemplate *)mono_image_alloc0 (klass->image, size);
 }
 
 /* LOCKING: Takes the loader lock */
@@ -363,7 +363,7 @@ alloc_oti (MonoImage *image)
 	num_oti_allocted++;
 	num_oti_bytes += size;
 
-	return mono_image_alloc0 (image, size);
+	return (MonoRuntimeGenericContextInfoTemplate *)mono_image_alloc0 (image, size);
 }
 
 #define MONO_RGCTX_SLOT_USED_MARKER	((gpointer)&mono_defaults.object_class->byval_arg)
@@ -383,7 +383,7 @@ info_has_identity (MonoRgctxInfoType info_type)
  * LOCKING: loader lock
  */
 static void
-rgctx_template_set_slot (MonoImage *image, MonoRuntimeGenericContextTemplate *template, int type_argc,
+rgctx_template_set_slot (MonoImage *image, MonoRuntimeGenericContextTemplate *template_, int type_argc,
 	int slot, gpointer data, MonoRgctxInfoType info_type)
 {
 	static gboolean inited = FALSE;
@@ -391,7 +391,7 @@ rgctx_template_set_slot (MonoImage *image, MonoRuntimeGenericContextTemplate *te
 	static int num_data = 0;
 
 	int i;
-	MonoRuntimeGenericContextInfoTemplate *list = get_info_templates (template, type_argc);
+	MonoRuntimeGenericContextInfoTemplate *list = get_info_templates (template_, type_argc);
 	MonoRuntimeGenericContextInfoTemplate **oti = &list;
 
 	if (!inited) {
@@ -416,7 +416,7 @@ rgctx_template_set_slot (MonoImage *image, MonoRuntimeGenericContextTemplate *te
 	(*oti)->data = data;
 	(*oti)->info_type = info_type;
 
-	set_info_templates (image, template, type_argc, list);
+	set_info_templates (image, template_, type_argc, list);
 
 	if (data == MONO_RGCTX_SLOT_USED_MARKER)
 		++num_markers;
@@ -530,7 +530,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_BOX:
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX: {
 		gpointer result = mono_class_inflate_generic_type_with_mempool (temporary ? NULL : klass->image,
-			data, context, &error);
+			(MonoType *)data, context, &error);
 		g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
 		return result;
 	}
@@ -541,7 +541,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	case MONO_RGCTX_INFO_METHOD_CONTEXT:
 	case MONO_RGCTX_INFO_REMOTING_INVOKE_WITH_CHECK:
 	case MONO_RGCTX_INFO_METHOD_DELEGATE_CODE: {
-		MonoMethod *method = data;
+		MonoMethod *method = (MonoMethod *)data;
 		MonoMethod *inflated_method;
 		MonoType *inflated_type = mono_class_inflate_generic_type (&method->klass->byval_arg, context);
 		MonoClass *inflated_class = mono_class_from_mono_type (inflated_type);
@@ -566,12 +566,12 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 		return inflated_method;
 	}
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO: {
-		MonoGSharedVtMethodInfo *oinfo = data;
+		MonoGSharedVtMethodInfo *oinfo = (MonoGSharedVtMethodInfo *)data;
 		MonoGSharedVtMethodInfo *res;
 		MonoDomain *domain = mono_domain_get ();
 		int i;
 
-		res = mono_domain_alloc0 (domain, sizeof (MonoGSharedVtMethodInfo));
+		res = (MonoGSharedVtMethodInfo *)mono_domain_alloc0 (domain, sizeof (MonoGSharedVtMethodInfo));
 		/*
 		res->nlocals = info->nlocals;
 		res->locals_types = g_new0 (MonoType*, info->nlocals);
@@ -579,19 +579,19 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 			res->locals_types [i] = mono_class_inflate_generic_type (info->locals_types [i], context);
 		*/
 		res->num_entries = oinfo->num_entries;
-		res->entries = mono_domain_alloc0 (domain, sizeof (MonoRuntimeGenericContextInfoTemplate) * oinfo->num_entries);
+		res->entries = (MonoRuntimeGenericContextInfoTemplate *)mono_domain_alloc0 (domain, sizeof (MonoRuntimeGenericContextInfoTemplate) * oinfo->num_entries);
 		for (i = 0; i < oinfo->num_entries; ++i) {
 			MonoRuntimeGenericContextInfoTemplate *otemplate = &oinfo->entries [i];
-			MonoRuntimeGenericContextInfoTemplate *template = &res->entries [i];
+			MonoRuntimeGenericContextInfoTemplate *template_ = &res->entries [i];
 
-			memcpy (template, otemplate, sizeof (MonoRuntimeGenericContextInfoTemplate));
-			template->data = inflate_info (template, context, klass, FALSE);
+			memcpy (template_, otemplate, sizeof (MonoRuntimeGenericContextInfoTemplate));
+			template_->data = inflate_info (template_, context, klass, FALSE);
 		}
 		return res;
 	}
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE:
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE_VIRT: {
-		MonoJumpInfoGSharedVtCall *info = data;
+		MonoJumpInfoGSharedVtCall *info = (MonoJumpInfoGSharedVtCall *)data;
 		MonoMethod *method = info->method;
 		MonoMethod *inflated_method;
 		MonoType *inflated_type = mono_class_inflate_generic_type (&method->klass->byval_arg, context);
@@ -599,7 +599,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 		MonoJumpInfoGSharedVtCall *res;
 		MonoDomain *domain = mono_domain_get ();
 
-		res = mono_domain_alloc0 (domain, sizeof (MonoJumpInfoGSharedVtCall));
+		res = (MonoJumpInfoGSharedVtCall *)mono_domain_alloc0 (domain, sizeof (MonoJumpInfoGSharedVtCall));
 		/* Keep the original signature */
 		res->sig = info->sig;
 
@@ -627,7 +627,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 
 	case MONO_RGCTX_INFO_CLASS_FIELD:
 	case MONO_RGCTX_INFO_FIELD_OFFSET: {
-		MonoClassField *field = data;
+		MonoClassField *field = (MonoClassField *)data;
 		MonoType *inflated_type = mono_class_inflate_generic_type (&field->parent->byval_arg, context);
 		MonoClass *inflated_class = mono_class_from_mono_type (inflated_type);
 		int i = field - field->parent->fields;
@@ -641,7 +641,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 		return &inflated_class->fields [i];
 	}
 	case MONO_RGCTX_INFO_SIG_GSHAREDVT_OUT_TRAMPOLINE_CALLI: {
-		MonoMethodSignature *sig = data;
+		MonoMethodSignature *sig = (MonoMethodSignature *)data;
 		MonoMethodSignature *isig;
 		MonoError error;
 
@@ -651,14 +651,14 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	}
 	case MONO_RGCTX_INFO_VIRT_METHOD_CODE:
 	case MONO_RGCTX_INFO_VIRT_METHOD_BOX_TYPE: {
-		MonoJumpInfoVirtMethod *info = data;
+		MonoJumpInfoVirtMethod *info = (MonoJumpInfoVirtMethod *)data;
 		MonoJumpInfoVirtMethod *res;
 		MonoType *t;
 		MonoDomain *domain = mono_domain_get ();
 		MonoError error;
 
 		// FIXME: Temporary
-		res = mono_domain_alloc0 (domain, sizeof (MonoJumpInfoVirtMethod));
+		res = (MonoJumpInfoVirtMethod *)mono_domain_alloc0 (domain, sizeof (MonoJumpInfoVirtMethod));
 		t = mono_class_inflate_generic_type (&info->klass->byval_arg, context);
 		res->klass = mono_class_from_mono_type (t);
 		mono_metadata_free_type (t);
@@ -689,7 +689,7 @@ free_inflated_info (MonoRgctxInfoType info_type, gpointer info)
 	case MONO_RGCTX_INFO_TYPE:
 	case MONO_RGCTX_INFO_REFLECTION_TYPE:
 	case MONO_RGCTX_INFO_CAST_CACHE:
-		mono_metadata_free_type (info);
+		mono_metadata_free_type ((MonoType *)info);
 		break;
 	default:
 		break;
@@ -728,21 +728,21 @@ get_shared_class (MonoClass *klass)
 static MonoRuntimeGenericContextTemplate*
 mono_class_get_runtime_generic_context_template (MonoClass *klass)
 {
-	MonoRuntimeGenericContextTemplate *parent_template, *template;
+	MonoRuntimeGenericContextTemplate *parent_template, *template_;
 	guint32 i;
 
 	klass = get_shared_class (klass);
 
 	mono_loader_lock ();
-	template = class_lookup_rgctx_template (klass);
+	template_ = class_lookup_rgctx_template (klass);
 	mono_loader_unlock ();
 
-	if (template)
-		return template;
+	if (template_)
+		return template_;
 
 	//g_assert (get_shared_class (class) == class);
 
-	template = alloc_template (klass);
+	template_ = alloc_template (klass);
 
 	mono_loader_lock ();
 
@@ -762,7 +762,7 @@ mono_class_get_runtime_generic_context_template (MonoClass *klass)
 
 				oti = class_get_rgctx_template_oti (klass->parent, type_argc, i, FALSE, FALSE, NULL);
 				if (oti.data && oti.data != MONO_RGCTX_SLOT_USED_MARKER) {
-					rgctx_template_set_slot (klass->image, template, type_argc, i,
+					rgctx_template_set_slot (klass->image, template_, type_argc, i,
 											 oti.data, oti.info_type);
 				}
 			}
@@ -771,9 +771,9 @@ mono_class_get_runtime_generic_context_template (MonoClass *klass)
 
 	if (class_lookup_rgctx_template (klass)) {
 		/* some other thread already set the template */
-		template = class_lookup_rgctx_template (klass);
+		template_ = class_lookup_rgctx_template (klass);
 	} else {
-		class_set_rgctx_template (klass, template);
+		class_set_rgctx_template (klass, template_);
 
 		if (klass->parent)
 			register_generic_subclass (klass);
@@ -781,7 +781,7 @@ mono_class_get_runtime_generic_context_template (MonoClass *klass)
 
 	mono_loader_unlock ();
 
-	return template;
+	return template_;
 }
 
 /*
@@ -820,11 +820,11 @@ class_get_rgctx_template_oti (MonoClass *klass, int type_argc, guint32 slot, gbo
 
 		return oti;
 	} else {
-		MonoRuntimeGenericContextTemplate *template;
+		MonoRuntimeGenericContextTemplate *template_;
 		MonoRuntimeGenericContextInfoTemplate *oti;
 
-		template = mono_class_get_runtime_generic_context_template (klass);
-		oti = rgctx_template_get_other_slot (template, type_argc, slot);
+		template_ = mono_class_get_runtime_generic_context_template (klass);
+		oti = rgctx_template_get_other_slot (template_, type_argc, slot);
 		g_assert (oti);
 
 		if (temporary)
@@ -856,8 +856,8 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 	}
 	case MONO_RGCTX_INFO_CAST_CACHE: {
 		/*First slot is the cache itself, the second the vtable.*/
-		gpointer **cache_data = mono_domain_alloc0 (domain, sizeof (gpointer) * 2);
-		cache_data [1] = (gpointer)klass;
+		gpointer **cache_data = (gpointer **)mono_domain_alloc0 (domain, sizeof (gpointer) * 2);
+		cache_data [1] = (gpointer *)klass;
 		return cache_data;
 	}
 	case MONO_RGCTX_INFO_ARRAY_ELEMENT_SIZE:
@@ -913,7 +913,7 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 			if (!domain_info->memcpy_addr [size]) {
 				gpointer addr = mono_compile_method (memcpy_method [size]);
 				mono_memory_barrier ();
-				domain_info->memcpy_addr [size] = addr;
+				domain_info->memcpy_addr [size] = (gpointer *)addr;
 			}
 			return domain_info->memcpy_addr [size];
 		} else {
@@ -933,7 +933,7 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 			if (!domain_info->bzero_addr [size]) {
 				gpointer addr = mono_compile_method (bzero_method [size]);
 				mono_memory_barrier ();
-				domain_info->bzero_addr [size] = addr;
+				domain_info->bzero_addr [size] = (gpointer *)addr;
 			}
 			return domain_info->bzero_addr [size];
 		}
@@ -955,7 +955,7 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 
 		addr = mono_compile_method (method);
 		// The caller uses the gsharedvt call signature
-		ji = mini_jit_info_table_find (mono_domain_get (), mono_get_addr_from_ftnptr (addr), NULL);
+		ji = mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (addr), NULL);
 		g_assert (ji);
 		if (mini_jit_info_is_gsharedvt (ji))
 			return mono_create_static_rgctx_trampoline (method, addr);
@@ -1005,7 +1005,7 @@ typedef struct {
 static guint
 tramp_info_hash (gconstpointer key)
 {
-	GSharedVtTrampInfo *tramp = (gpointer)key;
+	GSharedVtTrampInfo *tramp = (GSharedVtTrampInfo *)key;
 
 	return (gsize)tramp->addr;
 }
@@ -1013,8 +1013,8 @@ tramp_info_hash (gconstpointer key)
 static gboolean
 tramp_info_equal (gconstpointer a, gconstpointer b)
 {
-	GSharedVtTrampInfo *tramp1 = (gpointer)a;
-	GSharedVtTrampInfo *tramp2 = (gpointer)b;
+	GSharedVtTrampInfo *tramp1 = (GSharedVtTrampInfo *)a;
+	GSharedVtTrampInfo *tramp2 = (GSharedVtTrampInfo *)b;
 
 	/* The signatures should be internalized */
 	return tramp1->is_in == tramp2->is_in && tramp1->calli == tramp2->calli && tramp1->vcall_offset == tramp2->vcall_offset &&
@@ -1097,7 +1097,7 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 	num_trampolines ++;
 
 	/* Cache it */
-	tramp_info = mono_domain_alloc0 (domain, sizeof (GSharedVtTrampInfo));
+	tramp_info = (GSharedVtTrampInfo *)mono_domain_alloc0 (domain, sizeof (GSharedVtTrampInfo));
 	memcpy (tramp_info, &tinfo, sizeof (GSharedVtTrampInfo));
 
 	mono_domain_lock (domain);
@@ -1145,7 +1145,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 	case MONO_RGCTX_INFO_BZERO:
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_BOX:
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX: {
-		MonoClass *arg_class = mono_class_from_mono_type (data);
+		MonoClass *arg_class = mono_class_from_mono_type ((MonoType *)data);
 
 		free_inflated_info (oti->info_type, data);
 		g_assert (arg_class);
@@ -1161,17 +1161,17 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 	case MONO_RGCTX_INFO_TYPE:
 		return data;
 	case MONO_RGCTX_INFO_REFLECTION_TYPE:
-		return mono_type_get_object (domain, data);
+		return mono_type_get_object (domain, (MonoType *)data);
 	case MONO_RGCTX_INFO_METHOD:
 		return data;
 	case MONO_RGCTX_INFO_GENERIC_METHOD_CODE: {
 		gpointer addr;
 
-		addr = mono_compile_method (data);
-		return mini_add_method_trampoline (data, addr, mono_method_needs_static_rgctx_invoke (data, FALSE), FALSE);
+		addr = mono_compile_method ((MonoMethod *)data);
+		return mini_add_method_trampoline ((MonoMethod *)data, addr, mono_method_needs_static_rgctx_invoke ((MonoMethod *)data, FALSE), FALSE);
 	}
 	case MONO_RGCTX_INFO_VIRT_METHOD_CODE: {
-		MonoJumpInfoVirtMethod *info = data;
+		MonoJumpInfoVirtMethod *info = (MonoJumpInfoVirtMethod *)data;
 		MonoClass *iface_class = info->method->klass;
 		MonoMethod *method;
 		MonoError error;
@@ -1197,7 +1197,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		return mini_add_method_trampoline (method, addr, mono_method_needs_static_rgctx_invoke (method, FALSE), FALSE);
 	}
 	case MONO_RGCTX_INFO_VIRT_METHOD_BOX_TYPE: {
-		MonoJumpInfoVirtMethod *info = data;
+		MonoJumpInfoVirtMethod *info = (MonoJumpInfoVirtMethod *)data;
 		MonoClass *iface_class = info->method->klass;
 		MonoMethod *method;
 		MonoClass *impl_class;
@@ -1226,14 +1226,14 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 	}
 #ifndef DISABLE_REMOTING
 	case MONO_RGCTX_INFO_REMOTING_INVOKE_WITH_CHECK:
-		return mono_compile_method (mono_marshal_get_remoting_invoke_with_check (data));
+		return mono_compile_method (mono_marshal_get_remoting_invoke_with_check ((MonoMethod *)data));
 #endif
 	case MONO_RGCTX_INFO_METHOD_DELEGATE_CODE:
 		return mono_domain_alloc0 (domain, sizeof (gpointer));
 	case MONO_RGCTX_INFO_CLASS_FIELD:
 		return data;
 	case MONO_RGCTX_INFO_FIELD_OFFSET: {
-		MonoClassField *field = data;
+		MonoClassField *field = (MonoClassField *)data;
 
 		/* The value is offset by 1 */
 		if (field->parent->valuetype && !(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
@@ -1242,7 +1242,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 			return GUINT_TO_POINTER (field->offset + 1);
 	}
 	case MONO_RGCTX_INFO_METHOD_RGCTX: {
-		MonoMethodInflated *method = data;
+		MonoMethodInflated *method = (MonoMethodInflated *)data;
 		MonoVTable *vtable;
 
 		g_assert (method->method.method.is_inflated);
@@ -1255,7 +1255,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		return mono_method_lookup_rgctx (vtable, method->context.method_inst);
 	}
 	case MONO_RGCTX_INFO_METHOD_CONTEXT: {
-		MonoMethodInflated *method = data;
+		MonoMethodInflated *method = (MonoMethodInflated *)data;
 
 		g_assert (method->method.method.is_inflated);
 		g_assert (method->context.method_inst);
@@ -1263,8 +1263,8 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		return method->context.method_inst;
 	}
 	case MONO_RGCTX_INFO_SIG_GSHAREDVT_OUT_TRAMPOLINE_CALLI: {
-		MonoMethodSignature *gsig = oti->data;
-		MonoMethodSignature *sig = data;
+		MonoMethodSignature *gsig = (MonoMethodSignature *)oti->data;
+		MonoMethodSignature *sig = (MonoMethodSignature *)data;
 		gpointer addr;
 
 		/*
@@ -1275,12 +1275,12 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 	}
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE:
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE_VIRT: {
-		MonoJumpInfoGSharedVtCall *call_info = data;
+		MonoJumpInfoGSharedVtCall *call_info = (MonoJumpInfoGSharedVtCall *)data;
 		MonoMethodSignature *call_sig;
 		MonoMethod *method;
 		gpointer addr;
 		MonoJitInfo *callee_ji;
-		gboolean virtual = oti->info_type == MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE_VIRT;
+		gboolean virtual_ = oti->info_type == MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE_VIRT;
 		gint32 vcall_offset;
 		gboolean callee_gsharedvt;
 
@@ -1291,12 +1291,12 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 
 		g_assert (method->is_inflated);
 
-		if (!virtual)
+		if (!virtual_)
 			addr = mono_compile_method (method);
 		else
 			addr = NULL;
 
-		if (virtual) {
+		if (virtual_) {
 			/* Same as in mono_emit_method_call_full () */
 			if ((method->klass->parent == mono_defaults.multicastdelegate_class) && (!strcmp (method->name, "Invoke"))) {
 				/* See mono_emit_method_call_full () */
@@ -1314,7 +1314,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		}
 
 		// FIXME: This loads information in the AOT case
-		callee_ji = mini_jit_info_table_find (mono_domain_get (), mono_get_addr_from_ftnptr (addr), NULL);
+		callee_ji = mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (addr), NULL);
 		callee_gsharedvt = ji_is_gsharedvt (callee_ji);
 
 		/*
@@ -1328,7 +1328,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		 * caller -> out trampoline -> in trampoline -> callee
 		 * This is not very efficient, but it is easy to implement.
 		 */
-		if (virtual || !callee_gsharedvt) {
+		if (virtual_ || !callee_gsharedvt) {
 			MonoMethodSignature *sig, *gsig;
 
 			g_assert (method->is_inflated);
@@ -1382,21 +1382,21 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		return addr;
 	}
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO: {
-		MonoGSharedVtMethodInfo *info = data;
+		MonoGSharedVtMethodInfo *info = (MonoGSharedVtMethodInfo *)data;
 		MonoGSharedVtMethodRuntimeInfo *res;
 		MonoType *t;
 		int i, offset, align, size;
 
 		// FIXME:
-		res = g_malloc0 (sizeof (MonoGSharedVtMethodRuntimeInfo) + (info->num_entries * sizeof (gpointer)));
+		res = (MonoGSharedVtMethodRuntimeInfo *)g_malloc0 (sizeof (MonoGSharedVtMethodRuntimeInfo) + (info->num_entries * sizeof (gpointer)));
 
 		offset = 0;
 		for (i = 0; i < info->num_entries; ++i) {
-			MonoRuntimeGenericContextInfoTemplate *template = &info->entries [i];
+			MonoRuntimeGenericContextInfoTemplate *template_ = &info->entries [i];
 
-			switch (template->info_type) {
+			switch (template_->info_type) {
 			case MONO_RGCTX_INFO_LOCAL_OFFSET:
-				t = template->data;
+				t = (MonoType *)template_->data;
 
 				size = mono_type_size (t, &align);
 
@@ -1412,7 +1412,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 				offset += size;
 				break;
 			default:
-				res->entries [i] = instantiate_info (domain, template, context, klass);
+				res->entries [i] = instantiate_info (domain, template_, context, klass);
 				break;
 			}
 		}
@@ -1433,14 +1433,14 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 static void
 fill_in_rgctx_template_slot (MonoClass *klass, int type_argc, int index, gpointer data, MonoRgctxInfoType info_type)
 {
-	MonoRuntimeGenericContextTemplate *template = mono_class_get_runtime_generic_context_template (klass);
+	MonoRuntimeGenericContextTemplate *template_ = mono_class_get_runtime_generic_context_template (klass);
 	MonoClass *subclass;
 
-	rgctx_template_set_slot (klass->image, template, type_argc, index, data, info_type);
+	rgctx_template_set_slot (klass->image, template_, type_argc, index, data, info_type);
 
 	/* Recurse for all subclasses */
 	if (generic_subclass_hash)
-		subclass = g_hash_table_lookup (generic_subclass_hash, klass);
+		subclass = (MonoClass *)g_hash_table_lookup (generic_subclass_hash, klass);
 	else
 		subclass = NULL;
 
@@ -1514,11 +1514,11 @@ static int
 register_info (MonoClass *klass, int type_argc, gpointer data, MonoRgctxInfoType info_type)
 {
 	int i;
-	MonoRuntimeGenericContextTemplate *template = mono_class_get_runtime_generic_context_template (klass);
+	MonoRuntimeGenericContextTemplate *template_ = mono_class_get_runtime_generic_context_template (klass);
 	MonoClass *parent;
 	MonoRuntimeGenericContextInfoTemplate *oti;
 
-	for (i = 0, oti = get_info_templates (template, type_argc); oti; ++i, oti = oti->next) {
+	for (i = 0, oti = get_info_templates (template_, type_argc); oti; ++i, oti = oti->next) {
 		if (!oti->data)
 			break;
 	}
@@ -1542,7 +1542,7 @@ register_info (MonoClass *klass, int type_argc, gpointer data, MonoRgctxInfoType
 			break;
 
 		rgctx_template_set_slot (parent->image, parent_template, type_argc, i,
-								 MONO_RGCTX_SLOT_USED_MARKER, 0);
+								 MONO_RGCTX_SLOT_USED_MARKER, (MonoRgctxInfoType)0);
 
 		parent = parent->parent;
 	}
@@ -1572,7 +1572,7 @@ info_equal (gpointer data1, gpointer data2, MonoRgctxInfoType info_type)
 	case MONO_RGCTX_INFO_BZERO:
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_BOX:
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX:
-		return mono_class_from_mono_type (data1) == mono_class_from_mono_type (data2);
+		return mono_class_from_mono_type ((MonoType *)data1) == mono_class_from_mono_type ((MonoType *)data2);
 	case MONO_RGCTX_INFO_METHOD:
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO:
 	case MONO_RGCTX_INFO_GENERIC_METHOD_CODE:
@@ -1588,8 +1588,8 @@ info_equal (gpointer data1, gpointer data2, MonoRgctxInfoType info_type)
 		return data1 == data2;
 	case MONO_RGCTX_INFO_VIRT_METHOD_CODE:
 	case MONO_RGCTX_INFO_VIRT_METHOD_BOX_TYPE: {
-		MonoJumpInfoVirtMethod *info1 = data1;
-		MonoJumpInfoVirtMethod *info2 = data2;
+		MonoJumpInfoVirtMethod *info1 = (MonoJumpInfoVirtMethod *)data1;
+		MonoJumpInfoVirtMethod *info2 = (MonoJumpInfoVirtMethod *)data2;
 
 		return info1->klass == info2->klass && info1->method == info2->method;
 	}
@@ -1629,7 +1629,7 @@ mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
 		return MONO_PATCH_INFO_FIELD;
 	default:
 		g_assert_not_reached ();
-		return -1;
+		return (MonoJumpInfoType)-1;
 	}
 }
 
@@ -1756,7 +1756,7 @@ alloc_rgctx_array (MonoDomain *domain, int n, gboolean is_mrgctx)
 	static int mrgctx_bytes_alloced = 0;
 
 	int size = mono_class_rgctx_get_array_size (n, is_mrgctx) * sizeof (gpointer);
-	gpointer array = mono_domain_alloc0 (domain, size);
+	gpointer *array = (gpointer *)mono_domain_alloc0 (domain, size);
 
 	if (!inited) {
 		mono_counters_register ("RGCTX num arrays alloced", MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &rgctx_num_alloced);
@@ -1821,7 +1821,7 @@ fill_runtime_generic_context (MonoVTable *class_vtable, MonoRuntimeGenericContex
 		}
 		if (!rgctx [offset + 0])
 			rgctx [offset + 0] = alloc_rgctx_array (domain, i + 1, method_inst != NULL);
-		rgctx = rgctx [offset + 0];
+		rgctx = (void **)rgctx [offset + 0];
 		first_slot += size - 1;
 		size = mono_class_rgctx_get_array_size (i + 1, method_inst != NULL);
 	}
@@ -1919,7 +1919,7 @@ mono_method_fill_runtime_generic_context (MonoMethodRuntimeGenericContext *mrgct
 static guint
 mrgctx_hash_func (gconstpointer key)
 {
-	const MonoMethodRuntimeGenericContext *mrgctx = key;
+	const MonoMethodRuntimeGenericContext *mrgctx = (const MonoMethodRuntimeGenericContext *)key;
 
 	return mono_aligned_addr_hash (mrgctx->class_vtable) ^ mono_metadata_generic_inst_hash (mrgctx->method_inst);
 }
@@ -1927,8 +1927,8 @@ mrgctx_hash_func (gconstpointer key)
 static gboolean
 mrgctx_equal_func (gconstpointer a, gconstpointer b)
 {
-	const MonoMethodRuntimeGenericContext *mrgctx1 = a;
-	const MonoMethodRuntimeGenericContext *mrgctx2 = b;
+	const MonoMethodRuntimeGenericContext *mrgctx1 = (const MonoMethodRuntimeGenericContext *)a;
+	const MonoMethodRuntimeGenericContext *mrgctx2 = (const MonoMethodRuntimeGenericContext *)b;
 
 	return mrgctx1->class_vtable == mrgctx2->class_vtable &&
 		mono_metadata_generic_inst_equal (mrgctx1->method_inst, mrgctx2->method_inst);
@@ -1961,7 +1961,7 @@ mono_method_lookup_rgctx (MonoVTable *class_vtable, MonoGenericInst *method_inst
 	key.class_vtable = class_vtable;
 	key.method_inst = method_inst;
 
-	mrgctx = g_hash_table_lookup (domain->method_rgctx_hash, &key);
+	mrgctx = (MonoMethodRuntimeGenericContext *)g_hash_table_lookup (domain->method_rgctx_hash, &key);
 
 	if (!mrgctx) {
 		//int i;
@@ -2322,7 +2322,7 @@ get_object_generic_inst (int type_argc)
 	MonoType **type_argv;
 	int i;
 
-	type_argv = alloca (sizeof (MonoType*) * type_argc);
+	type_argv = (MonoType **)alloca (sizeof (MonoType*) * type_argc);
 
 	for (i = 0; i < type_argc; ++i)
 		type_argv [i] = &mono_defaults.object_class->byval_arg;
@@ -2784,11 +2784,11 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	}
 	if (!image->gshared_types [constraint->type])
 		image->gshared_types [constraint->type] = g_hash_table_new (shared_gparam_hash, shared_gparam_equal);
-	res = g_hash_table_lookup (image->gshared_types [constraint->type], &key);
+	res = (MonoType *)g_hash_table_lookup (image->gshared_types [constraint->type], &key);
 	mono_image_unlock (image);
 	if (res)
 		return res;
-	copy = mono_image_alloc0 (image, sizeof (MonoGSharedGenericParam));
+	copy = (MonoGSharedGenericParam *)mono_image_alloc0 (image, sizeof (MonoGSharedGenericParam));
 	memcpy (&copy->param, par, sizeof (MonoGenericParamFull));
 	copy->param.info.pklass = NULL;
 	name = get_shared_gparam_name (constraint->type, ((MonoGenericParamFull*)copy)->info.name);
@@ -2983,7 +2983,7 @@ mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry)
 		slot = mono_method_lookup_or_register_info (entry->method, entry->in_mrgctx, entry->data->data.sig, entry->info_type, mono_method_get_context (entry->method));
 		break;
 	case MONO_PATCH_INFO_GSHAREDVT_CALL: {
-		MonoJumpInfoGSharedVtCall *call_info = g_malloc0 (sizeof (MonoJumpInfoGSharedVtCall)); //mono_domain_alloc0 (domain, sizeof (MonoJumpInfoGSharedVtCall));
+		MonoJumpInfoGSharedVtCall *call_info = (MonoJumpInfoGSharedVtCall *)g_malloc0 (sizeof (MonoJumpInfoGSharedVtCall)); //mono_domain_alloc0 (domain, sizeof (MonoJumpInfoGSharedVtCall));
 
 		memcpy (call_info, entry->data->data.gsharedvt, sizeof (MonoJumpInfoGSharedVtCall));
 		slot = mono_method_lookup_or_register_info (entry->method, entry->in_mrgctx, call_info, entry->info_type, mono_method_get_context (entry->method));
@@ -2995,15 +2995,15 @@ mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry)
 		int i;
 
 		/* Make a copy into the domain mempool */
-		info = g_malloc0 (sizeof (MonoGSharedVtMethodInfo)); //mono_domain_alloc0 (domain, sizeof (MonoGSharedVtMethodInfo));
+		info = (MonoGSharedVtMethodInfo *)g_malloc0 (sizeof (MonoGSharedVtMethodInfo)); //mono_domain_alloc0 (domain, sizeof (MonoGSharedVtMethodInfo));
 		info->method = oinfo->method;
 		info->num_entries = oinfo->num_entries;
-		info->entries = g_malloc0 (sizeof (MonoRuntimeGenericContextInfoTemplate) * info->num_entries);
+		info->entries = (MonoRuntimeGenericContextInfoTemplate *)g_malloc0 (sizeof (MonoRuntimeGenericContextInfoTemplate) * info->num_entries);
 		for (i = 0; i < oinfo->num_entries; ++i) {
 			MonoRuntimeGenericContextInfoTemplate *otemplate = &oinfo->entries [i];
-			MonoRuntimeGenericContextInfoTemplate *template = &info->entries [i];
+			MonoRuntimeGenericContextInfoTemplate *template_ = &info->entries [i];
 
-			memcpy (template, otemplate, sizeof (MonoRuntimeGenericContextInfoTemplate));
+			memcpy (template_, otemplate, sizeof (MonoRuntimeGenericContextInfoTemplate));
 		}
 		slot = mono_method_lookup_or_register_info (entry->method, entry->in_mrgctx, info, entry->info_type, mono_method_get_context (entry->method));
 		break;
@@ -3012,7 +3012,7 @@ mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry)
 		MonoJumpInfoVirtMethod *info;
 		MonoJumpInfoVirtMethod *oinfo = entry->data->data.virt_method;
 
-		info = g_malloc0 (sizeof (MonoJumpInfoVirtMethod));
+		info = (MonoJumpInfoVirtMethod *)g_malloc0 (sizeof (MonoJumpInfoVirtMethod));
 		memcpy (info, oinfo, sizeof (MonoJumpInfoVirtMethod));
 		slot = mono_method_lookup_or_register_info (entry->method, entry->in_mrgctx, info, entry->info_type, mono_method_get_context (entry->method));
 		break;

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -130,19 +130,19 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 
 static GHashTable *mono_saved_signal_handlers = NULL;
 
-static gpointer
+static struct sigaction *
 get_saved_signal_handler (int signo)
 {
 	if (mono_saved_signal_handlers)
 		/* The hash is only modified during startup, so no need for locking */
-		return g_hash_table_lookup (mono_saved_signal_handlers, GINT_TO_POINTER (signo));
+		return (struct sigaction *)g_hash_table_lookup (mono_saved_signal_handlers, GINT_TO_POINTER (signo));
 	return NULL;
 }
 
 static void
 save_old_signal_handler (int signo, struct sigaction *old_action)
 {
-	struct sigaction *handler_to_save = g_malloc (sizeof (struct sigaction));
+	struct sigaction *handler_to_save = (struct sigaction *)g_malloc (sizeof (struct sigaction));
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_CONFIG,
 				"Saving old signal handler for signal %d.", signo);
@@ -189,7 +189,7 @@ gboolean
 MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 {
 	int signal = MONO_SIG_HANDLER_GET_SIGNO ();
-	struct sigaction *saved_handler = get_saved_signal_handler (signal);
+	struct sigaction *saved_handler = (struct sigaction *)get_saved_signal_handler (signal);
 
 	if (saved_handler && saved_handler->sa_handler) {
 		if (!(saved_handler->sa_flags & SA_SIGINFO)) {
@@ -211,7 +211,7 @@ MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 	MONO_SIG_HANDLER_GET_CONTEXT;
 
 	if (mono_thread_internal_current ())
-		ji = mono_jit_info_table_find_internal (mono_domain_get (), mono_arch_ip_from_context (ctx), TRUE, TRUE);
+		ji = mono_jit_info_table_find_internal (mono_domain_get (), (char *)mono_arch_ip_from_context (ctx), TRUE, TRUE);
 	if (!ji) {
         if (mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
 			return;
@@ -257,15 +257,15 @@ per_thread_profiler_hit (void *ctx)
 	MonoProfilerCallChainStrategy call_chain_strategy = mono_profiler_stat_get_call_chain_strategy ();
 
 	if (call_chain_depth == 0) {
-		mono_profiler_stat_hit (mono_arch_ip_from_context (ctx), ctx);
+		mono_profiler_stat_hit ((guchar *)mono_arch_ip_from_context (ctx), ctx);
 	} else {
-		MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+		MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 		int current_frame_index = 1;
 		MonoContext mono_context;
 		guchar *ips [call_chain_depth + 1];
 
 		mono_sigctx_to_monoctx (ctx, &mono_context);
-		ips [0] = MONO_CONTEXT_GET_IP (&mono_context);
+		ips [0] = (guchar *)MONO_CONTEXT_GET_IP (&mono_context);
 		
 		if (jit_tls != NULL) {
 			if (call_chain_strategy == MONO_PROFILER_CALL_CHAIN_NATIVE) {
@@ -274,17 +274,17 @@ per_thread_profiler_hit (void *ctx)
 			guchar *stack_bottom;
 			guchar *stack_top;
 			
-			stack_bottom = jit_tls->end_of_stack;
-			stack_top = MONO_CONTEXT_GET_SP (&mono_context);
-			current_frame = MONO_CONTEXT_GET_BP (&mono_context);
+			stack_bottom = (guchar *)jit_tls->end_of_stack;
+			stack_top = (guchar *)MONO_CONTEXT_GET_SP (&mono_context);
+			current_frame = (guchar *)MONO_CONTEXT_GET_BP (&mono_context);
 			
 			while ((current_frame_index <= call_chain_depth) &&
 					(stack_bottom IS_BEFORE_ON_STACK (guchar*) current_frame) &&
 					((guchar*) current_frame IS_BEFORE_ON_STACK stack_top)) {
-				ips [current_frame_index] = CURRENT_FRAME_GET_RETURN_ADDRESS (current_frame);
+				ips [current_frame_index] = (guchar *)CURRENT_FRAME_GET_RETURN_ADDRESS (current_frame);
 				current_frame_index ++;
 				stack_top = current_frame;
-				current_frame = CURRENT_FRAME_GET_BASE_POINTER (current_frame);
+				current_frame = (guchar *)CURRENT_FRAME_GET_BASE_POINTER (current_frame);
 			}
 #else
 				call_chain_strategy = MONO_PROFILER_CALL_CHAIN_GLIBC;
@@ -310,7 +310,7 @@ per_thread_profiler_hit (void *ctx)
 					ji = mono_find_jit_info (domain, jit_tls, &res, NULL, &mono_context,
 							&new_mono_context, NULL, &lmf, &native_offset, NULL);
 					while ((ji != NULL) && (current_frame_index <= call_chain_depth)) {
-						ips [current_frame_index] = MONO_CONTEXT_GET_IP (&new_mono_context);
+						ips [current_frame_index] = (guchar *)MONO_CONTEXT_GET_IP (&new_mono_context);
 						current_frame_index ++;
 						mono_context = new_mono_context;
 						ji = mono_find_jit_info (domain, jit_tls, &res, NULL, &mono_context,
@@ -393,7 +393,7 @@ add_signal_handler (int signo, gpointer handler)
 	struct sigaction previous_sa;
 
 #ifdef MONO_ARCH_USE_SIGACTION
-	sa.sa_sigaction = handler;
+	sa.sa_sigaction = (void (*)(int, siginfo_t *, void *))handler;
 	sigemptyset (&sa.sa_mask);
 	sa.sa_flags = SA_SIGINFO;
 #ifdef MONO_ARCH_SIGSEGV_ON_ALTSTACK
@@ -658,7 +658,7 @@ void
 mono_gdb_render_native_backtraces (pid_t crashed_pid)
 {
 	const char *argv [9];
-	char template [] = "/tmp/mono-lldb-commands.XXXXXX";
+	char template_ [] = "/tmp/mono-lldb-commands.XXXXXX";
 	char buf1 [128];
 	FILE *commands;
 	gboolean using_lldb = FALSE;
@@ -673,10 +673,10 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 		return;
 
 	if (using_lldb) {
-		if (mkstemp (template) == -1)
+		if (mkstemp (template_) == -1)
 			return;
 
-		commands = fopen (template, "w");
+		commands = fopen (template_, "w");
 
 		fprintf (commands, "process attach --pid %ld\n", (long) crashed_pid);
 		fprintf (commands, "thread list\n");
@@ -688,7 +688,7 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 		fclose (commands);
 
 		argv [1] = "--source";
-		argv [2] = template;
+		argv [2] = template_;
 		argv [3] = 0;
 	} else {
 		argv [1] = "-ex";
@@ -705,7 +705,7 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 	execv (argv [0], (char**)argv);
 
 	if (using_lldb)
-		unlink (template);
+		unlink (template_);
 }
 #endif
 #endif /* __native_client__ */

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -41,8 +41,8 @@ typedef struct {
 static gint
 rgctx_tramp_info_equal (gconstpointer ka, gconstpointer kb)
 {
-	const RgctxTrampInfo *i1 = ka;
-	const RgctxTrampInfo *i2 = kb;
+	const RgctxTrampInfo *i1 = (const RgctxTrampInfo *)ka;
+	const RgctxTrampInfo *i2 = (const RgctxTrampInfo *)kb;
 
 	if (i1->m == i2->m && i1->addr == i2->addr)
 		return 1;
@@ -53,7 +53,7 @@ rgctx_tramp_info_equal (gconstpointer ka, gconstpointer kb)
 static guint
 rgctx_tramp_info_hash (gconstpointer data)
 {
-	const RgctxTrampInfo *info = data;
+	const RgctxTrampInfo *info = (const RgctxTrampInfo *)data;
 
 	return GPOINTER_TO_UINT (info->m) ^ GPOINTER_TO_UINT (info->addr);
 }
@@ -112,11 +112,11 @@ mono_create_static_rgctx_trampoline (MonoMethod *m, gpointer addr)
 	if (mono_aot_only)
 		res = mono_aot_get_static_rgctx_trampoline (ctx, addr);
 	else
-		res = mono_arch_get_static_rgctx_trampoline (m, ctx, addr);
+		res = mono_arch_get_static_rgctx_trampoline (m, (MonoMethodRuntimeGenericContext *)ctx, addr);
 
 	mono_domain_lock (domain);
 	/* Duplicates inserted while we didn't hold the lock are OK */
-	info = mono_domain_alloc (domain, sizeof (RgctxTrampInfo));
+	info = (RgctxTrampInfo *)mono_domain_alloc (domain, sizeof (RgctxTrampInfo));
 	info->m = m;
 	info->addr = addr;
 	g_hash_table_insert (domain_jit_info (domain)->static_rgctx_trampoline_hash, info, res);
@@ -167,7 +167,7 @@ mini_resolve_imt_method (MonoVTable *vt, gpointer *vtable_slot, MonoMethod *imt_
 	/* This has to be variance aware since imt_method can be from an interface that vt->klass doesn't directly implement */
 	interface_offset = mono_class_interface_offset_with_variance (vt->klass, imt_method->klass, &variance_used);
 	if (interface_offset < 0)
-		g_error ("%s doesn't implement interface %s\n", mono_type_get_name_full (&vt->klass->byval_arg, 0), mono_type_get_name_full (&imt_method->klass->byval_arg, 0));
+		g_error ("%s doesn't implement interface %s\n", mono_type_get_name_full (&vt->klass->byval_arg, MONO_TYPE_NAME_FORMAT_IL), mono_type_get_name_full (&imt_method->klass->byval_arg, MONO_TYPE_NAME_FORMAT_IL));
 
 	*variant_iface = NULL;
 	if (imt_method->is_inflated && ((MonoMethodInflated*)imt_method)->context.method_inst) {
@@ -203,7 +203,7 @@ mini_resolve_imt_method (MonoVTable *vt, gpointer *vtable_slot, MonoMethod *imt_
 	} else {
 		/* Avoid loading metadata or creating a generic vtable if possible */
 		if (lookup_aot && !vt->klass->valuetype)
-			aot_addr = mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, interface_offset + mono_method_get_vtable_slot (imt_method));
+			aot_addr = (guint8 *)mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, interface_offset + mono_method_get_vtable_slot (imt_method));
 		else
 			aot_addr = NULL;
 		if (aot_addr)
@@ -298,7 +298,7 @@ mini_add_method_trampoline (MonoMethod *m, gpointer compiled_method, gboolean ad
 	MonoJitInfo *ji;
 
 	// FIXME: This loads information from AOT (perf problem)
-	ji = mini_jit_info_table_find (mono_domain_get (), mono_get_addr_from_ftnptr (compiled_method), NULL);
+	ji = mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (compiled_method), NULL);
 	callee_gsharedvt = mini_jit_info_is_gsharedvt (ji);
 
 	callee_array_helper = FALSE;
@@ -391,18 +391,18 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 	MonoMethod *declaring = NULL;
 	MonoMethod *generic_virtual = NULL, *variant_iface = NULL;
 	int context_used;
-	gboolean imt_call, virtual;
+	gboolean imt_call, virtual_;
 	gpointer *orig_vtable_slot, *vtable_slot_to_patch = NULL;
 	MonoJitInfo *ji = NULL;
 
-	virtual = vt && (gpointer)vtable_slot > (gpointer)vt;
+	virtual_ = vt && (gpointer)vtable_slot > (gpointer)vt;
 	imt_call = vt && (gpointer)vtable_slot < (gpointer)vt;
 
 	/*
 	 * rgctx trampolines are needed when the call is indirect so the caller can't pass
 	 * the rgctx argument needed by the callee.
 	 */
-	if (virtual && m)
+	if (virtual_ && m)
 		need_rgctx_tramp = mono_method_needs_static_rgctx_invoke (m, FALSE);
 
 	orig_vtable_slot = vtable_slot;
@@ -416,7 +416,7 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 		g_assert (vtable_slot);
 
 		imt_method = mono_arch_find_imt_method (regs, code);
-		this_arg = mono_arch_get_this_arg_from_call (regs, code);
+		this_arg = (MonoObject *)mono_arch_get_this_arg_from_call (regs, code);
 
 		if (mono_object_is_transparent_proxy (this_arg)) {
 			/* Use the slow path for now */
@@ -451,7 +451,7 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 	 * The virtual check is needed because is_generic_method_definition (m) could
 	 * return TRUE for methods used in IMT calls too.
 	 */
-	if (virtual && is_generic_method_definition (m)) {
+	if (virtual_ && is_generic_method_definition (m)) {
 		MonoError error;
 		MonoGenericContext context = { NULL, NULL };
 		MonoMethod *declaring;
@@ -499,7 +499,7 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 
 			klass = vtable->klass;
 		} else {
-			MonoObject *this_argument = mono_arch_get_this_arg_from_call (regs, code);
+			MonoObject *this_argument = (MonoObject *)mono_arch_get_this_arg_from_call (regs, code);
 
 			vt = this_argument->vtable;
 			vtable_slot = orig_vtable_slot;
@@ -605,10 +605,10 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 			GSList *list, *tmp;
 
 			mono_domain_lock (domain);
-			list = g_hash_table_lookup (domain_jit_info (domain)->jump_target_got_slot_hash, m);
+			list = (GSList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_got_slot_hash, m);
 			if (list) {
 				for (tmp = list; tmp; tmp = tmp->next) {
-					gpointer *got_slot = tmp->data;
+					gpointer *got_slot = (gpointer *)tmp->data;
 					*got_slot = addr;
 				}
 				g_hash_table_remove (domain_jit_info (domain)->jump_target_got_slot_hash, m);
@@ -635,7 +635,7 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 		if (plt_entry) {
 			if (generic_shared) {
 				target_ji =
-					mini_jit_info_table_find (mono_domain_get (), mono_get_addr_from_ftnptr (compiled_method), NULL);
+					mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (compiled_method), NULL);
 				if (!ji)
 					ji = mini_jit_info_table_find (mono_domain_get (), (char*)code, NULL);
 
@@ -644,7 +644,7 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 				}
 			}
 			if (!no_patch)
-				mono_aot_patch_plt_entry (code, plt_entry, NULL, regs, addr);
+				mono_aot_patch_plt_entry (code, plt_entry, NULL, regs, (guint8 *)addr);
 		} else {
 			if (generic_shared) {
 				if (m->wrapper_type != MONO_WRAPPER_NONE)
@@ -654,7 +654,7 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 
 			/* Patch calling code */
 			target_ji =
-				mini_jit_info_table_find (mono_domain_get (), mono_get_addr_from_ftnptr (compiled_method), NULL);
+				mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (compiled_method), NULL);
 			if (!ji)
 				ji = mini_jit_info_table_find (mono_domain_get (), (char*)code, NULL);
 
@@ -668,7 +668,7 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 			}
 
 			if (!no_patch && mono_method_same_domain (ji, target_ji))
-				mono_arch_patch_callsite (ji->code_start, code, addr);
+				mono_arch_patch_callsite ((guint8 *)ji->code_start, code, (guint8 *)addr);
 		}
 	}
 
@@ -695,7 +695,7 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 {
 	trampoline_calls ++;
 
-	return common_call_trampoline (regs, code, arg, NULL, NULL);
+	return common_call_trampoline (regs, code, (MonoMethod *)arg, NULL, NULL);
 }
 
 /**
@@ -725,7 +725,7 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 	/*
 	 * Obtain the vtable from the 'this' arg.
 	 */
-	this_arg = mono_arch_get_this_arg_from_call (regs, code);
+	this_arg = (MonoObject *)mono_arch_get_this_arg_from_call (regs, code);
 	g_assert (this_arg);
 
 	vt = this_arg->vtable;
@@ -823,7 +823,7 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
 
 	trampoline_calls ++;
 
-	image = *(gpointer*)(gpointer)token_info;
+	image = (MonoImage *)*(gpointer*)(gpointer)token_info;
 	token_info += sizeof (gpointer);
 	token = *(guint32*)(gpointer)token_info;
 
@@ -842,7 +842,7 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
 	plt_entry = mono_aot_get_plt_entry (code);
 	g_assert (plt_entry);
 
-	mono_aot_patch_plt_entry (code, plt_entry, NULL, regs, addr);
+	mono_aot_patch_plt_entry (code, plt_entry, NULL, regs, (guint8 *)addr);
 
 	return addr;
 }
@@ -894,9 +894,9 @@ mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, gu
 	num_lookups++;
 
 	if (mrgctx)
-		return mono_method_fill_runtime_generic_context (arg, index);
+		return mono_method_fill_runtime_generic_context ((MonoMethodRuntimeGenericContext *)arg, index);
 	else
-		return mono_class_fill_runtime_generic_context (arg, index);
+		return mono_class_fill_runtime_generic_context ((MonoVTable *)arg, index);
 }
 
 /*
@@ -914,7 +914,7 @@ create_delegate_trampoline_data (MonoDomain *domain, MonoClass *klass, MonoMetho
 	invoke = mono_get_delegate_invoke (klass);
 	g_assert (invoke);
 
-	tramp_data = mono_domain_alloc0 (domain, sizeof (MonoDelegateTrampInfo));
+	tramp_data = (MonoDelegateTrampInfo *)mono_domain_alloc0 (domain, sizeof (MonoDelegateTrampInfo));
 	tramp_data->invoke = invoke;
 	tramp_data->invoke_sig = mono_method_signature (invoke);
 	tramp_data->impl_this = mono_arch_get_delegate_invoke_impl (mono_method_signature (invoke), TRUE);
@@ -949,8 +949,8 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	gboolean enable_caching = TRUE;
 	MonoDelegateTrampInfo *tramp_info = (MonoDelegateTrampInfo*)arg;
 	MonoMethod *invoke = tramp_info->invoke;
-	guint8 *impl_this = tramp_info->impl_this;
-	guint8 *impl_nothis = tramp_info->impl_nothis;
+	guint8 *impl_this = (guint8 *)tramp_info->impl_this;
+	guint8 *impl_nothis = (guint8 *)tramp_info->impl_nothis;
 	MonoError err;
 	MonoMethodSignature *sig;
 	gpointer addr, compiled_method;
@@ -959,7 +959,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	trampoline_calls ++;
 
 	/* Obtain the delegate object according to the calling convention */
-	delegate = mono_arch_get_this_arg_from_call (regs, code);
+	delegate = (MonoDelegate *)mono_arch_get_this_arg_from_call (regs, code);
 	g_assert (mono_class_has_parent (mono_object_class (delegate), mono_defaults.multicastdelegate_class));
 
 	if (delegate->method) {
@@ -1009,7 +1009,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	// ftnptrs are being used.  "method" would end up null on archtitectures without
 	// ftnptrs so we can just skip this.
 	} else if (delegate->method_ptr) {
-		ji = mono_jit_info_table_find (domain, mono_get_addr_from_ftnptr (delegate->method_ptr));
+		ji = mono_jit_info_table_find (domain, (char *)mono_get_addr_from_ftnptr (delegate->method_ptr));
 		if (ji)
 			method = jinfo_get_method (ji);
 	}
@@ -1073,7 +1073,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 			addr = mini_add_method_trampoline (method, compiled_method, need_rgctx_tramp, need_unbox_tramp);
 			delegate->method_ptr = addr;
 			if (enable_caching && delegate->method_code)
-				*delegate->method_code = delegate->method_ptr;
+				*delegate->method_code = (guint8 *)delegate->method_ptr;
 		}
 	} else {
 		if (need_rgctx_tramp)
@@ -1095,8 +1095,8 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	if (!code) {
 		/* The general, unoptimized case */
 		m = mono_marshal_get_delegate_invoke (invoke, delegate);
-		code = mono_compile_method (m);
-		code = mini_add_method_trampoline (m, code, mono_method_needs_static_rgctx_invoke (m, FALSE), FALSE);
+		code = (guint8 *)mono_compile_method (m);
+		code = (guint8 *)mini_add_method_trampoline (m, code, mono_method_needs_static_rgctx_invoke (m, FALSE), FALSE);
 	}
 
 	delegate->invoke_impl = mono_get_addr_from_ftnptr (code);
@@ -1114,7 +1114,7 @@ mono_handler_block_guard_trampoline (mgreg_t *regs, guint8 *code, gpointer *tram
 {
 	MonoContext ctx;
 	MonoException *exc;
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	gpointer resume_ip = jit_tls->handler_block_return_address;
 
 	memcpy (&ctx, &jit_tls->handler_block_context, sizeof (MonoContext));
@@ -1129,7 +1129,7 @@ mono_handler_block_guard_trampoline (mgreg_t *regs, guint8 *code, gpointer *tram
 		exc = mono_thread_resume_interruption ();
 
 	if (exc) {
-		mono_handle_exception (&ctx, exc);
+		mono_handle_exception (&ctx, (MonoObject *)exc);
 		mono_restore_context (&ctx);
 	}
 
@@ -1306,7 +1306,7 @@ mono_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean ad
 	code = mono_create_specific_trampoline (method, MONO_TRAMPOLINE_JUMP, mono_domain_get (), &code_size);
 	g_assert (code_size);
 
-	ji = mono_domain_alloc0 (domain, MONO_SIZEOF_JIT_INFO);
+	ji = (MonoJitInfo *)mono_domain_alloc0 (domain, MONO_SIZEOF_JIT_INFO);
 	ji->code_start = code;
 	ji->code_size = code_size;
 	ji->d.method = method;
@@ -1383,7 +1383,7 @@ mono_create_jit_trampoline_from_token (MonoImage *image, guint32 token)
 	MonoDomain *domain = mono_domain_get ();
 	guint8 *buf, *start;
 
-	buf = start = mono_domain_alloc0 (domain, 2 * sizeof (gpointer));
+	buf = start = (guint8 *)mono_domain_alloc0 (domain, 2 * sizeof (gpointer));
 
 	*(gpointer*)(gpointer)buf = image;
 	buf += sizeof (gpointer);
@@ -1412,7 +1412,7 @@ mono_create_delegate_trampoline_info (MonoDomain *domain, MonoClass *klass, Mono
 	pair.klass = klass;
 	pair.method = method;
 	mono_domain_lock (domain);
-	tramp_info = g_hash_table_lookup (domain_jit_info (domain)->delegate_trampoline_hash, &pair);
+	tramp_info = (MonoDelegateTrampInfo *)g_hash_table_lookup (domain_jit_info (domain)->delegate_trampoline_hash, &pair);
 	mono_domain_unlock (domain);
 	if (tramp_info)
 		return tramp_info;
@@ -1422,7 +1422,7 @@ mono_create_delegate_trampoline_info (MonoDomain *domain, MonoClass *klass, Mono
 	tramp_info->invoke_impl = mono_create_specific_trampoline (tramp_info, MONO_TRAMPOLINE_DELEGATE, domain, &code_size);
 	g_assert (code_size);
 
-	dpair = mono_domain_alloc0 (domain, sizeof (MonoClassMethodPair));
+	dpair = (MonoClassMethodPair *)mono_domain_alloc0 (domain, sizeof (MonoClassMethodPair));
 	memcpy (dpair, &pair, sizeof (MonoClassMethodPair));
 
 	/* store trampoline address */

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -314,7 +314,7 @@ typedef struct {
 void
 mono_emit_unwind_op (MonoCompile *cfg, int when, int tag, int reg, int val)
 {
-	MonoUnwindOp *op = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoUnwindOp));
+	MonoUnwindOp *op = (MonoUnwindOp *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoUnwindOp));
 
 	op->op = tag;
 	op->reg = reg;
@@ -465,7 +465,7 @@ mono_find_spvar_for_region (MonoCompile *cfg, int region)
 {
 	region = mono_get_block_region_notry (cfg, region);
 
-	return g_hash_table_lookup (cfg->spvars, GINT_TO_POINTER (region));
+	return (MonoInst *)g_hash_table_lookup (cfg->spvars, GINT_TO_POINTER (region));
 }
 
 static void
@@ -787,7 +787,7 @@ set_vreg_to_inst (MonoCompile *cfg, int vreg, MonoInst *inst)
 
 		while (vreg >= cfg->vreg_to_inst_len)
 			cfg->vreg_to_inst_len = cfg->vreg_to_inst_len ? cfg->vreg_to_inst_len * 2 : 32;
-		cfg->vreg_to_inst = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * cfg->vreg_to_inst_len);
+		cfg->vreg_to_inst = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst*) * cfg->vreg_to_inst_len);
 		if (size)
 			memcpy (cfg->vreg_to_inst, tmp, size * sizeof (MonoInst*));
 	}
@@ -949,7 +949,7 @@ mono_mark_vreg_as_ref (MonoCompile *cfg, int vreg)
 
 		while (vreg >= cfg->vreg_is_ref_len)
 			cfg->vreg_is_ref_len = cfg->vreg_is_ref_len ? cfg->vreg_is_ref_len * 2 : 32;
-		cfg->vreg_is_ref = mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * cfg->vreg_is_ref_len);
+		cfg->vreg_is_ref = (gboolean *)mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * cfg->vreg_is_ref_len);
 		if (size)
 			memcpy (cfg->vreg_is_ref, tmp, size * sizeof (gboolean));
 	}
@@ -965,7 +965,7 @@ mono_mark_vreg_as_mp (MonoCompile *cfg, int vreg)
 
 		while (vreg >= cfg->vreg_is_mp_len)
 			cfg->vreg_is_mp_len = cfg->vreg_is_mp_len ? cfg->vreg_is_mp_len * 2 : 32;
-		cfg->vreg_is_mp = mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * cfg->vreg_is_mp_len);
+		cfg->vreg_is_mp = (gboolean *)mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * cfg->vreg_is_mp_len);
 		if (size)
 			memcpy (cfg->vreg_is_mp, tmp, size * sizeof (gboolean));
 	}
@@ -1079,10 +1079,10 @@ mono_add_ins_to_end (MonoBasicBlock *bb, MonoInst *inst)
 void
 mono_create_jump_table (MonoCompile *cfg, MonoInst *label, MonoBasicBlock **bbs, int num_blocks)
 {
-	MonoJumpInfo *ji = mono_mempool_alloc (cfg->mempool, sizeof (MonoJumpInfo));
+	MonoJumpInfo *ji = (MonoJumpInfo *)mono_mempool_alloc (cfg->mempool, sizeof (MonoJumpInfo));
 	MonoJumpInfoBBTable *table;
 
-	table = mono_mempool_alloc (cfg->mempool, sizeof (MonoJumpInfoBBTable));
+	table = (MonoJumpInfoBBTable *)mono_mempool_alloc (cfg->mempool, sizeof (MonoJumpInfoBBTable));
 	table->table = bbs;
 	table->table_size = num_blocks;
 	
@@ -1104,7 +1104,7 @@ mono_get_array_new_va_signature (int arity)
 	if (!sighash) {
 		sighash = g_hash_table_new (NULL, NULL);
 	}
-	else if ((res = g_hash_table_lookup (sighash, GINT_TO_POINTER (arity)))) {
+	else if ((res = (MonoMethodSignature *)g_hash_table_lookup (sighash, GINT_TO_POINTER (arity)))) {
 		mono_jit_unlock ();
 		return res;
 	}
@@ -1269,7 +1269,7 @@ mono_dynamic_code_hash_lookup (MonoDomain *domain, MonoMethod *method)
 	MonoJitDynamicMethodInfo *res;
 
 	if (domain_jit_info (domain)->dynamic_code_hash)
-		res = g_hash_table_lookup (domain_jit_info (domain)->dynamic_code_hash, method);
+		res = (MonoJitDynamicMethodInfo *)g_hash_table_lookup (domain_jit_info (domain)->dynamic_code_hash, method);
 	else
 		res = NULL;
 	return res;
@@ -1319,11 +1319,11 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 
 	LSCAN_DEBUG (printf ("Allocate Stack Slots 2 for %s:\n", mono_method_full_name (cfg->method, TRUE)));
 
-	scalar_stack_slots = mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * MONO_TYPE_PINNED);
+	scalar_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * MONO_TYPE_PINNED);
 	vtype_stack_slots = NULL;
 	nvtypes = 0;
 
-	offsets = mono_mempool_alloc (cfg->mempool, sizeof (gint32) * cfg->num_varinfo);
+	offsets = (gint32 *)mono_mempool_alloc (cfg->mempool, sizeof (gint32) * cfg->num_varinfo);
 	for (i = 0; i < cfg->num_varinfo; ++i)
 		offsets [i] = -1;
 
@@ -1355,7 +1355,7 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 	offset = 0;
 	*stack_align = 0;
 	for (unhandled = vars; unhandled; unhandled = unhandled->next) {
-		MonoMethodVar *current = unhandled->data;
+		MonoMethodVar *current = (MonoMethodVar *)unhandled->data;
 
 		vmv = current;
 		inst = cfg->varinfo [vmv->idx];
@@ -1393,7 +1393,7 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 			/* Fall through */
 		case MONO_TYPE_VALUETYPE:
 			if (!vtype_stack_slots)
-				vtype_stack_slots = mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * 256);
+				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * 256);
 			for (i = 0; i < nvtypes; ++i)
 				if (t->data.klass == vtype_stack_slots [i].vtype)
 					break;
@@ -1632,11 +1632,11 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 	if ((cfg->num_varinfo > 0) && MONO_VARINFO (cfg, 0)->interval)
 		return mono_allocate_stack_slots2 (cfg, backward, stack_size, stack_align);
 
-	scalar_stack_slots = mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * MONO_TYPE_PINNED);
+	scalar_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * MONO_TYPE_PINNED);
 	vtype_stack_slots = NULL;
 	nvtypes = 0;
 
-	offsets = mono_mempool_alloc (cfg->mempool, sizeof (gint32) * cfg->num_varinfo);
+	offsets = (gint32 *)mono_mempool_alloc (cfg->mempool, sizeof (gint32) * cfg->num_varinfo);
 	for (i = 0; i < cfg->num_varinfo; ++i)
 		offsets [i] = -1;
 
@@ -1654,7 +1654,7 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 	offset = 0;
 	*stack_align = sizeof(mgreg_t);
 	for (l = vars; l; l = l->next) {
-		vmv = l->data;
+		vmv = (MonoMethodVar *)l->data;
 		inst = cfg->varinfo [vmv->idx];
 
 		t = mono_type_get_underlying_type (inst->inst_vtype);
@@ -1692,7 +1692,7 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 			/* Fall through */
 		case MONO_TYPE_VALUETYPE:
 			if (!vtype_stack_slots)
-				vtype_stack_slots = mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * 256);
+				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * 256);
 			for (i = 0; i < nvtypes; ++i)
 				if (t->data.klass == vtype_stack_slots [i].vtype)
 					break;
@@ -1893,8 +1893,8 @@ mini_register_opcode_emulation (int opcode, const char *name, const char *sigstr
 	if (emul_opcode_num >= emul_opcode_alloced) {
 		int incr = emul_opcode_alloced? emul_opcode_alloced/2: 16;
 		emul_opcode_alloced += incr;
-		emul_opcode_map = g_realloc (emul_opcode_map, sizeof (emul_opcode_map [0]) * emul_opcode_alloced);
-		emul_opcode_opcodes = g_realloc (emul_opcode_opcodes, sizeof (emul_opcode_opcodes [0]) * emul_opcode_alloced);
+		emul_opcode_map = (MonoJitICallInfo **)g_realloc (emul_opcode_map, sizeof (emul_opcode_map [0]) * emul_opcode_alloced);
+		emul_opcode_opcodes = (short *)g_realloc (emul_opcode_opcodes, sizeof (emul_opcode_opcodes [0]) * emul_opcode_alloced);
 	}
 	emul_opcode_map [emul_opcode_num] = info;
 	emul_opcode_opcodes [emul_opcode_num] = opcode;
@@ -2070,7 +2070,7 @@ mono_destroy_compile (MonoCompile *cfg)
 	if (cfg->exvars)
 		g_hash_table_destroy (cfg->exvars);
 	for (l = cfg->headers_to_free; l; l = l->next)
-		mono_metadata_free_mh (l->data);
+		mono_metadata_free_mh ((MonoMethodHeader *)l->data);
 	g_list_free (cfg->ldstr_list);
 	g_hash_table_destroy (cfg->token_info_hash);
 	if (cfg->abs_patches)
@@ -2174,7 +2174,7 @@ mono_get_lmf_addr_intrinsic (MonoCompile* cfg)
 void
 mono_add_patch_info (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target)
 {
-	MonoJumpInfo *ji = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfo));
+	MonoJumpInfo *ji = (MonoJumpInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfo));
 
 	ji->ip.i = ip;
 	ji->type = type;
@@ -2187,7 +2187,7 @@ mono_add_patch_info (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpoin
 void
 mono_add_patch_info_rel (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target, int relocation)
 {
-	MonoJumpInfo *ji = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfo));
+	MonoJumpInfo *ji = (MonoJumpInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoJumpInfo));
 
 	ji->ip.i = ip;
 	ji->type = type;
@@ -2225,7 +2225,7 @@ mono_add_seq_point (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, int nat
 void
 mono_add_var_location (MonoCompile *cfg, MonoInst *var, gboolean is_reg, int reg, int offset, int from, int to)
 {
-	MonoDwarfLocListEntry *entry = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoDwarfLocListEntry));
+	MonoDwarfLocListEntry *entry = (MonoDwarfLocListEntry *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoDwarfLocListEntry));
 
 	if (is_reg)
 		g_assert (offset == 0);
@@ -2261,7 +2261,7 @@ mono_compile_create_vars (MonoCompile *cfg)
 	if (cfg->verbose_level > 2)
 		g_print ("creating vars\n");
 
-	cfg->args = mono_mempool_alloc0 (cfg->mempool, (sig->param_count + sig->hasthis) * sizeof (MonoInst*));
+	cfg->args = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, (sig->param_count + sig->hasthis) * sizeof (MonoInst*));
 
 	if (sig->hasthis)
 		cfg->args [0] = mono_compile_create_var (cfg, &cfg->method->klass->this_arg, OP_ARG);
@@ -2288,7 +2288,7 @@ mono_compile_create_vars (MonoCompile *cfg)
 	}
 
 	cfg->locals_start = cfg->num_varinfo;
-	cfg->locals = mono_mempool_alloc0 (cfg->mempool, header->num_locals * sizeof (MonoInst*));
+	cfg->locals = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, header->num_locals * sizeof (MonoInst*));
 
 	if (cfg->verbose_level > 2)
 		g_print ("creating locals\n");
@@ -2348,7 +2348,7 @@ mono_postprocess_patches (MonoCompile *cfg)
 
 			if (patch_info->type == MONO_PATCH_INFO_ABS) {
 				if (cfg->abs_patches) {
-					MonoJumpInfo *abs_ji = g_hash_table_lookup (cfg->abs_patches, patch_info->data.target);
+					MonoJumpInfo *abs_ji = (MonoJumpInfo *)g_hash_table_lookup (cfg->abs_patches, patch_info->data.target);
 					if (abs_ji) {
 						patch_info->type = abs_ji->type;
 						patch_info->data.target = abs_ji->data.target;
@@ -2367,9 +2367,9 @@ mono_postprocess_patches (MonoCompile *cfg)
 			table = g_malloc0 (sizeof(gpointer) * patch_info->data.table->table_size);
 #else
 			if (cfg->method->dynamic) {
-				table = mono_code_manager_reserve (cfg->dynamic_info->code_mp, sizeof (gpointer) * patch_info->data.table->table_size);
+				table = (void **)mono_code_manager_reserve (cfg->dynamic_info->code_mp, sizeof (gpointer) * patch_info->data.table->table_size);
 			} else {
-				table = mono_domain_code_reserve (cfg->domain, sizeof (gpointer) * patch_info->data.table->table_size);
+				table = (void **)mono_domain_code_reserve (cfg->domain, sizeof (gpointer) * patch_info->data.table->table_size);
 			}
 #endif
 
@@ -2397,9 +2397,9 @@ mono_postprocess_patches (MonoCompile *cfg)
 #endif
 
 			mono_domain_lock (domain);
-			jlist = g_hash_table_lookup (domain_jit_info (domain)->jump_target_hash, patch_info->data.method);
+			jlist = (MonoJumpList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_hash, patch_info->data.method);
 			if (!jlist) {
-				jlist = mono_domain_alloc0 (domain, sizeof (MonoJumpList));
+				jlist = (MonoJumpList *)mono_domain_alloc0 (domain, sizeof (MonoJumpList));
 				g_hash_table_insert (domain_jit_info (domain)->jump_target_hash, patch_info->data.method, jlist);
 			}
 			jlist->list = g_slist_prepend (jlist->list, ip);
@@ -2515,11 +2515,11 @@ mono_codegen (MonoCompile *cfg)
 
 		if (mono_using_xdebug)
 			/* See the comment for cfg->code_domain */
-			code = mono_domain_code_reserve (code_domain, cfg->code_size + cfg->thunk_area + unwindlen);
+			code = (guint8 *)mono_domain_code_reserve (code_domain, cfg->code_size + cfg->thunk_area + unwindlen);
 		else
-			code = mono_code_manager_reserve (cfg->dynamic_info->code_mp, cfg->code_size + cfg->thunk_area + unwindlen);
+			code = (guint8 *)mono_code_manager_reserve (cfg->dynamic_info->code_mp, cfg->code_size + cfg->thunk_area + unwindlen);
 	} else {
-		code = mono_domain_code_reserve (code_domain, cfg->code_size + cfg->thunk_area + unwindlen);
+		code = (guint8 *)mono_domain_code_reserve (code_domain, cfg->code_size + cfg->thunk_area + unwindlen);
 	}
 #if defined(__native_client_codegen__) && defined(__native_client__)
 	nacl_allow_target_modification (TRUE);
@@ -2685,7 +2685,7 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 	header = cfg->header;
 
 	if (cfg->gshared)
-		flags |= JIT_INFO_HAS_GENERIC_JIT_INFO;
+		flags = (MonoJitInfoFlags)(flags | JIT_INFO_HAS_GENERIC_JIT_INFO);
 
 	if (cfg->arch_eh_jit_info) {
 		MonoJitArgumentInfo *arg_info;
@@ -2699,18 +2699,18 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 		stack_size = mono_arch_get_argument_info (sig, sig->param_count, arg_info);
 
 		if (stack_size)
-			flags |= JIT_INFO_HAS_ARCH_EH_INFO;
+			flags = (MonoJitInfoFlags)(flags | JIT_INFO_HAS_ARCH_EH_INFO);
 	}
 
 	if (cfg->has_unwind_info_for_epilog && !(flags & JIT_INFO_HAS_ARCH_EH_INFO))
-		flags |= JIT_INFO_HAS_ARCH_EH_INFO;
+		flags = (MonoJitInfoFlags)(flags | JIT_INFO_HAS_ARCH_EH_INFO);
 
 	if (cfg->thunk_area)
-		flags |= JIT_INFO_HAS_THUNK_INFO;
+		flags = (MonoJitInfoFlags)(flags | JIT_INFO_HAS_THUNK_INFO);
 
 	if (cfg->try_block_holes) {
 		for (tmp = cfg->try_block_holes; tmp; tmp = tmp->next) {
-			TryBlockHole *hole = tmp->data;
+			TryBlockHole *hole = (TryBlockHole *)tmp->data;
 			MonoExceptionClause *ec = hole->clause;
 			int hole_end = hole->basic_block->native_offset + hole->basic_block->native_length;
 			MonoBasicBlock *clause_last_bb = cfg->cil_offset_to_bb [ec->try_offset + ec->try_len];
@@ -2721,7 +2721,7 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 				++num_holes;
 		}
 		if (num_holes)
-			flags |= JIT_INFO_HAS_TRY_BLOCK_HOLES;
+			flags = (MonoJitInfoFlags)(flags | JIT_INFO_HAS_TRY_BLOCK_HOLES);
 		if (G_UNLIKELY (cfg->verbose_level >= 4))
 			printf ("Number of try block holes %d\n", num_holes);
 	}
@@ -2732,9 +2732,9 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 		num_clauses = header->num_clauses;
 
 	if (cfg->method->dynamic)
-		jinfo = g_malloc0 (mono_jit_info_size (flags, num_clauses, num_holes));
+		jinfo = (MonoJitInfo *)g_malloc0 (mono_jit_info_size (flags, num_clauses, num_holes));
 	else
-		jinfo = mono_domain_alloc0 (cfg->domain, mono_jit_info_size (flags, num_clauses, num_holes));
+		jinfo = (MonoJitInfo *)mono_domain_alloc0 (cfg->domain, mono_jit_info_size (flags, num_clauses, num_holes));
 	mono_jit_info_init (jinfo, cfg->method_to_register, cfg->native_code, cfg->code_len, flags, num_clauses, num_holes);
 	jinfo->domain_neutral = (cfg->opt & MONO_OPT_SHARED) != 0;
 
@@ -2752,7 +2752,7 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 		if (cfg->method->dynamic)
 			gi->generic_sharing_context = g_new0 (MonoGenericSharingContext, 1);
 		else
-			gi->generic_sharing_context = mono_domain_alloc0 (cfg->domain, sizeof (MonoGenericSharingContext));
+			gi->generic_sharing_context = (MonoGenericSharingContext *)mono_domain_alloc0 (cfg->domain, sizeof (MonoGenericSharingContext));
 		mini_init_gsctx (cfg->method->dynamic ? NULL : cfg->domain, NULL, cfg->gsctx_context, gi->generic_sharing_context);
 
 		if ((method_to_compile->flags & METHOD_ATTRIBUTE_STATIC) ||
@@ -2782,9 +2782,9 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 
 			gi->nlocs = g_slist_length (loclist);
 			if (cfg->method->dynamic)
-				gi->locations = g_malloc0 (gi->nlocs * sizeof (MonoDwarfLocListEntry));
+				gi->locations = (MonoDwarfLocListEntry *)g_malloc0 (gi->nlocs * sizeof (MonoDwarfLocListEntry));
 			else
-				gi->locations = mono_domain_alloc0 (cfg->domain, gi->nlocs * sizeof (MonoDwarfLocListEntry));
+				gi->locations = (MonoDwarfLocListEntry *)mono_domain_alloc0 (cfg->domain, gi->nlocs * sizeof (MonoDwarfLocListEntry));
 			i = 0;
 			for (l = loclist; l; l = l->next) {
 				memcpy (&(gi->locations [i]), l->data, sizeof (MonoDwarfLocListEntry));
@@ -2825,7 +2825,7 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 		for (tmp = cfg->try_block_holes; tmp; tmp = tmp->next) {
 			guint32 start_bb_offset;
 			MonoTryBlockHoleJitInfo *hole;
-			TryBlockHole *hole_data = tmp->data;
+			TryBlockHole *hole_data = (TryBlockHole *)tmp->data;
 			MonoExceptionClause *ec = hole_data->clause;
 			int hole_end = hole_data->basic_block->native_offset + hole_data->basic_block->native_length;
 			MonoBasicBlock *clause_last_bb = cfg->cil_offset_to_bb [ec->try_offset + ec->try_len];
@@ -2933,7 +2933,7 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 			ei->handler_start = cfg->native_code + tblock->native_offset;
 
 			for (tmp = cfg->try_block_holes; tmp; tmp = tmp->next) {
-				TryBlockHole *hole = tmp->data;
+				TryBlockHole *hole = (TryBlockHole *)tmp->data;
 				gpointer hole_end = cfg->native_code + (hole->basic_block->native_offset + hole->basic_block->native_length);
 				if (hole->clause == ec && hole_end == ei->try_end) {
 					if (G_UNLIKELY (cfg->verbose_level >= 4))
@@ -3550,7 +3550,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		}
 	}
 
-	cfg->intvars = mono_mempool_alloc0 (cfg->mempool, sizeof (guint16) * STACK_MAX * header->max_stack);
+	cfg->intvars = (guint16 *)mono_mempool_alloc0 (cfg->mempool, sizeof (guint16) * STACK_MAX * header->max_stack);
 
 	if (cfg->verbose_level > 0) {
 		char *method_name;
@@ -3692,7 +3692,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	mono_threads_safepoint ();
 
 	/* Depth-first ordering on basic blocks */
-	cfg->bblocks = mono_mempool_alloc (cfg->mempool, sizeof (MonoBasicBlock*) * (cfg->num_bblocks + 1));
+	cfg->bblocks = (MonoBasicBlock **)mono_mempool_alloc (cfg->mempool, sizeof (MonoBasicBlock*) * (cfg->num_bblocks + 1));
 
 	cfg->max_block_num = cfg->num_bblocks;
 
@@ -3932,7 +3932,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 
 					bb->last_ins->opcode = mono_reverse_branch_op (bb->last_ins->opcode);
 				} else {			
-					MonoInst *inst = mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst));
+					MonoInst *inst = (MonoInst *)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst));
 					inst->opcode = OP_BR;
 					inst->inst_target_bb = bb->last_ins->inst_false_bb;
 					mono_bblock_add_inst (bb, inst);
@@ -4077,7 +4077,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 void
 mono_cfg_add_try_hole (MonoCompile *cfg, MonoExceptionClause *clause, guint8 *start, MonoBasicBlock *bb)
 {
-	TryBlockHole *hole = mono_mempool_alloc (cfg->mempool, sizeof (TryBlockHole));
+	TryBlockHole *hole = (TryBlockHole *)mono_mempool_alloc (cfg->mempool, sizeof (TryBlockHole));
 	hole->clause = clause;
 	hole->start_offset = start - cfg->native_code;
 	hole->basic_block = bb;
@@ -4108,7 +4108,7 @@ create_jit_info_for_trampoline (MonoMethod *wrapper, MonoTrampInfo *info)
 		uw_info = mono_unwind_ops_encode (info->unwind_ops, &info_len);
 	}
 
-	jinfo = mono_domain_alloc0 (domain, MONO_SIZEOF_JIT_INFO);
+	jinfo = (MonoJitInfo *)mono_domain_alloc0 (domain, MONO_SIZEOF_JIT_INFO);
 	jinfo->d.method = wrapper;
 	jinfo->code_start = info->code;
 	jinfo->code_size = info->code_size;
@@ -4156,9 +4156,9 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 		}
 		nm = mono_marshal_get_native_wrapper (method, TRUE, mono_aot_only);
 		code = mono_get_addr_from_ftnptr (mono_compile_method (nm));
-		jinfo = mono_jit_info_table_find (target_domain, code);
+		jinfo = mono_jit_info_table_find (target_domain, (char *)code);
 		if (!jinfo)
-			jinfo = mono_jit_info_table_find (mono_domain_get (), code);
+			jinfo = mono_jit_info_table_find (mono_domain_get (), (char *)code);
 		if (jinfo)
 			mono_profiler_method_end_jit (method, jinfo, MONO_PROFILE_OK);
 		return code;
@@ -4273,7 +4273,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 			ex = mono_loader_error_prepare_exception (error);
 		} else {
 			if (cfg->exception_ptr) {
-				ex = mono_class_get_exception_for_failure (cfg->exception_ptr);
+				ex = mono_class_get_exception_for_failure ((MonoClass *)cfg->exception_ptr);
 			} else {
 				if (cfg->exception_type == MONO_EXCEPTION_MISSING_FIELD)
 					ex = mono_exception_from_name_msg (mono_defaults.corlib, "System", "MissingFieldException", cfg->exception_message);
@@ -4304,7 +4304,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 		ex = mono_exception_from_name_msg (mono_defaults.corlib, "System", "FieldAccessException", cfg->exception_message);
 		break;
 	case MONO_EXCEPTION_OBJECT_SUPPLIED: {
-		MonoException *exp = cfg->exception_ptr;
+		MonoException *exp = (MonoException *)cfg->exception_ptr;
 		MONO_GC_UNREGISTER_ROOT (cfg->exception_ptr);
 
 		ex = exp;
@@ -4388,7 +4388,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 		MonoJumpInfo patch_info;
 		MonoJumpList *jlist;
 		GSList *tmp;
-		jlist = g_hash_table_lookup (domain_jit_info (target_domain)->jump_target_hash, method);
+		jlist = (MonoJumpList *)g_hash_table_lookup (domain_jit_info (target_domain)->jump_target_hash, method);
 		if (jlist) {
 			patch_info.next = NULL;
 			patch_info.ip.i = 0;
@@ -4402,8 +4402,8 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 #endif
 #ifdef MONO_ARCH_HAVE_PATCH_CODE_NEW
 			for (tmp = jlist->list; tmp; tmp = tmp->next) {
-				gpointer target = mono_resolve_patch_target (NULL, target_domain, tmp->data, &patch_info, TRUE);
-				mono_arch_patch_code_new (NULL, target_domain, tmp->data, &patch_info, target);
+				gpointer target = mono_resolve_patch_target (NULL, target_domain, (guint8 *)tmp->data, &patch_info, TRUE);
+				mono_arch_patch_code_new (NULL, target_domain, (guint8 *)tmp->data, &patch_info, target);
 			}
 #else
 			for (tmp = jlist->list; tmp; tmp = tmp->next)

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -389,7 +389,7 @@ enum {
 	} while (0)
 
 #define MONO_INST_NEW(cfg,dest,op) do {	\
-		(dest) = mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoInst));	\
+		(dest) = (MonoInst *)mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoInst));	\
 		(dest)->opcode = (op);	\
 		(dest)->dreg = -1;			    \
 		MONO_INST_NULLIFY_SREGS ((dest));	    \
@@ -397,7 +397,7 @@ enum {
 	} while (0)
 
 #define MONO_INST_NEW_CALL(cfg,dest,op) do {	\
-		(dest) = mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoCallInst));	\
+		(dest) = (MonoCallInst *)mono_mempool_alloc0 ((cfg)->mempool, sizeof (MonoCallInst));	\
 		(dest)->inst.opcode = (op);	\
 		(dest)->inst.dreg = -1;					\
 		MONO_INST_NULLIFY_SREGS (&(dest)->inst);		\
@@ -2576,7 +2576,7 @@ void      mono_arch_decompose_long_opts         (MonoCompile *cfg, MonoInst *ins
 GSList*   mono_arch_get_delegate_invoke_impls   (void);
 LLVMCallInfo* mono_arch_get_llvm_call_info      (MonoCompile *cfg, MonoMethodSignature *sig) MONO_LLVM_INTERNAL;
 guint8*   mono_arch_emit_load_got_addr          (guint8 *start, guint8 *code, MonoCompile *cfg, MonoJumpInfo **ji);
-guint8*   mono_arch_emit_load_aotconst          (guint8 *start, guint8 *code, MonoJumpInfo **ji, int tramp_type, gconstpointer target);
+guint8*   mono_arch_emit_load_aotconst          (guint8 *start, guint8 *code, MonoJumpInfo **ji, MonoJumpInfoType tramp_type, gconstpointer target);
 GSList*   mono_arch_get_cie_program             (void);
 void      mono_arch_set_target                  (char *mtriple);
 gboolean  mono_arch_gsharedvt_sig_supported     (MonoMethodSignature *sig);
@@ -2697,7 +2697,7 @@ mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo 
 typedef gboolean (*MonoJitStackWalk)            (StackFrameInfo *frame, MonoContext *ctx, gpointer data);
 
 void     mono_exceptions_init                   (void);
-gboolean mono_handle_exception                  (MonoContext *ctx, gpointer obj);
+gboolean mono_handle_exception                  (MonoContext *ctx, MonoObject *obj);
 void     mono_handle_native_sigsegv             (int signal, void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo);
 MONO_API void     mono_print_thread_dump                 (void *sigctx);
 MONO_API void     mono_print_thread_dump_from_ctx        (MonoContext *ctx);

--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -58,7 +58,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 
 	for (i = 0; i < cfg->seq_points->len; ++i) {
 		SeqPoint *sp = &seq_points [i];
-		MonoInst *ins = g_ptr_array_index (cfg->seq_points, i);
+		MonoInst *ins = (MonoInst *)g_ptr_array_index (cfg->seq_points, i);
 
 		sp->il_offset = ins->inst_imm;
 		sp->native_offset = ins->inst_offset;
@@ -79,7 +79,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 			bb_seq_points = g_slist_reverse (bb->seq_points);
 			last = NULL;
 			for (l = bb_seq_points; l; l = l->next) {
-				MonoInst *ins = l->data;
+				MonoInst *ins = (MonoInst *)l->data;
 
 				if (ins->inst_imm == METHOD_ENTRY_IL_OFFSET || ins->inst_imm == METHOD_EXIT_IL_OFFSET)
 				/* Used to implement method entry/exit events */
@@ -108,13 +108,13 @@ mono_save_seq_point_info (MonoCompile *cfg)
 				 */
 				l = g_slist_last (bb->seq_points);
 				if (l) {
-					endfinally_seq_point = l->data;
+					endfinally_seq_point = (MonoInst *)l->data;
 
 					for (bb2 = cfg->bb_entry; bb2; bb2 = bb2->next_bb) {
 						GSList *l = g_slist_last (bb2->seq_points);
 
 						if (l) {
-							MonoInst *ins = l->data;
+							MonoInst *ins = (MonoInst *)l->data;
 
 							if (!(ins->inst_imm == METHOD_ENTRY_IL_OFFSET || ins->inst_imm == METHOD_EXIT_IL_OFFSET) && ins != endfinally_seq_point)
 								next [endfinally_seq_point->backend.size] = g_slist_append (next [endfinally_seq_point->backend.size], GUINT_TO_POINTER (ins->backend.size));
@@ -198,12 +198,12 @@ mono_get_seq_points (MonoDomain *domain, MonoMethod *method)
 	}
 
 	mono_loader_lock ();
-	seq_points = g_hash_table_lookup (domain_jit_info (domain)->seq_points, method);
+	seq_points = (MonoSeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->seq_points, method);
 	if (!seq_points && method->is_inflated) {
 		/* generic sharing + aot */
-		seq_points = g_hash_table_lookup (domain_jit_info (domain)->seq_points, declaring_generic_method);
+		seq_points = (MonoSeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->seq_points, declaring_generic_method);
 		if (!seq_points)
-			seq_points = g_hash_table_lookup (domain_jit_info (domain)->seq_points, shared_method);
+			seq_points = (MonoSeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->seq_points, shared_method);
 	}
 	mono_loader_unlock ();
 
@@ -299,6 +299,6 @@ void
 mono_image_get_aot_seq_point_path (MonoImage *image, char **str)
 {
 	int size = strlen (image->name) + strlen (SEQ_POINT_AOT_EXT) + 1;
-	*str = g_malloc (size);
+	*str = (char *)g_malloc (size);
 	g_sprintf (*str, "%s%s", image->name, SEQ_POINT_AOT_EXT);
 }

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -686,7 +686,7 @@ mono_simd_simplify_indirection (MonoCompile *cfg)
 	}
 
 	DEBUG (printf ("[simd-simplify] max vreg is %d\n", max_vreg));
-	vreg_flags = g_malloc0 (max_vreg + 1);
+	vreg_flags = (char *)g_malloc0 (max_vreg + 1);
 	target_bb = g_new0 (MonoBasicBlock*, max_vreg + 1);
 
 	for (i = 0; i < cfg->num_varinfo; i++) {
@@ -1482,7 +1482,7 @@ simd_version_name (guint32 version)
 static MonoInst*
 emit_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args, const SimdIntrinsc *intrinsics, guint32 size)
 {
-	const SimdIntrinsc * result = mono_binary_search (cmethod->name, intrinsics, size, sizeof (SimdIntrinsc), &simd_intrinsic_compare_by_name);
+	const SimdIntrinsc *result = (const SimdIntrinsc *)mono_binary_search (cmethod->name, intrinsics, size, sizeof (SimdIntrinsc), &simd_intrinsic_compare_by_name);
 	if (!result) {
 		DEBUG (printf ("function doesn't have a simd intrinsic %s::%s/%d\n", cmethod->klass->name, cmethod->name, fsig->param_count));
 		return NULL;

--- a/mono/mini/ssa.c
+++ b/mono/mini/ssa.c
@@ -141,7 +141,7 @@ static inline void
 record_use (MonoCompile *cfg, MonoInst *var, MonoBasicBlock *bb, MonoInst *ins)
 {
 	MonoMethodVar *info;
-	MonoVarUsageInfo *ui = mono_mempool_alloc (cfg->mempool, sizeof (MonoVarUsageInfo));
+	MonoVarUsageInfo *ui = (MonoVarUsageInfo *)mono_mempool_alloc (cfg->mempool, sizeof (MonoVarUsageInfo));
 
 	info = MONO_VARINFO (cfg, var->inst_c0);
 	
@@ -352,7 +352,7 @@ mono_ssa_compute (MonoCompile *cfg)
 	mono_compile_dominator_info (cfg, MONO_COMP_DOM | MONO_COMP_IDOM | MONO_COMP_DFRONTIER);
 
 	bitsize = mono_bitset_alloc_size (cfg->num_bblocks, 0);
-	buf = buf_start = g_malloc0 (mono_bitset_alloc_size (cfg->num_bblocks, 0) * cfg->num_varinfo);
+	buf = buf_start = (guint8 *)g_malloc0 (mono_bitset_alloc_size (cfg->num_bblocks, 0) * cfg->num_varinfo);
 
 	for (i = 0; i < cfg->num_varinfo; ++i) {
 		vinfo [i].def_in = mono_bitset_mem_new (buf, cfg->num_bblocks, 0);
@@ -434,7 +434,7 @@ mono_ssa_compute (MonoCompile *cfg)
  			else
  				ins->klass = var->klass;
 
-			ins->inst_phi_args =  mono_mempool_alloc0 (cfg->mempool, sizeof (int) * (cfg->bblocks [idx]->in_count + 1));
+			ins->inst_phi_args = (int *)mono_mempool_alloc0 (cfg->mempool, sizeof (int) * (cfg->bblocks [idx]->in_count + 1));
 			ins->inst_phi_args [0] = cfg->bblocks [idx]->in_count;
 
 			/* For debugging */
@@ -457,7 +457,7 @@ mono_ssa_compute (MonoCompile *cfg)
 
 	/* Renaming phase */
 
-	stack = alloca (sizeof (MonoInst *) * cfg->num_varinfo);
+	stack = (MonoInst **)alloca (sizeof (MonoInst *) * cfg->num_varinfo);
 	memset (stack, 0, sizeof (MonoInst *) * cfg->num_varinfo);
 
 	lvreg_stack = g_new0 (guint32, cfg->next_vreg);
@@ -937,7 +937,7 @@ visit_inst (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, GList **cvars, 
 
 		if (MONO_IS_JUMP_TABLE (ins)) {
 			int i;
-			MonoJumpInfoBBTable *table = MONO_JUMP_TABLE_FROM_INS (ins);
+			MonoJumpInfoBBTable *table = (MonoJumpInfoBBTable *)MONO_JUMP_TABLE_FROM_INS (ins);
 
 			if (!ins->next || ins->next->opcode != OP_PADD) {
 				/* The PADD was optimized away */
@@ -973,7 +973,7 @@ visit_inst (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, GList **cvars, 
 
 		if (ins->opcode == OP_SWITCH) {
 			int i;
-			MonoJumpInfoBBTable *table = ins->inst_p0;
+			MonoJumpInfoBBTable *table = (MonoJumpInfoBBTable *)ins->inst_p0;
 
 			for (i = 0; i < table->table_size; i++)
 				if (table->table [i])
@@ -1049,7 +1049,7 @@ fold_ins (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **carray
 
 		if (MONO_IS_JUMP_TABLE (ins)) {
 			int i;
-			MonoJumpInfoBBTable *table = MONO_JUMP_TABLE_FROM_INS (ins);
+			MonoJumpInfoBBTable *table = (MonoJumpInfoBBTable *)MONO_JUMP_TABLE_FROM_INS (ins);
 
 			if (!ins->next || ins->next->opcode != OP_PADD) {
 				/* The PADD was optimized away */

--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -47,7 +47,7 @@ continuation_mark_frame (MonoContinuation *cont)
 	if (cont->domain)
 		return mono_get_exception_argument ("cont", "Already marked");
 
-	jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	lmf = mono_get_lmf();
 	cont->domain = mono_domain_get ();
 	cont->thread_id = mono_native_thread_id_get ();

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -158,7 +158,7 @@ static void get_string (void)
 	}
 	if (value != NULL)
 		g_free (value);
-	value = g_malloc (input - start + 1);
+	value = (char *)g_malloc (input - start + 1);
 	strncpy (value, start, input-start);
 	value [input-start] = 0;
 }
@@ -431,11 +431,11 @@ mono_trace_enter_method (MonoMethod *method, char *ebp)
 
 	sig = mono_method_signature (method);
 
-	arg_info = alloca (sizeof (MonoJitArgumentInfo) * (sig->param_count + 1));
+	arg_info = (MonoJitArgumentInfo *)alloca (sizeof (MonoJitArgumentInfo) * (sig->param_count + 1));
 
 	if (method->is_inflated) {
 		/* FIXME: Might be better to pass the ji itself */
-		MonoJitInfo *ji = mini_jit_info_table_find (mono_domain_get (), RETURN_ADDRESS (), NULL);
+		MonoJitInfo *ji = mini_jit_info_table_find (mono_domain_get (), (char *)RETURN_ADDRESS (), NULL);
 		if (ji) {
 			gsctx = mono_jit_info_get_generic_sharing_context (ji);
 			if (gsctx && gsctx->is_gsharedvt) {
@@ -455,11 +455,11 @@ mono_trace_enter_method (MonoMethod *method, char *ebp)
 	}
 
 	if (mono_method_signature (method)->hasthis) {
-		gpointer *this = (gpointer *)(ebp + arg_info [0].offset);
+		gpointer *this_obj = (gpointer *)(ebp + arg_info [0].offset);
 		if (method->klass->valuetype) {
-			printf ("value:%p, ", *arg_in_stack_slot(this, gpointer *));
+			printf ("value:%p, ", *arg_in_stack_slot(this_obj, gpointer *));
 		} else {
-			o = *arg_in_stack_slot(this, MonoObject *);
+			o = *arg_in_stack_slot(this_obj, MonoObject *);
 
 			if (o) {
 				klass = o->vtable->klass;
@@ -599,7 +599,7 @@ mono_trace_leave_method (MonoMethod *method, ...)
 
 	if (method->is_inflated) {
 		/* FIXME: Might be better to pass the ji itself */
-		MonoJitInfo *ji = mini_jit_info_table_find (mono_domain_get (), RETURN_ADDRESS (), NULL);
+		MonoJitInfo *ji = mini_jit_info_table_find (mono_domain_get (), (char *)RETURN_ADDRESS (), NULL);
 		if (ji) {
 			gsctx = mono_jit_info_get_generic_sharing_context (ji);
 			if (gsctx && gsctx->is_gsharedvt) {
@@ -694,7 +694,7 @@ mono_trace_leave_method (MonoMethod *method, ...)
 		break;
 	}
 	case MONO_TYPE_VALUETYPE:  {
-		guint8 *p = va_arg (ap, gpointer);
+		guint8 *p = (guint8 *)va_arg (ap, gpointer);
 		int j, size, align;
 		size = mono_type_size (type, &align);
 		printf ("[");

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -361,7 +361,7 @@ mono_unwind_ops_encode_full (GSList *unwind_ops, guint32 *out_len, gboolean enab
 	for (; l; l = l->next) {
 		int reg;
 
-		op = l->data;
+		op = (MonoUnwindOp *)l->data;
 
 		/* Convert the register from the hw encoding to the dwarf encoding */
 		reg = mono_hw_reg_to_dwarf_reg (op->reg);
@@ -446,7 +446,7 @@ mono_unwind_ops_encode_full (GSList *unwind_ops, guint32 *out_len, gboolean enab
 	
 	g_assert (p - buf < 4096);
 	*out_len = p - buf;
-	res = g_malloc (p - buf);
+	res = (guint8 *)g_malloc (p - buf);
 	memcpy (res, buf, p - buf);
 	return res;
 }
@@ -688,7 +688,7 @@ mono_cache_unwind_info (guint8 *unwind_info, guint32 unwind_info_len)
 		}
 	}
 
-	info = g_malloc (sizeof (MonoUnwindInfo) + unwind_info_len);
+	info = (MonoUnwindInfo *)g_malloc (sizeof (MonoUnwindInfo) + unwind_info_len);
 	info->len = unwind_info_len;
 	memcpy (&info->info, unwind_info, unwind_info_len);
 
@@ -881,11 +881,11 @@ decode_lsda (guint8 *lsda, guint8 *code, MonoJitExceptionInfo **ex_info, guint32
 	p = (guint8*)ALIGN_TO ((mgreg_t)p, 4);
 
 	if (ex_info) {
-		*ex_info = g_malloc0 (ncall_sites * sizeof (MonoJitExceptionInfo));
+		*ex_info = (MonoJitExceptionInfo *)g_malloc0 (ncall_sites * sizeof (MonoJitExceptionInfo));
 		*ex_info_len = ncall_sites;
 	}
 	if (type_info)
-		*type_info = g_malloc0 (ncall_sites * sizeof (gpointer));
+		*type_info = (gpointer *)g_malloc0 (ncall_sites * sizeof (gpointer));
 
 	for (i = 0; i < ncall_sites; ++i) {
 		int block_start_offset, block_size, landing_pad;
@@ -1058,7 +1058,7 @@ mono_unwind_decode_fde (guint8 *fde, guint32 *out_len, guint32 *code_len, MonoJi
 	g_assert (return_reg == DWARF_PC_REG);
 
 	buf_len = (cie + cie_len + 4 - cie_cfi) + (fde + fde_len + 4 - fde_cfi);
-	buf = g_malloc0 (buf_len);
+	buf = (guint8 *)g_malloc0 (buf_len);
 
 	i = 0;
 	p = cie_cfi;
@@ -1084,7 +1084,7 @@ mono_unwind_decode_fde (guint8 *fde, guint32 *out_len, guint32 *code_len, MonoJi
 
 	*out_len = i;
 
-	return g_realloc (buf, i);
+	return (guint8 *)g_realloc (buf, i);
 }
 
 /*
@@ -1158,7 +1158,7 @@ mono_unwind_decode_llvm_mono_fde (guint8 *fde, int fde_len, guint8 *cie, guint8 
 	cie_cfi_len = p - cie_cfi;
 	fde_cfi_len = (fde + fde_len - fde_cfi);
 
-	buf = g_malloc0 (cie_cfi_len + fde_cfi_len);
+	buf = (guint8 *)g_malloc0 (cie_cfi_len + fde_cfi_len);
 	memcpy (buf, cie_cfi, cie_cfi_len);
 	memcpy (buf + cie_cfi_len, fde_cfi, fde_cfi_len);
 

--- a/mono/profiler/decode.c
+++ b/mono/profiler/decode.c
@@ -133,7 +133,7 @@ static char*
 pstrdup (const char *s)
 {
 	int len = strlen (s) + 1;
-	char *p = malloc (len);
+	char *p = (char *)malloc (len);
 	memcpy (p, s, len);
 	return p;
 }
@@ -196,7 +196,7 @@ add_counter_to_section (Counter *counter)
 	CounterSection *csection, *s;
 	CounterList *clist;
 
-	clist = calloc (1, sizeof (CounterList));
+	clist = (CounterList *)calloc (1, sizeof (CounterList));
 	clist->counter = counter;
 
 	for (csection = counters_sections; csection; csection = csection->next) {
@@ -212,7 +212,7 @@ add_counter_to_section (Counter *counter)
 	}
 
 	/* If section does not exist */
-	csection = calloc (1, sizeof (CounterSection));
+	csection = (CounterSection *)calloc (1, sizeof (CounterSection));
 	csection->value = counter->section;
 	csection->counters = clist;
 	csection->counters_last = clist;
@@ -237,7 +237,7 @@ add_counter (const char *section, const char *name, int type, int unit, int vari
 		if (list->counter->index == index)
 			return;
 
-	counter = calloc (1, sizeof (Counter));
+	counter = (Counter *)calloc (1, sizeof (Counter));
 	counter->section = section;
 	counter->name = name;
 	counter->type = type;
@@ -245,7 +245,7 @@ add_counter (const char *section, const char *name, int type, int unit, int vari
 	counter->variance = variance;
 	counter->index = index;
 
-	list = calloc (1, sizeof (CounterList));
+	list = (CounterList *)calloc (1, sizeof (CounterList));
 	list->counter = counter;
 
 	if (!counters) {
@@ -268,7 +268,7 @@ add_counter_to_timestamp (uint64_t timestamp, Counter *counter)
 	CounterSection *csection;
 	CounterList *clist;
 
-	clist = calloc (1, sizeof (CounterList));
+	clist = (CounterList *)calloc (1, sizeof (CounterList));
 	clist->counter = counter;
 
 	for (ctimestamp = counters_timestamps; ctimestamp; ctimestamp = ctimestamp->next) {
@@ -286,7 +286,7 @@ add_counter_to_timestamp (uint64_t timestamp, Counter *counter)
 			}
 
 			/* if timestamp exist and section does not exist */
-			csection = calloc (1, sizeof (CounterSection));
+			csection = (CounterSection *)calloc (1, sizeof (CounterSection));
 			csection->value = counter->section;
 			csection->counters = clist;
 			csection->counters_last = clist;
@@ -301,12 +301,12 @@ add_counter_to_timestamp (uint64_t timestamp, Counter *counter)
 	}
 
 	/* If timestamp do not exist and section does not exist */
-	csection = calloc (1, sizeof (CounterSection));
+	csection = (CounterSection *)calloc (1, sizeof (CounterSection));
 	csection->value = counter->section;
 	csection->counters = clist;
 	csection->counters_last = clist;
 
-	ctimestamp = calloc (1, sizeof (CounterTimestamp));
+	ctimestamp = (CounterTimestamp *)calloc (1, sizeof (CounterTimestamp));
 	ctimestamp->value = timestamp;
 	ctimestamp->sections = csection;
 	ctimestamp->sections_last = csection;
@@ -564,7 +564,7 @@ static void
 add_image (intptr_t image, char *name)
 {
 	int slot = ((image >> 2) & 0xffff) % SMALL_HASH_SIZE;
-	ImageDesc *cd = malloc (sizeof (ImageDesc));
+	ImageDesc *cd = (ImageDesc *)malloc (sizeof (ImageDesc));
 	cd->image = image;
 	cd->filename = pstrdup (name);
 	cd->next = image_hash [slot];
@@ -587,7 +587,7 @@ static void
 add_assembly (intptr_t assembly, char *name)
 {
 	int slot = ((assembly >> 2) & 0xffff) % SMALL_HASH_SIZE;
-	AssemblyDesc *cd = malloc (sizeof (AssemblyDesc));
+	AssemblyDesc *cd = (AssemblyDesc *)malloc (sizeof (AssemblyDesc));
 	cd->assembly = assembly;
 	cd->asmname = pstrdup (name);
 	cd->next = assembly_hash [slot];
@@ -635,7 +635,7 @@ add_class (intptr_t klass, const char *name)
 		cd->name = pstrdup (name);
 		return cd;
 	}
-	cd = calloc (sizeof (ClassDesc), 1);
+	cd = (ClassDesc *)calloc (sizeof (ClassDesc), 1);
 	cd->klass = klass;
 	cd->name = pstrdup (name);
 	cd->next = class_hash [slot];
@@ -701,7 +701,7 @@ add_method (intptr_t method, const char *name, intptr_t code, int len)
 		cd->name = pstrdup (name);
 		return cd;
 	}
-	cd = calloc (sizeof (MethodDesc), 1);
+	cd = (MethodDesc *)calloc (sizeof (MethodDesc), 1);
 	cd->method = method;
 	cd->name = pstrdup (name);
 	cd->code = code;
@@ -743,8 +743,8 @@ add_stat_sample (int type, uintptr_t ip) {
 		size_stat_samples *= 2;
 		if (!size_stat_samples)
 		size_stat_samples = 32;
-		stat_samples = realloc (stat_samples, size_stat_samples * sizeof (uintptr_t));
-		stat_sample_desc = realloc (stat_sample_desc, size_stat_samples * sizeof (int));
+		stat_samples = (uintptr_t *)realloc (stat_samples, size_stat_samples * sizeof (uintptr_t));
+		stat_sample_desc = (int *)realloc (stat_sample_desc, size_stat_samples * sizeof (int));
 	}
 	stat_samples [num_stat_samples] = ip;
 	stat_sample_desc [num_stat_samples++] = type;
@@ -772,8 +772,8 @@ lookup_method_by_ip (uintptr_t ip)
 static int
 compare_method_samples (const void *a, const void *b)
 {
-	MethodDesc *const*A = a;
-	MethodDesc *const*B = b;
+	MethodDesc *const *A = (MethodDesc *const *)a;
+	MethodDesc *const *B = (MethodDesc *const *)b;
 	if ((*A)->sample_hits == (*B)->sample_hits)
 		return 0;
 	if ((*B)->sample_hits < (*A)->sample_hits)
@@ -798,8 +798,8 @@ static int usymbols_num = 0;
 static int
 compare_usymbol_addr (const void *a, const void *b)
 {
-	UnmanagedSymbol *const*A = a;
-	UnmanagedSymbol *const*B = b;
+	UnmanagedSymbol *const *A = (UnmanagedSymbol *const *)a;
+	UnmanagedSymbol *const *B = (UnmanagedSymbol *const *)b;
 	if ((*B)->addr == (*A)->addr)
 		return 0;
 	if ((*B)->addr > (*A)->addr)
@@ -810,8 +810,8 @@ compare_usymbol_addr (const void *a, const void *b)
 static int
 compare_usymbol_samples (const void *a, const void *b)
 {
-	UnmanagedSymbol *const*A = a;
-	UnmanagedSymbol *const*B = b;
+	UnmanagedSymbol *const *A = (UnmanagedSymbol *const *)a;
+	UnmanagedSymbol *const *B = (UnmanagedSymbol *const *)b;
 	if ((*B)->sample_hits == (*A)->sample_hits)
 		return 0;
 	if ((*B)->sample_hits < (*A)->sample_hits)
@@ -827,10 +827,10 @@ add_unmanaged_symbol (uintptr_t addr, char *name, uintptr_t size)
 		int new_size = usymbols_size * 2;
 		if (!new_size)
 			new_size = 16;
-		usymbols = realloc (usymbols, sizeof (void*) * new_size);
+		usymbols = (UnmanagedSymbol **)realloc (usymbols, sizeof (void*) * new_size);
 		usymbols_size = new_size;
 	}
-	sym = calloc (sizeof (UnmanagedSymbol), 1);
+	sym = (UnmanagedSymbol *)calloc (sizeof (UnmanagedSymbol), 1);
 	sym->addr = addr;
 	sym->name = name;
 	sym->size = size;
@@ -875,10 +875,10 @@ add_unmanaged_binary (uintptr_t addr, char *name, uintptr_t size)
 		int new_size = ubinaries_size * 2;
 		if (!new_size)
 			new_size = 16;
-		ubinaries = realloc (ubinaries, sizeof (void*) * new_size);
+		ubinaries = (UnmanagedSymbol **)realloc (ubinaries, sizeof (void*) * new_size);
 		ubinaries_size = new_size;
 	}
-	sym = calloc (sizeof (UnmanagedSymbol), 1);
+	sym = (UnmanagedSymbol *)calloc (sizeof (UnmanagedSymbol), 1);
 	sym->addr = addr;
 	sym->name = name;
 	sym->size = size;
@@ -965,7 +965,7 @@ dump_samples (void)
 					msize *= 2;
 					if (!msize)
 						msize = 4;
-					cachedm = realloc (cachedm, sizeof (void*) * msize);
+					cachedm = (MethodDesc **)realloc (cachedm, sizeof (void*) * msize);
 				}
 				cachedm [count++] = m;
 			}
@@ -983,7 +983,7 @@ dump_samples (void)
 						usize *= 2;
 						if (!usize)
 							usize = 4;
-						cachedus = realloc (cachedus, sizeof (void*) * usize);
+						cachedus = (UnmanagedSymbol **)realloc (cachedus, sizeof (void*) * usize);
 					}
 					cachedus [ucount++] = usym;
 				}
@@ -1091,7 +1091,7 @@ add_heap_class_rev (HeapClassDesc *from, HeapClassDesc *to)
 		to->rev_hash_size *= 2;
 		if (to->rev_hash_size == 0)
 			to->rev_hash_size = 4;
-		n = calloc (sizeof (HeapClassRevRef) * to->rev_hash_size, 1);
+		n = (HeapClassRevRef *)calloc (sizeof (HeapClassRevRef) * to->rev_hash_size, 1);
 		for (i = 0; i < old_size; ++i) {
 			if (to->rev_hash [i].klass)
 				add_rev_class_hashed (n, to->rev_hash_size, to->rev_hash [i].klass, to->rev_hash [i].count);
@@ -1133,9 +1133,9 @@ static int num_heap_shots = 0;
 static HeapShot*
 new_heap_shot (uint64_t timestamp)
 {
-	HeapShot *hs = calloc (sizeof (HeapShot), 1);
+	HeapShot *hs = (HeapShot *)calloc (sizeof (HeapShot), 1);
 	hs->hash_size = 4;
-	hs->class_hash = calloc (sizeof (void*), hs->hash_size);
+	hs->class_hash = (HeapClassDesc **)calloc (sizeof (void*), hs->hash_size);
 	hs->timestamp = timestamp;
 	num_heap_shots++;
 	hs->next = heap_shots;
@@ -1181,7 +1181,7 @@ add_heap_hashed (HeapClassDesc **hash, HeapClassDesc **retv, uintptr_t hsize, Cl
 				hash [i] = *retv;
 				return 1;
 			}
-			hash [i] = calloc (sizeof (HeapClassDesc), 1);
+			hash [i] = (HeapClassDesc *)calloc (sizeof (HeapClassDesc), 1);
 			hash [i]->klass = klass;
 			hash [i]->total_size += size;
 			hash [i]->count += count;
@@ -1208,7 +1208,7 @@ add_heap_shot_class (HeapShot *hs, ClassDesc *klass, uint64_t size)
 		hs->hash_size *= 2;
 		if (hs->hash_size == 0)
 			hs->hash_size = 4;
-		n = calloc (sizeof (void*) * hs->hash_size, 1);
+		n = (HeapClassDesc **)calloc (sizeof (void*) * hs->hash_size, 1);
 		for (i = 0; i < old_size; ++i) {
 			res = hs->class_hash [i];
 			if (hs->class_hash [i])
@@ -1228,7 +1228,7 @@ add_heap_shot_class (HeapShot *hs, ClassDesc *klass, uint64_t size)
 static HeapObjectDesc*
 alloc_heap_obj (uintptr_t objaddr, HeapClassDesc *hklass, uintptr_t num_refs)
 {
-	HeapObjectDesc* ho = calloc (sizeof (HeapObjectDesc) + num_refs * sizeof (uintptr_t), 1);
+	HeapObjectDesc* ho = (HeapObjectDesc *)calloc (sizeof (HeapObjectDesc) + num_refs * sizeof (uintptr_t), 1);
 	ho->objaddr = objaddr;
 	ho->hklass = hklass;
 	ho->num_refs = num_refs;
@@ -1311,7 +1311,7 @@ add_heap_shot_obj (HeapShot *hs, HeapObjectDesc *obj)
 		hs->objects_hash_size *= 2;
 		if (hs->objects_hash_size == 0)
 			hs->objects_hash_size = 4;
-		n = calloc (sizeof (void*) * hs->objects_hash_size, 1);
+		n = (HeapObjectDesc **)calloc (sizeof (void*) * hs->objects_hash_size, 1);
 		for (i = 0; i < old_size; ++i) {
 			if (hs->objects_hash [i])
 				add_heap_hashed_obj (n, hs->objects_hash_size, hs->objects_hash [i]);
@@ -1365,7 +1365,7 @@ heap_shot_mark_objects (HeapShot *hs)
 	if (!debug)
 		return;
 	/* consistency checks: it seems not all the objects are walked in the heap in some cases */
-	marks = calloc (hs->objects_hash_size, 1);
+	marks = (unsigned char *)calloc (hs->objects_hash_size, 1);
 	if (!marks)
 		return;
 	for (i = 0; i < hs->num_roots; ++i) {
@@ -1478,14 +1478,14 @@ add_backtrace (int count, MethodDesc **methods)
 			return bt;
 		bt = bt->next;
 	}
-	bt = malloc (sizeof (BackTrace) + ((count - 1) * sizeof (void*)));
+	bt = (BackTrace *)malloc (sizeof (BackTrace) + ((count - 1) * sizeof (void*)));
 	bt->next = backtrace_hash [slot];
 	backtrace_hash [slot] = bt;
 	if (next_backtrace == num_backtraces) {
 		num_backtraces *= 2;
 		if (!num_backtraces)
 			num_backtraces = 16;
-		backtraces = realloc (backtraces, sizeof (void*) * num_backtraces);
+		backtraces = (BackTrace **)realloc (backtraces, sizeof (void*) * num_backtraces);
 	}
 	bt->id = next_backtrace++;
 	backtraces [bt->id] = bt;
@@ -1562,7 +1562,7 @@ static void
 ensure_buffer (ProfContext *ctx, int size)
 {
 	if (ctx->size < size) {
-		ctx->buf = realloc (ctx->buf, size);
+		ctx->buf = (unsigned char *)realloc (ctx->buf, size);
 		ctx->size = size;
 	}
 }
@@ -1600,16 +1600,16 @@ get_thread (ProfContext *ctx, intptr_t thread_id)
 		}
 		thread = thread->next;
 	}
-	thread = calloc (sizeof (ThreadContext), 1);
+	thread = (ThreadContext *)calloc (sizeof (ThreadContext), 1);
 	thread->next = ctx->threads;
 	ctx->threads = thread;
 	thread->thread_id = thread_id;
 	thread->last_time = 0;
 	thread->stack_id = 0;
 	thread->stack_size = 32;
-	thread->stack = malloc (thread->stack_size * sizeof (void*));
-	thread->time_stack = malloc (thread->stack_size * sizeof (uint64_t));
-	thread->callee_time_stack = malloc (thread->stack_size * sizeof (uint64_t));
+	thread->stack = (MethodDesc **)malloc (thread->stack_size * sizeof (void*));
+	thread->time_stack = (uint64_t *)malloc (thread->stack_size * sizeof (uint64_t));
+	thread->callee_time_stack = (uint64_t *)malloc (thread->stack_size * sizeof (uint64_t));
 	return thread;
 }
 
@@ -1628,7 +1628,7 @@ get_domain (ProfContext *ctx, intptr_t domain_id)
 		domain = domain->next;
 	}
 
-	domain = calloc (sizeof (DomainContext), 1);
+	domain = (DomainContext *)calloc (sizeof (DomainContext), 1);
 	domain->next = ctx->domains;
 	ctx->domains = domain;
 	domain->domain_id = domain_id;
@@ -1651,7 +1651,7 @@ get_remctx (ProfContext *ctx, intptr_t remctx_id)
 		remctx = remctx->next;
 	}
 
-	remctx = calloc (sizeof (RemCtxContext), 1);
+	remctx = (RemCtxContext *)calloc (sizeof (RemCtxContext), 1);
 	remctx->next = ctx->remctxs;
 	ctx->remctxs = remctx;
 	remctx->remctx_id = remctx_id;
@@ -1672,9 +1672,9 @@ ensure_thread_stack (ThreadContext *thread)
 {
 	if (thread->stack_id == thread->stack_size) {
 		thread->stack_size *= 2;
-		thread->stack = realloc (thread->stack, thread->stack_size * sizeof (void*));
-		thread->time_stack = realloc (thread->time_stack, thread->stack_size * sizeof (uint64_t));
-		thread->callee_time_stack = realloc (thread->callee_time_stack, thread->stack_size * sizeof (uint64_t));
+		thread->stack = (MethodDesc **)realloc (thread->stack, thread->stack_size * sizeof (void*));
+		thread->time_stack = (uint64_t *)realloc (thread->time_stack, thread->stack_size * sizeof (uint64_t));
+		thread->callee_time_stack = (uint64_t *)realloc (thread->callee_time_stack, thread->stack_size * sizeof (uint64_t));
 	}
 }
 
@@ -1715,7 +1715,7 @@ add_trace_bt (BackTrace *bt, TraceDesc *trace, uint64_t value)
 		trace->size *= 2;
 		if (trace->size == 0)
 			trace->size = 4;
-		n = calloc (sizeof (CallContext) * trace->size, 1);
+		n = (CallContext *)calloc (sizeof (CallContext) * trace->size, 1);
 		for (i = 0; i < old_size; ++i) {
 			if (trace->traces [i].bt)
 				add_trace_hashed (n, trace->size, trace->traces [i].bt, trace->traces [i].count);
@@ -1761,9 +1761,9 @@ thread_add_root (ThreadContext *ctx, uintptr_t obj, int root_type, uintptr_t ext
 		int new_size = ctx->size_roots * 2;
 		if (!new_size)
 			new_size = 4;
-		ctx->roots = realloc (ctx->roots, new_size * sizeof (uintptr_t));
-		ctx->roots_extra = realloc (ctx->roots_extra, new_size * sizeof (uintptr_t));
-		ctx->roots_types = realloc (ctx->roots_types, new_size * sizeof (int));
+		ctx->roots = (uintptr_t *)realloc (ctx->roots, new_size * sizeof (uintptr_t));
+		ctx->roots_extra = (uintptr_t *)realloc (ctx->roots_extra, new_size * sizeof (uintptr_t));
+		ctx->roots_types = (int *)realloc (ctx->roots_types, new_size * sizeof (int));
 		ctx->size_roots = new_size;
 	}
 	ctx->roots_types [ctx->num_roots] = root_type;
@@ -1774,8 +1774,8 @@ thread_add_root (ThreadContext *ctx, uintptr_t obj, int root_type, uintptr_t ext
 static int
 compare_callc (const void *a, const void *b)
 {
-	const CallContext *A = a;
-	const CallContext *B = b;
+	const CallContext *A = (const CallContext *)a;
+	const CallContext *B = (const CallContext *)b;
 	if (B->count == A->count)
 		return 0;
 	if (B->count < A->count)
@@ -1908,7 +1908,7 @@ lookup_monitor (uintptr_t objid)
 	while (cd && cd->objid != objid)
 		cd = cd->next;
 	if (!cd) {
-		cd = calloc (sizeof (MonitorDesc), 1);
+		cd = (MonitorDesc *)calloc (sizeof (MonitorDesc), 1);
 		cd->objid = objid;
 		cd->next = monitor_hash [slot];
 		monitor_hash [slot] = cd;
@@ -1963,7 +1963,7 @@ decode_bt (MethodDesc** sframes, int *size, unsigned char *p, unsigned char **en
 	if (flags != 0)
 		return NULL;
 	if (count > *size)
-		frames = malloc (count * sizeof (void*));
+		frames = (MethodDesc **)malloc (count * sizeof (void*));
 	else
 		frames = sframes;
 	for (i = 0; i < count; ++i) {
@@ -2033,7 +2033,7 @@ static void
 found_object (uintptr_t obj)
 {
 	num_tracked_objects ++;
-	tracked_objects = realloc (tracked_objects, num_tracked_objects * sizeof (tracked_objects [0]));
+	tracked_objects = (uintptr_t *)realloc (tracked_objects, num_tracked_objects * sizeof (tracked_objects [0]));
 	tracked_objects [num_tracked_objects - 1] = obj;
 }
 
@@ -2120,8 +2120,8 @@ static void
 gather_coverage_statements (void)
 {
 	for (guint i = 0; i < coverage_statements->len; i++) {
-		CoverageCoverage *coverage = coverage_statements->pdata[i];
-		CoverageMethod *method = g_hash_table_lookup (coverage_methods_hash, GINT_TO_POINTER (coverage->method_id));
+		CoverageCoverage *coverage = (CoverageCoverage *)coverage_statements->pdata[i];
+		CoverageMethod *method = (CoverageMethod *)g_hash_table_lookup (coverage_methods_hash, GINT_TO_POINTER (coverage->method_id));
 		if (method == NULL) {
 			fprintf (outfile, "Cannot find method with ID: %d\n", coverage->method_id);
 			continue;
@@ -2163,7 +2163,7 @@ coverage_add_class (CoverageClass *klass)
 	}
 
 	g_ptr_array_add (coverage_classes, klass);
-	classes = g_hash_table_lookup (coverage_assembly_classes, klass->assembly_name);
+	classes = (GPtrArray *)g_hash_table_lookup (coverage_assembly_classes, klass->assembly_name);
 	if (classes == NULL) {
 		classes = g_ptr_array_new ();
 		g_hash_table_insert (coverage_assembly_classes, klass->assembly_name, classes);
@@ -2768,7 +2768,7 @@ decode_buffer (ProfContext *ctx)
 				int codelen = decode_uleb128 (p, &p);
 				const char *name;
 				if (type == MONO_PROFILER_CODE_BUFFER_SPECIFIC_TRAMPOLINE) {
-					name = (void*)p;
+					name = (const char *)p;
 					while (*p) p++;
 						p++;
 				} else {
@@ -2877,7 +2877,7 @@ decode_buffer (ProfContext *ctx)
 
 					type = decode_uleb128 (p, &p);
 
-					value = calloc (1, sizeof (CounterValue));
+					value = (CounterValue *)calloc (1, sizeof (CounterValue));
 					value->timestamp = timestamp;
 
 					switch (type) {
@@ -2885,11 +2885,11 @@ decode_buffer (ProfContext *ctx)
 #if SIZEOF_VOID_P == 4
 					case MONO_COUNTER_WORD:
 #endif
-						value->buffer = malloc (sizeof (int32_t));
+						value->buffer = (unsigned char *)malloc (sizeof (int32_t));
 						*(int32_t*)value->buffer = (int32_t)decode_sleb128 (p, &p) + (previous ? (*(int32_t*)previous->buffer) : 0);
 						break;
 					case MONO_COUNTER_UINT:
-						value->buffer = malloc (sizeof (uint32_t));
+						value->buffer = (unsigned char *)malloc (sizeof (uint32_t));
 						*(uint32_t*)value->buffer = (uint32_t)decode_uleb128 (p, &p) + (previous ? (*(uint32_t*)previous->buffer) : 0);
 						break;
 					case MONO_COUNTER_LONG:
@@ -2897,15 +2897,15 @@ decode_buffer (ProfContext *ctx)
 					case MONO_COUNTER_WORD:
 #endif
 					case MONO_COUNTER_TIME_INTERVAL:
-						value->buffer = malloc (sizeof (int64_t));
+						value->buffer = (unsigned char *)malloc (sizeof (int64_t));
 						*(int64_t*)value->buffer = (int64_t)decode_sleb128 (p, &p) + (previous ? (*(int64_t*)previous->buffer) : 0);
 						break;
 					case MONO_COUNTER_ULONG:
-						value->buffer = malloc (sizeof (uint64_t));
+						value->buffer = (unsigned char *)malloc (sizeof (uint64_t));
 						*(uint64_t*)value->buffer = (uint64_t)decode_uleb128 (p, &p) + (previous ? (*(uint64_t*)previous->buffer) : 0);
 						break;
 					case MONO_COUNTER_DOUBLE:
-						value->buffer = malloc (sizeof (double));
+						value->buffer = (unsigned char *)malloc (sizeof (double));
 #if TARGET_BYTE_ORDER == G_LITTLE_ENDIAN
 						for (i = 0; i < sizeof (double); i++)
 #else
@@ -2939,11 +2939,11 @@ decode_buffer (ProfContext *ctx)
 				int token, n_offsets, method_id;
 
 				p++;
-				assembly = (void *)p; while (*p) p++; p++;
-				klass = (void *)p; while (*p) p++; p++;
-				name = (void *)p; while (*p) p++; p++;
-				sig = (void *)p; while (*p) p++; p++;
-				filename = (void *)p; while (*p) p++; p++;
+				assembly = (const char *)p; while (*p) p++; p++;
+				klass = (const char *)p; while (*p) p++; p++;
+				name = (const char *)p; while (*p) p++; p++;
+				sig = (const char *)p; while (*p) p++; p++;
+				filename = (const char *)p; while (*p) p++; p++;
 
 				token = decode_uleb128 (p, &p);
 				method_id = decode_uleb128 (p, &p);
@@ -2989,9 +2989,9 @@ decode_buffer (ProfContext *ctx)
 				int number_of_methods, fully_covered, partially_covered;
 				p++;
 
-				name = (void *)p; while (*p) p++; p++;
-				guid = (void *)p; while (*p) p++; p++;
-				filename = (void *)p; while (*p) p++; p++;
+				name = (char *)p; while (*p) p++; p++;
+				guid = (char *)p; while (*p) p++; p++;
+				filename = (char *)p; while (*p) p++; p++;
 				number_of_methods = decode_uleb128 (p, &p);
 				fully_covered = decode_uleb128 (p, &p);
 				partially_covered = decode_uleb128 (p, &p);
@@ -3012,8 +3012,8 @@ decode_buffer (ProfContext *ctx)
 				int number_of_methods, fully_covered, partially_covered;
 				p++;
 
-				assembly_name = (void *)p; while (*p) p++; p++;
-				class_name = (void *)p; while (*p) p++; p++;
+				assembly_name = (char *)p; while (*p) p++; p++;
+				class_name = (char *)p; while (*p) p++; p++;
 				number_of_methods = decode_uleb128 (p, &p);
 				fully_covered = decode_uleb128 (p, &p);
 				partially_covered = decode_uleb128 (p, &p);
@@ -3049,7 +3049,7 @@ static ProfContext*
 load_file (char *name)
 {
 	unsigned char *p;
-	ProfContext *ctx = calloc (sizeof (ProfContext), 1);
+	ProfContext *ctx = (ProfContext *)calloc (sizeof (ProfContext), 1);
 	if (strcmp (name, "-") == 0)
 		ctx->file = stdin;
 	else
@@ -3091,8 +3091,8 @@ static int alloc_sort_mode = ALLOC_SORT_BYTES;
 static int
 compare_class (const void *a, const void *b)
 {
-	ClassDesc *const*A = a;
-	ClassDesc *const*B = b;
+	ClassDesc *const *A = (ClassDesc *const *)a;
+	ClassDesc *const *B = (ClassDesc *const *)b;
 	uint64_t vala, valb;
 	if (alloc_sort_mode == ALLOC_SORT_BYTES) {
 		vala = (*A)->alloc_size;
@@ -3190,8 +3190,8 @@ dump_exceptions (void)
 static int
 compare_monitor (const void *a, const void *b)
 {
-	MonitorDesc *const*A = a;
-	MonitorDesc *const*B = b;
+	MonitorDesc *const *A = (MonitorDesc *const *)a;
+	MonitorDesc *const *B = (MonitorDesc *const *)b;
 	if ((*B)->wait_time == (*A)->wait_time)
 		return 0;
 	if ((*B)->wait_time < (*A)->wait_time)
@@ -3206,7 +3206,7 @@ dump_monitors (void)
 	int i, j;
 	if (!num_monitors)
 		return;
-	monitors = malloc (sizeof (void*) * num_monitors);
+	monitors = (MonitorDesc **)malloc (sizeof (void*) * num_monitors);
 	for (i = 0, j = 0; i < SMALL_HASH_SIZE; ++i) {
 		MonitorDesc *mdesc = monitor_hash [i];
 		while (mdesc) {
@@ -3288,7 +3288,7 @@ dump_allocations (void)
 	intptr_t allocs = 0;
 	uint64_t size = 0;
 	int header_done = 0;
-	ClassDesc **classes = malloc (num_classes * sizeof (void*));
+	ClassDesc **classes = (ClassDesc **)malloc (num_classes * sizeof (void*));
 	ClassDesc *cd;
 	c = 0;
 	for (i = 0; i < HASH_SIZE; ++i) {
@@ -3331,8 +3331,8 @@ static int method_sort_mode = METHOD_SORT_TOTAL;
 static int
 compare_method (const void *a, const void *b)
 {
-	MethodDesc *const*A = a;
-	MethodDesc *const*B = b;
+	MethodDesc *const *A = (MethodDesc *const *)a;
+	MethodDesc *const *B = (MethodDesc *const *)b;
 	uint64_t vala, valb;
 	if (method_sort_mode == METHOD_SORT_SELF) {
 		vala = (*A)->self_time;
@@ -3387,7 +3387,7 @@ dump_methods (void)
 	int i, c;
 	uint64_t calls = 0;
 	int header_done = 0;
-	MethodDesc **methods = malloc (num_methods * sizeof (void*));
+	MethodDesc **methods = (MethodDesc **)malloc (num_methods * sizeof (void*));
 	MethodDesc *cd;
 	c = 0;
 	for (i = 0; i < HASH_SIZE; ++i) {
@@ -3428,8 +3428,8 @@ dump_methods (void)
 static int
 compare_heap_class (const void *a, const void *b)
 {
-	HeapClassDesc *const*A = a;
-	HeapClassDesc *const*B = b;
+	HeapClassDesc *const *A = (HeapClassDesc *const *)a;
+	HeapClassDesc *const *B = (HeapClassDesc *const *)b;
 	uint64_t vala, valb;
 	if (alloc_sort_mode == ALLOC_SORT_BYTES) {
 		vala = (*A)->total_size;
@@ -3448,8 +3448,8 @@ compare_heap_class (const void *a, const void *b)
 static int
 compare_rev_class (const void *a, const void *b)
 {
-	const HeapClassRevRef *A = a;
-	const HeapClassRevRef *B = b;
+	const HeapClassRevRef *A = (const HeapClassRevRef *)a;
+	const HeapClassRevRef *B = (const HeapClassRevRef *)b;
 	if (B->count == A->count)
 		return 0;
 	if (B->count < A->count)
@@ -3482,7 +3482,7 @@ heap_shot_summary (HeapShot *hs, int hs_num, HeapShot *last_hs)
 	int i;
 	HeapClassDesc *cd;
 	HeapClassDesc **sorted;
-	sorted = malloc (sizeof (void*) * hs->class_count);
+	sorted = (HeapClassDesc **)malloc (sizeof (void*) * hs->class_count);
 	for (i = 0; i < hs->hash_size; ++i) {
 		cd = hs->class_hash [i];
 		if (!cd)
@@ -3523,7 +3523,7 @@ heap_shot_summary (HeapShot *hs, int hs_num, HeapShot *last_hs)
 		}
 		if (!collect_traces)
 			continue;
-		rev_sorted = malloc (cd->rev_count * sizeof (HeapClassRevRef));
+		rev_sorted = (HeapClassRevRef *)malloc (cd->rev_count * sizeof (HeapClassRevRef));
 		k = 0;
 		for (j = 0; j < cd->rev_hash_size; ++j) {
 			if (cd->rev_hash [j].klass)
@@ -3542,8 +3542,8 @@ heap_shot_summary (HeapShot *hs, int hs_num, HeapShot *last_hs)
 static int
 compare_heap_shots (const void *a, const void *b)
 {
-	HeapShot *const*A = a;
-	HeapShot *const*B = b;
+	HeapShot *const *A = (HeapShot *const *)a;
+	HeapShot *const *B = (HeapShot *const *)b;
 	if ((*B)->timestamp == (*A)->timestamp)
 		return 0;
 	if ((*B)->timestamp > (*A)->timestamp)
@@ -3560,7 +3560,7 @@ dump_heap_shots (void)
 	int i;
 	if (!heap_shots)
 		return;
-	hs_sorted = malloc (num_heap_shots * sizeof (void*));
+	hs_sorted = (HeapShot **)malloc (num_heap_shots * sizeof (void*));
 	fprintf (outfile, "\nHeap shot summary\n");
 	i = 0;
 	for (hs = heap_shots; hs; hs = hs->next)
@@ -3650,7 +3650,7 @@ dump_coverage (void)
 	g_ptr_array_sort (coverage_assemblies, sort_assemblies);
 
 	for (guint i = 0; i < coverage_assemblies->len; i++) {
-		CoverageAssembly *assembly = coverage_assemblies->pdata[i];
+		CoverageAssembly *assembly = (CoverageAssembly *)coverage_assemblies->pdata[i];
 		GPtrArray *classes;
 
 		if (assembly->number_of_methods != 0) {
@@ -3670,10 +3670,10 @@ dump_coverage (void)
 			g_free (escaped_filename);
 		}
 
-		classes = g_hash_table_lookup (coverage_assembly_classes, assembly->name);
+		classes = (GPtrArray *)g_hash_table_lookup (coverage_assembly_classes, assembly->name);
 		if (classes) {
 			for (guint j = 0; j < classes->len; j++) {
-				CoverageClass *klass = classes->pdata[j];
+				CoverageClass *klass = (CoverageClass *)classes->pdata [j];
 
 				if (klass->number_of_methods > 0) {
 					int percentage = ((klass->fully_covered + klass->partially_covered) * 100) / klass->number_of_methods;
@@ -3693,7 +3693,7 @@ dump_coverage (void)
 	}
 
 	for (guint i = 0; i < coverage_methods->len; i++) {
-		CoverageMethod *method = coverage_methods->pdata[i];
+		CoverageMethod *method = (CoverageMethod *)coverage_methods->pdata [i];
 
 		if (coverage_outfile) {
 			char *escaped_assembly, *escaped_class, *escaped_method, *escaped_sig, *escaped_filename;
@@ -3713,7 +3713,7 @@ dump_coverage (void)
 			g_free (escaped_filename);
 
 			for (guint j = 0; j < method->coverage->len; j++) {
-				CoverageCoverage *coverage = method->coverage->pdata[j];
+				CoverageCoverage *coverage = (CoverageCoverage *)method->coverage->pdata [j];
 				fprintf (coverage_outfile, "\t\t<statement offset=\"%d\" counter=\"%d\" line=\"%d\" column=\"%d\"/>\n", coverage->offset, coverage->count, coverage->line, coverage->column);
 			}
 			fprintf (coverage_outfile, "\t</method>\n");

--- a/mono/profiler/mono-profiler-aot.c
+++ b/mono/profiler/mono-profiler-aot.c
@@ -124,7 +124,7 @@ prof_jit_leave (MonoProfiler *prof, MonoMethod *method, int result)
 	MonoImage *image = mono_class_get_image (mono_method_get_class (method));
 	PerImageData *data;
 
-	data = g_hash_table_lookup (prof->images, image);
+	data = (PerImageData *)g_hash_table_lookup (prof->images, image);
 	if (!data) {
 		data = g_new0 (PerImageData, 1);
 		g_hash_table_insert (prof->images, image, data);

--- a/mono/profiler/mono-profiler-iomap.c
+++ b/mono/profiler/mono-profiler-iomap.c
@@ -112,7 +112,7 @@ static void mismatched_stats_foreach_func (gpointer key, gpointer value, gpointe
 		return;
 	}
 
-	location = g_hash_table_lookup (prof->string_locations_hash, &hash);
+	location = (StringLocation *)g_hash_table_lookup (prof->string_locations_hash, &hash);
 	while (location) {
 		if (location->hint && strlen (location->hint) > 0) {
 			if (!bannerShown) {
@@ -243,7 +243,7 @@ static gboolean saved_strings_find_func (gpointer key, gpointer value, gpointer 
 
 static inline void store_string_location (MonoProfiler *prof, const gchar *string, guint32 hash, size_t len)
 {
-	StringLocation *location = g_hash_table_lookup (prof->string_locations_hash, &hash);
+	StringLocation *location = (StringLocation *)g_hash_table_lookup (prof->string_locations_hash, &hash);
 	SavedString *saved;
 	SavedStringFindInfo info;
 	guint32 *hashptr;
@@ -542,5 +542,5 @@ void mono_profiler_startup (const char *desc)
 	mono_profiler_install_iomap (mono_portability_iomap_event);
 	mono_profiler_install_allocation (mono_portability_remember_alloc);
 
-	mono_profiler_set_events (MONO_PROFILE_ALLOCATIONS | MONO_PROFILE_IOMAP_EVENTS);
+	mono_profiler_set_events ((MonoProfileFlags)(MONO_PROFILE_ALLOCATIONS | MONO_PROFILE_IOMAP_EVENTS));
 }

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -522,7 +522,7 @@ static char*
 pstrdup (const char *s)
 {
 	int len = strlen (s) + 1;
-	char *p = malloc (len);
+	char *p = (char *)malloc (len);
 	memcpy (p, s, len);
 	return p;
 }
@@ -530,7 +530,7 @@ pstrdup (const char *s)
 static StatBuffer*
 create_stat_buffer (void)
 {
-	StatBuffer* buf = alloc_buffer (BUFFER_SIZE);
+	StatBuffer* buf = (StatBuffer *)alloc_buffer (BUFFER_SIZE);
 	buf->size = BUFFER_SIZE;
 	buf->data_end = (uintptr_t*)((unsigned char*)buf + buf->size);
 	buf->data = buf->buf;
@@ -540,7 +540,7 @@ create_stat_buffer (void)
 static LogBuffer*
 create_buffer (void)
 {
-	LogBuffer* buf = alloc_buffer (BUFFER_SIZE);
+	LogBuffer* buf = (LogBuffer *)alloc_buffer (BUFFER_SIZE);
 	buf->size = BUFFER_SIZE;
 	buf->time_base = current_time ();
 	buf->last_time = buf->time_base;
@@ -571,29 +571,29 @@ ensure_logbuf_inner (LogBuffer *old, int bytes)
 	if (old && old->data + bytes + 100 < old->data_end)
 		return old;
 
-	LogBuffer *new = create_buffer ();
-	new->thread_id = thread_id ();
-	new->next = old;
+	LogBuffer *new_ = (LogBuffer *)create_buffer ();
+	new_->thread_id = thread_id ();
+	new_->next = old;
 
 	if (old)
-		new->call_depth = old->call_depth;
+		new_->call_depth = old->call_depth;
 
-	return new;
+	return new_;
 }
 
 static LogBuffer*
 ensure_logbuf (int bytes)
 {
 	LogBuffer *old = TLS_GET (LogBuffer, tlsbuffer);
-	LogBuffer *new = ensure_logbuf_inner (old, bytes);
+	LogBuffer *new_ = ensure_logbuf_inner (old, bytes);
 
-	if (new == old)
+	if (new_ == old)
 		return old; // Still enough space.
 
-	TLS_SET (tlsbuffer, new);
+	TLS_SET (tlsbuffer, new_);
 	init_thread ();
 
-	return new;
+	return new_;
 }
 
 static void
@@ -720,7 +720,7 @@ register_method_local (MonoProfiler *prof, MonoMethod *method, MonoJitInfo *ji)
 		 */
 		//g_assert (ji);
 
-		MethodInfo *info = malloc (sizeof (MethodInfo));
+		MethodInfo *info = (MethodInfo *)malloc (sizeof (MethodInfo));
 
 		info->method = method;
 		info->ji = ji;
@@ -845,7 +845,7 @@ dump_header (MonoProfiler *profiler)
 static void
 send_buffer (MonoProfiler *prof, GPtrArray *methods, LogBuffer *buffer)
 {
-	WriterQueueEntry *entry = calloc (1, sizeof (WriterQueueEntry));
+	WriterQueueEntry *entry = (WriterQueueEntry *)calloc (1, sizeof (WriterQueueEntry));
 	mono_lock_free_queue_node_init (&entry->node, FALSE);
 	entry->methods = methods;
 	entry->buffer = buffer;
@@ -1056,7 +1056,7 @@ static int num_frames = MAX_FRAMES;
 static mono_bool
 walk_stack (MonoMethod *method, int32_t native_offset, int32_t il_offset, mono_bool managed, void* data)
 {
-	FrameData *frame = data;
+	FrameData *frame = (FrameData *)data;
 	if (method && frame->count < num_frames) {
 		frame->il_offsets [frame->count] = il_offset;
 		frame->native_offsets [frame->count] = native_offset;
@@ -1271,7 +1271,7 @@ type_name (MonoClass *klass)
 	char buf [1024];
 	char *p;
 	push_nesting (buf, klass);
-	p = malloc (strlen (buf) + 1);
+	p = (char *)malloc (strlen (buf) + 1);
 	strcpy (p, buf);
 	return p;
 }
@@ -1595,7 +1595,7 @@ code_buffer_new (MonoProfiler *prof, void *buffer, int size, MonoProfilerCodeBuf
 	char *name;
 	LogBuffer *logbuffer;
 	if (type == MONO_PROFILER_CODE_BUFFER_SPECIFIC_TRAMPOLINE) {
-		name = data;
+		name = (char *)data;
 		nlen = strlen (name) + 1;
 	} else {
 		name = NULL;
@@ -1959,7 +1959,7 @@ typedef struct {
 static mono_bool
 async_walk_stack (MonoMethod *method, MonoDomain *domain, void *base_address, int offset, void *data)
 {
-	AsyncFrameData *frame = data;
+	AsyncFrameData *frame = (AsyncFrameData *)data;
 	if (frame->count < num_frames) {
 		frame->data [frame->count].method = method;
 		frame->data [frame->count].domain = domain;
@@ -2017,7 +2017,7 @@ mono_sample_hit (MonoProfiler *profiler, unsigned char *ip, void *context)
 		do {
 			oldsb = profiler->stat_buffers;
 			sbuf->next = oldsb;
-			foundsb = InterlockedCompareExchangePointer ((void * volatile*)&profiler->stat_buffers, sbuf, oldsb);
+			foundsb = (StatBuffer *)InterlockedCompareExchangePointer ((void * volatile*)&profiler->stat_buffers, sbuf, oldsb);
 		} while (foundsb != oldsb);
 		if (do_debug)
 			ign_res (write (2, "overflow\n", 9));
@@ -2032,7 +2032,7 @@ mono_sample_hit (MonoProfiler *profiler, unsigned char *ip, void *context)
 	do {
 		old_data = sbuf->data;
 		new_data = old_data + SAMPLE_EVENT_SIZE_IN_SLOTS (bt_data.count);
-		data = InterlockedCompareExchangePointer ((void * volatile*)&sbuf->data, new_data, old_data);
+		data = (uintptr_t *)InterlockedCompareExchangePointer ((void * volatile*)&sbuf->data, new_data, old_data);
 	} while (data != old_data);
 	if (old_data >= sbuf->data_end)
 		return; /* lost event */
@@ -2089,7 +2089,7 @@ add_code_pointer (uintptr_t ip)
 		size_code_pages *= 2;
 		if (size_code_pages == 0)
 			size_code_pages = 16;
-		n = calloc (sizeof (uintptr_t) * size_code_pages, 1);
+		n = (uintptr_t *)calloc (sizeof (uintptr_t) * size_code_pages, 1);
 		for (i = 0; i < old_size; ++i) {
 			if (code_pages [i])
 				add_code_page (n, size_code_pages, code_pages [i]);
@@ -2425,7 +2425,7 @@ dump_sample_hits (MonoProfiler *prof, StatBuffer *sbuf)
 	g_ptr_array_sort (prof->sorted_sample_events, compare_sample_events);
 
 	for (guint sidx = 0; sidx < prof->sorted_sample_events->len; sidx++) {
-		uintptr_t *sample = g_ptr_array_index (prof->sorted_sample_events, sidx);
+		uintptr_t *sample = (uintptr_t *)g_ptr_array_index (prof->sorted_sample_events, sidx);
 		int count = sample [0] & 0xff;
 		int mbt_count = (sample [0] & 0xff00) >> 8;
 		int type = sample [0] >> 16;
@@ -2438,7 +2438,7 @@ dump_sample_hits (MonoProfiler *prof, StatBuffer *sbuf)
 			void *address = (void*)managed_sample_base [i * 4 + 2];
 
 			if (!method) {
-				MonoJitInfo *ji = mono_jit_info_table_find (domain, address);
+				MonoJitInfo *ji = mono_jit_info_table_find (domain, (char *)address);
 
 				if (ji)
 					managed_sample_base [i * 4 + 0] = (uintptr_t)mono_jit_info_get_method (ji);
@@ -2795,7 +2795,7 @@ counters_add_agent (MonoCounter *counter)
 		}
 	}
 
-	agent = malloc (sizeof (MonoCounterAgent));
+	agent = (MonoCounterAgent *)malloc (sizeof (MonoCounterAgent));
 	agent->counter = counter;
 	agent->value = NULL;
 	agent->value_size = 0;
@@ -3275,7 +3275,7 @@ parse_generic_type_names(char *name)
 	if (name == NULL || *name == '\0')
 		return g_strdup ("");
 
-	if (!(ret = new_name = calloc (strlen (name) * 4 + 1, sizeof (char))))
+	if (!(ret = new_name = (char *)calloc (strlen (name) * 4 + 1, sizeof (char))))
 		return NULL;
 
 	do {
@@ -3340,7 +3340,7 @@ build_method_buffer (gpointer key, gpointer value, gpointer userdata)
 	method_name = mono_method_get_name (method);
 
 	if (coverage_data->len != 0) {
-		CoverageEntry *entry = coverage_data->pdata[0];
+		CoverageEntry *entry = (CoverageEntry *)coverage_data->pdata[0];
 		first_filename = entry->filename ? entry->filename : "";
 	} else
 		first_filename = "";
@@ -3377,7 +3377,7 @@ build_method_buffer (gpointer key, gpointer value, gpointer userdata)
 	safe_send (prof, logbuffer);
 
 	for (i = 0; i < coverage_data->len; i++) {
-		CoverageEntry *entry = coverage_data->pdata[i];
+		CoverageEntry *entry = (CoverageEntry *)coverage_data->pdata[i];
 
 		logbuffer = ensure_logbuf (
 			EVENT_SIZE /* event */ +
@@ -3473,7 +3473,7 @@ build_class_buffer (gpointer key, gpointer value, gpointer userdata)
 static void
 get_coverage_for_image (MonoImage *image, int *number_of_methods, guint *fully_covered, int *partially_covered)
 {
-	MonoLockFreeQueue *image_methods = mono_conc_hashtable_lookup (image_to_methods, image);
+	MonoLockFreeQueue *image_methods = (MonoLockFreeQueue *)mono_conc_hashtable_lookup (image_to_methods, image);
 
 	*number_of_methods = mono_image_get_table_rows (image, MONO_TABLE_METHOD);
 	if (image_methods)
@@ -3570,7 +3570,7 @@ process_method_enter_coverage (MonoProfiler *prof, MonoMethod *method)
 static MonoLockFreeQueueNode *
 create_method_node (MonoMethod *method)
 {
-	MethodNode *node = g_malloc (sizeof (MethodNode));
+	MethodNode *node = (MethodNode *)g_malloc (sizeof (MethodNode));
 	mono_lock_free_queue_node_init ((MonoLockFreeQueueNode *) node, FALSE);
 	node->method = method;
 
@@ -3631,7 +3631,7 @@ coverage_filter (MonoProfiler *prof, MonoMethod *method)
 		has_positive = FALSE;
 		found = FALSE;
 		for (guint i = 0; i < prof->coverage_filters->len; ++i) {
-			char *filter = g_ptr_array_index (prof->coverage_filters, i);
+			char *filter = (char *)g_ptr_array_index (prof->coverage_filters, i);
 
 			if (filter [0] == '+') {
 				filter = &filter [1];
@@ -3662,7 +3662,7 @@ coverage_filter (MonoProfiler *prof, MonoMethod *method)
 
 		for (guint i = 0; i < prof->coverage_filters->len; ++i) {
 			// FIXME: Is substring search sufficient?
-			char *filter = g_ptr_array_index (prof->coverage_filters, i);
+			char *filter = (char *)g_ptr_array_index (prof->coverage_filters, i);
 			if (filter [0] == '+')
 				continue;
 
@@ -3701,10 +3701,10 @@ coverage_filter (MonoProfiler *prof, MonoMethod *method)
 	mono_conc_hashtable_insert (coverage_assemblies, assembly, assembly);
 	mono_os_mutex_unlock (&coverage_mutex);
 
-	image_methods = mono_conc_hashtable_lookup (image_to_methods, image);
+	image_methods = (MonoLockFreeQueue *)mono_conc_hashtable_lookup (image_to_methods, image);
 
 	if (image_methods == NULL) {
-		image_methods = g_malloc (sizeof (MonoLockFreeQueue));
+		image_methods = (MonoLockFreeQueue *)g_malloc (sizeof (MonoLockFreeQueue));
 		mono_lock_free_queue_init (image_methods);
 		mono_os_mutex_lock (&coverage_mutex);
 		mono_conc_hashtable_insert (image_to_methods, image, image_methods);
@@ -3714,10 +3714,10 @@ coverage_filter (MonoProfiler *prof, MonoMethod *method)
 	node = create_method_node (method);
 	mono_lock_free_queue_enqueue (image_methods, node);
 
-	class_methods = mono_conc_hashtable_lookup (coverage_classes, klass);
+	class_methods = (MonoLockFreeQueue *)mono_conc_hashtable_lookup (coverage_classes, klass);
 
 	if (class_methods == NULL) {
-		class_methods = g_malloc (sizeof (MonoLockFreeQueue));
+		class_methods = (MonoLockFreeQueue *)g_malloc (sizeof (MonoLockFreeQueue));
 		mono_lock_free_queue_init (class_methods);
 		mono_os_mutex_lock (&coverage_mutex);
 		mono_conc_hashtable_insert (coverage_classes, klass, class_methods);
@@ -3756,7 +3756,7 @@ get_file_content (FILE *stream)
 	if (filesize > MAX_FILE_SIZE)
 	  return NULL;
 
-	buffer = g_malloc ((filesize + 1) * sizeof (char));
+	buffer = (char *)g_malloc ((filesize + 1) * sizeof (char));
 	while ((bytes_read = fread (buffer + offset, 1, LINE_BUFFER_SIZE, stream)) > 0)
 		offset += bytes_read;
 
@@ -3932,7 +3932,7 @@ new_filename (const char* filename)
 		1900 + ts->tm_year, 1 + ts->tm_mon, ts->tm_mday, ts->tm_hour, ts->tm_min, ts->tm_sec);
 	s_date = strlen (time_buf);
 	s_pid = strlen (pid_buf);
-	d = res = malloc (strlen (filename) + s_date * count_dates + s_pid * count_pids);
+	d = res = (char *)malloc (strlen (filename) + s_date * count_dates + s_pid * count_pids);
 	for (p = filename; *p; p++) {
 		if (*p != '%') {
 			*d++ = *p;
@@ -3967,7 +3967,7 @@ extern void mono_threads_attach_tools_thread (void);
 static void*
 helper_thread (void* arg)
 {
-	MonoProfiler* prof = arg;
+	MonoProfiler* prof = (MonoProfiler *)arg;
 	int command_socket;
 	int len;
 	char buf [64];
@@ -4153,7 +4153,7 @@ start_helper_thread (MonoProfiler* prof)
 static void *
 writer_thread (void *arg)
 {
-	MonoProfiler *prof = arg;
+	MonoProfiler *prof = (MonoProfiler *)arg;
 
 	mono_threads_attach_tools_thread ();
 
@@ -4175,7 +4175,7 @@ writer_thread (void *arg)
 			 * methods have metadata emitted before they're referenced.
 			 */
 			for (guint i = 0; i < entry->methods->len; i++) {
-				MethodInfo *info = g_ptr_array_index (entry->methods, i);
+				MethodInfo *info = (MethodInfo *)g_ptr_array_index (entry->methods, i);
 
 				if (mono_conc_hashtable_lookup (prof->method_table, info->method))
 					continue;
@@ -4274,7 +4274,7 @@ create_profiler (const char *filename, GPtrArray *filters)
 	MonoProfiler *prof;
 	char *nf;
 	int force_delete = 0;
-	prof = calloc (1, sizeof (MonoProfiler));
+	prof = (MonoProfiler *)calloc (1, sizeof (MonoProfiler));
 
 	prof->command_port = command_port;
 	if (filename && *filename == '-') {
@@ -4291,7 +4291,7 @@ create_profiler (const char *filename, GPtrArray *filters)
 		nf = new_filename (filename);
 		if (do_report) {
 			int s = strlen (nf) + 32;
-			char *p = malloc (s);
+			char *p = (char *)malloc (s);
 			snprintf (p, s, "|mprof-report '--out=%s' -", nf);
 			free (nf);
 			nf = p;
@@ -4404,7 +4404,7 @@ match_option (const char* p, const char *opt, char **rval)
 				} else {
 					l = end - opt;
 				}
-				val = malloc (l + 1);
+				val = (char *)malloc (l + 1);
 				memcpy (val, opt, l);
 				val [l] = 0;
 				*rval = val;
@@ -4756,7 +4756,7 @@ mono_profiler_startup (const char *desc)
 		mono_profiler_install_statistical (mono_sample_hit);
 	}
 
-	mono_profiler_set_events (events);
+	mono_profiler_set_events ((MonoProfileFlags)events);
 
 	TLS_INIT (tlsbuffer);
 	TLS_INIT (tlsmethodlist);

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -67,7 +67,7 @@ typedef enum {
 
 #define MONO_GC_HANDLE_TYPE_SHIFT (3)
 #define MONO_GC_HANDLE_TYPE_MASK ((1 << MONO_GC_HANDLE_TYPE_SHIFT) - 1)
-#define MONO_GC_HANDLE_TYPE(x) (((x) & MONO_GC_HANDLE_TYPE_MASK) - 1)
+#define MONO_GC_HANDLE_TYPE(x) ((GCHandleType)(((x) & MONO_GC_HANDLE_TYPE_MASK) - 1))
 #define MONO_GC_HANDLE_SLOT(x) ((x) >> MONO_GC_HANDLE_TYPE_SHIFT)
 #define MONO_GC_HANDLE_TYPE_IS_WEAK(x) ((x) <= HANDLE_WEAK_TRACK)
 #define MONO_GC_HANDLE(slot, type) (((slot) << MONO_GC_HANDLE_TYPE_SHIFT) | (((type) & MONO_GC_HANDLE_TYPE_MASK) + 1))

--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -86,8 +86,8 @@ sgen_card_table_wbarrier_set_field (GCObject *obj, gpointer field_ptr, GCObject*
 static void
 sgen_card_table_wbarrier_arrayref_copy (gpointer dest_ptr, gpointer src_ptr, int count)
 {
-	gpointer *dest = dest_ptr;
-	gpointer *src = src_ptr;
+	gpointer *dest = (gpointer *)dest_ptr;
+	gpointer *src = (gpointer *)src_ptr;
 
 	/*overlapping that required backward copying*/
 	if (src < dest && (src + count) > dest) {
@@ -284,7 +284,7 @@ sgen_card_table_find_address (char *addr)
 static gboolean
 sgen_card_table_find_address_with_cards (char *cards_start, guint8 *cards, char *addr)
 {
-	cards_start = sgen_card_table_align_pointer (cards_start);
+	cards_start = (char *)sgen_card_table_align_pointer (cards_start);
 	return cards [(addr - cards_start) >> CARD_BITS];
 }
 
@@ -303,7 +303,7 @@ guint8*
 sgen_card_table_alloc_mod_union (char *obj, mword obj_size)
 {
 	size_t num_cards = sgen_card_table_number_of_cards_in_range ((mword) obj, obj_size);
-	guint8 *mod_union = sgen_alloc_internal_dynamic (num_cards, INTERNAL_MEM_CARDTABLE_MOD_UNION, TRUE);
+	guint8 *mod_union = (guint8 *)sgen_alloc_internal_dynamic (num_cards, INTERNAL_MEM_CARDTABLE_MOD_UNION, TRUE);
 	memset (mod_union, 0, num_cards);
 	return mod_union;
 }
@@ -573,10 +573,10 @@ sgen_card_tables_collect_stats (gboolean begin)
 void
 sgen_card_table_init (SgenRememberedSet *remset)
 {
-	sgen_cardtable = sgen_alloc_os_memory (CARD_COUNT_IN_BYTES, SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE, "card table");
+	sgen_cardtable = (guint8 *)sgen_alloc_os_memory (CARD_COUNT_IN_BYTES, (SgenAllocFlags)(SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE), "card table");
 
 #ifdef SGEN_HAVE_OVERLAPPING_CARDS
-	sgen_shadow_cardtable = sgen_alloc_os_memory (CARD_COUNT_IN_BYTES, SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE, "shadow card table");
+	sgen_shadow_cardtable = (guint8 *)sgen_alloc_os_memory (CARD_COUNT_IN_BYTES, (SgenAllocFlags)(SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE), "shadow card table");
 #endif
 
 #ifdef HEAVY_STATISTICS

--- a/mono/sgen/sgen-copy-object.h
+++ b/mono/sgen/sgen-copy-object.h
@@ -50,15 +50,15 @@ par_copy_object_no_checks (char *destination, GCVTable vt, void *obj, mword objs
 	obj = destination;
 	if (queue) {
 		SGEN_LOG (9, "Enqueuing gray object %p (%s)", obj, sgen_client_vtable_get_name (vt));
-		GRAY_OBJECT_ENQUEUE (queue, obj, sgen_vtable_get_descriptor (vt));
+		GRAY_OBJECT_ENQUEUE (queue, (GCObject *)obj, sgen_vtable_get_descriptor (vt));
 	}
 }
 
 /*
  * This can return OBJ itself on OOM.
  */
-static MONO_NEVER_INLINE void*
-copy_object_no_checks (void *obj, SgenGrayQueue *queue)
+static MONO_NEVER_INLINE GCObject *
+copy_object_no_checks (GCObject *obj, SgenGrayQueue *queue)
 {
 	GCVTable vt = SGEN_LOAD_VTABLE_UNCHECKED (obj);
 	gboolean has_references = SGEN_VTABLE_HAS_REFERENCES (vt);
@@ -76,11 +76,11 @@ copy_object_no_checks (void *obj, SgenGrayQueue *queue)
 	if (!has_references)
 		queue = NULL;
 
-	par_copy_object_no_checks (destination, vt, obj, objsize, queue);
+	par_copy_object_no_checks ((char *)destination, vt, obj, objsize, queue);
 	/* FIXME: mark mod union cards if necessary */
 
 	/* set the forwarding pointer */
 	SGEN_FORWARD_OBJECT (obj, destination);
 
-	return destination;
+	return (GCObject *)destination;
 }

--- a/mono/sgen/sgen-descriptor.c
+++ b/mono/sgen/sgen-descriptor.c
@@ -95,7 +95,7 @@ alloc_complex_descriptor (gsize *bitmap, int numbits)
 	}
 	if (complex_descriptors_next + nwords > complex_descriptors_size) {
 		int new_size = complex_descriptors_size * 2 + nwords;
-		complex_descriptors = g_realloc (complex_descriptors, new_size * sizeof (gsize));
+		complex_descriptors = (gsize *)g_realloc (complex_descriptors, new_size * sizeof (gsize));
 		complex_descriptors_size = new_size;
 	}
 	SGEN_LOG (6, "Complex descriptor %d, size: %d (total desc memory: %d)", res, nwords, complex_descriptors_size);
@@ -293,7 +293,7 @@ mono_gc_make_root_descr_all_refs (int numbits)
 	if (numbits < 32 && all_ref_root_descrs [numbits])
 		return all_ref_root_descrs [numbits];
 
-	gc_bitmap = g_malloc0 (ALIGN_TO (ALIGN_TO (numbits, 8) + 1, sizeof (gsize)));
+	gc_bitmap = (gsize *)g_malloc0 (ALIGN_TO (ALIGN_TO (numbits, 8) + 1, sizeof (gsize)));
 	memset (gc_bitmap, 0xff, num_bytes);
 	if (numbits < ((sizeof (*gc_bitmap) * 8) - ROOT_DESC_TYPE_SHIFT)) 
 		gc_bitmap[0] = GUINT64_TO_LE(gc_bitmap[0]);

--- a/mono/sgen/sgen-fin-weak-hash.c
+++ b/mono/sgen/sgen-fin-weak-hash.c
@@ -121,7 +121,7 @@ sgen_collect_bridge_objects (int generation, ScanCopyContext ctx)
 	if (no_finalize)
 		return;
 
-	SGEN_HASH_TABLE_FOREACH (hash_table, object, dummy) {
+	SGEN_HASH_TABLE_FOREACH (hash_table, GCObject *, object, gpointer, dummy) {
 		int tag = tagged_object_get_tag (object);
 		object = tagged_object_get_object (object);
 
@@ -191,7 +191,7 @@ sgen_finalize_in_range (int generation, ScanCopyContext ctx)
 
 	if (no_finalize)
 		return;
-	SGEN_HASH_TABLE_FOREACH (hash_table, object, dummy) {
+	SGEN_HASH_TABLE_FOREACH (hash_table, GCObject *, object, gpointer, dummy) {
 		int tag = tagged_object_get_tag (object);
 		object = tagged_object_get_object (object);
 		if (!major_collector.is_object_live (object)) {
@@ -578,7 +578,7 @@ finalizers_with_predicate (SgenObjectPredicateFunc predicate, void *user_data, G
 	if (no_finalize || !out_size || !out_array)
 		return 0;
 	count = 0;
-	SGEN_HASH_TABLE_FOREACH (hash_table, object, dummy) {
+	SGEN_HASH_TABLE_FOREACH (hash_table, GCObject *, object, gpointer, dummy) {
 		object = tagged_object_get_object (object);
 
 		if (predicate (object, user_data)) {
@@ -634,7 +634,7 @@ sgen_remove_finalizers_if (SgenObjectPredicateFunc predicate, void *user_data, i
 	GCObject *object;
 	gpointer dummy G_GNUC_UNUSED;
 
-	SGEN_HASH_TABLE_FOREACH (hash_table, object, dummy) {
+	SGEN_HASH_TABLE_FOREACH (hash_table, GCObject *, object, gpointer, dummy) {
 		object = tagged_object_get_object (object);
 
 		if (predicate (object, user_data)) {

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -237,8 +237,8 @@ sgen_get_nursery_end (void)
 #define SGEN_POINTER_UNTAG_VTABLE(p)		SGEN_POINTER_UNTAG_ALL((p))
 
 /* returns NULL if not forwarded, or the forwarded address */
-#define SGEN_VTABLE_IS_FORWARDED(vtable) (SGEN_POINTER_IS_TAGGED_FORWARDED ((vtable)) ? SGEN_POINTER_UNTAG_VTABLE ((vtable)) : NULL)
-#define SGEN_OBJECT_IS_FORWARDED(obj) (SGEN_VTABLE_IS_FORWARDED (((mword*)(obj))[0]))
+#define SGEN_VTABLE_IS_FORWARDED(vtable) ((GCVTable *)(SGEN_POINTER_IS_TAGGED_FORWARDED ((vtable)) ? SGEN_POINTER_UNTAG_VTABLE ((vtable)) : NULL))
+#define SGEN_OBJECT_IS_FORWARDED(obj) ((GCObject *)SGEN_VTABLE_IS_FORWARDED (((mword*)(obj))[0]))
 
 #define SGEN_VTABLE_IS_PINNED(vtable) SGEN_POINTER_IS_TAGGED_PINNED ((vtable))
 #define SGEN_OBJECT_IS_PINNED(obj) (SGEN_VTABLE_IS_PINNED (((mword*)(obj))[0]))
@@ -264,7 +264,7 @@ sgen_get_nursery_end (void)
  * Since we set bits in the vtable, use the macro to load it from the pointer to
  * an object that is potentially pinned.
  */
-#define SGEN_LOAD_VTABLE(obj)		((GCVTable)(SGEN_POINTER_UNTAG_ALL (SGEN_LOAD_VTABLE_UNCHECKED ((obj)))))
+#define SGEN_LOAD_VTABLE(obj)		((GCVTable)(SGEN_POINTER_UNTAG_ALL (SGEN_LOAD_VTABLE_UNCHECKED ((GCObject *)(obj)))))
 
 /*
 List of what each bit on of the vtable gc bits means. 
@@ -441,7 +441,7 @@ void sgen_pin_stats_register_global_remset (GCObject *obj);
 void sgen_pin_stats_print_class_stats (void);
 
 void sgen_sort_addresses (void **array, size_t size);
-void sgen_add_to_global_remset (gpointer ptr, gpointer obj);
+void sgen_add_to_global_remset (gpointer ptr, GCObject *obj);
 
 int sgen_get_current_collection_generation (void);
 gboolean sgen_collection_is_concurrent (void);

--- a/mono/sgen/sgen-gray.c
+++ b/mono/sgen/sgen-gray.c
@@ -66,7 +66,7 @@ sgen_gray_object_alloc_queue_section (SgenGrayQueue *queue)
 		STATE_TRANSITION (section, GRAY_QUEUE_SECTION_STATE_FREE_LIST, GRAY_QUEUE_SECTION_STATE_FLOATING);
 	} else {
 		/* Allocate a new section */
-		section = sgen_alloc_internal (INTERNAL_MEM_GRAY_QUEUE);
+		section = (GrayQueueSection *)sgen_alloc_internal (INTERNAL_MEM_GRAY_QUEUE);
 		STATE_SET (section, GRAY_QUEUE_SECTION_STATE_FLOATING);
 	}
 

--- a/mono/sgen/sgen-hash-table.c
+++ b/mono/sgen/sgen-hash-table.c
@@ -53,7 +53,7 @@ rehash (SgenHashTable *hash_table)
 		new_size = g_spaced_primes_closest (hash_table->num_entries);
 	}
 
-	new_hash = sgen_alloc_internal_dynamic (new_size * sizeof (SgenHashTableEntry*), hash_table->table_mem_type, TRUE);
+	new_hash = (SgenHashTableEntry **)sgen_alloc_internal_dynamic (new_size * sizeof (SgenHashTableEntry*), hash_table->table_mem_type, TRUE);
 	for (i = 0; i < old_hash_size; ++i) {
 		for (entry = old_hash [i]; entry; entry = next) {
 			hash = hash_table->hash_func (entry->key) % new_size;
@@ -132,7 +132,7 @@ sgen_hash_table_replace (SgenHashTable *hash_table, gpointer key, gpointer new_v
 		return FALSE;
 	}
 
-	entry = sgen_alloc_internal (hash_table->entry_mem_type);
+	entry = (SgenHashTableEntry *)sgen_alloc_internal (hash_table->entry_mem_type);
 	entry->key = key;
 	memcpy (entry->data, new_value, hash_table->data_size);
 

--- a/mono/sgen/sgen-hash-table.h
+++ b/mono/sgen/sgen-hash-table.h
@@ -42,9 +42,9 @@ void sgen_init_hash_table (void);
 
 #define sgen_hash_table_num_entries(h)	((h)->num_entries)
 
-#define sgen_hash_table_key_for_value_pointer(v)	(((SgenHashTableEntry*)((char*)(v) - G_STRUCT_OFFSET (SgenHashTableEntry, data)))->key)
+#define sgen_hash_table_key_for_value_pointer(v)	((GCObject *)(((SgenHashTableEntry*)((char*)(v) - G_STRUCT_OFFSET (SgenHashTableEntry, data)))->key))
 
-#define SGEN_HASH_TABLE_FOREACH(h,k,v) do {				\
+#define SGEN_HASH_TABLE_FOREACH(h,tk,k,tv,v) do {				\
 		SgenHashTable *__hash_table = (h);			\
 		SgenHashTableEntry **__table = __hash_table->table;	\
 		guint __i;						\
@@ -53,8 +53,8 @@ void sgen_init_hash_table (void);
 			for (__iter = &__table [__i]; *__iter; __iter = __next) {	\
 				SgenHashTableEntry *__entry = *__iter;	\
 				__next = &__entry->next;	\
-				(k) = __entry->key;			\
-				(v) = (gpointer)__entry->data;
+				(k) = (tk)__entry->key;			\
+				(v) = (tv)__entry->data;
 
 /* The loop must be continue'd after using this! */
 #define SGEN_HASH_TABLE_FOREACH_REMOVE(free)	do {			\

--- a/mono/sgen/sgen-internal.c
+++ b/mono/sgen/sgen-internal.c
@@ -165,7 +165,7 @@ sgen_alloc_internal_dynamic (size_t size, int type, gboolean assert_on_failure)
 	void *p;
 
 	if (size > allocator_sizes [NUM_ALLOCATORS - 1]) {
-		p = sgen_alloc_os_memory (size, SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE, NULL);
+		p = sgen_alloc_os_memory (size, (SgenAllocFlags)(SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE), NULL);
 		if (!p)
 			sgen_assert_memory_alloc (NULL, size, description_for_type (type));
 	} else {

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -238,7 +238,7 @@ get_los_section_memory (size_t size)
 	if (!sgen_memgov_try_alloc_space (LOS_SECTION_SIZE, SPACE_LOS))
 		return NULL;
 
-	section = sgen_alloc_os_memory_aligned (LOS_SECTION_SIZE, LOS_SECTION_SIZE, SGEN_ALLOC_HEAP | SGEN_ALLOC_ACTIVATE, NULL);
+	section = (LOSSection *)sgen_alloc_os_memory_aligned (LOS_SECTION_SIZE, LOS_SECTION_SIZE, (SgenAllocFlags)(SGEN_ALLOC_HEAP | SGEN_ALLOC_ACTIVATE), NULL);
 
 	if (!section)
 		return NULL;
@@ -379,7 +379,7 @@ sgen_los_alloc_large_inner (GCVTable vtable, size_t size)
 		alloc_size += pagesize - 1;
 		alloc_size &= ~(pagesize - 1);
 		if (sgen_memgov_try_alloc_space (alloc_size, SPACE_LOS)) {
-			obj = sgen_alloc_os_memory (alloc_size, SGEN_ALLOC_HEAP | SGEN_ALLOC_ACTIVATE, NULL);
+			obj = (LOSObject *)sgen_alloc_os_memory (alloc_size, (SgenAllocFlags)(SGEN_ALLOC_HEAP | SGEN_ALLOC_ACTIVATE), NULL);
 		}
 	} else {
 		obj = get_los_section_memory (size + sizeof (LOSObject));
@@ -593,7 +593,7 @@ get_cardtable_mod_union_for_object (LOSObject *obj)
 	if (mod_union)
 		return mod_union;
 	mod_union = sgen_card_table_alloc_mod_union ((char*)obj->data, size);
-	other = SGEN_CAS_PTR ((gpointer*)&obj->cardtable_mod_union, mod_union, NULL);
+	other = (guint8 *)SGEN_CAS_PTR ((gpointer*)&obj->cardtable_mod_union, mod_union, NULL);
 	if (!other) {
 		SGEN_ASSERT (0, obj->cardtable_mod_union == mod_union, "Why did CAS not replace?");
 		return mod_union;

--- a/mono/sgen/sgen-marksweep-drain-gray-stack.h
+++ b/mono/sgen/sgen-marksweep-drain-gray-stack.h
@@ -74,7 +74,7 @@ COPY_OR_MARK_FUNCTION_NAME (GCObject **ptr, GCObject *obj, SgenGrayQueue *queue)
 			HEAVY_STAT (++stat_optimized_copy_nursery_pinned);
 			return TRUE;
 		}
-		if ((forwarded = SGEN_VTABLE_IS_FORWARDED (vtable_word))) {
+		if ((forwarded = (GCObject *)SGEN_VTABLE_IS_FORWARDED (vtable_word))) {
 			HEAVY_STAT (++stat_optimized_copy_nursery_forwarded);
 			SGEN_UPDATE_REFERENCE (ptr, forwarded);
 			return sgen_ptr_in_nursery (forwarded);
@@ -142,7 +142,7 @@ COPY_OR_MARK_FUNCTION_NAME (GCObject **ptr, GCObject *obj, SgenGrayQueue *queue)
 #ifdef COPY_OR_MARK_WITH_EVACUATION
 		{
 			GCObject *forwarded;
-			if ((forwarded = SGEN_VTABLE_IS_FORWARDED (vtable_word))) {
+			if ((forwarded = (GCObject *)SGEN_VTABLE_IS_FORWARDED (vtable_word))) {
 				HEAVY_STAT (++stat_optimized_copy_major_forwarded);
 				SGEN_UPDATE_REFERENCE (ptr, forwarded);
 				SGEN_ASSERT (9, !sgen_ptr_in_nursery (forwarded), "Cannot be forwarded to nursery.");
@@ -241,12 +241,12 @@ SCAN_OBJECT_FUNCTION_NAME (GCObject *full_object, SgenDescriptor desc, SgenGrayQ
 		} while (0)
 #else
 #define HANDLE_PTR(ptr,obj)	do {					\
-		void *__old = *(ptr);					\
+		GCObject *__old = *(ptr);					\
 		binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
 		if (__old) {						\
 			gboolean __still_in_nursery = COPY_OR_MARK_FUNCTION_NAME ((ptr), __old, queue); \
 			if (G_UNLIKELY (__still_in_nursery && !sgen_ptr_in_nursery ((ptr)) && !SGEN_OBJECT_IS_CEMENTED (*(ptr)))) { \
-				void *__copy = *(ptr);			\
+				GCObject *__copy = *(ptr);			\
 				sgen_add_to_global_remset ((ptr), __copy); \
 			}						\
 		}							\

--- a/mono/sgen/sgen-marksweep-scan-object-concurrent.h
+++ b/mono/sgen/sgen-marksweep-scan-object-concurrent.h
@@ -32,12 +32,12 @@
 
 #undef HANDLE_PTR
 #define HANDLE_PTR(ptr,obj)     do {                                    \
-                void *__old = *(ptr);                                   \
+                GCObject *__old = *(ptr);                                   \
                 binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
                 if (__old) {                                            \
                         gboolean __still_in_nursery = major_copy_or_mark_object_with_evacuation ((ptr), __old, queue); \
                         if (G_UNLIKELY (__still_in_nursery && !sgen_ptr_in_nursery ((ptr)) && !SGEN_OBJECT_IS_CEMENTED (*(ptr)))) { \
-                                void *__copy = *(ptr);                  \
+                                GCObject *__copy = *(ptr);                  \
                                 sgen_add_to_global_remset ((ptr), __copy); \
                         }						\
                 }                                                       \

--- a/mono/sgen/sgen-pinning-stats.c
+++ b/mono/sgen/sgen-pinning-stats.c
@@ -107,7 +107,7 @@ sgen_pin_stats_register_address (char *addr, int pin_type)
 			node_ptr = &node->right;
 	}
 
-	node = sgen_alloc_internal_dynamic (sizeof (PinStatAddress), INTERNAL_MEM_STATISTICS, TRUE);
+	node = (PinStatAddress *)sgen_alloc_internal_dynamic (sizeof (PinStatAddress), INTERNAL_MEM_STATISTICS, TRUE);
 	node->addr = addr;
 	node->pin_types = pin_type_bit;
 	node->left = node->right = NULL;
@@ -161,7 +161,7 @@ register_vtable (GCVTable vtable, int pin_types)
 	int i;
 
 	memset (&empty_entry, 0, sizeof (PinnedClassEntry));
-	entry = lookup_vtable_entry (&pinned_class_hash_table, vtable, &empty_entry);
+	entry = (PinnedClassEntry *)lookup_vtable_entry (&pinned_class_hash_table, vtable, &empty_entry);
 
 	for (i = 0; i < PIN_TYPE_MAX; ++i) {
 		if (pin_types & (1 << i))
@@ -194,7 +194,7 @@ sgen_pin_stats_register_global_remset (GCObject *obj)
 		return;
 
 	memset (&empty_entry, 0, sizeof (GlobalRemsetClassEntry));
-	entry = lookup_vtable_entry (&global_remset_class_hash_table, SGEN_LOAD_VTABLE (obj), &empty_entry);
+	entry = (GlobalRemsetClassEntry *)lookup_vtable_entry (&global_remset_class_hash_table, SGEN_LOAD_VTABLE (obj), &empty_entry);
 
 	++entry->num_remsets;
 }
@@ -210,7 +210,7 @@ sgen_pin_stats_print_class_stats (void)
 		return;
 
 	mono_gc_printf (gc_debug_file, "\n%-50s  %10s  %10s  %10s\n", "Class", "Stack", "Static", "Other");
-	SGEN_HASH_TABLE_FOREACH (&pinned_class_hash_table, name, pinned_entry) {
+	SGEN_HASH_TABLE_FOREACH (&pinned_class_hash_table, char *, name, PinnedClassEntry *, pinned_entry) {
 		int i;
 		mono_gc_printf (gc_debug_file, "%-50s", name);
 		for (i = 0; i < PIN_TYPE_MAX; ++i)
@@ -219,7 +219,7 @@ sgen_pin_stats_print_class_stats (void)
 	} SGEN_HASH_TABLE_FOREACH_END;
 
 	mono_gc_printf (gc_debug_file, "\n%-50s  %10s\n", "Class", "#Remsets");
-	SGEN_HASH_TABLE_FOREACH (&global_remset_class_hash_table, name, remset_entry) {
+	SGEN_HASH_TABLE_FOREACH (&global_remset_class_hash_table, char *, name, GlobalRemsetClassEntry *, remset_entry) {
 		mono_gc_printf (gc_debug_file, "%-50s  %10ld\n", name, remset_entry->num_remsets);
 	} SGEN_HASH_TABLE_FOREACH_END;
 

--- a/mono/sgen/sgen-pinning.c
+++ b/mono/sgen/sgen-pinning.c
@@ -173,7 +173,7 @@ sgen_dump_pin_queue (void)
 	int i;
 
 	for (i = 0; i < last_num_pinned; ++i) {
-		void *ptr = pin_queue.data [i];
+		GCObject *ptr = (GCObject *)pin_queue.data [i];
 		SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %zd", ptr, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (ptr)), sgen_safe_object_get_size (ptr));
 	}
 }

--- a/mono/sgen/sgen-pointer-queue.c
+++ b/mono/sgen/sgen-pointer-queue.c
@@ -43,7 +43,7 @@ static void
 realloc_queue (SgenPointerQueue *queue)
 {
 	size_t new_size = queue->size ? queue->size + queue->size/2 : 1024;
-	void **new_data = sgen_alloc_internal_dynamic (sizeof (void*) * new_size, queue->mem_type, TRUE);
+	void **new_data = (void **)sgen_alloc_internal_dynamic (sizeof (void*) * new_size, queue->mem_type, TRUE);
 
 	memcpy (new_data, queue->data, sizeof (void*) * queue->next_slot);
 	sgen_free_internal_dynamic (queue->data, sizeof (void*) * queue->size, queue->mem_type);

--- a/mono/sgen/sgen-protocol-def.h
+++ b/mono/sgen/sgen-protocol-def.h
@@ -112,7 +112,7 @@ MATCH_INDEX (matches_interval (ptr, entry->addr, entry->size) ? 0 : BINARY_PROTO
 IS_VTABLE_MATCH (FALSE)
 END_PROTOCOL_ENTRY_HEAVY
 
-BEGIN_PROTOCOL_ENTRY_HEAVY4 (binary_protocol_block_set_state, TYPE_POINTER, addr, TYPE_SIZE, size, TYPE_INT, old, TYPE_INT, new)
+BEGIN_PROTOCOL_ENTRY_HEAVY4 (binary_protocol_block_set_state, TYPE_POINTER, addr, TYPE_SIZE, size, TYPE_INT, old, TYPE_INT, new_)
 DEFAULT_PRINT ()
 IS_ALWAYS_MATCH (FALSE)
 MATCH_INDEX (matches_interval (ptr, entry->addr, entry->size) ? 0 : BINARY_PROTOCOL_NO_MATCH)

--- a/mono/sgen/sgen-protocol.c
+++ b/mono/sgen/sgen-protocol.c
@@ -69,7 +69,7 @@ filename_for_index (int index)
 
 	SGEN_ASSERT (0, file_size_limit > 0, "Indexed binary protocol filename must only be used with file size limit");
 
-	filename = sgen_alloc_internal_dynamic (strlen (filename_or_prefix) + 32, INTERNAL_MEM_BINARY_PROTOCOL, TRUE);
+	filename = (char *)sgen_alloc_internal_dynamic (strlen (filename_or_prefix) + 32, INTERNAL_MEM_BINARY_PROTOCOL, TRUE);
 	sprintf (filename, "%s.%d", filename_or_prefix, index);
 
 	return filename;
@@ -108,7 +108,7 @@ void
 binary_protocol_init (const char *filename, long long limit)
 {
 #ifdef HAVE_UNISTD_H
-	filename_or_prefix = sgen_alloc_internal_dynamic (strlen (filename) + 1, INTERNAL_MEM_BINARY_PROTOCOL, TRUE);
+	filename_or_prefix = (char *)sgen_alloc_internal_dynamic (strlen (filename) + 1, INTERNAL_MEM_BINARY_PROTOCOL, TRUE);
 	strcpy (filename_or_prefix, filename);
 
 	file_size_limit = limit;
@@ -251,7 +251,7 @@ binary_protocol_flush_buffers (gboolean force)
 
 	for (buf = binary_protocol_buffers; buf != NULL; buf = buf->next)
 		++num_buffers;
-	bufs = sgen_alloc_internal_dynamic (num_buffers * sizeof (BinaryProtocolBuffer*), INTERNAL_MEM_BINARY_PROTOCOL, TRUE);
+	bufs = (BinaryProtocolBuffer **)sgen_alloc_internal_dynamic (num_buffers * sizeof (BinaryProtocolBuffer*), INTERNAL_MEM_BINARY_PROTOCOL, TRUE);
 	for (buf = binary_protocol_buffers, i = 0; buf != NULL; buf = buf->next, i++)
 		bufs [i] = buf;
 	SGEN_ASSERT (0, i == num_buffers, "Binary protocol buffer count error");
@@ -280,7 +280,7 @@ binary_protocol_get_buffer (int length)
 	if (buffer && buffer->index + length <= BINARY_PROTOCOL_BUFFER_SIZE)
 		return buffer;
 
-	new_buffer = sgen_alloc_os_memory (sizeof (BinaryProtocolBuffer), SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE, "debugging memory");
+	new_buffer = (BinaryProtocolBuffer *)sgen_alloc_os_memory (sizeof (BinaryProtocolBuffer), (SgenAllocFlags)(SGEN_ALLOC_INTERNAL | SGEN_ALLOC_ACTIVATE), "debugging memory");
 	new_buffer->next = buffer;
 	new_buffer->index = 0;
 

--- a/mono/sgen/sgen-split-nursery.c
+++ b/mono/sgen/sgen-split-nursery.c
@@ -179,8 +179,8 @@ mark_bit (char *space_bitmap, char *pos)
 static void
 mark_bits_in_range (char *space_bitmap, char *start, char *end)
 {
-	start = align_down (start, SGEN_TO_SPACE_GRANULE_BITS);
-	end = align_up (end, SGEN_TO_SPACE_GRANULE_BITS);
+	start = (char *)align_down (start, SGEN_TO_SPACE_GRANULE_BITS);
+	end = (char *)align_up (end, SGEN_TO_SPACE_GRANULE_BITS);
 
 	for (;start < end; start += SGEN_TO_SPACE_GRANULE_IN_BYTES)
 		mark_bit (space_bitmap, start);
@@ -244,7 +244,7 @@ alloc_for_promotion_slow_path (int age, size_t objsize)
 	size_t allocated_size;
 	size_t aligned_objsize = (size_t)align_up (objsize, SGEN_TO_SPACE_GRANULE_BITS);
 
-	p = sgen_fragment_allocator_serial_range_alloc (
+	p = (char *)sgen_fragment_allocator_serial_range_alloc (
 		&collector_allocator,
 		MAX (aligned_objsize, AGE_ALLOC_BUFFER_DESIRED_SIZE),
 		MAX (aligned_objsize, AGE_ALLOC_BUFFER_MIN_SIZE),
@@ -336,8 +336,8 @@ prepare_to_space (char *to_space_bitmap, size_t space_bitmap_size)
 	previous = &collector_allocator.alloc_head;
 
 	for (frag = *previous; frag; frag = *previous) {
-		char *start = align_up (frag->fragment_next, SGEN_TO_SPACE_GRANULE_BITS);
-		char *end = align_down (frag->fragment_end, SGEN_TO_SPACE_GRANULE_BITS);
+		char *start = (char *)align_up (frag->fragment_next, SGEN_TO_SPACE_GRANULE_BITS);
+		char *end = (char *)align_down (frag->fragment_end, SGEN_TO_SPACE_GRANULE_BITS);
 
 		/* Fragment is too small to be usable. */
 		if ((end - start) < SGEN_MAX_NURSERY_WASTE) {
@@ -378,12 +378,12 @@ static void
 init_nursery (SgenFragmentAllocator *allocator, char *start, char *end)
 {
 	int alloc_quote = (int)((end - start) * alloc_ratio);
-	promotion_barrier = align_down (start + alloc_quote, 3);
+	promotion_barrier = (char *)align_down (start + alloc_quote, 3);
 	sgen_fragment_allocator_add (allocator, start, promotion_barrier);
 	sgen_fragment_allocator_add (&collector_allocator, promotion_barrier, end);
 
 	region_age_size = (end - start) >> SGEN_TO_SPACE_GRANULE_BITS;
-	region_age = g_malloc0 (region_age_size);
+	region_age = (char *)g_malloc0 (region_age_size);
 }
 
 static gboolean

--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -52,7 +52,7 @@ static SgenThreadPoolJob*
 get_job_and_set_in_progress (void)
 {
 	for (size_t i = 0; i < job_queue.next_slot; ++i) {
-		SgenThreadPoolJob *job = job_queue.data [i];
+		SgenThreadPoolJob *job = (SgenThreadPoolJob *)job_queue.data [i];
 		if (job->state == STATE_WAITING) {
 			job->state = STATE_IN_PROGRESS;
 			return job;
@@ -171,7 +171,7 @@ sgen_thread_pool_init (int num_threads, SgenThreadPoolThreadInitFunc init_func, 
 SgenThreadPoolJob*
 sgen_thread_pool_job_alloc (const char *name, SgenThreadPoolJobFunc func, size_t size)
 {
-	SgenThreadPoolJob *job = sgen_alloc_internal_dynamic (size, INTERNAL_MEM_THREAD_POOL_JOB, TRUE);
+	SgenThreadPoolJob *job = (SgenThreadPoolJob *)sgen_alloc_internal_dynamic (size, INTERNAL_MEM_THREAD_POOL_JOB, TRUE);
 	job->name = name;
 	job->size = size;
 	job->state = STATE_WAITING;

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -191,7 +191,7 @@ init_private_gray_queue (WorkerData *data)
 static void
 thread_pool_init_func (void *data_untyped)
 {
-	WorkerData *data = data_untyped;
+	WorkerData *data = (WorkerData *)data_untyped;
 	SgenMajorCollector *major = sgen_get_major_collector ();
 
 	sgen_client_thread_register_worker ();
@@ -211,7 +211,7 @@ continue_idle_func (void)
 static void
 marker_idle_func (void *data_untyped)
 {
-	WorkerData *data = data_untyped;
+	WorkerData *data = (WorkerData *)data_untyped;
 
 	SGEN_ASSERT (0, continue_idle_func (), "Why are we called when we're not supposed to work?");
 	SGEN_ASSERT (0, sgen_concurrent_collection_in_progress (), "The worker should only mark in concurrent collections.");
@@ -258,7 +258,7 @@ void
 sgen_workers_init (int num_workers)
 {
 	int i;
-	void **workers_data_ptrs = alloca(num_workers * sizeof(void *));
+	void **workers_data_ptrs = (void **)alloca(num_workers * sizeof(void *));
 
 	if (!sgen_get_major_collector ()->is_concurrent) {
 		sgen_thread_pool_init (num_workers, thread_pool_init_func, NULL, NULL, NULL);
@@ -269,7 +269,7 @@ sgen_workers_init (int num_workers)
 
 	workers_num = num_workers;
 
-	workers_data = sgen_alloc_internal_dynamic (sizeof (WorkerData) * num_workers, INTERNAL_MEM_WORKER_DATA, TRUE);
+	workers_data = (WorkerData *)sgen_alloc_internal_dynamic (sizeof (WorkerData) * num_workers, INTERNAL_MEM_WORKER_DATA, TRUE);
 	memset (workers_data, 0, sizeof (WorkerData) * num_workers);
 
 	init_distribute_gray_queue ();

--- a/mono/unit-tests/test-memfuncs.c
+++ b/mono/unit-tests/test-memfuncs.c
@@ -40,9 +40,9 @@
 int
 main (void)
 {
-	unsigned char *random_mem = malloc (POOL_SIZE);
-	unsigned char *reference = malloc (POOL_SIZE);
-	unsigned char *playground = malloc (POOL_SIZE);
+	unsigned char *random_mem = (unsigned char *)malloc (POOL_SIZE);
+	unsigned char *reference = (unsigned char *)malloc (POOL_SIZE);
+	unsigned char *playground = (unsigned char *)malloc (POOL_SIZE);
 	long *long_random_mem;
 	int i, offset, size, src_offset, dest_offset;
 

--- a/mono/unit-tests/test-mono-linked-list-set.c
+++ b/mono/unit-tests/test-mono-linked-list-set.c
@@ -48,7 +48,7 @@ mono_hazard_pointer_clear_all (MonoThreadHazardPointers *hp, int retain)
 static void
 free_node (void *n)
 {
-	node_t *node = n;
+	node_t *node = (node_t *)n;
 	assert (node->state == STATE_BUSY);
 	node->state = STATE_OUT;
 }
@@ -56,7 +56,7 @@ free_node (void *n)
 static void*
 worker (void *arg)
 {
-	thread_data_t *thread_data = arg;
+	thread_data_t *thread_data = (thread_data_t *)arg;
 	MonoThreadHazardPointers *hp;
 	int skip = thread_data->skip;
 	int i, j;

--- a/mono/unit-tests/test-sgen-qsort.c
+++ b/mono/unit-tests/test-sgen-qsort.c
@@ -100,7 +100,7 @@ compare_sorts2 (void *base, size_t nel)
 	memcpy (b2, base, len);
 
 	qsort (b1, nel, sizeof (teststruct_t*), compare_teststructs2);
-	qsort_test_struct (b2, nel);
+	qsort_test_struct ((teststruct_t **)b2, nel);
 
 	assert (!memcmp (b1, b2, len));
 

--- a/mono/utils/bsearch.c
+++ b/mono/utils/bsearch.c
@@ -42,7 +42,7 @@ mono_binary_search (
 	size_t member_size,
 	BinarySearchComparer comparer)
 {
-	const char *base = array;
+	const char *base = (const char *)array;
 	size_t lim;
 	int cmp;
 	const void *p;

--- a/mono/utils/memfuncs.c
+++ b/mono/utils/memfuncs.c
@@ -188,7 +188,7 @@ mono_gc_memmove_aligned (void *dest, const void *src, size_t size)
 			while (p > align_end)
 			        *--p = *--s;
 
-			word_start = align_up (start);
+			word_start = (char *)align_up (start);
 			bytes_to_memmove = p - word_start;
 			p -= bytes_to_memmove;
 			s -= bytes_to_memmove;

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -48,7 +48,7 @@ conc_table_new (int size)
 static void
 conc_table_free (gpointer ptr)
 {
-	conc_table *table = ptr;
+	conc_table *table = (conc_table *)ptr;
 	g_free (table->kvs);
 	g_free (table);
 }
@@ -164,7 +164,7 @@ mono_conc_hashtable_lookup (MonoConcurrentHashTable *hash_table, gpointer key)
 	hp = mono_hazard_pointer_get ();
 
 retry:
-	table = get_hazardous_pointer ((gpointer volatile*)&hash_table->table, hp, 0);
+	table = (conc_table *)get_hazardous_pointer ((gpointer volatile*)&hash_table->table, hp, 0);
 	table_mask = table->table_size - 1;
 	kvs = table->kvs;
 	i = hash & table_mask;

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -71,7 +71,7 @@ Requires the world to be stoped
 
 #define MONO_LLS_FOREACH_FILTERED(list, element, filter_func, type) {\
 	MonoLinkedListSetNode *__cur;	\
-	for (__cur = (list)->head; __cur; __cur = mono_lls_pointer_unmask (__cur->next)) \
+	for (__cur = (list)->head; __cur; __cur = (MonoLinkedListSetNode *)mono_lls_pointer_unmask (__cur->next)) \
 		if (!mono_lls_pointer_get_mark (__cur->next)) {	\
 			(element) = (type)__cur;			\
 			if (!filter_func (element)) continue;

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -161,7 +161,7 @@ mono_process_list (int *size)
 				count = 16;
 			else
 				count *= 2;
-			buf = g_realloc (buf, count * sizeof (void*));
+			buf = (void **)g_realloc (buf, count * sizeof (void*));
 		}
 		buf [i++] = GINT_TO_POINTER (pid);
 	}

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -157,7 +157,7 @@ mono_threads_finish_blocking (void *cookie, void* stackdata)
 	if (!mono_threads_is_coop_enabled ())
 		return;
 
-	info = cookie;
+	info = (MonoThreadInfo *)cookie;
 	if (!info)
 		return;
 
@@ -227,7 +227,7 @@ mono_threads_reset_blocking_end (void *cookie, void* stackdata)
 	if (!mono_threads_is_coop_enabled ())
 		return;
 
-	info = cookie;
+	info = (MonoThreadInfo *)cookie;
 	if (!info)
 		return;
 

--- a/mono/utils/mono-threads-posix-signals.c
+++ b/mono/utils/mono-threads-posix-signals.c
@@ -64,7 +64,7 @@ signal_add_handler (int signo, gpointer handler, int flags)
 	struct sigaction previous_sa;
 	int ret;
 
-	sa.sa_sigaction = handler;
+	sa.sa_sigaction = (void (*)(int, siginfo_t *, void *))handler;
 	sigfillset (&sa.sa_mask);
 
 	sa.sa_flags = SA_SIGINFO | flags;
@@ -216,7 +216,8 @@ suspend_signal_handler (int _dummy, siginfo_t *info, void *context)
 #if MONO_ARCH_HAS_MONO_CONTEXT
 		MonoContext tmp = current->thread_saved_state [ASYNC_SUSPEND_STATE_INDEX].ctx;
 		mono_threads_get_runtime_callbacks ()->setup_async_callback (&tmp, current->async_target, current->user_data);
-		current->async_target = current->user_data = NULL;
+		current->user_data = NULL;
+		current->async_target = NULL;
 		mono_monoctx_to_sigctx (&tmp, context);
 #else
 		g_error ("The new interruption machinery requires a working mono-context");

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1380,7 +1380,7 @@ mono_thread_info_install_interrupt (void (*callback) (gpointer data), gpointer d
 	token->callback = callback;
 	token->data = data;
 
-	previous_token = InterlockedCompareExchangePointer ((gpointer*) &info->interrupt_token, token, NULL);
+	previous_token = (MonoThreadInfoInterruptToken *)InterlockedCompareExchangePointer ((gpointer*) &info->interrupt_token, token, NULL);
 
 	if (previous_token) {
 		if (previous_token != INTERRUPT_STATE)
@@ -1407,7 +1407,7 @@ mono_thread_info_uninstall_interrupt (gboolean *interrupted)
 	info = mono_thread_info_current ();
 	g_assert (info);
 
-	previous_token = InterlockedExchangePointer ((gpointer*) &info->interrupt_token, NULL);
+	previous_token = (MonoThreadInfoInterruptToken *)InterlockedExchangePointer ((gpointer*) &info->interrupt_token, NULL);
 
 	/* only the installer can uninstall the token */
 	g_assert (previous_token);
@@ -1516,7 +1516,7 @@ mono_thread_info_clear_self_interrupt ()
 	info = mono_thread_info_current ();
 	g_assert (info);
 
-	previous_token = InterlockedCompareExchangePointer ((gpointer*) &info->interrupt_token, NULL, INTERRUPT_STATE);
+	previous_token = (MonoThreadInfoInterruptToken *)InterlockedCompareExchangePointer ((gpointer*) &info->interrupt_token, NULL, INTERRUPT_STATE);
 	g_assert (previous_token == NULL || previous_token == INTERRUPT_STATE);
 
 	THREADS_INTERRUPT_DEBUG ("interrupt clear self tid %p previous_token %p\n", mono_thread_info_get_tid (info), previous_token);

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -182,7 +182,7 @@ mono_get_local_interfaces (int family, int *interface_count)
 
 	memset (&ifc, 0, sizeof (ifc));
 	ifc.ifc_len = IFCONF_BUFF_SIZE;
-	ifc.ifc_buf = g_malloc (IFCONF_BUFF_SIZE); /* We can't have such huge buffers on the stack. */
+	ifc.ifc_buf = (char *)g_malloc (IFCONF_BUFF_SIZE); /* We can't have such huge buffers on the stack. */
 	if (ioctl (fd, SIOCGIFCONF, &ifc) < 0)
 		goto done;
 
@@ -219,7 +219,8 @@ mono_get_local_interfaces (int family, int *interface_count)
 		++if_count;
 	}
 
-	result_ptr = result = g_malloc (if_count * mono_address_size_for_family (family));
+	result = (char *)g_malloc (if_count * mono_address_size_for_family (family));
+	result_ptr = (char *)result;
 	FOREACH_IFR (ifr, ifc) {
 		if (ifr->ifr_name [0] == '\0')
 			continue;


### PR DESCRIPTION
 * Add explicit casts for void pointers and enums.

 * Rename `class` to `klass` and `this` to `this_obj`.

 * Avoid other C++ keywords by appending an underscore.

 * Change `MonoSeqPointInfo` to avoid empty struct size warnings.
