### PR TITLE
Add a rule for generating dSYM debugging entries for binaries on OS X.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,4 +162,5 @@ update-llvm-version:
 	if test "x$$LLVM_DIR" = "x"; then echo "Set the make variable LLVM_DIR to the directory containing the LLVM installation."; exit 1; fi
 	REV=`$(LLVM_DIR)/bin/llvm-config --version` && sed -e "s,expected_llvm_version=.*,expected_llvm_version=\"$$REV\"," < configure.ac > tmp && mv tmp configure.ac && echo "Version set to $$REV."
 
-
+dsymutil:
+	for f in $(bindir)/* ; do file -b "$$f" | grep -q Mach-O || continue ; $(DSYMUTIL) "$$f" ; done


### PR DESCRIPTION
Hello,
This PR adds a rule for generating dSYM debugging entries for binaries in the build. It should be useful for OSX development builds, since it would slightly simplify generation of multiple debug builds with a single source tree.
The rule is intended to be run after the `make install` step to link the debugging information for all the Mach-O binaries in the build. For instance, if I wanted to make a build that would retain its debugging information even after removal of the temporary .libs directories, I'd do something like this:

```
$ make && make install && make dsymutil
```

Not sure this is the best way to implement the rule (perhaps everything can be done within the logic of automake/autoconf?), hence the pull request.
