### PR TITLE
Using running process to determine mono exe path on windows

### DIFF
--- a/mcs/class/System.Web/System.Web.Compilation/AppResourcesAssemblyBuilder.cs
+++ b/mcs/class/System.Web/System.Web.Compilation/AppResourcesAssemblyBuilder.cs
@@ -47,8 +47,6 @@ namespace System.Web.Compilation
 {
 	class AppResourcesAssemblyBuilder
 	{
-		static string framework_version = "4.5";
-		static string profile_path = "net_4_x";
 		CompilationSection config;
 		CompilerInfo ci;
 		CodeDomProvider _provider;
@@ -233,36 +231,14 @@ namespace System.Web.Compilation
 		string SetAlPath (ProcessStartInfo info)
 		{			
 			if (RuntimeHelpers.RunningOnWindows) {
-				string alPath;
-				string monoPath;
-				PropertyInfo gac = typeof (Environment).GetProperty ("GacPath", BindingFlags.Static|BindingFlags.NonPublic);
-                                MethodInfo get_gac = gac.GetGetMethod (true);
-                                string p = Path.GetDirectoryName ((string) get_gac.Invoke (null, null));
-				monoPath = Path.Combine (Path.GetDirectoryName (Path.GetDirectoryName (p)), "bin\\mono.bat");
-                                if (!File.Exists (monoPath)) {
-                                        monoPath = Path.Combine (Path.GetDirectoryName (Path.GetDirectoryName (p)), "bin\\mono.exe");
-					if (!File.Exists (monoPath)) {
-						monoPath = Path.Combine (Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (p))), "mono\\mono\\mini\\mono.exe");
-						if (!File.Exists (monoPath))
-							throw new FileNotFoundException ("Windows mono path not found: " + monoPath);
-					}
-				}
-				alPath = Path.Combine (p, framework_version + "\\al.exe");
-				
-                                if (!File.Exists (alPath)) {
-					alPath = Path.Combine (Path.GetDirectoryName (p), "lib\\" + profile_path + "\\al.exe");
-					if (!File.Exists (alPath))
-						throw new FileNotFoundException ("Windows al path not found: " + alPath);
-				}
-
-				info.FileName = monoPath;
-				return alPath + " ";
+				info.FileName = MonoExeLocator.MonoPath;
+				return MonoExeLocator.AlPath + " ";
 			} else {
-				info.FileName = "al";
+				info.FileName = MonoExeLocator.AlPath;
 				return String.Empty;
 			}
 		}
