### PR TITLE
[runtime] test_op_il_seq_point.sh, test code and check determinism

### DIFF
--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -49,6 +49,20 @@ TMP_FILE2=$(tmp_file)
 echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_compile_dump $MONO_PATH $RUNTIME $TEST_FILE $USE_AOT)" >$TMP_FILE1
 echo "$(MONO_DEBUG=single-imm-size get_compile_dump $MONO_PATH $RUNTIME $TEST_FILE $USE_AOT)" >$TMP_FILE2
 
+LINE_DIFF_COUNT=$(diff -y --suppress-common-lines $TMP_FILE1 $TMP_FILE2 | grep '^' | wc -l)
+LINE_DIFF_COUNT_REF=0
+
+# Check if differences are due to JIT compiler beeing undeterminisc
+if [ $LINE_DIFF_COUNT != 0 ]; then
+	TMP_FILE1_REF=$(tmp_file)
+	echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_compile_dump $MONO_PATH $RUNTIME $TEST_FILE $USE_AOT)" >$TMP_FILE1_REF
+	LINE_DIFF_COUNT_REF=$(diff -y --suppress-common-lines $TMP_FILE1 $TMP_FILE1_REF| grep '^' | wc -l)
+	if [ $LINE_DIFF_COUNT_REF != 0 ]
+	then
+		$TMP_FILE2=$TMP_FILE1_REF
+	fi
+fi
+
 TMP_FILE=$(tmp_file)
 TMP_METHOD_DIFF_BAD=$(tmp_file)
 
@@ -76,39 +90,40 @@ awk \
 			break;
 		}
 	}
-}" $TMP_FILE > $TMP_METHOD_DIFF_BAD || (echo "awk failed" && echo "$(cat $TMP_METHOD_DIFF_BAD)" && exit 1)
+}" $TMP_FILE > $TMP_METHOD_DIFF_BAD || FAIL_MESSAGE_FILE=$TMP_METHOD_DIFF_BAD
+
+if [ $LINE_DIFF_COUNT_REF != 0 ]; then
+	FAIL_MESSAGE_FILE=$(tmp_file)
+	echo "Detected indeterministic JIT compilation on $TEST_FILE" >> $FAIL_MESSAGE_FILE
+	echo "  $LINE_DIFF_COUNT lines differ between compilations." >> $FAIL_MESSAGE_FILE
+	echo '  This is probably caused by a runtime optimization that is not deterministic' >> $FAIL_MESSAGE_FILE
+	echo '' >> $FAIL_MESSAGE_FILE
+	echo "$(cat $TMP_METHOD_DIFF_BAD)" >> $FAIL_MESSAGE_FILE
+elif [ $LINE_DIFF_COUNT != 0 ]; then
+	FAIL_MESSAGE_FILE=$(tmp_file)
+	echo "Detected OP_IL_SEQ_POINT incompatibility on $TEST_FILE" >> $FAIL_MESSAGE_FILE
+	echo "  $LINE_DIFF_COUNT lines differ when sequence points are enabled." >> $FAIL_MESSAGE_FILE
+	echo '  This is probably caused by a runtime optimization that is not handling OP_IL_SEQ_POINT' >> $FAIL_MESSAGE_FILE
+	echo '' >> $FAIL_MESSAGE_FILE
+	echo "Without IL_OP_SEQ_POINT                                                         With IL_OP_SEQ_POINT" >> $FAIL_MESSAGE_FILE
+	echo "$(cat $TMP_METHOD_DIFF_BAD)" >> $FAIL_MESSAGE_FILE
+fi
 
 TESTRESULT_FILE=TestResult-op_il_seq_point.tmp
-
 echo -n "              <test-case name=\"MonoTests.op_il_seq_point.${TEST_FILE}${USE_AOT}\" executed=\"True\" time=\"0\" asserts=\"0\" success=\"" >> $TESTRESULT_FILE
 
-LINE_DIFF_COUNT=$(diff -y --suppress-common-lines $TMP_FILE1 $TMP_FILE2 | grep '^' | wc -l)
-if [ $LINE_DIFF_COUNT != 0 ]
-then
+if [ $FAIL_MESSAGE_FILE ]; then
 	echo "False\">" >> $TESTRESULT_FILE
 	echo "                <failure>" >> $TESTRESULT_FILE
 	echo -n "                  <message><![CDATA[" >> $TESTRESULT_FILE
