### PR TITLE
[runtime] Make a copy of the wrapper date when instantiating generic …

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1350,6 +1350,12 @@ mono_class_get_generic_container (MonoClass *klass);
 MonoGenericClass*
 mono_class_get_generic_class (MonoClass *klass);
 
+gpointer
+mono_class_alloc (MonoClass *klass, int size);
+
+gpointer
+mono_class_alloc0 (MonoClass *klass, int size);
+
 void
 mono_class_alloc_ext (MonoClass *klass);
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1132,6 +1132,15 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 	result->sre_method = FALSE;
 	result->signature = NULL;
 
+	if (method->wrapper_type) {
+		MonoMethodWrapper *mw = (MonoMethodWrapper*)method;
+		MonoMethodWrapper *resw = (MonoMethodWrapper*)result;
+		int len = GPOINTER_TO_INT (((void**)mw->method_data) [0]);
+
+		resw->method_data = (void **)g_malloc (sizeof (gpointer) * (len + 1));
+		memcpy (resw->method_data, mw->method_data, sizeof (gpointer) * (len + 1));
+	}
+
 	if (iresult->context.method_inst) {
 		/* Set the generic_container of the result to the generic_container of method */
 		MonoGenericContainer *generic_container = mono_method_get_generic_container (method);
@@ -1424,7 +1433,7 @@ mono_error_set_for_class_failure (MonoError *oerror, MonoClass *klass)
  *   Allocate memory for some data belonging to CLASS, either from its image's mempool,
  * or from the heap.
  */
-static gpointer
+gpointer
 mono_class_alloc (MonoClass *klass, int size)
 {
 	if (klass->generic_class)
@@ -1433,7 +1442,7 @@ mono_class_alloc (MonoClass *klass, int size)
 		return mono_image_alloc (klass->image, size);
 }
 
-static gpointer
+gpointer
 mono_class_alloc0 (MonoClass *klass, int size)
 {
 	gpointer res;

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2141,8 +2141,6 @@ mono_method_get_wrapper_data (MonoMethod *method, guint32 id)
 	g_assert (method != NULL);
 	g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
 
-	if (method->is_inflated)
-		method = ((MonoMethodInflated *) method)->declaring;
 	data = (void **)((MonoMethodWrapper *)method)->method_data;
 	g_assert (data != NULL);
 	g_assert (id <= GPOINTER_TO_UINT (*data));

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2789,6 +2789,9 @@ free_inflated_method (MonoMethodInflated *imethod)
 	if (method->signature)
 		mono_metadata_free_inflated_signature (method->signature);
 
+	if (method->wrapper_type)
+		g_free (((MonoMethodWrapper*)method)->method_data);
+
 	g_free (method);
 }
 


### PR DESCRIPTION
…wrapper methods, to be able to store a different WrapperInfo for them.