### PR TITLE
[security-core-clr] remove `return` from void function

### DIFF
--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -1068,7 +1068,6 @@ void
 mono_security_core_clr_ensure_reflection_access_method (MonoMethod *method, MonoError *error)
 {
 	mono_error_init (error);
-	return TRUE;
 }
 
 gboolean


### PR DESCRIPTION
@lambdageek ^