### PR TITLE
[System.Web] Fixes 50 year form authentication

### DIFF
--- a/mcs/class/System.Web/System.Web.Security/FormsAuthentication.cs
+++ b/mcs/class/System.Web/System.Web.Security/FormsAuthentication.cs
@@ -212,21 +212,18 @@ namespace System.Web.Security
 				strCookiePath = cookiePath;
 
 			DateTime now = DateTime.Now;
-			DateTime then;
-	            	if (createPersistentCookie)
-	                	then = now.AddMinutes(timeout);
-	            	else
-	                	then = DateTime.MinValue;
+			DateTime ticketExpiry = now.AddMinutes(timeout);
+	            	DateTime cookieExpiry = createPersistentCookie ? ticketExpiry : DateTime.MinValue;
 
 			FormsAuthenticationTicket ticket = new FormsAuthenticationTicket (1,
 											  userName,
 											  now,
-                                              createPersistentCookie?then:now.AddYears (50),
+											  ticketExpiry,
 											  createPersistentCookie,
 											  String.Empty,
 											  cookiePath);
 
-			HttpCookie cookie = new HttpCookie (cookieName, Encrypt (ticket), strCookiePath, then);
+			HttpCookie cookie = new HttpCookie (cookieName, Encrypt (ticket), strCookiePath, cookieExpiry);
 			if (requireSSL)
 				cookie.Secure = true;
 			if (!String.IsNullOrEmpty (cookie_domain))


### PR DESCRIPTION
This fixes the bug where form authentication tickets do not expire until 50 years later.
I bumped into this bug after upgrading mono from 4.2.2 to 4.4.0

Firstly, the authentication ticket's expiry must always equal to the timeout attribute on the <forms/> element. It doesn't matter whether persistent or session cookies are used. 

Secondly, if the cookie is persistent, then it's expiry should be set to the same as that of the authentication ticket.

Reference: https://blogs.msdn.microsoft.com/dansellers/2006/02/15/change-to-asp-net-2-0-forms-authentication-persistent-cookies/