### PR TITLE
[System.ServiceModel] Recognize 'faultactor' in SOAP fault message

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MessageFault.cs
@@ -53,7 +53,7 @@ namespace System.ServiceModel.Channels
 		{
 			FaultCode fc = null;
 			FaultReason fr = null;
-			object details = null;
+			string actor = null;
 			XmlDictionaryReader r = message.GetReaderAtBodyContents ();
 			r.ReadStartElement ("Fault", message.Version.Envelope.Namespace);
 			r.MoveToContent ();
@@ -66,11 +66,13 @@ namespace System.ServiceModel.Channels
 				case "faultstring":
 					fr = new FaultReason (r.ReadElementContentAsString());
 					break;
-				case "detail":
-					return new XmlReaderDetailMessageFault (message, r, fc, fr, null, null);
 				case "faultactor":
+					actor = r.ReadElementContentAsString();
+					break;
+				case "detail":
+					return new XmlReaderDetailMessageFault (message, r, fc, fr, actor, null);
 				default:
-					throw new NotImplementedException ();
+					throw new XmlException (String.Format ("Unexpected node {0} name {1}", r.NodeType, r.Name));
 				}
 				r.MoveToContent ();
 			}
@@ -79,9 +81,7 @@ namespace System.ServiceModel.Channels
 			if (fr == null)
 				throw new XmlException ("Reason is missing in the Fault message");
 
-			if (details == null)
-				return CreateFault (fc, fr);
-			return CreateFault (fc, fr, details);
+			return new SimpleMessageFault (fc, fr, false, null, null, actor, null);
 		}
 
 		static MessageFault CreateFault12 (Message message, int maxBufferSize)

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageFaultTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageFaultTest.cs
@@ -71,6 +71,7 @@ namespace MonoTests.System.ServiceModel.Channels
     <s:Fault>
       <faultcode>a:ActionNotSupported</faultcode>
       <faultstring xml:lang='en-US'>some error</faultstring>
+      <faultactor>Random</faultactor>
     </s:Fault>
   </s:Body>
 </s:Envelope>";


### PR DESCRIPTION
It's an optional element according to [1] and we were simply throwing a NotImplementedException when encountering it.

Fixed by reading the element value instead. I noticed that we had a 'details' variable that was never assigned, so the check for `details == null` was always true and can be removed.
This makes inlining the body of the CreateFault() call easier since we no longer need to choose different overloads and makes the code consistent with the CreateFault12 method.
Also added a better exception in case of an unrecognized element.

The CreateFault12 method (handles SOAP 1.2) does not need a similar fix since actor is not an element in that version [2].

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42226

[1] https://www.w3.org/TR/soap11/#_Toc478383507
[2] https://www.w3.org/TR/soap12/#soapfault