### PR TITLE
[mobile_static] Pass correct MONO_LLVMONLY for bitcode script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,7 @@ get-monolite-latest:
 
 .PHONY: check-ci
 check-ci:
-	MONO_LLVMONLY=$(MONO_LLVMONLY) $(srcdir)/scripts/ci/run-test-$(TEST_PROFILE).sh
+	MONO_LLVMONLY=$(BITCODE) $(srcdir)/scripts/ci/run-test-$(TEST_PROFILE).sh
 
 .PHONY: validate do-build-mono-mcs mcs-do-clean mcs-do-tests
 validate: do-build-mono-mcs

--- a/configure.ac
+++ b/configure.ac
@@ -892,7 +892,10 @@ AM_CONDITIONAL(INSTALL_MOBILE_STATIC, [test "x$with_mobile_static" != "xno"])
 
 AC_SUBST(INSTALL_MOBILE_STATIC)
 
-AC_SUBST(BITCODE)
+AM_COND_IF(BITCODE, [
+	BITCODE=TRUE
+	AC_SUBST(BITCODE)
+])
 
 default_profile=net_4_x
 if test -z "$INSTALL_MONODROID_TRUE"; then :


### PR DESCRIPTION
The automake conditional for Bitcode wasn't visible at the right time, so the AM_COND_IF must be used to set it. Furthermore we don't set MONO_LLVMONLY in the automake system.  

This makes the mini tests on bitcode run llvmonlycheck rather than fullaotcheck.