### PR TITLE
[4.3.2][coop] Fix native-to-managed wrapper thread attach

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2008,7 +2008,7 @@ cominterop_get_ccw (MonoObject* object, MonoClass* itf)
 
 			cominterop_setup_marshal_context (&m, adjust_method);
 			m.mb = mb;
-			mono_marshal_emit_managed_wrapper (mb, sig_adjusted, mspecs, &m, adjust_method, 0);
+			mono_marshal_emit_managed_wrapper (mb, sig_adjusted, mspecs, &m, adjust_method, 0, FALSE);
 			mono_cominterop_lock ();
 			wrapper_method = mono_mb_create_method (mb, m.csig, m.csig->param_count + 16);
 			mono_cominterop_unlock ();

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -358,7 +358,7 @@ MonoMethodSignature*
 mono_marshal_get_string_ctor_signature (MonoMethod *method);
 
 MonoMethod *
-mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass, uint32_t this_loc);
+mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass, uint32_t this_loc, gboolean aot);
 
 gpointer
 mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type);
@@ -605,7 +605,7 @@ void
 mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodPInvoke *piinfo, MonoMarshalSpec **mspecs, gpointer func, gboolean aot, gboolean check_exceptions, gboolean func_param);
 
 void
-mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, uint32_t target_handle);
+mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, uint32_t target_handle, gboolean aot);
 
 GHashTable*
 mono_marshal_get_cache (GHashTable **var, GHashFunc hash_func, GCompareFunc equal_func);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3965,7 +3965,7 @@ add_wrappers (MonoAotCompile *acfg)
 					named += slen;
 				}
 
-				wrapper = mono_marshal_get_managed_wrapper (method, klass, 0);
+				wrapper = mono_marshal_get_managed_wrapper (method, klass, 0, TRUE);
 				add_method (acfg, wrapper);
 				if (export_name)
 					g_hash_table_insert (acfg->export_names, wrapper, export_name);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1181,7 +1181,7 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 			klass = decode_klass_ref (module, p, &p);
 			if (!klass)
 				return FALSE;
-			ref->method = mono_marshal_get_managed_wrapper (m, klass, 0);
+			ref->method = mono_marshal_get_managed_wrapper (m, klass, 0, TRUE);
 			break;
 		}
 		default:

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12713,65 +12713,6 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				ip += 6;
 				break;
 			}
-			case CEE_MONO_JIT_ATTACH: {
-				MonoInst *args [16], *domain_ins;
-				MonoInst *ad_ins, *jit_tls_ins;
-				MonoBasicBlock *next_bb = NULL, *call_bb = NULL;
-
-				cfg->orig_domain_var = mono_compile_create_var (cfg, &mono_defaults.int_class->byval_arg, OP_LOCAL);
-
-				EMIT_NEW_PCONST (cfg, ins, NULL);
-				MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->orig_domain_var->dreg, ins->dreg);
-
-				ad_ins = mono_get_domain_intrinsic (cfg);
-				jit_tls_ins = mono_get_jit_tls_intrinsic (cfg);
-
-				if (cfg->backend->have_tls_get && ad_ins && jit_tls_ins) {
-					NEW_BBLOCK (cfg, next_bb);
-					NEW_BBLOCK (cfg, call_bb);
-
-					if (cfg->compile_aot) {
-						/* AOT code is only used in the root domain */
-						EMIT_NEW_PCONST (cfg, domain_ins, NULL);
-					} else {
-						EMIT_NEW_PCONST (cfg, domain_ins, cfg->domain);
-					}
-					MONO_ADD_INS (cfg->cbb, ad_ins);
-					MONO_EMIT_NEW_BIALU (cfg, OP_COMPARE, -1, ad_ins->dreg, domain_ins->dreg);
-					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBNE_UN, call_bb);
-
-					MONO_ADD_INS (cfg->cbb, jit_tls_ins);
-					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, jit_tls_ins->dreg, 0);
-					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBEQ, call_bb);
-
-					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_BR, next_bb);
-					MONO_START_BB (cfg, call_bb);
-				}
-
-				if (cfg->compile_aot) {
-					/* AOT code is only used in the root domain */
-					EMIT_NEW_PCONST (cfg, args [0], NULL);
-				} else {
-					EMIT_NEW_PCONST (cfg, args [0], cfg->domain);
-				}
-				ins = mono_emit_jit_icall (cfg, mono_jit_thread_attach, args);
-				MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->orig_domain_var->dreg, ins->dreg);
-
-				if (next_bb)
-					MONO_START_BB (cfg, next_bb);
-				ip += 2;
-				break;
-			}
-			case CEE_MONO_JIT_DETACH: {
-				MonoInst *args [16];
-
-				/* Restore the original domain */
-				dreg = alloc_ireg (cfg);
-				EMIT_NEW_UNALU (cfg, args [0], OP_MOVE, dreg, cfg->orig_domain_var->dreg);
-				mono_emit_jit_icall (cfg, mono_jit_set_domain, args);
-				ip += 2;
-				break;
-			}
 			case CEE_MONO_CALLI_EXTRA_ARG: {
 				MonoInst *addr;
 				MonoMethodSignature *fsig;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -905,14 +905,6 @@ mono_jit_thread_attach (MonoDomain *domain)
 	return orig != domain ? orig : NULL;
 }
 
