### PR TITLE
[mcs] Remove NET_4_5 ifdef from the source files

### DIFF
--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Construction/ProjectRootElementTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Construction/ProjectRootElementTest.cs
@@ -58,11 +58,9 @@ namespace MonoTests.Microsoft.Build.Construction
 				ProjectRootElement.Create (XmlReader.Create (new StringReader (" <root/>")));
 				Assert.Fail ("should throw InvalidProjectFileException");
 			} catch (InvalidProjectFileException ex) {
-				#if NET_4_5
 				Assert.AreEqual (1, ex.LineNumber, "#1");
 				// it is very interesting, but unlike XmlReader.LinePosition it returns the position for '<'.
 				Assert.AreEqual (2, ex.ColumnNumber, "#2");
-				#endif
 			}
 		}
 
@@ -102,11 +100,9 @@ namespace MonoTests.Microsoft.Build.Construction
 				ProjectRootElement.Create (xml);
 				Assert.Fail ("should throw InvalidProjectFileException");
 			} catch (InvalidProjectFileException ex) {
-				#if NET_4_5
 				Assert.AreEqual (1, ex.LineNumber, "#1");
 				// unlike unexpected element case which returned the position for '<', it does return the name start char...
 				Assert.AreEqual (70, ex.ColumnNumber, "#2");
-				#endif
 			}
 		}
 

--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Evaluation/ProjectCollectionTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Evaluation/ProjectCollectionTest.cs
@@ -44,9 +44,7 @@ namespace MonoTests.Microsoft.Build.Evaluation
 		{
 			var g = ProjectCollection.GlobalProjectCollection;
 			Assert.AreEqual (0, g.GlobalProperties.Count, "#1");
-			#if NET_4_5
 			Assert.IsTrue (g.GlobalProperties.IsReadOnly, "#2");
-			#endif
 		}
 		
 		[Test]

--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Evaluation/ToolsetTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Evaluation/ToolsetTest.cs
@@ -40,11 +40,9 @@ namespace MonoTests.Microsoft.Build.Evaluation
 			var ts = new Toolset ("4.3", "c:\\", ProjectCollection.GlobalProjectCollection, null);
 			Assert.IsNotNull (ts.Properties, "#1");
 			Assert.AreEqual (0, ts.Properties.Count, "#2");
-#if NET_4_5
 			Assert.IsNull (ts.DefaultSubToolsetVersion, "#3");
 			Assert.IsNotNull (ts.SubToolsets, "#4");
 			Assert.AreEqual (0, ts.SubToolsets.Count, "#5");
-#endif
 			Assert.AreEqual ("c:\\", ts.ToolsPath, "#6");
 			Assert.AreEqual ("4.3", ts.ToolsVersion, "#7");
 		}

--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/ProjectTargetInstanceTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/ProjectTargetInstanceTest.cs
@@ -143,9 +143,7 @@ namespace MonoTests.Microsoft.Build.Execution
 			var root = ProjectRootElement.Create (xml);
 			root.FullPath = "ProjectInstanceTest.DependsOnTargets.proj";
 			var proj = new ProjectInstance (root);
-#if NET_4_5
 			Assert.AreEqual (2, proj.Targets.Count, "#1");
-#endif
 			Assert.IsFalse (proj.Build ("Bar", new ILogger [0]), "#2");
 		}
 		

--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/ProjectTaskInstanceTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/ProjectTaskInstanceTest.cs
@@ -42,7 +42,6 @@ namespace MonoTests.Microsoft.Build.Execution
 	[TestFixture]
 	public class ProjectTaskInstanceTest
 	{
-#if NET_4_5
 		[Test]
 		public void OutputPropertyExists ()
 		{
@@ -78,7 +77,6 @@ namespace MonoTests.Microsoft.Build.Execution
 			Assert.AreEqual (string.Empty, foo.Outputs, "#6");
 			Assert.AreEqual ("True", proj.GetPropertyValue ("C"), "#7");
 		}
-#endif
 	}
 }
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -829,9 +829,7 @@ public class Tests : TestsBase, ITest2
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
-#if NET_4_5
 	[StateMachine (typeof (int))]
