### PR TITLE
[metadata] Fix hardcoded mono/2.0 path in assembly.c

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -632,7 +632,7 @@ set_dirs (char *exe)
 
 	config = g_build_filename (base, "etc", NULL);
 	lib = g_build_filename (base, "lib", NULL);
-	mono = g_build_filename (lib, "mono/2.0", NULL);
+	mono = g_build_filename (lib, "mono/4.5", NULL);  // FIXME: stop hardcoding 4.5 here
 	if (stat (mono, &buf) == -1)
 		fallback ();
 	else {
@@ -3071,7 +3071,7 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 	corlib = load_in_path (corlib_file, default_path, status, FALSE);
 	g_free (corlib_file);
 	
-	if (corlib && !strcmp (runtime->framework_version, "4.5"))
+	if (corlib && !strcmp (runtime->framework_version, "4.5"))  // FIXME: stop hardcoding 4.5 here
 		default_path [1] = g_strdup_printf ("%s/mono/4.5/Facades", default_path [0]);
 		
 	return corlib;

--- a/mono/tests/assembly-load-stress.cs
+++ b/mono/tests/assembly-load-stress.cs
@@ -21,7 +21,7 @@ public class Tests
 			Thread[] threads = new Thread [nthreads];
 			for (int i = 0; i < nthreads; ++i) {
 				threads [i] = new Thread (delegate () {
-						foreach (string s in Directory.GetFiles ("/usr/local/lib/mono/2.0", "*.dll")) {
+						foreach (string s in Directory.GetFiles ("/usr/local/lib/mono/4.5", "*.dll")) {
 							AssemblyName.GetAssemblyName (s);
 						}
 					});


### PR DESCRIPTION
The performance team discovered this on their bots using the Jenkins snapshot packages. Mono would fail to start with a message like:

```
The assembly mscorlib.dll was not found or could not be loaded.
It should have been installed in the `/opt/mono-2016.02.08+15.25.39/lib/mono/4.5/mscorlib.dll' directory.
```

The one odd thing is that they are using Mono installed in a path which is different from the prefix used during compilation.

It turns out that the runtime has a hardcoded check for lib/mono/2.0 in [assembly.c#L633-L637](https://github.com/mono/mono/blob/7d5a7ea7ac324bb4ee63094ddcf8e20ae9ba4322/mono/metadata/assembly.c#L633-L637).

Since we recently stopped shipping 2.0 in the packages (we moved to 2.0-api for the reference assemblies) this directory wasn't there, so the code in `fallback()` called into `mono_config_get_assemblies_dir()` which just returns the MONO_ASSEMBLIES preprocessor symbol.

That preprocessor symbol is defined to the value of --prefix during compilation, so Mono couldn't find corlib there as well since it's installed in another path which ultimately results in the above error message.

The fix is to change the hardcoded value to 4.5, which is what we established as the directory with the "latest" assemblies now.
Ideally we should find a way to stop hardcoding those paths in the runtime.

PS: I grepped through the runtime source to make sure we don't hardcode 2.0/3.5/4.0 elsewhere and only found one instance in a test.
I fixed it there as well, though the test looks suspicious since it hardcodes /usr ...