### PR TITLE
[loader] Check for ReferenceAssemblyAttribute when loading

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1191,6 +1191,23 @@ mono_assembly_load_reference (MonoImage *image, int index)
 				   aname.major, aname.minor, aname.build, aname.revision,
 				   strlen ((char*)aname.public_key_token) == 0 ? "(none)" : (char*)aname.public_key_token, extra_msg);
 		g_free (extra_msg);
+
+	} else if (!image->assembly->ref_only) {
+		MonoError error;
+		if (mono_assembly_get_reference_assembly_attribute (reference, &error)) {
+			mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_ASSEMBLY, "The following reference assembly assembly referenced from %s was not loaded.  Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context:\n"
+				    "     Assembly:   %s    (assemblyref_index=%d)\n"
+				    "     Version:    %d.%d.%d.%d\n"
+				    "     Public Key: %s\n",
+				    image->name, aname.name, index,
+				    aname.major, aname.minor, aname.build, aname.revision,
+				    strlen ((char*)aname.public_key_token) == 0 ? "(none)" : (char*)aname.public_key_token);
+			reference = NULL; /* don't load reference assemblies for execution */
+		}
+		if (!is_ok (&error)) {
+			reference = NULL;
+			mono_error_cleanup (&error);
+		}
 	}
 
 	mono_assemblies_lock ();

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5591,6 +5591,7 @@ mono_class_setup_parent (MonoClass *klass, MonoClass *parent)
 			/* set the parent to something useful and safe, but mark the type as broken */
 			parent = mono_defaults.object_class;
 			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+			g_assert (parent);
 		}
 
 		klass->parent = parent;

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -700,4 +700,8 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 void
 mono_context_init_checked (MonoDomain *domain, MonoError *error);
 
+gboolean
+mono_assembly_get_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error);
+
+
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -808,6 +808,16 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_profiler_appdomain_name (domain, domain->friendly_name);
 
+	/* Have to do this quite late so that we at least have System.Object */
+	MonoError custom_attr_error;
+	if (mono_assembly_get_reference_assembly_attribute (ass, &custom_attr_error)) {
+		char *corlib_file = g_build_filename (mono_assembly_getrootdir (), "mono", current_runtime->framework_version, "mscorlib.dll", NULL);
+		g_print ("Could not load file or assembly %s. Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context.", corlib_file);
+		g_free (corlib_file);
+		exit (1);
+	}
+	mono_error_assert_ok (&custom_attr_error);
+
 	return domain;
 }
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -467,7 +467,8 @@ BASE_TEST_CS_SRC_UNIVERSAL=		\
 	pinvoke_ppcd.cs	\
 	bug-29585.cs	\
 	priority.cs	\
-	abort-cctor.cs
+	abort-cctor.cs	\
+	reference-loader.cs
 
 if INSTALL_MOBILE_STATIC
 BASE_TEST_CS_SRC= \
@@ -800,18 +801,22 @@ endif
 # but that need to be compiled
 PREREQ_IL_SRC=event-il.il module-cctor.il
 PREREQ_CS_SRC=
-PREREQ_IL_DLL_SRC=event-il.il module-cctor.il
-PREREQ_CS_DLL_SRC=
+PREREQ_IL_DLL_SRC=
+PREREQ_CS_DLL_SRC=TestingReferenceAssembly.cs TestingReferenceReferenceAssembly.cs
 
-PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe)
-PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe)
+PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe) \
+	$(PREREQ_IL_DLL_SRC:.il=.dll)
+PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe) \
+	$(PREREQ_CS_DLL_SRC:.cs=.dll)
 TESTSI_CS=$(TEST_CS_SRC:.cs=.exe)
 TESTSI_IL=$(TEST_IL_SRC:.il=.exe)
 TESTBS=$(BENCHSRC:.cs=.exe)
 STRESS_TESTS=$(STRESS_TESTS_SRC:.cs=.exe)
 
