### PR TITLE
[MonoError] Helpers for some common corlib exceptions

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1766,7 +1766,7 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 	if (!mono_error_ok (&error)) {
 		mono_error_cleanup (&error);
 		g_free (dir_name);
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Failed to create shadow copy (invalid characters in shadow directory name).");
+		mono_error_set_execution_engine (oerror, "Failed to create shadow copy (invalid characters in shadow directory name).");
 		return NULL;
 	}
 
@@ -1781,13 +1781,13 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 	shadow = get_shadow_assembly_location (filename, &error);
 	if (!mono_error_ok (&error)) {
 		mono_error_cleanup (&error);
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Failed to create shadow copy (invalid characters in file name).");
+		mono_error_set_execution_engine (oerror, "Failed to create shadow copy (invalid characters in file name).");
 		return NULL;
 	}
 
 	if (ensure_directory_exists (shadow) == FALSE) {
 		g_free (shadow);
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Failed to create shadow copy (ensure directory exists).");
+		mono_error_set_execution_engine (oerror, "Failed to create shadow copy (ensure directory exists).");
 		return NULL;
 	}	
 
@@ -1824,7 +1824,7 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 		if (GetLastError() == ERROR_FILE_NOT_FOUND || GetLastError() == ERROR_PATH_NOT_FOUND)
 			return NULL; /* file not found, shadow copy failed */
 
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Failed to create shadow copy (CopyFile).");
+		mono_error_set_execution_engine (oerror, "Failed to create shadow copy (CopyFile).");
 		return NULL;
 	}
 
@@ -1843,14 +1843,14 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 	
 	if (copy_result == FALSE)  {
 		g_free (shadow);
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Failed to create shadow copy of sibling data (CopyFile).");
+		mono_error_set_execution_engine (oerror, "Failed to create shadow copy of sibling data (CopyFile).");
 		return NULL;
 	}
 
 	/* Create a .ini file containing the original assembly location */
 	if (!shadow_copy_create_ini (shadow, filename)) {
 		g_free (shadow);
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Failed to create shadow copy .ini file.");
+		mono_error_set_execution_engine (oerror, "Failed to create shadow copy .ini file.");
 		return NULL;
 	}
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4881,7 +4881,7 @@ mono_object_new_specific_checked (MonoVTable *vtable, MonoError *error)
 
 			im = mono_class_get_method_from_name (klass, "CreateProxyForType", 1);
 			if (!im) {
-				mono_error_set_generic_error (error, "System", "NotSupportedException", "Linked away.");
+				mono_error_set_not_supported (error, "Linked away.");
 				return NULL;
 			}
 			vtable->domain->create_proxy_for_type_method = im;
