### PR TITLE
[sgen] Remove HAVE_KW_THREAD and speed up the managed allocator.

### DIFF
--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -129,8 +129,8 @@ DECL_OFFSET(MonoTypedRef, value)
 DECL_OFFSET(MonoThreadsSync, status)
 DECL_OFFSET(MonoThreadsSync, nest)
 
-#if defined (HAVE_SGEN_GC) && !defined (HAVE_KW_THREAD)
-DECL_OFFSET(SgenThreadInfo, tlab_next_addr)
+#if defined (HAVE_SGEN_GC)
+DECL_OFFSET(SgenThreadInfo, tlab_next)
 DECL_OFFSET(SgenThreadInfo, tlab_temp_end)
 #endif
 

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -694,21 +694,9 @@ gboolean sgen_suspend_thread (SgenThreadInfo *info);
 gboolean sgen_resume_thread (SgenThreadInfo *info);
 void sgen_wait_for_suspend_ack (int count);
 
-#ifdef HAVE_KW_THREAD
-extern __thread SgenThreadInfo *sgen_thread_info;
-#define TLAB_ACCESS_INIT
-#define IN_CRITICAL_REGION sgen_thread_info->client_info.in_critical_region
-#else
 extern MonoNativeTlsKey thread_info_key;
 #define TLAB_ACCESS_INIT	SgenThreadInfo *__thread_info__ = mono_native_tls_get_value (thread_info_key)
 #define IN_CRITICAL_REGION (__thread_info__->client_info.in_critical_region)
-#endif
-
-#ifdef HAVE_KW_THREAD
-#define IN_CRITICAL_REGION sgen_thread_info->client_info.in_critical_region
-#else
-#define IN_CRITICAL_REGION (__thread_info__->client_info.in_critical_region)
-#endif
 
 /* Enter must be visible before anything is done in the critical region. */
 #define ENTER_CRITICAL_REGION do { mono_atomic_store_acquire (&IN_CRITICAL_REGION, 1); } while (0)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -46,11 +46,8 @@ gboolean sgen_mono_xdomain_checks = FALSE;
 /* Functions supplied by the runtime to be called by the GC */
 static MonoGCCallbacks gc_callbacks;
 
-#ifdef HAVE_KW_THREAD
-__thread SgenThreadInfo *sgen_thread_info;
-#else
 MonoNativeTlsKey thread_info_key;
-#endif
+
 
 #define ALIGN_TO(val,align) ((((guint64)val) + ((align) - 1)) & ~((align) - 1))
 
@@ -990,22 +987,6 @@ static MonoMethod* slowpath_alloc_method_cache [ATYPE_NUM];
 static gboolean use_managed_allocator = TRUE;
 
 #ifdef MANAGED_ALLOCATION
-
-#ifdef HAVE_KW_THREAD
-
-#define EMIT_TLS_ACCESS_NEXT_ADDR(mb)	do {	\
-	mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX);	\
-	mono_mb_emit_byte ((mb), CEE_MONO_TLS);		\
-	mono_mb_emit_i4 ((mb), TLS_KEY_SGEN_TLAB_NEXT_ADDR);		\
-	} while (0)
-
-#define EMIT_TLS_ACCESS_TEMP_END(mb)	do {	\
-	mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX);	\
-	mono_mb_emit_byte ((mb), CEE_MONO_TLS);		\
-	mono_mb_emit_i4 ((mb), TLS_KEY_SGEN_TLAB_TEMP_END);		\
-	} while (0)
-
-#else
 
 #if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID) || defined(TARGET_IOS)
 #define EMIT_TLS_ACCESS_NEXT_ADDR(mb)	do {	\
@@ -2151,12 +2132,8 @@ sgen_client_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
 	size_t stsize = 0;
 	guint8 *staddr = NULL;
 
-#ifndef HAVE_KW_THREAD
 	g_assert (!mono_native_tls_get_value (thread_info_key));
 	mono_native_tls_set_value (thread_info_key, info);
-#else
-	sgen_thread_info = info;
-#endif
 
 	info->client_info.skip = 0;
 	info->client_info.stopped_ip = NULL;
