### PR TITLE
[coop] Fix regression in bug-70561.cs

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4775,13 +4775,7 @@ do_exec_main_checked (MonoMethod *method, MonoArray *args, MonoError *error)
 		if (is_ok (error))
 			rval = 0;
 		else {
-			/* If the return type of Main is void, only
-			 * set the exitcode if an exception was thrown
-			 * (we don't want to blow away an
-			 * explicitly-set exit code)
-			 */
 			rval = -1;
-			mono_environment_exitcode_set (rval);
 		}
 	}
 	return rval;


### PR DESCRIPTION
Match behavior of non-coop and don't set an exit code if the main method
throws an unhandled exception.