### PR TITLE
[System] Raise ArgumentOutOfRangeException for values > 255 in Socket.Ttl setter

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -702,8 +702,8 @@ namespace System.Net.Sockets
 			set {
 				ThrowIfDisposedAndClosed ();
 
-				if (value < 0)
-					throw new ArgumentOutOfRangeException ("value", "The value specified for a set operation is less than zero");
+				if (value < 0 || value > 255)
+					throw new ArgumentOutOfRangeException ("value", "The value specified for a set operation is less than zero or greater than 255.");
 
 				switch (address_family) {
 				case AddressFamily.InterNetwork:

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -987,7 +987,6 @@ namespace MonoTests.System.Net.Sockets
 		}
 
 		[Test]
-		[Category ("NotOnMac")] // Mac doesn't throw when overflowing the ttl
 		public void TtlChangeOverflow ()
 		{
 			Socket sock = new Socket (AddressFamily.InterNetwork,
@@ -997,8 +996,8 @@ namespace MonoTests.System.Net.Sockets
 			try {
 				sock.Ttl = 256;
 				Assert.Fail ("TtlChangeOverflow #1");
-			} catch (SocketException ex) {
-				Assert.AreEqual (10022, ex.ErrorCode,
+			} catch (ArgumentOutOfRangeException ex) {
+				Assert.AreEqual ("value", ex.ParamName,
 						 "TtlChangeOverflow #2");
 			} finally {
 				sock.Close ();


### PR DESCRIPTION
This is consistent with the .NET implementation: https://github.com/mono/mono/blob/8054793e5bc158015154fb8cdcdd56777a0c8351/mcs/class/referencesource/System/net/System/Net/Sockets/Socket.cs#L734-L737 (sadly, MSDN says SocketException should be thrown in this case...).

It fixes the SocketTest.TtlChangeoverflow test that started failing after https://github.com/mono/mono/pull/2250.
The reason is we refactored the SetSocketOption () overload the Ttl setter is using so that it now
checks for `error == (int) SocketError.InvalidArgument` instead of just falling through to raising
a SocketException with the error code.