### PR TITLE
[4.2.0][Process] Use ReferenceSource process async output/error reader

### DIFF
--- a/mcs/class/System/System.dll.sources
+++ b/mcs/class/System/System.dll.sources
@@ -1127,3 +1127,5 @@ ReferenceSources/Win32Exception.cs
 ../../../external/referencesource/System/compmod/system/codedom/compiler/ICodeParser.cs
 ../../../external/referencesource/System/compmod/system/codedom/compiler/IndentTextWriter.cs
 ../../../external/referencesource/System/compmod/system/codedom/compiler/LanguageOptions.cs
+
+../../../external/referencesource/System/services/monitoring/system/diagnosticts/AsyncStreamReader.cs

--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -604,16 +604,6 @@ is_socket_async_callback (MonoImage *system_image, MonoClass *class)
 	return class == socket_async_callback_class;
 }
 
-static gboolean
-is_async_read_handler (MonoImage *system_image, MonoClass *class)
-{
-	MonoClass *async_read_handler_class = NULL;
-
-	async_read_handler_class = mono_class_from_name (system_image, "System.Diagnostics", "Process/AsyncReadHandler");
-
-	return class == async_read_handler_class;
-}
-
 gboolean
 mono_threadpool_ms_is_io (MonoObject *target, MonoObject *state)
 {
@@ -624,7 +614,7 @@ mono_threadpool_ms_is_io (MonoObject *target, MonoObject *state)
 	if (!system_image)
 		return FALSE;
 
-	if (!is_socket_async_callback (system_image, target->vtable->klass) && !is_async_read_handler (system_image, target->vtable->klass))
+	if (!is_socket_async_callback (system_image, target->vtable->klass))
 		return FALSE;
 
 	sockares = (MonoSocketAsyncResult*) state;


### PR DESCRIPTION
By using the referencesource one, we remove a buggy part of the Process class.

It will now simply use Stream.{Begin/End}Read, and not a custom implementation that introduces its own bugs.

We also get rid of the very dirty hack in Delegate.BeginInvoke that check on the delegate type to know if it should use the IO threadpool or simply enqueue a threadpool job.