### PR TITLE
use Interrupt instead of Abort to shut down handler thread

### DIFF
--- a/mcs/class/System/System.IO/KeventWatcher.cs
+++ b/mcs/class/System/System.IO/KeventWatcher.cs
@@ -232,8 +232,8 @@ namespace System.IO {
 					conn = -1;
 				}
 
-				if (!thread.Join (2000))
-					thread.Abort ();
+				while (!thread.Join (2000))
+					thread.Interrupt ();
 
 				requestStop = false;
 				started = false;


### PR DESCRIPTION
The only place where the handler thread should block is in the
kqueue_notimeout() call; interrupting the thread should cause
that call to exit with EINTR, and allow the thread to exit.
