### PR TITLE
[versions.mk] Make path to SUBMODULES.json based on srcdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ obj/
 [Rr]elease*/
 Ankh.NoLoad
 *.gpState
+.vscode/
 
 # Tooling
 _ReSharper*/

--- a/acceptance-tests/versions.mk
+++ b/acceptance-tests/versions.mk
@@ -1,5 +1,6 @@
 .PHONY: validate-versions reset-versions
 
+SUBMODULES_CONFIG_FILE = $(top_srcdir)/acceptance-tests/SUBMODULES.json
 include $(top_srcdir)/scripts/submodules/versions.mk
 
 $(eval $(call ValidateVersionTemplate,roslyn,ROSLYN))

--- a/llvm/Makefile.am
+++ b/llvm/Makefile.am
@@ -7,6 +7,7 @@
 
 LLVM_PATH=llvm
 
+SUBMODULES_CONFIG_FILE = $(top_srcdir)/llvm/SUBMODULES.json
 include $(top_srcdir)/scripts/submodules/versions.mk
 
 $(eval $(call ValidateVersionTemplate,llvm,LLVM))

--- a/scripts/submodules/versions.mk
+++ b/scripts/submodules/versions.mk
@@ -1,9 +1,8 @@
 #
 # This is a python script and a set of make targets to implement support for conditional submodules
-# There should be a SUBMODULES.json file which contains information about the submodules.
+# Set the SUBMODULES_CONFIG_FILE make variable to the srcdir path of a SUBMODULES.json file which contains information about the submodules.
 #
 
-CONFIG=SUBMODULES.json
 SCRIPT=$(top_srcdir)/scripts/submodules/versions.py
 
 # usage $(call ValidateVersionTemplate (name,MAKEFILE VAR,repo name))
@@ -11,11 +10,11 @@ SCRIPT=$(top_srcdir)/scripts/submodules/versions.py
 
 define ValidateVersionTemplate
 #$(eval REPOSITORY_$(2):=$(shell test -z $(3) && echo $(1) || echo "$(3)"))
-#$(eval DIRECTORY_$(2):=$(shell python $(SCRIPT) get-dir $(1)))
+#$(eval DIRECTORY_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-dir $(1)))
 #$(eval DIRECTORY_$(2):=$(shell test -z $(DIRECTORY_$(2)) && echo $(1) || echo $(DIRECTORY_$(2))))
-#$(eval MODULE_$(2):=$(shell python $(SCRIPT) get-url $(1)))
-#$(eval NEEDED_$(2)_VERSION:=$(shell python $(SCRIPT) get-rev $(1)))
-#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python $(SCRIPT) get-remote-branch $(1)))
+#$(eval MODULE_$(2):=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-url $(1)))
+#$(eval NEEDED_$(2)_VERSION:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-rev $(1)))
+#$(eval $(2)_BRANCH_AND_REMOTE:=$(shell python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) get-remote-branch $(1)))
 
 #$(eval $(2)_VERSION:=$$$$(shell cd $($(2)_PATH) 2>/dev/null && git rev-parse HEAD ))
 
@@ -107,17 +106,17 @@ reset:
 
 __bump-version-%:
 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
-	python $(SCRIPT) set-rev $* $(REV)
-	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(CONFIG); fi
+	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
 
 __bump-branch-%:
 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
-	python $(SCRIPT) set-branch $* $(BRANCH)
-	python $(SCRIPT) set-remote-branch $* $(REMOTE_BRANCH)
-	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(CONFIG); fi
+	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
 
 __bump-current-version-%:
 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
-	python $(SCRIPT) set-rev $* $$REV; \
-	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(CONFIG); fi
+	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi

--- a/scripts/submodules/versions.py
+++ b/scripts/submodules/versions.py
@@ -12,38 +12,38 @@ def find_module(submodules, name):
     sys.exit(1)
 
 
-if len(sys.argv) < 2:
-    print("Usage: versions.py <command>")
+if len(sys.argv) < 3:
+    print("Usage: versions.py <path to SUBMODULES.json> <command>")
     sys.exit(1)
 
-CONFIG_FILE = "SUBMODULES.json"
-command = sys.argv[1]
+CONFIG_FILE = sys.argv[1]
+command = sys.argv[2]
 
 submodules = json.load(open(CONFIG_FILE))
 
 if command == "get-rev":
-    mod = find_module(submodules, sys.argv[2])
+    mod = find_module(submodules, sys.argv[3])
     print(mod["rev"])
 elif command == "get-url":
-    mod = find_module(submodules, sys.argv[2])
+    mod = find_module(submodules, sys.argv[3])
     print(mod["url"])
 elif command == "get-dir":
-    mod = find_module(submodules, sys.argv[2])
+    mod = find_module(submodules, sys.argv[3])
     print(mod["directory"])
 elif command == "get-remote-branch":
-    mod = find_module(submodules, sys.argv[2])
+    mod = find_module(submodules, sys.argv[3])
     print(mod["remote-branch"])
 elif command == "set-rev":
-    mod = find_module(submodules, sys.argv[2])
-    mod["rev"] = sys.argv[3]
+    mod = find_module(submodules, sys.argv[3])
+    mod["rev"] = sys.argv[4]
     json.dump(submodules, open(CONFIG_FILE, "w"), indent = 2)
 elif command == "set-branch":
-    mod = find_module(submodules, sys.argv[2])
-    mod["branch"] = sys.argv[3]
+    mod = find_module(submodules, sys.argv[3])
+    mod["branch"] = sys.argv[4]
     json.dump(submodules, open(CONFIG_FILE, "w"), indent = 2)
 elif command == "set-remote-branch":
-    mod = find_module(submodules, sys.argv[2])
-    mod["remote-branch"] = sys.argv[3]
+    mod = find_module(submodules, sys.argv[3])
+    mod["remote-branch"] = sys.argv[4]
     json.dump(submodules, open(CONFIG_FILE, "w"), indent = 2)
 elif command == "cat":
     print(json.dumps(submodules, indent = 2))


### PR DESCRIPTION
Since acceptance-tests/Makefile (and llvm/Makefile) include scripts/submodules/versions.mk which evals versions.py which looks for a SUBMODULES.json file in the current working directory we got confusing error messages if the build directory is not the src dir:

```
Traceback (most recent call last):
  File "../../mono/scripts/submodules/versions.py", line 22, in <module>
    submodules = json.load(open(CONFIG_FILE))
IOError: [Errno 2] No such file or directory: 'SUBMODULES.json'
```

Instead we now pass the path to SUBMODULES.json as a variable to versions.py and set it based on $(top_srcdir) so it works even for out-of-tree builds.

@monojenkins merge