### PR TITLE
Mono sym fixes

### DIFF
--- a/mcs/tools/mono-symbolicate/LocationProvider.cs
+++ b/mcs/tools/mono-symbolicate/LocationProvider.cs
@@ -12,10 +12,12 @@ namespace Mono
 	class AssemblyLocationProvider
 	{
 		AssemblyDefinition assembly;
+		Logger logger;
 
-		public AssemblyLocationProvider (string assemblyPath)
+		public AssemblyLocationProvider (string assemblyPath, Logger logger)
 		{
 			assemblyPath = Path.GetFullPath (assemblyPath);
+			this.logger = logger;
 
 			if (!File.Exists (assemblyPath))
 				throw new ArgumentException ("assemblyPath does not exist: "+ assemblyPath);
@@ -33,9 +35,10 @@ namespace Mono
 			var nested = sfData.TypeFullName.Split ('+');
 			var types = assembly.MainModule.Types;
 			foreach (var ntype in nested) {
-				type = types.FirstOrDefault (t => t.Name == ntype);
-				if (type == null)
+				if (type == null) {
+					logger.LogWarning ("Could not find type: {0}", ntype);
 					return false;
+				}
 
 				types = type.NestedTypes;
 			}
@@ -44,8 +47,10 @@ namespace Mono
 			var methodName = sfData.MethodSignature.Substring (0, parensStart).TrimEnd ();
 			var methodParameters = sfData.MethodSignature.Substring (parensStart);
 			var method = type.Methods.FirstOrDefault (m => CompareName (m, methodName) && CompareParameters (m.Parameters, methodParameters));
-			if (method == null)
+			if (method == null) {
+				logger.LogWarning ("Could not find method: {0}", methodName);
 				return false;
+			}
 
 			int ilOffset;
 			if (sfData.IsILOffset) {

--- a/mcs/tools/mono-symbolicate/LocationProvider.cs
+++ b/mcs/tools/mono-symbolicate/LocationProvider.cs
@@ -36,6 +36,13 @@ namespace Mono
 			var types = assembly.MainModule.Types;
 			foreach (var ntype in nested) {
 				if (type == null) {
+					// Use namespace first time.
+					type = types.FirstOrDefault (t => t.FullName == ntype);
+				} else {
+					type = types.FirstOrDefault (t => t.Name == ntype);
+				}
+
+				if (type == null) {
 					logger.LogWarning ("Could not find type: {0}", ntype);
 					return false;
 				}

--- a/mcs/tools/mono-symbolicate/Logger.cs
+++ b/mcs/tools/mono-symbolicate/Logger.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Mono
+{
+	public class Logger
+	{
+		public enum Level
+		{
+			Debug = 1,
+			Warning = 2,
+			Error = 3,
+			None = 4,
+		}
+
+		Level level;
+		Action<string> logAction;
+
+		public Logger (Level level, Action<string> logAction)
+		{
+			this.level = level;
+			this.logAction = logAction;
+		}
+
+		public void LogDebug (string str, params string[] vals)
+		{
+			Log (Level.Debug, "Debug: " + str, vals);
+		}
+
+		public void LogWarning (string str, params string[] vals)
+		{
+			Log (Level.Warning, "Warning: " + str, vals);
+		}
+
+		public void LogError (string str, params string[] vals)
+		{
+			Log (Level.Error, "Error: " + str, vals);
+		}
+
+		private void Log (Level msgLevel, string str, params string[] vals)
+		{
+			if ((int) level > (int) msgLevel)
+				return;
+
+			logAction (string.Format (str, vals));
+		}
+	}
+}
+

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -43,7 +43,8 @@ PREPARE_OUTDIR = @\
 
 COMPILE = \
 	$(CSCOMPILE) $(TEST_CS) -out:$(TEST_EXE); \
-	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(OUT_DIR)
+	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(OUT_DIR); \
+	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(LIB_PATH);
 
 check: test-local
 

--- a/mcs/tools/mono-symbolicate/StackFrameData.cs
+++ b/mcs/tools/mono-symbolicate/StackFrameData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 using System.Globalization;
 
@@ -14,6 +15,8 @@ namespace Mono
 		public readonly uint MethodIndex;
 		public readonly string Line;
 
+		public readonly bool IsValid;
+
 		public string File { get; private set; }
 		public int LineNumber { get; private set; }
 
@@ -27,6 +30,15 @@ namespace Mono
 			Offset = offset;
 			IsILOffset = isILOffset;
 			MethodIndex = methodIndex;
+
+			IsValid = true;
+		}
+
+		private StackFrameData (string line)
+		{
+			LineNumber = -1;
+
+			Line = line;
 		}
 
 		public static bool TryParse (string line, out StackFrameData stackFrame)
@@ -34,8 +46,13 @@ namespace Mono
 			stackFrame = null;
 
 			var match = regex.Match (line);
-			if (!match.Success)
+			if (!match.Success) {
+				if (line.Trim ().StartsWith ("at ", StringComparison.InvariantCulture)) {
+					stackFrame = new StackFrameData (line);
+					return true;
+				}
 				return false;
+			}
 
 			string typeFullName, methodSignature;
 			var methodStr = match.Groups ["Method"].Value.Trim ();

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -109,8 +109,11 @@ namespace Mono
 					var mvid = assembly.MainModule.Mvid.ToString ("N");
 					var mvidDir = Path.Combine (msymDir, mvid);
 
-					if (Directory.Exists (mvidDir))
-						Directory.Delete (mvidDir, true);
+					if (Directory.Exists (mvidDir)) {
+						try {
+							Directory.Delete (mvidDir, true);
+						} catch (DirectoryNotFoundException e) {}
+					}
 
 					Directory.CreateDirectory (mvidDir);
 

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -20,6 +20,8 @@ namespace Mono
 		internal bool TryResolveLocation (StackFrameData sfData, string mvid, string aotid)
 		{
 			var assemblyLocProvider = GetOrCreateAssemblyLocationProvider (mvid);
+			if (assemblyLocProvider == null)
+				return false;
 
 			SeqPointInfo seqPointInfo = null;
 			if (!sfData.IsILOffset && aotid != null)
@@ -36,8 +38,10 @@ namespace Mono
 				return assemblies[mvid];
 
 			var mvidDir = Path.Combine (msymDir, mvid);
-			if (!Directory.Exists (mvidDir))
-				throw new Exception (string.Format("MVID directory does not exist: {0}", mvidDir));
+			if (!Directory.Exists (mvidDir)) {
+				Console.Error.WriteLine ("MVID directory does not exist: {0}", mvidDir);
+				return  null;
+			}
 
 			string assemblyPath = null;
 			var exeFiles = Directory.GetFiles (mvidDir, "*.exe");

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -19,6 +19,9 @@ namespace Mono
 
 		internal bool TryResolveLocation (StackFrameData sfData, string mvid, string aotid)
 		{
+			if (mvid == null)
+				return false;
+
 			var assemblyLocProvider = GetOrCreateAssemblyLocationProvider (mvid);
 			if (assemblyLocProvider == null)
 				return false;

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -102,6 +102,9 @@ namespace Mono
 					var mvid = assembly.MainModule.Mvid.ToString ("N");
 					var mvidDir = Path.Combine (msymDir, mvid);
 
+					if (Directory.Exists (mvidDir))
+						Directory.Delete (mvidDir, true);
+
 					Directory.CreateDirectory (mvidDir);
 
 					var mvidAssemblyPath = Path.Combine (mvidDir, Path.GetFileName (assemblyPath));

--- a/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
+++ b/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
@@ -46,6 +46,11 @@ class StackTraceDumper {
 		Catch (() => InnerGenericClass<string>.InnerInnerGenericClass<int>.ThrowException ("Stack trace with 2 inner generic class and generic overload"));
 
 		Catch (() => InnerGenericClass<int>.InnerInnerGenericClass<string>.ThrowException ("Stack trace with 2 inner generic class and generic overload"));
+
+		Catch (() => {
+			var d = new Dictionary<string, string> ();
+			d.ContainsKey (null); // ArgumentNullException
+		});
 	}
 
 	public static void Catch (Action action)

--- a/mcs/tools/mono-symbolicate/Test/symbolicate.expected
+++ b/mcs/tools/mono-symbolicate/Test/symbolicate.expected
@@ -5,127 +5,141 @@ Stacktrace:
 
 System.Exception: Stacktrace with 2 frames
   at StackTraceDumper.<Main>m__0 () in StackTraceDumper.cs:16 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
   at StackTraceDumper.<Main>m__0 () in StackTraceDumper.cs:16 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stacktrace with 3 frames
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:83 
   at StackTraceDumper.<Main>m__1 () in StackTraceDumper.cs:18 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:83 
   at StackTraceDumper.<Main>m__1 () in StackTraceDumper.cs:18 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stacktrace with 4 frames
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:76 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:83 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:81 
   at StackTraceDumper.<Main>m__2 () in StackTraceDumper.cs:20 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:76 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:83 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:81 
   at StackTraceDumper.<Main>m__2 () in StackTraceDumper.cs:20 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack frame with method overload using ref parameter
-  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:70 
+  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:75 
   at StackTraceDumper.<Main>m__3 () in StackTraceDumper.cs:24 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:70 
+  at StackTraceDumper.ThrowException (System.String& message) in StackTraceDumper.cs:75 
   at StackTraceDumper.<Main>m__3 () in StackTraceDumper.cs:24 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack frame with method overload using out parameter
-  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:83 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:88 
   at StackTraceDumper.<Main>m__4 () in StackTraceDumper.cs:29 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:83 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in StackTraceDumper.cs:88 
   at StackTraceDumper.<Main>m__4 () in StackTraceDumper.cs:29 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack frame with 1 generic parameter
-  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:88 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:93 
   at StackTraceDumper.<Main>m__5 () in StackTraceDumper.cs:32 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:88 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in StackTraceDumper.cs:93 
   at StackTraceDumper.<Main>m__5 () in StackTraceDumper.cs:32 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack frame with 2 generic parameters
-  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:108 
+  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:113 
   at StackTraceDumper.<Main>m__6 () in StackTraceDumper.cs:34 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:108 
+  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in StackTraceDumper.cs:113 
   at StackTraceDumper.<Main>m__6 () in StackTraceDumper.cs:34 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack frame with generic method overload
-  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:93 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:98 
   at StackTraceDumper.<Main>m__7 () in StackTraceDumper.cs:36 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:93 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in StackTraceDumper.cs:98 
   at StackTraceDumper.<Main>m__7 () in StackTraceDumper.cs:36 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack trace with inner class
-  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:114 
+  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:119 
   at StackTraceDumper.<Main>m__8 () in StackTraceDumper.cs:38 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:114 
+  at StackTraceDumper+InnerClass.ThrowException (System.String message) in StackTraceDumper.cs:119 
   at StackTraceDumper.<Main>m__8 () in StackTraceDumper.cs:38 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack trace with inner generic class
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:121 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:126 
   at StackTraceDumper.<Main>m__9 () in StackTraceDumper.cs:40 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:121 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in StackTraceDumper.cs:126 
   at StackTraceDumper.<Main>m__9 () in StackTraceDumper.cs:40 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Generic to string:string
 
 System.Exception: Stack trace with inner generic class and method generic parameter
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:127 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:132 
   at StackTraceDumper.<Main>m__A () in StackTraceDumper.cs:42 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:127 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in StackTraceDumper.cs:132 
   at StackTraceDumper.<Main>m__A () in StackTraceDumper.cs:42 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack trace with inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:132 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:137 
   at StackTraceDumper.<Main>m__B () in StackTraceDumper.cs:44 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:132 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in StackTraceDumper.cs:137 
   at StackTraceDumper.<Main>m__B () in StackTraceDumper.cs:44 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack trace with 2 inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:138 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:143 
   at StackTraceDumper.<Main>m__C () in StackTraceDumper.cs:46 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:138 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in StackTraceDumper.cs:143 
   at StackTraceDumper.<Main>m__C () in StackTraceDumper.cs:46 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 
 System.Exception: Stack trace with 2 inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:143 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:148 
   at StackTraceDumper.<Main>m__D () in StackTraceDumper.cs:48 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:143 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in StackTraceDumper.cs:148 
   at StackTraceDumper.<Main>m__D () in StackTraceDumper.cs:48 
-  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
+
+System.ArgumentNullException: Value cannot be null.
+Parameter name: key
+  at System.ThrowHelper.ThrowArgumentNullException (System.ExceptionArgument argument) [0x00006] in /Users/marcos/dev/mono/mono8/mcs/class/referencesource/mscorlib/system/throwhelper.cs:80 
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) [0x0000b] in /Users/marcos/dev/mono/mono8/mcs/class/referencesource/mscorlib/system/collections/generic/dictionary.cs:299 
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].ContainsKey (TKey key) [0x00000] in /Users/marcos/dev/mono/mono8/mcs/class/referencesource/mscorlib/system/collections/generic/dictionary.cs:228 
+  at StackTraceDumper.<Main>m__E () in StackTraceDumper.cs:52 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 
+Stacktrace:
+  at System.ThrowHelper.ThrowArgumentNullException (System.ExceptionArgument argument) [0x00006] in /Users/marcos/dev/mono/mono8/mcs/class/referencesource/mscorlib/system/throwhelper.cs:80 
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) [0x0000b] in /Users/marcos/dev/mono/mono8/mcs/class/referencesource/mscorlib/system/collections/generic/dictionary.cs:299 
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].ContainsKey (TKey key) [0x00000] in /Users/marcos/dev/mono/mono8/mcs/class/referencesource/mscorlib/system/collections/generic/dictionary.cs:228 
+  at StackTraceDumper.<Main>m__E () in StackTraceDumper.cs:52 
+  at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:59 

--- a/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
+++ b/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
@@ -4,4 +4,5 @@ SeqPointInfo.cs
 StackFrameData.cs
 StackTraceMetadata.cs
 SymbolManager.cs
+Logger.cs
 ../../class/Mono.Options/Mono.Options/Options.cs

--- a/mcs/tools/mono-symbolicate/symbolicate.cs
+++ b/mcs/tools/mono-symbolicate/symbolicate.cs
@@ -32,15 +32,6 @@ namespace Mono
 
 			Command cmd = null;
 
-			if (args[0] == "store-symbols")
-				cmd = new Command (StoreSymbolsAction, 2);
-
-			if (cmd != null) {
-				args = args.Skip (1).ToArray ();
-			} else {
-				cmd = new Command (SymbolicateAction, 2, 2);
-			}
-
 			var logLevel = Logger.Level.Warning;
 
 			var options = new OptionSet {
@@ -56,9 +47,18 @@ namespace Mono
 				showHelp = true;
 			}
 
+			if (extra.Count > 0 && extra[0] == "store-symbols")
+				cmd = new Command (StoreSymbolsAction, 2);
+
+			if (cmd != null) {
+				extra.RemoveAt (0);
+			} else {
+				cmd = new Command (SymbolicateAction, 2, 2);
+			}
+
 			if (showHelp || extra == null || extra.Count < cmd.MinArgCount || extra.Count > cmd.MaxArgCount) {
-				Console.Error.WriteLine ("Usage: symbolicate <msym dir> <input file>");
-				Console.Error.WriteLine ("       symbolicate store-symbols <msym dir> [<dir>]+");
+				Console.Error.WriteLine ("Usage: symbolicate [options] <msym dir> <input file>");
+				Console.Error.WriteLine ("       symbolicate [options] store-symbols <msym dir> [<dir>]+");
 				Console.WriteLine ();
 				Console.WriteLine ("Available options:");
 				options.WriteOptionDescriptions (Console.Out);

--- a/mcs/tools/mono-symbolicate/symbolicate.cs
+++ b/mcs/tools/mono-symbolicate/symbolicate.cs
@@ -23,6 +23,8 @@ namespace Mono
 			}
 		}
 
