### PR TITLE
[msvc] Fix casts that result in an error when building with VS

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9069,7 +9069,7 @@ compile_methods (MonoAotCompile *acfg)
 			user_data [1] = acfg;
 			user_data [2] = frag;
 			
-			handle = mono_threads_create_thread ((unsigned int (*)(void *))compile_thread_main, user_data, 0, 0, NULL);
+			handle = mono_threads_create_thread ((LPTHREAD_START_ROUTINE)compile_thread_main, user_data, 0, 0, NULL);
 			g_ptr_array_add (threads, handle);
 		}
 		g_free (methods);

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -1067,7 +1067,7 @@ typedef int (STDCALL *SimpleDelegate9) (return_int_fnt d);
 LIBTEST_API int STDCALL 
 mono_test_marshal_delegate9 (SimpleDelegate9 delegate, gpointer ftn)
 {
-	return delegate ((int (*)(int))ftn);
+	return delegate ((return_int_fnt)ftn);
 }
 
 static int STDCALL 
@@ -3624,7 +3624,7 @@ test_method_thunk (int test_id, gpointer test_method_handle, gpointer create_obj
 		goto done;
 	}
 
-	CreateObject = (gpointer (*)(gpointer *))mono_method_get_unmanaged_thunk (create_object_method_handle);
+	CreateObject = (gpointer (STDCALL *)(gpointer *))mono_method_get_unmanaged_thunk (create_object_method_handle);
 	if (!CreateObject) {
 		ret = 3;
 		goto done;


### PR DESCRIPTION
Those showed up after the recent C++ compliance commit.