### PR TITLE
[corlib] Map SHA*Cng algorithms to SHA*Managed on monodroid

### DIFF
--- a/mcs/class/corlib/System.Security.Cryptography/CryptoConfig.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/CryptoConfig.cs
@@ -416,6 +416,15 @@ public partial class CryptoConfig {
 		unresolved_algorithms.Add (nameECDsa_2, defaultECDsa);
 		unresolved_algorithms.Add (nameECDsa_3, defaultECDsa);
 
+#if MONODROID
+		algorithms.Add (nameSHA1Cng, defaultSHA1);
+		algorithms.Add (nameSHA256Cng, defaultSHA256);
+		algorithms.Add (nameSHA256Provider, defaultSHA256);
+		algorithms.Add (nameSHA384Cng, defaultSHA384);
+		algorithms.Add (nameSHA384Provider, defaultSHA384);
+		algorithms.Add (nameSHA512Cng, defaultSHA512);
+		algorithms.Add (nameSHA512Provider, defaultSHA512);
+#else
 		unresolved_algorithms.Add (nameSHA1Cng, defaultSHA1Cng);
 		unresolved_algorithms.Add (nameSHA256Cng, defaultSHA256Cng);
 		unresolved_algorithms.Add (nameSHA256Provider, defaultSHA256Provider);
@@ -423,6 +432,7 @@ public partial class CryptoConfig {
 		unresolved_algorithms.Add (nameSHA384Provider, defaultSHA384Provider);
 		unresolved_algorithms.Add (nameSHA512Cng, defaultSHA512Cng);
 		unresolved_algorithms.Add (nameSHA512Provider, defaultSHA512Provider);
+#endif
 		Dictionary<string,string> oid = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
 		// comments here are to match with MS implementation (but not with doc)

--- a/mcs/class/corlib/Test/System.Security.Cryptography/SignatureDescriptionTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/SignatureDescriptionTest.cs
@@ -310,7 +310,7 @@ public class SignatureDescriptionTest {
 	public void RSASignatureDescription ()
 	{
 // TODO: this would be cleaner with NUnit TestCase'es but they're NUnit 2.5+ :(
-#if FULL_AOT_RUNTIME || MONOTOUCH
+#if FULL_AOT_RUNTIME || MONOTOUCH || MONODROID
 		RSASignatureDescriptionCore ("http://www.w3.org/2000/09/xmldsig#rsa-sha1", "System.Security.Cryptography.SHA1Cng", "System.Security.Cryptography.SHA1CryptoServiceProvider");
 		RSASignatureDescriptionCore ("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", "System.Security.Cryptography.SHA256Cng", "System.Security.Cryptography.SHA256Managed");
 		RSASignatureDescriptionCore ("http://www.w3.org/2001/04/xmldsig-more#rsa-sha384", "System.Security.Cryptography.SHA384Cng", "System.Security.Cryptography.SHA384Managed");


### PR DESCRIPTION
This is a followup to e9205142b29a81bb1225ae40500d2dd32ddc7e63.
Monodroid is missing the Cng and CryptoServiceProvider variants of the SHA algorithms as well so we need to map to the Managed variants there too, like on monotouch.