### PR TITLE
[System.Net.Http] Fix CFNetworkHandler.CookieContainer not to return null

### DIFF
--- a/mcs/class/System.Net.Http/CFNetworkHandler.cs
+++ b/mcs/class/System.Net.Http/CFNetworkHandler.cs
@@ -100,7 +100,7 @@ namespace System.Net.Http
 
 		public CookieContainer CookieContainer {
 			get {
-				return cookieContainer ?? (cookieContainer = new CookieContainer ());
+				return cookies ?? (cookies = new CookieContainer ());
 			}
 			set {
 				EnsureModifiability ();

--- a/mcs/class/System.Net.Http/CFNetworkHandler.cs
+++ b/mcs/class/System.Net.Http/CFNetworkHandler.cs
@@ -100,7 +100,7 @@ namespace System.Net.Http
 
 		public CookieContainer CookieContainer {
 			get {
-				return cookies;
+				return cookieContainer ?? (cookieContainer = new CookieContainer ());
 			}
 			set {
 				EnsureModifiability ();


### PR DESCRIPTION
This aligns the handler with the managed HttpClientHandler [1] and make
it easier to switch between them without additional or conditional code.

[1] https://github.com/mono/mono/blob/master/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs#L107