### PR TITLE
[WP] [runtime] Rewrite field loading and layout

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -911,7 +911,7 @@ void
 mono_classes_cleanup (void);
 
 void
-mono_class_layout_fields   (MonoClass *klass, int instance_size);
+mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size);
 
 void
 mono_class_setup_interface_offsets (MonoClass *klass);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -706,7 +706,7 @@ void
 mono_class_setup_supertypes (MonoClass *klass);
 
 void
-mono_class_setup_fields_locking (MonoClass *klass);
+mono_class_setup_fields (MonoClass *klass);
 
 /* WARNING
  * Only call this function if you can ensure both @klass and @parent

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -322,8 +322,7 @@ struct _MonoClass {
 	guint is_generic : 1; /* class is a generic type definition */
 	guint is_inflated : 1; /* class is a generic instance */
 	guint has_finalize_inited    : 1; /* has_finalize is initialized */
-	guint fields_inited : 1; /* fields is initialized */
-	guint setup_fields_called : 1; /* to prevent infinite loops in setup_fields */
+	guint fields_inited : 1; /* setup_fields () has finished */
 	guint has_failure : 1; /* See MONO_CLASS_PROP_EXCEPTION_DATA for a MonoErrorBoxed with the details */
 
 	MonoClass  *parent;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -910,7 +910,7 @@ void
 mono_classes_cleanup (void);
 
 void
-mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size);
+mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, gboolean sre);
 
 void
 mono_class_setup_interface_offsets (MonoClass *klass);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5352,11 +5352,7 @@ mono_class_has_finalizer (MonoClass *klass)
 gboolean
 mono_is_corlib_image (MonoImage *image)
 {
-	/* FIXME: allow the dynamic case for our compilers and with full trust */
-	if (image_is_dynamic (image))
-		return image->assembly && !strcmp (image->assembly->aname.name, "mscorlib");
-	else
-		return image == mono_defaults.corlib;
+	return image == mono_defaults.corlib;
 }
 
 /*
@@ -6611,7 +6607,6 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	GSList *list, *rootlist = NULL;
 	int nsize;
 	char *name;
-	gboolean corlib_type = FALSE;
 
 	g_assert (rank <= 255);
 
@@ -6653,15 +6648,9 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		}
 	}
 
-	/* for the building corlib use System.Array from it */
-	if (image->assembly && assembly_is_dynamic (image->assembly) && image->assembly_name && strcmp (image->assembly_name, "mscorlib") == 0) {
-		parent = mono_class_load_from_name (image, "System", "Array");
-		corlib_type = TRUE;
-	} else {
-		parent = mono_defaults.array_class;
-		if (!parent->inited)
-			mono_class_init (parent);
-	}
+	parent = mono_defaults.array_class;
+	if (!parent->inited)
+		mono_class_init (parent);
 
 	klass = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClass));
 
@@ -6765,9 +6754,6 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	}
 	klass->this_arg = klass->byval_arg;
 	klass->this_arg.byref = 1;
-	if (corlib_type) {
-		klass->inited = 1;
-	}
 
 	klass->generic_container = eclass->generic_container;
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1785,18 +1785,6 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		klass->min_align = 16;
 	 */
 
-	if (!top) {
-		klass->instance_size = instance_size;
-		mono_memory_barrier ();
-		klass->size_inited = 1;
-		klass->fields_inited = 1;
-		if (klass->parent)
-			klass->blittable = klass->parent->blittable;
-		else
-			klass->blittable = 1;
-		return;
-	}
-
 	/*
 	 * When we do generic sharing we need to have layout
 	 * information for open generic classes (either with a generic
@@ -1840,7 +1828,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		blittable = klass->parent->blittable;
 	if (layout == TYPE_ATTRIBUTE_AUTO_LAYOUT && !(mono_is_corlib_image (klass->image) && !strcmp (klass->name_space, "System") && !strcmp (klass->name, "ValueType")) && top)
 		blittable = FALSE;
-	for (i = 0; i < top; i++){
+	for (i = 0; i < top; i++) {
 		field = &klass->fields [i];
 
 		if (mono_field_is_deleted (field))
@@ -2104,13 +2092,13 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		 * performance, and since the JIT memset/memcpy code assumes this and generates 
 		 * unaligned accesses otherwise. See #78990 for a testcase.
 		 */
