### PR TITLE
[SRE] Make the TypeBuilderInst types user types, handling them in the…

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Type.cs
+++ b/mcs/class/corlib/ReferenceSources/Type.cs
@@ -102,6 +102,12 @@ namespace System
 			return UnderlyingSystemType;
 		}
 
+		// Called from the runtime to return the corresponding finished Type object
+		internal virtual Type RuntimeResolve ()
+		{
+			throw new NotImplementedException ();
+		}
+
 		internal virtual bool IsUserType {
 			get {
 				return true;

--- a/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.cs
@@ -145,7 +145,11 @@ namespace System.Reflection.Emit {
 		internal override Type GetParameterType (int pos) {
 			return parameters [pos];
 		}
-		
+
+		internal MethodBase RuntimeResolve () {
+			return type.RuntimeResolve ().GetConstructor (this);
+		}
+
 		public override Object Invoke (Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
 		{
 			throw not_supported ();
@@ -371,6 +375,11 @@ namespace System.Reflection.Emit {
 				foreach (var types in paramModOpt)
 					TypeBuilder.ResolveUserTypes (types);
 			}
+		}
+
+		internal void FixupTokens (Dictionary<int, int> token_map, Dictionary<int, MemberInfo> member_map) {
+			if (ilgen != null)
+				ilgen.FixupTokens (token_map, member_map);
 		}
 		
 		internal void GenerateDebugInfo (ISymbolWriter symbolWriter)

--- a/mcs/class/corlib/System.Reflection.Emit/ConstructorOnTypeBuilderInst.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ConstructorOnTypeBuilderInst.cs
@@ -42,8 +42,8 @@ namespace System.Reflection.Emit
 	internal class ConstructorOnTypeBuilderInst : ConstructorInfo
 	{
 		#region Keep in sync with object-internals.h
-		MonoGenericClass instantiation;
-		ConstructorInfo cb;
+		internal MonoGenericClass instantiation;
+		internal ConstructorInfo cb;
 		#endregion
 
 		public ConstructorOnTypeBuilderInst (MonoGenericClass instantiation, ConstructorInfo cb)
@@ -132,6 +132,26 @@ namespace System.Reflection.Emit
 				}
 			}
 			return res;
+		}
+
+		internal Type[] GetParameterTypes () {
+			if (cb is ConstructorBuilder) {
+				ConstructorBuilder cbuilder = (ConstructorBuilder)cb;
+				return cbuilder.parameters;
+			} else {
+				ParameterInfo[] parms = cb.GetParameters ();
+				var res = new Type [parms.Length];
+				for (int i = 0; i < parms.Length; i++) {
+					res [i] = parms [i].ParameterType;
+				}
+				return res;
+			}
+		}
+
+		// Called from the runtime to return the corresponding finished ConstructorInfo object
+		internal ConstructorInfo RuntimeResolve () {
+			var type = instantiation.InternalResolve ();
+			return type.GetConstructor (cb);
 		}
 
 		public override int MetadataToken {

--- a/mcs/class/corlib/System.Reflection.Emit/DerivedTypes.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/DerivedTypes.cs
@@ -131,6 +131,11 @@ namespace System.Reflection.Emit
 				return m_baseType.IsUserType;
 			}
 		}
+
+		// Called from the runtime to return the corresponding finished Type object
+		internal override Type RuntimeResolve () {
+			return InternalResolve ();
+		}
 	}
 
 	[StructLayout (LayoutKind.Sequential)]

--- a/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
@@ -228,6 +228,10 @@ namespace System.Reflection.Emit {
 				marshal_info.marshaltyperef = TypeBuilder.ResolveUserType (marshal_info.marshaltyperef);
 		}
 
+		internal FieldInfo RuntimeResolve () {
+			return typeb.CreateType ().GetField (this);
+		}
+
 		public override Module Module {
 			get {
 				return base.Module;

--- a/mcs/class/corlib/System.Reflection.Emit/FieldOnTypeBuilderInst.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldOnTypeBuilderInst.cs
@@ -127,6 +127,12 @@ namespace System.Reflection.Emit
 		public override void SetValue (object obj, object value, BindingFlags invokeAttr, Binder binder, CultureInfo culture) {
 			throw new NotSupportedException ();
 		}
+
+		// Called from the runtime to return the corresponding finished FieldInfo object
+		internal FieldInfo RuntimeResolve () {
+			var type = instantiation.RuntimeResolve ();
+			return type.GetField (Name);
+		}
 	}
 }
 #endif

--- a/mcs/class/corlib/System.Reflection.Emit/FieldOnTypeBuilderInst.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldOnTypeBuilderInst.cs
@@ -131,7 +131,7 @@ namespace System.Reflection.Emit
 		// Called from the runtime to return the corresponding finished FieldInfo object
 		internal FieldInfo RuntimeResolve () {
 			var type = instantiation.RuntimeResolve ();
-			return type.GetField (Name);
+			return type.GetField (fb);
 		}
 	}
 }

--- a/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.cs
@@ -93,6 +93,13 @@ namespace System.Reflection.Emit
 			return tbuilder.InternalResolve ().GetGenericArguments () [index]; 
 		}
 
+		internal override Type RuntimeResolve ()
+		{
+			if (mbuilder != null)
+				return MethodBase.GetMethodFromHandle (mbuilder.MethodHandleInternal, mbuilder.TypeBuilder.RuntimeResolve ().TypeHandle).GetGenericArguments () [index];
+			return tbuilder.RuntimeResolve ().GetGenericArguments () [index]; 
+		}
+
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern void initialize ();
 

