### PR TITLE
Resolve "you are registering twice the same counter address" warning on Windows Release builds.

### DIFF
--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -347,6 +347,13 @@ page_faults (void)
 	return mono_process_get_data (GINT_TO_POINTER (mono_process_current_pid ()), MONO_PROCESS_FAULTS);
 }
 
+
+// If cpu_load gets inlined on Windows then cpu_load_1min, cpu_load_5min and cpu_load_15min can be folded into a single function and that will
+// cause a failure when registering counters since the same function address will be used by all three functions. Preventing this method from being inlined
+// will make sure the registered callback functions remains unique.
+#ifdef _MSC_VER
+__declspec(noinline)
+#endif
 static double
 cpu_load (int kind)
 {


### PR DESCRIPTION
When registering profile counters on optimized Windows build you will get the following logging twice:

"you are registering twice the same counter address"

This happens since the optimizer will collapse cpu_load_1min, cpu_load_5min and cpu_load15min into
the same function on optimized Windows builds and that is not expected by register_internal.

By preventing inlining of cpu_load we can keep the different callback methods unique and optimizer
won't fold them into one single representation in the final binary.