### PR TITLE
[Mono.Posix] Make UnixSignalTest.TestRaiseStorm() more reliable

### DIFF
--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
@@ -424,6 +424,10 @@ namespace MonoTests.Mono.Unix {
 			foreach (Thread t in threads)
 				t.Join ();
 			AssertCountSet (usignals);
+			// signal delivery might take some time, wait a bit before closing
+			// the UnixSignal so we can ignore it and not terminate the process
+			// when a SIGHUP/SIGTERM arrives afterwards
+			Thread.Sleep (1000);
 			CloseSignals (usignals);
 		}
 


### PR DESCRIPTION
The test was reenabled in 3f3df2694529b6fc3b88bf9c83c76d792ff47428 and we were seeing it randomly fail on Jenkins on OSX like this:

```
[...]
***** MonoTests.Mono.Unix.UnixSignalTest.TestNoEmitAny
***** MonoTests.Mono.Unix.UnixSignalTest.TestRaise
***** MonoTests.Mono.Unix.UnixSignalTest.TestRaiseAny
***** MonoTests.Mono.Unix.UnixSignalTest.TestRaiseStorm
/bin/sh: line 1: 40164 Hangup: 1               PATH="/Users/builder/jenkins/workspace/test-mono-mainline/label/osx-i386/runtime/_tmpinst/bin:/opt/mono/bin/:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" MONO_REGISTRY_PATH="/Users/builder/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" MONO_PATH="./../../class/lib/net_4_x::$MONO_PATH" /Users/builder/jenkins/workspace/test-mono-mainline/label/osx-i386/runtime/mono-wrapper --debug ./../../class/lib/net_4_x/nunit-console.exe Mono.Posix_test_net_4_x.dll -noshadow -labels -exclude=NotOnMac,NotWorking,ValueAdd,CAS,InetAccess -labels -xml=TestResult-net_4_x.xml
make[1]: *** [run-test-lib] Error 1
make[1]: Leaving directory `/Users/builder/jenkins/workspace/test-mono-mainline/label/osx-i386/mcs/class/Mono.Posix'
make: *** [do-run-test] Error 1
```

The problem is that (especially on OSX it seems) the signals raised by the threads in the test can be delivered after we closed the UnixSignal, which means the default behavior of terminating the program kicks in.

The simplest fix is to just sleep for some time to make sure the signal is delivered and ignored before closing.

/cc @xmcclure @jonpryor