### PR TITLE
Check for ReferenceAssemblyAttribute when loading for execution

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1958,37 +1958,37 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoString *fname, MonoBoolean re
 	MonoDomain *domain = mono_domain_get ();
 	char *name, *filename;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
-	MonoAssembly *ass;
+	MonoAssembly *ass = NULL;
+
+	name = NULL;
+	result = NULL;
+
+	mono_error_init (&error);
 
 	if (fname == NULL) {
-		MonoException *exc = mono_get_exception_argument_null ("assemblyFile");
-		mono_set_pending_exception (exc);
-		return NULL;
+		mono_error_set_argument_null (&error, "assemblyFile", "");
+		goto leave;
 	}
 		
 	name = filename = mono_string_to_utf8_checked (fname, &error);
-	if (mono_error_set_pending_exception (&error))
-		return NULL;
+	if (!is_ok (&error))
+		goto leave;
 	
 	ass = mono_assembly_open_full (filename, &status, refOnly);
 	
 	if (!ass) {
-		MonoException *exc;
-
 		if (status == MONO_IMAGE_IMAGE_INVALID)
-			exc = mono_get_exception_bad_image_format2 (NULL, fname);
+			mono_error_set_bad_image_name (&error, name, "");
 		else
-			exc = mono_get_exception_file_not_found2 (NULL, fname);
-		g_free (name);
-		mono_set_pending_exception (exc);
-		return NULL;
+			mono_error_set_exception_instance (&error, mono_get_exception_file_not_found2 (NULL, fname));
+		goto leave;
 	}
 
-	g_free (name);
-
 	result = mono_assembly_get_object_checked (domain, ass, &error);
-	if (!result)
-		mono_error_set_pending_exception (&error);
+
+leave:
+	mono_error_set_pending_exception (&error);
+	g_free (name);
 	return result;
 }
 
@@ -2040,7 +2040,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 	MonoAssembly *ass;
 	MonoAssemblyName aname;
 	MonoReflectionAssembly *refass = NULL;
-	gchar *name;
+	gchar *name = NULL;
 	gboolean parsed;
 
 	g_assert (assRef);
@@ -2049,16 +2049,13 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 	if (mono_error_set_pending_exception (&error))
 		return NULL;
 	parsed = mono_assembly_name_parse (name, &aname);
-	g_free (name);
 
 	if (!parsed) {
 		/* This is a parse error... */
 		if (!refOnly) {
 			refass = mono_try_assembly_resolve (domain, assRef, NULL, refOnly, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
-				return NULL;
-			}
+			if (!is_ok (&error))
+				goto leave;
 		}
 		return refass;
 	}
@@ -2070,25 +2067,28 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 		/* MS.NET doesn't seem to call the assembly resolve handler for refonly assemblies */
 		if (!refOnly) {
 			refass = mono_try_assembly_resolve (domain, assRef, NULL, refOnly, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
-				return NULL;
-			}
+			if (!is_ok (&error))
+				goto leave;
 		}
 		else
 			refass = NULL;
-		if (!refass) {
-			return NULL;
-		}
+		if (!refass)
+			goto leave;
+		ass = refass->assembly;
 	}
 
-	if (refass == NULL)
+	g_assert (ass);
+	if (refass == NULL) {
 		refass = mono_assembly_get_object_checked (domain, ass, &error);
+		if (!is_ok (&error))
+			goto leave;
+	}
 
-	if (refass == NULL)
-		mono_error_set_pending_exception (&error);
-	else
-		MONO_OBJECT_SETREF (refass, evidence, evidence);
+	MONO_OBJECT_SETREF (refass, evidence, evidence);
+
+leave:
+	g_free (name);
+	mono_error_set_pending_exception (&error);
 	return refass;
 }
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5549,6 +5549,7 @@ mono_class_setup_parent (MonoClass *klass, MonoClass *parent)
 			/* set the parent to something useful and safe, but mark the type as broken */
 			parent = mono_defaults.object_class;
 			mono_class_set_type_load_failure (klass, "");
+			g_assert (parent);
 		}
 
 		klass->parent = parent;

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1438,7 +1438,7 @@ mono_custom_attrs_has_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 		if (centry->ctor == NULL)
 			continue;
 		MonoClass *klass = centry->ctor->klass;
-		if (mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from (attr_klass, klass)))
+		if (klass == attr_klass || mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from (attr_klass, klass)))
 			return TRUE;
 	}
 	return FALSE;
@@ -1468,7 +1468,7 @@ mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_k
 		if (centry->ctor == NULL)
 			continue;
 		MonoClass *klass = centry->ctor->klass;
