### PR TITLE
[jit] Optimize divisions by immediate

### DIFF
--- a/mono/arch/arm/arm-codegen.h
+++ b/mono/arch/arm/arm-codegen.h
@@ -500,14 +500,24 @@ typedef struct {
 /* Rd := (Rm * Rs)[31:0]; 32 x 32 -> 32 */
 #define ARM_MUL_COND(p, rd, rm, rs, cond) \
 	ARM_EMIT(p, ARM_DEF_MUL_COND(ARMOP_MUL, rd, rm, rs, 0, 0, cond))
+#define ARM_UMULL_COND(p, rdhi, rdlo, rm, rs, cond) \
+	ARM_EMIT(p, ARM_DEF_MUL_COND(ARMOP_UMULL, rdhi, rm, rs, rdlo, 0, cond))
+#define ARM_SMULL_COND(p, rdhi, rdlo, rm, rs, cond) \
+	ARM_EMIT(p, ARM_DEF_MUL_COND(ARMOP_SMULL, rdhi, rm, rs, rdlo, 0, cond))
 #define ARM_MUL(p, rd, rm, rs) \
 	ARM_MUL_COND(p, rd, rm, rs, ARMCOND_AL)
+#define ARM_UMULL(p, rdhi, rdlo, rm, rs) \
+	ARM_UMULL_COND(p, rdhi, rdlo, rm, rs, ARMCOND_AL)
+#define ARM_SMULL(p, rdhi, rdlo, rm, rs) \
+	ARM_SMULL_COND(p, rdhi, rdlo, rm, rs, ARMCOND_AL)
 #define ARM_MULS_COND(p, rd, rm, rs, cond) \
 	ARM_EMIT(p, ARM_DEF_MUL_COND(ARMOP_MUL, rd, rm, rs, 0, 1, cond))
 #define ARM_MULS(p, rd, rm, rs) \
 	ARM_MULS_COND(p, rd, rm, rs, ARMCOND_AL)
 #define ARM_MUL_REG_REG(p, rd, rm, rs) ARM_MUL(p, rd, rm, rs)
 #define ARM_MULS_REG_REG(p, rd, rm, rs) ARM_MULS(p, rd, rm, rs)
+#define ARM_UMULL_REG_REG(p, rdhi, rdlo, rm, rs) ARM_UMULL(p, rdhi, rdlo, rm, rs)
+#define ARM_SMULL_REG_REG(p, rdhi, rdlo, rm, rs) ARM_SMULL(p, rdhi, rdlo, rm, rs)
 
 /* inline */
 #define ARM_IASM_MUL_COND(rd, rm, rs, cond) \

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -187,6 +187,7 @@ mono_strength_reduction_division (MonoCompile *cfg, MonoInst *ins)
 			} else {
 				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_UN_IMM, ins->dreg, tmp_regl, 32 + mag.shift);
 			}
+			mono_jit_stats.optimized_divisions++;
 			break;
 		}
 		case OP_IDIV_IMM: {
@@ -236,6 +237,7 @@ mono_strength_reduction_division (MonoCompile *cfg, MonoInst *ins)
 			}
 			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_UN_IMM, ins->dreg, tmp_regl, SIZEOF_REGISTER * 8 - 1);
 			MONO_EMIT_NEW_BIALU (cfg, OP_LADD, ins->dreg, ins->dreg, tmp_regl);
+			mono_jit_stats.optimized_divisions++;
 			break;
 		}
 	}

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -49,6 +49,11 @@ struct magic_unsigned {
 	int shift;
 };
 
