### PR TITLE
Don't pass FILE_FLAG_OVERLAPPED to CreateFile()

### DIFF
--- a/mono/metadata/file-io.c
+++ b/mono/metadata/file-io.c
@@ -805,10 +805,6 @@ ves_icall_System_IO_MonoIO_Open (MonoString *filename, gint32 mode,
 		if (options & FileOptions_Temporary)
 			attributes |= FILE_ATTRIBUTE_TEMPORARY;
 		
-		/* Not sure if we should set FILE_FLAG_OVERLAPPED, how does this mix with the "Async" bool here? */
-		if (options & FileOptions_Asynchronous)
-			attributes |= FILE_FLAG_OVERLAPPED;
-		
 		if (options & FileOptions_WriteThrough)
 			attributes |= FILE_FLAG_WRITE_THROUGH;
 	} else


### PR DESCRIPTION
When a FileStream is opened with the FileOptions.Asynchronous flag set the code in file-io.c will pass FILE_FLAG_OVERLAPPED to the CreateFile() function. On Windows this means the file will be in asynchronous mode and when ReadFile()/WriteFile() are called an OVERLAPPED struct has to be passed. Mono doesn't do this which means that when reading/writing asynchronous FileStreams
Windows returns an ERROR_INVALID_PARAMETER and an exception is raised in managed code.

This patch simply removes the code which passes the FILE_FLAG_OVERLAPPED to CreateFile(). This will work since asynchronous I/O is handled in managed code anyway, using threads. On the OS level the I/O is still synchronous. The patch won't affect other platforms since the implementation of ReadFile()/WriteFile()/etc in mono/io-layer/, which is used on non-Windows, is
always synchronous and ignores the FILE_FLAG_OVERLAPPED.

This bug was triggered by the MonoTests.System.IO.BinaryWriterTest.AsynchronousModeWrites test.