### PR TITLE
[runtime] Fixed interruptible wapi_sendfile part2.

### DIFF
--- a/mono/io-layer/sockets.c
+++ b/mono/io-layer/sockets.c
@@ -996,7 +996,7 @@ wapi_sendfile (guint32 socket, gpointer fd, guint32 bytes_to_write, guint32 byte
 		do {
 			n = send (socket, buffer, n, 0); /* short sends? enclose this in a loop? */
 		} while (n == -1 && errno == EINTR && !_wapi_thread_cur_apc_pending ());
-	} while (n != -1);
+	} while (n != -1 && errno == EINTR && !_wapi_thread_cur_apc_pending ());
 
 	if (n == -1) {
 		gint errnum = errno;


### PR DESCRIPTION
Fixes issue where underlying system without HAVE_SENDFILE
would not interrupt while sending a file even when the socket was
set as a non blocking one.

This is an attempt to fix remaining crashes of SendAsyncFile on ubuntu 1404.