### PR TITLE
[jit] Fix duplicated left-hand side in comparison

### DIFF
--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1261,7 +1261,7 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 
 					if (info->exception_type == MONO_EXCEPTION_METHOD_ACCESS)
 						mono_error_set_generic_error (&cfg->error, "System", "MethodAccessException", "%s", msg);
-					else if (info->exception_type == info->exception_type == MONO_EXCEPTION_FIELD_ACCESS)
+					else if (info->exception_type == MONO_EXCEPTION_FIELD_ACCESS)
 						mono_error_set_generic_error (&cfg->error, "System", "FieldAccessException", "%s", msg);
 					else if (info->exception_type == MONO_EXCEPTION_UNVERIFIABLE_IL)
 						mono_error_set_generic_error (&cfg->error, "System.Security", "VerificationException", msg);


### PR DESCRIPTION
The typo introduced by 1a784475c04a7b371e53346bee032590f4f94853 caused the if to always be false, 
because it would compare like `if (true == MONO_EXCEPTION_FIELD_ACCESS)`.

Thanks to @pazof in IRC for noticing.