### PR TITLE
[runtime] Disallow unintended reuse of MonoError after mono_error_cleanup

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -457,6 +457,7 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 			MonoException *exc_to_store = mono_error_convert_to_exception (error);
 			/* What we really want to do here is clone the error object and store one copy in the
 			 * domain's exception hash and use the other one to error out here. */
+			mono_error_init (error);
 			mono_error_set_exception_instance (error, exc_to_store);
 			/*
 			 * Store the exception object so it could be thrown on subsequent

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1551,6 +1551,8 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, MonoObject *obj, gi
 					}
 				}
 
+				MonoError isinst_error;
+				mono_error_init (&isinst_error);
 				if (ei->flags == MONO_EXCEPTION_CLAUSE_NONE && mono_object_isinst_checked (ex_obj, catch_class, &error)) {
 					setup_stack_trace (mono_ex, dynamic_methods, initial_trace_ips, &trace_ips);
 					g_slist_free (dynamic_methods);
@@ -1562,7 +1564,7 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, MonoObject *obj, gi
 					MONO_CONTEXT_SET_IP (ctx, ei->handler_start);
 					return TRUE;
 				}
-				mono_error_cleanup (&error);
+				mono_error_cleanup (&isinst_error);
 			}
 		}
 

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -39,6 +39,8 @@ is_managed_exception (MonoErrorInternal *error)
 static void
 mono_error_prepare (MonoErrorInternal *error)
 {
+	/* mono_error_set_* after a mono_error_cleanup without an intervening init */
+	g_assert (error->error_code != MONO_ERROR_CLEANUP_CALLED_SENTINEL);
 	if (error->error_code != MONO_ERROR_NONE)
 		return;
 
@@ -106,15 +108,30 @@ void
 mono_error_cleanup (MonoError *oerror)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
-	if (error->error_code == MONO_ERROR_NONE)
+	short int orig_error_code = error->error_code;
+	gboolean free_strings = error->flags & MONO_ERROR_FREE_STRINGS;
+	gboolean has_instance_handle = is_managed_exception (error);
+
+	/* Two cleanups in a row without an intervening init. */
+	g_assert (orig_error_code != MONO_ERROR_CLEANUP_CALLED_SENTINEL);
+
+	/* Mark it as cleaned up. */
+	error->error_code = MONO_ERROR_CLEANUP_CALLED_SENTINEL;
+	error->flags = 0;
+
+	if (orig_error_code == MONO_ERROR_NONE)
 		return;
 
-	if (is_managed_exception (error))
+
+	if (has_instance_handle)
 		mono_gchandle_free (error->exn.instance_handle);
+
 
 	g_free ((char*)error->full_message);
 	g_free ((char*)error->full_message_with_fields);
-	if (!(error->flags & MONO_ERROR_FREE_STRINGS)) //no memory was allocated
+	error->full_message = NULL;
+	error->full_message_with_fields = NULL;
+	if (!free_strings) //no memory was allocated
 		return;
 
 	g_free ((char*)error->type_name);
@@ -123,6 +140,9 @@ mono_error_cleanup (MonoError *oerror)
 	g_free ((char*)error->exception_name_space);
 	g_free ((char*)error->exception_name);
 	g_free ((char*)error->first_argument);
+	error->type_name = error->assembly_name = error->member_name = error->exception_name_space = error->exception_name = error->first_argument = NULL;
+	error->exn.klass = NULL;
+
 }
 
 gboolean
@@ -664,6 +684,9 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 		exception = (MonoException*) mono_gchandle_get_target (error->exn.instance_handle);
 		break;
 
+	case MONO_ERROR_CLEANUP_CALLED_SENTINEL:
+		mono_error_set_execution_engine (error_out, "MonoError reused after mono_error_cleanup");
+		break;
 	default:
 		mono_error_set_execution_engine (error_out, "Invalid error-code %d", error->error_code);
 	}

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -32,7 +32,10 @@ enum {
 	 */
 	MONO_ERROR_GENERIC = 9,
 	/* This one encapsulates a managed exception instance */
-	MONO_ERROR_EXCEPTION_INSTANCE = 10
+	MONO_ERROR_EXCEPTION_INSTANCE = 10,
+
+	/* Not a valid error code - indicates that the error was cleaned up and reused */
+	MONO_ERROR_CLEANUP_CALLED_SENTINEL = 0xffff
 };
 
 /*Keep in sync with MonoErrorInternal*/


### PR DESCRIPTION
MonoError must be explicitly reinitialized if it is used again after
mono_error_cleanup.  But it is better to introduce an explicit inner
MonoError when possible.