### PR TITLE
[C9] Check for ReferenceAssemblyAttribute when loading for execution

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1942,37 +1942,37 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoString *fname, MonoBoolean re
 	MonoDomain *domain = mono_domain_get ();
 	char *name, *filename;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
-	MonoAssembly *ass;
+	MonoAssembly *ass = NULL;
+
+	name = NULL;
+	result = NULL;
+
+	mono_error_init (&error);
 
 	if (fname == NULL) {
-		MonoException *exc = mono_get_exception_argument_null ("assemblyFile");
-		mono_set_pending_exception (exc);
-		return NULL;
+		mono_error_set_argument_null (&error, "assemblyFile", "");
+		goto leave;
 	}
 		
 	name = filename = mono_string_to_utf8_checked (fname, &error);
-	if (mono_error_set_pending_exception (&error))
-		return NULL;
+	if (!is_ok (&error))
+		goto leave;
 	
 	ass = mono_assembly_open_full (filename, &status, refOnly);
 	
 	if (!ass) {
-		MonoException *exc;
-
 		if (status == MONO_IMAGE_IMAGE_INVALID)
-			exc = mono_get_exception_bad_image_format2 (NULL, fname);
+			mono_error_set_bad_image_name (&error, name, "");
 		else
-			exc = mono_get_exception_file_not_found2 (NULL, fname);
-		g_free (name);
-		mono_set_pending_exception (exc);
-		return NULL;
+			mono_error_set_exception_instance (&error, mono_get_exception_file_not_found2 (NULL, fname));
+		goto leave;
 	}
 
-	g_free (name);
-
 	result = mono_assembly_get_object_checked (domain, ass, &error);
-	if (!result)
-		mono_error_set_pending_exception (&error);
+
+leave:
+	mono_error_set_pending_exception (&error);
+	g_free (name);
 	return result;
 }
 
@@ -2024,7 +2024,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 	MonoAssembly *ass;
 	MonoAssemblyName aname;
 	MonoReflectionAssembly *refass = NULL;
-	gchar *name;
+	gchar *name = NULL;
 	gboolean parsed;
 
 	g_assert (assRef);
@@ -2033,16 +2033,13 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 	if (mono_error_set_pending_exception (&error))
 		return NULL;
 	parsed = mono_assembly_name_parse (name, &aname);
-	g_free (name);
 
 	if (!parsed) {
 		/* This is a parse error... */
 		if (!refOnly) {
 			refass = mono_try_assembly_resolve (domain, assRef, NULL, refOnly, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
-				return NULL;
-			}
+			if (!is_ok (&error))
+				goto leave;
 		}
 		return refass;
 	}
@@ -2054,25 +2051,28 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomain *ad,  MonoString *assRef,
 		/* MS.NET doesn't seem to call the assembly resolve handler for refonly assemblies */
 		if (!refOnly) {
 			refass = mono_try_assembly_resolve (domain, assRef, NULL, refOnly, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
-				return NULL;
-			}
+			if (!is_ok (&error))
+				goto leave;
 		}
 		else
 			refass = NULL;
-		if (!refass) {
-			return NULL;
-		}
+		if (!refass)
+			goto leave;
+		ass = refass->assembly;
 	}
 
-	if (refass == NULL)
+	g_assert (ass);
+	if (refass == NULL) {
 		refass = mono_assembly_get_object_checked (domain, ass, &error);
+		if (!is_ok (&error))
+			goto leave;
+	}
 
-	if (refass == NULL)
-		mono_error_set_pending_exception (&error);
-	else
-		MONO_OBJECT_SETREF (refass, evidence, evidence);
+	MONO_OBJECT_SETREF (refass, evidence, evidence);
+
+leave:
+	g_free (name);
+	mono_error_set_pending_exception (&error);
 	return refass;
 }
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -212,6 +212,9 @@ mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *request
 static MonoBoolean
 mono_assembly_is_in_gac (const gchar *filanem);
 
