### PR TITLE
Fix uninitialized MonoError in mono_basic_block_split

### DIFF
--- a/mono/metadata/mono-basic-block.c
+++ b/mono/metadata/mono-basic-block.c
@@ -240,6 +240,8 @@ bb_split (MonoSimpleBasicBlock *first, MonoSimpleBasicBlock *hint, MonoSimpleBas
 {
 	MonoSimpleBasicBlock *res, *bb = first;
 
+	mono_error_init (error);
+
 	if (bb_idx_is_contained (hint, target)) {
 		first = hint;
 	} else if (hint->next && bb_idx_is_contained (hint->next, target)) {
@@ -335,6 +337,8 @@ bb_formation_il_pass (const unsigned char *start, const unsigned char *end, Mono
 	guint cli_addr, offset;
 	MonoSimpleBasicBlock *branch, *next, *current;
 	const MonoOpcode *opcode;
+
+	mono_error_init (error);
 
 	current = bb;
 
@@ -464,6 +468,9 @@ bb_formation_eh_pass (MonoMethodHeader *header, MonoSimpleBasicBlock *bb, MonoSi
 {
 	int i;
 	int end = header->code_size;
+
+	mono_error_init (error);
+
 	/*We must split at all points to verify for targets in the middle of an instruction*/
 	for (i = 0; i < header->num_clauses; ++i) {
 		MonoExceptionClause *clause = header->clauses + i;
@@ -519,6 +526,8 @@ mono_basic_block_split (MonoMethod *method, MonoError *error, MonoMethodHeader *
 {
 	MonoSimpleBasicBlock *bb, *root;
 	const unsigned char *start, *end;
+
+	mono_error_init (error);
 
 	start = header->code;
 	end = start + header->code_size;

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -89,6 +89,13 @@ mono_error_init_flags (MonoError *oerror, unsigned short flags)
 	error->flags = flags;
 }
 
+/**
+ * mono_error_init:
+ * @error: Pointer to MonoError struct to initialize
+ *
+ * Any function which takes a MonoError for purposes of reporting an error
+ * is required to call either this or mono_error_init_flags on entry.
+ */
 void
 mono_error_init (MonoError *error)
 {


### PR DESCRIPTION
Follow-up on PR #2781 which removed a mono_error_init leading to memory unsafety. This was causing crashes when verifying assemblies in the 4.4 branch although it does not seem to have caused any known problems in master for some reason.