### PR TITLE
[runtime] Use MonoError for mono_string_new

### DIFF
--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -289,10 +289,12 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetCurrentToken (void)
 MonoString*
 ves_icall_System_Security_Principal_WindowsIdentity_GetTokenName (gpointer token)
 {
+	MonoError error;
 	MonoString *result = NULL;
 	gunichar2 *uniname = NULL;
 	gint32 size = 0;
 
+	mono_error_init (&error);
 #ifdef HOST_WIN32
 	GetTokenInformation (token, TokenUser, NULL, size, (PDWORD)&size);
 	if (size > 0) {
@@ -313,7 +315,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetTokenName (gpointer token
 #endif /* HOST_WIN32 */
 
 	if (size > 0) {
-		result = mono_string_new_utf16 (mono_domain_get (), uniname, size);
+		result = mono_string_new_utf16_checked (mono_domain_get (), uniname, size, &error);
 	}
 	else
 		result = mono_string_new (mono_domain_get (), "");
@@ -321,6 +323,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetTokenName (gpointer token
 	if (uniname)
 		g_free (uniname);
 
+	mono_error_raise_exception (&error);
 	return result;
 }
 
@@ -406,7 +409,9 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 				gunichar2 *uniname = GetSidName (NULL, tg->Groups [i].Sid, &size);
 
 				if (uniname) {
-					MonoString *str = mono_string_new_utf16 (domain, uniname, size);
+					MonoError error;
+					MonoString *str = mono_string_new_utf16_checked (domain, uniname, size, &error);
+					mono_error_raise_exception (&error);
 					mono_array_setref (array, i, str);
 					g_free (uniname);
 				}

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1692,6 +1692,9 @@ mono_object_clone_checked (MonoObject *obj, MonoError *error);
 MonoString *
 mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error);
 
+MonoString*
+mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *merror);
+
 MonoString *
 mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1692,6 +1692,9 @@ mono_object_clone_checked (MonoObject *obj, MonoError *error);
 MonoString *
 mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error);
 
+MonoString *
+mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
+
 #endif /* __MONO_OBJECT_INTERNALS_H__ */
 
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5319,53 +5319,78 @@ mono_string_new_len (MonoDomain *domain, const char *text, guint length)
  * @text: a pointer to an utf8 string
  *
  * Returns: A newly created string object which contains @text.
