### PR TITLE
[library.make] Make resource usage declarative in the class libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -152,6 +152,7 @@ package-inputs:
 		 read libou;  echo "      <library_output>$$libou</library_output>"; \
 		 read fx_ver; echo "      <fx_version>$$fx_ver</fx_version>"; \
 		 read profile; echo "      <profile>$$profile</profile>"; \
+		 read resxt;  echo "      <resources>$$resxt</resources>"; \
 		 read resp;   echo "      <response>$$resp</response>"; \
 		 echo "    </project>") >> msvc/scripts/order.xml; \
 	done

--- a/mcs/build/README.makefiles
+++ b/mcs/build/README.makefiles
@@ -15,8 +15,6 @@ build system needs to let us do, specifically:
 
 
 
-
-
 ** Makefile structure
 
 A general makefile looks like this:
@@ -438,7 +436,15 @@ To give it flags, set $(LOCAL_CFLAGS). As with compiling C#, the
 variable $(CFLAGS) will automatically be included on the command line.
 
 
+* Compiling resources with resgen
 
+If you have a resource that should be compiled with resgen and
+included in your assembly, you can use the RESOURCES_DEFS variable.
+This variable can contain lists of pairs that are separated by comma
+to represent the resource ID as embedded in the assembly followed by
+the file name, like this:
+
+RESOURCE_DEFS = Messages,TextResources.resx Errors,ErrorList.txt
 
 
 * Documentation-related needs? Use $(MDOC)

--- a/mcs/build/executable.make
+++ b/mcs/build/executable.make
@@ -173,6 +173,7 @@ csproj-local:
 	echo $(build_lib); \
 	echo $(FRAMEWORK_VERSION); \
 	echo $(PROFILE); \
+	echo $(RESOURCE_DEFS); \
 	echo $(response)) > $(topdir)/../msvc/scripts/inputs/$$config_file
 
 

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -145,6 +145,7 @@ csproj-library:
 	echo $(build_lib); \
 	echo $(FRAMEWORK_VERSION); \
 	echo $(PROFILE); \
+	echo $(RESOURCE_DEFS); \
 	echo $(response)) > $(topdir)/../msvc/scripts/inputs/$$config_file
 
 csproj-test:
@@ -216,7 +217,28 @@ clean-local:
 test-local run-test-local run-test-ondotnet-local:
 	@:
 
-DISTFILES = $(wildcard *$(LIBRARY)*.sources) $(EXTRA_DISTFILES)
+#
+# RESOURCES_DEFS is a list of ID,FILE pairs separated by spaces
+# for each of those, generate a rule that produces ID.resource from
+# FILE using the resgen tool, adds the generated file to CLENA_FILES and
+# passes the resource to the compiler
+#
+ccomma = ,
+define RESOURCE_template
+$(1).resources: $(2)
+	resgen "$$<" "$$@"
+
+GEN_RESOURCE_DEPS += $(1).resources
+GEN_RESOURCE_FLAGS += -resource:$(1).resources
+CLEAN_FILES += $(1).resources
+DIST_LISTED_RESOURCES += $(2)
+endef
+
+ifdef RESOURCE_DEFS
+$(foreach pair,$(RESOURCE_DEFS), $(eval $(call RESOURCE_template,$(word 1, $(subst $(ccomma), ,$(pair))), $(word 2, $(subst $(ccomma), ,$(pair))))))
+endif
+
+DISTFILES = $(wildcard *$(LIBRARY)*.sources) $(EXTRA_DISTFILES) $(DIST_LISTED_RESOURCES)
 
 ASSEMBLY      = $(LIBRARY)
 ASSEMBLY_EXT  = .dll
@@ -236,6 +258,7 @@ csproj-test:
 	echo $(test_lib); \
 	echo $(FRAMEWORK_VERSION); \
 	echo $(PROFILE); \
+	echo ""; \
 	echo $(test_response)) > $(topdir)/../msvc/scripts/inputs/$$config_file
 
 endif
@@ -275,8 +298,8 @@ endif
 
 $(the_lib): $(the_libdir)/.stamp
 
-$(build_lib): $(response) $(sn) $(BUILT_SOURCES) $(build_libdir:=/.stamp)
-	$(LIBRARY_COMPILE) $(LIBRARY_FLAGS) $(LIB_MCS_FLAGS) -target:library -out:$@ $(BUILT_SOURCES_cmdline) @$(response)
+$(build_lib): $(response) $(sn) $(BUILT_SOURCES) $(build_libdir:=/.stamp) $(GEN_RESOURCE_DEPS)
+	$(LIBRARY_COMPILE) $(LIBRARY_FLAGS) $(LIB_MCS_FLAGS) $(GEN_RESOURCE_FLAGS) -target:library -out:$@ $(BUILT_SOURCES_cmdline) @$(response)
 ifdef RESOURCE_STRINGS_FILES
 	$(Q) $(STRING_REPLACER) $(RESOURCE_STRINGS_FILES) $@
 endif

--- a/mcs/class/Novell.Directory.Ldap/Makefile
+++ b/mcs/class/Novell.Directory.Ldap/Makefile
@@ -5,25 +5,14 @@ include ../../build/rules.make
 LIBRARY = Novell.Directory.Ldap.dll
 
 LIB_REFS = System Mono.Security
-LIB_MCS_FLAGS = \
-	-warn:1 -nowarn:612 \
-	$(RESX_RES:%=/res:%)
+LIB_MCS_FLAGS = -warn:1 -nowarn:612 
 
+RESOURCE_DEFS = ResultCodeMessages,Novell.Directory.Ldap.Utilclass/ResultCodeMessages.txt
 include ../../build/library.make
-
-RESULTCODE_MESSAGES = Novell.Directory.Ldap.Utilclass/ResultCodeMessages.resources
-
-RESX_RES = $(RESULTCODE_MESSAGES)
-
-$(the_lib): $(RESULTCODE_MESSAGES)
-
-$(RESULTCODE_MESSAGES): Novell.Directory.Ldap.Utilclass/ResultCodeMessages.txt
-	$(RESGEN) $< $@
 
 EXTRA_DISTFILES = \
 	Novell.Directory.Ldap.Rfc2251/RfcLdapURL.cs \
 	Novell.Directory.Ldap.Utilclass/ExceptionMessages.resx \
 	Novell.Directory.Ldap.Utilclass/ExceptionMessages.txt \
-	Novell.Directory.Ldap.Utilclass/ResultCodeMessages.resx \
-	Novell.Directory.Ldap.Utilclass/ResultCodeMessages.txt 
+	Novell.Directory.Ldap.Utilclass/ResultCodeMessages.resx
 

--- a/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap-net_4_x.csproj
+++ b/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap-net_4_x.csproj
@@ -303,7 +303,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Novell.Directory.Ldap.Utilclass/ResultCodeMessages.resx">
+    <EmbeddedResource Include="Novell.Directory.Ldap.Utilclass/ResultCodeMessages.txt">
       <LogicalName>ResultCodeMessages.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/mcs/class/System.ComponentModel.Composition.4.5/Makefile
+++ b/mcs/class/System.ComponentModel.Composition.4.5/Makefile
@@ -4,18 +4,16 @@ include ../../build/rules.make
 
 LIBRARY = System.ComponentModel.Composition.dll
 LIB_REFS = System System.Core
-LIB_MCS_FLAGS = -d:CLR40 -resource:$(STRING_MESSAGES) -d:USE_ECMA_KEY,FEATURE_REFLECTIONCONTEXT,FEATURE_REFLECTIONFILEIO,FEATURE_SERIALIZATION,FEATURE_SLIMLOCK -nowarn:219,414
 
-STRING_MESSAGES = Microsoft.Internal.Strings.resources
+RESOURCE_DEFS = Microsoft.Internal.Strings,src/ComponentModel/Strings.resx
+LIB_MCS_FLAGS = -d:CLR40 -d:USE_ECMA_KEY,FEATURE_REFLECTIONCONTEXT,FEATURE_REFLECTIONFILEIO,FEATURE_SERIALIZATION,FEATURE_SLIMLOCK -nowarn:219,414
+
 
 CLEAN_FILES += $(STRING_MESSAGES)
 
 EXTRA_DISTFILES = \
 	src/ComponentModel/Strings.resx
-	
+
 include ../../build/library.make
 
-$(the_lib): $(STRING_MESSAGES)
 
-$(STRING_MESSAGES): src/ComponentModel/Strings.resx
-	$(RESGEN) $< $@

--- a/mcs/class/System.ComponentModel.Composition.4.5/System.ComponentModel.Composition-net_4_x.csproj
+++ b/mcs/class/System.ComponentModel.Composition.4.5/System.ComponentModel.Composition-net_4_x.csproj
@@ -232,10 +232,10 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-resgen $(ProjectDir)\src\ComponentModel\Strings.resx $(ProjectDir)\Microsoft.Internal.Strings.resx
+
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-resgen $(ProjectDir)\src\ComponentModel\Strings.resx $(ProjectDir)\Microsoft.Internal.Strings.resx
+
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
 
@@ -262,7 +262,7 @@ resgen $(ProjectDir)\src\ComponentModel\Strings.resx $(ProjectDir)\Microsoft.Int
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Microsoft.Internal.Strings.resx">
+    <EmbeddedResource Include="src/ComponentModel/Strings.resx">
       <LogicalName>Microsoft.Internal.Strings.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/mcs/class/System.Data.Services.Client/Makefile
+++ b/mcs/class/System.Data.Services.Client/Makefile
@@ -4,13 +4,11 @@ include ../../build/rules.make
 
 LIBRARY = System.Data.Services.Client.dll
 
-Client/System.Data.Services.Client.resources: Client/System.Data.Services.Client.txt
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = System.Data.Services.Client,Client/System.Data.Services.Client.txt
 
 LIB_REFS = System System.Core System.Xml.Linq System.Data System.Xml
 LIB_MCS_FLAGS = \
 	-d:NET_3_5	\
-	-resource:Client/System.Data.Services.Client.resources \
 	-warn:2
 
 ifndef NO_WINDOWS_BASE
@@ -21,7 +19,5 @@ endif
 
 include ../../build/library.make
 
-$(the_lib): Client/System.Data.Services.Client.resources
-
 EXTRA_DISTFILES = Client/System.Data.Services.Client.txt
-CLEAN_FILES += Client/System.Data.Services.Client.resources
+

--- a/mcs/class/System.Data.Services.Client/System.Data.Services.Client-net_4_x.csproj
+++ b/mcs/class/System.Data.Services.Client/System.Data.Services.Client-net_4_x.csproj
@@ -173,10 +173,10 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-resgen $(ProjectDir)\Client\System.Data.Services.Client.txt $(ProjectDir)\Client\System.Data.Services.Client.resx
+
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-resgen $(ProjectDir)\Client\System.Data.Services.Client.txt $(ProjectDir)\Client\System.Data.Services.Client.resx
+
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
 
@@ -219,7 +219,7 @@ resgen $(ProjectDir)\Client\System.Data.Services.Client.txt $(ProjectDir)\Client
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Client/System.Data.Services.Client.resx">
+    <EmbeddedResource Include="Client/System.Data.Services.Client.txt">
       <LogicalName>System.Data.Services.Client.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/mcs/class/System.Json.Microsoft/Makefile
+++ b/mcs/class/System.Json.Microsoft/Makefile
@@ -2,14 +2,11 @@ thisdir = class/System.Json.Microsoft
 SUBDIRS = 
 include ../../build/rules.make
 
-System.Json/Properties/Resources.resources: System.Json/Properties/Resources.resx
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = System.Json.Properties.Resources,System.Json/Properties/Resources.resx
 
 LIBRARY = System.Json.Microsoft.dll
 LIB_REFS = System System.Xml System.Core System.Runtime.Serialization
-LIB_MCS_FLAGS = /d:ASPNETMVC -keyfile:../winfx.pub -delaysign \
-		/resource:System.Json/Properties/Resources.resources,System.Json.Properties.Resources.resources
-
+LIB_MCS_FLAGS = /d:ASPNETMVC -keyfile:../winfx.pub -delaysign 
 EXTRA_DISTFILES = System.Json/Properties/Resources.resx
 
 ifeq (4, $(FRAMEWORK_VERSION_MAJOR))
@@ -24,5 +21,3 @@ endif
 TEST_MCS_FLAGS = $(LIB_MCS_FLAGS)
 
 include ../../build/library.make
-
-$(the_lib): System.Json/Properties/Resources.resources

--- a/mcs/class/System.Json.Microsoft/System.Json.Microsoft-net_4_x.csproj
+++ b/mcs/class/System.Json.Microsoft/System.Json.Microsoft-net_4_x.csproj
@@ -83,10 +83,10 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-cp $(ProjectDir)\System.Json\Properties\Resources.resx System.Json.Properties.Resources.resx
+
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-cp $(ProjectDir)\System.Json\Properties\Resources.resx System.Json.Properties.Resources.resx
+
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
 

--- a/mcs/class/System.Net.Http.Formatting/Makefile
+++ b/mcs/class/System.Net.Http.Formatting/Makefile
@@ -4,19 +4,12 @@ include ../../build/rules.make
 
 LIBRARY = System.Net.Http.Formatting.dll
 
-System.Net.Http.Properties.CommonWebApiResources.resources: ../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = \
+	System.Net.Http.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx \
+	System.Net.Http.Properties.Resources,../../../external/aspnetwebstack/src/System.Net.Http.Formatting/Properties/Resources.resx
 
-System.Net.Http.Properties.Resources.resources: ../../../external/aspnetwebstack/src/System.Net.Http.Formatting/Properties/Resources.resx
-	$(RESGEN) "$<" "$@"
 
 LIB_REFS = System.Core System System.Net.Http System.Xml System.Runtime.Serialization System.Xml.Linq System.Data System.Configuration
-LIB_MCS_FLAGS = \
-		-d:ASPNETMVC -keyfile:../winfx.pub -delaysign \
-		-resource:System.Net.Http.Properties.CommonWebApiResources.resources \
-		-resource:System.Net.Http.Properties.Resources.resources
+LIB_MCS_FLAGS = -d:ASPNETMVC -keyfile:../winfx.pub -delaysign 
 
 include ../../build/library.make
-
-$(the_lib): System.Net.Http.Properties.CommonWebApiResources.resources \
-	System.Net.Http.Properties.Resources.resources

--- a/mcs/class/System.Net.Http.Formatting/System.Net.Http.Formatting-net_4_x.csproj
+++ b/mcs/class/System.Net.Http.Formatting/System.Net.Http.Formatting-net_4_x.csproj
@@ -299,13 +299,9 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx $(ProjectDir)/System.Net.Http.Properties.CommonWebApiResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Net.Http.Formatting/Properties/Resources.resx $(ProjectDir)/System.Net.Http.Properties.Resources.resx
 
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx $(ProjectDir)/System.Net.Http.Properties.CommonWebApiResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Net.Http.Formatting/Properties/Resources.resx $(ProjectDir)/System.Net.Http.Properties.Resources.resx
 
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
@@ -357,10 +353,10 @@ cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Net.Http.Formatting
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="System.Net.Http.Properties.CommonWebApiResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx">
       <LogicalName>System.Net.Http.Properties.CommonWebApiResources.resources</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="System.Net.Http.Properties.Resources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Net.Http.Formatting/Properties/Resources.resx">
       <LogicalName>System.Net.Http.Properties.Resources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/mcs/class/System.Web.Http.SelfHost/Makefile
+++ b/mcs/class/System.Web.Http.SelfHost/Makefile
@@ -4,17 +4,12 @@ include ../../build/rules.make
 
 LIBRARY = System.Web.Http.SelfHost.dll
 
-System.Web.Http.SelfHost.Properties.CommonWebApiResources.resources: ../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx
-	$(RESGEN) "$<" "$@"
-
-System.Web.Http.SelfHost.Properties.SRResources.resources: ../../../external/aspnetwebstack/src/System.Web.Http.SelfHost/Properties/SRResources.resx
-	$(RESGEN) "$<" "$@"
-
+RESOURCE_DEFS = \
+	System.Web.Http.SelfHost.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx \
+	System.Web.Http.SelfHost.Properties.SRResources,../../../external/aspnetwebstack/src/System.Web.Http.SelfHost/Properties/SRResources.resx
 
 LIB_REFS = System.Core System System.Xml System.Configuration System.Net.Http System.Runtime.Serialization System.ServiceModel System.IdentityModel System.Web.Http System.Net.Http.Formatting
 LIB_MCS_FLAGS = -d:ASPNETMVC -keyfile:../winfx.pub -delaysign
 
 include ../../build/library.make
 
-$(the_lib): System.Web.Http.SelfHost.Properties.CommonWebApiResources.resources \
-	System.Web.Http.SelfHost.Properties.SRResources.resources

--- a/mcs/class/System.Web.Http.SelfHost/System.Web.Http.SelfHost-net_4_x.csproj
+++ b/mcs/class/System.Web.Http.SelfHost/System.Web.Http.SelfHost-net_4_x.csproj
@@ -165,5 +165,13 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx">
+      <LogicalName>System.Web.Http.SelfHost.Properties.CommonWebApiResources.resources</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Web.Http.SelfHost/Properties/SRResources.resx">
+      <LogicalName>System.Web.Http.SelfHost.Properties.SRResources.resources</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>
 

--- a/mcs/class/System.Web.Http.WebHost/Makefile
+++ b/mcs/class/System.Web.Http.WebHost/Makefile
@@ -4,17 +4,13 @@ include ../../build/rules.make
 
 LIBRARY = System.Web.Http.WebHost.dll
 
-System.Web.Http.WebHost.Properties.CommonWebApiResources.resources: ../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx
-	$(RESGEN) "$<" "$@"
-
-System.Web.Http.WebHost.Properties.SRResources.resources: ../../../external/aspnetwebstack/src/System.Web.Http.WebHost/Properties/SRResources.resx
-	$(RESGEN) "$<" "$@"
-
+RESOURCE_DEFS = \
+	System.Web.Http.WebHost.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx \
+	System.Web.Http.WebHost.Properties.SRResources,../../../external/aspnetwebstack/src/System.Web.Http.WebHost/Properties/SRResources.resx
 
 LIB_REFS = System.Core System System.Xml System.Configuration System.Net.Http System.Runtime.Serialization System.ServiceModel System.IdentityModel System.Web.Http System.Net.Http.Formatting System.Web.Routing System.Web Microsoft.Web.Infrastructure
 LIB_MCS_FLAGS = -d:ASPNETMVC -keyfile:../winfx.pub -delaysign
 
 include ../../build/library.make
 
-$(the_lib): System.Web.Http.WebHost.Properties.CommonWebApiResources.resources \
-	System.Web.Http.WebHost.Properties.SRResources.resources
+$(the_lib): 

--- a/mcs/class/System.Web.Http.WebHost/System.Web.Http.WebHost-net_4_x.csproj
+++ b/mcs/class/System.Web.Http.WebHost/System.Web.Http.WebHost-net_4_x.csproj
@@ -165,5 +165,13 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx">
+      <LogicalName>System.Web.Http.WebHost.Properties.CommonWebApiResources.resources</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Web.Http.WebHost/Properties/SRResources.resx">
+      <LogicalName>System.Web.Http.WebHost.Properties.SRResources.resources</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>
 

--- a/mcs/class/System.Web.Http/Makefile
+++ b/mcs/class/System.Web.Http/Makefile
@@ -4,20 +4,13 @@ include ../../build/rules.make
 
 LIBRARY = System.Web.Http.dll
 
-System.Web.Http.Properties.CommonWebApiResources.resources: ../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx
-	$(RESGEN) "$<" "$@"
-	
-System.Web.Http.Properties.SRResources.resources: ../../../external/aspnetwebstack/src/System.Web.Http/Properties/SRResources.resx
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = \
+	System.Web.Http.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx \
+	System.Web.Http.Properties.SRResources,../../../external/aspnetwebstack/src/System.Web.Http/Properties/SRResources.resx
+
 
 
 LIB_REFS = System.Core System System.Xml System.Net.Http System.ComponentModel.DataAnnotations System.Net.Http.Formatting System.Runtime.Caching System.Runtime.Serialization System.Data.Linq
-LIB_MCS_FLAGS = \
-		-d:ASPNETMVC -keyfile:../winfx.pub -delaysign \
-		-resource:System.Web.Http.Properties.CommonWebApiResources.resources \
-		-resource:System.Web.Http.Properties.SRResources.resources
+LIB_MCS_FLAGS = -d:ASPNETMVC -keyfile:../winfx.pub -delaysign 
 
 include ../../build/library.make
-
-$(the_lib): System.Web.Http.Properties.CommonWebApiResources.resources \
-	System.Web.Http.Properties.SRResources.resources

--- a/mcs/class/System.Web.Http/System.Web.Http-net_4_x.csproj
+++ b/mcs/class/System.Web.Http/System.Web.Http-net_4_x.csproj
@@ -327,13 +327,9 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx $(ProjectDir)/System.Web.Http.Properties.CommonWebApiResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.Http/Properties/SRResources.resx $(ProjectDir)/System.Web.Http.Properties.SRResources.resx
 
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx $(ProjectDir)/System.Web.Http.Properties.CommonWebApiResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.Http/Properties/SRResources.resx $(ProjectDir)/System.Web.Http.Properties.SRResources.resx
 
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
@@ -389,10 +385,10 @@ cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.Http/Properties
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="System.Web.Http.Properties.CommonWebApiResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx">
       <LogicalName>System.Web.Http.Properties.CommonWebApiResources.resources</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="System.Web.Http.Properties.SRResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Web.Http/Properties/SRResources.resx">
       <LogicalName>System.Web.Http.Properties.SRResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/mcs/class/System.Web.Mvc3/Makefile
+++ b/mcs/class/System.Web.Mvc3/Makefile
@@ -5,6 +5,7 @@ include ../../build/rules.make
 LIBRARY = System.Web.Mvc3.dll
 LIBRARY_NAME = System.Web.Mvc.dll
 
+RESOURCE_DEFS = System.Web.Mvc.Resources.MvcResources,Mvc/Resources/MvcResources.resx
 RESX_DIST =  Mvc/Resources/MvcResources.resx
 
 LIB_REFS = Microsoft.Web.Infrastructure System System.Core System.Configuration System.Data System.Xml System.Web System.Web.Abstractions System.Web.Routing System.Web.Extensions System.ComponentModel.DataAnnotations System.Data.Linq System.Runtime.Caching System.Web.Razor System.Web.WebPages.Razor System.Web.WebPages
@@ -12,14 +13,9 @@ LIB_MCS_FLAGS = \
 		/warn:1 \
 		/keyfile:../winfx.pub \
 		/d:MONO \
-		/delaysign \
-		$(foreach r, $(RESOURCES), /resource:$(r),System.Web.Mvc.Resources.$(notdir $(r)))
+		/delaysign
 
 EXTRA_DISTFILES = $(RESX_DIST)
-RESOURCES = $(RESX_DIST:.resx=.resources)
+
 include ../../build/library.make
 
-$(build_lib): $(RESOURCES)
-
-$(RESOURCES): %.resources: %.resx
-	$(RESGEN) `echo $< | $(PLATFORM_CHANGE_SEPARATOR_CMD)`

--- a/mcs/class/System.Web.Razor/Makefile
+++ b/mcs/class/System.Web.Razor/Makefile
@@ -5,21 +5,15 @@ include ../../build/rules.make
 LIBRARY = System.Web.Razor.dll
 LIBRARY_NAME = System.Web.Razor.dll
 
-System.Web.Razor.Common.CommonResources.resources: ../../../external/aspnetwebstack/src/CommonResources.resx
-	$(RESGEN) "$<" "$@"
-	
-System.Web.Razor.Resources.RazorResources.resources: ../../../external/aspnetwebstack/src/System.Web.Razor/Resources/RazorResources.resx
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = \
+	System.Web.Razor.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx \
+	System.Web.Razor.Resources.RazorResources,../../../external/aspnetwebstack/src/System.Web.Razor/Resources/RazorResources.resx
 
 LIB_REFS = System System.Core
 LIB_MCS_FLAGS = \
 		/warn:1 \
 		/keyfile:../winfx.pub -delaysign \
