### PR TITLE
[System] Fixes ConnectAsync UnhandledEx

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -1328,7 +1328,7 @@ namespace System.Net.Sockets
 			if (e.RemoteEndPoint == null)
 				throw new ArgumentNullException ("remoteEP");
 
-			InitSocketAsyncEventArgs (e, ConnectAsyncCallback, e, SocketOperation.Connect);
+			InitSocketAsyncEventArgs (e, null, e, SocketOperation.Connect);
 
 			try {
 				IPAddress [] addresses;

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -15,6 +15,7 @@ using System.Collections;
 using System.Threading;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Net;
 using System.Net.Sockets;
 using NUnit.Framework;
@@ -4344,6 +4345,23 @@ namespace MonoTests.System.Net.Sockets
 				socket.Bind (end_point);
 				socket.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 19);
 			}
+		}
+
+		[Test] // Covers 41616
+		public void ConnectAsyncUnhandledEx ()
+		{
+			var mre = new ManualResetEvent (false);
+
+			var endPoint = new IPEndPoint(0,0);
+			var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Unspecified);
+
+			var socketArgs = new SocketAsyncEventArgs();
+			socketArgs.RemoteEndPoint = endPoint;
+			socketArgs.Completed += (sender, e) => mre.Set ();
+
+			socket.ConnectAsync (socketArgs);
+
+			Assert.IsTrue (mre.WaitOne (1000), "ConnectedAsync timeout");
 		}
  	}
 }


### PR DESCRIPTION
Fixes [#41616](https://bugzilla.xamarin.com/show_bug.cgi?id=41616)

ConnectAsyncCallback now throws an exception when called a second time.
ConnectAsync reuses SocketAsyncEventArgs in BeginConnect which
already updates its state and calls ConnectAsyncCallback.

The changes make sure that ConnectAsyncCallback no longer called on
ConnectAsync catch block, while the state is still updated with the
exception.

Our console runner is currently swallowing this test unhandled exceptions.

To make it test show the failure I had to set legacyUnhandledExceptionPolicy to 0 in mcs/class/lib/net_4_x/nunit-console.exe.config

Then running we can observe the crash by running:
`make -C mcs/class/System check TESTNAME=System.Net.Sockets.SocketTest.ConnectAsyncUnhandledEx`

Other tests appear to crash with legacyUEP set to 0, while the runner
shows no errors.