### PR TITLE
[corlib] Bring the FileInfo.Delete fix

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
@@ -595,6 +595,8 @@ namespace MonoTests.System.IO
 			try {
 				FileInfo info = new FileInfo (path);
 				Assert.IsFalse (info.Exists, "#1");
+				info.Delete ();
+				Assert.IsFalse (info.Exists, "#1a");
 				info.Create ().Close ();
 				info = new FileInfo (path);
 				Assert.IsTrue (info.Exists, "#2");


### PR DESCRIPTION
See https://github.com/mono/referencesource/commit/fdebd8a4d709002bb499555c35e1dfd3834e2f4f for details.

Also add a test for checking if deleting a non-existent file works (we were missing coverage there before).