+static MonoAssembly*
+prevent_reference_assembly_from_running (MonoAssembly* candidate, gboolean refonly);
+
 static gchar*
 encode_public_tok (const guchar *token, gint32 len)
 {
@@ -1191,6 +1194,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 				   aname.major, aname.minor, aname.build, aname.revision,
 				   strlen ((char*)aname.public_key_token) == 0 ? "(none)" : (char*)aname.public_key_token, extra_msg);
 		g_free (extra_msg);
+
 	}
 
 	mono_assemblies_lock ();
@@ -1809,7 +1813,7 @@ mono_assembly_load_friends (MonoAssembly* ass)
 
 
 /**
- * mono_assembly_get_reference_assembly_attribute:
+ * mono_assembly_has_reference_assembly_attribute:
  * @assembly: a MonoAssembly
  * @error: set on error.
  *
@@ -1817,7 +1821,7 @@ mono_assembly_load_friends (MonoAssembly* ass)
  * On error returns FALSE and sets @error.
  */
 gboolean
-mono_assembly_get_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error)
+mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error)
 {
 	mono_error_init (error);
 
@@ -1826,14 +1830,8 @@ mono_assembly_get_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
 	if (!attrs)
 		return FALSE;
 	MonoClass *ref_asm_class = mono_class_try_get_reference_assembly_class ();
-	gboolean result = FALSE;
-	for (int i = 0; i < attrs->num_attrs; ++i) {
-		MonoCustomAttrEntry *attr = &attrs->attrs [i];
-		if (attr->ctor && attr->ctor->klass && attr->ctor->klass == ref_asm_class) {
-			result = TRUE;
-			break;
-		}
-	}
+	g_assert (ref_asm_class != NULL && ref_asm_class != mono_defaults.object_class && !strcmp(ref_asm_class->name, "ReferenceAssemblyAttribute") );
+	gboolean result = mono_custom_attrs_has_attr (attrs, ref_asm_class);
 	mono_custom_attrs_free (attrs);
 	return result;
 }
@@ -1971,6 +1969,36 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 		mono_image_close (image);
 		*status = MONO_IMAGE_OK;
 		return ass2;
+	}
+
+	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Prepared to set up assembly '%s' (%s)", ass->aname.name, image->name);
+
+	/* We need to check for ReferenceAssmeblyAttribute before we
+	 * mark the assembly as loaded and before we fire the load
+	 * hook. Otherwise mono_domain_fire_assembly_load () in
+	 * appdomain.c will cache a mapping from the assembly name to
+	 * this image and we won't be able to look for a different
+	 * candidate. */
+
+	if (!refonly && strcmp (ass->aname.name, "mscorlib") != 0) {
+		/* Don't check for reference assmebly attribute for
+		 * corlib here because if corlib isn't loaded yet,
+		 * it's too early to set up the
+		 * ReferenceAssemblyAttribute class.  We check that
+		 * we're not running with a reference corlib in
+		 * mono_init_internal().
+		 */
+		MonoError refasm_error;
+		if (mono_assembly_has_reference_assembly_attribute (ass, &refasm_error)) {
+			mono_assemblies_unlock ();
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Image for assembly '%s' (%s) has ReferenceAssemblyAttribute, skipping", ass->aname.name, image->name);
+			g_free (ass);
+			g_free (base_dir);
+			mono_image_close (image);
+			*status = MONO_IMAGE_IMAGE_INVALID;
+			return NULL;
+		}
+		mono_error_cleanup (&refasm_error);
 	}
 
 	image->assembly = ass;
@@ -3176,6 +3204,19 @@ return_corlib_and_facades:
 	return corlib;
 }
 
