### PR TITLE
Fixes stack alignment issue in handler_block_trampoline on Win64

### DIFF
--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -767,7 +767,6 @@ mono_amd64_handler_block_trampoline_helper (void)
 gpointer
 mono_arch_create_handler_block_trampoline (MonoTrampInfo **info, gboolean aot)
 {
-	guint8 *tramp = mono_get_trampoline_code (MONO_TRAMPOLINE_HANDLER_BLOCK_GUARD);
 	guint8 *code, *buf;
 	int tramp_size = 64;
 	MonoJumpInfo *ji = NULL;
@@ -778,47 +777,52 @@ mono_arch_create_handler_block_trampoline (MonoTrampInfo **info, gboolean aot)
 	unwind_ops = mono_arch_get_cie_program ();
 
 	/*
-	This trampoline restore the call chain of the handler block then jumps into the code that deals with it.
-	*/
-	if (!aot && mono_get_jit_tls_offset () != -1) {
-		code = mono_amd64_emit_tls_get (code, MONO_AMD64_ARG_REG1, mono_get_jit_tls_offset ());
-		amd64_mov_reg_membase (code, MONO_AMD64_ARG_REG1, MONO_AMD64_ARG_REG1, MONO_STRUCT_OFFSET (MonoJitTlsData, handler_block_return_address), 8);
-		/* Simulate a call */
-		amd64_push_reg (code, AMD64_RAX);
-		mono_add_unwind_op_def_cfa_offset (unwind_ops, code, buf, 16);
-		amd64_jump_code (code, tramp);
+	 * This trampoline restore the call chain of the handler block then jumps into the code that deals with it.
+	 * We get here from the ret emitted by CEE_ENDFINALLY.
+	 * The stack is misaligned.
+	 */
+	/* Align the stack before the call to mono_amd64_handler_block_trampoline_helper() */
+#ifdef TARGET_WIN32
+	/* Also make room for the "register parameter stack area" as specified by the Windows x64 ABI (4 64-bit registers) */
+	amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, 8 + 4 * 8);
+#else
+	amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, 8);
+#endif
+	if (aot) {
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "mono_amd64_handler_block_trampoline_helper");
+		amd64_call_reg (code, AMD64_R11);
 	} else {
-		/*
-		 * We get here from the ret emitted by CEE_ENDFINALLY.
-		 * The stack is misaligned.
-		 */
-		/* Align the stack before the call */
-		amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, 8);
-		if (aot) {
-			code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "mono_amd64_handler_block_trampoline_helper");
-			amd64_call_reg (code, AMD64_R11);
-		} else {
-			amd64_mov_reg_imm (code, AMD64_RAX, mono_amd64_handler_block_trampoline_helper);
-			amd64_call_reg (code, AMD64_RAX);
-		}
-		/* Undo stack alignment */
-		amd64_alu_reg_imm (code, X86_ADD, AMD64_RSP, 8);
-		/* Save the result to the stack */
-		amd64_push_reg (code, AMD64_RAX);
-		if (aot) {
-			char *name = g_strdup_printf ("trampoline_func_%d", MONO_TRAMPOLINE_HANDLER_BLOCK_GUARD);
-			code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, name);
-			amd64_mov_reg_reg (code, AMD64_RAX, AMD64_R11, 8);
-		} else {
-			amd64_mov_reg_imm (code, AMD64_RAX, tramp);
-		}
-		/* The stack is aligned */
+		amd64_mov_reg_imm (code, AMD64_RAX, mono_amd64_handler_block_trampoline_helper);
 		amd64_call_reg (code, AMD64_RAX);
-		/* Load return address */
-		amd64_pop_reg (code, AMD64_RAX);
-		/* The stack is misaligned, thats what the code we branch to expects */
-		amd64_jump_reg (code, AMD64_RAX);
 	}
+	/* Undo stack alignment */
+#ifdef TARGET_WIN32
+	amd64_alu_reg_imm (code, X86_ADD, AMD64_RSP, 8 + 4 * 8);
+#else
+	amd64_alu_reg_imm (code, X86_ADD, AMD64_RSP, 8);
+#endif
+	/* Save the result to the stack */
+	amd64_push_reg (code, AMD64_RAX);
+#ifdef TARGET_WIN32
+	/* Make room for the "register parameter stack area" as specified by the Windows x64 ABI (4 64-bit registers) */
+	amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, 4 * 8);
+#endif
+	if (aot) {
+		char *name = g_strdup_printf ("trampoline_func_%d", MONO_TRAMPOLINE_HANDLER_BLOCK_GUARD);
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, name);
+		amd64_mov_reg_reg (code, AMD64_RAX, AMD64_R11, 8);
+	} else {
+		amd64_mov_reg_imm (code, AMD64_RAX, mono_get_trampoline_func (MONO_TRAMPOLINE_HANDLER_BLOCK_GUARD));
+	}
+	/* The stack is aligned */
+	amd64_call_reg (code, AMD64_RAX);
+#ifdef TARGET_WIN32
+	amd64_alu_reg_imm (code, X86_ADD, AMD64_RSP, 4 * 8);
+#endif
+	/* Load return address */
+	amd64_pop_reg (code, AMD64_RAX);
+	/* The stack is misaligned, thats what the code we branch to expects */
+	amd64_jump_reg (code, AMD64_RAX);
 
 	mono_arch_flush_icache (buf, code - buf);
 	mono_profiler_code_buffer_new (buf, code - buf, MONO_PROFILER_CODE_BUFFER_HELPER, NULL);


### PR DESCRIPTION
On Win64 Mono doesn't (yet) implement fast JIT TLS (mono_get_jit_tls_offset() returns -1). This means that the code in mono_arch_create_handler_block_trampoline() takes the code path in the "else" which is the same code path taken when AOT compiling. The code generated in this code path manipulates the stack pointer to ensure it's aligned properly according to the ABI (RSP-8 is 16-byte aligned on function entry) for the AOT case where the mono_handler_block_guard_trampoline() C function is called directly from the handler_block_trampoline.

But in JIT mode the generated code calls a generated generic trampoline which assumes RSP is 16-byte aligned on function entry. When RSP isn't aligned as expected this generic trampoline will abort the process. Since Win64 Mono always takes this code path the process will be aborted and crash.

This patch splits the "else" into two separate code paths, JIT and AOT. In JIT mode Mono will now generate code similar to when fast JIT TLS is available and the stack pointer will be aligned as expected by the generic trampoline it calls. The AOT code path generates exactly the same code as before.

The tests mono/tests/finally_block_ending_in_dead_bb.exe and mono/tests/block_guard_restore_aligment_on_exit.exe trigger this bug.