### PR TITLE
Fix compilation of AOT-less Mono

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5834,7 +5834,7 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method)
 
 gpointer
 mono_aot_get_method_checked (MonoDomain *domain,
-							 MonoMethod *method, MonoError *error);
+							 MonoMethod *method, MonoError *error)
 {
 	mono_error_init (error);
 	return NULL;


### PR DESCRIPTION
```
aot-runtime.c:5838:1: error: expected identifier or ‘(’ before ‘{’ token
 {
 ^
```