### PR TITLE
[System.IO.Compression] Remove the entry from ZipArchive entries when its deleted

### DIFF
--- a/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
+++ b/mcs/class/System.IO.Compression/Test/System.IO.Compression/ZipTest.cs
@@ -183,6 +183,24 @@ namespace MonoTests.System.IO.Compression
 		}
 
 		[Test]
+		public void ZipDeleteEntryCheckEntries()
+		{
+			File.Copy("archive.zip", "delete.zip", overwrite: true);
+			using (var archive = new ZipArchive(File.Open("delete.zip", FileMode.Open),
+				ZipArchiveMode.Update))
+			{
+				var entry = archive.GetEntry("foo.txt");
+				Assert.IsNotNull(entry);
+
+				entry.Delete();
+
+				Assert.IsNull(archive.Entries.FirstOrDefault(e => e == entry));
+			}
+
+			File.Delete ("delete.zip");
+		}		
+
+		[Test]
 		public void ZipGetEntryDeleteUpdateMode()
 		{
 			File.Copy("archive.zip", "delete.zip", overwrite: true);

--- a/mcs/class/System.IO.Compression/ZipArchive.cs
+++ b/mcs/class/System.IO.Compression/ZipArchive.cs
@@ -237,6 +237,12 @@ namespace System.IO.Compression
 			}
 		}
 
+		internal void RemoveEntryInternal(ZipArchiveEntry entry)
+		{
+			zipFile.RemoveEntry(entry.entry);
+			entries.Remove(entry);
+		}
+
 		protected virtual void Dispose (bool disposing)
 		{
 			if (disposed)

--- a/mcs/class/System.IO.Compression/ZipArchiveEntry.cs
+++ b/mcs/class/System.IO.Compression/ZipArchiveEntry.cs
@@ -210,7 +210,7 @@ namespace System.IO.Compression
 				throw new IOException("The entry is already open for reading or writing.");
 
 			wasDeleted = true;
-			Archive.zipFile.RemoveEntry(entry);
+			Archive.RemoveEntryInternal(this);
 		}
 
 		public Stream Open()


### PR DESCRIPTION

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43022.