### PR TITLE
[C9][runtime] Fix MonoMethod.get_base_method when abstract methods are not overridden

### DIFF
--- a/mcs/class/corlib/Test/System/AttributeTest.cs
+++ b/mcs/class/corlib/Test/System/AttributeTest.cs
@@ -903,7 +903,13 @@ namespace MonoTests.System
 			Assert.AreEqual (1, res.Length, "#1");
 		}
 
-		abstract class Abs
+		abstract class Root
+		{
+			[MyAttribute]
+			public abstract void Foo ();
+		}
+
+		abstract class Abs : Root
 		{
 			public abstract string Name { get; set; }
 		}
@@ -915,6 +921,8 @@ namespace MonoTests.System
 				get { return ""; }
 				set {}
 			}
+
+			public override void Foo () { }
 		}
 		
 		class Sub: Base
@@ -1030,6 +1038,27 @@ namespace MonoTests.System
 			//check for not throwing stack overflow exception
 			AttributeWithTypeId a = new AttributeWithTypeId ();
 			a.GetHashCode ();
+		}
+
+
+		[Test]
+		public void DerivedClassOverrideHasInhertedAttributeFromAbstractRoot ()
+		{
+			// regression test for #44010
+			// we have
+			// abstract class Root {
+			//   [MyAttribute]
+			//   public abstract void Foo ();
+			// }
+			// abstract class Abs : Root { }
+			// class Base : Abs {
+			//   public override void  Foo () { }
+			// }
+			// note that Abs does not itself override Foo.
+			var bt = typeof(Base);
+			var m = bt.GetMethod ("Foo");
+			var attribute = Attribute.GetCustomAttribute (m, typeof (MyAttribute), true);
+			Assert.IsNotNull (attribute);
 		}
 
 		class ArrayAttribute : Attribute

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7389,6 +7389,7 @@ ves_icall_MonoMethod_get_base_method (MonoReflectionMethod *m, gboolean definiti
 		klass = klass->generic_class->container_class;
 	}
 
+retry:
 	if (definition) {
 		/* At the end of the loop, klass points to the eldest class that has this virtual function slot. */
 		for (parent = klass->parent; parent != NULL; parent = parent->parent) {
@@ -7475,14 +7476,38 @@ ves_icall_MonoMethod_get_base_method (MonoReflectionMethod *m, gboolean definiti
 	result = klass->vtable [slot];
 	if (result == NULL) {
 		/* It is an abstract method */
+		gboolean found = FALSE;
 		gpointer iter = NULL;
-		while ((result = mono_class_get_methods (klass, &iter)))
-			if (result->slot == slot)
+		while ((result = mono_class_get_methods (klass, &iter))) {
+			if (result->slot == slot) {
+				found = TRUE;
 				break;
+			}
+		}
+		/* found might be FALSE if we looked in an abstract class
+		 * that doesn't override an abstract method of its
+		 * parent: 
+		 *   abstract class Base {
+		 *     public abstract void Foo ();
+		 *   }
+		 *   abstract class Derived : Base { }
+		 *   class Child : Derived {
+		 *     public override void Foo () { }
+		 *  }
+		 *
+		 *  if m was Child.Foo and we ask for the base method,
+		 *  then we get here with klass == Derived and found == FALSE
+		 */
+		/* but it shouldn't be the case that if we're looking
+		 * for the definition and didn't find a result; the
+		 * loop above should've taken us as far as we could
+		 * go! */
+		g_assert (!(definition && !found));
+		if (!found)
+			goto retry;
 	}
 
-	if (result == NULL)
-		return m;
+	g_assert (result != NULL);
 
 	ret = mono_method_get_object_checked (mono_domain_get (), result, NULL, &error);
 	mono_error_set_pending_exception (&error);


### PR DESCRIPTION
When there is an abstract class in the middle of an inheritance
hierarchy that doesn't override a method, get_base_methods needs to search
the parent class instead aborting early.

Example:

```
abstract class Root {
  public abstract void Foo ();
}
abstract class Abs : Root { }
class Derived : Abs {
  public override void Foo () { }
}
```

If we ask for the base method of Derived.Foo we used to get Derived.Foo
back because Abs did not provide an override.  Instead we should skip
abs and look in Root.

Fixes [#44010](https://bugzilla.xamarin.com/show_bug.cgi?id=44010)

This is https://github.com/mono/mono/pull/3628 backported to mono-4.8.0-branch