### PR TITLE
[monodoc] HTML now renders member and type links with generic parameters

### DIFF
--- a/mcs/class/monodoc/Resources/mdoc-html-utils.xsl
+++ b/mcs/class/monodoc/Resources/mdoc-html-utils.xsl
@@ -208,7 +208,7 @@
 									<xsl:with-param name="TypeNamespace" select="$TypeNamespace"/>
 								</xsl:call-template>
 
-								<xsl:if test="not(position()=last())">, </xsl:if>
+								<xsl:if test="not(position()=last())">,</xsl:if>
 							</xsl:for-each>
 							
 							<xsl:value-of select="')'"/>
@@ -2336,27 +2336,20 @@
 				<xsl:if test="contains($membername, '&lt;')">
 					<xsl:value-of select="substring-before ($membername, '&lt;')" />
 				</xsl:if>
-				<xsl:text>``</xsl:text>
-				<xsl:value-of select="$numgenargs" />
+				<xsl:value-of select="'{'"/>
+					<xsl:for-each select="TypeParameters/TypeParameter">
+						<xsl:if test="not(position()=1)">, </xsl:if>
+						<xsl:value-of select="@Name"/>
+					</xsl:for-each>
+				<xsl:value-of select="'}'"/>
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
-
+    
 	<xsl:template name="GetEscapedTypeName">
 		<xsl:param name="typename" />
-		<xsl:variable name="base" select="substring-before ($typename, '&lt;')" />
-
-		<xsl:choose>
-			<xsl:when test="$base != ''">
-				<xsl:value-of select="translate ($base, '+', '.')" />
-				<xsl:text>`</xsl:text>
-				<xsl:call-template name="GetGenericArgumentCount">
-					<xsl:with-param name="arglist" select="substring-after ($typename, '&lt;')" />
-					<xsl:with-param name="count">1</xsl:with-param>
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise><xsl:value-of select="translate ($typename, '+', '.')" /></xsl:otherwise>
-		</xsl:choose>
+		<!-- no longer escaping as it was causing invalid links to be generated -->
+		<xsl:value-of select="$typename" />
 	</xsl:template>
 
 	<xsl:template name="GetGenericArgumentCount">
@@ -2632,52 +2625,16 @@ SkipGenericArgument: invalid type substring '<xsl:value-of select="$s" />'
 			</xsl:call-template>
 		</xsl:variable>
 
-		<xsl:variable name="gen-type">
-			<xsl:call-template name="GetEscapedParameter">
-				<xsl:with-param name="orig-parameter-type" select="$ptype" />
-				<xsl:with-param name="parameter-type">
-					<xsl:variable name="nested">
-						<xsl:call-template name="GetEscapedParameter">
-							<xsl:with-param name="orig-parameter-type" select="$ptype" />
-							<xsl:with-param name="parameter-type" select="$ptype" />
-							<xsl:with-param name="parameter-types" select="$type/Docs/typeparam" />
-							<xsl:with-param name="escape" select="'`'" />
-							<xsl:with-param name="index" select="1" />
-						</xsl:call-template>
-					</xsl:variable>
-					<xsl:choose>
-						<xsl:when test="$nested != ''">
-							<xsl:value-of select="$nested" />
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:value-of select="$ptype" />
-						</xsl:otherwise>
-					</xsl:choose>
-				</xsl:with-param>
-				<xsl:with-param name="parameter-types" select="$member/Docs/typeparam" />
-				<xsl:with-param name="escape" select="'``'" />
-				<xsl:with-param name="index" select="1" />
-			</xsl:call-template>
-		</xsl:variable>
-
 		<!-- the actual parameter type -->
 		<xsl:variable name="parameter-type">
-			<xsl:choose>
-				<xsl:when test="$gen-type != ''">
-					<xsl:value-of select="$gen-type" />
-					<xsl:value-of select="$pmodifier" />
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="concat($ptype, $pmodifier)" />
-				</xsl:otherwise>
-			</xsl:choose>
+			<xsl:value-of select="concat($ptype, $pmodifier)" />
 		</xsl:variable>
 
 		<!-- s/</{/g; s/>/}/g; so that less escaping is needed. -->
 		<xsl:call-template name="Replace">
 			<xsl:with-param name="s">
 				<xsl:call-template name="Replace">
-					<xsl:with-param name="s" select="translate ($parameter-type, '+', '.')" />
+					<xsl:with-param name="s" select="$parameter-type" />
 					<xsl:with-param name="from">&gt;</xsl:with-param>
 					<xsl:with-param name="to">}</xsl:with-param>
 				</xsl:call-template>

--- a/mcs/class/monodoc/Resources/mono-ecma-impl.xsl
+++ b/mcs/class/monodoc/Resources/mono-ecma-impl.xsl
@@ -470,8 +470,14 @@
 	<xsl:template name="GetLinkTarget">
 		<xsl:param name="type" />
 		<xsl:param name="cref" />
-
-		<xsl:value-of select="$cref" />
+		<xsl:choose>
+			<xsl:when test="string($cref) = ''">
+				<xsl:value-of select="$type" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$cref" />
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:template>
 
 	<xsl:template name="namespacetypes">

--- a/mcs/tools/mdoc/Resources/stylesheet.xsl
+++ b/mcs/tools/mdoc/Resources/stylesheet.xsl
@@ -205,9 +205,14 @@
 		<xsl:param name="cref" />
 		<xsl:param name="xmltarget" select="false()"/>
 		<!-- Search for type in the index.xml file. -->
+		<xsl:variable name="filesystemname">
+			<xsl:call-template name="GetFileSystemTypeName">
+				<xsl:with-param name="typename" select="$type" />
+			</xsl:call-template>
+		</xsl:variable>
 		<xsl:variable name="typeentry-rtf">
 			<xsl:call-template name="FindTypeInIndex">
-				<xsl:with-param name="type" select="$type" />
+				<xsl:with-param name="type" select="$filesystemname" />
 			</xsl:call-template>
 		</xsl:variable>
 		<xsl:variable name="typeentry" select="msxsl:node-set($typeentry-rtf)" />
@@ -257,6 +262,23 @@
 				<xsl:value-of select="$cref" />
 			</xsl:when>
 			<!--<xsl:otherwise>javascript:alert("Documentation not found for <xsl:value-of select="$type"/>.")</xsl:otherwise>-->
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template name="GetFileSystemTypeName">
+		<xsl:param name="typename" />
+		<xsl:variable name="base" select="substring-before ($typename, '&lt;')" />
+
+		<xsl:choose>
+			<xsl:when test="$base != ''">
+				<xsl:value-of select="translate ($base, '+', '.')" />
+				<xsl:text>`</xsl:text>
+				<xsl:call-template name="GetGenericArgumentCount">
+					<xsl:with-param name="arglist" select="substring-after ($typename, '&lt;')" />
+					<xsl:with-param name="count">1</xsl:with-param>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:otherwise><xsl:value-of select="translate ($typename, '+', '.')" /></xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
 

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/Extensions.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/Extensions.html
@@ -235,7 +235,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String)">Bar&lt;T&gt;</a>
+                    <a href="#M:Mono.DocTest.Generic.Extensions.Bar{T}(Mono.DocTest.Generic.IFoo{T},System.String)">Bar&lt;T&gt;</a>
                   </b>(<i>this</i> <a href="../Mono.DocTest.Generic/IFoo`1.html">IFoo&lt;T&gt;</a>, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.String">string</a>)<blockquote><a href="../Mono.DocTest.Generic/IFoo`1.html">Mono.DocTest.Generic.IFoo`1</a> extension method</blockquote></td>
               </tr>
               <tr valign="top">
@@ -244,8 +244,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})">ForEach&lt;T&gt;</a>
-                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a>, <a href="../System/Action`1.html">Action&lt;T&gt;</a>)<blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable`1</a> extension method</blockquote></td>
+                    <a href="#M:Mono.DocTest.Generic.Extensions.ForEach{T}(System.Collections.Generic.IEnumerable{T},System.Action{T})">ForEach&lt;T&gt;</a>
+                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a>, <a href="../System/Action`1.html">Action&lt;T&gt;</a>)<blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable`1</a> extension method</blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -254,7 +254,7 @@
                 <td colspan="2">
                   <b>
                     <a href="#M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32})">ToDouble</a>
-                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;double&gt;</a></nobr><blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a> 
+                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Double&gt;">IEnumerable&lt;double&gt;</a></nobr><blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a> 
                extension method.
              </blockquote></td>
               </tr>
@@ -264,7 +264,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0)">ToDouble&lt;T&gt;</a>
+                    <a href="#M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T)">ToDouble&lt;T&gt;</a>
                   </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a></nobr><blockquote><a href="../Mono.DocTest.Generic/IFoo`1.html">Mono.DocTest.Generic.IFoo`1</a> extension method.
              </blockquote></td>
               </tr>
@@ -274,8 +274,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                    <a href="#M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T)">ToEnumerable&lt;T&gt;</a>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
@@ -285,14 +285,14 @@
     <div class="Members" id="T:Mono.DocTest.Generic.Extensions:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String)">Bar&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String):member">
+        <h3 id="M:Mono.DocTest.Generic.Extensions.Bar{T}(Mono.DocTest.Generic.IFoo{T},System.String)">Bar&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.Extensions.Bar{T}(Mono.DocTest.Generic.IFoo{T},System.String):member">
           <div class="msummary">
             <a href="../Mono.DocTest.Generic/IFoo`1.html">Mono.DocTest.Generic.IFoo`1</a> extension method</div>
           <h2>Syntax</h2>
           <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Bar&lt;T&gt;</b> (<i>this</i> <a href="../Mono.DocTest.Generic/IFoo`1.html">IFoo&lt;T&gt;</a> self, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.String">string</a> s)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar{T}(Mono.DocTest.Generic.IFoo{T},System.String):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -303,7 +303,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar{T}(Mono.DocTest.Generic.IFoo{T},System.String):Parameters">
             <dl>
               <dt>
                 <i>self</i>
@@ -320,22 +320,22 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar{T}(Mono.DocTest.Generic.IFoo{T},System.String):Remarks">
             <tt>M:Mono.DocTest.Generic.Extensions.Bar``1</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.Bar{T}(Mono.DocTest.Generic.IFoo{T},System.String):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})">ForEach&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0}):member">
+        <h3 id="M:Mono.DocTest.Generic.Extensions.ForEach{T}(System.Collections.Generic.IEnumerable{T},System.Action{T})">ForEach&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.Extensions.ForEach{T}(System.Collections.Generic.IEnumerable{T},System.Action{T}):member">
           <div class="msummary">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable`1</a> extension method</div>
           <h2>Syntax</h2>
-          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>ForEach&lt;T&gt;</b> (<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a> self, <a href="../System/Action`1.html">Action&lt;T&gt;</a> a)</div>
+          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>ForEach&lt;T&gt;</b> (<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a> self, <a href="../System/Action`1.html">Action&lt;T&gt;</a> a)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0}):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach{T}(System.Collections.Generic.IEnumerable{T},System.Action{T}):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -346,7 +346,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0}):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach{T}(System.Collections.Generic.IEnumerable{T},System.Action{T}):Parameters">
             <dl>
               <dt>
                 <i>self</i>
@@ -363,22 +363,22 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0}):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach{T}(System.Collections.Generic.IEnumerable{T},System.Action{T}):Remarks">
             <tt>M:Mono.DocTest.Generic.Extensions.ForEach``1</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0}):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ForEach{T}(System.Collections.Generic.IEnumerable{T},System.Action{T}):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
         <h3 id="M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32})">ToDouble Method</h3>
         <blockquote id="M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32}):member">
           <div class="msummary">
-            <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a> 
+            <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a> 
                extension method.
              </div>
           <h2>Syntax</h2>
-          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;double&gt;</a> <b>ToDouble</b> (<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a> list)</div>
+          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Double&gt;">IEnumerable&lt;double&gt;</a> <b>ToDouble</b> (<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a> list)</div>
           <h4 class="Subsection">Parameters</h4>
           <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32}):Parameters">
             <dl>
@@ -403,15 +403,15 @@
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0)">ToDouble&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0):member">
+        <h3 id="M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T)">ToDouble&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T):member">
           <div class="msummary">
             <a href="../Mono.DocTest.Generic/IFoo`1.html">Mono.DocTest.Generic.IFoo`1</a> extension method.
              </div>
           <h2>Syntax</h2>
           <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>ToDouble&lt;T&gt;</b> (<i>this</i> <i title="To be added.">T</i> val)<br /> where T : <a href="../Mono.DocTest.Generic/IFoo`1.html">Mono.DocTest.Generic.IFoo&lt;T&gt;</a></div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -422,7 +422,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T):Parameters">
             <dl>
               <dt>
                 <i>val</i>
@@ -433,26 +433,26 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0):Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T):Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T):Remarks">
             <tt>M:Mono.DocTest.Generic.Extensions.ToDouble</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToDouble{T}(T):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0):member">
+        <h3 id="M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T)">ToEnumerable&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T):member">
           <div class="msummary">
             <tt>System.Object</tt> extension method</div>
           <h2>Syntax</h2>
