### PR TITLE
[xbuild] Use the xbuild ToolsVersion even if another one is specified in the csproj

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Project.cs
+++ b/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Project.cs
@@ -1077,6 +1077,11 @@ namespace Microsoft.Build.BuildEngine {
 			if (!String.IsNullOrEmpty (ToolsVersion))
 				return ToolsVersion;
 
+#if XBUILD_14
+			return "14.0";
+#elif XBUILD_12
+			return "12.0";
+#else
 			if (!HasToolsVersionAttribute)
 				return parentEngine.DefaultToolsVersion;
 
@@ -1088,6 +1093,7 @@ namespace Microsoft.Build.BuildEngine {
 			}
 
 			return DefaultToolsVersion;
+#endif
 		}
 		
 		void AddProjectExtensions (XmlElement xmlElement)


### PR DESCRIPTION
This is the recent behavior in .NET/MSBuild as well [1]:

> Starting in Visual Studio 2013, the MSBuild Toolset version is the same
> as the Visual Studio version number. MSBuild defaults to this Toolset
> within Visual Studio and on the command line, regardless of the
> toolset version specified in project file.

With this change xbuild will always use its own version instead
of the one specified in the project, unlessa ToolsVersion is forced
via the /tv switch on the command line.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42938

[1] https://msdn.microsoft.com/en-us/library/bb383796.aspx#Anchor_1

/cc @radical @mhutch this fixes the bug for me, but I'm not 100% sure whether or not this causes issues anywhere else so I'd appreciate your thoughts on this.