### PR TITLE
"disable_omit_fp" option for MONO_DEBUG

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1638,6 +1638,10 @@ option.
 When this option is set, the runtime will invalidate the domain memory
 pool instead of destroying it.
 .TP
+\fBdisable_omit_fp\fR
+Disables a compiler optimization where the frame pointer is omitted
+from the stack. This optimization can interact badly with debuggers.
+.TP
 \fBdont-free-domains\fR
 This is an Optimization for multi-AppDomain applications (most
 commonly ASP.NET applications).  Due to internal limitations Mono,

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3310,6 +3310,8 @@ mini_parse_debug_option (const char *option)
 		mono_align_small_structs = TRUE;
 	else if (!strcmp (option, "native-debugger-break"))
 		debug_options.native_debugger_break = TRUE;
+	else if (!strcmp (option, "disable_omit_fp"))
+		debug_options.disable_omit_fp = TRUE;
 	else
 		return FALSE;
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3478,6 +3478,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	cfg->verbose_level = mini_verbose;
 	cfg->compile_aot = compile_aot;
 	cfg->full_aot = full_aot;
+	cfg->disable_omit_fp = debug_options.disable_omit_fp;
 	cfg->skip_visibility = method->skip_visibility;
 	cfg->orig_method = method;
 	cfg->gen_seq_points = debug_options.gen_seq_points_compact_data || debug_options.gen_sdb_seq_points;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2131,6 +2131,11 @@ typedef struct {
 	 * Translate Debugger.Break () into a native breakpoint signal
 	 */
 	gboolean native_debugger_break;
+	/*
+	 * Disabling the frame pointer emit optimization can allow debuggers to more easily
+	 * identify the stack on some platforms
+	 */
+	gboolean disable_omit_fp;
 } MonoDebugOptions;
 
 enum {


### PR DESCRIPTION
Option disables a compiler optimization that omits framepointers from the stack. This option has been present for a long time but never user surfaced.