### PR TITLE
[4.4.0][corlib] Type.GetType parser and resolver improvements

### DIFF
--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -218,7 +218,7 @@ namespace System {
 			if (typeName == null)
 				throw new ArgumentNullException ("typeName");
 
-			TypeSpec res = Parse (typeName, ref pos, false, false);
+			TypeSpec res = Parse (typeName, ref pos, false, true);
 			if (pos < typeName.Length)
 				throw new ArgumentException ("Count not parse the whole type name", "typeName");
 			return res;
@@ -287,7 +287,7 @@ namespace System {
 		{
 			Assembly asm = null;
 			if (assemblyResolver == null && typeResolver == null)
-				return Type.GetType (name.DisplayName, throwOnError, ignoreCase);
+				return Type.GetType (DisplayFullName, throwOnError, ignoreCase);
 
 			if (assembly_name != null) {
 				if (assemblyResolver != null)
@@ -376,6 +376,12 @@ namespace System {
 			pos = p;
 		}
 
+		static void BoundCheck (int idx, string s)
+		{
+			if (idx >= s.Length)
+				throw new ArgumentException ("Invalid generic arguments spec", "typeName");
+		}
+
 		static TypeIdentifier ParsedTypeIdentifier (string displayName)
 		{
 			return TypeIdentifiers.FromDisplay(displayName);
@@ -383,6 +389,17 @@ namespace System {
 
 		static TypeSpec Parse (string name, ref int p, bool is_recurse, bool allow_aqn)
 		{
+			// Invariants:
+			//  - On exit p, is updated to pos the current unconsumed character.
+			//
+			//  - The callee peeks at but does not consume delimiters following
+			//    recurisve parse (so for a recursive call like the args of "Foo[P,Q]"
+			//    we'll return with p either on ',' or on ']'.  If the name was aqn'd
+			//    "Foo[[P,assmblystuff],Q]" on return p with be on the ']' just
+			//    after the "assmblystuff")
+			//
+			//  - If allow_aqn is True, assembly qualification is optional.
+			//    If allow_aqn is False, assembly qualification is prohibited.
 			int pos = p;
 			int name_start;
 			bool in_modifiers = false;
@@ -450,18 +467,24 @@ namespace System {
 						data.AddModifier (new PointerSpec(pointer_level));
 						break;
 					case ',':
-						if (is_recurse) {
+						if (is_recurse && allow_aqn) {
 							int end = pos;
 							while (end < name.Length && name [end] != ']')
 								++end;
 							if (end >= name.Length)
 								throw new ArgumentException ("Unmatched ']' while parsing generic argument assembly name");
 							data.assembly_name = name.Substring (pos + 1, end - pos - 1).Trim ();
-							p = end + 1;
+							p = end;
 							return data;						
 						}
-						data.assembly_name = name.Substring (pos + 1).Trim ();
-						pos = name.Length;
+						if (is_recurse) {
+							p = pos;
+							return data;
+						}
+						if (allow_aqn) {
+							data.assembly_name = name.Substring (pos + 1).Trim ();
+							pos = name.Length;
+						}
 						break;
 					case '[':
 						if (data.is_byref)
@@ -482,11 +505,17 @@ namespace System {
 								if (aqn)
 									++pos; //skip '[' to the start of the type
 								args.Add (Parse (name, ref pos, true, aqn));
-								if (pos >= name.Length)
-									throw new ArgumentException ("Invalid generic arguments spec", "typeName");
+								BoundCheck (pos, name);
+								if (aqn) {
+									if (name [pos] == ']')
+										++pos;
+									else
+										throw new ArgumentException ("Unclosed assembly-qualified type name at " + name[pos], "typeName");
+									BoundCheck (pos, name);
+}
 
 								if (name [pos] == ']')
-										break;
+									break;
 								if (name [pos] == ',')
 									++pos; // skip ',' to the start of the next arg
 								else
@@ -523,7 +552,7 @@ namespace System {
 						break;
 					case ']':
 						if (is_recurse) {
-							p = pos + 1;
+							p = pos;
 							return data;
 						}
 						throw new ArgumentException ("Unmatched ']'", "typeName");

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1243,6 +1243,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase)
 	MonoType *type = NULL;
 	MonoAssembly *assembly = NULL;
 	gboolean type_resolve = FALSE;
+	MonoImage *rootimage = NULL;
 
 	/*
 	 * We must compute the calling assembly as type loading must happen under a metadata context.
@@ -1267,6 +1268,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase)
 	if (dest) {
 		assembly = dest->klass->image->assembly;
 		type_resolve = TRUE;
+		rootimage = assembly->image;
 	} else {
 		g_warning (G_STRLOC);
 	}
@@ -1274,18 +1276,26 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase)
 	if (info->assembly.name)
 		assembly = mono_assembly_load (&info->assembly, assembly ? assembly->basedir : NULL, NULL);
 
-
 	if (assembly) {
 		/* When loading from the current assembly, AppDomain.TypeResolve will not be called yet */
-		type = mono_reflection_get_type (assembly->image, info, ignoreCase, &type_resolve);
+		type = mono_reflection_get_type_checked (rootimage, assembly->image, info, ignoreCase, &type_resolve);
 	}
 
-	if (!info->assembly.name && !type) /* try mscorlib */
-		type = mono_reflection_get_type (NULL, info, ignoreCase, &type_resolve);
-
+	// XXXX - aleksey -
+	//  Say we're looking for System.Generic.Dict<int, Local>
+	//  we FAIL the get type above, because S.G.Dict isn't in assembly->image.  So we drop down here.
+	//  but then we FAIL AGAIN because now we pass null as the image and the rootimage and everything is
+	//  messed up when we go to construct the Local as the type arg...
+	//
+	// By contrast, if we started with Mine<System.Generic.Dict<int, Local>> we'd go in with assembly->image
+	// as the root and then even the detour into generics would still not screw us when we went to load Local.
+	if (!info->assembly.name && !type) {
+		/* try mscorlib */
+		type = mono_reflection_get_type_checked (rootimage, NULL, info, ignoreCase, &type_resolve);
+	}
 	if (assembly && !type && type_resolve) {
 		type_resolve = FALSE; /* This will invoke TypeResolve if not done in the first 'if' */
-		type = mono_reflection_get_type (assembly->image, info, ignoreCase, &type_resolve);
+		type = mono_reflection_get_type_checked (rootimage, assembly->image, info, ignoreCase, &type_resolve);
 	}
 
 	if (!type) 
@@ -3983,9 +3993,9 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssembly *as
 	}
 
 	if (module != NULL) {
-		if (module->image)
-			type = mono_reflection_get_type (module->image, &info, ignoreCase, &type_resolve);
-		else
+		if (module->image) {
+			type = mono_reflection_get_type_checked (module->image, module->image, &info, ignoreCase, &type_resolve);
+		} else
 			type = NULL;
 	}
 	else
@@ -3998,7 +4008,7 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssembly *as
 			if (abuilder->modules) {
 				for (i = 0; i < mono_array_length (abuilder->modules); ++i) {
 					MonoReflectionModuleBuilder *mb = mono_array_get (abuilder->modules, MonoReflectionModuleBuilder*, i);
-					type = mono_reflection_get_type (&mb->dynamic_image->image, &info, ignoreCase, &type_resolve);
+					type = mono_reflection_get_type_checked (&mb->dynamic_image->image, &mb->dynamic_image->image, &info, ignoreCase, &type_resolve);
 					if (type)
 						break;
 				}
@@ -4007,14 +4017,15 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssembly *as
 			if (!type && abuilder->loaded_modules) {
 				for (i = 0; i < mono_array_length (abuilder->loaded_modules); ++i) {
 					MonoReflectionModule *mod = mono_array_get (abuilder->loaded_modules, MonoReflectionModule*, i);
-					type = mono_reflection_get_type (mod->image, &info, ignoreCase, &type_resolve);
+					type = mono_reflection_get_type_checked (mod->image, mod->image, &info, ignoreCase, &type_resolve);
 					if (type)
 						break;
 				}
 			}
 		}
-		else
-			type = mono_reflection_get_type (assembly->assembly->image, &info, ignoreCase, &type_resolve);
+		else {
+			type = mono_reflection_get_type_checked (assembly->assembly->image, assembly->assembly->image, &info, ignoreCase, &type_resolve);
+		}
 	g_free (str);
 	mono_reflection_free_type_info (&info);
 	if (!type) {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1221,13 +1221,14 @@ get_caller_no_reflection (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed
 	if (m->wrapper_type != MONO_WRAPPER_NONE)
 		return FALSE;
 
-	if (m->klass->image == mono_defaults.corlib && !strcmp (m->klass->name_space, "System.Reflection"))
-		return FALSE;
-
 	if (m == *dest) {
 		*dest = NULL;
 		return FALSE;
 	}
+
+	if (m->klass->image == mono_defaults.corlib && !strcmp (m->klass->name_space, "System.Reflection"))
+		return FALSE;
+
 	if (!(*dest)) {
 		*dest = m;
 		return TRUE;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1236,6 +1236,34 @@ get_caller_no_reflection (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed
 	return FALSE;
 }
 
+static gboolean
+get_caller_no_system_or_reflection (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed, gpointer data)
+{
+	MonoMethod **dest = (MonoMethod **)data;
+
+	/* skip unmanaged frames */
+	if (!managed)
+		return FALSE;
+
+	if (m->wrapper_type != MONO_WRAPPER_NONE)
+		return FALSE;
+
+	if (m == *dest) {
+		*dest = NULL;
+		return FALSE;
+	}
+
+	if (m->klass->image == mono_defaults.corlib && ((!strcmp (m->klass->name_space, "System.Reflection"))
+							|| (!strcmp (m->klass->name_space, "System"))))
+		return FALSE;
+
+	if (!(*dest)) {
+		*dest = m;
+		return TRUE;
+	}
+	return FALSE;
+}
+
 static MonoReflectionType *
 type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase)
 {
@@ -1254,9 +1282,20 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase)
 	m = mono_method_get_last_managed ();
 	dest = m;
 
-	mono_stack_walk_no_il (get_caller_no_reflection, &dest);
+	/* Ugly hack: type_from_parsed_name is called from
+	 * System.Type.internal_from_name, which is called most
+	 * directly from System.Type.GetType(string,bool,bool) but
+	 * also indirectly from places such as
+	 * System.Type.GetType(string,func,func) (via
+	 * System.TypeNameParser.GetType and System.TypeSpec.Resolve)
+	 * so we need to skip over all of those to find the true caller.
+	 *
+	 * It would be nice if we had stack marks.
+	 */
+	mono_stack_walk_no_il (get_caller_no_system_or_reflection, &dest);
 	if (!dest)
 		dest = m;
+
 
 	/*
 	 * FIXME: mono_method_get_last_managed() sometimes returns NULL, thus
@@ -1345,10 +1384,10 @@ ves_icall_type_from_name (MonoString *name,
 	/* mono_reflection_parse_type() mangles the string */
 	if (!parsedOk) {
 		mono_reflection_free_type_info (&info);
-		g_free (str);
 		if (throwOnError) {
 			mono_set_pending_exception(mono_get_exception_argument("typeName", "failed parse"));
 		}
+		g_free (str);
 		return NULL;
 	}
 

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -8,6 +8,9 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-error.h>
 
+MonoType*
+mono_reflection_get_type_checked (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, mono_bool ignorecase, mono_bool *type_resolve);
+
 MonoObject*
 mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass, MonoError *error);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -7955,6 +7955,23 @@ mono_reflection_get_type (MonoImage* image, MonoTypeNameParse *info, gboolean ig
 	return mono_reflection_get_type_with_rootimage(image, image, info, ignorecase, type_resolve);
 }
 
+/**
+ * mono_reflection_get_type_checked:
+ * @rootimage: the image of the currently active managed caller
+ * @image: a metadata context
+ * @info: type description structure
+ * @ignorecase: flag for case-insensitive string compares
+ * @type_resolve: whenever type resolve was already tried
+ *
+ * Build a MonoType from the type description in @info. On failure returns NULL.
+ *
+ */
+MonoType*
+mono_reflection_get_type_checked (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve) {
+	return mono_reflection_get_type_with_rootimage (rootimage, image, info, ignorecase, type_resolve);
+}
+
+
 static MonoType*
 mono_reflection_get_type_internal_dynamic (MonoImage *rootimage, MonoAssembly *assembly, MonoTypeNameParse *info, gboolean ignorecase)
 {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -62,6 +62,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/runtime.h>
 #include <mono/metadata/verify-internals.h>
+#include <mono/metadata/reflection-internals.h>
 #include <mono/utils/mono-coop-mutex.h>
 #include <mono/utils/mono-coop-semaphore.h>
 #include <mono/utils/mono-error-internals.h>
@@ -7229,7 +7230,8 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 
 				if (ass->image) {
 					type_resolve = TRUE;
-					t = mono_reflection_get_type (ass->image, &info, ignore_case, &type_resolve);
+					/* FIXME really okay to call while holding locks? */
+					t = mono_reflection_get_type_checked (ass->image, ass->image, &info, ignore_case, &type_resolve);
 					if (t) {
 						g_ptr_array_add (res_classes, mono_type_get_class (t));
 						g_ptr_array_add (res_domains, domain);
@@ -7651,7 +7653,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		} else {
 			if (info.assembly.name)
 				NOT_IMPLEMENTED;
-			t = mono_reflection_get_type (ass->image, &info, ignorecase, &type_resolve);
+			t = mono_reflection_get_type_checked (ass->image, ass->image, &info, ignorecase, &type_resolve);
 		}
 		buffer_add_typeid (buf, domain, t ? mono_class_from_mono_type (t) : NULL);
 		mono_reflection_free_type_info (&info);


### PR DESCRIPTION
*This is a backport of #2841 to the mono-4.4.0-branch.*

We have two type parsers the one invoked by `Type.GetType(string)` (and some others) which is implemented in C in `reflection.c`, and the one invoked by `Type.GetType(string, Func<...>, Func<...>)` implemented in managed code as `System.TypeSpec`.

In both cases `string→Type` conversion goes in two stages: parsing and resolution.  Parsing just changes the string into an AST.  And resolution crawls the AST and constructs the appropriate types.

This fixes [Bugzilla #40060](https://bugzilla.xamarin.com/show_bug.cgi?id=40060)

1. Fix the resolver on the native side for types like `"System.Generic.Collections.Dictionary[System.Int32,MyType]"` where the generic type is from corlib and a type argument is from the current assembly.
2. Fix `get_caller_no_reflection` to work correctly when the call stack has a System.Reflection method as the immediate caller of the icall.
3. Fix the resolver on the native side to work when it's called from corlib's System namespace, not just System.Reflection.
4. Fix the managed parser to work with types like `"MyGeneric[MyType]"` where the generic argument is not an assembly qualified name or there's a mixture of aqn and non-aqn type arguments.  Also rationalize how the code handles assembly qualification in general.
5. Test cases
