### PR TITLE
Stacktraces metadata

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -326,6 +326,26 @@ namespace System.Diagnostics {
 			string aotid = Assembly.GetAotId ();
 			if (aotid != "00000000-0000-0000-0000-000000000000")
 				AddMetadataHandler ("AOTID", st => { return aotid; });
+
+			AddMetadataHandler ("MVID", st => {
+				var mvidLines = new Dictionary<Guid, List<int>> ();
+				var frames = st.GetFrames ();
+				for (var lineNumber = 0; lineNumber < frames.Length; lineNumber++) {
+					var mvid = frames[lineNumber].GetMethod ().Module.ModuleVersionId;
+					if (!mvidLines.ContainsKey (mvid))
+						mvidLines.Add (mvid, new List<int> ());
+
+					mvidLines[mvid].Add (lineNumber);
+				}
+
+				var sb = new StringBuilder ();
+				foreach (var kv in mvidLines) {
+					var mvid = kv.Key.ToString ().ToUpper ();
+					sb.AppendLine (string.Format ("{0} {1}", mvid, string.Join (",", kv.Value)));
+				}
+
+				return sb.ToString ();
+			});
 		}
 
 		private static void AddMetadataHandler (string id, Func<StackTrace, string> handler)

--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -37,6 +37,7 @@ using System.Security;
 using System.Security.Permissions;
 using System.Text;
 using System.Threading;
+using System.IO;
 
 namespace System.Diagnostics {
 
@@ -59,6 +60,15 @@ namespace System.Diagnostics {
 		private StackFrame[] frames;
 		readonly StackTrace[] captured_traces;
 		private bool debug_info;
+
+		private static Dictionary<string, Func<StackTrace, string>> metadataHandlers;
+
+		static StackTrace ()
+		{
+			metadataHandlers = new Dictionary<string, Func<StackTrace, string>> ();
+
+			InitMetadataHandlers ();
+		}
 
 		public StackTrace ()
 		{
@@ -290,13 +300,37 @@ namespace System.Diagnostics {
 			}
 
 			AddFrames (sb);
+
+			sb.AppendLine ();
+			foreach (var handler in metadataHandlers) {
+				var lines = handler.Value (this);
+				using (var reader = new StringReader (lines)) {
+					string line;
+					while ((line = reader.ReadLine()) != null)
+						sb.AppendLine (string.Format ("[{0}] {1}", handler.Key, line));
+				}
+			}
+
 			return sb.ToString ();
 		}
 
+		
 		internal String ToString (TraceFormat traceFormat)
 		{
 			// TODO:
 			return ToString ();
+		}
+
+		static void InitMetadataHandlers ()
+		{
+			string aotid = Assembly.GetAotId ();
+			if (aotid != "00000000-0000-0000-0000-000000000000")
+				AddMetadataHandler ("AOTID", st => { return aotid; });
+		}
+
+		private static void AddMetadataHandler (string id, Func<StackTrace, string> handler)
+		{
+			metadataHandlers.Add (id, handler);
 		}
 	}
 }

