### PR TITLE
[DO NOT MERGE] Revert b3fa096e5eceea1c3b289b3655244a42c2884274

### DIFF
--- a/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SocketResponder.cs
+++ b/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SocketResponder.cs
@@ -96,13 +96,6 @@ namespace MonoTests.System.Web.Services.Protocols
 				if (tcpListener != null) {
 					tcpListener.Stop ();
 					tcpListener = null;
-#if MONO_FEATURE_THREAD_ABORT
-					listenThread.Abort ();
-#else
-					listenThread.Interrupt ();
-#endif
-					listenThread.Join ();
-					listenThread = null;
 				}
 			}
 		}

--- a/mcs/class/System/Test/System.Net/SocketResponder.cs
+++ b/mcs/class/System/Test/System.Net/SocketResponder.cs
@@ -105,13 +105,6 @@ namespace MonoTests.System.Net
 					tcpListener = null;
 					if (listenSocket != null)
 						listenSocket.Close ();
-#if MONO_FEATURE_THREAD_ABORT
-					listenThread.Abort ();
-#else
-					listenThread.Interrupt ();
-#endif
-					listenThread.Join ();
-					listenThread = null;
 					Thread.Sleep (50);
 				}
 			}


### PR DESCRIPTION
This is a Jenkins check to see if the tests that use `SocketResponder` will actually work fine without this particular commit.

The short story is that `Thread.Abort` is super unreliable in general, so we should avoid using it wherever possible. It currently causes crashes on Android when running the `HttpWebRequestTest` suite. The idea here is that it might not even be necessary anymore as 1103abf3830131ba2a1deabc133e8d27402302c7 closes `listenSocket` which should cause the listening thread to shut down normally. Let's see what happens.

/cc @ludovic-henry