### PR TITLE
[bcl] Fix method parameter names to match .NET

### DIFF
--- a/mcs/class/Facades/System.Net.Sockets/SocketTaskExtensions.cs
+++ b/mcs/class/Facades/System.Net.Sockets/SocketTaskExtensions.cs
@@ -28,12 +28,12 @@ namespace System.Net.Sockets
                 state: socket);
         }
 
-        public static Task ConnectAsync(this Socket socket, EndPoint remoteEndPoint)
+        public static Task ConnectAsync(this Socket socket, EndPoint remoteEP)
         {
             return Task.Factory.FromAsync(
                 (targetEndPoint, callback, state) => ((Socket)state).BeginConnect(targetEndPoint, callback, state),
                 asyncResult => ((Socket)asyncResult.AsyncState).EndConnect(asyncResult),
-                remoteEndPoint,
+                remoteEP,
                 state: socket);
         }
 
@@ -229,7 +229,7 @@ namespace System.Net.Sockets
             this Socket socket,
             ArraySegment<byte> buffer,
             SocketFlags socketFlags,
-            EndPoint remoteEndPoint)
+            EndPoint remoteEP)
         {
             return Task<int>.Factory.FromAsync(
                 (targetBuffer, flags, endPoint, callback, state) => ((Socket)state).BeginSendTo(
@@ -243,7 +243,7 @@ namespace System.Net.Sockets
                 asyncResult => ((Socket)asyncResult.AsyncState).EndSendTo(asyncResult),
                 buffer,
                 socketFlags,
-                remoteEndPoint,
+                remoteEP,
                 state: socket);
         }
     }

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlDataReader.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlDataReader.cs
@@ -38,6 +38,8 @@ using Mono.Data.Tds.Protocol;
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Collections;
 using System.ComponentModel;
 using System.Data;
@@ -1424,6 +1426,25 @@ namespace System.Data.SqlClient
 		public virtual XmlReader GetXmlReader (int i)
 		{
 			throw new NotImplementedException ();	
+		}
+
+		override public Task<T> GetFieldValueAsync<T> (int i, CancellationToken cancellationToken)
+		{
+			return base.GetFieldValueAsync<T> (i, cancellationToken);
+		}
+
+		override public Stream GetStream (int i)
+		{
+			return base.GetStream (i);
+		}
+		override public TextReader GetTextReader (int i)
+		{
+			return base.GetTextReader (i);
+		}
+
+		override public Task<bool> IsDBNullAsync (int i, CancellationToken cancellationToken)
+		{
+			return base.IsDBNullAsync (i, cancellationToken);
 		}
 
 		#endregion // Methods

--- a/mcs/class/System.Security/System.Security.Cryptography.Pkcs/AlgorithmIdentifier.cs
+++ b/mcs/class/System.Security/System.Security.Cryptography.Pkcs/AlgorithmIdentifier.cs
@@ -45,15 +45,15 @@ namespace System.Security.Cryptography.Pkcs {
 			_params = new byte [0];
 		}
 
-		public AlgorithmIdentifier (Oid algorithm)
+		public AlgorithmIdentifier (Oid oid)
 		{
-			_oid = algorithm;
+			_oid = oid;
 			_params = new byte [0];
 		}
 
-		public AlgorithmIdentifier (Oid algorithm, int keyLength)
+		public AlgorithmIdentifier (Oid oid, int keyLength)
 		{
-			_oid = algorithm;
+			_oid = oid;
 			_length = keyLength;
 			_params = new byte [0];
 		}

--- a/mcs/class/System.Security/System.Security.Cryptography.Pkcs/ContentInfo.cs
+++ b/mcs/class/System.Security/System.Security.Cryptography.Pkcs/ContentInfo.cs
@@ -53,14 +53,14 @@ namespace System.Security.Cryptography.Pkcs {
 		{
 		} 
 
-		public ContentInfo (Oid oid, byte[] content) 
+		public ContentInfo (Oid contentType, byte[] content) 
 		{
-			if (oid == null)
-				throw new ArgumentNullException ("oid");
+			if (contentType == null)
+				throw new ArgumentNullException ("contentType");
 			if (content == null)
 				throw new ArgumentNullException ("content");
 
-			_oid = oid;
+			_oid = contentType;
 			_content = content;
 		}
 

--- a/mcs/class/System.Security/System.Security.Cryptography.Pkcs/EnvelopedCms.cs
+++ b/mcs/class/System.Security/System.Security.Cryptography.Pkcs/EnvelopedCms.cs
@@ -61,12 +61,12 @@ namespace System.Security.Cryptography.Pkcs {
 			_uattribs = new CryptographicAttributeObjectCollection ();
 		}
 
-		public EnvelopedCms (ContentInfo content) : this ()
+		public EnvelopedCms (ContentInfo contentInfo) : this ()
 		{
-			if (content == null)
-				throw new ArgumentNullException ("content");
+			if (contentInfo == null)
+				throw new ArgumentNullException ("contentInfo");
 
-			_content = content;
+			_content = contentInfo;
 		}
 
 		public EnvelopedCms (ContentInfo contentInfo, AlgorithmIdentifier encryptionAlgorithm)

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/AddressHeader.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/AddressHeader.cs
@@ -45,9 +45,9 @@ namespace System.ServiceModel.Channels
 			return new DefaultAddressHeader (value);
 		}
 
-		public static AddressHeader CreateAddressHeader (object value, XmlObjectSerializer formatter)
+		public static AddressHeader CreateAddressHeader (object value, XmlObjectSerializer serializer)
 		{
-			return new DefaultAddressHeader (value, formatter);
+			return new DefaultAddressHeader (value, serializer);
 		}
 
 		public static AddressHeader CreateAddressHeader (string name, string ns, object value)
@@ -56,11 +56,11 @@ namespace System.ServiceModel.Channels
 		}
 
 		public static AddressHeader CreateAddressHeader (string name, string ns, object value, 
-								 XmlObjectSerializer formatter)
+								 XmlObjectSerializer serializer)
 		{
-			if (formatter == null)
-				throw new ArgumentNullException ("formatter");
-			return new DefaultAddressHeader (name, ns, value, formatter);
+			if (serializer == null)
+				throw new ArgumentNullException ("serializer");
+			return new DefaultAddressHeader (name, ns, value, serializer);
 		}
 
 		public override bool Equals (object obj)
@@ -93,9 +93,9 @@ namespace System.ServiceModel.Channels
 			return GetValue<T> (new DataContractSerializer (typeof (T)));
 		}
 
-		public T GetValue<T> (XmlObjectSerializer formatter)
+		public T GetValue<T> (XmlObjectSerializer serializer)
 		{
-			return (T) formatter.ReadObject (GetAddressHeaderReader ());
+			return (T) serializer.ReadObject (GetAddressHeaderReader ());
 		}
 
 		protected abstract void OnWriteAddressHeaderContents (XmlDictionaryWriter writer);

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/AddressHeaderCollection.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/AddressHeaderCollection.cs
@@ -47,8 +47,8 @@ namespace System.ServiceModel.Channels
 		{
 		}
 
-		public AddressHeaderCollection (IEnumerable<AddressHeader> headers)
-			: base (GetList (headers))
+		public AddressHeaderCollection (IEnumerable<AddressHeader> addressHeaders)
+			: base (GetList (addressHeaders))
 		{
 		}
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BindingContext.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BindingContext.cs
@@ -44,17 +44,17 @@ namespace System.ServiceModel.Channels
 		BindingElementCollection elements; // for internal use
 
 		public BindingContext (CustomBinding binding,
-			BindingParameterCollection parms)
+			BindingParameterCollection parameters)
 		{
 			if (binding == null)
 				throw new ArgumentNullException ("binding");
-			if (parms == null)
-				throw new ArgumentNullException ("parms");
+			if (parameters == null)
+				throw new ArgumentNullException ("parameters");
 
 			this.binding = binding;
-			parameters = new BindingParameterCollection ();
-			foreach (var item in parms)
-				parameters.Add (item);
+			this.parameters = new BindingParameterCollection ();
+			foreach (var item in parameters)
+				this.parameters.Add (item);
 			this.elements = new BindingElementCollection ();
 			foreach (var item in binding.Elements)
 				this.elements.Add (item);

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BindingElement.cs
@@ -40,7 +40,7 @@ namespace System.ServiceModel.Channels
 		}
 
 		[MonoTODO]
-		protected BindingElement (BindingElement other)
+		protected BindingElement (BindingElement elementToBeCloned)
 		{
 		}
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BindingElementCollection.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BindingElementCollection.cs
@@ -38,14 +38,14 @@ namespace System.ServiceModel.Channels
 		{
 		}
 
-		public BindingElementCollection (BindingElement [] bindings)
+		public BindingElementCollection (BindingElement [] elements)
 		{
-			AddRange (bindings);
+			AddRange (elements);
 		}
 
-		public BindingElementCollection (IEnumerable<BindingElement> bindings)
+		public BindingElementCollection (IEnumerable<BindingElement> elements)
 		{
-			foreach (BindingElement e in bindings)
+			foreach (BindingElement e in elements)
 				Add (e);
 		}
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/ChannelBase.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/ChannelBase.cs
@@ -39,9 +39,9 @@ namespace System.ServiceModel.Channels
 	{
 		ChannelManagerBase manager;
 
-		protected ChannelBase (ChannelManagerBase manager)
+		protected ChannelBase (ChannelManagerBase channelManager)
 		{
-			this.manager = manager;
+			this.manager = channelManager;
 		}
 
 		protected internal override TimeSpan DefaultCloseTimeout {

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/ChannelFactoryBase.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/ChannelFactoryBase.cs
@@ -98,29 +98,29 @@ namespace System.ServiceModel.Channels
 		}
 
 		public TChannel CreateChannel (
-			EndpointAddress remoteAddress)
+			EndpointAddress address)
 		{
-			if (remoteAddress == null)
-				throw new ArgumentNullException ("remoteAddress");
-			return CreateChannel (remoteAddress, remoteAddress.Uri);
+			if (address == null)
+				throw new ArgumentNullException ("address");
+			return CreateChannel (address, address.Uri);
 		}
 
 		public TChannel CreateChannel (
-			EndpointAddress remoteAddress, Uri via)
+			EndpointAddress address, Uri via)
 		{
-			if (remoteAddress == null)
-				throw new ArgumentNullException ("remoteAddress");
+			if (address == null)
+				throw new ArgumentNullException ("address");
 			if (via == null)
 				throw new ArgumentNullException ("via");
 
 			ValidateCreateChannel ();
-			var ch = OnCreateChannel (remoteAddress, via);
+			var ch = OnCreateChannel (address, via);
 			channels.Add (ch);
 			return ch;
 		}
 
 		protected abstract TChannel OnCreateChannel (
-			EndpointAddress remoteAddress, Uri via);
+			EndpointAddress address, Uri via);
 
 		protected override void OnAbort ()
 		{

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/CustomBinding.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/CustomBinding.cs
@@ -68,19 +68,19 @@ namespace System.ServiceModel.Channels
 			security = binding as ISecurityCapabilities;
 		}
 
