### PR TITLE
[System]: Move MonoBtlsProvider.IsSupported() -> MonoTlsProviderFactory.IsBtlsSupported()

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -32,7 +32,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Authentication;
 
@@ -59,12 +58,9 @@ namespace Mono.Btls
 			get { return "btls"; }
 		}
 
-		[MethodImpl (MethodImplOptions.InternalCall)]
-		public extern static bool IsSupported ();
-
 		internal MonoBtlsProvider ()
 		{
-			if (!IsSupported ())
+			if (!MNS.MonoTlsProviderFactory.IsBtlsSupported ())
 				throw new NotSupportedException ("BTLS is not supported in this runtime.");
 		}
 

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -39,6 +39,7 @@ using System.Security.Cryptography.X509Certificates;
 using System;
 using System.Net;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 #if !MOBILE
 using System.Reflection;
@@ -107,6 +108,9 @@ namespace Mono.Net.Security
 				initialized = true;
 			}
 		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		internal extern static bool IsBtlsSupported ();
 #endif
 
 		static object locker = new object ();
@@ -157,7 +161,7 @@ namespace Mono.Net.Security
 				providerRegistration = new Dictionary<string,string> ();
 				providerRegistration.Add ("legacy", "Mono.Net.Security.LegacyTlsProvider");
 				providerRegistration.Add ("default", "Mono.Net.Security.LegacyTlsProvider");
-				if (Mono.Btls.MonoBtlsProvider.IsSupported ())
+				if (IsBtlsSupported ())
 					providerRegistration.Add ("btls", "Mono.Btls.MonoBtlsProvider");
 				X509Helper2.Initialize ();
 			}

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -124,9 +124,6 @@ ICALL(BTLS_PKCS12_8, "mono_btls_pkcs12_import", mono_btls_pkcs12_import)
 ICALL(BTLS_PKCS12_9, "mono_btls_pkcs12_new", mono_btls_pkcs12_new)
 ICALL(BTLS_PKCS12_10, "mono_btls_pkcs12_up_ref", mono_btls_pkcs12_up_ref)
 
-ICALL_TYPE(BTLS_PROVIDER, "Mono.Btls.MonoBtlsProvider", BTLS_PROVIDER_1)
-ICALL(BTLS_PROVIDER_1, "IsSupported", ves_icall_Mono_Btls_Provider_IsSupported)
-
 ICALL_TYPE(BTLS_SSL, "Mono.Btls.MonoBtlsSsl", BTLS_SSL_1)
 ICALL(BTLS_SSL_1, "mono_btls_ssl_accept", mono_btls_ssl_accept)
 ICALL(BTLS_SSL_2, "mono_btls_ssl_add_chain_certificate", mono_btls_ssl_add_chain_certificate)
@@ -314,9 +311,6 @@ ICALL(BTLS_X509_VERIFY_PARAM_16, "mono_btls_x509_verify_param_set_mono_flags", m
 ICALL(BTLS_X509_VERIFY_PARAM_17, "mono_btls_x509_verify_param_set_name", mono_btls_x509_verify_param_set_name)
 ICALL(BTLS_X509_VERIFY_PARAM_18, "mono_btls_x509_verify_param_set_purpose", mono_btls_x509_verify_param_set_purpose)
 ICALL(BTLS_X509_VERIFY_PARAM_19, "mono_btls_x509_verify_param_set_time", mono_btls_x509_verify_param_set_time)
-#else
-ICALL_TYPE(BTLS_PROVIDER, "Mono.Btls.MonoBtlsProvider", BTLS_PROVIDER_1)
-ICALL(BTLS_PROVIDER_1, "IsSupported", ves_icall_Mono_Btls_Provider_IsSupported)
 #endif
 
 #ifndef DISABLE_COM
@@ -324,6 +318,9 @@ ICALL_TYPE(COMPROX, "Mono.Interop.ComInteropProxy", COMPROX_1)
 ICALL(COMPROX_1, "AddProxy", ves_icall_Mono_Interop_ComInteropProxy_AddProxy)
 ICALL(COMPROX_2, "FindProxy", ves_icall_Mono_Interop_ComInteropProxy_FindProxy)
 #endif
+
+ICALL_TYPE(TLS_PROVIDER_FACTORY, "Mono.Net.Security.MonoTlsProviderFactory", TLS_PROVIDER_FACTORY_1)
+ICALL(TLS_PROVIDER_FACTORY_1, "IsBtlsSupported", ves_icall_Mono_TlsProviderFactory_IsBtlsSupported)
 
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
 ICALL(RUNTIME_1, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8090,7 +8090,7 @@ ves_icall_Microsoft_Win32_NativeMethods_SetPriorityClass (gpointer handle, gint3
 }
 
 ICALL_EXPORT MonoBoolean
-ves_icall_Mono_Btls_Provider_IsSupported (void)
+ves_icall_Mono_TlsProviderFactory_IsBtlsSupported (void)
 {
 #if HAVE_BTLS
 	return TRUE;


### PR DESCRIPTION
[System]: Move MonoBtlsProvider.IsSupported() -> MonoTlsProviderFactory.IsBtlsSupported()

Move the intern-call which is used to determine whether we're using BTLS out of MonoBtlsProvider
to allow the managed linker to eliminate the Mono.Btls.* classes when it's not supported.