### PR TITLE
[corlib] Fix three decimal tests to not rely on current culture for formatting

### DIFF
--- a/mcs/class/corlib/Test/System/DecimalTest.cs
+++ b/mcs/class/corlib/Test/System/DecimalTest.cs
@@ -1571,7 +1571,7 @@ namespace MonoTests.System
 		{
 			decimal value = 1.600000m;
 			var roundedValue = Math.Round (value, 3);
-			Assert.AreEqual ("1.600", roundedValue.ToString (), "#1");
+			Assert.AreEqual ("1.600", roundedValue.ToString (CultureInfo.InvariantCulture), "#1");
 		}
 
 		[Test] // Bug Xamarin#17538
@@ -1585,7 +1585,6 @@ namespace MonoTests.System
 		}
 
 		[Test] // Bug Xamarin #24411
-		[Category ("MobileNotWorking")] // Bug Xamarin #27269
 		public void DecimalDivision_24411  ()
 		{
 			decimal dd = 45m;
@@ -1599,19 +1598,18 @@ namespace MonoTests.System
 			// The side effect is that 45m/100 should render as 0.45, not 0.4500000000000000000000000000
 			// Just for completeness:
 
-			Assert.AreEqual ("0.45", (45m/100).ToString ());
+			Assert.AreEqual ("0.45", (45m/100).ToString (CultureInfo.InvariantCulture));
 		}
 
 		[Test] // Bug SUSE #655780
-		[Category ("MobileNotWorking")] // Bug Xamarin #27269
 		public void TrailingZerosBug ()
 		{
 			decimal d;
-			Assert.AreEqual ("0", (0m/5).ToString ());
-			Assert.AreEqual ("0.2", (1m/5).ToString ());
-			Assert.AreEqual ("0.4", (2m/5).ToString ());
-			Assert.AreEqual ("0.6", (3m/5).ToString ());
-			Assert.AreEqual ("0.8", (4m/5).ToString ());
+			Assert.AreEqual ("0", (0m/5).ToString (CultureInfo.InvariantCulture));
+			Assert.AreEqual ("0.2", (1m/5).ToString (CultureInfo.InvariantCulture));
+			Assert.AreEqual ("0.4", (2m/5).ToString (CultureInfo.InvariantCulture));
+			Assert.AreEqual ("0.6", (3m/5).ToString (CultureInfo.InvariantCulture));
+			Assert.AreEqual ("0.8", (4m/5).ToString (CultureInfo.InvariantCulture));
 		}
 	}
 }


### PR DESCRIPTION
They'd fail on cultures where "." is not the decimal separator before.

I've also reenabled them on mobile cause the workaround for #27269 is no longer necessary since all bots are now on Mono 4.0+.

@monojenkins merge