### PR TITLE
[wip] Fix scanning of SIMD registers.

### DIFF
--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -350,7 +350,7 @@ mono_setup_thread_context(DWORD thread_id, MonoContext *mono_context)
 	handle = OpenThread (THREAD_ALL_ACCESS, FALSE, thread_id);
 	g_assert (handle);
 
-	context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
+	context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL | CONTEXT_FLOATING_POINT;
 
 	if (!GetThreadContext (handle, &context)) {
 		CloseHandle (handle);
@@ -359,6 +359,7 @@ mono_setup_thread_context(DWORD thread_id, MonoContext *mono_context)
 
 	g_assert (context.ContextFlags & CONTEXT_INTEGER);
 	g_assert (context.ContextFlags & CONTEXT_CONTROL);
+	g_assert (context.ContextFlags & CONTEXT_FLOATING_POINT);
 
 	memset (mono_context, 0, sizeof (MonoContext));
 	mono_sigctx_to_monoctx (&context, mono_context);

--- a/mono/utils/mach-support-amd64.c
+++ b/mono/utils/mach-support-amd64.c
@@ -18,7 +18,7 @@
 #include "utils/mono-sigcontext.h"
 #include "mach-support.h"
 
-//For reg numbers
+// For reg numbers
 #include <mono/arch/amd64/amd64-codegen.h>
 
 /* Known offsets used for TLS storage*/

--- a/mono/utils/mono-context.c
+++ b/mono/utils/mono-context.c
@@ -210,6 +210,23 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 	mctx->gregs [AMD64_R13] = context->R13;
 	mctx->gregs [AMD64_R14] = context->R14;
 	mctx->gregs [AMD64_R15] = context->R15;
+
+	mctx->fregs [AMD64_XMM0] = context->Xmm0;
+	mctx->fregs [AMD64_XMM1] = context->Xmm1;
+	mctx->fregs [AMD64_XMM2] = context->Xmm2;
+	mctx->fregs [AMD64_XMM3] = context->Xmm3;
+	mctx->fregs [AMD64_XMM4] = context->Xmm4;
+	mctx->fregs [AMD64_XMM5] = context->Xmm5;
+	mctx->fregs [AMD64_XMM6] = context->Xmm6;
+	mctx->fregs [AMD64_XMM7] = context->Xmm7;
+	mctx->fregs [AMD64_XMM8] = context->Xmm8;
+	mctx->fregs [AMD64_XMM9] = context->Xmm9;
+	mctx->fregs [AMD64_XMM10] = context->Xmm10;
+	mctx->fregs [AMD64_XMM11] = context->Xmm11;
+	mctx->fregs [AMD64_XMM12] = context->Xmm12;
+	mctx->fregs [AMD64_XMM13] = context->Xmm13;
+	mctx->fregs [AMD64_XMM14] = context->Xmm14;
+	mctx->fregs [AMD64_XMM15] = context->Xmm15;
 #else
 	g_assert_not_reached ();
 #endif
@@ -284,6 +301,24 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 	context->R13 = mctx->gregs [AMD64_R13];
 	context->R14 = mctx->gregs [AMD64_R14];
 	context->R15 = mctx->gregs [AMD64_R15];
+
+	context->Xmm0 = mctx->fregs [AMD64_XMM0];
+	context->Xmm1 = mctx->fregs [AMD64_XMM1];
+	context->Xmm2 = mctx->fregs [AMD64_XMM2];
+	context->Xmm3 = mctx->fregs [AMD64_XMM3];
+	context->Xmm4 = mctx->fregs [AMD64_XMM4];
+	context->Xmm5 = mctx->fregs [AMD64_XMM5];
+	context->Xmm6 = mctx->fregs [AMD64_XMM6];
+	context->Xmm7 = mctx->fregs [AMD64_XMM7];
+	context->Xmm8 = mctx->fregs [AMD64_XMM8];
+	context->Xmm9 = mctx->fregs [AMD64_XMM9];
+	context->Xmm10 = mctx->fregs [AMD64_XMM10];
+	context->Xmm11 = mctx->fregs [AMD64_XMM11];
+	context->Xmm12 = mctx->fregs [AMD64_XMM12];
+	context->Xmm13 = mctx->fregs [AMD64_XMM13];
+	context->Xmm14 = mctx->fregs [AMD64_XMM14];
+	context->Xmm15 = mctx->fregs [AMD64_XMM15];
+
 #else
 	g_assert_not_reached ();
 #endif

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -18,6 +18,10 @@
 #include <signal.h>
 #endif
 
+#ifdef HOST_WIN32
+#include <windows.h>
+#endif
+
 #define MONO_CONTEXT_OFFSET(field, index, field_type) \
     "i" (offsetof (MonoContext, field) + (index) * sizeof (field_type))
 
@@ -27,10 +31,6 @@ typedef struct __darwin_xmm_reg MonoContextSimdReg;
 typedef struct _libc_xmmreg MonoContextSimdReg;
 #elif defined(HOST_WIN32)
 typedef M128A MonoContextSimdReg;
-#endif
-
-#ifdef HOST_WIN32
-#include <windows.h>
 #endif
 
 /*

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -23,6 +23,14 @@
 
 #if defined(__APPLE__)
 typedef struct __darwin_xmm_reg MonoContextSimdReg;
+#elif defined(__linux__) && defined(__x86_64__)
+typedef struct _libc_xmmreg MonoContextSimdReg;
+#elif defined(HOST_WIN32)
+typedef M128A MonoContextSimdReg;
+#endif
+
+#ifdef HOST_WIN32
+#include <windows.h>
 #endif
 
 /*
@@ -106,8 +114,8 @@ typedef struct {
 	mgreg_t esi;
 	mgreg_t edi;
 	mgreg_t eip;
-#ifdef __APPLE__
-    MonoContextSimdReg fregs [X86_XMM_NREG];
+#if defined(__APPLE__) || defined(HOST_WIN32)
+	MonoContextSimdReg fregs [X86_XMM_NREG];
 #endif
 } MonoContext;
 
@@ -121,6 +129,7 @@ typedef struct {
 
 /*We set EAX to zero since we are clobering it anyway*/
 #ifdef _MSC_VER
+
 #define MONO_CONTEXT_GET_CURRENT(ctx) do { \
 	void *_ptr = &(ctx);												\
 	__asm {																\
@@ -138,21 +147,24 @@ typedef struct {
 	 __asm pop dword ptr [eax+0x20]										\
 		 }																\
 	} while (0)
+
 #else
-#define MONO_CONTEXT_GET_CURRENT(ctx) \
-	__asm__ __volatile__(   \
-	"movl $0x0, %c[eax](%0)\n" \
-	"mov %%ebx, %c[ebx](%0)\n" \
-	"mov %%ecx, %c[ecx](%0)\n" \
-	"mov %%edx, %c[edx](%0)\n" \
-	"mov %%ebp, %c[ebp](%0)\n" \
-	"mov %%esp, %c[esp](%0)\n" \
-	"mov %%esi, %c[esi](%0)\n" \
-	"mov %%edi, %c[edi](%0)\n" \
-	"call 1f\n"     \
-	"1: pop 0x20(%0)\n"     \
-	:	\
-	: "a" (&(ctx)),	\
+
+#define MONO_CONTEXT_GET_CURRENT_GREGS(ctx) \
+	do { \
+		__asm__ __volatile__(   \
+		"movl $0x0, %c[eax](%0)\n" \
+		"mov %%ebx, %c[ebx](%0)\n" \
+		"mov %%ecx, %c[ecx](%0)\n" \
+		"mov %%edx, %c[edx](%0)\n" \
+		"mov %%ebp, %c[ebp](%0)\n" \
+		"mov %%esp, %c[esp](%0)\n" \
+		"mov %%esi, %c[esi](%0)\n" \
+		"mov %%edi, %c[edi](%0)\n" \
+		"call 1f\n"     \
+		"1: pop %c[eip](%0)\n"     \
+		:	\
+		: "a" (&(ctx)),	\
 		[eax] MONO_CONTEXT_OFFSET (eax, 0, mgreg_t), \
 		[ebx] MONO_CONTEXT_OFFSET (ebx, 0, mgreg_t), \
 		[ecx] MONO_CONTEXT_OFFSET (ecx, 0, mgreg_t), \
@@ -160,8 +172,45 @@ typedef struct {
 		[ebp] MONO_CONTEXT_OFFSET (ebp, 0, mgreg_t), \
 		[esp] MONO_CONTEXT_OFFSET (esp, 0, mgreg_t), \
 		[esi] MONO_CONTEXT_OFFSET (esi, 0, mgreg_t), \
-		[edi] MONO_CONTEXT_OFFSET (edi, 0, mgreg_t) \
-	: "memory")
+		[edi] MONO_CONTEXT_OFFSET (edi, 0, mgreg_t), \
+		[eip] MONO_CONTEXT_OFFSET (eip, 0, mgreg_t) \
+		: "memory"); \
+	} while (0)
+
+#ifdef UCONTEXT_REG_XMM
+#define MONO_CONTEXT_GET_CURRENT_FREGS(ctx) \
+	do { \
+		__asm__ __volatile__(   \
+			"movups %%xmm0, %c[xmm0](%0)\n"	\
+			"movups %%xmm1, %c[xmm1](%0)\n"	\
+			"movups %%xmm2, %c[xmm2](%0)\n"	\
+			"movups %%xmm3, %c[xmm3](%0)\n"	\
+			"movups %%xmm4, %c[xmm4](%0)\n"	\
+			"movups %%xmm5, %c[xmm5](%0)\n"	\
+			"movups %%xmm6, %c[xmm6](%0)\n"	\
+			"movups %%xmm7, %c[xmm7](%0)\n"	\
+			:	\
+			: "a" (&(ctx)),	\
+			[xmm0] MONO_CONTEXT_OFFSET (fregs, X86_XMM0, MonoContextSimdReg), \
+			[xmm1] MONO_CONTEXT_OFFSET (fregs, X86_XMM1, MonoContextSimdReg), \
+			[xmm2] MONO_CONTEXT_OFFSET (fregs, X86_XMM2, MonoContextSimdReg), \
+			[xmm3] MONO_CONTEXT_OFFSET (fregs, X86_XMM3, MonoContextSimdReg), \
+			[xmm4] MONO_CONTEXT_OFFSET (fregs, X86_XMM4, MonoContextSimdReg), \
+			[xmm5] MONO_CONTEXT_OFFSET (fregs, X86_XMM5, MonoContextSimdReg), \
+			[xmm6] MONO_CONTEXT_OFFSET (fregs, X86_XMM6, MonoContextSimdReg), \
+			[xmm7] MONO_CONTEXT_OFFSET (fregs, X86_XMM7, MonoContextSimdReg) \
+			: "memory"); \
+	} while (0)
+#else
+#define MONO_CONTEXT_GET_CURRENT_FREGS(ctx)
+#endif
+
+#define MONO_CONTEXT_GET_CURRENT(ctx) \
+	do { \
+		MONO_CONTEXT_GET_CURRENT_GREGS (ctx); \
+		MONO_CONTEXT_GET_CURRENT_FREGS (ctx); \
+	} while (0)
+
 #endif
 
 #define MONO_ARCH_HAS_MONO_CONTEXT 1
@@ -180,11 +229,7 @@ typedef struct {
 
 typedef struct {
 	mgreg_t gregs [AMD64_NREG];
-#ifdef __APPLE__
 	MonoContextSimdReg fregs [AMD64_XMM_NREG];
-#else
-	double fregs [AMD64_XMM_NREG];
-#endif
 } MonoContext;
 
 #define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->gregs [AMD64_RIP] = (mgreg_t)(ip); } while (0);

--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -45,6 +45,15 @@
 	#define UCONTEXT_REG_ESI(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__esi)
 	#define UCONTEXT_REG_EDI(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__edi)
 	#define UCONTEXT_REG_EIP(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__eip)
+	#define UCONTEXT_REG_XMM
+	#define UCONTEXT_REG_XMM0(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm0)
+	#define UCONTEXT_REG_XMM1(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm1)
+	#define UCONTEXT_REG_XMM2(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm2)
+	#define UCONTEXT_REG_XMM3(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm3)
+	#define UCONTEXT_REG_XMM4(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm4)
+	#define UCONTEXT_REG_XMM5(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm5)
+	#define UCONTEXT_REG_XMM6(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm6)
+	#define UCONTEXT_REG_XMM7(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm7)
 #  else
 	#define UCONTEXT_REG_EAX(ctx) (((ucontext_t*)(ctx))->uc_mcontext->ss.eax)
 	#define UCONTEXT_REG_EBX(ctx) (((ucontext_t*)(ctx))->uc_mcontext->ss.ebx)

--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -247,6 +247,23 @@ typedef struct ucontext {
 	#define UCONTEXT_REG_R15(ctx) (((ucontext_t*)(ctx))->sc_r15)
 #elif !defined(HOST_WIN32)
 	#define UCONTEXT_GREGS(ctx)	((guint64*)&(((ucontext_t*)(ctx))->uc_mcontext.gregs))
+	#define UCONTEXT_REG_XMM
+	#define UCONTEXT_REG_XMM0(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [0])
+	#define UCONTEXT_REG_XMM1(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [1])
+	#define UCONTEXT_REG_XMM2(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [2])
+	#define UCONTEXT_REG_XMM3(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [3])
+	#define UCONTEXT_REG_XMM4(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [4])
+	#define UCONTEXT_REG_XMM5(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [5])
+	#define UCONTEXT_REG_XMM6(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [6])
+	#define UCONTEXT_REG_XMM7(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [7])
+	#define UCONTEXT_REG_XMM8(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [8])
+	#define UCONTEXT_REG_XMM9(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm [9])
+	#define UCONTEXT_REG_XMM10(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm	[10])
+	#define UCONTEXT_REG_XMM11(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm	[11])
+	#define UCONTEXT_REG_XMM12(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm	[12])
+	#define UCONTEXT_REG_XMM13(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm	[13])
+	#define UCONTEXT_REG_XMM14(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm	[14])
+	#define UCONTEXT_REG_XMM15(ctx) (((ucontext_t*)(ctx))->uc_mcontext.fpregs->_xmm	[15])
 #endif
 
 #ifdef UCONTEXT_GREGS

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -119,7 +119,7 @@ mono_threads_suspend_begin_async_resume (MonoThreadInfo *info)
 		mono_threads_get_runtime_callbacks ()->setup_async_callback (&ctx, info->async_target, info->user_data);
 		info->async_target = info->user_data = NULL;
 
-		context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
+		context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL | CONTEXT_FLOATING_POINT;
 
 		if (!GetThreadContext (handle, &context)) {
 			CloseHandle (handle);
@@ -128,10 +128,11 @@ mono_threads_suspend_begin_async_resume (MonoThreadInfo *info)
 
 		g_assert (context.ContextFlags & CONTEXT_INTEGER);
 		g_assert (context.ContextFlags & CONTEXT_CONTROL);
+		g_assert (context.ContextFlags & CONTEXT_FLOATING_POINT);
 
 		mono_monoctx_to_sigctx (&ctx, &context);
 
-		context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
+		context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL | CONTEXT_FLOATING_POINT;
 		res = SetThreadContext (handle, &context);
 		if (!res) {
 			CloseHandle (handle);

--- a/mono/utils/win64.asm
+++ b/mono/utils/win64.asm
@@ -30,7 +30,22 @@ mono_context_get_current PROC
 	mov [rcx + 68h], r13
 	mov [rcx + 70h], r14
 	mov [rcx + 78h], r15
-
+    movups [rcx + 090h], xmm0
+    movups [rcx + 0a0h], xmm1
+    movups [rcx + 0b0h], xmm2
+    movups [rcx + 0c0h], xmm3
+    movups [rcx + 0d0h], xmm4
+    movups [rcx + 0e0h], xmm5
+    movups [rcx + 0f0h], xmm6
+    movups [rcx + 100h], xmm7
+    movups [rcx + 110h], xmm8
+    movups [rcx + 120h], xmm9
+    movups [rcx + 130h], xmm10
+    movups [rcx + 140h], xmm11
+    movups [rcx + 150h], xmm12
+    movups [rcx + 160h], xmm13
+    movups [rcx + 170h], xmm14
+    movups [rcx + 180h], xmm15
 	lea rax, __mono_current_ip
 __mono_current_ip:
 	mov [rcx + 80h], rax


### PR DESCRIPTION
Just getting this out for discussion, and so I can see build results for different platforms.
- I think the individual `XMM*` macros are the way to go (i.e., not assuming that they’re contiguous) but they’re annoyingly repetitive.
- Pretty sure `MonoContextSimdReg` is an okay abstraction, but if we wanted to avoid platform-specific types, we could use our own `struct { char [16] }` type and `memcpy` into it.
- What about regular FP registers and AVX registers?
- I still don’t really know how to reliably test this.
