### PR TITLE
Fix hazard free

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -757,6 +757,8 @@ finalizer_thread (gpointer unused)
 
 		reference_queue_proccess_all ();
 
+		mono_thread_hazardous_try_free_all ();
+
 		/* Avoid posting the pending done event until there are pending finalizers */
 		if (mono_coop_sem_timedwait (&finalizer_sem, 0, MONO_SEM_FLAGS_NONE) == 0) {
 			/* Don't wait again at the start of the loop */

--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -613,7 +613,7 @@ jit_info_table_add (MonoDomain *domain, MonoJitInfoTable *volatile *table_ptr, M
 		*table_ptr = new_table;
 		mono_memory_barrier ();
 		domain->num_jit_info_tables++;
-		mono_thread_hazardous_free_or_queue (table, (MonoHazardousFreeFunc)mono_jit_info_table_free, HAZARD_FREE_MAY_LOCK, HAZARD_FREE_SAFE_CTX);
+		mono_thread_hazardous_try_free (table, (MonoHazardousFreeFunc)mono_jit_info_table_free);
 		table = new_table;
 
 		goto restart;
@@ -691,7 +691,7 @@ mono_jit_info_free_or_queue (MonoDomain *domain, MonoJitInfo *ji)
 	if (domain->num_jit_info_tables <= 1) {
 		/* Can it actually happen that we only have one table
 		   but ji is still hazardous? */
-		mono_thread_hazardous_free_or_queue (ji, g_free, HAZARD_FREE_MAY_LOCK, HAZARD_FREE_SAFE_CTX);
+		mono_thread_hazardous_try_free (ji, g_free);
 	} else {
 		domain->jit_info_free_queue = g_slist_prepend (domain->jit_info_free_queue, ji);
 	}

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -343,7 +343,6 @@ nursery_canaries_enabled (void)
  * ######################################################################
  */
 MonoCoopMutex gc_mutex;
-gboolean sgen_try_free_some_memory;
 
 #define SCAN_START_SIZE	SGEN_SCAN_START_SIZE
 
@@ -3179,11 +3178,7 @@ sgen_gc_lock (void)
 void
 sgen_gc_unlock (void)
 {
-	gboolean try_free = sgen_try_free_some_memory;
-	sgen_try_free_some_memory = FALSE;
 	mono_coop_mutex_unlock (&gc_mutex);
-	if (try_free)
-		mono_thread_hazardous_try_free_some ();
 }
 
 void
@@ -3249,8 +3244,6 @@ sgen_restart_world (int generation, GGTimingInfo *timing)
 	world_is_stopped = FALSE;
 
 	binary_protocol_world_restarted (generation, sgen_timestamp ());
-
-	sgen_try_free_some_memory = TRUE;
 
 	if (sgen_client_bridge_need_processing ())
 		sgen_client_bridge_processing_finish (generation);

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -31,8 +31,6 @@ typedef enum {
 gboolean mono_thread_hazardous_try_free (gpointer p, MonoHazardousFreeFunc free_func);
 void mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func);
 
-void mono_thread_hazardous_free_or_queue (gpointer p, MonoHazardousFreeFunc free_func,
-                                          HazardFreeLocking locking, HazardFreeContext context);
 void mono_thread_hazardous_try_free_all (void);
 void mono_thread_hazardous_try_free_some (void);
 MonoThreadHazardPointers* mono_hazard_pointer_get (void);

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -58,6 +58,9 @@ int mono_thread_small_id_alloc (void);
 int mono_hazard_pointer_save_for_signal_handler (void);
 void mono_hazard_pointer_restore_for_signal_handler (int small_id);
 
+typedef void (*MonoHazardFreeQueueSizeCallback)(size_t size);
+void mono_hazard_pointer_install_free_queue_size_callback (MonoHazardFreeQueueSizeCallback cb);
+
 void mono_thread_smr_init (void);
 void mono_thread_smr_cleanup (void);
 #endif /*__MONO_HAZARD_POINTER_H__*/

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -28,6 +28,9 @@ typedef enum {
 	HAZARD_FREE_ASYNC_CTX,
 } HazardFreeContext;
 
+gboolean mono_thread_hazardous_try_free (gpointer p, MonoHazardousFreeFunc free_func);
+void mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func);
+
 void mono_thread_hazardous_free_or_queue (gpointer p, MonoHazardousFreeFunc free_func,
                                           HazardFreeLocking locking, HazardFreeContext context);
 void mono_thread_hazardous_try_free_all (void);

--- a/mono/utils/lock-free-alloc.c
+++ b/mono/utils/lock-free-alloc.c
@@ -250,7 +250,7 @@ desc_retire (Descriptor *desc)
 	g_assert (desc->in_use);
 	desc->in_use = FALSE;
 	free_sb (desc->sb, desc->block_size);
-	mono_thread_hazardous_free_or_queue (desc, desc_enqueue_avail, HAZARD_FREE_NO_LOCK, HAZARD_FREE_ASYNC_CTX);
+	mono_thread_hazardous_try_free (desc, desc_enqueue_avail);
 }
 #else
 MonoLockFreeQueue available_descs;
