### PR TITLE
[System] Throw PlatformNotSupportedException if NetworkInformation.NetworkChange is used on watchOS.

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
@@ -101,6 +101,9 @@ namespace System.Net.NetworkInformation {
 
 		static void MaybeCreate ()
 		{
+#if MONOTOUCH_WATCH
+			throw new PlatformNotSupportedException ("NetworkInformation.NetworkChange is not supported on the current platform.");
+#else
 			if (networkChange != null)
 				return;
 
@@ -111,6 +114,7 @@ namespace System.Net.NetworkInformation {
 				networkChange = new LinuxNetworkChange ();
 #endif
 			}
+#endif // MONOTOUCH_WATCH
 		}
 
 		static void MaybeDispose ()
@@ -122,6 +126,7 @@ namespace System.Net.NetworkInformation {
 		}
 	}
 
+#if !MONOTOUCH_WATCH
 	internal sealed class MacNetworkChange : INetworkChange
 	{
 		const string DL_LIB = "/usr/lib/libSystem.dylib";
@@ -317,6 +322,7 @@ namespace System.Net.NetworkInformation {
 				availabilityChanged (null, new NetworkAvailabilityEventArgs (instance.IsAvailable));
 		}
 	}
+#endif // !MONOTOUCH_WATCH
 
 #if !NETWORK_CHANGE_STANDALONE && !MONOTOUCH
 


### PR DESCRIPTION
NetworkInformation.NetworkChange requires the SystemConfiguration framework,
which isn't available on watchOS.