### PR TITLE
[reflection] Don't leak GPtrArray internal array

### DIFF
--- a/mcs/class/corlib/Mono/RuntimeHandles.cs
+++ b/mcs/class/corlib/Mono/RuntimeHandles.cs
@@ -262,11 +262,11 @@ namespace Mono {
 		}
 
 		[MethodImpl(MethodImplOptions.InternalCall)]
-		unsafe extern static void GPtrArrayFree (RuntimeStructs.GPtrArray* value, bool freeSeg);
+		unsafe extern static void GPtrArrayFree (RuntimeStructs.GPtrArray* value);
 
-		internal static void DestroyAndFree (ref RuntimeGPtrArrayHandle h, bool freeSeg) {
+		internal static void DestroyAndFree (ref RuntimeGPtrArrayHandle h) {
 			unsafe {
-				GPtrArrayFree (h.value, freeSeg);
+				GPtrArrayFree (h.value);
 				h.value = null;
 			}
 		}

--- a/mcs/class/corlib/Mono/SafeGPtrArrayHandle.cs
+++ b/mcs/class/corlib/Mono/SafeGPtrArrayHandle.cs
@@ -15,12 +15,10 @@ using System.Runtime.CompilerServices;
 namespace Mono {
 	internal sealed class SafeGPtrArrayHandle : IDisposable {
 		RuntimeGPtrArrayHandle handle;
-		bool freeSeg;
 
-		internal SafeGPtrArrayHandle (IntPtr ptr, bool freeSeg)
+		internal SafeGPtrArrayHandle (IntPtr ptr)
 		{
 			handle = new RuntimeGPtrArrayHandle (ptr);
-			this.freeSeg = freeSeg;
 		}
 
 		~SafeGPtrArrayHandle ()
@@ -30,7 +28,7 @@ namespace Mono {
 
 		void Dispose (bool disposing)
 		{
-			RuntimeGPtrArrayHandle.DestroyAndFree (ref handle, freeSeg);
+			RuntimeGPtrArrayHandle.DestroyAndFree (ref handle);
 		}
 
 		public void Dispose () {

--- a/mcs/class/corlib/Mono/SafeGPtrArrayHandle.cs
+++ b/mcs/class/corlib/Mono/SafeGPtrArrayHandle.cs
@@ -13,7 +13,7 @@ using System;
 using System.Runtime.CompilerServices;
 
 namespace Mono {
-	internal sealed class SafeGPtrArrayHandle : IDisposable {
+	internal struct SafeGPtrArrayHandle : IDisposable {
 		RuntimeGPtrArrayHandle handle;
 
 		internal SafeGPtrArrayHandle (IntPtr ptr)
@@ -21,19 +21,8 @@ namespace Mono {
 			handle = new RuntimeGPtrArrayHandle (ptr);
 		}
 
-		~SafeGPtrArrayHandle ()
-		{
-			Dispose (false);
-		}
-
-		void Dispose (bool disposing)
-		{
-			RuntimeGPtrArrayHandle.DestroyAndFree (ref handle);
-		}
-
 		public void Dispose () {
-			Dispose (true);
-			GC.SuppressFinalize (this);
+			RuntimeGPtrArrayHandle.DestroyAndFree (ref handle);
 		}
 
 		internal int Length {

--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -477,7 +477,7 @@ namespace System
 		internal RuntimeMethodInfo[] GetMethodsByName (string name, BindingFlags bindingAttr, bool ignoreCase, RuntimeType reflectedType)
 		{
 			var refh = new RuntimeTypeHandle (reflectedType);
-			using (var h = new Mono.SafeGPtrArrayHandle (GetMethodsByName_native (name, bindingAttr, ignoreCase), false)) {
+			using (var h = new Mono.SafeGPtrArrayHandle (GetMethodsByName_native (name, bindingAttr, ignoreCase))) {
 				var n = h.Length;
 				var a = new RuntimeMethodInfo [n];
 				for (int i = 0; i < n; i++) {
@@ -497,7 +497,7 @@ namespace System
 		RuntimeConstructorInfo[] GetConstructors_internal (BindingFlags bindingAttr, RuntimeType reflectedType)
 		{
 			var refh = new RuntimeTypeHandle (reflectedType);
-			using (var h = new Mono.SafeGPtrArrayHandle (GetConstructors_native (bindingAttr), false)) {
+			using (var h = new Mono.SafeGPtrArrayHandle (GetConstructors_native (bindingAttr))) {
 				var n = h.Length;
 				var a = new RuntimeConstructorInfo [n];
 				for (int i = 0; i < n; i++) {
@@ -511,7 +511,7 @@ namespace System
 		RuntimePropertyInfo[] GetPropertiesByName (string name, BindingFlags bindingAttr, bool icase, RuntimeType reflectedType)
 		{
 			var refh = new RuntimeTypeHandle (reflectedType);
-			using (var h = new Mono.SafeGPtrArrayHandle (GetPropertiesByName_native (name, bindingAttr, icase), false)) {
+			using (var h = new Mono.SafeGPtrArrayHandle (GetPropertiesByName_native (name, bindingAttr, icase))) {
 				var n = h.Length;
 				var a = new RuntimePropertyInfo [n];
 				for (int i = 0; i < n; i++) {
@@ -677,7 +677,7 @@ namespace System
 		RuntimeFieldInfo[] GetFields_internal (string name, BindingFlags bindingAttr, RuntimeType reflectedType)
 		{
 			var refh = new RuntimeTypeHandle (reflectedType);
-			using (var h = new Mono.SafeGPtrArrayHandle (GetFields_native (name, bindingAttr), false)) {
+			using (var h = new Mono.SafeGPtrArrayHandle (GetFields_native (name, bindingAttr))) {
 				int n = h.Length;
 				var a = new RuntimeFieldInfo[n];
 				for (int i = 0; i < n; i++) {
@@ -691,7 +691,7 @@ namespace System
 		RuntimeEventInfo[] GetEvents_internal (string name, BindingFlags bindingAttr, RuntimeType reflectedType)
 		{
 			var refh = new RuntimeTypeHandle (reflectedType);
-			using (var h = new Mono.SafeGPtrArrayHandle (GetEvents_native (name, bindingAttr), false)) {
+			using (var h = new Mono.SafeGPtrArrayHandle (GetEvents_native (name, bindingAttr))) {
 				int n = h.Length;
 				var a = new RuntimeEventInfo[n];
 				for (int i = 0; i < n; i++) {

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 151;
+		private const int mono_corlib_version = 152;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -83,7 +83,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 151
+#define MONO_CORLIB_VERSION 152
 
 typedef struct
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1536,9 +1536,9 @@ ves_icall_Mono_RuntimeClassHandle_GetTypeFromClass (MonoClass *klass)
 }
 
 ICALL_EXPORT void
-ves_icall_Mono_RuntimeGPtrArrayHandle_GPtrArrayFree (GPtrArray *ptr_array, MonoBoolean freeSeg)
+ves_icall_Mono_RuntimeGPtrArrayHandle_GPtrArrayFree (GPtrArray *ptr_array)
 {
-	g_ptr_array_free (ptr_array, freeSeg);
+	g_ptr_array_free (ptr_array, TRUE);
 }
 
 /* System.TypeCode */


### PR DESCRIPTION
`g_ptr_array_free (..., FALSE)` was the wrong thing here.  We always
want `TRUE`.