### PR TITLE
[runtime] Deal with MonoErrors from string_to_utf8_checked changes

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2920,7 +2920,9 @@ mono_assembly_apply_binding (MonoAssemblyName *aname, MonoAssemblyName *dest_nam
 		mono_domain_lock (domain);
 		if (!domain->assembly_bindings_parsed) {
 			gchar *domain_config_file_name = mono_string_to_utf8_checked (domain->setup->configuration_file, &error);
-			mono_error_raise_exception (&error); /* FIXME don't raise here */
+			/* expect this to succeed because mono_domain_set_options_from_config () did
+			 * the same thing when the domain was created. */
+			mono_error_assert_ok (&error);
 
 			gchar *domain_config_file_path = mono_portability_find_file (domain_config_file_name, TRUE);
 

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -928,14 +928,18 @@ mono_object_describe (MonoObject *obj)
 	klass = mono_object_class (obj);
 	if (klass == mono_defaults.string_class) {
 		char *utf8 = mono_string_to_utf8_checked ((MonoString*)obj, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
-		if (strlen (utf8) > 60) {
+		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		if (utf8 && strlen (utf8) > 60) {
 			utf8 [57] = '.';
 			utf8 [58] = '.';
 			utf8 [59] = '.';
 			utf8 [60] = 0;
 		}
-		g_print ("String at %p, length: %d, '%s'\n", obj, mono_string_length ((MonoString*) obj), utf8);
+		if (utf8) {
+			g_print ("String at %p, length: %d, '%s'\n", obj, mono_string_length ((MonoString*) obj), utf8);
+		} else {
+			g_print ("String at %p, length: %d, unable to decode UTF16\n", obj, mono_string_length ((MonoString*) obj));
+		}
 		g_free (utf8);
 	} else if (klass->rank) {
 		MonoArray *array = (MonoArray*)obj;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7549,6 +7549,7 @@ ves_icall_System_Configuration_DefaultConfig_get_machine_config_path (void)
 	return mcpath;
 }
 
+/* this is an icall */
 static MonoString *
 get_bundled_app_config (void)
 {
@@ -7567,7 +7568,8 @@ get_bundled_app_config (void)
 
 	// Retrieve config file and remove the extension
 	config_file_name = mono_string_to_utf8_checked (file, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 	config_file_path = mono_portability_find_file (config_file_name, TRUE);
 	if (!config_file_path)
 		config_file_path = config_file_name;


### PR DESCRIPTION
When we switched to use `mono_string_to_utf8_checked` in the runtime, there were several new instances of `mono_error_raise_exception`.  This PR addresses most of them.