### PR TITLE
Make GC bridge perform well in the "double fan" scenario

### DIFF
--- a/docs/sources/mono-api-gc.html
+++ b/docs/sources/mono-api-gc.html
@@ -40,9 +40,8 @@
 	<p>The output of the SCC analysis is passed to the
 	`cross_references()` callback.  It is expected to set the
 	`is_alive` flag on those strongly connected components that it
-	wishes to be kept alive.  Only bridged objects will be
-	reported to the callback, i.e., non-bridged objects are
-	removed from the callback graph.
+	wishes to be kept alive.  The value of `is_alive` will be
+	ignored on any SCCs which lack bridges.
 	
 	<p>In monodroid each bridged object has a corresponding Java
 	mirror object.  In the bridge callback it reifies the Mono
@@ -63,7 +62,7 @@
 
 <div class="mapi-header">
 enum {
-        SGEN_BRIDGE_VERSION = 4
+        SGEN_BRIDGE_VERSION = 5
 };
         
 typedef enum {

--- a/mono/metadata/sgen-bridge-internals.h
+++ b/mono/metadata/sgen-bridge-internals.h
@@ -37,6 +37,12 @@ gboolean sgen_bridge_handle_gc_debug (const char *opt);
 void sgen_bridge_print_gc_debug_usage (void);
 
 typedef struct {
+	char *dump_prefix;
+	gboolean accounting;
+	gboolean scc_precise_merge; // Used by Tarjan
+} SgenBridgeProcessorConfig;
+
+typedef struct {
 	void (*reset_data) (void);
 	void (*processing_stw_step) (void);
 	void (*processing_build_callback_data) (int generation);
@@ -44,10 +50,9 @@ typedef struct {
 	MonoGCBridgeObjectKind (*class_kind) (MonoClass *klass);
 	void (*register_finalized_object) (GCObject *object);
 	void (*describe_pointer) (GCObject *object);
-	void (*enable_accounting) (void);
 
-	// Optional-- used for debugging
-	void (*set_dump_prefix) (const char *prefix);
+	/* Should be called once, immediately after init */
+	void (*set_config) (const SgenBridgeProcessorConfig *);
 
 	/*
 	 * These are set by processing_build_callback_data().

--- a/mono/metadata/sgen-bridge-internals.h
+++ b/mono/metadata/sgen-bridge-internals.h
@@ -33,6 +33,7 @@ void sgen_bridge_describe_pointer (GCObject *object);
 gboolean sgen_is_bridge_object (GCObject *obj);
 void sgen_mark_bridge_object (GCObject *obj);
 
+gboolean sgen_bridge_handle_gc_param (const char *opt);
 gboolean sgen_bridge_handle_gc_debug (const char *opt);
 void sgen_bridge_print_gc_debug_usage (void);
 

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -666,6 +666,20 @@ register_test_bridge_callbacks (const char *bridge_class_name)
 }
 
 gboolean
+sgen_bridge_handle_gc_param (const char *opt)
+{
+	assert (!bridge_processor_started ());
+
+	if (!strcmp (opt, "bridge-require-precise-merge")) {
+		bridge_processor_config.scc_precise_merge = TRUE;
+	} else {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean
 sgen_bridge_handle_gc_debug (const char *opt)
 {
 	assert (!bridge_processor_started ());
@@ -675,8 +689,6 @@ sgen_bridge_handle_gc_debug (const char *opt)
 		register_test_bridge_callbacks (g_strdup (opt));
 	} else if (!strcmp (opt, "enable-bridge-accounting")) {
 		bridge_processor_config.accounting = TRUE;
-	} else if (!strcmp (opt, "enable-tarjan-precise-merge")) {
-		bridge_processor_config.scc_precise_merge = TRUE;
 	} else if (g_str_has_prefix (opt, "bridge-dump=")) {
 		char *prefix = strchr (opt, '=') + 1;
 		set_dump_prefix(prefix);

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -668,7 +668,7 @@ register_test_bridge_callbacks (const char *bridge_class_name)
 gboolean
 sgen_bridge_handle_gc_param (const char *opt)
 {
-	assert (!bridge_processor_started ());
+	g_assert (!bridge_processor_started ());
 
 	if (!strcmp (opt, "bridge-require-precise-merge")) {
 		bridge_processor_config.scc_precise_merge = TRUE;
@@ -682,7 +682,7 @@ sgen_bridge_handle_gc_param (const char *opt)
 gboolean
 sgen_bridge_handle_gc_debug (const char *opt)
 {
-	assert (!bridge_processor_started ());
+	g_assert (!bridge_processor_started ());
 
 	if (g_str_has_prefix (opt, "bridge=")) {
 		opt = strchr (opt, '=') + 1;

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -33,6 +33,8 @@ typedef enum {
 static BridgeProcessorSelection bridge_processor_selection = BRIDGE_PROCESSOR_DEFAULT;
 // Most recently requested callbacks
 static MonoGCBridgeCallbacks pending_bridge_callbacks;
+// Configuration to be passed to bridge processor after init
+static SgenBridgeProcessorConfig bridge_processor_config;
 // Currently-in-use callbacks
 MonoGCBridgeCallbacks bridge_callbacks;
 
@@ -84,6 +86,12 @@ bridge_processor_name (const char *name)
 	}
 }
 
+static gboolean
+bridge_processor_started ()
+{
+	return bridge_processor.reset_data != NULL;
+}
+
 // Initialize a single bridge processor
 static void
 init_bridge_processor (SgenBridgeProcessor *processor, BridgeProcessorSelection selection)
@@ -133,8 +141,16 @@ sgen_init_bridge ()
 		bridge_callbacks = pending_bridge_callbacks;
 
 		// If a bridge was registered but there is no bridge processor yet
-		if (bridge_callbacks.cross_references && !bridge_processor.reset_data)
+		if (bridge_callbacks.cross_references && !bridge_processor_started ()) {
 			init_bridge_processor (&bridge_processor, bridge_processor_selection);
+
+			if (bridge_processor.set_config)
+				bridge_processor.set_config (&bridge_processor_config);
+
+			// Config is no longer needed so free its memory
+			free (bridge_processor_config.dump_prefix);
+			bridge_processor_config.dump_prefix = NULL;
+		}
 
 		sgen_gc_unlock ();
 	}
@@ -147,7 +163,7 @@ sgen_set_bridge_implementation (const char *name)
 
 	if (selection == BRIDGE_PROCESSOR_INVALID)
 		g_warning ("Invalid value for bridge processor implementation, valid values are: 'new', 'old' and 'tarjan'.");
-	else if (bridge_processor.reset_data)
+	else if (bridge_processor_started ())
 		g_warning ("Cannot set bridge processor implementation once bridge has already started");
 	else
 		bridge_processor_selection = selection;
@@ -480,12 +496,9 @@ sgen_bridge_describe_pointer (GCObject *obj)
 static void
 set_dump_prefix (const char *prefix)
 {
-	if (!bridge_processor.set_dump_prefix) {
-		fprintf (stderr, "Warning: Bridge implementation does not support dumping - ignoring.\n");
-		return;
-	}
-
-	bridge_processor.set_dump_prefix (prefix);
+	if (bridge_processor_config.dump_prefix)
+		free (bridge_processor_config.dump_prefix);
+	bridge_processor_config.dump_prefix = strdup (prefix);
 }
 
 /* Test support code */
@@ -655,19 +668,24 @@ register_test_bridge_callbacks (const char *bridge_class_name)
 gboolean
 sgen_bridge_handle_gc_debug (const char *opt)
 {
+	assert (!bridge_processor_started ());
+
 	if (g_str_has_prefix (opt, "bridge=")) {
 		opt = strchr (opt, '=') + 1;
 		register_test_bridge_callbacks (g_strdup (opt));
 	} else if (!strcmp (opt, "enable-bridge-accounting")) {
-		bridge_processor.enable_accounting ();
+		bridge_processor_config.accounting = TRUE;
+	} else if (!strcmp (opt, "enable-tarjan-precise-merge")) {
+		bridge_processor_config.scc_precise_merge = TRUE;
 	} else if (g_str_has_prefix (opt, "bridge-dump=")) {
 		char *prefix = strchr (opt, '=') + 1;
-		set_dump_prefix (prefix);
+		set_dump_prefix(prefix);
 	} else if (g_str_has_prefix (opt, "bridge-compare-to=")) {
 		const char *name = strchr (opt, '=') + 1;
 		BridgeProcessorSelection selection = bridge_processor_name (name);
 
 		if (selection != BRIDGE_PROCESSOR_INVALID) {
+			// Compare processor doesn't get config
 			init_bridge_processor (&compare_to_bridge_processor, selection);
 		} else {
 			g_warning ("Invalid bridge implementation to compare against - ignoring.");

--- a/mono/metadata/sgen-bridge.h
+++ b/mono/metadata/sgen-bridge.h
@@ -17,8 +17,8 @@
  * When SGen is done marking, it puts together a list of all dead bridged
  * objects.  This is passed to the bridge processor, which does an analysis to
  * simplify the graph: It replaces strongly-connected components with single
- * nodes, and then removes any nodes corresponding to components which do not
- * contain bridged objects.
+ * nodes, and may remove nodes corresponding to components which do not contain
+ * bridged objects.
  *
  * The output of the SCC analysis is passed to the client's `cross_references()`
  * callback.  This consists of 2 arrays, an array of SCCs (MonoGCBridgeSCC),
@@ -54,7 +54,7 @@
 MONO_BEGIN_DECLS
 
 enum {
-	SGEN_BRIDGE_VERSION = 4
+	SGEN_BRIDGE_VERSION = 5
 };
 	
 typedef enum {

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2896,7 +2896,7 @@ sgen_client_handle_gc_param (const char *opt)
 	} else if (g_str_has_prefix (opt, "toggleref-test")) {
 		/* FIXME: This should probably in MONO_GC_DEBUG */
 		sgen_register_test_toggleref_callback ();
-	} else {
+	} else if (!sgen_bridge_handle_gc_param (opt)) {
 		return FALSE;
 	}
 	return TRUE;

--- a/mono/metadata/sgen-new-bridge.c
+++ b/mono/metadata/sgen-new-bridge.c
@@ -101,6 +101,8 @@ typedef struct _SCC {
 #endif
 } SCC;
 
+static char *dump_prefix = NULL;
+
 // Maps managed objects to corresponding HashEntry stricts
 static SgenHashTable hash_table = SGEN_HASH_TABLE_INIT (INTERNAL_MEM_BRIDGE_HASH_TABLE, INTERNAL_MEM_BRIDGE_HASH_TABLE_ENTRY, sizeof (HashEntry), mono_aligned_addr_hash, NULL);
 
@@ -161,11 +163,16 @@ dyn_array_int_contains (DynIntArray *da, int x)
 #endif
 
 static void
-enable_accounting (void)
+set_config (const SgenBridgeProcessorConfig *config)
 {
-	SgenHashTable table = SGEN_HASH_TABLE_INIT (INTERNAL_MEM_BRIDGE_HASH_TABLE, INTERNAL_MEM_BRIDGE_HASH_TABLE_ENTRY, sizeof (HashEntryWithAccounting), mono_aligned_addr_hash, NULL);
-	bridge_accounting_enabled = TRUE;
-	hash_table = table;
+	if (config->accounting) {
+		SgenHashTable table = SGEN_HASH_TABLE_INIT (INTERNAL_MEM_BRIDGE_HASH_TABLE, INTERNAL_MEM_BRIDGE_HASH_TABLE_ENTRY, sizeof (HashEntryWithAccounting), mono_aligned_addr_hash, NULL);
+		bridge_accounting_enabled = TRUE;
+		hash_table = table;
+	}
+	if (config->dump_prefix) {
+		dump_prefix = strdup (config->dump_prefix);
+	}
 }
 
 static MonoGCBridgeObjectKind
@@ -604,8 +611,6 @@ reset_flags (SCC *scc)
 }
 #endif
 
-static char *dump_prefix = NULL;
-
 static void
 dump_graph (void)
 {
@@ -655,12 +660,6 @@ dump_graph (void)
 	fprintf (file, "</graph></gexf>\n");
 
 	fclose (file);
-}
-
-static void
-set_dump_prefix (const char *prefix)
-{
-	dump_prefix = strdup (prefix);
 }
 
 static int
@@ -1087,8 +1086,7 @@ sgen_new_bridge_init (SgenBridgeProcessor *collector)
 	collector->class_kind = class_kind;
 	collector->register_finalized_object = register_finalized_object;
 	collector->describe_pointer = describe_pointer;
-	collector->enable_accounting = enable_accounting;
-	collector->set_dump_prefix = set_dump_prefix;
+	collector->set_config = set_config;
 
 	bridge_processor = collector;
 }

--- a/mono/metadata/sgen-old-bridge.c
+++ b/mono/metadata/sgen-old-bridge.c
@@ -372,11 +372,13 @@ dyn_array_int_merge_one (DynIntArray *array, int value)
 
 
 static void
-enable_accounting (void)
+set_config (const SgenBridgeProcessorConfig *config)
 {
-	SgenHashTable table = SGEN_HASH_TABLE_INIT (INTERNAL_MEM_BRIDGE_HASH_TABLE, INTERNAL_MEM_BRIDGE_HASH_TABLE_ENTRY, sizeof (HashEntryWithAccounting), mono_aligned_addr_hash, NULL);
-	bridge_accounting_enabled = TRUE;
-	hash_table = table;
+	if (config->accounting) {
+		SgenHashTable table = SGEN_HASH_TABLE_INIT (INTERNAL_MEM_BRIDGE_HASH_TABLE, INTERNAL_MEM_BRIDGE_HASH_TABLE_ENTRY, sizeof (HashEntryWithAccounting), mono_aligned_addr_hash, NULL);
+		bridge_accounting_enabled = TRUE;
+		hash_table = table;
+	}
 }
 
 static MonoGCBridgeObjectKind
@@ -922,7 +924,7 @@ sgen_old_bridge_init (SgenBridgeProcessor *collector)
 	collector->class_kind = class_kind;
 	collector->register_finalized_object = register_finalized_object;
 	collector->describe_pointer = describe_pointer;
-	collector->enable_accounting = enable_accounting;
+	collector->set_config = set_config;
 
 	bridge_processor = collector;
 }

--- a/mono/metadata/sgen-tarjan-bridge.c
+++ b/mono/metadata/sgen-tarjan-bridge.c
@@ -19,8 +19,6 @@
 
 #include "sgen/sgen-gc.h"
 #include "sgen-bridge-internals.h"
-#include "sgen/sgen-hash-table.h"
-#include "sgen/sgen-qsort.h"
 #include "tabledefs.h"
 #include "utils/mono-logger-internals.h"
 

--- a/mono/tests/sgen-bridge-pathologies.cs
+++ b/mono/tests/sgen-bridge-pathologies.cs
@@ -111,13 +111,29 @@ class Driver {
 		var heads = new Bridge [FAN_OUT];
 		for (int i = 0; i < FAN_OUT; ++i)
 			heads [i] = new Bridge ();
-		var multiplexer = new Bridge [FAN_OUT];
-		for (int i = 0; i < FAN_OUT; ++i)
-		{
-			heads [i].Links.Add (multiplexer);
-			multiplexer [i] = new Bridge ();
+
+		// We make five identical multiplexers to verify Tarjan-bridge can merge them together correctly.
+		var MULTIPLEXER_COUNT = 5;
+		Bridge[] multiplexer0 = null;
+		for(int m = 0; m < MULTIPLEXER_COUNT; m++) {
+			var multiplexer = new Bridge [FAN_OUT];
+			if (m == 0) {
+				multiplexer0 = multiplexer;
+				for (int i = 0; i < FAN_OUT; ++i)
+				{
+					heads [i].Links.Add (multiplexer);
+					multiplexer [i] = new Bridge ();
+				}
+			} else {
+				for (int i = 0; i < FAN_OUT; ++i)
+				{
+					heads [i].Links.Add (multiplexer);
+					multiplexer [i] = multiplexer0 [i];
+				}
+			}
 		}
-		Console.WriteLine ("-double fan done-");
+
+		Console.WriteLine ("-double fan x5 done-");
 	}
 
 	/*


### PR DESCRIPTION
The GC bridge currently performs VERY poorly when the object graph has a "double fan" shape. If M Java objects point to 1 C# object which points to N Java objects, the graph exported to Monodroid will currently drop the C# object node and replace it with (M\*N) edges. It is easy to write code where (M\*N) grows ludicrously big.

In testing on device, this patch solves that problem while leaving other cases unaffected. In testing on device, I found:
* All performance tests except double fan: No discernible performance difference after patch
* Double fan test with M=N=1000: Before the patch this took between three and seven seconds. After the patch this took between 0.2 and 0.3 seconds.
* Double fan test with M=N=4000: Before the patch this took anywhere from one to two minutes. After the patch, this took about 1.2 seconds.
* Double fan test with M=N=6000: Before the patch, this took so long I was not able to get it to ever complete. After the patch, this took about 1.3 seconds.
* Double fan test with M=N=20000: I did not attempt this test pre-patch. After the patch, it took about 5.6 seconds.

The commit messages describe the changes in some detail but the short version is:
* Add a mechanism for exporting non-bridged SCCs to the bridge client
* Turn that mechanism on whenever the product fanin*fanout grows too large
* Make the merge cache more aggressive

To function, this patch requires a corresponding change to monodroid. See https://github.com/xamarin/xamarin-android/pull/154