### PR TITLE
[runtime] Fix unhandled exception fatal error message. Fixes #43410

### DIFF
--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1076,10 +1076,10 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 		
 		if (str && is_ok (&inner_error)) {
 			msg = mono_string_to_utf8_checked (str, &inner_error);
-		}
-		if (!is_ok (&inner_error)) {
-			msg = g_strdup_printf ("Nested exception while formatting original exception");
-			mono_error_cleanup (&inner_error);
+			if (!is_ok (&inner_error)) {
+				msg = g_strdup_printf ("Nested exception while formatting original exception");
+				mono_error_cleanup (&inner_error);
+			}
 		} else if (other) {
 			char *original_backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
 			char *nested_backtrace = mono_exception_get_managed_backtrace ((MonoException*)other);


### PR DESCRIPTION
Partially revert bcbd0ac0c018b0a68caa63ac1135052b2082f468

Fixes [#43410](https://bugzilla.xamarin.com/show_bug.cgi?id=43410)