### PR TITLE
WSDualHttpBinding: Additional constructor overloads to match .NET 4.5

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel/WSDualHttpBinding.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/WSDualHttpBinding.cs
@@ -58,7 +58,12 @@ namespace System.ServiceModel
 		{
 		}
 
-		protected WSDualHttpBinding (WSDualHttpSecurityMode securityMode)
+		public WSDualHttpBinding(string configName)
+			: this (WSDualHttpSecurityMode.Message)
+		{
+		}
+
+		public WSDualHttpBinding (WSDualHttpSecurityMode securityMode)
 		{
 			security = new WSDualHttpSecurity (securityMode);
 		}

--- a/mcs/class/WindowsBase/System.Windows.Threading/DispatcherOperation.cs
+++ b/mcs/class/WindowsBase/System.Windows.Threading/DispatcherOperation.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Windows.Threading {
 
@@ -88,6 +89,12 @@ namespace System.Windows.Threading {
 		{
 			status = DispatcherOperationStatus.Aborted;
 			throw new NotImplementedException ();
+		}
+
+		public Task Task {
+			get {
+				throw new NotImplementedException();
+			}
 		}
 
 		public DispatcherOperationStatus Status {


### PR DESCRIPTION
In .NET 4.5 (cfr. the [reference source](http://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/WSDualHttpBinding.cs,7ee145a30f302d4f)), `WSDualHttpBinding` has three different public constructors. Mono only had one.

This PR adds the missing constructors to Mono.

PS: I considered including `WSDualHttpBinding.cs` from the references sources instead of modifying this one; unfortunately, the amount of dependencies that that would require, together with a couple of secondary issues (resource files are missing from the reference source, circular dependencies between `System.ServiceModel` and` System.IdentityModel`) seemed to make the task too large for such a minor fix.