### PR TITLE
[eglib/mono] Aleksey caught a discrepancy between the semantics of Un…

### DIFF
--- a/eglib/src/gfile-unix.c
+++ b/eglib/src/gfile-unix.c
@@ -78,3 +78,11 @@ g_file_test (const gchar *filename, GFileTest test)
 	}
 	return FALSE;
 }
+
+gchar *
+g_mkdtemp (char *tmp_template)
+{
+	char *template_copy = g_strdup (tmp_template);
+
+	return mkdtemp (template_copy);
+}

--- a/eglib/src/glib.h
+++ b/eglib/src/glib.h
@@ -887,11 +887,7 @@ gboolean   g_file_test (const gchar *filename, GFileTest test);
 #define g_ascii_strtod strtod
 #define g_ascii_isalnum isalnum
 
-#ifdef WIN32
 gchar *g_mkdtemp (gchar *tmpl);
-#else
-#define g_mkdtemp mkdtemp
-#endif
 
 /*
  * Pattern matching

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -151,7 +151,7 @@ bundle_save_library_initialize ()
 	bundle_save_library_initialized = 1;
 	char *path = g_build_filename (g_get_tmp_dir (), "mono-bundle-XXXXXX", NULL);
 	bundled_dylibrary_directory = g_mkdtemp (path);
-	/* don't free path - mkdtemp modifies it in place, and bundled_dylibrary_directory is an alias of it */
+	g_free (path);
 	if (bundled_dylibrary_directory == NULL)
 		return;
 	atexit (delete_bundled_libraries);


### PR DESCRIPTION
…ix and Windows, our eglib version should always strdup