### PR TITLE
[arm64] Set a flag in MonoContext if the fp regs are saved, and only …

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -386,6 +386,11 @@ typedef struct {
 	mgreg_t regs [32];
 	double fregs [32];
 	mgreg_t pc;
+	/*
+	 * fregs might not be initialized if this context was created from a
+	 * ucontext.
+	 */
+	mgreg_t has_fregs;
 } MonoContext;
 
 #define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (mgreg_t)ip; } while (0)


### PR DESCRIPTION
…restore them if they are. These registers are not saved when the context is created from a ucontext.