### PR TITLE
[System] Remove any CFNetwork usage from the watchOS profile. Fixes #45847.

### DIFF
--- a/mcs/class/System/System.Net/MacProxy.cs
+++ b/mcs/class/System/System.Net/MacProxy.cs
@@ -24,6 +24,8 @@
 // THE SOFTWARE.
 // 
 
+#if !MONOTOUCH_WATCH
+
 using System;
 using System.Net;
 using System.Collections.Generic;
@@ -1067,3 +1069,5 @@ namespace Mono.Net
 		}
 	}
 }
+
+#endif // !MONOTOUCH_WATCH

--- a/mcs/class/System/System.Net/WebRequest.cs
+++ b/mcs/class/System/System.Net/WebRequest.cs
@@ -352,7 +352,9 @@ namespace System.Net
 		[MonoTODO("Look in other places for proxy config info")]
 		public static IWebProxy GetSystemWebProxy ()
 		{
-#if MONOTOUCH
+#if MONOTOUCH_WATCH
+			throw new PlatformNotSupportedException ();
+#elif MONOTOUCH
 			return CFNetwork.GetDefaultProxy ();
 #else
 #if MONODROID

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -1771,6 +1771,9 @@ namespace MonoTests.System.Net
 		}
 
 		[Test]
+#if MONOTOUCH_WATCH
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
 		public void DefaultProxy ()
 		{
 			WebClient wc = new WebClient ();


### PR DESCRIPTION
The MacProxy class uses CFNetwork, but since CFNetwork is not a public
framework on watchOS, we can't use it.

So remove MacProxy completely (it only contains internal classes), and throw
PlatformNotSupportedException in any API that used it (the managed networking
stack is not supported on watchOS anyway, so this should be safe).

This is a backport of the following commits: c023b2b30aa3bd0d2f0eafb5e983861df7f67de4 and 16b8979fd1698669499defc95cc069c0adf1e291.

https://bugzilla.xamarin.com/show_bug.cgi?id=45847
