### PR TITLE
[System.IO.Compression] Fixed writes to newly-created Zip archive entries in Update mode.

### DIFF
--- a/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
+++ b/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
@@ -341,6 +341,23 @@ namespace MonoTests.System.IO.Compression
 		}
 
 		[Test]
+		public void ZipWriteEntriesUpdateModeNewEntry()
+		{
+			var stream = new MemoryStream();
+			var zipArchive = new ZipArchive(stream, ZipArchiveMode.Update);
+
+			var newEntry = zipArchive.CreateEntry("testEntry");
+
+			using (var newStream = newEntry.Open())
+			{
+				using (var sw = new StreamWriter(newStream))
+				{
+					sw.Write("TEST");
+				}
+			}
+		}
+
+		[Test]
 		public void ZipWriteEntriesUpdateModeNonZeroPosition()
 		{
 			File.Copy("archive.zip", "test.zip", overwrite: true);

--- a/mcs/class/System.IO.Compression/ZipArchiveEntry.cs
+++ b/mcs/class/System.IO.Compression/ZipArchiveEntry.cs
@@ -98,7 +98,8 @@ namespace System.IO.Compression
 			if (entry.Archive.Mode == ZipArchiveMode.Update && !entry.wasWritten)
 			{
 				// Replace the read-only stream with a writeable memory stream.
-				SetWriteable();
+				if (!stream.CanWrite)
+				    SetWriteable();
 				entry.wasWritten = true;
 			}
 


### PR DESCRIPTION
This regression was reported by RichardW of Open XML SDK project.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=39282.

Related https://github.com/OfficeDev/Open-XML-SDK/issues/64.