### PR TITLE
[mdoc] Extension method crash fix, removes -multiassembly

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -186,12 +186,12 @@ check-monodocer-dropns-multi: $(PROGRAM)
 	$(MAKE) Test/DocTest-DropNS-unified-multitest.dll
 
 	# mdoc update for both classic and unified
-	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic -multiassembly
-	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework -multiassembly
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic 
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework 
 	
 	# now run it again to verify idempotency
-	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic -multiassembly
-	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework -multiassembly
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic 
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework 
 	
 	diff --exclude=.svn -rup Test/en.expected-dropns-multi Test/en.actual
 
@@ -208,8 +208,8 @@ check-monodocer-dropns-multi-withexisting: $(PROGRAM)
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-DropNS-unified.dll --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework 
 	
 	# mdoc update for both classic and unified
-	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic -multiassembly
-	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework -multiassembly
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic 
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework 
 	
 	diff --exclude=.svn -rup Test/en.expected-dropns-multi-withexisting Test/en.actual
 

--- a/mcs/tools/mdoc/Test/DocTest-DropNS-classic.cs
+++ b/mcs/tools/mdoc/Test/DocTest-DropNS-classic.cs
@@ -21,6 +21,9 @@ namespace MyFramework.MyNamespace {
 		public string WillDeleteInV2Classic {get;set;}
 		#endif
 	}
+	public static class MyClassExtensions {
+		public static bool AnExtension (this MyClass value) { return false; }
+	}
 
 	#if DELETETEST 
 	public class TypeOnlyInClassic {}

--- a/mcs/tools/mdoc/Test/DocTest-DropNS-unified.cs
+++ b/mcs/tools/mdoc/Test/DocTest-DropNS-unified.cs
@@ -22,6 +22,9 @@ namespace MyNamespace {
 		#endif
 	}
 