+struct magic_signed {
+	gint32 magic_number;
+	int shift;
+};
+
 /* http://www.hackersdelight.org/hdcodetxt/magicu.c.txt */
 static struct magic_unsigned
 compute_magic_unsigned (guint32 divisor) {
@@ -92,6 +97,49 @@ compute_magic_unsigned (guint32 divisor) {
 	magu.magic_number = q2 + 1;
 	magu.shift = p - 32;
 	return magu;
+}
+
+/* http://www.hackersdelight.org/hdcodetxt/magic.c.txt */
+static struct magic_signed
+compute_magic_signed (gint32 divisor) {
+	int p;
+	guint32 ad, anc, delta, q1, r1, q2, r2, t;
+	const guint32 two31 = 0x80000000;
+	struct magic_signed mag;
+
+	ad = abs (divisor);
+	t = two31 + ((unsigned)divisor >> 31);
+	anc = t - 1 - t % ad;
+	p = 31;
+	q1 = two31 / anc;
+	r1 = two31 - q1 * anc;
+	q2 = two31 / ad;
+	r2 = two31 - q2 * ad;
+	do {
+		p++;
+		q1 *= 2;
+		r1 *= 2;
+		if (r1 >= anc) {
+			q1++;
+			r1 -= anc;
+		}
+
+		q2 *= 2;
+		r2 *= 2;
+
+		if (r2 >= ad) {
+			q2++;
+			r2 -= ad;
+		}
+
+		delta = ad - r2;
+	} while (q1 < delta || (q1 == delta && r1 == 0));
+
+	mag.magic_number = q2 + 1;
+	if (divisor < 0)
+		mag.magic_number = -mag.magic_number;
+	mag.shift = p - 32;
+	return mag;
 }
 #endif
 
@@ -139,6 +187,55 @@ mono_strength_reduction_division (MonoCompile *cfg, MonoInst *ins)
 			} else {
 				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_UN_IMM, ins->dreg, tmp_regl, 32 + mag.shift);
 			}
+			break;
+		}
+		case OP_IDIV_IMM: {
+			guint32 tmp_regl, dividend_reg;
+			struct magic_signed mag;
+			int power2 = mono_is_power_of_two (ins->inst_imm);
+
+			/* The decomposition doesn't handle exception throwing */
+			if (ins->inst_imm == 0 || ins->inst_imm == -1)
+				break;
+			allocated_vregs = TRUE;
+			if (power2 == 1) {
+				guint32 r1 = alloc_ireg (cfg);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_UN_IMM, r1, ins->sreg1, 31);
+				MONO_EMIT_NEW_BIALU (cfg, OP_IADD, r1, r1, ins->sreg1);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_IMM, ins->dreg, r1, 1);
+				break;
+			} else if (power2 > 0 && power2 < 31) {
+				guint32 r1 = alloc_ireg (cfg);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_IMM, r1, ins->sreg1, 31);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_UN_IMM, r1, r1, (32 - power2));
+				MONO_EMIT_NEW_BIALU (cfg, OP_IADD, r1, r1, ins->sreg1);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_IMM, ins->dreg, r1, power2);
+				break;
+			}
+
+			/*
+			 * Replacement of signed division with multiplication,
+			 * shifts and additions Hacker's Delight, chapter 10-6.
+			 */
+			mag = compute_magic_signed (ins->inst_imm);
+			tmp_regl = alloc_lreg (cfg);
+			dividend_reg = alloc_lreg (cfg);
+			MONO_EMIT_NEW_I8CONST (cfg, tmp_regl, mag.magic_number);
+			MONO_EMIT_NEW_UNALU (cfg, OP_SEXT_I4, dividend_reg, ins->sreg1);
+			MONO_EMIT_NEW_BIALU (cfg, OP_LMUL, tmp_regl, dividend_reg, tmp_regl);
+			if ((ins->inst_imm > 0 && mag.magic_number < 0) || (ins->inst_imm < 0 && mag.magic_number > 0)) {
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_IMM, tmp_regl, tmp_regl, 32);
+				if (ins->inst_imm > 0 && mag.magic_number < 0) {
+					MONO_EMIT_NEW_BIALU (cfg, OP_LADD, tmp_regl, tmp_regl, dividend_reg);
+				} else if (ins->inst_imm < 0 && mag.magic_number > 0) {
+					MONO_EMIT_NEW_BIALU (cfg, OP_LSUB, tmp_regl, tmp_regl, dividend_reg);
+				}
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_IMM, tmp_regl, tmp_regl, mag.shift);
+			} else {
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_IMM, tmp_regl, tmp_regl, 32 + mag.shift);
+			}
+			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_UN_IMM, ins->dreg, tmp_regl, SIZEOF_REGISTER * 8 - 1);
+			MONO_EMIT_NEW_BIALU (cfg, OP_LADD, ins->dreg, ins->dreg, tmp_regl);
 			break;
 		}
 	}
@@ -213,32 +310,9 @@ mono_strength_reduction_ins (MonoCompile *cfg, MonoInst *ins, const char **spec)
 		}
 		break;
 	}
