### PR TITLE
Revert "[threadpool-ms] Switch Monitor thread to a MonoThreadInfo (#3538)"

### DIFF
--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -184,7 +184,6 @@ enum {
 	MONITOR_STATUS_NOT_RUNNING,
 };
 
-static MonoNativeThreadId monitor_tid;
 static gint32 monitor_status = MONITOR_STATUS_NOT_RUNNING;
 
 static ThreadPool* threadpool;
@@ -327,8 +326,6 @@ initialize (void)
 
 static void worker_kill (ThreadPoolWorkingThread *thread);
 
-static void monitor_kill (void);
-
 static void
 cleanup (void)
 {
@@ -338,7 +335,8 @@ cleanup (void)
 	 * cleaning up only if the runtime is shutting down */
 	g_assert (mono_runtime_is_shutting_down ());
 
-	monitor_kill ();
+	while (monitor_status != MONITOR_STATUS_NOT_RUNNING)
+		mono_thread_info_sleep (1, NULL);
 
 	mono_coop_mutex_lock (&threadpool->active_threads_lock);
 
@@ -904,11 +902,11 @@ monitor_sufficient_delay_since_last_dequeue (void)
 
 static void hill_climbing_force_change (gint16 new_thread_count, ThreadPoolHeuristicStateTransition transition);
 
-static gsize WINAPI
-monitor_thread (gpointer unused G_GNUC_UNUSED)
+static void
+monitor_thread (void)
 {
+	MonoInternalThread *current_thread = mono_thread_internal_current ();
 	guint i;
-	gboolean alerted;
 
 	mono_cpu_usage (threadpool->cpu_usage_state);
 
@@ -926,22 +924,28 @@ monitor_thread (gpointer unused G_GNUC_UNUSED)
 
 		do {
 			gint64 ts;
+			gboolean alerted = FALSE;
 
-			alerted = FALSE;
+			if (mono_runtime_is_shutting_down ())
+				break;
 
 			ts = mono_msec_ticks ();
 			if (mono_thread_info_sleep (interval_left, &alerted) == 0)
 				break;
-
 			interval_left -= mono_msec_ticks () - ts;
-		} while (!alerted && interval_left > 0 && ++awake < 10);
+
+			mono_gc_set_skip_thread (FALSE);
+			if ((current_thread->state & (ThreadState_StopRequested | ThreadState_SuspendRequested)) != 0)
+				mono_thread_interruption_checkpoint ();
+			mono_gc_set_skip_thread (TRUE);
+		} while (interval_left > 0 && ++awake < 10);
 
 		mono_gc_set_skip_thread (FALSE);
 
-		if (mono_runtime_is_shutting_down ())
+		if (threadpool->suspended)
 			continue;
 
-		if (threadpool->suspended)
+		if (mono_runtime_is_shutting_down ())
 			continue;
 
 		mono_coop_mutex_lock (&threadpool->domains_lock);
@@ -988,13 +992,12 @@ monitor_thread (gpointer unused G_GNUC_UNUSED)
 	} while (monitor_should_keep_running ());
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] monitor thread, finished", mono_native_thread_id_get ());
-
-	return 0;
 }
 
 static void
 monitor_ensure_running (void)
 {
+	MonoError error;
 	for (;;) {
 		switch (monitor_status) {
 		case MONITOR_STATUS_REQUESTED:
@@ -1006,53 +1009,16 @@ monitor_ensure_running (void)
 			if (mono_runtime_is_shutting_down ())
 				return;
 			if (InterlockedCompareExchange (&monitor_status, MONITOR_STATUS_REQUESTED, MONITOR_STATUS_NOT_RUNNING) == MONITOR_STATUS_NOT_RUNNING) {
-				MonoThreadParm tp;
-				gpointer handle;
-
-				tp.priority = MONO_THREAD_PRIORITY_NORMAL;
-				tp.stack_size = SMALL_STACK;
-				tp.creation_flags = 0;
-				handle = mono_threads_create_thread (monitor_thread, NULL, &tp, &monitor_tid);
-				if (!handle) {
-					mono_atomic_store_release (&monitor_status, MONITOR_STATUS_NOT_RUNNING);
-					g_warning ("%s: failed to create monitor thread", __func__);
-					return;
+				if (!mono_thread_create_internal (mono_get_root_domain (), monitor_thread, NULL, TRUE, SMALL_STACK, &error)) {
+					monitor_status = MONITOR_STATUS_NOT_RUNNING;
+					mono_error_cleanup (&error);
 				}
-
-				mono_threads_close_thread_handle (handle);
 				return;
 			}
 			break;
 		default: g_assert_not_reached ();
 		}
 	}
-}
-
-static void
-monitor_kill (void)
-{
-	MonoThreadHazardPointers *hp;
-	MonoThreadInfo *info;
-	MonoThreadInfoInterruptToken *token;
-
-	if (!monitor_tid)
-		return;
-
-	hp = mono_hazard_pointer_get ();
-
-	info = mono_thread_info_lookup (monitor_tid);
-
-	if (!info)
-		goto cleanup;
-
-	token = mono_thread_info_prepare_interrupt (info);
-	mono_thread_info_finish_interrupt (token);
-
-	while (monitor_status != MONITOR_STATUS_NOT_RUNNING)
-		mono_thread_info_sleep (1, NULL);
-
-cleanup:
-	mono_hazard_pointer_clear (hp, 1);
 }
 
 static void

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1328,14 +1328,9 @@ mono_thread_info_sleep (guint32 ms, gboolean *alerted)
 
 		mono_thread_info_yield ();
 
-		if (!alerted)
-			return 0;
-
 		info = mono_thread_info_current ();
-		if (mono_thread_info_is_interrupt_state (info)) {
-			*alerted = TRUE;
+		if (info && mono_thread_info_is_interrupt_state (info))
 			return WAIT_IO_COMPLETION;
-		}
 
 		return 0;
 	}


### PR DESCRIPTION
There is a subtle problem with turning the monitor thread into a simple
MonoThreadInfo: It creates worker threads via mono_thread_create_internal (),
which allocates the thread object from the GC. No thread can allocate from
the GC unless it's actually attached, which the worker thread is not when
created with just mono_threads_create ().