### PR TITLE
Infinite loop on SSL handshake

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Protocol.Tls/RecordProtocol.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Protocol.Tls/RecordProtocol.cs
@@ -343,8 +343,7 @@ namespace Mono.Security.Protocol.Tls
 				//We're at the end of the stream. Time to bail.
 				if (bytesRead == 0)
 				{
-					internalResult.SetComplete((byte[])null);
-					return;
+					throw new TlsException(AlertDescription.CloseNotify, "Received 0 bytes from stream. It must be closed.");
 				}
 
 				// Try to read the Record Content Type
@@ -451,7 +450,7 @@ namespace Mono.Security.Protocol.Tls
 			//We're at the end of the stream. Time to bail.
 			if (bytesRead == 0)
 			{
-				return null;
+				throw new TlsException(AlertDescription.CloseNotify, "Received 0 bytes from stream. It must be closed.");
 			}
 
 			// Try to read the Record Content Type


### PR DESCRIPTION
While doing the SSL handshake if the server closes the connection then mono goes into an infinite loop.

The problem is in `RecordProtocol.cs`, when `EndRead` and `Read` from the Socket return 0, the resultingBuffer is set to a null value which is indistinguishable from the case when the record is incomplete. Therefore `SslClientStream:SafeEndReceiveRecord` simply assumes  that the record is incomplete and keeps trying to read the server hello over and over.

The solution is to throw an exception as in the `ReadRecodBuffer` (line 550) method when `Read` returns 0.

More information (and a test case to reproduce the problem) can be found in the bug report https://bugzilla.xamarin.com/show_bug.cgi?id=39626
