### PR TITLE
[sgen] Fix concurrent card clean

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1698,7 +1698,7 @@ major_copy_or_mark_from_roots (size_t *old_next_pin_slot, CopyOrMarkFromRootsMod
 
 	sgen_client_pre_collection_checks ();
 
-	if (!concurrent) {
+	if (mode != COPY_OR_MARK_FROM_ROOTS_START_CONCURRENT) {
 		/* Remsets are not useful for a major collection */
 		remset.clear_cards ();
 	}


### PR DESCRIPTION
It is not used during a major collection. The collector will add the necessary global remsets afterwards, for the nursery collections.