### PR TITLE
fixed the bug that was preventing HttpWebRequest to go through digest authentication 

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -1691,7 +1691,7 @@ namespace System.Net
 				code = webResponse.StatusCode;
 				if ((!auth_state.IsCompleted && code == HttpStatusCode.Unauthorized && credentials != null) ||
 					(ProxyQuery && !proxy_auth_state.IsCompleted && code == HttpStatusCode.ProxyAuthenticationRequired)) {
-					if (!usedPreAuth && CheckAuthorization (webResponse, code)) {
+					if (CheckAuthorization (webResponse, code)) {
 						// Keep the written body, so it can be rewritten in the retry
 						if (MethodWithBuffer) {
 							if (AllowWriteStreamBuffering) {


### PR DESCRIPTION
Fixed the bug that was preventing HttpWebRequest to go through digest authentication if authentication type wasn't specified. 
I have attached code example with comments that can reproduce problem under mono.
[Program.zip](https://github.com/mono/mono/files/329940/Program.zip)
