### PR TITLE
[4.4][System] Overwrite Console encoding to match mcs text output for CodeDOM compiler. Fixes #41979

### DIFF
--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
@@ -215,6 +215,10 @@ namespace Mono.CSharp
 			mcs.StartInfo.RedirectStandardOutput=true;
 			mcs.StartInfo.RedirectStandardError=true;
 			mcs.ErrorDataReceived += new DataReceivedEventHandler (McsStderrDataReceived);
+
+			// Use same text decoder as mcs and not user set values in Console
+			mcs.StartInfo.StandardOutputEncoding =
+			mcs.StartInfo.StandardErrorEncoding = Encoding.UTF8;
 			
 			try {
 				mcs.Start();


### PR DESCRIPTION
Backport of 27482448e956fcedb4c254fdea3a072f5153094b to Mono 4.4. Discussed with Marek, a lot of FAKE users are running into this.