### PR TITLE
[4.2.0][delegate] Fix multicast Method property implementation

### DIFF
--- a/mcs/class/corlib/System/Delegate.cs
+++ b/mcs/class/corlib/System/Delegate.cs
@@ -102,17 +102,7 @@ namespace System
 
 		public MethodInfo Method {
 			get {
-				if (method_info != null) {
-					return method_info;
-				} else {
-					if (method != IntPtr.Zero) {
-						if (!method_is_virtual)
-							method_info = (MethodInfo)MethodBase.GetMethodFromHandleNoGenericCheck (new RuntimeMethodHandle (method));
-						else
-							method_info = GetVirtualMethod_internal ();
-					}
-					return method_info;
-				}
+				return GetMethodImpl ();
 			}
 		}
 
@@ -511,7 +501,17 @@ namespace System
 
 		protected virtual MethodInfo GetMethodImpl ()
 		{
-			return Method;
+			if (method_info != null) {
+				return method_info;
+			} else {
+				if (method != IntPtr.Zero) {
+					if (!method_is_virtual)
+						method_info = (MethodInfo)MethodBase.GetMethodFromHandleNoGenericCheck (new RuntimeMethodHandle (method));
+					else
+						method_info = GetVirtualMethod_internal ();
+				}
+				return method_info;
+			}
 		}
 
 		// This is from ISerializable

--- a/mcs/class/corlib/System/MulticastDelegate.cs
+++ b/mcs/class/corlib/System/MulticastDelegate.cs
@@ -33,6 +33,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 
@@ -110,6 +111,14 @@ namespace System
 		public sealed override int GetHashCode ()
 		{
 			return base.GetHashCode ();
+		}
+
+		protected override MethodInfo GetMethodImpl ()
+		{
+			if (delegates != null)
+				return delegates [delegates.Length - 1].Method;
+
+			return base.GetMethodImpl ();
 		}
 
 		// <summary>

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -182,6 +182,7 @@ BASE_TEST_CS_SRC=		\
 	delegate10.cs		\
 	delegate11.cs		\
 	delegate12.cs		\
+	delegate13.cs		\
 	remoting1.cs		\
 	remoting2.cs		\
 	remoting3.cs		\

--- a/mono/tests/delegate13.cs
+++ b/mono/tests/delegate13.cs
@@ -1,0 +1,31 @@
+using System;
+
+public static class Program
+{
+	public static int Main ()
+	{
+		Action d1 = new Action (Method1);
+		Action d2 = new Action (Method2);
+		Action d12 = d1 + d2;
+		Action d21 = d2 + d1;
+
+		if (d1.Method.Name != "Method1")
+			return 1;
+		if (d2.Method.Name != "Method2")
+			return 2;
+		if (d12.Method.Name != "Method2")
+			return 3;
+		if (d21.Method.Name != "Method1")
+			return 4;
+
+		return 0;
+	}
+
+	public static void Method1 ()
+	{
+	}
+
+	public static void Method2 ()
+	{
+	}
+}


### PR DESCRIPTION
.NET returns the method for the last delegate of the multicast delegate.