### PR TITLE
Some improvements to thread names

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2431,6 +2431,7 @@ unload_thread_main (void *arg)
 	/* Force it to be attached to avoid racing during shutdown. */
 	thread = mono_thread_attach_full (mono_get_root_domain (), TRUE, &error);
 	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Domain unloader"), TRUE);
 
 	/* 
 	 * FIXME: Abort our parent thread last, so we can return a failure 

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -480,6 +480,8 @@ receiver_thread (void *arg)
 	guint8 *p, *p_end;
 	MonoObject *exc;
 
+	mono_thread_info_set_name (mono_native_thread_id_get (), "Attach receiver");
+
 	printf ("attach: Listening on '%s'...\n", server_uri);
 
 	while (TRUE) {
@@ -490,11 +492,12 @@ receiver_thread (void *arg)
 
 		printf ("attach: Connected.\n");
 
-		mono_thread_attach (mono_get_root_domain ());
+		MonoThread *thread = mono_thread_attach (mono_get_root_domain ());
+		mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Attach receiver"), TRUE);
 		/* Ask the runtime to not abort this thread */
 		//mono_thread_current ()->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 		/* Ask the runtime to not wait for this thread */
-		mono_thread_internal_current ()->state |= ThreadState_Background;
+		thread->internal_thread->state |= ThreadState_Background;
 
 		while (TRUE) {
 			char *cmd, *agent_name, *agent_args;

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -748,7 +748,7 @@ finalize_domain_objects (DomainFinalizationReq *req)
 static guint32
 finalizer_thread (gpointer unused)
 {
-	mono_thread_set_name_internal (mono_thread_internal_current (), mono_string_new (mono_get_root_domain (), "Finalizer"), TRUE);
+	mono_thread_set_name_internal (mono_thread_internal_current (), mono_string_new (mono_get_root_domain (), "Finalizer"), FALSE);
 
 	gboolean wait = TRUE;
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -748,6 +748,8 @@ finalize_domain_objects (DomainFinalizationReq *req)
 static guint32
 finalizer_thread (gpointer unused)
 {
+	mono_thread_set_name_internal (mono_thread_internal_current (), mono_string_new (mono_get_root_domain (), "Finalizer"), TRUE);
+
 	gboolean wait = TRUE;
 
 	/* Register a hazard free queue pump callback */
@@ -823,7 +825,6 @@ void
 mono_gc_init_finalizer_thread (void)
 {
 	gc_thread = mono_thread_create_internal (mono_domain_get (), finalizer_thread, NULL, FALSE, 0);
-	ves_icall_System_Threading_Thread_SetName_internal (gc_thread, mono_string_new (mono_domain_get (), "Finalizer"));
 }
 
 void

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2298,6 +2298,7 @@ void
 sgen_client_thread_register_worker (void)
 {
 	mono_thread_info_register_small_id ();
+	mono_thread_info_set_name (mono_native_thread_id_get (), "SGen worker");
 }
 
 /* Variables holding start/end nursery so it won't have to be passed at every call */

--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -592,7 +592,7 @@ worker_thread (gpointer data)
 	thread = mono_thread_internal_current ();
 	g_assert (thread);
 
-	mono_thread_set_name_internal (thread, mono_string_new (mono_domain_get (), "Threadpool worker"), FALSE);
+	mono_thread_set_name_internal (thread, mono_string_new (mono_get_root_domain (), "Threadpool worker"), FALSE);
 
 	mono_coop_mutex_lock (&threadpool->active_threads_lock);
 	g_ptr_array_add (threadpool->working_threads, thread);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7865,7 +7865,8 @@ compile_thread_main (gpointer *user_data)
 	GPtrArray *methods = (GPtrArray *)user_data [2];
 	int i;
 
-	mono_thread_attach (domain);
+	MonoThread *thread = mono_thread_attach (domain);
+	mono_thread_info_set_name (mono_native_thread_id_get (), "AOT compiler");
 
 	for (i = 0; i < methods->len; ++i)
 		compile_method (acfg, (MonoMethod *)g_ptr_array_index (methods, i));

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9690,8 +9690,10 @@ debugger_thread (void *arg)
 	debugger_thread_id = mono_native_thread_id_get ();
 
 	attach_cookie = mono_jit_thread_attach (mono_get_root_domain (), &attach_dummy);
+	MonoInternalThread *thread = mono_thread_internal_current ();
+	mono_thread_set_name_internal (thread, mono_string_new (mono_get_root_domain (), "Debugger agent"), TRUE);
 
-	mono_thread_internal_current ()->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
+	thread->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 
 	mono_set_is_debugger_attached (TRUE);
 	

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -668,6 +668,7 @@ static mono_native_thread_return_t
 sampling_thread_func (void *data)
 {
 	mono_threads_attach_tools_thread ();
+	mono_thread_info_set_name (mono_native_thread_id_get (), "Profiler sampler");
 
 	gint64 rate = 1000000000 / mono_profiler_get_sampling_rate ();
 

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -4067,6 +4067,8 @@ helper_thread (void* arg)
 	MonoThread *thread = NULL;
 
 	mono_threads_attach_tools_thread ();
+	mono_thread_info_set_name (mono_native_thread_id_get (), "Profiler helper");
+
 	//fprintf (stderr, "Server listening\n");
 	command_socket = -1;
 	while (1) {
@@ -4249,6 +4251,7 @@ writer_thread (void *arg)
 	MonoProfiler *prof = (MonoProfiler *)arg;
 
 	mono_threads_attach_tools_thread ();
+	mono_thread_info_set_name (mono_native_thread_id_get (), "Profiler writer");
 
 	dump_header (prof);
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -357,7 +357,7 @@ mono_thread_info_lookup (MonoNativeThreadId id);
 gboolean
 mono_thread_info_resume (MonoNativeThreadId tid);
 
-void
+MONO_API void
 mono_thread_info_set_name (MonoNativeThreadId tid, const char *name);
 
 void
@@ -523,7 +523,7 @@ void mono_threads_core_set_name (MonoNativeThreadId tid, const char *name);
 void mono_threads_coop_begin_global_suspend (void);
 void mono_threads_coop_end_global_suspend (void);
 
-MonoNativeThreadId
+MONO_API MonoNativeThreadId
 mono_native_thread_id_get (void);
 
 gboolean


### PR DESCRIPTION
**Do not merge.**

This makes debugging a little easier since GDB can actually tell you which threads are which. Should also work for ~most threads on Mac now.