### PR TITLE
Jenkins test Thread KeyNotFoundException issues.

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
+++ b/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
@@ -59,8 +59,13 @@ namespace System.Net.Sockets {
 								StringBuilder sb = new StringBuilder ();
 								sb.AppendLine ("Could not abort registered blocking threads before closing socket.");
 								foreach (var thread in blocking_threads) {
+									var hc = thread.GetHashCode();
 									sb.AppendLine ("Thread StackTrace:");
-									sb.AppendLine (threads_stacktraces[thread].ToString ());
+									try {
+										sb.AppendLine (threads_stacktraces[thread].ToString ());
+									} catch {
+										sb.AppendFormat("Hashcodes: {0} {1}\n", hc, thread.GetHashCode ());
+									}
 								}
 								sb.AppendLine ();
 

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -671,12 +671,18 @@ namespace System.Threading {
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.MayFail)]
 		public static void BeginCriticalRegion ()
 		{
+			if (CurrentThread.Internal.critical_region_level > int.MaxValue - 100)
+				throw new Exception ("critical_region_level too big, probable leak");
+
 			CurrentThread.Internal.critical_region_level++;
 		}
 
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
 		public static void EndCriticalRegion ()
 		{
+			if (CurrentThread.Internal.critical_region_level < 0)
+				throw new Exception ("critical_region_level negative, probable leak");
+
 			CurrentThread.Internal.critical_region_level--;
 		}
 


### PR DESCRIPTION
We are getting strange behavior while running the test suite on arm64.
KeyNotFoundException of threads that should be in the dictionary.

This commits are to be tested in Jenkins to verify if the source of the problem is related with Thread.GetHashCode changing overtime.

This also tests if the volatile field critical_region_level overflows which might change on arm64 the value of managed_id used in Thread.GetHashCode.
