### PR TITLE
[Mono.Security]: X509StoreManager now automatically chooses the correct store.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/X509Store.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X509Store.cs
@@ -387,7 +387,8 @@ namespace Mono.Security.X509 {
 			if (!CheckStore (path, false))
 				return coll;	// empty collection
 
-			string[] files = Directory.GetFiles (path, "*.cer");
+			var pattern = _newFormat ? "*.0" : "*.cer";
+			string[] files = Directory.GetFiles (path, pattern);
 			if ((files != null) && (files.Length > 0)) {
 				foreach (string file in files) {
 					try {

--- a/mcs/class/Mono.Security/Mono.Security.X509/X509StoreManager.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X509StoreManager.cs
@@ -31,6 +31,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using MNS = Mono.Net.Security;
 
 using Mono.Security.X509.Extensions;
 
@@ -54,6 +55,10 @@ namespace Mono.Security.X509 {
 
 		private X509StoreManager ()
 		{
+		}
+
+		static bool UsingBtls {
+			get { return MNS.MonoTlsProviderFactory.UsingBtls; }
 		}
 
 		internal static string CurrentUserPath {
@@ -106,8 +111,12 @@ namespace Mono.Security.X509 {
 
 		static public X509Stores CurrentUser {
 			get { 
-				if (_userStore == null)
-					_userStore = new X509Stores (CurrentUserPath, false);
+				if (_userStore == null) {
+					if (UsingBtls)
+						_userStore = new X509Stores (NewCurrentUserPath, true);
+					else
+						_userStore = new X509Stores (CurrentUserPath, false);
+				}
 				
 				return _userStore;
 			}
@@ -115,28 +124,14 @@ namespace Mono.Security.X509 {
 
 		static public X509Stores LocalMachine {
 			get {
-				if (_machineStore == null) 
-					_machineStore = new X509Stores (LocalMachinePath, false);
+				if (_machineStore == null) {
+					if (UsingBtls)
+						_machineStore = new X509Stores (NewLocalMachinePath, true);
+					else
+						_machineStore = new X509Stores (LocalMachinePath, false);
+				}
 
 				return _machineStore;
-			}
-		}
-
-		static public X509Stores NewCurrentUser {
-			get {
-				if (_newUserStore == null)
-					_newUserStore = new X509Stores (NewCurrentUserPath, true);
-
-				return _newUserStore;
-			}
-		}
-
-		static public X509Stores NewLocalMachine {
-			get {
-				if (_newMachineStore == null)
-					_newMachineStore = new X509Stores (NewLocalMachinePath, true);
-
-				return _newMachineStore;
 			}
 		}
 

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -50,10 +50,8 @@ namespace Mono.Btls
 {
 	class MonoBtlsProvider : MonoTlsProvider
 	{
-		static readonly Guid id = new Guid ("432d18c9-9348-4b90-bfbf-9f2a10e1f15b");
-
 		public override Guid ID {
-			get { return id; }
+			get { return MNS.MonoTlsProviderFactory.BtlsID; }
 		}
 		public override string Name {
 			get { return "btls"; }

--- a/mcs/class/System/Mono.Net.Security/LegacyTlsProvider.cs
+++ b/mcs/class/System/Mono.Net.Security/LegacyTlsProvider.cs
@@ -48,10 +48,8 @@ namespace Mono.Net.Security
 	 */
 	class LegacyTlsProvider : MSI.MonoTlsProvider
 	{
-		static readonly Guid id = new Guid ("809e77d5-56cc-4da8-b9f0-45e65ba9cceb");
-
 		public override Guid ID {
-			get { return id; }
+			get { return MonoTlsProviderFactory.LegacyID; }
 		}
 
 		public override string Name {

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -54,6 +54,20 @@ namespace Mono.Net.Security
 	{
 		#region Internal API
 
+		internal static readonly Guid LegacyID = new Guid ("809e77d5-56cc-4da8-b9f0-45e65ba9cceb");
+		internal static readonly Guid BtlsID = new Guid ("432d18c9-9348-4b90-bfbf-9f2a10e1f15b");
+
+		internal static bool UsingBtls {
+			get {
+				#if SECURITY_DEP
+				var provider = GetProviderInternal ();
+				return provider.Provider.ID == BtlsID;
+				#else
+				throw new NotSupportedException ("TLS Support not available.");
+				#endif
+			}
+		}
+
 		/*
 		 * APIs in this section are for consumption within System.dll only - do not access via
 		 * reflection or from friend assemblies.

--- a/mcs/tools/btls/btls-cert-sync.cs
+++ b/mcs/tools/btls/btls-cert-sync.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Security.Cryptography.X509Certificates;
-using Mono.Btls;
+using Mono.Security.Interface;
 
 namespace Mono.Btls
 {
@@ -14,6 +14,8 @@ namespace Mono.Btls
 				Console.Error.WriteLine ("BTLS is not supported in this runtime!");
 				Environment.Exit (255);
 			}
+
+			MonoTlsProviderFactory.Initialize ("btls");
 
 			var configPath = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
 			configPath = Path.Combine (configPath, ".mono");

--- a/mcs/tools/security/cert-sync.cs
+++ b/mcs/tools/security/cert-sync.cs
@@ -50,7 +50,6 @@ namespace Mono.Tools
 		static string inputFile;
 		static bool quiet;
 		static bool userStore;
-		static bool btlsStore = true;
 
 		static X509Certificate DecodeCertificate (string s)
 		{
@@ -119,9 +118,9 @@ namespace Mono.Tools
 				
 			X509Stores stores;
 			if (userStore)
-				stores = btlsStore ? X509StoreManager.NewCurrentUser : X509StoreManager.CurrentUser;
+				stores = X509StoreManager.CurrentUser;
 			else
-				stores = btlsStore ? X509StoreManager.NewLocalMachine : X509StoreManager.LocalMachine;
+				stores = X509StoreManager.LocalMachine;
 			X509Store store = stores.TrustedRoot;
 			X509CertificateCollection trusted = store.Certificates;
 			int additions = 0;
@@ -178,9 +177,6 @@ namespace Mono.Tools
 					break;
 				case "--user":
 					userStore = true;
-					break;
-				case "--legacy":
-					btlsStore = false;
 					break;
 				default:
 					WriteLine ("Unknown option '{0}'.", args[i]);


### PR DESCRIPTION
* X509StoreManager.NewCurrentUser and X509StoreManager.NewLocalMachine
  have been merged into CurrentUser/LocalMachine.
  We now check which TLS Provider we're using and automatically choose
  the correct store.

* cert-sync: remove the "--btls" and "--legacy" options.

  We now automatically choose between old and new format based on the
  current TLS Provider (which can be set via the MONO_TLS_PROVIDER
  environment variable).