### PR TITLE
[bcl] fix compilation of test on mobile

### DIFF
--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -1019,6 +1019,7 @@ namespace MonoTests.System.Diagnostics
 			}
 		}
 
+#if MONO_FEATURE_PROCESS_START
 		[Test]
 		[NUnit.Framework.Category ("MobileNotWorking")]
 		[ExpectedException (typeof (InvalidOperationException))]
@@ -1058,5 +1059,6 @@ namespace MonoTests.System.Diagnostics
 				Assert.Fail ();
 			}
 		}
+#endif // MONO_FEATURE_PROCESS_START
 	}
 }


### PR DESCRIPTION
although a nunit category is specified, the compilation still failed on mobile.