### PR TITLE
[System.Reflection.Emit] Propagate MonoError through some more static functions

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -503,7 +503,7 @@ ICALL(ASSEMB_1, "InternalAddModule", ves_icall_System_Reflection_Emit_AssemblyBu
 ICALL(ASSEMB_2, "basic_init", mono_image_basic_init)
 
 ICALL_TYPE(CATTRB, "System.Reflection.Emit.CustomAttributeBuilder", CATTRB_1)
-ICALL(CATTRB_1, "GetBlob", mono_reflection_get_custom_attrs_blob)
+ICALL(CATTRB_1, "GetBlob", ves_icall_System_Reflection_Emit_CustomAttributeBuilder_GetBlob)
 
 #ifndef DISABLE_REFLECTION_EMIT
 ICALL_TYPE(DERIVEDTYPE, "System.Reflection.Emit.DerivedType", DERIVEDTYPE_1)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2701,10 +2701,12 @@ ves_icall_Type_MakeGenericType (MonoReflectionType *type, MonoArray *type_array)
 		types [i] = t->type;
 	}
 
-	geninst = mono_reflection_bind_generic_parameters (type, count, types);
+	geninst = mono_reflection_bind_generic_parameters (type, count, types, &error);
 	g_free (types);
-	if (!geninst)
+	if (!geninst) {
+		mono_error_set_pending_exception (&error);
 		return NULL;
+	}
 
 	klass = mono_class_from_mono_type (geninst);
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1256,6 +1256,15 @@ ves_icall_System_Reflection_Emit_AssemblyBuilder_InternalAddModule (MonoReflecti
 	return result;
 }
 
+ICALL_EXPORT MonoArray*
+ves_icall_System_Reflection_Emit_CustomAttributeBuilder_GetBlob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues)
+{
+	MonoError error;
+	MonoArray *result = mono_reflection_get_custom_attrs_blob_checked (assembly, ctor, ctorArgs, properties, propValues, fields, fieldValues, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
+}
+
 static gboolean
 get_caller (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed, gpointer data)
 {

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1428,7 +1428,7 @@ MonoArray* mono_param_get_objects_internal  (MonoDomain *domain, MonoMethod *met
 MonoClass*
 mono_class_bind_generic_parameters (MonoClass *klass, int type_argc, MonoType **types, gboolean is_dynamic);
 MonoType*
-mono_reflection_bind_generic_parameters (MonoReflectionType *type, int type_argc, MonoType **types);
+mono_reflection_bind_generic_parameters (MonoReflectionType *type, int type_argc, MonoType **types, MonoError *error);
 MonoReflectionMethod*
 mono_reflection_bind_generic_method_parameters (MonoReflectionMethod *method, MonoArray *types);
 void

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1411,7 +1411,7 @@ void        mono_reflection_create_generic_class  (MonoReflectionTypeBuilder *tb
 
 MonoReflectionType* mono_reflection_create_runtime_class  (MonoReflectionTypeBuilder *tb);
 
-void        mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides, int *num_overrides);
+void        mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides, int *num_overrides, MonoError *error);
 
 void mono_reflection_create_dynamic_method (MonoReflectionDynamicMethod *m);
 void mono_reflection_destroy_dynamic_method (MonoReflectionDynamicMethod *mb);

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -27,6 +27,9 @@ mono_reflection_get_custom_attrs_info_checked (MonoObject *obj, MonoError *error
 MonoArray*
 mono_reflection_get_custom_attrs_data_checked (MonoObject *obj, MonoError *error);
 
+MonoArray*
+mono_reflection_get_custom_attrs_blob_checked (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues, MonoError *error);
+
 MonoCustomAttrInfo*
 mono_custom_attrs_from_index_checked    (MonoImage *image, uint32_t idx, MonoError *error);
 MonoCustomAttrInfo*

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -12645,13 +12645,13 @@ mono_reflection_method_get_handle (MonoObject *method, MonoError *error)
 }
 
 void
-mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides, int *num_overrides)
+mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides, int *num_overrides, MonoError *error)
 {
-	MonoError error;
 	MonoReflectionTypeBuilder *tb;
 	int i, j, onum;
 	MonoReflectionMethod *m;
 
+	mono_error_init (error);
 	*overrides = NULL;
 	*num_overrides = 0;
 
@@ -12685,8 +12685,8 @@ mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides
 				for (j = 0; j < mono_array_length (mb->override_methods); ++j) {
 					m = mono_array_get (mb->override_methods, MonoReflectionMethod*, j);
 
-					(*overrides) [onum * 2] = mono_reflection_method_get_handle ((MonoObject*)m, &error);
-					mono_error_raise_exception (&error); /* FIXME don't raise here */
+					(*overrides) [onum * 2] = mono_reflection_method_get_handle ((MonoObject*)m, error);
+					return_if_nok (error);
 					(*overrides) [onum * 2 + 1] = mb->mhandle;
 
 					g_assert (mb->mhandle);
@@ -13977,8 +13977,9 @@ mono_reflection_generic_class_initialize (MonoReflectionGenericClass *type, Mono
 }
 
 void
-mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides, int *num_overrides)
+mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides, int *num_overrides, MonoError *error)
 {
+	mono_error_init (error);
 	*overrides = NULL;
 	*num_overrides = 0;
 }

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -12511,12 +12511,7 @@ ensure_generic_class_runtime_vtable (MonoClass *klass, MonoError *error)
 	if (!ensure_runtime_vtable (gklass, error))
 		return FALSE;
 
-	if (!fix_partial_generic_class (klass, error)) {
-		mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
-		return FALSE;
-	}
-
-	return TRUE;
+	return fix_partial_generic_class (klass, error);
 }
 
 /**
@@ -12575,8 +12570,10 @@ ensure_runtime_vtable (MonoClass *klass, MonoError *error)
 			klass->interfaces_inited = 1;
 		}
 	} else if (klass->generic_class){
-		if (!ensure_generic_class_runtime_vtable (klass, error))
+		if (!ensure_generic_class_runtime_vtable (klass, error)) {
+			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
 			return FALSE;
+		}
 	}
 
 	if (klass->flags & TYPE_ATTRIBUTE_INTERFACE) {

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -77,6 +77,7 @@ MONO_API MonoArray*  mono_reflection_get_custom_attrs_by_type (MonoObject *obj, 
 MONO_API MonoArray*  mono_reflection_get_custom_attrs (MonoObject *obj);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray*  mono_reflection_get_custom_attrs_data (MonoObject *obj);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray*  mono_reflection_get_custom_attrs_blob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *porpValues, MonoArray *fields, MonoArray* fieldValues);
 
 MONO_RT_EXTERNAL_ONLY


### PR DESCRIPTION
Some externally visible changes include:
* Bubble MonoError up to one more SRE icall: `System.Reflection.Emit.CustomAttributeBuilder.GetBlob()`
* `fix_partial_generic_class` and `ensure_generic_class_runtime_vtable` now expect their callers to set the class failure state which they do under slightly more circumstances now than previously (now: whenever there's an error set from the above functions; before: only when we had trouble initializing the generic type definition.)
* Previous API for `mono_reflection_bind_generic_parameters` didn't make it clear whether NULL was a valid return value or not.  Now when we return NULL we always set the `error` out-arg. So non-NULL is success and NULL is failure.