### PR TITLE
[mcs] Accept and ignore command line args supported by csc that we don't

### DIFF
--- a/mcs/mcs/settings.cs
+++ b/mcs/mcs/settings.cs
@@ -1228,6 +1228,8 @@ namespace Mono.CSharp {
 			case "/pdb":
 			case "/preferreduilang":
 			case "/publicsign":
+			case "/publicsign+":
+			case "/publicsign-":
 			case "/reportanalyzer":
 			case "/ruleset":
 			case "/sqmsessionguid":


### PR DESCRIPTION
.. support:

```
/publicsign+
/publicsign-
```
