### PR TITLE
Removing invalid null check of hostname

### DIFF
--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -2675,7 +2675,7 @@ ves_icall_System_Net_Dns_GetHostByName_internal (MonoString *host, MonoString **
 		}
 	}
 
-	if (*hostname && mono_get_address_info (hostname, 0, MONO_HINT_CANONICAL_NAME | hint, &info))
+	if (mono_get_address_info (hostname, 0, MONO_HINT_CANONICAL_NAME | hint, &info))
 		add_info_ok = FALSE;
 
 	g_free(hostname);


### PR DESCRIPTION
The check if `*hostname` is set causes problems when `hostname`
points to an empty string. It will be then be false and cause
the following call to `mono_get_address_info` not to be made
resulting in `info` will not be filled with proper value but
point to null. Also, there is no point of checking if hostname
is set here since it's content is already used earlier in the
method.