### PR TITLE
[Process] Fix NullReferenceException in AsyncStreamReader.ReadBuffer after disposing the Process

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -1490,11 +1490,8 @@ namespace System.Diagnostics {
 			// dispose all managed resources.
 			if (disposing) {
 #if MONO_FEATURE_PROCESS_START
-				/* These have open FileStreams on the pipes we are about to close */
-				if (async_output != null)
-					async_output.Close ();
-				if (async_error != null)
-					async_error.Close ();
+				async_output = null;
+				async_error = null;
 
 				if (input_stream != null) {
 					if (!input_stream_exposed)


### PR DESCRIPTION
The following exception would arise if we dispose the Process before making sure the AsyncStreamReader finished its work:

Unhandled Exception:
System.NullReferenceException: Object reference not set to an instance of an object
  at System.Diagnostics.AsyncStreamReader.ReadBuffer (IAsyncResult ar) [0x00000] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/System/services/monitoring/system/diagnosticts/AsyncStreamReader.cs:158
  at System.IO.Stream+ReadWriteTask.InvokeAsyncCallback (System.Object completedTask) [0x00015] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/io/stream.cs:670
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, Boolean preserveSyncCtx) [0x0008d] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/executioncontext.cs:957
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, Boolean preserveSyncCtx) [0x00000] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/executioncontext.cs:904
  at System.IO.Stream+ReadWriteTask.System.Threading.Tasks.ITaskCompletionAction.Invoke (System.Threading.Tasks.Task completingTask) [0x0005e] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/io/stream.cs:696
  at System.Threading.Tasks.Task.FinishContinuations () [0x0009a] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:3633
  at System.Threading.Tasks.Task.FinishStageThree () [0x00045] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:2366
  at System.Threading.Tasks.Task.FinishStageTwo () [0x000f8] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:2339
  at System.Threading.Tasks.Task.Finish (Boolean bUserDelegateExecuted) [0x00049] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:2239
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task& currentTaskSlot) [0x00079] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:2834
  at System.Threading.Tasks.Task.ExecuteEntry (Boolean bPreventDoubleExecution) [0x0006f] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:2760
  at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00000] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/Tasks/Task.cs:2707
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00096] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/threadpool.cs:857
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in /media/ssd/jenkins/workspace/test-mono-mainline/label/debian-armhf/external/referencesource/mscorlib/system/threading/threadpool.cs:1212

This would arise in test-runner.cs when one of the test would timeout, leading to the Process being disposed. This would then dispose the AsyncStreamReader, setting its `stream` value to null. The callback to ReadBuffer would then try to access `stream`, but would throw a NullReferenceException. By not disposing the AsyncStreamReader explicitely, we close the stream first, which will trigger a call to ReadBuffer, thus not triggering the NullReferenceException.