### PR TITLE
[sgen] Don't wait for sweep finish on forced collections

### DIFF
--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -205,15 +205,11 @@ sgen_memgov_major_collection_start (void)
 }
 
 void
-sgen_memgov_major_collection_end (gboolean forced)
+sgen_memgov_major_collection_end (void)
 {
 	last_collection_los_memory_usage = los_memory_usage;
 
 	total_allocated_major_end = total_allocated_major;
-	if (forced) {
-		sgen_get_major_collector ()->finish_sweeping ();
-		sgen_memgov_calculate_minor_collection_allowance ();
-	}
 }
 
 void

--- a/mono/sgen/sgen-memory-governor.h
+++ b/mono/sgen/sgen-memory-governor.h
@@ -19,7 +19,7 @@ void sgen_memgov_minor_collection_end (void);
 void sgen_memgov_major_pre_sweep (void);
 void sgen_memgov_major_post_sweep (mword used_slots_size);
 void sgen_memgov_major_collection_start (void);
-void sgen_memgov_major_collection_end (gboolean forced);
+void sgen_memgov_major_collection_end (void);
 
 void sgen_memgov_collection_start (int generation);
 void sgen_memgov_collection_end (int generation, GGTimingInfo* info, int info_count);


### PR DESCRIPTION
This affects domain_unload collections or collections triggered from user land. For domain unload we don't need to wait for sweep to finish and free all the blocks, reducing mainly the ending pause for an application.
