### PR TITLE
Make Zone.CreateFromUrl() work with URLs like file://C:\foo\bar

### DIFF
--- a/mcs/class/corlib/Mono.Security/Uri.cs
+++ b/mcs/class/corlib/Mono.Security/Uri.cs
@@ -1015,7 +1015,7 @@ namespace Mono.Security {
 			}
 			
 			// 5 path
-			pos = uriString.IndexOfAny (new char[] {'/'});
+			pos = uriString.IndexOfAny (new char[] {'/', '\\'});
 			if (unixAbsPath)
 				pos = -1;
 			if (pos == -1) {
@@ -1041,6 +1041,8 @@ namespace Mono.Security {
 			port = -1;
 			pos = uriString.LastIndexOf (":");
 			if (unixAbsPath)
+				pos = -1;
+			if (pos == 1 && scheme == Uri.UriSchemeFile && Char.IsLetter (uriString [0]))
 				pos = -1;
 			if (pos != -1 && pos != (uriString.Length - 1)) {
 				string portStr = uriString.Remove (0, pos + 1);

--- a/mcs/class/corlib/System.Security.Policy/Zone.cs
+++ b/mcs/class/corlib/System.Security.Policy/Zone.cs
@@ -83,7 +83,13 @@ namespace System.Security.Policy {
 			if (url.Length == 0)
 				return new Zone (z);
 
-			Uri uri = new Uri (url);
+			Uri uri = null;
+			try {
+				uri = new Uri (url);
+			}
+			catch {
+				return new Zone (z);
+			}
 			// TODO: apply zone configuration
 			// this is the only way to use the Trusted and Untrusted zones
 

--- a/mcs/class/corlib/Test/System.Security.Policy/ZoneTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Policy/ZoneTest.cs
@@ -229,7 +229,7 @@ namespace MonoTests.System.Security.Policy {
 			"http://*.go-mono.com",
 			"http://www.go-mono.com:8080/index.html",
 			"mono://unknown/protocol",
-			Path.DirectorySeparatorChar + "mono" + Path.DirectorySeparatorChar + "index.html",
+			"/mono/index.html",
 		};
 
 		[Test]


### PR DESCRIPTION
On Windows the test used URLs like `file://C:\tmp\foo` which the Mono.Security.Uri class was incapable of parsing. System.Uri from referencesource parses such URLs just fine. This patch fixes the Mono.Security.Uri class to be able to parse such URLs. It also changes the Zone class to not throw an exception if the Zone.CreateFromUrl() method is passed an invalid URL. Instead
the zone is set to NoZone. This seems to be how Zone in .NET behaves.