### PR TITLE
Lookup of test resource files in ResourceReaderTest fails on Windows

### DIFF
--- a/mcs/class/corlib/Test/System.Resources/ResourceReaderTest.cs
+++ b/mcs/class/corlib/Test/System.Resources/ResourceReaderTest.cs
@@ -28,15 +28,9 @@ namespace MonoTests.System.Resources
 		[TestFixtureSetUp]
 		public void FixtureSetUp ()
 		{
-			char ds = Path.DirectorySeparatorChar;
-			if (ds == '/') {
-				string base_path = Path.Combine (Directory.GetCurrentDirectory (), Path.Combine ("Test", "resources"));
-				m_ResourceFile = Path.Combine (base_path, "MyResources.resources");
-				m_BadResourceFile = Path.Combine (base_path, "Empty.resources");
-			} else {
-				m_ResourceFile = Path.Combine ("Test", Path.Combine ("resources", "MyResources.resources"));
-				m_BadResourceFile = "resources" + ds + "Empty.resources";
-			}
+			string base_path = Path.Combine (Directory.GetCurrentDirectory (), Path.Combine ("Test", "resources"));
+			m_ResourceFile = Path.Combine (base_path, "MyResources.resources");
+			m_BadResourceFile = Path.Combine (base_path, "Empty.resources");
 		}
 
 		[SetUp]


### PR DESCRIPTION
The FixtureSetUp() seems to assume that we're running on .NET if `Path.DirectorySeparatorChar == '\'`. This patch checks whether running on Mono instead and uses the same code path to lookup the test resources. Makes the test work on Mono on Windows.