### PR TITLE
Various cleanups on profiler

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -786,7 +786,8 @@ to Mono, like this:
 .PP
 In the above sample Mono will load the user defined profiler from the
 shared library `mono-profiler-custom.so'.  This profiler module must
-be on your dynamic linker library path.
+be on your dynamic linker library path, or in the MONO_PROFILER_LIB_DIR
+path (see "RUNTIME OPTIONS" below).
 .PP 
 A list of other third party profilers is available from Mono's web
 site (www.mono-project.com/docs/advanced/performance-tips/)
@@ -1512,6 +1513,12 @@ libraries side-by-side with the main executable.
 For a complete description of recommended practices for application
 deployment, see
 http://www.mono-project.com/docs/getting-started/application-deployment/
+.TP
+\fBMONO_PROFILER_LIB_DIR\fR
+Provides a search path to the runtime where to look for custom profilers. See the
+section "CUSTOM PROFILERS" above for more information. Custom profilers will be
+searched for in the MONO_PROFILER_LIB_DIR path before the standard library paths.
+
 .TP
 \fBMONO_RTC\fR
 Experimental RTC support in the statistical profiler: if the user has

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -23,6 +23,7 @@
 #include "mono/metadata/mono-config-dirs.h"
 #include "mono/io-layer/io-layer.h"
 #include "mono/utils/mono-dl.h"
+#include <mono/utils/mono-logger-internals.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -1167,10 +1168,13 @@ load_profiler_from_directory (const char *directory, const char *libname, const 
 	char *err;
 	void *iter;
 
+	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Attempting to load profiler %s from %s (desc %s)", libname, directory, desc);
+
 	iter = NULL;
 	err = NULL;
 	while ((path = mono_dl_build_path (directory, libname, &iter))) {
 		pmodule = mono_dl_open (path, MONO_DL_LAZY, &err);
+		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Attempting to load profiler: %s %ssuccessful, err: %s", path, pmodule?"":"not ", err);
 		g_free (path);
 		g_free (err);
 		if (pmodule)
@@ -1249,7 +1253,10 @@ mono_profiler_load (const char *desc)
 		}
 		if (!load_embedded_profiler (desc, mname)) {
 			libname = g_strdup_printf ("mono-profiler-%s", mname);
-			if (mono_config_get_assemblies_dir ())
+			char *profiler_lib_dir = getenv ("MONO_PROFILER_LIB_DIR");
+			if (profiler_lib_dir)
+				res = load_profiler_from_directory (profiler_lib_dir, libname, desc);
+			if (!res && mono_config_get_assemblies_dir ())
 				res = load_profiler_from_directory (mono_assembly_getrootdir (), libname, desc);
 			if (!res)
 				res = load_profiler_from_directory (NULL, libname, desc);

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -2074,10 +2074,11 @@ mono_sample_hit (MonoProfiler *profiler, unsigned char *ip, void *context)
 	do {
 		old_data = sbuf->cursor;
 		new_data = old_data + SAMPLE_EVENT_SIZE_IN_SLOTS (bt_data.count);
+		if (new_data > sbuf->buf_end)
+			return; /* Not enough room in buf to hold this event-- lost event */
 		data = (uintptr_t *)InterlockedCompareExchangePointer ((void * volatile*)&sbuf->cursor, new_data, old_data);
 	} while (data != old_data);
-	if (old_data >= sbuf->buf_end)
-		return; /* lost event */
+
 	old_data [0] = 1 | (sample_type << 16) | (bt_data.count << 8);
 	old_data [1] = thread_id ();
 	old_data [2] = elapsed;

--- a/mono/profiler/proflog.h
+++ b/mono/profiler/proflog.h
@@ -93,6 +93,8 @@ enum {
 	TYPE_END
 };
 
+// Sampling sources
+// Unless you have compiled with --enable-perf-events, only SAMPLE_CYCLES is available
 enum {
 	SAMPLE_CYCLES = 1,
 	SAMPLE_INSTRUCTIONS,

--- a/mono/profiler/ptestrunner.pl
+++ b/mono/profiler/ptestrunner.pl
@@ -15,8 +15,7 @@ my $minibuilddir = $builddir . "/mono/mini";
 
 # Setup the execution environment
 # for the profiler module
-append_path ("LD_LIBRARY_PATH", $profbuilddir . "/.libs");
-append_path ("DYLD_LIBRARY_PATH", $profbuilddir . "/.libs");
+append_path ("MONO_PROFILER_LIB_DIR", $profbuilddir . "/.libs");
 append_path ("DYLD_LIBRARY_PATH", $minibuilddir . "/.libs");
 # for mprof-report
 append_path ("PATH", $profbuilddir);


### PR DESCRIPTION
3 commits:

Assist on profiler module loading

- Add a MONO_PROFILER_LIB_DIR from which profiler modules are
  dynamically loading, in case it is not the normal library path
- Add information about profiler loading to mono_trace

Comments and clarity in proflog.c

- Add comments on structures
- Rename 'data' and 'data_end' to 'cursor' and 'buf_end' in LogBuffer/StatsBuffer as the old names were confusing
- Add new assert when processing samples

Improve a safety check when writing data into StatBuffer

- The safety check should occur such that if the new value for
StatBuffer::cursor is beyond the bounds of the StatBuffer, the cursor
is not updated.