### PR TITLE
[corlib] Ifdef out calls to SynchronizationAttribute on monotouch

### DIFF
--- a/mcs/class/corlib/System.Threading/Monitor.cs
+++ b/mcs/class/corlib/System.Threading/Monitor.cs
@@ -159,33 +159,33 @@ namespace System.Threading
 
 		public static bool Wait(object obj, int millisecondsTimeout, bool exitContext) {
 			try {
-				if (exitContext) {
-#if MONOTOUCH
-					throw new NotSupportedException ("exitContext == true is not supported");
-#else
+#if !DISABLE_REMOTING
+				if (exitContext)
 					SynchronizationAttribute.ExitContext ();
 #endif
-				}
 				return Wait (obj, millisecondsTimeout);
 			}
 			finally {
-				if (exitContext) SynchronizationAttribute.EnterContext ();
+#if !DISABLE_REMOTING
+				if (exitContext)
+					SynchronizationAttribute.EnterContext ();
+#endif
 			}
 		}
 
 		public static bool Wait(object obj, TimeSpan timeout, bool exitContext) {
 			try {
-				if (exitContext) {
-#if MONOTOUCH
-					throw new NotSupportedException ("exitContext == true is not supported");
-#else
+#if !DISABLE_REMOTING
+				if (exitContext)
 					SynchronizationAttribute.ExitContext ();
 #endif
-				}
 				return Wait (obj, timeout);
 			}
 			finally {
-				if (exitContext) SynchronizationAttribute.EnterContext ();
+#if !DISABLE_REMOTING
+				if (exitContext)
+					SynchronizationAttribute.EnterContext ();
+#endif
 			}
 		}
 

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 145;
+		private const int mono_corlib_version = 146;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -81,7 +81,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 145
+#define MONO_CORLIB_VERSION 146
 
 typedef struct
 {

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -96,10 +96,10 @@ gboolean ves_icall_System_Threading_Events_ResetEvent_internal (HANDLE handle);
 void ves_icall_System_Threading_Events_CloseEvent_internal (HANDLE handle);
 HANDLE ves_icall_System_Threading_Events_OpenEvent_internal (MonoString *name, gint32 rights, gint32 *error);
 
-gint32 ves_icall_System_Threading_WaitHandle_WaitAll_internal(MonoArray *mono_handles, gint32 ms, gboolean exitContext);
-gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_handles, gint32 ms, gboolean exitContext);
-gint32 ves_icall_System_Threading_WaitHandle_WaitOne_internal(HANDLE handle, gint32 ms, gboolean exitContext);
-gint32 ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (HANDLE toSignal, HANDLE toWait, gint32 ms, gboolean exitContext);
+gint32 ves_icall_System_Threading_WaitHandle_WaitAll_internal(MonoArray *mono_handles, gint32 ms);
+gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_handles, gint32 ms);
+gint32 ves_icall_System_Threading_WaitHandle_WaitOne_internal(HANDLE handle, gint32 ms);
+gint32 ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (HANDLE toSignal, HANDLE toWait, gint32 ms);
 
 MonoArray* ves_icall_System_Threading_Thread_ByteArrayToRootDomain (MonoArray *arr);
 MonoArray* ves_icall_System_Threading_Thread_ByteArrayToCurrentDomain (MonoArray *arr);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1607,8 +1607,7 @@ mono_wait_uninterrupted (MonoInternalThread *thread, gboolean multiple, guint32 
 	return ret;
 }
 
-/* FIXME: exitContext isnt documented */
-gint32 ves_icall_System_Threading_WaitHandle_WaitAll_internal(MonoArray *mono_handles, gint32 ms, gboolean exitContext)
+gint32 ves_icall_System_Threading_WaitHandle_WaitAll_internal(MonoArray *mono_handles, gint32 ms)
 {
 	HANDLE *handles;
 	guint32 numhandles;
@@ -1645,8 +1644,7 @@ gint32 ves_icall_System_Threading_WaitHandle_WaitAll_internal(MonoArray *mono_ha
 	return ret == WAIT_FAILED ? 0x7fffffff : ret;
 }
 
-/* FIXME: exitContext isnt documented */
-gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_handles, gint32 ms, gboolean exitContext)
+gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_handles, gint32 ms)
 {
 	HANDLE handles [MAXIMUM_WAIT_OBJECTS];
 	uintptr_t numhandles;
@@ -1694,8 +1692,7 @@ gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_ha
 	}
 }
 
-/* FIXME: exitContext isnt documented */
-gint32 ves_icall_System_Threading_WaitHandle_WaitOne_internal(HANDLE handle, gint32 ms, gboolean exitContext)
+gint32 ves_icall_System_Threading_WaitHandle_WaitOne_internal(HANDLE handle, gint32 ms)
 {
 	guint32 ret;
 	MonoInternalThread *thread = mono_thread_internal_current ();
@@ -1719,7 +1716,7 @@ gint32 ves_icall_System_Threading_WaitHandle_WaitOne_internal(HANDLE handle, gin
 }
 
 gint32
-ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (HANDLE toSignal, HANDLE toWait, gint32 ms, gboolean exitContext)
+ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (HANDLE toSignal, HANDLE toWait, gint32 ms)
 {
 	guint32 ret;
 	MonoInternalThread *thread = mono_thread_internal_current ();


### PR DESCRIPTION
When WaitHandle was imported from referencesource in f6fa8f0, the code was refactored and basically all WaitHandle.Wait* calls end up in WaitOneNative or WaitMultiple now.

On monotouch those methods threw a NotSupportedException when exitContext == true even before the import, so this behavior got inherited to some other methods that didn't throw after the exception was removed from them in 93e31cb. This broke tests in maccore and other code that passed exitContext=true.

To fix this, we just ifdef out the calls to SynchronizationAttribute on monotouch since they don't make sense there anyway since remoting isn't available. The commit that initially added the exception in 2ce9fc1 only did that to make the behavior consistent when the linker is enabled. By removing the calls we get the same result.

Do the same for Monitor so we're consistent.

commit message from @akoeplinger