-	        /d:ASPNETWEBPAGES \
-		/resource:System.Web.Razor.Resources.RazorResources.resources \
-		/resource:System.Web.Razor.Common.CommonResources.resources
+	        /d:ASPNETWEBPAGES 
 
 include ../../build/library.make
 
-$(build_lib): System.Web.Razor.Resources.RazorResources.resources \
-		System.Web.Razor.Common.CommonResources.resources

--- a/mcs/class/System.Web.Razor/System.Web.Razor-net_4_x.csproj
+++ b/mcs/class/System.Web.Razor/System.Web.Razor-net_4_x.csproj
@@ -213,12 +213,10 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-resgen $(ProjectDir)\..\..\..\external\aspnetwebstack\src\CommonResources.resx $(ProjectDir)\System.Web.Razor.Common.CommonResources.resx
-resgen $(ProjectDir)\..\..\..\external\aspnetwebstack\src\System.Web.Razor\Resources\RazorResources.resx $(ProjectDir)\System.Web.Razor.Resources.RazorResources.resx
+
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-resgen $(ProjectDir)\..\..\..\external\aspnetwebstack\src\CommonResources.resx $(ProjectDir)\System.Web.Razor.Common.CommonResources.resx
-resgen $(ProjectDir)\..\..\..\external\aspnetwebstack\src\System.Web.Razor\Resources\RazorResources.resx $(ProjectDir)\System.Web.Razor.Resources.RazorResources.resx
+
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
 
@@ -245,11 +243,11 @@ resgen $(ProjectDir)\..\..\..\external\aspnetwebstack\src\System.Web.Razor\Resou
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="System.Web.Razor.Resources.RazorResources.resx">
-      <LogicalName>System.Web.Razor.Resources.RazorResources.resources</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="System.Web.Razor.Common.CommonResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/CommonResources.resx">
       <LogicalName>System.Web.Razor.Common.CommonResources.resources</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Web.Razor/Resources/RazorResources.resx">
+      <LogicalName>System.Web.Razor.Resources.RazorResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/mcs/class/System.Web.WebPages.Deployment/Makefile
+++ b/mcs/class/System.Web.WebPages.Deployment/Makefile
@@ -5,21 +5,15 @@ include ../../build/rules.make
 LIBRARY = System.Web.WebPages.Deployment.dll
 LIBRARY_NAME = System.Web.WebPages.Deployment.dll
 
-System.Web.WebPages.Deployment.Common.CommonResources.resources: ../../../external/aspnetwebstack/src/CommonResources.resx
-	$(RESGEN) "$<" "$@"
-	
-System.Web.WebPages.Deployment.Resources.ConfigurationResources.resources: ../../../external/aspnetwebstack/src/System.Web.WebPages.Deployment/Resources/ConfigurationResources.resx
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = \
+	System.Web.WebPages.Deployment.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx \
+	System.Web.WebPages.Deployment.Resources.ConfigurationResources,../../../external/aspnetwebstack/src/System.Web.WebPages.Deployment/Resources/ConfigurationResources.resx
+
 
 LIB_REFS = System System.Core System.Configuration System.Web Microsoft.Web.Infrastructure
 LIB_MCS_FLAGS = \
 		/warn:1 \
 		/keyfile:../winfx.pub -delaysign \
-	        /d:ASPNETWEBPAGES \
-		/resource:System.Web.WebPages.Deployment.Common.CommonResources.resources \
-		/resource:System.Web.WebPages.Deployment.Resources.ConfigurationResources.resources
+	        /d:ASPNETWEBPAGES 
 
 include ../../build/library.make
-
-$(build_lib): System.Web.WebPages.Deployment.Common.CommonResources.resources \
-		System.Web.WebPages.Deployment.Resources.ConfigurationResources.resources

