### PR TITLE
[marshal] Don't raise an exception, just assert

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1843,11 +1843,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 	}
 		
 	default: {
-		char *msg = g_strdup_printf ("marshalling conversion %d not implemented", conv);
-		MonoException *exc = mono_get_exception_not_implemented (msg);
-		g_warning ("%s", msg);
-		g_free (msg);
-		mono_raise_exception (exc);
+		g_error ("marshalling conversion %d not implemented", conv);
 	}
 	}
 }


### PR DESCRIPTION
Don't raise deep in the marshalling code, just assert.

(Raising means we'd have to convert the code to use MonoError and then
thread it out through all of the marshalling code resulting in a lot of
code churn)