### PR TITLE
[coop handles] Support out args; convert some icalls.

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -223,3 +223,11 @@ mono_handle_verify (MonoRawHandle raw_handle)
 	
 }
 #endif
+
+uintptr_t
+mono_array_handle_length (MonoArrayHandle arr)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	return MONO_HANDLE_RAW (arr)->max_length;
+}

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -231,3 +231,24 @@ mono_array_handle_length (MonoArrayHandle arr)
 
 	return MONO_HANDLE_RAW (arr)->max_length;
 }
+
+uint32_t
+mono_gchandle_from_handle (MonoObjectHandle handle, mono_bool pinned)
+{
+	return mono_gchandle_new (MONO_HANDLE_RAW(handle), pinned);
+}
+
+MonoObjectHandle
+mono_gchandle_get_target_handle (uint32_t gchandle)
+{
+	return MONO_HANDLE_NEW (MonoObject, mono_gchandle_get_target);
+}
+
+gpointer
+mono_array_handle_pin_with_size (MonoArrayHandle handle, int size, uintptr_t idx, uint32_t *gchandle)
+{
+	g_assert (gchandle != NULL);
+	*gchandle = mono_gchandle_from_handle (MONO_HANDLE_CAST(MonoObject,handle), TRUE);
+	MonoArray *raw = MONO_HANDLE_RAW (handle);
+	return mono_array_addr_with_size (raw, size, idx);
+}

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -116,6 +116,19 @@ Icall macros
 	mono_stack_mark_record_size (__info, &__mark, __FUNCTION__);	\
 	mono_stack_mark_pop (__info, &__mark);
 
+#define HANDLE_FUNCTION_ENTER() do {				\
+	MonoThreadInfo *__info = mono_thread_info_current ();	\
+	SETUP_ICALL_FRAME					\
+
+#define HANDLE_FUNCTION_RETURN()		\
+	CLEAR_ICALL_FRAME;			\
+	} while (0)
+
+#define HANDLE_FUNCTION_RETURN_VAL(VAL)		\
+	CLEAR_ICALL_FRAME;			\
+	return (VAL);				\
+	} while (0)
+
 #ifdef MONO_NEEDS_STACK_WATERMARK
 
 static void

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -322,6 +322,25 @@ uintptr_t mono_array_handle_length (MonoArrayHandle arr);
 
 #define mono_handle_class(o) mono_object_class (MONO_HANDLE_RAW (o))
 
+/* Local handles to global GC handles and back */
+
+uint32_t
+mono_gchandle_from_handle (MonoObjectHandle handle, mono_bool pinned);
+
+MonoObjectHandle
+mono_gchandle_get_target_handle (uint32_t gchandle);
+
+
+
+/* Pins the MonoArray using a gchandle and returns a pointer to the
+ * element with the given index (where each element is of the given
+ * size.  Call mono_gchandle_free to unpin.
+ */
+gpointer
+mono_array_handle_pin_with_size (MonoArrayHandle handle, int size, uintptr_t index, uint32_t *gchandle);
+
+#define MONO_ARRAY_HANDLE_PIN(handle,type,index,gchandle_out) mono_array_handle_pin_with_size (MONO_HANDLE_CAST(MonoArray,(handle)), sizeof (type), (index), (gchandle_out))
+
 G_END_DECLS
 
 #endif /* __MONO_HANDLE_H__ */

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -91,9 +91,10 @@ static inline void
 mono_stack_mark_pop (MonoThreadInfo *info, HandleStackMark *stackmark)
 {
 	HandleStack *handles = (HandleStack *)info->handle_stack;
-	handles->top->size = stackmark->size;
+	HandleChunk *old_top = stackmark->chunk;
+	old_top->size = stackmark->size;
 	mono_memory_write_barrier ();
-	handles->top = stackmark->chunk;
+	handles->top = old_top;
 }
 
 /*

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -201,6 +201,8 @@ void mono_handle_verify (MonoRawHandle handle);
 
 #define TYPED_HANDLE_PAYLOAD_NAME(TYPE) TYPE ## HandlePayload
 #define TYPED_HANDLE_NAME(TYPE) TYPE ## Handle
+#define TYPED_OUT_HANDLE_NAME(TYPE) TYPE ## HandleOut
+
 
 /*
  * TYPED_HANDLE_DECL(SomeType):
@@ -213,8 +215,12 @@ void mono_handle_verify (MonoRawHandle handle);
  * } MonoObjectHandlePayload;
  *
  * typedef MonoObjectHandlePayload* MonoObjectHandle;
+ * typedef MonoObjectHandlePayload* MonoObjectHandleOut;
  */