-		public CustomBinding (params BindingElement [] binding)
-			: this ("CustomBinding", default_ns, binding)
+		public CustomBinding (params BindingElement [] bindingElementsInTopDownChannelStackOrder)
+			: this ("CustomBinding", default_ns, bindingElementsInTopDownChannelStackOrder)
 		{
 		}
 
-		public CustomBinding (IEnumerable<BindingElement> bindingElements)
-			: this (bindingElements, "CustomBinding", default_ns)
+		public CustomBinding (IEnumerable<BindingElement> bindingElementsInTopDownChannelStackOrder)
+			: this (bindingElementsInTopDownChannelStackOrder, "CustomBinding", default_ns)
 		{
 		}
 
 		public CustomBinding (string name, string ns,
-			params BindingElement [] binding)
-			: this (binding, name, ns)
+			params BindingElement [] bindingElementsInTopDownChannelStackOrder)
+			: this (bindingElementsInTopDownChannelStackOrder, name, ns)
 		{
 		}
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/FaultConverter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/FaultConverter.cs
@@ -47,20 +47,20 @@ namespace System.ServiceModel.Channels
 
 		[MonoTODO]
 		protected abstract bool OnTryCreateException (
-			Message message, MessageFault fault, out Exception error);
+			Message message, MessageFault fault, out Exception exception);
 
 		[MonoTODO]
 		protected abstract bool OnTryCreateFaultMessage (
-			Exception error, out Message message);
+			Exception exception, out Message message);
 
-		public bool TryCreateException (Message message, MessageFault fault, out Exception error)
+		public bool TryCreateException (Message message, MessageFault fault, out Exception exception)
 		{
-			return OnTryCreateException (message, fault, out error);
+			return OnTryCreateException (message, fault, out exception);
 		}
 
-		public bool TryCreateFaultMessage (Exception error, out Message message)
+		public bool TryCreateFaultMessage (Exception exception, out Message message)
 		{
-			return OnTryCreateFaultMessage (error, out message);
+			return OnTryCreateFaultMessage (exception, out message);
 		}
 	}
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/HttpTransportBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/HttpTransportBindingElement.cs
@@ -67,28 +67,28 @@ namespace System.ServiceModel.Channels
 		}
 
 		protected HttpTransportBindingElement (
-			HttpTransportBindingElement other)
-			: base (other)
+			HttpTransportBindingElement elementToBeCloned)
+			: base (elementToBeCloned)
 		{
-			allow_cookies = other.allow_cookies;
-			bypass_proxy_on_local = other.bypass_proxy_on_local;
-			unsafe_ntlm_auth = other.unsafe_ntlm_auth;
-			use_default_proxy = other.use_default_proxy;
-			keep_alive_enabled = other.keep_alive_enabled;
-			max_buffer_size = other.max_buffer_size;
-			host_cmp_mode = other.host_cmp_mode;
-			proxy_address = other.proxy_address;
-			realm = other.realm;
-			transfer_mode = other.transfer_mode;
+			allow_cookies = elementToBeCloned.allow_cookies;
+			bypass_proxy_on_local = elementToBeCloned.bypass_proxy_on_local;
+			unsafe_ntlm_auth = elementToBeCloned.unsafe_ntlm_auth;
+			use_default_proxy = elementToBeCloned.use_default_proxy;
+			keep_alive_enabled = elementToBeCloned.keep_alive_enabled;
+			max_buffer_size = elementToBeCloned.max_buffer_size;
+			host_cmp_mode = elementToBeCloned.host_cmp_mode;
+			proxy_address = elementToBeCloned.proxy_address;
+			realm = elementToBeCloned.realm;
+			transfer_mode = elementToBeCloned.transfer_mode;
 			// FIXME: it does not look safe
-			timeouts = other.timeouts;
-			auth_scheme = other.auth_scheme;
-			proxy_auth_scheme = other.proxy_auth_scheme;
+			timeouts = elementToBeCloned.timeouts;
+			auth_scheme = elementToBeCloned.auth_scheme;
+			proxy_auth_scheme = elementToBeCloned.proxy_auth_scheme;
 
-			DecompressionEnabled = other.DecompressionEnabled;
-			LegacyExtendedProtectionPolicy = other.LegacyExtendedProtectionPolicy;
-			ExtendedProtectionPolicy = other.ExtendedProtectionPolicy;
-			cookie_manager = other.cookie_manager;
+			DecompressionEnabled = elementToBeCloned.DecompressionEnabled;
+			LegacyExtendedProtectionPolicy = elementToBeCloned.LegacyExtendedProtectionPolicy;
+			ExtendedProtectionPolicy = elementToBeCloned.ExtendedProtectionPolicy;
+			cookie_manager = elementToBeCloned.cookie_manager;
 		}
 
 		[DefaultValue (AuthenticationSchemes.Anonymous)]

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/HttpsTransportBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/HttpsTransportBindingElement.cs
@@ -47,10 +47,10 @@ namespace System.ServiceModel.Channels
 		}
 
 		protected HttpsTransportBindingElement (
-			HttpsTransportBindingElement other)
-			: base (other)
+			HttpsTransportBindingElement elementToBeCloned)
+			: base (elementToBeCloned)
 		{
-			req_cli_cert = other.req_cli_cert;
+			req_cli_cert = elementToBeCloned.req_cli_cert;
 		}
 
 		public bool RequireClientCertificate {

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/Message.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/Message.cs
@@ -98,10 +98,10 @@ namespace System.ServiceModel.Channels
 			return OnGetBody<T> (GetReaderAtBodyContents ());
 		}
 
-		public T GetBody<T> (XmlObjectSerializer xmlFormatter)
+		public T GetBody<T> (XmlObjectSerializer serializer)
 		{
 			// FIXME: Somehow use OnGetBody() here as well?
-			return (T)xmlFormatter.ReadObject (GetReaderAtBodyContents ());
+			return (T)serializer.ReadObject (GetReaderAtBodyContents ());
 		}
 
 		protected virtual T OnGetBody<T> (XmlDictionaryReader reader)
@@ -369,13 +369,13 @@ namespace System.ServiceModel.Channels
 
 		// 5)
 		public static Message CreateMessage (MessageVersion version,
-			string action, object body, XmlObjectSerializer xmlFormatter)
+			string action, object body, XmlObjectSerializer serializer)
 		{
 			return body == null ?
 				CreateMessage (version, action) :
 				CreateMessage (
 					version, action,
-					new XmlObjectSerializerBodyWriter (body, xmlFormatter));
+					new XmlObjectSerializerBodyWriter (body, serializer));
 		}
 
 		// 6)

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageEncodingBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageEncodingBindingElement.cs
@@ -42,9 +42,9 @@ namespace System.ServiceModel.Channels
 
 		[MonoTODO]
 		public
-		MessageEncodingBindingElement (MessageEncodingBindingElement source)
+		MessageEncodingBindingElement (MessageEncodingBindingElement elementToBeCloned)
 		{
-			MessageVersion = source.MessageVersion;
+			MessageVersion = elementToBeCloned.MessageVersion;
 		}
 
 		public abstract MessageEncoderFactory
@@ -52,11 +52,11 @@ namespace System.ServiceModel.Channels
 
 		public abstract MessageVersion MessageVersion { get; set; }
 
-		public override T GetProperty<T> (BindingContext ctx)
+		public override T GetProperty<T> (BindingContext context)
 		{
 			if (typeof (T) == typeof (MessageVersion))
 				return (T) (object) MessageVersion;
-			return ctx.GetInnerProperty<T> ();
+			return context.GetInnerProperty<T> ();
 		}
 
 #if !MOBILE && !XAMMAC_4_5

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
@@ -397,12 +397,12 @@ namespace System.ServiceModel.Channels
 			return GetDetail<T> (new DataContractSerializer (typeof (T)));
 		}
 
-		public T GetDetail<T> (XmlObjectSerializer formatter)
+		public T GetDetail<T> (XmlObjectSerializer serializer)
 		{
 			if (!HasDetail)
 				throw new InvalidOperationException ("This message does not have details.");
 
-			return (T) formatter.ReadObject (GetReaderAtDetailContents ());
+			return (T) serializer.ReadObject (GetReaderAtDetailContents ());
 		}
 
 		public XmlDictionaryReader GetReaderAtDetailContents ()

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageHeader.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageHeader.cs
@@ -59,56 +59,56 @@ namespace System.ServiceModel.Channels
 			return CreateHeader (name, ns, value, default_must_understand);
 		}
 
-		public static MessageHeader CreateHeader (string name, string ns, object value, bool must_understand)
+		public static MessageHeader CreateHeader (string name, string ns, object value, bool mustUnderstand)
 		{
-			return CreateHeader (name, ns, value, must_understand, default_actor);
+			return CreateHeader (name, ns, value, mustUnderstand, default_actor);
 		}
 
-		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer formatter)
+		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer serializer)
 		{
-			return CreateHeader (name, ns, value, formatter, default_must_understand, 
+			return CreateHeader (name, ns, value, serializer, default_must_understand, 
 					     default_actor, default_relay);
 		}
 
 		public static MessageHeader CreateHeader (string name, string ns, object value, 
-						   bool must_understand, string actor)
+						   bool mustUnderstand, string actor)
 		{
-			return CreateHeader (name, ns, value, must_understand, actor, default_relay);
+			return CreateHeader (name, ns, value, mustUnderstand, actor, default_relay);
 		}
 
-		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer formatter, 
-						   bool must_understand)
+		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer serializer, 
+						   bool mustUnderstand)
 		{
-			return CreateHeader (name, ns, value, formatter, must_understand, default_actor, default_relay);
+			return CreateHeader (name, ns, value, serializer, mustUnderstand, default_actor, default_relay);
 		}
 		
 		public static MessageHeader CreateHeader (string name, string ns, object value, 
-						   bool must_understand, string actor, bool relay)
+						   bool mustUnderstand, string actor, bool relay)
 		{
 			return CreateHeader (name, ns, value, new DataContractSerializer (value.GetType ()),
-					must_understand, actor, relay);
+					mustUnderstand, actor, relay);
 		}
 
-		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer formatter,
-						   bool must_understand, string actor)
+		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer serializer,
+						   bool mustUnderstand, string actor)
 		{
-			return CreateHeader (name, ns, value, formatter, must_understand, actor, default_relay);
+			return CreateHeader (name, ns, value, serializer, mustUnderstand, actor, default_relay);
 		}
 		
-		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer formatter,
-						   bool must_understand, string actor, bool relay)
+		public static MessageHeader CreateHeader (string name, string ns, object value, XmlObjectSerializer serializer,
+						   bool mustUnderstand, string actor, bool relay)
 		{
 			// FIXME: how to get IsReferenceParameter ?
-			return new DefaultMessageHeader (name, ns, value, formatter, default_is_ref, must_understand, actor, relay);
+			return new DefaultMessageHeader (name, ns, value, serializer, default_is_ref, mustUnderstand, actor, relay);
 		}
 
