### PR TITLE
[monop] Fix NullReferenceException in monop

### DIFF
--- a/mcs/tools/monop/outline.cs
+++ b/mcs/tools/monop/outline.cs
@@ -696,7 +696,7 @@ public class Outline {
 		// automatically get the namespace imported by virtue of the
 		// namespace {} block.
 		//	
-		if (this.t.Namespace.StartsWith (t.Namespace + ".") || t.Namespace == this.t.Namespace)
+		if (this.t.Namespace != null && (this.t.Namespace.StartsWith (t.Namespace + ".") || t.Namespace == this.t.Namespace))
 			return type.Substring (t.Namespace.Length + 1);
 	
 		return type;


### PR DESCRIPTION
Fix a NullReferenceException in monop when printing a type name in a
namespace somewhere below System while working on a class which does not
have a namespace.

Test case:

    echo 'public class A { public void Foo (System.Collections.IEnumerable a) {} }' > test.cs
    mcs -target:library test.cs
    monop -a -r test.dll 

This will cause this exception:

    Unhandled Exception:
    System.NullReferenceException: Object reference not set to an instance of an object
      at Mono.CSharp.Outline.FormatType (System.Type t) [0x00000] in <filename unknown>:0 
    [...]
