### PR TITLE
Update the `System.Diagnostics.Tracing` namespace to better match the .NET API

### DIFF
--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventActivityOptions.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventActivityOptions.cs
@@ -1,0 +1,40 @@
+//
+// EventActivityOptions.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace System.Diagnostics.Tracing
+{
+	[Flags]
+	public enum EventActivityOptions
+	{
+		None = 0,
+		Disable = 2,
+		Recursive = 4,
+		Detachable = 8
+	}
+}
+

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventChannel.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventChannel.cs
@@ -1,0 +1,41 @@
+//
+// EventChannel.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace System.Diagnostics.Tracing
+{
+	public enum EventChannel : byte
+	{
+		None = 0,
+		Admin = 16,
+		Operational = 17,
+		Analytic = 18,
+		Debug = 19
+	}
+}
+

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventOpcode.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventOpcode.cs
@@ -1,0 +1,47 @@
+//
+// EventOpcode.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace System.Diagnostics.Tracing
+{
+	public enum EventOpcode
+	{
+		Info = 0,
+		Start,
+		Stop,
+		DataCollectionStart,
+		DataCollectionStop,
+		Extension,
+		Reply,
+		Resume,
+		Suspend,
+		Send,
+		Receive = 240
+	}
+}
+

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventSource.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventSource.cs
@@ -31,66 +31,192 @@ namespace System.Diagnostics.Tracing
 {
 	public class EventSource : IDisposable
 	{
-		protected EventSource ()
+		protected EventSource()
+		{
+			this.Name = this.GetType().Name;
+		}
+
+		protected EventSource(bool throwOnEventWriteErrors)
+			: this()
 		{
 		}
 
-		protected EventSource (bool throwOnEventWriteErrors)
+		protected EventSource(EventSourceSettings settings)
+			: this()
+		{
+			this.Settings = settings;
+		}
+
+		protected EventSource(EventSourceSettings settings, params string[] traits)
+			: this(settings)
 		{
 		}
 
-		public bool IsEnabled ()
+		public EventSource(string eventSourceName)
+		{
+			this.Name = eventSourceName;
+		}
+
+		public EventSource(string eventSourceName, EventSourceSettings config)
+			: this(eventSourceName)
+		{
+			this.Settings = config;
+		}
+
+		public EventSource(string eventSourceName, EventSourceSettings config, params string[] traits)
+			: this(eventSourceName, config)
+		{
+		}
+
+		public Exception ConstructionException
+		{
+			get { return null; }
+		}
+
+		public static Guid CurrentThreadActivityId
+		{
+			get { return Guid.Empty; }
+		}
+
+		public Guid Guid
+		{
+			get { return Guid.Empty; }
+		}
+
+		public string Name
+		{
+			get;
+			private set;
+		}
+
+		public EventSourceSettings Settings
+		{
+			get;
+			private set;
+		}
+
+		public bool IsEnabled()
 		{
 			return false;
 		}
 
-		public bool IsEnabled (EventLevel level, EventKeywords keywords)
+		public bool IsEnabled(EventLevel level, EventKeywords keywords)
 		{
 			return false;
 		}
 
-		public void Dispose ()
+		public bool IsEnabled(EventLevel level, EventKeywords keywords, EventChannel channel)
 		{
-			Dispose (true);
+			return false;
 		}
 
-		protected virtual void Dispose (bool disposing)
-		{			
-		}
-
-		protected virtual void OnEventCommand (EventCommandEventArgs command)
+		public void Dispose()
 		{
+			Dispose(true);
 		}
 
-		protected void WriteEvent (int eventId, string arg1)
+		public string GetTrait(string key)
 		{
+			return null;
 		}
 
-		protected void WriteEvent (int eventId, string arg1, int arg2)
+		public void Write(string eventName)
 		{
 		}
 
-		protected void WriteEvent (int eventId, int arg1, int arg2, int arg3)
+		public void Write<T>(string eventName, T data)
 		{
 		}
 
-		protected void WriteEvent (int eventId, string arg1, int arg2, int arg3)
+		public void Write<T>(string eventName, EventSourceOptions options, T data)
 		{
 		}
 
-		protected void WriteEvent (int eventId, long arg1)
+		public void Write<T>(string eventName, ref EventSourceOptions options, ref T data)
 		{
 		}
 
-		protected void WriteEvent (int eventId, long arg1, long arg2)
+		public void Write<T>(string eventName, ref EventSourceOptions options, ref Guid activityId, ref Guid relatedActivityId, ref T data)
 		{
 		}
 
-		protected void WriteEvent (int eventId, long arg1, long arg2, long arg3)
+		protected virtual void Dispose(bool disposing)
 		{
 		}
 
-		protected void WriteEvent (int eventId, params object[] args)
+		protected virtual void OnEventCommand(EventCommandEventArgs command)
+		{
+		}
+
+		protected void WriteEvent(int eventId)
+		{
+		}
+
+		protected void WriteEvent(int eventId, byte[] arg1)
+		{
+		}
+
+		protected void WriteEvent(int eventId, int arg1)
+		{
+		}
+
+		protected void WriteEvent(int eventId, string arg1)
+		{
+		}
+
+		protected void WriteEvent(int eventId, int arg1, int arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, int arg1, int arg2, int arg3)
+		{
+		}
+
+		protected void WriteEvent(int eventId, int arg1, string arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, long arg1)
+		{
+		}
+
+		protected void WriteEvent(int eventId, long arg1, byte[] arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, long arg1, long arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, long arg1, long arg2, long arg3)
+		{
+		}
+
+		protected void WriteEvent(int eventId, long arg1, string arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, params object[] args)
+		{
+		}
+
+		protected void WriteEvent(int eventId, string arg1, int arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, string arg1, int arg2, int arg3)
+		{
+		}
+
+		protected void WriteEvent(int eventId, string arg1, long arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, string arg1, string arg2)
+		{
+		}
+
+		protected void WriteEvent(int eventId, string arg1, string arg2, string arg3)
 		{
 		}
 	}

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventSourceOptions.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventSourceOptions.cs
@@ -1,0 +1,45 @@
+//
+// EventSourceOptions.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace System.Diagnostics.Tracing
+{
+	public struct EventSourceOptions
+	{
+		public EventActivityOptions ActivityOptions { get; set; }
+
+		public EventKeywords Keywords { get; set; }
+
+		public EventLevel Level { get; set; }
+
+		public EventOpcode Opcode { get; set; }
+
+		public EventTags Tags { get; set; }
+	}
+}
+

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventSourceSettings.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventSourceSettings.cs
@@ -1,0 +1,41 @@
+//
+// EventSourceSettings.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace System.Diagnostics.Tracing
+{
+	[Flags]
+	public enum EventSourceSettings
+	{
+		Default = 0,
+		EtwManifestEventFormat = 1,
+		EtwSelfDescribingEventFormat = 4,
+		ThrowOnEventWriteErrors = 8
+	}
+}
+

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventTags.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventTags.cs
@@ -1,0 +1,37 @@
+//
+// EventTags.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace System.Diagnostics.Tracing
+{
+	public enum EventTags
+	{
+		None
+	}
+}
+

--- a/mcs/class/corlib/corlib-net_4_x.csproj
+++ b/mcs/class/corlib/corlib-net_4_x.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -824,13 +824,19 @@
     <Compile Include="System.Diagnostics.SymbolStore\SymDocumentType.cs" />
     <Compile Include="System.Diagnostics.SymbolStore\SymLanguageType.cs" />
     <Compile Include="System.Diagnostics.SymbolStore\SymLanguageVendor.cs" />
+    <Compile Include="System.Diagnostics.Tracing\EventActivityOptions.cs" />
     <Compile Include="System.Diagnostics.Tracing\EventAttribute.cs" />
+    <Compile Include="System.Diagnostics.Tracing\EventChannel.cs" />
     <Compile Include="System.Diagnostics.Tracing\EventCommand.cs" />
     <Compile Include="System.Diagnostics.Tracing\EventCommandEventArgs.cs" />
     <Compile Include="System.Diagnostics.Tracing\EventKeywords.cs" />
     <Compile Include="System.Diagnostics.Tracing\EventLevel.cs" />
+    <Compile Include="System.Diagnostics.Tracing\EventOpcode.cs" />
     <Compile Include="System.Diagnostics.Tracing\EventSource.cs" />
     <Compile Include="System.Diagnostics.Tracing\EventSourceAttribute.cs" />
+    <Compile Include="System.Diagnostics.Tracing\EventSourceOptions.cs" />
+    <Compile Include="System.Diagnostics.Tracing\EventSourceSettings.cs" />
+    <Compile Include="System.Diagnostics.Tracing\EventTags.cs" />
     <Compile Include="System.Diagnostics.Tracing\NonEventAttribute.cs" />
     <Compile Include="System.Diagnostics\Debugger.cs" />
     <Compile Include="System.Diagnostics\StackFrame.cs" />
@@ -1604,7 +1610,8 @@
     <Compile Include="System\Void.cs" />
     <Compile Include="System\WeakReference.cs" />
     <Compile Include="System\WeakReference_T.cs" />
-    <Compile Include="System\WindowsConsoleDriver.cs" />  </ItemGroup>
+    <Compile Include="System\WindowsConsoleDriver.cs" />
+  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
A couple of constructors, method and properties are missing on the `EventSource` class, causing .NET code that makes use of these constructors, methods or properties to fail on Mono.

This patch adds these constructors, method and properties with no-op implementations, like the reset of the `EventSource` class.

All feedback is welcome!