### PR TITLE
[profiler] Implement global flush points for thread-local buffers.

### DIFF
--- a/libgc/include/gc.h
+++ b/libgc/include/gc.h
@@ -93,6 +93,7 @@ GC_API GC_PTR (*GC_oom_fn) GC_PROTO((size_t bytes_requested));
 			/* pointer to a previously allocated heap 	*/
 			/* object.					*/
 
+// Keep somewhat in sync with mono/metadata/profiler.h:enum MonoGCEvent
 typedef enum {
 	GC_EVENT_START,
 	GC_EVENT_MARK_START,

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -428,7 +428,6 @@ on_gc_notification (GC_EventType event)
 	switch (e) {
 	case MONO_GC_EVENT_PRE_STOP_WORLD:
 		MONO_GC_WORLD_STOP_BEGIN ();
-		mono_thread_info_suspend_lock ();
 		break;
 
 	case MONO_GC_EVENT_POST_STOP_WORLD:
@@ -441,7 +440,6 @@ on_gc_notification (GC_EventType event)
 
 	case MONO_GC_EVENT_POST_START_WORLD:
 		MONO_GC_WORLD_RESTART_END (1);
-		mono_thread_info_suspend_unlock ();
 		break;
 
 	case MONO_GC_EVENT_START:
@@ -481,7 +479,21 @@ on_gc_notification (GC_EventType event)
 	}
 
 	mono_profiler_gc_event (e, 0);
+
+	switch (e) {
+	case MONO_GC_EVENT_PRE_STOP_WORLD:
+		mono_thread_info_suspend_lock ();
+		mono_profiler_gc_event (MONO_GC_EVENT_PRE_STOP_WORLD_LOCKED, 0);
+		break;
+	case MONO_GC_EVENT_POST_START_WORLD:
+		mono_thread_info_suspend_unlock ();
+		mono_profiler_gc_event (MONO_GC_EVENT_POST_START_WORLD_UNLOCKED, 0);
+		break;
+	default:
+		break;
+	}
 }
+
  
 static void
 on_gc_heap_resize (size_t new_size)