--- a/mcs/class/System.Web.WebPages.Deployment/System.Web.WebPages.Deployment-net_4_x.csproj
+++ b/mcs/class/System.Web.WebPages.Deployment/System.Web.WebPages.Deployment-net_4_x.csproj
@@ -81,13 +81,9 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages.Deployment/Resources/ConfigurationResources.resx $(ProjectDir)/System.Web.WebPages.Deployment.Resources.ConfigurationResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(ProjectDir)/System.Web.WebPages.Deployment.Common.CommonResources.resx
 
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages.Deployment/Resources/ConfigurationResources.resx $(ProjectDir)/System.Web.WebPages.Deployment.Resources.ConfigurationResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(ProjectDir)/System.Web.WebPages.Deployment.Common.CommonResources.resx
 
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
@@ -127,10 +123,10 @@ cp $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(Pro
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="System.Web.WebPages.Deployment.Common.CommonResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/CommonResources.resx">
       <LogicalName>System.Web.WebPages.Deployment.Common.CommonResources.resources</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="System.Web.WebPages.Deployment.Resources.ConfigurationResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Web.WebPages.Deployment/Resources/ConfigurationResources.resx">
       <LogicalName>System.Web.WebPages.Deployment.Resources.ConfigurationResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/mcs/class/System.Web.WebPages.Razor/Makefile
+++ b/mcs/class/System.Web.WebPages.Razor/Makefile
@@ -5,24 +5,18 @@ include ../../build/rules.make
 LIBRARY = System.Web.WebPages.Razor.dll
 LIBRARY_NAME = System.Web.WebPages.Razor.dll
 
-System.Web.WebPages.Razor.Common.CommonResources.resources: ../../../external/aspnetwebstack/src/CommonResources.resx
-	$(RESGEN) "$<" "$@"
-	
-System.Web.WebPages.Razor.Resources.RazorWebResources.resources: ../../../external/aspnetwebstack/src/System.Web.WebPages.Razor/Resources/RazorWebResources.resx
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = \
+	System.Web.WebPages.Razor.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx \
+	System.Web.WebPages.Razor.Resources.RazorWebResources,../../../external/aspnetwebstack/src/System.Web.WebPages.Razor/Resources/RazorWebResources.resx
 
 LIB_REFS = System System.Core System.Configuration System.Web System.Web.WebPages System.Web.Razor
 LIB_MCS_FLAGS = \
 		/warn:1 \
 		/keyfile:../winfx.pub \
 		/delaysign \
-	        /d:ASPNETWEBPAGES \
-		/resource:System.Web.WebPages.Razor.Resources.RazorWebResources.resources \
-		/resource:System.Web.WebPages.Razor.Common.CommonResources.resources
+	        /d:ASPNETWEBPAGES
 
 include ../../build/library.make
 
-$(build_lib): System.Web.WebPages.Razor.Resources.RazorWebResources.resources \
-		System.Web.WebPages.Razor.Common.CommonResources.resources
 
 

--- a/mcs/class/System.Web.WebPages.Razor/System.Web.WebPages.Razor-net_4_x.csproj
+++ b/mcs/class/System.Web.WebPages.Razor/System.Web.WebPages.Razor-net_4_x.csproj
@@ -84,12 +84,10 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(ProjectDir)/System.Web.WebPages.Razor.Common.CommonResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages.Razor/Resources/RazorWebResources.resx $(ProjectDir)/System.Web.WebPages.Razor.Resources.RazorWebResources.resx
+
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(ProjectDir)/System.Web.WebPages.Razor.Common.CommonResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages.Razor/Resources/RazorWebResources.resx $(ProjectDir)/System.Web.WebPages.Razor.Resources.RazorWebResources.resx
+
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
 
@@ -132,11 +130,11 @@ cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages.Razor/
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="System.Web.WebPages.Razor.Resources.RazorWebResources.resx">
-      <LogicalName>System.Web.WebPages.Razor.Resources.RazorWebResources.resources</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="System.Web.WebPages.Razor.Common.CommonResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/CommonResources.resx">
       <LogicalName>System.Web.WebPages.Razor.Common.CommonResources.resources</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Web.WebPages.Razor/Resources/RazorWebResources.resx">
+      <LogicalName>System.Web.WebPages.Razor.Resources.RazorWebResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/mcs/class/System.Web.WebPages/Makefile
+++ b/mcs/class/System.Web.WebPages/Makefile
@@ -5,24 +5,18 @@ include ../../build/rules.make
 LIBRARY = System.Web.WebPages.dll
 LIBRARY_NAME = System.Web.WebPages.dll
 
-System.Web.WebPages.Common.CommonResources.resources: ../../../external/aspnetwebstack/src/CommonResources.resx
-	$(RESGEN) "$<" "$@"
-	
-System.Web.WebPages.Resources.WebPageResources.resources: ../../../external/aspnetwebstack/src/System.Web.WebPages/Resources/WebPageResources.resx
-	$(RESGEN) "$<" "$@"
+RESOURCE_DEFS = \
+	System.Web.WebPages.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx \
+	System.Web.WebPages.Resources.WebPageResources,../../../external/aspnetwebstack/src/System.Web.WebPages/Resources/WebPageResources.resx
 
 LIB_REFS = Microsoft.CSharp Microsoft.Web.Infrastructure System System.ComponentModel.DataAnnotations System.Configuration System.Core System.Data.Linq System.Web System.Web.WebPages.Deployment System.Web.Razor System.Xml System.Xml.Linq
+
 LIB_MCS_FLAGS = \
 		/warn:1 \
 		/keyfile:../winfx.pub \
 		/delaysign \
-	        /d:ASPNETWEBPAGES \
-		/resource:System.Web.WebPages.Resources.WebPageResources.resources \
-		/resource:System.Web.WebPages.Common.CommonResources.resources
+	        /d:ASPNETWEBPAGES 
 
 EXTRA_DISTFILES = $(RESX_DIST)
 
 include ../../build/library.make
-
-$(build_lib): System.Web.WebPages.Resources.WebPageResources.resources \
-		System.Web.WebPages.Common.CommonResources.resources

--- a/mcs/class/System.Web.WebPages/System.Web.WebPages-net_4_x.csproj
+++ b/mcs/class/System.Web.WebPages/System.Web.WebPages-net_4_x.csproj
@@ -208,12 +208,10 @@
   -->
   <PropertyGroup>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(ProjectDir)/System.Web.WebPages.Common.CommonResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages/Resources/WebPageResources.resx $(ProjectDir)/System.Web.WebPages.Resources.WebPageResources.resx
+
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(ProjectDir)/System.Web.WebPages.Common.CommonResources.resx
-cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages/Resources/WebPageResources.resx $(ProjectDir)/System.Web.WebPages.Resources.WebPageResources.resx
+
     </PreBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">
 
@@ -280,11 +278,11 @@ cp $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages/Resour
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="System.Web.WebPages.Resources.WebPageResources.resx">
-      <LogicalName>System.Web.WebPages.Resources.WebPageResources.resources</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="System.Web.WebPages.Common.CommonResources.resx">
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/CommonResources.resx">
       <LogicalName>System.Web.WebPages.Common.CommonResources.resources</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../../external/aspnetwebstack/src/System.Web.WebPages/Resources/WebPageResources.resx">
+      <LogicalName>System.Web.WebPages.Resources.WebPageResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/mcs/class/System.Web/Makefile
+++ b/mcs/class/System.Web/Makefile
@@ -254,7 +254,7 @@ ifneq (plainweb/,$(intermediate))
 LIB_REFS += System.Web.Services plaindesign/System.Design
 LIB_MCS_FLAGS += -define:WEBSERVICES_DEP
 
-all-local: System.Web/UplevelHelper.cs resources/TranslationResources.resources 
+all-local: System.Web/UplevelHelper.cs 
 
 endif
 

--- a/mcs/class/System.Web/Makefile
+++ b/mcs/class/System.Web/Makefile
@@ -225,8 +225,8 @@ TEST_RESOURCE_FILES = \
 	Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx.cs \
 	Test/mainsoft/NunitWebResources/HtmlTitleCodeRender_Bug662918.aspx
 
-RESX_DIST =  resources/TranslationResources.resx
-RESX_RES = $(RESX_DIST:.resx=.resources)
+RESOURCE_DEFS = \
+	TranslationResources,resources/TranslationResources.resx
 
 NUNIT_RESOURCE_FILES = $(TEST_RESOURCE_FILES)
 NUNIT_APP_CODE_FILES = $(TEST_APP_CODE_FILES)
@@ -272,7 +272,6 @@ EXTRA_DISTFILES = \
 	$(TEST_APP_CODE_FILES) \
 	$(TEST_APP_GLOBALRESOURCES_FILES) \
 	UplevelHelperDefinitions.xml \
-	$(RESX_DIST) \
 	SQLiteProviders_DatabaseSchema.sql \
 	$(shell find Test/standalone-runner-support/ -name "*.cs" -type f -printf "'%p' ") \
 	$(shell find Test/standalone-tests/ -name "*.cs" -type f -printf "'%p' " -o -name "*.cs.in" -type f -printf "'%p' ") \

--- a/mcs/class/System.Web/System.Web-net_4_x.csproj
+++ b/mcs/class/System.Web/System.Web-net_4_x.csproj
@@ -1564,9 +1564,6 @@ mono $(ProjectDir)\..\lib\net_4_x\culevel.exe -o $(ProjectDir)\System.Web\Upleve
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="resources/TranslationResources.resx">
-      <LogicalName>TranslationResources.resources</LogicalName>
-    </EmbeddedResource>
     <EmbeddedResource Include="resources/WebUIValidation.js">
       <LogicalName>WebUIValidation.js</LogicalName>
     </EmbeddedResource>
@@ -1728,6 +1725,9 @@ mono $(ProjectDir)\..\lib\net_4_x\culevel.exe -o $(ProjectDir)\System.Web\Upleve
     </EmbeddedResource>
     <EmbeddedResource Include="System.Web.UI.WebControls/MenuModern.js">
       <LogicalName>MenuModern.js</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="resources/TranslationResources.resx">
+      <LogicalName>TranslationResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/mcs/class/System.Web/System.Web-plainweb-net_4_x.csproj
+++ b/mcs/class/System.Web/System.Web-plainweb-net_4_x.csproj
@@ -1556,9 +1556,6 @@ mono $(ProjectDir)\..\lib\net_4_x\culevel.exe -o $(ProjectDir)\System.Web\Upleve
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="resources/TranslationResources.resx">
-      <LogicalName>TranslationResources.resources</LogicalName>
-    </EmbeddedResource>
     <EmbeddedResource Include="resources/WebUIValidation.js">
       <LogicalName>WebUIValidation.js</LogicalName>
     </EmbeddedResource>
@@ -1720,6 +1717,9 @@ mono $(ProjectDir)\..\lib\net_4_x\culevel.exe -o $(ProjectDir)\System.Web\Upleve
     </EmbeddedResource>
     <EmbeddedResource Include="System.Web.UI.WebControls/MenuModern.js">
       <LogicalName>MenuModern.js</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="resources/TranslationResources.resx">
+      <LogicalName>TranslationResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/msvc/scripts/System.ComponentModel.Composition.pre
+++ b/msvc/scripts/System.ComponentModel.Composition.pre
@@ -1,1 +1,0 @@
-resgen $(ProjectDir)\src\ComponentModel\Strings.resx $(ProjectDir)\Microsoft.Internal.Strings.resx

--- a/msvc/scripts/System.Data.Services.Client.pre
+++ b/msvc/scripts/System.Data.Services.Client.pre
@@ -1,1 +1,0 @@
-resgen $(ProjectDir)\Client\System.Data.Services.Client.txt $(ProjectDir)\Client\System.Data.Services.Client.resx

--- a/msvc/scripts/System.Json.Microsoft.pre
+++ b/msvc/scripts/System.Json.Microsoft.pre
@@ -1,1 +1,0 @@
-cp $(ProjectDir)\System.Json\Properties\Resources.resx System.Json.Properties.Resources.resx

--- a/msvc/scripts/System.Net.Http.Formatting.pre
+++ b/msvc/scripts/System.Net.Http.Formatting.pre
@@ -1,2 +1,0 @@
-@COPY@ $(ProjectDir)/../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx $(ProjectDir)/System.Net.Http.Properties.CommonWebApiResources.resx
-@COPY@ $(ProjectDir)/../../../external/aspnetwebstack/src/System.Net.Http.Formatting/Properties/Resources.resx $(ProjectDir)/System.Net.Http.Properties.Resources.resx

--- a/msvc/scripts/System.Web.Http.pre
+++ b/msvc/scripts/System.Web.Http.pre
@@ -1,2 +1,0 @@
-@COPY@ $(ProjectDir)/../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx $(ProjectDir)/System.Web.Http.Properties.CommonWebApiResources.resx
-@COPY@ $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.Http/Properties/SRResources.resx $(ProjectDir)/System.Web.Http.Properties.SRResources.resx

--- a/msvc/scripts/System.Web.Razor.pre
+++ b/msvc/scripts/System.Web.Razor.pre
@@ -1,2 +1,0 @@
-resgen $(ProjectDir)\..\..\..\external\aspnetwebstack\src\CommonResources.resx $(ProjectDir)\System.Web.Razor.Common.CommonResources.resx
-resgen $(ProjectDir)\..\..\..\external\aspnetwebstack\src\System.Web.Razor\Resources\RazorResources.resx $(ProjectDir)\System.Web.Razor.Resources.RazorResources.resx

--- a/msvc/scripts/System.Web.WebPages.Deployment.pre
+++ b/msvc/scripts/System.Web.WebPages.Deployment.pre
@@ -1,2 +1,0 @@
-@COPY@ $(ProjectDir)/../../../external/aspnetwebstack/src/System.Web.WebPages.Deployment/Resources/ConfigurationResources.resx $(ProjectDir)/System.Web.WebPages.Deployment.Resources.ConfigurationResources.resx
-@COPY@ $(ProjectDir)/../../../external/aspnetwebstack/src/CommonResources.resx $(ProjectDir)/System.Web.WebPages.Deployment.Common.CommonResources.resx

--- a/msvc/scripts/TODO.md
+++ b/msvc/scripts/TODO.md
@@ -9,4 +9,4 @@ These are the tasks that are pending in the MSVC scripts to fully roll it out:
 [ ] Eliminate the need for "build-libs.sh/build-libs.bat" at the toplevel with proper MSBuild idioms
 [ ] Integrate the "update-solution-files" with each build, so we auto-update the files on commits
 [ ] Make it work with MSBuild instead of xbuild
-[ ] Design a system for listing resources, so we avoid the ".pre" that runs resgen or copy by hand, because this ruins dependencies.  Alternatively, have @COPY@ be a "Copy if newer"
+[x] Design a system for listing resources, so we avoid the ".pre" that runs resgen or copy by hand, because this ruins dependencies.  Alternatively, have @COPY@ be a "Copy if newer"

--- a/msvc/scripts/order.xml
+++ b/msvc/scripts/order.xml
@@ -8,6 +8,7 @@
       <library_output>./../class/lib/basic/basic.exe</library_output>
       <fx_version>4.0</fx_version>
       <profile>basic</profile>
+      <resources></resources>
       <response>mcs.exe.sources</response>
     </project>
     <project dir="class/corlib" library="corlib-basic">
@@ -18,6 +19,7 @@
       <library_output>./../../class/lib/basic/mscorlib.dll</library_output>
       <fx_version>4.0</fx_version>
       <profile>basic</profile>
+      <resources></resources>
       <response>corlib.dll.sources</response>
     </project>
     <project dir="class/Mono.Security" library="Mono.Security-basic">
@@ -28,6 +30,7 @@
       <library_output>./../../class/lib/basic/Mono.Security.dll</library_output>
       <fx_version>4.0</fx_version>
       <profile>basic</profile>
+      <resources></resources>
       <response>Mono.Security.dll.sources</response>
     </project>
     <project dir="class/System" library="System-basic">
@@ -38,6 +41,7 @@
       <library_output>./../../class/lib/basic/System.dll</library_output>
       <fx_version>4.0</fx_version>
       <profile>basic</profile>
+      <resources></resources>
       <response>./../../build/deps/basic_System.dll.sources</response>
     </project>
     <project dir="class/System.XML" library="System.Xml-basic">
@@ -48,6 +52,7 @@
       <library_output>./../../class/lib/basic/System.Xml.dll</library_output>
       <fx_version>4.0</fx_version>
       <profile>basic</profile>
+      <resources></resources>
       <response>System.Xml.dll.sources</response>
     </project>
     <project dir="class/System.Core" library="System.Core-basic">
@@ -58,6 +63,7 @@
       <library_output>./../../class/lib/basic/System.Core.dll</library_output>
       <fx_version>4.0</fx_version>
       <profile>basic</profile>
+      <resources></resources>
       <response>./../../build/deps/basic_System.Core.dll.sources</response>
     </project>
     <project dir="class/corlib" library="corlib-build">
@@ -68,6 +74,7 @@
       <library_output>./../../class/lib/build/mscorlib.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>corlib.dll.sources</response>
     </project>
     <project dir="class/Mono.Security" library="Mono.Security-build">
@@ -78,6 +85,7 @@
       <library_output>./../../class/lib/build/Mono.Security.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>Mono.Security.dll.sources</response>
     </project>
     <project dir="class/System" library="System-build">
@@ -88,6 +96,7 @@
       <library_output>./../../class/lib/build/System.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>System.dll.sources</response>
     </project>
     <project dir="class/System" library="System-bare-build">
@@ -98,6 +107,7 @@
       <library_output>./../../class/lib/build/bare/System.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>System.dll.sources</response>
     </project>
     <project dir="class/System" library="System-secxml-build">
@@ -108,6 +118,7 @@
       <library_output>./../../class/lib/build/secxml/System.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>System.dll.sources</response>
     </project>
     <project dir="class/System.XML" library="System.Xml-build">
@@ -118,6 +129,7 @@
       <library_output>./../../class/lib/build/System.Xml.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>System.Xml.dll.sources</response>
     </project>
     <project dir="class/System.XML" library="System.Xml-bare-build">
@@ -128,6 +140,7 @@
       <library_output>./../../class/lib/build/bare/System.Xml.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>System.Xml.dll.sources</response>
     </project>
     <project dir="class/Mono.Posix" library="Mono.Posix-build">
@@ -138,6 +151,7 @@
       <library_output>./../../class/lib/build/Mono.Posix.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>Mono.Posix.dll.sources</response>
     </project>
     <project dir="class/System.Core" library="System.Core-build">
@@ -148,6 +162,7 @@
       <library_output>./../../class/lib/build/System.Core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>./../../build/deps/build_System.Core.dll.sources</response>
     </project>
     <project dir="class/System.Core" library="System.Core-plaincore-build">
@@ -158,6 +173,7 @@
       <library_output>./../../class/lib/build/plaincore/System.Core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>./../../build/deps/build_System.Core.dll.sources</response>
     </project>
     <project dir="class/Mono.Cecil" library="Mono.Cecil-build">
@@ -168,6 +184,7 @@
       <library_output>./../../class/lib/build/Mono.Cecil.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>Mono.Cecil.dll.sources</response>
     </project>
     <project dir="class/Mono.Cecil.Mdb" library="Mono.Cecil.Mdb-build">
@@ -178,6 +195,7 @@
       <library_output>./../../class/lib/build/Mono.Cecil.Mdb.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>Mono.Cecil.Mdb.dll.sources</response>
     </project>
     <project dir="mcs" library="mcs-build">
@@ -188,6 +206,7 @@
       <library_output>mcs.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>mcs.exe.sources</response>
     </project>
     <project dir="tools/gacutil" library="gacutil-build">
@@ -198,6 +217,7 @@
       <library_output>./../../class/lib/build/gacutil.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>gacutil.exe.sources</response>
     </project>
     <project dir="tools/culevel" library="culevel-build">
@@ -208,6 +228,7 @@
       <library_output>./../../class/lib/build/culevel.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>culevel.exe.sources</response>
     </project>
     <project dir="tools/cil-stringreplacer" library="cil-stringreplacer-build">
@@ -218,6 +239,7 @@
       <library_output>./../../class/lib/build/cil-stringreplacer.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>cil-stringreplacer.exe.sources</response>
     </project>
     <project dir="tools/commoncryptogenerator" library="commoncryptogenerator-build">
@@ -228,6 +250,7 @@
       <library_output>./../../class/lib/build/commoncryptogenerator.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>build</profile>
+      <resources></resources>
       <response>commoncryptogenerator.exe.sources</response>
     </project>
     <project dir="mcs" library="mcs-net_4_x">
@@ -238,6 +261,7 @@
       <library_output>mcs.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mcs.exe.sources</response>
     </project>
     <project dir="class/corlib" library="corlib-net_4_x">
@@ -248,6 +272,7 @@
       <library_output>./../../class/lib/net_4_x/mscorlib.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_corlib.dll.sources</response>
     </project>
     <project dir="class/corlib" library="corlib-tests-net_4_x">
@@ -258,6 +283,7 @@
       <library_output>net_4_x_corlib_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_corlib_test.dll.response</response>
     </project>
     <project dir="class/Mono.Security" library="Mono.Security-net_4_x">
@@ -268,6 +294,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Security.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Security.dll.sources</response>
     </project>
     <project dir="class/Mono.Security" library="Mono.Security-tests-net_4_x">
@@ -278,6 +305,7 @@
       <library_output>net_4_x_Mono.Security_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Security_test.dll.response</response>
     </project>
     <project dir="class/System" library="System-net_4_x">
@@ -288,6 +316,7 @@
       <library_output>./../../class/lib/net_4_x/System.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.dll.sources</response>
     </project>
     <project dir="class/System" library="System-tests-net_4_x">
@@ -298,6 +327,7 @@
       <library_output>net_4_x_System_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System_test.dll.response</response>
     </project>
     <project dir="class/System" library="System-bare-net_4_x">
@@ -308,6 +338,7 @@
       <library_output>./../../class/lib/net_4_x/bare/System.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.dll.sources</response>
     </project>
     <project dir="class/System" library="System-tests-net_4_x">
@@ -318,6 +349,7 @@
       <library_output>net_4_x_System_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System_test.dll.response</response>
     </project>
     <project dir="class/System" library="System-secxml-net_4_x">
@@ -328,6 +360,7 @@
       <library_output>./../../class/lib/net_4_x/secxml/System.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.dll.sources</response>
     </project>
     <project dir="class/System" library="System-tests-net_4_x">
@@ -338,6 +371,7 @@
       <library_output>net_4_x_System_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System_test.dll.response</response>
     </project>
     <project dir="class/System.XML" library="System.Xml-net_4_x">
@@ -348,6 +382,7 @@
       <library_output>./../../class/lib/net_4_x/System.Xml.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.dll.sources</response>
     </project>
     <project dir="class/System.XML" library="System.Xml-tests-net_4_x">
@@ -358,6 +393,7 @@
       <library_output>net_4_x_System.Xml_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Xml_test.dll.response</response>
     </project>
     <project dir="class/System.XML" library="System.Xml-bare-net_4_x">
@@ -368,6 +404,7 @@
       <library_output>./../../class/lib/net_4_x/bare/System.Xml.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.dll.sources</response>
     </project>
     <project dir="class/System.XML" library="System.Xml-tests-net_4_x">
@@ -378,6 +415,7 @@
       <library_output>net_4_x_System.Xml_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Xml_test.dll.response</response>
     </project>
     <project dir="class/Mono.CompilerServices.SymbolWriter" library="Mono.CompilerServices.SymbolWriter-net_4_x">
@@ -388,6 +426,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.CompilerServices.SymbolWriter.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.CompilerServices.SymbolWriter.dll.sources</response>
     </project>
     <project dir="class/Mono.Posix" library="Mono.Posix-net_4_x">
@@ -398,6 +437,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Posix.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Posix.dll.sources</response>
     </project>
     <project dir="class/Mono.Posix" library="Mono.Posix-tests-net_4_x">
@@ -408,6 +448,7 @@
       <library_output>net_4_x_Mono.Posix_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Posix_test.dll.response</response>
     </project>
     <project dir="class/System.Core" library="System.Core-net_4_x">
@@ -418,6 +459,7 @@
       <library_output>./../../class/lib/net_4_x/System.Core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Core.dll.sources</response>
     </project>
     <project dir="class/System.Core" library="System.Core-tests-net_4_x">
@@ -428,6 +470,7 @@
       <library_output>net_4_x_System.Core_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Core_test.dll.response</response>
     </project>
     <project dir="class/System.Core" library="System.Core-plaincore-net_4_x">
@@ -438,6 +481,7 @@
       <library_output>./../../class/lib/net_4_x/plaincore/System.Core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Core.dll.sources</response>
     </project>
     <project dir="class/System.Core" library="System.Core-tests-net_4_x">
@@ -448,6 +492,7 @@
       <library_output>net_4_x_System.Core_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Core_test.dll.response</response>
     </project>
     <project dir="class/System.Security" library="System.Security-net_4_x">
@@ -458,6 +503,7 @@
       <library_output>./../../class/lib/net_4_x/System.Security.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.dll.sources</response>
     </project>
     <project dir="class/System.Security" library="System.Security-tests-net_4_x">
@@ -468,6 +514,7 @@
       <library_output>net_4_x_System.Security_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Security_test.dll.response</response>
     </project>
     <project dir="class/System.Configuration" library="System.Configuration-net_4_x">
@@ -478,6 +525,7 @@
       <library_output>./../../class/lib/net_4_x/System.Configuration.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Configuration.dll.sources</response>
     </project>
     <project dir="class/System.Configuration" library="System.Configuration-tests-net_4_x">
@@ -488,6 +536,7 @@
       <library_output>net_4_x_System.Configuration_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Configuration_test.dll.response</response>
     </project>
     <project dir="tools/resgen" library="resgen-net_4_x">
@@ -498,6 +547,7 @@
       <library_output>./../../class/lib/net_4_x/resgen.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>resgen.exe.sources</response>
     </project>
     <project dir="class/System.IO.Compression" library="System.IO.Compression-net_4_x">
@@ -508,6 +558,7 @@
       <library_output>./../../class/lib/net_4_x/System.IO.Compression.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.Compression.dll.sources</response>
     </project>
     <project dir="class/System.IO.Compression" library="System.IO.Compression-tests-net_4_x">
@@ -518,6 +569,7 @@
       <library_output>net_4_x_System.IO.Compression_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.IO.Compression_test.dll.response</response>
     </project>
     <project dir="class/System.IO.Compression.FileSystem" library="System.IO.Compression.FileSystem-net_4_x">
@@ -528,6 +580,7 @@
       <library_output>./../../class/lib/net_4_x/System.IO.Compression.FileSystem.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.Compression.FileSystem.dll.sources</response>
     </project>
     <project dir="class/System.IO.Compression.FileSystem" library="System.IO.Compression.FileSystem-tests-net_4_x">
@@ -538,6 +591,7 @@
       <library_output>net_4_x_System.IO.Compression.FileSystem_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.IO.Compression.FileSystem_test.dll.response</response>
     </project>
     <project dir="class/System.Drawing" library="System.Drawing-net_4_x">
@@ -548,6 +602,7 @@
       <library_output>./../../class/lib/net_4_x/System.Drawing.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Drawing.dll.sources</response>
     </project>
     <project dir="class/System.Drawing" library="System.Drawing-tests-net_4_x">
@@ -558,6 +613,7 @@
       <library_output>net_4_x_System.Drawing_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Drawing_test.dll.response</response>
     </project>
     <project dir="class/System.Transactions" library="System.Transactions-net_4_x">
@@ -568,6 +624,7 @@
       <library_output>./../../class/lib/net_4_x/System.Transactions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Transactions.dll.sources</response>
     </project>
     <project dir="class/System.Transactions" library="System.Transactions-tests-net_4_x">
@@ -578,6 +635,7 @@
       <library_output>net_4_x_System.Transactions_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Transactions_test.dll.response</response>
     </project>
     <project dir="class/System.EnterpriseServices" library="System.EnterpriseServices-net_4_x">
@@ -588,6 +646,7 @@
       <library_output>./../../class/lib/net_4_x/System.EnterpriseServices.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.EnterpriseServices.dll.sources</response>
     </project>
     <project dir="class/Mono.Data.Tds" library="Mono.Data.Tds-net_4_x">
@@ -598,6 +657,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Data.Tds.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Data.Tds.dll.sources</response>
     </project>
     <project dir="class/Mono.Data.Tds" library="Mono.Data.Tds-tests-net_4_x">
@@ -608,6 +668,7 @@
       <library_output>net_4_x_Mono.Data.Tds_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Data.Tds_test.dll.response</response>
     </project>
     <project dir="class/System.Numerics" library="System.Numerics-net_4_x">
@@ -618,6 +679,7 @@
       <library_output>./../../class/lib/net_4_x/System.Numerics.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Numerics.dll.sources</response>
     </project>
     <project dir="class/System.Numerics" library="System.Numerics-tests-net_4_x">
@@ -628,6 +690,7 @@
       <library_output>net_4_x_System.Numerics_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Numerics_test.dll.response</response>
     </project>
     <project dir="class/System.Numerics.Vectors" library="System.Numerics.Vectors-net_4_x">
@@ -638,6 +701,7 @@
       <library_output>./../../class/lib/net_4_x/System.Numerics.Vectors.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Numerics.Vectors.dll.sources</response>
     </project>
     <project dir="class/System.Data" library="System.Data-net_4_x">
@@ -648,6 +712,7 @@
       <library_output>./../../class/lib/net_4_x/System.Data.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Data.dll.sources</response>
     </project>
     <project dir="class/System.Data" library="System.Data-tests-net_4_x">
@@ -658,6 +723,7 @@
       <library_output>net_4_x_System.Data_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Data_test.dll.response</response>
     </project>
     <project dir="class/System.ComponentModel.DataAnnotations" library="System.ComponentModel.DataAnnotations-net_4_x">
@@ -668,6 +734,7 @@
       <library_output>./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ComponentModel.DataAnnotations.dll.sources</response>
     </project>
     <project dir="class/System.ComponentModel.DataAnnotations" library="System.ComponentModel.DataAnnotations-tests-net_4_x">
@@ -678,6 +745,7 @@
       <library_output>net_4_x_System.ComponentModel.DataAnnotations_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.ComponentModel.DataAnnotations_test.dll.response</response>
     </project>
     <project dir="class/Accessibility" library="Accessibility-net_4_x">
@@ -688,6 +756,7 @@
       <library_output>./../../class/lib/net_4_x/Accessibility.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Accessibility.dll.sources</response>
     </project>
     <project dir="class/Mono.WebBrowser" library="Mono.WebBrowser-net_4_x">
@@ -698,6 +767,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.WebBrowser.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.WebBrowser.dll.sources</response>
     </project>
     <project dir="class/System.Runtime.Serialization.Formatters.Soap" library="System.Runtime.Serialization.Formatters.Soap-net_4_x">
@@ -708,6 +778,7 @@
       <library_output>./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Serialization.Formatters.Soap.dll.sources</response>
     </project>
     <project dir="class/System.Runtime.Serialization.Formatters.Soap" library="System.Runtime.Serialization.Formatters.Soap-tests-net_4_x">
@@ -718,6 +789,7 @@
       <library_output>net_4_x_System.Runtime.Serialization.Formatters.Soap_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Runtime.Serialization.Formatters.Soap_test.dll.response</response>
     </project>
     <project dir="class/System.Windows.Forms" library="System.Windows.Forms-net_4_x">
@@ -728,6 +800,7 @@
       <library_output>./../../class/lib/net_4_x/System.Windows.Forms.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Windows.Forms.dll.sources</response>
     </project>
     <project dir="class/System.Windows.Forms" library="System.Windows.Forms-tests-net_4_x">
@@ -738,6 +811,7 @@
       <library_output>net_4_x_System.Windows.Forms_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Windows.Forms_test.dll.response</response>
     </project>
     <project dir="class/Mono.Data.Sqlite" library="Mono.Data.Sqlite-net_4_x">
@@ -748,6 +822,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Data.Sqlite.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Data.Sqlite.dll.sources</response>
     </project>
     <project dir="class/Mono.Data.Sqlite" library="Mono.Data.Sqlite-tests-net_4_x">
@@ -758,6 +833,7 @@
       <library_output>net_4_x_Mono.Data.Sqlite_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Data.Sqlite_test.dll.response</response>
     </project>
     <project dir="class/System.Web.ApplicationServices" library="System.Web.ApplicationServices-net_4_x">
@@ -768,16 +844,18 @@
       <library_output>./../../class/lib/net_4_x/System.Web.ApplicationServices.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.ApplicationServices.dll.sources</response>
     </project>
     <project dir="class/Novell.Directory.Ldap" library="Novell.Directory.Ldap-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -warn:1 -nowarn:612 /res:Novell.Directory.Ldap.Utilclass/ResultCodeMessages.resources -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/Mono.Security.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -warn:1 -nowarn:612 -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/Mono.Security.dll</flags>
       <output>Novell.Directory.Ldap.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/Novell.Directory.Ldap.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>ResultCodeMessages,Novell.Directory.Ldap.Utilclass/ResultCodeMessages.txt</resources>
       <response>Novell.Directory.Ldap.dll.sources</response>
     </project>
     <project dir="class/Novell.Directory.Ldap" library="Novell.Directory.Ldap-tests-net_4_x">
@@ -788,6 +866,7 @@
       <library_output>net_4_x_Novell.Directory.Ldap_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Novell.Directory.Ldap_test.dll.response</response>
     </project>
     <project dir="class/System.DirectoryServices" library="System.DirectoryServices-net_4_x">
@@ -798,6 +877,7 @@
       <library_output>./../../class/lib/net_4_x/System.DirectoryServices.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.DirectoryServices.dll.sources</response>
     </project>
     <project dir="class/System.DirectoryServices" library="System.DirectoryServices-tests-net_4_x">
@@ -808,46 +888,51 @@
       <library_output>net_4_x_System.DirectoryServices_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.DirectoryServices_test.dll.response</response>
     </project>
     <project dir="class/System.Web" library="System.Web-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/TranslationResources.resources /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -define:WEBSERVICES_DEP -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll -r:./../../class/lib/net_4_x/System.Web.Services.dll -r:./../../class/lib/net_4_x/plaindesign/System.Design.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -define:WEBSERVICES_DEP -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll -r:./../../class/lib/net_4_x/System.Web.Services.dll -r:./../../class/lib/net_4_x/plaindesign/System.Design.dll</flags>
       <output>System.Web.dll</output>
       <built_sources>System.Web/UplevelHelper.cs</built_sources>
       <library_output>./../../class/lib/net_4_x/System.Web.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>TranslationResources,resources/TranslationResources.resx</resources>
       <response>System.Web.dll.sources</response>
     </project>
     <project dir="class/System.Web" library="System.Web-tests-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize -r:./../../class/lib/net_4_x/plainweb/System.Web.dll -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/TranslationResources.resources /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll -doc:net_4_x_System.Web_test.xml -nowarn:219,169,1591 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Global.asax /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.ashx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.master /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx.cs /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPageWithMaster.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config.4.0 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/sub_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_02.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_03.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_04.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_05.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_06.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_07.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_08.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_09.sitemap /resource:Test/mainsoft/NunitWebResources/menuclass.aspx /resource:Test/mainsoft/NunitWebResources/FormView.aspx /resource:Test/mainsoft/NunitWebResources/PostBackMenuTest.aspx /resource:Test/mainsoft/NunitWebResources/PageWithStyleSheet.aspx /resource:Test/mainsoft/NunitWebResources/PageWithTheme.aspx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.ascx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.aspx /resource:Test/mainsoft/NunitWebResources/RunTimeSetTheme.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyBind.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyControl.ascx /resource:Test/mainsoft/NunitWebResources/Theme1.skin /resource:Test/mainsoft/NunitWebResources/Theme2.skin /resource:Test/mainsoft/NunitWebResources/UrlProperty.aspx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx.cs /resource:Test/mainsoft/NunitWebResources/Web.sitemap /resource:Test/mainsoft/NunitWebResources/WizardTest.skin /resource:Test/mainsoft/NunitWebResources/FooterTemplateTest.aspx /resource:Test/mainsoft/NunitWebResources/DataGrid.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_2.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_3.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewDataActions.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewProperties1.aspx /resource:Test/mainsoft/NunitWebResources/Bluehills.jpg /resource:Test/mainsoft/NunitWebResources/FormViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_2.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_3.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_4.aspx /resource:Test/mainsoft/NunitWebResources/FormViewInsertEditDelete.aspx /resource:Test/mainsoft/NunitWebResources/GridViewUpdate.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xml /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xsl /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest1.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest2.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest3.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest4.aspx /resource:Test/mainsoft/NunitWebResources/LoginViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/WebControl.config /resource:Test/mainsoft/NunitWebResources/WebLogin.config /resource:Test/mainsoft/NunitWebResources/CallbackTest1.aspx /resource:Test/mainsoft/NunitWebResources/CallbackTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest1.aspx /resource:Test/mainsoft/NunitWebResources/ClientScript.js /resource:Test/mainsoft/NunitWebResources/EvalTest.aspx /resource:Test/mainsoft/NunitWebResources/TemplateUserControl.ascx /resource:Test/mainsoft/NunitWebResources/WebMapping.config /resource:Test/mainsoft/NunitWebResources/Mapping.aspx /resource:Test/mainsoft/NunitWebResources/Mapping1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting2.aspx /resource:Test/mainsoft/NunitWebResources/MyDerived.master /resource:Test/mainsoft/NunitWebResources/MyPageWithDerivedMaster.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest1.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest2.aspx /resource:Test/mainsoft/NunitWebResources/PageLifecycleTest.aspx /resource:Test/mainsoft/NunitWebResources/PageValidationTest.aspx /resource:Test/mainsoft/NunitWebResources/AsyncPage.aspx /resource:Test/mainsoft/NunitWebResources/PageCultureTest.aspx /resource:Test/mainsoft/NunitWebResources/adapters.browser /resource:Test/mainsoft/NunitWebResources/NoEventValidation.aspx /resource:Test/mainsoft/NunitWebResources/ListControlPage.aspx /resource:Test/mainsoft/NunitWebResources/TextBoxTestlPage.aspx /resource:Test/mainsoft/NunitWebResources/ClearErrorOnError.aspx /resource:Test/mainsoft/NunitWebResources/RedirectOnError.aspx /resource:Test/mainsoft/NunitWebResources/TestCapability.browser /resource:Test/mainsoft/NunitWebResources/PageWithAdapter.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind5.aspx /resource:Test/mainsoft/NunitWebResources/ReadWritePropertyControl.ascx /resource:Test/mainsoft/MainsoftWebTest/nunitweb_config.xml /resource:Test/mainsoft/NunitWebResources/TemplateControlParsingTest.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.master /resource:Test/mainsoft/NunitWebResources/MissingMasterFile.aspx /resource:Test/mainsoft/NunitWebResources/CustomSectionEmptyCollection.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx.cs /resource:Test/mainsoft/NunitWebResources/LoginDisplayRememberMe.aspx /resource:Test/mainsoft/NunitWebResources/NoBindForMethodsWithBindInName.aspx /resource:Test/mainsoft/NunitWebResources/LinkInHeadWithEmbeddedExpression.aspx /resource:Test/mainsoft/NunitWebResources/ExpressionInListControl.aspx /resource:Test/mainsoft/NunitWebResources/ServerSideControlsInScriptBlock.aspx /resource:Test/mainsoft/NunitWebResources/ServerControlInClientSideComment.aspx /resource:Test/mainsoft/NunitWebResources/PreprocessorDirectivesInMarkup.aspx /resource:Test/mainsoft/NunitWebResources/UnquotedAngleBrackets.aspx /resource:Test/mainsoft/NunitWebResources/FullTagsInText.aspx /resource:Test/mainsoft/NunitWebResources/TagsExpressionsAndCommentsInText.aspx /resource:Test/mainsoft/NunitWebResources/NewlineInCodeExpression.aspx /resource:Test/mainsoft/NunitWebResources/DuplicateControlsInClientComment.aspx /resource:Test/mainsoft/NunitWebResources/TagsNestedInClientTag.aspx /resource:Test/mainsoft/NunitWebResources/ConditionalClientComments.aspx /resource:Test/mainsoft/NunitWebResources/OneLetterIdentifierInCodeRender.aspx /resource:Test/mainsoft/NunitWebResources/GlobalResourcesLocalization.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx.cs /resource:Test/mainsoft/NunitWebResources/NestedParserFileText.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CorrectConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx.cs /resource:Test/mainsoft/NunitWebResources/ChangePasswordContainer_FindControl.aspx /resource:Test/mainsoft/NunitWebResources/TagWithExpressionWithinAttribute.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug578770.aspx /resource:Test/mainsoft/NunitWebResources/EnumConverter_Bug578586.aspx /resource:Test/mainsoft/NunitWebResources/ButtonColor_Bug325489.aspx /resource:Test/mainsoft/NunitWebResources/SqlDataSource_OnInit_Bug572781.aspx /resource:Test/mainsoft/NunitWebResources/FormViewPagerVisibility.aspx /resource:Test/mainsoft/NunitWebResources/OverridenControlsPropertyAndPostBack_Bug594238.aspx /resource:Test/mainsoft/NunitWebResources/GlobalizationEncodingName.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_0.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_5.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_6.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_7.aspx /resource:Test/mainsoft/NunitWebResources/GridView_Bug595567.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug600415.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx.cs /resource:Test/mainsoft/NunitWebResources/HtmlTitleCodeRender_Bug662918.aspx /resource:Test/mainsoft/NunitWebResources/App_Code/EnumConverterControl.cs,App_Code/EnumConverterControl.cs /resource:Test/mainsoft/NunitWebResources/App_Code/MyContainer.cs,App_Code/MyContainer.cs /resource:Test/mainsoft/NunitWebResources/App_Code/CustomCheckBoxColumn.cs,App_Code/CustomCheckBoxColumn.cs /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.resx,App_GlobalResources/Common.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.fr-FR.resx,App_GlobalResources/Common.fr-FR.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Resource1.resx,App_GlobalResources/Resource1.resx</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize -r:./../../class/lib/net_4_x/plainweb/System.Web.dll -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll -doc:net_4_x_System.Web_test.xml -nowarn:219,169,1591 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Global.asax /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.ashx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.master /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx.cs /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPageWithMaster.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config.4.0 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/sub_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_02.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_03.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_04.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_05.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_06.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_07.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_08.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_09.sitemap /resource:Test/mainsoft/NunitWebResources/menuclass.aspx /resource:Test/mainsoft/NunitWebResources/FormView.aspx /resource:Test/mainsoft/NunitWebResources/PostBackMenuTest.aspx /resource:Test/mainsoft/NunitWebResources/PageWithStyleSheet.aspx /resource:Test/mainsoft/NunitWebResources/PageWithTheme.aspx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.ascx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.aspx /resource:Test/mainsoft/NunitWebResources/RunTimeSetTheme.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyBind.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyControl.ascx /resource:Test/mainsoft/NunitWebResources/Theme1.skin /resource:Test/mainsoft/NunitWebResources/Theme2.skin /resource:Test/mainsoft/NunitWebResources/UrlProperty.aspx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx.cs /resource:Test/mainsoft/NunitWebResources/Web.sitemap /resource:Test/mainsoft/NunitWebResources/WizardTest.skin /resource:Test/mainsoft/NunitWebResources/FooterTemplateTest.aspx /resource:Test/mainsoft/NunitWebResources/DataGrid.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_2.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_3.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewDataActions.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewProperties1.aspx /resource:Test/mainsoft/NunitWebResources/Bluehills.jpg /resource:Test/mainsoft/NunitWebResources/FormViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_2.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_3.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_4.aspx /resource:Test/mainsoft/NunitWebResources/FormViewInsertEditDelete.aspx /resource:Test/mainsoft/NunitWebResources/GridViewUpdate.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xml /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xsl /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest1.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest2.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest3.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest4.aspx /resource:Test/mainsoft/NunitWebResources/LoginViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/WebControl.config /resource:Test/mainsoft/NunitWebResources/WebLogin.config /resource:Test/mainsoft/NunitWebResources/CallbackTest1.aspx /resource:Test/mainsoft/NunitWebResources/CallbackTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest1.aspx /resource:Test/mainsoft/NunitWebResources/ClientScript.js /resource:Test/mainsoft/NunitWebResources/EvalTest.aspx /resource:Test/mainsoft/NunitWebResources/TemplateUserControl.ascx /resource:Test/mainsoft/NunitWebResources/WebMapping.config /resource:Test/mainsoft/NunitWebResources/Mapping.aspx /resource:Test/mainsoft/NunitWebResources/Mapping1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting2.aspx /resource:Test/mainsoft/NunitWebResources/MyDerived.master /resource:Test/mainsoft/NunitWebResources/MyPageWithDerivedMaster.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest1.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest2.aspx /resource:Test/mainsoft/NunitWebResources/PageLifecycleTest.aspx /resource:Test/mainsoft/NunitWebResources/PageValidationTest.aspx /resource:Test/mainsoft/NunitWebResources/AsyncPage.aspx /resource:Test/mainsoft/NunitWebResources/PageCultureTest.aspx /resource:Test/mainsoft/NunitWebResources/adapters.browser /resource:Test/mainsoft/NunitWebResources/NoEventValidation.aspx /resource:Test/mainsoft/NunitWebResources/ListControlPage.aspx /resource:Test/mainsoft/NunitWebResources/TextBoxTestlPage.aspx /resource:Test/mainsoft/NunitWebResources/ClearErrorOnError.aspx /resource:Test/mainsoft/NunitWebResources/RedirectOnError.aspx /resource:Test/mainsoft/NunitWebResources/TestCapability.browser /resource:Test/mainsoft/NunitWebResources/PageWithAdapter.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind5.aspx /resource:Test/mainsoft/NunitWebResources/ReadWritePropertyControl.ascx /resource:Test/mainsoft/MainsoftWebTest/nunitweb_config.xml /resource:Test/mainsoft/NunitWebResources/TemplateControlParsingTest.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.master /resource:Test/mainsoft/NunitWebResources/MissingMasterFile.aspx /resource:Test/mainsoft/NunitWebResources/CustomSectionEmptyCollection.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx.cs /resource:Test/mainsoft/NunitWebResources/LoginDisplayRememberMe.aspx /resource:Test/mainsoft/NunitWebResources/NoBindForMethodsWithBindInName.aspx /resource:Test/mainsoft/NunitWebResources/LinkInHeadWithEmbeddedExpression.aspx /resource:Test/mainsoft/NunitWebResources/ExpressionInListControl.aspx /resource:Test/mainsoft/NunitWebResources/ServerSideControlsInScriptBlock.aspx /resource:Test/mainsoft/NunitWebResources/ServerControlInClientSideComment.aspx /resource:Test/mainsoft/NunitWebResources/PreprocessorDirectivesInMarkup.aspx /resource:Test/mainsoft/NunitWebResources/UnquotedAngleBrackets.aspx /resource:Test/mainsoft/NunitWebResources/FullTagsInText.aspx /resource:Test/mainsoft/NunitWebResources/TagsExpressionsAndCommentsInText.aspx /resource:Test/mainsoft/NunitWebResources/NewlineInCodeExpression.aspx /resource:Test/mainsoft/NunitWebResources/DuplicateControlsInClientComment.aspx /resource:Test/mainsoft/NunitWebResources/TagsNestedInClientTag.aspx /resource:Test/mainsoft/NunitWebResources/ConditionalClientComments.aspx /resource:Test/mainsoft/NunitWebResources/OneLetterIdentifierInCodeRender.aspx /resource:Test/mainsoft/NunitWebResources/GlobalResourcesLocalization.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx.cs /resource:Test/mainsoft/NunitWebResources/NestedParserFileText.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CorrectConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx.cs /resource:Test/mainsoft/NunitWebResources/ChangePasswordContainer_FindControl.aspx /resource:Test/mainsoft/NunitWebResources/TagWithExpressionWithinAttribute.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug578770.aspx /resource:Test/mainsoft/NunitWebResources/EnumConverter_Bug578586.aspx /resource:Test/mainsoft/NunitWebResources/ButtonColor_Bug325489.aspx /resource:Test/mainsoft/NunitWebResources/SqlDataSource_OnInit_Bug572781.aspx /resource:Test/mainsoft/NunitWebResources/FormViewPagerVisibility.aspx /resource:Test/mainsoft/NunitWebResources/OverridenControlsPropertyAndPostBack_Bug594238.aspx /resource:Test/mainsoft/NunitWebResources/GlobalizationEncodingName.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_0.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_5.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_6.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_7.aspx /resource:Test/mainsoft/NunitWebResources/GridView_Bug595567.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug600415.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx.cs /resource:Test/mainsoft/NunitWebResources/HtmlTitleCodeRender_Bug662918.aspx /resource:Test/mainsoft/NunitWebResources/App_Code/EnumConverterControl.cs,App_Code/EnumConverterControl.cs /resource:Test/mainsoft/NunitWebResources/App_Code/MyContainer.cs,App_Code/MyContainer.cs /resource:Test/mainsoft/NunitWebResources/App_Code/CustomCheckBoxColumn.cs,App_Code/CustomCheckBoxColumn.cs /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.resx,App_GlobalResources/Common.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.fr-FR.resx,App_GlobalResources/Common.fr-FR.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Resource1.resx,App_GlobalResources/Resource1.resx</flags>
       <output>net_4_x_System.Web_test.dll</output>
       <built_sources>System.Web/UplevelHelper.cs</built_sources>
       <library_output>net_4_x_System.Web_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Web_test.dll.response</response>
     </project>
     <project dir="class/System.Web" library="System.Web-plainweb-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/TranslationResources.resources /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll</flags>
       <output>System.Web.dll</output>
       <built_sources>System.Web/UplevelHelper.cs</built_sources>
       <library_output>./../../class/lib/net_4_x/plainweb/System.Web.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>TranslationResources,resources/TranslationResources.resx</resources>
       <response>System.Web.dll.sources</response>
     </project>
     <project dir="class/System.Web" library="System.Web-tests-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize -r:./../../class/lib/net_4_x/plainweb/System.Web.dll -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/TranslationResources.resources /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll -doc:net_4_x_System.Web_test.xml -nowarn:219,169,1591 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Global.asax /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.ashx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.master /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx.cs /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPageWithMaster.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config.4.0 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/sub_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_02.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_03.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_04.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_05.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_06.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_07.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_08.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_09.sitemap /resource:Test/mainsoft/NunitWebResources/menuclass.aspx /resource:Test/mainsoft/NunitWebResources/FormView.aspx /resource:Test/mainsoft/NunitWebResources/PostBackMenuTest.aspx /resource:Test/mainsoft/NunitWebResources/PageWithStyleSheet.aspx /resource:Test/mainsoft/NunitWebResources/PageWithTheme.aspx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.ascx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.aspx /resource:Test/mainsoft/NunitWebResources/RunTimeSetTheme.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyBind.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyControl.ascx /resource:Test/mainsoft/NunitWebResources/Theme1.skin /resource:Test/mainsoft/NunitWebResources/Theme2.skin /resource:Test/mainsoft/NunitWebResources/UrlProperty.aspx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx.cs /resource:Test/mainsoft/NunitWebResources/Web.sitemap /resource:Test/mainsoft/NunitWebResources/WizardTest.skin /resource:Test/mainsoft/NunitWebResources/FooterTemplateTest.aspx /resource:Test/mainsoft/NunitWebResources/DataGrid.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_2.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_3.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewDataActions.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewProperties1.aspx /resource:Test/mainsoft/NunitWebResources/Bluehills.jpg /resource:Test/mainsoft/NunitWebResources/FormViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_2.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_3.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_4.aspx /resource:Test/mainsoft/NunitWebResources/FormViewInsertEditDelete.aspx /resource:Test/mainsoft/NunitWebResources/GridViewUpdate.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xml /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xsl /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest1.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest2.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest3.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest4.aspx /resource:Test/mainsoft/NunitWebResources/LoginViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/WebControl.config /resource:Test/mainsoft/NunitWebResources/WebLogin.config /resource:Test/mainsoft/NunitWebResources/CallbackTest1.aspx /resource:Test/mainsoft/NunitWebResources/CallbackTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest1.aspx /resource:Test/mainsoft/NunitWebResources/ClientScript.js /resource:Test/mainsoft/NunitWebResources/EvalTest.aspx /resource:Test/mainsoft/NunitWebResources/TemplateUserControl.ascx /resource:Test/mainsoft/NunitWebResources/WebMapping.config /resource:Test/mainsoft/NunitWebResources/Mapping.aspx /resource:Test/mainsoft/NunitWebResources/Mapping1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting2.aspx /resource:Test/mainsoft/NunitWebResources/MyDerived.master /resource:Test/mainsoft/NunitWebResources/MyPageWithDerivedMaster.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest1.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest2.aspx /resource:Test/mainsoft/NunitWebResources/PageLifecycleTest.aspx /resource:Test/mainsoft/NunitWebResources/PageValidationTest.aspx /resource:Test/mainsoft/NunitWebResources/AsyncPage.aspx /resource:Test/mainsoft/NunitWebResources/PageCultureTest.aspx /resource:Test/mainsoft/NunitWebResources/adapters.browser /resource:Test/mainsoft/NunitWebResources/NoEventValidation.aspx /resource:Test/mainsoft/NunitWebResources/ListControlPage.aspx /resource:Test/mainsoft/NunitWebResources/TextBoxTestlPage.aspx /resource:Test/mainsoft/NunitWebResources/ClearErrorOnError.aspx /resource:Test/mainsoft/NunitWebResources/RedirectOnError.aspx /resource:Test/mainsoft/NunitWebResources/TestCapability.browser /resource:Test/mainsoft/NunitWebResources/PageWithAdapter.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind5.aspx /resource:Test/mainsoft/NunitWebResources/ReadWritePropertyControl.ascx /resource:Test/mainsoft/MainsoftWebTest/nunitweb_config.xml /resource:Test/mainsoft/NunitWebResources/TemplateControlParsingTest.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.master /resource:Test/mainsoft/NunitWebResources/MissingMasterFile.aspx /resource:Test/mainsoft/NunitWebResources/CustomSectionEmptyCollection.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx.cs /resource:Test/mainsoft/NunitWebResources/LoginDisplayRememberMe.aspx /resource:Test/mainsoft/NunitWebResources/NoBindForMethodsWithBindInName.aspx /resource:Test/mainsoft/NunitWebResources/LinkInHeadWithEmbeddedExpression.aspx /resource:Test/mainsoft/NunitWebResources/ExpressionInListControl.aspx /resource:Test/mainsoft/NunitWebResources/ServerSideControlsInScriptBlock.aspx /resource:Test/mainsoft/NunitWebResources/ServerControlInClientSideComment.aspx /resource:Test/mainsoft/NunitWebResources/PreprocessorDirectivesInMarkup.aspx /resource:Test/mainsoft/NunitWebResources/UnquotedAngleBrackets.aspx /resource:Test/mainsoft/NunitWebResources/FullTagsInText.aspx /resource:Test/mainsoft/NunitWebResources/TagsExpressionsAndCommentsInText.aspx /resource:Test/mainsoft/NunitWebResources/NewlineInCodeExpression.aspx /resource:Test/mainsoft/NunitWebResources/DuplicateControlsInClientComment.aspx /resource:Test/mainsoft/NunitWebResources/TagsNestedInClientTag.aspx /resource:Test/mainsoft/NunitWebResources/ConditionalClientComments.aspx /resource:Test/mainsoft/NunitWebResources/OneLetterIdentifierInCodeRender.aspx /resource:Test/mainsoft/NunitWebResources/GlobalResourcesLocalization.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx.cs /resource:Test/mainsoft/NunitWebResources/NestedParserFileText.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CorrectConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx.cs /resource:Test/mainsoft/NunitWebResources/ChangePasswordContainer_FindControl.aspx /resource:Test/mainsoft/NunitWebResources/TagWithExpressionWithinAttribute.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug578770.aspx /resource:Test/mainsoft/NunitWebResources/EnumConverter_Bug578586.aspx /resource:Test/mainsoft/NunitWebResources/ButtonColor_Bug325489.aspx /resource:Test/mainsoft/NunitWebResources/SqlDataSource_OnInit_Bug572781.aspx /resource:Test/mainsoft/NunitWebResources/FormViewPagerVisibility.aspx /resource:Test/mainsoft/NunitWebResources/OverridenControlsPropertyAndPostBack_Bug594238.aspx /resource:Test/mainsoft/NunitWebResources/GlobalizationEncodingName.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_0.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_5.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_6.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_7.aspx /resource:Test/mainsoft/NunitWebResources/GridView_Bug595567.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug600415.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx.cs /resource:Test/mainsoft/NunitWebResources/HtmlTitleCodeRender_Bug662918.aspx /resource:Test/mainsoft/NunitWebResources/App_Code/EnumConverterControl.cs,App_Code/EnumConverterControl.cs /resource:Test/mainsoft/NunitWebResources/App_Code/MyContainer.cs,App_Code/MyContainer.cs /resource:Test/mainsoft/NunitWebResources/App_Code/CustomCheckBoxColumn.cs,App_Code/CustomCheckBoxColumn.cs /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.resx,App_GlobalResources/Common.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.fr-FR.resx,App_GlobalResources/Common.fr-FR.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Resource1.resx,App_GlobalResources/Resource1.resx</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize -r:./../../class/lib/net_4_x/plainweb/System.Web.dll -unsafe -nowarn:612,618 -d:INSIDE_SYSTEM_WEB -nowarn:618 /resource:resources/WebUIValidation.js /resource:resources/folder.gif /resource:resources/file.gif /resource:resources/computer.gif /resource:resources/arrow_minus.gif /resource:resources/arrow_noexpand.gif /resource:resources/arrow_plus.gif /resource:resources/arrow_up.gif /resource:resources/arrow_down.gif /resource:resources/box_full.gif /resource:resources/box_empty.gif /resource:resources/box_minus.gif /resource:resources/box_noexpand.gif /resource:resources/box_plus.gif /resource:resources/contact.gif /resource:resources/dot_empty.gif /resource:resources/dot_full.gif /resource:resources/dots.gif /resource:resources/inbox.gif /resource:resources/star_empty.gif /resource:resources/star_full.gif /resource:resources/warning.gif /resource:resources/TreeView_noexpand.gif /resource:resources/TreeView_dash.gif /resource:resources/TreeView_dashminus.gif /resource:resources/TreeView_dashplus.gif /resource:resources/TreeView_i.gif /resource:resources/TreeView_l.gif /resource:resources/TreeView_lminus.gif /resource:resources/TreeView_lplus.gif /resource:resources/TreeView_minus.gif /resource:resources/TreeView_plus.gif /resource:resources/TreeView_r.gif /resource:resources/TreeView_rminus.gif /resource:resources/TreeView_rplus.gif /resource:resources/TreeView_t.gif /resource:resources/TreeView_tminus.gif /resource:resources/TreeView_tplus.gif /resource:resources/transparent.gif /resource:resources/webform.js /resource:resources/WebUIValidation_2.0.js /resource:resources/ErrorTemplateCommon_Top.html /resource:resources/DefaultErrorTemplate_CustomErrorDefault.html /resource:resources/ErrorTemplateCommon_Bottom.html /resource:resources/DefaultErrorTemplate_StandardPage.html /resource:resources/HtmlizedExceptionPage_Top.html /resource:resources/HtmlizedExceptionPage_FileLongSource.html /resource:resources/HtmlizedExceptionPage_FileShortSource.html /resource:resources/HtmlizedExceptionPage_CompilerOutput.html /resource:System.Web.UI.WebControls/GridView.js /resource:System.Web.UI.WebControls/DetailsView.js /resource:System.Web.UI.WebControls/TreeView.js /resource:System.Web.UI.WebControls/Menu.js /resource:System.Web.UI.WebControls/MenuModern.js -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Drawing.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.EnterpriseServices.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.Formatters.Soap.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Web.ApplicationServices.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/Mono.Data.Sqlite.dll -doc:net_4_x_System.Web_test.xml -nowarn:219,169,1591 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Global.asax /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.ashx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/My.master /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPage.aspx.cs /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/MyPageWithMaster.aspx /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/Web.mono.config.4.0 /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/sub_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_01.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_02.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_03.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_04.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_05.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_06.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_07.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_08.sitemap /resource:Test/mainsoft/NunitWeb/NunitWeb/Resources/test_map_09.sitemap /resource:Test/mainsoft/NunitWebResources/menuclass.aspx /resource:Test/mainsoft/NunitWebResources/FormView.aspx /resource:Test/mainsoft/NunitWebResources/PostBackMenuTest.aspx /resource:Test/mainsoft/NunitWebResources/PageWithStyleSheet.aspx /resource:Test/mainsoft/NunitWebResources/PageWithTheme.aspx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.ascx /resource:Test/mainsoft/NunitWebResources/ResolveUrl.aspx /resource:Test/mainsoft/NunitWebResources/RunTimeSetTheme.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyBind.aspx /resource:Test/mainsoft/NunitWebResources/ReadOnlyPropertyControl.ascx /resource:Test/mainsoft/NunitWebResources/Theme1.skin /resource:Test/mainsoft/NunitWebResources/Theme2.skin /resource:Test/mainsoft/NunitWebResources/UrlProperty.aspx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx /resource:Test/mainsoft/NunitWebResources/UrlProperty.ascx.cs /resource:Test/mainsoft/NunitWebResources/Web.sitemap /resource:Test/mainsoft/NunitWebResources/WizardTest.skin /resource:Test/mainsoft/NunitWebResources/FooterTemplateTest.aspx /resource:Test/mainsoft/NunitWebResources/DataGrid.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_2.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewTemplates_3.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewDataActions.aspx /resource:Test/mainsoft/NunitWebResources/DetailsViewProperties1.aspx /resource:Test/mainsoft/NunitWebResources/Bluehills.jpg /resource:Test/mainsoft/NunitWebResources/FormViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_2.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_3.aspx /resource:Test/mainsoft/NunitWebResources/FormViewTest1_4.aspx /resource:Test/mainsoft/NunitWebResources/FormViewInsertEditDelete.aspx /resource:Test/mainsoft/NunitWebResources/GridViewUpdate.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xml /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest.xsl /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest1.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest2.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest3.aspx /resource:Test/mainsoft/NunitWebResources/XMLDataSourceTest4.aspx /resource:Test/mainsoft/NunitWebResources/LoginViewTest1.aspx /resource:Test/mainsoft/NunitWebResources/WebControl.config /resource:Test/mainsoft/NunitWebResources/WebLogin.config /resource:Test/mainsoft/NunitWebResources/CallbackTest1.aspx /resource:Test/mainsoft/NunitWebResources/CallbackTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest2.aspx /resource:Test/mainsoft/NunitWebResources/EventValidationTest1.aspx /resource:Test/mainsoft/NunitWebResources/ClientScript.js /resource:Test/mainsoft/NunitWebResources/EvalTest.aspx /resource:Test/mainsoft/NunitWebResources/TemplateUserControl.ascx /resource:Test/mainsoft/NunitWebResources/WebMapping.config /resource:Test/mainsoft/NunitWebResources/Mapping.aspx /resource:Test/mainsoft/NunitWebResources/Mapping1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting1.aspx /resource:Test/mainsoft/NunitWebResources/CrossPagePosting2.aspx /resource:Test/mainsoft/NunitWebResources/MyDerived.master /resource:Test/mainsoft/NunitWebResources/MyPageWithDerivedMaster.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest1.aspx /resource:Test/mainsoft/NunitWebResources/MasterTypeTest2.aspx /resource:Test/mainsoft/NunitWebResources/PageLifecycleTest.aspx /resource:Test/mainsoft/NunitWebResources/PageValidationTest.aspx /resource:Test/mainsoft/NunitWebResources/AsyncPage.aspx /resource:Test/mainsoft/NunitWebResources/PageCultureTest.aspx /resource:Test/mainsoft/NunitWebResources/adapters.browser /resource:Test/mainsoft/NunitWebResources/NoEventValidation.aspx /resource:Test/mainsoft/NunitWebResources/ListControlPage.aspx /resource:Test/mainsoft/NunitWebResources/TextBoxTestlPage.aspx /resource:Test/mainsoft/NunitWebResources/ClearErrorOnError.aspx /resource:Test/mainsoft/NunitWebResources/RedirectOnError.aspx /resource:Test/mainsoft/NunitWebResources/TestCapability.browser /resource:Test/mainsoft/NunitWebResources/PageWithAdapter.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/InvalidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind1.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind2.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind3.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind4.aspx /resource:Test/mainsoft/NunitWebResources/ValidPropertyBind5.aspx /resource:Test/mainsoft/NunitWebResources/ReadWritePropertyControl.ascx /resource:Test/mainsoft/MainsoftWebTest/nunitweb_config.xml /resource:Test/mainsoft/NunitWebResources/TemplateControlParsingTest.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.aspx /resource:Test/mainsoft/NunitWebResources/ContentPlaceHolderInTemplate.master /resource:Test/mainsoft/NunitWebResources/MissingMasterFile.aspx /resource:Test/mainsoft/NunitWebResources/CustomSectionEmptyCollection.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx /resource:Test/mainsoft/NunitWebResources/NoDoubleOnInitOnRemoveAdd.aspx.cs /resource:Test/mainsoft/NunitWebResources/LoginDisplayRememberMe.aspx /resource:Test/mainsoft/NunitWebResources/NoBindForMethodsWithBindInName.aspx /resource:Test/mainsoft/NunitWebResources/LinkInHeadWithEmbeddedExpression.aspx /resource:Test/mainsoft/NunitWebResources/ExpressionInListControl.aspx /resource:Test/mainsoft/NunitWebResources/ServerSideControlsInScriptBlock.aspx /resource:Test/mainsoft/NunitWebResources/ServerControlInClientSideComment.aspx /resource:Test/mainsoft/NunitWebResources/PreprocessorDirectivesInMarkup.aspx /resource:Test/mainsoft/NunitWebResources/UnquotedAngleBrackets.aspx /resource:Test/mainsoft/NunitWebResources/FullTagsInText.aspx /resource:Test/mainsoft/NunitWebResources/TagsExpressionsAndCommentsInText.aspx /resource:Test/mainsoft/NunitWebResources/NewlineInCodeExpression.aspx /resource:Test/mainsoft/NunitWebResources/DuplicateControlsInClientComment.aspx /resource:Test/mainsoft/NunitWebResources/TagsNestedInClientTag.aspx /resource:Test/mainsoft/NunitWebResources/ConditionalClientComments.aspx /resource:Test/mainsoft/NunitWebResources/OneLetterIdentifierInCodeRender.aspx /resource:Test/mainsoft/NunitWebResources/GlobalResourcesLocalization.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx /resource:Test/mainsoft/NunitWebResources/TableSections_Bug551666.aspx.cs /resource:Test/mainsoft/NunitWebResources/NestedParserFileText.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CorrectConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx /resource:Test/mainsoft/NunitWebResources/StateFormatter_CollectionConverter.aspx.cs /resource:Test/mainsoft/NunitWebResources/ChangePasswordContainer_FindControl.aspx /resource:Test/mainsoft/NunitWebResources/TagWithExpressionWithinAttribute.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug377703_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug578770.aspx /resource:Test/mainsoft/NunitWebResources/EnumConverter_Bug578586.aspx /resource:Test/mainsoft/NunitWebResources/ButtonColor_Bug325489.aspx /resource:Test/mainsoft/NunitWebResources/SqlDataSource_OnInit_Bug572781.aspx /resource:Test/mainsoft/NunitWebResources/FormViewPagerVisibility.aspx /resource:Test/mainsoft/NunitWebResources/OverridenControlsPropertyAndPostBack_Bug594238.aspx /resource:Test/mainsoft/NunitWebResources/GlobalizationEncodingName.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_0.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_1.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_2.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_5.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_6.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxField_Bug595568_7.aspx /resource:Test/mainsoft/NunitWebResources/GridView_Bug595567.aspx /resource:Test/mainsoft/NunitWebResources/CheckBoxList_Bug600415.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx /resource:Test/mainsoft/NunitWebResources/BoundField_Bug646505.aspx.cs /resource:Test/mainsoft/NunitWebResources/HtmlTitleCodeRender_Bug662918.aspx /resource:Test/mainsoft/NunitWebResources/App_Code/EnumConverterControl.cs,App_Code/EnumConverterControl.cs /resource:Test/mainsoft/NunitWebResources/App_Code/MyContainer.cs,App_Code/MyContainer.cs /resource:Test/mainsoft/NunitWebResources/App_Code/CustomCheckBoxColumn.cs,App_Code/CustomCheckBoxColumn.cs /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.resx,App_GlobalResources/Common.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Common.fr-FR.resx,App_GlobalResources/Common.fr-FR.resx /resource:Test/mainsoft/NunitWebResources/App_GlobalResources/Resource1.resx,App_GlobalResources/Resource1.resx</flags>
       <output>net_4_x_System.Web_test.dll</output>
       <built_sources>System.Web/UplevelHelper.cs</built_sources>
       <library_output>net_4_x_System.Web_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Web_test.dll.response</response>
     </project>
     <project dir="class/System.Web.Services" library="System.Web.Services-net_4_x">
@@ -858,6 +943,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Services.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.Services.dll.sources</response>
     </project>
     <project dir="class/System.Web.Services" library="System.Web.Services-tests-net_4_x">
@@ -868,6 +954,7 @@
       <library_output>net_4_x_System.Web.Services_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Web.Services_test.dll.response</response>
     </project>
     <project dir="class/System.Design" library="System.Design-net_4_x">
@@ -878,6 +965,7 @@
       <library_output>./../../class/lib/net_4_x/System.Design.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Design.dll.sources</response>
     </project>
     <project dir="class/System.Design" library="System.Design-tests-net_4_x">
@@ -888,6 +976,7 @@
       <library_output>net_4_x_System.Design_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Design_test.dll.response</response>
     </project>
     <project dir="class/System.Design" library="System.Design-plaindesign-net_4_x">
@@ -898,6 +987,7 @@
       <library_output>./../../class/lib/net_4_x/plaindesign/System.Design.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Design.dll.sources</response>
     </project>
     <project dir="class/System.Design" library="System.Design-tests-net_4_x">
@@ -908,6 +998,7 @@
       <library_output>net_4_x_System.Design_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Design_test.dll.response</response>
     </project>
     <project dir="class/System.Runtime.Remoting" library="System.Runtime.Remoting-net_4_x">
@@ -918,6 +1009,7 @@
       <library_output>./../../class/lib/net_4_x/System.Runtime.Remoting.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Remoting.dll.sources</response>
     </project>
     <project dir="class/System.Runtime.Remoting" library="System.Runtime.Remoting-tests-net_4_x">
@@ -928,6 +1020,7 @@
       <library_output>net_4_x_System.Runtime.Remoting_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Runtime.Remoting_test.dll.response</response>
     </project>
     <project dir="class/System.Configuration.Install" library="System.Configuration.Install-net_4_x">
@@ -938,6 +1031,7 @@
       <library_output>./../../class/lib/net_4_x/System.Configuration.Install.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Configuration.Install.dll.sources</response>
     </project>
     <project dir="class/System.Management" library="System.Management-net_4_x">
@@ -948,6 +1042,7 @@
       <library_output>./../../class/lib/net_4_x/System.Management.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Management.dll.sources</response>
     </project>
     <project dir="class/System.Data.OracleClient" library="System.Data.OracleClient-net_4_x">
@@ -958,6 +1053,7 @@
       <library_output>./../../class/lib/net_4_x/System.Data.OracleClient.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Data.OracleClient.dll.sources</response>
     </project>
     <project dir="class/System.Data.OracleClient" library="System.Data.OracleClient-tests-net_4_x">
@@ -968,6 +1064,7 @@
       <library_output>net_4_x_System.Data.OracleClient_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Data.OracleClient_test.dll.response</response>
     </project>
     <project dir="class/Cscompmgd" library="Cscompmgd-net_4_x">
@@ -978,6 +1075,7 @@
       <library_output>./../../class/lib/net_4_x/cscompmgd.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Cscompmgd.dll.sources</response>
     </project>
     <project dir="class/Cscompmgd" library="Cscompmgd-tests-net_4_x">
@@ -988,6 +1086,7 @@
       <library_output>net_4_x_Cscompmgd_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Cscompmgd_test.dll.response</response>
     </project>
     <project dir="class/Commons.Xml.Relaxng" library="Commons.Xml.Relaxng-net_4_x">
@@ -998,6 +1097,7 @@
       <library_output>./../../class/lib/net_4_x/Commons.Xml.Relaxng.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Commons.Xml.Relaxng.dll.sources</response>
     </project>
     <project dir="class/Commons.Xml.Relaxng" library="Commons.Xml.Relaxng-tests-net_4_x">
@@ -1008,6 +1108,7 @@
       <library_output>net_4_x_Commons.Xml.Relaxng_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Commons.Xml.Relaxng_test.dll.response</response>
     </project>
     <project dir="class/Mono.Messaging" library="Mono.Messaging-net_4_x">
@@ -1018,6 +1119,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Messaging.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Messaging.dll.sources</response>
     </project>
     <project dir="class/Mono.Messaging" library="Mono.Messaging-tests-net_4_x">
@@ -1028,6 +1130,7 @@
       <library_output>net_4_x_Mono.Messaging_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Messaging_test.dll.response</response>
     </project>
     <project dir="class/System.Messaging" library="System.Messaging-net_4_x">
@@ -1038,6 +1141,7 @@
       <library_output>./../../class/lib/net_4_x/System.Messaging.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Messaging.dll.sources</response>
     </project>
     <project dir="class/System.Messaging" library="System.Messaging-tests-net_4_x">
@@ -1048,6 +1152,7 @@
       <library_output>net_4_x_System.Messaging_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Messaging_test.dll.response</response>
     </project>
     <project dir="class/System.ServiceProcess" library="System.ServiceProcess-net_4_x">
@@ -1058,6 +1163,7 @@
       <library_output>./../../class/lib/net_4_x/System.ServiceProcess.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceProcess.dll.sources</response>
     </project>
     <project dir="class/System.ServiceProcess" library="System.ServiceProcess-tests-net_4_x">
@@ -1068,6 +1174,7 @@
       <library_output>net_4_x_System.ServiceProcess_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.ServiceProcess_test.dll.response</response>
     </project>
     <project dir="class/System.Drawing.Design" library="System.Drawing.Design-net_4_x">
@@ -1078,6 +1185,7 @@
       <library_output>./../../class/lib/net_4_x/System.Drawing.Design.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Drawing.Design.dll.sources</response>
     </project>
     <project dir="class/ICSharpCode.SharpZipLib" library="ICSharpCode.SharpZipLib-net_4_x">
@@ -1088,6 +1196,7 @@
       <library_output>./../../class/lib/net_4_x/ICSharpCode.SharpZipLib.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>ICSharpCode.SharpZipLib.dll.sources</response>
     </project>
     <project dir="class/IBM.Data.DB2" library="IBM.Data.DB2-net_4_x">
@@ -1098,6 +1207,7 @@
       <library_output>./../../class/lib/net_4_x/IBM.Data.DB2.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>IBM.Data.DB2.dll.sources</response>
     </project>
     <project dir="class/CustomMarshalers" library="CustomMarshalers-net_4_x">
@@ -1108,6 +1218,7 @@
       <library_output>./../../class/lib/net_4_x/CustomMarshalers.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>CustomMarshalers.dll.sources</response>
     </project>
     <project dir="class/SystemWebTestShim" library="SystemWebTestShim-net_4_x">
@@ -1118,6 +1229,7 @@
       <library_output>./../../class/lib/net_4_x/SystemWebTestShim.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>SystemWebTestShim.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel.Internals" library="System.ServiceModel.Internals-net_4_x">
@@ -1128,6 +1240,7 @@
       <library_output>./../../class/lib/net_4_x/System.ServiceModel.Internals.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Internals.dll.sources</response>
     </project>
     <project dir="class/SMDiagnostics" library="SMDiagnostics-net_4_x">
@@ -1138,6 +1251,7 @@
       <library_output>./../../class/lib/net_4_x/SMDiagnostics.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>SMDiagnostics.dll.sources</response>
     </project>
     <project dir="class/System.Runtime.Serialization" library="System.Runtime.Serialization-net_4_x">
@@ -1148,6 +1262,7 @@
       <library_output>./../../class/lib/net_4_x/System.Runtime.Serialization.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Runtime.Serialization.dll.sources</response>
     </project>
     <project dir="class/System.Runtime.Serialization" library="System.Runtime.Serialization-tests-net_4_x">
@@ -1158,6 +1273,7 @@
       <library_output>net_4_x_System.Runtime.Serialization_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Runtime.Serialization_test.dll.response</response>
     </project>
     <project dir="class/System.Xml.Linq" library="System.Xml.Linq-net_4_x">
@@ -1168,6 +1284,7 @@
       <library_output>./../../class/lib/net_4_x/System.Xml.Linq.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.Linq.dll.sources</response>
     </project>
     <project dir="class/System.Xml.Linq" library="System.Xml.Linq-tests-net_4_x">
@@ -1178,6 +1295,7 @@
       <library_output>net_4_x_System.Xml.Linq_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Xml.Linq_test.dll.response</response>
     </project>
     <project dir="class/System.Data.Linq" library="System.Data.Linq-net_4_x">
@@ -1188,6 +1306,7 @@
       <library_output>./../../class/lib/net_4_x/System.Data.Linq.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Data.Linq.dll.sources</response>
     </project>
     <project dir="class/System.Data.Linq" library="System.Data.Linq-tests-net_4_x">
@@ -1198,6 +1317,7 @@
       <library_output>net_4_x_System.Data.Linq_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Data.Linq_test.dll.response</response>
     </project>
     <project dir="class/System.Web.Abstractions" library="System.Web.Abstractions-net_4_x">
@@ -1208,6 +1328,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Abstractions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.Abstractions.dll.sources</response>
     </project>
     <project dir="class/System.Web.Abstractions" library="System.Web.Abstractions-tests-net_4_x">
@@ -1218,6 +1339,7 @@
       <library_output>net_4_x_System.Web.Abstractions_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Web.Abstractions_test.dll.response</response>
     </project>
     <project dir="class/System.Web.Routing" library="System.Web.Routing-net_4_x">
@@ -1228,6 +1350,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Routing.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.Routing.dll.sources</response>
     </project>
     <project dir="class/System.Web.Routing" library="System.Web.Routing-tests-net_4_x">
@@ -1238,6 +1361,7 @@
       <library_output>net_4_x_System.Web.Routing_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Web.Routing_test.dll.response</response>
     </project>
     <project dir="class/System.Runtime.DurableInstancing" library="System.Runtime.DurableInstancing-net_4_x">
@@ -1248,6 +1372,7 @@
       <library_output>./../../class/lib/net_4_x/System.Runtime.DurableInstancing.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.DurableInstancing.dll.sources</response>
     </project>
     <project dir="class/System.Runtime.DurableInstancing" library="System.Runtime.DurableInstancing-tests-net_4_x">
@@ -1258,6 +1383,7 @@
       <library_output>net_4_x_System.Runtime.DurableInstancing_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Runtime.DurableInstancing_test.dll.response</response>
     </project>
     <project dir="class/System.IdentityModel" library="System.IdentityModel-net_4_x">
@@ -1268,6 +1394,7 @@
       <library_output>./../../class/lib/net_4_x/System.IdentityModel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IdentityModel.dll.sources</response>
     </project>
     <project dir="class/System.IdentityModel" library="System.IdentityModel-tests-net_4_x">
@@ -1278,6 +1405,7 @@
       <library_output>net_4_x_System.IdentityModel_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.IdentityModel_test.dll.response</response>
     </project>
     <project dir="class/System.IdentityModel.Selectors" library="System.IdentityModel.Selectors-net_4_x">
@@ -1288,6 +1416,7 @@
       <library_output>./../../class/lib/net_4_x/System.IdentityModel.Selectors.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IdentityModel.Selectors.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel" library="System.ServiceModel-net_4_x">
@@ -1298,6 +1427,7 @@
       <library_output>./../../class/lib/net_4_x/System.ServiceModel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel" library="System.ServiceModel-tests-net_4_x">
@@ -1308,6 +1438,7 @@
       <library_output>net_4_x_System.ServiceModel_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.ServiceModel_test.dll.response</response>
     </project>
     <project dir="class/System.ServiceModel" library="System.ServiceModel-plainservice-net_4_x">
@@ -1318,6 +1449,7 @@
       <library_output>./../../class/lib/net_4_x/plainservice/System.ServiceModel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel" library="System.ServiceModel-tests-net_4_x">
@@ -1328,6 +1460,7 @@
       <library_output>net_4_x_System.ServiceModel_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.ServiceModel_test.dll.response</response>
     </project>
     <project dir="class/System.Web.Extensions" library="System.Web.Extensions-net_4_x">
@@ -1338,6 +1471,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Extensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.Extensions.dll.sources</response>
     </project>
     <project dir="class/System.Web.Extensions" library="System.Web.Extensions-tests-net_4_x">
@@ -1348,6 +1482,7 @@
       <library_output>net_4_x_System.Web.Extensions_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Web.Extensions_test.dll.response</response>
     </project>
     <project dir="class/System.Web.Extensions.Design" library="System.Web.Extensions.Design-net_4_x">
@@ -1358,6 +1493,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Extensions.Design.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.Extensions.Design.dll.sources</response>
     </project>
     <project dir="class/System.Web.DynamicData" library="System.Web.DynamicData-net_4_x">
@@ -1368,6 +1504,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.DynamicData.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.DynamicData.dll.sources</response>
     </project>
     <project dir="class/System.Web.DynamicData" library="System.Web.DynamicData-tests-net_4_x">
@@ -1378,6 +1515,7 @@
       <library_output>net_4_x_System.Web.DynamicData_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Web.DynamicData_test.dll.response</response>
     </project>
     <project dir="class/Mono.CSharp" library="Mono.CSharp-net_4_x">
@@ -1388,6 +1526,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.CSharp.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.CSharp.dll.sources</response>
     </project>
     <project dir="class/Mono.CSharp" library="Mono.CSharp-tests-net_4_x">
@@ -1398,6 +1537,7 @@
       <library_output>net_4_x_Mono.CSharp_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.CSharp_test.dll.response</response>
     </project>
     <project dir="class/System.Net" library="System.Net-net_4_x">
@@ -1408,6 +1548,7 @@
       <library_output>./../../class/lib/net_4_x/System.Net.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.dll.sources</response>
     </project>
     <project dir="class/System.Json" library="System.Json-net_4_x">
@@ -1418,6 +1559,7 @@
       <library_output>./../../class/lib/net_4_x/System.Json.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Json.dll.sources</response>
     </project>
     <project dir="class/System.Json" library="System.Json-tests-net_4_x">
@@ -1428,6 +1570,7 @@
       <library_output>net_4_x_System.Json_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Json_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.CSharp" library="Microsoft.CSharp-net_4_x">
@@ -1438,6 +1581,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.CSharp.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.CSharp.dll.sources</response>
     </project>
     <project dir="class/System.Xaml" library="System.Xaml-net_4_x">
@@ -1448,6 +1592,7 @@
       <library_output>./../../class/lib/net_4_x/System.Xaml.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xaml.dll.sources</response>
     </project>
     <project dir="class/System.Xaml" library="System.Xaml-tests-net_4_x">
@@ -1458,6 +1603,7 @@
       <library_output>net_4_x_System.Xaml_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Xaml_test.dll.response</response>
     </project>
     <project dir="class/WindowsBase" library="WindowsBase-net_4_x">
@@ -1468,6 +1614,7 @@
       <library_output>./../../class/lib/net_4_x/WindowsBase.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>WindowsBase.dll.sources</response>
     </project>
     <project dir="class/WindowsBase" library="WindowsBase-tests-net_4_x">
@@ -1478,6 +1625,7 @@
       <library_output>net_4_x_WindowsBase_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_WindowsBase_test.dll.response</response>
     </project>
     <project dir="class/System.ServiceModel.Activation" library="System.ServiceModel.Activation-net_4_x">
@@ -1488,6 +1636,7 @@
       <library_output>./../../class/lib/net_4_x/System.ServiceModel.Activation.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Activation.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel.Routing" library="System.ServiceModel.Routing-net_4_x">
@@ -1498,6 +1647,7 @@
       <library_output>./../../class/lib/net_4_x/System.ServiceModel.Routing.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Routing.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel.Discovery" library="System.ServiceModel.Discovery-net_4_x">
@@ -1508,6 +1658,7 @@
       <library_output>./../../class/lib/net_4_x/System.ServiceModel.Discovery.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Discovery.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel.Discovery" library="System.ServiceModel.Discovery-tests-net_4_x">
@@ -1518,6 +1669,7 @@
       <library_output>net_4_x_System.ServiceModel.Discovery_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.ServiceModel.Discovery_test.dll.response</response>
     </project>
     <project dir="class/System.Runtime.Caching" library="System.Runtime.Caching-net_4_x">
@@ -1528,6 +1680,7 @@
       <library_output>./../../class/lib/net_4_x/System.Runtime.Caching.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Caching.dll.sources</response>
     </project>
     <project dir="class/System.Runtime.Caching" library="System.Runtime.Caching-tests-net_4_x">
@@ -1538,6 +1691,7 @@
       <library_output>net_4_x_System.Runtime.Caching_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Runtime.Caching_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Web.Infrastructure" library="Microsoft.Web.Infrastructure-net_4_x">
@@ -1548,6 +1702,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.Web.Infrastructure.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Web.Infrastructure.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel.Web" library="System.ServiceModel.Web-net_4_x">
@@ -1558,6 +1713,7 @@
       <library_output>./../../class/lib/net_4_x/System.ServiceModel.Web.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Web.dll.sources</response>
     </project>
     <project dir="class/System.ServiceModel.Web" library="System.ServiceModel.Web-tests-net_4_x">
@@ -1568,6 +1724,7 @@
       <library_output>net_4_x_System.ServiceModel.Web_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.ServiceModel.Web_test.dll.response</response>
     </project>
     <project dir="class/System.Net.Http" library="System.Net.Http-net_4_x">
@@ -1578,6 +1735,7 @@
       <library_output>./../../class/lib/net_4_x/System.Net.Http.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Http.dll.sources</response>
     </project>
     <project dir="class/System.Net.Http" library="System.Net.Http-tests-net_4_x">
@@ -1588,6 +1746,7 @@
       <library_output>net_4_x_System.Net.Http_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Net.Http_test.dll.response</response>
     </project>
     <project dir="class/System.Net.Http.WebRequest" library="System.Net.Http.WebRequest-net_4_x">
@@ -1598,76 +1757,84 @@
       <library_output>./../../class/lib/net_4_x/System.Net.Http.WebRequest.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Http.WebRequest.dll.sources</response>
     </project>
     <project dir="class/System.Web.Razor" library="System.Web.Razor-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub -delaysign /d:ASPNETWEBPAGES /resource:System.Web.Razor.Resources.RazorResources.resources /resource:System.Web.Razor.Common.CommonResources.resources -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub -delaysign /d:ASPNETWEBPAGES -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll</flags>
       <output>System.Web.Razor.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Web.Razor.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.Razor.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx System.Web.Razor.Resources.RazorResources,../../../external/aspnetwebstack/src/System.Web.Razor/Resources/RazorResources.resx</resources>
       <response>System.Web.Razor.dll.sources</response>
     </project>
     <project dir="class/System.Web.WebPages.Deployment" library="System.Web.WebPages.Deployment-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub -delaysign /d:ASPNETWEBPAGES /resource:System.Web.WebPages.Deployment.Common.CommonResources.resources /resource:System.Web.WebPages.Deployment.Resources.ConfigurationResources.resources -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/Microsoft.Web.Infrastructure.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub -delaysign /d:ASPNETWEBPAGES -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/Microsoft.Web.Infrastructure.dll</flags>
       <output>System.Web.WebPages.Deployment.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Web.WebPages.Deployment.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.WebPages.Deployment.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx System.Web.WebPages.Deployment.Resources.ConfigurationResources,../../../external/aspnetwebstack/src/System.Web.WebPages.Deployment/Resources/ConfigurationResources.resx</resources>
       <response>System.Web.WebPages.Deployment.dll.sources</response>
     </project>
     <project dir="class/System.Web.WebPages" library="System.Web.WebPages-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub /delaysign /d:ASPNETWEBPAGES /resource:System.Web.WebPages.Resources.WebPageResources.resources /resource:System.Web.WebPages.Common.CommonResources.resources -r:./../../class/lib/net_4_x/Microsoft.CSharp.dll -r:./../../class/lib/net_4_x/Microsoft.Web.Infrastructure.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Data.Linq.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.Deployment.dll -r:./../../class/lib/net_4_x/System.Web.Razor.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Xml.Linq.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub /delaysign /d:ASPNETWEBPAGES -r:./../../class/lib/net_4_x/Microsoft.CSharp.dll -r:./../../class/lib/net_4_x/Microsoft.Web.Infrastructure.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Data.Linq.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.Deployment.dll -r:./../../class/lib/net_4_x/System.Web.Razor.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Xml.Linq.dll</flags>
       <output>System.Web.WebPages.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Web.WebPages.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.WebPages.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx System.Web.WebPages.Resources.WebPageResources,../../../external/aspnetwebstack/src/System.Web.WebPages/Resources/WebPageResources.resx</resources>
       <response>System.Web.WebPages.dll.sources</response>
     </project>
     <project dir="class/System.Web.WebPages.Razor" library="System.Web.WebPages.Razor-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub /delaysign /d:ASPNETWEBPAGES /resource:System.Web.WebPages.Razor.Resources.RazorWebResources.resources /resource:System.Web.WebPages.Razor.Common.CommonResources.resources -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.dll -r:./../../class/lib/net_4_x/System.Web.Razor.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub /delaysign /d:ASPNETWEBPAGES -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.dll -r:./../../class/lib/net_4_x/System.Web.Razor.dll</flags>
       <output>System.Web.WebPages.Razor.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Web.WebPages.Razor.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.WebPages.Razor.Common.CommonResources,../../../external/aspnetwebstack/src/CommonResources.resx System.Web.WebPages.Razor.Resources.RazorWebResources,../../../external/aspnetwebstack/src/System.Web.WebPages.Razor/Resources/RazorWebResources.resx</resources>
       <response>System.Web.WebPages.Razor.dll.sources</response>
     </project>
     <project dir="class/System.Web.Mvc3" library="System.Web.Mvc3-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub /d:MONO /delaysign /resource:Mvc/Resources/MvcResources.resources,System.Web.Mvc.Resources.MvcResources.resources -r:./../../class/lib/net_4_x/Microsoft.Web.Infrastructure.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/System.Web.Abstractions.dll -r:./../../class/lib/net_4_x/System.Web.Routing.dll -r:./../../class/lib/net_4_x/System.Web.Extensions.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Data.Linq.dll -r:./../../class/lib/net_4_x/System.Runtime.Caching.dll -r:./../../class/lib/net_4_x/System.Web.Razor.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.Razor.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /warn:1 /keyfile:../winfx.pub /d:MONO /delaysign -r:./../../class/lib/net_4_x/Microsoft.Web.Infrastructure.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Configuration.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Web.dll -r:./../../class/lib/net_4_x/System.Web.Abstractions.dll -r:./../../class/lib/net_4_x/System.Web.Routing.dll -r:./../../class/lib/net_4_x/System.Web.Extensions.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Data.Linq.dll -r:./../../class/lib/net_4_x/System.Runtime.Caching.dll -r:./../../class/lib/net_4_x/System.Web.Razor.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.Razor.dll -r:./../../class/lib/net_4_x/System.Web.WebPages.dll</flags>
       <output>System.Web.Mvc.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Web.Mvc.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.Mvc.Resources.MvcResources,Mvc/Resources/MvcResources.resx</resources>
       <response>System.Web.Mvc3.dll.sources</response>
     </project>
     <project dir="class/System.Net.Http.Formatting" library="System.Net.Http.Formatting-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:ASPNETMVC -keyfile:../winfx.pub -delaysign -resource:System.Net.Http.Properties.CommonWebApiResources.resources -resource:System.Net.Http.Properties.Resources.resources -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Net.Http.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/System.Xml.Linq.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Configuration.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:ASPNETMVC -keyfile:../winfx.pub -delaysign -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Net.Http.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/System.Xml.Linq.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Configuration.dll</flags>
       <output>System.Net.Http.Formatting.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Net.Http.Formatting.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Net.Http.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx System.Net.Http.Properties.Resources,../../../external/aspnetwebstack/src/System.Net.Http.Formatting/Properties/Resources.resx</resources>
       <response>System.Net.Http.Formatting.dll.sources</response>
     </project>
     <project dir="class/System.Web.Http" library="System.Web.Http-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:ASPNETMVC -keyfile:../winfx.pub -delaysign -resource:System.Web.Http.Properties.CommonWebApiResources.resources -resource:System.Web.Http.Properties.SRResources.resources -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Net.Http.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Net.Http.Formatting.dll -r:./../../class/lib/net_4_x/System.Runtime.Caching.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/System.Data.Linq.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:ASPNETMVC -keyfile:../winfx.pub -delaysign -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Net.Http.dll -r:./../../class/lib/net_4_x/System.ComponentModel.DataAnnotations.dll -r:./../../class/lib/net_4_x/System.Net.Http.Formatting.dll -r:./../../class/lib/net_4_x/System.Runtime.Caching.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/System.Data.Linq.dll</flags>
       <output>System.Web.Http.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Web.Http.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.Http.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx System.Web.Http.Properties.SRResources,../../../external/aspnetwebstack/src/System.Web.Http/Properties/SRResources.resx</resources>
       <response>System.Web.Http.dll.sources</response>
     </project>
     <project dir="class/System.Web.Http.SelfHost" library="System.Web.Http.SelfHost-net_4_x">
@@ -1678,6 +1845,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Http.SelfHost.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.Http.SelfHost.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx System.Web.Http.SelfHost.Properties.SRResources,../../../external/aspnetwebstack/src/System.Web.Http.SelfHost/Properties/SRResources.resx</resources>
       <response>System.Web.Http.SelfHost.dll.sources</response>
     </project>
     <project dir="class/System.Web.Http.WebHost" library="System.Web.Http.WebHost-net_4_x">
@@ -1688,6 +1856,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Http.WebHost.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Web.Http.WebHost.Properties.CommonWebApiResources,../../../external/aspnetwebstack/src/Common/CommonWebApiResources.resx System.Web.Http.WebHost.Properties.SRResources,../../../external/aspnetwebstack/src/System.Web.Http.WebHost/Properties/SRResources.resx</resources>
       <response>System.Web.Http.WebHost.dll.sources</response>
     </project>
     <project dir="class/Mono.Security.Providers.NewSystemSource" library="Mono.Security.Providers.NewSystemSource-net_4_x">
@@ -1698,6 +1867,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Security.Providers.NewSystemSource.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Security.Providers.NewSystemSource.dll.sources</response>
     </project>
     <project dir="class/Mono.Security.Providers.NewTls" library="Mono.Security.Providers.NewTls-net_4_x">
@@ -1708,6 +1878,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Security.Providers.NewTls.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Security.Providers.NewTls.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Framework" library="Microsoft.Build.Framework-net_4_x">
@@ -1718,6 +1889,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.Build.Framework.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Build.Framework.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Framework" library="Microsoft.Build.Framework-tests-net_4_x">
@@ -1728,6 +1900,7 @@
       <library_output>net_4_x_Microsoft.Build.Framework_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Microsoft.Build.Framework_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Utilities" library="Microsoft.Build.Utilities-net_4_x">
@@ -1738,6 +1911,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.Build.Utilities.v4.0.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Build.Utilities.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Utilities" library="Microsoft.Build.Utilities-tests-net_4_x">
@@ -1748,6 +1922,7 @@
       <library_output>net_4_x_Microsoft.Build.Utilities_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Microsoft.Build.Utilities_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Engine" library="Microsoft.Build.Engine-net_4_x">
@@ -1758,6 +1933,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.Build.Engine.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Build.Engine.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Engine" library="Microsoft.Build.Engine-tests-net_4_x">
@@ -1768,6 +1944,7 @@
       <library_output>net_4_x_Microsoft.Build.Engine_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Microsoft.Build.Engine_test.dll.response</response>
     </project>
     <project dir="class/Mono.XBuild.Tasks" library="Mono.XBuild.Tasks-net_4_x">
@@ -1778,6 +1955,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.XBuild.Tasks.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.XBuild.Tasks.dll.sources</response>
     </project>
     <project dir="class/Mono.XBuild.Tasks" library="Mono.XBuild.Tasks-tests-net_4_x">
@@ -1788,6 +1966,7 @@
       <library_output>net_4_x_Mono.XBuild.Tasks_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.XBuild.Tasks_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Tasks" library="Microsoft.Build.Tasks-net_4_x">
@@ -1798,6 +1977,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.Build.Tasks.v4.0.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Build.Tasks.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Tasks" library="Microsoft.Build.Tasks-tests-net_4_x">
@@ -1808,6 +1988,7 @@
       <library_output>net_4_x_Microsoft.Build.Tasks_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Microsoft.Build.Tasks_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build" library="Microsoft.Build-net_4_x">
@@ -1818,6 +1999,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.Build.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Build.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build" library="Microsoft.Build-tests-net_4_x">
@@ -1828,6 +2010,7 @@
       <library_output>net_4_x_Microsoft.Build_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Microsoft.Build_test.dll.response</response>
     </project>
     <project dir="class/PEAPI" library="PEAPI-net_4_x">
@@ -1838,6 +2021,7 @@
       <library_output>./../../class/lib/net_4_x/PEAPI.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>PEAPI.dll.sources</response>
     </project>
     <project dir="class/I18N/Common" library="I18N-net_4_x">
@@ -1848,6 +2032,7 @@
       <library_output>./../../../class/lib/net_4_x/I18N.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>I18N.dll.sources</response>
     </project>
     <project dir="class/I18N/West" library="I18N.West-net_4_x">
@@ -1858,6 +2043,7 @@
       <library_output>./../../../class/lib/net_4_x/I18N.West.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>I18N.West.dll.sources</response>
     </project>
     <project dir="class/I18N/West" library="I18N.West-tests-net_4_x">
@@ -1868,6 +2054,7 @@
       <library_output>net_4_x_I18N.West_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../../build/deps/net_4_x_I18N.West_test.dll.response</response>
     </project>
     <project dir="class/I18N/MidEast" library="I18N.MidEast-net_4_x">
@@ -1878,6 +2065,7 @@
       <library_output>./../../../class/lib/net_4_x/I18N.MidEast.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>I18N.MidEast.dll.sources</response>
     </project>
     <project dir="class/I18N/MidEast" library="I18N.MidEast-tests-net_4_x">
@@ -1888,6 +2076,7 @@
       <library_output>net_4_x_I18N.MidEast_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../../build/deps/net_4_x_I18N.MidEast_test.dll.response</response>
     </project>
     <project dir="class/I18N/Other" library="I18N.Other-net_4_x">
@@ -1898,6 +2087,7 @@
       <library_output>./../../../class/lib/net_4_x/I18N.Other.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>I18N.Other.dll.sources</response>
     </project>
     <project dir="class/I18N/Rare" library="I18N.Rare-net_4_x">
@@ -1908,6 +2098,7 @@
       <library_output>./../../../class/lib/net_4_x/I18N.Rare.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>I18N.Rare.dll.sources</response>
     </project>
     <project dir="class/I18N/CJK" library="I18N.CJK-net_4_x">
@@ -1918,6 +2109,7 @@
       <library_output>./../../../class/lib/net_4_x/I18N.CJK.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>I18N.CJK.dll.sources</response>
     </project>
     <project dir="class/I18N/CJK" library="I18N.CJK-tests-net_4_x">
@@ -1928,6 +2120,7 @@
       <library_output>net_4_x_I18N.CJK_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../../build/deps/net_4_x_I18N.CJK_test.dll.response</response>
     </project>
     <project dir="class/Mono.Http" library="Mono.Http-net_4_x">
@@ -1938,6 +2131,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Http.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Http.dll.sources</response>
     </project>
     <project dir="class/Mono.Cairo" library="Mono.Cairo-net_4_x">
@@ -1948,6 +2142,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Cairo.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Cairo.dll.sources</response>
     </project>
     <project dir="class/Mono.Cecil" library="Mono.Cecil-net_4_x">
@@ -1958,6 +2153,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Cecil.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Cecil.dll.sources</response>
     </project>
     <project dir="class/Mono.Cecil.Mdb" library="Mono.Cecil.Mdb-net_4_x">
@@ -1968,6 +2164,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Cecil.Mdb.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Cecil.Mdb.dll.sources</response>
     </project>
     <project dir="class/Mono.Debugger.Soft" library="Mono.Debugger.Soft-net_4_x">
@@ -1978,6 +2175,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Debugger.Soft.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Debugger.Soft.dll.sources</response>
     </project>
     <project dir="class/Mono.Debugger.Soft" library="Mono.Debugger.Soft-tests-net_4_x">
@@ -1988,6 +2186,7 @@
       <library_output>net_4_x_Mono.Debugger.Soft_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Debugger.Soft_test.dll.response</response>
     </project>
     <project dir="class/Mono.C5" library="Mono.C5-net_4_x">
@@ -1998,6 +2197,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.C5.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.C5.dll.sources</response>
     </project>
     <project dir="class/Mono.C5" library="Mono.C5-tests-net_4_x">
@@ -2008,6 +2208,7 @@
       <library_output>net_4_x_Mono.C5_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.C5_test.dll.response</response>
     </project>
     <project dir="class/Mono.Management" library="Mono.Management-net_4_x">
@@ -2018,6 +2219,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Management.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Management.dll.sources</response>
     </project>
     <project dir="class/Mono.Options" library="Mono.Options-net_4_x">
@@ -2028,6 +2230,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Options.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Options.dll.sources</response>
     </project>
     <project dir="class/Mono.Options" library="Mono.Options-tests-net_4_x">
@@ -2038,6 +2241,7 @@
       <library_output>net_4_x_Mono.Options_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Options_test.dll.response</response>
     </project>
     <project dir="class/Mono.Simd" library="Mono.Simd-net_4_x">
@@ -2048,6 +2252,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Simd.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Simd.dll.sources</response>
     </project>
     <project dir="class/Mono.Tasklets" library="Mono.Tasklets-net_4_x">
@@ -2058,6 +2263,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Tasklets.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Tasklets.dll.sources</response>
     </project>
     <project dir="class/Mono.CodeContracts" library="Mono.CodeContracts-net_4_x">
@@ -2068,6 +2274,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.CodeContracts.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.CodeContracts.dll.sources</response>
     </project>
     <project dir="class/Mono.CodeContracts" library="Mono.CodeContracts-tests-net_4_x">
@@ -2078,6 +2285,7 @@
       <library_output>net_4_x_Mono.CodeContracts_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.CodeContracts_test.dll.response</response>
     </project>
     <project dir="class/Mono.Parallel" library="Mono.Parallel-net_4_x">
@@ -2088,6 +2296,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Parallel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Parallel.dll.sources</response>
     </project>
     <project dir="class/Mono.Parallel" library="Mono.Parallel-tests-net_4_x">
@@ -2098,6 +2307,7 @@
       <library_output>net_4_x_Mono.Parallel_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Parallel_test.dll.response</response>
     </project>
     <project dir="class/Mono.Security.Win32" library="Mono.Security.Win32-net_4_x">
@@ -2108,6 +2318,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Security.Win32.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Security.Win32.dll.sources</response>
     </project>
     <project dir="class/RabbitMQ.Client/src/apigen" library="RabbitMQ.Client.Apigen-net_4_x">
@@ -2118,6 +2329,7 @@
       <library_output>./../../../../class/lib/net_4_x/RabbitMQ.Client.Apigen.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>RabbitMQ.Client.Apigen.exe.sources</response>
     </project>
     <project dir="class/RabbitMQ.Client/src/client" library="RabbitMQ.Client-net_4_x">
@@ -2128,6 +2340,7 @@
       <library_output>./../../../../class/lib/net_4_x/RabbitMQ.Client.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>RabbitMQ.Client.dll.sources</response>
     </project>
     <project dir="class/Mono.Messaging.RabbitMQ" library="Mono.Messaging.RabbitMQ-net_4_x">
@@ -2138,6 +2351,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Messaging.RabbitMQ.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Messaging.RabbitMQ.dll.sources</response>
     </project>
     <project dir="class/Mono.Messaging.RabbitMQ" library="Mono.Messaging.RabbitMQ-tests-net_4_x">
@@ -2148,6 +2362,7 @@
       <library_output>net_4_x_Mono.Messaging.RabbitMQ_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_Mono.Messaging.RabbitMQ_test.dll.response</response>
     </project>
     <project dir="class/System.Dynamic" library="System.Dynamic-net_4_x">
@@ -2158,6 +2373,7 @@
       <library_output>./../../class/lib/net_4_x/System.Dynamic.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Dynamic.dll.sources</response>
     </project>
     <project dir="class/System.Windows.Forms.DataVisualization" library="System.Windows.Forms.DataVisualization-net_4_x">
@@ -2168,6 +2384,7 @@
       <library_output>./../../class/lib/net_4_x/System.Windows.Forms.DataVisualization.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Windows.Forms.DataVisualization.dll.sources</response>
     </project>
     <project dir="class/System.Windows.Forms.DataVisualization" library="System.Windows.Forms.DataVisualization-tests-net_4_x">
@@ -2178,6 +2395,7 @@
       <library_output>net_4_x_System.Windows.Forms.DataVisualization_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Windows.Forms.DataVisualization_test.dll.response</response>
     </project>
     <project dir="class/System.Reactive.Interfaces" library="System.Reactive.Interfaces-net_4_x">
@@ -2188,6 +2406,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Interfaces.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Interfaces.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Core" library="System.Reactive.Core-net_4_x">
@@ -2198,6 +2417,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Core.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Linq" library="System.Reactive.Linq-net_4_x">
@@ -2208,6 +2428,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Linq.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Linq.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.PlatformServices" library="System.Reactive.PlatformServices-net_4_x">
@@ -2218,6 +2439,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.PlatformServices.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.PlatformServices.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Providers" library="System.Reactive.Providers-net_4_x">
@@ -2228,6 +2450,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Providers.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Providers.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Runtime.Remoting" library="System.Reactive.Runtime.Remoting-net_4_x">
@@ -2238,6 +2461,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Runtime.Remoting.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Runtime.Remoting.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Windows.Forms" library="System.Reactive.Windows.Forms-net_4_x">
@@ -2248,6 +2472,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Windows.Forms.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Windows.Forms.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Windows.Threading" library="System.Reactive.Windows.Threading-net_4_x">
@@ -2258,6 +2483,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Windows.Threading.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Windows.Threading.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Observable.Aliases" library="System.Reactive.Observable.Aliases-net_4_x">
@@ -2268,6 +2494,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Observable.Aliases.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Observable.Aliases.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Experimental" library="System.Reactive.Experimental-net_4_x">
@@ -2278,6 +2505,7 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Experimental.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Experimental.dll.sources</response>
     </project>
     <project dir="class/System.Reactive.Debugger" library="System.Reactive.Debugger-net_4_x">
@@ -2288,16 +2516,18 @@
       <library_output>./../../class/lib/net_4_x/System.Reactive.Debugger.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reactive.Debugger.dll.sources</response>
     </project>
     <project dir="class/System.Data.Services.Client" library="System.Data.Services.Client-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:NET_3_5 -resource:Client/System.Data.Services.Client.resources -warn:2 -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Xml.Linq.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/WindowsBase.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:NET_3_5 -warn:2 -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Xml.Linq.dll -r:./../../class/lib/net_4_x/System.Data.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/WindowsBase.dll</flags>
       <output>System.Data.Services.Client.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Data.Services.Client.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Data.Services.Client,Client/System.Data.Services.Client.txt</resources>
       <response>System.Data.Services.Client.dll.sources</response>
     </project>
     <project dir="class/System.Data.Services" library="System.Data.Services-net_4_x">
@@ -2308,6 +2538,7 @@
       <library_output>./../../class/lib/net_4_x/System.Data.Services.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Data.Services.dll.sources</response>
     </project>
     <project dir="class/System.Data.Services" library="System.Data.Services-tests-net_4_x">
@@ -2318,6 +2549,7 @@
       <library_output>net_4_x_System.Data.Services_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Data.Services_test.dll.response</response>
     </project>
     <project dir="class/System.Data.Entity" library="System.Data.Entity-net_4_x">
@@ -2328,6 +2560,7 @@
       <library_output>./../../class/lib/net_4_x/System.Data.Entity.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Data.Entity.dll.sources</response>
     </project>
     <project dir="class/System.Data.DataSetExtensions" library="System.Data.DataSetExtensions-net_4_x">
@@ -2338,6 +2571,7 @@
       <library_output>./../../class/lib/net_4_x/System.Data.DataSetExtensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Data.DataSetExtensions.dll.sources</response>
     </project>
     <project dir="class/System.Data.DataSetExtensions" library="System.Data.DataSetExtensions-tests-net_4_x">
@@ -2348,26 +2582,29 @@
       <library_output>net_4_x_System.Data.DataSetExtensions_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Data.DataSetExtensions_test.dll.response</response>
     </project>
     <project dir="class/System.Json.Microsoft" library="System.Json.Microsoft-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /d:ASPNETMVC -keyfile:../winfx.pub -delaysign /resource:System.Json/Properties/Resources.resources,System.Json.Properties.Resources.resources -d:FEATURE_DYNAMIC -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/Microsoft.CSharp.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig /d:ASPNETMVC -keyfile:../winfx.pub -delaysign -d:FEATURE_DYNAMIC -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/Microsoft.CSharp.dll</flags>
       <output>System.Json.Microsoft.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.Json.Microsoft.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>System.Json.Properties.Resources,System.Json/Properties/Resources.resx</resources>
       <response>System.Json.Microsoft.dll.sources</response>
     </project>
     <project dir="class/System.Json.Microsoft" library="System.Json.Microsoft-tests-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize -r:./../../class/lib/net_4_x/System.Json.Microsoft.dll /d:ASPNETMVC -keyfile:../winfx.pub -delaysign /resource:System.Json/Properties/Resources.resources,System.Json.Properties.Resources.resources -d:FEATURE_DYNAMIC -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/Microsoft.CSharp.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize -r:./../../class/lib/net_4_x/System.Json.Microsoft.dll /d:ASPNETMVC -keyfile:../winfx.pub -delaysign -d:FEATURE_DYNAMIC -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Xml.dll -r:./../../class/lib/net_4_x/System.Core.dll -r:./../../class/lib/net_4_x/System.Runtime.Serialization.dll -r:./../../class/lib/net_4_x/Microsoft.CSharp.dll</flags>
       <output>net_4_x_System.Json.Microsoft_test.dll</output>
       <built_sources></built_sources>
       <library_output>net_4_x_System.Json.Microsoft_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Json.Microsoft_test.dll.response</response>
     </project>
     <project dir="class/System.Threading.Tasks.Dataflow" library="System.Threading.Tasks.Dataflow-net_4_x">
@@ -2378,6 +2615,7 @@
       <library_output>./../../class/lib/net_4_x/System.Threading.Tasks.Dataflow.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.Tasks.Dataflow.dll.sources</response>
     </project>
     <project dir="class/System.Threading.Tasks.Dataflow" library="System.Threading.Tasks.Dataflow-tests-net_4_x">
@@ -2388,16 +2626,18 @@
       <library_output>net_4_x_System.Threading.Tasks.Dataflow_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_System.Threading.Tasks.Dataflow_test.dll.response</response>
     </project>
     <project dir="class/System.ComponentModel.Composition.4.5" library="System.ComponentModel.Composition-net_4_x">
       <boot>false</boot>
-      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:CLR40 -resource:Microsoft.Internal.Strings.resources -d:USE_ECMA_KEY,FEATURE_REFLECTIONCONTEXT,FEATURE_REFLECTIONFILEIO,FEATURE_SERIALIZATION,FEATURE_SLIMLOCK -nowarn:219,414 -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll</flags>
+      <flags>/codepage:65001 -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:DISABLE_CAS_USE -nowarn:1699 -nostdlib -r:./../../class/lib/net_4_x/mscorlib.dll -debug -optimize /noconfig -d:CLR40 -d:USE_ECMA_KEY,FEATURE_REFLECTIONCONTEXT,FEATURE_REFLECTIONFILEIO,FEATURE_SERIALIZATION,FEATURE_SLIMLOCK -nowarn:219,414 -r:./../../class/lib/net_4_x/System.dll -r:./../../class/lib/net_4_x/System.Core.dll</flags>
       <output>System.ComponentModel.Composition.dll</output>
       <built_sources></built_sources>
       <library_output>./../../class/lib/net_4_x/System.ComponentModel.Composition.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources>Microsoft.Internal.Strings,src/ComponentModel/Strings.resx</resources>
       <response>System.ComponentModel.Composition.dll.sources</response>
     </project>
     <project dir="class/System.Windows" library="System.Windows-net_4_x">
@@ -2408,6 +2648,7 @@
       <library_output>./../../class/lib/net_4_x/System.Windows.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Windows.dll.sources</response>
     </project>
     <project dir="class/System.Xml.Serialization" library="System.Xml.Serialization-net_4_x">
@@ -2418,6 +2659,7 @@
       <library_output>./../../class/lib/net_4_x/System.Xml.Serialization.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.Serialization.dll.sources</response>
     </project>
     <project dir="class/Mono.Security.Providers.DotNet" library="Mono.Security.Providers.DotNet-net_4_x">
@@ -2428,6 +2670,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Security.Providers.DotNet.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Security.Providers.DotNet.dll.sources</response>
     </project>
     <project dir="class/Mono.Security.Providers.OldTls" library="Mono.Security.Providers.OldTls-net_4_x">
@@ -2438,6 +2681,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Security.Providers.OldTls.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Security.Providers.OldTls.dll.sources</response>
     </project>
     <project dir="class/System.DirectoryServices.Protocols" library="System.DirectoryServices.Protocols-net_4_x">
@@ -2448,6 +2692,7 @@
       <library_output>./../../class/lib/net_4_x/System.DirectoryServices.Protocols.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.DirectoryServices.Protocols.dll.sources</response>
     </project>
     <project dir="class/Microsoft.VisualC" library="Microsoft.VisualC-net_4_x">
@@ -2458,6 +2703,7 @@
       <library_output>./../../class/lib/net_4_x/Microsoft.VisualC.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.VisualC.dll.sources</response>
     </project>
     <project dir="class/WebMatrix.Data" library="WebMatrix.Data-net_4_x">
@@ -2468,6 +2714,7 @@
       <library_output>./../../class/lib/net_4_x/WebMatrix.Data.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>WebMatrix.Data.dll.sources</response>
     </project>
     <project dir="class/WebMatrix.Data" library="WebMatrix.Data-tests-net_4_x">
@@ -2478,6 +2725,7 @@
       <library_output>net_4_x_WebMatrix.Data_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_WebMatrix.Data_test.dll.response</response>
     </project>
     <project dir="class/monodoc" library="monodoc-net_4_x">
@@ -2488,6 +2736,7 @@
       <library_output>./../../class/lib/net_4_x/monodoc.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>monodoc.dll.sources</response>
     </project>
     <project dir="class/monodoc" library="monodoc-tests-net_4_x">
@@ -2498,6 +2747,7 @@
       <library_output>net_4_x_monodoc_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>./../../build/deps/net_4_x_monodoc_test.dll.response</response>
     </project>
     <project dir="class/System.Deployment" library="System.Deployment-net_4_x">
@@ -2508,6 +2758,7 @@
       <library_output>./../../class/lib/net_4_x/System.Deployment.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Deployment.dll.sources</response>
     </project>
     <project dir="class/System.Web.Mobile" library="System.Web.Mobile-net_4_x">
@@ -2518,6 +2769,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.Mobile.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.Mobile.dll.sources</response>
     </project>
     <project dir="class/System.Web.RegularExpressions" library="System.Web.RegularExpressions-net_4_x">
@@ -2528,6 +2780,7 @@
       <library_output>./../../class/lib/net_4_x/System.Web.RegularExpressions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Web.RegularExpressions.dll.sources</response>
     </project>
     <project dir="class/System.Workflow.Activities" library="System.Workflow.Activities-net_4_x">
@@ -2538,6 +2791,7 @@
       <library_output>./../../class/lib/net_4_x/System.Workflow.Activities.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Workflow.Activities.dll.sources</response>
     </project>
     <project dir="class/System.Workflow.ComponentModel" library="System.Workflow.ComponentModel-net_4_x">
@@ -2548,6 +2802,7 @@
       <library_output>./../../class/lib/net_4_x/System.Workflow.ComponentModel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Workflow.ComponentModel.dll.sources</response>
     </project>
     <project dir="class/System.Workflow.Runtime" library="System.Workflow.Runtime-net_4_x">
@@ -2558,6 +2813,7 @@
       <library_output>./../../class/lib/net_4_x/System.Workflow.Runtime.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Workflow.Runtime.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Collections.Concurrent" library="Facades_System.Collections.Concurrent-net_4_x">
@@ -2568,6 +2824,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Collections.Concurrent.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Collections.Concurrent.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Collections" library="Facades_System.Collections-net_4_x">
@@ -2578,6 +2835,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Collections.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Collections.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ComponentModel.Annotations" library="Facades_System.ComponentModel.Annotations-net_4_x">
@@ -2588,6 +2846,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ComponentModel.Annotations.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ComponentModel.Annotations.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ComponentModel.EventBasedAsync" library="Facades_System.ComponentModel.EventBasedAsync-net_4_x">
@@ -2598,6 +2857,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ComponentModel.EventBasedAsync.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ComponentModel.EventBasedAsync.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ComponentModel" library="Facades_System.ComponentModel-net_4_x">
@@ -2608,6 +2868,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ComponentModel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ComponentModel.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.Contracts" library="Facades_System.Diagnostics.Contracts-net_4_x">
@@ -2618,6 +2879,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.Contracts.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.Contracts.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.Debug" library="Facades_System.Diagnostics.Debug-net_4_x">
@@ -2628,6 +2890,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.Debug.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.Debug.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.Tracing" library="Facades_System.Diagnostics.Tracing-net_4_x">
@@ -2638,6 +2901,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.Tracing.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.Tracing.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.Tools" library="Facades_System.Diagnostics.Tools-net_4_x">
@@ -2648,6 +2912,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.Tools.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.Tools.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Dynamic.Runtime" library="Facades_System.Dynamic.Runtime-net_4_x">
@@ -2658,6 +2923,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Dynamic.Runtime.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Dynamic.Runtime.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Globalization" library="Facades_System.Globalization-net_4_x">
@@ -2668,6 +2934,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Globalization.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Globalization.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO" library="Facades_System.IO-net_4_x">
@@ -2678,6 +2945,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Linq.Expressions" library="Facades_System.Linq.Expressions-net_4_x">
@@ -2688,6 +2956,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Linq.Expressions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Linq.Expressions.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Linq.Parallel" library="Facades_System.Linq.Parallel-net_4_x">
@@ -2698,6 +2967,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Linq.Parallel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Linq.Parallel.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Linq.Queryable" library="Facades_System.Linq.Queryable-net_4_x">
@@ -2708,6 +2978,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Linq.Queryable.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Linq.Queryable.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Linq" library="Facades_System.Linq-net_4_x">
@@ -2718,6 +2989,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Linq.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Linq.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.NetworkInformation" library="Facades_System.Net.NetworkInformation-net_4_x">
@@ -2728,6 +3000,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.NetworkInformation.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.NetworkInformation.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Primitives" library="Facades_System.Net.Primitives-net_4_x">
@@ -2738,6 +3011,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Requests" library="Facades_System.Net.Requests-net_4_x">
@@ -2748,6 +3022,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Requests.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Requests.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ObjectModel" library="Facades_System.ObjectModel-net_4_x">
@@ -2758,6 +3033,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ObjectModel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ObjectModel.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Reflection.Extensions" library="Facades_System.Reflection.Extensions-net_4_x">
@@ -2768,6 +3044,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Reflection.Extensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reflection.Extensions.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Reflection.Primitives" library="Facades_System.Reflection.Primitives-net_4_x">
@@ -2778,6 +3055,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Reflection.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reflection.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Reflection" library="Facades_System.Reflection-net_4_x">
@@ -2788,6 +3066,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Reflection.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reflection.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Resources.ResourceManager" library="Facades_System.Resources.ResourceManager-net_4_x">
@@ -2798,6 +3077,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Resources.ResourceManager.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Resources.ResourceManager.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.Extensions" library="Facades_System.Runtime.Extensions-net_4_x">
@@ -2808,6 +3088,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.Extensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Extensions.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.InteropServices" library="Facades_System.Runtime.InteropServices-net_4_x">
@@ -2818,6 +3099,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.InteropServices.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.InteropServices.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.InteropServices.WindowsRuntime" library="Facades_System.Runtime.InteropServices.WindowsRuntime-net_4_x">
@@ -2828,6 +3110,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.InteropServices.WindowsRuntime.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.InteropServices.WindowsRuntime.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.Numerics" library="Facades_System.Runtime.Numerics-net_4_x">
@@ -2838,6 +3121,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.Numerics.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Numerics.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.Serialization.Json" library="Facades_System.Runtime.Serialization.Json-net_4_x">
@@ -2848,6 +3132,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.Serialization.Json.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Serialization.Json.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.Serialization.Primitives" library="Facades_System.Runtime.Serialization.Primitives-net_4_x">
@@ -2858,6 +3143,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.Serialization.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Serialization.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.Serialization.Xml" library="Facades_System.Runtime.Serialization.Xml-net_4_x">
@@ -2868,6 +3154,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.Serialization.Xml.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Serialization.Xml.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime" library="Facades_System.Runtime-net_4_x">
@@ -2878,6 +3165,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Principal" library="Facades_System.Security.Principal-net_4_x">
@@ -2888,6 +3176,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Principal.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Principal.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ServiceModel.Http" library="Facades_System.ServiceModel.Http-net_4_x">
@@ -2898,6 +3187,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ServiceModel.Http.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Http.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ServiceModel.Primitives" library="Facades_System.ServiceModel.Primitives-net_4_x">
@@ -2908,6 +3198,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ServiceModel.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ServiceModel.Security" library="Facades_System.ServiceModel.Security-net_4_x">
@@ -2918,6 +3209,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ServiceModel.Security.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Security.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Text.Encoding.Extensions" library="Facades_System.Text.Encoding.Extensions-net_4_x">
@@ -2928,6 +3220,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Text.Encoding.Extensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Text.Encoding.Extensions.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Text.Encoding" library="Facades_System.Text.Encoding-net_4_x">
@@ -2938,6 +3231,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Text.Encoding.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Text.Encoding.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Text.RegularExpressions" library="Facades_System.Text.RegularExpressions-net_4_x">
@@ -2948,6 +3242,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Text.RegularExpressions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Text.RegularExpressions.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading.Tasks.Parallel" library="Facades_System.Threading.Tasks.Parallel-net_4_x">
@@ -2958,6 +3253,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.Tasks.Parallel.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.Tasks.Parallel.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading.Tasks" library="Facades_System.Threading.Tasks-net_4_x">
@@ -2968,6 +3264,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.Tasks.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.Tasks.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading.Timer" library="Facades_System.Threading.Timer-net_4_x">
@@ -2978,6 +3275,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.Timer.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.Timer.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading" library="Facades_System.Threading-net_4_x">
@@ -2988,6 +3286,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Xml.ReaderWriter" library="Facades_System.Xml.ReaderWriter-net_4_x">
@@ -2998,6 +3297,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Xml.ReaderWriter.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.ReaderWriter.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Xml.XDocument" library="Facades_System.Xml.XDocument-net_4_x">
@@ -3008,6 +3308,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Xml.XDocument.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.XDocument.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Xml.XmlSerializer" library="Facades_System.Xml.XmlSerializer-net_4_x">
@@ -3018,6 +3319,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Xml.XmlSerializer.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.XmlSerializer.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.Handles" library="Facades_System.Runtime.Handles-net_4_x">
@@ -3028,6 +3330,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.Handles.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.Handles.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ServiceModel.Duplex" library="Facades_System.ServiceModel.Duplex-net_4_x">
@@ -3038,6 +3341,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ServiceModel.Duplex.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.Duplex.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ServiceModel.NetTcp" library="Facades_System.ServiceModel.NetTcp-net_4_x">
@@ -3048,6 +3352,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ServiceModel.NetTcp.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceModel.NetTcp.dll.sources</response>
     </project>
     <project dir="class/Facades/Microsoft.Win32.Primitives" library="Facades_Microsoft.Win32.Primitives-net_4_x">
@@ -3058,6 +3363,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/Microsoft.Win32.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Win32.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/Microsoft.Win32.Registry" library="Facades_Microsoft.Win32.Registry-net_4_x">
@@ -3068,6 +3374,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/Microsoft.Win32.Registry.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Win32.Registry.dll.sources</response>
     </project>
     <project dir="class/Facades/System.AppContext" library="Facades_System.AppContext-net_4_x">
@@ -3078,6 +3385,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.AppContext.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.AppContext.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Collections.NonGeneric" library="Facades_System.Collections.NonGeneric-net_4_x">
@@ -3088,6 +3396,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Collections.NonGeneric.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Collections.NonGeneric.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Collections.Specialized" library="Facades_System.Collections.Specialized-net_4_x">
@@ -3098,6 +3407,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Collections.Specialized.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Collections.Specialized.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ComponentModel.Primitives" library="Facades_System.ComponentModel.Primitives-net_4_x">
@@ -3108,6 +3418,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ComponentModel.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ComponentModel.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ComponentModel.TypeConverter" library="Facades_System.ComponentModel.TypeConverter-net_4_x">
@@ -3118,6 +3429,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ComponentModel.TypeConverter.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ComponentModel.TypeConverter.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Console" library="Facades_System.Console-net_4_x">
@@ -3128,6 +3440,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Console.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Console.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Data.Common" library="Facades_System.Data.Common-net_4_x">
@@ -3138,6 +3451,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Data.Common.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Data.Common.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Data.SqlClient" library="Facades_System.Data.SqlClient-net_4_x">
@@ -3148,6 +3462,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Data.SqlClient.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Data.SqlClient.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.FileVersionInfo" library="Facades_System.Diagnostics.FileVersionInfo-net_4_x">
@@ -3158,6 +3473,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.FileVersionInfo.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.FileVersionInfo.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.Process" library="Facades_System.Diagnostics.Process-net_4_x">
@@ -3168,6 +3484,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.Process.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.Process.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.TextWriterTraceListener" library="Facades_System.Diagnostics.TextWriterTraceListener-net_4_x">
@@ -3178,6 +3495,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.TextWriterTraceListener.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.TextWriterTraceListener.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.TraceEvent" library="Facades_System.Diagnostics.TraceEvent-net_4_x">
@@ -3188,6 +3506,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.TraceEvent.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.TraceEvent.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.TraceSource" library="Facades_System.Diagnostics.TraceSource-net_4_x">
@@ -3198,6 +3517,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.TraceSource.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.TraceSource.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Globalization.Calendars" library="Facades_System.Globalization.Calendars-net_4_x">
@@ -3208,6 +3528,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Globalization.Calendars.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Globalization.Calendars.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.Compression.ZipFile" library="Facades_System.IO.Compression.ZipFile-net_4_x">
@@ -3218,6 +3539,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.Compression.ZipFile.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.Compression.ZipFile.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.FileSystem" library="Facades_System.IO.FileSystem-net_4_x">
@@ -3228,6 +3550,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.FileSystem.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.FileSystem.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.FileSystem.DriveInfo" library="Facades_System.IO.FileSystem.DriveInfo-net_4_x">
@@ -3238,6 +3561,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.FileSystem.DriveInfo.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.FileSystem.DriveInfo.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.FileSystem.Primitives" library="Facades_System.IO.FileSystem.Primitives-net_4_x">
@@ -3248,6 +3572,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.FileSystem.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.FileSystem.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.IsolatedStorage" library="Facades_System.IO.IsolatedStorage-net_4_x">
@@ -3258,6 +3583,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.IsolatedStorage.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.IsolatedStorage.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.MemoryMappedFiles" library="Facades_System.IO.MemoryMappedFiles-net_4_x">
@@ -3268,6 +3594,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.MemoryMappedFiles.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.MemoryMappedFiles.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.UnmanagedMemoryStream" library="Facades_System.IO.UnmanagedMemoryStream-net_4_x">
@@ -3278,6 +3605,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.UnmanagedMemoryStream.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.UnmanagedMemoryStream.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.AuthenticationManager" library="Facades_System.Net.AuthenticationManager-net_4_x">
@@ -3288,6 +3616,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.AuthenticationManager.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.AuthenticationManager.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Cache" library="Facades_System.Net.Cache-net_4_x">
@@ -3298,6 +3627,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Cache.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Cache.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.HttpListener" library="Facades_System.Net.HttpListener-net_4_x">
@@ -3308,6 +3638,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.HttpListener.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.HttpListener.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Mail" library="Facades_System.Net.Mail-net_4_x">
@@ -3318,6 +3649,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Mail.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Mail.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.NameResolution" library="Facades_System.Net.NameResolution-net_4_x">
@@ -3328,6 +3660,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.NameResolution.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.NameResolution.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Security" library="Facades_System.Net.Security-net_4_x">
@@ -3338,6 +3671,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Security.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Security.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.ServicePoint" library="Facades_System.Net.ServicePoint-net_4_x">
@@ -3348,6 +3682,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.ServicePoint.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.ServicePoint.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Sockets" library="Facades_System.Net.Sockets-net_4_x">
@@ -3358,6 +3693,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Sockets.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Sockets.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Utilities" library="Facades_System.Net.Utilities-net_4_x">
@@ -3368,6 +3704,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Utilities.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Utilities.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.WebHeaderCollection" library="Facades_System.Net.WebHeaderCollection-net_4_x">
@@ -3378,6 +3715,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.WebHeaderCollection.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.WebHeaderCollection.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.WebSockets" library="Facades_System.Net.WebSockets-net_4_x">
@@ -3388,6 +3726,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.WebSockets.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.WebSockets.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.WebSockets.Client" library="Facades_System.Net.WebSockets.Client-net_4_x">
@@ -3398,6 +3737,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.WebSockets.Client.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.WebSockets.Client.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Resources.ReaderWriter" library="Facades_System.Resources.ReaderWriter-net_4_x">
@@ -3408,6 +3748,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Resources.ReaderWriter.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Resources.ReaderWriter.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Runtime.CompilerServices.VisualC" library="Facades_System.Runtime.CompilerServices.VisualC-net_4_x">
@@ -3418,6 +3759,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Runtime.CompilerServices.VisualC.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Runtime.CompilerServices.VisualC.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.AccessControl" library="Facades_System.Security.AccessControl-net_4_x">
@@ -3428,6 +3770,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.AccessControl.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.AccessControl.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Claims" library="Facades_System.Security.Claims-net_4_x">
@@ -3438,6 +3781,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Claims.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Claims.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.DeriveBytes" library="Facades_System.Security.Cryptography.DeriveBytes-net_4_x">
@@ -3448,6 +3792,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.DeriveBytes.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.DeriveBytes.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.Encoding" library="Facades_System.Security.Cryptography.Encoding-net_4_x">
@@ -3458,6 +3803,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.Encoding.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.Encoding.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.Encryption" library="Facades_System.Security.Cryptography.Encryption-net_4_x">
@@ -3468,6 +3814,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.Encryption.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.Encryption.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.Encryption.Aes" library="Facades_System.Security.Cryptography.Encryption.Aes-net_4_x">
@@ -3478,6 +3825,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.Encryption.Aes.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.Encryption.Aes.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.Encryption.ECDiffieHellman" library="Facades_System.Security.Cryptography.Encryption.ECDiffieHellman-net_4_x">
@@ -3488,6 +3836,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.Encryption.ECDiffieHellman.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.Encryption.ECDiffieHellman.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.Encryption.ECDsa" library="Facades_System.Security.Cryptography.Encryption.ECDsa-net_4_x">
@@ -3498,6 +3847,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.Encryption.ECDsa.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.Encryption.ECDsa.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.Hashing" library="Facades_System.Security.Cryptography.Hashing-net_4_x">
@@ -3508,6 +3858,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.Hashing.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.Hashing.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.Hashing.Algorithms" library="Facades_System.Security.Cryptography.Hashing.Algorithms-net_4_x">
@@ -3518,6 +3869,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.Hashing.Algorithms.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.Hashing.Algorithms.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.RSA" library="Facades_System.Security.Cryptography.RSA-net_4_x">
@@ -3528,6 +3880,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.RSA.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.RSA.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.RandomNumberGenerator" library="Facades_System.Security.Cryptography.RandomNumberGenerator-net_4_x">
@@ -3538,6 +3891,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.RandomNumberGenerator.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.RandomNumberGenerator.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.X509Certificates" library="Facades_System.Security.Cryptography.X509Certificates-net_4_x">
@@ -3548,6 +3902,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.X509Certificates.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.X509Certificates.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Principal.Windows" library="Facades_System.Security.Principal.Windows-net_4_x">
@@ -3558,6 +3913,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Principal.Windows.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Principal.Windows.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading.Thread" library="Facades_System.Threading.Thread-net_4_x">
@@ -3568,6 +3924,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.Thread.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.Thread.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading.ThreadPool" library="Facades_System.Threading.ThreadPool-net_4_x">
@@ -3578,6 +3935,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.ThreadPool.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.ThreadPool.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Xml.XPath" library="Facades_System.Xml.XPath-net_4_x">
@@ -3588,6 +3946,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Xml.XPath.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.XPath.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Xml.XmlDocument" library="Facades_System.Xml.XmlDocument-net_4_x">
@@ -3598,6 +3957,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Xml.XmlDocument.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.XmlDocument.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Xml.Xsl.Primitives" library="Facades_System.Xml.Xsl.Primitives-net_4_x">
@@ -3608,6 +3968,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Xml.Xsl.Primitives.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.Xsl.Primitives.dll.sources</response>
     </project>
     <project dir="class/Facades/Microsoft.Win32.Registry.AccessControl" library="Facades_Microsoft.Win32.Registry.AccessControl-net_4_x">
@@ -3618,6 +3979,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/Microsoft.Win32.Registry.AccessControl.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Microsoft.Win32.Registry.AccessControl.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.StackTrace" library="Facades_System.Diagnostics.StackTrace-net_4_x">
@@ -3628,6 +3990,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.StackTrace.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.StackTrace.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Globalization.Extensions" library="Facades_System.Globalization.Extensions-net_4_x">
@@ -3638,6 +4001,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Globalization.Extensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Globalization.Extensions.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.FileSystem.AccessControl" library="Facades_System.IO.FileSystem.AccessControl-net_4_x">
@@ -3648,6 +4012,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.FileSystem.AccessControl.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.FileSystem.AccessControl.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Private.CoreLib.InteropServices" library="Facades_System.Private.CoreLib.InteropServices-net_4_x">
@@ -3658,6 +4023,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Private.CoreLib.InteropServices.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Private.CoreLib.InteropServices.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Private.CoreLib.Threading" library="Facades_System.Private.CoreLib.Threading-net_4_x">
@@ -3668,6 +4034,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Private.CoreLib.Threading.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Private.CoreLib.Threading.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Reflection.TypeExtensions" library="Facades_System.Reflection.TypeExtensions-net_4_x">
@@ -3678,6 +4045,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Reflection.TypeExtensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reflection.TypeExtensions.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.SecureString" library="Facades_System.Security.SecureString-net_4_x">
@@ -3688,6 +4056,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.SecureString.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.SecureString.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading.AccessControl" library="Facades_System.Threading.AccessControl-net_4_x">
@@ -3698,6 +4067,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.AccessControl.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.AccessControl.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Threading.Overlapped" library="Facades_System.Threading.Overlapped-net_4_x">
@@ -3708,6 +4078,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Threading.Overlapped.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Threading.Overlapped.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Xml.XPath.XDocument" library="Facades_System.Xml.XPath.XDocument-net_4_x">
@@ -3718,6 +4089,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Xml.XPath.XDocument.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Xml.XPath.XDocument.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Reflection.Emit.ILGeneration" library="Facades_System.Reflection.Emit.ILGeneration-net_4_x">
@@ -3728,6 +4100,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Reflection.Emit.ILGeneration.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reflection.Emit.ILGeneration.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Reflection.Emit.Lightweight" library="Facades_System.Reflection.Emit.Lightweight-net_4_x">
@@ -3738,6 +4111,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Reflection.Emit.Lightweight.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reflection.Emit.Lightweight.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Reflection.Emit" library="Facades_System.Reflection.Emit-net_4_x">
@@ -3748,6 +4122,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Reflection.Emit.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Reflection.Emit.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Diagnostics.PerformanceCounter" library="Facades_System.Diagnostics.PerformanceCounter-net_4_x">
@@ -3758,6 +4133,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Diagnostics.PerformanceCounter.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Diagnostics.PerformanceCounter.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.FileSystem.Watcher" library="Facades_System.IO.FileSystem.Watcher-net_4_x">
@@ -3768,6 +4144,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.FileSystem.Watcher.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.FileSystem.Watcher.dll.sources</response>
     </project>
     <project dir="class/Facades/System.IO.Pipes" library="Facades_System.IO.Pipes-net_4_x">
@@ -3778,6 +4155,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.IO.Pipes.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.IO.Pipes.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Security.Cryptography.ProtectedData" library="Facades_System.Security.Cryptography.ProtectedData-net_4_x">
@@ -3788,6 +4166,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Security.Cryptography.ProtectedData.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Security.Cryptography.ProtectedData.dll.sources</response>
     </project>
     <project dir="class/Facades/System.ServiceProcess.ServiceController" library="Facades_System.ServiceProcess.ServiceController-net_4_x">
@@ -3798,6 +4177,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.ServiceProcess.ServiceController.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.ServiceProcess.ServiceController.dll.sources</response>
     </project>
     <project dir="class/Facades/System.Net.Http.WebRequestHandler" library="Facades_System.Net.Http.WebRequestHandler-net_4_x">
@@ -3808,6 +4188,7 @@
       <library_output>./../../../class/lib/net_4_x/Facades/System.Net.Http.WebRequestHandler.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>System.Net.Http.WebRequestHandler.dll.sources</response>
     </project>
     <project dir="nunit24/NUnitFramework/framework" library="NUnit.Framework-net_4_x">
@@ -3818,6 +4199,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit.framework.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>NUnit.Framework.dll.sources</response>
     </project>
     <project dir="nunit24/NUnitCore/interfaces" library="nunit.core.interfaces-net_4_x">
@@ -3828,6 +4210,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit.core.interfaces.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit.core.interfaces.dll.sources</response>
     </project>
     <project dir="nunit24/NUnitCore/core" library="nunit.core-net_4_x">
@@ -3838,6 +4221,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit.core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit.core.dll.sources</response>
     </project>
     <project dir="nunit24/ClientUtilities/util" library="nunit.util-net_4_x">
@@ -3848,6 +4232,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit.util.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit.util.dll.sources</response>
     </project>
     <project dir="nunit24/NUnitMocks/mocks" library="nunit.mocks-net_4_x">
@@ -3858,6 +4243,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit.mocks.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit.mocks.dll.sources</response>
     </project>
     <project dir="nunit24/NUnitExtensions/framework" library="nunit.framework.extensions-net_4_x">
@@ -3868,6 +4254,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit.framework.extensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit.framework.extensions.dll.sources</response>
     </project>
     <project dir="nunit24/NUnitExtensions/core" library="nunit.core.extensions-net_4_x">
@@ -3878,6 +4265,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit.core.extensions.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit.core.extensions.dll.sources</response>
     </project>
     <project dir="nunit24/ConsoleRunner/nunit-console" library="nunit-console-runner-net_4_x">
@@ -3888,6 +4276,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit-console-runner.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit-console-runner.dll.sources</response>
     </project>
     <project dir="nunit24/ConsoleRunner/nunit-console-exe" library="nunit-console-net_4_x">
@@ -3898,6 +4287,7 @@
       <library_output>./../../../class/lib/net_4_x/nunit-console.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunit-console.exe.sources</response>
     </project>
     <project dir="ilasm" library="ilasm-net_4_x">
@@ -3908,6 +4298,7 @@
       <library_output>./../class/lib/net_4_x/ilasm.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>ilasm.exe.sources</response>
     </project>
     <project dir="tools/gacutil" library="gacutil-net_4_x">
@@ -3918,6 +4309,7 @@
       <library_output>./../../class/lib/net_4_x/gacutil.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>gacutil.exe.sources</response>
     </project>
     <project dir="tools/culevel" library="culevel-net_4_x">
@@ -3928,6 +4320,7 @@
       <library_output>./../../class/lib/net_4_x/culevel.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>culevel.exe.sources</response>
     </project>
     <project dir="tools/cil-stringreplacer" library="cil-stringreplacer-net_4_x">
@@ -3938,6 +4331,7 @@
       <library_output>./../../class/lib/net_4_x/cil-stringreplacer.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>cil-stringreplacer.exe.sources</response>
     </project>
     <project dir="tools/commoncryptogenerator" library="commoncryptogenerator-net_4_x">
@@ -3948,6 +4342,7 @@
       <library_output>./../../class/lib/net_4_x/commoncryptogenerator.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>commoncryptogenerator.exe.sources</response>
     </project>
     <project dir="tools/al" library="al-net_4_x">
@@ -3958,6 +4353,7 @@
       <library_output>./../../class/lib/net_4_x/al.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>al.exe.sources</response>
     </project>
     <project dir="tools/linker" library="monolinker-net_4_x">
@@ -3968,6 +4364,7 @@
       <library_output>./../../class/lib/net_4_x/monolinker.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>monolinker.exe.sources</response>
     </project>
     <project dir="tools/tuner" library="Mono.Tuner-net_4_x">
@@ -3978,6 +4375,7 @@
       <library_output>./../../class/lib/net_4_x/Mono.Tuner.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Tuner.dll.sources</response>
     </project>
     <project dir="tools/culevel" library="culevel-net_4_x">
@@ -3988,6 +4386,7 @@
       <library_output>./../../class/lib/net_4_x/culevel.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>culevel.exe.sources</response>
     </project>
     <project dir="tools/genxs" library="genxs-net_4_x">
@@ -3998,6 +4397,7 @@
       <library_output>./../../class/lib/net_4_x/genxs.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>genxs.exe.sources</response>
     </project>
     <project dir="tools/mkbundle" library="mkbundle-net_4_x">
@@ -4008,6 +4408,7 @@
       <library_output>./../../class/lib/net_4_x/mkbundle.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mkbundle.exe.sources</response>
     </project>
     <project dir="tools/monop" library="monop-net_4_x">
@@ -4018,6 +4419,7 @@
       <library_output>./../../class/lib/net_4_x/monop.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>monop.exe.sources</response>
     </project>
     <project dir="tools/mono-service" library="mono-service-net_4_x">
@@ -4028,6 +4430,7 @@
       <library_output>./../../class/lib/net_4_x/mono-service.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-service.exe.sources</response>
     </project>
     <project dir="tools/mono-xsd" library="xsd-net_4_x">
@@ -4038,6 +4441,7 @@
       <library_output>./../../class/lib/net_4_x/xsd.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>xsd.exe.sources</response>
     </project>
     <project dir="tools/resgen" library="resgen-net_4_x">
@@ -4048,6 +4452,7 @@
       <library_output>./../../class/lib/net_4_x/resgen.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>resgen.exe.sources</response>
     </project>
     <project dir="tools/gacutil" library="gacutil-net_4_x">
@@ -4058,6 +4463,7 @@
       <library_output>./../../class/lib/net_4_x/gacutil.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>gacutil.exe.sources</response>
     </project>
     <project dir="tools/wsdl" library="wsdl-net_4_x">
@@ -4068,6 +4474,7 @@
       <library_output>./../../class/lib/net_4_x/wsdl.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>wsdl.exe.sources</response>
     </project>
     <project dir="tools/xbuild" library="xbuild-net_4_x">
@@ -4078,6 +4485,7 @@
       <library_output>./../../class/lib/net_4_x/xbuild.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>xbuild.exe.sources</response>
     </project>
     <project dir="tools/csharp" library="csharp-net_4_x">
@@ -4088,6 +4496,7 @@
       <library_output>./../../class/lib/net_4_x/csharp.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>csharp.exe.sources</response>
     </project>
     <project dir="tools/corcompare" library="mono-api-info-net_4_x">
@@ -4098,6 +4507,7 @@
       <library_output>./../../class/lib/net_4_x/mono-api-info.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-api-info.exe.sources</response>
     </project>
     <project dir="tools/mono-api-html" library="mono-api-html-net_4_x">
@@ -4108,6 +4518,7 @@
       <library_output>./../../class/lib/net_4_x/mono-api-html.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-api-html.exe.sources</response>
     </project>
     <project dir="tools/compiler-tester" library="compiler-tester-net_4_x">
@@ -4118,6 +4529,7 @@
       <library_output>./../../class/lib/net_4_x/compiler-tester.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>compiler-tester.exe.sources</response>
     </project>
     <project dir="tools/mono-xmltool" library="mono-xmltool-net_4_x">
@@ -4128,6 +4540,7 @@
       <library_output>./../../class/lib/net_4_x/mono-xmltool.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-xmltool.exe.sources</response>
     </project>
     <project dir="tools/mono-shlib-cop" library="mono-shlib-cop-net_4_x">
@@ -4138,6 +4551,7 @@
       <library_output>./../../class/lib/net_4_x/mono-shlib-cop.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-shlib-cop.exe.sources</response>
     </project>
     <project dir="tools/sgen" library="sgen-net_4_x">
@@ -4148,6 +4562,7 @@
       <library_output>./../../class/lib/net_4_x/sgen.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>sgen.exe.sources</response>
     </project>
     <project dir="tools/mconfig" library="mconfig-net_4_x">
@@ -4158,6 +4573,7 @@
       <library_output>./../../class/lib/net_4_x/mconfig.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mconfig.exe.sources</response>
     </project>
     <project dir="tools/installutil" library="installutil-net_4_x">
@@ -4168,6 +4584,7 @@
       <library_output>./../../class/lib/net_4_x/installutil.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>installutil.exe.sources</response>
     </project>
     <project dir="tools/nunitreport" library="nunitreport-net_4_x">
@@ -4178,6 +4595,7 @@
       <library_output>./../../class/lib/net_4_x/nunitreport.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>nunitreport.exe.sources</response>
     </project>
     <project dir="tools/pdb2mdb" library="pdb2mdb-net_4_x">
@@ -4188,6 +4606,7 @@
       <library_output>./../../class/lib/net_4_x/pdb2mdb.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>pdb2mdb.exe.sources</response>
     </project>
     <project dir="tools/SqlSharp" library="sqlsharp-net_4_x">
@@ -4198,6 +4617,7 @@
       <library_output>./../../class/lib/net_4_x/sqlsharp.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>sqlsharp.exe.sources</response>
     </project>
     <project dir="tools/sqlmetal" library="sqlmetal-net_4_x">
@@ -4208,6 +4628,7 @@
       <library_output>./../../class/lib/net_4_x/sqlmetal.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>sqlmetal.exe.sources</response>
     </project>
     <project dir="tools/svcutil" library="svcutil-net_4_x">
@@ -4218,6 +4639,7 @@
       <library_output>./../../class/lib/net_4_x/svcutil.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>svcutil.exe.sources</response>
     </project>
     <project dir="tools/ictool" library="ictool-net_4_x">
@@ -4228,6 +4650,7 @@
       <library_output>./../../class/lib/net_4_x/ictool.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>ictool.exe.sources</response>
     </project>
     <project dir="tools/disco" library="disco-net_4_x">
@@ -4238,6 +4661,7 @@
       <library_output>./../../class/lib/net_4_x/disco.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>disco.exe.sources</response>
     </project>
     <project dir="tools/soapsuds" library="soapsuds-net_4_x">
@@ -4248,6 +4672,7 @@
       <library_output>./../../class/lib/net_4_x/soapsuds.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>soapsuds.exe.sources</response>
     </project>
     <project dir="tools/browsercaps-updater" library="browsercaps-updater-net_4_x">
@@ -4258,6 +4683,7 @@
       <library_output>./../../class/lib/net_4_x/browsercaps-updater.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>browsercaps-updater.exe.sources</response>
     </project>
     <project dir="tools/cil-strip" library="mono-cil-strip-net_4_x">
@@ -4268,6 +4694,7 @@
       <library_output>./../../class/lib/net_4_x/mono-cil-strip.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-cil-strip.exe.sources</response>
     </project>
     <project dir="tools/macpack" library="macpack-net_4_x">
@@ -4278,6 +4705,7 @@
       <library_output>./../../class/lib/net_4_x/macpack.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>macpack.exe.sources</response>
     </project>
     <project dir="tools/dtd2rng" library="dtd2rng-net_4_x">
@@ -4288,6 +4716,7 @@
       <library_output>./../../class/lib/net_4_x/dtd2rng.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>dtd2rng.exe.sources</response>
     </project>
     <project dir="tools/dtd2xsd" library="dtd2xsd-net_4_x">
@@ -4298,6 +4727,7 @@
       <library_output>./../../class/lib/net_4_x/dtd2xsd.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>dtd2xsd.exe.sources</response>
     </project>
     <project dir="tools/mdoc" library="mdoc-net_4_x">
@@ -4308,6 +4738,7 @@
       <library_output>./../../class/lib/net_4_x/mdoc.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mdoc.exe.sources</response>
     </project>
     <project dir="tools/mod" library="mod-net_4_x">
@@ -4318,6 +4749,7 @@
       <library_output>./../../class/lib/net_4_x/mod.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mod.exe.sources</response>
     </project>
     <project dir="tools/installvst" library="installvst-net_4_x">
@@ -4328,6 +4760,7 @@
       <library_output>./../../class/lib/net_4_x/installvst.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>installvst.exe.sources</response>
     </project>
     <project dir="tools/lc" library="lc-net_4_x">
@@ -4338,6 +4771,7 @@
       <library_output>./../../class/lib/net_4_x/lc.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>lc.exe.sources</response>
     </project>
     <project dir="tools/mono-configuration-crypto/lib" library="Mono.Configuration.Crypto-net_4_x">
@@ -4348,6 +4782,7 @@
       <library_output>./../../../class/lib/net_4_x/Mono.Configuration.Crypto.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>Mono.Configuration.Crypto.dll.sources</response>
     </project>
     <project dir="tools/mono-configuration-crypto/cli" library="mono-configuration-crypto-net_4_x">
@@ -4358,6 +4793,7 @@
       <library_output>./../../../class/lib/net_4_x/mono-configuration-crypto.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-configuration-crypto.exe.sources</response>
     </project>
     <project dir="tools/ccrewrite" library="ccrewrite-net_4_x">
@@ -4368,6 +4804,7 @@
       <library_output>./../../class/lib/net_4_x/ccrewrite.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>ccrewrite.exe.sources</response>
     </project>
     <project dir="tools/cccheck" library="cccheck-net_4_x">
@@ -4378,6 +4815,7 @@
       <library_output>./../../class/lib/net_4_x/cccheck.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>cccheck.exe.sources</response>
     </project>
     <project dir="tools/mdbrebase" library="mdbrebase-net_4_x">
@@ -4388,6 +4826,7 @@
       <library_output>./../../class/lib/net_4_x/mdbrebase.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mdbrebase.exe.sources</response>
     </project>
     <project dir="tools/ikdasm" library="ikdasm-net_4_x">
@@ -4398,6 +4837,7 @@
       <library_output>./../../class/lib/net_4_x/ikdasm.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>ikdasm.exe.sources</response>
     </project>
     <project dir="tools/mono-symbolicate" library="mono-symbolicate-net_4_x">
@@ -4408,6 +4848,7 @@
       <library_output>./../../class/lib/net_4_x/mono-symbolicate.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>mono-symbolicate.exe.sources</response>
     </project>
     <project dir="tools/linker-analyzer" library="linkeranalyzer-net_4_x">
@@ -4418,6 +4859,7 @@
       <library_output>./../../class/lib/net_4_x/linkeranalyzer.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>net_4_x</profile>
+      <resources></resources>
       <response>linkeranalyzer.exe.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Framework" library="Microsoft.Build.Framework-xbuild_12">
@@ -4428,6 +4870,7 @@
       <library_output>./../../class/lib/xbuild_12/Microsoft.Build.Framework.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>Microsoft.Build.Framework.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Framework" library="Microsoft.Build.Framework-tests-xbuild_12">
@@ -4438,6 +4881,7 @@
       <library_output>xbuild_12_Microsoft.Build.Framework_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_12_Microsoft.Build.Framework_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Utilities" library="Microsoft.Build.Utilities-xbuild_12">
@@ -4448,6 +4892,7 @@
       <library_output>./../../class/lib/xbuild_12/Microsoft.Build.Utilities.v12.0.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>Microsoft.Build.Utilities.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Utilities" library="Microsoft.Build.Utilities-tests-xbuild_12">
@@ -4458,6 +4903,7 @@
       <library_output>xbuild_12_Microsoft.Build.Utilities_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_12_Microsoft.Build.Utilities_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Engine" library="Microsoft.Build.Engine-xbuild_12">
@@ -4468,6 +4914,7 @@
       <library_output>./../../class/lib/xbuild_12/Microsoft.Build.Engine.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>Microsoft.Build.Engine.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Engine" library="Microsoft.Build.Engine-tests-xbuild_12">
@@ -4478,6 +4925,7 @@
       <library_output>xbuild_12_Microsoft.Build.Engine_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_12_Microsoft.Build.Engine_test.dll.response</response>
     </project>
     <project dir="class/Mono.XBuild.Tasks" library="Mono.XBuild.Tasks-xbuild_12">
@@ -4488,6 +4936,7 @@
       <library_output>./../../class/lib/xbuild_12/Mono.XBuild.Tasks.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>Mono.XBuild.Tasks.dll.sources</response>
     </project>
     <project dir="class/Mono.XBuild.Tasks" library="Mono.XBuild.Tasks-tests-xbuild_12">
@@ -4498,6 +4947,7 @@
       <library_output>xbuild_12_Mono.XBuild.Tasks_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_12_Mono.XBuild.Tasks_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Tasks" library="Microsoft.Build.Tasks-xbuild_12">
@@ -4508,6 +4958,7 @@
       <library_output>./../../class/lib/xbuild_12/Microsoft.Build.Tasks.v12.0.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>Microsoft.Build.Tasks.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Tasks" library="Microsoft.Build.Tasks-tests-xbuild_12">
@@ -4518,6 +4969,7 @@
       <library_output>xbuild_12_Microsoft.Build.Tasks_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_12_Microsoft.Build.Tasks_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build" library="Microsoft.Build-xbuild_12">
@@ -4528,6 +4980,7 @@
       <library_output>./../../class/lib/xbuild_12/Microsoft.Build.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>Microsoft.Build.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build" library="Microsoft.Build-tests-xbuild_12">
@@ -4538,6 +4991,7 @@
       <library_output>xbuild_12_Microsoft.Build_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_12_Microsoft.Build_test.dll.response</response>
     </project>
     <project dir="tools/xbuild" library="xbuild-xbuild_12">
@@ -4548,6 +5002,7 @@
       <library_output>./../../class/lib/xbuild_12/xbuild.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_12</profile>
+      <resources></resources>
       <response>xbuild.exe.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Framework" library="Microsoft.Build.Framework-xbuild_14">
@@ -4558,6 +5013,7 @@
       <library_output>./../../class/lib/xbuild_14/Microsoft.Build.Framework.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>Microsoft.Build.Framework.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Framework" library="Microsoft.Build.Framework-tests-xbuild_14">
@@ -4568,6 +5024,7 @@
       <library_output>xbuild_14_Microsoft.Build.Framework_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_14_Microsoft.Build.Framework_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Utilities" library="Microsoft.Build.Utilities-xbuild_14">
@@ -4578,6 +5035,7 @@
       <library_output>./../../class/lib/xbuild_14/Microsoft.Build.Utilities.Core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>Microsoft.Build.Utilities.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Utilities" library="Microsoft.Build.Utilities-tests-xbuild_14">
@@ -4588,6 +5046,7 @@
       <library_output>xbuild_14_Microsoft.Build.Utilities_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_14_Microsoft.Build.Utilities_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Engine" library="Microsoft.Build.Engine-xbuild_14">
@@ -4598,6 +5057,7 @@
       <library_output>./../../class/lib/xbuild_14/Microsoft.Build.Engine.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>Microsoft.Build.Engine.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Engine" library="Microsoft.Build.Engine-tests-xbuild_14">
@@ -4608,6 +5068,7 @@
       <library_output>xbuild_14_Microsoft.Build.Engine_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_14_Microsoft.Build.Engine_test.dll.response</response>
     </project>
     <project dir="class/Mono.XBuild.Tasks" library="Mono.XBuild.Tasks-xbuild_14">
@@ -4618,6 +5079,7 @@
       <library_output>./../../class/lib/xbuild_14/Mono.XBuild.Tasks.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>Mono.XBuild.Tasks.dll.sources</response>
     </project>
     <project dir="class/Mono.XBuild.Tasks" library="Mono.XBuild.Tasks-tests-xbuild_14">
@@ -4628,6 +5090,7 @@
       <library_output>xbuild_14_Mono.XBuild.Tasks_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_14_Mono.XBuild.Tasks_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build.Tasks" library="Microsoft.Build.Tasks-xbuild_14">
@@ -4638,6 +5101,7 @@
       <library_output>./../../class/lib/xbuild_14/Microsoft.Build.Tasks.Core.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>Microsoft.Build.Tasks.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build.Tasks" library="Microsoft.Build.Tasks-tests-xbuild_14">
@@ -4648,6 +5112,7 @@
       <library_output>xbuild_14_Microsoft.Build.Tasks_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_14_Microsoft.Build.Tasks_test.dll.response</response>
     </project>
     <project dir="class/Microsoft.Build" library="Microsoft.Build-xbuild_14">
@@ -4658,6 +5123,7 @@
       <library_output>./../../class/lib/xbuild_14/Microsoft.Build.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>Microsoft.Build.dll.sources</response>
     </project>
     <project dir="class/Microsoft.Build" library="Microsoft.Build-tests-xbuild_14">
@@ -4668,6 +5134,7 @@
       <library_output>xbuild_14_Microsoft.Build_test.dll</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>./../../build/deps/xbuild_14_Microsoft.Build_test.dll.response</response>
     </project>
     <project dir="tools/xbuild" library="xbuild-xbuild_14">
@@ -4678,6 +5145,7 @@
       <library_output>./../../class/lib/xbuild_14/xbuild.exe</library_output>
       <fx_version>4.5</fx_version>
       <profile>xbuild_14</profile>
+      <resources></resources>
       <response>xbuild.exe.sources</response>
     </project>
 </root>

--- a/net_4_x.sln
+++ b/net_4_x.sln
@@ -23,9 +23,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Security-net_4_x", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Core-net_4_x", "mcs/class/System.Core/System.Core-net_4_x.csproj", "{359142A1-D80F-401E-AA64-7167C9317649}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.CompilerServices.SymbolWriter-net_4_x", "mcs/class/Mono.CompilerServices.SymbolWriter/Mono.CompilerServices.SymbolWriter-net_4_x.csproj", "{88177C4B-894F-485D-B95A-44199C06BE9F}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Posix-net_4_x", "mcs/class/Mono.Posix/Mono.Posix-net_4_x.csproj", "{66DBB049-785B-4C2E-9EF6-C9E163F7DDD1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.CompilerServices.SymbolWriter-net_4_x", "mcs/class/Mono.CompilerServices.SymbolWriter/Mono.CompilerServices.SymbolWriter-net_4_x.csproj", "{88177C4B-894F-485D-B95A-44199C06BE9F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Core-plaincore-net_4_x", "mcs/class/System.Core/System.Core-plaincore-net_4_x.csproj", "{1EC0EBC0-0B35-454C-89AE-3F8F0FDD9705}"
 EndProject
@@ -725,14 +725,14 @@ Global
 		{359142A1-D80F-401E-AA64-7167C9317649}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{359142A1-D80F-401E-AA64-7167C9317649}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{359142A1-D80F-401E-AA64-7167C9317649}.Release|Any CPU.Build.0 = Release|Any CPU
-		{88177C4B-894F-485D-B95A-44199C06BE9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{88177C4B-894F-485D-B95A-44199C06BE9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{88177C4B-894F-485D-B95A-44199C06BE9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{88177C4B-894F-485D-B95A-44199C06BE9F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{66DBB049-785B-4C2E-9EF6-C9E163F7DDD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{66DBB049-785B-4C2E-9EF6-C9E163F7DDD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66DBB049-785B-4C2E-9EF6-C9E163F7DDD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66DBB049-785B-4C2E-9EF6-C9E163F7DDD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88177C4B-894F-485D-B95A-44199C06BE9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88177C4B-894F-485D-B95A-44199C06BE9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88177C4B-894F-485D-B95A-44199C06BE9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88177C4B-894F-485D-B95A-44199C06BE9F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1EC0EBC0-0B35-454C-89AE-3F8F0FDD9705}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1EC0EBC0-0B35-454C-89AE-3F8F0FDD9705}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EC0EBC0-0B35-454C-89AE-3F8F0FDD9705}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Previously, every assembly that needed resources had to manually add
targets to convert the resource files from a text file, or a resx file
into a .resources file.   Then it had to manually list the file as a
clean target, and had to list it as a set of extra command line options
to the compiler.

This was error prone, but most importantly, did not allow me to get
rich information about how a resource was actually created.  This means
that this valuable information was lost, and we could not pass this
data to the project generator.

So the project generator relied on "pre-processing" hooks to manually
create the resources that were required at build time, as opposed to
using the built-in capability of msbuild to turn a source file with
resource information into a compiled resource file.

With this change, .resource files that are produced from either a
.txt or a .resx file are declared on the Makefile like this:

     RESOURCE_DEFS = ID1,FILE1 ID2,FILE2

The makefile infrastructure will now take care of producing the resources
without having to manually specify either the rule, the EXTRA_DIST
or the CLEAN_FILES.

The genproj system now uses this information to produce resource
requirements without the ".pre" hack that we used before to run
resgen or copy before the build started.