### PR TITLE
…

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -820,14 +820,14 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray (MonoAr
 	}
 
 #if G_BYTE_ORDER != G_LITTLE_ENDIAN
-#define SWAP(n) {\
-	guint ## n *data = (guint ## n *) mono_array_addr (array, char, 0); \
-	guint ## n *src = (guint ## n *) field_data; \
-	guint ## n *end = (guint ## n *)((char*)src + size); \
-\
-	for (; src < end; data++, src++) { \
-		*data = read ## n (src); \
-	} \
+#define SWAP(n) {								\
+	guint ## n *data = (guint ## n *) mono_array_addr (array, char, 0); 	\
+	guint ## n *src = (guint ## n *) field_data; 				\
+	int i;									\
+										\
+	for (i = 0; i < (size / sizeof(guint ## n)); i++) { 			\
+		data[i] = read ## n (&src[i]);					\
+	} 									\
 }
 
 	/* printf ("Initialize array with elements of %s type\n", klass->element_class->name); */


### PR DESCRIPTION
To get around a problem with gcc 4.4.7 on s390x, the SWAP macro is re-worked so that it correctly processes all elements. As written there was a compiler error such that only the first element of the array was processed (byte-swapped). The remaining entries were left uninitialized. [The for loop would only be gone through once as the src++ would be equal to end.] This manifest itself in bizarre error messages like: "System/Guid.MonoTouch.cs(24,253): error CS1525: Unexpected symbol `end-of-file', expecting `end-of-file'"