+ *
+ * This function asserts if it cannot allocate a new string.
+ *
+ * @deprecated Use mono_string_new_checked in new code.
  */
 MonoString*
 mono_string_new (MonoDomain *domain, const char *text)
 {
+	MonoError error;
+	MonoString *res = NULL;
+	res = mono_string_new_checked (domain, text, &error);
+	mono_error_assert_ok (&error);
+	return res;
+}
+
+/**
+ * mono_string_new_checked:
+ * @text: a pointer to an utf8 string
+ * @merror: set on error
+ *
+ * Returns: A newly created string object which contains @text.
+ * On error returns NULL and sets @merror.
+ */
+MonoString*
+mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *error)
+{
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
     GError *eg_error = NULL;
     MonoString *o = NULL;
     guint16 *ut;
     glong items_written;
     int l;
 
-    mono_error_init (&error);
+    mono_error_init (error);
 
     l = strlen (text);
    
     ut = g_utf8_to_utf16 (text, l, NULL, &items_written, &eg_error);
 
     if (!eg_error)
-	    o = mono_string_new_utf16_checked (domain, ut, items_written, &error);
+	    o = mono_string_new_utf16_checked (domain, ut, items_written, error);
     else
         g_error_free (eg_error);
 
     g_free (ut);
-    mono_error_raise_exception (&error);
+    mono_error_raise_exception (error);
     
 /*FIXME g_utf8_get_char, g_utf8_next_char and g_utf8_validate are not part of eglib.*/
 #if 0
-	MonoError error;
 	gunichar2 *str;
 	const gchar *end;
 	int len;
 	MonoString *o = NULL;
 
-	if (!g_utf8_validate (text, -1, &end))
-		return NULL;
+	if (!g_utf8_validate (text, -1, &end)) {
+		mono_error_set_argument (error, "text", "Not a valid utf8 string");
+		goto leave;
+	}
 
 	len = g_utf8_strlen (text, -1);
-	o = mono_string_new_size_checked (domain, len, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	o = mono_string_new_size_checked (domain, len, error);
+	if (!o)
+		goto leave;
 	str = mono_string_chars (o);
 
 	while (text < end) {
 		*str++ = g_utf8_get_char (text);
 		text = g_utf8_next_char (text);
 	}
+
+leave:
 #endif
 	return o;
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5163,12 +5163,34 @@ mono_string_new_utf16 (MonoDomain *domain, const guint16 *text, gint32 len)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoError error;
+	MonoString *res = NULL;
+	res = mono_string_new_utf16_checked (domain, text, len, &error);
+	mono_error_raise_exception (&error);
+
+	return res;
+}
+
+/**
+ * mono_string_new_utf16_checked:
+ * @text: a pointer to an utf16 string
+ * @len: the length of the string
+ * @error: written on error.
+ *
+ * Returns: A newly created string object which contains @text.
+ * On error, returns NULL and sets @error.
+ */
+MonoString *
+mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoString *s;
 	
-	s = mono_string_new_size_checked (domain, len, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
-
-	memcpy (mono_string_chars (s), text, len * 2);
+	mono_error_init (error);
+	
+	s = mono_string_new_size_checked (domain, len, error);
+	if (s != NULL)
+		memcpy (mono_string_chars (s), text, len * 2);
 
 	return s;
 }

--- a/mono/metadata/process.c
+++ b/mono/metadata/process.c
@@ -105,12 +105,14 @@ static void process_set_field_object (MonoObject *obj, const gchar *fieldname,
 static void process_set_field_string (MonoObject *obj, const gchar *fieldname,
 				      const gunichar2 *val, guint32 len)
 {
+	MonoError error;
 	MonoClassField *field;
 	MonoString *string;
 
 	LOGDEBUG (g_message ("%s: Setting field %s to [%s]", __func__, fieldname, g_utf16_to_utf8 (val, len, NULL, NULL, NULL)));
 
-	string=mono_string_new_utf16 (mono_object_domain (obj), val, len);
+	string = mono_string_new_utf16_checked (mono_object_domain (obj), val, len, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	
 	field=mono_class_get_field_from_name (mono_object_class (obj),
 					      fieldname);
@@ -879,6 +881,7 @@ gint32 ves_icall_System_Diagnostics_Process_ExitCode_internal (HANDLE process)
 
 MonoString *ves_icall_System_Diagnostics_Process_ProcessName_internal (HANDLE process)
 {
+	MonoError error;
 	MonoString *string;
 	gboolean ok;
 	HMODULE mod;
@@ -898,7 +901,9 @@ MonoString *ves_icall_System_Diagnostics_Process_ProcessName_internal (HANDLE pr
 	
 	LOGDEBUG (g_message ("%s: process name is [%s]", __func__, g_utf16_to_utf8 (name, -1, NULL, NULL, NULL)));
 	
-	string=mono_string_new_utf16 (mono_domain_get (), name, len);
+	string = mono_string_new_utf16_checked (mono_domain_get (), name, len, &error);
+
+	mono_error_raise_exception (&error);
 	
 	return(string);
 }

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -1977,6 +1977,7 @@ mono_get_xdomain_marshal_type (MonoType *t)
 MonoObject *
 mono_marshal_xdomain_copy_value (MonoObject *val)
 {
+	MonoError error;
 	MonoDomain *domain;
 	if (val == NULL) return NULL;
 
@@ -2002,7 +2003,10 @@ mono_marshal_xdomain_copy_value (MonoObject *val)
 	}
 	case MONO_TYPE_STRING: {
 		MonoString *str = (MonoString *) val;
-		return (MonoObject *) mono_string_new_utf16 (domain, mono_string_chars (str), mono_string_length (str));
+		MonoObject *res = NULL;
+		res = (MonoObject *) mono_string_new_utf16_checked (domain, mono_string_chars (str), mono_string_length (str), &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		return res;
 	}
 	case MONO_TYPE_ARRAY:
 	case MONO_TYPE_SZARRAY: {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1322,16 +1322,21 @@ mono_thread_get_managed_id (MonoThread *thread)
 MonoString* 
 ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThread *this_obj)
 {
+	MonoError error;
 	MonoString* str;
+
+	mono_error_init (&error);
 
 	LOCK_THREAD (this_obj);
 	
 	if (!this_obj->name)
 		str = NULL;
 	else
-		str = mono_string_new_utf16 (mono_domain_get (), this_obj->name, this_obj->name_len);
+		str = mono_string_new_utf16_checked (mono_domain_get (), this_obj->name, this_obj->name_len, &error);
 	
 	UNLOCK_THREAD (this_obj);
+
+	mono_error_raise_exception (&error);
 	
 	return str;
 }

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -80,6 +80,9 @@ void
 mono_error_set_argument (MonoError *error, const char *argument, const char *msg_format, ...);
 
 void
+mono_error_set_argument_null (MonoError *oerror, const char *argument, const char *msg_format, ...);
+
+void
 mono_error_set_not_verifiable (MonoError *oerror, MonoMethod *method, const char *msg_format, ...);
 
 void

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -481,6 +481,18 @@ mono_error_set_argument (MonoError *oerror, const char *argument, const char *ms
 }
 
 void
+mono_error_set_argument_null (MonoError *oerror, const char *argument, const char *msg_format, ...)
+{
+	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
+	mono_error_prepare (error);
+
+	error->error_code = MONO_ERROR_ARGUMENT_NULL;
+	error->first_argument = argument;
+
+	set_error_message ();
+}
+
+void
 mono_error_set_not_verifiable (MonoError *oerror, MonoMethod *method, const char *msg_format, ...)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
@@ -642,6 +654,10 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 
 	case MONO_ERROR_ARGUMENT:
 		exception = mono_get_exception_argument (error->first_argument, error->full_message);
+		break;
+
+	case MONO_ERROR_ARGUMENT_NULL:
+		exception = mono_get_exception_argument_null (error->first_argument);
 		break;
 
 	case MONO_ERROR_NOT_VERIFIABLE: {

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -24,6 +24,7 @@ enum {
 	MONO_ERROR_BAD_IMAGE = 5,
 	MONO_ERROR_OUT_OF_MEMORY = 6,
 	MONO_ERROR_ARGUMENT = 7,
+	MONO_ERROR_ARGUMENT_NULL = 11,
 	MONO_ERROR_NOT_VERIFIABLE = 8,
 	/*
 	 * This is a generic error mechanism is you need to raise an arbitrary corlib exception.


### PR DESCRIPTION
We are refraining from changing runtime callers of `mono_string_new` to `mono_string_new_checked` in one commit. String creation is used in several hundred places and threading error handling through all the callers is very intrusive. Additionally, AFAIK the only error condition from mono_string_new is out-of-memory. In a lot of cases there's no way to meaningfully recover.

We should revisit individual callers when it makes sense, but just mechanically updating everywhere doesn't get us a lot of benefit.