### PR TITLE
[4.2.0][reflection] Fix #38220 - explicit interface implementation using a generic type instance

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/MonoGenericClassTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MonoGenericClassTest.cs
@@ -204,6 +204,88 @@ namespace MonoTests.System.Reflection.Emit
 			Assert.AreSame (expected, t.BaseType, "#1");
 			
 		}
+
+		[Test]
+		public void GenericClassFromStaleTypeBuilderDoesNotClassInit ()
+		{
+			// interface JJJ<T> {
+			//   abstract void W (x : T)
+			// }
+			MethodInfo winfo = null;
+			TypeBuilder ib = null;
+			Type ic = null;
+			Type icreated = null;
+			{
+				ib = module.DefineType ("Foo.JJJ`1",
+							 TypeAttributes.Public
+							 | TypeAttributes.Interface
+							 | TypeAttributes.Abstract);
+				String[] gens = { "T" };
+				GenericTypeParameterBuilder[] gbs = ib.DefineGenericParameters (gens);
+				var gb = gbs[0];
+				winfo = ib.DefineMethod ("W",
+							 MethodAttributes.Public |
+							 MethodAttributes.Abstract |
+							 MethodAttributes.Virtual,
+							 CallingConventions.HasThis,
+							 typeof(void),
+					 new Type[] { gb });
+				icreated = ib.CreateType();
+
+			}
+
+			// class SSS : JJJ<char> {
+			//   bool wasCalled;
+			//   void JJJ.W (x : T) { wasCalled = true; return; }
+		        // }
+			TypeBuilder tb = null;
+			MethodBuilder mb = null;
+			{
+				tb = module.DefineType ("Foo.SSS",
+							TypeAttributes.Public,
+							null,
+							new Type[]{ icreated.MakeGenericType(typeof(char)) });
+				var wasCalledField = tb.DefineField ("wasCalled",
+								     typeof(bool),
+								     FieldAttributes.Public);
+				mb = tb.DefineMethod ("W_impl",
+						      MethodAttributes.Public | MethodAttributes.Virtual,
+						      CallingConventions.HasThis,
+						      typeof (void),
+						      new Type[] { typeof (char) });
+				{
+					var il = mb.GetILGenerator ();
+					il.Emit (OpCodes.Ldarg_0); // this
+					il.Emit (OpCodes.Ldc_I4_1);
+					il.Emit (OpCodes.Stfld, wasCalledField); // this.wasCalled = true
+					il.Emit (OpCodes.Ret);
+				}
+			}
+
+			ic = ib.MakeGenericType(typeof (char)); // this is a MonoGenericMethod
+			var mintf = TypeBuilder.GetMethod(ic, winfo);
+			// the next line causes mono_class_init() to
+			// be called on JJJ<char> when we try to setup
+			// the vtable for SSS
+			tb.DefineMethodOverride(mb, mintf);
+
+			var result = tb.CreateType();
+
+			// o = new SSS()
+			object o = Activator.CreateInstance(result);
+			Assert.IsNotNull(o, "#1");
+
+			// ((JJJ<char>)o).W('a');
+			var m = icreated.MakeGenericType(typeof(char)).GetMethod("W", BindingFlags.Public | BindingFlags.Instance);
+			Assert.IsNotNull(m, "#2");
+			m.Invoke(o, new object[] {'a'});
+
+			var f = result.GetField("wasCalled", BindingFlags.Public | BindingFlags.Instance);
+			Assert.IsNotNull(f, "#3");
+			var wasCalledVal = f.GetValue(o);
+			Assert.IsInstanceOfType (typeof(Boolean), wasCalledVal, "#4");
+			Assert.AreEqual (wasCalledVal, true, "#5");
+		}
 	}
 }
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5241,7 +5241,7 @@ mono_class_init (MonoClass *class)
 		if (!MONO_CLASS_IS_INTERFACE (class) || class->image != mono_defaults.corlib) {
 			MonoMethod *cmethod = NULL;
 
-			if (class->type_token) {
+			if (class->type_token && !image_is_dynamic(class->image)) {
 				cmethod = find_method_in_metadata (class, ".cctor", 0, METHOD_ATTRIBUTE_SPECIAL_NAME);
 				/* The find_method function ignores the 'flags' argument */
 				if (cmethod && (cmethod->flags & METHOD_ATTRIBUTE_SPECIAL_NAME))


### PR DESCRIPTION
Backports the fix for [#35375](https://bugzilla.xamarin.com/show_bug.cgi?id=35375) to 4.2.0 to fix [#38220](https://bugzilla.xamarin.com/show_bug.cgi?id=35375).