### PR TITLE
Update to tests config file reflecting changed libtest module location on Windows.

### DIFF
--- a/mono/tests/tests-config.in
+++ b/mono/tests/tests-config.in
@@ -1,7 +1,7 @@
 <configuration>
 	<dllmap dll="cygwin1.dll" target="@LIBC@" />
 	<dllmap dll="libc" target="@LIBC@" />
-	<dllmap os="windows" cpu="x86" dll="libtest" target="../../msvc/Win32/bin/Release/libtest.dll" />
-	<dllmap os="windows" cpu="x86-64" dll="libtest" target="../../msvc/x64/bin/Release/libtest.dll" />
+	<dllmap os="windows" cpu="x86" dll="libtest" target="../../msvc/build/sgen/Win32/bin/Release/libtest.dll" />
+	<dllmap os="windows" cpu="x86-64" dll="libtest" target="../../msvc/build/sgen/x64/bin/Release/libtest.dll" />
 </configuration>
 


### PR DESCRIPTION
Updated Visual Studio build uses a different default build location of modules
compared to previous version. The tests config file includes a relative
path to libtest used by all pinvoke tests. Since the module is now
placed at a different location the load failed during the test.

The fix updates the location of the module matching new default build folder.