### PR TITLE
Making named pipe connects alertable on Windows

### DIFF
--- a/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting.Channels.Ipc.Win32/NamedPipeHelper.cs
+++ b/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting.Channels.Ipc.Win32/NamedPipeHelper.cs
@@ -26,10 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-
-using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 
 namespace System.Runtime.Remoting.Channels.Ipc.Win32
 {
@@ -89,6 +88,7 @@ namespace System.Runtime.Remoting.Channels.Ipc.Win32
         public const uint OPEN_EXISTING     = 3;
         public const uint OPEN_ALWAYS       = 4;
         public const uint TRUNCATE_EXISTING = 5;
+	    public const uint FILE_FLAG_OVERLAPPED = 0x40000000;
         
         // Access flags
         public const uint GENERIC_READ = 0x80000000;
@@ -103,6 +103,7 @@ namespace System.Runtime.Remoting.Channels.Ipc.Win32
         public const int ERROR_PIPE_NOT_CONNECTED = 233;
         public const int ERROR_PIPE_CONNECTED = 535;
         public const int ERROR_PIPE_LISTENING = 536;
+	    public const int ERROR_IO_PENDING = 997;
 
         public const int INVALID_HANDLE_VALUE = -1;
 
@@ -121,7 +122,7 @@ namespace System.Runtime.Remoting.Channels.Ipc.Win32
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool ConnectNamedPipe(
             IntPtr hPipe,
-            IntPtr lpOverlapped
+            [In] ref NativeOverlapped lpOverlapped
             );
 
         [DllImport("kernel32.dll", SetLastError = true)]

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -29,7 +29,7 @@ if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=Mo
 ${TESTCMD} --label=System.Web --timeout=30m make -w -C mcs/class/System.Web run-test
 ${TESTCMD} --label=System.Web.Services --timeout=5m make -w -C mcs/class/System.Web.Services run-test
 ${TESTCMD} --label=System.Runtime.SFS --timeout=5m make -w -C mcs/class/System.Runtime.Serialization.Formatters.Soap run-test;
-if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=System.Runtime.Remoting --skip; else ${TESTCMD} --label=System.Runtime.Remoting --timeout=5m make -w -C mcs/class/System.Runtime.Remoting run-test; fi
+${TESTCMD} --label=System.Runtime.Remoting --timeout=5m make -w -C mcs/class/System.Runtime.Remoting run-test
 ${TESTCMD} --label=Cscompmgd --timeout=5m make -w -C mcs/class/Cscompmgd run-test;
 ${TESTCMD} --label=Commons.Xml.Relaxng --timeout=5m make -w -C mcs/class/Commons.Xml.Relaxng run-test;
 if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=System.ServiceProcess --skip; else ${TESTCMD} --label=System.ServiceProcess --timeout=5m make -w -C mcs/class/System.ServiceProcess run-test; fi


### PR DESCRIPTION
This fix makes sure that an aborted thread will wake up
a blocking named pipe connect.