### PR TITLE
[handles] Add coop handles in wrapper to icalls with HANDLES() declaration

### DIFF
--- a/mcs/class/corlib/Mono/RuntimeStructs.cs
+++ b/mcs/class/corlib/Mono/RuntimeStructs.cs
@@ -13,7 +13,10 @@ using System;
 using System.Runtime.InteropServices;
 
 namespace Mono {
-	internal class RuntimeStructs {
+	//
+	// Managed representations of mono runtime types
+	//
+	internal static class RuntimeStructs {
 		// class-internals.h MonoRemoteClass
 		[StructLayout(LayoutKind.Sequential)]
 		internal unsafe struct RemoteClass {
@@ -42,6 +45,20 @@ namespace Mono {
 		internal unsafe struct GPtrArray {
 			internal IntPtr* data;
 			internal int len;
+		}
+
+		// handle.h HandleStackMark
+		struct HandleStackMark {
+			int size;
+			IntPtr chunk;
+		}
+
+		// mono-error.h MonoError
+		struct MonoError {
+			ushort error_code;
+			ushort hidden_0;
+			IntPtr hidden_1, hidden_2, hidden_3, hidden_4, hidden_5, hidden_6, hidden_7, hidden_8;
+			IntPtr hidden_11, hidden_12, hidden_13, hidden_14, hidden_15, hidden_16, hidden_17, hidden_18;
 		}
 	}
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -196,6 +196,7 @@ void mono_handle_verify (MonoRawHandle handle);
  * typedef MonoObjectHandlePayload* MonoObjectHandle;
  */
 #define TYPED_HANDLE_DECL(TYPE) typedef struct { TYPE *__obj; } TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE)
+#define MONO_HANDLE_PAYLOAD_OFFSET(TYPE) MONO_STRUCT_OFFSET(TYPED_HANDLE_PAYLOAD_NAME (TYPE), __obj)
 
 #define MONO_HANDLE_INIT ((void*) mono_null_value_handle)
 #define NULL_HANDLE mono_null_value_handle

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -187,6 +187,7 @@ void mono_handle_verify (MonoRawHandle handle);
 
 #define TYPED_HANDLE_PAYLOAD_NAME(TYPE) TYPE ## HandlePayload
 #define TYPED_HANDLE_NAME(TYPE) TYPE ## Handle
+
 /*
  * typedef struct {
  *   MonoObject *__obj;
@@ -194,7 +195,7 @@ void mono_handle_verify (MonoRawHandle handle);
  *
  * typedef MonoObjectHandlePayload* MonoObjectHandle;
  */
-#define TYPED_HANDLE_DECL(TYPE) typedef struct { TYPE *__obj; } TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE);
+#define TYPED_HANDLE_DECL(TYPE) typedef struct { TYPE *__obj; } TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE)
 
 #define MONO_HANDLE_INIT ((void*) mono_null_value_handle)
 #define NULL_HANDLE mono_null_value_handle
@@ -244,9 +245,11 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 
 
 /* Baked typed handles we all want */
-TYPED_HANDLE_DECL (MonoString)
-TYPED_HANDLE_DECL (MonoArray)
-TYPED_HANDLE_DECL (MonoObject)
+TYPED_HANDLE_DECL (MonoString);
+TYPED_HANDLE_DECL (MonoArray);
+TYPED_HANDLE_DECL (MonoObject);
+
+#define NULL_HANDLE_STRING MONO_HANDLE_CAST(MonoString, NULL_HANDLE)
 
 /*
 This is the constant for a handle that points nowhere.

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -767,7 +767,7 @@ ICALL(RT_28, "IsTypeExportedToWindowsRuntime", ves_icall_System_RuntimeType_IsTy
 ICALL(RT_29, "IsWindowsRuntimeObjectType", ves_icall_System_RuntimeType_IsWindowsRuntimeObjectType)
 ICALL(RT_17, "MakeGenericType", ves_icall_RuntimeType_MakeGenericType)
 ICALL(RT_18, "MakePointerType", ves_icall_RuntimeType_MakePointerType)
-ICALL(RT_19, "getFullName", ves_icall_System_MonoType_getFullName)
+ICALL(RT_19, "getFullName", ves_icall_System_RuntimeType_getFullName)
 ICALL(RT_21, "get_DeclaringMethod", ves_icall_RuntimeType_get_DeclaringMethod)
 ICALL(RT_22, "get_DeclaringType", ves_icall_RuntimeType_get_DeclaringType)
 ICALL(RT_23, "get_Name", ves_icall_RuntimeType_get_Name)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -35,6 +35,32 @@
  * you need to insert a method in the middle, don't bother renaming all the symbols.
  * Remember to change also the first_icall_id argument in the ICALL_TYPE 
  * declaration if you add a new icall at the beginning of a type's icall list.
+ *
+ *
+ * *** (Experimental) Cooperative GC support via Handles and MonoError ***
+ * An icall can use the coop GC handles infrastructure from handles.h to avoid some
+ * boilerplate when manipulating managed objects from runtime code and to use MonoError for
+ * threading exceptions out to managed callerrs:
+ *
+ * HANDLES(ICALL(icallid, methodname, cfuncptr))
+ *
+ * An icall with a HANDLES() declaration wrapped around it will have a generated wrapper
+ * that:
+ *   (1) Updates the coop handle stack on entry and exit
+ *   (2) Call the cfuncptr with a new signature:
+ *     (a) All managed object reference in arguments will be wrapped in a handle
+ *         (ie, MonoString* becomes MonoStringHandle)
+ *     (b) the same for the return value (MonoObject* return becomes MonoObjectHandle)
+ *     (c) An additional final argument is added of type MonoError*
+ *     example:    class object {
+ *                     [MethodImplOptions(InternalCall)]
+ *                     String some_icall (object[] x);
+ *                 }
+ *     should be implemented as:
+ *        MonoStringHandle some_icall (MonoObjectHandle this_handle, MonoArrayHandle x_handle, MonoError *error);
+ *   (3) The wrapper will automatically call mono_error_set_pending_exception (error) and raise the resulting exception.
+ * Note:  valuetypes use the same calling convention as normal.
+ * Limitations: "out" and "ref" arguments are not supported yet. 
  */
 
 #ifndef DISABLE_PROCESS_HANDLING
@@ -767,7 +793,7 @@ ICALL(RT_28, "IsTypeExportedToWindowsRuntime", ves_icall_System_RuntimeType_IsTy
 ICALL(RT_29, "IsWindowsRuntimeObjectType", ves_icall_System_RuntimeType_IsWindowsRuntimeObjectType)
 ICALL(RT_17, "MakeGenericType", ves_icall_RuntimeType_MakeGenericType)
 ICALL(RT_18, "MakePointerType", ves_icall_RuntimeType_MakePointerType)
-ICALL(RT_19, "getFullName", ves_icall_System_RuntimeType_getFullName)
+HANDLES(ICALL(RT_19, "getFullName", ves_icall_System_RuntimeType_getFullName))
 ICALL(RT_21, "get_DeclaringMethod", ves_icall_RuntimeType_get_DeclaringMethod)
 ICALL(RT_22, "get_DeclaringType", ves_icall_RuntimeType_get_DeclaringType)
 ICALL(RT_23, "get_Name", ves_icall_RuntimeType_get_Name)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8630,7 +8630,7 @@ no_icall_table (void)
  * If the method is not found, warns and returns NULL.
  */
 gpointer
-mono_lookup_internal_call_full (MonoMethod *method, gboolean *uses_handles)
+mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles)
 {
 	char *sigstart;
 	char *tmpsig;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5302,7 +5302,7 @@ ves_icall_System_Reflection_Assembly_GetCallingAssembly (void)
 
 ICALL_EXPORT MonoStringHandle
 ves_icall_System_RuntimeType_getFullName (MonoReflectionTypeHandle object, gboolean full_name,
-										  gboolean assembly_qualified)
+										  gboolean assembly_qualified, MonoError *error)
 {
 	MonoDomain *domain = mono_object_domain (MONO_HANDLE_RAW (object));
 	MonoType *type = MONO_HANDLE_RAW (object)->type;

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -1,6 +1,7 @@
 #ifndef _MONO_METADATA_LOADER_H_
 #define _MONO_METADATA_LOADER_H_ 1
 
+#include <glib.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/image.h>
 #include <mono/utils/mono-error.h>
@@ -59,6 +60,10 @@ mono_add_internal_call     (const char *name, const void* method);
 
 MONO_API void*
 mono_lookup_internal_call (MonoMethod *method);
+
+void*
+mono_lookup_internal_call_full (MonoMethod *method, gboolean *uses_handles);
+
 
 MONO_API const char*
 mono_lookup_icall_symbol (MonoMethod *m);

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -1,7 +1,6 @@
 #ifndef _MONO_METADATA_LOADER_H_
 #define _MONO_METADATA_LOADER_H_ 1
 
-#include <glib.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/image.h>
 #include <mono/utils/mono-error.h>
@@ -62,7 +61,7 @@ MONO_API void*
 mono_lookup_internal_call (MonoMethod *method);
 
 void*
-mono_lookup_internal_call_full (MonoMethod *method, gboolean *uses_handles);
+mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles);
 
 
 MONO_API const char*

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -7819,8 +7819,12 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 				mono_mb_emit_byte (mb, CEE_LDARG_0);
 				mono_mb_emit_icall (mb, mono_handle_new);
 			}
-			for (i = 0; i < sig->param_count; i++)
+			for (i = 0; i < sig->param_count; i++) {
 				mono_mb_emit_ldarg (mb, i + sig->hasthis);
+				if (MONO_TYPE_IS_REFERENCE (sig->params [i])) {
+					mono_mb_emit_icall (mb, mono_handle_new);
+				}
+			}
 			mono_mb_emit_ldloc_addr (mb, error_var);
 		} else {
 			if (sig->hasthis)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -7770,6 +7770,10 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 		gboolean uses_handles;
 		(void) mono_lookup_internal_call_full (method, &uses_handles);
 
+
+		/* If it uses handles and MonoError, it had better check exceptions */
+		g_assert (!uses_handles || check_exceptions);
+
 		if (uses_handles) {
 			MonoMethodSignature *ret;
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -7602,23 +7602,6 @@ mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoM
 }
 #endif /* DISABLE_JIT */
 
-/*
- * icall_uses_handles:
- *
- *   Return whenever the icall METHOD uses the object handles infrastructure in handle.h.
- */
-static gboolean
-icall_uses_handles (MonoMethod *method)
-{
-	if (!strcmp (method->klass->name, "RuntimeType")) {
-		if (!strcmp (method->name, "getFullName"))
-			return TRUE;
-		return FALSE;
-	} else {
-		return FALSE;
-	}
-}
-
 /**
  * mono_marshal_get_native_wrapper:
  * @method: The MonoMethod to wrap.
@@ -7784,7 +7767,8 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 		MonoClass *error_class;
 		int thread_info_var = -1, stack_mark_var = -1, error_var = -1;
 		MonoMethodSignature *call_sig = csig;
-		gboolean uses_handles = icall_uses_handles (method);
+		gboolean uses_handles;
+		(void) mono_lookup_internal_call_full (method, &uses_handles);
 
 		if (uses_handles) {
 			MonoMethodSignature *ret;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -7849,12 +7849,11 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 		if (uses_handles) {
 			if (MONO_TYPE_IS_REFERENCE (sig->ret)) {
 				// if (ret != NULL_HANDLE) {
-				//   ret = *ret
+				//   ret = MONO_HANDLE_RAW(ret)
 				// }
-				// FIXME: Do this properly
 				mono_mb_emit_byte (mb, CEE_DUP);
 				int pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-				mono_mb_emit_byte (mb, CEE_CONV_I);
+				mono_mb_emit_ldflda (mb, MONO_HANDLE_PAYLOAD_OFFSET (MonoObject));
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 				mono_mb_patch_branch (mb, pos);
 			}

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -7783,8 +7783,11 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 
 			ret->param_count = csig->param_count + 1;
 			ret->ret = csig->ret;
-			for (int i = 0; i < csig->param_count; ++i)
+			for (int i = 0; i < csig->param_count; ++i) {
+				// FIXME: TODO implement handle wrapping for out and inout params.
+				g_assert (!mono_signature_param_is_out (csig, i));
 				ret->params [i] = csig->params [i];
+			}
 			ret->params [csig->param_count] = &mono_get_intptr_class ()->byval_arg;
 			call_sig = ret;
 		}


### PR DESCRIPTION
There's two things in here:
 1. rebased (but not finished) version of @vargaz's #3153 
 2. A new macro for `icall-def.h` to signal when an icall needs to have its managed object arguments wrapped in handles.

Example:

```c
HANDLES(ICALL(RT_19, "getFullName", ves_icall_System_RuntimeType_getFullName))
```

So everything in `icall-def.h` stays the same as before, but now we stick `HANDLES()` around the icall declaration.

Implementation:
As before `icall.c` includes `icall-def.h` multiple times while redefining the `ICALL` and `ICALL_TYPE` macros in order to populate multiple static tables.

For handles most of the time we `#define HANDLE(x) x` so the macro just expands to whatever the ICALL expands to.  When we create the icall_uses_handles table, `ICALL(...)` expands to 0 but `HANDLE(...)` expands to 1.  So as a result we get a table of 0's with 1's for the icalls that get the special treatment.

Cost:

I make a gigantic table of mostly 0's.  It would be better if we had some kind of sparse data structure.  Ultimately I don't think the table will be quite so sparse, but it would be nicer if we could pack the bits or borrow a bit in some other table.