### PR TITLE
[System] Fixes socket async exception.

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -4289,7 +4289,22 @@ namespace MonoTests.System.Net.Sockets
 		[Test]
 		public void SendAsyncFile ()
 		{
-			Socket serverSocket = StartSocketServer ();
+			Socket serverSocket = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+			serverSocket.Bind (new IPEndPoint (IPAddress.Loopback, 0));
+			serverSocket.Listen (1);
+
+			var mReceived = new ManualResetEvent (false);
+
+			serverSocket.BeginAccept (AsyncCall => {
+				byte[] bytes = new byte [1024];
+
+				Socket listener = (Socket)AsyncCall.AsyncState;
+				Socket client = listener.EndAccept (AsyncCall);
+				client.Receive (bytes, bytes.Length, 0);
+				client.Close ();
+				mReceived.Set ();
+			}, serverSocket);
 			
 			Socket clientSocket = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 			clientSocket.Connect (serverSocket.LocalEndPoint);
@@ -4307,18 +4322,19 @@ namespace MonoTests.System.Net.Sockets
 					sw.Write (buffer);
 				}
 
-				var m = new ManualResetEvent (false);
+				var mSent = new ManualResetEvent (false);
 
 				// Async Send File to server
 				clientSocket.BeginSendFile(temp, (ar) => {
 					Socket client = (Socket) ar.AsyncState;
 					client.EndSendFile (ar);
-					m.Set ();
+					mSent.Set ();
 				}, clientSocket);
 
-				if (!m.WaitOne (1500))
+				if (!mSent.WaitOne (1500))
 					throw new TimeoutException ();
-				m.Reset ();
+				if (!mReceived.WaitOne (1500))
+					throw new TimeoutException ();
 			} finally {
 				if (File.Exists (temp))
 					File.Delete (temp);
@@ -4376,30 +4392,6 @@ namespace MonoTests.System.Net.Sockets
 				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#2");
 				client.Disconnect (true);
 			}
-		}
-
-		Socket StartSocketServer ()
-		{
-
-			Socket listenSocket = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-			
-			listenSocket.Bind (new IPEndPoint (IPAddress.Loopback, 0));
-			listenSocket.Listen (1);
-
-			listenSocket.BeginAccept (new AsyncCallback (ReceiveCallback), listenSocket);
-			
-			return listenSocket;
-		}
-
-		public static void ReceiveCallback (IAsyncResult AsyncCall)
-		{
-			byte[] bytes = new byte [1024];
-
-			Socket listener = (Socket)AsyncCall.AsyncState;
-			Socket client = listener.EndAccept (AsyncCall);
- 
-			client.Receive (bytes, bytes.Length, 0);
-			client.Close ();
 		}
 
 		[Test]


### PR DESCRIPTION
SendAsyncFile uses StartSocketServer to start a server and at the same
time begins to accept a client socket. The issue is that when
the accept callback is called SendAsyncFile already closed the socket.

Fixed race condition by moving StartSocketServer and ReceiveCallback
logic into SendAsyncFile, and by using a new MRE to ensure that the
client receives all the data before the server is closed.

Fixes [#41264](https://bugzilla.xamarin.com/show_bug.cgi?id=41264)