### PR TITLE
[runtime] Use explicit protected regions to handle more EH edge cases

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4263,7 +4263,7 @@ init_llvmonly_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *
 		MonoException *ex = mono_error_convert_to_exception (&error);
 		/* Its okay to raise in llvmonly mode */
 		if (ex)
-			mono_llvm_throw_exception ((MonoObject*)ex);
+			mono_llvm_throw_exception ((MonoObject*)ex, TRUE);
 	}
 }
 

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1551,7 +1551,7 @@ mono_resolve_iface_call_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMetho
 	gpointer res = resolve_iface_call (this_obj, imt_slot, imt_method, out_arg, TRUE, &error);
 	if (!is_ok (&error)) {
 		MonoException *ex = mono_error_convert_to_exception (&error);
-		mono_llvm_throw_exception ((MonoObject*)ex);
+		mono_llvm_throw_exception ((MonoObject*)ex, TRUE);
 	}
 	return res;
 }
@@ -1661,7 +1661,7 @@ mono_resolve_vcall_gsharedvt (MonoObject *this_obj, int slot, MonoMethod *imt_me
 	gpointer result = resolve_vcall (this_obj->vtable, slot, imt_method, out_arg, TRUE, &error);
 	if (!is_ok (&error)) {
 		MonoException *ex = mono_error_convert_to_exception (&error);
-		mono_llvm_throw_exception ((MonoObject*)ex);
+		mono_llvm_throw_exception ((MonoObject*)ex, TRUE);
 	}
 	return result;
 }
@@ -1748,7 +1748,7 @@ mono_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMetho
 	mini_resolve_imt_method (vt, imt + imt_slot, generic_virtual, &m, &aot_addr, &need_rgctx_tramp, &variant_iface, &error);
 	if (!is_ok (&error)) {
 		MonoException *ex = mono_error_convert_to_exception (&error);
-		mono_llvm_throw_exception ((MonoObject*)ex);
+		mono_llvm_throw_exception ((MonoObject*)ex, TRUE);
 	}
 
 	if (vt->klass->valuetype)

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -246,7 +246,16 @@ build_stack_trace (struct _Unwind_Context *frame_ctx, void *state)
 	MonoDomain *domain = mono_domain_get ();
 	uintptr_t ip = _Unwind_GetIP (frame_ctx);
 
-	if (show_native_addresses || mono_jit_info_table_find (domain, (char*)ip)) {
+	gboolean add_ptr = FALSE;
+	if (show_native_addresses) {
+		add_ptr = TRUE;
+	} else {
+		MonoJitInfo *found = mono_jit_info_table_find (domain, (char*)ip);
+		if (found && found->d.method->wrapper_type == MONO_WRAPPER_NONE)
+			add_ptr = TRUE;
+	}
+
+	if (add_ptr) {
 		GList **trace_ips = (GList **)state;
 		*trace_ips = g_list_prepend (*trace_ips, (gpointer)ip);
 	}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3078,7 +3078,7 @@ mono_llvm_match_exception (MonoJitInfo *jinfo, guint32 region_start, guint32 reg
 		MonoJitExceptionInfo *ei = &jinfo->clauses [i];
 		MonoClass *catch_class;
 
-		if (! (ei->try_offset == region_start && ei->try_offset + ei->try_len == region_end) )
+		if (! (ei->flags == MONO_EXCEPTION_CLAUSE_NONE && ei->try_offset == region_start && ei->try_offset + ei->try_len == region_end) )
 			continue;
 
 		catch_class = ei->data.catch_class;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2911,7 +2911,7 @@ mono_jinfo_get_epilog_size (MonoJitInfo *ji)
  */
 
 static void
-throw_exception (MonoObject *ex, gboolean rethrow)
+throw_exception (MonoObject *ex, gboolean rethrow, gboolean actually_throw)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
@@ -2939,19 +2939,20 @@ throw_exception (MonoObject *ex, gboolean rethrow)
 #endif
 	}
 
-	mono_llvm_cpp_throw_exception ();
+	if (actually_throw)
+		mono_llvm_cpp_throw_exception ();
 }
 
 void
-mono_llvm_throw_exception (MonoObject *ex)
+mono_llvm_throw_exception (MonoObject *ex, gboolean actually_throw)
 {
-	throw_exception (ex, FALSE);
+	throw_exception (ex, FALSE, actually_throw);
 }
 
 void
