### PR TITLE
Fix compilation errors in mono/utils/os-event-win32.c with Mingw/GCC

### DIFF
--- a/mono/utils/os-event-win32.c
+++ b/mono/utils/os-event-win32.c
@@ -15,7 +15,7 @@
 #include "atomic.h"
 
 void
-mono_os_event_init (MonoOSEvent *event, gboolean manual, gboolean initial, MonoOSEventFreeCb free_cb)
+mono_os_event_init (MonoOSEvent *event, gboolean manual, gboolean initial)
 {
 	g_assert (event);
 

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -122,6 +122,7 @@
     <ClCompile Include="..\mono\utils\mono-uri.c" />
     <ClCompile Include="..\mono\utils\mono-value-hash.c" />
     <ClCompile Include="..\mono\utils\monobitset.c" />
+    <ClCompile Include="..\mono\utils\os-event-win32.c" />
     <ClCompile Include="..\mono\utils\strenc.c" />
     <ClCompile Include="..\mono\utils\atomic.c" />
     <ClCompile Include="..\mono\utils\mono-hwcap.c" />
@@ -196,6 +197,7 @@
     <ClInclude Include="..\mono\utils\mono-uri.h" />
     <ClInclude Include="..\mono\utils\mono-value-hash.h" />
     <ClInclude Include="..\mono\utils\monobitset.h" />
+    <ClInclude Include="..\mono\utils\os-event.h" />
     <ClInclude Include="..\mono\utils\strenc.h" />
     <ClInclude Include="..\mono\utils\valgrind.h" />
     <ClInclude Include="..\mono\utils\atomic.h" />

--- a/msvc/libmonoutils.vcxproj.filters
+++ b/msvc/libmonoutils.vcxproj.filters
@@ -196,6 +196,9 @@
     <ClCompile Include="..\mono\utils\mono-mmap-windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mono\utils\os-event-win32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\mono\utils\atomic.h">
@@ -415,6 +418,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\mono\utils\mono-proclib-windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\utils\os-event.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This was introduced in 92be5357d12ecf0cc4c51fbcb76fc0514b375d1c. The patch also adds the os-event-win32.c file to the libmonoutils Visual Studio project.