### PR TITLE
[sgen] Fix register scanning on ARM

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2382,7 +2382,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 
 		if (!precise) {
 #ifdef USE_MONO_CTX
-			sgen_conservatively_pin_objects_from ((void**)&info->client_info.ctx, (void**)&info->client_info.ctx + ARCH_NUM_REGS,
+			sgen_conservatively_pin_objects_from ((void**)&info->client_info.ctx, (void**)(&info->client_info.ctx + 1),
 				start_nursery, end_nursery, PIN_TYPE_STACK);
 #else
 			sgen_conservatively_pin_objects_from ((void**)&info->client_info.regs, (void**)&info->client_info.regs + ARCH_NUM_REGS,

--- a/mono/sgen/sgen-protocol.c
+++ b/mono/sgen/sgen-protocol.c
@@ -99,6 +99,9 @@ binary_protocol_open_file (void)
 			break; /* Failed */
 	} while (binary_protocol_file == -1);
 
+	if (binary_protocol_file == -1)
+		g_error ("sgen binary protocol: failed to open file");
+
 	if (file_size_limit > 0)
 		free_filename (filename);
 }
@@ -114,6 +117,8 @@ binary_protocol_init (const char *filename, long long limit)
 	file_size_limit = limit;
 
 	binary_protocol_open_file ();
+#else
+	g_error ("sgen binary protocol: not supported");
 #endif
 }
 


### PR DESCRIPTION
This bug would trigger a use after sweep in System.Threading.Tasks.Task.FinishContinuations:3621.

The issue would arise on ARM, as `MonoContext` and `ARCH_NUM_REGS` are defined as followed :

```
typedef struct {
  mgreg_t pc;
  mgreg_t regs [16];
  double fregs [16];
  mgreg_t cpsr;
} MonoContext;

\#define ARCH_NUM_REGS 14
```

As you can see, the MonoContext structure is bigger than 14 words, and it does not even covers the last 3 values of `regs`. By using pointer arithmetic, we ensure that we do not miss some parts of the `MonoContext` structure.

The observed behaviour in System.Threading.Tasks.Task.FinishContinuations would be that `continuationObject` would not be marked, and thus freed; `continuationObject` would still contains the pointer to the old location, meaning it wouldn't be null. We would then try to check its type via a call to the `as` operator. This would call the `isinst` IL opcode which would load `continuationObject->vtable->klass->supertypes [...]`, which would trigger a segfault, as `supertypes` would be null.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=38012