### PR TITLE
[w32handle] Allow lazy initialization

### DIFF
--- a/mono/utils/w32handle.c
+++ b/mono/utils/w32handle.c
@@ -93,8 +93,6 @@ static mono_cond_t global_signal_cond;
 
 static mono_mutex_t scan_mutex;
 
-static gboolean shutting_down = FALSE;
-
 static gboolean
 type_is_fd (MonoW32HandleType type)
 {
@@ -322,9 +320,6 @@ cleanup (void)
 {
 	int i, j, k;
 
-	g_assert (!shutting_down);
-	shutting_down = TRUE;
-
 	/* Every shared handle we were using ought really to be closed
 	 * by now, but to make sure just blow them all away.  The
 	 * exiting finalizer thread in particular races us to the
@@ -362,8 +357,6 @@ mono_w32handle_cleanup (void)
 static void mono_w32handle_init_handle (MonoW32HandleBase *handle,
 			       MonoW32HandleType type, gpointer handle_specific)
 {
-	g_assert (!shutting_down);
-	
 	handle->type = type;
 	handle->signalled = FALSE;
 	handle->ref = 1;
@@ -389,8 +382,6 @@ static guint32 mono_w32handle_new_internal (MonoW32HandleType type,
 	guint32 i, k, count;
 	static guint32 last = 0;
 	gboolean retry = FALSE;
-	
-	g_assert (!shutting_down);
 	
 	/* A linear scan should be fast enough.  Start from the last
 	 * allocation, assuming that handles are allocated more often
@@ -439,8 +430,6 @@ mono_w32handle_new (MonoW32HandleType type, gpointer handle_specific)
 	guint32 handle_idx = 0;
 	gpointer handle;
 
-	g_assert (!shutting_down);
-
 	mono_lazy_initialize (&status, initialize);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_W32HANDLE, "%s: Creating new handle of type %s", __func__,
@@ -487,8 +476,6 @@ gpointer mono_w32handle_new_fd (MonoW32HandleType type, int fd,
 {
 	MonoW32HandleBase *handle_data;
 	int fd_index, fd_offset;
-
-	g_assert (!shutting_down);
 
 	mono_lazy_initialize (&status, initialize);
 


### PR DESCRIPTION
When using the log profiler, we would call `mono_gc_base_init`, which would end calling `mono_threads_suspend_register` which would create a handle for the main thread. The issue arise because we initialize the profiler, before we initialize parts of the runtime, which would themselves initialize the w32handle subsystem.

```
#0  thread_handle_create () at mono-threads-posix.c:55
#1  0x00000000007c4267 in mono_threads_suspend_register (info=0xb63a10) at mono-threads-posix.c:636
#2  0x00000000007bfb79 in register_thread (info=0xb63a10, baseptr=0x7fffffffd228) at mono-threads.c:376
#3  0x00000000007c0024 in mono_thread_info_attach (baseptr=0x7fffffffd228) at mono-threads.c:599
#4  0x000000000071c59d in mono_gc_register_thread (baseptr=0x7fffffffd228) at sgen-mono.c:2311
#5  0x000000000071d1c5 in sgen_client_init () at sgen-mono.c:2877
#6  0x00000000007404ff in sgen_gc_init () at sgen-gc.c:2815
#7  0x000000000071d56a in mono_gc_base_init () at sgen-mono.c:2986
#8  0x0000000000685cd6 in mono_profiler_load (desc=0x7fffffffdd5e "log") at profiler.c:1223
#9  0x00000000004d4af5 in mono_main (argc=3, argv=0x7fffffffd638) at driver.c:1999
#10 0x000000000041366b in mono_main_with_options (argc=3, argv=0x7fffffffd638) at main.c:28
#11 0x0000000000413cf9 in main (argc=3, argv=0x7fffffffd638) at main.c:176
```

This would lead to the main thread having handle value `0x1`, which is normally attributed to the FileStream for Console.Out. When trying to call `mono_threads_platform_set_exited` on the main thread, we would try to access handle `0x1` which wouldn't be found as it's a handle for a file, not a thread, leading to a SIGABRT:

```
#0  0x00007f9374de988d in __libc_waitpid (pid=<optimized out>, stat_loc=<optimized out>, options=<optimized out>) at ../sysdeps/unix/sysv/linux/waitpid.c:41
#1  0x000000000050efe9 in mono_handle_native_sigsegv (signal=6, ctx=0x7ffece5270c0, info=0x7ffece5271f0) at mini-exceptions.c:2424
#2  0x00000000005bde00 in sigabrt_signal_handler (_dummy=6, _info=0x7ffece5271f0, context=0x7ffece5270c0) at mini-posix.c:227
#3  <signal handler called>
#4  0x00007f937483b0d5 in __GI_raise (sig=<optimized out>) at ../nptl/sysdeps/unix/sysv/linux/raise.c:64
#5  0x00007f937483e83b in __GI_abort () at abort.c:91
#6  0x00000000007d05e7 in monoeg_log_default_handler (log_domain=0x0, log_level=G_LOG_LEVEL_ERROR, message=0x24ae300 "unknown thread handle 0x1", unused_data=0x0) at goutput.c:231
#7  0x00000000007d03d1 in monoeg_g_logv (log_domain=0x0, log_level=G_LOG_LEVEL_ERROR, format=0x89d128 "unknown thread handle %p", args=0x7ffece527838) at goutput.c:111
#8  0x00000000007d048a in monoeg_g_log (log_domain=0x0, log_level=G_LOG_LEVEL_ERROR, format=0x89d128 "unknown thread handle %p") at goutput.c:121
#9  0x00000000007c3a46 in mono_threads_platform_set_exited (info=0x2455a10) at mono-threads-posix.c:416
#10 0x00000000007c1895 in mono_thread_info_set_exited (info=0x2455a10) at mono-threads.c:1590
#11 0x0000000000692c61 in mono_thread_cleanup () at threads.c:2952
#12 0x00000000006bc98e in mono_runtime_cleanup (domain=0x2471ca0) at appdomain.c:399
#13 0x000000000041cbcb in mini_cleanup (domain=0x2471ca0) at mini-runtime.c:4061
#14 0x00000000004d5031 in mono_main (argc=3, argv=0x7ffece527c58) at driver.c:2152
#15 0x000000000041366b in mono_main_with_options (argc=3, argv=0x7ffece527c58) at main.c:28
#16 0x0000000000413cf9 in main (argc=3, argv=0x7ffece527c58) at main.c:176
```

cc @alexrp