-#endif
 	public static void locals2<T> (string[] args, int arg, T t, ref string rs, ref AStruct astruct) {
 		long i = 42;
 		string s = "AB";
@@ -1184,12 +1182,10 @@ public class Tests : TestsBase, ITest2
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void unhandled_exception_user () {
-#if NET_4_5
 		System.Threading.Tasks.Task.Factory.StartNew (() => {
 				Throw ();
 			});
 		Thread.Sleep (10000);
-#endif
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -2447,7 +2447,6 @@ public class DebuggerTests
 			Assert.AreEqual ("Exception", ex.Exception.Type.Name);
 		}
 
-#if NET_4_5
 		// out argument
 		m = t.GetMethod ("invoke_out");
 		var out_task = this_obj.InvokeMethodAsyncWithResult (e.Thread, m, new Value [] { vm.CreateValue (1), vm.CreateValue (null) }, InvokeOptions.ReturnOutArgs);
@@ -2460,7 +2459,6 @@ public class DebuggerTests
 		out_task = this_obj.InvokeMethodAsyncWithResult (e.Thread, m, new Value [] { vm.CreateValue (1), vm.CreateValue (null) });
 		out_args = out_task.Result.OutArgs;
 		Assert.IsNull (out_args);
-#endif
 
 		// newobj
 		m = t.GetMethod (".ctor");
@@ -2484,7 +2482,6 @@ public class DebuggerTests
 		v = t.InvokeMethod (e.Thread, m, new Value [] { vm.RootDomain.CreateString ("ABC") }, InvokeOptions.Virtual);
 		AssertValue ("ABC", v);
 
-#if NET_4_5
 		// instance
 		m = t.GetMethod ("invoke_pass_ref");
 		var task = this_obj.InvokeMethodAsync (e.Thread, m, new Value [] { vm.RootDomain.CreateString ("ABC") });
@@ -2494,7 +2491,6 @@ public class DebuggerTests
 		m = t.GetMethod ("invoke_static_pass_ref");
 		task = t.InvokeMethodAsync (e.Thread, m, new Value [] { vm.RootDomain.CreateString ("ABC") });
 		AssertValue ("ABC", task.Result);
-#endif
 
 		// Argument checking
 		
@@ -2588,7 +2584,6 @@ public class DebuggerTests
 		v = t.InvokeMethod (e.Thread, m, new Value [] { vm.CreateValue (1) });
 		AssertValue (1, (v as StructMirror)["i"]);
 
-#if NET_4_5
 		// Invoke a method which changes state
 		s = frame.GetArgument (1) as StructMirror;
 		t = s.Type;
@@ -2615,7 +2610,6 @@ public class DebuggerTests
 		m = vm.RootDomain.Corlib.GetType ("System.Object").GetMethod ("ToString");
 		v = s.InvokeMethod (e.Thread, m, null, InvokeOptions.Virtual);
 		AssertValue ("42", v);
-#endif
 	}
 
 	[Test]
@@ -3790,7 +3784,6 @@ public class DebuggerTests
 		vm = null;
 	}
 
-#if NET_4_5
 	[Test]
 	public void UnhandledExceptionUserCode () {
 		vm.Detach ();
@@ -3811,7 +3804,6 @@ public class DebuggerTests
 		vm.Exit (0);
 		vm = null;
 	}
-#endif
 
 	[Test]
 	public void GCWhileSuspended () {

--- a/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/CompareAttributeTest.cs
+++ b/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/CompareAttributeTest.cs
@@ -36,7 +36,6 @@ using MonoTests.Common;
 
 namespace MonoTests.System.ComponentModel.DataAnnotations
 {
-#if NET_4_5
 	[TestFixture]
 	public class CompareAttributeTest
 	{
@@ -66,5 +65,4 @@ namespace MonoTests.System.ComponentModel.DataAnnotations
 			Assert.IsNotNull (sla.GetValidationResult (DateTime.Now, ctx), "#B-4");
 		}
 	}
-#endif
 }

--- a/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/CreditCardAttributeTest.cs
+++ b/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/CreditCardAttributeTest.cs
@@ -36,7 +36,6 @@ using MonoTests.Common;
 
 namespace MonoTests.System.ComponentModel.DataAnnotations
 {
-#if NET_4_5
 	[TestFixture]
 	public class CreditCardAttributeTest
 	{
@@ -56,5 +55,4 @@ namespace MonoTests.System.ComponentModel.DataAnnotations
 			Assert.IsFalse (sla.IsValid (DateTime.Now), "#A1-8");
 		}
 	}
-#endif
 }

--- a/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/EmailAddressAttributeTest.cs
+++ b/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/EmailAddressAttributeTest.cs
@@ -36,7 +36,6 @@ using MonoTests.Common;
 
 namespace MonoTests.System.ComponentModel.DataAnnotations
 {
-#if NET_4_5
 	[TestFixture]
 	public class EmailAddressAttributeTest
 	{
@@ -84,5 +83,4 @@ namespace MonoTests.System.ComponentModel.DataAnnotations
 				Assert.IsFalse (sla.IsValid (InvalidAddresses[i]), "#B1-{0}", i);
 		}
 	}
-#endif
 }

--- a/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/FileExtensionsAttributeTest.cs
+++ b/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/FileExtensionsAttributeTest.cs
@@ -36,7 +36,6 @@ using MonoTests.Common;
 
 namespace MonoTests.System.ComponentModel.DataAnnotations
 {
-#if NET_4_5
 	[TestFixture]
 	public class FileExtensionsAttributeTest
 	{
@@ -57,5 +56,4 @@ namespace MonoTests.System.ComponentModel.DataAnnotations
 			Assert.IsFalse (sla.IsValid (DateTime.Now), "#A1-8");
 		}
 	}
-#endif
 }

--- a/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/PhoneAttributeTest.cs
+++ b/mcs/class/System.ComponentModel.DataAnnotations/Test/System.ComponentModel.DataAnnotations/PhoneAttributeTest.cs
@@ -36,7 +36,6 @@ using MonoTests.Common;
 
 namespace MonoTests.System.ComponentModel.DataAnnotations
 {
-#if NET_4_5
 	[TestFixture]
 	public class PhoneAttributeTest
 	{
@@ -54,5 +53,4 @@ namespace MonoTests.System.ComponentModel.DataAnnotations
 			Assert.IsFalse (sla.IsValid (DateTime.Now), "#A1-7");
 		}
 	}
-#endif
 }

--- a/mcs/class/System.Data/Test/System.Data.Common/DbDataReaderTest.cs
+++ b/mcs/class/System.Data/Test/System.Data.Common/DbDataReaderTest.cs
@@ -61,7 +61,6 @@ namespace MonoTests.System.Data.Common
 		{
 		}
 
-		#if NET_4_5
 		[Test]
 		public void GetFieldValueTest ()
 		{
@@ -155,7 +154,6 @@ namespace MonoTests.System.Data.Common
 			Assert.IsFalse (dataReader.Read (), "#5");
 		}
 
