### PR TITLE
[docs] Added index.xml entry for CFNetworkHandler.

### DIFF
--- a/mcs/class/System.Net.Http/Documentation/en/index.xml
+++ b/mcs/class/System.Net.Http/Documentation/en/index.xml
@@ -56,6 +56,7 @@
   <Types>
     <Namespace Name="System.Net.Http">
       <Type Name="ByteArrayContent" Kind="Class" />
+      <Type Name="CFNetworkHandler" Kind="Class" />
       <Type Name="ClientCertificateOption" Kind="Enumeration" />
       <Type Name="DelegatingHandler" Kind="Class" />
       <Type Name="FormUrlEncodedContent" Kind="Class" />


### PR DESCRIPTION
This particular piece of documentation is added manually, because it's not in the regular BCL library, but is provided by Xamarin on the iOS platform. Because it was missing an entry in the index file, it was excluded from the published documentation when doing mdoc assemble.