-PREREQSI_IL_AOT=$(PREREQ_IL_SRC:.il=.exe$(PLATFORM_AOT_SUFFIX))
-PREREQSI_CS_AOT=$(PREREQ_CS_SRC:.cs=.exe$(PLATFORM_AOT_SUFFIX))
+PREREQSI_IL_AOT=$(PREREQ_IL_SRC:.il=.exe$(PLATFORM_AOT_SUFFIX)) \
+		$(PREREQ_IL_DLL_SRC:.il=.dll$(PLATFORM_AOT_SUFFIX))
+PREREQSI_CS_AOT=$(PREREQ_CS_SRC:.cs=.exe$(PLATFORM_AOT_SUFFIX)) \
+		$(PREREQ_CS_DLL_SRC:.cs=.dll$(PLATFORM_AOT_SUFFIX))
 
 EXTRA_DIST=test-driver test-runner.cs $(TEST_CS_SRC_DIST) $(TEST_IL_SRC) \
 	$(BENCHSRC) $(STRESS_TESTS_SRC) stress-runner.pl $(PREREQ_IL_SRC) $(PREREQ_CS_SRC)
@@ -831,6 +836,12 @@ endif
 
 %.exe: %.cs $(TEST_DRIVER_DEPEND)
 	$(MCS) -r:System.dll -r:System.Xml.dll -r:System.Core.dll -r:TestDriver.dll $(TEST_DRIVER_HARD_KILL_FEATURE) -out:$@ $<
+
+%.dll: %.cs
+	$(MCS) -r:System.dll -target:library -out:$@ $<
+
+TestingReferenceReferenceAssembly.dll: TestingReferenceReferenceAssembly.cs TestingReferenceAssembly.dll
+	$(MCS) -r:TestingReferenceAssembly.dll -target:library -out:$@ $<
 
 %.exe$(PLATFORM_AOT_SUFFIX): %.exe 
 	$(RUNTIME) $(AOT_BUILD_FLAGS) $<

--- a/mono/tests/TestingReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceAssembly.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: ReferenceAssemblyAttribute]
+
+public class X {
+	public int Y;
+}

--- a/mono/tests/TestingReferenceReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceReferenceAssembly.cs
@@ -1,0 +1,7 @@
+// An assembly that refereces the TestingReferenceAssembly
+
+class Z : X {
+	public Z () {
+		Y = 1;
+	}
+}

--- a/mono/tests/reference-loader.cs
+++ b/mono/tests/reference-loader.cs
@@ -1,0 +1,111 @@
+//
+// reference-loader.cs:
+//
+//  Test for reference assembly loading
+
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Tests {
+	public static int Main (string[] args)
+	{
+		return TestDriver.RunTests (typeof (Tests), args);
+	}
+
+	public static int test_0_loadFrom_reference ()
+	{
+		// Check that loading a reference assembly by filename for execution is an error
+		try {
+			var a = Assembly.LoadFrom ("./TestingReferenceAssembly.dll");
+		} catch (BadImageFormatException exn) {
+			// Console.Error.WriteLine ("exn was {0}", exn);
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_load_reference ()
+	{
+		// Check that loading a reference assembly for execution is an error
+		try {
+			var an = new AssemblyName ("TestingReferenceAssembly");
+			var a = Assembly.Load (an);
+		} catch (BadImageFormatException exn) {
+			//Console.Error.WriteLine ("exn was {0}", exn);
+			return 0;
+		} catch (FileNotFoundException exn) {
+			Console.Error.WriteLine ("incorrect exn was {0}", exn);
+			return 2;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference ()
+	{
+		// Check that reflection-only loading a reference assembly is okay
+		var an = new AssemblyName ("TestingReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+	public static int test_0_load_reference_asm_via_reference ()
+	{
+		// Check that loading an assembly that references a reference assembly doesn't succeed.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		try {
+			var a = Assembly.Load (an);
+			var t = a.GetType ("Z");
+		} catch (FileNotFoundException){
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_asm_via_reference ()
+	{
+		// Check that reflection-only loading an assembly that
+		// references a reference assembly is okay.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("Z");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+
+	public static int test_0_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte array for execution is an error
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		try {
+			var a = Assembly.Load (bs);
+		} catch (BadImageFormatException) {
+			return 0;
+		} catch (FileNotFoundException exn) {
+			Console.Error.WriteLine ("incorrect exn was {0}", exn);
+			return 2;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte
+		// array for reflection only is okay.
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		var a = Assembly.ReflectionOnlyLoad (bs);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+}


### PR DESCRIPTION
Only load assemblies with the ReferenceAssemblyAttribute for reflection, not for execution.

Added a few tests:
 - using reflection api to open for execution throws an exception
 - using reflection api to open for reflection-only is okay
 - same thing as above two, but using `Load(byte[])`
 - compiled assembly references a reference assembly