### PR TITLE
Uncomment and fix ServiceHost creation via ServiceFactory in SvcHttpHandler.cs

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/SvcHttpHandler.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/SvcHttpHandler.cs
@@ -128,10 +128,10 @@ namespace System.ServiceModel.Channels
 
 			//ServiceHost for this not created yet
 			var baseUri = new Uri (new Uri (HttpContext.Current.Request.Url.GetLeftPart (UriPartial.Authority)), path);
-//			if (factory_type != null) {
-//				host = ((ServiceHostFactory) Activator.CreateInstance (factory_type)).CreateServiceHost (type, new Uri [] {baseUri});
-//			}
-//			else
+			if (factory_type != null) {
+				host = ((ServiceHostFactory) Activator.CreateInstance (factory_type)).CreateServiceHost (type.ToString(), new Uri [] {baseUri});
+			}
+			else
 				host = new ServiceHost (type, baseUri);
 			host.Extensions.Add (new VirtualPathExtension (baseUri.AbsolutePath));
 


### PR DESCRIPTION
This commit allows customization of WCF service creation via the Factory attribute in an .svc file:

`<%@ ServiceHost Language="C#" Service="CustomService" Factory="CustomServiceHostFactory" %>`

All the patch does is uncomment a few lines that were already there and fix a small error. I am not sure why these lines were commented. Possibly the code is not sufficiently robust or it was just never given another look. But this works for me and it seems better than no support at all. For example, a custom ServiceHostFactory appears to be the only way to create a WCF service in a managed host which customizes EndpointDispatcher.AddressFilter and EndpointDispatcher.ContractFilter. This in turn is useful for proxied WCF services.

See also http://mono.1490590.n4.nabble.com/Mono-WCF-ServiceHost-Factory-option-td4251992.html (from 2012; never posted on the mailing list for some reason).
