### PR TITLE
[profiler] Fix incorrect initial writer semaphore value.

### DIFF
--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -4488,7 +4488,7 @@ create_profiler (const char *filename, GPtrArray *filters)
 #endif
 
 	mono_lock_free_queue_init (&prof->writer_queue);
-	mono_os_sem_init (&prof->writer_queue_sem, 1);
+	mono_os_sem_init (&prof->writer_queue_sem, 0);
 
 	mono_os_mutex_init (&prof->method_table_mutex);
 	prof->method_table = mono_conc_hashtable_new (NULL, NULL);


### PR DESCRIPTION
This was used during debugging. I forgot to revert it back to 0 before posting
the pull request (#2838). This led to ~3-5% more CPU usage by the writer thread
than actually necessary; it now sits around 0-1% for typical workloads.