### PR TITLE
[gc] Change the GC interface to be friendlier to coop and misc cleanups.

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -749,6 +749,12 @@ mono_gc_alloc_mature (MonoVTable *vtable, size_t size)
 	return mono_gc_alloc_obj (vtable, size);
 }
 
+void*
+mono_gc_alloc_pinned_obj (MonoVTable *vtable, size_t size)
+{
+	return mono_gc_alloc_obj (vtable, size);
+}
+
 int
 mono_gc_invoke_finalizers (void)
 {

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -629,7 +629,7 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 
 		obj->vtable = vtable;
@@ -638,11 +638,11 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 		memset ((char *) obj + sizeof (MonoObject), 0, size - sizeof (MonoObject));
 	} else if (vtable->gc_descr != GC_NO_DESCRIPTOR) {
 		obj = (MonoObject *)GC_GCJ_MALLOC (size, vtable);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 	} else {
 		obj = (MonoObject *)GC_MALLOC (size);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 
 		obj->vtable = vtable;
@@ -661,7 +661,7 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoArray *)GC_MALLOC_ATOMIC (size);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 
 		obj->obj.vtable = vtable;
@@ -670,11 +670,11 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 		memset ((char *) obj + sizeof (MonoObject), 0, size - sizeof (MonoObject));
 	} else if (vtable->gc_descr != GC_NO_DESCRIPTOR) {
 		obj = (MonoArray *)GC_GCJ_MALLOC (size, vtable);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 	} else {
 		obj = (MonoArray *)GC_MALLOC (size);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 
 		obj->obj.vtable = vtable;
@@ -695,7 +695,7 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoArray *)GC_MALLOC_ATOMIC (size);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 
 		obj->obj.vtable = vtable;
@@ -704,11 +704,11 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 		memset ((char *) obj + sizeof (MonoObject), 0, size - sizeof (MonoObject));
 	} else if (vtable->gc_descr != GC_NO_DESCRIPTOR) {
 		obj = (MonoArray *)GC_GCJ_MALLOC (size, vtable);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 	} else {
 		obj = (MonoArray *)GC_MALLOC (size);
-		if (!G_UNLIKELY (obj))
+		if (G_UNLIKELY (!obj))
 			return NULL;
 
 		obj->obj.vtable = vtable;
@@ -729,7 +729,7 @@ void *
 mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 {
 	MonoString *obj = (MonoString *)GC_MALLOC_ATOMIC (size);
-	if (!G_UNLIKELY (obj))
+	if (G_UNLIKELY (!obj))
 		return NULL;
 
 	obj->object.vtable = vtable;

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -190,7 +190,6 @@ mono_gc_base_init (void)
 
 	GC_init ();
 
-	GC_oom_fn = mono_gc_out_of_memory;
 	GC_set_warn_proc (mono_gc_warning);
 	GC_finalize_on_demand = 1;
 	GC_finalizer_notifier = mono_gc_finalize_notify;
@@ -630,6 +629,8 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 
 		obj->vtable = vtable;
 		obj->synchronisation = NULL;
@@ -637,8 +638,12 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 		memset ((char *) obj + sizeof (MonoObject), 0, size - sizeof (MonoObject));
 	} else if (vtable->gc_descr != GC_NO_DESCRIPTOR) {
 		obj = (MonoObject *)GC_GCJ_MALLOC (size, vtable);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 	} else {
 		obj = (MonoObject *)GC_MALLOC (size);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 
 		obj->vtable = vtable;
 	}
@@ -656,6 +661,8 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoArray *)GC_MALLOC_ATOMIC (size);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 
 		obj->obj.vtable = vtable;
 		obj->obj.synchronisation = NULL;
@@ -663,8 +670,12 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 		memset ((char *) obj + sizeof (MonoObject), 0, size - sizeof (MonoObject));
 	} else if (vtable->gc_descr != GC_NO_DESCRIPTOR) {
 		obj = (MonoArray *)GC_GCJ_MALLOC (size, vtable);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 	} else {
 		obj = (MonoArray *)GC_MALLOC (size);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 
 		obj->obj.vtable = vtable;
 	}
