### PR TITLE
Fix overload error on Microsoft.Build.Evaluation.Project(string)

### DIFF
--- a/mcs/class/Microsoft.Build/Microsoft.Build.Evaluation/Project.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Evaluation/Project.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.Evaluation
 		public Project (string projectFile, IDictionary<string, string> globalProperties,
 				string toolsVersion, ProjectCollection projectCollection,
 				ProjectLoadSettings loadSettings)
-			: this (ProjectRootElement.Create (projectFile), globalProperties, toolsVersion, projectCollection, loadSettings)
+			: this (XmlReader.Create (projectFile), globalProperties, toolsVersion, projectCollection, loadSettings)
 		{
 		}
 


### PR DESCRIPTION
The overload for `Microsoft.Build.Evaluation.Project(string)` should map to `Microsoft.Build.Evaluation.Project(XmlReader)` rather than the current `Microsoft.Builder.Evaluation.Project(ProjectRootElement)`.

Related issue: https://bugzilla.xamarin.com/show_bug.cgi?id=38224