### PR TITLE
Rewriite `MonoMethodMessage::InitMessage` in managed code

### DIFF
--- a/mcs/class/corlib/System.Runtime.Remoting.Messaging/MonoMethodMessage.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting.Messaging/MonoMethodMessage.cs
@@ -68,8 +68,38 @@ namespace System.Runtime.Remoting.Messaging {
 		internal static String CallContextKey = "__CallContext";
 		internal static String UriKey           = "__Uri";
 
-		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		internal extern void InitMessage (MonoMethod method, object [] out_args);
+		internal void InitMessage (MonoMethod method, object [] out_args)
+		{
+			this.method = method;
+			ParameterInfo[] paramInfo = method.GetParametersInternal ();
+			int param_count = paramInfo.Length;
+			args = new object[param_count];
+			arg_types = new byte[param_count];
+			asyncResult = null;
+			call_type = CallType.Sync;
+			names = new string[param_count];
+			for (int i = 0; i < param_count; i++) {
+				names[i] = paramInfo[i].Name;
+			}
+			bool hasOutArgs = out_args != null;
+			int j = 0;
+			for (int i = 0; i < param_count; i++) {
+				byte arg_type;
+				bool isOut = paramInfo[i].IsOut;
+				if (paramInfo[i].ParameterType.IsByRef) {
+					if (hasOutArgs)
+						args[i] = out_args[j++];
+					arg_type = 2; // OUT
+					if (!isOut)
+						arg_type |= 1; // INOUT
+				} else {
+					arg_type = 1; // IN
+					if (isOut)
+						arg_type |= 4; // IN, COPY OUT
+				}
+				arg_types[i] = arg_type;
+			}
+		}
 
 		public MonoMethodMessage (MethodBase method, object [] out_args)
 		{

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -706,9 +706,6 @@ ICALL(CONTEXT_2, "ReleaseContext", ves_icall_System_Runtime_Remoting_Contexts_Co
 ICALL_TYPE(ARES, "System.Runtime.Remoting.Messaging.AsyncResult", ARES_1)
 ICALL(ARES_1, "Invoke", ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke)
 
-ICALL_TYPE(MONOMM, "System.Runtime.Remoting.Messaging.MonoMethodMessage", MONOMM_1)
-ICALL(MONOMM_1, "InitMessage", ves_icall_MonoMethodMessage_InitMessage)
-
 #ifndef DISABLE_REMOTING
 ICALL_TYPE(REALP, "System.Runtime.Remoting.Proxies.RealProxy", REALP_1)
 ICALL(REALP_1, "InternalGetProxyType", ves_icall_Remoting_RealProxy_InternalGetProxyType)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7331,16 +7331,6 @@ ves_icall_System_Runtime_Versioning_VersioningHelper_GetRuntimeId (void)
 	return 9;
 }
 
-ICALL_EXPORT void
-ves_icall_MonoMethodMessage_InitMessage (MonoMethodMessage *this_obj, 
-					 MonoReflectionMethod *method,
-					 MonoArray *out_args)
-{
-	MonoError error;
-	mono_message_init (mono_object_domain (this_obj), this_obj, method, out_args, &error);
-	mono_error_set_pending_exception (&error);
-}
-
 #ifndef DISABLE_REMOTING
 ICALL_EXPORT MonoBoolean
 ves_icall_IsTransparentProxy (MonoObject *proxy)


### PR DESCRIPTION
Change icall
`System.Runtime.Remoting.Messaging/MonoMethodMessage::InitMessage` to
managed code.

Also update `mono_message_init()` to invoke `InitMessage`.