### PR TITLE
Changes to "checked build" feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3547,35 +3547,34 @@ AC_ARG_WITH(cooperative_gc, [  --with-cooperative-gc=yes|no      Enable cooperat
 	fi
 ], [with_cooperative_gc=no])
 
-AC_ARG_WITH(checked_build, [  --with-checked-build=yes|no      Enable checked build (expensive asserts)) (defaults to no)],[
-	if test x$with_checked_build != xno ; then
-		AC_DEFINE(CHECKED_BUILD,1,[Enable checked build.])
+AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable checked build (expensive asserts), configure with a comma-separated LIST of checked build modules and then include that same list in the environment variable MONO_CHECK_MODE at runtime. Recognized checked build modules: all, gc, metadata, thread],[
+
+	if test x$enable_checked_build != x ; then
+		AC_DEFINE(ENABLE_CHECKED_BUILD,1,[Enable checked build])
 	fi
-], [with_checked_build=no])
+	for feature in `echo "$enable_checked_build" | sed -e "s/,/ /g"`; do
+		eval "mono_checked_build_test_enable_$feature='yes'"
+	done
 
-if test x$with_checked_build != xno ; then
-	DISABLED_CHECKED_BUILD_TEST=none
-
-	AC_ARG_ENABLE(checked_build_test, [  --enable-checked-build-test=LIST      drop support for LIST checked build tests. LIST is a comma-separated list from: gc, metadata, thread.],
-	[
-		for feature in `echo "$enable_checked_build_test" | sed -e "s/,/ /g"`; do
-			eval "mono_checked_build_test_disable_$feature='yes'"
-		done
-		DISABLED_CHECKED_BUILD_TEST=$enable_checked_build_test
-	],[])
-
-	if test "x$mono_checked_build_test_disable_gc" = "xyes"; then
-		AC_DEFINE(DISABLE_CHECKED_BUILD_GC, 1, [Disable GC checked build])
+	if test "x$mono_checked_build_test_enable_all" = "xyes"; then
+		eval "mono_checked_build_test_enable_gc='yes'"
+		eval "mono_checked_build_test_enable_metadata='yes'"
+		eval "mono_checked_build_test_enable_thread='yes'"
 	fi
 
-	if test "x$mono_checked_build_test_disable_metadata" = "xyes"; then
-		AC_DEFINE(DISABLE_CHECKED_BUILD_METADATA, 1, [Disable metadata checked build])
+	if test "x$mono_checked_build_test_enable_gc" = "xyes"; then
+		AC_DEFINE(ENABLE_CHECKED_BUILD_GC, 1, [Enable GC checked build])
 	fi
 
-	if test "x$mono_checked_build_test_disable_thread" = "xyes"; then
-		AC_DEFINE(DISABLE_CHECKED_BUILD_THREAD, 1, [Disable thread checked build])
+	if test "x$mono_checked_build_test_enable_metadata" = "xyes"; then
+		AC_DEFINE(ENABLE_CHECKED_BUILD_METADATA, 1, [Enable metadata checked build])
 	fi
-fi
+
+	if test "x$mono_checked_build_test_enable_thread" = "xyes"; then
+		AC_DEFINE(ENABLE_CHECKED_BUILD_THREAD, 1, [Enable thread checked build])
+	fi
+
+], [])
 
 AC_CHECK_HEADER([malloc.h], 
 		[AC_DEFINE([HAVE_USR_INCLUDE_MALLOC_H], [1], 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -94,7 +94,7 @@ mono_handle_elevate (MonoHandle handle)
 	return mono_handle_arena_elevate (mono_handle_arena_current (), handle);
 }
 
-#ifndef CHECKED_BUILD
+#ifndef ENABLE_CHECKED_BUILD
 
 #define mono_handle_obj(handle) ((handle)->__private_obj)
 

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -8,7 +8,7 @@
  */
 #include <config.h>
 
-#ifdef CHECKED_BUILD
+#ifdef ENABLE_CHECKED_BUILD
 
 #include <mono/utils/checked-build.h>
 #include <mono/utils/mono-threads.h>
@@ -50,7 +50,7 @@ get_state (void)
 	return state;
 }
 
-#if !defined(DISABLE_CHECKED_BUILD_THREAD)
+#ifdef ENABLE_CHECKED_BUILD_THREAD
 
 #define MAX_NATIVE_BT 6
 #define MAX_NATIVE_BT_PROBE (MAX_NATIVE_BT + 5)
@@ -143,9 +143,9 @@ checked_build_thread_transition (const char *transition, void *info, int from_st
 	g_ptr_array_add (state->transitions, t);
 }
 
-#endif /* !defined(DISABLE_CHECKED_BUILD_THREAD) */
+#endif /* defined(ENABLE_CHECKED_BUILD_THREAD) */
 
-#if !defined(DISABLE_CHECKED_BUILD_GC)
+#ifdef ENABLE_CHECKED_BUILD_GC
 
 static void
 assertion_fail (const char *msg, ...)
@@ -180,6 +180,10 @@ assertion_fail (const char *msg, ...)
 	g_error (err->str);
 	g_string_free (err, TRUE);
 }
