### PR TITLE
[threads] Replace use of W32Handle by MonoOSEvent for MonoThreadInfo exited event

### DIFF
--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -49,7 +49,8 @@ namespace System.Threading {
 		#region Sync with metadata/object-internals.h
 		int lock_thread_id;
 		// stores a thread handle
-		internal IntPtr system_thread_handle;
+		IntPtr handle;
+		IntPtr native_handle; // used only on Win32
 
 		/* Note this is an opaque object (an array), not a CultureInfo */
 		private object cached_culture_info;
@@ -109,11 +110,11 @@ namespace System.Threading {
 
 		// Closes the system thread handle
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		private extern void Thread_free_internal(IntPtr handle);
+		private extern void Thread_free_internal();
 
 		[ReliabilityContract (Consistency.WillNotCorruptState, Cer.Success)]
 		~InternalThread() {
-			Thread_free_internal(system_thread_handle);
+			Thread_free_internal();
 		}
 	}
 

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 160;
+		private const int mono_corlib_version = 161;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -45,7 +45,7 @@
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-once.h>
 #include <mono/utils/mono-logger-internals.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 /*
  * If SHM is disabled, this will point to a hash of _WapiFileShare structures, otherwise

--- a/mono/io-layer/locking.c
+++ b/mono/io-layer/locking.c
@@ -18,7 +18,7 @@
 #include <mono/io-layer/io-private.h>
 #include <mono/io-layer/io-trace.h>
 #include <mono/utils/mono-logger-internals.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 gboolean
 _wapi_lock_file_region (int fd, off_t offset, off_t length)

--- a/mono/io-layer/posix.c
+++ b/mono/io-layer/posix.c
@@ -25,7 +25,7 @@
 #include <mono/io-layer/io-private.h>
 #include <mono/io-layer/io-trace.h>
 #include <mono/utils/mono-logger-internals.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 static guint32
 convert_from_flags(int flags)

--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -107,7 +107,7 @@
 #include <mono/utils/mono-proclib.h>
 #include <mono/utils/mono-once.h>
 #include <mono/utils/mono-logger-internals.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 #define STILL_ACTIVE STATUS_PENDING
 

--- a/mono/io-layer/sockets.c
+++ b/mono/io-layer/sockets.c
@@ -44,7 +44,7 @@
 #include <mono/utils/mono-poll.h>
 #include <mono/utils/mono-once.h>
 #include <mono/utils/mono-logger-internals.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 #include <netinet/in.h>
 #include <netinet/tcp.h>

--- a/mono/io-layer/wait.c
+++ b/mono/io-layer/wait.c
@@ -14,7 +14,7 @@
 
 #include <mono/io-layer/wapi.h>
 #include <mono/io-layer/wapi-private.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 /**
  * WaitForSingleObjectEx:

--- a/mono/io-layer/wait.h
+++ b/mono/io-layer/wait.h
@@ -11,7 +11,7 @@
 #define _WAPI_WAIT_H_
 
 #include "mono/io-layer/status.h"
-#include "mono/utils/w32handle.h"
+#include "mono/metadata/w32handle.h"
 
 G_BEGIN_DECLS
 

--- a/mono/io-layer/wapi-private.h
+++ b/mono/io-layer/wapi-private.h
@@ -27,7 +27,7 @@ extern gboolean _wapi_has_shut_down;
 #include <mono/io-layer/io-private.h>
 #include <mono/io-layer/socket-private.h>
 #include <mono/io-layer/process-private.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 struct _WapiHandle_shared_ref
 {

--- a/mono/io-layer/wapi.c
+++ b/mono/io-layer/wapi.c
@@ -7,7 +7,7 @@
 #include "socket-private.h"
 
 #include "mono/utils/mono-lazy-init.h"
-#include "mono/utils/w32handle.h"
+#include "mono/metadata/w32handle.h"
 
 gboolean _wapi_has_shut_down = FALSE;
 

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -256,7 +256,9 @@ common_sources = \
 	w32semaphore.h	\
 	w32event.h	\
 	w32handle-namespace.h	\
-	w32handle-namespace.c
+	w32handle-namespace.c	\
+	w32handle.h	\
+	w32handle.c
 
 # These source files have compile time dependencies on GC code
 gc_dependent_sources = \

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -68,7 +68,7 @@
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/mono-threads.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 #ifdef HOST_WIN32
 #include <direct.h>
 #endif

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -84,7 +84,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 160
+#define MONO_CORLIB_VERSION 161
 
 typedef struct
 {
@@ -2481,12 +2481,12 @@ mono_domain_unload (MonoDomain *domain)
 }
 
 static MonoThreadInfoWaitRet
-guarded_wait (HANDLE handle, guint32 timeout, gboolean alertable)
+guarded_wait (MonoThreadHandle *thread_handle, guint32 timeout, gboolean alertable)
 {
 	MonoThreadInfoWaitRet result;
 
 	MONO_ENTER_GC_SAFE;
-	result = mono_thread_info_wait_one_handle (handle, timeout, alertable);
+	result = mono_thread_info_wait_one_handle (thread_handle, timeout, alertable);
 	MONO_EXIT_GC_SAFE;
 
 	return result;
@@ -2515,7 +2515,7 @@ void
 mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 {
 	MonoError error;
-	HANDLE thread_handle;
+	MonoThreadHandle *thread_handle;
 	MonoAppDomainState prev_state;
 	MonoMethod *method;
 	unload_data *thread_data;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -94,7 +94,7 @@ static char *ipc_filename;
 
 static char *server_uri;
 
-static HANDLE receiver_thread_handle;
+static MonoThreadHandle *receiver_thread_handle;
 
 static gboolean stop_receiver_thread;
 

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -260,7 +260,7 @@ mono_attach_cleanup (void)
 
 	/* Wait for the receiver thread to exit */
 	if (receiver_thread_handle)
-		WaitForSingleObjectEx (receiver_thread_handle, 0, FALSE);
+		mono_thread_info_wait_one_handle (receiver_thread_handle, 0, FALSE);
 }
 
 static int

--- a/mono/metadata/file-io.c
+++ b/mono/metadata/file-io.c
@@ -35,7 +35,7 @@
 #include <mono/metadata/marshal.h>
 #include <mono/utils/strenc.h>
 #include <utils/mono-io-portability.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 #undef DEBUG
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -92,12 +92,12 @@ static void reference_queue_clear_for_domain (MonoDomain *domain);
 
 
 static MonoThreadInfoWaitRet
-guarded_wait (HANDLE handle, guint32 timeout, gboolean alertable)
+guarded_wait (MonoThreadHandle *thread_handle, guint32 timeout, gboolean alertable)
 {
 	MonoThreadInfoWaitRet result;
 
 	MONO_ENTER_GC_SAFE;
-	result = mono_thread_info_wait_one_handle (handle, timeout, alertable);
+	result = mono_thread_info_wait_one_handle (thread_handle, timeout, alertable);
 	MONO_EXIT_GC_SAFE;
 
 	return result;

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -91,13 +91,13 @@ static void mono_reference_queue_cleanup (void);
 static void reference_queue_clear_for_domain (MonoDomain *domain);
 
 
-static guint32
+static MonoThreadInfoWaitRet
 guarded_wait (HANDLE handle, guint32 timeout, gboolean alertable)
 {
-	guint32 result;
+	MonoThreadInfoWaitRet result;
 
 	MONO_ENTER_GC_SAFE;
-	result = WaitForSingleObjectEx (handle, timeout, alertable);
+	result = mono_thread_info_wait_one_handle (handle, timeout, alertable);
 	MONO_EXIT_GC_SAFE;
 
 	return result;
@@ -642,7 +642,9 @@ ves_icall_System_GC_WaitForPendingFinalizers (void)
 	ResetEvent (pending_done_event);
 	mono_gc_finalize_notify ();
 	/* g_print ("Waiting for pending finalizers....\n"); */
-	guarded_wait (pending_done_event, INFINITE, TRUE);
+	MONO_ENTER_GC_SAFE;
+	WaitForSingleObjectEx (pending_done_event, INFINITE, TRUE);
+	MONO_EXIT_GC_SAFE;
 	/* g_print ("Done pending....\n"); */
 #else
 	gboolean alerted = FALSE;
@@ -1014,6 +1016,7 @@ mono_gc_cleanup (void)
 	if (!gc_disabled) {
 		finished = TRUE;
 		if (mono_thread_internal_current () != gc_thread) {
+			int ret;
 			gint64 start_ticks = mono_msec_ticks ();
 			gint64 end_ticks = start_ticks + 2000;
 
@@ -1035,8 +1038,6 @@ mono_gc_cleanup (void)
 			}
 
 			if (!finalizer_thread_exited) {
-				int ret;
-
 				/* Set a flag which the finalizer thread can check */
 				suspend_finalizers = TRUE;
 				mono_gc_suspend_finalizers ();
@@ -1047,23 +1048,22 @@ mono_gc_cleanup (void)
 				/* Wait for it to stop */
 				ret = guarded_wait (gc_thread->handle, 100, TRUE);
 
-				if (ret == WAIT_TIMEOUT) {
+				if (ret == MONO_THREAD_INFO_WAIT_RET_TIMEOUT) {
 					/*
 					 * The finalizer thread refused to exit. Make it stop.
 					 */
 					mono_thread_internal_stop (gc_thread);
 					ret = guarded_wait (gc_thread->handle, 100, TRUE);
-					g_assert (ret != WAIT_TIMEOUT);
+					g_assert (ret != MONO_THREAD_INFO_WAIT_RET_TIMEOUT);
 					/* The thread can't set this flag */
 					finalizer_thread_exited = TRUE;
 				}
 			}
 
-			int ret;
 
 			/* Wait for the thread to actually exit */
 			ret = guarded_wait (gc_thread->handle, INFINITE, TRUE);
-			g_assert (ret == WAIT_OBJECT_0);
+			g_assert (ret == MONO_THREAD_INFO_WAIT_RET_SUCCESS_0);
 
 			mono_thread_join (GUINT_TO_POINTER (gc_thread->tid));
 			g_assert (finalizer_thread_exited);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -349,7 +349,8 @@ typedef enum {
 struct _MonoInternalThread {
 	MonoObject  obj;
 	volatile int lock_thread_id; /* to be used as the pre-shifted thread id in thin locks. Used for appdomain_ref push/pop */
-	HANDLE	    handle;
+	MonoThreadHandle *handle;
+	HANDLE native_handle;
 	MonoArray  *cached_culture_info;
 	gunichar2  *name;
 	guint32	    name_len;

--- a/mono/metadata/process.c
+++ b/mono/metadata/process.c
@@ -28,7 +28,7 @@
 #include <mono/io-layer/io-layer.h>
 /* FIXME: fix this code to not depend so much on the internals */
 #include <mono/metadata/class-internals.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 #define LOGDEBUG(...)  
 /* define LOGDEBUG(...) g_message(__VA_ARGS__)  */

--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -62,7 +62,7 @@
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/networking.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 
 #include <time.h>
 #ifdef HAVE_SYS_TIME_H

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -70,7 +70,7 @@ void mono_threads_install_cleanup (MonoThreadCleanupFunc func);
 
 void ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThread *this_obj);
 HANDLE ves_icall_System_Threading_Thread_Thread_internal(MonoThread *this_obj, MonoObject *start);
-void ves_icall_System_Threading_InternalThread_Thread_free_internal(MonoInternalThread *this_obj, HANDLE thread);
+void ves_icall_System_Threading_InternalThread_Thread_free_internal(MonoInternalThread *this_obj);
 void ves_icall_System_Threading_Thread_Sleep_internal(gint32 ms);
 gboolean ves_icall_System_Threading_Thread_Join_internal(MonoThread *this_obj, int ms);
 gint32 ves_icall_System_Threading_Thread_GetDomainID (void);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1197,7 +1197,7 @@ mono_thread_exit (void)
 	if (mono_thread_get_main () && (thread == mono_thread_get_main ()->internal_thread))
 		exit (mono_environment_exitcode_get ());
 
-	mono_thread_info_exit ();
+	mono_thread_info_exit (0);
 }
 
 void
@@ -3122,7 +3122,7 @@ mono_threads_set_shutting_down (void)
 		mono_thread_detach_internal (current_thread);
 
 		/* Wake up other threads potentially waiting for us */
-		mono_thread_info_exit ();
+		mono_thread_info_exit (0);
 	} else {
 		shutting_down = TRUE;
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -44,7 +44,7 @@
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-error-internals.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 #include <mono/metadata/w32event.h>
 #include <mono/metadata/w32mutex.h>
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3029,7 +3029,7 @@ static void build_wait_tids (gpointer key, gpointer value, gpointer user)
 			return;
 		}
 
-		handle = mono_threads_open_thread_handle (thread->handle, thread_get_tid (thread));
+		handle = mono_threads_open_thread_handle (thread->handle);
 		if (handle == NULL) {
 			THREAD_DEBUG (g_message ("%s: ignoring unopenable thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
 			return;
@@ -3070,7 +3070,7 @@ remove_and_abort_threads (gpointer key, gpointer value, gpointer user)
 	     && (thread->state & ThreadState_Background) != 0
 	     && (thread->flags & MONO_THREAD_FLAG_DONT_MANAGE) == 0
 	) {
-		handle = mono_threads_open_thread_handle (thread->handle, thread_get_tid (thread));
+		handle = mono_threads_open_thread_handle (thread->handle);
 		if (handle == NULL)
 			return FALSE;
 
@@ -3229,7 +3229,7 @@ collect_threads_for_suspend (gpointer key, gpointer value, gpointer user_data)
 		return;
 
 	if (wait->num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-		handle = mono_threads_open_thread_handle (thread->handle, thread_get_tid (thread));
+		handle = mono_threads_open_thread_handle (thread->handle);
 		if (handle == NULL)
 			return;
 
@@ -3757,7 +3757,7 @@ collect_appdomain_thread (gpointer key, gpointer value, gpointer user_data)
 		/* printf ("ABORTING THREAD %p BECAUSE IT REFERENCES DOMAIN %s.\n", thread->tid, domain->friendly_name); */
 
 		if(data->wait.num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-			HANDLE handle = mono_threads_open_thread_handle (thread->handle, thread_get_tid (thread));
+			HANDLE handle = mono_threads_open_thread_handle (thread->handle);
 			if (handle == NULL)
 				return;
 			data->wait.handles [data->wait.num] = handle;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -213,7 +213,7 @@ static mono_mutex_t interlocked_mutex;
 static gint32 thread_interruption_requested = 0;
 
 /* Event signaled when a thread changes its background mode */
-static HANDLE background_change_event;
+static MonoOSEvent background_change_event;
 
 static gboolean shutting_down = FALSE;
 
@@ -592,7 +592,6 @@ static void
 mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPriority priority)
 {
 	g_assert (internal);
-	g_assert (internal->handle);
 
 	g_assert (priority >= MONO_THREAD_PRIORITY_LOWEST);
 	g_assert (priority <= MONO_THREAD_PRIORITY_HIGHEST);
@@ -601,7 +600,9 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 #ifdef HOST_WIN32
 	BOOL res;
 
-	res = SetThreadPriority (internal->handle, priority - 2);
+	g_assert (internal->native_handle);
+
+	res = SetThreadPriority (internal->native_handle, priority - 2);
 	if (!res)
 		g_error ("%s: SetThreadPriority failed, error %d", __func__, GetLastError ());
 #else /* HOST_WIN32 */
@@ -676,7 +677,10 @@ mono_thread_attach_internal (MonoThread *thread, gboolean force_attach, gboolean
 	info = mono_thread_info_current ();
 
 	internal = thread->internal_thread;
-	internal->handle = mono_thread_info_duplicate_handle (info);
+	internal->handle = mono_threads_open_thread_handle (info->handle);
+#ifdef HOST_WIN32
+	internal->native_handle = OpenThread (THREAD_ALL_ACCESS, FALSE, GetCurrentThreadId ());
+#endif
 	internal->tid = MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ());
 	internal->thread_info = info;
 	internal->small_id = info->small_id;
@@ -907,7 +911,7 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 	gboolean threadpool_thread, guint32 stack_size, MonoError *error)
 {
 	StartInfo *start_info = NULL;
-	HANDLE thread_handle;
+	MonoThreadHandle *thread_handle;
 	MonoNativeThreadId tid;
 	gboolean ret;
 	gsize stack_set_size;
@@ -1258,17 +1262,23 @@ ves_icall_System_Threading_Thread_Thread_internal (MonoThread *this_obj,
  * This is called from the finalizer of the internal thread object.
  */
 void
-ves_icall_System_Threading_InternalThread_Thread_free_internal (MonoInternalThread *this_obj, HANDLE thread)
+ves_icall_System_Threading_InternalThread_Thread_free_internal (MonoInternalThread *this_obj)
 {
-	THREAD_DEBUG (g_message ("%s: Closing thread %p, handle %p", __func__, this, thread));
+	THREAD_DEBUG (g_message ("%s: Closing thread %p, handle %p", __func__, this, this_obj->handle));
 
 	/*
 	 * Since threads keep a reference to their thread object while running, by the time this function is called,
 	 * the thread has already exited/detached, i.e. thread_cleanup () has ran. The exception is during shutdown,
 	 * when thread_cleanup () can be called after this.
 	 */
-	if (thread)
-		mono_threads_close_thread_handle (thread);
+	if (this_obj->handle) {
+		mono_threads_close_thread_handle (this_obj->handle);
+		this_obj->handle = NULL;
+	}
+
+#if HOST_WIN32
+	CloseHandle (this_obj->native_handle);
+#endif
 
 	if (this_obj->synch_cs) {
 		MonoCoopMutex *synch_cs = this_obj->synch_cs;
@@ -1515,7 +1525,7 @@ ves_icall_System_Threading_Thread_SetPriority (MonoThread *this_obj, int priorit
 
 	LOCK_THREAD (internal);
 	internal->priority = priority;
-	if (internal->handle != NULL)
+	if (internal->thread_info != NULL)
 		mono_thread_internal_set_priority (internal, priority);
 	UNLOCK_THREAD (internal);
 }
@@ -1603,7 +1613,7 @@ gboolean
 ves_icall_System_Threading_Thread_Join_internal(MonoThread *this_obj, int ms)
 {
 	MonoInternalThread *thread = this_obj->internal_thread;
-	HANDLE handle = thread->handle;
+	MonoThreadHandle *handle = thread->handle;
 	MonoInternalThread *cur_thread = mono_thread_internal_current ();
 	gboolean ret;
 
@@ -2072,7 +2082,7 @@ ves_icall_System_Threading_Thread_ClrState (MonoInternalThread* this_obj, guint3
 		 * be notified, since it has to rebuild the list of threads to
 		 * wait for.
 		 */
-		mono_w32event_set (background_change_event);
+		mono_os_event_set (&background_change_event);
 	}
 }
 
@@ -2086,7 +2096,7 @@ ves_icall_System_Threading_Thread_SetState (MonoInternalThread* this_obj, guint3
 		 * be notified, since it has to rebuild the list of threads to
 		 * wait for.
 		 */
-		mono_w32event_set (background_change_event);
+		mono_os_event_set (&background_change_event);
 	}
 }
 
@@ -2837,8 +2847,7 @@ void mono_thread_init (MonoThreadStartCB start_cb,
 	mono_os_mutex_init_recursive(&interlocked_mutex);
 	mono_os_mutex_init_recursive(&joinable_threads_mutex);
 	
-	background_change_event = mono_w32event_create (TRUE, FALSE);
-	g_assert(background_change_event != NULL);
+	mono_os_event_init (&background_change_event, TRUE, FALSE);
 	
 	mono_init_static_data_info (&thread_static_info);
 	mono_init_static_data_info (&context_static_info);
@@ -2865,7 +2874,7 @@ void mono_thread_cleanup (void)
 	 * thread exits, but if it's not running in a subthread it
 	 * won't exit in time.
 	 */
-	mono_thread_info_set_exited (mono_thread_info_current ());
+	mono_threads_signal_thread_handle (mono_thread_info_current ()->handle);
 #endif
 
 #if 0
@@ -2877,7 +2886,7 @@ void mono_thread_cleanup (void)
 	mono_os_mutex_destroy (&interlocked_mutex);
 	mono_os_mutex_destroy (&delayed_free_table_mutex);
 	mono_os_mutex_destroy (&small_id_mutex);
-	CloseHandle (background_change_event);
+	mono_os_event_destroy (&background_change_event);
 #endif
 
 	mono_native_tls_free (current_object_key);
@@ -2909,7 +2918,7 @@ static void print_tids (gpointer key, gpointer value, gpointer user)
 
 struct wait_data 
 {
-	HANDLE handles[MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
+	MonoThreadHandle *handles[MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
 	MonoInternalThread *threads[MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
 	guint32 num;
 };
@@ -2923,7 +2932,7 @@ wait_for_tids (struct wait_data *wait, guint32 timeout)
 	THREAD_DEBUG (g_message("%s: %d threads to wait for in this batch", __func__, wait->num));
 
 	MONO_ENTER_GC_SAFE;
-	ret=mono_thread_info_wait_multiple_handle(wait->handles, wait->num, TRUE, timeout, TRUE);
+	ret = mono_thread_info_wait_multiple_handle(wait->handles, wait->num, NULL, TRUE, timeout, TRUE);
 	MONO_EXIT_GC_SAFE;
 
 	if(ret==MONO_THREAD_INFO_WAIT_RET_FAILED) {
@@ -2952,22 +2961,16 @@ wait_for_tids (struct wait_data *wait, guint32 timeout)
 
 static void wait_for_tids_or_state_change (struct wait_data *wait, guint32 timeout)
 {
-	guint32 i, count;
+	guint32 i;
 	MonoThreadInfoWaitRet ret;
 	
 	THREAD_DEBUG (g_message("%s: %d threads to wait for in this batch", __func__, wait->num));
 
-	/* Add the thread state change event, so it wakes up if a thread changes
-	 * to background mode.
-	 */
-	count = wait->num;
-	if (count < MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-		wait->handles [count] = background_change_event;
-		count++;
-	}
+	/* Add the thread state change event, so it wakes
+	 * up if a thread changes to background mode. */
 
 	MONO_ENTER_GC_SAFE;
-	ret=mono_thread_info_wait_multiple_handle (wait->handles, count, FALSE, timeout, TRUE);
+	ret = mono_thread_info_wait_multiple_handle (wait->handles, wait->num, &background_change_event, FALSE, timeout, TRUE);
 	MONO_EXIT_GC_SAFE;
 
 	if(ret==MONO_THREAD_INFO_WAIT_RET_FAILED) {
@@ -2998,8 +3001,7 @@ static void build_wait_tids (gpointer key, gpointer value, gpointer user)
 {
 	struct wait_data *wait=(struct wait_data *)user;
 
-	if(wait->num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-		HANDLE handle;
+	if(wait->num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS - 1) {
 		MonoInternalThread *thread=(MonoInternalThread *)value;
 
 		/* Ignore background threads, we abort them later */
@@ -3029,15 +3031,9 @@ static void build_wait_tids (gpointer key, gpointer value, gpointer user)
 			return;
 		}
 
-		handle = mono_threads_open_thread_handle (thread->handle);
-		if (handle == NULL) {
-			THREAD_DEBUG (g_message ("%s: ignoring unopenable thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
-			return;
-		}
-		
 		THREAD_DEBUG (g_message ("%s: Invoking mono_thread_manage callback on thread %p", __func__, thread));
 		if ((thread->manage_callback == NULL) || (thread->manage_callback (thread->root_domain_thread) == TRUE)) {
-			wait->handles[wait->num]=handle;
+			wait->handles[wait->num]=mono_threads_open_thread_handle (thread->handle);
 			wait->threads[wait->num]=thread;
 			wait->num++;
 
@@ -3060,7 +3056,6 @@ remove_and_abort_threads (gpointer key, gpointer value, gpointer user)
 	struct wait_data *wait=(struct wait_data *)user;
 	MonoNativeThreadId self = mono_native_thread_id_get ();
 	MonoInternalThread *thread = (MonoInternalThread *)value;
-	HANDLE handle;
 
 	if (wait->num >= MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS)
 		return FALSE;
@@ -3070,11 +3065,7 @@ remove_and_abort_threads (gpointer key, gpointer value, gpointer user)
 	     && (thread->state & ThreadState_Background) != 0
 	     && (thread->flags & MONO_THREAD_FLAG_DONT_MANAGE) == 0
 	) {
-		handle = mono_threads_open_thread_handle (thread->handle);
-		if (handle == NULL)
-			return FALSE;
-
-		wait->handles[wait->num] = handle;
+		wait->handles[wait->num] = mono_threads_open_thread_handle (thread->handle);
 		wait->threads[wait->num] = thread;
 		wait->num++;
 
@@ -3130,7 +3121,7 @@ mono_threads_set_shutting_down (void)
 		 * interrupt the main thread if it is waiting for all
 		 * the other threads.
 		 */
-		mono_w32event_set (background_change_event);
+		mono_os_event_set (&background_change_event);
 		
 		mono_threads_unlock ();
 	}
@@ -3163,7 +3154,7 @@ void mono_thread_manage (void)
 		THREAD_DEBUG (g_message ("%s: There are %d threads to join", __func__, mono_g_hash_table_size (threads));
 			mono_g_hash_table_foreach (threads, print_tids, NULL));
 	
-		mono_w32event_reset (background_change_event);
+		mono_os_event_reset (&background_change_event);
 		wait->num=0;
 		/*We must zero all InternalThread pointers to avoid making the GC unhappy.*/
 		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
@@ -3217,7 +3208,6 @@ collect_threads_for_suspend (gpointer key, gpointer value, gpointer user_data)
 {
 	MonoInternalThread *thread = (MonoInternalThread*)value;
 	struct wait_data *wait = (struct wait_data*)user_data;
-	HANDLE handle;
 
 	/* 
 	 * We try to exclude threads early, to avoid running into the MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS
@@ -3229,11 +3219,7 @@ collect_threads_for_suspend (gpointer key, gpointer value, gpointer user_data)
 		return;
 
 	if (wait->num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-		handle = mono_threads_open_thread_handle (thread->handle);
-		if (handle == NULL)
-			return;
-
-		wait->handles [wait->num] = handle;
+		wait->handles [wait->num] = mono_threads_open_thread_handle (thread->handle);
 		wait->threads [wait->num] = thread;
 		wait->num++;
 	}
@@ -3757,10 +3743,7 @@ collect_appdomain_thread (gpointer key, gpointer value, gpointer user_data)
 		/* printf ("ABORTING THREAD %p BECAUSE IT REFERENCES DOMAIN %s.\n", thread->tid, domain->friendly_name); */
 
 		if(data->wait.num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-			HANDLE handle = mono_threads_open_thread_handle (thread->handle);
-			if (handle == NULL)
-				return;
-			data->wait.handles [data->wait.num] = handle;
+			data->wait.handles [data->wait.num] = mono_threads_open_thread_handle (thread->handle);
 			data->wait.threads [data->wait.num] = thread;
 			data->wait.num++;
 		} else {
@@ -4419,7 +4402,7 @@ mono_thread_request_interruption (gboolean running_managed)
 		   or similar */
 		/* Our implementation of this function ignores the func argument */
 #ifdef HOST_WIN32
-		QueueUserAPC ((PAPCFUNC)dummy_apc, thread->handle, (ULONG_PTR)NULL);
+		QueueUserAPC ((PAPCFUNC)dummy_apc, thread->native_handle, (ULONG_PTR)NULL);
 #else
 		mono_thread_info_self_interrupt ();
 #endif

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2867,14 +2867,14 @@ void mono_thread_init (MonoThreadStartCB start_cb,
 
 void mono_thread_cleanup (void)
 {
-#if !defined(RUN_IN_SUBTHREAD)
+#if !defined(RUN_IN_SUBTHREAD) && !defined(HOST_WIN32)
 	/* The main thread must abandon any held mutexes (particularly
 	 * important for named mutexes as they are shared across
 	 * processes, see bug 74680.)  This will happen when the
 	 * thread exits, but if it's not running in a subthread it
 	 * won't exit in time.
 	 */
-	mono_threads_signal_thread_handle (mono_thread_info_current ()->handle);
+	mono_w32mutex_abandon ();
 #endif
 
 #if 0

--- a/mono/metadata/w32event-unix.c
+++ b/mono/metadata/w32event-unix.c
@@ -12,7 +12,7 @@
 #include "w32handle-namespace.h"
 #include "mono/io-layer/io-layer.h"
 #include "mono/utils/mono-logger-internals.h"
-#include "mono/utils/w32handle.h"
+#include "mono/metadata/w32handle.h"
 
 typedef struct {
 	gboolean manual;

--- a/mono/metadata/w32handle-namespace.h
+++ b/mono/metadata/w32handle-namespace.h
@@ -5,7 +5,7 @@
 #include <config.h>
 #include <glib.h>
 
-#include "mono/utils/w32handle.h"
+#include "mono/metadata/w32handle.h"
 
 #define MONO_W32HANDLE_NAMESPACE_MAX_PATH 260
 

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -42,12 +42,12 @@
 
 #include "w32handle.h"
 
-#include "atomic.h"
-#include "mono-logger-internals.h"
-#include "mono-os-mutex.h"
-#include "mono-proclib.h"
-#include "mono-threads.h"
-#include "mono-time.h"
+#include "utils/atomic.h"
+#include "utils/mono-logger-internals.h"
+#include "utils/mono-os-mutex.h"
+#include "utils/mono-proclib.h"
+#include "utils/mono-threads.h"
+#include "utils/mono-time.h"
 
 #undef DEBUG_REFS
 

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -1,6 +1,6 @@
 
-#ifndef _MONO_UTILS_W32HANDLE_H_
-#define _MONO_UTILS_W32HANDLE_H_
+#ifndef _MONO_METADATA_W32HANDLE_H_
+#define _MONO_METADATA_W32HANDLE_H_
 
 #include <config.h>
 #include <glib.h>
@@ -183,4 +183,4 @@ mono_w32handle_wait_multiple (gpointer *handles, gsize nhandles, gboolean waital
 MonoW32HandleWaitRet
 mono_w32handle_signal_and_wait (gpointer signal_handle, gpointer wait_handle, guint32 timeout, gboolean alertable);
 
-#endif /* _MONO_UTILS_W32HANDLE_H_ */
+#endif /* _MONO_METADATA_W32HANDLE_H_ */

--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -16,7 +16,7 @@
 #include "mono/metadata/object-internals.h"
 #include "mono/utils/mono-logger-internals.h"
 #include "mono/utils/mono-threads.h"
-#include "mono/utils/w32handle.h"
+#include "mono/metadata/w32handle.h"
 
 typedef struct {
 	MonoNativeThreadId tid;

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -12,7 +12,7 @@
 #include "w32handle-namespace.h"
 #include "mono/io-layer/io-layer.h"
 #include "mono/utils/mono-logger-internals.h"
-#include "mono/utils/w32handle.h"
+#include "mono/metadata/w32handle.h"
 
 typedef struct {
 	guint32 val;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9830,7 +9830,7 @@ compile_methods (MonoAotCompile *acfg)
 		g_free (methods);
 
 		for (i = 0; i < threads->len; ++i) {
-			WaitForSingleObjectEx (g_ptr_array_index (threads, i), INFINITE, FALSE);
+			mono_thread_info_wait_one_handle (g_ptr_array_index (threads, i), INFINITE, FALSE);
 			mono_threads_close_thread_handle (g_ptr_array_index (threads, i));
 		}
 	} else {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9791,7 +9791,7 @@ compile_methods (MonoAotCompile *acfg)
 		GPtrArray *frag;
 		int len, j;
 		GPtrArray *threads;
-		HANDLE handle;
+		MonoThreadHandle *thread_handle;
 		gpointer *user_data;
 		MonoMethod **methods;
 
@@ -9824,8 +9824,8 @@ compile_methods (MonoAotCompile *acfg)
 			user_data [1] = acfg;
 			user_data [2] = frag;
 			
-			handle = mono_threads_create_thread (compile_thread_main, (gpointer) user_data, NULL, NULL);
-			g_ptr_array_add (threads, handle);
+			thread_handle = mono_threads_create_thread (compile_thread_main, (gpointer) user_data, NULL, NULL);
+			g_ptr_array_add (threads, thread_handle);
 		}
 		g_free (methods);
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -669,7 +669,7 @@ static MonoGHashTable *tid_to_thread_obj;
 
 static MonoNativeThreadId debugger_thread_id;
 
-static HANDLE debugger_thread_handle;
+static MonoThreadHandle *debugger_thread_handle;
 
 static int log_level;
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -52,7 +52,7 @@
 #include "mono/utils/mono-counters.h"
 #include "mono/utils/mono-hwcap.h"
 #include "mono/utils/mono-logger-internals.h"
-#include "mono/utils/w32handle.h"
+#include "mono/metadata/w32handle.h"
 
 #include "mini.h"
 #include "jit.h"

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -65,7 +65,7 @@
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/checked-build.h>
-#include <mono/utils/w32handle.h>
+#include <mono/metadata/w32handle.h>
 #include <mono/io-layer/io-layer.h>
 
 #include "mini.h"

--- a/mono/unit-tests/test-conc-hashtable.c
+++ b/mono/unit-tests/test-conc-hashtable.c
@@ -11,7 +11,7 @@
 #include "utils/mono-threads.h"
 #include "utils/mono-conc-hashtable.h"
 #include "utils/checked-build.h"
-#include "utils/w32handle.h"
+#include "metadata/w32handle.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -173,8 +173,6 @@ monoutils_sources = \
 	parse.h	\
 	checked-build.c \
 	checked-build.h \
-	w32handle.c \
-	w32handle.h \
 	os-event.h
 
 arch_sources = 

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -36,10 +36,6 @@ extern int tkill (pid_t tid, int signal);
 
 #include <sys/resource.h>
 
-#if defined(__native_client__)
-void nacl_shutdown_gc_thread(void);
-#endif
-
 typedef struct {
 	guint32 ref;
 	MonoOSEvent event;
@@ -163,15 +159,9 @@ mono_threads_platform_yield (void)
 }
 
 void
-mono_threads_platform_exit (int exit_code)
+mono_threads_platform_exit (gsize exit_code)
 {
-#if defined(__native_client__)
-	nacl_shutdown_gc_thread();
-#endif
-
-	mono_thread_info_detach ();
-
-	pthread_exit (NULL);
+	pthread_exit ((gpointer) exit_code);
 }
 
 void

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -198,14 +198,8 @@ mono_threads_get_max_stack_size (void)
 	return (int)lim.rlim_max;
 }
 
-gpointer
-mono_threads_platform_duplicate_handle (MonoThreadInfo *info)
-{
-	return mono_threads_platform_open_thread_handle (info->handle, (MonoNativeThreadId) (gsize) -1);
-}
-
 HANDLE
-mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
+mono_threads_platform_open_thread_handle (HANDLE handle)
 {
 	ThreadHandle *thread_handle;
 	guint32 oldref, newref;

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -41,8 +41,8 @@ typedef struct {
 	MonoOSEvent event;
 } ThreadHandle;
 
-void
-mono_threads_platform_register (MonoThreadInfo *info)
+HANDLE
+mono_threads_platform_create_thread_handle (void)
 {
 	ThreadHandle *thread_handle;
 
@@ -50,8 +50,7 @@ mono_threads_platform_register (MonoThreadInfo *info)
 	thread_handle->ref = 1;
 	mono_os_event_init (&thread_handle->event, TRUE, FALSE);
 
-	g_assert (!info->handle);
-	info->handle = thread_handle;
+	return thread_handle;
 }
 
 int
@@ -162,16 +161,6 @@ void
 mono_threads_platform_exit (gsize exit_code)
 {
 	pthread_exit ((gpointer) exit_code);
-}
-
-void
-mono_threads_platform_unregister (MonoThreadInfo *info)
-{
-	g_assert (info->handle);
-
-	/* The thread is no longer active, so unref it */
-	mono_threads_platform_close_thread_handle (info->handle);
-	info->handle = NULL;
 }
 
 int

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -215,6 +215,43 @@ mono_threads_platform_close_thread_handle (HANDLE handle)
 	mono_w32handle_unref (handle);
 }
 
+MonoThreadInfoWaitRet
+mono_threads_platform_wait_one_handle (gpointer handle, guint32 timeout, gboolean alertable)
+{
+	MonoW32HandleWaitRet res;
+
+	res = mono_w32handle_wait_one (handle, timeout, alertable);
+	if (res == MONO_W32HANDLE_WAIT_RET_SUCCESS_0)
+		return MONO_THREAD_INFO_WAIT_RET_SUCCESS_0;
+	else if (res == MONO_W32HANDLE_WAIT_RET_ALERTED)
+		return MONO_THREAD_INFO_WAIT_RET_ALERTED;
+	else if (res == MONO_W32HANDLE_WAIT_RET_TIMEOUT)
+		return MONO_THREAD_INFO_WAIT_RET_TIMEOUT;
+	else if (res == MONO_W32HANDLE_WAIT_RET_FAILED)
+		return MONO_THREAD_INFO_WAIT_RET_FAILED;
+	else
+		g_error ("%s: unknown res value %d", __func__, res);
+}
+
+MonoThreadInfoWaitRet
+mono_threads_platform_wait_multiple_handle (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable)
+{
+	MonoW32HandleWaitRet res;
+
+	res = mono_w32handle_wait_multiple (handles, nhandles, waitall, timeout, alertable);
+	if (res >= MONO_W32HANDLE_WAIT_RET_SUCCESS_0 && res <= MONO_W32HANDLE_WAIT_RET_SUCCESS_0 + nhandles - 1)
+		return MONO_THREAD_INFO_WAIT_RET_SUCCESS_0 + (res - MONO_W32HANDLE_WAIT_RET_SUCCESS_0);
+	else if (res == MONO_W32HANDLE_WAIT_RET_ALERTED)
+		return MONO_THREAD_INFO_WAIT_RET_ALERTED;
+	else if (res == MONO_W32HANDLE_WAIT_RET_TIMEOUT)
+		return MONO_THREAD_INFO_WAIT_RET_TIMEOUT;
+	else if (res == MONO_W32HANDLE_WAIT_RET_FAILED)
+		return MONO_THREAD_INFO_WAIT_RET_FAILED;
+	else
+		g_error ("%s: unknown res value %d", __func__, res);
+}
+
+
 int
 mono_threads_pthread_kill (MonoThreadInfo *info, int signum)
 {

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -334,21 +334,15 @@ mono_threads_get_max_stack_size (void)
 	return INT_MAX;
 }
 
-gpointer
-mono_threads_platform_duplicate_handle (MonoThreadInfo *info)
+HANDLE
+mono_threads_platform_open_thread_handle (HANDLE handle)
 {
 	HANDLE thread_handle;
 
-	g_assert (info->handle);
-	DuplicateHandle (GetCurrentProcess (), info->handle, GetCurrentProcess (), &thread_handle, THREAD_ALL_ACCESS, TRUE, 0);
+	g_assert (handle);
+	DuplicateHandle (GetCurrentProcess (), handle, GetCurrentProcess (), &thread_handle, THREAD_ALL_ACCESS, TRUE, 0);
 
 	return thread_handle;
-}
-
-HANDLE
-mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
-{
-	return OpenThread (THREAD_ALL_ACCESS, TRUE, tid);
 }
 
 void

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -312,9 +312,8 @@ mono_threads_platform_yield (void)
 }
 
 void
-mono_threads_platform_exit (int exit_code)
+mono_threads_platform_exit (gsize exit_code)
 {
-	mono_thread_info_detach ();
 	ExitThread (exit_code);
 }
 

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -189,8 +189,8 @@ mono_threads_suspend_get_abort_signal (void)
 
 #if defined (HOST_WIN32)
 
-void
-mono_threads_platform_register (MonoThreadInfo *info)
+HANDLE
+mono_threads_platform_create_thread_handle (void)
 {
 	HANDLE thread_handle;
 
@@ -201,8 +201,7 @@ mono_threads_platform_register (MonoThreadInfo *info)
 	 * be used to refer to the thread from other threads for things like aborting. */
 	DuplicateHandle (GetCurrentProcess (), thread_handle, GetCurrentProcess (), &thread_handle, THREAD_ALL_ACCESS, TRUE, 0);
 
-	g_assert (!info->handle);
-	info->handle = thread_handle;
+	return thread_handle;
 }
 
 int
@@ -315,15 +314,6 @@ void
 mono_threads_platform_exit (gsize exit_code)
 {
 	ExitThread (exit_code);
-}
-
-void
-mono_threads_platform_unregister (MonoThreadInfo *info)
-{
-	g_assert (info->handle);
-
-	CloseHandle (info->handle);
-	info->handle = NULL;
 }
 
 int

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1138,7 +1138,7 @@ inner_start_thread (gpointer data)
 	MonoThreadInfo *info;
 	MonoThreadStart start_routine;
 	gpointer start_routine_arg;
-	guint32 start_routine_res;
+	gsize start_routine_res;
 	gsize dummy;
 
 	thread_data = (CreateThreadData*) data;
@@ -1165,7 +1165,7 @@ inner_start_thread (gpointer data)
 	/* Run the actual main function of the thread */
 	start_routine_res = start_routine (start_routine_arg);
 
-	mono_threads_platform_exit (start_routine_res);
+	mono_thread_info_exit (start_routine_res);
 
 	g_assert_not_reached ();
 }
@@ -1401,6 +1401,10 @@ mono_thread_info_tls_set (THREAD_INFO_TYPE *info, MonoTlsKey key, gpointer value
 	((MonoThreadInfo*)info)->tls [key] = value;
 }
 
+#if defined(__native_client__)
+void nacl_shutdown_gc_thread(void);
+#endif
+
 /*
  * mono_thread_info_exit:
  *
@@ -1408,8 +1412,14 @@ mono_thread_info_tls_set (THREAD_INFO_TYPE *info, MonoTlsKey key, gpointer value
  * This function doesn't return.
  */
 void
-mono_thread_info_exit (void)
+mono_thread_info_exit (gsize exit_code)
 {
+#if defined(__native_client__)
+	nacl_shutdown_gc_thread();
+#endif
+
+	mono_thread_info_detach ();
+
 	mono_threads_platform_exit (0);
 }
 

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -397,6 +397,9 @@ static void
 mono_thread_info_suspend_lock_with_info (MonoThreadInfo *info);
 
 static void
+mono_threads_signal_thread_handle (MonoThreadHandle* thread_handle);
+
+static void
 unregister_thread (void *arg)
 {
 	gpointer gc_unsafe_stackdata;
@@ -1471,7 +1474,7 @@ mono_threads_close_thread_handle (MonoThreadHandle *thread_handle)
 	}
 }
 
-void
+static void
 mono_threads_signal_thread_handle (MonoThreadHandle* thread_handle)
 {
 	mono_os_event_set (&thread_handle->event);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -426,7 +426,7 @@ unregister_thread (void *arg)
 
 	/* we need to duplicate it, as the info->handle is going
 	 * to be closed when unregistering from the platform */
-	handle = mono_threads_platform_duplicate_handle (info);
+	handle = mono_thread_info_duplicate_handle (info);
 
 	/*
 	First perform the callback that requires no locks.
@@ -468,7 +468,7 @@ unregister_thread (void *arg)
 	 * neither does it switch state to BLOCKING. */
 	mono_threads_platform_set_exited (handle);
 
-	mono_threads_platform_close_thread_handle (handle);
+	mono_threads_close_thread_handle (handle);
 }
 
 static void
@@ -1417,13 +1417,13 @@ mono_thread_info_exit (void)
  * mono_threads_open_thread_handle:
  *
  *   Return a io-layer/win32 handle for the thread identified by HANDLE/TID.
- * The handle need to be closed by calling CloseHandle () when it is no
+ * The handle need to be closed by calling mono_threads_close_thread_handle () when it is no
  * longer needed.
  */
 HANDLE
-mono_threads_open_thread_handle (HANDLE handle, MonoNativeThreadId tid)
+mono_threads_open_thread_handle (HANDLE handle)
 {
-	return mono_threads_platform_open_thread_handle (handle, tid);
+	return mono_threads_platform_open_thread_handle (handle);
 }
 
 void
@@ -1651,7 +1651,7 @@ gpointer
 mono_thread_info_duplicate_handle (MonoThreadInfo *info)
 {
 	g_assert (mono_thread_info_is_current (info));
-	return mono_threads_platform_duplicate_handle (info);
+	return mono_threads_open_thread_handle (info->handle);
 }
 
 MonoThreadInfoWaitRet

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1653,3 +1653,15 @@ mono_thread_info_duplicate_handle (MonoThreadInfo *info)
 	g_assert (mono_thread_info_is_current (info));
 	return mono_threads_platform_duplicate_handle (info);
 }
+
+MonoThreadInfoWaitRet
+mono_thread_info_wait_one_handle (gpointer handle, guint32 timeout, gboolean alertable)
+{
+	return mono_threads_platform_wait_one_handle (handle, timeout, alertable);
+}
+
+MonoThreadInfoWaitRet
+mono_thread_info_wait_multiple_handle (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable)
+{
+	return mono_threads_platform_wait_multiple_handle (handles, nhandles, waitall, timeout, alertable);
+}

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -378,9 +378,6 @@ void
 mono_thread_info_exit (gsize exit_code);
 
 void
-mono_threads_signal_thread_handle (MonoThreadHandle *handle);
-
-void
 mono_thread_info_install_interrupt (void (*callback) (gpointer data), gpointer data, gboolean *interrupted);
 
 void

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -369,7 +369,7 @@ void
 mono_thread_info_tls_set (THREAD_INFO_TYPE *info, MonoTlsKey key, gpointer value);
 
 void
-mono_thread_info_exit (void);
+mono_thread_info_exit (gsize exit_code);
 
 void
 mono_thread_info_set_exited (THREAD_INFO_TYPE *info);
@@ -482,7 +482,7 @@ void mono_threads_platform_unregister (THREAD_INFO_TYPE *info);
 int mono_threads_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_data, gsize* const stack_size, MonoNativeThreadId *out_tid);
 void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
 gboolean mono_threads_platform_yield (void);
-void mono_threads_platform_exit (int exit_code);
+void mono_threads_platform_exit (gsize exit_code);
 HANDLE mono_threads_platform_open_thread_handle (HANDLE handle);
 void mono_threads_platform_close_thread_handle (HANDLE handle);
 void mono_threads_platform_set_exited (gpointer handle);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -408,7 +408,7 @@ int
 mono_threads_get_max_stack_size (void);
 
 HANDLE
-mono_threads_open_thread_handle (HANDLE handle, MonoNativeThreadId tid);
+mono_threads_open_thread_handle (HANDLE handle);
 
 void
 mono_threads_close_thread_handle (HANDLE handle);
@@ -483,10 +483,9 @@ int mono_threads_platform_create_thread (MonoThreadStart thread_fn, gpointer thr
 void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
 gboolean mono_threads_platform_yield (void);
 void mono_threads_platform_exit (int exit_code);
-HANDLE mono_threads_platform_open_thread_handle (HANDLE handle, MonoNativeThreadId tid);
+HANDLE mono_threads_platform_open_thread_handle (HANDLE handle);
 void mono_threads_platform_close_thread_handle (HANDLE handle);
 void mono_threads_platform_set_exited (gpointer handle);
-gpointer mono_threads_platform_duplicate_handle (THREAD_INFO_TYPE *info);
 
 void mono_threads_coop_begin_global_suspend (void);
 void mono_threads_coop_end_global_suspend (void);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -477,12 +477,11 @@ gint mono_threads_suspend_get_suspend_signal (void);
 gint mono_threads_suspend_get_restart_signal (void);
 gint mono_threads_suspend_get_abort_signal (void);
 
-void mono_threads_platform_register (THREAD_INFO_TYPE *info);
-void mono_threads_platform_unregister (THREAD_INFO_TYPE *info);
 int mono_threads_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_data, gsize* const stack_size, MonoNativeThreadId *out_tid);
 void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
 gboolean mono_threads_platform_yield (void);
 void mono_threads_platform_exit (gsize exit_code);
+HANDLE mono_threads_platform_create_thread_handle (void);
 HANDLE mono_threads_platform_open_thread_handle (HANDLE handle);
 void mono_threads_platform_close_thread_handle (HANDLE handle);
 void mono_threads_platform_set_exited (gpointer handle);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -15,6 +15,7 @@
 #include <mono/utils/mono-linked-list-set.h>
 #include <mono/utils/mono-tls.h>
 #include <mono/utils/mono-coop-semaphore.h>
+#include <mono/utils/os-event.h>
 
 #include <mono/io-layer/io-layer.h>
 
@@ -61,6 +62,11 @@ typedef void* mono_native_thread_return_t;
 typedef gsize (*MonoThreadStart)(gpointer);
 
 #endif /* #ifdef HOST_WIN32 */
+
+typedef struct {
+	guint32 ref;
+	MonoOSEvent event;
+} MonoThreadHandle;
 
 /*
 THREAD_INFO_TYPE is a way to make the mono-threads module parametric - or sort of.
@@ -192,7 +198,7 @@ typedef struct {
 
 	/* IO layer handle for this thread */
 	/* Set when the thread is started, or in _wapi_thread_duplicate () */
-	HANDLE handle;
+	MonoThreadHandle *handle;
 
 	void *jit_data;
 
@@ -372,7 +378,7 @@ void
 mono_thread_info_exit (gsize exit_code);
 
 void
-mono_thread_info_set_exited (THREAD_INFO_TYPE *info);
+mono_threads_signal_thread_handle (MonoThreadHandle *handle);
 
 void
 mono_thread_info_install_interrupt (void (*callback) (gpointer data), gpointer data, gboolean *interrupted);
@@ -401,17 +407,17 @@ mono_thread_info_describe_interrupt_token (THREAD_INFO_TYPE *info, GString *text
 gboolean
 mono_thread_info_is_live (THREAD_INFO_TYPE *info);
 
-HANDLE
+MonoThreadHandle*
 mono_threads_create_thread (MonoThreadStart start, gpointer arg, gsize * const stack_size, MonoNativeThreadId *out_tid);
 
 int
 mono_threads_get_max_stack_size (void);
 
-HANDLE
-mono_threads_open_thread_handle (HANDLE handle);
+MonoThreadHandle*
+mono_threads_open_thread_handle (MonoThreadHandle *handle);
 
 void
-mono_threads_close_thread_handle (HANDLE handle);
+mono_threads_close_thread_handle (MonoThreadHandle *handle);
 
 MONO_API void
 mono_threads_attach_tools_thread (void);
@@ -435,8 +441,6 @@ This is called very early in the runtime, it cannot access any runtime facilitie
 void mono_threads_suspend_init (void); //ok
 
 void mono_threads_suspend_init_signals (void);
-
-void mono_threads_platform_init (void);
 
 void mono_threads_coop_init (void);
 
@@ -481,10 +485,6 @@ int mono_threads_platform_create_thread (MonoThreadStart thread_fn, gpointer thr
 void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
 gboolean mono_threads_platform_yield (void);
 void mono_threads_platform_exit (gsize exit_code);
-HANDLE mono_threads_platform_create_thread_handle (void);
-HANDLE mono_threads_platform_open_thread_handle (HANDLE handle);
-void mono_threads_platform_close_thread_handle (HANDLE handle);
-void mono_threads_platform_set_exited (gpointer handle);
 
 void mono_threads_coop_begin_global_suspend (void);
 void mono_threads_coop_end_global_suspend (void);
@@ -602,9 +602,6 @@ void mono_threads_end_global_suspend (void);
 gboolean
 mono_thread_info_is_current (THREAD_INFO_TYPE *info);
 
-gpointer
-mono_thread_info_duplicate_handle (THREAD_INFO_TYPE *info);
-
 typedef enum {
 	MONO_THREAD_INFO_WAIT_RET_SUCCESS_0   =  0,
 	MONO_THREAD_INFO_WAIT_RET_ALERTED     = -1,
@@ -613,15 +610,9 @@ typedef enum {
 } MonoThreadInfoWaitRet;
 
 MonoThreadInfoWaitRet
-mono_threads_platform_wait_one_handle (gpointer handle, guint32 timeout, gboolean alertable);
+mono_thread_info_wait_one_handle (MonoThreadHandle *handle, guint32 timeout, gboolean alertable);
 
 MonoThreadInfoWaitRet
-mono_threads_platform_wait_multiple_handle (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable);
-
-MonoThreadInfoWaitRet
-mono_thread_info_wait_one_handle (gpointer handle, guint32 timeout, gboolean alertable);
-
-MonoThreadInfoWaitRet
-mono_thread_info_wait_multiple_handle (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable);
+mono_thread_info_wait_multiple_handle (MonoThreadHandle **thread_handles, gsize nhandles, MonoOSEvent *background_change_event, gboolean waitall, guint32 timeout, gboolean alertable);
 
 #endif /* __MONO_THREADS_H__ */

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -607,4 +607,23 @@ mono_thread_info_is_current (THREAD_INFO_TYPE *info);
 gpointer
 mono_thread_info_duplicate_handle (THREAD_INFO_TYPE *info);
 
+typedef enum {
+	MONO_THREAD_INFO_WAIT_RET_SUCCESS_0   =  0,
+	MONO_THREAD_INFO_WAIT_RET_ALERTED     = -1,
+	MONO_THREAD_INFO_WAIT_RET_TIMEOUT     = -2,
+	MONO_THREAD_INFO_WAIT_RET_FAILED      = -3,
+} MonoThreadInfoWaitRet;
+
+MonoThreadInfoWaitRet
+mono_threads_platform_wait_one_handle (gpointer handle, guint32 timeout, gboolean alertable);
+
+MonoThreadInfoWaitRet
+mono_threads_platform_wait_multiple_handle (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable);
+
+MonoThreadInfoWaitRet
+mono_thread_info_wait_one_handle (gpointer handle, guint32 timeout, gboolean alertable);
+
+MonoThreadInfoWaitRet
+mono_thread_info_wait_multiple_handle (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable);
+
 #endif /* __MONO_THREADS_H__ */


### PR DESCRIPTION
I still have to make the wait alertable.

cc @kumpera @vargaz