### PR TITLE
[System.Data.SqlClient] Fix for bulk copy inserts via IDataReader

### DIFF
--- a/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.cs
@@ -587,7 +587,7 @@ namespace System.Data.SqlClient {
 
 		public void WriteToServer (IDataReader reader)
 		{
-			DataTable table = new DataTable ();
+			DataTable table = new DataTable ("SourceTable");
 			SqlDataAdapter adapter = new SqlDataAdapter ();
 			adapter.FillInternal (table, reader);
 			BulkCopyToServer (table, 0);


### PR DESCRIPTION
This fixes an exception in System.Data.Common.DataTableMappingCollection that requires the source table name to be non-empty when using SqlBulkCopy with an IDataReader.  

Similar fix commit: 1858ce4a94ab07f615a0e5ded37f8caa18473700
