### PR TITLE
Do not run 4GB string tests on low memory systems (fixes #38392)

### DIFF
--- a/mcs/class/corlib/Makefile
+++ b/mcs/class/corlib/Makefile
@@ -67,7 +67,7 @@ CORLIB_MONO_POSIX_REF = -r:Mono.Posix.dll
 endif
 
 # System.IO/DirectoryInfoTest.cs needs Mono.Posix
-TEST_MCS_FLAGS += -debug -nowarn:168,219,618,672 -unsafe $(CORLIB_MONO_POSIX_REF) -r:System.Core.dll \
+TEST_MCS_FLAGS += -debug -nowarn:168,219,618,672 -unsafe $(CORLIB_MONO_POSIX_REF) -r:System.Core.dll -r:System.dll \
 				 -define:MONO_DATACONVERTER_STATIC_METHODS $(TEST_RESX_RESOURCES:%=-resource:%)
 
 EXTRA_DISTFILES = \

--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -16,6 +16,10 @@ using System.Globalization;
 using System.Reflection;
 using System.Threading;
 
+#if !MOBILE
+using System.Diagnostics;
+#endif
+
 using NUnit.Framework;
 
 namespace MonoTests.System
@@ -92,19 +96,36 @@ public class StringTest
 		}
 	}
 
+	// Several tests in this file, to run properly, allocate 4GB objects.
+	// Obviously this creates problems on several kinds of systems, so we
+	// conservatively skip these tests unless we find a high-RAM environment.
+	// Checking RAM requires PerformanceCounter which is absent on mobile,
+	// so any test that calls this must be category MobileNotWorking.
+	static bool LowMemoryTestEnvironment ()
+	{
+#if MOBILE
+		return true;
+#else
+		if (!Environment.Is64BitProcess)
+			return true;
+
+		// Require 6 GB physical RAM, for the 4GB string plus 2GB headroom 
+		var pc = new PerformanceCounter ("Mono Memory", "Total Physical Memory");
+
+		return pc.RawValue < 6L*1024L*1024L*1024L;
+#endif
+	}
+
 	[Test] // ctor (Char, Int32)
+	[Category ("MobileNotWorking")]
 	public void Constructor4_LargeString ()
 	{
-		try {
-			var x = new String ('A', int.MaxValue);
-			if (Environment.Is64BitProcess) {
-				Assert.AreEqual ('A', x[0]);
-				Assert.AreEqual ('A', x[int.MaxValue - 1]);
-			}
-			else
-				Assert.Fail ("Expected OutOfMemoryException.");
-		} catch (OutOfMemoryException) {
-		}
+		if (LowMemoryTestEnvironment())
+			return;
+
+		var x = new String ('A', int.MaxValue);
+		Assert.AreEqual ('A', x[0]);
+		Assert.AreEqual ('A', x[int.MaxValue - 1]);
 	}
 
 	[Test] // ctor (Char [], Int32, Int32)
@@ -3008,18 +3029,15 @@ public class StringTest
 	}
 
 	[Test]
+	[Category ("MobileNotWorking")]
 	public void PadLeft_LargeString ()
 	{
-		try {
-			var x = "x".PadLeft (int.MaxValue, '-');
-			if (Environment.Is64BitProcess) {
-				Assert.AreEqual ('-', x[0]);
-				Assert.AreEqual ('x', x[int.MaxValue - 1]);
-			}
-			else
-				Assert.Fail ("Expected OutOfMemoryException.");
-		} catch (OutOfMemoryException) {
-		}
+		if (LowMemoryTestEnvironment())
+			return;
+
+		var x = "x".PadLeft (int.MaxValue, '-');
+		Assert.AreEqual ('-', x[0]);
+		Assert.AreEqual ('x', x[int.MaxValue - 1]);
 	}
 
 	[Test] // PadRight (Int32)
@@ -3064,18 +3082,15 @@ public class StringTest
 	}
 
 	[Test]
+	[Category ("MobileNotWorking")]
 	public void PadRight_LargeString ()
 	{
-		try {
-			var x = "x".PadRight (int.MaxValue, '-');
-			if (Environment.Is64BitProcess) {
-				Assert.AreEqual ('x', x[0]);
-				Assert.AreEqual ('-', x[int.MaxValue - 1]);
-			}
-			else
-				Assert.Fail ("Expected OutOfMemoryException.");
-		} catch (OutOfMemoryException) {
-		}
+		if (LowMemoryTestEnvironment())
+			return;
+
+		var x = "x".PadRight (int.MaxValue, '-');
+		Assert.AreEqual ('x', x[0]);
+		Assert.AreEqual ('-', x[int.MaxValue - 1]);
 	}
 
 	[Test] // Remove (Int32, Int32)

--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -101,18 +101,19 @@ public class StringTest
 	// conservatively skip these tests unless we find a high-RAM environment.
 	// Checking RAM requires PerformanceCounter which is absent on mobile,
 	// so any test that calls this must be category MobileNotWorking.
-	static bool LowMemoryTestEnvironment ()
+	static void RequireHighMemoryTestEnvironment ()
 	{
 #if MOBILE
-		return true;
+		Assert.Ignore("PerformanceCounter not available.")
 #else
 		if (!Environment.Is64BitProcess)
-			return true;
+			Assert.Ignore("This test cannot run on a 32-bit system.");
 
-		// Require 6 GB physical RAM, for the 4GB string plus 2GB headroom 
+		// Require 6 GB physical RAM, for the 4GB string plus 2GB headroom
 		var pc = new PerformanceCounter ("Mono Memory", "Total Physical Memory");
 
-		return pc.RawValue < 6L*1024L*1024L*1024L;
+		if (pc.RawValue < 6L*1024L*1024L*1024L)
+			Assert.Ignore("This machine may not have enough RAM to run this test.");
 #endif
 	}
 
@@ -120,8 +121,7 @@ public class StringTest
 	[Category ("MobileNotWorking")]
 	public void Constructor4_LargeString ()
 	{
-		if (LowMemoryTestEnvironment())
-			return;
+		RequireHighMemoryTestEnvironment();
 
 		var x = new String ('A', int.MaxValue);
 		Assert.AreEqual ('A', x[0]);
@@ -3032,8 +3032,7 @@ public class StringTest
 	[Category ("MobileNotWorking")]
 	public void PadLeft_LargeString ()
 	{
-		if (LowMemoryTestEnvironment())
-			return;
+		RequireHighMemoryTestEnvironment();
 
 		var x = "x".PadLeft (int.MaxValue, '-');
 		Assert.AreEqual ('-', x[0]);
@@ -3085,8 +3084,7 @@ public class StringTest
 	[Category ("MobileNotWorking")]
 	public void PadRight_LargeString ()
 	{
-		if (LowMemoryTestEnvironment())
-			return;
+		RequireHighMemoryTestEnvironment();
 
 		var x = "x".PadRight (int.MaxValue, '-');
 		Assert.AreEqual ('x', x[0]);


### PR DESCRIPTION
"Low memory" here is defined as 32-bit, less than 6GB of physical RAM, or mobile (since mobile lacks the class for querying physical RAM).

Without this patch, one of the corlib tests allocates 4 GB of RAM, which causes OOM crashes on low-memory Jenkins instances and also mobile phones.