### PR TITLE
RFC: collect code coverage statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ GTAGS
 docs/doxygen*
 docs/perlmod*
 
+# gcov
+*.gcda
+*.gcno
 
 ##############################################################################
 # Mono-specific patterns

--- a/Makefile.am
+++ b/Makefile.am
@@ -172,3 +172,5 @@ update-solution-files:
 	make update-csproj
 	make package-inputs
 	(cd msvc/scripts; make genproj.exe; mono genproj.exe)
+
+include $(top_srcdir)/Makefile.am.coverage

--- a/Makefile.am.coverage
+++ b/Makefile.am.coverage
@@ -1,0 +1,41 @@
+
+# Coverage targets
+
+if HAVE_GCOV
+
+.PHONY: clean-gcda
+clean-gcda:
+	@echo Removing old coverage results
+	-find . \( -name '*.gcda' -o -name '*.gcno' \) -exec rm -f {} +
+
+.PHONY: coverage-html generate-coverage-html clean-coverage-html
+coverage-html: clean-gcda
+	-$(MAKE) $(AM_MAKEFLAGS) -k check
+	$(MAKE) $(AM_MAKEFLAGS) generate-coverage-html
+
+generate-coverage-html:
+	@echo Collecting coverage data
+	$(LCOV) \
+		$$(find $(top_srcdir) \
+			-name '*.gcda' \
+			-exec dirname {} \; \
+			| sort | uniq | perl -ne 'print "--directory $$_"') \
+		--capture \
+		--output-file coverage.info \
+		--no-checksum \
+		--compat-libtool
+	LANG=C $(GENHTML) \
+		--prefix $(top_builddir) \
+		--output-directory coverage-html \
+		--title "Code Coverage" \
+		--legend \
+		--show-details \
+		coverage.info
+
+clean-coverage-html: clean-gcda
+	-$(LCOV) --directory $(top_builddir) -z
+	-rm -rf coverage.info coveragereport
+
+clean-local: clean-coverage-html
+
+endif # HAVE_GCOV

--- a/configure.ac
+++ b/configure.ac
@@ -3918,6 +3918,13 @@ AC_SUBST(LDFLAGS)
 #This must always be defined when building the runtime
 AC_DEFINE(MONO_INSIDE_RUNTIME,1, [Disable banned functions from being used by the runtime])
 
+# gcov
+m4_include([m4/gcov.m4])
+AC_TDD_GCOV
+AC_SUBST(COVERAGE_CFLAGS)
+AC_SUBST(COVERAGE_CXXFLAGS)
+AC_SUBST(COVERAGE_LDFLAGS)
+
 mono_build_root=`pwd`
 AC_SUBST(mono_build_root)
 

