### PR TITLE
Using max level allowed when getting current token

### DIFF
--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -276,9 +276,9 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetCurrentToken (void)
 	 */
 
 	/* thread may be impersonating somebody */
-	if (OpenThreadToken (GetCurrentThread (), TOKEN_QUERY, 1, &token) == 0) {
+	if (OpenThreadToken (GetCurrentThread (), MAXIMUM_ALLOWED, 1, &token) == 0) {
 		/* if not take the process identity */
-		OpenProcessToken (GetCurrentProcess (), TOKEN_QUERY, &token);
+		OpenProcessToken (GetCurrentProcess (), MAXIMUM_ALLOWED, &token);
 	}
 #else
 	token = GINT_TO_POINTER (geteuid ());


### PR DESCRIPTION
[Reference source of WindowsIdentity] (http://referencesource.microsoft.com/#mscorlib/system/security/principal/windowsidentity.cs,265)  is using `MAXIMUM_ALLOWED`
as desired level by default when getting current token.
Changing to same behaviour to enable duplicate and impersonation
to be made on the token retrieved by `GetCurrentToken`. 
This PR fixes test failures in [ExecutorTest] (https://github.com/mono/mono/blob/master/mcs/class/System/Test/System.CodeDom.Compiler/ExecutorTest.cs)