-          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a> <b>ToEnumerable&lt;T&gt;</b> (<i>this</i> <i title="To be added.">T</i> self)</div>
+          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a> <b>ToEnumerable&lt;T&gt;</b> (<i>this</i> <i title="To be added.">T</i> self)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -463,7 +463,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T):Parameters">
             <dl>
               <dt>
                 <i>self</i>
@@ -474,15 +474,15 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0):Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T):Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T):Remarks">
             <tt>M:Mono.DocTest.Generic.Extensions.ToEnumerable``1</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.Extensions.ToEnumerable{T}(T):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/Func`2.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/Func`2.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.Func`2">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.Func`2:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.Func`2:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.Func`2:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.Func`2">Func&lt;TArg,TRet&gt; Generic Delegate</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.Func`2:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;">Func&lt;TArg,TRet&gt; Generic Delegate</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.Func`2:Signature">[Mono.DocTest.Doc("method")]<br />[return:Mono.DocTest.Doc("return", Field=false)]<br />public delegate <i title="return type, with attributes!">TRet</i> <b>Func&lt;[Mono.DocTest.Doc("arg!")] TArg, [Mono.DocTest.Doc("ret!")] TRet&gt;</b> ([Mono.DocTest.Doc("arg-actual")] <i title="argument type, with attributes!">TArg</i> a)<br /> where TArg : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Exception">Exception</a></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Signature">[Mono.DocTest.Doc("method")]<br />[return:Mono.DocTest.Doc("return", Field=false)]<br />public delegate <i title="return type, with attributes!">TRet</i> <b>Func&lt;[Mono.DocTest.Doc("arg!")] TArg, [Mono.DocTest.Doc("ret!")] TRet&gt;</b> ([Mono.DocTest.Doc("arg-actual")] <i title="argument type, with attributes!">TArg</i> a)<br /> where TArg : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Exception">Exception</a></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.Func`2:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.Func`2:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>TArg</i>
@@ -228,7 +228,7 @@
         </dl>
       </blockquote>
       <h4 class="Subsection">Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.Func`2:Docs:Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Docs:Parameters">
         <dl>
           <dt>
             <i>a</i>
@@ -239,17 +239,17 @@
         </dl>
       </blockquote>
       <h4 class="Subsection">Returns</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.Func`2:Docs:Returns">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Docs:Returns">
         <span class="NotEntered">Documentation for this section has not yet been entered.</span>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.Func`2:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Docs:Remarks">
         <tt>T:Mono.DocTest.Generic.Func`2</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.Func`2:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.Func`2:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;:Members">
     </div>
     <hr size="1" />
     <div class="Copyright">

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+FooEventArgs.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+FooEventArgs.html
@@ -190,34 +190,34 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs">GenericBase&lt;U&gt;.FooEventArgs  Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs">GenericBase&lt;U&gt;.FooEventArgs  Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Signature">public class  <b>GenericBase&lt;U&gt;.FooEventArgs</b> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.EventArgs">EventArgs</a></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Signature">public class  <b>GenericBase&lt;U&gt;.FooEventArgs</b> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.EventArgs">EventArgs</a></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Docs:Remarks">T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs</div>
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Docs:Remarks">T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -237,7 +237,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Generic.GenericBase`1.FooEventArgs()">GenericBase</a>
+                      <a href="#C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs()">GenericBase</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -258,29 +258,29 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Generic.GenericBase`1.FooEventArgs()">GenericBase Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Generic.GenericBase`1.FooEventArgs():member">
+        <h3 id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs()">GenericBase Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>GenericBase</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase`1.FooEventArgs():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase`1.FooEventArgs():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.html
@@ -190,34 +190,34 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator">GenericBase&lt;U&gt;.NestedCollection.Enumerator  Struct</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">GenericBase&lt;U&gt;.NestedCollection.Enumerator  Struct</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Signature">protected struct  <b>GenericBase&lt;U&gt;.NestedCollection.Enumerator</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Signature">protected struct  <b>GenericBase&lt;U&gt;.NestedCollection.Enumerator</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Docs:Remarks">T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator</div>
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Docs:Remarks">T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -236,14 +236,14 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
       </div>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection.html
@@ -190,34 +190,34 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection">GenericBase&lt;U&gt;.NestedCollection  Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection">GenericBase&lt;U&gt;.NestedCollection  Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Signature">public class  <b>GenericBase&lt;U&gt;.NestedCollection</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Signature">public class  <b>GenericBase&lt;U&gt;.NestedCollection</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Docs:Remarks">T:Mono.DocTest.Generic.GenericBase`1.NestedCollection</div>
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Docs:Remarks">T:Mono.DocTest.Generic.GenericBase`1.NestedCollection</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -237,7 +237,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Generic.GenericBase`1.NestedCollection()">GenericBase</a>
+                      <a href="#C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection()">GenericBase</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -258,29 +258,29 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Generic.GenericBase`1.NestedCollection()">GenericBase Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Generic.GenericBase`1.NestedCollection():member">
+        <h3 id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection()">GenericBase Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>GenericBase</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase`1.NestedCollection():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase`1.NestedCollection():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.GenericBase`1:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase`1">GenericBase&lt;U&gt; Generic Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase`1:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;">GenericBase&lt;U&gt; Generic Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1:Signature">public class  <b>GenericBase&lt;U&gt;</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Signature">public class  <b>GenericBase&lt;U&gt;</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase`1:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.GenericBase`1:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>U</i>
@@ -224,10 +224,10 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Docs:Remarks">
         <tt>T:Mono.DocTest.Generic.GenericBase`1</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase`1:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -247,7 +247,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Generic.GenericBase`1()">GenericBase</a>
+                      <a href="#C:Mono.DocTest.Generic.GenericBase&lt;U&gt;()">GenericBase</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -267,7 +267,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#F:Mono.DocTest.Generic.GenericBase`1.ConstField1">ConstField1</a>
+                    <a href="#F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ConstField1">ConstField1</a>
                   </b>
                 </td>
                 <td>
@@ -281,7 +281,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#F:Mono.DocTest.Generic.GenericBase`1.StaticField1">StaticField1</a>
+                    <a href="#F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.StaticField1">StaticField1</a>
                   </b>
                 </td>
                 <td>
@@ -303,7 +303,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0)">BaseMethod&lt;S&gt;</a>
+                    <a href="#M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S)">BaseMethod&lt;S&gt;</a>
                   </b>(<i title="Insert more text here.">S</i>)<nobr> : <i title="Insert text here.">U</i></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -320,7 +320,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#E:Mono.DocTest.Generic.GenericBase`1.ItemChanged">ItemChanged</a>
+                    <a href="#E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged">ItemChanged</a>
                   </b>
                 </td>
                 <td>
@@ -334,7 +334,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#E:Mono.DocTest.Generic.GenericBase`1.MyEvent">MyEvent</a>
+                    <a href="#E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent">MyEvent</a>
                   </b>
                 </td>
                 <td>
@@ -354,7 +354,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0">Conversion to U</a>
+                    <a href="#M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.op_Explicit(Mono.DocTest.Generic.GenericBase{U})~U">Conversion to U</a>
                   </b>(Explicit)</td>
                 <td>
                   <span class="NotEntered">Documentation for this section has not yet been entered.</span>
@@ -374,41 +374,41 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase`1:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.GenericBase&lt;U&gt;:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Generic.GenericBase`1()">GenericBase Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Generic.GenericBase`1():member">
+        <h3 id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;()">GenericBase Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>GenericBase</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase`1():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase`1():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.GenericBase&lt;U&gt;():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0)">BaseMethod&lt;S&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0):member">
+        <h3 id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S)">BaseMethod&lt;S&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <i title="Insert text here.">U</i> <b>BaseMethod&lt;[Mono.DocTest.Doc("S")] S&gt;</b> (<i title="Insert more text here.">S</i> genericParameter)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S):Type Parameters">
             <dl>
               <dt>
                 <i>S</i>
@@ -417,7 +417,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S):Parameters">
             <dl>
               <dt>
                 <i>genericParameter</i>
@@ -426,40 +426,40 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0):Returns">The default value.</blockquote>
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S):Returns">The default value.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S):Remarks">
             <tt>M:Mono.DocTest.GenericBase`1.BaseMethod``1(``0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="F:Mono.DocTest.Generic.GenericBase`1.ConstField1">ConstField1 Field</h3>
-        <blockquote id="F:Mono.DocTest.Generic.GenericBase`1.ConstField1:member">
+        <h3 id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ConstField1">ConstField1 Field</h3>
+        <blockquote id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ConstField1:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public const <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> <b>ConstField1</b> </div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase`1.ConstField1:Remarks">
+          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ConstField1:Remarks">
             <tt>F:Mono.DocTest.GenericBase`1.ConstField1</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase`1.ConstField1:Version Information">
+          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ConstField1:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="E:Mono.DocTest.Generic.GenericBase`1.ItemChanged">ItemChanged Event</h3>
-        <blockquote id="E:Mono.DocTest.Generic.GenericBase`1.ItemChanged:member">
+        <h3 id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged">ItemChanged Event</h3>
+        <blockquote id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Action`2">Action&lt;MyList&lt;U&gt;, MyList&lt;U&gt;.Helper&lt;U, U&gt;&gt;</a> <b>ItemChanged</b> </div>
+          <div class="Signature">public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Action&lt;Mono.DocTest.Generic.MyList&lt;U&gt;,Mono.DocTest.Generic.MyList&lt;U&gt;+Helper&lt;U,U&gt;&gt;">Action&lt;MyList&lt;U&gt;, MyList&lt;U&gt;.Helper&lt;U, U&gt;&gt;</a> <b>ItemChanged</b> </div>
           <h4 class="Subsection">Exceptions</h4>
-          <blockquote class="SubsectionBox" id="E:Mono.DocTest.Generic.GenericBase`1.ItemChanged:Exceptions">
+          <blockquote class="SubsectionBox" id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged:Exceptions">
             <table class="TypeDocumentation">
               <tr>
                 <th>Type</th>
@@ -548,21 +548,21 @@
             </table>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase`1.ItemChanged:Remarks">E:Mono.DocTest.Generic.GenericBase`1.ItemChanged</div>
+          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged:Remarks">E:Mono.DocTest.Generic.GenericBase`1.ItemChanged</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase`1.ItemChanged:Version Information">
+          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="E:Mono.DocTest.Generic.GenericBase`1.MyEvent">MyEvent Event</h3>
-        <blockquote id="E:Mono.DocTest.Generic.GenericBase`1.MyEvent:member">
+        <h3 id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent">MyEvent Event</h3>
+        <blockquote id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.EventHandler`1">EventHandler&lt;GenericBase&lt;U&gt;.FooEventArgs&gt;</a> <b>MyEvent</b> </div>
+          <div class="Signature">public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.EventHandler&lt;Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs&gt;">EventHandler&lt;GenericBase&lt;U&gt;.FooEventArgs&gt;</a> <b>MyEvent</b> </div>
           <h4 class="Subsection">Exceptions</h4>
-          <blockquote class="SubsectionBox" id="E:Mono.DocTest.Generic.GenericBase`1.MyEvent:Exceptions">
+          <blockquote class="SubsectionBox" id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent:Exceptions">
             <table class="TypeDocumentation">
               <tr>
                 <th>Type</th>
@@ -651,21 +651,21 @@
             </table>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase`1.MyEvent:Remarks">E:Mono.DocTest.Generic.GenericBase`1.MyEvent</div>
+          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent:Remarks">E:Mono.DocTest.Generic.GenericBase`1.MyEvent</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase`1.MyEvent:Version Information">
+          <div class="SectionBox" id="E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0">Conversion Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0:member">
+        <h3 id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.op_Explicit(Mono.DocTest.Generic.GenericBase{U})~U">Conversion Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.op_Explicit(Mono.DocTest.Generic.GenericBase{U})~U:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public static explicit operator <i title="Insert text here.">U</i> (<a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a> list)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0:Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.op_Explicit(Mono.DocTest.Generic.GenericBase{U})~U:Parameters">
             <dl>
               <dt>
                 <i>list</i>
@@ -674,29 +674,29 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0:Returns">The default value for <i>U</i>.</blockquote>
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.op_Explicit(Mono.DocTest.Generic.GenericBase{U})~U:Returns">The default value for <i>U</i>.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0:Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.op_Explicit(Mono.DocTest.Generic.GenericBase{U})~U:Remarks">
             <tt>M:Mono.DocTest.GenericBase`1.op_Explicit(Mono.DocTest.GenericBase{`0})~`0</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0:Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.op_Explicit(Mono.DocTest.Generic.GenericBase{U})~U:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="F:Mono.DocTest.Generic.GenericBase`1.StaticField1">StaticField1 Field</h3>
