### PR TITLE
[runtime] Grab bag of MonoError fixes in object.c

### DIFF
--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -309,11 +309,16 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 		main_args = (MonoArray*)mono_array_new (domain, mono_defaults.string_class, 0);
 	}
 
-	g_free (agent);
-
 	pa [0] = main_args;
 	mono_runtime_try_invoke (method, NULL, pa, exc, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (!is_ok (&error)) {
+		g_print ("The entry point method of assembly '%s' could not be executed due to %s\n", agent, mono_error_get_message (&error));
+		mono_error_cleanup (&error);
+		g_free (agent);
+		return 1;
+	}
+
+	g_free (agent);
 
 	return 0;
 }

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -302,12 +302,19 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 		return 1;
 	}
 	
-	if (args) {
-		main_args = (MonoArray*)mono_array_new (domain, mono_defaults.string_class, 1);
-		mono_array_set (main_args, MonoString*, 0, mono_string_new (domain, args));
-	} else {
-		main_args = (MonoArray*)mono_array_new (domain, mono_defaults.string_class, 0);
+	
+	main_args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, (args == NULL) ? 0 : 1, &error);
+	if (main_args == NULL) {
+		g_print ("Could not allocate main method args due to %s\n", mono_error_get_message (&error));
+		mono_error_cleanup (&error);
+		g_free (agent);
+		return 1;
 	}
+
+	if (args) {
+		mono_array_set (main_args, MonoString*, 0, mono_string_new (domain, args));
+	}
+
 
 	pa [0] = main_args;
 	mono_runtime_try_invoke (method, NULL, pa, exc, &error);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1005,7 +1005,7 @@ gpointer
 mono_lookup_dynamic_token_class (MonoImage *image, guint32 token, gboolean check_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
 
 gpointer
-mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper);
+mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper, MonoError *error);
 
 gpointer
 mono_runtime_create_delegate_trampoline (MonoClass *klass);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -224,7 +224,7 @@ ICALL(ENUM_7, "get_value", ves_icall_System_Enum_get_value)
 
 ICALL_TYPE(ENV, "System.Environment", ENV_1)
 ICALL(ENV_1, "Exit", ves_icall_System_Environment_Exit)
-ICALL(ENV_2, "GetCommandLineArgs", mono_runtime_get_main_args)
+ICALL(ENV_2, "GetCommandLineArgs", ves_icall_System_Environment_GetCoomandLineArgs)
 ICALL(ENV_3, "GetEnvironmentVariableNames", ves_icall_System_Environment_GetEnvironmentVariableNames)
 ICALL(ENV_31, "GetIs64BitOperatingSystem", ves_icall_System_Environment_GetIs64BitOperatingSystem)
 ICALL(ENV_4, "GetLogicalDrivesInternal", ves_icall_System_Environment_GetLogicalDrives )

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -104,7 +104,7 @@ ICALL(ARGI_4, "Setup",                            mono_ArgIterator_Setup)
 
 ICALL_TYPE(ARRAY, "System.Array", ARRAY_1)
 ICALL(ARRAY_1, "ClearInternal",    ves_icall_System_Array_ClearInternal)
-ICALL(ARRAY_2, "Clone",            mono_array_clone)
+ICALL(ARRAY_2, "Clone",            ves_icall_System_Array_Clone)
 ICALL(ARRAY_3, "CreateInstanceImpl",   ves_icall_System_Array_CreateInstanceImpl)
 ICALL(ARRAY_14, "CreateInstanceImpl64",   ves_icall_System_Array_CreateInstanceImpl64)
 ICALL(ARRAY_4, "FastCopy",         ves_icall_System_Array_FastCopy)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6435,8 +6435,10 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionType *type, Mon
 	} else {
 		if (target && method->flags & METHOD_ATTRIBUTE_VIRTUAL && method->klass != mono_object_class (target))
 			method = mono_object_get_virtual_method (target, method);
-		func = mono_create_ftnptr (mono_domain_get (),
-			mono_runtime_create_jump_trampoline (mono_domain_get (), method, TRUE));
+		gpointer trampoline = mono_runtime_create_jump_trampoline (mono_domain_get (), method, TRUE, &error);
+		if (mono_error_set_pending_exception (&error))
+			return NULL;
+		func = mono_create_ftnptr (mono_domain_get (), trampoline);
 	}
 
 	mono_delegate_ctor_with_method (delegate, target, func, method);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -713,6 +713,15 @@ ves_icall_System_Array_ClearInternal (MonoArray *arr, int idx, int length)
 	mono_gc_bzero_atomic (mono_array_addr_with_size_fast (arr, sz, idx), length * sz);
 }
 
+ICALL_EXPORT MonoArray*
+ves_icall_System_Array_Clone (MonoArray *arr)
+{
+	MonoError error;
+	MonoArray *result = mono_array_clone_checked (arr, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
+}
+
 ICALL_EXPORT gboolean
 ves_icall_System_Array_FastCopy (MonoArray *source, int source_idx, MonoArray* dest, int dest_idx, int length)
 {

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -92,10 +92,12 @@ region_name_locator (const void *a, const void *b)
 }
 
 static MonoArray*
-create_group_sizes_array (const gint *gs, gint ml)
+create_group_sizes_array (const gint *gs, gint ml, MonoError *error)
 {
 	MonoArray *ret;
 	int i, len = 0;
+
+	mono_error_init (error);
 
 	for (i = 0; i < ml; i++) {
 		if (gs [i] == -1)
@@ -104,7 +106,8 @@ create_group_sizes_array (const gint *gs, gint ml)
 	}
 	
 	ret = mono_array_new_cached (mono_domain_get (),
-			mono_get_int32_class (), len);
+				     mono_get_int32_class (), len, error);
+	return_val_if_nok (error, NULL);
 
 	for(i = 0; i < len; i++)
 		mono_array_set (ret, gint32, i, gs [i]);
@@ -113,18 +116,21 @@ create_group_sizes_array (const gint *gs, gint ml)
 }
 
 static MonoArray*
