### PR TITLE
[mcs] Accept and ignore command line args supported by csc that we don't

### DIFF
--- a/mcs/mcs/settings.cs
+++ b/mcs/mcs/settings.cs
@@ -1242,6 +1242,8 @@ namespace Mono.CSharp {
 			case "/appconfig":
 			case "/baseaddress":
 			case "/deterministic":
+			case "/deterministic+":
+			case "/deterministic-":
 			case "/errorendlocation":
 			case "/errorlog":
 			case "/features":


### PR DESCRIPTION
.. support:

	/deterministic+
	/deterministic-