-		
+
 		string BuildAssemblyPath (string cultureName)
 		{
 			string baseDir = Path.Combine (baseAssemblyDirectory, cultureName);

--- a/mcs/class/System.Web/System.Web.dll.sources
+++ b/mcs/class/System.Web/System.Web.dll.sources
@@ -2,6 +2,7 @@ Assembly/AssemblyInfo.cs
 ../../build/common/Consts.cs
 ../../build/common/Locale.cs
 ../../build/common/MonoTODOAttribute.cs
+../System/System/MonoExeLocator.cs
 ../System.Windows.Forms/System.Resources/AssemblyNamesTypeResolutionService.cs
 ../System.Windows.Forms/System.Resources/ByteArrayFromResXHandler.cs
 ../System.Windows.Forms/System.Resources/ResXNullRef.cs

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.dll.sources
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.dll.sources
@@ -2,6 +2,7 @@
 ../../build/common/MonoTODOAttribute.cs
 Assembly/AssemblyInfo.cs
 Assembly/Locale.cs
+../System/System/MonoExeLocator.cs
 System.Resources/AssemblyNamesTypeResolutionService.cs
 System.Resources/ByteArrayFromResXHandler.cs
 System.Resources/ResXNullRef.cs

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Application.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Application.cs
@@ -560,35 +560,7 @@ namespace System.Windows.Forms
 			if (Assembly.GetEntryAssembly () == null)
 				throw new NotSupportedException ("The method 'Restart' is not supported by this application type.");
 
-			string mono_path = null;
-
-			//Get mono path
-			PropertyInfo gac = typeof (Environment).GetProperty ("GacPath", BindingFlags.Static | BindingFlags.NonPublic);
-			MethodInfo get_gac = null;
-			if (gac != null)
-				get_gac = gac.GetGetMethod (true);
-
-			if (get_gac != null) {
-				string gac_path = Path.GetDirectoryName ((string)get_gac.Invoke (null, null));
-				string mono_prefix = Path.GetDirectoryName (Path.GetDirectoryName (gac_path));
-
-				if (XplatUI.RunningOnUnix) {
-					mono_path = Path.Combine (mono_prefix, "bin/mono");
-					if (!File.Exists (mono_path))
-						mono_path = "mono";
-				} else {
-					mono_path = Path.Combine (mono_prefix, "bin\\mono.bat");
-
-					if (!File.Exists (mono_path))
-						mono_path = Path.Combine (mono_prefix, "bin\\mono.exe");
-
-					if (!File.Exists (mono_path))
-						mono_path = Path.Combine (mono_prefix, "mono\\mono\\mini\\mono.exe");
-
-					if (!File.Exists (mono_path))
-						throw new FileNotFoundException (string.Format ("Windows mono path not found: '{0}'", mono_path));
-				}
-			}
+			string mono_path = MonoExeLocator.MonoPath;
 
 			//Get command line arguments
 			StringBuilder argsBuilder = new StringBuilder ();

--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeCompiler.cs
@@ -48,54 +48,9 @@ namespace Mono.CSharp
 	
 	internal class CSharpCodeCompiler : CSharpCodeGenerator, ICodeCompiler
 	{
-		static string windowsMcsPath;
-		static string windowsMonoPath;
-		static string unixMcsCommand;
-
 		Mutex mcsOutMutex;
 		StringCollection mcsOutput;
 		
-		static CSharpCodeCompiler ()
-		{
-			if (Path.DirectorySeparatorChar == '\\') {
-				PropertyInfo gac = typeof (Environment).GetProperty ("GacPath", BindingFlags.Static|BindingFlags.NonPublic);
-				MethodInfo get_gac = gac.GetGetMethod (true);
-				string p = Path.GetDirectoryName (
-					(string) get_gac.Invoke (null, null));
-				windowsMonoPath = Path.Combine (
-					Path.GetDirectoryName (
-						Path.GetDirectoryName (p)),
-					"bin\\mono.bat");
-				if (!File.Exists (windowsMonoPath))
-					windowsMonoPath = Path.Combine (
-						Path.GetDirectoryName (
-							Path.GetDirectoryName (p)),
-						"bin\\mono.exe");
-				if (!File.Exists (windowsMonoPath))
-					windowsMonoPath = Path.Combine (
-						Path.GetDirectoryName (
-							Path.GetDirectoryName (
-								Path.GetDirectoryName (p))),
-						"mono\\mono\\mini\\mono.exe");
-				if (!File.Exists (windowsMonoPath))
-					throw new FileNotFoundException ("Windows mono path not found: " + windowsMonoPath);
-
-				windowsMcsPath = Path.Combine (p, "4.5\\mcs.exe");
-				if (!File.Exists (windowsMcsPath))
-					windowsMcsPath = Path.Combine(Path.GetDirectoryName (p), "lib\\build\\mcs.exe");
-				
-				if (!File.Exists (windowsMcsPath))
-					throw new FileNotFoundException ("Windows mcs path not found: " + windowsMcsPath);
-			} else {
-				var mscorlibPath = new Uri (typeof (object).Assembly.CodeBase).LocalPath;
-				var unixMcsPath = Path.GetFullPath (Path.Combine (mscorlibPath, "..", "..", "..", "..", "bin", "mcs"));
-				if (File.Exists (unixMcsPath))
-					unixMcsCommand = unixMcsPath;
-				else
-					unixMcsCommand = "mcs";
-			}
-		}
-
 		//
 		// Constructors
 		//
@@ -177,13 +132,13 @@ namespace Mono.CSharp
 
 			// FIXME: these lines had better be platform independent.
 			if (Path.DirectorySeparatorChar == '\\') {
-				mcs.StartInfo.FileName = windowsMonoPath;
-				mcs.StartInfo.Arguments = "\"" + windowsMcsPath + "\" " +
-					BuildArgs (options, fileNames, ProviderOptions);
+				mcs.StartInfo.FileName = MonoExeLocator.MonoPath;
+				mcs.StartInfo.Arguments = "\"" + MonoExeLocator.McsPath + "\" ";
 			} else {
-				mcs.StartInfo.FileName=unixMcsCommand;
-				mcs.StartInfo.Arguments=BuildArgs(options, fileNames, ProviderOptions);
+				mcs.StartInfo.FileName = MonoExeLocator.McsPath;
 			}
+
+			mcs.StartInfo.Arguments += BuildArgs (options, fileNames, ProviderOptions);
 
 			mcsOutput = new StringCollection ();
 			mcsOutMutex = new Mutex ();

--- a/mcs/class/System/Microsoft.VisualBasic/VBCodeCompiler.cs
+++ b/mcs/class/System/Microsoft.VisualBasic/VBCodeCompiler.cs
@@ -48,38 +48,6 @@ namespace Microsoft.VisualBasic
 {
 	internal class VBCodeCompiler : VBCodeGenerator, ICodeCompiler
 	{
-		static string windowsMonoPath;
-		static string windowsvbncPath;
-		static string unixVbncCommand;
-
-		static VBCodeCompiler ()
-		{
-			if (Path.DirectorySeparatorChar == '\\') {
-				PropertyInfo gac = typeof (Environment).GetProperty ("GacPath", BindingFlags.Static | BindingFlags.NonPublic);
-				MethodInfo get_gac = gac.GetGetMethod (true);
-				string p = Path.GetDirectoryName (
-					(string) get_gac.Invoke (null, null));
-				windowsMonoPath = Path.Combine (
-					Path.GetDirectoryName (
-						Path.GetDirectoryName (p)),
-					"bin\\mono.bat");
-				if (!File.Exists (windowsMonoPath))
-					windowsMonoPath = Path.Combine (
-						Path.GetDirectoryName (
-							Path.GetDirectoryName (p)),
-						"bin\\mono.exe");
-				windowsvbncPath =
-					Path.Combine (p, "2.0\\vbnc.exe");
-			} else {
-				var mscorlibPath = new Uri (typeof (object).Assembly.CodeBase).LocalPath;
-				var unixMcsPath = Path.GetFullPath (Path.Combine (mscorlibPath, "..", "..", "..", "..", "bin", "vbnc"));
-				if (File.Exists (unixMcsPath))
-					unixVbncCommand = unixMcsPath;
-				else
-					unixVbncCommand = "vbnc";
-			}
-		}
-
 		public CompilerResults CompileAssemblyFromDom (CompilerParameters options, CodeCompileUnit e)
 		{
 			return CompileAssemblyFromDomBatch (options, new CodeCompileUnit[] { e });
@@ -248,10 +216,10 @@ namespace Microsoft.VisualBasic
 			string[] vbnc_output_lines;
 			// FIXME: these lines had better be platform independent.
 			if (Path.DirectorySeparatorChar == '\\') {
-				vbnc.StartInfo.FileName = windowsMonoPath;
-				vbnc.StartInfo.Arguments = windowsvbncPath + ' ' + BuildArgs (options, fileNames);
+				vbnc.StartInfo.FileName = MonoExeLocator.MonoPath;
+				vbnc.StartInfo.Arguments = MonoExeLocator.VbncPath + ' ' + BuildArgs (options, fileNames);
 			} else {
-				vbnc.StartInfo.FileName = "vbnc";
+				vbnc.StartInfo.FileName = MonoExeLocator.VbncPath;
 				vbnc.StartInfo.Arguments = BuildArgs (options, fileNames);
 			}
 			//Console.WriteLine (vbnc.StartInfo.Arguments);

--- a/mcs/class/System/System.dll.sources
+++ b/mcs/class/System/System.dll.sources
@@ -164,6 +164,7 @@ System.Diagnostics/TraceSourceInfo.cs
 System.Diagnostics/Win32EventLog.cs
 System.Diagnostics.CodeAnalysis/ExcludeFromCodeCoverageAttribute.cs
 System/Platform.cs
+System/MonoExeLocator.cs
 System.IO.Compression/CompressionLevel.cs
 System.IO.Compression/CompressionMode.cs
 System.IO.Compression/DeflateStream.cs

--- a/mcs/class/System/System/MonoExeLocator.cs
+++ b/mcs/class/System/System/MonoExeLocator.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace System {
+
+	internal static class MonoExeLocator {
+
+		public static string GacPath { get; private set; }
+		public static string MonoPath { get; private set; }
+		public static string McsPath { get; private set; }
+		public static string VbncPath { get; private set; }
+		public static string AlPath { get; private set; }
+
+		static MonoExeLocator () {
+
+			PropertyInfo gac = typeof (Environment).GetProperty ("GacPath", BindingFlags.Static | BindingFlags.NonPublic);
+			MethodInfo getGacMethod = gac.GetGetMethod (true);
+			GacPath = Path.GetDirectoryName ((string) getGacMethod.Invoke (null, null));
+
+			string monoPath = null;
+			string mcsPath = null;
+			string vbncPath = null;
+			string alPath = null;
+
+			if (Path.DirectorySeparatorChar == '\\') {
+				string processExe = Process.GetCurrentProcess ().MainModule.FileName;
+				if (processExe != null) {
+					string fileName = Path.GetFileName (processExe);
+					if (fileName.StartsWith ("mono") && fileName.EndsWith (".exe"))
+						monoPath = processExe;
+				}
+
+				if (!File.Exists (monoPath))
+					monoPath = Path.Combine (
+						Path.GetDirectoryName (
+							Path.GetDirectoryName (GacPath)),
+						"bin\\mono.exe");
+
+				if (!File.Exists (monoPath))
+					monoPath = Path.Combine (
+						Path.GetDirectoryName (
+							Path.GetDirectoryName (
+								Path.GetDirectoryName (GacPath))),
+						"mono\\mini\\mono.exe");
+
+				if (!File.Exists (monoPath))
+					throw new FileNotFoundException ("Windows mono path not found: " + monoPath);
+
+				mcsPath = Path.Combine (GacPath, "4.5\\mcs.exe");
+				if (!File.Exists (mcsPath))
+					mcsPath = Path.Combine (Path.GetDirectoryName (GacPath), "lib\\build\\mcs.exe");
+
+				if (!File.Exists (mcsPath))
+					throw new FileNotFoundException ("Windows mcs path not found: " + mcsPath);
+
+				vbncPath = Path.Combine (GacPath,  "4.5\\vbnc.exe");
+				vbncPath = Path.Combine (GacPath,  "4.5\\vbnc.exe");
+				alPath = Path.Combine (GacPath, "4.5\\al.exe");
+
+				if (!File.Exists (alPath)) {
+					alPath = Path.Combine (Path.GetDirectoryName (GacPath), "lib\\net_4_x\\al.exe");
+					if (!File.Exists (alPath))
+						throw new FileNotFoundException ("Windows al path not found: " + alPath);
+				}
+			} else {
+				monoPath = Path.Combine (GacPath, "bin/mono");
+				if (!File.Exists (MonoPath))
+					monoPath = "mono";
+
+				var mscorlibPath = new Uri (typeof (object).Assembly.CodeBase).LocalPath;
+				mcsPath = Path.GetFullPath( Path.Combine (mscorlibPath, "..", "..", "..", "..", "bin", "mcs"));
+				if (!File.Exists (mcsPath))
+					mcsPath = "mcs";
+
+				vbncPath = Path.Combine (Path.GetDirectoryName (mcsPath), "vbnc");
+				if (!File.Exists (vbncPath))
+					vbncPath = "vbnc";
+
+				alPath = "al";
+			}
+
+			McsPath = mcsPath;
+			MonoPath = monoPath;
+			VbncPath = vbncPath;
+			AlPath = alPath;
+		}
+
+		
+	}
+}


### PR DESCRIPTION
* Using the process info to first try to use the current mono exe to launch mcs.exe when running on windows.
* Also updating to correct path to the cygwin mono which had one `mono` folder too much in the path.
* Removing the `.bat` lookup code path since Mono do not ship a `mono.bat` any longer.
* Extracting mono, mcs, vbnc and gac path lookup to a common class `MonoExeLocator`.
