### PR TITLE
[corlib] Add API to uninstall/reinstall signal handlers.

### DIFF
--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -40,10 +40,25 @@ namespace Mono {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private static extern void mono_runtime_install_handlers ();
 
-		static internal void InstallSignalHandlers ()
+#if MOBILE
+		public
+#else
+		internal
+#endif
+		static void InstallSignalHandlers ()
 		{
 			mono_runtime_install_handlers ();
 		}
+
+#if MOBILE
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern void mono_runtime_cleanup_handlers ();
+
+		public static void RemoveSignalHandlers ()
+		{
+			mono_runtime_cleanup_handlers ();
+		}
+#endif
 
 		// Should not be removed intended for external use
 		// Safe to be called using reflection

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -167,21 +167,14 @@ save_old_signal_handler (int signo, struct sigaction *old_action)
 	handler_to_save->sa_flags = old_action->sa_flags;
 	
 	if (!mono_saved_signal_handlers)
-		mono_saved_signal_handlers = g_hash_table_new (NULL, NULL);
+		mono_saved_signal_handlers = g_hash_table_new_full (NULL, NULL, NULL, g_free);
 	g_hash_table_insert (mono_saved_signal_handlers, GINT_TO_POINTER (signo), handler_to_save);
-}
-
-static void
-free_saved_sig_handler_func (gpointer key, gpointer value, gpointer user_data)
-{
-	g_free (value);
 }
 
 static void
 free_saved_signal_handlers (void)
 {
 	if (mono_saved_signal_handlers) {
-		g_hash_table_foreach (mono_saved_signal_handlers, free_saved_sig_handler_func, NULL);
 		g_hash_table_destroy (mono_saved_signal_handlers);
 		mono_saved_signal_handlers = NULL;
 	}

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3742,6 +3742,8 @@ register_icalls (void)
 				ves_icall_get_trace);
 	mono_add_internal_call ("Mono.Runtime::mono_runtime_install_handlers",
 				mono_runtime_install_handlers);
+	mono_add_internal_call ("Mono.Runtime::mono_runtime_cleanup_handlers",
+				mono_runtime_cleanup_handlers);
 
 #if defined(PLATFORM_ANDROID) || defined(TARGET_ANDROID)
 	mono_add_internal_call ("System.Diagnostics.Debugger::Mono_UnhandledException_internal",


### PR DESCRIPTION
This API is provided to be used by libraries providing crash reporting, so
that those libraries can install signal handlers and at the same time not
interfere with Mono's signals.

The intended pattern is this:

    Mono.Runtime.RemoveSignalHandlers ();
    InstallThirdPartySignalHandlers ();
    Mono.Runtime.InstallSignalHandlers ();

This ensures that Mono is always notified first of any signals, and will then
chain to the third-party signal handlers if the signal did not originate in
managed code.

Mono's signals must first be removed, so that if third-party signal handler
does signal chaining, we don't end up in Mono's signal handler again.

Mailing-list thread: http://lists.dot.net/pipermail/macios-devel/2016-September/000016.html [Signal-chaining & crash reporters]
Example usage: https://github.com/rolfbjarne/HockeySDK-Xamarin/commit/862721199f1adec210bfc7b1943f975ffb8048a9