--- a/m4/gcov.m4
+++ b/m4/gcov.m4
@@ -1,0 +1,93 @@
+# Copyright 2012 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it 
+# under the terms of the GNU General Public License version 3, as published 
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but 
+# WITHOUT ANY WARRANTY; without even the implied warranties of 
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR 
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along 
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Checks for existence of coverage tools:
+#  * gcov
+#  * lcov
+#  * genhtml
+#  * gcovr
+# 
+# Sets ac_cv_check_gcov to yes if tooling is present
+# and reports the executables to the variables LCOV, GCOVR and GENHTML.
+AC_DEFUN([AC_TDD_GCOV],
+[
+  AC_ARG_ENABLE(gcov,
+  AS_HELP_STRING([--enable-gcov],
+		 [enable coverage testing with gcov]),
+  [use_gcov=yes], [use_gcov=no])
+
+  AM_CONDITIONAL(HAVE_GCOV, test "x$use_gcov" = "xyes")
+
+  if test "x$use_gcov" = "xyes"; then
+  # we need gcc:
+  if test "$GCC" != "yes"; then
+    AC_MSG_ERROR([GCC is required for --enable-gcov])
+  fi
+
+  # Check if ccache is being used
+  AC_CHECK_PROG(SHTOOL, shtool, shtool)
+  if test "$SHTOOL"; then
+    AS_CASE([`$SHTOOL path $CC`],
+                [*ccache*], [gcc_ccache=yes],
+                [gcc_ccache=no])
+  fi
+
+  if test "$gcc_ccache" = "yes" && (test -z "$CCACHE_DISABLE" || test "$CCACHE_DISABLE" != "1"); then
+    AC_MSG_ERROR([ccache must be disabled when --enable-gcov option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
+  fi
+
+  lcov_version_list="1.6 1.7 1.8 1.9 1.10 1.11 1.12"
+  AC_CHECK_PROG(LCOV, lcov, lcov)
+  AC_CHECK_PROG(GENHTML, genhtml, genhtml)
+
+  if test "$LCOV"; then
+    AC_CACHE_CHECK([for lcov version], glib_cv_lcov_version, [
+      glib_cv_lcov_version=invalid
+      lcov_version=`$LCOV -v 2>/dev/null | $SED -e 's/^.* //'`
+      for lcov_check_version in $lcov_version_list; do
+        if test "$lcov_version" = "$lcov_check_version"; then
+          glib_cv_lcov_version="$lcov_check_version (ok)"
+        fi
+      done
+    ])
+  else
+    lcov_msg="To enable code coverage reporting you must have one of the following lcov versions installed: $lcov_version_list"
+    AC_MSG_ERROR([$lcov_msg])
+  fi
+
+  case $glib_cv_lcov_version in
+    ""|invalid[)]
+      lcov_msg="You must have one of the following versions of lcov: $lcov_version_list (found: $lcov_version)."
+      AC_MSG_ERROR([$lcov_msg])
+      LCOV="exit 0;"
+      ;;
+  esac
+
+  if test -z "$GENHTML"; then
+    AC_MSG_ERROR([Could not find genhtml from the lcov package])
+  fi
+
+  # Remove all optimization flags from CFLAGS
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9]*//g'`
+  changequote([,])
+
+  # Add the special gcc flags
+  COVERAGE_CFLAGS="-fprofile-arcs -ftest-coverage -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/7.3.0/lib/darwin/ -lclang_rt.profile_osx"
+  COVERAGE_CXXFLAGS="-fprofile-arcs -ftest-coverage -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/7.3.0/lib/darwin/ -lclang_rt.profile_osx"
+  COVERAGE_LDFLAGS=""
+
+fi
+]) # AC_TDD_GCOV
+

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -30,16 +30,18 @@ lib_LTLIBRARIES = \
 suppressiondir = $(datadir)/mono-$(API_VER)/mono/profiler
 suppression_DATA = mono-profiler-log.suppression
 
+libmono_profiler_log_la_CFLAGS = $(COVERAGE_CFLAGS)
+
 if PLATFORM_DARWIN
 if BITCODE
 prof_ldflags = -no-undefined
 else
-prof_ldflags = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
+prof_ldflags = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace $(COVERAGE_LDFLAGS)
 endif
 endif
 
 if PLATFORM_ANDROID
-prof_ldflags = -avoid-version
+prof_ldflags = -avoid-version $(COVERAGE_LDFLAGS)
 endif
 
 # FIXME fix the profiler tests to work with coop.
@@ -65,7 +67,7 @@ libmono_profiler_aot_la_SOURCES = mono-profiler-aot.c
 libmono_profiler_aot_la_LIBADD =  $(monodir)/mono/mini/$(LIBMONO_LA) $(GLIB_LIBS) $(LIBICONV)
 libmono_profiler_aot_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_aot_static_la_SOURCES = mono-profiler-aot.c
-libmono_profiler_aot_static_la_LDFLAGS = -static
+libmono_profiler_aot_static_la_LDFLAGS = -static $(COVERAGE_CFLAGS)
 
 libmono_profiler_iomap_la_SOURCES = mono-profiler-iomap.c
 libmono_profiler_iomap_la_LIBADD = $(monodir)/mono/mini/$(LIBMONO_LA) $(GLIB_LIBS) $(LIBICONV)

--- a/mono/sgen/Makefile.am
+++ b/mono/sgen/Makefile.am
@@ -71,8 +71,8 @@ monosgen_sources = \
 	sgen-workers.h
 
 libmonosgen_la_SOURCES = $(monosgen_sources)
-libmonosgen_la_CFLAGS = $(SGEN_DEFINES)
+libmonosgen_la_CFLAGS = $(SGEN_DEFINES) $(COVERAGE_CFLAGS)
 
 libmonosgen_static_la_SOURCES = $(libmonosgen_la_SOURCES)
