### PR TITLE
[sgen] Initialize stack_start to 0 when a thread is signaled for stw

### DIFF
--- a/mono/metadata/sgen-os-posix.c
+++ b/mono/metadata/sgen-os-posix.c
@@ -46,6 +46,7 @@ suspend_thread (SgenThreadInfo *info, void *context)
 	gpointer stack_start;
 
 	info->client_info.stopped_domain = mono_domain_get ();
+	info->client_info.stack_start = NULL;
 	info->client_info.signal = 0;
 	stop_count = sgen_global_stop_count;
 	/* duplicate signal */


### PR DESCRIPTION
If we have an invalid SP in the suspended thread, we don't set stack_start in the thread info, expecting it to be 0 in order to signal a resume and suspend retry to the suspender thread. If the thread was already restarted before (from a different reason like IP in critical section), it would have a nonzero stack_start from the previous suspend, leading to an assertion in the previously described case.

This is also what we do on mach.