### PR TITLE
[mono4.6] [arm64] fixes around icache flushing

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1777,7 +1777,33 @@ mono_arch_flush_icache (guint8 *code, gint size)
 #if __APPLE__
 	sys_icache_invalidate (code, size);
 #else
-	__clear_cache (code, code + size);
+	/* Don't rely on GCC's __clear_cache implementation, as it caches
+	 * icache/dcache cache line sizes, that can vary between cores on
+	 * big.LITTLE architectures. */
+	guint64 end = (guint64) (code + size);
+	guint64 addr, ctr_el0;
+	static size_t icache_line_size = 0xffff, dcache_line_size = 0xffff;
+	size_t isize, dsize;
+
+	asm volatile ("mrs %0, ctr_el0" : "=r" (ctr_el0));
+	isize = 4 << ((ctr_el0 >> 0 ) & 0xf);
+	dsize = 4 << ((ctr_el0 >> 16) & 0xf);
+
+	/* determine the global minimum cache line size */
+	icache_line_size = isize = MIN (icache_line_size, isize);
+	dcache_line_size = dsize = MIN (dcache_line_size, dsize);
+
+	addr = (guint64) code & ~(guint64) (dsize - 1);
+	for (; addr < end; addr += dsize)
+		asm volatile("dc cvau, %0" : : "r" (addr) : "memory");
+	asm volatile("dsb ish" : : : "memory");
+
+	addr = (guint64) code & ~(guint64) (isize - 1);
+	for (; addr < end; addr += isize)
+		asm volatile("ic ivau, %0" : : "r" (addr) : "memory");
+
+	asm volatile ("dsb ish" : : : "memory");
+	asm volatile ("isb" : : : "memory");
 #endif
 #endif
 }

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1795,7 +1795,7 @@ mono_arch_flush_icache (guint8 *code, gint size)
 
 	addr = (guint64) code & ~(guint64) (dsize - 1);
 	for (; addr < end; addr += dsize)
-		asm volatile("dc cvau, %0" : : "r" (addr) : "memory");
+		asm volatile("dc civac, %0" : : "r" (addr) : "memory");
 	asm volatile("dsb ish" : : : "memory");
 
 	addr = (guint64) code & ~(guint64) (isize - 1);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -839,6 +839,7 @@ emit_thunk (guint8 *code, gconstpointer target)
 	arm_ldrx_lit (code, ARMREG_IP0, code + 8);
 	arm_brx (code, ARMREG_IP0);
 	*(guint64*)code = (guint64)target;
+	code += sizeof (guint64);
 
 	mono_arch_flush_icache (p, code - p);
 	return code;


### PR DESCRIPTION
backport of https://github.com/mono/mono/pull/3549