### PR TITLE
[reflection] MonoError for mono_reflection_type_get_handle

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1444,7 +1444,7 @@ void
 mono_reflection_resolve_custom_attribute_data (MonoReflectionMethod *method, MonoReflectionAssembly *assembly, gpointer data, guint32 data_length, MonoArray **ctor_args, MonoArray ** named_args);
 
 MonoType*
-mono_reflection_type_get_handle (MonoReflectionType *ref);
+mono_reflection_type_get_handle (MonoReflectionType *ref, MonoError *error);
 
 void
 mono_reflection_free_dynamic_generic_class (MonoGenericClass *gclass);


### PR DESCRIPTION
`mono_reflection_type_get_handle` is really a kind of normalization procedure that synthesizes real `MonoType`s from reflection's derived types such as `System.Reflection.Emit.ArrayType, ByRefType`, etc.  So we call it all over the place in System.Reflection.Emit runtime code.

That would all be fine, except that users are allowed to subclass `System.Type`, so we have to call the `UnderlyingSystemType()` method to get a real type.  Which means that an override can throw.  Which in coop mode means we have to thread around a `MonoError`.  So that's why this code is uglier.

But really this code is doing a lot of type inspection and high-level work that we should figure out how to migrate to managed.