### PR TITLE
[IO] Implement FileOptions.SequentialScan for Mac/BSD

### DIFF
--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -1763,6 +1763,9 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 		posix_fadvise (fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 	if (attrs & FILE_FLAG_RANDOM_ACCESS)
 		posix_fadvise (fd, 0, 0, POSIX_FADV_RANDOM);
+#elif defined(PLATFORM_MACOSX) || defined(PLATFORM_BSD)
+	if (attrs & FILE_FLAG_SEQUENTIAL_SCAN)
+		fcntl(fd, F_RDAHEAD, 1);
 #endif
 	
 #ifndef S_ISFIFO

--- a/mono/io-layer/io.c
+++ b/mono/io-layer/io.c
@@ -1763,11 +1763,13 @@ gpointer CreateFile(const gunichar2 *name, guint32 fileaccess,
 		posix_fadvise (fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 	if (attrs & FILE_FLAG_RANDOM_ACCESS)
 		posix_fadvise (fd, 0, 0, POSIX_FADV_RANDOM);
-#elif defined(PLATFORM_MACOSX) || defined(PLATFORM_BSD)
+#endif
+
+#ifdef F_RDAHEAD
 	if (attrs & FILE_FLAG_SEQUENTIAL_SCAN)
 		fcntl(fd, F_RDAHEAD, 1);
 #endif
-	
+
 #ifndef S_ISFIFO
 #define S_ISFIFO(m) ((m & S_IFIFO) != 0)
 #endif


### PR DESCRIPTION
The F_RDAHEAD define seems to be introduced in BSD, being the equivalent of POSIX_FADV_SEQUENTIAL.
This should improve sequential scanning speed by having the read ahead buffer doubled.
