### PR TITLE
[profiler] Fix a rare crash when sending SIGPROF to a starting thread.

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -342,7 +342,8 @@ MONO_SIG_HANDLER_FUNC (static, sigprof_signal_handler)
 	/* If we can't consume a profiling request it means we're the initiator. */
 	if (!(mono_threads_consume_async_jobs () & MONO_SERVICE_REQUEST_SAMPLE)) {
 		FOREACH_THREAD_SAFE (info) {
-			if (mono_thread_info_get_tid (info) == mono_native_thread_id_get ())
+			if (mono_thread_info_get_tid (info) == mono_native_thread_id_get () ||
+			    !mono_thread_info_is_live (info))
 				continue;
 
 			mono_threads_add_async_job (info, MONO_SERVICE_REQUEST_SAMPLE);


### PR DESCRIPTION
When sample profiling is enabled and we send a SIGPROF signal to a thread that
hasn't yet transitioned to a running state (e.g. STATE_RUNNING), the signal can
sometimes be delivered at such an early point that libc has not even finished
initializing TLS for that thread yet. This is problematic because we then go
right on to crash in the SIGPROF signal handler when we try to save errno. We
then further crash in the SIGSEGV handler because we can't access the jit_tls
variable either.

The fix is fairly simple: Only send SIGPROF to threads that have transitioned
to a running state. Technically, TLS is initialized 'much' earlier than when
this state transition happens, but since the worst thing that can happen is
that we miss one sampling event (i.e. ~1sec by default) right at the beginning
of the thread's lifetime, this simple fix is good enough.

This crash seemingly only happened on OS X.