### PR TITLE
[x86] Don't pop arguments when returning from a managed-to-native wrapper.

### DIFF
--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -63,9 +63,9 @@ static mono_mutex_t mini_arch_mutex;
 
 #ifdef TARGET_WIN32
 /* Under windows, the default pinvoke calling convention is stdcall */
-#define CALLCONV_IS_STDCALL(sig) ((((sig)->call_convention) == MONO_CALL_STDCALL) || ((sig)->pinvoke && ((sig)->call_convention) == MONO_CALL_DEFAULT) || ((sig)->pinvoke && ((sig)->call_convention) == MONO_CALL_THISCALL))
+#define CALLCONV_IS_STDCALL(sig) ((sig)->pinvoke && ((sig)->call_convention == MONO_CALL_STDCALL || (sig)->call_convention == MONO_CALL_DEFAULT || (sig)->call_convention == MONO_CALL_THISCALL))
 #else
-#define CALLCONV_IS_STDCALL(sig) (((sig)->call_convention) == MONO_CALL_STDCALL || ((sig)->pinvoke && ((sig)->call_convention) == MONO_CALL_THISCALL))
+#define CALLCONV_IS_STDCALL(sig) ((sig)->pinvoke && ((sig)->call_convention == MONO_CALL_STDCALL || (sig)->call_convention == MONO_CALL_THISCALL))
 #endif
 
 #define X86_IS_CALLEE_SAVED_REG(reg) (((reg) == X86_EBX) || ((reg) == X86_EDI) || ((reg) == X86_ESI))
@@ -543,7 +543,7 @@ get_call_info_internal (CallInfo *cinfo, MonoMethodSignature *sig)
 	if (cinfo->vtype_retaddr) {
 		/* if the function returns a struct on stack, the called method already does a ret $0x4 */
 		cinfo->callee_stack_pop = 4;
-	} else if (CALLCONV_IS_STDCALL (sig) && sig->pinvoke) {
+	} else if (CALLCONV_IS_STDCALL (sig)) {
 		/* Have to compensate for the stack space popped by the native callee */
 		cinfo->callee_stack_pop = stack_size;
 	}

--- a/mono/tests/pinvoke2.cs
+++ b/mono/tests/pinvoke2.cs
@@ -1433,6 +1433,13 @@ public class Tests {
 		return mono_test_stdcall_name_mangling (0, 1, 2) == 3 ? 0 : 1;
 	}
 
+	/* Test multiple calls to stdcall wrapper, xamarin bug 30146 */
+	public static int test_0_stdcall_many_calls () {
+		for (int i=0; i<256; i++)
+			mono_test_stdcall_name_mangling (0, 0, 0);
+		return 0;
+	}
+
 	/* Float test */
 
 	[DllImport ("libtest", EntryPoint="mono_test_marshal_pass_return_float")]


### PR DESCRIPTION
Callers do not expect these methods to pop arguments, resulting in a
wrong stack pointer.

For xamarin bug 30146.