@@ -684,6 +695,8 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoArray *)GC_MALLOC_ATOMIC (size);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 
 		obj->obj.vtable = vtable;
 		obj->obj.synchronisation = NULL;
@@ -691,8 +704,12 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 		memset ((char *) obj + sizeof (MonoObject), 0, size - sizeof (MonoObject));
 	} else if (vtable->gc_descr != GC_NO_DESCRIPTOR) {
 		obj = (MonoArray *)GC_GCJ_MALLOC (size, vtable);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 	} else {
 		obj = (MonoArray *)GC_MALLOC (size);
+		if (!G_UNLIKELY (obj))
+			return NULL;
 
 		obj->obj.vtable = vtable;
 	}
@@ -712,6 +729,8 @@ void *
 mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 {
 	MonoString *obj = (MonoString *)GC_MALLOC_ATOMIC (size);
+	if (!G_UNLIKELY (obj))
+		return NULL;
 
 	obj->object.vtable = vtable;
 	obj->object.synchronisation = NULL;

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -743,6 +743,12 @@ mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 	return obj;
 }
 
+void*
+mono_gc_alloc_mature (MonoVTable *vtable, size_t size)
+{
+	return mono_gc_alloc_obj (vtable, size);
+}
+
 int
 mono_gc_invoke_finalizers (void)
 {

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -153,6 +153,7 @@ void* mono_gc_alloc_obj (MonoVTable *vtable, size_t size);
 void* mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length);
 void* mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uintptr_t bounds_size);
 void* mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len);
+void* mono_gc_alloc_mature (MonoVTable *vtable, size_t size);
 MonoGCDescriptor mono_gc_make_descr_for_string (gsize *bitmap, int numbits);
 
 void  mono_gc_register_for_finalization (MonoObject *obj, void *user_data);
@@ -162,7 +163,7 @@ void  mono_gc_deregister_root (char* addr);
 int   mono_gc_finalizers_for_domain (MonoDomain *domain, MonoObject **out_array, int out_size);
 void  mono_gc_run_finalize (void *obj, void *data);
 void  mono_gc_clear_domain (MonoDomain * domain);
-void* mono_gc_alloc_mature (MonoVTable *vtable);
+
 
 /* 
  * Register a root which can only be written using a write barrier.

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -914,15 +914,6 @@ mono_gc_get_mach_exception_thread (void)
 }
 #endif
 
-#ifndef HAVE_SGEN_GC
-void*
-mono_gc_alloc_mature (MonoVTable *vtable)
-{
-	return mono_object_new_specific (vtable);
-}
-#endif
-
-
 static MonoReferenceQueue *ref_queues;
 
 static void

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -234,6 +234,12 @@ mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 	return obj;
 }
 
+void*
+mono_gc_alloc_mature (MonoVTable *vtable, size_t size)
+{
+	return mono_gc_alloc_obj (vtable, size);
+}
+
 void
 mono_gc_wbarrier_set_field (MonoObject *obj, gpointer field_ptr, MonoObject* value)
 {

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -240,6 +240,12 @@ mono_gc_alloc_mature (MonoVTable *vtable, size_t size)
 	return mono_gc_alloc_obj (vtable, size);
 }
 
+void*
+mono_gc_alloc_pinned_obj (MonoVTable *vtable, size_t size)
+{
+	return mono_gc_alloc_obj (vtable, size);
+}
+
 void
 mono_gc_wbarrier_set_field (MonoObject *obj, gpointer field_ptr, MonoObject* value)
 {

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1652,6 +1652,9 @@ mono_error_set_pending_exception (MonoError *error);
 MonoArray *
 mono_glist_to_array (GList *list, MonoClass *eclass);
 
+MonoObject*
+mono_object_new_mature (MonoVTable *vtable);
+
 #endif /* __MONO_OBJECT_INTERNALS_H__ */
 
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4601,6 +4601,21 @@ mono_object_new_fast (MonoVTable *vtable)
 	return o;
 }
 
