### PR TITLE
[threads] Use MonoOSEvent for Thread.Suspend/Resume

### DIFF
--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -93,6 +93,7 @@ namespace System.Threading {
 		private IntPtr abort_protected_block_count;
 		private int priority = (int) ThreadPriority.Normal;
 		private IntPtr owned_mutex;
+		private IntPtr suspended_event;
 		/* 
 		 * These fields are used to avoid having to increment corlib versions
 		 * when a new field is added to the unmanaged MonoThread structure.

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -57,7 +57,7 @@ namespace System {
 		 * of icalls, do not require an increment.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 161;
+		private const int mono_corlib_version = 162;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -84,7 +84,7 @@
  * Changes which are already detected at runtime, like the addition
  * of icalls, do not require an increment.
  */
-#define MONO_CORLIB_VERSION 161
+#define MONO_CORLIB_VERSION 162
 
 typedef struct
 {

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -383,6 +383,7 @@ struct _MonoInternalThread {
 	gsize abort_protected_block_count;
 	gint32 priority;
 	GPtrArray *owned_mutexes;
+	MonoOSEvent *suspended;
 	/* 
 	 * These fields are used to avoid having to increment corlib versions
 	 * when a new field is added to this structure.

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -539,22 +539,18 @@ set_current_thread_for_domain (MonoDomain *domain, MonoInternalThread *thread, M
 }
 
 static MonoThread*
-create_thread_object (MonoDomain *domain)
-{
-	MonoError error;
-	MonoVTable *vt = mono_class_vtable (domain, mono_defaults.thread_class);
-	MonoThread *t = (MonoThread*)mono_object_new_mature (vt, &error);
-	/* only possible failure mode is OOM, from which we don't expect to recover. */
-	mono_error_assert_ok (&error);
-	return t;
-}
-
-static MonoThread*
-new_thread_with_internal (MonoDomain *domain, MonoInternalThread *internal)
+create_thread_object (MonoDomain *domain, MonoInternalThread *internal)
 {
 	MonoThread *thread;
+	MonoVTable *vtable;
+	MonoError error;
 
-	thread = create_thread_object (domain);
+	vtable = mono_class_vtable (domain, mono_defaults.thread_class);
+	g_assert (vtable);
+
+	thread = (MonoThread*)mono_object_new_mature (vtable, &error);
+	/* only possible failure mode is OOM, from which we don't expect to recover. */
+	mono_error_assert_ok (&error);
 
 	MONO_OBJECT_SETREF (thread, internal_thread, internal);
 
@@ -562,7 +558,7 @@ new_thread_with_internal (MonoDomain *domain, MonoInternalThread *internal)
 }
 
 static MonoInternalThread*
-create_internal_thread (void)
+create_internal_thread_object (void)
 {
 	MonoError error;
 	MonoInternalThread *thread;
@@ -731,7 +727,7 @@ mono_thread_attach_internal (MonoThread *thread, gboolean force_attach, gboolean
 
 	g_assert (!internal->root_domain_thread);
 	if (domain != root_domain)
-		MONO_OBJECT_SETREF (internal, root_domain_thread, new_thread_with_internal (root_domain, internal));
+		MONO_OBJECT_SETREF (internal, root_domain_thread, create_thread_object (root_domain, internal));
 	else
 		MONO_OBJECT_SETREF (internal, root_domain_thread, thread);
 
@@ -1030,11 +1026,9 @@ mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, gb
 
 	mono_error_init (error);
 
-	thread = create_thread_object (domain);
+	internal = create_internal_thread_object ();
 
-	internal = create_internal_thread ();
-
-	MONO_OBJECT_SETREF (thread, internal_thread, internal);
+	thread = create_thread_object (domain, internal);
 
 	LOCK_THREAD (internal);
 
@@ -1089,9 +1083,9 @@ mono_thread_attach_full (MonoDomain *domain, gboolean force_attach)
 
 	tid=mono_native_thread_id_get ();
 
-	internal = create_internal_thread ();
+	internal = create_internal_thread_object ();
 
-	thread = new_thread_with_internal (domain, internal);
+	thread = create_thread_object (domain, internal);
 
 	if (!mono_thread_attach_internal (thread, force_attach, TRUE, &stack_ptr)) {
 		/* Mono is shutting down, so just wait for the end */
@@ -1206,7 +1200,7 @@ ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThread *this_obj)
 {
 	MonoInternalThread *internal;
 
-	internal = create_internal_thread ();
+	internal = create_internal_thread_object ();
 
 	internal->state = ThreadState_Unstarted;
 
@@ -1576,7 +1570,7 @@ mono_thread_current (void)
 
 	if (!*current_thread_ptr) {
 		g_assert (domain != mono_get_root_domain ());
-		*current_thread_ptr = new_thread_with_internal (domain, internal);
+		*current_thread_ptr = create_thread_object (domain, internal);
 	}
 	return *current_thread_ptr;
 }
@@ -1593,7 +1587,7 @@ mono_thread_current_for_thread (MonoInternalThread *internal)
 
 	if (!*current_thread_ptr) {
 		g_assert (domain != mono_get_root_domain ());
-		*current_thread_ptr = new_thread_with_internal (domain, internal);
+		*current_thread_ptr = create_thread_object (domain, internal);
 	}
 	return *current_thread_ptr;
 }

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -471,7 +471,8 @@ BASE_TEST_CS_SRC_UNIVERSAL=		\
 	priority.cs	\
 	abort-cctor.cs	\
 	thread-native-exit.cs \
-	reference-loader.cs
+	reference-loader.cs \
+	thread-suspend-suspended.cs
 
 if INSTALL_MOBILE_STATIC
 BASE_TEST_CS_SRC= \

--- a/mono/tests/thread-suspend-suspended.cs
+++ b/mono/tests/thread-suspend-suspended.cs
@@ -1,0 +1,43 @@
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+class Driver
+{
+	public static void Main ()
+	{
+		bool finished = false;
+
+		Thread t1 = new Thread (() => {
+			while (!finished) {}
+		});
+
+		Thread t2 = new Thread (() => {
+			while (!finished) {
+				GC.Collect ();
+				Thread.Yield ();
+			}
+		});
+
+		t1.Start ();
+		t2.Start ();
+
+		Thread.Sleep (10);
+
+		for (int i = 0; i < 50 * 40 * 20; ++i) {
+			t1.Suspend ();
+			Thread.Yield ();
+			t1.Resume ();
+			if ((i + 1) % (50) == 0)
+				Console.Write (".");
+			if ((i + 1) % (50 * 40) == 0)
+				Console.WriteLine ();
+		}
+
+		finished = true;
+
+		t1.Join ();
+		t2.Join ();
+	}
+}

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -135,7 +135,7 @@ mono_threads_state_poll_with_info (MonoThreadInfo *info)
 	/* commit the saved state and notify others if needed */
 	switch (mono_threads_transition_state_poll (info)) {
 	case SelfSuspendResumed:
-		return;
+		break;
 	case SelfSuspendWait:
 		mono_thread_info_wait_for_resume (info);
 		break;
@@ -143,6 +143,12 @@ mono_threads_state_poll_with_info (MonoThreadInfo *info)
 		mono_threads_notify_initiator_of_suspend (info);
 		mono_thread_info_wait_for_resume (info);
 		break;
+	}
+
+	if (info->async_target) {
+		info->async_target (info->user_data);
+		info->async_target = NULL;
+		info->user_data = NULL;
 	}
 }
 

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -729,6 +729,8 @@ To finish suspending, call mono_suspend_check.
 void
 mono_thread_info_begin_self_suspend (void)
 {
+	g_assert (!mono_threads_is_coop_enabled ());
+
 	MonoThreadInfo *info = mono_thread_info_current_unchecked ();
 	if (!info)
 		return;
@@ -741,6 +743,8 @@ void
 mono_thread_info_end_self_suspend (void)
 {
 	MonoThreadInfo *info;
+
+	g_assert (!mono_threads_is_coop_enabled ());
 
 	info = mono_thread_info_current ();
 	if (!info)
@@ -1001,6 +1005,7 @@ mono_thread_info_safe_suspend_and_run (MonoNativeThreadId id, gboolean interrupt
 		mono_threads_wait_pending_operations ();
 		break;
 	case KeepSuspended:
+		g_assert (!mono_threads_is_coop_enabled ());
 		break;
 	default:
 		g_error ("Invalid suspend_and_run callback return value %d", result);


### PR DESCRIPTION
By using a MonoOSEvent we avoid relying on the utils/threads suspend
mechanism to suspend a metadata/threads. This reduce coupling between both
mechanism, and that would allow us to remove a bunch of code from
utils/threads when switching to coop.

This only works with coop suspend, as we need the ability to return from an
async call, and that's not possible with preemptive suspend.