### PR TITLE
Make versions script compatible to python3: Add () when using `print'.

### DIFF
--- a/acceptance-tests/versions.py
+++ b/acceptance-tests/versions.py
@@ -8,12 +8,12 @@ def find_module(submodules, name):
         if item["name"] == name:
             return item
 
-    print "Not found"
+    print("Not found")
     sys.exit(1)
 
 
 if len(sys.argv) < 2:
-    print "Usage: versions.py <command>"
+    print("Usage: versions.py <command>")
     sys.exit(1)
 
 CONFIG_FILE = "SUBMODULES.json"
@@ -23,16 +23,16 @@ submodules = json.load(open(CONFIG_FILE))
 
 if command == "get-rev":
     mod = find_module(submodules, sys.argv[2])
-    print mod["rev"]
+    print(mod["rev"])
 elif command == "get-url":
     mod = find_module(submodules, sys.argv[2])
-    print mod["url"]
+    print(mod["url"])
 elif command == "get-dir":
     mod = find_module(submodules, sys.argv[2])
-    print mod["directory"]
+    print(mod["directory"])
 elif command == "get-remote-branch":
     mod = find_module(submodules, sys.argv[2])
-    print mod["remote-branch"]
+    print(mod["remote-branch"])
 elif command == "set-rev":
     mod = find_module(submodules, sys.argv[2])
     mod["rev"] = sys.argv[3]
@@ -46,7 +46,7 @@ elif command == "set-remote-branch":
     mod["remote-branch"] = sys.argv[3]
     json.dump(submodules, open(CONFIG_FILE, "w"), indent = 2)
 elif command == "cat":
-    print json.dumps(submodules, indent = 2)
+    print(json.dumps(submodules, indent = 2))
 else:
-    print "Unknown command "" + command + ""."
+    print("Unknown command "" + command + "".")
     sys.exit(1)


### PR DESCRIPTION
Currently, `make` fails when running `acceptance-tests/versions.py` if the system defaults to `python3` instead of `python2`.

This PR makes the script compatible to `python3`