### PR TITLE
[Mono.Posix] Fix OSX build break by checking if accept4() is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2078,6 +2078,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(setpgid)
 	AC_CHECK_FUNCS(system)
 	AC_CHECK_FUNCS(fork execv execve)
+	AC_CHECK_FUNCS(accept4)
 	AC_CHECK_SIZEOF(size_t)
 	AC_CHECK_TYPES([blksize_t], [AC_DEFINE(HAVE_BLKSIZE_T)], , 
 		[#include <sys/types.h>

--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Native/SocketTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Native/SocketTest.cs
@@ -515,6 +515,7 @@ namespace MonoTests.Mono.Unix.Native
 		}
 
 		[Test]
+		[Category ("NotOnMac")]
 		public void Accept4 ()
 		{
 			WithSockets (UnixAddressFamily.AF_UNIX, UnixSocketType.SOCK_STREAM, 0, (so1, so2) => {

--- a/support/sys-socket.c
+++ b/support/sys-socket.c
@@ -397,6 +397,7 @@ Mono_Posix_Syscall_accept (int socket, struct Mono_Posix__SockaddrHeader* addres
 int
 Mono_Posix_Syscall_accept4 (int socket, struct Mono_Posix__SockaddrHeader* address, int flags)
 {
+#ifdef HAVE_ACCEPT4
 	int r;
 
 	ALLOC_SOCKADDR
@@ -412,6 +413,10 @@ Mono_Posix_Syscall_accept4 (int socket, struct Mono_Posix__SockaddrHeader* addre
 		free (addr);
 
 	return r;
+#else
+	errno = EINVAL;
+	return -1;
+#endif
 }
 
 int


### PR DESCRIPTION
It's a Linux-specific extension and not available on OSX or Linux <2.6.28

/cc @steffen-kiess @jonpryor 

@monojenkins merge