### PR TITLE
Fix delegation of FP values in epilogue method instrumentation on x86.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,4 +162,8 @@ update-llvm-version:
 	if test "x$$LLVM_DIR" = "x"; then echo "Set the make variable LLVM_DIR to the directory containing the LLVM installation."; exit 1; fi
 	REV=`$(LLVM_DIR)/bin/llvm-config --version` && sed -e "s,expected_llvm_version=.*,expected_llvm_version=\"$$REV\"," < configure.ac > tmp && mv tmp configure.ac && echo "Version set to $$REV."
 
+tags:
+	etags -o TAGS `find .. -name "*.h" -o -name "*.c"`
 
+dsymutil:
+	for f in $(bindir)/* ; do file -b $$f | grep -q Mach-O || continue ; $(DSYMUTIL) $$f ; done

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -1786,12 +1786,13 @@ mono_arch_instrument_epilog_full (MonoCompile *cfg, void *func, void *p, gboolea
 		break;
 	case SAVE_FP:
 		x86_alu_reg_imm (code, X86_SUB, X86_ESP, 8);
-		x86_fst_membase (code, X86_ESP, 0, TRUE, TRUE);
 		if (enable_arguments) {
-			x86_alu_reg_imm (code, X86_SUB, X86_ESP, 8);
+			x86_fld_reg (code, 0);
 			x86_fst_membase (code, X86_ESP, 0, TRUE, TRUE);
+			x86_alu_reg_imm (code, X86_SUB, X86_ESP, 8);
 			arg_size = 8;
 		}
+		x86_fst_membase (code, X86_ESP, 0, TRUE, TRUE);
 		break;
 	case SAVE_STRUCT:
 		if (enable_arguments) {


### PR DESCRIPTION
The problem with the existing code is that it issues two FST instructions which store two _different_ FP registers (one of which is irrelevant and possibly invalid) into memory due to the fact that TOP changes its value after the first store.
The fixed implementation duplicates ST(0) before issuing two FSTs, hence storing two correct values side by side (one for restoring later, another as an argument for the function that we're calling).