-        <blockquote id="F:Mono.DocTest.Generic.GenericBase`1.StaticField1:member">
+        <h3 id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.StaticField1">StaticField1 Field</h3>
+        <blockquote id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.StaticField1:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public static readonly <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a> <b>StaticField1</b> </div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase`1.StaticField1:Remarks">
+          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.StaticField1:Remarks">
             <tt>F:Mono.DocTest.GenericBase`1.StaticField1</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase`1.StaticField1:Version Information">
+          <div class="SectionBox" id="F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.StaticField1:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/IFoo`1.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/IFoo`1.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.IFoo`1">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.IFoo&lt;T&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.IFoo`1:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.IFoo`1:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.IFoo`1:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.IFoo`1">IFoo&lt;T&gt; Generic Interface</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.IFoo`1:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;">IFoo&lt;T&gt; Generic Interface</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.IFoo`1:Signature">public interface  <b>IFoo&lt;T&gt;</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Signature">public interface  <b>IFoo&lt;T&gt;</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.IFoo`1:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.IFoo`1:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>T</i>
@@ -224,10 +224,10 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.IFoo`1:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Docs:Remarks">
         <tt>T:Mono.DocTest.IFoo`1</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.IFoo`1:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -242,7 +242,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0)">Method&lt;U&gt;</a>
+                    <a href="#M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U)">Method&lt;U&gt;</a>
                   </b>(<i title="T generic param">T</i>, <i title="U generic param">U</i>)<nobr> : <i title="T generic param">T</i></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -278,25 +278,25 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.IFoo`1:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.IFoo&lt;T&gt;:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0)">Method&lt;U&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0):member">
+        <h3 id="M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U)">Method&lt;U&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <i title="T generic param">T</i> <b>Method&lt;U&gt;</b> (<i title="T generic param">T</i> t, <i title="U generic param">U</i> u)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U):Type Parameters">
             <dl>
               <dt>
                 <i>U</i>
@@ -305,7 +305,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U):Parameters">
             <dl>
               <dt>
                 <i>t</i>
@@ -322,14 +322,14 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0):Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U):Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U):Remarks">
             <tt>T:Mono.DocTest.IFoo`1.Method``1(`0,``0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.IFoo&lt;T&gt;.Method{U}(T,U):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`1+Helper`2.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`1+Helper`2.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1.Helper`2">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1.Helper`2:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1.Helper`2:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1.Helper`2:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList`1.Helper`2">MyList&lt;T&gt;.Helper&lt;U,V&gt; Generic Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.MyList`1.Helper`2:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;">MyList&lt;T&gt;.Helper&lt;U,V&gt; Generic Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.MyList`1.Helper`2:Signature">public class  <b>MyList&lt;T, U, V&gt;</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Signature">public class  <b>MyList&lt;T, U, V&gt;</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList`1.Helper`2:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList`1.Helper`2:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>U</i>
@@ -228,10 +228,10 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1.Helper`2:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Docs:Remarks">
         <tt>T:Mono.DocTest.MyList`1.Helper`2</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1.Helper`2:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -251,7 +251,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Generic.MyList`1.Helper`2()">MyList</a>
+                      <a href="#C:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;()">MyList</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -272,7 +272,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(T,`0,`1)">UseT</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;.UseT(T,U,V)">UseT</a>
                   </b>(<i title="">T</i>, <i title="Seriously!">U</i>, <i title="Too many docs!">V</i>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -289,41 +289,41 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.MyList`1.Helper`2:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Generic.MyList`1.Helper`2()">MyList Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Generic.MyList`1.Helper`2():member">
+        <h3 id="C:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;()">MyList Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>MyList</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList`1.Helper`2():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList`1.Helper`2():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(T,`0,`1)">UseT Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(T,`0,`1):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;.UseT(T,U,V)">UseT Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;.UseT(T,U,V):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>UseT</b> (<i title="">T</i> a, <i title="Seriously!">U</i> b, <i title="Too many docs!">V</i> c)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(T,`0,`1):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;.UseT(T,U,V):Parameters">
             <dl>
               <dt>
                 <i>a</i>
@@ -340,10 +340,10 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(T,`0,`1):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;.UseT(T,U,V):Remarks">
             <tt>M:Mono.DocTest.MyList`1.Helper`2.UseT(`0,`1,`2)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(T,`0,`1):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;.UseT(T,U,V):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`1.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`1.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`1:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;T&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList`1">MyList&lt;T&gt; Generic Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.MyList`1:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;">MyList&lt;T&gt; Generic Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.MyList`1:Signature">public class  <b>MyList&lt;[Mono.DocTest.Doc("Type Parameter!")] T&gt;</b> : <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;T&gt;</a>,	<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;Int32[]&gt;</a></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;:Signature">public class  <b>MyList&lt;[Mono.DocTest.Doc("Type Parameter!")] T&gt;</b> : <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;T&gt;</a>,	<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32[]&gt;">IEnumerable&lt;Int32[]&gt;</a></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList`1:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList`1:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>T</i>
@@ -224,10 +224,10 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;:Docs:Remarks">
         <tt>T:Mono.DocTest.Generic.MyList`1</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -247,7 +247,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Generic.MyList`1()">MyList</a>
+                      <a href="#C:Mono.DocTest.Generic.MyList&lt;T&gt;()">MyList</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -267,7 +267,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#F:Mono.DocTest.Generic.GenericBase`1.ConstField1">ConstField1</a>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ConstField1">ConstField1</a>
                   </b>
                 </td>
                 <td>
@@ -289,7 +289,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0)">BaseMethod&lt;S&gt;</a>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S)">BaseMethod&lt;S&gt;</a>
                   </b>(<i title="Insert more text here.">S</i>)<nobr> : <i title="I'm Dying Here!">T</i></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span> (<i>Inherited from <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a>.</i>)</blockquote></td>
               </tr>
               <tr valign="top">
@@ -299,8 +299,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`1.GetEnumerator()">GetEnumerator</a>
-                  </b>()<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator`1">IEnumerator&lt;Int32[]&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetEnumerator()">GetEnumerator</a>
+                  </b>()<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator&lt;System.Int32[]&gt;">IEnumerator&lt;Int32[]&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -309,8 +309,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`1.GetHelper``2()">GetHelper&lt;U,V&gt;</a>
-                  </b>()<nobr> : <a href="../Mono.DocTest.Generic/MyList`1+Helper`2.html">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetHelper{U, V}()">GetHelper&lt;U,V&gt;</a>
+                  </b>()<nobr> : <a href="javascript:alert(&quot;Documentation not found.&quot;)">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -319,7 +319,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0)">Method&lt;U&gt;</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;.Method{U}(T,U)">Method&lt;U&gt;</a>
                   </b>(<i title="I'm Dying Here!">T</i>, <i title="Method generic parameter">U</i>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
@@ -329,7 +329,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@)">RefMethod&lt;U&gt;</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;.RefMethod{U}(T@,U@)">RefMethod&lt;U&gt;</a>
                   </b>(<i>ref</i> <i title="I'm Dying Here!">T</i>, <i>ref</i> <i title="To be added.">U</i>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
@@ -339,7 +339,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`1.Test(`0)">Test</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;.Test(T)">Test</a>
                   </b>(<i title="I'm Dying Here!">T</i>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
@@ -349,8 +349,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{`0}.Helper{``0,``1})">UseHelper&lt;U,V&gt;</a>
-                  </b>(<a href="../Mono.DocTest.Generic/MyList`1+Helper`2.html">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;.UseHelper{U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V})">UseHelper&lt;U,V&gt;</a>
+                  </b>(<a href="javascript:alert(&quot;Documentation not found.&quot;)">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
           </div>
@@ -366,7 +366,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase`1.ItemChanged">ItemChanged</a>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged">ItemChanged</a>
                   </b>
                 </td>
                 <td>
@@ -379,7 +379,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase`1.MyEvent">MyEvent</a>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent">MyEvent</a>
                   </b>
                 </td>
                 <td>
@@ -398,7 +398,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`1.System#Collections#IEnumerable#GetEnumerator()">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;T&gt;.System#Collections#IEnumerable#GetEnumerator()">
                     <b>IEnumerable.GetEnumerator</b>
                   </a>
                 </td>
@@ -420,7 +420,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})">ForEach&lt;T&gt;</a>
-                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a>, <a href="../System/Action`1.html">Action&lt;T&gt;</a>)<blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable`1</a> extension method</blockquote></td>
+                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a>, <a href="../System/Action`1.html">Action&lt;T&gt;</a>)<blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable`1</a> extension method</blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -429,7 +429,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32})">ToDouble</a>
-                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;double&gt;</a></nobr><blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a> 
+                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Double&gt;">IEnumerable&lt;double&gt;</a></nobr><blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a> 
                extension method.
              </blockquote></td>
               </tr>
@@ -440,60 +440,60 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.MyList`1:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.MyList&lt;T&gt;:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Generic.MyList`1()">MyList Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Generic.MyList`1():member">
+        <h3 id="C:Mono.DocTest.Generic.MyList&lt;T&gt;()">MyList Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Generic.MyList&lt;T&gt;():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>MyList</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList`1():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList&lt;T&gt;():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList`1():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList&lt;T&gt;():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.GetEnumerator()">GetEnumerator Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.GetEnumerator():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetEnumerator()">GetEnumerator Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetEnumerator():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator`1">IEnumerator&lt;Int32[]&gt;</a> <b>GetEnumerator</b> ()</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator&lt;System.Int32[]&gt;">IEnumerator&lt;Int32[]&gt;</a> <b>GetEnumerator</b> ()</div>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.GetEnumerator():Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetEnumerator():Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.GetEnumerator():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetEnumerator():Remarks">
             <tt>M:Mono.DocTest.MyList`1.GetEnumerator</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.GetEnumerator():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetEnumerator():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.GetHelper``2()">GetHelper&lt;U,V&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.GetHelper``2():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetHelper{U, V}()">GetHelper&lt;U,V&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetHelper{U, V}():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="../Mono.DocTest.Generic/MyList`1+Helper`2.html">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a> <b>GetHelper&lt;U, V&gt;</b> ()</div>
+          <div class="Signature">public <a href="javascript:alert(&quot;Documentation not found.&quot;)">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a> <b>GetHelper&lt;U, V&gt;</b> ()</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.GetHelper``2():Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetHelper{U, V}():Type Parameters">
             <dl>
               <dt>
                 <i>U</i>
