### PR TITLE
[coop] Use GC safe/unsafe macros inside the runtime

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2537,9 +2537,9 @@ guarded_wait (HANDLE handle, guint32 timeout, gboolean alertable)
 {
 	guint32 result;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	result = WaitForSingleObjectEx (handle, timeout, alertable);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return result;
 }

--- a/mono/metadata/file-io.c
+++ b/mono/metadata/file-io.c
@@ -270,7 +270,7 @@ MonoBoolean
 ves_icall_System_IO_MonoIO_CreateDirectory (MonoString *path, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 	
@@ -279,7 +279,7 @@ ves_icall_System_IO_MonoIO_CreateDirectory (MonoString *path, gint32 *error)
 		*error=GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -287,7 +287,7 @@ MonoBoolean
 ves_icall_System_IO_MonoIO_RemoveDirectory (MonoString *path, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 	
@@ -296,7 +296,7 @@ ves_icall_System_IO_MonoIO_RemoveDirectory (MonoString *path, gint32 *error)
 		*error=GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -404,9 +404,9 @@ ves_icall_System_IO_MonoIO_GetFileSystemEntries (MonoString *path,
 	
 	*ioerror = ERROR_SUCCESS;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	names = get_filesystem_entries (mono_string_chars (path), mono_string_chars (path_with_pattern), attrs, mask, ioerror);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if (!names) {
 		// If there's no array and no error, then return an empty array.
@@ -531,14 +531,14 @@ ves_icall_System_IO_MonoIO_FindClose (gpointer handle)
 	IncrementalFind *ifh = (IncrementalFind *)handle;
 	gint32 error;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	if (FindClose (ifh->find_handle) == FALSE){
 		error = GetLastError ();
 	} else
 		error = ERROR_SUCCESS;
 	g_free (ifh->utf8_path);
 	g_free (ifh);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return error;
 }
@@ -602,7 +602,7 @@ ves_icall_System_IO_MonoIO_MoveFile (MonoString *path, MonoString *dest,
 				     gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 
@@ -611,7 +611,7 @@ ves_icall_System_IO_MonoIO_MoveFile (MonoString *path, MonoString *dest,
 		*error=GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -623,7 +623,7 @@ ves_icall_System_IO_MonoIO_ReplaceFile (MonoString *sourceFileName, MonoString *
 	gboolean ret;
 	gunichar2 *utf16_sourceFileName = NULL, *utf16_destinationFileName = NULL, *utf16_destinationBackupFileName = NULL;
 	guint32 replaceFlags = REPLACEFILE_WRITE_THROUGH;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	if (sourceFileName)
 		utf16_sourceFileName = mono_string_chars (sourceFileName);
@@ -642,7 +642,7 @@ ves_icall_System_IO_MonoIO_ReplaceFile (MonoString *sourceFileName, MonoString *
 	if (ret == FALSE)
 		*error = GetLastError ();
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return ret;
 }
 
@@ -651,7 +651,7 @@ ves_icall_System_IO_MonoIO_CopyFile (MonoString *path, MonoString *dest,
 				     MonoBoolean overwrite, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 	
@@ -660,7 +660,7 @@ ves_icall_System_IO_MonoIO_CopyFile (MonoString *path, MonoString *dest,
 		*error=GetLastError ();
 	}
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -668,7 +668,7 @@ MonoBoolean
 ves_icall_System_IO_MonoIO_DeleteFile (MonoString *path, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 	
@@ -677,7 +677,7 @@ ves_icall_System_IO_MonoIO_DeleteFile (MonoString *path, gint32 *error)
 		*error=GetLastError ();
 	}
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -685,7 +685,7 @@ gint32
 ves_icall_System_IO_MonoIO_GetFileAttributes (MonoString *path, gint32 *error)
 {
 	gint32 ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -702,7 +702,7 @@ ves_icall_System_IO_MonoIO_GetFileAttributes (MonoString *path, gint32 *error)
 		*error=GetLastError ();
 	}
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -711,7 +711,7 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (MonoString *path, gint32 attrs,
 					      gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 	
@@ -721,7 +721,7 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (MonoString *path, gint32 attrs,
 		*error=GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -729,7 +729,7 @@ gint32
 ves_icall_System_IO_MonoIO_GetFileType (HANDLE handle, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -741,7 +741,7 @@ ves_icall_System_IO_MonoIO_GetFileType (HANDLE handle, gint32 *error)
 		*error=GetLastError ();
 	}
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -751,7 +751,7 @@ ves_icall_System_IO_MonoIO_GetFileStat (MonoString *path, MonoIOStat *stat,
 {
 	gboolean result;
 	WIN32_FILE_ATTRIBUTE_DATA data;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -764,7 +764,7 @@ ves_icall_System_IO_MonoIO_GetFileStat (MonoString *path, MonoIOStat *stat,
 		memset (stat, 0, sizeof (MonoIOStat));
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return result;
 }
 
@@ -776,7 +776,7 @@ ves_icall_System_IO_MonoIO_Open (MonoString *filename, gint32 mode,
 	HANDLE ret;
 	int attributes, attrs;
 	gunichar2 *chars;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	chars = mono_string_chars (filename);	
 	*error=ERROR_SUCCESS;
@@ -821,7 +821,7 @@ ves_icall_System_IO_MonoIO_Open (MonoString *filename, gint32 mode,
 		*error=GetLastError ();
 	} 
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -829,7 +829,7 @@ MonoBoolean
 ves_icall_System_IO_MonoIO_Close (HANDLE handle, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -838,7 +838,7 @@ ves_icall_System_IO_MonoIO_Close (HANDLE handle, gint32 *error)
 		*error=GetLastError ();
 	}
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -862,9 +862,9 @@ ves_icall_System_IO_MonoIO_Read (HANDLE handle, MonoArray *dest,
 
 	buffer = mono_array_addr (dest, guchar, dest_offset);
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	result = ReadFile (handle, buffer, count, &n, NULL);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if (!result) {
 		*error=GetLastError ();
@@ -893,9 +893,9 @@ ves_icall_System_IO_MonoIO_Write (HANDLE handle, MonoArray *src,
 	}
 	
 	buffer = mono_array_addr (src, guchar, src_offset);
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	result = WriteFile (handle, buffer, count, &n, NULL);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if (!result) {
 		*error=GetLastError ();
@@ -910,7 +910,7 @@ ves_icall_System_IO_MonoIO_Seek (HANDLE handle, gint64 offset, gint32 origin,
 				 gint32 *error)
 {
 	gint32 offset_hi;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -922,7 +922,7 @@ ves_icall_System_IO_MonoIO_Seek (HANDLE handle, gint64 offset, gint32 origin,
 		*error=GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return offset | ((gint64)offset_hi << 32);
 }
 
@@ -930,7 +930,7 @@ MonoBoolean
 ves_icall_System_IO_MonoIO_Flush (HANDLE handle, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -939,7 +939,7 @@ ves_icall_System_IO_MonoIO_Flush (HANDLE handle, gint32 *error)
 		*error=GetLastError ();
 	}
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -948,7 +948,7 @@ ves_icall_System_IO_MonoIO_GetLength (HANDLE handle, gint32 *error)
 {
 	gint64 length;
 	guint32 length_hi;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -957,7 +957,7 @@ ves_icall_System_IO_MonoIO_GetLength (HANDLE handle, gint32 *error)
 		*error=GetLastError ();
 	}
 	
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return length | ((gint64)length_hi << 32);
 }
 
@@ -1019,7 +1019,7 @@ ves_icall_System_IO_MonoIO_SetFileTime (HANDLE handle, gint64 creation_time,
 	const FILETIME *creation_filetime;
 	const FILETIME *last_access_filetime;
 	const FILETIME *last_write_filetime;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	*error=ERROR_SUCCESS;
 	
@@ -1043,7 +1043,7 @@ ves_icall_System_IO_MonoIO_SetFileTime (HANDLE handle, gint64 creation_time,
 		*error=GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return(ret);
 }
 
@@ -1075,9 +1075,9 @@ ves_icall_System_IO_MonoIO_CreatePipe (HANDLE *read_handle, HANDLE *write_handle
 	attr.bInheritHandle=TRUE;
 	attr.lpSecurityDescriptor=NULL;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret=CreatePipe (read_handle, write_handle, &attr, 0);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if(ret==FALSE) {
 		*error = GetLastError ();
@@ -1095,9 +1095,9 @@ ves_icall_System_IO_MonoIO_DuplicateHandle (HANDLE source_process_handle, HANDLE
 	/* This is only used on Windows */
 	gboolean ret;
 	
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret=DuplicateHandle (source_process_handle, source_handle, target_process_handle, target_handle, access, inherit, options);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if(ret==FALSE) {
 		*error = GetLastError ();
@@ -1196,7 +1196,7 @@ void ves_icall_System_IO_MonoIO_Lock (HANDLE handle, gint64 position,
 				      gint64 length, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 	
@@ -1206,14 +1206,14 @@ void ves_icall_System_IO_MonoIO_Lock (HANDLE handle, gint64 position,
 		*error = GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 }
 
 void ves_icall_System_IO_MonoIO_Unlock (HANDLE handle, gint64 position,
 					gint64 length, gint32 *error)
 {
 	gboolean ret;
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	
 	*error=ERROR_SUCCESS;
 	
@@ -1223,7 +1223,7 @@ void ves_icall_System_IO_MonoIO_Unlock (HANDLE handle, gint64 position,
 		*error = GetLastError ();
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 }
 
 //Support for io-layer free mmap'd files.
@@ -1237,7 +1237,7 @@ mono_filesize_from_path (MonoString *string)
 	gint64 res;
 	char *path = mono_string_to_utf8 (string);
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	if (stat (path, &buf) == -1)
 		res = -1;
 	else
@@ -1245,7 +1245,7 @@ mono_filesize_from_path (MonoString *string)
 
 	g_free (path);
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return res;
 }
 
@@ -1255,9 +1255,9 @@ mono_filesize_from_fd (int fd)
 	struct stat buf;
 	int res;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	res = fstat (fd, &buf);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	
 	if (res == -1)
 		return (gint64)-1;

--- a/mono/metadata/filewatcher.c
+++ b/mono/metadata/filewatcher.c
@@ -231,9 +231,9 @@ ves_icall_System_IO_KqueueMonitor_kevent_notimeout (int *kq_ptr, gpointer change
 		return -1;
 	}
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	res = kevent (*kq_ptr, changelist, nchanges, eventlist, nevents, NULL);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	mono_thread_info_uninstall_interrupt (&interrupted);
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -85,9 +85,9 @@ guarded_wait (HANDLE handle, guint32 timeout, gboolean alertable)
 {
 	guint32 result;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	result = WaitForSingleObjectEx (handle, timeout, alertable);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return result;
 }

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -881,9 +881,9 @@ retry_contended:
 	 * We pass TRUE instead of allow_interruption since we have to check for the
 	 * StopRequested case below.
 	 */
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret = WaitForSingleObjectEx (mon->entry_sem, waitms, TRUE);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	mono_thread_clr_state (thread, ThreadState_WaitSleepJoin);
 	
@@ -1279,9 +1279,9 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 	 * is private to this thread.  Therefore even if the event was
 	 * signalled before we wait, we still succeed.
 	 */
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret = WaitForSingleObjectEx (event, ms, TRUE);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	/* Reset the thread state fairly early, so we don't have to worry
 	 * about the monitor error checking
@@ -1304,9 +1304,9 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 		/* Poll the event again, just in case it was signalled
 		 * while we were trying to regain the monitor lock
 		 */
-		MONO_PREPARE_BLOCKING;
+		MONO_ENTER_GC_SAFE;
 		ret = WaitForSingleObjectEx (event, 0, FALSE);
-		MONO_FINISH_BLOCKING;
+		MONO_EXIT_GC_SAFE;
 	}
 
 	/* Pulse will have popped our event from the queue if it signalled

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2892,11 +2892,11 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 	if (mono_profiler_get_events () & MONO_PROFILE_METHOD_EVENTS)
 		mono_profiler_method_start_invoke (method);
 
-	MONO_PREPARE_RESET_BLOCKING;
+	MONO_ENTER_GC_UNSAFE;
 
 	result = callbacks.runtime_invoke (method, obj, params, exc, error);
 
-	MONO_FINISH_RESET_BLOCKING;
+	MONO_EXIT_GC_UNSAFE;
 
 	if (mono_profiler_get_events () & MONO_PROFILE_METHOD_EVENTS)
 		mono_profiler_method_end_invoke (method);
@@ -3117,10 +3117,10 @@ mono_method_get_unmanaged_thunk (MonoMethod *method)
 
 	g_assert (!mono_threads_is_coop_enabled ());
 
-	MONO_PREPARE_RESET_BLOCKING;
+	MONO_ENTER_GC_UNSAFE;
 	method = mono_marshal_get_thunk_invoke_wrapper (method);
 	res = mono_compile_method (method);
-	MONO_FINISH_RESET_BLOCKING;
+	MONO_EXIT_GC_UNSAFE;
 
 	return res;
 }

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -294,9 +294,9 @@ mono_reflection_init (void)
 static inline void
 dynamic_image_lock (MonoDynamicImage *image)
 {
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	mono_image_lock ((MonoImage*)image);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 }
 
 static inline void

--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -1401,9 +1401,9 @@ mono_threadpool_ms_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, Mono
 			MONO_OBJECT_SETREF (ares, handle, (MonoObject*) wait_handle);
 		}
 		mono_monitor_exit ((MonoObject*) ares);
-		MONO_PREPARE_BLOCKING;
+		MONO_ENTER_GC_SAFE;
 		WaitForSingleObjectEx (wait_event, INFINITE, TRUE);
-		MONO_FINISH_BLOCKING;
+		MONO_EXIT_GC_SAFE;
 	}
 
 	ac = (MonoAsyncCall*) ares->object_data;
@@ -1461,9 +1461,9 @@ mono_threadpool_ms_remove_domain_jobs (MonoDomain *domain, int timeout)
 			}
 		}
 
-		MONO_PREPARE_BLOCKING;
+		MONO_ENTER_GC_SAFE;
 		WaitForSingleObject (sem, timeout != -1 ? end - now : timeout);
-		MONO_FINISH_BLOCKING;
+		MONO_EXIT_GC_SAFE;
 	}
 
 	domain->cleanup_semaphore = NULL;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -882,9 +882,9 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, StartInfo *star
 		 */
 		THREAD_DEBUG (g_message ("%s: (%"G_GSIZE_FORMAT") waiting for thread %p (%"G_GSIZE_FORMAT") to start", __func__, mono_native_thread_id_get (), internal, (gsize)internal->tid));
 
-		MONO_PREPARE_BLOCKING;
+		MONO_ENTER_GC_SAFE;
 		WaitForSingleObjectEx (internal->start_notify, INFINITE, FALSE);
-		MONO_FINISH_BLOCKING;
+		MONO_EXIT_GC_SAFE;
 
 		CloseHandle (internal->start_notify);
 		internal->start_notify = NULL;
@@ -1560,9 +1560,9 @@ ves_icall_System_Threading_Thread_Join_internal(MonoThread *this_obj, int ms)
 	
 	mono_thread_set_state (cur_thread, ThreadState_WaitSleepJoin);
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret=WaitForSingleObjectEx (handle, ms, TRUE);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	mono_thread_clr_state (cur_thread, ThreadState_WaitSleepJoin);
 	
@@ -1588,12 +1588,12 @@ mono_wait_uninterrupted (MonoInternalThread *thread, gboolean multiple, guint32 
 
 	start = (ms == -1) ? 0 : mono_100ns_ticks ();
 	do {
-		MONO_PREPARE_BLOCKING;
+		MONO_ENTER_GC_SAFE;
 			if (multiple)
 			ret = WaitForMultipleObjectsEx (numhandles, handles, waitall, wait, alertable);
 		else
 			ret = WaitForSingleObjectEx (handles [0], ms, alertable);
-		MONO_FINISH_BLOCKING;
+		MONO_EXIT_GC_SAFE;
 
 		if (ret != WAIT_IO_COMPLETION)
 			break;
@@ -1738,9 +1738,9 @@ ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (HANDLE toSignal, H
 
 	mono_thread_set_state (thread, ThreadState_WaitSleepJoin);
 	
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret = SignalObjectAndWait (toSignal, toWait, ms, TRUE);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	
 	mono_thread_clr_state (thread, ThreadState_WaitSleepJoin);
 
@@ -2909,9 +2909,9 @@ static void wait_for_tids (struct wait_data *wait, guint32 timeout)
 	
 	THREAD_DEBUG (g_message("%s: %d threads to wait for in this batch", __func__, wait->num));
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret=WaitForMultipleObjectsEx(wait->num, wait->handles, TRUE, timeout, TRUE);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if(ret==WAIT_FAILED) {
 		/* See the comment in build_wait_tids() */
@@ -2972,9 +2972,9 @@ static void wait_for_tids_or_state_change (struct wait_data *wait, guint32 timeo
 		count++;
 	}
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret=WaitForMultipleObjectsEx (count, wait->handles, FALSE, timeout, TRUE);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if(ret==WAIT_FAILED) {
 		/* See the comment in build_wait_tids() */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -956,11 +956,11 @@ mono_jit_thread_attach (MonoDomain *domain, gpointer *dummy)
 			*dummy = NULL;
 			/* mono_thread_attach put the thread in RUNNING mode from STARTING, but we need to
 			 * return the right cookie. */
-			return mono_threads_cookie_for_reset_blocking_start (mono_thread_info_current ());
+			return mono_threads_enter_gc_unsafe_region_cookie (mono_thread_info_current ());
 		} else {
 			*dummy = orig;
 			/* thread state (BLOCKING|RUNNING) -> RUNNING */
-			return mono_threads_reset_blocking_start (dummy);
+			return mono_threads_enter_gc_unsafe_region (dummy);
 		}
 	}
 }
@@ -994,7 +994,7 @@ mono_jit_thread_detach (gpointer cookie, gpointer *dummy)
 
 		/* it won't do anything if cookie is NULL
 		 * thread state RUNNING -> (RUNNING|BLOCKING) */
-		mono_threads_reset_blocking_end (cookie, dummy);
+		mono_threads_exit_gc_unsafe_region (cookie, dummy);
 
 		if (orig != domain) {
 			if (!orig)

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -814,7 +814,7 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 {
 	gpointer res;
 
-	MONO_PREPARE_RESET_BLOCKING_UNBALANCED;
+	MONO_ENTER_GC_UNSAFE_UNBALANCED;
 
 	MonoError error;
 
@@ -825,7 +825,7 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 
 	mono_interruption_checkpoint_from_trampoline ();
 
-	MONO_FINISH_RESET_BLOCKING_UNBALANCED;
+	MONO_EXIT_GC_UNSAFE_UNBALANCED;
 
 	return res;
 }

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3133,7 +3133,7 @@ mono_insert_safepoints (MonoCompile *cfg)
 
 		if (info && info->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER &&
 			(info->d.icall.func == mono_thread_interruption_checkpoint ||
-			info->d.icall.func == mono_threads_finish_blocking_unbalanced)) {
+			info->d.icall.func == mono_threads_exit_gc_safe_region_unbalanced)) {
 			/* These wrappers are called from the wrapper for the polling function, leading to potential stack overflow */
 			if (cfg->verbose_level > 1)
 				printf ("SKIPPING SAFEPOINTS for wrapper %s\n", cfg->method->name);

--- a/mono/utils/mono-coop-mutex.h
+++ b/mono/utils/mono-coop-mutex.h
@@ -50,11 +50,11 @@ mono_coop_mutex_lock (MonoCoopMutex *mutex)
 	if (mono_os_mutex_trylock (&mutex->m) == 0)
 		return 0;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	res = mono_os_mutex_lock (&mutex->m);
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return res;
 }
@@ -88,11 +88,11 @@ mono_coop_cond_wait (MonoCoopCond *cond, MonoCoopMutex *mutex)
 {
 	gint res;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	res = mono_os_cond_wait (&cond->c, &mutex->m);
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return res;
 }
@@ -102,11 +102,11 @@ mono_coop_cond_timedwait (MonoCoopCond *cond, MonoCoopMutex *mutex, guint32 time
 {
 	gint res;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	res = mono_os_cond_timedwait (&cond->c, &mutex->m, timeout_ms);
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return res;
 }

--- a/mono/utils/mono-coop-semaphore.h
+++ b/mono/utils/mono-coop-semaphore.h
@@ -35,11 +35,11 @@ mono_coop_sem_wait (MonoCoopSem *sem, MonoSemFlags flags)
 {
 	gint res;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	res = mono_os_sem_wait (&sem->s, flags);
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return res;
 }
@@ -49,11 +49,11 @@ mono_coop_sem_timedwait (MonoCoopSem *sem, guint timeout_ms, MonoSemFlags flags)
 {
 	gint res;
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	res = mono_os_sem_timedwait (&sem->s, timeout_ms, flags);
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return res;
 }

--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -44,24 +44,23 @@ This will put the current thread in GC Unsafe mode.
 
 For further explanation of what can and can't be done in GC unsafe mode:
 http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-mode
-
 */
-#define MONO_BEGIN_GC_UNSAFE	\
+#define MONO_ENTER_GC_UNSAFE	\
 	do {	\
-		gpointer __dummy;	\
-		gpointer __gc_unsafe_cookie = mono_threads_enter_gc_unsafe_region (&__dummy)	\
+		gpointer __gc_unsafe_dummy;	\
+		gpointer __gc_unsafe_cookie = mono_threads_enter_gc_unsafe_region (&__gc_unsafe_dummy)	\
 
-#define MONO_END_GC_UNSAFE	\
-		mono_threads_exit_gc_unsafe_region	(__gc_unsafe_cookie, &__dummy);	\
+#define MONO_EXIT_GC_UNSAFE	\
+		mono_threads_exit_gc_unsafe_region	(__gc_unsafe_cookie, &__gc_unsafe_dummy);	\
 	} while (0)
 
-#define MONO_BEGIN_GC_SAFE	\
+#define MONO_ENTER_GC_SAFE	\
 	do {	\
-		gpointer __dummy;	\
-		gpointer __gc_safe_cookie = mono_threads_enter_gc_safe_region (&__dummy)	\
+		gpointer __gc_safe_dummy;	\
+		gpointer __gc_safe_cookie = mono_threads_enter_gc_safe_region (&__gc_safe_dummy)	\
 
-#define MONO_END_GC_SAFE	\
-		mono_threads_exit_gc_safe_region (__gc_safe_cookie, &__dummy);	\
+#define MONO_EXIT_GC_SAFE	\
+		mono_threads_exit_gc_safe_region (__gc_safe_cookie, &__gc_safe_dummy);	\
 	} while (0)
 
 MONO_END_DECLS

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1193,7 +1193,7 @@ mono_thread_info_sleep (guint32 ms, gboolean *alerted)
 	if (alerted)
 		return sleep_interruptable (ms, alerted);
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 
 	if (ms == INFINITE) {
 		do {
@@ -1238,7 +1238,7 @@ mono_thread_info_sleep (guint32 ms, gboolean *alerted)
 #endif /* __linux__ */
 	}
 
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	return 0;
 }
@@ -1246,9 +1246,9 @@ mono_thread_info_sleep (guint32 ms, gboolean *alerted)
 gint
 mono_thread_info_usleep (guint64 us)
 {
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	g_usleep (us);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 	return 0;
 }
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -608,7 +608,7 @@ MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE
 MonoThreadUnwindState* mono_thread_info_get_suspend_state (THREAD_INFO_TYPE *info);
 
 gpointer
-mono_threads_cookie_for_reset_blocking_start (THREAD_INFO_TYPE *info);
+mono_threads_enter_gc_unsafe_region_cookie (THREAD_INFO_TYPE *info);
 
 
 void mono_thread_info_wait_for_resume (THREAD_INFO_TYPE *info);

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -73,9 +73,9 @@ mono_get_address_info (const char *hostname, int port, int flags, MonoAddressInf
 #endif
 	sprintf (service_name, "%d", port);
 
-	MONO_PREPARE_BLOCKING;
+	MONO_ENTER_GC_SAFE;
 	ret = getaddrinfo (hostname, service_name, &hints, &info);
-	MONO_FINISH_BLOCKING;
+	MONO_EXIT_GC_SAFE;
 
 	if (ret)
 		return 1; /* FIXME propagate the error */


### PR DESCRIPTION
This allow the removal of MONO_(PREPARE|FINISH)_BLOCKING and MONO_(PREPARE|FINISH)_RESET_BLOCKING, which were not explicit in their intent, leading to confusion. This also harmonize how the product and the runtime transition between thread states.

cc @kumpera @lambdageek @vargaz