### PR TITLE
[Facades] Implement methods for *Extensions types that are available on the extended type

### DIFF
--- a/mcs/class/Facades/Microsoft.Win32.Registry.AccessControl/RegistryAclExtensions.cs
+++ b/mcs/class/Facades/Microsoft.Win32.Registry.AccessControl/RegistryAclExtensions.cs
@@ -36,22 +36,19 @@ namespace Microsoft.Win32
 {
 	public static class RegistryAclExtensions
 	{
-		[MonoTODO]
 		public static RegistrySecurity GetAccessControl (this RegistryKey key)
 		{
-			throw new NotImplementedException ();
+			return key.GetAccessControl ();
 		}
 
-		[MonoTODO]
 		public static RegistrySecurity GetAccessControl (this RegistryKey key, AccessControlSections includeSections)
 		{
-			throw new NotImplementedException ();
+			return key.GetAccessControl (includeSections);
 		}
 
-		[MonoTODO]
 		public static void SetAccessControl (this RegistryKey key, RegistrySecurity registrySecurity)
 		{
-			throw new NotImplementedException ();
+			key.SetAccessControl (registrySecurity);
 		}
 	}
 }

--- a/mcs/class/Facades/Microsoft.Win32.Registry.AccessControl/RegistryAclExtensions.cs
+++ b/mcs/class/Facades/Microsoft.Win32.Registry.AccessControl/RegistryAclExtensions.cs
@@ -38,16 +38,25 @@ namespace Microsoft.Win32
 	{
 		public static RegistrySecurity GetAccessControl (this RegistryKey key)
 		{
+			if (key == null)
+				throw new ArgumentNullException (nameof (key));
+
 			return key.GetAccessControl ();
 		}
 
 		public static RegistrySecurity GetAccessControl (this RegistryKey key, AccessControlSections includeSections)
 		{
+			if (key == null)
+				throw new ArgumentNullException (nameof (key));
+
 			return key.GetAccessControl (includeSections);
 		}
 
 		public static void SetAccessControl (this RegistryKey key, RegistrySecurity registrySecurity)
 		{
+			if (key == null)
+				throw new ArgumentNullException (nameof (key));
+
 			key.SetAccessControl (registrySecurity);
 		}
 	}

--- a/mcs/class/Facades/System.Diagnostics.StackTrace/StackFrameExtensions.cs
+++ b/mcs/class/Facades/System.Diagnostics.StackTrace/StackFrameExtensions.cs
@@ -37,36 +37,54 @@ namespace System.Diagnostics
 		[MonoTODO]
 		public static IntPtr GetNativeImageBase (this StackFrame stackFrame)
 		{
+			if (stackFrame == null)
+				throw new ArgumentNullException (nameof (stackFrame));
+
 			throw new NotImplementedException ();
 		}
 
 		[MonoTODO]
 		public static IntPtr GetNativeIP (this StackFrame stackFrame)
 		{
+			if (stackFrame == null)
+				throw new ArgumentNullException (nameof (stackFrame));
+
 			throw new NotImplementedException ();
 		}
 
 		[MonoTODO]
 		public static bool HasNativeImage (this StackFrame stackFrame)
 		{
+			if (stackFrame == null)
+				throw new ArgumentNullException (nameof (stackFrame));
+
 			throw new NotImplementedException ();
 		}
 
 		[MonoTODO]
 		public static bool HasMethod (this StackFrame stackFrame)
 		{
+			if (stackFrame == null)
+				throw new ArgumentNullException (nameof (stackFrame));
+
 			throw new NotImplementedException ();
 		}
 
 		[MonoTODO]
 		public static bool HasILOffset (this StackFrame stackFrame)
 		{
+			if (stackFrame == null)
+				throw new ArgumentNullException (nameof (stackFrame));
+
 			throw new NotImplementedException ();
 		}
 
 		[MonoTODO]
 		public static bool HasSource (this StackFrame stackFrame)
 		{
+			if (stackFrame == null)
+				throw new ArgumentNullException (nameof (stackFrame));
+
 			throw new NotImplementedException ();
 		}
 	}

