### PR TITLE
[mcs] Accept and ignore command line args supported by csc ..

### DIFF
--- a/mcs/mcs/settings.cs
+++ b/mcs/mcs/settings.cs
@@ -1210,6 +1210,14 @@ namespace Mono.CSharp {
 				settings.RuntimeMetadataVersion = value;
 				return ParseResult.Success;
 
+			// csc options that we don't support
+			case "/utf8output":
+			case "/subsystemversion":
+			case "/highentropyva":
+			case "/highentropyva+":
+			case "/highentropyva-":
+				return ParseResult.Success;
+
 			default:
 				return ParseResult.UnknownOption;
 			}


### PR DESCRIPTION
.. that we don't support:

	/utf8output
	/subsystemversion
	/highentropyva
	/highentropyva+
	/highentropyva-