### PR TITLE
Implement a SetPriority/GetPriority facility for real-time threads

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/PKCS12.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/PKCS12.cs
@@ -383,8 +383,13 @@ namespace Mono.Security.X509 {
 
 				byte[] authSafeData = authSafe.Content [0].Value;
 				byte[] calculatedMac = MAC (_password, macSalt.Value, _iterations, authSafeData);
-				if (!Compare (macValue, calculatedMac))
-					throw new CryptographicException ("Invalid MAC - file may have been tampered!");
+				if (!Compare (macValue, calculatedMac)) {
+					byte[] nullPassword = {0, 0};
+					calculatedMac = MAC(nullPassword, macSalt.Value, _iterations, authSafeData);
+					if (!Compare (macValue, calculatedMac))
+						throw new CryptographicException ("Invalid MAC - file may have been tampered!");
+					_password = nullPassword;
+				}
 			}
 
 			// we now returns to our original presentation - PFX

--- a/mono/io-layer/threads.h
+++ b/mono/io-layer/threads.h
@@ -33,5 +33,8 @@ gpointer wapi_get_current_thread_handle (void);
 
 char* wapi_current_thread_desc (void);
 
+extern gint32 GetThreadPriority (gpointer handle);
+extern gboolean SetThreadPriority (gpointer handle, gint32 priority);
+
 G_END_DECLS
 #endif /* _WAPI_THREADS_H_ */

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -205,7 +205,7 @@ static void abort_thread_internal (MonoInternalThread *thread, gboolean can_rais
 static void suspend_thread_internal (MonoInternalThread *thread, gboolean interrupt);
 static void self_suspend_internal (MonoInternalThread *thread);
 
-static MonoException* mono_thread_execute_interruption ();
+static MonoException* mono_thread_execute_interruption (void);
 static void ref_stack_destroy (gpointer rs);
 
 /* Spin lock for InterlockedXXX 64 bit functions */
@@ -1296,15 +1296,40 @@ ves_icall_System_Threading_Thread_SetName_internal (MonoInternalThread *this_obj
 	mono_thread_set_name_internal (this_obj, name, TRUE);
 }
 
+/*
+ * ves_icall_System_Threading_Thread_GetPriority_internal:
+ * @param this_obj: The MonoInternalThread on which to operate.
+ *
+ * Gets the priority of the given thread.
+ * @return: The priority of the given thread.
+ */
 int
 ves_icall_System_Threading_Thread_GetPriority (MonoThread *this_obj)
 {
-	return ThreadPriority_Lowest;
+	gint32 priority;
+	MonoInternalThread *internal = this_obj->internal_thread;
+
+	LOCK_THREAD (internal);
+	priority = GetThreadPriority (internal->handle) + 2;
+	UNLOCK_THREAD (internal);
+	return priority;
 }
 
+/* 
+ * ves_icall_System_Threading_Thread_SetPriority_internal:
+ * @param this_obj: The MonoInternalThread on which to operate.
+ * @param priority: The priority to set.
+ *
+ * Sets the priority of the given thread.
+ */
 void
 ves_icall_System_Threading_Thread_SetPriority (MonoThread *this_obj, int priority)
 {
+	MonoInternalThread *internal = this_obj->internal_thread;
+
+	LOCK_THREAD (internal);
+	SetThreadPriority (internal->handle, priority - 2);
+	UNLOCK_THREAD (internal);
 }
 
 /* If the array is already in the requested domain, we just return it,


### PR DESCRIPTION
If mono is executed using the SCHED_RR policy, we will map POSIX priorities
to .NET priorities. Under this policy a thread running under this policy
which uses the SetPriority API will have its priority remapped and a
call to pthread_setschedparam() made to change its priority.

The following code fragment may be used to run a mono application
without requiring all root privileges other than the CAP_SYS_NICE
capability which enables priority manipulation:

void
runMonoRT(const char *const name, const int policy, char **argv)
{
    const pid_t         me = getpid();
    struct sched_param  param;

    param.sched_priority = sched_get_priority_min(policy);
    if (sched_setscheduler(me, policy, &param) == -1)
        fprintf(stderr, "sched_setscheduler(getpid(), %s, { %d }): %s.\n",
			name, param.sched_priority, strerror(errno));
    else
        execvp("mono", argv);
}

int
main(int argc, char **argv)
{
    uid_t       user;
    cap_value_t root_caps[2] = { CAP_SYS_NICE, CAP_SETUID };
    cap_value_t user_caps[1] = { CAP_SYS_NICE };
    cap_t       capabilities;

    /* Get real user ID. */
    user = getuid();

    /* Get full root privileges. Normally being effectively root
     * (see man 7 credentials, User and Group Identifiers, for explanation
     *  for effective versus real identity) is enough, but some security
     * modules restrict actions by processes that are only effectively root.
     * To make sure we don't hit those problems, we switch to root fully. */
    if (setresuid(0, 0, 0)) {
        fprintf(stderr, "Cannot switch to root: %s.\n", strerror(errno));
        return 1;
    }

    /* Create an empty set of capabilities. */
    capabilities = cap_init();

    /* Capabilities have three subsets:
     *      INHERITABLE:    Capabilities permitted after an execv()
     *      EFFECTIVE:      Currently effective capabilities
     *      PERMITTED:      Limiting set for the two above.
     * See man 7 capabilities for details, Thread Capability Sets.
     *
     * We need the following capabilities:
     *      CAP_SYS_NICE    For nice(2), setpriority(2),
     *                      sched_setscheduler(2), sched_setparam(2),
     *                      sched_setaffinity(2), etc.
     *      CAP_SETUID      For setuid(), setresuid()
     * in the last two subsets. We do not need to retain any capabilities
     * over an exec().
    */
    if (cap_set_flag(capabilities, CAP_PERMITTED, sizeof root_caps / sizeof root_caps[0], root_caps, CAP_SET) ||
        cap_set_flag(capabilities, CAP_EFFECTIVE, sizeof root_caps / sizeof root_caps[0], root_caps, CAP_SET)) {
        fprintf(stderr, "Cannot manipulate capability data structure as root: %s.\n", strerror(errno));
        return 1;
    }

    /* Above, we just manipulated the data structure describing the flags,
     * not the capabilities themselves. So, set those capabilities now. */
    if (cap_set_proc(capabilities)) {
        fprintf(stderr, "Cannot set capabilities as root: %s.\n", strerror(errno));
        return 1;
    }

    /* We wish to retain the capabilities across the identity change,
     * so we need to tell the kernel. */
    if (prctl(PR_SET_KEEPCAPS, 1L)) {
        fprintf(stderr, "Cannot keep capabilities after dropping privileges: %s.\n", strerror(errno));
        return 1;
    }

    /* Drop extra privileges (aside from capabilities) by switching
     * to the original real user. */
    if (setresuid(user, user, user)) {
        fprintf(stderr, "Cannot drop root privileges: %s.\n", strerror(errno));
        return 1;
    }

    /* We can still switch to a different user due to having the CAP_SETUID
     * capability. Let's clear the capability set, except for the CAP_SYS_NICE
     * in the permitted and effective sets. */
    if (cap_clear(capabilities)) {
        fprintf(stderr, "Cannot clear capability data structure: %s.\n", strerror(errno));
        return 1;
    }
    if (cap_set_flag(capabilities, CAP_PERMITTED, sizeof user_caps / sizeof user_caps[0], user_caps, CAP_SET) ||
        cap_set_flag(capabilities, CAP_EFFECTIVE, sizeof user_caps / sizeof user_caps[0], user_caps, CAP_SET)) {
        fprintf(stderr, "Cannot manipulate capability data structure as user: %s.\n", strerror(errno));
        return 1;
    }

    /* Apply modified capabilities. */
    if (cap_set_proc(capabilities)) {
        fprintf(stderr, "Cannot set capabilities as user: %s.\n", strerror(errno));
        return 1;
    }

    /*
     * Now we have just the normal user privileges,
     * plus user_caps.
    */
    runMonoRT("SCHED_RR", SCHED_RR, argv);

    return 0;
}