### PR TITLE
[threads] Fix potential deadlock on suspend

### DIFF
--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -910,7 +910,7 @@ suspend_sync_nolock (MonoNativeThreadId id, gboolean interrupt_kernel)
 		if (sleep_duration == 0)
 			mono_thread_info_yield ();
 		else
-			mono_thread_info_usleep (sleep_duration);
+			g_usleep (sleep_duration);
 
 		sleep_duration += 10;
 	}


### PR DESCRIPTION
Because mono_thread_info_safe_suspend_and_run is locking the suspend lock, we cannot enter the blocking state in any of its callee, as that could lead to a deadlock.