--- a/mcs/class/Facades/System.Globalization.Extensions/StringNormalizationExtensions.cs
+++ b/mcs/class/Facades/System.Globalization.Extensions/StringNormalizationExtensions.cs
@@ -33,28 +33,24 @@ namespace System
 {
 	public static class StringNormalizationExtensions
 	{
-		[MonoTODO]
 		public static bool IsNormalized(this string value)
 		{
-			throw new NotImplementedException ();
+			return value.IsNormalized ();
 		}
 
-		[MonoTODO]
 		public static bool IsNormalized(this string value, NormalizationForm normalizationForm)
 		{
-			throw new NotImplementedException ();
+			return value.IsNormalized (normalizationForm);
 		}
 
-		[MonoTODO]
 		public static String Normalize(this string value)
 		{
-			throw new NotImplementedException ();
+			return value.Normalize ();
 		}
 
-		[MonoTODO]
 		public static String Normalize(this string value, NormalizationForm normalizationForm)
 		{
-			throw new NotImplementedException ();
+			return value.Normalize (normalizationForm);
 		}
 	}
 }

--- a/mcs/class/Facades/System.Globalization.Extensions/StringNormalizationExtensions.cs
+++ b/mcs/class/Facades/System.Globalization.Extensions/StringNormalizationExtensions.cs
@@ -35,21 +35,33 @@ namespace System
 	{
 		public static bool IsNormalized(this string value)
 		{
+			if (value == null)
+				throw new ArgumentNullException (nameof (value));
+
 			return value.IsNormalized ();
 		}
 
 		public static bool IsNormalized(this string value, NormalizationForm normalizationForm)
 		{
+			if (value == null)
+				throw new ArgumentNullException (nameof (value));
+
 			return value.IsNormalized (normalizationForm);
 		}
 
 		public static String Normalize(this string value)
 		{
+			if (value == null)
+				throw new ArgumentNullException (nameof (value));
+
 			return value.Normalize ();
 		}
 
 		public static String Normalize(this string value, NormalizationForm normalizationForm)
 		{
+			if (value == null)
+				throw new ArgumentNullException (nameof (value));
+
 			return value.Normalize (normalizationForm);
 		}
 	}

--- a/mcs/class/Facades/System.IO.FileSystem.AccessControl/FileSystemAclExtensions.cs
+++ b/mcs/class/Facades/System.IO.FileSystem.AccessControl/FileSystemAclExtensions.cs
@@ -28,56 +28,50 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Security.AccessControl;
+
 namespace System.IO
 {
-	public static partial class FileSystemAclExtensions
+	public static class FileSystemAclExtensions
 	{
-		[MonoTODO]
-		public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo)
+		public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo)
 		{
-			throw new NotImplementedException ();
+			return directoryInfo.GetAccessControl ();
 		}
 
-		[MonoTODO]
-		public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.AccessControlSections includeSections)
+		public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo, AccessControlSections includeSections)
 		{
-			throw new NotImplementedException ();
+			return directoryInfo.GetAccessControl (includeSections);
 		}
 
-		[MonoTODO]
-		public static System.Security.AccessControl.FileSecurity GetAccessControl(this System.IO.FileInfo fileInfo)
+		public static FileSecurity GetAccessControl(this FileInfo fileInfo)
 		{
-			throw new NotImplementedException ();
+			return fileInfo.GetAccessControl ();
 		}
 
-		[MonoTODO]
-		public static System.Security.AccessControl.FileSecurity GetAccessControl(this System.IO.FileInfo fileInfo, System.Security.AccessControl.AccessControlSections includeSections)
+		public static FileSecurity GetAccessControl(this FileInfo fileInfo, AccessControlSections includeSections)
 		{
-			throw new NotImplementedException ();
+			return fileInfo.GetAccessControl (includeSections);
 		}
 
