### PR TITLE
[corlib] Ensure PCL compatibility with Mono.DataConverter

### DIFF
--- a/mcs/class/corlib/Mono/DataConverter.cs
+++ b/mcs/class/corlib/Mono/DataConverter.cs
@@ -683,7 +683,11 @@ namespace Mono {
 						n = 2;
 						break;
 					case '7':
+#if PCL
+						e = Encoding.GetEncoding ("utf-7");
+#else
 						e = Encoding.UTF7;
+#endif
 						n = 1;
 						break;
 					case 'b':
@@ -691,11 +695,19 @@ namespace Mono {
 						n = 2;
 						break;
 					case '3':
+#if PCL
+						e = Encoding.GetEncoding ("utf-32");
+#else
 						e = Encoding.GetEncoding (12000);
+#endif
 						n = 4;
 						break;
 					case '4':
+#if PCL
+						e = Encoding.GetEncoding ("utf-32BE");
+#else
 						e = Encoding.GetEncoding (12001);
+#endif
 						n = 4;
 						break;
 					


### PR DESCRIPTION
This is simple the same logic as here:

https://github.com/mono/mono/blob/master/mcs/class/corlib/Mono/DataConverter.cs#L466-L490