### PR TITLE
[bcl] Add stub Mono.Posix.dll to 4.0 folder so FSharp bootstrapping works

### DIFF
--- a/mcs/class/reference-assemblies/Makefile
+++ b/mcs/class/reference-assemblies/Makefile
@@ -18,11 +18,12 @@ install-local:
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5/*.dll $(PROFILE_DIR)/4.5-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5/Facades/*.dll $(PROFILE_DIR)/4.5-api/Facades
 
-	# Unfortunately, a few programs (most notably NUnit) have hardcoded checks for <prefix>/lib/mono/4.0/mscorlib.dll,
+	# Unfortunately, a few programs (most notably NUnit and FSharp) have hardcoded checks for <prefix>/lib/mono/4.0/mscorlib.dll or Mono.Posix.dll,
 	# so we need to place something there or those tools break. We decided to symlink to the reference assembly for now.
-	# See https://bugzilla.xamarin.com/show_bug.cgi?id=38331
+	# See https://bugzilla.xamarin.com/show_bug.cgi?id=38331 and https://bugzilla.xamarin.com/show_bug.cgi?id=41052
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.0
 	ln -sf ../4.0-api/mscorlib.dll $(PROFILE_DIR)/4.0/mscorlib.dll
+	ln -sf ../4.0-api/Mono.Posix.dll $(PROFILE_DIR)/4.0/Mono.Posix.dll
 
 DISTFILES = $(wildcard ../../../external/binary-reference-assemblies/v4.5/Facades/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v4.5/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v4.0/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v3.5/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v2.0/*.dll) Makefile
 


### PR DESCRIPTION
It was checking the existence of the file which doesn't work anymore after the -api rename.
This was already fixed upstream in https://github.com/fsharp/fsharp/pull/525 but the bootstrap package doesn't have the fix yet.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41052