### PR TITLE
[System.IO.Compression] Fixed stream writes when Zip archive is opened in Update mode

### DIFF
--- a/mcs/class/System.IO.Compression/SharpCompress/Archive/Zip/ZipArchiveEntry.cs
+++ b/mcs/class/System.IO.Compression/SharpCompress/Archive/Zip/ZipArchiveEntry.cs
@@ -32,5 +32,10 @@ namespace SharpCompress.Archive.Zip
         {
             get { return (Parts.Single() as SeekableZipFilePart).Comment; }
         }
+
+        public override string ToString()
+        {
+            return this.Key;
+        }
     }
 }

--- a/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
+++ b/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
@@ -311,6 +311,70 @@ namespace MonoTests.System.IO.Compression
 		}
 
 		[Test]
+		public void ZipWriteEntriesUpdateMode()
+		{
+			File.Copy("archive.zip", "test.zip", overwrite: true);
+			using (var archive = new ZipArchive(File.Open("test.zip", FileMode.Open),
+				ZipArchiveMode.Update))
+			{
+				var foo = archive.GetEntry("foo.txt");
+				using (var stream = foo.Open())
+				using (var sw = new StreamWriter(stream))
+				{
+					sw.Write("TEST");
+				}
+			}
+
+			using (var archive = new ZipArchive(File.Open("test.zip", FileMode.Open),
+				ZipArchiveMode.Read))
+			{
+				var foo = archive.GetEntry("foo.txt");
+				using (var stream = foo.Open())
+				using (var sr = new StreamReader(stream))
+				{
+					var line = sr.ReadLine();
+					Assert.AreEqual("TEST", line);
+				}
+			}
+
+			File.Delete ("test.zip");
+		}
+
+		[Test]
+		public void ZipWriteEntriesUpdateModeNonZeroPosition()
+		{
+			File.Copy("archive.zip", "test.zip", overwrite: true);
+			using (var archive = new ZipArchive(File.Open("test.zip", FileMode.Open),
+				ZipArchiveMode.Update))
+			{
+				var foo = archive.GetEntry("foo.txt");
+				using (var stream = foo.Open())
+				{
+					var line = stream.ReadByte();
+					using (var sw = new StreamWriter(stream))
+					{
+						sw.Write("TEST");
+					}
+				}
+			}
+
+			using (var archive = new ZipArchive(File.Open("test.zip", FileMode.Open),
+				ZipArchiveMode.Read))
+			{
+				var entries = archive.Entries;
+				var foo = archive.GetEntry("foo.txt");
+				using (var stream = foo.Open())
+				using (var sr = new StreamReader(stream))
+				{
+					var line = sr.ReadLine();
+					Assert.AreEqual("fTEST", line);
+				}
+			}
+
+			File.Delete ("test.zip");
+		}
+
+		[Test]
 		public void ZipEnumerateEntriesUpdateMode()
 		{
 			File.Copy("archive.zip", "test.zip", overwrite: true);

--- a/mcs/class/System.IO.Compression/ZipArchive.cs
+++ b/mcs/class/System.IO.Compression/ZipArchive.cs
@@ -161,6 +161,14 @@ namespace System.IO.Compression
 			return CreateEntry(entryName, CompressionLevel.Optimal);
 		}
 
