### PR TITLE
Enhance log tracing

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1756,6 +1756,10 @@ Controls where trace log messages are written. If not set then the messages go t
 If set, the string either specifies a path to a file that will have messages appended to
 it, or the string "syslog" in which case the messages will be written to the system log.
 Under Windows, this is simulated by writing to a file called "mono.log". 
+\fBMONO_LOG_HEADER\fR
+Controls whether trace log messages not directed to syslog have the id, timestamp, and
+pid as the prefix to the log message. To enable a header this environment variable need
+just be non-null. 
 .TP
 \fBMONO_TRACE\fR
 Used for runtime tracing of method calls. The format of the comma separated

--- a/man/mono.1
+++ b/man/mono.1
@@ -1751,6 +1751,12 @@ messages for a certain component. You can use multiple masks by comma
 separating them. For example to see config file messages and assembly loader
 messages set you mask to "asm,cfg".
 .TP
+\fBMONO_LOG_DEST\fR
+Controls where trace log messages are written. If not set then the messages go to stdout. 
+If set, the string either specifies a path to a file that will have messages appended to
+it, or the string "syslog" in which case the messages will be written to the system log.
+Under Windows, this is simulated by writing to a file called "mono.log". 
+.TP
 \fBMONO_TRACE\fR
 Used for runtime tracing of method calls. The format of the comma separated
 trace options is:

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -130,13 +130,26 @@ extern guint64 stat_objects_copied_major;
 
 #define SGEN_LOG(level, format, ...) do {      \
 	if (G_UNLIKELY ((level) <= SGEN_MAX_DEBUG_LEVEL && (level) <= gc_debug_level)) {	\
-		mono_gc_printf (gc_debug_file, format "\n", ##__VA_ARGS__);	\
+		time_t t;									\
+		struct tm tod;									\
+		char logTime[80];								\
+		time(&t);									\
+		localtime_r(&t, &tod);								\
+		strftime(logTime, sizeof(logTime), "%F-%T", &tod);				\
+		mono_gc_printf (gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__);	\
 } } while (0)
 
 #define SGEN_COND_LOG(level, cond, format, ...) do {	\
-	if (G_UNLIKELY ((level) <= SGEN_MAX_DEBUG_LEVEL && (level) <= gc_debug_level)) {	\
-		if (cond)	\
-			mono_gc_printf (gc_debug_file, format "\n", ##__VA_ARGS__);	\
+	if (G_UNLIKELY ((level) <= SGEN_MAX_DEBUG_LEVEL && (level) <= gc_debug_level)) {		\
+		if (cond) {										\
+			time_t t;									\
+			struct tm tod;									\
+			char logTime[80];								\
+			time(&t);									\
+			localtime_r(&t,&tod);								\
+			strftime(logTime, sizeof(logTime), "%F-%T", &tod);				\
+			mono_gc_printf (gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__);	\
+		}											\
 } } while (0)
 
 extern int gc_debug_level;

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -135,7 +135,7 @@ extern guint64 stat_objects_copied_major;
 		char logTime[80];								\
 		time(&t);									\
 		localtime_r(&t, &tod);								\
-		strftime(logTime, sizeof(logTime), "%F-%T", &tod);				\
+		strftime(logTime, sizeof(logTime), "%F %T", &tod);				\
 		mono_gc_printf (gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__);	\
 } } while (0)
 
@@ -147,7 +147,7 @@ extern guint64 stat_objects_copied_major;
 			char logTime[80];								\
 			time(&t);									\
 			localtime_r(&t,&tod);								\
-			strftime(logTime, sizeof(logTime), "%F-%T", &tod);				\
+			strftime(logTime, sizeof(logTime), "%F %T", &tod);				\
 			mono_gc_printf (gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__);	\
 		}											\
 } } while (0)

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -128,13 +128,19 @@ extern guint64 stat_objects_copied_major;
 } } while (0)
 
 
+#ifdef HOST_WIN32
+# define LOG_LOCALTIME localtime
+#else
+# define LOG_LOCALTIME localtime_r
+#endif
+
 #define SGEN_LOG(level, format, ...) do {      \
 	if (G_UNLIKELY ((level) <= SGEN_MAX_DEBUG_LEVEL && (level) <= gc_debug_level)) {	\
 		time_t t;									\
 		struct tm tod;									\
 		char logTime[80];								\
 		time(&t);									\
-		localtime_r(&t, &tod);								\
+		LOG_LOCALTIME(&t, &tod);							\
 		strftime(logTime, sizeof(logTime), "%F %T", &tod);				\
 		mono_gc_printf (gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__);	\
 } } while (0)
@@ -146,7 +152,7 @@ extern guint64 stat_objects_copied_major;
 			struct tm tod;									\
 			char logTime[80];								\
 			time(&t);									\
-			localtime_r(&t,&tod);								\
+			LOG_LOCALTIME(&t,&tod);								\
 			strftime(logTime, sizeof(logTime), "%F %T", &tod);				\
 			mono_gc_printf (gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__);	\
 		}											\

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -134,7 +134,7 @@ extern guint64 stat_objects_copied_major;
 		struct tm tod;									\
 		time(&t);									\
 		localtime_r(&t, &tod);								\
