### PR TITLE
Fixes SendAsyncFile flaky failures

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
+++ b/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
@@ -7,7 +7,9 @@
 
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
+using System.Diagnostics;
 using System.Collections.Generic;
 using Microsoft.Win32.SafeHandles;
 
@@ -16,6 +18,8 @@ namespace System.Net.Sockets {
 	sealed class SafeSocketHandle : SafeHandleZeroOrMinusOneIsInvalid {
 
 		List<Thread> blocking_threads;
+		Dictionary<Thread, StackTrace> threads_stacktraces;
+
 		bool in_cleanup;
 
 		const int SOCKET_CLOSED = 10004;
@@ -26,6 +30,9 @@ namespace System.Net.Sockets {
 		public SafeSocketHandle (IntPtr preexistingHandle, bool ownsHandle) : base (ownsHandle)
 		{
 			SetHandle (preexistingHandle);
+
+			if (THROW_ON_ABORT_RETRIES)
+				threads_stacktraces = new Dictionary<Thread, StackTrace> ();
 		}
 
 		// This is just for marshalling
@@ -48,8 +55,17 @@ namespace System.Net.Sockets {
 					int abort_attempts = 0;
 					while (blocking_threads.Count > 0) {
 						if (abort_attempts++ >= ABORT_RETRIES) {
-							if (THROW_ON_ABORT_RETRIES)
-								throw new Exception ("Could not abort registered blocking threads before closing socket.");
+							if (THROW_ON_ABORT_RETRIES) {
+								StringBuilder sb = new StringBuilder ();
+								sb.AppendLine ("Could not abort registered blocking threads before closing socket.");
+								foreach (var thread in blocking_threads) {
+									sb.AppendLine ("Thread StackTrace:");
+									sb.AppendLine (threads_stacktraces[thread].ToString ());
+								}
+								sb.AppendLine ();
+
+								throw new Exception (sb.ToString ());
+							}
 
 							// Attempts to close the socket safely failed.
 							// We give up, and close the socket with pending blocking system calls.
@@ -94,6 +110,8 @@ namespace System.Net.Sockets {
 				/* We must use a finally block here to make this atomic. */
 				lock (blocking_threads) {
 					blocking_threads.Add (Thread.CurrentThread);
+					if (THROW_ON_ABORT_RETRIES)
+						threads_stacktraces.Add (Thread.CurrentThread, new StackTrace (true));
 				}
 				if (release)
 					DangerousRelease ();
@@ -110,6 +128,9 @@ namespace System.Net.Sockets {
 			//If this NRE, we're in deep problems because Register Must have
 			lock (blocking_threads) {
 				blocking_threads.Remove (Thread.CurrentThread);
+				if (THROW_ON_ABORT_RETRIES)
+					threads_stacktraces.Remove (Thread.CurrentThread);
+
 				if (in_cleanup && blocking_threads.Count == 0)
 					Monitor.Pulse (blocking_threads);
 			}

--- a/mono/io-layer/sockets.c
+++ b/mono/io-layer/sockets.c
@@ -969,7 +969,7 @@ wapi_sendfile (guint32 socket, gpointer fd, guint32 bytes_to_write, guint32 byte
 		/* TODO: Might not send the entire file for non-blocking sockets */
 		res = sendfile (file, socket, 0, &statbuf.st_size, NULL, 0);
 #endif
-	} while (res != -1 && (errno == EINTR || errno == EAGAIN) && !_wapi_thread_cur_apc_pending ());
+	} while (res != -1 && errno == EINTR && !_wapi_thread_cur_apc_pending ());
 	if (res == -1) {
 		errnum = errno;
 		errnum = errno_to_WSA (errnum, __func__);


### PR DESCRIPTION
Stack traces of blocked threads are now displayed on the exception. This help us determining which system calls are not aborted properly.

Before closing a socket we try to interrupt and wait for all socket
pending system calls to return. For that we set the socket as non
blocking which makes the system calls to return with EAGAIN\EWOULDBLOCK.

This issue was caught by System.Net.Sockets.SocketTest.SendAsyncFile
that was intermittently failing, we were only able to reproduce it while
running multiple test suites in parallel. We now can say that it only failed when
the the socket was closed and the sendfile was waiting for the OS to
allocate enough resources to send the file.

This was fixed by changing wapi_sendfile to return on EAGAIN.

Thanks to @akoeplinger  suggestions I was able to login into Jenkins bots and reproduce the flaky failure, I was also able to confirm that with the fix the issue no longer occurred while looping two instance of System tests in parallel for more than one hour.