### PR TITLE
[utils] Fix MONO_SIGNAL_USE_UCONTEXT_T not being defined on tvOS simulator

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -31,7 +31,7 @@
 /*HACK, move this to an eventual mono-signal.c*/
 #if defined( __linux__) || defined(__sun) || defined(__APPLE__) || defined(__NetBSD__) || \
        defined(__FreeBSD__) || defined(__OpenBSD__)
-#ifdef HAVE_SIGACTION
+#if defined(HAVE_SIGACTION) || defined(__APPLE__)  // the __APPLE__ check is required for the tvos simulator, which has ucontext_t but not sigaction
 #define MONO_SIGNAL_USE_UCONTEXT_T 1
 #endif
 #endif
@@ -152,7 +152,7 @@ typedef struct {
 
 #if !defined( HOST_WIN32 ) && !defined(__native_client__) && !defined(__native_client_codegen__)
 
-#ifdef HAVE_SIGACTION
+#if defined(HAVE_SIGACTION) || defined(__APPLE__)  // the __APPLE__ check is required for the tvos simulator, which has ucontext_t but not sigaction
 #define MONO_SIGNAL_USE_UCONTEXT_T 1
 #endif
 


### PR DESCRIPTION
In the maccore tvossimulator tests we were seeing the following assertion with the Mono 4.5 preview:

```
error: * Assertion: should not be reached at /Users/builder/data/lanes/1381/0d6923b4/source/maccore/external/mono/mono/utils/mono-context.c:194

0   dont link                           0x000000010175702d mono_handle_native_sigsegv + 253
1   libsystem_platform.dylib            0x000000010a0cfeaa _sigtramp + 26
2   ???                                 0x0000000001bfc4db 0x0 + 29344987
3   libsystem_c.dylib                   0x0000000109e56cbc abort + 129
4   dont link                           0x00000001018d1503 _ZL12log_callbackPKcS0_S0_iPv + 67
5   dont link                           0x00000001018c26d0 monoeg_assertion_message + 192
6   dont link                           0x00000001018af6de mono_sigctx_to_monoctx + 30
7   dont link                           0x000000010183f473 sgen_suspend_thread + 323
8   dont link                           0x000000010183f58e sgen_thread_handshake + 126
9   dont link                           0x000000010183fb20 sgen_client_stop_world + 1296
10  dont link                           0x0000000101871283 sgen_stop_world + 67
11  dont link                           0x0000000101870d43 sgen_perform_collection + 99
12  dont link                           0x0000000101872576 sgen_gc_collect + 102
13  dont link                           0x00000001018d1886 _ZL7pump_gcPv + 54
14  libsystem_pthread.dylib             0x000000010a0b7c13 _pthread_body + 131
15  libsystem_pthread.dylib             0x000000010a0b7b90 _pthread_body + 0
16  libsystem_pthread.dylib             0x000000010a0b5375 thread_start + 13
```

This was caused by a4e257a07f511062a8feb3e06e1566fd980110ce, the issue is that the check was changed from UCONTEXT_REG_RAX to MONO_SIGNAL_USE_UCONTEXT_T, but that is only available when HAVE_SIGACTION is defined which it is not in this case.

Talked with Zoltan, fixing this by enabling MONO_SIGNAL_USE_UCONTEXT_T on all apple platforms for now.

/cc @vargaz @xmcclure 

@monojenkins merge