### PR TITLE
[io] Release Pipe and Console shared handles

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
@@ -1660,6 +1660,25 @@ namespace MonoTests.System.IO
 			
 		}
 
+		[Test]
+		public void OpenCharDeviceRepeatedly ()
+		{
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=38408
+			try {
+				using (var f = new FileStream ("/dev/zero", FileMode.Open))
+				{
+				}
+			} catch (FileNotFoundException) {
+				// Only run this test on platforms where /dev/zero exists
+				Assert.Ignore();
+			}
+
+			// this shouldn't throw
+			using (var g = new FileStream ("/dev/zero", FileMode.Open))
+			{
+			}
+		}
+
 #if !MOBILE
 		[Test]
 		public void WriteWithExposedHandle ()

--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -1636,6 +1636,10 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 #endif
 	if (S_ISFIFO (statbuf.st_mode)) {
 		handle_type = WAPI_HANDLE_PIPE;
+		/* maintain invariant that pipes have no filename */
+		file_handle.filename = NULL;
+		g_free (filename);
+		filename = NULL;
 	} else if (S_ISCHR (statbuf.st_mode)) {
 		handle_type = WAPI_HANDLE_CONSOLE;
 	} else {

--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -1037,8 +1037,11 @@ static void console_close (gpointer handle, gpointer data)
 
 	g_free (console_handle->filename);
 
-	if (fd > 2)
+	if (fd > 2) {
+		if (console_handle->share_info)
+			_wapi_handle_share_release (console_handle->share_info);
 		close (fd);
+	}
 }
 
 static WapiFileType console_getfiletype(void)
@@ -1158,6 +1161,9 @@ static void pipe_close (gpointer handle, gpointer data)
 	MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: closing pipe handle %p", __func__, handle);
 
 	/* No filename with pipe handles */
+
+	if (pipe_handle->share_info)
+		_wapi_handle_share_release (pipe_handle->share_info);
 
 	close (fd);
 }


### PR DESCRIPTION
Fixes [Bugzilla #38408](https://bugzilla.xamarin.com/show_bug.cgi?id=38408)

Allows opening a character device or named fifo more than once with code like:

```csharp
    using (var f = new FileStream ("/dev/zero", FileMode.Open))
    {
       ...
    }
    using (var f = new FileStream ("/dev/zero", FileMode.Open))
    {
       ...
    }
```