### PR TITLE
[corlib] Fix potential RegisteredWaitHandle resource leak

### DIFF
--- a/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
+++ b/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
@@ -40,7 +40,6 @@ namespace System.Threading
 		: MarshalByRefObject
 	{
 		WaitHandle _waitObject;
-		bool _releaseWaitObject;
 		WaitOrTimerCallback _callback;
 		object _state;
 		WaitHandle _finalEvent;
@@ -53,7 +52,6 @@ namespace System.Threading
 		internal RegisteredWaitHandle (WaitHandle waitObject, WaitOrTimerCallback callback, object state, TimeSpan timeout, bool executeOnlyOnce)
 		{
 			_waitObject = waitObject;
-			_waitObject.SafeWaitHandle.DangerousAddRef (ref _releaseWaitObject);
 			_callback = callback;
 			_state = state;
 			_timeout = timeout;
@@ -121,9 +119,6 @@ namespace System.Threading
 			{
 				if (_unregistered)
 					return false;
-
-				if (_releaseWaitObject)
-					_waitObject.SafeWaitHandle.DangerousRelease ();
 
 				_finalEvent = waitObject;
 				_unregistered = true;


### PR DESCRIPTION
If we construct RegisteredWaitHandle with executeOnlyOnce = true, and never call Unregister, we will keep _waitObject.SafeWaitHandle reference count unbalanced. This will lead to never releasing the waitObject handle.

As we only need to ensure that the waitObject handle is alive while in the Wait method, we use the SafeHandle mechanism only there. The 2 possibles scenarios in the Wait method are:
 - waitObject has not been closed: we increment its ref count, so we ensure that it's alive as long as we use it here
 - waitObject has been closed: a ObjectDisposedException is thrown, we catch it and keep on without trying to wait on the handle