### PR TITLE
[eglib] Ignore nl_langinfo as it doesn't return the actual system def…

### DIFF
--- a/eglib/configure.ac
+++ b/eglib/configure.ac
@@ -181,7 +181,7 @@ if test "x$have_iso_varargs" = "xyes"; then
 fi
 AC_SUBST(G_HAVE_ISO_VARARGS)
 
-AC_CHECK_HEADERS(getopt.h sys/select.h sys/time.h sys/wait.h pwd.h langinfo.h iconv.h localcharset.h sys/types.h sys/resource.h)
+AC_CHECK_HEADERS(getopt.h sys/select.h sys/time.h sys/wait.h pwd.h iconv.h localcharset.h sys/types.h sys/resource.h)
 AC_CHECK_LIB([iconv], [locale_charset],[],[AC_CHECK_LIB([charset], [locale_charset],[LIBS+="-liconv -lcharset"])])
 AC_CHECK_HEADER(alloca.h, [HAVE_ALLOCA_H=1], [HAVE_ALLOCA_H=0])
 AC_SUBST(HAVE_ALLOCA_H)

--- a/eglib/src/gunicode.c
+++ b/eglib/src/gunicode.c
@@ -44,9 +44,6 @@
 #  define CODESET 1
 #  include <windows.h>
 #else
-#    ifdef HAVE_LANGINFO_H
-#       include <langinfo.h>
-#    endif
 #    ifdef HAVE_LOCALCHARSET_H
 #       include <localcharset.h>
 #    endif
@@ -219,9 +216,7 @@ g_get_charset (G_CONST_RETURN char **charset)
 		is_utf8 = FALSE;
 #else
 		/* These shouldn't be heap allocated */
-#if defined(HAVE_LANGINFO_H)
-		my_charset = nl_langinfo (CODESET);
-#elif defined(HAVE_LOCALCHARSET_H)
+#if defined(HAVE_LOCALCHARSET_H)
 		my_charset = locale_charset ();
 #else
 		my_charset = "UTF-8";


### PR DESCRIPTION
…ault. Fixes #41128.

nl_langinfo doesn't query the right system value, it returns ASCII on OSX, for example.