### PR TITLE
[msbuild] Registered the XmlPeek Build Task in the Microsoft.Common.tasks

### DIFF
--- a/mcs/tools/xbuild/data/12.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/12.0/Microsoft.Common.tasks
@@ -36,4 +36,5 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.Warning"		AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.WriteCodeFragment"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile"	AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.XmlPeek"		AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 </Project>

--- a/mcs/tools/xbuild/data/14.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/14.0/Microsoft.Common.tasks
@@ -35,4 +35,5 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.Warning"		AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.WriteCodeFragment"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.XmlPeek"		AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 </Project>

--- a/mcs/tools/xbuild/data/4.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/4.0/Microsoft.Common.tasks
@@ -36,4 +36,5 @@
 	<UsingTask TaskName="Microsoft.Build.Tasks.Warning"		AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.WriteCodeFragment"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
 	<UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile"	AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.XmlPeek"		AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 </Project>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=36183
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=38638

The previous commit () was incomplete, while it added the source
file for XmlPeek it did not register them in the appropriate
MSBuild tasks files. As a result the XmlPeek task cannot be used.