### PR TITLE
[System] EndRead now throws WebException on abort. 

### DIFF
--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -896,6 +896,8 @@ namespace System.Net
 		{
 			Stream s = null;
 			lock (this) {
+				if (request.Aborted)
+					throw new WebException ("Request aborted", WebExceptionStatus.RequestCanceled);
 				if (Data.request != request)
 					throw new ObjectDisposedException (typeof (NetworkStream).FullName);
 				if (nstream == null)

--- a/mcs/class/System/Test/System.Net/WebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/WebRequestTest.cs
@@ -11,8 +11,10 @@
 //
 
 using NUnit.Framework;
+using MonoTests.Helpers;
 using System;
 using System.Net;
+using System.Threading;
 using System.Collections;
 using System.Runtime.Serialization;
 using Socks = System.Net.Sockets;
@@ -409,6 +411,52 @@ namespace MonoTests.System.Net {
 	internal class TestWebRequest3 : WebRequest
 	{
 		internal TestWebRequest3 () { }
+	}
+
+	[Test] // Covers #41477
+	public void TestReceiveCancelation ()
+	{
+		var uri = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
+
+		HttpListener listener = new HttpListener ();
+		listener.Prefixes.Add (uri);
+		listener.Start ();
+
+		try {
+			for (var i = 0; i < 10; i++) {
+				var request = WebRequest.CreateHttp (uri);
+				request.Method = "GET";
+
+				var tokenSource = new CancellationTokenSource ();
+				tokenSource.Token.Register(() => request.Abort ());
+
+				var responseTask = request.GetResponseAsync ();
+
+				var context = listener.GetContext ();
+				byte[] outBuffer = new byte[8 * 1024];
+				context.Response.OutputStream.WriteAsync (outBuffer, 0, outBuffer.Length);
+
+				Assert.IsTrue (responseTask.Wait (1000), "Timeout #1");
+
+				WebResponse response = responseTask.Result;
+				var stream = response.GetResponseStream ();
+
+				byte[] buffer = new byte[8 * 1024];
+				var taskRead = stream.ReadAsync (buffer, 0, buffer.Length, tokenSource.Token);
+
+				tokenSource.Cancel ();
+
+				Assert.IsTrue (taskRead.Wait (1000), "Timeout #2");
+
+				var byteRead = taskRead.Result;
+			}
+		} catch (AggregateException ex) {
+			var webEx = ex.InnerException as WebException;
+			Assert.IsNotNull(webEx, "Inner exception is not a WebException");
+			Assert.AreEqual (webEx.Status, WebExceptionStatus.RequestCanceled);
+		}
+
+		listener.Close ();
 	}
 }
 


### PR DESCRIPTION
When a request is aborted on .NET a WebException is thrown and not a
ObjectDisposedException as we were doing.

Fixes [#41477](https://bugzilla.xamarin.com/show_bug.cgi?id=41477)

Stand alone repro for comparing with .NET: https://gist.github.com/esdrubal/ba8e1e1708303fd1ca0e0078b64369da