-		#endif //NET_4_5
 	}
 }
 

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/BootstrapContextTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/BootstrapContextTest.cs
@@ -2,7 +2,6 @@
 // BootstrapContextTest.cs - NUnit Test Cases for System.IdentityModel.Tokens.BootstrapContext
 //
 
-#if NET_4_5
 using System;
 using System.IO;
 using System.IdentityModel.Tokens;
@@ -248,4 +247,3 @@ namespace MonoTests.System.IdentityModel.Tokens.net_4_5 {
 		}
 	}
 }
-#endif

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests.cs
@@ -129,7 +129,6 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 				AuthenticationSchemes.Ntlm, label);
 		}
 
-#if NET_4_5
 		[Test]
 		public virtual void BasicHttps ()
 		{
@@ -179,7 +178,6 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 				WSMessageEncoding.Text, HttpClientCredentialType.None,
 				AuthenticationSchemes.Anonymous, label);
 		}
-#endif
 		
 		[Test]
 		public virtual void NetTcp ()

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/MetadataSamples.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/MetadataSamples.cs
@@ -136,7 +136,6 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 			return exporter.GetGeneratedMetadata ();
 		}
 		
-#if NET_4_5
 		[MetadataSample]
 		public static MetadataSet BasicHttps ()
 		{
@@ -197,7 +196,6 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 			
 			return exporter.GetGeneratedMetadata ();
 		}
-#endif
 		
 		[MetadataSample]
 		public static MetadataSet NetTcp ()

--- a/mcs/class/System.Web/Test/System.Web.Security/MachineKeyTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.Security/MachineKeyTest.cs
@@ -169,7 +169,6 @@ namespace MonoTests.System.Web.Security
 			}
 		}
 
-#if NET_4_5
 		[Test]
 		public void Protect ()
 		{
@@ -200,6 +199,5 @@ namespace MonoTests.System.Web.Security
 				MachineKey.Unprotect (encryptedBytes, oneUsage), 
 				"Single purpose working when multiple supplied");
 		}
-#endif
 	}
 }

--- a/mcs/class/System.Web/Test/System.Web.Security/MembershipPasswordAttributeTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.Security/MembershipPasswordAttributeTest.cs
@@ -1,4 +1,3 @@
-﻿#if NET_4_5
 
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -137,4 +136,3 @@ namespace MonoTests.System.Web.Security {
 		}
 	}
 }
-#endif

--- a/mcs/class/System.Web/Test/System.Web/EventHandlerTaskAsyncHelperTest.cs
+++ b/mcs/class/System.Web/Test/System.Web/EventHandlerTaskAsyncHelperTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Threading.Tasks;
@@ -115,4 +114,3 @@ namespace MonoTests.System.Web
 	}
 }
 
-#endif

--- a/mcs/class/System.Web/Test/System.Web/HttpTaskAsyncHandlerTest.cs
+++ b/mcs/class/System.Web/Test/System.Web/HttpTaskAsyncHandlerTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.IO;
@@ -129,4 +128,3 @@ namespace MonoTests.System.Web
 	}
 }
 
-#endif

--- a/mcs/class/System.Web/Test/System.Web/TaskAsyncResultTest.cs
+++ b/mcs/class/System.Web/Test/System.Web/TaskAsyncResultTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Threading;
@@ -331,4 +330,3 @@ namespace MonoTests.System.Web
 	}
 }
 
-#endif

--- a/mcs/class/System.XML/Test/System.Xml/XmlReaderCommonTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlReaderCommonTests.cs
@@ -15,10 +15,8 @@ using System.Text;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.XPath;
-#if NET_4_5
 using System.Threading;
 using System.Threading.Tasks;
-#endif
 
 using NUnit.Framework;
 
@@ -2298,7 +2296,6 @@ namespace MonoTests.System.Xml
 			Assert.AreEqual ((UInt64) 1, xr.ReadContentAs (typeof (UInt64), null), "#8");
 		}
 
-#if NET_4_5
 		[Test]
 		[ExpectedException(typeof(InvalidOperationException))]
 		public void MustSetAsyncFlag ()
@@ -2347,6 +2344,5 @@ namespace MonoTests.System.Xml
 			if (task.Result != null)
 				throw task.Result;
 		}
-#endif
 	}
 }

--- a/mcs/class/System.XML/Test/System.Xml/XmlReaderSettingsTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlReaderSettingsTests.cs
@@ -419,7 +419,6 @@ namespace MonoTests.System.Xml
 			Assert.AreEqual ("urn:foo", r.BaseURI);
 		}
 
-#if NET_4_5
 		[Test]
 		[ExpectedException (typeof (XmlException))]
 		public void ReadonlyAsync ()
@@ -444,6 +443,5 @@ namespace MonoTests.System.Xml
 			var r2 = XmlReader.Create (r, c);
 			Assert.IsTrue (r2.Settings.Async);
 		}
-#endif
 	}
 }

--- a/mcs/class/System.XML/Test/System.Xml/XmlResolverTest.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlResolverTest.cs
@@ -103,7 +103,6 @@ namespace MonoTests.System.Xml {
 			Assert.IsTrue (u2.IsAbsoluteUri, "null,absolute/file");
 		}
 
-#if NET_4_5
 		class AsyncXmlResolver : XmlResolver
 		{
 			public override object GetEntity (Uri absoluteUri, string role, Type ofObjectToReturn)
@@ -121,6 +120,5 @@ namespace MonoTests.System.Xml {
 			var uri = new Uri ("http://www.mono-project.com");
 			ar.GetEntityAsync (uri, null, typeof(string));
 		}
-#endif
 	}
 }