-create_names_array_idx (const guint16 *names, int ml)
+create_names_array_idx (const guint16 *names, int ml, MonoError *error)
 {
 	MonoArray *ret;
 	MonoDomain *domain;
 	int i;
+
+	mono_error_init (error);
 
 	if (names == NULL)
 		return NULL;
 
 	domain = mono_domain_get ();
 
-	ret = mono_array_new_cached (mono_domain_get (), mono_get_string_class (), ml);
+	ret = mono_array_new_cached (mono_domain_get (), mono_get_string_class (), ml, error);
+	return_val_if_nok (error, NULL);
 
 	for(i = 0; i < ml; i++)
 		mono_array_setref (ret, i, mono_string_new (domain, idx2string (names [i])));
@@ -133,11 +139,13 @@ create_names_array_idx (const guint16 *names, int ml)
 }
 
 static MonoArray*
-create_names_array_idx_dynamic (const guint16 *names, int ml)
+create_names_array_idx_dynamic (const guint16 *names, int ml, MonoError *error)
 {
 	MonoArray *ret;
 	MonoDomain *domain;
 	int i, len = 0;
+
+	mono_error_init (error);
 
 	if (names == NULL)
 		return NULL;
@@ -150,7 +158,8 @@ create_names_array_idx_dynamic (const guint16 *names, int ml)
 		len++;
 	}
 
-	ret = mono_array_new_cached (mono_domain_get (), mono_get_string_class (), len);
+	ret = mono_array_new_cached (mono_domain_get (), mono_get_string_class (), len, error);
+	return_val_if_nok (error, NULL);
 
 	for(i = 0; i < len; i++)
 		mono_array_setref (ret, i, mono_string_new (domain, idx2string (names [i])));
@@ -161,6 +170,7 @@ create_names_array_idx_dynamic (const guint16 *names, int ml)
 MonoBoolean
 ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData *this_obj, MonoString *name, gint32 calendar_index)
 {
+	MonoError error;
 	MonoDomain *domain;
 	const DateTimeFormatEntry *dfe;
 	const CultureInfoNameEntry *ne;
@@ -181,24 +191,52 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 	domain = mono_domain_get ();
 
 	MONO_OBJECT_SETREF (this_obj, NativeName, mono_string_new (domain, idx2string (ci->nativename)));
-	MONO_OBJECT_SETREF (this_obj, ShortDatePatterns, create_names_array_idx_dynamic (dfe->short_date_patterns,
-			NUM_SHORT_DATE_PATTERNS));
-	MONO_OBJECT_SETREF (this_obj, YearMonthPatterns, create_names_array_idx_dynamic (dfe->year_month_patterns,
-			NUM_YEAR_MONTH_PATTERNS));
+	MonoArray *short_date_patterns = create_names_array_idx_dynamic (dfe->short_date_patterns,
+									 NUM_SHORT_DATE_PATTERNS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, ShortDatePatterns, short_date_patterns);
+	MonoArray *year_month_patterns =create_names_array_idx_dynamic (dfe->year_month_patterns,
+									NUM_YEAR_MONTH_PATTERNS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, YearMonthPatterns, year_month_patterns);
 
-	MONO_OBJECT_SETREF (this_obj, LongDatePatterns, create_names_array_idx_dynamic (dfe->long_date_patterns,
-			NUM_LONG_DATE_PATTERNS));
+	MonoArray *long_date_patterns = create_names_array_idx_dynamic (dfe->long_date_patterns,
+									NUM_LONG_DATE_PATTERNS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, LongDatePatterns, long_date_patterns);
+
 	MONO_OBJECT_SETREF (this_obj, MonthDayPattern, mono_string_new (domain, idx2string (dfe->month_day_pattern)));
 
-	MONO_OBJECT_SETREF (this_obj, DayNames, create_names_array_idx (dfe->day_names, NUM_DAYS));
-	MONO_OBJECT_SETREF (this_obj, AbbreviatedDayNames, create_names_array_idx (dfe->abbreviated_day_names, 
-			NUM_DAYS));
-	MONO_OBJECT_SETREF (this_obj, SuperShortDayNames, create_names_array_idx (dfe->shortest_day_names, NUM_DAYS));
-	MONO_OBJECT_SETREF (this_obj, MonthNames, create_names_array_idx (dfe->month_names, NUM_MONTHS));
-	MONO_OBJECT_SETREF (this_obj, AbbreviatedMonthNames, create_names_array_idx (dfe->abbreviated_month_names,
-			NUM_MONTHS));
-	MONO_OBJECT_SETREF (this_obj, GenitiveMonthNames, create_names_array_idx (dfe->month_genitive_names, NUM_MONTHS));
-	MONO_OBJECT_SETREF (this_obj, GenitiveAbbreviatedMonthNames, create_names_array_idx (dfe->abbreviated_month_genitive_names, NUM_MONTHS));
+	MonoArray *day_names = create_names_array_idx (dfe->day_names, NUM_DAYS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, DayNames, day_names);
+
+	MonoArray *abbr_day_names = create_names_array_idx (dfe->abbreviated_day_names, 
+							    NUM_DAYS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, AbbreviatedDayNames, abbr_day_names);
+
+	MonoArray *ss_day_names = create_names_array_idx (dfe->shortest_day_names, NUM_DAYS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, SuperShortDayNames, ss_day_names);
+
+	MonoArray *month_names = create_names_array_idx (dfe->month_names, NUM_MONTHS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, MonthNames, month_names);
+
+	MonoArray *abbr_mon_names = create_names_array_idx (dfe->abbreviated_month_names,
+							    NUM_MONTHS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, AbbreviatedMonthNames, abbr_mon_names);
+
+	
+	MonoArray *gen_month_names = create_names_array_idx (dfe->month_genitive_names, NUM_MONTHS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, GenitiveMonthNames, gen_month_names);
+
+	MonoArray *gen_abbr_mon_names = create_names_array_idx (dfe->abbreviated_month_genitive_names, NUM_MONTHS, &error);
+	return_val_and_set_pending_if_nok (&error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, GenitiveAbbreviatedMonthNames, gen_abbr_mon_names);
 
 	return TRUE;
 }
