### PR TITLE
[runtime] Add a mono_threads_close_thread_handle () function and use …

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1085,7 +1085,7 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 	SET_CURRENT_OBJECT (NULL);
 	mono_domain_unset ();
 
-	/* Don't need to CloseHandle this thread, even though we took a
+	/* Don't need to close the handle to this thread, even though we took a
 	 * reference in mono_thread_attach (), because the GC will do it
 	 * when the Thread object is finalised.
 	 */
@@ -1214,7 +1214,7 @@ ves_icall_System_Threading_InternalThread_Thread_free_internal (MonoInternalThre
 	 * when thread_cleanup () can be called after this.
 	 */
 	if (thread)
-		CloseHandle (thread);
+		mono_threads_close_thread_handle (thread);
 
 	if (this_obj->synch_cs) {
 		MonoCoopMutex *synch_cs = this_obj->synch_cs;
@@ -2989,7 +2989,8 @@ struct wait_data
 	guint32 num;
 };
 
-static void wait_for_tids (struct wait_data *wait, guint32 timeout)
+static void
+wait_for_tids (struct wait_data *wait, guint32 timeout)
 {
 	guint32 i, ret;
 	
@@ -3006,7 +3007,7 @@ static void wait_for_tids (struct wait_data *wait, guint32 timeout)
 	}
 	
 	for(i=0; i<wait->num; i++)
-		CloseHandle (wait->handles[i]);
+		mono_threads_close_thread_handle (wait->handles [i]);
 
 	if (ret == WAIT_TIMEOUT)
 		return;
@@ -3069,7 +3070,7 @@ static void wait_for_tids_or_state_change (struct wait_data *wait, guint32 timeo
 	}
 	
 	for(i=0; i<wait->num; i++)
-		CloseHandle (wait->handles[i]);
+		mono_threads_close_thread_handle (wait->handles [i]);
 
 	if (ret == WAIT_TIMEOUT)
 		return;
@@ -3389,7 +3390,7 @@ void mono_thread_suspend_all_other_threads (void)
 			     || mono_gc_is_finalizer_internal_thread (thread)
 			     || (thread->flags & MONO_THREAD_FLAG_DONT_MANAGE)
 			) {
-				//CloseHandle (wait->handles [i]);
+				//mono_threads_close_thread_handle (wait->handles [i]);
 				wait->threads [i] = NULL; /* ignore this thread in next loop */
 				continue;
 			}
@@ -3400,7 +3401,7 @@ void mono_thread_suspend_all_other_threads (void)
 				(thread->state & ThreadState_StopRequested) != 0 ||
 				(thread->state & ThreadState_Stopped) != 0) {
 				UNLOCK_THREAD (thread);
-				CloseHandle (wait->handles [i]);
+				mono_threads_close_thread_handle (wait->handles [i]);
 				wait->threads [i] = NULL; /* ignore this thread in next loop */
 				continue;
 			}

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -274,6 +274,12 @@ mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
 	return handle;
 }
 
+void
+mono_threads_platform_close_thread_handle (HANDLE handle)
+{
+	mono_w32handle_unref (handle);
+}
+
 int
 mono_threads_pthread_kill (MonoThreadInfo *info, int signum)
 {

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -319,6 +319,12 @@ mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
 	return OpenThread (THREAD_ALL_ACCESS, TRUE, tid);
 }
 
+void
+mono_threads_platform_close_thread_handle (HANDLE handle)
+{
+	CloseHandle (handle);
+}
+
 #if defined(_MSC_VER)
 const DWORD MS_VC_EXCEPTION=0x406D1388;
 #pragma pack(push,8)

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1365,6 +1365,12 @@ mono_threads_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
 	return mono_threads_platform_open_thread_handle (handle, tid);
 }
 
+void
+mono_threads_close_thread_handle (HANDLE handle)
+{
+	return mono_threads_platform_close_thread_handle (handle);
+}
+
 #define INTERRUPT_STATE ((MonoThreadInfoInterruptToken*) (size_t) -1)
 
 struct _MonoThreadInfoInterruptToken {

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -473,6 +473,9 @@ mono_threads_get_max_stack_size (void);
 HANDLE
 mono_threads_open_thread_handle (HANDLE handle, MonoNativeThreadId tid);
 
+void
+mono_threads_close_thread_handle (HANDLE handle);
+
 MONO_API void
 mono_threads_attach_tools_thread (void);
 
@@ -540,6 +543,7 @@ void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
 gboolean mono_threads_platform_yield (void);
 void mono_threads_platform_exit (int exit_code);
 HANDLE mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid);
+void mono_threads_platform_close_thread_handle (HANDLE handle);
 void mono_threads_platform_set_exited (THREAD_INFO_TYPE *info);
 void mono_threads_platform_describe (THREAD_INFO_TYPE *info, GString *text);
 void mono_threads_platform_own_mutex (THREAD_INFO_TYPE *info, gpointer mutex_handle);


### PR DESCRIPTION
…it to close thread handles instead of CloseHandle ().