### PR TITLE
Fixes illegal CALL emitted in handler_block_trampoline on Win64

### DIFF
--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -798,7 +798,8 @@ mono_arch_create_handler_block_trampoline (MonoTrampInfo **info, gboolean aot)
 			code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "mono_amd64_handler_block_trampoline_helper");
 			amd64_call_reg (code, AMD64_R11);
 		} else {
-			amd64_call_code (code, mono_amd64_handler_block_trampoline_helper);
+			amd64_mov_reg_imm (code, AMD64_RAX, mono_amd64_handler_block_trampoline_helper);
+			amd64_call_reg (code, AMD64_RAX);
 		}
 		/* Undo stack alignment */
 		amd64_alu_reg_imm (code, X86_ADD, AMD64_RSP, 8);


### PR DESCRIPTION
The code in mono_arch_create_handler_block_trampoline() in tramp-amd64.c emits a relative CALL which calls the mono_amd64_handler_block_trampoline_helper() functions via:

  amd64_call_code (code, mono_amd64_handler_block_trampoline_helper)

This macro however only works properly for offsets less than 32-bits. For 64-bit offsets it truncates the offset to a 32-bit number. On Win64 the offset in this case is always a number larger than 2^32. The emitted CALL will jump to an illegal address causing a crash.

This patch changes the emitted code sequence to load the address of mono_amd64_handler_block_trampoline_helper() to RAX and then calls the address
in RAX.

The test mono/tests/finally_block_ending_in_dead_bb.exe triggered this bug. After this patch the test still crashes but in a new way related to another bug.