--- a/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.cs
@@ -88,6 +88,8 @@ namespace System.Reflection.Emit
 
 		internal override Type InternalResolve ()
 		{
+			if (mbuilder != null)
+				return MethodBase.GetMethodFromHandle (mbuilder.MethodHandleInternal).GetGenericArguments () [index];
 			return tbuilder.InternalResolve ().GetGenericArguments () [index]; 
 		}
 

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
@@ -521,7 +521,7 @@ namespace System.Reflection.Emit {
 			int token = token_gen.GetToken (con, true);
 			make_room (6);
 			ll_emit (opcode);
-			if (con.DeclaringType.Module == module || (con is ConstructorOnTypeBuilderInst))
+			if (con.DeclaringType.Module == module || (con is ConstructorOnTypeBuilderInst) || (con is ConstructorBuilder))
 				add_token_fixup (con);
 			emit_int (token);
 			
@@ -737,7 +737,7 @@ namespace System.Reflection.Emit {
 			Type declaringType = meth.DeclaringType;
 			// Might be a DynamicMethod with no declaring type
 			if (declaringType != null) {
-				if (declaringType.Module == module || meth is MethodOnTypeBuilderInst)
+				if (declaringType.Module == module || meth is MethodOnTypeBuilderInst || meth is MethodBuilder || meth is ConstructorBuilder)
 					add_token_fixup (meth);
 			}
 			emit_int (token);
@@ -755,7 +755,7 @@ namespace System.Reflection.Emit {
 			// Might be a DynamicMethod with no declaring type
 			Type declaringType = method.DeclaringType;
 			if (declaringType != null) {
-				if (declaringType.Module == module)
+				if (declaringType.Module == module || method is MethodBuilder || method is ConstructorBuilder)
 					add_token_fixup (method);
 			}
 			emit_int (token);

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
@@ -814,7 +814,7 @@ namespace System.Reflection.Emit {
 			make_room (6);
 			ll_emit (opcode);
 			int token = token_gen.GetToken (cls, opcode != OpCodes.Ldtoken);
-			if (cls is MonoGenericClass || cls is SymbolType)
+			if (cls is MonoGenericClass || cls is SymbolType || cls is TypeBuilder)
 				add_token_fixup (cls);
 			emit_int (token);
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
@@ -554,7 +554,7 @@ namespace System.Reflection.Emit {
 			int token = token_gen.GetToken (field, true);
 			make_room (6);
 			ll_emit (opcode);
-			if (field.DeclaringType.Module == module || (field is FieldOnTypeBuilderInst))
+			if (field.DeclaringType.Module == module || (field is FieldOnTypeBuilderInst) || (field is FieldBuilder))
 				add_token_fixup (field);
 			emit_int (token);
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
@@ -521,7 +521,7 @@ namespace System.Reflection.Emit {
 			int token = token_gen.GetToken (con, true);
 			make_room (6);
 			ll_emit (opcode);
-			if (con.DeclaringType.Module == module)
+			if (con.DeclaringType.Module == module || (con is ConstructorOnTypeBuilderInst))
 				add_token_fixup (con);
 			emit_int (token);
 			
@@ -554,7 +554,7 @@ namespace System.Reflection.Emit {
 			int token = token_gen.GetToken (field, true);
 			make_room (6);
 			ll_emit (opcode);
-			if (field.DeclaringType.Module == module)
+			if (field.DeclaringType.Module == module || (field is FieldOnTypeBuilderInst))
 				add_token_fixup (field);
 			emit_int (token);
 		}
@@ -737,7 +737,7 @@ namespace System.Reflection.Emit {
 			Type declaringType = meth.DeclaringType;
 			// Might be a DynamicMethod with no declaring type
 			if (declaringType != null) {
-				if (declaringType.Module == module)
+				if (declaringType.Module == module || meth is MethodOnTypeBuilderInst)
 					add_token_fixup (meth);
 			}
 			emit_int (token);
@@ -813,7 +813,10 @@ namespace System.Reflection.Emit {
 
 			make_room (6);
 			ll_emit (opcode);
-			emit_int (token_gen.GetToken (cls, opcode != OpCodes.Ldtoken));
+			int token = token_gen.GetToken (cls, opcode != OpCodes.Ldtoken);
+			if (cls is MonoGenericClass)
+				add_token_fixup (cls);
+			emit_int (token);
 		}
 
 		[MonoLimitation ("vararg methods are not supported")]
@@ -1002,6 +1005,21 @@ namespace System.Reflection.Emit {
 					int old_cl = code_len;
 					code_len = fixups [i].pos;
 					emit_int (diff);
+					code_len = old_cl;
+				}
+			}
+		}
+
+		internal void FixupTokens (Dictionary<int, int> token_map, Dictionary<int, MemberInfo> member_map) {
+			for (int i = 0; i < num_token_fixups; ++i) {
+				int pos = token_fixups [i].code_pos;
+				int old_token = code [pos] | (code [pos + 1] << 8) | (code [pos + 2] << 16) | (code [pos + 3] << 24);
+				int new_token;
+				if (token_map.TryGetValue (old_token, out new_token)) {
+					token_fixups [i].member = member_map [old_token];
+					int old_cl = code_len;
+					code_len = pos;
+					emit_int (new_token);
 					code_len = old_cl;
 				}
 			}

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
@@ -814,7 +814,7 @@ namespace System.Reflection.Emit {
 			make_room (6);
 			ll_emit (opcode);
 			int token = token_gen.GetToken (cls, opcode != OpCodes.Ldtoken);
-			if (cls is MonoGenericClass)
+			if (cls is MonoGenericClass || cls is SymbolType)
 				add_token_fixup (cls);
 			emit_int (token);
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
@@ -814,7 +814,7 @@ namespace System.Reflection.Emit {
 			make_room (6);
 			ll_emit (opcode);
 			int token = token_gen.GetToken (cls, opcode != OpCodes.Ldtoken);
-			if (cls is MonoGenericClass || cls is SymbolType || cls is TypeBuilder)
+			if (cls is MonoGenericClass || cls is SymbolType || cls is TypeBuilder || cls is GenericTypeParameterBuilder)
 				add_token_fixup (cls);
 			emit_int (token);
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.cs
@@ -138,6 +138,12 @@ namespace System.Reflection.Emit
 			}
 		}
 
+		internal RuntimeMethodHandle MethodHandleInternal {
+			get {
+				return mhandle;
+			}
+		}
+
 		public override Type ReturnType {
 			get { return rtype; }
 		}
@@ -380,6 +386,11 @@ namespace System.Reflection.Emit
 			}
 		}
 
+		internal void FixupTokens (Dictionary<int, int> token_map, Dictionary<int, MemberInfo> member_map) {
+			if (ilgen != null)
+				ilgen.FixupTokens (token_map, member_map);
+		}
+		
 		internal void GenerateDebugInfo (ISymbolWriter symbolWriter)
 		{
 			if (ilgen != null && ilgen.HasDebugInfo) {

--- a/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.cs
@@ -254,6 +254,10 @@ namespace System.Reflection.Emit
 			return parameters [pos];
 		}
 
+		internal MethodBase RuntimeResolve () {
+			return type.RuntimeResolve ().GetMethod (this);
+		}
+
 		public Module GetModule ()
 		{
 			return type.Module;

--- a/mcs/class/corlib/System.Reflection.Emit/MethodOnTypeBuilderInst.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodOnTypeBuilderInst.cs
@@ -100,6 +100,19 @@ namespace System.Reflection.Emit
 			return instantiation.GetGenericArguments ();
 		}
 
+		// Called from the runtime to return the corresponding finished MethodInfo object
+		internal MethodInfo RuntimeResolve () {
+			var type = instantiation.InternalResolve ();
+			var m = type.GetMethod (base_method);
+			if (method_arguments != null) {
+				var args = new Type [method_arguments.Length];
+				for (int i = 0; i < method_arguments.Length; ++i)
+					args [i] = method_arguments [i].InternalResolve ();
+				m = m.MakeGenericMethod (args);
+			}
+			return m;
+		}
+
 		//
 		// MemberInfo members
 		//

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -696,6 +696,8 @@ namespace System.Reflection.Emit {
 				token = memberref_tokengen --;
 			else if (member is MethodOnTypeBuilderInst)
 				token = memberref_tokengen --;
+			else if (member is FieldBuilder)
+				token = memberref_tokengen --;
 			else
 				throw new NotImplementedException ();
 			inst_tokens [member] = token;
@@ -704,7 +706,7 @@ namespace System.Reflection.Emit {
 		}
 
 		internal int GetToken (MemberInfo member, bool create_open_instance) {
-			if (member is MonoGenericClass || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst || member is SymbolType)
+			if (member is MonoGenericClass || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst || member is SymbolType || member is FieldBuilder)
 				return GetPseudoToken (member);
 			return getToken (this, member, create_open_instance);
 		}
@@ -771,6 +773,8 @@ namespace System.Reflection.Emit {
 					finished = (member as ConstructorOnTypeBuilderInst).RuntimeResolve ();
 				} else if (member is MethodOnTypeBuilderInst) {
 					finished = (member as MethodOnTypeBuilderInst).RuntimeResolve ();
+				} else if (member is FieldBuilder) {
+					finished = (member as FieldBuilder).RuntimeResolve ();
 				} else {
 					throw new NotImplementedException ();
 				}

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -721,6 +721,8 @@ namespace System.Reflection.Emit {
 					token = methoddef_tokengen --;
 				else
 					token = memberref_tokengen --;
+			} else if (member is GenericTypeParameterBuilder) {
+				token = typespec_tokengen --;
 			} else
 				throw new NotImplementedException ();
 			if (create_open_instance)
@@ -738,7 +740,7 @@ namespace System.Reflection.Emit {
 		}
 
 		internal int GetToken (MemberInfo member, bool create_open_instance) {
-			if (member is MonoGenericClass || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst || member is SymbolType || member is FieldBuilder || member is TypeBuilder || member is ConstructorBuilder || member is MethodBuilder)
+			if (member is MonoGenericClass || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst || member is SymbolType || member is FieldBuilder || member is TypeBuilder || member is ConstructorBuilder || member is MethodBuilder || member is GenericTypeParameterBuilder)
 				return GetPseudoToken (member, create_open_instance);
 			return getToken (this, member, create_open_instance);
 		}
@@ -814,6 +816,8 @@ namespace System.Reflection.Emit {
 					finished = (member as ConstructorBuilder).RuntimeResolve ();
 				} else if (member is MethodBuilder) {
 					finished = (member as MethodBuilder).RuntimeResolve ();
+				} else if (member is GenericTypeParameterBuilder) {
+					finished = (member as GenericTypeParameterBuilder).RuntimeResolve ();
 				} else {
 					throw new NotImplementedException ();
 				}

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -688,7 +688,7 @@ namespace System.Reflection.Emit {
 				return token;
 			// Count backwards to avoid collisions with the tokens
 			// allocated by the runtime
-			if (member is MonoGenericClass)
+			if (member is MonoGenericClass || member is SymbolType)
 				token = typespec_tokengen --;
 			else if (member is FieldOnTypeBuilderInst)
 				token = memberref_tokengen --;
@@ -704,7 +704,7 @@ namespace System.Reflection.Emit {
 		}
 
 		internal int GetToken (MemberInfo member, bool create_open_instance) {
-			if (member is MonoGenericClass || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst)
+			if (member is MonoGenericClass || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst || member is SymbolType)
 				return GetPseudoToken (member);
 			return getToken (this, member, create_open_instance);
 		}
@@ -763,10 +763,10 @@ namespace System.Reflection.Emit {
 
 				// Construct the concrete reflection object corresponding to the
 				// TypeBuilderInst object, and request a token for it instead.
-				if (member is FieldOnTypeBuilderInst) {
+				if (member is MonoGenericClass || member is SymbolType) {
+					finished = (member as Type).RuntimeResolve ();
+				} else if (member is FieldOnTypeBuilderInst) {
 					finished = (member as FieldOnTypeBuilderInst).RuntimeResolve ();
-				} else if (member is MonoGenericClass) {
-					finished = (member as MonoGenericClass).RuntimeResolve ();
 				} else if (member is ConstructorOnTypeBuilderInst) {
 					finished = (member as ConstructorOnTypeBuilderInst).RuntimeResolve ();
 				} else if (member is MethodOnTypeBuilderInst) {

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
@@ -876,10 +876,12 @@ namespace System.Reflection.Emit
 
 		internal void FixupTokens (Dictionary<int, int> token_map, Dictionary<int, MemberInfo> member_map) {
 			if (methods != null) {
-				for (int i = 0; i < num_methods; ++i) {
-					MethodBuilder mb = (MethodBuilder)(methods[i]);
-					mb.FixupTokens (token_map, member_map);
-				}
+				for (int i = 0; i < num_methods; ++i)
+					methods[i].FixupTokens (token_map, member_map);
+			}
+			if (ctors != null) {
+				foreach (var cb in ctors)
+					cb.FixupTokens (token_map, member_map);
 			}
 		}
 

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
@@ -40,6 +40,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Globalization;
 using System.Collections;
+using System.Collections.Generic;
 using System.Security;
 using System.Security.Permissions;
 using System.Diagnostics.SymbolStore;
@@ -870,6 +871,15 @@ namespace System.Reflection.Emit
 				return t;
 			} else {
 				return t;
+			}
+		}
+
+		internal void FixupTokens (Dictionary<int, int> token_map, Dictionary<int, MemberInfo> member_map) {
+			if (methods != null) {
+				for (int i = 0; i < num_methods; ++i) {
+					MethodBuilder mb = (MethodBuilder)(methods[i]);
+					mb.FixupTokens (token_map, member_map);
+				}
 			}
 		}
 

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
@@ -1676,6 +1676,12 @@ namespace System.Reflection.Emit
 			return created;
 		}
 
+		internal override Type RuntimeResolve ()
+		{
+			check_created ();
+			return created;
+		}
+
 		internal bool is_created {
 			get {
 				return createTypeCalled;

--- a/mcs/class/corlib/System.Reflection/MonoGenericClass.cs
+++ b/mcs/class/corlib/System.Reflection/MonoGenericClass.cs
@@ -96,7 +96,7 @@ namespace System.Reflection
 		}
 
 		// Called from the runtime to return the corresponding finished Type object
-		internal Type RuntimeResolve ()
+		internal override Type RuntimeResolve ()
 		{
 			if (generic_type is TypeBuilder && !(generic_type as TypeBuilder).IsCreated ())
 				AppDomain.CurrentDomain.DoTypeResolve (generic_type);

--- a/mcs/class/corlib/System.Reflection/MonoGenericClass.cs
+++ b/mcs/class/corlib/System.Reflection/MonoGenericClass.cs
@@ -95,6 +95,19 @@ namespace System.Reflection
 			return gtd.MakeGenericType (args);
 		}
 
+		// Called from the runtime to return the corresponding finished Type object
+		internal Type RuntimeResolve ()
+		{
+			if (generic_type is TypeBuilder && !(generic_type as TypeBuilder).IsCreated ())
+				AppDomain.CurrentDomain.DoTypeResolve (generic_type);
+			for (int i = 0; i < type_arguments.Length; ++i) {
+				var t = type_arguments [i];
+				if (t is TypeBuilder && !(t as TypeBuilder).IsCreated ())
+					AppDomain.CurrentDomain.DoTypeResolve (t);
+			}
+			return InternalResolve ();
+		}
+
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern void initialize (FieldInfo[] fields);
 

--- a/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
@@ -535,6 +535,8 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
+		// The token is not guaranteed to be 0x0a000002
+		[Category ("NotWorking")]
 		public void ResolveMethodMemberRefWithGenericArguments ()
 		{
 			var assembly = genAssembly ();

--- a/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
@@ -570,6 +570,8 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
+		// The token is not guaranteed to be 0x2b000001
+		[Category("NotWorking")]
 		public void ResolveMethodSpecWithGenericArguments ()
 		{
 			var assembly = genAssembly ();

--- a/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
@@ -506,6 +506,8 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
+		// The token is not guaranteed to be 0x0a000001
+		[Category ("NotWorking")]
 		public void ResolveFieldMemberRefWithGenericArguments ()
 		{
 			var assembly = genAssembly ();

--- a/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
@@ -9746,6 +9746,33 @@ namespace MonoTests.System.Reflection.Emit
 			//Console.WriteLine (res[0]);
 		}
 
+		[Test]
+		public void FieldWithInitializedDataWorksWithCompilerRuntimeHelpers2 ()
+		{
+			TypeBuilder tb = module.DefineType ("Type1", TypeAttributes.Public);
+			var garg = tb.DefineGenericParameters ("T") [0];
+			FieldBuilder fb = tb.DefineInitializedData ("Foo", new byte [] {1,2,3,4}, FieldAttributes.Static|FieldAttributes.Public);
+			tb.CreateType ();
+
+			assembly = Thread.GetDomain ().DefineDynamicAssembly (new AssemblyName (ASSEMBLY_NAME+"2"), AssemblyBuilderAccess.RunAndSave, Path.GetTempPath ());
+			module = assembly.DefineDynamicModule ("Instance.exe");
+
+			TypeBuilder tb2 = module.DefineType ("Type2", TypeAttributes.Public);
+			MethodBuilder mb = tb2.DefineMethod ("Test", MethodAttributes.Public | MethodAttributes.Static, typeof (object), new Type [0]);
+			ILGenerator il = mb.GetILGenerator ();
+
+			il.Emit (OpCodes.Ldc_I4_1);
+			il.Emit (OpCodes.Newarr, typeof (int));
+			il.Emit (OpCodes.Dup);
+			il.Emit (OpCodes.Ldtoken, fb);
+			il.Emit (OpCodes.Call, typeof (RuntimeHelpers).GetMethod ("InitializeArray"));
+			il.Emit (OpCodes.Ret);
+
+			Type t = tb2.CreateType ();
+			int[] res = (int[])t.GetMethod ("Test").Invoke (null, new object[0]);
+			//Console.WriteLine (res[0]);
+		}
+
 		public interface IDelegateFactory
 		{
 			Delegate Create (Delegate del);

--- a/mcs/tools/linker/Descriptors/mscorlib.xml
+++ b/mcs/tools/linker/Descriptors/mscorlib.xml
@@ -294,6 +294,11 @@
 		  <method name="RuntimeResolve" />
 		</type>
 
+		<type fullname="System.Reflection.Emit.SymbolType">
+		  <!-- called from the runtime -->
+		  <method name="RuntimeResolve" />
+		</type>
+
 		<!--
 		<type fullname="System.Runtime.CompilerServices.CallConvCdecl" />
 		<type fullname="System.Runtime.CompilerServices.CallConvStdcall" />

--- a/mcs/tools/linker/Descriptors/mscorlib.xml
+++ b/mcs/tools/linker/Descriptors/mscorlib.xml
@@ -279,17 +279,17 @@
 			<method name="DefineLPArrayInternal" />
 		</type>
 
-		<type fullname="FieldOnTypeBuilderInst">
+		<type fullname="System.Reflection.Emit.FieldOnTypeBuilderInst">
 		  <!-- called from the runtime -->
 		  <method name="RuntimeResolve" />
 		</type>
 
-		<type fullname="MethodOnTypeBuilderInst">
+		<type fullname="System.Reflection.Emit.MethodOnTypeBuilderInst">
 		  <!-- called from the runtime -->
 		  <method name="RuntimeResolve" />
 		</type>
 
-		<type fullname="ConstructorOnTypeBuilderInst">
+		<type fullname="System.Reflection.Emit.ConstructorOnTypeBuilderInst">
 		  <!-- called from the runtime -->
 		  <method name="RuntimeResolve" />
 		</type>

--- a/mcs/tools/linker/Descriptors/mscorlib.xml
+++ b/mcs/tools/linker/Descriptors/mscorlib.xml
@@ -218,7 +218,10 @@
 		<type fullname="System.Reflection.MonoEvent" preserve="fields" />
 		<type fullname="System.Reflection.MonoEventInfo" preserve="fields" />
 		<type fullname="System.Reflection.MonoField" preserve="fields" />
-		<type fullname="System.Reflection.MonoGenericClass" preserve="fields" />
+		<type fullname="System.Reflection.MonoGenericClass" preserve="fields" >
+		  <!-- called from the runtime -->
+		  <method name="RuntimeResolve" />
+		</type>
 		<type fullname="System.Reflection.MonoGenericMethod" preserve="fields" />
 		<type fullname="System.Reflection.MonoGenericCMethod" preserve="fields" />
 		<type fullname="System.Reflection.MonoMethod" preserve="fields" />
@@ -274,6 +277,21 @@
 		<type fullname="System.Reflection.Emit.UnmanagedMarshal" preserve="fields">
 			<method name="DefineCustom" />
 			<method name="DefineLPArrayInternal" />
+		</type>
+
+		<type fullname="FieldOnTypeBuilderInst">
+		  <!-- called from the runtime -->
+		  <method name="RuntimeResolve" />
+		</type>
+
+		<type fullname="MethodOnTypeBuilderInst">
+		  <!-- called from the runtime -->
+		  <method name="RuntimeResolve" />
+		</type>
+
+		<type fullname="ConstructorOnTypeBuilderInst">
+		  <!-- called from the runtime -->
+		  <method name="RuntimeResolve" />
 		</type>
 
 		<!--

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1568,22 +1568,11 @@ mono_reflection_get_custom_attrs_info_checked (MonoObject *obj, MonoError *error
 		} 
 #ifndef DISABLE_REFLECTION_EMIT
 		else if (mono_is_sre_method_on_tb_inst (member_class)) {/*XXX This is a workaround for Compiler Context*/
-			MonoMethod *method = mono_reflection_method_on_tb_inst_get_handle ((MonoReflectionMethodOnTypeBuilderInst*)param->MemberImpl, error);
-			return_val_if_nok (error, NULL);
-			cinfo = mono_custom_attrs_from_param_checked (method, param->PositionImpl + 1, error);
-			return_val_if_nok (error, NULL);
+			// FIXME: Is this still needed ?
+			g_assert_not_reached ();
 		} else if (mono_is_sre_ctor_on_tb_inst (member_class)) { /*XX This is a workaround for Compiler Context*/
-			MonoReflectionCtorOnTypeBuilderInst *c = (MonoReflectionCtorOnTypeBuilderInst*)param->MemberImpl;
-			MonoMethod *method = NULL;
-			if (mono_is_sre_ctor_builder (mono_object_class (c->cb)))
-				method = ((MonoReflectionCtorBuilder *)c->cb)->mhandle;
-			else if (mono_is_sr_mono_cmethod (mono_object_class (c->cb)))
-				method = ((MonoReflectionMethod *)c->cb)->method;
-			else
-				g_error ("mono_reflection_get_custom_attrs_info:: can't handle a CTBI with base_method of type %s", mono_type_get_full_name (member_class));
-
-			cinfo = mono_custom_attrs_from_param_checked (method, param->PositionImpl + 1, error);
-			return_val_if_nok (error, NULL);
+			// FIXME: Is this still needed ?
+			g_assert_not_reached ();
 		} 
 #endif
 		else {

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -545,7 +545,7 @@ ICALL_TYPE(ENUMB, "System.Reflection.Emit.EnumBuilder", ENUMB_1)
 ICALL(ENUMB_1, "setup_enum_type", ves_icall_EnumBuilder_setup_enum_type)
 
 ICALL_TYPE(GPARB, "System.Reflection.Emit.GenericTypeParameterBuilder", GPARB_1)
-ICALL(GPARB_1, "initialize", ves_icall_GenericTypeParameterBuilder_initialize_generic_parameter)
+ICALL(GPARB_1, "initialize", ves_icall_GenericTypeParameterBuilder_initialize)
 
 ICALL_TYPE(METHODB, "System.Reflection.Emit.MethodBuilder", METHODB_1)
 ICALL(METHODB_1, "MakeGenericMethod", ves_icall_MethodBuilder_MakeGenericMethod)

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1283,26 +1283,6 @@ typedef struct {
 
 typedef struct {
 	MonoObject object;
-	MonoReflectionGenericClass *inst;
-	MonoObject *fb; /*can be either a MonoField or a FieldBuilder*/
-} MonoReflectionFieldOnTypeBuilderInst;
-
-typedef struct {
-	MonoObject object;
-	MonoReflectionGenericClass *inst;
-	MonoObject *cb; /*can be either a MonoCMethod or ConstructorBuilder*/
-} MonoReflectionCtorOnTypeBuilderInst;
-
-typedef struct {
-	MonoObject object;
-	MonoReflectionType *inst;
-	MonoObject *mb; /*can be either a MonoMethod or MethodBuilder*/
-	MonoArray *method_args;
-	MonoReflectionMethodBuilder *generic_method_definition;
-} MonoReflectionMethodOnTypeBuilderInst;
-
-typedef struct {
-	MonoObject object;
 	MonoBoolean visible;
 } MonoReflectionComVisibleAttribute;
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1793,7 +1793,7 @@ void
 ves_icall_ModuleBuilder_set_wrappers_type (MonoReflectionModuleBuilder *moduleb, MonoReflectionType *type);
 
 void
-ves_icall_GenericTypeParameterBuilder_initialize_generic_parameter (MonoReflectionGenericParam *gparam);
+ves_icall_GenericTypeParameterBuilder_initialize (MonoReflectionGenericParam *gparam);
 
 MonoReflectionMethod*
 ves_icall_MethodBuilder_MakeGenericMethod (MonoReflectionMethod *rmethod, MonoArray *types);

--- a/mono/metadata/sre-internals.h
+++ b/mono/metadata/sre-internals.h
@@ -80,9 +80,6 @@ mono_reflection_create_generic_class (MonoReflectionTypeBuilder *tb, MonoError *
 MonoMethod*
 mono_reflection_method_builder_to_mono_method (MonoReflectionMethodBuilder *mb, MonoError *error);
 
-MonoMethod*
-mono_reflection_method_on_tb_inst_get_handle (MonoReflectionMethodOnTypeBuilderInst *m, MonoError *error);
-
 gpointer
 mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
 

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1776,6 +1776,13 @@ fixup_method (MonoReflectionILGen *ilgen, gpointer value, MonoDynamicImage *asse
 				g_assert_not_reached ();
 			}
 			break;
+		case MONO_TABLE_TYPESPEC:
+			if (!strcmp (iltoken->member->vtable->klass->name, "RuntimeType")) {
+				continue;
+			} else {
+				g_assert_not_reached ();
+			}
+			break;
 		default:
 			g_error ("got unexpected table 0x%02x in fixup", target [3]);
 		}

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1730,10 +1730,19 @@ fixup_method (MonoReflectionILGen *ilgen, gpointer value, MonoDynamicImage *asse
 			}
 			break;
 		case MONO_TABLE_TYPEDEF:
-			if (strcmp (iltoken->member->vtable->klass->name, "TypeBuilder"))
+			if (!strcmp (iltoken->member->vtable->klass->name, "TypeBuilder")) {
+				tb = (MonoReflectionTypeBuilder *)iltoken->member;
+				idx = tb->table_idx;
+			} else if (!strcmp (iltoken->member->vtable->klass->name, "RuntimeType")) {
+				MonoClass *k = mono_class_from_mono_type (((MonoReflectionType*)iltoken->member)->type);
+				MonoObject *obj = mono_class_get_ref_info (k);
+				g_assert (obj);
+				g_assert (!strcmp (obj->vtable->klass->name, "TypeBuilder"));
+				tb = (MonoReflectionTypeBuilder*)obj;
+				idx = tb->table_idx;
+			} else {
 				g_assert_not_reached ();
-			tb = (MonoReflectionTypeBuilder *)iltoken->member;
-			idx = tb->table_idx;
+			}
 			break;
 		case MONO_TABLE_MEMBERREF:
 			if (!strcmp (iltoken->member->vtable->klass->name, "MonoArrayMethod")) {

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1699,6 +1699,8 @@ fixup_method (MonoReflectionILGen *ilgen, gpointer value, MonoDynamicImage *asse
 	guint32 i, idx = 0;
 	unsigned char *target;
 
+	// FIXME: Remove support for builder objects
+
 	for (i = 0; i < ilgen->num_token_fixups; ++i) {
 		iltoken = (MonoReflectionILTokenInfo *)mono_array_addr_with_size (ilgen->token_fixups, sizeof (MonoReflectionILTokenInfo), i);
 		target = (guchar*)assembly->code.data + code_idx + iltoken->code_pos;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -65,6 +65,7 @@ static gboolean is_sre_generic_instance (MonoClass *klass);
 static gboolean is_sre_type_builder (MonoClass *klass);
 static gboolean is_sre_method_builder (MonoClass *klass);
 static gboolean is_sre_field_builder (MonoClass *klass);
+static gboolean is_sre_gparam_builder (MonoClass *klass);
 static gboolean is_sr_mono_method (MonoClass *klass);
 static gboolean is_sr_mono_generic_method (MonoClass *klass);
 static gboolean is_sr_mono_generic_cmethod (MonoClass *klass);
@@ -1668,6 +1669,12 @@ is_sre_field_builder (MonoClass *klass)
 	check_corlib_type_cached (klass, "System.Reflection.Emit", "FieldBuilder");
 }
 
+static gboolean
+is_sre_gparam_builder (MonoClass *klass)
+{
+	check_corlib_type_cached (klass, "System.Reflection.Emit", "GenericTypeParameterBuilder");
+}
+
 gboolean
 mono_is_sre_method_on_tb_inst (MonoClass *klass)
 {
@@ -1771,6 +1778,36 @@ mono_reflection_type_get_handle (MonoReflectionType* ref, MonoError *error)
 		g_assert (res);
 		gclass->type.type = res;
 		return res;
+	} else if (is_sre_gparam_builder (klass)) {
+		MonoReflectionGenericParam *gparam = (MonoReflectionGenericParam *)ref;
+		MonoGenericParamFull *param;
+		MonoImage *image;
+		MonoClass *pklass;
+
+		image = &gparam->tbuilder->module->dynamic_image->image;
+
+		param = mono_image_new0 (image, MonoGenericParamFull, 1);
+
+		param->info.name = mono_string_to_utf8_image (image, gparam->name, error);
+		mono_error_assert_ok (error);
+		param->param.num = gparam->index;
+
+		if (gparam->mbuilder) {
+			g_assert (gparam->mbuilder->generic_container);
+			param->param.owner = gparam->mbuilder->generic_container;
+		} else if (gparam->tbuilder) {
+			g_assert (gparam->tbuilder->generic_container);
+			param->param.owner = gparam->tbuilder->generic_container;
+		}
+
+		pklass = mono_class_from_generic_parameter_internal ((MonoGenericParam *) param);
+
+		gparam->type.type = &pklass->byval_arg;
+
+		mono_class_set_ref_info (pklass, gparam);
+		mono_image_append_class_to_reflection_info_set (pklass);
+
+		return &pklass->byval_arg;
 	}
 
 	g_error ("Cannot handle corlib user type %s", mono_type_full_name (&mono_object_class(ref)->byval_arg));
@@ -1780,51 +1817,11 @@ mono_reflection_type_get_handle (MonoReflectionType* ref, MonoError *error)
 void
 ves_icall_SymbolType_create_unmanaged_type (MonoReflectionType *type)
 {
-	MonoError error;
-	mono_reflection_type_get_handle (type, &error);
-	mono_error_set_pending_exception (&error);
-}
-
-static gboolean
-reflection_register_with_runtime (MonoReflectionType *type, MonoError *error)
-{
-	MonoDomain *domain = mono_object_domain ((MonoObject*)type);
-	MonoClass *klass;
-
-	mono_error_init (error);
-
-	MonoType *res = mono_reflection_type_get_handle (type, error);
-
-	if (!res && is_ok (error)) {
-		mono_error_set_argument (error, NULL, "Invalid generic instantiation, one or more arguments are not proper user types");
-	}
-	return_val_if_nok (error, FALSE);
-
-	klass = mono_class_from_mono_type (res);
-
-	mono_loader_lock (); /*same locking as mono_type_get_object_checked */
-	mono_domain_lock (domain);
-
-	if (!image_is_dynamic (klass->image)) {
-		mono_class_setup_supertypes (klass);
-	} else {
-		if (!domain->type_hash)
-			domain->type_hash = mono_g_hash_table_new_type ((GHashFunc)mono_metadata_type_hash, 
-					(GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection types table");
-		mono_g_hash_table_insert (domain->type_hash, res, type);
-	}
-	mono_domain_unlock (domain);
-	mono_loader_unlock ();
-
-	return TRUE;
 }
 
 void
 mono_reflection_register_with_runtime (MonoReflectionType *type)
 {
-	MonoError error;
-	(void) reflection_register_with_runtime (type, &error);
-	mono_error_set_pending_exception (&error);
 }
 
 /**
@@ -3137,37 +3134,9 @@ methodbuilder_to_mono_method (MonoClass *klass, MonoReflectionMethodBuilder* mb,
 	return mb->mhandle;
 }
 
-static void
-reflection_generic_class_initialize (MonoReflectionGenericClass *type, MonoError *error)
-{
-	MonoGenericClass *gclass;
-	MonoClass *klass, *gklass;
-	MonoType *gtype;
-
-	mono_error_init (error);
-
-	gtype = mono_reflection_type_get_handle ((MonoReflectionType*)type, error);
-	return_if_nok (error);
-	klass = mono_class_from_mono_type (gtype);
-	g_assert (gtype->type == MONO_TYPE_GENERICINST);
-	gclass = gtype->data.generic_class;
-
-	if (!gclass->is_dynamic)
-		return;
-
-	gklass = gclass->container_class;
-	mono_class_init (gklass);
-
-	/* Mark this as needing synchronization with its generic container */
-	gclass->need_sync = TRUE;
-}
-
 void
 mono_reflection_generic_class_initialize (MonoReflectionGenericClass *type, MonoArray *fields)
 {
-	MonoError error;
-	reflection_generic_class_initialize (type, &error);
-	mono_error_set_pending_exception (&error);
 }
 
 /**
@@ -3783,22 +3752,6 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilder *tb)
 	mono_class_setup_supertypes (klass);
 	mono_class_setup_mono_type (klass);
 
-#if 0
-	if (!((MonoDynamicImage*)klass->image)->run) {
-		if (klass->generic_container) {
-			/* FIXME: The code below can't handle generic classes */
-			klass->wastypebuilder = TRUE;
-			mono_loader_unlock ();
-			mono_domain_unlock (domain);
-
-			res = mono_type_get_object_checked (mono_object_domain (tb), &klass->byval_arg, &error);
-			mono_error_set_pending_exception (&error);
-
-			return res;
-		}
-	}
-#endif
-
 	/* enums are done right away */
 	if (!klass->enumtype)
 		if (!ensure_runtime_vtable (klass, &error))
@@ -3893,19 +3846,11 @@ failure_unlocked:
 static gboolean
 reflection_initialize_generic_parameter (MonoReflectionGenericParam *gparam, MonoError *error)
 {
-	MonoGenericParamFull *param;
 	MonoImage *image;
-	MonoClass *pklass;
 
 	mono_error_init (error);
 
 	image = &gparam->tbuilder->module->dynamic_image->image;
-
-	param = mono_image_new0 (image, MonoGenericParamFull, 1);
-
-	param->info.name = mono_string_to_utf8_image (image, gparam->name, error);
-	mono_error_assert_ok (error);
-	param->param.num = gparam->index;
 
 	if (gparam->mbuilder) {
 		if (!gparam->mbuilder->generic_container) {
@@ -3922,7 +3867,6 @@ reflection_initialize_generic_parameter (MonoReflectionGenericParam *gparam, Mon
 			gparam->mbuilder->generic_container->is_anonymous = TRUE;
 			gparam->mbuilder->generic_container->owner.image = klass->image;
 		}
-		param->param.owner = gparam->mbuilder->generic_container;
 	} else if (gparam->tbuilder) {
 		if (!gparam->tbuilder->generic_container) {
 			MonoType *tb = mono_reflection_type_get_handle ((MonoReflectionType*)gparam->tbuilder, error);
@@ -3931,21 +3875,13 @@ reflection_initialize_generic_parameter (MonoReflectionGenericParam *gparam, Mon
 			gparam->tbuilder->generic_container = (MonoGenericContainer *)mono_image_alloc0 (klass->image, sizeof (MonoGenericContainer));
 			gparam->tbuilder->generic_container->owner.klass = klass;
 		}
-		param->param.owner = gparam->tbuilder->generic_container;
 	}
-
-	pklass = mono_class_from_generic_parameter_internal ((MonoGenericParam *) param);
-
-	gparam->type.type = &pklass->byval_arg;
-
-	mono_class_set_ref_info (pklass, gparam);
-	mono_image_append_class_to_reflection_info_set (pklass);
 
 	return TRUE;
 }
 
 void
-ves_icall_GenericTypeParameterBuilder_initialize_generic_parameter (MonoReflectionGenericParam *gparam)
+ves_icall_GenericTypeParameterBuilder_initialize (MonoReflectionGenericParam *gparam)
 {
 	MonoError error;
 	(void) reflection_initialize_generic_parameter (gparam, &error);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1328,23 +1328,8 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObject *obj,
 		/* These are handled in managed code */
 		g_assert_not_reached ();
 	} else if (strcmp (klass->name, "TypeBuilder") == 0) {
-		MonoReflectionTypeBuilder *tb = (MonoReflectionTypeBuilder *)obj;
-		if (create_open_instance && tb->generic_params) {
-			MonoType *type;
-			mono_reflection_init_type_builder_generics (obj, error);
-			return_val_if_nok (error, 0);
-			type = mono_reflection_type_get_handle ((MonoReflectionType *)obj, error);
-			return_val_if_nok (error, 0);
-			token = mono_dynimage_encode_typedef_or_ref_full (assembly, type, TRUE);
-			token = mono_metadata_token_from_dor (token);
-		} else if (tb->module->dynamic_image == assembly) {
-			token = tb->table_idx | MONO_TOKEN_TYPE_DEF;
-		} else {
-			MonoType *type;
-			type = mono_reflection_type_get_handle ((MonoReflectionType *)obj, error);
-			return_val_if_nok (error, 0);
-			token = mono_metadata_token_from_dor (mono_image_typedef_or_ref (assembly, type));
-		}
+		/* These are handled in managed code */
+		g_assert_not_reached ();
 	} else if (strcmp (klass->name, "RuntimeType") == 0) {
 		MonoType *type = mono_reflection_type_get_handle ((MonoReflectionType *)obj, error);
 		return_val_if_nok (error, 0);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -72,7 +72,6 @@ static gboolean is_sr_mono_field (MonoClass *klass);
 
 static guint32 mono_image_get_methodspec_token (MonoDynamicImage *assembly, MonoMethod *method);
 static guint32 mono_image_get_inflated_method_token (MonoDynamicImage *assembly, MonoMethod *m);
-static MonoMethod * inflate_method (MonoReflectionType *type, MonoObject *obj, MonoError *error);
 
 #define mono_type_array_get_and_resolve(array, index, error) mono_reflection_type_get_handle ((MonoReflectionType*)mono_array_get (array, gpointer, index), error)
 
@@ -627,7 +626,6 @@ mono_image_get_memberref_token (MonoDynamicImage *assembly, MonoType *type, cons
 	return mono_image_add_memberef_row (assembly, parent, name, sig);
 }
 
-
 static guint32
 mono_image_get_methodref_token (MonoDynamicImage *assembly, MonoMethod *method, gboolean create_typespec)
 {
@@ -975,59 +973,6 @@ mono_image_get_inflated_method_token (MonoDynamicImage *assembly, MonoMethod *m)
 		assembly, &m->klass->byval_arg, m->name, sig);
 
 	return token;
-}
-
-/*
- * Return a copy of TYPE, adding the custom modifiers in MODREQ and MODOPT.
- */
-static MonoType*
-add_custom_modifiers (MonoDynamicImage *assembly, MonoType *type, MonoArray *modreq, MonoArray *modopt, MonoError *error)
-{
-	int i, count, len, pos;
-	MonoType *t;
-
-	mono_error_init (error);
-
-	count = 0;
-	if (modreq)
-		count += mono_array_length (modreq);
-	if (modopt)
-		count += mono_array_length (modopt);
-
-	if (count == 0)
-		return mono_metadata_type_dup (NULL, type);
-
-	len = MONO_SIZEOF_TYPE + ((gint32)count) * sizeof (MonoCustomMod);
-	t = (MonoType *)g_malloc (len);
-	memcpy (t, type, MONO_SIZEOF_TYPE);
-
-	t->num_mods = count;
-	pos = 0;
-	if (modreq) {
-		for (i = 0; i < mono_array_length (modreq); ++i) {
-			MonoType *mod = mono_type_array_get_and_resolve (modreq, i, error);
-			if (!is_ok (error))
-				goto fail;
-			t->modifiers [pos].required = 1;
-			t->modifiers [pos].token = mono_image_typedef_or_ref (assembly, mod);
-			pos ++;
-		}
-	}
-	if (modopt) {
-		for (i = 0; i < mono_array_length (modopt); ++i) {
-			MonoType *mod = mono_type_array_get_and_resolve (modopt, i, error);
-			if (!is_ok (error))
-				goto fail;
-			t->modifiers [pos].required = 0;
-			t->modifiers [pos].token = mono_image_typedef_or_ref (assembly, mod);
-			pos ++;
-		}
-	}
-
-	return t;
-fail:
-	g_free (t);
-	return NULL;
 }
 
 void
@@ -3190,101 +3135,6 @@ methodbuilder_to_mono_method (MonoClass *klass, MonoReflectionMethodBuilder* mb,
 		mb->ilgen = NULL;
 	}
 	return mb->mhandle;
-}
-#endif
-
-#ifndef DISABLE_REFLECTION_EMIT
-
-static MonoMethod *
-inflate_mono_method (MonoClass *klass, MonoMethod *method, MonoObject *obj)
-{
-	MonoMethodInflated *imethod;
-	MonoGenericContext *context;
-	int i;
-
-	/*
-	 * With generic code sharing the klass might not be inflated.
-	 * This can happen because classes inflated with their own
-	 * type arguments are "normalized" to the uninflated class.
-	 */
-	if (!klass->generic_class)
-		return method;
-
-	context = mono_class_get_context (klass);
-
-	if (klass->method.count && klass->methods) {
-		/* Find the already created inflated method */
-		for (i = 0; i < klass->method.count; ++i) {
-			g_assert (klass->methods [i]->is_inflated);
-			if (((MonoMethodInflated*)klass->methods [i])->declaring == method)
-				break;
-		}
-		g_assert (i < klass->method.count);
-		imethod = (MonoMethodInflated*)klass->methods [i];
-	} else {
-		MonoError error;
-		imethod = (MonoMethodInflated *) mono_class_inflate_generic_method_full_checked (method, klass, context, &error);
-		mono_error_assert_ok (&error);
-	}
-
-	if (method->is_generic && image_is_dynamic (method->klass->image)) {
-		MonoDynamicImage *image = (MonoDynamicImage*)method->klass->image;
-
-		mono_image_lock ((MonoImage*)image);
-		mono_g_hash_table_insert (image->generic_def_objects, imethod, obj);
-		mono_image_unlock ((MonoImage*)image);
-	}
-	return (MonoMethod *) imethod;
-}
-
-static MonoMethod *
-inflate_method (MonoReflectionType *type, MonoObject *obj, MonoError *error)
-{
-	MonoMethod *method;
-	MonoClass *gklass;
-
-	mono_error_init (error);
-
-	MonoClass *type_class = mono_object_class (type);
-
-	if (is_sre_generic_instance (type_class)) {
-		MonoReflectionGenericClass *mgc = (MonoReflectionGenericClass*)type;
-		MonoType *generic_type = mono_reflection_type_get_handle ((MonoReflectionType*)mgc->generic_type, error);
-		return_val_if_nok (error, NULL);
-		gklass = mono_class_from_mono_type (generic_type);
-	} else if (is_sre_type_builder (type_class)) {
-		MonoType *t = mono_reflection_type_get_handle (type, error);
-		return_val_if_nok (error, NULL);
-		gklass = mono_class_from_mono_type (t);
-	} else if (type->type) {
-		gklass = mono_class_from_mono_type (type->type);
-		gklass = mono_class_get_generic_type_definition (gklass);
-	} else {
-		g_error ("Can't handle type %s", mono_type_get_full_name (mono_object_class (type)));
-	}
-
-	if (!strcmp (obj->vtable->klass->name, "MethodBuilder"))
-		if (((MonoReflectionMethodBuilder*)obj)->mhandle)
-			method = ((MonoReflectionMethodBuilder*)obj)->mhandle;
-		else {
-			method = methodbuilder_to_mono_method (gklass, (MonoReflectionMethodBuilder *) obj, error);
-			if (!method)
-				return NULL;
-		}
-	else if (!strcmp (obj->vtable->klass->name, "ConstructorBuilder")) {
-		method = ctorbuilder_to_mono_method (gklass, (MonoReflectionCtorBuilder *) obj, error);
-		if (!method)
-			return NULL;
-	} else if (!strcmp (obj->vtable->klass->name, "MonoMethod") || !strcmp (obj->vtable->klass->name, "MonoCMethod"))
-		method = ((MonoReflectionMethod *) obj)->method;
-	else {
-		method = NULL; /* prevent compiler warning */
-		g_error ("can't handle type %s", obj->vtable->klass->name);
-	}
-
-	MonoType *t = mono_reflection_type_get_handle (type, error);
-	return_val_if_nok (error, NULL);
-	return inflate_mono_method (mono_class_from_mono_type (t), method, obj);
 }
 
 static void


### PR DESCRIPTION
… BCL instead of the runtime.

This works by assigning pseudo tokens for them in ModuleBuilder.GetToken (), so they no longer need to be handled in the GetToken () icall.
Real tokens are assigned after the dynamic types they depend on have been created, by creating the corresponding finished reflection object
(i.e. a MonoMethod for a MethodOnTypeBuilderInst etc.) and obtaining its token.
In Save mode, this is done in ModuleBuilder.Save ().
In Run mode, this is done on-demand when the JIT tries to resolve a token into its corresponding metadata object, by the runtime calling
the RuntimeResolve () method on the builder object.