### PR TITLE
[C6SR2][System.Web.Services] Fix DiscoveryClientProtocol 

### DIFF
--- a/mcs/class/System.Web.Services/System.Web.Services_test.dll.sources
+++ b/mcs/class/System.Web.Services/System.Web.Services_test.dll.sources
@@ -10,6 +10,7 @@ System.Web.Services.Configuration/WsdlHelpGeneratorElementTest.cs
 System.Web.Services.Configuration/WsiProfilesElementTest.cs
 System.Web.Services.Configuration/XmlFormatExtensionAttributeTest.cs
 System.Web.Services.Discovery/ContractReferenceTest.cs
+System.Web.Services.Discovery/DiscoveryClientProtocolTest.cs
 System.Web.Services.Description/BindingCollectionTest.cs
 System.Web.Services.Description/DocumentableItemTest.cs
 System.Web.Services.Description/TypesTest.cs

--- a/mcs/class/System.Web.Services/Test/System.Web.Services.Discovery/DiscoveryClientProtocolTest.cs
+++ b/mcs/class/System.Web.Services/Test/System.Web.Services.Discovery/DiscoveryClientProtocolTest.cs
@@ -1,0 +1,45 @@
+//
+// MonoTests.System.Web.Services.Discovery.DiscoveryClientProtocolTest.cs
+//
+// Author:
+//   Marcos Henrich (marcos.henrich@xamarin.com)
+//
+// Copyright (C) Xamarin Inc. 2016
+//
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Web.Services.Discovery;
+
+namespace MonoTests.System.Web.Services.Discovery {
+
+	[TestFixture]
+	public class DiscoveryClientProtocolTest {
+
+		[Test] // Covers #36116
+		[Category ("InetAccess")]
+		public void ReadWriteTest ()
+		{
+			string directory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			Directory.CreateDirectory (directory);
+			try {
+				string url = "http://www.w3schools.com/WebServices/TempConvert.asmx";
+				var p1 = new DiscoveryClientProtocol ();
+				p1.DiscoverAny (url);
+				p1.ResolveAll ();
+
+				p1.WriteAll (directory, "Reference.map");
+
+				var p2 = new DiscoveryClientProtocol ();
+				var results = p2.ReadAll (Path.Combine (directory, "Reference.map"));
+
+				Assert.AreEqual (2, results.Count);
+				Assert.AreEqual ("TempConvert.disco", results [0].Filename);
+				Assert.AreEqual ("TempConvert.wsdl", results [1].Filename);
+			} finally {
+				Directory.Delete (directory, true);
+			}
+		}
+	}
+}


### PR DESCRIPTION
DiscoveryClientProtocol.GetRelativePath in reference sources was harcoded to use '\\'.

Fixes [#36116](https://bugzilla.xamarin.com/show_bug.cgi?id=36116)

The pull only contains the test.
The fix is in https://github.com/mono/referencesource/pull/24.
Once this is accepted a reference source bump will be required.