-	echo "Detected OP_IL_SEQ_POINT incompatibility on $TEST_FILE" >> $TESTRESULT_FILE
-	echo "  $LINE_DIFF_COUNT lines differ when sequence points are enabled." >> $TESTRESULT_FILE
-	echo '  This is probably caused by a runtime optimization that is not handling OP_IL_SEQ_POINT' >> $TESTRESULT_FILE
-	echo '' >> $TESTRESULT_FILE
-	echo "Without IL_OP_SEQ_POINT                                                         With IL_OP_SEQ_POINT" >> $TESTRESULT_FILE
-	echo "$(cat $TMP_METHOD_DIFF_BAD)" >> $TESTRESULT_FILE
+	echo "$(cat $FAIL_MESSAGE_FILE)" >> $TESTRESULT_FILE
 	echo "]]></message>" >> $TESTRESULT_FILE
 	echo "                  <stack-trace>" >> $TESTRESULT_FILE
 	echo "                  </stack-trace>" >> $TESTRESULT_FILE
 	echo "                </failure>" >> $TESTRESULT_FILE
 	echo "              </test-case>" >> $TESTRESULT_FILE
 
-	echo ''
-	echo "Detected OP_IL_SEQ_POINT incompatibility on $TEST_FILE"
-	echo "  $LINE_DIFF_COUNT lines differ when sequence points are enabled."
-	echo '  This is probably caused by a runtime optimization that is not handling OP_IL_SEQ_POINT'
-
-	echo ''
-	echo "Without IL_OP_SEQ_POINT                                                         With IL_OP_SEQ_POINT"
-	echo "$(cat $TMP_METHOD_DIFF_BAD)"
-
+	echo "$(cat $FAIL_MESSAGE_FILE)"
 	exit 1
 else
 	echo "True\" />" >> $TESTRESULT_FILE

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -29,46 +29,13 @@ clean_aot () {
 # In some architectures ie:amd64 when possible 32bit instructions and registers are used instead of 64bit ones.
 # Using MONO_DEBUG=single-imm-size avoids 32bit optimizations thus mantaining the native code size between compilations.
 
-get_methods () {
+get_compile_dump () {
 	if [ -z $4 ]; then
-		MONO_PATH=$1 $2 -v --compile-all=1 $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
+		MONO_PATH=$1 $2 -v -v -O=all --compile-all=1 $3
 	else
 		clean_aot
-		MONO_PATH=$1 $2 -v --aot $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
-	fi
-}
-
-get_method () {
-	if [ -z $5 ]; then
-		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 --compile-all=1 $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
-	else
-		clean_aot
-		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 --aot $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
-	fi
-}
-
-diff_methods () {
-	TMP_FILE1=$(tmp_file)
-	TMP_FILE2=$(tmp_file)
-	echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE1
-	echo "$(MONO_DEBUG=single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE2
-	diff $TMP_FILE1 $TMP_FILE2
-}
-
-diff_method () {
-	TMP_FILE1=$(tmp_file)
-	TMP_FILE2=$(tmp_file)
-	echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_method $1 $2 $3 $4 $5)" >$TMP_FILE1
-	echo "$(MONO_DEBUG=single-imm-size get_method $1 $2 $3 $4 $5 | grep -Ev il_seq_point)" >$TMP_FILE2
-	sdiff -w 150 $TMP_FILE1 $TMP_FILE2
-}
-
-get_method_name () {
-	echo $1 | sed -E 's/.*Method (\([^)]*\) )?([^ ]*).*/\2/g'
-}
-
-get_method_length () {
-	echo $1 | sed 's/.*code length \([0-9]*\).*/\1/'
+		MONO_PATH=$1 $2 -v -v -O=all --aot $3
+	fi | grep  '^Method .* (code length\|^0[0-9a-f]\+' | sed 's/0x[0-9a-fA-F]*/0x0/g'
 }
 
 if [ -z $USE_AOT ]; then
@@ -77,46 +44,56 @@ else
 	echo "Checking unintended native code changes in $TEST_FILE with AOT"
 fi
 
+TMP_FILE1=$(tmp_file)
+TMP_FILE2=$(tmp_file)
+echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_compile_dump $MONO_PATH $RUNTIME $TEST_FILE $USE_AOT)" >$TMP_FILE1
+echo "$(MONO_DEBUG=single-imm-size get_compile_dump $MONO_PATH $RUNTIME $TEST_FILE $USE_AOT)" >$TMP_FILE2
+
 TMP_FILE=$(tmp_file)
+TMP_METHOD_DIFF_BAD=$(tmp_file)
 
-echo "$(diff_methods $MONO_PATH $RUNTIME $TEST_FILE $USE_AOT)" > $TMP_FILE
+SDIFF_WIDTH=150
+SDIFF_SEP_POS=$(expr $SDIFF_WIDTH / 2 - 1)
 
