### PR TITLE
Allow xml configuration sections to reference System.dll (bug#39669)

### DIFF
--- a/mcs/class/System.Configuration/System.Configuration/InternalConfigurationHost.cs
+++ b/mcs/class/System.Configuration/System.Configuration/InternalConfigurationHost.cs
@@ -69,6 +69,11 @@ namespace System.Configuration
 		public virtual Type GetConfigType (string typeName, bool throwOnError)
 		{
 			Type type = Type.GetType (typeName);
+
+			// This code is in System.Configuration.dll, but some of the classes we might want to load here are in System.dll.
+			if (type == null)
+				type = Type.GetType (typeName + ",System");
+
 			if (type == null && throwOnError)
 				throw new ConfigurationErrorsException ("Type '" + typeName + "' not found.");
 			return type;

--- a/mcs/class/System.Configuration/Test/standalone/Makefile
+++ b/mcs/class/System.Configuration/Test/standalone/Makefile
@@ -2,7 +2,7 @@ thisdir = class/System.Configuration/Test/standalone
 SUBDIRS = 
 include ../../../../build/rules.make
 
-TESTS = t1.exe t2.exe t3.exe t4.exe t5.exe t6.exe t7.exe t8.exe t9.exe t10.exe t11.exe t12.exe t15.exe t16.exe t17.exe t18.exe t19.exe t20.exe t21.exe t22.exe t23.exe t24.exe t25.exe t28.exe t29.exe t30.exe t31.exe t32.exe t33.exe t34.exe t35.exe t36.exe t37.exe t38.exe t39.exe t40.exe t41.exe t42.exe t43.exe t44.exe t45.exe t46.exe t47.exe
+TESTS = t1.exe t2.exe t3.exe t4.exe t5.exe t6.exe t7.exe t8.exe t9.exe t10.exe t11.exe t12.exe t15.exe t16.exe t17.exe t18.exe t19.exe t20.exe t21.exe t22.exe t23.exe t24.exe t25.exe t28.exe t29.exe t30.exe t31.exe t32.exe t33.exe t34.exe t35.exe t36.exe t37.exe t38.exe t39.exe t40.exe t41.exe t42.exe t43.exe t44.exe t45.exe t46.exe t47.exe t48.exe
 # t13.exe t14.exe t26.exe t27.exe
 
 check:	local compare

--- a/mcs/class/System.Configuration/Test/standalone/t48.cs
+++ b/mcs/class/System.Configuration/Test/standalone/t48.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections;
+
+// Bugzilla #39669
+
+namespace TestConfigSection
+{
+	class Test
+	{
+		public static int Main (string[] args)
+		{
+			Hashtable testCustomSection = (Hashtable)System.Configuration.ConfigurationManager.GetSection ("TestCustomSection");
+			string proxyServer = (string)testCustomSection["ProxyServer"];
+
+			if (proxyServer == null)
+				throw new Exception("Custom section value is null");
+
+			if (proxyServer != "server.example.com")
+				throw new Exception("Custom section value is incorrect");
+
+			return 0;
+		}
+	}
+}

--- a/mcs/class/System.Configuration/Test/standalone/t48.exe.config
+++ b/mcs/class/System.Configuration/Test/standalone/t48.exe.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="TestCustomSection" type="System.Configuration.DictionarySectionHandler" />
+  </configSections>
+  <TestCustomSection>
+    <add key="ProxyServer" value="server.example.com" />
+    <add key="ConnectOnStart" value="false" />
+  </TestCustomSection>
+</configuration>


### PR DESCRIPTION
When using an app.config file, a type is specified for configuration sections. Some of the types are in System.dll. However, the loader code is in System.Configuration.dll. Currently it uses GetType, so it does not find classes in System.dll.

This code checks System.dll as a fallback.

[Text updated]
I am SOMEWHAT UNCERTAIN about how I implemented this.

- Should we be searching any assemblies other than System.Configuration.dll and System.dll?
- Is searching System.Configuration.dll (which this code does) inappropriate?

The patch does fix the bug in testing.