### PR TITLE
[C9][custom attr] Add low-level metadata iterator for assembly custom attributes

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1980,14 +1980,7 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 	 * this image and we won't be able to look for a different
 	 * candidate. */
 
-	if (!refonly && strcmp (ass->aname.name, "mscorlib") != 0) {
-		/* Don't check for reference assmebly attribute for
-		 * corlib here because if corlib isn't loaded yet,
-		 * it's too early to set up the
-		 * ReferenceAssemblyAttribute class.  We check that
-		 * we're not running with a reference corlib in
-		 * mono_init_internal().
-		 */
+	if (!refonly) {
 		MonoError refasm_error;
 		if (mono_assembly_has_reference_assembly_attribute (ass, &refasm_error)) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Image for assembly '%s' (%s) has ReferenceAssemblyAttribute, skipping", ass->aname.name, image->name);

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -37,6 +37,7 @@
 #include <mono/metadata/reflection.h>
 #include <mono/metadata/coree.h>
 #include <mono/metadata/cil-coff.h>
+#include <mono/metadata/tokentype.h>
 #include <mono/utils/mono-io-portability.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-os-mutex.h>
@@ -1823,26 +1824,77 @@ mono_assembly_load_friends (MonoAssembly* ass)
 gboolean
 mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error)
 {
+	MonoImage *image;
+	guint32 mtoken, i;
+	guint32 cols [MONO_CUSTOM_ATTR_SIZE];
+	MonoTableInfo *ca;
+	guint32 idx;
+
 	mono_error_init (error);
 
-/* TODO: mono_custom_attrs_from_assembly_checked returns NULL if a
- * single assembly is missing.  The custom attr we want is from
- * corlib, however, so we need a more robust version that doesn't care
- * about missing attributes.
- */
-#if 1
-	MonoCustomAttrInfo *attrs = mono_custom_attrs_from_assembly_checked (assembly, TRUE, error);
-	return_val_if_nok (error, FALSE);
-	if (!attrs)
+	/*
+	 * This might be called during assembly loading, so do everything using the low-level
+	 * metadata APIs.
+	 */
+
+	image = assembly->image;
+	idx = 1; /* there is only one assembly */
+	idx <<= MONO_CUSTOM_ATTR_BITS;
+	idx |= MONO_CUSTOM_ATTR_ASSEMBLY;
+
+	/* Inlined from mono_custom_attrs_from_index_checked () */
+	ca = &image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
+	i = mono_metadata_custom_attrs_from_index (image, idx);
+	if (!i)
 		return FALSE;
-	MonoClass *ref_asm_class = mono_class_try_get_reference_assembly_class ();
-	g_assert (ref_asm_class != NULL && ref_asm_class != mono_defaults.object_class && !strcmp(ref_asm_class->name, "ReferenceAssemblyAttribute") );
-	gboolean result = mono_custom_attrs_has_attr (attrs, ref_asm_class);
-	mono_custom_attrs_free (attrs);
-	return result;
-#else
+	i --;
+	while (i < ca->rows) {
+		if (mono_metadata_decode_row_col (ca, i, MONO_CUSTOM_ATTR_PARENT) != idx)
+			break;
+		mono_metadata_decode_row (ca, i, cols, MONO_CUSTOM_ATTR_SIZE);
+		i ++;
+		mtoken = cols [MONO_CUSTOM_ATTR_TYPE] >> MONO_CUSTOM_ATTR_TYPE_BITS;
+		if ((cols [MONO_CUSTOM_ATTR_TYPE] & MONO_CUSTOM_ATTR_TYPE_MASK) != MONO_CUSTOM_ATTR_TYPE_MEMBERREF)
+			continue;
+		mtoken |= MONO_TOKEN_MEMBER_REF;
+		{
+			/* method_from_memberref () */
+			guint32 cols[6];
+			guint32 nindex, class_index;
+
+			int idx = mono_metadata_token_index (mtoken);
+
+			mono_metadata_decode_row (&image->tables [MONO_TABLE_MEMBERREF], idx-1, cols, 3);
+			nindex = cols [MONO_MEMBERREF_CLASS] >> MONO_MEMBERREF_PARENT_BITS;
+			class_index = cols [MONO_MEMBERREF_CLASS] & MONO_MEMBERREF_PARENT_MASK;
+			if (class_index == MONO_MEMBERREF_PARENT_TYPEREF) {
+				guint32 type_token = MONO_TOKEN_TYPE_REF | nindex;
+				/* mono_class_from_typeref_checked () */
+				{
+					guint32 cols [MONO_TYPEREF_SIZE];
+					const char *name, *nspace;
+					MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
+					guint32 idx;
+
+					mono_metadata_decode_row (t, (type_token&0xffffff)-1, cols, MONO_TYPEREF_SIZE);
+
+					name = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAME]);
+					nspace = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAMESPACE]);
+					idx = cols [MONO_TYPEREF_SCOPE] >> MONO_RESOLUTION_SCOPE_BITS;
+
+					if (!strcmp (name, "ReferenceAssemblyAttribute") && !strcmp (nspace, "System.Runtime.CompilerServices")) {
+						if ((cols [MONO_TYPEREF_SCOPE] & MONO_RESOLUTION_SCOPE_MASK) == MONO_RESOLUTION_SCOPE_ASSEMBLYREF) {
+							MonoAssemblyName aname;
+							mono_assembly_get_assemblyref (image, idx - 1, &aname);
+							if (!strcmp (aname.name, "System.Runtime") || !strcmp (aname.name, "mscorlib"))
+								return TRUE;
+						}
+					}
+				}
+			}
+		}
+	}
 	return FALSE;
