### PR TITLE
[sgen] Improve caching of los objects

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1400,10 +1400,7 @@ create_allocator (int atype, gboolean slowpath)
 int
 mono_gc_get_aligned_size_for_allocator (int size)
 {
-	int aligned_size = size;
-	aligned_size += SGEN_ALLOC_ALIGN - 1;
-	aligned_size &= ~(SGEN_ALLOC_ALIGN - 1);
-	return aligned_size;
+	return SGEN_ALIGN_UP (size);
 }
 
 /*

--- a/mono/sgen/sgen-descriptor.c
+++ b/mono/sgen/sgen-descriptor.c
@@ -123,10 +123,7 @@ mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
 {
 	int first_set = -1, num_set = 0, last_set = -1, i;
 	SgenDescriptor desc = 0;
-	size_t stored_size = obj_size;
-
-	stored_size += SGEN_ALLOC_ALIGN - 1;
-	stored_size &= ~(SGEN_ALLOC_ALIGN - 1);
+	size_t stored_size = SGEN_ALIGN_UP (obj_size);
 
 	for (i = 0; i < numbits; ++i) {
 		if (bitmap [i / GC_BITS_PER_WORD] & ((gsize)1 << (i % GC_BITS_PER_WORD))) {

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -146,12 +146,16 @@ extern int current_collection_generation;
 
 extern unsigned int sgen_global_stop_count;
 
+#define SGEN_ALIGN_UP_TO(val,align)	(((val) + (align - 1)) & ~(align - 1))
+#define SGEN_ALIGN_DOWN_TO(val,align)	((val) & ~(align - 1))
+
 #define SGEN_ALLOC_ALIGN		8
 #define SGEN_ALLOC_ALIGN_BITS	3
 
 /* s must be non-negative */
 #define SGEN_CAN_ALIGN_UP(s)		((s) <= SIZE_MAX - (SGEN_ALLOC_ALIGN - 1))
-#define SGEN_ALIGN_UP(s)		(((s)+(SGEN_ALLOC_ALIGN-1)) & ~(SGEN_ALLOC_ALIGN-1))
+#define SGEN_ALIGN_UP(s)		SGEN_ALIGN_UP_TO(s, SGEN_ALLOC_ALIGN)
+#define SGEN_ALIGN_DOWN(s)		SGEN_ALIGN_DOWN_TO(s, SGEN_ALLOC_ALIGN)
 
 #if SIZEOF_VOID_P == 4
 #define ONE_P 1

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -204,11 +204,31 @@ get_from_size_list (LOSFreeChunks **list, size_t size)
 }
 
 static LOSObject*
+randomize_los_object_start (gpointer addr, size_t obj_size, size_t alloced_size, size_t addr_alignment)
+{
+	size_t offset = 0;
+	if (alloced_size != obj_size) {
+		/*
+		 * We want to get a random offset between 0 and (alloced_size - obj_size)
+		 * We do a prime multiplication to avoid usage of functions which might not
+		 * be thread/signal safe (like rand ()). We subtract 1 to avoid common
+		 * power by 2 factors.
+		 */
+		offset = SGEN_ALIGN_DOWN ((((size_t)addr - 1) * 2654435761u) % (alloced_size - obj_size));
+	}
+	SGEN_ASSERT (0, (alloced_size - obj_size) < addr_alignment, "Why are we wasting one entire chunk for a los object ?");
+	/* Randomize the location within the reserved chunks to improve cache performance */
+	return (LOSObject*)((guint8*)addr + offset);
+
+}
+
+static LOSObject*
 get_los_section_memory (size_t size)
 {
 	LOSSection *section;
 	LOSFreeChunks *free_chunks;
 	size_t num_chunks;
+	size_t obj_size = size;
 
 	size = SGEN_ALIGN_UP_TO (size, LOS_CHUNK_SIZE);
 
@@ -231,8 +251,9 @@ get_los_section_memory (size_t size)
 			free_chunks = get_from_size_list (&los_fast_free_lists [0], size);
 	}
 
-	if (free_chunks)
-		return (LOSObject*)free_chunks;
+	if (free_chunks) {
+		return randomize_los_object_start (free_chunks, obj_size, size, LOS_CHUNK_SIZE);
+	}
 
 	if (!sgen_memgov_try_alloc_space (LOS_SECTION_SIZE, SPACE_LOS))
 		return NULL;
@@ -290,7 +311,7 @@ free_los_section_memory (LOSObject *obj, size_t size)
 		section->free_chunk_map [i] = 1;
 	}
 
-	add_free_chunk ((LOSFreeChunks*)obj, size);
+	add_free_chunk ((LOSFreeChunks*)SGEN_ALIGN_DOWN_TO ((mword)obj, LOS_CHUNK_SIZE), size);
 }
 
 void
@@ -313,7 +334,7 @@ sgen_los_free_object (LOSObject *obj)
 		int pagesize = mono_pagesize ();
 		size += sizeof (LOSObject);
 		size = SGEN_ALIGN_UP_TO (size, pagesize);
