### PR TITLE
ContentStream can be null

### DIFF
--- a/mcs/class/System.Net.Http/CFNetworkHandler.cs
+++ b/mcs/class/System.Net.Http/CFNetworkHandler.cs
@@ -61,7 +61,9 @@ namespace System.Net.Http
 			public void Close ()
 			{
 				CancellationTokenRegistration.Dispose ();
-				ContentStream.Close ();
+                                if (ContentStream != null) {
+                                    ContentStream.Close ();
+                                }
 			}
 		}
 


### PR DESCRIPTION
Getting this crash in an app and looks to be when the content-stream is null.

```
*** Terminating app due to uncaught exception 'System.NullReferenceException: Object reference not set to an instance of an object', reason: 'System.NullReferenceException: Object reference not set to an instance of an object
  at System.Net.Http.CFNetworkHandler+StreamBucket.Close () <0x10112e890 + 0x00030> in <filename unknown>:0 
  at System.Net.Http.CFNetworkHandler.CloseStream (CoreServices.CFHTTPStream stream) <0x10112e280 + 0x0004f> in <filename unknown>:0 
  at System.Net.Http.CFNetworkHandler.HandleErrorEvent (System.Object sender, CoreFoundation.StreamEventArgs e) <0x10112e120 + 0x000b7> in <filename unknown>:0 
  at CoreFoundation.CFStream.OnErrorEvent (CoreFoundation.StreamEventArgs args) <0x10068d6f0 + 0x00037> in <filename unknown>:0 
  at CoreFoundation.CFStream.OnCallback (CFStreamEventType type) <0x10068d840 + 0x000e7> in <filename unknown>:0 
  at CoreFoundation.CFStream.OnCallback (IntPtr s, nint type, IntPtr info) <0x10068d790 + 0x0008f> in <filename unknown>:0 
  at (wrapper native-to-managed) CoreFoundation.CFStream:OnCallback (intptr,System.nint,intptr)
  at (wrapper managed-to-native) UIKit.UIApplication:UIApplicationMain (int,string[],intptr,intptr)
```