### PR TITLE
[runtime] Pass MonoError to exception creation utilities

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -39,6 +39,7 @@
 #include "mono/metadata/metadata-internals.h"
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/exception.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/threads.h>
 #include <mono/metadata/threadpool-ms.h>
 #include <mono/metadata/socket-io.h>
@@ -189,16 +190,19 @@ create_domain_objects (MonoDomain *domain)
 	 * Create an instance early since we can't do it when there is no memory.
 	 */
 	arg = mono_string_new (domain, "Out of memory");
-	domain->out_of_memory_ex = mono_exception_from_name_two_strings (mono_defaults.corlib, "System", "OutOfMemoryException", arg, NULL);
+	domain->out_of_memory_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "OutOfMemoryException", arg, NULL, &error);
+	mono_error_assert_ok (&error);
 
 	/* 
 	 * These two are needed because the signal handlers might be executing on
 	 * an alternate stack, and Boehm GC can't handle that.
 	 */
 	arg = mono_string_new (domain, "A null value was found where an object instance was required");
-	domain->null_reference_ex = mono_exception_from_name_two_strings (mono_defaults.corlib, "System", "NullReferenceException", arg, NULL);
+	domain->null_reference_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "NullReferenceException", arg, NULL, &error);
+	mono_error_assert_ok (&error);
 	arg = mono_string_new (domain, "The requested operation caused a stack overflow.");
