### PR TITLE
Miscellaneous minor improvements around amd64 aot

### DIFF
--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -16,6 +16,21 @@
 #ifndef AMD64_H
 #define AMD64_H
 
+// Conventions in this file:
+
+// body: implementation. other macros call this one
+// disp: displacement
+// inst: instruction
+// is_half: short if true, byte if false (then why is it named is_half...?)
+// imm: immediate
+// mem: read from (immediate-supplied address?)
+// membase: read from address in a base register plus a displacement
+// memindex: SIP addressing: (address in base register) + (displacement in index register)<<(shift)
+// reg: register, encode modR/M bits 00
+// regp: register, encode modR/M bits 11
+// size: Expected 1,2,4 or 8
+// widen: extends from 1 or 2 bytes
+
 #include <glib.h>
 
 typedef enum {

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -480,7 +480,7 @@ if AMD64
 arch_sources = $(amd64_sources)
 arch_built=cpu-amd64.h
 arch_define=__x86_64__
-ARCH_FULLAOT_EXCLUDE=--exclude DYNCALL --exclude GSHAREDVT
+ARCH_FULLAOT_EXCLUDE=--exclude DYNCALL
 endif
 
 if POWERPC

--- a/mono/mini/TestDriver.cs
+++ b/mono/mini/TestDriver.cs
@@ -32,6 +32,7 @@ public class TestDriver {
 
 		var exclude = new Dictionary<string, string> ();
 		List<string> run_only = new List<string> ();
+		List<string> exclude_test = new List<string> ();
 		if (args != null && args.Length > 0) {
 			for (j = 0; j < args.Length;) {
 				if (args [j] == "--time") {
@@ -50,6 +51,9 @@ public class TestDriver {
 					j += 1;
 				} else if (args [j] == "--exclude") {
 					exclude [args [j + 1]] = args [j + 1];
+					j += 2;
+				} else if (args [j] == "--exclude-test") {
+					exclude_test.Add (args [j + 1]);
 					j += 2;
 				} else if (args [j] == "--run-only") {
 					run_only.Add (args [j + 1]);
@@ -78,9 +82,15 @@ public class TestDriver {
 					if (!found)
 						continue;
 				}
-				if (exclude.Count > 0) {
+				if (exclude.Count > 0 || exclude_test.Count > 0) {
 					var attrs = methods [i].GetCustomAttributes (typeof (CategoryAttribute), false);
 					bool skip = false;
+					for (j = 0; j < exclude_test.Count; j++) {
+						if (name.EndsWith (exclude_test [j])) {
+							skip = true;
+							break;
+						}
+					}
 					foreach (CategoryAttribute attr in attrs) {
 						if (exclude.ContainsKey (attr.Category))
 							skip = true;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5266,7 +5266,7 @@ get_numerous_trampoline (MonoAotTrampoline tramp_type, int n_got_slots, MonoAotM
 #define	MONOTOUCH_TRAMPOLINES_ERROR ""
 #endif
 	if (amodule->trampoline_index [tramp_type] == amodule->info.num_trampolines [tramp_type]) {
-		g_error ("Ran out of trampolines of type %d in '%s' (%d)%s\n", 
+		g_error ("Ran out of trampolines of type %d in '%s' (limit %d)%s\n", 
 				 tramp_type, image ? image->name : "mscorlib", amodule->info.num_trampolines [tramp_type], MONOTOUCH_TRAMPOLINES_ERROR);
 	}
 	index = amodule->trampoline_index [tramp_type] ++;

--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -732,8 +732,29 @@ public class Tests
 	}
 
 	public static int test_0_gsharedvt_ginstvt_constructed_arg () {
+		{
+			// AOT: Force a instantiation of use_kvp<long>
+			long a = 1;
+			var t = make_kvp (a, a);
+			var z = use_kvp (t);
+		}
+
 		IFaceKVP c = new ClassKVP ();
 		if (c.do_kvp<long> (1) != 1)
+			return 1;
+		return 0;
+	}
+
+	public static int test_0_gsharedvt_ginstvt_constructed_arg_float () {
+		{
+			// AOT: Force a instantiation of use_kvp<double>
+			double a = 1;
+			var t = make_kvp (a, a);
+			var z = use_kvp (t);
+		}
+
+		IFaceKVP c = new ClassKVP ();
+		if (c.do_kvp<double> (1) != 1)
 			return 1;
 		return 0;
 	}
@@ -1759,6 +1780,115 @@ public class Tests
 		IFaceConstrainedIFace obj = new ConstrainedIFace ();
 		IFaceTest t = new ClassTest ();
 		return obj.foo<IFaceTest, int> (ref t);
+	}
+
+	// Sign extension tests
+	// 0x55   == 85    == 01010101
+	// 0xAA   == 170   == 10101010
+	// 0x5555 == 21845 == 0101010101010101
+	// 0xAAAA == 43690 == 1010101010101010
+	// 0x55555555 == 1431655765
+	// 0xAAAAAAAA == 2863311530
+	// 0x5555555555555555 == 6148914691236517205
+	// 0xAAAAAAAAAAAAAAAA == 12297829382473034410
+
+	public interface SEFace<T> {
+		T Copy (int a, int b, int c, int d, T t);
+	}
+
+	class SEClass<T> : SEFace<T> {
+		public T Copy (int a, int b, int c, int d, T t) {
+			return t;
+		}
+	}
+
+	// Test extension
+	static int test_20_signextension_sbyte () {
+		Type t = typeof (sbyte);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<sbyte>)o;
+
+		long zz = i.Copy (1,2,3,4,(sbyte)(-0x55));
+
+		bool success = zz == -0x55;
+		return success ? 20 : 1;
+	}
+
+	static int test_20_signextension_byte () {
+		Type t = typeof (byte);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<byte>)o;
+
+		ulong zz = i.Copy (1,2,3,4,(byte)(0xAA));
+
+		bool success = zz == 0xAA;
+		return success ? 20 : 1;
+	}
+
+	static int test_20_signextension_short () {
+		Type t = typeof (short);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<short>)o;
+
+		long zz = i.Copy (1,2,3,4,(short)(-0x5555));
+
+		bool success = zz == -0x5555;
+		return success ? 20 : 1;
+	}
+
+	static int test_20_signextension_ushort () {
+		Type t = typeof (ushort);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<ushort>)o;
+
+		ulong zz = i.Copy (1,2,3,4,(ushort)(0xAAAA));
+
+		bool success = zz == 0xAAAA;
+		return success ? 20 : 1;
+	}
+
+	static int test_20_signextension_int () {
+		Type t = typeof (int);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<int>)o;
+
+		long zz = i.Copy (1,2,3,4,(int)(-0x55555555));
+
+		bool success = zz == -0x55555555;
+		return success ? 20 : 1;
+	}
+
+	static int test_20_signextension_uint () {
+		Type t = typeof (uint);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<uint>)o;
+
+		ulong zz = i.Copy (1,2,3,4,(uint)(0xAAAAAAAA));
+
+		bool success = zz == 0xAAAAAAAA;
+		return success ? 20 : 1;
+	}
+
+	static int test_20_signextension_long () {
+		Type t = typeof (long);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<long>)o;
+
+		long zz = i.Copy (1,2,3,4,(long)(-0x5555555555555555));
+
+		bool success = zz == -0x5555555555555555;
+		return success ? 20 : 1;
+	}
+
+	static int test_20_signextension_ulong () {
+		Type t = typeof (ulong);
+		object o = Activator.CreateInstance (typeof (SEClass<>).MakeGenericType (new Type[] { t }));
+		var i = (SEFace<ulong>)o;
+
+		ulong zz = i.Copy (1,2,3,4,(ulong)(0xAAAAAAAAAAAAAAAA));
+
+		bool success = zz == 0xAAAAAAAAAAAAAAAA;
+		return success ? 20 : 1;
 	}
 }
 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -523,16 +523,6 @@ typedef struct {
 
 #define DEBUG(a) if (cfg->verbose_level > 1) a
 
-#ifdef TARGET_WIN32
-static AMD64_Reg_No param_regs [] = { AMD64_RCX, AMD64_RDX, AMD64_R8, AMD64_R9 };
-
-static AMD64_Reg_No return_regs [] = { AMD64_RAX, AMD64_RDX };
-#else
-static AMD64_Reg_No param_regs [] = { AMD64_RDI, AMD64_RSI, AMD64_RDX, AMD64_RCX, AMD64_R8, AMD64_R9 };
-
- static AMD64_Reg_No return_regs [] = { AMD64_RAX, AMD64_RDX };
-#endif
-
 static void inline
 add_general (guint32 *gr, guint32 *stack_size, ArgInfo *ainfo)
 {
@@ -551,12 +541,6 @@ add_general (guint32 *gr, guint32 *stack_size, ArgInfo *ainfo)
 		(*gr) ++;
     }
 }
-
-#ifdef TARGET_WIN32
-#define FLOAT_PARAM_REGS 4
-#else
-#define FLOAT_PARAM_REGS 8
-#endif
 
 static void inline
 add_float (guint32 *gr, guint32 *stack_size, ArgInfo *ainfo, gboolean is_double)

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -501,11 +501,11 @@ typedef struct {
 	/* Only if storage == ArgValuetypeInReg */
 	ArgStorage pair_storage [2];
 	gint8 pair_regs [2];
-	/* The size of each pair */
+	/* The size of each pair (bytes) */
 	int pair_size [2];
 	int nregs;
 	/* Only if storage == ArgOnStack */
-	int arg_size;
+	int arg_size; // Bytes, will always be rounded up/aligned to 8 byte boundary
 } ArgInfo;
 
 typedef struct {

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -224,9 +224,10 @@ typedef struct {
 	gpointer addr;
 	/* The trampoline reads this, so keep the size explicit */
 	int ret_marshal;
-	/* If ret_marshal != NONE, this is the reg of the vret arg, else -1 */
+	/* If ret_marshal != NONE, this is the reg of the vret arg, else -1 (used in out case) */
+	/* Equivalent of vret_arg_slot in the x86 implementation. */
 	int vret_arg_reg;
-	/* The stack slot where the return value will be stored */
+	/* The stack slot where the return value will be stored (used in in case) */
 	int vret_slot;
 	int stack_usage, map_count;
 	/* If not -1, then make a virtual call using this vtable offset */

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -215,8 +215,18 @@ typedef struct MonoCompileArch {
 
 #ifdef TARGET_WIN32
 #define PARAM_REGS 4
+#define FLOAT_PARAM_REGS 4
+
+static AMD64_Reg_No param_regs [] = { AMD64_RCX, AMD64_RDX, AMD64_R8, AMD64_R9 };
+
+static AMD64_Reg_No return_regs [] = { AMD64_RAX, AMD64_RDX };
 #else
 #define PARAM_REGS 6
+#define FLOAT_PARAM_REGS 8
+
+static AMD64_Reg_No param_regs [] = { AMD64_RDI, AMD64_RSI, AMD64_RDX, AMD64_RCX, AMD64_R8, AMD64_R9 };
+
+static AMD64_Reg_No return_regs [] = { AMD64_RAX, AMD64_RDX };
 #endif
 
 typedef struct {


### PR DESCRIPTION
4 commits

* Enable by default and expand gsharedvt amd64 tests
* Minor additions to comments around amd64 aot
* Debug helpers: Add `mono_signature_get_return_desc` in addition to existing `mono_signature_get_desc`
* Add --exclude-test option to mono/mini test driver