### PR TITLE
[Windows] Make the code compile under Windows Subsystem for Linux

### DIFF
--- a/mono/metadata/coree-internals.h
+++ b/mono/metadata/coree-internals.h
@@ -9,7 +9,7 @@
 #include <glib.h>
 
 #ifdef HOST_WIN32
-#include <Windows.h>
+#include <windows.h>
 
 BOOL STDMETHODCALLTYPE
 _CorDllMain (HINSTANCE hInst, DWORD dwReason, LPVOID lpReserved);

--- a/mono/metadata/file-io-windows.c
+++ b/mono/metadata/file-io-windows.c
@@ -8,8 +8,8 @@
 #include <glib.h>
 
 #if defined(HOST_WIN32)
-#include <WinSock2.h>
-#include <Windows.h>
+#include <winsock2.h>
+#include <windows.h>
 #include "mono/metadata/file-io-windows-internals.h"
 
 gunichar2

--- a/mono/metadata/icall-windows.c
+++ b/mono/metadata/icall-windows.c
@@ -8,8 +8,8 @@
 #include <glib.h>
 
 #if defined(HOST_WIN32)
-#include <WinSock2.h>
-#include <Windows.h>
+#include <winsock2.h>
+#include <windows.h>
 #include "mono/metadata/icall-windows-internals.h"
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -8,8 +8,8 @@
 #include <glib.h>
 
 #if defined(HOST_WIN32)
-#include <WinSock2.h>
-#include <Windows.h>
+#include <winsock2.h>
+#include <windows.h>
 #include <objbase.h>
 #include "mono/metadata/marshal-windows-internals.h"
 

--- a/mono/metadata/mono-security-windows.c
+++ b/mono/metadata/mono-security-windows.c
@@ -8,8 +8,8 @@
 #include <glib.h>
 
 #if defined(HOST_WIN32)
-#include <WinSock2.h>
-#include <Windows.h>
+#include <winsock2.h>
+#include <windows.h>
 #include "mono/metadata/mono-security-windows-internals.h"
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)

--- a/mono/metadata/process-windows.c
+++ b/mono/metadata/process-windows.c
@@ -9,8 +9,8 @@
 #include <glib.h>
 
 #if defined(HOST_WIN32)
-#include <WinSock2.h>
-#include <Windows.h>
+#include <winsock2.h>
+#include <windows.h>
 #include "mono/metadata/process-windows-internals.h"
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)

--- a/mono/mini/mini-windows.h
+++ b/mono/mini/mini-windows.h
@@ -5,7 +5,7 @@
 #include <glib.h>
 
 #ifdef HOST_WIN32
-#include "Windows.h"
+#include "windows.h"
 #include "mini.h"
 #include "mono/utils/mono-context.h"
 

--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -12,7 +12,7 @@
 #include <glib.h>
 
 #if defined(HOST_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #include "mono/utils/mono-mmap-windows.h"
 #include <mono/utils/mono-counters.h>
 #include <io.h>


### PR DESCRIPTION
While cross compiling with WSL, the file system is case sensitive,
 and the header files are "windows.h" and "winsock2.h" instead
of "Windows.h" and "WinSock2.h"