### PR TITLE
Use MonoError for mono_runtime_invoke

### DIFF
--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -311,7 +311,8 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 	g_free (agent);
 
 	pa [0] = main_args;
-	mono_runtime_invoke (method, NULL, pa, exc);
+	mono_runtime_try_invoke (method, NULL, pa, exc, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return 0;
 }

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -475,11 +475,16 @@ cominterop_com_visible (MonoClass* klass)
 static void cominterop_raise_hr_exception (int hr)
 {
 	static MonoMethod* throw_exception_for_hr = NULL;
+	MonoError error;
 	MonoException* ex;
 	void* params[1] = {&hr};
+
 	if (!throw_exception_for_hr)
 		throw_exception_for_hr = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetExceptionForHR", 1);
-	ex = (MonoException*)mono_runtime_invoke (throw_exception_for_hr, NULL, params, NULL);
+
+	ex = (MonoException*)mono_runtime_invoke_checked (throw_exception_for_hr, NULL, params, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+
 	mono_raise_exception (ex);
 }
 

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -144,7 +144,10 @@ create_exception_two_strings (MonoClass *klass, MonoString *a1, MonoString *a2)
 
 	args [0] = a1;
 	args [1] = a2;
-	mono_runtime_invoke (method, o, args, NULL);
+
+	mono_runtime_invoke_checked (method, o, args, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+
 	return (MonoException *) o;
 }
 
@@ -602,7 +605,8 @@ mono_get_exception_type_initialization (const gchar *type_name, MonoException *i
 
 	exc = mono_object_new_checked (mono_domain_get (), klass, &error);
 	mono_error_assert_ok (&error);
-	mono_runtime_invoke (method, exc, args, NULL);
+	mono_runtime_invoke_checked (method, exc, args, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return (MonoException *) exc;
 }
@@ -777,7 +781,9 @@ mono_get_exception_reflection_type_load (MonoArray *types, MonoArray *exceptions
 
 	exc = mono_object_new_checked (mono_domain_get (), klass, &error);
 	mono_error_assert_ok (&error);
-	mono_runtime_invoke (method, exc, args, NULL);
+
+	mono_runtime_invoke_checked (method, exc, args, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return (MonoException *) exc;
 }
@@ -802,7 +808,9 @@ mono_get_exception_runtime_wrapped (MonoObject *wrapped_exception)
 	g_assert (method);
 
 	params [0] = wrapped_exception;
-	mono_runtime_invoke (method, o, params, NULL);
+
+	mono_runtime_invoke_checked (method, o, params, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return (MonoException *)o;
 }	

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -228,7 +228,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	}
 
 	/* 
-	 * To avoid the locking plus the other overhead of mono_runtime_invoke (),
+	 * To avoid the locking plus the other overhead of mono_runtime_invoke_checked (),
 	 * create and precompile a wrapper which calls the finalize method using
 	 * a CALLVIRT.
 	 */

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -941,6 +941,7 @@ ves_icall_System_Security_SecureString_EncryptInternal (MonoArray* data, MonoObj
 
 void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt)
 {
+	MonoError error;
 	MonoClass *klass;
 	MonoMethod *method;
 	void *params [2];
@@ -960,5 +961,7 @@ void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolea
 	method = mono_class_get_method_from_name (klass, encrypt ? "Protect" : "Unprotect", 2);
 	params [0] = data;
 	params [1] = scope; /* MemoryProtectionScope.SameProcess */
-	mono_runtime_invoke (method, NULL, params, NULL);
+
+	mono_runtime_invoke_checked (method, NULL, params, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 }

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -618,7 +618,7 @@ typedef struct {
 	gboolean (*debug_log_is_enabled) (void);
 	gboolean (*tls_key_supported) (MonoTlsKey key);
 	void     (*init_delegate) (MonoDelegate *del);
-	MonoObject* (*runtime_invoke) (MonoMethod *method, void *obj, void **params, MonoError *error, MonoObject **exc);
+	MonoObject* (*runtime_invoke) (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);
 	void*    (*compile_method) (MonoMethod *method, MonoError *error);
 } MonoRuntimeCallbacks;
 
@@ -1695,6 +1695,13 @@ mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *merror
 
 MonoString *
 mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
+
+MonoObject*
+mono_runtime_try_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);
+
+MonoObject*
+mono_runtime_invoke_checked (MonoMethod *method, void *obj, void **params, MonoError *error);
+
 
 #endif /* __MONO_OBJECT_INTERNALS_H__ */
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -69,6 +69,7 @@ mono_runtime_object_init (MonoObject *this_obj)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	MonoError error;
 	MonoMethod *method = NULL;
 	MonoClass *klass = this_obj->vtable->klass;
 
@@ -78,7 +79,9 @@ mono_runtime_object_init (MonoObject *this_obj)
 
 	if (method->klass->valuetype)
 		this_obj = (MonoObject *)mono_object_unbox (this_obj);
-	mono_runtime_invoke (method, this_obj, NULL, NULL);
+
+	mono_runtime_invoke_checked (method, this_obj, NULL, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 }
 
 /* The pseudo algorithm for type initialization from the spec
@@ -277,6 +280,7 @@ mono_runtime_class_init_full (MonoVTable *vtable, gboolean raise_exception)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	MonoError error;
 	MonoException *exc;
 	MonoException *exc_to_throw;
 	MonoMethod *method = NULL;
@@ -394,7 +398,9 @@ mono_runtime_class_init_full (MonoVTable *vtable, gboolean raise_exception)
 	mono_type_initialization_unlock ();
 
 	if (do_initialization) {
-		mono_runtime_invoke (method, NULL, NULL, (MonoObject **) &exc);
+		mono_runtime_try_invoke (method, NULL, NULL, (MonoObject**) &exc, &error);
+		if (exc == NULL && !mono_error_ok (&error))
+			exc = mono_error_convert_to_exception (&error);
 
 		/* If the initialization failed, mark the class as unusable. */
 		/* Avoid infinite loops */
@@ -2840,19 +2846,28 @@ mono_object_get_virtual_method (MonoObject *obj, MonoMethod *method)
 static MonoObject*
 do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoObject *result = NULL;
-	MonoError error;
 
 	g_assert (callbacks.runtime_invoke);
-	result = callbacks.runtime_invoke (method, obj, params, &error, exc);
-	if (!mono_error_ok (&error)) {
-		if (exc) {
-			*exc = (MonoObject*)mono_error_convert_to_exception (&error);
-			return NULL;
-		} else {
-			mono_error_raise_exception (&error);
-		}
-	}
+
+	mono_error_init (error);
+	
+	if (mono_profiler_get_events () & MONO_PROFILE_METHOD_EVENTS)
+		mono_profiler_method_start_invoke (method);
+
+	MONO_PREPARE_RESET_BLOCKING;
+
+	result = callbacks.runtime_invoke (method, obj, params, exc, error);
+
+	MONO_FINISH_RESET_BLOCKING;
+
+	if (mono_profiler_get_events () & MONO_PROFILE_METHOD_EVENTS)
+		mono_profiler_method_end_invoke (method);
+
+	if (!mono_error_ok (error))
+		return NULL;
 
 	return result;
 }
@@ -2894,28 +2909,116 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 MonoObject*
 mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc)
 {
+	MonoError error;
+	MonoObject *res;
+	if (exc) {
+		res = mono_runtime_try_invoke (method, obj, params, exc, &error);
+		if (*exc == NULL && !mono_error_ok(&error)) {
+			*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+		}
+	} else {
+		res = mono_runtime_invoke_checked (method, obj, params, &error);
+		mono_error_raise_exception (&error);
+	}
+	return res;
+}
+
+/**
+ * mono_runtime_try_invoke:
+ * @method: method to invoke
+ * @obJ: object instance
+ * @params: arguments to the method
+ * @exc: exception information.
+ * @error: set on error
+ *
+ * Invokes the method represented by @method on the object @obj.
+ *
+ * obj is the 'this' pointer, it should be NULL for static
+ * methods, a MonoObject* for object instances and a pointer to
+ * the value type for value types.
+ *
+ * The params array contains the arguments to the method with the
+ * same convention: MonoObject* pointers for object instances and
+ * pointers to the value type otherwise. 
+ * 
+ * From unmanaged code you'll usually use the
+ * mono_runtime_invoke() variant.
+ *
+ * Note that this function doesn't handle virtual methods for
+ * you, it will exec the exact method you pass: we still need to
+ * expose a function to lookup the derived class implementation
+ * of a virtual method (there are examples of this in the code,
+ * though).
+ * 
+ * For this function, you must not pass NULL as the exc argument if
+ * you don't want to catch exceptions, use
+ * mono_runtime_invoke_checked().  If an exception is thrown, you
+ * can't use the MonoObject* result from the function.
+ * 
+ * If this method cannot be invoked, @error will be set and @exc and
+ * the return value must not be used.
+ *
+ * If the method returns a value type, it is boxed in an object
+ * reference.
+ */
+MonoObject*
+mono_runtime_try_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError* error)
+{
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
-	MonoObject *result;
+	g_assert (exc != NULL);
 
 	if (mono_runtime_get_no_exec ())
 		g_warning ("Invoking method '%s' when running in no-exec mode.\n", mono_method_full_name (method, TRUE));
 
-	if (mono_profiler_get_events () & MONO_PROFILE_METHOD_EVENTS)
-		mono_profiler_method_start_invoke (method);
+	return do_runtime_invoke (method, obj, params, exc, error);
+}
 
