### PR TITLE
[runtime] Mark mono_object_to_string external only.

### DIFF
--- a/mono/metadata/file-io.c
+++ b/mono/metadata/file-io.c
@@ -1240,7 +1240,7 @@ mono_filesize_from_path (MonoString *string)
 	struct stat buf;
 	gint64 res;
 	char *path = mono_string_to_utf8_checked (string, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_error_raise_exception (&error); /* OK to throw, external only without a good alternative */
 
 	MONO_ENTER_GC_SAFE;
 	if (stat (path, &buf) == -1)

--- a/mono/metadata/file-io.h
+++ b/mono/metadata/file-io.h
@@ -248,6 +248,7 @@ ves_icall_System_IO_MonoIO_ReplaceFile (MonoString *sourceFileName, MonoString *
 					MonoString *destinationBackupFileName, MonoBoolean ignoreMetadataErrors,
 					gint32 *error);
 
+MONO_RT_EXTERNAL_ONLY
 extern gint64
 mono_filesize_from_path (MonoString *path);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1623,6 +1623,12 @@ mono_property_set_value_checked (MonoProperty *prop, void *obj, void **params, M
 MonoObject*
 mono_property_get_value_checked (MonoProperty *prop, void *obj, void **params, MonoError *error);
 
+MonoString*
+mono_object_to_string_checked (MonoObject *obj, MonoError *error);
+
+MonoString*
+mono_object_try_to_string (MonoObject *obj, MonoObject **exc, MonoError *error);
+
 char *
 mono_string_to_utf8_ignore (MonoString *s);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3007,7 +3007,7 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 			mono_error_cleanup (&error);
 	} else {
 		res = mono_runtime_invoke_checked (method, obj, params, &error);
-		mono_error_raise_exception (&error);
+		mono_error_raise_exception (&error); /* OK to throw, external only without a good alternative */
 	}
 	return res;
 }
@@ -4015,7 +4015,7 @@ mono_runtime_delegate_invoke (MonoObject *delegate, void **params, MonoObject **
 		}
 	} else {
 		MonoObject *result = mono_runtime_delegate_invoke_checked (delegate, params, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_error_raise_exception (&error); /* OK to throw, external only without a good alternative */
 		return result;
 	}
 }
@@ -7635,7 +7635,7 @@ mono_object_to_string (MonoObject *obj, MonoObject **exc)
 			mono_error_cleanup (&error);
 	} else {
 		s = (MonoString *) mono_runtime_invoke_checked (method, target, NULL, &error);
-		mono_error_raise_exception (&error);
+		mono_error_raise_exception (&error); /* OK to throw, external only without a good alternative */
 	}
 
 	return s;

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -175,6 +175,7 @@ mono_string_hash            (MonoString *s);
 MONO_API int
 mono_object_hash            (MonoObject* obj);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString *
 mono_object_to_string (MonoObject *obj, MonoObject **exc);
 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -426,7 +426,7 @@ fail:
 	 * is_running_protected_wrapper () in threads.c and
 	 * mono_marshal_get_remoting_invoke () in remoting.c)
 	 */
-	mono_error_raise_exception (&error);
+	mono_error_raise_exception (&error); /* OK to throw, see note */
 	return NULL;
 } 
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2535,7 +2535,7 @@ void mono_thread_stop (MonoThread *thread)
 		This function is part of the embeding API and has no way to return the exception
 		to be thrown. So what we do is keep the old behavior and raise the exception.
 		*/
-		mono_error_raise_exception (&error);
+		mono_error_raise_exception (&error); /* OK to throw, see note */
 	} else {
 		async_abort_internal (internal, TRUE);
 	}

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4602,7 +4602,7 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method)
 
 	gpointer res = mono_aot_get_method_checked (domain, method, &error);
 	/* This is external only, so its ok to raise here */
-	mono_error_raise_exception (&error);
+	mono_error_raise_exception (&error); /* OK to throw, external only without a good alternative */
 	return res;
 }
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2835,19 +2835,18 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 	if (unhandled_exception_hook) {
 		unhandled_exception_hook (exc, unhandled_exception_hook_data);
 	} else {
+		MonoError inner_error;
 		MonoObject *other = NULL;
-		MonoString *str = mono_object_to_string (exc, &other);
+		MonoString *str = mono_object_try_to_string (exc, &other, &inner_error);
 		char *msg = NULL;
 		
-		if (str) {
-			MonoError inner_error;
+		if (str && is_ok (&inner_error)) {
 			msg = mono_string_to_utf8_checked (str, &inner_error);
-			if (!is_ok (&inner_error)) {
-				msg = g_strdup_printf ("Nested exception while formatting original exception");
-				mono_error_cleanup (&inner_error);
-			}
 		}
-		else if (other) {
+		if (!is_ok (&inner_error)) {
+			msg = g_strdup_printf ("Nested exception while formatting original exception");
+			mono_error_cleanup (&inner_error);
+		} else if (other) {
 			char *original_backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
 			char *nested_backtrace = mono_exception_get_managed_backtrace ((MonoException*)other);
 


### PR DESCRIPTION
Runtime should use mono_object_to_string_checked and mono_object_try_to_string.