### PR TITLE
SpecialFolder.CommonApplicationData support for El Capitan

### DIFF
--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -736,6 +736,10 @@ namespace System {
 				return String.Empty;
 			// This is where data common to all users goes
 			case SpecialFolder.CommonApplicationData:
+				Version v = CreateVersionFromString (GetOSVersionString ());
+				if (Platform == PlatformID.MacOSX && v >= new Version(15, 0)) {
+					return "/usr/local/share";
+				}
 				return "/usr/share";
 			default:
 				throw new ArgumentException ("Invalid SpecialFolder");


### PR DESCRIPTION
Apple has introduced the System Integrety Protection in OS X 10.11. This prevents writes to /usr amongst other paths. /usr/local is still writable though.

`System.Environment.SpecialFolder.CommonApplicationData` returns `/usr/share` on OS X 10.11, which is now not a very good place to put things :) This patch changes this folder to `/usr/local/share`.

https://support.apple.com/en-us/HT204899
https://en.wikipedia.org/wiki/System_Integrity_Protection