### PR TITLE
Bump mono version from 4.4.0 to 4.4.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 #AC_PREREQ([2.62])
 
-AC_INIT(mono, [4.4.0],
+AC_INIT(mono, [4.4.1],
         [http://bugzilla.xamarin.com/enter_bug.cgi?classification=Mono])
 
 AC_CONFIG_SRCDIR([README.md])

--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -41,9 +41,9 @@ targets, and the "--cross" argument to specify the target, like this:
 	$ mkbundle --local-targets	
 	Available targets:
 		default	- Current System Mono
-		4.4.0-macosx-x86
-		4.4.0-debian-8-arm64
-	$ mkbundle --cross 4.4.0-debian-8-arm64 hello.exe -o hello-debian
+		4.4.1-macosx-x86
+		4.4.1-debian-8-arm64
+	$ mkbundle --cross 4.4.1-debian-8-arm64 hello.exe -o hello-debian
 .fi
 .PP
 The above will bundle your native library into hello-debian for


### PR DESCRIPTION
Doing this as a PR so @alexischr can briefly review.