-		public virtual bool IsMessageVersionSupported (MessageVersion version)
+		public virtual bool IsMessageVersionSupported (MessageVersion messageVersion)
 		{
-			if (version.Envelope == EnvelopeVersion.Soap12)
+			if (messageVersion.Envelope == EnvelopeVersion.Soap12)
 				if (Actor == EnvelopeVersion.Soap11.NextDestinationActorValue)
 					return false;
 
-			if (version.Envelope == EnvelopeVersion.Soap11)
+			if (messageVersion.Envelope == EnvelopeVersion.Soap11)
 				if (Actor == EnvelopeVersion.Soap12.NextDestinationActorValue ||
 				    Actor == EnvelopeVersion.Soap12UltimateReceiver)
 					return false;
@@ -117,9 +117,9 @@ namespace System.ServiceModel.Channels
 			return true;
 		}
 
-		protected abstract void OnWriteHeaderContents (XmlDictionaryWriter writer, MessageVersion version);
+		protected abstract void OnWriteHeaderContents (XmlDictionaryWriter writer, MessageVersion messageVersion);
 
-		protected virtual void OnWriteStartHeader (XmlDictionaryWriter writer, MessageVersion version)
+		protected virtual void OnWriteStartHeader (XmlDictionaryWriter writer, MessageVersion messageVersion)
 		{
 			var dic = Constants.SoapDictionary;
 			XmlDictionaryString name, ns;
@@ -128,7 +128,7 @@ namespace System.ServiceModel.Channels
 				writer.WriteStartElement (prefix, name, ns);
 			else
 				writer.WriteStartElement (prefix, this.Name, this.Namespace);
-			WriteHeaderAttributes (writer, version);
+			WriteHeaderAttributes (writer, messageVersion);
 		}
 
 		public override string ToString ()
@@ -143,58 +143,58 @@ namespace System.ServiceModel.Channels
 			return sb.ToString ();
 		}
 
-		public void WriteHeader (XmlDictionaryWriter writer, MessageVersion version)
+		public void WriteHeader (XmlDictionaryWriter writer, MessageVersion messageVersion)
 		{
 			if (writer == null)
 				throw new ArgumentNullException ("writer is null.");
 
-			if (version == null)
-				throw new ArgumentNullException ("version is null.");
+			if (messageVersion == null)
+				throw new ArgumentNullException ("messageVersion is null.");
 
-			if (version.Envelope == EnvelopeVersion.None)
+			if (messageVersion.Envelope == EnvelopeVersion.None)
 				return;
 
-			WriteStartHeader (writer, version);
-			WriteHeaderContents (writer, version);
+			WriteStartHeader (writer, messageVersion);
+			WriteHeaderContents (writer, messageVersion);
 
 			writer.WriteEndElement ();
 		}
 
-		public void WriteHeader (XmlWriter writer, MessageVersion version)
+		public void WriteHeader (XmlWriter writer, MessageVersion messageVersion)
 		{
-			WriteHeader (XmlDictionaryWriter.CreateDictionaryWriter (writer), version);
+			WriteHeader (XmlDictionaryWriter.CreateDictionaryWriter (writer), messageVersion);
 		}
 
-		protected void WriteHeaderAttributes (XmlDictionaryWriter writer, MessageVersion version)
+		protected void WriteHeaderAttributes (XmlDictionaryWriter writer, MessageVersion messageVersion)
 		{
 			var dic = Constants.SoapDictionary;
 			if (Id != null)
 				writer.WriteAttributeString ("u", dic.Add ("Id"), dic.Add (Constants.WsuNamespace), Id);
 			if (!String.IsNullOrEmpty (Actor)) {
-				if (version.Envelope == EnvelopeVersion.Soap11) 
-					writer.WriteAttributeString ("s", dic.Add ("actor"), dic.Add (version.Envelope.Namespace), Actor);
+				if (messageVersion.Envelope == EnvelopeVersion.Soap11) 
+					writer.WriteAttributeString ("s", dic.Add ("actor"), dic.Add (messageVersion.Envelope.Namespace), Actor);
 
-				if (version.Envelope == EnvelopeVersion.Soap12) 
-					writer.WriteAttributeString ("s", dic.Add ("role"), dic.Add (version.Envelope.Namespace), Actor);
+				if (messageVersion.Envelope == EnvelopeVersion.Soap12) 
+					writer.WriteAttributeString ("s", dic.Add ("role"), dic.Add (messageVersion.Envelope.Namespace), Actor);
 			}
 
 			// mustUnderstand is the same across SOAP 1.1 and 1.2
 			if (MustUnderstand == true)
-				writer.WriteAttributeString ("s", dic.Add ("mustUnderstand"), dic.Add (version.Envelope.Namespace), "1");
+				writer.WriteAttributeString ("s", dic.Add ("mustUnderstand"), dic.Add (messageVersion.Envelope.Namespace), "1");
 
 			// relay is only available on SOAP 1.2
-			if (Relay == true && version.Envelope == EnvelopeVersion.Soap12)
-				writer.WriteAttributeString ("s", dic.Add ("relay"), dic.Add (version.Envelope.Namespace), "true");
+			if (Relay == true && messageVersion.Envelope == EnvelopeVersion.Soap12)
+				writer.WriteAttributeString ("s", dic.Add ("relay"), dic.Add (messageVersion.Envelope.Namespace), "true");
 		}
 
-		public void WriteHeaderContents (XmlDictionaryWriter writer, MessageVersion version)
+		public void WriteHeaderContents (XmlDictionaryWriter writer, MessageVersion messageVersion)
 		{
-			this.OnWriteHeaderContents (writer, version);
+			this.OnWriteHeaderContents (writer, messageVersion);
 		}
 
-		public void WriteStartHeader (XmlDictionaryWriter writer, MessageVersion version)
+		public void WriteStartHeader (XmlDictionaryWriter writer, MessageVersion messageVersion)
 		{
-			this.OnWriteStartHeader (writer, version);
+			this.OnWriteStartHeader (writer, messageVersion);
 		}
 
 		public override string Actor { get { return default_actor; }}

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageHeaders.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageHeaders.cs
@@ -72,9 +72,9 @@ namespace System.ServiceModel.Channels
 			l.Add (header);
 		}
 
-		public void CopyHeaderFrom (Message m, int index)
+		public void CopyHeaderFrom (Message message, int headerIndex)
 		{
-			CopyHeaderFrom (m.Headers, index);
+			CopyHeaderFrom (message.Headers, headerIndex);
 		}
 
 		public void Clear ()
@@ -82,25 +82,25 @@ namespace System.ServiceModel.Channels
 			l.Clear ();
 		}
 
-		public void CopyHeaderFrom (MessageHeaders headers, int index)
+		public void CopyHeaderFrom (MessageHeaders collection, int headerIndex)
 		{
-			l.Add (headers [index]);
+			l.Add (collection [headerIndex]);
 		}
 
-		public void CopyHeadersFrom (Message m)
+		public void CopyHeadersFrom (Message message)
 		{
-			CopyHeadersFrom (m.Headers);
+			CopyHeadersFrom (message.Headers);
 		}
 
-		public void CopyHeadersFrom (MessageHeaders headers)
+		public void CopyHeadersFrom (MessageHeaders collection)
 		{
-			foreach (MessageHeaderInfo h in headers)
+			foreach (MessageHeaderInfo h in collection)
 				l.Add (h);
 		}
 
-		public void CopyTo (MessageHeaderInfo [] dst, int index)
+		public void CopyTo (MessageHeaderInfo [] array, int index)
 		{
-			l.CopyTo (dst, index);
+			l.CopyTo (array, index);
 		}
 
 		public int FindHeader (string name, string ns)
@@ -203,11 +203,11 @@ namespace System.ServiceModel.Channels
 			return GetHeader<T> (idx, serializer);
 		}
 
-		public XmlDictionaryReader GetReaderAtHeader (int index)
+		public XmlDictionaryReader GetReaderAtHeader (int headerIndex)
 		{
-			if (index >= l.Count)
-				throw new ArgumentOutOfRangeException (String.Format ("Index is out of range. Current header count is {0}", index));
-			MessageHeader item = (MessageHeader) l [index];
+			if (headerIndex >= l.Count)
+				throw new ArgumentOutOfRangeException (String.Format ("Index is out of range. Current header count is {0}", l.Count));
+			MessageHeader item = (MessageHeader) l [headerIndex];
 
 			XmlReader reader =
 				item is MessageHeader.XmlMessageHeader ?
@@ -231,9 +231,9 @@ namespace System.ServiceModel.Channels
 			throw new NotImplementedException ();
 		}
 
-		public void Insert (int index, MessageHeader header)
+		public void Insert (int headerIndex, MessageHeader header)
 		{
-			l.Insert (index, header);
+			l.Insert (headerIndex, header);
 		}
 
 		public void RemoveAll (string name, string ns)
@@ -251,9 +251,9 @@ namespace System.ServiceModel.Channels
 				l.RemoveAt (l.Count - 1);
 		}
 
-		public void RemoveAt (int index)
+		public void RemoveAt (int headerIndex)
 		{
-			l.RemoveAt (index);
+			l.RemoveAt (headerIndex);
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()
@@ -261,48 +261,48 @@ namespace System.ServiceModel.Channels
 			return ((IEnumerable) l).GetEnumerator ();
 		}
 
-		public void WriteHeader (int index, XmlDictionaryWriter writer)
+		public void WriteHeader (int headerIndex, XmlDictionaryWriter writer)
 		{
 			if (version.Envelope == EnvelopeVersion.None)
 				return;
-			WriteStartHeader (index, writer);
-			WriteHeaderContents (index, writer);
+			WriteStartHeader (headerIndex, writer);
+			WriteHeaderContents (headerIndex, writer);
 			writer.WriteEndElement ();
 		}
 
-		public void WriteHeader (int index, XmlWriter writer)
+		public void WriteHeader (int headerIndex, XmlWriter writer)
 		{
-			WriteHeader (index, XmlDictionaryWriter.CreateDictionaryWriter (writer));
+			WriteHeader (headerIndex, XmlDictionaryWriter.CreateDictionaryWriter (writer));
 		}
 
-		public void WriteHeaderContents (int index, XmlDictionaryWriter writer)
+		public void WriteHeaderContents (int headerIndex, XmlDictionaryWriter writer)
 		{
-			if (index > l.Count)
-				throw new ArgumentOutOfRangeException ("There is no header at position " + index + ".");
+			if (headerIndex > l.Count)
+				throw new ArgumentOutOfRangeException ("There is no header at position " + headerIndex + ".");
 			
-			MessageHeader h = l [index] as MessageHeader;
+			MessageHeader h = l [headerIndex] as MessageHeader;
 
 			h.WriteHeaderContents (writer, version);
 		}
 
-		public void WriteHeaderContents (int index, XmlWriter writer)
+		public void WriteHeaderContents (int headerIndex, XmlWriter writer)
 		{
-			WriteHeaderContents (index, XmlDictionaryWriter.CreateDictionaryWriter (writer));
+			WriteHeaderContents (headerIndex, XmlDictionaryWriter.CreateDictionaryWriter (writer));
 		}
 
