### PR TITLE
[corlib] Increase timeout for TaskTests.WaitAll_ManyTasks.

### DIFF
--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
@@ -312,7 +312,7 @@ namespace MonoTests.System.Threading.Tasks
 				}
 				AddToCleanup (tasks);
 
-				Assert.IsTrue (Task.WaitAll (tasks, 5000));
+				Assert.IsTrue (Task.WaitAll (tasks, 20000));
 			}
 		}
 


### PR DESCRIPTION
5 seconds is not enough to create 2000 threads on watch devices, so bump
timeout to 20 seconds (it seems to be able to finish in ~15 seconds).