### PR TITLE
jlorenss/win x64 support

### DIFF
--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -249,6 +249,21 @@ typedef union {
 		x86_reg_emit ((inst), (dreg), (reg));	\
 	} while (0)
 
+#define amd64_test_reg_imm_size_body(inst,reg,imm,size) \
+	do { \
+		amd64_codegen_pre(inst); \
+		amd64_emit_rex ((inst),(size),0,0,(reg)); \
+		if ((reg) == AMD64_RAX) { \
+			*(inst)++ = (unsigned char)0xa9; \
+		} \
+		else { \
+			*(inst)++ = (unsigned char)0xf7;	\
+			x86_reg_emit((inst), 0, (reg));	\
+		} \
+		x86_imm_emit32((inst), (imm));	\
+		amd64_codegen_post(inst); \
+	} while (0)
+
 #if defined(__default_codegen__)
 
 #define amd64_alu_reg_imm_size(inst,opc,reg,imm,size) \
@@ -256,6 +271,9 @@ typedef union {
 
 #define amd64_alu_reg_reg_size(inst,opc,dreg,reg,size) \
 		amd64_alu_reg_reg_size_body((inst), (opc), (dreg), (reg), (size))
+
+#define amd64_test_reg_imm_size(inst, reg, imm, size) \
+		amd64_test_reg_imm_size_body(inst, reg, imm, size)
 
 #elif defined(__native_client_codegen__)
 /* NaCl modules may not directly update RSP or RBP other than direct copies */
@@ -297,6 +315,8 @@ typedef union {
 #define amd64_alu_reg_imm(inst,opc,reg,imm) amd64_alu_reg_imm_size((inst),(opc),(reg),(imm),8)
 
 #define amd64_alu_reg_reg(inst,opc,dreg,reg) amd64_alu_reg_reg_size ((inst),(opc),(dreg),(reg),8)
+
+#define amd64_test_reg_imm(inst,reg,imm) amd64_test_reg_imm_size(inst,reg,imm,8)
 
 #define amd64_alu_reg_membase_size(inst,opc,reg,basereg,disp,size) \
 	do { \
@@ -1465,7 +1485,7 @@ typedef union {
 #define amd64_alu_reg8_reg8_size(inst,opc,dreg,reg,is_dreg_h,is_reg_h,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),(dreg),0,(reg)); x86_alu_reg8_reg8((inst),(opc),((dreg)&0x7),((reg)&0x7),(is_dreg_h),(is_reg_h)); amd64_codegen_post(inst); } while (0)
 #define amd64_alu_reg_mem_size(inst,opc,reg,mem,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,(reg)); x86_alu_reg_mem((inst),(opc),((reg)&0x7),(mem)); amd64_codegen_post(inst); } while (0)
 //#define amd64_alu_reg_membase_size(inst,opc,reg,basereg,disp,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),(reg),0,(basereg)); x86_alu_reg_membase((inst),(opc),((reg)&0x7),((basereg)&0x7),(disp)); amd64_codegen_post(inst); } while (0)
-#define amd64_test_reg_imm_size(inst,reg,imm,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,(reg)); x86_test_reg_imm((inst),((reg)&0x7),(imm)); amd64_codegen_post(inst); } while (0)
+//#define amd64_test_reg_imm_size(inst,reg,imm,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,(reg)); x86_test_reg_imm((inst),((reg)&0x7),(imm)); amd64_codegen_post(inst); } while (0)
 #define amd64_test_mem_imm_size(inst,mem,imm,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,0); x86_test_mem_imm((inst),(mem),(imm)); amd64_codegen_post(inst); } while (0)
 #define amd64_test_membase_imm_size(inst,basereg,disp,imm,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),0,0,(basereg)); x86_test_membase_imm((inst),((basereg)&0x7),(disp),(imm)); amd64_codegen_post(inst); } while (0)
 #define amd64_test_reg_reg_size(inst,dreg,reg,size) do { amd64_codegen_pre(inst); amd64_emit_rex ((inst),(size),(dreg),0,(reg)); x86_test_reg_reg((inst),((dreg)&0x7),((reg)&0x7)); amd64_codegen_post(inst); } while (0)
@@ -1710,7 +1730,7 @@ typedef union {
 #define amd64_alu_reg8_reg8(inst,opc,dreg,reg,is_dreg_h,is_reg_h) amd64_alu_reg8_reg8_size(inst,opc,dreg,reg,is_dreg_h,is_reg_h,8)
 #define amd64_alu_reg_mem(inst,opc,reg,mem) amd64_alu_reg_mem_size(inst,opc,reg,mem,8)
 #define amd64_alu_reg_membase(inst,opc,reg,basereg,disp) amd64_alu_reg_membase_size(inst,opc,reg,basereg,disp,8)
-#define amd64_test_reg_imm(inst,reg,imm) amd64_test_reg_imm_size(inst,reg,imm,8)
+//#define amd64_test_reg_imm(inst,reg,imm) amd64_test_reg_imm_size(inst,reg,imm,8)
 #define amd64_test_mem_imm(inst,mem,imm) amd64_test_mem_imm_size(inst,mem,imm,8)
 #define amd64_test_membase_imm(inst,basereg,disp,imm) amd64_test_membase_imm_size(inst,basereg,disp,imm,8)
 #define amd64_test_reg_reg(inst,dreg,reg) amd64_test_reg_reg_size(inst,dreg,reg,8)

--- a/winconfig.h
+++ b/winconfig.h
@@ -371,6 +371,9 @@
  /* Have signal */
 #define HAVE_SIGNAL 1
 
+ /* Define to 1 if you have the <signal.h> header file. */
+#define HAVE_SIGNAL_H 1
+
 /* Have signbit */
 /* #undef HAVE_SIGNBIT */
 


### PR DESCRIPTION
Initial fixes needed in order to get pass on mono regression tests for windows x64 visual studio build,

--regression basic.exe basic-float.exe basic-long.exe basic-calls.exe objects.exe arrays.exe basic-math.exe exceptions.exe iltests.exe devirtualization.exe generics.exe basic-simd.exe

Before fixes there were failures in basic.exe, exceptions.exe and objects.exe for windows x64  Visual studio build.

Failures in basic.exe and exceptions.exe was due to a mix up of signal defines on windows platform in Visual Studio build  where SIGILL and SIGFPE was defined differently in different source files causing incorrect signal handler to be invoked at runtime, causing incorrect thrown .NET exception. Fix is to make sure signal.h is always included giving the same value for SIGILl and SIGFPE over all source files. 

Failures in objects.exe test_0_mul_ovf_regress_36052 caused a stack overflow crash when running togehter with branch optimization mode. This was due to incorrect lowering of x64 test instruction when optimization moved over to use R8 instead of RAX and current lowering didn't handle that correctly meaning that the actual test was performed against wrong register causing a loop that caused a stack overflow error. The specific amd64 codegen , amd64_test_reg_imm, is currently only used on x64 windows platform for the stackalloc call.

