### PR TITLE
[linker] Mark declaring types of nested types resolved from xml descriptors. Fixes #43658.

### DIFF
--- a/mcs/tools/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
+++ b/mcs/tools/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
@@ -174,6 +174,14 @@ namespace Mono.Linker.Steps {
 
 			Annotations.Mark (type);
 
+			if (type.IsNested) {
+				var parent = type;
+				while (parent.IsNested) {
+					parent = parent.DeclaringType;
+					Annotations.Mark (parent);
+				}
+			}
+
 			switch (preserve) {
 			case TypePreserve.Nothing:
 				if (!nav.HasChildren)


### PR DESCRIPTION
If the declaring type of a nested type marked by an xml descriptor
is not otherwise marked, the members of the nested type will not
be preserved, because the linker will not process the nested type
(since the parent type isn't marked, MarkStep:InitializeAssembly
will skip it, and thus skip all its nested types as well).

https://bugzilla.xamarin.com/show_bug.cgi?id=43658