### PR TITLE
Fix the failure of the async-exc-compilation.exe test on Windows

### DIFF
--- a/mono/tests/async-exc-compilation.cs
+++ b/mono/tests/async-exc-compilation.cs
@@ -27,6 +27,7 @@ class MainClass
 			Thread.Sleep (10000);
 		}
 		catch (ThreadAbortException) {
+			Thread.ResetAbort ();
 			Console.WriteLine ("OK");
 		}
 	}


### PR DESCRIPTION
The test fails due an ArgumentException being thrown when the catch handler in the test's Run() method tries to write to the console. The ArgumentException is thrown in EncodingTable.GetCodePageFromName(string) since the encoding name passed to it is null. Normally this exception would be caught and the default encoding would fall back to UTF8. However, since the thread is aborted the ThreadAbortException will be rethrown and terminates the test with an uncaught exception. I have verified that the same behavior is seen on OS X if I mock up the default encoding code to throw the same ArgumentException.

This patch adds a call to Thread.ResetAbort() just before the call to Console.WriteLine() in the catch handler. This removes the abort status of the thread and avoids the rethrow of the ThreadAbortException.