### PR TITLE
[runtime] Fix MonoError lifecycle in do_try_exec_main

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1746,13 +1746,13 @@ mono_runtime_run_main_checked (MonoMethod *method, int argc, char* argv[],
 
 int
 mono_runtime_try_run_main (MonoMethod *method, int argc, char* argv[],
-			   MonoObject **exc, MonoError *error);
+			   MonoObject **exc);
 
 int
 mono_runtime_exec_main_checked (MonoMethod *method, MonoArray *args, MonoError *error);
 
 int
-mono_runtime_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc, MonoError *error);
+mono_runtime_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc);
 
 
 #endif /* __MONO_OBJECT_INTERNALS_H__ */

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1029,11 +1029,7 @@ mono_jit_exec (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[
 		MonoObject *exc = NULL;
 		int res;
 
-		res = mono_runtime_try_run_main (method, argc, argv, &exc, &error);
-		if (exc == NULL && !is_ok (&error))
-			exc = (MonoObject*) mono_error_convert_to_exception (&error);
-		else
-			mono_error_cleanup (&error);
+		res = mono_runtime_try_run_main (method, argc, argv, &exc);
 		if (exc) {
 			mono_unhandled_exception (exc);
 			mono_invoke_unhandled_exception_hook (exc);


### PR DESCRIPTION
The do_try_exec_main function is always called in contexts where any
exception from doing the invoke is going to be stored in the exc outarg.
That means any MonoError will be handled locally by do_try_exec_main.
So we don't need a MonoError argument, we just need an inner_error.