### PR TITLE
[runtime] Remove most of the contents of MonoDynamicGenericClass, the…

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -529,8 +529,9 @@ struct _MonoMethodInflated {
 struct _MonoGenericClass {
 	MonoClass *container_class;	/* the generic type definition */
 	MonoGenericContext context;	/* a context that contains the type instantiation doesn't contain any method instantiation */ /* FIXME: Only the class_inst member of "context" is ever used, so this field could be replaced with just a monogenericinst */
-	guint is_dynamic  : 1;		/* We're a MonoDynamicGenericClass */
+	guint is_dynamic  : 1;		/* Contains dynamic types */
 	guint is_tb_open  : 1;		/* This is the fully open instantiation for a type_builder. Quite ugly, but it's temporary.*/
+	guint need_sync   : 1;      /* Only if dynamic. Need to be synchronized with its container class after its finished. */
 	MonoClass *cached_class;	/* if present, the MonoClass corresponding to the instantiation.  */
 
 	/* 
@@ -539,15 +540,6 @@ struct _MonoGenericClass {
 	 * so it is easy to free.
 	 */
 	MonoImageSet *owner;
-};
-
-/*
- * This is used when instantiating a generic type definition which is
- * a TypeBuilder.
- */
-struct _MonoDynamicGenericClass {
-	MonoGenericClass generic_class;
-	guint initialized;
 };
 
 /*

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -547,13 +547,7 @@ struct _MonoGenericClass {
  */
 struct _MonoDynamicGenericClass {
 	MonoGenericClass generic_class;
-	int count_fields;
-	MonoClassField *fields;
 	guint initialized;
-	/* The non-inflated types of the fields */
-	MonoType **field_generic_types;
-	/* The managed objects representing the fields */
-	MonoObject **field_objects;
 };
 
 /*

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2806,8 +2806,6 @@ static void
 free_generic_class (MonoGenericClass *gclass)
 {
 	/* The gclass itself is allocated from the image set mempool */
-	if (gclass->is_dynamic)
-		mono_reflection_free_dynamic_generic_class (gclass);
 	if (gclass->cached_class && gclass->cached_class->interface_id)
 		mono_unload_interface_id (gclass->cached_class);
 }

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2982,13 +2982,9 @@ mono_metadata_lookup_generic_class (MonoClass *container_class, MonoGenericInst 
 		return gclass;
 	}
 
