### PR TITLE
[runtime] Document MonoDomain.static_data_array.

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -325,7 +325,10 @@ struct _MonoDomain {
 	/* hashtables for Reflection handles */
 	MonoGHashTable     *type_hash;
 	MonoGHashTable     *refobject_hash;
-	/* a GC-tracked array to keep references to the static fields of types */
+	/*
+	 * A GC-tracked array to keep references to the static fields of types.
+	 * See note [Domain Static Data Array].
+	 */
 	gpointer           *static_data_array;
 	/* maps class -> type initialization exception object */
 	MonoGHashTable    *type_init_exception_hash;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1483,8 +1483,10 @@ mono_context_get_domain_id (MonoAppContext *context)
 void
 mono_domain_add_class_static_data (MonoDomain *domain, MonoClass *klass, gpointer data, guint32 *bitmap)
 {
-	/* The first entry in the array is the index of the next free slot
-	 * and the total size of the array
+	/* Note [Domain Static Data Array]:
+	 *
+	 * Entry 0 in the array is the index of the next free slot.
+	 * Entry 1 is the total size of the array.
 	 */
 	int next;
 	if (domain->static_data_array) {


### PR DESCRIPTION
Saw a confusing comment, updated it. Also used the GHC “note” style for greppability.

I presume this was done so that the length & next slots are allocated along with the array, which may not always be allocated? If that’s not the case, it would be simpler to put them in the `MonoDomain` structure.
