### PR TITLE
Minor certificate validation fixes.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/ChainValidationHelper.cs
+++ b/mcs/class/System/Mono.Net.Security/ChainValidationHelper.cs
@@ -335,14 +335,15 @@ namespace Mono.Net.Security
 			result = provider.ValidateCertificate (this, host, server, certs, wantsChain, ref chain, ref xerrors, ref status11);
 			errors = (SslPolicyErrors)xerrors;
 
+			if (status11 == 0 && errors != 0) {
+				// TRUST_E_FAIL
+				status11 = unchecked ((int)0x800B010B);
+			}
+
 			if (policy != null && (!(policy is DefaultCertificatePolicy) || certValidationCallback == null)) {
 				ServicePoint sp = null;
 				if (request != null)
 					sp = request.ServicePointNoLock;
-				if (status11 == 0 && errors != 0) {
-					// TRUST_E_FAIL
-					status11 = unchecked ((int)0x800B010B);
-				}
 
 				// pre 2.0 callback
 				result = policy.CheckValidationResult (sp, leaf, request, status11);

--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/OSX509Certificates.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/OSX509Certificates.cs
@@ -146,7 +146,7 @@ namespace System.Security.Cryptography.X509Certificates {
 
 				certArray = FromIntPtrs (secCerts);
 
-				if (!string.IsNullOrEmpty (hostName))
+				if (hostName != null)
 					host = CFStringCreateWithCharacters (IntPtr.Zero, hostName, (IntPtr) hostName.Length);
 				sslsecpolicy = SecPolicyCreateSSL (true, host);
 


### PR DESCRIPTION
`SecPolicyCreateSSL()` distinguishes between an empty string (validation will fail if the certificate contains host name constraints) and a null pointer (no host name checking will be performed) for the hostname.

We incorrectly used `string.IsNullOrEmpty (host)` in the system certificate validator.

In `ChainValidationHelper`, make sure to always set `status11` when validation fails.