### PR TITLE
Make xbuild on Windows use Mono instead of .NET

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Csc.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Csc.cs
@@ -144,7 +144,11 @@ namespace Microsoft.Build.Tasks {
 		{
 			if (!string.IsNullOrEmpty (ToolPath))
 				return Path.Combine (ToolPath, ToolExe);
-			return ToolLocationHelper.GetPathToDotNetFrameworkFile (ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
+			var possibleToolPath = ToolLocationHelper.GetPathToDotNetFrameworkFile (ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
+			if (!string.IsNullOrEmpty(possibleToolPath))
+				return  possibleToolPath;
+
+			return ToolLocationHelper.GetPathToDotNetFrameworkBinFile(ToolExe);
 		}
 
 		[MonoTODO]
@@ -215,7 +219,7 @@ namespace Microsoft.Build.Tasks {
 
 		protected override string ToolName {
 			get {
-				return "mcs.exe";
+				return MSBuildUtils.RunningOnWindows ? "mcs.bat" : "mcs.exe";
 			}
 		}
 

--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolLocationHelper.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolLocationHelper.cs
@@ -148,6 +148,16 @@ namespace Microsoft.Build.Utilities
 			return null;
 		}
 
+		public static string GetPathToDotNetFrameworkBinFile (string fileName)
+		{
+			string dir = Path.Combine(Directory.GetParent(Directory.GetParent(lib_mono_dir).FullName).FullName, "bin");
+			string file = Path.Combine (dir, fileName);
+			if (File.Exists (file))
+				return file;
+
+			return null;
+		}
+
 		public static string GetPathToDotNetFrameworkSdk (TargetDotNetFrameworkVersion version)
 		{
 			return GetPathToDotNetFramework (version);


### PR DESCRIPTION
We don't have .Net 4.6 installed on all of our build machines, so
running mcs.exe on Windows fails, as it was built with .NET 4.6.
Instead, we will run mcs.exe via Mono on Windows (which is what happens
on OSX, although there the low-level Process class handles it).

To accomplish this, we run mcs.bat instead of mcs.exe.