### PR TITLE
Fix unreliability in async_read.exe test

### DIFF
--- a/mono/tests/async_read.cs
+++ b/mono/tests/async_read.cs
@@ -5,11 +5,13 @@ using System.Threading;
 class Test {
 
 	static int sum = 0;
+	static int count = 0;
 	
 	static void async_callback (IAsyncResult ar)
 	{
 		byte [] buf = (byte [])ar.AsyncState;
-		sum += buf [0];
+		Interlocked.Add (ref sum, buf [0]);
+		Interlocked.Increment (ref count);
 	}
 
 	static int Main () {
@@ -17,13 +19,15 @@ class Test {
 		AsyncCallback ac = new AsyncCallback (async_callback);
 		IAsyncResult ar;
 		int sum0 = 0;
+		int count0 = 0;
 		
 		FileStream s = new FileStream ("async_read.exe",  FileMode.Open, FileAccess.Read);
 
 		s.Position = 0;
-		sum0 = 0;
-		while (s.Read (buf, 0, 1) == 1)
+		while (s.Read (buf, 0, 1) == 1) {
 			sum0 += buf [0];
+			count0 ++;
+		}
 		
 		s.Position = 0;
 		
@@ -31,14 +35,15 @@ class Test {
 			buf = new byte [1];
 			ar = s.BeginRead (buf, 0, 1, ac, buf);
 		} while (s.EndRead (ar) == 1);
-		sum -= buf [0];
 		
 		Thread.Sleep (100);
 		
 		s.Close ();
 
+		count0 ++;  // async_callback is invoked for the "finished reading" case too
 		Console.WriteLine ("CSUM: " + sum + " " + sum0);
-		if (sum != sum0)
+		Console.WriteLine ("Count: " + count + " " + count0);
+		if (sum != sum0 || count != count0)
 			return 1;
 		
 		return 0;


### PR DESCRIPTION
It failed on [Jenkins](https://jenkins.mono-project.com/job/test-mono-mainline/label=debian-amd64/3611/parsed_console/log_content.html#WARNING1) today and I could repro it after running the test in a loop.

While looking at the test, the `sum -= buf [0]` seemed suspicious to me. The final callback invocation after the last byte was read results in buf [0] being 0 most of the time (because no bytes were read). However, due to the async nature of the test that final callback might happen before another callback and buf then has a value, resulting in a wrong checksum if that value is substracted.

The fix is to remove the substraction. I have no idea why it was done in the first place, but it's been there since the test was added in 2003...

While at it, I've added another check for the number of bytes read and used proper Interlocked.* operations to ensure atomicity.