### PR TITLE
Allow a single dll to be mapped to different targets based on function name.

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1281,6 +1281,7 @@ mono_dllmap_lookup_list (MonoDllMap *dll_map, const char *dll, const char* func,
 			 */
 		}
 		if (dll_map->func && strcmp (dll_map->func, func) == 0) {
+			*rdll = dll_map->target;
 			*rfunc = dll_map->target_func;
 			break;
 		}
@@ -1308,7 +1309,7 @@ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, cons
  * @dll: The name of the external library, as it would be found in the DllImport declaration.  If prefixed with 'i:' the matching of the library name is done without case sensitivity
  * @func: if not null, the mapping will only applied to the named function (the value of EntryPoint)
  * @tdll: The name of the library to map the specified @dll if it matches.
- * @tfunc: if func is not NULL, the name of the function that replaces the invocation
+ * @tfunc: The name of the function that replaces the invocation.  If NULL, it is replaced with a copy of @func.
  *
  * LOCKING: Acquires the loader lock.
  *
@@ -1343,7 +1344,7 @@ mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, cons
 		entry->dll = dll? g_strdup (dll): NULL;
 		entry->target = tdll? g_strdup (tdll): NULL;
 		entry->func = func? g_strdup (func): NULL;
-		entry->target_func = tfunc? g_strdup (tfunc): NULL;
+		entry->target_func = tfunc? g_strdup (tfunc): (func? g_strdup (func): NULL);
 
 		global_loader_data_lock ();
 		entry->next = global_dll_map;
@@ -1354,7 +1355,7 @@ mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, cons
 		entry->dll = dll? mono_image_strdup (assembly, dll): NULL;
 		entry->target = tdll? mono_image_strdup (assembly, tdll): NULL;
 		entry->func = func? mono_image_strdup (assembly, func): NULL;
-		entry->target_func = tfunc? mono_image_strdup (assembly, tfunc): NULL;
+		entry->target_func = tfunc? mono_image_strdup (assembly, tfunc): (func? mono_image_strdup (assembly, func): NULL);
 
 		mono_image_lock (assembly);
 		entry->next = assembly->dll_map;


