### PR TITLE
Various xbuild 14.0 fixes

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Project.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Project.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.Build.BuildEngine {
 			evaluatedProperties.AddProperty (new BuildProperty ("OS", OS, PropertyType.Environment));
 #if XBUILD_12
 			// see http://msdn.microsoft.com/en-us/library/vstudio/hh162058(v=vs.120).aspx
-			if (effective_tools_version == "12.0") {
+			if (effective_tools_version == "12.0" || effective_tools_version == "14.0") {
 				evaluatedProperties.AddProperty (new BuildProperty ("MSBuildToolsPath32", toolsPath, PropertyType.Reserved));
 
 				var frameworkToolsPath = ToolLocationHelper.GetPathToDotNetFramework (TargetDotNetFrameworkVersion.Version451);

--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/ResolveAssemblyReference.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/ResolveAssemblyReference.cs
@@ -128,6 +128,10 @@ namespace Microsoft.Build.Tasks {
 			relatedFiles = tempRelatedFiles.Values.ToArray ();
 			resolvedDependencyFiles = tempResolvedDepFiles.Values.ToArray ();
 
+#if XBUILD_14
+			DependsOnSystemRuntime = resolvedDependencyFiles.Any (x => Path.GetFileName (x.ItemSpec) == "System.Runtime.dll").ToString ();
+#endif
+
 			tempResolvedFiles.Clear ();
 			tempCopyLocalFiles.Clear ();
 			tempSatelliteFiles.Clear ();

--- a/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets
@@ -104,7 +104,10 @@
 			Text="OutDir property must end with a slash."/>
 	</Target>
 
-	<Target Name="PrepareForBuild">
+	<PropertyGroup>
+		<PrepareForBuildDependsOn>AssignLinkMetadata</PrepareForBuildDependsOn>
+	</PropertyGroup>
+	<Target Name="PrepareForBuild" DependsOnTargets="$(PrepareForBuildDependsOn)">
 		<Message Importance="High" Text="Configuration: $(Configuration) Platform: $(Platform)"/>
 
 		<!-- Look for app.config, if $(AppConfig) is specified, then use that. Else look in
@@ -122,6 +125,18 @@
 		<MakeDir
 			Directories="$(OutDir);$(IntermediateOutputPath);@(DocFileItem->'%(RelativeDir)')"
 		/>
+	</Target>
+
+	<Target Name="AssignLinkMetadata">
+	    <AssignLinkMetadata Items="@(EmbeddedResource)" Condition="'@(EmbeddedResource)' != '' and '%(EmbeddedResource.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)'">
+	      <Output TaskParameter="OutputItems" ItemName="_EmbeddedResourceWithLinkAssigned" />
+	    </AssignLinkMetadata>
+
+	    <ItemGroup>
+		<EmbeddedResource Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+		<EmbeddedResource Include="@(_EmbeddedResourceWithLinkAssigned)" />
+		<_EmbeddedResourceWithLinkAssigned Remove="@(_EmbeddedResourceWithLinkAssigned)" />
+	    </ItemGroup>
 	</Target>
 
 	<PropertyGroup>

--- a/mcs/tools/xbuild/data/14.0/Microsoft.Common.tasks
+++ b/mcs/tools/xbuild/data/14.0/Microsoft.Common.tasks
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
 	<UsingTask TaskName="Microsoft.Build.Tasks.AL"			AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignTargetPath"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.AssignLinkMetadata"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignCulture"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"	AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 	<UsingTask TaskName="Microsoft.Build.Tasks.CallTarget"		AssemblyName="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />


### PR DESCRIPTION
These are required to make sure xbuild 14.0 behaves the same as xbuild 12.0 or earlier.

The most important one is d44824b as it fixes a compilation error.

Bugzilla bug: https://bugzilla.xamarin.com/show_bug.cgi?id=41227