-		[MonoTODO]
-		public static System.Security.AccessControl.FileSecurity GetAccessControl(this System.IO.FileStream fileStream)
+		public static FileSecurity GetAccessControl(this FileStream fileStream)
 		{
-			throw new NotImplementedException ();
+			return fileStream.GetAccessControl ();
 		}
 
-		[MonoTODO]
-		public static void SetAccessControl(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.DirectorySecurity directorySecurity)
+		public static void SetAccessControl(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
 		{
-			throw new NotImplementedException ();
+			directoryInfo.SetAccessControl (directorySecurity);
 		}
 
-		[MonoTODO]
-		public static void SetAccessControl(this System.IO.FileInfo fileInfo, System.Security.AccessControl.FileSecurity fileSecurity)
+		public static void SetAccessControl(this FileInfo fileInfo, FileSecurity fileSecurity)
 		{
-			throw new NotImplementedException ();
+			fileInfo.SetAccessControl (fileSecurity);
 		}
 
-		[MonoTODO]
-		public static void SetAccessControl(this System.IO.FileStream fileStream, System.Security.AccessControl.FileSecurity fileSecurity)
+		public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
 		{
-			throw new NotImplementedException ();
+			fileStream.SetAccessControl (fileSecurity);
 		}
 	}
 }

--- a/mcs/class/Facades/System.IO.FileSystem.AccessControl/FileSystemAclExtensions.cs
+++ b/mcs/class/Facades/System.IO.FileSystem.AccessControl/FileSystemAclExtensions.cs
@@ -36,41 +36,65 @@ namespace System.IO
 	{
 		public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo)
 		{
+			if (directoryInfo == null)
+				throw new ArgumentNullException (nameof (directoryInfo));
+
 			return directoryInfo.GetAccessControl ();
 		}
 
 		public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo, AccessControlSections includeSections)
 		{
+			if (directoryInfo == null)
+				throw new ArgumentNullException (nameof (directoryInfo));
+
 			return directoryInfo.GetAccessControl (includeSections);
 		}
 
 		public static FileSecurity GetAccessControl(this FileInfo fileInfo)
 		{
+			if (fileInfo == null)
+				throw new ArgumentNullException (nameof (fileInfo));
+
 			return fileInfo.GetAccessControl ();
 		}
 
 		public static FileSecurity GetAccessControl(this FileInfo fileInfo, AccessControlSections includeSections)
 		{
+			if (fileInfo == null)
+				throw new ArgumentNullException (nameof (fileInfo));
+
 			return fileInfo.GetAccessControl (includeSections);
 		}
 
 		public static FileSecurity GetAccessControl(this FileStream fileStream)
 		{
+			if (fileStream == null)
+				throw new ArgumentNullException (nameof (fileStream));
+
 			return fileStream.GetAccessControl ();
 		}
 
 		public static void SetAccessControl(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
 		{
+			if (directoryInfo == null)
+				throw new ArgumentNullException (nameof (directoryInfo));
+
 			directoryInfo.SetAccessControl (directorySecurity);
 		}
 
 		public static void SetAccessControl(this FileInfo fileInfo, FileSecurity fileSecurity)
 		{
+			if (fileInfo == null)
+				throw new ArgumentNullException (nameof (fileInfo));
+
 			fileInfo.SetAccessControl (fileSecurity);
 		}
 
 		public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
 		{
+			if (fileStream == null)
+				throw new ArgumentNullException (nameof (fileStream));
+
 			fileStream.SetAccessControl (fileSecurity);
 		}
 	}

