### PR TITLE
[WIP][OSX] Use syscall for mmap and munmap on OSX. Fixes #19379

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2458,6 +2458,13 @@ if test "x$enable_big_arrays" = "xyes" ; then
 fi
 AC_MSG_RESULT($enable_big_arrays)
 
+AC_MSG_CHECKING([if OSX sandboxing is to be enabled])
+AC_ARG_ENABLE(osx-sandboxing,  [  --enable-osx-sandboxing	Restrict the runtime from using functionality disalowed by the OSX sandbox], enable_osx_sandbox=$enableval, enable_osx_sandbox=no)
+if test "x$enable_osx_sandbox" = "xyes" ; then
+	AC_DEFINE(ENABLE_OSX_SANDBOXING,1,[Restrict the runtime from using functionality disalowed by the OSX sandbox])
+fi
+AC_MSG_RESULT($enable_osx_sandbox)
+
 dnl **************
 dnl *** DTRACE ***
 dnl **************


### PR DESCRIPTION
The problem with #19379 is that instruments interpose mmap and munmap
with code that takes a lock and record arguments in a global table.

It doesn't go without saying that taking locks is not signal safe
meaning it deadlocks when using async suspend.

The first attempt at fixing this was using a suspend critical section,
but that didn't work as that lock is taken for malloc/free too, which
are called by the whole world outside of the runtime too.

The alternative is to completely bipass instruments here and ensure the
lock is not taken. This requires us doing the syscall directly.

The only concern with this is OSX sandboxed apps, to ensure this is not a problem,
I added a configure option that will disable it for XM to use.
