### PR TITLE
[threadpool-io] Fix crash on shutdownin System.Net.Sockets.Socket:Close_internal

### DIFF
--- a/mono/metadata/threadpool-ms-io-epoll.c
+++ b/mono/metadata/threadpool-ms-io-epoll.c
@@ -48,13 +48,6 @@ epoll_init (gint wakeup_pipe_fd)
 }
 
 static void
-epoll_cleanup (void)
-{
-	g_free (epoll_events);
-	close (epoll_fd);
-}
-
-static void
 epoll_register_fd (gint fd, gint events, gboolean is_new)
 {
 	struct epoll_event event;
@@ -127,7 +120,6 @@ epoll_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), g
 
 static ThreadPoolIOBackend backend_epoll = {
 	.init = epoll_init,
-	.cleanup = epoll_cleanup,
 	.register_fd = epoll_register_fd,
 	.remove_fd = epoll_remove_fd,
 	.event_wait = epoll_event_wait,

--- a/mono/metadata/threadpool-ms-io-kqueue.c
+++ b/mono/metadata/threadpool-ms-io-kqueue.c
@@ -44,13 +44,6 @@ kqueue_init (gint wakeup_pipe_fd)
 }
 
 static void
-kqueue_cleanup (void)
-{
-	g_free (kqueue_events);
-	close (kqueue_fd);
-}
-
-static void
 kqueue_register_fd (gint fd, gint events, gboolean is_new)
 {
 	if (events & EVENT_IN) {
@@ -124,7 +117,6 @@ kqueue_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), 
 
 static ThreadPoolIOBackend backend_kqueue = {
 	.init = kqueue_init,
-	.cleanup = kqueue_cleanup,
 	.register_fd = kqueue_register_fd,
 	.remove_fd = kqueue_remove_fd,
 	.event_wait = kqueue_event_wait,

--- a/mono/metadata/threadpool-ms-io-poll.c
+++ b/mono/metadata/threadpool-ms-io-poll.c
@@ -29,12 +29,6 @@ poll_init (gint wakeup_pipe_fd)
 }
 
 static void
-poll_cleanup (void)
-{
-	g_free (poll_fds);
-}
-
-static void
 poll_register_fd (gint fd, gint events, gboolean is_new)
 {
 	gint i;
@@ -236,7 +230,6 @@ poll_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), gp
 
 static ThreadPoolIOBackend backend_poll = {
 	.init = poll_init,
-	.cleanup = poll_cleanup,
 	.register_fd = poll_register_fd,
 	.remove_fd = poll_remove_fd,
 	.event_wait = poll_event_wait,

--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -32,7 +32,6 @@
 
 typedef struct {
 	gboolean (*init) (gint wakeup_pipe_fd);
-	void     (*cleanup) (void);
 	void     (*register_fd) (gint fd, gint events, gboolean is_new);
 	void     (*remove_fd) (gint fd);
 	gint     (*event_wait) (void (*callback) (gint fd, gint events, gpointer user_data), gpointer user_data);
@@ -551,24 +550,6 @@ cleanup (void)
 	selector_thread_wakeup ();
 	while (io_selector_running)
 		mono_thread_info_usleep (1000);
-
-	mono_coop_mutex_destroy (&threadpool_io->updates_lock);
-	mono_coop_cond_destroy (&threadpool_io->updates_cond);
-
-	threadpool_io->backend.cleanup ();
-
-#if !defined(HOST_WIN32)
-	close (threadpool_io->wakeup_pipes [0]);
-	close (threadpool_io->wakeup_pipes [1]);
-#else
-	closesocket (threadpool_io->wakeup_pipes [0]);
-	closesocket (threadpool_io->wakeup_pipes [1]);
-#endif
-
-	g_assert (threadpool_io);
-	g_free (threadpool_io);
-	threadpool_io = NULL;
-	g_assert (!threadpool_io);
 }
 
 void


### PR DESCRIPTION
There could be a race between System.Net.Sockets.Socket:Close_internal and the io threadpool cleanup, which would lead to a native crash. That's because the io threadpool cleanup would clean the mutex, condition variables as well as close the sockets.

The easiest way to fix that is by cleaning only what's going to stop the runtime from shutting down, and in this case the background selector thread. The same is done for the threadpool where we just shutdown the monitor thread and the worker threads.

```
  * frame #0: 0x00007fff94d8f4a1 libsystem_pthread.dylib`pthread_mutex_unlock
    frame #1: 0x00000001001b23b4 mono`mono_threadpool_ms_io_remove_socket [inlined] mono_os_mutex_unlock + 196 at mono-os-mutex.h:85
    frame #2: 0x00000001001b23af mono`mono_threadpool_ms_io_remove_socket [inlined] mono_coop_mutex_unlock + 7 at mono-coop-mutex.h:71
    frame #3: 0x00000001001b23a8 mono`mono_threadpool_ms_io_remove_socket(fd=<unavailable>) + 184 at threadpool-ms-io.c:624
    frame #4: 0x00000001001985c7 mono`ves_icall_System_Net_Sockets_Socket_Close_internal(sock=10, error=<unavailable>) + 23 at socket-io.c:692
    frame #5: 0x1057ecc16 (wrapper managed-to-native) System.Net.Sockets.Socket:Close_internal (intptr,int&) + 0x66 (0x1057ecbb0 0x1057ecc8c) [0x1005034f0 - Xamarin.WebTests.Console.exe]
    frame #6: 0x00000001034f83e4 mscorlib.dll.dylib`System_Runtime_InteropServices_SafeHandle_DangerousReleaseInternal_bool(this=0x000000000000000a, dispose=true) + 244 at SafeHandle.cs:215
    frame #7: 0x00000001034f8295 mscorlib.dll.dylib`System_Runtime_InteropServices_SafeHandle_InternalDispose(this=0x0000000102070550) + 37 at SafeHandle.cs:150
    frame #8: 0x00000001034f810f mscorlib.dll.dylib`System_Runtime_InteropServices_SafeHandle_Dispose_bool(this=0x0000000102070550, disposing=true) + 31 at safehandle.cs:260
    frame #9: 0x00000001034f80e7 mscorlib.dll.dylib`System_Runtime_InteropServices_SafeHandle_Dispose(this=0x0000000102070550) + 23 at safehandle.cs:252
    frame #10: 0x1057ec758 System.Net.Sockets.Socket:Dispose (bool) + 0x88 (0x1057ec6d0 0x1057ec761) [0x1005034f0 - Xamarin.WebTests.Console.exe]
    frame #11: 0x1075acaa3 System.Net.WebConnection:InitConnection (object) + 0x453 (0x1075ac650 0x1075acb90) [0x1005034f0 - Xamarin.WebTests.Console.exe]
```

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40306

@monojenkins merge