### PR TITLE
[mono-threads] Create Win32 handle when attaching the thread

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -43,7 +43,6 @@
 #include <metadata/threads.h>
 #include <metadata/profiler-private.h>
 #include <mono/metadata/coree.h>
-#include <mono/utils/w32handle.h>
 
 //#define DEBUG_DOMAIN_UNLOAD 1
 
@@ -526,7 +525,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 #endif
 
 #ifndef HOST_WIN32
-	mono_w32handle_init ();
 	wapi_init ();
 #endif
 
@@ -895,7 +893,6 @@ mono_cleanup (void)
 
 #ifndef HOST_WIN32
 	wapi_cleanup ();
-	mono_w32handle_cleanup ();
 #endif
 }
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -52,6 +52,7 @@
 #include "mono/utils/mono-counters.h"
 #include "mono/utils/mono-hwcap.h"
 #include "mono/utils/mono-logger-internals.h"
+#include "mono/utils/w32handle.h"
 
 #include "mini.h"
 #include "jit.h"
@@ -1961,6 +1962,10 @@ mono_main (int argc, char* argv[])
 	}
 
 	mono_counters_init ();
+
+#ifndef HOST_WIN32
+	mono_w32handle_init ();
+#endif
 
 	/* Set rootdir before loading config */
 	mono_set_rootdir ();

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -65,6 +65,7 @@
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/checked-build.h>
+#include <mono/utils/w32handle.h>
 #include <mono/io-layer/io-layer.h>
 
 #include "mini.h"
@@ -3569,6 +3570,10 @@ mini_init (const char *filename, const char *runtime_version)
 
 	mono_counters_init ();
 
+#ifndef HOST_WIN32
+	mono_w32handle_init ();
+#endif
+
 	mono_threads_runtime_init (&ticallbacks);
 
 	if (g_getenv ("MONO_DEBUG") != NULL)
@@ -4109,6 +4114,10 @@ mini_cleanup (MonoDomain *domain)
 	mono_os_mutex_destroy (&jit_mutex);
 
 	mono_code_manager_cleanup ();
+
+#ifndef HOST_WIN32
+	mono_w32handle_cleanup ();
+#endif
 }
 
 void

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -121,8 +121,6 @@ mono_threads_suspend_begin_async_resume (MonoThreadInfo *info)
 void
 mono_threads_suspend_register (MonoThreadInfo *info)
 {
-	g_assert (!info->handle);
-	info->handle = mono_threads_platform_open_handle();
 }
 
 void
@@ -134,6 +132,22 @@ mono_threads_suspend_free (MonoThreadInfo *info)
 
 #if defined (HOST_WIN32)
 
