### PR TITLE
Remove Assert.Fail() calls in ThreadTest when running on Windows

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -94,25 +94,6 @@ namespace MonoTests.System.Threading
 		//TimeSpan MaxValue = TimeSpan.FromMilliseconds ((long) Int32.MaxValue);
 		TimeSpan TooLarge = TimeSpan.FromMilliseconds ((long) Int32.MaxValue + 1);
 
-		static bool is_win32;
-		static bool is_mono;
-
-		static ThreadTest ()
-		{
-			switch (Environment.OSVersion.Platform) {
-			case PlatformID.Win32NT:
-			case PlatformID.Win32S:
-			case PlatformID.Win32Windows:
-			case PlatformID.WinCE:
-				is_win32 = true;
-				break;
-			}
-
-			// check a class in mscorlib to determine if we're running on Mono
-			if (Type.GetType ("Mono.Runtime", false) != null)
-				is_mono = true;
-		}
-
 		//Some Classes to test as threads
 		private class C1Test
 		{
@@ -327,8 +308,6 @@ namespace MonoTests.System.Threading
 		[Category ("NotDotNet")] // it hangs.
 		public void TestStart()
 		{
-			if (is_win32 && is_mono)
-				Assert.Fail ("This test fails on Win32. The test should be fixed.");
 		{
 			C1Test test1 = new C1Test();
 			Thread TestThread = new Thread(new ThreadStart(test1.TestMethod));
@@ -370,9 +349,6 @@ namespace MonoTests.System.Threading
 		[Test]
 		public void TestApartmentState ()
 		{
-			if (is_win32 && is_mono)
-				Assert.Fail ("This test fails on mono on win32. Our runtime should be fixed.");
-
 			C2Test test1 = new C2Test();
 			Thread TestThread = new Thread(new ThreadStart(test1.TestMethod));
 			Assert.AreEqual (ApartmentState.Unknown, TestThread.ApartmentState, "#1");
@@ -390,9 +366,6 @@ namespace MonoTests.System.Threading
 		[Category ("NotWorking")] // setting the priority of a Thread before it is started isn't implemented in Mono yet
 		public void TestPriority1()
 		{
-			if (is_win32 && is_mono)
-				Assert.Fail ("This test fails on mono on Win32. Our runtime should be fixed.");
-
 			C2Test test1 = new C2Test();
 			Thread TestThread = new Thread(new ThreadStart(test1.TestMethod));
 			try {
@@ -487,9 +460,6 @@ namespace MonoTests.System.Threading
 		[Test]
 		public void TestIsBackground1 ()
 		{
-			if (is_win32 && is_mono)
-				Assert.Fail ("This test fails on mono on Win32. Our runtime should be fixed.");
-
 			C2Test test1 = new C2Test();
 			Thread TestThread = new Thread(new ThreadStart(test1.TestMethod));
 			try {
@@ -534,9 +504,6 @@ namespace MonoTests.System.Threading
 		[Test]
 		public void TestName()
 		{
-			if (is_win32 && is_mono)
-				Assert.Fail ("This test fails on mono on Win32. Our runtime should be fixed.");
-
 			C2Test test1 = new C2Test();
 			Thread TestThread = new Thread(new ThreadStart(test1.TestMethod));
 			try {
@@ -696,9 +663,6 @@ namespace MonoTests.System.Threading
 		[Test]
 		public void TestThreadState ()
 		{
-			if (is_win32 && is_mono)
-				Assert.Fail ("This test fails on mono on Win32. Our runtime should be fixed.");
-
 			//TODO: Test The rest of the possible transitions
 			C2Test test1 = new C2Test();
 			Thread TestThread = new Thread(new ThreadStart(test1.TestMethod));
@@ -830,9 +794,6 @@ namespace MonoTests.System.Threading
 		[Category("NotDotNet")] // On MS, ThreadStateException is thrown on Abort: "Thread is suspended; attempting to abort"
 		public void TestSuspendAbort ()
 		{
-			if (is_win32 && is_mono)
-				Assert.Fail ("This test fails on Win32. The test should be fixed.");
-
 			Thread t = new Thread (new ThreadStart (DoCount));
 			t.IsBackground = true;
 			t.Start ();
@@ -898,7 +859,6 @@ namespace MonoTests.System.Threading
 		}
 		
 		[Test]
-		[Category ("NotDotNet")] // it crashes nunit.
 		public void Test_InterruptCurrentThread ()
 		{
 			ManualResetEvent mre = new ManualResetEvent (false);
@@ -937,6 +897,7 @@ namespace MonoTests.System.Threading
 
 #if MONO_FEATURE_MULTIPLE_APPDOMAINS
 		[Test]
+		[Category ("NotDotNet")]
 		public void CurrentThread_Domains ()
 		{
 			AppDomain ad = AppDomain.CreateDomain ("foo");


### PR DESCRIPTION
The tests that fail like this actually work just fine on Mono on Windows. Added the NotDotNet category to the CurrentThread_Domains() test since it fails on .NET.