### PR TITLE
System.Diagnostics.Tracing: Add EventListener and related classes

### DIFF
--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventListener.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventListener.cs
@@ -1,0 +1,71 @@
+//
+// EventListener.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+
+namespace System.Diagnostics.Tracing
+{
+	public abstract class EventListener : IDisposable
+	{
+		protected EventListener ()
+		{
+		}
+
+		public static int EventSourceIndex(EventSource eventSource)
+		{
+			return 0;
+		}
+
+		public void EnableEvents (EventSource eventSource, EventLevel level)
+		{
+		}
+
+		public void EnableEvents (EventSource eventSource, EventLevel level, EventKeywords matchAnyKeyword)
+		{
+		}
+
+		public void EnableEvents (EventSource eventSource, EventLevel level, EventKeywords matchAnyKeyword, IDictionary<string, string> arguments)
+		{
+		}
+
+		public void DisableEvents (EventSource eventSource)
+		{
+		}
+
+		protected internal virtual void OnEventSourceCreated (EventSource eventSource)
+		{
+		}
+
+		protected internal abstract void OnEventWritten (EventWrittenEventArgs eventData);
+
+		public virtual void Dispose()
+		{
+		}
+	}
+}
+

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventSource.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventSource.cs
@@ -3,8 +3,10 @@
 //
 // Authors:
 //	Marek Safar  <marek.safar@gmail.com>
+//	Frederik Carlier <frederik.carlier@quamotion.mobi>
 //
 // Copyright (C) 2014 Xamarin Inc (http://www.xamarin.com)
+// Copyrithg (C) 2015 Quamotion (http://quamotion.mobi)
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -150,50 +152,62 @@ namespace System.Diagnostics.Tracing
 
 		protected void WriteEvent (int eventId)
 		{
+			WriteEvent (eventId, new object[] { } );
 		}
 
 		protected void WriteEvent (int eventId, byte[] arg1)
 		{
+			WriteEvent (eventId, new object[] { arg1 } );
 		}
 
 		protected void WriteEvent (int eventId, int arg1)
 		{
+			WriteEvent (eventId, new object[] { arg1 } );
 		}
 
 		protected void WriteEvent (int eventId, string arg1)
 		{
+			WriteEvent (eventId, new object[] { arg1 } );
 		}
 
 		protected void WriteEvent (int eventId, int arg1, int arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, int arg1, int arg2, int arg3)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2, arg3 } );
 		}
 
 		protected void WriteEvent (int eventId, int arg1, string arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, long arg1)
 		{
+			WriteEvent (eventId, new object[] { arg1 } );
 		}
 
 		protected void WriteEvent (int eventId, long arg1, byte[] arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, long arg1, long arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, long arg1, long arg2, long arg3)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2, arg3 } );
 		}
 
 		protected void WriteEvent (int eventId, long arg1, string arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, params object[] args)
@@ -202,22 +216,27 @@ namespace System.Diagnostics.Tracing
 
 		protected void WriteEvent (int eventId, string arg1, int arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, string arg1, int arg2, int arg3)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2, arg3 } );
 		}
 
 		protected void WriteEvent (int eventId, string arg1, long arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, string arg1, string arg2)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2 } );
 		}
 
 		protected void WriteEvent (int eventId, string arg1, string arg2, string arg3)
 		{
+			WriteEvent (eventId, new object[] { arg1, arg2, arg3 } );
 		}
 	}
 }

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventWrittenEventArgs.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventWrittenEventArgs.cs
@@ -1,0 +1,124 @@
+//
+// EventWrittenEventArgs.cs
+//
+// Authors:
+//	Frederik Carlier  <frederik.carlier@quamotion.mobi>
+//
+// Copyright (C) 2015 Quamotion (http://quamotion.mobi)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace System.Diagnostics.Tracing
+{
+	public class EventWrittenEventArgs : EventArgs
+	{
+		internal EventWrittenEventArgs (EventSource eventSource)
+		{
+			this.EventSource = eventSource;
+		}
+
+		public Guid ActivityId
+		{
+			get { return EventSource.CurrentThreadActivityId; }
+		}
+
+		public EventChannel Channel
+		{
+			get { return EventChannel.None; }
+		}
+
+		public int EventId
+		{
+			get;
+			internal set;
+		}
+
+		public string EventName
+		{
+			get;
+			internal set;
+		}
+
+		public EventSource EventSource
+		{
+			get;
+			private set;
+		}
+
+		public EventKeywords Keywords
+		{
+			get { return EventKeywords.None; }
+		}
+
+		public EventLevel Level
+		{
+			get { return EventLevel.LogAlways; }
+		}
+
+		public string Message
+		{
+			get;
+			internal set;
+		}
+
+		public EventOpcode Opcode
+		{
+			get { return EventOpcode.Info; }
+		}
+
+		public ReadOnlyCollection<object> Payload
+		{
+			get;
+			internal set;
+		}
+
+		public ReadOnlyCollection<string> PayloadNames
+		{
+			get;
+			internal set;
+		}
+
+		public Guid RelatedActivityId
+		{
+			get;
+			internal set;
+		}
+
+		public EventTags Tags
+		{
+			get { return EventTags.None; }
+		}
+
+		public EventTask Task
+		{
+			get { return EventTask.None; }
+		}
+
+		public byte Version
+		{
+			get { return 0; }
+		}
+	}
+}
+

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -166,6 +166,8 @@ System.Diagnostics.Tracing/EventSource.cs
 System.Diagnostics.Tracing/EventSourceAttribute.cs
 System.Diagnostics.Tracing/EventSourceSettings.cs
 System.Diagnostics.Tracing/EventCommandEventArgs.cs
+System.Diagnostics.Tracing/EventListener.cs
+System.Diagnostics.Tracing/EventWrittenEventArgs.cs
 System.Diagnostics.Tracing/NonEventAttribute.cs
 System.Diagnostics.SymbolStore/ISymbolBinder.cs
 System.Diagnostics.SymbolStore/ISymbolBinder1.cs


### PR DESCRIPTION
Second attempt at #2738

This PR adds the [EventListener](https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventlistener(v=vs.110).aspx) and [EventWrittenEventArgs](https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventwritteneventargs) classes to Mono. They have been in .NET since 4.5.

Both [EventListener](http://referencesource.microsoft.com/#mscorlib/system/diagnostics/eventing/eventsource.cs,36c1ccbaddc7598f) and [EventWrittenEventArgs](http://referencesource.microsoft.com/#mscorlib/system/diagnostics/eventing/eventsource.cs,9317b6858407017e) are available in the .NET Reference Source.

Unfortunately, it's not possible to just include the files from the reference source, as they take a deep dependency on ETW (see the Design Notes at the top of the file). So the idea was just to stub them.
I may follow up with a PR which adds a very basic implementation of the `EventSource` and `EventListener` classes so that at least, say, logging to a file should work.

**NOTE** Since this PR is adding public classes to the API surface, it is my understanding that the Reference Assemblies should also be updated to include these APIs. I've asked the question over at mono/reference-assemblies/2 but didn't get clear guidance yet on how to get the reference assemblies updated.

Questions, feedback, feel free to let me know.