### PR TITLE
[runtime] Fixes an abort caused by a TypeLoadException in certain ins…

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1893,7 +1893,13 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, MonoException
 			MonoException *tmpEx;
 
 			mono_jit_stats.methods_lookups++;
-			vtable = mono_class_vtable (domain, method->klass);
+
+			vtable = mono_class_vtable_full (domain, method->klass, ex == NULL);
+			if (ex && method->klass->exception_type) {
+				*ex = mono_class_get_exception_for_failure (method->klass);
+				return NULL;
+			}
+
 			g_assert (vtable);
 			tmpEx = mono_runtime_class_init_full (vtable, ex == NULL);
 			if (tmpEx) {


### PR DESCRIPTION
…tances.

Mono would abort if a TypeLoadException was thrown while JITing methods in certain instances. This commit changes that so the exception is thrown instead.

My CLA is still pending (I'm sure everyone knows legal takes time) but I heard you can accept small (less than 10) line commits without one.