### PR TITLE
[bcl] Deprecate old NUnit 2.4 framework shipped with Mono

### DIFF
--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -18,7 +18,7 @@
   {
     "name": "ms-test-suite", 
     "url": "git@github.com:xamarin/ms-test-suite.git", 
-    "rev": "eb7cd709549bffe170653a50805f1593d66ea81e", 
+    "rev": "55b6637eb1de61c743323ec82db1e0cadfee5b32", 
     "remote-branch": "origin/master", 
     "branch": "master", 
     "directory": "ms-test-suite"

--- a/acceptance-tests/ms-test-suite.mk
+++ b/acceptance-tests/ms-test-suite.mk
@@ -1,7 +1,7 @@
 check-ms-test-suite:
 	@if $(MAKE) validate-ms-test-suite RESET_VERSIONS=1; then \
-		$(MAKE) -C $(MSTESTSUITE_PATH)/conformance build MCS="$(MCS) -debug -t:library -warn:1 -r:nunit.framework" && \
-		$(MAKE) -C $(MSTESTSUITE_PATH)/conformance run NUNIT-CONSOLE="$(RUNTIME) $(CLASS)/nunit-console.exe -nologo -exclude=MonoBug,BadTest" NUNIT_XML_RESULT=$(abs_top_builddir)/acceptance-tests/TestResult-ms-test-suite-conformance.xml || EXIT_CODE=1; \
+		$(MAKE) -C $(MSTESTSUITE_PATH)/conformance build MCS="$(MCS) -debug -t:library -warn:1 -r:nunitlite.dll" && \
+		$(MAKE) -C $(MSTESTSUITE_PATH)/conformance run NUNIT-CONSOLE="$(RUNTIME) $(CLASS)/nunit-lite-console.exe -exclude=MonoBug,BadTest -format:nunit2" NUNIT_XML_RESULT="-result:$(abs_top_builddir)/acceptance-tests/TestResult-ms-test-suite-conformance.xml" || EXIT_CODE=1; \
 		$(MAKE) -C $(MSTESTSUITE_PATH)/systemruntimebringup build MCS="$(MCS) -debug -warn:1" && \
 		$(MAKE) -C $(MSTESTSUITE_PATH)/systemruntimebringup run MONO="$(RUNTIME)" || EXIT_CODE=1; \
 		exit $$EXIT_CODE; \

--- a/mcs/nunit24/ConsoleRunner/nunit-console-exe/Class1.cs
+++ b/mcs/nunit24/ConsoleRunner/nunit-console-exe/Class1.cs
@@ -19,6 +19,9 @@ namespace NUnit.ConsoleRunner
 		[STAThread]
 		public static int Main(string[] args)
 		{
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.WriteLine ("Note: nunit-console shipped with Mono is deprecated, please use the NUnit NuGet package or some other form of acquiring NUnit.");
+			Console.ResetColor ();
 			return Runner.Main( args );
 		}
 	}

--- a/mcs/nunit24/NUnitFramework/framework/TestFixtureAttribute.cs
+++ b/mcs/nunit24/NUnitFramework/framework/TestFixtureAttribute.cs
@@ -14,6 +14,7 @@ namespace NUnit.Framework
 	/// {}
 	/// </example>
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+	[Obsolete ("The NUnit framework shipped with Mono is deprecated and will be removed in a future release. It was based on NUnit 2.4 which is long outdated. Please move to the NUnit NuGet package or some other form of acquiring NUnit.", true)]
 	public class TestFixtureAttribute : Attribute
 	{
 		private string description;


### PR DESCRIPTION
Print a message when running nunit-console about the deprecation.
Additionally, throw a compilation error if compiling against the TestFixtureAttribute from old NUnit.

Needed changes in ms-test-suite as well since it was still using NUnit.

**Note**: please leave merging to me since I need to coordinate a Wrench change with this.