### PR TITLE
[corlib] Make CountdownEventTests.Signal_Concurrent more reliable

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/CountdownEventTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/CountdownEventTests.cs
@@ -304,7 +304,7 @@ namespace MonoTests.System.Threading
 						});
 					}
 
-					Assert.IsTrue (ce.Wait (1000), "#1");
+					Assert.IsTrue (ce.Wait (10000), "#1");
 				}
 			}
 		}


### PR DESCRIPTION
We were seeing random failures of the test in the iOS simulator and devices.

Looking at the test, it seems to me like the 1000ms timeout is just too short. In a single iteration we're
enqueuing 500 threadpool workitems and effectively give each of them just 2ms to run and signal the CountdownEvent.

Indeed I can easily repro this in the simulator on my box if I lower the timeout to 900ms.
This may be a side effect of the new threadpool which starts threads more conservatively afaik.

Bumping the timeout should fix this.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=39305

@monojenkins merge