@@ -2198,11 +2175,7 @@ sgen_client_thread_unregister (SgenThreadInfo *p)
 {
 	MonoNativeThreadId tid;
 
-#ifndef HAVE_KW_THREAD
 	mono_native_tls_set_value (thread_info_key, NULL);
-#else
-	sgen_thread_info = NULL;
-#endif
 
 	tid = mono_thread_info_get_tid (p);
 
@@ -2814,22 +2787,12 @@ sgen_client_init (void)
 
 	mono_sgen_init_stw ();
 
-#ifndef HAVE_KW_THREAD
 	mono_native_tls_alloc (&thread_info_key, NULL);
-#if defined(TARGET_OSX) || defined(TARGET_WIN32) || defined(TARGET_ANDROID) || defined(TARGET_IOS)
 	/* 
 	 * CEE_MONO_TLS requires the tls offset, not the key, so the code below only works on darwin,
 	 * where the two are the same.
 	 */
 	mono_tls_key_set_offset (TLS_KEY_SGEN_THREAD_INFO, thread_info_key);
-#endif
-#else
-	{
-		int tls_offset = -1;
-		MONO_THREAD_VAR_OFFSET (sgen_thread_info, tls_offset);
-		mono_tls_key_set_offset (TLS_KEY_SGEN_THREAD_INFO, tls_offset);
-	}
-#endif
 
 	/*
 	 * This needs to happen before any internal allocations because
@@ -2952,12 +2915,6 @@ mono_gc_base_init (void)
 	if (nursery_canaries_enabled ())
 		sgen_set_use_managed_allocator (FALSE);
 
-#if defined(HAVE_KW_THREAD)
-	/* This can happen with using libmonosgen.so */
-	if (mono_tls_key_get_offset (TLS_KEY_SGEN_TLAB_NEXT_ADDR) == -1)
-		sgen_set_use_managed_allocator (FALSE);
-#endif
-
 	gc_inited = TRUE;
 }
 
@@ -2973,4 +2930,3 @@ mono_gc_is_null (void)
 	return FALSE;
 }
 
-#endif

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -993,9 +993,8 @@ static gboolean use_managed_allocator = TRUE;
 	mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX);	\
 	mono_mb_emit_byte ((mb), CEE_MONO_TLS);		\
 	mono_mb_emit_i4 ((mb), TLS_KEY_SGEN_THREAD_INFO);	\
-	mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenThreadInfo, tlab_next_addr));	\
+	mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenThreadInfo, tlab_next));	\
 	mono_mb_emit_byte ((mb), CEE_ADD);		\
-	mono_mb_emit_byte ((mb), CEE_LDIND_I);		\
 	} while (0)
 
 #define EMIT_TLS_ACCESS_TEMP_END(mb)	do {	\

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -603,6 +603,7 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 		break;
 	case OP_ADD_IMM:
 	case OP_LADD_IMM:
+	case OP_LAND_IMM:
 		g_string_append_printf (sbuf, " [%d]", (int)(gssize)ins->inst_p1);
 		break;
 	case OP_I8CONST:

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -475,12 +475,6 @@ sgen_alloc_obj_mature (GCVTable vtable, size_t size)
 void
 sgen_init_tlab_info (SgenThreadInfo* info)
 {
-	SgenThreadInfo *__thread_info__ = info;
-
-	info->tlab_start_addr = &TLAB_START;
-	info->tlab_next_addr = &TLAB_NEXT;
-	info->tlab_temp_end_addr = &TLAB_TEMP_END;
-	info->tlab_real_end_addr = &TLAB_REAL_END;
 }
 
 /*
@@ -491,10 +485,10 @@ sgen_clear_tlabs (void)
 {
 	FOREACH_THREAD (info) {
 		/* A new TLAB will be allocated when the thread does its first allocation */
-		*info->tlab_start_addr = NULL;
-		*info->tlab_next_addr = NULL;
-		*info->tlab_temp_end_addr = NULL;
-		*info->tlab_real_end_addr = NULL;
+		info->tlab_start = NULL;
+		info->tlab_next = NULL;
+		info->tlab_temp_end = NULL;
+		info->tlab_real_end = NULL;
 	} FOREACH_THREAD_END
 }
 

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -57,30 +57,10 @@ static guint64 stat_bytes_alloced_los = 0;
  * tlab_real_end points to the end of the TLAB.
  */
 
