### PR TITLE
[runtime] Okay to raise MonoError in thread start functions.

### DIFF
--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -198,7 +198,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	LocalFree (argvw);
 
 	mono_runtime_run_main_checked (method, argc, argv, &error);
-	mono_error_raise_exception (&error); /* FIXME don't raise here */
+	mono_error_raise_exception (&error); /* OK, triggers unhandled exn handler */
 	mono_thread_manage ();
 
 	mono_runtime_quit ();

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -744,7 +744,7 @@ static guint32 WINAPI start_wrapper_internal(void *data)
 		args [0] = start_arg;
 		/* we may want to handle the exception here. See comment below on unhandled exceptions */
 		mono_runtime_delegate_invoke_checked (start_delegate, args, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_error_raise_exception (&error); /* OK, triggers unhandled exn handler */
 	}
 
 	/* If the thread calls ExitThread at all, this remaining code

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1042,7 +1042,7 @@ mono_jit_exec (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[
 		return res;
 	} else {
 		int res = mono_runtime_run_main_checked (method, argc, argv, &error);
-		mono_error_raise_exception (&error); /* FIXME don't raise here */
+		mono_error_raise_exception (&error); /* OK, triggers unhandled exn handler */
 		return res;
 	}
 }


### PR DESCRIPTION
So all the functions here are executed soon after a thread starts running without any managed code beneath them.  So the calls to `mono_error_raise_exception` should immediately turn into unhandled exceptions.