### PR TITLE
Use NUnit's SetCulture attribute rather than Culture

### DIFF
--- a/mcs/class/corlib/Test/System/DateTimeTest.cs
+++ b/mcs/class/corlib/Test/System/DateTimeTest.cs
@@ -2646,7 +2646,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Culture ("en-us")]
+		[SetCulture ("en-us")]
 		public void ToUniversalTime_TimeZoneOffsetShouldNotOverflow ()
 		{
 			var m = DateTime.MaxValue;
@@ -2662,7 +2662,7 @@ namespace MonoTests.System
 			res = m.ToUniversalTime ();
 
 			// It does not matter which time zone but we should never overflow or have DateTime.MinValue
-			Assert.AreEqual (0, res.Year, "#10");
+			Assert.AreEqual (1, res.Year, "#10");
 			Assert.AreEqual (1, res.Month, "#11");
 			Assert.AreEqual (1, res.Day, "#12");
 			Assert.AreEqual (DateTimeKind.Utc, res.Kind, "#13");

--- a/mcs/class/corlib/Test/System/DecimalTest-Microsoft.cs
+++ b/mcs/class/corlib/Test/System/DecimalTest-Microsoft.cs
@@ -496,7 +496,7 @@ namespace MonoTests.System
 		}
 		
 		[Test]
-		[Culture ("en")]
+		[SetCulture ("en")]
 		public void TestParse()
 		{
 		    // Boolean Decimal.TryParse(String, NumberStyles, IFormatProvider, Decimal)
@@ -810,7 +810,7 @@ namespace MonoTests.System
 		}
 		
 		[Test]
-		[Culture ("en")]
+		[SetCulture ("en")]
 		public void TestToString()
 		{
 		    // String Decimal.ToString()
@@ -865,7 +865,7 @@ namespace MonoTests.System
 		}
 		
 		[Test]
-		[Culture ("en")]
+		[SetCulture ("en")]
 		public void TestNumberBufferLimit()
 		{
 		    Decimal dE = 1234567890123456789012345.6785m;

--- a/mcs/class/corlib/Test/System/DoubleTest.cs
+++ b/mcs/class/corlib/Test/System/DoubleTest.cs
@@ -147,7 +147,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Culture ("en-US")]
+		[SetCulture ("en-US")]
 		public void Parse ()
 		{
 			int i = 0;


### PR DESCRIPTION
A few tests are currently ignored when running on a system where the default culture isn't "en" or "en-US". This patch changes Culture attributes to SetCulture attributes instead to make those tests run on all system and make NUnit set the culture to the required one during the test run.

Also found and fixed a test failure in one of these methods, DateTimeTest.ToUniversalTime_TimeZoneOffsetShouldNotOverflow(), which assumed the minimum year is 0 while it's actually 1. Confirmed that this is the case on .NET as well.