### PR TITLE
Fix for non GCC win x64 calling convention when passing empty structs over pinvoke.

### DIFF
--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -267,6 +267,7 @@ typedef struct {
 	int nregs;
 	/* Only if storage == ArgOnStack */
 	int arg_size; // Bytes, will always be rounded up/aligned to 8 byte boundary
+	gboolean pass_empty_struct; // Set in scenarios when empty structs needs to be represented as argument.
 } ArgInfo;
 
 typedef struct {


### PR DESCRIPTION
Standard C and C++ doesn't allow empty structs, empty structs will always have a
size of 1 byte. GCC have an extension to allow empty structs,
https://gcc.gnu.org/onlinedocs/gcc/Empty-Structures.html. This cause a
little dilemma since runtime build using none GCC compiler will not be
compatible with GCC build C libraries and the other way around. On platforms
where empty structs has size of 1 byte it must be represented in call and cannot
be dropped.

Libraries build using for example MSVC failed pinvoke call when empty
structs where used in pinvoke2.cs tests. The problem was that current
implementation dropped value types of size 0, eliminating them from the
call. Since MSVC implements C/C++ standard regarding empty structs (no extension used),
the function expected the parameter to be present, even if was not used.
This became a problem if the empty struct ended up in one of the 4 first
parameters (backed by registers) since if excluded, wrong parameter gets
into wrong registers (the same will apply to stack slots as well). For example,
a C signature like this, (int a, EmptyStruct es, int b) will get lowered to the
following on MSVC win x64, a -> rcx, es -> rdx and b -> r8, but since caller
eliminated es from the call, the register assignment from the caller was
a -> rcx and b -> rdx causing a violation of the calling convention and
error in callee.

The fix is to make sure that empty structs are still represented on none GCC
compilers on windows x64 (MSVC), since they must be represented in the call
to pinvoked methods. Fix will also use a const value of 0 to represent the value
passed as the struct instead of loading a value from stack into register/stack slot,
this is inline with the value the .NET runtime passes to pinvoked method. The reason
why we use a 0 instead of loading from stack is because a struct of size 0 is not explicitly
represented on stack and will have garbage data if loaded. Since it’s an empty struct value
type there is no need to load anything, just represent it as 0 in the register/stack slot passed
to caller.

There is also a case when returning an empty struct from a pinvoked method. Result will be returned
as 0 in RAX by MSVC compiled libraries (or whatever value stored in the 1 byte representation).
Since we have similar issues as above with empty structs of size 0 not explicitly represented on the
stack, the store will be eliminated and not written back to stack by caller since an empty struct doesn’t
represent any unique data.

Calling convention for managed->managed code is kept intact since it is working as expected
handling the case with empty structs as input and return values.

With fix all pinvoke2.cs tests now pass running on Windows x64 JIT.