### PR TITLE
[tests] print name of current test in appdomain-unload

### DIFF
--- a/mono/tests/appdomain-unload.cs
+++ b/mono/tests/appdomain-unload.cs
@@ -102,6 +102,7 @@ public class Tests
 	}
 
 	public static int test_0_unload () {
+		Console.WriteLine ("running test_0_unload");
 		for (int i = 0; i < 10; ++i) {
 			AppDomain appDomain = AppDomain.CreateDomain("Test-unload" + i);
 
@@ -115,6 +116,7 @@ public class Tests
 	}
 
 	public static int test_0_unload_default () {
+		Console.WriteLine ("running test_0_unload_default");
 		try {
 			AppDomain.Unload (Thread.GetDomain ());
 		}
@@ -125,6 +127,7 @@ public class Tests
 	}
 
 	public static int test_0_unload_after_unload () {
+		Console.WriteLine ("running test_0_unload_after_unload");
 		AppDomain domain = AppDomain.CreateDomain ("Test2");
 		AppDomain.Unload (domain);
 
@@ -139,6 +142,7 @@ public class Tests
 	}
 
 	public static int test_0_is_finalizing () {
+		Console.WriteLine ("running test_0_is_finalizing");
 		AppDomain domain = AppDomain.CreateDomain ("Test-is-finalizing");
 		object o = domain.CreateInstanceFromAndUnwrap (typeof (Tests).Assembly.Location, "Foo");
 
@@ -151,6 +155,7 @@ public class Tests
 	}
 
 	public static int test_0_unload_with_active_threads () {
+		Console.WriteLine ("running test_0_unload_with_active_threads");
 		AppDomain domain = AppDomain.CreateDomain ("Test3");
 		object o = domain.CreateInstanceFromAndUnwrap (typeof (Tests).Assembly.Location, "AThread");
 		Thread.Sleep (100);
@@ -191,6 +196,7 @@ public class Tests
 	}
 
 	public static int test_0_unload_with_threadpool () {
+		Console.WriteLine ("running test_0_unload_with_threadpool");
 		AppDomain domain = AppDomain.CreateDomain ("test_0_unload_with_threadpool");
 
 		domain.DoCallBack (new CrossAppDomainDelegate (invoke_workers));
@@ -229,6 +235,7 @@ public class Tests
 	}		
 
 	public static int test_0_unload_inside_appdomain_sync () {
+		Console.WriteLine ("running test_0_unload_inside_appdomain_sync");
 		AppDomain domain = AppDomain.CreateDomain ("Test3");
 
 		try {
@@ -243,6 +250,7 @@ public class Tests
 	}
 
 	public static int test_0_invoke_after_unload () {
+		Console.WriteLine ("running test_0_invoke_after_unload");
 		AppDomain domain = AppDomain.CreateDomain ("DeadInvokeTest");
 		Bar bar = (Bar)domain.CreateInstanceAndUnwrap (typeof (Tests).Assembly.FullName, "Bar");
 		int x;


### PR DESCRIPTION
in order to get a better sense where the test fails/hangs on the bots