@@ -206,6 +244,7 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 void
 ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *this_obj, gint32 datetime_index)
 {
+	MonoError error;
 	MonoDomain *domain;
 	const DateTimeFormatEntry *dfe;
 
@@ -218,10 +257,18 @@ ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *t
 	MONO_OBJECT_SETREF (this_obj, AMDesignator, mono_string_new (domain, idx2string (dfe->am_designator)));
 	MONO_OBJECT_SETREF (this_obj, PMDesignator, mono_string_new (domain, idx2string (dfe->pm_designator)));
 	MONO_OBJECT_SETREF (this_obj, TimeSeparator, mono_string_new (domain, idx2string (dfe->time_separator)));
-	MONO_OBJECT_SETREF (this_obj, LongTimePatterns, create_names_array_idx_dynamic (dfe->long_time_patterns,
-			NUM_LONG_TIME_PATTERNS));
-	MONO_OBJECT_SETREF (this_obj, ShortTimePatterns, create_names_array_idx_dynamic (dfe->short_time_patterns,
-			NUM_SHORT_TIME_PATTERNS));
+
+	MonoArray *long_time_patterns = create_names_array_idx_dynamic (dfe->long_time_patterns,
+									NUM_LONG_TIME_PATTERNS, &error);
+	if (mono_error_set_pending_exception (&error))
+		return;
+	MONO_OBJECT_SETREF (this_obj, LongTimePatterns, long_time_patterns);
+
+	MonoArray *short_time_patterns = create_names_array_idx_dynamic (dfe->short_time_patterns,
+									 NUM_SHORT_TIME_PATTERNS, &error);
+	if (mono_error_set_pending_exception (&error))
+		return;
+	MONO_OBJECT_SETREF (this_obj, ShortTimePatterns, short_time_patterns);
 	this_obj->FirstDayOfWeek = dfe->first_day_of_week;
 	this_obj->CalendarWeekRule = dfe->calendar_week_rule;
 }
@@ -229,6 +276,7 @@ ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *t
 void
 ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInfo* number, gint32 number_index)
 {
+	MonoError error;
 	MonoDomain *domain;
 	const NumberFormatEntry *nfe;
 
@@ -243,8 +291,11 @@ ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInf
 			idx2string (nfe->currency_decimal_separator)));
 	MONO_OBJECT_SETREF (number, currencyGroupSeparator, mono_string_new (domain,
 			idx2string (nfe->currency_group_separator)));
-	MONO_OBJECT_SETREF (number, currencyGroupSizes, create_group_sizes_array (nfe->currency_group_sizes,
-			GROUP_SIZE));
+	MonoArray *currency_sizes_arr = create_group_sizes_array (nfe->currency_group_sizes,
+								  GROUP_SIZE, &error);
+	if (mono_error_set_pending_exception (&error))
+		return;
+	MONO_OBJECT_SETREF (number, currencyGroupSizes, currency_sizes_arr);
 	number->currencyNegativePattern = nfe->currency_negative_pattern;
 	number->currencyPositivePattern = nfe->currency_positive_pattern;
 	MONO_OBJECT_SETREF (number, currencySymbol, mono_string_new (domain, idx2string (nfe->currency_symbol)));
@@ -256,8 +307,11 @@ ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInf
 	MONO_OBJECT_SETREF (number, numberDecimalSeparator, mono_string_new (domain,
 			idx2string (nfe->number_decimal_separator)));
 	MONO_OBJECT_SETREF (number, numberGroupSeparator, mono_string_new (domain, idx2string (nfe->number_group_separator)));
-	MONO_OBJECT_SETREF (number, numberGroupSizes, create_group_sizes_array (nfe->number_group_sizes,
-			GROUP_SIZE));
+	MonoArray *number_sizes_arr = create_group_sizes_array (nfe->number_group_sizes,
+								GROUP_SIZE, &error);
+	if (mono_error_set_pending_exception (&error))
+		return;
+	MONO_OBJECT_SETREF (number, numberGroupSizes, number_sizes_arr);
 	number->numberNegativePattern = nfe->number_negative_pattern;
 	number->percentNegativePattern = nfe->percent_negative_pattern;
 	number->percentPositivePattern = nfe->percent_positive_pattern;
@@ -269,9 +323,11 @@ ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInf
 }
 
 static MonoBoolean
