### PR TITLE
[SWF] Fix behavior when scrollbar values change in TreeView

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
@@ -1853,7 +1853,8 @@ namespace System.Windows.Forms {
 
 		private void VScrollBarValueChanged (object sender, EventArgs e)
 		{
-			EndEdit (edit_node);
+			if (edit_node != null)
+				EndEdit (edit_node);
 
 			SetVScrollPos (vbar.Value, null);
 		}
@@ -1886,7 +1887,8 @@ namespace System.Windows.Forms {
 
 		private void HScrollBarValueChanged(object sender, EventArgs e)
 		{
-			EndEdit (edit_node);
+			if (edit_node != null)
+				EndEdit (edit_node);
 
 			int old_offset = hbar_offset;
 			hbar_offset = hbar.Value;


### PR DESCRIPTION
* only call EndEdit in scrollbar value changed handlers when currently
  editing a node
* fix for bug [33183](https://bugzilla.xamarin.com/show_bug.cgi?id=33183)