### PR TITLE
[corlib] Fix FileInfo.ToString after MoveTo

### DIFF
--- a/mcs/class/corlib/System.IO/FileInfo.cs
+++ b/mcs/class/corlib/System.IO/FileInfo.cs
@@ -48,6 +48,7 @@ namespace System.IO {
 	public sealed class FileInfo : FileSystemInfo
 	{
 		private bool exists;
+		private string displayPath;
 
 		public FileInfo (string fileName)
 		{
@@ -59,11 +60,14 @@ namespace System.IO {
 
 			OriginalPath = fileName;
 			FullPath = Path.GetFullPath (fileName);
+			
+			displayPath = OriginalPath;
 		}
 
 		private FileInfo (SerializationInfo info, StreamingContext context)
 			: base (info, context)
 		{
+			displayPath = OriginalPath;
 		}
 
 		internal override void InternalRefresh ()
@@ -241,6 +245,8 @@ namespace System.IO {
 
 			File.Move (FullPath, destFullPath);
 			this.FullPath = destFullPath;
+
+			displayPath = destFileName;
 		}
 
 		public FileInfo CopyTo (string destFileName)
@@ -267,7 +273,7 @@ namespace System.IO {
 
 		public override string ToString ()
 		{
-			return OriginalPath;
+			return displayPath;
 		}
 
 #if !MOBILE

--- a/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
@@ -880,6 +880,29 @@ namespace MonoTests.System.IO
 			}
 		}
 
+		[Test] //Covers #38796
+		public void ToStringAfterMoveTo ()
+		{
+			string name1 = "FIT.ToStringAfterMoveTo.Test";
+			string name2 = "FIT.ToStringAfterMoveTo.Test.Alt";
+			string path1 = TempFolder + DSC + name1;
+			string path2 = TempFolder + DSC + name2;
+			DeleteFile (path1);
+			DeleteFile (path2);
+			
+			try {
+				File.Create (path1).Close ();
+				FileInfo info = new FileInfo (path1);
+				Assert.AreEqual (path1, info.ToString (), "#A");
+
+				info.MoveTo (path2);
+				Assert.AreEqual (path2, info.ToString (), "#B");
+			} finally {
+				DeleteFile (path1);
+				DeleteFile (path2);
+			}
+		}
+
 #if !MOBILE
 		[Test]
 		public void Replace1 ()


### PR DESCRIPTION
Fixes [#38796](https://bugzilla.xamarin.com/show_bug.cgi?id=38796)