### PR TITLE
[System.Drawing] Include new .NET4.5 attributes (OWIN)

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.dll.sources
+++ b/mcs/class/System.Drawing/System.Drawing.dll.sources
@@ -2,6 +2,8 @@ Assembly/AssemblyInfo.cs
 ../../build/common/Consts.cs
 ../../build/common/Locale.cs
 System.Drawing/Bitmap.cs
+System.Drawing/BitmapSuffixInSameAssemblyAttribute.cs
+System.Drawing/BitmapSuffixInSatelliteAssemblyAttribute.cs
 System.Drawing/Brush.cs
 System.Drawing/Brushes.cs
 System.Drawing/BufferedGraphics.cs

--- a/mcs/class/System.Drawing/System.Drawing/BitmapSuffixInSameAssemblyAttribute.cs
+++ b/mcs/class/System.Drawing/System.Drawing/BitmapSuffixInSameAssemblyAttribute.cs
@@ -1,0 +1,48 @@
+//
+// System.Drawing.BitmapSuffixInSameAssemblyAttribute.cs
+//
+// Authors:
+//   Andrés G. Aragoneses (knocte@gmail.com)
+//
+// Copyright (C) 2016 Andrés G. Aragoneses
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+
+namespace System.Drawing
+{
+	[AttributeUsage (AttributeTargets.Assembly)]
+	public class BitmapSuffixInSameAssemblyAttribute : Attribute {
+
+		public BitmapSuffixInSameAssemblyAttribute ()
+			: base ()
+		{
+		}
+
+		public virtual object TypeId {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+	}
+}

--- a/mcs/class/System.Drawing/System.Drawing/BitmapSuffixInSatelliteAssemblyAttribute.cs
+++ b/mcs/class/System.Drawing/System.Drawing/BitmapSuffixInSatelliteAssemblyAttribute.cs
@@ -1,0 +1,48 @@
+//
+// System.Drawing.BitmapSuffixInSatelliteAssemblyAttribute.cs
+//
+// Authors:
+//   Andrés G. Aragoneses (knocte@gmail.com)
+//
+// Copyright (C) 2016 Andrés G. Aragoneses
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel;
+
+namespace System.Drawing
+{
+	[AttributeUsage (AttributeTargets.Assembly)]
+	public class BitmapSuffixInSatelliteAssemblyAttribute : Attribute {
+
+		public BitmapSuffixInSatelliteAssemblyAttribute ()
+			: base ()
+		{
+		}
+
+		public virtual object TypeId {
+			get {
+				throw new NotImplementedException ();
+			}
+		}
+	}
+}


### PR DESCRIPTION
This stubs should fix this OWIN issue brought up in StackOverflow:
http://stackoverflow.com/questions/34751771/system-drawing-bitmapsuffixinsameassemblyattribute-missing-in-mono

Docs:
* https://msdn.microsoft.com/en-us/library/system.drawing.bitmapsuffixinsameassemblyattribute%28v=vs.110%29.aspx
* https://msdn.microsoft.com/en-us/library/system.drawing.bitmapsuffixinsatelliteassemblyattribute%28v=vs.110%29.aspx