### PR TITLE
bugfix numInfo of Cultureinfo NonSerialized on Windows

### DIFF
--- a/mcs/class/corlib/System.Globalization/CultureInfo.cs
+++ b/mcs/class/corlib/System.Globalization/CultureInfo.cs
@@ -59,7 +59,6 @@ namespace System.Globalization
 		[NonSerialized]
 		int default_calendar_type;
 		bool m_useUserOverride;
-		[NonSerialized]
 		internal volatile NumberFormatInfo numInfo;
 		internal volatile DateTimeFormatInfo dateTimeInfo;
 		volatile TextInfo textInfo;


### PR DESCRIPTION
Xamarin Bug: https://bugzilla.xamarin.com/show_bug.cgi?id=35872

Cultureinfo numInfo is not NonSerialized on DotNet for windows, so it also should not on mono.

http://referencesource.microsoft.com/#mscorlib/system/globalization/cultureinfo.cs,76