### PR TITLE
[System]: Rename MonoLegacyTlsProvider into LegacyTlsProvider.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.Droid.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.Droid.cs
@@ -18,7 +18,7 @@ namespace Mono.Net.Security
 			case null:
 			case "default":
 			case "legacy":
-				return new Private.MonoLegacyTlsProvider ();
+				return new LegacyTlsProvider ();
 			case "btls":
 #if HAVE_BTLS
 				if (!MonoBtlsProvider.IsSupported ())

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -155,7 +155,7 @@ namespace Mono.Net.Security
 				if (providerRegistration != null)
 					return;
 				providerRegistration = new Dictionary<string,string> ();
-				providerRegistration.Add ("legacy", "Mono.Net.Security.Private.MonoLegacyTlsProvider");
+				providerRegistration.Add ("legacy", "Mono.Net.Security.LegacyTlsProvider");
 #if HAVE_BTLS
 				if (Mono.Btls.MonoBtlsProvider.IsSupported ())
 					providerRegistration.Add ("btls", "Mono.Btls.MonoBtlsProvider");
@@ -183,7 +183,7 @@ namespace Mono.Net.Security
 			if (provider != null)
 				return provider;
 
-			return new Private.MonoLegacyTlsProvider ();
+			return new LegacyTlsProvider ();
 		}
 #endif
 

--- a/mcs/class/System/System.dll.sources
+++ b/mcs/class/System/System.dll.sources
@@ -544,7 +544,7 @@ Mono.Net.Security/IMonoSslStream.cs
 Mono.Net.Security/LegacySslStream.cs
 Mono.Net.Security/MobileAuthenticatedStream.cs
 Mono.Net.Security/MobileTlsContext.cs
-Mono.Net.Security/MonoLegacyTlsProvider.cs
+Mono.Net.Security/LegacyTlsProvider.cs
 Mono.Net.Security/MonoSslStreamImpl.cs
 Mono.Net.Security/MonoSslStreamWrapper.cs
 Mono.Net.Security/MonoTlsProviderFactory.cs

--- a/mcs/class/System/mobile_System.dll.sources
+++ b/mcs/class/System/mobile_System.dll.sources
@@ -292,7 +292,7 @@ Mono.Net.Security/IMonoSslStream.cs
 Mono.Net.Security/LegacySslStream.cs
 Mono.Net.Security/MobileAuthenticatedStream.cs
 Mono.Net.Security/MobileTlsContext.cs
-Mono.Net.Security/MonoLegacyTlsProvider.cs
+Mono.Net.Security/LegacyTlsProvider.cs
 Mono.Net.Security/MonoSslStreamImpl.cs
 Mono.Net.Security/MonoSslStreamWrapper.cs
 Mono.Net.Security/MonoTlsProviderFactory.cs

--- a/mcs/class/System/monotouch_watch_System.dll.exclude.sources
+++ b/mcs/class/System/monotouch_watch_System.dll.exclude.sources
@@ -1,5 +1,5 @@
 Mono.Net.Security/LegacySslStream.cs
-Mono.Net.Security/MonoLegacyTlsProvider.cs
+Mono.Net.Security/LegacyTlsProvider.cs
 System.Net.Mail/SmtpClient.cs
 System.Net.Sockets/TcpClient.cs
 System.Net.Sockets/TcpListener.cs


### PR DESCRIPTION
LegacyTlsProvider now lives in the 'Mono.Net.Security' namespace
(previously 'Mono.Net.Security.Private') and derives directly from
the public 'Mono.Security.Interface.MonoTlsProvider'.

This allows it to be used by products, for instance replacing
xamarin-macios/src/Security/Tls/OldTlsProvider.cs.

The idea is to have all 'MonoTlsProvider' implementations inside
System.dll and not access any of the private APIs from outside of it.