### PR TITLE
[pedump] Fix init crash on pedump when using --verify.

### DIFF
--- a/mono/metadata/pedump.c
+++ b/mono/metadata/pedump.c
@@ -467,6 +467,7 @@ verify_image_file (const char *fname)
 
 	mono_install_assembly_preload_hook (pedump_preload, GUINT_TO_POINTER (FALSE));
 
+	mono_icall_init ();
 	mono_marshal_init ();
 
 


### PR DESCRIPTION
@marek-safar  here's your fix

@monojenkins merge
