### PR TITLE
[mono-config] fix warning

### DIFF
--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -314,7 +314,7 @@ dllmap_start (gpointer user_data,
 			else if (strcmp (attribute_names [i], "target") == 0){
 				char *p = strstr (attribute_values [i], "$mono_libdir");
 				if (p != NULL){
-					const char *libdir = mono_native_getrootdir ();
+					char *libdir = mono_native_getrootdir ();
 					size_t libdir_len = strlen (libdir);
 					char *result;
 					


### PR DESCRIPTION
fixes

```
mono-config.c:324:14: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
                                        g_free (libdir);
                                                ^~~~~~
../../eglib/src/glib.h:125:20: note: passing argument to parameter 'ptr' here
void g_free (void *ptr);
                   ^
1 warning generated.
```

/cc @akoeplinger 

@monojenkins merge