### PR TITLE
Fix two test failures in the FullAOT Jenkins job

### DIFF
--- a/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebOperationContextTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebOperationContextTest.cs
@@ -48,7 +48,7 @@ namespace MonoTests.System.ServiceModel.Web
 	public class WebOperationContextTest
 	{
 // MonoTouch does not support dynamic proxy code generation.
-#if !MONOTOUCH
+#if !MONOTOUCH && !MOBILE_STATIC
 		[Test]
 #endif
 		public void Current ()

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -140,6 +140,7 @@ BASE_TEST_MOBILE_STATIC_NOT_SUPPORTED= \
 	threadpool-exceptions7.cs # Needs AppDomains \
 	cross-domain.cs # Needs AppDomains \
 	generic-unloading.2.cs # Needs AppDomains \
+	namedmutex-destroy-race.cs # needs named Mutex \
 	thread6.cs # On MOBILE, ThreadAbortException doesn't have necessary field for this test
 
 # Disabled until ?mcs is fixed
@@ -468,7 +469,6 @@ BASE_TEST_CS_SRC_UNIVERSAL=		\
 	bug-29585.cs	\
 	priority.cs	\
 	abort-cctor.cs	\
-	namedmutex-destroy-race.cs	\
 	thread-native-exit.cs
 
 if INSTALL_MOBILE_STATIC


### PR DESCRIPTION
Disable WebOperationsContextTest.Current like on monotouch, it relies on dynamic code generation.
The namedmutex-destroy-race.cs runtime test doesn't work on mobile_static since we don't have named Mutexes.