-		public void WriteStartHeader (int index, XmlDictionaryWriter writer)
+		public void WriteStartHeader (int headerIndex, XmlDictionaryWriter writer)
 		{
-			if (index > l.Count)
-				throw new ArgumentOutOfRangeException ("There is no header at position " + index + ".");
+			if (headerIndex > l.Count)
+				throw new ArgumentOutOfRangeException ("There is no header at position " + headerIndex + ".");
 
-			MessageHeader h = l [index] as MessageHeader;
+			MessageHeader h = l [headerIndex] as MessageHeader;
 			
 			h.WriteStartHeader (writer, version);
 		}
 
-		public void WriteStartHeader (int index, XmlWriter writer)
+		public void WriteStartHeader (int headerIndex, XmlWriter writer)
 		{
-			WriteStartHeader (index, XmlDictionaryWriter.CreateDictionaryWriter (writer));
+			WriteStartHeader (headerIndex, XmlDictionaryWriter.CreateDictionaryWriter (writer));
 		}
 
 		public string Action {

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageVersion.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageVersion.cs
@@ -53,36 +53,36 @@ namespace System.ServiceModel.Channels {
 			this.addressing = addressing;
 		}
 		
-		public static MessageVersion CreateVersion (EnvelopeVersion envelope_version)
+		public static MessageVersion CreateVersion (EnvelopeVersion envelopeVersion)
 		{
-			return CreateVersion (envelope_version,
+			return CreateVersion (envelopeVersion,
 				AddressingVersion.WSAddressing10);
 		}
 
-		public static MessageVersion CreateVersion (EnvelopeVersion envelope_version,
-							    AddressingVersion addressing_version)
+		public static MessageVersion CreateVersion (EnvelopeVersion envelopeVersion,
+							    AddressingVersion addressingVersion)
 		{
-			if (envelope_version == EnvelopeVersion.None && addressing_version == AddressingVersion.None)
+			if (envelopeVersion == EnvelopeVersion.None && addressingVersion == AddressingVersion.None)
 				return None;
-			if (envelope_version == EnvelopeVersion.Soap11 && addressing_version == AddressingVersion.None)
+			if (envelopeVersion == EnvelopeVersion.Soap11 && addressingVersion == AddressingVersion.None)
 				return Soap11;
-			if (envelope_version == EnvelopeVersion.Soap12 && addressing_version == AddressingVersion.WSAddressing10)
+			if (envelopeVersion == EnvelopeVersion.Soap12 && addressingVersion == AddressingVersion.WSAddressing10)
 				return Soap12WSAddressing10;
 
-			if (envelope_version == EnvelopeVersion.Soap12 && addressing_version == AddressingVersion.None)
+			if (envelopeVersion == EnvelopeVersion.Soap12 && addressingVersion == AddressingVersion.None)
 				return Soap12;
-			if (envelope_version == EnvelopeVersion.Soap11 && addressing_version == AddressingVersion.WSAddressing10)
+			if (envelopeVersion == EnvelopeVersion.Soap11 && addressingVersion == AddressingVersion.WSAddressing10)
 				return Soap11WSAddressing10;
-			if (envelope_version == EnvelopeVersion.Soap11 && addressing_version == AddressingVersion.WSAddressingAugust2004)
+			if (envelopeVersion == EnvelopeVersion.Soap11 && addressingVersion == AddressingVersion.WSAddressingAugust2004)
 				return Soap11WSAddressingAugust2004;
-			if (envelope_version == EnvelopeVersion.Soap12 && addressing_version == AddressingVersion.WSAddressingAugust2004)
+			if (envelopeVersion == EnvelopeVersion.Soap12 && addressingVersion == AddressingVersion.WSAddressingAugust2004)
 				return Soap12WSAddressingAugust2004;
-			throw new ArgumentException (string.Format ("EnvelopeVersion {0} cannot be used with AddressingVersion {1}", envelope_version, addressing_version));
+			throw new ArgumentException (string.Format ("EnvelopeVersion {0} cannot be used with AddressingVersion {1}", envelopeVersion, addressingVersion));
 		}
 
-		public override bool Equals (object value)
+		public override bool Equals (object obj)
 		{
-			MessageVersion other = value as MessageVersion;
+			MessageVersion other = obj as MessageVersion;
 
 			if (other == null)
 				return false;

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/SecurityBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/SecurityBindingElement.cs
@@ -531,29 +531,29 @@ namespace System.ServiceModel.Channels
 #endif
 
 		public static SecurityBindingElement 
-			CreateSecureConversationBindingElement (SecurityBindingElement binding)
+			CreateSecureConversationBindingElement (SecurityBindingElement bootstrapSecurity)
 		{
-			return CreateSecureConversationBindingElement (binding, false);
+			return CreateSecureConversationBindingElement (bootstrapSecurity, false);
 		}
 
 		public static SecurityBindingElement 
 			CreateSecureConversationBindingElement (
-			SecurityBindingElement binding, bool requireCancellation)
+			SecurityBindingElement bootstrapSecurity, bool requireCancellation)
 		{
-			return CreateSecureConversationBindingElement (binding, requireCancellation, null);
+			return CreateSecureConversationBindingElement (bootstrapSecurity, requireCancellation, null);
 		}
 
 		public static SecurityBindingElement 
 			CreateSecureConversationBindingElement (
-			SecurityBindingElement binding, bool requireCancellation,
-			ChannelProtectionRequirements protectionRequirements)
+			SecurityBindingElement bootstrapSecurity, bool requireCancellation,
+			ChannelProtectionRequirements bootstrapProtectionRequirements)
 		{
 #if !MOBILE && !XAMMAC_4_5
 			SymmetricSecurityBindingElement be =
 				new SymmetricSecurityBindingElement ();
 			be.ProtectionTokenParameters =
 				new SecureConversationSecurityTokenParameters (
-					binding, requireCancellation, protectionRequirements);
+					bootstrapSecurity, requireCancellation, bootstrapProtectionRequirements);
 			return be;
 #else
 			throw new NotImplementedException ();

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TcpTransportBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TcpTransportBindingElement.cs
@@ -53,12 +53,12 @@ namespace System.ServiceModel.Channels
 		}
 
 		protected TcpTransportBindingElement (
-			TcpTransportBindingElement other)
-			: base (other)
+			TcpTransportBindingElement elementToBeCloned)
+			: base (elementToBeCloned)
 		{
-			listen_backlog = other.listen_backlog;
-			port_sharing_enabled = other.port_sharing_enabled;
-			pool.CopyPropertiesFrom (other.pool);
+			listen_backlog = elementToBeCloned.listen_backlog;
+			port_sharing_enabled = elementToBeCloned.port_sharing_enabled;
+			pool.CopyPropertiesFrom (elementToBeCloned.pool);
 		}
 		
 		public TcpConnectionPoolSettings ConnectionPoolSettings {

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransportBindingElement.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransportBindingElement.cs
@@ -48,12 +48,12 @@ namespace System.ServiceModel.Channels
 		}
 
 		protected TransportBindingElement (
-			TransportBindingElement other)
-			: base (other)
+			TransportBindingElement elementToBeCloned)
+			: base (elementToBeCloned)
 		{
-			manual_addressing = other.manual_addressing;
-			max_buffer_pool_size = other.max_buffer_pool_size;
-			max_recv_message_size = other.max_recv_message_size;
+			manual_addressing = elementToBeCloned.manual_addressing;
+			max_buffer_pool_size = elementToBeCloned.max_buffer_pool_size;
+			max_recv_message_size = elementToBeCloned.max_recv_message_size;
 		}
 
 		public virtual bool ManualAddressing {

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/ClientCredentials.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/ClientCredentials.cs
@@ -51,17 +51,17 @@ namespace System.ServiceModel.Description
 		}
 
 		[MonoTODO]
-		protected ClientCredentials (ClientCredentials source)
+		protected ClientCredentials (ClientCredentials other)
 		{
-			userpass = source.userpass.Clone ();
-			digest = source.digest.Clone ();
-			initiator = source.initiator.Clone ();
-			recipient = source.recipient.Clone ();
-			windows = source.windows.Clone ();
+			userpass = other.userpass.Clone ();
+			digest = other.digest.Clone ();
+			initiator = other.initiator.Clone ();
+			recipient = other.recipient.Clone ();
+			windows = other.windows.Clone ();
 #if !MOBILE
-			issued_token = source.issued_token.Clone ();
-			peer = source.peer.Clone ();
-			support_interactive = source.support_interactive;
+			issued_token = other.issued_token.Clone ();
+			peer = other.peer.Clone ();
+			support_interactive = other.support_interactive;
 #endif
 		}
 
@@ -159,10 +159,10 @@ namespace System.ServiceModel.Description
 
 		[MonoTODO]
 		public virtual void ApplyClientBehavior (
-			ServiceEndpoint endpoint, ClientRuntime behavior)
+			ServiceEndpoint serviceEndpoint, ClientRuntime behavior)
 		{
-			if (endpoint == null)
-				throw new ArgumentNullException ("endpoint");
+			if (serviceEndpoint == null)
+				throw new ArgumentNullException ("serviceEndpoint");
 			if (behavior == null)
 				throw new ArgumentNullException ("behavior");
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/IContractBehavior.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/IContractBehavior.cs
@@ -35,22 +35,22 @@ namespace System.ServiceModel.Description
 	public interface IContractBehavior
 	{
 		void AddBindingParameters (
-			ContractDescription description,
+			ContractDescription contractDescription,
 			ServiceEndpoint endpoint,
-			BindingParameterCollection parameters);
+			BindingParameterCollection bindingParameters);
 
 		void ApplyClientBehavior (
-			ContractDescription description,
+			ContractDescription contractDescription,
 			ServiceEndpoint endpoint,
-			ClientRuntime proxy);
+			ClientRuntime clientRuntime);
 
 		void ApplyDispatchBehavior (
-			ContractDescription description,
+			ContractDescription contractDescription,
 			ServiceEndpoint endpoint,
-			DispatchRuntime dispatch);
+			DispatchRuntime dispatchRuntime);
 
 		void Validate (
-			ContractDescription description,
+			ContractDescription contractDescription,
 			ServiceEndpoint endpoint);
 	}
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/IEndpointBehavior.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/IEndpointBehavior.cs
@@ -34,11 +34,11 @@ namespace System.ServiceModel.Description
 	public interface IEndpointBehavior
 	{
 		void AddBindingParameters (ServiceEndpoint endpoint,
-			BindingParameterCollection parameters);
-		void ApplyDispatchBehavior (ServiceEndpoint serviceEndpoint,
-			EndpointDispatcher dispatcher);
-		void ApplyClientBehavior (ServiceEndpoint serviceEndpoint,
-			ClientRuntime behavior);
-		void Validate (ServiceEndpoint serviceEndpoint);
+			BindingParameterCollection bindingParameters);
+		void ApplyDispatchBehavior (ServiceEndpoint endpoint,
+			EndpointDispatcher endpointDispatcher);
+		void ApplyClientBehavior (ServiceEndpoint endpoint,
+			ClientRuntime clientRuntime);
+		void Validate (ServiceEndpoint endpoint);
 	}
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/IOperationBehavior.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/IOperationBehavior.cs
@@ -34,18 +34,18 @@ namespace System.ServiceModel.Description
 	public interface IOperationBehavior
 	{
 		void AddBindingParameters (
-			OperationDescription description,
-			BindingParameterCollection parameters);
+			OperationDescription operationDescription,
+			BindingParameterCollection bindingParameters);
 
 		void ApplyDispatchBehavior (
-			OperationDescription description,
-			DispatchOperation dispatch);
+			OperationDescription operationDescription,
+			DispatchOperation dispatchOperation);
 
 		void ApplyClientBehavior (
-			OperationDescription description,
-			ClientOperation proxy);
+			OperationDescription operationDescription,
+			ClientOperation clientOperation);
 
 		void Validate (
-			OperationDescription description);
+			OperationDescription operationDescription);
 	}
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/IClientMessageFormatter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/IClientMessageFormatter.cs
@@ -31,7 +31,7 @@ namespace System.ServiceModel.Dispatcher
 {
 	public interface IClientMessageFormatter
 	{
-		object DeserializeReply (Message message, object [] paremeters);
-		Message SerializeRequest (MessageVersion version, object [] inputs);
+		object DeserializeReply (Message message, object [] parameters);
+		Message SerializeRequest (MessageVersion messageVersion, object [] parameters);
 	}
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/IClientMessageInspector.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/IClientMessageInspector.cs
@@ -31,7 +31,7 @@ namespace System.ServiceModel.Dispatcher
 {
 	public interface IClientMessageInspector
 	{
-		void AfterReceiveReply (ref Message message, object correlationState);
-		object BeforeSendRequest (ref Message message, IClientChannel channel);
+		void AfterReceiveReply (ref Message reply, object correlationState);
+		object BeforeSendRequest (ref Message request, IClientChannel channel);
 	}
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Security.Tokens/SecureConversationSecurityTokenParameters.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Security.Tokens/SecureConversationSecurityTokenParameters.cs
@@ -75,30 +75,30 @@ namespace System.ServiceModel.Security.Tokens
 		}
 
 		public SecureConversationSecurityTokenParameters (
-			SecurityBindingElement element)
-			: this (element, true)
+			SecurityBindingElement bootstrapSecurityBindingElement)
+			: this (bootstrapSecurityBindingElement, true)
 		{
 		}
 
 		public SecureConversationSecurityTokenParameters (
-			SecurityBindingElement element,
+			SecurityBindingElement bootstrapSecurityBindingElement,
 			bool requireCancellation)
