### PR TITLE
Replace the old DEBUG messages with calls to mono_trace.

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -888,7 +888,9 @@ environment variable to limit the extent of the messages you get:
 If set, the log mask is changed to the set value. Possible values are
 "asm" (assembly loader), "type", "dll" (native library loader), "gc"
 (garbage collector), "cfg" (config file loader), "aot" (precompiler),
-"security" (e.g. Moonlight CoreCLR support) and "all". 
+"security" (e.g. Moonlight CoreCLR support), "threadpool" (thread pool generic), 
+"io-threadpool" (thread pool I/O), "io-layer" (I/O layer - sockets, handles, shared memory etc) 
+and "all". 
 The default value is "all". Changing the mask value allows you to display only 
 messages for a certain component. You can use multiple masks by comma 
 separating them. For example to see config file messages and assembly loader

--- a/mono/io-layer/events.c
+++ b/mono/io-layer/events.c
@@ -16,13 +16,9 @@
 #include <mono/io-layer/wapi-private.h>
 #include <mono/io-layer/handles-private.h>
 #include <mono/io-layer/event-private.h>
+#include <mono/io-layer/io-trace.h>
 #include <mono/utils/mono-once.h>
-
-#if 0
-#define DEBUG(...) g_message(__VA_ARGS__)
-#else
-#define DEBUG(...)
-#endif
+#include <mono/utils/mono-logger-internals.h>
 
 static void event_signal(gpointer handle);
 static gboolean event_own (gpointer handle);
@@ -111,7 +107,7 @@ static gboolean event_own (gpointer handle)
 		return (FALSE);
 	}
 	
