### PR TITLE
Change test suite to use nunit-lite.

### DIFF
--- a/mcs/build/config-default.make
+++ b/mcs/build/config-default.make
@@ -10,7 +10,7 @@
 CODEPAGE = 65001
 
 RUNTIME_FLAGS = 
-TEST_HARNESS = $(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)nunit-console.exe
+TEST_HARNESS = $(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)nunit-lite-console.exe
 MCS_FLAGS = 
 MBAS_FLAGS = $(PLATFORM_DEBUG_FLAGS)
 LIBRARY_FLAGS = /noconfig

--- a/mcs/build/profiles/mobile_static.make
+++ b/mcs/build/profiles/mobile_static.make
@@ -32,7 +32,6 @@ PROFILE_MCS_FLAGS = \
 	$(PLATFORM_DEBUG_FLAGS)
 
 FRAMEWORK_VERSION = 2.1
-NUNIT_LITE = yes
 
 # the tuner takes care of the install
 NO_INSTALL = yes

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -117,17 +117,7 @@ endif
 include $(topdir)/build/profiles/$(PROFILE).make
 
 # If the profile is using nunit-lite, use it
-ifdef NUNIT_LITE
 TEST_HARNESS=$(topdir)/class/lib/$(PROFILE)/nunit-lite-console.exe
-endif
-
-# Make sure propagates
-export TEST_HARNESS
-
-# If the profile is using nunit-lite, use it
-ifdef NUNIT_LITE
-TEST_HARNESS=$(topdir)/class/lib/$(PROFILE)/nunit-lite-console.exe
-endif
 
 # Make sure propagates
 export TEST_HARNESS

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -116,12 +116,6 @@ endif
 
 include $(topdir)/build/profiles/$(PROFILE).make
 
-# If the profile is using nunit-lite, use it
-TEST_HARNESS=$(topdir)/class/lib/$(PROFILE)/nunit-lite-console.exe
-
-# Make sure propagates
-export TEST_HARNESS
-
 ifdef BCL_OPTIMIZE
 PROFILE_MCS_FLAGS += -optimize
 endif

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -19,11 +19,7 @@ TEST_RUNTIME_WRAPPERS_PATH = $(shell dirname $(RUNTIME))/_tmpinst/bin
 ## Unit test support
 ifndef NO_TEST
 
-ifdef NUNIT_LITE
 test_nunit_lib = nunitlite.dll
-else
-test_nunit_lib = nunit.framework.dll nunit.core.dll nunit.util.dll nunit.mocks.dll
-endif
 
 TEST_LIB_MCS_FLAGS = $(patsubst %,-r:$(topdir)/class/lib/$(PROFILE)/%.dll,$(TEST_LIB_REFS))
 
@@ -58,19 +54,11 @@ ifndef NO_TEST
 $(test_nunit_dep): $(topdir)/build/deps/nunit-$(PROFILE).stamp
 	@if test -f $@; then :; else rm -f $<; $(MAKE) $<; fi
 
-ifdef NUNIT_LITE
 $(topdir)/build/deps/nunit-$(PROFILE).stamp:
 ifndef PARENT_PROFILE
 	cd ${topdir}/tools/nunit-lite && $(MAKE)
 endif
 	echo "stamp" >$@
-else
-$(topdir)/build/deps/nunit-$(PROFILE).stamp:
-ifndef PARENT_PROFILE
-	cd ${topdir}/nunit24 && $(MAKE)
-endif
-	echo "stamp" >$@
-endif
 
 tests_CLEAN_FILES += $(topdir)/build/deps/nunit-$(PROFILE).stamp
 endif
@@ -90,25 +78,9 @@ run-test-ondotnet-local: run-test-ondotnet-lib
 TEST_HARNESS_EXCLUDES = -exclude=$(PLATFORM_TEST_HARNESS_EXCLUDES)$(PROFILE_TEST_HARNESS_EXCLUDES)NotWorking,ValueAdd,CAS,InetAccess
 TEST_HARNESS_EXCLUDES_ONDOTNET = /exclude:$(PLATFORM_TEST_HARNESS_EXCLUDES)$(PROFILE_TEST_HARNESS_EXCLUDES)NotDotNet,CAS
 
-ifdef NUNIT_LITE
 NOSHADOW_FLAG =
 NUNIT_XML_FLAG = -format:nunit2 -result:
 OUTPUT_FILE_FLAG=-out
-else
-OUTPUT_FILE_FLAG=-output
-NOSHADOW_FLAG = -noshadow
-NUNIT_XML_FLAG = -xml=
-endif
-
-ifdef NUNIT_LITE
-NOSHADOW_FLAG =
-NUNIT_XML_FLAG = -format:nunit2 -result:
-OUTPUT_FILE_FLAG=-out
-else
-OUTPUT_FILE_FLAG=-output
-NOSHADOW_FLAG = -noshadow
-NUNIT_XML_FLAG = -xml=
-endif
 
 ifdef TEST_HARNESS_VERBOSE
 TEST_HARNESS_OUTPUT = -labels

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -95,11 +95,11 @@ TEST_HARNESS_POSTPROC_ONDOTNET = (echo ''; cat TestResult-ondotnet-$(PROFILE).lo
 endif
 
 ifdef FIXTURE
-FIXTURE_ARG = -fixture=MonoTests.$(FIXTURE)
+FIXTURE_ARG = -test=MonoTests.$(FIXTURE)
 endif
 
 ifdef TESTNAME
-TESTNAME_ARG = -run=MonoTests.$(TESTNAME)
+TESTNAME_ARG = -test=MonoTests.$(TESTNAME)
 endif
 
 ifdef ALWAYS_AOT

--- a/mcs/class/Microsoft.Build/Microsoft.Build_test.dll.sources
+++ b/mcs/class/Microsoft.Build/Microsoft.Build_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 FunctionalTest.cs
 Microsoft.Build.Construction/ProjectItemElementTest.cs
 Microsoft.Build.Construction/ProjectRootElementTest.cs

--- a/mcs/class/Mono.CodeContracts/Mono.CodeContracts_test.dll.sources
+++ b/mcs/class/Mono.CodeContracts/Mono.CodeContracts_test.dll.sources
@@ -1,2 +1,3 @@
+../../test-helpers/NunitHelpers.cs
 RewriteAndLoad.cs
 TestCCRewrite.cs

--- a/mcs/class/Mono.Parallel/Mono.Parallel_test.dll.sources
+++ b/mcs/class/Mono.Parallel/Mono.Parallel_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 Mono.Collections.Concurrent/CollectionStressTestHelper.cs
 Mono.Collections.Concurrent/ConcurrentSkipListTests.cs
 Mono.Threading/ParallelTestHelper.cs

--- a/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
+++ b/mcs/class/Mono.Posix/Mono.Posix_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 Mono.Unix/ReadlinkTest.cs
 Mono.Unix/StdioFileStreamTest.cs
 Mono.Unix/UnixEncodingTest.cs

--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Native/RealTimeSignumTests.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Native/RealTimeSignumTests.cs
@@ -8,9 +8,7 @@
 //
 
 using NUnit.Framework;
-#if !MONODROID
-using NUnit.Framework.SyntaxHelpers;
-#endif
+
 using System;
 using System.Text;
 using System.Threading;

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/ReadlinkTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/ReadlinkTest.cs
@@ -173,7 +173,7 @@ namespace MonoTests.Mono.Unix
 					long r = Syscall.readlink (link, buf);
 					if (r < 0)
 						UnixMarshal.ThrowExceptionForLastError ();
-					Assert.GreaterOrEqual (buf.Length, r);
+					AssertHelper.GreaterOrEqual (buf.Length, r);
 					if (r == buf.Length)
 						buf = new byte[checked (buf.Length * 2)];
 					else
@@ -199,7 +199,7 @@ namespace MonoTests.Mono.Unix
 					long r = Syscall.readlinkat (TempFD, "link", buf);
 					if (r < 0)
 						UnixMarshal.ThrowExceptionForLastError ();
-					Assert.GreaterOrEqual (buf.Length, r);
+					AssertHelper.GreaterOrEqual (buf.Length, r);
 					if (r == buf.Length)
 						buf = new byte[checked (buf.Length * 2)];
 					else
@@ -226,7 +226,7 @@ namespace MonoTests.Mono.Unix
 					if (r < 0)
 						UnixMarshal.ThrowExceptionForLastError ();
 					Assert.AreEqual (r, sb.Length);
-					Assert.GreaterOrEqual (sb.Capacity, r);
+					AssertHelper.GreaterOrEqual (sb.Capacity, r);
 					if (r == sb.Capacity)
 						checked { sb.Capacity *= 2; }
 					else
@@ -255,7 +255,7 @@ namespace MonoTests.Mono.Unix
 					if (r < 0)
 						UnixMarshal.ThrowExceptionForLastError ();
 					Assert.AreEqual (r, sb.Length);
-					Assert.GreaterOrEqual (sb.Capacity, r);
+					AssertHelper.GreaterOrEqual (sb.Capacity, r);
 					if (r == sb.Capacity)
 						checked { sb.Capacity *= 2; }
 					else

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
@@ -8,18 +8,14 @@
 //
 
 using NUnit.Framework;
-#if !MONODROID
-using NUnit.Framework.SyntaxHelpers;
-#endif
+
 using System;
 using System.Text;
 using System.Threading;
 using Mono.Unix;
 using Mono.Unix.Android;
 using Mono.Unix.Native;
-#if !MONODROID
-namespace NUnit.Framework.SyntaxHelpers { class Dummy {} }
-#endif
+
 namespace MonoTests.Mono.Unix {
 
 	[TestFixture]

--- a/mcs/class/Mono.Reactive.Testing/Makefile
+++ b/mcs/class/Mono.Reactive.Testing/Makefile
@@ -3,7 +3,7 @@ SUBDIRS =
 include ../../build/rules.make
 
 LIBRARY = Mono.Reactive.Testing.dll
-LIB_REFS = System System.Core System.Reactive.Interfaces System.Reactive.Core System.Reactive.Linq System.Reactive.PlatformServices System.Reactive.Providers System.Reactive.Runtime.Remoting System.Reactive.Experimental System.Reactive.Windows.Forms System.Reactive.Windows.Threading System.Reactive.Observable.Aliases System.Windows.Forms WindowsBase nunit.framework
+LIB_REFS = System System.Core System.Reactive.Interfaces System.Reactive.Core System.Reactive.Linq System.Reactive.PlatformServices System.Reactive.Providers System.Reactive.Runtime.Remoting System.Reactive.Experimental System.Reactive.Windows.Forms System.Reactive.Windows.Threading System.Reactive.Observable.Aliases System.Windows.Forms WindowsBase nunitlite
 LIB_MCS_FLAGS = \
 		@more_build_args \
 		-d:NUNIT -d:MONO -d:DESKTOPCLR

--- a/mcs/class/Mono.Security/Test/tools/sockethell/Makefile
+++ b/mcs/class/Mono.Security/Test/tools/sockethell/Makefile
@@ -2,7 +2,7 @@ thisdir = class/Mono.Security/Test/tools/sockethell
 SUBDIRS = 
 include ../../../../../build/rules.make
 
-LOCAL_MCS_FLAGS = -r:System.dll -r:Mono.Security.dll -r:../../../../lib/net_4_x/nunit.framework.dll
+LOCAL_MCS_FLAGS = -r:System.dll -r:Mono.Security.dll -r:../../../../lib/net_4_x/nunitlite.dll
 
 all-local install-local uninstall-local:
 

--- a/mcs/class/Mono.XBuild.Tasks/Mono.XBuild.Tasks_test.dll.sources
+++ b/mcs/class/Mono.XBuild.Tasks/Mono.XBuild.Tasks_test.dll.sources
@@ -1,1 +1,2 @@
+../../test-helpers/NunitHelpers.cs
 Mono.XBuild.Tasks/PcFileCacheTest.cs

--- a/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationSaveTest.cs
+++ b/mcs/class/System.Configuration/Test/System.Configuration/ConfigurationSaveTest.cs
@@ -37,7 +37,6 @@ using SysConfig = System.Configuration.Configuration;
 
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 namespace MonoTests.System.Configuration {
 	using Util;

--- a/mcs/class/System.Core/Test/System.Linq/EnumerableFixture.cs
+++ b/mcs/class/System.Core/Test/System.Linq/EnumerableFixture.cs
@@ -34,11 +34,8 @@ using System.Text;
 using System.Threading;
 using NUnit.Framework;
 using System.Linq;
-using NUnit.Framework.SyntaxHelpers;
 using NUnit.Framework.Constraints;
 using System.Diagnostics;
-
-namespace NUnit.Framework.SyntaxHelpers { class Dummy {} }
 
 namespace MonoTests.System.Linq
 {

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/DataContext.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/DataContext.cs
@@ -71,7 +71,7 @@ using MsNorthwind;
             
 
             Assert.IsNotNull(dbCommand.CommandText);
-            Assert.Greater(dbCommand.Parameters.Count, 0);
+            AssertHelper.Greater(dbCommand.Parameters.Count, 0);
         }
     }
 }

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/DynamicLinqTest.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/DynamicLinqTest.cs
@@ -186,7 +186,7 @@ using nwind;
             Northwind db = CreateDB();
             Expression<Func<Customer, bool>> predicate = c => c.City == "Paris";
             int count = db.Customers.Count(predicate);
-            Assert.Greater(count, 0); // Some databases have more than 1 customer in Paris
+            AssertHelper.Greater(count, 0); // Some databases have more than 1 customer in Paris
         }
 
         /// <summary>

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ExecuteCommand_Test.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ExecuteCommand_Test.cs
@@ -68,7 +68,7 @@ using nwind;
         {
             Northwind db = CreateDB();
             int result = db.ExecuteCommand("SELECT count(*) FROM \"Products\"");
-            Assert.Greater(result, 0, "Expecting some rows in Products table, got:" + result);
+            AssertHelper.Greater(result, 0, "Expecting some rows in Products table, got:" + result);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ using nwind;
             Northwind db = CreateDB();
             int result = db.ExecuteCommand("SELECT count(*) FROM [Products] WHERE [ProductID]>{0}", 3);
             //long iResult = base.ExecuteScalar(sql);
-            Assert.Greater(result, 0, "Expecting some rows in Products table, got:" + result);
+            AssertHelper.Greater(result, 0, "Expecting some rows in Products table, got:" + result);
         }
 
     }

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ExecuteQuery_Test.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ExecuteQuery_Test.cs
@@ -67,7 +67,7 @@ using nwind;
             string beforecountry = character.Country;
             character.Country = "Burmuda";
 
