### PR TITLE
fixes not listening to return value on AcceptAsync

### DIFF
--- a/mcs/class/System/System.Net/EndPointListener.cs
+++ b/mcs/class/System/System.Net/EndPointListener.cs
@@ -31,6 +31,8 @@
 #if MONO_SECURITY_ALIAS
 extern alias MonoSecurity;
 using MonoSecurity::Mono.Security.Authenticode;
+#else
+using Mono.Security.Authenticode;
 #endif
 using System;
 using System.IO;

--- a/mcs/class/System/System.Net/EndPointListener.cs
+++ b/mcs/class/System/System.Net/EndPointListener.cs
@@ -28,10 +28,7 @@
 //
 
 #if SECURITY_DEP
-
-#if MONOTOUCH || MONODROID
-using Mono.Security.Authenticode;
-#else
+#if MONO_SECURITY_ALIAS
 extern alias MonoSecurity;
 using MonoSecurity::Mono.Security.Authenticode;
 #endif


### PR DESCRIPTION
Affects all HttpListener usages.

A connect flood will break the async loop and take down the entire HttpListener instance (will stop accepting connections).

To reproduce. Take a HttpListener run say 2 wrk test instances against it (1000 connections each works here). After the run the HttpListener has broken its async loop and will no longer accept any connections after. The reason for this is that it was not previously handling the case that AcceptAsync can return synchronously. In this case event will not be called with args.

Patch handles this case and the above issue is not reproducible with.