### PR TITLE
[C8][loader] Check for ReferenceAssemblyAttribute (Fixes #42584)

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1927,6 +1927,20 @@ mono_domain_assembly_search (MonoAssemblyName *aname,
 	return NULL;
 }
 
+static gboolean
+prevent_running_reference_assembly (MonoAssembly *ass, MonoError *error)
+{
+	mono_error_init (error);
+	gboolean refasm = mono_assembly_get_reference_assembly_attribute (ass, error);
+	if (!is_ok (error))
+		return TRUE;
+	if (refasm) {
+		mono_error_set_bad_image (error, ass->image, "Could not load file or assembly or one of its dependencies. Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context.\n");
+		return TRUE;
+	}
+	return FALSE;
+}
+
 MonoReflectionAssembly *
 ves_icall_System_Reflection_Assembly_LoadFrom (MonoString *fname, MonoBoolean refOnly)
 {
@@ -1935,37 +1949,40 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoString *fname, MonoBoolean re
 	MonoDomain *domain = mono_domain_get ();
 	char *name, *filename;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
-	MonoAssembly *ass;
+	MonoAssembly *ass = NULL;
+
+	name = NULL;
+	result = NULL;
+
+	mono_error_init (&error);
 
 	if (fname == NULL) {
-		MonoException *exc = mono_get_exception_argument_null ("assemblyFile");
-		mono_set_pending_exception (exc);
-		return NULL;
+		mono_error_set_argument_null (&error, "assemblyFile", "");
+		goto leave;
 	}
 		
 	name = filename = mono_string_to_utf8_checked (fname, &error);
-	if (mono_error_set_pending_exception (&error))
-		return NULL;
+	if (!is_ok (&error))
+		goto leave;
 	
 	ass = mono_assembly_open_full (filename, &status, refOnly);
 	
 	if (!ass) {
-		MonoException *exc;
-
 		if (status == MONO_IMAGE_IMAGE_INVALID)
-			exc = mono_get_exception_bad_image_format2 (NULL, fname);
+			mono_error_set_bad_image_name (&error, name, "");
 		else
-			exc = mono_get_exception_file_not_found2 (NULL, fname);
-		g_free (name);
-		mono_set_pending_exception (exc);
-		return NULL;
+			mono_error_set_exception_instance (&error, mono_get_exception_file_not_found2 (NULL, fname));
+		goto leave;
 	}
 
-	g_free (name);
+	if (!refOnly && prevent_running_reference_assembly (ass, &error))
+		goto leave;
 
 	result = mono_assembly_get_object_checked (domain, ass, &error);
-	if (!result)
-		mono_error_set_pending_exception (&error);
+
+leave:
+	mono_error_set_pending_exception (&error);
+	g_free (name);
 	return result;
 }
 
@@ -2000,6 +2017,11 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomain *ad,
 		return NULL; 
 	}
 
+	if (!refonly && prevent_running_reference_assembly (ass, &error)) {
+		mono_error_set_pending_exception (&error);
+		return NULL;
+	}
+
 	refass = mono_assembly_get_object_checked (domain, ass, &error);
 	if (!refass)
 		mono_error_set_pending_exception (&error);
@@ -2017,7 +2039,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 	MonoAssembly *ass;
 	MonoAssemblyName aname;
 	MonoReflectionAssembly *refass = NULL;
-	gchar *name;
+	gchar *name = NULL;
 	gboolean parsed;
 
 	g_assert (assRef);
@@ -2026,16 +2048,13 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 	if (mono_error_set_pending_exception (&error))
 		return NULL;
 	parsed = mono_assembly_name_parse (name, &aname);
-	g_free (name);
 
 	if (!parsed) {
 		/* This is a parse error... */
 		if (!refOnly) {
 			refass = mono_try_assembly_resolve (domain, assRef, NULL, refOnly, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
-				return NULL;
-			}
+			if (!is_ok (&error))
+				goto leave;
 		}
 		return refass;
 	}
@@ -2047,25 +2066,31 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 		/* MS.NET doesn't seem to call the assembly resolve handler for refonly assemblies */
 		if (!refOnly) {
 			refass = mono_try_assembly_resolve (domain, assRef, NULL, refOnly, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
-				return NULL;
-			}
+			if (!is_ok (&error))
+				goto leave;
 		}
 		else
 			refass = NULL;
-		if (!refass) {
-			return NULL;
-		}
+		if (!refass)
+			goto leave;
+		ass = refass->assembly;
 	}
 
-	if (refass == NULL)
-		refass = mono_assembly_get_object_checked (domain, ass, &error);
+	if (!refOnly && prevent_running_reference_assembly (ass, &error))
+		goto leave;
 
