### PR TITLE
Remove throw statement in IPAddress.TryParse

### DIFF
--- a/mcs/class/System/System.Net/IPAddress.cs
+++ b/mcs/class/System/System.Net/IPAddress.cs
@@ -184,6 +184,9 @@ namespace System.Net {
 
 		public static IPAddress Parse (string ipString)
 		{
+            if (ipString == null)
+                throw new ArgumentNullException("ipString");
+
 			IPAddress ret;
 			if (TryParse (ipString, out ret))
 				return ret;

--- a/mcs/class/System/System.Net/IPAddress.cs
+++ b/mcs/class/System/System.Net/IPAddress.cs
@@ -193,7 +193,10 @@ namespace System.Net {
 		public static bool TryParse (string ipString, out IPAddress address)
 		{
 			if (ipString == null)
-				throw new ArgumentNullException ("ipString");
+			{
+				address = null;
+				return false;
+			}
 
 			if ((address = ParseIPV4 (ipString)) == null)
 				if ((address = ParseIPV6 (ipString)) == null)

--- a/mcs/class/System/Test/System.Net/IPAddressTest.cs
+++ b/mcs/class/System/Test/System.Net/IPAddressTest.cs
@@ -532,16 +532,11 @@ public class IPAddressTest
 	public void TryParse_IpString_Null ()
 	{
 		IPAddress i;
-
-		try {
-			IPAddress.TryParse ((string) null, out i);
-			Assert.Fail ("#1");
-		} catch (ArgumentNullException ex) {
-			Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
-			Assert.IsNull (ex.InnerException, "#3");
-			Assert.IsNotNull (ex.Message, "#4");
-			Assert.AreEqual ("ipString", ex.ParamName, "#5");
-		}
+		
+		bool val1 = IPAddress.TryParse ((string) null, out i);
+		
+		Assert.IsFalse (val1, "#1");
+		Assert.IsNull (i, "#2");
 	}
 
 	[Test]


### PR DESCRIPTION
In Microsoft's implementation, no exceptions are thrown in this particular method. See here for details: http://referencesource.microsoft.com/#System/net/System/Net/IPAddress.cs,54a3a3f536d5a22c