### PR TITLE
Restore NULL check which PR #3040/#3105 mistakenly removed (bug 41623)

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5325,7 +5325,8 @@ ss_start (SingleStepReq *ss_req, MonoMethod *method, SeqPoint* sp, MonoSeqPointI
 						found_sp = mono_find_next_seq_point_for_native_offset (frame->domain, frame->method, (char*)ei->handler_start - (char*)jinfo->code_start, NULL, &local_sp);
 						sp = (found_sp)? &local_sp : NULL;
 
-						ss_bp_add_one (ss_req, &ss_req_bp_count, &ss_req_bp_cache, frame->method, sp->il_offset);
+						if (found_sp)
+							ss_bp_add_one (ss_req, &ss_req_bp_count, &ss_req_bp_cache, frame->method, sp->il_offset);
 					}
 				}
 			}


### PR DESCRIPTION
Could cause crash while stepping over in SDB.

This will need to be backported to 4.5.1. This *could* have bearing on bugzilla 42191.

I haven't verified this resolves 41623, please don't merge until I've done so.