### PR TITLE
[msvc] Fix Windows build breaks caused by a595d489fa64d8e213c74470f23c576296e2d548

### DIFF
--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -250,7 +250,7 @@ mono_os_mutex_trylock (mono_mutex_t *mutex)
 static inline int
 mono_os_mutex_unlock (mono_mutex_t *mutex)
 {
-	LeaveCriticalSection (mutex));
+	LeaveCriticalSection (mutex);
 	return 0;
 }
 

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -45,7 +45,6 @@
     <ClCompile Include="..\mono\utils\mono-math.c" />
     <ClCompile Include="..\mono\utils\mono-md5.c" />
     <ClCompile Include="..\mono\utils\mono-mmap.c" />
-    <ClCompile Include="..\mono\utils\mono-mutex.c" />
     <ClCompile Include="..\mono\utils\mono-networkinterfaces.c" />
     <ClCompile Include="..\mono\utils\mono-rand.c" />
     <ClCompile Include="..\mono\utils\mono-threads-state-machine.c" />
@@ -58,7 +57,6 @@
     <ClCompile Include="..\mono\utils\mono-proclib.c" />
     <ClCompile Include="..\mono\utils\mono-property-hash.c" />
     <ClCompile Include="..\mono\utils\mono-publib.c" />
-    <ClCompile Include="..\mono\utils\mono-semaphore.c" />
     <ClCompile Include="..\mono\utils\mono-sha1.c" />
     <ClCompile Include="..\mono\utils\mono-stdlib.c" />
     <ClCompile Include="..\mono\utils\mono-threads-mach.c" />
@@ -104,6 +102,8 @@
     <ClInclude Include="..\mono\utils\mono-complex.h" />
     <ClInclude Include="..\mono\utils\mono-conc-hashtable.h" />
     <ClInclude Include="..\mono\utils\mono-context.h" />
+    <ClInclude Include="..\mono\utils\mono-coop-mutex.h" />
+    <ClInclude Include="..\mono\utils\mono-coop-semaphore.h" />
     <ClInclude Include="..\mono\utils\mono-counters.h" />
     <ClInclude Include="..\mono\utils\mono-digest.h" />
     <ClInclude Include="..\mono\utils\mono-dl-fallback.h" />
@@ -120,15 +120,16 @@
     <ClInclude Include="..\mono\utils\mono-membar.h" />
     <ClInclude Include="..\mono\utils\mono-memory-model.h" />
     <ClInclude Include="..\mono\utils\mono-mmap.h" />
-    <ClInclude Include="..\mono\utils\mono-mutex.h" />
     <ClInclude Include="..\mono\utils\mono-networkinterfaces.h" />
+    <ClInclude Include="..\mono\utils\mono-once.h" />
+    <ClInclude Include="..\mono\utils\mono-os-mutex.h" />
+    <ClInclude Include="..\mono\utils\mono-os-semaphore.h" />
     <ClInclude Include="..\mono\utils\mono-path.h" />
     <ClInclude Include="..\mono\utils\mono-poll.h" />
     <ClInclude Include="..\mono\utils\mono-proclib.h" />
     <ClInclude Include="..\mono\utils\mono-property-hash.h" />
     <ClInclude Include="..\mono\utils\mono-publib.h" />
     <ClInclude Include="..\mono\utils\mono-rand.h" />
-    <ClInclude Include="..\mono\utils\mono-semaphore.h" />
     <ClInclude Include="..\mono\utils\mono-sigcontext.h" />
     <ClInclude Include="..\mono\utils\mono-stack-unwinding.h" />
     <ClInclude Include="..\mono\utils\mono-stdlib.h" />

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -759,9 +759,6 @@ mono_security_core_clr_require_elevated_permissions
 mono_security_core_clr_set_options
 mono_security_enable_core_clr
 mono_security_set_core_clr_platform_callback
-mono_sem_post
-mono_sem_timedwait
-mono_sem_wait
 mono_set_assemblies_path
 mono_set_break_policy
 mono_set_config_dir

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -761,9 +761,6 @@ mono_security_core_clr_require_elevated_permissions
 mono_security_core_clr_set_options
 mono_security_enable_core_clr
 mono_security_set_core_clr_platform_callback
-mono_sem_post
-mono_sem_timedwait
-mono_sem_wait
 mono_set_assemblies_path
 mono_set_break_policy
 mono_set_config_dir


### PR DESCRIPTION
The .vcproj's and .def's weren't updated and there was a typo in mono-os-mutex.h that caused a build break.