### PR TITLE
Fix regressions in Microsoft.Build.dll

### DIFF
--- a/mcs/class/Microsoft.Build/Microsoft.Build.Execution/BuildManager.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Execution/BuildManager.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Build.Execution
 		
 		public void Dispose ()
 		{
-			WaitHandle.WaitAll (submissions.Select (s => s.WaitHandle).ToArray ());
+			if (submissions.Count > 0)
+				WaitHandle.WaitAll (submissions.Select (s => s.WaitHandle).ToArray ());
 			BuildNodeManager.Stop ();
 		}
 

--- a/mcs/class/Microsoft.Build/Microsoft.Build.Execution/ProjectInstance.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Execution/ProjectInstance.cs
@@ -427,6 +427,7 @@ namespace Microsoft.Build.Execution
 			};
 			var requestData = new BuildRequestData (this, targets ?? DefaultTargets.ToArray ());
 			var result = manager.Build (parameters, requestData);
+			manager.Dispose ();
 			targetOutputs = result.ResultsByTarget;
 			return result.OverallResult == BuildResultCode.Success;
 		}

--- a/mcs/class/Microsoft.Build/Microsoft.Build.Internal/BuildNodeManager.cs
+++ b/mcs/class/Microsoft.Build/Microsoft.Build.Internal/BuildNodeManager.cs
@@ -41,7 +41,10 @@ namespace Microsoft.Build.Internal
 		public BuildNodeManager (BuildManager buildManager)
 		{
 			BuildManager = buildManager;
-			new Thread (RunLoop).Start ();
+			new Thread (RunLoop) {
+				IsBackground = true,
+				Name = "xbuild request handler"
+			}.Start ();
 		}
 
 		~BuildNodeManager ()


### PR DESCRIPTION
Fix a bunch of regressions in Microsoft.Build.dll I found when I was using it for unit testing MSBuild targets.

It's not used by xbuild, so this should be low risk.