### PR TITLE
fixed replacement of $mono_libdir in config file

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2673,8 +2673,9 @@ mono_assembly_load_publisher_policy (MonoAssemblyName *aname)
 
 	if (strstr (aname->name, ".dll")) {
 		len = strlen (aname->name) - 4;
-		name = (gchar *)g_malloc (len);
+		name = (gchar *)g_malloc (len + 1);
 		strncpy (name, aname->name, len);
+		name[len] = 0;
 	} else
 		name = g_strdup (aname->name);
 	
@@ -2984,8 +2985,9 @@ mono_assembly_load_from_gac (MonoAssemblyName *aname,  gchar *filename, MonoImag
 
 	if (strstr (aname->name, ".dll")) {
 		len = strlen (filename) - 4;
-		name = (gchar *)g_malloc (len);
+		name = (gchar *)g_malloc (len + 1);
 		strncpy (name, aname->name, len);
+		name[len] = 0;
 	} else {
 		name = g_strdup (aname->name);
 	}

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -285,7 +285,7 @@ dllmap_start (gpointer user_data,
 					char *result;
 					
 					result = (char *)g_malloc (libdir_len-strlen("$mono_libdir")+strlen(attribute_values[i])+1);
-					strncpy (result, attribute_names[i], p-attribute_values[i]);
+					strncpy (result, attribute_values[i], p-attribute_values[i]);
 					strcpy (result+(p-attribute_values[i]), libdir);
 					strcat (result, p+strlen("$mono_libdir"));
 					info->target = result;

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -286,7 +286,7 @@ dllmap_start (gpointer user_data,
 					
 					result = (char *)g_malloc (libdir_len-strlen("$mono_libdir")+strlen(attribute_values[i])+1);
 					strncpy (result, attribute_names[i], p-attribute_values[i]);
-					strcat (result, libdir);
+					strcpy (result+(p-attribute_values[i]), libdir);
 					strcat (result, p+strlen("$mono_libdir"));
 					info->target = result;
 				} else 


### PR DESCRIPTION
strncpy does not NUL-terminate the destination string in this case so one cannot use strcat to append

This fixes the error "malloc: top chunk is corrupt" as reported on mono-devel-list back in 2015-10-20 (subject: "malloc error executing OBS-built mono") at least for me.