### PR TITLE
Correctly escape proxy domains in WebRequest (bug #36356)

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -931,7 +931,12 @@ by setting the option
 Turns off the garbage collection in Mono.  This should be only used
 for debugging purposes
 .TP
-\fBLVM_COUNT\fR
+\fBHTTP_PROXY\fR
+(Also \fBhttp_proxy\fR) If set, web requests using the Mono
+Class Library will be automatically proxied through the given URL.
+Not supported on Windows, Mac OS, iOS or Android. See also \fBNO_PROXY\fR.
+.TP
+\fBLLVM_COUNT\fR
 When Mono is compiled with LLVM support, this instructs the runtime to
 stop using LLVM after the specified number of methods are JITed.
 This is a tool used in diagnostics to help isolate problems in the
@@ -1538,6 +1543,13 @@ ftps, smtps...).  The default is 'nocheck', which performs no revocation check
 at all. The other possible values are 'offline', which performs CRL check (not
 implemented yet) and 'online' which uses OCSP and CRL to verify the revocation
 status (not implemented yet).
+.TP
+\fBNO_PROXY\fR
+(Also \fBno_proxy\fR) If both \fBHTTP_PROXY\fR and \fBNO_PROXY\fR are
+set, \fBNO_PROXY\fR will be treated as a comma-separated list of "bypass" domains
+which will not be sent through the proxy. Domains in \fBNO_PROXY\fR may contain
+wildcards, as in "*.mono-project.com" or "build????.local". Not supported on
+Windows, Mac OS, iOS or Android.
 .SH ENVIRONMENT VARIABLES FOR DEBUGGING
 .TP
 \fBMONO_ASPNET_NODELETE\fR

--- a/mcs/class/System/Documentation/en/System.Net/WebRequest.xml
+++ b/mcs/class/System/Documentation/en/System.Net/WebRequest.xml
@@ -1036,9 +1036,10 @@ public class CreateDefaultExample
       <Parameters />
       <Docs>
         <remarks>
-          <attribution license="cc4" from="Microsoft" modified="false" />
-          <para>
-            <see cref="M:System.Net.WebRequest.GetSystemWebProxy" /> method reads the current user's Internet Explorer (IE) proxy settings. This process includes the IE options to automatically detect proxy settings, use an automatic configuration script, manual proxy server settings, and advanced manual proxy server settings.</para>
+          <attribution license="cc4" from="Microsoft" modified="true" />
+          <para><see cref="M:System.Net.WebRequest.GetSystemWebProxy" /> creates an appropriate proxy object for the current user.</para>
+          <para>On Windows, the method reads the current user's Internet Explorer (IE) proxy settings. The settings supported on Mono are proxy enabled, proxy URL, and proxy excluded domains.</para>
+          <para>On UNIX-like systems (but not including Mac OS, iOS, or Android), the method reads the environment variables "MONO_PROXY" (or "mono_proxy") and "NO_PROXY" (or "no_proxy"). See the mono man page for more information.</para>
           <para>If your application is impersonating several users, you can use the <see cref="M:System.Net.WebRequest.GetSystemWebProxy" /> method to retrieve a proxy for each impersonated user.</para>
         </remarks>
         <summary>

--- a/mcs/class/System/System.Net/WebRequest.cs
+++ b/mcs/class/System/System.Net/WebRequest.cs
@@ -40,6 +40,7 @@ using System.Net.Security;
 using System.Net.Cache;
 using System.Security.Principal;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 #if NET_2_1
 using ConfigurationException = System.ArgumentException;
@@ -332,6 +333,19 @@ namespace System.Net
 			throw GetMustImplement ();
 		}
 		
+		// Takes an ArrayList of fileglob-formatted strings and returns an array of Regex-formatted strings
+		private static string[] CreateBypassList (ArrayList al)
+		{
+			string[] result = al.ToArray (typeof (string)) as string[];
+			for (int c = 0; c < result.Length; c++)
+			{
+				result [c] = "^" +
+					Regex.Escape (result [c]).Replace (@"\*", ".*").Replace (@"\?", ".") +
+					"$";
+			}
+			return result;
+		}
+
 		[MonoTODO("Look in other places for proxy config info")]
 		public static IWebProxy GetSystemWebProxy ()
 		{
@@ -375,7 +389,7 @@ namespace System.Net
 						}
 					}
 					
-					return new WebProxy (strHttpProxy, bBypassOnLocal, al.ToArray (typeof(string)) as string[]);
+					return new WebProxy (strHttpProxy, bBypassOnLocal, CreateBypassList (al));
 				}
 			} else {
 #endif
@@ -425,7 +439,7 @@ namespace System.Net
 							}
 						}
 						
-						return new WebProxy (uri, bBypassOnLocal, al.ToArray (typeof(string)) as string[]);
+						return new WebProxy (uri, bBypassOnLocal, CreateBypassList (al));
 					} catch (UriFormatException) {
 					}
 				}


### PR DESCRIPTION
This was causing seemingly random failures in NuGet for Linux users.

Note 1: I did not fully test this. I tested it only to the extent that triggering the feature no longer crashes. Not having a proxy server handy, I have not attempted to test that the proxy exclusion feature itself currently works.

Note 2: This whole feature smells weird to me. It isn't documented, and it doesn't seem to be supported on Mac.

Anyway: Our implementation for System.Net.WebRequest takes proxy exclusions
which are in fileglob (*.example.com) format, and passes them to
System.Net.WebProxy as a "bypass list", which expects Regex format.
This means immediate failure if you have an exclusion with a fileglob,
because WebProxy will throw an exception for bad Regex format.