### PR TITLE
[sgen] Set ARCH_MIN_MS_BLOCK_SIZE to 64k on both ppc32 and ppc64.

### DIFF
--- a/mono/sgen/sgen-archdep.h
+++ b/mono/sgen/sgen-archdep.h
@@ -78,7 +78,7 @@
 
 /* MS_BLOCK_SIZE must be a multiple of the system pagesize, which for some
    architectures is 64k.  */
-#if defined(TARGET_POWERPC64)
+#if defined(TARGET_POWERPC) || defined(TARGET_POWERPC64)
 #define ARCH_MIN_MS_BLOCK_SIZE	(64*1024)
 #define ARCH_MIN_MS_BLOCK_SIZE_SHIFT	16
 #endif


### PR DESCRIPTION
This fixes a problem that was happening on Debian ppc32 build machines. Since
they are set up as a 32-bit userland on a 64-bit kernel, Mono would be compiled
with an ARCH_MIN_MS_BLOCK_SIZE value of 16k. However, at runtime, the system
page size would be 64k (due to the 64-bit kernel with PPC_64K_PAGES set).

Signed-off-by: `Alex Rønne Petersen <alexrp@xamarin.com>`