### PR TITLE
Fixes for System.Web to work on windows

### DIFF
--- a/mcs/class/System.Web/System.Web.dll.sources
+++ b/mcs/class/System.Web/System.Web.dll.sources
@@ -2,7 +2,7 @@ Assembly/AssemblyInfo.cs
 ../../build/common/Consts.cs
 ../../build/common/Locale.cs
 ../../build/common/MonoTODOAttribute.cs
-../System/System/MonoExeLocator.cs
+../System/System/MonoToolsLocator.cs
 ../System.Windows.Forms/System.Resources/AssemblyNamesTypeResolutionService.cs
 ../System.Windows.Forms/System.Resources/ByteArrayFromResXHandler.cs
 ../System.Windows.Forms/System.Resources/ResXNullRef.cs

--- a/mcs/class/System.Web/Test/System.Web.UI.WebControls.Adapters/HideDisabledControlAdapterTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.UI.WebControls.Adapters/HideDisabledControlAdapterTest.cs
@@ -57,7 +57,7 @@ namespace MonoTests.System.Web.UI.WebControls.Adapters
 			sw = new StringWriter();
 			w = new HtmlTextWriter(sw);
 			a.Render (w);
-			Assert.AreEqual ("RenderBeginTag\nRenderContents\nRenderEndTag\n", sw.ToString(), "Render #1");
+			Assert.AreEqual ("RenderBeginTag\nRenderContents\nRenderEndTag\n", sw.ToString().Replace ("\r", ""), "Render #1");
 			
 			
 			sw = new StringWriter();

--- a/mcs/class/System.Web/Test/System.Web.UI.WebControls.Adapters/MenuAdapterTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.UI.WebControls.Adapters/MenuAdapterTest.cs
@@ -91,21 +91,21 @@ namespace MonoTests.System.Web.UI.WebControls.Adapters
 		public void RenderBeginTag ()
 		{
 			a.RenderBeginTag (w);
-			Assert.AreEqual ("RenderBeginTag\n", sw.ToString (), "RenderBeginTag #1");
+			Assert.AreEqual ("RenderBeginTag\n", sw.ToString ().Replace ("\r", ""), "RenderBeginTag #1");
 		}
 
 		[Test]
 		public void RenderContentsTag ()
 		{
 			a.RenderContents (w);
-			Assert.AreEqual ("RenderContents\n", sw.ToString (), "RenderContents #1");
+			Assert.AreEqual ("RenderContents\n", sw.ToString ().Replace ("\r", ""), "RenderContents #1");
 		}
 
 		[Test]
 		public void RenderEndTag ()
 		{
 			a.RenderEndTag (w);
-			Assert.AreEqual ("RenderEndTag\n", sw.ToString (), "RenderEndTag #1");
+			Assert.AreEqual ("RenderEndTag\n", sw.ToString ().Replace ("\r", ""), "RenderEndTag #1");
 		}
 
 		[Test]

--- a/mcs/class/System.Web/Test/System.Web.UI.WebControls.Adapters/WebControlAdapterTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.UI.WebControls.Adapters/WebControlAdapterTest.cs
@@ -63,28 +63,28 @@ namespace MonoTests.System.Web.UI.WebControls.Adapters
 		public void RenderBeginTag ()
 		{
 			a.RenderBeginTag (w);
-			Assert.AreEqual ("RenderBeginTag\n", sw.ToString (), "RenderBeginTag #1");
+			Assert.AreEqual ("RenderBeginTag\n", sw.ToString ().Replace ("\r", ""), "RenderBeginTag #1");
 		}
 
 		[Test]
 		public void RenderContentsTag ()
 		{
 			a.RenderContents (w);
-			Assert.AreEqual ("RenderContents\n", sw.ToString (), "RenderContents #1");
+			Assert.AreEqual ("RenderContents\n", sw.ToString ().Replace ("\r", ""), "RenderContents #1");
 		}
 
 		[Test]
 		public void RenderEndTag ()
 		{
 			a.RenderEndTag (w);
-			Assert.AreEqual ("RenderEndTag\n", sw.ToString (), "RenderEndTag #1");
+			Assert.AreEqual ("RenderEndTag\n", sw.ToString ().Replace ("\r", ""), "RenderEndTag #1");
 		}
 
 		[Test]
 		public void Render ()
 		{
 			a.Render (w);
-			Assert.AreEqual ("RenderBeginTag\nRenderContents\nRenderEndTag\n", sw.ToString (), "Render #1");
+			Assert.AreEqual ("RenderBeginTag\nRenderContents\nRenderEndTag\n", sw.ToString ().Replace ("\r", ""), "Render #1");
 		}
 		
 		[Test]

