### PR TITLE
scripts/babysitter stdout logging improvements

### DIFF
--- a/scripts/babysitter
+++ b/scripts/babysitter
@@ -150,7 +150,7 @@ logging = LOG_FILE_KEY in global_env
 logfile = global_env[LOG_FILE_KEY] if logging else None
 crash_resuming = True # TODO: Consider exposing this option, or adding a retry_on_crash option.
 failmax = int(global_env[RETRY_KEY]) if RETRY_KEY in global_env else 0
-babysitting = logging or failmax
+babysitting = True # If false, babysitter becomes a timeout clone with no env manipulation or anything.
 if babysitting:
 	babysitter_dir = tempfile.mkdtemp()
 	global_env[CURRENT_TEST_KEY] = os.path.join(babysitter_dir, CURRENT_TEST_FILE)
@@ -250,15 +250,10 @@ def run(): # Returns exit code
 	code = None
 
 	# Set up logging
-	if logging:
-		log = {DATE_JSON: posixtime(), COUNT_JSON:0, LIMIT_JSON:failmax, SUPPORT_JSON:False,
-			INVOKE_JSON: " ".join(command)}
-	else:
-		log = None
+	log = {DATE_JSON: posixtime(), COUNT_JSON:0, LIMIT_JSON:failmax, SUPPORT_JSON:False,
+		INVOKE_JSON: " ".join(command)}
 
 	def log_value(key, set=None, add=None, target=log): # Call to add toplevel value to log
-		if not logging:
-			return
 		if add is not None:
 			if key not in target:
 				target[key] = 0
@@ -267,8 +262,6 @@ def run(): # Returns exit code
 			target[key] = set
 
 	def log_test(testname, key, set=None, add=None):   # Call to add test-case-level value to log
-		if not logging:
-			return
 		if TESTS_JSON not in log:
 			log[TESTS_JSON] = {}
 		if testname not in log[TESTS_JSON]:
@@ -342,7 +335,7 @@ def run(): # Returns exit code
 				bailout = True
 				code = 124      # See GNU timeout manpage
 
-			if (code or crashed_at) and babysitting: # Process failures
+			if code or crashed_at: # Process failures
 				# Handle crash failures
 				if crashed_at and not timed_out:
 					log_test(crashed_at, TEST_CRASH_FAILURES, add=1)
@@ -377,11 +370,17 @@ def run(): # Returns exit code
 					message += " Saw crash in test case %s." % (failure_annotate(crashed_at))
 				if failed_tests:
 					message += " Saw test failure in test case%s %s." % (pluralize(failed_tests), "; ".join(map(failure_annotate, failed_tests)))
-				if bailout:
+				if not (timed_out or crashed_at or failed_tests):
+					message += " Test suite terminated with code %d, " % (code)
+					if log[SUPPORT_JSON]:
+						message += "but failure did not occur during a test case. Halting."
+					else:
+						message += "and suite cannot report test case data. Halting."
+				elif bailout:
 					message += " Will halt testing."
 				print(message)
 
-			if bailout or not (babysitting and (resume_after or retry_next)): # If not retrying
+			if bailout or not (resume_after or retry_next): # If not retrying
 				return code
 
 			# If we got here, a retry is occurring


### PR DESCRIPTION
Always print stdout log statements, even when all babysitter features
are turned off, even when the test suite does not support the protocol.