### PR TITLE
[runtime] Enable compact seq point by default

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1652,11 +1652,11 @@ Automatically generates sequence points where the
 IL stack is empty.  These are places where the debugger can set a
 breakpoint.
 .TP
-\fBgen-compact-seq-points\fR
-This option generates sequence points data that maps native offsets to
-IL offsets. Sequence point data is used to display IL offset in
-stacktraces. Stacktraces with IL offsets can be symbolicated using
-mono-symbolicate tool.
+\fBno-compact-seq-points\fR
+Unless the option is used, the runtime generates sequence points data that
+maps native offsets to IL offsets. Sequence point data is used to
+display IL offset in stacktraces. Stacktraces with IL offsets can be
+symbolicated using mono-symbolicate tool.
 .TP
 \fBhandle-sigint\fR
 Captures the interrupt signal (Control-C) and displays a stack trace

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -24,7 +24,7 @@ SYMBOLICATE_RESULT_FILE = $(OUT_DIR)/symbolicate.result
 SYMBOLICATE_EXPECTED_FILE = Test/symbolicate.expected
 
 CHECK_DIFF = @\
-	MONO_DEBUG=gen-compact-seq-points $(MONO) $(TEST_EXE) > $(STACKTRACE_FILE); \
+	$(MONO) $(TEST_EXE) > $(STACKTRACE_FILE); \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) $(MSYM_DIR) $(STACKTRACE_FILE) > $(SYMBOLICATE_RAW_FILE); \
 	sed "s/).*Test\//) in /" $(SYMBOLICATE_RAW_FILE) | sed '/\[MVID\]/d' | sed '/\[AOTID\]/d' > $(SYMBOLICATE_RESULT_FILE); \
 	DIFF=$$(diff $(SYMBOLICATE_RESULT_FILE) $(SYMBOLICATE_EXPECTED_FILE)); \
@@ -64,7 +64,7 @@ ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
 	$(COMPILE)
