### PR TITLE
[WindowsBase] Fix off-by-one error in ZipTime

### DIFF
--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackageTest.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackageTest.cs
@@ -432,7 +432,11 @@ namespace MonoTests.System.IO.Packaging {
             using (var archive = new ZipArchive(stream))
             {                
                 foreach (var entry in archive.Entries)
+                {
                     Assert.AreEqual (DateTime.Now.Year, entry.LastWriteTime.Year);
+                    Assert.AreEqual (DateTime.Now.Month, entry.LastWriteTime.Month);
+                    Assert.AreEqual (DateTime.Now.Day, entry.LastWriteTime.Day);
+                }
             }
         }           
     }

--- a/mcs/class/WindowsBase/ZipSharp/ZipTime.cs
+++ b/mcs/class/WindowsBase/ZipSharp/ZipTime.cs
@@ -25,13 +25,13 @@ namespace zipsharp
 			minute = (uint) time.Minute;
 			hour = (uint) time.Hour;
 			day = (uint) time.Day;
-			month = (uint) time.Month;
+			month = (uint) time.Month - 1;
 			year = (uint) time.Year;
 		}
 
 		public DateTime Date
 		{
-			get { return new DateTime ((int) year, (int) month, (int) day, (int) hour, (int) minute, (int) second); }
+			get { return new DateTime ((int) year, (int) month + 1, (int) day, (int) hour, (int) minute, (int) second); }
 		}
 	}
 }


### PR DESCRIPTION
The date/time struct in zip.h defines the month value as

    uInt tm_mon;            /* months since January - [0,11] */

.NET's DateTime struct in turn stores months from 1-12. We didn't take this into account when passing the values from managed->native so the month ended up being off by one.

We didn't use this codepath before https://github.com/mono/mono/pull/3036 that's why it didn't show up until now.

@monojenkins merge