### PR TITLE
[sgen] Improve memory usage with the concurrent collector

### DIFF
--- a/mono/sgen/sgen-conf.h
+++ b/mono/sgen/sgen-conf.h
@@ -191,12 +191,6 @@ typedef mword SgenDescriptor;
 #define SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO 0.33
 
 /*
- * How much more we allow the heap to grow, relative to the allowance, while doing
- * a concurrent collection, before forcing its finish.
- */
-#define SGEN_DEFAULT_CONCURRENT_HEAP_ALLOWANCE_RATIO 0.25
-
-/*
  * Default ratio of memory we want to release in a major collection in relation to the the current heap size.
  *
  * A major collection target is to free a given amount of memory. This amount is a ratio of the major heap size.

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1974,6 +1974,7 @@ major_finish_collection (const char *reason, size_t old_next_pin_slot, gboolean 
 	time_major_fragment_creation += TV_ELAPSED (atv, btv);
 
 	binary_protocol_sweep_begin (GENERATION_OLD, !major_collector.sweeps_lazily);
+	sgen_memgov_major_pre_sweep ();
 
 	TV_GETTIME (atv);
 	time_major_free_bigobjs += TV_ELAPSED (btv, atv);

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -56,6 +56,9 @@ static gboolean debug_print_allowance = FALSE;
 /* use this to tune when to do a major/minor collection */
 static mword major_collection_trigger_size;
 
+static mword major_pre_sweep_heap_size;
+static mword major_start_heap_size;
+
 static mword last_major_num_sections = 0;
 static mword last_los_memory_usage = 0;
 
@@ -73,6 +76,7 @@ static void
 sgen_memgov_calculate_minor_collection_allowance (void)
 {
 	size_t new_major, new_heap_size, allowance_target, allowance;
+	size_t decrease;
 
 	if (!need_calculate_minor_collection_allowance)
 		return;
@@ -89,6 +93,16 @@ sgen_memgov_calculate_minor_collection_allowance (void)
 	allowance_target = new_heap_size * SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO;
 
 	allowance = MAX (allowance_target, MIN_MINOR_COLLECTION_ALLOWANCE);
+
+	/*
+	 * For the concurrent collector, we decrease the allowance relative to the memory
+	 * growth during the M&S phase, survival rate of the collection and the allowance
+	 * ratio.
+	 */
+	decrease = (major_pre_sweep_heap_size - major_start_heap_size) * ((float)new_heap_size / major_pre_sweep_heap_size) * (SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO + 1);
+	if (decrease > allowance)
+		decrease = allowance;
+	allowance -= decrease;
 
 	if (new_heap_size + allowance > soft_heap_limit) {
 		if (new_heap_size > soft_heap_limit)
@@ -129,13 +143,14 @@ sgen_need_major_collection (mword space_needed)
 		if (heap_size <= major_collection_trigger_size)
 			return FALSE; 
 
-		/* We allow the heap to grow an additional third of the allowance during a concurrent collection */
-		if ((heap_size - major_collection_trigger_size) >
-				(major_collection_trigger_size
-				* (SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO / (SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO + 1))
-				* SGEN_DEFAULT_CONCURRENT_HEAP_ALLOWANCE_RATIO)) {
+		/*
+		 * The more the heap grows, the more we need to decrease the allowance above,
+		 * in order to have similar trigger sizes as the synchronous collector.
+		 * If the heap grows so much that we would need to have a negative allowance,
+		 * we force the finishing of the collection, to avoid increased memory usage.
+		 */
+		if ((heap_size - major_start_heap_size) > major_start_heap_size * SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO)
 			return TRUE;
-		}
 		return FALSE;
 	}
 
@@ -164,12 +179,24 @@ sgen_memgov_minor_collection_end (void)
 }
 
 void
+sgen_memgov_major_pre_sweep (void)
+{
+	if (sgen_concurrent_collection_in_progress ()) {
+		major_pre_sweep_heap_size = get_heap_size ();
+	} else {
+		/* We decrease the allowance only in the concurrent case */
+		major_pre_sweep_heap_size = major_start_heap_size;
+	}
+}
+
+void
 sgen_memgov_major_collection_start (void)
 {
 	need_calculate_minor_collection_allowance = TRUE;
+	major_start_heap_size = get_heap_size ();
 
 	if (debug_print_allowance) {
-		SGEN_LOG (0, "Starting collection with heap size %ld bytes", (long)get_heap_size ());
+		SGEN_LOG (0, "Starting collection with heap size %ld bytes", (long)major_start_heap_size);
 	}
 }
 

--- a/mono/sgen/sgen-memory-governor.h
+++ b/mono/sgen/sgen-memory-governor.h
@@ -33,6 +33,7 @@ gboolean sgen_memgov_try_alloc_space (mword size, int space);
 void sgen_memgov_minor_collection_start (void);
 void sgen_memgov_minor_collection_end (void);
 
+void sgen_memgov_major_pre_sweep (void);
 void sgen_memgov_major_collection_start (void);
 void sgen_memgov_major_collection_end (gboolean forced);
 


### PR DESCRIPTION
This PR makes the concurrent collector do a similar amount of collection work as the synchronous collector.

The number of synchronous major collections compared to the number of concurrent major collections before and after this commit :  
MSBiology : sync - 270, conc_before - 240, conc_after - 257
binarytree : sync - 161, conc_before - 121, conc_after 136
Roslyn : sync - 11, conc_before - 10, conc_after - 11
FSharp : sync - 21, conc_before - 19, conc_after - 21
lcscbench : sync - 10, conc_before - 8, conc_after 10

It also has significant impact on the longest pause times, since we allow more time for the concurrent mark to run. On list, for example, it decreases by 2-3 times the average pause time.
