### PR TITLE
[System] Add IPv6 support to FtpWebRequest

### DIFF
--- a/mcs/class/System/System.Net/FtpWebRequest.cs
+++ b/mcs/class/System/System.Net/FtpWebRequest.cs
@@ -17,6 +17,7 @@ using MSI = Mono.Security.Interface;
 #endif
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
@@ -42,6 +43,7 @@ namespace System.Net
 		NetworkCredential credentials;
 		IPHostEntry hostEntry;
 		IPEndPoint localEndPoint;
+		IPEndPoint remoteEndPoint;
 		IWebProxy proxy;
 		int timeout = 100000;
 		int rwTimeout = 300000;
@@ -65,7 +67,9 @@ namespace System.Net
 		const string PasswordCommand = "PASS";
 		const string TypeCommand = "TYPE";
 		const string PassiveCommand = "PASV";
+		const string ExtendedPassiveCommand = "EPSV";
 		const string PortCommand = "PORT";
+		const string ExtendedPortCommand = "EPRT";
 		const string AbortCommand = "ABOR";
 		const string AuthCommand = "AUTH";
 		const string RestCommand = "REST";
@@ -777,14 +781,14 @@ namespace System.Net
 			foreach (IPAddress address in hostEntry.AddressList) {
 				sock = new Socket (address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-				IPEndPoint remote = new IPEndPoint (address, requestUri.Port);
+				remoteEndPoint = new IPEndPoint (address, requestUri.Port);
 
-				if (!ServicePoint.CallEndPointDelegate (sock, remote)) {
+				if (!ServicePoint.CallEndPointDelegate (sock, remoteEndPoint)) {
 					sock.Close ();
 					sock = null;
 				} else {
 					try {
-						sock.Connect (remote);
+						sock.Connect (remoteEndPoint);
 						localEndPoint = (IPEndPoint) sock.LocalEndPoint;
 						break;
 					} catch (SocketException exc) {
@@ -839,52 +843,19 @@ namespace System.Net
 		}
 
 		// Probably we could do better having here a regex
-		Socket SetupPassiveConnection (string statusDescription)
+		Socket SetupPassiveConnection (string statusDescription, bool ipv6)
 		{
 			// Current response string
 			string response = statusDescription;
 			if (response.Length < 4)
 				throw new WebException ("Cannot open passive data connection");
-			
-			// Look for first digit after code
-			int i;
-			for (i = 3; i < response.Length && !Char.IsDigit (response [i]); i++)
-				;
-			if (i >= response.Length)
-				throw new WebException ("Cannot open passive data connection");
 
-			// Get six elements
-			string [] digits = response.Substring (i).Split (new char [] {','}, 6);
-			if (digits.Length != 6)
-				throw new WebException ("Cannot open passive data connection");
+			int port = ipv6 ? GetPortV6 (response) : GetPortV4 (response);
 
-			// Clean non-digits at the end of last element
-			int j;
-			for (j = digits [5].Length - 1; j >= 0 && !Char.IsDigit (digits [5][j]); j--)
-				;
-			if (j < 0)
-				throw new WebException ("Cannot open passive data connection");
-			
-			digits [5] = digits [5].Substring (0, j + 1);
-
-			IPAddress ip;
-			try {
-				ip = IPAddress.Parse (String.Join (".", digits, 0, 4));
-			} catch (FormatException) {
-				throw new WebException ("Cannot open passive data connection");
-			}
-
-			// Get the port
-			int p1, p2, port;
-			if (!Int32.TryParse (digits [4], out p1) || !Int32.TryParse (digits [5], out p2))
-				throw new WebException ("Cannot open passive data connection");
-
-			port = (p1 << 8) + p2; // p1 * 256 + p2
-			//port = p1 * 256 + p2;
 			if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
 				throw new WebException ("Cannot open passive data connection");
 
-			IPEndPoint ep = new IPEndPoint (ip, port);
+			IPEndPoint ep = new IPEndPoint (remoteEndPoint.Address, port);
 			Socket sock = new Socket (ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 			try {
 				sock.Connect (ep);
@@ -895,6 +866,87 @@ namespace System.Net
 
 			return sock;
 		}
+
+		// GetPortV4, GetPortV6, FormatAddress and FormatAddressV6 are copied from referencesource
+		// TODO: replace FtpWebRequest completely.
+		private int GetPortV4(string responseString)
+		{
+			string [] parsedList = responseString.Split(new char [] {' ', '(', ',', ')'});
+
+			// We need at least the status code and the port
+			if (parsedList.Length <= 7) {
+				throw new FormatException(SR.GetString(SR.net_ftp_response_invalid_format, responseString));
+			}
+
+			int index = parsedList.Length-1;
+			// skip the last non-number token (e.g. terminating '.')
+#if MONO
+			// the MS code expects \r\n here in parsedList[index],
+			// but we're stripping the EOL off earlier so the array contains
+			// an empty string here which would make Char.IsNumber throw
+			// TODO: this can be removed once we switch FtpWebRequest to referencesource
+			if (parsedList[index] == "" || !Char.IsNumber(parsedList[index], 0))
+#else
+			if (!Char.IsNumber(parsedList[index], 0))
+#endif
+				index--;
+
+			int port = Convert.ToByte(parsedList[index--], NumberFormatInfo.InvariantInfo);
+			port = port |
+				(Convert.ToByte(parsedList[index--], NumberFormatInfo.InvariantInfo) << 8);
+
+			return port;
+		}
+
+		private int GetPortV6(string responseString)
+		{
+			int pos1 = responseString.LastIndexOf("(");
+			int pos2 = responseString.LastIndexOf(")");
+			if (pos1 == -1 || pos2 <= pos1) 
+				throw new FormatException(SR.GetString(SR.net_ftp_response_invalid_format, responseString));
+
+			// addressInfo will contain a string of format "|||<tcp-port>|"
+			string addressInfo = responseString.Substring(pos1+1, pos2-pos1-1);
+
+			// Although RFC2428 recommends using "|" as the delimiter,
+			// It allows ASCII characters in range 33-126 inclusive.
+			// We should consider allowing the full range.
+
+			string [] parsedList = addressInfo.Split(new char [] {'|'});
+			if (parsedList.Length < 4)
+				throw new FormatException(SR.GetString(SR.net_ftp_response_invalid_format, responseString));
+			
+			return Convert.ToInt32(parsedList[3], NumberFormatInfo.InvariantInfo);
+		}
+
+		private String FormatAddress(IPAddress address, int Port )
+		{
+			byte [] localAddressInBytes = address.GetAddressBytes();
+
+			// produces a string in FTP IPAddress/Port encoding (a1, a2, a3, a4, p1, p2), for sending as a parameter
+			// to the port command.
+			StringBuilder sb = new StringBuilder(32);
+			foreach (byte element in localAddressInBytes) {
+				sb.Append(element);
+				sb.Append(',');
+			}
+			sb.Append(Port / 256 );
+			sb.Append(',');
+			sb.Append(Port % 256 );
+			return sb.ToString();
+		}
+
+		private string FormatAddressV6(IPAddress address, int port) {
+			StringBuilder sb = new StringBuilder(43); // based on max size of IPv6 address + port + seperators
+			String addressString = address.ToString();
+			sb.Append("|2|");
+			sb.Append(addressString);
+			sb.Append('|');
+			sb.Append(port.ToString(NumberFormatInfo.InvariantInfo));
+			sb.Append('|');
+			return sb.ToString();
+		}
+		//
 
 		Exception CreateExceptionFromResponse (FtpStatus status)
 		{
@@ -934,18 +986,19 @@ namespace System.Net
 		Socket InitDataConnection ()
 		{
 			FtpStatus status;
-			
+			bool ipv6 = remoteEndPoint.AddressFamily == AddressFamily.InterNetworkV6;
+
 			if (usePassive) {
-				status = SendCommand (PassiveCommand);
-				if (status.StatusCode != FtpStatusCode.EnteringPassive) {
+				status = SendCommand (ipv6 ? ExtendedPassiveCommand : PassiveCommand);
+				if (status.StatusCode != (ipv6 ? (FtpStatusCode)229 : FtpStatusCode.EnteringPassive)) { // FtpStatusCode doesn't contain code 229 for EPSV so we need to cast...
 					throw CreateExceptionFromResponse (status);
 				}
 				
-				return SetupPassiveConnection (status.StatusDescription);
+				return SetupPassiveConnection (status.StatusDescription, ipv6);
 			}
 
 			// Open a socket to listen the server's connection
-			Socket sock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			Socket sock = new Socket (remoteEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 			try {
 				sock.Bind (new IPEndPoint (localEndPoint.Address, 0));
 				sock.Listen (1); // We only expect a connection from server
@@ -957,12 +1010,10 @@ namespace System.Net
 			}
 
 			IPEndPoint ep = (IPEndPoint) sock.LocalEndPoint;
-			string ipString = ep.Address.ToString ().Replace ('.', ',');
-			int h1 = ep.Port >> 8; // ep.Port / 256
-			int h2 = ep.Port % 256;
 
-			string portParam = ipString + "," + h1 + "," + h2;
-			status = SendCommand (PortCommand, portParam);
+			var portParam = ipv6 ? FormatAddressV6 (ep.Address, ep.Port) : FormatAddress (ep.Address, ep.Port);
+
+			status = SendCommand (ipv6 ? ExtendedPortCommand : PortCommand, portParam);
 			
 			if (status.StatusCode != FtpStatusCode.CommandOK) {
 				sock.Close ();

--- a/mcs/class/System/System.Net/FtpWebRequest.cs
+++ b/mcs/class/System/System.Net/FtpWebRequest.cs
@@ -401,6 +401,7 @@ namespace System.Net
 						State = RequestState.Scheduled;
 
 					Thread thread = new Thread (ProcessRequest);
+					thread.IsBackground = true;
 					thread.Start ();
 				}
 			}
@@ -452,6 +453,7 @@ namespace System.Net
 
 			asyncResult = new FtpAsyncResult (callback, state);
 			Thread thread = new Thread (ProcessRequest);
+			thread.IsBackground = true;
 			thread.Start ();
 
 			return asyncResult;

--- a/mcs/class/System/Test/System.Net/FtpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/FtpWebRequestTest.cs
@@ -231,11 +231,28 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
-		public void UploadFile1 ()
+		public void UploadFile1_v4 ()
 		{
-			ServerPut sp = new ServerPut ();
+			UploadFile1 (false);
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void UploadFile1_v6 ()
+		{
+			if (!Socket.OSSupportsIPv6)
+				Assert.Ignore ("IPv6 not supported.");
+
+			UploadFile1 (true);
+		}
+
+		void UploadFile1 (bool ipv6)
+		{
+			ServerPut sp = new ServerPut (ipv6);
 			sp.Start ();
-			string uri = String.Format ("ftp://{0}:{1}/uploads/file.txt", sp.IPAddress, sp.Port);
+			string uri = String.Format ("ftp://{0}:{1}/uploads/file.txt", EncloseIPv6 (sp.IPAddress), sp.Port);
 			try {
 				FtpWebRequest ftp = (FtpWebRequest) WebRequest.Create (uri);
 				ftp.KeepAlive = false;
@@ -264,15 +281,32 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
-		public void UploadFile_WebClient ()
+		public void UploadFile_WebClient_v4 ()
 		{
-			ServerPut sp = new ServerPut ();
+			UploadFile_WebClient (false);
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void UploadFile_WebClient_v6 ()
+		{
+			if (!Socket.OSSupportsIPv6)
+				Assert.Ignore ("IPv6 not supported.");
+
+			UploadFile_WebClient (true);
+		}
+
+		public void UploadFile_WebClient (bool ipv6)
+		{
+			ServerPut sp = new ServerPut (ipv6);
 			File.WriteAllText (_tempFile, "0123456789");
 			sp.Start ();
 
 			using (WebClient m_WebClient = new WebClient())
 			{
-				string uri = String.Format ("ftp://{0}:{1}/uploads/file.txt", sp.IPAddress, sp.Port);
+				string uri = String.Format ("ftp://{0}:{1}/uploads/file.txt", EncloseIPv6 (sp.IPAddress), sp.Port);
 				
 				m_WebClient.UploadFile(uri, _tempFile);
 			}
@@ -285,15 +319,27 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
-		public void DownloadFile1 ()
+		public void DownloadFile1_v4 ()
 		{
-			DownloadFile (new ServerDownload ());
+			DownloadFile (new ServerDownload (false));
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void DownloadFile1_v6 ()
+		{
+			if (!Socket.OSSupportsIPv6)
+				Assert.Ignore ("IPv6 not supported.");
+
+			DownloadFile (new ServerDownload (true));
 		}
 
 		void DownloadFile (ServerDownload sp)
 		{
 			sp.Start ();
-			string uri = String.Format ("ftp://{0}:{1}/file.txt", sp.IPAddress, sp.Port);
+			string uri = String.Format ("ftp://{0}:{1}/file.txt", EncloseIPv6 (sp.IPAddress), sp.Port);
 			try {
 				FtpWebRequest ftp = (FtpWebRequest) WebRequest.Create (uri);
 				ftp.KeepAlive = false;
@@ -320,22 +366,50 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
-		public void DownloadFile2 ()
+		public void DownloadFile2_v4 ()
 		{
 			// Some embedded FTP servers in Industrial Automation Hardware report
 			// the PWD using backslashes, but allow forward slashes for CWD.
-			DownloadFile (new ServerDownload (@"\Users\someuser", "/Users/someuser/"));
+			DownloadFile (new ServerDownload (@"\Users\someuser", "/Users/someuser/", false));
 		}
 
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
-		public void DeleteFile1 ()
+		public void DownloadFile2_v6 ()
 		{
-			ServerDeleteFile sp = new ServerDeleteFile ();
+			// Some embedded FTP servers in Industrial Automation Hardware report
+			// the PWD using backslashes, but allow forward slashes for CWD.
+			DownloadFile (new ServerDownload (@"\Users\someuser", "/Users/someuser/", true));
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void DeleteFile1_v4 ()
+		{
+			DeleteFile1 (false);
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void DeleteFile1_v6 ()
+		{
+			if (!Socket.OSSupportsIPv6)
+				Assert.Ignore ("IPv6 not supported.");
+
+			DeleteFile1 (true);
+		}
+
+		void DeleteFile1 (bool ipv6)
+		{
+			ServerDeleteFile sp = new ServerDeleteFile (ipv6);
 			sp.Start ();
-			string uri = String.Format ("ftp://{0}:{1}/file.txt", sp.IPAddress, sp.Port);
+			string uri = String.Format ("ftp://{0}:{1}/file.txt", EncloseIPv6 (sp.IPAddress), sp.Port);
 			try {
 				FtpWebRequest ftp = (FtpWebRequest) WebRequest.Create (uri);
 				Console.WriteLine (ftp.RequestUri);
@@ -360,11 +434,28 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
-		public void ListDirectory1 ()
+		public void ListDirectory1_v4 ()
 		{
-			ServerListDirectory sp = new ServerListDirectory ();
+			ListDirectory1 (false);
+		}
+
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
+		public void ListDirectory1_v6 ()
+		{
+			if (!Socket.OSSupportsIPv6)
+				Assert.Ignore ("IPv6 not supported.");
+
+			ListDirectory1 (true);
+		}
+
+		void ListDirectory1 (bool ipv6)
+		{
+			ServerListDirectory sp = new ServerListDirectory (ipv6);
 			sp.Start ();
-			string uri = String.Format ("ftp://{0}:{1}/somedir/", sp.IPAddress, sp.Port);
+			string uri = String.Format ("ftp://{0}:{1}/somedir/", EncloseIPv6 (sp.IPAddress), sp.Port);
 			try {
 				FtpWebRequest ftp = (FtpWebRequest) WebRequest.Create (uri);
 				Console.WriteLine (ftp.RequestUri);
@@ -387,7 +478,20 @@ namespace MonoTests.System.Net
 			}
 		}
 
+		string EncloseIPv6 (IPAddress address)
+		{
+			if (address.AddressFamily == AddressFamily.InterNetwork)
+				return address.ToString ();
+			
+			return String.Format ("[{0}]", address.ToString ());
+		}
+
 		class ServerListDirectory : FtpServer {
+			public ServerListDirectory (bool ipv6)
+				: base (ipv6)
+			{
+			}
+
 			protected override void Run ()
 			{
 				Socket client = control.Accept ();
@@ -405,24 +509,12 @@ namespace MonoTests.System.Net
 				}
 
 				string str = reader.ReadLine ();
-				if (str != "PASV") {
-					Where = "PASV";
+				string resp = FormatPassiveResponse (str);
+				if (resp == null) {
 					client.Close ();
 					return;
 				}
-
-				IPEndPoint end_data = (IPEndPoint) data.LocalEndPoint;
-				byte [] addr_bytes = end_data.Address.GetAddressBytes ();
-				byte [] port = new byte [2];
-				port[0] = (byte) ((end_data.Port >> 8) & 255);
-				port[1] = (byte) (end_data.Port & 255);
-				StringBuilder sb = new StringBuilder ("227 Passive (");
-				foreach (byte b in addr_bytes) {
-					sb.AppendFormat ("{0},", b);	
-				}
-				sb.AppendFormat ("{0},", port [0]);	
-				sb.AppendFormat ("{0})", port [1]);	
-				writer.WriteLine (sb.ToString ());
+				writer.WriteLine (resp);
 				writer.Flush ();
 
 				str = reader.ReadLine ();
@@ -449,6 +541,11 @@ namespace MonoTests.System.Net
 		}
 
 		class ServerDeleteFile : FtpServer {
+			public ServerDeleteFile (bool ipv6)
+				: base (ipv6)
+			{
+			}
+
 			protected override void Run ()
 			{
 				Socket client = control.Accept ();
@@ -485,12 +582,13 @@ namespace MonoTests.System.Net
 
 			string Pwd, Cwd;
 
-			public ServerDownload ()
-				: this (null, null)
+			public ServerDownload (bool ipv6)
+				: this (null, null, ipv6)
 			{
 			}
 
-			public ServerDownload (string pwd, string cwd)
+			public ServerDownload (string pwd, string cwd, bool ipv6)
+				: base (ipv6)
 			{
 				Pwd = pwd ?? "/home/someuser";
 				Cwd = cwd ?? "/home/someuser/";
@@ -513,24 +611,12 @@ namespace MonoTests.System.Net
 				}
 
 				string str = reader.ReadLine ();
-				if (str != "PASV") {
-					Where = "PASV";
+				string resp = FormatPassiveResponse (str);
+				if (resp == null) {
 					client.Close ();
 					return;
 				}
-
-				IPEndPoint end_data = (IPEndPoint) data.LocalEndPoint;
-				byte [] addr_bytes = end_data.Address.GetAddressBytes ();
-				byte [] port = new byte [2];
-				port[0] = (byte) ((end_data.Port >> 8) & 255);
-				port[1] = (byte) (end_data.Port & 255);
-				StringBuilder sb = new StringBuilder ("227 Passive (");
-				foreach (byte b in addr_bytes) {
-					sb.AppendFormat ("{0},", b);	
-				}
-				sb.AppendFormat ("{0},", port [0]);	
-				sb.AppendFormat ("{0})", port [1]);	
-				writer.WriteLine (sb.ToString ());
+				writer.WriteLine (resp);
 				writer.Flush ();
 
 				str = reader.ReadLine ();
@@ -559,6 +645,11 @@ namespace MonoTests.System.Net
 		class ServerPut : FtpServer {
 			public List<byte> result = new List<byte> ();
 			
+			public ServerPut (bool ipv6)
+				: base (ipv6)
+			{
+			}
+
 			protected override void Run ()
 			{
 				Socket client = control.Accept ();
@@ -576,24 +667,12 @@ namespace MonoTests.System.Net
 				}
 
 				string str = reader.ReadLine ();
-				if (str != "PASV") {
-					Where = "PASV";
+				string resp = FormatPassiveResponse (str);
+				if (resp == null) {
 					client.Close ();
 					return;
 				}
-
-				IPEndPoint end_data = (IPEndPoint) data.LocalEndPoint;
-				byte [] addr_bytes = end_data.Address.GetAddressBytes ();
-				byte [] port = new byte [2];
-				port[0] = (byte) ((end_data.Port >> 8) & 255);
-				port[1] = (byte) (end_data.Port & 255);
-				StringBuilder sb = new StringBuilder ("227 Passive (");
-				foreach (byte b in addr_bytes) {
-					sb.AppendFormat ("{0},", b);	
-				}
-				sb.AppendFormat ("{0},", port [0]);	
-				sb.AppendFormat ("{0})", port [1]);	
-				writer.WriteLine (sb.ToString ());
+				writer.WriteLine (resp);
 				writer.Flush ();
 
 				str = reader.ReadLine ();
@@ -627,16 +706,18 @@ namespace MonoTests.System.Net
 			protected Socket control;
 			protected Socket data;
 			protected ManualResetEvent evt;
+			protected bool ipv6;
 			public string Where = "";
 
-			public FtpServer ()
+			public FtpServer (bool ipv6)
 			{
-				control = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-				control.Bind (new IPEndPoint (IPAddress.Loopback, 0));
+				control = new Socket (ipv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+				control.Bind (new IPEndPoint (ipv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback, 0));
 				control.Listen (1);
-				data = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-				data.Bind (new IPEndPoint (IPAddress.Loopback, 0));
+				data = new Socket (ipv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+				data.Bind (new IPEndPoint (ipv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback, 0));
 				data.Listen (1);
+				this.ipv6 = ipv6;
 			}
 
 			public void Start ()
@@ -720,7 +801,39 @@ namespace MonoTests.System.Net
 				writer.Flush ();
 				return true;
 			}
-			
+
+			protected string FormatPassiveResponse (string request)
+			{
+				if (ipv6) {
+					if (request != "EPSV") {
+						Where = "EPSV";
+						return null;
+					}
+
+					IPEndPoint end_data = (IPEndPoint) data.LocalEndPoint;
+					return String.Format ("229 Extended Passive (|||{0}|)", end_data.Port);
+				}
+				else {
+					if (request != "PASV") {
+						Where = "PASV";
+						return null;
+					}
+
+					IPEndPoint end_data = (IPEndPoint) data.LocalEndPoint;
+					byte [] addr_bytes = end_data.Address.GetAddressBytes ();
+					byte [] port = new byte [2];
+					port[0] = (byte) ((end_data.Port >> 8) & 255);
+					port[1] = (byte) (end_data.Port & 255);
+					StringBuilder sb = new StringBuilder ("227 Passive (");
+					foreach (byte b in addr_bytes) {
+						sb.AppendFormat ("{0},", b);	
+					}
+					sb.AppendFormat ("{0},", port [0]);	
+					sb.AppendFormat ("{0})", port [1]);	
+					return sb.ToString ();
+				}
+			}
+
 			public IPAddress IPAddress {
 				get { return ((IPEndPoint) control.LocalEndPoint).Address; }
 			}


### PR DESCRIPTION
When connecting to an FTP server we weren't handling the RFC2428 extension to the FTP protocol which allows connections over IPv6 for the data channel.

We'd try to connect via IPv4 and the server would return an error saying that this protocol is not supported.

The fix is to add handling for the protocol extension, namely to use EPSV (for passive FTP) or EPRT (for active FTP) when opening the data channel and send/parse the IPv6 addresses.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44025

_Note:_ we're now using the IP address of the the control channel we connected to for the
data channel instead of the address that is returned by the server in the FTP response message.
The reason is that for EPSV there's no IP returned by the server, and it should be more reliable for normal PASV as well since the server might not know the correct external address. This is also what MS does in referencesource.