### PR TITLE
[sgen] Add missing memory barrier

### DIFF
--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -1572,6 +1572,12 @@ ensure_block_is_checked_for_sweeping (guint32 block_index, gboolean wait, gboole
 	}
 
  done:
+	/*
+	 * Once the block is written back without the checking bit other threads are
+	 * free to access it. Make sure the block state is visible before we write it
+	 * back.
+	 */
+	mono_memory_write_barrier ();
 	*block_slot = tagged_block;
 	return !!tagged_block;
 }


### PR DESCRIPTION
When doing the first phase of sweeping we tag the block pointer within the block list with a CAS, after which we own the block and we are free to update the state and do sweep computations on the block. When we finish this phase we directly write the untagged block pointer back in the list, making the block available to inspect by other threads. We need a write barrier before writting the untagged pointer back because, when another thread might acquire the block, it might encounter an invalid block state.