### PR TITLE
[AppleTls]: Flush the write queue before finishing the handshake.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -660,6 +660,7 @@ namespace Mono.Net.Security
 			if (wantMore || writeBuffer.Size > 0)
 				return AsyncOperationStatus.WantWrite;
 
+			asyncRequest.ResetWrite ();
 			asyncRequest.UserResult = asyncRequest.CurrentSize;
 			return AsyncOperationStatus.Complete;
 		}


### PR DESCRIPTION
It is possible for SSLHandshake() to return SslStatus.Success while we're still
having a pending write (AsyncOperationStatus.WantWrite).

This is because our managed write callback must never return 'WouldBlock', so
SSLHandshake() things that all data have been sent while we still have them in
our write queue.

When this happens, we currently flush the write queue then call SSLHandshake()
again via AsyncOperationStatus.WantWrite -> AsyncOperationStatus.Continue.

This returns SslStatus.Protocol on iOS 10.