### PR TITLE
[mini] emit sequence point before branching off for tail call [was: respect seq points when adding instruction at end of block]

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9732,6 +9732,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				}
 
 				if (!has_vtargs) {
+					if (need_seq_point) {
+						emit_seq_point (cfg, method, ip, FALSE, TRUE);
+						need_seq_point = FALSE;
+					}
 					for (i = 0; i < n; ++i)
 						EMIT_NEW_ARGSTORE (cfg, ins, i, sp [i]);
 					MONO_INST_NEW (cfg, ins, OP_BR);


### PR DESCRIPTION
should fix https://bugzilla.xamarin.com/show_bug.cgi?id=42606

As reported in the bug report, something odd happens when running `mcs` in `Mono.CSharp.VarianceDecl:CheckTypeVariance` that leads to a hang. So I took a look at this method with [IGV](http://www.mono-project.com/docs/advanced/runtime/docs/other/#dumping-jit-ir-to-igv).

There's something odd after SSA removal, let's have a look at the graph diff:
<img width="647" alt="screen shot 2016-08-30 at 11 12 07 pm" src="https://cloud.githubusercontent.com/assets/75403/18107169/350f3ffa-6f07-11e6-924b-bfdf32e7bd6c.png">

The phi deconstruction inserts a `move`, however that `move` ends up _after_ the `branch` (even after the sequence point). Without sequence points (`MONO_DEBUG=no-compact-seq-points`) the graph diff looks like this:
<img width="606" alt="screen shot 2016-08-30 at 11 13 00 pm" src="https://cloud.githubusercontent.com/assets/75403/18107220/593aae5a-6f07-11e6-88ff-3ea6080bdc67.png">

The fix is to respect sequence point instructions in the helper function for inserting instructions at the end of a basic block.

cc @esdrubal 