### PR TITLE
[sre] Assign consecutive unique tokens to fields in a module

### DIFF
--- a/mcs/class/corlib/ReferenceSources/MethodBase.cs
+++ b/mcs/class/corlib/ReferenceSources/MethodBase.cs
@@ -30,15 +30,15 @@ namespace System.Reflection
 			throw new NotImplementedException ();
 		}
 
-		internal virtual int get_next_table_index (object obj, int table, bool inc) {
+		internal virtual int get_next_table_index (object obj, int table, int count) {
 #if !FULL_AOT_RUNTIME
 			if (this is MethodBuilder) {
 				MethodBuilder mb = (MethodBuilder)this;
-				return mb.get_next_table_index (obj, table, inc);
+				return mb.get_next_table_index (obj, table, count);
 			}
 			if (this is ConstructorBuilder) {
 				ConstructorBuilder mb = (ConstructorBuilder)this;
-				return mb.get_next_table_index (obj, table, inc);
+				return mb.get_next_table_index (obj, table, count);
 			}
 #endif
 			throw new Exception ("Method is not a builder method");

--- a/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.cs
@@ -81,7 +81,7 @@ namespace System.Reflection.Emit {
 			type = tb;
 			this.paramModReq = paramModReq;
 			this.paramModOpt = paramModOpt;
-			table_idx = get_next_table_index (this, 0x06, true);
+			table_idx = get_next_table_index (this, 0x06, 1);
 
 			((ModuleBuilder) tb.Module).RegisterToken (this, GetToken ().Token);
 		}
@@ -393,9 +393,9 @@ namespace System.Reflection.Emit {
 			}
 		}
 
-		internal override int get_next_table_index (object obj, int table, bool inc)
+		internal override int get_next_table_index (object obj, int table, int count)
 		{
-			return type.get_next_table_index (obj, table, inc);
+			return type.get_next_table_index (obj, table, count);
 		}
 
 		private void RejectIfCreated ()

--- a/mcs/class/corlib/System.Reflection.Emit/EventBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/EventBuilder.cs
@@ -63,11 +63,11 @@ namespace System.Reflection.Emit {
 			attrs = eventAttrs;
 			type = eventType;
 			typeb = tb;
-			table_idx = get_next_table_index (this, 0x14, true);
+			table_idx = get_next_table_index (this, 0x14, 1);
 		}
 
-		internal int get_next_table_index (object obj, int table, bool inc) {
-			return typeb.get_next_table_index (obj, table, inc);
+		internal int get_next_table_index (object obj, int table, int count) {
+			return typeb.get_next_table_index (obj, table, count);
 		}
 
 		public void AddOtherMethod( MethodBuilder mdBuilder) {

--- a/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
@@ -52,7 +52,6 @@ namespace System.Reflection.Emit {
 		private String name;
 		private object def_value;
 		private int offset;
-		private int table_idx;
 		internal TypeBuilder typeb;
 		private byte[] rva_data;
 		private CustomAttributeBuilder[] cattrs;
@@ -74,7 +73,6 @@ namespace System.Reflection.Emit {
 			this.modOpt = modOpt;
 			offset = -1;
 			typeb = tb;
-			table_idx = tb.get_next_table_index (this, 0x04, true);
 
 			((ModuleBuilder) tb.Module).RegisterToken (this, GetToken ().Token);
 		}
@@ -123,6 +121,8 @@ namespace System.Reflection.Emit {
 			else
 				throw CreateNotSupportedException ();
 		}
+
+		public override int MetadataToken { get { return ((ModuleBuilder) typeb.Module).GetToken (this); } }
 
 		public FieldToken GetToken() {
 			return new FieldToken (MetadataToken);

--- a/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.cs
@@ -103,7 +103,7 @@ namespace System.Reflection.Emit
 				System.Array.Copy (parameterTypes, this.parameters, parameterTypes.Length);
 			}
 			type = tb;
-			table_idx = get_next_table_index (this, 0x06, true);
+			table_idx = get_next_table_index (this, 0x06, 1);
 
 			((ModuleBuilder)tb.Module).RegisterToken (this, GetToken ().Token);
 		}
@@ -566,9 +566,9 @@ namespace System.Reflection.Emit
 			return name.GetHashCode ();
 		}
 
-		internal override int get_next_table_index (object obj, int table, bool inc)
+		internal override int get_next_table_index (object obj, int table, int count)
 		{
-			return type.get_next_table_index (obj, table, inc);
+			return type.get_next_table_index (obj, table, count);
 		}
 
 		void ExtendArray<T> (ref T[] array, T elem) {

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -62,7 +62,7 @@ namespace System.Reflection.Emit {
 		private FieldBuilder[] global_fields;
 		bool is_main;
 		private MonoResource[] resources;
-		uint next_field_idx;
+		private int[] table_indexes;
 		#endregion
 #pragma warning restore 169, 414
 		
@@ -71,7 +71,6 @@ namespace System.Reflection.Emit {
 		// name_cache keys are display names
 		Dictionary<TypeName, TypeBuilder> name_cache;
 		Dictionary<string, int> us_string_cache;
-		private int[] table_indexes;
 		bool transient;
 		ModuleBuilderTokenGenerator token_gen;
 		Hashtable resource_writers;
@@ -94,8 +93,6 @@ namespace System.Reflection.Emit {
 			table_idx = get_next_table_index (this, 0x00, 1);
 			name_cache = new Dictionary<TypeName, TypeBuilder> ();
 			us_string_cache = new Dictionary<string, int> (512);
-
-			next_field_idx = 0;
 
 			basic_init (this);
 

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -62,6 +62,7 @@ namespace System.Reflection.Emit {
 		private FieldBuilder[] global_fields;
 		bool is_main;
 		private MonoResource[] resources;
+		uint next_field_idx;
 		#endregion
 #pragma warning restore 169, 414
 		
@@ -93,6 +94,8 @@ namespace System.Reflection.Emit {
 			table_idx = get_next_table_index (this, 0x00, true);
 			name_cache = new Dictionary<TypeName, TypeBuilder> ();
 			us_string_cache = new Dictionary<string, int> (512);
+
+			next_field_idx = 0;
 
 			basic_init (this);
 

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -91,7 +91,7 @@ namespace System.Reflection.Emit {
 			// to keep mcs fast we do not want CryptoConfig wo be involved to create the RNG
 			guid = Guid.FastNewGuidArray ();
 			// guid = Guid.NewGuid().ToByteArray ();
-			table_idx = get_next_table_index (this, 0x00, true);
+			table_idx = get_next_table_index (this, 0x00, 1);
 			name_cache = new Dictionary<TypeName, TypeBuilder> ();
 			us_string_cache = new Dictionary<string, int> (512);
 
@@ -423,7 +423,7 @@ namespace System.Reflection.Emit {
 				return result;
 		}
 
-		internal int get_next_table_index (object obj, int table, bool inc) {
+		internal int get_next_table_index (object obj, int table, int count) {
 			if (table_indexes == null) {
 				table_indexes = new int [64];
 				for (int i=0; i < 64; ++i)
@@ -432,9 +432,9 @@ namespace System.Reflection.Emit {
 				table_indexes [0x02] = 2;
 			}
 			// Console.WriteLine ("getindex for table "+table.ToString()+" got "+table_indexes [table].ToString());
-			if (inc)
-				return table_indexes [table]++;
-			return table_indexes [table];
+			var index = table_indexes [table];
+			table_indexes [table] += count;
+			return index;
 		}
 
 		public void SetCustomAttribute( CustomAttributeBuilder customBuilder) {

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -750,7 +750,7 @@ namespace System.Reflection.Emit {
 		}
 
 		internal int GetToken (MemberInfo member) {
-			if (member is ConstructorBuilder || member is MethodBuilder)
+			if (member is ConstructorBuilder || member is MethodBuilder || member is FieldBuilder)
 				return GetPseudoToken (member, false);
 			return getToken (this, member, true);
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/ParameterBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ParameterBuilder.cs
@@ -66,7 +66,7 @@ namespace System.Reflection.Emit {
 			if (mb is DynamicMethod)
 				table_idx = 0;
 			else
-				table_idx = mb.get_next_table_index (this, 0x08, true);
+				table_idx = mb.get_next_table_index (this, 0x08, 1);
 		}
 
 		public virtual int Attributes {

--- a/mcs/class/corlib/System.Reflection.Emit/PropertyBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/PropertyBuilder.cs
@@ -80,7 +80,7 @@ namespace System.Reflection.Emit {
 				System.Array.Copy (parameterTypes, this.parameters, this.parameters.Length);
 			}
 			typeb = tb;
-			table_idx = tb.get_next_table_index (this, 0x17, true);
+			table_idx = tb.get_next_table_index (this, 0x17, 1);
 		}
 
 		public override PropertyAttributes Attributes {

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
@@ -137,7 +137,7 @@ namespace System.Reflection.Emit
 				this.parent = typeof (object);
 
 			// skip .<Module> ?
-			table_idx = mb.get_next_table_index (this, 0x02, true);
+			table_idx = mb.get_next_table_index (this, 0x02, 1);
 			fullname = GetFullName ();
 		}
 
@@ -1600,8 +1600,8 @@ namespace System.Reflection.Emit
 			this.parent = ResolveUserType (this.parent);
 		}
 
-		internal int get_next_table_index (object obj, int table, bool inc) {
-			return pmodule.get_next_table_index (obj, table, inc);
+		internal int get_next_table_index (object obj, int table, int count) {
+			return pmodule.get_next_table_index (obj, table, count);
 		}
 
 		[ComVisible (true)]

--- a/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/ModuleBuilderTest.cs
@@ -480,7 +480,7 @@ namespace MonoTests.System.Reflection.Emit
 
 			var field = type.DefineField ("field", t, FieldAttributes.Public);
 
-			type.CreateType ();
+			var tc = type.CreateType ();
 
 			var resolved_field = (FieldInfo) module.ResolveMember (0x04000001, new [] { typeof (string) }, Type.EmptyTypes);
 			Assert.IsNotNull (resolved_field);
@@ -812,6 +812,57 @@ namespace MonoTests.System.Reflection.Emit
 			Assert.AreEqual ("t1*", module.GetType ("t1*").FullName);
 			Assert.AreEqual ("t1&", module.GetType ("t1&").FullName);
 			Assert.AreEqual ("t1[]&", module.GetType ("t1[]&").FullName);
+		}
+
+		[Test]
+		public void FieldBuilder_DistinctTokens ()
+		{
+			// Regression test for #33208
+			// Fields of distinct classes in the same
+			// module should have distinct tokens.
+
+			AssemblyBuilder ab = genAssembly ();
+			ModuleBuilder module = ab.DefineDynamicModule ("foo.dll", "foo.dll");
+
+			var tb1 = module.DefineType ("T1", TypeAttributes.Public);
+
+			var tb2 = module.DefineType ("T2", TypeAttributes.Public);
+
+			FieldBuilder fbX1 = tb1.DefineField ("X", typeof (Object), FieldAttributes.Public);
+
+			FieldBuilder fbX2 = tb2.DefineField ("X", typeof (Object), FieldAttributes.Public);
+
+			FieldBuilder fbY1 = tb1.DefineField ("Y", typeof (int), FieldAttributes.Public);
+
+			Assert.AreNotEqual (fbX1.GetToken (), fbX2.GetToken (), "GetToken() T1.X != T2.X");
+			Assert.AreNotEqual (fbX1.GetToken (), fbY1.GetToken (), "GetToken() T1.X != T1.Y");
+			Assert.AreNotEqual (fbY1.GetToken (), fbX2.GetToken (), "GetToken() T1.Y != T2.X");
+
+			// .NET throws NotSupportedException for
+			// FieldBuilder.MetadataToken, Mono doesn't.
+			// We'll check that the metadata tokens are
+			// distinct, but it's also okay to take these
+			// assertions out if we start following .NET
+			// behavior.
+			Assert.AreNotEqual (fbX1.MetadataToken, fbX2.MetadataToken, "MetadataToken T1.X != T2.X");
+			Assert.AreNotEqual (fbX1.MetadataToken, fbY1.MetadataToken, "MetadataToken T1.X != T1.Y");
+			Assert.AreNotEqual (fbY1.MetadataToken, fbX2.MetadataToken, "MetadataToken T1.Y != T2.X");
+
+			var t1 = tb1.CreateType ();
+			var t2 = tb2.CreateType ();
+
+			FieldInfo fX1 = t1.GetField ("X");
+			FieldInfo fX2 = t2.GetField ("X");
+
+			FieldInfo fY1 = t1.GetField ("Y");
+
+			Assert.AreNotEqual (fX1.MetadataToken, fX2.MetadataToken, "T1.X != T2.X");
+			Assert.AreNotEqual (fX1.MetadataToken, fY1.MetadataToken, "T1.X != T1.Y");
+			Assert.AreNotEqual (fY1.MetadataToken, fX2.MetadataToken, "T1.Y != T2.X");
+
+			Assert.AreEqual (module.ResolveField (fX1.MetadataToken), fX1, "resolve T1.X");
+			Assert.AreEqual (module.ResolveField (fX2.MetadataToken), fX2, "resolve T2.X");
+			Assert.AreEqual (module.ResolveField (fY1.MetadataToken), fY1, "resolve T1.Y");
 		}
 	}
 }

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1128,7 +1128,7 @@ typedef struct {
 	MonoArray *global_fields;
 	gboolean is_main;
 	MonoArray *resources;
-	guint32    next_field_idx;
+	MonoArray *table_indexes;
 } MonoReflectionModuleBuilder;
 
 typedef struct {

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1073,7 +1073,6 @@ typedef struct {
 	MonoString *name;
 	MonoObject *def_value;
 	gint32 offset;
-	gint32 table_idx;
 	MonoReflectionType *typeb;
 	MonoArray *rva_data;
 	MonoArray *cattrs;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1128,6 +1128,7 @@ typedef struct {
 	MonoArray *global_fields;
 	gboolean is_main;
 	MonoArray *resources;
+	guint32    next_field_idx;
 } MonoReflectionModuleBuilder;
 
 typedef struct {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -2043,9 +2043,7 @@ mono_reflection_get_token_checked (MonoObject *obj, MonoError *error)
 
 		token = mb->table_idx | MONO_TOKEN_METHOD_DEF;
 	} else if (strcmp (klass->name, "FieldBuilder") == 0) {
-		MonoReflectionFieldBuilder *fb = (MonoReflectionFieldBuilder *)obj;
-
-		token = fb->table_idx | MONO_TOKEN_FIELD_DEF;
+		g_assert_not_reached ();
 	} else if (strcmp (klass->name, "TypeBuilder") == 0) {
 		MonoReflectionTypeBuilder *tb = (MonoReflectionTypeBuilder *)obj;
 		token = tb->table_idx | MONO_TOKEN_TYPE_DEF;

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -696,9 +696,9 @@ mono_image_get_field_info (MonoReflectionFieldBuilder *fb, MonoDynamicImage *ass
 	if (fb->attrs & FIELD_ATTRIBUTE_LITERAL)
 		fb->attrs |= FIELD_ATTRIBUTE_HAS_DEFAULT;
 	table = &assembly->tables [MONO_TABLE_FIELD];
-	fb->table_idx = table->next_idx ++;
-	g_hash_table_insert (assembly->field_to_table_idx, fb->handle, GUINT_TO_POINTER (fb->table_idx));
-	values = table->values + fb->table_idx * MONO_FIELD_SIZE;
+	guint32 fb_table_idx = table->next_idx ++;
+	g_hash_table_insert (assembly->field_to_table_idx, fb->handle, GUINT_TO_POINTER (fb_table_idx));
+	values = table->values + fb_table_idx * MONO_FIELD_SIZE;
 	values [MONO_FIELD_NAME] = string_heap_insert_mstring (&assembly->sheap, fb->name, error);
 	return_if_nok (error);
 	values [MONO_FIELD_FLAGS] = fb->attrs;
@@ -710,7 +710,7 @@ mono_image_get_field_info (MonoReflectionFieldBuilder *fb, MonoDynamicImage *ass
 		table->rows ++;
 		alloc_table (table, table->rows);
 		values = table->values + table->rows * MONO_FIELD_LAYOUT_SIZE;
-		values [MONO_FIELD_LAYOUT_FIELD] = fb->table_idx;
+		values [MONO_FIELD_LAYOUT_FIELD] = fb_table_idx;
 		values [MONO_FIELD_LAYOUT_OFFSET] = fb->offset;
 	}
 	if (fb->attrs & FIELD_ATTRIBUTE_LITERAL) {
@@ -719,7 +719,7 @@ mono_image_get_field_info (MonoReflectionFieldBuilder *fb, MonoDynamicImage *ass
 		table->rows ++;
 		alloc_table (table, table->rows);
 		values = table->values + table->rows * MONO_CONSTANT_SIZE;
-		values [MONO_CONSTANT_PARENT] = MONO_HASCONSTANT_FIEDDEF | (fb->table_idx << MONO_HASCONSTANT_BITS);
+		values [MONO_CONSTANT_PARENT] = MONO_HASCONSTANT_FIEDDEF | (fb_table_idx << MONO_HASCONSTANT_BITS);
 		values [MONO_CONSTANT_VALUE] = mono_dynimage_encode_constant (assembly, fb->def_value, &field_type);
 		values [MONO_CONSTANT_TYPE] = field_type;
 		values [MONO_CONSTANT_PADDING] = 0;
@@ -730,7 +730,7 @@ mono_image_get_field_info (MonoReflectionFieldBuilder *fb, MonoDynamicImage *ass
 		table->rows ++;
 		alloc_table (table, table->rows);
 		values = table->values + table->rows * MONO_FIELD_RVA_SIZE;
-		values [MONO_FIELD_RVA_FIELD] = fb->table_idx;
+		values [MONO_FIELD_RVA_FIELD] = fb_table_idx;
 		/*
 		 * We store it in the code section because it's simpler for now.
 		 */
@@ -747,7 +747,7 @@ mono_image_get_field_info (MonoReflectionFieldBuilder *fb, MonoDynamicImage *ass
 		table->rows ++;
 		alloc_table (table, table->rows);
 		values = table->values + table->rows * MONO_FIELD_MARSHAL_SIZE;
-		values [MONO_FIELD_MARSHAL_PARENT] = (fb->table_idx << MONO_HAS_FIELD_MARSHAL_BITS) | MONO_HAS_FIELD_MARSHAL_FIELDSREF;
+		values [MONO_FIELD_MARSHAL_PARENT] = (fb_table_idx << MONO_HAS_FIELD_MARSHAL_BITS) | MONO_HAS_FIELD_MARSHAL_FIELDSREF;
 		values [MONO_FIELD_MARSHAL_NATIVE_TYPE] = mono_dynimage_save_encode_marshal_blob (assembly, fb->marshal_info, error);
 		return_if_nok (error);
 	}
@@ -1029,6 +1029,12 @@ params_add_cattrs (MonoDynamicImage *assembly, MonoArray *pinfo, MonoError *erro
 	return TRUE;
 }
 
+static guint32
+field_builder_table_index (MonoDynamicImage* assembly, MonoReflectionFieldBuilder *fb)
+{
+	return GPOINTER_TO_UINT (g_hash_table_lookup (assembly->field_to_table_idx, fb->handle));
+}
+
 static gboolean
 type_add_cattrs (MonoDynamicImage *assembly, MonoReflectionTypeBuilder *tb, MonoError *error) {
 	int i;
@@ -1041,7 +1047,7 @@ type_add_cattrs (MonoDynamicImage *assembly, MonoReflectionTypeBuilder *tb, Mono
 		for (i = 0; i < tb->num_fields; ++i) {
 			MonoReflectionFieldBuilder* fb;
 			fb = mono_array_get (tb->fields, MonoReflectionFieldBuilder*, i);
-			if (!mono_image_add_cattrs (assembly, fb->table_idx, MONO_CUSTOM_ATTR_FIELDDEF, fb->cattrs, error))
+			if (!mono_image_add_cattrs (assembly, field_builder_table_index (assembly, fb), MONO_CUSTOM_ATTR_FIELDDEF, fb->cattrs, error))
 				return FALSE;
 		}
 	}
@@ -1113,7 +1119,7 @@ module_add_cattrs (MonoDynamicImage *assembly, MonoReflectionModuleBuilder *modu
 	if (moduleb->global_fields) {
 		for (i = 0; i < mono_array_length (moduleb->global_fields); ++i) {
 			MonoReflectionFieldBuilder *fb = mono_array_get (moduleb->global_fields, MonoReflectionFieldBuilder*, i);
-			if (!mono_image_add_cattrs (assembly, fb->table_idx, MONO_CUSTOM_ATTR_FIELDDEF, fb->cattrs, error))
+			if (!mono_image_add_cattrs (assembly, field_builder_table_index (assembly, fb), MONO_CUSTOM_ATTR_FIELDDEF, fb->cattrs, error))
 				return FALSE;
 		}
 	}

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3170,14 +3170,23 @@ mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides
 	*num_overrides = onum;
 }
 
-static guint32
-modulebuilder_next_field_idx (MonoReflectionModuleBuilder *mb, guint32 num_fields, MonoError *error)
+static gint32
+modulebuilder_get_next_table_index (MonoReflectionModuleBuilder *mb, gint32 table, gint32 num_fields, MonoError *error)
 {
 	mono_error_init (error);
 
-	guint32 first_field_idx = mb->next_field_idx;
-	mb->next_field_idx += num_fields;
-	return first_field_idx;
+	if (mb->table_indexes == NULL) {
+		MonoArray *arr = mono_array_new_checked (mono_object_domain (&mb->module.obj), mono_defaults.int_class, 64, error);
+		return_val_if_nok (error, 0);
+		for (int i = 0; i < 64; i++) {
+			mono_array_set (arr, int, i, 1);
+		}
+		MONO_OBJECT_SETREF (mb, table_indexes, arr);
+	}
+	gint32 index = mono_array_get (mb->table_indexes, gint32, table);
+	gint32 next_index = index + num_fields;
+	mono_array_set (mb->table_indexes, gint32, table, next_index);
+	return index;
 }
 
 /* This initializes the same data as mono_class_setup_fields () */
@@ -3202,8 +3211,14 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 		instance_size = sizeof (MonoObject);
 	}
 
+	gint32 first_idx = 0;
+	if (tb->num_fields > 0) {
+		first_idx = modulebuilder_get_next_table_index (tb->module, MONO_TABLE_FIELD, (gint32)tb->num_fields, error);
+		return_if_nok (error);
+	}
+
+	klass->field.first = first_idx - 1; /* Why do we subtract 1? because mono_class_create_from_typedef does it, too. */
 	klass->field.count = tb->num_fields;
-	klass->field.first = modulebuilder_next_field_idx (tb->module, tb->num_fields, error);
 
 	if (tb->class_size) {
 		packing_size = tb->packing_size;
@@ -3263,6 +3278,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 			klass->ext->field_def_values [i].data = (const char *)mono_image_alloc (image, len);
 			memcpy ((gpointer)klass->ext->field_def_values [i].data, p, len);
 		}
+		mono_dynamic_image_register_token (tb->module->dynamic_image, mono_metadata_make_token (MONO_TABLE_FIELD, first_idx + i), (MonoObject*)fb);
 	}
 
 	mono_class_layout_fields (klass, instance_size, packing_size, TRUE);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3170,6 +3170,16 @@ mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides
 	*num_overrides = onum;
 }
 
+static guint32
+modulebuilder_next_field_idx (MonoReflectionModuleBuilder *mb, guint32 num_fields, MonoError *error)
+{
+	mono_error_init (error);
+
+	guint32 first_field_idx = mb->next_field_idx;
+	mb->next_field_idx += num_fields;
+	return first_field_idx;
+}
+
 /* This initializes the same data as mono_class_setup_fields () */
 static void
 typebuilder_setup_fields (MonoClass *klass, MonoError *error)
@@ -3182,6 +3192,8 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 	int i, instance_size, packing_size = 0;
 	guint32 len, idx;
 
+	mono_error_init (error);
+
 	if (klass->parent) {
 		if (!klass->parent->size_inited)
 			mono_class_init (klass->parent);
@@ -3191,9 +3203,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 	}
 
 	klass->field.count = tb->num_fields;
-	klass->field.first = 0;
-
-	mono_error_init (error);
+	klass->field.first = modulebuilder_next_field_idx (tb->module, tb->num_fields, error);
 
 	if (tb->class_size) {
 		packing_size = tb->packing_size;


### PR DESCRIPTION
- Remove `System.Reflection.Emit.FieldBuilder:table_idx` field
  The field was used in two ways:
  1. as the temporary token returned by `MemberInfo.MetadataToken`
     property
  2. as a way for sre-save to record the field index in the dynamic assembly.
  
  For (1) we now use the value returned by
    `ModuleBuilder.GetToken(MemberInfo)` (ie a pseudotoken).
  
  For (2) we lookup the field index in the dynamic assembly hash that maps
  MonoClassField pointers to indices.
- Assign consecutive tokens to all fields in a class.
  
  Ensure that a token and a Module are enough to uniquely identify every
  MonoClassField.
  
  Because of how metadata is represented in Mono, the fields defined in a
  class must have consecutive tokens (because the MonoClass:field.first
  and and MonoClass:field.count are used to index into the
  MonoClass:fields array).
  
  When the class is created we bump the "next available field token" value
  in the ModuleBuilder.  Any FieldBuilder objects that are still alive
  after the type is created will use RuntimeResolve() to map from their
  pseudotoken to the real token.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=33208
