### PR TITLE
Add MONO_ATTR_FORMAT_PRINTF macro

### DIFF
--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -2806,7 +2806,7 @@ process_wait (gpointer handle, guint32 timeout, gboolean *alerted)
 	while (1) {
 		if (timeout != INFINITE) {
 			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): waiting on semaphore for %li ms...", 
-				   __func__, handle, timeout, (timeout - (now - start)));
+				    __func__, handle, timeout, (long)(timeout - (now - start)));
 			ret = mono_os_sem_timedwait (&mp->exit_sem, (timeout - (now - start)), alerted ? MONO_SEM_FLAGS_ALERTABLE : MONO_SEM_FLAGS_NONE);
 		} else {
 			MONO_TRACE (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %u): waiting on semaphore forever...", 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1391,7 +1391,7 @@ mono_error_set_for_class_failure (MonoError *oerror, MonoClass *klass)
 		return;
 	}
 	case MONO_EXCEPTION_INVALID_PROGRAM: {
-		mono_error_set_invalid_program (oerror, (const char *)exception_data);
+		mono_error_set_invalid_program (oerror, "%s", (const char *)exception_data);
 		return;
 	}
 	case MONO_EXCEPTION_MISSING_METHOD:
@@ -5696,7 +5696,7 @@ static void
 mono_class_set_failure_and_error (MonoClass *klass, MonoError *error, const char *msg)
 {
 	mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, mono_image_strdup (klass->image, msg));
