### PR TITLE
[System] Ignore ReceiveIPv6() UdpClient test when IPv6 is not available

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/UdpClientTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/UdpClientTest.cs
@@ -1068,6 +1068,9 @@ namespace MonoTests.System.Net.Sockets {
 		[Test] // #6057
 		public void ReceiveIPv6 ()
 		{
+			if (!Socket.OSSupportsIPv6)
+				Assert.Ignore ("IPv6 not enabled.");
+
 			int PORT = 9997;
 			using(var udpClient = new UdpClient (PORT, AddressFamily.InterNetworkV6))
 			using(var udpClient2 = new UdpClient (PORT+1, AddressFamily.InterNetworkV6))


### PR DESCRIPTION
The test hangs on Jenkins otherwise.

/cc @esdrubal 

@monojenkins merge if tests pass