### PR TITLE
[System.Drawing] Disable failing PngCodec 2bpp tests on ARM64

### DIFF
--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/PngCodecTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/PngCodecTest.cs
@@ -71,6 +71,27 @@ namespace MonoTests.System.Drawing.Imaging {
 			return sRslt;
 		}
 
+		private bool IsArm64Process ()
+		{
+			if (Environment.OSVersion.Platform != PlatformID.Unix || !Environment.Is64BitProcess)
+				return false;
+
+			try {
+				var process = new global::System.Diagnostics.Process ();
+				process.StartInfo.FileName = "uname";
+				process.StartInfo.Arguments = "-m";
+				process.StartInfo.RedirectStandardOutput = true;
+				process.StartInfo.UseShellExecute = false;
+				process.Start ();
+				process.WaitForExit ();
+				var output = process.StandardOutput.ReadToEnd ();
+
+				return output.Trim () == "aarch64";
+			} catch {
+				return false;
+			}
+		}
+
 		/* Checks bitmap features on a known 1bbp bitmap */
 		[Test]
 		public void Bitmap1bitFeatures ()
@@ -290,6 +311,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Bitmap2bitFeatures ()
 		{
+			if (IsArm64Process ())
+				Assert.Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=41171");
+
 			string sInFile = getInFile ("bitmaps/81674-2bpp.png");
 			using (Bitmap bmp = new Bitmap (sInFile)) {
 				GraphicsUnit unit = GraphicsUnit.World;
@@ -318,6 +342,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Bitmap2bitPixels ()
 		{
+			if (IsArm64Process ())
+				Assert.Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=41171");
+
 			string sInFile = getInFile ("bitmaps/81674-2bpp.png");
 			using (Bitmap bmp = new Bitmap (sInFile)) {
 #if false
@@ -350,6 +377,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Bitmap2bitData ()
 		{
+			if (IsArm64Process ())
+				Assert.Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=41171");
+
 			string sInFile = getInFile ("bitmaps/81674-2bpp.png");
 			using (Bitmap bmp = new Bitmap (sInFile)) {
 				BitmapData data = bmp.LockBits (new Rectangle (0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);


### PR DESCRIPTION
They fail on the new Jenkins ARM64 bots, disable them until we figure out the cause.
It looks like a libgdiplus issue to me which makes deploying a fixed version a bit more difficult.

Filed https://bugzilla.xamarin.com/show_bug.cgi?id=41171 to track.