### PR TITLE
Enforce restrictions on pinned GCHandle objects

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
@@ -197,6 +197,79 @@ namespace MonoTests.System.Runtime.InteropServices
 			private readonly string _assemblyName;
 		}
 #endif
+
+		class AnyClass
+		{
+		}
+
+		struct StructWithReferenceTypeInside
+		{
+			public string myStr;
+		}
+
+		struct GenericStruct<T>
+		{
+			public T myItem;
+		}
+
+		[StructLayout(LayoutKind.Auto)]
+		struct StructWithIntInsideAutoLayout
+		{
+			public int myInt;
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnArrayOfStrings()
+		{
+			var arrayOfStrings = new string[] { "a", "B" };
+			GCHandle.Alloc(arrayOfStrings, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnArrayOfIntArrays()
+		{
+			var arrayOfIntArrays = new int[][] { new int[] {1, 2}, new int[] {3, 4, 5} };
+			GCHandle.Alloc(arrayOfIntArrays, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAClass()
+		{
+			GCHandle.Alloc(new AnyClass(), GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToANonBlittableStruct()
+		{
+			var nonBlittableStruct = default(StructWithReferenceTypeInside);
+			GCHandle.Alloc(nonBlittableStruct, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAGenericStruct()
+		{
+			var nonBlittableGenericStruct = default(GenericStruct<string>);
+			GCHandle.Alloc(nonBlittableGenericStruct, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToADateTime()
+		{
+			GCHandle.Alloc(default(DateTime), GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnAutoLayoutStruct()
+		{
+			GCHandle.Alloc(default(StructWithIntInsideAutoLayout), GCHandleType.Pinned);
+		}
 	}
 
 }

--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
@@ -212,7 +212,7 @@ namespace MonoTests.System.Runtime.InteropServices
 			public T myItem;
 		}
 
-		[StructLayout(LayoutKind.Auto)]
+		[StructLayout (LayoutKind.Auto)]
 		struct StructWithIntInsideAutoLayout
 		{
 			public int myInt;

--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
@@ -219,56 +219,56 @@ namespace MonoTests.System.Runtime.InteropServices
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
-		public void CannotAllocAPinnedGCHandleToAnArrayOfStrings()
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnArrayOfStrings ()
 		{
 			var arrayOfStrings = new string[] { "a", "B" };
-			GCHandle.Alloc(arrayOfStrings, GCHandleType.Pinned);
+			GCHandle.Alloc (arrayOfStrings, GCHandleType.Pinned);
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
-		public void CannotAllocAPinnedGCHandleToAnArrayOfIntArrays()
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnArrayOfIntArrays ()
 		{
 			var arrayOfIntArrays = new int[][] { new int[] {1, 2}, new int[] {3, 4, 5} };
-			GCHandle.Alloc(arrayOfIntArrays, GCHandleType.Pinned);
+			GCHandle.Alloc (arrayOfIntArrays, GCHandleType.Pinned);
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
-		public void CannotAllocAPinnedGCHandleToAClass()
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAClass ()
 		{
-			GCHandle.Alloc(new AnyClass(), GCHandleType.Pinned);
+			GCHandle.Alloc (new AnyClass (), GCHandleType.Pinned);
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
-		public void CannotAllocAPinnedGCHandleToANonBlittableStruct()
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToANonBlittableStruct ()
 		{
-			var nonBlittableStruct = default(StructWithReferenceTypeInside);
+			var nonBlittableStruct = default (StructWithReferenceTypeInside);
 			GCHandle.Alloc(nonBlittableStruct, GCHandleType.Pinned);
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
-		public void CannotAllocAPinnedGCHandleToAGenericStruct()
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAGenericStruct ()
 		{
-			var nonBlittableGenericStruct = default(GenericStruct<string>);
-			GCHandle.Alloc(nonBlittableGenericStruct, GCHandleType.Pinned);
+			var nonBlittableGenericStruct = default (GenericStruct<string>);
+			GCHandle.Alloc (nonBlittableGenericStruct, GCHandleType.Pinned);
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
-		public void CannotAllocAPinnedGCHandleToADateTime()
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToADateTime ()
 		{
-			GCHandle.Alloc(default(DateTime), GCHandleType.Pinned);
+			GCHandle.Alloc (default (DateTime), GCHandleType.Pinned);
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
-		public void CannotAllocAPinnedGCHandleToAnAutoLayoutStruct()
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnAutoLayoutStruct ()
 		{
-			GCHandle.Alloc(default(StructWithIntInsideAutoLayout), GCHandleType.Pinned);
+			GCHandle.Alloc (default (StructWithIntInsideAutoLayout), GCHandleType.Pinned);
 		}
 	}
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -23,6 +23,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/mono-mlist.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/threadpool-ms.h>
 #include <mono/sgen/sgen-conf.h>
@@ -681,20 +682,21 @@ ves_icall_System_GCHandle_GetTarget (guint32 handle)
 	return mono_gchandle_get_target (handle);
 }
 
-static gboolean is_object_pinnable(MonoObject* obj)
+static gboolean
+is_object_pinnable(MonoObject *obj)
 {
 	if (obj == NULL)
 		return TRUE;
 
-	MonoClass* klass = obj->vtable->klass;
+	MonoClass *klass = obj->vtable->klass;
 	MonoTypeEnum type = klass->byval_arg.type;
 
 	if (type == MONO_TYPE_CHAR || type == MONO_TYPE_BOOLEAN || type == MONO_TYPE_STRING)
 		return TRUE;
 
 	if (type == MONO_TYPE_ARRAY || type == MONO_TYPE_SZARRAY) {
-		MonoTypeEnum elementType = klass->element_class->byval_arg.type;
-		if (elementType == MONO_TYPE_ARRAY || elementType == MONO_TYPE_SZARRAY)
+		MonoTypeEnum element_type = klass->element_class->byval_arg.type;
+		if (element_type == MONO_TYPE_ARRAY || element_type == MONO_TYPE_SZARRAY)
 			return FALSE;
 		return klass->element_class->blittable;
 	}
@@ -725,7 +727,7 @@ ves_icall_System_GCHandle_GetTargetHandle (MonoObject *obj, guint32 handle, gint
 		return mono_gchandle_new (obj, FALSE);
 	case HANDLE_PINNED:
 		if (!is_object_pinnable (obj))
-			mono_raise_exception (mono_get_exception_argument ("value", "Object contains non-primitive or non-blittable data."));
+			mono_set_pending_exception (mono_get_exception_argument ("value", "Object contains non-primitive or non-blittable data."));
 		return mono_gchandle_new (obj, TRUE);
 	default:
 		g_assert_not_reached ();

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -681,6 +681,30 @@ ves_icall_System_GCHandle_GetTarget (guint32 handle)
 	return mono_gchandle_get_target (handle);
 }
 
+static gboolean is_object_pinnable(MonoObject* obj)
+{
+	if (obj == NULL)
+		return TRUE;
+
+	MonoClass* klass = obj->vtable->klass;
+	MonoTypeEnum type = klass->byval_arg.type;
+
+	if (type == MONO_TYPE_CHAR || type == MONO_TYPE_BOOLEAN || type == MONO_TYPE_STRING)
+		return TRUE;
+
+	if (type == MONO_TYPE_ARRAY || type == MONO_TYPE_SZARRAY) {
+		MonoTypeEnum elementType = klass->element_class->byval_arg.type;
+		if (elementType == MONO_TYPE_ARRAY || elementType == MONO_TYPE_SZARRAY)
+			return FALSE;
+		return klass->element_class->blittable;
+	}
+
+	if (type == MONO_TYPE_CLASS)
+		return FALSE;
+
+	return klass->blittable;
+}
+
 /*
  * if type == -1, change the target of the handle, otherwise allocate a new handle.
  */
@@ -700,6 +724,8 @@ ves_icall_System_GCHandle_GetTargetHandle (MonoObject *obj, guint32 handle, gint
 	case HANDLE_NORMAL:
 		return mono_gchandle_new (obj, FALSE);
 	case HANDLE_PINNED:
+		if (!is_object_pinnable (obj))
+			mono_raise_exception (mono_get_exception_argument ("value", "Object contains non-primitive or non-blittable data."));
 		return mono_gchandle_new (obj, TRUE);
 	default:
 		g_assert_not_reached ();

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -683,7 +683,7 @@ ves_icall_System_GCHandle_GetTarget (guint32 handle)
 }
 
 static gboolean
-is_object_pinnable(MonoObject *obj)
+is_object_pinnable (MonoObject *obj)
 {
 	if (obj == NULL)
 		return TRUE;
@@ -726,8 +726,11 @@ ves_icall_System_GCHandle_GetTargetHandle (MonoObject *obj, guint32 handle, gint
 	case HANDLE_NORMAL:
 		return mono_gchandle_new (obj, FALSE);
 	case HANDLE_PINNED:
-		if (!is_object_pinnable (obj))
+		if (!is_object_pinnable (obj)) {
 			mono_set_pending_exception (mono_get_exception_argument ("value", "Object contains non-primitive or non-blittable data."));
+			return 0;
+		}
+
 		return mono_gchandle_new (obj, TRUE);
 	default:
 		g_assert_not_reached ();


### PR DESCRIPTION
* A pinned GCHandle should not be allowed for some types.
* The GCHandle.Alloc method should throw an ArgumentException in these cases.
* This change corrects bug https://bugzilla.xamarin.com/show_bug.cgi?id=46660.