@@ -510,25 +510,25 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.GetHelper``2():Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetHelper{U, V}():Returns">
             <tt>null</tt>.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.GetHelper``2():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetHelper{U, V}():Remarks">
             <tt>M:Mono.DocTest.Generic.MyList`1.GetHelper``2</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.GetHelper``2():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.GetHelper{U, V}():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0)">Method&lt;U&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Method{U}(T,U)">Method&lt;U&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Method{U}(T,U):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Method&lt;U&gt;</b> (<i title="I'm Dying Here!">T</i> t, <i title="Method generic parameter">U</i> u)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Method{U}(T,U):Type Parameters">
             <dl>
               <dt>
                 <i>U</i>
@@ -537,7 +537,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Method{U}(T,U):Parameters">
             <dl>
               <dt>
                 <i>t</i>
@@ -550,22 +550,22 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Method{U}(T,U):Remarks">
             <tt>M:Mono.DocTest.MyList`1.Method``1(`0,``0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Method{U}(T,U):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@)">RefMethod&lt;U&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.RefMethod{U}(T@,U@)">RefMethod&lt;U&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.RefMethod{U}(T@,U@):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>RefMethod&lt;U&gt;</b> (<i>ref</i> <i title="I'm Dying Here!">T</i> t, <i>ref</i> <i title="To be added.">U</i> u)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.RefMethod{U}(T@,U@):Type Parameters">
             <dl>
               <dt>
                 <i>U</i>
@@ -576,7 +576,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.RefMethod{U}(T@,U@):Parameters">
             <dl>
               <dt>
                 <i>t</i>
@@ -593,16 +593,16 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.RefMethod{U}(T@,U@):Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.RefMethod{U}(T@,U@):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.System#Collections#IEnumerable#GetEnumerator()">System.Collections.IEnumerable.GetEnumerator Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.System#Collections#IEnumerable#GetEnumerator():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.System#Collections#IEnumerable#GetEnumerator()">System.Collections.IEnumerable.GetEnumerator Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.System#Collections#IEnumerable#GetEnumerator():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -610,26 +610,26 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.IEnumerator">IEnumerator</a> <b>System.Collections.IEnumerable.GetEnumerator</b> ()</div>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.System#Collections#IEnumerable#GetEnumerator():Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.System#Collections#IEnumerable#GetEnumerator():Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.System#Collections#IEnumerable#GetEnumerator():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.System#Collections#IEnumerable#GetEnumerator():Remarks">
             <tt>M:Mono.DocTest.MyList`1.System#Collections#GetEnumerator</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.System#Collections#IEnumerable#GetEnumerator():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.System#Collections#IEnumerable#GetEnumerator():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.Test(`0)">Test Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.Test(`0):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Test(T)">Test Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Test(T):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Test</b> (<i title="I'm Dying Here!">T</i> t)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.Test(`0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Test(T):Parameters">
             <dl>
               <dt>
                 <i>t</i>
@@ -638,22 +638,22 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.Test(`0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Test(T):Remarks">
             <tt>M:Mono.DocTest.MyList`1.Test(`0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.Test(`0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.Test(T):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{`0}.Helper{``0,``1})">UseHelper&lt;U,V&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{`0}.Helper{``0,``1}):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.UseHelper{U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V})">UseHelper&lt;U,V&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.UseHelper{U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>UseHelper&lt;U, V&gt;</b> (<a href="../Mono.DocTest.Generic/MyList`1+Helper`2.html">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a> helper)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>UseHelper&lt;U, V&gt;</b> (<a href="javascript:alert(&quot;Documentation not found.&quot;)">MyList&lt;T&gt;.Helper&lt;U, V&gt;</a> helper)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{`0}.Helper{``0,``1}):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.UseHelper{U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Type Parameters">
             <dl>
               <dt>
                 <i>U</i>
@@ -666,7 +666,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{`0}.Helper{``0,``1}):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.UseHelper{U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Parameters">
             <dl>
               <dt>
                 <i>helper</i>
@@ -675,10 +675,10 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{`0}.Helper{``0,``1}):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.UseHelper{U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Remarks">
             <tt>M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2})</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{`0}.Helper{``0,``1}):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;T&gt;.UseHelper{U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`2.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`2.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`2">Overview</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;A,B&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`2:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`2:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Generic.MyList`2:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList`2">MyList&lt;A,B&gt; Generic Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Generic.MyList`2:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;">MyList&lt;A,B&gt; Generic Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.MyList`2:Signature">public class  <b>MyList&lt;A, B&gt;</b> : <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;Dictionary&lt;A, B&gt;&gt;</a>,	<a href="../Mono.DocTest.Generic/IFoo`1.html">IFoo&lt;A&gt;</a>, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.ICollection`1">ICollection&lt;A&gt;</a>, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;A&gt;</a>, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator`1">IEnumerator&lt;A&gt;</a><br /> where A : class, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IList`1">IList&lt;B&gt;</a>, new()<br /> where B : class, <i title="Ako generic param">A</i></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Signature">public class  <b>MyList&lt;A, B&gt;</b> : <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;Dictionary&lt;A, B&gt;&gt;</a>,	<a href="../Mono.DocTest.Generic/IFoo`1.html">IFoo&lt;A&gt;</a>, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.ICollection&lt;A&gt;">ICollection&lt;A&gt;</a>, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;A&gt;">IEnumerable&lt;A&gt;</a>, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator&lt;A&gt;">IEnumerator&lt;A&gt;</a><br /> where A : class, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IList&lt;B&gt;">IList&lt;B&gt;</a>, new()<br /> where B : class, <i title="Ako generic param">A</i></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList`2:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList`2:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>A</i>
@@ -228,10 +228,10 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`2:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Docs:Remarks">
         <tt>T:Mono.DocTest.MyList`2</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`2:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -251,7 +251,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Generic.MyList`2()">MyList</a>
+                      <a href="#C:Mono.DocTest.Generic.MyList&lt;A,B&gt;()">MyList</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -271,7 +271,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#F:Mono.DocTest.Generic.GenericBase`1.ConstField1">ConstField1</a>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#F:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ConstField1">ConstField1</a>
                   </b>
                 </td>
                 <td>
@@ -290,7 +290,7 @@
                 <td>[read-only]<div></div></td>
                 <td>
                   <b>
-                    <a href="#P:Mono.DocTest.Generic.MyList`2.Count">Count</a>
+                    <a href="#P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Count">Count</a>
                   </b>
                 </td>
                 <td>
@@ -302,7 +302,7 @@
                 <td>[read-only]<div></div></td>
                 <td>
                   <b>
-                    <a href="#P:Mono.DocTest.Generic.MyList`2.Current">Current</a>
+                    <a href="#P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Current">Current</a>
                   </b>
                 </td>
                 <td>
@@ -324,8 +324,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0)">BaseMethod&lt;S&gt;</a>
-                  </b>(<i title="Insert more text here.">S</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary`2">Dictionary&lt;A, B&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span> (<i>Inherited from <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a>.</i>)</blockquote></td>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#M:Mono.DocTest.Generic.GenericBase&lt;U&gt;.BaseMethod{S}(S)">BaseMethod&lt;S&gt;</a>
+                  </b>(<i title="Insert more text here.">S</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary&lt;A,B&gt;">Dictionary&lt;A, B&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span> (<i>Inherited from <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a>.</i>)</blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -334,7 +334,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32)">CopyTo</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.CopyTo(A[],System.Int32)">CopyTo</a>
                   </b>(<i title="Ako generic param">A</i>[], <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
@@ -344,7 +344,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`2.Dispose()">Dispose</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Dispose()">Dispose</a>
                   </b>()<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
@@ -354,8 +354,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`2.Foo()">Foo</a>
-                  </b>()<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.KeyValuePair`2">KeyValuePair&lt;IEnumerable&lt;A&gt;, IEnumerable&lt;B&gt;&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Foo()">Foo</a>
+                  </b>()<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.KeyValuePair&lt;System.Collections.Generic.IEnumerable&lt;A&gt;,System.Collections.Generic.IEnumerable&lt;B&gt;&gt;">KeyValuePair&lt;IEnumerable&lt;A&gt;, IEnumerable&lt;B&gt;&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -364,8 +364,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`2.GetEnumerator()">GetEnumerator</a>
-                  </b>()<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1.Enumerator">List&lt;A&gt;.Enumerator</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.GetEnumerator()">GetEnumerator</a>
+                  </b>()<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;A&gt;+Enumerator">List&lt;A&gt;.Enumerator</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -374,7 +374,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`2.MoveNext()">MoveNext</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.MoveNext()">MoveNext</a>
                   </b>()<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
@@ -384,7 +384,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Generic.MyList`2.Reset()">Reset</a>
+                    <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Reset()">Reset</a>
                   </b>()<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -401,7 +401,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase`1.ItemChanged">ItemChanged</a>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.ItemChanged">ItemChanged</a>
                   </b>
                 </td>
                 <td>
@@ -414,7 +414,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase`1.MyEvent">MyEvent</a>
+                    <a href="../Mono.DocTest.Generic/GenericBase`1.html#E:Mono.DocTest.Generic.GenericBase&lt;U&gt;.MyEvent">MyEvent</a>
                   </b>
                 </td>
                 <td>
@@ -433,7 +433,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0)">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Add(A)">
                     <b>ICollection&lt;A&gt;.Add</b>
                   </a>
                 </td>
@@ -447,7 +447,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Clear()">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Clear()">
                     <b>ICollection&lt;A&gt;.Clear</b>
                   </a>
                 </td>
@@ -461,7 +461,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Contains(`0)">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Contains(A)">
                     <b>ICollection&lt;A&gt;.Contains</b>
                   </a>
                 </td>
@@ -472,7 +472,7 @@
               <tr valign="top">
                 <td>[read-only]<div></div></td>
                 <td>
-                  <a href="#P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerator{A}#Current">
+                  <a href="#P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerator{A}#Current">
                     <b>IEnumerator&lt;A&gt;.Current</b>
                   </a>
                 </td>
@@ -484,7 +484,7 @@
               <tr valign="top">
                 <td>[read-only]<div></div></td>
                 <td>
-                  <a href="#P:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerator#Current">
+                  <a href="#P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerator#Current">
                     <b>IEnumerator.Current</b>
                   </a>
                 </td>
@@ -499,7 +499,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator()">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerable{A}#GetEnumerator()">
                     <b>IEnumerable&lt;A&gt;.GetEnumerator</b>
                   </a>
                 </td>
@@ -513,7 +513,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerable#GetEnumerator()">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerable#GetEnumerator()">
                     <b>IEnumerable.GetEnumerator</b>
                   </a>
                 </td>
@@ -524,7 +524,7 @@
               <tr valign="top">
                 <td>[read-only]<div></div></td>
                 <td>
-                  <a href="#P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly">
+                  <a href="#P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#IsReadOnly">
                     <b>ICollection&lt;A&gt;.IsReadOnly</b>
                   </a>
                 </td>
@@ -539,7 +539,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0)">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U)">
                     <b>Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;</b>
                   </a>
                 </td>
@@ -553,7 +553,7 @@
                   </div>
                 </td>
                 <td>
-                  <a href="#M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0)">
+                  <a href="#M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Remove(A)">
                     <b>ICollection&lt;A&gt;.Remove</b>
                   </a>
                 </td>
@@ -584,7 +584,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})">ForEach&lt;T&gt;</a>
-                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a>, <a href="../System/Action`1.html">Action&lt;T&gt;</a>)<blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable`1</a> extension method</blockquote></td>
+                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a>, <a href="../System/Action`1.html">Action&lt;T&gt;</a>)<blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable`1</a> extension method</blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -593,7 +593,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32})">ToDouble</a>
-                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;double&gt;</a></nobr><blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;int&gt;</a> 
+                  </b>(<i>this</i> <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Double&gt;">IEnumerable&lt;double&gt;</a></nobr><blockquote><a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;System.Int32&gt;">IEnumerable&lt;int&gt;</a> 
                extension method.
              </blockquote></td>
               </tr>
@@ -614,41 +614,41 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Generic.MyList`2:Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.MyList&lt;A,B&gt;:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Generic.MyList`2()">MyList Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Generic.MyList`2():member">
+        <h3 id="C:Mono.DocTest.Generic.MyList&lt;A,B&gt;()">MyList Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Generic.MyList&lt;A,B&gt;():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>MyList</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList`2():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList&lt;A,B&gt;():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList`2():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Generic.MyList&lt;A,B&gt;():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32)">CopyTo Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.CopyTo(A[],System.Int32)">CopyTo Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.CopyTo(A[],System.Int32):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>CopyTo</b> (<i title="Ako generic param">A</i>[] array, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> arrayIndex)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.CopyTo(A[],System.Int32):Parameters">
             <dl>
               <dt>
                 <i>array</i>
@@ -661,99 +661,99 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.CopyTo(A[],System.Int32):Remarks">
             <tt>M:Mono.DocTest.MyList`2.CopyTo(`0[],System.Int32)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.CopyTo(A[],System.Int32):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="P:Mono.DocTest.Generic.MyList`2.Count">Count Property</h3>
-        <blockquote id="P:Mono.DocTest.Generic.MyList`2.Count:member">
+        <h3 id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Count">Count Property</h3>
+        <blockquote id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Count:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> <b>Count</b>  { get; }</div>
           <h4 class="Subsection">Value</h4>
-          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList`2.Count:Value">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a>.</blockquote>
+          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Count:Value">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a>.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.Count:Remarks">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Count:Remarks">
             <tt>P:Mono.DocTest.MyList`2.Count</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.Count:Version Information">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Count:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="P:Mono.DocTest.Generic.MyList`2.Current">Current Property</h3>
-        <blockquote id="P:Mono.DocTest.Generic.MyList`2.Current:member">
+        <h3 id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Current">Current Property</h3>
+        <blockquote id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Current:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <i title="Ako generic param">A</i> <b>Current</b>  { get; }</div>
           <h4 class="Subsection">Value</h4>
-          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList`2.Current:Value">The current value.</blockquote>
+          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Current:Value">The current value.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.Current:Remarks">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Current:Remarks">
             <tt>P:Mono.DocTest.MyList`2.Current</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.Current:Version Information">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Current:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.Dispose()">Dispose Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.Dispose():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Dispose()">Dispose Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Dispose():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Dispose</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Dispose():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Dispose():Remarks">
             <tt>M:Mono.DocTest.MyList`2.Dispose</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Dispose():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Dispose():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.Foo()">Foo Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.Foo():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Foo()">Foo Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Foo():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.KeyValuePair`2">KeyValuePair&lt;IEnumerable&lt;A&gt;, IEnumerable&lt;B&gt;&gt;</a> <b>Foo</b> ()</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.KeyValuePair&lt;System.Collections.Generic.IEnumerable&lt;A&gt;,System.Collections.Generic.IEnumerable&lt;B&gt;&gt;">KeyValuePair&lt;IEnumerable&lt;A&gt;, IEnumerable&lt;B&gt;&gt;</a> <b>Foo</b> ()</div>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.Foo():Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Foo():Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Foo():Remarks">M:Mono.DocTest.Generic.MyList`2.Foo</div>
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Foo():Remarks">M:Mono.DocTest.Generic.MyList`2.Foo</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Foo():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Foo():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.GetEnumerator()">GetEnumerator Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.GetEnumerator():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.GetEnumerator()">GetEnumerator Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.GetEnumerator():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1.Enumerator">List&lt;A&gt;.Enumerator</a> <b>GetEnumerator</b> ()</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;A&gt;+Enumerator">List&lt;A&gt;.Enumerator</a> <b>GetEnumerator</b> ()</div>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.GetEnumerator():Returns">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1.Enumerator">List&lt;`0&gt;.Enumerator</a>.</blockquote>
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.GetEnumerator():Returns">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;`0&gt;.Enumerator">List&lt;`0&gt;.Enumerator</a>.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.GetEnumerator():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.GetEnumerator():Remarks">
             <tt>M:Mono.DocTest.MyList`2.GetEnumerator</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.GetEnumerator():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.GetEnumerator():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0)">Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U)">Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -761,7 +761,7 @@
           <div class="Signature">
             <i title="Ako generic param">A</i> <b>Mono.DocTest.Generic.IFoo&lt;U&gt;</b> (<i title="Ako generic param">A</i> a, <i title="U generic param on MyList`2">U</i> u)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U):Type Parameters">
             <dl>
               <dt>
                 <i>U</i>
@@ -770,7 +770,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U):Parameters">
             <dl>
               <dt>
                 <i>a</i>
