### PR TITLE
[coop] Allow BLOCKING->DETACHED transition

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -951,7 +951,7 @@ mono_jit_thread_attach (MonoDomain *domain, gpointer *dummy)
 
 			/* mono_threads_reset_blocking_start returns the current MonoThreadInfo
 			 * if we were in BLOCKING mode */
-			return mono_thread_info_current ();
+			return mono_threads_cookie_for_reset_blocking_start (mono_thread_info_current (), 1);
 		} else {
 			orig = mono_domain_get ();
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -608,6 +608,9 @@ MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE
 
 MonoThreadUnwindState* mono_thread_info_get_suspend_state (THREAD_INFO_TYPE *info);
 
+gpointer
+mono_threads_cookie_for_reset_blocking_start (THREAD_INFO_TYPE *info, int reset_blocking_count);
+
 
 void mono_thread_info_wait_for_resume (THREAD_INFO_TYPE *info);
 /* Advanced suspend API, used for suspending multiple threads as once. */


### PR DESCRIPTION
Also use the correct reset blocking cookie when MONO_CHECK_MODE includes "gc".

On coop, an OS thread can have the following state transitions: "STARTING->BLOCKING->RUNNING->BLOCKING->DETACHED".

For ordinary managed threads BLOCKING->DETACHED is still a bug like
before, but hopefully the checked build machinery will help us to catch
those situations.

Fixes pinvoke3.cs test in coop mode.