### PR TITLE
[ServiceModel] Remove custom free port finder code

### DIFF
--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataExchangeBindingsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataExchangeBindingsTest.cs
@@ -38,21 +38,13 @@ using System.ServiceModel.Dispatcher;
 using System.Text;
 
 using NUnit.Framework;
+using MonoTests.Helpers;
 
 namespace MonoTests.System.ServiceModel.Description
 {
 	[TestFixture]
 	public class MetadataExchangeBindingsTest
 	{
-		Uri CreateUri (string uriString)
-		{
-			var uri = new Uri (uriString);
-			var l = new TcpListener (uri.Port);
-			l.Start ();
-			l.Stop ();
-			return uri;
-		}
-
 		[Test]
 		public void CreateMexHttpBinding ()
 		{
@@ -69,7 +61,7 @@ namespace MonoTests.System.ServiceModel.Description
 			Assert.AreEqual (MessageVersion.Soap12WSAddressing10, b.GetProperty<MessageVersion> (new BindingParameterCollection ()), "#6");
 
 			var host = new ServiceHost (typeof (MetadataExchange));
-			host.AddServiceEndpoint (typeof (IMetadataExchange), MetadataExchangeBindings.CreateMexHttpBinding (), CreateUri ("http://localhost:30158"));
+			host.AddServiceEndpoint (typeof (IMetadataExchange), MetadataExchangeBindings.CreateMexHttpBinding (), "http://localhost:" + NetworkHelpers.FindFreePort ());
 			host.Open ();
 			try {
 				// it still does not rewrite MessageVersion.None. It's rather likely ServiceMetadataExtension which does overwriting.
@@ -96,7 +88,7 @@ namespace MonoTests.System.ServiceModel.Description
 			Assert.AreEqual(Uri.UriSchemeHttps, b.Scheme, "#8");
 
 			var host = new ServiceHost(typeof(MetadataExchange));
-			host.AddServiceEndpoint(typeof(IMetadataExchange), MetadataExchangeBindings.CreateMexHttpsBinding(), CreateUri("https://localhost:30158"));
+			host.AddServiceEndpoint(typeof(IMetadataExchange), MetadataExchangeBindings.CreateMexHttpsBinding(), "https://localhost:" + NetworkHelpers.FindFreePort ());
 			host.Open();
 			try
 			{

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceDebugBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceDebugBehaviorTest.cs
@@ -57,18 +57,9 @@ namespace MonoTests.System.ServiceModel.Description
 			}
 		}
 
-		Uri CreateUri (string uriString)
-		{
-			var uri = new Uri (uriString);
-			var l = new TcpListener (uri.Port);
-			l.Start ();
-			l.Stop ();
-			return uri;
-		}
-
 		[Test]
 		public void InitializeRuntime1 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "e1");
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
@@ -105,7 +96,7 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime2 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
@@ -124,7 +115,7 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime3 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ()))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
 				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageEnabled = false;
 
@@ -143,7 +134,7 @@ namespace MonoTests.System.ServiceModel.Description
 		[Test]
 		public void InitializeRuntime4 () {
 			int port = NetworkHelpers.FindFreePort ();
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + port))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
 				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:" + port + "/help");
 
