### PR TITLE
Remove G_BREAKPOINT in mini-exceptions.c

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2724,7 +2724,7 @@ mono_thread_state_init_from_sigctx (MonoThreadUnwindState *ctx, void *sigctx)
 	MonoThreadInfo *thread = mono_thread_info_current_unchecked ();
 	if (!thread) {
 		ctx->valid = FALSE;
-		G_BREAKPOINT ();
+		g_error ("Invoked mono_thread_state_init_from_sigctx from non-Mono thread");
 		return FALSE;
 	}
 


### PR DESCRIPTION
This could be hit during user execution. This will not be caught by our normal crash reporter, so we should use g_error here instead.