### PR TITLE
[MonoError] Don't overwrite computed TypeLoadException message with empty string

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1404,7 +1404,7 @@ ves_icall_System_Type_internal_from_name (MonoString *name,
 
 	if (type == NULL){
 		if (throwOnError) {
-			mono_error_set_type_load_name (&error, g_strdup (str), NULL, "");
+			mono_error_set_type_load_name (&error, g_strdup (str), g_strdup (""), "");
 			goto leave;
 		}
 	}

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -618,7 +618,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 			}
 
 			exception = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System", "TypeLoadException", type_name, assembly_name, error_out);
-			if (exception)
+			if (exception && error->full_message != NULL && strcmp (error->full_message, ""))
 				set_message_on_exception (exception, error, error_out);
 		} else {
 			exception = mono_exception_from_name_msg (mono_defaults.corlib, "System", "TypeLoadException", error->full_message);


### PR DESCRIPTION
Fixes [#44729](https://bugzilla.xamarin.com/show_bug.cgi?id=44729).