### PR TITLE
Cherry-picking PR #3649 into master.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProviderFactory.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProviderFactory.cs
@@ -39,7 +39,37 @@ namespace Mono.Security.Interface
 	public static partial class MonoTlsProviderFactory
 	{
 		/*
-		 * Returns the currently installed @MonoTlsProvider, falling back to the default one.
+		 * TLS Provider Initialization
+		 * ===========================
+		 * 
+		 * The "global" TLS Provider (returned by GetProvider()) may only be modified at
+		 * application startup (before any of the TLS / Certificate code has been used).
+		 * 
+		 * On mobile, the default provider is specified at compile time using a property
+		 * in the .csproj file (which can be set from the IDE).  When using the linker, all
+		 * other providers will be linked-out, so you won't be able to choose a different
+		 * provider at run-time.
+		 * 
+		 * On desktop, the default provider can be specified with the MONO_TLS_PROVIDER
+		 * environment variable.  The following options are currently supported:
+		 * 
+		 *    "default" - let Mono pick the best one for you (recommended)
+		 *    "old" or "legacy" - Mono's old managed TLS implementation
+		 *    "appletls" (currently XamMac only, set via .csproj property)
+		 *    "btls" - the new boringssl based provider (coming soon).
+		 * 
+		 * On all platforms (except mobile with linker), you can call
+		 * 
+		 *     MonoTlsProviderFactory.Initialize(string)
+		 * 
+		 * to use a different provider.
+		 * 
+		 */
+
+		#region Provider Initialization
+
+		/*
+		 * Returns the global @MonoTlsProvider, initializing the TLS Subsystem if necessary.
 		 *
 		 * This method throws @NotSupportedException if no TLS Provider can be found.
 		 */
@@ -49,42 +79,64 @@ namespace Mono.Security.Interface
 		}
 
 		/*
-		 * Returns the default @MonoTlsProvider.
-		 *
-		 * This method throws @NotSupportedException if no TLS Provider can be found.
+		 * Check whether the TLS Subsystem is initialized.
 		 */
