### PR TITLE
[runtime] Set klass-error-based MonoError state without allocating

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1443,6 +1443,9 @@ mono_class_load_from_name (MonoImage *image, const char* name_space, const char 
 MonoClass*
 mono_class_try_load_from_name (MonoImage *image, const char* name_space, const char *name);
 
+void
+mono_error_set_for_class_failure (MonoError *orerror, MonoClass *klass);
+
 static inline guint8
 mono_class_get_failure (MonoClass *klass)
 {

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1369,6 +1369,53 @@ mono_type_has_exceptions (MonoType *type)
 	}
 }
 
+void
+mono_error_set_for_class_failure (MonoError *oerror, MonoClass *klass)
+{
+	gpointer exception_data = mono_class_get_exception_data (klass);
+
+	switch (mono_class_get_failure(klass)) {
+	case MONO_EXCEPTION_TYPE_LOAD: {
+		mono_error_set_type_load_class (oerror, klass, "Error Loading class");
+		return;
+	}
+	case MONO_EXCEPTION_MISSING_METHOD: {
+		char *class_name = (char *)exception_data;
+		char *member_name = class_name + strlen (class_name) + 1;
+
+		mono_error_set_method_load (oerror, klass, member_name, "Error Loading Method");
+		return;
+	}
+	case MONO_EXCEPTION_MISSING_FIELD: {
+		char *class_name = (char *)exception_data;
+		char *member_name = class_name + strlen (class_name) + 1;
+
+		mono_error_set_field_load (oerror, klass, member_name, "Error Loading Field");
+		return;
+	}
+	case MONO_EXCEPTION_FILE_NOT_FOUND: {
+		char *msg_format = (char *)exception_data;
+		char *assembly_name = msg_format + strlen (msg_format) + 1;
+		char *msg = g_strdup_printf (msg_format, assembly_name);
+
+		mono_error_set_assembly_load (oerror, assembly_name, msg);
+		return;
+	}
+	case MONO_EXCEPTION_BAD_IMAGE: {
+		mono_error_set_bad_image (oerror, NULL, (const char *)exception_data);
+		return;
+	}
+	case MONO_EXCEPTION_INVALID_PROGRAM: {
+		mono_error_set_invalid_program (oerror, (const char *)exception_data);
+		return;
+	}
+	default: {
+		g_assert_not_reached ();
+	}
+	}
+}
+
+
 /*
  * mono_class_alloc:
  *

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -133,7 +133,7 @@ mono_class_init_checked (MonoClass *klass, MonoError *error)
 	mono_error_init (error);
 
 	if (!mono_class_init (klass))
-		mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (klass));
+		mono_error_set_for_class_failure (error, klass);
 }
 
 ICALL_EXPORT MonoObject *
@@ -4320,9 +4320,8 @@ handle_parent:
 
 
 loader_error:
-	if (mono_class_has_failure (klass)) {
-		mono_error_set_exception_instance (&error, mono_class_get_exception_for_failure (klass));
-	}
+	if (mono_class_has_failure (klass))
+		mono_error_set_for_class_failure (&error, klass);
 
 failure:
 	if (properties)
@@ -4469,9 +4468,8 @@ handle_parent:
 	return res;
 
 loader_error:
-	if (mono_class_has_failure (klass)) {
-		mono_error_set_exception_instance (&error, mono_class_get_exception_for_failure (klass));
-	}
+	if (mono_class_has_failure (klass))
+		mono_error_set_for_class_failure (&error, klass);
 
 failure:
 	

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1905,7 +1905,7 @@ mono_class_vtable_full (MonoDomain *domain, MonoClass *klass, MonoError *error)
 	g_assert (klass);
 
 	if (mono_class_has_failure (klass)) {
-		mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (klass));
+		mono_error_set_for_class_failure (error, klass);
 		return NULL;
 	}
 
@@ -1992,7 +1992,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 		if (!mono_class_init (klass) || mono_class_has_failure (klass)) {
 			mono_domain_unlock (domain);
 			mono_loader_unlock ();
-			mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (klass));
+			mono_error_set_for_class_failure (error, klass);
 			return NULL;
 		}
 	}
@@ -2013,7 +2013,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 				mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
 			mono_domain_unlock (domain);
 			mono_loader_unlock ();
-			mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (klass));
+			mono_error_set_for_class_failure (error, klass);
 			return NULL;
 		}
 	}
@@ -2034,7 +2034,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 	if (mono_class_has_failure (klass)) {
 		mono_domain_unlock (domain);
 		mono_loader_unlock ();
-		mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (klass));
+		mono_error_set_for_class_failure (error, klass);
 		return NULL;
 	}
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -8989,7 +8989,7 @@ mono_reflection_get_token_checked (MonoObject *obj, MonoError *error)
 		return_val_if_nok (error, 0);
 		MonoClass *mc = mono_class_from_mono_type (type);
 		if (!mono_class_init (mc)) {
-			mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (mc));
+			mono_error_set_for_class_failure (error, mc);
 			return 0;
 		}
 
@@ -9818,7 +9818,7 @@ reflection_resolve_custom_attribute_data (MonoReflectionMethod *ref_method, Mono
 	domain = mono_object_domain (ref_method);
 
 	if (!mono_class_init (method->klass)) {
-		mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (method->klass));
+		mono_error_set_for_class_failure (error, method->klass);
 		goto leave;
 	}
 
@@ -13952,7 +13952,7 @@ resolve_object (MonoImage *image, MonoObject *obj, MonoClass **handle_class, Mon
 		return_val_if_nok (error, NULL);
 		MonoClass *mc = mono_class_from_mono_type (type);
 		if (!mono_class_init (mc)) {
-			mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (mc));
+			mono_error_set_for_class_failure (error, mc);
 			return NULL;
 		}
 

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -862,7 +862,7 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 	case MONO_RGCTX_INFO_STATIC_DATA: {
 		MonoVTable *vtable = mono_class_vtable (domain, klass);
 		if (!vtable) {
-			mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (klass));
+			mono_error_set_for_class_failure (error, klass);
 			return NULL;
 		}
 		return mono_vtable_get_static_field_data (vtable);
@@ -874,7 +874,7 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 	case MONO_RGCTX_INFO_VTABLE: {
 		MonoVTable *vtable = mono_class_vtable (domain, klass);
 		if (!vtable) {
-			mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (klass));
+			mono_error_set_for_class_failure (error, klass);
 			return NULL;
 		}
 		return vtable;
@@ -1704,7 +1704,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 
 		vtable = mono_class_vtable (domain, method->method.method.klass);
 		if (!vtable) {
-			mono_error_set_exception_instance (error, mono_class_get_exception_for_failure (method->method.method.klass));
+			mono_error_set_for_class_failure (error, method->method.method.klass);
 			return NULL;
 		}
 

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -113,6 +113,9 @@ mono_error_set_invalid_operation (MonoError *error, const char *msg_format, ...)
 void
 mono_error_set_exception_instance (MonoError *error, MonoException *exc);
 
+void
+mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...);
+
 MonoException*
 mono_error_prepare_exception (MonoError *error, MonoError *error_out);
 

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -441,6 +441,17 @@ mono_error_set_invalid_operation (MonoError *oerror, const char *msg_format, ...
 }
 
 void
+mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...)
+{
+	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
+
+	mono_error_prepare (error);
+	error->error_code = MONO_ERROR_INVALID_PROGRAM;
+
+	set_error_message ();
+}
+
+void
 mono_error_set_exception_instance (MonoError *oerror, MonoException *exc)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
@@ -687,6 +698,14 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 	case MONO_ERROR_CLEANUP_CALLED_SENTINEL:
 		mono_error_set_execution_engine (error_out, "MonoError reused after mono_error_cleanup");
 		break;
+
+	case MONO_ERROR_INVALID_PROGRAM: {
+		gboolean lacks_message = error->flags & MONO_ERROR_INCOMPLETE;
+		if (lacks_message)
+			return mono_exception_from_name_msg (mono_defaults.corlib, "System", "InvalidProgramException", "");
+		else
+			return mono_exception_from_name_msg (mono_defaults.corlib, "System", "InvalidProgramException", error->full_message);
+	}
 	default:
 		mono_error_set_execution_engine (error_out, "Invalid error-code %d", error->error_code);
 	}

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -26,6 +26,8 @@ enum {
 	MONO_ERROR_ARGUMENT = 7,
 	MONO_ERROR_ARGUMENT_NULL = 11,
 	MONO_ERROR_NOT_VERIFIABLE = 8,
+	MONO_ERROR_INVALID_PROGRAM = 12,
+
 	/*
 	 * This is a generic error mechanism is you need to raise an arbitrary corlib exception.
 	 * You must pass the exception name otherwise prepare_exception will fail with internal execution. 


### PR DESCRIPTION
We were seeing an issue where attempts to create the MonoClass for an
exception in a no-exec context was causing failure. No-exec will forbid
the constructor call. Our solution was to realize that there was no
need to allocate an exception, as MonoError could already encode the
errors.