### PR TITLE
[corlib] Simplify RNGCryptoServiceProvider file name on MT and enable tests

### DIFF
--- a/mcs/class/corlib/CommonCrypto/RNGCryptoServiceProvider.cryptor.cs
+++ b/mcs/class/corlib/CommonCrypto/RNGCryptoServiceProvider.cryptor.cs
@@ -1,5 +1,5 @@
 //
-// SecRandom.cs: based on Mono's System.Security.Cryptography.RNGCryptoServiceProvider
+// RngCryptoServiceProvider.cryptor.cs: based on Mono's System.Security.Cryptography.RNGCryptoServiceProvider
 //
 // Authors:
 //	Mark Crichton (crichton@gimp.org)
@@ -32,6 +32,8 @@
 using Crimson.CommonCrypto;
 
 // http://developer.apple.com/library/ios/#DOCUMENTATION/Security/Reference/RandomizationReference/Reference/reference.html
+// we need to use the CommonCrypto implementation instead of the runtime-supported RNGCryptoServiceProvider
+// since we have no guarantee (on iOS) about /dev/[u]random availability or quality
 #if MONOTOUCH || XAMMAC
 namespace System.Security.Cryptography {
 	public class RNGCryptoServiceProvider : RandomNumberGenerator {
@@ -54,14 +56,6 @@ namespace System.Security.Cryptography {
 		~RNGCryptoServiceProvider () 
 		{
 		}
-#else
-using System;
-using System.Security.Cryptography;
-
-namespace Crimson.Security.Cryptography {
-			
-	public class SecRandom : RandomNumberGenerator {
-#endif
 		
 		public override void GetBytes (byte[] data) 
 		{
@@ -91,3 +85,4 @@ namespace Crimson.Security.Cryptography {
 		}
 	}
 }
+#endif

--- a/mcs/class/corlib/Test/System.Security.Cryptography/RNGCryptoServiceProviderTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/RNGCryptoServiceProviderTest.cs
@@ -25,7 +25,7 @@ namespace MonoTests.System.Security.Cryptography {
 		{
 			_algo = new RNGCryptoServiceProvider ();
 		}
-#if !MOBILE
+
 		[Test]
 		public void ConstructorByteArray () 
 		{
@@ -62,7 +62,7 @@ namespace MonoTests.System.Security.Cryptography {
 			string s = null;
 			RNGCryptoServiceProvider rng = new RNGCryptoServiceProvider (s);
 		}
-#endif
+
 		[Test]
 		public void GetBytes () 
 		{

--- a/mcs/class/corlib/monotouch_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/monotouch_corlib.dll.exclude.sources
@@ -1,6 +1,7 @@
 System.Security.Cryptography/MD5CryptoServiceProvider.cs
 System.Security.Cryptography/SHA1CryptoServiceProvider.cs
 System.Security.Cryptography/SHA1CryptoServiceProvider.cs
+System.Security.Cryptography/RNGCryptoServiceProvider.cs
 ../referencesource/mscorlib/system/security/cryptography/descryptoserviceprovider.cs
 ../referencesource/mscorlib/system/security/cryptography/rc2cryptoserviceprovider.cs
 ../referencesource/mscorlib/system/security/cryptography/rijndaelmanaged.cs
@@ -9,7 +10,6 @@ System.Security.Cryptography/SHA1CryptoServiceProvider.cs
 ../referencesource/mscorlib/system/security/cryptography/sha384managed.cs
 ../referencesource/mscorlib/system/security/cryptography/sha512managed.cs
 ../referencesource/mscorlib/system/security/cryptography/tripledescryptoserviceprovider.cs
-System.Security.Cryptography/RNGCryptoServiceProvider.cs
 ../Mono.Security/Mono.Security.Cryptography/ARC4Managed.cs
 ../Mono.Security/Mono.Security.Cryptography/MD2Managed.cs
 ../Mono.Security/Mono.Security.Cryptography/MD4Managed.cs

--- a/mcs/class/corlib/monotouch_corlib.dll.sources
+++ b/mcs/class/corlib/monotouch_corlib.dll.sources
@@ -4,12 +4,12 @@ CommonCrypto/CryptorTransform.cs
 CommonCrypto/FastCryptorTransform.cs
 CommonCrypto/CorlibExtras.cs
 CommonCrypto/RijndaelManaged.cs
-CommonCrypto/SecRandom.cs
+CommonCrypto/RNGCryptoServiceProvider.cryptor.cs
 CommonCrypto/RC4CommonCrypto.cs
-System/Environment.iOS.cs
-System/Guid.MonoTouch.cs
-System/NotSupportedException.iOS.cs
 CoreFoundation/CFHelpers.cs
 System.Security.Cryptography.X509Certificates/X509CertificateImplApple.cs
 System.Security.Cryptography.X509Certificates/X509Helper.Apple.cs
 System.Text/EncodingHelper.MonoTouch.cs
+System/Environment.iOS.cs
+System/Guid.MonoTouch.cs
+System/NotSupportedException.iOS.cs

--- a/mcs/class/corlib/xammac_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/xammac_corlib.dll.exclude.sources
@@ -1,14 +1,6 @@
-System.Security.Cryptography/MD5CryptoServiceProvider.cs
-System.Security.Cryptography/SHA1CryptoServiceProvider.cs
-System.Security.Cryptography/SHA1CryptoServiceProvider.cs
-../referencesource/mscorlib/system/security/cryptography/descryptoserviceprovider.cs
-../referencesource/mscorlib/system/security/cryptography/rc2cryptoserviceprovider.cs
-../referencesource/mscorlib/system/security/cryptography/rijndaelmanaged.cs
-../referencesource/mscorlib/system/security/cryptography/sha1managed.cs
-../referencesource/mscorlib/system/security/cryptography/sha256managed.cs
-../referencesource/mscorlib/system/security/cryptography/sha384managed.cs
-../referencesource/mscorlib/system/security/cryptography/sha512managed.cs
-../referencesource/mscorlib/system/security/cryptography/tripledescryptoserviceprovider.cs
-../Mono.Security/Mono.Security.Cryptography/ARC4Managed.cs
-../Mono.Security/Mono.Security.Cryptography/MD2Managed.cs
-../Mono.Security/Mono.Security.Cryptography/MD4Managed.cs
+#include monotouch_corlib.dll.exclude.sources
+System.Text/EncodingHelper.MonoTouch.cs
+System/Environment.iOS.cs
+System/Guid.MonoTouch.cs
+System/NotSupportedException.iOS.cs
+

--- a/mcs/class/corlib/xammac_corlib.dll.sources
+++ b/mcs/class/corlib/xammac_corlib.dll.sources
@@ -1,10 +1,1 @@
-#include corlib.dll.sources
-CommonCrypto/CommonCrypto.cs
-CommonCrypto/CryptorTransform.cs
-CommonCrypto/FastCryptorTransform.cs
-CommonCrypto/CorlibExtras.cs
-CommonCrypto/RijndaelManaged.cs
-CommonCrypto/RC4CommonCrypto.cs
-CoreFoundation/CFHelpers.cs
-System.Security.Cryptography.X509Certificates/X509CertificateImplApple.cs
-System.Security.Cryptography.X509Certificates/X509Helper.Apple.cs
+#include monotouch_corlib.dll.sources


### PR DESCRIPTION
Also unify xammac and monotouch .sources files.
We're now using the CommonCrypto-based RNGCryptoServiceProvider on xammac too.

/cc @marek-safar 
