### PR TITLE
[runtime] Eliminate some mono_error_raise_exception calls

### DIFF
--- a/mono/metadata/cominterop.h
+++ b/mono/metadata/cominterop.h
@@ -47,8 +47,15 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum,
 										int conv_arg, MonoType **conv_arg_type,
 										MarshalAction action);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString * 
 mono_string_from_bstr (gpointer bstr);
+
+MonoString *
+mono_string_from_bstr_icall (gpointer bstr);
+
+MonoString *
+mono_string_from_bstr_checked (gpointer bstr, MonoError *error);
 
 MONO_API void 
 mono_free_bstr (gpointer bstr);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -95,11 +95,13 @@ guarded_wait (HANDLE handle, guint32 timeout, gboolean alertable)
 static void
 add_thread_to_finalize (MonoInternalThread *thread)
 {
+	MonoError error;
 	mono_finalizer_lock ();
 	if (!threads_to_finalize)
 		MONO_GC_REGISTER_ROOT_SINGLE (threads_to_finalize, MONO_ROOT_SOURCE_FINALIZER_QUEUE, "finalizable threads list");
-	threads_to_finalize = mono_mlist_append (threads_to_finalize, (MonoObject*)thread);
+	threads_to_finalize = mono_mlist_append_checked (threads_to_finalize, (MonoObject*)thread, &error);
 	mono_finalizer_unlock ();
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 }
 
 static gboolean suspend_finalizers = FALSE;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1600,7 +1600,7 @@ conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 		return mono_string_to_bstr;
 	case MONO_MARSHAL_CONV_BSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return mono_string_from_bstr;
+		return mono_string_from_bstr_icall;
 	case MONO_MARSHAL_CONV_STR_TBSTR:
 	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
 		return mono_string_to_ansibstr;

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -13,6 +13,11 @@
 #include "mono/metadata/class-internals.h"
 #include "mono/metadata/object-internals.h"
 