@@ -787,53 +787,53 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0):Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U):Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U):Remarks">
             <tt>M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo{A}#Method``1(`0,``0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo``1(`0,``0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Mono#DocTest#Generic#IFoo{U}(A,U):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.MoveNext()">MoveNext Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.MoveNext():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.MoveNext()">MoveNext Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.MoveNext():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> <b>MoveNext</b> ()</div>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.MoveNext():Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.MoveNext():Returns">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.MoveNext():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.MoveNext():Remarks">
             <tt>M:Mono.DocTest.MyList`2.MoveNext</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.MoveNext():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.MoveNext():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.Reset()">Reset Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.Reset():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Reset()">Reset Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Reset():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Reset</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Reset():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Reset():Remarks">
             <tt>M:Mono.DocTest.MyList`2.Reset</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.Reset():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.Reset():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0)">System.Collections.Generic.ICollection&lt;A&gt;.Add Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Add(A)">System.Collections.Generic.ICollection&lt;A&gt;.Add Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Add(A):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -841,7 +841,7 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>System.Collections.Generic.ICollection&lt;A&gt;.Add</b> (<i title="Ako generic param">A</i> item)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Add(A):Parameters">
             <dl>
               <dt>
                 <i>item</i>
@@ -850,15 +850,15 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Add(A):Remarks">
             <tt>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Add(A):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Clear()">System.Collections.Generic.ICollection&lt;A&gt;.Clear Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Clear():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Clear()">System.Collections.Generic.ICollection&lt;A&gt;.Clear Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Clear():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -866,15 +866,15 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>System.Collections.Generic.ICollection&lt;A&gt;.Clear</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Clear():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Clear():Remarks">
             <tt>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#Clear</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Clear():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Clear():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Contains(`0)">System.Collections.Generic.ICollection&lt;A&gt;.Contains Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Contains(`0):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Contains(A)">System.Collections.Generic.ICollection&lt;A&gt;.Contains Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Contains(A):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -882,7 +882,7 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> <b>System.Collections.Generic.ICollection&lt;A&gt;.Contains</b> (<i title="Ako generic param">A</i> item)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Contains(`0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Contains(A):Parameters">
             <dl>
               <dt>
                 <i>item</i>
@@ -891,17 +891,17 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Contains(`0):Returns">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> instance (<tt>false</tt>).</blockquote>
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Contains(A):Returns">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> instance (<tt>false</tt>).</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Contains(`0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Contains(A):Remarks">
             <tt>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}.Contains(`0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Contains(`0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Contains(A):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly">System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly Property</h3>
-        <blockquote id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly:member">
+        <h3 id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#IsReadOnly">System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly Property</h3>
+        <blockquote id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#IsReadOnly:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -909,17 +909,17 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> <b>System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly</b>  { get; }</div>
           <h4 class="Subsection">Value</h4>
-          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly:Value">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a>.</blockquote>
+          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#IsReadOnly:Value">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a>.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly:Remarks">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#IsReadOnly:Remarks">
             <tt>P:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly:Version Information">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#IsReadOnly:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0)">System.Collections.Generic.ICollection&lt;A&gt;.Remove Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0):member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Remove(A)">System.Collections.Generic.ICollection&lt;A&gt;.Remove Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Remove(A):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -927,7 +927,7 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> <b>System.Collections.Generic.ICollection&lt;A&gt;.Remove</b> (<i title="Ako generic param">A</i> item)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Remove(A):Parameters">
             <dl>
               <dt>
                 <i>item</i>
@@ -936,35 +936,35 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0):Returns">Whether the item was removed.</blockquote>
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Remove(A):Returns">Whether the item was removed.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Remove(A):Remarks">
             <tt>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#ICollection{A}#Remove(A):Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator()">System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerable{A}#GetEnumerator()">System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerable{A}#GetEnumerator():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">
-            <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator`1">IEnumerator&lt;A&gt;</a> <b>System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator</b> ()</div>
+            <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator&lt;A&gt;">IEnumerator&lt;A&gt;</a> <b>System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator</b> ()</div>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator():Returns">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator`1">IEnumerator&lt;`0&gt;</a>.</blockquote>
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerable{A}#GetEnumerator():Returns">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerator&lt;`0&gt;">IEnumerator&lt;`0&gt;</a>.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerable{A}#GetEnumerator():Remarks">
             <tt>M:Mono.DocTest.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerable{A}#GetEnumerator():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerator{A}#Current">System.Collections.Generic.IEnumerator&lt;A&gt;.Current Property</h3>
-        <blockquote id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerator{A}#Current:member">
+        <h3 id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerator{A}#Current">System.Collections.Generic.IEnumerator&lt;A&gt;.Current Property</h3>
+        <blockquote id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerator{A}#Current:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -972,17 +972,17 @@
           <div class="Signature">
             <i title="Ako generic param">A</i> <b>System.Collections.Generic.IEnumerator&lt;A&gt;.Current</b>  { get; }</div>
           <h4 class="Subsection">Value</h4>
-          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerator{A}#Current:Value">The current value.</blockquote>
+          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerator{A}#Current:Value">The current value.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerator{A}#Current:Remarks">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerator{A}#Current:Remarks">
             <tt>P:Mono.DocTest.MyList`2.Current</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerator{A}#Current:Version Information">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#Generic#IEnumerator{A}#Current:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerable#GetEnumerator()">System.Collections.IEnumerable.GetEnumerator Method</h3>
-        <blockquote id="M:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerable#GetEnumerator():member">
+        <h3 id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerable#GetEnumerator()">System.Collections.IEnumerable.GetEnumerator Method</h3>
+        <blockquote id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerable#GetEnumerator():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -990,19 +990,19 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.IEnumerator">IEnumerator</a> <b>System.Collections.IEnumerable.GetEnumerator</b> ()</div>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerable#GetEnumerator():Returns">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerable#GetEnumerator():Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerable#GetEnumerator():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerable#GetEnumerator():Remarks">
             <tt>M:Mono.DocTest.MyList`2.System#Collections#GetEnumerator</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerable#GetEnumerator():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerable#GetEnumerator():Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="P:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerator#Current">System.Collections.IEnumerator.Current Property</h3>
-        <blockquote id="P:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerator#Current:member">
+        <h3 id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerator#Current">System.Collections.IEnumerator.Current Property</h3>
+        <blockquote id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerator#Current:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
@@ -1010,15 +1010,15 @@
           <div class="Signature">
             <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Object">object</a> <b>System.Collections.IEnumerator.Current</b>  { get; }</div>
           <h4 class="Subsection">Value</h4>
-          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerator#Current:Value">
+          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerator#Current:Value">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerator#Current:Remarks">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerator#Current:Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerator#Current:Version Information">
+          <div class="SectionBox" id="P:Mono.DocTest.Generic.MyList&lt;A,B&gt;.System#Collections#IEnumerator#Current:Version Information">
             <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/D.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/D.html
@@ -211,7 +211,7 @@
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.D:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Object">object</a> <b>D</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`3">Func&lt;string, object, object&gt;</a> value)</div>
+      <div class="Signature" id="T:Mono.DocTest.D:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Object">object</a> <b>D</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.String,System.Object,System.Object&gt;">Func&lt;string, object, object&gt;</a> value)</div>
     </div>
     <div class="Remarks" id="T:Mono.DocTest.D:Docs">
       <h4 class="Subsection">Parameters</h4>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/DocAttribute.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/DocAttribute.html
@@ -361,7 +361,7 @@ class Example {
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/DocValueType.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/DocValueType.html
@@ -274,7 +274,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/IProcess.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/IProcess.html
@@ -231,7 +231,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/UseLists.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/UseLists.html
@@ -259,7 +259,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.UseLists.GetValues``1(``0)">GetValues&lt;T&gt;</a>
+                    <a href="#M:Mono.DocTest.UseLists.GetValues{T}(T)">GetValues&lt;T&gt;</a>
                   </b>(<i title="Something">T</i>)<nobr> : <a href="../Mono.DocTest.Generic/MyList`1.html">Mono.DocTest.Generic.MyList&lt;T&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
@@ -280,7 +280,7 @@
                 <td colspan="2">
                   <b>
                     <a href="#M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Int32})">Process</a>
-                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1">List&lt;int&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;System.Int32&gt;">List&lt;int&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -290,7 +290,7 @@
                 <td colspan="2">
                   <b>
                     <a href="#M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Predicate{System.Int32}})">Process</a>
-                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1">List&lt;Predicate&lt;int&gt;&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;System.Predicate&lt;System.Int32&gt;&gt;">List&lt;Predicate&lt;int&gt;&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -299,8 +299,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}})">Process&lt;T&gt;</a>
-                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1">List&lt;Predicate&lt;T&gt;&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}})">Process&lt;T&gt;</a>
+                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;System.Predicate&lt;T&gt;&gt;">List&lt;Predicate&lt;T&gt;&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -309,8 +309,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2})">UseHelper&lt;T,U,V&gt;</a>
-                  </b>(<a href="../Mono.DocTest.Generic/MyList`1+Helper`2.html">Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U, V&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:Mono.DocTest.UseLists.UseHelper{T, U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V})">UseHelper&lt;T,U,V&gt;</a>
+                  </b>(<a href="javascript:alert(&quot;Documentation not found.&quot;)">Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U, V&gt;</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
           </div>
@@ -326,7 +326,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
@@ -352,15 +352,15 @@
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.UseLists.GetValues``1(``0)">GetValues&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.UseLists.GetValues``1(``0):member">
+        <h3 id="M:Mono.DocTest.UseLists.GetValues{T}(T)">GetValues&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.UseLists.GetValues{T}(T):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="../Mono.DocTest.Generic/MyList`1.html">Mono.DocTest.Generic.MyList&lt;T&gt;</a> <b>GetValues&lt;T&gt;</b> (<i title="Something">T</i> value)<br /> where T : struct</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.GetValues``1(``0):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.GetValues{T}(T):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -369,7 +369,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.GetValues``1(``0):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.GetValues{T}(T):Parameters">
             <dl>
               <dt>
                 <i>value</i>
@@ -378,12 +378,12 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.GetValues``1(``0):Returns">A <a href="../Mono.DocTest.Generic/MyList`1.html">Mono.DocTest.Generic.MyList`1</a> instance.</blockquote>
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.GetValues{T}(T):Returns">A <a href="../Mono.DocTest.Generic/MyList`1.html">Mono.DocTest.Generic.MyList`1</a> instance.</blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.UseLists.GetValues``1(``0):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.UseLists.GetValues{T}(T):Remarks">
             <tt>M:Mono.DocTest.UseLists.GetValues``1(``0)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.UseLists.GetValues``1(``0):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.UseLists.GetValues{T}(T):Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
@@ -417,7 +417,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Process</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1">List&lt;int&gt;</a> list)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Process</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;System.Int32&gt;">List&lt;int&gt;</a> list)</div>
           <h4 class="Subsection">Parameters</h4>
           <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Int32}):Parameters">
             <dl>
@@ -469,7 +469,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Process</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1">List&lt;Predicate&lt;int&gt;&gt;</a> list)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Process</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;System.Predicate&lt;System.Int32&gt;&gt;">List&lt;Predicate&lt;int&gt;&gt;</a> list)</div>
           <h4 class="Subsection">Parameters</h4>
           <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Predicate{System.Int32}}):Parameters">
             <dl>