--- a/mcs/class/Facades/System.Reflection.TypeExtensions/TypeExtensions.CoreCLR.cs
+++ b/mcs/class/Facades/System.Reflection.TypeExtensions/TypeExtensions.CoreCLR.cs
@@ -15,199 +15,199 @@ namespace System.Reflection
 {
     public static class TypeExtensions
     {
-        public static ConstructorInfo GetConstructor(Type type, Type[] types)
+        public static ConstructorInfo GetConstructor(this Type type, Type[] types)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetConstructor(types);
         }
 
-        public static ConstructorInfo[] GetConstructors(Type type)
+        public static ConstructorInfo[] GetConstructors(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetConstructors();
         }
 
-        public static ConstructorInfo[] GetConstructors(Type type, BindingFlags bindingAttr)
+        public static ConstructorInfo[] GetConstructors(this Type type, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetConstructors(bindingAttr);
         }
 
-        public static MemberInfo[] GetDefaultMembers(Type type)
+        public static MemberInfo[] GetDefaultMembers(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetDefaultMembers();
         }
 
-        public static EventInfo GetEvent(Type type, string name)
+        public static EventInfo GetEvent(this Type type, string name)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetEvent(name);
         }
 
-        public static EventInfo GetEvent(Type type, string name, BindingFlags bindingAttr)
+        public static EventInfo GetEvent(this Type type, string name, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetEvent(name, bindingAttr);
         }
 
-        public static EventInfo[] GetEvents(Type type)
+        public static EventInfo[] GetEvents(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetEvents();
         }
 
-        public static EventInfo[] GetEvents(Type type, BindingFlags bindingAttr)
+        public static EventInfo[] GetEvents(this Type type, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetEvents(bindingAttr);
         }
 
-        public static FieldInfo GetField(Type type, string name)
+        public static FieldInfo GetField(this Type type, string name)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetField(name);
         }
 
-        public static FieldInfo GetField(Type type, string name, BindingFlags bindingAttr)
+        public static FieldInfo GetField(this Type type, string name, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetField(name, bindingAttr);
         }
 
-        public static FieldInfo[] GetFields(Type type)
+        public static FieldInfo[] GetFields(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetFields();
         }
 
-        public static FieldInfo[] GetFields(Type type, BindingFlags bindingAttr)
+        public static FieldInfo[] GetFields(this Type type, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetFields(bindingAttr);
         }
 
-        public static Type[] GetGenericArguments(Type type)
+        public static Type[] GetGenericArguments(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetGenericArguments();
         }
 
-        public static Type[] GetInterfaces(Type type)
+        public static Type[] GetInterfaces(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetInterfaces();
         }
 
-        public static MemberInfo[] GetMember(Type type, string name)
+        public static MemberInfo[] GetMember(this Type type, string name)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMember(name);
         }
 
-        public static MemberInfo[] GetMember(Type type, string name, BindingFlags bindingAttr)
+        public static MemberInfo[] GetMember(this Type type, string name, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMember(name, bindingAttr);
         }
 
-        public static MemberInfo[] GetMembers(Type type)
+        public static MemberInfo[] GetMembers(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMembers();
         }
 
-        public static MemberInfo[] GetMembers(Type type, BindingFlags bindingAttr)
+        public static MemberInfo[] GetMembers(this Type type, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMembers(bindingAttr);
         }
 
-        public static MethodInfo GetMethod(Type type, string name)
+        public static MethodInfo GetMethod(this Type type, string name)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMethod(name);
         }
 
-        public static MethodInfo GetMethod(Type type, string name, BindingFlags bindingAttr)
+        public static MethodInfo GetMethod(this Type type, string name, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMethod(name, bindingAttr);
         }
 
-        public static MethodInfo GetMethod(Type type, string name, Type[] types)
+        public static MethodInfo GetMethod(this Type type, string name, Type[] types)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMethod(name, types);
         }
 
-        public static MethodInfo[] GetMethods(Type type)
+        public static MethodInfo[] GetMethods(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMethods();
         }
 
-        public static MethodInfo[] GetMethods(Type type, BindingFlags bindingAttr)
+        public static MethodInfo[] GetMethods(this Type type, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetMethods(bindingAttr);
         }
 
