### PR TITLE
Duplicate the behaviour of .NET when calculating DateTime.Now() within ambiguous hour

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -868,7 +868,7 @@ namespace System
 			AdjustmentRule rule = GetApplicableRule (dateTime);
 			if (rule != null) {
 				DateTime tpoint = TransitionPoint (rule.DaylightTransitionEnd, dateTime.Year);
-				if (dateTime > tpoint - rule.DaylightDelta  && dateTime <= tpoint)
+				if (dateTime > tpoint - rule.DaylightDelta && dateTime <= tpoint)
 					return true;
 			}
 				
@@ -1185,28 +1185,15 @@ namespace System
 			}
 
 			var inDelta = false;
-			for (var i =  transitions.Count - 1; i >= 0; i--) {
-				var pair = transitions [i];
-				DateTime ttime = pair.Key;
-				TimeType ttype = pair.Value;
-
-				var delta =  new TimeSpan (0, 0, ttype.Offset) - BaseUtcOffset;
-
-				if ((ttime + delta) > date) {
-					inDelta = ttime <= date;
-					continue;
+			AdjustmentRule current = GetApplicableRule(date);
+			if (current != null) {
+				DateTime tStart = TransitionPoint(current.DaylightTransitionStart, date.Year);
+				DateTime tEnd = TransitionPoint(current.DaylightTransitionEnd, date.Year);
+				if ((date >= tStart) && (date <= tEnd)) {
+					offset = baseUtcOffset + current.DaylightDelta; 
+					isDst = true;
+					return true;
 				}
-
-				offset =  new TimeSpan (0, 0, ttype.Offset);
-				if (inDelta) {
-					// Replicate what .NET does when given a time which falls into the hour which is lost when
-					// DST starts. isDST should be true but the offset should be the non-DST offset.
-					isDst = transitions [i - 1].Value.IsDst;
-				} else {
-					isDst = ttype.IsDst;
-				}
-
-				return true;
 			}
 
 			return false;
@@ -1496,10 +1483,9 @@ namespace System
 			isAmbiguousLocalDst = false;
 			TimeSpan baseOffset = zone.BaseUtcOffset;
 
-			if (zone.IsAmbiguousTime (time)) {
+			// In .NET if we are in the ambiguous time then we return the DST version  
+			if (zone.IsAmbiguousTime (time))
 				isAmbiguousLocalDst = true;
-				return baseOffset;
-			}
 
 			return zone.GetUtcOffset (time, out isDaylightSavings);
 		}


### PR DESCRIPTION
During the ambiguous hour .NET will return the DST version of the time whereas mono is returning the base time. Rather than use the transitions array we look up the Adjustment rules (which are created from the transition rules in the first place).