-            Assert.Greater(db.GetChangeSet().Updates.Count, 0);
+            AssertHelper.Greater(db.GetChangeSet().Updates.Count, 0);
             db.SubmitChanges();
 
             var character2 = db.Customers.First(c=>c.CustomerID==character.CustomerID);

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/Linq_101_Samples/Advanced.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/Linq_101_Samples/Advanced.cs
@@ -159,7 +159,7 @@ using nwind;
 
             var q3 = q1.Union(q2);
 
-            Assert.Greater(q1.Count(), 0);
+            AssertHelper.Greater(q1.Count(), 0);
             Assert.IsTrue(q1.Count() + q2.Count() >= q3.Count());
 
         }

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTest.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTest.cs
@@ -234,7 +234,7 @@ namespace nwind
             var q = from p in db.Products select p;
             List<Product> products = q.ToList();
             int productCount = products.Count;
-            Assert.Greater(productCount, 0, "Expected some products, got none");
+            AssertHelper.Greater(productCount, 0, "Expected some products, got none");
         }
 
 #if !DEBUG && SQLITE
@@ -572,7 +572,7 @@ namespace nwind
                         .Join(db.GetTable<EmployeeTerritory>(), t => t.TerritoryID, l => l.TerritoryID, (t, l) => l)
                         .Join(db.GetTable<Employee>().Where(e => e.EmployeeID > 0), l => l.EmployeeID, e => e.EmployeeID, (l, e) => e);
             var employeeCount = q.Count();
-            Assert.Greater(employeeCount, 0, "Expected any employees, got count=" + employeeCount);
+            AssertHelper.Greater(employeeCount, 0, "Expected any employees, got count=" + employeeCount);
         }
 
         /// <summary>
@@ -839,7 +839,7 @@ namespace nwind
 
             var q = from p in db.Products where p.ProductName == "Chai" select p.ProductID;
             var productID = q.First();
-            Assert.Greater(productID, 0, "Expected penID>0, got " + productID);
+            AssertHelper.Greater(productID, 0, "Expected penID>0, got " + productID);
         }
 
 
@@ -880,7 +880,7 @@ namespace nwind
 
             var q = from p in db.Products where p.ProductName == "Chai" select p.ProductID;
             var productID = q.Last();
-            Assert.Greater(productID, 0, "Expected penID>0, got " + productID);
+            AssertHelper.Greater(productID, 0, "Expected penID>0, got " + productID);
         }
 
 #if !DEBUG && (POSTGRES || (MSSQL && !L2SQL))
@@ -906,7 +906,7 @@ namespace nwind
                 }
                 prevProductName = p.ProductName;
             }
-            //Assert.Greater(productID,0,"Expected penID>0, got "+productID);
+            //AssertHelper.Greater(productID,0,"Expected penID>0, got "+productID);
         }
 
         [Test]
@@ -915,7 +915,7 @@ namespace nwind
             Northwind db = CreateDB();
             //var q = from p in db.Products where "Chai"==p.ProductName select p.Order;
             //List<Order> penOrders = q.ToList();
-            //Assert.Greater(penOrders.Count,0,"Expected some orders for product 'Chai'");
+            //AssertHelper.Greater(penOrders.Count,0,"Expected some orders for product 'Chai'");
 
             var q =
                 from o in db.Orders
@@ -929,7 +929,7 @@ namespace nwind
                 Assert.IsNotNull(co.c.City, "Expected non-null customer city");
                 Assert.IsNotNull(co.o, "Expected non-null order");
             }
-            Assert.Greater(list1.Count, 0, "Expected some orders for London customers");
+            AssertHelper.Greater(list1.Count, 0, "Expected some orders for London customers");
         }
 
         [Test]
@@ -947,7 +947,7 @@ namespace nwind
                 Assert.IsNotNull(co.c, "Expected non-null customer");
                 Assert.IsNotNull(co.o, "Expected non-null order");
             }
-            Assert.Greater(list1.Count, 0, "Expected some orders for London customers");
+            AssertHelper.Greater(list1.Count, 0, "Expected some orders for London customers");
         }
 
         [Test]
@@ -962,7 +962,7 @@ namespace nwind
                 where c.City == "London"
                 select new { c, o };
 
-            Assert.Greater(q.ToList().Count, 0, "Expected some orders for London customers");
+            AssertHelper.Greater(q.ToList().Count, 0, "Expected some orders for London customers");
         }
 
         [Test]
@@ -987,7 +987,7 @@ namespace nwind
 #else
             int expectedCount = 2; //Oracle, Mysql: 'Toilet Paper' and 'iPod'
 #endif
-            Assert.Greater(prods.Count, expectedCount, "Expected couple of products with letter 'p'");
+            AssertHelper.Greater(prods.Count, expectedCount, "Expected couple of products with letter 'p'");
         }
 
         [Test]
@@ -1002,11 +1002,11 @@ namespace nwind
             ).Take(5);
             //var q = db.Products.Where( p=>p.ProductName.Contains("p")).Take(5);
             List<Product> prods = q.ToList();
-            Assert.Greater(prods.Count, 2, "Expected couple of products with letter 'p'");
+            AssertHelper.Greater(prods.Count, 2, "Expected couple of products with letter 'p'");
 
             var prodID0 = prods[0].ProductID;
             var prodID1 = prods[1].ProductID;
-            Assert.Greater(prodID0, prodID1, "Sorting is broken");
+            AssertHelper.Greater(prodID0, prodID1, "Sorting is broken");
         }
 
         [Test]

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTest_Complex.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTest_Complex.cs
@@ -136,7 +136,7 @@ using Id = System.Int32;
         {
             var q = from p in db.Products select p;
             int productCount = q.Count();
-            Assert.Greater(productCount, 0, "Expected non-zero product count");
+            AssertHelper.Greater(productCount, 0, "Expected non-zero product count");
         }
 
         [Test]
@@ -144,7 +144,7 @@ using Id = System.Int32;
         {
             var q = from p in db.Products select p.ProductID;
             int productCount = q.Count();
-            Assert.Greater(productCount, 0, "Expected non-zero product count");
+            AssertHelper.Greater(productCount, 0, "Expected non-zero product count");
             Console.WriteLine();
         }
         [Test]
@@ -152,7 +152,7 @@ using Id = System.Int32;
         {
             var q = from p in db.Products select p.ProductID;
             int productCount = q.Count(i => i < 3);
-            Assert.Greater(productCount, 0, "Expected non-zero product count");
+            AssertHelper.Greater(productCount, 0, "Expected non-zero product count");
             Assert.IsTrue(productCount < 4, "Expected product count < 3");
         }
 
@@ -161,7 +161,7 @@ using Id = System.Int32;
         {
             var q = from p in db.Products select p.ProductID;
             var maxID = q.Max();
-            Assert.Greater(maxID, 0, "Expected non-zero product count");
+            AssertHelper.Greater(maxID, 0, "Expected non-zero product count");
         }
 
         [Test]
@@ -169,7 +169,7 @@ using Id = System.Int32;
         {
             var q = from p in db.Products select p.ProductID;
             var minID = q.Min();
-            Assert.Greater(minID, 0, "Expected non-zero product count");
+            AssertHelper.Greater(minID, 0, "Expected non-zero product count");
         }
 
 #if !ORACLE // picrap: this test causes an internal buffer overflow when marshaling with oracle win32 driver
@@ -179,7 +179,7 @@ using Id = System.Int32;
         {
             var q = from p in db.Products select p.ProductID;
             double avg = q.Average();
-            Assert.Greater(avg, 0, "Expected non-zero productID average");
+            AssertHelper.Greater(avg, 0, "Expected non-zero productID average");
         }
 
 #endif
@@ -268,7 +268,7 @@ using Id = System.Int32;
             var q4 = from p in db.Products select p.ProductName + p.ProductID;
             //var q4 = from p in db.Products select p.ProductID;
             var q5 = q4.ToList();
-            Assert.Greater(q5.Count, 2, "Expected to see some concat strings");
+            AssertHelper.Greater(q5.Count, 2, "Expected to see some concat strings");
             foreach (string s0 in q5)
             {
                 bool startWithLetter = Char.IsLetter(s0[0]);
@@ -288,7 +288,7 @@ using Id = System.Int32;
                      select p.ProductName+p.ProductID;
             //var q4 = from p in db.Products select p.ProductID;
             //var q5 = q4.ToList();
-            Assert.Greater( q4.Count(), 2, "Expected to see some concat strings");
+            AssertHelper.Greater( q4.Count(), 2, "Expected to see some concat strings");
             foreach(string s0 in q4)
             {
                 bool startWithLetter = Char.IsLetter(s0[0]);
@@ -312,8 +312,8 @@ using Id = System.Int32;
                                           CustomerID = c.CustomerID
                                       });
             var list = q.ToList();
-            Assert.Greater(list.Count(), 0, "Expected list");
-            //Assert.Greater(list.Count(), 0, "Expected list");
+            AssertHelper.Greater(list.Count(), 0, "Expected list");
+            //AssertHelper.Greater(list.Count(), 0, "Expected list");
             Assert.Ignore("test passed but: theoretically constructions of entity types are not allowed");
         }
 
@@ -331,8 +331,8 @@ using Id = System.Int32;
             //this OrderBy clause messes up the SQL statement
             var q2 = q.OrderBy(c => c.CustomerID);
             var list = q2.ToList();
-            Assert.Greater(list.Count(), 0, "Expected list");
-            //Assert.Greater(list.Count(), 0, "Expected list");
+            AssertHelper.Greater(list.Count(), 0, "Expected list");
+            //AssertHelper.Greater(list.Count(), 0, "Expected list");
         }
 
 
@@ -344,7 +344,7 @@ using Id = System.Int32;
                     orderby c.ContactName ?? ""
                     select c;
             var list = q.ToList();
-            Assert.Greater(list.Count(), 0, "Expected list");
+            AssertHelper.Greater(list.Count(), 0, "Expected list");
         }
 
         [Test(Description = "Non-dynamic version of DL5_NestedObjectSelect")]

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTest_GroupBy.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTest_GroupBy.cs
@@ -231,10 +231,10 @@ using nwind;
                      select new { g.Key, OrderCount = g.Count() };
 
             var lst = q2.ToList();
-            Assert.Greater(lst.Count, 0, "Expected some grouped order results");
+            AssertHelper.Greater(lst.Count, 0, "Expected some grouped order results");
             var result0 = lst[0];
             Assert.IsTrue(result0.Key != null, "Key must be non-null");
-            Assert.Greater(result0.OrderCount, 0, "Count must be > 0");
+            AssertHelper.Greater(result0.OrderCount, 0, "Count must be > 0");
             //select new { g.Key , SumPerCustomer = g.Sum(o2=>o2.OrderID) };
         }
 
@@ -252,10 +252,10 @@ using nwind;
                      select new { g.Key, OrderCount = g.Count() };
 
             var lst = q2.ToList();
-            Assert.Greater(lst.Count, 0, "Expected some grouped order results");
+            AssertHelper.Greater(lst.Count, 0, "Expected some grouped order results");
             var result0 = lst[0];
             Assert.IsTrue(result0.Key != null, "Key must be non-null");
-            Assert.Greater(result0.OrderCount, 0, "Count must be > 0");
+            AssertHelper.Greater(result0.OrderCount, 0, "Count must be > 0");
             //select new { g.Key , SumPerCustomer = g.Sum(o2=>o2.OrderID) };
         }
 
@@ -272,12 +272,12 @@ using nwind;
                      //where g.Count()>1
                      select new { g.Key, OrderSum = g.Sum(o => o.OrderID) };
             var lst = q2.ToList();
-            Assert.Greater(lst.Count, 0, "Expected some grouped order results");
+            AssertHelper.Greater(lst.Count, 0, "Expected some grouped order results");
             foreach (var result in lst)
             {
                 Console.WriteLine("  Result: custID=" + result.Key + " sum=" + result.OrderSum);
                 Assert.IsTrue(result.Key != null, "Key must be non-null");
-                Assert.Greater(result.OrderSum, 0, "OrderSum must be > 0");
+                AssertHelper.Greater(result.OrderSum, 0, "OrderSum must be > 0");
             }
             //select new { g.Key , SumPerCustomer = g.Sum(o2=>o2.OrderID) };
         }

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTests_AnyCountFirst.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTests_AnyCountFirst.cs
@@ -331,7 +331,7 @@ using nwind;
             decimal[] d = new decimal[] { 1, 4, 5, 6, 10248, 10255 };
             var q = db.OrderDetails.Where(o => d.Contains(o.OrderID));
 
-            Assert.Greater(q.Count(), 0);
+            AssertHelper.Greater(q.Count(), 0);
         }
 
 

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTests_DateTimeFunctions.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTests_DateTimeFunctions.cs
@@ -265,7 +265,7 @@ using DbLinq.Data.Linq;
 
 
             var list = query.ToList();
-            Assert.Greater(list.Count, 0);
+            AssertHelper.Greater(list.Count, 0);
         }
 
 #if !DEBUG && SQLITE
@@ -299,7 +299,7 @@ using DbLinq.Data.Linq;
 
 
             var list = query.ToList();
-            Assert.Greater(list.Count, 0);
+            AssertHelper.Greater(list.Count, 0);
         }
 
 
@@ -334,7 +334,7 @@ using DbLinq.Data.Linq;
 
 
             var list = query.ToList();
-            Assert.Greater(list.Count, 0);
+            AssertHelper.Greater(list.Count, 0);
         }
 
 #if !DEBUG && (SQLITE || MSSQL)
