### PR TITLE
Microsoft.Build.Engine] Implement ConvertToITaskItemArray

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/MemberInvocationReference.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/MemberInvocationReference.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Globalization;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using System.Text;
 
 namespace Microsoft.Build.BuildEngine
@@ -280,7 +281,10 @@ namespace Microsoft.Build.BuildEngine
 
 		public ITaskItem[] ConvertToITaskItemArray (Project project, ExpressionOptions options)
 		{
-			throw new NotImplementedException ();
+			var items = new ITaskItem[1];
+			items[0] = new TaskItem (ConvertToString (project, options));
+
+			return items;
 		}
 	}
 }


### PR DESCRIPTION
I'm not going to lie and say I really know what's going on here, but I'm trying to get xbuild to be able to handle the following line from the OpenLiveWriter build

```<WriteLinesToFile File="$(UnmanagedVersionPath)" Lines="#define FILE_VERSION $(BuildVersion.Replace(&quot;.&quot;,&quot;,&quot;));#define PRODUCT_VERSION $(BuildVersion)" Overwrite="true" />```

Combined with https://github.com/mono/mono/pull/2334 this patch makes the build do what is expected, but I don't know if MemberInvocationReference is meant to support other things.