### PR TITLE
[mcs] Accept and ignore command line args supported by csc that we don't

### DIFF
--- a/mcs/mcs/settings.cs
+++ b/mcs/mcs/settings.cs
@@ -1216,6 +1216,8 @@ namespace Mono.CSharp {
 			case "/highentropyva":
 			case "/highentropyva+":
 			case "/highentropyva-":
+			case "/win32manifest":
+			case "/nowin32manifest":
 				return ParseResult.Success;
 
 			default:


### PR DESCRIPTION
support:

	/win32manifest
	/nowin32manifest