### PR TITLE
[profiler} Don't crash if a zero sampling frequency is given.

### DIFF
--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -143,8 +143,8 @@ to the control port
 program behaviour.
 The default is to collect a 100 times per second (100 Hz) the
 instruction pointer.
-This is equivalent to the value \[lq]cycles/100\[rq] for
-\f[I]TYPE\f[].
+This is equivalent to the value \[lq]cycles/100\[rq].
+A value of zero for \f[I]FREQ\f[] effectively disables sampling.
 On some systems, like with recent Linux kernels, it is possible to
 cause the sampling to happen for other events provided by the
 performance counters of the cpu.

--- a/mono/profiler/proflog.c
+++ b/mono/profiler/proflog.c
@@ -4913,7 +4913,7 @@ create_profiler (const char *args, const char *filename, GPtrArray *filters)
 		prof->gzfile = gzdopen (fileno (prof->file), "wb");
 #endif
 #if USE_PERF_EVENTS
-	if (sample_type && !do_mono_sample)
+	if (sample_type && sample_freq && !do_mono_sample)
 		need_helper_thread = setup_perf_event ();
 	if (!perf_data) {
 		/* FIXME: warn if different freq or sample type */
@@ -5384,7 +5384,7 @@ mono_profiler_startup (const char *desc)
 	if (do_coverage)
 		mono_profiler_install_coverage_filter (coverage_filter);
 
-	if (do_mono_sample && sample_type == SAMPLE_CYCLES && !only_counters) {
+	if (do_mono_sample && sample_type == SAMPLE_CYCLES && sample_freq && !only_counters) {
 		events |= MONO_PROFILE_STATISTICAL;
 		mono_profiler_set_statistical_mode (sampling_mode, sample_freq);
 		mono_profiler_install_statistical (mono_sample_hit);


### PR DESCRIPTION
The sampling thread would crash with a division by zero `SIGFPE`. The logical thing to do in this case is disabling sampling.