+
+static
+MonoMList*  mono_mlist_alloc_checked       (MonoObject *data, MonoError *error);
+
+
 /* matches the System.MonoListItem object*/
 struct _MonoMList {
 	MonoObject object;
@@ -40,14 +45,35 @@ MonoMList*
 mono_mlist_alloc (MonoObject *data)
 {
 	MonoError error;
+	MonoMList *result = mono_mlist_alloc_checked (data, &error);
+	mono_error_cleanup (&error);
+	return result;
+}
+
+/**
+ * mono_mlist_alloc_checked:
+ * @data: object to use as data
+ * @error: set on error
+ *
+ * Allocates a new managed list node with @data as the contents.  A
+ * managed list node also represents a singly-linked list.  Managed
+ * lists are garbage collected, so there is no free routine and the
+ * user is required to keep references to the managed list to prevent
+ * it from being garbage collected. On failure returns NULL and sets
+ * @error.
+ */
+MonoMList*
+mono_mlist_alloc_checked (MonoObject *data, MonoError *error)
+{
+	mono_error_init (error);
 	MonoMList* res;
 	if (!monolist_item_vtable) {
 		MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System", "MonoListItem");
 		monolist_item_vtable = mono_class_vtable (mono_get_root_domain (), klass);
 		g_assert (monolist_item_vtable);
 	}
-	res = (MonoMList*)mono_object_new_fast_checked (monolist_item_vtable, &error);
-	mono_error_raise_exception (&error);
+	res = (MonoMList*)mono_object_new_fast_checked (monolist_item_vtable, error);
+	return_val_if_nok (error, NULL);
 	MONO_OBJECT_SETREF (res, data, data);
 	return res;
 }
@@ -152,7 +178,29 @@ mono_mlist_last (MonoMList* list)
 MonoMList*
 mono_mlist_prepend (MonoMList* list, MonoObject *data)
 {
-	MonoMList* res = mono_mlist_alloc (data);
+	MonoError error;
+	MonoMList *result = mono_mlist_prepend_checked (list, data, &error);
+	mono_error_cleanup (&error);
+	return result;
+}
+
+/**
+ * mono_mlist_prepend_checked:
+ * @list: the managed list
+ * @data: the object to add to the list
+ * @error: set on error
+ *
+ * Allocate a new list node with @data as content and prepend it to
+ * the list @list. @list can be NULL. On failure returns NULL and sets
+ * @error.
+ */
+MonoMList*
+mono_mlist_prepend_checked (MonoMList* list, MonoObject *data, MonoError *error)
+{
+	mono_error_init (error);
+	MonoMList* res = mono_mlist_alloc_checked (data, error);
+	return_val_if_nok (error, NULL);
+
 	if (list)
 		MONO_OBJECT_SETREF (res, next, list);
 	return res;
@@ -170,7 +218,30 @@ mono_mlist_prepend (MonoMList* list, MonoObject *data)
 MonoMList*
 mono_mlist_append (MonoMList* list, MonoObject *data)
 {
-	MonoMList* res = mono_mlist_alloc (data);
+	MonoError error;
+	MonoMList *result = mono_mlist_append_checked (list, data, &error);
+	mono_error_cleanup (&error);
+	return result;
+}
+
+/**
+ * mono_mlist_append_checked:
+ * @list: the managed list
+ * @data: the object to add to the list
+ * @error: set on error
+ *
+ * Allocate a new list node with @data as content and append it
+ * to the list @list. @list can be NULL.
+ * Since managed lists are singly-linked, this operation takes O(n) time.
+ * On failure returns NULL and sets @error.
+ */
+MonoMList*
+mono_mlist_append_checked (MonoMList* list, MonoObject *data, MonoError *error)
+{
+	mono_error_init (error);
+	MonoMList* res = mono_mlist_alloc_checked (data, error);
+	return_val_if_nok (error, NULL);
+
 	if (list) {
 		MonoMList* last = mono_mlist_last (list);
 		MONO_OBJECT_SETREF (last, next, res);

--- a/mono/metadata/mono-mlist.h
+++ b/mono/metadata/mono-mlist.h
@@ -8,6 +8,7 @@
 #include <mono/metadata/object.h>
 
 typedef struct _MonoMList MonoMList;
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMList*  mono_mlist_alloc       (MonoObject *data);
 MONO_API MonoObject* mono_mlist_get_data    (MonoMList* list);
 MONO_API void        mono_mlist_set_data    (MonoMList* list, MonoObject *data);
@@ -15,8 +16,14 @@ MONO_API MonoMList*  mono_mlist_set_next    (MonoMList* list, MonoMList *next);
 MONO_API int         mono_mlist_length      (MonoMList* list);
 MONO_API MonoMList*  mono_mlist_next        (MonoMList* list);
 MONO_API MonoMList*  mono_mlist_last        (MonoMList* list);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMList*  mono_mlist_prepend     (MonoMList* list, MonoObject *data);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMList*  mono_mlist_append      (MonoMList* list, MonoObject *data);
+
+MonoMList*  mono_mlist_prepend_checked      (MonoMList* list, MonoObject *data, MonoError *error);
+MonoMList*  mono_mlist_append_checked       (MonoMList* list, MonoObject *data, MonoError *error);
+
 MONO_API MonoMList*  mono_mlist_remove_item (MonoMList* list, MonoMList *item);
 
 #endif /* __MONO_METADATA_MONO_MLIST_H__ */

--- a/mono/metadata/string-icalls.c
+++ b/mono/metadata/string-icalls.c
@@ -39,7 +39,7 @@ ves_icall_System_String_InternalAllocateStr (gint32 length)
 {
 	MonoError error;
 	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, &error);
-	mono_error_raise_exception (&error);
+	mono_error_set_pending_exception (&error);
 
 	return str;
 }

--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -347,7 +347,8 @@ selector_thread (gpointer data)
 				g_assert (job);
 
 				exists = mono_g_hash_table_lookup_extended (states, GINT_TO_POINTER (fd), &k, (gpointer*) &list);
-				list = mono_mlist_append (list, (MonoObject*) job);
+				list = mono_mlist_append_checked (list, (MonoObject*) job, &error);
+				mono_error_raise_exception (&error); /* FIXME don't raise here */
 				mono_g_hash_table_replace (states, GINT_TO_POINTER (fd), list);
 
 				operations = get_operations_for_jobs (list);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1167,13 +1167,18 @@ load_agent (MonoDomain *domain, char *desc)
 		return 1;
 	}
 	
-	g_free (agent);
 
 	pa [0] = main_args;
 	/* Pass NULL as 'exc' so unhandled exceptions abort the runtime */
 	mono_runtime_invoke_checked (method, NULL, pa, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (!is_ok (&error)) {
+		g_print ("The entry point method of assembly '%s' could not execute due to %s\n", agent, mono_error_get_message (&error));
+		mono_error_cleanup (&error);
+		g_free (agent);
+		return 1;
+	}
 
+	g_free (agent);
 	return 0;
 }
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5343,8 +5343,10 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 				return FALSE;
 			if (!cfg->compile_aot) {
 				MonoError error;
-				if (!mono_runtime_class_init_full (vtable, &error))
-					mono_error_raise_exception (&error); /* FIXME don't raise here */
+				if (!mono_runtime_class_init_full (vtable, &error)) {
+					mono_error_cleanup (&error);
+					return FALSE;
+				}
 			}
 		} else if (method->klass->flags & TYPE_ATTRIBUTE_BEFORE_FIELD_INIT) {
 			if (cfg->run_cctors && method->klass->has_cctor) {
@@ -5361,8 +5363,10 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 				if (! vtable->initialized)
 					return FALSE;
 				MonoError error;
-				if (!mono_runtime_class_init_full (vtable, &error))
-					mono_error_raise_exception (&error); /* FIXME don't raise here */
+				if (!mono_runtime_class_init_full (vtable, &error)) {
+					mono_error_cleanup (&error);
+					return FALSE;
+				}
 			}
 		} else if (mono_class_needs_cctor_run (method->klass, NULL)) {
 			if (!method->klass->runtime_info)

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1332,7 +1332,8 @@ setup_stack_trace (MonoException *mono_ex, GSList *dynamic_methods, MonoArray *i
 					if (dis_link) {
 						MonoObject *o = mono_gchandle_get_target (dis_link);
 						if (o) {
-							list = mono_mlist_prepend (list, o);
+							list = mono_mlist_prepend_checked (list, o, &error);
+							mono_error_assert_ok (&error);
 						}
 					}
 				}


### PR DESCRIPTION
We prefer `mono_error_set_pending_exception` in order to avoid unwinding the native stack.

This PR has changes to COM interop, mono_mlist and some MonoString construction icalls.