### PR TITLE
Use MonoError for mono_field_get_value_object

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -307,6 +307,7 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 static int
 mono_get_corlib_version (void)
 {
+	MonoError error;
 	MonoClass *klass;
 	MonoClassField *field;
 	MonoObject *value;
@@ -318,7 +319,8 @@ mono_get_corlib_version (void)
 		return -1;
 	if (! (field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 		return -1;
-	value = mono_field_get_value_object (mono_domain_get (), field, NULL);
+	value = mono_field_get_value_object_checked (mono_domain_get (), field, NULL, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	return *(gint32*)((gchar*)value + sizeof (MonoObject));
 }
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -985,6 +985,7 @@ ves_icall_System_Object_MemberwiseClone (MonoObject *this_obj)
 ICALL_EXPORT gint32
 ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray **fields)
 {
+	MonoError error;
 	MonoClass *klass;
 	MonoObject **values = NULL;
 	MonoObject *o;
@@ -1024,7 +1025,11 @@ ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray 
 		default:
 			if (!values)
 				values = g_newa (MonoObject*, mono_class_num_fields (klass));
-			o = mono_field_get_value_object (mono_object_domain (this_obj), field, this_obj);
+			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, this_obj, &error);
+			if (!is_ok (&error)) {
+				mono_error_set_pending_exception (&error);
+				return 0;
+			}
 			values [count++] = o;
 		}
 	}
@@ -1043,6 +1048,7 @@ ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray 
 ICALL_EXPORT MonoBoolean
 ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoArray **fields)
 {
+	MonoError error;
 	MonoClass *klass;
 	MonoObject **values = NULL;
 	MonoObject *o;
@@ -1128,9 +1134,17 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 		default:
 			if (!values)
 				values = g_newa (MonoObject*, mono_class_num_fields (klass) * 2);
-			o = mono_field_get_value_object (mono_object_domain (this_obj), field, this_obj);
+			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, this_obj, &error);
+			if (!is_ok (&error)) {
+				mono_error_set_pending_exception (&error);
+				return FALSE;
+			}
 			values [count++] = o;
-			o = mono_field_get_value_object (mono_object_domain (this_obj), field, that);
+			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, that, &error);
+			if (!is_ok (&error)) {
+				mono_error_set_pending_exception (&error);
+				return FALSE;
+			}
 			values [count++] = o;
 		}
 
