### PR TITLE
[4.8.0][profiler] Fix a regression that caused all buffers to have a zero thread ID.

### DIFF
--- a/mono/profiler/mono-profiler-log.c
+++ b/mono/profiler/mono-profiler-log.c
@@ -558,10 +558,12 @@ init_time (void)
 }
 
 /*
- * These macros create a scope to avoid leaking the buffer returned
- * from ensure_logbuf () as it may have been invalidated by a GC
- * thread during STW. If you called init_thread () with add_to_lls =
- * FALSE, then don't use these macros.
+ * These macros should be used when writing an event to a log buffer. They take
+ * care of a bunch of stuff that can be repetitive and error-prone, such as
+ * acquiring/releasing the buffer lock, incrementing the event counter,
+ * expanding the log buffer, processing requests, etc. They also create a scope
+ * so that it's harder to leak the LogBuffer pointer, which can be problematic
+ * as the pointer is unstable when the buffer lock isn't acquired.
  */
 
 #define ENTER_LOG(COUNTER, BUFFER, SIZE) \

--- a/mono/profiler/mono-profiler-log.c
+++ b/mono/profiler/mono-profiler-log.c
@@ -1298,6 +1298,8 @@ sync_point_flush (void)
 	g_assert (InterlockedReadPointer (&buffer_rwlock_exclusive) == (gpointer) thread_id () && "Why don't we hold the exclusive lock?");
 
 	MONO_LLS_FOREACH_SAFE (&profiler_thread_list, MonoProfilerThread, thread) {
+		g_assert (thread->attached && "Why is a thread in the LLS not attached?");
+
 		send_buffer (thread);
 		init_buffer_state (thread);
 	} MONO_LLS_FOREACH_SAFE_END
@@ -3895,6 +3897,8 @@ log_shutdown (MonoProfiler *prof)
 	 */
 	while (profiler_thread_list.head) {
 		MONO_LLS_FOREACH_SAFE (&profiler_thread_list, MonoProfilerThread, thread) {
+			g_assert (thread->attached && "Why is a thread in the LLS not attached?");
+
 			remove_thread (thread);
 		} MONO_LLS_FOREACH_SAFE_END
 	}


### PR DESCRIPTION
This was introduced in 928b840dad3c9cc1c39c3fe5820bf8394ae9b66b.