### PR TITLE
[4.8][threads] Fix suspend on watchos

### DIFF
--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -916,7 +916,7 @@ suspend_sync (MonoNativeThreadId tid, gboolean interrupt_kernel)
 		}
 		break;
 	case AsyncSuspendBlocking:
-		if (interrupt_kernel)
+		if (interrupt_kernel && mono_threads_suspend_needs_abort_syscall ())
 			mono_threads_suspend_abort_syscall (info);
 
 		break;


### PR DESCRIPTION
Because certain platform (such as WatchOS) do not support syscall abort, we need to ensure that it is supported before we call the `mono_threads_suspend_abort_syscall` function.