### PR TITLE
Fix for double CloseHandle() on AppDomain unload

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2575,12 +2575,10 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 		if (mono_thread_internal_has_appdomain_ref (mono_thread_internal_current (), domain) && (mono_thread_interruption_requested ())) {
 			/* The unload thread tries to abort us */
 			/* The icall wrapper will execute the abort */
-			CloseHandle (thread_handle);
 			unload_data_unref (thread_data);
 			return;
 		}
 	}
-	CloseHandle (thread_handle);
 
 	if (thread_data->failure_reason) {
 		/* Roll back the state change */

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -314,12 +314,14 @@ mono_threads_platform_yield (void)
 void
 mono_threads_platform_exit (int exit_code)
 {
+	mono_thread_info_detach ();
 	ExitThread (exit_code);
 }
 
 void
 mono_threads_platform_unregister (MonoThreadInfo *info)
 {
+	mono_threads_platform_set_exited (info);
 }
 
 int
@@ -370,6 +372,10 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 void
 mono_threads_platform_set_exited (MonoThreadInfo *info)
 {
+	g_assert (info->handle);
+	// No need to call CloseHandle() here since the InternalThread
+	// destructor will close the handle when the finalizer thread calls it
+	info->handle = NULL;
 }
 
 void


### PR DESCRIPTION
When AppDomain.Unload() is called a new thread is created and attached. When this thread is done the thread handle is immediately closed using CloseHandle() but the same handle is also passed to CloseHandle() later on by the InternalThread destructor. On the second CloseHandle() call Windows will abort the process with an "Invalid handle" error.

This patch removes the CloseHandle() calls in mono_domain_try_unload() which is called by AppDomain.Unload(). The patch also wires up some more functions in mono/utils/mono-threads-windows.c to set the MonoThreadInfo.handle field to NULL when a thread has exited.