### PR TITLE
FileInfo.MoveTo() throws DirectoryNotFoundException rather than FileNotFoundException on Windows when target doesn't exist

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileInfoTest.cs
@@ -758,9 +758,9 @@ namespace MonoTests.System.IO
 				try {
 					info.MoveTo (destFile);
 					Assert.Fail ("#1");
-				} catch (FileNotFoundException ex) {
+				} catch (DirectoryNotFoundException ex) {
 					// Could not find a part of the path
-					Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
+					Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#2");
 					Assert.IsNull (ex.InnerException, "#3");
 					Assert.IsNotNull (ex.Message, "#4");
 				}

--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -1994,9 +1994,14 @@ gboolean MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 		case EXDEV:
 			/* Ignore here, it is dealt with below */
 			break;
-			
+
+		case ENOENT:
+			/* We already know src exists. Must be dest that doesn't exist. */
+			_wapi_set_last_path_error_from_errno (NULL, utf8_dest_name);
+			break;
+
 		default:
-			_wapi_set_last_path_error_from_errno (NULL, utf8_name);
+			_wapi_set_last_error_from_errno ();
 		}
 	}
 	


### PR DESCRIPTION
FileInfoTest.MoveTo_DestFileName_DirectoryDoesNotExist() expects FileNotFoundException to be thrown but on Windows a DirectoryNotFoundException is thrown instead.

This patch adds a catch clause for DirectoryNotFoundException to the test. The docs for FileInfo.MoveTo() declares that both FileNotFoundException and DirectoryNotFoundException may be thrown and the same test throws DirectoryNotFoundException on .NET.