### PR TITLE
Fix monodoc tests on Windows

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -70,6 +70,13 @@ MONO = \
 	MONO_PATH="$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" \
 	$(RUNTIME) $(RUNTIME_FLAGS)
 
+DIFF = diff -rup
+DIFF_QUIET = diff --brief
+ifeq ($(PLATFORM), win32)
+DIFF = diff -rupZ
+DIFF_QUIET = diff --brief -Z
+endif
+
 dist-local: dist-default dist-tests
 
 dist-tests:
@@ -160,7 +167,7 @@ check-monodocer-addNonGeneric: $(PROGRAM)
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
-	diff -rup Test/en.expected-addNonGeneric Test/en.actual
+	$(DIFF) Test/en.expected-addNonGeneric Test/en.actual
 
 check-monodocer-dropns-classic: $(PROGRAM)
 	# tests the simplest --dropns case, a single class where the root namespace was dropped.
@@ -168,7 +175,7 @@ check-monodocer-dropns-classic: $(PROGRAM)
 	$(MAKE) Test/DocTest-DropNS-classic.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-DropNS-classic.dll --api-style=classic
 	$(MAKE) update-monodocer-dropns-unified
-	diff -rup Test/en.expected-dropns-classic-v1 Test/en.actual
+	$(DIFF) Test/en.expected-dropns-classic-v1 Test/en.actual
 
 check-monodocer-dropns-multi: $(PROGRAM)
 	-rm -Rf Test/en.actual
@@ -185,7 +192,7 @@ check-monodocer-dropns-multi: $(PROGRAM)
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic 
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework 
 	
-	diff -rup Test/en.expected-dropns-multi Test/en.actual
+	$(DIFF) Test/en.expected-dropns-multi Test/en.actual
 
 
 check-monodocer-dropns-multi-withexisting: $(PROGRAM)
@@ -203,7 +210,7 @@ check-monodocer-dropns-multi-withexisting: $(PROGRAM)
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-CLASSIC) --api-style=classic 
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual $(MULTI-UNIFIED) --api-style=unified --dropns Test/DocTest-DropNS-unified.dll=MyFramework --dropns Test/DocTest-DropNS-unified-multitest.dll=MyFramework 
 	
-	diff -rup Test/en.expected-dropns-multi-withexisting Test/en.actual
+	$(DIFF) Test/en.expected-dropns-multi-withexisting Test/en.actual
 
 check-monodocer-dropns-delete: $(PROGRAM)
 	-rm -Rf Test/en.actual
@@ -217,7 +224,7 @@ check-monodocer-dropns-delete: $(PROGRAM)
 	$(MONO) $(PROGRAM) update --delete --exceptions=all -o Test/en.actual Test/DocTest-DropNS-classic-deletetest.dll --api-style=classic
 	$(MAKE) Test/DocTest-DropNS-unified-deletetest-V2.dll
 	$(MONO) $(PROGRAM) update --delete --exceptions=all -o Test/en.actual Test/DocTest-DropNS-unified-deletetest.dll --api-style=unified --dropns Test/DocTest-DropNS-unified-deletetest.dll=MyFramework
-	diff -rup Test/en.expected-dropns-delete Test/en.actual
+	$(DIFF) Test/en.expected-dropns-delete Test/en.actual
 
 check-monodocer-dropns-classic-withsecondary: $(PROGRAM)
 	# tests case where a secondary assembly is included with a --dropns parameter
@@ -226,7 +233,7 @@ check-monodocer-dropns-classic-withsecondary: $(PROGRAM)
 	$(MAKE) Test/DocTest-DropNS-classic-secondary.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-DropNS-classic.dll Test/DocTest-DropNS-classic-secondary.dll --api-style=classic
 	$(MAKE) update-monodocer-dropns-unified-withsecondary
-	diff -rup Test/en.expected-dropns-classic-withsecondary Test/en.actual
+	$(DIFF) Test/en.expected-dropns-classic-withsecondary Test/en.actual
 
 update-monodocer-dropns-unified: $(PROGRAM)
 	$(MAKE) Test/DocTest-DropNS-unified.dll
@@ -245,13 +252,13 @@ check-monodocer-internal-interface: $(PROGRAM)
 	-rm -Rf Test/en.actual
 	$(MAKE) Test/DocTest-InternalInterface.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-InternalInterface.dll
