### PR TITLE
[DO NOT MERGE] [runtime] Use a more uniform address hash function.

### DIFF
--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -563,7 +563,7 @@ mono_object_hash (MonoObject* obj)
 {
 #ifdef HAVE_MOVING_COLLECTOR
 	LockWord lw;
-	unsigned int hash;
+	guint32 hash;
 	if (!obj)
 		return 0;
 	lw.sync = obj->synchronisation;
@@ -584,7 +584,10 @@ mono_object_hash (MonoObject* obj)
 	 * another thread computes the hash at the same time, because it'll end up
 	 * with the same value.
 	 */
-	hash = (GPOINTER_TO_UINT (obj) >> MONO_OBJECT_ALIGNMENT_SHIFT) * 2654435761u;
+	hash = GPOINTER_TO_UINT (obj) >> MONO_OBJECT_ALIGNMENT_SHIFT;
+	hash = ((hash >> 16) ^ hash) * 0x45d9f3b;
+	hash = ((hash >> 16) ^ hash) * 0x45d9f3b;
+	hash = (hash >> 16) ^ hash;
 #if SIZEOF_VOID_P == 4
 	/* clear the top bits as they can be discarded */
 	hash &= ~(LOCK_WORD_STATUS_MASK << (32 - LOCK_WORD_STATUS_BITS));
@@ -622,10 +625,14 @@ mono_object_hash (MonoObject* obj)
 	return hash;
 #else
 /*
- * Wang's address-based hash function:
- *   http://www.concentric.net/~Ttwang/tech/addrhash.htm
+ * Thomas Mueller's uniform hash:
+ * http://stackoverflow.com/a/12996028
  */
-	return (GPOINTER_TO_UINT (obj) >> MONO_OBJECT_ALIGNMENT_SHIFT) * 2654435761u;
+	hash = GPOINTER_TO_UINT (obj) >> MONO_OBJECT_ALIGNMENT_SHIFT;
+	hash = ((hash >> 16) ^ hash) * 0x45d9f3b;
+	hash = ((hash >> 16) ^ hash) * 0x45d9f3b;
+	hash = (hash >> 16) ^ hash;
+	return hash;
 #endif
 }
 


### PR DESCRIPTION
The Knuth multiplicative hash is fast, but it doesn’t have a very uniform distribution. It’s also a 32-bit function, so this code was wrong if `sizeof (unsigned int) != 4`. Trying a different hash to see what happens.
