### PR TITLE
Mono.Dynamic.Interpreter: Avoid NRE when loop body is not a block.

### DIFF
--- a/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/LoopCompiler.cs
+++ b/mcs/class/dlr/Runtime/Microsoft.Dynamic/Interpreter/LoopCompiler.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Scripting.Interpreter {
             LoopVariable existing;
             LocalVariable loc;
 
-            if (_loopLocals.Contains(node)) {
+            if (_loopLocals != null && _loopLocals.Contains(node)) {
                 // local to the loop - not propagated in or out
                 return node;
             } else if (_loopVariables.TryGetValue(node, out existing)) {


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=45141