-		sgen_free_os_memory (obj, size, SGEN_ALLOC_HEAP);
+		sgen_free_os_memory ((gpointer)SGEN_ALIGN_DOWN_TO ((mword)obj, pagesize), size, SGEN_ALLOC_HEAP);
 		sgen_memgov_release_space (size, SPACE_LOS);
 	} else {
 		free_los_section_memory (obj, size + sizeof (LOSObject));
@@ -366,12 +387,13 @@ sgen_los_alloc_large_inner (GCVTable vtable, size_t size)
 	memset (obj, 0, size + sizeof (LOSObject));
 #else
 	if (size > LOS_SECTION_OBJECT_LIMIT) {
-		size_t alloc_size = size;
+		size_t obj_size = size + sizeof (LOSObject);
 		int pagesize = mono_pagesize ();
-		alloc_size += sizeof (LOSObject);
-		alloc_size = SGEN_ALIGN_UP_TO (alloc_size, pagesize);
+		size_t alloc_size = SGEN_ALIGN_UP_TO (obj_size, pagesize);
 		if (sgen_memgov_try_alloc_space (alloc_size, SPACE_LOS)) {
 			obj = (LOSObject *)sgen_alloc_os_memory (alloc_size, (SgenAllocFlags)(SGEN_ALLOC_HEAP | SGEN_ALLOC_ACTIVATE), NULL);
+			if (obj)
+				obj = randomize_los_object_start (obj, obj_size, alloc_size, pagesize);
 		}
 	} else {
 		obj = get_los_section_memory (size + sizeof (LOSObject));
@@ -696,9 +718,9 @@ sgen_los_mark_mod_union_card (GCObject *mono_obj, void **ptr)
 {
 	LOSObject *obj = sgen_los_header_for_object (mono_obj);
 	guint8 *mod_union = get_cardtable_mod_union_for_object (obj);
-	size_t offset = sgen_card_table_get_card_offset ((char*)ptr, (char*)sgen_card_table_align_pointer ((char*)obj));
+	/* The LOSObject structure is not represented within the card space */
+	size_t offset = sgen_card_table_get_card_offset ((char*)ptr, (char*)sgen_card_table_align_pointer((char*)mono_obj));
 	SGEN_ASSERT (0, mod_union, "FIXME: optionally allocate the mod union if it's not here and CAS it in.");
-	SGEN_ASSERT (0, (char*)obj == (char*)sgen_card_table_align_pointer ((char*)obj), "Why are LOS objects not card aligned?");
 	mod_union [offset] = 1;
 }
 

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -210,8 +210,7 @@ get_los_section_memory (size_t size)
 	LOSFreeChunks *free_chunks;
 	size_t num_chunks;
 
-	size += LOS_CHUNK_SIZE - 1;
-	size &= ~(LOS_CHUNK_SIZE - 1);
+	size = SGEN_ALIGN_UP_TO (size, LOS_CHUNK_SIZE);
 
 	num_chunks = size >> LOS_CHUNK_BITS;
 
@@ -269,8 +268,7 @@ free_los_section_memory (LOSObject *obj, size_t size)
 	LOSSection *section = LOS_SECTION_FOR_OBJ (obj);
 	size_t num_chunks, i, start_index;
 
-	size += LOS_CHUNK_SIZE - 1;
-	size &= ~(LOS_CHUNK_SIZE - 1);
+	size = SGEN_ALIGN_UP_TO (size, LOS_CHUNK_SIZE);
 
 	num_chunks = size >> LOS_CHUNK_BITS;
 
@@ -317,8 +315,7 @@ sgen_los_free_object (LOSObject *obj)
 		if (!pagesize)
 			pagesize = mono_pagesize ();
 		size += sizeof (LOSObject);
-		size += pagesize - 1;
-		size &= ~(pagesize - 1);
+		size = SGEN_ALIGN_UP_TO (size, pagesize);
 		sgen_free_os_memory (obj, size, SGEN_ALLOC_HEAP);
 		sgen_memgov_release_space (size, SPACE_LOS);
 	} else {
@@ -376,8 +373,7 @@ sgen_los_alloc_large_inner (GCVTable vtable, size_t size)
 		if (!pagesize)
 			pagesize = mono_pagesize ();
 		alloc_size += sizeof (LOSObject);
-		alloc_size += pagesize - 1;
-		alloc_size &= ~(pagesize - 1);
+		alloc_size = SGEN_ALIGN_UP_TO (alloc_size, pagesize);
 		if (sgen_memgov_try_alloc_space (alloc_size, SPACE_LOS)) {
 			obj = (LOSObject *)sgen_alloc_os_memory (alloc_size, (SgenAllocFlags)(SGEN_ALLOC_HEAP | SGEN_ALLOC_ACTIVATE), NULL);
 		}

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -293,8 +293,6 @@ free_los_section_memory (LOSObject *obj, size_t size)
 	add_free_chunk ((LOSFreeChunks*)obj, size);
 }
 
-static int pagesize;
-
 void
 sgen_los_free_object (LOSObject *obj)
 {
@@ -312,8 +310,7 @@ sgen_los_free_object (LOSObject *obj)
 	free (obj);
 #else
 	if (size > LOS_SECTION_OBJECT_LIMIT) {
-		if (!pagesize)
-			pagesize = mono_pagesize ();
+		int pagesize = mono_pagesize ();
 		size += sizeof (LOSObject);
 		size = SGEN_ALIGN_UP_TO (size, pagesize);
 		sgen_free_os_memory (obj, size, SGEN_ALLOC_HEAP);
@@ -370,8 +367,7 @@ sgen_los_alloc_large_inner (GCVTable vtable, size_t size)
 #else
 	if (size > LOS_SECTION_OBJECT_LIMIT) {
 		size_t alloc_size = size;
-		if (!pagesize)
-			pagesize = mono_pagesize ();
+		int pagesize = mono_pagesize ();
 		alloc_size += sizeof (LOSObject);
 		alloc_size = SGEN_ALIGN_UP_TO (alloc_size, pagesize);
 		if (sgen_memgov_try_alloc_space (alloc_size, SPACE_LOS)) {


### PR DESCRIPTION
We used to have all los objects aligned to the page_size. Since we allocate los objects in page_size chunks, we randomly slide the objects within this space to have them start at different offsets. This improves caching behavior, especially when traversing multiple los objects at the same time.