### PR TITLE
[mobile_static] Merge changes for valgrind bitcode lane

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -754,6 +754,7 @@ AC_ARG_WITH(monotouch_tv,    [  --with-monotouch_tv=yes,no      If you want to b
 AC_ARG_WITH(bitcode,         [  --with-bitcode=yes,no           If bitcode is enabled (defaults to no)],                              [], [with_bitcode=default])
 AC_ARG_WITH(xammac,          [  --with-xammac=yes,no            If you want to build the Xamarin.Mac assemblies (defaults to no)],    [], [with_xammac=default])
 AC_ARG_WITH(mobile_static,   [  --with-mobile_static=yes,no     If you want to build the mobile_static assemblies (defaults to no)],  [], [with_mobile_static=default])
+AC_ARG_WITH(bitcode_valgrind,         [  --with-bitcode_valgrind=yes,no           If bitcode C defines will aid valgrind (defaults to no)],                              [], [with_bitcode_valgrind=default])
 
 AC_ARG_WITH(runtime_preset, [  --with-runtime_preset=net_4_x,all,mobile_static,bitcode_mobile_static   Which default profile to build (defaults to net_4_x)],  [], [with_runtime_preset=net_4_x])
 
@@ -840,6 +841,11 @@ elif test x$with_runtime_preset = xbitcode_mobile_static; then
 
    AOT_BUILD_FLAGS="--aot=llvmonly,$INVARIANT_AOT_OPTIONS"
    AOT_RUN_FLAGS="--llvmonly"
+
+if test x$with_bitcode_valgrind = xyes; then
+   CFLAGS="$CFLAGS -DMONO_ARCH_NOMAP32BIT=1"
+fi
+
 else
    with_profile4_x_default=yes
    with_monodroid_default=no
@@ -4272,6 +4278,10 @@ fi
     if test "x$AOT_BUILD_FLAGS" != "x" ; then
       echo "AOT_RUN_FLAGS=$AOT_RUN_FLAGS" >> $srcdir/$mcsdir/build/config.make
       echo "AOT_BUILD_FLAGS=$AOT_BUILD_FLAGS" >> $srcdir/$mcsdir/build/config.make
+    fi
+
+    if test x$with_bitcode_valgrind = xyes; then
+      echo 'RUNTIME_TOOLING_INJECT="valgrind --tool=memcheck --track-origins=yes --leak-check=full --show-leak-kinds=all --quiet --xml=yes --xml-file=valgrind_log_`date +"%s.%N"`.xml  -- ' "$mono_build_root/$mono_runtime" '"' >> $srcdir/$mcsdir/build/config.make
     fi
 
   fi

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -200,7 +200,7 @@ aot-all-profile: $(patsubst %,$(topdir)/class/lib/$(PROFILE)/%$(PLATFORM_AOT_SUF
 
 $(topdir)/class/lib/$(PROFILE)/%$(PLATFORM_AOT_SUFFIX): $(topdir)/class/lib/$(PROFILE)/%
 	@ mkdir -p $(topdir)/class/lib/$(PROFILE)/$*_bitcode_tmp
-	@echo "AOT     [$(PROFILE)] AOT $* " && cd $(topdir)/class/lib/$(PROFILE)/ && MONO_PATH="." $(RUNTIME) $(RUNTIME_FLAGS) $(AOT_BUILD_FLAGS),temp-path=$*_bitcode_tmp $* >> $(PROFILE)-aot.log
+	@echo "AOT     [$(PROFILE)] AOT $* " && cd $(topdir)/class/lib/$(PROFILE)/ && MONO_PATH="." MONO_EXECUTABLE=$(RUNTIME_TOOLING_INJECT) $(RUNTIME) $(RUNTIME_FLAGS) $(AOT_BUILD_FLAGS),temp-path=$*_bitcode_tmp $* >> $(PROFILE)-aot.log
 	@ rm -rf $(topdir)/class/lib/$(PROFILE)/$*_bitcode_tmp
 
 endif #ifneq ("$(wildcard $(topdir)/class/lib/$(PROFILE))","")

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -132,7 +132,7 @@ endif
 
 ifdef ALWAYS_AOT
 test-local-aot-compile: $(topdir)/build/deps/nunit-$(PROFILE).stamp
-	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(AOT_BUILD_FLAGS) $(test_assemblies)
+	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" MONO_EXECUTABLE=$(RUNTIME_TOOLING_INJECT) $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(AOT_BUILD_FLAGS) $(test_assemblies)
 
 else
 test-local-aot-compile: $(topdir)/build/deps/nunit-$(PROFILE).stamp
@@ -142,7 +142,7 @@ endif # ALWAYS_AOT
 ## FIXME: i18n problem in the 'sed' command below
 run-test-lib: test-local test-local-aot-compile
 	ok=:; \
-	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(AOT_RUN_FLAGS) $(TEST_HARNESS) $(test_assemblies) $(NOSHADOW_FLAG) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) $(NUNIT_XML_FLAG)TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
+	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" MONO_EXECUTABLE=$(RUNTIME_TOOLING_INJECT) $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(AOT_RUN_FLAGS) $(TEST_HARNESS) $(test_assemblies) $(NOSHADOW_FLAG) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) $(NUNIT_XML_FLAG)TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
 	if [ ! -f "TestResult-$(PROFILE).xml" ]; then echo "<?xml version='1.0' encoding='utf-8'?><test-results failures='1' total='1' not-run='0' name='bcl-tests' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='$(strip $(test_assemblies))' success='False' time='0'><results><test-case name='crash' executed='True' success='False' time='0'><failure><message>The test runner didn't produce a test result XML, probably due to a crash of the runtime. Check the log for more details.</message><stack-trace></stack-trace></failure></test-case></results></test-suite></test-results>" > TestResult-$(PROFILE).xml; fi; \
 	$(TEST_HARNESS_POSTPROC) ; $$ok
 

--- a/mono/utils/mono-codeman.c
+++ b/mono/utils/mono-codeman.c
@@ -53,7 +53,7 @@ static size_t dynamic_code_frees_count;
 #define MAX_WASTAGE 32
 #define MIN_BSIZE 32
 
-#ifdef __x86_64__
+#if !defined(MONO_ARCH_NOMAP32BIT) && defined(__x86_64__)
 #define ARCH_MAP_FLAGS MONO_MMAP_32BIT
 #else
 #define ARCH_MAP_FLAGS 0


### PR DESCRIPTION
This injects valgrind into the places where we run entirely AOT, and fixes a memory mapping thing. This is what the bots have been building, with frequent rebases onto master. Valgrind appears to run on our AOT pipeline pretty well. After merge the lane will be changed to point to master.

This also offers a framework to use gcov and similar tools, by changing what RUNTIME_TOOLING_INJECT is. 
