### PR TITLE
[C9][runtime] Ensure generic type definition arity matches generic context arity

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -4328,6 +4328,24 @@ namespace MonoTests.System
 		}
 #endif
 
+
+		[Test]
+		public void GetTypeBadArity()
+		{
+			// Regression test for #46250
+			try {
+				Type.GetType ("System.Collections.Generic.Dictionary`2[System.String]", true);
+				Assert.Fail ("Did not throw an exception (#1)");
+			} catch (ArgumentException) {
+			}
+
+			try {
+				Type.GetType ("System.Collections.Generic.Dictionary`2[System.String,System.Int32,System.Int64]", true);
+				Assert.Fail ("Did not throw an exception (#2)");
+			} catch (ArgumentException) {
+			}
+		}
+
 		public abstract class Stream : IDisposable
 		{
 			public void Dispose ()

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2956,6 +2956,8 @@ mono_metadata_lookup_generic_class (MonoClass *container_class, MonoGenericInst 
 	MonoImageSet *set;
 	CollectData data;
 
+	g_assert (mono_class_get_generic_container (container_class)->type_argc == inst->type_argc);
+
 	memset (&helper, 0, sizeof(helper)); // act like g_new0
 	helper.container_class = container_class;
 	helper.context.class_inst = inst;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -2259,9 +2259,16 @@ mono_reflection_bind_generic_parameters (MonoReflectionType *type, int type_argc
 
 	if (klass->wastypebuilder) {
 		tb = (MonoReflectionTypeBuilder *) mono_class_get_ref_info (klass);
-
 		is_dynamic = TRUE;
 	}
+
+	guint gtd_type_argc = mono_class_get_generic_container (klass)->type_argc;
+	if (gtd_type_argc != type_argc) {
+		mono_loader_unlock ();
+		mono_error_set_argument (error, "types", "The generic type definition needs %d type arguments, but was instantiated with %d ", gtd_type_argc, type_argc);
+		return NULL;
+	}
+
 
 	mono_loader_unlock ();
 


### PR DESCRIPTION
Don't instantiate generic type definitions (like Dictionary'2) with too few or too many
type arguments.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=46250

This is #3885 backported to `mono-4.8.0-branch`