-	mono_error_set_type_load_class (error, klass, msg);
+	mono_error_set_type_load_class (error, klass, "%s", msg);
 }
 
 /**

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -194,7 +194,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 	fname = mono_metadata_string_heap (image, cols [MONO_MEMBERREF_NAME]);
 
 	if (!mono_verifier_verify_memberref_field_signature (image, cols [MONO_MEMBERREF_SIGNATURE], NULL)) {
-		mono_error_set_bad_image (error, image, "Bad field '%s' signature 0x%08x", class_index, token);
+		mono_error_set_bad_image (error, image, "Bad field '%u' signature 0x%08x", class_index, token);
 		return NULL;
 	}
 
@@ -209,7 +209,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 		klass = mono_class_get_and_inflate_typespec_checked (image, MONO_TOKEN_TYPE_SPEC | nindex, context, error);
 		break;
 	default:
-		mono_error_set_bad_image (error, image, "Bad field field '%s' signature 0x%08x", class_index, token);
+		mono_error_set_bad_image (error, image, "Bad field field '%u' signature 0x%08x", class_index, token);
 	}
 
 	if (!klass)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -10531,7 +10531,7 @@ mono_marshal_alloc (gulong size, MonoError *error)
 #else
 	res = g_try_malloc ((gulong)size);
 	if (!res)
-		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", size);
+		mono_error_set_out_of_memory (error, "Could not allocate %lu bytes", size);
 #endif
 	return res;
 }

--- a/mono/metadata/mempool-internals.h
+++ b/mono/metadata/mempool-internals.h
@@ -61,7 +61,7 @@ char*
 mono_mempool_strdup_vprintf (MonoMemPool *pool, const char *format, va_list args);
 
 char*
-mono_mempool_strdup_printf (MonoMemPool *pool, const char *format, ...);
+mono_mempool_strdup_printf (MonoMemPool *pool, const char *format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);;
 
 long
 mono_mempool_get_bytes_allocated (void);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -643,7 +643,7 @@ char*
 mono_image_strdup_vprintf (MonoImage *image, const char *format, va_list args);
 
 char*
-mono_image_strdup_printf (MonoImage *image, const char *format, ...);
+mono_image_strdup_printf (MonoImage *image, const char *format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);;
 
 GList*
 g_list_prepend_image (MonoImage *image, GList *list, gpointer data);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5822,7 +5822,7 @@ mono_array_new_full_checked (MonoDomain *domain, MonoClass *array_class, uintptr
 		o = (MonoObject *)mono_gc_alloc_vector (vtable, byte_len, len);
 
 	if (G_UNLIKELY (!o)) {
-		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", byte_len);
+		mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", (gsize) byte_len);
 		return NULL;
 	}
 
@@ -5936,7 +5936,7 @@ mono_array_new_specific_checked (MonoVTable *vtable, uintptr_t n, MonoError *err
 	o = (MonoObject *)mono_gc_alloc_vector (vtable, byte_len, n);
 
 	if (G_UNLIKELY (!o)) {
-		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", byte_len);
+		mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", (gsize) byte_len);
 		return NULL;
 	}
 
@@ -6094,7 +6094,7 @@ mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error)
 	s = (MonoString *)mono_gc_alloc_string (vtable, size, len);
 
 	if (G_UNLIKELY (!s)) {
-		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", size);
+		mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", size);
 		return NULL;
 	}
 

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -165,7 +165,7 @@ set_type_load_exception_type (const char *format, MonoClass *klass)
 	g_free (parent_name);
 	g_free (type_name);
 	
-	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, message);
+	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, "%s", message);
 	mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, message);
 	// note: do not free string given to mono_class_set_failure
 }
@@ -188,7 +188,7 @@ set_type_load_exception_methods (const char *format, MonoMethod *override, MonoM
 	g_free (base_name);
 	g_free (method_name);
 
-	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, message);
+	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, "%s", message);
 	mono_class_set_failure (override->klass, MONO_EXCEPTION_TYPE_LOAD, message);
 	// note: do not free string given to mono_class_set_failure
 }
@@ -561,7 +561,7 @@ get_argument_exception (const char *format, MonoMethod *caller, MonoMethod *call
 	g_free (callee_name);
 	g_free (caller_name);
 
-	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, message);
+	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, "%s", message);
 	ex = mono_get_exception_argument ("method", message);
 	g_free (message);
 
@@ -586,7 +586,7 @@ get_field_access_exception (const char *format, MonoMethod *caller, MonoClassFie
 	g_free (field_name);
 	g_free (caller_name);
 
-	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, message);
+	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, "%s", message);
 	ex = mono_get_exception_field_access_msg (message);
 	g_free (message);
 
@@ -611,7 +611,7 @@ get_method_access_exception (const char *format, MonoMethod *caller, MonoMethod 
 	g_free (callee_name);
 	g_free (caller_name);
 
-	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, message);
+	mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_SECURITY, "%s", message);
 	ex = mono_get_exception_method_access_msg (message);
 	g_free (message);
 

--- a/mono/metadata/sgen-new-bridge.c
+++ b/mono/metadata/sgen-new-bridge.c
@@ -1030,7 +1030,7 @@ processing_after_callback (int generation)
 			for (j = 0; j < api_sccs [i]->num_objs; ++j) {
 				GCVTable vtable = SGEN_LOAD_VTABLE (api_sccs [i]->objs [j]);
 				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC,
-					"OBJECT %s (%p) SCC [%d] %s",
+					"OBJECT %s.%s (%p) SCC [%d] %s",
 						sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable), api_sccs [i]->objs [j],
 						i,
 						api_sccs [i]->is_alive  ? "ALIVE" : "DEAD");

--- a/mono/metadata/threadpool-ms.c
+++ b/mono/metadata/threadpool-ms.c
@@ -658,7 +658,7 @@ worker_thread (gpointer data)
 		tpdomain->outstanding_request --;
 		g_assert (tpdomain->outstanding_request >= 0);
 
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] worker running in domain %p",
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] worker running in domain %p (outstanding requests %d) ",
 			mono_native_thread_id_get (), tpdomain->domain, tpdomain->outstanding_request);
 
 		g_assert (tpdomain->domain);
@@ -778,7 +778,7 @@ worker_try_create (void)
 	if ((thread = mono_thread_create_internal (mono_get_root_domain (), worker_thread, NULL, TRUE, 0, &error)) != NULL) {
 		threadpool->worker_creation_current_count += 1;
 
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] try create worker, created %p, now = %d count = %d", mono_native_thread_id_get (), thread->tid, now, threadpool->worker_creation_current_count);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] try create worker, created %p, now = %d count = %d", mono_native_thread_id_get (), GUINT_TO_POINTER(thread->tid), now, threadpool->worker_creation_current_count);
 		mono_coop_mutex_unlock (&threadpool->worker_creation_lock);
 		return TRUE;
 	}

--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -412,7 +412,7 @@ ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
 		ret = FALSE;
 
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: we don't own %s handle %p (owned by %ld, me %ld)",
-			__func__, mono_w32handle_ops_typename (type), handle, mutex_handle->tid, tid);
+			    __func__, mono_w32handle_ops_typename (type), handle, (long)mutex_handle->tid, (long)tid);
 	} else {
 		ret = TRUE;
 

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -184,7 +184,7 @@ namedsem_create (gint32 initial, gint32 max, const gunichar2 *name)
 	gchar *utf8_name;
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: creating %s handle, initial %d max %d name \"%s\"",
-		__func__, mono_w32handle_ops_typename (MONO_W32HANDLE_NAMEDSEM), initial, max, name);
+		    __func__, mono_w32handle_ops_typename (MONO_W32HANDLE_NAMEDSEM), initial, max, (const char*)name);
 
 	/* w32 seems to guarantee that opening named objects can't race each other */
 	mono_w32handle_namespace_lock ();

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1052,7 +1052,7 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 					else if (info->exception_type == MONO_EXCEPTION_FIELD_ACCESS)
 						mono_error_set_generic_error (&cfg->error, "System", "FieldAccessException", "%s", msg);
 					else if (info->exception_type == MONO_EXCEPTION_UNVERIFIABLE_IL)
