### PR TITLE
[System] Remove any CFNetwork usage from the watchOS profile. Fixes #45847.

### DIFF
--- a/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
+++ b/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
@@ -1,7 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+#if !MONOTOUCH_WATCH
 using Mono.Net;
+#endif
 
 namespace System.Net
 {

--- a/mcs/class/System/monotouch_watch_System.dll.exclude.sources
+++ b/mcs/class/System/monotouch_watch_System.dll.exclude.sources
@@ -107,6 +107,7 @@ Mono.Net.Security/MonoTlsProviderWrapper.cs
 Mono.Net.Security/MonoTlsStream.cs
 Mono.Net.Security/NoReflectionHelper.cs
 Mono.Net.Security/SystemCertificateValidator.cs
+System.Net/MacProxy.cs
 System.Net.Mail/SmtpClient.cs
 System.Net.Security/SslStream.cs
 System.Net.Sockets/TcpClient.cs

--- a/mcs/class/referencesource/System/net/System/Net/webproxy.cs
+++ b/mcs/class/referencesource/System/net/System/Net/webproxy.cs
@@ -504,7 +504,9 @@ namespace System.Net {
 #if MONO
         public static IWebProxy CreateDefaultProxy ()
         {
-#if MONOTOUCH
+#if MONOTOUCH_WATCH
+            throw new PlatformNotSupportedException ();
+#elif MONOTOUCH
             return Mono.Net.CFNetwork.GetDefaultProxy ();
 #elif MONODROID
             // Return the system web proxy.  This only works for ICS+.


### PR DESCRIPTION
The MacProxy class uses CFNetwork, but since CFNetwork is not a public
framework on watchOS, we can't use it.

So remove MacProxy completely (it only contains internal classes), and throw
PlatformNotSupportedException in any API that used it (the managed networking
stack is not supported on watchOS anyway, so this should be safe).

https://bugzilla.xamarin.com/show_bug.cgi?id=45847