### PR TITLE
Various GC bridge cleanup from looking at bug #40844

### DIFF
--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -375,6 +375,8 @@ sgen_bridge_processing_finish (int generation)
 	if (compare_bridge_processors ())
 		compare_to_bridge_processor.processing_after_callback (generation);
 
+	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_BRIDGE: Complete, was running for %.2fms", mono_time_since_last_stw () / 10000.0f);
+
 	bridge_processing_in_progress = FALSE;
 }
 

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -74,7 +74,7 @@ void
 sgen_set_bridge_implementation (const char *name)
 {
 	if (!init_bridge_processor (&bridge_processor, name))
-		g_warning ("Invalid value for bridge implementation, valid values are: 'new' and 'old'.");
+		g_warning ("Invalid value for bridge implementation, valid values are: 'new', 'old' and 'tarjan'.");
 }
 
 gboolean

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -727,6 +727,8 @@ extern MonoNativeTlsKey thread_info_key;
 #define SGEN_TV_GETTIME(tv) tv = mono_100ns_ticks ()
 #define SGEN_TV_ELAPSED(start,end) ((gint64)(end-start))
 
+guint64 mono_time_since_last_stw (void);
+
 typedef MonoSemType SgenSemaphore;
 
 #define SGEN_SEMAPHORE_INIT(sem,initial)	mono_os_sem_init ((sem), (initial))

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2726,7 +2726,7 @@ sgen_client_log_timing (GGTimingInfo *info, mword last_major_num_sections, mword
 	full_timing_buff [0] = '\0';
 
 	if (!info->is_overflow)
-	        sprintf (full_timing_buff, "total %.2fms, bridge %.2fms", info->stw_time / 10000.0f, (int)info->bridge_time / 10000.0f);
+	        sprintf (full_timing_buff, "total %.2fms", info->stw_time / 10000.0f);
 	if (info->generation == GENERATION_OLD)
 	        mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) pause %.2fms, %s los %dK/%dK",
 	                info->is_overflow ? "_OVERFLOW" : "",

--- a/mono/metadata/sgen-new-bridge.c
+++ b/mono/metadata/sgen-new-bridge.c
@@ -65,9 +65,11 @@ typedef struct {
 
 
 /*
+ * Bridge data for a single managed object
+ *
  * FIXME: Optimizations:
  *
- * Don't allocate a scrs array for just one source.  Most objects have
+ * Don't allocate a srcs array for just one source.  Most objects have
  * just one source, so use the srcs pointer itself.
  */
 typedef struct _HashEntry {
@@ -80,10 +82,12 @@ typedef struct _HashEntry {
 			struct _HashEntry *forwarded_to;
 		} dfs1;
 		struct {
+			// Index in sccs array of SCC this object was folded into
 			int scc_index;
 		} dfs2;
 	} v;
 
+	// "Source" managed objects pointing at this destination
 	DynPtrArray srcs;
 } HashEntry;
 
@@ -92,12 +96,19 @@ typedef struct {
 	double weight;
 } HashEntryWithAccounting;
 
+// The graph of managed objects/HashEntries is reduced to a graph of strongly connected components
 typedef struct _SCC {
 	int index;
 	int api_index;
+
+	// How many bridged objects does this SCC hold references to?
 	int num_bridge_entries;
+
 	gboolean flag;
+
 	/*
+	 * Index in global sccs array of SCCs holding pointers to this SCC
+	 *
 	 * New and old xrefs are typically mutually exclusive.  Only when TEST_NEW_XREFS is
 	 * enabled we do both, and compare the results.  This should only be done for
 	 * debugging, obviously.
@@ -110,6 +121,7 @@ typedef struct _SCC {
 #endif
 } SCC;
 
+// Maps managed objects to corresponding HashEntry stricts
 static SgenHashTable hash_table = SGEN_HASH_TABLE_INIT (INTERNAL_MEM_BRIDGE_HASH_TABLE, INTERNAL_MEM_BRIDGE_HASH_TABLE_ENTRY, sizeof (HashEntry), mono_aligned_addr_hash, NULL);
 
 static guint32 current_time;

--- a/mono/metadata/sgen-old-bridge.c
+++ b/mono/metadata/sgen-old-bridge.c
@@ -41,11 +41,12 @@ typedef struct {
 	DynArray array;
 } DynSCCArray;
 
-
 /*
+ * Bridge data for a single managed object
+ *
  * FIXME: Optimizations:
  *
- * Don't allocate a scrs array for just one source.  Most objects have
+ * Don't allocate a srcs array for just one source.  Most objects have
  * just one source, so use the srcs pointer itself.
  */
 typedef struct _HashEntry {
@@ -56,8 +57,10 @@ typedef struct _HashEntry {
 
 	int finishing_time;
 
+	// "Source" managed objects pointing at this destination
 	DynPtrArray srcs;
 
+	// Index in sccs array of SCC this object was folded into
 	int scc_index;
 } HashEntry;
 
@@ -66,13 +69,19 @@ typedef struct {
 	double weight;
 } HashEntryWithAccounting;
 
+// The graph of managed objects/HashEntries is reduced to a graph of strongly connected components
 typedef struct _SCC {
 	int index;
 	int api_index;
+
+	// How many bridged objects does this SCC hold references to?
 	int num_bridge_entries;
+
+	// Index in global sccs array of SCCs holding pointers to this SCC
 	DynIntArray xrefs;		/* these are incoming, not outgoing */
 } SCC;
 
+// Maps managed objects to corresponding HashEntry stricts
 static SgenHashTable hash_table = SGEN_HASH_TABLE_INIT (INTERNAL_MEM_OLD_BRIDGE_HASH_TABLE, INTERNAL_MEM_OLD_BRIDGE_HASH_TABLE_ENTRY, sizeof (HashEntry), mono_aligned_addr_hash, NULL);
 
 static int current_time;

--- a/mono/metadata/sgen-tarjan-bridge.c
+++ b/mono/metadata/sgen-tarjan-bridge.c
@@ -924,11 +924,6 @@ processing_stw_step (void)
 #if defined (DUMP_GRAPH)
 	printf ("-----------------\n");
 #endif
-	/*
-	 * bridge_processing_in_progress must be set with the world
-	 * stopped.  If not there would be race conditions.
-	 */
-	bridge_processing_in_progress = TRUE;
 
 	SGEN_TV_GETTIME (curtime);
 
@@ -1134,7 +1129,6 @@ processing_after_callback (int generation)
 
 	cache_hits = cache_misses = 0;
 	ignored_objects = 0;
-	bridge_processing_in_progress = FALSE;
 }
 
 static void

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -817,7 +817,6 @@ typedef struct {
 	gboolean is_overflow;
 	gint64 total_time;
 	gint64 stw_time;
-	gint64 bridge_time;
 } GGTimingInfo;
 
 void sgen_stop_world (int generation);


### PR DESCRIPTION
While debugging bug #40844 I did some dead code and comment cleanup. Most notably, I removed a trace printing bridge processing time time which always printed 0, and replaced it with one which reports accurately.

Commits:
*	More accurate trace reporting duration of android gc bridge
*	Remove redundant flag set in sgen-tarjan-bridge
*	Fix error message in sgen-bridge which does not list all options
*	Add some comments in new/old gc bridges