### PR TITLE
Revert "[runtime] Fix potential overflow when using mono_msec_ticks"

### DIFF
--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -2727,7 +2727,8 @@ process_wait (gpointer handle, guint32 timeout, gboolean alertable)
 	WapiHandle_process *process_handle;
 	pid_t pid G_GNUC_UNUSED, ret;
 	int status;
-	gint64 start, now;
+	guint32 start;
+	guint32 now;
 	struct MonoProcess *mp;
 
 	/* FIXME: We can now easily wait on processes that aren't our own children,

--- a/mono/io-layer/timefuncs-private.h
+++ b/mono/io-layer/timefuncs-private.h
@@ -15,6 +15,8 @@
 #include <sys/time.h>
 
 extern void _wapi_time_t_to_filetime (time_t timeval, WapiFileTime *filetime);
+extern void _wapi_timeval_to_filetime (struct timeval *tv,
+				       WapiFileTime *filetime);
 extern void _wapi_guint64_to_filetime (guint64 ticks, WapiFileTime *filetime);
 
 #endif /* _WAPI_TIMEFUNCS_PRIVATE_H_ */

--- a/mono/io-layer/timefuncs.c
+++ b/mono/io-layer/timefuncs.c
@@ -28,8 +28,33 @@ void _wapi_time_t_to_filetime (time_t timeval, WapiFileTime *filetime)
 	filetime->dwHighDateTime = ticks >> 32;
 }
 
+void _wapi_timeval_to_filetime (struct timeval *tv, WapiFileTime *filetime)
+{
+	guint64 ticks;
+	
+	ticks = ((guint64)tv->tv_sec * 10000000) +
+		((guint64)tv->tv_usec * 10) + 116444736000000000ULL;
+	filetime->dwLowDateTime = ticks & 0xFFFFFFFF;
+	filetime->dwHighDateTime = ticks >> 32;
+}
+
 void _wapi_guint64_to_filetime (guint64 ticks, WapiFileTime *filetime)
 {
 	filetime->dwLowDateTime = ticks & 0xFFFFFFFF;
 	filetime->dwHighDateTime = ticks >> 32;
+}
+
+gboolean QueryPerformanceCounter(WapiLargeInteger *count G_GNUC_UNUSED)
+{
+	return(FALSE);
+}
+
+gboolean QueryPerformanceFrequency(WapiLargeInteger *freq G_GNUC_UNUSED)
+{
+	return(FALSE);
+}
+
+guint32 GetTickCount (void)
+{
+	return mono_msec_ticks ();
 }

--- a/mono/io-layer/timefuncs.h
+++ b/mono/io-layer/timefuncs.h
@@ -30,5 +30,9 @@ typedef struct
 #endif
 } WapiFileTime;
 
+extern gboolean QueryPerformanceCounter(WapiLargeInteger *count);
+extern gboolean QueryPerformanceFrequency(WapiLargeInteger *freq);
+extern guint32 GetTickCount (void);
+
 G_END_DECLS
 #endif /* _WAPI_TIME_H_ */

--- a/mono/io-layer/wapi-remap.h
+++ b/mono/io-layer/wapi-remap.h
@@ -89,6 +89,9 @@
 #define WSARecv wapi_WSARecv 
 #define WSASend wapi_WSASend 
 #define GetSystemInfo wapi_GetSystemInfo