-#endif
 }
 
 /**
@@ -1964,26 +2016,6 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 		}
 	}
 
-	mono_assemblies_lock ();
-
-	if (image->assembly) {
-		/* 
-		 * This means another thread has already loaded the assembly, but not yet
-		 * called the load hooks so the search hook can't find the assembly.
-		 */
-		mono_assemblies_unlock ();
-		ass2 = image->assembly;
-		g_free (ass);
-		g_free (base_dir);
-		mono_image_close (image);
-		*status = MONO_IMAGE_OK;
-		return ass2;
-	}
-
-	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Prepared to set up assembly '%s' (%s)", ass->aname.name, image->name);
-
-	image->assembly = ass;
-
 	/* We need to check for ReferenceAssmeblyAttribute before we
 	 * mark the assembly as loaded and before we fire the load
 	 * hook. Otherwise mono_domain_fire_assembly_load () in
@@ -2001,7 +2033,6 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 		 */
 		MonoError refasm_error;
 		if (mono_assembly_has_reference_assembly_attribute (ass, &refasm_error)) {
-			mono_assemblies_unlock ();
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Image for assembly '%s' (%s) has ReferenceAssemblyAttribute, skipping", ass->aname.name, image->name);
 			g_free (ass);
 			g_free (base_dir);
@@ -2011,6 +2042,26 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 		}
 		mono_error_cleanup (&refasm_error);
 	}
+
+	mono_assemblies_lock ();
+
+	if (image->assembly) {
+		/*
+		 * This means another thread has already loaded the assembly, but not yet
+		 * called the load hooks so the search hook can't find the assembly.
+		 */
+		mono_assemblies_unlock ();
+		ass2 = image->assembly;
+		g_free (ass);
+		g_free (base_dir);
+		mono_image_close (image);
+		*status = MONO_IMAGE_OK;
+		return ass2;
+	}
+
+	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Prepared to set up assembly '%s' (%s)", ass->aname.name, image->name);
+
+	image->assembly = ass;
 
 	loaded_assemblies = g_list_prepend (loaded_assemblies, ass);
 	mono_assemblies_unlock ();

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1815,7 +1815,7 @@ struct HasReferenceAssemblyAttributeIterData {
 };
 
 static gboolean
-has_reference_assembly_attribute_iterator (MonoImage *image, guint32 typeref_scope_token, const char *nspace, const char *name, guint32 memberref_token, gpointer user_data)
+has_reference_assembly_attribute_iterator (MonoImage *image, guint32 typeref_scope_token, const char *nspace, const char *name, guint32 method_token, gpointer user_data)
 {
 	gboolean stop_scanning = FALSE;
 	struct HasReferenceAssemblyAttributeIterData *iter_data = (struct HasReferenceAssemblyAttributeIterData*)user_data;

--- a/mono/metadata/custom-attrs-internals.h
+++ b/mono/metadata/custom-attrs-internals.h
@@ -7,7 +7,7 @@
 MonoCustomAttrInfo*
 mono_custom_attrs_from_builders (MonoImage *alloc_img, MonoImage *image, MonoArray *cattrs);
 
-typedef gboolean (*MonoAssemblyMetadataCustomAttrIterFunc) (MonoImage *image, guint32 typeref_scope_token, const gchar* nspace, const gchar* name, guint32 methodref_token, gpointer user_data);
+typedef gboolean (*MonoAssemblyMetadataCustomAttrIterFunc) (MonoImage *image, guint32 typeref_scope_token, const gchar* nspace, const gchar* name, guint32 method_token, gpointer user_data);
 
 void
 mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);

