### PR TITLE
[threadpool-ms] MonoError-ize

### DIFF
--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -254,7 +254,11 @@ do_console_cancel_event (void)
 	method = mono_class_get_method_from_name (klass, "BeginInvoke", -1);
 	g_assert (method != NULL);
 
-	mono_threadpool_ms_begin_invoke (domain, (MonoObject*) load_value, method, NULL);
+	mono_threadpool_ms_begin_invoke (domain, (MonoObject*) load_value, method, NULL, &error);
+	if (!is_ok (&error)) {
+		g_warning ("Couldn't invoke System.Console cancel handler due to %s", mono_error_get_message (&error));
+		mono_error_cleanup (&error);
+	}
 }
 
 static int need_cancel = FALSE;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -2205,7 +2205,9 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 		method = mono_get_delegate_invoke (klass);
 	g_assert (method);
 
-	return mono_threadpool_ms_begin_invoke (mono_domain_get (), (MonoObject*) delegate, method, params);
+	MonoAsyncResult *result = mono_threadpool_ms_begin_invoke (mono_domain_get (), (MonoObject*) delegate, method, params, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 #ifndef DISABLE_JIT

--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -1583,7 +1583,9 @@ void
 ves_icall_System_Threading_ThreadPool_ReportThreadStatus (MonoBoolean is_working)
 {
 	// TODO
-	mono_raise_exception (mono_get_exception_not_implemented (NULL));
+	MonoError error;
+	mono_error_set_not_implemented (&error, "");
+	mono_error_set_pending_exception (&error);
 }
 
 MonoBoolean
@@ -1596,7 +1598,9 @@ MonoBoolean G_GNUC_UNUSED
 ves_icall_System_Threading_ThreadPool_PostQueuedCompletionStatus (MonoNativeOverlapped *native_overlapped)
 {
 	/* This copy the behavior of the current Mono implementation */
-	mono_raise_exception (mono_get_exception_not_implemented (NULL));
+	MonoError error;
+	mono_error_set_not_implemented (&error, "");
+	mono_error_set_pending_exception (&error);
 	return FALSE;
 }
 

--- a/mono/metadata/threadpool-ms.h
+++ b/mono/metadata/threadpool-ms.h
@@ -59,7 +59,7 @@ ves_icall_System_Threading_ThreadPool_IsThreadPoolHosted (void);
 
 /* Internals */
 
-void
-mono_threadpool_ms_enqueue_work_item (MonoDomain *domain, MonoObject *work_item);
+gboolean
+mono_threadpool_ms_enqueue_work_item (MonoDomain *domain, MonoObject *work_item, MonoError *error);
 
 #endif // _MONO_THREADPOOL_MICROSOFT_H_

--- a/mono/metadata/threadpool-ms.h
+++ b/mono/metadata/threadpool-ms.h
@@ -15,7 +15,7 @@ void
 mono_threadpool_ms_cleanup (void);
 
 MonoAsyncResult *
-mono_threadpool_ms_begin_invoke (MonoDomain *domain, MonoObject *target, MonoMethod *method, gpointer *params);
+mono_threadpool_ms_begin_invoke (MonoDomain *domain, MonoObject *target, MonoMethod *method, gpointer *params, MonoError *error);
 MonoObject *
 mono_threadpool_ms_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, MonoObject **exc);
 


### PR DESCRIPTION
1. Convert icalls that throw `NotImplementedException` to do it via mono_error_set_pending_exception
2. Add MonoError outargs to `mono_threadpool_ms_enqueue_work_item` and `mono_threadpool_ms_begin_invoke`