### PR TITLE
[System] Fix extra head in config bug.

### DIFF
--- a/mcs/class/System.Configuration/System.Configuration/Configuration.cs
+++ b/mcs/class/System.Configuration/System.Configuration/Configuration.cs
@@ -133,8 +133,12 @@ namespace System.Configuration {
 				rootGroup.StreamName = streamName;
 			}
 			
-			if (streamName != null)
-				Load ();
+			try {
+				if (streamName != null)
+					Load ();
+			} catch (XmlException ex) {
+				throw new ConfigurationErrorsException (ex.Message, ex, streamName, 0);
+			}
 		}
 		
 		internal Configuration Parent {

--- a/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationManagerTest.cs
+++ b/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationManagerTest.cs
@@ -627,5 +627,23 @@ namespace MonoTests.System.Configuration {
 			Assert.AreEqual ("Server=(local);Initial Catalog=someDb;User Id=someUser;Password=somePassword;Application Name=someAppName;Min Pool Size=5;Max Pool Size=500;Connect Timeout=10;Connection Lifetime=29;",
 			                 connString);
 		}
+
+		[Test]
+		public void BadConfig ()
+		{
+			string xml = @" badXml";
+
+			var file = Path.Combine (tempFolder, "badConfig.config");
+			File.WriteAllText (file, xml);
+
+			try {
+				var fileMap = new ConfigurationFileMap (file);
+				var configuration = ConfigurationManager.OpenMappedMachineConfiguration (fileMap);
+				Assert.Fail ("Exception ConfigurationErrorsException was expected.");
+			} catch (ConfigurationErrorsException e) {
+				Assert.AreEqual (file, e.Filename);
+			}
+
+		}
 	}
 }

--- a/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
+++ b/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
@@ -578,6 +578,34 @@ namespace System.Configuration
 		private ExeConfigurationFileMap exeMapPrev = null;
 		private SettingsPropertyValueCollection values = null;
 
+		/// <remarks>
+		/// Hack to remove the XmlDeclaration that the XmlSerializer adds.
+		/// <br />
+		/// see <a href="https://github.com/mono/mono/pull/2273">Issue 2273</a> for details
+		/// </remarks>
+		private string StripXmlHeader (string serializedValue)
+		{
+			if (serializedValue == null)
+			{
+				return string.Empty;
+			}
+
+			XmlDocument doc = new XmlDocument ();
+			XmlElement valueXml = doc.CreateElement ("value");
+			valueXml.InnerXml = serializedValue;
+
+			foreach (XmlNode child in valueXml.ChildNodes) {
+				if (child.NodeType == XmlNodeType.XmlDeclaration) {
+					valueXml.RemoveChild (child);
+					break;
+				}
+			}
+
+			// InnerXml will give you well-formed XML that you could save as a separate document, and 
+			// InnerText will immediately give you a pure-text representation of this inner XML.
+			return valueXml.InnerXml;
+		}
+
 		private void SaveProperties (ExeConfigurationFileMap exeMap, SettingsPropertyValueCollection collection, ConfigurationUserLevel level, SettingsContext context, bool checkUserLevel)
 		{
 			Configuration config = ConfigurationManager.OpenMappedExeConfiguration (exeMap, level);
@@ -623,7 +651,7 @@ namespace System.Configuration
 					element.Value.ValueXml = new XmlDocument ().CreateElement ("value");
 				switch (value.Property.SerializeAs) {
 				case SettingsSerializeAs.Xml:
-					element.Value.ValueXml.InnerXml = (value.SerializedValue as string) ?? string.Empty;
+					element.Value.ValueXml.InnerXml = StripXmlHeader (value.SerializedValue as string);
 					break;
 				case SettingsSerializeAs.String:
 					element.Value.ValueXml.InnerText = value.SerializedValue as string;

--- a/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
+++ b/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
@@ -613,8 +613,6 @@ namespace System.Configuration
 			UserSettingsGroup userGroup = config.GetSectionGroup ("userSettings") as UserSettingsGroup;
 			bool isRoaming = (level == ConfigurationUserLevel.PerUserRoaming);
 
-#if true // my reimplementation
-
 			if (userGroup == null) {
 				userGroup = new UserSettingsGroup ();
 				config.SectionGroups.Add ("userSettings", userGroup);
@@ -665,43 +663,6 @@ namespace System.Configuration
 			}
 			if (hasChanges)
 				config.Save (ConfigurationSaveMode.Minimal, true);
-
-#else // original impl. - likely buggy to miss some properties to save
-
-			foreach (ConfigurationSection configSection in userGroup.Sections)
-			{
-				ClientSettingsSection userSection = configSection as ClientSettingsSection;
-				if (userSection != null)
-				{
-/*
-					userSection.Settings.Clear();
-
-					foreach (SettingsPropertyValue propertyValue in collection)
-					{
-						if (propertyValue.IsDirty)
-						{
-							SettingElement element = new SettingElement(propertyValue.Name, SettingsSerializeAs.String);
-							element.Value.ValueXml = new XmlDocument();
-							element.Value.ValueXml.InnerXml = (string)propertyValue.SerializedValue;
-							userSection.Settings.Add(element);
-						}
-					}
-*/
-					foreach (SettingElement element in userSection.Settings)
-					{
-						if (collection [element.Name] != null) {
-							if (collection [element.Name].Property.Attributes.Contains (typeof (SettingsManageabilityAttribute)) != isRoaming)
-								continue;
-
-							element.SerializeAs = SettingsSerializeAs.String;
-							element.Value.ValueXml.InnerXml = (string) collection [element.Name].SerializedValue;	///Value = XmlElement
-						}
-					}
- 
-				}
-			}
-			config.Save (ConfigurationSaveMode.Minimal, true);
-#endif
 		}
 
 		// NOTE: We should add here all the chars that are valid in a name of a class (Ecma-wise),


### PR DESCRIPTION
This includes #2273 fix and tests.

Had to fix another issue that caused XmlException to be thrown instead of ConfigurationErrorsException.
ConfigurationErrorsException was required to test #2273 properly because it contains the path to the corrupted xml that needs to be deleted for other tests to pass.

Fixes [#36388](https://bugzilla.xamarin.com/show_bug.cgi?id=36388)