-CHANGES=0
-METHOD=""
-MIN_SIZE=10000
+sdiff -w $SDIFF_WIDTH $TMP_FILE1 $TMP_FILE2 |
+	expand -t 8                   | # Replacing tabs is required for the awk regex to work
+	sed 's/^Method/@&/' > $TMP_FILE # Add @ before each method so awk can use it as record separator
 
-while read line; do
-	if [ "$line" != "" ]; then
-		echo $line
-		if [[ ${line:0:1} == "<" ]]; then
-			CHANGES=$((CHANGES+1))
-			SIZE=$(get_method_length "$line")
-			if [[ SIZE -lt MIN_SIZE ]]; then
-				MIN_SIZE=$SIZE
-				METHOD="$line"
-			fi
-		fi
-	fi
-done < $TMP_FILE
+# Use awk to print records that include differences
+# Using @ as RS because BSD awk ignores all characters after the first one.
+awk \
+"{
+	RS=\"@\";
+	FS=\"\n\";
+	if(NF<=2) {
+		print \$0;
+		print \"ERROR: Method native code not found.\"
+		exit 1;
+	}
+	for(i=1; i<=NF; i++) {
+		if (match(\$i, /^.{$SDIFF_SEP_POS}[^ ]/)) {
+			print \$0;
+			break;
+		}
+	}
+}" $TMP_FILE > $TMP_METHOD_DIFF_BAD || (echo "awk failed" && echo "$(cat $TMP_METHOD_DIFF_BAD)" && exit 1)
 
 TESTRESULT_FILE=TestResult-op_il_seq_point.tmp
 
 echo -n "              <test-case name=\"MonoTests.op_il_seq_point.${TEST_FILE}${USE_AOT}\" executed=\"True\" time=\"0\" asserts=\"0\" success=\"" >> $TESTRESULT_FILE
 
-if [ $CHANGES != 0 ]
+LINE_DIFF_COUNT=$(diff -y --suppress-common-lines $TMP_FILE1 $TMP_FILE2 | grep '^' | wc -l)
+if [ $LINE_DIFF_COUNT != 0 ]
 then
-	METHOD_NAME=$(get_method_name "$METHOD")
-
 	echo "False\">" >> $TESTRESULT_FILE
 	echo "                <failure>" >> $TESTRESULT_FILE
 	echo -n "                  <message><![CDATA[" >> $TESTRESULT_FILE
 	echo "Detected OP_IL_SEQ_POINT incompatibility on $TEST_FILE" >> $TESTRESULT_FILE
-	echo "  $CHANGES methods differ when sequence points are enabled." >> $TESTRESULT_FILE
+	echo "  $LINE_DIFF_COUNT lines differ when sequence points are enabled." >> $TESTRESULT_FILE
 	echo '  This is probably caused by a runtime optimization that is not handling OP_IL_SEQ_POINT' >> $TESTRESULT_FILE
 	echo '' >> $TESTRESULT_FILE
-	echo "Diff $METHOD_NAME" >> $TESTRESULT_FILE
 	echo "Without IL_OP_SEQ_POINT                                                         With IL_OP_SEQ_POINT" >> $TESTRESULT_FILE
-	echo -n "$(diff_method $MONO_PATH $RUNTIME $TEST_FILE $METHOD_NAME $USE_AOT)" >> $TESTRESULT_FILE
+	echo "$(cat $TMP_METHOD_DIFF_BAD)" >> $TESTRESULT_FILE
 	echo "]]></message>" >> $TESTRESULT_FILE
 	echo "                  <stack-trace>" >> $TESTRESULT_FILE
 	echo "                  </stack-trace>" >> $TESTRESULT_FILE
@@ -125,13 +102,13 @@ then
 
 	echo ''
 	echo "Detected OP_IL_SEQ_POINT incompatibility on $TEST_FILE"
-	echo "  $CHANGES methods differ when sequence points are enabled."
+	echo "  $LINE_DIFF_COUNT lines differ when sequence points are enabled."
 	echo '  This is probably caused by a runtime optimization that is not handling OP_IL_SEQ_POINT'
 
 	echo ''
-	echo "Diff $METHOD_NAME"
 	echo "Without IL_OP_SEQ_POINT                                                         With IL_OP_SEQ_POINT"
-	echo "$(diff_method $MONO_PATH $RUNTIME $TEST_FILE $METHOD_NAME $USE_AOT)"
+	echo "$(cat $TMP_METHOD_DIFF_BAD)"
+
 	exit 1
 else
 	echo "True\" />" >> $TESTRESULT_FILE


### PR DESCRIPTION
test_op_il_seq_point.sh was only checking generated native assembly for
size mismatches. Nonetheless some optimizations may produce different
native assembly with the same size.

When mismatches are found between compilation with and without
OP_IL_SEQ_POINTS, now the script checks it is not due to indeterministic
JIT compilations.