### PR TITLE
[logging] Default to stdout if MONO_LOG_DEST is unset

### DIFF
--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -148,7 +148,7 @@ mono_trace_set_logdest_string (const char *dest)
 	if(level_stack == NULL)
 		mono_trace_init();
 
-	if ((dest != NULL) && (strcmp("syslog", dest) != 0)) {
+	if ((dest == NULL) || (strcmp("syslog", dest) != 0)) {
 		logger.opener = mono_log_open_logfile;
 		logger.writer = mono_log_write_logfile;
 		logger.closer = mono_log_close_logfile;


### PR DESCRIPTION
Follow up to e70a8aca1cd575582459db406ab3410e53074b73, do what the man
page says and default to stdout if MONO_LOG_DEST isn't specified.