### PR TITLE
[cycle8][coop] Temporarily restore MonoThreadInfo when TLS destructor runs.  Fixes #43099

### DIFF
--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -282,7 +282,7 @@ MonoSelfSupendResult
 mono_threads_transition_state_poll (MonoThreadInfo *info)
 {
 	int raw_state, cur_state, suspend_count;
-	g_assert (info == mono_thread_info_current ());
+	g_assert (mono_thread_info_is_current (info));
 
 retry_state_change:
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, info);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -398,6 +398,8 @@ unregister_thread (void *arg)
 
 	info = (MonoThreadInfo *) arg;
 	g_assert (info);
+	g_assert (mono_thread_info_is_current (info));
+	g_assert (mono_thread_info_is_live (info));
 
 	small_id = info->small_id;
 
@@ -633,6 +635,20 @@ mono_thread_info_is_exiting (void)
 	return FALSE;
 }
 
+#ifndef HOST_WIN32
+static void
+thread_info_key_dtor (void *arg)
+{
+	/* Put the MonoThreadInfo back for the duration of the
+	 * unregister code.  In some circumstances the thread needs to
+	 * take the GC lock which may block which requires a coop
+	 * state transition. */
+	mono_native_tls_set_value (thread_info_key, arg);
+	unregister_thread (arg);
+	mono_native_tls_set_value (thread_info_key, NULL);
+}
+#endif
+
 void
 mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 {
@@ -643,7 +659,7 @@ mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 	res = mono_native_tls_alloc (&thread_info_key, NULL);
 	res = mono_native_tls_alloc (&thread_exited_key, NULL);
 #else
-	res = mono_native_tls_alloc (&thread_info_key, (void *) unregister_thread);
+	res = mono_native_tls_alloc (&thread_info_key, (void *) thread_info_key_dtor);
 	res = mono_native_tls_alloc (&thread_exited_key, (void *) thread_exited_dtor);
 #endif
 
@@ -1010,6 +1026,8 @@ static void
 mono_thread_info_suspend_lock_with_info (MonoThreadInfo *info)
 {
 	g_assert (info);
+	g_assert (mono_thread_info_is_current (info));
+	g_assert (mono_thread_info_is_live (info));
 
 	MONO_ENTER_GC_SAFE_WITH_INFO(info);
 


### PR DESCRIPTION
We need a valid `MonoThreadInfo*` in the TLS key while we run
`unregister_thread` because we may need to block the thread when it tries
to take the sgen GC mutex.

Fixes [#43099](https://bugzilla.xamarin.com/show_bug.cgi?id=43099)