### PR TITLE
Fix for failures in RegistryKeyTest on Windows

### DIFF
--- a/mcs/class/corlib/Microsoft.Win32/Win32ResultCode.cs
+++ b/mcs/class/corlib/Microsoft.Win32/Win32ResultCode.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Win32
 		public const int NetworkPathNotFound = 53;
 		public const int NoMoreEntries = 259;
 		public const int MarkedForDeletion = 1018;
+		public const int ChildMustBeVolatile = 1021;
 	}
 }
 

--- a/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
+++ b/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
@@ -679,6 +679,7 @@ namespace MonoTests.Microsoft.Win32
 					subkey.Close ();
 				if (key != null)
 					key.Close ();
+				Registry.CurrentUser.DeleteSubKeyTree (subKeyName, false);
 			}
 		}
 
@@ -699,6 +700,7 @@ namespace MonoTests.Microsoft.Win32
 					subkey.Close ();
 				if (key != null)
 					key.Close ();
+				Registry.CurrentUser.DeleteSubKeyTree (subKeyName, false);
 			}
 		}
 
@@ -708,14 +710,15 @@ namespace MonoTests.Microsoft.Win32
 			RegistryKey key = null;
 			RegistryKey key2 = null;
 			RegistryKey subkey = null;
-			string subKeyName = "VolatileKey";
+			string subKeyNameVolatile = "VolatileKey";
+			string subKeyNameNonVolatile = "NonVolatileKey";
 
 			try {
 				// 
 				// Create a volatile key and try to open it as a normal one
 				//
-				key = Registry.CurrentUser.CreateSubKey (subKeyName, RegistryKeyPermissionCheck.Default, RegistryOptions.Volatile);
-				key2 = Registry.CurrentUser.CreateSubKey (subKeyName, RegistryKeyPermissionCheck.Default, RegistryOptions.None);
+				key = Registry.CurrentUser.CreateSubKey (subKeyNameVolatile, RegistryKeyPermissionCheck.Default, RegistryOptions.Volatile);
+				key2 = Registry.CurrentUser.CreateSubKey (subKeyNameVolatile, RegistryKeyPermissionCheck.Default, RegistryOptions.None);
 				Assert.AreEqual (key.Name, key2.Name, "A0");
 
 				subkey = key2.CreateSubKey ("Child", RegistryKeyPermissionCheck.Default, RegistryOptions.Volatile);
@@ -729,10 +732,9 @@ namespace MonoTests.Microsoft.Win32
 				// 
 				// Create a non-volatile key and try to open it as a volatile one
 				//
-				subKeyName = "NonVolatileKey";
-				key2 = Registry.CurrentUser.CreateSubKey (subKeyName, RegistryKeyPermissionCheck.Default, RegistryOptions.None);
+				key2 = Registry.CurrentUser.CreateSubKey (subKeyNameNonVolatile, RegistryKeyPermissionCheck.Default, RegistryOptions.None);
 				key2.SetValue ("Name", "Mono");
-				key = Registry.CurrentUser.CreateSubKey (subKeyName, RegistryKeyPermissionCheck.Default, RegistryOptions.Volatile);
+				key = Registry.CurrentUser.CreateSubKey (subKeyNameNonVolatile, RegistryKeyPermissionCheck.Default, RegistryOptions.Volatile);
 				Assert.AreEqual (key.Name, key2.Name, "B0");
 				Assert.AreEqual ("Mono", key.GetValue ("Name"), "#B1");
 				Assert.AreEqual ("Mono", key2.GetValue ("Name"), "#B2");
@@ -746,7 +748,7 @@ namespace MonoTests.Microsoft.Win32
 				//
 				key.Close ();
 				key2.Close ();
-				key = Registry.CurrentUser.CreateSubKey (subKeyName, RegistryKeyPermissionCheck.Default, RegistryOptions.Volatile);
+				key = Registry.CurrentUser.CreateSubKey (subKeyNameNonVolatile, RegistryKeyPermissionCheck.Default, RegistryOptions.Volatile);
 				Assert.AreEqual ("Mono", key.GetValue ("Name"), "#C0");
 				Assert.AreEqual (true, key.OpenSubKey ("Child") != null, "#C1");
 			} finally {
@@ -756,6 +758,8 @@ namespace MonoTests.Microsoft.Win32
 					key.Close ();
 				if (key2 != null)
 					key2.Close ();
+				Registry.CurrentUser.DeleteSubKeyTree (subKeyNameVolatile, false);
+				Registry.CurrentUser.DeleteSubKeyTree (subKeyNameNonVolatile, false);
 			}
 		}
 


### PR DESCRIPTION
Refcatored Win32RegistryApi.SetValue() to accept uint/byte/etc values for DWord registry values.

Added handling of ERROR_CHILD_MUST_BE_VOLATILE errors to GenerateException().

Centralized MarkedForDeletion error handling to GenerateException().

Fixed tests which create volatile subkeys in RegistryKeyTest which used the same key names but didn't clean up properly.