### PR TITLE
Fix issues (leaks, possible crash) around netmodule loading

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015 Xamarin Inc
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_METADATA_ASSEMBLY_INTERNALS_H__
+#define __MONO_METADATA_ASSEMBLY_INTERNALS_H__
+
+#include <mono/metadata/assembly.h>
+
+MONO_API MonoImage*    mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error);
+
+#endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -16,7 +16,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include "assembly.h"
+#include "assembly-internals.h"
 #include "image.h"
+#include "image-internals.h"
 #include "object-internals.h"
 #include <mono/metadata/loader.h>
 #include <mono/metadata/tabledefs.h>
@@ -3449,6 +3451,13 @@ mono_assembly_load_module (MonoAssembly *assembly, guint32 idx)
 {
 	return mono_image_load_file_for_image (assembly->image, idx);
 }
+
+MONO_API MonoImage*
+mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error)
+{
+	return mono_image_load_file_for_image_checked (assembly->image, idx, error);
+}
+
 
 /**
  * mono_assembly_foreach:

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3449,7 +3449,10 @@ mono_assembly_close (MonoAssembly *assembly)
 MonoImage*
 mono_assembly_load_module (MonoAssembly *assembly, guint32 idx)
 {
-	return mono_image_load_file_for_image (assembly->image, idx);
+	MonoError error;
+	MonoImage *result = mono_assembly_load_module_checked (assembly, idx, &error);
+	mono_error_assert_ok (&error);
+	return result;
 }
 
 MONO_API MonoImage*

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -1,6 +1,7 @@
 #ifndef _MONONET_METADATA_ASSEMBLY_H_ 
 #define _MONONET_METADATA_ASSEMBLY_H_
 
+#include <mono/utils/mono-error.h>
 #include <mono/metadata/image.h>
 
 MONO_BEGIN_DECLS
@@ -32,7 +33,7 @@ MONO_API MonoAssembly* mono_assembly_loaded_full (MonoAssemblyName *aname, mono_
 MONO_API void          mono_assembly_get_assemblyref (MonoImage *image, int index, MonoAssemblyName *aname);
 MONO_API void          mono_assembly_load_reference (MonoImage *image, int index);
 MONO_API void          mono_assembly_load_references (MonoImage *image, MonoImageOpenStatus *status);
-MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32_t idx);
+MONO_RT_EXTERNAL_ONLY MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32_t idx);
 MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
 MONO_API void          mono_assembly_setrootdir (const char *root_dir);
 MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -18,7 +18,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <mono/metadata/image.h>
+#include <mono/metadata/image-internals.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/profiler-private.h>
@@ -216,7 +218,7 @@ mono_class_from_typeref_checked (MonoImage *image, guint32 type_token, MonoError
 		goto done;
 
 	case MONO_RESOLUTION_SCOPE_MODULEREF:
-		module = mono_image_load_module (image, idx);
+		module = mono_image_load_module_checked (image, idx, error);
 		if (module)
 			res = mono_class_from_name_checked (module, nspace, name, error);
 		goto done;
@@ -7814,7 +7816,7 @@ search_modules (MonoImage *image, const char *name_space, const char *name, Mono
 		if (cols [MONO_FILE_FLAGS] == FILE_CONTAINS_NO_METADATA)
 			continue;
 
-		file_image = mono_image_load_file_for_image (image, i + 1);
+		file_image = mono_image_load_file_for_image_checked (image, i + 1, error);
 		if (file_image) {
 			klass = mono_class_from_name_checked (file_image, name_space, name, error);
 			if (klass || !is_ok (error))
@@ -7910,7 +7912,7 @@ mono_class_from_name_checked_aux (MonoImage *image, const char* name_space, cons
 
 		impl = cols [MONO_EXP_TYPE_IMPLEMENTATION];
 		if ((impl & MONO_IMPLEMENTATION_MASK) == MONO_IMPLEMENTATION_FILE) {
-			loaded_image = mono_assembly_load_module (image->assembly, impl >> MONO_IMPLEMENTATION_BITS);
+			loaded_image = mono_assembly_load_module_checked (image->assembly, impl >> MONO_IMPLEMENTATION_BITS, error);
 			if (!loaded_image)
 				return NULL;
 			klass = mono_class_from_name_checked_aux (loaded_image, name_space, name, visited_images, error);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -43,7 +43,9 @@
 #include <mono/metadata/threadpool-ms-io.h>
 #include <mono/metadata/monitor.h>
 #include <mono/metadata/reflection.h>
+#include <mono/metadata/image-internals.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/exception-internals.h>
@@ -4827,8 +4829,8 @@ ves_icall_System_Reflection_Assembly_GetManifestResourceInternal (MonoReflection
 		g_assert ((impl & MONO_IMPLEMENTATION_MASK) == MONO_IMPLEMENTATION_FILE);
 		file_idx = impl >> MONO_IMPLEMENTATION_BITS;
 
-		module = mono_image_load_file_for_image (assembly->assembly->image, file_idx);
-		if (!module)
+		module = mono_image_load_file_for_image_checked (assembly->assembly->image, file_idx, &error);
+		if (mono_error_set_pending_exception (&error) || !module)
 			return NULL;
 	}
 	else
@@ -5028,7 +5030,9 @@ ves_icall_System_Reflection_Assembly_GetModulesInternal (MonoReflectionAssembly 
 			mono_array_setref (res, j, rm);
 		}
 		else {
-			MonoImage *m = mono_image_load_file_for_image (image, i + 1);
+			MonoImage *m = mono_image_load_file_for_image_checked (image, i + 1, &error);
+			if (mono_error_set_pending_exception (&error))
+				return NULL;
 			if (!m) {
 				MonoString *fname = mono_string_new (mono_domain_get (), mono_metadata_string_heap (image, cols [MONO_FILE_NAME]));
 				mono_set_pending_exception (mono_get_exception_file_not_found2 (NULL, fname));
@@ -5552,7 +5556,9 @@ ves_icall_System_Reflection_Assembly_GetTypes (MonoReflectionAssembly *assembly,
 	/* Append data from all modules in the assembly */
 	for (i = 0; i < table->rows; ++i) {
 		if (!(mono_metadata_decode_row_col (table, i, MONO_FILE_FLAGS) & FILE_CONTAINS_NO_METADATA)) {
-			MonoImage *loaded_image = mono_assembly_load_module (image->assembly, i + 1);
+			MonoImage *loaded_image = mono_assembly_load_module_checked (image->assembly, i + 1, &error);
+			if (mono_error_set_pending_exception (&error))
+				return NULL;
 			if (loaded_image) {
 				MonoArray *ex2;
 				MonoArray *res2;

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -10,4 +10,10 @@
 MonoImage *
 mono_find_image_owner (void *ptr);
 
+MonoImage*
+mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError *error);
+
+MonoImage*
+mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
+
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -673,6 +673,8 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 	GList *list_iter, *valid_modules = NULL;
 	MonoImageOpenStatus status;
 
+	mono_error_init (error);
+
 	if ((image->module_count == 0) || (idx > image->module_count || idx <= 0))
 		return NULL;
 	if (image->modules_loaded [idx - 1])
@@ -709,10 +711,7 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 		if (valid) {
 			module_ref = g_build_filename (base_dir, name, NULL);
 			MonoImage *moduleImage = mono_image_open_full (module_ref, &status, refonly);
-			if (image->modules [idx - 1]) {
-				g_assert(!image->modules [idx - 1]->assembly || image->modules [idx - 1]->assembly == image->assembly);
-				image->modules [idx - 1]->assembly = image->assembly;
-
+			if (moduleImage) {
 				if (!assign_assembly_parent_for_netmodule (moduleImage, image, error)) {
 					mono_image_close (moduleImage);
 					g_free (module_ref);
@@ -745,10 +744,8 @@ MonoImage*
 mono_image_load_module (MonoImage *image, int idx)
 {
 	MonoError error;
-	mono_error_init (&error);
 	MonoImage *result = mono_image_load_module_checked (image, idx, &error);
 	mono_error_assert_ok (&error);
-	mono_error_cleanup (&error);
 	return result;
 }
 
@@ -2223,6 +2220,8 @@ mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError
 	const char *fname;
 	guint32 fname_id;
 
+	mono_error_init (error);
+
 	if (fileidx < 1 || fileidx > t->rows)
 		return NULL;
 
@@ -2284,10 +2283,8 @@ MonoImage*
 mono_image_load_file_for_image (MonoImage *image, int fileidx)
 {
 	MonoError error;
-	mono_error_init (&error);
 	MonoImage *result = mono_image_load_file_for_image_checked (image, fileidx, &error);
 	mono_error_assert_ok (&error);
-	mono_error_cleanup (&error);
 	return result;
 }
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -66,16 +66,41 @@ enum {
 };
 static GHashTable *loaded_images_hashes [4] = {NULL, NULL, NULL, NULL};
 
-static GHashTable *get_loaded_images_hash (gboolean refonly)
+static GHashTable *
+get_loaded_images_hash (gboolean refonly)
 {
 	int idx = refonly ? IMAGES_HASH_PATH_REFONLY : IMAGES_HASH_PATH;
 	return loaded_images_hashes [idx];
 }
 
-static GHashTable *get_loaded_images_by_name_hash (gboolean refonly)
+static GHashTable *
+get_loaded_images_by_name_hash (gboolean refonly)
 {
 	int idx = refonly ? IMAGES_HASH_NAME_REFONLY : IMAGES_HASH_NAME;
 	return loaded_images_hashes [idx];
+}
+
+// Change the assembly set in `image` to the assembly set in `assemblyImage`. Halt if overwriting is attempted.
+// Can be used on modules loaded through either the "file" or "module" mechanism
+static gboolean
+assign_assembly_parent_for_netmodule (MonoImage *image, MonoImage *assemblyImage, MonoError *error)
+{
+	// Assembly to assign
+	MonoAssembly *assembly = assemblyImage->assembly;
+
+	while (1) {
+		// Assembly currently assigned
+		MonoAssembly *assemblyOld = image->assembly;
+		if (assemblyOld) {
+			if (assemblyOld == assembly)
+				return TRUE;
+			mono_error_set_bad_image (error, assemblyImage, "Attempted to load module %s which has already been loaded by assembly %s. This is not supported in Mono.", image->name, assemblyOld->image->name);
+			return FALSE;
+		}
+		gpointer result = InterlockedExchangePointer((gpointer *)&image->assembly, assembly);
+		if (result == assembly)
+			return TRUE;
+	}
 }
 
 static gboolean debug_assembly_unload = FALSE;
@@ -632,13 +657,13 @@ load_modules (MonoImage *image)
 }
 
 /**
- * mono_image_load_module:
+ * mono_image_load_module_checked:
  *
  *   Load the module with the one-based index IDX from IMAGE and return it. Return NULL if
- * it cannot be loaded.
+ * it cannot be loaded. NULL without MonoError being set will be interpreted as "not found".
  */
 MonoImage*
-mono_image_load_module (MonoImage *image, int idx)
+mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 {
 	MonoTableInfo *t;
 	MonoTableInfo *file_table;
@@ -683,9 +708,21 @@ mono_image_load_module (MonoImage *image, int idx)
 		}
 		if (valid) {
 			module_ref = g_build_filename (base_dir, name, NULL);
-			image->modules [idx - 1] = mono_image_open_full (module_ref, &status, refonly);
+			MonoImage *moduleImage = mono_image_open_full (module_ref, &status, refonly);
 			if (image->modules [idx - 1]) {
+				g_assert(!image->modules [idx - 1]->assembly || image->modules [idx - 1]->assembly == image->assembly);
 				image->modules [idx - 1]->assembly = image->assembly;
+
+				if (!assign_assembly_parent_for_netmodule (moduleImage, image, error)) {
+					mono_image_close (moduleImage);
+					g_free (module_ref);
+					g_free (base_dir);
+					g_list_free (valid_modules);
+					return NULL;
+				}
+
+				image->modules [idx - 1] = image;
+
 #ifdef HOST_WIN32
 				if (image->modules [idx - 1]->is_module_handle)
 					mono_image_fixup_vtable (image->modules [idx - 1]);
@@ -702,6 +739,17 @@ mono_image_load_module (MonoImage *image, int idx)
 	g_list_free (valid_modules);
 
 	return image->modules [idx - 1];
+}
+
+MonoImage*
+mono_image_load_module (MonoImage *image, int idx)
+{
+	MonoError error;
+	mono_error_init (&error);
+	MonoImage *result = mono_image_load_module_checked (image, idx, &error);
+	mono_error_assert_ok (&error);
+	mono_error_cleanup (&error);
+	return result;
 }
 
 static gpointer
@@ -2165,8 +2213,9 @@ mono_image_get_resource (MonoImage *image, guint32 offset, guint32 *size)
 	return data;
 }
 
+// Returning NULL with no error set will be interpeted as "not found"
 MonoImage*
-mono_image_load_file_for_image (MonoImage *image, int fileidx)
+mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError *error)
 {
 	char *base_dir, *name;
 	MonoImage *res;
@@ -2201,7 +2250,12 @@ mono_image_load_file_for_image (MonoImage *image, int fileidx)
 	} else {
 		int i;
 		/* g_print ("loaded file %s from %s (%p)\n", name, image->name, image->assembly); */
-		res->assembly = image->assembly;
+		if (!assign_assembly_parent_for_netmodule (res, image, error)) {
+			mono_image_unlock (image);
+			mono_image_close (res);
+			return NULL;
+		}
+
 		for (i = 0; i < res->module_count; ++i) {
 			if (res->modules [i] && !res->modules [i]->assembly)
 				res->modules [i]->assembly = image->assembly;
@@ -2224,6 +2278,17 @@ done:
 	g_free (name);
 	g_free (base_dir);
 	return res;
+}
+
+MonoImage*
+mono_image_load_file_for_image (MonoImage *image, int fileidx)
+{
+	MonoError error;
+	mono_error_init (&error);
+	MonoImage *result = mono_image_load_file_for_image_checked (image, fileidx, &error);
+	mono_error_assert_ok (&error);
+	mono_error_cleanup (&error);
+	return result;
 }
 
 /**

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <mono/utils/mono-publib.h>
+#include <mono/utils/mono-error.h>
 
 MONO_BEGIN_DECLS
 
@@ -50,9 +51,9 @@ MONO_API int           mono_image_ensure_section_idx (MonoImage *image,
 
 MONO_API uint32_t       mono_image_get_entry_point    (MonoImage *image);
 MONO_API const char   *mono_image_get_resource       (MonoImage *image, uint32_t offset, uint32_t *size);
-MONO_API MonoImage*    mono_image_load_file_for_image (MonoImage *image, int fileidx);
+MONO_RT_EXTERNAL_ONLY MONO_API MonoImage*    mono_image_load_file_for_image (MonoImage *image, int fileidx);
 
-MONO_API MonoImage*    mono_image_load_module (MonoImage *image, int idx);
+MONO_RT_EXTERNAL_ONLY MONO_API MonoImage*    mono_image_load_module (MonoImage *image, int idx);
 
 MONO_API const char*   mono_image_get_name       (MonoImage *image);
 MONO_API const char*   mono_image_get_filename   (MonoImage *image);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -175,10 +175,12 @@ typedef struct {
 
 struct _MonoImage {
 	/*
-	 * The number of assemblies which reference this MonoImage though their 'image'
-	 * field plus the number of images which reference this MonoImage through their 
-	 * 'modules' field, plus the number of threads holding temporary references to
-	 * this image between calls of mono_image_open () and mono_image_close ().
+	 * This count is incremented during these situations:
+	 *   - An assembly references this MonoImage though its 'image' field
+	 *   - This MonoImage is present in the 'files' field of an image
+	 *   - This MonoImage is present in the 'modules' field of an image
+	 *   - A thread is holding a temporary reference to this MonoImage between
+	 *     calls to mono_image_open and mono_image_close ()
 	 */
 	int   ref_count;
 
@@ -258,16 +260,16 @@ struct _MonoImage {
 	MonoAssembly **references;
 	int nreferences;
 
-	/* Code files in the assembly. */
+	/* Code files in the assembly. The main assembly has a "file" table and also a "module"
+	 * table, where the module table is a subset of the file table. We track both lists,
+	 * and because we can lazy-load them at different times we reference-increment both.
+	 */
 	MonoImage **modules;
 	guint32 module_count;
 	gboolean *modules_loaded;
 
-	/*
-	 * Files in the assembly. Items are either NULL or alias items in modules, so this does not impact ref_count.
-	 * Protected by the image lock.
-	 */
 	MonoImage **files;
+	guint32 file_count;
 
 	gpointer aot_module;
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -6,7 +6,7 @@ else
 FEATUREFUL_RUNTIME_TEST = test-appdomain-unload
 endif
 
-check-local: assemblyresolve/test/asm.dll testjit test-generic-sharing test-type-load test-cattr-type-load test-reflection-load-with-context test_platform	\
+check-local: assemblyresolve/test/asm.dll testjit test-generic-sharing test-type-load test-multi-netmodule test-cattr-type-load test-reflection-load-with-context test_platform	\
 		 test-console-output test-messages test-env-options test-unhandled-exception-2 $(FEATUREFUL_RUNTIME_TEST) test-process-stress rm-empty-logs
 check-full: test-sgen check-local
 check-parallel: compile-tests check-full
@@ -1075,6 +1075,14 @@ test-type-load: $(TEST_DRIVER_DEPEND)
 	@$(MCS) -t:library -out:t.dll $(srcdir)/t-missing.cs
 	@echo "Testing load-exception.exe..."
 	@$(RUNTIME) load-exceptions.exe > load-exceptions.exe.stdout 2> load-exceptions.exe.stderr
+
+EXTRA_DIST += test-multi-netmodule-1-netmodule.cs test-multi-netmodule-2-dll1.cs test-multi-netmodule-3-dll2.cs test-multi-netmodule-4-exe.cs
+test-multi-netmodule:
+	@$(MCS) -t:module test-multi-netmodule-1-netmodule.cs
+	@$(MCS) -addmodule:test-multi-netmodule-1-netmodule.netmodule -t:library test-multi-netmodule-2-dll1.cs
+	@$(MCS) -addmodule:test-multi-netmodule-1-netmodule.netmodule -t:library test-multi-netmodule-3-dll2.cs
+	@$(MCS) -r:test-multi-netmodule-2-dll1.dll test-multi-netmodule-4-exe.cs
+	$(RUNTIME) test-multi-netmodule-4-exe.exe > test-multi-netmodule-4-exe.exe.stdout 2> test-multi-netmodule-4-exe.exe.stderr
 
 EXTRA_DIST += custom-attr-errors.cs custom-attr-errors-lib.cs
 test-cattr-type-load: $(TEST_DRIVER_DEPEND) custom-attr-errors.cs custom-attr-errors-lib.cs

--- a/mono/tests/test-multi-netmodule-1-netmodule.cs
+++ b/mono/tests/test-multi-netmodule-1-netmodule.cs
@@ -1,0 +1,4 @@
+// Compiler options: -t:module
+
+public class M1 {
+}

--- a/mono/tests/test-multi-netmodule-2-dll1.cs
+++ b/mono/tests/test-multi-netmodule-2-dll1.cs
@@ -1,0 +1,5 @@
+// Compiler options: -addmodule:test-multi-netmodule-1-netmodule.netmodule -t:library
+
+public class M2 {
+	public M1 m1 = new M1();
+}

--- a/mono/tests/test-multi-netmodule-3-dll2.cs
+++ b/mono/tests/test-multi-netmodule-3-dll2.cs
@@ -1,0 +1,5 @@
+// Compiler options: -addmodule:test-multi-netmodule-1-netmodule.netmodule -t:library
+
+public class M3 {
+	public M1 m1 = new M1();
+}

--- a/mono/tests/test-multi-netmodule-4-exe.cs
+++ b/mono/tests/test-multi-netmodule-4-exe.cs
@@ -1,0 +1,28 @@
+// Compiler options: -r:test-multi-netmodule-2-dll1.dll
+
+using System;
+using System.Reflection;
+
+public class M4 {
+	public static int Main () {
+		M2 m2 = new M2();
+
+		// Expecting failure
+		try {
+			var DLL = Assembly.LoadFile(@"test-multi-netmodule-3-dll2.dll");
+	        var m3Type = DLL.GetType("M3");
+	        var m3 = Activator.CreateInstance(m3Type);
+	        var m3m1Field = m3Type.GetField("m1");
+
+    		Console.WriteLine("M3    assembly:" + m3Type.Assembly);
+			Console.WriteLine("M3.M1 assembly:" + m3m1Field.DeclaringType.Assembly);
+        } catch (System.TypeLoadException) {
+        	return 0;
+        }
+
+		Console.WriteLine("M2    assembly:" + typeof (M2).Assembly);
+		Console.WriteLine("M2.M1 assembly:" + m2.m1.GetType().Assembly);
+
+		return 1;
+	}
+}

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -473,6 +473,12 @@ check_image_may_reference_image(MonoImage *from, MonoImage *to)
 			// For each queued image visit all directly referenced images
 			int inner_idx;
 
+			// 'files' and 'modules' semantically contain the same items but because of lazy loading we must check both
+			for (inner_idx = 0; !success && inner_idx < checking->file_count; inner_idx++)
+			{
+				CHECK_IMAGE_VISIT (checking->files[inner_idx]);
+			}
+
 			for (inner_idx = 0; !success && inner_idx < checking->module_count; inner_idx++)
 			{
 				CHECK_IMAGE_VISIT (checking->modules[inner_idx]);
@@ -480,12 +486,7 @@ check_image_may_reference_image(MonoImage *from, MonoImage *to)
 
 			for (inner_idx = 0; !success && inner_idx < checking->nreferences; inner_idx++)
 			{
-				// References are lazy-loaded and thus allowed to be NULL.
-				// If they are NULL, we don't care about them for this search, because they haven't impacted ref_count yet.
-				if (checking->references[inner_idx])
-				{
-					CHECK_IMAGE_VISIT (checking->references[inner_idx]->image);
-				}
+				CHECK_IMAGE_VISIT (checking->references[inner_idx]->image);
 			}
 
 			mono_image_unlock (checking);


### PR DESCRIPTION
Test `mcs/tests/test-418.exe` was failing when running a checked build with MONO_CHECK_MODE=metadata. This lead me to audit the code around module loading. I found a bunch of issues. There are two commits, the first is needed to resolve the failing test-418 test in checked build mode, the second is not required.

## Commit 1: Leaks

1. The checked build metadata "reference audit" was following references stored in the "modules" field, but not the "files" field. I changed the audit code to follow both.
2. Loading a module into the "modules[]" field was causing a leak because mono_image_addref() was being called after mono_image_open_full(), even though mono_image_open_full itself returns the module +1. I removed the addref.
3. Loading a module into the "files[]" field was causing a leak because we were opening the module with mono_image_open_full and then never attempting to close it. I modified our image close to do the same thing to "files[]" we do to "modules[]".

In order for 1 and 3 to work, I modified MonoImages to track the size of the "files[]" field.

## Commit 2: Potential crash in "diamond dependency" scenario

The ECMA-335 spec contains the text:

> "Usually, a module belongs only to one assembly, but it is possible to share it across assemblies. When assembly A is loaded at runtime, an instance of M3 will be loaded for it. When assembly B is loaded into the same application domain, possibly simultaneously with assembly A, M3 will be shared for both assemblies. Both assemblies also reference F2, for which similar rules apply."

What happens in Mono when two assemblies both load the same module? We never planned for that possibility in our architecture. Looking at our current code, when an assembly image loads a module image into its modules[] or files[] array, it immediately sets the "assembly" field of that module to its own MonoAssembly. This field is a plain C pointer with no safety on it whatsoever, and is references in various places including by icalls. Consider the following scenario:

- Assembly A is loaded, references module M3, sets M3->assembly to A->assembly.
- Assembly B is loaded, references module M3, sets M3->assembly to b->assembly.
- Assembly B is unloaded.

At this point the image for B is unloaded, but M3 is still alive because A keeps it alive, and its image contains a C pointer to freed memory. There is likely some way to trigger a crash from this point.

Because the above scenario is fairly exotic, I dealt with it by just causing the module loader to detect when multiple assemblies are referencing the same module and throwing an exception in this case. I also added a test to verify the exception is thrown. Allowing the module load to raise an exception required adding _checked versions of several functions.