### PR TITLE
SGen: Fix parsing of default-allowance-ratio

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -2919,7 +2919,7 @@ sgen_gc_init (void)
 				double val;
 				opt = strchr (opt, '=') + 1;
 				if (parse_double_in_interval (MONO_GC_PARAMS_NAME, "default-allowance-ratio", opt,
-						SGEN_MIN_ALLOWANCE_NURSERY_SIZE_RATIO, SGEN_MIN_ALLOWANCE_NURSERY_SIZE_RATIO, &val)) {
+						SGEN_MIN_ALLOWANCE_NURSERY_SIZE_RATIO, SGEN_MAX_ALLOWANCE_NURSERY_SIZE_RATIO, &val)) {
 					allowance_ratio = val;
 				}
 				continue;


### PR DESCRIPTION
Parsing ```default-allowance-ratio``` in ```MONO_GC_PARAMS``` is completely broken and accepts only one value - 1.0, while it should accept range of 1.0-10.0. We can clearly notice that when setting ```default-allowance-ratio``` to e.g. ```2.0``` and trying to run any program through Mono runtime:

```
Warning: In environment variable `MONO_GC_PARAMS': `default-allowance-ratio` must be between 1.00 - 1.00. - Using default value.
```

Therefore, correct this for using proper 1.0-10.0 range.