### PR TITLE
Add missing source file, sgen-os-coop.c, to libmonoruntime Visual Studio project.

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1916,5 +1916,9 @@ mono_gchandle_free_domain (MonoDomain *domain)
 	}
 
 }
-
+#else
+	#ifdef _MSC_VER
+		// Quiet Visual Studio linker warning, LNK4221, in cases when this source file intentional ends up empty.
+		void __mono_win32_boehm_gc_quiet_lnk4221(void) {}
+	#endif
 #endif /* no Boehm GC */

--- a/mono/metadata/lock-tracer.c
+++ b/mono/metadata/lock-tracer.c
@@ -24,7 +24,6 @@
 
 #include "lock-tracer.h"
 
-
 /*
  * This is a very simple lock trace implementation. It can be used to verify that the runtime is
  * correctly following all locking rules.
@@ -141,5 +140,9 @@ mono_locks_lock_released (RuntimeLocks kind, gpointer lock)
 {
 	add_record (RECORD_LOCK_RELEASED, kind, lock);
 }
-
-#endif
+#else
+	#ifdef _MSC_VER
+		// Quiet Visual Studio linker warning, LNK4221, in cases when this source file intentional ends up empty.
+		void __mono_win32_lock_tracer_quiet_lnk4221(void) {}
+	#endif
+#endif /* LOCK_TRACER */

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -551,5 +551,9 @@ mono_gc_is_null (void)
 {
 	return TRUE;
 }
-
-#endif
+#else
+	#ifdef _MSC_VER
+		// Quiet Visual Studio linker warning, LNK4221, in cases when this source file intentional ends up empty.
+		void __mono_win32_null_gc_quiet_lnk4221(void) {}
+	#endif
+#endif /* HAVE_NULL_GC */

--- a/mono/metadata/sgen-os-coop.c
+++ b/mono/metadata/sgen-os-coop.c
@@ -9,6 +9,7 @@
  */
 
 #include "config.h"
+
 #ifdef HAVE_SGEN_GC
 
 
@@ -65,6 +66,10 @@ mono_gc_get_restart_signal (void)
 {
 	return -1;
 }
-
-#endif
+#else
+	#ifdef _MSC_VER
+		// Quiet Visual Studio linker warning, LNK4221, in cases when this source file intentional ends up empty.
+		void __mono_win32_sgen_os_coop_quiet_lnk4221(void) {}
+	#endif
+#endif /* USE_COOP_GC */
 #endif

--- a/msvc/libmonoruntime.vcxproj
+++ b/msvc/libmonoruntime.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -80,6 +80,7 @@
     <ClCompile Include="..\mono\metadata\mono-security.c" />
     <ClCompile Include="..\mono\metadata\seq-points-data.c" />
     <ClCompile Include="..\mono\metadata\sgen-mono.c" />
+    <ClCompile Include="..\mono\metadata\sgen-os-coop.c" />
     <ClCompile Include="..\mono\metadata\threadpool-ms-io.c" />
     <ClCompile Include="..\mono\metadata\threadpool-ms.c" />
     <ClCompile Include="..\mono\metadata\sgen-bridge.c" />

--- a/msvc/libmonoruntime.vcxproj.filters
+++ b/msvc/libmonoruntime.vcxproj.filters
@@ -223,6 +223,27 @@
     <ClCompile Include="..\mono\metadata\metadata-cross-helpers.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mono\metadata\custom-attrs.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\metadata\dynamic-image.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\metadata\dynamic-stream.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\metadata\sre.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\metadata\sre-encode.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\metadata\sre-save.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\metadata\sgen-os-coop.c">
+      <Filter>Source Files\sgen</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\mono\metadata\appdomain.h">
@@ -452,6 +473,24 @@
     </ClInclude>
     <ClInclude Include="..\mono\metadata\gc-internals.h">
       <Filter>Header Files\gc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\custom-attrs-internals.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\dynamic-image-internals.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\dynamic-stream-internals.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\reflection-cache.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\reflection-internals.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\sre-internals.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add missing source file, sgen-os-coop.c to project.

Add source files and headers into correct filters (Header/Source Files).

Eliminated Visual Studio linker warning LNK4221 for libmonoruntime project generated by empty source files under certain configurations, boehm-gc.c, lock-tracer.c, null-gc.c and sgen-os-coop.c.