-construct_culture (MonoCultureInfo *this_obj, const CultureInfoEntry *ci)
+construct_culture (MonoCultureInfo *this_obj, const CultureInfoEntry *ci, MonoError *error)
 {
 	MonoDomain *domain = mono_domain_get ();
+
+	mono_error_init (error);
 
 	this_obj->lcid = ci->lcid;
 	MONO_OBJECT_SETREF (this_obj, name, mono_string_new (domain, idx2string (ci->name)));
@@ -284,7 +340,10 @@ construct_culture (MonoCultureInfo *this_obj, const CultureInfoEntry *ci)
 	// It's null for neutral cultures
 	if (ci->territory > 0)
 		MONO_OBJECT_SETREF (this_obj, territory, mono_string_new (domain, idx2string (ci->territory)));
-	MONO_OBJECT_SETREF (this_obj, native_calendar_names, create_names_array_idx (ci->native_calendar_names, NUM_CALENDARS));
+
+	MonoArray *native_calendar_names = create_names_array_idx (ci->native_calendar_names, NUM_CALENDARS, error);
+	return_val_if_nok (error, FALSE);
+	MONO_OBJECT_SETREF (this_obj, native_calendar_names, native_calendar_names);
 	this_obj->parent_lcid = ci->parent_lcid;
 	this_obj->datetime_index = ci->datetime_format_index;
 	this_obj->number_index = ci->number_format_index;
@@ -493,19 +552,25 @@ MonoBoolean
 ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_lcid (MonoCultureInfo *this_obj,
 		gint lcid)
 {
+	MonoError error;
 	const CultureInfoEntry *ci;
 	
 	ci = culture_info_entry_from_lcid (lcid);
 	if(ci == NULL)
 		return FALSE;
 
-	return construct_culture (this_obj, ci);
+	if (!construct_culture (this_obj, ci, &error)) {
+		mono_error_set_pending_exception (&error);
+		return FALSE;
+	}
+	return TRUE;
 }
 
 MonoBoolean
 ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (MonoCultureInfo *this_obj,
 		MonoString *name)
 {
+	MonoError error;
 	const CultureInfoNameEntry *ne;
 	char *n;
 	
@@ -520,7 +585,11 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (
 	}
 	g_free (n);
 
-	return construct_culture (this_obj, &culture_entries [ne->culture_entry_index]);
+	if (!construct_culture (this_obj, &culture_entries [ne->culture_entry_index], &error)) {
+		mono_error_set_pending_exception (&error);
+		return FALSE;
+	}
+	return TRUE;
 }
 /*
 MonoBoolean
@@ -620,7 +689,8 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 			if (!is_ok (&error)) goto fail;
 			mono_runtime_object_init_checked ((MonoObject *) culture, &error);
 			if (!is_ok (&error)) goto fail;
-			construct_culture (culture, ci);
+			if (!construct_culture (culture, ci, &error))
+				goto fail;
 			culture->use_user_override = TRUE;
 			mono_array_setref (ret, len++, culture);
 		}

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -601,7 +601,9 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 	if (neutral)
 		len++;
 
-	ret = mono_array_new (domain, klass, len);
+	ret = mono_array_new_checked (domain, klass, len, &error);
+	if (!is_ok (&error))
+		goto fail;
 
 	if (len == 0)
 		return ret;
@@ -642,13 +644,17 @@ int ves_icall_System_Globalization_CompareInfo_internal_compare (MonoCompareInfo
 
 void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo *this_obj, MonoSortKey *key, MonoString *source, gint32 options)
 {
+	MonoError error;
 	MonoArray *arr;
 	gint32 keylen, i;
 
 	keylen=mono_string_length (source);
 	
-	arr=mono_array_new (mono_domain_get (), mono_get_byte_class (),
-			    keylen);
+	arr=mono_array_new_checked (mono_domain_get (), mono_get_byte_class (),
+				    keylen, &error);
+	if (mono_error_set_pending_exception (&error))
+		return;
+
 	for(i=0; i<keylen; i++) {
 		mono_array_set (arr, guint8, i, mono_string_chars (source)[i]);
 	}

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -606,9 +606,11 @@ mono_delegate_free_ftnptr (MonoDelegate *delegate)
 	}
 }
 
+/* This is a JIT icall, it sets the pending exception and returns NULL on error */
 static MonoString *
 mono_string_from_byvalstr (const char *data, int max_len)
 {
+	MonoError error;
 	MonoDomain *domain = mono_domain_get ();
 	int len = 0;
 
@@ -618,7 +620,9 @@ mono_string_from_byvalstr (const char *data, int max_len)
 	while (len < max_len - 1 && data [len])
 		len++;
 
-	return mono_string_new_len (domain, data, len);
+	MonoString *result = mono_string_new_len_checked (domain, data, len, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 /* This is a JIT icall, it sets the pending exception and return NULL on error */
@@ -1126,10 +1130,14 @@ mono_string_to_byvalwstr (gpointer dst, MonoString *src, int size)
 	*((gunichar2 *) dst + len) = 0;
 }
 
+/* this is an icall, it sets the pending exception and returns NULL on error */
 static MonoString*
 mono_string_new_len_wrapper (const char *text, guint length)
 {
-	return mono_string_new_len (mono_domain_get (), text, length);
+	MonoError error;
+	MonoString *result = mono_string_new_len_checked (mono_domain_get (), text, length, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 #ifndef DISABLE_JIT
@@ -10507,12 +10515,15 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi (char *ptr)
 MonoString *
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (char *ptr, gint32 len)
 {
-	if (ptr == NULL) {
-		mono_set_pending_exception (mono_get_exception_argument_null ("ptr"));
-		return NULL;
-	} else {
-		return mono_string_new_len (mono_domain_get (), ptr, len);
-	}
+	MonoError error;
+	MonoString *result = NULL;
+	mono_error_init (&error);
+	if (ptr == NULL)
+		mono_error_set_argument_null (&error, "ptr", "");
+	else
+		result = mono_string_new_len_checked (mono_domain_get (), ptr, len, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 MonoString *

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1609,6 +1609,9 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 gboolean
 mono_property_set_value_checked (MonoProperty *prop, void *obj, void **params, MonoError *error);
 
+MonoObject*
+mono_property_get_value_checked (MonoProperty *prop, void *obj, void **params, MonoError *error);
+
 char *
 mono_string_to_utf8_ignore (MonoString *s);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1418,7 +1418,10 @@ mono_string_to_utf8_image (MonoImage *image, MonoString *s, MonoError *error);
 
 
 MonoArray*
-mono_array_clone_in_domain (MonoDomain *domain, MonoArray *array);
+mono_array_clone_in_domain (MonoDomain *domain, MonoArray *array, MonoError *error);
+
+MonoArray*
+mono_array_clone_checked (MonoArray *array, MonoError *error);
 
 void
 mono_array_full_copy (MonoArray *src, MonoArray *dest);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -80,18 +80,16 @@
 			}; \
 			tmp_klass; })
 /* eclass should be a run-time constant */
-#define mono_array_new_cached(domain, eclass, size) ({	\
-			MonoError __error;	\
+#define mono_array_new_cached(domain, eclass, size, error) ({	\
 			MonoVTable *__vtable = mono_class_vtable ((domain), mono_array_class_get_cached ((eclass), 1));	\
-			MonoArray *__arr = mono_array_new_specific_checked (__vtable, (size), &__error);	\
-			mono_error_raise_exception (&__error); /* FIXME don't raise here */	\
+			MonoArray *__arr = mono_array_new_specific_checked (__vtable, (size), (error)); \
 			__arr; })
 
 #else
 
 #define mono_class_get_field_from_name_cached(klass,name) mono_class_get_field_from_name ((klass), (name))
 #define mono_array_class_get_cached(eclass,rank) mono_array_class_get ((eclass), (rank))
-#define mono_array_new_cached(domain, eclass, size) mono_array_new_specific (mono_class_vtable ((domain), mono_array_class_get_cached ((eclass), 1)), (size))
+#define mono_array_new_cached(domain, eclass, size, error) mono_array_new_specific_checked (mono_class_vtable ((domain), mono_array_class_get_cached ((eclass), 1)), (size), (error))
 
 #endif
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1680,6 +1680,9 @@ MonoString *
 mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error);
 
 MonoString*
+mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error);
+
+MonoString*
 mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *merror);
 
 MonoString *

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1564,7 +1564,7 @@ gsize*
 mono_class_compute_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int *max_set, gboolean static_fields);
 
 MonoObject*
-mono_object_xdomain_representation (MonoObject *obj, MonoDomain *target_domain, MonoObject **exc);
+mono_object_xdomain_representation (MonoObject *obj, MonoDomain *target_domain, MonoError *error);
 
 gboolean
 mono_class_is_reflection_method_or_constructor (MonoClass *klass);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -600,7 +600,7 @@ MonoObject *
 ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult *ares);
 
 MonoWaitHandle *
-mono_wait_handle_new	    (MonoDomain *domain, HANDLE handle);
+mono_wait_handle_new	    (MonoDomain *domain, HANDLE handle, MonoError *error);
 
 HANDLE
 mono_wait_handle_get_handle (MonoWaitHandle *handle);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1430,10 +1430,16 @@ gboolean
 mono_array_calc_byte_len (MonoClass *klass, uintptr_t len, uintptr_t *res);
 
 MonoArray*
+mono_array_new_checked (MonoDomain *domain, MonoClass *eclass, uintptr_t n, MonoError *error);
+
+MonoArray*
 mono_array_new_full_checked (MonoDomain *domain, MonoClass *array_class, uintptr_t *lengths, intptr_t *lower_bounds, MonoError *error);
 
 MonoArray*
 mono_array_new_specific_checked (MonoVTable *vtable, uintptr_t n, MonoError *error);
+
+MonoArray*
+ves_icall_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n);
 
 MonoArray*
 ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n);
@@ -1649,7 +1655,7 @@ gboolean
 mono_error_set_pending_exception (MonoError *error);
 
 MonoArray *
-mono_glist_to_array (GList *list, MonoClass *eclass);
+mono_glist_to_array (GList *list, MonoClass *eclass, MonoError *error);
 
 MonoObject *
 mono_object_new_checked (MonoDomain *domain, MonoClass *klass, MonoError *error);
@@ -1690,6 +1696,9 @@ mono_runtime_try_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 MonoObject*
 mono_runtime_invoke_checked (MonoMethod *method, void *obj, void **params, MonoError *error);
 
+
+MonoArray*
+mono_runtime_get_main_args_checked (MonoError *error);
 
 #endif /* __MONO_OBJECT_INTERNALS_H__ */
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1606,6 +1606,9 @@ mono_vtable_get_static_field_data (MonoVTable *vt);
 MonoObject *
 mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, MonoObject *obj, MonoError *error);
 
+gboolean
+mono_property_set_value_checked (MonoProperty *prop, void *obj, void **params, MonoError *error);
+
 char *
 mono_string_to_utf8_ignore (MonoString *s);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -628,16 +628,14 @@ mono_compile_method (MonoMethod *method)
 }
 
 gpointer
-mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper)
+mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper, MonoError *error)
 {
-	MonoError error;
 	gpointer res;
 
 	MONO_REQ_GC_NEUTRAL_MODE;
 
-	res = callbacks.create_jump_trampoline (domain, method, add_sync_wrapper, &error);
-	if (!mono_error_ok (&error))
-		mono_error_raise_exception (&error); /* FIXME: Don't raise here */
+	mono_error_init (error);
+	res = callbacks.create_jump_trampoline (domain, method, add_sync_wrapper, error);
 	return res;
 }
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -979,7 +979,7 @@ ves_icall_string_alloc (int length)
 {
 	MonoError error;
 	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, &error);
-	mono_error_raise_exception (&error);
+	mono_error_set_pending_exception (&error);
 
 	return str;
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5180,11 +5180,11 @@ mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, guint32 token
 	MonoClass *klass;
 
 	klass = mono_class_get_checked (image, token, &error);
-	g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+	mono_error_assert_ok (&error);
 	
 	result = mono_object_new_checked (domain, klass, &error);
 
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_error_cleanup (&error); /* FIXME don't raise here */
 	return result;
 	
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3654,8 +3654,35 @@ mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 	if (exc && *exc == NULL && !mono_error_ok (&error)) {
 		*exc = (MonoObject*) mono_error_convert_to_exception (&error);
 	} else {
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_error_cleanup (&error);
 	}
+}
+
+/**
+ * mono_property_set_value_checked:
+ * @prop: MonoProperty to set
+ * @obj: instance object on which to act
+ * @params: parameters to pass to the propery
+ * @error: set on error
+ *
+ * Invokes the property's set method with the given arguments on the
+ * object instance obj (or NULL for static properties). 
+ * 
+ * Returns: TRUE on success.  On failure returns FALSE and sets @error.
+ * If an exception is thrown, it will be caught and returned via @error.
+ */
+gboolean
+mono_property_set_value_checked (MonoProperty *prop, void *obj, void **params, MonoError *error)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	MonoObject *exc;
+
+	mono_error_init (error);
+	do_runtime_invoke (prop->set, obj, params, &exc, error);
+	if (exc != NULL && is_ok (error))
+		mono_error_set_exception_instance (error, (MonoException*)exc);
+	return is_ok (error);
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5816,23 +5816,41 @@ mono_string_new_len (MonoDomain *domain, const char *text, guint length)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoError error;
+	MonoString *result = mono_string_new_len_checked (domain, text, length, &error);
+	mono_error_cleanup (&error);
+	return result;
+}
+
+/**
+ * mono_string_new_len_checked:
+ * @text: a pointer to an utf8 string
+ * @length: number of bytes in @text to consider
+ * @error: set on error
+ *
+ * Returns: A newly created string object which contains @text. On
+ * failure returns NULL and sets @error.
+ */
+MonoString*
+mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	mono_error_init (error);
+
 	GError *eg_error = NULL;
 	MonoString *o = NULL;
-	guint16 *ut;
+	guint16 *ut = NULL;
 	glong items_written;
-
-	mono_error_init (&error);
 
 	ut = eg_utf8_to_utf16_with_nuls (text, length, NULL, &items_written, &eg_error);
 
 	if (!eg_error)
-		o = mono_string_new_utf16_checked (domain, ut, items_written, &error);
+		o = mono_string_new_utf16_checked (domain, ut, items_written, error);
 	else 
 		g_error_free (eg_error);
 
 	g_free (ut);
 
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	return o;
 }
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4846,7 +4846,7 @@ ves_icall_object_new (MonoDomain *domain, MonoClass *klass)
 
 	MonoObject * result = mono_object_new_checked (domain, klass, &error);
 
-	mono_error_raise_exception (&error);
+	mono_error_set_pending_exception (&error);
 	return result;
 }
 
@@ -4970,7 +4970,7 @@ ves_icall_object_new_specific (MonoVTable *vtable)
 {
 	MonoError error;
 	MonoObject *o = mono_object_new_specific_checked (vtable, &error);
-	mono_error_raise_exception (&error);
+	mono_error_set_pending_exception (&error);
 
 	return o;
 }
@@ -5098,7 +5098,7 @@ ves_icall_object_new_fast (MonoVTable *vtable)
 {
 	MonoError error;
 	MonoObject *o = mono_object_new_fast_checked (vtable, &error);
-	mono_error_raise_exception (&error);
+	mono_error_set_pending_exception (&error);
 
 	return o;
 }
@@ -5582,7 +5582,7 @@ ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n)
 {
 	MonoError error;
 	MonoArray *arr = mono_array_new_specific_checked (vtable, n, &error);
-	mono_error_raise_exception (&error);
+	mono_error_set_pending_exception (&error);
 
 	return arr;
 }
@@ -6917,7 +6917,8 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 
 		if (ac->cb_method) {
 			mono_runtime_invoke_checked (ac->cb_method, ac->cb_target, (gpointer*) &ares, &error);
-			mono_error_raise_exception (&error);
+			if (mono_error_set_pending_exception (&error))
+				return NULL;
 		}
 	}
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -315,6 +315,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObject *obj);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -89,6 +89,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, uint32_t token);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray*
 mono_array_new		    (MonoDomain *domain, MonoClass *eclass, uintptr_t n);
 
