### PR TITLE
Using mono_marshal_free n mono_string_builder_to_utf8

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -938,7 +938,7 @@ mono_string_utf16_to_builder (MonoStringBuilder *sb, gunichar2 *text)
  *
  * Returns: a utf8 string with the contents of the StringBuilder.
  *
- * The return value must be released with g_free.
+ * The return value must be released with mono_marshal_free.
  *
  * This is a JIT icall, it sets the pending exception and returns NULL on error.
  */
@@ -959,14 +959,14 @@ mono_string_builder_to_utf8 (MonoStringBuilder *sb)
 
 	if (gerror) {
 		g_error_free (gerror);
-		g_free (str_utf16);
+		mono_marshal_free (str_utf16);
 		mono_set_pending_exception (mono_get_exception_execution_engine ("Failed to convert StringBuilder from utf16 to utf8"));
 		return NULL;
 	} else {
 		guint len = mono_string_builder_capacity (sb) + 1;
 		gchar *res = (gchar *)mono_marshal_alloc (len * sizeof (gchar), &error);
 		if (!mono_error_ok (&error)) {
-			g_free (str_utf16);
+			mono_marshal_free (str_utf16);
 			g_free (tmp);
 			mono_error_set_pending_exception (&error);
 			return NULL;
@@ -976,7 +976,7 @@ mono_string_builder_to_utf8 (MonoStringBuilder *sb)
 		memcpy (res, tmp, str_len * sizeof (gchar));
 		res[str_len] = '\0';
 
-		g_free (str_utf16);
+		mono_marshal_free (str_utf16);
 		g_free (tmp);
 		return res;
 	}
@@ -990,7 +990,8 @@ mono_string_builder_to_utf8 (MonoStringBuilder *sb)
  *
  * Returns: a utf16 string with the contents of the StringBuilder.
  *
- * The return value must not be freed.
+ * The return value must be released with mono_marshal_free.
+ *
  * This is a JIT icall, it sets the pending exception and returns NULL on error.
  */
 gunichar2*


### PR DESCRIPTION
`mono_string_builder_to_utf16` is allocating using `mono_marshal_alloc` which, on windows, allocates memory using `CoTaskMemAlloc`. This buffer was then released in `mono_string_builder_to_utf8` using `g_free` which resulted in a crash since that's a different memory on windows. The fix in this PR makes sure `mono_marshal_free` is called instead which has the correct behaviour and results in a `CoTaskMemFree` on windows.
