### PR TITLE
Removing symlink of TestHelpers.cs

### DIFF
--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -513,4 +513,4 @@ System.Threading/CountdownEventTests.cs
 System/AggregateExceptionTests.cs
 System.Threading/ThreadLocalTests.cs
 System.Threading/SpinLockTests.cs
-../../test-helpers/TestHelpers.cs
+../../../../mono/mini/TestHelpers.cs

--- a/mcs/class/test-helpers/TestHelpers.cs
+++ b/mcs/class/test-helpers/TestHelpers.cs
@@ -1,1 +1,0 @@
-../../../mono/mini/TestHelpers.cs


### PR DESCRIPTION
Removing symlink to TestHelpers introduced in commit @220b5f56b817618506efbfd370d8b5c8d66081fd, as it breaks windows builds (symlinks not supported on Windows). 
Pointing to the TestHelpers.cs file from the sources file instead. @BrzVlad does this look ok?