-	if (refass == NULL)
-		mono_error_set_pending_exception (&error);
-	else
-		MONO_OBJECT_SETREF (refass, evidence, evidence);
+	g_assert (ass);
+	if (refass == NULL) {
+		refass = mono_assembly_get_object_checked (domain, ass, &error);
+		if (!is_ok (&error))
+			goto leave;
+	}
+
+	MONO_OBJECT_SETREF (refass, evidence, evidence);
+
+leave:
+	g_free (name);
+	mono_error_set_pending_exception (&error);
 	return refass;
 }
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1176,6 +1176,23 @@ mono_assembly_load_reference (MonoImage *image, int index)
 				   aname.major, aname.minor, aname.build, aname.revision,
 				   strlen ((char*)aname.public_key_token) == 0 ? "(none)" : (char*)aname.public_key_token, extra_msg);
 		g_free (extra_msg);
+
+	} else if (!image->assembly->ref_only) {
+		MonoError error;
+		if (mono_assembly_get_reference_assembly_attribute (reference, &error)) {
+			mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_ASSEMBLY, "The following reference assembly assembly referenced from %s was not loaded.  Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context:\n"
+				    "     Assembly:   %s    (assemblyref_index=%d)\n"
+				    "     Version:    %d.%d.%d.%d\n"
+				    "     Public Key: %s\n",
+				    image->name, aname.name, index,
+				    aname.major, aname.minor, aname.build, aname.revision,
+				    strlen ((char*)aname.public_key_token) == 0 ? "(none)" : (char*)aname.public_key_token);
+			reference = NULL; /* don't load reference assemblies for execution */
+		}
+		if (!is_ok (&error)) {
+			reference = NULL;
+			mono_error_cleanup (&error);
+		}
 	}
 
 	mono_assemblies_lock ();

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -203,6 +203,7 @@ static GSList *loaded_assembly_bindings = NULL;
 
 /* Class lazy loading functions */
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (internals_visible, System.Runtime.CompilerServices, InternalsVisibleToAttribute)
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (reference_assembly, System.Runtime.CompilerServices, ReferenceAssemblyAttribute)
 
 static MonoAssembly*
 mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload);
@@ -1786,6 +1787,37 @@ mono_assembly_load_friends (MonoAssembly* ass)
 	mono_memory_barrier ();
 	ass->friend_assembly_names_inited = TRUE;
 	mono_assemblies_unlock ();
+}
+
+
+/**
+ * mono_assembly_get_reference_assembly_attribute:
+ * @assembly: a MonoAssembly
+ * @error: set on error.
+ *
+ * Returns TRUE if @assembly has the System.Runtime.CompilerServices.ReferenceAssemblyAttribute set.
+ * On error returns FALSE and sets @error.
+ */
+gboolean
+mono_assembly_get_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error)
+{
+	mono_error_init (error);
+
+	MonoCustomAttrInfo *attrs = mono_custom_attrs_from_assembly_checked (assembly, error);
+	return_val_if_nok (error, FALSE);
+	if (!attrs)
+		return FALSE;
+	MonoClass *ref_asm_class = mono_class_try_get_reference_assembly_class ();
+	gboolean result = FALSE;
+	for (int i = 0; i < attrs->num_attrs; ++i) {
+		MonoCustomAttrEntry *attr = &attrs->attrs [i];
+		if (attr->ctor && attr->ctor->klass && attr->ctor->klass == ref_asm_class) {
+			result = TRUE;
+			break;
+		}
+	}
+	mono_custom_attrs_free (attrs);
+	return result;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5544,6 +5544,7 @@ mono_class_setup_parent (MonoClass *klass, MonoClass *parent)
 			/* set the parent to something useful and safe, but mark the type as broken */
 			parent = mono_defaults.object_class;
 			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+			g_assert (parent);
 		}
 
 		klass->parent = parent;

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -697,4 +697,8 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 void
 mono_context_init_checked (MonoDomain *domain, MonoError *error);
 
+gboolean
+mono_assembly_get_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error);
+
+
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -807,6 +807,16 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_profiler_appdomain_name (domain, domain->friendly_name);
 
+	/* Have to do this quite late so that we at least have System.Object */
+	MonoError custom_attr_error;
+	if (mono_assembly_get_reference_assembly_attribute (ass, &custom_attr_error)) {
+		char *corlib_file = g_build_filename (mono_assembly_getrootdir (), "mono", current_runtime->framework_version, "mscorlib.dll", NULL);
+		g_print ("Could not load file or assembly %s. Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context.", corlib_file);
+		g_free (corlib_file);
+		exit (1);
+	}
+	mono_error_assert_ok (&custom_attr_error);
+
 	return domain;
 }
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -436,7 +436,8 @@ BASE_TEST_CS_SRC=		\
 	pinvoke_ppci.cs	\
 	pinvoke_ppcf.cs	\
 	pinvoke_ppcd.cs	\