-	case OP_IDIV_UN_IMM: {
-		allocated_vregs = mono_strength_reduction_division (cfg, ins);
-		break;
-	}
+	case OP_IDIV_UN_IMM:
 	case OP_IDIV_IMM: {
-		int c = ins->inst_imm;
-		int power2 = mono_is_power_of_two (c);
-
-		if (power2 == 1) {
-			int r1 = mono_alloc_ireg (cfg);
-
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_UN_IMM, r1, ins->sreg1, 31);
-			MONO_EMIT_NEW_BIALU (cfg, OP_IADD, r1, r1, ins->sreg1);
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_IMM, ins->dreg, r1, 1);
-
-			allocated_vregs = TRUE;
-		} else if (power2 > 0 && power2 < 31) {
-			int r1 = mono_alloc_ireg (cfg);
-
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_IMM, r1, ins->sreg1, 31);
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_UN_IMM, r1, r1, (32 - power2));
-			MONO_EMIT_NEW_BIALU (cfg, OP_IADD, r1, r1, ins->sreg1);
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_IMM, ins->dreg, r1, power2);
-
-			allocated_vregs = TRUE;
-		}
+		allocated_vregs = mono_strength_reduction_division (cfg, ins);
 		break;
 	}
 #if SIZEOF_REGISTER == 8

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -42,6 +42,110 @@ mono_bitset_mp_new_noinit (MonoMemPool *mp,  guint32 max_size)
 	return mono_bitset_mem_new (mem, max_size, MONO_BITSET_DONT_FREE);
 }
 