+MonoObject*
+mono_object_new_mature (MonoVTable *vtable)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	MonoObject *o = mono_gc_alloc_mature (vtable, vtable->klass->instance_size);
+
+	if (G_UNLIKELY (!o))
+		mono_gc_out_of_memory (vtable->klass->instance_size);
+	else if (G_UNLIKELY (vtable->klass->has_finalize))
+		mono_object_register_finalizer (o);
+
+	return o;
+}
+
 /**
  * mono_class_get_allocation_ftn:
  * @vtable: vtable

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4521,10 +4521,15 @@ mono_object_new_pinned (MonoDomain *domain, MonoClass *klass)
 		return NULL;
 
 #ifdef HAVE_SGEN_GC
-	return (MonoObject *)mono_gc_alloc_pinned_obj (vtable, mono_class_instance_size (klass));
+	MonoObject *o = (MonoObject *)mono_gc_alloc_pinned_obj (vtable, mono_class_instance_size (klass));
 #else
-	return mono_object_new_specific (vtable);
+	MonoObject *o = mono_object_new_specific (vtable);
 #endif
+
+	if (G_UNLIKELY (!o))
+		mono_gc_out_of_memory (mono_class_instance_size (klass));
+
+	return o;
 }
 
 /**
@@ -4575,7 +4580,9 @@ mono_object_new_alloc_specific (MonoVTable *vtable)
 
 	MonoObject *o = (MonoObject *)mono_gc_alloc_obj (vtable, vtable->klass->instance_size);
 
-	if (G_UNLIKELY (vtable->klass->has_finalize))
+	if (G_UNLIKELY (!o))
+		mono_gc_out_of_memory (vtable->klass->instance_size);
+	else if (G_UNLIKELY (vtable->klass->has_finalize))
 		mono_object_register_finalizer (o);
 
 	return o;
@@ -4586,7 +4593,12 @@ mono_object_new_fast (MonoVTable *vtable)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	return (MonoObject *)mono_gc_alloc_obj (vtable, vtable->klass->instance_size);
+	MonoObject *o = mono_gc_alloc_obj (vtable, vtable->klass->instance_size);
+
+	if (G_UNLIKELY (!o))
+		mono_gc_out_of_memory (vtable->klass->instance_size);
+
+	return o;
 }
 
 /**
@@ -4670,6 +4682,9 @@ mono_object_clone (MonoObject *obj)
 		return (MonoObject*)mono_array_clone ((MonoArray*)obj);
 
 	o = (MonoObject *)mono_gc_alloc_obj (obj->vtable, size);
+
+	if (G_UNLIKELY (!o))
+		mono_gc_out_of_memory (size);
 
 	/* If the object doesn't contain references this will do a simple memmove. */
 	mono_gc_wbarrier_object_copy (o, obj);
