### PR TITLE
[runtime] Use MonoError for mono_method_get_object

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -2795,7 +2795,9 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 
 	if (!delegate->method_info) {
 		g_assert (delegate->method);
-		MONO_OBJECT_SETREF (delegate, method_info, mono_method_get_object (domain, delegate->method, NULL));
+		MonoReflectionMethod *rm = mono_method_get_object_checked (domain, delegate->method, NULL, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		MONO_OBJECT_SETREF (delegate, method_info, rm);
 	}
 
 	if (!delegate->method_info || !delegate->method_info->method)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6769,6 +6769,7 @@ mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoError error;
+
 	MonoDomain *domain = mono_domain_get ();
 	MonoMethodSignature *sig = mono_method_signature (method);
 	MonoMethodMessage *msg;
@@ -6778,10 +6779,14 @@ mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	if (invoke) {
-		mono_message_init (domain, msg, mono_method_get_object (domain, invoke, NULL), NULL);
+		MonoReflectionMethod *rm = mono_method_get_object_checked (domain, invoke, NULL, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_message_init (domain, msg, rm, NULL);
 		count =  sig->param_count - 2;
 	} else {
-		mono_message_init (domain, msg, mono_method_get_object (domain, method, NULL), NULL);
+		MonoReflectionMethod *rm = mono_method_get_object_checked (domain, method, NULL, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_message_init (domain, msg, rm, NULL);
 		count =  sig->param_count;
 	}
 
@@ -6889,6 +6894,7 @@ mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoError error;
+
 	static MonoMethod *getter = NULL;
 	MonoDomain *domain = mono_domain_get ();
 	MonoTransparentProxy *tp = (MonoTransparentProxy *) this_obj;
@@ -6917,7 +6923,9 @@ mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *
 	msg = (MonoMethodMessage *)mono_object_new_checked (domain, mono_defaults.mono_method_message_class, &error);
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	out_args = mono_array_new (domain, mono_defaults.object_class, 1);
-	mono_message_init (domain, msg, mono_method_get_object (domain, getter, NULL), out_args);
+	MonoReflectionMethod *rm = mono_method_get_object_checked (domain, getter, NULL, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_message_init (domain, msg, rm, out_args);
 
 	full_name = mono_type_get_full_name (klass);
 	mono_array_setref (msg->args, 0, mono_string_new (domain, full_name));
@@ -6953,6 +6961,7 @@ mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassFie
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoError error;
+
 	static MonoMethod *getter = NULL;
 	MonoDomain *domain = mono_domain_get ();
 	MonoTransparentProxy *tp = (MonoTransparentProxy *) this_obj;
@@ -6989,7 +6998,9 @@ mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassFie
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	out_args = mono_array_new (domain, mono_defaults.object_class, 1);
 
-	mono_message_init (domain, msg, mono_method_get_object (domain, getter, NULL), out_args);
+	MonoReflectionMethod *rm = mono_method_get_object_checked (domain, getter, NULL, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_message_init (domain, msg, rm, out_args);
 
 	full_name = mono_type_get_full_name (klass);
 	mono_array_setref (msg->args, 0, mono_string_new (domain, full_name));
@@ -7025,6 +7036,7 @@ mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField 
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoError error;
+
 	static MonoMethod *setter = NULL;
 	MonoDomain *domain = mono_domain_get ();
 	MonoTransparentProxy *tp = (MonoTransparentProxy *) this_obj;
@@ -7059,7 +7071,9 @@ mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField 
 
 	msg = (MonoMethodMessage *)mono_object_new_checked (domain, mono_defaults.mono_method_message_class, &error);
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
-	mono_message_init (domain, msg, mono_method_get_object (domain, setter, NULL), NULL);
+	MonoReflectionMethod *rm = mono_method_get_object_checked (domain, setter, NULL, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_message_init (domain, msg, rm, NULL);
 
 	full_name = mono_type_get_full_name (klass);
 	mono_array_setref (msg->args, 0, mono_string_new (domain, full_name));
@@ -7087,6 +7101,7 @@ mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassFi
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoError error;
+
 	static MonoMethod *setter = NULL;
 	MonoDomain *domain = mono_domain_get ();
 	MonoTransparentProxy *tp = (MonoTransparentProxy *) this_obj;
@@ -7113,8 +7128,10 @@ mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassFi
 	}
 
 	msg = (MonoMethodMessage *)mono_object_new_checked (domain, mono_defaults.mono_method_message_class, &error);
-	mono_error_raise_exception (&error);
-	mono_message_init (domain, msg, mono_method_get_object (domain, setter, NULL), NULL);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	MonoReflectionMethod *rm = mono_method_get_object_checked (domain, setter, NULL, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_message_init (domain, msg, rm, NULL);
 
 	full_name = mono_type_get_full_name (klass);
 	mono_array_setref (msg->args, 0, mono_string_new (domain, full_name));

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -23,4 +23,7 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 MonoReflectionField*
 mono_field_get_object_checked (MonoDomain *domain, MonoClass *klass, MonoClassField *field, MonoError *error);
 
+MonoReflectionMethod*
+mono_method_get_object_checked (MonoDomain *domain, MonoMethod *method, MonoClass *refclass, MonoError *error);
+
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -6834,6 +6834,26 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 MonoReflectionMethod*
 mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refclass)
 {
+	MonoError error;
+	MonoReflectionMethod *ret = NULL;
+	ret = mono_method_get_object_checked (domain, method, refclass, &error);
+	mono_error_raise_exception (&error);
+	return ret;
+}
+
+/*
+ * mono_method_get_object_checked:
+ * @domain: an app domain
+ * @method: a method
+ * @refclass: the reflected type (can be NULL)
+ * @error: set on error.
+ *
+ * Return an System.Reflection.MonoMethod object representing the method @method.
+ * Returns NULL and sets @error on error.
+ */
+MonoReflectionMethod*
+mono_method_get_object_checked (MonoDomain *domain, MonoMethod *method, MonoClass *refclass, MonoError *error)
+{
 	/*
 	 * We use the same C representation for methods and constructors, but the type 
 	 * name in C# is different.
@@ -6842,10 +6862,11 @@ mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refcl
 	static MonoClass *System_Reflection_MonoCMethod = NULL;
 	static MonoClass *System_Reflection_MonoGenericMethod = NULL;
 	static MonoClass *System_Reflection_MonoGenericCMethod = NULL;
-	MonoError error;
 	MonoReflectionType *rt;
 	MonoClass *klass;
 	MonoReflectionMethod *ret;
+
+	mono_error_init (error);
 
 	if (method->is_inflated) {
 		MonoReflectionGenericMethod *gret;
@@ -6854,22 +6875,30 @@ mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refcl
 			refclass = method->klass;
 		CHECK_OBJECT (MonoReflectionMethod *, method, refclass);
 		if ((*method->name == '.') && (!strcmp (method->name, ".ctor") || !strcmp (method->name, ".cctor"))) {
-			if (!System_Reflection_MonoGenericCMethod)
-				System_Reflection_MonoGenericCMethod = mono_class_from_name (mono_defaults.corlib, "System.Reflection", "MonoGenericCMethod");
+			if (!System_Reflection_MonoGenericCMethod) {
+				System_Reflection_MonoGenericCMethod = mono_class_from_name_checked (mono_defaults.corlib, "System.Reflection", "MonoGenericCMethod", error);
+				if (!mono_error_ok (error))
+					goto leave;
+			}
 			klass = System_Reflection_MonoGenericCMethod;
 		} else {
-			if (!System_Reflection_MonoGenericMethod)
-				System_Reflection_MonoGenericMethod = mono_class_from_name (mono_defaults.corlib, "System.Reflection", "MonoGenericMethod");
+			if (!System_Reflection_MonoGenericMethod) {
+				System_Reflection_MonoGenericMethod = mono_class_from_name_checked (mono_defaults.corlib, "System.Reflection", "MonoGenericMethod", error);
+				if (!mono_error_ok (error))
+					goto leave;
+			}
 			klass = System_Reflection_MonoGenericMethod;
 		}
-		gret = (MonoReflectionGenericMethod*)mono_object_new_checked (domain, klass, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		gret = (MonoReflectionGenericMethod*)mono_object_new_checked (domain, klass, error);
+		if (!mono_error_ok (error))
+			goto leave;
 		gret->method.method = method;
 
 		MONO_OBJECT_SETREF (gret, method.name, mono_string_new (domain, method->name));
 
-		rt = mono_type_get_object_checked (domain, &refclass->byval_arg, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		rt = mono_type_get_object_checked (domain, &refclass->byval_arg, error);
+		if (!mono_error_ok (error))
+		    goto leave;
 
 		MONO_OBJECT_SETREF (gret, method.reftype, rt);
 
@@ -6881,25 +6910,37 @@ mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refcl
 
 	CHECK_OBJECT (MonoReflectionMethod *, method, refclass);
 	if (*method->name == '.' && (strcmp (method->name, ".ctor") == 0 || strcmp (method->name, ".cctor") == 0)) {
-		if (!System_Reflection_MonoCMethod)
-			System_Reflection_MonoCMethod = mono_class_from_name (mono_defaults.corlib, "System.Reflection", "MonoCMethod");
+		if (!System_Reflection_MonoCMethod) {
+			System_Reflection_MonoCMethod = mono_class_from_name_checked (mono_defaults.corlib, "System.Reflection", "MonoCMethod", error);
+			if (!mono_error_ok (error))
+				goto leave;
+		}
 		klass = System_Reflection_MonoCMethod;
 	}
 	else {
-		if (!System_Reflection_MonoMethod)
-			System_Reflection_MonoMethod = mono_class_from_name (mono_defaults.corlib, "System.Reflection", "MonoMethod");
+		if (!System_Reflection_MonoMethod) {
+			System_Reflection_MonoMethod = mono_class_from_name_checked (mono_defaults.corlib, "System.Reflection", "MonoMethod", error);
+			if (!mono_error_ok (error))
+				goto leave;
+		}
 		klass = System_Reflection_MonoMethod;
 	}
-	ret = (MonoReflectionMethod*)mono_object_new_checked (domain, klass, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	ret = (MonoReflectionMethod*)mono_object_new_checked (domain, klass, error);
+	if (!mono_error_ok (error))
+		goto leave;
 	ret->method = method;
 
-	rt = mono_type_get_object_checked (domain, &refclass->byval_arg, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */;
+	rt = mono_type_get_object_checked (domain, &refclass->byval_arg, error);
+	if (!mono_error_ok (error))
+		goto leave;
 
 	MONO_OBJECT_SETREF (ret, reftype, rt);
 
 	CACHE_OBJECT (MonoReflectionMethod *, method, ret, refclass);
+
+leave:
+	g_assert (!mono_error_ok (error));
+	return NULL;
 }
 
 /*

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -51,6 +51,7 @@ MONO_API MonoReflectionAssembly* mono_assembly_get_object (MonoDomain *domain, M
 MONO_API MonoReflectionModule*   mono_module_get_object   (MonoDomain *domain, MonoImage *image);
 MONO_API MonoReflectionModule*   mono_module_file_get_object (MonoDomain *domain, MonoImage *image, int table_index);
 MONO_API MonoReflectionType*     mono_type_get_object     (MonoDomain *domain, MonoType *type);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionMethod*   mono_method_get_object   (MonoDomain *domain, MonoMethod *method, MonoClass *refclass);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionField*    mono_field_get_object    (MonoDomain *domain, MonoClass *klass, MonoClassField *field);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -42,6 +42,7 @@
 #include <mono/utils/mono-memory-model.h>
 
 #include <mono/metadata/gc-internals.h>
+#include <mono/metadata/reflection-internals.h>
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
@@ -3487,6 +3488,7 @@ static void
 mono_threads_get_thread_dump (MonoArray **out_threads, MonoArray **out_stack_frames)
 {
 	MonoError error;
+
 	ThreadDumpUserData ud;
 	MonoInternalThread *thread_array [128];
 	MonoDomain *domain = mono_domain_get ();
@@ -3543,7 +3545,9 @@ mono_threads_get_thread_dump (MonoArray **out_threads, MonoArray **out_stack_fra
 			if (method) {
 				sf->method_address = (gsize) frame->ji->code_start;
 
-				MONO_OBJECT_SETREF (sf, method, mono_method_get_object (domain, method, NULL));
+				MonoReflectionMethod *rm = mono_method_get_object_checked (domain, method, NULL, &error);
+				mono_error_raise_exception (&error); /* FIXME don't raise here */
+				MONO_OBJECT_SETREF (sf, method, rm);
 
 				location = mono_debug_lookup_source_location (method, frame->native_offset, domain);
 				if (location) {

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -19,6 +19,7 @@
 #include "jit-icalls.h"
 #include <mono/utils/mono-error-internals.h>
 #include <mono/metadata/threads-types.h>
+#include <mono/metadata/reflection-internals.h>
 
 #ifdef ENABLE_LLVM
 #include "mini-llvm-cpp.h"
@@ -1733,7 +1734,11 @@ mono_get_assembly_object (MonoImage *image)
 MonoObject*
 mono_get_method_object (MonoMethod *method)
 {
-	return (MonoObject*)mono_method_get_object (mono_domain_get (), method, method->klass);
+	MonoError error;
+	MonoObject * result;
+	result = (MonoObject*)mono_method_get_object_checked (mono_domain_get (), method, method->klass, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 double

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -53,6 +53,7 @@
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/object-internals.h>
+#include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/profiler.h>
@@ -741,8 +742,11 @@ ves_icall_get_trace (MonoException *exc, gint32 skip, MonoBoolean need_file_info
 			MONO_OBJECT_SETREF (sf, internal_method_name, mono_string_new (domain, s));
 			g_free (s);
 		}
-		else
-			MONO_OBJECT_SETREF (sf, method, mono_method_get_object (domain, method, NULL));
+		else {
+			MonoReflectionMethod *rm = mono_method_get_object_checked (domain, method, NULL, &error);
+			mono_error_raise_exception (&error);
+			MONO_OBJECT_SETREF (sf, method, rm);
+		}
 
 		sf->method_index = ji->from_aot ? mono_aot_find_method_index (method) : 0xffffff;
 		sf->method_address = (gsize) ji->code_start;
@@ -960,6 +964,7 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 			  gint32 *iloffset, gint32 *native_offset,
 			  MonoString **file, gint32 *line, gint32 *column)
 {
+	MonoError error;
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoLMF *lmf = mono_get_lmf ();
@@ -1035,7 +1040,9 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 		actual_method = get_method_from_stack_frame (ji, get_generic_info_from_stack_frame (ji, &ctx));
 	}
 
-	mono_gc_wbarrier_generic_store (method, (MonoObject*) mono_method_get_object (domain, actual_method, NULL));
+	MonoReflectionMethod *rm = mono_method_get_object_checked (domain, actual_method, NULL, &error);
+	mono_error_raise_exception (&error);
+	mono_gc_wbarrier_generic_store (method, (MonoObject*) rm);
 
 	location = mono_debug_lookup_source_location (jmethod, *native_offset, domain);
 	if (location)


### PR DESCRIPTION
Depends on #2532 

Issues:

- [x] ~~depends on #2486~~
- [x] ~~Should use `mono_object_new_checked` #2532~~ 
- [x] ~~Should use `mono_string_new_checked`~~ (`mono_string_new` will assert instead of raising an exception - #2530)