### PR TITLE
Backport to 4.8.0 of mkbundle SDK + native library support

### DIFF
--- a/eglib/src/gfile-win32.c
+++ b/eglib/src/gfile-win32.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/types.h>
+#include <direct.h>
 
 #ifdef G_OS_WIN32
 #include <io.h>
@@ -68,6 +69,26 @@ int mkstemp (char *tmp_template)
 	return fd;
 }
 
+gchar *
+g_mkdtemp (char *tmp_template)
+{
+	gunichar2* utf16_template;
+
+	utf16_template  = u8to16 (tmp_template);
+
+	utf16_template = _wmktemp(utf16_template);
+	if (utf16_template && *utf16_template) {
+		if (_wmkdir (utf16_template) == 0){
+			char *ret = u16to8 (utf16_template);
+			g_free (utf16_template);
+			return ret;
+		}
+	}
+
+	g_free (utf16_template);
+	return NULL;
+}
+	     
 #ifdef _MSC_VER
 #pragma warning(disable:4701)
 #endif

--- a/eglib/src/glib.h
+++ b/eglib/src/glib.h
@@ -887,6 +887,12 @@ gboolean   g_file_test (const gchar *filename, GFileTest test);
 #define g_ascii_strtod strtod
 #define g_ascii_isalnum isalnum
 
+#ifdef WIN32
+gchar *g_mkdtemp (gchar *tmpl);
+#else
+#define g_mkdtemp mkdtemp
+#endif
+
 /*
  * Pattern matching
  */

--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -159,10 +159,16 @@ flag to bundle all available encodings.
 Or you can use a comma delimited list of the workds CJK, MidWest,
 Other, Rare and West to specificy which encoding assemblies to distribute.
 .TP
-.TP
 .I "-L path"
 Adds the `path' do the search list for assemblies.  The rules are the
 same as for the compiler -lib: or -L flags.
+.TP
+.I "--library [LIB,]PATH"
+Embeds the dynamic library file pointed to by `PATH' and optionally
+give it the name `LIB' into the bundled executable.   This is used to
+ship native library dependencies that are unpacked at startup and
+loaded from the runtime.
+.TP
 .I "--lists-targets"
 Lists all of the available local cross compilation targets available
 as precompiled binaries on the Mono distribution server.

--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -24,7 +24,8 @@ dependencies referenced, use the "--deps" command line option.
 There are two modes of operation, one uses an existing Mono binary or
 a server-hosted list of binaries and is enabled when you use either
 the 
-.B --cross
+.B --cross,
+.B --sdk
 or the
 .B --runtime
 command line options.   
@@ -119,10 +120,19 @@ are using (1.0 or 2.0)
 When passed, DIR will be set for the MONO_CFG_DIR environment variable
 .TP
 .I "--cross target"
-Creates a bundle for the specified target platform.   The target
-must be a directory in ~/.mono/targets/ that contains a "mono"
-binary.   You can fetch various targets using the --fetch-target
-command line option.
+Use this to request mkbundle generate a cross-compiled binary.  It
+Creates a bundle for the specified target platform.  The target must
+be a directory in ~/.mono/targets/ that contains an SDK installation
+as produced by the mono-package-runtime tool.  You can get a list of
+the precompiled versions of the runtime using --list-targets and you
+can fetch a specific target using the --fetch-target command line
+option.
+.Sp
+This flag is mutually exclusive with 
+.I --sdk
+which is used to specify an absolute path to resolve the Mono runtime
+from and the --runtime option which is used to manually construct the
+cross-platform package.
 .TP
 .I "--deps"
 This option will bundle all of the referenced assemblies for the
@@ -219,6 +229,10 @@ When this flag is specified,
 .I mkbundle
 will resolve the runtime, the framework libraries, unmanaged resources
 and configuration files from the files located in this directory.
+.Sp
+This flag is mutually exlusive with 
+.I --cross
+.
 .TP
 .I "--target-server SERVER"
 By default the mkbundle tool will download from a Mono server the

--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -203,7 +203,22 @@ executed.
 Additionally, users of your binary can still configure their own
 options by setting the 
 .I MONO_ENV_OPTIONS
-environment variable.   
+environment variable.
+.TP
+.I "--sdk SDK_PATH"
+Use this flag to specify a path from which mkbundle will resolve the
+Mono SDK from.   The SDK path should be the prefix path that you used
+to configure a Mono installation.   And would typically contain files
+lik
+.I SDK_PATH/bin/mono
+,
+.I SDK_PATH/lib/mono/4.5
+and so on.
+.Sp
+When this flag is specified,
+.I mkbundle
+will resolve the runtime, the framework libraries, unmanaged resources
+and configuration files from the files located in this directory.
 .TP
 .I "--target-server SERVER"
 By default the mkbundle tool will download from a Mono server the

--- a/mcs/tools/mkbundle/Makefile
+++ b/mcs/tools/mkbundle/Makefile
@@ -11,7 +11,7 @@ RESOURCE_FILES = $(OTHER_RES)
 LOCAL_MCS_FLAGS= $(OTHER_RES:%=-resource:%)
 
 LOCAL_MCS_FLAGS += -d:STATIC,NO_SYMBOL_WRITER,NO_AUTHENTICODE
-LIB_REFS = System.Xml System System.Core
+LIB_REFS = System.Xml System System.Core System.IO.Compression.FileSystem
 
 EXTRA_DISTFILES = $(RESOURCE_FILES)
 

--- a/mcs/tools/mkbundle/Makefile
+++ b/mcs/tools/mkbundle/Makefile
@@ -18,3 +18,16 @@ EXTRA_DISTFILES = $(RESOURCE_FILES)
 include ../../build/executable.make
 
 mkbundle.exe: $(RESOURCE_FILES)
+
+test-simple: simple.exe
+	mono --debug $(the_lib) --simple simple.exe -o foo && ./foo
+	mono --debug $(the_lib) --cross default simple.exe -o foo && ./foo
+	mono --debug $(the_lib) --sdk `dirname \`which mono\``/.. simple.exe -o foo && ./foo
+	-rm DEMO.zip
+	mono-package-runtime `dirname \`which mono\``/.. DEMO
+	mkdir -p ~/.mono/targets/DEMO
+	unzip -d ~/.mono/targets/DEMO DEMO.zip
+	mono --debug $(the_lib) --cross DEMO simple.exe -o foo && ./foo
+
+simple.exe: Makefile
+	echo 'class X { static void Main () { System.Console.WriteLine ("OK");}}' > simple.cs && mcs simple.cs

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -386,11 +386,11 @@ class MakeBundle {
 					}
 				}
 				
