### PR TITLE
[runtime] Fix pedump by using the normal embedding APIs instead of in…

### DIFF
--- a/tools/pedump/Makefile.am
+++ b/tools/pedump/Makefile.am
@@ -21,6 +21,7 @@ pedump_LDADD = 			\
 	$(top_builddir)/mono/sgen/libmonosgen-static.la \
 	$(top_builddir)/mono/io-layer/libwapi.la	\
 	$(top_builddir)/mono/utils/libmonoutils.la \
+	$(top_builddir)/mono/mini/libmini.la \
 	$(LLVM_LIBS)			\
 	$(LLVM_LDFLAGS)			\
 	$(GLIB_LIBS)			\


### PR DESCRIPTION
…itializing parts of the runtime. Fixes #43786.