### PR TITLE
Fix getting/setting thread priority on Windows

### DIFF
--- a/mono/tests/priority.cs
+++ b/mono/tests/priority.cs
@@ -5,8 +5,11 @@ using System.Text;
 
 public class Tests
 {
+	private static int mainThreadId;
+
 	public static int Main ()
 	{
+		mainThreadId = Thread.CurrentThread.ManagedThreadId;
 		return TestDriver.RunTests (typeof (Tests));
 	}
 
@@ -21,6 +24,46 @@ public class Tests
 			Thread.CurrentThread.Priority.ToString());
 	}
 	
+	public static int test_0_main_thread_priority ()
+	{
+		Console.WriteLine("Testing main thread's priority");
+		if (Thread.CurrentThread.ManagedThreadId != mainThreadId)
+		{
+			Console.WriteLine("test_0_main_thread_priority() must be run on the main thread");
+			return 1;
+		}
+
+		var before = Thread.CurrentThread.Priority;
+		Console.WriteLine("Priority: {0}", before);
+		if (before != ThreadPriority.Normal)
+			return 2;
+
+		Console.WriteLine("Setting main thread's priority to AboveNormal");
+		Thread.CurrentThread.Priority = ThreadPriority.AboveNormal;
+		var after = Thread.CurrentThread.Priority;
+		Console.WriteLine("Priority: {0} {1}", before, after);
+		if (after != ThreadPriority.AboveNormal)
+			return 3;
+
+		before = after;
+		Console.WriteLine("Setting main thread's priority to BelowNormal");
+		Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
+		after = Thread.CurrentThread.Priority;
+		Console.WriteLine("Priority: {0} {1}", before, after);
+		if (after != ThreadPriority.BelowNormal)
+			return 4;
+
+		before = after;
+		Console.WriteLine("Setting main thread's priority to Normal");
+		Thread.CurrentThread.Priority = ThreadPriority.Normal;
+		after = Thread.CurrentThread.Priority;
+		Console.WriteLine("Priority: {0} {1}", before, after);
+		if (after != ThreadPriority.Normal)
+			return 5;
+
+		return 0;
+	}
+
 	public static int test_0_thread_priority () 
 	{
 		int res = 0;


### PR DESCRIPTION
The mono_threads_platform_get_priority()/mono_threads_platform_set_priority() functions in mono-threads-windows.c assume the "handle" member has been set in the MonoThreadInfo struct passed to it but it's always NULL. This patch implements mono_threads_suspend_register() in the same file which sets the "handle" member at thread registration time, like it's done in mono-threads-posix.c.

This patch also makes sure the priority of a new thread is set as expected when the Thread.Priority property has been changed prior to the thread being started.

Also added a test method to mono/tests/priority.cs which tests that the priority of the main thread is Normal by default and that it can be changed as expected.

The changes in this patch fixes the failures in mono/tests/priority.exe on Windows i386 and x64.