### PR TITLE
[threads] avoid race between setting the state flag and suspension

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2306,9 +2306,6 @@ mono_thread_suspend (MonoInternalThread *thread)
 	}
 	
 	thread->state |= ThreadState_SuspendRequested;
-
-	UNLOCK_THREAD (thread);
-
 	suspend_thread_internal (thread, FALSE);
 	return TRUE;
 }
@@ -3290,9 +3287,6 @@ void mono_thread_suspend_all_other_threads (void)
 				thread->state &= ~ThreadState_AbortRequested;
 			
 			thread->state |= ThreadState_SuspendRequested;
-
-			UNLOCK_THREAD (thread);
-
 			/* Signal the thread to suspend */
 			suspend_thread_internal (thread, TRUE);
 		}
@@ -4791,7 +4785,6 @@ suspend_thread_critical (MonoThreadInfo *info, gpointer ud)
 static void
 suspend_thread_internal (MonoInternalThread *thread, gboolean interrupt)
 {
-	LOCK_THREAD (thread);
 	if (thread == mono_thread_internal_current ()) {
 		mono_thread_info_begin_self_suspend ();
 		//XXX replace this with better named functions


### PR DESCRIPTION
there's a short window where we release the lock and another thread
could modify the state.  That is what we saw on the ARM machines for a
while, e.g. in `subthread-exit.cs` there's a race between
`mono_thread_execute_interruption` and `mono_thread_suspend_all_other_threads`:

> Thread 2 (Thread 0x429ff430 (LWP 5189)):  // SUB THREAD
> #0  0x40398e30 in nanosleep () from /lib/arm-linux-gnueabihf/libpthread.so.0
> #1  0x0028c0ac in monoeg_g_usleep (microseconds=86650) at gdate-unix.c:53
> #2  0x0027b1d8 in suspend_sync_nolock (id=1079603792, interrupt_kernel=1) at mono-threads.c:913
> #3  0x0027b2d4 in mono_thread_info_safe_suspend_and_run (id=1079603792, interrupt_kernel=1, callback=0x1ab109 <suspend_thread_critical>, user_data=0x429fe534)
>     at mono-threads.c:935
> #4  0x001ab28a in suspend_thread_internal (thread=0x401c0120, interrupt=1) at threads.c:4807
> #5  0x001a91ec in mono_thread_suspend_all_other_threads () at threads.c:3297
> #6  0x00158d8c in ves_icall_System_Environment_Exit (result=0) at icall.c:6378
> #7  0x400e7d9c in ?? ()
> Backtrace stopped: previous frame identical to this frame (corrupt stack?)
>
> Thread 1 (Thread 0x40597250 (LWP 5186)):  // MAIN THREAD
> #0  0x4039a5f4 in __libc_do_syscall () from /lib/arm-linux-gnueabihf/libpthread.so.0
> #1  0x4039796e in do_futex_wait () from /lib/arm-linux-gnueabihf/libpthread.so.0
> #2  0x403979da in sem_wait@@GLIBC_2.4 () from /lib/arm-linux-gnueabihf/libpthread.so.0
> #3  0x002788d8 in mono_os_sem_wait (sem=0x388248, flags=MONO_SEM_FLAGS_NONE) at ../../mono/utils/mono-os-semaphore.h:163
> #4  0x00279722 in mono_thread_info_wait_for_resume (info=0x388210) at mono-threads.c:144
> #5  0x0027ad5e in mono_thread_info_end_self_suspend () at mono-threads.c:700
> #6  0x001ab2d2 in self_suspend_internal (thread=0x401c0120) at threads.c:4822
> #7  0x001aab0a in mono_thread_execute_interruption () at threads.c:4337
> #8  0x001a6a82 in ves_icall_System_Threading_Thread_Sleep_internal (ms=1200) at threads.c:1217
> #9  0x400da75c in ?? ()
> Backtrace stopped: previous frame identical to this frame (corrupt stack?)