### PR TITLE
[sgen] Improve logging

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2718,7 +2718,7 @@ sgen_client_degraded_allocation (size_t size)
 }
 
 void
-sgen_client_log_timing (GGTimingInfo *info, mword last_major_num_sections, mword last_los_memory_usage)
+sgen_client_log_timing (GGTimingInfo *info, mword promoted_size, mword last_los_memory_usage)
 {
 	SgenMajorCollector *major_collector = sgen_get_major_collector ();
 	mword num_major_sections = major_collector->get_num_major_sections ();
@@ -2741,7 +2741,7 @@ sgen_client_log_timing (GGTimingInfo *info, mword last_major_num_sections, mword
 	                info->reason ? info->reason : "",
 	                (int)info->total_time / 10000.0f,
 	                full_timing_buff,
-	                (num_major_sections - last_major_num_sections) * major_collector->section_size / 1024,
+	                (int)promoted_size / 1024,
 	                major_collector->section_size * num_major_sections / 1024,
 	                los_memory_usage / 1024);
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2718,7 +2718,7 @@ sgen_client_degraded_allocation (size_t size)
 }
 
 void
-sgen_client_log_timing (GGTimingInfo *info, mword promoted_size)
+sgen_client_log_timing (GGTimingInfo *info, mword promoted_size, mword major_used_size)
 {
 	SgenMajorCollector *major_collector = sgen_get_major_collector ();
 	mword num_major_sections = major_collector->get_num_major_sections ();
@@ -2736,13 +2736,14 @@ sgen_client_log_timing (GGTimingInfo *info, mword promoted_size)
 	                los_memory_usage_total / 1024,
 	                los_memory_usage / 1024);
 	else
-	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) pause %.2fms, %s promoted %dK major %dK los size: %dK in use: %dK",
+	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) pause %.2fms, %s promoted %dK major size: %dK in use: %dK los size: %dK in use: %dK",
 	        		info->is_overflow ? "_OVERFLOW" : "",
 	                info->reason ? info->reason : "",
 	                (int)info->total_time / 10000.0f,
 	                full_timing_buff,
 	                (int)promoted_size / 1024,
 	                major_collector->section_size * num_major_sections / 1024,
+			major_used_size / 1024,
 	                los_memory_usage_total / 1024,
 			los_memory_usage / 1024);
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2728,21 +2728,23 @@ sgen_client_log_timing (GGTimingInfo *info, mword promoted_size)
 	if (!info->is_overflow)
 	        sprintf (full_timing_buff, "total %.2fms, bridge %.2fms", info->stw_time / 10000.0f, (int)info->bridge_time / 10000.0f);
 	if (info->generation == GENERATION_OLD)
-	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) pause %.2fms, %s los %dK",
+	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) pause %.2fms, %s los size: %dK in use: %dK",
 	                info->is_overflow ? "_OVERFLOW" : "",
 	                info->reason ? info->reason : "",
 	                (int)info->total_time / 10000.0f,
 	                full_timing_buff,
+	                los_memory_usage_total / 1024,
 	                los_memory_usage / 1024);
 	else
-	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) pause %.2fms, %s promoted %dK major %dK los %dK",
+	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) pause %.2fms, %s promoted %dK major %dK los size: %dK in use: %dK",
 	        		info->is_overflow ? "_OVERFLOW" : "",
 	                info->reason ? info->reason : "",
 	                (int)info->total_time / 10000.0f,
 	                full_timing_buff,
 	                (int)promoted_size / 1024,
 	                major_collector->section_size * num_major_sections / 1024,
