### PR TITLE
[runtime] MonoError-ize mono_thread_create{,_internal}

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -828,7 +828,9 @@ static
 void
 mono_gc_init_finalizer_thread (void)
 {
-	gc_thread = mono_thread_create_internal (mono_domain_get (), finalizer_thread, NULL, FALSE, 0);
+	MonoError error;
+	gc_thread = mono_thread_create_internal (mono_domain_get (), finalizer_thread, NULL, FALSE, 0, &error);
+	mono_error_assert_ok (&error);
 }
 
 void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4475,7 +4475,9 @@ mono_runtime_exec_managed_code (MonoDomain *domain,
 				MonoMainThreadFunc main_func,
 				gpointer main_args)
 {
-	mono_thread_create (domain, main_func, main_args);
+	MonoError error;
+	mono_thread_create_checked (domain, main_func, main_args, &error);
+	mono_error_assert_ok (&error);
 
 	mono_thread_manage ();
 }

--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -536,8 +536,9 @@ initialize (void)
 	if (!threadpool_io->backend.init (threadpool_io->wakeup_pipes [0]))
 		g_error ("initialize: backend->init () failed");
 
-	if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, TRUE, SMALL_STACK))
-		g_error ("initialize: mono_thread_create_internal () failed");
+	MonoError error;
+	if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, TRUE, SMALL_STACK, &error))
+		g_error ("initialize: mono_thread_create_internal () failed due to %s", mono_error_get_message (&error));
 }
 
 static void

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -65,7 +65,7 @@ typedef void (*MonoThreadCleanupFunc) (MonoNativeThreadId tid);
 /* INFO has type MonoThreadInfo* */
 typedef void (*MonoThreadNotifyPendingExcFunc) (gpointer info);
 
-MonoInternalThread* mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, gboolean threadpool_thread, guint32 stack_size);
+MonoInternalThread* mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, gboolean threadpool_thread, guint32 stack_size, MonoError *error);
 
 void mono_threads_install_cleanup (MonoThreadCleanupFunc func);
 
@@ -244,6 +244,9 @@ gpointer mono_get_special_static_data_for_thread (MonoInternalThread *thread, gu
 
 MonoException* mono_thread_resume_interruption (void);
 void mono_threads_perform_thread_dump (void);
+
+gboolean
+mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, MonoError *error);
 
 MonoThread *
 mono_thread_attach_full (MonoDomain *domain, gboolean force_attach, MonoError *error);

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -34,7 +34,10 @@ extern MONO_API void mono_thread_stop (MonoThread *thread);
 
 extern MONO_API void mono_thread_new_init (intptr_t tid, void* stack_start,
 				  void* func);
-extern MONO_API void mono_thread_create (MonoDomain *domain, void* func, void* arg);
+
+extern MONO_RT_EXTERNAL_ONLY MONO_API void
+mono_thread_create (MonoDomain *domain, void* func, void* arg);
+
 extern MONO_API MonoThread *mono_thread_attach (MonoDomain *domain);
 extern MONO_API void mono_thread_detach (MonoThread *thread);
 extern MONO_API void mono_thread_exit (void);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -851,6 +851,7 @@ small_id_thread_func (gpointer arg)
 static void
 jit_info_table_test (MonoDomain *domain)
 {
+	MonoError error;
 	int i;
 
 	g_print ("testing jit_info_table\n");
@@ -879,8 +880,10 @@ jit_info_table_test (MonoDomain *domain)
 	sleep (2);
 	*/
 
-	for (i = 0; i < num_threads; ++i)
-		mono_thread_create (domain, test_thread_func, &thread_datas [i]);
+	for (i = 0; i < num_threads; ++i) {
+		mono_thread_create_checked (domain, test_thread_func, &thread_datas [i], &error);
+		mono_error_assert_ok (&error);
+	}
 }
 #endif
 
@@ -973,6 +976,7 @@ compile_all_methods_thread_main (CompileAllThreadArgs *args)
 static void
 compile_all_methods (MonoAssembly *ass, int verbose, guint32 opts, guint32 recompilation_times)
 {
+	MonoError error;
 	CompileAllThreadArgs args;
 
 	args.ass = ass;
@@ -984,7 +988,8 @@ compile_all_methods (MonoAssembly *ass, int verbose, guint32 opts, guint32 recom
 	 * Need to create a mono thread since compilation might trigger
 	 * running of managed code.
 	 */
-	mono_thread_create (mono_domain_get (), compile_all_methods_thread_main, &args);
+	mono_thread_create_checked (mono_domain_get (), compile_all_methods_thread_main, &args, &error);
+	mono_error_assert_ok (&error);
 
 	mono_thread_manage ();
 }


### PR DESCRIPTION
Mark mono_thread_create external only.  Runtime should use
mono_thread_create_checked.