### PR TITLE
Build libmono under none desktop Windows API family.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -373,6 +373,7 @@ darwin_sources = \
 
 windows_sources = \
 	mini-windows.c \
+	mini-windows.h \
 	mini-windows-dllmain.c
 
 posix_sources = \

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8895,13 +8895,13 @@ emit_extra_methods (MonoAotCompile *acfg)
 static void
 generate_aotid (guint8* aotid)
 {
-	gpointer *rand_handle;
+	gpointer rand_handle;
 	MonoError error;
 
 	mono_rand_open ();
 	rand_handle = mono_rand_init (NULL, 0);
 
-	mono_rand_try_get_bytes (rand_handle, aotid, 16, &error);
+	mono_rand_try_get_bytes (&rand_handle, aotid, 16, &error);
 	mono_error_assert_ok (&error);
 
 	mono_rand_close (rand_handle);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -71,6 +71,7 @@
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/networking.h>
+#include <mono/utils/mono-proclib.h>
 #include "debugger-agent.h"
 #include "mini.h"
 #include "seq-points.h"
@@ -932,7 +933,7 @@ mono_debugger_agent_parse_options (char *options)
 		/* Waiting for deferred attachment */
 		agent_config.defer = TRUE;
 		if (agent_config.address == NULL) {
-			agent_config.address = g_strdup_printf ("0.0.0.0:%u", 56000 + (getpid () % 1000));
+			agent_config.address = g_strdup_printf ("0.0.0.0:%u", 56000 + (mono_process_current_pid () % 1000));
 		}
 	}
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2113,7 +2113,7 @@ mono_main (int argc, char* argv[])
 			exit (1);
 		}
 
-#ifdef HOST_WIN32
+#if defined(HOST_WIN32) && G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 		/* Detach console when executing IMAGE_SUBSYSTEM_WINDOWS_GUI on win32 */
 		if (!enable_debugging && !mono_compile_aot && ((MonoCLIImageInfo*)(mono_assembly_get_image (assembly)->image_info))->cli_header.nt.pe_subsys_required == IMAGE_SUBSYSTEM_WINDOWS_GUI)
 			FreeConsole ();

--- a/mono/mini/mini-windows-uwp.c
+++ b/mono/mini/mini-windows-uwp.c
@@ -1,0 +1,43 @@
+/*
+ * mini-windows-uwp.c: UWP profiler stat support for Mono.
+ *
+ * Copyright 2016 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#include <config.h>
+#include <glib.h>
+
+#if G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT)
+#include <Windows.h>
+
+void
+mono_runtime_setup_stat_profiler (void)
+{
+	g_unsupported_api ("OpenThread, GetThreadContext");
+	SetLastError (ERROR_NOT_SUPPORTED);
+	return;
+}
+
+void
+mono_runtime_shutdown_stat_profiler (void)
+{
+	g_unsupported_api ("OpenThread, GetThreadContext");
+	SetLastError (ERROR_NOT_SUPPORTED);
+	return;
+}
+
+static gboolean
+mono_setup_thread_context(DWORD thread_id, MonoContext *mono_context)
+{
+	memset (mono_context, 0, sizeof (MonoContext));
+	return FALSE;
+}
+
+#else /* G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT) */
+
+#ifdef _MSC_VER
+// Quiet Visual Studio linker warning, LNK4221, in cases when this source file intentional ends up empty.
+void __mono_win32_mini_windows_uwp_quiet_lnk4221(void) {}
+#endif
+#endif /* G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT) */
+

--- a/mono/mini/mini-windows.h
+++ b/mono/mini/mini-windows.h
@@ -1,0 +1,15 @@
+#ifndef __MONO_MINI_WINDOWS_H__
+#define __MONO_MINI_WINDOWS_H__
+
+#include <config.h>
+#include <glib.h>
+
+#ifdef HOST_WIN32
+#include "Windows.h"
+#include "mini.h"
+#include "mono/utils/mono-context.h"
+
+gboolean
+mono_setup_thread_context(DWORD thread_id, MonoContext *mono_context);
+#endif /* HOST_WIN32 */
+#endif /* __MONO_MINI_WINDOWS_H__ */

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -33,6 +33,7 @@
 
 #define IS_REX(inst) (((inst) >= 0x40) && ((inst) <= 0x4f))
 
+#ifndef DISABLE_JIT
 /*
  * mono_arch_get_unbox_trampoline:
  * @m: method pointer
@@ -110,6 +111,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericCo
 
 	return start;
 }
+#endif /* !DISABLE_JIT */
 
 #ifdef _WIN64
 // Workaround lack of Valgrind support for 64-bit Windows
