### PR TITLE
[runtime] Mark mono_string_to_utf8 external only.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -706,6 +706,7 @@ mono_domain_set (MonoDomain *domain, gboolean force)
 MonoObject *
 ves_icall_System_AppDomain_GetData (MonoAppDomain *ad, MonoString *name)
 {
+	MonoError error;
 	MonoDomain *add;
 	MonoObject *o;
 	char *str;
@@ -716,7 +717,9 @@ ves_icall_System_AppDomain_GetData (MonoAppDomain *ad, MonoString *name)
 	add = ad->data;
 	g_assert (add);
 
-	str = mono_string_to_utf8 (name);
+	str = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 
 	mono_domain_lock (add);
 
@@ -959,7 +962,9 @@ ves_icall_System_AppDomain_createDomain (MonoString *friendly_name, MonoAppDomai
 #else
 	char *fname;
 
-	fname = mono_string_to_utf8 (friendly_name);
+	fname = mono_string_to_utf8_checked (friendly_name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	ad = mono_domain_create_appdomain_internal (fname, setup, &error);
 
 	g_free (fname);
@@ -2029,7 +2034,9 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoString *fname, MonoBoolean re
 		return NULL;
 	}
 		
-	name = filename = mono_string_to_utf8 (fname);
+	name = filename = mono_string_to_utf8_checked (fname, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	
 	ass = mono_assembly_open_full (filename, &status, refOnly);
 	
@@ -2106,7 +2113,9 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 
 	g_assert (assRef);
 
-	name = mono_string_to_utf8 (assRef);
+	name = mono_string_to_utf8_checked (assRef, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	parsed = mono_assembly_name_parse (name, &aname);
 	g_free (name);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2888,6 +2888,7 @@ get_per_domain_assembly_binding_info (MonoDomain *domain, MonoAssemblyName *anam
 static MonoAssemblyName*
 mono_assembly_apply_binding (MonoAssemblyName *aname, MonoAssemblyName *dest_name)
 {
+	MonoError error;
 	MonoAssemblyBindingInfo *info, *info2;
 	MonoImage *ppimage;
 	MonoDomain *domain;
@@ -2918,7 +2919,9 @@ mono_assembly_apply_binding (MonoAssemblyName *aname, MonoAssemblyName *dest_nam
 	if (domain && domain->setup && domain->setup->configuration_file) {
 		mono_domain_lock (domain);
 		if (!domain->assembly_bindings_parsed) {
-			gchar *domain_config_file_name = mono_string_to_utf8 (domain->setup->configuration_file);
+			gchar *domain_config_file_name = mono_string_to_utf8_checked (domain->setup->configuration_file, &error);
+			mono_error_raise_exception (&error); /* FIXME don't raise here */
+
 			gchar *domain_config_file_path = mono_portability_find_file (domain_config_file_name, TRUE);
 
 			if (!domain_config_file_path)

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -498,13 +498,21 @@ ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardow
 	if (setup_finished)
 		return TRUE;
 
-	keypad_xmit_str = keypad != NULL ? mono_string_to_utf8 (keypad) : NULL;
+	keypad_xmit_str = NULL;
+	if (keypad != NULL) {
+		keypad_xmit_str = mono_string_to_utf8_checked (keypad, &error);
+		if (mono_error_set_pending_exception (&error))
+			return FALSE;
+	}
 	
 	console_set_signal_handlers ();
 	setup_finished = TRUE;
 	if (!atexit_called) {
-		if (teardown != NULL)
-			teardown_str = mono_string_to_utf8 (teardown);
+		if (teardown != NULL) {
+			teardown_str = mono_string_to_utf8_checked (teardown, &error);
+			if (mono_error_set_pending_exception (&error))
+				return FALSE;
+		}
 
 		mono_atexit (tty_teardown);
 	}

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -918,6 +918,7 @@ print_name_space (MonoClass *klass)
 void
 mono_object_describe (MonoObject *obj)
 {
+	MonoError error;
 	MonoClass* klass;
 	const char* sep;
 	if (!obj) {
@@ -926,7 +927,8 @@ mono_object_describe (MonoObject *obj)
 	}
 	klass = mono_object_class (obj);
 	if (klass == mono_defaults.string_class) {
-		char *utf8 = mono_string_to_utf8 ((MonoString*)obj);
+		char *utf8 = mono_string_to_utf8_checked ((MonoString*)obj, &error);
+		mono_error_raise_exception (&error); /* FIXME don't raise here */
 		if (strlen (utf8) > 60) {
 			utf8 [57] = '.';
 			utf8 [58] = '.';

--- a/mono/metadata/filewatcher.c
+++ b/mono/metadata/filewatcher.c
@@ -149,13 +149,16 @@ ves_icall_System_IO_InotifyWatcher_GetInotifyInstance ()
 int
 ves_icall_System_IO_InotifyWatcher_AddWatch (int fd, MonoString *name, gint32 mask)
 {
+	MonoError error;
 	char *str, *path;
 	int retval;
 
 	if (name == NULL)
 		return -1;
 
-	str = mono_string_to_utf8 (name);
+	str = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return -1;
 	path = mono_portability_find_file (str, TRUE);
 	if (!path)
 		path = str;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1477,31 +1477,41 @@ ves_icall_System_Type_internal_from_name (MonoString *name,
 										  MonoBoolean ignoreCase)
 {
 	MonoError error;
-	char *str = mono_string_to_utf8 (name);
 	MonoTypeNameParse info;
-	MonoReflectionType *type;
+	MonoReflectionType *type = NULL;
 	gboolean parsedOk;
+
+	char *str = mono_string_to_utf8_checked (name, &error);
+	if (!is_ok (&error))
+		goto leave;
 
 	parsedOk = mono_reflection_parse_type (str, &info);
 
 	/* mono_reflection_parse_type() mangles the string */
 	if (!parsedOk) {
 		mono_reflection_free_type_info (&info);
-		if (throwOnError) {
-			mono_error_init (&error);
+		if (throwOnError)
 			mono_error_set_argument (&error, "typeName", "failed parse: %s", str);
-			mono_error_set_pending_exception (&error);
-		}
-		g_free (str);
-		return NULL;
+		goto leave;
 	}
 
 	type = type_from_parsed_name (&info, ignoreCase, &error);
 
 	mono_reflection_free_type_info (&info);
-	g_free (str);
 
-	if (!mono_error_ok (&error)) {
+	if (!is_ok (&error))
+		goto leave;
+
+	if (type == NULL){
+		if (throwOnError) {
+			mono_error_set_type_load_name (&error, g_strdup (str), NULL, "");
+			goto leave;
+		}
+	}
+	
+leave:
+	g_free (str);
+	if (!is_ok (&error)) {
 		if (throwOnError)
 			mono_error_set_pending_exception (&error);
 		else
@@ -1509,18 +1519,6 @@ ves_icall_System_Type_internal_from_name (MonoString *name,
 		return NULL;
 	}
 
-	if (type == NULL){
-		MonoException *e = NULL;
-		
-		if (throwOnError)
-			e = mono_get_exception_type_load (name, NULL);
-
-		if (e) {
-			mono_set_pending_exception (e);
-			return NULL;
-		}
-	}
-	
 	return type;
 }
 
@@ -3345,7 +3343,9 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 			}
 			
 			name = mono_array_get (params, MonoString *, 1);
-			str = mono_string_to_utf8 (name);
+			str = mono_string_to_utf8_checked (name, &error);
+			if (mono_error_set_pending_exception (&error))
+				return NULL;
 		
 			do {
 				MonoClassField* field = mono_class_get_field_from_name (k, str);
@@ -3388,7 +3388,9 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 			}
 			
 			name = mono_array_get (params, MonoString *, 1);
-			str = mono_string_to_utf8 (name);
+			str = mono_string_to_utf8_checked (name, &error);
+			if (mono_error_set_pending_exception (&error))
+				return NULL;
 		
 			do {
 				MonoClassField* field = mono_class_get_field_from_name (k, str);
@@ -3840,7 +3842,9 @@ handle_parent:
 
 		if (name != NULL) {
 			if (utf8_name == NULL) {
-				utf8_name = mono_string_to_utf8 (name);
+				utf8_name = mono_string_to_utf8_checked (name, &error);
+				if (!is_ok (&error))
+					goto fail;
 				compare_func = (bflags & BFLAGS_IgnoreCase) ? mono_utf8_strcasecmp : strcmp;
 			}
 
@@ -4039,8 +4043,11 @@ ves_icall_Type_GetMethodsByName (MonoReflectionType *type, MonoString *name, gui
 		return res;
 	}
 
-	if (name)
-		mname = mono_string_to_utf8 (name);
+	if (name) {
+		mname = mono_string_to_utf8_checked (name, &error);
+		if (mono_error_set_pending_exception (&error))
+		    return NULL;
+	}
 
 	method_array = mono_class_get_methods_by_name (klass, mname, bflags, ignore_case, FALSE, &ex);
 	g_free ((char*)mname);
@@ -4237,7 +4244,9 @@ ves_icall_Type_GetPropertiesByName (MonoReflectionType *type, MonoString *name, 
 	klass = startklass = mono_class_from_mono_type (type->type);
 
 	if (name != NULL) {
-		propname = mono_string_to_utf8 (name);
+		propname = mono_string_to_utf8_checked (name, &error);
+		if (mono_error_set_pending_exception (&error))
+			return NULL;
 		compare_func = (ignore_case) ? mono_utf8_strcasecmp : strcmp;
 	}
 
@@ -4426,7 +4435,9 @@ handle_parent:
 
 		if (name != NULL) {
 			if (utf8_name == NULL) {
-				utf8_name = mono_string_to_utf8 (name);
+				utf8_name = mono_string_to_utf8_checked (name, &error);
+				if (!is_ok (&error))
+					goto failure;
 				compare_func = (bflags & BFLAGS_IgnoreCase) ? mono_utf8_strcasecmp : strcmp;
 			}
 
@@ -4534,7 +4545,9 @@ ves_icall_Type_GetNestedTypes (MonoReflectionType *type, MonoString *name, guint
 
 		if (name != NULL) {
 			if (str == NULL) {
-				str = mono_string_to_utf8 (name);
+				str = mono_string_to_utf8_checked (name, &error);
+				if (!is_ok (&error))
+					goto leave;
 				mono_identifier_unescape_type_name_chars (str);
 			}
 
@@ -4577,7 +4590,9 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssembly *as
 
 	/* On MS.NET, this does not fire a TypeResolve event */
 	type_resolve = TRUE;
-	str = mono_string_to_utf8 (name);
+	str = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	/*g_print ("requested type %s in %s\n", str, assembly->assembly->aname.name);*/
 	if (!mono_reflection_parse_type (str, &info)) {
 		g_free (str);
@@ -4790,7 +4805,9 @@ ves_icall_System_Reflection_Assembly_load_with_partial_name (MonoString *mname, 
 	MonoImageOpenStatus status;
 	MonoReflectionAssembly* result = NULL;
 	
-	name = mono_string_to_utf8 (mname);
+	name = mono_string_to_utf8_checked (mname, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	res = mono_assembly_load_with_partial_name (name, &status);
 
 	g_free (name);
@@ -5037,13 +5054,16 @@ ICALL_EXPORT void *
 ves_icall_System_Reflection_Assembly_GetManifestResourceInternal (MonoReflectionAssembly *assembly, MonoString *name, gint32 *size, MonoReflectionModule **ref_module) 
 {
 	MonoError error;
-	char *n = mono_string_to_utf8 (name);
 	MonoTableInfo *table = &assembly->assembly->image->tables [MONO_TABLE_MANIFESTRESOURCE];
 	guint32 i;
 	guint32 cols [MONO_MANIFEST_SIZE];
 	guint32 impl, file_idx;
 	const char *val;
 	MonoImage *module;
+
+	char *n = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 
 	for (i = 0; i < table->rows; ++i) {
 		mono_metadata_decode_row (table, i, cols, MONO_MANIFEST_SIZE);
@@ -5091,7 +5111,9 @@ ves_icall_System_Reflection_Assembly_GetManifestResourceInfoInternal (MonoReflec
 	const char *val;
 	char *n;
 
-	n = mono_string_to_utf8 (name);
+	n = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
 	for (i = 0; i < table->rows; ++i) {
 		mono_metadata_decode_row (table, i, cols, MONO_MANIFEST_SIZE);
 		val = mono_metadata_string_heap (assembly->assembly->image, cols [MONO_MANIFEST_NAME]);
@@ -5163,7 +5185,10 @@ ves_icall_System_Reflection_Assembly_GetFilesInternal (MonoReflectionAssembly *a
 
 	/* check hash if needed */
 	if (name) {
-		n = mono_string_to_utf8 (name);
+		n = mono_string_to_utf8_checked (name, &error);
+		if (mono_error_set_pending_exception (&error))
+			return NULL;
+
 		for (i = 0; i < table->rows; ++i) {
 			val = mono_metadata_string_heap (assembly->assembly->image, mono_metadata_decode_row_col (table, i, MONO_FILE_NAME));
 			if (strcmp (val, n) == 0) {
@@ -5643,7 +5668,9 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoString *fname,
 	MonoAssemblyName name;
 	char *dirname;
 
-	filename = mono_string_to_utf8 (fname);
+	filename = mono_string_to_utf8_checked (fname, &error);
+	if (mono_error_set_pending_exception (&error))
+		return;
 
 	dirname = g_path_get_dirname (filename);
 	replace_shadow_path (mono_domain_get (), dirname, &filename);
@@ -5904,7 +5931,10 @@ ves_icall_System_Reflection_AssemblyName_ParseName (MonoReflectionAssemblyName *
 	gboolean is_token_defined;
 
 	aname.public_key = NULL;
-	val = mono_string_to_utf8 (assname);
+	val = mono_string_to_utf8_checked (assname, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
+
 	if (!mono_assembly_name_parse_full (val, &aname, TRUE, &is_version_defined, &is_token_defined)) {
 		g_free ((guint8*) aname.public_key);
 		g_free (val);
@@ -6368,8 +6398,10 @@ ves_icall_ModuleBuilder_create_modified_type (MonoReflectionTypeBuilder *tb, Mon
 	MonoReflectionType *ret;
 	MonoClass *klass;
 	int isbyref = 0, rank;
-	char *str = mono_string_to_utf8 (smodifiers);
 	char *p;
+	char *str = mono_string_to_utf8_checked (smodifiers, &error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 
 	klass = mono_class_from_mono_type (tb->type.type);
 	p = str;
@@ -6867,13 +6899,16 @@ ves_icall_System_Environment_GetIs64BitOperatingSystem (void)
 ICALL_EXPORT MonoString *
 ves_icall_System_Environment_GetEnvironmentVariable (MonoString *name)
 {
+	MonoError error;
 	const gchar *value;
 	gchar *utf8_name;
 
 	if (name == NULL)
 		return NULL;
 
-	utf8_name = mono_string_to_utf8 (name);	/* FIXME: this should be ascii */
+	utf8_name = mono_string_to_utf8_checked (name, &error);	/* FIXME: this should be ascii */
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	value = g_getenv (utf8_name);
 
 	g_free (utf8_name);
@@ -7034,7 +7069,9 @@ ves_icall_System_Environment_InternalSetEnvironmentVariable (MonoString *name, M
 	g_free (utf16_name);
 	g_free (utf16_value);
 #else
-	utf8_name = mono_string_to_utf8 (name);	/* FIXME: this should be ascii */
+	utf8_name = mono_string_to_utf8_checked (name, &error);	/* FIXME: this should be ascii */
+	if (mono_error_set_pending_exception (&error))
+		return;
 
 	if ((value == NULL) || (mono_string_length (value) == 0) || (mono_string_chars (value)[0] == 0)) {
 		g_unsetenv (utf8_name);
@@ -7522,6 +7559,7 @@ ves_icall_System_Configuration_DefaultConfig_get_machine_config_path (void)
 static MonoString *
 get_bundled_app_config (void)
 {
+	MonoError error;
 	const gchar *app_config;
 	MonoDomain *domain;
 	MonoString *file;
@@ -7535,7 +7573,8 @@ get_bundled_app_config (void)
 		return NULL;
 
 	// Retrieve config file and remove the extension
-	config_file_name = mono_string_to_utf8 (file);
+	config_file_name = mono_string_to_utf8_checked (file, &error);
+	mono_error_raise_exception (&error); /* FIXME don't raise here */
 	config_file_path = mono_portability_find_file (config_file_name, TRUE);
 	if (!config_file_path)
 		config_file_path = config_file_name;

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -177,7 +177,9 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 	const CultureInfoEntry *ci;
 	char *n;
 
-	n = mono_string_to_utf8 (name);
+	n = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
 	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
 			sizeof (CultureInfoNameEntry), culture_name_locator);
 	g_free (n);
@@ -574,7 +576,9 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (
 	const CultureInfoNameEntry *ne;
 	char *n;
 	
-	n = mono_string_to_utf8 (name);
+	n = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
 	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
 			sizeof (CultureInfoNameEntry), culture_name_locator);
 
@@ -623,10 +627,13 @@ MonoBoolean
 ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (MonoRegionInfo *this_obj,
 		MonoString *name)
 {
+	MonoError error;
 	const RegionInfoNameEntry *ne;
 	char *n;
 	
-	n = mono_string_to_utf8 (name);
+	n = mono_string_to_utf8_checked (name, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
 	ne = (const RegionInfoNameEntry *)mono_binary_search (n, region_name_entries, NUM_REGION_ENTRIES,
 		sizeof (RegionInfoNameEntry), region_name_locator);
 

--- a/mono/metadata/mono-route.c
+++ b/mono/metadata/mono-route.c
@@ -21,6 +21,7 @@
 
 extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfaceProperties_ParseRouteInfo_internal(MonoString *iface, MonoArray **gw_addr_list)
 {
+	MonoError error;
 	size_t needed;
 	in_addr_t in;
 	int mib[6];
@@ -31,7 +32,10 @@ extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfacePrope
 
 	MonoDomain *domain = mono_domain_get ();
 
-	ifacename = mono_string_to_utf8(iface);
+	ifacename = mono_string_to_utf8_checked(iface, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
+
 	if ((ifindex = if_nametoindex(ifacename)) == 0)
 		return FALSE;
 	g_free(ifacename);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6833,8 +6833,10 @@ mono_string_to_utf8 (MonoString *s)
 	MonoError error;
 	char *result = mono_string_to_utf8_checked (s, &error);
 	
-	if (!mono_error_ok (&error))
-		mono_error_raise_exception (&error);
+	if (!is_ok (&error)) {
+		mono_error_cleanup (&error);
+		return NULL;
+	}
 	return result;
 }
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -145,6 +145,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
 mono_string_new_utf32	    (MonoDomain *domain, const mono_unichar4 *text, int32_t len);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API char *
 mono_string_to_utf8	    (MonoString *string_obj);
 

--- a/mono/metadata/process.c
+++ b/mono/metadata/process.c
@@ -693,6 +693,7 @@ ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoProcessStartIn
 MonoBoolean
 ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoProcessStartInfo *proc_start_info, HANDLE stdin_handle, HANDLE stdout_handle, HANDLE stderr_handle, MonoProcInfo *process_info)
 {
+	MonoError error G_GNUC_UNUSED;
 	gboolean ret;
 	gunichar2 *dir;
 	STARTUPINFO startinfo={0};
@@ -727,7 +728,11 @@ ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoProcessStartInf
 	free_shell_path = FALSE;
 	if (cmd) {
 		gchar *newcmd, *tmp;
-		tmp = mono_string_to_utf8 (cmd);
+		tmp = mono_string_to_utf8_checked (cmd, &error);
+		if (mono_error_set_pending_exception (&error)) {
+			g_free (spath);
+			return NULL;
+		}
 		newcmd = g_strdup_printf ("%s %s", spath, tmp);
 		cmd = mono_string_new_wrapper (newcmd);
 		g_free (tmp);

--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -2647,12 +2647,15 @@ get_addrinfo_family_hint (MonoError *error)
 MonoBoolean
 ves_icall_System_Net_Dns_GetHostByName_internal (MonoString *host, MonoString **h_name, MonoArray **h_aliases, MonoArray **h_addr_list)
 {
+	MonoError error;
 	gboolean add_local_ips = FALSE, add_info_ok = TRUE;
 	gchar this_hostname [256];
 	MonoAddressInfo *info = NULL;
-	char *hostname = mono_string_to_utf8 (host);
-	MonoError error;
 	int hint;
+
+	char *hostname = mono_string_to_utf8_checked (host, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
 
 	hint = get_addrinfo_family_hint (&error);
 	if (!mono_error_ok (&error)) {
@@ -2697,7 +2700,9 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 	gchar hostname [NI_MAXHOST] = { 0 };
 	gboolean ret;
 
-	address = mono_string_to_utf8 (addr);
+	address = mono_string_to_utf8_checked (addr, &error);
+	if (mono_error_set_pending_exception (&error))
+		return FALSE;
 
 	if (inet_pton (AF_INET, address, &saddr.sin_addr ) == 1) {
 		family = AF_INET;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1386,7 +1386,8 @@ mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, g
 	UNLOCK_THREAD (this_obj);
 
 	if (this_obj->name && this_obj->tid) {
-		char *tname = mono_string_to_utf8 (name);
+		char *tname = mono_string_to_utf8_checked (name, error);
+		return_if_nok (error);
 		mono_profiler_thread_name (this_obj->tid, tname);
 		mono_native_thread_set_name (thread_get_tid (this_obj), tname);
 		mono_free (tname);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6834,7 +6834,8 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			MONO_INST_NEW (cfg, ins, OP_OBJC_GET_SELECTOR);
 			ins->dreg = mono_alloc_ireg (cfg);
 			// FIXME: Leaks
-			ins->inst_p0 = mono_string_to_utf8 (s);
+			ins->inst_p0 = mono_string_to_utf8_checked (s, &cfg->error);
+			return_val_if_nok (&cfg->error, NULL);
 			MONO_ADD_INS (cfg->cbb, ins);
 			return ins;
 		}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1697,7 +1697,15 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 				mono_error_assert_ok (&error);
 			}
 			if (msg == NULL) {
-				msg = message ? mono_string_to_utf8 ((MonoString *) message) : g_strdup ("(System.Exception.Message property not available)");
+				if (message) {
+					msg = mono_string_to_utf8_checked ((MonoString *) message, &error);
+					if (!is_ok (&error)) {
+						mono_error_cleanup (&error);
+						msg = g_strdup ("(error while display System.Exception.Message property)");
+					}
+				} else {
+					msg = g_strdup ("(System.Exception.Message property not available)");
+				}
 			}
 			g_print ("[%p:] EXCEPTION handling: %s.%s: %s\n", (void*)mono_native_thread_id_get (), mono_object_class (obj)->name_space, mono_object_class (obj)->name, msg);
 			g_free (msg);
@@ -2831,8 +2839,14 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 		MonoString *str = mono_object_to_string (exc, &other);
 		char *msg = NULL;
 		
-		if (str)
-			msg = mono_string_to_utf8 (str);
+		if (str) {
+			MonoError inner_error;
+			msg = mono_string_to_utf8_checked (str, &inner_error);
+			if (!is_ok (&inner_error)) {
+				msg = g_strdup_printf ("Nested exception while formatting original exception");
+				mono_error_cleanup (&inner_error);
+			}
+		}
 		else if (other) {
 			char *original_backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
 			char *nested_backtrace = mono_exception_get_managed_backtrace ((MonoException*)other);

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -765,6 +765,19 @@ cvtMonoType(MonoTypeEnum t)
 /*		                               			    */
 /*------------------------------------------------------------------*/
 
+static void
+decodeParmString (MonoString *s)
+{
+	char *str = mono_string_to_utf8(s, &error);
+	if (is_ok (&error))  {
+		printf("[STRING:%p:%s], ", s, str);
+		g_free (str);
+	} else {
+		mono_error_cleanup (&error);
+		printf("[STRING:%p:], ", s);
+	}
+}
+
 static void 
 decodeParm(MonoType *type, void *curParm, int size)
 {
@@ -813,7 +826,7 @@ enum_parmtype:
 				MonoString *s = *((MonoString **) curParm);
 				if (s) {
 					g_assert (((MonoObject *) s)->vtable->klass == mono_defaults.string_class);
-					printf("[STRING:%p:%s], ", s, mono_string_to_utf8(s));
+					decodeParmString (s);
 				} else {
 					printf("[STRING:null], ");
 				}
@@ -828,8 +841,7 @@ enum_parmtype:
 					klass = obj->vtable->klass;
 					printf("%p [%p] ",obj,curParm);
 					if (klass == mono_defaults.string_class) {
-						printf("[STRING:%p:%s]", 
-						       obj, mono_string_to_utf8 ((MonoString *) obj));
+						decodeParmString ((MonoString *)obj);
 					} else if (klass == mono_defaults.int32_class) { 
 						printf("[INT32:%p:%d]", 
 							obj, *(gint32 *)((char *)obj + sizeof (MonoObject)));
@@ -969,8 +981,8 @@ enter_method (MonoMethod *method, RegParm *rParm, char *sp)
 				if (obj->vtable) {
 					klass = obj->vtable->klass;
 					if (klass == mono_defaults.string_class) {
-						printf ("this:[STRING:%p:%s], ", 
-							obj, mono_string_to_utf8 ((MonoString *)obj));
+						printf ("this:");
+						decodeParmString((MonoString *)obj);
 					} else {
 						printf ("this:%p[%s.%s], ", 
 							obj, klass->name_space, klass->name);
@@ -1126,7 +1138,7 @@ handle_enum:
 ;
 		if (s) {
 			g_assert (((MonoObject *)s)->vtable->klass == mono_defaults.string_class);
-			printf ("[STRING:%p:%s]", s, mono_string_to_utf8 (s));
+			decodeParmString (s);
 		} else 
 			printf ("[STRING:null], ");
 		break;

--- a/mono/profiler/mono-profiler-iomap.c
+++ b/mono/profiler/mono-profiler-iomap.c
@@ -203,7 +203,8 @@ static inline void print_report (const gchar *format, ...)
 	prop = mono_class_get_property_from_name (klass, "StackTrace");
 	str = (MonoString*)mono_property_get_value_checked (prop, NULL, NULL, &error);
 	mono_error_assert_ok (&error);
-	stack_trace = mono_string_to_utf8 (str);
+	stack_trace = mono_string_to_utf8_checked (str, &error);
+	mono_error_assert_ok (&error);
 
 	fprintf (stdout, "-= Stack Trace =-\n%s\n\n", stack_trace);
 	g_free (stack_trace);
@@ -223,6 +224,7 @@ static inline void append_report (GString **report, const gchar *format, ...)
 
 static gboolean saved_strings_find_func (gpointer key, gpointer value, gpointer user_data)
 {
+	MonoError error;
 	SavedStringFindInfo *info = (SavedStringFindInfo*)user_data;
 	SavedString *saved = (SavedString*)value;
 	gchar *utf_str;
@@ -231,7 +233,8 @@ static gboolean saved_strings_find_func (gpointer key, gpointer value, gpointer 
 	if (!info || !saved || mono_string_length (saved->string) != info->len)
 		return FALSE;
 
-	utf_str = mono_string_to_utf8 (saved->string);
+	utf_str = mono_string_to_utf8_checked (saved->string, &error);
+	mono_error_assert_ok (&error);
 	hash = do_calc_string_hash (0, utf_str);
 	g_free (utf_str);
 

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -992,9 +992,11 @@ check_reference_for_xdomain (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 			break;
 	}
 
-	if (ref->vtable->klass == mono_defaults.string_class)
-		str = mono_string_to_utf8 ((MonoString*)ref);
-	else
+	if (ref->vtable->klass == mono_defaults.string_class) {
+		MonoError error;
+		str = mono_string_to_utf8_checked ((MonoString*)ref, &error);
+		mono_error_cleanup (&error);
+	} else
 		str = NULL;
 	g_print ("xdomain reference in %p (%s.%s) at offset %d (%s) to %p (%s.%s) (%s)  -  pointed to by:\n",
 			obj, obj->vtable->klass->name_space, obj->vtable->klass->name,


### PR DESCRIPTION
Runtime should use mono_string_to_utf8_checked.