+
+#endif /* defined(ENABLE_CHECKED_BUILD_THREAD) */
+
+#ifdef ENABLE_CHECKED_BUILD_GC
 
 void
 assert_gc_safe_mode (void)
@@ -273,9 +277,9 @@ assert_in_gc_critical_region (void)
 		assertion_fail("Expected GC critical region");
 }
 
-#endif /* !defined(DISABLE_CHECKED_BUILD_GC) */
+#endif /* defined(ENABLE_CHECKED_BUILD_GC) */
 
-#if !defined(DISABLE_CHECKED_BUILD_METADATA)
+#ifdef ENABLE_CHECKED_BUILD_METADATA
 
 // check_metadata_store et al: The goal of these functions is to verify that if there is a pointer from one mempool into
 // another, that the pointed-to memory is protected by the reference count mechanism for MonoImages.
@@ -610,6 +614,6 @@ check_metadata_store_local (void *from, void *to)
     check_mempool_may_reference_mempool (from, to, TRUE);
 }
 
-#endif /* !defined(DISABLE_CHECKED_BUILD_METADATA) */
+#endif /* defined(ENABLE_CHECKED_BUILD_METADATA) */
 
-#endif /* CHECKED_BUILD */
+#endif /* ENABLE_CHECKED_BUILD */

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -202,12 +202,8 @@ checked_build_thread_transition (const char *transition, void *info, int from_st
 	g_ptr_array_add (state->transitions, t);
 }
 
-#endif /* defined(ENABLE_CHECKED_BUILD_THREAD) */
-
-#ifdef ENABLE_CHECKED_BUILD_GC
-
-static void
-assertion_fail (const char *msg, ...)
+void
+mono_fatal_with_history (const char *msg, ...)
 {
 	int i;
 	GString* err = g_string_sized_new (100);
@@ -258,14 +254,14 @@ assert_gc_safe_mode (void)
 	int state;
 
 	if (!cur)
-		assertion_fail ("Expected GC Safe mode but thread is not attached");
+		mono_fatal_with_history ("Expected GC Safe mode but thread is not attached");
 
 	switch (state = mono_thread_info_current_state (cur)) {
 	case STATE_BLOCKING:
 	case STATE_BLOCKING_AND_SUSPENDED:
 		break;
 	default:
-		assertion_fail ("Expected GC Safe mode but was in %s state", mono_thread_state_name (state));
+		mono_fatal_with_history ("Expected GC Safe mode but was in %s state", mono_thread_state_name (state));
 	}
 }
 
@@ -279,7 +275,7 @@ assert_gc_unsafe_mode (void)
 	int state;
 
 	if (!cur)
-		assertion_fail ("Expected GC Unsafe mode but thread is not attached");
+		mono_fatal_with_history ("Expected GC Unsafe mode but thread is not attached");
 
 	switch (state = mono_thread_info_current_state (cur)) {
 	case STATE_RUNNING:
@@ -287,7 +283,7 @@ assert_gc_unsafe_mode (void)
 	case STATE_SELF_SUSPEND_REQUESTED:
 		break;
 	default:
-		assertion_fail ("Expected GC Unsafe mode but was in %s state", mono_thread_state_name (state));
+		mono_fatal_with_history ("Expected GC Unsafe mode but was in %s state", mono_thread_state_name (state));
 	}
 }
 
