### PR TITLE
Use the path of the current executable by default in soft debugger test on Windows to launch the child mono process

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -69,9 +69,17 @@ public class DebuggerTests
 		if (!listening) {
 			var pi = new Diag.ProcessStartInfo ();
 
-			if (runtime != null)
+			if (runtime != null) {
 				pi.FileName = runtime;
-			else
+			} else if (Path.DirectorySeparatorChar == '\\') {
+				string processExe = Diag.Process.GetCurrentProcess ().MainModule.FileName;
+				if (processExe != null) {
+					string fileName = Path.GetFileName (processExe);
+					if (fileName.StartsWith ("mono") && fileName.EndsWith (".exe"))
+						pi.FileName = processExe;
+				}
+			}
+			if (string.IsNullOrEmpty (pi.FileName))
 				pi.FileName = "mono";
 			pi.Arguments = String.Join (" ", args);
 			vm = VirtualMachineManager.Launch (pi, new LaunchOptions { AgentArgs = agent_args });


### PR DESCRIPTION
The 'mono' shell script generated by the Cygwin make file system doesn't work when running the soft debugger tests against an MSVC built mono executable. This patch first tries with the main module of the current process when running on Windows (and mono is built using MSVC). If it looks like a mono executable the tests will use it before falling back to the shell script.