### PR TITLE
Rename fix for lpstr to utf8str on Windows

### DIFF
--- a/mono/metadata/marshal-internals.h
+++ b/mono/metadata/marshal-internals.h
@@ -32,7 +32,7 @@ void
 mono_marshal_free_hglobal (void *ptr);
 
 gpointer
-mono_string_to_lpstr (MonoString *s);
+mono_string_to_utf8str (MonoString *s);
 #endif  /* HOST_WIN32 */
 
 #endif /* __MONO_METADATA_MARSHAL_INTERNALS_H__ */

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -93,7 +93,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalUni (MonoString 
 }
 
 gpointer
-mono_string_to_lpstr (MonoString *s)
+mono_string_to_utf8str (MonoString *s)
 {
 	char *as, *tmp;
 	glong len;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -109,8 +109,10 @@ mono_marshal_string_to_utf16 (MonoString *s);
 static void *
 mono_marshal_string_to_utf16_copy (MonoString *s);
 
+#ifndef HOST_WIN32
 static gpointer
 mono_string_to_utf8str (MonoString *string_obj);
+#endif
 
 static MonoStringBuilder *
 mono_string_utf8_to_builder2 (char *text);
@@ -1080,6 +1082,7 @@ mono_string_builder_to_utf16 (MonoStringBuilder *sb)
 	return str;
 }
 
+#ifndef HOST_WIN32
 /* This is a JIT icall, it sets the pending exception and returns NULL on error. */
 static gpointer
 mono_string_to_utf8str (MonoString *s)
@@ -1089,6 +1092,7 @@ mono_string_to_utf8str (MonoString *s)
 	mono_error_set_pending_exception (&error);
 	return result;
 }
+#endif
 
 gpointer
 mono_string_to_ansibstr (MonoString *string_obj)


### PR DESCRIPTION
PR https://github.com/mono/mono/pull/3776 renamed `mono_string_to_lpstr`
to `mono_string_to_utf8str` without updating the Windows version.
This fix renames `mono_string_to_lpstr` to `mono_string_to_utf8str` to
make sure the string is allocated using `CoTaskMemAlloc` on Windows
since it will be freed using `CoTaskMemFree`.