+static MonoAssembly*
+prevent_reference_assembly_from_running (MonoAssembly* candidate, gboolean refonly)
+{
+	MonoError refasm_error;
+	mono_error_init (&refasm_error);
+	if (candidate && !refonly && mono_assembly_has_reference_assembly_attribute (candidate, &refasm_error)) {
+		candidate = NULL;
+	}
+	mono_error_cleanup (&refasm_error);
+	return candidate;
+}
+
+
 MonoAssembly*
 mono_assembly_load_full_nosearch (MonoAssemblyName *aname, 
 								  const char       *basedir, 
@@ -3257,9 +3298,11 @@ mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *request
 {
 	MonoAssembly *result = mono_assembly_load_full_nosearch (aname, basedir, status, refonly);
 
-	if (!result)
+	if (!result) {
 		/* Try a postload search hook */
 		result = mono_assembly_invoke_search_hook_internal (aname, requesting, refonly, TRUE);
+		result = prevent_reference_assembly_from_running (result, refonly);
+	}
 	return result;
 }
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1825,6 +1825,12 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
 {
 	mono_error_init (error);
 
+/* TODO: mono_custom_attrs_from_assembly_checked returns NULL if a
+ * single assembly is missing.  The custom attr we want is from
+ * corlib, however, so we need a more robust version that doesn't care
+ * about missing attributes.
+ */
+#if 0
 	MonoCustomAttrInfo *attrs = mono_custom_attrs_from_assembly_checked (assembly, error);
 	return_val_if_nok (error, FALSE);
 	if (!attrs)
@@ -1834,6 +1840,9 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
 	gboolean result = mono_custom_attrs_has_attr (attrs, ref_asm_class);
 	mono_custom_attrs_free (attrs);
 	return result;
+#else
+	return FALSE;
+#endif
 }
 
 /**

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1830,7 +1830,7 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
  * corlib, however, so we need a more robust version that doesn't care
  * about missing attributes.
  */
-#if 0
+#if 1
 	MonoCustomAttrInfo *attrs = mono_custom_attrs_from_assembly_checked (assembly, TRUE, error);
 	return_val_if_nok (error, FALSE);
 	if (!attrs)
@@ -1982,6 +1982,8 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Prepared to set up assembly '%s' (%s)", ass->aname.name, image->name);
 
+	image->assembly = ass;
+
 	/* We need to check for ReferenceAssmeblyAttribute before we
 	 * mark the assembly as loaded and before we fire the load
 	 * hook. Otherwise mono_domain_fire_assembly_load () in
@@ -2009,8 +2011,6 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 		}
 		mono_error_cleanup (&refasm_error);
 	}
-
-	image->assembly = ass;
 
 	loaded_assemblies = g_list_prepend (loaded_assemblies, ass);
 	mono_assemblies_unlock ();

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1751,7 +1751,7 @@ mono_assembly_load_friends (MonoAssembly* ass)
 	if (ass->friend_assembly_names_inited)
 		return;
 
-	attrs = mono_custom_attrs_from_assembly_checked (ass, &error);
+	attrs = mono_custom_attrs_from_assembly_checked (ass, FALSE, &error);
 	mono_error_assert_ok (&error);
 	if (!attrs) {
 		mono_assemblies_lock ();
@@ -1831,7 +1831,7 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
  * about missing attributes.
  */
 #if 0
-	MonoCustomAttrInfo *attrs = mono_custom_attrs_from_assembly_checked (assembly, error);
+	MonoCustomAttrInfo *attrs = mono_custom_attrs_from_assembly_checked (assembly, TRUE, error);
 	return_val_if_nok (error, FALSE);
 	if (!attrs)
 		return FALSE;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5591,6 +5591,7 @@ mono_class_setup_parent (MonoClass *klass, MonoClass *parent)
 			/* set the parent to something useful and safe, but mark the type as broken */
 			parent = mono_defaults.object_class;
 			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, NULL);
+			g_assert (parent);
 		}
 
 		klass->parent = parent;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -10679,14 +10679,18 @@ mono_field_resolve_type (MonoClassField *field, MonoError *error)
 		MonoClassField *gfield = &gtd->fields [field_idx];
 		MonoType *gtype = mono_field_get_type_checked (gfield, error);
 		if (!mono_error_ok (error)) {
-			char *err_msg = g_strdup_printf ("Could not load field %d type due to: %s", field_idx, mono_error_get_message (error));
+			char *full_name = mono_type_get_full_name (gtd);
+			char *err_msg = g_strdup_printf ("Could not load generic type of field '%s:%s' (%d) due to: %s", full_name, gfield->name, field_idx, mono_error_get_message (error));
 			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, err_msg);