--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -195,7 +195,7 @@ jit_info_table_chunk_index (MonoJitInfoTableChunk *chunk, MonoThreadHazardPointe
 
 	while (left < right) {
 		int pos = (left + right) / 2;
-		MonoJitInfo *ji = (MonoJitInfo *)get_hazardous_pointer((gpointer volatile*)&chunk->data [pos], hp, JIT_INFO_HAZARD_INDEX);
+		MonoJitInfo *ji = (MonoJitInfo *)mono_get_hazardous_pointer((gpointer volatile*)&chunk->data [pos], hp, JIT_INFO_HAZARD_INDEX);
 		gint8 *code_end = (gint8*)ji->code_start + ji->code_size;
 
 		if (addr < code_end)
@@ -228,7 +228,7 @@ jit_info_table_find (MonoJitInfoTable *table, MonoThreadHazardPointers *hp, gint
 		MonoJitInfoTableChunk *chunk = table->chunks [chunk_pos];
 
 		while (pos < chunk->num_elements) {
-			ji = (MonoJitInfo *)get_hazardous_pointer ((gpointer volatile*)&chunk->data [pos], hp, JIT_INFO_HAZARD_INDEX);
+			ji = (MonoJitInfo *)mono_get_hazardous_pointer ((gpointer volatile*)&chunk->data [pos], hp, JIT_INFO_HAZARD_INDEX);
 
 			++pos;
 
@@ -286,7 +286,7 @@ mono_jit_info_table_find_internal (MonoDomain *domain, char *addr, gboolean try_
 	   table by a hazard pointer and make sure that the pointer is
 	   still there after we've made it hazardous, we don't have to
 	   worry about the writer freeing the table. */
-	table = (MonoJitInfoTable *)get_hazardous_pointer ((gpointer volatile*)&domain->jit_info_table, hp, JIT_INFO_TABLE_HAZARD_INDEX);
+	table = (MonoJitInfoTable *)mono_get_hazardous_pointer ((gpointer volatile*)&domain->jit_info_table, hp, JIT_INFO_TABLE_HAZARD_INDEX);
 
 	ji = jit_info_table_find (table, hp, (gint8*)addr);
 	if (hp)
@@ -298,7 +298,7 @@ mono_jit_info_table_find_internal (MonoDomain *domain, char *addr, gboolean try_
 
 	/* Maybe its an AOT module */
 	if (try_aot && mono_get_root_domain () && mono_get_root_domain ()->aot_modules) {
-		table = (MonoJitInfoTable *)get_hazardous_pointer ((gpointer volatile*)&mono_get_root_domain ()->aot_modules, hp, JIT_INFO_TABLE_HAZARD_INDEX);
+		table = (MonoJitInfoTable *)mono_get_hazardous_pointer ((gpointer volatile*)&mono_get_root_domain ()->aot_modules, hp, JIT_INFO_TABLE_HAZARD_INDEX);
 		module_ji = jit_info_table_find (table, hp, (gint8*)addr);
 		if (module_ji)
 			ji = jit_info_find_in_aot_func (domain, module_ji->d.image, addr);

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -39,6 +39,7 @@ typedef enum {
 	MONO_PROFILE_FAILED
 } MonoProfileResult;
 
+// Keep somewhat in sync with libgc/include/gc.h:enum GC_EventType
 typedef enum {
 	MONO_GC_EVENT_START,
 	MONO_GC_EVENT_MARK_START,
@@ -46,10 +47,26 @@ typedef enum {
 	MONO_GC_EVENT_RECLAIM_START,
 	MONO_GC_EVENT_RECLAIM_END,
 	MONO_GC_EVENT_END,
+	/*
+	 * This is the actual arrival order of the following events:
+	 *
+	 * MONO_GC_EVENT_PRE_STOP_WORLD
+	 * MONO_GC_EVENT_PRE_STOP_WORLD_LOCKED
+	 * MONO_GC_EVENT_POST_STOP_WORLD
+	 * MONO_GC_EVENT_PRE_START_WORLD
+	 * MONO_GC_EVENT_POST_START_WORLD_UNLOCKED
+	 * MONO_GC_EVENT_POST_START_WORLD
+	 *
+	 * The LOCKED and UNLOCKED events guarantee that, by the time they arrive,
+	 * the GC and suspend locks will both have been acquired and released,
+	 * respectively.
+	 */
 	MONO_GC_EVENT_PRE_STOP_WORLD,
 	MONO_GC_EVENT_POST_STOP_WORLD,
 	MONO_GC_EVENT_PRE_START_WORLD,
-	MONO_GC_EVENT_POST_START_WORLD
+	MONO_GC_EVENT_POST_START_WORLD,
+	MONO_GC_EVENT_PRE_STOP_WORLD_LOCKED,
+	MONO_GC_EVENT_POST_START_WORLD_UNLOCKED
 } MonoGCEvent;
 
 /* coverage info */

--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -209,6 +209,8 @@ sgen_client_stop_world (int generation)
 
 	acquire_gc_locks ();
 
+	mono_profiler_gc_event (MONO_GC_EVENT_PRE_STOP_WORLD_LOCKED, generation);
+
 	/* We start to scan after locks are taking, this ensures we won't be interrupted. */
 	sgen_process_togglerefs ();
 
@@ -282,6 +284,8 @@ sgen_client_restart_world (int generation, gint64 *stw_time)
 	 * cannot answer the restart signal, so a deadlock results.
 	 */
 	release_gc_locks ();
+
+	mono_profiler_gc_event (MONO_GC_EVENT_POST_START_WORLD_UNLOCKED, generation);
 
 	*stw_time = usec;
 }

--- a/mono/profiler/decode.c
+++ b/mono/profiler/decode.c
@@ -1862,9 +1862,11 @@ gc_event_name (int ev)
 	case MONO_GC_EVENT_RECLAIM_END: return "reclaim end";
 	case MONO_GC_EVENT_END: return "end";
 	case MONO_GC_EVENT_PRE_STOP_WORLD: return "pre stop";
+	case MONO_GC_EVENT_PRE_STOP_WORLD_LOCKED: return "pre stop lock";
 	case MONO_GC_EVENT_POST_STOP_WORLD: return "post stop";
 	case MONO_GC_EVENT_PRE_START_WORLD: return "pre start";
 	case MONO_GC_EVENT_POST_START_WORLD: return "post start";
+	case MONO_GC_EVENT_POST_START_WORLD_UNLOCKED: return "post start unlock";
 	default:
 		return "unknown";
 	}

--- a/mono/profiler/decode.c
+++ b/mono/profiler/decode.c
@@ -1970,21 +1970,25 @@ get_root_name (int rtype)
 }
 
 static MethodDesc**
-decode_bt (MethodDesc** sframes, int *size, unsigned char *p, unsigned char **endp, intptr_t ptr_base)
+decode_bt (ProfContext *ctx, MethodDesc** sframes, int *size, unsigned char *p, unsigned char **endp, intptr_t ptr_base, intptr_t *method_base)
 {
 	MethodDesc **frames;
 	int i;
-	int flags = decode_uleb128 (p, &p);
+	if (ctx->data_version < 13)
+		decode_uleb128 (p, &p); /* flags */
 	int count = decode_uleb128 (p, &p);
-	if (flags != 0)
-		return NULL;
 	if (count > *size)
 		frames = (MethodDesc **)malloc (count * sizeof (void*));
 	else
 		frames = sframes;
 	for (i = 0; i < count; ++i) {
 		intptr_t ptrdiff = decode_sleb128 (p, &p);
-		frames [i] = lookup_method (ptr_base + ptrdiff);
+		if (ctx->data_version > 12) {
+			*method_base += ptrdiff;
+			frames [i] = lookup_method (*method_base);
+		} else {
+			frames [i] = lookup_method (ptr_base + ptrdiff);
+		}
 	}
 	*size = count;
 	*endp = p;
@@ -2293,8 +2297,16 @@ decode_buffer (ProfContext *ctx)
 				if (new_size > max_heap_size)
 					max_heap_size = new_size;
 			} else if (subtype == TYPE_GC_EVENT) {
-				uint64_t ev = decode_uleb128 (p, &p);
-				int gen = decode_uleb128 (p, &p);
+				uint64_t ev;
+				if (ctx->data_version > 12)
+					ev = *p++;
+				else
+					ev = decode_uleb128 (p, &p);
+				int gen;
+				if (ctx->data_version > 12)
+					gen = *p++;
+				else
+					gen = decode_uleb128 (p, &p);
 				if (debug)
 					fprintf (outfile, "gc event for gen%d: %s at %llu (thread: 0x%zx)\n", gen, gc_event_name (ev), (unsigned long long) time_base, thread->thread_id);
 				if (gen > 2) {
@@ -2332,7 +2344,7 @@ decode_buffer (ProfContext *ctx)
 				intptr_t objdiff = decode_sleb128 (p, &p);
 				if (has_bt) {
 					num_bt = 8;
-					frames = decode_bt (sframes, &num_bt, p, &p, ptr_base);
+					frames = decode_bt (ctx, sframes, &num_bt, p, &p, ptr_base, &method_base);
 					if (!frames) {
 						fprintf (outfile, "Cannot load backtrace\n");
 						return 0;
@@ -2366,7 +2378,7 @@ decode_buffer (ProfContext *ctx)
 				uint32_t handle = decode_uleb128 (p, &p);
 				if (has_bt) {
 					num_bt = 8;
-					frames = decode_bt (sframes, &num_bt, p, &p, ptr_base);
+					frames = decode_bt (ctx, sframes, &num_bt, p, &p, ptr_base, &method_base);
 					if (!frames) {
 						fprintf (outfile, "Cannot load backtrace\n");
 						return 0;
@@ -2401,11 +2413,8 @@ decode_buffer (ProfContext *ctx)
 			time_base += tdiff;
 			if (mtype == TYPE_CLASS) {
 				intptr_t imptrdiff = decode_sleb128 (p, &p);
-				uint64_t flags = decode_uleb128 (p, &p);
-				if (flags) {
-					fprintf (outfile, "non-zero flags in class\n");
-					return 0;
-				}
+				if (ctx->data_version < 13)
+					decode_uleb128 (p, &p); /* flags */
 				if (debug)
 					fprintf (outfile, "%s class %p (%s in %p) at %llu\n", load_str, (void*)(ptr_base + ptrdiff), p, (void*)(ptr_base + imptrdiff), (unsigned long long) time_base);
 				if (subtype == TYPE_END_LOAD)
@@ -2413,11 +2422,8 @@ decode_buffer (ProfContext *ctx)
 				while (*p) p++;
 				p++;
 			} else if (mtype == TYPE_IMAGE) {
-				uint64_t flags = decode_uleb128 (p, &p);
-				if (flags) {
-					fprintf (outfile, "non-zero flags in image\n");
-					return 0;
-				}
+				if (ctx->data_version < 13)
+					decode_uleb128 (p, &p); /* flags */
 				if (debug)
 					fprintf (outfile, "%s image %p (%s) at %llu\n", load_str, (void*)(ptr_base + ptrdiff), p, (unsigned long long) time_base);
 				if (subtype == TYPE_END_LOAD)
@@ -2425,11 +2431,8 @@ decode_buffer (ProfContext *ctx)
 				while (*p) p++;
 				p++;
 			} else if (mtype == TYPE_ASSEMBLY) {
-				uint64_t flags = decode_uleb128 (p, &p);
-				if (flags) {
-					fprintf (outfile, "non-zero flags in assembly\n");
-					return 0;
-				}
+				if (ctx->data_version < 13)
+					decode_uleb128 (p, &p); /* flags */
 				if (debug)
 					fprintf (outfile, "%s assembly %p (%s) at %llu\n", load_str, (void*)(ptr_base + ptrdiff), p, (unsigned long long) time_base);
 				if (subtype == TYPE_END_LOAD)
@@ -2437,11 +2440,8 @@ decode_buffer (ProfContext *ctx)
 				while (*p) p++;
 				p++;
 			} else if (mtype == TYPE_DOMAIN) {
-				uint64_t flags = decode_uleb128 (p, &p);
-				if (flags) {
-					fprintf (outfile, "non-zero flags in domain\n");
-					return 0;
-				}
+				if (ctx->data_version < 13)
+					decode_uleb128 (p, &p); /* flags */
 				DomainContext *nd = get_domain (ctx, ptr_base + ptrdiff);
 				/* no subtype means it's a name event, rather than start/stop */
 				if (subtype == 0)
@@ -2457,22 +2457,16 @@ decode_buffer (ProfContext *ctx)
 					p++;
 				}
 			} else if (mtype == TYPE_CONTEXT) {
-				uint64_t flags = decode_uleb128 (p, &p);
-				if (flags) {
-					fprintf (outfile, "non-zero flags in context\n");
-					return 0;
-				}
+				if (ctx->data_version < 13)
+					decode_uleb128 (p, &p); /* flags */
 				intptr_t domaindiff = decode_sleb128 (p, &p);
 				if (debug)
 					fprintf (outfile, "%s context %p (%p) at %llu\n", load_str, (void*)(ptr_base + ptrdiff), (void *) (ptr_base + domaindiff), (unsigned long long) time_base);
 				if (subtype == TYPE_END_LOAD)
 					get_remctx (ctx, ptr_base + ptrdiff)->domain_id = ptr_base + domaindiff;
 			} else if (mtype == TYPE_THREAD) {
-				uint64_t flags = decode_uleb128 (p, &p);
-				if (flags) {
-					fprintf (outfile, "non-zero flags in thread\n");
-					return 0;
-				}
+				if (ctx->data_version < 13)
+					decode_uleb128 (p, &p); /* flags */
 				ThreadContext *nt = get_thread (ctx, ptr_base + ptrdiff);
 				/* no subtype means it's a name event, rather than start/stop */
 				if (subtype == 0)
@@ -2507,7 +2501,7 @@ decode_buffer (ProfContext *ctx)
 				fprintf (outfile, "alloced object %p, size %llu (%s) at %llu\n", (void*)OBJ_ADDR (objdiff), (unsigned long long) len, lookup_class (ptr_base + ptrdiff)->name, (unsigned long long) time_base);
 			if (has_bt) {
 				num_bt = 8;
-				frames = decode_bt (sframes, &num_bt, p, &p, ptr_base);
+				frames = decode_bt (ctx, sframes, &num_bt, p, &p, ptr_base, &method_base);
 				if (!frames) {
 					fprintf (outfile, "Cannot load backtrace\n");
 					return 0;
@@ -2684,7 +2678,7 @@ decode_buffer (ProfContext *ctx)
 				}
 				if (has_bt) {
 					num_bt = 8;
-					frames = decode_bt (sframes, &num_bt, p, &p, ptr_base);
+					frames = decode_bt (ctx, sframes, &num_bt, p, &p, ptr_base, &method_base);
 					if (!frames) {
 						fprintf (outfile, "Cannot load backtrace\n");
 						return 0;
@@ -2739,7 +2733,11 @@ decode_buffer (ProfContext *ctx)
 			if (!(time_base >= time_from && time_base < time_to))
 				record = 0;
 			if (subtype == TYPE_CLAUSE) {
-				int clause_type = decode_uleb128 (p, &p);
+				int clause_type;
+				if (ctx->data_version > 12)
+					clause_type = *p++;
+				else
+					clause_type = decode_uleb128 (p, &p);
 				int clause_num = decode_uleb128 (p, &p);
 				int64_t ptrdiff = decode_sleb128 (p, &p);
 				method_base += ptrdiff;
@@ -2753,7 +2751,7 @@ decode_buffer (ProfContext *ctx)
 					throw_count++;
 				if (has_bt) {
 					has_bt = 8;
-					frames = decode_bt (sframes, &has_bt, p, &p, ptr_base);
+					frames = decode_bt (ctx, sframes, &has_bt, p, &p, ptr_base, &method_base);
 					if (!frames) {
 						fprintf (outfile, "Cannot load backtrace\n");
 						return 0;
@@ -2777,7 +2775,11 @@ decode_buffer (ProfContext *ctx)
 			LOG_TIME (time_base, tdiff);
 			time_base += tdiff;
 			if (subtype == TYPE_JITHELPER) {
-				int type = decode_uleb128 (p, &p);
+				int type;
+				if (ctx->data_version > 12)
+					type = *p++;
+				else
+					type = decode_uleb128 (p, &p);
 				intptr_t codediff = decode_sleb128 (p, &p);
 				int codelen = decode_uleb128 (p, &p);
 				const char *name;
@@ -2799,7 +2801,12 @@ decode_buffer (ProfContext *ctx)
 			int subtype = *p & 0xf0;
 			if (subtype == TYPE_SAMPLE_HIT) {
 				int i;
-				int sample_type = decode_uleb128 (p + 1, &p);
+				int sample_type;
+				if (ctx->data_version > 12) {
+					p++;
+					sample_type = *p++;
+				} else
+					sample_type = decode_uleb128 (p + 1, &p);
 				uint64_t tstamp = decode_uleb128 (p, &p);
 				void *tid = (void *) thread_id;
 				if (ctx->data_version > 10)
@@ -2817,12 +2824,14 @@ decode_buffer (ProfContext *ctx)
 					for (i = 0; i < count; ++i) {
 						MethodDesc *method;
 						int64_t ptrdiff = decode_sleb128 (p, &p);
-						int il_offset = decode_sleb128 (p, &p);
-						int native_offset = decode_sleb128 (p, &p);
 						method_base += ptrdiff;
 						method = lookup_method (method_base);
 						if (debug)
-							fprintf (outfile, "sample hit bt %d: %s at IL offset %d (native: %d)\n", i, method->name, il_offset, native_offset);
+							fprintf (outfile, "sample hit bt %d: %s\n", i, method->name);
+						if (ctx->data_version < 13) {
+							decode_sleb128 (p, &p); /* il offset */
+							decode_sleb128 (p, &p); /* native offset */
+						}
 					}
 				}
 			} else if (subtype == TYPE_SAMPLE_USYM) {
@@ -2865,9 +2874,15 @@ decode_buffer (ProfContext *ctx)
 					}
 					name = pstrdup ((char*)p);
 					while (*p++);
-					type = decode_uleb128 (p, &p);
-					unit = decode_uleb128 (p, &p);
-					variance = decode_uleb128 (p, &p);
+					if (ctx->data_version > 12) {
+						type = *p++;
+						unit = *p++;
+						variance = *p++;
+					} else {
+						type = decode_uleb128 (p, &p);
+						unit = decode_uleb128 (p, &p);
+						variance = decode_uleb128 (p, &p);
+					}
 					index = decode_uleb128 (p, &p);
 					add_counter (section_str, name, (int)type, (int)unit, (int)variance, (int)index);
 				}
@@ -2889,7 +2904,10 @@ decode_buffer (ProfContext *ctx)
 						}
 					}
 
-					type = decode_uleb128 (p, &p);
+					if (ctx->data_version > 12)
+						type = *p++;
+					else
+						type = decode_uleb128 (p, &p);
 
 					value = (CounterValue *)calloc (1, sizeof (CounterValue));
 					value->timestamp = timestamp;

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -1339,7 +1339,7 @@ gc_event (MonoProfiler *profiler, MonoGCEvent ev, int generation)
 		if (generation == mono_gc_max_generation ())
 			gc_count++;
 		break;
-	case MONO_GC_EVENT_PRE_STOP_WORLD:
+	case MONO_GC_EVENT_PRE_STOP_WORLD_LOCKED:
 		/*
 		 * Ensure that no thread can be in the middle of writing to
 		 * a buffer when the world stops...
@@ -1364,7 +1364,7 @@ gc_event (MonoProfiler *profiler, MonoGCEvent ev, int generation)
 	case MONO_GC_EVENT_PRE_START_WORLD:
 		heap_walk (profiler);
 		break;
-	case MONO_GC_EVENT_POST_START_WORLD:
+	case MONO_GC_EVENT_POST_START_WORLD_UNLOCKED:
 		/*
 		 * Similarly, we must now make sure that any object moves
 		 * written to the GC thread's buffer are flushed. Otherwise,

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -4480,6 +4480,16 @@ helper_thread (void* arg)
 
 		counters_and_perfcounters_sample (prof, TRUE);
 
+		buffer_lock_excl ();
+
+		// Periodically flush all thread-local buffers.
+		MONO_LLS_FOREACH_SAFE (&profiler_thread_list, MonoProfilerThread, thread) {
+			send_buffer (prof, thread);
+			init_buffer_state (thread);
+		} MONO_LLS_FOREACH_SAFE_END
+
+		buffer_unlock_excl ();
+
 		tv.tv_sec = 1;
 		tv.tv_usec = 0;
 		len = select (max_fd + 1, &rfds, NULL, NULL, &tv);

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -109,6 +109,8 @@ static int read_perf_mmap (MonoProfiler* prof, int cpu);
 #define LEB128_SIZE 10
 /* Size in bytes of the event ID prefix. */
 #define EVENT_SIZE 1
+/* Size of a value encoded as a single byte. */
+#define BYTE_SIZE 1
 
 static int nocalls = 0;
 static int notraces = 0;
@@ -214,7 +216,6 @@ static MonoLinkedListSet profiler_thread_list;
  * strings are represented as a 0-terminated utf8 sequence.
  *
  * backtrace format:
- * [flags: uleb128] must be 0
  * [num: uleb128] number of frames following
  * [frame: sleb128]* num MonoMethod pointers as differences from ptr_base
  *
@@ -235,8 +236,8 @@ static MonoLinkedListSet profiler_thread_list;
  * if exinfo == TYPE_GC_RESIZE
  *	[heap_size: uleb128] new heap size
  * if exinfo == TYPE_GC_EVENT
- *	[event type: uleb128] GC event (MONO_GC_EVENT_* from profiler.h)
- *	[generation: uleb128] GC generation event refers to
+ *	[event type: byte] GC event (MONO_GC_EVENT_* from profiler.h)
+ *	[generation: byte] GC generation event refers to
  * if exinfo == TYPE_GC_MOVE
  *	[num_objects: uleb128] number of object moves that follow
  *	[objaddr: sleb128]+ num_objects object pointer differences from obj_base
@@ -263,23 +264,16 @@ static MonoLinkedListSet profiler_thread_list;
  * [pointer: sleb128] pointer of the metadata type depending on mtype
  * if mtype == TYPE_CLASS
  *	[image: sleb128] MonoImage* as a pointer difference from ptr_base
- * 	[flags: uleb128] must be 0
  * 	[name: string] full class name
  * if mtype == TYPE_IMAGE
- * 	[flags: uleb128] must be 0
  * 	[name: string] image file name
  * if mtype == TYPE_ASSEMBLY
- * 	[flags: uleb128] must be 0
  * 	[name: string] assembly name
- * if mtype == TYPE_DOMAIN
- * 	[flags: uleb128] must be 0
  * if mtype == TYPE_DOMAIN && exinfo == 0
  * 	[name: string] domain friendly name
  * if mtype == TYPE_CONTEXT
- * 	[flags: uleb128] must be 0
  * 	[domain: sleb128] domain id as pointer
  * if mtype == TYPE_THREAD && (format_version < 11 || (format_version > 10 && exinfo == 0))
- * 	[flags: uleb128] must be 0
  * 	[name: string] thread name
  *
  * type method format:
@@ -298,7 +292,7 @@ static MonoLinkedListSet profiler_thread_list;
  * exinfo: one of: TYPE_JITHELPER
  * [time diff: uleb128] nanoseconds since last timing
  * if exinfo == TYPE_JITHELPER
- *	[type: uleb128] MonoProfilerCodeBufferType enum value
+ *	[type: byte] MonoProfilerCodeBufferType enum value
  *	[buffer address: sleb128] pointer to the native code as a diff from ptr_base
  *	[buffer size: uleb128] size of the generated code
  *	if type == MONO_PROFILER_CODE_BUFFER_SPECIFIC_TRAMPOLINE
@@ -343,18 +337,16 @@ static MonoLinkedListSet profiler_thread_list;
  * type: TYPE_SAMPLE
  * exinfo: one of TYPE_SAMPLE_HIT, TYPE_SAMPLE_USYM, TYPE_SAMPLE_UBIN, TYPE_SAMPLE_COUNTERS_DESC, TYPE_SAMPLE_COUNTERS
  * if exinfo == TYPE_SAMPLE_HIT
- * 	[sample_type: uleb128] type of sample (SAMPLE_*)
+ * 	[sample_type: byte] type of sample (SAMPLE_*)
  * 	[timestamp: uleb128] nanoseconds since startup (note: different from other timestamps!)
  * 	if (format_version > 10)
  * 		[thread: sleb128] thread id as difference from ptr_base
  * 	[count: uleb128] number of following instruction addresses
  * 	[ip: sleb128]* instruction pointer as difference from ptr_base
  *	if (format_version > 5)
- *		[mbt_count: uleb128] number of managed backtrace info triplets (method + IL offset + native offset)
+ *		[mbt_count: uleb128] number of managed backtrace frames
  *		[method: sleb128]* MonoMethod* as a pointer difference from the last such
  * 		pointer or the buffer method_base (the first such method can be also indentified by ip, but this is not neccessarily true)
- *		[il_offset: sleb128]* IL offset inside method where the hit occurred
- *		[native_offset: sleb128]* native offset inside method where the hit occurred
  * if exinfo == TYPE_SAMPLE_USYM
  * 	[address: sleb128] symbol address as a difference from ptr_base
  * 	[size: uleb128] symbol size (may be 0 if unknown)
@@ -372,9 +364,9 @@ static MonoLinkedListSet profiler_thread_list;
  * 		if section == MONO_COUNTER_PERFCOUNTERS:
  * 			[section_name: string] section name of counter
  * 		[name: string] name of counter
- * 		[type: uleb128] type of counter
- * 		[unit: uleb128] unit of counter
- * 		[variance: uleb128] variance of counter
+ * 		[type: byte] type of counter
+ * 		[unit: byte] unit of counter
+ * 		[variance: byte] variance of counter
  * 		[index: uleb128] unique index of counter
  * if exinfo == TYPE_SAMPLE_COUNTERS
  * 	[timestamp: uleb128] sampling timestamp
@@ -382,7 +374,7 @@ static MonoLinkedListSet profiler_thread_list;
  * 		[index: uleb128] unique index of counter
  * 		if index == 0:
  * 			break
- * 		[type: uleb128] type of counter value
+ * 		[type: byte] type of counter value
  * 		if type == string:
  * 			if value == null:
  * 				[0: uleb128] 0 -> value is null
@@ -434,19 +426,6 @@ static MonoLinkedListSet profiler_thread_list;
  * [time diff: uleb128] nanoseconds since last timing
  * if exinfo == TYPE_SYNC_POINT
  *	[type: byte] MonoProfilerSyncPointType enum value
- */
-
-/*
- * Format oddities that we ought to fix:
- *
- * - Methods written in emit_bt () should be based on the buffer's base
- *   method instead of the base pointer.
- * - The TYPE_SAMPLE_HIT event contains (currently) pointless data like
- *   always-one unmanaged frame count and always-zero IL offsets.
- *
- * These are mostly small things and are not worth a format change by
- * themselves. They should be done when some other major change has to
- * be done to the format.
  */
 
 // Pending data to be written to the log, for a single thread.
@@ -956,13 +935,6 @@ emit_method (MonoProfiler *prof, LogBuffer *logbuffer, MonoMethod *method)
 }
 
 static void
-emit_method_as_ptr (MonoProfiler *prof, LogBuffer *logbuffer, MonoMethod *method)
-{
-	register_method_local (prof, method, NULL);
-	emit_ptr (logbuffer, method);
-}
-
-static void
 emit_obj (LogBuffer *logbuffer, void *ptr)
 {
 	if (!logbuffer->obj_base)
@@ -1096,9 +1068,8 @@ remove_thread (MonoProfiler *prof, MonoProfilerThread *thread, gboolean from_cal
 			buffer = ensure_logbuf_inner (buffer,
 				EVENT_SIZE /* event */ +
 				LEB128_SIZE /* time */ +
-				EVENT_SIZE /* type */ +
-				LEB128_SIZE /* tid */ +
-				LEB128_SIZE /* flags */
+				BYTE_SIZE /* type */ +
+				LEB128_SIZE /* tid */
 			);
 
 			uint64_t now = current_time ();
@@ -1107,7 +1078,6 @@ remove_thread (MonoProfiler *prof, MonoProfilerThread *thread, gboolean from_cal
 			emit_time (buffer, now);
 			emit_byte (buffer, TYPE_THREAD);
 			emit_ptr (buffer, (void *) thread->node.key);
-			emit_value (buffer, 0); /* flags */
 		}
 
 		send_buffer (prof, thread);
@@ -1381,16 +1351,16 @@ gc_event (MonoProfiler *profiler, MonoGCEvent ev, int generation)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		LEB128_SIZE /* gc event */ +
-		LEB128_SIZE /* generation */
+		BYTE_SIZE /* gc event */ +
+		BYTE_SIZE /* generation */
 	);
 
 	uint64_t now = current_time ();
 
 	emit_byte (logbuffer, TYPE_GC_EVENT | TYPE_GC);
 	emit_time (logbuffer, now);
-	emit_value (logbuffer, ev);
-	emit_value (logbuffer, generation);
+	emit_byte (logbuffer, ev);
+	emit_byte (logbuffer, generation);
 
 	EXIT_LOG;
 
@@ -1507,12 +1477,11 @@ emit_bt (MonoProfiler *prof, LogBuffer *logbuffer, FrameData *data)
 	 */
 	if (data->count > num_frames)
 		printf ("bad num frames: %d\n", data->count);
-	emit_value (logbuffer, 0); /* flags */
 	emit_value (logbuffer, data->count);
 	//if (*p != data.count) {
 	//	printf ("bad num frames enc at %d: %d -> %d\n", count, data.count, *p); printf ("frames end: %p->%p\n", p, logbuffer->cursor); exit(0);}
 	while (data->count) {
-		emit_method_as_ptr (prof, logbuffer, data->methods [--data->count]);
+		emit_method (prof, logbuffer, data->methods [--data->count]);
 	}
 }
 
@@ -1540,7 +1509,6 @@ gc_alloc (MonoProfiler *prof, MonoObject *obj, MonoClass *klass)
 		LEB128_SIZE /* obj */ +
 		LEB128_SIZE /* size */ +
 		(do_bt ? (
-			LEB128_SIZE /* flags */ +
 			LEB128_SIZE /* count */ +
 			data.count * (
 				LEB128_SIZE /* method */
@@ -1641,7 +1609,6 @@ gc_handle (MonoProfiler *prof, int op, int type, uintptr_t handle, MonoObject *o
 			LEB128_SIZE /* obj */
 		) : 0) +
 		(do_bt ? (
-			LEB128_SIZE /* flags */ +
 			LEB128_SIZE /* count */ +
 			data.count * (
 				LEB128_SIZE /* method */
@@ -1723,9 +1690,8 @@ image_loaded (MonoProfiler *prof, MonoImage *image, int result)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* image */ +
-		LEB128_SIZE /* flags */ +
 		nlen /* name */
 	);
 
@@ -1735,7 +1701,6 @@ image_loaded (MonoProfiler *prof, MonoImage *image, int result)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_IMAGE);
 	emit_ptr (logbuffer, image);
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, nlen);
 	logbuffer->cursor += nlen;
 
@@ -1759,9 +1724,8 @@ image_unloaded (MonoProfiler *prof, MonoImage *image)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* image */ +
-		LEB128_SIZE /* flags */ +
 		nlen /* name */
 	);
 
@@ -1771,7 +1735,6 @@ image_unloaded (MonoProfiler *prof, MonoImage *image)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_IMAGE);
 	emit_ptr (logbuffer, image);
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, nlen);
 	logbuffer->cursor += nlen;
 
@@ -1798,9 +1761,8 @@ assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly, int result)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* assembly */ +
-		LEB128_SIZE /* flags */ +
 		nlen /* name */
 	);
 
@@ -1810,7 +1772,6 @@ assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly, int result)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_ASSEMBLY);
 	emit_ptr (logbuffer, assembly);
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, nlen);
 	logbuffer->cursor += nlen;
 
@@ -1836,9 +1797,8 @@ assembly_unloaded (MonoProfiler *prof, MonoAssembly *assembly)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* assembly */ +
-		LEB128_SIZE /* flags */ +
 		nlen /* name */
 	);
 
@@ -1848,7 +1808,6 @@ assembly_unloaded (MonoProfiler *prof, MonoAssembly *assembly)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_ASSEMBLY);
 	emit_ptr (logbuffer, assembly);
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, nlen);
 	logbuffer->cursor += nlen;
 
@@ -1884,10 +1843,9 @@ class_loaded (MonoProfiler *prof, MonoClass *klass, int result)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* klass */ +
 		LEB128_SIZE /* image */ +
-		LEB128_SIZE /* flags */ +
 		nlen /* name */
 	);
 
@@ -1898,7 +1856,6 @@ class_loaded (MonoProfiler *prof, MonoClass *klass, int result)
 	emit_byte (logbuffer, TYPE_CLASS);
 	emit_ptr (logbuffer, klass);
 	emit_ptr (logbuffer, image);
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, nlen);
 	logbuffer->cursor += nlen;
 
@@ -1934,10 +1891,9 @@ class_unloaded (MonoProfiler *prof, MonoClass *klass)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* klass */ +
 		LEB128_SIZE /* image */ +
-		LEB128_SIZE /* flags */ +
 		nlen /* name */
 	);
 
@@ -1948,7 +1904,6 @@ class_unloaded (MonoProfiler *prof, MonoClass *klass)
 	emit_byte (logbuffer, TYPE_CLASS);
 	emit_ptr (logbuffer, klass);
 	emit_ptr (logbuffer, image);
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, nlen);
 	logbuffer->cursor += nlen;
 
