### PR TITLE
[runtime] Simplify MonoError handling in finalizer creation and in thread objects

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2439,12 +2439,8 @@ unload_thread_main (void *arg)
 
 	/* Have to attach to the runtime so shutdown can wait for this thread */
 	/* Force it to be attached to avoid racing during shutdown. */
-	thread = mono_thread_attach_full (mono_get_root_domain (), TRUE, &error);
-	if (!is_ok (&error)) {
-		data->failure_reason = g_strdup (mono_error_get_message (&error));
-		mono_error_cleanup (&error);
-		goto failure;
-	}
+	thread = mono_thread_attach_full (mono_get_root_domain (), TRUE);
+
 	mono_thread_set_name_internal (thread->internal_thread, mono_string_new (mono_get_root_domain (), "Domain unloader"), TRUE, &error);
 	if (!is_ok (&error)) {
 		data->failure_reason = g_strdup (mono_error_get_message (&error));

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1984,8 +1984,7 @@ cominterop_get_ccw_checked (MonoObject* object, MonoClass* itf, MonoError *error
 		g_hash_table_insert (ccw_hash, GINT_TO_POINTER (mono_object_hash (object)), ccw_list);
 		mono_cominterop_unlock ();
 		/* register for finalization to clean up ccw */
-		mono_object_register_finalizer (object, error);
-		return_val_if_nok (error, NULL);
+		mono_object_register_finalizer (object);
 	}
 
 	cinfo = mono_custom_attrs_from_class_checked (itf, error);

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -66,7 +66,7 @@
 /* useful until we keep track of gc-references in corlib etc. */
 #define IS_GC_REFERENCE(class,t) (mono_gc_is_moving () ? FALSE : ((t)->type == MONO_TYPE_U && (class)->image == mono_defaults.corlib))
 
-void   mono_object_register_finalizer               (MonoObject  *obj, MonoError *error);
+void   mono_object_register_finalizer               (MonoObject  *obj);
 void   ves_icall_System_GC_InternalCollect          (int          generation);
 gint64 ves_icall_System_GC_GetTotalMemory           (MonoBoolean  forceCollection);
 void   ves_icall_System_GC_KeepAlive                (MonoObject  *obj);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -73,7 +73,7 @@ static MonoCoopCond exited_cond;
 
 static MonoInternalThread *gc_thread;
 
-static void object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*), MonoError *error);
+static void object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*));
 
 static void reference_queue_proccess_all (void);
 static void mono_reference_queue_cleanup (void);
@@ -166,8 +166,7 @@ mono_gc_run_finalize (void *obj, void *data)
 #endif
 
 	/* make sure the finalizer is not called again if the object is resurrected */
-	object_register_finalizer ((MonoObject *)obj, NULL, &error);
-	mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+	object_register_finalizer ((MonoObject *)obj, NULL);
 
 	if (log_finalizers)
 		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Registered finalizer as processed.", o->vtable->klass->name, o);
@@ -275,14 +274,12 @@ mono_gc_run_finalize (void *obj, void *data)
 void
 mono_gc_finalize_threadpool_threads (void)
 {
-	MonoError error;
 	while (threads_to_finalize) {
 		MonoInternalThread *thread = (MonoInternalThread*) mono_mlist_get_data (threads_to_finalize);
 
 		/* Force finalization of the thread. */
 		thread->threadpool_thread = FALSE;
-		mono_object_register_finalizer ((MonoObject*)thread, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		mono_object_register_finalizer ((MonoObject*)thread);
 
 		mono_gc_run_finalize (thread, NULL);
 
@@ -312,16 +309,11 @@ mono_gc_out_of_memory (size_t size)
  * since that, too, can cause the underlying pointer to be offset.
  */
 static void
-object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*), MonoError *error)
+object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*))
 {
 	MonoDomain *domain;
 
-	mono_error_init (error);
-
-	if (obj == NULL) {
-		mono_error_set_argument_null (error, "obj", "");
-		return;
-	}
+	g_assert (obj != NULL);
 
 	domain = obj->vtable->domain;
 
@@ -363,10 +355,10 @@ object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*), Mon
  * 
  */
 void