-						mono_error_set_generic_error (&cfg->error, "System.Security", "VerificationException", msg);
+						mono_error_set_generic_error (&cfg->error, "System.Security", "VerificationException", "%s", msg);
 					if (!mono_error_ok (&cfg->error)) {
 						mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 						g_free (msg);
@@ -4053,7 +4053,7 @@ void
 mono_cfg_set_exception_invalid_program (MonoCompile *cfg, char *msg)
 {
 	mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
-	mono_error_set_generic_error (&cfg->error, "System", "InvalidProgramException", msg);
+	mono_error_set_generic_error (&cfg->error, "System", "InvalidProgramException", "%s", msg);
 }
 
 #endif /* DISABLE_JIT */

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -295,7 +295,7 @@ sgen_output_log_entry (SgenLogEntry *entry, gint64 stw_time, int generation)
 
 	switch (entry->type) {
 		case SGEN_LOG_NURSERY:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) time %.2fms, %s promoted %dK major size: %dK in use: %dK los size: %dK in use: %dK",
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) time %.2fms, %s promoted %zdK major size: %zdK in use: %zdK los size: %zdK in use: %zdK",
 				entry->is_overflow ? "_OVERFLOW" : "",
 				entry->reason ? entry->reason : "",
 				entry->time / 10000.0f,
@@ -307,7 +307,7 @@ sgen_output_log_entry (SgenLogEntry *entry, gint64 stw_time, int generation)
 				entry->los_size_in_use / 1024);
 			break;
 		case SGEN_LOG_MAJOR_SERIAL:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) time %.2fms, %s los size: %dK in use: %dK",
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) time %.2fms, %s los size: %zdK in use: %zdK",
 				entry->is_overflow ? "_OVERFLOW" : "",
 				entry->reason ? entry->reason : "",
 				(int)entry->time / 10000.0f,
