### PR TITLE
[runtime] Fix stacktrace creation on llvmonly backend

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -373,11 +373,10 @@ static gboolean show_native_addresses = TRUE;
 static gboolean show_native_addresses = FALSE;
 #endif
 
-static _Unwind_Reason_Code
-build_stack_trace (struct _Unwind_Context *frame_ctx, void *state)
+static gboolean
+add_ptr_to_stack_trace (uintptr_t ip)
 {
 	MonoDomain *domain = mono_domain_get ();
-	uintptr_t ip = _Unwind_GetIP (frame_ctx);
 
 	gboolean add_ptr = FALSE;
 	if (show_native_addresses) {
@@ -388,6 +387,29 @@ build_stack_trace (struct _Unwind_Context *frame_ctx, void *state)
 			add_ptr = TRUE;
 	}
 
+	return add_ptr;
+}
+
+static _Unwind_Reason_Code
+count_frames (struct _Unwind_Context *frame_ctx, void *state)
+{
+	uintptr_t ip = _Unwind_GetIP (frame_ctx);
+	gboolean add_ptr = add_ptr_to_stack_trace (ip);
+
+	if (add_ptr) {
+		size_t *frame_size = (size_t *)state;
+		*frame_size = *frame_size + 1;
+	}
+
+	return _URC_NO_REASON;
+}
+
+static _Unwind_Reason_Code
+build_stack_trace (struct _Unwind_Context *frame_ctx, void *state)
+{
+	uintptr_t ip = _Unwind_GetIP (frame_ctx);
+	gboolean add_ptr = add_ptr_to_stack_trace (ip);
+ 
 	if (add_ptr) {
 		GList **trace_ips = (GList **)state;
 		*trace_ips = g_list_prepend (*trace_ips, (gpointer)ip);
@@ -395,6 +417,9 @@ build_stack_trace (struct _Unwind_Context *frame_ctx, void *state)
 
 	return _URC_NO_REASON;
 }
+
+
+
 
 static GSList*
 get_unwind_backtrace (void)
@@ -3688,23 +3713,9 @@ throw_exception (MonoObject *ex, gboolean rethrow)
 
 	if (!rethrow) {
 #ifdef MONO_ARCH_HAVE_UNWIND_BACKTRACE
-		GList *l, *ips = NULL;
-		GList *trace;
-
-		_Unwind_Backtrace (build_stack_trace, &ips);
-		/* The list contains ip-gshared info pairs */
-		trace = NULL;
-		ips = g_list_reverse (ips);
-		for (l = ips; l; l = l->next) {
-			trace = g_list_append (trace, l->data);
-			trace = g_list_append (trace, NULL);
-			trace = g_list_append (trace, NULL);
-		}
-		MonoArray *ips_arr = mono_glist_to_array (trace, mono_defaults.int_class, error);
-		mono_error_assert_ok (error);
-		MONO_OBJECT_SETREF_INTERNAL (mono_ex, trace_ips, ips_arr);
-		g_list_free (l);
-		g_list_free (trace);
+		GList *trace = NULL;
+		_Unwind_Backtrace (build_stack_trace, &trace);
+		jit_tls->trace_ips = trace;
 #endif
 	}
 
@@ -3881,6 +3892,53 @@ mono_llvm_match_exception (MonoJitInfo *jinfo, guint32 region_start, guint32 reg
 			g_assert_not_reached ();
 		}
 	}
+
+ // If no trace_ips, then a rethrow
+	if (index != -1 && ((MonoException *)exc)->trace_ips == NULL) {
+#ifdef MONO_ARCH_HAVE_UNWIND_BACKTRACE
+		// Find the number of frames above us
+		size_t count = 0;
+		_Unwind_Backtrace (count_frames, &count);
+
+		GList *forward = jit_tls->trace_ips;
+
+		// Skip the frames above us
+		for (size_t i = 1; i < count; i++)
+			forward = forward->next;
+
+		g_assert (forward != NULL);
+
+		// Build stacktrace backwards, move cursor to end
+		GList *backward = forward;
+		int size = 1;
+		while(backward->next) {
+			backward = backward->next;
+			size++;
+		}
+		/* The list contains ip-gshared info pairs */
+		size = size * 2;
+
+		ERROR_DECL (error);
+		error_init (error);
+		MonoArray *trace_arr = mono_array_new_checked (mono_domain_get (), mono_defaults.int_class, size, error);
+		mono_error_assert_ok (error);
+
+		for(int index = 0; index < size; index += 2, backward = backward->prev) {
+			g_assert(backward != NULL);
+
+			/* The list contains ip-gshared info pairs */
+			mono_array_set_internal (trace_arr, gpointer, index, backward->data);
+			mono_array_set_internal (trace_arr, gpointer, index + 1, NULL);
+		}
+
+		g_list_free (jit_tls->trace_ips);
+		jit_tls->trace_ips = NULL;
+
+		MONO_OBJECT_SETREF_INTERNAL ((MonoException *)exc, trace_ips, trace_arr);
+		mono_memory_barrier ();
+#endif
+	}
+
 
 	return index;
 }

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -379,7 +379,16 @@ build_stack_trace (struct _Unwind_Context *frame_ctx, void *state)
 	MonoDomain *domain = mono_domain_get ();
 	uintptr_t ip = _Unwind_GetIP (frame_ctx);
 
-	if (show_native_addresses || mono_jit_info_table_find (domain, (char*)ip)) {
+	gboolean add_ptr = FALSE;
+	if (show_native_addresses) {
+		add_ptr = TRUE;
+	} else {
+		MonoJitInfo *found = mono_jit_info_table_find (domain, (char*)ip);
+		if (found && found->d.method->wrapper_type == MONO_WRAPPER_NONE)
+			add_ptr = TRUE;
+	}
+
+	if (add_ptr) {
 		GList **trace_ips = (GList **)state;
 		*trace_ips = g_list_prepend (*trace_ips, (gpointer)ip);
 	}

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -123,6 +123,13 @@ struct MonoJitTlsData {
 	 */
 	guint32 thrown_non_exc;
 
+	/* 
+	 * A temporary reference to the ips for the whole
+	 * stack t			race when thrown. These are truncated when the
+	 * exception is final	ly caught. 
+	 */
+	GList *trace_ips;
+
 	/*
 	 * The calling assembly in llvmonly mode.
 	 */


### PR DESCRIPTION
This got corlib exception tests passing. 

Without this test, the bitcode backend will make the stacktrace of an exception object into the stacktrace of the site where it is thrown. 

This does not follow the normal .NET semantics. In .NET, catching an exception causes the stacktrace to be truncated. Only the frames that lie between where the exception was thrown and where it was caught are supposed to end up in the stacktrace.

I do this here by making a system that determines the number of managed frames above the current method (https://github.com/mono/mono/pull/3166/files#diff-39d30c5616c9c238bfca3c7abd6df526R394). This is used to find the number of frames above the place where the exception is caught, and to remove that number of frames from above the caught frame in the stacktrace (https://github.com/mono/mono/pull/3166/files#diff-39d30c5616c9c238bfca3c7abd6df526R3899). 

The other change lumped in here that is implicit in count_frames and build_stack_trace is that we now filter the wrapper frames out of the stack when it's created. This is to be expected, managed stacktraces shouldn't show a lot of m2n and n2m calls between the managed frames. 

The tests that this was written to fix (corlib's ExceptionTest) should be able to spot regressions or failures if this breaks in the future. 