-	MONO_PREPARE_RESET_BLOCKING;
+/**
+ * mono_runtime_invoke_checked:
+ * @method: method to invoke
+ * @obJ: object instance
+ * @params: arguments to the method
+ * @error: set on error
+ *
+ * Invokes the method represented by @method on the object @obj.
+ *
+ * obj is the 'this' pointer, it should be NULL for static
+ * methods, a MonoObject* for object instances and a pointer to
+ * the value type for value types.
+ *
+ * The params array contains the arguments to the method with the
+ * same convention: MonoObject* pointers for object instances and
+ * pointers to the value type otherwise. 
+ * 
+ * From unmanaged code you'll usually use the
+ * mono_runtime_invoke() variant.
+ *
+ * Note that this function doesn't handle virtual methods for
+ * you, it will exec the exact method you pass: we still need to
+ * expose a function to lookup the derived class implementation
+ * of a virtual method (there are examples of this in the code,
+ * though).
+ * 
+ * If an exception is thrown, you can't use the MonoObject* result
+ * from the function.
+ * 
+ * If this method cannot be invoked, @error will be set.  If the
+ * method throws an exception (and we're in coop mode) the exception
+ * will be set in @error.
+ *
+ * If the method returns a value type, it is boxed in an object
+ * reference.
+ */
+MonoObject*
+mono_runtime_invoke_checked (MonoMethod *method, void *obj, void **params, MonoError* error)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
 