+#if SIZEOF_REGISTER == 8
+struct magic_unsigned {
+	guint32 magic_number;
+	gboolean addition;
+	int shift;
+};
+
+/* http://www.hackersdelight.org/hdcodetxt/magicu.c.txt */
+static struct magic_unsigned
+compute_magic_unsigned (guint32 divisor) {
+	guint32 nc, delta, q1, r1, q2, r2;
+	struct magic_unsigned magu;
+	gboolean gt = FALSE;
+	int p;
+
+	magu.addition = 0;
+	nc = -1 - (-divisor) % divisor;
+	p = 31;
+	q1 = 0x80000000 / nc;
+	r1 = 0x80000000 - q1 * nc;
+	q2 = 0x7FFFFFFF / divisor;
+	r2 = 0x7FFFFFFF - q2 * divisor;
+	do {
+		p = p + 1;
+		if (q1 >= 0x80000000)
+			gt = TRUE;
+		if (r1 >= nc - r1) {
+			q1 = 2 * q1 + 1;
+			r1 = 2 * r1 - nc;
+		} else {
+			q1 = 2 * q1;
+			r1 = 2 * r1;
+		}
+		if (r2 + 1 >= divisor - r2) {
+			if (q2 >= 0x7FFFFFFF)
+				magu.addition = 1;
+			q2 = 2 * q2 + 1;
+			r2 = 2 * r2 + 1 - divisor;
+		} else {
+			if (q2 >= 0x80000000)
+				magu.addition = 1;
+			q2 = 2 * q2;
+			r2 = 2 * r2 + 1;
+		}
+		delta = divisor - 1 - r2;
+	} while (!gt && (q1 < delta || (q1 == delta && r1 == 0)));
+
+	magu.magic_number = q2 + 1;
+	magu.shift = p - 32;
+	return magu;
+}
+#endif
+
+static gboolean
+mono_strength_reduction_division (MonoCompile *cfg, MonoInst *ins)
+{
+	gboolean allocated_vregs = FALSE;
+	/*
+	 * We don't use it on 32bit systems because on those
+	 * platforms we emulate long multiplication, driving the
+	 * performance back down.
+	 */
+#if SIZEOF_REGISTER == 8
+	switch (ins->opcode) {
+		case OP_IDIV_UN_IMM: {
+			guint32 tmp_regl, dividend_reg;
+			struct magic_unsigned mag;
+			int power2 = mono_is_power_of_two (ins->inst_imm);
+
+			/* The decomposition doesn't handle exception throwing */
+			if (ins->inst_imm == 0)
+				break;
+
+			if (power2 >= 0) {
+				ins->opcode = OP_ISHR_UN_IMM;
+				ins->sreg2 = -1;
+				ins->inst_imm = power2;
+				break;
+			}
+			allocated_vregs = TRUE;
+			/*
+			 * Replacement of unsigned division with multiplication,
+			 * shifts and additions Hacker's Delight, chapter 10-10.
+			 */
+			mag = compute_magic_unsigned (ins->inst_imm);
+			tmp_regl = alloc_lreg (cfg);
+			dividend_reg = alloc_lreg (cfg);
+			MONO_EMIT_NEW_I8CONST (cfg, tmp_regl, mag.magic_number);
+			MONO_EMIT_NEW_UNALU (cfg, OP_ZEXT_I4, dividend_reg, ins->sreg1);
+			MONO_EMIT_NEW_BIALU (cfg, OP_LMUL, tmp_regl, dividend_reg, tmp_regl);
+			if (mag.addition) {
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_UN_IMM, tmp_regl, tmp_regl, 32);
+				MONO_EMIT_NEW_BIALU (cfg, OP_LADD, tmp_regl, tmp_regl, dividend_reg);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_UN_IMM, ins->dreg, tmp_regl, mag.shift);
+			} else {
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_LSHR_UN_IMM, ins->dreg, tmp_regl, 32 + mag.shift);
+			}
+			break;
+		}
+	}
+#endif
+	return allocated_vregs;
+}
+
 /*
  * Replaces ins with optimized opcodes.
  *
@@ -99,22 +203,18 @@ mono_strength_reduction_ins (MonoCompile *cfg, MonoInst *ins, const char **spec)
 			}
 		}
 		break;
-	case OP_IREM_UN_IMM:
-	case OP_IDIV_UN_IMM: {
-		int c = ins->inst_imm;
-		int power2 = mono_is_power_of_two (c);
+	case OP_IREM_UN_IMM: {
+		int power2 = mono_is_power_of_two (ins->inst_imm);
 
 		if (power2 >= 0) {
-			if (ins->opcode == OP_IREM_UN_IMM) {
-				ins->opcode = OP_IAND_IMM;
-				ins->sreg2 = -1;
-				ins->inst_imm = (1 << power2) - 1;
-			} else if (ins->opcode == OP_IDIV_UN_IMM) {
-				ins->opcode = OP_ISHR_UN_IMM;
-				ins->sreg2 = -1;
-				ins->inst_imm = power2;
-			}
+			ins->opcode = OP_IAND_IMM;
+			ins->sreg2 = -1;
+			ins->inst_imm = (1 << power2) - 1;
 		}
+		break;
+	}
+	case OP_IDIV_UN_IMM: {
+		allocated_vregs = mono_strength_reduction_division (cfg, ins);
 		break;
 	}
 	case OP_IDIV_IMM: {

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -4442,14 +4442,12 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				ARM_DMB (code, ARM_DMB_SY);
 			break;
 		}
-		/*case OP_BIGMUL:
-			ppc_mullw (code, ppc_r4, ins->sreg1, ins->sreg2);
-			ppc_mulhw (code, ppc_r3, ins->sreg1, ins->sreg2);
+		case OP_BIGMUL:
+			ARM_SMULL_REG_REG (code, ins->backend.reg3, ins->dreg, ins->sreg1, ins->sreg2);
 			break;
 		case OP_BIGMUL_UN:
-			ppc_mullw (code, ppc_r4, ins->sreg1, ins->sreg2);
-			ppc_mulhwu (code, ppc_r3, ins->sreg1, ins->sreg2);
-			break;*/
+			ARM_UMULL_REG_REG (code, ins->backend.reg3, ins->dreg, ins->sreg1, ins->sreg2);
+			break;
 		case OP_STOREI1_MEMBASE_IMM:
 			code = mono_arm_emit_load_imm (code, ARMREG_LR, ins->inst_imm & 0xFF);
 			g_assert (arm_is_imm12 (ins->inst_offset));

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3328,6 +3328,7 @@ register_jit_stats (void)
 	mono_counters_register ("Aliases eliminated", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.alias_removed);
 	mono_counters_register ("Aliased loads eliminated", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.loads_eliminated);
 	mono_counters_register ("Aliased stores eliminated", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.stores_eliminated);