@@ -190,7 +181,7 @@ namespace MonoTests.System.ServiceModel.Description
 		[Test]
 		public void ServiceMetadataExtension1 () {
 			int port = NetworkHelpers.FindFreePort ();
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + port))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
 				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:" + port + "/help");
 				try {
@@ -207,9 +198,9 @@ namespace MonoTests.System.ServiceModel.Description
 		[Test]
 		public void ServiceMetadataExtension2 () {
 			int port = NetworkHelpers.FindFreePort ();
-			using (ServiceHost host = new ServiceHost (typeof (MyService), CreateUri ("http://localhost:" + port))) {
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = CreateUri ("http://localhost:" + port + "/help");
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:" + port + "/help");
 
 				ServiceMetadataExtension extension = new ServiceMetadataExtension ();
 				host.Extensions.Add (extension);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ChannelDispatcherTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ChannelDispatcherTest.cs
@@ -17,19 +17,6 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 	[TestFixture]
 	public class ChannelDispatcherTest
 	{
-		Uri CreateAvailableUri (string uriString)
-		{
-			var uri = new Uri (uriString);
-			try {
-				var t = new TcpListener (uri.Port);
-				t.Start ();
-				t.Stop ();
-			} catch (Exception ex) {
-				Assert.Fail (String.Format ("Port {0} is not open. It is likely previous tests have failed and the port is kept opened", uri.Port));
-			}
-			return uri;
-		}
-
 		[Test]
 		public void ConstructorNullBindingName ()
 		{
@@ -44,7 +31,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 			var st = cd.ServiceThrottle;
 			Assert.IsNull (st, "#0");
 
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			h.AddServiceEndpoint (typeof (TestContract).FullName, new BasicHttpBinding (), "address");
 			h.ChannelDispatchers.Add (cd);
@@ -71,7 +58,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]			
 		public void Collection_Add_Remove () {
 			Console.WriteLine ("STart test Collection_Add_Remove");
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			h.AddServiceEndpoint (typeof (TestContract).FullName, new BasicHttpBinding (), "address");
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
@@ -89,7 +76,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]
 		public void EndpointDispatcherAddTest ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
 			d.Endpoints.Add (new EndpointDispatcher (new EndpointAddress (uri), "", ""));
 		}
@@ -97,7 +84,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]
 		[ExpectedException (typeof (InvalidOperationException))] 
 		public void EndpointDispatcherAddTest2 () {
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
 			d.Endpoints.Add (new EndpointDispatcher (new EndpointAddress (uri), "", ""));
 			d.Open (); // the dispatcher must be attached.
@@ -107,7 +94,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void EndpointDispatcherAddTest3 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			MyChannelDispatcher d = new MyChannelDispatcher (new MyChannelListener (uri));
 			d.Endpoints.Add (new EndpointDispatcher (new EndpointAddress (uri), "", ""));
@@ -119,7 +106,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))] // i.e. it is thrown synchronously in current thread.
 		public void EndpointDispatcherAddTest4 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var listener = new MyChannelListener (uri);
 			MyChannelDispatcher d = new MyChannelDispatcher (listener);
@@ -151,7 +138,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))] // i.e. it is thrown synchronously in current thread.
 		public void EndpointDispatcherAddTest5 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var binding = new BasicHttpBinding ();
 			var listener = new MyChannelListener (uri);
@@ -173,7 +160,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[Test]
 		public void EndpointDispatcherAddTest6 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var binding = new BasicHttpBinding ();
 			var listener = new MyChannelListener<IReplyChannel> (uri);
@@ -204,7 +191,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void EndpointDispatcherAddTest7 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var binding = new BasicHttpBinding ();
 			var listener = new MyChannelListener<IReplyChannel> (uri);
@@ -239,7 +226,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		// but it makes little sense especially for checking duplicate listen URIs. Duplicate listen URIs should be rejected anyways.
 		public void EndpointDispatcherAddTest8 ()
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (typeof (TestContract), uri);
 			var listener = new MyChannelListener<IReplyChannel> (uri);
 			MyChannelDispatcher d = new MyChannelDispatcher (listener);
@@ -284,7 +271,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 //		[Test]
 		public void EndpointDispatcherAddTest9 () // test singleton service
 		{
-			var uri = CreateAvailableUri ("http://localhost:" + NetworkHelpers.FindFreePort ());
+			var uri = new Uri ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			ServiceHost h = new ServiceHost (new TestContract (), uri);
 			h.Description.Behaviors.Find<ServiceBehaviorAttribute> ().InstanceContextMode = InstanceContextMode.Single;
 			var listener = new MyChannelListener<IReplyChannel> (uri);


### PR DESCRIPTION
We have a common one in NetworkHelpers now.

@monojenkins merge