-mono_object_register_finalizer (MonoObject *obj, MonoError *error)
+mono_object_register_finalizer (MonoObject *obj)
 {
 	/* g_print ("Registered finalizer on %p %s.%s\n", obj, mono_object_class (obj)->name_space, mono_object_class (obj)->name); */
-	object_register_finalizer (obj, mono_gc_run_finalize, error);
+	object_register_finalizer (obj, mono_gc_run_finalize);
 }
 
 /**
@@ -486,19 +478,14 @@ ves_icall_System_GC_KeepAlive (MonoObject *obj)
 void
 ves_icall_System_GC_ReRegisterForFinalize (MonoObject *obj)
 {
-	MonoError error;
-
 	MONO_CHECK_ARG_NULL (obj,);
 
-	object_register_finalizer (obj, mono_gc_run_finalize, &error);
-	mono_error_set_pending_exception (&error);
+	object_register_finalizer (obj, mono_gc_run_finalize);
 }
 
 void
 ves_icall_System_GC_SuppressFinalize (MonoObject *obj)
 {
-	MonoError error;
-
 	MONO_CHECK_ARG_NULL (obj,);
 
 	/* delegates have no finalizers, but we register them to deal with the
@@ -512,8 +499,7 @@ ves_icall_System_GC_SuppressFinalize (MonoObject *obj)
 	 * generated for it that needs cleaned up, but user wants to suppress
 	 * their derived object finalizer. */
 
-	object_register_finalizer (obj, NULL, &error);
-	mono_error_set_pending_exception (&error);
+	object_register_finalizer (obj, NULL);
 }
 
 void
@@ -1122,18 +1108,18 @@ mono_gc_reference_queue_new (mono_reference_queue_callback callback)
 gboolean
 mono_gc_reference_queue_add (MonoReferenceQueue *queue, MonoObject *obj, void *user_data)
 {
-	MonoError error;
 	RefQueueEntry *entry;
 	if (queue->should_be_deleted)
 		return FALSE;
+
+	g_assert (obj != NULL);
 
 	entry = g_new0 (RefQueueEntry, 1);
 	entry->user_data = user_data;
 	entry->domain = mono_object_domain (obj);
 
 	entry->gchandle = mono_gchandle_new_weakref (obj, TRUE);
-	mono_object_register_finalizer (obj, &error);
-	mono_error_assert_ok (&error);
+	mono_object_register_finalizer (obj);
 
 	ref_list_push (&queue->queue, entry);
 	return TRUE;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -407,14 +407,10 @@ mono_delegate_to_ftnptr (MonoDelegate *delegate)
 	delegate_hash_table_add (delegate);
 
 	/* when the object is collected, collect the dynamic method, too */
-	mono_object_register_finalizer ((MonoObject*)delegate, &error);
-	if (!is_ok (&error))
-		goto fail2;
+	mono_object_register_finalizer ((MonoObject*)delegate);
 
 	return delegate->delegate_trampoline;
 
-fail2:
-	delegate_hash_table_remove (delegate);
 fail:
 	mono_gchandle_free (target_handle);
 	mono_error_set_pending_exception (&error);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5156,7 +5156,7 @@ mono_object_new_pinned (MonoDomain *domain, MonoClass *klass, MonoError *error)
 	if (G_UNLIKELY (!o))
 		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", mono_class_instance_size (klass));
 	else if (G_UNLIKELY (vtable->klass->has_finalize))
-		mono_object_register_finalizer (o, error);
+		mono_object_register_finalizer (o);
 
 	return o;
 }
@@ -5286,7 +5286,7 @@ mono_object_new_alloc_specific_checked (MonoVTable *vtable, MonoError *error)
 	if (G_UNLIKELY (!o))
 		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", vtable->klass->instance_size);
 	else if (G_UNLIKELY (vtable->klass->has_finalize))
-		mono_object_register_finalizer (o, error);
+		mono_object_register_finalizer (o);
 
 	return o;
 }