+void
+mono_threads_platform_register (MonoThreadInfo *info)
+{
+	HANDLE thread_handle;
+
+	thread_handle = GetCurrentThread ();
+	g_assert (thread_handle);
+
+	/* The handle returned by GetCurrentThread () is a pseudo handle, so it can't
+	 * be used to refer to the thread from other threads for things like aborting. */
+	DuplicateHandle (GetCurrentProcess (), thread_handle, GetCurrentProcess (), &thread_handle, THREAD_ALL_ACCESS, TRUE, 0);
+
+	g_assert (!info->handle);
+	info->handle = thread_handle;
+}
+
 typedef struct {
 	LPTHREAD_START_ROUTINE start_routine;
 	void *arg;
@@ -141,6 +155,7 @@ typedef struct {
 	MonoCoopSem registered;
 	gboolean suspend;
 	HANDLE suspend_event;
+	HANDLE handle;
 } ThreadStartInfo;
 
 static DWORD WINAPI
@@ -148,7 +163,6 @@ inner_start_thread (LPVOID arg)
 {
 	ThreadStartInfo *start_info = arg;
 	void *t_arg = start_info->arg;
-	int post_result;
 	LPTHREAD_START_ROUTINE start_func = start_info->start_routine;
 	DWORD result;
 	gboolean suspend = start_info->suspend;
@@ -158,6 +172,8 @@ inner_start_thread (LPVOID arg)
 	info = mono_thread_info_attach (&result);
 	info->runtime_thread = TRUE;
 	info->create_suspended = suspend;
+
+	start_info->handle = info->handle;
 
 	mono_threads_platform_set_priority(info, start_info->priority);
 
@@ -203,6 +219,10 @@ mono_threads_platform_create_thread (MonoThreadStart start_routine, gpointer arg
 	if (result) {
 		res = mono_coop_sem_wait (&(start_info->registered), MONO_SEM_FLAGS_NONE);
 		g_assert (res != -1);
+
+		/* A new handle has been opened when attaching
+		 * the thread, so we don't need this one */
+		CloseHandle (result);
 
 		if (start_info->suspend) {
 			g_assert (SuspendThread (result) != (DWORD)-1);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -373,6 +373,7 @@ register_thread (MonoThreadInfo *info, gpointer baseptr)
 
 	info->stackdata = g_byte_array_new ();
 
+	mono_threads_platform_register (info);
 	mono_threads_suspend_register (info);
 
 	/*

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -536,12 +536,13 @@ void mono_threads_suspend_free (THREAD_INFO_TYPE *info);
 void mono_threads_suspend_abort_syscall (THREAD_INFO_TYPE *info);
 gboolean mono_threads_suspend_needs_abort_syscall (void);
 
+void mono_threads_platform_register (THREAD_INFO_TYPE *info);
+void mono_threads_platform_unregister (THREAD_INFO_TYPE *info);
 HANDLE mono_threads_platform_create_thread (MonoThreadStart start, gpointer arg, MonoThreadParm *, MonoNativeThreadId *out_tid);
 void mono_threads_platform_resume_created (THREAD_INFO_TYPE *info, MonoNativeThreadId tid);
 void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
 gboolean mono_threads_platform_yield (void);
 void mono_threads_platform_exit (int exit_code);
-void mono_threads_platform_unregister (THREAD_INFO_TYPE *info);
 HANDLE mono_threads_platform_open_handle (void);
 HANDLE mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid);
 void mono_threads_platform_set_exited (THREAD_INFO_TYPE *info);

--- a/mono/utils/w32handle.c
+++ b/mono/utils/w32handle.c
@@ -293,6 +293,11 @@ mono_w32handle_unlock_handle (gpointer handle)
 void
 mono_w32handle_init (void)
 {
+	static gboolean initialized = FALSE;
+
+	if (initialized)
+		return;
+
 	g_assert ((sizeof (handle_ops) / sizeof (handle_ops[0]))
 		  == MONO_W32HANDLE_COUNT);
 
@@ -313,6 +318,8 @@ mono_w32handle_init (void)
 
 	mono_os_cond_init (&global_signal_cond);
 	mono_os_mutex_init (&global_signal_mutex);
+
+	initialized = TRUE;
 }
 
 static void mono_w32handle_unref_full (gpointer handle, gboolean ignore_private_busy_handles);

--- a/mono/utils/w32handle.c
+++ b/mono/utils/w32handle.c
@@ -357,8 +357,6 @@ mono_w32handle_cleanup (void)
 static void mono_w32handle_init_handle (MonoW32HandleBase *handle,
 			       MonoW32HandleType type, gpointer handle_specific)
 {
-	g_assert (!shutting_down);
-	
 	handle->type = type;
 	handle->signalled = FALSE;
 	handle->ref = 1;
@@ -384,8 +382,6 @@ static guint32 mono_w32handle_new_internal (MonoW32HandleType type,
 	guint32 i, k, count;
 	static guint32 last = 0;
 	gboolean retry = FALSE;
-	
-	g_assert (!shutting_down);
 	
 	/* A linear scan should be fast enough.  Start from the last
 	 * allocation, assuming that handles are allocated more often


### PR DESCRIPTION
This guarantee that a MonoThreadInfo always has a handle.