### PR TITLE
[sgen] Remove a pointless memory barrier from the middle of the managed allocator.

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1320,11 +1320,6 @@ create_allocator (int atype, gboolean slowpath)
 	mono_mb_emit_ldloc (mb, new_next_var);
 	mono_mb_emit_byte (mb, CEE_STIND_I);
 
-	/*The tlab store must be visible before the the vtable store. This could be replaced with a DDS but doing it with IL would be tricky. */
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_MEMORY_BARRIER);
-	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_REL);
-
 	/* *p = vtable; */
 	mono_mb_emit_ldloc (mb, p_var);
 	mono_mb_emit_ldarg (mb, 0);

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -197,11 +197,6 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 		if (G_LIKELY (new_next < TLAB_TEMP_END)) {
 			/* Fast path */
 
-			/* 
-			 * FIXME: We might need a memory barrier here so the change to tlab_next is 
-			 * visible before the vtable store.
-			 */
-
 			CANARIFY_ALLOC(p,real_size);
 			SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
 			binary_protocol_alloc (p , vtable, size, sgen_client_get_provenance ());


### PR DESCRIPTION
This appears to serve no purpose as tlab_next is a thread-local variable. It's
only ever accessed by other threads in order to write to it, not read it. We
also don't do this memory barrier in the native allocation functions.

-

Creating this as a separate PR from #2881 as @lewurm is interested to see the perf improvement on ARM in isolation.