### PR TITLE
[reflection] Correct ReflectedType for generic methods

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoGenericMethod.cs
+++ b/mcs/class/corlib/System.Reflection/MonoGenericMethod.cs
@@ -45,10 +45,6 @@ namespace System.Reflection
 			throw new InvalidOperationException ();
 		}
 
-		public override extern Type ReflectedType {
-			[MethodImplAttribute(MethodImplOptions.InternalCall)]
-			get;
-		}
 	}
 
 	[Serializable]
@@ -59,11 +55,6 @@ namespace System.Reflection
 		{
 			// this should not be used
 			throw new InvalidOperationException ();
-		}
-
-		public override extern Type ReflectedType {
-			[MethodImplAttribute(MethodImplOptions.InternalCall)]
-			get;
 		}
 	}
 }

--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -308,6 +308,9 @@ namespace MonoTests.System.Reflection
 			public override void f2 () { }
 		}
 
+		class DerivedFromGenericBase : GenericBase<int, int> {
+		}
+
 		[Test]
 		public void GetBaseDefinition_OpenConstructedBaseType () // 36305
 		{
@@ -822,6 +825,33 @@ namespace MonoTests.System.Reflection
 		{
 			var m = GetType ().GetMethod ("Bug12856");
 			Assert.AreEqual ("System.Nullable`1[System.Int32] Bug12856()", m.ToString (), "#1");
+		}
+
+		[Test]
+		public void GetReflectedType () // #12205
+		{
+			// public method declared in base type, queried from a derived type
+			MethodInfo mi = typeof (TestInheritedMethodB).GetMethod ("TestMethod2");
+			Assert.AreEqual (mi.ReflectedType, typeof (TestInheritedMethodB), "#1");
+
+			// public method declared in a generic class,
+			// queried from a non-generic class derived
+			// from an instantiation of the generic class.
+			mi = typeof (DerivedFromGenericBase).GetMethod ("f2");
+			Assert.AreEqual (mi.ReflectedType, typeof (DerivedFromGenericBase), "#2");
+
+			// public method declared in a generic class,
+			// queried from the generic type defintion of
+			// a generic derived class.
+			mi = typeof (GenericMid<,>).GetMethod ("f2");
+			Assert.AreEqual (mi.ReflectedType, typeof (GenericMid<,>), "#3");
+
+			// public method declared in a generic class,
+			// queried from an instantiation of a generic
+			// derived class.
+			mi = typeof (GenericMid<int,int>).GetMethod ("f2");
+			Assert.AreEqual (mi.ReflectedType, typeof (GenericMid<int,int>), "#4");
+
 		}
 
 #if !MONOTOUCH

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -590,16 +590,9 @@ ICALL(MFIELD_6, "ResolveType", ves_icall_MonoField_ResolveType)
 ICALL(MFIELD_4, "SetValueInternal", ves_icall_MonoField_SetValueInternal)
 ICALL(MFIELD_7, "get_core_clr_security_level", ves_icall_MonoField_get_core_clr_security_level)
 
-ICALL_TYPE(MGENCM, "System.Reflection.MonoGenericCMethod", MGENCM_1)
-ICALL(MGENCM_1, "get_ReflectedType", ves_icall_MonoGenericMethod_get_ReflectedType)
-
 ICALL_TYPE(MGENCL, "System.Reflection.MonoGenericClass", MGENCL_5)
 ICALL(MGENCL_5, "initialize", mono_reflection_generic_class_initialize)
 ICALL(MGENCL_6, "register_with_runtime", mono_reflection_register_with_runtime)
-
-/* note this is the same as above: unify */
-ICALL_TYPE(MGENM, "System.Reflection.MonoGenericMethod", MGENM_1)
-ICALL(MGENM_1, "get_ReflectedType", ves_icall_MonoGenericMethod_get_ReflectedType)
 
 ICALL_TYPE(MMETH, "System.Reflection.MonoMethod", MMETH_2)
 ICALL(MMETH_2, "GetGenericArguments", ves_icall_MonoMethod_GetGenericArguments)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1927,14 +1927,6 @@ ves_icall_MonoField_ResolveType (MonoReflectionField *ref_field)
 	return mono_type_get_object (mono_object_domain (ref_field), type);
 }
 
-ICALL_EXPORT MonoReflectionType*
-ves_icall_MonoGenericMethod_get_ReflectedType (MonoReflectionGenericMethod *rmethod)
-{
-	MonoMethod *method = rmethod->method.method;
-
-	return mono_type_get_object (mono_object_domain (rmethod), &method->klass->byval_arg);
-}
-
 /* From MonoProperty.cs */
 typedef enum {
 	PInfo_Attributes = 1,

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -6816,7 +6816,8 @@ mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refcl
 	if (method->is_inflated) {
 		MonoReflectionGenericMethod *gret;
 
-		refclass = method->klass;
+		if (!refclass)
+			refclass = method->klass;
 		CHECK_OBJECT (MonoReflectionMethod *, method, refclass);
 		if ((*method->name == '.') && (!strcmp (method->name, ".ctor") || !strcmp (method->name, ".cctor"))) {
 			if (!System_Reflection_MonoGenericCMethod)


### PR DESCRIPTION
Return the correct reflected type for generic methods.

Remove unnecessary override, and kill the icall.

Fixes [#12205](https://bugzilla.xamarin.com/show_bug.cgi?id=12205)