### PR TITLE
[System.Runtime.Caching] Add missing locking when accessing cache entries

### DIFF
--- a/mcs/class/System.Runtime.Caching/ReferenceSources/CacheEntryCollection.cs
+++ b/mcs/class/System.Runtime.Caching/ReferenceSources/CacheEntryCollection.cs
@@ -68,15 +68,17 @@ namespace System.Runtime.Caching
 			if (blockInsert)
 				store.BlockInsert ();
 
-			foreach (var entry in entries) {
-				if (helper.GetDateTime (entry) > limit || flushedItems >= count)
-					break;
+			lock (entries) {
+				foreach (var entry in entries) {
+					if (helper.GetDateTime (entry) > limit || flushedItems >= count)
+						break;
 
-				flushedItems++;
+					flushedItems++;
+				}
+
+				for (var f = 0; f < flushedItems; f++)
+					store.Remove (entries.Min, null, reason);
 			}
-
-			for (var f = 0; f < flushedItems; f++)
-				store.Remove (entries.Min, null, reason);
 
 			if (blockInsert)
 				store.UnblockInsert ();


### PR DESCRIPTION
The "entries" collection in CacheEntryCollection can be modified while we're enumerating it,
which is not allowed. Add locking in FlushItems() to prevent this.