### PR TITLE
[System] Get rid of useless catch-all clauses in SocketTest

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -573,8 +573,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.DontFragment = true;
 				Assert.Fail ("DontFragment #1");
 			} catch (NotSupportedException) {
-			} catch {
-				Assert.Fail ("DontFragment #2");
 			} finally {
 				sock.Close ();
 			}
@@ -592,8 +590,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("EnableBroadcastDefaultTcp #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10042, ex.ErrorCode, "EnableBroadcastDefaultTcp #2");
-			} catch {
-				Assert.Fail ("EnableBroadcastDefaultTcp #2");
 			} finally {
 				sock.Close ();
 			}
@@ -623,8 +619,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("EnableBroadcastChangeTcp #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10042, ex.ErrorCode, "EnableBroadcastChangeTcp #2");
-			} catch {
-				Assert.Fail ("EnableBroadcastChangeTcp #2");
 			} finally {
 				sock.Close ();
 			}
@@ -793,8 +787,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("MulticastLoopbackDefaultTcp #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10042, ex.ErrorCode, "MulticastLoopbackDefaultTcp #2");
-			} catch {
-				Assert.Fail ("MulticastLoopbackDefaultTcp #2");
 			} finally {
 				sock.Close ();
 			}
@@ -812,8 +804,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("MulticastLoopbackChangeTcp #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10042, ex.ErrorCode, "MulticastLoopbackChangeTcp #2");
-			} catch {
-				Assert.Fail ("MulticastLoopbackChangeTcp #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1010,8 +1000,6 @@ namespace MonoTests.System.Net.Sockets
 			} catch (SocketException ex) {
 				Assert.AreEqual (10022, ex.ErrorCode,
 						 "TtlChangeOverflow #2");
-			} catch {
-				Assert.Fail ("TtlChangeoverflow #3");
 			} finally {
 				sock.Close ();
 			}
@@ -1024,8 +1012,6 @@ namespace MonoTests.System.Net.Sockets
 			} catch (SocketException ex) {
 				Assert.AreEqual (10022, ex.ErrorCode,
 						 "TtlChangeOverflow #5");
-			} catch {
-				Assert.Fail ("TtlChangeOverflow #6");
 			} finally {
 				sock.Close ();
 			}
@@ -1139,8 +1125,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.SendTimeout = -2;
 				Assert.Fail ("SendTimeoutChange #8");
 			} catch (ArgumentOutOfRangeException) {
-			} catch {
-				Assert.Fail ("SendTimeoutChange #9");
 			} finally {
 				sock.Close ();
 			}
@@ -1198,8 +1182,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.ReceiveTimeout = -2;
 				Assert.Fail ("ReceiveTimeoutChange #8");
 			} catch (ArgumentOutOfRangeException) {
-			} catch {
-				Assert.Fail ("ReceiveTimeoutChange #9");
 			} finally {
 				sock.Close ();
 			}
@@ -1257,8 +1239,6 @@ namespace MonoTests.System.Net.Sockets
 			} catch (SocketException ex) {
 				Assert.AreEqual (10042, ex.ErrorCode,
 						 "NoDelayDefaultUdp #2");
-			} catch {
-				Assert.Fail ("NoDelayDefaultUdp #3");
 			} finally {
 				sock.Close ();
 			}
@@ -1277,8 +1257,6 @@ namespace MonoTests.System.Net.Sockets
 			} catch (SocketException ex) {
 				Assert.AreEqual (10042, ex.ErrorCode,
 						 "NoDelayChangeUdp #2");
-			} catch {
-				Assert.Fail ("NoDelayChangeUdp #3");
 			} finally {
 				sock.Close ();
 			}
@@ -1491,8 +1469,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("BeginAcceptSocketUdp #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10022, ex.ErrorCode, "BeginAcceptSocketUdp #2");
-			} catch {
-				Assert.Fail ("BeginAcceptSocketUdp #3");
 			} finally {
 				acc.Close ();
 				sock.Close ();
@@ -1524,8 +1500,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.BeginAccept (acc, 256, BADCallback, sock);
 				Assert.Fail ("BeginAcceptSocketBound #1");
 			} catch (InvalidOperationException) {
-			} catch {
-				Assert.Fail ("BeginAcceptSocketBound #2");
 			} finally {
 				acc.Close ();
 				sock.Close ();
@@ -1608,8 +1582,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.BeginAccept (acc, 256, BADCallback, null);
 				Assert.Fail ("BeginAcceptSocketClosed #1");
 			} catch (ObjectDisposedException) {
-			} catch {
-				Assert.Fail ("BeginAcceptSocketClosed #2");
 			} finally {
 				acc.Close ();
 			}
