### PR TITLE
Removing hard coded preamble length

### DIFF
--- a/mcs/class/System/System.Net/HttpListenerResponse.cs
+++ b/mcs/class/System/System.Net/HttpListenerResponse.cs
@@ -430,7 +430,7 @@ namespace System.Net {
 			string headers_str = headers.ToString ();
 			writer.Write (headers_str);
 			writer.Flush ();
-			int preamble = (encoding.CodePage == 65001) ? 3 : encoding.GetPreamble ().Length;
+			int preamble = encoding.GetPreamble ().Length;
 			if (output_stream == null)
 				output_stream = context.Connection.GetResponseStream ();
 


### PR DESCRIPTION
For some reason preamble length was asumed to be 3 for cp 65001 (UTF-8)
instead of always looking att the preamble length of the encoding.
This resulted in responses cropped by 3 chars on windows.