-	                los_memory_usage / 1024);
+	                los_memory_usage_total / 1024,
+			los_memory_usage / 1024);
 }
 
 /*

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2718,7 +2718,7 @@ sgen_client_degraded_allocation (size_t size)
 }
 
 void
-sgen_client_log_timing (GGTimingInfo *info, mword promoted_size, mword last_los_memory_usage)
+sgen_client_log_timing (GGTimingInfo *info, mword promoted_size)
 {
 	SgenMajorCollector *major_collector = sgen_get_major_collector ();
 	mword num_major_sections = major_collector->get_num_major_sections ();
@@ -2728,13 +2728,12 @@ sgen_client_log_timing (GGTimingInfo *info, mword promoted_size, mword last_los_
 	if (!info->is_overflow)
 	        sprintf (full_timing_buff, "total %.2fms, bridge %.2fms", info->stw_time / 10000.0f, (int)info->bridge_time / 10000.0f);
 	if (info->generation == GENERATION_OLD)
-	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) pause %.2fms, %s los %dK/%dK",
+	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) pause %.2fms, %s los %dK",
 	                info->is_overflow ? "_OVERFLOW" : "",
 	                info->reason ? info->reason : "",
 	                (int)info->total_time / 10000.0f,
 	                full_timing_buff,
-	                los_memory_usage / 1024,
-	                last_los_memory_usage / 1024);
+	                los_memory_usage / 1024);
 	else
 	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) pause %.2fms, %s promoted %dK major %dK los %dK",
 	        		info->is_overflow ? "_OVERFLOW" : "",

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -100,17 +100,17 @@ probe_embedded (const char *program, int *ref_argc, char **ref_argv [])
 			if (entry_point == NULL)
 				entry_point = aname;
 		} else if (strncmp (kind, "config:", strlen ("config:")) == 0){
-			printf ("c-Found: %s %llx\n", kind, offset);
+			printf ("c-Found: %s %llx\n", kind, (long long)offset);
 			char *config = kind + strlen ("config:");
 			char *aname = g_strdup (config);
 			aname [strlen(aname)-strlen(".config")] = 0;
 			mono_register_config_for_assembly (aname, config);
 		} else if (strncmp (kind, "system_config:", strlen ("system_config:")) == 0){
-			printf ("TODO s-Found: %s %llx\n", kind, offset);
+			printf ("TODO s-Found: %s %llx\n", kind, (long long)offset);
 		} else if (strncmp (kind, "options:", strlen ("options:")) == 0){
 			mono_parse_options_from (kind + strlen("options:"), ref_argc, ref_argv);
 		} else if (strncmp (kind, "config_dir:", strlen ("config_dir:")) == 0){
-			printf ("TODO Found: %s %llx\n", kind, offset);
+			printf ("TODO Found: %s %llx\n", kind, (long long)offset);
 		} else {
 			fprintf (stderr, "Unknown stream on embedded package: %s\n", kind);
 			exit (1);

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -201,7 +201,7 @@ void sgen_client_clear_togglerefs (char *start, char *end, ScanCopyContext ctx);
  * Called after collections, reporting the amount of time they took.  No action is
  * necessary.
  */
-void sgen_client_log_timing (GGTimingInfo *info, mword promoted_size, mword last_los_memory_usage);
+void sgen_client_log_timing (GGTimingInfo *info, mword promoted_size);
 
 /*
  * Called to handle `MONO_GC_PARAMS` and `MONO_GC_DEBUG` options.  The `handle` functions

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -201,7 +201,7 @@ void sgen_client_clear_togglerefs (char *start, char *end, ScanCopyContext ctx);
  * Called after collections, reporting the amount of time they took.  No action is
  * necessary.
  */
-void sgen_client_log_timing (GGTimingInfo *info, mword last_major_num_sections, mword last_los_memory_usage);
+void sgen_client_log_timing (GGTimingInfo *info, mword promoted_size, mword last_los_memory_usage);
 
 /*
  * Called to handle `MONO_GC_PARAMS` and `MONO_GC_DEBUG` options.  The `handle` functions

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -201,7 +201,7 @@ void sgen_client_clear_togglerefs (char *start, char *end, ScanCopyContext ctx);
  * Called after collections, reporting the amount of time they took.  No action is
  * necessary.
  */