+	public static class MyClassExtensions {
+		public static bool AnExtension (this MyClass value) { return false; }
+	}
 	#if DELETETEST
 	public struct nint {
 

--- a/mcs/tools/mdoc/Test/en.expected-dropns-classic-v1/MyFramework.MyNamespace/MyClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-classic-v1/MyFramework.MyNamespace/MyClass.xml
@@ -23,9 +23,11 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters />
@@ -39,9 +41,11 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -62,9 +66,11 @@
       <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -81,6 +87,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance float64 OnlyInClassic" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -97,6 +104,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance char OnlyInUnified" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-classic-v1/MyFramework.MyNamespace/MyClassExtensions.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-classic-v1/MyFramework.MyNamespace/MyClassExtensions.xml
@@ -1,0 +1,47 @@
+<Type Name="MyClassExtensions" FullName="MyFramework.MyNamespace.MyClassExtensions">
+  <TypeSignature Language="C#" Value="public static class MyClassExtensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MyClassExtensions extends System.Object" />
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnExtension">
+      <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-classic-v1/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-classic-v1/index.xml
@@ -1,5 +1,15 @@
 <Overview>
   <Assemblies>
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
     <Assembly Name="DocTest-DropNS-unified" Version="0.0.0.0">
       <Attributes>
         <Attribute>
@@ -16,7 +26,31 @@
   <Types>
     <Namespace Name="MyFramework.MyNamespace">
       <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyClassExtensions" Kind="Class" />
     </Namespace>
   </Types>
   <Title>DocTest-DropNS-classic</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:MyFramework.MyNamespace.MyClass" />
+      </Targets>
+      <Member MemberName="AnExtension">
+        <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="MyFramework.MyNamespace.MyClassExtensions" Member="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
 </Overview>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/MyFramework.MyNamespace/MyClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/MyFramework.MyNamespace/MyClass.xml
@@ -23,9 +23,11 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters />
@@ -39,9 +41,11 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -62,9 +66,11 @@
       <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -81,6 +87,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance float64 OnlyInClassic" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -97,6 +104,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance char OnlyInUnified" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/MyFramework.MyNamespace/MyClassExtensions.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/MyFramework.MyNamespace/MyClassExtensions.xml
@@ -1,0 +1,47 @@
+<Type Name="MyClassExtensions" FullName="MyFramework.MyNamespace.MyClassExtensions">
+  <TypeSignature Language="C#" Value="public static class MyClassExtensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MyClassExtensions extends System.Object" />
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnExtension">
+      <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/MyFramework.MyOtherNamespace/MyOtherClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/MyFramework.MyOtherNamespace/MyOtherClass.xml
@@ -14,11 +14,12 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
-    <Member MemberName=".ctor">
+    <Member MemberName=".ctor" apistyle="classic">
       <MemberSignature Language="C#" Value="public MyOtherClass ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
-      <AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters />
@@ -27,11 +28,12 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Hello">
+    <Member MemberName="Hello" apistyle="classic">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberType>Method</MemberType>
-      <AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -47,11 +49,12 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="MyProperty">
+    <Member MemberName="MyProperty" apistyle="classic">
       <MemberSignature Language="C#" Value="public string MyProperty { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
       <MemberType>Property</MemberType>
-      <AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-classic-withsecondary/index.xml
@@ -1,5 +1,15 @@
 <Overview>
   <Assemblies>
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
     <Assembly Name="DocTest-DropNS-unified" Version="0.0.0.0">
       <Attributes>
         <Attribute>
@@ -26,10 +36,34 @@
   <Types>
     <Namespace Name="MyFramework.MyNamespace">
       <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyClassExtensions" Kind="Class" />
     </Namespace>
     <Namespace Name="MyFramework.MyOtherNamespace">
       <Type Name="MyOtherClass" Kind="Class" />
     </Namespace>
   </Types>
   <Title>Untitled</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:MyFramework.MyNamespace.MyClass" />
+      </Targets>
+      <Member MemberName="AnExtension">
+        <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="MyFramework.MyNamespace.MyClassExtensions" Member="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
 </Overview>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/MyClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/MyClass.xml
@@ -23,9 +23,11 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters />
@@ -39,9 +41,11 @@
       <MemberSignature Language="ILAsm" Value=".property instance string AddedInV2" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -58,6 +62,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance string AddedInV2Classic" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -74,6 +79,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance string AddedInV2Unified" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -90,9 +96,11 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -113,9 +121,11 @@
       <MemberSignature Language="ILAsm" Value=".property instance string InBoth" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -132,6 +142,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance string InBothClassic" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -150,9 +161,11 @@
       <MemberSignature Language="ILAsm" Value=".property instance valuetype MyFramework.MyNamespace.nint InBothMagicType" apistyle="unified" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -170,6 +183,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance string InBothUnified" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -186,9 +200,11 @@
       <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -205,6 +221,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance float64 OnlyInClassic" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
@@ -221,6 +238,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance char OnlyInUnified" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/MyClassExtensions.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/MyClassExtensions.xml
@@ -1,0 +1,47 @@
+<Type Name="MyClassExtensions" FullName="MyFramework.MyNamespace.MyClassExtensions">
+  <TypeSignature Language="C#" Value="public static class MyClassExtensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MyClassExtensions extends System.Object" />
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnExtension">
+      <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/TypeOnlyInClassic.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/TypeOnlyInClassic.xml
@@ -14,11 +14,12 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
-    <Member MemberName=".ctor">
+    <Member MemberName=".ctor" apistyle="classic">
       <MemberSignature Language="C#" Value="public TypeOnlyInClassic ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
-      <AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters />

--- a/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/WillDelete.xml.remove
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-delete/MyFramework.MyNamespace/WillDelete.xml.remove
@@ -1,6 +1,10 @@
 <Type Name="WillDelete" FullName="MyFramework.MyNamespace.WillDelete">
   <TypeSignature Language="C#" Value="public class WillDelete" />
   <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit WillDelete extends System.Object" />
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
   <Base>
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
@@ -15,6 +19,7 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters />
@@ -28,6 +33,7 @@
       <MemberSignature Language="ILAsm" Value=".property instance string Name" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-deletetest</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-delete/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-delete/index.xml
@@ -1,5 +1,15 @@
 <Overview>
   <Assemblies>
+    <Assembly Name="DocTest-DropNS-classic-deletetest" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
     <Assembly Name="DocTest-DropNS-unified-deletetest" Version="0.0.0.0">
       <Attributes>
         <Attribute>
@@ -16,8 +26,32 @@
   <Types>
     <Namespace Name="MyFramework.MyNamespace">
       <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyClassExtensions" Kind="Class" />
       <Type Name="nint" Kind="Structure" />
     </Namespace>
   </Types>
   <Title>DocTest-DropNS-classic-deletetest</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:MyFramework.MyNamespace.MyClass" />
+      </Targets>
+      <Member MemberName="AnExtension">
+        <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="MyFramework.MyNamespace.MyClassExtensions" Member="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
 </Overview>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/MyClass.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/MyClass.xml
@@ -31,12 +31,12 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo apistyle="classic">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="classic">
         <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
@@ -57,12 +57,12 @@
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo apistyle="classic">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="classic">
         <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
@@ -90,12 +90,12 @@
       <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="classic">
         <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
@@ -119,8 +119,8 @@
       <MemberSignature Language="ILAsm" Value=".property instance float64 OnlyInClassic" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="classic">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="classic">
         <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
@@ -140,8 +140,8 @@
       <MemberSignature Language="ILAsm" Value=".property instance char OnlyInUnified" />
       <MemberType>Property</MemberType>
       <AssemblyInfo apistyle="unified">
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
         <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <AssemblyInfo apistyle="unified">
         <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/MyClassExtensions.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/MyFramework.MyNamespace/MyClassExtensions.xml
@@ -1,0 +1,63 @@
+<Type Name="MyClassExtensions" FullName="MyFramework.MyNamespace.MyClassExtensions">
+  <TypeSignature Language="C#" Value="public static class MyClassExtensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MyClassExtensions extends System.Object" />
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnExtension">
+      <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi-withexisting/index.xml
@@ -46,8 +46,32 @@
   <Types>
     <Namespace Name="MyFramework.MyNamespace">
       <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyClassExtensions" Kind="Class" />
       <Type Name="OnlyInMulti" Kind="Class" />
     </Namespace>
   </Types>
   <Title>DocTest-DropNS-classic</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:MyFramework.MyNamespace.MyClass" />
+      </Targets>
+      <Member MemberName="AnExtension">
+        <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="MyFramework.MyNamespace.MyClassExtensions" Member="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
 </Overview>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi/MyFramework.MyNamespace/MyClassExtensions.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi/MyFramework.MyNamespace/MyClassExtensions.xml
@@ -1,0 +1,63 @@
+<Type Name="MyClassExtensions" FullName="MyFramework.MyNamespace.MyClassExtensions">
+  <TypeSignature Language="C#" Value="public static class MyClassExtensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MyClassExtensions extends System.Object" />
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="classic">
+    <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo apistyle="unified">
+    <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnExtension">
+      <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="classic">
+        <AssemblyName>DocTest-DropNS-classic-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo apistyle="unified">
+        <AssemblyName>DocTest-DropNS-unified-multitest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mcs/tools/mdoc/Test/en.expected-dropns-multi/index.xml
+++ b/mcs/tools/mdoc/Test/en.expected-dropns-multi/index.xml
@@ -46,8 +46,32 @@
   <Types>
     <Namespace Name="MyFramework.MyNamespace">
       <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyClassExtensions" Kind="Class" />
       <Type Name="OnlyInMulti" Kind="Class" />
     </Namespace>
   </Types>
   <Title>Untitled</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:MyFramework.MyNamespace.MyClass" />
+      </Targets>
+      <Member MemberName="AnExtension">
+        <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="MyFramework.MyNamespace.MyClassExtensions" Member="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
 </Overview>


### PR DESCRIPTION

The tests added during the initial development of the -multiassembly argument failed to test the presence of extension methods;
the result was a crash that occurred when there were extension methods present in multiple assemblies.
    
This patch addresses the issue by putting a guard clause around the code that adds the extension method to the index.
Tests have been modified accordingly to verify this bug and include extension methods
    
Additionally, the -multiassembly parameter was removed entirely. This behavior is now triggered by the presence of -apistyle, which is where support for "multiple assemblies" was meant to work anyways. To review, this is to support cross-platform development, where you have multiple -- *different* -- assemblies for each platform. These assemblies will share a certain cross-section of APIs that will be *exactly* the same in each assembly (as opposed to multiple versions of literally the same assembly).

As a result, every member (when run with `apistyle`) will now contain an individual `AssemblyInfo` tag that also contains the name of the assembly.