@@ -354,7 +354,7 @@ using DbLinq.Data.Linq;
             
 
             var list = query.ToList();
-            Assert.Greater(list.Count, 0);
+            AssertHelper.Greater(list.Count, 0);
         }
 
 #if !DEBUG && SQLITE
@@ -388,7 +388,7 @@ using DbLinq.Data.Linq;
 
 
             var list = query.ToList();
-            Assert.Greater(list.Count, 0);
+            AssertHelper.Greater(list.Count, 0);
         }
 
 #if !DEBUG && SQLITE
@@ -410,7 +410,7 @@ using DbLinq.Data.Linq;
 
             var list = query.ToList();
 
-            Assert.Greater(list.Count, 0);
+            AssertHelper.Greater(list.Count, 0);
         }
 
 #if !DEBUG && POSTGRES
@@ -443,7 +443,7 @@ using DbLinq.Data.Linq;
 
                 var list = query.ToList();
 
-                Assert.Greater(list.Count, 0);
+                AssertHelper.Greater(list.Count, 0);
             }
             finally
             {
@@ -481,7 +481,7 @@ using DbLinq.Data.Linq;
 
                 var list = query.ToList();
 
-                Assert.Greater(list.Count, 0);
+                AssertHelper.Greater(list.Count, 0);
             }
             finally
             {

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTests_EntitySet.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/ReadTests_EntitySet.cs
@@ -53,7 +53,7 @@ using nwind;
         {
             var db = CreateDB();
             var customer = db.Customers.First();
-            Assert.Greater(customer.Orders.Count, 0);
+            AssertHelper.Greater(customer.Orders.Count, 0);
         }
 
 #if !DEBUG && (SQLITE || (MSSQL && !L2SQL))
@@ -65,7 +65,7 @@ using nwind;
             var db = CreateDB();
             var results = (from c in db.Customers select c.Orders).ToList();
 
-            Assert.Greater(results.Count, 0);
+            AssertHelper.Greater(results.Count, 0);
         }
 
         [Test]
@@ -98,7 +98,7 @@ using nwind;
             var db = CreateDB();
             var customer = db.Customers.First();
 
-            Assert.Greater(customer.Orders.Count, 0, "#1");
+            AssertHelper.Greater(customer.Orders.Count, 0, "#1");
             Assert.IsTrue(customer.Orders.HasLoadedOrAssignedValues, "#2");
             customer.Orders.SetSource(System.Linq.Enumerable.Empty<Order>());
         }
@@ -136,7 +136,7 @@ using nwind;
             int ordersCount = (from cust in db.Customers
                                select cust.Orders.Count).First();
 
-            Assert.Greater(ordersCount, 0);
+            AssertHelper.Greater(ordersCount, 0);
 
             var customer2 = db.Customers.First();
             customer2.Orders.SetSource(System.Linq.Enumerable.Empty<Order>());
@@ -154,11 +154,11 @@ using nwind;
             var c = db.Customers.First();
 
             int beforeCount = c.Orders.Count;
-            Assert.Greater(beforeCount, 0);
+            AssertHelper.Greater(beforeCount, 0);
             c.Orders.Clear();
             Assert.AreEqual(c.Orders.Count, 0);
             c.Orders.AddRange(db.Orders);
-            Assert.Greater(c.Orders.Count, beforeCount);
+            AssertHelper.Greater(c.Orders.Count, beforeCount);
             db.Refresh(RefreshMode.OverwriteCurrentValues, c.Orders);
 
             Assert.AreEqual(c.Orders.Count, beforeCount);
@@ -174,13 +174,13 @@ using nwind;
             var c = db.Customers.First();
 
             int beforeCount = c.Orders.Count;
-            Assert.Greater(beforeCount, 0);
+            AssertHelper.Greater(beforeCount, 0);
             c.Orders.Clear();
             Assert.AreEqual(c.Orders.Count, 0);
             c.Orders.AddRange(db.Orders);
 
             int middleCount = c.Orders.Count;
-            Assert.Greater(c.Orders.Count, beforeCount);
+            AssertHelper.Greater(c.Orders.Count, beforeCount);
 
             db.Refresh(RefreshMode.KeepCurrentValues, c.Orders);
             Assert.AreEqual(c.Orders.Count, middleCount);
@@ -233,7 +233,7 @@ using nwind;
         {
             var db = CreateDB();
             var customer = db.Customers.Where(c => c.Orders.Count > 0).First();
-            Assert.Greater(customer.Orders.Count, 0);
+            AssertHelper.Greater(customer.Orders.Count, 0);
             bool ok;
             System.ComponentModel.ListChangedEventArgs args = null;
             customer.Orders.ListChanged += delegate(object sender, System.ComponentModel.ListChangedEventArgs a) 

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/StoredProcTest.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/StoredProcTest.cs
@@ -86,10 +86,10 @@ using nwind;
             foreach (var c in q)
             {
                 Assert.IsNotNull(c.CustomerID);
-                Assert.Greater(c.OrderCount, -1);
+                AssertHelper.Greater(c.OrderCount, -1);
                 count++;
             }
-            Assert.Greater(count, 0);
+            AssertHelper.Greater(count, 0);
         }
 
         [Test]
@@ -103,10 +103,10 @@ using nwind;
             foreach (var v in q)
             {
                 Assert.IsNotNull(v.c.CustomerID);
-                Assert.Greater(v.OrderCount, -1);
+                AssertHelper.Greater(v.OrderCount, -1);
                 count++;
             }
-            Assert.Greater(count, 0);
+            AssertHelper.Greater(count, 0);
         }
 
         [Test]
@@ -121,7 +121,7 @@ using nwind;
                 Assert.IsTrue(c.CustomerID!=null, "Non-null customerID required");
                 count++;
             }
-            Assert.Greater(count, 0);
+            AssertHelper.Greater(count, 0);
         }
 #endif
     }

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/Table.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/Table.cs
@@ -161,7 +161,7 @@ using nwind;
             var customer = new Customer();
             db.Customers.Attach(customer, originalCustomer);
 
-            Assert.Greater(db.Customers.GetModifiedMembers(customer).Count(), 0);
+            AssertHelper.Greater(db.Customers.GetModifiedMembers(customer).Count(), 0);
         }
 
 #if !DEBUG && (SQLITE || POSTGRES || (MSSQL && !L2SQL))

--- a/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/WriteTest.cs
+++ b/mcs/class/System.Data.Linq/src/DbLinq/Test/Providers/WriteTest.cs
@@ -165,7 +165,7 @@ using Id = System.Int32;
             newProd.QuantityPerUnit = "33 1/2";
             db.Products.InsertOnSubmit(newProd);
             db.SubmitChanges();
-            Assert.Greater(newProd.ProductID, 0, "After insertion, ProductID should be non-zero");
+            AssertHelper.Greater(newProd.ProductID, 0, "After insertion, ProductID should be non-zero");
             //Assert.IsFalse(newProd.IsModified, "After insertion, Product.IsModified should be false");
             return (int)newProd.ProductID; //this test cab be used from delete tests
         }