-void sgen_client_log_timing (GGTimingInfo *info, mword promoted_size);
+void sgen_client_log_timing (GGTimingInfo *info, mword promoted_size, mword major_used_size);
 
 /*
  * Called to handle `MONO_GC_PARAMS` and `MONO_GC_DEBUG` options.  The `handle` functions

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1163,7 +1163,7 @@ finish_gray_stack (int generation, ScanCopyContext ctx)
 	sgen_client_clear_togglerefs (start_addr, end_addr, ctx);
 
 	TV_GETTIME (btv);
-	SGEN_LOG (2, "Finalize queue handling scan for %s generation: %lld usecs %d ephemeron rounds", generation_name (generation), TV_ELAPSED (atv, btv), ephemeron_rounds);
+	SGEN_LOG (2, "Finalize queue handling scan for %s generation: %lld usecs %d ephemeron rounds", generation_name (generation), (long long)TV_ELAPSED (atv, btv), ephemeron_rounds);
 
 	/*
 	 * handle disappearing links
@@ -1557,7 +1557,7 @@ collect_nursery (SgenGrayQueue *unpin_queue, gboolean finish_up_concurrent_mark)
 
 	TV_GETTIME (atv);
 	time_minor_pinning += TV_ELAPSED (btv, atv);
-	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), TV_ELAPSED (btv, atv));
+	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), (long long)TV_ELAPSED (btv, atv));
 	SGEN_LOG (4, "Start scan with %zd pinned objects", sgen_get_pinned_count ());
 
 	sj = (ScanJob*)sgen_thread_pool_job_alloc ("scan remset", job_remembered_set_scan, sizeof (ScanJob));
@@ -1567,7 +1567,7 @@ collect_nursery (SgenGrayQueue *unpin_queue, gboolean finish_up_concurrent_mark)
 	/* we don't have complete write barrier yet, so we scan all the old generation sections */
 	TV_GETTIME (btv);
 	time_minor_scan_remsets += TV_ELAPSED (atv, btv);
-	SGEN_LOG (2, "Old generation scan: %lld usecs", TV_ELAPSED (atv, btv));
+	SGEN_LOG (2, "Old generation scan: %lld usecs", (long long)TV_ELAPSED (atv, btv));
 
 	sgen_pin_stats_print_class_stats ();
 
@@ -1608,7 +1608,7 @@ collect_nursery (SgenGrayQueue *unpin_queue, gboolean finish_up_concurrent_mark)
 	sgen_client_binary_protocol_reclaim_end (GENERATION_NURSERY);
 	TV_GETTIME (btv);
 	time_minor_fragment_creation += TV_ELAPSED (atv, btv);
-	SGEN_LOG (2, "Fragment creation: %lld usecs, %lu bytes available", TV_ELAPSED (atv, btv), (unsigned long)fragment_total);
+	SGEN_LOG (2, "Fragment creation: %lld usecs, %lu bytes available", (long long)TV_ELAPSED (atv, btv), (unsigned long)fragment_total);
 
 	if (consistency_check_at_minor_collection)
 		sgen_check_major_refs ();
@@ -1785,7 +1785,7 @@ major_copy_or_mark_from_roots (size_t *old_next_pin_slot, CopyOrMarkFromRootsMod
 
 	TV_GETTIME (btv);
 	time_major_pinning += TV_ELAPSED (atv, btv);
-	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), TV_ELAPSED (atv, btv));
+	SGEN_LOG (2, "Finding pinned pointers: %zd in %lld usecs", sgen_get_pinned_count (), (long long)TV_ELAPSED (atv, btv));
 	SGEN_LOG (4, "Start scan with %zd pinned objects", sgen_get_pinned_count ());
 
 	major_collector.init_to_space ();

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -953,6 +953,7 @@ extern guint32 tlab_size;
 extern NurseryClearPolicy nursery_clear_policy;
 extern gboolean sgen_try_free_some_memory;
 extern mword total_promoted_size;
+extern mword total_allocated_major;
 
 extern MonoCoopMutex gc_mutex;
 

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -840,6 +840,7 @@ struct _LOSObject {
 
 extern LOSObject *los_object_list;
 extern mword los_memory_usage;
+extern mword los_memory_usage_total;
 
 void sgen_los_free_object (LOSObject *obj);
 void* sgen_los_alloc_large_inner (GCVTable vtable, size_t size);

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -951,6 +951,7 @@ extern int default_nursery_size;
 extern guint32 tlab_size;
 extern NurseryClearPolicy nursery_clear_policy;
 extern gboolean sgen_try_free_some_memory;
+extern mword total_promoted_size;
 
 extern MonoCoopMutex gc_mutex;
 

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -51,9 +51,6 @@ static mword major_collection_trigger_size;
 static mword major_pre_sweep_heap_size;
 static mword major_start_heap_size;
 
-static mword last_major_num_sections = 0;
-static mword last_los_memory_usage = 0;
-
 static gboolean need_calculate_minor_collection_allowance;
 
 /* The size of the LOS after the last major collection, after sweeping. */
@@ -187,10 +184,8 @@ sgen_memgov_major_post_sweep (void)
 {
 	mword num_major_sections = major_collector.get_num_major_sections ();
 
-	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major %dK/%dK",
-		num_major_sections * major_collector.section_size / 1024,
-		last_major_num_sections * major_collector.section_size / 1024);
-	last_major_num_sections = num_major_sections;
+	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major %dK",
+		num_major_sections * major_collector.section_size / 1024);
 }
 
 void
