### PR TITLE
[appdomain] Cleanup MonoError code

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -320,7 +320,7 @@ mono_get_corlib_version (void)
 	if (! (field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 		return -1;
 	value = mono_field_get_value_object_checked (mono_domain_get (), field, NULL, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_error_assert_ok (&error);
 	return *(gint32*)((gchar*)value + sizeof (MonoObject));
 }
 
@@ -435,13 +435,18 @@ mono_domain_create_appdomain (char *friendly_name, char *configuration_file)
 
 	klass = mono_class_load_from_name (mono_defaults.corlib, "System", "AppDomainSetup");
 	setup = (MonoAppDomainSetup *) mono_object_new_checked (mono_domain_get (), klass, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (!is_ok (&error))
+		goto fail;
 	setup->configuration_file = configuration_file != NULL ? mono_string_new (mono_domain_get (), configuration_file) : NULL;
 
 	ad = mono_domain_create_appdomain_internal (friendly_name, setup, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (!is_ok (&error))
+		goto fail;
 
 	return mono_domain_from_appdomain (ad);
+fail:
+	mono_error_cleanup (&error);
+	return NULL;
 }
 
 /**
@@ -938,23 +943,20 @@ mono_domain_set_options_from_config (MonoDomain *domain)
 MonoAppDomain *
 ves_icall_System_AppDomain_createDomain (MonoString *friendly_name, MonoAppDomainSetup *setup)
 {
-#ifdef DISABLE_APPDOMAINS
-	mono_set_pending_exception (mono_get_exception_not_supported ("AppDomain creation is not supported on this runtime."));
-	return NULL;
-#else
 	MonoError error;
+	MonoAppDomain *ad = NULL;
+#ifdef DISABLE_APPDOMAINS
+	mono_error_set_not_supported (&error, "AppDomain creation is not supported on this runtime.");
+#else
 	char *fname;
-	MonoAppDomain *ad;
 
 	fname = mono_string_to_utf8 (friendly_name);
 	ad = mono_domain_create_appdomain_internal (fname, setup, &error);
 
 	g_free (fname);
-
-	mono_error_raise_exception (&error);
-
-	return ad;
 #endif
+	mono_error_set_pending_exception (&error);
+	return ad;
 }
 
 MonoArray *
@@ -1057,18 +1059,13 @@ mono_domain_assembly_postload_search (MonoAssemblyName *aname, MonoAssembly *req
 
 	/* FIXME: We invoke managed code here, so there is a potential for deadlocks */
 	str = mono_string_new (domain, aname_str);
+	g_free (aname_str);
 	if (!str) {
-		g_free (aname_str);
 		return NULL;
 	}
 
 	assembly = mono_try_assembly_resolve (domain, str, requesting, refonly, &error);
-	if (!mono_error_ok (&error)) {
-		g_free (aname_str);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
-	}
-
-	g_free (aname_str);
+	mono_error_cleanup (&error);
 
 	if (assembly)
 		return assembly->assembly;
@@ -1163,7 +1160,7 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 	*params = ref_assembly;
 
 	mono_runtime_invoke_checked (assembly_load_method, domain->domain, params, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_error_cleanup (&error);
 }
 
 /*
@@ -2309,7 +2306,7 @@ ves_icall_System_AppDomain_InternalGetProcessGuid (MonoString* newguid)
 		MonoError error;
 		MonoString *res = NULL;
 		res = mono_string_new_utf16_checked (mono_domain_get (), process_guid, sizeof(process_guid)/2, &error);
-		mono_error_raise_exception (&error);
+		mono_error_set_pending_exception (&error);
 		return res;
 	}
 	memcpy (process_guid, mono_string_chars(newguid), sizeof(process_guid));
@@ -2430,9 +2427,17 @@ unload_thread_main (void *arg)
 	/* Have to attach to the runtime so shutdown can wait for this thread */
 	/* Force it to be attached to avoid racing during shutdown. */
 	thread = mono_thread_attach_full (mono_get_root_domain (), TRUE, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (!is_ok (&error)) {
+		data->failure_reason = g_strdup (mono_error_get_message (&error));
+		mono_error_cleanup (&error);
+		goto failure;
+	}
 	mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Domain unloader"), TRUE, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (!is_ok (&error)) {
+		data->failure_reason = g_strdup (mono_error_get_message (&error));
+		mono_error_cleanup (&error);
+		goto failure;
+	}
 
 	/* 
 	 * FIXME: Abort our parent thread last, so we can return a failure 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2431,7 +2431,8 @@ unload_thread_main (void *arg)
 	/* Force it to be attached to avoid racing during shutdown. */
 	thread = mono_thread_attach_full (mono_get_root_domain (), TRUE, &error);
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
-	mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Domain unloader"), TRUE);
+	mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Domain unloader"), TRUE, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 
 	/* 
 	 * FIXME: Abort our parent thread last, so we can return a failure 

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -475,6 +475,7 @@ transport_start_receive (void)
 static guint32 WINAPI
 receiver_thread (void *arg)
 {
+	MonoError error;
 	int res, content_len;
 	guint8 buffer [256];
 	guint8 *p, *p_end;
@@ -493,7 +494,8 @@ receiver_thread (void *arg)
 		printf ("attach: Connected.\n");
 
 		MonoThread *thread = mono_thread_attach (mono_get_root_domain ());
-		mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Attach receiver"), TRUE);
+		mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Attach receiver"), TRUE, &error);
+		mono_error_assert_ok (&error);
 		/* Ask the runtime to not abort this thread */
 		//mono_thread_current ()->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 		/* Ask the runtime to not wait for this thread */

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -940,8 +940,10 @@ ves_icall_Mono_Runtime_GetNativeStackTrace (MonoException *exc)
 {
 	char *trace;
 	MonoString *res;
-	if (!exc)
-		mono_raise_exception (mono_get_exception_argument_null ("exception"));
+	if (!exc) {
+		mono_set_pending_exception (mono_get_exception_argument_null ("exception"));
+		return NULL;
+	}
 
 	trace = mono_exception_get_native_backtrace (exc);
 	res = mono_string_new (mono_domain_get (), trace);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -748,7 +748,9 @@ finalize_domain_objects (DomainFinalizationReq *req)
 static guint32
 finalizer_thread (gpointer unused)
 {
-	mono_thread_set_name_internal (mono_thread_internal_current (), mono_string_new (mono_get_root_domain (), "Finalizer"), FALSE);
+	MonoError error;
+	mono_thread_set_name_internal (mono_thread_internal_current (), mono_string_new (mono_get_root_domain (), "Finalizer"), FALSE, &error);
+	mono_error_assert_ok (&error);
 
 	gboolean wait = TRUE;
 

--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -592,7 +592,8 @@ worker_thread (gpointer data)
 	thread = mono_thread_internal_current ();
 	g_assert (thread);
 
-	mono_thread_set_name_internal (thread, mono_string_new (mono_get_root_domain (), "Threadpool worker"), FALSE);
+	mono_thread_set_name_internal (thread, mono_string_new (mono_get_root_domain (), "Threadpool worker"), FALSE, &error);
+	mono_error_assert_ok (&error);
 
 	mono_coop_mutex_lock (&threadpool->active_threads_lock);
 	g_ptr_array_add (threadpool->working_threads, thread);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -218,7 +218,7 @@ MONO_API MonoException* mono_thread_get_undeniable_exception (void);
 
 MonoException* mono_thread_get_and_clear_pending_exception (void);
 
-void mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, gboolean managed);
+void mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, gboolean managed, MonoError *error);
 
 void mono_runtime_set_has_tls_get (gboolean val);
 gboolean mono_runtime_has_tls_get (void);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1353,14 +1353,16 @@ ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThread *this_obj
 }
 
 void 
-mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, gboolean managed)
+mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, gboolean managed, MonoError *error)
 {
 	LOCK_THREAD (this_obj);
+
+	mono_error_init (error);
 
 	if ((this_obj->flags & MONO_THREAD_FLAG_NAME_SET) && !this_obj->threadpool_thread) {
 		UNLOCK_THREAD (this_obj);
 		
-		mono_raise_exception (mono_get_exception_invalid_operation ("Thread.Name can only be set once."));
+		mono_error_set_invalid_operation (error, "Thread.Name can only be set once.");
 		return;
 	}
 	if (this_obj->name) {
@@ -1391,7 +1393,9 @@ mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, g
 void 
 ves_icall_System_Threading_Thread_SetName_internal (MonoInternalThread *this_obj, MonoString *name)
 {
-	mono_thread_set_name_internal (this_obj, name, TRUE);
+	MonoError error;
+	mono_thread_set_name_internal (this_obj, name, TRUE, &error);
+	mono_error_set_pending_exception (&error);
 }
 
 /*

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7865,8 +7865,10 @@ compile_thread_main (gpointer *user_data)
 	GPtrArray *methods = (GPtrArray *)user_data [2];
 	int i;
 
+	MonoError error;
 	MonoThread *thread = mono_thread_attach (domain);
-	mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "AOT compiler"), TRUE);
+	mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "AOT compiler"), TRUE, &error);
+	mono_error_assert_ok (&error);
 
 	for (i = 0; i < methods->len; ++i)
 		compile_method (acfg, (MonoMethod *)g_ptr_array_index (methods, i));

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9675,6 +9675,7 @@ wait_for_attach (void)
 static guint32 WINAPI
 debugger_thread (void *arg)
 {
+	MonoError error;
 	int res, len, id, flags, command = 0;
 	CommandSet command_set = (CommandSet)0;
 	guint8 header [HEADER_LENGTH];
@@ -9691,7 +9692,8 @@ debugger_thread (void *arg)
 
 	attach_cookie = mono_jit_thread_attach (mono_get_root_domain (), &attach_dummy);
 	MonoInternalThread *thread = mono_thread_internal_current ();
-	mono_thread_set_name_internal (thread, mono_string_new (mono_get_root_domain (), "Debugger agent"), TRUE);
+	mono_thread_set_name_internal (thread, mono_string_new (mono_get_root_domain (), "Debugger agent"), TRUE, &error);
+	mono_error_assert_ok (&error);
 
 	thread->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -103,6 +103,9 @@ void
 mono_error_set_not_supported (MonoError *error, const char *msg_format, ...);
 
 void
+mono_error_set_invalid_operation (MonoError *error, const char *msg_format, ...);
+
+void
 mono_error_set_exception_instance (MonoError *error, MonoException *exc);
 
 MonoException*

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -393,7 +393,7 @@ mono_error_set_execution_engine (MonoError *oerror, const char *msg_format, ...)
 }
 
 /**
- * mono_error_set_execution_engine:
+ * mono_error_set_not_supported:
  *
  * System.NotSupportedException
  */
@@ -403,6 +403,20 @@ mono_error_set_not_supported (MonoError *oerror, const char *msg_format, ...)
 	va_list args;
 	va_start (args, msg_format);
 	mono_error_set_generic_errorv (oerror, "System", "NotSupportedException", msg_format, args);
+	va_end (args);
+}
+
+/**
+ * mono_error_set_invalid_operation:
+ *
+ * System.InvalidOperationException
+ */
+void
+mono_error_set_invalid_operation (MonoError *oerror, const char *msg_format, ...)
+{
+	va_list args;
+	va_start (args, msg_format);
+	mono_error_set_generic_errorv (oerror, "System", "InvalidOperationException", msg_format, args);
 	va_end (args);
 }
 


### PR DESCRIPTION
1. Assert in mono_get_corlib_version instead of raising an exn.
2. Don't raise in mono_domain_create_appdomain external API function.
3. Assert in mono_domain_assembly_postload_search instead of raising.
4. Don't raise in mono_domain_fire_assembly_load.
5. Use mono_error_set_pending_exception in
   ves_icall_System_AppDomain_InternalGetProcessGuid
6. Dont' raise in unload_thread_main, populate unload_data instead.