--- a/mcs/class/System.XML/Test/System.Xml/XmlSecureResolverTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlSecureResolverTests.cs
@@ -124,7 +124,6 @@ namespace MonoTests.System.Xml
 			Assert.IsTrue (site, "Site-2");
 		}
 
-#if NET_4_5
 		[Test]
 		[Category("Async")]
 		public void TestAsync ()
@@ -139,7 +138,6 @@ namespace MonoTests.System.Xml
 			Assert.That (task.Wait (3000));
 			Assert.IsInstanceOfType (typeof (Stream), task.Result);
 		}
-#endif
 
 	}
 }

--- a/mcs/class/System.XML/Test/System.Xml/XmlUrlResolverTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlUrlResolverTests.cs
@@ -10,9 +10,7 @@ using System;
 using System.IO;
 using System.Xml;
 using NUnit.Framework;
-#if NET_4_5
 using System.Reflection;
-#endif
 
 namespace MonoTests.System.Xml
 {
@@ -98,7 +96,6 @@ namespace MonoTests.System.Xml
 			Assert.AreEqual ("view:Standard.xslt", uri.AbsoluteUri, "#2");
 		}
 
-#if NET_4_5
 		[Test]
 		public void TestAsync ()
 		{
@@ -126,6 +123,5 @@ namespace MonoTests.System.Xml
 				Assert.IsTrue (ex is XmlException);
 			}
 		}
-#endif
 	}
 }

--- a/mcs/class/System.XML/Test/System.Xml/XmlWriterSettingsTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml/XmlWriterSettingsTests.cs
@@ -40,9 +40,7 @@ namespace MonoTests.System.Xml
 			Assert.AreEqual (false, s.NewLineOnAttributes);
 			Assert.AreEqual (false, s.OmitXmlDeclaration);
 			Assert.AreEqual (NewLineHandling.Replace, s.NewLineHandling);
-#if NET_4_5
 			Assert.IsFalse (s.Async);
-#endif
 		}
 
 		[Test]
@@ -381,7 +379,6 @@ namespace MonoTests.System.Xml
 			Assert.AreEqual (xml, sw.ToString ());
 		}
 
-#if NET_4_5
 		[Test]
 		[ExpectedException (typeof (XmlException))]
 		public void ReadonlyAsync ()
@@ -408,7 +405,6 @@ namespace MonoTests.System.Xml
 			var w2 = XmlWriter.Create (w, c);
 			Assert.IsTrue (w2.Settings.Async);
 		}
-#endif
 
 	}
 }

--- a/mcs/class/System.Xml.Linq/Test/System.Xml.Linq/XElementTest.cs
+++ b/mcs/class/System.Xml.Linq/Test/System.Xml.Linq/XElementTest.cs
@@ -2084,7 +2084,6 @@ namespace MonoTests.System.Xml.Linq
 			public XElement Content;
 		}
 
-#if NET_4_5
 		[Test]
 		// Bug #12571
 		public void DeserializeXElement ()
@@ -2099,7 +2098,6 @@ namespace MonoTests.System.Xml.Linq
 			var xe = (SerializableClass)res;
 			Assert.AreEqual (xe.Content.ToString (), "<Data />", "#3");
 		}
-#endif
 
 		[Test] // Bug #20151
 		public void XElementFromArrayWithNullValuesAsObject ()

--- a/mcs/class/System/Test/System.IO.Compression/DeflateStreamTest.cs
+++ b/mcs/class/System/Test/System.IO.Compression/DeflateStreamTest.cs
@@ -343,7 +343,6 @@ namespace MonoTests.System.IO.Compression
 			return new MemoryStream (Encoding.UTF8.GetBytes (s));
 		}
 
-#if NET_4_5
 		[Test]
 		public void CheckNet45Overloads () // Xambug #21982
 		{
@@ -361,7 +360,6 @@ namespace MonoTests.System.IO.Compression
 			decompressing.Close();
 			backing.Close();
 		}
-#endif	
 
 		[Test]
 		[ExpectedException (typeof (ArgumentException))]

--- a/mcs/class/System/Test/System.IO.Compression/GzipStreamTest.cs
+++ b/mcs/class/System/Test/System.IO.Compression/GzipStreamTest.cs
@@ -303,7 +303,6 @@ namespace MonoTests.System.IO.Compression
 			return new MemoryStream (Encoding.UTF8.GetBytes (s));
 		}
 
-#if NET_4_5
 		[Test]
 		public void CheckNet45Overloads () // Xambug #21982
 		{
@@ -321,7 +320,6 @@ namespace MonoTests.System.IO.Compression
 			decompressing.Close();
 			backing.Close();
 		}
-#endif
 	}
 }
 

--- a/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
+++ b/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
@@ -1,4 +1,3 @@
-#if NET_4_5
 using System;
 using System.Net;
 using System.Threading;
@@ -297,4 +296,3 @@ namespace MonoTests.System.Net.WebSockets
 	}
 }
 
-#endif

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -2482,7 +2482,6 @@ namespace MonoTests.System.Net
 			}
 		}
 
-#if NET_4_5
 		[Test]
 		public void AllowReadStreamBuffering ()
 		{
@@ -2494,7 +2493,6 @@ namespace MonoTests.System.Net
 			} catch (InvalidOperationException) {
 			}
 		}