-/* Called by native->managed wrappers */
-void
-mono_jit_set_domain (MonoDomain *domain)
-{
-	if (domain)
-		mono_domain_set (domain, TRUE);
-}
-
 /**
  * mono_thread_abort:
  * @obj: exception object
@@ -3690,8 +3682,6 @@ register_icalls (void)
 	register_icall (mono_trace_enter_method, "mono_trace_enter_method", NULL, TRUE);
 	register_icall (mono_trace_leave_method, "mono_trace_leave_method", NULL, TRUE);
 	register_icall (mono_get_lmf_addr, "mono_get_lmf_addr", "ptr", TRUE);
-	register_icall (mono_jit_thread_attach, "mono_jit_thread_attach", "ptr ptr", TRUE);
-	register_icall (mono_jit_set_domain, "mono_jit_set_domain", "void ptr", TRUE);
 	register_icall (mono_domain_get, "mono_domain_get", "ptr", TRUE);
 
 	register_icall (mono_llvm_throw_exception, "mono_llvm_throw_exception", "void object", TRUE);


### PR DESCRIPTION
Previously, when we would invoke a native-to-managed wrapper from a thread that has not been attached to the runtime, we would simply ensure to attach this thread to the runtime. The issue arise when using coop and needing to switch a thread which is not executing runtime or managed code to BLOCKING state.

That would arise on iOS when using dispatch_async:
 - the user would enqueue a Delegate, triggering a call to mono_delegate_to_ftnptr, generating this native-to-managed wrapper
 - the wrapper would be called asynchronously on a thread managed by the OS/dispatch_async
 - the thread would attach to the runtime, switching its state from STARTING -> RUNNING
 - the thread would finish executing the delegate, thus 'detaching' from the runtime, but without switching its state from RUNNING -> BLOCKING
 - during the next garbage collection, the GC would try to suspend this thread as it is still in RUNNING state, but because it's neither executing runtime code, neither managed code, it will never hit a safepoint, leading to a timeouting suspend.

To fix that issue, we need to support the following state switches:
 - STARTING -> RUNNING -> BLOCKING: happens when it's the first time this thread calls a native-to-managed wrapper
 - BLOCKING -> RUNNING -> BLOCKING: happens when it's not the first time this thread is called from a facility like dispatch_async, or if it is, for example, called as a callback from an external library
 - RUNNING -> RUNNING -> RUNNING: if we call this wrapper from runtime or managed code, see for example System.Reflection.Emit.ILGeneratorTest.TestEmitCalliWithNullReturnType

This facility also need to take care of the current domain, to ensure that we switch properly between domains, and set it to the one that was used when creating this delegate, then restoring the original one.