--- a/mcs/class/System.Web/Test/System.Web.UI.WebControls/WizardTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.UI.WebControls/WizardTest.cs
@@ -1538,7 +1538,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			Console.WriteLine ("----------------------------");
 			Console.WriteLine (renderedHtml);
 			
-			Assert.AreEqual (origHtml, renderedHtml, "#A1");
+			Assert.AreEqual (origHtml.Replace ("\r", ""), renderedHtml.Replace ("\r", ""), "#A1");
 		}
 
 		[Test]
@@ -1566,13 +1566,13 @@ namespace MonoTests.System.Web.UI.WebControls
 			string origHtml = "Header<table cellspacing=\"5\" cellpadding=\"5\">\r\n\t<tr>\r\n\t\t<td align=\"right\"><input type=\"submit\" name=\"MyWizard$StepNavigationTemplateContainerID$StepPreviousButton\" value=\"Previous\" id=\"MyWizard_StepNavigationTemplateContainerID_StepPreviousButton\" /></td><td align=\"right\"><input type=\"submit\" name=\"MyWizard$StepNavigationTemplateContainerID$StepNextButton\" value=\"Next\" id=\"MyWizard_StepNavigationTemplateContainerID_StepNextButton\" /></td>\n\t</tr>\n</table>Step";
 			string renderedHtml = HtmlDiff.GetControlFromPageHtml (result);
 
-			Assert.AreEqual (origHtml, renderedHtml, "#A1");
+			Assert.AreEqual (origHtml.Replace ("\r", ""), renderedHtml.Replace ("\r", ""), "#A1");
 
 			t.UserData = "RenderHeader_InSpan";
 			result = t.Run ();
 			origHtml = "Header<table cellspacing=\"5\" cellpadding=\"5\">\r\n\t<tr>\r\n\t\t<td align=\"right\"><input type=\"submit\" name=\"MyWizard$StepNavigationTemplateContainerID$StepPreviousButton\" value=\"Previous\" id=\"MyWizard_StepNavigationTemplateContainerID_StepPreviousButton\" /></td><td align=\"right\"><input type=\"submit\" name=\"MyWizard$StepNavigationTemplateContainerID$StepNextButton\" value=\"Next\" id=\"MyWizard_StepNavigationTemplateContainerID_StepNextButton\" /></td>\n\t</tr>\n</table>Step";
 			renderedHtml = HtmlDiff.GetControlFromPageHtml (result);
-			Assert.AreEqual (origHtml, renderedHtml, "#A2");
+			Assert.AreEqual (origHtml.Replace ("\r", ""), renderedHtml.Replace ("\r", ""), "#A2");
 		}
 
 		[Test]

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.dll.sources
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.dll.sources
@@ -2,7 +2,7 @@
 ../../build/common/MonoTODOAttribute.cs
 Assembly/AssemblyInfo.cs
 Assembly/Locale.cs
-../System/System/MonoExeLocator.cs
+../System/System/MonoToolsLocator.cs
 System.Resources/AssemblyNamesTypeResolutionService.cs
 System.Resources/ByteArrayFromResXHandler.cs
 System.Resources/ResXNullRef.cs

--- a/mcs/class/System/System.dll.sources
+++ b/mcs/class/System/System.dll.sources
@@ -161,7 +161,7 @@ System.Diagnostics/TraceImpl.cs
 System.Diagnostics/TraceSourceInfo.cs
 System.Diagnostics/Win32EventLog.cs
 System/Platform.cs