-#endif
 
 		class ListenerScope : IDisposable {
 			EventWaitHandle completed;

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -1781,7 +1781,6 @@ namespace MonoTests.System.Net
 			Assert.AreSame (wc.Proxy, WebRequest.DefaultWebProxy);
 		}
 		 
-#if NET_4_5
 		[Test]
 		[Category ("AndroidNotWorking")] // Fails when ran as part of the entire BCL test suite. Works when only this fixture is ran
 		public void UploadStringAsyncCancelEvent ()
@@ -1873,7 +1872,6 @@ namespace MonoTests.System.Net
 			}
 			listener.Close ();
 		}
-#endif
 
 		public void UploadAsyncCancelEventTest (int port, Action<WebClient, Uri, EventWaitHandle> uploadAction)
 		{

--- a/mcs/class/System/Test/System.Net/WebClientTestAsync.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTestAsync.cs
@@ -26,7 +26,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-#if NET_4_5
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -276,4 +275,3 @@ namespace MonoTests.System.Net
 		}
 	}
 }
-#endif

--- a/mcs/class/System/Test/System/UriPermutationsTest.cs
+++ b/mcs/class/System/Test/System/UriPermutationsTest.cs
@@ -62,11 +62,7 @@ namespace MonoTests.System {
 		public void Setup()
 		{
 			StringTester.CreateMode = createMode;
-#if NET_4_5
 			StringTester.Location = location + "NET_4_5";
-#else
-			StringTester.Location = location + "NET_4_0";
-#endif
 		}
 
 		[TearDown]

--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -836,11 +836,7 @@ namespace MonoTests.System
 		{
 			Uri u = new Uri("http://localhost/index.asp#main#start", false);
 
-#if NET_4_5
 				Assert.AreEqual (u.Fragment, "#main#start", "#1");
-#else
-				Assert.AreEqual (u.Fragment, "#main%23start", "#1");
-#endif
 
 			u = new Uri("http://localhost/index.asp#main#start", true);
 			Assert.AreEqual (u.Fragment, "#main#start", "#2");
@@ -849,11 +845,7 @@ namespace MonoTests.System
 
 			Uri b = new Uri ("http://www.gnome.org");
 			Uri n = new Uri (b, "blah#main#start");
-#if NET_4_5
 				Assert.AreEqual (n.Fragment, "#main#start", "#3");
-#else
-				Assert.AreEqual (n.Fragment, "#main%23start", "#3");
-#endif
 
 			n = new Uri (b, "blah#main#start", true);
 			Assert.AreEqual (n.Fragment, "#main#start", "#4");
@@ -1071,13 +1063,8 @@ namespace MonoTests.System
 			Uri ftp = new Uri ("FTP://[::ffFF:169.32.14.5]/");
 			Assert.AreEqual ("ftp", ftp.Scheme, "#7");
 
-#if NET_4_5
 			Assert.AreEqual ("[::ffff:169.32.14.5]", ftp.Host, "#8");
 			Assert.AreEqual ("ftp://[::ffff:169.32.14.5]/", ftp.ToString (), "#9");
-#else
-			Assert.AreEqual ("[0000:0000:0000:0000:0000:FFFF:A920:0E05]", ftp.Host, "#8");
-			Assert.AreEqual ("ftp://[0000:0000:0000:0000:0000:FFFF:A920:0E05]/", ftp.ToString (), "#9");
-#endif
 		}
 
 		[Test]
@@ -1484,15 +1471,9 @@ namespace MonoTests.System
 			for (int i = 0; i < 128; i++)
 				sb.Append ((char) i);
 
-#if NET_4_5
 			Assert.AreEqual (
 				"%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F",
 				Uri.EscapeDataString (sb.ToString ()));
-#else
-			Assert.AreEqual (
-				"%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20!%22%23%24%25%26'()*%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F",
-				Uri.EscapeDataString (sb.ToString ()));
-#endif
 
 			Assert.AreEqual ("%C3%A1", Uri.EscapeDataString ("á"));
 		}
@@ -1503,15 +1484,9 @@ namespace MonoTests.System
 			for (int i = 0; i < 128; i++)
 				sb.Append ((char) i);
 
-#if NET_4_5
 			Assert.AreEqual (
 				"%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20!%22#$%25&'()*+,-./0123456789:;%3C=%3E?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[%5C]%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F",
 				Uri.EscapeUriString (sb.ToString ()));
-#else
-			Assert.AreEqual (
-				"%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20!%22#$%25&'()*+,-./0123456789:;%3C=%3E?@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F",
-				Uri.EscapeUriString (sb.ToString ()));
-#endif
 
 			Assert.AreEqual ("%C3%A1", Uri.EscapeDataString ("á"));
 		}

--- a/mcs/class/corlib/Test/System.Collections.Generic/ComparerTest.cs
+++ b/mcs/class/corlib/Test/System.Collections.Generic/ComparerTest.cs
@@ -53,7 +53,6 @@ namespace MonoTests.System.Collections.Generic
 			}
 		}
 
-#if NET_4_5
 		[Test]
 		public void Create ()
 		{
@@ -70,7 +69,6 @@ namespace MonoTests.System.Collections.Generic
 			} catch (ArgumentNullException) {
 			}
 		}
-#endif
 
 		[Test]
 		public void DefaultComparer_UserComparable ()

--- a/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
@@ -623,7 +623,6 @@ namespace MonoTests.System.Globalization
 			Assert.IsFalse (zh2.Equals (zh1), "#2");
 		}
 
