### PR TITLE
[runtime] Propagate error from class loading when JIT-ing

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2007,7 +2007,9 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, MonoError *er
 			MonoVTable *vtable;
 
 			mono_jit_stats.methods_lookups++;
-			vtable = mono_class_vtable (domain, method->klass);
+			vtable = mono_class_vtable_full (domain, method->klass, error);
+			if (!is_ok (error))
+				return NULL;
 			g_assert (vtable);
 			if (!mono_runtime_class_init_full (vtable, error))
 				return NULL;


### PR DESCRIPTION
This is trying to address the same issue that @tastywheattasteslikechicken 's PR #2454 tried to address, except while that PR was baking we switched the JIT over to `MonoError` rather than using an exception out-arg.

This is another approach to a341404ecdd3b5ca2ed0ab1e9a5bcb9b5ccd2566 which was backed out because it was stale (2a899492c30740f6785883fae14bb1ddacbc8b77).

CC: @vargaz 