### PR TITLE
[profiler] Fix usage of the lock-free queue API.

### DIFF
--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -3516,7 +3516,7 @@ count_queue (MonoLockFreeQueue *queue)
 
 	while ((node = mono_lock_free_queue_dequeue (queue))) {
 		count++;
-		mono_lock_free_queue_node_free (node);
+		mono_thread_hazardous_try_free (node, free);
 	}
 
 	return count;
@@ -4352,7 +4352,7 @@ handle_writer_queue_entry (MonoProfiler *prof)
 
 		dump_buffer (prof, entry->buffer);
 
-		free (entry);
+		mono_thread_hazardous_try_free (entry, free);
 
 		return TRUE;
 	}

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -4364,7 +4364,6 @@ static void *
 writer_thread (void *arg)
 {
 	MonoProfiler *prof = (MonoProfiler *)arg;
-	WriterQueueEntry *entry;
 
 	mono_threads_attach_tools_thread ();
 	mono_thread_info_set_name (mono_native_thread_id_get (), "Profiler writer");

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -10,6 +10,7 @@
 #include <glib.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-membar.h>
+#include <mono/utils/mono-publib.h>
 
 #define HAZARD_POINTER_COUNT 3
 
@@ -29,7 +30,7 @@ typedef enum {
 	HAZARD_FREE_ASYNC_CTX,
 } HazardFreeContext;
 
-gboolean mono_thread_hazardous_try_free (gpointer p, MonoHazardousFreeFunc free_func);
+MONO_API gboolean mono_thread_hazardous_try_free (gpointer p, MonoHazardousFreeFunc free_func);
 void mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func);
 
 void mono_thread_hazardous_try_free_all (void);


### PR DESCRIPTION
* Free nodes hazardously.
* No need to unpoison nodes since we're not reusing them.
* Fix memory leak when emptying coverage queues.