### PR TITLE
Generate RSA keys using public exponent 65537 (was 17)

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Cryptography/RSAManaged.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Cryptography/RSAManaged.cs
@@ -93,7 +93,7 @@ namespace Mono.Security.Cryptography {
 			// p and q values should have a length of half the strength in bits
 			int pbitlength = ((KeySize + 1) >> 1);
 			int qbitlength = (KeySize - pbitlength);
-			const uint uint_e = 17;
+			const uint uint_e = 65537;
 			e = uint_e; // fixed
 	
 			// generate p, prime and (p-1) relatively prime to e


### PR DESCRIPTION
OpenSSL and the MS RSA CSP (Win7 x64) generate RSA keys with a public exponent of 65537. Smaller public exponents are not allowed by some specifications and may be rejected by other software.

"In addition to the key sizes, keys must be generated using secure parameters. Rivest, Shamir,
Adleman (RSA) keys must be generated using a public exponent of 65 537"
[NIST Special Publication 800-78-4](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-78-4.pdf)

"RSA: The CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or more. Additionally, the public exponent SHOULD be in the range between 2**16+1 and 2**256-1."
[Baseline Requirements Certificate Policy for the Issuance and Management of Publicly-Trusted Certificates](https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.3.4.pdf)

The Let's Encrypt CA rejects keys with an exponent < 2^16 + 1.
[good_key.go](https://github.com/letsencrypt/boulder/blob/master/core/good_key.go#L204)