### PR TITLE
[C8] mono-symbolicate spec implementation

### DIFF
--- a/eglib/src/glib.h
+++ b/eglib/src/glib.h
@@ -772,6 +772,8 @@ const gchar *g_get_user_name   (void);
 gchar *g_get_prgname           (void);
 void  g_set_prgname            (const gchar *prgname);
 
+gboolean g_ensure_directory_exists (const gchar *filename);
+
 /*
  * Shell
  */

--- a/eglib/src/gpath.c
+++ b/eglib/src/gpath.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <glib.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 #ifdef G_OS_WIN32
 #include <direct.h> 
@@ -294,3 +295,95 @@ g_get_prgname (void)
 {
 	return name;
 }
+
+gboolean
+g_ensure_directory_exists (const gchar *filename)
+{
+#ifdef HOST_WIN32
+	gchar *dir_utf8 = g_path_get_dirname (filename);
+	gunichar2 *p;
+	gunichar2 *dir_utf16 = NULL;
+	int retval;
+	
+	if (!dir_utf8 || !dir_utf8 [0])
+		return FALSE;
+
+	dir_utf16 = g_utf8_to_utf16 (dir_utf8, strlen (dir_utf8), NULL, NULL, NULL);
+	g_free (dir_utf8);
+
+	if (!dir_utf16)
+		return FALSE;
+
+	p = dir_utf16;
+
+	/* make life easy and only use one directory seperator */
+	while (*p != '\0')
+	{
+		if (*p == '/')
+			*p = '\\';
+		p++;
+	}
+
+	p = dir_utf16;
+
+	/* get past C:\ )*/
+	while (*p++ != '\\')	
+	{
+	}
+
+	while (1) {
+		BOOL bRet = FALSE;
+		p = wcschr (p, '\\');
+		if (p)
+			*p = '\0';
+		retval = _wmkdir (dir_utf16);
+		if (retval != 0 && errno != EEXIST) {
+			g_free (dir_utf16);
+			return FALSE;
+		}
+		if (!p)
+			break;
+		*p++ = '\\';
+	}
+	
+	g_free (dir_utf16);
+	return TRUE;
+#else
+	char *p;
+	gchar *dir = g_path_get_dirname (filename);
+	int retval;
+	struct stat sbuf;
+	
+	if (!dir || !dir [0]) {
+		g_free (dir);
+		return FALSE;
+	}
+	
+	if (stat (dir, &sbuf) == 0 && S_ISDIR (sbuf.st_mode)) {
+		g_free (dir);
+		return TRUE;
+	}
+	
+	p = dir;
+	while (*p == '/')
+		p++;
+
+	while (1) {
+		p = strchr (p, '/');
+		if (p)
+			*p = '\0';
+		retval = mkdir (dir, 0777);
+		if (retval != 0 && errno != EEXIST) {
+			g_free (dir);
+			return FALSE;
+		}
+		if (!p)
+			break;
+		*p++ = '/';
+	}
+	
+	g_free (dir);
+	return TRUE;
+#endif
+}
+

--- a/man/mono.1
+++ b/man/mono.1
@@ -142,10 +142,10 @@ instead of going through the operating system symbol lookup operation.
 .I llvm-path=<PREFIX>
 Same for the llvm tools 'opt' and 'llc'.
 .TP
-.I gen-seq-points-file=FILE.msym
+.I msym-dir=<PATH>
 Instructs the AOT compiler to generate offline sequence points .msym files.
-The path is optional, if none is passed then a .msym file will be generated
-next to the input assembly.
+The generated .msym files will be stored into a subfolder of <PATH> named as the
+compilation AOTID.
 .TP
 .I mtriple=<TRIPLE>
 Use the GNU style target triple <TRIPLE> to determine some code generation options, i.e.

