### PR TITLE
[4.2.0][sgen] Fix register scanning on ARM

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2374,7 +2374,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 
 		if (!precise) {
 #ifdef USE_MONO_CTX
-			sgen_conservatively_pin_objects_from ((void**)&info->client_info.ctx, (void**)&info->client_info.ctx + ARCH_NUM_REGS,
+			sgen_conservatively_pin_objects_from ((void**)&info->client_info.ctx, (void**)(&info->client_info.ctx + 1),
 				start_nursery, end_nursery, PIN_TYPE_STACK);
 #else
 			sgen_conservatively_pin_objects_from ((void**)&info->client_info.regs, (void**)&info->client_info.regs + ARCH_NUM_REGS,


### PR DESCRIPTION
This bug would trigger a use after sweep in System.Threading.Tasks.Task.FinishContinuations:3621.

The issue would arise on ARM, as `MonoContext` and `ARCH_NUM_REGS` are defined as followed :

```
typedef struct {
  mgreg_t pc;
  mgreg_t regs [16];
  double fregs [16];
  mgreg_t cpsr;
} MonoContext;

\#define ARCH_NUM_REGS 14
```

As you can see, the MonoContext structure is bigger than 14 words, and it does not even covers the last 3 values of `regs`. By using pointer arithmetic, we ensure that we do not miss some parts of the `MonoContext` structure.

The observed behaviour in System.Threading.Tasks.Task.FinishContinuations would be that `continuationObject` would not be marked, and thus freed; `continuationObject` would still contains the pointer to the old location, meaning it wouldn't be null. We would then try to check its type via a call to the `as` operator. This would call the `isinst` IL opcode which would load `continuationObject->vtable->klass->supertypes [...]`, which would trigger a segfault, as `supertypes` would be null.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=38012