### PR TITLE
[runtime] Make VolatileRead/VolatileWrite semantics compatible with MS.NET.

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2346,64 +2346,64 @@ void mono_thread_stop (MonoThread *thread)
 gint8
 ves_icall_System_Threading_Thread_VolatileRead1 (void *ptr)
 {
-	gint8 tmp;
-	mono_atomic_load_acquire (tmp, gint8, (volatile gint8 *) ptr);
+	gint8 tmp = *(volatile gint8 *)ptr;
+	mono_memory_barrier ();
 	return tmp;
 }
 
 gint16
 ves_icall_System_Threading_Thread_VolatileRead2 (void *ptr)
 {
-	gint16 tmp;
-	mono_atomic_load_acquire (tmp, gint16, (volatile gint16 *) ptr);
+	gint16 tmp = *(volatile gint16 *)ptr;
+	mono_memory_barrier ();
 	return tmp;
 }
 
 gint32
 ves_icall_System_Threading_Thread_VolatileRead4 (void *ptr)
 {
-	gint32 tmp;
-	mono_atomic_load_acquire (tmp, gint32, (volatile gint32 *) ptr);
+	gint32 tmp = *(volatile gint32 *)ptr;
+	mono_memory_barrier ();
 	return tmp;
 }
 
 gint64
 ves_icall_System_Threading_Thread_VolatileRead8 (void *ptr)
 {
-	gint64 tmp;
-	mono_atomic_load_acquire (tmp, gint64, (volatile gint64 *) ptr);
+	gint64 tmp = *(volatile gint64 *)ptr;
+	mono_memory_barrier ();
 	return tmp;
 }
 
 void *
 ves_icall_System_Threading_Thread_VolatileReadIntPtr (void *ptr)
 {
-	volatile void *tmp;
-	mono_atomic_load_acquire (tmp, volatile void *, (volatile void **) ptr);
+	volatile void *tmp = *(volatile void **)ptr;
+	mono_memory_barrier ();
 	return (void *) tmp;
 }
 
 void *
 ves_icall_System_Threading_Thread_VolatileReadObject (void *ptr)
 {
-	volatile MonoObject *tmp;
-	mono_atomic_load_acquire (tmp, volatile MonoObject *, (volatile MonoObject **) ptr);
+	volatile MonoObject *tmp = *(volatile MonoObject **)ptr;
+	mono_memory_barrier ();
 	return (MonoObject *) tmp;
 }
 
 double
 ves_icall_System_Threading_Thread_VolatileReadDouble (void *ptr)
 {
-	double tmp;
-	mono_atomic_load_acquire (tmp, double, (volatile double *) ptr);
+	double tmp = *(volatile double *)ptr;
+	mono_memory_barrier ();
 	return tmp;
 }
 
 float
 ves_icall_System_Threading_Thread_VolatileReadFloat (void *ptr)
 {
-	float tmp;
-	mono_atomic_load_acquire (tmp, float, (volatile float *) ptr);
+	float tmp = *(volatile float *)ptr;
+	mono_memory_barrier ();
 	return tmp;
 }
 
@@ -2485,49 +2485,57 @@ ves_icall_System_Threading_Volatile_Read_T (void *ptr)
 void
 ves_icall_System_Threading_Thread_VolatileWrite1 (void *ptr, gint8 value)
 {
-	mono_atomic_store_release ((volatile gint8 *) ptr, value);
+	mono_memory_barrier ();
+	*(volatile gint8 *)ptr = value;
 }
 
 void
 ves_icall_System_Threading_Thread_VolatileWrite2 (void *ptr, gint16 value)
 {
-	mono_atomic_store_release ((volatile gint16 *) ptr, value);
+	mono_memory_barrier ();
+	*(volatile gint16 *)ptr = value;
 }
 
 void
 ves_icall_System_Threading_Thread_VolatileWrite4 (void *ptr, gint32 value)
 {
-	mono_atomic_store_release ((volatile gint32 *) ptr, value);
+	mono_memory_barrier ();
+	*(volatile gint32 *)ptr = value;
 }
 
 void
 ves_icall_System_Threading_Thread_VolatileWrite8 (void *ptr, gint64 value)
 {
-	mono_atomic_store_release ((volatile gint64 *) ptr, value);
+	mono_memory_barrier ();
+	*(volatile gint64 *)ptr = value;
 }
 
 void
 ves_icall_System_Threading_Thread_VolatileWriteIntPtr (void *ptr, void *value)
 {
-	mono_atomic_store_release ((volatile void **) ptr, value);
+	mono_memory_barrier ();
+	*(volatile void **)ptr = value;
 }
 
 void
 ves_icall_System_Threading_Thread_VolatileWriteObject (void *ptr, MonoObject *value)
 {
-	mono_gc_wbarrier_generic_store_atomic (ptr, value);
+	mono_memory_barrier ();
+	mono_gc_wbarrier_generic_store (ptr, value);
 }
 
 void
 ves_icall_System_Threading_Thread_VolatileWriteDouble (void *ptr, double value)
 {
-	mono_atomic_store_release ((volatile double *) ptr, value);
+	mono_memory_barrier ();
+	*(volatile double *)ptr = value;
 }
 
 void
 ves_icall_System_Threading_Thread_VolatileWriteFloat (void *ptr, float value)
 {
-	mono_atomic_store_release ((volatile float *) ptr, value);
+	mono_memory_barrier ();
+	*(volatile float *)ptr = value;
 }
 
 void

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6160,7 +6160,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				if (opcode == OP_LOADI8_MEMBASE)
 					ins = mono_decompose_opcode (cfg, ins);
 
-				emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_ACQ);
+				emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_SEQ);
 
 				return ins;
 			}
@@ -6184,7 +6184,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				opcode = OP_STORE_MEMBASE_REG;
 
 			if (opcode) {
-				emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
+				emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_SEQ);
 
 				MONO_INST_NEW (cfg, ins, opcode);
 				ins->sreg1 = args [1]->dreg;


### PR DESCRIPTION
This changes our implementation of `Thread.VolatileRead ()` and `Thread.VolatileWrite ()` to be compatible with MS.NET in that we use full memory barriers instead of acquire/release barriers (even though the latter is sufficient to be spec-compliant).

I propose this change because we've been importing huge amounts of reference source code over the past year and this trend will probably continue. I don't know that we generally audit reference source code for being compatible with our implementation of these methods. We would have to check every single use of `volatile` variables. This seems rather laborious as these are used *all over the place* in the reference source code.

There's also the problem that any amount of user code in the wild could be relying on these methods to have the semantics that they do on MS.NET. Such code could break in subtle ways regardless of our reference source import effort. It could also break *because* of our reference source importing because uses of `volatile` have visible effects outside of the framework code in many cases (though it's of course arguable whether users should be relying on it, ever).

I'm not a huge fan of doing this as it does make these methods have a (slightly) worse effect on performance of surrounding code. I think it'll save us and our users a lot of headaches, though. It's also worth mentioning that the recommended methods to use these days are the ones on `System.Threading.Volatile` which actually make sense and which are unaffected by this change.