### PR TITLE
[runtime] Fix Mach ARM build.

### DIFF
--- a/mono/utils/mach-support-arm.c
+++ b/mono/utils/mach-support-arm.c
@@ -84,7 +84,7 @@ mono_mach_arch_mcontext_to_thread_state (void *context, thread_state_t state)
 }
 
 void
-mono_mach_arch_thread_state_to_mono_context (thread_state_t state, MonoContext *context)
+mono_mach_arch_thread_states_to_mono_context (thread_state_t state, thread_state_t fpstate, MonoContext *context)
 {
 	int i;
 	arm_thread_state_t *arch_state = (arm_thread_state_t *) state;
@@ -101,6 +101,12 @@ int
 mono_mach_arch_get_thread_state_size ()
 {
 	return sizeof (arm_thread_state_t);
+}
+
+int
+mono_mach_arch_get_thread_fpstate_size ()
+{
+	g_assert_not_reached ();
 }
 
 kern_return_t

--- a/mono/utils/mach-support-arm64.c
+++ b/mono/utils/mach-support-arm64.c
@@ -66,7 +66,7 @@ mono_mach_arch_get_mcontext_size ()
 }
 
 void
-mono_mach_arch_thread_state_to_mcontext (thread_state_t state, void *context)
+mono_mach_arch_thread_states_to_mcontext (thread_state_t state, thread_state_t fpstate, void *context)
 {
 	arm_unified_thread_state_t *arch_state = (arm_unified_thread_state_t *) state;
 	struct __darwin_mcontext64 *ctx = (struct __darwin_mcontext64 *) context;
@@ -75,7 +75,7 @@ mono_mach_arch_thread_state_to_mcontext (thread_state_t state, void *context)
 }
 
 void
-mono_mach_arch_mcontext_to_thread_state (void *context, thread_state_t state)
+mono_mach_arch_mcontext_to_thread_states (void *context, thread_state_t state, thread_state_t fpstate)
 {
 	arm_unified_thread_state_t *arch_state = (arm_unified_thread_state_t *) state;
 	struct __darwin_mcontext64 *ctx = (struct __darwin_mcontext64 *) context;
@@ -84,7 +84,7 @@ mono_mach_arch_mcontext_to_thread_state (void *context, thread_state_t state)
 }
 
 void
-mono_mach_arch_thread_state_to_mono_context (thread_state_t state, MonoContext *context)
+mono_mach_arch_thread_states_to_mono_context (thread_state_t state, thread_state_t fpstate, MonoContext *context)
 {
 	int i;
 	arm_unified_thread_state_t *arch_state = (arm_unified_thread_state_t *) state;
@@ -103,8 +103,14 @@ mono_mach_arch_get_thread_state_size ()
 	return sizeof (arm_unified_thread_state_t);
 }
 
+int
+mono_mach_arch_get_thread_fpstate_size ()
+{
+	g_assert_not_reached ();
+}
+
 kern_return_t
-mono_mach_arch_get_thread_state (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count)
+mono_mach_arch_get_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count, thread_state_t fpstate, mach_msg_type_number_t *fpcount)
 {
 	arm_unified_thread_state_t *arch_state = (arm_unified_thread_state_t *) state;
 	kern_return_t ret;
@@ -116,7 +122,7 @@ mono_mach_arch_get_thread_state (thread_port_t thread, thread_state_t state, mac
 }
 
 kern_return_t
-mono_mach_arch_set_thread_state (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count)
+mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count, thread_state_t fpstate, mach_msg_type_number_t fpcount)
 {
 	return thread_set_state (thread, ARM_UNIFIED_THREAD_STATE, state, count);
 }

--- a/mono/utils/mach-support-unknown.c
+++ b/mono/utils/mach-support-unknown.c
@@ -35,19 +35,19 @@ mono_mach_arch_get_mcontext_size ()
 }
 
 void
-mono_mach_arch_thread_state_to_mcontext (thread_state_t state, void *context)
+mono_mach_arch_thread_states_to_mcontext (thread_state_t state, void *context)
 {
 	g_assert_not_reached ();
 }
 
 void
-mono_mach_arch_mcontext_to_thread_state (void *context, thread_state_t state)
+mono_mach_arch_mcontext_to_thread_states (void *context, thread_state_t state, thread_state_t fpstate)
 {
 	g_assert_not_reached ();
 }
 
 void
-mono_mach_arch_thread_state_to_mono_context (thread_state_t state, MonoContext *context)
+mono_mach_arch_thread_states_to_mono_context (thread_state_t state, thread_state_t fpstate, MonoContext *context)
 {
 	g_assert_not_reached ();
 }
@@ -58,14 +58,20 @@ mono_mach_arch_get_thread_state_size ()
 	g_assert_not_reached ();
 }
 
-kern_return_t
-mono_mach_arch_get_thread_state (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count)
+int
+mono_mach_arch_get_thread_fpstate_size ()
 {
 	g_assert_not_reached ();
 }
 
 kern_return_t
-mono_mach_arch_set_thread_state (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count)
+mono_mach_arch_get_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count, thread_state_t fpstate, mach_msg_type_number_t *fpcount)
+{
+	g_assert_not_reached ();
+}
+
+kern_return_t
+mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count, thread_state_t fpstate, mach_msg_type_number_t fpcount)
 {
 	g_assert_not_reached ();	
 }

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -405,7 +405,7 @@ typedef struct {
 	thread_port_t self = mach_thread_self ();	\
 	kern_return_t ret = thread_get_state (self, state_flavor, (thread_state_t) &thread_state, &state_count);	\
 	g_assert (ret == 0);	\
-	mono_mach_arch_thread_state_to_mono_context ((thread_state_t)&thread_state, &ctx); \
+	mono_mach_arch_thread_states_to_mono_context ((thread_state_t)&thread_state, (thread_state_t)NULL, &ctx); \
 	mach_port_deallocate (current_task (), self);	\
 } while (0);
 


### PR DESCRIPTION
#3764 broke maccore because a function was renamed. Currently the fpstate is not used on ARM.