-mono_llvm_rethrow_exception (MonoObject *ex)
+mono_llvm_rethrow_exception (MonoObject *ex, gboolean actually_throw)
 {
-	throw_exception (ex, TRUE);
+	throw_exception (ex, TRUE, actually_throw);
 }
 
 void

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2958,7 +2958,7 @@ mono_llvm_rethrow_exception (MonoObject *ex, gboolean actually_throw)
 void
 mono_llvm_raise_exception (MonoException *e)
 {
-	mono_llvm_throw_exception ((MonoObject*)e);
+	mono_llvm_throw_exception ((MonoObject*)e, TRUE);
 }
 
 void
@@ -2969,7 +2969,7 @@ mono_llvm_throw_corlib_exception (guint32 ex_token_index)
 
 	ex = mono_exception_from_token (mono_defaults.exception_class->image, ex_token);
 
-	mono_llvm_throw_exception ((MonoObject*)ex);
+	mono_llvm_throw_exception ((MonoObject*)ex, TRUE);
 }
 
 /*

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3765,8 +3765,8 @@ register_icalls (void)
 	register_icall (mono_jit_set_domain, "mono_jit_set_domain", "void ptr", TRUE);
 	register_icall (mono_domain_get, "mono_domain_get", "ptr", TRUE);
 
-	register_icall (mono_llvm_throw_exception, "mono_llvm_throw_exception", "void object", TRUE);
-	register_icall (mono_llvm_rethrow_exception, "mono_llvm_rethrow_exception", "void object", TRUE);
+	register_icall (mono_llvm_throw_exception, "mono_llvm_throw_exception", "void object bool", TRUE);
+	register_icall (mono_llvm_rethrow_exception, "mono_llvm_rethrow_exception", "void object bool", TRUE);
 	register_icall (mono_llvm_resume_exception, "mono_llvm_resume_exception", "void", TRUE);
 	register_icall (mono_llvm_match_exception, "mono_llvm_match_exception", "int ptr int int", TRUE);
 	register_icall (mono_llvm_clear_exception, "mono_llvm_clear_exception", NULL, TRUE);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2851,8 +2851,8 @@ MONO_API gboolean mono_exception_walk_trace     (MonoException *ex, MonoExceptio
 void mono_restore_context                       (MonoContext *ctx);
 guint8* mono_jinfo_get_unwind_info              (MonoJitInfo *ji, guint32 *unwind_info_len);
 int  mono_jinfo_get_epilog_size                 (MonoJitInfo *ji);
-void     mono_llvm_rethrow_exception            (MonoObject *ex);
-void     mono_llvm_throw_exception              (MonoObject *ex);
+void     mono_llvm_rethrow_exception            (MonoObject *ex, gboolean actually_throw);
+void     mono_llvm_throw_exception              (MonoObject *ex, gboolean actually_throw);
 void     mono_llvm_throw_corlib_exception       (guint32 ex_token_index);
 void     mono_llvm_resume_exception             (void);
 void     mono_llvm_clear_exception              (void);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1181,11 +1181,19 @@ typedef struct {
 	 * The current exception in flight
 	 */
 	guint32 thrown_exc;
+
 	/*
 	 * If the current exception is not a subclass of Exception,
 	 * the original exception.
 	 */
 	guint32 thrown_non_exc;
+
+	/* 
+	 * A temporary reference to the ips for the whole
+	 * stack trace when thrown. These are truncated when the
+	 * exception is final	ly caught. 
+	 */
+	GList *trace_ips;		
 
 	/*
 	 * The calling assembly in llvmonly mode.


### PR DESCRIPTION
Some of the edge cases for llvmonly exception handling were only exposed by the mono/tests tests, not the bcl tests. It seems that a few things were broken. Throwing in a protected region's clauses could break when there was nesting. Finally clauses also didn't necessarily chain with nesting. This is a fix to both, also bringing with it an explicit interval tree (a bit of a hack at one, due to the queries we're making) in order to make this kind of thing a lot easier to write than the offset manipulation of the previous implementation. This fixes crashes or asserts in exception7, exception4, and a lot of other exception tests. Not everything is perfect, but this implementation started by mimicking the old control flow, so there shouldn't be regressions. 

Let's see what CI thinks of this. This will only apply to the mobile_static bitcode lane, other failures should be outside the scope of my changes. 