-		if (mono_align_small_structs) {
+		if (mono_align_small_structs && top) {
 			if (instance_size <= sizeof (MonoObject) + sizeof (gpointer))
 				klass->min_align = MAX (klass->min_align, instance_size - sizeof (MonoObject));
 		}
 	}
 
-	if (klass->instance_size && !klass->image->dynamic) {
+	if (klass->instance_size && !klass->image->dynamic && top) {
 		/* Might be already set using cached info */
 		g_assert (klass->instance_size == instance_size);
 	} else {
@@ -2122,7 +2110,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	/*
 	 * Compute static field layout and size
 	 */
-	for (i = 0; i < top; i++){
+	for (i = 0; i < top; i++) {
 		gint32 align;
 		guint32 size;
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1839,8 +1839,7 @@ mono_class_layout_fields (MonoClass *klass, int instance_size)
 	gboolean blittable;
 
 	if (!top) {
-		if (!klass->instance_size)
-			klass->instance_size = instance_size;
+		klass->instance_size = instance_size;
 		mono_memory_barrier ();
 		klass->size_inited = 1;
 		if (klass->parent)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1883,7 +1883,7 @@ ves_icall_MonoField_GetFieldOffset (MonoReflectionField *field)
 	MonoClass *parent = field->field->parent;
 	if (!parent->size_inited)
 		mono_class_init (parent);
-	mono_class_setup_fields_locking (parent);
+	mono_class_setup_fields (parent);
 
 	return field->field->offset - sizeof (MonoObject);
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3745,7 +3745,7 @@ mono_nullable_init (guint8 *buf, MonoObject *value, MonoClass *klass)
 
 	MonoClass *param_class = klass->cast_class;
 
-	mono_class_setup_fields_locking (klass);
+	mono_class_setup_fields (klass);
 	g_assert (klass->fields_inited);
 				
 	g_assert (mono_class_from_mono_type (klass->fields [0].type) == param_class);
@@ -3779,7 +3779,7 @@ mono_nullable_box (guint8 *buf, MonoClass *klass, MonoError *error)
 	mono_error_init (error);
 	MonoClass *param_class = klass->cast_class;
 
-	mono_class_setup_fields_locking (klass);
+	mono_class_setup_fields (klass);
 	g_assert (klass->fields_inited);
 
 	g_assert (mono_class_from_mono_type (klass->fields [0].type) == param_class);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3252,8 +3252,6 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 		}
 	}
 
-	klass->setup_fields_called = 1;
-
 	mono_class_layout_fields (klass, instance_size, packing_size);
 }
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3252,7 +3252,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 		}
 	}
 
-	mono_class_layout_fields (klass, instance_size, packing_size);
+	mono_class_layout_fields (klass, instance_size, packing_size, TRUE);
 }
 
 static void

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3239,9 +3239,6 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 		fb->handle = field;
 		mono_save_custom_attrs (klass->image, field, fb->cattrs);
 
-		if (klass->enumtype && !(field->type->attrs & FIELD_ATTRIBUTE_STATIC)) {
-			klass->cast_class = klass->element_class = mono_class_from_mono_type (field->type);
-		}
 		if (fb->def_value) {
 			MonoDynamicImage *assembly = (MonoDynamicImage*)klass->image;
 			field->type->attrs |= FIELD_ATTRIBUTE_HAS_DEFAULT;


### PR DESCRIPTION
This PR completely rewrites field loading and layout. This includes:
* the code is cleaned up.
* locking is minimized, the critical sections contain only the code which makes modifications
  to MonoClass, no higher level code is inside the locks.
* the normal and SRE cases are unified as much as possible.
* the race introduced by the 'setup_fields_called' flag is fixed.
* the set of MonoClass fields initialized by mono_class_setup_fields () is documented.