@@ -2082,7 +2037,7 @@ code_buffer_new (MonoProfiler *prof, void *buffer, int size, MonoProfilerCodeBuf
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		LEB128_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* buffer */ +
 		LEB128_SIZE /* size */ +
 		(name ? (
@@ -2094,7 +2049,7 @@ code_buffer_new (MonoProfiler *prof, void *buffer, int size, MonoProfilerCodeBuf
 
 	emit_byte (logbuffer, TYPE_JITHELPER | TYPE_RUNTIME);
 	emit_time (logbuffer, now);
-	emit_value (logbuffer, type);
+	emit_byte (logbuffer, type);
 	emit_ptr (logbuffer, buffer);
 	emit_value (logbuffer, size);
 
@@ -2124,7 +2079,6 @@ throw_exc (MonoProfiler *prof, MonoObject *object)
 		LEB128_SIZE /* time */ +
 		LEB128_SIZE /* object */ +
 		(do_bt ? (
-			LEB128_SIZE /* flags */ +
 			LEB128_SIZE /* count */ +
 			data.count * (
 				LEB128_SIZE /* method */
@@ -2154,7 +2108,7 @@ clause_exc (MonoProfiler *prof, MonoMethod *method, int clause_type, int clause_
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		LEB128_SIZE /* clause type */ +
+		BYTE_SIZE /* clause type */ +
 		LEB128_SIZE /* clause num */ +
 		LEB128_SIZE /* method */
 	);
@@ -2163,7 +2117,7 @@ clause_exc (MonoProfiler *prof, MonoMethod *method, int clause_type, int clause_
 
 	emit_byte (logbuffer, TYPE_EXCEPTION | TYPE_CLAUSE);
 	emit_time (logbuffer, now);
-	emit_value (logbuffer, clause_type);
+	emit_byte (logbuffer, clause_type);
 	emit_value (logbuffer, clause_num);
 	emit_method (prof, logbuffer, method);
 
@@ -2188,7 +2142,6 @@ monitor_event (MonoProfiler *profiler, MonoObject *object, MonoProfilerMonitorEv
 		LEB128_SIZE /* time */ +
 		LEB128_SIZE /* object */ +
 		(do_bt ? (
-			LEB128_SIZE /* flags */ +
 			LEB128_SIZE /* count */ +
 			data.count * (
 				LEB128_SIZE /* method */
@@ -2220,9 +2173,8 @@ thread_start (MonoProfiler *prof, uintptr_t tid)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
-		LEB128_SIZE /* tid */ +
-		LEB128_SIZE /* flags */
+		BYTE_SIZE /* type */ +
+		LEB128_SIZE /* tid */
 	);
 
 	uint64_t now = current_time ();
@@ -2231,7 +2183,6 @@ thread_start (MonoProfiler *prof, uintptr_t tid)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_THREAD);
 	emit_ptr (logbuffer, (void*) tid);
-	emit_value (logbuffer, 0); /* flags */
 
 	EXIT_LOG;
 
@@ -2250,9 +2201,8 @@ thread_end (MonoProfiler *prof, uintptr_t tid)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
-		LEB128_SIZE /* tid */ +
-		LEB128_SIZE /* flags */
+		BYTE_SIZE /* type */ +
+		LEB128_SIZE /* tid */
 	);
 
 	uint64_t now = current_time ();
@@ -2261,7 +2211,6 @@ thread_end (MonoProfiler *prof, uintptr_t tid)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_THREAD);
 	emit_ptr (logbuffer, (void*) tid);
-	emit_value (logbuffer, 0); /* flags */
 
 	EXIT_LOG;
 
@@ -2283,9 +2232,8 @@ domain_loaded (MonoProfiler *prof, MonoDomain *domain, int result)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
-		LEB128_SIZE /* domain id */ +
-		LEB128_SIZE /* flags */
+		BYTE_SIZE /* type */ +
+		LEB128_SIZE /* domain id */
 	);
 
 	uint64_t now = current_time ();
@@ -2294,7 +2242,6 @@ domain_loaded (MonoProfiler *prof, MonoDomain *domain, int result)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_DOMAIN);
 	emit_ptr (logbuffer, (void*)(uintptr_t) mono_domain_get_id (domain));
-	emit_value (logbuffer, 0); /* flags */
 
 	EXIT_LOG;
 
@@ -2313,9 +2260,8 @@ domain_unloaded (MonoProfiler *prof, MonoDomain *domain)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
-		LEB128_SIZE /* domain id */ +
-		LEB128_SIZE /* flags */
+		BYTE_SIZE /* type */ +
+		LEB128_SIZE /* domain id */
 	);
 
 	uint64_t now = current_time ();
@@ -2324,7 +2270,6 @@ domain_unloaded (MonoProfiler *prof, MonoDomain *domain)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_DOMAIN);
 	emit_ptr (logbuffer, (void*)(uintptr_t) mono_domain_get_id (domain));
-	emit_value (logbuffer, 0); /* flags */
 
 	EXIT_LOG;
 
@@ -2345,9 +2290,8 @@ domain_name (MonoProfiler *prof, MonoDomain *domain, const char *name)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* domain id */ +
-		LEB128_SIZE /* flags */ +
 		nlen /* name */
 	);
 
@@ -2357,7 +2301,6 @@ domain_name (MonoProfiler *prof, MonoDomain *domain, const char *name)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_DOMAIN);
 	emit_ptr (logbuffer, (void*)(uintptr_t) mono_domain_get_id (domain));
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, nlen);
 	logbuffer->cursor += nlen;
 
@@ -2376,9 +2319,8 @@ context_loaded (MonoProfiler *prof, MonoAppContext *context)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* context id */ +
-		LEB128_SIZE /* flags */ +
 		LEB128_SIZE /* domain id */
 	);
 
