### PR TITLE
[4.3.2][reflection] Set pending loader exception in mono_reflection_get_custom_attrs_data

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -398,7 +398,7 @@ ICALL(MATH_17, "Tan", ves_icall_System_Math_Tan)
 ICALL(MATH_18, "Tanh", ves_icall_System_Math_Tanh)
 
 ICALL_TYPE(MCATTR, "System.MonoCustomAttrs", MCATTR_1)
-ICALL(MCATTR_1, "GetCustomAttributesDataInternal", mono_reflection_get_custom_attrs_data)
+ICALL(MCATTR_1, "GetCustomAttributesDataInternal", ves_icall_MonoCustomAttrs_GetCustomAttributesDataInternal)
 ICALL(MCATTR_2, "GetCustomAttributesInternal", custom_attrs_get_by_type)
 ICALL(MCATTR_3, "IsDefinedInternal", custom_attrs_defined_internal)
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7157,6 +7157,17 @@ custom_attrs_get_by_type (MonoObject *obj, MonoReflectionType *attr_type)
 	}
 }
 
+ICALL_EXPORT MonoArray*
+ves_icall_MonoCustomAttrs_GetCustomAttributesDataInternal (MonoObject *obj)
+{
+	MonoError error;
+	MonoArray *result;
+	result = mono_reflection_get_custom_attrs_data_checked (obj, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
+}
+
+
 ICALL_EXPORT MonoString*
 ves_icall_Mono_Runtime_GetDisplayName (void)
 {

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -11,6 +11,9 @@
 MonoObject*
 mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass, MonoError *error);
 
+MonoArray*
+mono_reflection_get_custom_attrs_data_checked (MonoObject *obj, MonoError *error);
+
 char*
 mono_identifier_unescape_type_name_chars (char* identifier);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -9518,8 +9518,29 @@ mono_reflection_get_custom_attrs (MonoObject *obj)
 MonoArray*
 mono_reflection_get_custom_attrs_data (MonoObject *obj)
 {
+	MonoError error;
+	MonoArray* result;
+	result = mono_reflection_get_custom_attrs_data_checked (obj, &error);
+	mono_error_cleanup (&error); /* FIXME new API that doesn't swallow the error */
+	return result;
+}
+
+/*
+ * mono_reflection_get_custom_attrs_data_checked:
+ * @obj: a reflection obj handle
+ * @error: set on error
+ *
+ * Returns an array of System.Reflection.CustomAttributeData,
+ * which include information about attributes reflected on
+ * types loaded using the Reflection Only methods
+ */
+MonoArray*
+mono_reflection_get_custom_attrs_data_checked (MonoObject *obj, MonoError *error)
+{
 	MonoArray *result;
 	MonoCustomAttrInfo *cinfo;
+
+	mono_error_init (error);
 
 	cinfo = mono_reflection_get_custom_attrs_info (obj);
 	if (cinfo) {
@@ -9528,6 +9549,9 @@ mono_reflection_get_custom_attrs_data (MonoObject *obj)
 			mono_custom_attrs_free (cinfo);
 	} else
 		result = mono_array_new (mono_domain_get (), mono_defaults.customattribute_data_class, 0);
+
+	if (mono_loader_get_last_error ())
+		mono_error_set_from_loader_error (error);
 
 	return result;
 }

--- a/mono/tests/load-exceptions.cs
+++ b/mono/tests/load-exceptions.cs
@@ -339,6 +339,16 @@ public class Tests : LoadMissing {
 		return 2;
 	}
 
+	public static int test_0_reflection_on_field_with_missing_custom_attr () {
+		var t = typeof (BadOverridesDriver).Assembly.GetType ("FieldWithMissingCustomAttribute");
+		try {
+			Console.WriteLine (t.GetFields ()[0].CustomAttributes);
+			return 1;
+		} catch (FileNotFoundException) {
+			return 0;
+		}
+		return 2;
+	}
 
 	public static int Main () {
 		return TestDriver.RunTests (typeof (Tests));

--- a/mono/tests/load-missing.il
+++ b/mono/tests/load-missing.il
@@ -11,6 +11,10 @@
 {
   .ver 0:0:0:0
 }
+.assembly extern notFoundAssembly
+{
+  .ver 0:0:0:0
+}
 
 .assembly 'load-missing'
 {
@@ -724,4 +728,10 @@
 {
 	.field  public class [t]Missing BrokenField
     .field  public static int32 WorkingField
+}
+
+.class public auto ansi beforefieldinit FieldWithMissingCustomAttribute
+{
+    .field	public object f
+    .custom	instance void class [notFoundAssembly]SomeAttribute::'.ctor'() = (01 00 00 00 ) // ....
 }


### PR DESCRIPTION
This is a backport of #2585 to the `mono-4.3.2-branch`

Fixes [Bugzilla 38222](https://bugzilla.xamarin.com/show_bug.cgi?id=38222)

While we're at it, convert mono_reflection_get_custom_attrs_data to use
MonoError, runtime should use mono_reflection_get_custom_attrs_data_checked