### PR TITLE
[4.4.0][Process] Avoid process native handle use-after-dispose in Exited callback

### DIFF
--- a/mono/metadata/process.c
+++ b/mono/metadata/process.c
@@ -57,11 +57,10 @@ ves_icall_System_Diagnostics_Process_GetPid_internal (void)
 	return mono_process_current_pid ();
 }
 
-void ves_icall_System_Diagnostics_Process_Process_free_internal (MonoObject *this_obj,
-								 HANDLE process)
+void ves_icall_System_Diagnostics_Process_Process_free_internal (HANDLE process)
 {
 #ifdef THREAD_DEBUG
-	g_message ("%s: Closing process %p, handle %p", __func__, this_obj, process);
+	g_message ("%s: Closing process handle %p", __func__, process);
 #endif
 
 #if defined(TARGET_WIN32) || defined(HOST_WIN32)

--- a/mono/metadata/process.h
+++ b/mono/metadata/process.h
@@ -60,7 +60,7 @@ G_BEGIN_DECLS
 HANDLE ves_icall_System_Diagnostics_Process_GetProcess_internal (guint32 pid);
 MonoArray *ves_icall_System_Diagnostics_Process_GetProcesses_internal (void);
 guint32 ves_icall_System_Diagnostics_Process_GetPid_internal (void);
-void ves_icall_System_Diagnostics_Process_Process_free_internal (MonoObject *this_obj, HANDLE process);
+void ves_icall_System_Diagnostics_Process_Process_free_internal (HANDLE process);
 MonoArray *ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, HANDLE process);
 void ves_icall_System_Diagnostics_FileVersionInfo_GetVersionInfo_internal (MonoObject *this_obj, MonoString *filename);
 MonoBoolean ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoProcessStartInfo *proc_start_info, MonoProcInfo *process_handle);


### PR DESCRIPTION
There is a race condition between the call to Dispose, and the background thread launched for the Exited event. It can lead to the following SIGABRT:

```
Bad call to pthread_cond_broadcast result 22 for handle 0x4c2
* Assertion at ../../mono/io-layer/handles-private.h:154, condition `thr_ret == 0' not met

Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.Diagnostics.Process.WaitForExit_internal (System.Diagnostics.Process,intptr,int) <IL 0x00015, 0x00074>
  at System.Diagnostics.Process/<StartBackgroundWaitForExit>c__AnonStorey0.<>m__0 (object) [0x00000] in /private/tmp/source-mono-4.3.2/bockbuild-xamarin/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/System/System.Diagnostics/Process.cs:1587
  at System.Threading.ThreadHelper.ThreadStart_Context (object) [0x0002c] in /private/tmp/source-mono-4.3.2/bockbuild-xamarin/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/thread.cs:72
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x0008d] in /private/tmp/source-mono-4.3.2/bockbuild-xamarin/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/executioncontext.cs:957
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00000] in /private/tmp/source-mono-4.3.2/bockbuild-xamarin/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/executioncontext.cs:904
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object) [0x00031] in /private/tmp/source-mono-4.3.2/bockbuild-xamarin/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/executioncontext.cs:893
  at System.Threading.ThreadHelper.ThreadStart (object) [0x00012] in /private/tmp/source-mono-4.3.2/bockbuild-xamarin/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/mscorlib/system/threading/thread.cs:87
  at (wrapper runtime-invoke) <Module>.runtime_invoke_void__this___object (object,intptr,intptr,intptr) <IL 0x00053, 0x000ed>

Native stacktrace:

	   0   mono64                              0x000000010080a2ba mono_handle_native_sigsegv + 282
   	   1   libsystem_platform.dylib            0x00007fff91219f1a _sigtramp + 26
   	   2   mono64                              0x0000000100ae5619 tmp_dir + 3017
   	   3   libsystem_c.dylib                   0x00007fff980669b3 abort + 129
   	   4   mono64                              0x00000001009b2efd monoeg_log_default_handler + 125
   	   5   mono64                              0x00000001009b30c0 monoeg_assertion_message + 192
   	   6   mono64                              0x000000010098e2f9 process_wait + 1769
   	   7   mono64                              0x0000000100996eda wapi_WaitForSingleObjectEx + 186
   	   8   mono64                              0x00000001008eafad ves_icall_System_Diagnostics_Process_WaitForExit_internal + 61
  	   9   ???                                 0x00000001053f7b45 0x0 + 4383013701
	   10  mscorlib.dll.dylib                  0x00000001029410b1 System_Threading_ExecutionContext_Run_System_Threading_ExecutionContext_System_Threading_ContextCallback_object_bool + 33
	   11  mono64                              0x0000000100761520 mono_jit_runtime_invoke + 1776
   	   12  mono64                              0x0000000100920c62 mono_runtime_invoke + 130
   	   13  mono64                              0x00000001008f9ff3 start_wrapper + 659
   	   14  mono64                              0x00000001009aba08 inner_start_thread + 312
   	   15  libsystem_pthread.dylib             0x00007fff8cbc805a _pthread_body + 131
   	   16  libsystem_pthread.dylib             0x00007fff8cbc7fd7 _pthread_body + 0
  	   17  libsystem_pthread.dylib             0x00007fff8cbc53ed thread_start + 13
```

The race happens as follow:
 1. T1 : process.EnabledRaisingEvents = true
 2. T1 : process.Start ()
 3. T1 :  process.StartBackgroundWaitForExit () -> launch T2
 4. T1 : process.Dispose ()
 5. T2 : WaitForExit_internal (process_handle)

At step 4, Dispose called Process_free_internal which destroys the handle, and thus its io-layer signal condition variable. Then at step 5, it tries to wait on that previously destroyed handle's io-layer signal condition variable.

By using a SafeProcessHandle, we guarantee that at all time of use, the handle is still a valid one, and has not been destroyed.