### PR TITLE
[exception] retain stack trace when an exception is rethrown

### DIFF
--- a/mono/tests/exception18.cs
+++ b/mono/tests/exception18.cs
@@ -51,27 +51,51 @@ class C
 		}
 
 		try {
-			new C ().M1 ();
+			new C ().M1a ();
 		} catch (Exception ex) {
 			int frames = FrameCount (ex);
 			if (frames != 4)
 				throw new Exception (String.Format("Exception carried {0} frames along with it when it should have reported four.", frames));
 		}
+
+		try {
+			new C ().M1b ();
+		} catch (Exception ex) {
+			int frames = FrameCount (ex);
+			if (frames != 3)
+				throw new Exception (String.Format("Exception carried {0} frames along with it when it should have reported three.", frames));
+		}
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
-	private void M1 ()
+	private void M1a ()
 	{
-		M2 ();
+		M2a ();
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
-	private void M2 ()
+	private void M1b ()
+	{
+		M2b ();
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void M2a ()
 	{
 		try {
 			M3 ();
 		} catch {
 			throw;
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void M2b ()
+	{
+		try {
+			M3 ();
+		} catch (Exception ex) {
+			throw ex;
 		}
 	}
 

--- a/mono/tests/exception18.cs
+++ b/mono/tests/exception18.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 class C
 {
@@ -49,5 +50,34 @@ class C
 				throw new Exception (String.Format("Exception carried {0} frames along with it when it should have reported four.", frames));
 		}
 
+		try {
+			new C ().M1 ();
+		} catch (Exception ex) {
+			int frames = FrameCount (ex);
+			if (frames != 4)
+				throw new Exception (String.Format("Exception carried {0} frames along with it when it should have reported four.", frames));
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void M1 ()
+	{
+		M2 ();
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void M2 ()
+	{
+		try {
+			M3 ();
+		} catch {
+			throw;
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void M3 ()
+	{
+		throw new NotImplementedException ();
 	}
 }


### PR DESCRIPTION
Someone reported on the mailing list that mono cuts off the stack trace at the point where an exception is rethrown (that is, `CEE_RETHROW`).

This is supported by the behavior on .NET and https://msdn.microsoft.com/en-us/library/ms182363.aspx :

> To keep the original stack trace information with the exception, use the throw statement without specifying the exception.

@vargaz: can I have a review on this please? :)
