### PR TITLE
Fix SocketResponder on Windows

### DIFF
--- a/mcs/class/test-helpers/SocketResponder.cs
+++ b/mcs/class/test-helpers/SocketResponder.cs
@@ -91,8 +91,11 @@ namespace MonoTests.Helpers
 					listenSocket = tcpListener.AcceptSocket ();
 					listenSocket.Send (requestHandler (listenSocket));
 					try {
-						listenSocket.Shutdown (SocketShutdown.Receive);
+						// On Windows a Receive() is needed here before Shutdown() to consume the data some tests send.
+						listenSocket.ReceiveTimeout = 10 * 1000;
+						listenSocket.Receive (new byte [0]);
 						listenSocket.Shutdown (SocketShutdown.Send);
+						listenSocket.Shutdown (SocketShutdown.Receive);
 					} catch {
 					}
 				} catch (SocketException ex) {


### PR DESCRIPTION
There seems to be a race in some tests in the System test suite that use SocketResponder on Windows. Some tests fail with an exception that the socket has been closed before they get a chance to see the response sent by the SocketResponder. The same happens occasionally when using SocketResponder on .NET. This patch changes the order of the Socket.Shutdown() calls and adds a Socket.Receive() before Shutdown() is called to give the sender a chance to actually send any data before the responder shuts down and closes its side of the connection.