-/*
- * FIXME: What is faster, a TLS variable pointing to a structure, or separate TLS 
- * variables for next+temp_end ?
- */
-#ifdef HAVE_KW_THREAD
-static __thread char *tlab_start;
-static __thread char *tlab_next;
-static __thread char *tlab_temp_end;
-static __thread char *tlab_real_end;
-/* Used by the managed allocator/wbarrier */
-static __thread char **tlab_next_addr MONO_ATTR_USED;
-#endif
-
-#ifdef HAVE_KW_THREAD
-#define TLAB_START	tlab_start
-#define TLAB_NEXT	tlab_next
-#define TLAB_TEMP_END	tlab_temp_end
-#define TLAB_REAL_END	tlab_real_end
-#else
 #define TLAB_START	(__thread_info__->tlab_start)
 #define TLAB_NEXT	(__thread_info__->tlab_next)
 #define TLAB_TEMP_END	(__thread_info__->tlab_temp_end)
 #define TLAB_REAL_END	(__thread_info__->tlab_real_end)
-#endif
 
 static GCObject*
 alloc_degraded (GCVTable vtable, size_t size, gboolean for_mature)
@@ -495,18 +475,12 @@ sgen_alloc_obj_mature (GCVTable vtable, size_t size)
 void
 sgen_init_tlab_info (SgenThreadInfo* info)
 {
-#ifndef HAVE_KW_THREAD
 	SgenThreadInfo *__thread_info__ = info;
-#endif
 
 	info->tlab_start_addr = &TLAB_START;
 	info->tlab_next_addr = &TLAB_NEXT;
 	info->tlab_temp_end_addr = &TLAB_TEMP_END;
 	info->tlab_real_end_addr = &TLAB_REAL_END;
-
-#ifdef HAVE_KW_THREAD
-	tlab_next_addr = &tlab_next;
-#endif
 }
 
 /*
@@ -527,18 +501,6 @@ sgen_clear_tlabs (void)
 void
 sgen_init_allocator (void)
 {
-#if defined(HAVE_KW_THREAD) && !defined(SGEN_WITHOUT_MONO)
-	int tlab_next_addr_offset = -1;
-	int tlab_temp_end_offset = -1;
-
-
-	MONO_THREAD_VAR_OFFSET (tlab_next_addr, tlab_next_addr_offset);
-	MONO_THREAD_VAR_OFFSET (tlab_temp_end, tlab_temp_end_offset);
-
-	mono_tls_key_set_offset (TLS_KEY_SGEN_TLAB_NEXT_ADDR, tlab_next_addr_offset);
-	mono_tls_key_set_offset (TLS_KEY_SGEN_TLAB_TEMP_END, tlab_temp_end_offset);
-#endif
-
 #ifdef HEAVY_STATISTICS
 	mono_counters_register ("# objects allocated", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_objects_alloced);
 	mono_counters_register ("bytes allocated", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &stat_bytes_alloced);

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -2567,9 +2567,7 @@ sgen_get_current_collection_generation (void)
 void*
 sgen_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
 {
-#ifndef HAVE_KW_THREAD
 	info->tlab_start = info->tlab_next = info->tlab_temp_end = info->tlab_real_end = NULL;
-#endif
 
 	sgen_init_tlab_info (info);
 

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -378,11 +378,11 @@ void sgen_scan_area_with_callback (char *start, char *end, IterateObjectCallback
 struct _SgenThreadInfo {
 	SgenClientThreadInfo client_info;
 
-	char **tlab_next_addr;
+/*	char **tlab_next_addr;
 	char **tlab_start_addr;
 	char **tlab_temp_end_addr;
 	char **tlab_real_end_addr;
-
+*/
 	char *tlab_start;
 	char *tlab_next;
 	char *tlab_temp_end;

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -377,12 +377,6 @@ void sgen_scan_area_with_callback (char *start, char *end, IterateObjectCallback
  */
 struct _SgenThreadInfo {
 	SgenClientThreadInfo client_info;
-
-/*	char **tlab_next_addr;
-	char **tlab_start_addr;
-	char **tlab_temp_end_addr;
-	char **tlab_real_end_addr;
-*/
 	char *tlab_start;
 	char *tlab_next;
 	char *tlab_temp_end;

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -383,12 +383,10 @@ struct _SgenThreadInfo {
 	char **tlab_temp_end_addr;
 	char **tlab_real_end_addr;
 
-#ifndef HAVE_KW_THREAD
 	char *tlab_start;
 	char *tlab_next;
 	char *tlab_temp_end;
 	char *tlab_real_end;
-#endif
 };
 
 gboolean sgen_is_worker_thread (MonoNativeThreadId thread);


### PR DESCRIPTION
HAVE_KW_THREAD is only used and supported on linux+gcc. This set of
cleanup favors the pthread_getspecific implementation which is
what all other platforms use.

This change doesn't make the KW_THREAD version worse since we
now cache the thread info pointer.