### PR TITLE
[runtime] Use explicit loop checking to remove depth limitation of sequence point search.

### DIFF
--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -11,29 +11,45 @@
 #include "seq-points.h"
 
 static void
-collect_pred_seq_points (MonoBasicBlock *bb, MonoInst *ins, GSList **next, int depth)
+insert_pred_seq_point (MonoBasicBlock *in_bb, MonoInst *ins, GSList **next)
 {
-	int i;
-	MonoBasicBlock *in_bb;
 	GSList *l;
+	int src_index = in_bb->last_seq_point->backend.size;
+	int dst_index = ins->backend.size;
 
-	for (i = 0; i < bb->in_count; ++i) {
-		in_bb = bb->in_bb [i];
+	/* bb->in_bb might contain duplicates */
+	for (l = next [src_index]; l; l = l->next)
+		if (GPOINTER_TO_UINT (l->data) == dst_index)
+			break;
+	if (!l)
+		next [src_index] = g_slist_append (next [src_index], GUINT_TO_POINTER (dst_index));
+}
 
-		if (in_bb->last_seq_point) {
-			int src_index = in_bb->last_seq_point->backend.size;
-			int dst_index = ins->backend.size;
+static void
+collect_pred_seq_points (MonoBasicBlock *bb, MonoInst *ins, GSList **next, GHashTable *memoize)
+{
+	const gpointer MONO_SEQ_SEEN_LOOP = GINT_TO_POINTER(-1);
 
-			/* bb->in_bb might contain duplicates */
-			for (l = next [src_index]; l; l = l->next)
-				if (GPOINTER_TO_UINT (l->data) == dst_index)
-					break;
-			if (!l)
-				next [src_index] = g_slist_append (next [src_index], GUINT_TO_POINTER (dst_index));
+	for (int i = 0; i < bb->in_count; ++i) {
+		MonoBasicBlock *in_bb = bb->in_bb [i];
+		gpointer result = g_hash_table_lookup (memoize, in_bb);
+
+		if (result == MONO_SEQ_SEEN_LOOP) {
+			// We've looped or handled this before, exit early.
+			// No last sequence points to find.
+			continue;
+		} else if (in_bb->last_seq_point) {
+			// if last seq point, insert into next
+			insert_pred_seq_point (in_bb, ins, next);
 		} else {
-			/* Have to look at its predecessors */
-			if (depth < 5)
-				collect_pred_seq_points (in_bb, ins, next, depth + 1);
+			// Compute predecessors of in_bb
+
+			// Insert/remove sentinel into the memoize table to detect loops containing in_bb
+			// This works to ensure that we only have a basic block on the stack once
+			// at any given time
+			g_hash_table_insert (memoize, in_bb, MONO_SEQ_SEEN_LOOP);
+			collect_pred_seq_points (in_bb, ins, next, memoize);
+			g_hash_table_remove (memoize, in_bb);
 		}
 	}
 }
@@ -75,6 +91,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 		 * following it, this is needed to implement 'step over' in the debugger agent.
 		 */
 		next = g_new0 (GSList*, cfg->seq_points->len);
+		GHashTable *memoize = g_hash_table_new (NULL, NULL);
 		for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
 			bb_seq_points = g_slist_reverse (bb->seq_points);
 			last = NULL;
@@ -92,7 +109,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 					next [last->backend.size] = g_slist_append (next [last->backend.size], GUINT_TO_POINTER (ins->backend.size));
 				} else {
 					/* Link with the last bb in the previous bblocks */
-					collect_pred_seq_points (bb, ins, next, 0);
+					collect_pred_seq_points (bb, ins, next, memoize);
 				}
 
 				last = ins;
@@ -123,6 +140,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 				}
 			}
 		}
+		g_hash_table_destroy (memoize);
 
 		if (cfg->verbose_level > 2) {
 			printf ("\nSEQ POINT MAP: \n");


### PR DESCRIPTION
We were recursing without a proper check for loops, which resulted in needing to fix a depth. "Magic numbers" are problematic, and we saw cases where longer expressions could result in the disappearance of sequence points. This should fix this. It uses a hash table to check if the given basic block has been seen before in this traversal.

FIXES https://bugzilla.xamarin.com/show_bug.cgi?id=30930

In the indicated reproduction:

```
	//1. Breakpoint on line below
			if (arg is Class1 ||//2. Step over on this works correctly and gets to next IF(notice only 3 checks)
				arg is Class2 ||
				arg is Class3)
				Console.WriteLine("3");
			if (arg is Class1 ||//3. Step over on this doesn't work correctly and gets out of this method(notice 4 checks)
			    arg is Class2 ||
			    arg is Class3 ||
			    arg is Class4)
				Console.WriteLine("4");
			Console.WriteLine("5");//4. Step over IF above should end here
		}
```

where we previously stepped out of the method these are in, sdb now performs like so:

```
(sdb) c
Inferior process '0' ('127.0.0.1:12345') resumed
Inferior process '0' ('127.0.0.1:12345') suspended
#0 [0x00000066] cp765432.MainClass.Method1 at /Users/akyte/sdb/Test.cs:29
                        System.Diagnostics.Debugger.Break ();
(sdb) step
Inferior process '0' ('127.0.0.1:12345') resumed
Inferior process '0' ('127.0.0.1:12345') suspended
#0 [0x0000006B] cp765432.MainClass.Method1 at /Users/akyte/sdb/Test.cs:31
                        if (arg is Class1 ||//3. Step over on this doesn't work correctly and gets out of this method(notice 4 checks)
(sdb) step
Inferior process '0' ('127.0.0.1:12345') resumed
Inferior process '0' ('127.0.0.1:12345') suspended
#0 [0x000000A1] cp765432.MainClass.Method1 at /Users/akyte/sdb/Test.cs:36
                        Console.WriteLine("5");//4. Step over IF above should end here
```