### PR TITLE
Do not allow undefined references if bitcode is enabled.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3464,6 +3464,7 @@ AC_ARG_WITH(monodroid,       [  --with-monodroid=yes,no         If you want to b
 AC_ARG_WITH(monotouch,       [  --with-monotouch=yes,no         If you want to build the Xamarin.iOS assemblies (defaults to no)],    [], [with_monotouch=no])
 AC_ARG_WITH(monotouch_watch, [  --with-monotouch_watch=yes,no   If you want to build the Xamarin.WatchOS assemblies (defaults to no)],[], [with_monotouch_watch=no])
 AC_ARG_WITH(monotouch_tv,    [  --with-monotouch_tv=yes,no      If you want to build the Xamarin.TVOS assemblies (defaults to no)],   [], [with_monotouch_tv=no])
+AC_ARG_WITH(bitcode,         [  --with-bitcode=yes,no           If bitcode is enabled (defaults to no)],                              [], [with_bitcode=no])
 AC_ARG_WITH(xammac,          [  --with-xammac=yes,no            If you want to build the Xamarin.Mac assemblies (defaults to no)],    [], [with_xammac=no])
 
 OPROFILE=no
@@ -3577,6 +3578,7 @@ AM_CONDITIONAL(INSTALL_MONODROID, [test "x$with_monodroid" != "xno"])
 AM_CONDITIONAL(INSTALL_MONOTOUCH, [test "x$with_monotouch" != "xno"])
 AM_CONDITIONAL(INSTALL_MONOTOUCH_WATCH, [test "x$with_monotouch_watch" != "xno"])
 AM_CONDITIONAL(INSTALL_MONOTOUCH_TV, [test "x$with_monotouch_tv" != "xno"])
+AM_CONDITIONAL(BITCODE, test "x$with_bitcode" = "xyes")
 AM_CONDITIONAL(INSTALL_XAMMAC, [test "x$with_xammac" != "xno"])
 
 AM_CONDITIONAL(MIPS_GCC, test ${TARGET}${ac_cv_prog_gcc} = MIPSyes)

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -243,6 +243,10 @@ mono_sgen_LDADD = \
 
 mono_sgen_LDFLAGS = $(static_flags) -export-dynamic $(monobinldflags) $(monobin_platform_ldflags)
 
+if BITCODE
+libmonoldflags += -no-undefined
+endif
+
 # if SUPPORT_SGEN
 # 
 # mono_LDADD = $(mono_sgen_LDADD)

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -22,7 +22,11 @@ endif
 lib_LTLIBRARIES = libmono-profiler-aot.la libmono-profiler-iomap.la libmono-profiler-log.la libmono-profiler-log-static.la $(vtune_lib)
 
 if PLATFORM_DARWIN
+if BITCODE
+libmono_profiler_log_la_LDFLAGS = -no-undefined
+else
 libmono_profiler_log_la_LDFLAGS = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
+endif
 endif
 if PLATFORM_ANDROID
 libmono_profiler_log_la_LDFLAGS = -avoid-version
@@ -58,8 +62,14 @@ endif
 
 libmono_profiler_aot_la_SOURCES = mono-profiler-aot.c
 libmono_profiler_aot_la_LIBADD = $(LIBMONO) $(GLIB_LIBS) $(LIBICONV)
+if BITCODE
+libmono_profiler_aot_la_LDFLAGS = -no-undefined
+endif
 libmono_profiler_iomap_la_SOURCES = mono-profiler-iomap.c
 libmono_profiler_iomap_la_LIBADD = $(LIBMONO) $(GLIB_LIBS) $(LIBICONV)
+if BITCODE
+libmono_profiler_iomap_la_LDFLAGS = -no-undefined
+endif
 libmono_profiler_log_la_SOURCES = proflog.c
 libmono_profiler_log_la_LIBADD = $(LIBMONO) $(GLIB_LIBS) $(Z_LIBS)
 if HAVE_VTUNE


### PR DESCRIPTION
The linker does not allow the '-undefined' flag when bitcode
is enabled, so we can't pass it to the linker at all.