### PR TITLE
[sgen] Fix sgen_resume_thread return value on Windows

### DIFF
--- a/mono/metadata/sgen-os-win32.c
+++ b/mono/metadata/sgen-os-win32.c
@@ -21,7 +21,7 @@ sgen_resume_thread (SgenThreadInfo *info)
 
 	CloseHandle (handle);
 
-	return result != (DWORD)-1;
+	return result != (DWORD)-1 && result > 0;
 }
 
 gboolean


### PR DESCRIPTION
According to sgen_resume_thread in sgen-os-mach.c, the function is supposed to return false if the thread was not suspended.