### PR TITLE
Use the MSVC built libtest.dll when running the P/Invoke tests in mono/tests/ on Windows

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -23,9 +23,9 @@ JITTEST_PROG_RUN = MONO_CFG_DIR=$(mono_build_root)/runtime/etc $(LIBTOOL) --mode
 RUNTIME_ARGS=--config tests-config --optimize=all --debug
 
 if HOST_WIN32
-TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),mono)
+TEST_RUNNER_ARGS=--config tests-config --runtime $(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),mono)
 else
-TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),mono)
+TEST_RUNNER_ARGS=--config tests-config --runtime $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),mono)
 endif
 
 CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)

--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -50,6 +50,7 @@ public class TestRunner
 
 		string disabled_tests = null;
 		string runtime = "mono";
+		string config = null;
 		var opt_sets = new List<string> ();
 
 		// Process options
@@ -86,6 +87,13 @@ public class TestRunner
 						return 1;
 					}
 					runtime = args [i + 1];
+					i += 2;
+				} else if (args [i] == "--config") {
+					if (i + 1 >= args.Length) {
+						Console.WriteLine ("Missing argument to --config command line option.");
+						return 1;
+					}
+					config = args [i + 1];
 					i += 2;
 				} else if (args [i] == "--opt-sets") {
 					if (i + 1 >= args.Length) {
@@ -207,6 +215,8 @@ public class TestRunner
 					info.RedirectStandardOutput = true;
 					info.RedirectStandardError = true;
 					info.EnvironmentVariables[ENV_TIMEOUT] = timeout.ToString();
+					if (config != null)
+						info.EnvironmentVariables["MONO_CONFIG"] = config;
 					Process p = new Process ();
 					p.StartInfo = info;
 

--- a/mono/tests/tests-config.in
+++ b/mono/tests/tests-config.in
@@ -1,5 +1,7 @@
 <configuration>
 	<dllmap dll="cygwin1.dll" target="@LIBC@" />
 	<dllmap dll="libc" target="@LIBC@" />
+	<dllmap os="windows" cpu="x86" dll="libtest" target="../../msvc/Win32/bin/Release/libtest.dll" />
+	<dllmap os="windows" cpu="x86-64" dll="libtest" target="../../msvc/x64/bin/Release/libtest.dll" />
 </configuration>
 


### PR DESCRIPTION
Updates the `tests-config.in` file with Windows specific `<dllmap>` elements that map 'libtest' to the MSVC built `libtest.dll` for the current architecture. `test-runner.cs` has been modified to accept a `--config` option to be able to use a specific config file. `Makefile.am` now configures `test-runner.exe` to use the `tests-config` config file when running the tests.