-	bug-29585.cs
+	bug-29585.cs	\
+	reference-loader.cs
 
 TEST_CS_SRC_DIST=	\
 	$(BASE_TEST_CS_SRC)	\
@@ -700,11 +701,13 @@ TEST_IL_SRC=			\
 # but that need to be compiled
 PREREQ_IL_SRC=event-il.il module-cctor.il
 PREREQ_CS_SRC=
-PREREQ_IL_DLL_SRC=event-il.il module-cctor.il
-PREREQ_CS_DLL_SRC=
+PREREQ_IL_DLL_SRC=
+PREREQ_CS_DLL_SRC=TestingReferenceAssembly.cs TestingReferenceReferenceAssembly.cs
 
-PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe)
-PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe)
+PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe) \
+	$(PREREQ_IL_DLL_SRC:.il=.dll)
+PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe) \
+	$(PREREQ_CS_DLL_SRC:.cs=.dll)
 TESTSI_CS=$(TEST_CS_SRC:.cs=.exe)
 TESTSI_IL=$(TEST_IL_SRC:.il=.exe)
 TESTBS=$(BENCHSRC:.cs=.exe)
@@ -718,6 +721,13 @@ EXTRA_DIST=test-driver test-runner.cs $(TEST_CS_SRC_DIST) $(TEST_IL_SRC) \
 
 %.exe: %.cs TestDriver.dll
 	$(MCS) -r:System.dll -r:System.Xml.dll -r:System.Core.dll -r:TestDriver.dll -r:Mono.Posix.dll -out:$@ $<
+
+%.dll: %.cs
+	$(MCS) -r:System.dll -target:library -out:$@ $<
+
+TestingReferenceReferenceAssembly.dll: TestingReferenceReferenceAssembly.cs TestingReferenceAssembly.dll
+	$(MCS) -r:TestingReferenceAssembly.dll -target:library -out:$@ $<
+
 
 # mkbundle works on ppc, but the pkg-config POC doesn't when run with make test
 if POWERPC

--- a/mono/tests/TestingReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceAssembly.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: ReferenceAssemblyAttribute]
+
+public class X {
+	public int Y;
+}

--- a/mono/tests/TestingReferenceReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceReferenceAssembly.cs
@@ -1,0 +1,7 @@
+// An assembly that refereces the TestingReferenceAssembly
+
+class Z : X {
+	public Z () {
+		Y = 1;
+	}
+}

--- a/mono/tests/reference-loader.cs
+++ b/mono/tests/reference-loader.cs
@@ -1,0 +1,111 @@
+//
+// reference-loader.cs:
+//
+//  Test for reference assembly loading
+
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Tests {
+	public static int Main (string[] args)
+	{
+		return TestDriver.RunTests (typeof (Tests), args);
+	}
+
+	public static int test_0_loadFrom_reference ()
+	{
+		// Check that loading a reference assembly by filename for execution is an error
+		try {
+			var a = Assembly.LoadFrom ("./TestingReferenceAssembly.dll");
+		} catch (BadImageFormatException exn) {
+			// Console.Error.WriteLine ("exn was {0}", exn);
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_load_reference ()
+	{
+		// Check that loading a reference assembly for execution is an error
+		try {
+			var an = new AssemblyName ("TestingReferenceAssembly");
+			var a = Assembly.Load (an);
+		} catch (BadImageFormatException exn) {
+			//Console.Error.WriteLine ("exn was {0}", exn);
+			return 0;
+		} catch (FileNotFoundException exn) {
+			Console.Error.WriteLine ("incorrect exn was {0}", exn);
+			return 2;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference ()
+	{
+		// Check that reflection-only loading a reference assembly is okay
+		var an = new AssemblyName ("TestingReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+	public static int test_0_load_reference_asm_via_reference ()
+	{
+		// Check that loading an assembly that references a reference assembly doesn't succeed.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		try {
+			var a = Assembly.Load (an);
+			var t = a.GetType ("Z");
+		} catch (FileNotFoundException){
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_asm_via_reference ()
+	{
+		// Check that reflection-only loading an assembly that
+		// references a reference assembly is okay.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("Z");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+
+	public static int test_0_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte array for execution is an error
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		try {
+			var a = Assembly.Load (bs);
+		} catch (BadImageFormatException) {
+			return 0;
+		} catch (FileNotFoundException exn) {
+			Console.Error.WriteLine ("incorrect exn was {0}", exn);
+			return 2;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte
+		// array for reflection only is okay.
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		var a = Assembly.ReflectionOnlyLoad (bs);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+}


### PR DESCRIPTION
If an assembly has the `ReferenceAssemblyAttribute` applied to it, only allow the assembly to be loaded for reflection, not for execution.

Fixes [#42584](https://bugzilla.xamarin.com/show_bug.cgi?id=42584)

This is the Cycle8 version of #3446 