### PR TITLE
Threads: Increase timeouts

### DIFF
--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -75,10 +75,10 @@ static gboolean unified_suspend_enabled;
 
 #define mono_thread_info_run_state(info) (((MonoThreadInfo*)info)->thread_state & THREAD_STATE_MASK)
 
-/*warn at 50 ms*/
-#define SLEEP_DURATION_BEFORE_WARNING (10)
-/*abort at 1 sec*/
-#define SLEEP_DURATION_BEFORE_ABORT 200
+/*warn at 15 ms*/
+#define SLEEP_DURATION_BEFORE_WARNING (15)
+/*abort at 300 ms*/
+#define SLEEP_DURATION_BEFORE_ABORT 300
 
 static long sleepWarnDuration = SLEEP_DURATION_BEFORE_WARNING,
 	    sleepAbortDuration = SLEEP_DURATION_BEFORE_ABORT;

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -31,6 +31,7 @@
 #include <mono/utils/mono-threads-coop.h>
 
 #include <errno.h>
+#include <limits.h>
 
 #if defined(__MACH__)
 #include <mono/utils/mach-support.h>
@@ -75,10 +76,10 @@ static gboolean unified_suspend_enabled;
 
 #define mono_thread_info_run_state(info) (((MonoThreadInfo*)info)->thread_state & THREAD_STATE_MASK)
 
-/*warn at 15 ms*/
-#define SLEEP_DURATION_BEFORE_WARNING (15)
-/*abort at 300 ms*/
-#define SLEEP_DURATION_BEFORE_ABORT 300
+/*don't warn by default*/
+#define SLEEP_DURATION_BEFORE_WARNING LONG_MAX
+/*don't abort by default*/
+#define SLEEP_DURATION_BEFORE_ABORT LONG_MAX
 
 static long sleepWarnDuration = SLEEP_DURATION_BEFORE_WARNING,
 	    sleepAbortDuration = SLEEP_DURATION_BEFORE_ABORT;


### PR DESCRIPTION
Default values were changed quite long ago, in https://github.com/mono/mono/commit/084cb4d103acfe0342af0eed6b47952d9c7805a3

We had abort at 1000 ms back then, which was more than required. Now abort is set at 200 ms, but this value is a bit too low for low-end machines running programs that are doing many (async) tasks on the threadpool in background, like mine:

```
WAITING for 12 threads, got 11 suspended
suspend_thread suspend took 202 ms, which is more than the allowed 200 ms
...
Native stacktrace:

        mono() [0x492e2f]
        /lib/x86_64-linux-gnu/libpthread.so.0(+0x10ed0) [0x7f81ec3b5ed0]
        /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x38) [0x7f81ebe211c8]
        /lib/x86_64-linux-gnu/libc.so.6(abort+0x16a) [0x7f81ebe2264a]
        mono() [0x6445a9]
        mono() [0x644893]
        mono() [0x6353b4]
        mono() [0x5dd799]
        mono() [0x5eb3ea]
        mono() [0x5de663]
        mono() [0x5deb20]
        mono() [0x5c2799]
        [0x41dc2c6c]

Debug info from gdb:


=================================================================
Got a SIGABRT while executing native code. This usually indicates
a fatal error in the mono runtime or one of the native libraries
used by your application.
=================================================================
```

Valid apps and setups are getting ```SIGABRT```ed due to running (only a bit) above threshold.

Therefore, I'd like to slightly increase the timeout, from ```200``` to ```300``` ms, which would solve my issue without resorting to setting it through environment property.

I know that this issue is specific because most likely nobody is running into such problems with more powerful machines, but for low-end servers running with low tick frequency and slower CPUs, this might be a really good change.

Note: ```SLEEP_DURATION_BEFORE_WARNING``` doesn't seem to be used anymore, but I adapted it for consistency, as well as corrected outdated comments.