### PR TITLE
Correctly handle abandoned mutexes on non-Windows platforms

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/MutexTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/MutexTest.cs
@@ -20,6 +20,7 @@ namespace MonoTests.System.Threading
 		{
 			public int id;
 			public Mutex mut;
+			public bool abandoned_exception;
 			public ConcClass(int id,Mutex mut)
 			{
 				this.id = id;
@@ -63,7 +64,12 @@ namespace MonoTests.System.Threading
 
 			public void WaitAndForget()
 			{
-				this.Wait();
+				try {
+					this.Wait();
+				} catch (AbandonedMutexException) {
+					this.abandoned_exception = true;
+				}
+
 				this.marker = id;
 			}
 			public void WaitAndWait()
@@ -137,7 +143,7 @@ namespace MonoTests.System.Threading
 		}
 
 		[Test]
-		public void TestWaitAndFoget1()
+		public void TestWaitAndForget1()
 		{
 			Mutex Sem = new Mutex(false);
 			ConcClassLoop class1 = new ConcClassLoop(1,Sem);
@@ -148,9 +154,11 @@ namespace MonoTests.System.Threading
 			try {
 				thread1.Start();
 				TestUtil.WaitForNotAlive (thread1, "t1");
+				Assert.IsFalse (class1.abandoned_exception, "e1");
 	
 				thread2.Start();
 				TestUtil.WaitForNotAlive (thread2, "t2");
+				Assert.IsTrue (class2.abandoned_exception, "e2");
 			
 				Assert.AreEqual (class2.id, class2.marker);
 			} finally {

--- a/mono/io-layer/wait.c
+++ b/mono/io-layer/wait.c
@@ -42,6 +42,8 @@ guint32 WaitForSingleObjectEx(gpointer handle, guint32 timeout, gboolean alertab
 	ret = mono_w32handle_wait_one (handle, timeout, alertable);
 	if (ret == MONO_W32HANDLE_WAIT_RET_SUCCESS_0)
 		return WAIT_OBJECT_0;
+	else if (ret == MONO_W32HANDLE_WAIT_RET_ABANDONED_0)
+		return WAIT_ABANDONED_0;
 	else if (ret == MONO_W32HANDLE_WAIT_RET_ALERTED)
 		return WAIT_IO_COMPLETION;
 	else if (ret == MONO_W32HANDLE_WAIT_RET_TIMEOUT)
@@ -96,6 +98,8 @@ guint32 SignalObjectAndWait(gpointer signal_handle, gpointer wait,
 	ret = mono_w32handle_signal_and_wait (signal_handle, wait, timeout, alertable);
 	if (ret == MONO_W32HANDLE_WAIT_RET_SUCCESS_0)
 		return WAIT_OBJECT_0;
+	else if (ret == MONO_W32HANDLE_WAIT_RET_ABANDONED_0)
+		return WAIT_ABANDONED_0;
 	else if (ret == MONO_W32HANDLE_WAIT_RET_ALERTED)
 		return WAIT_IO_COMPLETION;
 	else if (ret == MONO_W32HANDLE_WAIT_RET_TIMEOUT)
@@ -143,8 +147,10 @@ guint32 WaitForMultipleObjectsEx(guint32 numobjects, gpointer *handles,
 	MonoW32HandleWaitRet ret;
 
 	ret = mono_w32handle_wait_multiple (handles, numobjects, waitall, timeout, alertable);
-	if (ret >= MONO_W32HANDLE_WAIT_RET_SUCCESS_0)
+	if (ret >= MONO_W32HANDLE_WAIT_RET_SUCCESS_0 && ret <= MONO_W32HANDLE_WAIT_RET_SUCCESS_0 + numobjects - 1)
 		return WAIT_OBJECT_0 + (ret - MONO_W32HANDLE_WAIT_RET_SUCCESS_0);
+	else if (ret >= MONO_W32HANDLE_WAIT_RET_ABANDONED_0 && ret <= MONO_W32HANDLE_WAIT_RET_ABANDONED_0 + numobjects - 1)
+		return WAIT_ABANDONED_0 + (ret - MONO_W32HANDLE_WAIT_RET_ABANDONED_0);
 	else if (ret == MONO_W32HANDLE_WAIT_RET_ALERTED)
 		return WAIT_IO_COMPLETION;
 	else if (ret == MONO_W32HANDLE_WAIT_RET_TIMEOUT)

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1760,19 +1760,9 @@ gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_ha
 	THREAD_WAIT_DEBUG (g_message ("%s: (%"G_GSIZE_FORMAT") returning %d", __func__, mono_native_thread_id_get (), ret));
 
 	mono_error_set_pending_exception (&error);
-	/*
-	 * These need to be here.  See MSDN dos on WaitForMultipleObjects.
-	 */
-	if (ret >= WAIT_OBJECT_0 && ret <= WAIT_OBJECT_0 + numhandles - 1) {
-		return map_native_wait_result_to_managed (ret - WAIT_OBJECT_0);
-	}
-	else if (ret >= WAIT_ABANDONED_0 && ret <= WAIT_ABANDONED_0 + numhandles - 1) {
-		return map_native_wait_result_to_managed (ret - WAIT_ABANDONED_0);
-	}
-	else {
-		/* WAIT_FAILED in waithandle.cs is different from WAIT_FAILED in Win32 API */
-		return map_native_wait_result_to_managed (ret);
-	}
+
+	/* WAIT_FAILED in waithandle.cs is different from WAIT_FAILED in Win32 API */
+	return map_native_wait_result_to_managed (ret);
 }
 
 gint32 ves_icall_System_Threading_WaitHandle_WaitOne_internal(HANDLE handle, gint32 ms)

--- a/mono/metadata/w32event-unix.c
+++ b/mono/metadata/w32event-unix.c
@@ -24,10 +24,12 @@ struct MonoW32HandleNamedEvent {
 	MonoW32HandleNamespace sharedns;
 };
 
-static gboolean event_handle_own (gpointer handle, MonoW32HandleType type)
+static gboolean event_handle_own (gpointer handle, MonoW32HandleType type, guint32 *statuscode)
 {
 	MonoW32HandleEvent *event_handle;
 	gboolean ok;
+
+	*statuscode = WAIT_OBJECT_0;
 
 	ok = mono_w32handle_lookup (handle, type, (gpointer *)&event_handle);
 	if (!ok) {
@@ -55,9 +57,9 @@ static void event_signal(gpointer handle)
 	ves_icall_System_Threading_Events_SetEvent_internal (handle);
 }
 
-static gboolean event_own (gpointer handle)
+static gboolean event_own (gpointer handle, guint32 *statuscode)
 {
-	return event_handle_own (handle, MONO_W32HANDLE_EVENT);
+	return event_handle_own (handle, MONO_W32HANDLE_EVENT, statuscode);
 }
 
 static void namedevent_signal (gpointer handle)
@@ -66,9 +68,9 @@ static void namedevent_signal (gpointer handle)
 }
 
 /* NB, always called with the shared handle lock held */
-static gboolean namedevent_own (gpointer handle)
+static gboolean namedevent_own (gpointer handle, guint32 *statuscode)
 {
-	return event_handle_own (handle, MONO_W32HANDLE_NAMEDEVENT);
+	return event_handle_own (handle, MONO_W32HANDLE_NAMEDEVENT, statuscode);
 }
 
 static void event_details (gpointer data)

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -24,9 +24,11 @@ struct MonoW32HandleNamedSemaphore {
 	MonoW32HandleNamespace sharedns;
 };
 
-static gboolean sem_handle_own (gpointer handle, MonoW32HandleType type)
+static gboolean sem_handle_own (gpointer handle, MonoW32HandleType type, guint32 *statuscode)
 {
 	MonoW32HandleSemaphore *sem_handle;
+
+	*statuscode = WAIT_OBJECT_0;
 
 	if (!mono_w32handle_lookup (handle, type, (gpointer *)&sem_handle)) {
 		g_warning ("%s: error looking up %s handle %p",
@@ -50,9 +52,9 @@ static void sema_signal(gpointer handle)
 	ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal(handle, 1, NULL);
 }
 
-static gboolean sema_own (gpointer handle)
+static gboolean sema_own (gpointer handle, guint32 *statuscode)
 {
-	return sem_handle_own (handle, MONO_W32HANDLE_SEM);
+	return sem_handle_own (handle, MONO_W32HANDLE_SEM, statuscode);
 }
 
 static void namedsema_signal (gpointer handle)
@@ -61,9 +63,9 @@ static void namedsema_signal (gpointer handle)
 }
 
 /* NB, always called with the shared handle lock held */
-static gboolean namedsema_own (gpointer handle)
+static gboolean namedsema_own (gpointer handle, guint32 *statuscode)
 {
-	return sem_handle_own (handle, MONO_W32HANDLE_NAMEDSEM);
+	return sem_handle_own (handle, MONO_W32HANDLE_NAMEDSEM, statuscode);
 }
 
 static void sema_details (gpointer data)

--- a/mono/utils/w32handle.h
+++ b/mono/utils/w32handle.h
@@ -39,8 +39,10 @@ typedef struct
 	/* Called by WaitForSingleObject and WaitForMultipleObjects,
 	 * with the handle locked (shared handles aren't locked.)
 	 * Returns TRUE if ownership was established, false otherwise.
+	 * If TRUE, *statuscode contains a status code such as
+	 * WAIT_OBJECT_0 or WAIT_ABANDONED_0.
 	 */
-	gboolean (*own_handle)(gpointer handle);
+	gboolean (*own_handle)(gpointer handle, guint32 *statuscode);
 
 	/* Called by WaitForSingleObject and WaitForMultipleObjects, if the
 	 * handle in question is "ownable" (ie mutexes), to see if the current
@@ -129,7 +131,7 @@ void
 mono_w32handle_ops_signal (gpointer handle);
 
 gboolean
-mono_w32handle_ops_own (gpointer handle);
+mono_w32handle_ops_own (gpointer handle, guint32 *statuscode);
 
 gboolean
 mono_w32handle_ops_isowned (gpointer handle);
@@ -165,10 +167,11 @@ int
 mono_w32handle_unlock_handle (gpointer handle);
 
 typedef enum {
-	MONO_W32HANDLE_WAIT_RET_SUCCESS_0 =  0,
-	MONO_W32HANDLE_WAIT_RET_ALERTED   = -1,
-	MONO_W32HANDLE_WAIT_RET_TIMEOUT   = -2,
-	MONO_W32HANDLE_WAIT_RET_FAILED    = -3,
+	MONO_W32HANDLE_WAIT_RET_SUCCESS_0   =  0,
+	MONO_W32HANDLE_WAIT_RET_ABANDONED_0 =  MONO_W32HANDLE_WAIT_RET_SUCCESS_0 + MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS,
+	MONO_W32HANDLE_WAIT_RET_ALERTED     = -1,
+	MONO_W32HANDLE_WAIT_RET_TIMEOUT     = -2,
+	MONO_W32HANDLE_WAIT_RET_FAILED      = -3,
 } MonoW32HandleWaitRet;
 
 MonoW32HandleWaitRet


### PR DESCRIPTION
When a thread owning a mutex doesn't release it before it exits and a second thread tries to take it using e.g. Mutex.WaitOne() an AbandonedMutexException should be thrown. This is what .NET and Mono on Windows does.

This patch builds on the work done in PR #2267, which modifies the Win32 emulation of WaitForSingleObjectEx(), SignalObjectAndWait() and WaitForMultipleObjectsEx() to return WAIT_ABANDONED_0 when expected, and updates it to the current HEAD. It also adds a few test methods to WaitHandleTest that test that WaitHandle.WaitAny() and WaitHandle.WaitAll() follows the .NET behaviour.