### PR TITLE
[System] Fix ServicePointManager.GetLegacyPolicy() that broke SSL on Linux due to a recent refactoring

### DIFF
--- a/mcs/class/System/System.Net/ServicePointManager.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.cs
@@ -184,7 +184,7 @@ namespace System.Net
 
 		internal static ICertificatePolicy GetLegacyCertificatePolicy ()
 		{
-			return policy;
+			return CertificatePolicy;
 		}
 
 		[MonoTODO("CRL checks not implemented")]


### PR DESCRIPTION
In 80741c16fdd267534cbe33c188c581dcc92c0c69 the 'policy' static field was changed to be lazily initialized in the CertificatePolicy getter. However, GetLegacyPolicy() still returned the field which would now be potentially uninitialized.

This broke HTTPS requests on Linux which now failed with an exception:

```
csharp> new System.Net.WebClient().DownloadString("https://www.example.org")
System.Net.WebException: Error: TrustFailure
  at System.Net.WebClient.DownloadDataInternal (System.Uri address, System.Net.WebRequest& request) <0x40c2bb20 + 0x00323> in <filename unknown>:0
  at System.Net.WebClient.DownloadString (System.Uri address) <0x40c2b910 + 0x0004f> in <filename unknown>:0
  at System.Net.WebClient.DownloadString (System.String address) <0x40c24fd0 + 0x00033> in <filename unknown>:0
```

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=39307

@baulig please take a look