### PR TITLE
[metadata] Use g_snprintf instead of snprintf to fix MSVC build

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -6158,7 +6158,7 @@ char *
 make_generic_name_string (MonoImage *image, int num)
 {
 	char *name = mono_image_alloc0 (image, INT_STRING_SIZE);
-	snprintf (name, INT_STRING_SIZE, "%d", num);
+	g_snprintf (name, INT_STRING_SIZE, "%d", num);
 	return name;
 }
 


### PR DESCRIPTION
The latter only works with Visual Studio 2015 and later. We're still using VS2013 on Jenkins