-	diff -rup Test/en.expected-internal-interface Test/en.actual
+	$(DIFF) Test/en.expected-internal-interface Test/en.actual
 
 check-monodocer-enumerations: $(PROGRAM)
 	-rm -Rf Test/en.actual
 	$(MAKE) Test/DocTest-enumerations.dll
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-enumerations.dll
-	diff -rup Test/en.expected-enumerations Test/en.actual
+	$(DIFF) Test/en.expected-enumerations Test/en.actual
 
 check-monodocer-update: $(PROGRAM)
 	find Test/en.expected -name \*.xml -exec rm "{}" \;
@@ -262,9 +269,9 @@ check-monodocer: $(PROGRAM)
 	-rm -Rf Test/en.actual
 	$(MAKE) Test/DocTest.dll-v1
 	$(MONO) $(PROGRAM) update --debug --exceptions=all -o Test/en.actual Test/DocTest.dll
-	diff -rup Test/en.expected Test/en.actual
+	$(DIFF) Test/en.expected Test/en.actual
 	$(MONO) $(PROGRAM) update --debug --exceptions=all -o Test/en.actual Test/DocTest.dll 
-	diff -rup Test/en.expected Test/en.actual
+	$(DIFF) Test/en.expected Test/en.actual
 
 check-monodocer-since-update: $(PROGRAM)
 	find Test/en.expected.since -name \*.xml -exec rm "{}" \;
@@ -281,7 +288,7 @@ check-monodocer-since: $(PROGRAM)
 	$(MAKE) Test/DocTest.dll-v2
 	$(MONO) $(PROGRAM) --debug update --exceptions=all --since="Version 2.0" \
 		-o Test/en.actual Test/DocTest.dll 
-	diff -rup Test/en.expected.since Test/en.actual
+	$(DIFF) Test/en.expected.since Test/en.actual
 
 check-monodocer-delete-update: $(PROGRAM)
 	find Test/en.expected.delete -type f -exec rm "{}" \;
@@ -301,7 +308,7 @@ check-monodocer-delete: $(PROGRAM)
 	$(MONO) $(PROGRAM) --debug update --exceptions=all -o Test/en.actual Test/DocTest.dll
 	$(MAKE) Test/DocTest.dll-v1
 	$(MONO) $(PROGRAM) --debug update -fno-assembly-versions --delete --exceptions=all -o Test/en.actual Test/DocTest.dll
-	diff -rup Test/en.expected.delete Test/en.actual
+	$(DIFF) Test/en.expected.delete Test/en.actual
 
 check-monodocer-importslashdoc-update: $(PROGRAM)
 	find Test/en.expected.importslashdoc -name \*.xml -exec rm "{}" \;
@@ -314,7 +321,7 @@ check-monodocer-importslashdoc: $(PROGRAM)
 	$(MAKE) Test/DocTest.dll-v1 TEST_CSCFLAGS=-doc:Test/DocTest.xml
 	$(MONO) $(PROGRAM) --debug update --exceptions=all -i Test/DocTest.xml \
 		-o Test/en.actual Test/DocTest.dll 
-	diff -rup Test/en.expected.importslashdoc Test/en.actual
+	$(DIFF) Test/en.expected.importslashdoc Test/en.actual
 
 check-monodocer-importecmadoc-update: $(PROGRAM)
 	find Test/en.expected.importecmadoc -name \*.xml -exec rm "{}" \;
@@ -331,7 +338,7 @@ check-monodocer-importecmadoc: $(PROGRAM)
 		'--type=System.Action`1' --type=System.AsyncCallback \
 		--type=System.Environment --type=System.Array \
 		-o Test/en.actual Test/DocTest.dll 
-	diff -rup Test/en.expected.importecmadoc Test/en.actual
+	$(DIFF) Test/en.expected.importecmadoc Test/en.actual
 
 check-mdoc-export-html-update: $(PROGRAM)
 	find Test/html.expected -name \*.html -exec rm "{}" \;
@@ -342,7 +349,7 @@ check-mdoc-export-html: check-monodocer $(PROGRAM)
 	rm -Rf Test/html.actual
 	$(MONO) $(PROGRAM) export-html -o Test/html.actual \
 		Test/en.expected.importslashdoc
-	diff -rup Test/html.expected Test/html.actual
+	$(DIFF) Test/html.expected Test/html.actual
 
 check-mdoc-export-html-with-version: $(PROGRAM)
 	rm -Rf Test/html.actual.v0 Test/html.actual.since-with-v0 .v0.txt .v2.txt
