### PR TITLE
[System.Web] HeadersCollection read only exception

### DIFF
--- a/mcs/class/System.Web/System.Web/HeadersCollection.cs
+++ b/mcs/class/System.Web/System.Web/HeadersCollection.cs
@@ -39,6 +39,30 @@ namespace System.Web
 		{
 		}
 
+		public override void Add (string name, string value)
+		{
+			if (IsReadOnly)
+				throw new PlatformNotSupportedException ();
+
+			base.Set (name, value);
+		}
+
+		public override void Set (string name, string value)
+		{
+			if (IsReadOnly)
+				throw new PlatformNotSupportedException ();
+
+			base.Set (name, value);
+		}
+
+		public override void Remove (string name)
+		{
+			if (IsReadOnly)
+				throw new PlatformNotSupportedException ();
+
+			base.Remove (name);
+		}
+
 		protected override void InsertInfo()
 		{
 			HttpWorkerRequest worker_request = _request.WorkerRequest;

--- a/mcs/class/System.Web/Test/System.Web/HttpRequestTest.cs
+++ b/mcs/class/System.Web/Test/System.Web/HttpRequestTest.cs
@@ -254,6 +254,30 @@ namespace MonoTests.System.Web {
 		{
 			HttpContext.Current.Request.MapPath ("Web.config", "something", false);
 		}
+	
+		[Test]
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+		public void ReadOnlyHeadersAdd ()
+		{
+			var r = new HttpRequest ("file", "http://www.gnome.org", "key=value&key2=value%32second");
+			r.Headers.Add ("a","a");
+		}
+
+		[Test]
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+		public void ReadOnlyHeadersSet ()
+		{
+			var r = new HttpRequest ("file", "http://www.gnome.org", "key=value&key2=value%32second");
+			r.Headers.Set ("a","a");
+		}
+
+		[Test]
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+		public void ReadOnlyHeadersRemove ()
+		{
+			var r = new HttpRequest ("file", "http://www.gnome.org", "key=value&key2=value%32second");
+			r.Headers.Remove ("a");
+		}
 	}
 	
 	[TestFixture]


### PR DESCRIPTION
In reference source HttpHeaderCollection [1] when Add, Set or Remove is
called and the collection is readonly a PlatformNotSupportedException is
thrown.

Mono HeadersCollection was throwing NotSupportedException and
Microsoft.Owin.Host.SystemWeb.OwinCallContext.RemoveAcceptEncoding was
not catching the exception because it was expecting
PlatformNotSupportedException.

Fixes [#33809](https://bugzilla.xamarin.com/show_bug.cgi?id=33809)

[1] http://referencesource.microsoft.com/#System.Web/HttpHeaderCollection.cs,73