### PR TITLE
[sgen] Move the logic to determine whenever an ip is in a critical me…

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1115,7 +1115,7 @@ create_allocator (int atype, int tls_key, gboolean slowpath)
 static MonoMethod* alloc_method_cache [ATYPE_NUM];
 static MonoMethod* slowpath_alloc_method_cache [ATYPE_NUM];
 
-static G_GNUC_UNUSED gboolean
+gboolean
 mono_gc_is_critical_method (MonoMethod *method)
 {
 	int i;
@@ -1234,7 +1234,7 @@ mono_gc_get_write_barrier (void)
 
 #else
 
-static G_GNUC_UNUSED gboolean
+gboolean
 mono_gc_is_critical_method (MonoMethod *method)
 {
 	return FALSE;

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -360,6 +360,8 @@ guint mono_gc_get_vtable_bits (MonoClass *klass);
 
 void mono_gc_register_altstack (gpointer stack, gint32 stack_size, gpointer altstack, gint32 altstack_size);
 
+gboolean mono_gc_is_critical_method (MonoMethod *method);
+
 /* If set, print debugging messages around finalizers. */
 extern gboolean log_finalizers;
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1879,6 +1879,15 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, MonoError *er
 		if ((code = mono_aot_get_method_checked (domain, method, error))) {
 			MonoVTable *vtable;
 
+			if (mono_runtime_is_critical_method (method) || mono_gc_is_critical_method (method)) {
+				/*
+				 * The suspend code needs to be able to lookup these methods by ip in async context,
+				 * so preload their jit info.
+				 */
+				MonoJitInfo *ji = mono_jit_info_table_find (domain, code);
+				g_assert (ji);
+			}
+
 			/*
 			 * In llvm-only mode, method might be a shared method, so we can't initialize its class.
 			 * This is not a problem, since it will be initialized when the method is first

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -875,6 +875,9 @@ is_thread_in_critical_region (MonoThreadInfo *info)
 	if (stack_start < info->stack_start_limit || stack_start >= info->stack_end)
 		return TRUE;
 
+	if (threads_callbacks.ip_in_critical_region)
+		return threads_callbacks.ip_in_critical_region ((MonoDomain *) state->unwind_data [MONO_UNWIND_DATA_DOMAIN], (char *) MONO_CONTEXT_GET_IP (&state->ctx));
+
 	ji = mono_jit_info_table_find (
 		(MonoDomain *) state->unwind_data [MONO_UNWIND_DATA_DOMAIN],
 		(char *) MONO_CONTEXT_GET_IP (&state->ctx));

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -229,6 +229,7 @@ typedef struct {
 	void (*thread_detach)(THREAD_INFO_TYPE *info);
 	void (*thread_attach)(THREAD_INFO_TYPE *info);
 	gboolean (*mono_method_is_critical) (void *method);
+	gboolean (*ip_in_critical_region) (MonoDomain *domain, gpointer ip);
 	gboolean (*mono_thread_in_critical_region) (THREAD_INFO_TYPE *info);
 } MonoThreadInfoCallbacks;
 


### PR DESCRIPTION
…thod to sgen code. Avoid loading aot info because its not async safe.
