### PR TITLE
use native realpath() function

### DIFF
--- a/mcs/class/System/System.IO/KeventWatcher.cs
+++ b/mcs/class/System/System.IO/KeventWatcher.cs
@@ -300,11 +300,10 @@ namespace System.IO {
 			else
 				fullPathNoLastSlash = fsw.FullPath;
 				
-			// GetFilenameFromFd() returns the *realpath* which can be different than fsw.FullPath because symlinks.
+			// realpath() returns the *realpath* which can be different than fsw.FullPath because symlinks.
 			// If so, introduce a fixup step.
-			int fd = open (fullPathNoLastSlash, O_EVTONLY, 0);
-			var resolvedFullPath = GetFilenameFromFd (fd);
-			close (fd);
+			var sb = new StringBuilder (__DARWIN_MAXPATHLEN);
+			var resolvedFullPath = (realpath(fsw.FullPath, sb) == IntPtr.Zero) ? "" : sb.ToString();
 
 			if (resolvedFullPath != fullPathNoLastSlash)
 				fixupPath = resolvedFullPath;
@@ -667,6 +666,9 @@ namespace System.IO {
 
 		[DllImport ("libc", EntryPoint="fcntl", CharSet=CharSet.Auto, SetLastError=true)]
 		static extern int fcntl (int file_names_by_descriptor, int cmd, StringBuilder sb);
+
+		[DllImport ("libc", CharSet=CharSet.Auto, SetLastError=true)]
+		static extern IntPtr realpath (string pathname, StringBuilder sb);
 
 		[DllImport ("libc")]
 		extern static int open (string path, int flags, int mode_t);

--- a/mcs/class/System/System.IO/KeventWatcher.cs
+++ b/mcs/class/System/System.IO/KeventWatcher.cs
@@ -303,7 +303,11 @@ namespace System.IO {
 			// realpath() returns the *realpath* which can be different than fsw.FullPath because symlinks.
 			// If so, introduce a fixup step.
 			var sb = new StringBuilder (__DARWIN_MAXPATHLEN);
-			var resolvedFullPath = (realpath(fsw.FullPath, sb) == IntPtr.Zero) ? "" : sb.ToString();
+			if (realpath(fsw.FullPath, sb) == IntPtr.Zero) {
+				var errMsg = String.Format ("realpath({0}) failed, error code = '{1}'", fsw.FullPath, Marshal.GetLastWin32Error ());
+				throw new IOException (errMsg);
+			}
+			var resolvedFullPath = sb.ToString();
 
 			if (resolvedFullPath != fullPathNoLastSlash)
 				fixupPath = resolvedFullPath;


### PR DESCRIPTION
Instead of opening a file for the sole purpose of calling
F_GETPATH on the resulting descriptor, we can just use the
native realpath() function; as a side benefit, this also works
on *BSD where F_GETPATH isn't supported.