### PR TITLE
[Mono.Data.Sqlite] Added checks for entry point existence

### DIFF
--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLite3.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLite3.cs
@@ -125,17 +125,9 @@ namespace Mono.Data.Sqlite
 	// Compatibility with versions < 3.5.0
         int n;
 
-#if MONOTOUCH
 	if (UnsafeNativeMethods.use_sqlite3_open_v2) {
-#else
-	try {
-#endif
 		n = UnsafeNativeMethods.sqlite3_open_v2(ToUTF8(strFilename), out db, (int)flags, IntPtr.Zero);
-#if MONOTOUCH
 	} else {
-#else
-	} catch (EntryPointNotFoundException) {
-#endif
 		Console.WriteLine ("Your sqlite3 version is old - please upgrade to at least v3.5.0!");
 		n = UnsafeNativeMethods.sqlite3_open (ToUTF8 (strFilename), out db);
 	}

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLite3.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLite3.cs
@@ -125,9 +125,17 @@ namespace Mono.Data.Sqlite
 	// Compatibility with versions < 3.5.0
         int n;
 
+#if MONOTOUCH
+	if (UnsafeNativeMethods.use_sqlite3_open_v2) {
+#else
 	try {
+#endif
 		n = UnsafeNativeMethods.sqlite3_open_v2(ToUTF8(strFilename), out db, (int)flags, IntPtr.Zero);
+#if MONOTOUCH
+	} else {
+#else
 	} catch (EntryPointNotFoundException) {
+#endif
 		Console.WriteLine ("Your sqlite3 version is old - please upgrade to at least v3.5.0!");
 		n = UnsafeNativeMethods.sqlite3_open (ToUTF8 (strFilename), out db);
 	}

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteBase.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteBase.cs
@@ -208,9 +208,17 @@ namespace Mono.Data.Sqlite
 #else
         ResetConnection(db);
         int n;
+#if MONOTOUCH
+        if (UnsafeNativeMethods.use_sqlite3_close_v2) {
+#else
         try {
+#endif
           n = UnsafeNativeMethods.sqlite3_close_v2(db);
+#if MONOTOUCH
+        } else {
+#else
         } catch (EntryPointNotFoundException) {
+#endif
           n = UnsafeNativeMethods.sqlite3_close(db);
         }
 #endif

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteBase.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteBase.cs
@@ -208,17 +208,9 @@ namespace Mono.Data.Sqlite
 #else
         ResetConnection(db);
         int n;
-#if MONOTOUCH
         if (UnsafeNativeMethods.use_sqlite3_close_v2) {
-#else
-        try {
-#endif
           n = UnsafeNativeMethods.sqlite3_close_v2(db);
-#if MONOTOUCH
         } else {
-#else
-        } catch (EntryPointNotFoundException) {
-#endif
           n = UnsafeNativeMethods.sqlite3_close(db);
         }
 #endif

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
@@ -24,19 +24,17 @@ namespace Mono.Data.Sqlite
       // calculate the version number parts
       // https://www.sqlite.org/c3ref/c_source_id.html
       // (<major> * 1000000) + (<minor> * 1000) + (<release>)
-      int version = sqlite3_libversion_number();
-      int release = version % 1000;
-      int minor = (version / 1000) % 1000;
-      int major = version / 1000000;
+      int versionNumber = sqlite3_libversion_number();
+      int release = versionNumber % 1000;
+      int minor = (versionNumber / 1000) % 1000;
+      int major = versionNumber / 1000000;
+      Version version = new Version(major, minor, release);
 
       // set the various versions
       // https://sqlite.org/changes.html
-      bool v3_5_0 = major >= 3 && minor >= 5 && release >= 0;
-      bool v3_7_14 = major >= 3 && minor >= 7 && release >= 14;
-      bool v3_7_3 = major >= 3 && minor >= 7 && release >= 3;
-      use_sqlite3_open_v2 = v3_5_0;
-      use_sqlite3_close_v2 = v3_7_14;
-      use_sqlite3_create_function_v2 = v3_7_3;
+      use_sqlite3_open_v2 = version >= new Version(3, 5, 0);
+      use_sqlite3_close_v2 = version >= new Version(3, 7, 14);
+      use_sqlite3_create_function_v2 = version >= new Version(3, 7, 3);
     }
 
 #if !SQLITE_STANDARD

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
@@ -17,8 +17,8 @@ namespace Mono.Data.Sqlite
   internal static class UnsafeNativeMethods
   {
 #if MONOTOUCH
-    internal static bool use_sqlite3_close_v2 = false;
-    internal static bool use_sqlite3_open_v2 = false;
+    internal static readonly bool use_sqlite3_close_v2 = false;
+    internal static readonly bool use_sqlite3_open_v2 = false;
     static UnsafeNativeMethods()
     {
       IntPtr lib = ObjCRuntime.Dlfcn.dlopen(SQLITE_DLL, 0);

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/UnsafeNativeMethods.cs
@@ -16,6 +16,16 @@ namespace Mono.Data.Sqlite
 #endif
   internal static class UnsafeNativeMethods
   {
+#if MONOTOUCH
+    internal static bool use_sqlite3_close_v2 = false;
+    internal static bool use_sqlite3_open_v2 = false;
+    static UnsafeNativeMethods()
+    {
+      IntPtr lib = ObjCRuntime.Dlfcn.dlopen(SQLITE_DLL, 0);
+      use_sqlite3_open_v2 = ObjCRuntime.Dlfcn.dlsym(lib, "sqlite3_open_v2") != IntPtr.Zero;
+      use_sqlite3_close_v2 = ObjCRuntime.Dlfcn.dlsym(lib, "sqlite3_close_v2") != IntPtr.Zero;
+    }
+#endif
 #if !SQLITE_STANDARD
 
 #if !USE_INTEROP_DLL


### PR DESCRIPTION
As a result of https://bugzilla.xamarin.com/show_bug.cgi?id=41723

~~Using `Dlfcn.dlsym` to avoid P/Invoke exceptions, by first checking at startup for the existence of the various entry points. Then, instead of waiting for an exception, check the field to call the correct method the first time.~~

To avoid exceptions, just get the version number once, and then associate the version with API members. No need for entry point lookups, just integer comparison.

Version details: https://www.sqlite.org/c3ref/c_source_id.html
API details per version: https://sqlite.org/changes.html
