### PR TITLE
Added support for SHA256, 384 and 512 in AuthenticodeDeformatter.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Authenticode/AuthenticodeDeformatter.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Authenticode/AuthenticodeDeformatter.cs
@@ -205,6 +205,18 @@ namespace Mono.Security.Authenticode {
 					ha = SHA1.Create ();
 					hash = GetHash (ha);
 					break;
+				case 32:
+					ha = SHA256.Create ();
+					hash = GetHash (ha);
+					break;
+				case 48:
+					ha = SHA384.Create ();
+					hash = GetHash (ha);
+					break;
+				case 64:
+					ha = SHA512.Create ();
+					hash = GetHash (ha);
+					break;
 				default:
 					reason = 5;
 					Close ();
@@ -401,6 +413,15 @@ namespace Mono.Security.Authenticode {
 					break;
 				case 20:
 					hashName = "SHA1";
+					break;
+				case 32:
+					hashName = "SHA256";
+					break;
+				case 48:
+					hashName = "SHA384";
+					break;
+				case 64:
+					hashName = "SHA512";
 					break;
 			}
 			HashAlgorithm ha = HashAlgorithm.Create (hashName);


### PR DESCRIPTION
Due to the changes introduced by Microsoft to require signing with stronger algorithms, SHA-256, SHA-384 and SHA-512 support was needed.

This change is released under the MIT license.