### PR TITLE
[mini] Fix mention of --aot-only option, it no longer exists

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -341,7 +341,7 @@ void *mono_global_codeman_reserve (int size)
 	void *ptr;
 
 	if (mono_aot_only)
-		g_error ("Attempting to allocate from the global code manager while running with --aot-only.\n");
+		g_error ("Attempting to allocate from the global code manager while running in aot-only mode.\n");
 
 	if (!global_codeman) {
 		/* This can happen during startup */

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4244,7 +4244,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 
 	if (mono_aot_only) {
 		char *fullname = mono_method_full_name (method, TRUE);
-		mono_error_set_execution_engine (error, "Attempting to JIT compile method '%s' while running with --aot-only. See http://docs.xamarin.com/ios/about/limitations for more information.\n", fullname);
+		mono_error_set_execution_engine (error, "Attempting to JIT compile method '%s' while running in aot-only mode. See https://developer.xamarin.com/guides/ios/advanced_topics/limitations/ for more information.\n", fullname);
 		g_free (fullname);
 
 		return NULL;


### PR DESCRIPTION
It was replaced with --full-aot in ba99fd833400666f574c571cc1981e846d09a610, but there were still two places left that talked about the old option which leads to confusion.

Also updated the link to Xamarin docs to the current URL.

/cc @vargaz 