### PR TITLE
Do not remap framework assembly if it's version is higher than the ru…

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1016,6 +1016,12 @@ mono_assembly_remap_version (MonoAssemblyName *aname, MonoAssemblyName *dest_ana
 			if (aname->major == vset->major && aname->minor == vset->minor &&
 				aname->build == vset->build && aname->revision == vset->revision)
 				return aname;
+
+			if (compare_versions (vset, aname) < 0) {
+				// requested version is newer than current
+				// runtime version, don't remap
+				return aname;
+			}
 		
 			if ((aname->major | aname->minor | aname->build | aname->revision) != 0)
 				mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_ASSEMBLY,


### PR DESCRIPTION
…ntime version

Currently, assemblies like Microsoft.Build.Framework and
Microsoft.Build.Engine get remapped to the current runtime version, at
load time. This means that if an assembly references the above
assemblies with a version like `14.1.0.0`, then that would get remapped
to `4.0.0.0`. This is incorrect behavior and breaks msbuild. Instead,
now we do the remapping only if the requested version is lower than the
runtime version.