### PR TITLE
[linker] Add MonoMethodMessage::InitMessage to mscorlib descriptor

### DIFF
--- a/mcs/tools/linker/Descriptors/mscorlib.xml
+++ b/mcs/tools/linker/Descriptors/mscorlib.xml
@@ -290,7 +290,9 @@
 		<type fullname="System.Runtime.Remoting.Messaging.CallContext">
 			<method name="SetCurrentCallContext" />
 		</type>
-		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields" />
+		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields">
+			<method name="InitMessage" />
+		</type>
 		<type fullname="System.Runtime.Remoting.Proxies.RealProxy" preserve="fields">
 			<method name="PrivateInvoke" />
 			<method name="GetAppDomainTarget" />


### PR DESCRIPTION
That method gets called from the runtime, it shouldn't be linked out.