### PR TITLE
AL: Use IKVM.Reflection to get custom attributes from the template assembly,

### DIFF
--- a/mcs/tools/al/Makefile
+++ b/mcs/tools/al/Makefile
@@ -3,7 +3,7 @@ SUBDIRS =
 include ../../build/rules.make
 
 LOCAL_MCS_FLAGS =
-LIB_REFS = Mono.Security
+LIB_REFS = System System.Core Mono.Security System.Security Mono.CompilerServices.SymbolWriter
 PROGRAM = al.exe
 
 CLEAN_FILES = al.exe al.exe.mdb

--- a/mcs/tools/al/al.exe.sources
+++ b/mcs/tools/al/al.exe.sources
@@ -1,2 +1,9 @@
 Al.cs
 ../../build/common/Consts.cs
+../../../external/ikvm/reflect/*.cs
+../../../external/ikvm/reflect/Emit/*.cs
+../../../external/ikvm/reflect/Metadata/*.cs
+../../../external/ikvm/reflect/Reader/*.cs
+../../../external/ikvm/reflect/Writer/*.cs
+../../../external/ikvm/reflect/Impl/*.cs
+../../../external/ikvm/reflect/Properties/*.cs


### PR DESCRIPTION
.. instead of System.Reflection. This allows AL to work even if the
dependent assemblies of the template are not available.