### PR TITLE
[metadata] Don't require HandleRef in domain.c

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -783,7 +783,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_assembly_load_friends (ass);
 
-	mono_defaults.handleref_class = mono_class_load_from_name (
+	mono_defaults.handleref_class = mono_class_try_load_from_name (
 		mono_defaults.corlib, "System.Runtime.InteropServices", "HandleRef");
 
 	mono_defaults.attribute_class = mono_class_load_from_name (


### PR DESCRIPTION
In 1da6b7629701e71afed2a28c86e7a9cb0f2c6f07 loading of System.Runtime.InteropServices.HandleRef
was changed from optional to required. This caused errors in the maccore tests:

```
MONO_PATH=/Users/builder/data/lanes/1411/5ca65b46/source/maccore/msbuild/tests/MyKeyboardExtension/obj/iPhone/Debug/mtouch-cache/64/Build /Users/builder/data/lanes/1411/5ca65b46/source/maccore/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/bin/arm64-darwin-mono-sgen --debug -O=gsharedvt  --aot=mtriple=arm64-ios,data-outfile=/Users/builder/data/lanes/1411/5ca65b46/source/maccore/msbuild/tests/MyKeyboardExtension/obj/iPhone/Debug/mtouch-cache/System.arm64.aotdata,static,asmonly,direct-icalls,full,dwarfdebug,no-direct-calls,outfile=/Users/builder/data/lanes/1411/5ca65b46/source/maccore/msbuild/tests/MyKeyboardExtension/obj/iPhone/Debug/mtouch-cache/System.dll.arm64.s "/Users/builder/data/lanes/1411/5ca65b46/source/maccore/msbuild/tests/MyKeyboardExtension/obj/iPhone/Debug/mtouch-cache/64/Build/System.dll"
Runtime critical type System.Runtime.InteropServices.HandleRef not found
AOT Compilation exited with code 134, command:
```

@monojenkins merge