### PR TITLE
[Debugger] GetLocals was throwing NullReferenceException(li.scopes_start) if ran against older runtime

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/LocalScope.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/LocalScope.cs
@@ -19,13 +19,13 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
-		internal int LiveRangeStart {
+		public int LiveRangeStart {
 			get {
 				return live_range_start;
 			}
 		}
 
-		internal int LiveRangeEnd {
+		public int LiveRangeEnd {
 			get {
 				return live_range_end;
 			}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -240,7 +240,8 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
-		public LocalScope[] GetScopes () {
+		public LocalScope [] GetScopes () {
+			vm.CheckProtocolVersion (2, 43);
 			GetLocals ();
 			return scopes;
 		}
@@ -265,9 +266,11 @@ namespace Mono.Debugger.Soft
 				for (int i = 0; i < li.names.Length; ++i)
 					locals [i + pi.Length] = new LocalVariable (vm, this, i, li.types [i], li.names [i], li.live_range_start [i], li.live_range_end [i], false);
 
-				scopes = new LocalScope [li.scopes_start.Length];
-				for (int i = 0; i < scopes.Length; ++i)
-					scopes [i] = new LocalScope (vm, this, li.scopes_start [i], li.scopes_end [i]);
+				if (vm.Version.AtLeast (2, 43)) {
+					scopes = new LocalScope [li.scopes_start.Length];
+					for (int i = 0; i < scopes.Length; ++i)
+						scopes [i] = new LocalScope (vm, this, li.scopes_start [i], li.scopes_end [i]);
+				}
 			}
 			return locals;
 		}


### PR DESCRIPTION
Added logic to make sure user of API handles version checking when calling GetScope
Made properties in LocalScope class public

/cc @vargaz 