### PR DESCRIPTION
[dllmap](http://www.mono-project.com/docs/advanced/pinvoke/dllmap/) usually makes it possible to import different native libraries depending on platform, but I recently came across the interesting case of [Tox](https://github.com/irungentoo/toxcore).  On Windows, they distribute a single `libtox.dll`, which exports all the library functions.  On other platforms, those functions are spread among four separate shared libraries.  Mono's configuration loader doesn't handle the situation correctly because it always tries to load the `dll` of the last `<dllentry>` in the list, even if it doesn't match by `name`.

Modify the configuration loader so that

- A single dll can be mapped to different targets based on function name.
- The dllentry `target` can be omitted if it is the same as the source.


With this patch, the following configuration is now parsed correctly:

```
<configuration>
	<dllmap os="!windows" dll="libtox">
		<dllentry dll="libtoxcore" name="tox_new" />
		<dllentry dll="libtoxcore" name="tox_options_default" />
		<dllentry dll="libtoxcore" name="tox_options_new" />
		<dllentry dll="libtoxcore" name="tox_options_free" />
		<dllentry dll="libtoxcore" name="tox_version_major" />
		<dllentry dll="libtoxcore" name="tox_version_minor" />
		<dllentry dll="libtoxcore" name="tox_version_patch" />
		<dllentry dll="libtoxcore" name="tox_version_is_compatible" />
		<dllentry dll="libtoxcore" name="tox_bootstrap" />
		<dllentry dll="libtoxcore" name="tox_self_get_connection_status" />
		<dllentry dll="libtoxcore" name="tox_self_get_address" />
		<dllentry dll="libtoxcore" name="tox_friend_by_public_key" />
		<dllentry dll="libtoxcore" name="tox_friend_get_public_key" />
		<dllentry dll="libtoxcore" name="tox_iterate" />
		<dllentry dll="libtoxcore" name="tox_iteration_interval" />
		<dllentry dll="libtoxcore" name="tox_kill" />
		<dllentry dll="libtoxcore" name="tox_friend_delete" />
		<dllentry dll="libtoxcore" name="tox_friend_get_connection_status" />
		<dllentry dll="libtoxcore" name="tox_friend_get_status" />
		<dllentry dll="libtoxcore" name="tox_self_get_status" />
		<dllentry dll="libtoxcore" name="tox_friend_exists" />
		<dllentry dll="libtoxcore" name="tox_self_get_friend_list_size" />
		<dllentry dll="libtoxcore" name="tox_self_get_friend_list" />
		<dllentry dll="libtoxcore" name="tox_get_savedata_size" />
		<dllentry dll="libtoxcore" name="tox_get_savedata" />
		<dllentry dll="libtoxcore" name="tox_friend_add" />
		<dllentry dll="libtoxcore" name="tox_friend_add_norequest" />
		<dllentry dll="libtoxcore" name="tox_self_set_name" />
		<dllentry dll="libtoxcore" name="tox_self_get_name" />
		<dllentry dll="libtoxcore" name="tox_self_get_name_size" />
		<dllentry dll="libtoxcore" name="tox_self_set_typing" />
		<dllentry dll="libtoxcore" name="tox_friend_get_typing" />
		<dllentry dll="libtoxcore" name="tox_add_tcp_relay" />
		<dllentry dll="libtoxcore" name="tox_self_set_nospam" />
		<dllentry dll="libtoxcore" name="tox_self_get_nospam" />
		<dllentry dll="libtoxcore" name="tox_self_get_public_key" />
		<dllentry dll="libtoxcore" name="tox_self_get_secret_key" />
		<dllentry dll="libtoxcore" name="tox_self_get_status_message" />
		<dllentry dll="libtoxcore" name="tox_self_get_status_message_size" />
		<dllentry dll="libtoxcore" name="tox_self_set_status" />
		<dllentry dll="libtoxcore" name="tox_friend_get_name_size" />
		<dllentry dll="libtoxcore" name="tox_friend_get_name" />
		<dllentry dll="libtoxcore" name="tox_friend_get_status_message_size" />
		<dllentry dll="libtoxcore" name="tox_friend_get_status_message" />
		<dllentry dll="libtoxcore" name="tox_self_get_udp_port" />
		<dllentry dll="libtoxcore" name="tox_self_get_tcp_port" />
		<dllentry dll="libtoxcore" name="tox_self_get_dht_id" />
		<dllentry dll="libtoxcore" name="tox_hash" />
		<dllentry dll="libtoxcore" name="tox_file_control" />
		<dllentry dll="libtoxcore" name="tox_file_send" />
		<dllentry dll="libtoxcore" name="tox_file_send_chunk" />
		<dllentry dll="libtoxcore" name="tox_file_get_file_id" />
		<dllentry dll="libtoxcore" name="tox_file_seek" />
		<dllentry dll="libtoxcore" name="tox_friend_send_lossy_packet" />
		<dllentry dll="libtoxcore" name="tox_friend_send_lossless_packet" />
		<dllentry dll="libtoxcore" name="tox_friend_get_last_online" />
		<dllentry dll="libtoxcore" name="tox_add_groupchat" />
		<dllentry dll="libtoxcore" name="tox_del_groupchat" />
		<dllentry dll="libtoxcore" name="tox_group_peername" />
		<dllentry dll="libtoxcore" name="tox_invite_friend" />
		<dllentry dll="libtoxcore" name="tox_join_groupchat" />
		<dllentry dll="libtoxcore" name="tox_group_message_send" />
		<dllentry dll="libtoxcore" name="tox_group_action_send" />
		<dllentry dll="libtoxcore" name="tox_group_number_peers" />
		<dllentry dll="libtoxcore" name="tox_group_get_names" />
		<dllentry dll="libtoxcore" name="tox_group_peernumber_is_ours" />
		<dllentry dll="libtoxcore" name="tox_group_set_title" />
		<dllentry dll="libtoxcore" name="tox_group_get_type" />
		<dllentry dll="libtoxcore" name="tox_group_get_title" />
		<dllentry dll="libtoxcore" name="tox_group_peer_pubkey" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_request" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_message" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_name" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_status_message" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_status" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_typing" />
		<dllentry dll="libtoxcore" name="tox_callback_self_connection_status" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_connection_status" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_read_receipt" />
		<dllentry dll="libtoxcore" name="tox_callback_file_recv" />
		<dllentry dll="libtoxcore" name="tox_callback_file_recv_control" />
		<dllentry dll="libtoxcore" name="tox_callback_file_recv_chunk" />
		<dllentry dll="libtoxcore" name="tox_callback_file_chunk_request" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_lossy_packet" />
		<dllentry dll="libtoxcore" name="tox_callback_friend_lossless_packet" />
		<dllentry dll="libtoxcore" name="tox_callback_group_invite" />
		<dllentry dll="libtoxcore" name="tox_callback_file_recv" />
		<dllentry dll="libtoxcore" name="tox_callback_group_message" />
		<dllentry dll="libtoxcore" name="tox_callback_group_action" />
		<dllentry dll="libtoxcore" name="tox_callback_group_namelist_change" />
		<dllentry dll="libtoxcore" name="tox_callback_group_title" />

		<dllentry dll="libtoxav" name="toxav_version_major" />
		<dllentry dll="libtoxav" name="toxav_version_minor" />
		<dllentry dll="libtoxav" name="toxav_version_patch" />
		<dllentry dll="libtoxav" name="toxav_version_is_compatible" />
		<dllentry dll="libtoxav" name="toxav_new" />
		<dllentry dll="libtoxav" name="toxav_kill" />
		<dllentry dll="libtoxav" name="toxav_get_tox" />
		<dllentry dll="libtoxav" name="toxav_iteration_interval" />
		<dllentry dll="libtoxav" name="toxav_iterate" />
		<dllentry dll="libtoxav" name="toxav_call" />
		<dllentry dll="libtoxav" name="toxav_answer" />
		<dllentry dll="libtoxav" name="toxav_call_control" />
		<dllentry dll="libtoxav" name="toxav_bit_rate_set" />
		<dllentry dll="libtoxav" name="toxav_video_send_frame" />
		<dllentry dll="libtoxav" name="toxav_audio_send_frame" />
		<dllentry dll="libtoxav" name="toxav_add_av_groupchat" />
		<dllentry dll="libtoxav" name="toxav_join_av_groupchat" />
		<dllentry dll="libtoxav" name="toxav_group_send_audio" />
		<dllentry dll="libtoxav" name="toxav_callback_call" />
		<dllentry dll="libtoxav" name="toxav_callback_call_state" />
		<dllentry dll="libtoxav" name="toxav_callback_bit_rate_status" />
		<dllentry dll="libtoxav" name="toxav_callback_video_receive_frame" />
		<dllentry dll="libtoxav" name="toxav_callback_audio_receive_frame" />

		<dllentry dll="libtoxdns" name="tox_dns3_new" />
		<dllentry dll="libtoxdns" name="tox_dns3_kill" />
		<dllentry dll="libtoxdns" name="tox_generate_dns3_string" />
		<dllentry dll="libtoxdns" name="tox_decrypt_dns3_TXT" />

		<dllentry dll="libtoxencryptsave" name="tox_derive_key_from_pass" />
		<dllentry dll="libtoxencryptsave" name="tox_derive_key_with_salt" />
		<dllentry dll="libtoxencryptsave" name="tox_get_salt" />
		<dllentry dll="libtoxencryptsave" name="tox_pass_key_encrypt" />
		<dllentry dll="libtoxencryptsave" name="tox_pass_encrypt" />
		<dllentry dll="libtoxencryptsave" name="tox_pass_key_decrypt" />
		<dllentry dll="libtoxencryptsave" name="tox_pass_decrypt" />
		<dllentry dll="libtoxencryptsave" name="tox_is_data_encrypted" />
	</dllmap>
</configuration>
```