### PR TITLE
[PATCH] SemaphoreSlim, fail faster for timeout 0

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/threading/SemaphoreSlim.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/SemaphoreSlim.cs
@@ -79,6 +79,9 @@ namespace System.Threading
         // A pre-completed task with Result==true
         private readonly static Task<bool> s_trueTask =
             new Task<bool>(false, true, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default(CancellationToken));
+        // A pre-completed task with Result==false
+        private readonly static Task<bool> s_falseTask =
+            new Task<bool>(false, false, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default(CancellationToken));
 
         // No maximum constant
         private const int NO_MAXIMUM = Int32.MaxValue;
@@ -322,6 +325,13 @@ namespace System.Threading
             }
 
             cancellationToken.ThrowIfCancellationRequested();
+
+            // Perf: Check the stack timeout parameter before checking the volatile count
+            if (millisecondsTimeout == 0 && m_currentCount == 0)
+            {
+                // Pessimistic fail fast, check volatile count outside lock (only when timeout is zero!)
+                return false;
+            }
 
             uint startTime = 0;
             if (millisecondsTimeout != Timeout.Infinite && millisecondsTimeout > 0)
@@ -620,6 +630,11 @@ namespace System.Threading
                     --m_currentCount;
                     if (m_waitHandle != null && m_currentCount == 0) m_waitHandle.Reset();
                     return s_trueTask;
+                }
+                else if (millisecondsTimeout == 0)
+                {
+                    // No counts, if timeout is zero fail fast
+                    return s_falseTask;
                 }
                     // If there aren't, create and return a task to the caller.
                     // The task will be completed either when they've successfully acquired


### PR DESCRIPTION
This brings the patch: https://github.com/dotnet/coreclr/pull/6898

Fail faster for `Wait(0)` when no counts available.

Don't allocate in the `Wait(0)` and `WaitAsync(0)` fail paths.

1M iters Server GC

method | pre (ms) | post (ms) | improvement
-------- |------- |------- |------ |
Wait(0) | 33,788.25 | 12.28 | x 2751.5
WaitAsync(0) | 360.79 | 24.38 | x 14.8

Memory allocations, saves 360MB over the 1M ops