-	result = do_runtime_invoke (method, obj, params, exc, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (mono_runtime_get_no_exec ())
+		g_warning ("Invoking method '%s' when running in no-exec mode.\n", mono_method_full_name (method, TRUE));
 
-	MONO_FINISH_RESET_BLOCKING;
-
-	if (mono_profiler_get_events () & MONO_PROFILE_METHOD_EVENTS)
-		mono_profiler_method_end_invoke (method);
-
-	return result;
+	return do_runtime_invoke (method, obj, params, NULL, error);
 }
 
 /**
@@ -3332,7 +3435,10 @@ mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObje
 		args [1] = mono_type_get_object_checked (mono_domain_get (), type, &error);
 		mono_error_raise_exception (&error); /* FIXME don't raise here */
 
-		return mono_runtime_invoke (m, NULL, args, NULL);
+		o = mono_runtime_invoke_checked (m, NULL, args, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+
+		return o;
 	}
 
 	/* boxed value type */
@@ -3485,7 +3591,11 @@ mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 
 	MonoError error;
 	do_runtime_invoke (prop->set, obj, params, exc, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (exc && *exc == NULL && !mono_error_ok (&error)) {
+		*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+	} else {
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+	}
 }
 
 /**
@@ -3512,7 +3622,11 @@ mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 
 	MonoError error;
 	MonoObject *val = do_runtime_invoke (prop->get, obj, params, exc, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (exc && *exc == NULL && !mono_error_ok (&error)) {
+		*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+	} else {
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+	}
 
 	return val;
 }
@@ -3672,14 +3786,25 @@ mono_runtime_delegate_invoke (MonoObject *delegate, void **params, MonoObject **
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	MonoError error;
 	MonoMethod *im;
 	MonoClass *klass = delegate->vtable->klass;
+	MonoObject *o;
 
 	im = mono_get_delegate_invoke (klass);
 	if (!im)
 		g_error ("Could not lookup delegate invoke method for delegate %s", mono_type_get_full_name (klass));
 
-	return mono_runtime_invoke (im, delegate, params, exc);
+	if (exc) {
+		o = mono_runtime_try_invoke (im, delegate, params, exc, &error);
+		if (*exc == NULL && !mono_error_ok (&error))
+			*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+	} else {
+		o = mono_runtime_invoke_checked (im, delegate, params, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+	}
+
+	return o;
 }
 
 static char **main_args = NULL;
@@ -3867,6 +3992,7 @@ serialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 {
 	static MonoMethod *serialize_method;
 
+	MonoError error;
 	void *params [1];
 	MonoObject *array;
 
@@ -3884,7 +4010,11 @@ serialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 
 	params [0] = obj;
 	*exc = NULL;
-	array = mono_runtime_invoke (serialize_method, NULL, params, exc);
+
+	array = mono_runtime_try_invoke (serialize_method, NULL, params, exc, &error);
+	if (*exc == NULL && !mono_error_ok (&error))
+		*exc = (MonoObject*) mono_error_convert_to_exception (&error); /* FIXME convert serialize_object to MonoError */
+
 	if (*exc)
 		*failure = TRUE;
 
