### PR TITLE
[runtime] Make mono_value_box use MonoError

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -519,7 +519,11 @@ mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn)
 
 		if (use_aot_wrappers) {
 			wrapper = mono_marshal_get_native_func_wrapper_aot (klass);
-			this_obj = mono_value_box (mono_domain_get (), mono_defaults.int_class, &ftn);
+			this_obj = mono_value_box_checked (mono_domain_get (), mono_defaults.int_class, &ftn, &error);
+			if (!is_ok (&error)) {
+				mono_error_set_pending_exception (&error);
+				return NULL;
+			}
 		} else {
 			memset (&piinfo, 0, sizeof (piinfo));
 			parse_unmanaged_function_pointer_attr (klass, &piinfo);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1454,6 +1454,9 @@ mono_get_addr_from_ftnptr (gpointer descr);
 void
 mono_nullable_init (guint8 *buf, MonoObject *value, MonoClass *klass);
 
+MonoObject *
+mono_value_box_checked (MonoDomain *domain, MonoClass *klass, void* val, MonoError *error);
+
 MonoObject*
 mono_nullable_box (guint8 *buf, MonoClass *klass);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1458,7 +1458,7 @@ MonoObject *
 mono_value_box_checked (MonoDomain *domain, MonoClass *klass, void* val, MonoError *error);
 
 MonoObject*
-mono_nullable_box (guint8 *buf, MonoClass *klass);
+mono_nullable_box (guint8 *buf, MonoClass *klass, MonoError *error);
 
 #ifdef MONO_SMALL_CONFIG
 #define MONO_IMT_SIZE 9

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4600,7 +4600,8 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 						 * boxed object in the arg array with the copy.
 						 */
 						MonoObject *orig = mono_array_get (params, MonoObject*, i);
-						MonoObject *copy = mono_value_box (mono_domain_get (), orig->vtable->klass, mono_object_unbox (orig));
+						MonoObject *copy = mono_value_box_checked (mono_domain_get (), orig->vtable->klass, mono_object_unbox (orig), &error);
+						mono_error_raise_exception (&error); /* FIXME don't raise here */
 						mono_array_setref (params, i, copy);
 					}
 						
@@ -4652,8 +4653,11 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 
 			if (!params)
 				return NULL;
