### PR TITLE
Add missing type forwarder for System.Diagnostics.Tracing.EventSource…

### DIFF
--- a/mcs/class/Facades/System.Diagnostics.Tracing/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Diagnostics.Tracing/TypeForwarders.cs
@@ -29,6 +29,7 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventOpcode))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventSource))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventSourceAttribute))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventSourceSettings))]
 //[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventSourceException))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventTask))]
 //[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventWrittenEventArgs))]


### PR DESCRIPTION
…Settings.  ASP.net Core 1.0 RC2 apps will not run against mono without this.

When running ASP.net Core 1.0 RC2 apps against mono, the following stack trace is generated:

System.TypeInitializationException: The type initializer for 'System.Diagnostics.DiagnosticSourceEventSource' threw an exception. ---> System.TypeLoadException: Could not load type 'System.Diagnostics.Tracing.EventSourceSettings' from assembly 'System.Diagnostics.Tracing, Version=4.0.20.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
  at System.Diagnostics.DiagnosticSourceEventSource..cctor () <0x407db920 + 0x0001f> in <filename unknown>:0 
  --- End of inner exception stack trace ---
  at Microsoft.AspNetCore.Hosting.WebHostBuilder.BuildHostingServices () <0x407bad40 + 0x002e7> in <filename unknown>:0 
  at Microsoft.AspNetCore.Hosting.WebHostBuilder.Build () <0x407bab70 + 0x0000f> in <filename unknown>:0 
  at aspnetcoreapp.Program.Main (System.String[] args) [0x00012] in /root/app/Program.cs:15 
[ERROR] FATAL UNHANDLED EXCEPTION: System.TypeInitializationException: The type initializer for 'System.Diagnostics.DiagnosticSourceEventSource' threw an exception. ---> System.TypeLoadException: Could not load type 'System.Diagnostics.Tracing.EventSourceSettings' from assembly 'System.Diagnostics.Tracing, Version=4.0.20.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
  at System.Diagnostics.DiagnosticSourceEventSource..cctor () <0x407db920 + 0x0001f> in <filename unknown>:0 
  --- End of inner exception stack trace ---
  at Microsoft.AspNetCore.Hosting.WebHostBuilder.BuildHostingServices () <0x407bad40 + 0x002e7> in <filename unknown>:0 
  at Microsoft.AspNetCore.Hosting.WebHostBuilder.Build () <0x407bab70 + 0x0000f> in <filename unknown>:0 
at aspnetcoreapp.Program.Main (System.String[] args) [0x00012] in /root/app/Program.cs:15 

Adding this missing type forwarder to the enumeration that already exists in the mono corelib assembly resolves the issue.