### PR TITLE
[runtime] Allow getting thread name, managed id from embedding API

### DIFF
--- a/docs/public-api
+++ b/docs/public-api
@@ -750,6 +750,8 @@ mono_thread_current
 mono_thread_detach
 mono_thread_exit
 mono_thread_get_main
+mono_thread_get_managed_id
+mono_thread_get_name_utf8
 mono_thread_get_undeniable_exception
 mono_thread_hazardous_free_or_queue
 mono_thread_hazardous_try_free_all

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1246,6 +1246,53 @@ mono_thread_get_name (MonoInternalThread *this_obj, guint32 *name_len)
 	return res;
 }
 
+/*
+ * mono_thread_get_name_utf8:
+ *
+ * Return the name of the thread in UTF-8.
+ * Return NULL if the thread has no name.
+ * The returned memory is owned by the caller.
+ */
+char *
+mono_thread_get_name_utf8 (MonoThread *thread)
+{
+	if (thread == NULL)
+		return NULL;
+
+	MonoInternalThread *internal = thread->internal_thread;
+	if (internal == NULL)
+		return NULL;
+
+	LOCK_THREAD (internal);
+
+	char *tname = g_utf16_to_utf8 (internal->name, internal->name_len, NULL, NULL, NULL);
+
+	UNLOCK_THREAD (internal);
+
+	return tname;
+}
+
+/*
+ * mono_thread_get_managed_id:
+ *
+ * Return the Thread.ManagedThreadId value of `thread`.
+ * Returns -1 if `thread` is NULL.
+ */
+int32_t
+mono_thread_get_managed_id (MonoThread *thread)
+{
+	if (thread == NULL)
+		return -1;
+
+	MonoInternalThread *internal = thread->internal_thread;
+	if (internal == NULL)
+		return -1;
+
+	int32_t id = internal->managed_id;
+
+	return id;
+}
+
 MonoString* 
 ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThread *this_obj)
 {

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -39,6 +39,9 @@ extern MONO_API MonoThread *mono_thread_attach (MonoDomain *domain);
 extern MONO_API void mono_thread_detach (MonoThread *thread);
 extern MONO_API void mono_thread_exit (void);
 
+extern MONO_API char   *mono_thread_get_name_utf8 (MonoThread *thread);
+extern MONO_API int32_t mono_thread_get_managed_id (MonoThread *thread);
+
 MONO_API void     mono_thread_set_manage_callback (MonoThread *thread, MonoThreadManageCallback func);
 
 extern MONO_API void mono_threads_set_default_stacksize (uint32_t stacksize);

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -824,6 +824,8 @@ mono_thread_detach
 mono_thread_detach_if_exiting
 mono_thread_exit
 mono_thread_get_main
+mono_thread_get_managed_id
+mono_thread_get_name_utf8
 mono_thread_get_undeniable_exception
 mono_thread_init
 mono_thread_is_foreign

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -826,6 +826,8 @@ mono_thread_detach
 mono_thread_detach_if_exiting
 mono_thread_exit
 mono_thread_get_main
+mono_thread_get_managed_id
+mono_thread_get_name_utf8
 mono_thread_get_undeniable_exception
 mono_thread_init
 mono_thread_is_foreign


### PR DESCRIPTION
When tracing multi-threaded program execution, it is useful to have a
way of separating which events happen on which thread. The
`System.Threading.Thread.Name` and `Thread.ManagedThreadId` properties are
useful proxies for tracking program execution.

However, if program execution spans both managed and embedded mono
native code, there is no existing mechanism to read the `Thread.Name` or
`Thread.ManagedThreadId` properties from native code without using
delegates, and delegates may not be usable in all circumstances (e.g.
within a `mono_gc_register_bridge_callbacks()` callback).

Add the following APIs to the embedding API to permit reading the
`Thread.Name` and `Thread.ManagedThreadId` properties:

	char   *mono_thread_get_name_utf8 (MonoThread *thread);
	gint32  mono_thread_get_managed_id (MonoThread *thread);

`mono_thread_get_name_utf8()` returns the `Thread.Name` value as a UTF-8
string in newly allocated memory; the caller must `g_free()` this value.

`mono_thread_get_managed_id()` returns the `Thread.ManagedThreadId` value.