### PR TITLE
Fix symbolicate tests stack trace diff on Windows

### DIFF
--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -26,7 +26,7 @@ SYMBOLICATE_EXPECTED_FILE = Test/symbolicate.expected
 CHECK_DIFF = @\
 	$(MONO) $(TEST_EXE) > $(STACKTRACE_FILE); \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) $(MSYM_DIR) $(STACKTRACE_FILE) > $(SYMBOLICATE_RAW_FILE); \
-	sed "s/) .* in .*\/mcs\//) in mcs\//" $(SYMBOLICATE_RAW_FILE) | sed '/\[MVID\]/d' | sed '/\[AOTID\]/d' > $(SYMBOLICATE_RESULT_FILE); \
+	cat $(SYMBOLICATE_RAW_FILE) | tr '\\' '/' | sed "s/) .* in .*\/mcs\//) in mcs\//" | sed '/\[MVID\]/d' | sed '/\[AOTID\]/d' > $(SYMBOLICATE_RESULT_FILE); \
 	DIFF=$$(diff -up $(SYMBOLICATE_EXPECTED_FILE) $(SYMBOLICATE_RESULT_FILE)); \
 	if [ ! -z "$$DIFF" ]; then \
 		echo "Symbolicate tests failed."; \


### PR DESCRIPTION
The symbolicate tests compare stack traces generated by the mono-symbolicate tool against expected stack traces. The expected stack trace files have been preprocessed to remove absolute paths and the Makefile does the same with the output from the tool. However, the preprocessing doesn't take different directory separator characters into account. This patch adds a 'tr' command to the Makefile which converts \ -> / before the absolute paths are filtered out from the actual output from the tool to make the comparison succeed on Windows as well.