### PR TITLE
[arm] Also check the 'model name' line for the architecture version.

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -880,6 +880,21 @@ mono_arch_init (void)
 	v6_supported = mono_hwcap_arm_is_v6;
 	v7_supported = mono_hwcap_arm_is_v7;
 
+	/*
+	 * On weird devices, the hwcap code may fail to detect
+	 * the ARM version. In that case, we can at least safely
+	 * assume the version the runtime was compiled for.
+	 */
+#ifdef HAVE_ARMV5
+	v5_supported = TRUE;
+#endif
+#ifdef HAVE_ARMV6
+	v6_supported = TRUE;
+#endif
+#ifdef HAVE_ARMV7
+	v7_supported = TRUE;
+#endif
+
 #if defined(__APPLE__)
 	/* iOS is special-cased here because we don't yet
 	   have a way to properly detect CPU features on it. */

--- a/mono/utils/mono-hwcap-arm.c
+++ b/mono/utils/mono-hwcap-arm.c
@@ -159,7 +159,8 @@ mono_hwcap_arch_init (void)
 
 	if (file) {
 		while ((line = fgets (buf, 512, file))) {
-			if (!strncmp (line, "Processor", 9)) {
+			if (!strncmp (line, "Processor", 9) ||
+			    !strncmp (line, "model name", 10)) {
 				char *ver = strstr (line, "(v");
 
 				if (ver) {


### PR DESCRIPTION
Some Android devices for some reason have a 'model name' line instead of a
'Processor' line. On such devices, we would fail to detect the architecture
version at all, and end up thinking that it's ARMv4 (even if the runtime
was compiled for ARMv7).

Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=42814