### PR TITLE
Disable tests which instantiate COM objects on Windows

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -266,6 +266,7 @@ namespace MonoTests.System
 #endif
 		const string ASSEMBLY_NAME = "MonoTests.System.TypeTest";
 		static int typeIndexer = 0;
+		static bool isMono = Type.GetType ("Mono.Runtime", false) != null;
 
 		[SetUp]
 		public void SetUp ()
@@ -1834,8 +1835,8 @@ namespace MonoTests.System
 
 			Assert.AreEqual (t1.FullName, "System.__ComObject");
 
-			if (Environment.OSVersion.Platform == PlatformID.Win32Windows ||
-				Environment.OSVersion.Platform == PlatformID.Win32NT)
+			if (!isMono && (Environment.OSVersion.Platform == PlatformID.Win32Windows ||
+				Environment.OSVersion.Platform == PlatformID.Win32NT))
 				Activator.CreateInstance(t1);
 
 			Assert.AreEqual (t2.FullName, "System.__ComObject");


### PR DESCRIPTION
COM is not working on Mono on Windows and adding support for it is not a priority at the moment.