### PR TITLE
[System][tests] Tweak Dns unit tests so it does not fail on an IPv6 only network

### DIFF
--- a/mcs/class/System/Test/System.Net/DnsTest.cs
+++ b/mcs/class/System/Test/System.Net/DnsTest.cs
@@ -9,7 +9,7 @@
 // 
 
 using System;
-using System.Collections;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -56,7 +56,7 @@ namespace MonoTests.System.Net
 			IAsyncResult async = Dns.BeginResolve (site1Dot, null, null);
 			IPHostEntry entry = Dns.EndResolve (async);
 			SubTestValidIPHostEntry (entry);
-			var ip = GetNonIPv6Address (entry);
+			var ip = GetIPv4Address (entry);
 			Assert.AreEqual (site1Dot, ip.ToString ());
 		}
 
@@ -206,12 +206,12 @@ namespace MonoTests.System.Net
 			}
 		}
 
-		static IPAddress GetNonIPv6Address (IPHostEntry h)
+		static IPAddress GetIPv4Address (IPHostEntry h)
 		{
-			var al0 = h.AddressList [0];
-			if (al0.AddressFamily == AddressFamily.InterNetworkV6)
-				Assert.Ignore ("Resolve address is incompatible, e.g. running on an IPv6 only network");
-			return al0;
+			var al = h.AddressList.FirstOrDefault (x => x.AddressFamily == AddressFamily.InterNetwork);
+			if (al == null)
+				Assert.Ignore ("Could not resolve an IPv4 address as required by this test case, e.g. running on an IPv6 only network");
+			return al;
 		}
 
 		void SubTestGetHostByName (string siteName, string siteDot)
@@ -219,7 +219,7 @@ namespace MonoTests.System.Net
 			IPHostEntry h = Dns.GetHostByName (siteName);
 			SubTestValidIPHostEntry (h);
 			Assert.AreEqual (siteName, h.HostName, "siteName");
-			var ip = GetNonIPv6Address (h);
+			var ip = GetIPv4Address (h);
 			Assert.AreEqual (siteDot, ip.ToString (), "siteDot");
 		}
 
@@ -297,7 +297,7 @@ namespace MonoTests.System.Net
 			IPAddress addr = new IPAddress (IPAddress.NetworkToHostOrder ((int) site1IP));
 			IPHostEntry h = Dns.GetHostByAddress (addr);
 			SubTestValidIPHostEntry (h);
-			var ip = GetNonIPv6Address (h);
+			var ip = GetIPv4Address (h);
 			Assert.AreEqual (addr.ToString (), ip.ToString ());
 		}
 
@@ -307,7 +307,7 @@ namespace MonoTests.System.Net
 			IPAddress addr = new IPAddress (IPAddress.NetworkToHostOrder ((int) site2IP));
 			IPHostEntry h = Dns.GetHostByAddress (addr);
 			SubTestValidIPHostEntry (h);
-			var ip = GetNonIPv6Address (h);
+			var ip = GetIPv4Address (h);
 			Assert.AreEqual (addr.ToString (), ip.ToString ());
 		}
 

--- a/mcs/class/System/Test/System.Net/DnsTest.cs
+++ b/mcs/class/System/Test/System.Net/DnsTest.cs
@@ -56,7 +56,8 @@ namespace MonoTests.System.Net
 			IAsyncResult async = Dns.BeginResolve (site1Dot, null, null);
 			IPHostEntry entry = Dns.EndResolve (async);
 			SubTestValidIPHostEntry (entry);
-			Assert.AreEqual (site1Dot, entry.AddressList [0].ToString ());
+			var ip = GetNonIPv6Address (entry);
+			Assert.AreEqual (site1Dot, ip.ToString ());
 		}
 
 		void ResolveCallback (IAsyncResult ar)
@@ -205,12 +206,21 @@ namespace MonoTests.System.Net
 			}
 		}
 
+		static IPAddress GetNonIPv6Address (IPHostEntry h)
+		{
+			var al0 = h.AddressList [0];
+			if (al0.AddressFamily == AddressFamily.InterNetworkV6)
+				Assert.Ignore ("Resolve address is incompatible, e.g. running on an IPv6 only network");
+			return al0;
+		}
+
 		void SubTestGetHostByName (string siteName, string siteDot)
 		{
 			IPHostEntry h = Dns.GetHostByName (siteName);
 			SubTestValidIPHostEntry (h);
 			Assert.AreEqual (siteName, h.HostName, "siteName");
-			Assert.AreEqual (siteDot, h.AddressList [0].ToString (), "siteDot");
+			var ip = GetNonIPv6Address (h);
+			Assert.AreEqual (siteDot, ip.ToString (), "siteDot");
 		}
 
 		[Test]
@@ -287,7 +297,8 @@ namespace MonoTests.System.Net
 			IPAddress addr = new IPAddress (IPAddress.NetworkToHostOrder ((int) site1IP));
 			IPHostEntry h = Dns.GetHostByAddress (addr);
 			SubTestValidIPHostEntry (h);
-			Assert.AreEqual (addr.ToString (), h.AddressList [0].ToString ());
+			var ip = GetNonIPv6Address (h);
+			Assert.AreEqual (addr.ToString (), ip.ToString ());
 		}
 
 		[Test]
@@ -296,7 +307,8 @@ namespace MonoTests.System.Net
 			IPAddress addr = new IPAddress (IPAddress.NetworkToHostOrder ((int) site2IP));
 			IPHostEntry h = Dns.GetHostByAddress (addr);
 			SubTestValidIPHostEntry (h);
-			Assert.AreEqual (addr.ToString (), h.AddressList [0].ToString ());
+			var ip = GetNonIPv6Address (h);
+			Assert.AreEqual (addr.ToString (), ip.ToString ());
 		}
 
 		[Test]


### PR DESCRIPTION
Some existing tests only works when IPv4 is available, which was fine as
it match how we historically ran those tests.

Apple has a new requirement [1] to test under an "IPv6 only network" and
the change facilitate this.

[1] https://developer.apple.com/news/?id=05042016a