+	mono_counters_register ("Optimized immediate divisions", MONO_COUNTER_JIT | MONO_COUNTER_INT, &mono_jit_stats.optimized_divisions);
 }
 
 static void runtime_invoke_info_free (gpointer value);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1917,6 +1917,7 @@ typedef struct {
 	gint32 alias_removed;
 	gint32 loads_eliminated;
 	gint32 stores_eliminated;
+	gint32 optimized_divisions;
 	int methods_with_llvm;
 	int methods_without_llvm;
 	char *max_ratio_method;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -254,6 +254,7 @@ BASE_TEST_CS_SRC_UNIVERSAL=		\
 	long.cs			\
 	jit-ulong.cs		\
 	jit-float.cs		\
+	constant-division.cs	\
 	pop.cs			\
 	time.cs			\
 	pointer.cs		\

--- a/mono/tests/constant-division.cs
+++ b/mono/tests/constant-division.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Test {
+	public class T {
+		private delegate TReturn OneParameter<TReturn, TParameter0> (TParameter0 p0);
+
+		private static Type[] SDivisionArgs = {typeof(int)};
+		private static Type[] UDivisionArgs = {typeof(uint)};
+
+		public static int Main (string[] args) {
+			if (TestSDivision (2000, 10) != 0)
+				return -1;
+
+			if (TestUDivision (2000, 10) != 0)
+				return -1;
+
+			return 0;
+		}
+
+		private static int TestSDivision (int divisions, int invokes)
+		{
+			int i, j;
+			Random rand = new Random ();
+			for (i = 0; i < divisions; i++) {
+				int divisor = rand.Next (Int32.MinValue, Int32.MaxValue);
+
+				if (divisor == 0 || divisor == -1)
+					continue;
+
+				DynamicMethod SDivision = new DynamicMethod(
+					String.Format ("SDivision{0}", i),
+					typeof(int),
+					SDivisionArgs,
+					typeof(T).Module);
+
+				ILGenerator il = SDivision.GetILGenerator();
+				il.Emit(OpCodes.Ldarg_0);
+				il.Emit(OpCodes.Ldc_I4, divisor);
+				il.Emit(OpCodes.Div);
+				il.Emit(OpCodes.Ret);
+
+				OneParameter<int, int> invokeSDivision =
+					(OneParameter<int, int>)
+					SDivision.CreateDelegate(typeof(OneParameter<int, int>));
+
+				for (j = 0; j < invokes; j++) {
+					int dividend = rand.Next (Int32.MinValue, Int32.MaxValue);
+					int result, expected;
+
+					result = invokeSDivision (dividend);
+					expected = dividend / divisor;
+
+					if (result != expected) {
+						Console.WriteLine("{0} / {1} = {2} != {3})", dividend, divisor, expected, result);
+						return -1;
+					}
+				}
+			}
+
+			return 0;
+		}
+
+		private static int TestUDivision (int divisions, int invokes)
+		{
+			int i, j;
+			Random rand = new Random ();
+			for (i = 0; i < divisions; i++) {
+				uint divisor = (uint)rand.Next (Int32.MinValue, Int32.MaxValue);
+
+				if (divisor == 0)
+					continue;
+
+				DynamicMethod UDivision = new DynamicMethod(
+					String.Format ("UDivision{0}", i),
+					typeof(uint),
+					UDivisionArgs,
+					typeof(T).Module);
+
+				ILGenerator il = UDivision.GetILGenerator();
+				il.Emit(OpCodes.Ldarg_0);
+				il.Emit(OpCodes.Ldc_I4, divisor);
+				il.Emit(OpCodes.Div_Un);
+				il.Emit(OpCodes.Ret);
+
+				OneParameter<uint, uint> invokeUDivision =
+					(OneParameter<uint, uint>)
+					UDivision.CreateDelegate(typeof(OneParameter<uint, uint>));
+
+				for (j = 0; j < invokes; j++) {
+					uint dividend = (uint)rand.Next (Int32.MinValue, Int32.MaxValue);
+					uint result, expected;
+
+					result = invokeUDivision (dividend);
+					expected = dividend / divisor;
+
+					if (result != expected) {
+						Console.WriteLine("{0} / {1} = {2} != {3})", dividend, divisor, expected, result);
+						return -1;
+					}
+				}
+			}
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
This optimizes div imm operations by replacing them with multiplication, addition and shift operations which are faster. We only use it on 64bit architectures, since 32 bit architectures emulate OP_LMUL.

The performance increase is about 3 times for signed division and about 6 times for unsigned division. On amd64 the emitted code for an immediate division can increase from ~15 bytes, up to ~30 bytes, while on arm64 it actually decreases the size of the emitted code. The overall jit processing time per division would increase from ~1μs to ~1.5μs (about 200 runs of the optimized code would make up for this time). But the code size/jit time is negligible since it is not common in most methods (the optimization applies to 64 cases in corlib, 220 cases in entire bcl)

Historic PR : https://github.com/mono/mono/pull/1350

http://www.hackersdelight.org/permissions.htm