### PR TITLE
[runtime] Use boxed MonoError for class failure.

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3058,9 +3058,15 @@ namespace MonoTests.System
 		public void MakeArrayTypeTest ()
 		{
 			// This should not crash:
-			typeof (void).MakeArrayType ();
+			Type t = typeof (void).MakeArrayType ();
 		}
 		
+		[Test]
+		[ExpectedException (typeof (InvalidProgramException))]
+		public void MakeArrayTypedReferenceInstanceTest ()
+		{
+			object o = Array.CreateInstance (typeof (global::System.TypedReference), 1);
+		}
 
 		[ComVisible (true)]
 		public class ComFoo<T> {

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1439,18 +1439,7 @@ mono_class_try_load_from_name (MonoImage *image, const char* name_space, const c
 void
 mono_error_set_for_class_failure (MonoError *orerror, MonoClass *klass);
 
-static inline guint8
-mono_class_get_failure (MonoClass *klass)
-{
-	g_assert (klass != NULL);
-	return klass->exception_type;
-}
-
-static inline gboolean
-mono_class_has_failure (MonoClass *klass)
-{
-	g_assert (klass != NULL);
-	return mono_class_get_failure (klass) != MONO_EXCEPTION_NONE;
-}
+gboolean
+mono_class_has_failure (MonoClass *klass);
 
 #endif /* __MONO_METADATA_CLASS_INTERNALS_H__ */

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1258,7 +1258,7 @@ const char*
 mono_lookup_jit_icall_symbol (const char *name);
 
 gboolean
-mono_class_set_failure (MonoClass *klass, guint32 ex_type, void *ex_data);
+mono_class_set_type_load_failure (MonoClass *klass, const char * fmt, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 gpointer
 mono_class_get_exception_data (MonoClass *klass);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -324,12 +324,7 @@ struct _MonoClass {
 	guint has_finalize_inited    : 1; /* has_finalize is initialized */
 	guint fields_inited : 1; /* fields is initialized */
 	guint setup_fields_called : 1; /* to prevent infinite loops in setup_fields */
-
-	guint8     exception_type;	/* MONO_EXCEPTION_* */
-
-	/* Additional information about the exception */
-	/* Stored as property MONO_CLASS_PROP_EXCEPTION_DATA */
-	//void       *exception_data;
+	guint has_failure : 1; /* See MONO_CLASS_PROP_EXCEPTION_DATA for a MonoErrorBoxed with the details */
 
 	MonoClass  *parent;
 	MonoClass  *nested_in;
@@ -1260,9 +1255,6 @@ mono_lookup_jit_icall_symbol (const char *name);
 gboolean
 mono_class_set_type_load_failure (MonoClass *klass, const char * fmt, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
-gpointer
-mono_class_get_exception_data (MonoClass *klass);
-
 MonoException*
 mono_class_get_exception_for_failure (MonoClass *klass);
 
@@ -1437,9 +1429,9 @@ MonoClass*
 mono_class_try_load_from_name (MonoImage *image, const char* name_space, const char *name);
 
 void
-mono_error_set_for_class_failure (MonoError *orerror, MonoClass *klass);
+mono_error_set_for_class_failure (MonoError *orerror, const MonoClass *klass);
 
 gboolean
-mono_class_has_failure (MonoClass *klass);
+mono_class_has_failure (const MonoClass *klass);
 
 #endif /* __MONO_METADATA_CLASS_INTERNALS_H__ */

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -78,6 +78,7 @@ static void mono_class_setup_vtable_full (MonoClass *klass, GList *in_setup);
 static void mono_generic_class_setup_parent (MonoClass *klass, MonoClass *gklass);
 
 static gboolean mono_class_set_failure (MonoClass *klass, guint32 ex_type, void *ex_data);
+static guint8 mono_class_get_failure (MonoClass *klass);
 
 
 /*
@@ -9928,6 +9929,21 @@ mono_class_set_failure (MonoClass *klass, guint32 ex_type, void *ex_data)
 
 	return TRUE;
 }
+
+static guint8
+mono_class_get_failure (MonoClass *klass)
+{
+	g_assert (klass != NULL);
+	return klass->exception_type;
+}
+
+gboolean
+mono_class_has_failure (MonoClass *klass)
+{
+	g_assert (klass != NULL);
+	return mono_class_get_failure (klass) != MONO_EXCEPTION_NONE;
+}
+
 
 /**
  * mono_class_set_type_load_failure:

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4433,8 +4433,8 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssembly *as
 		/* need to report exceptions ? */
 		if (throwOnError && mono_class_has_failure (klass)) {
 			/* report SecurityException (or others) that occured when loading the assembly */
-			MonoException *exc = mono_class_get_exception_for_failure (klass);
-			mono_set_pending_exception (exc);
+			mono_error_set_for_class_failure (&error, klass);
+			mono_error_set_pending_exception (&error);
 			return NULL;
 		}
 	}
@@ -6166,7 +6166,8 @@ ves_icall_RuntimeType_make_array_type (MonoReflectionType *type, int rank)
 
 	klass = mono_class_from_mono_type (type->type);
 	check_for_invalid_type (klass, &error);
-	mono_error_set_pending_exception (&error);
+	if (mono_error_set_pending_exception (&error))
+		return NULL;
 
 	if (rank == 0) //single dimentional array
 		aklass = mono_array_class_get (klass, 1);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6144,7 +6144,6 @@ static void
 check_for_invalid_type (MonoClass *klass, MonoError *error)
 {
 	char *name;
-	MonoString *str;
 
 	mono_error_init (error);
 
@@ -6152,10 +6151,7 @@ check_for_invalid_type (MonoClass *klass, MonoError *error)
 		return;
 
 	name = mono_type_get_full_name (klass);
-	str =  mono_string_new (mono_domain_get (), name);
-	g_free (name);
-	mono_error_set_exception_instance (error, mono_get_exception_type_load (str, NULL));
-
+	mono_error_set_type_load_name (error, name, g_strdup (""), "");
 }
 ICALL_EXPORT MonoReflectionType *
 ves_icall_RuntimeType_make_array_type (MonoReflectionType *type, int rank)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -9369,6 +9369,7 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 #endif
 
 	if (method->klass->valuetype && !(method->flags & MONO_METHOD_ATTR_STATIC)) {
+		/* FIXME Is this really the best way to signal an error here?  Isn't this called much later after class setup? -AK */
 		mono_class_set_type_load_failure (method->klass, "");
 #ifndef DISABLE_JIT
 		/* This will throw the type load exception when the wrapper is compiled */

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -9369,7 +9369,7 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 #endif
 
 	if (method->klass->valuetype && !(method->flags & MONO_METHOD_ATTR_STATIC)) {
-		mono_class_set_failure (method->klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+		mono_class_set_type_load_failure (method->klass, "");
 #ifndef DISABLE_JIT
 		/* This will throw the type load exception when the wrapper is compiled */
 		mono_mb_emit_byte (mb, CEE_LDNULL);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1890,7 +1890,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 		if (mono_class_has_failure (element_class)) {
 			/*Can happen if element_class only got bad after mono_class_setup_vtable*/
 			if (!mono_class_has_failure (klass))
-				mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+				mono_class_set_type_load_failure (klass, "");
 			mono_domain_unlock (domain);
 			mono_loader_unlock ();
 			mono_error_set_for_class_failure (error, klass);

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -166,7 +166,7 @@ set_type_load_exception_type (const char *format, MonoClass *klass)
 	g_free (type_name);
 	
 	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, "%s", message);
-	mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, message);
+	mono_class_set_type_load_failure (klass, "%s", message);
 	// note: do not free string given to mono_class_set_failure
 }
 
@@ -189,7 +189,7 @@ set_type_load_exception_methods (const char *format, MonoMethod *override, MonoM
 	g_free (method_name);
 
 	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, "%s", message);
-	mono_class_set_failure (override->klass, MONO_EXCEPTION_TYPE_LOAD, message);
+	mono_class_set_type_load_failure (override->klass, "%s", message);
 	// note: do not free string given to mono_class_set_failure
 }
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3053,7 +3053,7 @@ ensure_runtime_vtable (MonoClass *klass, MonoError *error)
 		}
 	} else if (klass->generic_class){
 		if (!ensure_generic_class_runtime_vtable (klass, error)) {
-			mono_class_set_type_load_failure (klass, "");
+			mono_class_set_type_load_failure (klass, "Could not initialize vtable for generic class due to: %s", mono_error_get_message (error));
 			return FALSE;
 		}
 	}
@@ -3380,7 +3380,7 @@ remove_instantiations_of_and_ensure_contents (gpointer key,
 		MonoClass *inst_klass = mono_class_from_mono_type (type);
 		//Ensure it's safe to use it.
 		if (!fix_partial_generic_class (inst_klass, error)) {
-			mono_class_set_type_load_failure (inst_klass, "");
+			mono_class_set_type_load_failure (inst_klass, "Could not initialized generic type instance due to: %s", mono_error_get_message (error));
 			// Marked the class with failure, but since some other instantiation already failed,
 			// just report that one, and swallow the error from this one.
 			if (already_failed)
@@ -3512,7 +3512,7 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilder *tb)
 	mono_loader_unlock ();
 
 	if (klass->enumtype && !mono_class_is_valid_enum (klass)) {
-		mono_class_set_type_load_failure (klass, "");
+		mono_class_set_type_load_failure (klass, "Not a valid enumeration");
 		mono_error_set_type_load_class (&error, klass, "Not a valid enumeration");
 		goto failure_unlocked;
 	}
@@ -3526,7 +3526,7 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilder *tb)
 	return res;
 
 failure:
-	mono_class_set_type_load_failure (klass, "");
+	mono_class_set_type_load_failure (klass, "TypeBuilder could not create runtime class due to: %s", mono_error_get_message (&error));
 	klass->wastypebuilder = TRUE;
 	mono_domain_unlock (domain);
 	mono_loader_unlock ();

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3053,7 +3053,7 @@ ensure_runtime_vtable (MonoClass *klass, MonoError *error)
 		}
 	} else if (klass->generic_class){
 		if (!ensure_generic_class_runtime_vtable (klass, error)) {
-			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+			mono_class_set_type_load_failure (klass, "");
 			return FALSE;
 		}
 	}
