### PR TITLE
Use the correct function signature for MonoThreadStart consistently.

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -882,7 +882,7 @@ finalize_domain_objects (void)
 	}
 }
 
-static guint32
+static guint32 WINAPI
 finalizer_thread (gpointer unused)
 {
 	MonoError error;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4557,6 +4557,22 @@ mono_unhandled_exception (MonoObject *exc)
 	}
 }
 
+struct exec_managed_args {
+	MonoMainThreadFunc main_func;
+	gpointer main_args;
+};
+
+static gsize WINAPI
+exec_managed_thread (void *args)
+{
+	struct exec_managed_args exec_args = *(struct exec_managed_args*)args;
+
+	g_free (args);
+	exec_args.main_func (exec_args.main_args);
+
+	return 0;
+}
+
 /**
  * mono_runtime_exec_managed_code:
  * @domain: Application domain
@@ -4579,7 +4595,13 @@ mono_runtime_exec_managed_code (MonoDomain *domain,
 				gpointer main_args)
 {
 	MonoError error;
-	mono_thread_create_checked (domain, main_func, main_args, &error);
+	struct exec_managed_args *exec_args;
+
+	exec_args = g_malloc (sizeof (*exec_args));
+	exec_args->main_func = main_func;
+	exec_args->main_args = main_args;
+
+	mono_thread_create_checked (domain, exec_managed_thread, exec_args, &error);
 	mono_error_assert_ok (&error);
 
 	mono_thread_manage ();

--- a/mono/metadata/threadpool-ms-io.c
+++ b/mono/metadata/threadpool-ms-io.c
@@ -305,7 +305,7 @@ wait_callback (gint fd, gint events, gpointer user_data)
 	}
 }
 
-static void
+static gsize WINAPI
 selector_thread (gpointer data)
 {
 	MonoError error;
@@ -315,7 +315,7 @@ selector_thread (gpointer data)
 
 	if (mono_runtime_is_shutting_down ()) {
 		io_selector_running = FALSE;
-		return;
+		return 0;
 	}
 
 	states = mono_g_hash_table_new_type (g_direct_hash, g_direct_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_THREAD_POOL, "i/o thread pool states table");
@@ -430,6 +430,8 @@ selector_thread (gpointer data)
 	mono_g_hash_table_destroy (states);
 
 	io_selector_running = FALSE;
+
+	return 0;
 }
 
 /* Locking: threadpool_io->updates_lock must be held */

--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -590,7 +590,7 @@ worker_kill (ThreadPoolWorkingThread *thread)
 	mono_thread_internal_stop ((MonoInternalThread*) thread);
 }
 
-static void
+static gsize WINAPI
 worker_thread (gpointer data)
 {
 	MonoError error;
@@ -731,6 +731,8 @@ worker_thread (gpointer data)
 	});
 
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_THREADPOOL, "[%p] worker finishing", mono_native_thread_id_get ());
+
+	return 0;
 }
 
 static gboolean

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -731,7 +731,7 @@ free_jit_info_data (ThreadData *td, JitInfoData *free)
 #define MODE_ALLOC	1
 #define MODE_FREE	2
 
-static void
+static gsize WINAPI
 test_thread_func (ThreadData *td)
 {
 	int mode = MODE_ALLOC;
@@ -833,10 +833,12 @@ test_thread_func (ThreadData *td)
 		else if (td->num_datas > 2000)
 			mode = MODE_FREE;
 	}
+
+	return 0;
 }
 
 /*
-static void
+static gsize WINAPI
 small_id_thread_func (gpointer arg)
 {
 	MonoThread *thread = mono_thread_current ();
@@ -846,6 +848,7 @@ small_id_thread_func (gpointer arg)
 	mono_hazard_pointer_clear (hp, 1);
 	sleep (3);
 	g_print ("done %d\n", (int)thread->small_id);
+	return 0;
 }
 */
 
@@ -966,12 +969,13 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 		exit (1);
 }
 
-static void
+static gsize WINAPI
 compile_all_methods_thread_main (CompileAllThreadArgs *args)
 {
 	guint32 i;
 	for (i = 0; i < args->recompilation_times; ++i)
 		compile_all_methods_thread_main_inner (args);
+	return 0;
 }
 
 static void

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -32,8 +32,6 @@ typedef DWORD mono_native_thread_return_t;
 #define MONO_NATIVE_THREAD_ID_TO_UINT(tid) (tid)
 #define MONO_UINT_TO_NATIVE_THREAD_ID(tid) ((MonoNativeThreadId)(tid))
 
-typedef LPTHREAD_START_ROUTINE MonoThreadStart;
-
 #else
 
 #include <pthread.h>
@@ -58,9 +56,9 @@ typedef void* mono_native_thread_return_t;
 #define MONO_NATIVE_THREAD_ID_TO_UINT(tid) (gsize)(tid)
 #define MONO_UINT_TO_NATIVE_THREAD_ID(tid) (MonoNativeThreadId)(gsize)(tid)
 
-typedef gsize (*MonoThreadStart)(gpointer);
-
 #endif /* #ifdef HOST_WIN32 */
+
+typedef gsize (WINAPI *MonoThreadStart)(gpointer);
 
 /*
 THREAD_INFO_TYPE is a way to make the mono-threads module parametric - or sort of.


### PR DESCRIPTION
Trying to use a cdecl function when stdcall is expected can crash on x86 Windows when the function returns.
