### PR TITLE
NetBSD and other supported Unices ship with alloca(3) in <stdlib.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -415,7 +415,7 @@ AC_PROG_LD_GNU
 AM_ICONV()
 
 AC_CHECK_HEADERS(sys/filio.h sys/sockio.h netdb.h utime.h sys/utime.h semaphore.h sys/un.h linux/rtc.h sys/syscall.h sys/mkdev.h sys/uio.h sys/param.h sys/sysctl.h libproc.h sys/prctl.h)
-AC_CHECK_HEADERS(sys/param.h sys/socket.h sys/ipc.h sys/utsname.h alloca.h ucontext.h pwd.h sys/select.h netinet/tcp.h netinet/in.h unistd.h sys/types.h link.h asm/sigcontext.h sys/inotify.h arpa/inet.h complex.h unwind.h)
+AC_CHECK_HEADERS(sys/param.h sys/socket.h sys/ipc.h sys/utsname.h ucontext.h pwd.h sys/select.h netinet/tcp.h netinet/in.h unistd.h sys/types.h link.h asm/sigcontext.h sys/inotify.h arpa/inet.h complex.h unwind.h)
 AC_CHECK_HEADERS([linux/netlink.h linux/rtnetlink.h],
                   [], [], [#include <stddef.h>
 		  #include <sys/socket.h>

--- a/eglib/configure.ac
+++ b/eglib/configure.ac
@@ -183,8 +183,6 @@ AC_SUBST(G_HAVE_ISO_VARARGS)
 
 AC_CHECK_HEADERS(getopt.h sys/select.h sys/time.h sys/wait.h pwd.h langinfo.h iconv.h localcharset.h sys/types.h sys/resource.h)
 AC_CHECK_LIB([iconv], [locale_charset],[],[AC_CHECK_LIB([charset], [locale_charset],[LIBS+="-liconv -lcharset"])])
-AC_CHECK_HEADER(alloca.h, [HAVE_ALLOCA_H=1], [HAVE_ALLOCA_H=0])
-AC_SUBST(HAVE_ALLOCA_H)
 
 if test $ac_cv_sizeof_void_p = $ac_cv_sizeof_int; then
    GPOINTER_TO_INT="((gint) (ptr))"

--- a/eglib/src/eglib-config.h.in
+++ b/eglib/src/eglib-config.h.in
@@ -19,10 +19,6 @@
 #define GINT_TO_POINTER(v)     @GINT_TO_POINTER@
 #define GUINT_TO_POINTER(v)    @GUINT_TO_POINTER@
 
-#if @HAVE_ALLOCA_H@ == 1
-#define G_HAVE_ALLOCA_H
-#endif
-
 typedef unsigned @GSIZE@ gsize;
 typedef signed   @GSIZE@ gssize;
 

--- a/eglib/src/glib.h
+++ b/eglib/src/glib.h
@@ -24,13 +24,11 @@
 #include <eglib-remap.h>
 #endif
 
-#ifdef G_HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
-
-#ifdef WIN32
 /* For alloca */
+#ifdef WIN32
 #include <malloc.h>
+#else
+#include <stdlib.h>
 #endif
 
 #ifndef offsetof
@@ -1081,6 +1079,3 @@ glong     g_utf8_pointer_to_offset (const gchar *str, const gchar *pos);
 G_END_DECLS
 
 #endif
-
-
-

--- a/ikvm-native/jni.c
+++ b/ikvm-native/jni.c
@@ -28,11 +28,7 @@
 #include <malloc.h>
 #define ALLOCA _alloca
 #else
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
-#else
-#include <alloca.h>
-#endif
 #define ALLOCA alloca
 #endif
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -10,9 +10,6 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 #include <config.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
 #include <glib.h>
 #include <stdio.h>
 #include <string.h>

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -7,9 +7,7 @@
  */
 
 #include "config.h"
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 
 #include "object.h"
 #include "loader.h"

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -19,9 +19,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
@@ -8941,4 +8939,3 @@ mono_register_jit_icall (gconstpointer func, const char *name, MonoMethodSignatu
 {
 	return mono_register_jit_icall_full (func, name, sig, is_save, FALSE, NULL);
 }
-

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -12,9 +12,7 @@
  */
 
 #include "config.h"
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 
 #include "object.h"
 #include "loader.h"

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -11,9 +11,6 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 #include <config.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -13,9 +13,7 @@
 #include <config.h>
 #include <math.h>
 #include <limits.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 
 #include "jit-icalls.h"
 #include <mono/utils/mono-error-internals.h>

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -18,9 +18,7 @@
 
 #include <string.h>
 #include <stdio.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/mempool.h>

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -29,9 +29,7 @@
 #include <sys/time.h>
 #endif
 
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 
 #include <mono/utils/memcheck.h>
 #include "mini.h"

--- a/mono/mini/mini-darwin.c
+++ b/mono/mini/mini-darwin.c
@@ -12,9 +12,7 @@
  */
 #include <config.h>
 #include <signal.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -13,9 +13,7 @@
  */
 #include <config.h>
 #include <signal.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -13,9 +13,7 @@
  */
 
 #include <config.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -12,9 +12,7 @@
  */
 
 #include <config.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/mono/mini/ssa.c
+++ b/mono/mini/ssa.c
@@ -17,9 +17,7 @@
 #ifndef DISABLE_JIT
 
 #include "mini.h"
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 
 #define CREATE_PRUNED_SSA
 

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -11,9 +11,7 @@
  */
 
 #include <config.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif


### PR DESCRIPTION
Obsolete the <alloca.h> header usage.