### PR TITLE
[win32_threads] Mark an inline function as static.

### DIFF
--- a/libgc/win32_threads.c
+++ b/libgc/win32_threads.c
@@ -184,7 +184,7 @@ static GC_thread GC_new_thread(void) {
 #ifdef __GNUC__
 __inline__
 #endif
-LONG GC_get_max_thread_index()
+static LONG GC_get_max_thread_index()
 {
   LONG my_max = GC_max_thread_index;
 


### PR DESCRIPTION
If the C compiler decides not to inline the function, and it's not declared
static, it'll look for an extern version, and linking will fail.