### PR TITLE
[compiler-tester] Fix incorrect failure with Windows paths in error messages

### DIFF
--- a/mcs/tools/compiler-tester/compiler-tester.cs
+++ b/mcs/tools/compiler-tester/compiler-tester.cs
@@ -1442,6 +1442,7 @@ namespace TestRunner {
 
 		static bool TryToMatchErrorMessage (string actual, string expected)
 		{
+			actual = actual.Replace ("\\", "/");
 			var path_mask_start = expected.IndexOf ("*PATH*");
 			if (path_mask_start > 0 && actual.Length > path_mask_start) {
 				var path_mask_continue = expected.Substring (path_mask_start + 6);


### PR DESCRIPTION
On Windows we saw a failure like the following in mcs tests:

```
cs1589-2.cs...	REGRESSION (CORRECT ERROR -> WRONG ERROR MESSAGE)
Exp: Unable to include XML fragment `/foo/bar' of file `there-is-no-such-file'. Could not find file "*PATH*/there-is-no-such-file"
Was: Unable to include XML fragment `/foo/bar' of file `there-is-no-such-file'. Could not find file "C:\j\workspace\z\label\w64\mcs\errors\there-is-no-such-file"
```

Fixing it by replacing the backslash with forward slash before comparing it to the expected value.

--
This is an old fix from months ago that I forgot to upstream and was sitting in a branch somewhere :smile:

@marek-safar please take a look