### PR TITLE
Fixes DllNotFoundException in FileStreamTest.SetUp() on Windows

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
@@ -25,10 +25,6 @@ namespace MonoTests.System.IO
 	{
 		string TempFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
 		static readonly char DSC = Path.DirectorySeparatorChar;
-		static bool MacOSX = false;
-
-		[DllImport ("libc")]
-		static extern int uname (IntPtr buf);
 
 		[TearDown]
 		public void TearDown ()
@@ -44,13 +40,6 @@ namespace MonoTests.System.IO
 				Directory.Delete (TempFolder, true);
 
 			Directory.CreateDirectory (TempFolder);
-#if !MOBILE			
-			// from XplatUI.cs
-			IntPtr buf = Marshal.AllocHGlobal (8192);
-			if (uname (buf) == 0)
-				MacOSX = Marshal.PtrToStringAnsi (buf) == "Darwin";
-			Marshal.FreeHGlobal (buf);
-#endif
 		}
 
 		public void TestCtr ()


### PR DESCRIPTION
SetUp() calls uname() in libc to check whether the test is running on OS X. On Windows this fails since libc isn't available.

This patch removes the call to uname() completely since the result wasn't used by the test anyway.