### PR TITLE
Don't assume "3 5" is unparseable in the current culture in DoubleTest.Parse()

### DIFF
--- a/mcs/class/corlib/Test/System/DoubleTest.cs
+++ b/mcs/class/corlib/Test/System/DoubleTest.cs
@@ -147,6 +147,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Culture ("en-US")]
 		public void Parse ()
 		{
 			int i = 0;


### PR DESCRIPTION
DoubleTest.Parse() expects "3 5" to be unparseable in the current culture and expects an exception to be thrown. In sv-SE however "3 5" parses to 35 and this test fails.

This patch sets the current culture to en-US around the assertions in the DoubleTest.Parse() test.