### PR TITLE
[metadata] Fix Windows gcc build break

### DIFF
--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -23,6 +23,7 @@
 #include "domain-internals.h"
 #include "appdomain.h"
 #include "object.h"
+#include "object-internals.h"
 #include "loader.h"
 #include "threads.h"
 #include "environment.h"


### PR DESCRIPTION
After 680fe21e6952ba6dc73ad89095b34ebb3a9bfc86 it failed with:

```
coree.c: In function '_CorExeMain':
coree.c:200:2: error: implicit declaration of function 'mono_runtime_run_main_checked' [-Werror=implicit-function-declaration]
  mono_runtime_run_main_checked (method, argc, argv, &error);
  ^
[...]
Makefile:2137: recipe for target 'libmonoruntime_la-coree.lo' failed
make[3]: *** [libmonoruntime_la-coree.lo] Error 1
```

@lambdageek please take a look :)