### PR TITLE
[msvc] Fix a few missing renames from ARCHITECTURE -> MONO_ARCHITECTURE

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1257,7 +1257,7 @@ mini_debug_usage (void)
 }
 
 #if defined(MONO_ARCH_ARCHITECTURE)
-/* Redefine ARCHITECTURE to include more information */
+/* Redefine MONO_ARCHITECTURE to include more information */
 #undef MONO_ARCHITECTURE
 #define MONO_ARCHITECTURE MONO_ARCH_ARCHITECTURE
 #endif

--- a/winconfig.h
+++ b/winconfig.h
@@ -7,11 +7,11 @@
 
 /* The architecture this is running on */
 #if defined(_M_IA64)
-#define ARCHITECTURE "ia64"
+#define MONO_ARCHITECTURE "ia64"
 #elif defined(_M_AMD64)
-#define ARCHITECTURE "amd64"
+#define MONO_ARCHITECTURE "amd64"
 #elif defined(_M_IX86)
-#define ARCHITECTURE "x86"
+#define MONO_ARCHITECTURE "x86"
 #else
 #error Unknown architecture
 #endif


### PR DESCRIPTION
They were missed in 43403b8221ed0d6e65d4766fc629f178915df4e4.