+			g_free (full_name);
 		}
 
 		field->type = mono_class_inflate_generic_type_no_copy (image, gtype, mono_class_get_context (klass), error);
 		if (!mono_error_ok (error)) {
-			char *err_msg = g_strdup_printf ("Could not load field %d type due to: %s", field_idx, mono_error_get_message (error));
+			char *full_name = mono_type_get_full_name (klass);
+			char *err_msg = g_strdup_printf ("Could not load instantiated type of field '%s:%s' (%d) due to: %s", full_name, field->name, field_idx, mono_error_get_message (error));
 			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, err_msg);
+			g_free (full_name);
 		}
 	} else {
 		const char *sig;
@@ -10708,8 +10712,10 @@ mono_field_resolve_type (MonoClassField *field, MonoError *error)
 		mono_metadata_decode_table_row (image, MONO_TABLE_FIELD, idx, cols, MONO_FIELD_SIZE);
 
 		if (!mono_verifier_verify_field_signature (image, cols [MONO_FIELD_SIGNATURE], NULL)) {
-			mono_error_set_type_load_class (error, klass, "Could not verify field %s signature", field->name);;
+			char *full_name = mono_type_get_full_name (klass);
+			mono_error_set_type_load_class (error, klass, "Could not verify field '%s:%s' signature", full_name, field->name);;
 			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, g_strdup (mono_error_get_message (error)));
+			g_free (full_name);
 			return;
 		}
 
@@ -10721,8 +10727,10 @@ mono_field_resolve_type (MonoClassField *field, MonoError *error)
 
 		field->type = mono_metadata_parse_type_checked (image, container, cols [MONO_FIELD_FLAGS], FALSE, sig + 1, &sig, error);
 		if (!field->type) {
-			char *err_msg = g_strdup_printf ("Could not load field %d type due to: %s", field_idx, mono_error_get_message (error));
+			char *full_name = mono_type_get_full_name (klass);
+			char *err_msg = g_strdup_printf ("Could not load type of field '%s:%s' (%d) due to: %s", full_name, field->name, field_idx, mono_error_get_message (error));
 			mono_class_set_failure (klass, MONO_EXCEPTION_TYPE_LOAD, err_msg);
+			g_free (full_name);
 		}
 	}
 }

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1438,7 +1438,7 @@ mono_custom_attrs_has_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 		if (centry->ctor == NULL)
 			continue;
 		MonoClass *klass = centry->ctor->klass;
-		if (mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from (attr_klass, klass)))
+		if (klass == attr_klass || mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from (attr_klass, klass)))
 			return TRUE;
 	}
 	return FALSE;
@@ -1468,7 +1468,7 @@ mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_k
 		if (centry->ctor == NULL)
 			continue;
 		MonoClass *klass = centry->ctor->klass;
-		if (mono_class_is_assignable_from (attr_klass, klass))
+		if (attr_klass == klass || mono_class_is_assignable_from (attr_klass, klass))
 			break;
 	}
 	if (centry == NULL)

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1453,26 +1453,25 @@ mono_custom_attrs_get_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 MonoObject*
 mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass, MonoError *error)
 {
-	int i, attr_index;
-	MonoArray *attrs;
+	int i;
+	MonoCustomAttrEntry *centry = NULL;
+
+	g_assert (attr_klass != NULL);
 
 	mono_error_init (error);
 
-	attr_index = -1;
 	for (i = 0; i < ainfo->num_attrs; ++i) {
-		MonoClass *klass = ainfo->attrs [i].ctor->klass;
-		if (mono_class_has_parent (klass, attr_klass)) {
-			attr_index = i;
+		centry = &ainfo->attrs[i];
+		if (centry->ctor == NULL)
+			continue;
+		MonoClass *klass = centry->ctor->klass;
+		if (mono_class_is_assignable_from (attr_klass, klass))
 			break;
-		}
 	}
-	if (attr_index == -1)
+	if (centry == NULL)
 		return NULL;
 
-	attrs = mono_custom_attrs_construct_by_type (ainfo, NULL, error);
-	if (!mono_error_ok (error))
-		return NULL;
-	return mono_array_get (attrs, MonoObject*, attr_index);
+	return create_custom_attr (ainfo->image, centry->ctor, centry->data, centry->data_size, error);
 }
 
 /*

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1434,7 +1434,10 @@ mono_custom_attrs_has_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 {
 	int i;
 	for (i = 0; i < ainfo->num_attrs; ++i) {
-		MonoClass *klass = ainfo->attrs [i].ctor->klass;
+		MonoCustomAttrEntry *centry = &ainfo->attrs[i];
+		if (centry->ctor == NULL)
+			continue;
+		MonoClass *klass = centry->ctor->klass;
 		if (mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from (attr_klass, klass)))
 			return TRUE;
 	}

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -698,7 +698,7 @@ void
 mono_context_init_checked (MonoDomain *domain, MonoError *error);
 
 gboolean
-mono_assembly_get_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error);
+mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error);
 
 
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -808,6 +808,16 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_profiler_appdomain_name (domain, domain->friendly_name);
 
+	/* Have to do this quite late so that we at least have System.Object */
+	MonoError custom_attr_error;
+	if (mono_assembly_has_reference_assembly_attribute (ass, &custom_attr_error)) {
+		char *corlib_file = g_build_filename (mono_assembly_getrootdir (), "mono", current_runtime->framework_version, "mscorlib.dll", NULL);
+		g_print ("Could not load file or assembly %s. Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context.", corlib_file);
+		g_free (corlib_file);
+		exit (1);
+	}
+	mono_error_assert_ok (&custom_attr_error);
+
 	return domain;
 }
 

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -41,13 +41,13 @@ MonoArray*
 mono_reflection_get_custom_attrs_blob_checked (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues, MonoError *error);
 
 MonoCustomAttrInfo*