@@ -301,7 +297,7 @@ assert_gc_neutral_mode (void)
 	int state;
 
 	if (!cur)
-		assertion_fail ("Expected GC Neutral mode but thread is not attached");
+		mono_fatal_with_history ("Expected GC Neutral mode but thread is not attached");
 
 	switch (state = mono_thread_info_current_state (cur)) {
 	case STATE_RUNNING:
@@ -311,7 +307,7 @@ assert_gc_neutral_mode (void)
 	case STATE_BLOCKING_AND_SUSPENDED:
 		break;
 	default:
-		assertion_fail ("Expected GC Neutral mode but was in %s state", mono_thread_state_name (state));
+		mono_fatal_with_history ("Expected GC Neutral mode but was in %s state", mono_thread_state_name (state));
 	}
 }
 
@@ -346,7 +342,7 @@ assert_not_in_gc_critical_region(void)
 
 	CheckState *state = get_state();
 	if (state->in_gc_critical_region > 0) {
-		assertion_fail("Expected GC Unsafe mode, but was in %s state", mono_thread_state_name (mono_thread_info_current_state (mono_thread_info_current ())));
+		mono_fatal_with_history("Expected GC Unsafe mode, but was in %s state", mono_thread_state_name (mono_thread_info_current_state (mono_thread_info_current ())));
 	}
 }
 
@@ -358,7 +354,7 @@ assert_in_gc_critical_region (void)
 
 	CheckState *state = get_state();
 	if (state->in_gc_critical_region == 0)
-		assertion_fail("Expected GC critical region");
+		mono_fatal_with_history("Expected GC critical region");
 }
 
 #endif /* defined(ENABLE_CHECKED_BUILD_GC) */

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -12,6 +12,18 @@
 
 #include <config.h>
 #include <mono/utils/atomic.h>
+#include <mono/utils/mono-publib.h>
+
+typedef enum {
+	MONO_CHECK_MODE_NONE = 0,
+	MONO_CHECK_MODE_GC = 0x1,
+	MONO_CHECK_MODE_METADATA = 0x2,
+	MONO_CHECK_MODE_THREAD = 0x4,
+	MONO_CHECK_MODE_ALL = MONO_CHECK_MODE_GC | MONO_CHECK_MODE_METADATA | MONO_CHECK_MODE_THREAD,
+	MONO_CHECK_MODE_UNKNOWN = 0x8
+} MonoCheckMode;
+
+mono_bool mono_check_mode_enabled (MonoCheckMode query);
 
 // This is for metadata writes which we have chosen not to check at the current time.
 // Because in principle this should never happen, we still use a macro so that the exemptions will be easier to find, and remove, later.

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -18,7 +18,7 @@
 // The current reason why this is needed is for pointers to constant strings, which the checker cannot verify yet.
 #define CHECKED_METADATA_WRITE_PTR_EXEMPT(ptr, val) do { (ptr) = (val); } while (0)
 
-#if defined(CHECKED_BUILD)
+#ifdef ENABLE_CHECKED_BUILD
 
 #define g_assert_checked g_assert
 
@@ -45,10 +45,9 @@ void checked_build_init (void);
 
 #define CHECKED_MONO_INIT()
 
-#endif /* CHECKED_BUILD */
+#endif /* ENABLE_CHECKED_BUILD */
 
-#if defined(CHECKED_BUILD) && !defined(DISABLE_CHECKED_BUILD_GC)
-
+#ifdef ENABLE_CHECKED_BUILD_GC
 /*
 GC runtime modes rules:
 
@@ -149,9 +148,9 @@ void assert_in_gc_critical_region (void);
 #define MONO_REQ_GC_NOT_CRITICAL
 #define MONO_REQ_GC_CRITICAL
 
-#endif /* defined(CHECKED_BUILD) && !defined(DISABLE_CHECKED_BUILD_GC) */
+#endif /* defined(ENABLE_CHECKED_BUILD_GC) */
 
