### PR TITLE
Cherry-picking PR #3636

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/CertificateValidationHelper.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/CertificateValidationHelper.cs
@@ -148,17 +148,23 @@ namespace Mono.Security.Interface
 		/*
 		 * Internal API, intended to be used by MonoTlsProvider implementations.
 		 */
+		internal static ICertificateValidator2 GetInternalValidator (MonoTlsSettings settings, MonoTlsProvider provider)
+		{
+			return (ICertificateValidator2)NoReflectionHelper.GetInternalValidator (provider, settings);
+		}
+
+		[Obsolete ("Use GetInternalValidator")]
 		internal static ICertificateValidator2 GetDefaultValidator (MonoTlsSettings settings, MonoTlsProvider provider)
 		{
-			return (ICertificateValidator2)NoReflectionHelper.GetDefaultCertificateValidator (provider, settings);
+			GetInternalValidator (settings, provider);
 		}
 
 		/*
 		 * Use this overloaded version in user code.
 		 */
-		public static ICertificateValidator GetValidator (MonoTlsSettings settings, MonoTlsProvider provider = null)
+		public static ICertificateValidator GetValidator (MonoTlsSettings settings)
 		{
-			return GetDefaultValidator (settings, provider);
+			return (ICertificateValidator)NoReflectionHelper.GetDefaultValidator (settings);
 		}
 	}
 }

--- a/mcs/class/System/Mono.Net.Security/ChainValidationHelper.cs
+++ b/mcs/class/System/Mono.Net.Security/ChainValidationHelper.cs
@@ -77,12 +77,22 @@ namespace Mono.Net.Security
 		readonly MonoTlsStream tlsStream;
 		readonly HttpWebRequest request;
 
-		internal static ICertificateValidator GetDefaultValidator (MonoTlsProvider provider, MonoTlsSettings settings)
+		internal static ICertificateValidator GetInternalValidator (MonoTlsProvider provider, MonoTlsSettings settings)
 		{
 			if (settings == null)
 				return new ChainValidationHelper (provider, null, false, null, null);
 			if (settings.CertificateValidator != null)
 				return settings.CertificateValidator;
+			return new ChainValidationHelper (provider, settings, false, null, null);
+		}
+
+		internal static ICertificateValidator GetDefaultValidator (MonoTlsSettings settings)
+		{
+			var provider = MonoTlsProviderFactory.GetProvider ();
+			if (settings == null)
+				return new ChainValidationHelper (provider, null, false, null, null);
+			if (settings.CertificateValidator != null)
+				throw new NotSupportedException ();
 			return new ChainValidationHelper (provider, settings, false, null, null);
 		}
 
@@ -138,6 +148,8 @@ namespace Mono.Net.Security
 				settings = MonoTlsSettings.CopyDefaultSettings ();
 			if (cloneSettings)
 				settings = settings.CloneWithValidator (this);
+			if (provider == null)
+				provider = MonoTlsProviderFactory.GetProvider ();
 
 			this.provider = provider;
 			this.settings = settings;

--- a/mcs/class/System/Mono.Net.Security/LegacySslStream.cs
+++ b/mcs/class/System/Mono.Net.Security/LegacySslStream.cs
@@ -91,7 +91,7 @@ namespace Mono.Net.Security.Private
 			: base (innerStream, leaveInnerStreamOpen)
 		{
 			this.provider = provider;
-			certificateValidator = ChainValidationHelper.GetDefaultValidator (provider, settings);
+			certificateValidator = ChainValidationHelper.GetInternalValidator (provider, settings);
 		}
 		#endregion // Constructors
 

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -54,7 +54,7 @@ namespace Mono.Net.Security
 			this.clientCertificates = clientCertificates;
 			this.askForClientCert = askForClientCert;
 
-			certificateValidator = CertificateValidationHelper.GetDefaultValidator (
+			certificateValidator = CertificateValidationHelper.GetInternalValidator (
 				parent.Settings, parent.Provider);
 		}
 


### PR DESCRIPTION
This is https://github.com/mono/mono/pull/3636 against mono-4.8.0-branch.

[Mono.Security]: Cleanup CertificateValidationHelper.

* CertificateValidationHelper.GetDefaultValidator(): rename this internal method into
  GetInternalValidator() (keeping the old as [Obsolete] until products have been updated).

* CertificateValidationHelper.GetValidator(): remove the 'provider' argument.

This is part of a set of cleanups and simplifications for the upcoming BTLS integration.

(cherry picked from commit d3cdcdf426a127e9515187f4f93d7a64c95931d7)