### PR TITLE
[Mono.Security]: Rename MonoTlsProviderFactory.SetDefaultProvider()

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProviderFactory.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProviderFactory.cs
@@ -72,14 +72,18 @@ namespace Mono.Security.Interface
 		}
 
 		/*
-		 * Selects the default TLS Provider.
+		 * Selects the current TLS Provider.
 		 *
-		 * May only be called at application startup and will throw
-		 * @InvalidOperationException if a provider has already been installed.
 		 */
+		public static void SetProvider (string name)
+		{
+			NoReflectionHelper.SetProvider (name);
+		}
+
+		[Obsolete ("Use SetProvider(name); modifying the default provider is not supported.")]
 		public static void SetDefaultProvider (string name)
 		{
-			NoReflectionHelper.SetDefaultProvider (name);
+			NoReflectionHelper.SetProvider (name);
 		}
 
 		public static MonoTlsProvider GetProvider (string name)

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -244,7 +244,7 @@ namespace Mono.Net.Security
 			}
 		}
 
-		internal static void SetDefaultProvider (string name)
+		internal static void SetProvider (string name)
 		{
 			lock (locker) {
 				var provider = LookupProvider (name, true);

--- a/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
+++ b/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
@@ -84,10 +84,10 @@ namespace Mono.Net.Security
 			}
 		}
 
-		internal static void SetDefaultProvider (string name)
+		internal static void SetProvider (string name)
 		{
 			#if SECURITY_DEP
-			MonoTlsProviderFactory.SetDefaultProvider (name);
+			MonoTlsProviderFactory.SetProvider (name);
 			#else
 			throw new NotSupportedException ();
 			#endif


### PR DESCRIPTION
This is an API cleanup because MonoTlsProviderFactory.SetDefaultProvider() never actually modified the default provider.  It is now marked as obsolete and there's a new SetProvider() method.