### PR TITLE
[runtime] Add MONO_ERROR_EXCEPTION_INSTANCE MonoError

### DIFF
--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -15,7 +15,16 @@ typedef struct {
 	const char *member_name;
 	const char *exception_name_space;
 	const char *exception_name;
-	MonoClass *klass;
+	union {
+		/* Valid if error_code != MONO_ERROR_EXCEPTION_INSTANCE.
+		 * Used by type or field load errors and generic error specified by class.
+		 */
+		MonoClass *klass;
+		/* Valid if error_code == MONO_ERROR_EXCEPTION_INSTANCE.
+		 * Generic error specified by a managed instance.
+		 */
+		uint32_t instance_handle;
+	} exn;
 	const char *full_message;
 	const char *full_message_with_fields;
 	const char *first_argument;
@@ -75,6 +84,9 @@ mono_error_set_not_verifiable (MonoError *oerror, MonoMethod *method, const char
 
 void
 mono_error_set_generic_error (MonoError *error, const char * name_space, const char *name, const char *msg_format, ...);
+
+void
+mono_error_set_exception_instance (MonoError *error, MonoException *exc);
 
 void
 mono_error_set_from_loader_error (MonoError *error);

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -29,7 +29,9 @@ enum {
 	 * This is a generic error mechanism is you need to raise an arbitrary corlib exception.
 	 * You must pass the exception name otherwise prepare_exception will fail with internal execution. 
 	 */
-	MONO_ERROR_GENERIC = 9
+	MONO_ERROR_GENERIC = 9,
+	/* This one encapsulates a managed exception instance */
+	MONO_ERROR_EXCEPTION_INSTANCE = 10
 };
 
 /*Keep in sync with MonoErrorInternal*/


### PR DESCRIPTION
This kind of MonoError can encapsulate a managed MonoException
object.  (For example as a result of mono_runtime_invoke ()).

Issues:

- [x] Memory leak correctness.
    `MonoError` already leaks memory if you simply swallow it without calling `mono_error_cleanup` or some function that calls it (for example `mono_error_raise_exception` or `mono_error_convert_to_exception`).
    Now if we have an encapsulated exception, we'll leak a GC handle unless cleanup happens.
 