### PR TITLE
Remove obsolete stack limit checks on Windows

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -981,11 +981,6 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStac
 	/* if we have no info we are optimistic and assume there is enough room */
 	if (!stack_addr)
 		return TRUE;
-#ifdef HOST_WIN32
-	// FIXME: Windows dynamically extends the stack, so stack_addr might be close
-	// to the current sp
-	return TRUE;
-#endif
 	current = (guint8 *)&stack_addr;
 	if (current > stack_addr) {
 		if ((current - stack_addr) < min_size)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2208,12 +2208,9 @@ sgen_client_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
 	info->client_info.signal = 0;
 #endif
 
-	/* On win32, stack_start_limit should be 0, since the stack can grow dynamically */
 	mono_thread_info_get_stack_bounds (&staddr, &stsize);
 	if (staddr) {
-#ifndef HOST_WIN32
 		info->client_info.stack_start_limit = staddr;
-#endif
 		info->client_info.stack_end = staddr + stsize;
 	} else {
 		gsize stack_bottom = (gsize)stack_bottom_fallback;


### PR DESCRIPTION
mono_thread_info_get_stack_bounds has been updated to correctly report the stack reserved base address quite some time ago.
Remove a couple of checks that still assume the old behavior of reporting the committed base address.