### PR TITLE
[mini] small improvements around `MONO_IS_CALL` macro and `local-prop`

### DIFF
--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -555,13 +555,13 @@ mono_local_cprop (MonoCompile *cfg)
 					ins->inst_destbasereg = def->sreg1;
 					ins->inst_offset += def->inst_imm;
 				}
+
+				if (!MONO_IS_STORE_MEMBASE (ins) && !vreg_is_volatile (cfg, ins->dreg)) {
+					defs [ins->dreg] = ins;
+					def_index [ins->dreg] = ins_index;
+				}
 			}
 			
-			if ((spec [MONO_INST_DEST] != ' ') && !MONO_IS_STORE_MEMBASE (ins) && !vreg_is_volatile (cfg, ins->dreg)) {
-				defs [ins->dreg] = ins;
-				def_index [ins->dreg] = ins_index;
-			}
-
 			if (MONO_IS_CALL (ins))
 				last_call_index = ins_index;
 

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -42,6 +42,7 @@ MINI_OP(OP_SEQ_POINT, "seq_point", NONE, NONE, NONE)
 MINI_OP(OP_IL_SEQ_POINT, "il_seq_point", NONE, NONE, NONE)
 MINI_OP(OP_IMPLICIT_EXCEPTION, "implicit_exception", NONE, NONE, NONE)
 
+/* CALL opcodes need to stay together, see MONO_IS_CALL macro */
 MINI_OP(OP_VOIDCALL,	"voidcall", NONE, NONE, NONE)
 MINI_OP(OP_VOIDCALL_REG,	"voidcall_reg", NONE, IREG, NONE)
 MINI_OP(OP_VOIDCALL_MEMBASE,	"voidcall_membase", NONE, IREG, NONE)

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -484,7 +484,8 @@ enum {
 #define MONO_IS_STORE_MEMBASE(ins) (((ins)->opcode >= OP_STORE_MEMBASE_REG && (ins)->opcode <= OP_STOREV_MEMBASE) || ((ins)->opcode >= OP_ATOMIC_STORE_I1 && (ins)->opcode <= OP_ATOMIC_STORE_R8))
 #define MONO_IS_STORE_MEMINDEX(ins) (((ins)->opcode >= OP_STORE_MEMINDEX) && ((ins)->opcode <= OP_STORER8_MEMINDEX))
 
-#define MONO_IS_CALL(ins) (((ins->opcode >= OP_VOIDCALL) && (ins->opcode <= OP_VOIDCALL_MEMBASE)) || ((ins->opcode >= OP_FCALL) && (ins->opcode <= OP_FCALL_MEMBASE)) || ((ins->opcode >= OP_LCALL) && (ins->opcode <= OP_LCALL_MEMBASE)) || ((ins->opcode >= OP_VCALL) && (ins->opcode <= OP_VCALL_MEMBASE)) || ((ins->opcode >= OP_CALL) && (ins->opcode <= OP_CALL_MEMBASE)) || ((ins->opcode >= OP_VCALL2) && (ins->opcode <= OP_VCALL2_MEMBASE)) || (ins->opcode == OP_TAILCALL) || ((ins->opcode >= OP_RCALL) && (ins->opcode <= OP_RCALL_MEMBASE)))
+// OP_DYN_CALL is not a MonoCallInst
+#define MONO_IS_CALL(ins) (((ins->opcode >= OP_VOIDCALL) && (ins->opcode <= OP_VCALL2_MEMBASE)) || (ins->opcode == OP_TAILCALL))
 
 #define MONO_IS_JUMP_TABLE(ins) (((ins)->opcode == OP_JUMP_TABLE) ? TRUE : ((((ins)->opcode == OP_AOTCONST) && (ins->inst_i1 == (gpointer)MONO_PATCH_INFO_SWITCH)) ? TRUE : ((ins)->opcode == OP_SWITCH) ? TRUE : ((((ins)->opcode == OP_GOT_ENTRY) && ((ins)->inst_right->inst_i1 == (gpointer)MONO_PATCH_INFO_SWITCH)) ? TRUE : FALSE)))
 


### PR DESCRIPTION
showed up in vtunes when running 
```
./mono/mini/mono-sgen --stats -O=all --aot=threads=1,asmonly ~/work/benchmarker/tests/fsharp/lib/bootstrap/4.0/FSharp.Compiler.dll
```

also, I think when `OP_DYN_CALL` was introduced, it wasn't added to the `MONO_IS_CALL` macro. @vargaz, what do you think?
