### PR TITLE
fix musl incorrect sigcontext include

### DIFF
--- a/libgc/os_dep.c
+++ b/libgc/os_dep.c
@@ -32,7 +32,7 @@
       /* prototypes, so we have to include the top-level sigcontext.h to    */
       /* make sure the former gets defined to be the latter if appropriate. */
 #     include <features.h>
-#     if 2 <= __GLIBC__
+#     if 2 <= __GLIBC__ || !defined(__GLIBC__)
 #       if 2 == __GLIBC__ && 0 == __GLIBC_MINOR__
 	  /* glibc 2.1 no longer has sigcontext.h.  But signal.h	*/
 	  /* has the right declaration for glibc 2.1.			*/

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -14,7 +14,7 @@
 #include <string.h>
 
 #ifndef MONO_CROSS_COMPILE
-#ifdef HAVE_ASM_SIGCONTEXT_H
+#if defined(HAVE_ASM_SIGCONTEXT_H) && defined(__GLIBC__)
 #include <asm/sigcontext.h>
 #endif  /* def HAVE_ASM_SIGCONTEXT_H */
 #endif


### PR DESCRIPTION
On musl __GLIBC__ is not defined, so the conditional logic will
not produce a correct result. Add a specific cases to handle when
__GLIBC__ is not defined.