### PR TITLE
[4.3.2][AsyncResult] Fix unhandled exception behaviour in AsyncCallback

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6115,11 +6115,7 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 			SetEvent (wait_event);
 
 		if (ac->cb_method) {
-			/* we swallow the excepton as it is the behavior on .NET */
-			MonoObject *exc = NULL;
-			mono_runtime_invoke (ac->cb_method, ac->cb_target, (gpointer*) &ares, &exc);
-			if (exc)
-				mono_unhandled_exception (exc);
+			mono_runtime_invoke (ac->cb_method, ac->cb_target, (gpointer*) &ares, NULL);
 		}
 	}
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1393,9 +1393,9 @@ test-unhandled-exception-2-4: unhandled-exception-4.exe test-runner.exe
 test-unhandled-exception-2-5: unhandled-exception-5.exe test-runner.exe
 	@$(RUNTIME) ./test-runner.exe --testsuite-name $@ --expected-exit-code 255 $<
 test-unhandled-exception-2-6: unhandled-exception-6.exe test-runner.exe
-	@$(RUNTIME) ./test-runner.exe --testsuite-name $@ --expected-exit-code 0 $<
+	@$(RUNTIME) ./test-runner.exe --testsuite-name $@ --expected-exit-code 255 $<
 test-unhandled-exception-2-7: unhandled-exception-7.exe test-runner.exe
-	@$(RUNTIME) ./test-runner.exe --testsuite-name $@ --expected-exit-code 0 $<
+	@$(RUNTIME) ./test-runner.exe --testsuite-name $@ --expected-exit-code 255 $<
 test-unhandled-exception-2-8: unhandled-exception-8.exe test-runner.exe
 	@$(RUNTIME) ./test-runner.exe --testsuite-name $@ --expected-exit-code 3 $<
 endif

--- a/mono/tests/unhandled-exception-7.cs
+++ b/mono/tests/unhandled-exception-7.cs
@@ -2,12 +2,9 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.Remoting.Messaging;
 
 class CustomException : Exception
-{
-}
-
-class CustomException2 : Exception
 {
 }
 
@@ -38,18 +35,16 @@ class Driver
 
 		var cd = (CrossDomain) AppDomain.CreateDomain ("ad").CreateInstanceAndUnwrap (typeof(CrossDomain).Assembly.FullName, "CrossDomain");
 
-		var a = cd.NewDelegateWithoutTarget ();
-		var ares = a.BeginInvoke (delegate { throw new CustomException2 (); }, null);
+		var action = cd.NewDelegateWithoutTarget ();
+		var ares = action.BeginInvoke (Callback, null);
 
-		try {
-			a.EndInvoke (ares);
-			Environment.Exit (4);
-		} catch (CustomException) {
-		} catch (Exception ex) {
-			Console.WriteLine (ex);
-			Environment.Exit (3);
-		}
+		Thread.Sleep (5000);
 
-		Environment.Exit (0);
+		Environment.Exit (1);
+	}
+
+	static void Callback (IAsyncResult iares)
+	{
+		((Action) ((AsyncResult) iares).AsyncDelegate).EndInvoke (iares);
 	}
 }


### PR DESCRIPTION
The AsyncCallback is called after the BeginInvoke has completed. In all cases, this AsyncCallback is called on the ThreadPool, meaning that an unhandled exception would lead to a process crash.

The correct behaviour, after verification on .NET, is to not swallow the exception, and to properly crash the process.

@monojenkins merge