### PR TITLE
Fix mobile/AOT build following System.Diagnostics.Process import

### DIFF
--- a/mcs/class/System/mobile_System.dll.sources
+++ b/mcs/class/System/mobile_System.dll.sources
@@ -371,6 +371,7 @@ Mono.Net.Security/NoReflectionHelper.cs
 Mono.Net.Security/SystemCertificateValidator.cs
 
 ReferenceSources/AssertWrapper.cs
+ReferenceSources/EnvironmentHelpers.cs
 ReferenceSources/Internal.cs
 ReferenceSources/HttpSysSettings.cs
 ReferenceSources/Logging.cs
@@ -789,6 +790,11 @@ ReferenceSources/Win32Exception.cs
 ../../../external/referencesource/System/compmod/system/diagnostics/TextWriterTraceListener.cs
 
 ../../../external/referencesource/System/services/monitoring/system/diagnosticts/AsyncStreamReader.cs
+../../../external/referencesource/System/services/monitoring/system/diagnosticts/Process.cs
+../../../external/referencesource/System/services/monitoring/system/diagnosticts/ProcessStartInfo.cs
+../../../external/referencesource/System/services/monitoring/system/diagnosticts/processwaithandle.cs
+
+../../../external/referencesource/System/compmod/microsoft/win32/safehandles/SafeProcessHandle.cs
 
 ../Mono.Security/Mono.Security.Authenticode/PrivateKey.cs
 ../Mono.Security/Mono.Security.Cryptography/MD5SHA1.cs


### PR DESCRIPTION
System.Diagnostics.Process was recently added to Mono. This introduced two problems for mobile builds:

- Support classes were not added to the mobile profile .sources.
- The imported referencesource code did not build on fullaot.

This PR fixes both issues.