### PR TITLE
[utils] Fix cygwin build

### DIFF
--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -265,6 +265,7 @@ static inline int
 mono_os_cond_destroy (mono_cond_t *cond)
 {
 	/* Beauty of win32 API: do not destroy it */
+	return 0;
 }
 
 static inline int

--- a/mono/utils/mono-os-semaphore.h
+++ b/mono/utils/mono-os-semaphore.h
@@ -245,12 +245,6 @@ mono_os_sem_destroy (MonoSemType *sem)
 }
 
 static inline int
-mono_os_sem_wait (MonoSemType *sem, MonoSemFlags flags)
-{
-	return mono_os_sem_timedwait (sem, INFINITE, flags);
-}
-
-static inline int
 mono_os_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, MonoSemFlags flags)
 {
 	gboolean res;
@@ -262,6 +256,12 @@ retry:
 		goto retry;
 
 	return res != WAIT_OBJECT_0 ? -1 : 0;
+}
+
+static inline int
+mono_os_sem_wait (MonoSemType *sem, MonoSemFlags flags)
+{
+	return mono_os_sem_timedwait (sem, INFINITE, flags);
 }
 
 static inline int


### PR DESCRIPTION
mono_os_sem_wait() used mono_os_sem_timedwait() before it was defined in mono-os-semaphore.h.
Moved the function to fix the cygwin build on Jenkins.

Also added a missing return statement in mono-os-mutex.h that was causing a lot of warnings.