@@ -319,7 +319,7 @@ sgen_output_log_entry (SgenLogEntry *entry, gint64 stw_time, int generation)
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_CONCURRENT_START: (%s)", entry->reason ? entry->reason : "");
 			break;
 		case SGEN_LOG_MAJOR_CONC_FINISH:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_CONCURRENT_FINISH: (%s) time %.2fms, %s los size: %dK in use: %dK",
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_CONCURRENT_FINISH: (%s) time %.2fms, %s los size: %zdK in use: %zdK",
 				entry->reason ? entry->reason : "",
 				entry->time / 10000.0f,
 				full_timing_buff,
@@ -327,7 +327,7 @@ sgen_output_log_entry (SgenLogEntry *entry, gint64 stw_time, int generation)
 				entry->los_size_in_use / 1024);
 			break;
 		case SGEN_LOG_MAJOR_SWEEP_FINISH:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major size: %dK in use: %dK",
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major size: %zdK in use: %zdK",
 				entry->major_size / 1024,
 				entry->major_size_in_use / 1024);
 			break;

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -207,7 +207,7 @@ void check_metadata_store_local(void *from, void *to);
 
 void checked_build_thread_transition(const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta);
 
-G_GNUC_NORETURN void mono_fatal_with_history(const char *msg, ...);
+G_GNUC_NORETURN void mono_fatal_with_history(const char *msg, ...) MONO_ATTR_FORMAT_PRINTF(1,2);
 
 #else
 

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -12,6 +12,7 @@
 
 #include <config.h>
 #include <mono/utils/atomic.h>
