### PR TITLE
Fixes the mono/tests/gc-graystack-stress test on Windows x64

### DIFF
--- a/mono/tests/gc-graystack-stress.cs
+++ b/mono/tests/gc-graystack-stress.cs
@@ -33,7 +33,11 @@ class Program {
 		if (args.Length > 0)
 			width = Math.Max (width, Int32.Parse (args [0]));
 
-		int depth = 10000;
+		// Windows x64 only has 1 MB of stack per thread which is less than other x86 64-bit OSes.
+		// Using 10000 for depth will cause a stack overflow on Windows x64. 5000 will fit.
+		int platform = (int) Environment.OSVersion.Platform;
+		bool isWin64 = !(platform == 4 || platform == 128) && Environment.Is64BitProcess;
+		int depth = isWin64 ? 5000 : 10000;
 		if (args.Length > 1)
 			depth = Math.Max (depth, Int32.Parse (args [1]));
 


### PR DESCRIPTION
Windows x64 only has 1 MB of stack per thread which is less than other x86 64-bit OSes. Using 10000 for "depth" in this test causes a stack overflow on Windows x64. This patch changes "depth" to 5000 only on Windows x64. 5000 will fit within the default stack size.