### PR TITLE
[sgen] Speed up domain finalization at shutdown

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -105,7 +105,7 @@ add_thread_to_finalize (MonoInternalThread *thread, MonoError *error)
 	return is_ok (error);
 }
 
-static gboolean suspend_finalizers = FALSE;
+static volatile gboolean suspend_finalizers = FALSE;
 /* 
  * actually, we might want to queue the finalize requests in a separate thread,
  * but we need to be careful about the execution domain of the thread...

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -724,7 +724,7 @@ finalize_domain_objects (DomainFinalizationReq *req)
 		g_ptr_array_free (objs, TRUE);
 	}
 #elif defined(HAVE_SGEN_GC)
-	while ((count = mono_gc_finalizers_for_domain (domain, to_finalize, NUM_FOBJECTS))) {
+	while (!suspend_finalizers && (count = mono_gc_finalizers_for_domain (domain, to_finalize, NUM_FOBJECTS))) {
 		int i;
 		for (i = 0; i < count; ++i) {
 			mono_gc_run_finalize (to_finalize [i], 0);


### PR DESCRIPTION
When we cleanup the gc at shutdown, we no longer care about running the remaining finalizers so we set the suspend_finalizers flag. This flag skipped running the finalizers but we would still traverse and modify the sgen finalizer hashes (on an arm box this could take even longer than 1s and lead to finalizer_thread_exited assertion failure since it's over the 100ms limit).

Avoid traversing sgen finalization hashes as soon as we see that we are shutting down.