@@ -512,15 +512,15 @@
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}})">Process&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}}):member">
+        <h3 id="M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}})">Process&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}}):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Process&lt;T&gt;</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List`1">List&lt;Predicate&lt;T&gt;&gt;</a> list)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Process&lt;T&gt;</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.List&lt;System.Predicate&lt;T&gt;&gt;">List&lt;Predicate&lt;T&gt;&gt;</a> list)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}}):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}}):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -529,7 +529,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}}):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}}):Parameters">
             <dl>
               <dt>
                 <i>list</i>
@@ -538,7 +538,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Exceptions</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}}):Exceptions">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}}):Exceptions">
             <table class="TypeDocumentation">
               <tr>
                 <th>Type</th>
@@ -563,22 +563,22 @@
             </table>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}}):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}}):Remarks">
             <tt>M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}})</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}}):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.UseLists.Process{T}(System.Collections.Generic.List{System.Predicate{T}}):Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2})">UseHelper&lt;T,U,V&gt; Generic Method</h3>
-        <blockquote id="M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2}):member">
+        <h3 id="M:Mono.DocTest.UseLists.UseHelper{T, U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V})">UseHelper&lt;T,U,V&gt; Generic Method</h3>
+        <blockquote id="M:Mono.DocTest.UseLists.UseHelper{T, U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>UseHelper&lt;T, U, V&gt;</b> (<a href="../Mono.DocTest.Generic/MyList`1+Helper`2.html">Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U, V&gt;</a> helper)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>UseHelper&lt;T, U, V&gt;</b> (<a href="javascript:alert(&quot;Documentation not found.&quot;)">Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U, V&gt;</a> helper)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2}):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.UseHelper{T, U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -601,19 +601,19 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2}):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.UseLists.UseHelper{T, U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Parameters">
             <dl>
               <dt>
                 <i>helper</i>
               </dt>
-              <dd>A <a href="../Mono.DocTest.Generic/MyList`1+Helper`2.html">Mono.DocTest.Generic.MyList&lt;``0&gt;.Helper&lt;``1, ``2&gt;</a>.</dd>
+              <dd>A <a href="javascript:alert(&quot;Documentation not found.&quot;)">Mono.DocTest.Generic.MyList&lt;``0&gt;.Helper&lt;``1, ``2&gt;</a>.</dd>
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2}):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.UseLists.UseHelper{T, U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Remarks">
             <tt>M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2})</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2}):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.UseLists.UseHelper{T, U, V}(Mono.DocTest.Generic.MyList{T}+Helper{U,V}):Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+Del.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+Del.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.Del">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+Del">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.Del:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+Del:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.Del:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+Del:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.Del:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+Del:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.Del">Widget.Del  Delegate</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.Del:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+Del">Widget.Del  Delegate</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+Del:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.Del:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Widget.Del</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> i)</div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+Del:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Widget.Del</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> i)</div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.Del:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+Del:Docs">
       <h4 class="Subsection">Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Widget.Del:Docs:Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Widget+Del:Docs:Parameters">
         <dl>
           <dt>
             <i>i</i>
@@ -226,13 +226,13 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.Del:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+Del:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.Del</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.Del:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+Del:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.Del:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+Del:Members">
     </div>
     <hr size="1" />
     <div class="Copyright">

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+Direction.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+Direction.html
@@ -190,35 +190,35 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.Direction">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+Direction">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.Direction:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+Direction:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.Direction:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+Direction:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.Direction:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+Direction:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.Direction">Widget.Direction  Enum</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.Direction:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+Direction">Widget.Direction  Enum</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+Direction:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.Direction:Signature">[System.Flags]<br />protected enum <b>Widget.Direction</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+Direction:Signature">[System.Flags]<br />protected enum <b>Widget.Direction</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.Direction:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+Direction:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.Direction:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+Direction:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.Direction</tt>.</div>
       <h2 class="Section">Members</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.Direction:Docs:Members">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+Direction:Docs:Members">
         <table class="Enumeration">
           <tr>
             <th>Member Name</th>
@@ -259,10 +259,10 @@
         </table>
       </div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.Direction:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+Direction:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.Direction:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+Direction:Members">
     </div>
     <hr size="1" />
     <div class="Copyright">

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+IMenuItem.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+IMenuItem.html
@@ -190,35 +190,35 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.IMenuItem">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+IMenuItem">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.IMenuItem:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+IMenuItem:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.IMenuItem:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+IMenuItem:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.IMenuItem:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+IMenuItem:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.IMenuItem">Widget.IMenuItem  Interface</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.IMenuItem:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+IMenuItem">Widget.IMenuItem  Interface</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+IMenuItem:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.IMenuItem:Signature">public interface  <b>Widget.IMenuItem</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+IMenuItem:Signature">public interface  <b>Widget.IMenuItem</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.IMenuItem:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+IMenuItem:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.IMenuItem:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+IMenuItem:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.IMenuItem</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.IMenuItem:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+IMenuItem:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -233,7 +233,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#P:Mono.DocTest.Widget.IMenuItem.B">B</a>
+                    <a href="#P:Mono.DocTest.Widget+IMenuItem.B">B</a>
                   </b>
                 </td>
                 <td>
@@ -255,7 +255,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Widget.IMenuItem.A()">A</a>
+                    <a href="#M:Mono.DocTest.Widget+IMenuItem.A()">A</a>
                   </b>()<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -272,47 +272,47 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.IMenuItem:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+IMenuItem:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="M:Mono.DocTest.Widget.IMenuItem.A()">A Method</h3>
-        <blockquote id="M:Mono.DocTest.Widget.IMenuItem.A():member">
+        <h3 id="M:Mono.DocTest.Widget+IMenuItem.A()">A Method</h3>
+        <blockquote id="M:Mono.DocTest.Widget+IMenuItem.A():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>A</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.IMenuItem.A():Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget+IMenuItem.A():Remarks">
             <tt>M:Mono.DocTest.Widget.IMenuItem.A</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.IMenuItem.A():Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget+IMenuItem.A():Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="P:Mono.DocTest.Widget.IMenuItem.B">B Property</h3>
-        <blockquote id="P:Mono.DocTest.Widget.IMenuItem.B:member">
+        <h3 id="P:Mono.DocTest.Widget+IMenuItem.B">B Property</h3>
+        <blockquote id="P:Mono.DocTest.Widget+IMenuItem.B:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> <b>B</b>  { get; set; }</div>
           <h4 class="Subsection">Value</h4>
-          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Widget.IMenuItem.B:Value">
+          <blockquote class="SubsectionBox" id="P:Mono.DocTest.Widget+IMenuItem.B:Value">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Widget.IMenuItem.B:Remarks">
+          <div class="SectionBox" id="P:Mono.DocTest.Widget+IMenuItem.B:Remarks">
             <tt>P:Mono.DocTest.Widget.IMenuItem.P</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="P:Mono.DocTest.Widget.IMenuItem.B:Version Information">
+          <div class="SectionBox" id="P:Mono.DocTest.Widget+IMenuItem.B:Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.html
@@ -190,35 +190,35 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple">Widget.NestedClass.Double.Triple.Quadruple  Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple">Widget.NestedClass.Double.Triple.Quadruple  Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Signature">public class  <b>Widget.NestedClass.Double.Triple.Quadruple</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Signature">public class  <b>Widget.NestedClass.Double.Triple.Quadruple</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -238,7 +238,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple()">Widget.NestedClass.Double.Triple.Quadruple</a>
+                      <a href="#C:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple()">Widget.NestedClass.Double.Triple.Quadruple</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -259,29 +259,29 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple()">Widget.NestedClass.Double.Triple.Quadruple Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple():member">
+        <h3 id="C:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple()">Widget.NestedClass.Double.Triple.Quadruple Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>Widget.NestedClass.Double.Triple.Quadruple</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple():Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass+Double+Triple.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass+Double+Triple.html
@@ -190,35 +190,35 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double.Triple:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double+Triple:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple">Widget.NestedClass.Double.Triple  Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple">Widget.NestedClass.Double.Triple  Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple:Signature">public class  <b>Widget.NestedClass.Double.Triple</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple:Signature">public class  <b>Widget.NestedClass.Double.Triple</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.NestedClass.Double.Triple</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -238,7 +238,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Widget.NestedClass.Double.Triple()">Widget.NestedClass.Double.Triple</a>
+                      <a href="#C:Mono.DocTest.Widget+NestedClass+Double+Triple()">Widget.NestedClass.Double.Triple</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -259,29 +259,29 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.NestedClass.Double.Triple:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+NestedClass+Double+Triple:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Widget.NestedClass.Double.Triple()">Widget.NestedClass.Double.Triple Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Widget.NestedClass.Double.Triple():member">
+        <h3 id="C:Mono.DocTest.Widget+NestedClass+Double+Triple()">Widget.NestedClass.Double.Triple Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Widget+NestedClass+Double+Triple():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>Widget.NestedClass.Double.Triple</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass.Double.Triple():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass+Double+Triple():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass.Double.Triple():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass+Double+Triple():Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass+Double.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass+Double.html
@@ -190,35 +190,35 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass.Double:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass+Double:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.NestedClass.Double">Widget.NestedClass.Double  Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.NestedClass.Double:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+NestedClass+Double">Widget.NestedClass.Double  Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+NestedClass+Double:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.NestedClass.Double:Signature">public class  <b>Widget.NestedClass.Double</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+NestedClass+Double:Signature">public class  <b>Widget.NestedClass.Double</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.NestedClass.Double:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+NestedClass+Double:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass.Double:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass+Double:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.NestedClass.Double</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass.Double:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass+Double:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -238,7 +238,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Widget.NestedClass.Double()">Widget.NestedClass.Double</a>
+                      <a href="#C:Mono.DocTest.Widget+NestedClass+Double()">Widget.NestedClass.Double</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -259,29 +259,29 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.NestedClass.Double:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+NestedClass+Double:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Widget.NestedClass.Double()">Widget.NestedClass.Double Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Widget.NestedClass.Double():member">
+        <h3 id="C:Mono.DocTest.Widget+NestedClass+Double()">Widget.NestedClass.Double Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Widget+NestedClass+Double():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>Widget.NestedClass.Double</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass.Double():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass+Double():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass.Double():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass+Double():Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass.html
@@ -190,35 +190,35 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.NestedClass">Widget.NestedClass  Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.NestedClass:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+NestedClass">Widget.NestedClass  Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+NestedClass:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.NestedClass:Signature">public class  <b>Widget.NestedClass</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+NestedClass:Signature">public class  <b>Widget.NestedClass</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.NestedClass:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+NestedClass:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.NestedClass</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -238,7 +238,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Widget.NestedClass()">Widget.NestedClass</a>
+                      <a href="#C:Mono.DocTest.Widget+NestedClass()">Widget.NestedClass</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -259,7 +259,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#F:Mono.DocTest.Widget.NestedClass.value">value</a>
+                    <a href="#F:Mono.DocTest.Widget+NestedClass.value">value</a>
                   </b>
                 </td>
                 <td>
@@ -281,7 +281,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Widget.NestedClass.M(System.Int32)">M</a>
+                    <a href="#M:Mono.DocTest.Widget+NestedClass.M(System.Int32)">M</a>
                   </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -298,41 +298,41 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.NestedClass:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+NestedClass:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Widget.NestedClass()">Widget.NestedClass Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Widget.NestedClass():member">
+        <h3 id="C:Mono.DocTest.Widget+NestedClass()">Widget.NestedClass Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Widget+NestedClass():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>Widget.NestedClass</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass():Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Widget.NestedClass.M(System.Int32)">M Method</h3>
-        <blockquote id="M:Mono.DocTest.Widget.NestedClass.M(System.Int32):member">
+        <h3 id="M:Mono.DocTest.Widget+NestedClass.M(System.Int32)">M Method</h3>
+        <blockquote id="M:Mono.DocTest.Widget+NestedClass.M(System.Int32):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>M</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> i)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget.NestedClass.M(System.Int32):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget+NestedClass.M(System.Int32):Parameters">
             <dl>
               <dt>
                 <i>i</i>
@@ -341,25 +341,25 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.NestedClass.M(System.Int32):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget+NestedClass.M(System.Int32):Remarks">
             <tt>M:Mono.DocTest.Widget.NestedClass.M(System.Int32)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.NestedClass.M(System.Int32):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget+NestedClass.M(System.Int32):Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="F:Mono.DocTest.Widget.NestedClass.value">value Field</h3>
-        <blockquote id="F:Mono.DocTest.Widget.NestedClass.value:member">
+        <h3 id="F:Mono.DocTest.Widget+NestedClass.value">value Field</h3>
+        <blockquote id="F:Mono.DocTest.Widget+NestedClass.value:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> <b>value</b> </div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Widget.NestedClass.value:Remarks">
+          <div class="SectionBox" id="F:Mono.DocTest.Widget+NestedClass.value:Remarks">
             <tt>F:Mono.DocTest.Widget.NestedClass.value</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Widget.NestedClass.value:Version Information">
+          <div class="SectionBox" id="F:Mono.DocTest.Widget+NestedClass.value:Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass`1.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget+NestedClass`1.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass`1">Overview</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass&lt;T&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass`1:Signature">Signature</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass`1:Docs">Remarks</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:Mono.DocTest.Widget.NestedClass`1:Members">Member Details</a>
+        <a href="#T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:Mono.DocTest.Widget.NestedClass`1">Widget.NestedClass&lt;T&gt; Generic Class</h1>
-    <p class="Summary" id="T:Mono.DocTest.Widget.NestedClass`1:Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;">Widget.NestedClass&lt;T&gt; Generic Class</h1>
+    <p class="Summary" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.NestedClass`1:Signature">public class  <b>Widget.NestedClass&lt;T&gt;</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Signature">public class  <b>Widget.NestedClass&lt;T&gt;</b></div>
     </div>
-    <div class="Remarks" id="T:Mono.DocTest.Widget.NestedClass`1:Docs">
+    <div class="Remarks" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Widget.NestedClass`1:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>T</i>
@@ -226,10 +226,10 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass`1:Docs:Remarks">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Docs:Remarks">
         <tt>T:Mono.DocTest.Widget.NestedClass`1</tt>.</div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:Mono.DocTest.Widget.NestedClass`1:Docs:Version Information">
+      <div class="SectionBox" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Docs:Version Information">
         <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
       <h2 class="Section" id="Members">Members</h2>
       <div class="SectionBox" id="_Members">
@@ -249,7 +249,7 @@
                 <td>
                   <div>
                     <b>
-                      <a href="#C:Mono.DocTest.Widget.NestedClass`1()">Widget.NestedClass</a>
+                      <a href="#C:Mono.DocTest.Widget+NestedClass&lt;T&gt;()">Widget.NestedClass</a>
                     </b>()</div>
                 </td>
                 <td>
@@ -270,7 +270,7 @@
                 </td>
                 <td>
                   <b>
-                    <a href="#F:Mono.DocTest.Widget.NestedClass`1.value">value</a>
+                    <a href="#F:Mono.DocTest.Widget+NestedClass&lt;T&gt;.value">value</a>
                   </b>
                 </td>
                 <td>
@@ -292,7 +292,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32)">M</a>
+                    <a href="#M:Mono.DocTest.Widget+NestedClass&lt;T&gt;.M(System.Int32)">M</a>
                   </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -309,41 +309,41 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <a href="javascript:alert(&quot;Documentation not found.&quot;)">T</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
         </div>
       </div>
     </div>
