### PR TITLE
[sgen] Don't consider managed write barriers to be critical methods.

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -189,13 +189,13 @@ static MonoMethod *write_barrier_noconc_method;
 gboolean
 sgen_is_critical_method (MonoMethod *method)
 {
-	return (method == write_barrier_conc_method || method == write_barrier_noconc_method || sgen_is_managed_allocator (method));
+	return sgen_is_managed_allocator (method);
 }
 
 gboolean
 sgen_has_critical_method (void)
 {
-	return write_barrier_conc_method || write_barrier_noconc_method || sgen_has_managed_allocator ();
+	return sgen_has_managed_allocator ();
 }
 
 #ifndef DISABLE_JIT


### PR DESCRIPTION
When we emit calls to them, we also emit an `OP_DUMMY_USE` instruction to keep the object alive, so it is OK for the GC to interrupt write barriers now.

I left `sgen_is_critical_method` and `sgen_has_critical_method` even though they're just wrappers now since we might want to extend them in the future.