### PR TITLE
When basic.exe isn't in DISTFILES, it gets excluded from `make dist`

### DIFF
--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -344,6 +344,7 @@ DISTFILES = \
 	MicrosoftAjaxLibrary/License.htm	\
 	test-helpers/NetworkHelpers.cs	\
 	test-helpers/SocketResponder.cs	\
+	lib/$(monolite_dir)/basic.exe	\
 	$(monolite_files)
 
 .PHONY: all-local $(STD_TARGETS:=-local)
@@ -376,11 +377,13 @@ $(monolite_files): | lib/$(monolite_dir)/Facades
 $(monolite_files): lib/$(monolite_dir)/%: lib/build/%
 	cp -p $< $@
 
+lib/$(monolite_dir)/basic.exe:
+	cp -p lib/basic/basic.exe lib/$(monolite_dir)
+
 $(build_files:%=lib/build/%):
 	cd $(topdir) && $(MAKE) profile-do--build--all NO_DIR_CHECK=1 SKIP_AOT=1
 
-dist-monolite: $(monolite_files)
-	cp -p lib/basic/basic.exe lib/$(monolite_dir)
+dist-monolite: $(monolite_files) lib/$(monolite_dir)/basic.exe
 
 dist-default: dist-monolite
 

--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -1,8 +1,6 @@
 BTLS_STATIC_LIST = build-static/mono-btls-static-lo.txt
 BTLS_SHARED_LIST = build-shared/mono-btls-shared-lo.txt
 
-BTLS_DEPS = $(BTLS_LIBS) build-shared/Makefile build-static/Makefile
-
 CMAKE_VERBOSE=$(if $(V),VERBOSE=1,)
 
 CMAKE_ARGS = -D CMAKE_INSTALL_PREFIX:PATH=$(prefix) -D BTLS_ROOT:PATH=$(BTLS_ROOT) \

--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -1,6 +1,44 @@
 BTLS_STATIC_LIST = build-static/mono-btls-static-lo.txt
 BTLS_SHARED_LIST = build-shared/mono-btls-shared-lo.txt
 
+EXTRA_DIST = btls-android-utils.c \
+	btls-bio.c \
+	btls-bio.h \
+	btls-error.c \
+	btls-error.h \
+	btls-key.c \
+	btls-key.h \
+	btls-pkcs12.c \
+	btls-pkcs12.h \
+	btls-ssl.c \
+	btls-ssl-ctx.c \
+	btls-ssl-ctx.h \
+	btls-ssl.h \
+	btls-util.c \
+	btls-util.h \
+	btls-x509.c \
+	btls-x509-chain.c \
+	btls-x509-chain.h \
+	btls-x509-crl.c \
+	btls-x509-crl.h \
+	btls-x509.h \
+	btls-x509-lookup.c \
+	btls-x509-lookup.h \
+	btls-x509-lookup-mono.c \
+	btls-x509-lookup-mono.h \
+	btls-x509-name.c \
+	btls-x509-name.h \
+	btls-x509-revoked.c \
+	btls-x509-revoked.h \
+	btls-x509-store.c \
+	btls-x509-store-ctx.c \
+	btls-x509-store-ctx.h \
+	btls-x509-store.h \
+	btls-x509-verify-param.c \
+	btls-x509-verify-param.h \
+	CMakeLists.txt \
+	create-object-library.sh
+
 CMAKE_VERBOSE=$(if $(V),VERBOSE=1,)
 
 CMAKE_ARGS = -D CMAKE_INSTALL_PREFIX:PATH=$(prefix) -D BTLS_ROOT:PATH=$(BTLS_ROOT) \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -158,6 +158,7 @@ EXTRA_DIST =			\
 	update_submodules		\
 	mcs.in				\
 	dmcs.in				\
+	mono-package-runtime	\
 	mono-test-install	\
 	mono-heapviz		\
 	$(MDOC_COMPAT)		\


### PR DESCRIPTION
We can't just add basic.exe to `monolite_files`, as it's named mcs.exe in the build system, so work around it by adding it to `DISTFILES`