-	DEBUG("%s: owning event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: owning event handle %p", __func__, handle);
 
 	if(event_handle->manual==FALSE) {
 		g_assert (event_handle->set_count > 0);
@@ -135,7 +131,7 @@ static gboolean namedevent_own (gpointer handle)
 	struct _WapiHandle_namedevent *namedevent_handle;
 	gboolean ok;
 	
-	DEBUG ("%s: owning named event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: owning named event handle %p", __func__, handle);
 
 	ok = _wapi_lookup_handle (handle, WAPI_HANDLE_NAMEDEVENT,
 				  (gpointer *)&namedevent_handle);
@@ -168,7 +164,7 @@ static gpointer event_create (WapiSecurityAttributes *security G_GNUC_UNUSED,
 	 */
 	SetLastError (ERROR_SUCCESS);
 
-	DEBUG ("%s: Creating unnamed event", __func__);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Creating unnamed event", __func__);
 	
 	event_handle.manual = manual;
 	event_handle.set_count = 0;
@@ -193,7 +189,7 @@ static gpointer event_create (WapiSecurityAttributes *security G_GNUC_UNUSED,
 		_wapi_handle_set_signal_state (handle, TRUE, FALSE);
 	}
 	
-	DEBUG("%s: created new event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: created new event handle %p", __func__, handle);
 
 	thr_ret = _wapi_handle_unlock_handle (handle);
 	g_assert (thr_ret == 0);
@@ -227,7 +223,7 @@ static gpointer namedevent_create (WapiSecurityAttributes *security G_GNUC_UNUSE
 	
 	utf8_name = g_utf16_to_utf8 (name, -1, NULL, NULL, NULL);
 	
-	DEBUG ("%s: Creating named event [%s]", __func__, utf8_name);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Creating named event [%s]", __func__, utf8_name);
 	
 	offset = _wapi_search_handle_namespace (WAPI_HANDLE_NAMEDEVENT,
 						utf8_name);
@@ -298,7 +294,7 @@ static gpointer namedevent_create (WapiSecurityAttributes *security G_GNUC_UNUSE
 		_wapi_handle_unlock_shared_handles ();
 	}
 	
-	DEBUG ("%s: returning event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: returning event handle %p", __func__, handle);
 
 cleanup:
 	g_free (utf8_name);
@@ -360,7 +356,7 @@ static gboolean event_pulse (gpointer handle)
 	thr_ret = _wapi_handle_lock_handle (handle);
 	g_assert (thr_ret == 0);
 
-	DEBUG ("%s: Pulsing event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Pulsing event handle %p", __func__, handle);
 
 	if (event_handle->manual == TRUE) {
 		_wapi_handle_set_signal_state (handle, TRUE, TRUE);
@@ -385,7 +381,7 @@ static gboolean event_pulse (gpointer handle)
 		 * have proceeded.  Currently we rely on broadcasting
 		 * a condition.
 		 */
-		DEBUG ("%s: Obtained write lock on event handle %p",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Obtained write lock on event handle %p",
 			   __func__, handle);
 
 		thr_ret = _wapi_handle_lock_handle (handle);
@@ -417,7 +413,7 @@ static gboolean namedevent_pulse (gpointer handle)
 	thr_ret = _wapi_handle_lock_shared_handles ();
 	g_assert (thr_ret == 0);
 
-	DEBUG ("%s: Pulsing named event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Pulsing named event handle %p", __func__, handle);
 
 	if (namedevent_handle->manual == TRUE) {
 		_wapi_shared_handle_set_signal_state (handle, TRUE);
@@ -441,7 +437,7 @@ static gboolean namedevent_pulse (gpointer handle)
 		 * have proceeded.  Currently we rely on waiting for
 		 * twice the shared handle poll interval.
 		 */
-		DEBUG ("%s: Obtained write lock on event handle %p",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Obtained write lock on event handle %p",
 			   __func__, handle);
 
 		thr_ret = _wapi_handle_lock_shared_handles ();
@@ -503,16 +499,16 @@ static gboolean event_reset (gpointer handle)
 		return(FALSE);
 	}
 
-	DEBUG ("%s: Resetting event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Resetting event handle %p", __func__, handle);
 
 	thr_ret = _wapi_handle_lock_handle (handle);
 	g_assert (thr_ret == 0);
 	
 	if (_wapi_handle_issignalled (handle) == FALSE) {
-		DEBUG ("%s: No need to reset event handle %p", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: No need to reset event handle %p", __func__,
 			   handle);
 	} else {
-		DEBUG ("%s: Obtained write lock on event handle %p",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Obtained write lock on event handle %p",
 			   __func__, handle);
 
 		_wapi_handle_set_signal_state (handle, FALSE, FALSE);
@@ -540,16 +536,16 @@ static gboolean namedevent_reset (gpointer handle)
 		return(FALSE);
 	}
 
-	DEBUG ("%s: Resetting named event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Resetting named event handle %p", __func__, handle);
 
 	thr_ret = _wapi_handle_lock_shared_handles ();
 	g_assert (thr_ret == 0);
 	
 	if (_wapi_handle_issignalled (handle) == FALSE) {
-		DEBUG ("%s: No need to reset named event handle %p",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: No need to reset named event handle %p",
 			   __func__, handle);
 	} else {
-		DEBUG ("%s: Obtained write lock on named event handle %p",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Obtained write lock on named event handle %p",
 			   __func__, handle);
 
 		_wapi_shared_handle_set_signal_state (handle, FALSE);
@@ -607,7 +603,7 @@ static gboolean event_set (gpointer handle)
 	thr_ret = _wapi_handle_lock_handle (handle);
 	g_assert (thr_ret == 0);
 
-	DEBUG ("%s: Setting event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Setting event handle %p", __func__, handle);
 
 	if (event_handle->manual == TRUE) {
 		_wapi_handle_set_signal_state (handle, TRUE, TRUE);
@@ -639,7 +635,7 @@ static gboolean namedevent_set (gpointer handle)
 	thr_ret = _wapi_handle_lock_shared_handles ();
 	g_assert (thr_ret == 0);
 
-	DEBUG ("%s: Setting named event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Setting named event handle %p", __func__, handle);
 
 	if (namedevent_handle->manual == TRUE) {
 		_wapi_shared_handle_set_signal_state (handle, TRUE);
@@ -704,7 +700,7 @@ gpointer OpenEvent (guint32 access G_GNUC_UNUSED, gboolean inherit G_GNUC_UNUSED
 
 	utf8_name = g_utf16_to_utf8 (name, -1, NULL, NULL, NULL);
 	
-	DEBUG ("%s: Opening named event [%s]", __func__, utf8_name);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Opening named event [%s]", __func__, utf8_name);
 	
 	offset = _wapi_search_handle_namespace (WAPI_HANDLE_NAMEDEVENT,
 						utf8_name);
@@ -733,7 +729,7 @@ gpointer OpenEvent (guint32 access G_GNUC_UNUSED, gboolean inherit G_GNUC_UNUSED
 	}
 	ret = handle;
 
-	DEBUG ("%s: returning named event handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: returning named event handle %p", __func__, handle);
 
 cleanup:
 	g_free (utf8_name);

--- a/mono/io-layer/io-trace.h
+++ b/mono/io-layer/io-trace.h
@@ -1,0 +1,18 @@
+/*
+ * io-trace.h: tracing macros
+ *
+ * Authors:
+ *  Marek Habersack <grendel@twistedcode.net>
+ *
+ * Copyright 2016 Xamarin, Inc (http://xamarin.com/)
+ */
+
+#ifndef __IO_TRACE_H
+
+#ifdef DISABLE_IO_LAYER_TRACE
+#define MONO_TRACE(...)
+#else
+#define MONO_TRACE(...) mono_trace (__VA_ARGS__)
+#endif
+
+#endif

--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -42,15 +42,10 @@
 #include <mono/io-layer/timefuncs-private.h>
 #include <mono/io-layer/thread-private.h>
 #include <mono/io-layer/io-portability.h>
+#include <mono/io-layer/io-trace.h>
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-once.h>
-
-#if 0
-#define DEBUG(...) g_message(__VA_ARGS__)
-#define DEBUG_ENABLED 1
-#else
-#define DEBUG(...)
-#endif
+#include <mono/utils/mono-logger-internals.h>
 
 static void file_close (gpointer handle, gpointer data);
 static WapiFileType file_getfiletype(void);
@@ -367,7 +362,7 @@ static void file_close (gpointer handle, gpointer data)
 	struct _WapiHandle_file *file_handle = (struct _WapiHandle_file *)data;
 	int fd = file_handle->fd;
 	
-	DEBUG("%s: closing file handle %p [%s]", __func__, handle,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: closing file handle %p [%s]", __func__, handle,
 		  file_handle->filename);
 
 	if (file_handle->attrs & FILE_FLAG_DELETE_ON_CLOSE)
@@ -410,7 +405,7 @@ static gboolean file_read(gpointer handle, gpointer buffer,
 	
 	if(!(file_handle->fileaccess & GENERIC_READ) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_READ access: %u",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ access: %u",
 			  __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
@@ -425,7 +420,7 @@ static gboolean file_read(gpointer handle, gpointer buffer,
 	if(ret==-1) {
 		gint err = errno;
 
-		DEBUG("%s: read of handle %p error: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: read of handle %p error: %s", __func__,
 			  handle, strerror(err));
 		SetLastError (_wapi_get_win32_file_error (err));
 		return(FALSE);
@@ -464,7 +459,7 @@ static gboolean file_write(gpointer handle, gconstpointer buffer,
 	
 	if(!(file_handle->fileaccess & GENERIC_WRITE) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
@@ -477,7 +472,7 @@ static gboolean file_write(gpointer handle, gconstpointer buffer,
 		 */
 		current_pos = lseek (fd, (off_t)0, SEEK_CUR);
 		if (current_pos == -1) {
-			DEBUG ("%s: handle %p lseek failed: %s", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p lseek failed: %s", __func__,
 				   handle, strerror (errno));
 			_wapi_set_last_error_from_errno ();
 			return(FALSE);
@@ -505,7 +500,7 @@ static gboolean file_write(gpointer handle, gconstpointer buffer,
 		} else {
 			_wapi_set_last_error_from_errno ();
 				
-			DEBUG("%s: write of handle %p error: %s",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: write of handle %p error: %s",
 				  __func__, handle, strerror(errno));
 
 			return(FALSE);
@@ -536,7 +531,7 @@ static gboolean file_flush(gpointer handle)
 
 	if(!(file_handle->fileaccess & GENERIC_WRITE) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
@@ -544,7 +539,7 @@ static gboolean file_flush(gpointer handle)
 
 	ret=fsync(fd);
 	if (ret==-1) {
-		DEBUG("%s: fsync of handle %p error: %s", __func__, handle,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: fsync of handle %p error: %s", __func__, handle,
 			  strerror(errno));
 
 		_wapi_set_last_error_from_errno ();
@@ -577,7 +572,7 @@ static guint32 file_seek(gpointer handle, gint32 movedistance,
 	if(!(file_handle->fileaccess & GENERIC_READ) &&
 	   !(file_handle->fileaccess & GENERIC_WRITE) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG ("%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(INVALID_SET_FILE_POINTER);
@@ -594,7 +589,7 @@ static guint32 file_seek(gpointer handle, gint32 movedistance,
 		whence=SEEK_END;
 		break;
 	default:
-		DEBUG("%s: invalid seek type %d", __func__, method);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: invalid seek type %d", __func__, method);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
 		return(INVALID_SET_FILE_POINTER);
@@ -603,18 +598,18 @@ static guint32 file_seek(gpointer handle, gint32 movedistance,
 #ifdef HAVE_LARGE_FILE_SUPPORT
 	if(highmovedistance==NULL) {
 		offset=movedistance;
-		DEBUG("%s: setting offset to %lld (low %d)", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: setting offset to %lld (low %d)", __func__,
 			  offset, movedistance);
 	} else {
 		offset=((gint64) *highmovedistance << 32) | (guint32)movedistance;
 		
-		DEBUG("%s: setting offset to %lld 0x%llx (high %d 0x%x, low %d 0x%x)", __func__, offset, offset, *highmovedistance, *highmovedistance, movedistance, movedistance);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: setting offset to %lld 0x%llx (high %d 0x%x, low %d 0x%x)", __func__, offset, offset, *highmovedistance, *highmovedistance, movedistance, movedistance);
 	}
 #else
 	offset=movedistance;
 #endif
 
-	DEBUG ("%s: moving handle %p by %lld bytes from %d", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: moving handle %p by %lld bytes from %d", __func__,
 		   handle, (long long)offset, whence);
 
 #ifdef PLATFORM_ANDROID
@@ -624,14 +619,14 @@ static guint32 file_seek(gpointer handle, gint32 movedistance,
 	newpos=lseek(fd, offset, whence);
 #endif
 	if(newpos==-1) {
-		DEBUG("%s: lseek on handle %p returned error %s",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: lseek on handle %p returned error %s",
 			  __func__, handle, strerror(errno));
 
 		_wapi_set_last_error_from_errno ();
 		return(INVALID_SET_FILE_POINTER);
 	}
 
-	DEBUG ("%s: lseek returns %lld", __func__, newpos);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: lseek returns %lld", __func__, newpos);
 
 #ifdef HAVE_LARGE_FILE_SUPPORT
 	ret=newpos & 0xFFFFFFFF;
@@ -646,7 +641,7 @@ static guint32 file_seek(gpointer handle, gint32 movedistance,
 	}
 #endif
 
-	DEBUG ("%s: move of handle %p returning %d/%d", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: move of handle %p returning %d/%d", __func__,
 		   handle, ret, highmovedistance==NULL?0:*highmovedistance);
 
 	return(ret);
@@ -672,7 +667,7 @@ static gboolean file_setendoffile(gpointer handle)
 	
 	if(!(file_handle->fileaccess & GENERIC_WRITE) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
@@ -686,7 +681,7 @@ static gboolean file_setendoffile(gpointer handle)
 	
 	ret=fstat(fd, &statbuf);
 	if(ret==-1) {
-		DEBUG ("%s: handle %p fstat failed: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p fstat failed: %s", __func__,
 			   handle, strerror(errno));
 
 		_wapi_set_last_error_from_errno ();
@@ -695,7 +690,7 @@ static gboolean file_setendoffile(gpointer handle)
 
 	pos=lseek(fd, (off_t)0, SEEK_CUR);
 	if(pos==-1) {
-		DEBUG("%s: handle %p lseek failed: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p lseek failed: %s", __func__,
 			  handle, strerror(errno));
 
 		_wapi_set_last_error_from_errno ();
@@ -722,7 +717,7 @@ static gboolean file_setendoffile(gpointer handle)
 			 !_wapi_thread_cur_apc_pending());
 
 		if(ret==-1) {
-			DEBUG("%s: handle %p extend write failed: %s", __func__, handle, strerror(errno));
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p extend write failed: %s", __func__, handle, strerror(errno));
 
 			_wapi_set_last_error_from_errno ();
 			return(FALSE);
@@ -731,7 +726,7 @@ static gboolean file_setendoffile(gpointer handle)
 		/* And put the file position back after the write */
 		ret = lseek (fd, pos, SEEK_SET);
 		if (ret == -1) {
-			DEBUG ("%s: handle %p second lseek failed: %s",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p second lseek failed: %s",
 				   __func__, handle, strerror(errno));
 
 			_wapi_set_last_error_from_errno ();
@@ -750,7 +745,7 @@ static gboolean file_setendoffile(gpointer handle)
 	}
 	while (ret==-1 && errno==EINTR && !_wapi_thread_cur_apc_pending()); 
 	if(ret==-1) {
-		DEBUG("%s: handle %p ftruncate failed: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p ftruncate failed: %s", __func__,
 			  handle, strerror(errno));
 		
 		_wapi_set_last_error_from_errno ();
@@ -783,7 +778,7 @@ static guint32 file_getfilesize(gpointer handle, guint32 *highsize)
 	if(!(file_handle->fileaccess & GENERIC_READ) &&
 	   !(file_handle->fileaccess & GENERIC_WRITE) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(INVALID_FILE_SIZE);
@@ -797,7 +792,7 @@ static guint32 file_getfilesize(gpointer handle, guint32 *highsize)
 	
 	ret = fstat(fd, &statbuf);
 	if (ret == -1) {
-		DEBUG ("%s: handle %p fstat failed: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p fstat failed: %s", __func__,
 			   handle, strerror(errno));
 
 		_wapi_set_last_error_from_errno ();
@@ -809,7 +804,7 @@ static guint32 file_getfilesize(gpointer handle, guint32 *highsize)
 	if (S_ISBLK(statbuf.st_mode)) {
 		guint64 bigsize;
 		if (ioctl(fd, BLKGETSIZE64, &bigsize) < 0) {
-			DEBUG ("%s: handle %p ioctl BLKGETSIZE64 failed: %s",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p ioctl BLKGETSIZE64 failed: %s",
 				   __func__, handle, strerror(errno));
 
 			_wapi_set_last_error_from_errno ();
@@ -821,7 +816,7 @@ static guint32 file_getfilesize(gpointer handle, guint32 *highsize)
 			*highsize = bigsize>>32;
 		}
 
-		DEBUG ("%s: Returning block device size %d/%d",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Returning block device size %d/%d",
 			   __func__, size, *highsize);
 	
 		return(size);
@@ -841,7 +836,7 @@ static guint32 file_getfilesize(gpointer handle, guint32 *highsize)
 	size = statbuf.st_size;
 #endif
 
-	DEBUG ("%s: Returning size %d/%d", __func__, size, *highsize);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Returning size %d/%d", __func__, size, *highsize);
 	
 	return(size);
 }
@@ -868,7 +863,7 @@ static gboolean file_getfiletime(gpointer handle, WapiFileTime *create_time,
 
 	if(!(file_handle->fileaccess & GENERIC_READ) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_READ access: %u",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ access: %u",
 			  __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
@@ -877,14 +872,14 @@ static gboolean file_getfiletime(gpointer handle, WapiFileTime *create_time,
 	
 	ret=fstat(fd, &statbuf);
 	if(ret==-1) {
-		DEBUG("%s: handle %p fstat failed: %s", __func__, handle,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p fstat failed: %s", __func__, handle,
 			  strerror(errno));
 
 		_wapi_set_last_error_from_errno ();
 		return(FALSE);
 	}
 
-	DEBUG("%s: atime: %ld ctime: %ld mtime: %ld", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: atime: %ld ctime: %ld mtime: %ld", __func__,
 		  statbuf.st_atime, statbuf.st_ctime,
 		  statbuf.st_mtime);
 
@@ -905,7 +900,7 @@ static gboolean file_getfiletime(gpointer handle, WapiFileTime *create_time,
 	access_ticks=((guint64)statbuf.st_atime*10000000)+116444736000000000ULL;
 	write_ticks=((guint64)statbuf.st_mtime*10000000)+116444736000000000ULL;
 	
-	DEBUG("%s: aticks: %llu cticks: %llu wticks: %llu", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: aticks: %llu cticks: %llu wticks: %llu", __func__,
 		  access_ticks, create_ticks, write_ticks);
 
 	if(create_time!=NULL) {
@@ -950,14 +945,14 @@ static gboolean file_setfiletime(gpointer handle,
 	
 	if(!(file_handle->fileaccess & GENERIC_WRITE) &&
 	   !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
 	}
 
 	if(file_handle->filename == NULL) {
-		DEBUG("%s: handle %p unknown filename", __func__, handle);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p unknown filename", __func__, handle);
 
 		SetLastError (ERROR_INVALID_HANDLE);
 		return(FALSE);
@@ -968,7 +963,7 @@ static gboolean file_setfiletime(gpointer handle,
 	 */
 	ret=fstat (fd, &statbuf);
 	if(ret==-1) {
-		DEBUG("%s: handle %p fstat failed: %s", __func__, handle,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p fstat failed: %s", __func__, handle,
 			  strerror(errno));
 
 		SetLastError (ERROR_INVALID_PARAMETER);
@@ -982,7 +977,7 @@ static gboolean file_setfiletime(gpointer handle,
 		 * but this will do for now.
 		 */
 		if (access_ticks < 116444736000000000ULL) {
-			DEBUG ("%s: attempt to set access time too early",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: attempt to set access time too early",
 				   __func__);
 			SetLastError (ERROR_INVALID_PARAMETER);
 			return(FALSE);
@@ -1000,7 +995,7 @@ static gboolean file_setfiletime(gpointer handle,
 		 * but this will do for now.
 		 */
 		if (write_ticks < 116444736000000000ULL) {
-			DEBUG ("%s: attempt to set write time too early",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: attempt to set write time too early",
 				   __func__);
 			SetLastError (ERROR_INVALID_PARAMETER);
 			return(FALSE);
@@ -1011,12 +1006,12 @@ static gboolean file_setfiletime(gpointer handle,
 		utbuf.modtime=statbuf.st_mtime;
 	}
 
-	DEBUG ("%s: setting handle %p access %ld write %ld", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: setting handle %p access %ld write %ld", __func__,
 		   handle, utbuf.actime, utbuf.modtime);
 
 	ret = _wapi_utime (file_handle->filename, &utbuf);
 	if (ret == -1) {
-		DEBUG ("%s: handle %p [%s] utime failed: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p [%s] utime failed: %s", __func__,
 			   handle, file_handle->filename, strerror(errno));
 
 		SetLastError (ERROR_INVALID_PARAMETER);
@@ -1031,7 +1026,7 @@ static void console_close (gpointer handle, gpointer data)
 	struct _WapiHandle_file *console_handle = (struct _WapiHandle_file *)data;
 	int fd = console_handle->fd;
 	
-	DEBUG("%s: closing console handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: closing console handle %p", __func__, handle);
 
 	g_free (console_handle->filename);
 
@@ -1068,7 +1063,7 @@ static gboolean console_read(gpointer handle, gpointer buffer,
 	
 	if(!(console_handle->fileaccess & GENERIC_READ) &&
 	   !(console_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG ("%s: handle %p doesn't have GENERIC_READ access: %u",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ access: %u",
 			   __func__, handle, console_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
@@ -1080,7 +1075,7 @@ static gboolean console_read(gpointer handle, gpointer buffer,
 	} while (ret==-1 && errno==EINTR && !_wapi_thread_cur_apc_pending());
 
 	if(ret==-1) {
-		DEBUG("%s: read of handle %p error: %s", __func__, handle,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: read of handle %p error: %s", __func__, handle,
 			  strerror(errno));
 
 		_wapi_set_last_error_from_errno ();
@@ -1118,7 +1113,7 @@ static gboolean console_write(gpointer handle, gconstpointer buffer,
 	
 	if(!(console_handle->fileaccess & GENERIC_WRITE) &&
 	   !(console_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, console_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, console_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
@@ -1135,7 +1130,7 @@ static gboolean console_write(gpointer handle, gconstpointer buffer,
 		} else {
 			_wapi_set_last_error_from_errno ();
 			
-			DEBUG ("%s: write of handle %p error: %s",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: write of handle %p error: %s",
 				   __func__, handle, strerror(errno));
 
 			return(FALSE);
@@ -1153,7 +1148,7 @@ static void pipe_close (gpointer handle, gpointer data)
 	struct _WapiHandle_file *pipe_handle = (struct _WapiHandle_file*)data;
 	int fd = pipe_handle->fd;
 
-	DEBUG("%s: closing pipe handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: closing pipe handle %p", __func__, handle);
 
 	/* No filename with pipe handles */
 
@@ -1189,14 +1184,14 @@ static gboolean pipe_read (gpointer handle, gpointer buffer,
 	
 	if(!(pipe_handle->fileaccess & GENERIC_READ) &&
 	   !(pipe_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_READ access: %u",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ access: %u",
 			  __func__, handle, pipe_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
 	}
 	
-	DEBUG ("%s: reading up to %d bytes from pipe %p", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: reading up to %d bytes from pipe %p", __func__,
 		   numbytes, handle);
 
 	do {
@@ -1209,14 +1204,14 @@ static gboolean pipe_read (gpointer handle, gpointer buffer,
 		} else {
 			_wapi_set_last_error_from_errno ();
 			
-			DEBUG("%s: read of handle %p error: %s", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: read of handle %p error: %s", __func__,
 				  handle, strerror(errno));
 
 			return(FALSE);
 		}
 	}
 	
-	DEBUG ("%s: read %d bytes from pipe", __func__, ret);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: read %d bytes from pipe", __func__, ret);
 
 	if(bytesread!=NULL) {
 		*bytesread=ret;
@@ -1249,13 +1244,13 @@ static gboolean pipe_write(gpointer handle, gconstpointer buffer,
 	
 	if(!(pipe_handle->fileaccess & GENERIC_WRITE) &&
 	   !(pipe_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG("%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, pipe_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_WRITE access: %u", __func__, handle, pipe_handle->fileaccess);
 
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
 	}
 	
-	DEBUG ("%s: writing up to %d bytes to pipe %p", __func__, numbytes,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: writing up to %d bytes to pipe %p", __func__, numbytes,
 		   handle);
 
 	do {
@@ -1269,7 +1264,7 @@ static gboolean pipe_write(gpointer handle, gconstpointer buffer,
 		} else {
 			_wapi_set_last_error_from_errno ();
 			
-			DEBUG("%s: write of handle %p error: %s", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: write of handle %p error: %s", __func__,
 				  handle, strerror(errno));
 
 			return(FALSE);
@@ -1297,7 +1292,7 @@ static int convert_flags(guint32 fileaccess, guint32 createmode)
 		flags=O_RDWR;
 		break;
 	default:
-		DEBUG("%s: Unknown access type 0x%x", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Unknown access type 0x%x", __func__,
 			  fileaccess);
 		break;
 	}
@@ -1318,7 +1313,7 @@ static int convert_flags(guint32 fileaccess, guint32 createmode)
 		flags|=O_TRUNC;
 		break;
 	default:
-		DEBUG("%s: Unknown create mode 0x%x", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Unknown create mode 0x%x", __func__,
 			  createmode);
 		break;
 	}
@@ -1358,7 +1353,7 @@ static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 		 */
 		if (file_existing_share == 0) {
 			/* Quick and easy, no possibility to share */
-			DEBUG ("%s: Share mode prevents open: requested access: 0x%x, file has sharing = NONE", __func__, fileaccess);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Share mode prevents open: requested access: 0x%x, file has sharing = NONE", __func__, fileaccess);
 
 			_wapi_handle_share_release (*share_info);
 			
@@ -1370,7 +1365,7 @@ static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 		    ((file_existing_share == FILE_SHARE_WRITE) &&
 		     (fileaccess != GENERIC_WRITE))) {
 			/* New access mode doesn't match up */
-			DEBUG ("%s: Share mode prevents open: requested access: 0x%x, file has sharing: 0x%x", __func__, fileaccess, file_existing_share);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Share mode prevents open: requested access: 0x%x, file has sharing: 0x%x", __func__, fileaccess, file_existing_share);
 
 			_wapi_handle_share_release (*share_info);
 		
@@ -1382,14 +1377,14 @@ static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 		    ((file_existing_access & GENERIC_WRITE) &&
 		     !(sharemode & FILE_SHARE_WRITE))) {
 			/* New share mode doesn't match up */
-			DEBUG ("%s: Access mode prevents open: requested share: 0x%x, file has access: 0x%x", __func__, sharemode, file_existing_access);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Access mode prevents open: requested share: 0x%x, file has access: 0x%x", __func__, sharemode, file_existing_access);
 
 			_wapi_handle_share_release (*share_info);
 		
 			return(FALSE);
 		}
 	} else {
-		DEBUG ("%s: New file!", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: New file!", __func__);
 	}
 
 	return(TRUE);
@@ -1411,7 +1406,7 @@ share_allows_delete (struct stat *statbuf, struct _WapiFileShare **share_info)
 		 */
 		if (file_existing_share == 0) {
 			/* Quick and easy, no possibility to share */
-			DEBUG ("%s: Share mode prevents open: requested access: 0x%x, file has sharing = NONE", __func__, fileaccess);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Share mode prevents open: requested access: 0x%x, file has sharing = NONE", __func__, (*share_info)->access);
 
 			_wapi_handle_share_release (*share_info);
 
@@ -1420,14 +1415,14 @@ share_allows_delete (struct stat *statbuf, struct _WapiFileShare **share_info)
 
 		if (!(file_existing_share & FILE_SHARE_DELETE)) {
 			/* New access mode doesn't match up */
-			DEBUG ("%s: Share mode prevents open: requested access: 0x%x, file has sharing: 0x%x", __func__, fileaccess, file_existing_share);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Share mode prevents open: requested access: 0x%x, file has sharing: 0x%x", __func__, (*share_info)->access, file_existing_share);
 
 			_wapi_handle_share_release (*share_info);
 
 			return(FALSE);
 		}
 	} else {
-		DEBUG ("%s: New file!", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: New file!", __func__);
 	}
 
 	return(TRUE);
@@ -1514,7 +1509,7 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 	}
 	
 	if (name == NULL) {
-		DEBUG ("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(INVALID_HANDLE_VALUE);
@@ -1522,13 +1517,13 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 
 	filename = mono_unicode_to_external (name);
 	if (filename == NULL) {
-		DEBUG("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(INVALID_HANDLE_VALUE);
 	}
 	
-	DEBUG ("%s: Opening %s with share 0x%x and access 0x%x", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Opening %s with share 0x%x and access 0x%x", __func__,
 		   filename, sharemode, fileaccess);
 	
 	fd = _wapi_open (filename, flags, perms);
@@ -1548,7 +1543,7 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 	}
 	
 	if (fd == -1) {
-		DEBUG("%s: Error opening file %s: %s", __func__, filename,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Error opening file %s: %s", __func__, filename,
 			  strerror(errno));
 		_wapi_set_last_path_error_from_errno (NULL, filename);
 		g_free (filename);
@@ -1557,7 +1552,7 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 	}
 
 	if (fd >= _wapi_fd_reserve) {
-		DEBUG ("%s: File descriptor is too big", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: File descriptor is too big", __func__);
 
 		SetLastError (ERROR_TOO_MANY_OPEN_FILES);
 		
@@ -1569,7 +1564,7 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 
 	ret = fstat (fd, &statbuf);
 	if (ret == -1) {
-		DEBUG ("%s: fstat error of file %s: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: fstat error of file %s: %s", __func__,
 			   filename, strerror (errno));
 		_wapi_set_last_error_from_errno ();
 		g_free (filename);
@@ -1595,7 +1590,7 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 	}
 	if (file_handle.share_info == NULL) {
 		/* No space, so no more files can be opened */
-		DEBUG ("%s: No space in the share table", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: No space in the share table", __func__);
 
 		SetLastError (ERROR_TOO_MANY_OPEN_FILES);
 		close (fd);
@@ -1644,7 +1639,7 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 		return(INVALID_HANDLE_VALUE);
 	}
 	
-	DEBUG("%s: returning handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: returning handle %p", __func__, handle);
 	
 	return(handle);
 }
@@ -1670,7 +1665,7 @@ gboolean DeleteFile(const gunichar2 *name)
 #endif
 	
 	if(name==NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -1678,7 +1673,7 @@ gboolean DeleteFile(const gunichar2 *name)
 
 	filename=mono_unicode_to_external(name);
 	if(filename==NULL) {
-		DEBUG("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -1686,7 +1681,7 @@ gboolean DeleteFile(const gunichar2 *name)
 
 	attrs = GetFileAttributes (name);
 	if (attrs == INVALID_FILE_ATTRIBUTES) {
-		DEBUG ("%s: file attributes error", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: file attributes error", __func__);
 		/* Error set by GetFileAttributes() */
 		g_free (filename);
 		return(FALSE);
@@ -1751,7 +1746,7 @@ gboolean MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 	struct _WapiFileShare *shareinfo;
 	
 	if(name==NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -1759,14 +1754,14 @@ gboolean MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 
 	utf8_name = mono_unicode_to_external (name);
 	if (utf8_name == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 		
 		SetLastError (ERROR_INVALID_NAME);
 		return FALSE;
 	}
 	
 	if(dest_name==NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		g_free (utf8_name);
 		SetLastError (ERROR_INVALID_NAME);
@@ -1775,7 +1770,7 @@ gboolean MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 
 	utf8_dest_name = mono_unicode_to_external (dest_name);
 	if (utf8_dest_name == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 		g_free (utf8_name);
 		SetLastError (ERROR_INVALID_NAME);
@@ -1896,7 +1891,7 @@ write_file (int src_fd, int dest_fd, struct stat *st_src, gboolean report_errors
 
 				if (report_errors)
 					_wapi_set_last_error_from_errno ();
-				DEBUG ("%s: write failed.", __func__);
+				MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: write failed.", __func__);
 				free (buf);
 				return FALSE;
 			}
@@ -1933,7 +1928,7 @@ gboolean CopyFile (const gunichar2 *name, const gunichar2 *dest_name,
 	int ret_utime;
 	
 	if(name==NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -1941,7 +1936,7 @@ gboolean CopyFile (const gunichar2 *name, const gunichar2 *dest_name,
 	
 	utf8_src = mono_unicode_to_external (name);
 	if (utf8_src == NULL) {
-		DEBUG ("%s: unicode conversion of source returned NULL",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion of source returned NULL",
 			   __func__);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
@@ -1949,7 +1944,7 @@ gboolean CopyFile (const gunichar2 *name, const gunichar2 *dest_name,
 	}
 	
 	if(dest_name==NULL) {
-		DEBUG("%s: dest is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: dest is NULL", __func__);
 
 		g_free (utf8_src);
 		SetLastError (ERROR_INVALID_NAME);
@@ -1958,7 +1953,7 @@ gboolean CopyFile (const gunichar2 *name, const gunichar2 *dest_name,
 	
 	utf8_dest = mono_unicode_to_external (dest_name);
 	if (utf8_dest == NULL) {
-		DEBUG ("%s: unicode conversion of dest returned NULL",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion of dest returned NULL",
 			   __func__);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
@@ -2039,7 +2034,7 @@ gboolean CopyFile (const gunichar2 *name, const gunichar2 *dest_name,
 	dest_time.actime = st.st_atime;
 	ret_utime = utime (utf8_dest, &dest_time);
 	if (ret_utime == -1)
-		DEBUG ("%s: file [%s] utime failed: %s", __func__, utf8_dest, strerror(errno));
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: file [%s] utime failed: %s", __func__, utf8_dest, strerror(errno));
 	
 	g_free (utf8_src);
 	g_free (utf8_dest);
@@ -2053,14 +2048,14 @@ convert_arg_to_utf8 (const gunichar2 *arg, const gchar *arg_name)
 	gchar *utf8_ret;
 
 	if (arg == NULL) {
-		DEBUG ("%s: %s is NULL", __func__, arg_name);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: %s is NULL", __func__, arg_name);
 		SetLastError (ERROR_INVALID_NAME);
 		return NULL;
 	}
 
 	utf8_ret = mono_unicode_to_external (arg);
 	if (utf8_ret == NULL) {
-		DEBUG ("%s: unicode conversion of %s returned NULL",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion of %s returned NULL",
 			   __func__, arg_name);
 		SetLastError (ERROR_INVALID_PARAMETER);
 		return NULL;
@@ -2163,7 +2158,7 @@ gpointer GetStdHandle(WapiStdHandle stdhandle)
 		break;
 
 	default:
-		DEBUG("%s: unknown standard handle type", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unknown standard handle type", __func__);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
 		return(INVALID_HANDLE_VALUE);
@@ -2549,7 +2544,7 @@ gboolean FileTimeToSystemTime(const WapiFileTime *file_time,
 	const guint16 *ip;
 	
 	if(system_time==NULL) {
-		DEBUG("%s: system_time NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: system_time NULL", __func__);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
 		return(FALSE);
@@ -2563,7 +2558,7 @@ gboolean FileTimeToSystemTime(const WapiFileTime *file_time,
 	 * year and day calculation to work later
 	 */
 	if(file_ticks<0) {
-		DEBUG("%s: file_time too big", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: file_time too big", __func__);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
 		return(FALSE);
@@ -2571,29 +2566,29 @@ gboolean FileTimeToSystemTime(const WapiFileTime *file_time,
 
 	totaldays=(file_ticks / TICKS_PER_DAY);
 	rem = file_ticks % TICKS_PER_DAY;
-	DEBUG("%s: totaldays: %lld rem: %lld", __func__, totaldays, rem);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: totaldays: %lld rem: %lld", __func__, totaldays, rem);
 
 	system_time->wHour=rem/TICKS_PER_HOUR;
 	rem %= TICKS_PER_HOUR;
-	DEBUG("%s: Hour: %d rem: %lld", __func__, system_time->wHour, rem);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Hour: %d rem: %lld", __func__, system_time->wHour, rem);
 	
 	system_time->wMinute = rem / TICKS_PER_MINUTE;
 	rem %= TICKS_PER_MINUTE;
-	DEBUG("%s: Minute: %d rem: %lld", __func__, system_time->wMinute,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Minute: %d rem: %lld", __func__, system_time->wMinute,
 		  rem);
 	
 	system_time->wSecond = rem / TICKS_PER_SECOND;
 	rem %= TICKS_PER_SECOND;
-	DEBUG("%s: Second: %d rem: %lld", __func__, system_time->wSecond,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Second: %d rem: %lld", __func__, system_time->wSecond,
 		  rem);
 	
 	system_time->wMilliseconds = rem / TICKS_PER_MILLISECOND;
-	DEBUG("%s: Milliseconds: %d", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Milliseconds: %d", __func__,
 		  system_time->wMilliseconds);
 
 	/* January 1, 1601 was a Monday, according to Emacs calendar */
 	system_time->wDayOfWeek = ((1 + totaldays) % 7) + 1;
-	DEBUG("%s: Day of week: %d", __func__, system_time->wDayOfWeek);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Day of week: %d", __func__, system_time->wDayOfWeek);
 	
 	/* This algorithm to find year and month given days from epoch
 	 * from glibc
@@ -2606,7 +2601,7 @@ gboolean FileTimeToSystemTime(const WapiFileTime *file_time,
 	while(totaldays < 0 || totaldays >= (isleap(y)?366:365)) {
 		/* Guess a corrected year, assuming 365 days per year */
 		gint64 yg = y + totaldays / 365 - (totaldays % 365 < 0);
-		DEBUG("%s: totaldays: %lld yg: %lld y: %lld", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: totaldays: %lld yg: %lld y: %lld", __func__,
 			  totaldays, yg,
 			  y);
 		g_message("%s: LEAPS(yg): %lld LEAPS(y): %lld", __func__,
@@ -2616,13 +2611,13 @@ gboolean FileTimeToSystemTime(const WapiFileTime *file_time,
 		totaldays -= ((yg - y) * 365
 			      + LEAPS_THRU_END_OF (yg - 1)
 			      - LEAPS_THRU_END_OF (y - 1));
-		DEBUG("%s: totaldays: %lld", __func__, totaldays);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: totaldays: %lld", __func__, totaldays);
 		y = yg;
-		DEBUG("%s: y: %lld", __func__, y);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: y: %lld", __func__, y);
 	}
 	
 	system_time->wYear = y;
-	DEBUG("%s: Year: %d", __func__, system_time->wYear);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Year: %d", __func__, system_time->wYear);
 
 	ip = mon_yday[isleap(y)];
 	
@@ -2630,13 +2625,13 @@ gboolean FileTimeToSystemTime(const WapiFileTime *file_time,
 		continue;
 	}
 	totaldays-=ip[y];
-	DEBUG("%s: totaldays: %lld", __func__, totaldays);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: totaldays: %lld", __func__, totaldays);
 	
 	system_time->wMonth = y + 1;
-	DEBUG("%s: Month: %d", __func__, system_time->wMonth);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Month: %d", __func__, system_time->wMonth);
 
 	system_time->wDay = totaldays + 1;
-	DEBUG("%s: Day: %d", __func__, system_time->wDay);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Day: %d", __func__, system_time->wDay);
 	
 	return(TRUE);
 }
@@ -2649,7 +2644,7 @@ gpointer FindFirstFile (const gunichar2 *pattern, WapiFindData *find_data)
 	int result;
 	
 	if (pattern == NULL) {
-		DEBUG ("%s: pattern is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: pattern is NULL", __func__);
 
 		SetLastError (ERROR_PATH_NOT_FOUND);
 		return(INVALID_HANDLE_VALUE);
@@ -2657,13 +2652,13 @@ gpointer FindFirstFile (const gunichar2 *pattern, WapiFindData *find_data)
 
 	utf8_pattern = mono_unicode_to_external (pattern);
 	if (utf8_pattern == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 		
 		SetLastError (ERROR_INVALID_NAME);
 		return(INVALID_HANDLE_VALUE);
 	}
 
-	DEBUG ("%s: looking for [%s]", __func__, utf8_pattern);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: looking for [%s]", __func__, utf8_pattern);
 	
 	/* Figure out which bit of the pattern is the directory */
 	dir_part = _wapi_dirname (utf8_pattern);
@@ -2719,12 +2714,8 @@ gpointer FindFirstFile (const gunichar2 *pattern, WapiFindData *find_data)
 	}
 	
 	if (result < 0) {
-#ifdef DEBUG_ENABLED
-		gint errnum = errno;
-#endif
 		_wapi_set_last_path_error_from_errno (dir_part, NULL);
-		DEBUG ("%s: scandir error: %s", __func__,
-			   g_strerror (errnum));
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: scandir error: %s", __func__, g_strerror (errno));
 		g_free (utf8_pattern);
 		g_free (entry_part);
 		g_free (dir_part);
@@ -2734,7 +2725,7 @@ gpointer FindFirstFile (const gunichar2 *pattern, WapiFindData *find_data)
 	g_free (utf8_pattern);
 	g_free (entry_part);
 	
-	DEBUG ("%s: Got %d matches", __func__, result);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Got %d matches", __func__, result);
 
 	find_handle.dir_part = dir_part;
 	find_handle.num = result;
@@ -2804,7 +2795,7 @@ retry:
 	}
 	
 	if (result != 0) {
-		DEBUG ("%s: stat failed: %s", __func__, filename);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: stat failed: %s", __func__, filename);
 
 		g_free (filename);
 		goto retry;
@@ -2813,7 +2804,7 @@ retry:
 #ifndef __native_client__
 	result = _wapi_lstat (filename, &linkbuf);
 	if (result != 0) {
-		DEBUG ("%s: lstat failed: %s", __func__, filename);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: lstat failed: %s", __func__, filename);
 
 		g_free (filename);
 		goto retry;
@@ -2833,7 +2824,7 @@ retry:
 	}
 	g_free (filename);
 	
-	DEBUG ("%s: Found [%s]", __func__, utf8_filename);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Found [%s]", __func__, utf8_filename);
 	
 	/* fill data block */
 
@@ -2956,7 +2947,7 @@ gboolean CreateDirectory (const gunichar2 *name,
 	int result;
 	
 	if (name == NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -2964,7 +2955,7 @@ gboolean CreateDirectory (const gunichar2 *name,
 	
 	utf8_name = mono_unicode_to_external (name);
 	if (utf8_name == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 	
 		SetLastError (ERROR_INVALID_NAME);
 		return FALSE;
@@ -2997,7 +2988,7 @@ gboolean RemoveDirectory (const gunichar2 *name)
 	int result;
 	
 	if (name == NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -3005,7 +2996,7 @@ gboolean RemoveDirectory (const gunichar2 *name)
 
 	utf8_name = mono_unicode_to_external (name);
 	if (utf8_name == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 		
 		SetLastError (ERROR_INVALID_NAME);
 		return FALSE;
@@ -3039,7 +3030,7 @@ guint32 GetFileAttributes (const gunichar2 *name)
 	guint32 ret;
 	
 	if (name == NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -3047,7 +3038,7 @@ guint32 GetFileAttributes (const gunichar2 *name)
 	
 	utf8_name = mono_unicode_to_external (name);
 	if (utf8_name == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
 		return (INVALID_FILE_ATTRIBUTES);
@@ -3105,7 +3096,7 @@ gboolean GetFileAttributesEx (const gunichar2 *name, WapiGetFileExInfoLevels lev
 	int result;
 	
 	if (level != GetFileExInfoStandard) {
-		DEBUG ("%s: info level %d not supported.", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: info level %d not supported.", __func__,
 			   level);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
@@ -3113,7 +3104,7 @@ gboolean GetFileAttributesEx (const gunichar2 *name, WapiGetFileExInfoLevels lev
 	}
 	
 	if (name == NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -3121,7 +3112,7 @@ gboolean GetFileAttributesEx (const gunichar2 *name, WapiGetFileExInfoLevels lev
 
 	utf8_name = mono_unicode_to_external (name);
 	if (utf8_name == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 		SetLastError (ERROR_INVALID_PARAMETER);
 		return FALSE;
@@ -3199,7 +3190,7 @@ extern gboolean SetFileAttributes (const gunichar2 *name, guint32 attrs)
 	 */
 	
 	if (name == NULL) {
-		DEBUG("%s: name is NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: name is NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return(FALSE);
@@ -3207,7 +3198,7 @@ extern gboolean SetFileAttributes (const gunichar2 *name, guint32 attrs)
 
 	utf8_name = mono_unicode_to_external (name);
 	if (utf8_name == NULL) {
-		DEBUG ("%s: unicode conversion returned NULL", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 		SetLastError (ERROR_INVALID_NAME);
 		return FALSE;
@@ -3351,11 +3342,11 @@ gboolean CreatePipe (gpointer *readpipe, gpointer *writepipe,
 	
 	mono_once (&io_ops_once, io_ops_init);
 	
-	DEBUG ("%s: Creating pipe", __func__);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Creating pipe", __func__);
 
 	ret=pipe (filedes);
 	if(ret==-1) {
-		DEBUG ("%s: Error creating pipe: %s", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Error creating pipe: %s", __func__,
 			   strerror (errno));
 		
 		_wapi_set_last_error_from_errno ();
@@ -3364,7 +3355,7 @@ gboolean CreatePipe (gpointer *readpipe, gpointer *writepipe,
 
 	if (filedes[0] >= _wapi_fd_reserve ||
 	    filedes[1] >= _wapi_fd_reserve) {
-		DEBUG ("%s: File descriptor is too big", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: File descriptor is too big", __func__);
 
 		SetLastError (ERROR_TOO_MANY_OPEN_FILES);
 		
@@ -3407,7 +3398,7 @@ gboolean CreatePipe (gpointer *readpipe, gpointer *writepipe,
 	*readpipe = read_handle;
 	*writepipe = write_handle;
 
-	DEBUG ("%s: Returning pipe: read handle %p, write handle %p",
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Returning pipe: read handle %p, write handle %p",
 		   __func__, read_handle, write_handle);
 
 	return(TRUE);
@@ -3879,7 +3870,7 @@ gboolean GetDiskFreeSpaceEx(const gunichar2 *path_name, WapiULargeInteger *free_
 	else {
 		utf8_path_name = mono_unicode_to_external (path_name);
 		if (utf8_path_name == NULL) {
-			DEBUG("%s: unicode conversion returned NULL", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 			SetLastError (ERROR_INVALID_NAME);
 			return(FALSE);
@@ -3906,7 +3897,7 @@ gboolean GetDiskFreeSpaceEx(const gunichar2 *path_name, WapiULargeInteger *free_
 
 	if (ret == -1) {
 		_wapi_set_last_error_from_errno ();
-		DEBUG ("%s: statvfs failed: %s", __func__, strerror (errno));
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: statvfs failed: %s", __func__, strerror (errno));
 		return(FALSE);
 	}
 
@@ -4199,7 +4190,7 @@ guint32 GetDriveType(const gunichar2 *root_path_name)
 	else {
 		utf8_root_path_name = mono_unicode_to_external (root_path_name);
 		if (utf8_root_path_name == NULL) {
-			DEBUG("%s: unicode conversion returned NULL", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 			return(DRIVE_NO_ROOT_DIR);
 		}
 		

--- a/mono/io-layer/locking.c
+++ b/mono/io-layer/locking.c
@@ -16,12 +16,8 @@
 #include <mono/io-layer/wapi-private.h>
 #include <mono/io-layer/handles-private.h>
 #include <mono/io-layer/io-private.h>
-
-#if 0
-// #define DEBUG(...) g_message(__VA_ARGS__)
-#else
-#define DEBUG(...)
-#endif
+#include <mono/io-layer/io-trace.h>
+#include <mono/utils/mono-logger-internals.h>
 
 gboolean
 _wapi_lock_file_region (int fd, off_t offset, off_t length)
@@ -48,7 +44,7 @@ _wapi_lock_file_region (int fd, off_t offset, off_t length)
 		ret = fcntl (fd, F_SETLK, &lock_data);
 	} while(ret == -1 && errno == EINTR);
 	
-	DEBUG ("%s: fcntl returns %d", __func__, ret);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: fcntl returns %d", __func__, ret);
 
 	if (ret == -1) {
 		/*
@@ -93,7 +89,7 @@ _wapi_unlock_file_region (int fd, off_t offset, off_t length)
 		ret = fcntl (fd, F_SETLK, &lock_data);
 	} while(ret == -1 && errno == EINTR);
 	
-	DEBUG ("%s: fcntl returns %d", __func__, ret);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: fcntl returns %d", __func__, ret);
 	
 	if (ret == -1) {
 		/*
@@ -140,7 +136,7 @@ LockFile (gpointer handle, guint32 offset_low, guint32 offset_high,
 	if (!(file_handle->fileaccess & GENERIC_READ) &&
 	    !(file_handle->fileaccess & GENERIC_WRITE) &&
 	    !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG ("%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
 	}
@@ -149,7 +145,7 @@ LockFile (gpointer handle, guint32 offset_low, guint32 offset_high,
 	offset = ((gint64)offset_high << 32) | offset_low;
 	length = ((gint64)length_high << 32) | length_low;
 
-	DEBUG ("%s: Locking handle %p, offset %lld, length %lld", __func__, handle, offset, length);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Locking handle %p, offset %lld, length %lld", __func__, handle, offset, length);
 #else
 	if (offset_high > 0 || length_high > 0) {
 		SetLastError (ERROR_INVALID_PARAMETER);
@@ -158,7 +154,7 @@ LockFile (gpointer handle, guint32 offset_low, guint32 offset_high,
 	offset = offset_low;
 	length = length_low;
 
-	DEBUG ("%s: Locking handle %p, offset %ld, length %ld", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Locking handle %p, offset %ld, length %ld", __func__,
 		   handle, offset, length);
 #endif
 
@@ -187,7 +183,7 @@ UnlockFile (gpointer handle, guint32 offset_low,
 	if (!(file_handle->fileaccess & GENERIC_READ) &&
 	    !(file_handle->fileaccess & GENERIC_WRITE) &&
 	    !(file_handle->fileaccess & GENERIC_ALL)) {
-		DEBUG ("%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
 		SetLastError (ERROR_ACCESS_DENIED);
 		return(FALSE);
 	}
@@ -196,12 +192,12 @@ UnlockFile (gpointer handle, guint32 offset_low,
 	offset = ((gint64)offset_high << 32) | offset_low;
 	length = ((gint64)length_high << 32) | length_low;
 
-	DEBUG ("%s: Unlocking handle %p, offset %lld, length %lld", __func__, handle, offset, length);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Unlocking handle %p, offset %lld, length %lld", __func__, handle, offset, length);
 #else
 	offset = offset_low;
 	length = length_low;
 
-	DEBUG ("%s: Unlocking handle %p, offset %ld, length %ld", __func__, handle, offset, length);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Unlocking handle %p, offset %ld, length %ld", __func__, handle, offset, length);
 #endif
 
 	return(_wapi_unlock_file_region (fd, offset, length));

--- a/mono/io-layer/posix.c
+++ b/mono/io-layer/posix.c
@@ -23,12 +23,8 @@
 #include <mono/io-layer/wapi-private.h>
 #include <mono/io-layer/handles-private.h>
 #include <mono/io-layer/io-private.h>
-
-#if 0
-#define DEBUG(...) g_message(__VA_ARGS__)
-#else
-#define DEBUG(...)
-#endif
+#include <mono/io-layer/io-trace.h>
+#include <mono/utils/mono-logger-internals.h>
 
 static guint32
 convert_from_flags(int flags)
@@ -46,7 +42,7 @@ convert_from_flags(int flags)
 	} else if ((flags & O_ACCMODE) == O_RDWR) {
 		fileaccess=GENERIC_READ|GENERIC_WRITE;
 	} else {
-		DEBUG("%s: Can't figure out flags 0x%x", __func__, flags);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't figure out flags 0x%x", __func__, flags);
 	}
 
 	/* Maybe sort out create mode too */
@@ -61,7 +57,7 @@ gpointer _wapi_stdhandle_create (int fd, const gchar *name)
 	gpointer handle;
 	int flags;
 	
-	DEBUG("%s: creating standard handle type %s, fd %d", __func__,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: creating standard handle type %s, fd %d", __func__,
 		  name, fd);
 
 #if !defined(__native_client__)	
@@ -74,7 +70,7 @@ gpointer _wapi_stdhandle_create (int fd, const gchar *name)
 		/* Invalid fd.  Not really much point checking for EBADF
 		 * specifically
 		 */
-		DEBUG("%s: fcntl error on fd %d: %s", __func__, fd,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: fcntl error on fd %d: %s", __func__, fd,
 			  strerror(errno));
 
 		SetLastError (_wapi_get_win32_file_error (errno));
@@ -111,7 +107,7 @@ gpointer _wapi_stdhandle_create (int fd, const gchar *name)
 		return(INVALID_HANDLE_VALUE);
 	}
 	
-	DEBUG("%s: returning handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: returning handle %p", __func__, handle);
 
 	return(handle);
 }

--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -97,6 +97,7 @@
 #include <mono/io-layer/handles-private.h>
 #include <mono/io-layer/process-private.h>
 #include <mono/io-layer/threads.h>
+#include <mono/io-layer/io-trace.h>
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-path.h>
 #include <mono/io-layer/timefuncs-private.h>
@@ -106,6 +107,7 @@
 #include <mono/utils/mono-signal-handler.h>
 #include <mono/utils/mono-proclib.h>
 #include <mono/utils/mono-once.h>
+#include <mono/utils/mono-logger-internals.h>
 
 /* The process' environment strings */
 #if defined(__APPLE__)
@@ -122,13 +124,6 @@ static char *mono_environ[1] = { NULL };
 #endif /* defined (TARGET_OSX) */
 #else
 extern char **environ;
-#endif
-
-#if 0
-#define DEBUG(...) g_message(__VA_ARGS__)
-#define DEBUG_ENABLED 1
-#else
-#define DEBUG(...)
 #endif
 
 static guint32 process_wait (gpointer handle, guint32 timeout, gboolean alertable);
@@ -576,11 +571,11 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 	char *dir = NULL, **env_strings = NULL, **argv = NULL;
 	guint32 i, env_count = 0;
 	gboolean ret = FALSE;
-	gpointer handle;
+	gpointer handle = NULL;
 	WapiHandle_process process_handle = {0}, *process_handle_data;
 	GError *gerr = NULL;
 	int in_fd, out_fd, err_fd;
-	pid_t pid;
+	pid_t pid = 0;
 	int thr_ret;
 	int startup_pipe [2] = {-1, -1};
 	int dummy;
@@ -618,7 +613,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 	if (appname != NULL) {
 		cmd = mono_unicode_to_external (appname);
 		if (cmd == NULL) {
-			DEBUG ("%s: unicode conversion returned NULL",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL",
 				   __func__);
 
 			SetLastError (ERROR_PATH_NOT_FOUND);
@@ -631,7 +626,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 	if (cmdline != NULL) {
 		args = mono_unicode_to_external (cmdline);
 		if (args == NULL) {
-			DEBUG ("%s: unicode conversion returned NULL", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 			SetLastError (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
@@ -641,7 +636,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 	if (cwd != NULL) {
 		dir = mono_unicode_to_external (cwd);
 		if (dir == NULL) {
-			DEBUG ("%s: unicode conversion returned NULL", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unicode conversion returned NULL", __func__);
 
 			SetLastError (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
@@ -671,7 +666,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 
 			/* Executable existing ? */
 			if (!is_readable_or_executable (prog)) {
-				DEBUG ("%s: Couldn't find executable %s",
+				MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Couldn't find executable %s",
 					   __func__, prog);
 				g_free (unquoted);
 				SetLastError (ERROR_FILE_NOT_FOUND);
@@ -688,7 +683,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 
 			/* And make sure it's readable */
 			if (!is_readable_or_executable (prog)) {
-				DEBUG ("%s: Couldn't find executable %s",
+				MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Couldn't find executable %s",
 					   __func__, prog);
 				g_free (unquoted);
 				SetLastError (ERROR_FILE_NOT_FOUND);
@@ -753,7 +748,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 		
 		if (token == NULL) {
 			/* Give up */
-			DEBUG ("%s: Couldn't find what to exec", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Couldn't find what to exec", __func__);
 
 			SetLastError (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
@@ -779,7 +774,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 			
 			/* Executable existing ? */
 			if (!is_readable_or_executable (prog)) {
-				DEBUG ("%s: Couldn't find executable %s",
+				MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Couldn't find executable %s",
 					   __func__, token);
 				g_free (token);
 				SetLastError (ERROR_FILE_NOT_FOUND);
@@ -806,7 +801,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 				g_free (prog);
 				prog = g_find_program_in_path (token);
 				if (prog == NULL) {
-					DEBUG ("%s: Couldn't find executable %s", __func__, token);
+					MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Couldn't find executable %s", __func__, token);
 
 					g_free (token);
 					SetLastError (ERROR_FILE_NOT_FOUND);
@@ -818,7 +813,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 		g_free (token);
 	}
 
-	DEBUG ("%s: Exec prog [%s] args [%s]", __func__, prog,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Exec prog [%s] args [%s]", __func__, prog,
 		   args_after_prog);
 	
 	/* Check for CLR binaries; if found, we will try to invoke
@@ -861,7 +856,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 		}
 	} else {
 		if (!is_executable (prog)) {
-			DEBUG ("%s: Executable permisson not set on %s", __func__, prog);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Executable permisson not set on %s", __func__, prog);
 			SetLastError (ERROR_ACCESS_DENIED);
 			goto free_strings;
 		}
@@ -972,7 +967,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 		/* Could not create the pipe to synchroniz process startup. We'll just not synchronize.
 		 * This is just for a very hard to hit race condition in the first place */
 		startup_pipe [0] = startup_pipe [1] = -1;
-		DEBUG ("%s: new process startup not synchronized. We may not notice if the newly created process exits immediately.", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: new process startup not synchronized. We may not notice if the newly created process exits immediately.", __func__);
 	}
 
 	thr_ret = _wapi_handle_lock_shared_handles ();
@@ -991,7 +986,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 		if (startup_pipe [0] != -1) {
 			/* Wait until the parent has updated it's internal data */
 			ssize_t _i G_GNUC_UNUSED = read (startup_pipe [0], &dummy, 1);
-			DEBUG ("%s: child: parent has completed its setup", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: child: parent has completed its setup", __func__);
 			close (startup_pipe [0]);
 			close (startup_pipe [1]);
 		}
@@ -1012,7 +1007,7 @@ gboolean CreateProcess (const gunichar2 *appname, const gunichar2 *cmdline,
 			close (i);
 
 #ifdef DEBUG_ENABLED
-		DEBUG ("%s: exec()ing [%s] in dir [%s]", __func__, cmd,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: exec()ing [%s] in dir [%s]", __func__, cmd,
 			   dir == NULL?".":dir);
 		for (i = 0; argv[i] != NULL; i++)
 			g_message ("arg %d: [%s]", i, argv[i]);
@@ -1109,8 +1104,7 @@ free_strings:
 	if (argv)
 		g_strfreev (argv);
 	
-	DEBUG ("%s: returning handle %p for pid %d", __func__, handle,
-		   pid);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: returning handle %p for pid %d", __func__, handle, pid);
 
 	/* Check if something needs to be cleaned up. */
 	mono_processes_cleanup ();
@@ -1130,7 +1124,7 @@ process_set_name (WapiHandle_process *process_handle)
 	progname = g_get_prgname ();
 	utf8_progname = mono_utf8_from_external (progname);
 
-	DEBUG ("%s: using [%s] as prog name", __func__, progname);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: using [%s] as prog name", __func__, progname);
 
 	if (utf8_progname) {
 		slash = strrchr (utf8_progname, '/');
@@ -1208,7 +1202,7 @@ process_open_compare (gpointer handle, gpointer user_data)
 	process_handle = lookup_process_handle (handle);
 	g_assert (process_handle);
 	
-	DEBUG ("%s: looking at process %d", __func__, process_handle->id);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: looking at process %d", __func__, process_handle->id);
 
 	checking_pid = process_handle->id;
 
@@ -1250,7 +1244,7 @@ OpenProcess (guint32 req_access G_GNUC_UNUSED, gboolean inherit G_GNUC_UNUSED, g
 	/* Find the process handle that corresponds to pid */
 	gpointer handle = NULL;
 	
-	DEBUG ("%s: looking for process %d", __func__, pid);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: looking for process %d", __func__, pid);
 
 	handle = _wapi_search_handle (WAPI_HANDLE_PROCESS,
 				      process_open_compare,
@@ -1262,7 +1256,7 @@ OpenProcess (guint32 req_access G_GNUC_UNUSED, gboolean inherit G_GNUC_UNUSED, g
 			 */
 			return WAPI_PID_TO_HANDLE (pid);
 		} else {
-			DEBUG ("%s: Can't find pid %d", __func__, pid);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find pid %d", __func__, pid);
 
 			SetLastError (ERROR_PROC_NOT_FOUND);
 	
@@ -1298,7 +1292,7 @@ GetExitCodeProcess (gpointer process, guint32 *code)
 
 	process_handle = lookup_process_handle (process);
 	if (!process_handle) {
-		DEBUG ("%s: Can't find process %p", __func__, process);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__, process);
 		
 		return FALSE;
 	}
@@ -1352,7 +1346,7 @@ GetProcessTimes (gpointer process, WapiFileTime *create_time,
 
 	process_handle = lookup_process_handle (process);
 	if (!process_handle) {
-		DEBUG ("%s: Can't find process %p", __func__, process);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__, process);
 		
 		return FALSE;
 	}
@@ -1517,7 +1511,7 @@ static GSList *load_modules (void)
 		mod->inode = i;
 		mod->filename = g_strdup (info->dlpi_name); 
 
-		DEBUG ("%s: inode=%d, filename=%s, address_start=%p, address_end=%p", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: inode=%d, filename=%s, address_start=%p, address_end=%p", __func__,
 				   mod->inode, mod->filename, mod->address_start, mod->address_end);
 
 		free(info);
@@ -1698,7 +1692,7 @@ static gboolean match_procname_to_modulename (char *procname, char *modulename)
 	if (procname == NULL || modulename == NULL)
 		return (FALSE);
 
-	DEBUG ("%s: procname=\"%s\", modulename=\"%s\"", __func__, procname, modulename);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: procname=\"%s\", modulename=\"%s\"", __func__, procname, modulename);
 	pname = mono_path_resolve_symlinks (procname);
 	mname = mono_path_resolve_symlinks (modulename);
 
@@ -1727,7 +1721,7 @@ static gboolean match_procname_to_modulename (char *procname, char *modulename)
 	g_free (pname);
 	g_free (mname);
 
-	DEBUG ("%s: result is %d", __func__, result);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: result is %d", __func__, result);
 	return result;
 }
 
@@ -1788,7 +1782,7 @@ gboolean EnumProcessModules (gpointer process, gpointer *modules,
 	} else {
 		process_handle = lookup_process_handle (process);
 		if (!process_handle) {
-			DEBUG ("%s: Can't find process %p", __func__, process);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__, process);
 		
 			return FALSE;
 		}
@@ -1925,7 +1919,7 @@ get_process_name_from_proc (pid_t pid)
 	if (sysctl (mib, 4, pi, &size, NULL, 0) < 0) {
 		if (errno == ENOMEM) {
 			free(pi);
-			DEBUG ("%s: Didn't allocate enough memory for kproc info", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Didn't allocate enough memory for kproc info", __func__);
 		}
 		return(ret);
 	}
@@ -1942,7 +1936,7 @@ get_process_name_from_proc (pid_t pid)
 	mib [2] = KERN_PROC_PID;
 	mib [3] = pid;
 	if (sysctl(mib, 4, NULL, &size, NULL, 0) < 0) {
-		DEBUG ("%s: sysctl() failed: %d", __func__, errno);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: sysctl() failed: %d", __func__, errno);
 		return(ret);
 	}
 
@@ -1952,7 +1946,7 @@ get_process_name_from_proc (pid_t pid)
 	if (sysctl (mib, 4, pi, &size, NULL, 0) < 0) {
 		if (errno == ENOMEM) {
 			free(pi);
-			DEBUG ("%s: Didn't allocate enough memory for kproc info", __func__);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Didn't allocate enough memory for kproc info", __func__);
 		}
 		return(ret);
 	}
@@ -1970,7 +1964,7 @@ get_process_name_from_proc (pid_t pid)
 
 retry:
 	if (sysctl(mib, 6, NULL, &size, NULL, 0) < 0) {
-		DEBUG ("%s: sysctl() failed: %d", __func__, errno);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: sysctl() failed: %d", __func__, errno);
 		return(ret);
 	}
 
@@ -2106,7 +2100,7 @@ get_module_name (gpointer process, gpointer module,
 	int i;
 	char *proc_name = NULL;
 	
-	DEBUG ("%s: Getting module base name, process handle %p module %p",
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Getting module base name, process handle %p module %p",
 		   __func__, process, module);
 
 	size = size * sizeof (gunichar2); /* adjust for unicode characters */
@@ -2121,7 +2115,7 @@ get_module_name (gpointer process, gpointer module,
 	} else {
 		process_handle = lookup_process_handle (process);
 		if (!process_handle) {
-			DEBUG ("%s: Can't find process %p", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__,
 				   process);
 			
 			return 0;
@@ -2182,7 +2176,7 @@ get_module_name (gpointer process, gpointer module,
 	g_free (proc_name);
 
 	if (procname_ext) {
-		DEBUG ("%s: Process name is [%s]", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Process name is [%s]", __func__,
 			   procname_ext);
 
 		procname = mono_unicode_from_external (procname_ext, &bytes);
@@ -2198,11 +2192,11 @@ get_module_name (gpointer process, gpointer module,
 		bytes += 2;
 		
 		if (size < bytes) {
-			DEBUG ("%s: Size %d smaller than needed (%ld); truncating", __func__, size, bytes);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Size %d smaller than needed (%ld); truncating", __func__, size, bytes);
 
 			memcpy (basename, procname, size);
 		} else {
-			DEBUG ("%s: Size %d larger than needed (%ld)",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Size %d larger than needed (%ld)",
 				   __func__, size, bytes);
 
 			memcpy (basename, procname, bytes);
@@ -2249,11 +2243,11 @@ get_module_filename (gpointer process, gpointer module,
 	bytes += 2;
 
 	if (size < bytes) {
-		DEBUG ("%s: Size %d smaller than needed (%ld); truncating", __func__, size, bytes);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Size %d smaller than needed (%ld); truncating", __func__, size, bytes);
 
 		memcpy (basename, proc_path, size);
 	} else {
-		DEBUG ("%s: Size %d larger than needed (%ld)",
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Size %d larger than needed (%ld)",
 			   __func__, size, bytes);
 
 		memcpy (basename, proc_path, bytes);
@@ -2294,7 +2288,7 @@ GetModuleInformation (gpointer process, gpointer module,
 	gboolean ret = FALSE;
 	char *proc_name = NULL;
 	
-	DEBUG ("%s: Getting module info, process handle %p module %p",
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Getting module info, process handle %p module %p",
 		   __func__, process, module);
 
 	if (modinfo == NULL || size < sizeof (WapiModuleInfo))
@@ -2306,7 +2300,7 @@ GetModuleInformation (gpointer process, gpointer module,
 	} else {
 		process_handle = lookup_process_handle (process);
 		if (!process_handle) {
-			DEBUG ("%s: Can't find process %p", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__,
 				   process);
 			
 			return FALSE;
@@ -2370,7 +2364,7 @@ GetProcessWorkingSetSize (gpointer process, size_t *min, size_t *max)
 	
 	process_handle = lookup_process_handle (process);
 	if (!process_handle) {
-		DEBUG ("%s: Can't find process %p", __func__, process);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__, process);
 		
 		return FALSE;
 	}
@@ -2393,7 +2387,7 @@ SetProcessWorkingSetSize (gpointer process, size_t min, size_t max)
 
 	process_handle = lookup_process_handle (process);
 	if (!process_handle) {
-		DEBUG ("%s: Can't find process %p", __func__, process);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__, process);
 		
 		return FALSE;
 	}
@@ -2420,7 +2414,7 @@ TerminateProcess (gpointer process, gint32 exitCode)
 	} else {
 		process_handle = lookup_process_handle (process);
 		if (!process_handle) {
-			DEBUG ("%s: Can't find process %p", __func__, process);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Can't find process %p", __func__, process);
 			SetLastError (ERROR_INVALID_HANDLE);
 			return FALSE;
 		}
@@ -2585,7 +2579,7 @@ mono_processes_cleanup (void)
 	GSList *l;
 	gpointer unref_handle;
 
-	DEBUG ("%s", __func__);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s", __func__);
 
 	/* Ensure we're not in here in multiple threads at once, nor recursive. */
 	if (InterlockedCompareExchange (&mono_processes_cleaning_up, 1, 0) != 0)
@@ -2649,7 +2643,7 @@ mono_processes_cleanup (void)
 
 	mono_os_mutex_unlock (&mono_processes_mutex);
 
-	DEBUG ("%s done", __func__);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s done", __func__);
 
 	InterlockedDecrement (&mono_processes_cleaning_up);
 }
@@ -2659,7 +2653,7 @@ process_close (gpointer handle, gpointer data)
 {
 	WapiHandle_process *process_handle;
 
-	DEBUG ("%s", __func__);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s", __func__);
 
 	process_handle = (WapiHandle_process *) data;
 	g_free (process_handle->proc_name);
@@ -2676,7 +2670,7 @@ MONO_SIGNAL_HANDLER_FUNC (static, mono_sigchld_signal_handler, (int _dummy, sigi
 	int pid;
 	struct MonoProcess *p;
 
-	DEBUG ("SIG CHILD handler for pid: %i\n", info->si_pid);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "SIG CHILD handler for pid: %i\n", info->si_pid);
 
 	do {
 		do {
@@ -2686,7 +2680,7 @@ MONO_SIGNAL_HANDLER_FUNC (static, mono_sigchld_signal_handler, (int _dummy, sigi
 		if (pid <= 0)
 			break;
 
-		DEBUG ("child ended: %i", pid);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "child ended: %i", pid);
 
 		/*
 		 * This can run concurrently with the code in the rest of this module.
@@ -2706,7 +2700,7 @@ MONO_SIGNAL_HANDLER_FUNC (static, mono_sigchld_signal_handler, (int _dummy, sigi
 		}
 	} while (1);
 
-	DEBUG ("SIG CHILD handler: done looping.");
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "SIG CHILD handler: done looping.");
 }
 
 #endif
@@ -2721,7 +2715,7 @@ process_add_sigchld_handler (void)
 	sigemptyset (&sa.sa_mask);
 	sa.sa_flags = SA_NOCLDSTOP | SA_SIGINFO;
 	g_assert (sigaction (SIGCHLD, &sa, &previous_chld_sa) != -1);
-	DEBUG ("Added SIGCHLD handler");
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "Added SIGCHLD handler");
 #endif
 }
 
@@ -2739,7 +2733,7 @@ process_wait (gpointer handle, guint32 timeout, gboolean alertable)
 	 * but WaitFor*Object won't call us for pseudo handles. */
 	g_assert ((GPOINTER_TO_UINT (handle) & _WAPI_PROCESS_UNHANDLED) != _WAPI_PROCESS_UNHANDLED);
 
-	DEBUG ("%s (%p, %u)", __func__, handle, timeout);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u)", __func__, handle, timeout);
 
 	process_handle = lookup_process_handle (handle);
 	if (!process_handle) {
@@ -2749,13 +2743,13 @@ process_wait (gpointer handle, guint32 timeout, gboolean alertable)
 
 	if (process_handle->exited) {
 		/* We've already done this one */
-		DEBUG ("%s (%p, %u): Process already exited", __func__, handle, timeout);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): Process already exited", __func__, handle, timeout);
 		return WAIT_OBJECT_0;
 	}
 
 	pid = process_handle->id;
 
-	DEBUG ("%s (%p, %u): PID: %d", __func__, handle, timeout, pid);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): PID: %d", __func__, handle, timeout, pid);
 
 	/* We don't need to lock mono_processes here, the entry
 	 * has a handle_count > 0 which means it will not be freed. */
@@ -2767,17 +2761,17 @@ process_wait (gpointer handle, guint32 timeout, gboolean alertable)
 
 	while (1) {
 		if (timeout != INFINITE) {
-			DEBUG ("%s (%p, %u): waiting on semaphore for %li ms...", 
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): waiting on semaphore for %li ms...", 
 				   __func__, handle, timeout, (timeout - (now - start)));
 			ret = mono_os_sem_timedwait (&mp->exit_sem, (timeout - (now - start)), alertable ? MONO_SEM_FLAGS_ALERTABLE : MONO_SEM_FLAGS_NONE);
 		} else {
-			DEBUG ("%s (%p, %u): waiting on semaphore forever...", 
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): waiting on semaphore forever...", 
 				   __func__, handle, timeout);
 			ret = mono_os_sem_wait (&mp->exit_sem, alertable ? MONO_SEM_FLAGS_ALERTABLE : MONO_SEM_FLAGS_NONE);
 		}
 
 		if (ret == -1 && errno != EINTR && errno != ETIMEDOUT) {
-			DEBUG ("%s (%p, %u): sem_timedwait failure: %s", 
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): sem_timedwait failure: %s", 
 				   __func__, handle, timeout, g_strerror (errno));
 			/* Should we return a failure here? */
 		}
@@ -2789,24 +2783,24 @@ process_wait (gpointer handle, guint32 timeout, gboolean alertable)
 		}
 
 		if (timeout == 0) {
-			DEBUG ("%s (%p, %u): WAIT_TIMEOUT (timeout = 0)", __func__, handle, timeout);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): WAIT_TIMEOUT (timeout = 0)", __func__, handle, timeout);
 			return WAIT_TIMEOUT;
 		}
 
 		now = mono_msec_ticks ();
 		if (now - start >= timeout) {
-			DEBUG ("%s (%p, %u): WAIT_TIMEOUT", __func__, handle, timeout);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): WAIT_TIMEOUT", __func__, handle, timeout);
 			return WAIT_TIMEOUT;
 		}
 		
 		if (alertable && _wapi_thread_cur_apc_pending ()) {
-			DEBUG ("%s (%p, %u): WAIT_IO_COMPLETION", __func__, handle, timeout);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): WAIT_IO_COMPLETION", __func__, handle, timeout);
 			return WAIT_IO_COMPLETION;
 		}
 	}
 
 	/* Process must have exited */
-	DEBUG ("%s (%p, %u): Waited successfully", __func__, handle, timeout);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): Waited successfully", __func__, handle, timeout);
 
 	ret = _wapi_handle_lock_shared_handles ();
 	g_assert (ret == 0);
@@ -2820,7 +2814,7 @@ process_wait (gpointer handle, guint32 timeout, gboolean alertable)
 
 	process_handle->exited = TRUE;
 
-	DEBUG ("%s (%p, %u): Setting pid %d signalled, exit status %d",
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): Setting pid %d signalled, exit status %d",
 		   __func__, handle, timeout, process_handle->id, process_handle->exitstatus);
 
 	_wapi_handle_set_signal_state (handle, TRUE, TRUE);

--- a/mono/io-layer/wait.c
+++ b/mono/io-layer/wait.c
@@ -15,12 +15,8 @@
 #include <mono/io-layer/wapi.h>
 #include <mono/io-layer/handles-private.h>
 #include <mono/io-layer/wapi-private.h>
-
-#if 0
-#define DEBUG(...) g_message(__VA_ARGS__)
-#else
-#define DEBUG(...)
-#endif
+#include <mono/io-layer/io-trace.h>
+#include <mono/utils/mono-logger-internals.h>
 
 static gboolean own_if_signalled(gpointer handle)
 {
@@ -113,7 +109,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 	
 	if (_wapi_handle_test_capabilities (handle,
 					    WAPI_HANDLE_CAP_WAIT) == FALSE) {
-		DEBUG ("%s: handle %p can't be waited for", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p can't be waited for", __func__,
 			   handle);
 
 		return(WAIT_FAILED);
@@ -122,7 +118,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 	_wapi_handle_ops_prewait (handle);
 	
 	if (_wapi_handle_test_capabilities (handle, WAPI_HANDLE_CAP_SPECIAL_WAIT) == TRUE) {
-		DEBUG ("%s: handle %p has special wait", __func__, handle);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p has special wait", __func__, handle);
 
 		ret = _wapi_handle_ops_special_wait (handle, timeout, alertable);
 	
@@ -133,7 +129,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 	}
 	
 	
-	DEBUG ("%s: locking handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: locking handle %p", __func__, handle);
 
 	thr_ret = _wapi_handle_lock_handle (handle);
 	g_assert (thr_ret == 0);
@@ -141,7 +137,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 	if (_wapi_handle_test_capabilities (handle,
 					    WAPI_HANDLE_CAP_OWN) == TRUE) {
 		if (own_if_owned (handle) == TRUE) {
-			DEBUG ("%s: handle %p already owned", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p already owned", __func__,
 				   handle);
 			ret = WAIT_OBJECT_0;
 			goto done;
@@ -149,7 +145,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 	}
 
 	if (own_if_signalled (handle) == TRUE) {
-		DEBUG ("%s: handle %p already signalled", __func__,
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p already signalled", __func__,
 			   handle);
 
 		ret=WAIT_OBJECT_0;
@@ -167,7 +163,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 		_wapi_handle_ops_prewait (handle);
 
 		if (own_if_signalled (handle)) {
-			DEBUG ("%s: handle %p signalled", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p signalled", __func__,
 				   handle);
 
 			ret = WAIT_OBJECT_0;
@@ -182,7 +178,7 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 			 * if someone else got in before us.)
 			 */
 			if (own_if_signalled (handle)) {
-				DEBUG ("%s: handle %p signalled", __func__,
+				MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p signalled", __func__,
 					   handle);
 
 				ret=WAIT_OBJECT_0;
@@ -194,14 +190,14 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout,
 	} while(waited == 0 && !apc_pending);
 
 	/* Timeout or other error */
-	DEBUG ("%s: wait on handle %p error: %s", __func__, handle,
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: wait on handle %p error: %s", __func__, handle,
 		   strerror (waited));
 
 	ret = apc_pending ? WAIT_IO_COMPLETION : WAIT_TIMEOUT;
 
 done:
 
-	DEBUG ("%s: unlocking handle %p", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unlocking handle %p", __func__, handle);
 	
 	thr_ret = _wapi_handle_unlock_handle (handle);
 	g_assert (thr_ret == 0);
@@ -253,7 +249,7 @@ guint32 WaitForSingleObject(gpointer handle, guint32 timeout)
 guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 			    guint32 timeout, gboolean alertable)
 {
-	guint32 ret, waited;
+	guint32 ret = 0, waited;
 	int thr_ret;
 	gboolean apc_pending = FALSE;
 	gpointer current_thread = wapi_get_current_thread_handle ();
@@ -308,7 +304,7 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 		return (WAIT_FAILED);
 	}
 
-	DEBUG ("%s: locking handle %p", __func__, wait);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: locking handle %p", __func__, wait);
 
 	thr_ret = _wapi_handle_lock_handle (wait);
 	g_assert (thr_ret == 0);
@@ -317,7 +313,7 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 
 	if (_wapi_handle_test_capabilities (wait, WAPI_HANDLE_CAP_OWN)==TRUE) {
 		if (own_if_owned (wait)) {
-			DEBUG ("%s: handle %p already owned", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p already owned", __func__,
 				   wait);
 			ret = WAIT_OBJECT_0;
 			goto done;
@@ -325,7 +321,7 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 	}
 
 	if (own_if_signalled (wait)) {
-		DEBUG ("%s: handle %p already signalled", __func__, wait);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p already signalled", __func__, wait);
 
 		ret = WAIT_OBJECT_0;
 		goto done;
@@ -337,7 +333,7 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 		_wapi_handle_ops_prewait (wait);
 	
 		if (own_if_signalled (wait)) {
-			DEBUG ("%s: handle %p signalled", __func__, wait);
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p signalled", __func__, wait);
 
 			ret = WAIT_OBJECT_0;
 			goto done;
@@ -351,7 +347,7 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 			 * if someone else got in before us.)
 			 */
 			if (own_if_signalled (wait)) {
-				DEBUG ("%s: handle %p signalled", __func__,
+				MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p signalled", __func__,
 					   wait);
 
 				ret = WAIT_OBJECT_0;
@@ -363,14 +359,13 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 	} while(waited == 0 && !apc_pending);
 
 	/* Timeout or other error */
-	DEBUG ("%s: wait on handle %p error: %s", __func__, wait,
-		   strerror (ret));
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: wait on handle %p error: %s", __func__, wait, strerror (ret));
 
 	ret = apc_pending ? WAIT_IO_COMPLETION : WAIT_TIMEOUT;
 
 done:
 
-	DEBUG ("%s: unlocking handle %p", __func__, wait);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unlocking handle %p", __func__, wait);
 
 	thr_ret = _wapi_handle_unlock_handle (wait);
 	g_assert (thr_ret == 0);
@@ -385,7 +380,7 @@ static gboolean test_and_own (guint32 numobjects, gpointer *handles,
 	gboolean done;
 	int i;
 	
-	DEBUG ("%s: locking handles", __func__);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: locking handles", __func__);
 	
 	done = _wapi_handle_count_signalled_handles (numobjects, handles,
 						     waitall, count, lowest);
@@ -399,7 +394,7 @@ static gboolean test_and_own (guint32 numobjects, gpointer *handles,
 		}
 	}
 	
-	DEBUG ("%s: unlocking handles", __func__);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unlocking handles", __func__);
 
 	_wapi_handle_unlock_handles (numobjects, handles);
 
@@ -457,7 +452,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 	}
 	
 	if (numobjects > MAXIMUM_WAIT_OBJECTS) {
-		DEBUG ("%s: Too many handles: %d", __func__, numobjects);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Too many handles: %d", __func__, numobjects);
 
 		return(WAIT_FAILED);
 	}
@@ -472,7 +467,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 			handles[i] = wapi_get_current_thread_handle ();
 			
 			if (handles[i] == NULL) {
-				DEBUG ("%s: Handle %d bogus", __func__, i);
+				MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Handle %d bogus", __func__, i);
 
 				bogustype = TRUE;
 				break;
@@ -480,7 +475,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 		}
 
 		if ((GPOINTER_TO_UINT (handles[i]) & _WAPI_PROCESS_UNHANDLED) == _WAPI_PROCESS_UNHANDLED) {
-			DEBUG ("%s: Handle %d pseudo process", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Handle %d pseudo process", __func__,
 				   i);
 
 			bogustype = TRUE;
@@ -488,7 +483,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 		}
 
 		if (_wapi_handle_test_capabilities (handles[i], WAPI_HANDLE_CAP_WAIT) == FALSE) {
-			DEBUG ("%s: Handle %p can't be waited for",
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Handle %p can't be waited for",
 				   __func__, handles[i]);
 
 			bogustype = TRUE;
@@ -508,13 +503,13 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 	}
 
 	if (duplicate == TRUE) {
-		DEBUG ("%s: Returning due to duplicates", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Returning due to duplicates", __func__);
 
 		return(WAIT_FAILED);
 	}
 
 	if (bogustype == TRUE) {
-		DEBUG ("%s: Returning due to bogus type", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Returning due to bogus type", __func__);
 
 		return(WAIT_FAILED);
 	}
@@ -556,7 +551,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 			}
 		}
 		
-		DEBUG ("%s: locking signal mutex", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: locking signal mutex", __func__);
 
 		thr_ret = _wapi_handle_lock_signal_mutex ();
 		g_assert (thr_ret == 0);
@@ -582,7 +577,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 			ret = 0;
 		}
 
-		DEBUG ("%s: unlocking signal mutex", __func__);
+		MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: unlocking signal mutex", __func__);
 
 		thr_ret = _wapi_handle_unlock_signal_mutex (NULL);
 		g_assert (thr_ret == 0);
@@ -605,7 +600,7 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 			/* Didn't get all handles, and there was a
 			 * timeout or other error
 			 */
-			DEBUG ("%s: wait returned error: %s", __func__,
+			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: wait returned error: %s", __func__,
 				   strerror (ret));
 
 			if(ret==ETIMEDOUT) {

--- a/mono/io-layer/wthreads.c
+++ b/mono/io-layer/wthreads.c
@@ -25,26 +25,16 @@
 #include <mono/io-layer/handles-private.h>
 #include <mono/io-layer/thread-private.h>
 #include <mono/io-layer/mutex-private.h>
+#include <mono/io-layer/io-trace.h>
 
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-once.h>
+#include <mono/utils/mono-logger-internals.h>
 
 #ifdef HAVE_VALGRIND_MEMCHECK_H
 #include <valgrind/memcheck.h>
-#endif
-
-#if 0
-#define DEBUG(...) g_message(__VA_ARGS__)
-#else
-#define DEBUG(...)
-#endif
-
-#if 0
-#define WAIT_DEBUG(code) do { code } while (0)
-#else
-#define WAIT_DEBUG(code) do { } while (0)
 #endif
 
 struct _WapiHandleOps _wapi_thread_ops = {
@@ -126,11 +116,11 @@ wapi_thread_handle_set_exited (gpointer handle, guint32 exitstatus)
 		return;
 	}
 
-	DEBUG ("%s: Thread %p terminating", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Thread %p terminating", __func__, handle);
 
 	thread_handle = lookup_thread (handle);
 
-	DEBUG ("%s: Thread %p abandoning held mutexes", __func__, handle);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Thread %p abandoning held mutexes", __func__, handle);
 
 	for (i = 0; i < thread_handle->owned_mutexes->len; i++) {
 		gpointer mutex = g_ptr_array_index (thread_handle->owned_mutexes, i);
@@ -148,7 +138,7 @@ wapi_thread_handle_set_exited (gpointer handle, guint32 exitstatus)
 	thr_ret = _wapi_handle_unlock_handle (handle);
 	g_assert (thr_ret == 0);
 	
-	DEBUG("%s: Recording thread handle %p id %ld status as %d",
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: Recording thread handle %p id %ld status as %d",
 		  __func__, handle, thread_handle->id, exitstatus);
 	
 	/* The thread is no longer active, so unref it */
@@ -188,7 +178,7 @@ wapi_create_thread_handle (void)
 	 */
 	_wapi_handle_ref (handle);
 
-	DEBUG ("%s: started thread id %ld", __func__, thread->id);
+	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: started thread id %ld", __func__, thread->id);
 	
 	return handle;
 }

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -278,7 +278,7 @@ mono_runtime_init (MonoDomain *domain, MonoThreadStartCB start_cb,
 
 	/* mscorlib is loaded before we install the load hook */
 	mono_domain_fire_assembly_load (mono_defaults.corlib->assembly, NULL);
-	
+
 	return;
 }
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -50,6 +50,7 @@
 #include <mono/metadata/attach.h>
 #include "mono/utils/mono-counters.h"
 #include "mono/utils/mono-hwcap.h"
+#include "mono/utils/mono-logger-internals.h"
 
 #include "mini.h"
 #include "jit.h"
@@ -1574,7 +1575,7 @@ mono_main (int argc, char* argv[])
 #if TARGET_OSX
 	darwin_change_default_file_handles ();
 #endif
-	
+
 	if (g_getenv ("MONO_NO_SMP"))
 		mono_set_use_smp (FALSE);
 	


### PR DESCRIPTION
The messages contain useful debugging information which is unavailable
unless the mono runtime is recompiled. The debugging information is
particularly useful on mobile platforms and in test runs on bots.

This commit also moves mono_trace to a header file so that all the
calls are inlined, avoiding one function call at the small expense
of binary size.

The I/O layer trace messages can be disabled on compile time by
defining the DISABLE_IO_LAYER_TRACE preprocessor symbol.