-			: this (element, requireCancellation, null)
+			: this (bootstrapSecurityBindingElement, requireCancellation, null)
 		{
 		}
 
 #if !MOBILE && !XAMMAC_4_5
 		public SecureConversationSecurityTokenParameters (
-			SecurityBindingElement element,
+			SecurityBindingElement bootstrapSecurityBindingElement,
 			bool requireCancellation,
-			ChannelProtectionRequirements requirements)
+			ChannelProtectionRequirements bootstrapProtectionRequirements)
 		{
-			this.element = element;
+			this.element = bootstrapSecurityBindingElement;
 			this.cancellable = requireCancellation;
-			if (requirements == null)
+			if (bootstrapProtectionRequirements == null)
 				this.requirements = new ChannelProtectionRequirements (default_channel_protection_requirements);
 			else
-				this.requirements = new ChannelProtectionRequirements (requirements);
+				this.requirements = new ChannelProtectionRequirements (bootstrapProtectionRequirements);
 		}
 #else
 		internal SecureConversationSecurityTokenParameters (

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ActionNotSupportedException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ActionNotSupportedException.cs
@@ -35,8 +35,8 @@ namespace System.ServiceModel
 	public class ActionNotSupportedException : CommunicationException
 	{
 		public ActionNotSupportedException () : base () {}
-		public ActionNotSupportedException (string msg) : base (msg) {}
-		public ActionNotSupportedException (string msg, Exception inner) : base (msg, inner) {}
+		public ActionNotSupportedException (string message) : base (message) {}
+		public ActionNotSupportedException (string message, Exception innerException) : base (message, innerException) {}
 		protected ActionNotSupportedException (SerializationInfo info, StreamingContext context) :
 			base (info, context) {}
 	}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory.cs
@@ -85,9 +85,9 @@ namespace System.ServiceModel
 			get { return Endpoint.Binding.OpenTimeout; }
 		}
 
-		protected virtual void ApplyConfiguration (string endpointConfig)
+		protected virtual void ApplyConfiguration (string configurationName)
 		{
-			if (endpointConfig == null)
+			if (configurationName == null)
 				return;
 
 #if MOBILE || XAMMAC_4_5
@@ -96,22 +96,22 @@ namespace System.ServiceModel
 				var cfg = new SilverlightClientConfigLoader ().Load (XmlReader.Create ("ServiceReferences.ClientConfig"));
 
 				SilverlightClientConfigLoader.ServiceEndpointConfiguration se = null;
-				if (endpointConfig == "*")
+				if (configurationName == "*")
 					se = cfg.GetServiceEndpointConfiguration (Endpoint.Contract.Name);
 				if (se == null)
-					se = cfg.GetServiceEndpointConfiguration (endpointConfig);
+					se = cfg.GetServiceEndpointConfiguration (configurationName);
 
 				if (se.Binding != null && Endpoint.Binding == null)
 					Endpoint.Binding = se.Binding;
 				else // ignore it
-					Console.WriteLine ("WARNING: Configured binding not found in configuration {0}", endpointConfig);
+					Console.WriteLine ("WARNING: Configured binding not found in configuration {0}", configurationName);
 				if (se.Address != null && Endpoint.Address == null)
 					Endpoint.Address = se.Address;
 				else // ignore it
-					Console.WriteLine ("WARNING: Configured endpoint address not found in configuration {0}", endpointConfig);
+					Console.WriteLine ("WARNING: Configured endpoint address not found in configuration {0}", configurationName);
 			} catch (Exception) {
 				// ignore it.
-				Console.WriteLine ("WARNING: failed to load endpoint configuration for {0}", endpointConfig);
+				Console.WriteLine ("WARNING: failed to load endpoint configuration for {0}", configurationName);
 			}
 #else
 
@@ -120,7 +120,7 @@ namespace System.ServiceModel
 			ChannelEndpointElement endpoint = null;
 
 			foreach (ChannelEndpointElement el in client.Endpoints) {
-				if (el.Contract == contractName && (endpointConfig == el.Name || endpointConfig == "*")) {
+				if (el.Contract == contractName && (configurationName == el.Name || configurationName == "*")) {
 					if (endpoint != null)
 						throw new InvalidOperationException (String.Format ("More then one endpoint matching contract {0} was found.", contractName));
 					endpoint = el;
@@ -128,7 +128,7 @@ namespace System.ServiceModel
 			}
 
 			if (endpoint == null)
-				throw new InvalidOperationException (String.Format ("Client endpoint configuration '{0}' was not found in {1} endpoints.", endpointConfig, client.Endpoints.Count));
+				throw new InvalidOperationException (String.Format ("Client endpoint configuration '{0}' was not found in {1} endpoints.", configurationName, client.Endpoints.Count));
 
 			var binding = String.IsNullOrEmpty (endpoint.Binding) ? null : ConfigUtil.CreateBinding (endpoint.Binding, endpoint.BindingConfiguration);
 			var contractType = ConfigUtil.GetTypeFromConfigString (endpoint.Contract, NamedConfigCategory.Contract);
@@ -298,23 +298,23 @@ namespace System.ServiceModel
 		}
 
 		protected void InitializeEndpoint (
-			string endpointConfigurationName,
+			string configurationName,
 			EndpointAddress remoteAddress)
 		{
 			InitializeEndpoint (CreateDescription ());
 			if (remoteAddress != null)
 				service_endpoint.Address = remoteAddress;
-			ApplyConfiguration (endpointConfigurationName);
+			ApplyConfiguration (configurationName);
 		}
 
 		protected void InitializeEndpoint (Binding binding,
-			EndpointAddress remoteAddress)
+			EndpointAddress address)
 		{
 			InitializeEndpoint (CreateDescription ());
 			if (binding != null)
 				service_endpoint.Binding = binding;
-			if (remoteAddress != null)
-				service_endpoint.Address = remoteAddress;
+			if (address != null)
+				service_endpoint.Address = address;
 		}
 
 		protected void InitializeEndpoint (ServiceEndpoint endpoint)

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory_1.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory_1.cs
@@ -46,12 +46,12 @@ namespace System.ServiceModel
 		{
 		}
 
