### PR TITLE
[4.6] Handle relocatable libMonoPosixHelper.so when --libdir= isn't lib/

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,11 @@ AC_SUBST(libmono_cflags)
 AC_SUBST(libmono_ldflags)
 
 # Variable to have relocatable .pc files (lib, or lib64)
-reloc_libdir=`basename ${libdir}`
+# realpath isn't always available, and requires that all but the tip of the provided
+# path exists. Fall back to the old behaviour, but realpath allows depth >1
+# e.g. Debian puts Mono in /usr/bin and libs in /usr/lib/x86_64-linux-gnu/ which is
+# too deep for the old method to work
+reloc_libdir=`realpath --relative-to=${prefix} ${libdir} 2> /dev/null || basename ${libdir}`
 AC_SUBST(reloc_libdir)
 
 # Set to yes if Unix sockets cannot be created in an anonymous namespace

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -88,7 +88,7 @@ mono-config-dirs.lo: Makefile
 libmonoruntime_config_la_SOURCES = \
 	mono-config-dirs.h		\
 	mono-config-dirs.c
-libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\"
+libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\" -DMONO_RELOC_LIBDIR=\"../$(reloc_libdir)\"
 
 CLEANFILES = mono-bundle.stamp
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -557,6 +557,21 @@ mono_assembly_getrootdir (void)
 }
 
 /**
+ * mono_native_getrootdir:
+ * 
+ * Obtains the root directory used for looking up native libs (.so, .dylib).
+ *
+ * Returns: a string with the directory, this string should be freed by
+ * the caller.
+ */
+G_CONST_RETURN gchar *
+mono_native_getrootdir (void)
+{
+	gchar* fullpath = g_build_path (G_DIR_SEPARATOR_S, mono_assembly_getrootdir (), mono_config_get_reloc_lib_dir(), NULL);
+	return fullpath;
+}
+
+/**
  * mono_set_dirs:
  * @assembly_dir: the base directory for assemblies
  * @config_dir: the base directory for configuration files

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -564,7 +564,7 @@ mono_assembly_getrootdir (void)
  * Returns: a string with the directory, this string should be freed by
  * the caller.
  */
-G_CONST_RETURN gchar *
+gchar *
 mono_native_getrootdir (void)
 {
 	gchar* fullpath = g_build_path (G_DIR_SEPARATOR_S, mono_assembly_getrootdir (), mono_config_get_reloc_lib_dir(), NULL);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -36,6 +36,7 @@ MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32
 MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
 MONO_API void          mono_assembly_setrootdir (const char *root_dir);
 MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
+MONO_API MONO_CONST_RETURN char *mono_native_getrootdir (void);
 MONO_API void	      mono_assembly_foreach    (MonoFunc func, void* user_data);
 MONO_API void          mono_assembly_set_main   (MonoAssembly *assembly);
 MONO_API MonoAssembly *mono_assembly_get_main   (void);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -36,8 +36,8 @@ MONO_API MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32
 MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
 MONO_API void          mono_assembly_setrootdir (const char *root_dir);
 MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
-MONO_API MONO_CONST_RETURN char *mono_native_getrootdir (void);
-MONO_API void	      mono_assembly_foreach    (MonoFunc func, void* user_data);
+MONO_API               char *mono_native_getrootdir (void);
+MONO_API void          mono_assembly_foreach    (MonoFunc func, void* user_data);
 MONO_API void          mono_assembly_set_main   (MonoAssembly *assembly);
 MONO_API MonoAssembly *mono_assembly_get_main   (void);
 MONO_API MonoImage    *mono_assembly_get_image  (MonoAssembly *assembly);

--- a/mono/metadata/mono-config-dirs.c
+++ b/mono/metadata/mono-config-dirs.c
@@ -41,3 +41,13 @@ mono_config_get_bin_dir (void)
 #endif
 }
 
+const char*
+mono_config_get_reloc_lib_dir (void)
+{
+#ifdef MONO_RELOC_LIBDIR
+	return MONO_RELOC_LIBDIR;
+#else
+	return NULL;
+#endif
+}
+

--- a/mono/metadata/mono-config-dirs.h
+++ b/mono/metadata/mono-config-dirs.h
@@ -13,4 +13,7 @@ mono_config_get_cfg_dir (void);
 const char*
 mono_config_get_bin_dir (void);
 
+const char*
+mono_config_get_reloc_lib_dir (void);
+
 #endif

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -314,13 +314,14 @@ dllmap_start (gpointer user_data,
 			else if (strcmp (attribute_names [i], "target") == 0){
 				char *p = strstr (attribute_values [i], "$mono_libdir");
 				if (p != NULL){
-					const char *libdir = mono_assembly_getrootdir ();
+					const char *libdir = mono_native_getrootdir ();
 					size_t libdir_len = strlen (libdir);
 					char *result;
 					
 					result = (char *)g_malloc (libdir_len-strlen("$mono_libdir")+strlen(attribute_values[i])+1);
 					strncpy (result, attribute_values[i], p-attribute_values[i]);
 					strcpy (result+(p-attribute_values[i]), libdir);
+					g_free (libdir);
 					strcat (result, p+strlen("$mono_libdir"));
 					info->target = result;
 				} else 

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -314,7 +314,7 @@ dllmap_start (gpointer user_data,
 			else if (strcmp (attribute_names [i], "target") == 0){
 				char *p = strstr (attribute_values [i], "$mono_libdir");
 				if (p != NULL){
-					const char *libdir = mono_native_getrootdir ();
+					char *libdir = mono_native_getrootdir ();
 					size_t libdir_len = strlen (libdir);
 					char *result;
 					


### PR DESCRIPTION
Backported from PR #3591 (a342bb00ca0e7b7c5267845f45b928055f412b2c)

This change is critical on 64-bit Redhat based distributions