### PR TITLE
[arm] Fix MONO_CONTEXT_GET_CURRENT (), the inline assembly block was …

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -264,15 +264,15 @@ typedef struct {
 		"push {r0}\n"				\
 		"push {r1}\n"				\
 		"mov r0, %0\n"				\
-		"ldr r1, [sp, #4]\n"			\
-		"str r1, [r0]!\n"			\
-		"ldr r1, [sp, #0]\n"			\
-		"str r1, [r0]!\n"			\
+		"ldr r1, [sp, #4]\n"   		\
+		"str r1, [r0], #4\n"   		\
+		"ldr r1, [sp, #0]\n"	   	\
+		"str r1, [r0], #4\n"	   	\
 		"stmia r0!, {r2-r12}\n"		\
-		"str sp, [r0]!\n"			\
-		"str lr, [r0]!\n"			\
+		"str sp, [r0], #4\n"		\
+		"str lr, [r0], #4\n"		\
 		"mov r1, pc\n"				\
-		"str r1, [r0]!\n"			\
+		"str r1, [r0], #4\n"		\
 		"pop {r1}\n"				\
 		"pop {r0}\n"				\
 		:							\


### PR DESCRIPTION
…using pre-increment addressing instead of post increment.