### PR TITLE
Enable reuse of eglib native test framework and test driver source.

### DIFF
--- a/eglib/test/driver.c
+++ b/eglib/test/driver.c
@@ -28,7 +28,10 @@
 
 #include <config.h>
 #include "test.h"
+
+#ifndef DRIVER_EXTERNAL_TESTS
 #include "tests.h"
+#endif
 
 #include <stdio.h>
 #ifdef HAVE_GETOPT_H
@@ -102,7 +105,11 @@ static void print_help(char *s)
 	printf("\n");
 }
 
+#ifdef DRIVER_EXTERNAL_MAIN
+gint run_tests_main(gint argc, gchar **argv)
+#else
 gint main(gint argc, gchar **argv)
+#endif
 {
 	gint i, j, c, iterations = 1;
 	StringArray *tests_to_run = NULL;


### PR DESCRIPTION
In current eglib test framework there is no mechanism to specify where the include file describing all tests is located. Current implementation also assumes it is the main entry point of the process since it defines the main symbol.

There are several scenarios where it could make sense to reuse eglib test framework and its driver in other native unit test projects. In those scenarios it would be nice to include existing driver.c from glib/test (no copy) and use toolchain capabilities to include needed header with test descriptions and change main symbol name, since main will most likely be defined elsewhere.

This can be achieved by two simple defines that can be set when embedding eglib test framwork in other
native binaries. By default these defines will not be set and current behavior will be preserved.