### PR TITLE
[runtime] MonoError-ize marshal and remoting code

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -2979,7 +2979,8 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 		mono_set_pending_exception ((MonoException*)exc);
 	}
 
-	mono_method_return_message_restore (method, params, out_args);
+	mono_method_return_message_restore (method, params, out_args, &error);
+	mono_error_set_pending_exception (&error);
 	return res;
 }
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -620,7 +620,7 @@ mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *
 			      MonoDelegate **cb, MonoObject **state);
 
 void
-mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoArray *out_args);
+mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoArray *out_args, MonoError *error);
 
 void
 mono_delegate_ctor_with_method (MonoObject *this_obj, MonoObject *target, gpointer addr, MonoMethod *method);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1457,6 +1457,13 @@ mono_load_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, Mono
 gboolean
 mono_store_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void* val, MonoError *error);
 
+void
+mono_store_remote_field_new_icall (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg);
+
+gboolean
+mono_store_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg, MonoError *error);
+
+
 #endif
 
 gpointer

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1444,6 +1444,10 @@ mono_remote_class_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mon
 
 void
 mono_upgrade_remote_class (MonoDomain *domain, MonoObject *tproxy, MonoClass *klass);
+
+void*
+mono_load_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void **res, MonoError *error);
+
 #endif
 
 gpointer

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1448,6 +1448,12 @@ mono_upgrade_remote_class (MonoDomain *domain, MonoObject *tproxy, MonoClass *kl
 void*
 mono_load_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void **res, MonoError *error);
 
+MonoObject *
+mono_load_remote_field_new_icall (MonoObject *this_obj, MonoClass *klass, MonoClassField *field);
+
+MonoObject *
+mono_load_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoError *error);
+
 #endif
 
 gpointer

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1454,6 +1454,9 @@ mono_load_remote_field_new_icall (MonoObject *this_obj, MonoClass *klass, MonoCl
 MonoObject *
 mono_load_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoError *error);
 
+gboolean
+mono_store_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void* val, MonoError *error);
+
 #endif
 
 gpointer

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7328,9 +7328,11 @@ mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *
  * Restore results from message based processing back to arguments pointers
  */
 void
-mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoArray *out_args)
+mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoArray *out_args, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
+
+	mono_error_init (error);
 
 	MonoMethodSignature *sig = mono_method_signature (method);
 	int i, j, type, size, out_len;
