### PR TITLE
sgen: fix bit counting in mword

### DIFF
--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -1401,8 +1401,8 @@ bitcount (mword d)
 	int count = 0;
 
 #ifdef __GNUC__
-	if (sizeof (mword) == sizeof (unsigned long))
-		count += __builtin_popcountl (d);
+	if (sizeof (mword) == 8)
+		count += __builtin_popcountll (d);
 	else
 		count += __builtin_popcount (d);
 #else


### PR DESCRIPTION
Fixes GC crashe for 64-bit architecture when using libmono.
http://lists.ximian.com/pipermail/mono-devel-list/2016-February/043507.html