### PR TITLE
[mono] test_op_il_seq_point test should use a temp file for NUnit results

### DIFF
--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -16,7 +16,7 @@ tmp_file () {
 }
 
 clean_aot () {
-	rm -rf *.exe..so *.exe.dylib *.exe.dylib.dSYM
+	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM
 }
 
 # The test compares the generated native code size between a compilation with and without seq points.
@@ -89,7 +89,7 @@ while read line; do
 	fi
 done < $TMP_FILE
 
-TESTRESULT_FILE=TestResult-op_il_seq_point.xml
+TESTRESULT_FILE=TestResult-op_il_seq_point.tmp
 
 echo -n "              <test-case name=\"MonoTests.op_il_seq_point.${TEST_FILE}${USE_AOT}\" executed=\"True\" time=\"0\" asserts=\"0\" success=\"" >> $TESTRESULT_FILE
 

--- a/mono/mini/test_op_il_seq_point_headerfooter.sh
+++ b/mono/mini/test_op_il_seq_point_headerfooter.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TESTRESULT_FILE=TestResult-op_il_seq_point.xml
+TESTRESULT_FILE=TestResult-op_il_seq_point.tmp
 TOTAL=$(grep -c "<test-case" $TESTRESULT_FILE)
 FAILURES=$(grep -c "<failure>" $TESTRESULT_FILE)
 if [ "$FAILURES" -eq "0" ]
@@ -36,6 +36,5 @@ echo "        <results>" >> $TESTRESULT_FILE.header
 echo "          <test-suite name=\"op_il_seq_point\" success=\"${PASS}\" time=\"0\" asserts=\"0\">" >> $TESTRESULT_FILE.header
 echo "            <results>" >> $TESTRESULT_FILE.header
 
-cat $TESTRESULT_FILE.header $TESTRESULT_FILE > $TESTRESULT_FILE.new
-mv $TESTRESULT_FILE.new $TESTRESULT_FILE
-rm -f $TESTRESULT_FILE.header
+cat $TESTRESULT_FILE.header $TESTRESULT_FILE > $(basename $TESTRESULT_FILE .tmp).xml
+rm -f $TESTRESULT_FILE.header $TESTRESULT_FILE


### PR DESCRIPTION
We were seeing red builds on Jenkins because the NUnit xml was malformed when something bad happened during the test_op_il_seq_point tests and Jenkins couldn't parse it.

To fix this, write the results into a temp file and only rename to .xml at the end when everything worked.

Additionally, fixed a small typo in cleaning the .so files.

@monojenkins merge