### PR TITLE
Fix certmgr when a unicode encoded null is used as password

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/PKCS12.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/PKCS12.cs
@@ -383,8 +383,13 @@ namespace Mono.Security.X509 {
 
 				byte[] authSafeData = authSafe.Content [0].Value;
 				byte[] calculatedMac = MAC (_password, macSalt.Value, _iterations, authSafeData);
-				if (!Compare (macValue, calculatedMac))
-					throw new CryptographicException ("Invalid MAC - file may have been tampered!");
+				if (!Compare (macValue, calculatedMac)) {
+					byte[] nullPassword = {0, 0};
+					calculatedMac = MAC(nullPassword, macSalt.Value, _iterations, authSafeData);
+					if (!Compare (macValue, calculatedMac))
+						throw new CryptographicException ("Invalid MAC - file may have been tampe red!");
+					_password = nullPassword;
+				}
 			}
 
 			// we now returns to our original presentation - PFX


### PR DESCRIPTION
If no password is specified when creating a cert/key in a unicode locale then a unicode "null" must be tried when calculating the MAC and extracting the key etc.  This fixes #35064.