### PR TITLE
[4.2.0][threadpool] Fix overflow of max number of worker threads

### DIFF
--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -876,8 +876,18 @@ monitor_thread (void)
 
 		if (all_waitsleepjoin) {
 			ThreadPoolCounter counter;
-			COUNTER_ATOMIC (counter, { counter._.max_working ++; });
-			hill_climbing_force_change (counter._.max_working, TRANSITION_STARVATION);
+			gboolean limit_worker_max_reached = FALSE;
+
+			COUNTER_ATOMIC (counter, {
+				if (counter._.max_working >= threadpool->limit_worker_max) {
+					limit_worker_max_reached = TRUE;
+					break;
+				}
+				counter._.max_working ++;
+			});
+
+			if (!limit_worker_max_reached)
+				hill_climbing_force_change (counter._.max_working, TRANSITION_STARVATION);
 		}
 
 		threadpool->cpu_usage = mono_cpu_usage (threadpool->cpu_usage_state);


### PR DESCRIPTION
In case all threads would wait on a Sleep or a Wait, the monitor thread would simply increase the number of max working thread, up to the point it would overflow the number of max worker threads.