### PR TITLE
[runtime] Fix MonoMethod.get_base_method when abstract methods are not overridden

### DIFF
--- a/mcs/class/corlib/Test/System/AttributeTest.cs
+++ b/mcs/class/corlib/Test/System/AttributeTest.cs
@@ -903,7 +903,13 @@ namespace MonoTests.System
 			Assert.AreEqual (1, res.Length, "#1");
 		}
 
-		abstract class Abs
+		abstract class Root
+		{
+			[MyAttribute]
+			public abstract void Foo ();
+		}
+
+		abstract class Abs : Root
 		{
 			public abstract string Name { get; set; }
 		}
@@ -915,6 +921,8 @@ namespace MonoTests.System
 				get { return ""; }
 				set {}
 			}
+
+			public override void Foo () { }
 		}
 		
 		class Sub: Base
@@ -1030,6 +1038,27 @@ namespace MonoTests.System
 			//check for not throwing stack overflow exception
 			AttributeWithTypeId a = new AttributeWithTypeId ();
 			a.GetHashCode ();
+		}
+
+
+		[Test]
+		public void DerivedClassOverrideHasInhertedAttributeFromAbstractRoot ()
+		{
+			// regression test for #44010
+			// we have
+			// abstract class Root {
+			//   [MyAttribute]
+			//   public abstract void Foo ();
+			// }
+			// abstract class Abs : Root { }
+			// class Base : Abs {
+			//   public override void  Foo () { }
+			// }
+			// note that Abs does not itself override Foo.
+			var bt = typeof(Base);
+			var m = bt.GetMethod ("Foo");
+			var attribute = Attribute.GetCustomAttribute (m, typeof (MyAttribute), true);
+			Assert.IsNotNull (attribute);
 		}
 
 		class ArrayAttribute : Attribute


### PR DESCRIPTION
When there is an abstract class in the middle of an inheritance
hierarchy that doesn't override a method, get_base_methods needs to search
the parent class instead aborting early.

Example:

```
abstract class Root {
  public abstract void Foo ();
}
abstract class Abs : Root { }
class Derived : Abs {
  public override void Foo () { }
}
```

If we ask for the base method of Derived.Foo we used to get Derived.Foo
back because Abs did not provide an override.  Instead we should skip
abs and look in Root.

Fixes [#44010](https://bugzilla.xamarin.com/show_bug.cgi?id=44010)