@@ -171,6 +173,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 	}
 }
 
+#ifndef DISABLE_JIT
 guint8*
 mono_arch_create_llvm_native_thunk (MonoDomain *domain, guint8 *addr)
 {
@@ -190,6 +193,7 @@ mono_arch_create_llvm_native_thunk (MonoDomain *domain, guint8 *addr)
 	mono_profiler_code_buffer_new (thunk_start, thunk_code - thunk_start, MONO_PROFILER_CODE_BUFFER_HELPER, NULL);
 	return addr;
 }
+#endif /* !DISABLE_JIT */
 
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
@@ -208,6 +212,7 @@ mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *a
 	InterlockedExchangePointer (plt_jump_table_entry, addr);
 }
 
+#ifndef DISABLE_JIT
 static void
 stack_unaligned (MonoTrampolineType tramp_type)
 {
@@ -756,6 +761,7 @@ mono_arch_invalidate_method (MonoJitInfo *ji, void *func, gpointer func_arg)
 	x86_push_imm (code, (guint64)func_arg);
 	amd64_call_reg (code, AMD64_R11);
 }
+#endif /* !DISABLE_JIT */
 
 gpointer
 mono_amd64_handler_block_trampoline_helper (void)
@@ -764,6 +770,7 @@ mono_amd64_handler_block_trampoline_helper (void)
 	return jit_tls->handler_block_return_address;
 }
 
+#ifndef DISABLE_JIT
 gpointer
 mono_arch_create_handler_block_trampoline (MonoTrampInfo **info, gboolean aot)
 {
@@ -832,6 +839,7 @@ mono_arch_create_handler_block_trampoline (MonoTrampInfo **info, gboolean aot)
 
 	return buf;
 }
+#endif /* !DISABLE_JIT */
 
 /*
  * mono_arch_get_call_target:
@@ -862,6 +870,7 @@ mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
 	return *(guint32*)(plt_entry + 6);
 }
 
+#ifndef DISABLE_JIT
 /*
  * mono_arch_create_sdb_trampoline:
  *
@@ -960,3 +969,69 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 
 	return buf;
 }
+#endif /* !DISABLE_JIT */
+
+#ifdef DISABLE_JIT
+gpointer
+mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info, gboolean aot)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+guchar*
+mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInfo **info, gboolean aot)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, guint32 *code_len)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_create_general_rgctx_lazy_fetch_trampoline (MonoTrampInfo **info, gboolean aot)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_create_handler_block_trampoline (MonoTrampInfo **info, gboolean aot)
+{
+        g_assert_not_reached ();
+        return NULL;
+}
+
+void
+mono_arch_invalidate_method (MonoJitInfo *ji, void *func, gpointer func_arg)
+{
+	g_assert_not_reached ();
+	return;
+}
+
+guint8*
+mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gboolean aot)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+#endif /* DISABLE_JIT */

--- a/msvc/libmono-static.vcxproj
+++ b/msvc/libmono-static.vcxproj
@@ -60,6 +60,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="..\mono\mini\mini-windows.h" />
     <ClInclude Include="..\mono\mini\mini-x86.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/msvc/libmono-static.vcxproj.filters
+++ b/msvc/libmono-static.vcxproj.filters
@@ -231,6 +231,9 @@
     <ClInclude Include="..\mono\mini\mini-amd64-gsharedvt.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\mono\mini\mini-windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">


### PR DESCRIPTION
Initial work to build libmono under none desktop Windows API families. It also fixes a couple of bugs

This PR is a continuation of #3626 fixing what's needed to get next runtime library to build under none desktop Windows API family. NOTE, this is initial work, so the functionality in none "classic" windows API code paths are still under development.

The classic Windows API have been split into families and partitions in order to support
different subsets off the Windows API on different platforms. In order to build against other Windows targets/platforms, Mono needs to follow these families/partitions in order to successfully build where API’s have been removed/replaced/extended. Since most Mono platforms uses the Windows API signatures, a new defined has been added to all platforms, HAVE_CLASSIC_WINAPI_SUPPORT, used to decide what implementation to include. On none Windows platforms this is always defined and on Windows platforms it follows the winapifamily.h setup in winconfig.h. In order to keep down regressions, the existing API’s are kept for HAVE_CLASSIC_WINAPI_SUPPORT even if there are more modern alternatives and replacements available.