### PR TITLE
[mcs] Use InvariantCulture for GetValueAsLiteral() in constant.cs

### DIFF
--- a/mcs/mcs/constant.cs
+++ b/mcs/mcs/constant.cs
@@ -478,7 +478,7 @@ namespace Mono.CSharp {
 			catch
 			{
 				ec.Report.Error (31, loc, "Constant value `{0}' cannot be converted to a `{1}'",
-					GetValue ().ToString (), target.GetSignatureForError ());
+					GetValueAsLiteral (), target.GetSignatureForError ());
 			}
 		}
 
@@ -1697,7 +1697,7 @@ namespace Mono.CSharp {
 
 		public override string GetValueAsLiteral ()
 		{
-			return Value.ToString ();
+			return Value.ToString (CultureInfo.InvariantCulture);
 		}
 
 		public override long GetValueAsLong ()
@@ -1820,7 +1820,7 @@ namespace Mono.CSharp {
 
 		public override string GetValueAsLiteral ()
 		{
-			return Value.ToString ();
+			return Value.ToString (CultureInfo.InvariantCulture);
 		}
 
 		public override long GetValueAsLong ()
@@ -2021,7 +2021,7 @@ namespace Mono.CSharp {
 
 		public override string GetValueAsLiteral ()
 		{
-			return Value.ToString () + "M";
+			return Value.ToString (CultureInfo.InvariantCulture) + "M";
 		}
 
 		public override long GetValueAsLong ()


### PR DESCRIPTION
Without it mcs would've printed the following error for code like `const int val = 1.42f`
on a system where the decimal separator is not the dot, e.g. German:

```
test.cs(3,18): error CS0031: Constant value `1,42' cannot be converted to a `int'
```

@marek-safar just a small commit from last year that I never upstreamed and stumbled over again today :)