### PR TITLE
[runtime] Make the pdb lookup function return NULL for runtime-generated methods rather than asserting.

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -291,7 +291,8 @@ mono_ppdb_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset)
 	gboolean first = TRUE, first_non_hidden = TRUE;
 	MonoDebugSourceLocation *location;
 
-	g_assert (method->token);
+	if (!method->token)
+		return NULL;
 
 	idx = mono_metadata_token_index (method->token);
 


### PR DESCRIPTION
This makes it consistent with the behavior of it's sister function 

mono_debug_symfile_lookup_location

Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=37257