### PR TITLE
[threads] Detach thread in all possible cases

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2301,7 +2301,7 @@ sgen_thread_detach (SgenThreadInfo *p)
 	 * so we assume that if the domain is still registered, we can detach
 	 * the thread
 	 */
-	if (mono_domain_get ())
+	if (mono_thread_internal_current_is_attached ())
 		mono_thread_detach_internal (mono_thread_internal_current ());
 }
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -260,4 +260,7 @@ void mono_threads_begin_abort_protected_block (void);
 void mono_threads_end_abort_protected_block (void);
 MonoException* mono_thread_try_resume_interruption (void);
 
+gboolean
+mono_thread_internal_current_is_attached (void);
+
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3111,8 +3111,8 @@ mono_threads_set_shutting_down (void)
 			UNLOCK_THREAD (current_thread);
 		}
 
-		/*since we're killing the thread, unset the current domain.*/
-		mono_domain_unset ();
+		/*since we're killing the thread, detach it.*/
+		mono_thread_detach_internal (current_thread);
 
 		/* Wake up other threads potentially waiting for us */
 		mono_thread_info_exit ();

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1065,7 +1065,7 @@ mono_thread_attach_full (MonoDomain *domain, gboolean force_attach)
 	MonoNativeThreadId tid;
 	gsize stack_ptr;
 
-	if ((internal = mono_thread_internal_current ())) {
+	if (mono_thread_internal_current_is_attached ()) {
 		if (domain != mono_domain_get ())
 			mono_domain_set (domain, TRUE);
 		/* Already attached */
@@ -1156,6 +1156,18 @@ mono_thread_detach_if_exiting (void)
 		}
 	}
 	return FALSE;
+}
+
+gboolean
+mono_thread_internal_current_is_attached (void)
+{
+	MonoInternalThread *internal;
+
+	internal = GET_CURRENT_OBJECT ();
+	if (!internal)
+		return FALSE;
+
+	return TRUE;
 }
 
 void


### PR DESCRIPTION
All possible cases are:
 - mono_thread_exit
 - end of start_wrapper_internal
 - callback from unregister_thread for MonoThreadInfo destructor