--- a/mono/metadata/custom-attrs-internals.h
+++ b/mono/metadata/custom-attrs-internals.h
@@ -7,4 +7,9 @@
 MonoCustomAttrInfo*
 mono_custom_attrs_from_builders (MonoImage *alloc_img, MonoImage *image, MonoArray *cattrs);
 
+typedef gboolean (*MonoAssemblyMetadataCustomAttrIterFunc) (MonoImage *image, guint32 typeref_scope_token, const gchar* nspace, const gchar* name, guint32 methodref_token, gpointer user_data);
+
+void
+mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
+
 #endif  /* __MONO_METADATA_REFLECTION_CUSTOM_ATTRS_INTERNALS_H__ */

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1727,6 +1727,111 @@ mono_reflection_get_custom_attrs_data_checked (MonoObject *obj, MonoError *error
 	return result;
 }
 
+static gboolean
+custom_attr_class_name_from_methoddef (MonoImage *image, guint32 method_token, const gchar **nspace, const gchar **class_name)
+{
+	/* mono_get_method_from_token () */
+	g_assert (mono_metadata_token_table (method_token) == MONO_TABLE_METHOD);
+	guint32 type_token = mono_metadata_typedef_from_method (image, method_token);
+	if (!type_token) {
+		/* Bad method token (could not find corresponding typedef) */
+		return FALSE;
+	}
+	type_token |= MONO_TOKEN_TYPE_DEF;
+	{
+		/* mono_class_create_from_typedef () */
+		MonoTableInfo *tt = &image->tables [MONO_TABLE_TYPEDEF];
+		guint32 cols [MONO_TYPEDEF_SIZE];
+		guint tidx = mono_metadata_token_index (type_token);
+
+		if (mono_metadata_token_table (type_token) != MONO_TABLE_TYPEDEF || tidx > tt->rows) {
+			/* "Invalid typedef token %x", type_token */
+			return FALSE;
+		}
+
+		mono_metadata_decode_row (tt, tidx - 1, cols, MONO_TYPEDEF_SIZE);
+
+		if (class_name)
+			*class_name = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAME]);
+		if (nspace)
+			*nspace = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAMESPACE]);
+		return TRUE;
+	}
+}
+
+
+/**
+ * custom_attr_class_name_from_method_token:
+ * @image: The MonoImage
+ * @method_token: a token for a custom attr constructor in @image
+ * @assembly_token: out argment set to the assembly ref token of the custom attr
+ * @nspace: out argument set to namespace (a string in the string heap of @image) of the custom attr
+ * @class_name: out argument set to the class name of the custom attr.
+ *
+ * Given an @image and a @method_token (which is assumed to be a
+ * constructor), fills in the out arguments with the assembly ref (if
+ * a methodref) and the namespace and class name of the custom
+ * attribute.
+ *
+ * Returns: TRUE on success, FALSE otherwise.
+ *
+ * LOCKING: does not take locks
+ */
+static gboolean
+custom_attr_class_name_from_method_token (MonoImage *image, guint32 method_token, guint32 *assembly_token, const gchar **nspace, const gchar **class_name)
+{
+	/* This only works with method tokens constructed from a
+	 * custom attr token, which can only be methoddef or
+	 * memberref */
+	g_assert (mono_metadata_token_table (method_token) == MONO_TABLE_METHOD
+		  || mono_metadata_token_table  (method_token) == MONO_TABLE_MEMBERREF);
+
+	if (mono_metadata_token_table (method_token) == MONO_TABLE_MEMBERREF) {
+		/* method_from_memberref () */
+		guint32 cols[6];
+		guint32 nindex, class_index;
+
+		int idx = mono_metadata_token_index (method_token);
+
+		mono_metadata_decode_row (&image->tables [MONO_TABLE_MEMBERREF], idx-1, cols, 3);
+		nindex = cols [MONO_MEMBERREF_CLASS] >> MONO_MEMBERREF_PARENT_BITS;
+		class_index = cols [MONO_MEMBERREF_CLASS] & MONO_MEMBERREF_PARENT_MASK;
+		if (class_index == MONO_MEMBERREF_PARENT_TYPEREF) {
+			guint32 type_token = MONO_TOKEN_TYPE_REF | nindex;
+			/* mono_class_from_typeref_checked () */
+			{
+				guint32 cols [MONO_TYPEREF_SIZE];
+				MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
+
+				mono_metadata_decode_row (t, (type_token&0xffffff)-1, cols, MONO_TYPEREF_SIZE);
+
+				if (class_name)
+					*class_name = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAME]);
+				if (nspace)
+					*nspace = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAMESPACE]);
+				if (assembly_token)
+					*assembly_token = cols [MONO_TYPEREF_SCOPE];
+				return TRUE;
+			}
+		} else if (class_index == MONO_MEMBERREF_PARENT_METHODDEF) {
+			guint32 methoddef_token = MONO_TOKEN_METHOD_DEF | nindex;
+			if (assembly_token)
+				*assembly_token = 0;
+			return custom_attr_class_name_from_methoddef (image, methoddef_token, nspace, class_name);
+		} else {
+			/* Attributes can't be generic, so it won't be
+			 * a typespec, and they're always
+			 * constructors, so it won't be a moduleref */
+			g_assert_not_reached ();
+		}
+	} else {
+		/* must be MONO_TABLE_METHOD */
+		if (assembly_token)
+			*assembly_token = 0;
+		return custom_attr_class_name_from_methoddef (image, method_token, nspace, class_name);
+	}
+}
+
 /**
  * mono_assembly_metadata_foreach_custom_attr:
  * @assembly: the assembly to iterate over
@@ -1752,6 +1857,7 @@ mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssembly
 	 */
 
 	image = assembly->image;