-		if (mono_class_is_assignable_from (attr_klass, klass))
+		if (attr_klass == klass || mono_class_is_assignable_from (attr_klass, klass))
 			break;
 	}
 	if (centry == NULL)

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1453,26 +1453,25 @@ mono_custom_attrs_get_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 MonoObject*
 mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass, MonoError *error)
 {
-	int i, attr_index;
-	MonoArray *attrs;
+	int i;
+	MonoCustomAttrEntry *centry = NULL;
+
+	g_assert (attr_klass != NULL);
 
 	mono_error_init (error);
 
-	attr_index = -1;
 	for (i = 0; i < ainfo->num_attrs; ++i) {
-		MonoClass *klass = ainfo->attrs [i].ctor->klass;
-		if (mono_class_has_parent (klass, attr_klass)) {
-			attr_index = i;
+		centry = &ainfo->attrs[i];
+		if (centry->ctor == NULL)
+			continue;
+		MonoClass *klass = centry->ctor->klass;
+		if (mono_class_is_assignable_from (attr_klass, klass))
 			break;
-		}
 	}
-	if (attr_index == -1)
+	if (centry == NULL)
 		return NULL;
 
-	attrs = mono_custom_attrs_construct_by_type (ainfo, NULL, error);
-	if (!mono_error_ok (error))
-		return NULL;
-	return mono_array_get (attrs, MonoObject*, attr_index);
+	return create_custom_attr (ainfo->image, centry->ctor, centry->data, centry->data_size, error);
 }
 
 /*

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1434,7 +1434,10 @@ mono_custom_attrs_has_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 {
 	int i;
 	for (i = 0; i < ainfo->num_attrs; ++i) {
-		MonoClass *klass = ainfo->attrs [i].ctor->klass;
+		MonoCustomAttrEntry *centry = &ainfo->attrs[i];
+		if (centry->ctor == NULL)
+			continue;
+		MonoClass *klass = centry->ctor->klass;
 		if (mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from (attr_klass, klass)))
 			return TRUE;
 	}

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -697,7 +697,7 @@ void
 mono_context_init_checked (MonoDomain *domain, MonoError *error);
 
 gboolean
-mono_assembly_get_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error);
+mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error);
 
 
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -816,6 +816,16 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_profiler_appdomain_name (domain, domain->friendly_name);
 
+	/* Have to do this quite late so that we at least have System.Object */
+	MonoError custom_attr_error;
+	if (mono_assembly_has_reference_assembly_attribute (ass, &custom_attr_error)) {
+		char *corlib_file = g_build_filename (mono_assembly_getrootdir (), "mono", current_runtime->framework_version, "mscorlib.dll", NULL);
+		g_print ("Could not load file or assembly %s. Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context.", corlib_file);
+		g_free (corlib_file);
+		exit (1);
+	}
+	mono_error_assert_ok (&custom_attr_error);
+
 	return domain;
 }
 

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -102,6 +102,7 @@ MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_field    (MonoClass *klass, 
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_param    (MonoMethod *method, uint32_t param);
 MONO_API mono_bool           mono_custom_attrs_has_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject*         mono_custom_attrs_get_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
 MONO_API void                mono_custom_attrs_free          (MonoCustomAttrInfo *ainfo);
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -469,7 +469,8 @@ BASE_TEST_CS_SRC_UNIVERSAL=		\
 	bug-29585.cs	\
 	priority.cs	\
 	abort-cctor.cs	\
-	thread-native-exit.cs
+	thread-native-exit.cs \
+	reference-loader.cs
 
 if INSTALL_MOBILE_STATIC
 BASE_TEST_CS_SRC= \
@@ -802,18 +803,22 @@ endif
 # but that need to be compiled
 PREREQ_IL_SRC=event-il.il module-cctor.il
 PREREQ_CS_SRC=
-PREREQ_IL_DLL_SRC=event-il.il module-cctor.il
-PREREQ_CS_DLL_SRC=
+PREREQ_IL_DLL_SRC=
+PREREQ_CS_DLL_SRC=TestingReferenceAssembly.cs TestingReferenceReferenceAssembly.cs
 
-PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe)
-PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe)
+PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe) \
+	$(PREREQ_IL_DLL_SRC:.il=.dll)
+PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe) \
+	$(PREREQ_CS_DLL_SRC:.cs=.dll)
 TESTSI_CS=$(TEST_CS_SRC:.cs=.exe)
 TESTSI_IL=$(TEST_IL_SRC:.il=.exe)
 TESTBS=$(BENCHSRC:.cs=.exe)
 STRESS_TESTS=$(STRESS_TESTS_SRC:.cs=.exe)
 
-PREREQSI_IL_AOT=$(PREREQ_IL_SRC:.il=.exe$(PLATFORM_AOT_SUFFIX))
-PREREQSI_CS_AOT=$(PREREQ_CS_SRC:.cs=.exe$(PLATFORM_AOT_SUFFIX))
+PREREQSI_IL_AOT=$(PREREQ_IL_SRC:.il=.exe$(PLATFORM_AOT_SUFFIX)) \
+		$(PREREQ_IL_DLL_SRC:.il=.dll$(PLATFORM_AOT_SUFFIX))
+PREREQSI_CS_AOT=$(PREREQ_CS_SRC:.cs=.exe$(PLATFORM_AOT_SUFFIX)) \
+		$(PREREQ_CS_DLL_SRC:.cs=.dll$(PLATFORM_AOT_SUFFIX))
 
 EXTRA_DIST=test-driver test-runner.cs $(TEST_CS_SRC_DIST) $(TEST_IL_SRC) \
 	$(BENCHSRC) $(STRESS_TESTS_SRC) stress-runner.pl $(PREREQ_IL_SRC) $(PREREQ_CS_SRC)