-#if defined(CHECKED_BUILD) && !defined(DISABLE_CHECKED_BUILD_METADATA)
+#ifdef ENABLE_CHECKED_BUILD_METADATA
 
 // Use when writing a pointer from one image or imageset to another.
 #define CHECKED_METADATA_WRITE_PTR(ptr, val) do {    \
@@ -180,9 +179,9 @@ void check_metadata_store_local(void *from, void *to);
 #define CHECKED_METADATA_WRITE_PTR_LOCAL(ptr, val) do { (ptr) = (val); } while (0)
 #define CHECKED_METADATA_WRITE_PTR_ATOMIC(ptr, val) do { mono_atomic_store_release (&(ptr), (val)); } while (0)
 
-#endif /* defined(CHECKED_BUILD) && !defined(DISABLE_CHECKED_BUILD_METADATA) */
+#endif /* defined(ENABLE_CHECKED_BUILD_METADATA) */
 
-#if defined(CHECKED_BUILD) && !defined(DISABLE_CHECKED_BUILD_THREAD)
+#ifdef ENABLE_CHECKED_BUILD_THREAD
 
 #define CHECKED_BUILD_THREAD_TRANSITION(transition, info, from_state, suspend_count, next_state, suspend_count_delta) do {	\
 	checked_build_thread_transition (transition, info, from_state, suspend_count, next_state, suspend_count_delta);	\
@@ -194,6 +193,6 @@ void checked_build_thread_transition(const char *transition, void *info, int fro
 
 #define CHECKED_BUILD_THREAD_TRANSITION(transition, info, from_state, suspend_count, next_state, suspend_count_delta)
 
-#endif /* defined(CHECKED_BUILD) && !defined(DISABLE_CHECKED_BUILD_THREAD) */
+#endif /* defined(ENABLE_CHECKED_BUILD_THREAD) */
 
 #endif /* __CHECKED_BUILD_H__ */

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -201,9 +201,13 @@ void check_metadata_store_local(void *from, void *to);
 
 void checked_build_thread_transition(const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta);
 
+void mono_fatal_with_history(const char *msg, ...);
+
 #else
 
 #define CHECKED_BUILD_THREAD_TRANSITION(transition, info, from_state, suspend_count, next_state, suspend_count_delta)
+
+#define mono_fatal_with_history g_error
 
 #endif /* defined(ENABLE_CHECKED_BUILD_THREAD) */
 

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -25,6 +25,7 @@
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-threads-api.h>
+#include <mono/utils/checked-build.h>
 
 #ifdef TARGET_OSX
 #include <mono/utils/mach-support.h>
@@ -38,6 +39,35 @@
 #endif
 
 volatile size_t mono_polling_required;
+
+// FIXME: This would be more efficient if instead of instantiating the stack it just pushed a simple depth counter up and down,
+// perhaps with a per-thread cookie in the high bits.
+#ifdef ENABLE_CHECKED_BUILD_GC
+// Maintains a single per-thread stack of ints, used to ensure nesting is not violated
+MonoNativeTlsKey coop_reset_count_stack_key;
+static int coop_tls_push (int v) {
+	GArray *stack = mono_native_tls_get_value (coop_reset_count_stack_key);
+	if (!stack) {
+		stack = g_array_new (FALSE,FALSE,sizeof(int));
+		mono_native_tls_set_value (coop_reset_count_stack_key, stack);
+	}
+	g_array_append_val (stack, v);
+	return stack->len;
+}
+static int coop_tls_pop (int *v) {
+	GArray *stack = mono_native_tls_get_value (coop_reset_count_stack_key);
+	if (!stack || 0 == stack->len)
+		return -1;
+	stack->len--;
+	*v = g_array_index (stack, int, stack->len);
+	int len = stack->len;
+	if (0 == len) {
+		g_array_free (stack,TRUE);
+		mono_native_tls_set_value (coop_reset_count_stack_key, NULL);
+	}
+	return len;
+}
+#endif
 
 static int coop_reset_blocking_count;
 static int coop_try_blocking_count;
@@ -193,9 +223,18 @@ mono_threads_reset_blocking_start (void* stackdata)
 	if (!mono_threads_is_coop_enabled ())
 		return NULL;
 
-	++coop_reset_blocking_count;
-
 	info = mono_thread_info_current_unchecked ();
+
+#ifdef ENABLE_CHECKED_BUILD_GC
+	int reset_blocking_count = InterlockedIncrement (&coop_reset_blocking_count);
+	// In this mode, the blocking count is used as the reset cookie. We would prefer
+	// (but do not require) this to be unique across invocations and threads.
+	if (reset_blocking_count == 0) // We *do* require it be nonzero
+		reset_blocking_count = coop_reset_blocking_count = 1;
+#else
+	++coop_reset_blocking_count;
+#endif
+
 	/* If the thread is not attached, it doesn't make sense prepare for suspend. */
 	if (!info || !mono_thread_info_is_live (info))
 		return NULL;
@@ -211,28 +250,50 @@ mono_threads_reset_blocking_start (void* stackdata)
 		return NULL;
 	case AbortBlockingOk:
 		info->thread_saved_state [SELF_SUSPEND_STATE_INDEX].valid = FALSE;
-		return info;
+		break;
 	case AbortBlockingOkAndPool:
 		mono_threads_state_poll ();
-		return info;
+		break;
 	default:
 		g_error ("Unknown thread state");
 	}
+
+#ifdef ENABLE_CHECKED_BUILD_GC
+	if (mono_check_mode_enabled (MONO_CHECK_MODE_GC)) {
+		int level = coop_tls_push (reset_blocking_count);
+		//g_warning("Entering reset nest; level %d; cookie %d\n", level, reset_blocking_count);
+		return (void *)(intptr_t)reset_blocking_count;
+	}
+#endif
+
+	return info;
 }
 
 void
 mono_threads_reset_blocking_end (void *cookie, void* stackdata)
 {
-	MonoThreadInfo *info;
-
 	if (!mono_threads_is_coop_enabled ())
 		return;
 
-	info = (MonoThreadInfo *)cookie;
-	if (!info)
+	if (!cookie)
 		return;
 
-	g_assert (info == mono_thread_info_current_unchecked ());
+#ifdef ENABLE_CHECKED_BUILD_GC
+	if (mono_check_mode_enabled (MONO_CHECK_MODE_GC)) {
+		int received_cookie = (int)(intptr_t)cookie;
+		int desired_cookie;
+		int level = coop_tls_pop (&desired_cookie);
+		//g_warning("Leaving reset nest; back to level %d; desired cookie %d; received cookie %d\n", level, desired_cookie, received_cookie);
+		if (level < 0)
+			g_error_with_history ("Expected cookie %d but found no stack at all\n", desired_cookie);
+		if (desired_cookie != received_cookie)
+			g_error_with_history ("Expected cookie %d but received %d\n", desired_cookie, received_cookie);
+	} else // Notice this matches the line after the endif
+#endif
+	{
+		g_assert (((MonoThreadInfo *)cookie) == mono_thread_info_current_unchecked ());
+	}
+
 	mono_threads_prepare_blocking (stackdata);
 }
 
@@ -248,6 +309,10 @@ mono_threads_init_coop (void)
 	mono_counters_register ("Coop Do Polling", MONO_COUNTER_GC | MONO_COUNTER_INT, &coop_do_polling_count);
 	mono_counters_register ("Coop Save Count", MONO_COUNTER_GC | MONO_COUNTER_INT, &coop_save_count);
 	//See the above for what's wrong here.
+
+#ifdef ENABLE_CHECKED_BUILD_GC
+	mono_native_tls_alloc (&coop_reset_count_stack_key, NULL);
+#endif
 }
 
 void

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -113,7 +113,7 @@ retry_state_change:
 		trace_state_change ("ATTACH", info, raw_state, STATE_RUNNING, 0);
 		break;
 	default:
-		g_error ("Cannot transition current thread from %s with ATTACH", state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition current thread from %s with ATTACH", state_name (cur_state));
 	}
 }
 
@@ -148,7 +148,7 @@ STATE_BLOCKING: This is a bug in the coop code that forgot to do a finish blocki
 STATE_BLOCKING_AND_SUSPENDED: This is a bug in coop x suspend that resulted the thread in an undetachable state.
 */
 	default:
