### PR TITLE
[System.Runtime.Serialization] Static writer fix.

### DIFF
--- a/mcs/class/System.Runtime.Serialization/ReferenceSources/XmlFormatWriterGenerator_static.cs
+++ b/mcs/class/System.Runtime.Serialization/ReferenceSources/XmlFormatWriterGenerator_static.cs
@@ -507,11 +507,15 @@ namespace System.Runtime.Serialization
 						} else {
 							var typeHandleValue = Type.GetTypeHandle (memberValue);
 							var isDeclaredType = typeHandleValue.Equals (CodeInterpreter.ConvertValue (memberValue, memberType, Globals.TypeOfObject));
-							if (isNullableOfT)
+							if (isNullableOfT) {
 								ctx.InternalSerialize (writer, memberValue, isDeclaredType, writeXsiType, DataContract.GetId (memberType.TypeHandle), memberType.TypeHandle);
-							else
-								ctx.InternalSerializeReference (writer, memberValue, isDeclaredType, writeXsiType, DataContract.GetId (memberType.TypeHandle), memberType.TypeHandle);								
-							//InternalSerialize((isNullableOfT ? XmlFormatGeneratorStatics.InternalSerializeMethod : XmlFormatGeneratorStatics.InternalSerializeReferenceMethod), () => memberValue, memberType, writeXsiType);
+							} else if (memberType == Globals.TypeOfObject) {
+								var dataContract = DataContract.GetDataContract (memberValue.GetType());
+								writer.WriteAttributeQualifiedName (Globals.XsiPrefix, DictionaryGlobals.XsiTypeLocalName, DictionaryGlobals.SchemaInstanceNamespace, dataContract.Name, dataContract.Namespace);
+								ctx.InternalSerializeReference (writer, memberValue, false, false, -1, typeHandleValue);
+							} else {
+								ctx.InternalSerializeReference (writer, memberValue, isDeclaredType, writeXsiType, DataContract.GetId (memberType.TypeHandle), memberType.TypeHandle);
+							}
 						}
 					}
 				}

--- a/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/DataContractSerializerTest.cs
+++ b/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/DataContractSerializerTest.cs
@@ -122,5 +122,17 @@ namespace MonoTests.System.Runtime.Serialization
 				Assert.IsTrue (s.Contains ("<Flags>All</Flags>"));
 			}
 		}
+
+		// Bug #37116
+		[Test]
+		public void KeyPairOfAny ()
+		{
+			var dict = new Dictionary<string, object> ();
+			dict.Add ("test", new List<string> () { "test entry" });
+
+			var dcs = new DataContractSerializer (typeof(Dictionary<string, object>));
+			dcs.WriteObject (new MemoryStream (), dict);
+			// Should not throw exception.
+		}
 	}
 }


### PR DESCRIPTION
While serializing any type into a contract member of type object an
exception would be thrown.

To avoid this XmlObjectSerializerWriteContext.InternalSerialize should
in this case be called using the object type instead of the member type,
similar how reference sources does in  type instead of the member type,
 referencesources seems to be doing something similar [1].

Fixes [#37116](https://bugzilla.xamarin.com/show_bug.cgi?id=37116).

[1]
http://referencesource.microsoft.com/#System.Runtime.Serialization/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs,619