### PR TITLE
DISABLE_HW_TRAPS flag to disable signal reliance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3020,6 +3020,7 @@ if test "x$host" != "x$target"; then
 		arch_target=amd64;
 		AC_DEFINE(TARGET_AMD64, 1, [...])
 		AC_DEFINE(TARGET_PS4, 1, [...])
+		AC_DEFINE(DISABLE_HW_TRAPS, 1, [...])
 		CPPFLAGS="$CPPFLAGS"
 		# Can't use tls, since it depends on the runtime detection of tls offsets
 		# in mono-compiler.h

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1928,6 +1928,11 @@ mono_main (int argc, char* argv[])
 	}
 #endif
 
+#ifdef DISABLE_HW_TRAPS
+	// Signal handlers not available
+	opt->explicit_null_checks = TRUE;
+#endif
+
 	if (!argv [i]) {
 		mini_usage ();
 		return 1;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -3115,6 +3115,11 @@ void mono_cross_helpers_run (void);
  * Signal handling
  */
 
+#ifdef DISABLE_HW_TRAPS
+ // Signal handlers not available
+#define MONO_ARCH_NEED_DIV_CHECK 1
+#endif
+
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigfpe_signal_handler) ;
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigill_signal_handler) ;
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigsegv_signal_handler);


### PR DESCRIPTION
Single switch for both explicit null checks and explicit illegal-divide checks.