### PR TITLE
[runtime] Make external executables use full path

### DIFF
--- a/mcs/build/platforms/darwin.make
+++ b/mcs/build/platforms/darwin.make
@@ -9,9 +9,9 @@ PLATFORM_RUNTIME = $(RUNTIME)
 PLATFORM_CORLIB = mscorlib.dll
 PLATFORM_TEST_HARNESS_EXCLUDES = NotOnMac,
 
-EXTERNAL_MCS = mcs
-EXTERNAL_MBAS = mbas
-EXTERNAL_RUNTIME = mono
+EXTERNAL_MCS := $(shell which mcs)
+EXTERNAL_MBAS := $(shell which mbas)
+EXTERNAL_RUNTIME := $(shell which mono)
 #ILDISASM = monodis
 ILDISASM = false
 

--- a/mcs/build/platforms/linux.make
+++ b/mcs/build/platforms/linux.make
@@ -9,9 +9,9 @@ PLATFORM_RUNTIME = $(RUNTIME)
 PLATFORM_CORLIB = mscorlib.dll
 PLATFORM_TEST_HARNESS_EXCLUDES =
 
-EXTERNAL_MCS = mcs
-EXTERNAL_MBAS = mbas
-EXTERNAL_RUNTIME = mono
+EXTERNAL_MCS := $(shell which mcs)
+EXTERNAL_MBAS := $(shell which mbas)
+EXTERNAL_RUNTIME := $(shell which mono)
 #ILDISASM = monodis
 ILDISASM = false
 


### PR DESCRIPTION
The issue of using the name "mono" without an absolute path
means that if the PATH is changed during scripted runs,
one can end up using the wrong mono.