@@ -5374,7 +5374,7 @@ mono_object_new_mature (MonoVTable *vtable, MonoError *error)
 	if (G_UNLIKELY (!o))
 		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", vtable->klass->instance_size);
 	else if (G_UNLIKELY (vtable->klass->has_finalize))
-		mono_object_register_finalizer (o, error);
+		mono_object_register_finalizer (o);
 
 	return o;
 }
@@ -5489,7 +5489,7 @@ mono_object_clone_checked (MonoObject *obj, MonoError *error)
 	mono_gc_wbarrier_object_copy (o, obj);
 
 	if (obj->vtable->klass->has_finalize)
-		mono_object_register_finalizer (o, error);
+		mono_object_register_finalizer (o);
 	return o;
 }
 
@@ -6264,7 +6264,7 @@ mono_value_box_checked (MonoDomain *domain, MonoClass *klass, gpointer value, Mo
 #endif
 #endif
 	if (klass->has_finalize) {
-		mono_object_register_finalizer (res, error);
+		mono_object_register_finalizer (res);
 		return_val_if_nok (error, NULL);
 	}
 	return res;

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -504,6 +504,8 @@ mono_marshal_get_remoting_invoke (MonoMethod *method)
 /* mono_marshal_xdomain_copy_out_value()
  * Copies the contents of the src instance into the dst instance. src and dst
  * must have the same type, and if they are arrays, the same size.
+ *
+ * This is an icall, it may use mono_error_set_pending_exception
  */
 static void
 mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
@@ -523,7 +525,8 @@ mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
 			for (i = 0; i < len; i++) {
 				MonoObject *item = (MonoObject *)mono_array_get ((MonoArray *)src, gpointer, i);
 				MonoObject *item_copy = mono_marshal_xdomain_copy_value (item, &error);
-				mono_error_raise_exception (&error); /* FIXME don't raise here */
+				if (mono_error_set_pending_exception (&error))
+					return;
 				mono_array_setref ((MonoArray *)dst, i, item_copy);
 			}
 		} else {
@@ -1259,7 +1262,7 @@ mono_marshal_load_remoting_wrapper (MonoRealProxy *rp, MonoMethod *method)
 	else
 		marshal_method = mono_marshal_get_remoting_invoke (method);
 	gpointer compiled_ptr = mono_compile_method_checked (marshal_method, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_error_assert_ok (&error);
 	return compiled_ptr;
 }
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -247,7 +247,7 @@ gboolean
 mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, MonoError *error);
 
 MonoThread *
-mono_thread_attach_full (MonoDomain *domain, gboolean force_attach, MonoError *error);
+mono_thread_attach_full (MonoDomain *domain, gboolean force_attach);
 
 void mono_thread_init_tls (void);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -583,21 +583,22 @@ set_current_thread_for_domain (MonoDomain *domain, MonoInternalThread *thread, M
 }
 
 static MonoThread*
-create_thread_object (MonoDomain *domain, MonoError *error)
+create_thread_object (MonoDomain *domain)
 {
+	MonoError error;
 	MonoVTable *vt = mono_class_vtable (domain, mono_defaults.thread_class);
-	MonoThread *t = (MonoThread*)mono_object_new_mature (vt, error);
+	MonoThread *t = (MonoThread*)mono_object_new_mature (vt, &error);
+	/* only possible failure mode is OOM, from which we don't expect to recover. */
+	mono_error_assert_ok (&error);
 	return t;
 }
 
 static MonoThread*
