### PR TITLE
[runtime] Use MonoError for mono_class_vtable_full and mono_runtime_class_init_full

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1426,7 +1426,7 @@ MonoClassField*
 mono_class_get_field_from_name_full (MonoClass *klass, const char *name, MonoType *type);
 
 MonoVTable*
-mono_class_vtable_full (MonoDomain *domain, MonoClass *klass, gboolean raise_on_error);
+mono_class_vtable_full (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
 gboolean
 mono_class_is_assignable_from_slow (MonoClass *target, MonoClass *candidate);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1628,7 +1628,9 @@ ves_icall_System_ComObject_CreateRCW (MonoReflectionType *type)
 	 * is called by the corresponding real proxy to create the real RCW.
 	 * Constructor does not need to be called. Will be called later.
 	*/
-	obj = mono_object_new_alloc_specific_checked (mono_class_vtable_full (domain, klass, TRUE), &error);
+	MonoVTable *vtable = mono_class_vtable_full (domain, klass, &error);
+	mono_error_raise_exception (&error);
+	obj = mono_object_new_alloc_specific_checked (vtable, &error);
 	mono_error_raise_exception (&error);
 
 	return obj;

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -221,6 +221,7 @@ static void
 do_console_cancel_event (void)
 {
 	static MonoClassField *cancel_handler_field;
+	MonoError error;
 	MonoDomain *domain = mono_domain_get ();
 	MonoClass *klass;
 	MonoDelegate *load_value;
@@ -240,9 +241,11 @@ do_console_cancel_event (void)
 		g_assert (cancel_handler_field);
 	}
 
-	vtable = mono_class_vtable_full (domain, klass, FALSE);
-	if (vtable == NULL)
+	vtable = mono_class_vtable_full (domain, klass, &error);
+	if (vtable == NULL || !is_ok (&error)) {
+		mono_error_cleanup (&error);
 		return;
+	}
 	mono_field_static_get_value (vtable, cancel_handler_field, &load_value);
 	if (load_value == NULL)
 		return;

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1079,14 +1079,18 @@ mono_value_describe_fields (MonoClass* klass, const char* addr)
 void
 mono_class_describe_statics (MonoClass* klass)
 {
+	MonoError error;
 	MonoClassField *field;
 	MonoClass *p;
 	const char *field_ptr;
-	MonoVTable *vtable = mono_class_vtable_full (mono_domain_get (), klass, FALSE);
+	MonoVTable *vtable = mono_class_vtable_full (mono_domain_get (), klass, &error);
 	const char *addr;
 
-	if (!vtable)
+	if (!vtable || !is_ok (&error)) {
+		mono_error_cleanup (&error);
 		return;
+	}
+
 	if (!(addr = (const char *)mono_vtable_get_static_field_data (vtable)))
 		return;
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -108,6 +108,7 @@ static gboolean suspend_finalizers = FALSE;
 void
 mono_gc_run_finalize (void *obj, void *data)
 {
+	MonoError error;
 	MonoObject *exc = NULL;
 	MonoObject *o;
 #ifndef HAVE_SGEN_GC
@@ -243,7 +244,8 @@ mono_gc_run_finalize (void *obj, void *data)
 
 	runtime_invoke = (RuntimeInvokeFunction)domain->finalize_runtime_invoke;
 
-	mono_runtime_class_init (o->vtable);
+	mono_runtime_class_init_full (o->vtable, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	if (G_UNLIKELY (MONO_GC_FINALIZE_INVOKE_ENABLED ())) {
 		MONO_GC_FINALIZE_INVOKE ((unsigned long)o, mono_object_get_size (o),

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1575,8 +1575,8 @@ mono_runtime_unhandled_exception_policy_set (MonoRuntimeUnhandledExceptionPolicy
 MonoVTable *
 mono_class_try_get_vtable (MonoDomain *domain, MonoClass *klass);
 
-MonoException *
-mono_runtime_class_init_full (MonoVTable *vtable, gboolean raise_exception);
+gboolean
+mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error);
 
 void
 mono_method_clear_object (MonoDomain *domain, MonoMethod *method);

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -212,6 +212,7 @@ mono_raise_exception	    (MonoException *ex);
 MONO_API void
 mono_runtime_object_init    (MonoObject *this_obj);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_runtime_class_init	    (MonoVTable *vtable);
 

--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -613,7 +613,9 @@ get_family_hint (void)
 		vtable = mono_class_vtable (mono_domain_get (), socket_class);
 		g_assert (vtable);
 
-		mono_runtime_class_init (vtable);
+		MonoError error;
+		mono_runtime_class_init_full (vtable, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 		mono_field_static_get_value (vtable, ipv4_field, &ipv4_enabled);
 		mono_field_static_get_value (vtable, ipv6_field, &ipv6_enabled);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4156,10 +4156,13 @@ init_llvm_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *meth
 	if (mini_get_debug_options ()->load_aot_jit_info_eagerly)
 		jinfo = mono_aot_find_jit_info (domain, amodule->assembly->image, code);
 
+	gboolean inited_ok = TRUE;
 	if (init_class)
-		mono_runtime_class_init (mono_class_vtable (domain, init_class));
+		inited_ok = mono_runtime_class_init_full (mono_class_vtable (domain, init_class), &error);
 	else if (from_plt && klass && !klass->generic_container)
-		mono_runtime_class_init (mono_class_vtable (domain, klass));
+		inited_ok = mono_runtime_class_init_full (mono_class_vtable (domain, klass), &error);
+	if (!inited_ok)
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return TRUE;
 

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -855,6 +855,7 @@ mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 gpointer
 mono_class_static_field_address (MonoDomain *domain, MonoClassField *field)
 {
+	MonoError error;
 	MonoVTable *vtable;
 	gpointer addr;
 	
@@ -862,9 +863,17 @@ mono_class_static_field_address (MonoDomain *domain, MonoClassField *field)
 
 	mono_class_init (field->parent);
 
-	vtable = mono_class_vtable_full (domain, field->parent, TRUE);
-	if (!vtable->initialized)
-		mono_runtime_class_init (vtable);
+	vtable = mono_class_vtable_full (domain, field->parent, &error);
+	if (!is_ok (&error)) {
+		mono_error_set_pending_exception (&error);
+		return NULL;
+	}
+	if (!vtable->initialized) {
+		if (!mono_runtime_class_init_full (vtable, &error)) {
+			mono_error_set_pending_exception (&error);
+			return NULL;
+		}
+	}
 
 	//printf ("SFLDA1 %p\n", (char*)vtable->data + field->offset);
 
@@ -1376,9 +1385,22 @@ mono_gsharedvt_value_copy (gpointer dest, gpointer src, MonoClass *klass)
 }
 
 void
+ves_icall_runtime_class_init (MonoVTable *vtable)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+	MonoError error;
+
+	mono_runtime_class_init_full (vtable, &error);
+	mono_error_set_pending_exception (&error);
+}
+
+
+void
 mono_generic_class_init (MonoVTable *vtable)
 {
-	mono_runtime_class_init (vtable);
+	MonoError error;
+	mono_runtime_class_init_full (vtable, &error);
+	mono_error_set_pending_exception (&error);
 }
 
 gpointer

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -184,6 +184,9 @@ MonoObject*
 mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
 
 void
+ves_icall_runtime_class_init (MonoVTable *vtable);
+
+void
 mono_generic_class_init (MonoVTable *vtable);
 
 void mono_interruption_checkpoint_from_trampoline (void);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4513,11 +4513,8 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 		}
 	}
 
-	ex = mono_runtime_class_init_full (vtable, FALSE);
-	if (ex) {
-		mono_error_set_exception_instance (error, ex);
+	if (!mono_runtime_class_init_full (vtable, error))
 		return NULL;
-	}
 	return code;
 }
 


### PR DESCRIPTION
Switch from a boolean `raise_on_error` arg to a MonoError outarg and let
callers decide what to do with the error.

Also mark mono_runtime_class_init external only.  Runtime should use
mono_runtime_class_init_full.