### PR TITLE
[msvc] Automatically update (win-)config.h with the correct version number

### DIFF
--- a/msvc/.gitignore
+++ b/msvc/.gitignore
@@ -7,3 +7,4 @@
 /ipch/
 /Win32/
 /x64/
+/include/

--- a/msvc/winsetup.bat
+++ b/msvc/winsetup.bat
@@ -4,6 +4,7 @@ if exist config.h if not exist cygconfig.h copy config.h cygconfig.h
 if exist eglib\config.h if not exist eglib\cygconfig.h copy eglib\config.h eglib\cygconfig.h
 copy winconfig.h config.h
 copy eglib\winconfig.h eglib\config.h
+powershell -Command "(Get-Content config.h) -replace '#MONO_VERSION#', (Select-String -path configure.ac -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value | Set-Content config.h"
 goto end
 :error
 echo fatal error: the VSDepenancies directory was not found in the "mono" directory

--- a/winconfig.h
+++ b/winconfig.h
@@ -645,5 +645,5 @@
 /* #undef USE_MONO_MUTEX */
 
 /* Version number of package */
-#define VERSION "4.1.0"
+#define VERSION "#MONO_VERSION#"
 #endif


### PR DESCRIPTION
A small powershell command grabs the version number from configure.ac and uses it during winsetup.bat, this way we don't have to manually keep them in sync.