### PR TITLE
Cleanup temp file handling in AssemblyTest

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
@@ -55,14 +55,27 @@ namespace MonoTests.System.Reflection
 	[TestFixture]
 	public class AssemblyTest
 	{
-		static string TempFolder = Path.Combine (Path.GetTempPath (),
+		static string BaseTempFolder = Path.Combine (Path.GetTempPath (),
 			"MonoTests.System.Reflection.AssemblyTest");
+		static string TempFolder;
+
+		[TestFixtureSetUp]
+		public void FixtureSetUp ()
+		{
+			try {
+				// Try to cleanup from any previous NUnit run.
+				Directory.Delete (BaseTempFolder, true);
+			} catch (Exception) {
+			}
+		}
 
 		[SetUp]
 		public void SetUp ()
 		{
-			while (Directory.Exists (TempFolder))
-				TempFolder = Path.Combine (TempFolder, "2");
+			int i = 0;
+			do {
+				TempFolder = Path.Combine (BaseTempFolder, (++i).ToString());
+			} while (Directory.Exists (TempFolder));
 			Directory.CreateDirectory (TempFolder);
 		}
 
@@ -70,8 +83,8 @@ namespace MonoTests.System.Reflection
 		public void TearDown ()
 		{
 			try {
-				// This throws an exception under MS.NET, since the directory contains loaded
-				// assemblies.
+				// This throws an exception under MS.NET and Mono on Windows,
+				// since the directory contains loaded assemblies.
 				Directory.Delete (TempFolder, true);
 			} catch (Exception) {
 			}
@@ -410,22 +423,21 @@ namespace MonoTests.System.Reflection
 		[Test] // bug #78517
 		public void LoadFrom_Empty_Assembly ()
 		{
-			string tempFile = Path.GetTempFileName ();
+			string tempFile = Path.Combine (TempFolder, Path.GetRandomFileName ());
+			File.CreateText (tempFile).Close ();
 
 			try {
 				Assembly.LoadFrom (tempFile);
 				Assert.Fail ("#1");
 			} catch (BadImageFormatException ex) {
 				Assert.IsNull (ex.InnerException, "#2");
-			} finally {
-				File.Delete (tempFile);
 			}
 		}
 
 		[Test] // bug #78517
 		public void LoadFrom_Invalid_Assembly ()
 		{
-			string tempFile = Path.GetTempFileName ();
+			string tempFile = Path.Combine (TempFolder, Path.GetRandomFileName ());
 			using (StreamWriter sw = File.CreateText (tempFile)) {
 				sw.WriteLine ("foo");
 				sw.Close ();
@@ -436,24 +448,19 @@ namespace MonoTests.System.Reflection
 				Assert.Fail ("#1");
 			} catch (BadImageFormatException ex) {
 				Assert.IsNull (ex.InnerException, "#2");
-			} finally {
-				File.Delete (tempFile);
 			}
 		}
 
 		[Test]
 		public void LoadFrom_NonExisting_Assembly ()
 		{
-			string tempFile = Path.GetTempFileName ();
-			File.Delete (tempFile);
+			string tempFile = Path.Combine (TempFolder, Path.GetRandomFileName ());
 
 			try {
 				Assembly.LoadFrom (tempFile);
 				Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.IsNull (ex.InnerException, "#2");
-			} finally {
-				File.Delete (tempFile);
 			}
 		}
 
@@ -520,28 +527,24 @@ namespace MonoTests.System.Reflection
 		[Test]
 		public void Location_Empty() {
 			string assemblyFileName = Path.Combine (
-				Path.GetTempPath (), "AssemblyLocation.dll");
+				TempFolder, "AssemblyLocation.dll");
 
-			try {
-				AssemblyName assemblyName = new AssemblyName ();
-				assemblyName.Name = "AssemblyLocation";
+			AssemblyName assemblyName = new AssemblyName ();
+			assemblyName.Name = "AssemblyLocation";
 
-				AssemblyBuilder ab = AppDomain.CurrentDomain
-					.DefineDynamicAssembly (assemblyName,
-					AssemblyBuilderAccess.Save,
-					Path.GetTempPath (),
-					AppDomain.CurrentDomain.Evidence);
-				ab.Save (Path.GetFileName (assemblyFileName));
+			AssemblyBuilder ab = AppDomain.CurrentDomain
+				.DefineDynamicAssembly (assemblyName,
+				AssemblyBuilderAccess.Save,
+				TempFolder,
+				AppDomain.CurrentDomain.Evidence);
+			ab.Save (Path.GetFileName (assemblyFileName));
 
-				using (FileStream fs = File.OpenRead (assemblyFileName)) {
-					byte[] buffer = new byte[fs.Length];
-					fs.Read (buffer, 0, buffer.Length);
-					Assembly assembly = Assembly.Load (buffer);
-					Assert.AreEqual (string.Empty, assembly.Location);
-					fs.Close ();
-				}
-			} finally {
-				File.Delete (assemblyFileName);
+			using (FileStream fs = File.OpenRead (assemblyFileName)) {
+				byte[] buffer = new byte[fs.Length];
+				fs.Read (buffer, 0, buffer.Length);
+				Assembly assembly = Assembly.Load (buffer);
+				Assert.AreEqual (string.Empty, assembly.Location);
+				fs.Close ();
 			}
 		}
 
@@ -549,56 +552,52 @@ namespace MonoTests.System.Reflection
 		public void SateliteAssemblyForInMemoryAssembly ()
 		{
 			string assemblyFileName = Path.Combine (
-				Path.GetTempPath (), "AssemblyLocation1.dll");
+				TempFolder, "AssemblyLocation1.dll");
 
-			try {
-				AssemblyName assemblyName = new AssemblyName ();
-				assemblyName.Name = "AssemblyLocation1";
+			AssemblyName assemblyName = new AssemblyName ();
+			assemblyName.Name = "AssemblyLocation1";
 
-				AssemblyBuilder ab = AppDomain.CurrentDomain
-					.DefineDynamicAssembly (assemblyName,
-						AssemblyBuilderAccess.Save,
-						Path.GetTempPath ());
+			AssemblyBuilder ab = AppDomain.CurrentDomain
+				.DefineDynamicAssembly (assemblyName,
+					AssemblyBuilderAccess.Save,
+					TempFolder);
 
-				ModuleBuilder moduleBuilder = ab.DefineDynamicModule (assemblyName.Name, assemblyName.Name + ".dll");
-				TypeBuilder typeBuilder = moduleBuilder.DefineType ("Program", TypeAttributes.Public);
+			ModuleBuilder moduleBuilder = ab.DefineDynamicModule (assemblyName.Name, assemblyName.Name + ".dll");
+			TypeBuilder typeBuilder = moduleBuilder.DefineType ("Program", TypeAttributes.Public);
 
-				MethodBuilder methodBuilder = typeBuilder.DefineMethod ("TestCall", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
-				ILGenerator gen = methodBuilder.GetILGenerator ();
+			MethodBuilder methodBuilder = typeBuilder.DefineMethod ("TestCall", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+			ILGenerator gen = methodBuilder.GetILGenerator ();
 
-				//
-				// 	var resourceManager = new ResourceManager (typeof (Program));
-				//	resourceManager.GetString ("test");
-				//
-				gen.Emit (OpCodes.Ldtoken, typeBuilder);
-				gen.Emit (OpCodes.Call, typeof(Type).GetMethod ("GetTypeFromHandle"));
-				gen.Emit (OpCodes.Newobj, typeof(ResourceManager).GetConstructor (new Type[] { typeof(Type) }));
-				gen.Emit (OpCodes.Ldstr, "test");
-				gen.Emit (OpCodes.Callvirt, typeof(ResourceManager).GetMethod ("GetString", new Type[] { typeof(string) }));
-				gen.Emit (OpCodes.Pop);
-				gen.Emit (OpCodes.Ret);
+			//
+			// 	var resourceManager = new ResourceManager (typeof (Program));
+			//	resourceManager.GetString ("test");
+			//
+			gen.Emit (OpCodes.Ldtoken, typeBuilder);
+			gen.Emit (OpCodes.Call, typeof(Type).GetMethod ("GetTypeFromHandle"));
+			gen.Emit (OpCodes.Newobj, typeof(ResourceManager).GetConstructor (new Type[] { typeof(Type) }));
+			gen.Emit (OpCodes.Ldstr, "test");
+			gen.Emit (OpCodes.Callvirt, typeof(ResourceManager).GetMethod ("GetString", new Type[] { typeof(string) }));
+			gen.Emit (OpCodes.Pop);
+			gen.Emit (OpCodes.Ret);
 
-				typeBuilder.CreateType ();
+			typeBuilder.CreateType ();
 
-				ab.Save (Path.GetFileName (assemblyFileName));
+			ab.Save (Path.GetFileName (assemblyFileName));
 
-				using (FileStream fs = File.OpenRead (assemblyFileName)) {
-					byte[] buffer = new byte[fs.Length];
-					fs.Read (buffer, 0, buffer.Length);
-					Assembly assembly = Assembly.Load (buffer);
+			using (FileStream fs = File.OpenRead (assemblyFileName)) {
+				byte[] buffer = new byte[fs.Length];
+				fs.Read (buffer, 0, buffer.Length);
+				Assembly assembly = Assembly.Load (buffer);
 
-					var mm = assembly.GetType ("Program").GetMethod ("TestCall");
-					try {
-						mm.Invoke (null, null);
-						Assert.Fail ();
-					} catch (TargetInvocationException e) {
-						Assert.IsTrue (e.InnerException is MissingManifestResourceException);
-					}
-
-					fs.Close ();
+				var mm = assembly.GetType ("Program").GetMethod ("TestCall");
+				try {
+					mm.Invoke (null, null);
+					Assert.Fail ();
+				} catch (TargetInvocationException e) {
+					Assert.IsTrue (e.InnerException is MissingManifestResourceException);
 				}
-			} finally {
-				File.Delete (assemblyFileName);
+
+				fs.Close ();
 			}
 		}
 
@@ -607,19 +606,15 @@ namespace MonoTests.System.Reflection
 		public void bug78464 ()
 		{
 			string assemblyFileName = Path.Combine (
-				Path.GetTempPath (), "bug78464.dll");
+				TempFolder, "bug78464.dll");
 
+			// execute test in separate appdomain to allow assembly to be unloaded
+			AppDomain testDomain = CreateTestDomain (AppDomain.CurrentDomain.BaseDirectory, false);
+			CrossDomainTester crossDomainTester = CreateCrossDomainTester (testDomain);
 			try {
-				// execute test in separate appdomain to allow assembly to be unloaded
-				AppDomain testDomain = CreateTestDomain (AppDomain.CurrentDomain.BaseDirectory, false);
-				CrossDomainTester crossDomainTester = CreateCrossDomainTester (testDomain);
-				try {
-					crossDomainTester.bug78464 (assemblyFileName);
-				} finally {
-					AppDomain.Unload (testDomain);
-				}
+				crossDomainTester.bug78464 (assemblyFileName);
 			} finally {
-				File.Delete (assemblyFileName);
+				AppDomain.Unload (testDomain);
 			}
 		}
 
@@ -628,36 +623,32 @@ namespace MonoTests.System.Reflection
 		public void bug78465 ()
 		{
 			string assemblyFileName = Path.Combine (
-				Path.GetTempPath (), "bug78465.dll");
+				TempFolder, "bug78465.dll");
 
+			AssemblyName assemblyName = new AssemblyName ();
+			assemblyName.Name = "bug78465";
+
+			AssemblyBuilder ab = AppDomain.CurrentDomain
+				.DefineDynamicAssembly (assemblyName,
+				AssemblyBuilderAccess.Save,
+				Path.GetDirectoryName (assemblyFileName),
+				AppDomain.CurrentDomain.Evidence);
+			ab.Save (Path.GetFileName (assemblyFileName));
+
+			using (FileStream fs = File.OpenRead (assemblyFileName)) {
+				byte[] buffer = new byte[fs.Length];
+				fs.Read (buffer, 0, buffer.Length);
+				Assembly assembly = Assembly.Load (buffer);
+				Assert.AreEqual (string.Empty, assembly.Location, "#1");
+				fs.Close ();
+			}
+
+			AppDomain testDomain = CreateTestDomain (AppDomain.CurrentDomain.BaseDirectory, false);
+			CrossDomainTester crossDomainTester = CreateCrossDomainTester (testDomain);
 			try {
-				AssemblyName assemblyName = new AssemblyName ();
-				assemblyName.Name = "bug78465";
-
-				AssemblyBuilder ab = AppDomain.CurrentDomain
-					.DefineDynamicAssembly (assemblyName,
-					AssemblyBuilderAccess.Save,
-					Path.GetDirectoryName (assemblyFileName),
-					AppDomain.CurrentDomain.Evidence);
-				ab.Save (Path.GetFileName (assemblyFileName));
-
-				using (FileStream fs = File.OpenRead (assemblyFileName)) {
-					byte[] buffer = new byte[fs.Length];
-					fs.Read (buffer, 0, buffer.Length);
-					Assembly assembly = Assembly.Load (buffer);
-					Assert.AreEqual (string.Empty, assembly.Location, "#1");
-					fs.Close ();
-				}
-
-				AppDomain testDomain = CreateTestDomain (AppDomain.CurrentDomain.BaseDirectory, false);
-				CrossDomainTester crossDomainTester = CreateCrossDomainTester (testDomain);
-				try {
-					crossDomainTester.bug78465 (assemblyFileName);
-				} finally {
-					AppDomain.Unload (testDomain);
-				}
+				crossDomainTester.bug78465 (assemblyFileName);
 			} finally {
-				File.Delete (assemblyFileName);
+				AppDomain.Unload (testDomain);
 			}
 		}
 
@@ -665,9 +656,9 @@ namespace MonoTests.System.Reflection
 		[Category("MobileNotWorking")]
 		public void bug78468 ()
 		{
-			string assemblyFileNameA = Path.Combine (Path.GetTempPath (),
+			string assemblyFileNameA = Path.Combine (TempFolder,
 				"bug78468a.dll");
-			string resourceFileName = Path.Combine (Path.GetTempPath (),
+			string resourceFileName = Path.Combine (TempFolder,
 				"readme.txt");
 
 			using (StreamWriter sw = File.CreateText (resourceFileName)) {
@@ -675,62 +666,56 @@ namespace MonoTests.System.Reflection
 				sw.Close ();
 			}
 
+			AssemblyName assemblyName = new AssemblyName ();
+			assemblyName.Name = "bug78468a";
+
+			AssemblyBuilder ab = AppDomain.CurrentDomain
+				.DefineDynamicAssembly (assemblyName,
+				AssemblyBuilderAccess.Save,
+				TempFolder,
+				AppDomain.CurrentDomain.Evidence);
+			ab.AddResourceFile ("read", "readme.txt");
+			ab.Save (Path.GetFileName (assemblyFileNameA));
+
+			Assembly assembly;
+
+			using (FileStream fs = File.OpenRead (assemblyFileNameA)) {
+				byte[] buffer = new byte[fs.Length];
+				fs.Read (buffer, 0, buffer.Length);
+				assembly = Assembly.Load (buffer);
+				fs.Close ();
+			}
+
+			Assert.AreEqual (string.Empty, assembly.Location, "#A1");
+			string[] resNames = assembly.GetManifestResourceNames ();
+			Assert.IsNotNull (resNames, "#A2");
+			Assert.AreEqual (1, resNames.Length, "#A3");
+			Assert.AreEqual ("read", resNames[0], "#A4");
+			ManifestResourceInfo resInfo = assembly.GetManifestResourceInfo ("read");
+			Assert.IsNotNull (resInfo, "#A5");
+			Assert.AreEqual ("readme.txt", resInfo.FileName, "#A6");
+			Assert.IsNull (resInfo.ReferencedAssembly, "#A7");
+			Assert.AreEqual ((ResourceLocation) 0, resInfo.ResourceLocation, "#A8");
 			try {
-				AssemblyName assemblyName = new AssemblyName ();
-				assemblyName.Name = "bug78468a";
+				assembly.GetManifestResourceStream ("read");
+				Assert.Fail ("#A9");
+			} catch (FileNotFoundException) {
+			}
+			try {
+				assembly.GetFile ("readme.txt");
+				Assert.Fail ("#A10");
+			} catch (FileNotFoundException) {
+			}
 
-				AssemblyBuilder ab = AppDomain.CurrentDomain
-					.DefineDynamicAssembly (assemblyName,
-					AssemblyBuilderAccess.Save,
-					Path.GetTempPath (),
-					AppDomain.CurrentDomain.Evidence);
-				ab.AddResourceFile ("read", "readme.txt");
-				ab.Save (Path.GetFileName (assemblyFileNameA));
+			string assemblyFileNameB = Path.Combine (TempFolder,
+				"bug78468b.dll");
 
-				Assembly assembly;
-
-				using (FileStream fs = File.OpenRead (assemblyFileNameA)) {
-					byte[] buffer = new byte[fs.Length];
-					fs.Read (buffer, 0, buffer.Length);
-					assembly = Assembly.Load (buffer);
-					fs.Close ();
-				}
-
-				Assert.AreEqual (string.Empty, assembly.Location, "#A1");
-				string[] resNames = assembly.GetManifestResourceNames ();
-				Assert.IsNotNull (resNames, "#A2");
-				Assert.AreEqual (1, resNames.Length, "#A3");
-				Assert.AreEqual ("read", resNames[0], "#A4");
-				ManifestResourceInfo resInfo = assembly.GetManifestResourceInfo ("read");
-				Assert.IsNotNull (resInfo, "#A5");
-				Assert.AreEqual ("readme.txt", resInfo.FileName, "#A6");
-				Assert.IsNull (resInfo.ReferencedAssembly, "#A7");
-				Assert.AreEqual ((ResourceLocation) 0, resInfo.ResourceLocation, "#A8");
-				try {
-					assembly.GetManifestResourceStream ("read");
-					Assert.Fail ("#A9");
-				} catch (FileNotFoundException) {
-				}
-				try {
-					assembly.GetFile ("readme.txt");
-					Assert.Fail ("#A10");
-				} catch (FileNotFoundException) {
-				}
-
-				string assemblyFileNameB = Path.Combine (Path.GetTempPath (),
-					"bug78468b.dll");
-
-				AppDomain testDomain = CreateTestDomain (AppDomain.CurrentDomain.BaseDirectory, false);
-				CrossDomainTester crossDomainTester = CreateCrossDomainTester (testDomain);
-				try {
-					crossDomainTester.bug78468 (assemblyFileNameB);
-				} finally {
-					AppDomain.Unload (testDomain);
-					File.Delete (assemblyFileNameB);
-				}
+			AppDomain testDomain = CreateTestDomain (AppDomain.CurrentDomain.BaseDirectory, false);
+			CrossDomainTester crossDomainTester = CreateCrossDomainTester (testDomain);
+			try {
+				crossDomainTester.bug78468 (assemblyFileNameB);
 			} finally {
-				File.Delete (assemblyFileNameA);
-				File.Delete (resourceFileName);
+				AppDomain.Unload (testDomain);
 			}
 		}
 
@@ -768,8 +753,7 @@ namespace MonoTests.System.Reflection
 		[Category ("NotWorking")] // patch for bug #79720 must be committed first
 		public void Load_Culture ()
 		{
-			string tempDir = Path.Combine (Path.GetTempPath (),
-				"MonoTests.System.Reflection.AssemblyTest");
+			string tempDir = TempFolder;
 			string cultureTempDir = Path.Combine (tempDir, "nl-BE");
 			if (!Directory.Exists (cultureTempDir))
 				Directory.CreateDirectory (cultureTempDir);
@@ -866,8 +850,6 @@ namespace MonoTests.System.Reflection
 				Assert.IsTrue (cdt.AssertFileNotFoundException (aname), "#D3");
 			} finally {
 				AppDomain.Unload (ad);
-				if (Directory.Exists (tempDir))
-					Directory.Delete (tempDir, true);
 			}
 		}
 
@@ -875,8 +857,7 @@ namespace MonoTests.System.Reflection
 		[Category ("NotWorking")] // in non-default domain, MS throws FileNotFoundException
 		public void Load_Culture_Mismatch ()
 		{
-			string tempDir = Path.Combine (Path.GetTempPath (),
-				"MonoTests.System.Reflection.AssemblyTest");
+			string tempDir = TempFolder;
 			string cultureTempDir = Path.Combine (tempDir, "en-US");
 			if (!Directory.Exists (cultureTempDir))
 				Directory.CreateDirectory (cultureTempDir);
@@ -910,8 +891,6 @@ namespace MonoTests.System.Reflection
 				Assert.IsTrue (cdt.AssertFileNotFoundException (aname), "#B1");
 			} finally {
 				AppDomain.Unload (ad);
-				if (Directory.Exists (tempDir))
-					Directory.Delete (tempDir, true);
 			}
 		}
 
@@ -920,10 +899,7 @@ namespace MonoTests.System.Reflection
 		[Category("MobileNotWorking")]
 		public void Load_PartialVersion ()
 		{
-			string tempDir = Path.Combine (Path.GetTempPath (),
-				"MonoTests.System.Reflection.AssemblyTest");
-			if (!Directory.Exists (tempDir))
-				Directory.CreateDirectory (tempDir);
+			string tempDir = TempFolder;
 
 			AppDomain ad = CreateTestDomain (tempDir, true);
 			try {
@@ -953,8 +929,6 @@ namespace MonoTests.System.Reflection
 				Assert.IsTrue (cdt.AssertLoad (aname.FullName), "#C2");
 			} finally {
 				AppDomain.Unload (ad);
-				if (Directory.Exists (tempDir))
-					Directory.Delete (tempDir, true);
 			}
 		}
 
@@ -1128,22 +1102,7 @@ namespace MonoTests.System.Reflection
 		[Test]
 		public void bug79872 ()
 		{
-			Random rnd = new Random ();
-			string outdir;
-			int tries = 0;
-
-		retry:
-			outdir = Path.Combine (Path.GetTempPath (), "bug79872-" + rnd.Next (10000, 99999));
-			if (Directory.Exists (outdir)) {
-				try {
-					Directory.Delete (outdir, true);
-				} catch {
-					if (++tries <= 100)
-						goto retry;
-				}
-			}
-
-			Directory.CreateDirectory (outdir);
+			string outdir = TempFolder;
 
 			AssemblyName an = new AssemblyName ();
 			an.Name = "bug79872";
@@ -1175,8 +1134,6 @@ namespace MonoTests.System.Reflection
 				// swallow the rest
 			}
 			Assert.IsTrue (ok, "Complain on loading a .NET metadata file without an assembly manifest");
-
-			Directory.Delete (outdir, true);
 		}
 #endif
 


### PR DESCRIPTION
SetUp() already sets up a temp folder for the test methods and TearDown() handles cleaning up and taking into account that on Windows, loaded assemblies cannot be deleted. However, some of the tests created temp files outside of this folder and had their own cleanup code which didn't expect temp files to be undeletable on Windows.

This patch removes any custom temp file creation/cleanup from individual test methods. It also slightly changes the way SetUp() created the temp folder for each test, now the paths will be shallower.