### PR TITLE
[scripts] Add deprecation warning to dmcs

### DIFF
--- a/scripts/dmcs.in
+++ b/scripts/dmcs.in
@@ -1,2 +1,3 @@
 #!/bin/sh
+echo "Note: dmcs is deprecated, please use mcs instead!"
 exec @bindir@/mono $MONO_OPTIONS @mono_instdir@/4.5/mcs.exe -sdk:4.0 "$@"


### PR DESCRIPTION
dmcs was deprecated in favor of mcs a while back, yet people are still creating new scripts with it.
Adding a message that shows up on each dmcs invocation should hopefully make this more obvious.