### PR TITLE
Include <errno.h> for errno on NetBSD

### DIFF
--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -27,6 +27,7 @@
 #if defined(_POSIX_VERSION)
 #include <sys/errno.h>
 #include <sys/param.h>
+#include <errno.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
The `<sys/errno.h>` header on NetBSD declares only a list of ERROR values.

This fixes the following build issue:

```
In file included from ../../mono/utils/mono-proclib.h:7:0,
                 from mono-proclib.c:8:
mono-proclib.c: In function 'mono_cpu_usage':
mono-proclib.c:893:54: error: 'errno' undeclared (first use in this function)
   g_error ("getrusage() failed, errno is %d (%s)\n", errno, strerror (errno));
                                                      ^
../../eglib/src/glib.h:600:70: note: in definition of macro 'g_error'
 #define g_error(...)    do { g_log (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, __VA_ARGS__); for (;;); } while (0)
                                                                      ^
mono-proclib.c:893:54: note: each undeclared identifier is reported only once for each function it appears in
   g_error ("getrusage() failed, errno is %d (%s)\n", errno, strerror (errno));
                                                      ^
../../eglib/src/glib.h:600:70: note: in definition of macro 'g_error'
 #define g_error(...)    do { g_log (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, __VA_ARGS__); for (;;); } while (0)
```