### PR TITLE
[monodoc] Fix literal formatting on systems where decimal separator is not a dot

### DIFF
--- a/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
+++ b/mcs/tools/mdoc/Mono.Documentation/monodocer.cs
@@ -2067,7 +2067,7 @@ class MDocUpdater : MDocCommand
 			if (val == null) value = "null";
 			else if (val is Enum) value = val.ToString();
 			else if (val is IFormattable) {
-				value = ((IFormattable)val).ToString();
+				value = ((IFormattable)val).ToString(null, CultureInfo.InvariantCulture);
 				if (val is string)
 					value = "\"" + value + "\"";
 			}
@@ -4966,7 +4966,7 @@ class ILFullMemberFormatter : MemberFormatter {
 					.Append (val.ToString ())
 					.Append (')');
 			else if (val is IFormattable) {
-				string value = ((IFormattable)val).ToString();
+				string value = ((IFormattable)val).ToString(null, CultureInfo.InvariantCulture);
 				buf.Append (" = ");
 				if (val is string)
 					buf.Append ("\"" + value + "\"");
@@ -5525,7 +5525,7 @@ class CSharpFullMemberFormatter : MemberFormatter {
 			else if (val is Enum)
 				buf.Append (" = ").Append (val.ToString ());
 			else if (val is IFormattable) {
-				string value = ((IFormattable)val).ToString();
+				string value = ((IFormattable)val).ToString(null, CultureInfo.InvariantCulture);
 				if (val is string)
 					value = "\"" + value + "\"";
 				buf.Append (" = ").Append (value);


### PR DESCRIPTION
E.g. on a German language OS the "make check-mdoc-export-html" test fails with this:

```
diff --exclude=.svn -rup Test/en.expected/Mono.DocTest/Widget.xml Test/en.actual/Mono.DocTest/Widget.xml
--- Test/en.expected/Mono.DocTest/Widget.xml	2015-11-18 04:42:11.000000000 +0100
+++ Test/en.actual/Mono.DocTest/Widget.xml	2016-02-04 02:38:09.000000000 +0100
@@ -1061,8 +1061,8 @@
       </Docs>
     </Member>
     <Member MemberName="PI">
-      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
-      <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
+      <MemberSignature Language="C#" Value="protected const double PI = 3,14159;" />
+      <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3,14159)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -1070,7 +1070,7 @@
       <ReturnValue>
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
-      <MemberValue>3.14159</MemberValue>
+      <MemberValue>3,14159</MemberValue>
       <Docs>
```

The fix is to always use InvariantCulture for literal formatting.

/cc @jonpryor 