+	g_assert (!image_is_dynamic (image));
 	idx = 1; /* there is only one assembly */
 	idx <<= MONO_CUSTOM_ATTR_BITS;
 	idx |= MONO_CUSTOM_ATTR_ASSEMBLY;
@@ -1769,35 +1875,25 @@ mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssembly
 		mono_metadata_decode_row (ca, i, cols, MONO_CUSTOM_ATTR_SIZE);
 		i ++;
 		mtoken = cols [MONO_CUSTOM_ATTR_TYPE] >> MONO_CUSTOM_ATTR_TYPE_BITS;
-		if ((cols [MONO_CUSTOM_ATTR_TYPE] & MONO_CUSTOM_ATTR_TYPE_MASK) != MONO_CUSTOM_ATTR_TYPE_MEMBERREF)
+		switch (cols [MONO_CUSTOM_ATTR_TYPE] & MONO_CUSTOM_ATTR_TYPE_MASK) {
+		case MONO_CUSTOM_ATTR_TYPE_METHODDEF:
+			mtoken |= MONO_TOKEN_METHOD_DEF;
+			break;
+		case MONO_CUSTOM_ATTR_TYPE_MEMBERREF:
+			mtoken |= MONO_TOKEN_MEMBER_REF;
+			break;
+		default:
+			g_warning ("Unknown table for custom attr type %08x", cols [MONO_CUSTOM_ATTR_TYPE]);
 			continue;
-		mtoken |= MONO_TOKEN_MEMBER_REF;
-		{
-			/* method_from_memberref () */
-			guint32 cols[6];
-			guint32 nindex, class_index;
-
-			int idx = mono_metadata_token_index (mtoken);
-
-			mono_metadata_decode_row (&image->tables [MONO_TABLE_MEMBERREF], idx-1, cols, 3);
-			nindex = cols [MONO_MEMBERREF_CLASS] >> MONO_MEMBERREF_PARENT_BITS;
-			class_index = cols [MONO_MEMBERREF_CLASS] & MONO_MEMBERREF_PARENT_MASK;
-			if (class_index == MONO_MEMBERREF_PARENT_TYPEREF) {
-				guint32 type_token = MONO_TOKEN_TYPE_REF | nindex;
-				/* mono_class_from_typeref_checked () */
-				{
-					guint32 cols [MONO_TYPEREF_SIZE];
-					const char *name, *nspace;
-					MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
-
-					mono_metadata_decode_row (t, (type_token&0xffffff)-1, cols, MONO_TYPEREF_SIZE);
-
-					name = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAME]);
-					nspace = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAMESPACE]);
-
-					stop_iterating = func (image, cols [MONO_TYPEREF_SCOPE], nspace, name, mtoken, user_data);
-				}
-			}
 		}
+
+		const char *nspace = NULL;
+		const char *name = NULL;
+		guint32 assembly_token = 0;
+
+		if (!custom_attr_class_name_from_method_token (image, mtoken, &assembly_token, &nspace, &name))
+			continue;
+
+		stop_iterating = func (image, assembly_token, nspace, name, mtoken, user_data);
 	}
 }

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -12,6 +12,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 #include <config.h>
+#include "mono/metadata/assembly.h"
 #include "mono/metadata/gc-internals.h"
 #include "mono/metadata/mono-endian.h"
 #include "mono/metadata/object-internals.h"
