### PR TITLE
[arm64] fixes around icache flushing

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1777,7 +1777,33 @@ mono_arch_flush_icache (guint8 *code, gint size)
 #if __APPLE__
 	sys_icache_invalidate (code, size);
 #else
-	__clear_cache (code, code + size);
+	/* Don't rely on GCC's __clear_cache implementation, as it caches
+	 * icache/dcache cache line sizes, that can vary between cores on
+	 * big.LITTLE architectures. */
+	guint64 end = (guint64) (code + size);
+	guint64 addr, ctr_el0;
+	static size_t icache_line_size = 0xffff, dcache_line_size = 0xffff;
+	size_t isize, dsize;
+
+	asm volatile ("mrs %0, ctr_el0" : "=r" (ctr_el0));
+	isize = 4 << ((ctr_el0 >> 0 ) & 0xf);
+	dsize = 4 << ((ctr_el0 >> 16) & 0xf);
+
+	/* determine the global minimum cache line size */
+	icache_line_size = isize = MIN (icache_line_size, isize);
+	dcache_line_size = dsize = MIN (dcache_line_size, dsize);
+
+	addr = (guint64) code & ~(guint64) (dsize - 1);
+	for (; addr < end; addr += dsize)
+		asm volatile("dc cvau, %0" : : "r" (addr) : "memory");
+	asm volatile("dsb ish" : : : "memory");
+
+	addr = (guint64) code & ~(guint64) (isize - 1);
+	for (; addr < end; addr += isize)
+		asm volatile("ic ivau, %0" : : "r" (addr) : "memory");
+
+	asm volatile ("dsb ish" : : : "memory");
+	asm volatile ("isb" : : : "memory");
 #endif
 #endif
 }

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1795,7 +1795,7 @@ mono_arch_flush_icache (guint8 *code, gint size)
 
 	addr = (guint64) code & ~(guint64) (dsize - 1);
 	for (; addr < end; addr += dsize)
-		asm volatile("dc cvau, %0" : : "r" (addr) : "memory");
+		asm volatile("dc civac, %0" : : "r" (addr) : "memory");
 	asm volatile("dsb ish" : : : "memory");
 
 	addr = (guint64) code & ~(guint64) (isize - 1);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -839,6 +839,7 @@ emit_thunk (guint8 *code, gconstpointer target)
 	arm_ldrx_lit (code, ARMREG_IP0, code + 8);
 	arm_brx (code, ARMREG_IP0);
 	*(guint64*)code = (guint64)target;
+	code += sizeof (guint64);
 
 	mono_arch_flush_icache (p, code - p);
 	return code;


### PR DESCRIPTION

This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=39859

The problem in `emit_thunk` and the workarounds for the Cortex A53 errata are unrelated to the bug above, but they don't hurt either.

The basic problem that we see is that the Exynos 8890 SoC (shipped for example in the world edition of the Samsung Galaxy S7) is a big.LITTLE architecture with two different CPUs, four of each. `__clear_cache` of GCC [1], the built-in that we use to flush the instruction cache, correctly reads the cache line sizes for data- and instruction cache from the CPU and then caches that result. However, the two CPUs on the Exynos 8890 have two different cache line sizes for the instruction cache (128 bytes vs. 64 bytes): If we happen to initialize the cache line sizes with the larger one, we only flush every other cache line if the code runs on the second CPU model.

Neither V8 [2] and LLVM [3] do caching of the cache line sizes, but just read it every time from the register.  We have a slightly different solution, where we cache _and_ read the value every time and try to determine a global minimum across CPUs, in case we get scheduled to a different CPU by the kernel during the flushing loop.


[1] https://android.googlesource.com/toolchain/gcc/+/master/gcc-4.9/libgcc/config/aarch64/sync-cache.c#33
[2] https://github.com/v8/v8/commit/fec99c689b8587b863df4a5c4793c601772ef663
[3] https://github.com/llvm-mirror/compiler-rt/blob/ff75f2a0260b1940436a483413091c5770427c04/lib/builtins/clear_cache.c#L146