@@ -1814,6 +1828,7 @@ ves_icall_MonoField_GetParentType (MonoReflectionField *field, MonoBoolean decla
 ICALL_EXPORT MonoObject *
 ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *obj)
 {	
+	MonoError error;
 	MonoClass *fklass = field->klass;
 	MonoClassField *cf = field->field;
 	MonoDomain *domain = mono_object_domain (field);
@@ -1827,7 +1842,9 @@ ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *ob
 	if (mono_security_core_clr_enabled ())
 		mono_security_core_clr_ensure_reflection_access_field (cf);
 
-	return mono_field_get_value_object (domain, cf, obj);
+	MonoObject * result = mono_field_get_value_object_checked (domain, cf, obj, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 ICALL_EXPORT void

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1639,6 +1639,9 @@ mono_field_static_get_value_for_thread (MonoInternalThread *thread, MonoVTable *
 MONO_API void *
 mono_vtable_get_static_field_data (MonoVTable *vt);
 
+MonoObject *
+mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, MonoObject *obj, MonoError *error);
+
 char *
 mono_string_to_utf8_ignore (MonoString *s);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3379,9 +3379,30 @@ mono_field_get_value (MonoObject *obj, MonoClassField *field, void *value)
 MonoObject *
 mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObject *obj)
 {	
+	MonoError error;
+	MonoObject* result = mono_field_get_value_object_checked (domain, field, obj, &error);
+	mono_error_assert_ok (&error);
+	return result;
+}
+
+/**
+ * mono_field_get_value_object_checked:
+ * @domain: domain where the object will be created (if boxing)
+ * @field: MonoClassField describing the field to fetch information from
+ * @obj: The object instance for the field.
+ * @error: Set on error.
+ *
+ * Returns: a new MonoObject with the value from the given field.  If the
+ * field represents a value type, the value is boxed.  On error returns NULL and sets @error.
+ *
+ */
+MonoObject *
+mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, MonoObject *obj, MonoError *error)
+{
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	mono_error_init (error);
+
 	MonoObject *o;
 	MonoClass *klass;
 	MonoVTable *vtable = NULL;
@@ -3390,10 +3411,9 @@ mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObje
 	gboolean is_ref = FALSE;
 	gboolean is_literal = FALSE;
 	gboolean is_ptr = FALSE;
-	MonoType *type = mono_field_get_type_checked (field, &error);
+	MonoType *type = mono_field_get_type_checked (field, error);
 
-	if (!mono_error_ok (&error))
-		mono_error_raise_exception (&error);  /* FIXME don't raise here */
+	return_val_if_nok (error, NULL);
 
 	switch (type->type) {
 	case MONO_TYPE_STRING:
@@ -3439,12 +3459,12 @@ mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObje
 		is_static = TRUE;
 
 		if (!is_literal) {
-			vtable = mono_class_vtable_full (domain, field->parent, &error);
-			mono_error_raise_exception (&error);  /* FIXME don't raise here */
+			vtable = mono_class_vtable_full (domain, field->parent, error);
+			return_val_if_nok (error, NULL);
 
 			if (!vtable->initialized) {
-				mono_runtime_class_init_full (vtable, &error);
-				mono_error_raise_exception (&error);  /* FIXME don't raise here */
+				mono_runtime_class_init_full (vtable, error);
+				return_val_if_nok (error, NULL);
 			}
 		}
 	} else {
@@ -3485,11 +3505,11 @@ mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObje
 
 		/* MONO_TYPE_PTR is passed by value to runtime_invoke () */
 		args [0] = ptr ? *ptr : NULL;
-		args [1] = mono_type_get_object_checked (mono_domain_get (), type, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		args [1] = mono_type_get_object_checked (mono_domain_get (), type, error);
+		return_val_if_nok (error, NULL);
 
-		o = mono_runtime_invoke_checked (m, NULL, args, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		o = mono_runtime_invoke_checked (m, NULL, args, error);
+		return_val_if_nok (error, NULL);
 
 		return o;
 	}
@@ -3500,8 +3520,8 @@ mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObje
 	if (mono_class_is_nullable (klass))
 		return mono_nullable_box (mono_field_get_addr (obj, vtable, field), klass);
 
-	o = mono_object_new_checked (domain, klass, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	o = mono_object_new_checked (domain, klass, error);
+	return_val_if_nok (error, NULL);
 	v = ((gchar *) o) + sizeof (MonoObject);
 
 	if (is_literal) {
@@ -4329,6 +4349,7 @@ mono_unhandled_exception (MonoObject *exc)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	MonoError error;
 	MonoClassField *field;
 	MonoDomain *current_domain, *root_domain;
 	MonoObject *current_appdomain_delegate = NULL, *root_appdomain_delegate = NULL;
@@ -4342,9 +4363,12 @@ mono_unhandled_exception (MonoObject *exc)
 	current_domain = mono_domain_get ();
 	root_domain = mono_get_root_domain ();
 
-	root_appdomain_delegate = mono_field_get_value_object (root_domain, field, (MonoObject*) root_domain->domain);
-	if (current_domain != root_domain)
-		current_appdomain_delegate = mono_field_get_value_object (current_domain, field, (MonoObject*) current_domain->domain);
+	root_appdomain_delegate = mono_field_get_value_object_checked (root_domain, field, (MonoObject*) root_domain->domain, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (current_domain != root_domain) {
+		current_appdomain_delegate = mono_field_get_value_object_checked (current_domain, field, (MonoObject*) current_domain->domain, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+	}
 
 	/* set exitcode only if we will abort the process */
 	if (!current_appdomain_delegate && !root_appdomain_delegate) {

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -303,6 +303,7 @@ mono_field_get_value (MonoObject *obj, MonoClassField *field, void *value);
 MONO_API void
 mono_field_static_get_value (MonoVTable *vt, MonoClassField *field, void *value);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObject *obj);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -7408,6 +7408,7 @@ mono_event_get_object_checked (MonoDomain *domain, MonoClass *klass, MonoEvent *
 static MonoObject *
 mono_get_reflection_missing_object (MonoDomain *domain)
 {
+	MonoError error;
 	MonoObject *obj;
 	static MonoClassField *missing_value_field = NULL;
 	
@@ -7418,8 +7419,8 @@ mono_get_reflection_missing_object (MonoDomain *domain)
 		missing_value_field = mono_class_get_field_from_name (missing_klass, "Value");
 		g_assert (missing_value_field);
 	}
-	obj = mono_field_get_value_object (domain, missing_value_field, NULL); 
-	g_assert (obj);
+	obj = mono_field_get_value_object_checked (domain, missing_value_field, NULL, &error);
+	mono_error_assert_ok (&error);
 	return obj;
 }
 
@@ -7738,6 +7739,7 @@ mono_method_body_get_object (MonoDomain *domain, MonoMethod *method)
 MonoObject *
 mono_get_dbnull_object (MonoDomain *domain)
 {
+	MonoError error;
 	MonoObject *obj;
 	static MonoClassField *dbnull_value_field = NULL;
 	
@@ -7747,8 +7749,8 @@ mono_get_dbnull_object (MonoDomain *domain)
 		dbnull_value_field = mono_class_get_field_from_name (dbnull_klass, "Value");
 		g_assert (dbnull_value_field);
 	}
-	obj = mono_field_get_value_object (domain, dbnull_value_field, NULL); 
-	g_assert (obj);
+	obj = mono_field_get_value_object_checked (domain, dbnull_value_field, NULL, &error);
+	mono_error_assert_ok (&error);
 	return obj;
 }
 


### PR DESCRIPTION
Mark it external only.  Runtime should use mono_field_get_value_object_checked.
