### PR TITLE
[coop] Fix native-to-managed wrapper

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9634,12 +9634,13 @@ debugger_thread (void *arg)
 	ErrorCode err;
 	gboolean no_reply;
 	gboolean attach_failed = FALSE;
+	gpointer attach_cookie, attach_dummy;
 
 	DEBUG_PRINTF (1, "[dbg] Agent thread started, pid=%p\n", (gpointer) (gsize) mono_native_thread_id_get ());
 
 	debugger_thread_id = mono_native_thread_id_get ();
 
-	mono_jit_thread_attach (mono_get_root_domain ());
+	attach_cookie = mono_jit_thread_attach (mono_get_root_domain (), &attach_dummy);
 
 	mono_thread_internal_current ()->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 
@@ -9792,7 +9793,9 @@ debugger_thread (void *arg)
 		DEBUG_PRINTF (2, "[dbg] Detached - restarting clean debugger thread.\n");
 		start_debugger_thread ();
 	}
-	
+
+	mono_jit_thread_detach (attach_cookie, &attach_dummy);
+
 	return 0;
 }
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12750,47 +12750,54 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				MonoInst *ad_ins, *jit_tls_ins;
 				MonoBasicBlock *next_bb = NULL, *call_bb = NULL;
 
-				cfg->orig_domain_var = mono_compile_create_var (cfg, &mono_defaults.int_class->byval_arg, OP_LOCAL);
+				cfg->attach_cookie = mono_compile_create_var (cfg, &mono_defaults.int_class->byval_arg, OP_LOCAL);
+				cfg->attach_dummy = mono_compile_create_var (cfg, &mono_defaults.int_class->byval_arg, OP_LOCAL);
 
-				EMIT_NEW_PCONST (cfg, ins, NULL);
-				MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->orig_domain_var->dreg, ins->dreg);
-
-				ad_ins = mono_get_domain_intrinsic (cfg);
-				jit_tls_ins = mono_get_jit_tls_intrinsic (cfg);
-
-				if (cfg->backend->have_tls_get && ad_ins && jit_tls_ins) {
-					NEW_BBLOCK (cfg, next_bb);
-					NEW_BBLOCK (cfg, call_bb);
-
-					if (cfg->compile_aot) {
-						/* AOT code is only used in the root domain */
-						EMIT_NEW_PCONST (cfg, domain_ins, NULL);
-					} else {
-						EMIT_NEW_PCONST (cfg, domain_ins, cfg->domain);
-					}
-					MONO_ADD_INS (cfg->cbb, ad_ins);
-					MONO_EMIT_NEW_BIALU (cfg, OP_COMPARE, -1, ad_ins->dreg, domain_ins->dreg);
-					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBNE_UN, call_bb);
-
-					MONO_ADD_INS (cfg->cbb, jit_tls_ins);
-					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, jit_tls_ins->dreg, 0);
-					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBEQ, call_bb);
-
-					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_BR, next_bb);
-					MONO_START_BB (cfg, call_bb);
-				}
-
-				if (cfg->compile_aot) {
+				if (mono_threads_is_coop_enabled ()) {
 					/* AOT code is only used in the root domain */
-					EMIT_NEW_PCONST (cfg, args [0], NULL);
+					EMIT_NEW_PCONST (cfg, args [0], cfg->compile_aot ? NULL : cfg->domain);
+					EMIT_NEW_VARLOADA (cfg, args [1], cfg->attach_dummy, cfg->attach_dummy->inst_vtype);
+					ins = mono_emit_jit_icall (cfg, mono_jit_thread_attach, args);
+					MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->attach_cookie->dreg, ins->dreg);
 				} else {
-					EMIT_NEW_PCONST (cfg, args [0], cfg->domain);
-				}
-				ins = mono_emit_jit_icall (cfg, mono_jit_thread_attach, args);
-				MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->orig_domain_var->dreg, ins->dreg);
+					EMIT_NEW_PCONST (cfg, ins, NULL);
+					MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->attach_cookie->dreg, ins->dreg);
 
-				if (next_bb)
-					MONO_START_BB (cfg, next_bb);
+					ad_ins = mono_get_domain_intrinsic (cfg);
+					jit_tls_ins = mono_get_jit_tls_intrinsic (cfg);
+
+					if (cfg->backend->have_tls_get && ad_ins && jit_tls_ins) {
+						NEW_BBLOCK (cfg, next_bb);
+						NEW_BBLOCK (cfg, call_bb);
+
+						if (cfg->compile_aot) {
+							/* AOT code is only used in the root domain */
+							EMIT_NEW_PCONST (cfg, domain_ins, NULL);
+						} else {
+							EMIT_NEW_PCONST (cfg, domain_ins, cfg->domain);
+						}
+						MONO_ADD_INS (cfg->cbb, ad_ins);
+						MONO_EMIT_NEW_BIALU (cfg, OP_COMPARE, -1, ad_ins->dreg, domain_ins->dreg);
+						MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBNE_UN, call_bb);
+
+						MONO_ADD_INS (cfg->cbb, jit_tls_ins);
+						MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, jit_tls_ins->dreg, 0);
+						MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBEQ, call_bb);
+
+						MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_BR, next_bb);
+						MONO_START_BB (cfg, call_bb);
+					}
+
+					/* AOT code is only used in the root domain */
+					EMIT_NEW_PCONST (cfg, args [0], cfg->compile_aot ? NULL : cfg->domain);
+					EMIT_NEW_PCONST (cfg, args [1], NULL);
+					ins = mono_emit_jit_icall (cfg, mono_jit_thread_attach, args);
+					MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->attach_cookie->dreg, ins->dreg);
+
+					if (next_bb)
+						MONO_START_BB (cfg, next_bb);
+				}
+
 				ip += 2;
 				break;
 			}
