### PR TITLE
[coop] Remove try { ... } finally { ... } blocks from wrappers + Fix state transitions in trampolines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3595,6 +3595,8 @@ AC_ARG_WITH(cooperative_gc, [  --with-cooperative-gc=yes|no      Enable cooperat
 	fi
 ], [with_cooperative_gc=no])
 
+AM_CONDITIONAL([ENABLE_COOP], [test x$with_cooperative_gc != xno])
+
 AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable checked build (expensive asserts), configure with a comma-separated LIST of checked build modules and then include that same list in the environment variable MONO_CHECK_MODE at runtime. Recognized checked build modules: all, gc, metadata, thread],[
 
 	if test x$enable_checked_build != x ; then

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -315,8 +315,8 @@ mono_marshal_init (void)
 		register_icall (mono_marshal_isinst_with_cache, "mono_marshal_isinst_with_cache", "object object ptr ptr", FALSE);
 		register_icall (mono_marshal_has_ftnptr_eh_callback, "mono_marshal_has_ftnptr_eh_callback", "int32", TRUE);
 		register_icall (mono_marshal_ftnptr_eh_callback, "mono_marshal_ftnptr_eh_callback", "void uint32", TRUE);
-		register_icall (mono_threads_prepare_blocking, "mono_threads_prepare_blocking", "ptr ptr", TRUE);
-		register_icall (mono_threads_finish_blocking, "mono_threads_finish_blocking", "void ptr ptr", TRUE);
+		register_icall (mono_threads_prepare_blocking_unbalanced, "mono_threads_prepare_blocking_unbalanced", "ptr ptr", TRUE);
+		register_icall (mono_threads_finish_blocking_unbalanced, "mono_threads_finish_blocking_unbalanced", "void ptr ptr", TRUE);
 
 		mono_cominterop_init ();
 		mono_remoting_init ();
@@ -7322,11 +7322,11 @@ mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoM
 	}
 
 	/*
-	 * cookie = mono_threads_prepare_blocking (ref dummy);
+	 * cookie = mono_threads_prepare_blocking_unbalanced (ref dummy);
 	 *
 	 * ret = method (...);
 	 *
-	 * mono_threads_finish_blocking (cookie, ref dummy);
+	 * mono_threads_finish_blocking_unbalanced (cookie, ref dummy);
 	 *
 	 * <interrupt check>
 	 *
@@ -7365,7 +7365,7 @@ mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoM
 		}
 
 		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
-		mono_mb_emit_icall (mb, mono_threads_prepare_blocking);
+		mono_mb_emit_icall (mb, mono_threads_prepare_blocking_unbalanced);
 		mono_mb_emit_stloc (mb, coop_gc_var);
 	}
 
@@ -7416,7 +7416,7 @@ mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoM
 	if (mono_threads_is_coop_enabled ()) {
 		mono_mb_emit_ldloc (mb, coop_gc_var);
 		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
-		mono_mb_emit_icall (mb, mono_threads_finish_blocking);
+		mono_mb_emit_icall (mb, mono_threads_finish_blocking_unbalanced);
 	}
 
 	/* Set LastError if needed */

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3115,6 +3115,8 @@ mono_method_get_unmanaged_thunk (MonoMethod *method)
 
 	gpointer res;
 
+	g_assert (!mono_threads_is_coop_enabled ());
+
 	MONO_PREPARE_RESET_BLOCKING;
 	method = mono_marshal_get_thunk_invoke_wrapper (method);
 	res = mono_compile_method (method);

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -189,8 +189,6 @@ ves_icall_runtime_class_init (MonoVTable *vtable);
 void
 mono_generic_class_init (MonoVTable *vtable);
 
-void mono_interruption_checkpoint_from_trampoline (void);
-
 MonoObject*
 mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *klass, gboolean deref_arg, gpointer *args);
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2006,6 +2006,8 @@ mono_debugger_run_finally (MonoContext *start_ctx)
 gboolean
 mono_handle_exception (MonoContext *ctx, MonoObject *obj)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 #ifndef DISABLE_PERFCOUNTERS
 	mono_perfcounters->exceptions_thrown++;
 #endif