-	@MONO_DEBUG=gen-compact-seq-points $(MONO) --aot $(TEST_EXE) > /dev/null
+	@$(MONO) --aot $(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
 endif
 
@@ -74,6 +74,6 @@ ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT (using .msym) in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
 	$(COMPILE)
-	@MONO_DEBUG=gen-compact-seq-points $(MONO) --aot=msym-dir=$(MSYM_DIR) $(TEST_EXE) > /dev/null
+	@$(MONO) --aot=msym-dir=$(MSYM_DIR) $(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
 endif

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7051,7 +7051,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 		} else if (str_begins_with (arg, "soft-debug")) {
 			opts->soft_debug = TRUE;
 		} else if (str_begins_with (arg, "msym-dir=")) {
-			debug_options.gen_seq_points_compact_data = TRUE;
+			debug_options.no_seq_points_compact_data = FALSE;
 			opts->gen_msym_dir = TRUE;
 			opts->gen_msym_dir_path = g_strdup (arg + strlen ("msym_dir="));;
 		} else if (str_begins_with (arg, "direct-pinvoke")) {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7050,6 +7050,8 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			opts->ld_flags = g_strdup (arg + strlen ("ld-flags="));			
 		} else if (str_begins_with (arg, "soft-debug")) {
 			opts->soft_debug = TRUE;
+		} else if (str_begins_with (arg, "gen-seq-points-file=")) {
+			fprintf (stderr, "Mono Warning: aot option gen-seq-points-file= is deprecated.\n");
 		} else if (str_begins_with (arg, "msym-dir=")) {
 			debug_options.no_seq_points_compact_data = FALSE;
 			opts->gen_msym_dir = TRUE;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3157,7 +3157,9 @@ mini_parse_debug_option (const char *option)
 	else if (!strcmp (option, "gen-seq-points"))
 		debug_options.gen_sdb_seq_points = TRUE;
 	else if (!strcmp (option, "gen-compact-seq-points"))
-		debug_options.gen_seq_points_compact_data = TRUE;
+		fprintf (stderr, "Mono Warning: option gen-compact-seq-points is deprecated.\n");
+	else if (!strcmp (option, "no-compact-seq-points"))
+		debug_options.no_seq_points_compact_data = TRUE;
 	else if (!strcmp (option, "single-imm-size"))
 		debug_options.single_imm_size = TRUE;
 	else if (!strcmp (option, "init-stacks"))
@@ -3202,7 +3204,7 @@ mini_parse_debug_options (void)
 
 		if (!mini_parse_debug_option (arg)) {
 			fprintf (stderr, "Invalid option for the MONO_DEBUG env variable: %s\n", arg);
-			fprintf (stderr, "Available options: 'handle-sigint', 'keep-delegates', 'reverse-pinvoke-exceptions', 'collect-pagefault-stats', 'break-on-unverified', 'no-gdb-backtrace', 'suspend-on-sigsegv', 'suspend-on-exception', 'suspend-on-unhandled', 'dont-free-domains', 'dyn-runtime-invoke', 'gdb', 'explicit-null-checks', 'gen-seq-points', 'gen-compact-seq-points', 'single-imm-size', 'init-stacks', 'casts', 'soft-breakpoints', 'check-pinvoke-callconv', 'arm-use-fallback-tls', 'debug-domain-unload', 'partial-sharing', 'align-small-structs', 'native-debugger-break'\n");
+			fprintf (stderr, "Available options: 'handle-sigint', 'keep-delegates', 'reverse-pinvoke-exceptions', 'collect-pagefault-stats', 'break-on-unverified', 'no-gdb-backtrace', 'suspend-on-sigsegv', 'suspend-on-exception', 'suspend-on-unhandled', 'dont-free-domains', 'dyn-runtime-invoke', 'gdb', 'explicit-null-checks', 'gen-seq-points', 'no-compact-seq-points', 'single-imm-size', 'init-stacks', 'casts', 'soft-breakpoints', 'check-pinvoke-callconv', 'arm-use-fallback-tls', 'debug-domain-unload', 'partial-sharing', 'align-small-structs', 'native-debugger-break'\n");
 			exit (1);
 		}
 	}

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3241,7 +3241,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	cfg->disable_omit_fp = debug_options.disable_omit_fp;
 	cfg->skip_visibility = method->skip_visibility;
 	cfg->orig_method = method;
-	cfg->gen_seq_points = debug_options.gen_seq_points_compact_data || debug_options.gen_sdb_seq_points;
+	cfg->gen_seq_points = !debug_options.no_seq_points_compact_data || debug_options.gen_sdb_seq_points;
 	cfg->gen_sdb_seq_points = debug_options.gen_sdb_seq_points;
 	cfg->llvm_only = (flags & JIT_FLAG_LLVM_ONLY) != 0;
 	cfg->backend = current_backend;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2121,7 +2121,7 @@ typedef struct {
 	 * Next sequence points and flags are required by the debugger agent.
 	 */
 	gboolean gen_sdb_seq_points;
-	gboolean gen_seq_points_compact_data;
+	gboolean no_seq_points_compact_data;
 	/*
 	 * Setting single_imm_size should guarantee that each time managed code is compiled
 	 * the same instructions and registers are used, regardless of the size of used values.

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -49,16 +49,16 @@ get_method () {
 diff_methods () {
 	TMP_FILE1=$(tmp_file)
 	TMP_FILE2=$(tmp_file)
-	echo "$(MONO_DEBUG=single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE1
-	echo "$(MONO_DEBUG=gen-compact-seq-points,single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE2
+	echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE1
+	echo "$(MONO_DEBUG=single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE2
 	diff $TMP_FILE1 $TMP_FILE2
 }
 
 diff_method () {
 	TMP_FILE1=$(tmp_file)
 	TMP_FILE2=$(tmp_file)
-	echo "$(MONO_DEBUG=single-imm-size get_method $1 $2 $3 $4 $5)" >$TMP_FILE1
-	echo "$(MONO_DEBUG=gen-compact-seq-points,single-imm-size get_method $1 $2 $3 $4 $5 | grep -Ev il_seq_point)" >$TMP_FILE2
+	echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_method $1 $2 $3 $4 $5)" >$TMP_FILE1
+	echo "$(MONO_DEBUG=single-imm-size get_method $1 $2 $3 $4 $5 | grep -Ev il_seq_point)" >$TMP_FILE2
 	sdiff -w 150 $TMP_FILE1 $TMP_FILE2
 }
 


### PR DESCRIPTION
Enable compact seq points by default so that the stack trace have IL
offsets instead os native ones.

This changes will allow any stacktrace generated from now on to be
symbolicated using mono-symbolicate.