-    <div class="Members" id="T:Mono.DocTest.Widget.NestedClass`1:Members">
+    <div class="Members" id="T:Mono.DocTest.Widget+NestedClass&lt;T&gt;:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="C:Mono.DocTest.Widget.NestedClass`1()">Widget.NestedClass Constructor</h3>
-        <blockquote id="C:Mono.DocTest.Widget.NestedClass`1():member">
+        <h3 id="C:Mono.DocTest.Widget+NestedClass&lt;T&gt;()">Widget.NestedClass Constructor</h3>
+        <blockquote id="C:Mono.DocTest.Widget+NestedClass&lt;T&gt;():member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public  <b>Widget.NestedClass</b> ()</div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass`1():Remarks">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass&lt;T&gt;():Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="C:Mono.DocTest.Widget.NestedClass`1():Version Information">
+          <div class="SectionBox" id="C:Mono.DocTest.Widget+NestedClass&lt;T&gt;():Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32)">M Method</h3>
-        <blockquote id="M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32):member">
+        <h3 id="M:Mono.DocTest.Widget+NestedClass&lt;T&gt;.M(System.Int32)">M Method</h3>
+        <blockquote id="M:Mono.DocTest.Widget+NestedClass&lt;T&gt;.M(System.Int32):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>M</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> i)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget+NestedClass&lt;T&gt;.M(System.Int32):Parameters">
             <dl>
               <dt>
                 <i>i</i>
@@ -352,25 +352,25 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget+NestedClass&lt;T&gt;.M(System.Int32):Remarks">
             <tt>M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget+NestedClass&lt;T&gt;.M(System.Int32):Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="F:Mono.DocTest.Widget.NestedClass`1.value">value Field</h3>
-        <blockquote id="F:Mono.DocTest.Widget.NestedClass`1.value:member">
+        <h3 id="F:Mono.DocTest.Widget+NestedClass&lt;T&gt;.value">value Field</h3>
+        <blockquote id="F:Mono.DocTest.Widget+NestedClass&lt;T&gt;.value:member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> <b>value</b> </div>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Widget.NestedClass`1.value:Remarks">
+          <div class="SectionBox" id="F:Mono.DocTest.Widget+NestedClass&lt;T&gt;.value:Remarks">
             <tt>F:Mono.DocTest.Widget.NestedClass`1.value</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="F:Mono.DocTest.Widget.NestedClass`1.value:Version Information">
+          <div class="SectionBox" id="F:Mono.DocTest.Widget+NestedClass&lt;T&gt;.value:Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget.html
+++ b/mcs/tools/mdoc/Test/html.expected/Mono.DocTest/Widget.html
@@ -260,7 +260,7 @@
                   <div>
                     <b>
                       <a href="#C:Mono.DocTest.Widget(System.Converter{System.String,System.String})">Widget</a>
-                    </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter`2">Converter&lt;string, string&gt;</a>)</div>
+                    </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter&lt;System.String,System.String&gt;">Converter&lt;string, string&gt;</a>)</div>
                 </td>
                 <td>
                   <span class="NotEntered">Documentation for this section has not yet been entered.</span>
@@ -341,7 +341,7 @@
                 </td>
                 <td>
                   <i>
-                    <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a>
+                    <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a>
                   </i>. <span class="NotEntered">Documentation for this section has not yet been entered.</span></td>
               </tr>
               <tr valign="top">
@@ -466,7 +466,7 @@
                 </td>
                 <td>
                   <i>
-                    <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a>
+                    <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a>
                   </i>. <span class="NotEntered">Documentation for this section has not yet been entered.</span></td>
               </tr>
               <tr valign="top">
@@ -609,7 +609,7 @@
                 <td colspan="2">
                   <b>
                     <a href="#M:Mono.DocTest.Widget.Dynamic1(System.Collections.Generic.Dictionary{System.Object,System.String})">Dynamic1</a>
-                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary`2">Dictionary&lt;object, string&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary`2">Dictionary&lt;object, string&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;">Dictionary&lt;object, string&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;">Dictionary&lt;object, string&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -619,7 +619,7 @@
                 <td colspan="2">
                   <b>
                     <a href="#M:Mono.DocTest.Widget.Dynamic2(System.Func{System.String,System.Object})">Dynamic2</a>
-                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;string, object&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;string, object&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.String,System.Object&gt;">Func&lt;string, object&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.String,System.Object&gt;">Func&lt;string, object&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -629,7 +629,7 @@
                 <td colspan="2">
                   <b>
                     <a href="#M:Mono.DocTest.Widget.Dynamic3(System.Func{System.Func{System.String,System.Object},System.Func{System.Object,System.String}})">Dynamic3</a>
-                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                  </b>(<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -667,7 +667,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple)">M7</a>
+                    <a href="#M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple)">M7</a>
                   </b>(<a href="../Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.html">Widget.NestedClass.Double.Triple.Quadruple</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -857,7 +857,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
@@ -898,14 +898,14 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public  <b>Widget</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter`2">Converter&lt;string, string&gt;</a> c)</div>
+          <div class="Signature">public  <b>Widget</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter&lt;System.String,System.String&gt;">Converter&lt;string, string&gt;</a> c)</div>
           <h4 class="Subsection">Parameters</h4>
           <blockquote class="SubsectionBox" id="C:Mono.DocTest.Widget(System.Converter{System.String,System.String}):Parameters">
             <dl>
               <dt>
                 <i>c</i>
               </dt>
-              <dd>A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter`2">Converter&lt;string, string&gt;</a>.</dd>
+              <dd>A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter&lt;System.String,System.String&gt;">Converter&lt;string, string&gt;</a>.</dd>
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
@@ -1249,7 +1249,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary`2">Dictionary&lt;object, string&gt;</a> <b>Dynamic1</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary`2">Dictionary&lt;object, string&gt;</a> value)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;">Dictionary&lt;object, string&gt;</a> <b>Dynamic1</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;">Dictionary&lt;object, string&gt;</a> value)</div>
           <h4 class="Subsection">Parameters</h4>
           <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget.Dynamic1(System.Collections.Generic.Dictionary{System.Object,System.String}):Parameters">
             <dl>
@@ -1280,7 +1280,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;string, object&gt;</a> <b>Dynamic2</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;string, object&gt;</a> value)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.String,System.Object&gt;">Func&lt;string, object&gt;</a> <b>Dynamic2</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.String,System.Object&gt;">Func&lt;string, object&gt;</a> value)</div>
           <h4 class="Subsection">Parameters</h4>
           <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget.Dynamic2(System.Func{System.String,System.Object}):Parameters">
             <dl>
@@ -1311,7 +1311,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a> <b>Dynamic3</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a> value)</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a> <b>Dynamic3</b> (<a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;">Func&lt;Func&lt;string, object&gt;, Func&lt;object, string&gt;&gt;</a> value)</div>
           <h4 class="Subsection">Parameters</h4>
           <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget.Dynamic3(System.Func{System.Func{System.String,System.Object},System.Func{System.Object,System.String}}):Parameters">
             <dl>
@@ -1342,7 +1342,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">[System.Obsolete("why not")]<br />public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`1">Func&lt;object&gt;</a> <b>DynamicE1</b> </div>
+          <div class="Signature">[System.Obsolete("why not")]<br />public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Object&gt;">Func&lt;object&gt;</a> <b>DynamicE1</b> </div>
           <h4 class="Subsection">Exceptions</h4>
           <blockquote class="SubsectionBox" id="E:Mono.DocTest.Widget.DynamicE1:Exceptions">
             <table class="TypeDocumentation">
@@ -1447,7 +1447,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`1">Func&lt;object&gt;</a> <b>DynamicE2</b> </div>
+          <div class="Signature">public event <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Object&gt;">Func&lt;object&gt;</a> <b>DynamicE2</b> </div>
           <h2 class="Section">Remarks</h2>
           <div class="SectionBox" id="E:Mono.DocTest.Widget.DynamicE2:Remarks">
             <tt>E:Mono.DocTest.Widget.DynamicE2</tt>
@@ -1463,7 +1463,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a> <b>DynamicF</b> </div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a> <b>DynamicF</b> </div>
           <h2 class="Section">Remarks</h2>
           <div class="SectionBox" id="F:Mono.DocTest.Widget.DynamicF:Remarks">
             <tt>F:Mono.DocTest.Widget.DynamicF</tt>
@@ -1479,7 +1479,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func`2">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a> <b>DynamicP</b>  { get; }</div>
+          <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;">Func&lt;Func&lt;string, object, string&gt;, Func&lt;object, Func&lt;System.Object&gt;,System.String&gt;&gt;</a> <b>DynamicP</b>  { get; }</div>
           <h4 class="Subsection">Value</h4>
           <blockquote class="SubsectionBox" id="P:Mono.DocTest.Widget.DynamicP:Value">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
@@ -1763,15 +1763,15 @@
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple)">M7 Method</h3>
-        <blockquote id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple):member">
+        <h3 id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple)">M7 Method</h3>
+        <blockquote id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>M7</b> (<a href="../Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.html">Widget.NestedClass.Double.Triple.Quadruple</a> a)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple):Parameters">
+          <blockquote class="SubsectionBox" id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple):Parameters">
             <dl>
               <dt>
                 <i>a</i>
@@ -1782,10 +1782,10 @@
             </dl>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple):Remarks">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple):Remarks">
             <tt>M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple)</tt>.</div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple):Version Information">
+          <div class="SectionBox" id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple):Version Information">
             <b>Namespace: </b>Mono.DocTest<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/NoNamespace.html
+++ b/mcs/tools/mdoc/Test/html.expected/NoNamespace.html
@@ -260,7 +260,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>

--- a/mcs/tools/mdoc/Test/html.expected/System/Action`1.html
+++ b/mcs/tools/mdoc/Test/html.expected/System/Action`1.html
@@ -190,32 +190,32 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">System Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:System.Action`1">Overview</a>
+        <a href="#T:System.Action&lt;T&gt;">Overview</a>
       </p>
       <p>
-        <a href="#T:System.Action`1:Signature">Signature</a>
+        <a href="#T:System.Action&lt;T&gt;:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:System.Action`1:Docs">Remarks</a>
+        <a href="#T:System.Action&lt;T&gt;:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:System.Action`1:Members">Member Details</a>
+        <a href="#T:System.Action&lt;T&gt;:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:System.Action`1">Action&lt;T&gt; Generic Delegate</h1>
-    <p class="Summary" id="T:System.Action`1:Summary">
+    <h1 class="PageTitle" id="T:System.Action&lt;T&gt;">Action&lt;T&gt; Generic Delegate</h1>
+    <p class="Summary" id="T:System.Action&lt;T&gt;:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:System.Action`1:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Action&lt;T&gt;</b> (<i title="To be added.">T</i> obj)</div>
+      <div class="Signature" id="T:System.Action&lt;T&gt;:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Action&lt;T&gt;</b> (<i title="To be added.">T</i> obj)</div>
     </div>
-    <div class="Remarks" id="T:System.Action`1:Docs">
+    <div class="Remarks" id="T:System.Action&lt;T&gt;:Docs">
       <h4 class="Subsection">Type Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:System.Action`1:Docs:Type Parameters">
+      <blockquote class="SubsectionBox" id="T:System.Action&lt;T&gt;:Docs:Type Parameters">
         <dl>
           <dt>
             <i>T</i>
@@ -226,7 +226,7 @@
         </dl>
       </blockquote>
       <h4 class="Subsection">Parameters</h4>
-      <blockquote class="SubsectionBox" id="T:System.Action`1:Docs:Parameters">
+      <blockquote class="SubsectionBox" id="T:System.Action&lt;T&gt;:Docs:Parameters">
         <dl>
           <dt>
             <i>obj</i>
@@ -237,14 +237,14 @@
         </dl>
       </blockquote>
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:System.Action`1:Docs:Remarks">
+      <div class="SectionBox" id="T:System.Action&lt;T&gt;:Docs:Remarks">
         <tt>T:System.Action`1</tt>
       </div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:System.Action`1:Docs:Version Information">
+      <div class="SectionBox" id="T:System.Action&lt;T&gt;:Docs:Version Information">
         <b>Namespace: </b>System<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
     </div>
-    <div class="Members" id="T:System.Action`1:Members">
+    <div class="Members" id="T:System.Action&lt;T&gt;:Members">
     </div>
     <hr size="1" />
     <div class="Copyright">

