### PR TITLE
[System] Set KeepAlive flag for HttpWebRequest

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/HttpRequestChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/HttpRequestChannel.cs
@@ -126,6 +126,7 @@ namespace System.ServiceModel.Channels
 			}
 
 			web_request.Timeout = (int) timeout.TotalMilliseconds;
+			web_request.KeepAlive = httpbe.KeepAliveEnabled;
 
 			// There is no SOAP Action/To header when AddressingVersion is None.
 			if (message.Version.Envelope.Equals (EnvelopeVersion.Soap11) ||


### PR DESCRIPTION
Before this fix http request creates with KeepAlive = true. In caused bugs when we want to close connection after use