### PR TITLE
UdpClient.Receive parameter refers to remote EP

### DIFF
--- a/mcs/class/System.Data/System.Data.SqlClient/SqlConnection.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlConnection.cs
@@ -931,13 +931,11 @@ namespace System.Data.SqlClient
 				if (Client.Available <= 0)
 					return -1; // Error
 
-				IPEndPoint endpoint = CreateLocalEndpoint ();
-				if (endpoint == null)
-					return -1;
+				IPEndPoint remoteEndpoint = new IPEndpoint(IPAddress.Any, 0);
 
 				Byte [] rawrs;
 
-				rawrs = Receive (ref endpoint);
+				rawrs = Receive (ref remoteEndpoint);
 
 				string rs = Encoding.ASCII.GetString (rawrs);
 
@@ -958,16 +956,6 @@ namespace System.Data.SqlClient
 				Close ();
 
 				return SqlServerTcpPort;
-			}
-
-			IPEndPoint CreateLocalEndpoint ()
-			{
-				foreach (var addr in Dns.GetHostEntry ("localhost").AddressList) {
-					if (addr.AddressFamily == Client.AddressFamily)
-						return new IPEndPoint (addr, 0);
-				}
-
-				return null;
 			}
 		}
 


### PR DESCRIPTION
Instead of listening to a local end point, listen to any remote endpoint answering to our request.