### PR TITLE
Continued profiler loading cleanup (PR#2816 follow up)

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -786,8 +786,7 @@ to Mono, like this:
 .PP
 In the above sample Mono will load the user defined profiler from the
 shared library `mono-profiler-custom.so'.  This profiler module must
-be on your dynamic linker library path, or in the MONO_PROFILER_LIB_DIR
-path (see "RUNTIME OPTIONS" below).
+be on your dynamic linker library path.
 .PP 
 A list of other third party profilers is available from Mono's web
 site (www.mono-project.com/docs/advanced/performance-tips/)
@@ -1508,11 +1507,6 @@ libraries side-by-side with the main executable.
 For a complete description of recommended practices for application
 deployment, see
 http://www.mono-project.com/docs/getting-started/application-deployment/
-.TP
-\fBMONO_PROFILER_LIB_DIR\fR
-Provides a search path to the runtime where to look for custom profilers. See the
-section "CUSTOM PROFILERS" above for more information. Custom profilers will be
-searched for in the MONO_PROFILER_LIB_DIR path before the standard library paths.
 .TP
 \fBMONO_SHARED_DIR\fR
 If set its the directory where the ".wapi" handle state is stored.

--- a/mono/profiler/ptestrunner.pl
+++ b/mono/profiler/ptestrunner.pl
@@ -15,7 +15,6 @@ my $minibuilddir = $builddir . "/mono/mini";
 
 # Setup the execution environment
 # for the profiler module
-append_path ("MONO_PROFILER_LIB_DIR", $profbuilddir . "/.libs");
 append_path ("DYLD_LIBRARY_PATH", $minibuilddir . "/.libs");
 # for mprof-report
 append_path ("PATH", $profbuilddir);

--- a/mono/utils/mono-dl.c
+++ b/mono/utils/mono-dl.c
@@ -402,28 +402,35 @@ mono_dl_open_runtime_lib (const char* lib_name, int flags, char **error_msg)
 	if (binl != -1) {
 		char *base;
 		char *resolvedname, *name;
+		char *baseparent = NULL;
 		buf [binl] = 0;
 		resolvedname = mono_path_resolve_symlinks (buf);
 		base = g_path_get_dirname (resolvedname);
 		name = g_strdup_printf ("%s/.libs", base);
 		runtime_lib = try_load (lib_name, name, flags, error_msg);
 		g_free (name);
+		if (!runtime_lib)
+			baseparent = g_path_get_dirname (base);
 		if (!runtime_lib) {
-			char *newbase = g_path_get_dirname (base);
-			name = g_strdup_printf ("%s/lib", newbase);
+			name = g_strdup_printf ("%s/lib", baseparent);
 			runtime_lib = try_load (lib_name, name, flags, error_msg);
 			g_free (name);
 		}
 #ifdef __MACH__
 		if (!runtime_lib) {
-			char *newbase = g_path_get_dirname (base);
-			name = g_strdup_printf ("%s/Libraries", newbase);
+			name = g_strdup_printf ("%s/Libraries", baseparent);
 			runtime_lib = try_load (lib_name, name, flags, error_msg);
 			g_free (name);
 		}
 #endif
+		if (!runtime_lib) {
+			name = g_strdup_printf ("%s/profiler/.libs", baseparent);
+			runtime_lib = try_load (lib_name, name, flags, error_msg);
+			g_free (name);
+		}
 		g_free (base);
 		g_free (resolvedname);
+		g_free (baseparent);
 	}
 	if (!runtime_lib)
 		runtime_lib = try_load (lib_name, NULL, flags, error_msg);


### PR DESCRIPTION
- Back out MONO_PROFILER_LIB_DIR change
- Profiler loading traces should use log mask “dll” not “asm”
- mono_dl_open_runtime_lib should preempt standard paths when loading profiler
- mono_dl_open_runtime_lib should check in profiler library directory
- mono_dl_open_runtime_lib contained a memory leak
- With above changes, ptestrunner.pl can remove some environment massaging