### PR TITLE
initialize ReaderQuotas, fixes bugzilla #15153

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel/NetTcpBinding.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/NetTcpBinding.cs
@@ -43,7 +43,8 @@ namespace System.ServiceModel
 		int max_conn;
 		OptionalReliableSession reliable_session;
 		NetTcpSecurity security;
-		XmlDictionaryReaderQuotas reader_quotas;
+		XmlDictionaryReaderQuotas reader_quotas
+			= new XmlDictionaryReaderQuotas ();
 		bool transaction_flow;
 		TransactionProtocol transaction_protocol;
 		TcpTransportBindingElement transport;

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetTcpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetTcpBindingTest.cs
@@ -213,6 +213,13 @@ namespace MonoTests.System.ServiceModel
 			Assert.IsTrue (Foo.JoinCalled, "#2");
 		}
 
+		[Test]
+		public ReaderQuotasDefault_Bug15153 ()
+		{
+			NetTcpBinding binding = new NetTcpBinding(SecurityMode.None);
+			binding.ReaderQuotas.MaxStringContentLength = 8192;
+		}
+
 		[ServiceContract]
 		public interface IFoo
 		{


### PR DESCRIPTION
Fixes [Bug 15153](https://bugzilla.xamarin.com/show_bug.cgi?id=15153) "System.ServiceModel.NetTcpBinding properties are not pre-initialized while they are in .NET causing interoperability problems."

Specifically the `reader_quotas` member of `System.ServiceModel.NetTcpBinding` is not initialized to a new `XmlDictionaryReaderQuotas` object which causes a "NullReferenceException: Object reference not set to an instance of an object." whenever an attempt is made to set any attributes of that property. For example: `using System.ServiceModel; NetTcpBinding binding = new NetTcpBinding(SecurityMode.None); binding.ReaderQuotas.MaxStringContentLength = 8192;` raises "NullReferenceException: Object reference not set to an instance of an object."

@monojenkins merge