--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -326,7 +326,7 @@ namespace System.Diagnostics {
 		static void InitMetadataHandlers ()
 		{
 			string aotid = Assembly.GetAotId ();
-			if (aotid != "00000000-0000-0000-0000-000000000000")
+			if (aotid != null)
 				AddMetadataHandler ("AOTID", st => { return aotid; });
 
 			AddMetadataHandler ("MVID", st => {

--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -294,6 +294,8 @@ namespace System.Diagnostics {
 					if (!t.AddFrames (sb))
 						continue;
 
+					t.AddMetadata (sb);
+
 					sb.Append (Environment.NewLine);
 					sb.Append ("--- End of stack trace from previous location where exception was thrown ---");
 					sb.Append (Environment.NewLine);
@@ -301,7 +303,13 @@ namespace System.Diagnostics {
 			}
 
 			AddFrames (sb);
+			AddMetadata (sb);
 
+			return sb.ToString ();
+		}
+
+		void AddMetadata (StringBuilder sb)
+		{
 			foreach (var handler in metadataHandlers) {
 				var lines = handler.Value (this);
 				using (var reader = new StringReader (lines)) {
@@ -312,11 +320,8 @@ namespace System.Diagnostics {
 					}
 				}
 			}
-
-			return sb.ToString ();
 		}
 
-		
 		internal String ToString (TraceFormat traceFormat)
 		{
 			// TODO:

--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -328,6 +328,26 @@ namespace System.Diagnostics {
 			string aotid = Assembly.GetAotId ();
 			if (aotid != "00000000-0000-0000-0000-000000000000")
 				AddMetadataHandler ("AOTID", st => { return aotid; });
+
+			AddMetadataHandler ("MVID", st => {
+				var mvidLines = new Dictionary<Guid, List<int>> ();
+				var frames = st.GetFrames ();
+				for (var lineNumber = 0; lineNumber < frames.Length; lineNumber++) {
+					var mvid = frames[lineNumber].GetMethod ().Module.ModuleVersionId;
+					if (!mvidLines.ContainsKey (mvid))
+						mvidLines.Add (mvid, new List<int> ());
+
+					mvidLines[mvid].Add (lineNumber);
+				}
+
+				var sb = new StringBuilder ();
+				foreach (var kv in mvidLines) {
+					var mvid = kv.Key.ToString ().ToUpper ();
+					sb.AppendLine (string.Format ("{0} {1}", mvid, string.Join (",", kv.Value)));
+				}
+
+				return sb.ToString ();
+			});
 		}
 
 		private static void AddMetadataHandler (string id, Func<StackTrace, string> handler)

--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -333,7 +333,10 @@ namespace System.Diagnostics {
 				var mvidLines = new Dictionary<Guid, List<int>> ();
 				var frames = st.GetFrames ();
 				for (var lineNumber = 0; lineNumber < frames.Length; lineNumber++) {
-					var mvid = frames[lineNumber].GetMethod ().Module.ModuleVersionId;
+					var method = frames[lineNumber].GetMethod ();
+					if (method == null)
+						continue;
+					var mvid = method.Module.ModuleVersionId;
 					if (!mvidLines.ContainsKey (mvid))
 						mvidLines.Add (mvid, new List<int> ());
 

--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -328,9 +328,9 @@ namespace System.Diagnostics {
 		{
 			metadataHandlers = new Dictionary<string, Func<StackTrace, string>> (StringComparer.Ordinal);
 
-			string aotid = Assembly.GetAotId ();
+			var aotid = Assembly.GetAotId ();
 			if (aotid != null)
-				AddMetadataHandler ("AOTID", st => { return aotid; });
+				AddMetadataHandler ("AOTID", st => { return new Guid (aotid).ToString ("N"); });
 
 			AddMetadataHandler ("MVID", st => {
 				var mvidLines = new Dictionary<Guid, List<int>> ();
@@ -354,10 +354,8 @@ namespace System.Diagnostics {
 				mvids.Sort ();
 
 				var sb = new StringBuilder ();
-				foreach (var mvid in mvids) {
-					var mvidStr = mvid.ToString ().ToUpper ();
-					sb.AppendLine (string.Format ("{0} {1}", mvid, string.Join (",", mvidLines[mvid])));
-				}
+				foreach (var mvid in mvids)
+					sb.AppendLine (string.Format ("{0} {1}", mvid.ToString ("N"), string.Join (",", mvidLines[mvid])));
 
 				return sb.ToString ();
 			});

--- a/mcs/class/corlib/System.Reflection/Assembly.cs
+++ b/mcs/class/corlib/System.Reflection/Assembly.cs
@@ -138,6 +138,9 @@ namespace System.Reflection {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern string InternalImageRuntimeVersion ();
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static internal extern string GetAotId ();
+
 		// SECURITY: this should be the only caller to icall get_code_base
 		private string GetCodeBase (bool escaped)
 		{

--- a/mcs/class/corlib/Test/System.Reflection.Emit/DynamicMethodTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/DynamicMethodTest.cs
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
+using System.Linq;
 
 using NUnit.Framework;
 
@@ -517,7 +518,10 @@ namespace MonoTests.System.Reflection.Emit
 			invoke (456324);
 
 			Assert.IsNotNull (ExceptionHandling_Test_Support.Caught, "#1");
-			Assert.AreEqual (2, ExceptionHandling_Test_Support.CaughtStackTrace.Split (new[] { Environment.NewLine }, StringSplitOptions.None).Length, "#2");
+
+			var lines = ExceptionHandling_Test_Support.CaughtStackTrace.Split (new[] { Environment.NewLine }, StringSplitOptions.None);
+			lines = lines.Where (l => !l.StartsWith ("[")).ToArray ();
+			Assert.AreEqual (2, lines.Length, "#2");
 
 			var st = new StackTrace (ExceptionHandling_Test_Support.Caught, 0, true);
 
@@ -552,9 +556,12 @@ namespace MonoTests.System.Reflection.Emit
 
 			public static void Handler (Exception e)
 			{
-				var split = e.StackTrace.Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-				Assert.AreEqual (5, split.Length, "#1");
-				Assert.IsTrue (split [1].Contains ("---"), "#2");
+				var lines = e.StackTrace.Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+				// Ignore Metadata
+				lines = lines.Where (l => !l.StartsWith ("[")).ToArray ();
+
+				Assert.AreEqual (5, lines.Length, "#1");
+				Assert.IsTrue (lines [1].Contains ("---"), "#2");
 			}
 		}
 

--- a/mcs/class/corlib/Test/System.Runtime.ExceptionServices/ExceptionDispatchInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.ExceptionServices/ExceptionDispatchInfoTest.cs
@@ -31,6 +31,7 @@ using NUnit.Framework;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Linq;
 
 namespace MonoTests.System.Runtime.ExceptionServices
 {
@@ -38,6 +39,14 @@ namespace MonoTests.System.Runtime.ExceptionServices
 	[Category ("BitcodeNotWorking")]
 	public class ExceptionDispatchInfoTest
 	{
+		static string[] GetLines (string str)
+		{
+			var lines = str.Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+			// Ignore Metadata
+			return lines.Where (l => !l.StartsWith ("[")).ToArray ();
+		}
+
 		[Test]
 		public void Capture_InvalidArguments ()
 		{
@@ -75,7 +84,7 @@ namespace MonoTests.System.Runtime.ExceptionServices
 				ed.Throw ();
 				Assert.Fail ("#0");
 			} catch (Exception e) {
-				var s = e.StackTrace.Split ('\n');
+				var s = GetLines (e.StackTrace);
 				Assert.AreEqual (4, s.Length, "#1");
 				Assert.AreEqual (orig, e, "#2");
 				Assert.AreNotEqual (orig_stack, e.StackTrace, "#3");
@@ -90,8 +99,9 @@ namespace MonoTests.System.Runtime.ExceptionServices
 				edi.Throw ();
 				Assert.Fail ("#0");
 			} catch (OperationCanceledException e) {
-				Assert.IsFalse (e.StackTrace.Contains ("---"));
-				Assert.AreEqual (2, e.StackTrace.Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Length);
+				Assert.IsTrue (!e.StackTrace.Contains("---"));
+				var lines = GetLines (e.StackTrace);
+				Assert.AreEqual (2, lines.Length, "#1");
 			}
 		}
 
@@ -120,9 +130,9 @@ namespace MonoTests.System.Runtime.ExceptionServices
 			try {
 				edi.Throw ();
 			} catch (Exception ex) {
-				var split = ex.StackTrace.Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-				Assert.AreEqual (4, split.Length, "#1");
-				Assert.IsTrue (split [1].Contains ("---"), "#2");
+				var lines = GetLines (ex.StackTrace);
+				Assert.AreEqual (4, lines.Length, "#1");
+				Assert.IsTrue (lines [1].Contains ("---"), "#2");
 			}
 		}
 
@@ -147,10 +157,10 @@ namespace MonoTests.System.Runtime.ExceptionServices
 			try {
 				edi.Throw ();
 			} catch (Exception ex) {
-				var split = ex.StackTrace.Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-				Assert.AreEqual (7, split.Length, "#1");
-				Assert.IsTrue (split [1].Contains ("---"), "#2");
-				Assert.IsTrue (split [4].Contains ("---"), "#3");
+				var lines = GetLines (ex.StackTrace);
+				Assert.AreEqual (7, lines.Length, "#1");
+				Assert.IsTrue (lines [1].Contains ("---"), "#2");
+				Assert.IsTrue (lines [4].Contains ("---"), "#3");
 			}
 		}
 
@@ -166,9 +176,9 @@ namespace MonoTests.System.Runtime.ExceptionServices
 				}
 			} catch (Exception ex) {
 				var st = new StackTrace (ex, true);
-				var split = st.ToString ().Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-				Assert.AreEqual (4, split.Length, "#1");
-				Assert.IsTrue (split [1].Contains ("---"), "#2");
+				var lines = GetLines (st.ToString ());
+				Assert.AreEqual (4, lines.Length, "#1");
+				Assert.IsTrue (lines [1].Contains ("---"), "#2");
 			}
 		}
 	}

--- a/mcs/tools/mono-symbolicate/LocationProvider.cs
+++ b/mcs/tools/mono-symbolicate/LocationProvider.cs
@@ -7,218 +7,143 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;
 
-namespace Symbolicate
+namespace Mono
 {
-	class LocationProvider {
-		class AssemblyLocationProvider {
-			AssemblyDefinition assembly;
-			string seqPointDataPath;
+	class AssemblyLocationProvider
+	{
+		AssemblyDefinition assembly;
 
-			public AssemblyLocationProvider (AssemblyDefinition assembly, string seqPointDataPath)
-			{
-				this.assembly = assembly;
-				this.seqPointDataPath = seqPointDataPath;
-			}
-
-			public SequencePoint TryGetLocation (string typeFullName, string methodSignature, int offset, bool isOffsetIL, uint methodIndex)
-			{
-				if (!assembly.MainModule.HasSymbols)
-					return null;
-
-				TypeDefinition type = null;
-				var nested = typeFullName.Split ('+');
-				var types = assembly.MainModule.Types;
-				foreach (var ntype in nested) {
-					type = types.FirstOrDefault (t => t.Name == ntype);
-					if (type == null)
-						return null;
-
-					types = type.NestedTypes;
-				}
-
-				var parensStart = methodSignature.IndexOf ('(');
-				var methodName = methodSignature.Substring (0, parensStart).TrimEnd ();
-				var methodParameters = methodSignature.Substring (parensStart);
-				var method = type.Methods.FirstOrDefault (m => CompareName (m, methodName) && CompareParameters (m.Parameters, methodParameters));
-				if (method == null)
-					return null;
-
-				int ilOffset = isOffsetIL ? offset : GetILOffsetFromFile (method.MetadataToken.ToInt32 (), methodIndex, offset);
-				if (ilOffset < 0)
-					return null;
-
-				SequencePoint sp = null;
-				foreach (var instr in method.Body.Instructions) {
-					if (instr.SequencePoint != null)
-						sp = instr.SequencePoint;
-					
-					if (instr.Offset >= ilOffset) {
-						return sp;
-					}
-				}
-
-				return null;
-			}
-
-			SeqPointInfo seqPointInfo;
-			private int GetILOffsetFromFile (int methodToken, uint methodIndex, int nativeOffset)
-			{
-				if (seqPointInfo == null)
-					seqPointInfo = SeqPointInfo.Read (seqPointDataPath);
-
-				return seqPointInfo.GetILOffset (methodToken, methodIndex, nativeOffset);
-			}
-
-			static bool CompareName (MethodDefinition candidate, string expected)
-			{
-				if (candidate.Name == expected)
-					return true;
-
-				if (!candidate.HasGenericParameters)
-					return false;
-				
-				var genStart = expected.IndexOf ('[');
-				if (genStart < 0)
-					return false;
-
-				if (candidate.Name != expected.Substring (0, genStart))
-					return false;
-
-				int arity = 1;
-				for (int pos = genStart; pos < expected.Length; ++pos) {
-					if (expected [pos] == ',')
-						++arity;
-				}
-
-				return candidate.GenericParameters.Count == arity;
-			}
-
-			static bool CompareParameters (Collection<ParameterDefinition> candidate, string expected)
-			{
-				var builder = new StringBuilder ();
-				builder.Append ("(");
-
-				for (int i = 0; i < candidate.Count; i++) {
-					var parameter = candidate [i];
-					if (i > 0)
-						builder.Append (", ");
-
-					if (parameter.ParameterType.IsSentinel)
-						builder.Append ("...,");
-
-					var pt = parameter.ParameterType;
-					if (!string.IsNullOrEmpty (pt.Namespace)) {
-						builder.Append (pt.Namespace);
-						builder.Append (".");
-					}
-
-					FormatElementType (pt, builder);
-
-					builder.Append (" ");
-					builder.Append (parameter.Name);
-				}
-
-				builder.Append (")");
-
-				return builder.ToString () == expected;
-			}
-
-			static void FormatElementType (TypeReference tr, StringBuilder builder)
-			{
-				var ts = tr as TypeSpecification;
-				if (ts != null) {
-					if (ts.IsByReference) {
-						FormatElementType (ts.ElementType, builder);
-						builder.Append ("&");
-						return;
-					}
-
-					var array = ts as ArrayType;
-					if (array != null) {
-						FormatElementType (ts.ElementType, builder);
-						builder.Append ("[");
-
-						for (int ii = 0; ii < array.Rank - 1; ++ii) {
-							builder.Append (",");
-						}
-
-						builder.Append ("]");
-						return;
-					}
-				}
-
-				builder.Append (tr.Name);
-			}
-		}
-
-		Dictionary<string, AssemblyLocationProvider> assemblies;
-		HashSet<string> directories;
-
-		public LocationProvider () {
-			assemblies = new Dictionary<string, AssemblyLocationProvider> ();
-			directories = new HashSet<string> ();
-		}
-
-		public void AddAssembly (string assemblyPath)
+		public AssemblyLocationProvider (string assemblyPath)
 		{
 			assemblyPath = Path.GetFullPath (assemblyPath);
-			if (assemblies.ContainsKey (assemblyPath))
-				return;
 
 			if (!File.Exists (assemblyPath))
 				throw new ArgumentException ("assemblyPath does not exist: "+ assemblyPath);
 
 			var readerParameters = new ReaderParameters { ReadSymbols = true };
-			var assembly = AssemblyDefinition.ReadAssembly (assemblyPath, readerParameters);
+			assembly = AssemblyDefinition.ReadAssembly (assemblyPath, readerParameters);
+		}
 
-			var seqPointDataPath = assemblyPath + ".msym";
-			if (!File.Exists (seqPointDataPath))
-				seqPointDataPath = null;
+		public bool TryResolveLocation (StackFrameData sfData, SeqPointInfo seqPointInfo)
+		{
+			if (!assembly.MainModule.HasSymbols)
+				return false;
 
-			assemblies.Add (assemblyPath, new AssemblyLocationProvider (assembly, seqPointDataPath));
+			TypeDefinition type = null;
+			var nested = sfData.TypeFullName.Split ('+');
+			var types = assembly.MainModule.Types;
+			foreach (var ntype in nested) {
+				type = types.FirstOrDefault (t => t.Name == ntype);
+				if (type == null)
+					return false;
 
-			// TODO: Should use AssemblyName with .net unification rules
-			directories.Add (Path.GetDirectoryName (assemblyPath));
+				types = type.NestedTypes;
+			}
 
-			foreach (var assemblyRef in assembly.MainModule.AssemblyReferences) {
-				string refPath = null;
-				foreach (var dir in directories) {
-					refPath = Path.Combine (dir, assemblyRef.Name);
-					if (File.Exists (refPath))
-						break;
-					refPath = Path.Combine (dir, assemblyRef.Name + ".dll");
-					if (File.Exists (refPath))
-						break;
-					refPath = Path.Combine (dir, assemblyRef.Name + ".exe");
-					if (File.Exists (refPath))
-						break;
-					refPath = null;
+			var parensStart = sfData.MethodSignature.IndexOf ('(');
+			var methodName = sfData.MethodSignature.Substring (0, parensStart).TrimEnd ();
+			var methodParameters = sfData.MethodSignature.Substring (parensStart);
+			var method = type.Methods.FirstOrDefault (m => CompareName (m, methodName) && CompareParameters (m.Parameters, methodParameters));
+			if (method == null)
+				return false;
+
+			int ilOffset = sfData.IsILOffset ? sfData.Offset : seqPointInfo.GetILOffset (method.MetadataToken.ToInt32 (), sfData.MethodIndex, sfData.Offset);
+			if (ilOffset < 0)
+				return false;
+
+			SequencePoint sp = null;
+			foreach (var instr in method.Body.Instructions) {
+				if (instr.SequencePoint != null)
+					sp = instr.SequencePoint;
+				
+				if (instr.Offset >= ilOffset) {
+					sfData.SetLocation (sp.Document.Url, sp.StartLine);
+					return true;
 				}
-				if (refPath != null)
-					AddAssembly (refPath);
 			}
+
+			return false;
 		}
 
-		public void AddDirectory (string directory)
+		static bool CompareName (MethodDefinition candidate, string expected)
 		{
-			directory = Path.GetFullPath (directory);
-			if (!Directory.Exists (directory)) {
-				Console.Error.WriteLine ("Directory " + directory + " does not exist.");
-				return;
+			if (candidate.Name == expected)
+				return true;
+
+			if (!candidate.HasGenericParameters)
+				return false;
+			
+			var genStart = expected.IndexOf ('[');
+			if (genStart < 0)
+				return false;
+
+			if (candidate.Name != expected.Substring (0, genStart))
+				return false;
+
+			int arity = 1;
+			for (int pos = genStart; pos < expected.Length; ++pos) {
+				if (expected [pos] == ',')
+					++arity;
 			}
 
-			directories.Add (directory);
+			return candidate.GenericParameters.Count == arity;
 		}
 
-		public SequencePoint TryGetLocation (string typeFullName, string methodSignature, int offset, bool isOffsetIL, uint methodIndex)
+		static bool CompareParameters (Collection<ParameterDefinition> candidate, string expected)
 		{
-			foreach (var assembly in assemblies.Values) {
-				var loc = assembly.TryGetLocation (typeFullName, methodSignature, offset, isOffsetIL, methodIndex);
-				if (loc != null)
-					return loc;
+			var builder = new StringBuilder ();
+			builder.Append ("(");
+
+			for (int i = 0; i < candidate.Count; i++) {
+				var parameter = candidate [i];
+				if (i > 0)
+					builder.Append (", ");
+
+				if (parameter.ParameterType.IsSentinel)
+					builder.Append ("...,");
+
+				var pt = parameter.ParameterType;
+				if (!string.IsNullOrEmpty (pt.Namespace)) {
+					builder.Append (pt.Namespace);
+					builder.Append (".");
+				}
+
+				FormatElementType (pt, builder);
+
+				builder.Append (" ");
+				builder.Append (parameter.Name);
 			}
 
-			return null;
+			builder.Append (")");
+
+			return builder.ToString () == expected;
+		}
+
+		static void FormatElementType (TypeReference tr, StringBuilder builder)
+		{
+			var ts = tr as TypeSpecification;
+			if (ts != null) {
+				if (ts.IsByReference) {
+					FormatElementType (ts.ElementType, builder);
+					builder.Append ("&");
+					return;
+				}
+
+				var array = ts as ArrayType;
+				if (array != null) {
+					FormatElementType (ts.ElementType, builder);
+					builder.Append ("[");
+
+					for (int ii = 0; ii < array.Rank - 1; ++ii) {
+						builder.Append (",");
+					}
+
+					builder.Append ("]");
+					return;
+				}
+			}
+
+			builder.Append (tr.Name);
 		}
 	}
 }

--- a/mcs/tools/mono-symbolicate/LocationProvider.cs
+++ b/mcs/tools/mono-symbolicate/LocationProvider.cs
@@ -47,7 +47,16 @@ namespace Mono
 			if (method == null)
 				return false;
 
-			int ilOffset = sfData.IsILOffset ? sfData.Offset : seqPointInfo.GetILOffset (method.MetadataToken.ToInt32 (), sfData.MethodIndex, sfData.Offset);
+			int ilOffset;
+			if (sfData.IsILOffset) {
+				ilOffset = sfData.Offset;
+			} else {
+				if (seqPointInfo == null)
+					return false;
+
+				ilOffset = seqPointInfo.GetILOffset (method.MetadataToken.ToInt32 (), sfData.MethodIndex, sfData.Offset);
+			}
+
 			if (ilOffset < 0)
 				return false;
 

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -15,45 +15,65 @@ LIB_PATH = $(topdir)/class/lib/$(PROFILE)
 
 MONO = MONO_PATH="$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) -O=-inline
 
-MSYM_DIR = msymdir
-OUT_DIR = Test/out
+MSYM_DIR = $(OUT_DIR)/msymdir
 TEST_CS = Test/StackTraceDumper.cs
 TEST_EXE = $(OUT_DIR)/StackTraceDumper.exe
-RELEASE_FILE = $(OUT_DIR)/release.out
-SYMBOLICATE_FILE = $(OUT_DIR)/symbolicate.out
+STACKTRACE_FILE = $(OUT_DIR)/stacktrace.out
+SYMBOLICATE_RAW_FILE = $(OUT_DIR)/symbolicate_raw.out
+SYMBOLICATE_RESULT_FILE = $(OUT_DIR)/symbolicate.result
 SYMBOLICATE_EXPECTED_FILE = Test/symbolicate.expected
 
 CHECK_DIFF = @\
-	MONO_DEBUG=gen-compact-seq-points $(MONO) $(TEST_EXE) > $(RELEASE_FILE); \
-	$(MONO) $(LIB_PATH)/$(PROGRAM) $(MSYM_DIR) $(RELEASE_FILE) | sed "s/).*Test\//) in /" > $(SYMBOLICATE_FILE); \
-	DIFF=$$(diff $(SYMBOLICATE_FILE) $(SYMBOLICATE_EXPECTED_FILE)); \
+	MONO_DEBUG=gen-compact-seq-points $(MONO) $(TEST_EXE) > $(STACKTRACE_FILE); \
+	$(MONO) $(LIB_PATH)/$(PROGRAM) $(MSYM_DIR) $(STACKTRACE_FILE) > $(SYMBOLICATE_RAW_FILE); \
+	sed "s/).*Test\//) in /" $(SYMBOLICATE_RAW_FILE) | sed '/\[MVID\]/d' | sed '/\[AOTID\]/d' > $(SYMBOLICATE_RESULT_FILE); \
+	DIFF=$$(diff $(SYMBOLICATE_RESULT_FILE) $(SYMBOLICATE_EXPECTED_FILE)); \
 	if [ ! -z "$$DIFF" ]; then \
 		echo "Symbolicate tests failed."; \
-		echo "If $(SYMBOLICATE_FILE) is correct copy it to $(SYMBOLICATE_EXPECTED_FILE)."; \
+		echo "If $(SYMBOLICATE_RESULT_FILE) is correct copy it to $(SYMBOLICATE_EXPECTED_FILE)."; \
 		echo "Otherwise runtime sequence points need to be fixed."; \
 		echo "$$DIFF"; \
 		exit 1; \
 	fi
 
-BUILD_TEST_EXE = \
+PREPARE_OUTDIR = @\
 	rm -rf $(OUT_DIR); \
 	mkdir -p $(OUT_DIR); \
-	$(CSCOMPILE) $(TEST_CS) -out:$(TEST_EXE)
+	mkdir -p $(MSYM_DIR);
+
+COMPILE = \
+	$(CSCOMPILE) $(TEST_CS) -out:$(TEST_EXE); \
+	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(OUT_DIR)
 
 check: test-local
 
 AOT_SUPPORTED = $(shell $(MONO) --aot 2>&1 | grep -q "AOT compilation is not supported" && echo 0 || echo 1)
 
-test-local: all
-	$(BUILD_TEST_EXE)
-	@echo "Checking $(TEST_EXE) without AOT"
+test-local: test-without-aot test-with-aot test-with-aot-msym
+
+test-without-aot: OUT_DIR = Test/without_aot
+test-without-aot: all
+	@echo "Checking $(TEST_EXE) without AOT in $(OUT_DIR)"
+	$(PREPARE_OUTDIR)
+	$(COMPILE)
 	$(CHECK_DIFF)
+
+test-with-aot: OUT_DIR = Test/with_aot
+test-with-aot: all
 ifeq ($(AOT_SUPPORTED), 1)
-	@echo "Checking $(TEST_EXE) with AOT"
+	@echo "Checking $(TEST_EXE) with AOT in $(OUT_DIR)"
+	$(PREPARE_OUTDIR)
+	$(COMPILE)
 	@MONO_DEBUG=gen-compact-seq-points $(MONO) --aot $(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
-	@echo "Checking $(TEST_EXE) with AOT (using .msym)"
-	$(BUILD_TEST_EXE)
-	@MONO_DEBUG=gen-compact-seq-points $(MONO) --aot=gen-seq-points-file $(TEST_EXE) > /dev/null
+endif
+
+test-with-aot-msym: OUT_DIR = Test/with_aot_msym
+test-with-aot-msym: all
+ifeq ($(AOT_SUPPORTED), 1)
+	@echo "Checking $(TEST_EXE) with AOT (using .msym) in $(OUT_DIR)"
+	$(PREPARE_OUTDIR)
+	$(COMPILE)
+	@MONO_DEBUG=gen-compact-seq-points $(MONO) --aot=msym-dir=$(MSYM_DIR) $(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
 endif

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -15,6 +15,7 @@ LIB_PATH = $(topdir)/class/lib/$(PROFILE)
 
 MONO = MONO_PATH="$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) -O=-inline
 
+MSYM_DIR = msymdir
 OUT_DIR = Test/out
 TEST_CS = Test/StackTraceDumper.cs
 TEST_EXE = $(OUT_DIR)/StackTraceDumper.exe
@@ -24,7 +25,7 @@ SYMBOLICATE_EXPECTED_FILE = Test/symbolicate.expected
 
 CHECK_DIFF = @\
 	MONO_DEBUG=gen-compact-seq-points $(MONO) $(TEST_EXE) > $(RELEASE_FILE); \
-	$(MONO) $(LIB_PATH)/$(PROGRAM) $(TEST_EXE) $(RELEASE_FILE) | sed "s/).*Test\//) in /" > $(SYMBOLICATE_FILE); \
+	$(MONO) $(LIB_PATH)/$(PROGRAM) $(MSYM_DIR) $(RELEASE_FILE) | sed "s/).*Test\//) in /" > $(SYMBOLICATE_FILE); \
 	DIFF=$$(diff $(SYMBOLICATE_FILE) $(SYMBOLICATE_EXPECTED_FILE)); \
 	if [ ! -z "$$DIFF" ]; then \
 		echo "Symbolicate tests failed."; \

--- a/mcs/tools/mono-symbolicate/SeqPointInfo.cs
+++ b/mcs/tools/mono-symbolicate/SeqPointInfo.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
-namespace Symbolicate
+namespace Mono
 {
 	static class BinaryReaderExtensions
 	{

--- a/mcs/tools/mono-symbolicate/StackFrameData.cs
+++ b/mcs/tools/mono-symbolicate/StackFrameData.cs
@@ -1,0 +1,99 @@
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace Mono
+{
+	class StackFrameData
+	{
+		static Regex regex = new Regex (@"\w*at (?<Method>.+) *(\[0x(?<IL>.+)\]|<0x.+ \+ 0x(?<NativeOffset>.+)>( (?<MethodIndex>\d+)|)) in <filename unknown>:0");
+
+		public readonly string TypeFullName;
+		public readonly string MethodSignature;
+		public readonly int Offset;
+		public readonly bool IsILOffset;
+		public readonly uint MethodIndex;
+		public readonly string Line;
+
+		public string File { get; private set; }
+		public int LineNumber { get; private set; }
+
+		private StackFrameData (string line, string typeFullName, string methodSig, int offset, bool isILOffset, uint methodIndex)
+		{
+			LineNumber = -1;
+
+			Line = line;
+			TypeFullName = typeFullName;
+			MethodSignature = methodSig;
+			Offset = offset;
+			IsILOffset = isILOffset;
+			MethodIndex = methodIndex;
+		}
+
+		public static bool TryParse (string line, out StackFrameData stackFrame)
+		{
+			stackFrame = null;
+
+			var match = regex.Match (line);
+			if (!match.Success)
+				return false;
+
+			string typeFullName, methodSignature;
+			var methodStr = match.Groups ["Method"].Value.Trim ();
+			if (!ExtractSignatures (methodStr, out typeFullName, out methodSignature))
+				return false;
+
+			var isILOffset = !string.IsNullOrEmpty (match.Groups ["IL"].Value);
+			var offsetVarName = (isILOffset)? "IL" : "NativeOffset";
+			var offset = int.Parse (match.Groups [offsetVarName].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+
+			uint methodIndex = 0xffffff;
+			if (!string.IsNullOrEmpty (match.Groups ["MethodIndex"].Value))
+				methodIndex = uint.Parse (match.Groups ["MethodIndex"].Value, CultureInfo.InvariantCulture);
+
+			stackFrame = new StackFrameData (line, typeFullName, methodSignature, offset, isILOffset, methodIndex);
+
+			return true;
+		}
+
+		static bool ExtractSignatures (string str, out string typeFullName, out string methodSignature)
+		{
+			var methodNameEnd = str.IndexOf ('(');
+			if (methodNameEnd == -1) {
+				typeFullName = methodSignature = null;
+				return false;
+			}
+
+			var typeNameEnd = str.LastIndexOf ('.', methodNameEnd);
+			if (typeNameEnd == -1) {
+				typeFullName = methodSignature = null;
+				return false;
+			}
+
+			// Adjustment for Type..ctor ()
+			if (typeNameEnd > 0 && str [typeNameEnd - 1] == '.') {
+				--typeNameEnd;
+			}
+
+			typeFullName = str.Substring (0, typeNameEnd);
+			// Remove generic parameters
+			typeFullName = Regex.Replace (typeFullName, @"\[[^\[\]]*\]", "");
+
+			methodSignature = str.Substring (typeNameEnd + 1);
+
+			return true;
+		}
+
+		internal void SetLocation (string file, int lineNumber)
+		{
+			File = file;
+			LineNumber = lineNumber;
+		}
+
+		public override string ToString () {
+			if (Line.Contains ("<filename unknown>:0") && LineNumber != -1)
+				return Line.Replace ("<filename unknown>:0", string.Format ("{0}:{1}", File, LineNumber));
+
+			return Line;
+		}
+	}
+}

--- a/mcs/tools/mono-symbolicate/StackTraceMetadata.cs
+++ b/mcs/tools/mono-symbolicate/StackTraceMetadata.cs
@@ -1,0 +1,36 @@
+using System.Text.RegularExpressions;
+
+namespace Mono
+{
+	class StackTraceMetadata
+	{
+		static Regex regex = new Regex (@"\[(?<Id>.+)\] (?<Value>.+)");
+
+		public readonly string Id;
+		public readonly string Value;
+		public readonly string Line;
+
+		private StackTraceMetadata (string line, string id, string val)
+		{
+			Line = line;
+			Id = id;
+			Value = val;
+		}
+	
+		public static bool TryParse (string line, out StackTraceMetadata metadata)
+		{
+			metadata = null;
+
+			var match = regex.Match (line);
+			if (!match.Success)
+				return false;
+
+			string id = match.Groups ["Id"].Value;
+			string val = match.Groups ["Value"].Value;
+
+			metadata = new StackTraceMetadata (line, id, val);
+
+			return true;
+		}
+	}
+}

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
+
+namespace Mono
+{
+	public class SymbolManager
+	{
+		string msymDir;
+
+		public SymbolManager (string msymDir) {
+			this.msymDir = msymDir;
+		}
+
+		internal bool TryResolveLocation (StackFrameData sfData, string mvid, string aotid)
+		{
+			var assemblyLocProvider = GetOrCreateAssemblyLocationProvider (mvid);
+
+			SeqPointInfo seqPointInfo = null;
+			if (aotid != null)
+				seqPointInfo = GetOrCreateSeqPointInfo (aotid);
+
+			return assemblyLocProvider.TryResolveLocation (sfData, seqPointInfo);
+		}
+
+		Dictionary<string, AssemblyLocationProvider> assemblies = new Dictionary<string, AssemblyLocationProvider> ();
+
+		private AssemblyLocationProvider GetOrCreateAssemblyLocationProvider (string mvid)
+		{
+			if (assemblies.ContainsKey (mvid))
+				return assemblies[mvid];
+
+			var mvidDir = Path.Combine (msymDir, mvid);
+			if (!Directory.Exists (mvidDir))
+				throw new Exception (string.Format("MVID directory does not exist: {0}", mvidDir));
+
+			string assemblyPath = null;
+			var exeFiles = Directory.GetFiles (mvidDir, "*.exe");
+			var dllFiles = Directory.GetFiles (mvidDir, "*.dll");
+
+			if (exeFiles.Length + dllFiles.Length != 1)
+				throw new Exception (string.Format ("MVID directory should include one assembly: {0}", mvidDir));
+
+			assemblyPath = (exeFiles.Length > 0)? exeFiles[0] : dllFiles[0];
+
+			var locProvider = new AssemblyLocationProvider (assemblyPath);
+
+			assemblies.Add (mvid, locProvider);
+
+			return locProvider;
+		}
+
+		Dictionary<string, SeqPointInfo> seqPointInfos = new Dictionary<string, SeqPointInfo> ();
+
+		private SeqPointInfo GetOrCreateSeqPointInfo (string aotid)
+		{
+			if (seqPointInfos.ContainsKey (aotid))
+				return seqPointInfos[aotid];
+
+			var aotidDir = Path.Combine (msymDir, aotid);
+			if (!Directory.Exists (aotidDir))
+				throw new Exception (string.Format("AOTID directory does not exist: {0}", aotidDir));
+
+			string msymFile = null;
+			var msymFiles = Directory.GetFiles(aotidDir, "*.msym");
+			msymFile = msymFiles[0];
+
+			var seqPointInfo = SeqPointInfo.Read (msymFile);
+
+			seqPointInfos.Add (aotid, seqPointInfo);
+
+			return seqPointInfo;
+		}
+	}
+}

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -76,5 +76,36 @@ namespace Mono
 
 			return seqPointInfo;
 		}
+
+		public void StoreSymbols (params string[] lookupDirs)
+		{
+			foreach (var dir in lookupDirs) {
+				var exeFiles = Directory.GetFiles (dir, "*.exe");
+				var dllFiles = Directory.GetFiles (dir, "*.dll");
+				var assemblies = exeFiles.Concat (dllFiles);
+				foreach (var assemblyPath in assemblies) {
+					var mdbPath = assemblyPath + ".mdb";
+					if (!File.Exists (mdbPath)) {
+						// assemblies without mdb files are useless
+						continue;
+					}
+
+					var assembly = AssemblyDefinition.ReadAssembly (assemblyPath);
+
+					var mvid = assembly.MainModule.Mvid.ToString ().ToUpper ();
+					var mvidDir = Path.Combine (msymDir, mvid);
+
+					Directory.CreateDirectory (mvidDir);
+
+					var mvidAssemblyPath = Path.Combine (mvidDir, Path.GetFileName (assemblyPath));
+					File.Copy (assemblyPath, mvidAssemblyPath);
+
+					var mvidMdbPath = Path.Combine (mvidDir, Path.GetFileName (mdbPath));
+					File.Copy (mdbPath, mvidMdbPath);
+
+					// TODO create MVID dir for non main modules with links to main module MVID
+				}
+			}
+		}
 	}
 }

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -22,7 +22,7 @@ namespace Mono
 			var assemblyLocProvider = GetOrCreateAssemblyLocationProvider (mvid);
 
 			SeqPointInfo seqPointInfo = null;
-			if (aotid != null)
+			if (!sfData.IsILOffset && aotid != null)
 				seqPointInfo = GetOrCreateSeqPointInfo (aotid);
 
 			return assemblyLocProvider.TryResolveLocation (sfData, seqPointInfo);

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -92,7 +92,7 @@ namespace Mono
 
 					var assembly = AssemblyDefinition.ReadAssembly (assemblyPath);
 
-					var mvid = assembly.MainModule.Mvid.ToString ().ToUpper ();
+					var mvid = assembly.MainModule.Mvid.ToString ("N");
 					var mvidDir = Path.Combine (msymDir, mvid);
 
 					Directory.CreateDirectory (mvidDir);

--- a/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
+++ b/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
@@ -1,3 +1,6 @@
 symbolicate.cs
 LocationProvider.cs
 SeqPointInfo.cs
+StackFrameData.cs
+StackTraceMetadata.cs
+SymbolManager.cs

--- a/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
+++ b/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
@@ -4,3 +4,4 @@ SeqPointInfo.cs
 StackFrameData.cs
 StackTraceMetadata.cs
 SymbolManager.cs
+../../class/Mono.Options/Mono.Options/Options.cs

--- a/mcs/tools/mono-symbolicate/symbolicate.cs
+++ b/mcs/tools/mono-symbolicate/symbolicate.cs
@@ -11,19 +11,30 @@ namespace Mono
 	{
 		public static int Main (String[] args)
 		{
-			if (args.Length < 2) {
+			if (args.Length != 2 && (args[0] == "store-symbols" && args.Length < 3)) {
 				Console.Error.WriteLine ("Usage: symbolicate <msym dir> <input file>");
+				Console.Error.WriteLine ("       symbolicate store-symbols <msym dir> [<dir>]+");
 				return 1;
 			}
 
-			var msymDir = args [0];
-			var inputFile = args [1];
+			if (args[0] == "store-symbols") {
+				var msymDir = args[1];
+				var lookupDirs = args.Skip (1).ToArray ();
 
-			var symbolManager = new SymbolManager (msymDir);
+				var symbolManager = new SymbolManager (msymDir);
 
-			using (StreamReader r = new StreamReader (inputFile)) {
-				var sb = Process (r, symbolManager);
-				Console.WriteLine (sb.ToString ());
+				symbolManager.StoreSymbols (lookupDirs);
+
+			} else {
+				var msymDir = args [0];
+				var inputFile = args [1];
+
+				var symbolManager = new SymbolManager (msymDir);
+
+				using (StreamReader r = new StreamReader (inputFile)) {
+					var sb = Process (r, symbolManager);
+					Console.Write (sb.ToString ());
+				}
 			}
 
 			return 0;

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1510,97 +1510,6 @@ get_shadow_assembly_location (const char *filename, MonoError *error)
 }
 
 static gboolean
-ensure_directory_exists (const char *filename)
-{
-#ifdef HOST_WIN32
-	gchar *dir_utf8 = g_path_get_dirname (filename);
-	gunichar2 *p;
-	gunichar2 *dir_utf16 = NULL;
-	int retval;
-	
-	if (!dir_utf8 || !dir_utf8 [0])
-		return FALSE;
-
-	dir_utf16 = g_utf8_to_utf16 (dir_utf8, strlen (dir_utf8), NULL, NULL, NULL);
-	g_free (dir_utf8);
-
-	if (!dir_utf16)
-		return FALSE;
-
-	p = dir_utf16;
-
-	/* make life easy and only use one directory seperator */
-	while (*p != '\0')
-	{
-		if (*p == '/')
-			*p = '\\';
-		p++;
-	}
-
-	p = dir_utf16;
-
-	/* get past C:\ )*/
-	while (*p++ != '\\')	
-	{
-	}
-
-	while (1) {
-		BOOL bRet = FALSE;
-		p = wcschr (p, '\\');
-		if (p)
-			*p = '\0';
-		retval = _wmkdir (dir_utf16);
-		if (retval != 0 && errno != EEXIST) {
-			g_free (dir_utf16);
-			return FALSE;
-		}
-		if (!p)
-			break;
-		*p++ = '\\';
-	}
-	
-	g_free (dir_utf16);
-	return TRUE;
-#else
-	char *p;
-	gchar *dir = g_path_get_dirname (filename);
-	int retval;
-	struct stat sbuf;
-	
-	if (!dir || !dir [0]) {
-		g_free (dir);
-		return FALSE;
-	}
-	
-	if (stat (dir, &sbuf) == 0 && S_ISDIR (sbuf.st_mode)) {
-		g_free (dir);
-		return TRUE;
-	}
-	
-	p = dir;
-	while (*p == '/')
-		p++;
-
-	while (1) {
-		p = strchr (p, '/');
-		if (p)
-			*p = '\0';
-		retval = mkdir (dir, 0777);
-		if (retval != 0 && errno != EEXIST) {
-			g_free (dir);
-			return FALSE;
-		}
-		if (!p)
-			break;
-		*p++ = '/';
-	}
-	
-	g_free (dir);
-	return TRUE;
-#endif
-}
-
-static gboolean
 private_file_needs_copying (const char *src, struct stat *sbuf_src, char *dest)
 {
 	struct stat sbuf_dest;
@@ -1798,7 +1707,7 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 		return NULL;
 	}
 
-	if (ensure_directory_exists (shadow) == FALSE) {
+	if (g_ensure_directory_exists (shadow) == FALSE) {
 		g_free (shadow);
 		mono_error_set_execution_engine (oerror, "Failed to create shadow copy (ensure directory exists).");
 		return NULL;

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -456,6 +456,7 @@ ICALL(OBJ_3, "MemberwiseClone", ves_icall_System_Object_MemberwiseClone)
 
 ICALL_TYPE(ASSEM, "System.Reflection.Assembly", ASSEM_1)
 ICALL(ASSEM_1, "FillName", ves_icall_System_Reflection_Assembly_FillName)
+ICALL(ASSEM_1a, "GetAotId", ves_icall_System_Reflection_Assembly_GetAotId)
 ICALL(ASSEM_2, "GetCallingAssembly", ves_icall_System_Reflection_Assembly_GetCallingAssembly)
 ICALL(ASSEM_3, "GetEntryAssembly", ves_icall_System_Reflection_Assembly_GetEntryAssembly)
 ICALL(ASSEM_4, "GetExecutingAssembly", ves_icall_System_Reflection_Assembly_GetExecutingAssembly)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4895,6 +4895,14 @@ ves_icall_System_Reflection_Assembly_GetManifestResourceNames (MonoReflectionAss
 	return result;
 }
 
+ICALL_EXPORT MonoString*
+ves_icall_System_Reflection_Assembly_GetAotId ()
+{
+	guint8* aotid = &mono_domain_get ()->entry_assembly->image->aotid;
+	
+	return mono_string_new (mono_domain_get (), mono_guid_to_string(aotid));
+}
+
 static MonoObject*
 create_version (MonoDomain *domain, guint32 major, guint32 minor, guint32 build, guint32 revision, MonoError *error)
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4898,9 +4898,22 @@ ves_icall_System_Reflection_Assembly_GetManifestResourceNames (MonoReflectionAss
 ICALL_EXPORT MonoString*
 ves_icall_System_Reflection_Assembly_GetAotId ()
 {
-	guint8* aotid = &mono_domain_get ()->entry_assembly->image->aotid;
+	int i;
+	guint8 aotid_sum = 0;
+	MonoDomain* domain = mono_domain_get ();
+
+	if (!domain->entry_assembly || !domain->entry_assembly->image)
+		return NULL;
+
+	guint8 (*aotid)[16] = &domain->entry_assembly->image->aotid;
+
+	for (i = 0; i < 16; ++i)
+		aotid_sum |= (*aotid)[i];
+
+	if (aotid_sum == 0)
+		return NULL;
 	
-	return mono_string_new (mono_domain_get (), mono_guid_to_string(aotid));
+	return mono_string_new (domain, mono_guid_to_string((guint8*) aotid));
 }
 
 static MonoObject*

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -271,6 +271,8 @@ struct _MonoImage {
 
 	gpointer aot_module;
 
+	guint8 aotid[16];
+
 	/*
 	 * The Assembly this image was loaded from.
 	 */

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6069,6 +6069,21 @@ mono_guid_to_string (const guint8 *guid)
 				guid[10], guid[11], guid[12], guid[13], guid[14], guid[15]);
 }
 
+/**
+ * mono_guid_to_string_minimal:
+ *
+ * Converts a 16 byte Microsoft GUID to lower case no '-' representation..
+ */
+char *
+mono_guid_to_string_minimal (const guint8 *guid)
+{
+	return g_strdup_printf ("%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+				guid[3], guid[2], guid[1], guid[0],
+				guid[5], guid[4],
+				guid[7], guid[6],
+				guid[8], guid[9],
+				guid[10], guid[11], guid[12], guid[13], guid[14], guid[15]);
+}
 static gboolean
 get_constraints (MonoImage *image, int owner, MonoClass ***constraints, MonoGenericContainer *container, MonoError *error)
 {

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -480,6 +480,8 @@ MONO_API uint32_t mono_metadata_token_from_dor (uint32_t dor_index);
 
 MONO_API char *mono_guid_to_string (const uint8_t *guid);
 
+MONO_API char *mono_guid_to_string_minimal (const uint8_t *guid);
+
 MONO_API uint32_t mono_metadata_declsec_from_index (MonoImage *meta, uint32_t idx);
 
 MONO_API uint32_t mono_metadata_translate_token_index (MonoImage *image, int table, uint32_t idx);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -114,8 +114,8 @@ typedef struct MonoAotOptions {
 	gboolean soft_debug;
 	gboolean log_generics;
 	gboolean log_instances;
-	gboolean gen_seq_points_file;
-	char *gen_seq_points_file_path;
+	gboolean gen_msym_dir;
+	char *gen_msym_dir_path;
 	gboolean direct_pinvoke;
 	gboolean direct_icalls;
 	gboolean no_direct_calls;
@@ -7041,13 +7041,10 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			opts->ld_flags = g_strdup (arg + strlen ("ld-flags="));			
 		} else if (str_begins_with (arg, "soft-debug")) {
 			opts->soft_debug = TRUE;
-		} else if (str_begins_with (arg, "gen-seq-points-file=")) {
+		} else if (str_begins_with (arg, "msym-dir=")) {
 			debug_options.gen_seq_points_compact_data = TRUE;
-			opts->gen_seq_points_file = TRUE;
-			opts->gen_seq_points_file_path = g_strdup (arg + strlen ("gen-seq-points-file="));;
-		} else if (str_begins_with (arg, "gen-seq-points-file")) {
-			debug_options.gen_seq_points_compact_data = TRUE;
-			opts->gen_seq_points_file = TRUE;
+			opts->gen_msym_dir = TRUE;
+			opts->gen_msym_dir_path = g_strdup (arg + strlen ("msym_dir="));;
 		} else if (str_begins_with (arg, "direct-pinvoke")) {
 			opts->direct_pinvoke = TRUE;
 		} else if (str_begins_with (arg, "direct-icalls")) {
@@ -7115,7 +7112,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			printf ("    tool-prefix=\n");
 			printf ("    readonly-value=\n");
 			printf ("    soft-debug\n");
-			printf ("    gen-seq-points-file\n");
+			printf ("    msym-dir=\n");
 			printf ("    gc-maps\n");
 			printf ("    print-skipped\n");
 			printf ("    no-instances\n");
@@ -8890,7 +8887,7 @@ emit_exception_info (MonoAotCompile *acfg)
 
 			// By design aot-runtime decode_exception_debug_info is not able to load sequence point debug data from a file.
 			// As it is not possible to load debug data from a file its is also not possible to store it in a file.
-			gboolean method_seq_points_to_file = acfg->aot_opts.gen_seq_points_file &&
+			gboolean method_seq_points_to_file = acfg->aot_opts.gen_msym_dir &&
 				cfg->gen_seq_points && !cfg->gen_sdb_seq_points;
 			gboolean method_seq_points_to_binary = cfg->gen_seq_points && !method_seq_points_to_file;
 			
@@ -8910,11 +8907,25 @@ emit_exception_info (MonoAotCompile *acfg)
 	}
 
 	if (seq_points_to_file) {
-		char *seq_points_aot_file = acfg->aot_opts.gen_seq_points_file_path ? acfg->aot_opts.gen_seq_points_file_path
-			: g_strdup_printf("%s%s", acfg->image->name, SEQ_POINT_AOT_EXT);
-		mono_seq_point_data_write (&sp_data, seq_points_aot_file);
+		char *aotid = mono_guid_to_string (acfg->image->aotid);
+		char *dir = g_build_filename (acfg->aot_opts.gen_msym_dir_path, aotid, NULL);
+		char *image_basename = g_path_get_basename (acfg->image->name);
+		char *aot_file = g_strdup_printf("%s%s", image_basename, SEQ_POINT_AOT_EXT);
+		char *aot_file_path = g_build_filename (dir, aot_file, NULL);
+
+		if (g_ensure_directory_exists (aot_file_path) == FALSE) {
+			fprintf (stderr, "AOT : failed to create msym directory: %s\n", aot_file_path);
+			exit (1);
+		}
+
+		mono_seq_point_data_write (&sp_data, aot_file_path);
 		mono_seq_point_data_free (&sp_data);
-		g_free (seq_points_aot_file);
+
+		g_free (aotid);
+		g_free (dir);
+		g_free (image_basename);
+		g_free (aot_file);
+		g_free (aot_file_path);
 	}
 
 	acfg->stats.offsets_size += emit_offset_table (acfg, "ex_info_offsets", MONO_AOT_TABLE_EX_INFO_OFFSETS, acfg->nmethods, 10, offsets);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9513,6 +9513,8 @@ emit_aot_file_info (MonoAotCompile *acfg, MonoAotFileInfo *info)
 	for (i = 0; i < MONO_AOT_TRAMP_NUM; ++i)
 		emit_int32 (acfg, info->tramp_page_code_offsets [i]);
 
+	emit_bytes (acfg, info->aotid, 16);
+
 	if (acfg->aot_opts.static_link) {
 		emit_global_inner (acfg, acfg->static_linking_symbol, FALSE);
 		emit_alignment (acfg, sizeof (gpointer));

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -51,6 +51,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-mmap.h>
+#include <mono/utils/mono-rand.h>
 #include <mono/utils/json.h>
 #include <mono/utils/mono-threads-coop.h>
 
@@ -8860,6 +8861,21 @@ emit_extra_methods (MonoAotCompile *acfg)
 }	
 
 static void
+generate_aotid (guint8* aotid)
+{
+	gpointer *rand_handle;
+	MonoError error;
+
+	mono_rand_open ();
+	rand_handle = mono_rand_init (NULL, 0);
+
+	mono_rand_try_get_bytes (rand_handle, aotid, 16, &error);
+	mono_error_assert_ok (&error);
+
+	mono_rand_close (rand_handle);
+}
+
+static void
 emit_exception_info (MonoAotCompile *acfg)
 {
 	int i;
@@ -9352,6 +9368,8 @@ init_aot_file_info (MonoAotCompile *acfg, MonoAotFileInfo *info)
 	info->nshared_got_entries = acfg->nshared_got_entries;
 	for (i = 0; i < MONO_AOT_TRAMP_NUM; ++i)
 		info->tramp_page_code_offsets [i] = acfg->tramp_page_code_offsets [i];
+
+	generate_aotid(&info->aotid);
 }
 
 static void

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9369,7 +9369,7 @@ init_aot_file_info (MonoAotCompile *acfg, MonoAotFileInfo *info)
 	for (i = 0; i < MONO_AOT_TRAMP_NUM; ++i)
 		info->tramp_page_code_offsets [i] = acfg->tramp_page_code_offsets [i];
 
-	generate_aotid(&info->aotid);
+	memcpy(&info->aotid, acfg->image->aotid, 16);
 }
 
 static void
@@ -10388,6 +10388,12 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options)
 		mono_set_generic_sharing_vt_supported (TRUE);
 
 	aot_printf (acfg, "Mono Ahead of Time compiler - compiling assembly %s\n", image->name);
+
+	generate_aotid ((guint8*) &acfg->image->aotid);
+
+	char *aotid = mono_guid_to_string (acfg->image->aotid);
+	aot_printf (acfg, "AOTID %s\n", aotid);
+	g_free (aotid);
 
 #ifndef MONO_ARCH_HAVE_FULL_AOT_TRAMPOLINES
 	if (mono_aot_mode_is_full (&acfg->aot_opts)) {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8907,7 +8907,7 @@ emit_exception_info (MonoAotCompile *acfg)
 	}
 
 	if (seq_points_to_file) {
-		char *aotid = mono_guid_to_string (acfg->image->aotid);
+		char *aotid = mono_guid_to_string_minimal (acfg->image->aotid);
 		char *dir = g_build_filename (acfg->aot_opts.gen_msym_dir_path, aotid, NULL);
 		char *image_basename = g_path_get_basename (acfg->image->name);
 		char *aot_file = g_strdup_printf("%s%s", image_basename, SEQ_POINT_AOT_EXT);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2016,6 +2016,9 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 		find_symbol (sofile, globals, "mono_aot_file_info", (gpointer*)&info);
 	}
 
+	// Copy aotid to MonoImage
+	memcpy(&assembly->image->aotid, info->aotid, 16);
+
 	if (version_symbol) {
 		/* Old file format */
 		version = atoi (version_symbol);

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8357,6 +8357,19 @@ llvm_array_from_uints (LLVMTypeRef el_type, guint32 *values, int nvalues)
 	return res;
 }
 
+static LLVMValueRef
+llvm_array_from_bytes (guint8 *values, int nvalues)
+{
+	int i;
+	LLVMValueRef res, *vals;
+
+	vals = g_new0 (LLVMValueRef, nvalues);
+	for (i = 0; i < nvalues; ++i)
+		vals [i] = LLVMConstInt (LLVMInt8Type (), values [i], FALSE);
+	res = LLVMConstArray (LLVMInt8Type (), vals, nvalues);
+	g_free (vals);
+	return res;
+}
 /*
  * mono_llvm_emit_aot_file_info:
  *
@@ -8420,7 +8433,7 @@ emit_aot_file_info (MonoLLVMModule *module)
 	info = &module->aot_info;
 
 	/* Create an LLVM type to represent MonoAotFileInfo */
-	nfields = 2 + MONO_AOT_FILE_INFO_NUM_SYMBOLS + 15 + 5;
+	nfields = 2 + MONO_AOT_FILE_INFO_NUM_SYMBOLS + 16 + 5;
 	eltypes = g_new (LLVMTypeRef, nfields);
 	tindex = 0;
 	eltypes [tindex ++] = LLVMInt32Type ();
@@ -8435,6 +8448,7 @@ emit_aot_file_info (MonoLLVMModule *module)
 	eltypes [tindex ++] = LLVMArrayType (LLVMInt32Type (), MONO_AOT_TABLE_NUM);
 	for (i = 0; i < 4; ++i)
 		eltypes [tindex ++] = LLVMArrayType (LLVMInt32Type (), MONO_AOT_TRAMP_NUM);
+	eltypes [tindex ++] = LLVMArrayType (LLVMInt8Type (), 16);
 	g_assert (tindex == nfields);
 	file_info_type = LLVMStructCreateNamed (module->context, "MonoAotFileInfo");
 	LLVMStructSetBody (file_info_type, eltypes, nfields, FALSE);
@@ -8557,6 +8571,8 @@ emit_aot_file_info (MonoLLVMModule *module)
 	fields [tindex ++] = llvm_array_from_uints (LLVMInt32Type (), info->trampoline_got_offset_base, MONO_AOT_TRAMP_NUM);
 	fields [tindex ++] = llvm_array_from_uints (LLVMInt32Type (), info->trampoline_size, MONO_AOT_TRAMP_NUM);
 	fields [tindex ++] = llvm_array_from_uints (LLVMInt32Type (), info->tramp_page_code_offsets, MONO_AOT_TRAMP_NUM);
+
+	fields [tindex ++] = llvm_array_from_bytes (info->aotid, 16);
 	g_assert (tindex == nfields);
 
 	LLVMSetInitializer (info_var, LLVMConstNamedStruct (file_info_type, fields, nfields));

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -307,6 +307,8 @@ typedef struct MonoAotFileInfo
 	guint32 trampoline_size [MONO_AOT_TRAMP_NUM];
 	/* The offset where the trampolines begin on a trampoline page */
 	guint32 tramp_page_code_offsets [MONO_AOT_TRAMP_NUM];
+	/* GUID of aot compilation */
+	guint8 aotid[16];
 } MonoAotFileInfo;
 
 /* Number of symbols in the MonoAotFileInfo structure */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -117,7 +117,7 @@
 #endif
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 133
+#define MONO_AOT_FILE_VERSION 134
 
 //TODO: This is x86/amd64 specific.
 #define mono_simd_shuffle_mask(a,b,c,d) ((a) | ((b) << 2) | ((c) << 4) | ((d) << 6))

--- a/mono/tests/exception18.cs
+++ b/mono/tests/exception18.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 class C
 {
@@ -17,6 +18,10 @@ class C
 	{
 			string fullTrace = ex.StackTrace;
 			string[] frames = fullTrace.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+
+			// Ignore metadata
+			frames = frames.Where (l => !l.StartsWith ("[")).ToArray ();
+
 			return frames.Length;
 	}
 


### PR DESCRIPTION
This is proposing changes that would make the symbolicate work with a directory of symbols and any stacktrace dump only. We already have native offsets, and IL offsets in stacktraces, the idea is to add more details so we can retrieve the exact symbols. 
We could probably find another solution, but this solution only requires a directory with the symbols of multiple versions of the app and it will know from the stacktraces metadata which symbols to use.

The metadata, extra noise, we are adding is a compromise so we can link stack traces to the correct symbols versions in a simple and reliable way.

More details can be read on the [spec](https://docs.google.com/document/d/1ohn_RfGvqWv9EDAPN3GxkM5Ri8GZRbcL3bT0TPj1isg/edit?usp=sharing).

This pull request includes all the implementation changes discussed in the spec, except the non main modules MVID directories.