### PR TITLE
Fix for DirectoryInfoTest assuming current dir is C:\ on Windows

### DIFF
--- a/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
@@ -168,6 +168,8 @@ namespace MonoTests.System.IO
 					info = new DirectoryInfo ("/test/");
 					Assert.AreEqual ("test", info.Name, "#4");
 				} else {
+					Directory.SetCurrentDirectory (@"C:\");
+
 					info = new DirectoryInfo (@"c:");
 					Assert.AreEqual (@"C:\", info.Name, "#4");
 
@@ -217,6 +219,8 @@ namespace MonoTests.System.IO
 					Assert.IsNotNull (info.Parent, "#7a");
 					Assert.AreEqual ("/", info.Parent.FullName, "#7b");
 				} else {
+					Directory.SetCurrentDirectory (@"C:\");
+
 					info = new DirectoryInfo (@"c:");
 					Assert.IsNull (info.Parent, "#4");
 
@@ -418,6 +422,8 @@ namespace MonoTests.System.IO
 				di = new DirectoryInfo ("/test/");
 				Assert.AreEqual ("/test/", di.FullName, "#D4");
 			} else {
+				Directory.SetCurrentDirectory (@"C:\");
+
 				di = new DirectoryInfo (@"c:");
 				Assert.AreEqual (@"C:\", di.FullName, "#D1");
 


### PR DESCRIPTION
This test assumes that `new DirectoryInfo (@"c:").Name == "C:\"` when run on Windows but the actual value depends on the current directory. If current dir is C:\temp the Name property will return "temp". Similar problem in the FullName() and Parent() tests.

This patch sets the current directory to C:\ explicitly before running the failing tests on Windows. The current dir is reset in TearDown().