### PR TITLE
[runtime] Move mono_invoke_unhandled_exception_hook to metadata

### DIFF
--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -1,6 +1,7 @@
 #ifndef _MONO_METADATA_EXCEPTION_H_
 #define _MONO_METADATA_EXCEPTION_H_
 
+#include <glib.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/image.h>
 
@@ -146,6 +147,14 @@ mono_get_exception_reflection_type_load (MonoArray *types, MonoArray *exceptions
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoException *
 mono_get_exception_runtime_wrapped (MonoObject *wrapped_exception);
+
+/* Installs a function which is called when the runtime encounters an unhandled exception.
+ * This hook isn't expected to return.
+ * If no hook has been installed, the runtime will print a message before aborting.
+ */
+typedef void  (*MonoUnhandledExceptionFunc)         (MonoObject *exc, gpointer user_data);
+MONO_API void mono_install_unhandled_exception_hook (MonoUnhandledExceptionFunc func, gpointer user_data);
+void          mono_invoke_unhandled_exception_hook  (MonoObject *exc);
 
 MONO_END_DECLS
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -748,8 +748,11 @@ static guint32 WINAPI start_wrapper_internal(void *data)
 
 		if (!mono_error_ok (&error)) {
 			MonoException *ex = mono_error_convert_to_exception (&error);
-			if (ex)
+			if (ex) {
 				mono_unhandled_exception (&ex->object);
+				mono_invoke_unhandled_exception_hook (&ex->object);
+				g_assert_not_reached ();
+			}
 		} else {
 			mono_error_cleanup (&error);
 		}
@@ -5068,6 +5071,7 @@ mono_thread_internal_unhandled_exception (MonoObject* exc)
 			mono_thread_internal_reset_abort (mono_thread_internal_current ());
 		} else if (!is_appdomainunloaded_exception (klass)) {
 			mono_unhandled_exception (exc);
+			// AK: Should we call mono_invoke_unhandled_exception_hook here?
 			if (mono_environment_exitcode_get () == 1)
 				exit (255);
 		}

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5071,9 +5071,11 @@ mono_thread_internal_unhandled_exception (MonoObject* exc)
 			mono_thread_internal_reset_abort (mono_thread_internal_current ());
 		} else if (!is_appdomainunloaded_exception (klass)) {
 			mono_unhandled_exception (exc);
-			// AK: Should we call mono_invoke_unhandled_exception_hook here?
-			if (mono_environment_exitcode_get () == 1)
-				exit (255);
+			if (mono_environment_exitcode_get () == 1) {
+				mono_environment_exitcode_set (255);
+				mono_invoke_unhandled_exception_hook (exc);
+				g_assert_not_reached ();
+			}
 		}
 	}
 }

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1033,15 +1033,18 @@ mono_jit_exec (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[
 		if (exc) {
 			mono_unhandled_exception (exc);
 			mono_invoke_unhandled_exception_hook (exc);
-			return 1;
+			g_assert_not_reached ();
 		}
 		return res;
 	} else {
 		int res = mono_runtime_run_main_checked (method, argc, argv, &error);
 		if (!is_ok (&error)) {
 			MonoException *ex = mono_error_convert_to_exception (&error);
-			if (ex)
-				mono_unhandled_exception ((MonoObject*)ex);
+			if (ex) {
+				mono_unhandled_exception (&ex->object);
+				mono_invoke_unhandled_exception_hook (&ex->object);
+				g_assert_not_reached ();
+			}
 		}
 		return res;
 	}

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9034,6 +9034,7 @@ default_mono_llvm_unhandled_exception (void)
 	MonoObject *target = mono_gchandle_get_target (jit_tls->thrown_exc);
 
 	mono_unhandled_exception (target);
+	// AK: should we call mono_invoke_unhandled_exception_hook here?
 	exit (mono_environment_exitcode_get ());
 }
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9034,8 +9034,8 @@ default_mono_llvm_unhandled_exception (void)
 	MonoObject *target = mono_gchandle_get_target (jit_tls->thrown_exc);
 
 	mono_unhandled_exception (target);
-	// AK: should we call mono_invoke_unhandled_exception_hook here?
-	exit (mono_environment_exitcode_get ());
+	mono_invoke_unhandled_exception_hook (target);
+	g_assert_not_reached ();
 }
 
 /*

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2866,14 +2866,6 @@ MonoBoolean ves_icall_get_frame_info            (gint32 skip, MonoBoolean need_f
 						 MonoString **file, gint32 *line, gint32 *column);
 void mono_set_cast_details                      (MonoClass *from, MonoClass *to);
 
-/* Installs a function which is called when the runtime encounters an unhandled exception.
- * This hook isn't expected to return.
- * If no hook has been installed, the runtime will print a message before aborting.
- */
-typedef void  (*MonoUnhandledExceptionFunc)         (MonoObject *exc, gpointer user_data);
-MONO_API void mono_install_unhandled_exception_hook (MonoUnhandledExceptionFunc func, gpointer user_data);
-void          mono_invoke_unhandled_exception_hook  (MonoObject *exc);
-
 void mono_decompose_typechecks (MonoCompile *cfg);
 /* Dominator/SSA methods */
 void        mono_compile_dominator_info         (MonoCompile *cfg, int dom_flags);


### PR DESCRIPTION
And call it consistently in thread start functions when the managed
thread start function returns with an exception.

(If coop is not enabled, the exception handling code unwinds the thread and
when there's no handler invokes the unhandled exception hook via
`jit_tls->abort_func`, so this is just for the coop case.)

Fixes `mono/tests/unhandled-exception-1.cs` for coop and bitcode.