### PR TITLE
[corlib] Fixed FileStream Write after Read issue

### DIFF
--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -639,6 +639,13 @@ namespace System.IO
 				MonoIOError error;
 
 				FlushBuffer ();
+
+				if (CanSeek && !isExposed) {
+					MonoIO.Seek (safeHandle, buf_start, SeekOrigin.Begin, out error);
+					if (error != MonoIOError.ERROR_SUCCESS)
+						throw MonoIO.GetException (GetSecureFileName (name), error);
+				}
+
 				int wcount = count;
 
 				while (wcount > 0){

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -1044,7 +1044,7 @@ namespace System.IO
 					int wcount = buf_length;
 					int offset = 0;
 					while (wcount > 0){
-						int n = MonoIO.Write (safeHandle, buf, 0, buf_length, out error);
+						int n = MonoIO.Write (safeHandle, buf, offset, buf_length, out error);
 						if (error != MonoIOError.ERROR_SUCCESS) {
 							// don't leak the path information for isolated storage
 							throw MonoIO.GetException (GetSecureFileName (name), error);

--- a/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
@@ -1725,5 +1725,30 @@ namespace MonoTests.System.IO
 			}
 		}
 #endif
+
+		[Test] // Covers #11699
+		public void ReadWriteFileLength ()
+		{
+			int bufferSize = 128;
+			int readLength = 1;
+			int writeLength = bufferSize + 1;
+
+			string path = TempFolder + DSC + "readwritefilelength.tmp";
+
+			try {
+				File.WriteAllBytes (path, new byte [readLength + 1]);
+
+				using (var file = new FileStream (path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read,
+												 bufferSize, FileOptions.SequentialScan))
+				{
+					file.Read (new byte [readLength], 0, readLength);
+					file.Write (new byte [writeLength], 0, writeLength);
+
+					Assert.AreEqual (readLength + writeLength, file.Length);
+				}
+			} finally {
+				DeleteFile (path);
+			}
+		}
 	}
 }


### PR DESCRIPTION
FileStream was writing to the wrong position When a value longer than
the FileStream buffer was written after a read.

This was fixed by doing a seek before doing the problematic write.

Fixes [#11699](https://bugzilla.xamarin.com/show_bug.cgi?id=11699)