### PR TITLE
Add new ./configure target & xtarget: arm*-netbsd*-eabi*

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2890,6 +2890,12 @@ case "$host" in
 		AOT_SUPPORTED="yes"
 		CPPFLAGS="$CPPFLAGS -D__ARM_EABI__"
 		;;
+	arm*-netbsd*-eabi*)
+		TARGET=ARM;
+		arch_target=arm;
+		ACCESS_UNALIGNED="no"
+		CPPFLAGS="$CPPFLAGS -D__ARM_EABI__"
+		;;
 # TODO: make proper support for NaCl host.
 #        arm*-*nacl)
 #		TARGET=ARM;
@@ -3003,6 +3009,17 @@ if test "x$host" != "x$target"; then
 			CPPFLAGS="$CPPFLAGS"
 			;;
 		esac
+		;;
+   arm*-netbsd*-eabi*)
+		TARGET=ARM;
+		arch_target=arm;
+		AC_DEFINE(TARGET_ARM, 1, [...])
+		ACCESS_UNALIGNED="no"
+		CPPFLAGS="$CPPFLAGS -D__ARM_EABI__"
+		# Can't use tls, since it depends on the runtime detection of tls offsets
+		# in mono-compiler.h
+		with_tls=pthread
+		target_mach=no
 		;;
    i686*-linux-*)
 		TARGET=X86;


### PR DESCRIPTION
Example GNU triplets:

evbarm	7.0	NetBSD	ignored	arm	arm-unknown-netbsdelf7.0
evbarm	7.0	NetBSD	ignored	armeb	armeb-unknown-netbsdelf7.0
evbarm	7.0	NetBSD	ignored	earmv6	armv6-unknown-netbsdelf7.0-eabi
evbarm	7.0	NetBSD	ignored	earmv6eb	armv6eb-unknown-netbsdelf7.0-eabi
evbarm	7.0	NetBSD	ignored	earmv6hf	armv6-unknown-netbsdelf7.0-eabihf
evbarm	7.0	NetBSD	ignored	earmv6hfeb	armv6eb-unknown-netbsdelf7.0-eabihf
evbarm	7.0	NetBSD	ignored	earmv7	armv7-unknown-netbsdelf7.0-eabi
evbarm	7.0	NetBSD	ignored	earmv7eb	armv7eb-unknown-netbsdelf7.0-eabi
evbarm	7.0	NetBSD	ignored	earmv7hf	armv7-unknown-netbsdelf7.0-eabihf
evbarm	7.0	NetBSD	ignored	earmv7hfeb	armv7eb-unknown-netbsdelf7.0-eabihf

-- http://git.savannah.gnu.org/cgit/config.git/tree/testsuite/config-guess.data

For now support just EABI targets (available since ARMv4).