### PR TITLE
[coop] Temporarily restore MonoThreadInfo when TLS destructor runs.  Fixes #43099

### DIFF
--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -282,7 +282,7 @@ MonoSelfSupendResult
 mono_threads_transition_state_poll (MonoThreadInfo *info)
 {
 	int raw_state, cur_state, suspend_count;
-	g_assert (info == mono_thread_info_current ());
+	g_assert (mono_thread_info_is_current (info));
 
 retry_state_change:
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, info);


### PR DESCRIPTION
We need a valid `MonoThreadInfo*` in the TLS key while we run
`unregister_thread` because we may need to block the thread when it tries
to take the sgen GC mutex.

Fixes [#43099](https://bugzilla.xamarin.com/show_bug.cgi?id=43099)