### PR TITLE
[runtime] Implement performant unbounded-depth sequence point search

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -714,7 +714,13 @@ struct MonoBasicBlock {
 	guint real_offset;
 
 	GSList *seq_points;
+
+	// The MonoInst of the last sequence point for the current basic block.
 	MonoInst *last_seq_point;
+	
+	// This will hold a list of last sequence points of incoming basic blocks
+	MonoInst **pred_seq_points;
+	guint num_pred_seq_points;
 
 	GSList *spill_slot_defs;
 

--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -11,31 +11,89 @@
 #include "seq-points.h"
 
 static void
-collect_pred_seq_points (MonoBasicBlock *bb, MonoInst *ins, GSList **next, int depth)
+insert_pred_seq_point (MonoInst *last_seq_ins, MonoInst *ins, GSList **next)
 {
-	int i;
 	MonoBasicBlock *in_bb;
 	GSList *l;
+	int src_index = last_seq_ins->backend.size;
+	int dst_index = ins->backend.size;
 
-	for (i = 0; i < bb->in_count; ++i) {
-		in_bb = bb->in_bb [i];
+	/* bb->in_bb might contain duplicates */
+	for (l = next [src_index]; l; l = l->next)
+		if (GPOINTER_TO_UINT (l->data) == dst_index)
+			break;
+	if (!l)
+		next [src_index] = g_slist_append (next [src_index], GUINT_TO_POINTER (dst_index));
+}
 
-		if (in_bb->last_seq_point) {
-			int src_index = in_bb->last_seq_point->backend.size;
-			int dst_index = ins->backend.size;
+static void
+recursively_make_pred_seq_points (MonoCompile *cfg, MonoBasicBlock *bb)
+{
+	const gpointer MONO_SEQ_SEEN_LOOP = GINT_TO_POINTER(-1);
 
-			/* bb->in_bb might contain duplicates */
-			for (l = next [src_index]; l; l = l->next)
-				if (GPOINTER_TO_UINT (l->data) == dst_index)
-					break;
-			if (!l)
-				next [src_index] = g_slist_append (next [src_index], GUINT_TO_POINTER (dst_index));
-		} else {
-			/* Have to look at its predecessors */
-			if (depth < 5)
-				collect_pred_seq_points (in_bb, ins, next, depth + 1);
+	GArray *predecessors = g_array_new (FALSE, TRUE, sizeof (gpointer));
+	GHashTable *seen = g_hash_table_new_full (g_direct_hash, NULL, NULL, NULL);
+
+	// Insert/remove sentinel into the memoize table to detect loops containing bb
+	bb->pred_seq_points = MONO_SEQ_SEEN_LOOP;
+
+	for (int i = 0; i < bb->in_count; ++i) {
+		MonoBasicBlock *in_bb = bb->in_bb [i];
+		
+		// This bb has the last seq point, append it and continue
+		if (in_bb->last_seq_point != NULL) {
+			predecessors = g_array_append_val (predecessors, in_bb->last_seq_point);
+			continue;
 		}
+
+		// We've looped or handled this before, exit early.
+		// No last sequence points to find.
+		if (in_bb->pred_seq_points == MONO_SEQ_SEEN_LOOP)
+			continue;
+
+		// Take sequence points from incoming basic blocks
+	
+		if (in_bb == cfg->bb_entry)
+			continue;
+
+		if (in_bb->pred_seq_points == NULL)
+			recursively_make_pred_seq_points (cfg, in_bb);
+
+		// Union sequence points with incoming bb's
+		for (int i=0; i < in_bb->num_pred_seq_points; i++) {
+			if (!g_hash_table_lookup (seen, in_bb->pred_seq_points [i])) {
+				g_array_append_val (predecessors, in_bb->pred_seq_points [i]);
+				g_hash_table_insert (seen, in_bb->pred_seq_points [i], &MONO_SEQ_SEEN_LOOP);
+			}
+		}
+		// predecessors = g_array_append_vals (predecessors, in_bb->pred_seq_points, in_bb->num_pred_seq_points);
 	}
+
+	g_hash_table_destroy (seen);
+
+	if (predecessors->len != 0) {
+		bb->pred_seq_points = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, sizeof (MonoInst *) * predecessors->len);
+		bb->num_pred_seq_points = predecessors->len;
+
+		for (int newer = 0; newer < bb->num_pred_seq_points; newer++) {
+			bb->pred_seq_points [newer] = g_array_index(predecessors, gpointer, newer);
+		}
+	} 
+
+	g_free (predecessors);
+}
+
+static void
+collect_pred_seq_points (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, GSList **next)
+{
+	// Doesn't have a last sequence point, must find from incoming basic blocks
+	if (bb->pred_seq_points == NULL && bb != cfg->bb_entry)
+		recursively_make_pred_seq_points (cfg, bb);
+
+	for (int i = 0; i < bb->num_pred_seq_points; i++)
+		insert_pred_seq_point (bb->pred_seq_points [i], ins, next);
+
+	return;
 }
 
 void
@@ -92,7 +150,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 					next [last->backend.size] = g_slist_append (next [last->backend.size], GUINT_TO_POINTER (ins->backend.size));
 				} else {
 					/* Link with the last bb in the previous bblocks */
-					collect_pred_seq_points (bb, ins, next, 0);
+					collect_pred_seq_points (cfg, bb, ins, next);
 				}
 
 				last = ins;


### PR DESCRIPTION
With this change we search for sequence points to unbounded depth and memoize in basic blocks.

The previous fix had the issue of not deduplicating basic blocks in the queue. We had this issue in the previous implementation, but hid it by limiting the depth. This depth limiting would break functionality when we have a long chain of basic blocks between sequence points. This runs pretty quickly on my machine with the reproduction that showed my previous implementation to be non-linear. I see a "0" for the time in the repro of

````
using System;

class Base {
}

class Sub1 : Base {
}

public class Tests {
	private static bool CheckStatement(Base b) {
		if (b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
b is Sub1 ||
			b is Sub1 ||
			b is Sub1 ||
			b is Sub1)
                return true;
            return false;
        }

	public static void Main (String[] args) {
		var w = System.Diagnostics.Stopwatch.StartNew ();
		CheckStatement (new Base ());
		w.Stop ();
		Console.WriteLine (w.ElapsedMilliseconds);
	}
}
```
with up to 95 lines inside the conditional.