### PR TITLE
[DONT-MERGE][MANUAL]: Update boringssl to latest chromium-stable from Google.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,4 +42,4 @@
 [submodule "external/boringssl"]
 	path = external/boringssl
 	url = git://github.com/mono/boringssl.git
-	branch = mono
+	branch = work-upstream-merge

--- a/mcs/class/System/Mono.Net.Security/ChainValidationHelper.cs
+++ b/mcs/class/System/Mono.Net.Security/ChainValidationHelper.cs
@@ -335,14 +335,15 @@ namespace Mono.Net.Security
 			result = provider.ValidateCertificate (this, host, server, certs, wantsChain, ref chain, ref xerrors, ref status11);
 			errors = (SslPolicyErrors)xerrors;
 
+			if (status11 == 0 && errors != 0) {
+				// TRUST_E_FAIL
+				status11 = unchecked ((int)0x800B010B);
+			}
+
 			if (policy != null && (!(policy is DefaultCertificatePolicy) || certValidationCallback == null)) {
 				ServicePoint sp = null;
 				if (request != null)
 					sp = request.ServicePointNoLock;
-				if (status11 == 0 && errors != 0) {
-					// TRUST_E_FAIL
-					status11 = unchecked ((int)0x800B010B);
-				}
 
 				// pre 2.0 callback
 				result = policy.CheckValidationResult (sp, leaf, request, status11);

--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/OSX509Certificates.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/OSX509Certificates.cs
@@ -146,7 +146,7 @@ namespace System.Security.Cryptography.X509Certificates {
 
 				certArray = FromIntPtrs (secCerts);
 
-				if (!string.IsNullOrEmpty (hostName))
+				if (hostName != null)
 					host = CFStringCreateWithCharacters (IntPtr.Zero, hostName, (IntPtr) hostName.Length);
 				sslsecpolicy = SecPolicyCreateSSL (true, host);
 


### PR DESCRIPTION
Needs manual merge, which updates the 'boringssl' module.

Bump boringssl to the latest upstream sources from their 'chromium-stable' branch:
https://boringssl.googlesource.com/boringssl/+/chromium-stable