-#define TYPED_HANDLE_DECL(TYPE) typedef struct { TYPE *__obj; } TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE)
+#define TYPED_HANDLE_DECL(TYPE)						\
+	typedef struct { TYPE *__obj; } TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; \
+	typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE); \
+	typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_OUT_HANDLE_NAME (TYPE)
 /* Have to double expand because MONO_STRUCT_OFFSET is doing token pasting on cross-compilers. */
 #define MONO_HANDLE_PAYLOAD_OFFSET_(PayloadType) MONO_STRUCT_OFFSET(PayloadType, __obj)
 #define MONO_HANDLE_PAYLOAD_OFFSET(TYPE) MONO_HANDLE_PAYLOAD_OFFSET_(TYPED_HANDLE_PAYLOAD_NAME (TYPE))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -88,8 +88,8 @@ ICALL_TYPE(TLS_PROVIDER_FACTORY, "Mono.Net.Security.MonoTlsProviderFactory", TLS
 ICALL(TLS_PROVIDER_FACTORY_1, "IsBtlsSupported", ves_icall_Mono_TlsProviderFactory_IsBtlsSupported)
 
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
-ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace)
 HANDLES(ICALL(RUNTIME_1, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
+HANDLES(ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace))
 
 ICALL_TYPE(RTCLASS, "Mono.RuntimeClassHandle", RTCLASS_1)
 ICALL(RTCLASS_1, "GetTypeFromClass", ves_icall_Mono_RuntimeClassHandle_GetTypeFromClass)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -652,7 +652,7 @@ ICALL_TYPE(RUNH, "System.Runtime.CompilerServices.RuntimeHelpers", RUNH_1)
 ICALL(RUNH_1, "GetObjectValue", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetObjectValue)
 	 /* REMOVEME: no longer needed, just so we dont break things when not needed */
 ICALL(RUNH_2, "GetOffsetToStringData", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetOffsetToStringData)
-ICALL(RUNH_3, "InitializeArray", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray)
+HANDLES(ICALL(RUNH_3, "InitializeArray", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray))
 ICALL(RUNH_4, "RunClassConstructor", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunClassConstructor)
 ICALL(RUNH_5, "RunModuleConstructor", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunModuleConstructor)
 ICALL(RUNH_5h, "SufficientExecutionStack", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStack)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -256,7 +256,7 @@ ICALL_TYPE(STOPWATCH, "System.Diagnostics.Stopwatch", STOPWATCH_1)
 ICALL(STOPWATCH_1, "GetTimestamp", mono_100ns_ticks)
 
 ICALL_TYPE(ENUM, "System.Enum", ENUM_1)
-ICALL(ENUM_1, "GetEnumValuesAndNames", ves_icall_System_Enum_GetEnumValuesAndNames)
+HANDLES(ICALL(ENUM_1, "GetEnumValuesAndNames", ves_icall_System_Enum_GetEnumValuesAndNames))
 ICALL(ENUM_2, "InternalBoxEnum", ves_icall_System_Enum_ToObject)
 ICALL(ENUM_3, "InternalCompareTo", ves_icall_System_Enum_compare_value_to)
 ICALL(ENUM_4, "InternalGetUnderlyingType", ves_icall_System_Enum_get_underlying_type)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -88,8 +88,8 @@ ICALL_TYPE(TLS_PROVIDER_FACTORY, "Mono.Net.Security.MonoTlsProviderFactory", TLS
 ICALL(TLS_PROVIDER_FACTORY_1, "IsBtlsSupported", ves_icall_Mono_TlsProviderFactory_IsBtlsSupported)
 
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
-ICALL(RUNTIME_1, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName)
 ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace)
+HANDLES(ICALL(RUNTIME_1, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
 
 ICALL_TYPE(RTCLASS, "Mono.RuntimeClassHandle", RTCLASS_1)
 ICALL(RTCLASS_1, "GetTypeFromClass", ves_icall_Mono_RuntimeClassHandle_GetTypeFromClass)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7937,14 +7937,15 @@ ves_icall_MonoCustomAttrs_GetCustomAttributesDataInternal (MonoObject *obj)
 }
 
 
-ICALL_EXPORT MonoString*
-ves_icall_Mono_Runtime_GetDisplayName (void)
+ICALL_EXPORT MonoStringHandle
+ves_icall_Mono_Runtime_GetDisplayName (MonoError *error)
 {
 	char *info;
-	MonoString *display_name;
+	MonoStringHandle display_name;
 
+	mono_error_init (error);
 	info = mono_get_runtime_callbacks ()->get_runtime_build_info ();
-	display_name = mono_string_new (mono_domain_get (), info);
+	display_name = mono_string_new_handle (mono_domain_get (), info, error);
 	g_free (info);
 	return display_name;
 }

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3646,64 +3646,77 @@ ves_icall_System_Enum_get_hashcode (MonoObject *eobj)
 	return 0;
 }
 
-ICALL_EXPORT MonoBoolean
-ves_icall_System_Enum_GetEnumValuesAndNames (MonoReflectionType *type, MonoArray **values, MonoArray **names)
+static void
+get_enum_field (MonoDomain *domain, MonoArrayHandle names, MonoArrayHandle values, int base_type, MonoClassField *field, guint* j, guint64 *previous_value, gboolean *sorted, MonoError *error)
 {
-	MonoError error;
-	MonoDomain *domain = mono_object_domain (type); 
-	MonoClass *enumc = mono_class_from_mono_type (type->type);
+	mono_error_init (error);
+	HANDLE_FUNCTION_ENTER();
+	guint64 field_value;
+	const char *p;
+	MonoTypeEnum def_type;
+
+	if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+		goto leave;
+	if (strcmp ("value__", mono_field_get_name (field)) == 0)
+		goto leave;
+	if (mono_field_is_deleted (field))
+		goto leave;
+	MonoStringHandle name = mono_string_new_handle (domain, mono_field_get_name (field), error);
+	if (!is_ok (error))
+		goto leave;
+	MONO_HANDLE_ARRAY_SETREF (names, *j, name);
+
+	p = mono_class_get_field_default_value (field, &def_type);
+	/* len = */ mono_metadata_decode_blob_size (p, &p);
+
+	field_value = read_enum_value (p, base_type);
+	MONO_HANDLE_ARRAY_SETVAL (values, guint64, *j, field_value);
+
+	if (*previous_value > field_value)
+		*sorted = FALSE;
+
+	*previous_value = field_value;
+	(*j)++;
+leave:
+	HANDLE_FUNCTION_RETURN();
+}
+
+ICALL_EXPORT MonoBoolean
+ves_icall_System_Enum_GetEnumValuesAndNames (MonoReflectionTypeHandle type, MonoArrayHandleOut values, MonoArrayHandleOut names, MonoError *error)
+{
+	MonoDomain *domain = MONO_HANDLE_DOMAIN (type);
+	MonoClass *enumc = mono_class_from_mono_type (MONO_HANDLE_RAW(type)->type);
 	guint j = 0, nvalues;
 	gpointer iter;
 	MonoClassField *field;
 	int base_type;
-	guint64 field_value, previous_value = 0;
+	guint64 previous_value = 0;
 	gboolean sorted = TRUE;
 
-	mono_class_init_checked (enumc, &error);
-	if (mono_error_set_pending_exception (&error))
-		return FALSE;
-
+	mono_error_init (error);
+	mono_class_init_checked (enumc, error);
+	return_val_if_nok (error, FALSE);
 
 	if (!enumc->enumtype) {
-		mono_set_pending_exception (mono_get_exception_argument ("enumType", "Type provided must be an Enum."));
+		mono_error_set_argument (error, "enumType", "Type provided must be an Enum.");
 		return TRUE;
 	}
 
 	base_type = mono_class_enum_basetype (enumc)->type;
 
-	nvalues = mono_class_num_fields (enumc) ? mono_class_num_fields (enumc) - 1 : 0;
-	*names = mono_array_new_checked (domain, mono_defaults.string_class, nvalues, &error);
-	if (mono_error_set_pending_exception (&error))
-		return FALSE;
-	*values = mono_array_new_checked (domain, mono_defaults.uint64_class, nvalues, &error);
-	if (mono_error_set_pending_exception (&error))
-		return FALSE;
+	nvalues = mono_class_num_fields (enumc) > 0 ? mono_class_num_fields (enumc) - 1 : 0;
+	MONO_HANDLE_ASSIGN(names, mono_array_new_handle (domain, mono_defaults.string_class, nvalues, error));
+	return_val_if_nok (error, FALSE);
+	MONO_HANDLE_ASSIGN(values, mono_array_new_handle (domain, mono_defaults.uint64_class, nvalues, error));
+	return_val_if_nok (error, FALSE);
 
 	iter = NULL;
 	while ((field = mono_class_get_fields (enumc, &iter))) {
-		const char *p;
-		MonoTypeEnum def_type;
-
-		if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
-			continue;
-		if (strcmp ("value__", mono_field_get_name (field)) == 0)
-			continue;
-		if (mono_field_is_deleted (field))
-			continue;
-		mono_array_setref (*names, j, mono_string_new (domain, mono_field_get_name (field)));
-
-		p = mono_class_get_field_default_value (field, &def_type);
-		/* len = */ mono_metadata_decode_blob_size (p, &p);
-
-		field_value = read_enum_value (p, base_type);
-		mono_array_set (*values, guint64, j, field_value);
-
-		if (previous_value > field_value)
-			sorted = FALSE;
-
-		previous_value = field_value;
-		++j;
+		get_enum_field(domain, names, values, base_type, field, &j, &previous_value, &sorted, error);
+		if (!is_ok (error))
+			break;
 	}
+	return_val_if_nok (error, FALSE);
 
 	return sorted;
 }

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -219,6 +219,9 @@ struct _MonoException {
 	MonoArray  *native_trace_ips;
 };
 
+/* Safely access System.Exception from native code */
+TYPED_HANDLE_DECL (MonoException);
+
 typedef struct {
 	MonoException base;
 } MonoSystemException;
@@ -1627,10 +1630,10 @@ MonoString*
 mono_string_intern_checked (MonoString *str, MonoError *error);
 
 char *
-mono_exception_get_native_backtrace (MonoException *exc);
+mono_exception_handle_get_native_backtrace (MonoExceptionHandle exc);
 
-MonoString *
-ves_icall_Mono_Runtime_GetNativeStackTrace (MonoException *exc);
+MonoStringHandle
+ves_icall_Mono_Runtime_GetNativeStackTrace (MonoExceptionHandle exc, MonoError *erro);
 
 char *
 mono_exception_get_managed_backtrace (MonoException *exc);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7700,6 +7700,15 @@ mono_object_try_to_string (MonoObject *obj, MonoObject **exc, MonoError *error)
 
 
 
+static char *
+get_native_backtrace (MonoException *exc_raw)
+{
+	HANDLE_FUNCTION_ENTER ();
+	MONO_HANDLE_DCL(MonoException, exc);
+	char * trace = mono_exception_handle_get_native_backtrace (exc);
+	HANDLE_FUNCTION_RETURN_VAL (trace);
+}
+
 /**
  * mono_print_unhandled_exception:
  * @exc: The exception
@@ -7725,7 +7734,7 @@ mono_print_unhandled_exception (MonoObject *exc)
 	} else {
 		
 		if (((MonoException*)exc)->native_trace_ips) {
-			message = mono_exception_get_native_backtrace ((MonoException*)exc);
+			message = get_native_backtrace ((MonoException*)exc);
 			free_message = TRUE;
 		} else {
 			MonoObject *other_exc = NULL;


### PR DESCRIPTION
- Many more get/set macros for coop handles
- New macros for manipulating handle stacks for functions in order to bound the number of allocated handles
- Functions for converting coop handles to `gchandle` and back.
- Support for `out` arguments when auto-adding handles in the icall wrappers
- Change icalls to use handles
  - `Mono.Runtime.GetDisplayName`
  - `Mono.Runtime.GetNativeStackTrace`
  - `System.Enum.GetEnumValuesAndNames` 
  - `System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray`