### PR TITLE
[handle] Add arena marks to support mono_raise_exception with coop handles

### DIFF
--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -51,6 +51,19 @@ void
 mono_handle_arena_stack_pop (MonoHandleArena **arena_stack, MonoHandleArena *arena);
 
 void
+mono_handle_arena_set_unwind_mark (MonoHandleArena *arena);
+
+void
+mono_handle_arena_clear_unwind_mark (MonoHandleArena *arena);
+
+gboolean
+mono_handle_arena_unwind_mark_is_set (MonoHandleArena *arena);
+
+void
+mono_handle_arena_stack_unwind_to_mark_and_clear (MonoHandleArena **arena_stack);
+
+
+void
 mono_handle_arena_init (MonoHandleArena **arena_stack);
 
 void
@@ -61,6 +74,7 @@ mono_handle_arena_current (void);
 
 MonoHandleArena**
 mono_handle_arena_current_addr (void);
+
 
 #define MONO_HANDLE_ARENA_PUSH()	\
 	do {	\
@@ -81,6 +95,15 @@ mono_handle_arena_current_addr (void);
 		*((MonoHandle**)(&(ret_handle))) = mono_handle_elevate ((MonoHandle*)(handle)); \
 		mono_handle_arena_stack_pop(__arena_stack, __arena);	\
 	} while (0)
+
+
+#define MONO_ICALL_ENTER () \
+	do { mono_handle_arena_set_unwind_mark (mono_handle_arena_current ()); } while (0)
+
+
+#define MONO_ICALL_LEAVE () \
+	do { mono_handle_arena_clear_unwind_mark (mono_handle_arena_current ()); } while (0)
+
 
 static inline MonoHandle
 mono_handle_new (MonoObject *obj)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5953,6 +5953,11 @@ mono_raise_exception (MonoException *ex)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	/* unwind the handle arena stack to remove handle arenas that
+	 * we added since we most recently transitioned from managed
+	 * to native. */
+	mono_handle_arena_stack_unwind_to_mark_and_clear (mono_handle_arena_current_addr ());
+
 	/*
 	 * NOTE: Do NOT annotate this function with G_GNUC_NORETURN, since
 	 * that will cause gcc to omit the function epilog, causing problems when

--- a/mono/unit-tests/test-mono-handle.c
+++ b/mono/unit-tests/test-mono-handle.c
@@ -38,12 +38,64 @@ test2_arena_push_pop ()
 	g_free (new_arena1);
 }
 
+static void
+test3_arena_mark_unwind ()
+{
+	MonoHandleArena *top = NULL;
+
+	// check that these don't crash when the stack is empty.
+	mono_handle_arena_set_unwind_mark (top);
+	mono_handle_arena_clear_unwind_mark (top);
+	g_assert (top == NULL);
+
+	mono_handle_arena_stack_unwind_to_mark_and_clear (&top);
+	g_assert (top == NULL);
+
+	MonoHandleArena *new_arena1 = g_malloc0 (mono_handle_arena_size ());
+	mono_handle_arena_stack_push (&top, new_arena1);
+
+	mono_handle_arena_set_unwind_mark (new_arena1);
+
+	g_assert (mono_handle_arena_unwind_mark_is_set (new_arena1));
+
+	//top: [arena1 marked]NULL
+	mono_handle_arena_stack_unwind_to_mark_and_clear (&top);
+	//top: [arena1]NULL
+
+	g_assert (top == new_arena1);
+	g_assert (!mono_handle_arena_unwind_mark_is_set (new_arena1));
+
+	MonoHandleArena *new_arena2 = g_malloc0 (mono_handle_arena_size ());
+	mono_handle_arena_stack_push (&top, new_arena2);
+	mono_handle_arena_set_unwind_mark (new_arena2);
+	MonoHandleArena *new_arena3 = g_malloc0 (mono_handle_arena_size ());
+	mono_handle_arena_stack_push (&top, new_arena3);
+	mono_handle_arena_set_unwind_mark (new_arena3);
+	MonoHandleArena *new_arena4 = g_malloc0 (mono_handle_arena_size ());
+	mono_handle_arena_stack_push (&top, new_arena4);
+
+	// top: [arena4][arena3 marked][arena2 marked][arena1]NULL
+	mono_handle_arena_stack_unwind_to_mark_and_clear (&top);
+	// top: [arena3][arena2 marked][arena1]NULL
+	g_assert (top == new_arena3);
+	g_assert (!mono_handle_arena_unwind_mark_is_set (new_arena3));
+	g_assert (mono_handle_arena_unwind_mark_is_set (new_arena2));
+
+	mono_handle_arena_stack_unwind_to_mark_and_clear (&top);
+	// top: [arena2][arena1]NULL
+	g_assert (top == new_arena2);
+	g_assert (!mono_handle_arena_unwind_mark_is_set (new_arena2));
+
+	mono_handle_arena_stack_unwind_to_mark_and_clear (&top);
+	g_assert (top == NULL);
+}
 
 
 int
 main (int argc, const char* argv[])
 {
 	test2_arena_push_pop ();
+	test3_arena_mark_unwind ();
 
 	return 0;
 }


### PR DESCRIPTION
The idea is that when we enter an icall from managed to native,
we put an unwind mark on the current top of the arena stack.
If we return normally, we clear the mark.
If an exception occurs, we unwind the stack until the current mark.

That way, handles that were used before the exception occurred are
cleaned up before we begin propagating the exception.

The easiest way to make use of unwind marks is using the
`MONO_ICALL_ENTER ()` and `MONO_ICALL_LEAVE ()` macros:

```c
void
my_icall (...)
{
	MONO_ICALL_ENTER ();

	MONO_HANDLE_ARENA_PUSH ();
	...
	MONO_HANDLE_ARENA_POP ();

	MONO_ICALL_LEAVE ();
}
```