### PR TITLE
[corlib] Displays correct aotid in stactraces

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -182,20 +182,6 @@ namespace System.Diagnostics {
 			return frames;
 		}
 
-		static bool isAotidSet;
-		static string aotid;
-		static string GetAotId ()
-		{
-			if (!isAotidSet) {
-				aotid = Assembly.GetAotId ();
-				if (aotid != null)
-					aotid = new Guid (aotid).ToString ("N");
-				isAotidSet = true;
-			}
-
-			return aotid;
-		}
-
 		bool AddFrames (StringBuilder sb)
 		{
 			string debugInfo, indentation;
@@ -234,8 +220,9 @@ namespace System.Diagnostics {
 
 					var filename = frame.GetSecureFileName ();
 					if (filename[0] == '<') {
-						var mvid = frame.GetMethod ().Module.ModuleVersionId.ToString ("N");
-						var aotid = GetAotId ();
+						var module = frame.GetMethod ().Module;
+						var mvid = module.ModuleVersionId.ToString ("N");
+						var aotid = module.GetAotId ().ToString ("N");
 						if (frame.GetILOffset () != -1 || aotid == null) {
 							filename = string.Format ("<{0}>", mvid);
 						} else {

--- a/mcs/class/corlib/System.Reflection/Assembly.cs
+++ b/mcs/class/corlib/System.Reflection/Assembly.cs
@@ -142,9 +142,6 @@ namespace System.Reflection {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern string InternalImageRuntimeVersion ();
 
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static internal extern string GetAotId ();
-
 		// SECURITY: this should be the only caller to icall get_code_base
 		private string GetCodeBase (bool escaped)
 		{

--- a/mcs/class/corlib/System.Reflection/Module.cs
+++ b/mcs/class/corlib/System.Reflection/Module.cs
@@ -85,6 +85,22 @@ namespace System.Reflection {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern int GetMDStreamVersion (IntPtr module_handle);
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		extern string GetAotIdInternal ();
+
+		bool isAotidSet;
+		Guid aotid;
+		internal Guid GetAotId ()
+		{
+			if (!isAotidSet) {
+				var aotidStr = GetAotIdInternal ();
+				aotid = aotidStr != null ? new Guid (aotidStr) : Guid.Empty;
+				isAotidSet = true;
+			}
+
+			return aotid;
+		}
+
 		public FieldInfo GetField (string name) 
 		{
 			return GetField (name, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 155;
+		private const int mono_corlib_version = 156;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -13,7 +13,7 @@ include ../../build/executable.make
 
 LIB_PATH = $(topdir)/class/lib/$(PROFILE)
 
-MONO = MONO_PATH="$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) -O=-inline
+MONO = MONO_PATH="$(OUT_DIR)$(PLATFORM_PATH_SEPARATOR)$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) -O=-inline
 
 MSYM_DIR = $(OUT_DIR)/msymdir
 TEST_CS = Test/StackTraceDumper.cs
@@ -65,6 +65,8 @@ ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
 	$(COMPILE)
+	cp -R $(LIB_PATH)/mscorlib.* $(OUT_DIR)
+	@$(MONO) --aot $(OUT_DIR)/mscorlib.dll > /dev/null
 	@$(MONO) --aot $(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
 endif
@@ -75,6 +77,8 @@ ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT (using .msym) in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
 	$(COMPILE)
+	cp -R $(LIB_PATH)/mscorlib.* $(OUT_DIR)
+	@$(MONO) --aot=msym-dir=$(MSYM_DIR) $(OUT_DIR)/mscorlib.dll > /dev/null
 	@$(MONO) --aot=msym-dir=$(MSYM_DIR) $(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
 endif

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -84,7 +84,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 155
+#define MONO_CORLIB_VERSION 156
 
 typedef struct
 {

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -493,8 +493,7 @@ ICALL(OBJ_1, "GetType", ves_icall_System_Object_GetType)
 ICALL(OBJ_2, "InternalGetHashCode", mono_object_hash)
 ICALL(OBJ_3, "MemberwiseClone", ves_icall_System_Object_MemberwiseClone)
 
-ICALL_TYPE(ASSEM, "System.Reflection.Assembly", ASSEM_1a)
-HANDLES(ICALL(ASSEM_1a, "GetAotId", ves_icall_System_Reflection_Assembly_GetAotId))
+ICALL_TYPE(ASSEM, "System.Reflection.Assembly", ASSEM_2)
 ICALL(ASSEM_2, "GetCallingAssembly", ves_icall_System_Reflection_Assembly_GetCallingAssembly)
 ICALL(ASSEM_3, "GetEntryAssembly", ves_icall_System_Reflection_Assembly_GetEntryAssembly)
 ICALL(ASSEM_4, "GetExecutingAssembly", ves_icall_System_Reflection_Assembly_GetExecutingAssembly)
@@ -596,6 +595,7 @@ ICALL(MBASE_4, "GetMethodFromHandleInternalType_native", ves_icall_System_Reflec
 
 ICALL_TYPE(MODULE, "System.Reflection.Module", MODULE_1)
 ICALL(MODULE_1, "Close", ves_icall_System_Reflection_Module_Close)
+HANDLES(ICALL(MODULE_1a, "GetAotIdInternal", ves_icall_System_Reflection_Module_GetAotIdInternal))
 ICALL(MODULE_2, "GetGlobalType", ves_icall_System_Reflection_Module_GetGlobalType)
 HANDLES(ICALL(MODULE_3, "GetGuidInternal", ves_icall_System_Reflection_Module_GetGuidInternal))
 ICALL(MODULE_14, "GetHINSTANCE", ves_icall_System_Reflection_Module_GetHINSTANCE)


### PR DESCRIPTION
 Stacktraces were displaying always the entrypoint module aotid.

Fixes mono-symbolicate not working with aot compiled assemblies other
than the entry one.