-        public static Type GetNestedType(Type type, string name, BindingFlags bindingAttr)
+        public static Type GetNestedType(this Type type, string name, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetNestedType(name, bindingAttr);
         }
 
-        public static Type[] GetNestedTypes(Type type, BindingFlags bindingAttr)
+        public static Type[] GetNestedTypes(this Type type, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetNestedTypes(bindingAttr);
         }
 
-        public static PropertyInfo[] GetProperties(Type type)
+        public static PropertyInfo[] GetProperties(this Type type)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetProperties();
         }
 
-        public static PropertyInfo[] GetProperties(Type type, BindingFlags bindingAttr)
+        public static PropertyInfo[] GetProperties(this Type type, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetProperties(bindingAttr);
         }
 
-        public static PropertyInfo GetProperty(Type type, string name)
+        public static PropertyInfo GetProperty(this Type type, string name)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetProperty(name);
         }
 
-        public static PropertyInfo GetProperty(Type type, string name, BindingFlags bindingAttr)
+        public static PropertyInfo GetProperty(this Type type, string name, BindingFlags bindingAttr)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetProperty(name, bindingAttr);
         }
 
-        public static PropertyInfo GetProperty(Type type, string name, Type returnType)
+        public static PropertyInfo GetProperty(this Type type, string name, Type returnType)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetProperty(name, returnType);
         }
 
-        public static PropertyInfo GetProperty(Type type, string name, Type returnType, Type[] types)
+        public static PropertyInfo GetProperty(this Type type, string name, Type returnType, Type[] types)
         {
             Requires.NotNull(type, nameof(type));
             return type.GetProperty(name, returnType, types);
         }
 
-        public static bool IsAssignableFrom(Type type, Type c)
+        public static bool IsAssignableFrom(this Type type, Type c)
         {
             Requires.NotNull(type, nameof(type));
             return type.IsAssignableFrom(c);
         }
 
