### PR TITLE
[reflection] Properties always use name and signature hidding rules. …

### DIFF
--- a/mcs/class/System.Web/System.Web.UI.WebControls/WebControl.cs
+++ b/mcs/class/System.Web/System.Web.UI.WebControls/WebControl.cs
@@ -284,7 +284,7 @@ namespace System.Web.UI.WebControls {
 		}
 
 		[Browsable (true)]
-		public virtual new string SkinID
+		public override string SkinID
 		{
 			get { return base.SkinID; }
 			set { base.SkinID = value; }

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -456,6 +456,51 @@ namespace MonoTests.System
 
 		}
 
+		class GetProperties_Overrides_Input
+		{
+			public class TestClass : BaseClass<object>
+			{
+				public override object TestProperty { get; set; }
+			}
+
+			public abstract class BaseClass<T>
+			{
+				public virtual T TestProperty { get; set; }
+			}
+
+			public class TestClass_Indexer : BaseClass_Indexer<object>
+			{
+				public override object this[int arg] { set { } }
+			}
+
+			public abstract class BaseClass_Indexer<T>
+			{
+				public virtual T this[int arg] { set { } }
+			}
+
+			public interface IB : IA<object>
+			{
+				new object TestProperty { get; set; }
+			}
+
+			public interface IA<T>
+			{
+				T TestProperty { get; set; }
+			}
+		}
+
+		[Test]
+		public void GetProperties_Overrides ()
+		{
+			Assert.AreEqual (1, typeof (GetProperties_Overrides_Input.IB).GetProperties().Length);
+
+			var prop = typeof (GetProperties_Overrides_Input.TestClass).GetProperty ("TestProperty");
+			Assert.AreEqual (typeof (GetProperties_Overrides_Input.TestClass), prop.DeclaringType);
+
+			Assert.AreEqual (1, typeof (GetProperties_Overrides_Input.TestClass).GetProperties().Length);
+			Assert.AreEqual (1, typeof (GetProperties_Overrides_Input.TestClass_Indexer).GetProperties().Length);
+	    }
+
 		[Test] // GetProperties (BindingFlags)
 		public void GetProperties_Flags ()
 		{


### PR DESCRIPTION
…Fixes #41874