@@ -3898,6 +4028,7 @@ deserialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 
 	static MonoMethod *deserialize_method;
 
+	MonoError error;
 	void *params [1];
 	MonoObject *result;
 
@@ -3912,7 +4043,11 @@ deserialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 
 	params [0] = obj;
 	*exc = NULL;
-	result = mono_runtime_invoke (deserialize_method, NULL, params, exc);
+
+	result = mono_runtime_try_invoke (deserialize_method, NULL, params, exc, &error);
+	if (*exc == NULL && !mono_error_ok (&error))
+		*exc = (MonoObject*) mono_error_convert_to_exception (&error); /* FIXME convert deserialize_object to MonoError */
+
 	if (*exc)
 		*failure = TRUE;
 
@@ -3947,7 +4082,10 @@ make_transparent_proxy (MonoObject *obj, gboolean *failure, MonoObject **exc)
 	MONO_OBJECT_SETREF (real_proxy, unwrapped_server, obj);
 
 	*exc = NULL;
-	transparent_proxy = (MonoTransparentProxy*) mono_runtime_invoke (get_proxy_method, real_proxy, NULL, exc);
+
+	transparent_proxy = (MonoTransparentProxy*) mono_runtime_try_invoke (get_proxy_method, real_proxy, NULL, exc, &error);
+	if (*exc == NULL && !mono_error_ok (&error))
+		*exc = (MonoObject*) mono_error_convert_to_exception (&error); /* FIXME change make_transparent_proxy outarg to MonoError */
 	if (*exc)
 		*failure = TRUE;
 
