### PR TITLE
[System] Fix more hardcoded test ports

### DIFF
--- a/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Description/WebScriptEnablingBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Description/WebScriptEnablingBehaviorTest.cs
@@ -38,6 +38,8 @@ using System.ServiceModel.Web;
 using System.Text;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Description
 {
 	public class MyHostFactory : WebScriptServiceHostFactory
@@ -64,7 +66,7 @@ namespace MonoTests.System.ServiceModel.Description
 		[Test]
 		public void ScriptGenerator ()
 		{
-			var url = "http://localhost:37564";
+			var url = "http://localhost:" + NetworkHelpers.FindFreePort ();
 			var host = new MyHostFactory ().CreateServiceHost (typeof (HogeService));
 			var binding = new WebHttpBinding ();
 			host.AddServiceEndpoint (typeof (IHogeService), binding, url);

--- a/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Dispatcher/WebHttpDispatchOperationSelectorTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Dispatcher/WebHttpDispatchOperationSelectorTest.cs
@@ -39,6 +39,8 @@ using System.Text;
 using System.Xml;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Dispatcher
 {
 	[TestFixture]
@@ -257,12 +259,13 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		public void WebMessageFormats ()
 		{
 			var host = new WebServiceHost (typeof (Hello));
-			host.AddServiceEndpoint (typeof (IHello), new WebHttpBinding (), "http://localhost:37564/");
+			var port = NetworkHelpers.FindFreePort ();
+			host.AddServiceEndpoint (typeof (IHello), new WebHttpBinding (), "http://localhost:" + port + "/");
 			host.Description.Behaviors.Find<ServiceDebugBehavior> ().IncludeExceptionDetailInFaults = true;
 			host.Open ();
 			try {
 				// run client
-				using (ChannelFactory<IHello> factory = new ChannelFactory<IHello> (new WebHttpBinding (), "http://localhost:37564/"))
+				using (ChannelFactory<IHello> factory = new ChannelFactory<IHello> (new WebHttpBinding (), "http://localhost:" + port + "/"))
 				{
 					factory.Endpoint.Behaviors.Add (new WebHttpBehavior ());
 					IHello h = factory.CreateChannel ();

--- a/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebOperationContextTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebOperationContextTest.cs
@@ -40,6 +40,8 @@ using NUnit.Framework;
 
 using CategoryAttribute = NUnit.Framework.CategoryAttribute;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Web
 {
 	[TestFixture]
@@ -55,7 +57,7 @@ namespace MonoTests.System.ServiceModel.Web
 			Assert.IsNull (WebOperationContext.Current, "#1");
 #endif
 			var binding = new WebHttpBinding ();
-			var address = new EndpointAddress ("http://localhost:37564");
+			var address = new EndpointAddress ("http://localhost:" + NetworkHelpers.FindFreePort ());
 			var ch = (IContextChannel) WebChannelFactory<IHogeService>.CreateChannel (binding, address);
 			using (var ocs = new OperationContextScope (ch)) {
 #if !MOBILE
@@ -101,11 +103,12 @@ namespace MonoTests.System.ServiceModel.Web
 		void CreateResponseTest (Action<IHogeService> a)
 		{
 			var host = new WebServiceHost (typeof (HogeService));
-			host.AddServiceEndpoint (typeof (IHogeService), new WebHttpBinding (), new Uri ("http://localhost:37564"));
+			var port = NetworkHelpers.FindFreePort ();
+			host.AddServiceEndpoint (typeof (IHogeService), new WebHttpBinding (), new Uri ("http://localhost:" + port));
 			host.Description.Behaviors.Find<ServiceDebugBehavior> ().IncludeExceptionDetailInFaults = true;
 			host.Open ();
 			try {
-				using (var cf = new ChannelFactory<IHogeService> (new WebHttpBinding (), new EndpointAddress ("http://localhost:37564"))) {
+				using (var cf = new ChannelFactory<IHogeService> (new WebHttpBinding (), new EndpointAddress ("http://localhost:" + port))) {
 					cf.Endpoint.Behaviors.Add (new WebHttpBehavior ());
 					cf.Open ();
 					var ch = cf.CreateChannel ();

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataBehaviorTest.cs
@@ -35,6 +35,8 @@ using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Channels;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Description
 {
 	[TestFixture]
@@ -56,7 +58,8 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime1 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
+			var port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "e1");
 				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true });
 
@@ -93,10 +96,11 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime2 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
+			var port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex_and_help") });
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:30158/mex_and_help");
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:" + port + "/mex_and_help") });
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:" + port + "/mex_and_help");
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
 
@@ -125,10 +129,11 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime3 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
+			var port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
-				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:30158/help");
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:" + port + "/mex") });
+				host.Description.Behaviors.Find<ServiceDebugBehavior> ().HttpHelpPageUrl = new Uri ("http://localhost:" + port + "/help");
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
 
@@ -176,9 +181,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void InitializeRuntime4 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
+			var port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:" + port + "/mex") });
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
 				Assert.AreEqual (0, host.ChannelDispatchers.Count, "ChannelDispatchers.Count #1");
@@ -204,7 +210,7 @@ namespace MonoTests.System.ServiceModel.Description
 				Assert.AreEqual (0, ed.FilterPriority, "FilterPriority");
 
 				EndpointAddress ea = ed.EndpointAddress;
-				Assert.AreEqual (new Uri ("http://localhost:30158/mex"), ea.Uri, "Uri");
+				Assert.AreEqual (new Uri ("http://localhost:" + port + "/mex"), ea.Uri, "Uri");
 
 				DispatchRuntime dr = ed.DispatchRuntime;
 				Assert.AreEqual (1, dr.Operations.Count, "Operations.Count");
@@ -221,9 +227,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void ServiceMetadataExtension1 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
+			var port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:" + port + "/mex") });
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
 				host.Open ();
@@ -237,9 +244,10 @@ namespace MonoTests.System.ServiceModel.Description
 
 		[Test]
 		public void ServiceMetadataExtension2 () {
-			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:30158"))) {
+			var port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost host = new ServiceHost (typeof (MyService), new Uri ("http://localhost:" + port))) {
 				host.AddServiceEndpoint (typeof (IMyContract), new BasicHttpBinding (), "");
-				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:30158/mex") });
+				host.Description.Behaviors.Add (new ServiceMetadataBehavior () { HttpGetEnabled = true, HttpGetUrl = new Uri ("http://localhost:" + port + "/mex") });
 				host.Description.Behaviors.Remove<ServiceDebugBehavior> ();
 
 				ServiceMetadataExtension extension = new ServiceMetadataExtension ();

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchRuntimeTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchRuntimeTest.cs
@@ -40,6 +40,8 @@ using System.Collections.ObjectModel;
 using SMMessage = System.ServiceModel.Channels.Message;
 using System.Threading;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.ServiceModel.Dispatcher
 {
 	[TestFixture]
@@ -153,7 +155,8 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 
 		void TestInstanceBehavior (MessageInspectBehavior b, string expected, Result actual, int invocations)
 		{
-			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:30158"));
+			var port = NetworkHelpers.FindFreePort ();
+			ServiceHost h = new ServiceHost (typeof (AllActions), new Uri ("http://localhost:" + port));
 			try {
 				h.AddServiceEndpoint (typeof (IAllActions).FullName, new BasicHttpBinding (), "AllActions");
 				h.Description.Behaviors.Add (b);
@@ -167,7 +170,7 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 						Assert.AreEqual (typeof (AllActions), ed.DispatchRuntime.Type, "Type property: " + ed.ContractName);
 					}
 				}
-				AllActionsProxy p = new AllActionsProxy (new BasicHttpBinding () { SendTimeout = TimeSpan.FromSeconds (5), ReceiveTimeout = TimeSpan.FromSeconds (5) }, new EndpointAddress ("http://localhost:30158/AllActions"));
+				AllActionsProxy p = new AllActionsProxy (new BasicHttpBinding () { SendTimeout = TimeSpan.FromSeconds (5), ReceiveTimeout = TimeSpan.FromSeconds (5) }, new EndpointAddress ("http://localhost:" + port + "/AllActions"));
 
 				for (int i = 0; i < invocations; ++i)
 					p.Get (10);

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
@@ -131,7 +131,8 @@ namespace MonoTests.System.ServiceModel
 		public void InitializeRuntime () {
 			Poker host = new Poker ();
 			host.CallInitializeDescription ();
-			EndpointAddress address = new EndpointAddress ("http://localhost:8090/");
+			var port = NetworkHelpers.FindFreePort ();
+			EndpointAddress address = new EndpointAddress ("http://localhost:" + port + "/");
 			ContractDescription contract = ContractDescription.GetContract (typeof (IMyContract));
 			ServiceEndpoint endpoint = new ServiceEndpoint (contract, new BasicHttpBinding (), address);
 			endpoint.ListenUri = address.Uri;
@@ -377,7 +378,8 @@ namespace MonoTests.System.ServiceModel
 		public void AddServiceEndpoint_Directly ()
 		{
 			var host = new ServiceHost (typeof (DummyService));
-			var address = new EndpointAddress ("http://localhost:30158");
+			var port = NetworkHelpers.FindFreePort ();
+			var address = new EndpointAddress ("http://localhost:" + port);
 			var binding = new BasicHttpBinding ();
 			var contract = ContractDescription.GetContract (typeof (IDummyService));
 			host.AddServiceEndpoint (new ServiceEndpoint (contract, binding, address));
@@ -398,7 +400,8 @@ namespace MonoTests.System.ServiceModel
 		public void AddServiceEndpoint_Directly_NullBinding ()
 		{
 			var host = new ServiceHost (typeof (DummyService));
-			var address = new EndpointAddress ("http://localhost:30158");
+			var port = NetworkHelpers.FindFreePort ();
+			var address = new EndpointAddress ("http://localhost:" + port);
 			var contract = ContractDescription.GetContract (typeof (IDummyService));
 			host.AddServiceEndpoint (new ServiceEndpoint (contract, null, address));
 		}
@@ -416,7 +419,8 @@ namespace MonoTests.System.ServiceModel
 		public void AddServiceEndpoint_Directly_ContractMismatch ()
 		{
 			var host = new ServiceHost (typeof (DummyService));
-			var address = new EndpointAddress ("http://localhost:30158");
+			var port = NetworkHelpers.FindFreePort ();
+			var address = new EndpointAddress ("http://localhost:" + port);
 			var binding = new BasicHttpBinding ();
 			var contract = ContractDescription.GetContract (typeof (INotImplementedService));
 			host.AddServiceEndpoint (new ServiceEndpoint (contract, binding, address));

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
@@ -270,7 +270,8 @@ namespace MonoTests.System.ServiceModel
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void AddServiceEndpointMexWithNoImpl ()
 		{
-			using (ServiceHost h = new ServiceHost (typeof (Foo), new Uri ("http://localhost:8080"))) {
+			var port = NetworkHelpers.FindFreePort ();
+			using (ServiceHost h = new ServiceHost (typeof (Foo), new Uri ("http://localhost:" + port))) {
 				// it expects ServiceMetadataBehavior
 				h.AddServiceEndpoint (ServiceMetadataBehavior.MexContractName, MetadataExchangeBindings.CreateMexHttpBinding (), "mex");
 			}
@@ -279,21 +280,23 @@ namespace MonoTests.System.ServiceModel
 		[Test]
 		public void AddServiceEndpointMetadataExchange ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// MyMetadataExchange implements IMetadataExchange
 			ServiceHost host = new ServiceHost (typeof (MyMetadataExchange));
 			host.AddServiceEndpoint ("IMetadataExchange",
 						 new BasicHttpBinding (),
-						 "http://localhost:8080/");
+						 "http://localhost:" + port + "/");
 		}
 
 		[Test]
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void AddServiceEndpointMetadataExchangeFullNameFails ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			ServiceHost host = new ServiceHost (typeof (MyMetadataExchange));
 			host.AddServiceEndpoint ("System.ServiceModel.Description.IMetadataExchange",
 						 new BasicHttpBinding (),
-						 "http://localhost:8080");
+						 "http://localhost:" + port);
 		}
 
 		[Test]

--- a/mcs/class/System/Test/System.Net.Sockets/TcpClientTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/TcpClientTest.cs
@@ -35,12 +35,13 @@ namespace MonoTests.System.Net.Sockets
 			Socket lSock = new Socket(AddressFamily.InterNetwork,
 				SocketType.Stream, ProtocolType.Tcp);
 			
-			lSock.Bind(new IPEndPoint(IPAddress.Any, 8765));
+			var port = NetworkHelpers.FindFreePort ();
+			lSock.Bind(new IPEndPoint(IPAddress.Any, port));
 			lSock.Listen(-1);
 
 
 			// connect to it with a TcpClient
-			TcpClient outClient = new TcpClient("localhost", 8765);
+			TcpClient outClient = new TcpClient("localhost", port);
 			Socket inSock = lSock.Accept();
 
 			
@@ -77,9 +78,10 @@ namespace MonoTests.System.Net.Sockets
 		[Test] // bug #81105
 		public void CloseTest ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8765);
+			var port = NetworkHelpers.FindFreePort ();
+			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, port);
 			using (SocketResponder sr = new SocketResponder (localEP, s => CloseRequestHandler (s))) {
-				TcpClient tcpClient = new TcpClient (IPAddress.Loopback.ToString (), 8765);
+				TcpClient tcpClient = new TcpClient (IPAddress.Loopback.ToString (), port);
 				NetworkStream ns = tcpClient.GetStream ();
 				Assert.IsNotNull (ns, "#A1");
 				Assert.AreEqual (0, tcpClient.Available, "#A2");
@@ -104,7 +106,7 @@ namespace MonoTests.System.Net.Sockets
 			}
 
 			using (SocketResponder sr = new SocketResponder (localEP, s => CloseRequestHandler (s))) {
-				TcpClient tcpClient = new TcpClient (IPAddress.Loopback.ToString (), 8765);
+				TcpClient tcpClient = new TcpClient (IPAddress.Loopback.ToString (), port);
 				Assert.AreEqual (0, tcpClient.Available, "#B1");
 				Assert.IsTrue (tcpClient.Connected, "#B2");
 				// Assert.IsFalse (tcpClient.ExclusiveAddressUse, "#B3");

--- a/mcs/class/System/Test/System.Net.Sockets/TcpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/TcpListenerTest.cs
@@ -15,6 +15,8 @@ using System.Net;
 using System.Net.Sockets;
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.Net.Sockets
 {
 	[TestFixture]
@@ -23,8 +25,9 @@ namespace MonoTests.System.Net.Sockets
 		[Test]
 		public void TcpListener ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// listen with a new listener (IPv4 is the default)
-			TcpListener inListener = new TcpListener (8766);
+			TcpListener inListener = new TcpListener (port);
 			inListener.Start();
 			
 
@@ -37,7 +40,7 @@ namespace MonoTests.System.Net.Sockets
 					/// Only keep IPv4 addresses, our Server is in IPv4 only mode.
 					outSock = new Socket (address.AddressFamily, SocketType.Stream,
 						ProtocolType.IP);
-					IPEndPoint remote = new IPEndPoint (address, 8766);
+					IPEndPoint remote = new IPEndPoint (address, port);
 					outSock.Connect (remote);
 					break;
 				}
@@ -106,7 +109,7 @@ namespace MonoTests.System.Net.Sockets
 		class MyListener : TcpListener
 		{
 			public MyListener ()
-				: base (IPAddress.Loopback, 5000)
+				: base (IPAddress.Loopback, NetworkHelpers.FindFreePort ())
 			{
 			}
 
@@ -171,7 +174,8 @@ namespace MonoTests.System.Net.Sockets
 		[Test]
 		public void StartListenMoreThan5 ()
 		{
-			TcpListener listen = new TcpListener (IPAddress.Loopback, 1234);
+			var port = NetworkHelpers.FindFreePort ();
+			TcpListener listen = new TcpListener (IPAddress.Loopback, port);
 
 			listen.Start (6);
 			listen.Stop ();

--- a/mcs/class/System/Test/System.Net/HttpListener2Test.cs
+++ b/mcs/class/System/Test/System.Net/HttpListener2Test.cs
@@ -38,6 +38,8 @@ using System.Threading;
 
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 // ***************************************************************************************
 // NOTE: when adding prefixes, make then unique per test, as MS might take 'some time' to
 // unregister it even after explicitly closing the listener.
@@ -136,8 +138,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test1 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test1/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test1/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "GET / HTTP/1.1\r\n\r\n"); // No host
 			string response = Receive (ns, 512);
 			ns.Close ();
@@ -147,8 +150,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test2 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test2/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test2/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"); // no prefix
 			string response = Receive (ns, 512);
 			ns.Close ();
@@ -182,8 +186,9 @@ namespace MonoTests.System.Net {
 			bad.Append ('}');
 
 			foreach (char b in bad.ToString ()){
-				HttpListener listener = CreateAndStartListener ("http://127.0.0.1:9000/test3/");
-				NetworkStream ns = CreateNS (9000);
+				var port = NetworkHelpers.FindFreePort ();
+				HttpListener listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test3/");
+				NetworkStream ns = CreateNS (port);
 				Send (ns, String.Format ("MA{0} / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n", b)); // bad method
 				
 				string response = Receive (ns, 512);
@@ -196,8 +201,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test4 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test4/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test4/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test4/ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"); // length required
 			string response = Receive (ns, 512);
 			ns.Close ();
@@ -207,8 +213,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test5 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test5/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test5/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: pepe\r\n\r\n"); // not implemented
 			string response = Receive (ns, 512);
 			ns.Close ();
@@ -218,8 +225,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test6 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test6/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test6/");
+			NetworkStream ns = CreateNS (port);
 			 // not implemented! This is against the RFC. Should be a bad request/length required
 			Send (ns, "POST /test6/ HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: identity\r\n\r\n");
 			string response = Receive (ns, 512);
@@ -230,8 +238,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test7 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test7/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test7/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test7/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			HttpListenerContext ctx = _listener.GetContext ();
 			Send (ctx.Response.OutputStream, "%%%OK%%%");
@@ -245,8 +254,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test8 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test8/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test8/");
+			NetworkStream ns = CreateNS (port);
 			// Just like Test7, but 1.0
 			Send (ns, "POST /test8/ HTTP/1.0\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			HttpListenerContext ctx = _listener.GetContext ();
@@ -261,9 +271,10 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test9 ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// 1.0 + "Transfer-Encoding: chunked"
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test9/");
-			NetworkStream ns = CreateNS (9000);
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test9/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test9/ HTTP/1.0\r\nHost: 127.0.0.1\r\nTransfer-Encoding: chunked\r\n\r\n3\r\n123\r\n0\r\n\r\n");
 			bool timeout;
 			string response = ReceiveWithTimeout (ns, 512, 1000, out timeout);
@@ -275,9 +286,10 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test10 ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// Same as Test9, but now we shutdown the socket for sending.
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test10/");
-			MyNetworkStream ns = CreateNS (9000);
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test10/");
+			MyNetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test10/ HTTP/1.0\r\nHost: 127.0.0.1\r\nTransfer-Encoding: chunked\r\n\r\n3\r\n123\r\n0\r\n\r\n");
 			ns.GetSocket ().Shutdown (SocketShutdown.Send);
 			bool timeout;
@@ -290,9 +302,10 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test11 ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// 0.9
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test11/");
-			MyNetworkStream ns = CreateNS (9000);
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test11/");
+			MyNetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test11/ HTTP/0.9\r\nHost: 127.0.0.1\r\n\r\n123");
 			ns.GetSocket ().Shutdown (SocketShutdown.Send);
 			string input = Receive (ns, 512);
@@ -303,9 +316,10 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test12 ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// 0.9
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test12/");
-			MyNetworkStream ns = CreateNS (9000);
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test12/");
+			MyNetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test12/ HTTP/0.9\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			ns.GetSocket ().Shutdown (SocketShutdown.Send);
 			string input = Receive (ns, 512);
@@ -316,9 +330,10 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test13 ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// 0.9
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test13/");
-			MyNetworkStream ns = CreateNS (9000);
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test13/");
+			MyNetworkStream ns = CreateNS (port);
 			Send (ns, "GEt /test13/ HTTP/0.9\r\nHost: 127.0.0.1\r\n\r\n");
 			ns.GetSocket ().Shutdown (SocketShutdown.Send);
 			string input = Receive (ns, 512);
@@ -332,8 +347,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test14 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test14/");
-			MyNetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test14/");
+			MyNetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test14/ HTTP/1.0\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			HttpListenerContext c = _listener.GetContext ();
 			test14_request = c.Request;
@@ -367,9 +383,10 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test15 ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// 2 separate writes -> 2 packets. Body size > 8kB
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test15/");
-			MyNetworkStream ns = CreateNS (9000);
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test15/");
+			MyNetworkStream ns = CreateNS (port);
 			Send (ns, "POST /test15/ HTTP/1.0\r\nHost: 127.0.0.1\r\nContent-Length: 8888\r\n\r\n");
 			Thread.Sleep (800);
 			string data = new string ('a', 8888);
@@ -388,9 +405,10 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test16 ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			// 1 single write with headers + body (size > 8kB)
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test16/");
-			MyNetworkStream ns = CreateNS (9000);
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test16/");
+			MyNetworkStream ns = CreateNS (port);
 			StringBuilder sb = new StringBuilder ();
 			sb.Append ("POST /test16/ HTTP/1.0\r\nHost: 127.0.0.1\r\nContent-Length: 8888\r\n\r\n");
 			string eights = new string ('b', 8888);
@@ -411,8 +429,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test17 ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/test17/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/test17/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "RANDOM /test17/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			HttpListenerContext ctx = _listener.GetContext ();
 			Send (ctx.Response.OutputStream, "%%%OK%%%");
@@ -426,8 +445,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test_MultipleClosesOnOuputStreamAllowed ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/MultipleCloses/");
-			NetworkStream ns = CreateNS (9000);
+			var port = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + port + "/MultipleCloses/");
+			NetworkStream ns = CreateNS (port);
 			Send (ns, "GET /MultipleCloses/ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
 
 			HttpListenerContext ctx = _listener.GetContext ();
@@ -438,8 +458,8 @@ namespace MonoTests.System.Net {
 		}
 	
 		void SendCookie ()
-		{
-			NetworkStream ns = CreateNS (9000);
+		{		
+			NetworkStream ns = CreateNS (sendCookiePort);
 			Send (ns, "GET /SendCookie/ HTTP/1.1\r\nHost: 127.0.0.1\r\n"+
 				"Cookie:$Version=\"1\"; "+
 				"Cookie1=Value1; $Path=\"/\"; "+
@@ -455,7 +475,8 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void ReceiveCookiesFromClient ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/SendCookie/");
+			sendCookiePort = NetworkHelpers.FindFreePort ();			
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + sendCookiePort + "/SendCookie/");
 			Thread clientThread = new Thread (new ThreadStart (SendCookie));
 			clientThread.Start ();
 
@@ -486,10 +507,12 @@ namespace MonoTests.System.Net {
 
 		private object _lock = new Object();
 		private string cookieResponse;
+		private int receiveCookiePort;
+		private int sendCookiePort;		
 
 		void ReceiveCookie () {
 			lock (_lock) {
-				NetworkStream ns = CreateNS (9000);
+				NetworkStream ns = CreateNS (receiveCookiePort);
 				Send (ns, "GET /ReceiveCookie/ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
 				cookieResponse = Receive (ns, 512);
 			}
@@ -498,7 +521,8 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void SendCookiestoClient ()
 		{
-			_listener = CreateAndStartListener ("http://127.0.0.1:9000/ReceiveCookie/");
+			receiveCookiePort = NetworkHelpers.FindFreePort ();
+			_listener = CreateAndStartListener ("http://127.0.0.1:" + receiveCookiePort + "/ReceiveCookie/");
 			Thread clientThread = new Thread (new ThreadStart (ReceiveCookie));
 			clientThread.Start ();
 
@@ -548,6 +572,7 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void MultiResponses ()
 		{
+			echoServerPort = NetworkHelpers.FindFreePort ();
 			Thread srv = new Thread (new ThreadStart (EchoServer));
 			srv.Start ();
 			Thread.Sleep (200);
@@ -557,7 +582,7 @@ namespace MonoTests.System.Net {
 					"Client{0}", i);
 
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (
-					"http://localhost:8888/foobar/");
+					"http://localhost:" + echoServerPort + "/foobar/");
 				req.ServicePoint.Expect100Continue = false;
 				req.ServicePoint.UseNagleAlgorithm = false;
 				req.Method = "POST";
@@ -575,10 +600,11 @@ namespace MonoTests.System.Net {
 			srv.Join ();
 		}
 
+		int echoServerPort;
 		void EchoServer ()
 		{
 			_listener = new HttpListener ();
-			_listener.Prefixes.Add ("http://*:8888/foobar/");
+			_listener.Prefixes.Add ("http://*:" + echoServerPort + "/foobar/");
 			_listener.Start ();
 
 			manualReset = new ManualResetEvent (false);
@@ -613,11 +639,12 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void TestNonChunkedAsync ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:9123/");
+			var port = NetworkHelpers.FindFreePort ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:" + port + "/");
 
 			listener.BeginGetContext (callback, listener);
 			
-			HttpListener2Test.MyNetworkStream ns = HttpListener2Test.CreateNS (9123);
+			HttpListener2Test.MyNetworkStream ns = HttpListener2Test.CreateNS (port);
 			string message = "<script>\n"+
 				" <!-- register the blueprint for our show-headers service -->\n"+
 				" <action verb=\"POST\" path=\"/host/register\">\n" +
@@ -666,10 +693,11 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test_MultipleConnections ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:9000/multiple/");
+			var port = NetworkHelpers.FindFreePort ();			
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:" + port + "/multiple/");
 
 			// First one
-			NetworkStream ns = HttpListener2Test.CreateNS (9000);
+			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "POST /multiple/ HTTP/1.0\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			HttpListenerContext ctx = listener.GetContext ();
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
@@ -678,7 +706,7 @@ namespace MonoTests.System.Net {
 			ns.Close ();
 
 			// Second one
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "POST /multiple/ HTTP/1.0\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			ctx = listener.GetContext ();
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
@@ -697,11 +725,12 @@ namespace MonoTests.System.Net {
 		{
 			var wait = new ManualResetEvent (false);
 			var wait2 = new ManualResetEvent (false);
+			var port = NetworkHelpers.FindFreePort ();
 			
 			Thread t = new Thread (delegate (object a) {
 				wait.WaitOne ();
 
-				NetworkStream ns = HttpListener2Test.CreateNS (9145);
+				NetworkStream ns = HttpListener2Test.CreateNS (port);
 				HttpListener2Test.Send (ns, "GET http://www.google.com/ HTTP/1.1\r\nHost: www.google.com\r\nContent-Length: 3\r\n\r\n123456");
 
 				wait2.WaitOne ();
@@ -709,11 +738,11 @@ namespace MonoTests.System.Net {
 			});
 			t.Start ();
 				
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://*:9145/");
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://*:" + port + "/");
 			wait.Set ();
 			HttpListenerContext ctx = listener.GetContext ();
 			
-			Assert.AreEqual ("http://www.google.com:9145/", ctx.Request.Url.ToString ());
+			Assert.AreEqual ("http://www.google.com:" + port + "/", ctx.Request.Url.ToString ());
 			Assert.AreEqual ("http://www.google.com/", ctx.Request.RawUrl);
 			wait2.Set ();
 
@@ -723,12 +752,13 @@ namespace MonoTests.System.Net {
 		[Test] // bug #513849
 		public void ClosePort ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			var h = new HttpListener ();
-			h.Prefixes.Add ("http://127.0.0.1:30158/");
+			h.Prefixes.Add ("http://127.0.0.1:" + port + "/");
 			h.Start ();
 			h.BeginGetContext (null, null);
 			h.Stop ();
-			TcpListener t = new TcpListener (IPAddress.Parse ("127.0.0.1"), 30158);
+			TcpListener t = new TcpListener (IPAddress.Parse ("127.0.0.1"), port);
 			t.Start ();
 			t.Stop ();
 		}
@@ -754,7 +784,7 @@ namespace MonoTests.System.Net {
 				Assert.Ignore ("Hostname couldn't be resolved.");
 			}
 			
-			int port = 61234;
+			int port = NetworkHelpers.FindFreePort ();;
 			var h = new HttpListener ();
 			h.Prefixes.Add ("http://" + machineAddress [0] + ":" + port + "/");
 			h.Start ();
@@ -772,7 +802,7 @@ namespace MonoTests.System.Net {
 		public void BindToAllInterfaces ()
 		{
 			var h = new HttpListener ();
-			int port = 62234;
+			int port = NetworkHelpers.FindFreePort ();
 			h.Prefixes.Add ("http://*:" + port + "/");
 			h.Start ();
 			var c = new TcpClient ("localhost", port);
@@ -783,8 +813,9 @@ namespace MonoTests.System.Net {
 		[Test]
 		public void Test_EmptyLineAtStart ()
 		{
-			var listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:9124/");
-			var ns = HttpListener2Test.CreateNS (9124);
+			var port = NetworkHelpers.FindFreePort ();
+			var listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:" + port + "/");
+			var ns = HttpListener2Test.CreateNS (port);
 
 			HttpListener2Test.Send (ns, "\r\nGET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
 

--- a/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
@@ -35,6 +35,8 @@ using System.Text;
 
 using NUnit.Framework;
 
+using MonoTests.Helpers;
+
 namespace MonoTests.System.Net
 {
 	[TestFixture]
@@ -47,12 +49,12 @@ namespace MonoTests.System.Net
 			HttpListenerContext ctx;
 			HttpListenerRequest request;
 			NetworkStream ns;
-
+			var port = NetworkHelpers.FindFreePort ();
 			HttpListener listener = HttpListener2Test.CreateAndStartListener (
-				"http://127.0.0.1:9000/HasEntityBody/");
+				"http://127.0.0.1:" + port + "/HasEntityBody/");
 
 			// POST with non-zero Content-Lenth
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "POST /HasEntityBody/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -60,7 +62,7 @@ namespace MonoTests.System.Net
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
 
 			// POST with zero Content-Lenth
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "POST /HasEntityBody/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 0\r\n\r\n123");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -68,7 +70,7 @@ namespace MonoTests.System.Net
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
 
 			// POST with chunked encoding
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "POST /HasEntityBody HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -76,7 +78,7 @@ namespace MonoTests.System.Net
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
 
 			// GET with no Content-Length
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /HasEntityBody HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -84,7 +86,7 @@ namespace MonoTests.System.Net
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
 
 			// GET with non-zero Content-Length
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /HasEntityBody HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -92,7 +94,7 @@ namespace MonoTests.System.Net
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
 
 			// GET with zero Content-Length
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /HasEntityBody HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 0\r\n\r\n");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -100,7 +102,7 @@ namespace MonoTests.System.Net
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
 
 			// GET with chunked encoding
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /HasEntityBody HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -108,35 +110,35 @@ namespace MonoTests.System.Net
 			HttpListener2Test.Send (ctx.Response.OutputStream, "%%%OK%%%");
 
 			// PUT with non-zero Content-Lenth
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "PUT /HasEntityBody/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
 			Assert.IsTrue (request.HasEntityBody, "#H");
 
 			// PUT with zero Content-Lenth
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "PUT /HasEntityBody/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 0\r\n\r\n123");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
 			Assert.IsFalse (request.HasEntityBody, "#I");
 
 			// INVALID with non-zero Content-Lenth
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "INVALID /HasEntityBody/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
 			Assert.IsTrue (request.HasEntityBody, "#J");
 
 			// INVALID with zero Content-Lenth
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "INVALID /HasEntityBody/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 0\r\n\r\n123");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
 			Assert.IsFalse (request.HasEntityBody, "#K");
 
 			// INVALID with chunked encoding
-			ns = HttpListener2Test.CreateNS (9000);
+			ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "INVALID /HasEntityBody/ HTTP/1.1\r\nHost: 127.0.0.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
 			ctx = listener.GetContext ();
 			request = ctx.Request;
@@ -148,9 +150,10 @@ namespace MonoTests.System.Net
 		[Test]
 		public void HttpMethod ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			HttpListener listener = HttpListener2Test.CreateAndStartListener (
-				"http://127.0.0.1:9000/HttpMethod/");
-			NetworkStream ns = HttpListener2Test.CreateNS (9000);
+				"http://127.0.0.1:" + port + "/HttpMethod/");
+			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "pOsT /HttpMethod/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			HttpListenerContext ctx = listener.GetContext ();
 			HttpListenerRequest request = ctx.Request;
@@ -161,10 +164,11 @@ namespace MonoTests.System.Net
 		[Test]
 		public void HttpBasicAuthScheme ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://*:9000/authTest/", AuthenticationSchemes.Basic);
+			var port = NetworkHelpers.FindFreePort ();			
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://*:" + port + "/authTest/", AuthenticationSchemes.Basic);
 			//dummy-wait for context
 			listener.BeginGetContext (null, listener);
-			NetworkStream ns = HttpListener2Test.CreateNS (9000);
+			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /authTest/ HTTP/1.0\r\n\r\n");
 			String response = HttpListener2Test.Receive (ns, 512);
 			Assert.IsTrue (response.Contains ("WWW-Authenticate: Basic realm"), "#A");
@@ -175,9 +179,10 @@ namespace MonoTests.System.Net
 		[Test]
 		public void HttpRequestUriIsNotDecoded ()
 		{
+			var port = NetworkHelpers.FindFreePort ();
 			HttpListener listener = HttpListener2Test.CreateAndStartListener (
-				"http://127.0.0.1:9000/RequestUriDecodeTest/");
-			NetworkStream ns = HttpListener2Test.CreateNS (9000);
+				"http://127.0.0.1:" + port + "/RequestUriDecodeTest/");
+			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /RequestUriDecodeTest/?a=b&c=d%26e HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
 			HttpListenerContext ctx = listener.GetContext ();
 			HttpListenerRequest request = ctx.Request;
@@ -188,7 +193,7 @@ namespace MonoTests.System.Net
 		[Test] // #29927
 		public void HttpRequestUriUnescape ()
 		{
-			var prefix = "http://localhost:12345/";
+			var prefix = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
 			var key = "Product/1";
 
 			var expectedUrl = prefix + key + "/";

--- a/mcs/class/System/Test/System.Net/HttpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerTest.cs
@@ -352,7 +352,7 @@ namespace MonoTests.System.Net {
 		public void CloseWhileBegin ()
 		{
 			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:9001/closewhilebegin/");
+			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/closewhilebegin/");
 			listener.Start ();
 			CallMe cm = new CallMe ();
 			listener.BeginGetContext (cm.Callback, listener);
@@ -368,7 +368,7 @@ namespace MonoTests.System.Net {
 		public void AbortWhileBegin ()
 		{
 			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:9001/abortwhilebegin/");
+			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/abortwhilebegin/");
 			listener.Start ();
 			CallMe cm = new CallMe ();
 			listener.BeginGetContext (cm.Callback, listener);
@@ -390,7 +390,7 @@ namespace MonoTests.System.Net {
 			//   at MonoTests.System.Net.HttpListenerTest.CloseWhileGet()
 
 			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:9001/closewhileget/");
+			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/closewhileget/");
 			listener.Start ();
 			RunMe rm = new RunMe (1000, new ThreadStart (listener.Close), new object [0]);
 			rm.Start ();
@@ -407,7 +407,7 @@ namespace MonoTests.System.Net {
 			//   at MonoTests.System.Net.HttpListenerTest.CloseWhileGet()
 
 			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:9001/abortwhileget/");
+			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/abortwhileget/");
 			listener.Start ();
 			RunMe rm = new RunMe (1000, new ThreadStart (listener.Abort), new object [0]);
 			rm.Start ();

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -958,7 +958,7 @@ namespace MonoTests.System.Net
 		[Ignore ("This does not timeout any more. That's how MS works when reading small responses")]
 		public void ReadTimeout ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8764);
+			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + localEP.ToString () + "/original/";
 
 			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
@@ -988,7 +988,7 @@ namespace MonoTests.System.Net
 		[Test] // bug #324300
 		public void AllowAutoRedirect ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8765);
+			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + localEP.ToString () + "/original/";
 
 			// allow autoredirect
@@ -1034,7 +1034,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void PostAndRedirect_NoCL ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8769);
+			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + localEP.ToString () + "/original/";
 
 			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
@@ -1062,7 +1062,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void PostAndRedirect_CL ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8770);
+			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + localEP.ToString () + "/original/";
 
 			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
@@ -1090,7 +1090,7 @@ namespace MonoTests.System.Net
 		[Test]
 		public void PostAnd401 ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8771);
+			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + localEP.ToString () + "/original/";
 
 			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
@@ -1119,7 +1119,7 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void InternalServerError ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8766);
+			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + localEP.ToString () + "/original/";
 
 			// POST
@@ -1176,7 +1176,7 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")] // #B3 fails; we get a SocketException: An existing connection was forcibly closed by the remote host
 		public void NoContentLength ()
 		{
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, 8767);
+			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + localEP.ToString () + "/original/";
 
 			// POST
@@ -1417,7 +1417,7 @@ namespace MonoTests.System.Net
 		[Test] // 1st possible case of https://bugzilla.novell.com/show_bug.cgi?id=MONO74177
 		public void TestTimeoutPropertyWithServerThatExistsAndRespondsButTooLate ()
 		{
-			var ep = new IPEndPoint (IPAddress.Loopback, 8123);
+			var ep = NetworkHelpers.LocalEphemeralEndPoint ();
 			string url = "http://" + ep + "/foobar/";
 
 			using (var responder = new SocketResponder (ep, TimeOutHandler))

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -1853,7 +1853,8 @@ namespace MonoTests.System.Net
 		[Category ("AndroidNotWorking")] // Test suite hangs if the tests runs as part of the entire BCL suite. Works when only this fixture is ran
 		public void UploadFileAsyncContentType ()
 		{
-			var serverUri = "http://localhost:13370/";
+			var port = NetworkHelpers.FindFreePort ();
+			var serverUri = "http://localhost:" + port + "/";
 			var filename = Path.GetTempFileName ();
 
 			HttpListener listener = new HttpListener ();


### PR DESCRIPTION
A test failed on Jenkins today with "address already in use".
Opportunistically replaced a few more hardcoded test ports to avoid failures in the future.

@monojenkins merge