### PR TITLE
ccrewrite.1: fix copyright

### DIFF
--- a/man/ccrewrite.1
+++ b/man/ccrewrite.1
@@ -1,6 +1,6 @@
 .\" 
 .\" ccrewrite manual page.
-.\" Copyright (C) 2010 Novell, Inc (http://www.novell.com)
+.\" Copyright (C) 2010 Chris Bacon.
 .\" Author:
 .\"   Chris Bacon <chrisbacon76@gmail.com>
 .\"


### PR DESCRIPTION
Following comment changed the copyright:
https://github.com/mono/mono/commit/5a3fb39ca6a46250aec3afef21c85bef30239fc5

Reflect same change in the comments.