@@ -2388,7 +2330,6 @@ context_loaded (MonoProfiler *prof, MonoAppContext *context)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_CONTEXT);
 	emit_ptr (logbuffer, (void*)(uintptr_t) mono_context_get_id (context));
-	emit_value (logbuffer, 0); /* flags */
 	emit_ptr (logbuffer, (void*)(uintptr_t) mono_context_get_domain_id (context));
 
 	EXIT_LOG;
@@ -2408,9 +2349,8 @@ context_unloaded (MonoProfiler *prof, MonoAppContext *context)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* context id */ +
-		LEB128_SIZE /* flags */ +
 		LEB128_SIZE /* domain id */
 	);
 
@@ -2420,7 +2360,6 @@ context_unloaded (MonoProfiler *prof, MonoAppContext *context)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_CONTEXT);
 	emit_ptr (logbuffer, (void*)(uintptr_t) mono_context_get_id (context));
-	emit_value (logbuffer, 0); /* flags */
 	emit_ptr (logbuffer, (void*)(uintptr_t) mono_context_get_domain_id (context));
 
 	EXIT_LOG;
@@ -2442,9 +2381,8 @@ thread_name (MonoProfiler *prof, uintptr_t tid, const char *name)
 	LogBuffer *logbuffer = ensure_logbuf (
 		EVENT_SIZE /* event */ +
 		LEB128_SIZE /* time */ +
-		EVENT_SIZE /* type */ +
+		BYTE_SIZE /* type */ +
 		LEB128_SIZE /* tid */ +
-		LEB128_SIZE /* flags */ +
 		len /* name */
 	);
 
