### PR TITLE
[bcl] Move a few types from the Facades into the framework for netstandard20 compatibility

### DIFF
--- a/mcs/class/Facades/System.Diagnostics.Tracing/System.Diagnostics.Tracing.dll.sources
+++ b/mcs/class/Facades/System.Diagnostics.Tracing/System.Diagnostics.Tracing.dll.sources
@@ -1,3 +1,2 @@
 TypeForwarders.cs
 AssemblyInfo.cs
-EventCounter.cs

--- a/mcs/class/Facades/System.Diagnostics.Tracing/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Diagnostics.Tracing/TypeForwarders.cs
@@ -44,3 +44,7 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventTask))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventWrittenEventArgs))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.NonEventAttribute))]
+
+#if NETSTANDARD
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Diagnostics.Tracing.EventCounter))]
+#endif

--- a/mcs/class/Facades/System.Net.Sockets/System.Net.Sockets.dll.sources
+++ b/mcs/class/Facades/System.Net.Sockets/System.Net.Sockets.dll.sources
@@ -1,5 +1,2 @@
 TypeForwarders.cs
 AssemblyInfo.cs
-SocketReceiveFromResult.cs
-SocketReceiveMessageFromResult.cs
-SocketTaskExtensions.cs

--- a/mcs/class/Facades/System.Net.Sockets/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Net.Sockets/TypeForwarders.cs
@@ -46,4 +46,8 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Net.Sockets.UdpClient))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Net.Sockets.UdpReceiveResult))]
 
-
+#if NETSTANDARD
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Net.Sockets.SocketReceiveFromResult))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Net.Sockets.SocketReceiveMessageFromResult))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Net.Sockets.SocketTaskExtensions))]
+#endif

--- a/mcs/class/System.Core/common_System.Core.dll.sources
+++ b/mcs/class/System.Core/common_System.Core.dll.sources
@@ -232,4 +232,3 @@ ReferenceSources/Strings.cs
 System.Security.Cryptography/ECCurve.cs
 System.Security.Cryptography/ECPoint.cs
 System.Security.Cryptography/ECParameters.cs
-System.Security.Cryptography/IncrementalHash.cs

--- a/mcs/class/System/System.Net.Sockets/SocketReceiveFromResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketReceiveFromResult.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#if NETSTANDARD
+
 namespace System.Net.Sockets
 {
 	public struct SocketReceiveFromResult
@@ -34,3 +36,5 @@ namespace System.Net.Sockets
 		public EndPoint RemoteEndPoint;
 	}
 }
+
+#endif

--- a/mcs/class/System/System.Net.Sockets/SocketReceiveMessageFromResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketReceiveMessageFromResult.cs
@@ -26,6 +26,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#if NETSTANDARD
+
 namespace System.Net.Sockets
 {
 	public struct SocketReceiveMessageFromResult
@@ -36,3 +38,5 @@ namespace System.Net.Sockets
 		public IPPacketInformation PacketInformation;
 	}
 }
+
+#endif

--- a/mcs/class/System/System.Net.Sockets/SocketTaskExtensions.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketTaskExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NETSTANDARD
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -248,3 +250,5 @@ namespace System.Net.Sockets
         }
     }
 }
+
+#endif

--- a/mcs/class/System/System.dll.sources
+++ b/mcs/class/System/System.dll.sources
@@ -380,6 +380,9 @@ System.Net.Sockets/Socket.cs
 System.Net.Sockets/SocketAsyncEventArgs.cs
 System.Net.Sockets/SocketAsyncResult.cs
 System.Net.Sockets/SocketOperation.cs
+System.Net.Sockets/SocketReceiveFromResult.cs
+System.Net.Sockets/SocketReceiveMessageFromResult.cs
+System.Net.Sockets/SocketTaskExtensions.cs
 System.Net/WebAsyncResult.cs
 System.Net/WebConnection.cs
 System.Net/WebConnectionData.cs

--- a/mcs/class/System/mobile_System.dll.sources
+++ b/mcs/class/System/mobile_System.dll.sources
@@ -123,6 +123,9 @@ System.Net.Sockets/Socket.cs
 System.Net.Sockets/SocketAsyncEventArgs.cs
 System.Net.Sockets/SocketAsyncResult.cs
 System.Net.Sockets/SocketOperation.cs
