### PR TITLE
Disabled client certificate request for HttpConnection (HttpListener)…

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/X509Chain.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X509Chain.cs
@@ -158,10 +158,10 @@ namespace Mono.Security.X509 {
 
 			// validate the chain
 			if ((_chain != null) && (_status == X509ChainStatusFlags.NoError)) {
-				foreach (X509Certificate x in _chain) {
+				foreach (X509Certificate y in _chain) {
 					// validate dates for each certificate in the chain
 					// note: we DO NOT check for nested date/time
-					if (!IsValid (x)) {
+					if (!IsValid (y)) {
 						return false;
 					}
 				}

--- a/mcs/class/System/System.Net/HttpConnection.cs
+++ b/mcs/class/System/System.Net/HttpConnection.cs
@@ -119,7 +119,7 @@ namespace System.Net {
 		void Init ()
 		{
 			if (ssl_stream != null) {
-				ssl_stream.AuthenticateAsServer (cert, true, (SslProtocols)ServicePointManager.SecurityProtocol, false);
+				ssl_stream.AuthenticateAsServer (cert, false, (SslProtocols)ServicePointManager.SecurityProtocol, false);
 			}
 
 			context_bound = false;


### PR DESCRIPTION
Enforcing HttpListener connections to validate client certificates by default render HttpListener unusable for most cases.

It was hardcoded to request the certificate, now it's disabled.

It should be extended to be configurable.

Also an small typo on x509 chain is corrected.
