### PR TITLE
Windows x64 full AOT support for mono/mini regression tests.

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -257,8 +257,14 @@ mono_thread_get_tls_key (void)
 gint32
 mono_thread_get_tls_offset (void)
 {
-	int offset;
+	int offset = -1;
+
+#ifdef HOST_WIN32
+	if (current_object_key)
+		offset = current_object_key;
+#else
 	MONO_THREAD_VAR_OFFSET (tls_current_object,offset);
+#endif
 	return offset;
 }
 

--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -332,7 +332,7 @@ amd64_set_xmmreg_r4: dest:f src1:f len:14 clob:m
 amd64_set_xmmreg_r8: dest:f src1:f len:14 clob:m
 amd64_save_sp_to_lmf: len:16
 tls_get: dest:i len:32
-tls_get_reg: dest:i src1:i len:32
+tls_get_reg: dest:i src1:i len:64
 tls_set: src1:i len:16
 tls_set_reg: src1:i src2:i len:32
 atomic_add_i4: src1:b src2:i dest:i len:32

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -435,7 +435,7 @@ typedef struct {
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 1
 #endif
 
-#if defined(TARGET_OSX) || defined(__linux__)
+#if defined(TARGET_OSX) || defined(__linux__) || defined(TARGET_WIN32)
 #define MONO_ARCH_HAVE_TLS_GET_REG 1
 #endif
 

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -59,14 +59,12 @@ void
 mono_runtime_install_handlers (void)
 {
 #ifndef MONO_CROSS_COMPILE
-	if (!mono_aot_only) {
-		win32_seh_init();
-		win32_seh_set_handler(SIGFPE, mono_sigfpe_signal_handler);
-		win32_seh_set_handler(SIGILL, mono_sigill_signal_handler);
-		win32_seh_set_handler(SIGSEGV, mono_sigsegv_signal_handler);
-		if (mini_get_debug_options ()->handle_sigint)
-			win32_seh_set_handler(SIGINT, mono_sigint_signal_handler);
-	}
+	win32_seh_init();
+	win32_seh_set_handler(SIGFPE, mono_sigfpe_signal_handler);
+	win32_seh_set_handler(SIGILL, mono_sigill_signal_handler);
+	win32_seh_set_handler(SIGSEGV, mono_sigsegv_signal_handler);
+	if (mini_get_debug_options ()->handle_sigint)
+		win32_seh_set_handler(SIGINT, mono_sigint_signal_handler);
 #endif
 }
 
@@ -74,9 +72,7 @@ void
 mono_runtime_cleanup_handlers (void)
 {
 #ifndef MONO_CROSS_COMPILE
-	if (!mono_aot_only) {
-		win32_seh_cleanup();
-	}
+	win32_seh_cleanup();
 #endif
 }
 


### PR DESCRIPTION
Fixes needed in order to get full AOT working for mono/mini regression tests on windows x64 builds (currently disabling the gsharedvt and dyncall tests).

Fixes are done in two main areas, exception and thread local storage support.

SEH exception handling enabled in order to catch CPU generated exceptions. All exception related regression tests pass with fix and runtime won't attempt to JIT any code since it is prevented when running with --full-aot startup argument.

Thread local storage (TLS) support was not complete on windows x64. When running full AOT the sgen allocator uses TLS for its allocator. AOT compiler will issues OP_TLS_GET_REG operations when compiling the “Alloc” methods. On win x64 this was not implemented, just the default OP_TLS_GET, meaning that methods compiled using OP_TLS_GET_REG was "silently" dropped when full AOT:ed compiled. At runtime, the sgen allocator would tried to locate the “Alloc” method but fails to find it and since this will cause an exception (that also needs the allocator to be used) and the program entered a loop that will end in a stack overflow crashing the program.

The fix implements OP_TLS_GET_REG and other needed support for win x64. It also fixes the offset calculation needed by full AOT builds (translating to correct runtime TLS key) for keys used by mono/mini regression tests. Since windows TLS support is a little more complex (two different conditions depending on where the TLS key gets allocated) the max size of tls_get_reg for amd64 has been increased from 32 to 64 byte as well.