### PR TITLE
Move call to sn.exe to *after* cil-stringreplacer.exe

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -277,10 +277,10 @@ $(the_lib): $(the_libdir)/.stamp
 
 $(build_lib): $(response) $(sn) $(BUILT_SOURCES) $(build_libdir:=/.stamp)
 	$(LIBRARY_COMPILE) $(LIBRARY_FLAGS) $(LIB_MCS_FLAGS) -target:library -out:$@ $(BUILT_SOURCES_cmdline) @$(response)
-	$(Q) $(SN) -R $@ $(LIBRARY_SNK)
 ifdef RESOURCE_STRINGS_FILES
 	$(Q) $(STRING_REPLACER) $(RESOURCE_STRINGS_FILES) $@
 endif
+	$(Q) $(SN) -R $@ $(LIBRARY_SNK)
 
 ifdef LIBRARY_USE_INTERMEDIATE_FILE
 $(the_lib): $(build_lib)


### PR DESCRIPTION
This makes sure mscorlib.dll still has a valid signature (fixes nightly builds on Linux)