### PR TITLE
Calling Join instead of Abort on loop thread

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
@@ -426,7 +426,7 @@ namespace System.ServiceModel.Dispatcher
 					owner.Listener.Abort ();
 				}
 				if (loop_thread != null && loop_thread.IsAlive)
-					loop_thread.Abort ();
+					loop_thread.Join ();
 				loop_thread = null;
 			}
 


### PR DESCRIPTION
This PR makes sure `Join` is used instead of `Abort` when closing down the loop thread in the `ChannelDispatcher`.
The `loop_thread` should end nicely and there should not be any reasons to do `Abort` in this scenario. Changing it to `Join` solves the issue with threads that hold the GC lock are getting suspended, which resulted in various tests that hung in the ServiceModel test suite on Windows.

There is probably an issue with `Thread.Abort()` on Windows since this lock-up could arise and we are tracking that issue in this [trello card] (https://trello.com/c/TnLq3jBP/115-improve-thread-abort-implementation-on-windows)