### PR TITLE
Only set the attached flag when a client attaches

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9833,16 +9833,17 @@ debugger_thread (void *arg)
 	thread->internal_thread->state |= ThreadState_Background;
 	thread->internal_thread->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 
-	mono_set_is_debugger_attached (TRUE);
-	
 	if (agent_config.defer) {
 		if (!wait_for_attach ()) {
 			DEBUG_PRINTF (1, "[dbg] Can't attach, aborting debugger thread.\n");
 			attach_failed = TRUE; // Don't abort process when we can't listen
 		} else {
+			mono_set_is_debugger_attached (TRUE);
 			/* Send start event to client */
 			process_profiler_event (EVENT_KIND_VM_START, mono_thread_get_main ());
 		}
+	} else {
+		mono_set_is_debugger_attached (TRUE);
 	}
 	
 	while (!attach_failed) {


### PR DESCRIPTION
In defer mode, the debugger thread is started as soon as possible before
any clients are attached, but the debugger is_attached flag was being set
immediately. This would cause the runtime (and the System.Diagnostics.Debugger
class) to wrongly report a client as being attached.

Originally fixed in the Unity fork here: https://github.com/Unity-Technologies/mono/commit/797a210e0f2416d779c448bb9e03bb16933e261f

I've not added ant tests for this change. Is there testing infrastructure for a change like this? If so, I'll be happy to add some tests.