@@ -1724,4 +1725,79 @@ mono_reflection_get_custom_attrs_data_checked (MonoObject *obj, MonoError *error
 		result = mono_array_new_checked (mono_domain_get (), mono_defaults.customattribute_data_class, 0, error);
 
 	return result;
+}
+
+/**
+ * mono_assembly_metadata_foreach_custom_attr:
+ * @assembly: the assembly to iterate over
+ * @func: the function to call for each custom attribute
+ * @user_data: passed to @func
+ *
+ * Calls @func for each custom attribute type on the given assembly until @func returns TRUE.
+ * Everything is done using low-level metadata APIs, so it is safe to use during assembly loading.
+ *
+ */
+void
+mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data)
+{
+	MonoImage *image;
+	guint32 mtoken, i;
+	guint32 cols [MONO_CUSTOM_ATTR_SIZE];
+	MonoTableInfo *ca;
+	guint32 idx;
+
+	/*
+	 * This might be called during assembly loading, so do everything using the low-level
+	 * metadata APIs.
+	 */
+
+	image = assembly->image;
+	idx = 1; /* there is only one assembly */
+	idx <<= MONO_CUSTOM_ATTR_BITS;
+	idx |= MONO_CUSTOM_ATTR_ASSEMBLY;
+
+	/* Inlined from mono_custom_attrs_from_index_checked () */
+	ca = &image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
+	i = mono_metadata_custom_attrs_from_index (image, idx);
+	if (!i)
+		return;
+	i --;
+	gboolean stop_iterating = FALSE;
+	while (!stop_iterating && i < ca->rows) {
+		if (mono_metadata_decode_row_col (ca, i, MONO_CUSTOM_ATTR_PARENT) != idx)
+			break;
+		mono_metadata_decode_row (ca, i, cols, MONO_CUSTOM_ATTR_SIZE);
+		i ++;
+		mtoken = cols [MONO_CUSTOM_ATTR_TYPE] >> MONO_CUSTOM_ATTR_TYPE_BITS;
+		if ((cols [MONO_CUSTOM_ATTR_TYPE] & MONO_CUSTOM_ATTR_TYPE_MASK) != MONO_CUSTOM_ATTR_TYPE_MEMBERREF)
+			continue;
+		mtoken |= MONO_TOKEN_MEMBER_REF;
+		{
+			/* method_from_memberref () */
+			guint32 cols[6];
+			guint32 nindex, class_index;
+
+			int idx = mono_metadata_token_index (mtoken);
+
+			mono_metadata_decode_row (&image->tables [MONO_TABLE_MEMBERREF], idx-1, cols, 3);
+			nindex = cols [MONO_MEMBERREF_CLASS] >> MONO_MEMBERREF_PARENT_BITS;
+			class_index = cols [MONO_MEMBERREF_CLASS] & MONO_MEMBERREF_PARENT_MASK;
+			if (class_index == MONO_MEMBERREF_PARENT_TYPEREF) {
+				guint32 type_token = MONO_TOKEN_TYPE_REF | nindex;
+				/* mono_class_from_typeref_checked () */
+				{
+					guint32 cols [MONO_TYPEREF_SIZE];
+					const char *name, *nspace;
+					MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
+
+					mono_metadata_decode_row (t, (type_token&0xffffff)-1, cols, MONO_TYPEREF_SIZE);
+
+					name = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAME]);
+					nspace = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAMESPACE]);
+
+					stop_iterating = func (image, cols [MONO_TYPEREF_SCOPE], nspace, name, mtoken, user_data);
+				}
+			}
+		}
+	}
 }

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -808,16 +808,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_profiler_appdomain_name (domain, domain->friendly_name);
 
-	/* Have to do this quite late so that we at least have System.Object */
-	MonoError custom_attr_error;
-	if (mono_assembly_has_reference_assembly_attribute (ass, &custom_attr_error)) {
-		char *corlib_file = g_build_filename (mono_assembly_getrootdir (), "mono", current_runtime->framework_version, "mscorlib.dll", NULL);
-		g_print ("Could not load file or assembly %s. Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context.", corlib_file);
-		g_free (corlib_file);
-		exit (1);
-	}
-	mono_error_assert_ok (&custom_attr_error);
-
 	return domain;
 }
 


### PR DESCRIPTION
This is a followup for https://bugzilla.xamarin.com/show_bug.cgi?id=42584 (for `mono-4.8.0-branch`) that fixes a deadlock in assembly loading.  (see `mono_assembly_load_from_full`)

This is #3863 backported to `mono-4.8.0-branch`