### PR TITLE
Fixes line ending issue in XmlReflectionImporterTests.Bug594490_SerializationOfXmlLangAttribute

### DIFF
--- a/mcs/class/System.XML/Test/System.Xml.Serialization/XmlReflectionImporterTests.cs
+++ b/mcs/class/System.XML/Test/System.Xml.Serialization/XmlReflectionImporterTests.cs
@@ -2052,8 +2052,8 @@ namespace MonoTests.System.XmlSerialization
 				serializer.Serialize (writer, obj);
 				writer.Close ();
 
-				Assert.AreEqual (@"<?xml version=""1.0"" encoding=""utf-16""?>
-<Bug594490Class xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xml:lang=""hello world"" />",
+				Assert.AreEqual (@"<?xml version=""1.0"" encoding=""utf-16""?>" + Environment.NewLine +
+				                 @"<Bug594490Class xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xml:lang=""hello world"" />",
 					writer.ToString (),
 					"Novell bug #594490 (https://bugzilla.novell.com/show_bug.cgi?id=594490) not fixed.");
 			}


### PR DESCRIPTION
This test is sensitive to the line ending mode used by git. When LF is used by git (which is what Cygwin's git defaults to) this test fails on Windows since CRLF will be used as line ending in the serialized XML. This patch changes the test to use Environment.NewLine explicitly in the expected string.