### PR TITLE
Try to use an IPv4 address first for TCP remoting

### DIFF
--- a/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.cs
+++ b/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.cs
@@ -71,7 +71,12 @@ namespace System.Runtime.Remoting.Channels.Tcp
 					else {
 						IPHostEntry he = Dns.Resolve (Dns.GetHostName());
 						if (he.AddressList.Length == 0) throw new RemotingException ("IP address could not be determined for this host");
-						host = he.AddressList [0].ToString ();
+						AddressFamily addressFamily = (Socket.OSSupportsIPv4) ? AddressFamily.InterNetwork : AddressFamily.InterNetworkV6;
+						IPAddress addr = GetMachineAddress (he, addressFamily);
+						if (addr != null)
+							host = addr.ToString ();
+						else
+							host = he.AddressList [0].ToString ();
 					}
 				}
 				else
@@ -258,6 +263,22 @@ namespace System.Runtime.Remoting.Channels.Tcp
 			threadPool.Free ();
 			server_thread.Join ();
 			server_thread = null;			
+		}
+
+		private static IPAddress GetMachineAddress (IPHostEntry host, AddressFamily addressFamily)
+		{
+			IPAddress result = null;
+			if (host != null) {
+				IPAddress[] addressList = host.AddressList;
+				for (int i = 0; i < addressList.Length; i++) {
+					if (addressList[i].AddressFamily == addressFamily) {
+						result = addressList[i];
+						break;
+					}
+				}
+			}
+
+			return result;
 		}
 	}
 


### PR DESCRIPTION
I'm opening this pull request more for initial discussion than anything else. Here are the details from the commit message:

* In the .NET implementation of TcpServerChannel, if IPv4 is supported, the address for the host will use the first IPv4 address.
* Even if the first address is an IPv6 address, it should be skipped, as the server side will expect and IPv4 address.
* Change this implementation to look for an IPv4 address first, then fall back to whatever the first address is (IPv4 or IPv6) if things don't work out.

Here are my questions:

1. Is there a good way to test this? I see one use of `TcpServerChannel` in mcs/class/System.Runtime.Remoting/Test/System.Runtime.Remoting.Channels.Tcp/TcpChannelTest.cs, but that test is ignored with a comment saying that it hangs. So I don't want to add another (possibly hanging) test.
2. I've taken the implementation here from .NET reference source, but I know the Mono is incorporating reference source independently. Is there a better way for me to integrate this other than copying the code?

I'll be happy to iterate on this and come back with a new PR if/when these answers are determined.