### PR TITLE
[C9][coop] Switch to GC SAFE for backtrace() and backtrace_symbols()

### DIFF
--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -976,8 +976,12 @@ mono_exception_get_native_backtrace (MonoException *exc)
 	domain = mono_domain_get ();
 	len = mono_array_length (arr);
 	text = g_string_new_len (NULL, len * 20);
-	messages = backtrace_symbols (mono_array_addr (arr, gpointer, 0), len);
-
+	uint32_t gchandle = mono_gchandle_new (&arr->obj, TRUE); /* pinned */
+	void* addr = mono_array_addr (arr, gpointer, 0);
+	MONO_ENTER_GC_SAFE;
+	messages = backtrace_symbols (addr, len);
+	MONO_EXIT_GC_SAFE;
+	mono_gchandle_free (gchandle);
 
 	for (i = 0; i < len; ++i) {
 		gpointer ip = mono_array_get (arr, gpointer, i);

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -210,8 +210,10 @@ mono_backtrace (int size)
 
         mono_os_mutex_lock (&mempool_tracing_lock);
         g_print ("Allocating %d bytes\n", size);
+	MONO_ENTER_GC_SAFE;
         symbols = backtrace (array, BACKTRACE_DEPTH);
         names = backtrace_symbols (array, symbols);
+	MONO_EXIT_GC_SAFE;
         for (i = 1; i < symbols; ++i) {
                 g_print ("\t%s\n", names [i]);
         }

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -198,27 +198,27 @@ static mono_mutex_t mempool_tracing_lock;
 static void
 mono_backtrace (int size)
 {
-        void *array[BACKTRACE_DEPTH];
-        char **names;
-        int i, symbols;
-        static gboolean inited;
+	void *array[BACKTRACE_DEPTH];
+	char **names;
+	int i, symbols;
+	static gboolean inited;
 
-        if (!inited) {
-            mono_os_mutex_init_recursive (&mempool_tracing_lock);
-            inited = TRUE;
-        }
+	if (!inited) {
+		mono_os_mutex_init_recursive (&mempool_tracing_lock);
+		inited = TRUE;
+	}
 
-        mono_os_mutex_lock (&mempool_tracing_lock);
-        g_print ("Allocating %d bytes\n", size);
+	mono_os_mutex_lock (&mempool_tracing_lock);
+	g_print ("Allocating %d bytes\n", size);
 	MONO_ENTER_GC_SAFE;
-        symbols = backtrace (array, BACKTRACE_DEPTH);
-        names = backtrace_symbols (array, symbols);
+	symbols = backtrace (array, BACKTRACE_DEPTH);
+	names = backtrace_symbols (array, symbols);
 	MONO_EXIT_GC_SAFE;
-        for (i = 1; i < symbols; ++i) {
-                g_print ("\t%s\n", names [i]);
-        }
-        g_free (names);
-        mono_os_mutex_unlock (&mempool_tracing_lock);
+	for (i = 1; i < symbols; ++i) {
+		g_print ("\t%s\n", names [i]);
+	}
+	g_free (names);
+	mono_os_mutex_unlock (&mempool_tracing_lock);
 }
 
 #endif

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1290,7 +1290,9 @@ build_native_trace (MonoError *error)
 #if defined (HAVE_BACKTRACE_SYMBOLS) && defined (TARGET_ARM)
 	MonoArray *res;
 	void *native_trace [MAX_UNMANAGED_BACKTRACE];
+	MONO_ENTER_GC_SAFE;
 	int size = backtrace (native_trace, MAX_UNMANAGED_BACKTRACE);
+	MONO_EXIT_GC_SAFE;
 	int i;
 
 	if (!size)


### PR DESCRIPTION
Fixes [#42271](https://bugzilla.xamarin.com/show_bug.cgi?id=42271)

There are several more uses of `backtrace` and `backtrace_symbols` in Mono, but:
* some of them are in debugging code (checked build, mempool tracing, lock-tracer)
* some are in SIGSEGV handlers
and it doesn't seem reasonable to mess with the coop state.

This is #3660 backported to `mono-4.8.0-branch`