-		protected ChannelFactory (Type type)
+		protected ChannelFactory (Type channelType)
 		{
-			if (type == null)
-				throw new ArgumentNullException ("type");
-			if (!type.IsInterface)
-				throw new InvalidOperationException ("The type argument to the generic ChannelFactory constructor must be an interface type.");
+			if (channelType == null)
+				throw new ArgumentNullException ("channelType");
+			if (!channelType.IsInterface)
+				throw new InvalidOperationException ("The channelType argument to the generic ChannelFactory constructor must be an interface type.");
 
 			InitializeEndpoint (CreateDescription ());
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/CommunicationException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/CommunicationException.cs
@@ -34,8 +34,8 @@ namespace System.ServiceModel {
 	public class CommunicationException : SystemException
 	{
 		public CommunicationException () : base () {}
-		public CommunicationException (string msg) : base (msg) {}
-		public CommunicationException (string msg, Exception inner) : base (msg, inner) {}
+		public CommunicationException (string message) : base (message) {}
+		public CommunicationException (string message, Exception innerException) : base (message, innerException) {}
 		protected CommunicationException (SerializationInfo info, StreamingContext context)
 			: base (info, context) {}
 	}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/CommunicationObjectAbortedException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/CommunicationObjectAbortedException.cs
@@ -34,9 +34,9 @@ namespace System.ServiceModel {
 	public class CommunicationObjectAbortedException : CommunicationException
 	{
 		public CommunicationObjectAbortedException () : base () {}
-		public CommunicationObjectAbortedException (string msg) : base (msg) {}
-		public CommunicationObjectAbortedException (string msg, Exception inner)
-			: base (msg, inner) {}		
+		public CommunicationObjectAbortedException (string message) : base (message) {}
+		public CommunicationObjectAbortedException (string message, Exception innerException)
+			: base (message, innerException) {}		
 		protected CommunicationObjectAbortedException (SerializationInfo info,
 					       StreamingContext context)
 			: base (info, context) {}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/CommunicationObjectFaultedException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/CommunicationObjectFaultedException.cs
@@ -34,9 +34,9 @@ namespace System.ServiceModel {
 	public class CommunicationObjectFaultedException : CommunicationException
 	{
 		public CommunicationObjectFaultedException () : base () {}
-		public CommunicationObjectFaultedException (string msg) : base (msg) {}
-		public CommunicationObjectFaultedException (string msg, Exception inner)
-			: base (msg, inner) {}
+		public CommunicationObjectFaultedException (string message) : base (message) {}
+		public CommunicationObjectFaultedException (string message, Exception innerException)
+			: base (message, innerException) {}
 		protected CommunicationObjectFaultedException (SerializationInfo info, StreamingContext context)
 			: base (info, context) {}
 	}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/DnsEndpointIdentity.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/DnsEndpointIdentity.cs
@@ -45,12 +45,12 @@ namespace System.ServiceModel
 			Initialize (identity);
 		}
 
-		public DnsEndpointIdentity (string dns)
-			: this (Claim.CreateDnsClaim (dns))
+		public DnsEndpointIdentity (string dnsName)
+			: this (Claim.CreateDnsClaim (dnsName))
 		{
 		}
 #else
-		public DnsEndpointIdentity (string dns)
+		public DnsEndpointIdentity (string dnsName)
 		{
 			throw new NotImplementedException ();
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/DuplexClientBase.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/DuplexClientBase.cs
@@ -34,71 +34,71 @@ namespace System.ServiceModel
 {
 	public class DuplexClientBase<TChannel> : ClientBase<TChannel> where TChannel : class
 	{
-		protected DuplexClientBase (object instance)
-			: this (new InstanceContext (instance), (Binding) null, null)
+		protected DuplexClientBase (object callbackInstance)
+			: this (new InstanceContext (callbackInstance), (Binding) null, null)
 		{
 		}
 
-		protected DuplexClientBase (object instance,
-			Binding binding, EndpointAddress address)
-			: this (new InstanceContext (instance), binding, address)
+		protected DuplexClientBase (object callbackInstance,
+			Binding binding, EndpointAddress remoteAddress)
+			: this (new InstanceContext (callbackInstance), binding, remoteAddress)
 		{
 		}
 
-		protected DuplexClientBase (object instance,
-			string configurationName)
-			: this (new InstanceContext (instance), configurationName)
+		protected DuplexClientBase (object callbackInstance,
+			string endpointConfigurationName)
+			: this (new InstanceContext (callbackInstance), endpointConfigurationName)
 		{
 		}
 
-		protected DuplexClientBase (object instance,
-			string bindingConfigurationName, EndpointAddress address)
-			: this (new InstanceContext (instance), bindingConfigurationName, address)
+		protected DuplexClientBase (object callbackInstance,
+			string bindingConfigurationName, EndpointAddress remoteAddress)
+			: this (new InstanceContext (callbackInstance), bindingConfigurationName, remoteAddress)
 		{
 		}
 
-		protected DuplexClientBase (object instance,
+		protected DuplexClientBase (object callbackInstance,
 			string endpointConfigurationName, string remoteAddress)
-			: this (new InstanceContext (instance), endpointConfigurationName, remoteAddress)
+			: this (new InstanceContext (callbackInstance), endpointConfigurationName, remoteAddress)
 		{
 		}
 
-		protected DuplexClientBase (InstanceContext instance)
-			: base (instance)
+		protected DuplexClientBase (InstanceContext callbackInstance)
+			: base (callbackInstance)
 		{
 		}
 
-		protected DuplexClientBase (InstanceContext instance,
-			Binding binding, EndpointAddress address)
-			: base (instance, binding, address)
+		protected DuplexClientBase (InstanceContext callbackInstance,
+			Binding binding, EndpointAddress remoteAddress)
+			: base (callbackInstance, binding, remoteAddress)
 		{
 		}
 
-		protected DuplexClientBase (InstanceContext instance,
-			string configurationName)
-			: base (instance, configurationName)
+		protected DuplexClientBase (InstanceContext callbackInstance,
+			string endpointConfigurationName)
+			: base (callbackInstance, endpointConfigurationName)
 		{
 		}
 
-		protected DuplexClientBase (InstanceContext instance,
+		protected DuplexClientBase (InstanceContext callbackInstance,
 			string endpointConfigurationName, string remoteAddress)
-			: base (instance, endpointConfigurationName, remoteAddress)
+			: base (callbackInstance, endpointConfigurationName, remoteAddress)
 		{
 		}
 
-		protected DuplexClientBase (InstanceContext instance,
-			string configurationName, EndpointAddress address)
-			: base (instance, configurationName, address)
+		protected DuplexClientBase (InstanceContext callbackInstance,
+			string endpointConfigurationName, EndpointAddress address)
+			: base (callbackInstance, endpointConfigurationName, address)
 		{
 		}
 
-		protected DuplexClientBase (object instance, ServiceEndpoint endpoint)
-			: this (new InstanceContext (instance), endpoint)
+		protected DuplexClientBase (object callbackInstance, ServiceEndpoint endpoint)
+			: this (new InstanceContext (callbackInstance), endpoint)
 		{
 		}
 
-		protected DuplexClientBase (InstanceContext instance, ServiceEndpoint endpoint)
-			: base (instance, endpoint)
+		protected DuplexClientBase (InstanceContext callbackInstance, ServiceEndpoint endpoint)
+			: base (callbackInstance, endpoint)
 		{
 		}
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel/EndpointAddress.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/EndpointAddress.cs
@@ -70,11 +70,11 @@ namespace System.ServiceModel
 		{
 		}
 
-		public EndpointAddress (Uri uri, params AddressHeader [] headers)
-			: this (uri, null, new AddressHeaderCollection (headers), null, null) {}
+		public EndpointAddress (Uri uri, params AddressHeader [] addressHeaders)
+			: this (uri, null, new AddressHeaderCollection (addressHeaders), null, null) {}
 
-		public EndpointAddress (Uri uri, EndpointIdentity identity, params AddressHeader [] headers)
-			: this (uri, identity, new AddressHeaderCollection (headers), null, null) {}
+		public EndpointAddress (Uri uri, EndpointIdentity identity, params AddressHeader [] addressHeaders)
+			: this (uri, identity, new AddressHeaderCollection (addressHeaders), null, null) {}
 
 		public EndpointAddress (Uri uri, EndpointIdentity identity, AddressHeaderCollection headers)
 			: this (uri, identity, headers, null, null) {}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/EndpointNotFoundException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/EndpointNotFoundException.cs
@@ -34,8 +34,8 @@ namespace System.ServiceModel {
 	public class EndpointNotFoundException : CommunicationException
 	{
 		public EndpointNotFoundException () : base () {}
-		public EndpointNotFoundException (string msg) : base (msg) {}
-		public EndpointNotFoundException (string msg, Exception inner) : base (msg, inner) {}
+		public EndpointNotFoundException (string message) : base (message) {}
+		public EndpointNotFoundException (string message, Exception innerException) : base (message, innerException) {}
 		protected EndpointNotFoundException (SerializationInfo info, StreamingContext context) :
 			base (info, context) {}
 	}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/FaultCode.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/FaultCode.cs
@@ -42,16 +42,16 @@ namespace System.ServiceModel
 		{
 		}
 
-		public FaultCode (string name, FaultCode subcode)
-			: this (name, String.Empty, subcode)
+		public FaultCode (string name, FaultCode subCode)
+			: this (name, String.Empty, subCode)
 		{
 		}
 
-		public FaultCode (string name, string ns, FaultCode subcode)
+		public FaultCode (string name, string ns, FaultCode subCode)
 		{
 			this.name = name;
 			this.ns = ns;
-			this.subcode = subcode;
+			this.subcode = subCode;
 		}
 
 		public bool IsPredefinedFault {
@@ -78,9 +78,9 @@ namespace System.ServiceModel
 			get { return subcode; }
 		}
 
-		public static FaultCode CreateReceiverFaultCode (FaultCode subcode)
+		public static FaultCode CreateReceiverFaultCode (FaultCode subCode)
 		{
-			return new FaultCode ("Receiver", subcode);
+			return new FaultCode ("Receiver", subCode);
 		}
 
 		public static FaultCode CreateReceiverFaultCode (string name, string ns)
@@ -88,9 +88,9 @@ namespace System.ServiceModel
 			return CreateReceiverFaultCode (new FaultCode (name, ns));
 		}
 		
-		public static FaultCode CreateSenderFaultCode (FaultCode subcode)
+		public static FaultCode CreateSenderFaultCode (FaultCode subCode)
 		{
-			return new FaultCode ("Sender", subcode);
+			return new FaultCode ("Sender", subCode);
 		}
 
 		public static FaultCode CreateSenderFaultCode (string name, string ns)

--- a/mcs/class/System.ServiceModel/System.ServiceModel/FaultException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/FaultException.cs
@@ -100,7 +100,7 @@ namespace System.ServiceModel
 		}
 
 		[MonoTODO]
-		public static FaultException CreateFault (MessageFault fault,  params Type [] details)
+		public static FaultException CreateFault (MessageFault messageFault,  params Type [] faultDetailTypes)
 		{
 			throw new NotImplementedException ();
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/InvalidMessageContractException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/InvalidMessageContractException.cs
@@ -34,8 +34,8 @@ namespace System.ServiceModel {
 	public class InvalidMessageContractException : SystemException
 	{
 		public InvalidMessageContractException () : base () {}
-		public InvalidMessageContractException (string msg) : base (msg) {}
-		public InvalidMessageContractException (string msg, Exception inner) : base (msg, inner) {}
+		public InvalidMessageContractException (string message) : base (message) {}
+		public InvalidMessageContractException (string message, Exception innerException) : base (message, innerException) {}
 		protected InvalidMessageContractException (SerializationInfo info, StreamingContext context) :
 			base (info, context) {}
 	}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/MessageHeaderException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/MessageHeaderException.cs
@@ -35,8 +35,8 @@ namespace System.ServiceModel {
 	public class MessageHeaderException : ProtocolException
 	{
 		public MessageHeaderException () : this ("Message header exception") {}
-		public MessageHeaderException (string msg) : this (msg, null) {}
-		public MessageHeaderException (string msg, Exception inner) : base (msg, inner) {}
+		public MessageHeaderException (string message) : this (message, null) {}
+		public MessageHeaderException (string message, Exception innerException) : base (message, innerException) {}
 		protected MessageHeaderException (SerializationInfo info, StreamingContext context) :
 			base (info, context)
 		{

--- a/mcs/class/System.ServiceModel/System.ServiceModel/MessageHeader_1.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/MessageHeader_1.cs
@@ -53,10 +53,10 @@ namespace System.ServiceModel
 		{
 		}
 
-		public MessageHeader (T content, bool must_understand, string actor, bool relay)
+		public MessageHeader (T content, bool mustUnderstand, string actor, bool relay)
 		{
 			this.content = content;
-			this.must_understand = must_understand;
+			this.must_understand = mustUnderstand;
 			this.actor = actor;
 			this.relay = relay;
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ProtocolException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ProtocolException.cs
@@ -34,9 +34,9 @@ namespace System.ServiceModel {
 	public class ProtocolException : CommunicationException
 	{
 		public ProtocolException () : base () {}
-		public ProtocolException (string msg) : base (msg) {}
-		public ProtocolException (string msg, Exception inner)
-			: base (msg, inner) {}		
+		public ProtocolException (string message) : base (message) {}
+		public ProtocolException (string message, Exception innerException)
+			: base (message, innerException) {}		
 		protected ProtocolException (SerializationInfo info,
 					  StreamingContext context)
 			: base (info, context) {}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/QuotaExceededException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/QuotaExceededException.cs
@@ -34,9 +34,9 @@ namespace System.ServiceModel {
 	public class QuotaExceededException : SystemException
 	{
 		public QuotaExceededException () : base () {}
-		public QuotaExceededException (string msg) : base (msg) {}
-		public QuotaExceededException (string msg, Exception inner)
-			: base (msg, inner) {}		
+		public QuotaExceededException (string message) : base (message) {}
+		public QuotaExceededException (string message, Exception innerException)
+			: base (message, innerException) {}		
 		protected QuotaExceededException (SerializationInfo info,
 					       StreamingContext context)
 			: base (info, context) {}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ServerTooBusyException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ServerTooBusyException.cs
@@ -34,9 +34,9 @@ namespace System.ServiceModel {
 	public class ServerTooBusyException : CommunicationException
 	{
 		public ServerTooBusyException () : base () {}
-		public ServerTooBusyException (string msg) : base (msg) {}
-		public ServerTooBusyException (string msg, Exception inner)
-			: base (msg, inner) {}		
+		public ServerTooBusyException (string message) : base (message) {}
+		public ServerTooBusyException (string message, Exception innerException)
+			: base (message, innerException) {}		
 		protected ServerTooBusyException (SerializationInfo info,
 					       StreamingContext context)
 			: base (info, context) {}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ServiceActivationException.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ServiceActivationException.cs
@@ -34,9 +34,9 @@ namespace System.ServiceModel {
 	public class ServiceActivationException : CommunicationException
 	{
 		public ServiceActivationException () : base () {}
-		public ServiceActivationException (string msg) : base (msg) {}
-		public ServiceActivationException (string msg, Exception inner)
-			: base (msg, inner) {}		
+		public ServiceActivationException (string message) : base (message) {}
+		public ServiceActivationException (string message, Exception innerException)
+			: base (message, innerException) {}		
 		protected ServiceActivationException (SerializationInfo info,
 					       StreamingContext context)
 			: base (info, context) {}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/SpnEndpointIdentity.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/SpnEndpointIdentity.cs
@@ -45,12 +45,12 @@ namespace System.ServiceModel
 			Initialize (identity);
 		}
 
-		public SpnEndpointIdentity (string spn)
-			: this (Claim.CreateSpnClaim (spn))
+		public SpnEndpointIdentity (string spnName)
+			: this (Claim.CreateSpnClaim (spnName))
 		{
 		}
 #else
-		public SpnEndpointIdentity (string spn)
+		public SpnEndpointIdentity (string spnName)
 		{
 			throw new NotImplementedException ();
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/UpnEndpointIdentity.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/UpnEndpointIdentity.cs
@@ -45,12 +45,12 @@ namespace System.ServiceModel
 			Initialize (identity);
 		}
 
-		public UpnEndpointIdentity (string upn)
-			: this (Claim.CreateUpnClaim (upn))
+		public UpnEndpointIdentity (string upnName)
+			: this (Claim.CreateUpnClaim (upnName))
 		{
 		}
 #else
-		public UpnEndpointIdentity (string upn)
+		public UpnEndpointIdentity (string upnName)
 		{
 			throw new NotImplementedException ();
 		}

--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -52,13 +52,13 @@ namespace System.IO.Compression
 		bool disposed;
 		DeflateStreamNative native;
 
-		public DeflateStream (Stream compressedStream, CompressionMode mode) :
-			this (compressedStream, mode, false, false)
+		public DeflateStream (Stream stream, CompressionMode mode) :
+			this (stream, mode, false, false)
 		{
 		}
 
-		public DeflateStream (Stream compressedStream, CompressionMode mode, bool leaveOpen) :
-			this (compressedStream, mode, leaveOpen, false)
+		public DeflateStream (Stream stream, CompressionMode mode, bool leaveOpen) :
+			this (stream, mode, leaveOpen, false)
 		{
 		}
 
@@ -124,23 +124,23 @@ namespace System.IO.Compression
 			}
 		}
 
-		public override int Read (byte[] dest, int dest_offset, int count)
+		public override int Read (byte[] array, int offset, int count)
 		{
 			if (disposed)
 				throw new ObjectDisposedException (GetType ().FullName);
-			if (dest == null)
+			if (array == null)
 				throw new ArgumentNullException ("Destination array is null.");
 			if (!CanRead)
 				throw new InvalidOperationException ("Stream does not support reading.");
-			int len = dest.Length;
-			if (dest_offset < 0 || count < 0)
+			int len = array.Length;
+			if (offset < 0 || count < 0)
 				throw new ArgumentException ("Dest or count is negative.");
-			if (dest_offset > len)
+			if (offset > len)
 				throw new ArgumentException ("destination offset is beyond array size");
-			if ((dest_offset + count) > len)
+			if ((offset + count) > len)
 				throw new ArgumentException ("Reading would overrun buffer");
 
-			return ReadInternal (dest, dest_offset, count);
+			return ReadInternal (array, offset, count);
 		}
 
 		unsafe void WriteInternal (byte[] array, int offset, int count)
@@ -154,16 +154,16 @@ namespace System.IO.Compression
 			}
 		}
 
-		public override void Write (byte[] src, int src_offset, int count)
+		public override void Write (byte[] array, int offset, int count)
 		{
 			if (disposed)
 				throw new ObjectDisposedException (GetType ().FullName);
 
-			if (src == null)
-				throw new ArgumentNullException ("src");
+			if (array == null)
+				throw new ArgumentNullException ("array");
 
-			if (src_offset < 0)
-				throw new ArgumentOutOfRangeException ("src_offset");
+			if (offset < 0)
+				throw new ArgumentOutOfRangeException ("offset");
 
 			if (count < 0)
 				throw new ArgumentOutOfRangeException ("count");
@@ -171,10 +171,10 @@ namespace System.IO.Compression
 			if (!CanWrite)
 				throw new NotSupportedException ("Stream does not support writing");
 
-			if (src_offset > src.Length - count)
+			if (offset > array.Length - count)
 				throw new ArgumentException ("Buffer too small. count/offset wrong.");
 
-			WriteInternal (src, src_offset, count);
+			WriteInternal (array, offset, count);
 		}
 
 		public override void Flush ()

--- a/mcs/class/System/System.IO.Compression/GZipStream.cs
+++ b/mcs/class/System/System.IO.Compression/GZipStream.cs
@@ -70,21 +70,21 @@ namespace System.IO.Compression {
 			base.Dispose (disposing);
 		}
 
-		public override int Read (byte[] dest, int dest_offset, int count)
+		public override int Read (byte[] array, int offset, int count)
 		{
 			if (deflateStream == null)
 				throw new ObjectDisposedException (GetType ().FullName);
 
-			return deflateStream.Read(dest, dest_offset, count);
+			return deflateStream.Read(array, offset, count);
 		}
 
 
-		public override void Write (byte[] src, int src_offset, int count)
+		public override void Write (byte[] array, int offset, int count)
 		{
 			if (deflateStream == null)
 				throw new ObjectDisposedException (GetType ().FullName);
 
-			deflateStream.Write (src, src_offset, count);
+			deflateStream.Write (array, offset, count);
 		}
 
 		public override void Flush()

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -811,7 +811,7 @@ namespace System.Net.Sockets
 
 #region Poll
 
-		public bool Poll (int time_us, SelectMode mode)
+		public bool Poll (int microSeconds, SelectMode mode)
 		{
 			ThrowIfDisposedAndClosed ();
 
@@ -819,7 +819,7 @@ namespace System.Net.Sockets
 				throw new NotSupportedException ("'mode' parameter is not valid.");
 
 			int error;
-			bool result = Poll_internal (safe_handle, mode, time_us, out error);
+			bool result = Poll_internal (safe_handle, mode, microSeconds, out error);
 
 			if (error != 0)
 				throw new SocketException (error);
@@ -1115,27 +1115,27 @@ namespace System.Net.Sockets
 
 #region Bind
 
-		public void Bind (EndPoint local_end)
+		public void Bind (EndPoint localEP)
 		{
 			ThrowIfDisposedAndClosed ();
 
-			if (local_end == null)
-				throw new ArgumentNullException("local_end");
+			if (localEP == null)
+				throw new ArgumentNullException("localEP");
 				
-			var ipEndPoint = local_end as IPEndPoint;
+			var ipEndPoint = localEP as IPEndPoint;
 			if (ipEndPoint != null) {
-				local_end = RemapIPEndPoint (ipEndPoint);	
+				localEP = RemapIPEndPoint (ipEndPoint);	
 			}
 			
 			int error;
-			Bind_internal (safe_handle, local_end.Serialize(), out error);
+			Bind_internal (safe_handle, localEP.Serialize(), out error);
 
 			if (error != 0)
 				throw new SocketException (error);
 			if (error == 0)
 				is_bound = true;
 
-			seed_endpoint = local_end;
+			seed_endpoint = localEP;
 		}
 
 		private static void Bind_internal (SafeSocketHandle safeHandle, SocketAddress sa, out int error)
@@ -1732,14 +1732,14 @@ namespace System.Net.Sockets
 			return Receive (buffer, SocketFlags.None);
 		}
 
-		public int Receive (byte [] buffer, SocketFlags flags)
+		public int Receive (byte [] buffer, SocketFlags socketFlags)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, 0, buffer.Length);
 
 			SocketError error;
-			int ret = Receive_nochecks (buffer, 0, buffer.Length, flags, out error);
+			int ret = Receive_nochecks (buffer, 0, buffer.Length, socketFlags, out error);
 
 			if (error != SocketError.Success) {
 				if (error == SocketError.WouldBlock && is_blocking) // This might happen when ReceiveTimeout is set
@@ -1750,14 +1750,14 @@ namespace System.Net.Sockets
 			return ret;
 		}
 
-		public int Receive (byte [] buffer, int size, SocketFlags flags)
+		public int Receive (byte [] buffer, int size, SocketFlags socketFlags)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, 0, size);
 
 			SocketError error;
-			int ret = Receive_nochecks (buffer, 0, size, flags, out error);
+			int ret = Receive_nochecks (buffer, 0, size, socketFlags, out error);
 
 			if (error != SocketError.Success) {
 				if (error == SocketError.WouldBlock && is_blocking) // This might happen when ReceiveTimeout is set
@@ -1768,14 +1768,14 @@ namespace System.Net.Sockets
 			return ret;
 		}
 
-		public int Receive (byte [] buffer, int offset, int size, SocketFlags flags)
+		public int Receive (byte [] buffer, int offset, int size, SocketFlags socketFlags)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, offset, size);
 
 			SocketError error;
-			int ret = Receive_nochecks (buffer, offset, size, flags, out error);
+			int ret = Receive_nochecks (buffer, offset, size, socketFlags, out error);
 
 			if (error != SocketError.Success) {
 				if (error == SocketError.WouldBlock && is_blocking) // This might happen when ReceiveTimeout is set
@@ -1786,13 +1786,13 @@ namespace System.Net.Sockets
 			return ret;
 		}
 
-		public int Receive (byte [] buffer, int offset, int size, SocketFlags flags, out SocketError error)
+		public int Receive (byte [] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, offset, size);
 
-			return Receive_nochecks (buffer, offset, size, flags, out error);
+			return Receive_nochecks (buffer, offset, size, socketFlags, out errorCode);
 		}
 
 		public int Receive (IList<ArraySegment<byte>> buffers)
@@ -2075,24 +2075,24 @@ namespace System.Net.Sockets
 			return ReceiveFrom (buffer, 0, buffer.Length, SocketFlags.None, ref remoteEP);
 		}
 
-		public int ReceiveFrom (byte [] buffer, SocketFlags flags, ref EndPoint remoteEP)
+		public int ReceiveFrom (byte [] buffer, SocketFlags socketFlags, ref EndPoint remoteEP)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 
-			return ReceiveFrom (buffer, 0, buffer.Length, flags, ref remoteEP);
+			return ReceiveFrom (buffer, 0, buffer.Length, socketFlags, ref remoteEP);
 		}
 
-		public int ReceiveFrom (byte [] buffer, int size, SocketFlags flags, ref EndPoint remoteEP)
+		public int ReceiveFrom (byte [] buffer, int size, SocketFlags socketFlags, ref EndPoint remoteEP)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, 0, size);
 
-			return ReceiveFrom (buffer, 0, size, flags, ref remoteEP);
+			return ReceiveFrom (buffer, 0, size, socketFlags, ref remoteEP);
 		}
 
-		public int ReceiveFrom (byte [] buffer, int offset, int size, SocketFlags flags, ref EndPoint remoteEP)
+		public int ReceiveFrom (byte [] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
@@ -2102,7 +2102,7 @@ namespace System.Net.Sockets
 				throw new ArgumentNullException ("remoteEP");
 
 			int error;
-			return ReceiveFrom_nochecks_exc (buffer, offset, size, flags, ref remoteEP, true, out error);
+			return ReceiveFrom_nochecks_exc (buffer, offset, size, socketFlags, ref remoteEP, true, out error);
 		}
 
 		public bool ReceiveFromAsync (SocketAsyncEventArgs e)
@@ -2325,14 +2325,14 @@ namespace System.Net.Sockets
 			return ret;
 		}
 
-		public int Send (byte [] buffer, SocketFlags flags)
+		public int Send (byte [] buffer, SocketFlags socketFlags)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, 0, buffer.Length);
 
 			SocketError error;
-			int ret = Send_nochecks (buffer, 0, buffer.Length, flags, out error);
+			int ret = Send_nochecks (buffer, 0, buffer.Length, socketFlags, out error);
 
 			if (error != SocketError.Success)
 				throw new SocketException ((int) error);
@@ -2340,14 +2340,14 @@ namespace System.Net.Sockets
 			return ret;
 		}
 
-		public int Send (byte [] buffer, int size, SocketFlags flags)
+		public int Send (byte [] buffer, int size, SocketFlags socketFlags)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, 0, size);
 
 			SocketError error;
-			int ret = Send_nochecks (buffer, 0, size, flags, out error);
+			int ret = Send_nochecks (buffer, 0, size, socketFlags, out error);
 
 			if (error != SocketError.Success)
 				throw new SocketException ((int) error);
@@ -2355,14 +2355,14 @@ namespace System.Net.Sockets
 			return ret;
 		}
 
-		public int Send (byte [] buffer, int offset, int size, SocketFlags flags)
+		public int Send (byte [] buffer, int offset, int size, SocketFlags socketFlags)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, offset, size);
 
 			SocketError error;
-			int ret = Send_nochecks (buffer, offset, size, flags, out error);
+			int ret = Send_nochecks (buffer, offset, size, socketFlags, out error);
 
 			if (error != SocketError.Success)
 				throw new SocketException ((int) error);
@@ -2370,13 +2370,13 @@ namespace System.Net.Sockets
 			return ret;
 		}
 
-		public int Send (byte [] buffer, int offset, int size, SocketFlags flags, out SocketError error)
+		public int Send (byte [] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, offset, size);
 
-			return Send_nochecks (buffer, offset, size, flags, out error);
+			return Send_nochecks (buffer, offset, size, socketFlags, out errorCode);
 		}
 
 		public
@@ -2685,37 +2685,37 @@ namespace System.Net.Sockets
 
 #region SendTo
 
-		public int SendTo (byte [] buffer, EndPoint remote_end)
+		public int SendTo (byte [] buffer, EndPoint remoteEP)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 
-			return SendTo (buffer, 0, buffer.Length, SocketFlags.None, remote_end);
+			return SendTo (buffer, 0, buffer.Length, SocketFlags.None, remoteEP);
 		}
 
