### PR TITLE
[runtime] Fix type mismatch between runtime invoke and aot compiler

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3471,7 +3471,6 @@ handle_enum:
 	case MONO_TYPE_CHAR:
 		return &mono_defaults.uint16_class->byval_arg;
 	case MONO_TYPE_U:
-	case MONO_TYPE_PTR:
 		return &mono_defaults.int_class->byval_arg;
 	case MONO_TYPE_VALUETYPE:
 		if (t->data.klass->enumtype) {


### PR DESCRIPTION
We were using get_runtime_invoke_type () to reduce the number of
wrappers we were using by sharing the wrappers that have MONO_TYPE_I
with that of MONO_TYPE_PTR. They have the same size, but these are not
valid types to share because they have different levels of indirection,
so runtime wrappers that have been aot'ed for the MONO_TYPE_I will be
used for MONO_TYPE_PTR and will dereference the value in the first word
of the pointer. In the case that this is null, we observed a segfault.

Specifically, the wrapper code in marshal.c looks like so:

```
		case MONO_TYPE_I:
		case MONO_TYPE_U:
		case MONO_TYPE_I4:
		case MONO_TYPE_U4:
		case MONO_TYPE_R4:
		case MONO_TYPE_R8:
		case MONO_TYPE_I8:
		case MONO_TYPE_U8:
			mono_mb_emit_byte (mb, CEE_LDIND_I);
			mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
			break;
		case MONO_TYPE_STRING:
		case MONO_TYPE_CLASS:
		case MONO_TYPE_ARRAY:
		case MONO_TYPE_PTR:
		case MONO_TYPE_SZARRAY:
		case MONO_TYPE_OBJECT:
			mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
			break;
```

showing that the two types are not equivalent.