### PR TITLE
[threads] Correct the spin waiting in 'sleep_interruptable'

### DIFF
--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1284,7 +1284,7 @@ sleep_interruptable (guint32 ms, gboolean *alerted)
 	*alerted = FALSE;
 
 	if (ms != INFINITE)
-		end = mono_100ns_ticks () + (ms * 1000 * 10);
+		end = mono_msec_ticks() + ms;
 
 	mono_lazy_initialize (&sleep_init, sleep_initialize);
 
@@ -1292,8 +1292,8 @@ sleep_interruptable (guint32 ms, gboolean *alerted)
 
 	for (;;) {
 		if (ms != INFINITE) {
-			now = mono_100ns_ticks ();
-			if (now > end)
+			now = mono_msec_ticks();
+			if (now >= end)
 				break;
 		}
 
@@ -1304,7 +1304,7 @@ sleep_interruptable (guint32 ms, gboolean *alerted)
 		}
 
 		if (ms != INFINITE)
-			mono_coop_cond_timedwait (&sleep_cond, &sleep_mutex, (end - now) / 10 / 1000);
+			mono_coop_cond_timedwait (&sleep_cond, &sleep_mutex, end - now);
 		else
 			mono_coop_cond_wait (&sleep_cond, &sleep_mutex);
 


### PR DESCRIPTION
After https://github.com/mono/mono/commit/089c47f1c07bf250d76c36e04675569fc6f5b4ba#diff-e7e458b6256eaa730c145f14a666652aR1141
the code started to use nanoseconds instead of milliseconds. The problem was that this caused `sleep_interruptable` to spin wait the last millisecond before the sleep was over, https://bugzilla.xamarin.com/show_bug.cgi?id=44132.

There is a loss of precision, but I don't think nanosecond precision is something you had expect to depend on when using `System.Threading.Sleep`. However now the precision is ~1 millisecond. Also `System.Threading.Sleep` is fundamentally implemented incorrectly, seen from a time precision point of view. The current time should be recorded right after `System.Threading.Sleep` is called. However instead the current time is recorded late in the calltree in eg. `sleep_interruptable`. So there is potentially a loss of a couple of microseconds already. 

This commit makes the code very similar to how it was before https://github.com/mono/mono/commit/089c47f1c07bf250d76c36e04675569fc6f5b4ba#diff-e7e458b6256eaa730c145f14a666652aR1141
Except that it doesn't have the overflow bug, by using int64 to store milliseconds. 

Also there is another possibility, which is to make `mono_coop_cond_timedwait` take nanoseconds instead of milliseconds as argument, and pass it down to `mono_os_cond_timedwait`. Then the precision would likely be better, but that depends on implementation and hardware. But for best precision the absolute end time should be calculated as early as possible, and passed down to `mono_thread_info_sleep` and used later on. 