### PR TITLE
[jit] Fix the support for gshared types in mini_emit_initobj (), prev…

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3348,7 +3348,7 @@ mini_emit_initobj (MonoCompile *cfg, MonoInst *dest, const guchar *ip, MonoClass
 		return;
 	}
 
-	klass = mono_class_from_mono_type (mini_get_underlying_type (&klass->byval_arg));
+	klass = mono_class_from_mono_type (mini_get_underlying_type (cfg, &klass->byval_arg));
 
 	n = mono_class_value_size (klass, &align);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3348,6 +3348,8 @@ mini_emit_initobj (MonoCompile *cfg, MonoInst *dest, const guchar *ip, MonoClass
 		return;
 	}
 
+	klass = mono_class_from_mono_type (mini_get_underlying_type (&klass->byval_arg));
+
 	n = mono_class_value_size (klass, &align);
 
 	if (n <= sizeof (gpointer) * 8) {


### PR DESCRIPTION
…iously we were treating them as reference types, leading to stack overwrites. Fixes #37079.