@@ -3977,6 +4115,7 @@ mono_object_xdomain_representation (MonoObject *obj, MonoDomain *target_domain, 
 	MonoObject *deserialized = NULL;
 	gboolean failure = FALSE;
 
+	g_assert (exc != NULL);
 	*exc = NULL;
 
 #ifndef DISABLE_REMOTING
@@ -4028,7 +4167,9 @@ create_unhandled_exception_eventargs (MonoObject *exc)
 
 	obj = mono_object_new_checked (mono_domain_get (), klass, &error);
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
-	mono_runtime_invoke (method, obj, args, NULL);
+
+	mono_runtime_invoke_checked (method, obj, args, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return obj;
 }
@@ -4198,6 +4339,7 @@ mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	MonoError error;
 	MonoDomain *domain;
 	gpointer pa [1];
 	int rval;
@@ -4250,7 +4392,15 @@ mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 	/* FIXME: check signature of method */
 	if (mono_method_signature (method)->ret->type == MONO_TYPE_I4) {
 		MonoObject *res;
-		res = mono_runtime_invoke (method, NULL, pa, exc);
+		if (exc) {
+			res = mono_runtime_try_invoke (method, NULL, pa, exc, &error);
+			if (*exc == NULL && !mono_error_ok (&error))
+				*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+		} else {
+			res = mono_runtime_invoke_checked (method, NULL, pa, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+		}
+
 		if (!exc || !*exc)
 			rval = *(guint32 *)((char *)res + sizeof (MonoObject));
 		else
@@ -4258,7 +4408,15 @@ mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 
 		mono_environment_exitcode_set (rval);
 	} else {
-		mono_runtime_invoke (method, NULL, pa, exc);
+		if (exc) {
+			mono_runtime_try_invoke (method, NULL, pa, exc, &error);
+			if (*exc == NULL && !mono_error_ok (&error))
+				*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+		} else {
+			mono_runtime_invoke_checked (method, NULL, pa, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+		}
+
 		if (!exc || !*exc)
 			rval = 0;
 		else {
@@ -4296,7 +4454,7 @@ mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
  * respective reference representation.
  * 
  * From unmanaged code you'll usually use the
- * mono_runtime_invoke() variant.
+ * mono_runtime_invoke_checked() variant.
  *
  * Note that this function doesn't handle virtual methods for
  * you, it will exec the exact method you pass: we still need to
@@ -4441,7 +4599,15 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			obj = mono_value_box (mono_domain_get (), method->klass, obj);
 		}
 
-		mono_runtime_invoke (method, o, pa, exc);
+		if (exc) {
+			mono_runtime_try_invoke (method, o, pa, exc, &error);
+			if (*exc == NULL && !mono_error_ok (&error))
+				*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+		} else {
+			mono_runtime_invoke_checked (method, o, pa, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+		}
+
 		return (MonoObject *)obj;
 	} else {
 		if (mono_class_is_nullable (method->klass)) {
@@ -4456,7 +4622,14 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 		}
 
 		/* obj must be already unboxed if needed */
-		res = mono_runtime_invoke (method, obj, pa, exc);
+		if (exc) {
+			res = mono_runtime_try_invoke (method, obj, pa, exc, &error);
+			if (*exc == NULL && !mono_error_ok (&error))
+				*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+		} else {
+			res = mono_runtime_invoke_checked (method, obj, pa, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+		}
 
 		if (sig->ret->type == MONO_TYPE_PTR) {
 			MonoClass *pointer_class;
@@ -4477,8 +4650,9 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			box_args [1] = mono_type_get_object_checked (mono_domain_get (), sig->ret, &error);
 			mono_error_raise_exception (&error); /* FIXME don't raise here */
 
-			res = mono_runtime_invoke (box_method, NULL, box_args, &box_exc);
-			g_assert (!box_exc);
+			res = mono_runtime_try_invoke (box_method, NULL, box_args, &box_exc, &error);
+			g_assert (box_exc == NULL);
+			mono_error_assert_ok (&error);
 		}
 
 		if (has_byref_nullables) {
@@ -4640,8 +4814,12 @@ mono_object_new_specific_checked (MonoVTable *vtable, MonoError *error)
 		if (!mono_error_ok (error))
 			return NULL;
 
-		o = mono_runtime_invoke (im, NULL, pa, NULL);		
-		if (o != NULL) return o;
+		o = mono_runtime_invoke_checked (im, NULL, pa, error);
+		if (!mono_error_ok (error))
+			return NULL;
+
+		if (o != NULL)
+			return o;
 	}
 
 	return mono_object_new_alloc_specific_checked (vtable, error);
@@ -5713,8 +5891,9 @@ mono_object_isinst_mbyref (MonoObject *obj, MonoClass *klass)
 		mono_error_raise_exception (&error); /* FIXME don't raise here */
 		pa [1] = obj;
 
-		res = mono_runtime_invoke (im, rp, pa, NULL);
-	
+		res = mono_runtime_invoke_checked (im, rp, pa, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+
 		if (*(MonoBoolean *) mono_object_unbox(res)) {
 			/* Update the vtable of the remote type, so it can safely cast to this new type */
 			mono_upgrade_remote_class (domain, obj, klass);
@@ -6328,7 +6507,9 @@ mono_wait_handle_new (MonoDomain *domain, HANDLE handle)
 		handle_set = mono_class_get_property_from_name (mono_defaults.manualresetevent_class, "Handle")->set;
 
 	params [0] = &handle;
-	mono_runtime_invoke (handle_set, res, params, NULL);
+
+	mono_runtime_invoke_checked (handle_set, res, params, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return res;
 }
@@ -6422,6 +6603,7 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	MonoError error;
 	MonoAsyncCall *ac;
 	MonoObject *res;
 
@@ -6450,7 +6632,10 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 		if (ac->cb_method) {
 			/* we swallow the excepton as it is the behavior on .NET */
 			MonoObject *exc = NULL;
-			mono_runtime_invoke (ac->cb_method, ac->cb_target, (gpointer*) &ares, &exc);
+			mono_runtime_try_invoke (ac->cb_method, ac->cb_target, (gpointer*) &ares, &exc, &error);
+			if (exc == NULL && !mono_error_ok (&error))
+				exc = (MonoObject*) mono_error_convert_to_exception (&error);
+
 			if (exc)
 				mono_unhandled_exception (exc);
 		}
@@ -6564,6 +6749,8 @@ mono_remoting_invoke (MonoObject *real_proxy, MonoMethodMessage *msg,
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	MonoError error;
+	MonoObject *o;
 	MonoMethod *im = real_proxy->vtable->domain->private_invoke_method;
 	gpointer pa [4];
 
@@ -6581,7 +6768,14 @@ mono_remoting_invoke (MonoObject *real_proxy, MonoMethodMessage *msg,
 	pa [2] = exc;
 	pa [3] = out_args;
 
-	return mono_runtime_invoke (im, NULL, pa, exc);
+	if (exc) {
+		o = mono_runtime_try_invoke (im, NULL, pa, exc, &error);
+	} else {
+		o = mono_runtime_invoke_checked (im, NULL, pa, &error);
+	}
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+
+	return o;
 }
 #endif
 
@@ -6663,7 +6857,9 @@ mono_object_to_string (MonoObject *obj, MonoObject **exc)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	static MonoMethod *to_string = NULL;
+	MonoError error;
 	MonoMethod *method;
+	MonoString *s;
 	void *target = obj;
 
 	g_assert (obj);
@@ -6678,7 +6874,16 @@ mono_object_to_string (MonoObject *obj, MonoObject **exc)
 		target = mono_object_unbox (obj);
 	}
 
-	return (MonoString *) mono_runtime_invoke (method, target, NULL, exc);
+	if (exc) {
+		s = (MonoString *) mono_runtime_try_invoke (method, target, NULL, exc, &error);
+		if (*exc == NULL && !mono_error_ok (&error))
+			*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+	} else {
+		s = (MonoString *) mono_runtime_invoke_checked (method, target, NULL, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+	}
+
+	return s;
 }
 
 /**

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -31,7 +31,7 @@ typedef struct _MonoObject {
 	MonoThreadsSync *synchronisation;
 } MonoObject;
 
-typedef MonoObject* (*MonoInvokeFunc)	     (MonoMethod *method, void *obj, void **params, MonoObject **exc);
+typedef MonoObject* (*MonoInvokeFunc)	     (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);
 typedef void*    (*MonoCompileFunc)	     (MonoMethod *method);
 typedef void	    (*MonoMainThreadFunc)    (void* user_data);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -218,6 +218,7 @@ mono_runtime_class_init	    (MonoVTable *vtable);
 MONO_API MonoMethod*
 mono_object_get_virtual_method (MonoObject *obj, MonoMethod *method);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject*
 mono_runtime_invoke	    (MonoMethod *method, void *obj, void **params,
 			     MonoObject **exc);

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -17,6 +17,9 @@ mono_identifier_unescape_type_name_chars (char* identifier);
 MonoImage *
 mono_find_dynamic_image_owner (void *ptr);
 
+MonoReflectionAssembly*
+mono_assembly_get_object_checked (MonoDomain *domain, MonoAssembly *assembly, MonoError *error);
+
 MonoReflectionType*
 mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *error);
 

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -47,6 +47,7 @@ MONO_API void          mono_reflection_free_type_info (MonoTypeNameParse *info);
 MONO_API MonoType*     mono_reflection_type_from_name (char *name, MonoImage *image);
 MONO_API uint32_t      mono_reflection_get_token (MonoObject *obj);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionAssembly* mono_assembly_get_object (MonoDomain *domain, MonoAssembly *assembly);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionModule*   mono_module_get_object   (MonoDomain *domain, MonoImage *image);

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -340,6 +340,7 @@ mono_remoting_mb_create_and_cache (MonoMethod *key, MonoMethodBuilder *mb,
 static MonoObject *
 mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 {
+	MonoError error;
 	MonoMethodMessage *msg;
 	MonoTransparentProxy *this_obj;
 	MonoObject *res, *exc;
@@ -377,7 +378,10 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 			}
 		}
 
-		return mono_runtime_invoke (method, method->klass->valuetype? mono_object_unbox ((MonoObject*)this_obj): this_obj, mparams, NULL);
+		res = mono_runtime_invoke_checked (method, method->klass->valuetype? mono_object_unbox ((MonoObject*)this_obj): this_obj, mparams, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+
+		return res;
 	}
 
 	msg = mono_method_call_message_new (method, params, NULL, NULL, NULL);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7648,7 +7648,10 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_ASSEMBLY_GET_OBJECT: {
-		MonoObject *o = (MonoObject*)mono_assembly_get_object (domain, ass);
+		MonoError error;
+		MonoObject *o = (MonoObject*)mono_assembly_get_object_checked (domain, ass, &error);
+		if (!o)
+			mono_error_cleanup (&error); /* FIXME don't swallow the error */
 		buffer_add_objid (buf, o);
 		break;
 	}

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1158,7 +1158,8 @@ load_agent (MonoDomain *domain, char *desc)
 
 	pa [0] = main_args;
 	/* Pass NULL as 'exc' so unhandled exceptions abort the runtime */
-	mono_runtime_invoke (method, NULL, pa, NULL);
+	mono_runtime_invoke_checked (method, NULL, pa, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return 0;
 }

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1327,12 +1327,13 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
  * mono_gsharedvt_constrained_call:
  *
  *   Make a call to CMETHOD using the receiver MP, which is assumed to be of type KLASS. ARGS contains
- * the arguments to the method in the format used by mono_runtime_invoke ().
+ * the arguments to the method in the format used by mono_runtime_invoke_checked ().
  */
 MonoObject*
 mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *klass, gboolean deref_arg, gpointer *args)
 {
 	MonoError error;
+	MonoObject *o;
 	MonoMethod *m;
 	gpointer this_arg;
 	gpointer new_args [16];
@@ -1355,7 +1356,14 @@ mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *kl
 		args [0] = this_arg;
 		this_arg = NULL;
 	}
-	return mono_runtime_invoke (m, this_arg, args, NULL);
+
+	o = mono_runtime_invoke_checked (m, this_arg, args, &error);
+	if (!mono_error_ok (&error)) {
+		mono_error_set_pending_exception (&error);
+		return NULL;
+	}
+
+	return o;
 }
 
 void

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1728,7 +1728,12 @@ mono_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, Mono
 MonoObject*
 mono_get_assembly_object (MonoImage *image)
 {
-	return (MonoObject*)mono_assembly_get_object (mono_domain_get (), image->assembly);
+	MonoError error;
+	MonoObject *result;
+	result = (MonoObject*)mono_assembly_get_object_checked (mono_domain_get (), image->assembly, &error);
+	if (!result)
+		mono_error_set_pending_exception (&error);
+	return result;
 }
 
 MonoObject*

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2328,7 +2328,7 @@ create_runtime_invoke_info (MonoDomain *domain, MonoMethod *method, gpointer com
 }
 
 static MonoObject*
-mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void *obj, void **params, MonoObject **exc)
+mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void *obj, void **params, MonoObject **exc, MonoError *error)
 {
 	MonoMethodSignature *sig = info->sig;
 	MonoDomain *domain = mono_domain_get ();
@@ -2338,6 +2338,8 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 	guint8 retval [256];
 	gpointer *param_refs;
 	int i, pindex;
+
+	mono_error_init (error);
 
 	g_assert (info->gsharedvt_invoke);
 
@@ -2407,7 +2409,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
  * @exc: used to catch exceptions objects
  */
 static MonoObject*
-mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoError *error, MonoObject **exc)
+mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error)
 {
 	MonoMethod *invoke, *callee;
 	MonoObject *(*runtime_invoke) (MonoObject *this_obj, void **params, MonoObject **exc, void* compiled_method);
@@ -2565,7 +2567,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoError
 #endif
 
 	if (mono_llvm_only)
-		return mono_llvmonly_runtime_invoke (method, info, obj, params, exc);
+		return mono_llvmonly_runtime_invoke (method, info, obj, params, exc, error);
 
 	runtime_invoke = (MonoObject *(*)(MonoObject *, void **, MonoObject **, void *))info->runtime_invoke;
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2393,6 +2393,8 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 	runtime_invoke = (MonoObject *(*)(MonoObject *, void **, MonoObject **, void *))info->runtime_invoke;
 
 	runtime_invoke (NULL, args, exc, info->compiled_method);
+	if (exc && *exc)
+		mono_error_set_exception_instance (error, (MonoException*) *exc);
 
 	if (sig->ret->type != MONO_TYPE_VOID && info->ret_box_class)
 		return mono_value_box (domain, info->ret_box_class, retval);
@@ -2405,8 +2407,10 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
  * @method: the method to invoke
  * @obj: this pointer
  * @params: array of parameter values.
- * @error: error
- * @exc: used to catch exceptions objects
+ * @exc: Set to the exception raised in the managed method.  If NULL, error is thrown instead.
+ *       If coop is enabled, this argument is ignored - all exceptoins are caught and propagated
+ *       through @error
+ * @error: error or caught exception object
  */
 static MonoObject*
 mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error)
@@ -2438,10 +2442,10 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 			 */
 			mono_class_setup_vtable (method->klass);
 			if (method->klass->exception_type != MONO_EXCEPTION_NONE) {
+				MonoException *fail_exc = mono_class_get_exception_for_failure (method->klass);
 				if (exc)
-					*exc = (MonoObject*)mono_class_get_exception_for_failure (method->klass);
-				else
-					mono_raise_exception (mono_class_get_exception_for_failure (method->klass));
+					*exc = (MonoObject*)fail_exc;
+				mono_error_set_exception_instance (error, fail_exc);
 				return NULL;
 			}
 		}
@@ -2506,13 +2510,24 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 	 * We need this here because mono_marshal_get_runtime_invoke can place
 	 * the helper method in System.Object and not the target class.
 	 */
-	if (exc) {
+	if (exc)
+	{
 		*exc = (MonoObject*)mono_runtime_class_init_full (info->vtable, FALSE);
-		if (*exc)
+		if (*exc) {
+			mono_error_set_exception_instance (error, (MonoException*) *exc);
 			return NULL;
+		}
 	} else {
 		mono_runtime_class_init (info->vtable);
 	}
+
+	/* If coop is enabled, and the caller didn't ask for the exception to be caught separately,
+	   we always catch the exception and propagate it through the MonoError */
+	gboolean catchExcInMonoError =
+		(exc == NULL) && mono_threads_is_coop_enabled ();
+	MonoObject *invoke_exc = NULL;
+	if (catchExcInMonoError)
+		exc = &invoke_exc;
 
 	/* The wrappers expect this to be initialized to NULL */
 	if (exc)
@@ -2556,6 +2571,8 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		mono_arch_start_dyn_call (info->dyn_call_info, (gpointer**)args, retval, buf, sizeof (buf));
 
 		dyn_runtime_invoke (buf, exc, info->compiled_method);
+		if (exc && *exc)
+			mono_error_set_exception_instance (error, (MonoException*) *exc);
 
 		mono_arch_finish_dyn_call (info->dyn_call_info, buf);
 
@@ -2571,7 +2588,10 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 
 	runtime_invoke = (MonoObject *(*)(MonoObject *, void **, MonoObject **, void *))info->runtime_invoke;
 
-	return runtime_invoke ((MonoObject *)obj, params, exc, info->compiled_method);
+	MonoObject *result = runtime_invoke ((MonoObject *)obj, params, exc, info->compiled_method);
+	if (catchExcInMonoError && *exc != NULL)
+		mono_error_set_exception_instance (error, (MonoException*) *exc);
+	return result;
 }
 
 typedef struct {


### PR DESCRIPTION
Resolved merge conflicts and replace  #2505.

This PR introduces two new functions:
1. `mono_runtime_try_invoke`: Takes both a `MonoObject **exc` outarg and a `MonoError *error` outarg. The behavior is to always catch exception from managed code to `exc` and all other errors from trying to invoke to `error`.
2. `mono_runtime_invoke_checked`: Takes only a `MonoError *error` outarg.  Behavior when not using coop is to allow managed exceptions to unwind past the native frames just the same way as `mono_runtime_invoke` with a `exc == NULL` today.  When using coop, managed exceptions get embedded in `error` and propagated  out through all the `MonoError` machinery.

`mono_runtime_invoke` is marked external-only and calls either `mono_runtime_try_invoke` or `mono_runtime_invoke_checked`, as appropriate.

The runtime is updated to call `mono_runtime_invoke_checked` except for those cases where it explicitly tried to catch an exception before (for example in async code where exceptions are captured and rethrown on different threads)