### PR TITLE
Fix certificate validation for wine.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/SystemCertificateValidator.cs
+++ b/mcs/class/System/Mono.Net.Security/SystemCertificateValidator.cs
@@ -45,7 +45,7 @@ namespace Mono.Net.Security
 #elif MONODROID
 			is_macosx = false;
 #else
-			is_macosx = System.IO.File.Exists (OSX509Certificates.SecurityLibrary);
+			is_macosx = Environment.OSVersion.Platform != PlatformID.Win32NT && System.IO.File.Exists (OSX509Certificates.SecurityLibrary);
 #endif
 
 #if !MOBILE

--- a/mcs/class/corlib/System.IO/Directory.cs
+++ b/mcs/class/corlib/System.IO/Directory.cs
@@ -50,6 +50,14 @@ namespace System.IO
 {
 	public static partial class Directory
 	{
+		public static string GetDirectoryRoot (string path)
+		{
+			Path.Validate (path);
+			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
+
+			// FIXME nice hack but that does not work under windows
+			return new String(Path.DirectorySeparatorChar, 1);
+		}
 
 		public static DirectoryInfo CreateDirectory (string path)
 		{

--- a/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
@@ -1527,7 +1527,23 @@ public class DirectoryTest
 		info = Directory.GetParent (Path.GetPathRoot (Path.GetTempPath ()));
 		Assert.IsNull (info);
 	}
-	
+
+	[Test]
+	public void GetDirectoryRoot ()
+	{
+		if (RunningOnUnix)
+		{
+			string path = "/usr/lib";
+			Assert.AreEqual ("/", Directory.GetDirectoryRoot (path));
+		}
+		else
+		{
+			Assert.Ignore ("TODO: no proper implementation on Windows.");
+			string path = "C:\\Windows";
+			Assert.AreEqual ("C:\\", Directory.GetDirectoryRoot (path));
+		}
+	}
+
 	[Test]
 	public void GetFiles ()
 	{


### PR DESCRIPTION
Or at least, if the file detection maters:

```
        is_macosx = Environment.OSVersion.Platform != PlatformID.Win32NT && System.IO.File.Exists(OSX509Certificates.SecurityLibrary);
```
