### PR TITLE
[System.Drawing.Printing] CUPS default PageSize and InputSlot should …

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.Printing/PrintingServicesUnix.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Printing/PrintingServicesUnix.cs
@@ -299,6 +299,9 @@ namespace System.Drawing.Printing
 			CUPS_OPTIONS cups_options;
 			string option_name, option_value;
 			int cups_size = Marshal.SizeOf(typeof(CUPS_OPTIONS));
+
+			LoadOptionList (ppd, "PageSize", paper_names, out defsize);
+			LoadOptionList (ppd, "InputSlot", paper_sources, out defsource);
 			
 			for (int j = 0; j < numOptions; j++)
 			{
@@ -306,6 +309,8 @@ namespace System.Drawing.Printing
 				option_name = Marshal.PtrToStringAnsi(cups_options.name);
 				option_value = Marshal.PtrToStringAnsi(cups_options.val);
 
+				if (option_name == "PageSize") defsize = option_value;
+				else if (option_name == "InputSlot") defsource = option_value;
 				#if PrintDebug
 				Console.WriteLine("{0} = {1}", option_name, option_value);
 				#endif
@@ -314,9 +319,6 @@ namespace System.Drawing.Printing
 
 				options = (IntPtr) ((long)options + cups_size);
 			}
-			
-			LoadOptionList (ppd, "PageSize", paper_names, out defsize);
-			LoadOptionList (ppd, "InputSlot", paper_sources, out defsource);
 		}
 		
 		/// <summary>

--- a/mcs/class/System.Drawing/Test/System.Drawing.Printing/PrintingServicesUnixTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Printing/PrintingServicesUnixTest.cs
@@ -99,7 +99,6 @@ namespace MonoTests.System.Drawing.Printing {
 				optionPtr = (IntPtr)((long)optionPtr + cupsOptionSize);
 			}
 			cupsFreeDests (1, destPtr);
-
 			return options;
 		}
 
@@ -115,8 +114,9 @@ namespace MonoTests.System.Drawing.Printing {
 			var settings = new PrinterSettings () { PrinterName = PrinterSettings.InstalledPrinters [0] };
 			Assert.AreEqual (options ["PageSize"], settings.DefaultPageSettings.PaperSize.PaperName,
 				"Bug #602934 (https://bugzilla.novell.com/show_bug.cgi?id=602934) not fixed (PaperSize)");
-			Assert.AreEqual (options ["Resolution"], string.Format ("{0}dpi", settings.DefaultPageSettings.PrinterResolution.X),
-				"Bug #602934 (https://bugzilla.novell.com/show_bug.cgi?id=602934) not fixed (Resolution)");
+			if (options.ContainsKey("Resolution"))
+				Assert.AreEqual (options ["Resolution"], string.Format ("{0}dpi", settings.DefaultPageSettings.PrinterResolution.X),
+					"Bug #602934 (https://bugzilla.novell.com/show_bug.cgi?id=602934) not fixed (Resolution)");
 		}
 
 		#endregion


### PR DESCRIPTION
[System.Drawing.Printing] CUPS default PageSize and InputSlot should override PPD defaults.

There is already a test case for that (PrintingServicesUnixTest.cs, Bug602934_PrinterSettingsReturnActualValues) which fails when user configured options are different from PPD settings. Patch also makes this test not to fail if "Resolution" option is not present in CUPS options.