### PR TITLE
[4.8][threads] Fix Posix async resume

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -456,8 +456,13 @@ This begins async resume. This function must do the following:
 gboolean
 mono_threads_suspend_begin_async_resume (MonoThreadInfo *info)
 {
-	mono_threads_add_to_pending_operation_set (info);
-	return mono_threads_pthread_kill (info, mono_threads_posix_get_restart_signal ()) == 0;
+	int sig = mono_threads_posix_get_restart_signal ();
+
+	if (!mono_threads_pthread_kill (info, sig)) {
+		mono_threads_add_to_pending_operation_set (info);
+		return TRUE;
+	}
+	return FALSE;
 }
 
 void


### PR DESCRIPTION
If we fail to send the signal, we should not add a pending operation, as the signal handler is never going to answer this operation (via mono_threads_notify_initiator_of_resume).