-new_thread_with_internal (MonoDomain *domain, MonoInternalThread *internal, MonoError *error)
+new_thread_with_internal (MonoDomain *domain, MonoInternalThread *internal)
 {
 	MonoThread *thread;
 
-	thread = create_thread_object (domain, error);
-	if (!mono_error_ok (error))
-		return NULL;
+	thread = create_thread_object (domain);
 
 	MONO_OBJECT_SETREF (thread, internal_thread, internal);
 
@@ -605,15 +606,16 @@ new_thread_with_internal (MonoDomain *domain, MonoInternalThread *internal, Mono
 }
 
 static MonoInternalThread*
-create_internal_thread (MonoError *error)
+create_internal_thread ()
 {
+	MonoError error;
 	MonoInternalThread *thread;
 	MonoVTable *vt;
 
 	vt = mono_class_vtable (mono_get_root_domain (), mono_defaults.internal_thread_class);
-	thread = (MonoInternalThread*) mono_object_new_mature (vt, error);
-	if (!mono_error_ok (error))
-		return NULL;
+	thread = (MonoInternalThread*) mono_object_new_mature (vt, &error);
+	/* only possible failure mode is OOM, from which we don't exect to recover */
+	mono_error_assert_ok (&error);
 
 	thread->synch_cs = g_new0 (MonoCoopMutex, 1);
 	mono_coop_mutex_init_recursive (thread->synch_cs);
@@ -629,14 +631,12 @@ create_internal_thread (MonoError *error)
 }
 
 static gboolean
-init_root_domain_thread (MonoInternalThread *thread, MonoThread *candidate, MonoError *error)
+init_root_domain_thread (MonoInternalThread *thread, MonoThread *candidate)
 {
 	MonoDomain *domain = mono_get_root_domain ();
 
-	mono_error_init (error);
 	if (!candidate || candidate->obj.vtable->domain != domain) {
-		candidate = new_thread_with_internal (domain, thread, error);
-		return_val_if_nok (error, FALSE);
+		candidate = new_thread_with_internal (domain, thread);
 	}
 	set_current_thread_for_domain (domain, thread, candidate);
 	g_assert (!thread->root_domain_thread);
@@ -695,8 +695,7 @@ static guint32 WINAPI start_wrapper_internal(void *data)
 	/* We have to do this here because mono_thread_new_init()
 	   requires that root_domain_thread is set up. */
 	thread_adjust_static_data (internal);
-	init_root_domain_thread (internal, start_info->obj, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	init_root_domain_thread (internal, start_info->obj);
 
 	/* This MUST be called before any managed code can be
 	 * executed, as it calls the callback function that (for the
@@ -936,11 +935,9 @@ mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, gb
 
 	mono_error_init (error);
 
-	thread = create_thread_object (domain, error);
-	return_val_if_nok (error, NULL);
+	thread = create_thread_object (domain);
 
-	internal = create_internal_thread (error);
-	return_val_if_nok (error, NULL);
+	internal = create_internal_thread ();
 
 	MONO_OBJECT_SETREF (thread, internal_thread, internal);
 
@@ -978,23 +975,19 @@ mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, Mon
 MonoThread *
 mono_thread_attach (MonoDomain *domain)
 {
-	MonoError error;
-	MonoThread *thread = mono_thread_attach_full (domain, FALSE, &error);
-	mono_error_raise_exception (&error);
+	MonoThread *thread = mono_thread_attach_full (domain, FALSE);
 
 	return thread;
 }
 
 MonoThread *
-mono_thread_attach_full (MonoDomain *domain, gboolean force_attach, MonoError *error)
+mono_thread_attach_full (MonoDomain *domain, gboolean force_attach)
 {
 	MonoThreadInfo *info;
 	MonoInternalThread *thread;
 	MonoThread *current_thread;
 	HANDLE thread_handle;
 	MonoNativeThreadId tid;
-
-	mono_error_init (error);
 
 	if ((thread = mono_thread_internal_current ())) {
 		if (domain != mono_domain_get ())
@@ -1007,9 +1000,7 @@ mono_thread_attach_full (MonoDomain *domain, gboolean force_attach, MonoError *e
 		g_error ("Thread %"G_GSIZE_FORMAT" calling into managed code is not registered with the GC. On UNIX, this can be fixed by #include-ing <gc.h> before <pthread.h> in the file containing the thread creation code.", mono_native_thread_id_get ());
 	}
 
-	thread = create_internal_thread (error);
-	if (!mono_error_ok (error))
-		return NULL;
+	thread = create_internal_thread ();
 
 	thread_handle = mono_thread_info_open_handle ();
 	g_assert (thread_handle);
@@ -1027,9 +1018,7 @@ mono_thread_attach_full (MonoDomain *domain, gboolean force_attach, MonoError *e
 	thread->thread_info = info;
 	thread->small_id = info->small_id;
 
-	current_thread = new_thread_with_internal (domain, thread, error);
-	if (!mono_error_ok (error))
-		return NULL;
+	current_thread = new_thread_with_internal (domain, thread);
 
 	if (!handle_store (current_thread, force_attach)) {
 		/* Mono is shutting down, so just wait for the end */
@@ -1044,8 +1033,7 @@ mono_thread_attach_full (MonoDomain *domain, gboolean force_attach, MonoError *e
 
 	thread_adjust_static_data (thread);
 
-	init_root_domain_thread (thread, current_thread, error);
-	return_val_if_nok (error, NULL);
+	init_root_domain_thread (thread, current_thread);
 
 	if (domain != mono_get_root_domain ())
 		set_current_thread_for_domain (domain, thread, current_thread);
@@ -1137,12 +1125,9 @@ mono_thread_exit ()
 void
 ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThread *this_obj)
 {
-	MonoError error;
 	MonoInternalThread *internal;
 
-	internal = create_internal_thread (&error);
-	if (mono_error_set_pending_exception (&error))
-		return;
+	internal = create_internal_thread ();
 
 	internal->state = ThreadState_Unstarted;
 
@@ -1500,7 +1485,6 @@ ves_icall_System_Threading_Thread_ByteArrayToCurrentDomain (MonoArray *arr)
 MonoThread *
 mono_thread_current (void)
 {
-	MonoError error;
 	MonoDomain *domain = mono_domain_get ();
 	MonoInternalThread *internal = mono_thread_internal_current ();
 	MonoThread **current_thread_ptr;
@@ -1510,8 +1494,7 @@ mono_thread_current (void)
 
 	if (!*current_thread_ptr) {
 		g_assert (domain != mono_get_root_domain ());
-		*current_thread_ptr = new_thread_with_internal (domain, internal, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		*current_thread_ptr = new_thread_with_internal (domain, internal);
 	}
 	return *current_thread_ptr;
 }
@@ -1520,7 +1503,6 @@ mono_thread_current (void)
 static MonoThread *
 mono_thread_current_for_thread (MonoInternalThread *internal)
 {
-	MonoError error;
 	MonoDomain *domain = mono_domain_get ();
 	MonoThread **current_thread_ptr;
 
@@ -1529,8 +1511,7 @@ mono_thread_current_for_thread (MonoInternalThread *internal)
 
 	if (!*current_thread_ptr) {
 		g_assert (domain != mono_get_root_domain ());
-		*current_thread_ptr = new_thread_with_internal (domain, internal, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		*current_thread_ptr = new_thread_with_internal (domain, internal);
 	}
 	return *current_thread_ptr;
 }
@@ -5031,7 +5012,6 @@ ves_icall_System_Threading_Thread_GetStackTraces (MonoArray **out_threads, MonoA
 gpointer
 mono_threads_attach_coop (MonoDomain *domain, gpointer *dummy)
 {
-	MonoError error;
 	MonoDomain *orig;
 	gboolean fresh_thread;
 
@@ -5052,8 +5032,7 @@ mono_threads_attach_coop (MonoDomain *domain, gpointer *dummy)
 	}
 
 	if (!mono_thread_internal_current ()) {
-		mono_thread_attach_full (domain, FALSE, &error);
-		mono_error_assert_ok (&error);
+		mono_thread_attach_full (domain, FALSE);
 
 		// #678164
 		mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);


### PR DESCRIPTION
* `object_register_finalizer` was doing NULL-argument checks using `MonoError`; we can just assert instead and shift responsibility to the callers.  Turns out this is easy because all the callers had non-NULL arguments already.

* `create_thread_object` and `create_internal_thread` only fail if we run out of memory, so let's just assert that we don't.