### PR TITLE
[System] Replace websocket echo test server with corefx one

### DIFF
--- a/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
+++ b/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
@@ -17,7 +17,7 @@ namespace MonoTests.System.Net.WebSockets
 	[TestFixture]
 	public class ClientWebSocketTest
 	{
-		const string EchoServerUrl = "ws://echo.websocket.org";
+		const string EchoServerUrl = "ws://corefx-net.cloudapp.net/WebSocket/EchoWebSocket.ashx";
 		int Port = NetworkHelpers.FindFreePort ();
 		HttpListener listener;
 		ClientWebSocket socket;


### PR DESCRIPTION
echo.websocket.org is down since yesterday. Let's use the one that corefx uses for now.

@monojenkins merge