-		public int SendTo (byte [] buffer, SocketFlags flags, EndPoint remote_end)
+		public int SendTo (byte [] buffer, SocketFlags socketFlags, EndPoint remoteEP)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 
-			return SendTo (buffer, 0, buffer.Length, flags, remote_end);
+			return SendTo (buffer, 0, buffer.Length, socketFlags, remoteEP);
 		}
 
-		public int SendTo (byte [] buffer, int size, SocketFlags flags, EndPoint remote_end)
+		public int SendTo (byte [] buffer, int size, SocketFlags socketFlags, EndPoint remoteEP)
 		{
-			return SendTo (buffer, 0, size, flags, remote_end);
+			return SendTo (buffer, 0, size, socketFlags, remoteEP);
 		}
 
-		public int SendTo (byte [] buffer, int offset, int size, SocketFlags flags, EndPoint remote_end)
+		public int SendTo (byte [] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP)
 		{
 			ThrowIfDisposedAndClosed ();
 			ThrowIfBufferNull (buffer);
 			ThrowIfBufferOutOfRange (buffer, offset, size);
 
-			if (remote_end == null)
-				throw new ArgumentNullException("remote_end");
+			if (remoteEP == null)
+				throw new ArgumentNullException("remoteEP");
 
-			return SendTo_nochecks (buffer, offset, size, flags, remote_end);
+			return SendTo_nochecks (buffer, offset, size, socketFlags, remoteEP);
 		}
 
 		public bool SendToAsync (SocketAsyncEventArgs e)