@@ -2549,6 +2551,8 @@ mono_print_thread_dump_from_ctx (MonoContext *ctx)
 void
 mono_resume_unwind (MonoContext *ctx)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);
 	MonoContext new_ctx;
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2146,6 +2146,8 @@ restore_stack_protection (void)
 gpointer
 mono_altstack_restore_prot (mgreg_t *regs, guint8 *code, gpointer *tramp_data, guint8* tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	void (*func)(void) = (void (*)(void))tramp_data;
 	func ();
 	return NULL;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -954,7 +954,7 @@ mono_jit_thread_attach (MonoDomain *domain, gpointer *dummy)
 			*dummy = NULL;
 			/* mono_thread_attach put the thread in RUNNING mode from STARTING, but we need to
 			 * return the right cookie. */
-			return mono_threads_cookie_for_reset_blocking_start (mono_thread_info_current (), 1);
+			return mono_threads_cookie_for_reset_blocking_start (mono_thread_info_current ());
 		} else {
 			*dummy = orig;
 			/* thread state (BLOCKING|RUNNING) -> RUNNING */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -163,7 +163,8 @@ G_GNUC_UNUSED static char*
 get_method_from_ip (void *ip)
 {
 	MonoJitInfo *ji;
-	char *method;
+	MonoMethod *method;
+	char *method_name;
 	char *res;
 	MonoDomain *domain = mono_domain_get ();
 	MonoDebugSourceLocation *location;
@@ -192,14 +193,15 @@ get_method_from_ip (void *ip)
 		return res;
 	}
 
-	method = mono_method_full_name (jinfo_get_method (ji), TRUE);
+	method = jinfo_get_method (ji);
+	method_name = mono_method_full_name (method, TRUE);
 	/* FIXME: unused ? */
-	location = mono_debug_lookup_source_location (jinfo_get_method (ji), (guint32)((guint8*)ip - (guint8*)ji->code_start), domain);
+	location = mono_debug_lookup_source_location (method, (guint32)((guint8*)ip - (guint8*)ji->code_start), domain);
 
-	res = g_strdup_printf (" %s + 0x%x (%p %p) [%p - %s]", method, (int)((char*)ip - (char*)ji->code_start), ji->code_start, (char*)ji->code_start + ji->code_size, domain, domain->friendly_name);
+	res = g_strdup_printf (" %s {%p} + 0x%x (%p %p) [%p - %s]", method_name, method, (int)((char*)ip - (char*)ji->code_start), ji->code_start, (char*)ji->code_start + ji->code_size, domain, domain->friendly_name);
 
 	mono_debug_free_source_location (location);
-	g_free (method);
+	g_free (method_name);
 
 	return res;
 }

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -502,13 +502,13 @@ mini_add_method_wrappers_llvmonly (MonoMethod *m, gpointer compiled_method, gboo
 }
 
 /**
- * common_call_trampoline_inner:
+ * common_call_trampoline:
  *
  *   The code to handle normal, virtual, and interface method calls and jumps, both
  * from JITted and LLVM compiled code.
  */
 static gpointer