-				Console.WriteLine ("Using runtime {0} for {1}", runtime, output);
 			}
 			GeneratePackage (files);
 		}
-		
+		Console.WriteLine ("Generated {0}", output);
+
 		return 0;
 	}
 
@@ -608,6 +608,7 @@ class MakeBundle {
 		}
 		
 		var maker = new PackageMaker (output);
+		Console.WriteLine ("Using runtime: " + runtime);
 		maker.AddFile (runtime);
 		
 		foreach (var url in files){
@@ -615,9 +616,13 @@ class MakeBundle {
 			string aname = MakeBundle.GetAssemblyName (fname);
 
 			maker.Add ("assembly:" + aname, fname);
-			if (File.Exists (fname + ".config"))
+			Console.WriteLine ("     Assembly: " + fname);
+			if (File.Exists (fname + ".config")){
 				maker.Add ("config:" + aname, fname + ".config");
+				Console.WriteLine ("       Config: " + runtime);
+			}
 		}
+		
 		if (!MaybeAddFile (maker, "systemconfig:", config_file) || !MaybeAddFile (maker, "machineconfig:", machine_config_file))
 			return false;
 
@@ -631,6 +636,7 @@ class MakeBundle {
 		}
 		if (libraries.Count > 0){
 			foreach (var alias_and_path in libraries){
+				Console.WriteLine ("     Library:  " + alias_and_path.Value);
 				maker.Add ("library:" + alias_and_path.Key, alias_and_path.Value);
 			}
 		}

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -23,7 +23,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using IKVM.Reflection;
 using System.Linq;
-using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -31,6 +30,7 @@ class MakeBundle {
 	static string output = "a.out";
 	static string object_out = null;
 	static List<string> link_paths = new List<string> ();
+	static Dictionary<string,string> libraries = new Dictionary<string,string> ();
 	static bool autodeps = false;
 	static bool keeptemp = false;
 	static bool compile_only = false;
@@ -124,6 +124,33 @@ class MakeBundle {
 				custom_mode = false;
 				autodeps = true;
 				cross_target = args [++i];
+				break;
+
+			case "--library":
+				if (i+1 == top){
+					Help (); 
+					return 1;
+				}
+				if (custom_mode){
+					Console.Error.WriteLine ("--library can only be used with --simple/--runtime/--cross mode");
+					Help ();
+					return 1;
+				}
+				var lspec = args [++i];
+				var p = lspec.IndexOf (",");
+				string alias, path;
+				if (p == -1){
+					alias = Path.GetFileName (lspec);
+					path = lspec;
+				} else {
+					alias = lspec.Substring (0, p);
+					path = lspec.Substring (p+1);
+				}
+				if (!File.Exists (path)){
+					Console.Error.WriteLine ($"The specified library file {path} does not exist");
+					return 1;
+				}
+				libraries [alias] = path;
 				break;
 
 			case "--fetch-target":
@@ -289,7 +316,7 @@ class MakeBundle {
 					return 1;
 				}
 				var env = args [++i];
-				var p = env.IndexOf ('=');
+				p = env.IndexOf ('=');
 				if (p == -1)
 					environment.Add (env, "");
 				else
@@ -602,6 +629,11 @@ class MakeBundle {
 			foreach (var key in environment.Keys)
 				maker.AddStringPair ("env:" + key, key, environment [key]);
 		}
+		if (libraries.Count > 0){
+			foreach (var alias_and_path in libraries){
+				maker.Add ("library:" + alias_and_path.Key, alias_and_path.Value);
+			}
+		}
 		maker.Dump ();
 		maker.Close ();
 		return true;
@@ -854,7 +886,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 				string monoPath = GetEnv("MONOPREFIX", @"C:\Program Files (x86)\Mono");
 
 				string[] includes = new string[] {winsdkPath + @"\Include\um", winsdkPath + @"\Include\shared", vsPath + @"\include", monoPath + @"\include\mono-2.0", "." };
-				string[] libs = new string[] { winsdkPath + @"\Lib\winv6.3\um\x86" , vsPath + @"\lib" };
+				// string[] libs = new string[] { winsdkPath + @"\Lib\winv6.3\um\x86" , vsPath + @"\lib" };
 				var linkLibraries = new string[] {  "kernel32.lib",
 												"version.lib",
 												"Ws2_32.lib",
@@ -1120,40 +1152,42 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 	{
 		Console.WriteLine ("Usage is: mkbundle [options] assembly1 [assembly2...]\n\n" +
 				   "Options:\n" +
-				   "    --config F          Bundle system config file `F'\n" +
-				   "    --config-dir D      Set MONO_CFG_DIR to `D'\n" +
-				   "    --deps              Turns on automatic dependency embedding (default on simple)\n" +
-				   "    -L path             Adds `path' to the search path for assemblies\n" +
-				   "    --machine-config F  Use the given file as the machine.config for the application.\n" +
-				   "    -o out              Specifies output filename\n" +
-				   "    --nodeps            Turns off automatic dependency embedding (default on custom)\n" +
-				   "    --skip-scan         Skip scanning assemblies that could not be loaded (but still embed them).\n" +
-				   "    --i18n ENCODING     none, all or comma separated list of CJK, MidWest, Other, Rare, West.\n" +
-				   "    -v                  Verbose output\n" + 
+				   "    --config F           Bundle system config file `F'\n" +
+				   "    --config-dir D       Set MONO_CFG_DIR to `D'\n" +
+				   "    --deps               Turns on automatic dependency embedding (default on simple)\n" +
+				   "    -L path              Adds `path' to the search path for assemblies\n" +
+				   "    --machine-config F   Use the given file as the machine.config for the application.\n" +
+				   "    -o out               Specifies output filename\n" +
+				   "    --nodeps             Turns off automatic dependency embedding (default on custom)\n" +
+				   "    --skip-scan          Skip scanning assemblies that could not be loaded (but still embed them).\n" +
+				   "    --i18n ENCODING      none, all or comma separated list of CJK, MidWest, Other, Rare, West.\n" +
+				   "    -v                   Verbose output\n" + 
 				   "\n" + 
 				   "--simple   Simple mode does not require a C toolchain and can cross compile\n" + 
-				   "    --cross TARGET      Generates a binary for the given TARGET\n"+
-				   "    --local-targets     Lists locally available targets\n" +
-				   "    --list-targets      Lists available targets on the remote server\n" +
-				   "    --options OPTIONS   Embed the specified Mono command line options on target\n" +
-				   "    --runtime RUNTIME   Manually specifies the Mono runtime to use\n" +
-				   "    --target-server URL Specified a server to download targets from, default is " + target_server + "\n" +
-				   "    --env KEY=VALUE     Hardcodes an environment variable for the target\n" +
+				   "    --cross TARGET       Generates a binary for the given TARGET\n"+
+				   "    --env KEY=VALUE      Hardcodes an environment variable for the target\n" +
+				   "    --library [LIB,]PATH Bundles the specified dynamic library to be used at runtime\n" +
+				   "                         LIB is optional shortname for file located at PATH\n" + 
+				   "    --list-targets       Lists available targets on the remote server\n" +
+				   "    --local-targets      Lists locally available targets\n" +
+				   "    --options OPTIONS    Embed the specified Mono command line options on target\n" +
+				   "    --runtime RUNTIME    Manually specifies the Mono runtime to use\n" +
+				   "    --target-server URL  Specified a server to download targets from, default is " + target_server + "\n" +
 				   "\n" +
 				   "--custom   Builds a custom launcher, options for --custom\n" +
-				   "    -c                  Produce stub only, do not compile\n" +
-				   "    -oo obj             Specifies output filename for helper object file\n" +
+				   "    -c                   Produce stub only, do not compile\n" +
+				   "    -oo obj              Specifies output filename for helper object file\n" +
 				   "    --dos2unix[=true|false]\n" +
-				   "                        When no value provided, or when `true` specified\n" +
-				   "                        `dos2unix` will be invoked to convert paths on Windows.\n" +
-				   "                        When `--dos2unix=false` used, dos2unix is NEVER used.\n" +
-				   "    --keeptemp          Keeps the temporary files\n" +
-				   "    --static            Statically link to mono libs\n" +
-				   "    --nomain            Don't include a main() function, for libraries\n" +
-				   "	--custom-main C     Link the specified compilation unit (.c or .obj) with entry point/init code\n" +
-				   "    -z                  Compress the assemblies before embedding.\n" +
-				   "    --static-ctor ctor  Add a constructor call to the supplied function.\n" +
-				   "                        You need zlib development headers and libraries.\n");
+				   "                         When no value provided, or when `true` specified\n" +
+				   "                         `dos2unix` will be invoked to convert paths on Windows.\n" +
+				   "                         When `--dos2unix=false` used, dos2unix is NEVER used.\n" +
+				   "    --keeptemp           Keeps the temporary files\n" +
+				   "    --static             Statically link to mono libs\n" +
+				   "    --nomain             Don't include a main() function, for libraries\n" +
+				   "	--custom-main C      Link the specified compilation unit (.c or .obj) with entry point/init code\n" +
+				   "    -z                   Compress the assemblies before embedding.\n" +
+				   "    --static-ctor ctor   Add a constructor call to the supplied function.\n" +
+				   "                         You need zlib development headers and libraries.\n");
 	}
 
 	[DllImport ("libc")]

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -3,6 +3,17 @@
 //
 // Based on the `make-bundle' Perl script written by Paolo Molaro (lupus@debian.org)
 //
+// TODO:
+//   [x] Rename the paths for the zip file that is downloaded
+//   [ ] Update documentation with new flag
+//   [x] Load internationalized assemblies
+//   [ ] Dependencies - if System.dll -> include Mono.Security.*
+//   [x] --list-targets should download from a different url
+//   [ ] target list should contain different files
+//   [ ] --fetch-target should unpack zip file
+//   [ ] Update --cross to use not a runtime, but an SDK
+//   [ ] Update --list-targets to show the downloaded SDKs
+//
 // Author:
 //   Miguel de Icaza
 //
@@ -52,6 +63,8 @@ class MakeBundle {
 	static bool custom_mode = true;
 	static string embedded_options = null;
 	static string runtime = null;
+	static string sdk_path = null;
+	static string lib_path = null;
 	static Dictionary<string,string> environment = new Dictionary<string,string>();
 	static string [] i18n = new string [] {
 		"West",
@@ -74,7 +87,7 @@ class MakeBundle {
 		link_paths.Add (".");
 
 		DetectOS ();
-		
+
 		for (int i = 0; i < top; i++){
 			switch (args [i]){
 			case "--help": case "-h": case "-?":
@@ -146,10 +159,8 @@ class MakeBundle {
 					alias = lspec.Substring (0, p);
 					path = lspec.Substring (p+1);
 				}
-				if (!File.Exists (path)){
-					Console.Error.WriteLine ($"The specified library file {path} does not exist");
-					return 1;
-				}
+				if (!File.Exists (path))
+					Error ($"The specified library file {path} does not exist");
 				libraries [alias] = path;
 				break;
 
@@ -163,7 +174,7 @@ class MakeBundle {
 
 			case "--list-targets":
 				var wc = new WebClient ();
-				var s = wc.DownloadString (new Uri (target_server + "target-list.txt"));
+				var s = wc.DownloadString (new Uri (target_server + "target-sdks.txt"));
 				Console.WriteLine ("Cross-compilation targets available:\n" + s);
 				
 				return 0;
@@ -190,6 +201,15 @@ class MakeBundle {
 					return 1;
 				}
 				embedded_options = args [++i];
+				break;
+			case "--sdk":
+				if (i + 1 == top) {
+					Help ();
+					return 1;
+				}
+				custom_mode = false;
+				autodeps = true;
+				sdk_path = args [++i];
 				break;
 			case "--runtime":
 				if (i+1 == top){
@@ -283,7 +303,7 @@ class MakeBundle {
 				case "linux":
 					break;
 				default:
-					Console.Error.WriteLine ("Invalid style '{0}' - only 'windows', 'mac' and 'linux' are supported for --style argument", style);
+					Error ("Invalid style '{0}' - only 'windows', 'mac' and 'linux' are supported for --style argument", style);
 					return 1;
 				}
 					
@@ -329,20 +349,27 @@ class MakeBundle {
 
 		}
 
+		if (sdk_path != null) {
+			VerifySdk (sdk_path);
+		}
+
 		if (fetch_target != null){
-			var truntime = Path.Combine (targets_dir, fetch_target, "mono");
-			Directory.CreateDirectory (Path.GetDirectoryName (truntime));
+			var directory = Path.Combine (targets_dir, fetch_target);
+			var zip_download = Path.Combine (directory, "sdk.zip");
+			Directory.CreateDirectory (Path.GetDirectoryName (directory));
 			var wc = new WebClient ();
 			var uri = new Uri ($"{target_server}{fetch_target}");
 			try {
 				if (!quiet){
-					Console.WriteLine ($"Downloading runtime {uri} to {truntime}");
+					Console.WriteLine ($"Downloading runtime {uri} to {zip_download}");
 				}
 				
-				wc.DownloadFile (uri, truntime);
+				wc.DownloadFile (uri, zip_download);
+				ZipFile.ExtractToDirectory(zip_download, directory);
+				File.Delete (zip_download);
 			} catch {
 				Console.Error.WriteLine ($"Failure to download the specified runtime from {uri}");
-				File.Delete (truntime);
+				File.Delete (zip_download);
 				return 1;
 			}
 			return 0;
@@ -359,6 +386,7 @@ class MakeBundle {
 		}
 
 		List<string> assemblies = LoadAssemblies (sources);
+		LoadLocalizedAssemblies (assemblies);
 		List<string> files = new List<string> ();
 		foreach (string file in assemblies)
 			if (!QueueAssembly (files, file))
@@ -392,6 +420,19 @@ class MakeBundle {
 		Console.WriteLine ("Generated {0}", output);
 
 		return 0;
+	}
+
+	static void VerifySdk (string path)
+	{
+		if (!Directory.Exists (path))
+			Error ($"The specified SDK path does not exist: {path}");
+		runtime = Path.Combine (sdk_path, "bin", "mono");
+		if (!File.Exists (runtime))
+			Error ($"The SDK location does not contain a {path}/bin/mono runtime");
+		lib_path = Path.Combine (path, "lib", "mono", "4.5");
+		if (!Directory.Exists (lib_path))
+			Error ($"The SDK location does not contain a {path}/lib/mono/4.5 directory");
+		link_paths.Add (lib_path);
 	}
 
 	static string targets_dir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".mono", "targets");
@@ -580,7 +621,7 @@ class MakeBundle {
 			return true;
 		
 		if (!File.Exists (file)){
-			Console.Error.WriteLine ("The file {0} does not exist", file);
+			Error ("The file {0} does not exist", file);
 			return false;
 		}
 		maker.Add (code, file);
@@ -593,17 +634,17 @@ class MakeBundle {
 			if (IsUnix)
 				runtime = Process.GetCurrentProcess().MainModule.FileName;
 			else {
-				Console.Error.WriteLine ("You must specify at least one runtime with --runtime or --cross");
+				Error ("You must specify at least one runtime with --runtime or --cross");
 				Environment.Exit (1);
 			}
 		}
 		if (!File.Exists (runtime)){
-			Console.Error.WriteLine ($"The specified runtime at {runtime} does not exist");
+			Error ($"The specified runtime at {runtime} does not exist");
 			Environment.Exit (1);
 		}
 		
 		if (ctor_func != null){
-			Console.Error.WriteLine ("--static-ctor not supported with package bundling, you must use native compilation for this");
+			Error ("--static-ctor not supported with package bundling, you must use native compilation for this");
 			return false;
 		}
 		
@@ -786,7 +827,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 				try {
 					conf = File.OpenRead (config_file);
 				} catch {
-					Error (String.Format ("Failure to open {0}", config_file));
+					Error ("Failure to open {0}", config_file);
 					return;
 				}
 				if (!quiet)
@@ -805,7 +846,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 				try {
 					conf = File.OpenRead (machine_config_file);
 				} catch {
-					Error (String.Format ("Failure to open {0}", machine_config_file));
+					Error ("Failure to open {0}", machine_config_file);
 					return;
 				}
 				if (!quiet)
@@ -1014,11 +1055,9 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 		List<string> assemblies = new List<string> ();
 		bool error = false;
 
-		var other = i18n.Select (x=> "I18N." + x + (x.Length > 0 ? "." : "") + "dll");
-		
-		foreach (string name in sources.Concat (other)){
+		foreach (string name in sources){
 			try {
-				Assembly a = LoadAssembly (name);
+				Assembly a = LoadAssemblyFile (name);
 
 				if (a == null){
 					error = true;
@@ -1039,9 +1078,40 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 
 		if (error)
 			Environment.Exit (1);
-
+		
 		return assemblies;
 	}
+
+	static void LoadLocalizedAssemblies (List<string> assemblies)
+	{
+		var other = i18n.Select (x => "I18N." + x + (x.Length > 0 ? "." : "") + "dll");
+		bool error = false;
+
+		foreach (string name in other) {
+			try {
+				Assembly a = LoadAssembly (name);
+
+				if (a == null) {
+					error = true;
+					continue;
+				}
+
+				assemblies.Add (a.CodeBase);
+			} catch (Exception) {
+				if (skip_scan) {
+					if (!quiet)
+						Console.WriteLine ("File will not be scanned: {0}", name);
+					assemblies.Add (new Uri (new FileInfo (name).FullName).ToString ());
+				} else {
+					throw;
+				}
+			}
+		}
+
+		if (error)
+			Environment.Exit (1);
+	}
+
 	
 	static readonly Universe universe = new Universe ();
 	static readonly Dictionary<string, string> loaded_assemblies = new Dictionary<string, string> ();
@@ -1076,7 +1146,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 		var name = GetAssemblyName (path);
 		string found;
 		if (loaded_assemblies.TryGetValue (name, out found)) {
-			Error (string.Format ("Duplicate assembly name `{0}'. Both `{1}' and `{2}' use same assembly name.", name, path, found));
+			Error ("Duplicate assembly name `{0}'. Both `{1}' and `{2}' use same assembly name.", name, path, found);
 			return false;
 		}
 
@@ -1089,7 +1159,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			Assembly a = universe.LoadFile (path);
 
 			foreach (AssemblyName an in a.GetReferencedAssemblies ()) {
-				a = universe.Load (an.FullName);
+				LoadAssembly (an.FullName);
 				if (!QueueAssembly (files, a.CodeBase))
 					return false;
 			}
@@ -1101,56 +1171,56 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 		return true;
 	}
 
-	static Assembly LoadAssembly (string assembly)
+	//
+	// Loads an assembly from a specific path
+	//
+	static Assembly LoadAssemblyFile (string assembly)
 	{
-		Assembly a;
+		Assembly a = null;
 		
 		try {
-			char[] path_chars = { '/', '\\' };
-			
-			if (assembly.IndexOfAny (path_chars) != -1) {
-				a = universe.LoadFile (assembly);
-			} else {
-				string ass = assembly;
-				if (ass.EndsWith (".dll"))
-					ass = assembly.Substring (0, assembly.Length - 4);
-				a = universe.Load (ass);
-			}
-			return a;
+			a = universe.LoadFile (assembly);
 		} catch (FileNotFoundException){
-			string total_log = "";
-			
-			foreach (string dir in link_paths){
-				string full_path = Path.Combine (dir, assembly);
-				if (!assembly.EndsWith (".dll") && !assembly.EndsWith (".exe"))
-					full_path += ".dll";
-				
-				try {
-					a = universe.LoadFile (full_path);
-					return a;
-				} catch (FileNotFoundException ff) {
-					total_log += ff.FusionLog;
-					continue;
-				}
-			}
-			Error ("Cannot find assembly `" + assembly + "'" );
-			if (!quiet)
-				Console.WriteLine ("Log: \n" + total_log);
+			Error ($"Cannot find assembly `{assembly}'");
 		} catch (IKVM.Reflection.BadImageFormatException f) {
 			if (skip_scan)
 				throw;
-			Error ("Cannot load assembly (bad file format) " + f.Message);
+			Error ($"Cannot load assembly (bad file format) " + f.Message);
 		} catch (FileLoadException f){
-			Error ("Cannot load assembly " + f.Message);
+			Error ($"Cannot load assembly " + f.Message);
 		} catch (ArgumentNullException){
-			Error("Cannot load assembly (null argument)");
+			Error( $"Cannot load assembly (null argument)");
 		}
-		return null;
+		return a;
 	}
 
-	static void Error (string msg)
+	//
+	// Loads an assembly from any of the link directories provided
+	//
+	static Assembly LoadAssembly (string assembly)
 	{
-		Console.Error.WriteLine ("ERROR: " + msg);
+		string total_log = "";
+		foreach (string dir in link_paths){
+			string full_path = Path.Combine (dir, assembly);
+			if (!assembly.EndsWith (".dll") && !assembly.EndsWith (".exe"))
+				full_path += ".dll";
+			
+			try {
+				var a = universe.LoadFile (full_path);
+				return a;
+			} catch (FileNotFoundException ff) {
+				total_log += ff.FusionLog;
+				continue;
+			}
+		}
+		if (!quiet)
+			Console.WriteLine ("Log: \n" + total_log);
+		return null;
+	}
+	
+	static void Error (string msg, params object [] args)
+	{
+		Console.Error.WriteLine ("ERROR: ", string.Format (msg, args));
 		Environment.Exit (1);
 	}
 
@@ -1308,7 +1378,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			p.WaitForExit ();
 			int ret = p.ExitCode;
 			if (ret != 0){
-				Error (String.Format("[Fail] {0}", ret));
+				Error ("[Fail] {0}", ret);
 			}
 		}
 	}

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -558,6 +558,21 @@ mono_assembly_getrootdir (void)
 }
 
 /**
+ * mono_native_getrootdir:
+ * 
+ * Obtains the root directory used for looking up native libs (.so, .dylib).
+ *
+ * Returns: a string with the directory, this string should be freed by
+ * the caller.
+ */
+gchar *
+mono_native_getrootdir (void)
+{
+	gchar* fullpath = g_build_path (G_DIR_SEPARATOR_S, mono_assembly_getrootdir (), mono_config_get_reloc_lib_dir(), NULL);
+	return fullpath;
+}
+
+/**
  * mono_set_dirs:
  * @assembly_dir: the base directory for assemblies
  * @config_dir: the base directory for configuration files

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -558,21 +558,6 @@ mono_assembly_getrootdir (void)
 }
 
 /**
- * mono_native_getrootdir:
- * 
- * Obtains the root directory used for looking up native libs (.so, .dylib).
- *
- * Returns: a string with the directory, this string should be freed by
- * the caller.
- */
-gchar *
-mono_native_getrootdir (void)
-{
-	gchar* fullpath = g_build_path (G_DIR_SEPARATOR_S, mono_assembly_getrootdir (), mono_config_get_reloc_lib_dir(), NULL);
-	return fullpath;
-}
-
-/**
  * mono_set_dirs:
  * @assembly_dir: the base directory for assemblies
  * @config_dir: the base directory for configuration files

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -36,7 +36,6 @@ MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32
 MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
 MONO_API void          mono_assembly_setrootdir (const char *root_dir);
 MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
-MONO_API char         *mono_native_getrootdir (void);
 MONO_API void	       mono_assembly_foreach    (MonoFunc func, void* user_data);
 MONO_API void          mono_assembly_set_main   (MonoAssembly *assembly);
 MONO_API MonoAssembly *mono_assembly_get_main   (void);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -36,7 +36,8 @@ MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32
 MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
 MONO_API void          mono_assembly_setrootdir (const char *root_dir);
 MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
-MONO_API void	      mono_assembly_foreach    (MonoFunc func, void* user_data);
+MONO_API char         *mono_native_getrootdir (void);
+MONO_API void	       mono_assembly_foreach    (MonoFunc func, void* user_data);
 MONO_API void          mono_assembly_set_main   (MonoAssembly *assembly);
 MONO_API MonoAssembly *mono_assembly_get_main   (void);
 MONO_API MonoImage    *mono_assembly_get_image  (MonoAssembly *assembly);

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1123,6 +1123,14 @@ cached_module_load (const char *name, int flags, char **err)
 	return res;
 }
 
+void
+mono_loader_register_module (const char *name, MonoDl *module)
+{
+	if (!global_module_map)
+		global_module_map = g_hash_table_new (g_str_hash, g_str_equal);
+	g_hash_table_insert (global_module_map, g_strdup (name), module);
+}
+
 static MonoDl *internal_module;
 
 static gboolean

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -4,6 +4,7 @@
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/image.h>
 #include <mono/utils/mono-error.h>
+#include <mono/utils/mono-dl.h>
 
 MONO_BEGIN_DECLS
 
@@ -63,6 +64,8 @@ mono_lookup_internal_call (MonoMethod *method);
 void*
 mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles);
 
+void
+mono_loader_register_module (const char *name, MonoDl *module);
 
 MONO_API const char*
 mono_lookup_icall_symbol (MonoMethod *m);

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -1,8 +1,24 @@
+/*
+ * main.c: The main entry point for the mono executable
+ *
+ * The main entry point does a few things:
+ * 
+ *   * It probes whether the executable has a bundle appended
+ *     at the end, and if so, registers the various bundled
+ *     resources with Mono and executes the contained bundle
+ *
+ *   * Parses the MONO_ENV_OPTIONS variable to treat the
+ *     contents of the variable as command line arguments for
+ *     the mono runtime
+ *
+ *   * Launches Mono, by calling mono_main.
+ */
 #include <config.h>
 #include <fcntl.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/mono-config.h>
 #include <mono/utils/mono-mmap.h>
+#include <mono/utils/mono-dl.h>
 #include "mini.h"
 
 #ifdef HAVE_UNISTD_H
@@ -29,6 +45,51 @@ mono_main_with_options (int argc, char *argv [])
 	return mono_main (argc, argv);
 }
 
+/*
+ * The Mono executable can initialize itself from a payload attached
+ * at the end of the main program.   The payload contains the
+ * main assembly, one or more managed assemblies, configuration
+ * files and other assets that are used instead of launching a
+ * program from the command line.
+ *
+ * The startup sequence probes for a magical signature at the end of
+ * the executable, if the 16 characters "xmonkeysloveplay" are found,
+ * the code expects the 64-bits just before it to contain an offset
+ * within the executable with a directory of assets.
+ *
+ * All pointers in the file format are encoded as little-endian values
+ *
+ * The format of the file is thus:
+ *
+ * Location        Content
+ * --------        -------
+ * lenght-16       Optional "xmonkeysloveplay", indicating that a
+ *                 bundled payload is contained in the executable.
+ * length-24       pointer to the directory in the file, address DIR
+ *
+ * DIR             32-bit value with the number of entries in the directory
+ * DIR+4           First directory entry.
+ *
+ * Each directory entry is made up of:
+ * 4-bytes         uint32_t containing the size of a string (STR)
+ * STRING          UTF8 encoded and \0 terminated string
+ * 8-bytes         uint64_t offset in the file with the payload associated with STRING
+ * 4-bytes         uint32_t size of the asset
+ *
+ * The following are the known directory entries, without the quotes:
+ * "assembly:NAME"  An assembly with the name NAME, assembly is in the payload
+ * "config:NAME"    A configuration file (usually file.dll.config) in the payload that is
+ *                  loaded as the config file for an assembly
+ * "systemconfig:"  Treats as a Mono system configuration, payload contains the config file.
+ * "options:"       The payload contains command line options to initialize Mono, as if you 
+                    had set them on MONO_ENV_OPTIONS
+ * "config_dir:DIR" Configures the MONO_PATH to point to point to DIR
+ * "machineconfig:" The payload contains the machine.config file to use at runtime
+ * "env:"           Sets the environment variable to the value encoded in the payload
+ *                  payload contains: 1-byte lenght for the \0 terminated variable,
+ *                  followed by the value.
+ * "library:NAME"   Bundled dynamic library NAME, payload contains the dynamic library
+ */
 #define STREAM_INT(x) GUINT32_TO_LE((*(uint32_t*)x))
 #define STREAM_LONG(x) GUINT64_TO_LE((*(uint64_t*)x))
 
@@ -62,6 +123,60 @@ load_from_region (int fd, uint64_t offset, uint64_t size)
 		return NULL;
 	}
 	return buffer;
+}
+
+/* Did we initialize the temporary directory for dynamic libraries */
+static int bundle_save_library_initialized;
+
+/* List of bundled libraries we unpacked */
+static GSList *bundle_library_paths;
+
+/* Directory where we unpacked dynamic libraries */
+static char *bundled_dylibrary_directory;
+
+static void
+delete_bundled_libraries ()
+{
+	GSList *list;
+
+	for (list = bundle_library_paths; list != NULL; list = list->next){
+		unlink (list->data);
+	}
+	rmdir (bundled_dylibrary_directory);
+}
+
+static void
+bundle_save_library_initialize ()
+{
+	bundle_save_library_initialized = 1;
+	char *path = g_build_filename (g_get_tmp_dir (), "mono-bundle-XXXXXX");
+	bundled_dylibrary_directory = g_mkdtemp (path);
+	g_free (path);
+	if (bundled_dylibrary_directory == NULL)
+		return;
+	atexit (delete_bundled_libraries);
+}
+
+static void
+save_library (int fd, uint64_t offset, uint64_t size, const char *destfname)
+{
+	MonoDl *lib;
+	char *file, *buffer, *err;
+	if (!bundle_save_library_initialized)
+		bundle_save_library_initialize ();
+	
+	file = g_build_filename (bundled_dylibrary_directory, destfname);
+	buffer = load_from_region (fd, offset, size);
+	g_file_set_contents (file, buffer, size, NULL);
+	lib = mono_dl_open (file, MONO_DL_LAZY, &err);
+	if (err != NULL){
+		fprintf (stderr, "Error loading shared library: %s\n", file);
+		exit (1);
+	}
+	mono_loader_register_module (destfname, lib);
+	bundle_library_paths = g_slist_append (bundle_library_paths, file);
+	
+	g_free (buffer);
 }
 
 static gboolean
@@ -150,13 +265,15 @@ probe_embedded (const char *program, int *ref_argc, char **ref_argv [])
 			uint8_t count = *data++;
 			char *value = data + count + 1;
 			g_setenv (data, value, FALSE);
+		} else if (strncmp (kind, "library:", strlen ("library:")) == 0){
+			save_library (fd, offset, item_size, kind + strlen ("library:"));
 		} else {
 			fprintf (stderr, "Unknown stream on embedded package: %s\n", kind);
 			exit (1);
 		}
 	}
 	g_array_append_val (assemblies, last);
-	
+
 	mono_register_bundled_assemblies ((const MonoBundledAssembly **) assemblies->data);
 	new_argv = g_new (char *, (*ref_argc)+1);
 	for (j = 0; j < *ref_argc; j++)

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -241,6 +241,7 @@ mono_disasm_code
 mono_disasm_code_one
 mono_dl_fallback_register
 mono_dl_fallback_unregister
+mono_dl_open
 mono_dllmap_insert
 mono_domain_add_class_static_data
 mono_domain_assembly_open
@@ -495,6 +496,7 @@ mono_ldstr
 mono_ldtoken
 mono_load_remote_field
 mono_load_remote_field_new
+mono_loader_register_module
 mono_lock_free_alloc
 mono_lock_free_allocator_check_consistency
 mono_lock_free_allocator_init_allocator

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -241,6 +241,7 @@ mono_disasm_code
 mono_disasm_code_one
 mono_dl_fallback_register
 mono_dl_fallback_unregister
+mono_dl_open
 mono_dllmap_insert
 mono_domain_add_class_static_data
 mono_domain_assembly_open
@@ -497,6 +498,7 @@ mono_ldstr
 mono_ldtoken
 mono_load_remote_field
 mono_load_remote_field_new
+mono_loader_register_module
 mono_lock_free_alloc
 mono_lock_free_allocator_check_consistency
 mono_lock_free_allocator_init_allocator

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -34,8 +34,9 @@ bin_SCRIPTS = \
 	$(MDOC_SUBCOMMANDS)	\
 	$(MDOC_COMPAT)		\
 	mono-test-install	\
-	peverify			\
-	mcs					\
+	peverify		\
+	mcs			\
+	mono-package-runtime	\
 	mono-heapviz		\
 	$(scripts_mono_configuration_crypto)
 

--- a/scripts/mono-package-runtime
+++ b/scripts/mono-package-runtime
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+if test x$2 = x; then
+   echo usage is: mono-package-runtime MONO_INSTALL_PREFIX LABEL
+   echo The file will be created in the current directory
+   exit 1
+fi
+
+prefix=$1
+output=$2
+if test ! -d $prefix; then
+   echo the specified path is not a directory: $prefix
+   exit 1
+fi
+
+if test -e $output.zip; then
+   echo The output file already exists, refusing to overwrite: $output.zip
+   exit 1
+fi
+
+if test ! -e $prefix/bin/mono; then
+   echo The $prefix does not contains a bin/mono
+   exit 1
+fi
+
+if test ! -d $prefix/lib/mono/4.5; then
+   echo The $prefix does not contains a lib/mono/4.5
+   exit 1
+fi
+
+o=`pwd`/$output
+
+cd $prefix
+(zip -u $o.zip bin/mono lib/mono/4.5/mscorlib.dll lib/mono/4.5/System*dll lib/mono/4.5/Mono.CSharp.dll lib/mono/4.5/Microsoft*dll lib/mono/4.5/FSharp*.dll lib/mono/4.5/I18N*dll lib/mono/4.5/Accessibility.dll lib/mono/4.5/RabbitMQ.Client.dll lib/mono/4.5/ICSharpCode.SharpZipLib.dll lib/mono/4.5/CustomMarshalers.dll etc/mono/config etc/mono/4.5/machine.config etc/mono/4.5/web.config lib/mono/4.5/Mono.Cairo.dll lib/mono/4.5/Mono.Data.Sqlite.dll lib/mono/4.5/Mono.Posix.dll lib/mono/4.5/Mono.Security.*dll lib/mono/4.5/Mono.Simd.dll)
+echo Created file $o.zip
+


### PR DESCRIPTION
This backports the mkbundle support that allows mkbundle to use complete SDKs, as opposed to a single runtime to bundle packages as completing the native library loading support.