### PR TITLE
[corlib] Ignore DirectoryNotFoundException in FileStreamTest.OpenCharDeviceRepeatedly test

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
@@ -1671,6 +1671,9 @@ namespace MonoTests.System.IO
 			} catch (FileNotFoundException) {
 				// Only run this test on platforms where /dev/zero exists
 				Assert.Ignore();
+			} catch (DirectoryNotFoundException) {
+				// Only run this test on platforms where /dev exists
+				Assert.Ignore();
 			}
 
 			// this shouldn't throw


### PR DESCRIPTION
It seems that older iOS6 devices don't allow access to /dev, as a DirectoryNotFoundException is
thrown when accessing /dev/zero in the FileStreamTest.OpenCharDeviceRepeatedly test there.

Ignore this exception and the test in those cases.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40462