### PR TITLE
[coop] Protect copy_stack_data from GCC optimizations.

### DIFF
--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -145,11 +145,14 @@ mono_threads_state_poll_with_info (MonoThreadInfo *info)
 	}
 }
 
-static void *
-return_stack_ptr ()
+static volatile gpointer* dummy_global;
+
+static void*
+MONO_NEVER_INLINE
+return_stack_ptr (gpointer *i)
 {
-	gpointer i;
-	return &i;
+	dummy_global = i;
+	return i;
 }
 
 static void
@@ -157,7 +160,8 @@ copy_stack_data (MonoThreadInfo *info, gpointer *stackdata_begin)
 {
 	MonoThreadUnwindState *state;
 	int stackdata_size;
-	void* stackdata_end = return_stack_ptr ();
+	gpointer dummy;
+	void* stackdata_end = return_stack_ptr (&dummy);
 
 	SAVE_REGS_ON_STACK;
 

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -147,8 +147,8 @@ mono_threads_state_poll_with_info (MonoThreadInfo *info)
 
 static volatile gpointer* dummy_global;
 
-static void*
-MONO_NEVER_INLINE
+static MONO_NEVER_INLINE
+void*
 return_stack_ptr (gpointer *i)
 {
 	dummy_global = i;


### PR DESCRIPTION
GCC 5.3.1 (Debian sid/amd64) "optimizied" the previous incarnation of
`void *stackdata_end = return_stack_ptr ()` to
`void *stackdata_end = 0`.