### PR TITLE
Implement mono_threads_core_set_name() on NetBSD

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -296,6 +296,16 @@ mono_threads_core_set_name (MonoNativeThreadId tid, const char *name)
 		n [62] = '\0';
 		pthread_setname_np (n);
 	}
+#elif defined (__NetBSD__)
+	if (!name) {
+		pthread_setname_np (tid, "%s", (void*)"");
+	} else {
+		char n [PTHREAD_MAX_NAMELEN_NP];
+
+		strncpy (n, name, PTHREAD_MAX_NAMELEN_NP);
+		n [PTHREAD_MAX_NAMELEN_NP - 1] = '\0';
+		pthread_setname_np (tid, "%s", (void*)n);
+	}
 #elif defined (HAVE_PTHREAD_SETNAME_NP)
 	if (!name) {
 		pthread_setname_np (tid, "");


### PR DESCRIPTION
Part of man-page showing this interface:

```
PTHREAD_GETNAME_NP(3)      Library Functions Manual      PTHREAD_GETNAME_NP(3)

NAME
     pthread_getname_np - get and set descriptive name of a thread

LIBRARY
     POSIX Threads Library (libpthread, -lpthread)

SYNOPSIS
     #include <pthread.h>

     int
     pthread_getname_np(pthread_t thread, char *name, size_t len);

     int
     pthread_setname_np(pthread_t thread, const char *name, void *arg);
```

   -- `pthread_setname_np`(3)