### PR TITLE
Don't remap all versions of Npgsql to 4.0.0.0

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -105,7 +105,6 @@ static const AssemblyVersionMap framework_assemblies [] = {
 	{"Mono.Security.Win32", 0},
 	{"Mono.Xml.Ext", 0},
 	{"Novell.Directory.Ldap", 0},
-	{"Npgsql", 0},
 	{"PEAPI", 0},
 	{"System", 0},
 	{"System.ComponentModel.Composition", 2},


### PR DESCRIPTION
Mono has a list of assemblies considered "internal", whose versions are automatically remapped to the distro default version.

Since we no longer bundle Npgsql, it is up to individual distributions to package their own Npgsql - but Mono cannot load any version other than 4.0.0.0 from the GAC, due to this remapping:

`Mono: The request to load the assembly Npgsql v2.2.7.0 was remapped to v4.0.0.0`

`Mono: Assembly Loader probing location: '/usr/lib/mono/gac/Npgsql/4.0.0.0__5d8b90d52f46fda7/Npgsql.dll'.`

Npgsql, Version=2.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7