-#if NET_4_5
 		CountdownEvent barrier = new CountdownEvent (3);
 		AutoResetEvent[] evt = new AutoResetEvent [] { new AutoResetEvent (false), new AutoResetEvent (false), new AutoResetEvent (false), new AutoResetEvent (false)};
 
@@ -743,6 +742,5 @@ namespace MonoTests.System.Globalization
 			Assert.AreEqual ("$100,000.00", us_str, "#1");
 			Assert.AreEqual ("R$ 100.000,00", br_str, "#2");
 		}
-#endif
 	}
 }

--- a/mcs/class/corlib/Test/System.IO/MemoryStreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/MemoryStreamTest.cs
@@ -17,9 +17,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using System.Threading;
-#if NET_4_5
 using System.Threading.Tasks;
-#endif
 
 using NUnit.Framework;
 
@@ -1119,7 +1117,6 @@ namespace MonoTests.System.IO
 			Assert.IsTrue (ms.DisposedCalled, "After");
 		}
 
-#if NET_4_5
 		[Test]
 		public void ReadAsync ()
 		{
@@ -1323,6 +1320,5 @@ namespace MonoTests.System.IO
 				return true;
 			}
 		}
-#endif
 	}
 }

--- a/mcs/class/corlib/Test/System.IO/StreamReaderTest.cs
+++ b/mcs/class/corlib/Test/System.IO/StreamReaderTest.cs
@@ -9,9 +9,7 @@
 using System;
 using System.IO;
 using System.Text;
-#if NET_4_5
 using System.Threading.Tasks;
-#endif
 
 using NUnit.Framework;
 
@@ -845,7 +843,6 @@ public class StreamReaderTest
 		Assert.AreEqual (0, StreamReader.Null.ReadBlock (buffer, 0, buffer.Length));
 	}
 
-#if NET_4_5
 	[Test]
 	public void ReadLineAsync ()
 	{
@@ -866,7 +863,6 @@ public class StreamReaderTest
 		Assert.IsTrue (result.Wait (3000), "#1");
 		Assert.AreEqual ("ab" + Environment.NewLine, result.Result);
 	}
-#endif
 }
 
 class MyStream : Stream {

--- a/mcs/class/corlib/Test/System.IO/StreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/StreamTest.cs
@@ -120,7 +120,6 @@ namespace MonoTests.System.IO
 			Assert.IsFalse (s.CanRead, "#1");
 		}
 
-#if NET_4_5
 		[Test]
 		public void CopyAsync ()
 		{
@@ -211,6 +210,5 @@ namespace MonoTests.System.IO
 			} catch (AggregateException) {
 			}
 		}
-#endif
 	}
 }

--- a/mcs/class/corlib/Test/System.IO/StreamWriterTest.cs
+++ b/mcs/class/corlib/Test/System.IO/StreamWriterTest.cs
@@ -1051,7 +1051,6 @@ namespace MonoTests.System.IO
 		Assert.AreEqual (5, ms.Position, "#2");
 	}
 
-#if NET_4_5
 	[Test]
 	public void FlushAsync ()
 	{
@@ -1098,7 +1097,6 @@ namespace MonoTests.System.IO
 		Assert.IsTrue (t.Wait (1000), "#5");
 	}
 
-#endif
 
 	// TODO - Write - test errors, functionality tested in TestFlush.
 }

--- a/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
@@ -1152,10 +1152,8 @@ public class AssemblyNameTest {
 		Assert.IsNull (an.GetPublicKey (), "GetPublicKey");
 		Assert.IsNull (an.GetPublicKeyToken (), "GetPublicKeyToken");
 		Assert.AreEqual ("TestAssembly", an.ToString (), "ToString");
-#if NET_4_5
 		Assert.IsNull (an.CultureName, "CultureName");
 		Assert.AreEqual (AssemblyContentType.Default, an.ContentType, "ContentType");
-#endif
 	}
 
 	[Test] // ctor (String)

--- a/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyTest.cs
@@ -1320,7 +1320,6 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (GetType().Assembly, a);
 		}
 
-#if NET_4_5
 		[Test]
 		public void DefinedTypes_Equality ()
 		{
@@ -1329,7 +1328,6 @@ namespace MonoTests.System.Reflection
 
 			Assert.AreSame (x1, x2, "#1");
 		}
-#endif
 
 		class MyAssembly : Assembly { }
 

--- a/mcs/class/corlib/Test/System.Reflection/IntrospectionExtensionsTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/IntrospectionExtensionsTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Reflection;
@@ -54,4 +53,3 @@ namespace MonoTests.System.Reflection
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -97,14 +97,12 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (ParamEnum.Foo, info [5].DefaultValue, "#2");
 		}
 
-#if NET_4_5
 		[Test]
 		public void HasDefaultValueEnum () {
 			ParameterInfo[] info = typeof (ParameterInfoTest).GetMethod ("paramMethod").GetParameters ();
 
 			Assert.IsTrue (info [5].HasDefaultValue);
 		}
-#endif
 
 		public static void Sample2 ([DecimalConstantAttribute(2,2,2,2,2)] decimal a, [DateTimeConstantAttribute(123456)] DateTime b) {}
 
@@ -125,7 +123,6 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (pi [1].DefaultValue.GetType (), typeof (Missing), "#2");
 		}
 
-#if NET_4_5
 		[Test]
 		public void TestHasDefaultValues ()
 		{
@@ -135,7 +132,6 @@ namespace MonoTests.System.Reflection
 			Assert.IsFalse (pi [1].HasDefaultValue, "#2");
 			Assert.IsTrue (pi [2].HasDefaultValue, "#3");
 		}