-common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *vt, gpointer *vtable_slot, MonoError *error)
+common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *vt, gpointer *vtable_slot, MonoError *error)
 {
 	gpointer addr, compiled_method;
 	gboolean generic_shared = FALSE;
@@ -804,16 +804,6 @@ common_call_trampoline_inner (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVT
 	return addr;
 }
 
-static gpointer
-common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *vt, gpointer *vtable_slot, MonoError *error)
-{
-	gpointer res;
-	MONO_PREPARE_RESET_BLOCKING;
-	res = common_call_trampoline_inner (regs, code, m, vt, vtable_slot, error);
-	MONO_FINISH_RESET_BLOCKING;
-	return res;
-}
-
 /**
  * mono_magic_trampoline:
  *
@@ -848,6 +838,8 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 static gpointer
 mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoObject *this_arg;
 	MonoVTable *vt;
 	gpointer *vtable_slot;
@@ -919,6 +911,8 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 gpointer
 mono_generic_virtual_remoting_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, guint8 *tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoError error;
 	MonoGenericContext context = { NULL, NULL };
 	MonoMethod *imt_method, *declaring;
@@ -967,6 +961,8 @@ gpointer
 mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info, 
 					 guint8* tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoImage *image;
 	guint32 token;
 	MonoMethod *method = NULL;
@@ -1010,6 +1006,8 @@ gpointer
 mono_aot_plt_trampoline (mgreg_t *regs, guint8 *code, guint8 *aot_module, 
 						 guint8* tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	guint32 plt_info_offset = mono_aot_get_plt_info_offset (regs, code);
 	gpointer res;
 	MonoError error;
@@ -1033,6 +1031,8 @@ mono_aot_plt_trampoline (mgreg_t *regs, guint8 *code, guint8 *aot_module,
 static gpointer
 mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, guint8 *tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	static gboolean inited = FALSE;
 	static int num_lookups = 0;
 	guint32 slot = GPOINTER_TO_UINT (data);
@@ -1072,6 +1072,8 @@ mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, gu
 gpointer
 mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoDomain *domain = mono_domain_get ();
 	MonoDelegate *delegate;
 	MonoJitInfo *ji;
@@ -1259,6 +1261,8 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 static gpointer
 mono_handler_block_guard_trampoline (mgreg_t *regs, guint8 *code, gpointer *tramp_info, guint8* tramp)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoContext ctx;
 	MonoException *exc;
 	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_native_tls_get_value (mono_jit_tls_id);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -822,16 +822,21 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
 gpointer
 mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 {
-	MonoError error;
 	gpointer res;
+
+	MONO_PREPARE_RESET_BLOCKING_UNBALANCED;
+
+	MonoError error;
 
 	trampoline_calls ++;
 
 	res = common_call_trampoline (regs, code, (MonoMethod *)arg, NULL, NULL, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
-		return NULL;
-	}
+	mono_error_set_pending_exception (&error);
+
+	mono_interruption_checkpoint_from_trampoline ();
+
+	MONO_FINISH_RESET_BLOCKING_UNBALANCED;
+
 	return res;
 }
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3133,7 +3133,7 @@ mono_insert_safepoints (MonoCompile *cfg)
 
 		if (info && info->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER &&
 			(info->d.icall.func == mono_thread_interruption_checkpoint ||
-			info->d.icall.func == mono_threads_finish_blocking)) {
+			info->d.icall.func == mono_threads_finish_blocking_unbalanced)) {
 			/* These wrappers are called from the wrapper for the polling function, leading to potential stack overflow */
 			if (cfg->verbose_level > 1)
 				printf ("SKIPPING SAFEPOINTS for wrapper %s\n", cfg->method->name);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3133,8 +3133,7 @@ mono_insert_safepoints (MonoCompile *cfg)
 
 		if (info && info->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER &&
 			(info->d.icall.func == mono_thread_interruption_checkpoint ||
-			info->d.icall.func == mono_threads_finish_blocking ||
-			info->d.icall.func == mono_threads_reset_blocking_start)) {
+			info->d.icall.func == mono_threads_finish_blocking)) {
 			/* These wrappers are called from the wrapper for the polling function, leading to potential stack overflow */
 			if (cfg->verbose_level > 1)
 				printf ("SKIPPING SAFEPOINTS for wrapper %s\n", cfg->method->name);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -3200,5 +3200,9 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
  */
 void mono_exception_native_unwind (void *ctx, MONO_SIG_HANDLER_INFO_TYPE *info);
 
+/*
+ * Coop support for trampolines
+ */
+void mono_interruption_checkpoint_from_trampoline (void);
 
 #endif /* __MONO_MINI_H__ */

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -585,6 +585,12 @@ endif
 
 endif
 
+if ENABLE_COOP
+COOP_DISABLED_TESTS= thunks.exe
+else
+COOP_DISABLED_TESTS= 
+endif
+
 # The two finalizer tests only work under sgen
 # gc-altstack.exe fails under boehm because it has no support for altstack
 # bug-459094.exe creates an extremely deep directory tree
@@ -598,7 +604,8 @@ DISABLED_TESTS=			\
 	delegate-invoke.exe \
 	bug-Xamarin-5278.exe \
 	$(PLATFORM_DISABLED_TESTS) \
-	$(EXTRA_DISABLED_TESTS)
+	$(EXTRA_DISABLED_TESTS) \
+	$(COOP_DISABLED_TESTS)
 
 DISABLED_TESTS_WRENCH=	\
 	$(DISABLED_TESTS)	\

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -95,6 +95,15 @@ mono_threads_reset_blocking_start_unbalanced (gpointer *stackdata);
 void
 mono_threads_reset_blocking_end_unbalanced (gpointer cookie, gpointer *stackdata);
 
+#define MONO_PREPARE_RESET_BLOCKING_UNBALANCED	\
+	do {	\
+		gpointer __dummy;	\
+		gpointer __reset_cookie = mono_threads_reset_blocking_start_unbalanced (&__dummy)
+
+#define MONO_FINISH_RESET_BLOCKING_UNBALANCED	\
+		mono_threads_reset_blocking_end_unbalanced (__reset_cookie, &__dummy);	\
+	} while (0)
+
 G_END_DECLS
 
 #endif

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -41,16 +41,16 @@ void
 mono_threads_state_poll (void);
 
 gpointer
-mono_threads_prepare_blocking (gpointer stackdata);
+mono_threads_prepare_blocking (gpointer *stackdata);
 
 void
-mono_threads_finish_blocking (gpointer cookie, gpointer stackdata);
+mono_threads_finish_blocking (gpointer cookie, gpointer *stackdata);
 
 gpointer
-mono_threads_reset_blocking_start (gpointer stackdata);
+mono_threads_reset_blocking_start (gpointer *stackdata);
 
 void
-mono_threads_reset_blocking_end (gpointer cookie, gpointer stackdata);
+mono_threads_reset_blocking_end (gpointer cookie, gpointer *stackdata);
 
 static inline void
 mono_threads_safepoint (void)
@@ -77,6 +77,23 @@ mono_threads_safepoint (void)
 #define MONO_FINISH_RESET_BLOCKING \
 		mono_threads_reset_blocking_end (__reset_cookie, &__dummy);	\
 	} while (0)
