### PR TITLE
Defer bridge processor init until after sgen init, fixing crash (bug 42469)

### DIFF
--- a/mono/metadata/sgen-bridge-internals.h
+++ b/mono/metadata/sgen-bridge-internals.h
@@ -64,6 +64,7 @@ void sgen_new_bridge_init (SgenBridgeProcessor *collector);
 void sgen_tarjan_bridge_init (SgenBridgeProcessor *collector);
 void sgen_set_bridge_implementation (const char *name);
 void sgen_bridge_set_dump_prefix (const char *prefix);
+void sgen_init_bridge_processor();
 
 #endif
 

--- a/mono/metadata/sgen-bridge.h
+++ b/mono/metadata/sgen-bridge.h
@@ -95,6 +95,7 @@ typedef struct {
 	void (*cross_references) (int num_sccs, MonoGCBridgeSCC **sccs, int num_xrefs, MonoGCBridgeXRef *xrefs);
 } MonoGCBridgeCallbacks;
 
+// Clients should call before initializing runtime.
 MONO_API void mono_gc_register_bridge_callbacks (MonoGCBridgeCallbacks *callbacks);
 
 MONO_API void mono_gc_wait_for_bridge_processing (void);

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -3142,6 +3142,8 @@ sgen_gc_init (void)
 
 	sgen_register_root (NULL, 0, sgen_make_user_root_descriptor (sgen_mark_normal_gc_handles), ROOT_TYPE_NORMAL, MONO_ROOT_SOURCE_GC_HANDLE, "normal gc handles");
 
+	sgen_init_bridge_processor();
+
 	gc_initialized = 1;
 }
 

--- a/mono/sgen/sgen-internal.c
+++ b/mono/sgen/sgen-internal.c
@@ -96,8 +96,10 @@ sgen_register_fixed_internal_mem_type (int type, size_t size)
 
 	if (fixed_type_allocator_indexes [type] == -1)
 		fixed_type_allocator_indexes [type] = slot;
-	else
-		g_assert (fixed_type_allocator_indexes [type] == slot);
+	else {
+		if (fixed_type_allocator_indexes [type] != slot)
+			g_error ("Invalid double registration of type %d old slot %d new slot %d", type, fixed_type_allocator_indexes [type], slot);
+	}
 }
 
 static const char*


### PR DESCRIPTION
mono_gc_register_bridge_callbacks is a function which the android implementation calls before initializing the runtime. One of the things this function previously did was initialize the default bridge processor if none has been initialized yet. However, because the function gets called before initializing the runtime, a bridge processor was never initialized. This lead to two bad effects:

- If a bridge processor was ever manually specified, the bridge processor would get initialized twice
- Tarjan crashes if initialized before sgen, so when Tarjan became the default bridge processor Android always crashed on launch

The default bridge processor is now initialized at the end of sgen_gc_init. Also the error message when sgen_register_fixed_internal_mem_type fails is now more verbose.