### PR TITLE
[System] Add back a few ServicePointManager properties that can be used by multiple networking stacks.

### DIFF
--- a/mcs/class/System/System.Net/ServicePointManager.platformnotsupported.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.platformnotsupported.cs
@@ -83,13 +83,13 @@ namespace System.Net
 		}
 
 		public static SecurityProtocolType SecurityProtocol {
-			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
-			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
-		}
+			get;
+			set;
+		} = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
 		public static RemoteCertificateValidationCallback ServerCertificateValidationCallback {
-			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
-			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			get;
+			set;
 		}
 
 		public static EncryptionPolicy EncryptionPolicy {


### PR DESCRIPTION
These properties are used here:

https://github.com/xamarin/ModernHttpClient/blob/master/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs#L350
https://github.com/xamarin/xamarin-macios/blob/master/src/Foundation/NSUrlSessionHandler.cs#L73