### PR TITLE
[corlib] Ifdef out calls to SynchronizationAttribute on monotouch

### DIFF
--- a/mcs/class/corlib/System.Threading/Monitor.cs
+++ b/mcs/class/corlib/System.Threading/Monitor.cs
@@ -159,33 +159,33 @@ namespace System.Threading
 
 		public static bool Wait(object obj, int millisecondsTimeout, bool exitContext) {
 			try {
+#if !MONOTOUCH
 				if (exitContext) {
-#if MONOTOUCH
-					throw new NotSupportedException ("exitContext == true is not supported");
-#else
 					SynchronizationAttribute.ExitContext ();
-#endif
 				}
+#endif
 				return Wait (obj, millisecondsTimeout);
 			}
 			finally {
+#if !MONOTOUCH
 				if (exitContext) SynchronizationAttribute.EnterContext ();
+#endif
 			}
 		}
 
 		public static bool Wait(object obj, TimeSpan timeout, bool exitContext) {
 			try {
+#if !MONOTOUCH
 				if (exitContext) {
-#if MONOTOUCH
-					throw new NotSupportedException ("exitContext == true is not supported");
-#else
 					SynchronizationAttribute.ExitContext ();
-#endif
 				}
+#endif
 				return Wait (obj, timeout);
 			}
 			finally {
+#if !MONOTOUCH
 				if (exitContext) SynchronizationAttribute.EnterContext ();
+#endif
 			}
 		}
 

--- a/mcs/class/corlib/System.Threading/WaitHandle.cs
+++ b/mcs/class/corlib/System.Threading/WaitHandle.cs
@@ -47,16 +47,13 @@ namespace System.Threading
 
 		static int WaitMultiple(WaitHandle[] waitHandles, int millisecondsTimeout, bool exitContext, bool WaitAll)
 		{
-#if MONOTOUCH
-			if (exitContext)
-				throw new NotSupportedException ("exitContext == true is not supported");
-#endif
-
 			int release_last = -1;
 
 			try {
+#if !MONOTOUCH
 				if (exitContext)
 					SynchronizationAttribute.ExitContext ();
+#endif
 
 				for (int i = 0; i < waitHandles.Length; ++i) {
 					try {
@@ -78,8 +75,10 @@ namespace System.Threading
 					waitHandles [i].SafeWaitHandle.DangerousRelease ();
 				}
 
+#ifdef !MONOTOUCH
 				if (exitContext)
 					SynchronizationAttribute.EnterContext ();
+#endif
 			}
 		}
 
@@ -91,15 +90,12 @@ namespace System.Threading
 
 		static int WaitOneNative (SafeHandle waitableSafeHandle, uint millisecondsTimeout, bool hasThreadAffinity, bool exitContext)
 		{
-#if MONOTOUCH
-			if (exitContext)
-				throw new NotSupportedException ("exitContext == true is not supported");
-#endif
-
 			bool release = false;
 			try {
+#ifdef !MONOTOUCH
 				if (exitContext)
 					SynchronizationAttribute.ExitContext ();
+#endif
 
 				waitableSafeHandle.DangerousAddRef (ref release);
 
@@ -108,8 +104,10 @@ namespace System.Threading
 				if (release)
 					waitableSafeHandle.DangerousRelease ();
 
+#ifdef !MONOTOUCH
 				if (exitContext)
 					SynchronizationAttribute.EnterContext ();
+#endif
 			}
 		}
 


### PR DESCRIPTION
When WaitHandle was imported from referencesource in f6fa8f03593266cd8d9c85771eb7db28eda85fa3, the code was refactored and basically all WaitHandle.Wait* calls end up in WaitOneNative or WaitMultiple now.

On monotouch those methods threw a NotSupportedException when exitContext == true even before the import, so this behavior got inherited to some other methods that didn't throw after the exception was removed from them in 93e31cbc63ffe70c6d4d0335a7fc822d996459a6. This broke tests in maccore and other code that passed exitContext=true.

To fix this, we just ifdef out the calls to SynchronizationAttribute on monotouch since they don't
make sense there anyway since remoting isn't available. The commit that initially added the exception
in 2ce9fc1b0e2afde3101537a27ee367683f1882af only did that to make the behavior consistent when the linker is enabled. By removing the calls we get the same result.

Do the same for Monitor so we're consistent.