### PR TITLE
[sgen] Fix MS block size calculation.

### DIFF
--- a/mono/sgen/sgen-archdep.h
+++ b/mono/sgen/sgen-archdep.h
@@ -38,13 +38,6 @@
 
 #define REDZONE_SIZE	224
 
-/* MS_BLOCK_SIZE must be a multiple of the system pagesize, which for some
-   architectures is 64k.  */
-#if defined(TARGET_POWERPC) || defined(TARGET_POWERPC64)
-#define ARCH_MIN_MS_BLOCK_SIZE	(64*1024)
-#define ARCH_MIN_MS_BLOCK_SIZE_SHIFT	16
-#endif
-
 #elif defined(TARGET_ARM)
 
 #define REDZONE_SIZE	0

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -149,9 +149,17 @@ int
 mono_pagesize (void)
 {
 	static int saved_pagesize = 0;
+
 	if (saved_pagesize)
 		return saved_pagesize;
+
+	// Prefer sysconf () as it's signal safe.
+#if defined (HAVE_SYSCONF) && defined (_SC_PAGESIZE)
+	saved_pagesize = sysconf (_SC_PAGESIZE);
+#else
 	saved_pagesize = getpagesize ();
+#endif
+
 	return saved_pagesize;
 }
 


### PR DESCRIPTION
The block size must be a multiple of the system page size. Page size simply
cannot be determined reliably at compile time, so we must obtain the page size
through a system call on startup and use it as the block size. We still enforce
a minimum block size of 16kb on systems where the page size is smaller than
that.

The old code hardcoded page sizes for certain architectures with large pages.
THe problem is that those architectures don't necessarily have to have large
pages and on systems where this wasn't the case, we'd end up with a block size
much larger than needed.