--- a/mcs/class/corlib/System.Reflection/Assembly.cs
+++ b/mcs/class/corlib/System.Reflection/Assembly.cs
@@ -138,6 +138,9 @@ namespace System.Reflection {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern string InternalImageRuntimeVersion ();
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static internal extern string GetAotId ();
+
 		// SECURITY: this should be the only caller to icall get_code_base
 		private string GetCodeBase (bool escaped)
 		{

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -456,6 +456,7 @@ ICALL(OBJ_3, "MemberwiseClone", ves_icall_System_Object_MemberwiseClone)
 
 ICALL_TYPE(ASSEM, "System.Reflection.Assembly", ASSEM_1)
 ICALL(ASSEM_1, "FillName", ves_icall_System_Reflection_Assembly_FillName)
+ICALL(ASSEM_1a, "GetAotId", ves_icall_System_Reflection_Assembly_GetAotId)
 ICALL(ASSEM_2, "GetCallingAssembly", ves_icall_System_Reflection_Assembly_GetCallingAssembly)
 ICALL(ASSEM_3, "GetEntryAssembly", ves_icall_System_Reflection_Assembly_GetEntryAssembly)
 ICALL(ASSEM_4, "GetExecutingAssembly", ves_icall_System_Reflection_Assembly_GetExecutingAssembly)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4888,6 +4888,16 @@ ves_icall_System_Reflection_Assembly_GetManifestResourceNames (MonoReflectionAss
 	return result;
 }
 
+ICALL_EXPORT MonoString*
+ves_icall_System_Reflection_Assembly_GetAotId ()
+{
+	printf ("GetAotId\n");
+	guint8* aotid = &mono_domain_get ()->entry_assembly->image->aotid;
+	printf ("%s\n", mono_guid_to_string(aotid));
+	
+	return mono_string_new (mono_domain_get (), mono_guid_to_string(aotid));
+}
+
 static MonoObject*
 create_version (MonoDomain *domain, guint32 major, guint32 minor, guint32 build, guint32 revision, MonoError *error)
 {

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -271,6 +271,8 @@ struct _MonoImage {
 
 	gpointer aot_module;
 
+	guint8 aotid[16];
+
 	/*
 	 * The Assembly this image was loaded from.
 	 */

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -51,6 +51,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-mmap.h>
+#include <mono/utils/mono-rand.h>
 #include <mono/utils/json.h>
 #include <mono/utils/mono-threads-coop.h>
 
@@ -8862,6 +8863,21 @@ emit_extra_methods (MonoAotCompile *acfg)
 }	
 
 static void
+generate_aotid (guint8* aotid)
+{
+	gpointer *rand_handle;
+	MonoError error;
+
+	mono_rand_open ();
+	rand_handle = mono_rand_init (NULL, 0);
+
+	mono_rand_try_get_bytes (rand_handle, aotid, 16, &error);
+	mono_error_assert_ok (&error);
+
+	mono_rand_close (rand_handle);
+}
+
+static void
 emit_exception_info (MonoAotCompile *acfg)
 {
 	int i;
@@ -9354,6 +9370,8 @@ init_aot_file_info (MonoAotCompile *acfg, MonoAotFileInfo *info)
 	info->nshared_got_entries = acfg->nshared_got_entries;
 	for (i = 0; i < MONO_AOT_TRAMP_NUM; ++i)
 		info->tramp_page_code_offsets [i] = acfg->tramp_page_code_offsets [i];
+
+	generate_aotid(&info->aotid);
 }
 
 static void

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2016,6 +2016,9 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 		find_symbol (sofile, globals, "mono_aot_file_info", (gpointer*)&info);
 	}
 
+	// Copy aotid to MonoImage
+	memcpy(&assembly->image->aotid, info->aotid, 16);
+
 	if (version_symbol) {
 		/* Old file format */
 		version = atoi (version_symbol);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -117,7 +117,7 @@
 #endif
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 133
+#define MONO_AOT_FILE_VERSION 134
 
 //TODO: This is x86/amd64 specific.
 #define mono_simd_shuffle_mask(a,b,c,d) ((a) | ((b) << 2) | ((c) << 4) | ((d) << 6))
@@ -307,6 +307,8 @@ typedef struct MonoAotFileInfo
 	guint32 trampoline_size [MONO_AOT_TRAMP_NUM];
 	/* The offset where the trampolines begin on a trampoline page */
 	guint32 tramp_page_code_offsets [MONO_AOT_TRAMP_NUM];
+	/* GUID of aot compilation */
+	guint8 aotid[16];
 } MonoAotFileInfo;
 
 /* Number of symbols in the MonoAotFileInfo structure */


### PR DESCRIPTION
The upcoming version of mono-symbolicate will require stack traces to display an AOT compilation GUID, and the MVID of each stack frame.

The following [spec](https://docs.google.com/document/d/1ohn_RfGvqWv9EDAPN3GxkM5Ri8GZRbcL3bT0TPj1isg/edit?usp=sharing) explains it on more detail.

The intent of this pull request is to review/discuss and possibly merge the stack traces changes as soon as possible. And verify if it introduces breaking changes or not.