@@ -6918,7 +6918,7 @@ mono_remoting_invoke (MonoObject *real_proxy, MonoMethodMessage *msg, MonoObject
 	if (!im) {
 		im = mono_class_get_method_from_name (mono_defaults.real_proxy_class, "PrivateInvoke", 4);
 		if (!im) {
-			mono_error_set_generic_error (error, "System", "NotSupportedException", "Linked away.");
+			mono_error_set_not_supported (error, "Linked away.");
 			return NULL;
 		}
 		real_proxy->vtable->domain->private_invoke_method = im;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -5533,7 +5533,7 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObject *obj,
 	/* Check for user defined reflection objects */
 	/* TypeDelegator is the only corlib type which doesn't look like a MonoReflectionType */
 	if (klass->image != mono_defaults.corlib || (strcmp (klass->name, "TypeDelegator") == 0)) {
-		mono_error_set_generic_error (error, "System", "NotSupportedException", "User defined subclasses of System.Type are not yet supported");
+		mono_error_set_not_supported (error, "User defined subclasses of System.Type are not yet supported");
 		return 0;
 	}
 
@@ -10371,7 +10371,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObject *obj, MonoError *error
 #endif
 		else {
 			char *type_name = mono_type_get_full_name (member_class);
-			mono_error_set_generic_error (error, "System", "NotSupportedException",
+			mono_error_set_not_supported (error,
 						      "Custom attributes on a ParamInfo with member %s are not supported",
 						      type_name);
 			g_free (type_name);
@@ -10944,7 +10944,7 @@ mono_reflection_type_resolve_user_types (MonoReflectionType *type, MonoError *er
 		type = mono_reflection_type_get_underlying_system_type (type, error);
 		return_val_if_nok (error, NULL);
 		if (is_usertype (type)) {
-			mono_error_set_generic_error (error, "System", "NotSupportedException", "User defined subclasses of System.Type are not yet supported22");
+			mono_error_set_not_supported (error, "User defined subclasses of System.Type are not yet supported22");
 			return NULL;
 		}
 	}

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -8923,8 +8923,8 @@ mono_reflection_get_token_checked (MonoObject *obj, MonoError *error)
 	} else if (strcmp (klass->name, "Assembly") == 0 || strcmp (klass->name, "MonoAssembly") == 0) {
 		token = mono_metadata_make_token (MONO_TABLE_ASSEMBLY, 1);
 	} else {
-		mono_error_set_generic_error (error, "System", "NotImplementedException",
-					      "MetadataToken is not supported for type '%s.%s'", klass->name_space, klass->name);
+		mono_error_set_not_implemented (error, "MetadataToken is not supported for type '%s.%s'",
+						klass->name_space, klass->name);
 		return 0;
 	}
 

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -94,6 +94,15 @@ void
 mono_error_set_generic_error (MonoError *error, const char * name_space, const char *name, const char *msg_format, ...);
 
 void
+mono_error_set_execution_engine (MonoError *error, const char *msg_format, ...);
+
+void
+mono_error_set_not_implemented (MonoError *error, const char *msg_format, ...);
+
+void
+mono_error_set_not_supported (MonoError *error, const char *msg_format, ...);
+
+void
 mono_error_set_exception_instance (MonoError *error, MonoException *exc);
 
 void

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -420,13 +420,13 @@ mono_error_set_from_loader_error (MonoError *oerror)
 	mono_error_prepare (error);
 
 	if (!loader_error) {
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Runtime tried to produce a mono-error from an empty loader-error");
+		mono_error_set_execution_engine (oerror, "Runtime tried to produce a mono-error from an empty loader-error");
 		return;
 	}
 
 	switch (loader_error->exception_type) {
 	case MONO_EXCEPTION_NONE:
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Runtime tried to produce a mono-error from a non-error loader-error");
+		mono_error_set_execution_engine (oerror, "Runtime tried to produce a mono-error from a non-error loader-error");
 		break;
 
 	case MONO_EXCEPTION_INVALID_PROGRAM:
@@ -467,7 +467,7 @@ mono_error_set_from_loader_error (MonoError *oerror)
 
 	case MONO_EXCEPTION_OBJECT_SUPPLIED:
 	case MONO_EXCEPTION_GENERIC_SHARING_FAILED:
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Runtime tried to produce a mono-error from JIT internal error %d", loader_error->exception_type);
+		mono_error_set_execution_engine (oerror, "Runtime tried to produce a mono-error from JIT internal error %d", loader_error->exception_type);
 		break;
 
 	case MONO_EXCEPTION_BAD_IMAGE:
@@ -479,7 +479,7 @@ mono_error_set_from_loader_error (MonoError *oerror)
 		break;
 
 	default:
-		mono_error_set_generic_error (oerror, "System", "ExecutionEngineException", "Runtime tried to produce an unknown loader-error %d", loader_error->exception_type);
+		mono_error_set_execution_engine (oerror, "Runtime tried to produce an unknown loader-error %d", loader_error->exception_type);
 		break;
 	}
 
@@ -741,7 +741,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 	}
 	case MONO_ERROR_GENERIC:
 		if (!error->exception_name_space || !error->exception_name)
-			mono_error_set_generic_error (error_out, "System", "ExecutionEngineException", "MonoError with generic error but no exception name was supplied");
+			mono_error_set_execution_engine (error_out, "MonoError with generic error but no exception name was supplied");
 		else
 			exception = mono_exception_from_name_msg (mono_defaults.corlib, error->exception_name_space, error->exception_name, error->full_message);
 		break;
@@ -751,7 +751,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 		break;
 
 	default:
-		mono_error_set_generic_error (error_out, "System", "ExecutionEngineException", "Invalid error-code %d", error->error_code);
+		mono_error_set_execution_engine (error_out, "Invalid error-code %d", error->error_code);
 	}
 
 	if (!mono_error_ok (error_out))

--- a/mono/utils/mono-rand.c
+++ b/mono/utils/mono-rand.c
@@ -123,7 +123,7 @@ mono_rand_try_get_bytes (gpointer *handle, guchar *buffer, gint buffer_size, Mon
 			/* exception will be thrown in managed code */
 			CryptReleaseContext (provider, 0);
 			*handle = 0;
-			mono_error_set_generic_error (error, "System", "ExecutionEngineException", "Failed to gen random bytes (%d)", GetLastError ());
+			mono_error_set_execution_engine (error, "Failed to gen random bytes (%d)", GetLastError ());
 			return FALSE;
 		}
 	}
@@ -186,7 +186,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, int buffer_size, MonoErr
 		if (file >= 0)
 			close (file);
 		g_warning ("Entropy problem! Can't create or connect to egd socket %s", path);
-		mono_error_set_generic_error (error, "System", "ExecutionEngineException", "Failed to open egd socket %s: %s", path, strerror (err));
+		mono_error_set_execution_engine (error, "Failed to open egd socket %s: %s", path, strerror (err));
 		return;
 	}
 
@@ -207,7 +207,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, int buffer_size, MonoErr
 			} else {
 				close (file);
 				g_warning ("Send egd request failed %d", err);
-				mono_error_set_generic_error (error, "System", "ExecutionEngineException", "Failed to send request to egd socket: %s", strerror (err));
+				mono_error_set_execution_engine (error, "Failed to send request to egd socket: %s", strerror (err));
 				return;
 			}
 		}
@@ -225,7 +225,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, int buffer_size, MonoErr
 			} else {
 				close (file);
 				g_warning ("Receive egd request failed %d", err);
-				mono_error_set_generic_error (error, "System", "ExecutionEngineException", "Failed to get response from egd socket: %s", strerror(err));
+				mono_error_set_execution_engine (error, "Failed to get response from egd socket: %s", strerror(err));
 				return;
 			}
 		}
@@ -295,7 +295,7 @@ mono_rand_try_get_bytes (gpointer *handle, guchar *buffer, gint buffer_size, Mon
 					continue;
 				g_warning("Entropy error! Error in read (%s).", strerror (errno));
 				/* exception will be thrown in managed code */
-				mono_error_set_generic_error (error, "System", "ExecutionEngineException", "Entropy error! Error in read (%s).", strerror (errno));
+				mono_error_set_execution_engine (error, "Entropy error! Error in read (%s).", strerror (errno));
 				return FALSE;
 			}
 			count += err;


### PR DESCRIPTION
Add helpers for constructing `System.NotSupportedException`, `System.NotImplementedException` and `System.ExecutionEngineException`.

Also varargs version of `mono_error_set_generic_error`