### PR TITLE
More MonoClass reorg, replace 3 fields with a property bag

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -201,6 +201,8 @@ common_sources = \
 	number-ms.h		\
 	object-internals.h	\
 	opcodes.c		\
+	property-bag.h	\
+	property-bag.c	\
 	socket-io.c		\
 	socket-io.h		\
 	w32process.c		\

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -9,6 +9,7 @@
 enum InfrequentDataKind {
 	PROP_MARSHAL_INFO = 1, /* MonoMarshalType */
 	PROP_EXT = 2, /* MonoClassExt */
+	PROP_REF_INFO_HANDLE = 3, /* gchandle */
 };
 
 /* Accessors based on class kind*/
@@ -252,4 +253,33 @@ mono_class_set_ext (MonoClass *class, MonoClassExt *ext)
 {
 	ext->head.tag = PROP_EXT;
 	mono_property_bag_add (&class->infrequent_data, ext);
+}
+
+typedef struct {
+	MonoPropertyBagItem head;
+	guint32 value;
+} Uint32Property;
+
+guint32
+mono_class_get_ref_info_handle (MonoClass *class)
+{
+	Uint32Property *prop = mono_property_bag_get (&class->infrequent_data, PROP_REF_INFO_HANDLE);
+	return prop ? prop->value : 0;
+}
+
+guint32
+mono_class_set_ref_info_handle (MonoClass *class, guint32 value)
+{
+	if (!value) {
+		Uint32Property *prop = mono_property_bag_get (&class->infrequent_data, PROP_REF_INFO_HANDLE);
+		if (prop)
+			prop->value = 0;
+		return 0;
+	}
+
+	Uint32Property *prop = mono_class_alloc (class, sizeof (Uint32Property));
+	prop->head.tag = PROP_REF_INFO_HANDLE;
+	prop->value = value;
+	prop = mono_property_bag_add (&class->infrequent_data, prop);
+	return prop->value;
 }

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -234,3 +234,16 @@ mono_class_set_marshal_info (MonoClass *class, MonoMarshalType *marshal_info)
 {
 	class->marshal_info = marshal_info;
 }
+
+MonoClassExt*
+mono_class_get_ext (MonoClass *class)
+{
+	return class->ext;
+}
+
+void
+mono_class_set_ext (MonoClass *class, MonoClassExt *ext)
+{
+	class->ext = ext;
+}
+

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -222,3 +222,15 @@ mono_class_set_field_count (MonoClass *klass, guint32 count)
 		break;
 	}
 }
+
+MonoMarshalType*
+mono_class_get_marshal_info (MonoClass *class)
+{
+	return class->marshal_info;
+}
+
+void
+mono_class_set_marshal_info (MonoClass *class, MonoMarshalType *marshal_info)
+{
+	class->marshal_info = marshal_info;
+}

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -6,6 +6,11 @@
 #include <mono/metadata/tabledefs.h>
 
 
