### PR TITLE
Fix memory leak in mono_aot_plt_resolve when exiting with exception

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4638,13 +4638,17 @@ mono_aot_plt_resolve (gpointer aot_module, guint32 plt_info_offset, guint8 *code
 	if (mono_aot_only && ji.type == MONO_PATCH_INFO_METHOD && !ji.data.method->is_generic && !mono_method_check_context_used (ji.data.method) && !(ji.data.method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) &&
 		!mono_method_needs_static_rgctx_invoke (ji.data.method, FALSE) && !using_gsharedvt) {
 		target = (guint8 *)mono_jit_compile_method (ji.data.method, error);
-		if (!mono_error_ok (error))
+		if (!mono_error_ok (error)) {
+			mono_mempool_destroy (mp);
 			return NULL;
+		}
 		no_ftnptr = TRUE;
 	} else {
 		target = (guint8 *)mono_resolve_patch_target_checked (NULL, mono_domain_get (), NULL, &ji, TRUE, error);
-		if (!mono_error_ok (error))
+		if (!mono_error_ok (error)) {
+			mono_mempool_destroy (mp);
 			return NULL;
+		}
 	}
 
 	/*


### PR DESCRIPTION
We were not cleaning up our allocated memory on all code paths.