-        public static bool IsInstanceOfType(Type type, object o)
+        public static bool IsInstanceOfType(this Type type, object o)
         {
             Requires.NotNull(type, nameof(type));
             return type.IsInstanceOfType(o);
@@ -216,19 +216,19 @@ namespace System.Reflection
 
     public static class AssemblyExtensions
     {
-        public static Type[] GetExportedTypes(Assembly assembly)
+        public static Type[] GetExportedTypes(this Assembly assembly)
         {
             Requires.NotNull(assembly, nameof(assembly));
             return assembly.GetExportedTypes();
         }
 
-        public static Module[] GetModules(Assembly assembly)
+        public static Module[] GetModules(this Assembly assembly)
         {
             Requires.NotNull(assembly, nameof(assembly));
             return assembly.GetModules();
         }
 
-        public static Type[] GetTypes(Assembly assembly)
+        public static Type[] GetTypes(this Assembly assembly)
         {
             Requires.NotNull(assembly, nameof(assembly));
             return assembly.GetTypes();
@@ -237,37 +237,37 @@ namespace System.Reflection
 
     public static class EventInfoExtensions
     {
-        public static MethodInfo GetAddMethod(EventInfo eventInfo)
+        public static MethodInfo GetAddMethod(this EventInfo eventInfo)
         {
             Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetAddMethod();
         }
 
-        public static MethodInfo GetAddMethod(EventInfo eventInfo, bool nonPublic)
+        public static MethodInfo GetAddMethod(this EventInfo eventInfo, bool nonPublic)
         {
             Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetAddMethod(nonPublic);
         }
 
-        public static MethodInfo GetRaiseMethod(EventInfo eventInfo)
+        public static MethodInfo GetRaiseMethod(this EventInfo eventInfo)
         {
             Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRaiseMethod();
         }
 
-        public static MethodInfo GetRaiseMethod(EventInfo eventInfo, bool nonPublic)
+        public static MethodInfo GetRaiseMethod(this EventInfo eventInfo, bool nonPublic)
         {
             Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRaiseMethod(nonPublic);
         }
 
-        public static MethodInfo GetRemoveMethod(EventInfo eventInfo)
+        public static MethodInfo GetRemoveMethod(this EventInfo eventInfo)
         {
             Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRemoveMethod();
         }
 
-        public static MethodInfo GetRemoveMethod(EventInfo eventInfo, bool nonPublic)
+        public static MethodInfo GetRemoveMethod(this EventInfo eventInfo, bool nonPublic)
         {
             Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRemoveMethod(nonPublic);
@@ -337,7 +337,7 @@ namespace System.Reflection
 
     public static class MethodInfoExtensions
     {
-        public static MethodInfo GetBaseDefinition(MethodInfo method)
+        public static MethodInfo GetBaseDefinition(this MethodInfo method)
         {
             Requires.NotNull(method, nameof(method));
             return method.GetBaseDefinition();
@@ -361,37 +361,37 @@ namespace System.Reflection
 
     public static class PropertyInfoExtensions
     {
-        public static MethodInfo[] GetAccessors(PropertyInfo property)
+        public static MethodInfo[] GetAccessors(this PropertyInfo property)
         {
             Requires.NotNull(property, nameof(property));
             return property.GetAccessors();
         }
 
-        public static MethodInfo[] GetAccessors(PropertyInfo property, bool nonPublic)
+        public static MethodInfo[] GetAccessors(this PropertyInfo property, bool nonPublic)
         {
             Requires.NotNull(property, nameof(property));
             return property.GetAccessors(nonPublic);
         }
 
-        public static MethodInfo GetGetMethod(PropertyInfo property)
+        public static MethodInfo GetGetMethod(this PropertyInfo property)
         {
             Requires.NotNull(property, nameof(property));
             return property.GetGetMethod();
         }
 
-        public static MethodInfo GetGetMethod(PropertyInfo property, bool nonPublic)
+        public static MethodInfo GetGetMethod(this PropertyInfo property, bool nonPublic)
         {
             Requires.NotNull(property, nameof(property));
             return property.GetGetMethod(nonPublic);
         }
 
-        public static MethodInfo GetSetMethod(PropertyInfo property)
+        public static MethodInfo GetSetMethod(this PropertyInfo property)
         {
             Requires.NotNull(property, nameof(property));
             return property.GetSetMethod();
         }
 
-        public static MethodInfo GetSetMethod(PropertyInfo property, bool nonPublic)
+        public static MethodInfo GetSetMethod(this PropertyInfo property, bool nonPublic)
         {
             Requires.NotNull(property, nameof(property));
             return property.GetSetMethod(nonPublic);

--- a/mcs/class/Facades/System.Security.SecureString/SecureStringMarshal.cs
+++ b/mcs/class/Facades/System.Security.SecureString/SecureStringMarshal.cs
@@ -20,28 +20,30 @@
 // THE SOFTWARE.
 // 
 
+using System.Runtime.InteropServices;
+
 namespace System.Security
 {
 	public static class SecureStringMarshal
 	{
 		public static IntPtr SecureStringToCoTaskMemAnsi (SecureString s)
 		{
-			throw new NotImplementedException ();
+			return Marshal.SecureStringToCoTaskMemAnsi (s);
 		}
 
 		public static IntPtr SecureStringToCoTaskMemUnicode (SecureString s)
 		{
-			throw new NotImplementedException ();
+			return Marshal.SecureStringToCoTaskMemUnicode (s);
 		}
 
 		public static IntPtr SecureStringToGlobalAllocAnsi (SecureString s)
 		{
-			throw new NotImplementedException ();
+			return Marshal.SecureStringToGlobalAllocAnsi (s);
 		}
 
 		public static IntPtr SecureStringToGlobalAllocUnicode (SecureString s)
 		{
-			throw new NotImplementedException ();
+			return Marshal.SecureStringToGlobalAllocUnicode (s);
 		}
 	}
 }

--- a/mcs/class/Facades/System.ServiceProcess.ServiceController/ServiceController_mobile.cs
+++ b/mcs/class/Facades/System.ServiceProcess.ServiceController/ServiceController_mobile.cs
@@ -37,208 +37,180 @@ namespace System.ServiceProcess
 {
 	public class ServiceController : IDisposable
 	{
-		[MonoTODO]
 		public bool CanPauseAndContinue
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public bool CanShutdown
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public bool CanStop
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public ServiceController[] DependentServices
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public string DisplayName
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public string MachineName
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public SafeHandle ServiceHandle
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public string ServiceName
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public ServiceController[] ServicesDependedOn
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public ServiceType ServiceType
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public ServiceStartMode StartType
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public ServiceControllerStatus Status
 		{
 			get
 			{
-				throw new NotImplementedException ();
+				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		[MonoTODO]
 		public ServiceController (string name)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public ServiceController (string name, string machineName)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void Continue ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void Dispose ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		protected virtual void Dispose (bool disposing)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public static ServiceController[] GetDevices ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public static ServiceController[] GetDevices (string machineName)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public static ServiceController[] GetServices ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public static ServiceController[] GetServices (string machineName)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void Pause ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void Refresh ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void Start ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void Start (string[] args)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void Stop ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void WaitForStatus (ServiceControllerStatus desiredStatus)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public void WaitForStatus (ServiceControllerStatus desiredStatus, TimeSpan timeout)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 	}
 }

--- a/mcs/class/Facades/System.ServiceProcess.ServiceController/TimeoutException_mobile.cs
+++ b/mcs/class/Facades/System.ServiceProcess.ServiceController/TimeoutException_mobile.cs
@@ -36,22 +36,19 @@ namespace System.ServiceProcess
 {
 	public class TimeoutException : Exception
 	{
-		[MonoTODO]
 		public TimeoutException ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public TimeoutException (string message)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 
-		[MonoTODO]
 		public TimeoutException (string message, Exception innerException)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException ();
 		}
 	}
 }

--- a/mcs/class/Facades/System.Threading.AccessControl/ThreadingAclExtensions.cs
+++ b/mcs/class/Facades/System.Threading.AccessControl/ThreadingAclExtensions.cs
@@ -36,40 +36,34 @@ namespace System.Threading
 {
     public static class ThreadingAclExtensions
     {
-        [MonoTODO]
         public static EventWaitHandleSecurity GetAccessControl (this EventWaitHandle handle)
         {
-            throw new NotImplementedException ();
+            return handle.GetAccessControl ();
         }
 
-        [MonoTODO]
         public static void SetAccessControl (this EventWaitHandle handle, EventWaitHandleSecurity eventSecurity)
         {
-            throw new NotImplementedException ();
+            handle.SetAccessControl (eventSecurity);
         }
 
-        [MonoTODO]
         public static MutexSecurity GetAccessControl (this Mutex mutex)
         {
-            throw new NotImplementedException ();
+            return mutex.GetAccessControl ();
         }
 
-        [MonoTODO]
         public static void SetAccessControl (this Mutex mutex, MutexSecurity mutexSecurity)
         {
-            throw new NotImplementedException ();
+            mutex.SetAccessControl (mutexSecurity);
         }
 
-        [MonoTODO]
         public static SemaphoreSecurity GetAccessControl (this Semaphore semaphore)
         {
-            throw new NotImplementedException ();
+            return semaphore.GetAccessControl ();
         }
 
-        [MonoTODO]
         public static void SetAccessControl (this Semaphore semaphore, SemaphoreSecurity semaphoreSecurity)
         {
-            throw new NotImplementedException ();
+            semaphore.SetAccessControl (semaphoreSecurity);
         }
     }
 }

--- a/mcs/class/Facades/System.Threading.AccessControl/ThreadingAclExtensions.cs
+++ b/mcs/class/Facades/System.Threading.AccessControl/ThreadingAclExtensions.cs
@@ -38,31 +38,49 @@ namespace System.Threading
     {
         public static EventWaitHandleSecurity GetAccessControl (this EventWaitHandle handle)
         {
+            if (handle == null)
+                throw new ArgumentNullException (nameof (handle));
+
             return handle.GetAccessControl ();
         }
 
         public static void SetAccessControl (this EventWaitHandle handle, EventWaitHandleSecurity eventSecurity)
         {
+            if (handle == null)
+                throw new ArgumentNullException (nameof (handle));
+
             handle.SetAccessControl (eventSecurity);
         }
 
         public static MutexSecurity GetAccessControl (this Mutex mutex)
         {
+            if (mutex == null)
+                throw new ArgumentNullException (nameof (mutex));
+
             return mutex.GetAccessControl ();
         }
 
         public static void SetAccessControl (this Mutex mutex, MutexSecurity mutexSecurity)
         {
+            if (mutex == null)
+                throw new ArgumentNullException (nameof (mutex));
+
             mutex.SetAccessControl (mutexSecurity);
         }
 
         public static SemaphoreSecurity GetAccessControl (this Semaphore semaphore)
         {
+            if (semaphore == null)
+                throw new ArgumentNullException (nameof (semaphore));
+
             return semaphore.GetAccessControl ();
         }
 
         public static void SetAccessControl (this Semaphore semaphore, SemaphoreSecurity semaphoreSecurity)
         {
+            if (semaphore == null)
+                throw new ArgumentNullException (nameof (semaphore));
+
             semaphore.SetAccessControl (semaphoreSecurity);
         }
     }

--- a/mcs/class/Facades/System.Threading.AccessControl/ThreadingAclExtensions.cs
+++ b/mcs/class/Facades/System.Threading.AccessControl/ThreadingAclExtensions.cs
@@ -37,37 +37,37 @@ namespace System.Threading
     public static class ThreadingAclExtensions
     {
         [MonoTODO]
-        public static EventWaitHandleSecurity GetAccessControl (EventWaitHandle handle)
+        public static EventWaitHandleSecurity GetAccessControl (this EventWaitHandle handle)
         {
             throw new NotImplementedException ();
         }
 
         [MonoTODO]
-        public static void SetAccessControl (EventWaitHandle handle, EventWaitHandleSecurity eventSecurity)
+        public static void SetAccessControl (this EventWaitHandle handle, EventWaitHandleSecurity eventSecurity)
         {
             throw new NotImplementedException ();
         }
 
         [MonoTODO]
-        public static MutexSecurity GetAccessControl (Mutex mutex)
+        public static MutexSecurity GetAccessControl (this Mutex mutex)
         {
             throw new NotImplementedException ();
         }
 
         [MonoTODO]
-        public static void SetAccessControl (Mutex mutex, MutexSecurity mutexSecurity)
+        public static void SetAccessControl (this Mutex mutex, MutexSecurity mutexSecurity)
         {
             throw new NotImplementedException ();
         }
 
         [MonoTODO]
-        public static SemaphoreSecurity GetAccessControl (Semaphore semaphore)
+        public static SemaphoreSecurity GetAccessControl (this Semaphore semaphore)
         {
             throw new NotImplementedException ();
         }
 
         [MonoTODO]
-        public static void SetAccessControl (Semaphore semaphore, SemaphoreSecurity semaphoreSecurity)
+        public static void SetAccessControl (this Semaphore semaphore, SemaphoreSecurity semaphoreSecurity)
         {
             throw new NotImplementedException ();
         }


### PR DESCRIPTION
Main fix:

The methods are already available in our implementations of those types so we can just forward the calls to the "real" types instead of throwing NotImplementedException.

I audited all code in mcs/class/Facades and the only places where we still throw NotImplementedException are ones where we really need to add a custom implementation.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43695

---

I also fixed a few other small issues that I noticed during working on the fix, see the other commits.