### PR TITLE
[WindowsBase] Serialization fix of Int32Rect, Point, Rect, Size, Vector, Matrix

### DIFF
--- a/mcs/class/WindowsBase/System.Windows.Media/Matrix.cs
+++ b/mcs/class/WindowsBase/System.Windows.Media/Matrix.cs
@@ -36,12 +36,12 @@ namespace System.Windows.Media {
 	[ValueSerializer (typeof (MatrixValueSerializer))]
 	public struct Matrix : IFormattable {
 
-		double m11;
-		double m12;
-		double m21;
-		double m22;
-		double offsetX;
-		double offsetY;
+		double _m11;
+		double _m12;
+		double _m21;
+		double _m22;
+		double _offsetX;
+		double _offsetY;
 
 		public Matrix (double m11,
 			       double m12,
@@ -50,12 +50,12 @@ namespace System.Windows.Media {
 			       double offsetX,
 			       double offsetY)
 		{
-			this.m11 = m11;
-			this.m12 = m12;
-			this.m21 = m21;
-			this.m22 = m22;
-			this.offsetX = offsetX;
-			this.offsetY = offsetY;
+			this._m11 = m11;
+			this._m12 = m12;
+			this._m21 = m21;
+			this._m22 = m22;
+			this._offsetX = offsetX;
+			this._offsetY = offsetY;
 		}
 
 		public void Append (Matrix matrix)
@@ -67,30 +67,30 @@ namespace System.Windows.Media {
 			double _offsetX;
 			double _offsetY;
 
-			_m11 = m11 * matrix.M11 + m12 * matrix.M21;
-			_m12 = m11 * matrix.M12 + m12 * matrix.M22;
-			_m21 = m21 * matrix.M11 + m22 * matrix.M21;
-			_m22 = m21 * matrix.M12 + m22 * matrix.M22;
+			_m11 = this._m11 * matrix.M11 + this._m12 * matrix.M21;
+			_m12 = this._m11 * matrix.M12 + this._m12 * matrix.M22;
+			_m21 = this._m21 * matrix.M11 + this._m22 * matrix.M21;
+			_m22 = this._m21 * matrix.M12 + this._m22 * matrix.M22;
 
-			_offsetX = offsetX * matrix.M11 + offsetY * matrix.M21 + matrix.OffsetX;
-			_offsetY = offsetX * matrix.M12 + offsetY * matrix.M22 + matrix.OffsetY;
+			_offsetX = this._offsetX * matrix.M11 + this._offsetY * matrix.M21 + matrix.OffsetX;
+			_offsetY = this._offsetX * matrix.M12 + this._offsetY * matrix.M22 + matrix.OffsetY;
 
-			m11 = _m11;
-			m12 = _m12;
-			m21 = _m21;
-			m22 = _m22;
-			offsetX = _offsetX;
-			offsetY = _offsetY;
+			this._m11 = _m11;
+			this._m12 = _m12;
+			this._m21 = _m21;
+			this._m22 = _m22;
+			this._offsetX = _offsetX;
+			this._offsetY = _offsetY;
 		}
 
 		public bool Equals (Matrix value)
 		{
-			return (m11 == value.M11 &&
-				m12 == value.M12 &&
-				m21 == value.M21 &&
-				m22 == value.M22 &&
-				offsetX == value.OffsetX &&
-				offsetY == value.OffsetY);
+			return (_m11 == value.M11 &&
+				_m12 == value.M12 &&
+				_m21 == value.M21 &&
+				_m22 == value.M22 &&
+				_offsetX == value.OffsetX &&
+				_offsetY == value.OffsetY);
 		}
 
 		public override bool Equals (object o)
@@ -121,20 +121,20 @@ namespace System.Windows.Media {
 
 			/* 1/(ad-bc)[d -b; -c a] */
 
-			double _m11 = m22;
-			double _m12 = -m12;
-			double _m21 = -m21;
-			double _m22 = m11;
+			double _m11 = this._m22;
+			double _m12 = -this._m12;
+			double _m21 = -this._m21;
+			double _m22 = this._m11;
 
-			double _offsetX = m21 * offsetY - m22 * offsetX;
-			double _offsetY = m12 * offsetX - m11 * offsetY;
+			double _offsetX = this._m21 * this._offsetY - this._m22 * this._offsetX;
+			double _offsetY = this._m12 * this._offsetX - this._m11 * this._offsetY;
 
-			m11 = _m11 / d;
-			m12 = _m12 / d;
-			m21 = _m21 / d;
-			m22 = _m22 / d;
-			offsetX = _offsetX / d;
-			offsetY = _offsetY / d;
+			this._m11 = _m11 / d;
+			this._m12 = _m12 / d;
+			this._m21 = _m21 / d;
+			this._m22 = _m22 / d;
+			this._offsetX = _offsetX / d;
+			this._offsetY = _offsetY / d;
 		}
 
 		public static Matrix Multiply (Matrix trans1,
@@ -179,20 +179,20 @@ namespace System.Windows.Media {
 			double _offsetX;
 			double _offsetY;
 
-			_m11 = matrix.M11 * m11 + matrix.M12 * m21;
-			_m12 = matrix.M11 * m12 + matrix.M12 * m22;
-			_m21 = matrix.M21 * m11 + matrix.M22 * m21;
-			_m22 = matrix.M21 * m12 + matrix.M22 * m22;
+			_m11 = matrix.M11 * this._m11 + matrix.M12 * this._m21;
+			_m12 = matrix.M11 * this._m12 + matrix.M12 * this._m22;
+			_m21 = matrix.M21 * this._m11 + matrix.M22 * this._m21;
+			_m22 = matrix.M21 * this._m12 + matrix.M22 * this._m22;
 
-			_offsetX = matrix.OffsetX * m11 + matrix.OffsetY * m21 + offsetX;
-			_offsetY = matrix.OffsetX * m12 + matrix.OffsetY * m22 + offsetY;
+			_offsetX = matrix.OffsetX * this._m11 + matrix.OffsetY * this._m21 + this._offsetX;
+			_offsetY = matrix.OffsetX * this._m12 + matrix.OffsetY * this._m22 + this._offsetY;
 
-			m11 = _m11;
-			m12 = _m12;
-			m21 = _m21;
-			m22 = _m22;
-			offsetX = _offsetX;
-			offsetY = _offsetY;
+			this._m11 = _m11;
+			this._m12 = _m12;
+			this._m21 = _m21;
+			this._m22 = _m22;
+			this._offsetX = _offsetX;
+			this._offsetY = _offsetY;
 		}
 
 		public void Rotate (double angle)
@@ -272,9 +272,9 @@ namespace System.Windows.Media {
 
 		public void SetIdentity ()
 		{
-			m11 = m22 = 1.0;
-			m12 = m21 = 0.0;
-			offsetX = offsetY = 0.0;
+			_m11 = _m22 = 1.0;
+			_m12 = _m21 = 0.0;
+			_offsetX = _offsetY = 0.0;
 		}
 
 		public void Skew (double skewX,
@@ -306,7 +306,7 @@ namespace System.Windows.Media {
 				return "Identity";
 			else
 				return string.Format ("{0},{1},{2},{3},{4},{5}",
-						      m11, m12, m21, m22, offsetX, offsetY);
+						      _m11, _m12, _m21, _m22, _offsetX, _offsetY);
 		}
 
 		public string ToString (IFormatProvider provider)
@@ -339,8 +339,8 @@ namespace System.Windows.Media {
 		public void Translate (double offsetX,
 				       double offsetY)
 		{
-			this.offsetX += offsetX;
-			this.offsetY += offsetY;
+			this._offsetX += offsetX;
+			this._offsetY += offsetY;
 		}
 
 		public void TranslatePrepend (double offsetX,
@@ -352,7 +352,7 @@ namespace System.Windows.Media {
 		}
 
 		public double Determinant {
-			get { return m11 * m22 - m12 * m21; }
+			get { return _m11 * _m22 - _m12 * _m21; }
 		}
 
 		public bool HasInverse {
@@ -368,28 +368,28 @@ namespace System.Windows.Media {
 		}
 
 		public double M11 { 
-			get { return m11; }
-			set { m11 = value; }
+			get { return _m11; }
+			set { _m11 = value; }
 		}
 		public double M12 { 
-			get { return m12; }
-			set { m12 = value; }
+			get { return _m12; }
+			set { _m12 = value; }
 		}
 		public double M21 { 
-			get { return m21; }
-			set { m21 = value; }
+			get { return _m21; }
+			set { _m21 = value; }
 		}
 		public double M22 { 
-			get { return m22; }
-			set { m22 = value; }
+			get { return _m22; }
+			set { _m22 = value; }
 		}
 		public double OffsetX { 
-			get { return offsetX; }
-			set { offsetX = value; }
+			get { return _offsetX; }
+			set { _offsetX = value; }
 		}
 		public double OffsetY { 
-			get { return offsetY; }
-			set { offsetY = value; }
+			get { return _offsetY; }
+			set { _offsetY = value; }
 		}
 	}
 

--- a/mcs/class/WindowsBase/System.Windows/Int32Rect.cs
+++ b/mcs/class/WindowsBase/System.Windows/Int32Rect.cs
@@ -38,14 +38,14 @@ namespace System.Windows {
 	[ValueSerializer (typeof(Int32RectValueSerializer))]
 	public struct Int32Rect : IFormattable
 	{
-		int x, y, width, height;
+		int _x, _y, _width, _height;
 
 		public Int32Rect (int x, int y, int width, int height)
 		{
-			this.x = x;
-			this.y = y;
-			this.width = width;
-			this.height = height;
+			this._x = x;
+			this._y = y;
+			this._width = width;
+			this._height = height;
 		}
 
 		public static bool operator != (Int32Rect int32Rect1, Int32Rect int32Rect2)
@@ -63,35 +63,35 @@ namespace System.Windows {
 		}
 
 		public int Height {
-			get { return height; }
-			set { height = value; }
+			get { return _height; }
+			set { _height = value; }
 		}
 
 		public bool IsEmpty {
-			get { return width == 0 && height == 0; }
+			get { return _width == 0 && _height == 0; }
 		}
 
 		public int Width {
-			get { return width; }
-			set { width = value; }
+			get { return _width; }
+			set { _width = value; }
 		}
 
 		public int X {
-			get { return x; }
-			set { x = value; }
+			get { return _x; }
+			set { _x = value; }
 		}
 
 		public int Y {
-			get { return y; }
-			set { y = value; }
+			get { return _y; }
+			set { _y = value; }
 		}
 
 		public bool Equals (Int32Rect value)
 		{
-			return (x == value.x &&
-				y == value.y &&
-				width == value.width &&
-				height == value.height);
+			return (_x == value._x &&
+				_y == value._y &&
+				_width == value._width &&
+				_height == value._height);
 		}
 
 		public override bool Equals (object o)
@@ -121,7 +121,7 @@ namespace System.Windows {
 		{
 			if (IsEmpty)
 				return "Empty";
-			return String.Format ("{0},{1},{2},{3}", x, y, width, height);
+			return String.Format ("{0},{1},{2},{3}", _x, _y, _width, _height);
 		}
 
 		public string ToString (IFormatProvider provider)

--- a/mcs/class/WindowsBase/System.Windows/Point.cs
+++ b/mcs/class/WindowsBase/System.Windows/Point.cs
@@ -39,18 +39,18 @@ namespace System.Windows {
 	{
 		public Point (double x, double y)
 		{
-			this.x = x;
-			this.y = y;
+			this._x = x;
+			this._y = y;
 		}
 
 		public double X {
-			get { return x; }
-			set { x = value; }
+			get { return _x; }
+			set { _x = value; }
 		}
 
 		public double Y {
-			get { return y; }
-			set { y = value; }
+			get { return _y; }
+			set { _y = value; }
 		}
 
 		public override bool Equals (object o)
@@ -62,19 +62,19 @@ namespace System.Windows {
 
 		public bool Equals (Point value)
 		{
-			return x == value.X && y == value.Y;
+			return _x == value.X && _y == value.Y;
 		}
 
 		public override int GetHashCode ()
 		{
-		    return (x.GetHashCode() ^ y.GetHashCode());
+		    return (_x.GetHashCode() ^ _y.GetHashCode());
 		}
 
 
 		public void Offset (double offsetX, double offsetY)
 		{
-			x += offsetX;
-			y += offsetY;
+			_x += offsetX;
+			_y += offsetY;
 		}
 
 		public static Point Add (Point point, Vector vector)
@@ -179,7 +179,7 @@ namespace System.Windows {
 				seperator = ";";
 			else
 				seperator = ",";
-			object[] ob = { this.x, seperator, this.y };
+			object[] ob = { this._x, seperator, this._y };
 
 			return string.Format(formatProvider, "{0:" + format + "}{1}{2:" + format + "}", ob);
 		}
@@ -189,7 +189,7 @@ namespace System.Windows {
 			return this.ToString(format, formatProvider);
 		}
 
-		double x;
-		double y;
+		double _x;
+		double _y;
 	}
 }

--- a/mcs/class/WindowsBase/System.Windows/Rect.cs
+++ b/mcs/class/WindowsBase/System.Windows/Rect.cs
@@ -41,9 +41,9 @@ namespace System.Windows {
 	{
 		public Rect (Size size)
 		{
-			x = y = 0.0;
-			width = size.Width;
-			height = size.Height;
+			_x = _y = 0.0;
+			_width = size.Width;
+			_height = size.Height;
 		}
 
 		public Rect (Point point, Vector vector) : this (point, Point.Add (point, vector))
@@ -52,21 +52,21 @@ namespace System.Windows {
 		public Rect (Point point1, Point point2)
 		{
 			if (point1.X < point2.X) {
-				x = point1.X;
-				width = point2.X - point1.X;
+				_x = point1.X;
+				_width = point2.X - point1.X;
 			}
 			else {
-				x = point2.X;
-				width = point1.X - point2.X;
+				_x = point2.X;
+				_width = point1.X - point2.X;
 			}
 
 			if (point1.Y < point2.Y) {
-				y = point1.Y;
-				height = point2.Y - point1.Y;
+				_y = point1.Y;
+				_height = point2.Y - point1.Y;
 			}
 			else {
-				y = point2.Y;
-				height = point1.Y - point2.Y;
+				_y = point2.Y;
+				_height = point1.Y - point2.Y;
 			}
 		}
 
@@ -74,26 +74,26 @@ namespace System.Windows {
 		{
 			if (width < 0 || height < 0)
 				throw new ArgumentException ("width and height must be non-negative.");
-			this.x = x;
-			this.y = y;
-			this.width = width;
-			this.height = height;
+			this._x = x;
+			this._y = y;
+			this._width = width;
+			this._height = height;
 		}
 
 		public Rect (Point location, Size size)
 		{
-			x = location.X;
-			y = location.Y;
-			width = size.Width;
-			height = size.Height;
+			_x = location.X;
+			_y = location.Y;
+			_width = size.Width;
+			_height = size.Height;
 		}
 
 		public bool Equals (Rect value)
 		{
-			return (x == value.X &&
-				y == value.Y &&
-				width == value.Width &&
-				height == value.Height);
+			return (_x == value.X &&
+				_y == value.Y &&
+				_width == value.Width &&
+				_height == value.Height);
 		}
 
 		public static bool operator != (Rect rect1, Rect rect2)
@@ -172,11 +172,11 @@ namespace System.Windows {
 		public void Inflate (double width, double height)
 		{
 			// XXX any error checking like in the static case?
-			x -= width;
-			y -= height;
+			_x -= width;
+			_y -= height;
 
-			this.width += 2*width;
-			this.height += 2*height;
+			this._width += 2*width;
+			this._height += 2*height;
 		}
 
 		public void Inflate (Size size)
@@ -192,20 +192,20 @@ namespace System.Windows {
 
 		public void Intersect(Rect rect)
 		{
-			double _x = Math.Max (x, rect.x);
-			double _y = Math.Max (y, rect.y);
+			double _x = Math.Max (this._x, rect._x);
+			double _y = Math.Max (this._y, rect._y);
 			double _width = Math.Min (Right, rect.Right) - _x;
 			double _height = Math.Min (Bottom, rect.Bottom) - _y; 
 
 			if (_width < 0 || _height < 0) {
-				x = y = Double.PositiveInfinity;
-				width = height = Double.NegativeInfinity;
+				this._x = this._y = Double.PositiveInfinity;
+				this._width = this._height = Double.NegativeInfinity;
 			}
 			else {
-				x = _x;
-				y = _y;
-				width = _width;
-				height = _height;
+				this._x = _x;
+				this._y = _y;
+				this._width = _width;
+				this._height = _height;
 			}
 		}
 
@@ -218,8 +218,8 @@ namespace System.Windows {
 
 		public void Offset(double offsetX, double offsetY)
 		{
-			x += offsetX;
-			y += offsetY;
+			_x += offsetX;
+			_y += offsetY;
 		}
 
 		public static Rect Offset(Rect rect, double offsetX, double offsetY)
@@ -231,8 +231,8 @@ namespace System.Windows {
 
 		public void Offset (Vector offsetVector)
 		{
-			x += offsetVector.X;
-			y += offsetVector.Y;
+			_x += offsetVector.X;
+			_y += offsetVector.Y;
 		}
 
 		public static Rect Offset (Rect rect, Vector offsetVector)
@@ -244,10 +244,10 @@ namespace System.Windows {
 
 		public void Scale(double scaleX, double scaleY)
 		{
-			x *= scaleX;
-			y *= scaleY;
-			width *= scaleX;
-			height *= scaleY;
+			_x *= scaleX;
+			_y *= scaleY;
+			_width *= scaleX;
+			_height *= scaleY;
 		}
 
 		public void Transform (Matrix matrix)
@@ -283,10 +283,10 @@ namespace System.Windows {
 			var right = Math.Max (Right, rect.Right);
 			var bottom = Math.Max (Bottom, rect.Bottom);
 			
-			x = left;
-			y = top;
-			width = right - left;
-			height = bottom - top;
+			_x = left;
+			_y = top;
+			_width = right - left;
+			_height = bottom - top;
 		}
 
 		public void Union(Point point)
@@ -336,37 +336,37 @@ namespace System.Windows {
 				"{{0:{0}}}{1}{{1:{0}}}{1}{{2:{0}}}{1}{{3:{0}}}",
 				format, separator);
 			return String.Format (provider, rectFormat,
-				x, y, width, height);
+				_x, _y, _width, _height);
 		}
 
 		public static Rect Empty { 
 			get {
 				Rect r = new Rect ();
-				r.x = r.y = Double.PositiveInfinity;
-				r.width = r.height = Double.NegativeInfinity;
+				r._x = r._y = Double.PositiveInfinity;
+				r._width = r._height = Double.NegativeInfinity;
 				return r;
 			} 
 		}
 		
 		public bool IsEmpty { 
 			get {
-				return (x == Double.PositiveInfinity &&
-					y == Double.PositiveInfinity &&
-					width == Double.NegativeInfinity &&
-					height == Double.NegativeInfinity);
+				return (_x == Double.PositiveInfinity &&
+					_y == Double.PositiveInfinity &&
+					_width == Double.NegativeInfinity &&
+					_height == Double.NegativeInfinity);
 			}
 		}
 		
 		public Point Location { 
 			get {
-				return new Point (x, y);
+				return new Point (_x, _y);
 			}
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Rect.");
 
-				x = value.X;
-				y = value.Y;
+				_x = value.X;
+				_y = value.Y;
 			}
 		}
 		
@@ -374,39 +374,39 @@ namespace System.Windows {
 			get { 
 				if (IsEmpty)
 					return Size.Empty; 
-				return new Size (width, height);
+				return new Size (_width, _height);
 			}
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Rect.");
 
-				width = value.Width;
-				height = value.Height;
+				_width = value.Width;
+				_height = value.Height;
 			}
 		}
 
 		public double X {
-			get { return x; }
+			get { return _x; }
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Rect.");
 
-				x = value;
+				_x = value;
 			}
 		}
 
 		public double Y {
-			get { return y; }
+			get { return _y; }
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Rect.");
 
-				y = value;
+				_y = value;
 			}
 		}
 
 		public double Width {
-			get { return width; }
+			get { return _width; }
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Rect.");
@@ -414,12 +414,12 @@ namespace System.Windows {
 				if (value < 0)
 					throw new ArgumentException ("width must be non-negative.");
 
-				width = value;
+				_width = value;
 			}
 		}
 
 		public double Height {
-			get { return height; }
+			get { return _height; }
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Rect.");
@@ -427,24 +427,24 @@ namespace System.Windows {
 				if (value < 0)
 					throw new ArgumentException ("height must be non-negative.");
 
-				height = value;
+				_height = value;
 			}
 		}
 
 		public double Left { 
-			get { return x; }
+			get { return _x; }
 		}
 
 		public double Top { 
-			get { return y; }
+			get { return _y; }
 		}
 		
 		public double Right { 
-			get { return x + width; }
+			get { return _x + _width; }
 		}
 		
 		public double Bottom { 
-			get { return y + height; }
+			get { return _y + _height; }
 		}
 		
 		public Point TopLeft { 
@@ -463,9 +463,9 @@ namespace System.Windows {
 			get { return new Point (Right, Bottom); }
 		}
 		
-		double x;
-		double y;
-		double width;
-		double height;
+		double _x;
+		double _y;
+		double _width;
+		double _height;
 	}
 }

--- a/mcs/class/WindowsBase/System.Windows/Size.cs
+++ b/mcs/class/WindowsBase/System.Windows/Size.cs
@@ -40,13 +40,13 @@ namespace System.Windows {
 			if (width < 0 || height < 0)
 				throw new ArgumentException ("Width and Height must be non-negative.");
 
-			this.width = width;
-			this.height = height;
+			this._width = width;
+			this._height = height;
 		}
 
 		public bool Equals (Size value)
 		{
-			return width == value.Width && height == value.Height;
+			return _width == value.Width && _height == value.Height;
 		}
 		
 		public override bool Equals (object o)
@@ -76,7 +76,7 @@ namespace System.Windows {
 		{
 			if (IsEmpty)
 				return "Empty";
-			return String.Format ("{0},{1}", width, height);
+			return String.Format ("{0},{1}", _width, _height);
 		}
 
 		public string ToString (IFormatProvider provider)
@@ -91,13 +91,13 @@ namespace System.Windows {
 
 		public bool IsEmpty {
 			get {
-				return (width == Double.NegativeInfinity &&
-					height == Double.NegativeInfinity);
+				return (_width == Double.NegativeInfinity &&
+					_height == Double.NegativeInfinity);
 			}
 		}
 
 		public double Height {
-			get { return height; }
+			get { return _height; }
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Size.");
@@ -105,12 +105,12 @@ namespace System.Windows {
 				if (value < 0)
 					throw new ArgumentException ("height must be non-negative.");
 
-				height = value;
+				_height = value;
 			}
 		}
 
 		public double Width {
-			get { return width; }
+			get { return _width; }
 			set {
 				if (IsEmpty)
 					throw new InvalidOperationException ("Cannot modify this property on the Empty Size.");
@@ -118,14 +118,14 @@ namespace System.Windows {
 				if (value < 0)
 					throw new ArgumentException ("width must be non-negative.");
 
-				width = value;
+				_width = value;
 			}
 		}
 
 		public static Size Empty {
 			get {
 				Size s = new Size ();
-				s.width = s.height = Double.NegativeInfinity;
+				s._width = s._height = Double.NegativeInfinity;
 				return s;
 			}
 		}
@@ -151,7 +151,7 @@ namespace System.Windows {
 			return !size1.Equals (size2);
 		}
 
-		double width;
-		double height;
+		double _width;
+		double _height;
 	}
 }

--- a/mcs/class/WindowsBase/System.Windows/Vector.cs
+++ b/mcs/class/WindowsBase/System.Windows/Vector.cs
@@ -38,13 +38,13 @@ namespace System.Windows {
 	{
 		public Vector (double x, double y)
 		{
-			this.x = x;
-			this.y = y;
+			this._x = x;
+			this._y = y;
 		}
 
 		public bool Equals (Vector value)
 		{
-			return x == value.X && y == value.Y;
+			return _x == value.X && _y == value.Y;
 		}
 
 		public override bool Equals (object o)
@@ -62,7 +62,7 @@ namespace System.Windows {
 
 		string IFormattable.ToString (string format, IFormatProvider provider)
 		{
-			return string.Format (provider, "{0:" + format + "},{1:" + format + "}", x, y);
+			return string.Format (provider, "{0:" + format + "},{1:" + format + "}", _x, _y);
 		}
 
 		public static bool Equals (Vector vector1, Vector vector2)
@@ -128,8 +128,8 @@ namespace System.Windows {
 
 		public void Negate ()
 		{
-			x = -x;
-			y = -y;
+			_x = -_x;
+			_y = -_y;
 		}
 
 		public void Normalize ()
@@ -139,8 +139,8 @@ namespace System.Windows {
 				return;
 
 			double l = Math.Sqrt (ls);
-			x /= l;
-			y /= l;
+			_x /= l;
+			_y /= l;
 		}
 
 		public static Vector Subtract (Vector vector1, Vector vector2)
@@ -155,7 +155,7 @@ namespace System.Windows {
 
 		public override string ToString ()
 		{
-			return String.Format ("{0},{1}", x, y);
+			return String.Format ("{0},{1}", _x, _y);
 		}
 
 		public string ToString (IFormatProvider provider)
@@ -168,17 +168,17 @@ namespace System.Windows {
 		}
 
 		public double LengthSquared {
-			get { return x * x + y * y; }
+			get { return _x * _x + _y * _y; }
 		}
 
 		public double X {
-			get { return x; }
-			set { x = value; }
+			get { return _x; }
+			set { _x = value; }
 		}
 
 		public double Y {
-			get { return y; }
-			set { y = value; }
+			get { return _y; }
+			set { _y = value; }
 		}
 
 		/* operators */
@@ -249,8 +249,8 @@ namespace System.Windows {
 			return Add (vector1, vector2);
 		}
 
-		double x;
-		double y;
+		double _x;
+		double _y;
 	}
 
 }


### PR DESCRIPTION
The problem is that private fields in described types doesn't start from _ prefix, but it should be so according to reference source. That's way MONO can't deserialize that types correctly if source stream was created by MS .NET binary serializer.