### PR TITLE
[runtime] MonoError mono_runtime_invoke_{array,delegate}

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3313,7 +3313,9 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 			return (MonoObject*)arr;
 		}
 	}
-	return mono_runtime_invoke_array (m, obj, params, NULL);
+	MonoObject *result = mono_runtime_invoke_array_checked (m, obj, params, &error);
+	mono_error_set_pending_exception (&error);
+	return result;
 }
 
 #ifndef DISABLE_REMOTING
@@ -3435,7 +3437,9 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 
 	/* This can be called only on MBR objects, so no need to unbox for valuetypes. */
 	g_assert (!method->method->klass->valuetype);
-	result = mono_runtime_invoke_array (method->method, this_arg, params, NULL);
+	result = mono_runtime_invoke_array_checked (method->method, this_arg, params, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 
 	for (i = 0, j = 0; i < mono_array_length (params); i++) {
 		if (sig->params [i]->byref) {

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1706,6 +1706,14 @@ mono_runtime_try_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 MonoObject*
 mono_runtime_invoke_checked (MonoMethod *method, void *obj, void **params, MonoError *error);
 
+MonoObject*
+mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
+			       MonoObject **exc, MonoError *error);
+
+MonoObject*
+mono_runtime_invoke_array_checked (MonoMethod *method, void *obj, MonoArray *params,
+				   MonoError *error);
+
 void* 
 mono_compile_method_checked (MonoMethod *method, MonoError *error);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1709,6 +1709,14 @@ mono_runtime_invoke_checked (MonoMethod *method, void *obj, void **params, MonoE
 void* 
 mono_compile_method_checked (MonoMethod *method, MonoError *error);
 
+MonoObject*
+mono_runtime_delegate_try_invoke (MonoObject *delegate, void **params,
+				  MonoObject **exc, MonoError *error);
+
+MonoObject*
+mono_runtime_delegate_invoke_checked (MonoObject *delegate, void **params,
+				      MonoError *error);
+
 MonoArray*
 mono_runtime_get_main_args_checked (MonoError *error);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -611,7 +611,7 @@ mono_message_init	    (MonoDomain *domain, MonoMethodMessage *this_obj,
 
 MonoObject *
 mono_message_invoke	    (MonoObject *target, MonoMethodMessage *msg, 
-			     MonoObject **exc, MonoArray **out_args);
+			     MonoObject **exc, MonoArray **out_args, MonoError *error);
 
 MonoMethodMessage *
 mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *invoke, 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -254,6 +254,7 @@ mono_get_delegate_begin_invoke (MonoClass *klass);
 MONO_API MonoMethod *
 mono_get_delegate_end_invoke (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject*
 mono_runtime_delegate_invoke (MonoObject *delegate, void **params, 
 			      MonoObject **exc);

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -259,6 +259,7 @@ MONO_API MonoObject*
 mono_runtime_delegate_invoke (MonoObject *delegate, void **params, 
 			      MonoObject **exc);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject*
 mono_runtime_invoke_array   (MonoMethod *method, void *obj, MonoArray *params,
 			     MonoObject **exc);

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -57,6 +57,7 @@ mono_runtime_is_shutting_down (void)
 static void
 fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 {
+	MonoError error;
 	MonoClassField *field;
 	gpointer pa [2];
 	MonoObject *delegate, *exc;
@@ -70,7 +71,8 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 
 	pa [0] = domain;
 	pa [1] = NULL;
-	mono_runtime_delegate_invoke (delegate, pa, &exc);
+	mono_runtime_delegate_try_invoke (delegate, pa, &exc, &error);
+	mono_error_cleanup (&error);
 }
 
 static void

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -744,7 +744,8 @@ static guint32 WINAPI start_wrapper_internal(void *data)
 		g_assert (start_delegate != NULL);
 		args [0] = start_arg;
 		/* we may want to handle the exception here. See comment below on unhandled exceptions */
-		mono_runtime_delegate_invoke (start_delegate, args, NULL);
+		mono_runtime_delegate_invoke_checked (start_delegate, args, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
 	}
 
 	/* If the thread calls ExitThread at all, this remaining code


### PR DESCRIPTION
and `mono_message_invoke`

All of these get triplicated the same way as mono_runtime_invoke: there's a `_try_` function that takes a `MonoException**` and a `MonoError*` outargs that should be seldom used and a more common `_checked` function that just takes a `MonoError` and should replace most of the places that used to call the invokes with a NULL exn.