-mono_custom_attrs_from_index_checked    (MonoImage *image, uint32_t idx, MonoError *error);
+mono_custom_attrs_from_index_checked    (MonoImage *image, uint32_t idx, gboolean ignore_missing, MonoError *error);
 MonoCustomAttrInfo*
 mono_custom_attrs_from_method_checked   (MonoMethod *method, MonoError *error);
 MonoCustomAttrInfo*
 mono_custom_attrs_from_class_checked   	(MonoClass *klass, MonoError *error);
 MonoCustomAttrInfo*
-mono_custom_attrs_from_assembly_checked	(MonoAssembly *assembly, MonoError *error);
+mono_custom_attrs_from_assembly_checked	(MonoAssembly *assembly, gboolean ignore_missing, MonoError *error);
 MonoCustomAttrInfo*
 mono_custom_attrs_from_property_checked	(MonoClass *klass, MonoProperty *property, MonoError *error);
 MonoCustomAttrInfo*

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -102,6 +102,7 @@ MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_field    (MonoClass *klass, 
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_param    (MonoMethod *method, uint32_t param);
 MONO_API mono_bool           mono_custom_attrs_has_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoObject*         mono_custom_attrs_get_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
 MONO_API void                mono_custom_attrs_free          (MonoCustomAttrInfo *ainfo);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7953,7 +7953,7 @@ is_jit_optimizer_disabled (MonoMethod *m)
 		return FALSE;
 	}
 
