### PR TITLE
[Profiler] Keep a reference to assemblies while coverage is running

### DIFF
--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -774,7 +774,7 @@ gboolean
 mono_metadata_generic_param_equal (MonoGenericParam *p1, MonoGenericParam *p2);
 
 void mono_dynamic_stream_reset  (MonoDynamicStream* stream);
-void mono_assembly_addref       (MonoAssembly *assembly);
+MONO_API void mono_assembly_addref       (MonoAssembly *assembly);
 void mono_assembly_load_friends (MonoAssembly* ass);
 gboolean mono_assembly_has_skip_verification (MonoAssembly* ass);
 

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -11,6 +11,7 @@
 
 #include <config.h>
 #include "../mini/jit.h"
+#include "../metadata/metadata-internals.h"
 #include <mono/metadata/profiler.h>
 #include <mono/metadata/threads.h>
 #include <mono/metadata/mono-gc.h>
@@ -3699,6 +3700,11 @@ coverage_filter (MonoProfiler *prof, MonoMethod *method)
 
 	assembly = mono_image_get_assembly (image);
 
+	// Need to keep the assemblies around for as long as they are kept in the hashtable
+	// Nunit, for example, has a habit of unloading them before the coverage statistics are
+	// generated causing a crash. See https://bugzilla.xamarin.com/show_bug.cgi?id=39325
+	InterlockedIncrement(&assembly->ref_count);
+
 	mono_os_mutex_lock (&coverage_mutex);
 	mono_conc_hashtable_insert (coverage_methods, method, method);
 	mono_conc_hashtable_insert (coverage_assemblies, assembly, assembly);
@@ -3841,6 +3847,13 @@ coverage_init (MonoProfiler *prof)
 }
 
 static void
+unref_coverage_assemblies (gpointer key, gpointer value, gpointer userdata)
+{
+	MonoAssembly *assembly = (MonoAssembly *)value;
+	mono_assembly_close (assembly);
+}
+
+static void
 log_shutdown (MonoProfiler *prof)
 {
 	void *res;
@@ -3889,6 +3902,10 @@ log_shutdown (MonoProfiler *prof)
 	mono_os_mutex_destroy (&prof->method_table_mutex);
 
 	if (coverage_initialized) {
+		mono_os_mutex_lock (&coverage_mutex);
+		mono_conc_hashtable_foreach (coverage_assemblies, unref_coverage_assemblies, prof);
+		mono_os_mutex_unlock (&coverage_mutex);
+
 		mono_conc_hashtable_destroy (coverage_methods);
 		mono_conc_hashtable_destroy (coverage_assemblies);
 		mono_conc_hashtable_destroy (coverage_classes);

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -3703,7 +3703,7 @@ coverage_filter (MonoProfiler *prof, MonoMethod *method)
 	// Need to keep the assemblies around for as long as they are kept in the hashtable
 	// Nunit, for example, has a habit of unloading them before the coverage statistics are
 	// generated causing a crash. See https://bugzilla.xamarin.com/show_bug.cgi?id=39325
-	InterlockedIncrement(&assembly->ref_count);
+	mono_assembly_addref (assembly);
 
 	mono_os_mutex_lock (&coverage_mutex);
 	mono_conc_hashtable_insert (coverage_methods, method, method);


### PR DESCRIPTION
In certain circumstances, for example when running under nunit-console, assemblies could be unloaded while the profiler still had a reference to them in order to generate the coverage data. In these cases, the memory referred to by the profiler would be invalid and would crash.

Fix this by incrementing the reference count of the assemblies preventing them from being unloaded while coverage is being collected.

Fixes BXC #39325