### PR TITLE
[corlib] Fix handling of ignorable chars when using ordinal comparison

### DIFF
--- a/mcs/class/corlib/Mono.Globalization.Unicode/SimpleCollator.cs
+++ b/mcs/class/corlib/Mono.Globalization.Unicode/SimpleCollator.cs
@@ -505,7 +505,8 @@ Console.WriteLine (" -> '{0}'", c.Replacement);
 
 		static bool IsIgnorable (int i, COpt opt)
 		{
-			return Uni.IsIgnorable (i, (byte) (1 +
+			return Uni.IsIgnorable (i, (byte)
+				(((opt & (COpt.Ordinal | COpt.OrdinalIgnoreCase)) == 0 ? 1 : 0) +
 				((opt & COpt.IgnoreSymbols) != 0 ? 2 : 0) +
 				((opt & COpt.IgnoreNonSpace) != 0 ? 4 : 0)));
 			

--- a/mcs/class/corlib/Test/System.Globalization/CompareInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CompareInfoTest.cs
@@ -1183,6 +1183,9 @@ public class CompareInfoTest
 		AssertCompare ("#12", 0, "aE", "AE", CompareOptions.OrdinalIgnoreCase);
 		AssertCompare ("#13", 0, "ae", "AE", CompareOptions.OrdinalIgnoreCase);
 		AssertCompare ("#14", 0, "ola", "OLA", CompareOptions.OrdinalIgnoreCase);
+		// check ignorable characters
+		AssertCompare ("#15", 0, "AE\uFFFC", "AE", CompareOptions.None);
+		AssertCompare ("#16", 1, "AE\uFFFC", "AE", CompareOptions.OrdinalIgnoreCase);
 	}
 
 	[Test]


### PR DESCRIPTION
* recognizes ignorable characters when `CompareOptions.Ordinal` is specified
* adds unit tests
* fixes bug [24641](https://bugzilla.xamarin.com/show_bug.cgi?id=24641)