### PR TITLE
[System] Fix tests that regressed in e6536dd.

### DIFF
--- a/mcs/class/System/Test/System.Net.Mail/SmtpClientTest.cs
+++ b/mcs/class/System/Test/System.Net.Mail/SmtpClientTest.cs
@@ -34,6 +34,7 @@ namespace MonoTests.System.Net.Mail
 		[TearDown]
 		public void TearDown ()
 		{
+			_smtp = null;
 			if (Directory.Exists (tempFolder))
 				Directory.Delete (tempFolder, true);
 		}

--- a/mcs/class/System/Test/System.Net.Sockets/SocketAcceptAsyncTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketAcceptAsyncTest.cs
@@ -48,10 +48,9 @@ namespace MonoTests.System.Net.Sockets
 					if (listenSocket.AcceptAsync(asyncEventArgs))
 						return;
 					acceptedSocket = asyncEventArgs.AcceptSocket;
+					mainEvent.Set();
 				} catch (Exception e) {
 					ex = e;
-				} finally {
-					mainEvent.Set();
 				}
 			});
 			Assert.IsTrue(readyEvent.WaitOne(1500));

--- a/mcs/class/System/Test/System.Net/HttpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerTest.cs
@@ -44,6 +44,12 @@ namespace MonoTests.System.Net {
 			get { return _port ?? (_port = NetworkHelpers.FindFreePort ()).Value; }
 		}
 
+		[TearDown]
+		public void Teardown ()
+		{
+			_port = null;
+		}
+
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]


### PR DESCRIPTION
* I got confused between [TestFixtureSetup] and [Setup], so fix tests whose
  [Setup] methods were changed/removed to properly clean up after each test
  (using a [TearDown] method) so that the next time the on-demand creation of
  objects works as expected (i.e. objects created in the [Setup] method should
  be created on-demand once for each method instead of once for each class).

* Also fix SocketAcceptAsyncTest, the change to properly catch exceptions on
  background threads was incorrect.

This is backport of PR #3671.