### PR TITLE
[coop] Put MonoHandleArena stack in MonoThreadInfo

### DIFF
--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -18,6 +18,7 @@
 #include "class-internals.h"
 #include "threads-types.h"
 
+#include "mono/utils/mono-threads.h"
 #include "mono/utils/mono-threads-coop.h"
 
 G_BEGIN_DECLS
@@ -116,11 +117,44 @@ typedef struct _MonoHandleArena MonoHandleArena;
 gsize
 mono_handle_arena_size (gsize nb_handles);
 
+void
+mono_handle_arena_push (MonoHandleArena *arena, gsize nb_handles);
+
+void
+mono_handle_arena_pop (MonoHandleArena *arena, gsize nb_handles);
+
+void
+mono_handle_arena_init_thread (MonoThreadInfo* thread);
+
+void
+mono_handle_arena_deinit_thread (MonoThreadInfo* thread);
+
+
 MonoHandle
 mono_handle_new (MonoObject *rawptr);
 
 MonoHandle
 mono_handle_elevate (MonoHandle handle);
+
+#define MONO_HANDLE_ARENA_PUSH(nb_handles)	\
+	do {	\
+		gsize __arena_nb_handles = (nb_handles);	\
+		MonoHandleArena *__arena = (MonoHandleArena*) g_alloca (mono_handle_arena_size (__arena_nb_handles));	\
+		mono_handle_arena_push (__arena, __arena_nb_handles)
+
+#define MONO_HANDLE_ARENA_POP	\
+		mono_handle_arena_pop (__arena, __arena_nb_handles);	\
+	} while (0)
+
+#define MONO_HANDLE_ARENA_POP_RETURN(handle,ret)	\
+		(ret) = (handle)->obj;	\
+		mono_handle_arena_pop (__arena, __arena_nb_handles);	\
+	} while (0)
+
+#define MONO_HANDLE_ARENA_POP_RETURN_ELEVATE(handle,ret_handle)	\
+		*((MonoHandle**)(&(ret_handle))) = mono_handle_elevate ((MonoHandle*)(handle)); \
+		mono_handle_arena_pop(__arena, __arena_nb_handles);	\
+	} while (0)
 
 /* Some common handle types */
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -34,6 +34,7 @@
 #include "metadata/runtime.h"
 #include "metadata/sgen-bridge-internals.h"
 #include "metadata/gc-internals.h"
+#include "metadata/handle.h"
 #include "utils/mono-memory-model.h"
 #include "utils/mono-logger-internals.h"
 
@@ -2218,6 +2219,8 @@ sgen_client_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
 	memset (&info->client_info.regs, 0, sizeof (info->client_info.regs));
 #endif
 
+	mono_handle_arena_init_thread(&info->client_info.info);
+	
 	if (mono_gc_get_gc_callbacks ()->thread_attach_func)
 		info->client_info.runtime_data = mono_gc_get_gc_callbacks ()->thread_attach_func ();
 
@@ -2246,6 +2249,8 @@ sgen_client_thread_unregister (SgenThreadInfo *p)
 		mono_gc_get_gc_callbacks ()->thread_detach_func (p->client_info.runtime_data);
 		p->client_info.runtime_data = NULL;
 	}
+
+	mono_handle_arena_deinit_thread(&p->client_info.info);
 
 	binary_protocol_thread_unregister ((gpointer)tid);
 	SGEN_LOG (3, "unregister thread %p (%p)", p, (gpointer)tid);

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -254,8 +254,8 @@ assert_not_in_gc_critical_region(void)
 	CheckState *state = get_state();
 	if (state->in_gc_critical_region) {
 		MonoThreadInfo *cur = mono_thread_info_current();
-		state = mono_thread_info_current_state(cur);
-		assertion_fail("Expected GC Unsafe mode, but was in %s state", mono_thread_state_name(state));
+		int thread_state = mono_thread_info_current_state(cur);
+		assertion_fail("Expected GC Unsafe mode, but was in %s state", mono_thread_state_name(thread_state));
 	}
 }
 

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -81,7 +81,7 @@ translate_backtrace (gpointer native_trace[], int size)
 
 typedef struct {
 	GPtrArray *transitions;
-	gboolean in_gc_critical_region;
+	guint32 in_gc_critical_region;
 } CheckState;
 
 typedef struct {
@@ -235,7 +235,7 @@ void *
 critical_gc_region_begin(void)
 {
 	CheckState *state = get_state ();
-	state->in_gc_critical_region = TRUE;
+	state->in_gc_critical_region++;
 	return state;
 }
 
@@ -245,14 +245,14 @@ critical_gc_region_end(void* token)
 {
 	CheckState *state = get_state();
 	g_assert (state == token);
-	state->in_gc_critical_region = FALSE;
+	state->in_gc_critical_region--;
 }
 
 void
 assert_not_in_gc_critical_region(void)
 {
 	CheckState *state = get_state();
-	if (state->in_gc_critical_region) {
+	if (state->in_gc_critical_region > 0) {
 		MonoThreadInfo *cur = mono_thread_info_current();
 		int thread_state = mono_thread_info_current_state(cur);
 		assertion_fail("Expected GC Unsafe mode, but was in %s state", mono_thread_state_name(thread_state));

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -83,7 +83,7 @@ Functions that can be called from both coop or preept modes.
  * The GC critical region must only occur in unsafe mode.
  */
 #define MONO_PREPARE_GC_CRITICAL_REGION					\
-	MON_REQ_GC_UNSAFE_MODE						\
+	MONO_REQ_GC_UNSAFE_MODE						\
 	do {								\
 		void* __critical_gc_region_cookie = critical_gc_region_begin()
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -250,6 +250,9 @@ typedef struct {
 	void *jit_data;
 
 	MonoThreadInfoInterruptToken *interrupt_token;
+
+	/* HandleArenaThreadData for coop handles */
+	void *coop_handle_data;
 } MonoThreadInfo;
 
 typedef struct {


### PR DESCRIPTION
This is part of the coop handles work.

Put a pointer to the top of the `MonoHandleArena` stack in the `MonoThreadInfo`, and initialize (add as an SGen root) in `sgen_client_thread_register ()`.