### PR TITLE
GC debug and params command line options

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -332,6 +332,12 @@ Currently this merely ensures that you are running either the
 \fBMONO_ENV_OPTIONS\fR environment variable to force all of your child
 processes to use one particular kind of GC with the Mono runtime.
 .TP
+\fB--gc-debug=[options]\fR
+Command line equivalent of the \fBMONO_GC_DEBUG\fR environment variable.
+.TP
+\fB--gc-params=[options]\fR
+Command line equivalent of the \fBMONO_GC_PARAMS\fR environment variable.
+.TP
 \fB--arch=32\fR, \fB--arch=64\fR
 (Mac OS X only): Selects the bitness of the Mono binary used, if
 available. If the binary used is already for the selected bitness, nothing

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1370,6 +1370,16 @@ mono_gc_get_logfile (void)
 }
 
 void
+mono_gc_params_set (const char* options)
+{
+}
+
+void
+mono_gc_debug_set (const char* options)
+{
+}
+
+void
 mono_gc_conservatively_scan_area (void *start, void *end)
 {
 	g_assert_not_reached ();

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -462,6 +462,16 @@ mono_gc_get_logfile (void)
 }
 
 void
+mono_gc_params_set (const char* options)
+{
+}
+
+void
+mono_gc_debug_set (const char* options)
+{
+}
+
+void
 mono_gc_conservatively_scan_area (void *start, void *end)
 {
 	g_assert_not_reached ();

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1434,6 +1434,10 @@ mono_jit_parse_options (int argc, char * argv[])
 			
 			if (!mono_debugger_insert_breakpoint (argv [++i], FALSE))
 				fprintf (stderr, "Error: invalid method name '%s'\n", argv [i]);
+		} else if (strncmp (argv[i], "--gc-params=", 12) == 0) {
+			mono_gc_params_set (argv[i] + 12);
+		} else if (strncmp (argv[i], "--gc-debug=", 11) == 0) {
+			mono_gc_debug_set (argv[i] + 11);
 		} else if (strcmp (argv [i], "--llvm") == 0) {
 #ifndef MONO_ARCH_LLVM_SUPPORTED
 			fprintf (stderr, "Mono Warning: --llvm not supported on this platform.\n");
@@ -1679,6 +1683,10 @@ mono_main (int argc, char* argv[])
 			switch_gc (argv, "sgen");
 		} else if (strcmp (argv [i], "--gc=boehm") == 0) {
 			switch_gc (argv, "boehm");
+		} else if (strncmp (argv[i], "--gc-params=", 12) == 0) {
+			mono_gc_params_set (argv[i] + 12);
+		} else if (strncmp (argv[i], "--gc-debug=", 11) == 0) {
+			mono_gc_debug_set (argv[i] + 11);
 		}
 #ifdef TARGET_OSX
 		else if (strcmp (argv [i], "--arch=32") == 0) {

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -110,4 +110,9 @@ void mono_gc_memmove_aligned (void *dest, const void *src, size_t size);
 
 FILE *mono_gc_get_logfile (void);
 
+/* equivalent to options set via MONO_GC_PARAMS */
+void mono_gc_params_set (const char* options);
+/* equivalent to options set via MONO_GC_DEBUG */
+void mono_gc_debug_set (const char* options);
+
 #endif


### PR DESCRIPTION
Exposes the same functionality as the MONO_GC_DEBUG and MONO_GC_PARAMS environment variables as command line arguments --gc-debug and --gc-params. This allows specifying these options without setting environment variables, which may affect child processes.

These command line arguments are also processed in the separate parsing logic within mono_jit_parse_options.