+#include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-publib.h>
 
 typedef enum {
@@ -207,7 +208,7 @@ void check_metadata_store_local(void *from, void *to);
 
 void checked_build_thread_transition(const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta);
 
-G_GNUC_NORETURN void mono_fatal_with_history(const char *msg, ...) MONO_ATTR_FORMAT_PRINTF(1,2);
+G_GNUC_NORETURN MONO_ATTR_FORMAT_PRINTF(1,2) void mono_fatal_with_history(const char *msg, ...);
 
 #else
 

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -13,6 +13,12 @@
 #define MONO_ATTR_USED
 #endif
 
+#ifdef __GNUC__
+#define MONO_ATTR_FORMAT_PRINTF(fmt_pos,arg_pos) __attribute__((format(printf,fmt_pos,arg_pos)))
+#else
+#define MONO_ATTR_FORMAT_PRINTF(fmt_pos,arg_pos)
+#endif
+
 #ifdef HAVE_KW_THREAD
 
 #define MONO_HAVE_FAST_TLS

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -57,64 +57,64 @@ mono_error_dup_strings (MonoError *error, gboolean dup_strings);
 
 /* This function is not very useful as you can't provide any details beyond the message.*/
 void
-mono_error_set_error (MonoError *error, int error_code, const char *msg_format, ...);
+mono_error_set_error (MonoError *error, int error_code, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_assembly_load (MonoError *error, const char *assembly_name, const char *msg_format, ...);
+mono_error_set_assembly_load (MonoError *error, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
 mono_error_set_assembly_load_simple (MonoError *error, const char *assembly_name, gboolean refection_only);
 
 void
-mono_error_set_type_load_class (MonoError *error, MonoClass *klass, const char *msg_format, ...);
+mono_error_set_type_load_class (MonoError *error, MonoClass *klass, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_type_load_name (MonoError *error, const char *type_name, const char *assembly_name, const char *msg_format, ...);
+mono_error_set_type_load_name (MonoError *error, const char *type_name, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_method_load (MonoError *error, MonoClass *klass, const char *method_name, const char *msg_format, ...);
+mono_error_set_method_load (MonoError *error, MonoClass *klass, const char *method_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_field_load (MonoError *error, MonoClass *klass, const char *field_name, const char *msg_format, ...);
+mono_error_set_field_load (MonoError *error, MonoClass *klass, const char *field_name, const char *msg_format, ...)  MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_bad_image (MonoError *error, MonoImage *image, const char *msg_format, ...);
+mono_error_set_bad_image (MonoError *error, MonoImage *image, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_bad_image_name (MonoError *error, const char *file_name, const char *msg_format, ...);
+mono_error_set_bad_image_name (MonoError *error, const char *file_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_out_of_memory (MonoError *error, const char *msg_format, ...);
+mono_error_set_out_of_memory (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
-mono_error_set_argument (MonoError *error, const char *argument, const char *msg_format, ...);
+mono_error_set_argument (MonoError *error, const char *argument, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_argument_null (MonoError *oerror, const char *argument, const char *msg_format, ...);
+mono_error_set_argument_null (MonoError *oerror, const char *argument, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_not_verifiable (MonoError *oerror, MonoMethod *method, const char *msg_format, ...);
+mono_error_set_not_verifiable (MonoError *oerror, MonoMethod *method, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_generic_error (MonoError *error, const char * name_space, const char *name, const char *msg_format, ...);
+mono_error_set_generic_error (MonoError *error, const char * name_space, const char *name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_execution_engine (MonoError *error, const char *msg_format, ...);
+mono_error_set_execution_engine (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
-mono_error_set_not_implemented (MonoError *error, const char *msg_format, ...);
+mono_error_set_not_implemented (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
-mono_error_set_not_supported (MonoError *error, const char *msg_format, ...);
+mono_error_set_not_supported (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
-mono_error_set_invalid_operation (MonoError *error, const char *msg_format, ...);
+mono_error_set_invalid_operation (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
 mono_error_set_exception_instance (MonoError *error, MonoException *exc);
 
 void
-mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...);
+mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 MonoException*
 mono_error_prepare_exception (MonoError *error, MonoError *error_out);

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -2,6 +2,7 @@
 #define __MONO_LOGGER_INTERNAL_H__
 
 #include <glib.h>
+#include <mono/utils/mono-compiler.h>
 #include "mono-logger.h"
 
 G_BEGIN_DECLS
@@ -74,8 +75,8 @@ mono_tracev (GLogLevelFlags level, MonoTraceMask mask, const char *format, va_li
  * Traces a new message, depending on the current logging level
  * and trace mask.
  */
-G_GNUC_UNUSED static void
-mono_trace (GLogLevelFlags level, MonoTraceMask mask, const char *format, ...) 
+G_GNUC_UNUSED MONO_ATTR_FORMAT_PRINTF(3,4) static void
+mono_trace (GLogLevelFlags level, MonoTraceMask mask, const char *format, ...)
 {
 	if(G_UNLIKELY (level <= mono_internal_current_level && mask & mono_internal_current_mask)) {
 		va_list args;

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -70,7 +70,7 @@ coop_tls_pop (gpointer received_cookie)
 
 	stack = mono_native_tls_get_value (coop_reset_count_stack_key);
 	if (!stack || 0 == stack->len)
-		mono_fatal_with_history ("Received cookie %p but found no stack at all, %x\n", received_cookie);
+		mono_fatal_with_history ("Received cookie %p but found no stack at all\n", received_cookie);
 
 	expected_cookie = g_array_index (stack, gpointer, stack->len - 1);
 	stack->len --;

--- a/mono/utils/w32handle.c
+++ b/mono/utils/w32handle.c
@@ -1295,7 +1295,7 @@ mono_w32handle_wait_multiple (gpointer *handles, gsize nhandles, gboolean waital
 	alerted = FALSE;
 
 	if (nhandles > MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_W32HANDLE, "%s: too many handles: %d",
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_W32HANDLE, "%s: too many handles: %zd",
 			__func__, nhandles);
 
 		return MONO_W32HANDLE_WAIT_RET_FAILED;


### PR DESCRIPTION
The macro expands to `__attribute__((format(printf,X,Y)))` which checks that the X-th argument to a function is a printf-like format string and the rest of arguments starting from Y are the corresponding values.

Applied the macro to most of our printf-like error and loging functions.

Fixed the resulting warnings.