@@ -261,6 +262,7 @@ mono_runtime_invoke_array   (MonoMethod *method, void *obj, MonoArray *params,
 MONO_API void*
 mono_method_get_unmanaged_thunk (MonoMethod *method);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray*
 mono_runtime_get_main_args  (void);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -72,13 +72,16 @@ MONO_API int            mono_string_length (MonoString *s);
 MONO_RT_EXTERNAL_ONLY MONO_API MonoObject *
 mono_object_new		    (MonoDomain *domain, MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_object_new_specific    (MonoVTable *vtable);
 
 /* can be used for classes without finalizer in non-profiling mode */
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_object_new_fast	    (MonoVTable *vtable);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_object_new_alloc_specific (MonoVTable *vtable);
 
@@ -89,10 +92,12 @@ mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, uint32_t toke
 MONO_API MonoArray*
 mono_array_new		    (MonoDomain *domain, MonoClass *eclass, uintptr_t n);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray*
 mono_array_new_full	    (MonoDomain *domain, MonoClass *array_class,
 			     uintptr_t *lengths, intptr_t *lower_bounds);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray *
 mono_array_new_specific	    (MonoVTable *vtable, uintptr_t n);
 
@@ -106,9 +111,11 @@ mono_array_addr_with_size   (MonoArray *array, int size, uintptr_t idx);
 MONO_API uintptr_t
 mono_array_length           (MonoArray *array);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
 mono_string_new_utf16	    (MonoDomain *domain, const mono_unichar2 *text, int32_t len);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
 mono_string_new_size	    (MonoDomain *domain, int32_t len);
 
@@ -131,6 +138,7 @@ mono_string_new_wrapper	    (const char *text);
 MONO_API MonoString*
 mono_string_new_len	    (MonoDomain *domain, const char *text, unsigned int length);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
 mono_string_new_utf32	    (MonoDomain *domain, const mono_unichar4 *text, int32_t len);
 
@@ -183,6 +191,7 @@ mono_object_get_class       (MonoObject *obj);
 MONO_API void*
 mono_object_unbox	    (MonoObject *obj);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_object_clone	    (MonoObject *obj);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -319,6 +319,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject*
 mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -136,6 +136,7 @@ mono_string_new		    (MonoDomain *domain, const char *text);
 MONO_API MonoString*
 mono_string_new_wrapper	    (const char *text);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
 mono_string_new_len	    (MonoDomain *domain, const char *text, unsigned int length);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -96,6 +96,7 @@ mono_array_new_full	    (MonoDomain *domain, MonoClass *array_class,
 MONO_API MonoArray *
 mono_array_new_specific	    (MonoVTable *vtable, uintptr_t n);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray*
 mono_array_clone	    (MonoArray *array);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -82,6 +82,7 @@ mono_object_new_fast	    (MonoVTable *vtable);
 MONO_API MonoObject *
 mono_object_new_alloc_specific (MonoVTable *vtable);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject *
 mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, uint32_t token);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -9066,7 +9066,7 @@ handle_enum:
 		}
 		slen = mono_metadata_decode_value (p, &p);
 		*end = p + slen;
-		return mono_string_new_len (mono_domain_get (), p, slen);
+		return mono_string_new_len_checked (mono_domain_get (), p, slen, error);
 	case MONO_TYPE_CLASS: {
 		MonoReflectionType *rt;
 		char *n;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -9531,9 +9531,13 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 			}
 
 
-			mono_property_set_value (prop, attr, pparams, NULL);
+			mono_property_set_value_checked (prop, attr, pparams, error);
 			if (!type_is_reference (prop_type))
 				g_free (pparams [0]);
+			if (!is_ok (error)) {
+				g_free (name);
+				goto fail;
+			}
 		}
 		g_free (name);
 	}

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -2038,7 +2038,9 @@ mono_marshal_xdomain_copy_value (MonoObject *val)
 		MonoArray *acopy;
 		MonoXDomainMarshalType mt = mono_get_xdomain_marshal_type (&(mono_object_class (val)->element_class->byval_arg));
 		if (mt == MONO_MARSHAL_SERIALIZE) return NULL;
