### PR TITLE
[configure] Build C/C++ code with -O3 by default.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -365,6 +365,9 @@ AC_SUBST(PLATFORM_AOT_SUFFIX)
 
 ## PLATFORM_AOT_SUFFIX not so simple for windows :-)
 
+: ${CFLAGS="-g -O3"}
+: ${CXXFLAGS="-g -O3"}
+
 AC_CHECK_TOOL(CC, gcc, gcc)
 AC_PROG_CC
 AC_CHECK_TOOL(CXX, g++, g++)

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -5,9 +5,9 @@ TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
 export TEST_HARNESS_VERBOSE=1
 if [[ ${label} == w* ]]; then
     # Passing -ggdb3 on Cygwin breaks linking against libmonosgen-x.y.dll
-    export CFLAGS="-g -O2"
+    export CFLAGS="-g -O3"
 else
-    export CFLAGS="-ggdb3 -O2"
+    export CFLAGS="-ggdb3 -O3"
 fi
 
 if [[ ${CI_TAGS} == *'coop-gc'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-cooperative-gc=yes"; export MONO_CHECK_MODE=gc,thread; fi


### PR DESCRIPTION
Let's see what happens now that we're in fairly good shape across architectures.
