### PR TITLE
Fix NRE in Win32 IpcChannel.StopListening() when no server started

### DIFF
--- a/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting.Channels.Ipc.Win32/IpcChannel.cs
+++ b/mcs/class/System.Runtime.Remoting/System.Runtime.Remoting.Channels.Ipc.Win32/IpcChannel.cs
@@ -115,7 +115,8 @@ namespace System.Runtime.Remoting.Channels.Ipc.Win32
 
         public void StartListening(object data)
         {
-            serverChannel.StartListening(data);
+            if (serverChannel != null)
+                serverChannel.StartListening(data);
         }
 
         public object ChannelData
@@ -128,7 +129,8 @@ namespace System.Runtime.Remoting.Channels.Ipc.Win32
 
         public void StopListening(object data)
         {
-            serverChannel.StopListening(data);
+            if (serverChannel != null)
+                serverChannel.StopListening(data);
         }
 
         public string[] GetUrlsForUri(string objectURI)


### PR DESCRIPTION
This makes the System.Runtime.Remoting test suite fail in various places on Windows due to the TestFixtureTearDown method in BaseCalls throwing an NRE.

The Unix IpcChannel.cs does the same null checks in StartListening()/StopListening() as those I added in the Win32 version in this PR.