-		acopy = mono_array_clone_in_domain (domain, (MonoArray *) val);
+		acopy = mono_array_clone_in_domain (domain, (MonoArray *) val, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
+
 		if (mt == MONO_MARSHAL_COPY) {
 			int i, len = mono_array_length (acopy);
 			for (i = 0; i < len; i++) {

--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -847,7 +847,8 @@ create_object_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 *werror
 	 * the length of the entire sockaddr_in/in6, including
 	 * sizeof (unsigned short) of the family */
 	/* We can't really avoid the +2 as all code below depends on this size - INCLUDING unix domain sockets.*/
-	data = mono_array_new_cached (domain, mono_get_byte_class (), sa_size + 2);
+	data = mono_array_new_cached (domain, mono_get_byte_class (), sa_size + 2, error);
+	return_val_if_nok (error, NULL);
 
 	/* The data buffer is laid out as follows:
 	 * bytes 0 and 1 are the address family

--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -1924,12 +1924,9 @@ ves_icall_System_Net_Sockets_Socket_Select_internal (MonoArray **sockets, gint32
 }
 
 static MonoObject*
-int_to_object (MonoDomain *domain, int val)
+int_to_object (MonoDomain *domain, int val, MonoError *error)
 {
-	MonoError error;
-	MonoObject *result = mono_value_box_checked (domain, mono_get_int32_class (), &val, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
-	return result;
+	return mono_value_box_checked (domain, mono_get_int32_class (), &val, error);
 }
 
 void
@@ -1976,7 +1973,8 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (SOCKET sock, g
 		return;
 	}
 	if (ret == -2) {
-		*obj_val = int_to_object (domain, 0);
+		*obj_val = int_to_object (domain, 0, &error);
+		mono_error_set_pending_exception (&error);
 		return;
 	}
 
@@ -2037,11 +2035,13 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (SOCKET sock, g
 		break;
 	case SocketOptionName_DontLinger:
 		/* construct a bool int in val - true if linger is off */
-		obj = int_to_object (domain, !linger.l_onoff);
+		obj = int_to_object (domain, !linger.l_onoff, &error);
+		mono_error_set_pending_exception (&error);
 		break;
 	case SocketOptionName_SendTimeout:
 	case SocketOptionName_ReceiveTimeout:
-		obj = int_to_object (domain, time_ms);
+		obj = int_to_object (domain, time_ms, &error);
+		mono_error_set_pending_exception (&error);
 		break;
 
 #ifdef SO_PEERCRED
@@ -2087,7 +2087,8 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (SOCKET sock, g
 		if (level == SocketOptionLevel_Socket && name == SocketOptionName_ExclusiveAddressUse)
 			val = val ? 0 : 1;
 #endif
-		obj = int_to_object (domain, val);
+		obj = int_to_object (domain, val, &error);
+		mono_error_set_pending_exception (&error);
 	}
 
 	*obj_val = obj;

--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -1361,6 +1361,7 @@ mono_threadpool_ms_begin_invoke (MonoDomain *domain, MonoObject *target, MonoMet
 MonoObject *
 mono_threadpool_ms_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, MonoObject **exc)
 {
+	MonoError error;
 	MonoAsyncCall *ac;
 
 	g_assert (exc);
@@ -1390,7 +1391,9 @@ mono_threadpool_ms_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, Mono
 		} else {
 			wait_event = CreateEvent (NULL, TRUE, FALSE, NULL);
 			g_assert(wait_event);
-			MONO_OBJECT_SETREF (ares, handle, (MonoObject*) mono_wait_handle_new (mono_object_domain (ares), wait_event));
+			MonoWaitHandle *wait_handle = mono_wait_handle_new (mono_object_domain (ares), wait_event, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+			MONO_OBJECT_SETREF (ares, handle, (MonoObject*) wait_handle);
 		}
 		mono_monitor_exit ((MonoObject*) ares);
 		MONO_PREPARE_BLOCKING;

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1520,7 +1520,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						MONO_INST_NEW (cfg, iargs [2], OP_MOVE);
 						iargs [2]->dreg = ins->sreg1;
 
-						dest = mono_emit_jit_icall (cfg, mono_array_new, iargs);
+						dest = mono_emit_jit_icall (cfg, ves_icall_array_new, iargs);
 						dest->dreg = ins->dreg;
 					} else {
 						MonoClass *array_class = mono_array_class_get (ins->inst_newa_class, 1);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11869,7 +11869,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					EMIT_NEW_CLASSCONST (cfg, iargs [1], klass);
 					iargs [2] = sp [0];
 
-					ins = mono_emit_jit_icall (cfg, mono_array_new, iargs);
+					ins = mono_emit_jit_icall (cfg, ves_icall_array_new, iargs);
 				} else {
 					/* Decompose later since it is needed by abcrem */
 					MonoClass *array_type = mono_array_class_get (klass, 1);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4050,7 +4050,7 @@ register_icalls (void)
 	register_icall (mono_helper_stelem_ref_check, "mono_helper_stelem_ref_check", "void object object", FALSE);
 	register_icall (ves_icall_object_new, "ves_icall_object_new", "object ptr ptr", FALSE);
 	register_icall (ves_icall_object_new_specific, "ves_icall_object_new_specific", "object ptr", FALSE);
-	register_icall (mono_array_new, "mono_array_new", "object ptr ptr int32", FALSE);
+	register_icall (ves_icall_array_new, "ves_icall_array_new", "object ptr ptr int32", FALSE);
 	register_icall (ves_icall_array_new_specific, "ves_icall_array_new_specific", "object ptr int32", FALSE);
 	register_icall (ves_icall_runtime_class_init, "ves_icall_runtime_class_init", "void ptr", FALSE);
 	register_icall (mono_ldftn, "mono_ldftn", "ptr ptr", FALSE);

--- a/mono/profiler/mono-profiler-iomap.c
+++ b/mono/profiler/mono-profiler-iomap.c
@@ -18,6 +18,7 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/class.h>
 #include <mono/metadata/class-internals.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/metadata/image.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/debug-helpers.h>
@@ -185,6 +186,7 @@ static inline guint32 calc_strings_hash (const gchar *str1, const gchar *str2, g
 
 static inline void print_report (const gchar *format, ...)
 {
+	MonoError error;
 	MonoClass *klass;
 	MonoProperty *prop;
 	MonoString *str;
@@ -199,7 +201,8 @@ static inline void print_report (const gchar *format, ...)
 	klass = mono_class_load_from_name (mono_get_corlib (), "System", "Environment");
 	mono_class_init (klass);
 	prop = mono_class_get_property_from_name (klass, "StackTrace");
-	str = (MonoString*)mono_property_get_value (prop, NULL, NULL, NULL);
+	str = (MonoString*)mono_property_get_value_checked (prop, NULL, NULL, &error);
+	mono_error_assert_ok (&error);
 	stack_trace = mono_string_to_utf8 (str);
 
 	fprintf (stdout, "-= Stack Trace =-\n%s\n\n", stack_trace);

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -42,6 +42,11 @@ typedef struct {
 #define return_if_nok(error) do { if (!is_ok ((error))) return; } while (0)
 #define return_val_if_nok(error,val) do { if (!is_ok ((error))) return (val); } while (0)
 
+/* Only use this in icalls */
+#define return_val_and_set_pending_if_nok(error,value)	\
+	if (mono_error_set_pending_exception ((error)))	\
+		return (value);
+
 void
 mono_error_assert_ok_pos (MonoError *error, const char* filename, int lineno) MONO_LLVM_INTERNAL;
 


### PR DESCRIPTION
Largest change is `mono_array_new` → `mono_array_new_checked`