### PR TITLE
[mini] Explicitly turn nunit output on or off based on variable

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -695,15 +695,11 @@ testi: mono test.exe
 checktests: $(regtests)
 	for i in $(regtests); do $(MINI_RUNTIME) $$i; done
 
-rcheck-ci: mono $(regtests)
-if NACL_CODEGEN
-	for i in $(regtests); do echo "running test $$i"; $(MINI_RUNTIME) $$i --exclude 'NaClDisable' || exit 1; done
-else
+rcheck-nunit: mono $(regtests)
 	-($(MINI_RUNTIME) --regression $(regtests); echo $$? > regressionexitcode.out) | $(srcdir)/emitnunit.pl
 	exit $$(cat regressionexitcode.out)
-endif
 
-rcheck-normal: mono $(regtests)
+rcheck: mono $(regtests)
 	$(MINI_RUNTIME) --regression $(regtests)
 
 if ARM
@@ -821,12 +817,8 @@ stat3: mono bench.exe
 docu: mini.sgm
 	docbook2txt mini.sgm
 
-# CI - Wrench
-# BUILD_URL = Jenkins
-RUNNING_ON_CI = $(CI)$(BUILD_URL)
-
 # We need these because automake can't process normal make conditionals
-check_local_targets = $(if $(RUNNING_ON_CI), rcheck-ci check-seq-points, rcheck-normal)
+check_local_targets = $(if $(EMIT_NUNIT), rcheck-nunit, rcheck)
 
 check-local: $(check_local_targets)
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -19,13 +19,6 @@ test-wrench: check-parallel
 
 aotcheck: testaot gshared-aot
 
-# Whenever running under CI
-# Can't use make conditionals since
-# automake doesn't support them
-# CI - Wrench
-# BUILD_URL = Jenkins
-RUNNING_ON_CI = $(CI)$(BUILD_URL)
-
 TEST_PROG = ../interpreter/mint
 
 JITTEST_PROG = $(if $(VALGRIND), valgrind $(VALGRIND_ARGS),) $(if $(SGEN),$(top_builddir)/mono/mini/mono-sgen,$(top_builddir)/mono/mini/mono)
@@ -41,7 +34,6 @@ else
 TEST_RUNNER_ARGS=--config tests-config --runtime $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),mono)
 endif
 
-TEST_RUNNER_ARGS += $(if $(RUNNING_ON_CI), --verbose,)
 TEST_RUNNER_ARGS += $(if $(V), --verbose,)
 
 CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -2,7 +2,7 @@
 
 export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
 
-${TESTCMD} --label=mini --timeout=5m make -w -C mono/mini -k check
+${TESTCMD} --label=mini --timeout=5m make -w -C mono/mini -k check check-seq-points EMIT_NUNIT=1
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1
 ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
 ${TESTCMD} --label=verify --timeout=15m make -w -C runtime mcs-compileall


### PR DESCRIPTION
Alternative implementation to 8f092147bb604485c78c80b9781536ec995d51fe.

In CI we explicitly pass EMIT_NUNIT=1 to generate the nunit xml and run the check-seq-points tests, locally those are omitted. This avoids needing to sniff for Jenkins/Wrench variables.

@vargaz what do you think?