-	domain->stack_overflow_ex = mono_exception_from_name_two_strings (mono_defaults.corlib, "System", "StackOverflowException", arg, NULL);
+	domain->stack_overflow_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "StackOverflowException", arg, NULL, &error);
+	mono_error_assert_ok (&error);
 
 	/*The ephemeron tombstone i*/
 	domain->ephemeron_tombstone = mono_object_new_checked (domain, mono_defaults.object_class, &error);

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -15,4 +15,9 @@ mono_get_exception_reflection_type_load_checked (MonoArray *types, MonoArray *ex
 MonoException *
 mono_get_exception_runtime_wrapped_checked (MonoObject *wrapped_exception, MonoError *error);
 
+MonoException *
+mono_exception_from_name_two_strings_checked (MonoImage *image, const char *name_space,
+					      const char *name, MonoString *a1, MonoString *a2,
+					      MonoError *error);
+
 #endif

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -20,4 +20,9 @@ mono_exception_from_name_two_strings_checked (MonoImage *image, const char *name
 					      const char *name, MonoString *a1, MonoString *a2,
 					      MonoError *error);
 
+MonoException *
+mono_exception_from_token_two_strings_checked (MonoImage *image, uint32_t token,
+					       MonoString *a1, MonoString *a2,
+					       MonoError *error);
+
 #endif

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -13,6 +13,7 @@
  */
 
 #include <glib.h>
+#include <config.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/exception-internals.h>
 
@@ -173,15 +174,39 @@ mono_exception_from_name_two_strings (MonoImage *image, const char *name_space,
 				      const char *name, MonoString *a1, MonoString *a2)
 {
 	MonoError error;
-	MonoClass *klass;
 	MonoException *ret;
 
+	ret = mono_exception_from_name_two_strings_checked (image, name_space, name, a1, a2, &error);
+	mono_error_cleanup (&error);
+	return ret;
+}
+
+/**
+ * mono_exception_from_name_two_strings_checked:
+ * @image: the Mono image where to look for the class
+ * @name_space: the namespace for the class
+ * @name: class name
+ * @a1: first string argument to pass
+ * @a2: second string argument to pass
+ * @error: set on error
+ *
+ * Creates an exception from a constructor that takes two string
+ * arguments.
+ *
+ * Returns: the initialized exception instance. On failure returns
+ * NULL and sets @error.
+ */
+MonoException *
+mono_exception_from_name_two_strings_checked (MonoImage *image, const char *name_space,
+					      const char *name, MonoString *a1, MonoString *a2,
+					      MonoError *error)
+{
+	MonoClass *klass;
+
+	mono_error_init (error);
 	klass = mono_class_load_from_name (image, name_space, name);
 
-	ret = create_exception_two_strings (klass, a1, a2, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
-
-	return ret;
+	return create_exception_two_strings (klass, a1, a2, error);
 }
 
 /**
@@ -400,8 +425,11 @@ mono_get_exception_type_load (MonoString *class_name, char *assembly_name)
 {
 	MonoString *s = assembly_name ? mono_string_new (mono_domain_get (), assembly_name) : mono_string_new (mono_domain_get (), "");
 
-	return mono_exception_from_name_two_strings (mono_get_corlib (), "System",
-						     "TypeLoadException", class_name, s);
+	MonoError error;
+	MonoException *ret = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System",
+								   "TypeLoadException", class_name, s, &error);
+	mono_error_assert_ok (&error);
+	return ret;
 }
 
 /**
@@ -441,8 +469,11 @@ mono_get_exception_missing_method (const char *class_name, const char *member_na
 	MonoString *s1 = mono_string_new (mono_domain_get (), class_name);
 	MonoString *s2 = mono_string_new (mono_domain_get (), member_name);
 
-	return mono_exception_from_name_two_strings (mono_get_corlib (), "System",
-						     "MissingMethodException", s1, s2);
+	MonoError error;
+	MonoException *ret = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System",
+									   "MissingMethodException", s1, s2, &error);
+	mono_error_assert_ok (&error);
+	return ret;
 }
 
 /**
@@ -458,8 +489,11 @@ mono_get_exception_missing_field (const char *class_name, const char *member_nam
 	MonoString *s1 = mono_string_new (mono_domain_get (), class_name);
 	MonoString *s2 = mono_string_new (mono_domain_get (), member_name);
 
-	return mono_exception_from_name_two_strings (mono_get_corlib (), "System",
-						     "MissingFieldException", s1, s2);
+	MonoError error;
+	MonoException *ret = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System",
+								   "MissingFieldException", s1, s2, &error);
+	mono_error_assert_ok (&error);
+	return ret;
 }
 
 /**
@@ -563,8 +597,11 @@ mono_get_exception_io (const char *msg)
 MonoException *
 mono_get_exception_file_not_found (MonoString *fname)
 {
-	return mono_exception_from_name_two_strings (
-		mono_get_corlib (), "System.IO", "FileNotFoundException", fname, fname);
+	MonoError error;
+	MonoException *ret = mono_exception_from_name_two_strings_checked (
+		mono_get_corlib (), "System.IO", "FileNotFoundException", fname, fname, &error);
+	mono_error_assert_ok (&error);
+	return ret;
 }
 
 /**
@@ -579,8 +616,11 @@ mono_get_exception_file_not_found2 (const char *msg, MonoString *fname)
 {
 	MonoString *s = msg ? mono_string_new (mono_domain_get (), msg) : NULL;
 
-	return mono_exception_from_name_two_strings (
-		mono_get_corlib (), "System.IO", "FileNotFoundException", s, fname);
+	MonoError error;
+	MonoException *ret = mono_exception_from_name_two_strings_checked (
+		mono_get_corlib (), "System.IO", "FileNotFoundException", s, fname, &error);
+	mono_error_assert_ok (&error);
+	return ret;
 }
 
 /**
@@ -699,8 +739,11 @@ mono_get_exception_bad_image_format2 (const char *msg, MonoString *fname)
 {
 	MonoString *s = msg ? mono_string_new (mono_domain_get (), msg) : NULL;
 
-	return mono_exception_from_name_two_strings (
-		mono_get_corlib (), "System", "BadImageFormatException", s, fname);
+	MonoError error;
+	MonoException *ret = mono_exception_from_name_two_strings_checked (
+		mono_get_corlib (), "System", "BadImageFormatException", s, fname, &error);
+	mono_error_assert_ok (&error);
+	return ret;
 }
 
 /**

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -245,16 +245,31 @@ mono_exception_from_token_two_strings (MonoImage *image, guint32 token,
 									   MonoString *a1, MonoString *a2)
 {
 	MonoError error;
-	MonoClass *klass;
 	MonoException *ret;
-
-	klass = mono_class_get_checked (image, token, &error);
-	mono_error_assert_ok (&error); /* FIXME handle the error. */
-
-	ret = create_exception_two_strings (klass, a1, a2, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
-
+	ret = mono_exception_from_token_two_strings_checked (image, token, a1, a2, &error);
+	mono_error_cleanup (&error);
 	return ret;
+}
+
+/**
+ * mono_exception_from_token_two_strings_checked:
+ *
+ *   Same as mono_exception_from_name_two_strings, but lookup the exception class using
+ * IMAGE and TOKEN.
+ */
+MonoException *
+mono_exception_from_token_two_strings_checked (MonoImage *image, guint32 token,
+					       MonoString *a1, MonoString *a2,
+					       MonoError *error)
+{
+	MonoClass *klass;
+
+	mono_error_init (error);
+
+	klass = mono_class_get_checked (image, token, error);
+	mono_error_assert_ok (error); /* FIXME handle the error. */
+
+	return create_exception_two_strings (klass, a1, a2, error);
 }
 
 /**

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -14,6 +14,7 @@ mono_exception_from_name               (MonoImage *image,
 MONO_API MonoException *
 mono_exception_from_token              (MonoImage *image, uint32_t token);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoException *
 mono_exception_from_name_two_strings (MonoImage *image, const char *name_space,
 				      const char *name, MonoString *a1, MonoString *a2);

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -23,6 +23,7 @@ MONO_API MonoException *
 mono_exception_from_name_msg	       (MonoImage *image, const char *name_space,
 					const char *name, const char *msg);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoException *
 mono_exception_from_token_two_strings (MonoImage *image, uint32_t token,
 						   MonoString *a1, MonoString *a2);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4894,7 +4894,7 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 		}
 	} else {
 		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, NULL, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_error_raise_exception (&error); /* OK to throw, external only without a good alternative */
 		return result;
 	}
 }

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -19,6 +19,7 @@
 
 #include "jit-icalls.h"
 #include <mono/utils/mono-error-internals.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/reflection-internals.h>
 
