### PR TITLE
[corlib] Ensure FileIOPermission ctor is not called on mobile 

### DIFF
--- a/mcs/class/corlib/System/AppDomainSetup.cs
+++ b/mcs/class/corlib/System/AppDomainSetup.cs
@@ -150,8 +150,18 @@ namespace System
 				}
 			}
 
-			// Trigger a validation of the path
-			new FileIOPermission (FileIOPermissionAccess.PathDiscovery, appBase);
+			// validate the path
+			string dir = Path.GetDirectoryName (appBase);
+			if ((dir != null) && (dir.LastIndexOfAny (Path.GetInvalidPathChars ()) >= 0)) {
+				string msg = String.Format (Locale.GetText ("Invalid path characters in path: '{0}'"), appBase);
+				throw new ArgumentException (msg, "appBase");
+			}
+
+			string fname = Path.GetFileName (appBase);
+			if ((fname != null) && (fname.LastIndexOfAny (Path.GetInvalidFileNameChars ()) >= 0)) {
+				string msg = String.Format (Locale.GetText ("Invalid filename characters in path: '{0}'"), appBase);
+				throw new ArgumentException (msg, "appBase");
+			}
 
 			return appBase;
 		}


### PR DESCRIPTION
After #3452 was merged, the LinkSdkRegressionTest.SecurityDeclaration test in XI started failing:

```
	[FAIL] LinkSdkRegressionTest.SecurityDeclaration :   FileIOPermissionAccess
  Expected: null
  But was:  <System.Security.Permissions.FileIOPermissionAccess>

		  at LinkSdk.LinkSdkRegressionTest.SecurityDeclaration () [0x00033] in /Users/builder/data/lanes/1411/2a96404f/source/xamarin-macios/tests/linker-ios/link sdk/LinkSdkRegressionTest.cs:990
		  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
		  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in /Users/builder/data/lanes/1411/2a96404f/source/xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/src/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
```

Due to the added call in the PR the linker preserved FileIOPermissionAccess enum, which is apparently something we want to avoid.

Since according to mono#3452 (comment) the only point of calling the FileIOPermission ctor is validating that the path doesn't contain invalid characters (mostly an issue on Windows), I decided to just copy those checks as it's way cleaner.