### PR TITLE
[SRE] MonoError-ize some icalls

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1446,7 +1446,7 @@ gpointer
 mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context);
 
 gboolean
-mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass);
+mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, MonoError *error);
 
 gboolean
 mono_reflection_is_valid_dynamic_token (MonoDynamicImage *image, guint32 token);


### PR DESCRIPTION
* Cleanup some memory that would leak on failure; improve a few error messages
* Add MonoError to `mono_reflection_call_is_assignable_to` and `fieldbuilder_to_mono_class_field`.
* Update several SRE icalls to follow the pattern:
  ```c
    void
    the_icall (args... )
    {
       MonoError error;
       (void) the_real_work_function (args..., &error);
       mono_error_set_pending_exception (&error);
    }
    
    static gboolean
    the_real_work_function (args..., MonoError *error)
    {
       ... /* return TRUE on success, FALSE and set error on failure */ ...
    }
  ```
  Do this to:
        1. `mono_reflection_register_with_runtime`
        2. `mono_reflection_setup_internal_class`
        3. `mono_reflection_create_internal_class`
        4. `mono_reflection_generic_class_initialize`
        5. `mono_reflection_event_builder_get_event_info`
        6. `mono_reflection_initialize_generic_parameter`
        7. `mono_reflection_create_dynamic_method`