@@ -226,9 +221,8 @@ sgen_memgov_collection_end (int generation, GGTimingInfo* info, int info_count)
 	int i;
 	for (i = 0; i < info_count; ++i) {
 		if (info[i].generation != -1)
-			sgen_client_log_timing (&info [i], total_promoted_size - total_promoted_size_start, last_los_memory_usage);
+			sgen_client_log_timing (&info [i], total_promoted_size - total_promoted_size_start);
 	}
-	last_los_memory_usage = los_memory_usage;
 }
 
 /*

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -26,7 +26,9 @@
 #define MIN_MINOR_COLLECTION_ALLOWANCE	((mword)(DEFAULT_NURSERY_SIZE * default_allowance_nursery_size_ratio))
 
 mword total_promoted_size = 0;
+mword total_allocated_major = 0;
 static mword total_promoted_size_start;
+static mword total_allocated_major_end;
 
 /*Heap limits and allocation knobs*/
 static mword max_heap_size = ((mword)0)- ((mword)1);
@@ -55,6 +57,7 @@ static gboolean need_calculate_minor_collection_allowance;
 
 /* The size of the LOS after the last major collection, after sweeping. */
 static mword last_collection_los_memory_usage = 0;
+static mword last_used_slots_size = 0;
 
 static mword sgen_memgov_available_free_space (void);
 
@@ -180,12 +183,14 @@ sgen_memgov_major_pre_sweep (void)
 }
 
 void
-sgen_memgov_major_post_sweep (void)
+sgen_memgov_major_post_sweep (mword used_slots_size)
 {
 	mword num_major_sections = major_collector.get_num_major_sections ();
 
-	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major %dK",
-		num_major_sections * major_collector.section_size / 1024);
+	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major size: %dK in use: %dK",
+		num_major_sections * major_collector.section_size / 1024,
+		(used_slots_size + total_allocated_major - total_allocated_major_end) / 1024);
+	last_used_slots_size = used_slots_size;
 }
 
 void
@@ -204,6 +209,7 @@ sgen_memgov_major_collection_end (gboolean forced)
 {
 	last_collection_los_memory_usage = los_memory_usage;
 
+	total_allocated_major_end = total_allocated_major;
 	if (forced) {
 		sgen_get_major_collector ()->finish_sweeping ();
 		sgen_memgov_calculate_minor_collection_allowance ();
@@ -221,7 +227,7 @@ sgen_memgov_collection_end (int generation, GGTimingInfo* info, int info_count)
 	int i;
 	for (i = 0; i < info_count; ++i) {
 		if (info[i].generation != -1)
-			sgen_client_log_timing (&info [i], total_promoted_size - total_promoted_size_start);
+			sgen_client_log_timing (&info [i], total_promoted_size - total_promoted_size_start, last_used_slots_size + total_allocated_major - total_allocated_major_end);
 	}
 }
 

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -25,6 +25,9 @@
 
 #define MIN_MINOR_COLLECTION_ALLOWANCE	((mword)(DEFAULT_NURSERY_SIZE * default_allowance_nursery_size_ratio))
 
+mword total_promoted_size = 0;
+static mword total_promoted_size_start;
+
 /*Heap limits and allocation knobs*/
 static mword max_heap_size = ((mword)0)- ((mword)1);
 static mword soft_heap_limit = ((mword)0) - ((mword)1);
@@ -160,6 +163,7 @@ sgen_need_major_collection (mword space_needed)
 void
 sgen_memgov_minor_collection_start (void)
 {
+	total_promoted_size_start = total_promoted_size;
 }
 
 void
@@ -222,7 +226,7 @@ sgen_memgov_collection_end (int generation, GGTimingInfo* info, int info_count)
 	int i;
 	for (i = 0; i < info_count; ++i) {
 		if (info[i].generation != -1)
-			sgen_client_log_timing (&info [i], last_major_num_sections, last_los_memory_usage);
+			sgen_client_log_timing (&info [i], total_promoted_size - total_promoted_size_start, last_los_memory_usage);
 	}
 	last_los_memory_usage = los_memory_usage;
 }

