### PR TITLE
[System.Web.Services] Fixes bad XmlMapping.Key.

### DIFF
--- a/mcs/class/System.Web.Services/System.Web.Services.Protocols/Methods.cs
+++ b/mcs/class/System.Web.Services/System.Web.Services.Protocols/Methods.cs
@@ -214,6 +214,9 @@ namespace System.Web.Services.Protocols {
 				OutputMembersMapping = soapImporter.ImportMembersMapping (ResponseName, ResponseNamespace, out_members, hasWrappingElem, writeAccessors);
 			}
 
+			InputMembersMapping.SetKey(RequestName);
+			OutputMembersMapping.SetKey(ResponseName);
+
 			requestSerializerId = parent.RegisterSerializer (InputMembersMapping);
 			responseSerializerId = parent.RegisterSerializer (OutputMembersMapping);
 
@@ -254,6 +257,8 @@ namespace System.Web.Services.Protocols {
 				else
 					InputHeaderMembersMapping = soapImporter.ImportMembersMapping ("", RequestNamespace, members, false, false);
 				
+				InputHeaderMembersMapping.SetKey(RequestName + ":InHeaders");
+				
 				requestHeadersSerializerId = parent.RegisterSerializer (InputHeaderMembersMapping);
 			}
 			
@@ -265,7 +270,9 @@ namespace System.Web.Services.Protocols {
 					OutputHeaderMembersMapping = xmlImporter.ImportMembersMapping ("", RequestNamespace, members, false);
 				else
 					OutputHeaderMembersMapping = soapImporter.ImportMembersMapping ("", RequestNamespace, members, false, false);
-				
+
+				OutputHeaderMembersMapping.SetKey(ResponseName + ":OutHeaders");
+
 				responseHeadersSerializerId = parent.RegisterSerializer (OutputHeaderMembersMapping);
 			}
 			

--- a/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SoapHttpClientProtocolTest.cs
+++ b/mcs/class/System.Web.Services/Test/System.Web.Services.Protocols/SoapHttpClientProtocolTest.cs
@@ -243,5 +243,44 @@ namespace MonoTests.System.Web.Services.Protocols
 				}
 			}
 		}
+
+		public class RequestHeader : SoapHeader
+		{
+		}
+
+		public class ResponseHeader : SoapHeader
+		{
+		}
+
+		[WebServiceBindingAttribute(Name = "ServiceWithHeaders", Namespace = "https://example.com")]
+		public class ServiceWithHeaders : SoapHttpClientProtocol
+		{
+			public RequestHeader RequestHeader { get; set; }
+			public ResponseHeader ResponseHeader { get; set; }
+
+			[SoapHeaderAttribute("ResponseHeader", Direction = SoapHeaderDirection.Out)]
+			[SoapHeaderAttribute("RequestHeader")]
+			[SoapDocumentMethodAttribute("", RequestNamespace = "https://example.com", ResponseNamespace = "https://example.com", Use = SoapBindingUse.Literal, ParameterStyle = SoapParameterStyle.Wrapped)]
+			public int method1()
+			{
+				return 0;
+			}
+
+			[SoapHeaderAttribute("ResponseHeader", Direction = SoapHeaderDirection.Out)]
+			[SoapHeaderAttribute("RequestHeader")]
+			[SoapDocumentMethodAttribute("", RequestNamespace = "https://example.com", ResponseNamespace = "https://example.com", Use = SoapBindingUse.Literal, ParameterStyle = SoapParameterStyle.Wrapped)]
+			public int method2()
+			{
+				return 0;
+			}
+		}
+
+		[Test] // Covers #41564
+		public void ServiceWithHeader () {
+			var service = new ServiceWithHeaders ();
+			Assert.IsNotNull (service);
+			// Should not throw an exception
+			// XAMMAC specific bug
+		}
 	}
 }


### PR DESCRIPTION
Fixes [#41564](https://bugzilla.xamarin.com/show_bug.cgi?id=41564)

Calling xmlImporter.ImportMembersMapping would set the key with the
underlying message type [1], thus if a service had remote calls using
the same types a key already exists exception would be thrown.

Furthermore reference source has special logic to set headers
XmlMappings key [2].

This pull request fixes the issue by overriding the XmlMappings.Key with
the values similar to those used in the reference source version.

[1] http://referencesource.microsoft.com/#System.Xml/System/Xml/Serialization/XmlMembersMapping.cs,28
[2] http://referencesource.microsoft.com/#System.Web.Services/System/Web/Services/Protocols/SoapReflector.cs,515