--- a/mcs/tools/mdoc/Test/html.expected/System/Array.html
+++ b/mcs/tools/mdoc/Test/html.expected/System/Array.html
@@ -259,8 +259,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:System.Array.AsReadOnly``1(``0[])">AsReadOnly&lt;T&gt;</a>
-                  </b>(<i title="To be added.">T</i>[])<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.ObjectModel.ReadOnlyCollection`1">System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:System.Array.AsReadOnly{T}(T[])">AsReadOnly&lt;T&gt;</a>
+                  </b>(<i title="To be added.">T</i>[])<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;">System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -268,8 +268,8 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1})">ConvertAll&lt;TInput,TOutput&gt;</a>
-                  </b>(<i title="To be added.">TInput</i>[], <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter`2">Converter&lt;TInput, TOutput&gt;</a>)<nobr> : <i title="To be added.">TOutput</i>[]</nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
+                    <a href="#M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput})">ConvertAll&lt;TInput,TOutput&gt;</a>
+                  </b>(<i title="To be added.">TInput</i>[], <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter&lt;TInput,TOutput&gt;">Converter&lt;TInput, TOutput&gt;</a>)<nobr> : <i title="To be added.">TOutput</i>[]</nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
               <tr valign="top">
                 <td>
@@ -277,7 +277,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:System.Array.Resize``1(``0[]@,System.Int32)">Resize&lt;T&gt;</a>
+                    <a href="#M:System.Array.Resize{T}(T[]@,System.Int32)">Resize&lt;T&gt;</a>
                   </b>(<i>ref</i> <i title="To be added.">T</i>[], <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a>)<blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -294,7 +294,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/Extensions.html#M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)">ToEnumerable&lt;T&gt;</a>
-                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable`1">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
+                  </b>(<i>this</i> <i title="To be added.">T</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.IEnumerable&lt;T&gt;">IEnumerable&lt;T&gt;</a></nobr><blockquote><tt>System.Object</tt> extension method</blockquote></td>
               </tr>
             </table>
           </div>
@@ -320,15 +320,15 @@
             <b>Namespace: </b>System<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:System.Array.AsReadOnly``1(``0[])">AsReadOnly&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:System.Array.AsReadOnly``1(``0[]):member">
+        <h3 id="M:System.Array.AsReadOnly{T}(T[])">AsReadOnly&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:System.Array.AsReadOnly{T}(T[]):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.ObjectModel.ReadOnlyCollection`1">System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</a> <b>AsReadOnly&lt;T&gt;</b> (<i title="To be added.">T</i>[] array)</div>
+          <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;">System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</a> <b>AsReadOnly&lt;T&gt;</b> (<i title="To be added.">T</i>[] array)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly``1(``0[]):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly{T}(T[]):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -339,7 +339,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly``1(``0[]):Parameters">
+          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly{T}(T[]):Parameters">
             <dl>
               <dt>
                 <i>array</i>
@@ -350,11 +350,11 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly``1(``0[]):Returns">
+          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly{T}(T[]):Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h4 class="Subsection">Exceptions</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly``1(``0[]):Exceptions">
+          <blockquote class="SubsectionBox" id="M:System.Array.AsReadOnly{T}(T[]):Exceptions">
             <table class="TypeDocumentation">
               <tr>
                 <th>Type</th>
@@ -371,23 +371,23 @@
             </table>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:System.Array.AsReadOnly``1(``0[]):Remarks">
+          <div class="SectionBox" id="M:System.Array.AsReadOnly{T}(T[]):Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:System.Array.AsReadOnly``1(``0[]):Version Information">
+          <div class="SectionBox" id="M:System.Array.AsReadOnly{T}(T[]):Version Information">
             <b>Namespace: </b>System<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1})">ConvertAll&lt;TInput,TOutput&gt; Generic Method</h3>
-        <blockquote id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1}):member">
+        <h3 id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput})">ConvertAll&lt;TInput,TOutput&gt; Generic Method</h3>
+        <blockquote id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput}):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">public static <i title="To be added.">TOutput</i>[] <b>ConvertAll&lt;TInput, TOutput&gt;</b> (<i title="To be added.">TInput</i>[] array, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter`2">Converter&lt;TInput, TOutput&gt;</a> converter)</div>
+          <div class="Signature">public static <i title="To be added.">TOutput</i>[] <b>ConvertAll&lt;TInput, TOutput&gt;</b> (<i title="To be added.">TInput</i>[] array, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Converter&lt;TInput,TOutput&gt;">Converter&lt;TInput, TOutput&gt;</a> converter)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1}):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput}):Type Parameters">
             <dl>
               <dt>
                 <i>TInput</i>
@@ -404,7 +404,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1}):Parameters">
+          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput}):Parameters">
             <dl>
               <dt>
                 <i>array</i>
@@ -421,11 +421,11 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1}):Returns">
+          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput}):Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h4 class="Subsection">Exceptions</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1}):Exceptions">
+          <blockquote class="SubsectionBox" id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput}):Exceptions">
             <table class="TypeDocumentation">
               <tr>
                 <th>Type</th>
@@ -442,23 +442,23 @@
             </table>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1}):Remarks">
+          <div class="SectionBox" id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput}):Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1}):Version Information">
+          <div class="SectionBox" id="M:System.Array.ConvertAll{TInput, TOutput}(TInput[],System.Converter{TInput,TOutput}):Version Information">
             <b>Namespace: </b>System<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>
-        <h3 id="M:System.Array.Resize``1(``0[]@,System.Int32)">Resize&lt;T&gt; Generic Method</h3>
-        <blockquote id="M:System.Array.Resize``1(``0[]@,System.Int32):member">
+        <h3 id="M:System.Array.Resize{T}(T[]@,System.Int32)">Resize&lt;T&gt; Generic Method</h3>
+        <blockquote id="M:System.Array.Resize{T}(T[]@,System.Int32):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Void">void</a> <b>Resize&lt;T&gt;</b> (<i>ref</i> <i title="To be added.">T</i>[] array, <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int32">int</a> newSize)</div>
           <h4 class="Subsection">Type Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.Resize``1(``0[]@,System.Int32):Type Parameters">
+          <blockquote class="SubsectionBox" id="M:System.Array.Resize{T}(T[]@,System.Int32):Type Parameters">
             <dl>
               <dt>
                 <i>T</i>
@@ -469,7 +469,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.Resize``1(``0[]@,System.Int32):Parameters">
+          <blockquote class="SubsectionBox" id="M:System.Array.Resize{T}(T[]@,System.Int32):Parameters">
             <dl>
               <dt>
                 <i>array</i>
@@ -486,7 +486,7 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Exceptions</h4>
-          <blockquote class="SubsectionBox" id="M:System.Array.Resize``1(``0[]@,System.Int32):Exceptions">
+          <blockquote class="SubsectionBox" id="M:System.Array.Resize{T}(T[]@,System.Int32):Exceptions">
             <table class="TypeDocumentation">
               <tr>
                 <th>Type</th>
@@ -503,11 +503,11 @@
             </table>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:System.Array.Resize``1(``0[]@,System.Int32):Remarks">
+          <div class="SectionBox" id="M:System.Array.Resize{T}(T[]@,System.Int32):Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:System.Array.Resize``1(``0[]@,System.Int32):Version Information">
+          <div class="SectionBox" id="M:System.Array.Resize{T}(T[]@,System.Int32):Version Information">
             <b>Namespace: </b>System<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>

--- a/mcs/tools/mdoc/Test/html.expected/System/Environment+SpecialFolder.html
+++ b/mcs/tools/mdoc/Test/html.expected/System/Environment+SpecialFolder.html
@@ -190,36 +190,36 @@
       <a href="../index.html">DocTest</a> : <a href="index.html">System Namespace</a></div>
     <div class="SideBar">
       <p>
-        <a href="#T:System.Environment.SpecialFolder">Overview</a>
+        <a href="#T:System.Environment+SpecialFolder">Overview</a>
       </p>
       <p>
-        <a href="#T:System.Environment.SpecialFolder:Signature">Signature</a>
+        <a href="#T:System.Environment+SpecialFolder:Signature">Signature</a>
       </p>
       <p>
-        <a href="#T:System.Environment.SpecialFolder:Docs">Remarks</a>
+        <a href="#T:System.Environment+SpecialFolder:Docs">Remarks</a>
       </p>
       <p>
         <a href="#Members">Members</a>
       </p>
       <p>
-        <a href="#T:System.Environment.SpecialFolder:Members">Member Details</a>
+        <a href="#T:System.Environment+SpecialFolder:Members">Member Details</a>
       </p>
     </div>
-    <h1 class="PageTitle" id="T:System.Environment.SpecialFolder">Environment.SpecialFolder  Enum</h1>
-    <p class="Summary" id="T:System.Environment.SpecialFolder:Summary">
+    <h1 class="PageTitle" id="T:System.Environment+SpecialFolder">Environment.SpecialFolder  Enum</h1>
+    <p class="Summary" id="T:System.Environment+SpecialFolder:Summary">
       <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:System.Environment.SpecialFolder:Signature">public enum <b>Environment.SpecialFolder</b></div>
+      <div class="Signature" id="T:System.Environment+SpecialFolder:Signature">public enum <b>Environment.SpecialFolder</b></div>
     </div>
-    <div class="Remarks" id="T:System.Environment.SpecialFolder:Docs">
+    <div class="Remarks" id="T:System.Environment+SpecialFolder:Docs">
       <h2 class="Section">Remarks</h2>
-      <div class="SectionBox" id="T:System.Environment.SpecialFolder:Docs:Remarks">
+      <div class="SectionBox" id="T:System.Environment+SpecialFolder:Docs:Remarks">
         <tt>T:System.Environment+SpecialFolder</tt>
       </div>
       <h2 class="Section">Members</h2>
-      <div class="SectionBox" id="T:System.Environment.SpecialFolder:Docs:Members">
+      <div class="SectionBox" id="T:System.Environment+SpecialFolder:Docs:Members">
         <table class="Enumeration">
           <tr>
             <th>Member Name</th>
@@ -228,10 +228,10 @@
         </table>
       </div>
       <h2 class="Section">Requirements</h2>
-      <div class="SectionBox" id="T:System.Environment.SpecialFolder:Docs:Version Information">
+      <div class="SectionBox" id="T:System.Environment+SpecialFolder:Docs:Version Information">
         <b>Namespace: </b>System<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
     </div>
-    <div class="Members" id="T:System.Environment.SpecialFolder:Members">
+    <div class="Members" id="T:System.Environment+SpecialFolder:Members">
     </div>
     <hr size="1" />
     <div class="Copyright">

--- a/mcs/tools/mdoc/Test/html.expected/System/Environment.html
+++ b/mcs/tools/mdoc/Test/html.expected/System/Environment.html
@@ -237,7 +237,7 @@
                 </td>
                 <td colspan="2">
                   <b>
-                    <a href="#M:System.Environment.GetFolderPath(System.Environment.SpecialFolder)">GetFolderPath</a>
+                    <a href="#M:System.Environment.GetFolderPath(System.Environment+SpecialFolder)">GetFolderPath</a>
                   </b>(<a href="../System/Environment+SpecialFolder.html">Environment.SpecialFolder</a>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.String">string</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span></blockquote></td>
               </tr>
             </table>
@@ -248,15 +248,15 @@
     <div class="Members" id="T:System.Environment:Members">
       <h2 class="Section" id="MemberDetails">Member Details</h2>
       <div class="SectionBox" id="_MemberDetails">
-        <h3 id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder)">GetFolderPath Method</h3>
-        <blockquote id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder):member">
+        <h3 id="M:System.Environment.GetFolderPath(System.Environment+SpecialFolder)">GetFolderPath Method</h3>
+        <blockquote id="M:System.Environment.GetFolderPath(System.Environment+SpecialFolder):member">
           <div class="msummary">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
           <div class="Signature">public static <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.String">string</a> <b>GetFolderPath</b> (<a href="../System/Environment+SpecialFolder.html">Environment.SpecialFolder</a> folder)</div>
           <h4 class="Subsection">Parameters</h4>
-          <blockquote class="SubsectionBox" id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder):Parameters">
+          <blockquote class="SubsectionBox" id="M:System.Environment.GetFolderPath(System.Environment+SpecialFolder):Parameters">
             <dl>
               <dt>
                 <i>folder</i>
@@ -267,11 +267,11 @@
             </dl>
           </blockquote>
           <h4 class="Subsection">Returns</h4>
-          <blockquote class="SubsectionBox" id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder):Returns">
+          <blockquote class="SubsectionBox" id="M:System.Environment.GetFolderPath(System.Environment+SpecialFolder):Returns">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </blockquote>
           <h4 class="Subsection">Exceptions</h4>
-          <blockquote class="SubsectionBox" id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder):Exceptions">
+          <blockquote class="SubsectionBox" id="M:System.Environment.GetFolderPath(System.Environment+SpecialFolder):Exceptions">
             <table class="TypeDocumentation">
               <tr>
                 <th>Type</th>
@@ -288,11 +288,11 @@
             </table>
           </blockquote>
           <h2 class="Section">Remarks</h2>
-          <div class="SectionBox" id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder):Remarks">
+          <div class="SectionBox" id="M:System.Environment.GetFolderPath(System.Environment+SpecialFolder):Remarks">
             <tt>M:System.Environment.GetFolderPath(System.Environment+SpecialFolder)</tt>
           </div>
           <h2 class="Section">Requirements</h2>
-          <div class="SectionBox" id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder):Version Information">
+          <div class="SectionBox" id="M:System.Environment.GetFolderPath(System.Environment+SpecialFolder):Version Information">
             <b>Namespace: </b>System<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
           <hr size="1" />
         </blockquote>


### PR DESCRIPTION
There is an issue with parsing CREF links that have generic parameters. As a workaround,
this patch changes the way we generate links to include
the generic types, rather than using the format using tick marks
ie.

```
M:MyNamespace.MyType`1.MyMethod(``0)
```
