### PR TITLE
[runtime] MonoError-ize mono_loookup_dynamic_token{,_class}

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -257,7 +257,6 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 	mono_install_assembly_postload_search_hook ((MonoAssemblySearchFunc)mono_domain_assembly_postload_search, GUINT_TO_POINTER (FALSE));
 	mono_install_assembly_postload_refonly_search_hook ((MonoAssemblySearchFunc)mono_domain_assembly_postload_search, GUINT_TO_POINTER (TRUE));
 	mono_install_assembly_load_hook (mono_domain_fire_assembly_load, NULL);
-	mono_install_lookup_dynamic_token (mono_reflection_lookup_dynamic_token);
 
 	mono_thread_init (start_cb, attach_cb);
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1009,7 +1009,7 @@ void
 mono_install_delegate_trampoline (MonoDelegateTrampoline func);
 
 gpointer
-mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *context);
+mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *context, MonoError *error);
 
 gpointer
 mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean check_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -918,7 +918,7 @@ extern MonoStats mono_stats;
 typedef gpointer (*MonoRemotingTrampoline)       (MonoDomain *domain, MonoMethod *method, MonoRemotingTarget target);
 typedef gpointer (*MonoDelegateTrampoline)       (MonoDomain *domain, MonoClass *klass);
 
-typedef gpointer (*MonoLookupDynamicToken) (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context);
+typedef gpointer (*MonoLookupDynamicToken) (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
 
 typedef gboolean (*MonoGetCachedClassInfo) (MonoClass *klass, MonoCachedClassInfo *res);
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -918,8 +918,6 @@ extern MonoStats mono_stats;
 typedef gpointer (*MonoRemotingTrampoline)       (MonoDomain *domain, MonoMethod *method, MonoRemotingTarget target);
 typedef gpointer (*MonoDelegateTrampoline)       (MonoDomain *domain, MonoClass *klass);
 
-typedef gpointer (*MonoLookupDynamicToken) (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
-
 typedef gboolean (*MonoGetCachedClassInfo) (MonoClass *klass, MonoCachedClassInfo *res);
 
 typedef gboolean (*MonoGetClassFromName) (MonoImage *image, const char *name_space, const char *name, MonoClass **res);
@@ -1015,9 +1013,6 @@ mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *
 
 gpointer
 mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean check_token, MonoClass **handle_class, MonoGenericContext *context);
-
-void
-mono_install_lookup_dynamic_token (MonoLookupDynamicToken func);
 
 gpointer
 mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1012,7 +1012,7 @@ gpointer
 mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *context);
 
 gpointer
-mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean check_token, MonoClass **handle_class, MonoGenericContext *context);
+mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean check_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
 
 gpointer
 mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -8864,25 +8864,13 @@ mono_ldtoken_checked (MonoImage *image, guint32 token, MonoClass **handle_class,
 	return NULL;
 }
 
