### PR TITLE
With Android 7.0 (Nougat) it is no longer possible to read some

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
@@ -631,6 +631,19 @@ namespace System.Net.NetworkInformation {
 		string               iface_operstate_path;
 		string               iface_flags_path;		
 
+#if MONODROID
+		[DllImport ("__Internal")]
+		protected static extern int _monodroid_get_android_api_level ();
+
+		[DllImport ("__Internal")]
+		protected static extern bool _monodroid_get_network_interface_up_state (string ifname, ref bool is_up);
+
+		[DllImport ("__Internal")]
+		protected static extern bool _monodroid_get_network_interface_supports_multicast (string ifname, ref bool supports_multicast);
+
+		bool android_use_java_api;
+#endif
+
 		internal string IfacePath {
 			get { return iface_path; }
 		}
@@ -641,6 +654,9 @@ namespace System.Net.NetworkInformation {
 			iface_path = "/sys/class/net/" + name + "/";
 			iface_operstate_path = iface_path + "operstate";
 			iface_flags_path = iface_path + "flags";
+#if MONODROID
+			android_use_java_api = _monodroid_get_android_api_level () >= 24;
+#endif
 		}
 
 		public override IPInterfaceProperties GetIPProperties ()
@@ -659,6 +675,23 @@ namespace System.Net.NetworkInformation {
 
 		public override OperationalStatus OperationalStatus {
 			get {
+#if MONODROID
+				if (android_use_java_api) {
+					// Starting from API 24 (Android 7 "Nougat") Android restricts access to many
+					// files in the /sys filesystem (see https://code.google.com/p/android/issues/detail?id=205565
+					// for more information) and therefore we are forced to call into Java API in
+					// order to get the information. Alas, what we can obtain in this way is quite
+					// limited. In the case of OperationalStatus we can only determine whether the
+					// interface is up or down. There is a way to get more detailed information but
+					// it requires an instance of the Android Context class which is not available
+					// to us here.
+					bool is_up = false;
+					if (_monodroid_get_network_interface_up_state (Name, ref is_up))
+						return is_up ? OperationalStatus.Up : OperationalStatus.Down;
+					else
+						return OperationalStatus.Unknown;
+				}
+#endif
 				if (!Directory.Exists (iface_path))
 					return OperationalStatus.Unknown;
 				
@@ -695,6 +728,17 @@ namespace System.Net.NetworkInformation {
 
 		public override bool SupportsMulticast {
 			get {
+#if MONODROID
+				if (android_use_java_api) {
+					// Starting from API 24 (Android 7 "Nougat") Android restricts access to many
+					// files in the /sys filesystem (see https://code.google.com/p/android/issues/detail?id=205565
+					// for more information) and therefore we are forced to call into Java API in
+					// order to get the information.
+					bool supports_multicast = false;
+					_monodroid_get_network_interface_supports_multicast (Name, ref supports_multicast);
+					return supports_multicast;
+				}
+#endif
 				if (!Directory.Exists (iface_path))
 					return false;
 				


### PR DESCRIPTION
information about network interfaces from the /sys filesystem. Google
placed restrictions on two files used by the Mono BCL to read
information about the interface:

      /sys/class/net/[DEVICE]/flags
      /sys/class/net/[DEVICE]/operstate

The information we used to read from `flags` let us determine whether
the interface supports multicast and the `operstate` file provided us
with detailed information on the current device state.

Additionally, it is now impossible to read the hardware MAC address used
by any interface. This bit of information is also unavailable when using
the Java APIs and therefore applications running on devices with API
24 (and possibly newer) will not be able to access this information.

More details about the issue are available from the upstream Android
bug:

      https://code.google.com/p/android/issues/detail?id=205565

In order to obtain the required information, we now need to use the Java
APIs on devices with API 24+ and this commit implements the backend to
retrieve this information. It is done in C in order to avoid overhead of
creating mirror .NET objects when calling Java, thus saving time and
memory during an operation which may be performed by some applications
quite frequently.

This patch implements code that calls into the Xamarin.Android
runtime when runnin under API24 or newer to obtain the information.

Part of fix for https://bugzilla.xamarin.com/show_bug.cgi?id=44296