### PR TITLE
[System.Windows.Forms] Locking Window Handle List

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
@@ -142,16 +142,30 @@ namespace System.Windows.Forms {
 			}
 
 			public int Count {
-				get { return hwnds.Count; }
+				get
+        {
+          int Count = 0;
+          lock ( hwnds )
+          {
+            Count = hwnds.Count;
+          }
+          return Count;
+        }
 			}
 
 			public void Enqueue (Hwnd hwnd) {
-				hwnds.Add(hwnd);
+        lock ( hwnds )
+        {
+          hwnds.Add( hwnd );
+        }
 			}
 
 			public void Remove(Hwnd hwnd) {
 				if (!hwnd.expose_pending && !hwnd.nc_expose_pending) {
-					hwnds.Remove(hwnd);
+          lock ( hwnds )
+          {
+            hwnds.Remove( hwnd );
+          }
 				}
 			}
 
@@ -159,37 +173,45 @@ namespace System.Windows.Forms {
 				Hwnd		hwnd;
 				IEnumerator	next;
 
-				if (hwnds.Count == 0) {
-					xevent.ExposeEvent.window = IntPtr.Zero;
-					return xevent;
-				}
+        lock( hwnds )
+        {
+          if( hwnds.Count == 0 )
+          {
+            xevent.ExposeEvent.window = IntPtr.Zero;
+            return xevent;
+          }
 
-				next = hwnds.GetEnumerator();
-				next.MoveNext();
-				hwnd = (Hwnd)next.Current;
+          next = hwnds.GetEnumerator();
+          next.MoveNext();
+          hwnd = (Hwnd)next.Current;
 
-				// We only remove the event from the queue if we have one expose left since
-				// a single 'entry in our queue may be for both NC and Client exposed
-				if ( !(hwnd.nc_expose_pending && hwnd.expose_pending)) {
-					hwnds.Remove(hwnd);
-				}
-				if (hwnd.expose_pending) {
-					xevent.ExposeEvent.window = hwnd.client_window;
+          // We only remove the event from the queue if we have one expose left since
+          // a single 'entry in our queue may be for both NC and Client exposed
+          if( !( hwnd.nc_expose_pending && hwnd.expose_pending ) )
+          {
+            hwnds.Remove( hwnd );
+          }
+          if( hwnd.expose_pending )
+          {
+            xevent.ExposeEvent.window = hwnd.client_window;
 #if not
-					xevent.ExposeEvent.x = hwnd.invalid.X;
-					xevent.ExposeEvent.y = hwnd.invalid.Y;
-					xevent.ExposeEvent.width = hwnd.invalid.Width;
-					xevent.ExposeEvent.height = hwnd.invalid.Height;
+					  xevent.ExposeEvent.x = hwnd.invalid.X;
+					  xevent.ExposeEvent.y = hwnd.invalid.Y;
+					  xevent.ExposeEvent.width = hwnd.invalid.Width;
+					  xevent.ExposeEvent.height = hwnd.invalid.Height;
 #endif
-					return xevent;
-				} else {
-					xevent.ExposeEvent.window = hwnd.whole_window;
-					xevent.ExposeEvent.x = hwnd.nc_invalid.X;
-					xevent.ExposeEvent.y = hwnd.nc_invalid.Y;
-					xevent.ExposeEvent.width = hwnd.nc_invalid.Width;
-					xevent.ExposeEvent.height = hwnd.nc_invalid.Height;
-					return xevent;
-				}
+            return xevent;
+          }
+          else
+          {
+            xevent.ExposeEvent.window = hwnd.whole_window;
+            xevent.ExposeEvent.x = hwnd.nc_invalid.X;
+            xevent.ExposeEvent.y = hwnd.nc_invalid.Y;
+            xevent.ExposeEvent.width = hwnd.nc_invalid.Width;
+            xevent.ExposeEvent.height = hwnd.nc_invalid.Height;
+            return xevent;
+          }
+        }
 			}
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
@@ -142,12 +142,10 @@ namespace System.Windows.Forms {
 			}
 
 			public int Count {
-				get	{
-					int Count = 0;
+				get {
 					lock (hwnds) {
-						Count = hwnds.Count;
+						return hwnds.Count;
 					}
-					return Count;
 				}
 			}
 
@@ -201,7 +199,7 @@ namespace System.Windows.Forms {
 						xevent.ExposeEvent.height = hwnd.nc_invalid.Height;
 						return xevent;
 					}
-        }
+				}
 			}
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
@@ -182,7 +182,7 @@ namespace System.Windows.Forms {
 					if (!(hwnd.nc_expose_pending && hwnd.expose_pending)) {
 						hwnds.Remove (hwnd);
 					}
-					if (wnd.expose_pending) {
+					if (hwnd.expose_pending) {
 						xevent.ExposeEvent.window = hwnd.client_window;
 #if not
 						xevent.ExposeEvent.x = hwnd.invalid.X;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
@@ -143,29 +143,29 @@ namespace System.Windows.Forms {
 
 			public int Count {
 				get
-        {
-          int Count = 0;
-          lock ( hwnds )
-          {
-            Count = hwnds.Count;
-          }
-          return Count;
-        }
+				{
+					int Count = 0;
+					lock ( hwnds )
+					{
+						Count = hwnds.Count;
+					}
+					return Count;
+				}
 			}
 
 			public void Enqueue (Hwnd hwnd) {
-        lock ( hwnds )
-        {
-          hwnds.Add( hwnd );
-        }
+				lock ( hwnds )
+				{
+					hwnds.Add( hwnd );
+				}
 			}
 
 			public void Remove(Hwnd hwnd) {
 				if (!hwnd.expose_pending && !hwnd.nc_expose_pending) {
-          lock ( hwnds )
-          {
-            hwnds.Remove( hwnd );
-          }
+					lock ( hwnds )
+					{
+						hwnds.Remove( hwnd );
+					}
 				}
 			}
 
@@ -173,44 +173,44 @@ namespace System.Windows.Forms {
 				Hwnd		hwnd;
 				IEnumerator	next;
 
-        lock( hwnds )
-        {
-          if( hwnds.Count == 0 )
-          {
-            xevent.ExposeEvent.window = IntPtr.Zero;
-            return xevent;
-          }
+				lock( hwnds )
+				{
+					if( hwnds.Count == 0 )
+					{
+						xevent.ExposeEvent.window = IntPtr.Zero;
+						return xevent;
+					}
 
-          next = hwnds.GetEnumerator();
-          next.MoveNext();
-          hwnd = (Hwnd)next.Current;
+					next = hwnds.GetEnumerator();
+					next.MoveNext();
+					hwnd = (Hwnd)next.Current;
 
-          // We only remove the event from the queue if we have one expose left since
-          // a single 'entry in our queue may be for both NC and Client exposed
-          if( !( hwnd.nc_expose_pending && hwnd.expose_pending ) )
-          {
-            hwnds.Remove( hwnd );
-          }
-          if( hwnd.expose_pending )
-          {
-            xevent.ExposeEvent.window = hwnd.client_window;
+					// We only remove the event from the queue if we have one expose left since
+					// a single 'entry in our queue may be for both NC and Client exposed
+					if( !( hwnd.nc_expose_pending && hwnd.expose_pending ) )
+					{
+						hwnds.Remove( hwnd );
+					}
+					if( hwnd.expose_pending )
+					{
+						xevent.ExposeEvent.window = hwnd.client_window;
 #if not
-					  xevent.ExposeEvent.x = hwnd.invalid.X;
-					  xevent.ExposeEvent.y = hwnd.invalid.Y;
-					  xevent.ExposeEvent.width = hwnd.invalid.Width;
-					  xevent.ExposeEvent.height = hwnd.invalid.Height;
+						xevent.ExposeEvent.x = hwnd.invalid.X;
+						xevent.ExposeEvent.y = hwnd.invalid.Y;
+						xevent.ExposeEvent.width = hwnd.invalid.Width;
+						xevent.ExposeEvent.height = hwnd.invalid.Height;
 #endif
-            return xevent;
-          }
-          else
-          {
-            xevent.ExposeEvent.window = hwnd.whole_window;
-            xevent.ExposeEvent.x = hwnd.nc_invalid.X;
-            xevent.ExposeEvent.y = hwnd.nc_invalid.Y;
-            xevent.ExposeEvent.width = hwnd.nc_invalid.Width;
-            xevent.ExposeEvent.height = hwnd.nc_invalid.Height;
-            return xevent;
-          }
+						return xevent;
+					}
+					else
+					{
+						xevent.ExposeEvent.window = hwnd.whole_window;
+						xevent.ExposeEvent.x = hwnd.nc_invalid.X;
+						xevent.ExposeEvent.y = hwnd.nc_invalid.Y;
+						xevent.ExposeEvent.width = hwnd.nc_invalid.Width;
+						xevent.ExposeEvent.height = hwnd.nc_invalid.Height;
+						return xevent;
+					}
         }
 			}
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XEventQueue.cs
@@ -118,7 +118,7 @@ namespace System.Windows.Forms {
 					return lqueue.Peek ();
 				}
 			}				
-			return xqueue.Peek();
+			return xqueue.Peek ();
 		}
 
 		public bool DispatchIdle {
@@ -136,17 +136,15 @@ namespace System.Windows.Forms {
 			private XEvent		xevent;
 			
 			public PaintQueue (int size) {
-				hwnds = new ArrayList(size);
-				xevent = new XEvent();
+				hwnds = new ArrayList (size);
+				xevent = new XEvent ();
 				xevent.AnyEvent.type = XEventName.Expose;
 			}
 
 			public int Count {
-				get
-				{
+				get	{
 					int Count = 0;
-					lock ( hwnds )
-					{
+					lock (hwnds) {
 						Count = hwnds.Count;
 					}
 					return Count;
@@ -154,17 +152,15 @@ namespace System.Windows.Forms {
 			}
 
 			public void Enqueue (Hwnd hwnd) {
-				lock ( hwnds )
-				{
-					hwnds.Add( hwnd );
+				lock (hwnds) {
+					hwnds.Add (hwnd);
 				}
 			}
 
 			public void Remove(Hwnd hwnd) {
 				if (!hwnd.expose_pending && !hwnd.nc_expose_pending) {
-					lock ( hwnds )
-					{
-						hwnds.Remove( hwnd );
+					lock (hwnds) {
+						hwnds.Remove (hwnd);
 					}
 				}
 			}
@@ -173,26 +169,22 @@ namespace System.Windows.Forms {
 				Hwnd		hwnd;
 				IEnumerator	next;
 
-				lock( hwnds )
-				{
-					if( hwnds.Count == 0 )
-					{
+				lock (hwnds) {
+					if (hwnds.Count == 0) {
 						xevent.ExposeEvent.window = IntPtr.Zero;
 						return xevent;
 					}
 
-					next = hwnds.GetEnumerator();
-					next.MoveNext();
+					next = hwnds.GetEnumerator ();
+					next.MoveNext ();
 					hwnd = (Hwnd)next.Current;
 
 					// We only remove the event from the queue if we have one expose left since
 					// a single 'entry in our queue may be for both NC and Client exposed
-					if( !( hwnd.nc_expose_pending && hwnd.expose_pending ) )
-					{
-						hwnds.Remove( hwnd );
+					if (!(hwnd.nc_expose_pending && hwnd.expose_pending)) {
+						hwnds.Remove (hwnd);
 					}
-					if( hwnd.expose_pending )
-					{
+					if (wnd.expose_pending) {
 						xevent.ExposeEvent.window = hwnd.client_window;
 #if not
 						xevent.ExposeEvent.x = hwnd.invalid.X;
@@ -201,9 +193,7 @@ namespace System.Windows.Forms {
 						xevent.ExposeEvent.height = hwnd.invalid.Height;
 #endif
 						return xevent;
-					}
-					else
-					{
+					} else {
 						xevent.ExposeEvent.window = hwnd.whole_window;
 						xevent.ExposeEvent.x = hwnd.nc_invalid.X;
 						xevent.ExposeEvent.y = hwnd.nc_invalid.Y;


### PR DESCRIPTION
A lock to the EventQueue Window Handle List is required to prevent multiple threads from modifying the list;