### PR TITLE
[HttpConnection] Bug fix: HttpListener's "IgnoreWriteExceptions" property value is ignored when "Expect: 100-Continue" header set in request

### DIFF
--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -214,6 +214,11 @@ namespace System.Net {
 			}
 			return o_stream;
 		}
+		
+		internal ResponseStream GetResponseStreamInternal()
+		{
+			return new ResponseStream (stream, context.Response, true);
+		}
 
 		static void OnRead (IAsyncResult ares)
 		{

--- a/mcs/class/System/System.Net/HttpListenerRequest.cs
+++ b/mcs/class/System/System.Net/HttpListenerRequest.cs
@@ -205,7 +205,7 @@ namespace System.Net {
 			}
 
 			if (String.Compare (Headers ["Expect"], "100-continue", StringComparison.OrdinalIgnoreCase) == 0) {
-				ResponseStream output = context.Connection.GetResponseStream ();
+				ResponseStream output = context.Connection.GetResponseStreamInternal ();
 				output.InternalWrite (_100continue, 0, _100continue.Length);
 			}
 		}


### PR DESCRIPTION
The problem is connected with "Listener" property of "context" object. It is null in "GetResponseStream" method, when it's called internally from "FinishInitialization" method of "HttpListenerRequest" class. Such behaviour possible only in situation when we have "Expect: 100-Continue" header from http client.

It seems that my solution looks dirty, but I did so to avoid unexpected bugs. I also added a test to approve that problem exists. Check it please.