### PR TITLE
[tools] Allow matching binary protocol events by name.

### DIFF
--- a/tools/sgen/sgen-entry-stream.h
+++ b/tools/sgen/sgen-entry-stream.h
@@ -6,6 +6,9 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+#ifndef SGEN_ENTRY_STREAM_H
+#define SGEN_ENTRY_STREAM_H
+
 typedef struct {
 	int file;
 	char *buffer;
@@ -18,3 +21,5 @@ void reset_stream (EntryStream *stream);
 void close_stream (EntryStream *stream);
 gboolean refill_stream (EntryStream *in, size_t size);
 ssize_t read_stream (EntryStream *stream, void *out, size_t size);
+
+#endif /* SGEN_ENTRY_STREAM_H */

--- a/tools/sgen/sgen-grep-binprot-main.c
+++ b/tools/sgen/sgen-grep-binprot-main.c
@@ -99,19 +99,22 @@ main (int argc, char *argv[])
 
 	input_file = input_path ? open (input_path, O_RDONLY) : STDIN_FILENO;
 	init_stream (&stream, input_file);
+
+	GrepOptions options = {
+		.num_nums = num_nums,
+		.nums = nums,
+		.num_patterns = num_patterns,
+		.patterns = patterns,
+		.num_vtables = num_vtables,
+		.vtables = vtables,
+		.dump_all = dump_all,
+		.pause_times = pause_times,
+		.color_output = color_output,
+		.first_entry_to_consider = first_entry_to_consider
+	};
+
 	for (i = 0; i < sizeof (grepers) / sizeof (GrepEntriesFunction *); i++) {
-		if (grepers [i] (
-				&stream,
-				num_nums,
-				nums,
-				num_patterns,
-				patterns,
-				num_vtables,
-				vtables,
-				dump_all,
-				pause_times,
-				color_output,
-				first_entry_to_consider)) {
+		if (grepers [i] (&stream, &options)) {
 			/* Success */
 			break;
 		}

--- a/tools/sgen/sgen-grep-binprot-main.c
+++ b/tools/sgen/sgen-grep-binprot-main.c
@@ -16,7 +16,7 @@
 #include "sgen-grep-binprot.h"
 
 /* FIXME Add grepers for specific endianness */
-GrepEntriesFunction grepers [] = {
+GrepEntriesFunction *grepers [] = {
 	sgen_binary_protocol_grep_entries32p, /* We have header, structures are packed, 32 bit word */
 	sgen_binary_protocol_grep_entries64p, /* We have header, structures are packed, 64 bit word */
 	sgen_binary_protocol_grep_entries /* No header, uses default word size and structure layout */
@@ -27,9 +27,11 @@ main (int argc, char *argv[])
 {
 	int num_args = argc - 1;
 	int num_nums = 0;
+	int num_patterns = 0;
 	int num_vtables = 0;
 	int i;
 	long nums [num_args];
+	const char *patterns [num_args];
 	long vtables [num_args];
 	gboolean dump_all = FALSE;
 	gboolean color_output = FALSE;
@@ -57,6 +59,9 @@ main (int argc, char *argv[])
 		} else if (!strcmp (arg, "-i") || !strcmp (arg, "--input")) {
 			input_path = next_arg;
 			++i;
+		} else if (!strcmp (arg, "-m") || !strcmp (arg, "--match")) {
+			patterns [num_patterns++] = next_arg;
+			++i;
 		} else if (!strcmp (arg, "--help")) {
 			printf (
 				"\n"
@@ -68,6 +73,7 @@ main (int argc, char *argv[])
 				"\n"
 				"\tsgen-grep-binprot --all </tmp/binprot\n"
 				"\tsgen-grep-binprot --input /tmp/binprot --color 0xdeadbeef\n"
+				"\tsgen-grep-binprot --input /tmp/binprot --all --match '*collect*'\n"
 				"\n"
 				"Options:\n"
 				"\n"
@@ -75,6 +81,7 @@ main (int argc, char *argv[])
 				"\t--color, -c              Highlight matches in color.\n"
 				"\t--help                   You're looking at it.\n"
 				"\t--input FILE, -i FILE    Read input from FILE instead of standard input.\n"
+				"\t--match GLOB, -m GLOB    Print entries matching GLOB.\n"
 				"\t--pause-times            Print GC pause times.\n"
 				"\t--start-at N, -s N       Begin filtering at the Nth entry.\n"
 				"\t--vtable PTR, -v PTR     Search for vtable pointer PTR.\n"
@@ -92,9 +99,19 @@ main (int argc, char *argv[])
 
 	input_file = input_path ? open (input_path, O_RDONLY) : STDIN_FILENO;
 	init_stream (&stream, input_file);
-	for (i = 0; i < sizeof (grepers) / sizeof (GrepEntriesFunction); i++) {
-		if (grepers [i] (&stream, num_nums, nums, num_vtables, vtables, dump_all,
-				pause_times, color_output, first_entry_to_consider)) {
+	for (i = 0; i < sizeof (grepers) / sizeof (GrepEntriesFunction *); i++) {
+		if (grepers [i] (
+				&stream,
+				num_nums,
+				nums,
+				num_patterns,
+				patterns,
+				num_vtables,
+				vtables,
+				dump_all,
+				pause_times,
+				color_output,
+				first_entry_to_consider)) {
 			/* Success */
 			break;
 		}

--- a/tools/sgen/sgen-grep-binprot.c
+++ b/tools/sgen/sgen-grep-binprot.c
@@ -57,29 +57,52 @@ typedef int64_t mword;
 #define MAX_ENTRY_SIZE (1 << 10)
 
 static int
-read_entry (EntryStream *stream, void *data)
+read_entry (EntryStream *stream, void *data, const char **name)
 {
 	unsigned char type;
 	ssize_t size;
 
-	if (read_stream (stream, &type, 1) <= 0)
+	if (read_stream (stream, &type, 1) <= 0) {
+		*name = NULL;
 		return SGEN_PROTOCOL_EOF;
+	}
 	switch (TYPE (type)) {
 
 #define BEGIN_PROTOCOL_ENTRY0(method) \
-	case PROTOCOL_ID(method): size = 0; break;
+	case PROTOCOL_ID(method): \
+		size = 0; \
+		*name = #method + strlen ("binary_protocol_"); \
+		break;
 #define BEGIN_PROTOCOL_ENTRY1(method,t1,f1) \
-	case PROTOCOL_ID(method): size = sizeof (PROTOCOL_STRUCT(method)); break;
+	case PROTOCOL_ID(method): \
+		size = sizeof (PROTOCOL_STRUCT(method)); \
+		*name = #method + strlen ("binary_protocol_"); \
+		break;
 #define BEGIN_PROTOCOL_ENTRY2(method,t1,f1,t2,f2) \
-	case PROTOCOL_ID(method): size = sizeof (PROTOCOL_STRUCT(method)); break;
+	case PROTOCOL_ID(method): \
+		size = sizeof (PROTOCOL_STRUCT(method)); \
+		*name = #method + strlen ("binary_protocol_"); \
+		break;
 #define BEGIN_PROTOCOL_ENTRY3(method,t1,f1,t2,f2,t3,f3) \
-	case PROTOCOL_ID(method): size = sizeof (PROTOCOL_STRUCT(method)); break;
+	case PROTOCOL_ID(method): \
+		size = sizeof (PROTOCOL_STRUCT(method)); \
+		*name = #method + strlen ("binary_protocol_"); \
+		break;
 #define BEGIN_PROTOCOL_ENTRY4(method,t1,f1,t2,f2,t3,f3,t4,f4) \
-	case PROTOCOL_ID(method): size = sizeof (PROTOCOL_STRUCT(method)); break;
+	case PROTOCOL_ID(method): \
+		size = sizeof (PROTOCOL_STRUCT(method)); \
+		*name = #method + strlen ("binary_protocol_"); \
+		break;
 #define BEGIN_PROTOCOL_ENTRY5(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5) \
-	case PROTOCOL_ID(method): size = sizeof (PROTOCOL_STRUCT(method)); break;
+	case PROTOCOL_ID(method): \
+		size = sizeof (PROTOCOL_STRUCT(method)); \
+		*name = #method + strlen ("binary_protocol_"); \
+		break;
 #define BEGIN_PROTOCOL_ENTRY6(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6) \
-	case PROTOCOL_ID(method): size = sizeof (PROTOCOL_STRUCT(method)); break;
+	case PROTOCOL_ID(method): \
+		size = sizeof (PROTOCOL_STRUCT(method)); \
+		*name = #method + strlen ("binary_protocol_"); \
+		break;
 
 #define BEGIN_PROTOCOL_ENTRY_HEAVY0(method) \
 	BEGIN_PROTOCOL_ENTRY0 (method)
@@ -562,11 +585,48 @@ is_vtable_match (mword ptr, int type, void *data)
 #undef TYPE_POINTER
 
 static gboolean
+match_pattern (const char * pattern, const char * string)
+{
+	const char *p = pattern;
+	const char *s = string;
+	for (;;) {
+		/* End of pattern matches end of string. */
+		if (!*p)
+			return !*s;
+		/* "*" matches zero or more characters. */
+		if (*p == '*') {
+			while (*s && *s != *(p + 1))
+				++s;
+			++p;
+		/* Match one character at a time, "?" for any character. */
+		} else if (*p == *s || *p == '?') {
+			++p;
+			++s;
+		} else {
+			return FALSE;
+		}
+	}
+}
+
+static int
+find_pattern (
+	const char *const string,
+	const char **const patterns,
+	const size_t num_patterns)
+{
+	for (size_t i = 0; i < num_patterns; ++i)
+		if (match_pattern (patterns [i], string))
+			return i;
+	return -1;
+}
+
+static gboolean
 sgen_binary_protocol_read_header (EntryStream *stream)
 {
 #ifdef BINPROT_HAS_HEADER
 	char data [MAX_ENTRY_SIZE];
-	int type = read_entry (stream, data);
+	const char *name = NULL;
+	int type = read_entry (stream, data, &name);
 	if (type == SGEN_PROTOCOL_EOF)
 		return FALSE;
 	if (type == PROTOCOL_ID (binary_protocol_header)) {
@@ -590,9 +650,20 @@ sgen_binary_protocol_read_header (EntryStream *stream)
 #define CONC_(A, B) A##B
 #define GREP_ENTRIES_FUNCTION_NAME CONC(sgen_binary_protocol_grep_entries, CONC(ARCH_SUFFIX,PACKED_SUFFIX))
 
+/* TODO: Make a struct for these options. */
 gboolean
-GREP_ENTRIES_FUNCTION_NAME (EntryStream *stream, int num_nums, long nums [], int num_vtables, long vtables [],
-			gboolean dump_all, gboolean pause_times, gboolean color_output, unsigned long long first_entry_to_consider)
+GREP_ENTRIES_FUNCTION_NAME (
+	EntryStream *stream,
+	int num_nums,
+	long nums [],
+	int num_patterns,
+	const char *patterns [],
+	int num_vtables,
+	long vtables [],
+	gboolean dump_all,
+	gboolean pause_times,
+	gboolean color_output,
+	unsigned long long first_entry_to_consider)
 {
 	int type;
 	void *data = g_malloc0 (MAX_ENTRY_SIZE);
@@ -607,7 +678,8 @@ GREP_ENTRIES_FUNCTION_NAME (EntryStream *stream, int num_nums, long nums [], int
 		return FALSE;
 
 	entry_index = 0;
-	while ((type = read_entry (stream, data)) != SGEN_PROTOCOL_EOF) {
+	const char *name = NULL;
+	while ((type = read_entry (stream, data, &name)) != SGEN_PROTOCOL_EOF) {
 		if (entry_index < first_entry_to_consider)
 			goto next_entry;
 		if (pause_times) {
@@ -640,7 +712,7 @@ GREP_ENTRIES_FUNCTION_NAME (EntryStream *stream, int num_nums, long nums [], int
 				break;
 			}
 			}
-		} else {
+		} else if (num_patterns == 0 || find_pattern (name, patterns, num_patterns) != -1) {
 			int match_indices [num_nums + 1];
 			gboolean match = is_always_match (type);
 			match_indices [num_nums] = num_nums == 0 ? match_index (0, type, data) : BINARY_PROTOCOL_NO_MATCH;

--- a/tools/sgen/sgen-grep-binprot.h
+++ b/tools/sgen/sgen-grep-binprot.h
@@ -1,3 +1,6 @@
+#ifndef SGEN_GREP_BINPROT_H
+#define SGEN_GREP_BINPROT_H
+
 typedef gboolean GrepEntriesFunction(
 	EntryStream *stream,
 	int num_nums,
@@ -15,3 +18,5 @@ GrepEntriesFunction
 	sgen_binary_protocol_grep_entries,
 	sgen_binary_protocol_grep_entries32p,
 	sgen_binary_protocol_grep_entries64p;
+
+#endif /* SGEN_GREP_BINPROT_H */

--- a/tools/sgen/sgen-grep-binprot.h
+++ b/tools/sgen/sgen-grep-binprot.h
@@ -1,12 +1,17 @@
-typedef gboolean (*GrepEntriesFunction) (EntryStream *stream, int num_nums, long nums [], int num_vtables, long vtables [],
-		gboolean dump_all, gboolean pause_times, gboolean color_output, unsigned long long first_entry_to_consider);
+typedef gboolean GrepEntriesFunction(
+	EntryStream *stream,
+	int num_nums,
+	long nums [],
+	int num_patterns,
+	const char *patterns [],
+	int num_vtables,
+	long vtables [],
+	gboolean dump_all,
+	gboolean pause_times,
+	gboolean color_output,
+	unsigned long long first_entry_to_consider);
 
-gboolean
-sgen_binary_protocol_grep_entries (EntryStream *stream, int num_nums, long nums [], int num_vtables, long vtables [],
-                        gboolean dump_all, gboolean pause_times, gboolean color_output, unsigned long long first_entry_to_consider);
-gboolean
-sgen_binary_protocol_grep_entries32p (EntryStream *stream, int num_nums, long nums [], int num_vtables, long vtables [],
-                        gboolean dump_all, gboolean pause_times, gboolean color_output, unsigned long long first_entry_to_consider);
-gboolean
-sgen_binary_protocol_grep_entries64p (EntryStream *stream, int num_nums, long nums [], int num_vtables, long vtables [],
-                        gboolean dump_all, gboolean pause_times, gboolean color_output, unsigned long long first_entry_to_consider);
+GrepEntriesFunction
+	sgen_binary_protocol_grep_entries,
+	sgen_binary_protocol_grep_entries32p,
+	sgen_binary_protocol_grep_entries64p;

--- a/tools/sgen/sgen-grep-binprot.h
+++ b/tools/sgen/sgen-grep-binprot.h
@@ -1,18 +1,21 @@
 #ifndef SGEN_GREP_BINPROT_H
 #define SGEN_GREP_BINPROT_H
 
-typedef gboolean GrepEntriesFunction(
-	EntryStream *stream,
-	int num_nums,
-	long nums [],
-	int num_patterns,
-	const char *patterns [],
-	int num_vtables,
-	long vtables [],
-	gboolean dump_all,
-	gboolean pause_times,
-	gboolean color_output,
-	unsigned long long first_entry_to_consider);
+typedef struct {
+	int num_nums;
+	long *nums;
+	int num_patterns;
+	const char **patterns;
+	int num_vtables;
+	long *vtables;
+	gboolean dump_all;
+	gboolean pause_times;
+	gboolean color_output;
+	unsigned long long first_entry_to_consider;
+} GrepOptions;
+
+typedef gboolean GrepEntriesFunction (
+	EntryStream *stream, const GrepOptions *options);
 
 GrepEntriesFunction
 	sgen_binary_protocol_grep_entries,


### PR DESCRIPTION
This adds a `--match` / `-m` flag to `sgen-grep-binprot`, so you can search for events without going through `grep`.

```
sgen-grep-binprot --all -m 'region_*' </tmp/binprot
```
