### PR TITLE
[corlib] Fix FileInfo.MoveTo with same name.

### DIFF
--- a/mcs/class/corlib/System.IO/FileInfo.cs
+++ b/mcs/class/corlib/System.IO/FileInfo.cs
@@ -230,13 +230,17 @@ namespace System.IO {
 		{
 			if (destFileName == null)
 				throw new ArgumentNullException ("destFileName");
-			if (destFileName == Name || destFileName == FullName)
+			if (destFileName.Length == 0)
+				throw new ArgumentException ("An empty file name is not valid.", "destFileName");
+
+			var destFullPath = Path.GetFullPath (destFileName);
+			if (destFullPath == FullPath)
 				return;
 			if (!File.Exists (FullPath))
 				throw new FileNotFoundException ();
 
-			File.Move (FullPath, destFileName);
-			this.FullPath = Path.GetFullPath (destFileName);
+			File.Move (FullPath, destFullPath);
+			this.FullPath = destFullPath;
 		}
 
 		public FileInfo CopyTo (string destFileName)

--- a/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
@@ -651,6 +651,33 @@ namespace MonoTests.System.IO
 			}
 		}
 
+		[Test] //Covers #18361
+		public void MoveTo_SameName ()
+		{
+			string name = "FIT.MoveTo.SameName.Test";
+			string path1 = TempFolder + DSC + name;
+			string path2 = name;
+			DeleteFile (path1);
+			DeleteFile (path2);
+			
+			try {
+				File.Create (path1).Close ();
+				FileInfo info1 = new FileInfo (path1);
+				FileInfo info2 = new FileInfo (path2);
+				Assert.IsTrue (info1.Exists, "#A1");
+				Assert.IsFalse (info2.Exists, "#A2");
+
+				info1.MoveTo (path2);
+				info1 = new FileInfo (path1);
+				info2 = new FileInfo (path2);
+				Assert.IsFalse (info1.Exists, "#B1");
+				Assert.IsTrue (info2.Exists, "#B2");
+			} finally {
+				DeleteFile (path1);
+				DeleteFile (path2);
+			}
+		}
+
 		[Test]
 		public void MoveTo_DestFileName_AlreadyExists ()
 		{


### PR DESCRIPTION
FileInfo.MoveTo was not moving a file from one directory to another when
the file name did not change.

Fixes [#18361](https://bugzilla.xamarin.com/show_bug.cgi?id=18361).

An ArgumentException when destFileName is an empty array was added,
otherwise FileInfoTest.MoveTo_DestFileName_Empty would fail. Both
Path.GetFullPath and File.Move throw similar exceptions but
MoveTo_DestFileName_Empty expects the one from File.Move so it was added
to this method.