@@ -2454,7 +2392,6 @@ thread_name (MonoProfiler *prof, uintptr_t tid, const char *name)
 	emit_time (logbuffer, now);
 	emit_byte (logbuffer, TYPE_THREAD);
 	emit_ptr (logbuffer, (void*)tid);
-	emit_value (logbuffer, 0); /* flags */
 	memcpy (logbuffer->cursor, name, len);
 	logbuffer->cursor += len;
 
@@ -3077,7 +3014,7 @@ dump_perf_hits (MonoProfiler *prof, void *buf, int size)
 
 		LogBuffer *logbuffer = ensure_logbuf (
 			EVENT_SIZE /* event */ +
-			LEB128_SIZE /* type */ +
+			BYTE_SIZE /* type */ +
 			LEB128_SIZE /* time */ +
 			LEB128_SIZE /* tid */ +
 			LEB128_SIZE /* count */ +
@@ -3086,14 +3023,12 @@ dump_perf_hits (MonoProfiler *prof, void *buf, int size)
 			) +
 			LEB128_SIZE /* managed count */ +
 			mbt_count * (
-				LEB128_SIZE /* method */ +
-				LEB128_SIZE /* il offset */ +
-				LEB128_SIZE /* native offset */
+				LEB128_SIZE /* method */
 			)
 		);
 
 		emit_byte (logbuffer, TYPE_SAMPLE | TYPE_SAMPLE_HIT);
-		emit_value (logbuffer, sample_type);
+		emit_byte (logbuffer, sample_type);
 		emit_uvalue (logbuffer, s->timestamp - prof->startup_time);
 		/*
 		 * No useful thread ID to write here, since throughout the
@@ -3321,9 +3256,9 @@ counters_emit (MonoProfiler *profiler)
 		size +=
 			LEB128_SIZE /* section */ +
 			strlen (mono_counter_get_name (agent->counter)) + 1 /* name */ +
-			LEB128_SIZE /* type */ +
-			LEB128_SIZE /* unit */ +
-			LEB128_SIZE /* variance */ +
+			BYTE_SIZE /* type */ +
+			BYTE_SIZE /* unit */ +
+			BYTE_SIZE /* variance */ +
 			LEB128_SIZE /* index */
 		;
 
@@ -3351,9 +3286,9 @@ counters_emit (MonoProfiler *profiler)
 		name = mono_counter_get_name (agent->counter);
 		emit_value (logbuffer, mono_counter_get_section (agent->counter));
 		emit_string (logbuffer, name, strlen (name) + 1);
-		emit_value (logbuffer, mono_counter_get_type (agent->counter));
-		emit_value (logbuffer, mono_counter_get_unit (agent->counter));
-		emit_value (logbuffer, mono_counter_get_variance (agent->counter));
+		emit_byte (logbuffer, mono_counter_get_type (agent->counter));
+		emit_byte (logbuffer, mono_counter_get_unit (agent->counter));
+		emit_byte (logbuffer, mono_counter_get_variance (agent->counter));
 		emit_value (logbuffer, agent->index);
 
 		agent->emitted = 1;
@@ -3392,7 +3327,7 @@ counters_sample (MonoProfiler *profiler, uint64_t timestamp)
 	for (agent = counters; agent; agent = agent->next) {
 		size +=
 			LEB128_SIZE /* index */ +
-			LEB128_SIZE /* type */ +
+			BYTE_SIZE /* type */ +
 			mono_counter_get_size (agent->counter) /* value */
 		;
 	}
@@ -3442,7 +3377,7 @@ counters_sample (MonoProfiler *profiler, uint64_t timestamp)
 		}
 
 		emit_uvalue (logbuffer, agent->index);
-		emit_uvalue (logbuffer, type);
+		emit_byte (logbuffer, type);
 		switch (type) {
 		case MONO_COUNTER_INT:
 #if SIZEOF_VOID_P == 4
@@ -3528,9 +3463,9 @@ perfcounters_emit (MonoProfiler *profiler)
 			LEB128_SIZE /* section */ +
 			strlen (pcagent->category_name) + 1 /* category name */ +
 			strlen (pcagent->name) + 1 /* name */ +
-			LEB128_SIZE /* type */ +
-			LEB128_SIZE /* unit */ +
-			LEB128_SIZE /* variance */ +
+			BYTE_SIZE /* type */ +
+			BYTE_SIZE /* unit */ +
+			BYTE_SIZE /* variance */ +
 			LEB128_SIZE /* index */
 		;
 
@@ -3554,9 +3489,9 @@ perfcounters_emit (MonoProfiler *profiler)
 		emit_value (logbuffer, MONO_COUNTER_PERFCOUNTERS);
 		emit_string (logbuffer, pcagent->category_name, strlen (pcagent->category_name) + 1);
 		emit_string (logbuffer, pcagent->name, strlen (pcagent->name) + 1);
-		emit_value (logbuffer, MONO_COUNTER_LONG);
-		emit_value (logbuffer, MONO_COUNTER_RAW);
-		emit_value (logbuffer, MONO_COUNTER_VARIABLE);
+		emit_byte (logbuffer, MONO_COUNTER_LONG);
+		emit_byte (logbuffer, MONO_COUNTER_RAW);
+		emit_byte (logbuffer, MONO_COUNTER_VARIABLE);
 		emit_value (logbuffer, pcagent->index);
 
 		pcagent->emitted = 1;
@@ -3628,7 +3563,7 @@ perfcounters_sample (MonoProfiler *profiler, uint64_t timestamp)
 
 		size +=
 			LEB128_SIZE /* index */ +
-			LEB128_SIZE /* type */ +
+			BYTE_SIZE /* type */ +
 			LEB128_SIZE /* value */
 		;
 	}
@@ -3648,7 +3583,7 @@ perfcounters_sample (MonoProfiler *profiler, uint64_t timestamp)
 		if (pcagent->deleted || !pcagent->updated)
 			continue;
 		emit_uvalue (logbuffer, pcagent->index);
-		emit_uvalue (logbuffer, MONO_COUNTER_LONG);
+		emit_byte (logbuffer, MONO_COUNTER_LONG);
 		emit_svalue (logbuffer, pcagent->value);
 
 		pcagent->updated = 0;
@@ -4826,7 +4761,7 @@ handle_dumper_queue_entry (MonoProfiler *prof)
 
 		LogBuffer *logbuffer = ensure_logbuf_unsafe (
 			EVENT_SIZE /* event */ +
-			LEB128_SIZE /* type */ +
+			BYTE_SIZE /* type */ +
 			LEB128_SIZE /* time */ +
 			LEB128_SIZE /* tid */ +
 			LEB128_SIZE /* count */ +
@@ -4835,14 +4770,12 @@ handle_dumper_queue_entry (MonoProfiler *prof)
 			) +
 			LEB128_SIZE /* managed count */ +
 			sample->count * (
-				LEB128_SIZE /* method */ +
-				LEB128_SIZE /* il offset */ +
-				LEB128_SIZE /* native offset */
+				LEB128_SIZE /* method */
 			)
 		);
 
 		emit_byte (logbuffer, TYPE_SAMPLE | TYPE_SAMPLE_HIT);
