### PR TITLE
Fix 16628

### DIFF
--- a/mcs/ilasm/parser/ILParser.jay
+++ b/mcs/ilasm/parser/ILParser.jay
@@ -3276,13 +3276,13 @@ exptype_head		: D_CLASS K_EXTERN expt_attr comp_name
 expt_attr 		: { $$ = 0; } /* EMPTY */
 			| expt_attr K_PRIVATE                   { $$ = (TypeAttr)$1 | TypeAttr.Private; }
 			| expt_attr K_PUBLIC                    { $$ = (TypeAttr)$1 | TypeAttr.Public; }
+			| expt_attr K_FORWARDER                 { $$ = (TypeAttr)$1 | TypeAttr.Forwarder; }
 			| expt_attr K_NESTED K_PUBLIC           { $$ = (TypeAttr)$1 | TypeAttr.NestedPublic; }
 			| expt_attr K_NESTED K_PRIVATE          { $$ = (TypeAttr)$1 | TypeAttr.NestedPrivate; }
 			| expt_attr K_NESTED K_FAMILY           { $$ = (TypeAttr)$1 | TypeAttr.NestedFamily; }
 			| expt_attr K_NESTED K_ASSEMBLY         { $$ = (TypeAttr)$1 | TypeAttr.NestedAssembly;}
 			| expt_attr K_NESTED K_FAMANDASSEM      { $$ = (TypeAttr)$1 | TypeAttr.NestedFamAndAssem; }
 			| expt_attr K_NESTED K_FAMORASSEM       { $$ = (TypeAttr)$1 | TypeAttr.NestedFamOrAssem; }
-			| K_FORWARDER                           { $$ = TypeAttr.Forwarder; }
 			;
 
 exptype_decls		: /* EMPTY */

--- a/mcs/tests/test-16628-lib.il
+++ b/mcs/tests/test-16628-lib.il
@@ -1,0 +1,33 @@
+.assembly bz16628.typeforwarder2 {}
+.assembly extern mscorlib {}
+.assembly extern bz16628.typeforwardee2 {}
+
+.class extern public forwarder NSwForwardee2.Foo_SPECIAL{
+	.assembly extern bz16628.typeforwardee2
+}
+
+.class public auto ansi beforefieldinit NSwForwardee2.Bar_SPECIAL
+       extends [mscorlib]System.Object
+{
+  .field public static int32 A
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Foo::.ctor
+
+  .method private hidebysig specialname rtspecialname static 
+          void  .cctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldc.i4.s   320
+    IL_0002:  stsfld     int32 NSwForwardee2.Bar_SPECIAL::A
+    IL_0007:  ret
+  } // end of method Foo::.cctor
+} 
+


### PR DESCRIPTION
This changes the IL parser to have the same behavior as ilasm.exe from
MS

https://bugzilla.xamarin.com/show_bug.cgi?id=16628