### PR TITLE
[btls] Use UTC for the Unix epoch in the managed BTLS code

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsX509.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509.cs
@@ -267,13 +267,13 @@ namespace Mono.Btls
 		public DateTime GetNotBefore ()
 		{
 			var ticks = mono_btls_x509_get_not_before (Handle.DangerousGetHandle ());
-			return new DateTime (1970, 1, 1).AddSeconds (ticks);
+			return new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds (ticks);
 		}
 
 		public DateTime GetNotAfter ()
 		{
 			var ticks = mono_btls_x509_get_not_after (Handle.DangerousGetHandle ());
-			return new DateTime (1970, 1, 1).AddSeconds (ticks);
+			return new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds (ticks);
 		}
 
 		public byte[] GetPublicKeyData ()

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509Crl.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509Crl.cs
@@ -160,13 +160,13 @@ namespace Mono.Btls
 		public DateTime GetLastUpdate ()
 		{
 			var ticks = mono_btls_x509_crl_get_last_update (Handle.DangerousGetHandle ());
-			return new DateTime (1970, 1, 1).AddSeconds (ticks);
+			return new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds (ticks);
 		}
 
 		public DateTime GetNextUpdate ()
 		{
 			var ticks = mono_btls_x509_crl_get_next_update (Handle.DangerousGetHandle ());
-			return new DateTime (1970, 1, 1).AddSeconds (ticks);
+			return new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds (ticks);
 		}
 
 		public long GetVersion ()

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509Revoked.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509Revoked.cs
@@ -103,7 +103,7 @@ namespace Mono.Btls
 		{
 			var ticks = mono_btls_x509_revoked_get_revocation_date (
 				Handle.DangerousGetHandle ());
-			return new DateTime (1970, 1, 1).AddSeconds (ticks);
+			return new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds (ticks);
 		}
 
 		public int GetReason ()

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509VerifyParam.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509VerifyParam.cs
@@ -258,7 +258,7 @@ namespace Mono.Btls
 		public void SetTime (DateTime time)
 		{
 			WantToModify ();
-			var epoch = new DateTime (1970, 1, 1);
+			var epoch = new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 			var ticks = (long)time.Subtract (epoch).TotalSeconds;
 			var ret = mono_btls_x509_verify_param_set_time (
 				Handle.DangerousGetHandle (), ticks);


### PR DESCRIPTION
The epoch is specified as being in UTC, but the DateTime(int, int, int) constructor
creates a DateTime with an 'Unspecified' timezone, which could lead to problems later on.

/cc @baulig 