### PR TITLE
[man] bump man's mono version number too (to 4.5.2)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 #AC_PREREQ([2.62])
 
+# when bumping version number below, keep it in sync with man/mono.1 too
 AC_INIT(mono, [4.5.2],
         [http://bugzilla.xamarin.com/enter_bug.cgi?classification=Mono])
 

--- a/man/mono.1
+++ b/man/mono.1
@@ -7,7 +7,7 @@
 .\" Author:
 .\"   Miguel de Icaza (miguel@gnu.org)
 .\"
-.TH Mono "Mono 3.0"
+.TH Mono "Mono 4.5.2"
 .SH NAME
 mono \- Mono's ECMA-CLI native code generator (Just-in-Time and Ahead-of-Time)
 .SH SYNOPSIS


### PR DESCRIPTION
Following this version bump:
https://github.com/mono/mono/commit/069cea3712a5bd4959e505260cdc4a0c37861e77

(Also add a note to configure.ac as a hint until
someone comes up with a way to sync man/mono.1's
version automatically.)