-			else
-				return mono_value_box (mono_domain_get (), method->klass->cast_class, pa [0]);
+			else {
+				MonoObject *result = mono_value_box_checked (mono_domain_get (), method->klass->cast_class, pa [0], &error);
+				mono_error_raise_exception (&error); /* FIXME don't raise here */
+				return result;
+			}
 		}
 
 		if (!obj) {
@@ -4669,7 +4673,8 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			else
 				o = obj;
 		} else if (method->klass->valuetype) {
-			obj = mono_value_box (mono_domain_get (), method->klass, obj);
+			obj = mono_value_box_checked (mono_domain_get (), method->klass, obj, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
 		}
 
 		if (exc) {
@@ -4692,7 +4697,9 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			nullable = mono_object_new_checked (mono_domain_get (), method->klass, &error);
 			mono_error_raise_exception (&error); /* FIXME don't raise here */
 
-			mono_nullable_init ((guint8 *)mono_object_unbox (nullable), mono_value_box (mono_domain_get (), method->klass->cast_class, obj), method->klass);
+			MonoObject *boxed = mono_value_box_checked (mono_domain_get (), method->klass->cast_class, obj, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+			mono_nullable_init ((guint8 *)mono_object_unbox (nullable), boxed, method->klass);
 			obj = mono_object_unbox (nullable);
 		}
 
@@ -5798,12 +5805,31 @@ mono_string_new_wrapper (const char *text)
 MonoObject *
 mono_value_box (MonoDomain *domain, MonoClass *klass, gpointer value)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
-
 	MonoError error;
+	MonoObject *result = mono_value_box_checked (domain, klass, value, &error);
+	mono_error_cleanup (&error);
+	return result;
+}
+
+/**
+ * mono_value_box_checked:
+ * @domain: the domain of the new object
+ * @class: the class of the value
+ * @value: a pointer to the unboxed data
+ * @error: set on error
+ *
+ * Returns: A newly created object which contains @value. On failure
+ * returns NULL and sets @error.
+ */
+MonoObject *
+mono_value_box_checked (MonoDomain *domain, MonoClass *klass, gpointer value, MonoError *error)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
 	MonoObject *res;
 	int size;
 	MonoVTable *vtable;
+
+	mono_error_init (error);
 
 	g_assert (klass->valuetype);
 	if (mono_class_is_nullable (klass))
@@ -5813,8 +5839,8 @@ mono_value_box (MonoDomain *domain, MonoClass *klass, gpointer value)
 	if (!vtable)
 		return NULL;
 	size = mono_class_instance_size (klass);
-	res = mono_object_new_alloc_specific_checked (vtable, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	res = mono_object_new_alloc_specific_checked (vtable, error);
+	return_val_if_nok (error, NULL);
 
 	size = size - sizeof (MonoObject);
 
@@ -5844,8 +5870,8 @@ mono_value_box (MonoDomain *domain, MonoClass *klass, gpointer value)
 #endif
 #endif
 	if (klass->has_finalize) {
-		mono_object_register_finalizer (res, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_object_register_finalizer (res, error);
+		return_val_if_nok (error, NULL);
 	}
 	return res;
 }
@@ -7235,9 +7261,10 @@ mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *
 
 		klass = mono_class_from_mono_type (sig->params [i]);
 
-		if (klass->valuetype)
-			arg = mono_value_box (domain, klass, vpos);
-		else 
+		if (klass->valuetype) {
+			arg = mono_value_box_checked (domain, klass, vpos, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+		} else 
 			arg = *((MonoObject **)vpos);
 		      
 		mono_array_setref (msg->args, i, arg);
@@ -7498,9 +7525,10 @@ mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField 
 			mono_raise_exception (mono_get_exception_not_supported ("Linked away."));
 	}
 
-	if (field_class->valuetype)
-		arg = mono_value_box (domain, field_class, val);
-	else 
+	if (field_class->valuetype) {
+		arg = mono_value_box_checked (domain, field_class, val, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+	} else 
 		arg = *((MonoObject **)val);
 		
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -162,6 +162,7 @@ mono_object_hash            (MonoObject* obj);
 MONO_API MonoString *
 mono_object_to_string (MonoObject *obj, MonoObject **exc);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_value_box		    (MonoDomain *domain, MonoClass *klass, void* val);
 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -373,9 +373,10 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 					mparams[i] = *((gpointer *)params [i]);
 				} else {
 					/* runtime_invoke expects a boxed instance */
-					if (mono_class_is_nullable (mono_class_from_mono_type (sig->params [i])))
-						mparams[i] = mono_nullable_box ((guint8 *)params [i], klass);
-					else
+					if (mono_class_is_nullable (mono_class_from_mono_type (sig->params [i]))) {
+						mparams[i] = mono_nullable_box ((guint8 *)params [i], klass, &error);
+						mono_error_raise_exception (&error); /* FIXME don't raise here */
+					} else
 						mparams[i] = params [i];
 				}
 			} else {

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -2009,7 +2009,10 @@ mono_marshal_xdomain_copy_value (MonoObject *val)
 	case MONO_TYPE_U8:
 	case MONO_TYPE_R4:
 	case MONO_TYPE_R8: {
-		return mono_value_box (domain, mono_object_class (val), ((char*)val) + sizeof(MonoObject));
+		MonoObject *res = mono_value_box_checked (domain, mono_object_class (val), ((char*)val) + sizeof(MonoObject), &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		return res;
+
 	}
 	case MONO_TYPE_STRING: {
 		MonoString *str = (MonoString *) val;

--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -1925,7 +1925,10 @@ ves_icall_System_Net_Sockets_Socket_Select_internal (MonoArray **sockets, gint32
 static MonoObject*
 int_to_object (MonoDomain *domain, int val)
 {
-	return mono_value_box (domain, mono_get_int32_class (), &val);
+	MonoError error;
+	MonoObject *result = mono_value_box_checked (domain, mono_get_int32_class (), &val, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	return result;
 }
 
 void

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1322,7 +1322,7 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
 		/*
 		 * Calling a non-vtype method with a vtype receiver, has to box.
 		 */
-		*this_arg = mono_value_box (mono_domain_get (), klass, mp);
+		*this_arg = mono_value_box_checked (mono_domain_get (), klass, mp, error);
 	else if (klass->valuetype)
 		/*
 		 * Calling a vtype method with a vtype receiver

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2502,7 +2502,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 		mono_error_set_exception_instance (error, (MonoException*) *exc);
 
 	if (sig->ret->type != MONO_TYPE_VOID && info->ret_box_class)
-		return mono_value_box (domain, info->ret_box_class, retval);
+		return mono_value_box_checked (domain, info->ret_box_class, retval, error);
 	else
 		return *(MonoObject**)retval;
 }
@@ -2677,7 +2677,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		mono_arch_finish_dyn_call (info->dyn_call_info, buf);
 
 		if (info->ret_box_class)
-			return mono_value_box (domain, info->ret_box_class, retval);
+			return mono_value_box_checked (domain, info->ret_box_class, retval, error);
 		else
 			return *(MonoObject**)retval;
 	}


### PR DESCRIPTION
Mark it external only.  Runtime should use mono_value_box_checked.