### PR TITLE
[C9][runtime] System.Configuration.InternalConfigurationHost:get_bundled_machine_config  needs HANDLES

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -418,7 +418,7 @@ ICALL(DEFAULTC_2, "get_machine_config_path", ves_icall_System_Configuration_Defa
 /* Note that the below icall shares the same function as DefaultConfig uses */
 ICALL_TYPE(INTCFGHOST, "System.Configuration.InternalConfigurationHost", INTCFGHOST_1)
 ICALL(INTCFGHOST_1, "get_bundled_app_config", get_bundled_app_config)
-ICALL(INTCFGHOST_2, "get_bundled_machine_config", get_bundled_machine_config)
+HANDLES(ICALL(INTCFGHOST_2, "get_bundled_machine_config", get_bundled_machine_config))
 
 ICALL_TYPE(CONSOLE, "System.ConsoleDriver", CONSOLE_1)
 ICALL(CONSOLE_1, "InternalKeyAvailable", ves_icall_System_ConsoleDriver_InternalKeyAvailable )


### PR DESCRIPTION

The method (which also goes by
System.Configuration.DefaultConfig:get_bundled_machine_config) was
converted to use coop handles earlier, but we missed this declaration.

This is #3731 backported to `mono-4.8.0-branch`