+
+/*
+ * The following are used for wrappers and trampolines as their
+ * calls might be unbalanced, due to exception unwinding.
+ */
+
+gpointer
+mono_threads_prepare_blocking_unbalanced (gpointer *stackdata);
+
+void
+mono_threads_finish_blocking_unbalanced (gpointer cookie, gpointer *stackdata);
+
+gpointer
+mono_threads_reset_blocking_start_unbalanced (gpointer *stackdata);
+
+void
+mono_threads_reset_blocking_end_unbalanced (gpointer cookie, gpointer *stackdata);
 
 G_END_DECLS
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -608,7 +608,7 @@ MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE
 MonoThreadUnwindState* mono_thread_info_get_suspend_state (THREAD_INFO_TYPE *info);
 
 gpointer
-mono_threads_cookie_for_reset_blocking_start (THREAD_INFO_TYPE *info, int reset_blocking_count);
+mono_threads_cookie_for_reset_blocking_start (THREAD_INFO_TYPE *info);
 
 
 void mono_thread_info_wait_for_resume (THREAD_INFO_TYPE *info);


### PR DESCRIPTION
The try { ... } finally { ... } clauses in the managed-to-native and native-to-managed wrappers would screw up the state while the unwinder is running. We need to stay in the RUNNING state, as it could access managed memory and hit safepoints.

To achieve that, the native-to-managed wrapper looks as follow:

```
ex = -1;
try {
  mono_jit_attach (); // also does BLOCKING -> RUNNING state transition
  <interrupt check>
  ret = method (...);
} catch (Exception e) {
  ex = mono_gchandle_new (e, false);
} finally {
  mono_jit_detach (); // also does RUNNING -> BLOCKING state transition
  if (ex != -1)
    mono_marshal_ftnptr_eh_callback (ex);
}
return ret;
```

mono_marshal_ftnptr_eh_callback default implementation, will simply reset blocking (switch back to RUNNING), and rethrow the exception. This default behaviour will then unwind native stack. We need to ensure that we call mono_jit_detach() as this also does the domain transition (if the delegate	in which the domain was created is different from the domain which the ftnptr is invoked).

The managed-to-native transition is implemented as follow:

```
mono_threads_prepare_blocking_unbalanced();
ret = method (...);
mono_threads_finish_blocking_unbalanced();
return ret;
```

In case there is a managed exception coming from the method, as the throw had to happen in the RUNNING state, we should not switch from BLOCKING to RUNNING in mono_threads_finish_blocking_unbalanced.