### PR TITLE
[sgen] catch NotSupportedException from system.xml.serialization

### DIFF
--- a/mcs/tools/sgen/sgen.cs
+++ b/mcs/tools/sgen/sgen.cs
@@ -110,6 +110,9 @@ public class Driver
 						Console.WriteLine (" - Warning: ignoring '" + t + "'");
 						Console.WriteLine ("   " + ex.Message);
 					}
+				} catch (NotSupportedException ex) {
+					if (verbose)
+						Console.WriteLine (" - Warning: " + ex.Message);
 				}
 			}
 		} else {
@@ -128,6 +131,9 @@ public class Driver
 						Console.WriteLine (" - Warning: ignoring '" + type + "'");
 						Console.WriteLine ("   " + ex.Message);
 					}
+				} catch (NotSupportedException ex) {
+					if (verbose)
+						Console.WriteLine (" - Warning: " + ex.Message);
 				}
 			}
 		}


### PR DESCRIPTION
If you try to run sgen [as in the serialization assembly generator] on an assembly that simply contains

```
namespace classlib1 
{ 	
    public interface testiface 	
    { 	
    }  	

    public class MyClass
     { 
        public MyClass() 		
        {
         }
     }
 }
```

You get the following

```
Generating serializer for the following types:

Unhandled Exception:
System.NotSupportedException: Cannot serialize interface classlib1.testiface.
  at System.Xml.Serialization.TypeDesc.CheckSupported () <0x106d5bf80 + 0x0012d> in <filename unknown>:0 
  at System.Xml.Serialization.TypeScope.GetTypeDesc (System.Type type, System.Reflection.MemberInfo source, Boolean directReference, Boolean throwOnError) <0x106d590c0 + 0x00125> in <filename unknown>:0 
  at System.Xml.Serialization.TypeScope.GetTypeDesc (System.Type type, System.Reflection.MemberInfo source, Boolean directReference) <0x106d59070 + 0x0002e> in <filename unknown>:0 
  at System.Xml.Serialization.ModelScope.GetTypeModel (System.Type type, Boolean directReference) <0x106d58c30 + 0x00093> in <filename unknown>:0 
  at System.Xml.Serialization.ModelScope.GetTypeModel (System.Type type) <0x106d58bf0 + 0x0001e> in <filename unknown>:0 
  at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping (System.Type type, System.Xml.Serialization.XmlRootAttribute root, System.String defaultNamespace) <0x106d589a0 + 0x00066> in <filename unknown>:0 
  at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping (System.Type type) <0x106d58960 + 0x0001d> in <filename unknown>:0 
  at Driver.Run (System.String[] args) <0x106d4f510 + 0x0052f> in <filename unknown>:0 
  at Driver.Main (System.String[] args) <0x106d4ed90 + 0x00054> in <filename unknown>:0 
```

This change catches the NotSupportedException and ignores the type in question