@@ -7346,8 +7348,10 @@ mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoAr
 
 		if (pt->byref) {
 			char *arg;
-			if (j >= out_len)
-				mono_raise_exception (mono_get_exception_execution_engine ("The proxy call returned an incorrect number of output arguments"));
+			if (j >= out_len) {
+				mono_error_set_execution_engine (error, "The proxy call returned an incorrect number of output arguments");
+				return;
+			}
 
 			arg = (char *)mono_array_get (out_args, gpointer, j);
 			type = pt->type;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7622,11 +7622,33 @@ mono_load_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, Mono
 void
 mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, gpointer val)
 {
+	MonoError error;
+	(void) mono_store_remote_field_checked (this_obj, klass, field, val, &error);
+	mono_error_cleanup (&error);
+}
+
+/**
+ * mono_store_remote_field_checked:
+ * @this_obj: pointer to an object
+ * @klass: klass of the object containing @field
+ * @field: the field to load
+ * @val: the value/object to store
+ * @error: set on error
+ *
+ * This method is called by the runtime on attempts to store fields of
+ * transparent proxy objects. @this_obj points to such TP, @klass is the class of
+ * the object containing @field. @val is the new value to store in @field.
+ *
+ * Returns: on success returns TRUE, on failure returns FALSE and sets @error.
+ */
+gboolean
+mono_store_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, gpointer val, MonoError *error)
+{
+	
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
-
 	static MonoMethod *setter = NULL;
+
 	MonoDomain *domain = mono_domain_get ();
 	MonoTransparentProxy *tp = (MonoTransparentProxy *) this_obj;
 	MonoClass *field_class;
@@ -7636,6 +7658,8 @@ mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField 
 	MonoObject *arg;
 	char* full_name;
 
+	mono_error_init (error);
+
 	g_assert (mono_object_is_transparent_proxy (this_obj));
 
 	field_class = mono_class_from_mono_type (field->type);
@@ -7643,26 +7667,28 @@ mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField 
 	if (mono_class_is_contextbound (tp->remote_class->proxy_class) && tp->rp->context == (MonoObject *) mono_context_get ()) {
 		if (field_class->valuetype) mono_field_set_value (tp->rp->unwrapped_server, field, val);
 		else mono_field_set_value (tp->rp->unwrapped_server, field, *((MonoObject **)val));
-		return;
+		return TRUE;
 	}
 
 	if (!setter) {
 		setter = mono_class_get_method_from_name (mono_defaults.object_class, "FieldSetter", -1);
-		if (!setter)
-			mono_raise_exception (mono_get_exception_not_supported ("Linked away."));
+		if (!setter) {
+			mono_error_set_not_supported (error, "Linked away.");
+			return FALSE;
+		}
 	}
 
 	if (field_class->valuetype) {
-		arg = mono_value_box_checked (domain, field_class, val, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		arg = mono_value_box_checked (domain, field_class, val, error);
+		return_val_if_nok (error, FALSE);
 	} else 
 		arg = *((MonoObject **)val);
 		
 
-	msg = (MonoMethodMessage *)mono_object_new_checked (domain, mono_defaults.mono_method_message_class, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
-	MonoReflectionMethod *rm = mono_method_get_object_checked (domain, setter, NULL, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	msg = (MonoMethodMessage *)mono_object_new_checked (domain, mono_defaults.mono_method_message_class, error);
+	return_val_if_nok (error, FALSE);
+	MonoReflectionMethod *rm = mono_method_get_object_checked (domain, setter, NULL, error);
+	return_val_if_nok (error, FALSE);
 	mono_message_init (domain, msg, rm, NULL);
 
 	full_name = mono_type_get_full_name (klass);
@@ -7671,10 +7697,14 @@ mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField 
 	mono_array_setref (msg->args, 2, arg);
 	g_free (full_name);
 
-	mono_remoting_invoke ((MonoObject *)(tp->rp), msg, &exc, &out_args, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_remoting_invoke ((MonoObject *)(tp->rp), msg, &exc, &out_args, error);
+	return_val_if_nok (error, FALSE);
 
-	if (exc) mono_raise_exception ((MonoException *)exc);
+	if (exc) {
+		mono_error_set_exception_instance (error, (MonoException *)exc);
+		return FALSE;
+	}
+	return TRUE;
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6096,8 +6096,10 @@ mono_object_isinst_mbyref_checked (MonoObject *obj, MonoClass *klass, MonoError 
 		gpointer pa [2];
 
 		im = mono_class_get_method_from_name (rpklass, "CanCastTo", -1);
-		if (!im)
-			mono_raise_exception (mono_get_exception_not_supported ("Linked away."));
+		if (!im) {
+			mono_error_set_not_supported (error, "Linked away.");
+			return NULL;
+		}
 		im = mono_object_get_virtual_method (rp, im);
 		g_assert (im);
 	

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -275,6 +275,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API void*
 mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void **res);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -283,6 +283,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void* val);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -271,6 +271,7 @@ mono_runtime_set_main_args  (int argc, char* argv[]);
 
 /* The following functions won't be available with mono was configured with remoting disabled. */
 /*#ifndef DISABLE_REMOTING */
+MONO_RT_EXTERNAL_ONLY
 MONO_API void*
 mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void **res);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -279,6 +279,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, void* val);
 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -194,6 +194,7 @@ mono_remoting_marshal_init (void)
 		register_icall (mono_marshal_xdomain_copy_out_value, "mono_marshal_xdomain_copy_out_value", "void object object", FALSE);
 		register_icall (mono_remoting_wrapper, "mono_remoting_wrapper", "object ptr ptr", FALSE);
 		register_icall (mono_upgrade_remote_class_wrapper, "mono_upgrade_remote_class_wrapper", "void object object", FALSE);
+		/* mono_load_remote_field_new_icall registered  by mini-runtime.c */
 	}
 
 	icalls_registered = TRUE;
@@ -1286,7 +1287,7 @@ mono_marshal_get_remoting_invoke_with_check (MonoMethod *method)
 MonoMethod *
 mono_marshal_get_ldfld_remote_wrapper (MonoClass *klass)
 {
-	MonoMethodSignature *sig, *csig;
+	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	static MonoMethod* cached = NULL;
@@ -1313,15 +1314,7 @@ mono_marshal_get_ldfld_remote_wrapper (MonoClass *klass)
 	mono_mb_emit_ldarg (mb, 1);
 	mono_mb_emit_ldarg (mb, 2);
 
-	csig = mono_metadata_signature_alloc (mono_defaults.corlib, 3);
-	csig->params [0] = &mono_defaults.object_class->byval_arg;
-	csig->params [1] = &mono_defaults.int_class->byval_arg;
-	csig->params [2] = &mono_defaults.int_class->byval_arg;
-	csig->ret = &mono_defaults.object_class->byval_arg;
-	csig->pinvoke = 1;
-
-	mono_mb_emit_native_call (mb, csig, mono_load_remote_field_new);
-	mono_marshal_emit_thread_interrupt_checkpoint (mb);
+	mono_mb_emit_icall (mb, mono_load_remote_field_new_icall);
 
 	mono_mb_emit_byte (mb, CEE_RET);
 #endif

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -399,7 +399,8 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 	if (exc)
 		mono_raise_exception ((MonoException *)exc);
 
-	mono_method_return_message_restore (method, params, out_args);
+	mono_method_return_message_restore (method, params, out_args, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	return res;
 } 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -195,6 +195,8 @@ mono_remoting_marshal_init (void)
 		register_icall (mono_remoting_wrapper, "mono_remoting_wrapper", "object ptr ptr", FALSE);
 		register_icall (mono_upgrade_remote_class_wrapper, "mono_upgrade_remote_class_wrapper", "void object object", FALSE);
 		/* mono_load_remote_field_new_icall registered  by mini-runtime.c */
+		/* mono_store_remote_field_new_icall registered  by mini-runtime.c */
+
 	}
 
 	icalls_registered = TRUE;
@@ -1637,7 +1639,7 @@ mono_marshal_get_ldflda_wrapper (MonoType *type)
 MonoMethod *
 mono_marshal_get_stfld_remote_wrapper (MonoClass *klass)
 {
-	MonoMethodSignature *sig, *csig;
+	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	static MonoMethod *cached = NULL;
@@ -1666,16 +1668,7 @@ mono_marshal_get_stfld_remote_wrapper (MonoClass *klass)
 	mono_mb_emit_ldarg (mb, 2);
 	mono_mb_emit_ldarg (mb, 3);
 
-	csig = mono_metadata_signature_alloc (mono_defaults.corlib, 4);
-	csig->params [0] = &mono_defaults.object_class->byval_arg;
-	csig->params [1] = &mono_defaults.int_class->byval_arg;
-	csig->params [2] = &mono_defaults.int_class->byval_arg;
-	csig->params [3] = &mono_defaults.object_class->byval_arg;
-	csig->ret = &mono_defaults.void_class->byval_arg;
-	csig->pinvoke = 1;
-
-	mono_mb_emit_native_call (mb, csig, mono_store_remote_field_new);
-	mono_marshal_emit_thread_interrupt_checkpoint (mb);
+	mono_mb_emit_icall (mb, mono_store_remote_field_new_icall);
 
 	mono_mb_emit_byte (mb, CEE_RET);
 #endif

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9255,6 +9255,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 static ErrorCode
 object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 {
+	MonoError error;
 	int objid;
 	ErrorCode err;
 	MonoObject *obj;
@@ -9332,7 +9333,11 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 				if (remote_obj) {
 #ifndef DISABLE_REMOTING
-					field_value = mono_load_remote_field(obj, obj_type, f, &field_storage);
+					field_value = mono_load_remote_field_checked(obj, obj_type, f, &field_storage, &error);
+					if (!is_ok (&error)) {
+						mono_error_cleanup (&error); /* FIXME report the error */
+						return ERR_INVALID_OBJECT;
+					}
 #else
 					g_assert_not_reached ();
 #endif

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3900,7 +3900,7 @@ register_icalls (void)
 	register_icall (mono_thread_interruption_checkpoint, "mono_thread_interruption_checkpoint", "object", FALSE);
 	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", "object", FALSE);
 #ifndef DISABLE_REMOTING
-	register_icall (mono_load_remote_field_new, "mono_load_remote_field_new", "object object ptr ptr", FALSE);
+	register_icall (mono_load_remote_field_new_icall, "mono_load_remote_field_new_icall", "object object ptr ptr", FALSE);
 	register_icall (mono_store_remote_field_new, "mono_store_remote_field_new", "void object ptr ptr object", FALSE);
 #endif
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3901,7 +3901,7 @@ register_icalls (void)
 	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", "object", FALSE);
 #ifndef DISABLE_REMOTING
 	register_icall (mono_load_remote_field_new_icall, "mono_load_remote_field_new_icall", "object object ptr ptr", FALSE);
-	register_icall (mono_store_remote_field_new, "mono_store_remote_field_new", "void object ptr ptr object", FALSE);
+	register_icall (mono_store_remote_field_new_icall, "mono_store_remote_field_new_icall", "void object ptr ptr object", FALSE);
 #endif
 
 #if defined(__native_client__) || defined(__native_client_codegen__)


### PR DESCRIPTION
Get rid of calls to `mono_raise_exception` in marshaling and remoting code.