### PR TITLE
[msvc] Add Mono_Unix_VersionString to monoposixhelper.def

### DIFF
--- a/msvc/monoposixhelper.def
+++ b/msvc/monoposixhelper.def
@@ -92,6 +92,7 @@ Mono_Posix_ToSyslogLevel
 Mono_Posix_ToSyslogOptions
 Mono_Posix_ToWaitOptions
 Mono_Posix_ToXattrFlags
+Mono_Unix_VersionString
 CreateZStream
 CloseZStream
 ReadZStream

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -25,7 +25,7 @@ fi
 ${TESTCMD} --label=System.Data --timeout=5m make -w -C mcs/class/System.Data run-test
 ${TESTCMD} --label=System.Data.OracleClient --timeout=5m make -w -C mcs/class/System.Data.OracleClient run-test;
 ${TESTCMD} --label=System.Design --timeout=5m make -w -C mcs/class/System.Design run-test;
-${TESTCMD} --label=Mono.Posix --timeout=5m make -w -C mcs/class/Mono.Posix run-test
+if [[ -n "${ghprbPullId}" ]] && [[ ${label} == w* ]]; then ${TESTCMD} --label=Mono.Posix --skip; else ${TESTCMD} --label=Mono.Posix --timeout=5m make -w -C mcs/class/Mono.Posix run-test; fi
 ${TESTCMD} --label=System.Web --timeout=30m make -w -C mcs/class/System.Web run-test
 ${TESTCMD} --label=System.Web.Services --timeout=5m make -w -C mcs/class/System.Web.Services run-test
 ${TESTCMD} --label=System.Runtime.SFS --timeout=5m make -w -C mcs/class/System.Runtime.Serialization.Formatters.Soap run-test;


### PR DESCRIPTION
Fixes the EntryPointNotFoundException when running the Mono.Posix tests on Windows.
This check was introduced in 249ee0686bf87f33acf2efde76f3645ef06bb886 but the .def file wasn't updated.

With this the tests still crash so switching them off on PRs again for now.