### PR TITLE
Check for libtoolize rather than libtool

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,18 +30,18 @@ fi
   DIE=1
 }
 
-if [ -z "$LIBTOOL" ]; then
-  LIBTOOL=`which glibtool 2>/dev/null` 
-  if [ ! -x "$LIBTOOL" ]; then
-    LIBTOOL=`which libtool`
+if [ -z "$LIBTOOLIZE" ]; then
+  LIBTOOLIZE=`which glibtoolize 2>/dev/null`
+  if [ ! -x "$LIBTOOLIZE" ]; then
+    LIBTOOLIZE=`which libtoolize`
   fi
 fi
 
 (grep "^AM_PROG_LIBTOOL" $srcdir/configure.ac >/dev/null) && {
-  ($LIBTOOL --version) < /dev/null > /dev/null 2>&1 || {
+  ($LIBTOOLIZE --version) < /dev/null > /dev/null 2>&1 || {
     echo
-    echo "**Error**: You must have \`libtool' installed to compile Mono."
-    echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"
+    echo "**Error**: You must have \`libtoolize' installed to compile Mono."
+    echo "Get ftp://ftp.gnu.org/gnu/libtool/libtool-1.2.tar.gz"
     echo "(or a newer version if it is available)"
     DIE=1
   }
@@ -98,7 +98,7 @@ esac
 if grep "^AM_PROG_LIBTOOL" configure.ac >/dev/null; then
   if test -z "$NO_LIBTOOLIZE" ; then 
     echo "Running libtoolize..."
-    ${LIBTOOL}ize --force --copy
+    $LIBTOOLIZE --force --copy
   fi
 fi
 

--- a/eglib/autogen.sh
+++ b/eglib/autogen.sh
@@ -30,18 +30,18 @@ fi
   DIE=1
 }
 
-if [ -z "$LIBTOOL" ]; then
-  LIBTOOL=`which glibtool 2>/dev/null` 
-  if [ ! -x "$LIBTOOL" ]; then
-    LIBTOOL=`which libtool`
+if [ -z "$LIBTOOLIZE" ]; then
+  LIBTOOLIZE=`which glibtoolize 2>/dev/null`
+  if [ ! -x "$LIBTOOLIZE" ]; then
+    LIBTOOLIZE=`which libtoolize`
   fi
 fi
 
 (grep "^AM_PROG_LIBTOOL" $srcdir/configure.ac >/dev/null) && {
-  ($LIBTOOL --version) < /dev/null > /dev/null 2>&1 || {
+  ($LIBTOOLIZE --version) < /dev/null > /dev/null 2>&1 || {
     echo
-    echo "**Error**: You must have \`libtool' installed to compile Mono."
-    echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"
+    echo "**Error**: You must have \`libtoolize' installed to compile Mono."
+    echo "Get ftp://ftp.gnu.org/gnu/libtool/libtool-1.2.tar.gz"
     echo "(or a newer version if it is available)"
     DIE=1
   }
@@ -98,7 +98,7 @@ esac
 if grep "^AM_PROG_LIBTOOL" configure.ac >/dev/null; then
   if test -z "$NO_LIBTOOLIZE" ; then 
     echo "Running libtoolize..."
-    ${LIBTOOL}ize --force --copy
+    $LIBTOOLIZE --force --copy
   fi
 fi
 

--- a/libgc/autogen.sh
+++ b/libgc/autogen.sh
@@ -15,18 +15,18 @@ test -z "$srcdir" && srcdir=.
   DIE=1
 }
 
-if [ -z "$LIBTOOL" ]; then
-  LIBTOOL=`which glibtool 2>/dev/null` 
-  if [ ! -x "$LIBTOOL" ]; then
-    LIBTOOL=`which libtool`
+if [ -z "$LIBTOOLIZE" ]; then
+  LIBTOOLIZE=`which glibtoolize 2>/dev/null`
+  if [ ! -x "$LIBTOOLIZE" ]; then
+    LIBTOOLIZE=`which libtoolize`
   fi
 fi
 
 (grep "^AM_PROG_LIBTOOL" $srcdir/configure.ac >/dev/null) && {
-  ($LIBTOOL --version) < /dev/null > /dev/null 2>&1 || {
+  ($LIBTOOLIZE --version) < /dev/null > /dev/null 2>&1 || {
     echo
-    echo "**Error**: You must have \`libtool' installed to compile Mono."
-    echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"
+    echo "**Error**: You must have \`libtoolize' installed to compile Mono."
+    echo "Get ftp://ftp.gnu.org/gnu/libtool/libtool-1.2.tar.gz"
     echo "(or a newer version if it is available)"
     DIE=1
   }
@@ -83,7 +83,7 @@ esac
 if grep "^AC_PROG_LIBTOOL" configure.ac >/dev/null; then
   if test -z "$NO_LIBTOOLIZE" ; then 
     echo "Running libtoolize..."
-    ${LIBTOOL}ize --force --copy
+    $LIBTOOLIZE --force --copy
   fi
 fi
 


### PR DESCRIPTION
Current Debian packaging puts libtool in its own package (libtool-bin)
leaving only libtoolize in the main package. The mono build process
uses libtoolize not libtool, so during autogen check for libtoolize
not libtool.