@@ -3027,12 +3027,12 @@ namespace System.Net.Sockets
 				throw new SocketException (error);
 		}
 
-		public byte [] GetSocketOption (SocketOptionLevel optionLevel, SocketOptionName optionName, int length)
+		public byte [] GetSocketOption (SocketOptionLevel optionLevel, SocketOptionName optionName, int optionLength)
 		{
 			ThrowIfDisposedAndClosed ();
 
 			int error;
-			byte[] byte_val = new byte [length];
+			byte[] byte_val = new byte [optionLength];
 			GetSocketOption_arr_internal (safe_handle, optionLevel, optionName, ref byte_val, out error);
 
 			if (error != 0)
@@ -3193,13 +3193,13 @@ namespace System.Net.Sockets
 
 #region IOControl
 
-		public int IOControl (int ioctl_code, byte [] in_value, byte [] out_value)
+		public int IOControl (int ioControlCode, byte [] optionInValue, byte [] optionOutValue)
 		{
 			if (is_disposed)
 				throw new ObjectDisposedException (GetType ().ToString ());
 
 			int error;
-			int result = IOControl_internal (safe_handle, ioctl_code, in_value, out_value, out error);
+			int result = IOControl_internal (safe_handle, ioControlCode, optionInValue, optionOutValue, out error);
 
 			if (error != 0)
 				throw new SocketException (error);

--- a/mcs/class/System/System.Security.AccessControl/SemaphoreAccessRule.cs
+++ b/mcs/class/System/System.Security.AccessControl/SemaphoreAccessRule.cs
@@ -34,16 +34,16 @@ namespace System.Security.AccessControl {
 	public sealed class SemaphoreAccessRule : AccessRule
 	{
 		public SemaphoreAccessRule (IdentityReference identity,
-					    SemaphoreRights semaphoreRights,
+					    SemaphoreRights eventRights,
 					    AccessControlType type)
-			: base (identity, (int)semaphoreRights, false, InheritanceFlags.None, PropagationFlags.None, type)
+			: base (identity, (int)eventRights, false, InheritanceFlags.None, PropagationFlags.None, type)
 		{
 		}
 
 		public SemaphoreAccessRule (string identity,
-					    SemaphoreRights semaphoreRights,
+					    SemaphoreRights eventRights,
 					    AccessControlType type)
-			: this (new NTAccount (identity), semaphoreRights, type)
+			: this (new NTAccount (identity), eventRights, type)
 		{
 		}
 		

--- a/mcs/class/System/System.Security.AccessControl/SemaphoreAuditRule.cs
+++ b/mcs/class/System/System.Security.AccessControl/SemaphoreAuditRule.cs
@@ -35,9 +35,9 @@ namespace System.Security.AccessControl {
 		: AuditRule
 	{
 		public SemaphoreAuditRule (IdentityReference identity,
-					   SemaphoreRights semaphoreRights,
+					   SemaphoreRights eventRights,
 					   AuditFlags flags)
-			: base (identity, (int)semaphoreRights, false, InheritanceFlags.None, PropagationFlags.None, flags)
+			: base (identity, (int)eventRights, false, InheritanceFlags.None, PropagationFlags.None, flags)
 		{
 		}
 		

--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/X509KeyUsageExtension.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/X509KeyUsageExtension.cs
@@ -94,14 +94,14 @@ namespace System.Security.Cryptography.X509Certificates {
 
 		// methods
 
-		public override void CopyFrom (AsnEncodedData encodedData)
+		public override void CopyFrom (AsnEncodedData asnEncodedData)
 		{
-			if (encodedData == null)
-				throw new ArgumentNullException ("encodedData");
+			if (asnEncodedData == null)
+				throw new ArgumentNullException ("asnEncodedData");
 
-			X509Extension ex = (encodedData as X509Extension);
+			X509Extension ex = (asnEncodedData as X509Extension);
 			if (ex == null)
-				throw new ArgumentException (Locale.GetText ("Wrong type."), "encodedData");
+				throw new ArgumentException (Locale.GetText ("Wrong type."), "asnEncodedData");
 
 			if (ex._oid == null)
 				_oid = new Oid (oid, friendlyName);

--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/X509SubjectKeyIdentifierExtension.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/X509SubjectKeyIdentifierExtension.cs
@@ -159,14 +159,14 @@ namespace System.Security.Cryptography.X509Certificates {
 
 		// methods
 
-		public override void CopyFrom (AsnEncodedData encodedData)
+		public override void CopyFrom (AsnEncodedData asnEncodedData)
 		{
-			if (encodedData == null)
-				throw new ArgumentNullException ("encodedData");
+			if (asnEncodedData == null)
+				throw new ArgumentNullException ("asnEncodedData");
 
-			X509Extension ex = (encodedData as X509Extension);
+			X509Extension ex = (asnEncodedData as X509Extension);
 			if (ex == null)
-				throw new ArgumentException (Locale.GetText ("Wrong type."), "encodedData");
+				throw new ArgumentException (Locale.GetText ("Wrong type."), "asnEncodedData");
 
 			if (ex._oid == null)
 				_oid = new Oid (oid, friendlyName);


### PR DESCRIPTION
The names were fixed only for the subset of methods that are included in netstandard,
and in cases where netstandard differs from Desktop .NET we match with .NET.