### PR TITLE
[runtime] Restrict delegate wrapper sharing

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3539,6 +3539,7 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 #endif /* DISABLE_JIT */
 
 	info = mono_wrapper_info_create (mb, subtype);
+	info->d.delegate_invoke.method = method;
 
 	if (ctx) {
 		MonoMethod *def;

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -191,6 +191,10 @@ typedef struct {
 	MonoMethodSignature *sig;
 } GsharedvtWrapperInfo;
 
+typedef struct {
+	MonoMethod *method;
+} DelegateInvokeWrapperInfo;
+
 /*
  * This structure contains additional information to uniquely identify a given wrapper
  * method. It can be retrieved by mono_marshal_get_wrapper_info () for certain types
@@ -231,6 +235,8 @@ typedef struct {
 		RemotingWrapperInfo remoting;
 		/* GSHAREDVT_IN_SIG/GSHAREDVT_OUT_SIG */
 		GsharedvtWrapperInfo gsharedvt;
+		/* DELEGATE_INVOKE */
+		DelegateInvokeWrapperInfo delegate_invoke;
 	} d;
 } WrapperInfo;
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4041,7 +4041,7 @@ find_aot_method_in_amodule (MonoAotModule *amodule, MonoMethod *method, guint32 
 			WrapperInfo *info1 = mono_marshal_get_wrapper_info (method);
 			WrapperInfo *info2 = mono_marshal_get_wrapper_info (m);
 
-			if (info1 && info2 && info1->subtype == info2->subtype && method->klass == m->klass) {
+			if (info1 && info2 && info1->subtype == info2->subtype && method->klass == m->klass && info1->d.delegate_invoke.method == info2->d.delegate_invoke.method) {
 				index = value;
 				break;
 			}


### PR DESCRIPTION
This fixes delegate.exe in the mono/tests suite. 

Without this, we find the wrong delegate wrapper and end up corrupting types for the delegate tests and seeing NULL in the place of actual arguments.