### PR TITLE
Fix empty hostname in GetHostByName on windows

### DIFF
--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -2676,8 +2676,16 @@ ves_icall_System_Net_Dns_GetHostByName_internal (MonoString *host, MonoString **
 		}
 	}
 
+#ifdef HOST_WIN32
+	// Win32 APIs already returns local interface addresses for empty hostname ("")
+	// so we never want to add them manually.
+	add_local_ips = FALSE;
+	if (mono_get_address_info(hostname, 0, MONO_HINT_CANONICAL_NAME | hint, &info))
+		add_info_ok = FALSE;
+#else
 	if (*hostname && mono_get_address_info (hostname, 0, MONO_HINT_CANONICAL_NAME | hint, &info))
 		add_info_ok = FALSE;
+#endif
 
 	g_free(hostname);
 


### PR DESCRIPTION
GetHostByName crashed on windows when "" hostname was sent. Win32 APIs define that local interface addresses should be added for empty hostnames. POSIX API doesn't seem to have this behaviour so current code add them manually. This PR makes sure we don't add local addresses manually but instead trust the Win32 API as it already returns the local addresses.