### PR TITLE
[System.TimeZoneInfo] Fix finding system time zone when /etc/localtim…

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -120,8 +120,12 @@ namespace System
 		{
 			name = null;
 			var linkPath = readlink (path);
-			if (linkPath != null)
-				path = linkPath;
+			if (linkPath != null) {
+				if (Path.IsPathRooted(linkPath))
+					path = linkPath;
+				else
+					path = Path.Combine(Path.GetDirectoryName(path), linkPath);
+			}
 
 			path = Path.GetFullPath (path);
 


### PR DESCRIPTION
[System.TimeZoneInfo] Fix finding system time zone when /etc/localtime has a relative path.

There is already a unit test for that (mcs/class/corlib/Test/System/TimeZoneInfoTest.cs) which was failing on my Fedora 23 (where /etc/localtime has a relative form: /etc/localtime -> ../usr/share/...). TryGetNameFromPath was using symlink path relative to current directory instead of /etc.
