### PR TITLE
[System] Make ServicePointTest.DnsRefreshTimeout test more reliable

### DIFF
--- a/mcs/class/System/Test/System.Net/ServicePointTest.cs
+++ b/mcs/class/System/Test/System.Net/ServicePointTest.cs
@@ -219,7 +219,7 @@ public class ServicePointTest
 
 		ServicePointManager.DnsRefreshTimeout = dnsRefreshTimeout;
 
-		uri = new Uri ("http://www.google.com/");
+		uri = new Uri ("http://localhost/");
 		sp = ServicePointManager.FindServicePoint (uri);
 
 		hostEntryProperty = typeof (ServicePoint).GetProperty ("HostEntry", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
We are still seeing quite rare failures of this test:

```
HostEntry should result in the same IPHostEntry object.
  Expected: same as <System.Net.IPHostEntry>
  But was:  <System.Net.IPHostEntry>

+++++++++++++++++++
STACK TRACE:
at MonoTests.System.Net.ServicePointTest.DnsRefreshTimeout () [0x00045] in /Users/builder/jenkins/workspace/test-mono-mainline/label/osx-i386/mcs/class/System/Test/System.Net/ServicePointTest.cs:228
at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in /Users/builder/jenkins/workspace/test-mono-mainline/label/osx-i386/mcs/class/corlib/System.Reflection/MonoMethod.cs:309
```

Since the test is only checking if expiring of the cached DNS lookup works, we don't really need to use an external domain name for this as "localhost" works just fine as well and typically doesn't trigger a DNS query which makes the test more reliable against network issues.

@monojenkins merge