### PR TITLE
[configure] Also check that inet_pton is defined when building for Windows.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2318,6 +2318,9 @@ else
 		#include <winsock2.h>
 		#include <ws2tcpip.h>
 	], [
+		#ifndef inet_pton
+		(void) inet_pton;
+		#endif
 		inet_pton (0, NULL, NULL);
 	], [
 		# Yes, we have it...


### PR DESCRIPTION
The version of mingw-w64 on Debian wheezy has this symbol in its libraries
but not its headers.