### PR TITLE
[runtime] Add SA_RESTART to SIG{CONT,INT,PROF,QUIT,USR2,WINCH}.

### DIFF
--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -345,19 +345,19 @@ console_set_signal_handlers ()
 	
 	// Continuing
 	sigcont.sa_handler = (void (*)(int)) sigcont_handler;
-	sigcont.sa_flags = 0;
+	sigcont.sa_flags = SA_RESTART;
 	sigemptyset (&sigcont.sa_mask);
 	sigaction (SIGCONT, &sigcont, &save_sigcont);
 	
 	// Interrupt handler
 	sigint.sa_handler = (void (*)(int)) sigint_handler;
-	sigint.sa_flags = 0;
+	sigint.sa_flags = SA_RESTART;
 	sigemptyset (&sigint.sa_mask);
 	sigaction (SIGINT, &sigint, &save_sigint);
 
 	// Window size changed
 	sigwinch.sa_handler = (void (*)(int)) sigwinch_handler;
-	sigwinch.sa_flags = 0;
+	sigwinch.sa_flags = SA_RESTART;
 	sigemptyset (&sigwinch.sa_mask);
 	sigaction (SIGWINCH, &sigwinch, &save_sigwinch);
 #endif

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -387,7 +387,7 @@ MONO_SIG_HANDLER_FUNC (static, sigusr2_signal_handler)
 }
 
 static void
-add_signal_handler (int signo, gpointer handler)
+add_signal_handler (int signo, gpointer handler, int flags)
 {
 	struct sigaction sa;
 	struct sigaction previous_sa;
@@ -395,7 +395,7 @@ add_signal_handler (int signo, gpointer handler)
 #ifdef MONO_ARCH_USE_SIGACTION
 	sa.sa_sigaction = (void (*)(int, siginfo_t *, void *))handler;
 	sigemptyset (&sa.sa_mask);
-	sa.sa_flags = SA_SIGINFO;
+	sa.sa_flags = SA_SIGINFO | flags;
 #ifdef MONO_ARCH_SIGSEGV_ON_ALTSTACK
 
 /*Apple likes to deliver SIGBUS for *0 */
@@ -426,7 +426,7 @@ add_signal_handler (int signo, gpointer handler)
 #else
 	sa.sa_handler = handler;
 	sigemptyset (&sa.sa_mask);
-	sa.sa_flags = 0;
+	sa.sa_flags = flags;
 #endif
 	g_assert (sigaction (signo, &sa, &previous_sa) != -1);
 
@@ -464,14 +464,14 @@ mono_runtime_posix_install_handlers (void)
 	sigset_t signal_set;
 
 	if (mini_get_debug_options ()->handle_sigint)
-		add_signal_handler (SIGINT, mono_sigint_signal_handler);
+		add_signal_handler (SIGINT, mono_sigint_signal_handler, SA_RESTART);
 
-	add_signal_handler (SIGFPE, mono_sigfpe_signal_handler);
-	add_signal_handler (SIGQUIT, sigquit_signal_handler);
-	add_signal_handler (SIGILL, mono_sigill_signal_handler);
-	add_signal_handler (SIGBUS, mono_sigsegv_signal_handler);
+	add_signal_handler (SIGFPE, mono_sigfpe_signal_handler, 0);
+	add_signal_handler (SIGQUIT, sigquit_signal_handler, SA_RESTART);
+	add_signal_handler (SIGILL, mono_sigill_signal_handler, 0);
+	add_signal_handler (SIGBUS, mono_sigsegv_signal_handler, 0);
 	if (mono_jit_trace_calls != NULL)
-		add_signal_handler (SIGUSR2, sigusr2_signal_handler);
+		add_signal_handler (SIGUSR2, sigusr2_signal_handler, SA_RESTART);
 
 	/* it seems to have become a common bug for some programs that run as parents
 	 * of many processes to block signal delivery for real time signals.
@@ -487,10 +487,10 @@ mono_runtime_posix_install_handlers (void)
 
 	signal (SIGPIPE, SIG_IGN);
 
-	add_signal_handler (SIGABRT, sigabrt_signal_handler);
+	add_signal_handler (SIGABRT, sigabrt_signal_handler, 0);
 
 	/* catch SIGSEGV */
-	add_signal_handler (SIGSEGV, mono_sigsegv_signal_handler);
+	add_signal_handler (SIGSEGV, mono_sigsegv_signal_handler, 0);
 }
 
 #ifndef PLATFORM_MACOSX
@@ -602,7 +602,7 @@ mono_runtime_setup_stat_profiler (void)
 			return;
 		}
 		profiling_signal_in_use = SIGPROF;
-		add_signal_handler (profiling_signal_in_use, sigprof_signal_handler);
+		add_signal_handler (profiling_signal_in_use, sigprof_signal_handler, SA_RESTART);
 		if (ioctl (rtc_fd, RTC_IRQP_SET, freq) == -1) {
 			perror ("set rtc freq");
 			return;
@@ -633,7 +633,7 @@ mono_runtime_setup_stat_profiler (void)
 		return;
 	inited = 1;
 	profiling_signal_in_use = get_itimer_signal ();
-	add_signal_handler (profiling_signal_in_use, sigprof_signal_handler);
+	add_signal_handler (profiling_signal_in_use, sigprof_signal_handler, SA_RESTART);
 	setitimer (get_itimer_mode (), &itval, NULL);
 #endif
 }


### PR DESCRIPTION
We need this as these signals can be delivered at any point and can interrupt system calls that external (non-Mono) code is executing, which such code may not be written to handle gracefully.