### PR TITLE
Socket.AcceptAsync should use SocketAsyncEventArgs.AcceptSocket

### DIFF
--- a/mcs/class/System/System_test.dll.sources
+++ b/mcs/class/System/System_test.dll.sources
@@ -247,6 +247,7 @@ System.Net.Sockets/MulticastOptionTest.cs
 System.Net.Sockets/NetworkStreamTest.cs
 System.Net.Sockets/TcpClientTest.cs
 System.Net.Sockets/TcpListenerTest.cs
+System.Net.Sockets/SocketAcceptAsyncTest.cs
 System.Net.Sockets/SocketTest.cs
 System.Net.Sockets/SocketAsyncEventArgsTest.cs
 System.Net.Sockets/SocketConnectAsyncTest.cs

--- a/mcs/class/System/Test/System.Net.Sockets/SocketAcceptAsyncTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketAcceptAsyncTest.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using System.Net;
+using System.Net.Sockets;
+using NUnit.Framework;
+
+namespace MonoTests.System.Net.Sockets
+{
+	[TestFixture]
+	public class SocketAcceptAsyncTest
+	{
+		private Socket _listenSocket;
+		private Socket _clientSocket;
+		private Socket _serverSocket;
+		private Socket _acceptedSocket;
+		private ManualResetEvent _readyEvent;
+		private ManualResetEvent _mainEvent;
+
+		[TestFixtureSetUp]
+		public void SetUp()
+		{
+			_readyEvent = new ManualResetEvent(false);
+			_mainEvent = new ManualResetEvent(false);
+
+			ThreadPool.QueueUserWorkItem(_ => StartListen());
+			if (!_readyEvent.WaitOne(1500))
+				throw new TimeoutException();
+
+			_clientSocket = new Socket(
+				AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			_clientSocket.Connect(_listenSocket.LocalEndPoint);
+			_clientSocket.NoDelay = true;
+		}
+
+		[TestFixtureTearDown]
+		public void TearDown()
+		{
+			if (_acceptedSocket != null)
+				_acceptedSocket.Close();
+			if (_listenSocket != null)
+				_listenSocket.Close();
+			_readyEvent.Close();
+			_mainEvent.Close();
+		}
+
+		private void StartListen()
+		{
+			_listenSocket = new Socket(
+				AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			_listenSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+			_listenSocket.Listen(1);
+
+			_serverSocket = new Socket(
+				AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+      var async = new SocketAsyncEventArgs();
+			async.AcceptSocket = _serverSocket;
+			async.Completed += (s, e) => OnAccepted(e);
+
+			_readyEvent.Set();
+
+			if (!_listenSocket.AcceptAsync(async))
+				OnAccepted(async);
+		}
+
+		private void OnAccepted(SocketAsyncEventArgs e)
+		{
+			_acceptedSocket = e.AcceptSocket;
+			_mainEvent.Set();
+		}
+
+		[Test]
+		[Category("Test")]
+		public void AcceptAsyncShouldUseAcceptSocketFromEventArgs()
+		{
+			if (!_mainEvent.WaitOne(1500))
+				throw new TimeoutException();
+			Assert.AreEqual(_serverSocket, _acceptedSocket);
+			_mainEvent.Reset();
+		}
+	}
+}

--- a/mcs/class/System/Test/System.Net.Sockets/SocketAcceptAsyncTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketAcceptAsyncTest.cs
@@ -23,8 +23,7 @@ namespace MonoTests.System.Net.Sockets
 			_mainEvent = new ManualResetEvent(false);
 
 			ThreadPool.QueueUserWorkItem(_ => StartListen());
-			if (!_readyEvent.WaitOne(1500))
-				throw new TimeoutException();
+			Assert.IsTrue(_readyEvent.WaitOne(1500));
 
 			_clientSocket = new Socket(
 				AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -70,11 +69,9 @@ namespace MonoTests.System.Net.Sockets
 		}
 
 		[Test]
-		[Category("Test")]
 		public void AcceptAsyncShouldUseAcceptSocketFromEventArgs()
 		{
-			if (!_mainEvent.WaitOne(1500))
-				throw new TimeoutException();
+			Assert.IsTrue(_mainEvent.WaitOne(1500));
 			Assert.AreEqual(_serverSocket, _acceptedSocket);
 			_mainEvent.Reset();
 		}


### PR DESCRIPTION
Socket.AcceptAsync shouldn't create new socket if SocketAsyncEventArgs.AcceptSocket isn't null.