@@ -4894,6 +4909,10 @@ mono_array_new_full (MonoDomain *domain, MonoClass *array_class, uintptr_t *leng
 		o = (MonoObject *)mono_gc_alloc_array (vtable, byte_len, len, bounds_size);
 	else
 		o = (MonoObject *)mono_gc_alloc_vector (vtable, byte_len, len);
+
+	if (G_UNLIKELY (!o))
+		mono_gc_out_of_memory (byte_len);
+
 	array = (MonoArray*)o;
 
 	bounds = array->bounds;
@@ -4944,7 +4963,6 @@ mono_array_new_specific (MonoVTable *vtable, uintptr_t n)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoObject *o;
-	MonoArray *ao;
 	uintptr_t byte_len;
 
 	if (G_UNLIKELY (n > MONO_ARRAY_MAX_INDEX)) {
@@ -4957,9 +4975,11 @@ mono_array_new_specific (MonoVTable *vtable, uintptr_t n)
 		return NULL;
 	}
 	o = (MonoObject *)mono_gc_alloc_vector (vtable, byte_len, n);
-	ao = (MonoArray*)o;
 
-	return ao;
+	if (G_UNLIKELY (!o))
+		mono_gc_out_of_memory (byte_len);
+
+	return (MonoArray*)o;
 }
 
 /**
@@ -5046,6 +5066,9 @@ mono_string_new_size (MonoDomain *domain, gint32 len)
 	g_assert (vtable);
 
 	s = (MonoString *)mono_gc_alloc_string (vtable, size, len);
+
+	if (G_UNLIKELY (!s))
+		mono_gc_out_of_memory (size);
 
 	return s;
 }
@@ -5454,6 +5477,8 @@ mono_string_get_pinned (MonoString *str)
 	if (news) {
 		memcpy (mono_string_chars (news), mono_string_chars (str), mono_string_length (str) * 2);
 		news->length = mono_string_length (str);
+	} else {
+		mono_gc_out_of_memory (size);
 	}
 	return news;
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -958,15 +958,12 @@ mono_gc_alloc_pinned_obj (MonoVTable *vtable, size_t size)
 }
 
 void*
-mono_gc_alloc_mature (MonoVTable *vtable)
+mono_gc_alloc_mature (MonoVTable *vtable, size_t size)
 {
-	MonoObject *obj = sgen_alloc_obj_mature (vtable, vtable->klass->instance_size);
+	MonoObject *obj = sgen_alloc_obj_mature (vtable, size);
 
-	if (obj) {
-		if (G_UNLIKELY (vtable->klass->has_finalize))
-			mono_object_register_finalizer (obj);
-
-		if (G_UNLIKELY (alloc_events))
+	if (G_UNLIKELY (alloc_events)) {
+		if (obj)
 			mono_profiler_allocation (obj);
 	}
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -936,8 +936,10 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj = sgen_alloc_obj (vtable, size);
 
-	if (G_UNLIKELY (alloc_events))
-		mono_profiler_allocation (obj);
+	if (G_UNLIKELY (alloc_events)) {
+		if (obj)
+			mono_profiler_allocation (obj);
+	}
 
 	return obj;
 }
@@ -947,8 +949,10 @@ mono_gc_alloc_pinned_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj = sgen_alloc_obj_pinned (vtable, size);
 
-	if (G_UNLIKELY (alloc_events))
-		mono_profiler_allocation (obj);
+	if (G_UNLIKELY (alloc_events)) {
+		if (obj)
+			mono_profiler_allocation (obj);
+	}
 
 	return obj;
 }
@@ -958,11 +962,13 @@ mono_gc_alloc_mature (MonoVTable *vtable)
 {
 	MonoObject *obj = sgen_alloc_obj_mature (vtable, vtable->klass->instance_size);
 
-	if (obj && G_UNLIKELY (obj->vtable->klass->has_finalize))
-		mono_object_register_finalizer (obj);
+	if (obj) {
+		if (G_UNLIKELY (vtable->klass->has_finalize))
+			mono_object_register_finalizer (obj);
 
-	if (G_UNLIKELY (alloc_events))
-		mono_profiler_allocation (obj);
+		if (G_UNLIKELY (alloc_events))
+			mono_profiler_allocation (obj);
+	}
 
 	return obj;
 }
@@ -1736,7 +1742,7 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 	arr = (MonoArray*)sgen_alloc_obj_nolock (vtable, size);
 	if (G_UNLIKELY (!arr)) {
 		UNLOCK_GC;
-		return mono_gc_out_of_memory (size);
+		return NULL;
 	}
 
 	arr->max_length = (mono_array_size_t)max_length;
@@ -1781,7 +1787,7 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 	arr = (MonoArray*)sgen_alloc_obj_nolock (vtable, size);
 	if (G_UNLIKELY (!arr)) {
 		UNLOCK_GC;
-		return mono_gc_out_of_memory (size);
+		return NULL;
 	}
 
 	arr->max_length = (mono_array_size_t)max_length;
@@ -1825,7 +1831,7 @@ mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 	str = (MonoString*)sgen_alloc_obj_nolock (vtable, size);
 	if (G_UNLIKELY (!str)) {
 		UNLOCK_GC;
-		return mono_gc_out_of_memory (size);
+		return NULL;
 	}
 
 	str->length = len;
@@ -2707,12 +2713,6 @@ void
 mono_gc_register_altstack (gpointer stack, gint32 stack_size, gpointer altstack, gint32 altstack_size)
 {
 	// FIXME:
-}
-
-void
-sgen_client_out_of_memory (size_t size)
-{
-	mono_gc_out_of_memory (size);
 }
 
 guint8*

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -571,9 +571,7 @@ static MonoThread*
 create_thread_object (MonoDomain *domain)
 {
 	MonoVTable *vt = mono_class_vtable (domain, mono_defaults.thread_class);
-	MonoThread *t = (MonoThread*)mono_gc_alloc_mature (vt);
-	if (!t)
-		mono_gc_out_of_memory (mono_class_instance_size (mono_defaults.thread_class));
+	MonoThread *t = (MonoThread*)mono_object_new_mature (vt);
 	return t;
 }
 
@@ -592,9 +590,7 @@ create_internal_thread (void)
 	MonoVTable *vt;
 
 	vt = mono_class_vtable (mono_get_root_domain (), mono_defaults.internal_thread_class);
-	thread = (MonoInternalThread*)mono_gc_alloc_mature (vt);
-	if (!thread)
-		mono_gc_out_of_memory (mono_class_instance_size (mono_defaults.internal_thread_class));
+	thread = (MonoInternalThread*)mono_object_new_mature (vt);
 
 	thread->synch_cs = g_new0 (MonoCoopMutex, 1);
 	mono_coop_mutex_init_recursive (thread->synch_cs);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -571,7 +571,10 @@ static MonoThread*
 create_thread_object (MonoDomain *domain)
 {
 	MonoVTable *vt = mono_class_vtable (domain, mono_defaults.thread_class);
-	return (MonoThread*)mono_gc_alloc_mature (vt);
+	MonoThread *t = (MonoThread*)mono_gc_alloc_mature (vt);
+	if (!t)
+		mono_gc_out_of_memory (mono_class_instance_size (mono_defaults.thread_class));
+	return t;
 }
 
 static MonoThread*
@@ -590,6 +593,8 @@ create_internal_thread (void)
 
 	vt = mono_class_vtable (mono_get_root_domain (), mono_defaults.internal_thread_class);
 	thread = (MonoInternalThread*)mono_gc_alloc_mature (vt);
+	if (!thread)
+		mono_gc_out_of_memory (mono_class_instance_size (mono_defaults.internal_thread_class));
 
 	thread->synch_cs = g_new0 (MonoCoopMutex, 1);
 	mono_coop_mutex_init_recursive (thread->synch_cs);

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -454,8 +454,6 @@ sgen_alloc_obj (GCVTable vtable, size_t size)
 	LOCK_GC;
 	res = sgen_alloc_obj_nolock (vtable, size);
 	UNLOCK_GC;
-	if (G_UNLIKELY (!res))
-		sgen_client_out_of_memory (size);
 	return res;
 }
 

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -141,14 +141,6 @@ void sgen_client_degraded_allocation (size_t size);
 void sgen_client_total_allocated_heap_changed (size_t allocated_heap_size);
 
 /*
- * Called when an object allocation fails.  The suggested action is to abort the program.
- *
- * FIXME: Don't we want to return a BOOL here that indicates whether to retry the
- * allocation?
- */
-void sgen_client_out_of_memory (size_t size);
-
-/*
  * If the client has registered any internal memory types, this must return a string
  * describing the given type.  Only used for debugging.
  */


### PR DESCRIPTION
Move OOM handling out of gc glue and into the runtime.

Make mono_object_new_mature and mono_object_new_pinned work as expected
and adjust their GC interfaces.
