### PR TITLE
[corlib] Handle user Assembly subclass and Assembly::GetName.

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.cs
@@ -1038,16 +1038,6 @@ namespace System.Reflection.Emit
 			return (str == "neutral" ? String.Empty : str);
 		}
 
-		internal override AssemblyName UnprotectedGetName ()
-		{
-			AssemblyName an = base.UnprotectedGetName ();
-			if (sn != null) {
-				an.SetPublicKey (sn.PublicKey);
-				an.SetPublicKeyToken (sn.PublicKeyToken);
-			}
-			return an;
-		}
-
 		/*Warning, @typeArguments must be a mscorlib internal array. So make a copy before passing it in*/
 		internal Type MakeGenericType (Type gtd, Type[] typeArguments)
 		{
@@ -1124,7 +1114,15 @@ namespace System.Reflection.Emit
 
 		public override AssemblyName GetName (bool copiedName)
 		{
-			return base.GetName (copiedName);
+			AssemblyName aname = new AssemblyName ();
+			FillName (this, aname);
+
+			if (sn != null) {
+				aname.SetPublicKey (sn.PublicKey);
+				aname.SetPublicKeyToken (sn.PublicKeyToken);
+			}
+			return aname;
+
 		}
 
 		[MonoTODO ("This always returns an empty array")]

--- a/mcs/class/corlib/System.Reflection/Assembly.cs
+++ b/mcs/class/corlib/System.Reflection/Assembly.cs
@@ -423,31 +423,16 @@ namespace System.Reflection {
 		internal extern static void InternalGetAssemblyName (string assemblyFile, AssemblyName aname);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern void FillName (Assembly ass, AssemblyName aname);
+		static extern internal void FillName (Assembly ass, AssemblyName aname);
 
-		[MonoTODO ("copiedName == true is not supported")]
 		public virtual AssemblyName GetName (Boolean copiedName)
 		{
-#if !MOBILE
-			// CodeBase, which is restricted, will be copied into the AssemblyName object so...
-			if (SecurityManager.SecurityEnabled) {
-				GetCodeBase (true); // this will ensure the Demand is made
-			}
-#endif
-			return UnprotectedGetName ();
+			throw new NotImplementedException ();
 		}
 
 		public virtual AssemblyName GetName ()
 		{
 			return GetName (false);
-		}
-
-		// the security runtime requires access to the assemblyname (e.g. to get the strongname)
-		internal virtual AssemblyName UnprotectedGetName ()
-		{
-			AssemblyName aname = new AssemblyName ();
-			FillName (this, aname);
-			return aname;
 		}
 
 		public override string ToString ()

--- a/mcs/class/corlib/System.Reflection/MonoAssembly.cs
+++ b/mcs/class/corlib/System.Reflection/MonoAssembly.cs
@@ -37,6 +37,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Diagnostics.Contracts;
+using System.Security;
 using System.Security.Policy;
 using System.Security.Permissions;
 
@@ -149,6 +150,22 @@ namespace System.Reflection {
 		internal static RuntimeAssembly LoadWithPartialNameInternal (AssemblyName an, Evidence securityEvidence, ref StackCrawlMark stackMark)
 		{
 			return LoadWithPartialNameInternal (an.ToString (), securityEvidence, ref stackMark);
+		}
+
+		// the security runtime requires access to the assemblyname (e.g. to get the strongname)
+		public override AssemblyName GetName (bool copiedName)
+		{
+
+#if !MOBILE
+			// CodeBase, which is restricted, will be copied into the AssemblyName object so...
+			if (SecurityManager.SecurityEnabled) {
+				var _ = CodeBase; // this will ensure the Demand is made
+			}
+#endif
+
+			AssemblyName aname = new AssemblyName ();
+			FillName (this, aname);
+			return aname;
 		}
 
 	}

--- a/mcs/class/corlib/System.Security.Policy/Evidence.cs
+++ b/mcs/class/corlib/System.Security.Policy/Evidence.cs
@@ -251,7 +251,7 @@ namespace System.Security.Policy {
 			}
 
 			// strongnamed assemblies gets a StrongName evidence
-			AssemblyName an = a.UnprotectedGetName ();
+			AssemblyName an = a.GetName ();
 			byte[] pk = an.GetPublicKey ();
 			if ((pk != null) && (pk.Length > 0)) {
 				StrongNamePublicKeyBlob blob = new StrongNamePublicKeyBlob (pk);

--- a/mcs/class/corlib/System.Security.Policy/PolicyLevel.cs
+++ b/mcs/class/corlib/System.Security.Policy/PolicyLevel.cs
@@ -582,7 +582,7 @@ namespace System.Security.Policy {
 
 		internal bool IsFullTrustAssembly (Assembly a)
 		{
-			AssemblyName an = a.UnprotectedGetName ();
+			AssemblyName an = a.GetName ();
 			StrongNamePublicKeyBlob snpkb = new StrongNamePublicKeyBlob (an.GetPublicKey ());
 			StrongNameMembershipCondition snMC = new StrongNameMembershipCondition (snpkb, an.Name, an.Version);
 			foreach (StrongNameMembershipCondition sn in full_trust_assemblies) {

--- a/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
@@ -1327,6 +1327,19 @@ namespace MonoTests.System.Reflection
 			Assert.AreSame (x1, x2, "#1");
 		}
 #endif
+
+		class MyAssembly : Assembly { }
+
+		[Test]
+		public void CustomAssemblyImplThrows ()
+		{
+			var ma = new MyAssembly();
+			try {
+				ma.GetName ();
+				Assert.Fail ("must throw");
+			} catch (NotImplementedException){
+			}
+		}
 	}
 
 	public class TestDefinedTypes

--- a/mcs/class/referencesource/mscorlib/system/exception.cs
+++ b/mcs/class/referencesource/mscorlib/system/exception.cs
@@ -429,7 +429,7 @@ namespace System {
 
 #if MONO
                         if (method != null) { // source can be null
-                            _source = method.DeclaringType.Assembly.UnprotectedGetName ().Name;
+                            _source = method.DeclaringType.Assembly.GetName ().Name;
                         }
 #else
                         Module module = method.Module;


### PR DESCRIPTION
Remove UnprotectedGetName and replace with overriding of GetName.

dotnet throws NIE if you subclass Assembly and call GetName on it.
We hard crashed.