### PR TITLE
[System.Xml] Fix sub class serialization on lists

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlTypeMapping.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlTypeMapping.cs
@@ -646,8 +646,15 @@ namespace System.Xml.Serialization
 			{
 				if (memberValue == null) return null;
 				Type type = memberValue.GetType();
-				foreach (XmlTypeMapElementInfo elem in _itemInfo)
-					if (elem.TypeData.Type == type) return elem;
+				XmlTypeMapElementInfo bestMatch = null;
+				foreach (XmlTypeMapElementInfo elem in _itemInfo) {
+					if (elem.TypeData.Type == type)
+						return elem;
+					if (elem.TypeData.Type.IsAssignableFrom (type) &&
+						(bestMatch == null || elem.TypeData.Type.IsAssignableFrom (bestMatch.TypeData.Type)))
+						bestMatch = elem;
+				}
+				return bestMatch;
 			}
 			return null;
 		}	

--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTestClasses.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTestClasses.cs
@@ -711,6 +711,13 @@ namespace MonoTests.System.Xml.TestClasses
 		public object data;
 	}
 
+	public class SubclassTestList
+	{
+		[XmlElement ("a", typeof (SimpleClass))]
+		[XmlElement ("b", typeof (SubclassTestBase))]
+		public List<object> Items;
+	}
+
 	public class DictionaryWithIndexer : DictionaryBase
 	{
 		public TimeSpan this[int index]

--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlSerializerTests.cs
@@ -1939,6 +1939,17 @@ namespace MonoTests.System.XmlSerialization
 			Assert.AreEqual (Infoset (res), WriterText);
 		}
 
+		[Test] // Covers #36829
+		public void TestSubclassElementList ()
+		{
+			var o = new SubclassTestList () { Items = new List<object> () { new SubclassTestSub () } };
+			Serialize (o);
+
+			string res = "<SubclassTestList xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>";
+			res += "<b xsi:type=\"SubclassTestSub\"/></SubclassTestList>";
+			Assert.AreEqual (Infoset (res), WriterText);
+		}
+
 		[Test]
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void TestArrayAttributeWithWrongDataType ()


### PR DESCRIPTION
Fixes failure, where XmlSerializer would crash while serializing
a list with multiple XmlElement when a sub class of the XmlElement is
used.

Fixes [#36829](https://bugzilla.xamarin.com/show_bug.cgi?id=36829).