@@ -180,7 +180,7 @@ using Id = System.Int32;
         public void G2_DeleteTest()
         {
             int insertedID = insertProduct_priv();
-            Assert.Greater(insertedID, 0, "DeleteTest cannot operate if row was not inserted");
+            AssertHelper.Greater(insertedID, 0, "DeleteTest cannot operate if row was not inserted");
 
             Northwind db = CreateDB();
 
@@ -200,7 +200,7 @@ using Id = System.Int32;
         public void G3_DeleteTest()
         {
             int insertedID = insertProduct_priv();
-            Assert.Greater(insertedID, 0, "DeleteTest cannot operate if row was not inserted");
+            AssertHelper.Greater(insertedID, 0, "DeleteTest cannot operate if row was not inserted");
 
             Northwind db = CreateDB();
 

--- a/mcs/class/System.Data/Test/System.Data/ConstraintCollectionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/ConstraintCollectionTest.cs
@@ -34,9 +34,6 @@
 using NUnit.Framework;
 using System;
 using System.Data;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Data
 {

--- a/mcs/class/System.Data/Test/System.Data/ConstraintTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/ConstraintTest.cs
@@ -34,9 +34,6 @@
 using NUnit.Framework;
 using System;
 using System.Data;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Data
 {

--- a/mcs/class/System.Data/Test/System.Data/DataRelationCollectionTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataRelationCollectionTest.cs
@@ -30,9 +30,6 @@
 using NUnit.Framework;
 using System;
 using System.Data;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Data
 {

--- a/mcs/class/System.Data/Test/System.Data/DataRelationTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/DataRelationTest.cs
@@ -34,9 +34,6 @@
 using NUnit.Framework;
 using System;
 using System.Data;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Data
 {

--- a/mcs/class/System.Data/Test/System.Data/TypedDataSetGeneratorTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/TypedDataSetGeneratorTest.cs
@@ -40,7 +40,7 @@ using Microsoft.CSharp;
 namespace MonoTests.System.Data
 {
 	[TestFixture]
-	public class TypedDataSetGeneratorTest : Assertion
+	public class TypedDataSetGeneratorTest
 	{
 		private ICodeGenerator gen;
 		private ICodeCompiler compiler;
@@ -70,20 +70,20 @@ namespace MonoTests.System.Data
 		public void TestGenerateIdName ()
 		{
 		
-			AssertEquals ("#1", "a", TypedDataSetGenerator.GenerateIdName ("a", gen));
-			AssertEquals ("#2", "_int", TypedDataSetGenerator.GenerateIdName ("int", gen));
-			AssertEquals ("#3", "_", TypedDataSetGenerator.GenerateIdName ("_", gen));
-			AssertEquals ("#3-2", "_", TypedDataSetGenerator.GenerateIdName ("_", gen));
-			AssertEquals ("#4", "_1", TypedDataSetGenerator.GenerateIdName ("1", gen));
-			AssertEquals ("#4-2", "_1", TypedDataSetGenerator.GenerateIdName ("1", gen));
-			AssertEquals ("#5", "_1a", TypedDataSetGenerator.GenerateIdName ("1a", gen));
-			AssertEquals ("#6", "_1_2", TypedDataSetGenerator.GenerateIdName ("1*2", gen));
-			AssertEquals ("#7", "__", TypedDataSetGenerator.GenerateIdName ("-", gen));
-			AssertEquals ("#8", "__", TypedDataSetGenerator.GenerateIdName ("+", gen));
-			AssertEquals ("#9", "_", TypedDataSetGenerator.GenerateIdName ("", gen));
-			AssertEquals ("#10", "___", TypedDataSetGenerator.GenerateIdName ("--", gen));
-			AssertEquals ("#11", "___", TypedDataSetGenerator.GenerateIdName ("++", gen));
-			AssertEquals ("#12", "\u3042", TypedDataSetGenerator.GenerateIdName ("\u3042", gen));
+			Assert.AreEqual ("a", TypedDataSetGenerator.GenerateIdName ("a", gen), "#1");
+			Assert.AreEqual ("_int", TypedDataSetGenerator.GenerateIdName ("int", gen), "#2");
+			Assert.AreEqual ("_", TypedDataSetGenerator.GenerateIdName ("_", gen), "#3");
+			Assert.AreEqual ("_", TypedDataSetGenerator.GenerateIdName ("_", gen), "#3-2");
+			Assert.AreEqual ("_1", TypedDataSetGenerator.GenerateIdName ("1", gen), "#4");
+			Assert.AreEqual ("_1", TypedDataSetGenerator.GenerateIdName ("1", gen), "#4-2");
+			Assert.AreEqual ("_1a", TypedDataSetGenerator.GenerateIdName ("1a", gen), "#5");
+			Assert.AreEqual ("_1_2", TypedDataSetGenerator.GenerateIdName ("1*2", gen), "#6");
+			Assert.AreEqual ("__", TypedDataSetGenerator.GenerateIdName ("-", gen), "#7");
+			Assert.AreEqual ("__", TypedDataSetGenerator.GenerateIdName ("+", gen), "#8");
+			Assert.AreEqual ("_", TypedDataSetGenerator.GenerateIdName ("", gen), "#9");
+			Assert.AreEqual ("___", TypedDataSetGenerator.GenerateIdName ("--", gen), "#10");
+			Assert.AreEqual ("___", TypedDataSetGenerator.GenerateIdName ("++", gen), "#11");
+			Assert.AreEqual ("\u3042", TypedDataSetGenerator.GenerateIdName ("\u3042", gen), "#12");
 		}
 
 		[Test]
@@ -98,7 +98,7 @@ namespace MonoTests.System.Data
 			ccu.Namespaces.Add (cns);
 			CompilerResults r = compiler.CompileAssemblyFromDom (
 				new CompilerParameters (), ccu);
-			AssertEquals (0, r.Errors.Count);
+			Assert.AreEqual (0, r.Errors.Count);
 		}
 	}
 }

--- a/mcs/class/System.Data/Test/System.Data/UniqueConstraintTest.cs
+++ b/mcs/class/System.Data/Test/System.Data/UniqueConstraintTest.cs
@@ -33,9 +33,6 @@
 using NUnit.Framework;
 using System;
 using System.Data;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Data
 {

--- a/mcs/class/System.Drawing/System.Drawing_test.dll.sources
+++ b/mcs/class/System.Drawing/System.Drawing_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 ../../../build/common/Locale.cs
 ../System.Drawing/gdipEnums.cs    
 ../System.Drawing/gdipFunctions.cs

--- a/mcs/class/System.Drawing/Test/DrawingTest/Test/Graphics.cs
+++ b/mcs/class/System.Drawing/Test/DrawingTest/Test/Graphics.cs
@@ -38,9 +38,6 @@ using System.Drawing.Text;
 using System.Drawing.Imaging;
 using DrawingTestHelper;
 using System.IO;
-#if !MONOTOUCH
-using  NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace Test.Sys.Drawing.GraphicsFixtures {
 	#region GraphicsFixtureProps

--- a/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting_test.dll.sources
+++ b/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 System.Runtime.Remoting.Channels.Tcp/TcpChannelTest.cs
 ServerObject.cs
 ContextsTest.cs

--- a/mcs/class/System.Runtime.Remoting/Test/IpcChannelTest.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/IpcChannelTest.cs
@@ -78,7 +78,7 @@ namespace MonoTests.Remoting
 			IpcServerChannel chan = new IpcServerChannel (channelName, portName);
 			string[] uris = chan.GetUrlsForUri ("server.rem");
 			Assert.IsNotNull (uris);
-			Assert.Greater (uris.Length, 0);
+			AssertHelper.Greater (uris.Length, 0);
 
 			bool found = false;
 			foreach (string s in uris) {
@@ -101,7 +101,7 @@ namespace MonoTests.Remoting
 			IpcChannel chan = new IpcChannel (props, null, null);
 			string[] uris = chan.GetUrlsForUri ("server.rem");
 			Assert.IsNotNull (uris);
-			Assert.Greater (uris.Length, 0);
+			AssertHelper.Greater (uris.Length, 0);
 
 			bool found = false;
 			foreach (string s in uris) {

--- a/mcs/class/System.Runtime.Remoting/Test/RemotingServicesTest.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/RemotingServicesTest.cs
@@ -193,7 +193,7 @@ namespace MonoTests.Remoting
 
 	// The main test class
 	[TestFixture]
-	public class RemotingServicesTest : Assertion
+	public class RemotingServicesTest
 	{
 		private static int MarshalObjectId = 0;
 
@@ -233,13 +233,13 @@ namespace MonoTests.Remoting
 			MarshalObject objMarshal = NewMarshalObject ();
 			ObjRef objRef = RemotingServices.Marshal (objMarshal);
 
-			Assert ("#A01", objRef.URI != null);
+			Assert.IsNotNull (objRef.URI, "#A01");
 
 			MarshalObject objRem = (MarshalObject) RemotingServices.Unmarshal (objRef);
-			AssertEquals ("#A02", objMarshal.Id, objRem.Id);
+			Assert.AreEqual (objMarshal.Id, objRem.Id, "#A02");
 
 			objRem.Id = 2;
-			AssertEquals ("#A03", objMarshal.Id, objRem.Id);
+			Assert.AreEqual (objMarshal.Id, objRem.Id, "#A03");
 
 			// TODO: uncomment when RemotingServices.Disconnect is implemented
 			//RemotingServices.Disconnect(objMarshal);
@@ -248,7 +248,7 @@ namespace MonoTests.Remoting
 
 			objRef = RemotingServices.Marshal (objMarshal, objMarshal.Uri);
 
-			Assert ("#A04", objRef.URI.EndsWith (objMarshal.Uri));
+			Assert.IsTrue (objRef.URI.EndsWith (objMarshal.Uri), "#A04");
 			// TODO: uncomment when RemotingServices.Disconnect is implemented
 			//RemotingServices.Disconnect(objMarshal);
 		}
@@ -261,7 +261,7 @@ namespace MonoTests.Remoting
 			ObjRef objRef = RemotingServices.Marshal (derivedObjMarshal, derivedObjMarshal.Uri, typeof (MarshalObject));
 
 			// Check that the type of the marshaled object is MarshalObject
-			Assert ("#A05", objRef.TypeInfo.TypeName.StartsWith ((typeof (MarshalObject)).ToString ()));
+			Assert.IsTrue (objRef.TypeInfo.TypeName.StartsWith ((typeof (MarshalObject)).ToString ()), "#A05");
 
 			// TODO: uncomment when RemotingServices.Disconnect is implemented
 			//RemotingServices.Disconnect(derivedObjMarshal);
@@ -273,11 +273,11 @@ namespace MonoTests.Remoting
 		{
 			MarshalObject objMarshal = NewMarshalObject ();
 
-			Assert ("#A06", RemotingServices.GetObjectUri (objMarshal) == null);
+			Assert.IsNull (RemotingServices.GetObjectUri (objMarshal), "#A06");
 
 			RemotingServices.Marshal (objMarshal);
 
-			Assert ("#A07", RemotingServices.GetObjectUri (objMarshal) != null);
+			Assert.IsNotNull (RemotingServices.GetObjectUri (objMarshal), "#A07");
 			// TODO: uncomment when RemotingServices.Disconnect is implemented
 			//RemotingServices.Disconnect(objMarshal);
 		}
@@ -297,7 +297,7 @@ namespace MonoTests.Remoting
 			try {
 				RemotingServices.Marshal (objMarshal, objMarshal.Uri);
 				MarshalObject objRem = (MarshalObject) RemotingServices.Connect (typeof (MarshalObject), "tcp://localhost:1236/" + objMarshal.Uri);
-				Assert ("#A08", RemotingServices.IsTransparentProxy (objRem));
+				Assert.IsTrue (RemotingServices.IsTransparentProxy (objRem), "#A08");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 				RemotingServices.Disconnect (objMarshal);
@@ -324,7 +324,7 @@ namespace MonoTests.Remoting
 				// a real object
 				try {
 					RemotingServices.Marshal (objRem, objMarshal.Uri);
-					Fail ("#1");
+					Assert.Fail ("#1");
 				} catch (RemotingException e) {
 				}
 			} finally {
@@ -355,15 +355,15 @@ namespace MonoTests.Remoting
 				objRem.Method1 ();
 
 				// Tests RemotingServices.GetMethodBaseFromMethodMessage()
-				AssertEquals ("#A09", "Method1", proxy.MthBase.Name);
-				Assert ("#A09.1", !proxy.IsMethodOverloaded);
+				Assert.AreEqual ("Method1", proxy.MthBase.Name, "#A09");
+				Assert.IsFalse (proxy.IsMethodOverloaded, "#A09.1");
 
 				objRem.Method2 ();
-				Assert ("#A09.2", proxy.IsMethodOverloaded);
+				Assert.IsTrue (proxy.IsMethodOverloaded, "#A09.2");
 
 				// Tests RemotingServices.ExecuteMessage();
 				// If ExecuteMessage does it job well, Method1 should be called 2 times
-				AssertEquals ("#A10", 2, MarshalObject.Called);
+				Assert.AreEqual (2, MarshalObject.Called, "#A10");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -380,14 +380,14 @@ namespace MonoTests.Remoting
 
 				MarshalObject objRem = (MarshalObject) Activator.GetObject (typeof (MarshalObject), "tcp://localhost:1238/MarshalObject.rem");
 
-				Assert ("#A10.1", RemotingServices.IsTransparentProxy (objRem));
+				Assert.IsTrue (RemotingServices.IsTransparentProxy (objRem), "#A10.1");
 
 				objRem.Method1 ();
 				Thread.Sleep (20);
-				Assert ("#A10.2", !MarshalObject.IsMethodOneWay);
+				Assert.IsFalse (MarshalObject.IsMethodOneWay, "#A10.2");
 				objRem.Method3 ();
 				Thread.Sleep (20);
-				Assert ("#A10.3", MarshalObject.IsMethodOneWay);
+				Assert.IsTrue (MarshalObject.IsMethodOneWay, "#A10.3");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -409,7 +409,7 @@ namespace MonoTests.Remoting
 
 				ObjRef objRefRem = RemotingServices.GetObjRefForProxy ((MarshalByRefObject) objRem);
 
-				Assert ("#A11", objRefRem != null);
+				Assert.IsNotNull (objRefRem, "#A11");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -429,8 +429,8 @@ namespace MonoTests.Remoting
 
 				RealProxy rp = RemotingServices.GetRealProxy (objRem);
 
-				Assert ("#A12", rp != null);
-				AssertEquals ("#A13", "MonoTests.System.Runtime.Remoting.RemotingServicesInternal.MyProxy", rp.GetType ().ToString ());
+				Assert.IsNotNull (rp, "#A12");
+				Assert.AreEqual ("MonoTests.System.Runtime.Remoting.RemotingServicesInternal.MyProxy", rp.GetType ().ToString (), "#A13");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -448,7 +448,7 @@ namespace MonoTests.Remoting
 				RemotingServices.Marshal (objRem);
 
 				objRem = (MarshalObject) Activator.GetObject (typeof (MarshalObject), "tcp://localhost:1242/" + objRem.Uri);
-				Assert ("#A14", objRem != null);
+				Assert.IsNotNull (objRem, "#A14");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -468,7 +468,7 @@ namespace MonoTests.Remoting
 				RemotingServices.Marshal (objRem);
 
 				Type typeRem = RemotingServices.GetServerTypeForUri (RemotingServices.GetObjectUri (objRem));
-				AssertEquals ("#A15", type, typeRem);
+				Assert.AreEqual (type, typeRem, "#A15");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -487,12 +487,12 @@ namespace MonoTests.Remoting
 
 				MarshalObject objRem = (MarshalObject) Activator.GetObject (typeof (MarshalObject), "tcp://localhost:1245/MarshalObject2.rem");
 
-				Assert ("#A16", RemotingServices.IsObjectOutOfAppDomain (objRem));
-				Assert ("#A17", RemotingServices.IsObjectOutOfContext (objRem));
+				Assert.IsTrue (RemotingServices.IsObjectOutOfAppDomain (objRem), "#A16");
+				Assert.IsTrue (RemotingServices.IsObjectOutOfContext (objRem), "#A17");
 
 				MarshalObject objMarshal = new MarshalObject ();
-				Assert ("#A18", !RemotingServices.IsObjectOutOfAppDomain (objMarshal));
-				Assert ("#A19", !RemotingServices.IsObjectOutOfContext (objMarshal));
+				Assert.IsFalse (RemotingServices.IsObjectOutOfAppDomain (objMarshal), "#A18");
+				Assert.IsFalse (RemotingServices.IsObjectOutOfContext (objMarshal), "#A19");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -510,16 +510,16 @@ namespace MonoTests.Remoting
 				MarshalObject objRem = (MarshalObject) Activator.GetObject (typeof (MarshalObject), "tcp://localhost:1246/app/obj3.rem");
 				MarshalObject objRem2 = (MarshalObject) Activator.GetObject (typeof (MarshalObject), "tcp://localhost:1246/obj3.rem");
 
-				Assert ("#AN1", RemotingServices.IsTransparentProxy (objRem));
-				Assert ("#AN2", RemotingServices.IsTransparentProxy (objRem2));
+				Assert.IsTrue (RemotingServices.IsTransparentProxy (objRem), "#AN1");
+				Assert.IsTrue (RemotingServices.IsTransparentProxy (objRem2), "#AN2");
 
-				AssertNotNull ("#AN3", RemotingServices.GetServerTypeForUri ("obj3.rem"));
-				AssertNotNull ("#AN4", RemotingServices.GetServerTypeForUri ("/app/obj3.rem"));
-				AssertNull ("#AN5", RemotingServices.GetServerTypeForUri ("//app/obj3.rem"));
-				AssertNull ("#AN6", RemotingServices.GetServerTypeForUri ("app/obj3.rem"));
-				AssertNull ("#AN7", RemotingServices.GetServerTypeForUri ("/whatever/obj3.rem"));
-				AssertNotNull ("#AN8", RemotingServices.GetServerTypeForUri ("/obj3.rem"));
-				AssertNull ("#AN9", RemotingServices.GetServerTypeForUri ("//obj3.rem"));
+				Assert.IsNotNull (RemotingServices.GetServerTypeForUri ("obj3.rem"), "#AN3");
+				Assert.IsNotNull (RemotingServices.GetServerTypeForUri ("/app/obj3.rem"), "#AN4");
+				Assert.IsNull (RemotingServices.GetServerTypeForUri ("//app/obj3.rem"), "#AN5");
+				Assert.IsNull (RemotingServices.GetServerTypeForUri ("app/obj3.rem"), "#AN6");
+				Assert.IsNull (RemotingServices.GetServerTypeForUri ("/whatever/obj3.rem"), "#AN7");
+				Assert.IsNotNull (RemotingServices.GetServerTypeForUri ("/obj3.rem"), "#AN8");
+				Assert.IsNull (RemotingServices.GetServerTypeForUri ("//obj3.rem"), "#AN9");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -534,7 +534,7 @@ namespace MonoTests.Remoting
 				RemotingConfiguration.RegisterWellKnownServiceType (typeof (MarshalObject), "getobjectwithchanneldata.rem", WellKnownObjectMode.Singleton);
 
 				string channelData = "test";
-				AssertNotNull ("#01", Activator.GetObject (typeof (MarshalObject), "tcp://localhost:1247/getobjectwithchanneldata.rem", channelData));
+				Assert.IsNotNull (Activator.GetObject (typeof (MarshalObject), "tcp://localhost:1247/getobjectwithchanneldata.rem", channelData), "#01");
 			} finally {
 				ChannelServices.UnregisterChannel (chn);
 			}
@@ -548,28 +548,28 @@ namespace MonoTests.Remoting
 			RemotingConfiguration.Configure (null);
 
 			o = RemotingServices.Connect (typeof (MarshalByRefObject), "tcp://localhost:3434/ff1.rem");
-			Assert ("#m1", o is DD);
-			Assert ("#m2", o is A);
-			Assert ("#m3", o is B);
-			Assert ("#m4", !(o is CC));
+			Assert.IsInstanceOfType (typeof (DD), o, "#m1");
+			Assert.IsInstanceOfType (typeof (A), o, "#m2");
+			Assert.IsInstanceOfType (typeof (B), o, "#m3");
+			AssertHelper.IsNotInstanceOfType (typeof (CC), !(o is CC), "#m4");
 
 			o = RemotingServices.Connect (typeof (A), "tcp://localhost:3434/ff3.rem");
-			Assert ("#a1", o is DD);
-			Assert ("#a2", o is A);
-			Assert ("#a3", o is B);
-			Assert ("#a4", !(o is CC));
+			Assert.IsInstanceOfType (typeof (DD), o, "#a1");
+			Assert.IsInstanceOfType (typeof (A), o, "#a2");
+			Assert.IsInstanceOfType (typeof (B), o, "#a3");
+			AssertHelper.IsNotInstanceOfType (typeof (CC), o, "#a4");
 
 			o = RemotingServices.Connect (typeof (DD), "tcp://localhost:3434/ff4.rem");
-			Assert ("#d1", o is DD);
-			Assert ("#d2", o is A);
-			Assert ("#d3", o is B);
-			Assert ("#d4", !(o is CC));
+			Assert.IsInstanceOfType (typeof (DD), o, "#d1");
+			Assert.IsInstanceOfType (typeof (A), o, "#d2");
+			Assert.IsInstanceOfType (typeof (B), o, "#d3");
+			AssertHelper.IsNotInstanceOfType (typeof (CC), o, "#d4");
 
 			o = RemotingServices.Connect (typeof (CC), "tcp://localhost:3434/ff5.rem");
-			Assert ("#c1", !(o is DD));
-			Assert ("#c2", o is A);
-			Assert ("#c3", o is B);
-			Assert ("#c4", o is CC);
+			AssertHelper.IsNotInstanceOfType (typeof (DD), o, "#c1");
+			Assert.IsInstanceOfType (typeof (A), o, "#c2");
+			Assert.IsInstanceOfType (typeof (B), o, "#c3");
+			Assert.IsInstanceOfType (typeof (CC), o, "#c4");
 		}
 		// Don't add any tests that must create channels
 		// after ConnectProxyCast (), because this test calls

--- a/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/CollectionSerialization.cs
+++ b/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/CollectionSerialization.cs
@@ -38,9 +38,6 @@ using System.Runtime.Serialization;
 using System.ServiceModel;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Runtime.Serialization
 {

--- a/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/XsdDataContractExporterTest2.cs
+++ b/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/XsdDataContractExporterTest2.cs
@@ -66,7 +66,7 @@ namespace MonoTests.System.Runtime.Serialization
 			var type = exporter.Schemas.GlobalTypes [typeName];
 
 			Assert.That (type, Is.Not.Null, "#2");
-			Assert.That (type, Is.InstanceOfType (typeof (XmlSchemaComplexType)), "#3");
+			Assert.IsInstanceOfType (typeof (XmlSchemaComplexType), type, "#3");
 
 			var complex = (XmlSchemaComplexType)type;
 			Assert.That (complex.Annotation, Is.Null, "#4");
@@ -82,16 +82,16 @@ namespace MonoTests.System.Runtime.Serialization
 			Assert.That (list, Is.Not.Null, "#6");
 			Assert.That (list.Annotation, Is.Null, "#6a");
 			Assert.That (list.Name, Is.EqualTo ("list"), "#6b");
-			Assert.That (list.ElementSchemaType, Is.InstanceOfType (typeof (XmlSchemaComplexType)), "#6c");
+			Assert.IsInstanceOfType (typeof (XmlSchemaComplexType), list.ElementSchemaType, "#6c");
 
 			var listElement = (XmlSchemaComplexType)list.ElementSchemaType;
 			Assert.That (listElement.QualifiedName.Namespace, Is.EqualTo (MSArraysNamespace), "#6d");
 			Assert.That (listElement.QualifiedName.Name, Is.EqualTo ("ArrayOfint"), "#6e");
 
-			Assert.That (listElement.Particle, Is.InstanceOfType (typeof(XmlSchemaSequence)), "#7");
+			Assert.IsInstanceOfType (typeof(XmlSchemaSequence), listElement.Particle, "#7");
 			var listSeq = (XmlSchemaSequence)listElement.Particle;
 			Assert.That (listSeq.Items.Count, Is.EqualTo (1), "#7b");
-			Assert.That (listSeq.Items[0], Is.InstanceOfType (typeof(XmlSchemaElement)), "#7c");
+			Assert.IsInstanceOfType (typeof(XmlSchemaElement), listSeq.Items[0], "#7c");
 			Assert.That (listSeq.Annotation, Is.Null, "#7d");
 
 			var listSeqElement = (XmlSchemaElement)listSeq.Items[0];
@@ -102,16 +102,16 @@ namespace MonoTests.System.Runtime.Serialization
 			Assert.That (dict, Is.Not.Null, "#8");
 			Assert.That (dict.Annotation, Is.Null, "#8a");
 			Assert.That (dict.Name, Is.EqualTo ("dictionary"), "#8b");
-			Assert.That (dict.ElementSchemaType, Is.InstanceOfType (typeof (XmlSchemaComplexType)), "#8c");
+			Assert.IsInstanceOfType (typeof (XmlSchemaComplexType), dict.ElementSchemaType, "#8c");
 			
 			var dictElement = (XmlSchemaComplexType)dict.ElementSchemaType;
 			Assert.That (dictElement.QualifiedName.Namespace, Is.EqualTo (MSArraysNamespace), "#8d");
 			Assert.That (dictElement.QualifiedName.Name, Is.EqualTo ("ArrayOfKeyValueOfstringdouble"), "#8e");
 
-			Assert.That (dictElement.Particle, Is.InstanceOfType (typeof(XmlSchemaSequence)), "#9");
+			Assert.IsInstanceOfType (typeof(XmlSchemaSequence), dictElement.Particle, "#9");
 			var dictSeq = (XmlSchemaSequence)dictElement.Particle;
 			Assert.That (dictSeq.Items.Count, Is.EqualTo (1), "#9b");
-			Assert.That (dictSeq.Items[0], Is.InstanceOfType (typeof(XmlSchemaElement)), "#9c");
+			Assert.IsInstanceOfType (typeof(XmlSchemaElement), dictSeq.Items[0], "#9c");
 			Assert.That (dictSeq.Annotation, Is.Null, "#9d");
 			
 			var dictSeqElement = (XmlSchemaElement)dictSeq.Items[0];
@@ -123,7 +123,7 @@ namespace MonoTests.System.Runtime.Serialization
 			Assert.That (custom, Is.Not.Null, "#10");
 			Assert.That (custom.Annotation, Is.Null, "#10a");
 			Assert.That (custom.Name, Is.EqualTo ("customCollection"), "#10b");
-			Assert.That (custom.ElementSchemaType, Is.InstanceOfType (typeof (XmlSchemaComplexType)), "#10c");
+			Assert.IsInstanceOfType (typeof (XmlSchemaComplexType), custom.ElementSchemaType, "#10c");
 			
 			var customElement = (XmlSchemaComplexType)custom.ElementSchemaType;
 			var customEQN = customElement.QualifiedName;
@@ -131,10 +131,10 @@ namespace MonoTests.System.Runtime.Serialization
 			Assert.That (customEQN.Name.StartsWith ("XsdDataContractExporterTest2.MyCollectionOfstring", StringComparison.InvariantCultureIgnoreCase),
 			             Is.True, "#10e");
 
-			Assert.That (customElement.Particle, Is.InstanceOfType (typeof(XmlSchemaSequence)), "#11");
+			Assert.IsInstanceOfType (typeof(XmlSchemaSequence), customElement.Particle, "#11");
 			var customSeq = (XmlSchemaSequence)customElement.Particle;
 			Assert.That (customSeq.Items.Count, Is.EqualTo (1), "#11b");
-			Assert.That (customSeq.Items[0], Is.InstanceOfType (typeof(XmlSchemaElement)), "#11c");
+			Assert.IsInstanceOfType (typeof(XmlSchemaElement), customSeq.Items[0], "#11c");
 			Assert.That (customSeq.Annotation, Is.Null, "#11d");
 			
 			var customSeqElement = (XmlSchemaElement)customSeq.Items[0];

--- a/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/XsdDataContractExporterTest2.cs
+++ b/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/XsdDataContractExporterTest2.cs
@@ -44,7 +44,6 @@ using System.Xml.Serialization;
 using Microsoft.CSharp;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 using QName = System.Xml.XmlQualifiedName;
 

--- a/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/XsdDataContractImporterTest2.cs
+++ b/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization/XsdDataContractImporterTest2.cs
@@ -43,7 +43,6 @@ using System.Xml.Serialization;
 using Microsoft.CSharp;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 using QName = System.Xml.XmlQualifiedName;
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel_test.dll.sources
+++ b/mcs/class/System.ServiceModel/System.ServiceModel_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 NUnitMoonHelper.cs
 FeatureBased/Features.Client/AsyncCallTesterProxy.cs
 FeatureBased/Features.Client/AsyncPatternServer.cs

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/BindingTestAssertions.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/BindingTestAssertions.cs
@@ -90,7 +90,7 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 		static void CheckSoapBinding (object extension, string transport, TestLabel label)
 		{
 			label.EnterScope ("soap");
-			Assert.That (extension, Is.InstanceOfType (typeof (WS.SoapBinding)), label.Get ());
+			Assert.IsInstanceOfType (typeof (WS.SoapBinding), extension, label.Get ());
 			var soap = (WS.SoapBinding)extension;
 			Assert.That (soap.Style, Is.EqualTo (WS.SoapBindingStyle.Document), label.Get ());
 			Assert.That (soap.Transport, Is.EqualTo (transport), label.Get ());
@@ -106,9 +106,9 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 			label.EnterScope ("http");
 
 			if (security == BasicHttpSecurityMode.Message) {
-				Assert.That (binding, Is.InstanceOfType (typeof(CustomBinding)), label.Get ());
+				Assert.IsInstanceOfType (typeof(CustomBinding), binding, label.Get ());
 			} else {
-				Assert.That (binding, Is.InstanceOfType (typeof(BasicHttpBinding)), label.Get ());
+				Assert.IsInstanceOfType (typeof(BasicHttpBinding), binding, label.Get ());
 				var basicHttp = (BasicHttpBinding)binding;
 				Assert.That (basicHttp.EnvelopeVersion, Is.EqualTo (EnvelopeVersion.Soap11), label.Get ());
 				Assert.That (basicHttp.MessageVersion, Is.EqualTo (MessageVersion.Soap11), label.Get ());
@@ -156,7 +156,7 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 			label.EnterScope ("text");
 			if (encoding == WSMessageEncoding.Text) {
 				Assert.That (textElement, Is.Not.Null, label.Get ());
-				Assert.That (textElement.WriteEncoding, Is.InstanceOfType (typeof(UTF8Encoding)), label.Get ());
+				Assert.IsInstanceOfType (typeof(UTF8Encoding), textElement.WriteEncoding, label.Get ());
 			} else {
 				Assert.That (textElement, Is.Null, label.Get ());
 			}
@@ -408,9 +408,9 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 		{
 			label.EnterScope ("net-tcp");
 			if (security == SecurityMode.Message) {
-				Assert.That (binding, Is.InstanceOfType (typeof(CustomBinding)), label.Get ());
+				Assert.IsInstanceOfType (typeof(CustomBinding), binding, label.Get ());
 			} else {
-				Assert.That (binding, Is.InstanceOfType (typeof(NetTcpBinding)), label.Get ());
+				Assert.IsInstanceOfType (typeof(NetTcpBinding), binding, label.Get ());
 				var netTcp = (NetTcpBinding)binding;
 				Assert.That (netTcp.EnvelopeVersion, Is.EqualTo (EnvelopeVersion.Soap12), label.Get ());
 				Assert.That (netTcp.MessageVersion, Is.EqualTo (MessageVersion.Soap12WSAddressing10), label.Get ());
@@ -750,7 +750,7 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 			foreach (var node in all.ChildNodes) {
 				if (node is XmlWhitespace)
 					continue;
-				Assert.That (node, Is.InstanceOfType (typeof (XmlElement)), label.ToString ());
+				Assert.IsInstanceOfType (typeof (XmlElement), node, label.ToString ());
 				collection.Add ((XmlElement)node);
 			}
 			label.LeaveScope ();
@@ -788,7 +788,7 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 			label.EnterScope ("extensions");
 			Assert.That (op.Extensions, Is.Not.Null, label.Get ());
 			Assert.That (op.Extensions.Count, Is.EqualTo (1), label.Get ());
-			Assert.That (op.Extensions [0], Is.InstanceOfType (typeof (WS.SoapOperationBinding)), label.Get ());
+			Assert.IsInstanceOfType (typeof (WS.SoapOperationBinding), op.Extensions [0], label.Get ());
 			var soap = (WS.SoapOperationBinding)op.Extensions [0];
 			TestSoap (soap, soap12, label);
 			label.LeaveScope ();
@@ -820,7 +820,7 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 			Assert.That (binding.ExtensibleAttributes, Is.Null, label.Get ());
 			Assert.That (binding.Extensions, Is.Not.Null, label.Get ());
 			Assert.That (binding.Extensions.Count, Is.EqualTo (1), label.Get ());
-			Assert.That (binding.Extensions [0], Is.InstanceOfType (typeof (WS.SoapBodyBinding)), label.Get ());
+			Assert.IsInstanceOfType (typeof (WS.SoapBodyBinding), binding.Extensions [0], label.Get ());
 			var body = (WS.SoapBodyBinding)binding.Extensions [0];
 			TestSoapBody (body, soap12, label);
 			label.LeaveScope ();

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/BindingTestAssertions.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/BindingTestAssertions.cs
@@ -37,7 +37,6 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 using QName = System.Xml.XmlQualifiedName;
 using WS = System.Web.Services.Description;

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ExportTests.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ExportTests.cs
@@ -36,7 +36,6 @@ using WS = System.Web.Services.Description;
 
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 namespace MonoTests.System.ServiceModel.MetadataTests {
 

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests.cs
@@ -34,7 +34,6 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 using WS = System.Web.Services.Description;
 

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_LoadMetadata.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_LoadMetadata.cs
@@ -34,7 +34,6 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 namespace MonoTests.System.ServiceModel.MetadataTests {
 	

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/MiscImportTests.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/MiscImportTests.cs
@@ -34,7 +34,6 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 using WS = System.Web.Services.Description;
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageEncoderTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageEncoderTest.cs
@@ -34,7 +34,6 @@ using System.ServiceModel.Description;
 using System.Text;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using NUnit.Framework.SyntaxHelpers;
 
 using TextElement = System.ServiceModel.Channels.TextMessageEncodingBindingElement;
 using BinaryElement = System.ServiceModel.Channels.BinaryMessageEncodingBindingElement;

--- a/mcs/class/System.ServiceProcess/System.ServiceProcess_test.dll.sources
+++ b/mcs/class/System.ServiceProcess/System.ServiceProcess_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 System.ServiceProcess/ServiceBaseTest.cs
 System.ServiceProcess/ServiceControllerTest.cs
 System.ServiceProcess/ServiceControllerPermissionAttributeTest.cs

--- a/mcs/class/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow_test.dll.sources
+++ b/mcs/class/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 TestScheduler.cs
 AssertEx.cs
 Blocks.cs

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BoundedCapacityTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/BoundedCapacityTest.cs
@@ -131,7 +131,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (transform.Post (1));
 			Assert.IsTrue (transform.Post (2));
 
-			Assert.GreaterOrEqual (scheduler.ExecuteAll (), 1);
+			AssertHelper.GreaterOrEqual (scheduler.ExecuteAll (), 1);
 
 			Assert.AreEqual (2, Volatile.Read (ref n));
 		}
@@ -154,7 +154,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 			Assert.IsTrue (transform.Post (1));
 			Assert.IsTrue (transform.Post (2));
 
-			Assert.GreaterOrEqual (scheduler.ExecuteAll (), 1);
+			AssertHelper.GreaterOrEqual (scheduler.ExecuteAll (), 1);
 
 			Assert.AreEqual (2, Volatile.Read (ref n));
 		}
@@ -177,7 +177,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			Assert.IsFalse (transform.Post (101));
 
-			Assert.GreaterOrEqual (scheduler.ExecuteAll (), 1);
+			AssertHelper.GreaterOrEqual (scheduler.ExecuteAll (), 1);
 
 			Assert.IsFalse (transform.Post (102));
 

--- a/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/OptionsTest.cs
+++ b/mcs/class/System.Threading.Tasks.Dataflow/Test/System.Threading.Tasks.Dataflow/OptionsTest.cs
@@ -90,7 +90,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 				var queue = new ConcurrentQueue<Tuple<int, int>> ();
 				var block = factory (queue);
 
-				Assert.IsEmpty (queue);
+				CollectionAssert.IsEmpty (queue);
 
 				for (int i = 0; i < 100; i++)
 					block.Post (i);
@@ -170,15 +170,15 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 				options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 2 };
 				foreach (var taskIds in GetTaskIdsForExecutionsOptions (options))
-					Assert.LessOrEqual (CalculateDegreeOfParallelism (taskIds), 2);
+					AssertHelper.LessOrEqual (CalculateDegreeOfParallelism (taskIds), 2);
 
 				options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 4 };
 				foreach (var taskIds in GetTaskIdsForExecutionsOptions (options))
-					Assert.LessOrEqual (CalculateDegreeOfParallelism (taskIds), 4);
+					AssertHelper.LessOrEqual (CalculateDegreeOfParallelism (taskIds), 4);
 
 				options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = -1 };
 				foreach (var taskIds in GetTaskIdsForExecutionsOptions (options))
-					Assert.LessOrEqual (CalculateDegreeOfParallelism (taskIds), taskIds.Length);
+					AssertHelper.LessOrEqual (CalculateDegreeOfParallelism (taskIds), taskIds.Length);
 			}
 		}
 
@@ -187,7 +187,7 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 		{
 			var options = new ExecutionDataflowBlockOptions ();
 			foreach (var taskIds in GetTaskIdsForExecutionsOptions (options))
-				Assert.GreaterOrEqual (taskIds.Distinct ().Count (), 1);
+				AssertHelper.GreaterOrEqual (taskIds.Distinct ().Count (), 1);
 
 			options = new ExecutionDataflowBlockOptions { MaxMessagesPerTask = 1 };
 			foreach (var taskIds in GetTaskIdsForExecutionsOptions (options))
@@ -195,11 +195,11 @@ namespace MonoTests.System.Threading.Tasks.Dataflow {
 
 			options = new ExecutionDataflowBlockOptions { MaxMessagesPerTask = 2 };
 			foreach (var taskIds in GetTaskIdsForExecutionsOptions (options))
-				Assert.GreaterOrEqual (taskIds.Distinct ().Count (), taskIds.Length / 2);
+				AssertHelper.GreaterOrEqual (taskIds.Distinct ().Count (), taskIds.Length / 2);
 
 			options = new ExecutionDataflowBlockOptions { MaxMessagesPerTask = 4 };
 			foreach (var taskIds in GetTaskIdsForExecutionsOptions (options))
-				Assert.GreaterOrEqual (taskIds.Distinct ().Count (), taskIds.Length / 4);
+				AssertHelper.GreaterOrEqual (taskIds.Distinct ().Count (), taskIds.Length / 4);
 		}
 
 		[Test]

--- a/mcs/class/System.Web.DynamicData/Makefile
+++ b/mcs/class/System.Web.DynamicData/Makefile
@@ -160,7 +160,7 @@ TEST_RESOURCE_FILES = \
 
 NUNIT_RESOURCE_FILES = $(TEST_RESOURCE_FILES)
 
-TEST_LIB_REFS = System.ComponentModel.DataAnnotations System.Configuration SystemWebTestShim System.Xml
+TEST_LIB_REFS = System.ComponentModel.DataAnnotations System.Configuration SystemWebTestShim System.Xml nunit.mocks
 TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(NUNIT_RESOURCE_FILES:%=/resource:%)
 
 ifeq (4, $(FRAMEWORK_VERSION_MAJOR))

--- a/mcs/class/System.Web.DynamicData/System.Web.DynamicData_test.dll.sources
+++ b/mcs/class/System.Web.DynamicData/System.Web.DynamicData_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 ../../System.Web/Test/mainsoft/MainsoftWebTest/HtmlAgilityPack/crc32.cs
 ../../System.Web/Test/mainsoft/MainsoftWebTest/HtmlAgilityPack/Header.cs
 ../../System.Web/Test/mainsoft/MainsoftWebTest/HtmlAgilityPack/HtmlAttribute.cs

--- a/mcs/class/System.Web.DynamicData/Test/System.Web.DynamicData/FieldTemplateFactoryTest.cs
+++ b/mcs/class/System.Web.DynamicData/Test/System.Web.DynamicData/FieldTemplateFactoryTest.cs
@@ -647,7 +647,7 @@ namespace MonoTests.System.Web.DynamicData
 			// Custom with UIHint attribute
 			mc = t.GetColumn ("CustomColumn2");
 			Assert.IsNotNull (mc.UIHint, "#A2");
-			Assert.Greater (mc.UIHint.Length, 0, "#A2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#A2-1");
 
 			// Proves that UIHint on the column is not used, just the uiHint argument
 			AssertExtensions.Throws<InvalidOperationException> (() => {
@@ -669,7 +669,7 @@ namespace MonoTests.System.Web.DynamicData
 			// Custom with UIHint attribute
 			mc = t.GetColumn ("CustomColumn4");
 			Assert.IsNotNull (mc.UIHint, "#A4");
-			Assert.Greater (mc.UIHint.Length, 0, "#A4-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#A4-1");
 
 			// Proves that UIHint on the column is not used, just the uiHint argument
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#A4-2");
@@ -686,7 +686,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("DateTimeColumn2");
 			Assert.IsNotNull (mc.UIHint, "#B2");
-			Assert.Greater (mc.UIHint.Length, 0, "#B2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#B2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "DateTime.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#B2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "DateTime.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#B2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "DateTime.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#B2-5");
@@ -701,7 +701,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("DateColumn2");
 			Assert.IsNotNull (mc.UIHint, "#C2");
-			Assert.Greater (mc.UIHint.Length, 0, "#C2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#C2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#C2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#C2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#C2-5");
@@ -715,7 +715,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("DateColumn4");
 			Assert.IsNotNull (mc.UIHint, "#C4");
-			Assert.Greater (mc.UIHint.Length, 0, "#C4-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#C4-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#C4-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#C4-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#C4-5");
@@ -730,7 +730,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("TimeColumn2");
 			Assert.IsNotNull (mc.UIHint, "#D2");
-			Assert.Greater (mc.UIHint.Length, 0, "#D2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#D2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#D2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#D2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#D2-5");
@@ -745,7 +745,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("DurationColumn2");
 			Assert.IsNotNull (mc.UIHint, "#E2");
-			Assert.Greater (mc.UIHint.Length, 0, "#E2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#E2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#E2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#E2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#E2-5");
@@ -760,7 +760,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("PhoneNumberColumn2");
 			Assert.IsNotNull (mc.UIHint, "#F2");
-			Assert.Greater (mc.UIHint.Length, 0, "#F2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#F2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#F2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#F2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#F2-5");
@@ -775,7 +775,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("CurrencyColumn2");
 			Assert.IsNotNull (mc.UIHint, "#G2");
-			Assert.Greater (mc.UIHint.Length, 0, "#G2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#G2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#G2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#G2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#G2-5");
@@ -790,7 +790,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("TextColumn2");
 			Assert.IsNotNull (mc.UIHint, "#H2");
-			Assert.Greater (mc.UIHint.Length, 0, "#H2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#H2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#H2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#H2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#H2-5");
@@ -805,7 +805,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("HtmlColumn2");
 			Assert.IsNotNull (mc.UIHint, "#I2");
-			Assert.Greater (mc.UIHint.Length, 0, "#I2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#I2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#I2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#I2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#I2-5");
@@ -820,7 +820,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("MultilineTextColumn2");
 			Assert.IsNotNull (mc.UIHint, "#J2");
-			Assert.Greater (mc.UIHint.Length, 0, "#J2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#J2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#J2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#J2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#J2-5");
@@ -835,7 +835,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("EmailAddressColumn2");
 			Assert.IsNotNull (mc.UIHint, "#K2");
-			Assert.Greater (mc.UIHint.Length, 0, "#K2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#K2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#K2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#K2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#K2-5");
@@ -850,7 +850,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("PasswordColumn2");
 			Assert.IsNotNull (mc.UIHint, "#L2");
-			Assert.Greater (mc.UIHint.Length, 0, "#L2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#L2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#L2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#L2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#L2-5");
@@ -865,7 +865,7 @@ namespace MonoTests.System.Web.DynamicData
 
 			mc = t.GetColumn ("UrlColumn2");
 			Assert.IsNotNull (mc.UIHint, "#M2");
-			Assert.Greater (mc.UIHint.Length, 0, "#M2-1");
+			AssertHelper.Greater (mc.UIHint.Length, 0, "#M2-1");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, null), "#M2-3");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, String.Empty), "#M2-4");
 			Assert.AreEqual (ftf.TemplateFolderVirtualPath + "Text.ascx", ftf.GetFieldTemplateVirtualPath (mc, DataBoundControlMode.ReadOnly, "Boolean.ascx"), "#M2-5");

--- a/mcs/class/System.Web.Extensions/Makefile
+++ b/mcs/class/System.Web.Extensions/Makefile
@@ -39,7 +39,7 @@ NUNIT_RESOURCE_FILES= \
 CLASSLIB_DIR = $(topdir)/class/lib/$(PROFILE)
 
 STANDALONE_RUNNER_SUPPORT_ASSEMBLY = $(CLASSLIB_DIR)/standalone-runner-support.dll
-STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Web.Extensions.dll -r:$(topdir)/class/lib/$(PROFILE)/nunit.framework.dll
+STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Web.Extensions.dll -r:$(topdir)/class/lib/$(PROFILE)/nunitlite.dll
 STANDALONE_TEST_ASSEMBLY = System.Web.Extensions_standalone_test_$(PROFILE).dll
 STANDALONE_TEST_MAKEFRAG = $(depsdir)/$(STANDALONE_TEST_ASSEMBLY).makefrag
 

--- a/mcs/class/System.Web.Extensions/Makefile
+++ b/mcs/class/System.Web.Extensions/Makefile
@@ -39,7 +39,7 @@ NUNIT_RESOURCE_FILES= \
 CLASSLIB_DIR = $(topdir)/class/lib/$(PROFILE)
 
 STANDALONE_RUNNER_SUPPORT_ASSEMBLY = $(CLASSLIB_DIR)/standalone-runner-support.dll
-STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Web.Extensions.dll -r:$(topdir)/class/lib/$(PROFILE)/nunitlite.dll
+STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Web.Extensions.dll -r:$(topdir)/class/lib/$(PROFILE)/nunit.framework.dll
 STANDALONE_TEST_ASSEMBLY = System.Web.Extensions_standalone_test_$(PROFILE).dll
 STANDALONE_TEST_MAKEFRAG = $(depsdir)/$(STANDALONE_TEST_ASSEMBLY).makefrag
 

--- a/mcs/class/System.Web/Makefile
+++ b/mcs/class/System.Web/Makefile
@@ -321,11 +321,11 @@ endif
 
 CLASSLIB_DIR = $(topdir)/class/lib/$(PROFILE)
 
-STANDALONE_RUNNER_SUPPORT_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -d:STANDALONE_TEST -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunit.framework.dll
+STANDALONE_RUNNER_SUPPORT_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -d:STANDALONE_TEST -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunitlite.dll
 STANDALONE_RUNNER_SUPPORT_ASSEMBLY = $(CLASSLIB_DIR)/standalone-runner-support.dll
 STANDALONE_RUNNER_SUPPORT_MAKEFRAG = $(depsdir)/$(PROFILE)_standalone-runner-support.dll.makefrag
 
-STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunit.framework.dll
+STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunitlite.dll
 STANDALONE_TEST_ASSEMBLY = System.Web_standalone_test_$(PROFILE).dll
 STANDALONE_TEST_MAKEFRAG = $(depsdir)/$(STANDALONE_TEST_ASSEMBLY).makefrag
 

--- a/mcs/class/System.Web/Makefile
+++ b/mcs/class/System.Web/Makefile
@@ -321,11 +321,11 @@ endif
 
 CLASSLIB_DIR = $(topdir)/class/lib/$(PROFILE)
 
-STANDALONE_RUNNER_SUPPORT_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -d:STANDALONE_TEST -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunitlite.dll
+STANDALONE_RUNNER_SUPPORT_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -d:STANDALONE_TEST -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunit.framework.dll
 STANDALONE_RUNNER_SUPPORT_ASSEMBLY = $(CLASSLIB_DIR)/standalone-runner-support.dll
 STANDALONE_RUNNER_SUPPORT_MAKEFRAG = $(depsdir)/$(PROFILE)_standalone-runner-support.dll.makefrag
 
-STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunitlite.dll
+STANDALONE_TEST_MCS_FLAGS = $(LIB_MCS_FLAGS) $(PROFILE_MCS_FLAGS) -r:$(STANDALONE_RUNNER_SUPPORT_ASSEMBLY) -r:$(topdir)/class/lib/$(PROFILE)/System.Web.dll -r:$(topdir)/class/lib/$(PROFILE)/nunit.framework.dll
 STANDALONE_TEST_ASSEMBLY = System.Web_standalone_test_$(PROFILE).dll
 STANDALONE_TEST_MAKEFRAG = $(depsdir)/$(STANDALONE_TEST_ASSEMBLY).makefrag
 

--- a/mcs/class/System.Web/System.Web_standalone_test.dll.sources
+++ b/mcs/class/System.Web/System.Web_standalone_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 Test/standalone-tests/Consts.cs
 Test/standalone-tests/Locations.cs
 Test/standalone-tests/OutputCacheProvider.cs

--- a/mcs/class/System.Web/System.Web_standalone_test.dll.sources
+++ b/mcs/class/System.Web/System.Web_standalone_test.dll.sources
@@ -1,4 +1,3 @@
-../../test-helpers/NunitHelpers.cs
 Test/standalone-tests/Consts.cs
 Test/standalone-tests/Locations.cs
 Test/standalone-tests/OutputCacheProvider.cs

--- a/mcs/class/System.Web/System.Web_test.dll.sources
+++ b/mcs/class/System.Web/System.Web_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 ../../System.Web.DynamicData/Test/Common/AssertExtensions.cs
 mainsoft/MainsoftWebTest/HtmlAgilityPack/AssemblyInfo.cs
 mainsoft/MainsoftWebTest/HtmlAgilityPack/crc32.cs

--- a/mcs/class/System.Web/Test/System.Web.Hosting/HostingEnvironmentTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.Hosting/HostingEnvironmentTest.cs
@@ -77,13 +77,13 @@ namespace MonoTests.System.Web.Hosting {
 			Assert.IsNull (HostingEnvironment.InitializationException, "During:InitializationException");
 			Assert.IsTrue (HostingEnvironment.IsHosted, "During:IsHosted");
 			Assert.IsNotNull (HostingEnvironment.ApplicationID, "During:ApplicationID:Null");
-			Assert.IsNotEmpty (HostingEnvironment.ApplicationID, "During:ApplicationID:Empty");
+			AssertHelper.IsNotEmpty (HostingEnvironment.ApplicationID, "During:ApplicationID:Empty");
 			Assert.IsNotNull (HostingEnvironment.ApplicationPhysicalPath, "During:ApplicationPhysicalPath:Null");
-			Assert.IsNotEmpty (HostingEnvironment.ApplicationPhysicalPath, "During:ApplicationPhysicalPath:Empty");
+			AssertHelper.IsNotEmpty (HostingEnvironment.ApplicationPhysicalPath, "During:ApplicationPhysicalPath:Empty");
 			Assert.IsNotNull (HostingEnvironment.ApplicationVirtualPath, "During:ApplicationVirtualPath:Null");
-			Assert.IsNotEmpty (HostingEnvironment.ApplicationVirtualPath, "During:ApplicationVirtualPath:Empty");
+			AssertHelper.IsNotEmpty (HostingEnvironment.ApplicationVirtualPath, "During:ApplicationVirtualPath:Empty");
 			Assert.IsNotNull (HostingEnvironment.SiteName, "During:SiteName:Null");
-			Assert.IsNotEmpty (HostingEnvironment.SiteName, "During:SiteName:Empty");
+			AssertHelper.IsNotEmpty (HostingEnvironment.SiteName, "During:SiteName:Empty");
 			Assert.IsNotNull (HostingEnvironment.Cache, "During:Cache");
 			Assert.AreEqual (ApplicationShutdownReason.None, HostingEnvironment.ShutdownReason, "During:ShutdownReason");
 			Assert.IsNotNull (HostingEnvironment.VirtualPathProvider, "During:VirtualPathProvider");

--- a/mcs/class/System.Web/Test/System.Web/HttpResponseTest.cs
+++ b/mcs/class/System.Web/Test/System.Web/HttpResponseTest.cs
@@ -547,7 +547,7 @@ namespace MonoTests.System.Web {
 
 			KnownResponseHeader known;
 
-			Assert.LessOrEqual (1, f.KnownResponseHeaders.Count, "#B1");
+			AssertHelper.LessOrEqual (1, f.KnownResponseHeaders.Count, "#B1");
 
 			known = (KnownResponseHeader)f.KnownResponseHeaders ["Content-Type"];
 			Assert.AreEqual (HttpWorkerRequest.HeaderContentType, known.Index, "#B2");
@@ -571,7 +571,7 @@ namespace MonoTests.System.Web {
 
 			KnownResponseHeader known;
 
-			Assert.LessOrEqual (1, f.KnownResponseHeaders.Count, "#B1");
+			AssertHelper.LessOrEqual (1, f.KnownResponseHeaders.Count, "#B1");
 
 			known = (KnownResponseHeader)f.KnownResponseHeaders ["Content-Type"];
 			Assert.AreEqual (HttpWorkerRequest.HeaderContentType, known.Index, "#B2");

--- a/mcs/class/System.Web/Test/System.Web/XmlSiteMapProviderTest.cs
+++ b/mcs/class/System.Web/Test/System.Web/XmlSiteMapProviderTest.cs
@@ -148,7 +148,7 @@ namespace MonoTests.System.Web
 			provider.DoAddNode (node, rootNode);
 
 			Assert.IsNotNull (provider.CallTrace, "#A1");
-			Assert.Greater (provider.CallTrace.Length, 1, "#A1-1");
+			AssertHelper.Greater (provider.CallTrace.Length, 1, "#A1-1");
 			Assert.AreEqual (provider.CallTrace[0].Name, "BuildSiteMap", "#A1-2");
 		}
 
@@ -247,7 +247,7 @@ namespace MonoTests.System.Web
 			Assert.IsNotNull (provider.RootNode, "#A1");
 			Assert.AreEqual (provider.RootNode.Provider, provider, "#A2");
 			Assert.IsNotNull (provider.CallTrace, "#A3");
-			Assert.Greater (provider.CallTrace.Length, 1, "#A3-1");
+			AssertHelper.Greater (provider.CallTrace.Length, 1, "#A3-1");
 			Assert.AreEqual ("BuildSiteMap", provider.CallTrace[0].Name, "#A3-2");
 			Assert.AreEqual ("get_RootNode", provider.CallTrace[1].Name, "#A3-3");
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms_test.dll.sources
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 ../../../build/common/Consts.cs
 System.Windows.Forms/ApplicationTest.cs
 System.Windows.Forms/AutoCompleteStringCollectionTest.cs

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeFileRefGetValueTests.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeFileRefGetValueTests.cs
@@ -47,7 +47,7 @@ namespace MonoTests.System.Resources {
 
 			Assert.IsNotNull (returnedNode, "#A1");
 			object val = returnedNode.GetValue (new ReturnSerializableSubClassITRS ());
-			Assert.IsNotInstanceOfType (typeof (serializableSubClass), val, "#A2");
+			AssertHelper.IsNotInstanceOfType (typeof (serializableSubClass), val, "#A2");
 			Assert.IsInstanceOfType (typeof (serializable), val, "#A3");
 		}
 
@@ -84,7 +84,7 @@ namespace MonoTests.System.Resources {
 			node = GetNodeFileRefToSerializable ("ser.bbb",true);
 
 			object val = node.GetValue (new ReturnSerializableSubClassITRS ());
-			Assert.IsNotInstanceOfType (typeof (serializableSubClass), val, "#A1");
+			AssertHelper.IsNotInstanceOfType (typeof (serializableSubClass), val, "#A1");
 			Assert.IsInstanceOfType (typeof (serializable), val, "#A2");
 		}
 

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeSerialisedGetValueTypeNameTests.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeSerialisedGetValueTypeNameTests.cs
@@ -90,7 +90,7 @@ namespace MonoTests.System.Resources {
 			// get value passing no params
 			object val = returnedNode.GetValue ((ITypeResolutionService) null);
 			Assert.IsInstanceOfType (typeof (serializable), val, "#A2");
-			Assert.IsNotInstanceOfType (typeof (serializableSubClass), val, "#A3");
+			AssertHelper.IsNotInstanceOfType (typeof (serializableSubClass), val, "#A3");
 
 			//get value type passing different params
 			string newType = returnedNode.GetValueTypeName (new ReturnSerializableSubClassITRS ());

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeSerializedGetValueTests.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeSerializedGetValueTests.cs
@@ -50,10 +50,10 @@ namespace MonoTests.System.Resources {
 
 			object defaultVal = returnedNode.GetValue ((ITypeResolutionService) null);
 			Assert.IsInstanceOfType (typeof (serializable), defaultVal, "#A2");
-			Assert.IsNotInstanceOfType (typeof (serializableSubClass), defaultVal, "#A3");
+			AssertHelper.IsNotInstanceOfType (typeof (serializableSubClass), defaultVal, "#A3");
 
 			object newVal = returnedNode.GetValue (new ReturnSerializableSubClassITRS ());
-			Assert.IsNotInstanceOfType (typeof (serializableSubClass), newVal, "#A4");
+			AssertHelper.IsNotInstanceOfType (typeof (serializableSubClass), newVal, "#A4");
 			Assert.IsInstanceOfType (typeof (serializable), newVal, "#A5");
 		}
 
@@ -88,7 +88,7 @@ namespace MonoTests.System.Resources {
 
 			// get value passing null params
 			object val = returnedNode.GetValue ((ITypeResolutionService) null);
-			// Assert.IsNotInstanceOfType (typeof (serializable), val, "#A5"); this would fail as subclasses are id-ed as instances of parents
+			// AssertHelper.IsNotInstanceOfType (typeof (serializable), val, "#A5"); this would fail as subclasses are id-ed as instances of parents
 			Assert.IsInstanceOfType (typeof (serializableSubClass), val, "#A4");
 		}
 

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeTest.cs
@@ -314,7 +314,7 @@ namespace MonoTests.System.Resources {
 
 			object o = node.GetValue ((AssemblyName []) null);
 
-			Assert.IsNotInstanceOfType (typeof (serializableSubClass), o, "#A2");
+			AssertHelper.IsNotInstanceOfType (typeof (serializableSubClass), o, "#A2");
 			Assert.IsInstanceOfType (typeof (serializable), o, "#A3");
 			rr.Close ();
 		}

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeWriteBehavior.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXDataNodeWriteBehavior.cs
@@ -252,7 +252,7 @@ namespace MonoTests.System.Resources {
 			Assert.IsNotNull (finalNode, "#A3");
 
 			object finalVal = finalNode.GetValue ((ITypeResolutionService) null);
-			Assert.IsNotInstanceOfType (typeof (serializableSubClass), finalVal, "#A4");
+			AssertHelper.IsNotInstanceOfType (typeof (serializableSubClass), finalVal, "#A4");
 			Assert.IsInstanceOfType (typeof (serializable), finalVal, "#A5");
 		}
 

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/TableLayoutTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/TableLayoutTest.cs
@@ -946,10 +946,10 @@ namespace MonoTests.System.Windows.Forms
 			Assert.AreEqual (31, p.GetRowHeights ()[0], "D1");
 			Assert.AreEqual (31, p.GetRowHeights ()[1], "D2");
 			Assert.AreEqual (81, p.GetColumnWidths ()[0], "D3");
-			Assert.LessOrEqual (75, p.GetColumnWidths ()[1], "D4");
-			Assert.GreaterOrEqual (78, p.GetColumnWidths ()[1], "D5");
-			Assert.LessOrEqual (78, p.GetColumnWidths ()[2], "D6");
-			Assert.GreaterOrEqual (81, p.GetColumnWidths ()[2], "D7");
+			AssertHelper.LessOrEqual (75, p.GetColumnWidths ()[1], "D4");
+			AssertHelper.GreaterOrEqual (78, p.GetColumnWidths ()[1], "D5");
+			AssertHelper.LessOrEqual (78, p.GetColumnWidths ()[2], "D6");
+			AssertHelper.GreaterOrEqual (81, p.GetColumnWidths ()[2], "D7");
 		}
 		
 		[Test]
@@ -1702,7 +1702,7 @@ namespace MonoTests.System.Windows.Forms
 			Assert.AreEqual (4, tlp.RowCount, "X18638-1");
 			Assert.AreEqual (3, tlp.ColumnCount, "X18638-2");
 			Assert.AreEqual (60, widths[0], "X18638-3");
-			Assert.Greater (label2.Width, widths[1], "X18638-5");
+			AssertHelper.Greater (label2.Width, widths[1], "X18638-5");
 			Assert.AreEqual (45, widths[2], "X18638-4");
 		}
 

--- a/mcs/class/System.Xml.Linq/System.Xml.Linq_test.dll.sources
+++ b/mcs/class/System.Xml.Linq/System.Xml.Linq_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 System.Xml.Linq/ExtensionsTest.cs
 System.Xml.Linq/XAttributeTest.cs
 System.Xml.Linq/XCommentTest.cs

--- a/mcs/class/System.Xml.Linq/Test/System.Xml.Schema/ExtensionsTest.cs
+++ b/mcs/class/System.Xml.Linq/Test/System.Xml.Schema/ExtensionsTest.cs
@@ -220,8 +220,8 @@ namespace MonoTests.System.Xml.Schema
 				}
 			}
 
-			Assert.GreaterOrEqual (afterNoOfAttributes, beforeNoOfAttributes, "newAttributes");
-			Assert.GreaterOrEqual (afterNoOfElements, beforeNoOfElements, "newElements");       
+			AssertHelper.GreaterOrEqual (afterNoOfAttributes, beforeNoOfAttributes, "newAttributes");
+			AssertHelper.GreaterOrEqual (afterNoOfElements, beforeNoOfElements, "newElements");       
 		}
 
 		/*

--- a/mcs/class/System/System_test.dll.sources
+++ b/mcs/class/System/System_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 Microsoft.CSharp/CodeGeneratorFromCompileUnitTest.cs
 Microsoft.CSharp/CodeGeneratorFromExpressionTest.cs
 Microsoft.CSharp/CodeGeneratorFromNamespaceTest.cs

--- a/mcs/class/System/Test/System.CodeDom.Compiler/CodeGeneratorGenerateFromCompileUnitTest.cs
+++ b/mcs/class/System/Test/System.CodeDom.Compiler/CodeGeneratorGenerateFromCompileUnitTest.cs
@@ -53,7 +53,7 @@ namespace MonoTests.System.CodeDom.Compiler
 			int importPosition = result.IndexOf (IMPORT);
 			int attributePosition = result.IndexOf (ATTRIBUTE);
 
-			Assert.Greater (attributePosition, importPosition, "Actual order: " + result);
+			AssertHelper.Greater (attributePosition, importPosition, "Actual order: " + result);
 		}
 
 		[Test]

--- a/mcs/class/System/Test/System.Collections.Generic/SortedListTest.cs
+++ b/mcs/class/System/Test/System.Collections.Generic/SortedListTest.cs
@@ -38,9 +38,6 @@ using System.Text;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Collections.Generic
 {

--- a/mcs/class/System/Test/System.Diagnostics/SourceSwitchTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/SourceSwitchTest.cs
@@ -53,7 +53,7 @@ namespace MonoTests.System.Diagnostics
 		public void ConstructorNullName ()
 		{
 			SourceSwitch s = new SourceSwitch (null);
-			Assert.IsEmpty (s.DisplayName);
+			AssertHelper.IsEmpty (s.DisplayName);
 		}
 
 		[Test]

--- a/mcs/class/System/Test/System.Diagnostics/SwitchesTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/SwitchesTest.cs
@@ -190,8 +190,8 @@ namespace MonoTests.System.Diagnostics {
 		public void NullSwitchHasEmptyDisplayNameAndDescription ()
 		{
 			var s = new TestNullSwitch ();
-			Assert.IsEmpty (s.DisplayName);
-			Assert.IsEmpty (s.Description);
+			AssertHelper.IsEmpty (s.DisplayName);
+			AssertHelper.IsEmpty (s.Description);
 		}
 	}
 }

--- a/mcs/class/WebMatrix.Data/WebMatrix.Data_test.dll.sources
+++ b/mcs/class/WebMatrix.Data/WebMatrix.Data_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 WebMatrix.Data/ConnectionEventArgsTests.cs
 WebMatrix.Data/DynamicRecordTests.cs
 ../WebMatrix.Data/DynamicRecord.cs

--- a/mcs/class/WindowsBase/WindowsBase_test.dll.sources
+++ b/mcs/class/WindowsBase/WindowsBase_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 System.Collections.ObjectModel/ObservableCollectionTest.cs
 System.Collections.ObjectModel/ReadOnlyObservableCollectionTest.cs
 System.Collections.Specialized/NotifyCollectionChangedEventArgsTest.cs

--- a/mcs/class/corlib/Test/Mono/DataConvertTest.cs
+++ b/mcs/class/corlib/Test/Mono/DataConvertTest.cs
@@ -4,10 +4,6 @@ using System.Text;
 using NUnit.Framework;
 using Mono;
 
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
-
 namespace MonoTests.Mono {
 
 	[TestFixture]

--- a/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentDictionaryTests.cs
+++ b/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentDictionaryTests.cs
@@ -32,9 +32,6 @@ using System.Collections.Concurrent;
 
 using NUnit;
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Collections.Concurrent
 {

--- a/mcs/class/corlib/Test/System.Collections.Concurrent/PartitionerTests.cs
+++ b/mcs/class/corlib/Test/System.Collections.Concurrent/PartitionerTests.cs
@@ -30,9 +30,6 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Collections.Concurrent
 {

--- a/mcs/class/corlib/Test/System.Security.AccessControl/RawSecurityDescriptorTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/RawSecurityDescriptorTest.cs
@@ -9,7 +9,6 @@ using System;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using NUnit.Framework;
-using NUnit.Framework.SyntaxHelpers;
 
 namespace MonoTests.System.Security.AccessControl {
 

--- a/mcs/class/corlib/Test/System.Text/ASCIIEncodingTest.cs
+++ b/mcs/class/corlib/Test/System.Text/ASCIIEncodingTest.cs
@@ -10,10 +10,6 @@ using System.Text;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
-
 namespace MonoTests.System.Text
 {
 	[TestFixture]

--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskCompletionSourceTests.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskCompletionSourceTests.cs
@@ -30,9 +30,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Threading.Tasks
 {

--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskFactoryTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskFactoryTest.cs
@@ -35,9 +35,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Threading.Tasks
 {

--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskFactoryTest_T.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskFactoryTest_T.cs
@@ -32,9 +32,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Threading.Tasks
 {

--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskSchedulerTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskSchedulerTest.cs
@@ -29,9 +29,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Threading.Tasks
 {

--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
@@ -34,10 +34,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using NUnit.Framework;
 
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
-
 namespace MonoTests.System.Threading.Tasks
 {
 	[TestFixture]

--- a/mcs/class/corlib/Test/System.Threading/ThreadLocalTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadLocalTests.cs
@@ -29,9 +29,6 @@ using System.Threading;
 
 using NUnit;
 using NUnit.Framework;
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
 
 namespace MonoTests.System.Threading
 {

--- a/mcs/class/corlib/Test/System/SingleTest.cs
+++ b/mcs/class/corlib/Test/System/SingleTest.cs
@@ -15,10 +15,6 @@ using System.Threading;
 
 using NUnit.Framework;
 
-#if !MOBILE
-using NUnit.Framework.SyntaxHelpers;
-#endif
-
 namespace MonoTests.System
 {
 	[TestFixture]

--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 Microsoft.Win32/RegistryKeyTest.cs
 Mono/DataConvertTest.cs
 ../Mono/DataConverter.cs

--- a/mcs/class/monodoc/Test/Monodoc.Generators/RawGeneratorTests.cs
+++ b/mcs/class/monodoc/Test/Monodoc.Generators/RawGeneratorTests.cs
@@ -47,7 +47,7 @@ namespace MonoTests.Monodoc.Generators
 		{
 			var xml = rootTree.RenderUrl ("T:System.String", generator);
 			Assert.IsNotNull (xml);
-			Assert.IsNotEmpty (xml);
+			AssertHelper.IsNotEmpty (xml);
 			AssertValidXml (xml);
 			AssertEcmaFullTypeName (xml, "System.String");
 		}
@@ -57,7 +57,7 @@ namespace MonoTests.Monodoc.Generators
 		{
 			var xml = rootTree.RenderUrl ("T:System.Int32", generator);
 			Assert.IsNotNull (xml);
-			Assert.IsNotEmpty (xml);
+			AssertHelper.IsNotEmpty (xml);
 			AssertValidXml (xml);
 			AssertEcmaFullTypeName (xml, "System.Int32");
 		}

--- a/mcs/class/monodoc/Test/Monodoc/HelpSourceTests.cs
+++ b/mcs/class/monodoc/Test/Monodoc/HelpSourceTests.cs
@@ -85,7 +85,7 @@ namespace MonoTests.Monodoc
 
 			// HACK: in reality we have currently 4 known issues which are due to duplicated namespaces across
 			// doc sources, something that was never supported and that we need to improve/fix at some stage
-			Assert.LessOrEqual (4, errorCount, errorCount + " / " + testCount.ToString ());
+			AssertHelper.LessOrEqual (4, errorCount, errorCount + " / " + testCount.ToString ());
 		}
 
 		IEnumerable<Node> GetLeaves (Node node)

--- a/mcs/class/monodoc/Test/Monodoc/SettingsTest.cs
+++ b/mcs/class/monodoc/Test/Monodoc/SettingsTest.cs
@@ -17,7 +17,7 @@ namespace MonoTests.Monodoc
 		{
 			// the docPath variable is the only one we know for sure should exist
 			Assert.IsNotNull (Config.Get ("docPath"));
-			Assert.IsNotEmpty (Config.Get ("docPath"));
+			AssertHelper.IsNotEmpty (Config.Get ("docPath"));
 		}
 	}
 }

--- a/mcs/class/monodoc/monodoc_test.dll.sources
+++ b/mcs/class/monodoc/monodoc_test.dll.sources
@@ -1,3 +1,4 @@
+../../test-helpers/NunitHelpers.cs
 Monodoc/HelpSourceTests.cs
 Monodoc/EcmaDocTests.cs
 Monodoc/TreeTest.cs

--- a/mcs/class/test-helpers/NunitHelpers.cs
+++ b/mcs/class/test-helpers/NunitHelpers.cs
@@ -1,0 +1,102 @@
+using System.IO;
+using System.Collections;
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework
+{
+	class CollectionAssert
+	{
+		public static void DoesNotContain (IEnumerable collection, object val)
+		{
+			 Assert.That(collection, Has.No.Member(val));
+		}
+
+		public static void Contains (IEnumerable collection, object val)
+		{
+			 Assert.That(collection, Has.Member(val));
+		}
+
+		public static void AreEqual (IEnumerable expected, IEnumerable actual, string message = null, params object[] args) 
+		{
+			Assert.That(actual, Is.EqualTo(expected), message, args);
+		}
+
+		public static void AreEquivalent (IEnumerable expected, IEnumerable actual, string message = null, params object[] args) 
+		{
+			Assert.That(actual, Is.EquivalentTo(expected), message, args);
+		}
+
+		public static void IsEmpty(IEnumerable collection, string message = null, params object[] args)
+		{
+			Assert.That(collection, new EmptyCollectionConstraint(), message, args);
+		}
+	}
+
+	class FileAssert
+	{
+		static public void AreEqual(Stream expected, Stream actual, string message, params object[] args)
+		{
+			Assert.That(actual, Is.EqualTo(expected), message, args);
+		}
+
+		static public void AreEqual(string expected, string actual, string message, params object[] args)
+		{
+			using (FileStream exStream = File.OpenRead(expected))
+			using (FileStream acStream = File.OpenRead(actual))
+			{
+				AreEqual(exStream, acStream, message, args);
+			}
+		}
+	}
+
+	class StringAssert
+	{
+		static public void Contains(string expected, string actual, string message = null, params object[] args)
+		{
+			Assert.That(actual, Is.StringContaining (expected), message, args);
+		}
+
+		static public void StartsWith(string expected, string actual, string message = null, params object[] args)
+		{
+			Assert.IsTrue (actual.StartsWith (expected), message, args);
+		}
+	}
+
+	class AssertHelper
+	{
+		public static void IsEmpty (string aString, string message = null, params object[] args )
+		{
+			Assert.That(aString, Is.Empty, message, args);
+		}
+
+		public static void IsNotEmpty (string aString, string message = null, params object[] args )
+		{
+			Assert.That(aString, Is.Not.Empty, message, args);
+		}
+
+		static public void Greater(int arg1, int arg2, string message = null, params object[] args) 
+		{
+			Assert.That(arg1, Is.GreaterThan(arg2), message, args);
+		}
+
+		static public void GreaterOrEqual(int arg1, int arg2, string message = null, params object[] args)
+		{
+			Assert.That(arg1, Is.GreaterThanOrEqualTo(arg2), message, args);
+		}
+
+		static public void GreaterOrEqual(long arg1, long arg2, string message = null, params object[] args)
+		{
+			Assert.That(arg1, Is.GreaterThanOrEqualTo(arg2), message, args);
+		}
+
+		static public void LessOrEqual (int arg1, int arg2, string message = null, params object[] args)
+		{
+			Assert.That(arg1, Is.LessThanOrEqualTo(arg2), message, args);
+		}
+
+		public static void IsNotInstanceOfType(System.Type expected, object actual, string message, params object[] args )
+		{
+			Assert.IsFalse (actual.GetType ().IsInstanceOfType (expected), message, args);
+		}
+	}
+}

--- a/mcs/tools/linker/Tests/Makefile
+++ b/mcs/tools/linker/Tests/Makefile
@@ -12,7 +12,7 @@ Mono.Linker.Tests.dll.sources:
 	find Mono.Linker.Tests -name "*.cs" > Mono.Linker.Tests.dll.sources
 
 Mono.Linker.Tests.dll: Mono.Cecil.dll monolinker.exe Mono.Linker.Tests.dll.sources
-	$(MCS) /target:library /out:Mono.Linker.Tests.dll /r:nunit.framework.dll /r:Mono.Cecil.dll /r:monolinker.exe @Mono.Linker.Tests.dll.sources
+	$(MCS) /target:library /out:Mono.Linker.Tests.dll /r:nunitlite.dll /r:Mono.Cecil.dll /r:monolinker.exe @Mono.Linker.Tests.dll.sources
 
 clean:
 	rm -rf Mono.Cecil.dll monolinker.exe Mono.Linker.Tests.dll.sources Mono.Linker.Tests.dll

--- a/mcs/tools/nunit-lite/nunit-lite-console/Console.cs
+++ b/mcs/tools/nunit-lite/nunit-lite-console/Console.cs
@@ -76,6 +76,9 @@ namespace NUnitLite
         public static void Main(string[] args)
         {
             new TextUI().Execute(args);
+
+            // Force exit, otherwise remaining threads will keep process alive.
+            Environment.Exit(Environment.ExitCode);
         }
     }
 }


### PR DESCRIPTION
Reasons for changing our test suite from nunit24 to nunit-lite are:
- Use same testing runners as other products, avoids problems of using methods not valid in other product test suite.
- nunit-lite is faster to start than nunit24.
- nunit-lite has better handlers for unhandled exceptions, it was noticed before that nunit24 swallows unhandled exceptions.

[Work in progress]
