### PR TITLE
[runtime] Use MonoError in mono_runtime_object_init

### DIFF
--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -67,11 +67,13 @@ mono_exception_from_name_domain (MonoDomain *domain, MonoImage *image,
 	klass = mono_class_load_from_name (image, name_space, name);
 
 	o = mono_object_new_checked (domain, klass, &error);
-	g_assert (o != NULL && mono_error_ok (&error)); /* FIXME don't swallow the error */
+	mono_error_assert_ok (&error);
 
 	if (domain != caller_domain)
 		mono_domain_set_internal (domain);
-	mono_runtime_object_init (o);
+	mono_runtime_object_init_checked (o, &error);
+	mono_error_assert_ok (&error);
+
 	if (domain != caller_domain)
 		mono_domain_set_internal (caller_domain);
 
@@ -96,12 +98,13 @@ mono_exception_from_token (MonoImage *image, guint32 token)
 	MonoObject *o;
 
 	klass = mono_class_get_checked (image, token, &error);
-	g_assert (mono_error_ok (&error)); /* FIXME handle the error. */
+	mono_error_assert_ok (&error);
 
 	o = mono_object_new_checked (mono_domain_get (), klass, &error);
-	g_assert (o != NULL && mono_error_ok (&error)); /* FIXME don't swallow the error */
+	mono_error_assert_ok (&error);
 	
-	mono_runtime_object_init (o);
+	mono_runtime_object_init_checked (o, &error);
+	mono_error_assert_ok (&error);
 
 	return (MonoException *)o;
 }

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -614,14 +614,19 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 		is_neutral = ci->territory == 0;
 		if ((neutral && is_neutral) || (specific && !is_neutral)) {
 			culture = (MonoCultureInfo *) mono_object_new_checked (domain, klass, &error);
-			mono_error_raise_exception (&error);
-			mono_runtime_object_init ((MonoObject *) culture);
+			if (!is_ok (&error)) goto fail;
+			mono_runtime_object_init_checked ((MonoObject *) culture, &error);
+			if (!is_ok (&error)) goto fail;
 			construct_culture (culture, ci);
 			culture->use_user_override = TRUE;
 			mono_array_setref (ret, len++, culture);
 		}
 	}
 
+	return ret;
+
+fail:
+	mono_error_set_pending_exception (&error);
 	return ret;
 }
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1684,6 +1684,9 @@ mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *merror
 MonoString *
 mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
 
+gboolean
+mono_runtime_object_init_checked (MonoObject *this_obj, MonoError *error);
+
 MonoObject*
 mono_runtime_try_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -71,15 +71,39 @@ static GENERATE_GET_CLASS_WITH_CACHE (activation_services, System.Runtime.Remoti
 #define ldstr_unlock() mono_os_mutex_unlock (&ldstr_section)
 static mono_mutex_t ldstr_section;
 
+/**
+ * mono_runtime_object_init:
+ * @this_obj: the object to initialize
+ *
+ * This function calls the zero-argument constructor (which must
+ * exist) for the given object.
+ */
 void
 mono_runtime_object_init (MonoObject *this_obj)
 {
+	MonoError error;
+	mono_runtime_object_init_checked (this_obj, &error);
+	mono_error_assert_ok (&error);
+}
+
+/**
+ * mono_runtime_object_init_checked:
+ * @this_obj: the object to initialize
+ * @error: set on error.
+ *
+ * This function calls the zero-argument constructor (which must
+ * exist) for the given object and returns TRUE on success, or FALSE
+ * on error and sets @error.
+ */
+gboolean
+mono_runtime_object_init_checked (MonoObject *this_obj, MonoError *error)
+{
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
 	MonoMethod *method = NULL;
 	MonoClass *klass = this_obj->vtable->klass;
 
+	mono_error_init (error);
 	method = mono_class_get_method_from_name (klass, ".ctor", 0);
 	if (!method)
 		g_error ("Could not lookup zero argument constructor for class %s", mono_type_get_full_name (klass));
@@ -87,8 +111,8 @@ mono_runtime_object_init (MonoObject *this_obj)
 	if (method->klass->valuetype)
 		this_obj = (MonoObject *)mono_object_unbox (this_obj);
 
-	mono_runtime_invoke_checked (method, this_obj, NULL, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_runtime_invoke_checked (method, this_obj, NULL, error);
+	return is_ok (error);
 }
 
 /* The pseudo algorithm for type initialization from the spec

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -209,6 +209,7 @@ mono_monitor_exit            (MonoObject *obj);
 MONO_API void
 mono_raise_exception	    (MonoException *ex);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_runtime_object_init    (MonoObject *this_obj);
 


### PR DESCRIPTION
Mark mono_runtime_object_init checked external only.  Runtime should use mono_runtime_object_init_checked.