-	if (is_dynamic) {
-		MonoDynamicGenericClass *dgclass = mono_image_set_new0 (set, MonoDynamicGenericClass, 1);
-		gclass = &dgclass->generic_class;
+	gclass = mono_image_set_new0 (set, MonoGenericClass, 1);
+	if (is_dynamic)
 		gclass->is_dynamic = 1;
-	} else {
-		gclass = mono_image_set_new0 (set, MonoGenericClass, 1);
-	}
 
 	gclass->is_tb_open = is_tb_open;
 	gclass->container_class = container_class;

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -284,7 +284,6 @@ typedef struct {
 typedef struct _MonoType MonoType;
 typedef struct _MonoGenericInst MonoGenericInst;
 typedef struct _MonoGenericClass MonoGenericClass;
-typedef struct _MonoDynamicGenericClass MonoDynamicGenericClass;
 typedef struct _MonoGenericContext MonoGenericContext;
 typedef struct _MonoGenericContainer MonoGenericContainer;
 typedef struct _MonoGenericParam MonoGenericParam;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1396,9 +1396,6 @@ ves_icall_System_Reflection_CustomAttributeData_ResolveArgumentsInternal (MonoRe
 MonoType*
 mono_reflection_type_get_handle (MonoReflectionType *ref, MonoError *error);
 
-void
-mono_reflection_free_dynamic_generic_class (MonoGenericClass *gclass);
-
 gboolean
 mono_image_build_metadata (MonoReflectionModuleBuilder *module, MonoError *error);
 

--- a/mono/metadata/sre-internals.h
+++ b/mono/metadata/sre-internals.h
@@ -69,9 +69,6 @@ gboolean
 mono_is_sre_ctor_on_tb_inst (MonoClass *klass);
 
 gboolean
-mono_is_sr_field_on_inst (MonoClassField *field);
-
-gboolean
 mono_is_sr_mono_cmethod (MonoClass *klass);
 
 gboolean
@@ -82,9 +79,6 @@ mono_reflection_create_generic_class (MonoReflectionTypeBuilder *tb, MonoError *
 
 MonoMethod*
 mono_reflection_method_builder_to_mono_method (MonoReflectionMethodBuilder *mb, MonoError *error);
-
-MonoType*
-mono_reflection_get_field_on_inst_generic_type (MonoClassField *field);
 
 MonoMethod*
 mono_reflection_method_on_tb_inst_get_handle (MonoReflectionMethodOnTypeBuilderInst *m, MonoError *error);

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1749,8 +1749,6 @@ fixup_method (MonoReflectionILGen *ilgen, gpointer value, MonoDynamicImage *asse
 			} else if (!strcmp (iltoken->member->vtable->klass->name, "FieldBuilder")) {
 				continue;
 			} else if (!strcmp (iltoken->member->vtable->klass->name, "MonoField")) {
-				MonoClassField *f = ((MonoReflectionField*)iltoken->member)->field;
-				g_assert (mono_is_sr_field_on_inst (f));
 				continue;
 			} else if (!strcmp (iltoken->member->vtable->klass->name, "MethodBuilder") ||
 					!strcmp (iltoken->member->vtable->klass->name, "ConstructorBuilder")) {

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -942,68 +942,8 @@ mono_image_get_ctorbuilder_token (MonoDynamicImage *assembly, MonoReflectionCtor
 static gboolean
 is_field_on_inst (MonoClassField *field)
 {
-	return (field->parent->generic_class && field->parent->generic_class->is_dynamic && ((MonoDynamicGenericClass*)field->parent->generic_class)->fields);
+	return field->parent->generic_class && field->parent->generic_class->is_dynamic;
 }
-
-/*
- * If FIELD is a field of a MonoDynamicGenericClass, return its non-inflated type.
- */
-static MonoType*
-get_field_on_inst_generic_type (MonoClassField *field)
-{
-	MonoClass *klass, *gtd;
-	MonoDynamicGenericClass *dgclass;
-	int field_index;
-
-	g_assert (is_field_on_inst (field));
-
-	dgclass = (MonoDynamicGenericClass*)field->parent->generic_class;
-
-	if (field >= dgclass->fields && field - dgclass->fields < dgclass->count_fields) {
-		field_index = field - dgclass->fields;
-		return dgclass->field_generic_types [field_index];		
-	}
-
-	klass = field->parent;
-	gtd = klass->generic_class->container_class;
-
-	if (field >= klass->fields && field - klass->fields < klass->field.count) {
-		field_index = field - klass->fields;
-		return gtd->fields [field_index].type;
-	}
-
-	g_assert_not_reached ();
-	return 0;
-}
-
-#ifndef DISABLE_REFLECTION_EMIT
-gboolean
-mono_is_sr_field_on_inst (MonoClassField *field)
-{
-	return is_field_on_inst (field);
-}
-#else
-gboolean
-mono_is_sr_field_on_inst (MonoClassField *field)
-{
-	return FALSE;
-}
-#endif /*DISABLE_REFLECTION_EMIT*/
-
-#ifndef DISABLE_REFLECTION_EMIT
-MonoType*
-mono_reflection_get_field_on_inst_generic_type (MonoClassField *field)
-{
-	return get_field_on_inst_generic_type (field);
-}
-#else
-MonoType*
-mono_reflection_get_field_on_inst_generic_type (MonoClassField *field)
-{
-	g_assert_not_reached ();
-	return NULL;
-}
-#endif /* DISABLE_REFLECTION_EMIT */
 
 #ifndef DISABLE_REFLECTION_EMIT
 static guint32
@@ -1023,10 +963,7 @@ mono_image_get_fieldref_token (MonoDynamicImage *assembly, MonoObject *f, MonoCl
 		int index = field - field->parent->fields;
 		type = mono_field_get_type (&field->parent->generic_class->container_class->fields [index]);
 	} else {
-		if (is_field_on_inst (field))
-			type = get_field_on_inst_generic_type (field);
-		else
-			type = mono_field_get_type (field);
+		type = mono_field_get_type (field);
 	}
 	token = mono_image_get_memberref_token (assembly, &field->parent->byval_arg,
 											mono_field_get_name (field),
@@ -3954,98 +3891,39 @@ inflate_method (MonoReflectionType *type, MonoObject *obj, MonoError *error)
 	return inflate_mono_method (mono_class_from_mono_type (t), method, obj);
 }
 
-/*TODO avoid saving custom attrs for generic classes as it's enough to have them on the generic type definition.*/
-static gboolean
-reflection_generic_class_initialize (MonoReflectionGenericClass *type, MonoArray *fields, MonoError *error)
+static void
+reflection_generic_class_initialize (MonoReflectionGenericClass *type, MonoError *error)
 {
 	MonoGenericClass *gclass;
 	MonoDynamicGenericClass *dgclass;
 	MonoClass *klass, *gklass;
 	MonoType *gtype;
-	int i;
 
 	mono_error_init (error);
 
 	gtype = mono_reflection_type_get_handle ((MonoReflectionType*)type, error);
-	return_val_if_nok (error, FALSE);
+	return_if_nok (error);
 	klass = mono_class_from_mono_type (gtype);
 	g_assert (gtype->type == MONO_TYPE_GENERICINST);
 	gclass = gtype->data.generic_class;
 
 	if (!gclass->is_dynamic)
-		return TRUE;
-
-	dgclass = (MonoDynamicGenericClass *) gclass;
-
-	if (dgclass->initialized)
-		return TRUE;
+		return;
 
 	gklass = gclass->container_class;
 	mono_class_init (gklass);
 
-	dgclass->count_fields = fields ? mono_array_length (fields) : 0;
-
-	dgclass->fields = mono_image_set_new0 (gclass->owner, MonoClassField, dgclass->count_fields);
-	dgclass->field_objects = mono_image_set_new0 (gclass->owner, MonoObject*, dgclass->count_fields);
-	dgclass->field_generic_types = mono_image_set_new0 (gclass->owner, MonoType*, dgclass->count_fields);
-
-	for (i = 0; i < dgclass->count_fields; i++) {
-		MonoObject *obj = (MonoObject *)mono_array_get (fields, gpointer, i);
-		MonoClassField *field, *inflated_field = NULL;
-
-		if (!strcmp (obj->vtable->klass->name, "FieldBuilder")) {
-			inflated_field = field = fieldbuilder_to_mono_class_field (klass, (MonoReflectionFieldBuilder *) obj, error);
-			return_val_if_nok (error, FALSE);
-		} else if (!strcmp (obj->vtable->klass->name, "MonoField"))
-			field = ((MonoReflectionField *) obj)->field;
-		else {
-			field = NULL; /* prevent compiler warning */
-			g_assert_not_reached ();
-		}
-
-		dgclass->fields [i] = *field;
-		dgclass->fields [i].parent = klass;
-		dgclass->fields [i].type = mono_class_inflate_generic_type_checked (
-			field->type, mono_generic_class_get_context ((MonoGenericClass *) dgclass), error);
-		mono_error_assert_ok (error); /* FIXME don't swallow the error */
-		dgclass->field_generic_types [i] = field->type;
-		MONO_GC_REGISTER_ROOT_IF_MOVING (dgclass->field_objects [i], MONO_ROOT_SOURCE_REFLECTION, "dynamic generic class field object");
-		dgclass->field_objects [i] = obj;
-
-		if (inflated_field) {
-			g_free (inflated_field);
-		} else {
-			dgclass->fields [i].name = mono_image_set_strdup (gclass->owner, dgclass->fields [i].name);
-		}
-	}
-
+	dgclass = (MonoDynamicGenericClass *) gclass;
 	dgclass->initialized = TRUE;
-	return TRUE;
+	return;
 }
 
 void
 mono_reflection_generic_class_initialize (MonoReflectionGenericClass *type, MonoArray *fields)
 {
 	MonoError error;
-	(void) reflection_generic_class_initialize (type, fields, &error);
+	reflection_generic_class_initialize (type, &error);
 	mono_error_set_pending_exception (&error);
-}
-
-void
-mono_reflection_free_dynamic_generic_class (MonoGenericClass *gclass)
-{
-	MonoDynamicGenericClass *dgclass;
-	int i;
-
-	g_assert (gclass->is_dynamic);
-
-	dgclass = (MonoDynamicGenericClass *)gclass;
-
-	for (i = 0; i < dgclass->count_fields; ++i) {
-		MonoClassField *field = dgclass->fields + i;
-		mono_metadata_free_type (field->type);
-		MONO_GC_UNREGISTER_ROOT_IF_MOVING (dgclass->field_objects [i]);
-	}
 }
 
 /**
@@ -5645,12 +5523,6 @@ mono_reflection_type_get_handle (MonoReflectionType* ref, MonoError *error)
 	if (!ref)
 		return NULL;
 	return ref->type;
-}
-
-void
-mono_reflection_free_dynamic_generic_class (MonoGenericClass *gclass)
-{
-	g_assert_not_reached ();
 }
 
 #endif /* DISABLE_REFLECTION_EMIT */


### PR DESCRIPTION
… elements of the 'fields' array are not used anywhere, making all the other fields unneccesary too.