-		strftime(logTime, sizeof(logTime), "%F %T", &tod);				\
+		strftime(logTime, sizeof(logTime), "%Y-%m-%d %H:%M:%S", &tod);			\
 	} while (0)
 #else
 # define LOG_TIMESTAMP  \

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -27,6 +27,9 @@ monoutils_sources = \
 	mono-dl-darwin.c	\
 	mono-dl-posix.c		\
 	mono-dl.h		\
+	mono-log-windows.c	\
+	mono-log-common.c	\
+	mono-log-posix.c	\
 	mono-internal-hash.c	\
 	mono-internal-hash.h	\
 	mono-io-portability.c 	\

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -1,0 +1,124 @@
+/*
+ * mono-log-common.c: Platform-independent interface to the logger
+ *
+ * This module contains the POSIX syslog logger interface
+ *
+ * Author:
+ *    Neale Ferguson <neale@sinenomine.net>
+ *
+ */
+#include <config.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <glib.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/time.h>
+#include "mono-logger.h"
+
+static FILE *logFile = NULL;
+static void *logUserData = NULL;
+
+/**
+ * mapSyslogLevel:
+ * 	
+ * 	@level - GLogLevelFlags value
+ * 	@returns The equivalent character identifier
+ */
+static __inline__ char 
+mapLogFileLevel(GLogLevelFlags level) 
+{
+	if (level & G_LOG_LEVEL_ERROR)
+		return ('E');
+	if (level & G_LOG_LEVEL_CRITICAL)
+		return ('C');
+	if (level & G_LOG_LEVEL_WARNING)
+		return ('W');
+	if (level & G_LOG_LEVEL_MESSAGE)
+		return ('N');
+	if (level & G_LOG_LEVEL_INFO)
+		return ('I');
+	if (level & G_LOG_LEVEL_DEBUG)
+		return ('D');
+	return ('I');
+}
+
+/**
+ * mono_log_open_logfile
+ * 	
+ *	Open the logfile. If the path is not specified default to stdout. If the
+ *	open fails issue a warning and use stdout as the log file destination.
+ *
+ * 	@path - Path for log file
+ * 	@userData - Not used
+ */
+void
+mono_log_open_logfile(const char *path, void *userData)
+{
+	if (path == NULL) {
+		logFile = stdout;
+	} else {
+		logFile = fopen(path, "w");
+		if (logFile == NULL) {
+			g_warning("opening of log file %s failed with %s - defaulting to stdout", 
+				  path, strerror(errno));
+		}
+	}
+	logUserData = userData;
+}
+
+/**
+ * mono_log_write_logfile
+ * 	
+ * 	Write data to the log file.
+ *
+ * 	@domain - Identifier string
+ * 	@level - Logging level flags
+ * 	@format - Printf format string
+ * 	@vargs - Variable argument list
+ */
+void
+mono_log_write_logfile(const char *domain, GLogLevelFlags level, const char *format, va_list args)
+{
+	time_t t;
+	struct tm tod;
+	char logTime[80];
+	pid_t pid;
+
+	if (logFile == NULL)
+		logFile = stdout;
+
+	time(&t);
+	localtime_r(&t, &tod);
+	pid = getpid();
+	strftime(logTime, sizeof(logTime), "%F %T", &tod);
+	fprintf(logFile, "%s level[%c] mono[%d]: ",logTime,mapLogFileLevel(level),pid);
+	vfprintf(logFile, format, args);
+	fputc('\n', logFile);
+	fflush(logFile);
+
+	if (level == G_LOG_FLAG_FATAL)
+		abort();
+}
+
+/**
+ * mono_log_close_logfile
+ *
+ * 	Close the log file
+ */
+void
+mono_log_close_logfile()
+{
+	if (logFile) {
+		if (logFile != stdout)
+			fclose(logFile);
+		logFile = NULL;
+	}
+}

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -72,7 +72,7 @@ mono_log_open_logfile(const char *path, void *userData)
 #ifndef HOST_WIN32
 		logFile = fopen(path, "w");
 #else
