### PR TITLE
[System] Fix error in new BeginConnectToIPV4EndPointUsingDualModelSocket test

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -4361,16 +4361,19 @@ namespace MonoTests.System.Net.Sockets
 				
 				var ep = server.LocalEndPoint as IPEndPoint;
 				
+				BCCalledBack.Reset ();
 				var ar1 = client.BeginConnect (ep, BCCallback, client);
-				client.EndConnect (ar1);
+				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#1");
 				client.Disconnect (true);
 				
+				BCCalledBack.Reset ();
 				var ar2 = client.BeginConnect (IPAddress.Loopback, ep.Port, BCCallback, client);
-				client.EndConnect (ar2);
+				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#2");
 				client.Disconnect (true);
 				
+				BCCalledBack.Reset ();
 				var ar3 = client.BeginConnect (new [] {IPAddress.Loopback}, ep.Port, BCCallback, client);
-				client.EndConnect (ar3);
+				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#2");
 				client.Disconnect (true);
 			}
 		}


### PR DESCRIPTION
It was added with 78c758494a04132c0965f8af82dd7370da5f4af1. The test fails on Jenkins:

```
Test Case Failures:
1) MonoTests.System.Net.Sockets.SocketTest.BeginConnectToIPV4EndPointUsingDualModelSocket : System.InvalidOperationException : EndConnect can only be called once per asynchronous operation
at System.Net.Sockets.Socket.ValidateEndIAsyncResult (IAsyncResult ares, System.String methodName, System.String argName) [0x0004a] in /var/lib/jenkins/workspace/test-mono-mainline/label/debian-amd64/mcs/class/System/System.Net.Sockets/Socket.cs:3412
at System.Net.Sockets.Socket.EndConnect (IAsyncResult result) [0x00006] in /var/lib/jenkins/workspace/test-mono-mainline/label/debian-amd64/mcs/class/System/System.Net.Sockets/Socket.cs:1584
at MonoTests.System.Net.Sockets.SocketTest.BeginConnectToIPV4EndPointUsingDualModelSocket () [0x0005d] in /var/lib/jenkins/workspace/test-mono-mainline/label/debian-amd64/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs:4365
at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in /var/lib/jenkins/workspace/test-mono-mainline/label/debian-amd64/mcs/class/corlib/System.Reflection/MonoMethod.cs:295
```

The reason is that BCCallback already calls EndConnect() so we need to remove it and just wait for the callback in the test itself.

@monojenkins merge