### PR TITLE
[corlib] Return e.HResult instead of PlatformNotSupportedException/-1 for Marshal.GetHRForException

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -422,16 +422,14 @@ namespace System.Runtime.InteropServices
 
 		public static int GetHRForException (Exception e)
 		{
+			if (e == null) return 0;
+
 #if FEATURE_COMINTEROP
 			var errorInfo = new ManagedErrorInfo(e);
 			SetErrorInfo (0, errorInfo);
+#endif
 
 			return e._HResult;
-#elif FULL_AOT_RUNTIME
-			throw new PlatformNotSupportedException ();
-#else			
-			return -1;
-#endif
 		}
 
 		[MonoTODO]

--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
@@ -260,6 +260,15 @@ namespace MonoTests.System.Runtime.InteropServices
 			}
 		}
 #endif
+
+		[Test]
+		public void GetHRForException ()
+		{
+			Assert.AreEqual (0, Marshal.GetHRForException (null));
+			Assert.Less (Marshal.GetHRForException (new Exception ()), 0);
+			Assert.AreEqual (12345, Marshal.GetHRForException (new IOException ("test message", 12345)));
+		}
+
 		[Test] // bug #319009
 		public void StringToHGlobalUni ()
 		{


### PR DESCRIPTION
Follow what coreclr/corefx does now: https://github.com/dotnet/coreclr/pull/6929.