### PR TITLE
[mono-threads] Fix lifetime of MonoThreadInfo->handle

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2599,10 +2599,13 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 		if (mono_thread_internal_has_appdomain_ref (mono_thread_internal_current (), domain) && (mono_thread_interruption_requested ())) {
 			/* The unload thread tries to abort us */
 			/* The icall wrapper will execute the abort */
+			mono_threads_close_thread_handle (thread_handle);
 			unload_data_unref (thread_data);
 			return;
 		}
 	}
+
+	mono_threads_close_thread_handle (thread_handle);
 
 	if (thread_data->failure_reason) {
 		/* Roll back the state change */

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -595,7 +595,7 @@ mono_thread_attach_internal (MonoThread *thread, gboolean force_attach, gboolean
 	info = mono_thread_info_current ();
 
 	internal = thread->internal_thread;
-	internal->handle = mono_thread_info_get_handle (info);
+	internal->handle = mono_thread_info_duplicate_handle (info);
 	internal->tid = MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ());
 	internal->thread_info = info;
 	internal->small_id = info->small_id;
@@ -909,6 +909,8 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 	 */
 
 	mono_coop_sem_wait (&start_info->registered, MONO_SEM_FLAGS_NONE);
+
+	mono_threads_close_thread_handle (thread_handle);
 
 	THREAD_DEBUG (g_message ("%s: (%"G_GSIZE_FORMAT") Done launching thread %p (%"G_GSIZE_FORMAT")", __func__, mono_native_thread_id_get (), internal, (gsize)internal->tid));
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9816,6 +9816,7 @@ compile_methods (MonoAotCompile *acfg)
 
 		for (i = 0; i < threads->len; ++i) {
 			WaitForSingleObjectEx (g_ptr_array_index (threads, i), INFINITE, FALSE);
+			mono_threads_close_thread_handle (g_ptr_array_index (threads, i));
 		}
 	} else {
 		methods_len = 0;

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -52,11 +52,6 @@ mono_threads_platform_register (MonoThreadInfo *info)
 	if (thread_handle == INVALID_HANDLE_VALUE)
 		g_error ("%s: failed to create handle", __func__);
 
-	/* We need to keep the handle alive, as long as the corresponding managed
-	 * thread object is alive. The handle is going to be unref when calling
-	 * the finalizer on the MonoThreadInternal object */
-	mono_w32handle_ref (thread_handle);
-
 	g_assert (!info->handle);
 	info->handle = thread_handle;
 }
@@ -139,6 +134,14 @@ mono_threads_get_max_stack_size (void)
 	if (lim.rlim_max > (rlim_t)INT_MAX)
 		return INT_MAX;
 	return (int)lim.rlim_max;
+}
+
+gpointer
+mono_threads_platform_duplicate_handle (MonoThreadInfo *info)
+{
+	g_assert (info->handle);
+	mono_w32handle_ref (info->handle);
+	return info->handle;
 }
 
 HANDLE

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -253,6 +253,17 @@ mono_threads_get_max_stack_size (void)
 	return INT_MAX;
 }
 
+gpointer
+mono_threads_platform_duplicate_handle (MonoThreadInfo *info)
+{
+	HANDLE thread_handle;
+
+	g_assert (info->handle);
+	DuplicateHandle (GetCurrentProcess (), info->handle, GetCurrentProcess (), &thread_handle, THREAD_ALL_ACCESS, TRUE, 0);
+
+	return thread_handle;
+}
+
 HANDLE
 mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
 {

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -551,6 +551,7 @@ void mono_threads_platform_own_mutex (THREAD_INFO_TYPE *info, gpointer mutex_han
 void mono_threads_platform_disown_mutex (THREAD_INFO_TYPE *info, gpointer mutex_handle);
 MonoThreadPriority mono_threads_platform_get_priority (THREAD_INFO_TYPE *info);
 void mono_threads_platform_set_priority (THREAD_INFO_TYPE *info, MonoThreadPriority priority);
+gpointer mono_threads_platform_duplicate_handle (THREAD_INFO_TYPE *info);
 
 void mono_threads_coop_begin_global_suspend (void);
 void mono_threads_coop_end_global_suspend (void);
@@ -666,7 +667,7 @@ gboolean
 mono_thread_info_is_current (THREAD_INFO_TYPE *info);
 
 gpointer
-mono_thread_info_get_handle (THREAD_INFO_TYPE *info);
+mono_thread_info_duplicate_handle (THREAD_INFO_TYPE *info);
 
 void
 mono_thread_info_describe (THREAD_INFO_TYPE *info, GString *text);


### PR DESCRIPTION
This handle should have a total of maximum 3 copies:
 - in MonoThreadInfo->handle
 - in the return value of mono_threads_create_thread
 - in MonoInternalThread->handle (if it's a managed thread)

Before, there would always be 2 references (in MonoThreadInfo->handle and another another for MonoInternalThread->handle), even if it would be referenced at one place only (MonoThreadInfo->handle), which would lead to a handle leak.

We also need to duplicate the returned handle, to avoid having a use-after-free of the handle (in case the thread exits before we access that handle)