### PR TITLE
[coop] Make mono_threads_is_coop_enabled a normal function

### DIFF
--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -377,6 +377,20 @@ mono_threads_assert_gc_unsafe_region (void)
 	MONO_REQ_GC_UNSAFE_MODE;
 }
 
+gboolean
+mono_threads_is_coop_enabled (void)
+{
+#if defined(USE_COOP_GC)
+	return TRUE;
+#else
+	static int is_coop_enabled = -1;
+	if (G_UNLIKELY (is_coop_enabled == -1))
+		is_coop_enabled = g_getenv ("MONO_ENABLE_COOP") != NULL ? 1 : 0;
+	return is_coop_enabled == 1;
+#endif
+}
+
+
 void
 mono_threads_init_coop (void)
 {

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -23,18 +23,8 @@ extern volatile size_t mono_polling_required;
 
 /* Runtime consumable API */
 
-static gboolean G_GNUC_UNUSED
-mono_threads_is_coop_enabled (void)
-{
-#if defined(USE_COOP_GC)
-	return TRUE;
-#else
-	static gboolean is_coop_enabled = -1;
-	if (G_UNLIKELY (is_coop_enabled == -1))
-		is_coop_enabled = g_getenv ("MONO_ENABLE_COOP") != NULL ? TRUE : FALSE;
-	return is_coop_enabled;
-#endif
-}
+gboolean
+mono_threads_is_coop_enabled (void);
 
 /* Internal API */
 


### PR DESCRIPTION
It doesn't need to live in the header.

In particular is_coop_enabled variable used to be in every translation
unit instead of just a single flag.