-libmonosgen_static_la_CFLAGS = $(SGEN_DEFINES)
-libmonosgen_static_la_LDFLAGS = -static
+libmonosgen_static_la_CFLAGS = $(SGEN_DEFINES) $(COVERAGE_CFLAGS)
+libmonosgen_static_la_LDFLAGS = -static $(COVERAGE_LDFLAGS)

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -992,9 +992,19 @@ runtest: $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la $(PREREQSI_IL) $(PREREQS
 	  exit 1; \
 	fi
 
+# 1. create baseline coverage data file
+# 2. perform test
+# 3. create test coverage data file
+# 4. combine baseline and test coverage data
+
 runtest-managed: test-runner.exe $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la $(PREREQSI_IL) $(PREREQSI_CS)
 	@if [ "x$$CI" = "x1" ]; then disabled_tests="$(DISABLED_TESTS_WRENCH)"; else disabled_tests="$(DISABLED_TESTS)"; fi; \
-	$(RUNTIME) --debug $(TEST_RUNNER) $(TEST_RUNNER_ARGS) -j a --testsuite-name "runtime" --timeout 300 --disabled "$${disabled_tests}" $(TESTSI_CS) $(TESTBS) $(TESTSI_IL)
+	$(LCOV) -c -i -d $(top_srcdir)/mono/sgen -d $(top_srcdir)/mono/mini -d $(top_srcdir)/mono/metadata \
+		-o coverage-base.info --test-name "runtime"; \
+	$(RUNTIME) --debug $(TEST_RUNNER) $(TEST_RUNNER_ARGS) -j a --testsuite-name "runtime" --timeout 300 --disabled "$${disabled_tests}" $(TESTSI_CS) $(TESTBS) $(TESTSI_IL); \
+	$(LCOV) -c -d $(top_srcdir)/mono/sgen -d $(top_srcdir)/mono/mini -d $(top_srcdir)/mono/metadata \
+		-o coverage-test.info --test-name "runtime"; \
+	$(LCOV) -a coverage-base.info -a coverage-test.info -o coverage-total.info
 
 runtest-managed-serial: test-runner.exe $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la $(PREREQSI_IL) $(PREREQSI_CS)
 	@if [ "x$$CI" = "x1" ]; then disabled_tests="$(DISABLED_TESTS_WRENCH)"; else disabled_tests="$(DISABLED_TESTS)"; fi; \
@@ -1651,12 +1661,12 @@ AM_CPPFLAGS = $(GLIB_CFLAGS)
 if HOST_WIN32
 # gcc-3.4.4 emits incorrect code when making indirect calls to stdcall functions using a tail call
 # This shows up when compiling mono_test_marshal_delegate ()
-libtest_la_CFLAGS=-fno-optimize-sibling-calls
+libtest_la_CFLAGS=-fno-optimize-sibling-calls $(COVERAGE_CFLAGS)
 # the exported names created by gcc for stdcall functions are missing the leading _, so MS.NET
 # can't find them. So we use --kill-at to remove the @ suffix as well.
-libtest_la_LDFLAGS=-no-undefined -rpath `pwd` -Wl,--kill-at
+libtest_la_LDFLAGS=-no-undefined -rpath `pwd` -Wl,--kill-at $(COVERAGE_LDFLAGS)
 else
-libtest_la_LDFLAGS = -rpath `pwd`
+libtest_la_LDFLAGS = -rpath `pwd` $(COVERAGE_LDFLAGS)
 endif
 libtest_la_SOURCES = libtest.c
 libtest_la_LIBADD = $(GLIB_LIBS) $(LIBICONV)

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -1,10 +1,12 @@
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\"
 
-test_cflags = $(AM_CFLAGS) $(SGEN_DEFINES)
+test_cflags = $(AM_CFLAGS) $(SGEN_DEFINES) $(COVERAGE_CFLAGS)
 test_ldadd = libtestlib.la \
 	$(LIBGC_LIBS) $(GLIB_LIBS) -lm $(LIBICONV)
 if PLATFORM_DARWIN
-test_ldflags = -framework CoreFoundation -framework Foundation
+test_ldflags = -framework CoreFoundation -framework Foundation $(COVERAGE_LDFLAGS)
+else
+test_ldflags = $(COVERAGE_LDFLAGS)
 endif
 
 if !CROSS_COMPILE


### PR DESCRIPTION
Usage:

    # Make a build with coverage enabled.
    autogen.sh --enable-gcov
    make -j8

    # Capture coverage data, then generate and view report.
    make check -C mono -j8
    make generate-coverage-html
    open coverage-html/index.html

This adds a new Makefile entry point target, `generate-coverage-html`, and updates .gitignore to ignore generated files.

Todo:

 * It tries to collect stats per test so they can be merged afterward, but I'm not sure this part actually works.

 * Coverage information is only collected for the `metadata`, `mini`, and `sgen` subdirectories; they should be discovered automatically.

I’m also not quite sure about whether we can use the GPL bits, so I can remove those if necessary.
