### PR TITLE
[MonoError] Use class name for mono_error_set_type_load_class() exceptions

### DIFF
--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -599,7 +599,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 		break;
 
 	case MONO_ERROR_TYPE_LOAD:
-		if (error->type_name && error->assembly_name) {
+		if ((error->type_name && error->assembly_name) || error->exn.klass) {
 			type_name = get_type_name_as_mono_string (error, domain, error_out);
 			if (!mono_error_ok (error_out))
 				break;


### PR DESCRIPTION

If `MONO_ERROR_TYPE_LOAD` is set and there's a `error->exn.klass` available,
try to grab the type name from the `klass` when preparing an exception.