-		guinchar2 *wPath = g_utf8_to_utf16(path, -1, 0, 0, 0);
+		gunichar2 *wPath = g_utf8_to_utf16(path, -1, 0, 0, 0);
 		if (wPath != NULL) {
 			logFile = _wfopen((wchar_t *) wPath, L"w");
 			g_free (wPath);

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -22,6 +22,8 @@
 #include <time.h>
 #ifndef HOST_WIN32
 #include <sys/time.h>
+#else
+#include <process.h>
 #endif
 #include "mono-logger.h"
 
@@ -118,6 +120,9 @@ mono_log_write_logfile(const char *domain, GLogLevelFlags level, mono_bool hdr, 
 	}
 	nLog = sizeof(logMessage) - iLog - 2;
 	iLog = vsnprintf(logMessage+iLog, nLog, format, args);
+#ifdef HOST_WIN32
+	logMessage[iLog++] = '\r';
+#endif
 	logMessage[iLog++] = '\n';
 	logMessage[iLog++] = '\0';
 	fputs(logMessage, logFile);

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -69,10 +69,19 @@ mono_log_open_logfile(const char *path, void *userData)
 	if (path == NULL) {
 		logFile = stdout;
 	} else {
+#ifndef HOST_WIN32
 		logFile = fopen(path, "w");
+#else
+		guinchar2 *wPath = g_utf8_to_utf16(path, -1, 0, 0, 0);
+		if (wPath != NULL) {
+			logFile = _wfopen((wchar_t *) wPath, L"w");
+			g_free (wPath);
+		}
+#endif
 		if (logFile == NULL) {
 			g_warning("opening of log file %s failed with %s - defaulting to stdout", 
 				  path, strerror(errno));
+			logFile = stdout;
 		}
 	}
 	logUserData = userData;

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -20,7 +20,9 @@
 #include <glib.h>
 #include <errno.h>
 #include <time.h>
+#ifndef HOST_WIN32
 #include <sys/time.h>
+#endif
 #include "mono-logger.h"
 
 static FILE *logFile = NULL;
@@ -32,7 +34,7 @@ static void *logUserData = NULL;
  * 	@level - GLogLevelFlags value
  * 	@returns The equivalent character identifier
  */
-static __inline__ char 
+static inline char 
 mapLogFileLevel(GLogLevelFlags level) 
 {
 	if (level & G_LOG_LEVEL_ERROR)
@@ -100,8 +102,13 @@ mono_log_write_logfile(const char *domain, GLogLevelFlags level, mono_bool hdr, 
 
 	if (hdr) {
 		time(&t);
+#ifndef HOST_WIN32
 		localtime_r(&t, &tod);
 		pid = getpid();
+#else
+		localtime(&t, &tod);
+		pid = _getpid();
+#endif
 		strftime(logTime, sizeof(logTime), "%F %T", &tod);
 		iLog = snprintf(logMessage, sizeof(logMessage), "%s level[%c] mono[%d]: ",
 				logTime,mapLogFileLevel(level),pid);

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -116,7 +116,7 @@ mono_log_write_logfile(const char *domain, GLogLevelFlags level, mono_bool hdr, 
 		time(&t);
 		localtime_r(&t, &tod);
 		pid = getpid();
-		strftime(logTime, sizeof(logTime), "%F %T", &tod);
+		strftime(logTime, sizeof(logTime), "%Y-%m-%d %H:%M:%S", &tod);
 #else
 		struct tm *tod;
 		time(&t);
@@ -129,9 +129,6 @@ mono_log_write_logfile(const char *domain, GLogLevelFlags level, mono_bool hdr, 
 	}
 	nLog = sizeof(logMessage) - iLog - 2;
 	iLog = vsnprintf(logMessage+iLog, nLog, format, args);
-#ifdef HOST_WIN32
-	logMessage[iLog++] = '\r';
-#endif
 	logMessage[iLog++] = '\n';
 	logMessage[iLog++] = '\0';
 	fputs(logMessage, logFile);

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -90,7 +90,6 @@ void
 mono_log_write_logfile(const char *domain, GLogLevelFlags level, mono_bool hdr, const char *format, va_list args)
 {
 	time_t t;
-	struct tm tod;
 	char logTime[80],	
 	     logMessage[512];
 	pid_t pid;
@@ -101,15 +100,19 @@ mono_log_write_logfile(const char *domain, GLogLevelFlags level, mono_bool hdr, 
 		logFile = stdout;
 
 	if (hdr) {
-		time(&t);
 #ifndef HOST_WIN32
+		struct tm tod;
+		time(&t);
 		localtime_r(&t, &tod);
 		pid = getpid();
-#else
-		localtime(&t, &tod);
-		pid = _getpid();
-#endif
 		strftime(logTime, sizeof(logTime), "%F %T", &tod);
+#else
+		struct tm *tod;
+		time(&t);
+		tod = localtime(&t);
+		pid = _getpid();
+		strftime(logTime, sizeof(logTime), "%F %T", tod);
+#endif
 		iLog = snprintf(logMessage, sizeof(logMessage), "%s level[%c] mono[%d]: ",
 				logTime,mapLogFileLevel(level),pid);
 	}

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -85,23 +85,32 @@ mono_log_open_logfile(const char *path, void *userData)
  * 	@vargs - Variable argument list
  */
 void
-mono_log_write_logfile(const char *domain, GLogLevelFlags level, const char *format, va_list args)
+mono_log_write_logfile(const char *domain, GLogLevelFlags level, mono_bool hdr, const char *format, va_list args)
 {
 	time_t t;
 	struct tm tod;
-	char logTime[80];
+	char logTime[80],	
+	     logMessage[512];
 	pid_t pid;
+	int iLog = 0;
+	size_t nLog;
 
 	if (logFile == NULL)
 		logFile = stdout;
 
-	time(&t);
-	localtime_r(&t, &tod);
-	pid = getpid();
-	strftime(logTime, sizeof(logTime), "%F %T", &tod);
-	fprintf(logFile, "%s level[%c] mono[%d]: ",logTime,mapLogFileLevel(level),pid);
-	vfprintf(logFile, format, args);
-	fputc('\n', logFile);
+	if (hdr) {
+		time(&t);
+		localtime_r(&t, &tod);
+		pid = getpid();
+		strftime(logTime, sizeof(logTime), "%F %T", &tod);
+		iLog = snprintf(logMessage, sizeof(logMessage), "%s level[%c] mono[%d]: ",
+				logTime,mapLogFileLevel(level),pid);
+	}
+	nLog = sizeof(logMessage) - iLog - 2;
+	iLog = vsnprintf(logMessage+iLog, nLog, format, args);
+	logMessage[iLog++] = '\n';
+	logMessage[iLog++] = '\0';
+	fputs(logMessage, logFile);
 	fflush(logFile);
 
 	if (level == G_LOG_FLAG_FATAL)

--- a/mono/utils/mono-log-posix.c
+++ b/mono/utils/mono-log-posix.c
@@ -1,5 +1,5 @@
 /*
- * mono-log-posix.c: POSIX nterface to the logger
+ * mono-log-posix.c: POSIX interface to the logger
  *
  * This module contains the POSIX syslog logger routines
  *

--- a/mono/utils/mono-log-posix.c
+++ b/mono/utils/mono-log-posix.c
@@ -1,0 +1,101 @@
+/*
+ * mono-log-posix.c: POSIX nterface to the logger
+ *
+ * This module contains the POSIX syslog logger routines
+ *
+ * Author:
+ *    Neale Ferguson <neale@sinenomine.net>
+ *
+ */
+#include <config.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#if defined(_POSIX_VERSION) 
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <glib.h>
+#include <syslog.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/time.h>
+#include "mono-logger.h"
+
+static void *logUserData = NULL;
+
+/**
+ * mapSyslogLevel:
+ * 	
+ * 	@level - GLogLevelFlags value
+ * 	@returns The equivalent syslog priority value
+ */
+static __inline__ int
+mapSyslogLevel(GLogLevelFlags level) 
+{
+	if (level & G_LOG_LEVEL_ERROR)
+		return (LOG_ERR);
+	if (level & G_LOG_LEVEL_CRITICAL)
+		return (LOG_CRIT);
+	if (level & G_LOG_LEVEL_WARNING)
+		return (LOG_WARNING);
+	if (level & G_LOG_LEVEL_MESSAGE)
+		return (LOG_NOTICE);
+	if (level & G_LOG_LEVEL_INFO)
+		return (LOG_INFO);
+	if (level & G_LOG_LEVEL_DEBUG)
+		return (LOG_DEBUG);
+	return (LOG_INFO);
+}
+
+/**
+ * mono_log_open_logfile
+ * 	
+ *	Open the syslog interface specifying that we want our PID recorded 
+ *	and that we're using the LOG_USER facility.
+ *
+ * 	@ident - Identifier: ignored
+ * 	@userData - Not used
+ */
+void
+mono_log_open_syslog(const char *ident, void *userData)
+{
+	openlog("mono", LOG_PID, LOG_USER);
+	logUserData = userData;
+}
+
+/**
+ * mono_log_write_logfile
+ * 	
+ * 	Write data to the log file.
+ *
+ * 	@domain - Identifier string
+ * 	@level - Logging level flags
+ * 	@format - Printf format string
+ * 	@vargs - Variable argument list
+ */
+void
+mono_log_write_syslog(const char *domain, GLogLevelFlags level, const char *format, va_list args)
+{
+	vsyslog(mapSyslogLevel(level), format, args);
+
+	if (level == G_LOG_FLAG_FATAL)
+		abort();
+}
+
+/**
+ * mono_log_close_logfile
+ *
+ * 	Close the log file
+ */
+void
+mono_log_close_syslog()
+{
+	closelog();
+}
+#endif

--- a/mono/utils/mono-log-posix.c
+++ b/mono/utils/mono-log-posix.c
@@ -80,7 +80,7 @@ mono_log_open_syslog(const char *ident, void *userData)
  * 	@vargs - Variable argument list
  */
 void
-mono_log_write_syslog(const char *domain, GLogLevelFlags level, const char *format, va_list args)
+mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, const char *format, va_list args)
 {
 	vsyslog(mapSyslogLevel(level), format, args);
 

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -63,7 +63,7 @@ mapLogFileLevel(GLogLevelFlags level)
  * 	@userData - Not used
  */
 void
-mono_log_open_logfile(const char *ident, void *userData)
+mono_log_open_syslog(const char *ident, void *userData)
 {
 	logFile = fopen(logFileName, "w");
 	if (logFile == NULL) {
@@ -84,7 +84,7 @@ mono_log_open_logfile(const char *ident, void *userData)
  * 	@vargs - Variable argument list
  */
 void
-mono_log_write_logfile(const char *domain, GLogLevelFlags level, const char *format, va_list args)
+mono_log_write_syslog(const char *domain, GLogLevelFlags level, const char *format, va_list args)
 {
 	time_t t;
 	struct tm tod;
@@ -113,7 +113,7 @@ mono_log_write_logfile(const char *domain, GLogLevelFlags level, const char *for
  * 	Close the log file
  */
 void
-mono_log_close_logfile()
+mono_log_close_syslog()
 {
 	if (logFile) {
 		fclose(logFile);

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -1,7 +1,7 @@
 /*
- * mono-log-common.c: Platform-independent interface to the logger
+ * mono-log-windows.c: Simplistic simulation of a syslog logger for Windows
  *
- * This module contains the POSIX syslog logger interface
+ * This module contains the Windows syslog logger interface
  *
  * Author:
  *    Neale Ferguson <neale@sinenomine.net>

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -1,0 +1,123 @@
+/*
+ * mono-log-common.c: Platform-independent interface to the logger
+ *
+ * This module contains the POSIX syslog logger interface
+ *
+ * Author:
+ *    Neale Ferguson <neale@sinenomine.net>
+ *
+ */
+#include <config.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef WIN32
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <glib.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/time.h>
+#include "mono-logger.h"
+
+static FILE *logFile = NULL;
+static void *logUserData = NULL;
+static char *logFileName = L".//mono.log";
+
+/**
+ * mapSyslogLevel:
+ * 	
+ * 	@level - GLogLevelFlags value
+ * 	@returns The equivalent character identifier
+ */
+static __inline__ char 
+mapLogFileLevel(GLogLevelFlags level) 
+{
+	if (level & G_LOG_LEVEL_ERROR)
+		return ('E');
+	if (level & G_LOG_LEVEL_CRIT)
+		return ('C');
+	if (level & G_LOG_LEVEL_WARNING)
+		return ('W');
+	if (level & G_LOG_LEVEL_MESSAGE)
+		return ('N');
+	if (level & G_LOG_LEVEL_INFO)
+		return ('I');
+	if (level & G_LOG_LEVEL_DEBUG)
+		return ('D');
+	return ('I');
+}
+
+/**
+ * mono_log_open_logfile
+ * 	
+ *	Open the logfile. If the path is not specified default to stdout. If the
+ *	open fails issue a warning and use stdout as the log file destination.
+ *
+ * 	@ident - Identifier: ignored
+ * 	@userData - Not used
+ */
+void
+mono_log_open_logfile(const char *ident, void *userData)
+{
+	logFile = fopen(logFileName, "w");
+	if (logFile == NULL) {
+		g_warning("opening of log file %s failed with %s",
+			  strerror(errno));
+	}
+	logUserData = userData;
+}
+
+/**
+ * mono_log_write_logfile
+ * 	
+ * 	Write data to the log file.
+ *
+ * 	@domain - Identifier string
+ * 	@level - Logging level flags
+ * 	@format - Printf format string
+ * 	@vargs - Variable argument list
+ */
+void
+mono_log_write_logfile(const char *domain, GLogLevelFlags level, const char *format, va_list args)
+{
+	time_t t;
+	struct tm tod;
+	char logTime[80];
+	pid_t pid;
+
+	if (logFile == NULL)
+		mono_log_open_logfile(NULL, NULL);
+
+	time(&t);
+	localtime_r(&t, &tod);
+	pid = getpid();
+	strftime(logTime, sizeof(logTime), "%F %T", &tod);
+	fprintf(logFile, "%s level[%c] mono[%d]: ",logTime,mapLogFileLevel(level),pid);
+	vfprintf(logFile, format, args);
+	fputc('\n', logFile);
+	fflush(logFile);
+
+	if (level == G_LOG_FLAG_FATAL)
+		abort();
+}
+
+/**
+ * mono_log_close_logfile
+ *
+ * 	Close the log file
+ */
+void
+mono_log_close_logfile()
+{
+	if (logFile) {
+		fclose(logFile);
+		logFile = NULL;
+	}
+}
+#endif

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -27,7 +27,7 @@
 
 static FILE *logFile = NULL;
 static void *logUserData = NULL;
-static char logFileName[] = L".//mono.log";
+static wchar_t *logFileName = L".//mono.log";
 
 /**
  * mapSyslogLevel:
@@ -65,7 +65,7 @@ mapLogFileLevel(GLogLevelFlags level)
 void
 mono_log_open_syslog(const char *ident, void *userData)
 {
-	logFile = fopen(logFileName, "w");
+	logFile = _wfopen(logFileName, L"w");
 	if (logFile == NULL) {
 		g_warning("opening of log file %s failed with %s",
 			  strerror(errno));

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -101,12 +101,11 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 	time(&t);
 	tod = localtime(&t);
 	pid = _getpid();
-	strftime(logTime, sizeof(logTime), "%F %T", tod);
+	strftime(logTime, sizeof(logTime), "%Y-%m-%d %H:%M:%S", tod);
 	iLog = snprintf(logMessage, sizeof(logMessage), "%s level[%c] mono[%d]: ",
 			logTime,mapLogFileLevel(level),pid);
 	nLog = sizeof(logMessage) - iLog - 2;
 	iLog = vsnprintf(logMessage+iLog, nLog, format, args);
-	logMessage[iLog++] = '\r';
 	logMessage[iLog++] = '\n';
 	logMessage[iLog++] = 0;
 	fputs(logMessage, logFile);

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -22,7 +22,6 @@
 #include <glib.h>
 #include <errno.h>
 #include <time.h>
-#include <sys/time.h>
 #include "mono-logger.h"
 
 static FILE *logFile = NULL;
@@ -98,8 +97,8 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 		mono_log_open_logfile(NULL, NULL);
 
 	time(&t);
-	localtime_r(&t, &tod);
-	pid = getpid();
+	localtime(&t, &tod);
+	pid = _getpid();
 	strftime(logTime, sizeof(logTime), "%F %T", &tod);
 	iLog = snprintf(logMessage, sizeof(logMessage), "%s level[%c] mono[%d]: ",
 			logTime,mapLogFileLevel(level),pid);

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -34,7 +34,7 @@ static char *logFileName = L".//mono.log";
  * 	@level - GLogLevelFlags value
  * 	@returns The equivalent character identifier
  */
-static __inline__ char 
+static inline char 
 mapLogFileLevel(GLogLevelFlags level) 
 {
 	if (level & G_LOG_LEVEL_ERROR)

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -86,7 +86,7 @@ void
 mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, const char *format, va_list args)
 {
 	time_t t;
-	struct tm tod;
+	struct tm *tod;
 	char logTime[80],
 	      logMessage[512];
 	pid_t pid;
@@ -97,9 +97,9 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 		mono_log_open_logfile(NULL, NULL);
 
 	time(&t);
-	localtime(&t, &tod);
+	tod = localtime(&t);
 	pid = _getpid();
-	strftime(logTime, sizeof(logTime), "%F %T", &tod);
+	strftime(logTime, sizeof(logTime), "%F %T", tod);
 	iLog = snprintf(logMessage, sizeof(logMessage), "%s level[%c] mono[%d]: ",
 			logTime,mapLogFileLevel(level),pid);
 	nLog = sizeof(logMessage) - iLog - 2;

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -39,7 +39,7 @@ mapLogFileLevel(GLogLevelFlags level)
 {
 	if (level & G_LOG_LEVEL_ERROR)
 		return ('E');
-	if (level & G_LOG_LEVEL_CRIT)
+	if (level & G_LOG_LEVEL_CRITICAL)
 		return ('C');
 	if (level & G_LOG_LEVEL_WARNING)
 		return ('W');
@@ -103,7 +103,7 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 	iLog = snprintf(logMessage, sizeof(logMessage), "%s level[%c] mono[%d]: ",
 			logTime,mapLogFileLevel(level),pid);
 	nLog = sizeof(logMessage) - iLog - 2;
-	iLog = vsnprintf(logMessage=iLog, nLog, format, args);
+	iLog = vsnprintf(logMessage+iLog, nLog, format, args);
 	logMessage[iLog++] = '\n';
 	logMessage[iLog++] = 0;
 	fputs(logMessage, logFile);

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -13,7 +13,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef WIN32
+#ifdef HOST_WIN32
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -84,7 +84,7 @@ mono_log_open_syslog(const char *ident, void *userData)
  * 	@vargs - Variable argument list
  */
 void
-mono_log_write_syslog(const char *domain, GLogLevelFlags level, const char *format, va_list args)
+mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, const char *format, va_list args)
 {
 	time_t t;
 	struct tm tod;

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -79,9 +79,9 @@ mono_tracev_inner (GLogLevelFlags level, MonoTraceMask mask, const char *format,
 	}
 
 	if (logCallback.opener == NULL) {
-                logCallback.opener = mono_log_open_logfile;
-                logCallback.writer = mono_log_write_logfile;
-                logCallback.closer = mono_log_close_logfile;
+		logCallback.opener = mono_log_open_logfile;
+		logCallback.writer = mono_log_write_logfile;
+		logCallback.closer = mono_log_close_logfile;
 		logCallback.opener(NULL, NULL);
 	}
 	logCallback.writer(mono_log_domain, level, format, args);

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -11,8 +11,9 @@ typedef struct {
 	MonoTraceMask	mask;
 } MonoLogLevelEntry;
 
-GLogLevelFlags mono_internal_current_level		= INT_MAX;
-MonoTraceMask  mono_internal_current_mask		= MONO_TRACE_ALL;
+GLogLevelFlags mono_internal_current_level	= INT_MAX;
+MonoTraceMask  mono_internal_current_mask	= MONO_TRACE_ALL;
+gboolean mono_trace_log_header			= FALSE;
 
 static GQueue		*level_stack		= NULL;
 static const char	*mono_log_domain	= "Mono";
@@ -39,8 +40,8 @@ mono_trace_init (void)
 
 		mono_trace_set_mask_string(g_getenv("MONO_LOG_MASK"));
 		mono_trace_set_level_string(g_getenv("MONO_LOG_LEVEL"));
-		mono_trace_set_logdest_string(g_getenv("MONO_LOG_DEST"));
 		mono_trace_set_logheader_string(g_getenv("MONO_LOG_HEADER"));
+		mono_trace_set_logdest_string(g_getenv("MONO_LOG_DEST"));
 	}
 }
 
@@ -122,7 +123,7 @@ mono_trace_set_mask (MonoTraceMask mask)
 	if(level_stack == NULL)
 		mono_trace_init();
 
-	mono_internal_current_mask	= mask;
+	mono_internal_current_mask = mask;
 }
 
 /**
@@ -166,13 +167,10 @@ mono_trace_set_logheader_string(const char *head)
 {
 	MonoLogCallback logger;
 
-	if(level_stack == NULL)
-		mono_trace_init();
-
 	if (head == NULL) {
-		logger.header = FALSE;
+		mono_trace_log_header = FALSE;
 	} else {
-		logger.header = TRUE;
+		mono_trace_log_header = TRUE;
 	}
 }
 
@@ -319,6 +317,7 @@ mono_trace_set_log_handler (MonoLogCallback *callback, const char *dest, void *u
 	logCallback.opener = callback->opener;
 	logCallback.writer = callback->writer;
 	logCallback.closer = callback->closer;
+	logCallback.header = mono_trace_log_header;
 	logCallback.opener(dest, user_data);
 }
 

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -21,7 +21,8 @@ static MonoPrintCallback print_callback, printerr_callback;
 static MonoLogCallback logCallback = {
 	.opener = NULL,
 	.writer = NULL,
-	.closer = NULL
+	.closer = NULL,
+	.header = FALSE
 };
 
 /**
@@ -39,6 +40,7 @@ mono_trace_init (void)
 		mono_trace_set_mask_string(g_getenv("MONO_LOG_MASK"));
 		mono_trace_set_level_string(g_getenv("MONO_LOG_LEVEL"));
 		mono_trace_set_logdest_string(g_getenv("MONO_LOG_DEST"));
+		mono_trace_set_logheader_string(g_getenv("MONO_LOG_HEADER"));
 	}
 }
 
@@ -84,7 +86,7 @@ mono_tracev_inner (GLogLevelFlags level, MonoTraceMask mask, const char *format,
 		logCallback.closer = mono_log_close_logfile;
 		logCallback.opener(NULL, NULL);
 	}
-	logCallback.writer(mono_log_domain, level, format, args);
+	logCallback.writer(mono_log_domain, level, logCallback.header, format, args);
 }
 
 /**
@@ -149,6 +151,28 @@ mono_trace_set_logdest_string (const char *dest)
 		logger.writer = mono_log_write_syslog;
 		logger.closer = mono_log_close_syslog;
 		mono_trace_set_log_handler(&logger, mono_log_domain, NULL);
+	}
+}
+
+/**
+ * mono_trace_set_logheader:
+ *
+ *	@head: Whether we want pid/date/time header on log messages
+ *
+ * Sets the current logging header option.
+ */
+void 
+mono_trace_set_logheader_string(const char *head)
+{
+	MonoLogCallback logger;
+
+	if(level_stack == NULL)
+		mono_trace_init();
+
+	if (head == NULL) {
+		logger.header = FALSE;
+	} else {
+		logger.header = TRUE;
 	}
 }
 

--- a/mono/utils/mono-logger.h
+++ b/mono/utils/mono-logger.h
@@ -10,11 +10,23 @@ mono_trace_set_level_string (const char *value);
 MONO_API void 
 mono_trace_set_mask_string (const char *value);
 
-typedef void (*MonoLogCallback) (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
+MONO_API void 
+mono_trace_set_logdest_string (const char *value);
+
 typedef void (*MonoPrintCallback) (const char *string, mono_bool is_stdout);
 
+typedef void (*MonoLoggerOpen) (const char *, void *);
+typedef void (*MonoLoggerWrite) (const char *, GLogLevelFlags, const char *, ...);
+typedef void (*MonoLoggerClose) (void);
+
+typedef struct _MonoLogCallback_ {
+	MonoLoggerOpen 	opener;		/* Routine to open logging */
+	MonoLoggerWrite	writer;		/* Routine to write log data */
+	MonoLoggerClose closer; 	/* Routine to close logging */
+} MonoLogCallback;
+
 MONO_API void
-mono_trace_set_log_handler (MonoLogCallback callback, void *user_data);
+mono_trace_set_log_handler (MonoLogCallback *callback, const char *dest, void *user_data);
 
 MONO_API void
 mono_trace_set_print_handler (MonoPrintCallback callback);
@@ -22,6 +34,23 @@ mono_trace_set_print_handler (MonoPrintCallback callback);
 MONO_API void
 mono_trace_set_printerr_handler (MonoPrintCallback callback);
 
+MONO_API void
+mono_log_open_syslog(const char *, void *);
+
+MONO_API void
+mono_log_write_syslog(const char *, GLogLevelFlags, const char *, va_list);
+
+MONO_API void
+mono_log_close_syslog(void);
+
+MONO_API void
+mono_log_open_logfile(const char *, void *);
+
+MONO_API void
+mono_log_write_logfile(const char *, GLogLevelFlags, const char *, va_list);
+
+MONO_API void
+mono_log_close_logfile(void);
 
 MONO_END_DECLS
 

--- a/mono/utils/mono-logger.h
+++ b/mono/utils/mono-logger.h
@@ -13,16 +13,20 @@ mono_trace_set_mask_string (const char *value);
 MONO_API void 
 mono_trace_set_logdest_string (const char *value);
 
+MONO_API void 
+mono_trace_set_logheader_string (const char *value);
+
 typedef void (*MonoPrintCallback) (const char *string, mono_bool is_stdout);
 
 typedef void (*MonoLoggerOpen) (const char *, void *);
-typedef void (*MonoLoggerWrite) (const char *, GLogLevelFlags, const char *, ...);
+typedef void (*MonoLoggerWrite) (const char *, GLogLevelFlags, mono_bool, const char *, va_list);
 typedef void (*MonoLoggerClose) (void);
 
 typedef struct _MonoLogCallback_ {
 	MonoLoggerOpen 	opener;		/* Routine to open logging */
 	MonoLoggerWrite	writer;		/* Routine to write log data */
 	MonoLoggerClose closer; 	/* Routine to close logging */
+	mono_bool       header;		/* Whether we want pid/time/date in log message */
 } MonoLogCallback;
 
 MONO_API void
@@ -38,7 +42,7 @@ MONO_API void
 mono_log_open_syslog(const char *, void *);
 
 MONO_API void
-mono_log_write_syslog(const char *, GLogLevelFlags, const char *, va_list);
+mono_log_write_syslog(const char *, GLogLevelFlags, mono_bool, const char *, va_list);
 
 MONO_API void
 mono_log_close_syslog(void);
@@ -47,7 +51,7 @@ MONO_API void
 mono_log_open_logfile(const char *, void *);
 
 MONO_API void
-mono_log_write_logfile(const char *, GLogLevelFlags, const char *, va_list);
+mono_log_write_logfile(const char *, GLogLevelFlags, mono_bool, const char *, va_list);
 
 MONO_API void
 mono_log_close_logfile(void);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -231,14 +231,14 @@ mono_threads_wait_pending_operations (void)
 		for (i = 0; i < pending_suspends; ++i) {
 			THREADS_SUSPEND_DEBUG ("[INITIATOR-WAIT-WAITING]\n");
 			InterlockedIncrement (&waits_done);
-			if (!mono_os_sem_timedwait (&suspend_semaphore, SLEEP_DURATION_BEFORE_ABORT, MONO_SEM_FLAGS_NONE))
+			if (!mono_os_sem_timedwait (&suspend_semaphore, sleepAbortDuration, MONO_SEM_FLAGS_NONE))
 				continue;
 			mono_stopwatch_stop (&suspension_time);
 
 			dump_threads ();
 
 			MOSTLY_ASYNC_SAFE_PRINTF ("WAITING for %d threads, got %d suspended\n", (int)pending_suspends, i);
-			g_error ("suspend_thread suspend took %d ms, which is more than the allowed %d ms", (int)mono_stopwatch_elapsed_ms (&suspension_time), SLEEP_DURATION_BEFORE_ABORT);
+			g_error ("suspend_thread suspend took %d ms, which is more than the allowed %d ms", (int)mono_stopwatch_elapsed_ms (&suspension_time), sleepAbortDuration);
 		}
 		mono_stopwatch_stop (&suspension_time);
 		THREADS_SUSPEND_DEBUG ("Suspending %d threads took %d ms.\n", (int)pending_suspends, (int)mono_stopwatch_elapsed_ms (&suspension_time));

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -44,7 +44,6 @@
     <ClCompile Include="..\mono\utils\mono-logger.c" />
     <ClCompile Include="..\mono\utils\mono-log-windows.c" />
     <ClCompile Include="..\mono\utils\mono-log-common.c" />
-    <ClCompile Include="..\mono\utils\mono-log-posix.c" />
     <ClCompile Include="..\mono\utils\mono-math.c" />
     <ClCompile Include="..\mono\utils\mono-md5.c" />
     <ClCompile Include="..\mono\utils\mono-mmap.c" />

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -42,6 +42,9 @@
     <ClCompile Include="..\mono\utils\mono-io-portability.c" />
     <ClCompile Include="..\mono\utils\mono-linked-list-set.c" />
     <ClCompile Include="..\mono\utils\mono-logger.c" />
+    <ClCompile Include="..\mono\utils\mono-log-windows.c" />
+    <ClCompile Include="..\mono\utils\mono-log-common.c" />
+    <ClCompile Include="..\mono\utils\mono-log-posix.c" />
     <ClCompile Include="..\mono\utils\mono-math.c" />
     <ClCompile Include="..\mono\utils\mono-md5.c" />
     <ClCompile Include="..\mono\utils\mono-mmap.c" />
@@ -110,9 +113,6 @@
     <ClInclude Include="..\mono\utils\mono-dl.h" />
     <ClInclude Include="..\mono\utils\mono-error-internals.h" />
     <ClInclude Include="..\mono\utils\mono-error.h" />
-    <ClInclude Include="..\mono\utils\mono-log-windows.c" />
-    <ClInclude Include="..\mono\utils\mono-log-common.c" />
-    <ClInclude Include="..\mono\utils\mono-log-posix.c" />
     <ClInclude Include="..\mono\utils\mono-internal-hash.h" />
     <ClInclude Include="..\mono\utils\mono-io-portability.h" />
     <ClInclude Include="..\mono\utils\mono-linked-list-set.h" />

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -110,6 +110,9 @@
     <ClInclude Include="..\mono\utils\mono-dl.h" />
     <ClInclude Include="..\mono\utils\mono-error-internals.h" />
     <ClInclude Include="..\mono\utils\mono-error.h" />
+    <ClInclude Include="..\mono\utils\mono-log-windows.c" />
+    <ClInclude Include="..\mono\utils\mono-log-common.c" />
+    <ClInclude Include="..\mono\utils\mono-log-posix.c" />
     <ClInclude Include="..\mono\utils\mono-internal-hash.h" />
     <ClInclude Include="..\mono\utils\mono-io-portability.h" />
     <ClInclude Include="..\mono\utils\mono-linked-list-set.h" />


### PR DESCRIPTION
- Add logfile and syslog capability. For Windows, the latter is simulated by writing to a file. Adding Eventlog support is for a future effort. The choice of logging mode is made via MONO_LOG_DEST environment variable. 
- Add timestamps and pid to the trace messages to make them more useful 
- Add timestamps to SGEN_LOG 
- Related to tracing: when tracing and using something like Valgrind the system may be slowed so much that the sleep abort limit may be exceeded for threads. This fix adds an environment variable lookup of "MONO_SLEEP_ABORT_LIMIT" which is a value greater than 40, which defines the number of milliseconds to wait for threads to complete pending operations. If not set, the valus is 200.