### PR TITLE
Fix for lock release in SynchronizationAttribute

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.Remoting.Contexts/SynchronizationAttributeTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Remoting.Contexts/SynchronizationAttributeTest.cs
@@ -72,6 +72,23 @@ namespace MonoTests.System.Runtime.Remoting.Contexts {
 		}
 
 		[Test]
+	    public void SetLocked()
+		{
+			SynchronizationAttribute sa = new SynchronizationAttribute(SynchronizationAttribute.REQUIRES_NEW);
+			sa.Locked = true;
+			Assert.IsTrue(sa.Locked, "Locked");
+			sa.Locked = false;
+			Assert.IsFalse(sa.Locked, "Locked");
+
+			sa.Locked = true;
+			Assert.IsTrue(sa.Locked, "Locked");
+			sa.Locked = true;
+			Assert.IsTrue(sa.Locked, "Locked");
+			sa.Locked = false;
+			Assert.IsFalse(sa.Locked, "Locked");
+		}
+
+		[Test]
 		public void SerializationRoundtrip ()
 		{
 			SynchronizationAttribute sa = new SynchronizationAttribute (SynchronizationAttribute.NOT_SUPPORTED, true);

--- a/mcs/class/corlib/Test/System.Runtime.Remoting/SynchronizationAttributeTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Remoting/SynchronizationAttributeTest.cs
@@ -220,6 +220,7 @@ namespace MonoTests.System.Runtime.Remoting
 		public void TestLocked1 ()
 		{
 			sincob.Lock (false);
+
 			Thread tr = new Thread (new ThreadStart (FirstSyncThread));
 			tr.Start ();
 			Thread.Sleep (200);
@@ -328,6 +329,21 @@ namespace MonoTests.System.Runtime.Remoting
 			notreentrant.CheckContext (Thread.CurrentContext);
 			
 			tr.Join ();
+			Assert.IsTrue (!otResult, "Concurrency detected in CallbackThread");
+		}
+
+		[Test]
+		public void TestSynchronizationReleasedOnMultipleAcquire ()
+		{
+
+			otResult = notreentrant.TestCallback ();
+		    
+			Thread tr = new Thread (new ThreadStart (CallbackThread));
+			tr.Start();
+			
+			bool terminated = tr.Join(2000);
+			Assert.IsTrue(terminated, "Thread didn't get lock of context bound object.");
+			
 			Assert.IsTrue (!otResult, "Concurrency detected in CallbackThread");
 		}
 


### PR DESCRIPTION
* Making sure ownerThread is not nulled unless lockCount is zero.
* Fixed so Locked property checks lockCount when determining if locked
   instead of _locked field which was never set.
* Added test for setting Locked property.
* Added test capturing the original issue.