### PR TITLE
[logging] Fix g_error not aborting.

### DIFF
--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -132,7 +132,7 @@ mono_log_write_logfile (const char *log_domain, GLogLevelFlags level, mono_bool 
 
 	fflush(logFile);
 
-	if (level == G_LOG_FLAG_FATAL)
+	if (level & G_LOG_LEVEL_ERROR)
 		abort();
 }
 

--- a/mono/utils/mono-log-posix.c
+++ b/mono/utils/mono-log-posix.c
@@ -84,7 +84,7 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 {
 	syslog (mapSyslogLevel(level), "%s", message);
 
-	if (level == G_LOG_FLAG_FATAL)
+	if (level & G_LOG_LEVEL_ERROR)
 		abort();
 }
 

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -104,7 +104,7 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 
 	fflush(logFile);
 
-	if (level == G_LOG_FLAG_FATAL)
+	if (level & G_LOG_LEVEL_ERROR)
 		abort();
 }
 


### PR DESCRIPTION
Once we enabled g_log redirection, we stopped aborting as the new handlers didn't behave like eglib.