-System/MonoExeLocator.cs
+System/MonoToolsLocator.cs
 System.IO.Compression/CompressionLevel.cs
 System.IO.Compression/CompressionMode.cs
 System.IO.Compression/DeflateStream.cs

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -28,7 +28,7 @@ ${TESTCMD} --label=System.Data --timeout=5m make -w -C mcs/class/System.Data run
 ${TESTCMD} --label=System.Data.OracleClient --timeout=5m make -w -C mcs/class/System.Data.OracleClient run-test;
 ${TESTCMD} --label=System.Design --timeout=5m make -w -C mcs/class/System.Design run-test;
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=Mono.Posix --skip; else ${TESTCMD} --label=Mono.Posix --timeout=5m make -w -C mcs/class/Mono.Posix run-test; fi
-if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=System.Web --skip; else ${TESTCMD} --label=System.Web --timeout=30m make -w -C mcs/class/System.Web run-test; fi
+${TESTCMD} --label=System.Web --timeout=30m make -w -C mcs/class/System.Web run-test
 ${TESTCMD} --label=System.Web.Services --timeout=5m make -w -C mcs/class/System.Web.Services run-test
 ${TESTCMD} --label=System.Runtime.SFS --timeout=5m make -w -C mcs/class/System.Runtime.Serialization.Formatters.Soap run-test;
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=System.Runtime.Remoting --skip; else ${TESTCMD} --label=System.Runtime.Remoting --timeout=5m make -w -C mcs/class/System.Runtime.Remoting run-test; fi
@@ -47,7 +47,7 @@ ${TESTCMD} --label=Mono.C5 --timeout=5m make -w -C mcs/class/Mono.C5 run-test
 ${TESTCMD} --label=Mono.Tasklets --timeout=5m make -w -C mcs/class/Mono.Tasklets run-test
 ${TESTCMD} --label=System.Configuration --timeout=5m make -w -C mcs/class/System.Configuration run-test
 ${TESTCMD} --label=System.Transactions --timeout=5m make -w -C mcs/class/System.Transactions run-test
-if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=System.Web.Extensions --skip; else ${TESTCMD} --label=System.Web.Extensions --timeout=5m make -w -C mcs/class/System.Web.Extensions run-test; fi
+${TESTCMD} --label=System.Web.Extensions --timeout=5m make -w -C mcs/class/System.Web.Extensions run-test
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=System.Core --skip; else ${TESTCMD} --label=System.Core --timeout=15m make -w -C mcs/class/System.Core run-test; fi
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=symbolicate --skip; else ${TESTCMD} --label=symbolicate --timeout=60m make -w -C mcs/tools/mono-symbolicate check; fi
 ${TESTCMD} --label=System.Xml.Linq --timeout=5m make -w -C mcs/class/System.Xml.Linq run-test
@@ -63,7 +63,7 @@ ${TESTCMD} --label=System.ComponentModel.DataAnnotations --timeout=5m make -w -C
 ${TESTCMD} --label=Mono.CodeContracts --timeout=5m make -w -C mcs/class/Mono.CodeContracts run-test
 ${TESTCMD} --label=System.Runtime.Caching --timeout=5m make -w -C mcs/class/System.Runtime.Caching run-test
 ${TESTCMD} --label=System.Data.Services --timeout=5m make -w -C mcs/class/System.Data.Services run-test
-if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=System.Web.DynamicData --skip; else ${TESTCMD} --label=System.Web.DynamicData --timeout=5m make -w -C mcs/class/System.Web.DynamicData run-test; fi
+${TESTCMD} --label=System.Web.DynamicData --timeout=5m make -w -C mcs/class/System.Web.DynamicData run-test
 ${TESTCMD} --label=Mono.CSharp --timeout=5m make -w -C mcs/class/Mono.CSharp run-test
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=WindowsBase --skip; else ${TESTCMD} --label=WindowsBase --timeout=5m make -w -C mcs/class/WindowsBase run-test; fi
 ${TESTCMD} --label=System.Numerics --timeout=5m make -w -C mcs/class/System.Numerics run-test


### PR DESCRIPTION
This PR should fix the failures in System.Web when running on Windows:

* Ignoring CR (\r) in some WebControls tests.
* Calling directly into Windows API function `GetModuleFileName` to get current process exe instead of using `Process.GetCurrentProcess ().MainModule.FileName` which caused problems in  AppDomain envionments (as seen in System.Web).
