### PR TITLE
Fix out-of-tree builds.

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -313,10 +313,10 @@ if SHARED_MONO
 pedump_SOURCES =		\
 	pedump.c
 
-$(top_srcdir)/mono/sgen/libmonosgen.la:
-	make -w -C $(top_srcdir)/mono/sgen libmonosgen.la
+../sgen/libmonosgen.la:
+	make -w -C ../sgen libmonosgen.la
 
-pedump_LDADD = $(sgen_libraries) $(top_srcdir)/mono/sgen/libmonosgen.la ../io-layer/libwapi.la ../utils/libmonoutils.la \
+pedump_LDADD = $(sgen_libraries) ../sgen/libmonosgen.la ../io-layer/libwapi.la ../utils/libmonoutils.la \
 	$(GLIB_LIBS) -lm $(LIBICONV) $(PEDUMP_DTRACE_OBJECT)
 
 if PLATFORM_DARWIN


### PR DESCRIPTION
Using top_srcdir to reference built files in
7bbf991bfff66e3e35ecc7e3a7217a8e81364af9 broke this.