### PR TITLE
Revert "[runtime] Fix jay path in Microsoft.Build"

### DIFF
--- a/mcs/class/Microsoft.Build/Makefile
+++ b/mcs/class/Microsoft.Build/Makefile
@@ -24,7 +24,7 @@ EXTRA_DISTFILES = \
 EXPR_PARSER = Microsoft.Build.Internal/ExpressionParser
 
 $(EXPR_PARSER).cs: $(EXPR_PARSER).jay $(topdir)/jay/skeleton.cs
-	(cd Microsoft.Build.Internal; $(topdir)/jay/jay -ctv < $(topdir)/jay/skeleton.cs ExpressionParser.jay > ExpressionParser.cs)
+	(cd Microsoft.Build.Internal; $(topdir)/../jay/jay -ctv < $(topdir)/../jay/skeleton.cs ExpressionParser.jay > ExpressionParser.cs)
 
 BUILT_SOURCES = $(EXPR_PARSER).cs
 


### PR DESCRIPTION
This reverts commit 6780bb169cc3e2fb96b951607a4027416171698b.

The topdir is relative on master. This fixed a breakage caused by making it absolute. Reverting this for now to fix build.