### PR TITLE
[test-runner] Write stdout/stderr into StringBuilder instead of an intermediate file

### DIFF
--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -259,7 +259,7 @@ public class TestRunner
 						} catch {
 						}
 
-						output.Write ("timed out");
+						output.Write ($"timed out ({timeout}s)");
 
 						try {
 							p.Kill ();

--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -11,6 +11,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Text;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Globalization;
@@ -29,8 +30,8 @@ public class TestRunner
 
 	class ProcessData {
 		public string test;
-		public StreamWriter stdout, stderr;
-		public string stdoutFile, stderrFile;
+		public StringBuilder stdout, stderr;
+		public string stdoutName, stderrName;
 	}
 
 	class TestInfo {
@@ -216,27 +217,21 @@ public class TestRunner
 					if (opt_set != null)
 						log_prefix = "." + opt_set.Replace ("-", "no").Replace (",", "_");
 
-					data.stdoutFile = test + log_prefix + ".stdout";
-					data.stdout = new StreamWriter (new FileStream (data.stdoutFile, FileMode.Create));
+					data.stdoutName = test + log_prefix + ".stdout";
+					data.stdout = new StringBuilder ();
 
-					data.stderrFile = test + log_prefix + ".stderr";
-					data.stderr = new StreamWriter (new FileStream (data.stderrFile, FileMode.Create));
+					data.stderrName = test + log_prefix + ".stderr";
+					data.stderr = new StringBuilder ();
 
 					p.OutputDataReceived += delegate (object sender, DataReceivedEventArgs e) {
 						if (e.Data != null) {
-							data.stdout.WriteLine (e.Data);
-						} else {
-							data.stdout.Flush ();
-							data.stdout.Close ();
+							data.stdout.AppendLine (e.Data);
 						}
 					};
 
 					p.ErrorDataReceived += delegate (object sender, DataReceivedEventArgs e) {
 						if (e.Data != null) {
-							data.stderr.WriteLine (e.Data);
-						} else {
-							data.stderr.Flush ();
-							data.stderr.Close ();
+							data.stderr.AppendLine (e.Data);
 						}
 					};
 
@@ -383,10 +378,10 @@ public class TestRunner
 				writer.WriteAttributeString ("asserts", "1");
 				writer.WriteStartElement ("failure");
 				writer.WriteStartElement ("message");
-				writer.WriteCData (DumpPseudoTrace (pd.stdoutFile));
+				writer.WriteCData (FilterInvalidXmlChars (pd.stdout.ToString ()));
 				writer.WriteEndElement ();
 				writer.WriteStartElement ("stack-trace");
-				writer.WriteCData (DumpPseudoTrace (pd.stderrFile));
+				writer.WriteCData (FilterInvalidXmlChars (pd.stderr.ToString ()));
 				writer.WriteEndElement ();
 				writer.WriteEndElement ();
 				writer.WriteEndElement ();
@@ -402,10 +397,10 @@ public class TestRunner
 				writer.WriteAttributeString ("asserts", "1");
 				writer.WriteStartElement ("failure");
 				writer.WriteStartElement ("message");
-				writer.WriteCData (DumpPseudoTrace (pd.stdoutFile));
+				writer.WriteCData (FilterInvalidXmlChars (pd.stdout.ToString ()));
 				writer.WriteEndElement ();
 				writer.WriteStartElement ("stack-trace");
-				writer.WriteCData (DumpPseudoTrace (pd.stderrFile));
+				writer.WriteCData (FilterInvalidXmlChars (pd.stderr.ToString ()));
 				writer.WriteEndElement ();
 				writer.WriteEndElement ();
 				writer.WriteEndElement ();
@@ -440,8 +435,8 @@ public class TestRunner
 			foreach (ProcessData pd in failed) {
 				Console.WriteLine ();
 				Console.WriteLine (pd.test);
-				DumpFile (pd.stdoutFile);
-				DumpFile (pd.stderrFile);
+				DumpFile (pd.stdoutName, pd.stdout.ToString ());
+				DumpFile (pd.stderrName, pd.stderr.ToString ());
 			}
 		}
 
@@ -451,27 +446,18 @@ public class TestRunner
 			foreach (ProcessData pd in timedout) {
 				Console.WriteLine ();
 				Console.WriteLine (pd.test);
-				DumpFile (pd.stdoutFile);
-				DumpFile (pd.stderrFile);
+				DumpFile (pd.stdoutName, pd.stdout.ToString ());
+				DumpFile (pd.stderrName, pd.stderr.ToString ());
 			}
 		}
 
 		return (ntimedout == 0 && nfailed == 0) ? 0 : 1;
 	}
 	
-	static void DumpFile (string filename) {
-		if (File.Exists (filename)) {
-			Console.WriteLine ("=============== {0} ===============", filename);
-			Console.WriteLine (File.ReadAllText (filename));
-			Console.WriteLine ("=============== EOF ===============");
-		}
-	}
-
-	static string DumpPseudoTrace (string filename) {
-		if (File.Exists (filename))
-			return FilterInvalidXmlChars (File.ReadAllText (filename));
-		else
-			return string.Empty;
+	static void DumpFile (string filename, string text) {
+		Console.WriteLine ("=============== {0} ===============", filename);
+		Console.WriteLine (text);
+		Console.WriteLine ("=============== EOF ===============");
 	}
 
 	static string FilterInvalidXmlChars (string text) {


### PR DESCRIPTION
We don't need to write out and then read back in the contents. Additionally, this will prevent
an unhandled exception we've seen on Jenkins:

```
Unhandled Exception:
System.IO.IOException: Sharing violation on path /media/ssd/jenkins/workspace/test-mono-mainline-linux/label/debian-8-arm64/mono/tests/finalizer-wait.exe.stdout
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) <0x7f7eb4a740 + 0x00650> in <filename unknown>:0
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options, System.String msgPath, System.Boolean bFromProxy, System.Boolean useLongPath, System.Boolean checkHost) <0x7f7eb4a620 + 0x00053> in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions,string,bool,bool,bool)
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize, System.Boolean checkHost) <0x7f7e9b2170 + 0x000f3> in <filename unknown>:0
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize) <0x7f7e9b2120 + 0x00037> in <filename unknown>:0
  at System.IO.StreamReader..ctor (System.String path, System.Boolean detectEncodingFromByteOrderMarks) <0x7f7e9b2040 + 0x0003b> in <filename unknown>:0
  at System.IO.StreamReader..ctor (System.String path) <0x7f7e9b2010 + 0x0001f> in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.IO.StreamReader:.ctor (string)
  at System.IO.File.ReadAllText (System.String path) <0x7f7eb48c70 + 0x0003b> in <filename unknown>:0
  at TestRunner.DumpPseudoTrace (System.String filename) <0x7f7cfc6450 + 0x00023> in <filename unknown>:0
  at TestRunner.Main (System.String[] args) <0x7f8128b770 + 0x01ed3> in <filename unknown>:0
```