### PR TITLE
compute_class_bitmap: don't assert on generic var fields.

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -785,6 +785,8 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 			case MONO_TYPE_BOOLEAN:
 			case MONO_TYPE_CHAR:
 				break;
+			case MONO_TYPE_VAR:
+				break;
 			default:
 				g_error ("compute_class_bitmap: Invalid type %x for field %s:%s\n", type->type, mono_type_get_full_name (field->parent), field->name);
 				break;


### PR DESCRIPTION
Fixes [#37313](https://bugzilla.xamarin.com/show_bug.cgi?id=37313)

----

I'm not sure this is the right thing to do - Does it even make sense to compute a gc descriptor for a generic class like `Foo<>` (rather than some concrete instantiation of it: `Foo<Int32>`)?  Maybe we should just bail from `RuntimeHelpers.RunClassConstructor()` if called on a generic type?