### PR TITLE
SWF - Fixed exiting modal runloop.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Application.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Application.cs
@@ -969,8 +969,8 @@ namespace System.Windows.Forms
 
 				EnableFormsForModalLoop (toplevels, context);
 				
-				if (context.MainForm != null && context.MainForm.IsHandleCreated) {
-					XplatUI.SetModal (context.MainForm.Handle, false);
+				if (old.MainForm != null && old.IsHandleCreated) {
+					XplatUI.SetModal (old.Handle, false);
 				}
 				#if DebugRunLoop
 					Console.WriteLine ("   Done with the SetModal");


### PR DESCRIPTION
Fixes a bug in exiting modal runloop that caused not really exiting it
(not calling XplatUI.SetModal(..., false).

It caused issues with menu, for example, if you first ran a modal
dialog (a wizard), and then you started the application (tested on Mac).