### PR TITLE
[hazard pointers] add write barrier on clear as well

### DIFF
--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -36,6 +36,7 @@ gpointer get_hazardous_pointer (gpointer volatile *pp, MonoThreadHazardPointers 
 
 #define mono_hazard_pointer_clear(hp,i)	\
 	do { g_assert ((i) >= 0 && (i) < HAZARD_POINTER_COUNT); \
+		mono_memory_write_barrier (); \
 		(hp)->hazard_pointers [(i)] = NULL; \
 	} while (0)
 


### PR DESCRIPTION
I noticed that a write barrier is missing on the clear macro (we have one on the set macro).  Is there a reason for that?

@kumpera, @schani: can I have a review please?