### PR TITLE
[System.Core] Add back AesManaged to tvOS and watchOS profiles. Fixes #40570

### DIFF
--- a/mcs/class/System.Core/monotouch_tv_System.Core.dll.sources
+++ b/mcs/class/System.Core/monotouch_tv_System.Core.dll.sources
@@ -1,2 +1,1 @@
-#include common_System.Core.dll.sources
-#include interpreter_System.Core.dll.sources
+#include monotouch_System.Core.dll.sources

--- a/mcs/class/System.Core/monotouch_watch_System.Core.dll.sources
+++ b/mcs/class/System.Core/monotouch_watch_System.Core.dll.sources
@@ -1,2 +1,1 @@
-#include common_System.Core.dll.sources
-#include interpreter_System.Core.dll.sources
+#include monotouch_System.Core.dll.sources


### PR DESCRIPTION
Switching maccore to use mono-4.5.0-branch introduced this bug where
AesManaged is not available in System.Core for both tvOS and watchOS
profiles (iOS is fine).

This results in unit tests failures on bots building maccore/master.

This fix the problem by importing the "main" monotouch_System.Core.
dll.sources into the other profiles - since they all share the same
feature set (in this case) and make it less likely to forget something
else in the future.

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=40570