### PR TITLE
[XBuild] Fixed method invocation with string argument containing ",` or '

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Expression.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Expression.cs
@@ -464,7 +464,8 @@ namespace Microsoft.Build.BuildEngine {
 			List<string> args = new List<string> ();
 			int parens = 0;
 			bool backticks = false;
-			bool inquotes = false;
+			bool inDoubleQuotes = false;
+			bool inSingleQuotes = false;
 			int start = pos;
 			for (; pos < text.Length; ++pos) {
 				var ch = text [pos];
@@ -477,8 +478,13 @@ namespace Microsoft.Build.BuildEngine {
 				if (backticks)
 					continue;
 
-				if (ch == '\"') {
-					inquotes = !inquotes;
+				if(ch == '\'' && !inDoubleQuotes) {
+					inSingleQuotes = !inSingleQuotes;
+					continue;
+				}
+
+				if (ch == '\"' && !inSingleQuotes) {
+					inDoubleQuotes = !inDoubleQuotes;
 					continue;
 				}
 
@@ -504,7 +510,7 @@ namespace Microsoft.Build.BuildEngine {
 				if (parens != 0)
 					continue;
 
-				if (ch == ',' && !inquotes) {
+				if (ch == ',' && !inDoubleQuotes && !inSingleQuotes) {
 					args.Add (text.Substring (start, pos - start));
 					start = pos + 1;
 					continue;

--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/MemberInvocationReference.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/MemberInvocationReference.cs
@@ -124,6 +124,14 @@ namespace Microsoft.Build.BuildEngine
 			return value;
 		}
 
+		static string TrimFirstAndLast(string unTrimmed)
+		{
+			if (unTrimmed.Length > 1 && Array.IndexOf (ArgumentTrimChars, unTrimmed [0]) != -1 && Array.IndexOf (ArgumentTrimChars, unTrimmed [unTrimmed.Length - 1]) != -1) {
+				return unTrimmed.Substring (1, unTrimmed.Length - 2);
+			}
+			return unTrimmed;
+		}
+
 		void ExpandArguments (Project project, ExpressionOptions options)
 		{
 			for (int i = 0; i < Arguments.Count; ++i) {
@@ -134,7 +142,7 @@ namespace Microsoft.Build.BuildEngine
 					arg = Expression.ParseAs<string> (arg, ParseOptions.None,
 						project, options);
 
-					arg = arg.Trim (ArgumentTrimChars);
+					arg = TrimFirstAndLast (arg);
 				}
 
 				Arguments [i] = arg;

--- a/mcs/class/Microsoft.Build.Engine/Test/various/Properties.cs
+++ b/mcs/class/Microsoft.Build.Engine/Test/various/Properties.cs
@@ -101,11 +101,17 @@ namespace MonoTests.Microsoft.Build.BuildEngine.Various {
 							<Config>debug</Config>
 							<NullValue>null</NullValue>
 							<TargetValue>  </TargetValue>
+							<StringWithQuotes>abc""def</StringWithQuotes>
 							<Prop1>$(Config.Substring(0,3)) </Prop1>
 							<Prop2>$(Config.Length )</Prop2>
 							<Prop3>$(Config.StartsWith ('DE', System.StringComparison.OrdinalIgnoreCase))</Prop3>
 							<Prop4>$(NullValue.StartsWith ('Te', StringComparison.OrdinalIgnoreCase))</Prop4>
 							<Prop5>$(TargetValue.Trim('\\'))</Prop5>
+							<Prop6>$(StringWithQuotes.Replace('""', ""'""))</Prop6>
+							<Prop7>$(StringWithQuotes.Replace('""', ''))</Prop7>
+							<Prop8>$(StringWithQuotes.Replace('""', """"))</Prop8>
+							<Prop9>$(StringWithQuotes.Replace('""', ``))</Prop9>
+							<Prop9>$(StringWithQuotes.Replace(`c""d`, `2""'3`))</Prop9>
 						</PropertyGroup>
 					</Project>
 				";
@@ -116,6 +122,10 @@ namespace MonoTests.Microsoft.Build.BuildEngine.Various {
 			Assert.AreEqual ("True", proj.GetEvaluatedProperty ("Prop3"), "#3");
 			Assert.AreEqual ("False", proj.GetEvaluatedProperty ("Prop4"), "#4");
 			Assert.AreEqual ("", proj.GetEvaluatedProperty ("Prop5"), "#5");
+			Assert.AreEqual ("abc'def", proj.GetEvaluatedProperty ("Prop6"), "#6");
+			Assert.AreEqual ("abcdef", proj.GetEvaluatedProperty ("Prop7"), "#7");
+			Assert.AreEqual ("abcdef", proj.GetEvaluatedProperty ("Prop8"), "#8");
+			Assert.AreEqual ("ab2\"'3ef", proj.GetEvaluatedProperty ("Prop9"), "#9");
 		}
 
 		[Test]


### PR DESCRIPTION
Before this commit string value starting or ending with this char was malformed because Trim removed also part of string value
Also fixed recent regression from 42c0a94445 which failed to split arguments if doubleQuote was inside singleQuoute

/cc: @marek-safar 