### PR TITLE
[jit] Relax assembly checking for 64 bit targets to allow running mix…

### DIFF
--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -25,6 +25,132 @@
 		ret
 	}
 
+	.method hidebysig static int32 comp_ptr_i8(void* arg, int64 v) cil managed
+	{
+		.maxstack 2
+
+		ldarg.0
+		ldarg.1
+		ceq
+		ret
+	}
+
+	.method hidebysig static int64 add_ptr_i4(void* arg) cil managed
+	{
+		.maxstack 2
+
+		ldarg.0
+		ldc.i4.2
+		add
+		ret
+	}
+
+	.method hidebysig static int64 add_ptr_i8(void* arg, int64 v) cil managed
+	{
+		.maxstack 2
+
+		ldarg.0
+		ldarg.1
+		add
+		ret
+	}
+
+	.method hidebysig static int64 and_ptr_i8(void* arg, int64 v) cil managed
+	{
+		.maxstack 2
+
+		ldarg.0
+		ldarg.1
+		and
+		ret
+	}
+
+	.method hidebysig static int32 i8_ptr_arithm_x64() cil managed
+	{
+		.maxstack 3
+
+		ldc.i4.1
+		ldc.i8 0x1111222233334444
+		call int64 class Tests::add_ptr_i4(void*)
+		ldc.i8 0x1111222233334446
+		bne.un FAIL1
+		pop
+
+		ldc.i4.2
+		ldc.i8 0x1111222233334444
+		ldc.i8 0x2
+		call int64 class Tests::add_ptr_i8(void*,int64)
+		ldc.i8 0x1111222233334446
+		bne.un FAIL1
+		pop
+
+		ldc.i4.3
+		ldc.i8 0x1111222233334444
+		ldc.i4 0x2
+		call int64 class Tests::add_ptr_i8(void*,int64)
+		ldc.i8 0x1111222233334446
+		bne.un FAIL1
+		pop
+
+		ldc.i4.4
+		ldc.i8 0x1111222233334444
+		ldc.i8 0x0000FFFF00000000
+		call int64 class Tests::and_ptr_i8(void*,int64)
+		ldc.i8 0x0000222200000000
+		bne.un FAIL1
+		pop
+
+		ldc.i4.5
+		ldc.i8 0x1111222233334444
+		ldc.i4 0xFFFF0000
+		call int64 class Tests::and_ptr_i8(void*,int64)
+		ldc.i8 0x1111222233330000
+		bne.un FAIL1
+		pop
+
+		ldc.i4.6
+		ldc.i8 0x1111222233334444
+		ldc.i4 0xFFFF0000
+		and
+		ldc.i8 0x1111222233330000
+		bne.un FAIL1
+		pop
+
+		ldc.i4.7
+		ldc.i8 0x1111222233334444
+		ldc.i8 0x1111222233334444
+		call int32 class Tests::comp_ptr_i8(void*,int64)
+		ldc.i4.1
+		bne.un FAIL1
+		pop
+
+		ldc.i4.8
+		ldc.i8 0x1111222233334444
+		ldc.i4 0x1111
+		add
+		ldc.i8 0x1111222233335555
+		bne.un FAIL1
+		pop
+
+		ldc.i4.0
+FAIL1:
+		ret
+	}
+
+	.method static public int32 test_0_i8_ptr_arithm() cil managed {
+		.maxstack 2
+
+		sizeof [mscorlib]System.IntPtr
+		ldc.i4.8
+		bne.un OK1
+		call int32 class Tests::i8_ptr_arithm_x64()
+		ret
+
+OK1:
+		ldc.i4.0
+		ret
+	}
+
 	// make sure the register allocator works when the return value of
 	// 'div' is discarded
 	.method static public int32 test_0_div_regalloc () il managed {


### PR DESCRIPTION
Relax assembly checking for 64 bit targets to allow running mixed-mode MSVC code.

Fixes [#37913](https://bugzilla.xamarin.com/show_bug.cgi?id=37913)
MSVC generated mixed mode IL code is different for x64 and x86. Bug description has standalone app & test case illustrating the issue. 

A test case included in iltests.il in this patch bypasses actual checking function if ptr size is not 8 and should always succeed on 32 bit arch.

The patch is checking for SIZEOF_VOID_P in method_to_ir.c (original patch attached to the bug had apparently wrong check). There was already a comparison (SIZEOF_VOID_P == 8) in the code to allow I8 and PTR comparison operation for 64bit targets, so it looks like my patch just extends this approach to more cases.

I would be grateful for comments on how this patch can be improved.