-		g_error ("Cannot transition current thread %p from %s with DETACH", info, state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition current thread %p from %s with DETACH", info, state_name (cur_state));
 	}
 }
 
@@ -190,7 +190,7 @@ STATE_BLOCKING_AND_SUSPENDED: Self suspension cannot be started when the thread 
 If this turns to be an issue we can introduce a new suspend request state for when both have been requested.
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with SUSPEND_REQUEST", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with SUSPEND_REQUEST", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 
@@ -252,7 +252,7 @@ The expected behavior is that the target should poll its state very soon so the 
 STATE_ASYNC_SUSPEND_REQUESTED: Since there can only be one async suspend in progress and it must finish, it should not be possible to witness this.
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with ASYNC_SUSPEND_REQUESTED", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with ASYNC_SUSPEND_REQUESTED", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 	return (MonoRequestAsyncSuspendResult) FALSE;
 }
@@ -301,7 +301,7 @@ STATE_BLOCKING:
 STATE_BLOCKING_AND_SUSPENDED: Pool is a local state transition. No VM activities are allowed while in blocking mode.
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with STATE_POLL", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with STATE_POLL", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 
@@ -401,7 +401,7 @@ If this turns to be a problem we should either implement [2] or make this an inv
 
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with REQUEST_RESUME", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with REQUEST_RESUME", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 
@@ -437,7 +437,7 @@ STATE_SELF_SUSPEND_REQUESTED: When self suspend and async suspend happen togethe
 STATE_BLOCKING: Async suspend only begins if a transition to async suspend requested happened. Blocking would have put us into blocking with positive suspend count if it raced with async finish.
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with FINISH_ASYNC_SUSPEND", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with FINISH_ASYNC_SUSPEND", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 
@@ -481,7 +481,7 @@ STATE_BLOCKING_AND_SUSPENDED
 STATE_SELF_SUSPEND_REQUESTED: All those are invalid end states of a sucessfull finish async suspend
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with COMPENSATE_FINISH_ASYNC_SUSPEND", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with COMPENSATE_FINISH_ASYNC_SUSPEND", mono_thread_info_get_tid (info), state_name (cur_state));
 
 	}
 }
@@ -526,7 +526,7 @@ STATE_BLOCKING:
 STATE_BLOCKING_AND_SUSPENDED: Blocking is not nestabled
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with DO_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with DO_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 
@@ -574,7 +574,7 @@ STATE_SELF_SUSPEND_REQUESTED: A blocking operation must not be done while trying
 STATE_BLOCKING_AND_SUSPENDED: This an exit state of done blocking
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 
@@ -624,7 +624,7 @@ STATE_SELF_SUSPEND_REQUESTED: A blocking operation must not be done while trying
 STATE_BLOCKING_AND_SUSPENDED: This is an exit state of done blocking, can't happen here.
 */
 	default:
-		g_error ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 


### PR DESCRIPTION
Here are some changes to checked builds I made while trying to debug some coop gc problems. The changes made are:

- Replace the checked build configure flags with a single --enable-checked-build= flag
- Runtime environment variable required for checked build asserts to run
- Report the thread transition history for more kinds of asserts
- For the `mono_threads_reset_blocking` functions, add an assert that guarantees proper nesting

In addition to this, I have documented the checked build feature as implemented here, see my pull request for the website: https://github.com/mono/website/pull/187

Overall my goals with this patch were

- Make it easier to do rapid-fire testing with the checked builds (runtime switch, default-off)
- Make the checked build implementation more internally consistent (more uniform names etc)

Notice I do make the change that instead of checked build sub-features being disabled with a blacklist, you now must enable them with a whitelist. I think this is an improvement because it makes it easier to just casually keep a checked build around  (for one thing I would have the option to ship debug builds to users with the checked build modes included but dormant) but I could be talked out of it if this change turns out to be controversial. The only thing I feel strongly about is that if the configure flag is changed back to a blacklist the environment variable should switch to a blacklist also.

If we accept this change the CI bots will need to adopt the new configure flag and environment variable.