### PR TITLE
Path.CleanPath() does not always replace AltDirectorySeparatorChar

### DIFF
--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -140,6 +140,7 @@ namespace System.IO {
 		{
 			int l = s.Length;
 			int sub = 0;
+			int alt = 0;
 			int start = 0;
 
 			// Host prefix?
@@ -158,6 +159,8 @@ namespace System.IO {
 				
 				if (c != DirectorySeparatorChar && c != AltDirectorySeparatorChar)
 					continue;
+				if (DirectorySeparatorChar != AltDirectorySeparatorChar && c == AltDirectorySeparatorChar)
+					alt++;
 				if (i+1 == l)
 					sub++;
 				else {
@@ -167,7 +170,7 @@ namespace System.IO {
 				}
 			}
 
-			if (sub == 0)
+			if (sub == 0 && alt == 0)
 				return s;
 
 			char [] copy = new char [l-sub];

--- a/mcs/class/corlib/Test/System.IO/PathTest.cs
+++ b/mcs/class/corlib/Test/System.IO/PathTest.cs
@@ -37,6 +37,7 @@ namespace MonoTests.System.IO
 		static string path3;
 		static OsType OS;
 		static char DSC = Path.DirectorySeparatorChar;
+		static char ADSC = Path.AltDirectorySeparatorChar;
 
 		[SetUp]
 		public void SetUp ()
@@ -357,6 +358,12 @@ namespace MonoTests.System.IO
 				Assert.IsNotNull (ex.Message, "#4");
 				Assert.IsNull (ex.ParamName, "#5");
 			}
+		}
+
+		[Test]
+		public void GetDirectoryName_Replaces_AltDirectorySeparatorChar ()
+		{
+			Assert.AreEqual ($"foo{DSC}bar", Path.GetDirectoryName ($"foo{ADSC}bar{ADSC}dingus"), "#1");
 		}
 
 		[Test]


### PR DESCRIPTION
If `sub == 0`, i.e. there are no repeated separators, this method just returns the input string. On Windows, where `DirectorySeparatorChar` (\\) is different from `AltDirectorySeparatorChar` (/), this means that the call

```c#
    Path.GetDirectoryName ("foo/bar/dingus")
```

won't return "foo\bar" as .NET would but rather returns "foo/bar".

This patch makes sure the '/' -> '\' conversion is run when `AltDirectorySeparatorChar` characters have been seen in the input string, even if `sub == 0`.

PathTest.GetDirectoryName() triggered this bug.