### PR TITLE
[runtime] Fix leaking of inflated method headers

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -517,7 +517,6 @@ struct _MonoMethodInflated {
 		MonoMethod method;
 		MonoMethodPInvoke pinvoke;
 	} method;
-	MonoMethodHeader *header;
 	MonoMethod *declaring;		/* the generic method definition. */
 	MonoGenericContext context;	/* The current instantiation */
 	MonoImageSet *owner; /* The image set that the inflated method belongs to. */

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -885,6 +885,8 @@ inflate_generic_header (MonoMethodHeader *header, MonoGenericContext *context, M
 	res->num_locals = header->num_locals;
 	res->clauses = header->clauses;
 
+	res->is_transient = TRUE;
+
 	mono_error_init (error);
 
 	for (i = 0; i < header->num_locals; ++i) {
@@ -2827,20 +2829,7 @@ mono_method_get_header_checked (MonoMethod *method, MonoError *error)
 			return NULL;
 		}
 
-		mono_image_lock (img);
-
-		if (imethod->header) {
-			mono_metadata_free_mh (iheader);
-			mono_image_unlock (img);
-			return imethod->header;
-		}
-
-		mono_memory_barrier ();
-		imethod->header = iheader;
-
-		mono_image_unlock (img);
-
-		return imethod->header;
+		return iheader;
 	}
 
 	if (method->wrapper_type != MONO_WRAPPER_NONE || method->sre_method) {

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2772,18 +2772,6 @@ free_inflated_method (MonoMethodInflated *imethod)
 	if (method->signature)
 		mono_metadata_free_inflated_signature (method->signature);
 
-	if (!((method->flags & METHOD_ATTRIBUTE_ABSTRACT) || (method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME) || (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) || (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))) {
-		MonoMethodHeader *header = imethod->header;
-
-		if (header) {
-			/* Allocated in inflate_generic_header () */
-			for (i = 0; i < header->num_locals; ++i)
-				mono_metadata_free_type (header->locals [i]);
-			g_free (header->clauses);
-			g_free (header);
-		}
-	}
-
 	g_free (method);
 }
 

--- a/mono/metadata/mono-basic-block.c
+++ b/mono/metadata/mono-basic-block.c
@@ -514,20 +514,11 @@ mono_basic_block_free (MonoSimpleBasicBlock *bb)
  * Return the list of basic blocks of method. Return NULL on failure and set @error.
 */
 MonoSimpleBasicBlock*
-mono_basic_block_split (MonoMethod *method, MonoError *error)
+mono_basic_block_split (MonoMethod *method, MonoError *error, MonoMethodHeader *header)
 {
 	MonoError inner_error;
 	MonoSimpleBasicBlock *bb, *root;
 	const unsigned char *start, *end;
-	MonoMethodHeader *header = mono_method_get_header_checked (method, &inner_error);
-
-	mono_error_init (error);
-
-	if (!header) {
-		mono_error_set_not_verifiable (error, method, "Could not decode header due to %s", mono_error_get_message (&inner_error));
-		mono_error_cleanup (&inner_error);
-		return NULL;
-	}
 
 	start = header->code;
 	end = start + header->code_size;
@@ -553,11 +544,9 @@ mono_basic_block_split (MonoMethod *method, MonoError *error)
 	dump_bb_list (bb, &root, g_strdup_printf("AFTER LIVENESS %s", mono_method_full_name (method, TRUE)));
 #endif
 
-	mono_metadata_free_mh (header);
 	return bb;
 
 fail:
-	mono_metadata_free_mh (header);
 	mono_basic_block_free (bb);
 	return NULL;
 }

--- a/mono/metadata/mono-basic-block.h
+++ b/mono/metadata/mono-basic-block.h
@@ -19,7 +19,7 @@ struct _MonoSimpleBasicBlock {
 };
 
 MonoSimpleBasicBlock*
-mono_basic_block_split (MonoMethod *method, MonoError *error);
+mono_basic_block_split (MonoMethod *method, MonoError *error, MonoMethodHeader *header);
 
 void
 mono_basic_block_free (MonoSimpleBasicBlock *bb);

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -5016,7 +5016,7 @@ mono_method_verify (MonoMethod *method, int level)
 	if (!ctx.valid)
 		goto cleanup;
 
-	original_bb = bb = mono_basic_block_split (method, &error);
+	original_bb = bb = mono_basic_block_split (method, &error, ctx.header);
 	if (!mono_error_ok (&error)) {
 		ADD_VERIFY_ERROR (&ctx, g_strdup_printf ("Invalid branch target: %s", mono_error_get_message (&error)));
 		mono_error_cleanup (&error);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8578,7 +8578,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 	skip_dead_blocks = !dont_verify;
 	if (skip_dead_blocks) {
-		original_bb = bb = mono_basic_block_split (method, &cfg->error);
+		original_bb = bb = mono_basic_block_split (method, &cfg->error, header);
 		CHECK_CFG_ERROR;
 		g_assert (bb);
 	}


### PR DESCRIPTION
We were never marking inflated headers as transient, so they were always leaked. In changing this, I noticed that we were freeing some headers in two places, but this duplication was hidden by the fact that we weren't actually freeing them in the first because we never marked them as transient.

This PR also removes a needless double-inflation of headers by simply passing the header to mono_basic_block_split. 