### PR TITLE
Fix NetworkInformation tests on Windows

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/IPAddressCollection.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/IPAddressCollection.cs
@@ -39,8 +39,6 @@ namespace System.Net.NetworkInformation {
 	{
 		public static readonly Win32IPAddressCollection Empty = new Win32IPAddressCollection (IntPtr.Zero);
 
-		bool is_readonly;
-
 		// for static methods
 		Win32IPAddressCollection ()
 		{
@@ -50,7 +48,6 @@ namespace System.Net.NetworkInformation {
 		{
 			foreach (IntPtr head in heads)
 				AddSubsequentlyString (head);
-			is_readonly = true;
 		}
 
 		public Win32IPAddressCollection (params Win32_IP_ADDR_STRING [] al)
@@ -58,10 +55,9 @@ namespace System.Net.NetworkInformation {
 			foreach (Win32_IP_ADDR_STRING a in al) {
 				if (String.IsNullOrEmpty (a.IpAddress))
 					continue;
-				Add (IPAddress.Parse (a.IpAddress));
+				InternalAdd (IPAddress.Parse (a.IpAddress));
 				AddSubsequentlyString (a.Next);
 			}
-			is_readonly = true;
 		}
 
 		public static Win32IPAddressCollection FromAnycast (IntPtr ptr)
@@ -70,9 +66,8 @@ namespace System.Net.NetworkInformation {
 			Win32_IP_ADAPTER_ANYCAST_ADDRESS a;
 			for (IntPtr p = ptr; p != IntPtr.Zero; p = a.Next) {
 				a = (Win32_IP_ADAPTER_ANYCAST_ADDRESS) Marshal.PtrToStructure (p, typeof (Win32_IP_ADAPTER_ANYCAST_ADDRESS));
-				c.Add (a.Address.GetIPAddress ());
+				c.InternalAdd (a.Address.GetIPAddress ());
 			}
-			c.is_readonly = true;
 			return c;
 		}
 
@@ -84,9 +79,8 @@ namespace System.Net.NetworkInformation {
 				a = (Win32_IP_ADAPTER_DNS_SERVER_ADDRESS) Marshal.PtrToStructure (p, typeof (Win32_IP_ADAPTER_DNS_SERVER_ADDRESS));
 // FIXME: It somehow fails here. Looks like there is something wrong.
 //if (a.Address.Sockaddr == IntPtr.Zero) throw new Exception ("pointer " + p + " a.length " + a.Address.SockaddrLength);
-				c.Add (a.Address.GetIPAddress ());
+				c.InternalAdd (a.Address.GetIPAddress ());
 			}
-			c.is_readonly = true;
 			return c;
 		}
 
@@ -95,12 +89,8 @@ namespace System.Net.NetworkInformation {
 			Win32_IP_ADDR_STRING a;
 			for (IntPtr p = head; p != IntPtr.Zero; p = a.Next) {
 				a = (Win32_IP_ADDR_STRING) Marshal.PtrToStructure (p, typeof (Win32_IP_ADDR_STRING));
-				Add (IPAddress.Parse (a.IpAddress));
+				InternalAdd (IPAddress.Parse (a.IpAddress));
 			}
-		}
-
-		public override bool IsReadOnly {
-			get { return is_readonly; }
 		}
 	}
 #endif

--- a/mcs/class/System/Test/System.Net.NetworkInformation/IPInterfacePropertiesTest.cs
+++ b/mcs/class/System/Test/System.Net.NetworkInformation/IPInterfacePropertiesTest.cs
@@ -113,6 +113,9 @@ namespace MonoTests.System.Net.NetworkInformation
 		[Test]
 		public void DnsEnabled ()
 		{
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				Assert.Ignore ("IsDnsEnabled is not nessasarily enabled for all interfaces on windows.");
+
 			NetworkInterface[] adapters = NetworkInterface.GetAllNetworkInterfaces ();
 			foreach (NetworkInterface adapter in adapters)
 			{


### PR DESCRIPTION
This PR includes the following fixes for NetworkInformation on Windows:

* Using InternalAdd to handle read only of IPAddressCollection
The read-only nature of `Win32IPAddressCollection` is handled by
the base class `IPAddressCollection`. Therefore removing the read-only
handling in this class and use InternalAdd from base class instead.
* Ignoring `IsDnsEnabled` test on Windows
* Implementation of GetLoopbackInterfaceIndex on Windows
