### PR TITLE
libgc: use __builtin_frame_address in GC_approx_sp

### DIFF
--- a/libgc/mark_rts.c
+++ b/libgc/mark_rts.c
@@ -368,6 +368,9 @@ ptr_t p;
 
 ptr_t GC_approx_sp()
 {
+#if defined(__GNUC__)
+    return __builtin_frame_address(0);
+#else
     VOLATILE word dummy;
 
     dummy = 42;	/* Force stack to grow if necessary.	Otherwise the	*/
@@ -376,17 +379,11 @@ ptr_t GC_approx_sp()
 #   ifdef _MSC_VER
 #     pragma warning(disable:4172)
 #   endif
-#   if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 408)
-#     pragma GCC diagnostic push
-#     pragma GCC diagnostic ignored "-Wreturn-local-addr"
-#   endif
     return((ptr_t)(&dummy));
-#   if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 408)
-#      pragma GCC diagnostic pop
-#   endif
 #   ifdef _MSC_VER
 #     pragma warning(default:4172)
 #   endif
+#endif  // __GNUC__
 }
 
 /*


### PR DESCRIPTION
With GCC 5.x, the compiler optimises away the dummy load used to
estimate the stack pointer address in GC_approx_sp; it returns
zero. This leads to segfaults when embedding Mono.

Instead, use __builtin_frame_address, which GCC's libgc uses for
the same purpose since 2009.

This may be the cause of Xamarin bug 34323: https://bugzilla.xamarin.com/show_bug.cgi?id=34323