### PR TITLE
[mini] Propagate MonoError in mini_get_signature

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -8681,12 +8681,14 @@ mono_marshal_get_castclass_with_cache (void)
 	return cached;
 }
 
+/* this is an icall */
 static MonoObject *
 mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache)
 {
 	MonoError error;
 	MonoObject *isinst = mono_object_isinst_checked (obj, klass, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 
 #ifndef DISABLE_REMOTING
 	if (obj->vtable->klass == mono_defaults.transparent_proxy_class)

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -735,6 +735,10 @@ mono_metadata_parse_mh_full                 (MonoImage             *image,
 					     const char            *ptr,
 						 MonoError *error);
 
+MonoMethodSignature  *mono_metadata_parse_signature_checked (MonoImage *image, 
+							     uint32_t    token,
+							     MonoError *error);
+
 gboolean
 mono_method_get_header_summary (MonoMethod *method, MonoMethodHeaderSummary *summary);
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1822,7 +1822,7 @@ mono_metadata_get_param_attrs (MonoImage *m, int def, int param_count)
 /*
  * mono_metadata_parse_signature:
  * @image: metadata context
- * @toke: metadata token
+ * @token: metadata token
  *
  * Decode a method signature stored in the STANDALONESIG table
  *
@@ -1833,15 +1833,34 @@ mono_metadata_parse_signature (MonoImage *image, guint32 token)
 {
 	MonoError error;
 	MonoMethodSignature *ret;
+	ret = mono_metadata_parse_signature_checked (image, token, &error);
+	mono_error_cleanup (&error);
+	return ret;
+}
+
+/*
+ * mono_metadata_parse_signature_checked:
+ * @image: metadata context
+ * @token: metadata token
+ * @error: set on error
+ *
+ * Decode a method signature stored in the STANDALONESIG table
+ *
+ * Returns: a MonoMethodSignature describing the signature. On failure
+ * returns NULL and sets @error.
+ */
+MonoMethodSignature*
+mono_metadata_parse_signature_checked (MonoImage *image, guint32 token, MonoError *error)
+{
+
+	mono_error_init (error);
 	MonoTableInfo *tables = image->tables;
 	guint32 idx = mono_metadata_token_index (token);
 	guint32 sig;
 	const char *ptr;
 
 	if (image_is_dynamic (image)) {
-		ret = (MonoMethodSignature *)mono_lookup_dynamic_token (image, token, NULL, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
-		return ret;
+		return (MonoMethodSignature *)mono_lookup_dynamic_token (image, token, NULL, error);
 	}
 
 	g_assert (mono_metadata_token_table(token) == MONO_TABLE_STANDALONESIG);
@@ -1851,9 +1870,7 @@ mono_metadata_parse_signature (MonoImage *image, guint32 token)
 	ptr = mono_metadata_blob_heap (image, sig);
 	mono_metadata_decode_blob_size (ptr, &ptr);
 
-	ret = mono_metadata_parse_method_signature_full (image, NULL, 0, ptr, NULL, &error);
-	mono_error_cleanup (&error); /*FIXME don't swallow the error message*/
-	return ret;
+	return mono_metadata_parse_method_signature_full (image, NULL, 0, ptr, NULL, error);
 }
 
 /*

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -422,6 +422,7 @@ MONO_API MonoMethodSignature  *mono_metadata_signature_alloc (MonoImage *image, 
 
 MONO_API MonoMethodSignature  *mono_metadata_signature_dup (MonoMethodSignature *sig);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMethodSignature  *mono_metadata_parse_signature (MonoImage *image, 
 						     uint32_t    token);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1139,7 +1139,8 @@ ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThread *this_obj)
 	MonoInternalThread *internal;
 
 	internal = create_internal_thread (&error);
-	mono_error_raise_exception (&error);
+	if (mono_error_set_pending_exception (&error))
+		return;
 
 	internal->state = ThreadState_Unstarted;
 
@@ -1368,7 +1369,8 @@ ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThread *this_obj
 	
 	UNLOCK_THREAD (this_obj);
 
-	mono_error_raise_exception (&error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	
 	return str;
 }


### PR DESCRIPTION
Also mark mono_metadata_parse_signature external only, runtime should
use mono_metadata_parse_signature_checked.

Also switch a few icalls to set pending exception instead of raising.