@@ -1189,13 +1190,21 @@ mono_create_corlib_exception_0 (guint32 token)
 MonoException *
 mono_create_corlib_exception_1 (guint32 token, MonoString *arg)
 {
-	return mono_exception_from_token_two_strings (mono_defaults.corlib, token, arg, NULL);
+	MonoError error;
+	MonoException *ret = mono_exception_from_token_two_strings_checked (
+		mono_defaults.corlib, token, arg, NULL, &error);
+	mono_error_set_pending_exception (&error);
+	return ret;
 }
 
 MonoException *
 mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg2)
 {
-	return mono_exception_from_token_two_strings (mono_defaults.corlib, token, arg1, arg2);
+	MonoError error;
+	MonoException *ret = mono_exception_from_token_two_strings_checked (
+		mono_defaults.corlib, token, arg1, arg2, &error);
+	mono_error_set_pending_exception (&error);
+	return ret;
 }
 
 MonoObject*

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -8,10 +8,12 @@
  */
 #include <glib.h>
 
+#include <config.h>
 #include "mono-error.h"
 #include "mono-error-internals.h"
 
 #include <mono/metadata/exception.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/object-internals.h>
 
@@ -562,7 +564,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 				break;
 			}
 
-			exception = mono_exception_from_name_two_strings (mono_defaults.corlib, "System", "MissingMethodException", type_name, method_name);
+			exception = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "MissingMethodException", type_name, method_name, error_out);
 			if (exception)
 				set_message_on_exception (exception, error, error_out);
 		} else {
@@ -582,7 +584,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 				break;
 			}
 			
-			exception = mono_exception_from_name_two_strings (mono_defaults.corlib, "System", "MissingFieldException", type_name, field_name);
+			exception = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "MissingFieldException", type_name, field_name, error_out);
 			if (exception)
 				set_message_on_exception (exception, error, error_out);
 		} else {
@@ -604,7 +606,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 				}
 			}
 
-			exception = mono_exception_from_name_two_strings (mono_get_corlib (), "System", "TypeLoadException", type_name, assembly_name);
+			exception = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System", "TypeLoadException", type_name, assembly_name, error_out);
 			if (exception)
 				set_message_on_exception (exception, error, error_out);
 		} else {
@@ -630,9 +632,9 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 			}
 
 			if (error->error_code == MONO_ERROR_FILE_NOT_FOUND)
-				exception = mono_exception_from_name_two_strings (mono_get_corlib (), "System.IO", "FileNotFoundException", msg, assembly_name);
+				exception = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System.IO", "FileNotFoundException", msg, assembly_name, error_out);
 			else
-				exception = mono_exception_from_name_two_strings (mono_defaults.corlib, "System", "BadImageFormatException", msg, assembly_name);
+				exception = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "BadImageFormatException", msg, assembly_name, error_out);
 		} else {
 			if (error->error_code == MONO_ERROR_FILE_NOT_FOUND)
 				exception = mono_exception_from_name_msg (mono_get_corlib (), "System.IO", "FileNotFoundException", error->full_message);


### PR DESCRIPTION
`mono_exception_from_name_two_strings` and `mono_exception_from_token_two_strings` are external-only now.  Runtime uses the `_checked` variants.