### PR TITLE
[reflection] MonoError for a few icalls

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -553,7 +553,7 @@ ICALL(FILEDI_2, "get_marshal_info", ves_icall_System_Reflection_FieldInfo_get_ma
 ICALL(FILEDI_3, "internal_from_handle_type", ves_icall_System_Reflection_FieldInfo_internal_from_handle_type)
 
 ICALL_TYPE(MEMBERI, "System.Reflection.MemberInfo", MEMBERI_1)
-ICALL(MEMBERI_1, "get_MetadataToken", mono_reflection_get_token)
+ICALL(MEMBERI_1, "get_MetadataToken", ves_icall_reflection_get_token)
 
 ICALL_TYPE(MBASE, "System.Reflection.MethodBase", MBASE_1)
 ICALL(MBASE_1, "GetCurrentMethod", ves_icall_GetCurrentMethod)
@@ -574,7 +574,7 @@ ICALL(MODULE_9, "ResolveMethodToken", ves_icall_System_Reflection_Module_Resolve
 ICALL(MODULE_10, "ResolveSignature", ves_icall_System_Reflection_Module_ResolveSignature)
 ICALL(MODULE_11, "ResolveStringToken", ves_icall_System_Reflection_Module_ResolveStringToken)
 ICALL(MODULE_12, "ResolveTypeToken", ves_icall_System_Reflection_Module_ResolveTypeToken)
-ICALL(MODULE_13, "get_MetadataToken", mono_reflection_get_token)
+ICALL(MODULE_13, "get_MetadataToken", ves_icall_reflection_get_token)
 
 ICALL_TYPE(MCMETH, "System.Reflection.MonoCMethod", MCMETH_1)
 ICALL(MCMETH_1, "GetGenericMethodDefinition_impl", ves_icall_MonoMethod_GetGenericMethodDefinition)
@@ -620,7 +620,7 @@ ICALL(MPROPI_3, "get_default_value", property_info_get_default_value)
 ICALL(MPROPI_2, "get_property_info", ves_icall_MonoPropertyInfo_get_property_info)
 
 ICALL_TYPE(PARAMI, "System.Reflection.ParameterInfo", PARAMI_1)
-ICALL(PARAMI_1, "GetMetadataToken", mono_reflection_get_token)
+ICALL(PARAMI_1, "GetMetadataToken", ves_icall_reflection_get_token)
 ICALL(PARAMI_2, "GetTypeModifiers", ves_icall_ParameterInfo_GetTypeModifiers)
 
 ICALL_TYPE(RTFIELD, "System.Reflection.RtFieldInfo", RTFIELD_1)
@@ -771,7 +771,7 @@ ICALL(RTH_3, "GetAttributes", ves_icall_RuntimeTypeHandle_GetAttributes)
 ICALL(RTH_4, "GetBaseType", ves_icall_RuntimeTypeHandle_GetBaseType)
 ICALL(RTH_5, "GetElementType", ves_icall_RuntimeTypeHandle_GetElementType)
 ICALL(RTH_6, "GetGenericTypeDefinition_impl", ves_icall_RuntimeTypeHandle_GetGenericTypeDefinition_impl)
-ICALL(RTH_7, "GetMetadataToken", ves_icall_RuntimeTypeHandle_GetMetadataToken)
+ICALL(RTH_7, "GetMetadataToken", ves_icall_reflection_get_token)
 ICALL(RTH_8, "GetModule", ves_icall_RuntimeTypeHandle_GetModule)
 ICALL(RTH_9, "HasInstantiation", ves_icall_RuntimeTypeHandle_HasInstantiation)
 ICALL(RTH_10, "IsArray", ves_icall_RuntimeTypeHandle_IsArray)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5103,7 +5103,10 @@ ves_icall_System_Reflection_MethodBase_GetMethodFromHandleInternalType (MonoMeth
 ICALL_EXPORT MonoReflectionMethodBody*
 ves_icall_System_Reflection_MethodBase_GetMethodBodyInternal (MonoMethod *method)
 {
-	return mono_method_body_get_object (mono_domain_get (), method);
+	MonoError error;
+	MonoReflectionMethodBody *result = mono_method_body_get_object_checked (mono_domain_get (), method, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 ICALL_EXPORT MonoReflectionAssembly*

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2477,9 +2477,12 @@ ves_icall_RuntimeTypeHandle_IsComObject (MonoReflectionType *type)
 }
 
 ICALL_EXPORT guint32
-ves_icall_RuntimeTypeHandle_GetMetadataToken (MonoReflectionType *obj)
+ves_icall_reflection_get_token (MonoObject* obj)
 {
-	return mono_reflection_get_token ((MonoObject*)obj);
+	MonoError error;
+	guint32 result = mono_reflection_get_token_checked (obj, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 ICALL_EXPORT MonoReflectionModule*

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -68,4 +68,8 @@ mono_module_get_object_checked (MonoDomain *domain, MonoImage *image, MonoError 
 MonoReflectionModule*
 mono_module_file_get_object_checked (MonoDomain *domain, MonoImage *image, int table_index, MonoError *error);
 
+MonoReflectionMethodBody*
+mono_method_body_get_object_checked (MonoDomain *domain, MonoMethod *method, MonoError *error);
+
+
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -9,6 +9,9 @@
 #include <mono/utils/mono-error.h>
 
 MonoType*
+mono_reflection_get_type_checked (MonoImage* image, MonoTypeNameParse *info, mono_bool ignorecase, mono_bool *type_resolve, MonoError *error);
+
+MonoType*
 mono_reflection_type_from_name_checked (char *name, MonoImage *image, MonoError *error);
 
 MonoObject*

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -14,6 +14,10 @@ mono_reflection_get_type_checked (MonoImage* image, MonoTypeNameParse *info, mon
 MonoType*
 mono_reflection_type_from_name_checked (char *name, MonoImage *image, MonoError *error);
 
+guint32
+mono_reflection_get_token_checked (MonoObject *obj, MonoError *error);
+
+
 MonoObject*
 mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass, MonoError *error);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -7802,7 +7802,7 @@ mono_method_body_get_object_checked (MonoDomain *domain, MonoMethod *method, Mon
 
 	/* for compatibility with .net */
 	if (method_is_dynamic (method)) {
-		mono_error_set_instance (error, mono_get_exception_invalid_operation (NULL));
+		mono_error_set_exception_instance (error, mono_get_exception_invalid_operation (NULL));
 		return NULL;
 	}
 
@@ -8610,10 +8610,28 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 MonoType*
 mono_reflection_get_type (MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve) {
 	MonoError error;
-	MonoType *result = mono_reflection_get_type_with_rootimage(image, image, info, ignorecase, type_resolve, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	MonoType *result = mono_reflection_get_type_with_rootimage (image, image, info, ignorecase, type_resolve, &error);
+	mono_error_cleanup (&error);
 	return result;
 }
+
+/**
+ * mono_reflection_get_type_checked:
+ * @image: a metadata context
+ * @info: type description structure
+ * @ignorecase: flag for case-insensitive string compares
+ * @type_resolve: whenever type resolve was already tried
+ * @error: set on error.
+ *
+ * Build a MonoType from the type description in @info. On failure returns NULL and sets @error.
+ *
+ */
+MonoType*
+mono_reflection_get_type_checked (MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve, MonoError *error) {
+	mono_error_init (error);
+	return mono_reflection_get_type_with_rootimage (image, image, info, ignorecase, type_resolve, error);
+}
+
 
 static MonoType*
 mono_reflection_get_type_internal_dynamic (MonoImage *rootimage, MonoAssembly *assembly, MonoTypeNameParse *info, gboolean ignorecase, MonoError *error)

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -42,6 +42,7 @@ typedef enum {
 } MonoResolveTokenError;
 
 MONO_API int           mono_reflection_parse_type (char *name, MonoTypeNameParse *info);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoType*     mono_reflection_get_type   (MonoImage* image, MonoTypeNameParse *info, mono_bool ignorecase, mono_bool *type_resolve);
 MONO_API void          mono_reflection_free_type_info (MonoTypeNameParse *info);
 MONO_RT_EXTERNAL_ONLY

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -47,6 +47,7 @@ MONO_API MonoType*     mono_reflection_get_type   (MonoImage* image, MonoTypeNam
 MONO_API void          mono_reflection_free_type_info (MonoTypeNameParse *info);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoType*     mono_reflection_type_from_name (char *name, MonoImage *image);
+MONO_RT_EXTERNAL_ONLY
 MONO_API uint32_t      mono_reflection_get_token (MonoObject *obj);
 
 MONO_RT_EXTERNAL_ONLY

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -66,6 +66,7 @@ MONO_API MonoReflectionEvent*    mono_event_get_object    (MonoDomain *domain, M
 /* note: this one is slightly different: we keep the whole array of params in the cache */
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray* mono_param_get_objects  (MonoDomain *domain, MonoMethod *method);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionMethodBody* mono_method_body_get_object (MonoDomain *domain, MonoMethod *method);
 
 MONO_API MonoObject *mono_get_dbnull_object (MonoDomain *domain);


### PR DESCRIPTION
- Separate `mono_reflection_get_token` (for the runtime API) from `ves_icall_reflection_get_token` (Used for 4 different icalls)
- `mono_reflection_get_type_checked` for `System.Reflection.Assembly.InternalGetType()`
- `mono_method_body_get_object_checked` for `System.Reflection.MethodBase.GetMethodBodyInternal()`
- Sprinkle `mono_error_set_pending_exception` throughout.