### PR TITLE
Use MonoError in mono_string_{is_interned,intern}

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -180,7 +180,9 @@ create_domain_objects (MonoDomain *domain)
 	string_vt = mono_class_vtable (domain, mono_defaults.string_class);
 	string_empty_fld = mono_class_get_field_from_name (mono_defaults.string_class, "Empty");
 	g_assert (string_empty_fld);
-	mono_field_static_set_value (string_vt, string_empty_fld, mono_string_intern (mono_string_new (domain, "")));
+	MonoString *empty_str = mono_string_intern_checked (mono_string_new (domain, ""), &error);
+	mono_error_assert_ok (&error);
+	mono_field_static_set_value (string_vt, string_empty_fld, empty_str);
 
 	/*
 	 * Create an instance early since we can't do it when there is no memory.

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1639,6 +1639,9 @@ mono_string_to_utf8_mp_ignore (MonoMemPool *mp, MonoString *s);
 gboolean
 mono_monitor_is_il_fastpath_wrapper (MonoMethod *method);
 
+MonoString*
+mono_string_intern_checked (MonoString *str, MonoError *error);
+
 char *
 mono_exception_get_native_backtrace (MonoException *exc);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -116,6 +116,7 @@ mono_ldstr		    (MonoDomain *domain, MonoImage *image, uint32_t str_index);
 MONO_API MonoString*
 mono_string_is_interned	    (MonoString *str);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
 mono_string_intern	    (MonoString *str);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -12855,7 +12855,8 @@ resolve_object (MonoImage *image, MonoObject *obj, MonoClass **handle_class, Mon
 	gpointer result = NULL;
 
 	if (strcmp (obj->vtable->klass->name, "String") == 0) {
-		result = mono_string_intern ((MonoString*)obj);
+		result = mono_string_intern_checked ((MonoString*)obj, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
 		*handle_class = mono_defaults.string_class;
 		g_assert (result);
 	} else if (strcmp (obj->vtable->klass->name, "MonoType") == 0) {

--- a/mono/metadata/string-icalls.c
+++ b/mono/metadata/string-icalls.c
@@ -46,11 +46,12 @@ ves_icall_System_String_InternalAllocateStr (gint32 length)
 MonoString  *
 ves_icall_System_String_InternalIntern (MonoString *str)
 {
+	MonoError error;
 	MonoString *res;
 
-	res = mono_string_intern(str);
+	res = mono_string_intern_checked (str, &error);
 	if (!res) {
-		mono_set_pending_exception (mono_domain_get ()->out_of_memory_ex);
+		mono_error_set_pending_exception (&error);
 		return NULL;
 	}
 	return res;
@@ -59,7 +60,7 @@ ves_icall_System_String_InternalIntern (MonoString *str)
 MonoString * 
 ves_icall_System_String_InternalIsInterned (MonoString *str)
 {
-	return mono_string_is_interned(str);
+	return mono_string_is_interned (str);
 }
 
 int


### PR DESCRIPTION
Also mark mono_string_intern external only.  Runtime should use
mono_string_intern_checked.