### PR TITLE
[xbuild] Fix incremental build of TargetFrameworkAttribute

### DIFF
--- a/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/12.0/Microsoft.Common.targets
@@ -263,11 +263,10 @@
 		<FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
 	</ItemGroup>
 
-	<Target Name="GenerateTargetFrameworkMonikerAttribute"
+	<Target Name="_GenerateTargetFrameworkMonikerAttribute"
 		DependsOnTargets="PrepareForBuild;GetReferenceAssemblyPaths"
 		Inputs="$(MSBuildToolsPath)\Microsoft.Common.targets"
-		Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)"
-		Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
+		Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)">
 
 		<WriteLinesToFile
 			File="$(TargetFrameworkMonikerAssemblyAttributesPath)"
@@ -276,6 +275,11 @@
 			ContinueOnError="true"
 			Condition="'@(Compile)' != '' and '$(TargetFrameworkMonikerAssemblyAttributeText)' != ''"
 		/>
+	</Target>
+
+	<Target Name="GenerateTargetFrameworkMonikerAttribute"
+		DependsOnTargets="_GenerateTargetFrameworkMonikerAttribute"
+		Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
 
 		<ItemGroup Condition="'@(Compile)' != '' and '$(TargetFrameworkMonikerAssemblyAttributeText)' != ''">
 			<Compile Include="$(TargetFrameworkMonikerAssemblyAttributesPath)"/>

--- a/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/14.0/Microsoft.Common.targets
@@ -265,11 +265,10 @@
 		<FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
 	</ItemGroup>
 
-	<Target Name="GenerateTargetFrameworkMonikerAttribute"
+	<Target Name="_GenerateTargetFrameworkMonikerAttribute"
 		DependsOnTargets="PrepareForBuild;GetReferenceAssemblyPaths"
 		Inputs="$(MSBuildToolsPath)\Microsoft.Common.targets"
-		Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)"
-		Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
+		Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)">
 
 		<WriteLinesToFile
 			File="$(TargetFrameworkMonikerAssemblyAttributesPath)"
@@ -278,6 +277,11 @@
 			ContinueOnError="true"
 			Condition="'@(Compile)' != '' and '$(TargetFrameworkMonikerAssemblyAttributeText)' != ''"
 		/>
+	</Target>
+
+	<Target Name="GenerateTargetFrameworkMonikerAttribute"
+		DependsOnTargets="_GenerateTargetFrameworkMonikerAttribute"
+		Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
 
 		<ItemGroup Condition="'@(Compile)' != '' and '$(TargetFrameworkMonikerAssemblyAttributeText)' != ''">
 			<Compile Include="$(TargetFrameworkMonikerAssemblyAttributesPath)"/>

--- a/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets
+++ b/mcs/tools/xbuild/data/4.0/Microsoft.Common.targets
@@ -263,11 +263,10 @@
 		<FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
 	</ItemGroup>
 
-	<Target Name="GenerateTargetFrameworkMonikerAttribute"
+	<Target Name="_GenerateTargetFrameworkMonikerAttribute"
 		DependsOnTargets="PrepareForBuild;GetReferenceAssemblyPaths"
 		Inputs="$(MSBuildToolsPath)\Microsoft.Common.targets"
-		Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)"
-		Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
+		Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)">
 
 		<WriteLinesToFile
 			File="$(TargetFrameworkMonikerAssemblyAttributesPath)"
@@ -276,6 +275,11 @@
 			ContinueOnError="true"
 			Condition="'@(Compile)' != '' and '$(TargetFrameworkMonikerAssemblyAttributeText)' != ''"
 		/>
+	</Target>
+
+	<Target Name="GenerateTargetFrameworkMonikerAttribute"
+		DependsOnTargets="_GenerateTargetFrameworkMonikerAttribute"
+		Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
 
 		<ItemGroup Condition="'@(Compile)' != '' and '$(TargetFrameworkMonikerAssemblyAttributeText)' != ''">
 			<Compile Include="$(TargetFrameworkMonikerAssemblyAttributesPath)"/>


### PR DESCRIPTION
The targets depended on a feature that doesn't exist in
xbuild (https://bugzilla.xamarin.com/show_bug.cgi?id=43645)
and as a consequence would fail to add the generated file to
the build when the GenerateTargetFrameworkMonikerAttribute
target was up to date.