### PR TITLE
[c8][threadpool-ms] Switch to GC Safe mode in event_wait backends

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -309,6 +310,10 @@ public class Tests : TestsBase, ITest2
 		}
 		if (args.Length >0 && args [0] == "wait-one") {
 			wait_one ();
+			return 0;
+		}
+		if (args.Length >0 && args [0] == "threadpool-io") {
+			threadpool_io ();
 			return 0;
 		}
 		breakpoints ();
@@ -1540,6 +1545,20 @@ public class Tests : TestsBase, ITest2
 
 	public override string virtual_method () {
 		return "V2";
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void threadpool_io () {
+		Task<int> t = Task.Run (async () => {
+			var wc = new System.Net.WebClient ();
+			string filename = System.IO.Path.GetTempFileName ();
+
+			var dl = wc.DownloadFileTaskAsync ("http://www.mono-project.com/", filename);
+			await dl;
+			System.IO.File.Delete (filename);
+			return 1;
+			});
+		var n = t.Result;
 	}
 }
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4035,6 +4035,30 @@ public class DebuggerTests
 		// Make sure we are still in the cctor
 		Assert.AreEqual (".cctor", e.Thread.GetFrames ()[0].Location.Method.Name);
 	}
+
+	[Test]
+	public void ThreadpoolIOsinglestep () {
+		// This is a regression test for #42625.
+		// It tests the interaction (particularly in coop GC of
+		// the threadpool I/O mechanism and the soft debugger.
+		Start (new string [] { "dtest-app.exe", "threadpool-io" });
+
+		Event e = run_until ("threadpool_io");
+		var req = create_step (e);
+		req.Enable ();
+
+		// step to start the task
+		e = step_once ();
+		
+		req.Disable ();
+
+		// run until completion of the test method
+		e = step_out ();
+
+		vm.Resume ();
+
+		vm.Suspend ();
+	}
 }
 
 }

--- a/mono/metadata/threadpool-ms-io-epoll.c
+++ b/mono/metadata/threadpool-ms-io-epoll.c
@@ -84,7 +84,9 @@ epoll_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), g
 
 	mono_gc_set_skip_thread (TRUE);
 
+	MONO_ENTER_GC_SAFE;
 	ready = epoll_wait (epoll_fd, epoll_events, EPOLL_NEVENTS, -1);
+	MONO_EXIT_GC_SAFE;
 
 	mono_gc_set_skip_thread (FALSE);
 

--- a/mono/metadata/threadpool-ms-io-kqueue.c
+++ b/mono/metadata/threadpool-ms-io-kqueue.c
@@ -81,7 +81,9 @@ kqueue_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), 
 
 	mono_gc_set_skip_thread (TRUE);
 
+	MONO_ENTER_GC_SAFE;
 	ready = kevent (kqueue_fd, NULL, 0, kqueue_events, KQUEUE_NEVENTS, NULL);
+	MONO_EXIT_GC_SAFE;
 
 	mono_gc_set_skip_thread (FALSE);
 

--- a/mono/metadata/threadpool-ms-io-poll.c
+++ b/mono/metadata/threadpool-ms-io-poll.c
@@ -143,7 +143,9 @@ poll_event_wait (void (*callback) (gint fd, gint events, gpointer user_data), gp
 
 	mono_gc_set_skip_thread (TRUE);
 
+	MONO_ENTER_GC_SAFE;
 	ready = mono_poll (poll_fds, poll_fds_size, -1);
+	MONO_EXIT_GC_SAFE;
 
 	mono_gc_set_skip_thread (FALSE);
 


### PR DESCRIPTION
Backport #3294 to mono-4.6.0-branch

Fixes [Bugzilla #42625](https://bugzilla.xamarin.com/show_bug.cgi?id=42625)