@@ -302,7 +302,7 @@ static void
 list_put_partial (Descriptor *desc)
 {
 	g_assert (desc->anchor.data.state != STATE_FULL);
-	mono_thread_hazardous_free_or_queue (desc, desc_put_partial, HAZARD_FREE_NO_LOCK, HAZARD_FREE_ASYNC_CTX);
+	mono_thread_hazardous_try_free (desc, desc_put_partial);
 }
 
 static void
@@ -321,7 +321,7 @@ list_remove_empty_desc (MonoLockFreeAllocSizeClass *sc)
 			desc_retire (desc);
 		} else {
 			g_assert (desc->heap->sc == sc);
-			mono_thread_hazardous_free_or_queue (desc, desc_put_partial, HAZARD_FREE_NO_LOCK, HAZARD_FREE_ASYNC_CTX);
+			mono_thread_hazardous_try_free (desc, desc_put_partial);
 			if (++num_non_empty >= 2)
 				return;
 		}

--- a/mono/utils/lock-free-queue.c
+++ b/mono/utils/lock-free-queue.c
@@ -286,7 +286,7 @@ mono_lock_free_queue_dequeue (MonoLockFreeQueue *q)
 		g_assert (q->has_dummy);
 		q->has_dummy = 0;
 		mono_memory_write_barrier ();
-		mono_thread_hazardous_free_or_queue (head, free_dummy, HAZARD_FREE_NO_LOCK, HAZARD_FREE_ASYNC_CTX);
+		mono_thread_hazardous_try_free (head, free_dummy);
 		if (try_reenqueue_dummy (q))
 			goto retry;
 		return NULL;

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -56,7 +56,7 @@ conc_table_free (gpointer ptr)
 static void
 conc_table_lf_free (conc_table *table)
 {
-	mono_thread_hazardous_free_or_queue (table, conc_table_free, HAZARD_FREE_MAY_LOCK, HAZARD_FREE_SAFE_CTX);
+	mono_thread_hazardous_try_free (table, conc_table_free);
 }
 
 

--- a/mono/utils/mono-linked-list-set.c
+++ b/mono/utils/mono-linked-list-set.c
@@ -126,7 +126,7 @@ try_again:
 				mono_memory_write_barrier ();
 				mono_hazard_pointer_clear (hp, 1);
 				if (list->free_node_func)
-					mono_thread_hazardous_free_or_queue (cur, list->free_node_func, list->locking, context);
+					mono_thread_hazardous_queue_free (cur, list->free_node_func);
 			} else
 				goto try_again;
 		}
@@ -198,7 +198,7 @@ mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLink
 			mono_memory_write_barrier ();
 			mono_hazard_pointer_clear (hp, 1);
 			if (list->free_node_func)
-				mono_thread_hazardous_free_or_queue (value, list->free_node_func, list->locking, context);
+				mono_thread_hazardous_try_free (value, list->free_node_func);
 		} else
 			mono_lls_find (list, hp, value->key, context);
 		return TRUE;

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -152,7 +152,7 @@ mono_lls_filter_accept_all (gpointer elem)
 						mono_memory_write_barrier (); \
 						mono_hazard_pointer_clear (hp__, 1); \
 						if (list__->free_node_func) { \
-							mono_thread_hazardous_free_or_queue (cur__, list__->free_node_func, list__->locking, HAZARD_FREE_ASYNC_CTX); \
+							mono_thread_hazardous_queue_free (cur__, list__->free_node_func); \
 						} \
 					} else { \
 						restart__ = TRUE; \

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -424,7 +424,10 @@ unregister_thread (void *arg)
 	g_byte_array_free (info->stackdata, /*free_segment=*/TRUE);
 
 	/*now it's safe to free the thread info.*/
-	mono_thread_hazardous_free_or_queue (info, free_thread_info, HAZARD_FREE_MAY_LOCK, HAZARD_FREE_SAFE_CTX);
+	mono_thread_hazardous_try_free (info, free_thread_info);
+	/* Pump the HP queue */
+	mono_thread_hazardous_try_free_some ();
+
 	mono_thread_small_id_free (small_id);
 }
 


### PR DESCRIPTION
Replace usage of mono_thread_hazardous_free_or_queue and remove it.
    
    mono_thread_hazardous_free_or_queue has a fundamentally broken design.
    
    It allows arbitrary free code to run in the context of its caller.
    
    The sync/async split on where it's called is not enough to know whether
    we can run free'ing code or not.
    
    Since in sync context we called free functions that could take locks,
    it happened that those locks conflicted with the ones already taken.
    
    In particular, mono_jit_info_table_free did take a domain lock and
    quite a few of the sync context calls would hold locks that must
    not be held when taking a domain lock.
    
    This, is practice, means that we'd need to partition the free calls
    into 3 groups: async context, reentrant context (no runtime locks held)
    and sync context (maybe some locks held).
    
    There was no case where reentrant context would be usable meaning,
    in practice, that all calls happens in what effectively is async context
    where free functions can't be called.
    
    The new design is a lot more straightforward:
    
    - No implicit free queue pumping
    - A pair of free functions with well defined behavior.
    	mono_thread_hazardous_try_free - to be used where the caller expects the free function to be called
    	mono_thread_hazardous_queue_free - to be used where the caller don't expect the free function to be called [1]
    - Explicit pumping on places that known to be ok
    	Thread detach
    	Finalizer thread
    
    [1] This might sound like a weird condition, but a lot of lock-free code
    have compensation logic that trigger free'ing during lookups.
