### PR TITLE
[Mono.CSharp] Fix test .sources to include ASTVisitorTest.cs

### DIFF
--- a/mcs/class/Mono.CSharp/Mono.CSharp_test.dll.sources
+++ b/mcs/class/Mono.CSharp/Mono.CSharp_test.dll.sources
@@ -5,3 +5,4 @@ Evaluator/EvaluatorFixture.cs
 Evaluator/EvaluatorTest.cs
 Evaluator/ExpressionsTest.cs
 Evaluator/TypesTest.cs
+Visit/ASTVisitorTest.cs

--- a/mcs/class/Mono.CSharp/Test/Visit/ASTVisitorTest.cs
+++ b/mcs/class/Mono.CSharp/Test/Visit/ASTVisitorTest.cs
@@ -38,24 +38,21 @@ completionList.Add (""delegate"" + sb, ""md-keyword"", GettextCatalog.GetString 
 
 			var stream = new MemoryStream (Encoding.UTF8.GetBytes (content));
 
-			var ctx = new CompilerContext (new CompilerSettings (), new Report (new AssertReportPrinter ()));
+			var ctx = new CompilerContext (new CompilerSettings (), new AssertReportPrinter ());
 
 			ModuleContainer module = new ModuleContainer (ctx);
+			var file = new SourceFile ("test", "asdfas", 0);
 			CSharpParser parser = new CSharpParser (
 				new SeekableStreamReader (stream, Encoding.UTF8),
-				new CompilationUnit ("name", "path", 0),
-				module);
+				new CompilationSourceFile (module, file),
+				ctx.Report,
+				new ParserSession ());
 
 			RootContext.ToplevelTypes = module;
-			Location.AddFile (ctx.Report, "asdfas");
-			Location.Initialize ();
-			parser.LocationsBag = new LocationsBag ();
+			Location.Initialize (new List<SourceFile> { file });
 			parser.parse ();
 
-			var m = module.Types[0].Methods[0] as Method;
-			var s = m.Block.FirstStatement;
-			var o = s.loc.Column;
-			
+			Assert.AreEqual (0, ctx.Report.Errors);
 
 			module.Accept (new TestVisitor ());
 		}

--- a/mcs/class/Mono.CSharp/monotouch_Mono.CSharp.dll.sources
+++ b/mcs/class/Mono.CSharp/monotouch_Mono.CSharp.dll.sources
@@ -1,2 +1,1 @@
 #include mobile_static_Mono.CSharp.dll.sources
-monotouch.cs

--- a/mcs/class/Mono.CSharp/monotouch_tv_Mono.CSharp.dll.sources
+++ b/mcs/class/Mono.CSharp/monotouch_tv_Mono.CSharp.dll.sources
@@ -1,2 +1,1 @@
 #include mobile_static_Mono.CSharp.dll.sources
-monotouch.cs

--- a/mcs/class/Mono.CSharp/monotouch_watch_Mono.CSharp.dll.sources
+++ b/mcs/class/Mono.CSharp/monotouch_watch_Mono.CSharp.dll.sources
@@ -1,2 +1,1 @@
 #include mobile_static_Mono.CSharp.dll.sources
-monotouch.cs


### PR DESCRIPTION
I noticed this while looking at why Mono.CSharp is registered as "crashed" in the the new
fullaot PR job on Jenkins. It turns out all tests were excluded in mobile_static which means
no NUnit xml was produced and that is exactly what the script then interprets as a crash.

I saw that ASTVisitorTest.cs was not included in the net_4_x tests as well, likely inadvertently.
It got bitrotten over the years so I had to fix it up a bit, now it compiles/runs on mobile_static as well and makes the mobile_static profile have at least one test.