### PR TITLE
Fix crash in SafePipeHandle.ReleaseHandle() on Windows

### DIFF
--- a/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafePipeHandle.cs
+++ b/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafePipeHandle.cs
@@ -46,12 +46,8 @@ namespace Microsoft.Win32.SafeHandles
 
 		protected override bool ReleaseHandle ()
 		{
-			try {
-				Marshal.FreeHGlobal (handle);
-				return true;
-			} catch (ArgumentException) {
-				return false;
-			}
+			MonoIOError error;
+			return MonoIO.Close (handle, out error);
 		}
 	}
 }


### PR DESCRIPTION
The ReleaseHandle() methods tries to deallocate the handle as if it was a
pointer to heap memory. But on Windows it's a HANDLE. The call to
Marshal.FreeHGlobal() causes a crash on Windows. It doesn't crash on other
platforms probably due to the emulated handles which are indeed heap allocated
memory objects. But the underlying file descriptor is never closed so there
should be a file descriptor leak on other platforms.

This patch fixes the issue by calling MonoIO.Close() on the handle rather than
Marshal.FreeHGlobal()