### PR TITLE
Embedded API. Fix method signature match failure.

### DIFF
--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -308,7 +308,8 @@ mono_method_desc_new (const char *name, gboolean include_namespace)
 	MonoMethodDesc *result;
 	char *class_name, *class_nspace, *method_name, *use_args, *end;
 	int use_namespace;
-	
+    int generic_delim_stack;
+    
 	class_nspace = g_strdup (name);
 	use_args = strchr (class_nspace, '(');
 	if (use_args) {
@@ -354,8 +355,14 @@ mono_method_desc_new (const char *name, gboolean include_namespace)
 		end = use_args;
 		if (*end)
 			result->num_args = 1;
+        generic_delim_stack = 0;
 		while (*end) {
-			if (*end == ',')
+            if (*end == '<')
+                generic_delim_stack++;
+            else if (*end == '>')
+                generic_delim_stack--;
+            
+			if (*end == ',' && generic_delim_stack == 0)
 				result->num_args++;
 			++end;
 		}


### PR DESCRIPTION
Embedded API. Fix method signature match failure for generic types with multiple type parameters.
I know that you probably aren't accepting pull requests on 4.0.0 put you can most likely just cherry pick this on to 4.2 - I don't have a working 4.2 build yet.

Details are on the list.
http://mono.1490590.n4.nabble.com/Re-Embedded-API-ctor-method-signature-query-mono-td4667551.html

Robert Jordan said:

It looks like a bug in mono_method_desc_new ():

https://github.com/mono/mono/blob/master/mono/metadata/debug-helpers.c#L378

The function is treating

	.ctor(System.Func`2<string, string>)

like a method with 2 arguments:

arg0 = System.Func`2<string
arg1 = string>

This is obviously wrong :)

The function is then storing the (wrong) argument count
for optimization purposes, and the comparison of methods
is starting to fail:

https://github.com/mono/mono/blob/master/mono/metadata/debug-helpers.c#L447

Robert