-		emit_value (logbuffer, sample_type);
+		emit_byte (logbuffer, sample_type);
 		emit_uvalue (logbuffer, prof->startup_time + sample->elapsed * 10000);
 		emit_ptr (logbuffer, (void *) sample->tid);
 		emit_value (logbuffer, 1);
@@ -4856,11 +4789,8 @@ handle_dumper_queue_entry (MonoProfiler *prof)
 		/* new in data version 6 */
 		emit_uvalue (logbuffer, sample->count);
 
-		for (int i = 0; i < sample->count; ++i) {
+		for (int i = 0; i < sample->count; ++i)
 			emit_method (prof, logbuffer, sample->frames [i].method);
-			emit_svalue (logbuffer, 0); /* il offset will always be 0 from now on */
-			emit_svalue (logbuffer, sample->frames [i].offset);
-		}
 
 		mono_thread_hazardous_try_free (sample, reuse_sample_hit);
 

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -273,7 +273,7 @@ static MonoLinkedListSet profiler_thread_list;
  * 	[name: string] domain friendly name
  * if mtype == TYPE_CONTEXT
  * 	[domain: sleb128] domain id as pointer
- * if mtype == TYPE_THREAD && (format_version < 11 || (format_version > 10 && exinfo == 0))
+ * if mtype == TYPE_THREAD && exinfo == 0
  * 	[name: string] thread name
  *
  * type method format:
@@ -318,9 +318,9 @@ static MonoLinkedListSet profiler_thread_list;
  * 	[class: sleb128] the object MonoClass* as a difference from ptr_base
  * 	[size: uleb128] size of the object on the heap
  * 	[num_refs: uleb128] number of object references
- * 	if (format version > 1) each referenced objref is preceded by a
- *	uleb128 encoded offset: the first offset is from the object address
- *	and each next offset is relative to the previous one
+ * 	each referenced objref is preceded by a uleb128 encoded offset: the
+ * 	first offset is from the object address and each next offset is relative
+ * 	to the previous one
  * 	[objrefs: sleb128]+ object referenced as a difference from obj_base
  * 	The same object can appear multiple times, but only the first time
  * 	with size != 0: in the other cases this data will only be used to
@@ -339,14 +339,12 @@ static MonoLinkedListSet profiler_thread_list;
  * if exinfo == TYPE_SAMPLE_HIT
  * 	[sample_type: byte] type of sample (SAMPLE_*)
  * 	[timestamp: uleb128] nanoseconds since startup (note: different from other timestamps!)
- * 	if (format_version > 10)
- * 		[thread: sleb128] thread id as difference from ptr_base
+ * 	[thread: sleb128] thread id as difference from ptr_base
  * 	[count: uleb128] number of following instruction addresses
  * 	[ip: sleb128]* instruction pointer as difference from ptr_base
- *	if (format_version > 5)
- *		[mbt_count: uleb128] number of managed backtrace frames
- *		[method: sleb128]* MonoMethod* as a pointer difference from the last such
- * 		pointer or the buffer method_base (the first such method can be also indentified by ip, but this is not neccessarily true)
+ *	[mbt_count: uleb128] number of managed backtrace frames
+ *	[method: sleb128]* MonoMethod* as a pointer difference from the last such
+ * 	pointer or the buffer method_base (the first such method can be also indentified by ip, but this is not neccessarily true)
  * if exinfo == TYPE_SAMPLE_USYM
  * 	[address: sleb128] symbol address as a difference from ptr_base
  * 	[size: uleb128] symbol size (may be 0 if unknown)

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -146,8 +146,6 @@ static gint32 image_unloads;
 static gint32 class_loads;
 static gint32 class_unloads;
 