-#endif
 
 		public void Sample (int a, [Optional] int b, object c = null)
 		{
@@ -252,13 +248,11 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (decimal.MaxValue, info [0].DefaultValue);
 		}
 
-#if NET_4_5
 		[Test]
 		public void HasDefaultValueDecimal () {
 			var info = typeof (ParameterInfoTest).GetMethod ("TestC").GetParameters ();
 			Assert.IsTrue (info [0].HasDefaultValue);
 		}
-#endif
 
 		class TestParamAttribute : Attribute
 		{
@@ -344,13 +338,11 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (0, p.GetCustomAttributes (typeof (FlagsAttribute), false).Length, "#3");
 			Assert.AreEqual (0, p.GetOptionalCustomModifiers ().Length, "#4");
 			Assert.AreEqual (0, p.GetRequiredCustomModifiers ().Length, "#5");
-#if NET_4_5
 			try {
 				var ign = p.HasDefaultValue;
 				Assert.Fail ("#6");
 			} catch (NotImplementedException) {
 			}
-#endif
 			Assert.IsFalse (p.IsIn, "#7");
 #if FEATURE_USE_LCID
 			Assert.IsFalse (p.IsLcid, "#8");
@@ -358,13 +350,11 @@ namespace MonoTests.System.Reflection
 			Assert.IsFalse (p.IsOptional, "#9");
 			Assert.IsFalse (p.IsOut, "#10");
 			Assert.IsFalse (p.IsRetval, "#10");
-#if NET_4_5
 			try {
 				var ign = p.CustomAttributes;
 				Assert.Fail ("#11");
 			} catch (NotImplementedException) {
 			}
-#endif
 			try {
 				p.GetCustomAttributesData ();
 				Assert.Fail ("#12");
@@ -446,9 +436,7 @@ namespace MonoTests.System.Reflection
 			Assert.IsFalse (p2.IsIn, "#1");
 			p2.MyAttrsImpl = ParameterAttributes.In;
 			Assert.IsTrue (p2.IsIn, "#2");
-#if NET_4_5
 			Assert.AreEqual (p2.myList, p2.CustomAttributes, "#3");
-#endif
 		}
 	}
 }

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/AsyncVoidMethodBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/AsyncVoidMethodBuilderTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Threading;
@@ -117,4 +116,3 @@ namespace MonoTests.System.Runtime.CompilerServices
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/TaskAwaiterTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/TaskAwaiterTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Threading;
@@ -396,4 +395,3 @@ namespace MonoTests.System.Runtime.CompilerServices
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/TaskAwaiterTest_T.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/TaskAwaiterTest_T.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Threading;
@@ -173,4 +172,3 @@ namespace MonoTests.System.Runtime.CompilerServices
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/YieldAwaitableTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/YieldAwaitableTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Collections.Generic;
@@ -183,4 +182,3 @@ namespace MonoTests.System.Runtime.CompilerServices
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
@@ -298,9 +298,7 @@ namespace MonoTests.System.Runtime.InteropServices
 				Assert.AreEqual (0x1234, Marshal.ReadInt16 (ptr));
 				Assert.AreEqual (0x1234, Marshal.ReadInt16 (ptr, 0));
 				Assert.AreEqual (0x4567, Marshal.ReadInt16 (ptr, 2));
-#if NET_4_5
 				Assert.AreEqual (0x4567, Marshal.ReadInt16 ((ptr + 5)));
-#endif
 				Assert.AreEqual (0x4567, Marshal.ReadInt16 (ptr, 5));
 			} finally {
 				Marshal.FreeHGlobal (ptr);
@@ -318,9 +316,7 @@ namespace MonoTests.System.Runtime.InteropServices
 				Assert.AreEqual (0x12345678, Marshal.ReadInt32 (ptr));
 				Assert.AreEqual (0x12345678, Marshal.ReadInt32 (ptr, 0));
 				Assert.AreEqual (0x77654321, Marshal.ReadInt32 (ptr, 4));
-#if NET_4_5
 				Assert.AreEqual (0x77654321, Marshal.ReadInt32 ((ptr + 10)));
-#endif
 				Assert.AreEqual (0x77654321, Marshal.ReadInt32 (ptr, 10));
 			} finally {
 				Marshal.FreeHGlobal (ptr);

--- a/mcs/class/corlib/Test/System.Security.Claims/ClaimsIdentityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Claims/ClaimsIdentityTest.cs
@@ -2,7 +2,6 @@
 // ClaimsIdentityTest.cs - NUnit Test Cases for System.Security.Claims.ClaimsIdentity
 //
 
-#if NET_4_5
 
 using NUnit.Framework;
 using System;
@@ -561,4 +560,3 @@ namespace MonoTests.System.Security.Claims
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Security.Claims/ClaimsPrincipalTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Claims/ClaimsPrincipalTest.cs
@@ -3,7 +3,6 @@
 // ClaimsPrincipalTest.cs - NUnit Test Cases for System.Security.Claims.ClaimsPrincipal
 //
 
-#if NET_4_5
 
 using NUnit.Framework;
 using System;
@@ -253,4 +252,3 @@ namespace MonoTests.System.Security.Claims
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Threading.Tasks/ConcurrentExclusiveSchedulerPairTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/ConcurrentExclusiveSchedulerPairTest.cs
@@ -24,7 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#if NET_4_5
 
 using System;
 using System.Threading;
@@ -176,4 +175,3 @@ namespace MonoTests.System.Threading.Tasks
 	}
 }
 