@@ -3185,8 +3185,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 
 	if (tb->class_size) {
 		if ((tb->packing_size & 0xffffff00) != 0) {
-			char *err_msg = mono_image_strdup_printf (klass->image, "Could not load struct '%s' with packing size %d >= 256", klass->name, tb->packing_size);
-			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, err_msg);
+			mono_class_set_type_load_failure (klass, "Could not load struct '%s' with packing size %d >= 256", klass->name, tb->packing_size);
 			return;
 		}
 		klass->packing_size = tb->packing_size;
@@ -3381,7 +3380,7 @@ remove_instantiations_of_and_ensure_contents (gpointer key,
 		MonoClass *inst_klass = mono_class_from_mono_type (type);
 		//Ensure it's safe to use it.
 		if (!fix_partial_generic_class (inst_klass, error)) {
-			mono_class_set_failure (inst_klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+			mono_class_set_type_load_failure (inst_klass, "");
 			// Marked the class with failure, but since some other instantiation already failed,
 			// just report that one, and swallow the error from this one.
 			if (already_failed)
@@ -3513,7 +3512,7 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilder *tb)
 	mono_loader_unlock ();
 
 	if (klass->enumtype && !mono_class_is_valid_enum (klass)) {
-		mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+		mono_class_set_type_load_failure (klass, "");
 		mono_error_set_type_load_class (&error, klass, "Not a valid enumeration");
 		goto failure_unlocked;
 	}
@@ -3527,7 +3526,7 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilder *tb)
 	return res;
 
 failure:
-	mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+	mono_class_set_type_load_failure (klass, "");
 	klass->wastypebuilder = TRUE;
 	mono_domain_unlock (domain);
 	mono_loader_unlock ();

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -75,6 +75,9 @@ void
 mono_error_set_type_load_class (MonoError *error, MonoClass *klass, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
+mono_error_vset_type_load_class (MonoError *error, MonoClass *klass, const char *msg_format, va_list args);
+
+void
 mono_error_set_type_load_name (MonoError *error, const char *type_name, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -32,6 +32,12 @@ typedef struct {
 	void *padding [3];
 } MonoErrorInternal;
 
+/* Invariant: the error strings are allocated in the mempool of the given image */
+struct _MonoErrorBoxed {
+	MonoError error;
+	MonoImage *image;
+};
+
 #define error_init(error) do {	\
 	((MonoErrorInternal*)(error))->error_code = MONO_ERROR_NONE;	\
 	((MonoErrorInternal*)(error))->flags = 0;	\
@@ -127,5 +133,12 @@ mono_error_raise_exception (MonoError *error);
 
 void
 mono_error_move (MonoError *dest, MonoError *src);
+
+MonoErrorBoxed*
+mono_error_box (const MonoError *error, MonoImage *image);
+
+gboolean
+mono_error_set_from_boxed (MonoError *error, const MonoErrorBoxed *from);
+
 
 #endif

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -303,12 +303,21 @@ mono_error_set_assembly_load_simple (MonoError *oerror, const char *assembly_nam
 void
 mono_error_set_type_load_class (MonoError *oerror, MonoClass *klass, const char *msg_format, ...)
 {
+	va_list args;
+	va_start (args, msg_format);
+	mono_error_vset_type_load_class (oerror, klass, msg_format, args);
+	va_end (args);
+}
+
+void
+mono_error_vset_type_load_class (MonoError *oerror, MonoClass *klass, const char *msg_format, va_list args)
+{
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 	mono_error_prepare (error);
 
 	error->error_code = MONO_ERROR_TYPE_LOAD;
 	mono_error_set_class (oerror, klass);
-	set_error_message ();
+	set_error_messagev ();
 }
 
 /*

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -12,7 +12,11 @@ enum {
 	/*
 	Something happened while processing the error and the resulting message is incomplete.
 	*/
-	MONO_ERROR_INCOMPLETE = 0x0002
+	MONO_ERROR_INCOMPLETE = 0x0002,
+	/*
+	This MonoError is heap allocated in a mempool
+        */
+	MONO_ERROR_MEMPOOL_BOXED = 0x0004
 };
 
 enum {
@@ -47,6 +51,9 @@ typedef struct _MonoError {
 
 	void *hidden_1 [12]; /*DON'T TOUCH */
 } MonoError;
+
+/* Mempool-allocated MonoError.*/
+typedef struct _MonoErrorBoxed MonoErrorBoxed;
 
 MONO_BEGIN_DECLS
 


### PR DESCRIPTION
- Add a new `MonoErrorBoxed` type that stores MonoError details in a mempool.
- Use `MonoErrorBoxed` for the `MONO_CLASS_PROP_EXCEPTION_DATA` property for a failed `MonoClass`
- Use a single `MonoClass:has_failure` bit instead of the old `MonoClass::exception_type` byte to signal a class failure.