### PR TITLE
[corlib] Disable Thread test that started failing after d5768a7f141e2a579cbca26f76c791c215f4aabf

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -387,6 +387,7 @@ namespace MonoTests.System.Threading
 		}
 
 		[Test]
+		[Category ("NotWorking")] // setting the priority of a Thread before it is started isn't implemented in Mono yet
 		public void TestPriority1()
 		{
 			if (is_win32 && is_mono)
@@ -396,10 +397,11 @@ namespace MonoTests.System.Threading
 			Thread TestThread = new Thread(new ThreadStart(test1.TestMethod));
 			try {
 				TestThread.Priority=ThreadPriority.BelowNormal;
-				ThreadPriority after = TestThread.Priority;
+				ThreadPriority before = TestThread.Priority;
+				Assert.AreEqual (ThreadPriority.BelowNormal, before, "#40 Unexpected priority before thread start: ");
 				TestThread.Start();
 				TestUtil.WaitForAlive (TestThread, "wait7");
-				ThreadPriority before = TestThread.Priority;
+				ThreadPriority after = TestThread.Priority;
 				Assert.AreEqual (before, after, "#41 Unexpected Priority Change: ");
 			} finally {
 #if MONO_FEATURE_THREAD_ABORT


### PR DESCRIPTION
Setting the priority before starting a Thread doesn't work right now as there's no handle to the native
thread at that point (the current implementation doesn't store the priority, it just tries setting it
on the native thread) so the test would remember the default 'Normal' priority instead of 'BelowNormal',
causing the test to fail later on.

Added an assert to verify that the thread priority can be set before starting and disable the test for now.

Note: variable names 'before' and 'after' were switched in the test, fixed those as well.