### PR TITLE
[utils] Get processor count from scheduler affinity if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1156,6 +1156,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(getrlimit)
 	AC_CHECK_FUNCS(prctl)
 
+	AC_CHECK_FUNCS(sched_getaffinity)
 	AC_CHECK_FUNCS(sched_setaffinity)
 	AC_CHECK_FUNCS(sched_getcpu)
 

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -33,6 +33,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SCHED_GETAFFINITY
+#include <sched.h>
+#endif
 #include <fcntl.h>
 #include <errno.h>
 #if defined(HOST_WIN32) || defined(DISABLE_SOCKETS)
@@ -2512,6 +2515,13 @@ mono_cpu_count (void)
 		close (present);
 	if (count > 0)
 		return count + 1;
+#endif
+#ifdef HAVE_SCHED_GETAFFINITY
+	{
+		cpu_set_t set;
+		if (sched_getaffinity (getpid (), sizeof (set), &set) == 0)
+			return CPU_COUNT (&set);
+	}
 #endif
 #ifdef _SC_NPROCESSORS_ONLN
 	count = sysconf (_SC_NPROCESSORS_ONLN);

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -14,6 +14,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SCHED_GETAFFINITY
+#include <sched.h>
+#endif
 
 #ifdef HOST_WIN32
 #include <windows.h>
@@ -638,6 +641,13 @@ mono_cpu_count (void)
 		close (present);
 	if (count > 0)
 		return count + 1;
+#endif
+#ifdef HAVE_SCHED_GETAFFINITY
+	{
+		cpu_set_t set;
+		if (sched_getaffinity (mono_process_current_pid (), sizeof (set), &set) == 0)
+			return CPU_COUNT (&set);
+	}
 #endif
 #ifdef _SC_NPROCESSORS_CONF
 	count = sysconf (_SC_NPROCESSORS_CONF);


### PR DESCRIPTION
In case the user has set a scheduler CPU affinity, we should use it as the number of available CPU for the runtime. This is particularly important on docket which uses cgroups that set the container a cpu affinity, and by not using that, the runtime report the total number of CPU the machine has, and not the number of CPU the container has.

Fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=39279