### PR TITLE
Build libgcmonosgen under none desktop Windows API family.

### DIFF
--- a/mono/io-layer/io-layer.h
+++ b/mono/io-layer/io-layer.h
@@ -11,6 +11,9 @@
 #ifndef _MONO_IOLAYER_IOLAYER_H_
 #define _MONO_IOLAYER_IOLAYER_H_
 
+#include <config.h>
+#include <glib.h>
+
 #if defined(__WIN32__) || defined(_WIN32)
 /* Native win32 */
 #define __USE_W32_SOCKETS
@@ -25,8 +28,8 @@
 #include <ws2tcpip.h>
 #endif
 #include <psapi.h>
-#include <shlobj.h>
-/*
+
+ /*
  * Workaround for missing WSAPOLLFD typedef in mingw's winsock2.h that is required for mswsock.h below.
  * Remove once http://sourceforge.net/p/mingw/bugs/1980/ is fixed.
  */
@@ -37,7 +40,11 @@ typedef struct pollfd {
   short  revents;
 } WSAPOLLFD, *PWSAPOLLFD, *LPWSAPOLLFD;
 #endif
+
+#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 #include <mswsock.h>
+#endif
+
 #else	/* EVERYONE ELSE */
 #include "mono/io-layer/wapi.h"
 #include "mono/io-layer/uglify.h"

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -40,6 +40,10 @@
 #include <string.h>
 #include <errno.h>
 
+#if defined(HOST_WIN32)
+#include <oleauto.h>
+#endif
+
 /*
 Code shared between the DISABLE_COM and !DISABLE_COM
 */

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -52,6 +52,10 @@
 #include <string.h>
 #include <errno.h>
 
+#if defined(HOST_WIN32)
+#include <objbase.h>
+#endif
+
 /* #define DEBUG_RUNTIME_CODE */
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -56,6 +56,10 @@
 #include <signal.h>
 #endif
 
+#if defined(HOST_WIN32)
+#include <objbase.h>
+#endif
+
 #if defined(PLATFORM_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
 #define USE_TKILL_ON_ANDROID 1
 #endif

--- a/mono/sgen/sgen-layout-stats.c
+++ b/mono/sgen/sgen-layout-stats.c
@@ -58,6 +58,11 @@ sgen_object_layout_dump (FILE *out)
 	fprintf (out, "ref-array %lu\n", count_ref_array);
 	fprintf (out, "vtype-array %lu\n", count_vtype_array);
 }
+#else
 
+#ifdef _MSC_VER
+// Quiet Visual Studio linker warning, LNK4221, in cases when this source file intentional ends up empty.
+void __mono_win32_sgen_layout_stats_quiet_lnk4221(void) {}
 #endif
+#endif /* SGEN_OBJECT_LAYOUT_STATISTICS */
 #endif

--- a/mono/utils/mono-os-semaphore.h
+++ b/mono/utils/mono-os-semaphore.h
@@ -291,7 +291,12 @@ typedef HANDLE MonoSemType;
 static inline void
 mono_os_sem_init (MonoSemType *sem, int value)
 {
+#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 	*sem = CreateSemaphore (NULL, value, 0x7FFFFFFF, NULL);
+#else
+	*sem = CreateSemaphoreEx (NULL, value, 0x7FFFFFFF, NULL, 0, SEMAPHORE_ALL_ACCESS);
+#endif
+
 	if (G_UNLIKELY (*sem == NULL))
 		g_error ("%s: CreateSemaphore failed with error %d", __func__, GetLastError ());
 }


### PR DESCRIPTION
Initial work to build libgcmonosgen under none desktop Windows API families.
Changes are mainly related to header files included by libgcmonosgen sources and shared
by other libraries.

This PR is a continuation of https://github.com/mono/mono/pull/3626 fixing what's needed to get next runtime library to build under none desktop Windows API family. NOTE, this is initial work, so the functionality in none "classic" windows API code paths are still under development.

The classic Windows API have been split into families and partitions in order to support
different subsets off the Windows API on different platforms. In order to build against other Windows targets/platforms, Mono needs to follow these families/partitions in order to successfully build where API’s have been removed/replaced/extended. Since most Mono platforms uses the Windows API signatures, a new defined has been added to all platforms, HAVE_CLASSIC_WINAPI_SUPPORT, used to decide what implementation to include. On none Windows platforms this is always defined and on Windows platforms it follows the winapifamily.h setup in winconfig.h. In order to keep down regressions, the existing API’s are kept for HAVE_CLASSIC_WINAPI_SUPPORT even if there are more modern alternatives and replacements available.