-/**
- * This function might need to call runtime functions so it can't be part
- * of the metadata library.
- */
-static MonoLookupDynamicToken lookup_dynamic = NULL;
-
-void
-mono_install_lookup_dynamic_token (MonoLookupDynamicToken func)
-{
-	lookup_dynamic = func;
-}
-
 gpointer
 mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *context)
 {
 	MonoError error;
 	MonoClass *handle_class;
 
-	gpointer result = lookup_dynamic (image, token, TRUE, &handle_class, context, &error);
+	gpointer result = mono_reflection_lookup_dynamic_token (image, token, TRUE, &handle_class, context, &error);
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	return result;
 
@@ -8892,7 +8880,7 @@ gpointer
 mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context)
 {
 	MonoError error;
-	gpointer result = lookup_dynamic (image, token, valid_token, handle_class, context, &error);
+	gpointer result = mono_reflection_lookup_dynamic_token (image, token, valid_token, handle_class, context, &error);
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	return result;
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -8879,15 +8879,23 @@ mono_install_lookup_dynamic_token (MonoLookupDynamicToken func)
 gpointer
 mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *context)
 {
+	MonoError error;
 	MonoClass *handle_class;
 
-	return lookup_dynamic (image, token, TRUE, &handle_class, context);
+	gpointer result = lookup_dynamic (image, token, TRUE, &handle_class, context, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	return result;
+
 }
 
 gpointer
 mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context)
 {
-	return lookup_dynamic (image, token, valid_token, handle_class, context);
+	MonoError error;
+	gpointer result = lookup_dynamic (image, token, valid_token, handle_class, context, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	return result;
+
 }
 
 static MonoGetCachedClassInfo get_cached_class_info = NULL;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -8783,8 +8783,9 @@ mono_ldtoken_checked (MonoImage *image, guint32 token, MonoClass **handle_class,
 
 	if (image_is_dynamic (image)) {
 		MonoClass *tmp_handle_class;
-		gpointer obj = mono_lookup_dynamic_token_class (image, token, TRUE, &tmp_handle_class, context);
+		gpointer obj = mono_lookup_dynamic_token_class (image, token, TRUE, &tmp_handle_class, context, error);
 
+		mono_error_assert_ok (error);
 		g_assert (tmp_handle_class);
 		if (handle_class)
 			*handle_class = tmp_handle_class;
@@ -8877,13 +8878,9 @@ mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *
 }
 
 gpointer
-mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context)
+mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error)
 {
-	MonoError error;
-	gpointer result = mono_reflection_lookup_dynamic_token (image, token, valid_token, handle_class, context, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
-	return result;
-
+	return mono_reflection_lookup_dynamic_token (image, token, valid_token, handle_class, context, error);
 }
 
 static MonoGetCachedClassInfo get_cached_class_info = NULL;

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -563,7 +563,9 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 		MonoClass *handle_class;
 
 		*retklass = NULL;
-		result = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, TRUE, &handle_class, context);
+		MonoError inner_error;
+		result = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, TRUE, &handle_class, context, &inner_error);
+		mono_error_cleanup (&inner_error);
 		// This checks the memberref type as well
 		if (!result || handle_class != mono_defaults.fieldhandle_class) {
 			mono_error_set_bad_image (error, image, "Bad field token 0x%08x", token);
@@ -1873,7 +1875,8 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 	if (image_is_dynamic (image)) {
 		MonoClass *handle_class;
 
-		result = (MonoMethod *)mono_lookup_dynamic_token_class (image, token, TRUE, &handle_class, context);
+		result = (MonoMethod *)mono_lookup_dynamic_token_class (image, token, TRUE, &handle_class, context, error);
+		mono_error_assert_ok (error);
 		mono_loader_assert_no_error ();
 
 		// This checks the memberref type as well

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1837,8 +1837,11 @@ mono_metadata_parse_signature (MonoImage *image, guint32 token)
 	guint32 sig;
 	const char *ptr;
 
-	if (image_is_dynamic (image))
-		return (MonoMethodSignature *)mono_lookup_dynamic_token (image, token, NULL);
+	if (image_is_dynamic (image)) {
+		ret = (MonoMethodSignature *)mono_lookup_dynamic_token (image, token, NULL, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		return ret;
+	}
 
 	g_assert (mono_metadata_token_table(token) == MONO_TABLE_STANDALONESIG);
 		

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1383,7 +1383,7 @@ MonoArray  *mono_reflection_sighelper_get_signature_field (MonoReflectionSigHelp
 MonoReflectionMarshalAsAttribute* mono_reflection_marshal_as_attribute_from_marshal_spec (MonoDomain *domain, MonoClass *klass, MonoMarshalSpec *spec, MonoError *error);
 
 gpointer
-mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context);
+mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
 
 gboolean
 mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, MonoError *error);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6295,9 +6295,11 @@ MonoString*
 mono_ldstr (MonoDomain *domain, MonoImage *image, guint32 idx)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
+	MonoError error;
 
 	if (image->dynamic) {
-		MonoString *str = (MonoString *)mono_lookup_dynamic_token (image, MONO_TOKEN_STRING | idx, NULL);
+		MonoString *str = (MonoString *)mono_lookup_dynamic_token (image, MONO_TOKEN_STRING | idx, NULL, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
 		return str;
 	} else {
 		if (!mono_verifier_verify_string_signature (image, idx, NULL))

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -13695,25 +13695,27 @@ mono_reflection_lookup_signature (MonoImage *image, MonoMethod *method, guint32 
  * LOCKING: Take the loader lock
  */
 gpointer
-mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context)
+mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error)
 {
-	MonoError error;
 	MonoDynamicImage *assembly = (MonoDynamicImage*)image;
 	MonoObject *obj;
 	MonoClass *klass;
 
+	mono_error_init (error);
+	
 	obj = lookup_dyn_token (assembly, token);
 	if (!obj) {
 		if (valid_token)
 			g_error ("Could not find required dynamic token 0x%08x", token);
-		else
+		else {
+			mono_error_set_execution_engine (error, "Could not find dynamic token 0x%08x", token);
 			return NULL;
+		}
 	}
 
 	if (!handle_class)
 		handle_class = &klass;
-	gpointer result = resolve_object (image, obj, handle_class, context, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	gpointer result = resolve_object (image, obj, handle_class, context, error);
 	return result;
 }
 


### PR DESCRIPTION
Push `MonoError` through `mono_lookup_dynamic_token_class` and `mono_lookup_dynamic_token`

Also simplify the implementations of those functions so that they call `mono_reflection_lookup_dynamic_token` directly, rather than via a function pointer.  The old implementation was a holdover from when the runtime was implemented as separate libraries.