### PR TITLE
Revert "[aot] Avoid raising exceptions in the AOT runtime."

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4320,10 +4320,8 @@ set_bp_in_method (MonoDomain *domain, MonoMethod *method, MonoSeqPointInfo *seq_
 
 	code = mono_jit_find_compiled_method_with_jit_info (domain, method, &ji);
 	if (!code) {
-		MonoError error;
-
 		/* Might be AOTed code */
-		code = mono_aot_get_method_checked (domain, method, &error);
+		code = mono_aot_get_method (domain, method);
 		g_assert (code);
 		ji = mono_jit_info_table_find (domain, (char *)code);
 		g_assert (ji);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -399,7 +399,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 				if (verbose >= 2)
 					g_print ("Running '%s' ...\n", method->name);
 #ifdef MONO_USE_AOT_COMPILER
-				if ((func = (TestMethod)mono_aot_get_method_checked (mono_get_root_domain (), method, &error)))
+				if ((func = (TestMethod)mono_aot_get_method (mono_get_root_domain (), method)))
 					;
 				else
 #endif

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1576,8 +1576,7 @@ resolve_vcall (MonoVTable *vt, int slot, MonoMethod *imt_method, gpointer *out_a
 	/* Same as in common_call_trampoline () */
 
 	/* Avoid loading metadata or creating a generic vtable if possible */
-	addr = mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, slot, &error);
-	mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+	addr = mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, slot);
 	if (addr && !vt->klass->valuetype)
 		return mono_create_ftnptr (mono_domain_get (), addr);
 

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -88,7 +88,7 @@ MONO_API char*       mono_get_runtime_build_info    (void);
 MONO_API MonoJitInfo *
 mono_get_jit_info_from_method (MonoDomain *domain, MonoMethod *method);
 
-MONO_RT_EXTERNAL_ONLY MONO_API void *
+MONO_API void *
 mono_aot_get_method (MonoDomain *domain, MonoMethod *method);
 
 MONO_END_DECLS

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -203,14 +203,11 @@ mini_resolve_imt_method (MonoVTable *vt, gpointer *vtable_slot, MonoMethod *imt_
 		impl = mono_class_inflate_generic_method_checked (impl, &context, &error);
 		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 	} else {
-		MonoError error;
 		/* Avoid loading metadata or creating a generic vtable if possible */
-		if (lookup_aot && !vt->klass->valuetype) {
-			aot_addr = (guint8 *)mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, interface_offset + mono_method_get_vtable_slot (imt_method), &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
-		} else {
+		if (lookup_aot && !vt->klass->valuetype)
+			aot_addr = (guint8 *)mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, interface_offset + mono_method_get_vtable_slot (imt_method));
+		else
 			aot_addr = NULL;
-		}
 		if (aot_addr)
 			impl = NULL;
 		else
@@ -873,11 +870,7 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 		vtable_slot = &(vt->vtable [slot]);
 
 		/* Avoid loading metadata or creating a generic vtable if possible */
-		addr = mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, slot, &error);
-		if (!is_ok (&error)) {
-			mono_error_set_pending_exception (&error);
-			return NULL;
-		}
+		addr = mono_aot_get_method_from_vt_slot (mono_domain_get (), vt, slot);
 		if (addr && !vt->klass->valuetype) {
 			if (mono_domain_owns_vtable_slot (mono_domain_get (), vtable_slot))
 				*vtable_slot = addr;
@@ -975,7 +968,6 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
 	MonoMethod *method = NULL;
 	gpointer addr;
 	guint8 *plt_entry;
-	MonoError error;
 
 	trampoline_calls ++;
 
@@ -983,13 +975,12 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
 	token_info += sizeof (gpointer);
 	token = *(guint32*)(gpointer)token_info;
 
-	addr = mono_aot_get_method_from_token (mono_domain_get (), image, token, &error);
+	addr = mono_aot_get_method_from_token (mono_domain_get (), image, token);
 	if (!addr) {
-		if (!is_ok (&error))
-			g_error ("Could not load AOT method due to %s", mono_error_get_message (&error));
+		MonoError error;
 		method = mono_get_method_checked (image, token, NULL, NULL, &error);
 		if (!method)
-			g_error ("Could not load AOT method due to %s", mono_error_get_message (&error));
+			g_error ("Could not load AOT trampoline due to %s", mono_error_get_message (&error));
 
 		/* Use the generic code */
 		return mono_magic_trampoline (regs, code, method, tramp);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2455,9 +2455,11 @@ jinfo_get_method (MonoJitInfo *ji)
 /* AOT */
 void      mono_aot_init                     (void);
 void      mono_aot_cleanup                  (void);
+gpointer  mono_aot_get_method               (MonoDomain *domain,
+											 MonoMethod *method);
 gpointer  mono_aot_get_method_checked       (MonoDomain *domain,
 											 MonoMethod *method, MonoError *error);
-gpointer  mono_aot_get_method_from_token    (MonoDomain *domain, MonoImage *image, guint32 token, MonoError *error);
+gpointer  mono_aot_get_method_from_token    (MonoDomain *domain, MonoImage *image, guint32 token);
 gboolean  mono_aot_is_got_entry             (guint8 *code, guint8 *addr);
 guint8*   mono_aot_get_plt_entry            (guint8 *code);
 guint32   mono_aot_get_plt_info_offset      (mgreg_t *regs, guint8 *code);
@@ -2466,7 +2468,7 @@ gboolean  mono_aot_get_class_from_name      (MonoImage *image, const char *name_
 MonoJitInfo* mono_aot_find_jit_info         (MonoDomain *domain, MonoImage *image, gpointer addr);
 gpointer mono_aot_plt_resolve               (gpointer aot_module, guint32 plt_info_offset, guint8 *code, MonoError *error);
 void     mono_aot_patch_plt_entry           (guint8 *code, guint8 *plt_entry, gpointer *got, mgreg_t *regs, guint8 *addr);
-gpointer mono_aot_get_method_from_vt_slot   (MonoDomain *domain, MonoVTable *vtable, int slot, MonoError *error);
+gpointer mono_aot_get_method_from_vt_slot   (MonoDomain *domain, MonoVTable *vtable, int slot);
 gpointer mono_aot_create_specific_trampoline   (MonoImage *image, gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, guint32 *code_len);
 gpointer mono_aot_get_trampoline            (const char *name);
 gpointer mono_aot_get_trampoline_full       (const char *name, MonoTrampInfo **out_tinfo);


### PR DESCRIPTION
Reverts mono/mono#3043 as it causes a lot of test failures: https://jenkins.mono-project.com/job/test-mono-mainline-linux/label=ubuntu-1404-amd64/138/

/cc @vargaz