### PR TITLE
Revert "[bcl] Fix System.Net.HttpWebRequestTest.GetRequestStream hang"

### DIFF
--- a/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SocketResponder.cs
+++ b/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SocketResponder.cs
@@ -96,13 +96,6 @@ namespace MonoTests.System.Web.Services.Protocols
 				if (tcpListener != null) {
 					tcpListener.Stop ();
 					tcpListener = null;
-#if MONO_FEATURE_THREAD_ABORT
-					listenThread.Abort ();
-#else
-					listenThread.Interrupt ();
-#endif
-					listenThread.Join ();
-					listenThread = null;
 				}
 			}
 		}

--- a/mcs/class/System/Test/System.Net/SocketResponder.cs
+++ b/mcs/class/System/Test/System.Net/SocketResponder.cs
@@ -130,10 +130,6 @@ namespace MonoTests.System.Net
 					Console.WriteLine (ex);
 					if (_state != STATE_STOPPED)
 						throw;
-#if !MONO_FEATURE_THREAD_ABORT
-				} catch (ThreadInterruptedException) {
-					break;
-#endif
 #if MOBILE
 				} catch (InvalidOperationException ex) {
 					// This breaks some tests running on Android. The problem is that the stack trace
@@ -143,15 +139,7 @@ namespace MonoTests.System.Net
 					Console.WriteLine (ex);
 #endif
 				} finally {
-#if MONO_FEATURE_THREAD_ABORT
 					Thread.Sleep (500);
-#else
-					try {
-						Thread.Sleep (500);
-					} catch (ThreadInterruptedException) {
-						// nothing to do
-					}
-#endif
 					if (listenSocket != null)
 						listenSocket.Close ();
 				}

--- a/mcs/class/System/Test/System.Net/SocketResponder.cs
+++ b/mcs/class/System/Test/System.Net/SocketResponder.cs
@@ -105,13 +105,6 @@ namespace MonoTests.System.Net
 					tcpListener = null;
 					if (listenSocket != null)
 						listenSocket.Close ();
-#if MONO_FEATURE_THREAD_ABORT
-					listenThread.Abort ();
-#else
-					listenThread.Interrupt ();
-#endif
-					listenThread.Join ();
-					listenThread = null;
 					Thread.Sleep (50);
 				}
 			}


### PR DESCRIPTION
The Abort () call is problematic on many platforms and is no longer necessary as we properly close the listening socket since 1103abf3830131ba2a1deabc133e8d27402302c7.