### PR TITLE
Fix issue with VB projects

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Vbc.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/Vbc.cs
@@ -153,7 +153,10 @@ namespace Microsoft.Build.Tasks {
 		{
 			if (!string.IsNullOrEmpty (ToolPath))
 				return Path.Combine (ToolPath, ToolExe);
-			return ToolLocationHelper.GetPathToDotNetFrameworkFile (ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
+			var possibleToolPath = ToolLocationHelper.GetPathToDotNetFrameworkFile (ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
+			if (!string.IsNullOrEmpty(possibleToolPath))
+				return  possibleToolPath;
+			return ToolLocationHelper.GetPathToDotNetFrameworkBinFile(ToolExe); 
 		}
 		
 		[MonoTODO]

--- a/mcs/tools/xbuild/tests/Vbc/1.vbproj
+++ b/mcs/tools/xbuild/tests/Vbc/1.vbproj
@@ -1,0 +1,22 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
+	
+	<ItemGroup>
+		<Input Include="test.vb" />
+		<Output Include="test.exe" />
+	</ItemGroup>
+	
+	<Target Name="Compile1" >
+		<Vbc
+			Sources="@(Input)"
+                        OutputAssembly="@(Output)"
+		/>
+	</Target>
+	
+	<Target Name="Clean" >
+		<Delete Files="@(Output)" />
+	</Target>
+	
+	<Target Name="Execute" >
+		<Exec Command="@(Output)" />
+	</Target>
+</Project>

--- a/mcs/tools/xbuild/tests/Vbc/2.vbproj
+++ b/mcs/tools/xbuild/tests/Vbc/2.vbproj
@@ -1,0 +1,13 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTarget="Build">
+	
+	<ItemGroup>
+		<Input Include="test.vb" />
+		<Output Include="test.exe" />
+	</ItemGroup>
+	
+	<Target Name="Build" >
+		<Vbc
+			Sources="@(Input)"
+		/>
+	</Target>
+</Project>

--- a/mcs/tools/xbuild/tests/Vbc/test.vb
+++ b/mcs/tools/xbuild/tests/Vbc/test.vb
@@ -1,0 +1,7 @@
+Imports System
+
+Public Module mainmod
+  Sub Main()
+    Console.WriteLine("Hello, world!")
+  End sub
+End Module


### PR DESCRIPTION
Fixed GenerateFullPathToTool for Vbc task to match behavior of the Csc
task. This allows VB.NET projects to build successfully.

See https://bugzilla.xamarin.com/show_bug.cgi?id=44714