### PR TITLE
[runtime] Add test for ThreadAbortException triggered while in a cctor

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -438,10 +438,12 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 
 		/* If the initialization failed, mark the class as unusable. */
 		/* Avoid infinite loops */
-		if (!(mono_error_ok(error) ||
-			  (klass->image == mono_defaults.corlib &&
-			   !strcmp (klass->name_space, "System") &&
-			   !strcmp (klass->name, "TypeInitializationException")))) {
+		if (!mono_error_ok(error)
+			 && !(klass->image == mono_defaults.corlib &&
+			      !strcmp (klass->name_space, "System") &&
+			      !strcmp (klass->name, "TypeInitializationException"))
+			 && !mono_class_has_parent (mono_object_class (exc), mono_defaults.threadabortexception_class))
+		{
 			vtable->init_failed = 1;
 
 			if (klass->name_space && *klass->name_space)

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -464,7 +464,8 @@ BASE_TEST_CS_SRC_UNIVERSAL=		\
 	pinvoke_ppcf.cs	\
 	pinvoke_ppcd.cs	\
 	bug-29585.cs	\
-	priority.cs
+	priority.cs	\
+	thread-abort-cctor.cs
 
 if INSTALL_MOBILE_STATIC
 BASE_TEST_CS_SRC= \

--- a/mono/tests/thread-abort-cctor.cs
+++ b/mono/tests/thread-abort-cctor.cs
@@ -1,0 +1,115 @@
+
+using System;
+using System.Threading;
+
+class Driver
+{
+	public static ManualResetEvent mre1 = new ManualResetEvent (false);
+	public static ManualResetEvent mre2 = new ManualResetEvent (false);
+
+	class StaticConstructor1
+	{
+		static StaticConstructor1 ()
+		{
+			Console.WriteLine ("StaticConstructor1.StaticConstructor1 (1)");
+			Driver.mre1.Set ();
+			Thread.Sleep (1000);
+			Console.WriteLine ("StaticConstructor1.StaticConstructor1 (2)");
+		}
+
+		public static void Init ()
+		{
+			Console.WriteLine ("StaticConstructor1.Init");
+		}
+	}
+
+	static void Test1 ()
+	{
+		Console.WriteLine ("Test 1:");
+
+		Driver.mre1.Reset ();
+		Driver.mre2.Reset ();
+
+		Thread thread = new Thread (() => {
+			try {
+				StaticConstructor1.Init ();
+			} catch (Exception e) {
+				Console.WriteLine (e);
+
+				if (!(e is ThreadAbortException))
+					throw;
+			}
+		});
+
+		thread.Start ();
+
+		Driver.mre1.WaitOne ();
+
+		// The ThreadAbortException should land while in
+		// the StaticConstructor1.cctor. The exception should
+		// be queued, and be rethrown when exiting the cctor.
+		thread.Abort ();
+
+		thread.Join ();
+	}
+
+	class StaticConstructor2Exception : Exception {}
+
+	class StaticConstructor2
+	{
+		static StaticConstructor2 ()
+		{
+			Console.WriteLine ("StaticConstructor2.StaticConstructor2 (1)");
+			Driver.mre1.Set ();
+			throw new StaticConstructor2Exception ();
+			/* Unreachable */
+			Driver.mre2.Set ();
+			Console.WriteLine ("StaticConstructor2.StaticConstructor2 (2)");
+		}
+
+		public static void Init ()
+		{
+			Console.WriteLine ("StaticConstructor2.Init");
+		}
+	}
+
+	static void Test2 ()
+	{
+		Console.WriteLine ("Test 2:");
+
+		Driver.mre1.Reset ();
+		Driver.mre2.Reset ();
+
+		Thread thread = new Thread (() => {
+			try {
+				StaticConstructor2.Init ();
+			} catch (TypeInitializationException e) {
+				Console.WriteLine (e);
+
+				if (!(e.InnerException is StaticConstructor2Exception))
+					throw;
+			}
+		});
+
+		thread.Start ();
+
+		Driver.mre1.WaitOne ();
+
+		// A InvalidOperationException should be thrown while in
+		// the StaticConstructor2.cctor. The exception should
+		// be wrapped in a TypeInitializationException.
+
+		if (Driver.mre2.WaitOne (500)) {
+			/* We shouldn't reach Driver.mre.Set () in StaticConstructor2.cctor */
+			Environment.Exit (1);
+		}
+
+		thread.Join ();
+	}
+
+	public static void Main ()
+	{
+		Test1 ();
+		Test2 ();
+	}
+}


### PR DESCRIPTION
The expected and observed output on .NET is:

```
Test 1:
StaticConstructor1.StaticConstructor1 (1)
StaticConstructor1.StaticConstructor1 (2)
System.Threading.ThreadAbortException: Thread was being aborted.
   at System.Threading.Monitor.Enter(Object obj)
   at System.IO.TextWriter.SyncTextWriter.WriteLine(String value)
   at System.Console.WriteLine(String value)
   at Driver.StaticConstructor1.Init()
   at Driver.<Test1>b__0()
Test 2:
StaticConstructor2.StaticConstructor2 (1)
System.TypeInitializationException: The type initializer for 'StaticConstructor2' threw an exception. ---> Driver+StaticConstructor2Exception: Exception of type 'Driver+StaticConstructor2Exception' was thrown.
   at Driver.StaticConstructor2..cctor()
   --- End of inner exception stack trace ---
   at Driver.StaticConstructor2.Init()
   at Driver.<Test2>b__2()
```

The actual output on Mono is:

```
Test 1:
StaticConstructor1.StaticConstructor1 (1)
System.Threading.ThreadAbortException
  at Driver.<Test1>m__0 () [0x00000] in <filename unknown>:0

Test 2:
StaticConstructor2.StaticConstructor2 (1)
System.TypeInitializationException: The type initializer for 'StaticConstructor2' threw an exception. ---> Driver+StaticConstructor2Exception: Exception of type 'Driver+StaticConstructor2Exception' was thrown.
  at Driver+StaticConstructor2..cctor () [0x0001a] in <filename unknown>:0
  --- End of inner exception stack trace ---
  at Driver.<Test2>m__1 () [0x00000] in <filename unknown>:0
```

The bug comes from the fact that a ThreadAbortException thrown from a cctor is wrapped in a TypeInitializationException, while it should simply be rethrown.