### PR TITLE
[jenkins] Include PR number in version.h if PR builder env is set

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -826,7 +826,11 @@ version.h: Makefile
 	if test -d $(top_srcdir)/.git; then \
 		(cd $(top_srcdir); \
 			LANG=C; export LANG; \
-			branch=`git branch | grep '^\*' | sed 's/(detached from .*/explicit/' | cut -d ' ' -f 2`; \
+			if test -z "$$ghprbPullId"; then \
+				branch=`git branch | grep '^\*' | sed 's/(detached from .*/explicit/' | cut -d ' ' -f 2`; \
+			else \
+				branch="pull-request-$$ghprbPullId"; \
+			fi; \
 			version=`git log --no-color --first-parent -n1 --pretty=format:%h`; \
 			echo "#define FULL_VERSION \"$$branch/$$version\""; \
 		); \


### PR DESCRIPTION
A while ago, we switched our PR builders from using the Github-provided PR branch head (i.e. `pull/merge/XXXX`) to the exact sha1 of the latest commit on the PR (i.e. `abcdefabc`). This change was needed for the performance team, otherwise the changes they wanted to test would be rebased against a new master several times per day, breaking their ability to meaningfully track the changes in a PR.

As a side effect of this, `version.h` went from setting the version from `XXXX/abcdefabc` to `explicit/abcdefabc`, and the Jenkins PR packages use the branch name `explicit` instead of the actual PR number `XXXX`, which is pretty bad from a UX perspective.

This change checks for the `ghprbPullId` environment variable and uses it instead of the actual branch name or `explicit` - it is always set on PR builds.