### PR TITLE
[System] Ignore some networking tests after we started throwing PlatformNotSupportedExceptions in WebRequest.GetSystemWebProxy for watchOS.

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketAsyncTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketAsyncTest.cs
@@ -8,6 +8,9 @@ using NUnit.Framework;
 namespace MonoTests.System.Net.Sockets
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class SocketAsyncTest
 	{
 		Socket serverSocket;

--- a/mcs/class/System/Test/System.Net/CookieParserTest.cs
+++ b/mcs/class/System/Test/System.Net/CookieParserTest.cs
@@ -9,6 +9,9 @@ using NUnit.Framework;
 namespace MonoTests.System.Net
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class CookieParserTest
 	{
 		public const string A = "Foo=Bar, expires=World; expires=Sat, 11-Oct-14 22:45:19 GMT, A=B";

--- a/mcs/class/System/Test/System.Net/FtpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/FtpWebRequestTest.cs
@@ -19,6 +19,9 @@ using System.Threading;
 namespace MonoTests.System.Net 
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class FtpWebRequestTest
 	{
 		FtpWebRequest defaultRequest;

--- a/mcs/class/System/Test/System.Net/HttpListener2Test.cs
+++ b/mcs/class/System/Test/System.Net/HttpListener2Test.cs
@@ -47,6 +47,9 @@ using MonoTests.Helpers;
 namespace MonoTests.System.Net {
 	
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpListener2Test {
 		
 		private HttpListener _listener = null;
@@ -645,6 +648,9 @@ namespace MonoTests.System.Net {
 	}
 
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpListenerBugs {
 		[Test]
 		public void TestNonChunkedAsync ()

--- a/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
@@ -42,6 +42,9 @@ using MonoTests.Helpers;
 namespace MonoTests.System.Net
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpListenerRequestTest
 	{
 		[Test]

--- a/mcs/class/System/Test/System.Net/HttpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerTest.cs
@@ -37,6 +37,9 @@ using MonoTests.Helpers;
 
 namespace MonoTests.System.Net {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpListenerTest {
 
 		int port;

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -36,6 +36,9 @@ using MonoTests.Helpers;
 namespace MonoTests.System.Net
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpWebRequestTest
 	{
 		private Random rand = new Random ();
@@ -2763,6 +2766,9 @@ namespace MonoTests.System.Net
 	}
 
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpRequestStreamTest
 	{
 		[Test]

--- a/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
@@ -21,6 +21,9 @@ using NUnit.Framework;
 namespace MonoTests.System.Net
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpWebResponseTest
 	{
 		[Test]
@@ -476,6 +479,9 @@ namespace MonoTests.System.Net
 	}
 
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class HttpResponseStreamTest
 	{
 		[Test]

--- a/mcs/class/System/Test/System.Net/ServicePointTest.cs
+++ b/mcs/class/System/Test/System.Net/ServicePointTest.cs
@@ -20,6 +20,9 @@ namespace MonoTests.System.Net
 {
 
 [TestFixture]
+#if __WATCHOS__
+[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 public class ServicePointTest
 {
 	static private int max;

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -21,6 +21,9 @@ using MonoTests.Helpers;
 namespace MonoTests.System.Net
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class WebClientTest
 	{
 		private string _tempFolder;

--- a/mcs/class/System/Test/System.Net/WebHeaderCollectionTest.cs
+++ b/mcs/class/System/Test/System.Net/WebHeaderCollectionTest.cs
@@ -26,6 +26,9 @@ using NUnit.Framework;
 namespace MonoTests.System.Net
 {
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class WebHeaderCollectionTest
 	{
 		WebHeaderCollection col;

--- a/mcs/class/System/Test/System.Net/WebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/WebRequestTest.cs
@@ -36,6 +36,9 @@ namespace MonoTests.System.Net {
 	}
 
 	[TestFixture]
+#if __WATCHOS__
+	[Ignore ("watchOS does not have a working networking stack.")]
+#endif
 	public class WebRequestTest {
 
 		private void Callback (IAsyncResult ar)


### PR DESCRIPTION
Ignore some networking test after we started throwing
PlatformNotSupportedExceptions in WebRequest.GetSystemWebProxy in
99f2e7d36d544f903bc3931db598137f087e5b2c.