-	attrs = mono_custom_attrs_from_assembly_checked (ass, &error);
+	attrs = mono_custom_attrs_from_assembly_checked (ass, FALSE, &error);
 	mono_error_cleanup (&error); /* FIXME don't swallow the error */
 	if (attrs) {
 		for (i = 0; i < attrs->num_attrs; ++i) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1229,7 +1229,7 @@ wrap_non_exception_throws (MonoMethod *m)
 
 	klass = mono_class_get_runtime_compat_attr_class ();
 
-	attrs = mono_custom_attrs_from_assembly_checked (ass, &error);
+	attrs = mono_custom_attrs_from_assembly_checked (ass, FALSE, &error);
 	mono_error_cleanup (&error); /* FIXME don't swallow the error */
 	if (attrs) {
 		for (i = 0; i < attrs->num_attrs; ++i) {

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -467,7 +467,8 @@ BASE_TEST_CS_SRC_UNIVERSAL=		\
 	pinvoke_ppcd.cs	\
 	bug-29585.cs	\
 	priority.cs	\
-	abort-cctor.cs
+	abort-cctor.cs	\
+	reference-loader.cs
 
 if INSTALL_MOBILE_STATIC
 BASE_TEST_CS_SRC= \
@@ -800,18 +801,22 @@ endif
 # but that need to be compiled
 PREREQ_IL_SRC=event-il.il module-cctor.il
 PREREQ_CS_SRC=
-PREREQ_IL_DLL_SRC=event-il.il module-cctor.il
-PREREQ_CS_DLL_SRC=
+PREREQ_IL_DLL_SRC=
+PREREQ_CS_DLL_SRC=TestingReferenceAssembly.cs TestingReferenceReferenceAssembly.cs
 
-PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe)
-PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe)
+PREREQSI_IL=$(PREREQ_IL_SRC:.il=.exe) \
+	$(PREREQ_IL_DLL_SRC:.il=.dll)
+PREREQSI_CS=$(PREREQ_CS_SRC:.cs=.exe) \
+	$(PREREQ_CS_DLL_SRC:.cs=.dll)
 TESTSI_CS=$(TEST_CS_SRC:.cs=.exe)
 TESTSI_IL=$(TEST_IL_SRC:.il=.exe)
 TESTBS=$(BENCHSRC:.cs=.exe)
 STRESS_TESTS=$(STRESS_TESTS_SRC:.cs=.exe)
 
-PREREQSI_IL_AOT=$(PREREQ_IL_SRC:.il=.exe$(PLATFORM_AOT_SUFFIX))
-PREREQSI_CS_AOT=$(PREREQ_CS_SRC:.cs=.exe$(PLATFORM_AOT_SUFFIX))
+PREREQSI_IL_AOT=$(PREREQ_IL_SRC:.il=.exe$(PLATFORM_AOT_SUFFIX)) \
+		$(PREREQ_IL_DLL_SRC:.il=.dll$(PLATFORM_AOT_SUFFIX))
+PREREQSI_CS_AOT=$(PREREQ_CS_SRC:.cs=.exe$(PLATFORM_AOT_SUFFIX)) \
+		$(PREREQ_CS_DLL_SRC:.cs=.dll$(PLATFORM_AOT_SUFFIX))
 
 EXTRA_DIST=test-driver test-runner.cs $(TEST_CS_SRC_DIST) $(TEST_IL_SRC) \
 	$(BENCHSRC) $(STRESS_TESTS_SRC) stress-runner.pl $(PREREQ_IL_SRC) $(PREREQ_CS_SRC)
@@ -831,6 +836,12 @@ endif
 
 %.exe: %.cs $(TEST_DRIVER_DEPEND)
 	$(MCS) -r:System.dll -r:System.Xml.dll -r:System.Core.dll -r:TestDriver.dll $(TEST_DRIVER_HARD_KILL_FEATURE) -out:$@ $<
+
+%.dll: %.cs
+	$(MCS) -r:System.dll -target:library -out:$@ $<
+
+TestingReferenceReferenceAssembly.dll: TestingReferenceReferenceAssembly.cs TestingReferenceAssembly.dll
+	$(MCS) -r:TestingReferenceAssembly.dll -target:library -out:$@ $<
 
 %.exe$(PLATFORM_AOT_SUFFIX): %.exe 
 	$(RUNTIME) $(AOT_BUILD_FLAGS) $<

--- a/mono/tests/TestingReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceAssembly.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: ReferenceAssemblyAttribute]
+
+public class X {
+	public int Y;
+}

--- a/mono/tests/TestingReferenceReferenceAssembly.cs
+++ b/mono/tests/TestingReferenceReferenceAssembly.cs
@@ -1,0 +1,7 @@
+// An assembly that refereces the TestingReferenceAssembly
+
+class Z : X {
+	public Z () {
+		Y = 1;
+	}
+}

--- a/mono/tests/custom-attr-errors.cs
+++ b/mono/tests/custom-attr-errors.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Reflection;
 
