### PR TITLE
Ignore the FileSecurityTest.EveryoneMayNotBeOwner test when running as Administrator

### DIFF
--- a/mcs/class/corlib/Test/System.Security.AccessControl/FileSecurityTest.cs
+++ b/mcs/class/corlib/Test/System.Security.AccessControl/FileSecurityTest.cs
@@ -98,6 +98,13 @@ namespace MonoTests.System.Security.AccessControl
 				security = File.GetAccessControl (path);
 				security.SetOwner (new SecurityIdentifier ("WD"));
 				File.SetAccessControl (path, security);
+				// If we don't get an InvalidOperationException it could be that we are running
+				// with administrator privileges. Don't fail the test if that is the case.
+				WindowsIdentity identity = WindowsIdentity.GetCurrent ();
+				WindowsPrincipal principal = new WindowsPrincipal (identity);
+				if (principal.IsInRole (WindowsBuiltInRole.Administrator)) {
+					Assert.Ignore ("Running as Administrator");
+				}
 			} finally {
 				File.Delete (path);
 			}


### PR DESCRIPTION
This test fails when running as Administrator since Administrator CAN set the owner to Everyone. This patch ignores the test when running as Administrator. The check has to be done after the File.SetAccessControl() call that is expected to fail since when we aren't running as Administrator the IsInRole() check will trigger UAC which we need to prevent when possible.