+		internal SharpCompress.Archive.Zip.ZipArchiveEntry CreateEntryInternal(string entryName)
+		{
+			var memoryStream = new MemoryStream();
+			var entry = zipFile.AddEntry(entryName, memoryStream);
+
+			return entry;
+		}
+
 		public ZipArchiveEntry CreateEntry (string entryName, CompressionLevel compressionLevel)
 		{
 			if (disposed)
@@ -178,9 +186,8 @@ namespace System.IO.Compression
 			if (zipFile == null)
 				throw new InvalidDataException("The zip archive is corrupt, and its entries cannot be retrieved.");
 
-			var memoryStream = new MemoryStream();
-			var entry = zipFile.AddEntry(entryName, memoryStream);
-			var archiveEntry = new ZipArchiveEntry(this, entry);
+			var internalEntry = CreateEntryInternal(entryName);
+			var archiveEntry = new ZipArchiveEntry(this, internalEntry);
 			entries[entryName] = archiveEntry;
 
 			return archiveEntry;

--- a/mcs/class/System.IO.Compression/ZipArchiveEntry.cs
+++ b/mcs/class/System.IO.Compression/ZipArchiveEntry.cs
@@ -32,7 +32,7 @@ namespace System.IO.Compression
 	internal class ZipArchiveEntryStream : Stream, IDisposable
 	{
 		private readonly ZipArchiveEntry entry;
-		private readonly Stream stream;
+		private Stream stream;
 
 		public override bool CanRead {
 			get { 
@@ -42,13 +42,13 @@ namespace System.IO.Compression
 
 		public override bool CanSeek {
 			get {
-				return stream.CanSeek;
+				return entry.Archive.Mode != ZipArchiveMode.Read;
 			}
 		}
 
 		public override bool CanWrite {
 			get {
-				return stream.CanWrite;
+				return entry.Archive.Mode != ZipArchiveMode.Read;
 			}
 		}
 
@@ -95,7 +95,37 @@ namespace System.IO.Compression
 
 		public override void Write (byte[] buffer, int offset, int count)
 		{
+			if (entry.Archive.Mode == ZipArchiveMode.Update && !entry.wasWritten)
+			{
+				// Replace the read-only stream with a writeable memory stream.
+				SetWriteable();
+				entry.wasWritten = true;
+			}
+
 			stream.Write(buffer, offset, count);
+		}
+
+		internal void SetWriteable()
+		{
+			var archive = entry.Archive;
+
+			var internalEntry = entry.entry;
+			var newEntry = archive.CreateEntryInternal(internalEntry.Key);
+			var newStream = newEntry.OpenEntryStream();
+
+			var openStream = stream;
+			var position = openStream.Position;
+
+			entry.openStream = null;
+			entry.Open();
+
+			openStream.CopyTo(newStream);
+			newStream.Position = position;
+			openStream.Dispose();
+
+			archive.zipFile.RemoveEntry(internalEntry);
+			entry.entry = newEntry;
+			stream = newStream;
 		}
 
 		public new void Dispose()
@@ -117,8 +147,9 @@ namespace System.IO.Compression
 
 	public class ZipArchiveEntry
 	{
-		readonly SharpCompress.Archive.Zip.ZipArchiveEntry entry;
+		internal SharpCompress.Archive.Zip.ZipArchiveEntry entry;
 		internal ZipArchiveEntryStream openStream;
+        internal bool wasWritten;
 		private bool wasDeleted;
 
 		internal ZipArchiveEntry(ZipArchive	archive, SharpCompress.Archive.Zip.ZipArchiveEntry entry)
@@ -174,7 +205,7 @@ namespace System.IO.Compression
 			if (Archive.disposed)
 				throw new ObjectDisposedException("The zip archive for this entry has been disposed.");
 
-			if (Archive.Mode !=	ZipArchiveMode.Update)
+			if (Archive.Mode != ZipArchiveMode.Update)
 				throw new NotSupportedException("The zip archive for this entry was opened in a mode other than Update.");
 
 			if (openStream != null)
@@ -198,9 +229,15 @@ namespace System.IO.Compression
 			if (Archive.Mode == ZipArchiveMode.Create && openStream != null)
 				throw new IOException("The archive for this entry was opened with the Create mode, and this entry has already been written to.");
 
-			openStream = new ZipArchiveEntryStream(this, entry.OpenEntryStream());
+			var entryStream = entry.OpenEntryStream();
+			openStream = new ZipArchiveEntryStream(this, entryStream);
 
 			return openStream;
+		}
+
+		public override string ToString()
+		{
+			return FullName;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=39282.

Also helps with https://github.com/OfficeDev/Open-XML-SDK/issues/64.