### PR TITLE
[tests] Simplify 'test-sgen' target logic in Makefile.am

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -768,25 +768,7 @@ endif
 test-env-options:
 	MONO_ENV_OPTIONS="--version" $(RUNTIME) array-init.exe | grep -q Architecture:
 
-if AMD64
 test-sgen : sgen-tests
-else
-if X86
-if HOST_WIN32
-test-sgen :
-else
-test-sgen : sgen-tests
-endif
-else
-if ARM
-test-sgen : sgen-tests
-else
-if S390X
-test-sgen : sgen-regular-tests
-endif
-endif
-endif
-endif
 
 # Precompile the test assemblies in parallel
 compile-tests:
@@ -969,9 +951,11 @@ EXTRA_DIST += sgen-bridge.cs sgen-descriptors.cs sgen-gshared-vtype.cs sgen-brid
 
 sgen-tests:
 	$(MAKE) sgen-regular-tests
+if !S390X
 	$(MAKE) sgen-toggleref-tests
 	$(MAKE) sgen-bridge-tests
 	$(MAKE) sgen-bridge2-tests
+endif
 
 SGEN_REGULAR_TESTS =	\
 	finalizer-wait.exe	\


### PR DESCRIPTION
The sgen tests should run on Windows x86 too (or at least they will in the near future), so we can get rid of all the special casing.
This also fixes an error in the ARM64 test run on Jenkins because test-sgen wasn't defined there.