### PR TITLE
[System.IO.Compression] Fixed stream length/position getters for ZIP entries

### DIFF
--- a/mcs/class/System.IO.Compression/SharpCompress/IO/ReadOnlySubStream.cs
+++ b/mcs/class/System.IO.Compression/SharpCompress/IO/ReadOnlySubStream.cs
@@ -16,6 +16,7 @@ namespace SharpCompress.IO
             {
                 stream.Position = origin.Value;
             }
+            length = bytesToRead;
             BytesLeftToRead = bytesToRead;
         }
 
@@ -26,6 +27,8 @@ namespace SharpCompress.IO
                 //Stream.Dispose();
             }
         }
+
+        private long length;
 
         private long BytesLeftToRead { get; set; }
 
@@ -53,12 +56,12 @@ namespace SharpCompress.IO
 
         public override long Length
         {
-            get { throw new System.NotImplementedException(); }
+            get { return length; }
         }
 
         public override long Position
         {
-            get { throw new System.NotImplementedException(); }
+            get { return Length - BytesLeftToRead; }
             set { throw new System.NotImplementedException(); }
         }
 

--- a/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
+++ b/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
@@ -276,6 +276,21 @@ namespace MonoTests.System.IO.Compression
 		}
 
 		[Test]
+		public void ZipGetArchiveEntryStreamLengthPositionReadMode()
+		{
+			using (var archive = new ZipArchive(File.Open("test.nupkg", FileMode.Open),
+				ZipArchiveMode.Read))
+			{
+				var entry = archive.GetEntry("_rels/.rels");
+				using (var stream = entry.Open())
+				{
+					Assert.AreEqual(0, stream.Position);
+					Assert.AreEqual(425, stream.Length);
+				}
+			}
+		}
+
+		[Test]
 		public void ZipEnumerateEntriesReadMode()
 		{
 			File.Copy("archive.zip", "test.zip", overwrite: true);


### PR DESCRIPTION
We still have another bug related to streams in Update mode which still needs some work and will come in a separate PR.

Partial fix for https://bugzilla.xamarin.com/show_bug.cgi?id=39282.

Fix for https://github.com/OfficeDev/Open-XML-SDK/issues/64.