@@ -1638,8 +1610,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.BeginAccept (acc, 256, BADCallback, null);
 				Assert.Fail ("BeginAcceptSocketAccClosed #1");
 			} catch (ObjectDisposedException) {
-			} catch {
-				Assert.Fail ("BeginAcceptSocketAccClosed #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1710,8 +1680,6 @@ namespace MonoTests.System.Net.Sockets
 						   sock);
 				Assert.Fail ("BeginConnectAddressPortNull #1");
 			} catch (ArgumentNullException) {
-			} catch {
-				Assert.Fail ("BeginConnectAddressPortNull #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1733,8 +1701,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.BeginConnect (ip, ep.Port, BCCallback, sock);
 				Assert.Fail ("BeginConnectAddressPortListen #1");
 			} catch (InvalidOperationException) {
-			} catch {
-				Assert.Fail ("BeginConnectAddressPortListen #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1880,8 +1846,6 @@ namespace MonoTests.System.Net.Sockets
 						   sock);
 				Assert.Fail ("BeginConnectMultipleNull #1");
 			} catch (ArgumentNullException) {
-			} catch {
-				Assert.Fail ("BeginConnectMultipleNull #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1910,8 +1874,6 @@ namespace MonoTests.System.Net.Sockets
 						   sock);
 				Assert.Fail ("BeginConnectMultipleListen #1");
 			} catch (InvalidOperationException) {
-			} catch {
-				Assert.Fail ("BeginConnectMultipleListen #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1948,8 +1910,6 @@ namespace MonoTests.System.Net.Sockets
 						   BCCallback, sock);
 				Assert.Fail ("BeginConnectHostPort #1");
 			} catch (ArgumentNullException) {
-			} catch {
-				Assert.Fail ("BeginConnectHostPort #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1972,8 +1932,6 @@ namespace MonoTests.System.Net.Sockets
 						   BCCallback, sock);
 				Assert.Fail ("BeginConnectHostPortListen #1");
 			} catch (InvalidOperationException) {
-			} catch {
-				Assert.Fail ("BeginConnectHostPortListen #2");
 			} finally {
 				sock.Close ();
 			}
@@ -1992,8 +1950,6 @@ namespace MonoTests.System.Net.Sockets
 						   sock);
 				Assert.Fail ("BeginConnectHostPortNotIP #1");
 			} catch (NotSupportedException) {
-			} catch {
-				Assert.Fail ("BeginConnectHostPortNotIP #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2102,8 +2058,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("BeginSendNotConnected #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10057, ex.ErrorCode, "BeginSendNotConnected #2");
-			} catch {
-				Assert.Fail ("BeginSendNotConnected #3");
 			} finally {
 				sock.Close ();
 			}
@@ -2142,8 +2096,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("BindTwice #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10022, ex.ErrorCode, "BindTwice #2");
-			} catch {
-				Assert.Fail ("BindTwice #3");
 			} finally {
 				sock.Close ();
 			}
@@ -2212,8 +2164,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.Connect (ip, 1249);
 				Assert.Fail ("ConnectAddressPortNull #1");
 			} catch (ArgumentNullException) {
-			} catch {
-				Assert.Fail ("ConnectAddressPortNull #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2235,8 +2185,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.Connect (ip, ep.Port);
 				Assert.Fail ("ConnectAddressPortListen #1");
 			} catch (InvalidOperationException) {
-			} catch {
-				Assert.Fail ("ConnectAddressPortListen #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2359,8 +2307,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.Connect (ips, 1251);
 				Assert.Fail ("ConnectMultipleNull #1");
 			} catch (ArgumentNullException) {
-			} catch {
-				Assert.Fail ("ConnectMultipleNull #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2388,8 +2334,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.Connect (ips, ep.Port);
 				Assert.Fail ("ConnectMultipleListen #1");
 			} catch (InvalidOperationException) {
-			} catch {
-				Assert.Fail ("ConnectMultipleListen #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2425,8 +2369,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.Connect ((string)null, 0);
 				Assert.Fail ("ConnectHostPort #1");
 			} catch (ArgumentNullException) {
-			} catch {
-				Assert.Fail ("ConnectHostPort #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2448,8 +2390,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.Connect ("localhost", ep.Port);
 				Assert.Fail ("ConnectHostPortListen #1");
 			} catch (InvalidOperationException) {
-			} catch {
-				Assert.Fail ("ConnectHostPortListen #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2467,8 +2407,6 @@ namespace MonoTests.System.Net.Sockets
 				sock.Connect ("localhost", 0);
 				Assert.Fail ("ConnectHostPortNotIP #1");
 			} catch (NotSupportedException) {
-			} catch {
-				Assert.Fail ("ConnectHostPortNotIP #2");
 			} finally {
 				sock.Close ();
 			}
@@ -2672,8 +2610,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.Fail ("ListenNotBound #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10022, ex.ErrorCode, "ListenNotBound #2");
-			} catch {
-				Assert.Fail ("ListenNotBound #3");
 			} finally {
 				sock.Close ();
 			}


### PR DESCRIPTION
When one of the tests doesn't fail with the expected exception, we'd get just a useless message
like `TtlChangeoverflow #3` instead of the much more useful exception info + stacktrace that
NUnit catches when an unhandled exception is thrown.