### PR TITLE
Handle NetBSD specific iconv(3) call prototype

### DIFF
--- a/eglib/src/giconv.c
+++ b/eglib/src/giconv.c
@@ -199,8 +199,11 @@ g_iconv (GIConv cd, gchar **inbytes, gsize *inbytesleft,
 		} else {
 			outleftptr = NULL;
 		}
-		
+#if defined(__NetBSD__)
+		return iconv (cd->cd, (const gchar **)inbytes, inleftptr, outbytes, outleftptr);
+#else
 		return iconv (cd->cd, inbytes, inleftptr, outbytes, outleftptr);
+#endif
 	}
 #endif
 	


### PR DESCRIPTION
In the past there were wars between constified and unconstified
second parameter.. NetBSD went with constifying it. POSIX went without
const and most other OSes standarized. NetBSD is still having
incompatible function prototype.

LIBRARY
     Standard C Library (libc, -lc)

SYNOPSIS
     #include <iconv.h>

     size_t
     iconv(iconv_t cd, const char ** restrict src, size_t * restrict srcleft,
           char ** restrict dst, size_t * restrict dstleft);