-#endif

--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
@@ -409,7 +409,6 @@ namespace MonoTests.System.Threading.Tasks
 			Assert.IsTrue (tasks[1].IsCanceled, "#4");
 		}
 
-#if NET_4_5		
 		[Test]
 		public void WaitAll_CancelledAndTimeout ()
 		{
@@ -418,7 +417,6 @@ namespace MonoTests.System.Threading.Tasks
 			var t2 = Task.Delay (3000);
 			Assert.IsFalse (Task.WaitAll (new[] { t1, t2 }, 10));
 		}
-#endif
 
 		[Test]
 		public void WaitAllExceptionThenCancelled ()
@@ -1219,7 +1217,6 @@ namespace MonoTests.System.Threading.Tasks
 			}
 		}
 
-#if NET_4_5
 		[Test]
 		public void ContinuationOnBrokenScheduler ()
 		{
@@ -2114,6 +2111,5 @@ namespace MonoTests.System.Threading.Tasks
 			}
 		}
 		
-#endif
 	}
 }

--- a/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
@@ -38,7 +38,6 @@ namespace MonoTests.System.Threading
 	[TestFixture]
 	public class CancellationTokenSourceTest
 	{
-#if NET_4_5
 
 		[Test]
 		public void Ctor_Invalid ()
@@ -100,7 +99,6 @@ namespace MonoTests.System.Threading
 			Assert.AreEqual (0, called, "#1");
 		}
 
-#endif
 
 		[Test]
 		public void Token ()
@@ -345,13 +343,11 @@ namespace MonoTests.System.Threading
 			} catch (ObjectDisposedException) {
 			}
 
-#if NET_4_5
 			try {
 				cts.CancelAfter (1);
 				Assert.Fail ("#6");
 			} catch (ObjectDisposedException) {
 			}
-#endif
 		}
 
 		[Test]
@@ -478,7 +474,6 @@ namespace MonoTests.System.Threading
 			}
 		}
 
-#if NET_4_5
 		[Test]
 		public void DisposeRace ()
 		{
@@ -490,7 +485,6 @@ namespace MonoTests.System.Threading
 				c1.Dispose ();
 			}
 		}
-#endif
 	}
 }
 

--- a/mcs/class/corlib/Test/System.Threading/VolatileTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/VolatileTest.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if NET_4_5
 
 using System;
 using System.Threading;
@@ -146,5 +145,4 @@ namespace MonoTests.System.Threading
 	}
 }
 
-#endif
 

--- a/mcs/class/corlib/Test/System/ArraySegmentTest.cs
+++ b/mcs/class/corlib/Test/System/ArraySegmentTest.cs
@@ -156,7 +156,6 @@ namespace MonoTests.System
 			Assert.AreEqual (myArrSeg_1 != myArrSeg_2, true);
 		}
 
-#if NET_4_5
 		[Test]
 		public void IList_NotSupported ()
 		{
@@ -278,6 +277,5 @@ namespace MonoTests.System
 			IList<byte> seg = new ArraySegment<byte> (arr);
 			seg[4] = 3;
 		}
-#endif
 	}
 }

--- a/mcs/class/corlib/Test/System/ConsoleTest.cs
+++ b/mcs/class/corlib/Test/System/ConsoleTest.cs
@@ -332,7 +332,6 @@ public class ConsoleTest
 
 #if !MOBILE
 
-#if NET_4_5
 	[Test]
 	public void RedirectedTest ()
 	{
@@ -343,7 +342,6 @@ public class ConsoleTest
 		Console.SetError (TextWriter.Null);
 		Assert.IsFalse (Console.IsErrorRedirected);
 	}
-#endif
 
 	// Bug 678357
 	[Test]

--- a/mcs/class/corlib/Test/System/WeakReferenceTest.cs
+++ b/mcs/class/corlib/Test/System/WeakReferenceTest.cs
@@ -124,7 +124,6 @@ namespace MonoTests.System {
 			Assert.IsFalse (Foo.failed);
 		}
 
-#if NET_4_5
 		[Test]
 		public void WeakReferenceT_TryGetTarget_NullTarget ()
 		{
@@ -132,7 +131,6 @@ namespace MonoTests.System {
 			object obj;
 			Assert.IsFalse (r.TryGetTarget (out obj), "#1");
 		}
-#endif
 	}
 }
 

--- a/mcs/class/referencesource/System.Core/System/threading/ReaderWriterLockSlim/ReaderWriterLockSlim.cs
+++ b/mcs/class/referencesource/System.Core/System/threading/ReaderWriterLockSlim/ReaderWriterLockSlim.cs
@@ -155,9 +155,7 @@ namespace System.Threading
             lockID = Interlocked.Increment(ref s_nextLockID);
         }
 
-#if NET_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool IsRWEntryEmpty(ReaderWriterCount rwc)
         {
             if (rwc.lockID == 0)
@@ -181,9 +179,7 @@ namespace System.Threading
         /// entry for this thread, but doesn't want to add one if an existing one
         /// could not be found.
         /// </summary>
-#if NET_4_5
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private ReaderWriterCount GetThreadRWCount(bool dontAllocate)
         {
 			ReaderWriterCount rwc = t_rwc;
@@ -1117,9 +1113,7 @@ namespace System.Threading
             return owners & READER_MASK;
         }
 
-#if NET_4_5
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private void EnterMyLock()
         {
             if (Interlocked.CompareExchange(ref myLock, 1, 0) != 0)


### PR DESCRIPTION
It is always set in all profiles that we support so we can remove it.