-typedef struct _LogBuffer LogBuffer;
-
 /*
  * file format:
  * [header] [buffer]*
@@ -442,6 +440,7 @@ typedef struct _LogBuffer LogBuffer;
 
 // Pending data to be written to the log, for a single thread.
 // Threads periodically flush their own LogBuffers by calling safe_send
+typedef struct _LogBuffer LogBuffer;
 struct _LogBuffer {
 	// Next (older) LogBuffer in processing queue
 	LogBuffer *next;
@@ -478,7 +477,6 @@ ign_res (int G_GNUC_UNUSED unused, ...)
 #define EXIT_LOG(lb) (lb)->locked--;
 
 typedef struct _BinaryObject BinaryObject;
-
 struct _BinaryObject {
 	BinaryObject *next;
 	void *addr;
@@ -516,19 +514,17 @@ struct _MonoProfiler {
 	GPtrArray *coverage_filters;
 };
 
-typedef struct _WriterQueueEntry WriterQueueEntry;
-struct _WriterQueueEntry {
+typedef struct {
 	MonoLockFreeQueueNode node;
 	GPtrArray *methods;
 	LogBuffer *buffer;
-};
+} WriterQueueEntry;
 
-typedef struct _MethodInfo MethodInfo;
-struct _MethodInfo {
+typedef struct {
 	MonoMethod *method;
 	MonoJitInfo *ji;
 	uint64_t time;
-};
+} MethodInfo;
 
 #ifdef TLS_INIT
 #undef TLS_INIT
@@ -3235,20 +3231,18 @@ static gboolean coverage_initialized = FALSE;
 static GPtrArray *coverage_data = NULL;
 static int previous_offset = 0;
 
-typedef struct _MethodNode MethodNode;
-struct _MethodNode {
+typedef struct {
 	MonoLockFreeQueueNode node;
 	MonoMethod *method;
-};
+} MethodNode;
 
-typedef struct _CoverageEntry CoverageEntry;
-struct _CoverageEntry {
+typedef struct {
 	int offset;
 	int counter;
 	char *filename;
 	int line;
 	int column;
-};
+} CoverageEntry;
 
 static void
 free_coverage_entry (gpointer data, gpointer userdata)

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -455,7 +455,6 @@ struct _LogBuffer {
 	uintptr_t last_method;
 	uintptr_t obj_base;
 	uintptr_t thread_id;
-	int locked;
 
 	// Bytes allocated for this LogBuffer
 	int size;
@@ -488,8 +487,8 @@ ign_res (int G_GNUC_UNUSED unused, ...)
 {
 }
 
-#define ENTER_LOG(lb,str) if ((lb)->locked) {ign_res (write(2, str, strlen(str))); ign_res (write(2, "\n", 1));return;} else {(lb)->locked++;}
-#define EXIT_LOG(lb) (lb)->locked--;
+#define ENTER_LOG(LB, STR)
+#define EXIT_LOG(LB)
 
 typedef struct _BinaryObject BinaryObject;
 struct _BinaryObject {

--- a/mono/profiler/proflog.h
+++ b/mono/profiler/proflog.h
@@ -28,6 +28,7 @@
                TYPE_JIT events are no longer guaranteed to have code start/size info (can be zero)
  * version 12: added MONO_COUNTER_PROFILER
  * version 13: added MONO_GC_EVENT_{PRE_STOP_WORLD_LOCKED,POST_START_WORLD_UNLOCKED}
+               added TYPE_META + TYPE_SYNC_POINT
  */
 
 enum {
@@ -41,6 +42,7 @@ enum {
 	TYPE_SAMPLE,
 	TYPE_RUNTIME,
 	TYPE_COVERAGE,
+	TYPE_META,
 	/* extended type for TYPE_HEAP */
 	TYPE_HEAP_START  = 0 << 4,
 	TYPE_HEAP_END    = 1 << 4,
@@ -92,8 +94,16 @@ enum {
 	TYPE_COVERAGE_METHOD   = 1 << 4,
 	TYPE_COVERAGE_STATEMENT = 2 << 4,
 	TYPE_COVERAGE_CLASS = 3 << 4,
+	/* extended type for TYPE_META */
+	TYPE_SYNC_POINT = 0 << 4,
 	TYPE_END
 };
+
+typedef enum {
+	SYNC_POINT_PERIODIC,
+	SYNC_POINT_WORLD_STOP,
+	SYNC_POINT_WORLD_START
+} MonoProfilerSyncPointType;
 
 // Sampling sources
 // Unless you have compiled with --enable-perf-events, only SAMPLE_CYCLES is available

--- a/mono/profiler/proflog.h
+++ b/mono/profiler/proflog.h
@@ -29,6 +29,17 @@
  * version 12: added MONO_COUNTER_PROFILER
  * version 13: added MONO_GC_EVENT_{PRE_STOP_WORLD_LOCKED,POST_START_WORLD_UNLOCKED}
                added TYPE_META + TYPE_SYNC_POINT
+               removed il and native offset in TYPE_SAMPLE_HIT
+               methods in backtraces are now encoded as proper method pointers
+               removed flags in backtrace format
+               removed flags in metadata events
+               changed the following fields to a single byte rather than leb128
+                   TYPE_GC_EVENT: event_type, generation
+                   TYPE_JITHELPER: type
+                   TYPE_SAMPLE_HIT: sample_type
+                   TYPE_CLAUSE: clause_type
+                   TYPE_SAMPLE_COUNTERS_DESC: type, unit, variance
+                   TYPE_SAMPLE_COUNTERS: type
  */
 
 enum {

--- a/mono/profiler/proflog.h
+++ b/mono/profiler/proflog.h
@@ -5,7 +5,7 @@
 #define LOG_HEADER_ID 0x4D505A01
 #define LOG_VERSION_MAJOR 0
 #define LOG_VERSION_MINOR 4
-#define LOG_DATA_VERSION 12
+#define LOG_DATA_VERSION 13
 /*
  * Changes in data versions:
  * version 2: added offsets in heap walk
@@ -27,6 +27,7 @@
                added TYPE_GC_HANDLE_{CREATED,DESTROYED}_BT
                TYPE_JIT events are no longer guaranteed to have code start/size info (can be zero)
  * version 12: added MONO_COUNTER_PROFILER
+ * version 13: added MONO_GC_EVENT_{PRE_STOP_WORLD_LOCKED,POST_START_WORLD_UNLOCKED}
  */
 
 enum {

--- a/mono/profiler/utils.c
+++ b/mono/profiler/utils.c
@@ -418,7 +418,7 @@ uintptr_t
 process_id (void)
 {
 #ifdef HOST_WIN32
-	return 0; /* FIXME */
+	return GetCurrentProcessId ();
 #else
 	return (uintptr_t)getpid ();
 #endif

--- a/mono/unit-tests/test-mono-linked-list-set.c
+++ b/mono/unit-tests/test-mono-linked-list-set.c
@@ -74,11 +74,11 @@ worker (void *arg)
 			break;
 		case STATE_OUT:
 			if (InterlockedCompareExchange (&nodes [i].state, STATE_BUSY, STATE_OUT) == STATE_OUT) {
-				result = mono_lls_find (&lls, hp, i, HAZARD_FREE_SAFE_CTX);
+				result = mono_lls_find (&lls, hp, i);
 				assert (!result);
 				mono_hazard_pointer_clear_all (hp, -1);
 
-				result = mono_lls_insert (&lls, hp, &nodes [i].node, HAZARD_FREE_SAFE_CTX);
+				result = mono_lls_insert (&lls, hp, &nodes [i].node);
 				mono_hazard_pointer_clear_all (hp, -1);
 
 				assert (nodes [i].state == STATE_BUSY);
@@ -89,12 +89,12 @@ worker (void *arg)
 			break;
 		case STATE_IN:
 			if (InterlockedCompareExchange (&nodes [i].state, STATE_BUSY, STATE_IN) == STATE_IN) {
-				result = mono_lls_find (&lls, hp, i, HAZARD_FREE_SAFE_CTX);
+				result = mono_lls_find (&lls, hp, i);
 				assert (result);
 				assert (mono_hazard_pointer_get_val (hp, 1) == &nodes [i].node);
 				mono_hazard_pointer_clear_all (hp, -1);
 
-				result = mono_lls_remove (&lls, hp, &nodes [i].node, HAZARD_FREE_SAFE_CTX);
+				result = mono_lls_remove (&lls, hp, &nodes [i].node);
 				mono_hazard_pointer_clear_all (hp, -1);
 
 				++thread_data->num_removes;
@@ -126,7 +126,7 @@ main (int argc, char *argv [])
 
 	mono_threads_init (&thread_callbacks, 0);
 
-	mono_lls_init (&lls, free_node, HAZARD_FREE_NO_LOCK);
+	mono_lls_init (&lls, free_node);
 
 	for (i = 0; i < N; ++i) {
 		nodes [i].node.key = i;

--- a/mono/utils/hazard-pointer.c
+++ b/mono/utils/hazard-pointer.c
@@ -190,7 +190,7 @@ mono_hazard_pointer_get (void)
    mono_jit_info_table_add(), which doesn't have to care about hazards
    because it holds the respective domain lock. */
 gpointer
-get_hazardous_pointer (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index)
+mono_get_hazardous_pointer (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index)
 {
 	gpointer p;
 

--- a/mono/utils/hazard-pointer.c
+++ b/mono/utils/hazard-pointer.c
@@ -29,7 +29,6 @@
 typedef struct {
 	gpointer p;
 	MonoHazardousFreeFunc free_func;
-	HazardFreeLocking locking;
 } DelayedFreeItem;
 
 /* The hazard table */
@@ -288,7 +287,7 @@ mono_hazard_pointer_restore_for_signal_handler (int small_id)
 }
 
 static gboolean
-try_free_delayed_free_item (HazardFreeContext context)
+try_free_delayed_free_item (void)
 {
 	DelayedFreeItem item;
 	gboolean popped = mono_lock_free_array_queue_pop (&delayed_free_queue, &item);
@@ -296,8 +295,7 @@ try_free_delayed_free_item (HazardFreeContext context)
 	if (!popped)
 		return FALSE;
 
-	if ((context == HAZARD_FREE_ASYNC_CTX && item.locking == HAZARD_FREE_MAY_LOCK) ||
-	    (is_pointer_hazardous (item.p))) {
+	if (is_pointer_hazardous (item.p)) {
 		mono_lock_free_array_queue_push (&delayed_free_queue, &item);
 		return FALSE;
 	}
@@ -348,7 +346,7 @@ mono_thread_hazardous_try_free (gpointer p, MonoHazardousFreeFunc free_func)
 void
 mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func)
 {
-	DelayedFreeItem item = { p, free_func, HAZARD_FREE_MAY_LOCK };
+	DelayedFreeItem item = { p, free_func };
 
 	InterlockedIncrement (&hazardous_pointer_count);
 
@@ -369,7 +367,7 @@ mono_hazard_pointer_install_free_queue_size_callback (MonoHazardFreeQueueSizeCal
 void
 mono_thread_hazardous_try_free_all (void)
 {
-	while (try_free_delayed_free_item (HAZARD_FREE_SAFE_CTX))
+	while (try_free_delayed_free_item ())
 		;
 }
 
@@ -378,7 +376,7 @@ mono_thread_hazardous_try_free_some (void)
 {
 	int i;
 	for (i = 0; i < 10; ++i)
-		try_free_delayed_free_item (HAZARD_FREE_SAFE_CTX);
+		try_free_delayed_free_item ();
 }
 
 void

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -21,11 +21,11 @@ typedef struct {
 typedef void (*MonoHazardousFreeFunc) (gpointer p);
 
 MONO_API gboolean mono_thread_hazardous_try_free (gpointer p, MonoHazardousFreeFunc free_func);
-void mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func);
+MONO_API void mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func);
 
 void mono_thread_hazardous_try_free_all (void);
 void mono_thread_hazardous_try_free_some (void);
-MonoThreadHazardPointers* mono_hazard_pointer_get (void);
+MONO_API MonoThreadHazardPointers* mono_hazard_pointer_get (void);
 gpointer mono_get_hazardous_pointer (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index);
 
 #define mono_hazard_pointer_set(hp,i,v)	\

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -26,7 +26,7 @@ void mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_fu
 void mono_thread_hazardous_try_free_all (void);
 void mono_thread_hazardous_try_free_some (void);
 MonoThreadHazardPointers* mono_hazard_pointer_get (void);
-gpointer get_hazardous_pointer (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index);
+gpointer mono_get_hazardous_pointer (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index);
 
 #define mono_hazard_pointer_set(hp,i,v)	\
 	do { g_assert ((i) >= 0 && (i) < HAZARD_POINTER_COUNT); \

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -20,16 +20,6 @@ typedef struct {
 
 typedef void (*MonoHazardousFreeFunc) (gpointer p);
 
-typedef enum {
-	HAZARD_FREE_MAY_LOCK,
-	HAZARD_FREE_NO_LOCK,
-} HazardFreeLocking;
-
-typedef enum {
-	HAZARD_FREE_SAFE_CTX,
-	HAZARD_FREE_ASYNC_CTX,
-} HazardFreeContext;
-
 MONO_API gboolean mono_thread_hazardous_try_free (gpointer p, MonoHazardousFreeFunc free_func);
 void mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func);
 

--- a/mono/utils/lock-free-alloc.c
+++ b/mono/utils/lock-free-alloc.c
@@ -170,7 +170,7 @@ desc_alloc (void)
 	for (;;) {
 		gboolean success;
 
-		desc = (Descriptor *) get_hazardous_pointer ((gpointer * volatile)&desc_avail, hp, 1);
+		desc = (Descriptor *) mono_get_hazardous_pointer ((gpointer * volatile)&desc_avail, hp, 1);
 		if (desc) {
 			Descriptor *next = desc->next;
 			success = (InterlockedCompareExchangePointer ((gpointer * volatile)&desc_avail, next, desc) == desc);

--- a/mono/utils/lock-free-queue.c
+++ b/mono/utils/lock-free-queue.c
@@ -133,7 +133,7 @@ mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node)
 	for (;;) {
 		MonoLockFreeQueueNode *next;
 
-		tail = (MonoLockFreeQueueNode *) get_hazardous_pointer ((gpointer volatile*)&q->tail, hp, 0);
+		tail = (MonoLockFreeQueueNode *) mono_get_hazardous_pointer ((gpointer volatile*)&q->tail, hp, 0);
 		mono_memory_read_barrier ();
 		/*
 		 * We never dereference next so we don't need a
@@ -243,7 +243,7 @@ mono_lock_free_queue_dequeue (MonoLockFreeQueue *q)
 	for (;;) {
 		MonoLockFreeQueueNode *tail, *next;
 
-		head = (MonoLockFreeQueueNode *) get_hazardous_pointer ((gpointer volatile*)&q->head, hp, 0);
+		head = (MonoLockFreeQueueNode *) mono_get_hazardous_pointer ((gpointer volatile*)&q->head, hp, 0);
 		tail = (MonoLockFreeQueueNode*)q->tail;
 		mono_memory_read_barrier ();
 		next = head->next;

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -164,7 +164,7 @@ mono_conc_hashtable_lookup (MonoConcurrentHashTable *hash_table, gpointer key)
 	hp = mono_hazard_pointer_get ();
 
 retry:
-	table = (conc_table *)get_hazardous_pointer ((gpointer volatile*)&hash_table->table, hp, 0);
+	table = (conc_table *)mono_get_hazardous_pointer ((gpointer volatile*)&hash_table->table, hp, 0);
 	table_mask = table->table_size - 1;
 	kvs = table->kvs;
 	i = hash & table_mask;

--- a/mono/utils/mono-linked-list-set.c
+++ b/mono/utils/mono-linked-list-set.c
@@ -56,28 +56,21 @@ get_hazardous_pointer_with_mask (gpointer volatile *pp, MonoThreadHazardPointers
 /*
 Initialize @list and will use @free_node_func to release memory.
 If @free_node_func is null the caller is responsible for releasing node memory.
-If @free_node_func may lock, @free_node_func_locking must be
-HAZARD_FREE_MAY_LOCK; otherwise, HAZARD_FREE_NO_LOCK. It is ignored if
-@free_node_func is null.
 */
 void
-mono_lls_init (MonoLinkedListSet *list, void (*free_node_func)(void *), HazardFreeLocking free_node_func_locking)
+mono_lls_init (MonoLinkedListSet *list, void (*free_node_func)(void *))
 {
 	list->head = NULL;
 	list->free_node_func = free_node_func;
-	list->locking = free_node_func_locking;
 }
 
 /*
 Search @list for element with key @key.
-@context specifies whether the function is being called from a lock-free (i.e.
-signal handler or world stopped) context. It is only relevant if a node free
-function was given.
 The nodes next, cur and prev are returned in @hp.
 Returns true if a node with key @key was found.
 */
 gboolean
-mono_lls_find (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, uintptr_t key, HazardFreeContext context)
+mono_lls_find (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, uintptr_t key)
 {
 	MonoLinkedListSetNode *cur, *next;
 	MonoLinkedListSetNode **prev;
@@ -137,15 +130,12 @@ try_again:
 
 /*
 Insert @value into @list.
-@context specifies whether the function is being called from a lock-free (i.e.
-signal handler or world stopped) context. It is only relevant if a node free
-function was given.
 The nodes value, cur and prev are returned in @hp.
 Return true if @value was inserted by this call. If it returns FALSE, it's the caller
 resposibility to release memory.
 */
 gboolean
-mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value, HazardFreeContext context)
+mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value)
 {
 	MonoLinkedListSetNode *cur, **prev;
 	/*We must do a store barrier before inserting 
@@ -153,7 +143,7 @@ mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLink
 	mono_memory_barrier ();
 
 	while (1) {
-		if (mono_lls_find (list, hp, value->key, context))
+		if (mono_lls_find (list, hp, value->key))
 			return FALSE;
 		cur = (MonoLinkedListSetNode *) mono_hazard_pointer_get_val (hp, 1);
 		prev = (MonoLinkedListSetNode **) mono_hazard_pointer_get_val (hp, 2);
@@ -169,18 +159,15 @@ mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLink
 
 /*
 Search @list for element with key @key and remove it.
-@context specifies whether the function is being called from a lock-free (i.e.
-signal handler or world stopped) context. It is only relevant if a node free
-function was given.
 The nodes next, cur and prev are returned in @hp
 Returns true if @value was removed by this call.
 */
 gboolean
-mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value, HazardFreeContext context)
+mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value)
 {
 	MonoLinkedListSetNode *cur, **prev, *next;
 	while (1) {
-		if (!mono_lls_find (list, hp, value->key, context))
+		if (!mono_lls_find (list, hp, value->key))
 			return FALSE;
 
 		next = (MonoLinkedListSetNode *) mono_hazard_pointer_get_val (hp, 0);
@@ -200,7 +187,7 @@ mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLink
 			if (list->free_node_func)
 				mono_thread_hazardous_try_free (value, list->free_node_func);
 		} else
-			mono_lls_find (list, hp, value->key, context);
+			mono_lls_find (list, hp, value->key);
 		return TRUE;
 	}
 }

--- a/mono/utils/mono-linked-list-set.c
+++ b/mono/utils/mono-linked-list-set.c
@@ -185,7 +185,7 @@ mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLink
 			mono_memory_write_barrier ();
 			mono_hazard_pointer_clear (hp, 1);
 			if (list->free_node_func)
-				mono_thread_hazardous_try_free (value, list->free_node_func);
+				mono_thread_hazardous_queue_free (value, list->free_node_func);
 		} else
 			mono_lls_find (list, hp, value->key);
 		return TRUE;

--- a/mono/utils/mono-linked-list-set.c
+++ b/mono/utils/mono-linked-list-set.c
@@ -25,7 +25,7 @@ mask (gpointer n, uintptr_t bit)
 }
 
 gpointer
-get_hazardous_pointer_with_mask (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index)
+mono_lls_get_hazardous_pointer_with_mask (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index)
 {
 	gpointer p;
 
@@ -88,12 +88,12 @@ try_again:
 	 */
 	mono_hazard_pointer_set (hp, 2, prev);
 
-	cur = (MonoLinkedListSetNode *) get_hazardous_pointer_with_mask ((gpointer*)prev, hp, 1);
+	cur = (MonoLinkedListSetNode *) mono_lls_get_hazardous_pointer_with_mask ((gpointer*)prev, hp, 1);
 
 	while (1) {
 		if (cur == NULL)
 			return FALSE;
-		next = (MonoLinkedListSetNode *) get_hazardous_pointer_with_mask ((gpointer*)&cur->next, hp, 0);
+		next = (MonoLinkedListSetNode *) mono_lls_get_hazardous_pointer_with_mask ((gpointer*)&cur->next, hp, 0);
 		cur_key = cur->key;
 
 		/*

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -24,7 +24,6 @@ struct _MonoLinkedListSetNode {
 typedef struct {
 	MonoLinkedListSetNode *head;
 	void (*free_node_func)(void *);
-	HazardFreeLocking locking;
 } MonoLinkedListSet;
 
 
@@ -46,16 +45,16 @@ You must manually clean the hazard pointer table after using them.
 */
 
 void
-mono_lls_init (MonoLinkedListSet *list, void (*free_node_func)(void *), HazardFreeLocking free_node_func_locking);
+mono_lls_init (MonoLinkedListSet *list, void (*free_node_func)(void *));
 
 gboolean
-mono_lls_find (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, uintptr_t key, HazardFreeContext context);
+mono_lls_find (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, uintptr_t key);
 
 gboolean
-mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value, HazardFreeContext context);
+mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value);
 
 gboolean
-mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value, HazardFreeContext context);
+mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value);
 
 gpointer
 get_hazardous_pointer_with_mask (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index);

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -57,7 +57,7 @@ gboolean
 mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value);
 
 gpointer
-get_hazardous_pointer_with_mask (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index);
+mono_lls_get_hazardous_pointer_with_mask (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index);
 
 static inline gboolean
 mono_lls_filter_accept_all (gpointer elem)
@@ -107,12 +107,12 @@ mono_lls_filter_accept_all (gpointer elem)
 			restart__ = FALSE; \
 			MonoLinkedListSetNode **prev__ = &list__->head; \
 			mono_hazard_pointer_set (hp__, 2, prev__); \
-			MonoLinkedListSetNode *cur__ = (MonoLinkedListSetNode *) get_hazardous_pointer_with_mask ((gpointer *) prev__, hp__, 1); \
+			MonoLinkedListSetNode *cur__ = (MonoLinkedListSetNode *) mono_lls_get_hazardous_pointer_with_mask ((gpointer *) prev__, hp__, 1); \
 			while (1) { \
 				if (!cur__) { \
 					break; \
 				} \
-				MonoLinkedListSetNode *next__ = (MonoLinkedListSetNode *) get_hazardous_pointer_with_mask ((gpointer *) &cur__->next, hp__, 0); \
+				MonoLinkedListSetNode *next__ = (MonoLinkedListSetNode *) mono_lls_get_hazardous_pointer_with_mask ((gpointer *) &cur__->next, hp__, 0); \
 				uintptr_t ckey__ = cur__->key; \
 				mono_memory_read_barrier (); \
 				if (*prev__ != cur__) { \

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -44,19 +44,19 @@ Those are low level operations. prev, cur, next are returned in the hazard point
 You must manually clean the hazard pointer table after using them.
 */
 
-void
+MONO_API void
 mono_lls_init (MonoLinkedListSet *list, void (*free_node_func)(void *));
 
-gboolean
+MONO_API gboolean
 mono_lls_find (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, uintptr_t key);
 
-gboolean
+MONO_API gboolean
 mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value);
 
-gboolean
+MONO_API gboolean
 mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLinkedListSetNode *value);
 
-gpointer
+MONO_API gpointer
 mono_lls_get_hazardous_pointer_with_mask (gpointer volatile *pp, MonoThreadHazardPointers *hp, int hazard_index);
 
 static inline gboolean

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -281,7 +281,7 @@ mono_thread_info_lookup (MonoNativeThreadId id)
 {
 		MonoThreadHazardPointers *hp = mono_hazard_pointer_get ();
 
-	if (!mono_lls_find (&thread_list, hp, (uintptr_t)id, HAZARD_FREE_ASYNC_CTX)) {
+	if (!mono_lls_find (&thread_list, hp, (uintptr_t)id)) {
 		mono_hazard_pointer_clear_all (hp, -1);
 		return NULL;
 	} 
@@ -295,7 +295,7 @@ mono_thread_info_insert (MonoThreadInfo *info)
 {
 	MonoThreadHazardPointers *hp = mono_hazard_pointer_get ();
 
-	if (!mono_lls_insert (&thread_list, hp, (MonoLinkedListSetNode*)info, HAZARD_FREE_SAFE_CTX)) {
+	if (!mono_lls_insert (&thread_list, hp, (MonoLinkedListSetNode*)info)) {
 		mono_hazard_pointer_clear_all (hp, -1);
 		return FALSE;
 	} 
@@ -311,7 +311,7 @@ mono_thread_info_remove (MonoThreadInfo *info)
 	gboolean res;
 
 	THREADS_DEBUG ("removing info %p\n", info);
-	res = mono_lls_remove (&thread_list, hp, (MonoLinkedListSetNode*)info, HAZARD_FREE_SAFE_CTX);
+	res = mono_lls_remove (&thread_list, hp, (MonoLinkedListSetNode*)info);
 	mono_hazard_pointer_clear_all (hp, -1);
 	return res;
 }
@@ -691,7 +691,7 @@ mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 	mono_os_sem_init (&global_suspend_semaphore, 1);
 	mono_os_sem_init (&suspend_semaphore, 0);
 
-	mono_lls_init (&thread_list, NULL, HAZARD_FREE_NO_LOCK);
+	mono_lls_init (&thread_list, NULL);
 	mono_thread_smr_init ();
 	mono_threads_platform_init ();
 	mono_threads_suspend_init ();

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -416,7 +416,7 @@ mono_thread_info_is_async_context (void);
 void
 mono_thread_info_get_stack_bounds (guint8 **staddr, size_t *stsize);
 
-gboolean
+MONO_API gboolean
 mono_thread_info_yield (void);
 
 gint


### PR DESCRIPTION
Plus a number of other improvements to the profiler as well as minor fixes in `mono/utils` code.

I would strongly recommend reviewing commits one-by-one rather than looking at the full diff.