### PR TITLE
Prevent ModuleTest failures due to too long temp folder path on Windows

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/ModuleTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ModuleTest.cs
@@ -24,13 +24,26 @@ namespace MonoTests.System.Reflection
 [TestFixture]
 public class ModuleTest
 {
-	static string TempFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.Reflection.ModuleTest");
+	static string BaseTempFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.Reflection.ModuleTest");
+	static string TempFolder;
+
+	[TestFixtureSetUp]
+	public void FixtureSetUp ()
+	{
+		try {
+			// Try to cleanup from any previous NUnit run.
+			Directory.Delete (BaseTempFolder, true);
+		} catch (Exception) {
+		}
+	}
 
 	[SetUp]
 	public void SetUp ()
 	{
-		while (Directory.Exists (TempFolder))
-			TempFolder = Path.Combine (TempFolder, "2");
+		int i = 0;
+		do {
+			TempFolder = Path.Combine (BaseTempFolder, (++i).ToString());
+		} while (Directory.Exists (TempFolder));
 		Directory.CreateDirectory (TempFolder);
 	}
 
@@ -38,8 +51,8 @@ public class ModuleTest
 	public void TearDown ()
 	{
 		try {
-			// This throws an exception under MS.NET, since the directory contains loaded
-			// assemblies.
+			// This throws an exception under MS.NET and Mono on Windows,
+			// since the directory contains loaded assemblies.
 			Directory.Delete (TempFolder, true);
 		} catch (Exception) {
 		}


### PR DESCRIPTION
On Windows the TearDown() cannot delete the temp folder since it contains loaded assemblies. The next time the test is run it will create a temp folder inside the previous folder. After a number of runs the temp folder path will approach the ~260 max path supported on Windows and some of the methods will start failing.

This patch changes the way the temp folder is created and reduces the depth in the same way as AssemblyTest was patched to fix a similar issue in b90617e7b7a9ecd501abc65d171d97163ce4ee3d.