@@ -12799,8 +12806,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 				/* Restore the original domain */
 				dreg = alloc_ireg (cfg);
-				EMIT_NEW_UNALU (cfg, args [0], OP_MOVE, dreg, cfg->orig_domain_var->dreg);
-				mono_emit_jit_icall (cfg, mono_jit_set_domain, args);
+				EMIT_NEW_UNALU (cfg, args [0], OP_MOVE, dreg, cfg->attach_cookie->dreg);
+				EMIT_NEW_VARLOADA (cfg, args [1], cfg->attach_dummy, cfg->attach_dummy->inst_vtype);
+				mono_emit_jit_icall (cfg, mono_jit_thread_detach, args);
 				ip += 2;
 				break;
 			}

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1605,8 +1605,9 @@ typedef struct {
 	/* Points to a MonoGSharedVtMethodRuntimeInfo at runtime */
 	MonoInst *gsharedvt_info_var;
 
-	/* For native-to-managed wrappers, the saved old domain */
-	MonoInst *orig_domain_var;
+	/* For native-to-managed wrappers, CEE_MONO_JIT_(AT|DE)TACH opcodes */
+	MonoInst *attach_cookie;
+	MonoInst *attach_dummy;
 
 	MonoInst *lmf_var;
 	MonoInst *lmf_addr_var;
@@ -2369,8 +2370,8 @@ MonoLMF * mono_get_lmf                      (void);
 MonoLMF** mono_get_lmf_addr                 (void);
 void      mono_set_lmf                      (MonoLMF *lmf);
 MonoJitTlsData* mono_get_jit_tls            (void);
-MONO_API MonoDomain *mono_jit_thread_attach          (MonoDomain *domain);
-MONO_API void      mono_jit_set_domain               (MonoDomain *domain);
+MONO_API gpointer  mono_jit_thread_attach            (MonoDomain *domain, gpointer *dummy);
+MONO_API void      mono_jit_thread_detach            (gpointer cookie, gpointer *dummy);
 gint32    mono_get_jit_tls_offset           (void);
 gint32    mono_get_lmf_tls_offset           (void);
 gint32    mono_get_lmf_addr_tls_offset      (void);

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -486,7 +486,6 @@ mono_jit_init_version
 mono_jit_parse_options
 mono_jit_set_aot_mode
 mono_jit_set_aot_only
-mono_jit_set_domain
 mono_jit_set_trace_options
 mono_jit_thread_attach
 mono_ldstr

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -488,7 +488,6 @@ mono_jit_init_version
 mono_jit_parse_options
 mono_jit_set_aot_mode
 mono_jit_set_aot_only
-mono_jit_set_domain
 mono_jit_set_trace_options
 mono_jit_thread_attach
 mono_ldstr


### PR DESCRIPTION
Previously, when we would invoke a native-to-managed wrapper from a thread that has not been attached to the runtime, we would simply ensure to attach this thread to the runtime. The issue arise when using coop and needing to switch a thread which is not executing runtime or managed code to BLOCKING state.

That would arise on iOS when using dispatch_async:
 - the user would enqueue a Delegate, triggering a call to mono_delegate_to_ftnptr, generating this native-to-managed wrapper
 - the wrapper would be called asynchronously on a thread managed by the OS/dispatch_async
 - the thread would attach to the runtime, switching its state from STARTING -> RUNNING
 - the thread would finish executing the delegate, thus 'detaching' from the runtime, but without switching its state from RUNNING -> BLOCKING
 - during the next garbage collection, the GC would try to suspend this thread as it is still in RUNNING state, but because it's neither executing runtime code, neither managed code, it will never hit a safepoint, leading to a timeouting suspend.

To fix that issue, we need to support the following state switches:
 - STARTING -> RUNNING -> BLOCKING: happens when it's the first time this thread calls a native-to-managed wrapper
 - BLOCKING -> RUNNING -> BLOCKING: happens when it's not the first time this thread is called from a facility like dispatch_async, or if it is, for example, called as a callback from an external library
 - RUNNING -> RUNNING -> RUNNING: if we call this wrapper from runtime or managed code, see for example System.Reflection.Emit.ILGeneratorTest.TestEmitCalliWithNullReturnType

This facility also need to take care of the current domain, to ensure that we switch properly between domains, and set it to the one that was used when creating this delegate, then restoring the original one.