--- a/mono/sgen/sgen-memory-governor.h
+++ b/mono/sgen/sgen-memory-governor.h
@@ -17,7 +17,7 @@ void sgen_memgov_minor_collection_start (void);
 void sgen_memgov_minor_collection_end (void);
 
 void sgen_memgov_major_pre_sweep (void);
-void sgen_memgov_major_post_sweep (void);
+void sgen_memgov_major_post_sweep (mword used_slots_size);
 void sgen_memgov_major_collection_start (void);
 void sgen_memgov_major_collection_end (gboolean forced);
 

--- a/mono/sgen/sgen-simple-nursery.c
+++ b/mono/sgen/sgen-simple-nursery.c
@@ -22,6 +22,7 @@
 static inline GCObject*
 alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean has_references)
 {
+	total_promoted_size += objsize;
 	return major_collector.alloc_object (vtable, objsize, has_references);
 }
 

--- a/mono/sgen/sgen-split-nursery.c
+++ b/mono/sgen/sgen-split-nursery.c
@@ -254,8 +254,10 @@ alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean ha
 	int age;
 
 	age = get_object_age (obj);
-	if (age >= promote_age)
+	if (age >= promote_age) {
+		total_promoted_size += objsize;
 		return major_collector.alloc_object (vtable, objsize, has_references);
+	}
 
 	/* Promote! */
 	++age;
@@ -265,8 +267,10 @@ alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean ha
         age_alloc_buffers [age].next += objsize;
 	} else {
 		p = alloc_for_promotion_slow_path (age, objsize);
-		if (!p)
+		if (!p) {
+			total_promoted_size += objsize;
 			return major_collector.alloc_object (vtable, objsize, has_references);
+		}
 	}
 
 	/* FIXME: assumes object layout */


### PR DESCRIPTION
Before
> Mono: GC_MINOR: (Nursery full) pause 10.41ms, total 10.41ms, bridge 0.00ms promoted 194800K major 800688K los 10753K
> Mono: GC_MINOR: (Nursery full) pause 8.99ms, total 8.99ms, bridge 0.00ms promoted 196272K major 802160K los 10753K
> Mono: GC_MAJOR: (Minor allowance) pause 649.05ms, total 649.05ms, bridge 0.00ms los 5111K/10753K
> Mono: GC_MAJOR_SWEEP: major 773696K/605888K
> Mono: GC_MINOR: (Nursery full) pause 16.61ms, total 16.61ms, bridge 0.00ms promoted 0K major 773696K los 5111K
> Mono: GC_MINOR: (Nursery full) pause 6.56ms, total 6.55ms, bridge 0.00ms promoted 48K major 773744K los 5111K

After
> Mono: GC_MINOR: (Nursery full) pause 7.59ms, total 7.59ms, bridge 0.00ms promoted 1600K major size: 802976K in use: 784355K los size: 20652K in use: 10833K
> Mono: GC_MINOR: (Nursery full) pause 6.49ms, total 6.49ms, bridge 0.00ms promoted 1644K major size: 804688K in use: 786049K los size: 20652K in use: 10833K
> Mono: GC_MAJOR: (Minor allowance) pause 681.82ms, total 681.82ms, bridge 0.00ms los size: 18604K in use: 5111K
> Mono: GC_MAJOR_SWEEP: major size: 775696K in use: 590703K
> Mono: GC_MINOR: (Nursery full) pause 17.13ms, total 17.13ms, bridge 0.00ms promoted 1291K major size: 775712K in use: 592030K los size: 18604K in use: 5111K
> Mono: GC_MINOR: (Nursery full) pause 7.10ms, total 7.10ms, bridge 0.00ms promoted 1683K major size: 775728K in use: 593767K los size: 18604K in use: 5111K
