### PR TITLE
[stw] Fix possible race condition in sgen STW

### DIFF
--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -302,9 +302,10 @@ sgen_unified_suspend_stop_world (void)
 			}
 		} FOREACH_THREAD_END
 
+		mono_threads_wait_pending_operations ();
+
 		if (restart_counter == 0)
 			break;
-		mono_threads_wait_pending_operations ();
 
 		if (sleep_duration < 0) {
 			mono_thread_info_yield ();


### PR DESCRIPTION
If a thread fail to be resumed, and there is no other thread to restart, then we are not going to wait for the pending resume operation.