+#define QueryPerformanceCounter wapi_QueryPerformanceCounter
+#define QueryPerformanceFrequency wapi_QueryPerformanceFrequency
+#define GetTickCount wapi_GetTickCount 
 #define GetFileVersionInfoSize wapi_GetFileVersionInfoSize 
 #define GetFileVersionInfo wapi_GetFileVersionInfo 
 #define VerQueryValue wapi_VerQueryValue 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -876,14 +876,14 @@ mono_gc_cleanup (void)
 		finished = TRUE;
 		if (mono_thread_internal_current () != gc_thread) {
 			gboolean timed_out = FALSE;
-			gint64 start_ticks = mono_msec_ticks ();
-			gint64 end_ticks = start_ticks + 2000;
+			guint32 start_ticks = mono_msec_ticks ();
+			guint32 end_ticks = start_ticks + 2000;
 
 			mono_gc_finalize_notify ();
 			/* Finishing the finalizer thread, so wait a little bit... */
 			/* MS seems to wait for about 2 seconds */
 			while (!finalizer_thread_exited) {
-				gint64 current_ticks = mono_msec_ticks ();
+				guint32 current_ticks = mono_msec_ticks ();
 				guint32 timeout;
 
 				if (current_ticks >= end_ticks)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -239,7 +239,7 @@ ICALL(ENV_10, "get_HasShutdownStarted", ves_icall_System_Environment_get_HasShut
 ICALL(ENV_11, "get_MachineName", ves_icall_System_Environment_get_MachineName)
 ICALL(ENV_13, "get_Platform", ves_icall_System_Environment_get_Platform)
 ICALL(ENV_14, "get_ProcessorCount", mono_cpu_count)
-ICALL(ENV_15, "get_TickCount", ves_icall_System_Environment_get_TickCount)
+ICALL(ENV_15, "get_TickCount", mono_msec_ticks)
 ICALL(ENV_16, "get_UserName", ves_icall_System_Environment_get_UserName)
 ICALL(ENV_16m, "internalBroadcastSettingChange", ves_icall_System_Environment_BroadcastSettingChange)
 ICALL(ENV_17, "internalGetEnvironmentVariable", ves_icall_System_Environment_GetEnvironmentVariable)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7278,14 +7278,6 @@ ves_icall_System_Environment_BroadcastSettingChange (void)
 #endif
 }
 
-ICALL_EXPORT
-gint32
-ves_icall_System_Environment_get_TickCount (void)
-{
-	/* this will overflow after ~24 days */
-	return (gint32) (mono_msec_boottime () & 0xffffffff);
-}
-
 ICALL_EXPORT gint32
 ves_icall_System_Runtime_Versioning_VersioningHelper_GetRuntimeId (void)
 {

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -743,7 +743,7 @@ mono_monitor_try_enter_inflated (MonoObject *obj, guint32 ms, gboolean allow_int
 	LockWord lw;
 	MonoThreadsSync *mon;
 	HANDLE sem;
-	gint64 then = 0, now, delta;
+	guint32 then = 0, now, delta;
 	guint32 waitms;
 	guint32 ret;
 	guint32 new_status, old_status, tmp_status;
@@ -900,9 +900,14 @@ retry_contended:
 		if (!mono_thread_test_state (mono_thread_internal_current (), (MonoThreadState)(ThreadState_StopRequested | ThreadState_SuspendRequested | ThreadState_AbortRequested))) {
 			if (ms != INFINITE) {
 				now = mono_msec_ticks ();
+				if (now < then) {
+					LOCK_DEBUG (g_message ("%s: wrapped around! now=0x%x then=0x%x", __func__, now, then));
 
-				/* it should not overflow before ~30k years */
-				g_assert (now >= then);
+					now += (0xffffffff - then);
+					then = 0;
+
+					LOCK_DEBUG (g_message ("%s: wrap rejig: now=0x%x then=0x%x delta=0x%x", __func__, now, then, now-then));
+				}
 
 				delta = now - then;
 				if (delta >= ms) {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3790,7 +3790,7 @@ mono_threads_abort_appdomain_threads (MonoDomain *domain, int timeout)
 #endif
 
 	abort_appdomain_data user_data;
-	gint64 start_time;
+	guint32 start_time;
 	int orig_timeout = timeout;
 	int i;
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1120,8 +1120,8 @@ socket_transport_recv (void *buf, int len)
 	int total = 0;
 	int fd = conn_fd;
 	int flags = 0;
-	static gint64 last_keepalive;
-	gint64 msecs;
+	static gint32 last_keepalive;
+	gint32 msecs;
 
 	MONO_PREPARE_BLOCKING;
 

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -325,7 +325,7 @@ mono_process_get_times (gpointer pid, gint64 *start_time, gint64 *user_time, gin
 		if (*start_time == 0) {
 			static guint64 boot_time = 0;
 			if (!boot_time)
-				boot_time = mono_100ns_datetime () - mono_msec_boottime () * 10000;
+				boot_time = mono_100ns_datetime () - ((guint64)mono_msec_ticks ()) * 10000;
 
 			*start_time = boot_time + mono_process_get_data (pid, MONO_PROCESS_ELAPSED);
 		}

--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -16,27 +16,16 @@
 #include <utils/mono-time.h>
 
 
-#define MTICKS_PER_SEC (10 * 1000 * 1000)
-
-gint64
-mono_msec_ticks (void)
-{
-	return mono_100ns_ticks () / 10 / 1000;
-}
+#define MTICKS_PER_SEC 10000000
 
 #ifdef HOST_WIN32
 #include <windows.h>
 
-#ifndef _MSC_VER
-/* we get "error: implicit declaration of function 'GetTickCount64'" */
-ULONGLONG GetTickCount64(void);
-#endif
-
-gint64
-mono_msec_boottime (void)
+guint32
+mono_msec_ticks (void)
 {
 	/* GetTickCount () is reportedly monotonic */
-	return GetTickCount64 ();
+	return GetTickCount ();
 }
 
 /* Returns the number of 100ns ticks from unspecified time: this should be monotonic */
@@ -125,8 +114,8 @@ get_boot_time (void)
 }
 
 /* Returns the number of milliseconds from boot time: this should be monotonic */
-gint64
-mono_msec_boottime (void)
+guint32
+mono_msec_ticks (void)
 {
 	static gint64 boot_time = 0;
 	gint64 now;
@@ -134,7 +123,6 @@ mono_msec_boottime (void)
 		boot_time = get_boot_time ();
 	now = mono_100ns_ticks ();
 	/*printf ("now: %llu (boot: %llu) ticks: %llu\n", (gint64)now, (gint64)boot_time, (gint64)(now - boot_time));*/
-	g_assert (now > boot_time);
 	return (now - boot_time)/10000;
 }
 

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -8,19 +8,14 @@
 #include <sys/time.h>
 #endif
 
-/* Returns the number of milliseconds from boot time: this should be monotonic
- *
- * Prefer to use mono_msec_ticks for elapsed time calculation. */
-gint64 mono_msec_boottime (void);
-
-/* Returns the number of milliseconds ticks from unspecified time: this should be monotonic */
-gint64 mono_msec_ticks (void);
+/* Returns the number of milliseconds from boot time: this should be monotonic */
+guint32 mono_msec_ticks      (void);
 
 /* Returns the number of 100ns ticks from unspecified time: this should be monotonic */
-gint64 mono_100ns_ticks (void);
+gint64  mono_100ns_ticks     (void);
 
 /* Returns the number of 100ns ticks since 1/1/1601, UTC timezone */
-gint64 mono_100ns_datetime (void);
+gint64  mono_100ns_datetime  (void);
 
 #ifndef HOST_WIN32
 gint64 mono_100ns_datetime_from_timeval (struct timeval tv);


### PR DESCRIPTION
Reverts mono/mono#2721

It crashes badly on OSX when getting Environment.TickCount:

```
* Assertion at mono-time.c:137, condition `now > boot_time' not met

Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.Environment.get_TickCount () <IL 0x00006, 0x00052>
```