@@ -352,12 +359,12 @@ check-mdoc-export-html-with-version: $(PROGRAM)
 		Test/en.expected.since -with-version 0.0.0.0
 	(cd Test/html.actual.v0            && find . -type f) | sort > .v0.txt
 	(cd Test/html.actual.since-with-v0 && find . -type f) | sort > .v2.txt
-	diff -rup .v0.txt .v2.txt   # assert no types added
+	$(DIFF) .v0.txt .v2.txt   # assert no types added
 
 check-md-html-dir: $(PROGRAM)
 	rm -Rf Test/html.actual
 	$(MONO) $(PROGRAM) export-html -dest:Test/html.actual $(DIR) 
-	diff -rup Test/html.expected Test/html.actual
+	$(DIFF) Test/html.expected Test/html.actual
 
 check-mdoc-export-msxdoc-update:
 	$(MONO) $(PROGRAM) export-msxdoc -o - Test/en.expected.importslashdoc \
@@ -365,7 +372,7 @@ check-mdoc-export-msxdoc-update:
 
 check-mdoc-export-msxdoc:
 	$(MONO) $(PROGRAM) export-msxdoc -o - Test/en.expected.importslashdoc \
-		| diff --brief - Test/msxdoc-expected.importslashdoc.xml
+		| $(DIFF_QUIET) - Test/msxdoc-expected.importslashdoc.xml
 
 my_abs_top_srcdir = $(shell cd . && pwd)
 
@@ -383,13 +390,13 @@ check-mdoc-validate-update: $(PROGRAM)
 check-mdoc-validate: $(PROGRAM)
 	$(MONO) $(PROGRAM) validate -f ecma Test/en.expected 2>&1 | \
 		sed 's#file://$(my_abs_top_srcdir)/##g' | \
-		diff - Test/validate.check.monodocer
+		$(DIFF_QUIET) - Test/validate.check.monodocer
 	$(MONO) $(PROGRAM) validate -f ecma Test/en.expected.importslashdoc 2>&1 | \
 		sed 's#file://$(my_abs_top_srcdir)/##g' | \
-		diff --brief - Test/validate.check.monodocer.importslashdoc
+		$(DIFF_QUIET) - Test/validate.check.monodocer.importslashdoc
 	$(MONO) $(PROGRAM) validate -f ecma Test/en.expected.since 2>&1 | \
 		sed 's#file://$(my_abs_top_srcdir)/##g' | \
-		diff --brief - Test/validate.check.monodocer.since
+		$(DIFF_QUIET) - Test/validate.check.monodocer.since
 
 run-test-local: check-doc-tools
 

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -72,7 +72,7 @@ ${TESTCMD} --label=System.Json --timeout=5m make -w -C mcs/class/System.Json run
 ${TESTCMD} --label=System.Threading.Tasks.Dataflow --timeout=5m make -w -C mcs/class/System.Threading.Tasks.Dataflow run-test
 ${TESTCMD} --label=Mono.Debugger.Soft --timeout=5m make -w -C mcs/class/Mono.Debugger.Soft run-test
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=Microsoft.Build --skip; else ${TESTCMD} --label=Microsoft.Build --timeout=5m make -w -C mcs/class/Microsoft.Build run-test; fi
-if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=monodoc --skip; else ${TESTCMD} --label=monodoc --timeout=10m make -w -C mcs/tools/mdoc run-test; fi
+${TESTCMD} --label=monodoc --timeout=10m make -w -C mcs/tools/mdoc run-test
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=Microsoft.Build-12 --skip; else ${TESTCMD} --label=Microsoft.Build-12 --timeout=10m make -w -C mcs/class/Microsoft.Build run-test PROFILE=xbuild_12; fi
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=Microsoft.Build.Engine-12 --skip; else ${TESTCMD} --label=Microsoft.Build.Engine-12 --timeout=60m make -w -C mcs/class/Microsoft.Build.Engine run-test PROFILE=xbuild_12; fi
 ${TESTCMD} --label=Microsoft.Build.Framework-12 --timeout=60m make -w -C mcs/class/Microsoft.Build.Framework run-test PROFILE=xbuild_12


### PR DESCRIPTION
These tests are sensitive to differences in line endings between Windows and other platforms. This patch changes the diff commands used on Windows to ignore changes in whitespaces at end of lines.