### PR TITLE
[runtime] Explicitly encode the need of running a cctor on method infos.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -5602,11 +5602,13 @@ emit_method_info (MonoAotCompile *acfg, MonoCompile *cfg)
 	buf_size = (patches->len < 1000) ? 40960 : 40960 + (patches->len * 64);
 	p = buf = (guint8 *)g_malloc (buf_size);
 
-	if (mono_class_get_cctor (method->klass))
+	if (mono_class_get_cctor (method->klass)) {
+		encode_value (1, p, &p);
 		encode_klass_ref (acfg, method->klass, p, &p);
-	else
+	} else {
 		/* Not needed when loading the method */
 		encode_value (0, p, &p);
+	}
 
 	g_assert (!(cfg->opt & MONO_OPT_SHARED));
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -114,7 +114,7 @@
 #endif
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 132
+#define MONO_AOT_FILE_VERSION 133
 
 //TODO: This is x86/amd64 specific.
 #define mono_simd_shuffle_mask(a,b,c,d) ((a) | ((b) << 2) | ((c) << 4) | ((d) << 6))


### PR DESCRIPTION
This removes the case where decode_klass_ref returning NULL would be ok.