### PR TITLE
[System.ServiceModel] Fixes missing xsi xsd attributes

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs
@@ -38,6 +38,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.Text;
 using System.Xml;
+using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace System.ServiceModel.Dispatcher
@@ -135,6 +136,11 @@ namespace System.ServiceModel.Dispatcher
 
 			protected override void OnWriteBodyContents (XmlDictionaryWriter writer)
 			{
+				if (writer.WriteState == WriteState.Element) {
+					writer.WriteXmlnsAttribute ("xsi", XmlSchema.InstanceNamespace);
+					writer.WriteXmlnsAttribute ("xsd", XmlSchema.Namespace);
+				}
+
 				serializer.Serialize (writer, body);
 			}
 		}


### PR DESCRIPTION
While serializing operations with XmlSerializerFormatAttribute,
attributes xmlns:xsi and xmlns:xsd were not added to the message body.

XmlBodyWriter now adds the missing attributes.

Fixes [#34413](https://bugzilla.xamarin.com/show_bug.cgi?id=34413).

To find the problem I did a comparison between reference source and Mono logic.

Reference source checks XmlSerializerFormatAttribute [here](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Description/TypeLoader.cs,313)
Mono checks XmlSerializerFormatAttribute [here](https://github.com/mono/mono/blob/468225a247b8897b2a4fa1e6bd7ffa32aa8c243b/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs#L343)

Reference source [adds](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Description/XmlSerializerOperationBehavior.cs,105) a behaviour called [XmlSerializerOperationBehavior](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Description/XmlSerializerOperationBehavior.cs)
Mono [adds](https://github.com/mono/mono/blob/master/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs#L343) a behavior called [XmlSerializerOperationBehavior](https://github.com/mono/mono/blob/b7a308f660de8174b64697a422abfc7315d07b8c/mcs/class/System.ServiceModel/System.ServiceModel.Description/XmlSerializerOperationBehavior.cs)

Reference source [XmlSerializerOperationBehavior.ApplyDispatchBehavior](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Description/XmlSerializerOperationBehavior.cs,140) uses formatter [XmlSerializerOperationFormatter](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Dispatcher/XmlSerializerOperationFormatter.cs)
Mono [XmlSerializerOperationBehavior.ApplyDispatchBehavior](https://github.com/mono/mono/blob/b7a308f660de8174b64697a422abfc7315d07b8c/mcs/class/System.ServiceModel/System.ServiceModel.Description/XmlSerializerOperationBehavior.cs#L99) uses formatter [XmlMessagesFormatter](https://github.com/mono/mono/blob/b7a308f660de8174b64697a422abfc7315d07b8c/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs)

Reference source XmlSerializerOperationFormatter [adds](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Dispatcher/XmlSerializerOperationFormatter.cs,267) xmlns:xsi and xmlns:xsd attributes
Mono XmlMessagesFormatter [does not](https://github.com/mono/mono/blob/b7a308f660de8174b64697a422abfc7315d07b8c/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs#L138).