### PR TITLE
[HttpConnection] Bug fix: HttpListener's "IgnoreWriteExceptions" property value is ignored when "Expect: 100-Continue" header set in request

### DIFF
--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -209,8 +209,11 @@ namespace System.Net {
 			// TODO: can we get this stream before reading the input?
 			if (o_stream == null) {
 				HttpListener listener = context.Listener;
-				bool ign = (listener == null) ? true : listener.IgnoreWriteExceptions;
-				o_stream = new ResponseStream (stream, context.Response, ign);
+				
+				if(listener == null)
+					return new ResponseStream (stream, context.Response, true);
+
+				o_stream = new ResponseStream (stream, context.Response, listener.IgnoreWriteExceptions);
 			}
 			return o_stream;
 		}


### PR DESCRIPTION
That problem was discussed previously here: https://github.com/mono/mono/pull/2300
I want to offer alternative solution now.