### PR TITLE
Handle relocatable libMonoPosixHelper.so when --libdir= isn't lib/

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,11 @@ AC_SUBST(libmono_cflags)
 AC_SUBST(libmono_ldflags)
 
 # Variable to have relocatable .pc files (lib, or lib64)
-reloc_libdir=`basename ${libdir}`
+# realpath isn't always available, and requires that all but the tip of the provided
+# path exists. Fall back to the old behaviour, but realpath allows depth >1
+# e.g. Debian puts Mono in /usr/bin and libs in /usr/lib/x86_64-linux-gnu/ which is
+# too deep for the old method to work
+reloc_libdir=`realpath --relative-to=${prefix} ${libdir} 2> /dev/null || basename ${libdir}`
 AC_SUBST(reloc_libdir)
 
 # Set to yes if Unix sockets cannot be created in an anonymous namespace

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -88,7 +88,7 @@ mono-config-dirs.lo: Makefile
 libmonoruntime_config_la_SOURCES = \
 	mono-config-dirs.h		\
 	mono-config-dirs.c
-libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\"
+libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\" -DMONO_RELOC_LIBDIR=\"../$(reloc_libdir)\"
 
 CLEANFILES = mono-bundle.stamp
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -558,6 +558,21 @@ mono_assembly_getrootdir (void)
 }
 
 /**
+ * mono_native_getrootdir:
+ * 
+ * Obtains the root directory used for looking up native libs (.so, .dylib).
+ *
+ * Returns: a string with the directory, this string should be freed by
+ * the caller.
+ */
+G_CONST_RETURN gchar *
+mono_native_getrootdir (void)
+{
+	gchar* fullpath = g_build_path (G_DIR_SEPARATOR_S, mono_assembly_getrootdir (), mono_config_get_reloc_lib_dir(), NULL);
+	return fullpath;
+}
+
+/**
  * mono_set_dirs:
  * @assembly_dir: the base directory for assemblies
  * @config_dir: the base directory for configuration files

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -36,6 +36,7 @@ MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32
 MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
 MONO_API void          mono_assembly_setrootdir (const char *root_dir);
 MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
+MONO_API MONO_CONST_RETURN char *mono_native_getrootdir (void);
 MONO_API void	      mono_assembly_foreach    (MonoFunc func, void* user_data);
 MONO_API void          mono_assembly_set_main   (MonoAssembly *assembly);
 MONO_API MonoAssembly *mono_assembly_get_main   (void);

--- a/mono/metadata/mono-config-dirs.c
+++ b/mono/metadata/mono-config-dirs.c
@@ -41,3 +41,13 @@ mono_config_get_bin_dir (void)
 #endif
 }
 
+const char*
+mono_config_get_reloc_lib_dir (void)
+{
+#ifdef MONO_RELOC_LIBDIR
+	return MONO_RELOC_LIBDIR;
+#else
+	return NULL;
+#endif
+}
+

--- a/mono/metadata/mono-config-dirs.h
+++ b/mono/metadata/mono-config-dirs.h
@@ -13,4 +13,7 @@ mono_config_get_cfg_dir (void);
 const char*
 mono_config_get_bin_dir (void);
 
+const char*
+mono_config_get_reloc_lib_dir (void);
+
 #endif

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -314,13 +314,14 @@ dllmap_start (gpointer user_data,
 			else if (strcmp (attribute_names [i], "target") == 0){
 				char *p = strstr (attribute_values [i], "$mono_libdir");
 				if (p != NULL){
-					const char *libdir = mono_assembly_getrootdir ();
+					const char *libdir = mono_native_getrootdir ();
 					size_t libdir_len = strlen (libdir);
 					char *result;
 					
 					result = (char *)g_malloc (libdir_len-strlen("$mono_libdir")+strlen(attribute_values[i])+1);
 					strncpy (result, attribute_values[i], p-attribute_values[i]);
 					strcpy (result+(p-attribute_values[i]), libdir);
+					g_free (libdir);
 					strcat (result, p+strlen("$mono_libdir"));
 					info->target = result;
 				} else 


### PR DESCRIPTION
Right now, we use a special token in mono/config which replaces `$mono_libdir` with the runtime-detected assemblies lib dir - e.g. `/usr/lib`

Unfortunately, this does not handle cases where a `--libdir=` value is passed to configure, such as on Red Hat where they use `--libdir=/usr/lib64` on AMD64

We already have a variable from configure - `reloc_libdir` - so introduce some helpers to use it in the `$mono_libdir` replacement.

This assumes the value of `--libdir` is a subdirectory of `--prefix`, but I doubt we have ever worked at all when that is not the case.

This change preserves relocation capability, but will look for the same relative path style in the relocated place, i.e. if you passed `--prefix=/opt/pony --libdir=/opt/pony/unicorns/are/pretty`, then the compiled `mono` binary will always replace `$mono_libdir` in a config file with `/mono_assembly_getrootdir()/../unicorns/are/pretty`

Fixes: #41953

This code is bad and wrong and probably leaky. Someone smarter than me should rewrite it. I am a bad C dev.