### PR TITLE
Explicitly use the ANSI version of GetLocaleInfo() in g_win32_getlocale()

### DIFF
--- a/eglib/src/gmisc-win32.c
+++ b/eglib/src/gmisc-win32.c
@@ -89,9 +89,9 @@ g_win32_getlocale(void)
 {
 	LCID lcid = GetThreadLocale();
 	gchar buf[19];
-	gint ccBuf = GetLocaleInfo(lcid, LOCALE_SISO639LANGNAME, buf, 9);
+	gint ccBuf = GetLocaleInfoA(lcid, LOCALE_SISO639LANGNAME, buf, 9);
 	buf[ccBuf - 1] = '-';
-	ccBuf += GetLocaleInfo(lcid, LOCALE_SISO3166CTRYNAME, buf + ccBuf, 9);
+	ccBuf += GetLocaleInfoA(lcid, LOCALE_SISO3166CTRYNAME, buf + ccBuf, 9);
 	return g_strdup (buf);
 }
 


### PR DESCRIPTION
Since `UNICODE` is defined when Mono is compiled under Windows the `GetLocaleInfo()` macro will expand to `GetLocaleInfoW()` which returns the current locale identifier in `g_win32_getlocale()` in 16-bit Unicode. `g_win32_getlocale()` however expects an 8-bit encoding. By using `GetLocaleInfoA()` explicitly we'll get the identifier back as an ordinary 8-bit C string.

This patch fixes the `mono/tests/threadpool-exceptions5.exe` test.