### PR TITLE
Send all data to a socket before exit from Socket.Send.

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -2464,6 +2464,7 @@ namespace System.Net.Sockets
 				if (error != SocketError.Success && error != SocketError.WouldBlock && error != SocketError.InProgress) {
 					is_connected = false;
 					is_bound = false;
+					break;
 				} else {
 					is_connected = true;
 				}

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -2600,6 +2600,67 @@ namespace MonoTests.System.Net.Sockets
 		}
 
 		[Test]
+		public void ConcurrentExceedSocketLimit ()
+		{
+			var tasks = new Task[4];
+			for (int i = 0; i < 4; i++) {
+				tasks[i] = Task.Factory.StartNew (() => SendGenericExceedBuffer ());
+			}
+			Task.WaitAll (tasks);
+		}
+
+		[Test]
+		public void SendGenericExceedBuffer ()
+		{
+			// Create a buffer larger than the default max.
+			const int BUFFER_SIZE = 256 * 256 * 65;
+			int i;
+
+			IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, NetworkHelpers.FindFreePort ());
+
+			Socket listensock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			listensock.Bind (endpoint);
+			listensock.Listen (1);
+
+			Socket sendsock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			sendsock.Connect (endpoint);
+
+			Socket clientsock = listensock.Accept ();
+
+			byte[] sendbuf = new byte[BUFFER_SIZE];
+
+			for (i = 0; i < BUFFER_SIZE; i++) {
+				sendbuf[i] = (byte)i;
+			}
+
+			SocketError err;
+			int sent = sendsock.Send (sendbuf);
+
+			Assert.AreEqual (BUFFER_SIZE, sent, "#1");
+
+			byte[] recvbuf = new byte[BUFFER_SIZE];
+
+			int totalReceived = 0;
+			byte[] buffer = new byte[256];
+			while (totalReceived < sendbuf.Length) {
+				int recvd = clientsock.Receive (buffer, 0, buffer.Length, SocketFlags.None);
+				buffer.CopyTo (recvbuf, totalReceived);
+				totalReceived += recvd;
+			}
+
+			Assert.AreEqual (BUFFER_SIZE, totalReceived, "#2");
+
+			for (i = 0; i < BUFFER_SIZE; i++) {
+				Assert.AreEqual (recvbuf[i], sendbuf[i],
+						 "#3/" + i.ToString());
+			}
+
+			sendsock.Close ();
+			clientsock.Close ();
+			listensock.Close ();
+		}
+
+		[Test]
 		public void ListenNotBound ()
 		{
 			Socket sock = new Socket (AddressFamily.InterNetwork,


### PR DESCRIPTION
Completely send data to a socket before exiting from Socket.Send.  This matches with the [behavior specified on MSDN](https://msdn.microsoft.com/en-us/library/4t14718h(v=vs.110).aspx):

> Send will block until the requested number of bytes are sent

This fix provides compatibility with the NetworkStream from [MS reference source](https://github.com/mono/mono/blob/d70777a3332af2d630d24adf620c2e548b92b56a/mcs/class/referencesource/System/net/System/Net/Sockets/NetworkStream.cs#L591).  The [prior mono version of NetworkStream](https://github.com/mono/mono/blob/mono-4.0.0-branch/mcs/class/System/System.Net.Sockets/NetworkStream.cs#L414) made up for Socket.Send by continuing to send data in a loop, but the reference source expects to Socket.Send to do this.

Released under MIT license.