+		static Logger logger;
+
 		public static int Main (String[] args)
 		{
 			var showHelp = false;
@@ -39,8 +41,12 @@ namespace Mono
 				cmd = new Command (SymbolicateAction, 2, 2);
 			}
 
+			var logLevel = Logger.Level.Warning;
+
 			var options = new OptionSet {
 				{ "h|help", "Show this help", v => showHelp = true },
+				{ "q", "Quiet, warnings are not displayed", v => logLevel = Logger.Level.Error },
+				{ "v", "Verbose, log debug messages", v => logLevel = Logger.Level.Debug },
 			};
 
 			try {
@@ -59,6 +65,8 @@ namespace Mono
 				return 1;
 			}
 
+			logger = new Logger (logLevel, msg => Console.Error.WriteLine (msg));
+
 			cmd.Action (extra);
 
 			return 0;
@@ -69,7 +77,7 @@ namespace Mono
 			var msymDir = args [0];
 			var inputFile = args [1];
 
-			var symbolManager = new SymbolManager (msymDir);
+			var symbolManager = new SymbolManager (msymDir, logger);
 
 			using (StreamReader r = new StreamReader (inputFile)) {
 				var sb = Process (r, symbolManager);
@@ -82,7 +90,7 @@ namespace Mono
 			var msymDir = args[0];
 			var lookupDirs = args.Skip (1).ToArray ();
 
-			var symbolManager = new SymbolManager (msymDir);
+			var symbolManager = new SymbolManager (msymDir, logger);
 
 			symbolManager.StoreSymbols (lookupDirs);
 		}

--- a/mcs/tools/mono-symbolicate/symbolicate.cs
+++ b/mcs/tools/mono-symbolicate/symbolicate.cs
@@ -145,11 +145,14 @@ namespace Mono
 				aotid = aotidMetadata.Value;
 
 			var linesMvid = ProcessLinesMVID (metadata);
-			var lineNumber = 0;
+			var lineNumber = -1;
 			foreach (var sfData in stackFrames) {
 				string mvid = null;
+				lineNumber++;
+				if (!sfData.IsValid)
+					continue;
 				if (linesMvid.ContainsKey (lineNumber))
-					mvid = linesMvid [lineNumber++];
+					mvid = linesMvid [lineNumber];
 
 				symbolManager.TryResolveLocation (sfData, mvid, aotid);
 


### PR DESCRIPTION
BCL symbols are now added to tests symbol directories.
We now test a stacktrace with stackframes on mscorlib.

Added logger to mono-symbolicate, so we can add debug, warning and error
log messages.

Fixes multiple crashes.