### PR TITLE
Added missing DeliveryFormat property to MailClient

### DIFF
--- a/mcs/class/System/System.Net.Mail/SmtpClient.cs
+++ b/mcs/class/System/System.Net.Mail/SmtpClient.cs
@@ -71,6 +71,7 @@ namespace System.Net.Mail {
 		ICredentialsByHost credentials;
 		string pickupDirectoryLocation;
 		SmtpDeliveryMethod deliveryMethod;
+		SmtpDeliveryFormat deliveryFormat;
 		bool enableSsl;
 #if SECURITY_DEP		
 		X509CertificateCollection clientCertificates;
@@ -223,7 +224,15 @@ namespace System.Net.Mail {
 				port = value;
 			}
 		}
-
+		
+		public SmtpDeliveryFormat DeliveryFormat {
+			get { return deliveryFormat; }
+			set {
+				CheckState ();
+				deliveryFormat = value;
+			}
+		}
+		
 		[MonoTODO]
 		public ServicePoint ServicePoint {
 			get { throw new NotImplementedException (); }


### PR DESCRIPTION
Doesn't actually change the behavior but at least allows to build sources referencing it on mono.
https://msdn.microsoft.com/en-us/library/system.net.mail.smtpclient.deliveryformat(v=vs.110).aspx