@@ -833,6 +838,12 @@ endif
 
 %.exe: %.cs $(TEST_DRIVER_DEPEND)
 	$(MCS) -r:System.dll -r:System.Xml.dll -r:System.Core.dll -r:TestDriver.dll $(TEST_DRIVER_HARD_KILL_FEATURE) -out:$@ $<
+
+%.dll: %.cs
+	$(MCS) -r:System.dll -target:library -out:$@ $<
+
+TestingReferenceReferenceAssembly.dll: TestingReferenceReferenceAssembly.cs TestingReferenceAssembly.dll
+	$(MCS) -r:TestingReferenceAssembly.dll -target:library -out:$@ $<
 
 %.exe$(PLATFORM_AOT_SUFFIX): %.exe 
 	$(RUNTIME) $(AOT_BUILD_FLAGS) $<

--- a/mono/tests/TestingReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceAssembly.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: ReferenceAssemblyAttribute]
+
+public class X {
+	public int Y;
+}

--- a/mono/tests/TestingReferenceReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceReferenceAssembly.cs
@@ -1,0 +1,7 @@
+// An assembly that refereces the TestingReferenceAssembly
+
+class Z : X {
+	public Z () {
+		Y = 1;
+	}
+}

--- a/mono/tests/reference-loader.cs
+++ b/mono/tests/reference-loader.cs
@@ -1,0 +1,110 @@
+//
+// reference-loader.cs:
+//
+//  Test for reference assembly loading
+
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Tests {
+	public static int Main (string[] args)
+	{
+		return TestDriver.RunTests (typeof (Tests), args);
+	}
+
+	public static int test_0_loadFrom_reference ()
+	{
+		// Check that loading a reference assembly by filename for execution is an error
+		try {
+			var a = Assembly.LoadFrom ("./TestingReferenceAssembly.dll");
+		} catch (BadImageFormatException exn) {
+			// .NET Framework 4.6.2 throws BIFE here.
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_load_reference ()
+	{
+		// Check that loading a reference assembly for execution is an error
+		try {
+			var an = new AssemblyName ("TestingReferenceAssembly");
+			var a = Assembly.Load (an);
+		} catch (FileNotFoundException exn) {
+			return 0;
+		} catch (BadImageFormatException exn) {
+			// .NET Framework 4.6.2 throws BIFE here.
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference ()
+	{
+		// Check that reflection-only loading a reference assembly is okay
+		var an = new AssemblyName ("TestingReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+	public static int test_0_load_reference_asm_via_reference ()
+	{
+		// Check that loading an assembly that references a reference assembly doesn't succeed.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		try {
+			var a = Assembly.Load (an);
+			var t = a.GetType ("Z");
+		} catch (FileNotFoundException){
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_asm_via_reference ()
+	{
+		// Check that reflection-only loading an assembly that
+		// references a reference assembly is okay.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("Z");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+
+	public static int test_0_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte array for execution is an error
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		try {
+			var a = Assembly.Load (bs);
+		} catch (BadImageFormatException) {
+			return 0;
+		} catch (FileNotFoundException exn) {
+			Console.Error.WriteLine ("incorrect exn was {0}", exn);
+			return 2;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte
+		// array for reflection only is okay.
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		var a = Assembly.ReflectionOnlyLoad (bs);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+}

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -297,7 +297,7 @@ mono_error_set_assembly_load_simple (MonoError *oerror, const char *assembly_nam
 	if (refection_only)
 		mono_error_set_assembly_load (oerror, assembly_name, "Cannot resolve dependency to assembly because it has not been preloaded. When using the ReflectionOnly APIs, dependent assemblies must be pre-loaded or loaded on demand through the ReflectionOnlyAssemblyResolve event.");
 	else
-		mono_error_set_assembly_load (oerror, assembly_name, "Could not load file or assembly or one of its dependencies.");
+		mono_error_set_assembly_load (oerror, assembly_name, "Could not load file or assembly '%s' or one of its dependencies.", assembly_name);
 }
 
 void


### PR DESCRIPTION
An assembly with a `System.Runtime.CompilerServices.ReferenceAssemblyAttribute`
may be loaded in a reflection-only context, but not for execution.

When loading assembly refs, or when loading assemblies by name (as
opposed to file path), a reference assembly will be skipped over and
other assemblies from the GAC and the load path will be tried.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42584

(This is a second try at a PR for this issue; the last one broke gacutil which has since been rewritten to avoid that problem)