-		public static MonoTlsProvider GetDefaultProvider ()
-		{
-			return (MonoTlsProvider)NoReflectionHelper.GetDefaultProvider ();
-		}
-
-		/*
-		 * GetProvider() attempts to load and install the default provider and throws on error.
-		 *
-		 * This property checks whether a provider has previously been installed by a call
-		 * to either GetProvider() or InstallProvider().
-		 *
-		 */
-		public static bool HasProvider {
+		public static bool IsInitialized {
 			get {
-				return NoReflectionHelper.HasProvider;
+				return NoReflectionHelper.IsInitialized;
 			}
 		}
 
 		/*
-		 * Selects the default TLS Provider.
-		 *
-		 * May only be called at application startup and will throw
-		 * @InvalidOperationException if a provider has already been installed.
+		 * Initialize the TLS Subsystem.
+		 * 
+		 * This method may be called at any time.  It ensures that the TLS Subsystem is
+		 * initialized and a provider available.
 		 */
-		public static void SetDefaultProvider (string name)
+		public static void Initialize ()
 		{
-			NoReflectionHelper.SetDefaultProvider (name);
+			NoReflectionHelper.Initialize ();
 		}
 
-		public static MonoTlsProvider GetProvider (string name)
+		/*
+		 * Initialize the TLS Subsystem with a specific provider.
+		 * 
+		 * May only be called at application startup (before any of the TLS / Certificate
+		 * APIs have been used).
+		 * 
+		 * Throws @NotSupportedException if the TLS Subsystem is already initialized
+		 * (@IsInitialized returns true) or the requested provider is not supported.
+		 * 
+		 * On mobile, this will always throw @NotSupportedException when using the linker.
+		 */
+		public static void Initialize (string provider)
 		{
-			return (MonoTlsProvider)NoReflectionHelper.GetProvider (name);
+			NoReflectionHelper.Initialize (provider);
+		}
+
+		/*
+		 * Checks whether @provider is supported.
+		 *
+		 * On mobile, this will always return false when using the linker.
+		 */
+		public static bool IsProviderSupported (string provider)
+		{
+			return NoReflectionHelper.IsProviderSupported (provider);
+		}
+
+		#endregion
+
+		#region Call-by-call selection
+
+		/*
+		 * Returns the requested TLS Provider, for use with the call-by-call APIs below.
+		 * 
+		 * Throw @NotSupportedException if the requested provider is not supported or
+		 * when using the linker on mobile.
+		 */
+		public static MonoTlsProvider GetProvider (string provider)
+		{
+			return (MonoTlsProvider)NoReflectionHelper.GetProvider (provider);
 		}
 
 		/*
@@ -108,6 +160,24 @@ namespace Mono.Security.Interface
 		{
 			return (IMonoSslStream)NoReflectionHelper.GetMonoSslStream (stream);
 		}
+
+		#endregion
+
+		#region Obsolete APIs
+
+		[Obsolete]
+		public static MonoTlsProvider GetDefaultProvider ()
+		{
+			return GetProvider ();
+		}
+
+		[Obsolete]
+		public static void SetDefaultProvider (string name)
+		{
+			Initialize (name);
+		}
+
+		#endregion
 	}
 }
 

--- a/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
+++ b/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
@@ -74,29 +74,29 @@ namespace Mono.Net.Security
 			#endif
 		}
 
-		internal static object GetDefaultProvider ()
-		{
-			#if SECURITY_DEP
-			return MonoTlsProviderFactory.GetDefaultProvider ();
-			#else
-			throw new NotSupportedException ();
-			#endif
-		}
-
-		internal static bool HasProvider {
+		internal static bool IsInitialized {
 			get {
 				#if SECURITY_DEP
-				return MonoTlsProviderFactory.HasProvider;
+				return MonoTlsProviderFactory.IsInitialized;
 				#else
 				throw new NotSupportedException ();
 				#endif
 			}
 		}
 
-		internal static void SetDefaultProvider (string name)
+		internal static void Initialize ()
 		{
 			#if SECURITY_DEP
-			MonoTlsProviderFactory.SetDefaultProvider (name);
+			MonoTlsProviderFactory.Initialize ();
+			#else
+			throw new NotSupportedException ();
+			#endif
+		}
+
+		internal static void Initialize (string provider)
+		{
+			#if SECURITY_DEP
+			MonoTlsProviderFactory.Initialize (provider);
 			#else
 			throw new NotSupportedException ();
 			#endif
@@ -124,6 +124,15 @@ namespace Mono.Net.Security
 		{
 			#if SECURITY_DEP
 			return stream.Impl;
+			#else
+			throw new NotSupportedException ();
+			#endif
+		}
+
+		internal static bool IsProviderSupported (string name)
+		{
+			#if SECURITY_DEP
+			return MonoTlsProviderFactory.IsProviderSupported (name);
 			#else
 			throw new NotSupportedException ();
 			#endif


### PR DESCRIPTION
Cherry-picking https://github.com/mono/mono/pull/3649 into master.

[Mono.Security.Interface] Cleanup and simplify MonoTlsProviderFactory.

The "global" TLS Provider (returned by MonoTlsProviderFactory.GetProvider())
may only be modified at application startup (before any of the TLS / Certificate
code has been used).

* MonoTlsProviderFactory.HasProvider has been removed.

  This property used to initialize the TLS Subsystem without throwing any
  exceptions.  However, properties with side-effects is a bad design principle.

* Add MonoTlsProviderFactory.IsInitialized.

  Does not have any side-effects.

* Add MonoTlsProviderFactory.Initialize() and Initialize(string).

  May only be called at application startup and explicitly initializes the
  TLS Subsystem.

* Rename MonoTlsProviderFactory.GetDefaultProvider() into GetProvider()
  and removed MonoTlsProviderFactory.GetCurrentProvider().

  We do not distinguish between a "default" and a "current" provider anymore;
  there is only one "global" provider.

* Add MonoTlsProviderFactory.IsProviderSupported(string).

  Checks whether a specific TLS Provider is supported, without having side-effects.

* Make the old APIs [Obsolete] until products have been updated.

* Add some documentation to MonoTlsProviderFactory.

(cherry picked from commit 7b1d13cbe1581bee07106bea92342355612a7646)