+// this for test_0_missing_attr_on_assembly
+[assembly: MissingAttribute]
+
 public sealed class MyAttribute : Attribute
 {
 	public Type Type { get; set; }
@@ -44,6 +47,15 @@ public sealed class ExceptionOnCtor : Attribute
 public class Bar {}
 
 class Tests {
+
+	public static int test_0_missing_attr_on_assembly () {
+		try {
+			Assembly.GetExecutingAssembly().GetCustomAttributes (false);
+			return 1;
+		} catch (TypeLoadException exn) {
+			return 0;
+		}
+	}
 
 	[My3 (new object[] { DisappearingEnum.V0 })]
 	public static int test_0_missing_enum_arg_alt3 () {

--- a/mono/tests/reference-loader.cs
+++ b/mono/tests/reference-loader.cs
@@ -1,0 +1,110 @@
+//
+// reference-loader.cs:
+//
+//  Test for reference assembly loading
+
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Tests {
+	public static int Main (string[] args)
+	{
+		return TestDriver.RunTests (typeof (Tests), args);
+	}
+
+	public static int test_0_loadFrom_reference ()
+	{
+		// Check that loading a reference assembly by filename for execution is an error
+		try {
+			var a = Assembly.LoadFrom ("./TestingReferenceAssembly.dll");
+		} catch (BadImageFormatException exn) {
+			// .NET Framework 4.6.2 throws BIFE here.
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_load_reference ()
+	{
+		// Check that loading a reference assembly for execution is an error
+		try {
+			var an = new AssemblyName ("TestingReferenceAssembly");
+			var a = Assembly.Load (an);
+		} catch (FileNotFoundException exn) {
+			return 0;
+		} catch (BadImageFormatException exn) {
+			// .NET Framework 4.6.2 throws BIFE here.
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference ()
+	{
+		// Check that reflection-only loading a reference assembly is okay
+		var an = new AssemblyName ("TestingReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+	public static int test_0_load_reference_asm_via_reference ()
+	{
+		// Check that loading an assembly that references a reference assembly doesn't succeed.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		try {
+			var a = Assembly.Load (an);
+			var t = a.GetType ("Z");
+		} catch (FileNotFoundException){
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_asm_via_reference ()
+	{
+		// Check that reflection-only loading an assembly that
+		// references a reference assembly is okay.
+		var an = new AssemblyName ("TestingReferenceReferenceAssembly");
+		var a = Assembly.ReflectionOnlyLoad (an.FullName);
+		var t = a.GetType ("Z");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+
+	public static int test_0_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte array for execution is an error
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		try {
+			var a = Assembly.Load (bs);
+		} catch (BadImageFormatException) {
+			return 0;
+		} catch (FileNotFoundException exn) {
+			Console.Error.WriteLine ("incorrect exn was {0}", exn);
+			return 2;
+		}
+		return 1;
+	}
+
+	public static int test_0_reflection_load_reference_bytes ()
+	{
+		// Check that loading a reference assembly from a byte
+		// array for reflection only is okay.
+		byte[] bs = File.ReadAllBytes ("./TestingReferenceAssembly.dll");
+		var a = Assembly.ReflectionOnlyLoad (bs);
+		var t = a.GetType ("X");
+		var f = t.GetField ("Y");
+		if (f.FieldType.Equals (typeof (Int32)))
+			return 0;
+		return 1;
+	}
+
+}

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -289,7 +289,7 @@ mono_error_set_assembly_load_simple (MonoError *oerror, const char *assembly_nam
 	if (refection_only)
 		mono_error_set_assembly_load (oerror, assembly_name, "Cannot resolve dependency to assembly because it has not been preloaded. When using the ReflectionOnly APIs, dependent assemblies must be pre-loaded or loaded on demand through the ReflectionOnlyAssemblyResolve event.");
 	else
-		mono_error_set_assembly_load (oerror, assembly_name, "Could not load file or assembly or one of its dependencies.");
+		mono_error_set_assembly_load (oerror, assembly_name, "Could not load file or assembly '%s' or one of its dependencies.", assembly_name);
 }
 
 void


### PR DESCRIPTION
An assembly with a `System.Runtime.CompilerServices.ReferenceAssemblyAttribute`
may be loaded in a reflection-only context, but not for execution.

When loading assembly refs, or when loading assemblies by name (as
opposed to file path), a reference assembly will be skipped over and
other assemblies from the GAC and the load path will be tried.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42584

(This is a second try at a PR for this issue; the last one broke gacutil which has since been rewritten to avoid that problem)

This is #3786 backported to `mono-4.8.0-branch`