+System.Net.Sockets/SocketReceiveFromResult.cs
+System.Net.Sockets/SocketReceiveMessageFromResult.cs
+System.Net.Sockets/SocketTaskExtensions.cs
 System.Net/AuthenticationManager.cs
 System.Net/BasicClient.cs
 System.Net/BindIPEndPoint.cs

--- a/mcs/class/corlib/System.Diagnostics.Tracing/EventCounter.cs
+++ b/mcs/class/corlib/System.Diagnostics.Tracing/EventCounter.cs
@@ -1,5 +1,5 @@
 //
-// IncrementalHash.cs
+// EventCounter.cs
 //
 // Authors:
 //	Marek Safar  <marek.safar@gmail.com>
@@ -28,19 +28,18 @@
 
 #if NETSTANDARD
 
-namespace System.Security.Cryptography
+namespace System.Diagnostics.Tracing
 {
-    public sealed class IncrementalHash : IDisposable
-    {
-        private IncrementalHash () { }
-        public HashAlgorithmName AlgorithmName { get { throw new NotImplementedException (); } }
-        public void AppendData (byte[] data) { }
-        public void AppendData (byte[] data, int offset, int count) { }
-        public static IncrementalHash CreateHash (HashAlgorithmName hashAlgorithm) { throw new NotImplementedException (); }
-        public static IncrementalHash CreateHMAC (HashAlgorithmName hashAlgorithm, byte[] key) { throw new NotImplementedException (); }
-        public void Dispose () { }
-        public byte[] GetHashAndReset () { throw new NotImplementedException (); }
-    }
+	public class EventCounter
+	{
+		public EventCounter (string name, EventSource eventSource)
+		{
+		}
+
+		public void WriteMetric (float value)
+		{
+		}
+	}
 }
 
 #endif

--- a/mcs/class/corlib/System.Security.Cryptography/IncrementalHash.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/IncrementalHash.cs
@@ -1,5 +1,5 @@
 //
-// EventCounter.cs
+// IncrementalHash.cs
 //
 // Authors:
 //	Marek Safar  <marek.safar@gmail.com>
@@ -26,16 +26,21 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace System.Diagnostics.Tracing
-{
-	public class EventCounter
-	{
-		public EventCounter (string name, EventSource eventSource)
-		{
-		}
+#if NETSTANDARD
 
-		public void WriteMetric (float value)
-		{
-		}
-	}
+namespace System.Security.Cryptography
+{
+    public sealed class IncrementalHash : IDisposable
+    {
+        public IncrementalHash () { }
+        public HashAlgorithmName AlgorithmName { get { throw new NotImplementedException (); } }
+        public void AppendData (byte[] data) { }
+        public void AppendData (byte[] data, int offset, int count) { }
+        public static IncrementalHash CreateHash (HashAlgorithmName hashAlgorithm) { throw new NotImplementedException (); }
+        public static IncrementalHash CreateHMAC (HashAlgorithmName hashAlgorithm, byte[] key) { throw new NotImplementedException (); }
+        public void Dispose () { }
+        public byte[] GetHashAndReset () { throw new NotImplementedException (); }
+    }
 }
+
+#endif

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -164,6 +164,7 @@ System.Diagnostics/StackFrame.cs
 System.Diagnostics/StackTrace.cs
 System.Diagnostics.Tracing/EventAttribute.cs
 System.Diagnostics.Tracing/EventCommand.cs
+System.Diagnostics.Tracing/EventCounter.cs
 System.Diagnostics.Tracing/EventSource.cs
 System.Diagnostics.Tracing/EventSourceAttribute.cs
 System.Diagnostics.Tracing/EventSourceSettings.cs
@@ -704,6 +705,7 @@ System.Security.Cryptography/CspKeyContainerInfo.cs
 System.Security.Cryptography/DESCryptoServiceProvider.cs
 System.Security.Cryptography/DSACryptoServiceProvider.cs
 System.Security.Cryptography/ICspAsymmetricAlgorithm.cs
+System.Security.Cryptography/IncrementalHash.cs
 System.Security.Cryptography/KeyNumber.cs
 System.Security.Cryptography/MD5CryptoServiceProvider.cs
 System.Security.Cryptography/RC2CryptoServiceProvider.cs


### PR DESCRIPTION
See https://github.com/dotnet/standard/pull/76.

Also moved IncrementalHash from System.Core.dll to mscorlib.dll as per discussion with Wes.