### PR TITLE
mono_context_get_current() on Windows stores registers at incorrect indexes

### DIFF
--- a/mono/utils/win64.asm
+++ b/mono/utils/win64.asm
@@ -13,13 +13,13 @@ ifdef RAX
 PUBLIC mono_context_get_current
 
 mono_context_get_current PROC
-;rdi has the ctx ptr
+;rcx has the ctx ptr
 	mov [rcx + 00h], rax
-	mov [rcx + 08h], rbx
-	mov [rcx + 10h], rcx
-	mov [rcx + 18h], rdx
-	mov [rcx + 20h], rbp
-	mov [rcx + 28h], rsp
+	mov [rcx + 08h], rcx
+	mov [rcx + 10h], rdx
+	mov [rcx + 18h], rbx
+	mov [rcx + 20h], rsp
+	mov [rcx + 28h], rbp
 	mov [rcx + 30h], rsi
 	mov [rcx + 38h], rdi
 	mov [rcx + 40h], r8


### PR DESCRIPTION
The indexes must correspond to the values in the `AMD64_Reg_No` enum in `amd64-codegen.h`. Looks like the `win64.asm` file wasn't updated when `MonoContext` was changed to use an array for the saved registers rather than fields (92c36fdbd2997982e7e2f5342871f070ff2fb121).