+enum InfrequentDataKind {
+	PROP_MARSHAL_INFO = 1, /* MonoMarshalType */
+	PROP_EXT = 2, /* MonoClassExt */
+};
+
 /* Accessors based on class kind*/
 
 /*
@@ -226,24 +231,25 @@ mono_class_set_field_count (MonoClass *klass, guint32 count)
 MonoMarshalType*
 mono_class_get_marshal_info (MonoClass *class)
 {
-	return class->marshal_info;
+	return mono_property_bag_get (&class->infrequent_data, PROP_MARSHAL_INFO);
 }
 
 void
 mono_class_set_marshal_info (MonoClass *class, MonoMarshalType *marshal_info)
 {
-	class->marshal_info = marshal_info;
+	marshal_info->head.tag = PROP_MARSHAL_INFO;
+	mono_property_bag_add (&class->infrequent_data, marshal_info);
 }
 
 MonoClassExt*
 mono_class_get_ext (MonoClass *class)
 {
-	return class->ext;
+	return mono_property_bag_get (&class->infrequent_data, PROP_EXT);
 }
 
 void
 mono_class_set_ext (MonoClass *class, MonoClassExt *ext)
 {
-	class->ext = ext;
+	ext->head.tag = PROP_EXT;
+	mono_property_bag_add (&class->infrequent_data, ext);
 }
-

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -9,6 +9,7 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/mempool.h>
 #include <mono/metadata/metadata-internals.h>
+#include <mono/metadata/property-bag.h>
 #include <mono/io-layer/io-layer.h>
 #include "mono/utils/mono-compiler.h"
 #include "mono/utils/mono-error.h"
@@ -164,6 +165,8 @@ typedef struct {
 } MonoMarshalField;
 
 typedef struct {
+	MonoPropertyBagItem head;
+
 	guint32 native_size, min_align;
 	guint32 num_fields;
 	MonoMethod *ptr_to_str;
@@ -232,6 +235,8 @@ typedef struct {
  * be used for fields which are only used in like 5% of all classes.
  */
 typedef struct {
+	MonoPropertyBagItem head;
+
 	struct {
 #if MONO_SMALL_CONFIG
 		guint16 first, count;
@@ -365,9 +370,6 @@ struct _MonoClass {
 	/* A GC handle pointing to the corresponding type builder/generic param builder */
 	guint32 ref_info_handle;
 
-	/* loaded on demand */
-	MonoMarshalType *marshal_info;
-
 	/*
 	 * Field information: Type and location from object base
 	 */
@@ -386,8 +388,8 @@ struct _MonoClass {
 	/* Generic vtable. Initialized by a call to mono_class_setup_vtable () */
 	MonoMethod **vtable;
 
-	/* Rarely used fields of classes */
-	MonoClassExt *ext;
+	/* Infrequently used items. See class-accessors.c: InfrequentDataKind for what goes into here. */
+	MonoPropertyBag infrequent_data;
 };
 
 typedef struct {

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1494,6 +1494,12 @@ mono_class_get_field_count (MonoClass *klass);
 void
 mono_class_set_field_count (MonoClass *klass, guint32 count);
 
+MonoMarshalType*
+mono_class_get_marshal_info (MonoClass *class);
+
+void
+mono_class_set_marshal_info (MonoClass *class, MonoMarshalType *marshal_info);
+
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -367,9 +367,6 @@ struct _MonoClass {
 		int generic_param_token; /* for generic param types, both var and mvar */
 	} sizes;
 
-	/* A GC handle pointing to the corresponding type builder/generic param builder */
-	guint32 ref_info_handle;
-
 	/*
 	 * Field information: Type and location from object base
 	 */
@@ -1507,6 +1504,12 @@ mono_class_get_ext (MonoClass *class);
 
 void
 mono_class_set_ext (MonoClass *class, MonoClassExt *ext);
+
+guint32
+mono_class_get_ref_info_handle (MonoClass *class);
+
+guint32
+mono_class_set_ref_info_handle (MonoClass *class, guint32 value);
 
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1500,6 +1500,12 @@ mono_class_get_marshal_info (MonoClass *class);
 void
 mono_class_set_marshal_info (MonoClass *class, MonoMarshalType *marshal_info);
 
+MonoClassExt*
+mono_class_get_ext (MonoClass *class);
+
+void
+mono_class_set_ext (MonoClass *class, MonoClassExt *ext);
+
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -6772,9 +6772,10 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		mono_class_set_failure (klass, mono_error_box (&prepared_error, klass->image));
 		mono_error_cleanup (&prepared_error);
 	} else if (eclass->enumtype && !mono_class_enum_basetype (eclass)) {
-		if (!eclass->ref_info_handle || eclass->wastypebuilder) {
+		guint32 ref_info_handle = mono_class_get_ref_info_handle (eclass);
+		if (!ref_info_handle || eclass->wastypebuilder) {
 			g_warning ("Only incomplete TypeBuilder objects are allowed to be an enum without base_type");
-			g_assert (eclass->ref_info_handle && !eclass->wastypebuilder);
+			g_assert (ref_info_handle && !eclass->wastypebuilder);
 		}
 		/* element_size -1 is ok as this is not an instantitable type*/
 		klass->sizes.element_size = -1;
@@ -8383,7 +8384,7 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 		}
 
 		/* interface_offsets might not be set for dynamic classes */
-		if (oklass->ref_info_handle && !oklass->interface_bitmap) {
+		if (mono_class_get_ref_info_handle (oklass) && !oklass->interface_bitmap) {
 			/* 
 			 * oklass might be a generic type parameter but they have 
 			 * interface_offsets set.

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -134,10 +134,11 @@ find_field_index (MonoClass *klass, MonoClassField *field) {
 static guint32
 find_property_index (MonoClass *klass, MonoProperty *property) {
 	int i;
+	MonoClassExt *ext = mono_class_get_ext (klass);
 
-	for (i = 0; i < klass->ext->property.count; ++i) {
-		if (property == &klass->ext->properties [i])
-			return klass->ext->property.first + 1 + i;
+	for (i = 0; i < ext->property.count; ++i) {
+		if (property == &ext->properties [i])
+			return ext->property.first + 1 + i;
 	}
 	return 0;
 }
@@ -148,10 +149,11 @@ find_property_index (MonoClass *klass, MonoProperty *property) {
 static guint32
 find_event_index (MonoClass *klass, MonoEvent *event) {
 	int i;
+	MonoClassExt *ext = mono_class_get_ext (klass);
 
-	for (i = 0; i < klass->ext->event.count; ++i) {
-		if (event == &klass->ext->events [i])
-			return klass->ext->event.first + 1 + i;
+	for (i = 0; i < ext->event.count; ++i) {
+		if (event == &ext->events [i])
+			return ext->event.first + 1 + i;
 	}
 	return 0;
 }

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2098,12 +2098,13 @@ ves_icall_MonoField_GetRawConstantValue (MonoReflectionField *rfield)
 	if (image_is_dynamic (field->parent->image)) {
 		MonoClass *klass = field->parent;
 		int fidx = field - klass->fields;
+		MonoClassExt *ext = mono_class_get_ext (klass);
 
-		g_assert (fidx >= 0 && fidx < mono_class_get_field_count (klass));
-		g_assert (klass->ext);
-		g_assert (klass->ext->field_def_values);
-		def_type = klass->ext->field_def_values [fidx].def_type;
-		def_value = klass->ext->field_def_values [fidx].data;
+		g_assert (ext);
+		g_assert (ext->field_def_values);
+		def_type = ext->field_def_values [fidx].def_type;
+		def_value = ext->field_def_values [fidx].data;
+
 		if (def_type == MONO_TYPE_END) {
 			mono_set_pending_exception (mono_get_exception_invalid_operation (NULL));
 			return NULL;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -9128,8 +9128,8 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 
 	mono_marshal_load_type_info (klass);
 
-	if (klass->marshal_info->str_to_ptr)
-		return klass->marshal_info->str_to_ptr;
+	if (mono_class_get_marshal_info (klass)->str_to_ptr)
+		return mono_class_get_marshal_info (klass)->str_to_ptr;
 
 	if (!stoptr) 
 		stoptr = mono_class_get_method_from_name (mono_defaults.marshal_class, "StructureToPtr", 3);
@@ -9175,10 +9175,10 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 	mono_mb_free (mb);
 
 	mono_marshal_lock ();
-	if (!klass->marshal_info->str_to_ptr)
-		klass->marshal_info->str_to_ptr = res;
+	if (!mono_class_get_marshal_info (klass)->str_to_ptr)
+		mono_class_get_marshal_info (klass)->str_to_ptr = res;
 	else
-		res = klass->marshal_info->str_to_ptr;
+		res = mono_class_get_marshal_info (klass)->str_to_ptr;
 	mono_marshal_unlock ();
 	return res;
 }
@@ -9201,8 +9201,8 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 
 	mono_marshal_load_type_info (klass);
 
-	if (klass->marshal_info->ptr_to_str)
-		return klass->marshal_info->ptr_to_str;
+	if (mono_class_get_marshal_info (klass)->ptr_to_str)
+		return mono_class_get_marshal_info (klass)->ptr_to_str;
 
 	if (!ptostr) {
 		MonoMethodSignature *sig;
@@ -9253,10 +9253,10 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 	mono_mb_free (mb);
 
 	mono_marshal_lock ();
-	if (!klass->marshal_info->ptr_to_str)
-		klass->marshal_info->ptr_to_str = res;
+	if (!mono_class_get_marshal_info (klass)->ptr_to_str)
+		mono_class_get_marshal_info (klass)->ptr_to_str = res;
 	else
-		res = klass->marshal_info->ptr_to_str;
+		res = mono_class_get_marshal_info (klass)->ptr_to_str;
 	mono_marshal_unlock ();
 	return res;
 }
@@ -11233,7 +11233,7 @@ mono_marshal_is_loading_type_info (MonoClass *klass)
 /**
  * mono_marshal_load_type_info:
  *
- *  Initialize klass->marshal_info using information from metadata. This function can
+ *  Initialize klass::marshal_info using information from metadata. This function can
  * recursively call itself, and the caller is responsible to avoid that by calling 
  * mono_marshal_is_loading_type_info () beforehand.
  *
@@ -11252,14 +11252,14 @@ mono_marshal_load_type_info (MonoClass* klass)
 
 	g_assert (klass != NULL);
 
-	if (klass->marshal_info)
-		return klass->marshal_info;
+	if (mono_class_get_marshal_info (klass))
+		return mono_class_get_marshal_info (klass);
 
 	if (!klass->inited)
 		mono_class_init (klass);
 
-	if (klass->marshal_info)
-		return klass->marshal_info;
+	if (mono_class_get_marshal_info (klass))
+		return mono_class_get_marshal_info (klass);
 
 	/*
 	 * This function can recursively call itself, so we keep the list of classes which are
@@ -11381,15 +11381,15 @@ mono_marshal_load_type_info (MonoClass* klass)
 	mono_native_tls_set_value (load_type_info_tls_id, loads_list);
 
 	mono_marshal_lock ();
-	if (!klass->marshal_info) {
+	if (!mono_class_get_marshal_info (klass)) {
 		/*We do double-checking locking on marshal_info */
 		mono_memory_barrier ();
-		klass->marshal_info = info;
+		mono_class_set_marshal_info (klass, info);
 		++class_marshal_info_count;
 	}
 	mono_marshal_unlock ();
 
-	return klass->marshal_info;
+	return mono_class_get_marshal_info (klass);
 }
 
 /**
@@ -11402,7 +11402,7 @@ mono_marshal_load_type_info (MonoClass* klass)
 gint32
 mono_class_native_size (MonoClass *klass, guint32 *align)
 {	
-	if (!klass->marshal_info) {
+	if (!mono_class_get_marshal_info (klass)) {
 		if (mono_marshal_is_loading_type_info (klass)) {
 			if (align)
 				*align = 0;
@@ -11413,9 +11413,9 @@ mono_class_native_size (MonoClass *klass, guint32 *align)
 	}
 
 	if (align)
-		*align = klass->marshal_info->min_align;
+		*align = mono_class_get_marshal_info (klass)->min_align;
 
-	return klass->marshal_info->native_size;
+	return mono_class_get_marshal_info (klass)->native_size;
 }
 
 /*

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -9128,8 +9128,9 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 
 	mono_marshal_load_type_info (klass);
 
-	if (mono_class_get_marshal_info (klass)->str_to_ptr)
-		return mono_class_get_marshal_info (klass)->str_to_ptr;
+	MonoMarshalType *marshal_info = mono_class_get_marshal_info (klass);
+	if (marshal_info->str_to_ptr)
+		return marshal_info->str_to_ptr;
 
 	if (!stoptr) 
 		stoptr = mono_class_get_method_from_name (mono_defaults.marshal_class, "StructureToPtr", 3);
@@ -9175,10 +9176,10 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 	mono_mb_free (mb);
 
 	mono_marshal_lock ();
-	if (!mono_class_get_marshal_info (klass)->str_to_ptr)
-		mono_class_get_marshal_info (klass)->str_to_ptr = res;
+	if (!marshal_info->str_to_ptr)
+		marshal_info->str_to_ptr = res;
 	else
-		res = mono_class_get_marshal_info (klass)->str_to_ptr;
+		res = marshal_info->str_to_ptr;
 	mono_marshal_unlock ();
 	return res;
 }
@@ -9201,8 +9202,9 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 
 	mono_marshal_load_type_info (klass);
 
-	if (mono_class_get_marshal_info (klass)->ptr_to_str)
-		return mono_class_get_marshal_info (klass)->ptr_to_str;
+	MonoMarshalType *marshal_info = mono_class_get_marshal_info (klass);
+	if (marshal_info->ptr_to_str)
+		return marshal_info->ptr_to_str;
 
 	if (!ptostr) {
 		MonoMethodSignature *sig;
@@ -9253,10 +9255,10 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 	mono_mb_free (mb);
 
 	mono_marshal_lock ();
-	if (!mono_class_get_marshal_info (klass)->ptr_to_str)
-		mono_class_get_marshal_info (klass)->ptr_to_str = res;
+	if (!marshal_info->ptr_to_str)
+		marshal_info->ptr_to_str = res;
 	else
-		res = mono_class_get_marshal_info (klass)->ptr_to_str;
+		res = marshal_info->ptr_to_str;
 	mono_marshal_unlock ();
 	return res;
 }
@@ -11252,14 +11254,16 @@ mono_marshal_load_type_info (MonoClass* klass)
 
 	g_assert (klass != NULL);
 
-	if (mono_class_get_marshal_info (klass))
-		return mono_class_get_marshal_info (klass);
+	info = mono_class_get_marshal_info (klass);
+	if (info)
+		return info;
 
 	if (!klass->inited)
 		mono_class_init (klass);
 
-	if (mono_class_get_marshal_info (klass))
-		return mono_class_get_marshal_info (klass);
+	info = mono_class_get_marshal_info (klass);
+	if (info)
+		return info;
 
 	/*
 	 * This function can recursively call itself, so we keep the list of classes which are
@@ -11381,15 +11385,17 @@ mono_marshal_load_type_info (MonoClass* klass)
 	mono_native_tls_set_value (load_type_info_tls_id, loads_list);
 
 	mono_marshal_lock ();
-	if (!mono_class_get_marshal_info (klass)) {
+	MonoMarshalType *info2 = mono_class_get_marshal_info (klass);
+	if (!info2) {
 		/*We do double-checking locking on marshal_info */
 		mono_memory_barrier ();
 		mono_class_set_marshal_info (klass, info);
 		++class_marshal_info_count;
+		info2 = info;
 	}
 	mono_marshal_unlock ();
 
-	return mono_class_get_marshal_info (klass);
+	return info2;
 }
 
 /**
@@ -11401,8 +11407,9 @@ mono_marshal_load_type_info (MonoClass* klass)
  */
 gint32
 mono_class_native_size (MonoClass *klass, guint32 *align)
-{	
-	if (!mono_class_get_marshal_info (klass)) {
+{
+	MonoMarshalType *info = mono_class_get_marshal_info (klass);
+	if (!info) {
 		if (mono_marshal_is_loading_type_info (klass)) {
 			if (align)
 				*align = 0;
@@ -11410,12 +11417,13 @@ mono_class_native_size (MonoClass *klass, guint32 *align)
 		} else {
 			mono_marshal_load_type_info (klass);
 		}
+		info = mono_class_get_marshal_info (klass);
 	}
 
 	if (align)
-		*align = mono_class_get_marshal_info (klass)->min_align;
+		*align = info->min_align;
 
-	return mono_class_get_marshal_info (klass)->native_size;
+	return info->native_size;
 }
 
 /*

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6634,8 +6634,8 @@ mono_metadata_get_corresponding_event_from_generic_type_definition (MonoEvent *e
 		return event;
 
 	gtd = mono_class_get_generic_class (event->parent)->container_class;
-	offset = event - event->parent->ext->events;
-	return gtd->ext->events + offset;
+	offset = event - mono_class_get_ext (event->parent)->events;
+	return mono_class_get_ext (gtd)->events + offset;
 }
 
 /*
@@ -6652,8 +6652,8 @@ mono_metadata_get_corresponding_property_from_generic_type_definition (MonoPrope
 		return property;
 
 	gtd = mono_class_get_generic_class (property->parent)->container_class;
-	offset = property - property->parent->ext->properties;
-	return gtd->ext->properties + offset;
+	offset = property - mono_class_get_ext (property->parent)->properties;
+	return mono_class_get_ext (gtd)->properties + offset;
 }
 
 MonoWrapperCaches*

--- a/mono/metadata/property-bag.c
+++ b/mono/metadata/property-bag.c
@@ -1,0 +1,49 @@
+
+/*
+ * property-bag.c: Linearizable property bag.
+ *
+ * Authors:
+ *   Rodrigo Kumpera (kumpera@gmail.com)
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#include <mono/metadata/property-bag.h>
+#include <mono/utils/atomic.h>
+#include <mono/utils/mono-membar.h>
+
+void*
+mono_property_bag_get (MonoPropertyBag *bag, int tag)
+{
+	MonoPropertyBagItem *item;
+	
+	for (item = bag->head; item && item->tag <= tag; item = item->next) {
+		if (item->tag == tag)
+			return item;
+	}
+	return NULL;
+}
+
+void*
+mono_property_bag_add (MonoPropertyBag *bag, void *value)
+{
+	MonoPropertyBagItem *cur, **prev, *item = value;
+	int tag = item->tag;
+	mono_memory_barrier (); //publish the values in value
+
+retry:
+	prev = &bag->head;
+	while (1) {
+		cur = *prev;
+		if (!cur || cur->tag > tag) {
+			item->next = cur;
+			if (InterlockedCompareExchangePointer ((void*)prev, item, cur) == cur)
+				return item;
+			goto retry;
+		} else if (cur->tag == tag) {
+			return cur;
+		} else {
+			prev = &cur->next;
+		}
+	}
+	return value;
+}

--- a/mono/metadata/property-bag.h
+++ b/mono/metadata/property-bag.h
@@ -1,0 +1,28 @@
+/*
+ * property-bag.h: Linearizable property bag.
+ *
+ * Authors:
+ *   Rodrigo Kumpera (kumpera@gmail.com)
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_METADATA_PROPERTY_BAG_H__
+#define __MONO_METADATA_PROPERTY_BAG_H__
+
+#include <mono/utils/mono-compiler.h>
+
+typedef struct _MonoPropertyBagItem MonoPropertyBagItem;
+
+struct _MonoPropertyBagItem {
+	MonoPropertyBagItem *next;
+	int tag;
+};
+
+typedef struct {
+	MonoPropertyBagItem *head;
+} MonoPropertyBag;
+
+void* mono_property_bag_get (MonoPropertyBag *bag, int tag);
+void* mono_property_bag_add (MonoPropertyBag *bag, void *value);
+
+#endif

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -2363,7 +2363,8 @@ guint32
 mono_declsec_flags_from_class (MonoClass *klass)
 {
 	if (mono_class_get_flags (klass) & TYPE_ATTRIBUTE_HAS_SECURITY) {
-		if (!klass->ext || !klass->ext->declsec_flags) {
+		MonoClassExt *ext = mono_class_get_ext (klass);
+		if (!ext || !ext->declsec_flags) {
 			guint32 idx;
 
 			idx = mono_metadata_token_index (klass->type_token);
@@ -2371,11 +2372,12 @@ mono_declsec_flags_from_class (MonoClass *klass)
 			idx |= MONO_HAS_DECL_SECURITY_TYPEDEF;
 			mono_loader_lock ();
 			mono_class_alloc_ext (klass);
+			ext = mono_class_get_ext (klass);
 			mono_loader_unlock ();
 			/* we cache the flags on classes */
-			klass->ext->declsec_flags = mono_declsec_get_flags (klass->image, idx);
+			ext->declsec_flags = mono_declsec_get_flags (klass->image, idx);
 		}
-		return klass->ext->declsec_flags;
+		return ext->declsec_flags;
 	}
 	return 0;
 }

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1217,10 +1217,11 @@ mono_image_fill_export_table_from_class (MonoDomain *domain, MonoClass *klass,
 	table->next_idx ++;
 
 	/* Emit nested types */
-	if (klass->ext && klass->ext->nested_classes) {
+	MonoClassExt *ext = mono_class_get_ext (klass);
+	if (ext && ext->nested_classes) {
 		GList *tmp;
 
-		for (tmp = klass->ext->nested_classes; tmp; tmp = tmp->next)
+		for (tmp = ext->nested_classes; tmp; tmp = tmp->next)
 			mono_image_fill_export_table_from_class (domain, (MonoClass *)tmp->data, module_index, table->next_idx - 1, assembly);
 	}
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6314,7 +6314,7 @@ emit_klass_info (MonoAotCompile *acfg, guint32 token)
 		encode_value (-1, p, &p);
 	} else {
 		encode_value (klass->vtable_size, p, &p);
-		encode_value ((mono_class_is_gtd (klass) ? (1 << 8) : 0) | (no_special_static << 7) | (klass->has_static_refs << 6) | (klass->has_references << 5) | ((klass->blittable << 4) | ((klass->ext && klass->ext->nested_classes) ? 1 : 0) << 3) | (klass->has_cctor << 2) | (klass->has_finalize << 1) | klass->ghcimpl, p, &p);
+		encode_value ((mono_class_is_gtd (klass) ? (1 << 8) : 0) | (no_special_static << 7) | (klass->has_static_refs << 6) | (klass->has_references << 5) | ((klass->blittable << 4) | ((mono_class_get_ext (klass) && mono_class_get_ext (klass)->nested_classes) ? 1 : 0) << 3) | (klass->has_cctor << 2) | (klass->has_finalize << 1) | klass->ghcimpl, p, &p);
 		if (klass->has_cctor)
 			encode_method_ref (acfg, mono_class_get_cctor (klass), p, &p);
 		if (klass->has_finalize)


### PR DESCRIPTION
This PR removes the following fields: marshal_info, ref_info_handle and ext. It introduces an infrequent_data field that is made out of a property bag.

A property bag is a lock-free linearizable set that supports adding (but not removing).

