### PR TITLE
[runtime] MonoError cleanup in mono-security.c

### DIFF
--- a/mono/metadata/security.h
+++ b/mono/metadata/security.h
@@ -55,7 +55,7 @@ MonoBoolean ves_icall_System_Security_Policy_Evidence_IsAuthenticodePresent (Mon
 /* System.Security.SecureString */
 extern void ves_icall_System_Security_SecureString_DecryptInternal (MonoArray *data, MonoObject *scope);
 extern void ves_icall_System_Security_SecureString_EncryptInternal (MonoArray *data, MonoObject *scope);
-void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt);
+void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt, MonoError *error);
 
 G_END_DECLS
 


### PR DESCRIPTION
Some easy MonoError cleanup in mono-security.c: use set_pending_exception, don't raise in helper functions, free memory on errors.