### PR TITLE
MonoClass cleanup: array rank accessors, sizes union to MonoClass subtypes

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -1054,7 +1054,7 @@ get_escaped_class_name (MonoClass *c)
 		/* <Module> */
 		return NULL;
 
-	if (c->rank || c->byval_arg.type == MONO_TYPE_PTR) 
+	if (mono_class_is_array (c) || c->byval_arg.type == MONO_TYPE_PTR) 
 		g_assert (0);
 
 	esname = get_escaped_name (c->name);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1154,7 +1154,7 @@ mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean know
 		return NULL;
 	if (mono_profiler_get_events () & (MONO_PROFILE_ALLOCATIONS | MONO_PROFILE_STATISTICAL))
 		return NULL;
-	if (klass->rank)
+	if (mono_class_is_array (klass))
 		return NULL;
 	if (mono_class_is_open_constructed_type (&klass->byval_arg))
 		return NULL;

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -284,6 +284,20 @@ mono_class_set_ref_info_handle (MonoClass *class, guint32 value)
 	return prop->value;
 }
 
+guint8
+mono_class_get_array_rank (MonoClass *klass)
+{
+	g_assert (klass->class_kind == MONO_CLASS_ARRAY);
+	return klass->rank;
+}
+
+void
+mono_class_set_array_rank (MonoClass *klass, guint8 rank)
+{
+	g_assert (rank == 0 || klass->class_kind == MONO_CLASS_ARRAY);
+	klass->rank = rank;
+}
+
 void
 mono_class_set_class_size (MonoClass *klass, guint32 class_size)
 {

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -283,3 +283,61 @@ mono_class_set_ref_info_handle (MonoClass *class, guint32 value)
 	prop = mono_property_bag_add (&class->infrequent_data, prop);
 	return prop->value;
 }
+
+void
+mono_class_set_class_size (MonoClass *klass, guint32 class_size)
+{
+	switch (klass->class_kind) {
+	case MONO_CLASS_DEF:
+	case MONO_CLASS_GTD:
+		((MonoClassDef*)klass)->class_size = class_size;
+		break;
+	case MONO_CLASS_GINST:
+		((MonoClassGenericInst*)klass)->class_size = class_size;
+		break;
+	default:
+		g_assert_not_reached ();
+	}
+}
+
+guint32
+mono_class_get_class_size (MonoClass *klass)
+{
+	switch (klass->class_kind) {
+	case MONO_CLASS_DEF:
+	case MONO_CLASS_GTD:
+	case MONO_CLASS_GINST:
+		return ((MonoClassGenericInst*)klass)->class_size;
+	default:
+		g_assert_not_reached ();
+	}
+}
+
+
+void
+mono_class_set_generic_param_token (MonoClass *klass, guint32 generic_param_token)
+{
+	g_assert (klass && klass->class_kind == MONO_CLASS_GPARAM);
+	((MonoClassGenericParam*)klass)->generic_param_token = generic_param_token;
+}
+
+guint32
+mono_class_get_generic_param_token (MonoClass *klass)
+{
+	g_assert (klass && klass->class_kind == MONO_CLASS_GPARAM);
+	return ((MonoClassGenericParam*)klass)->generic_param_token;
+}
+
+void
+mono_class_set_element_size (MonoClass *klass, gint32 element_size)
+{
+	g_assert (klass && klass->class_kind == MONO_CLASS_ARRAY);
+	((MonoClassArray*)klass)->element_size = element_size;
+}
+
+gint32
+mono_class_get_element_size (MonoClass *klass)
+{
+	g_assert (klass && klass->class_kind == MONO_CLASS_ARRAY);
+	return ((MonoClassArray*)klass)->element_size;
+}

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -15,7 +15,7 @@
 #include "mono/utils/mono-error.h"
 #include "mono/sgen/gc-internal-agnostic.h"
 
-#define MONO_CLASS_IS_ARRAY(c) ((c)->rank)
+#define MONO_CLASS_IS_ARRAY(c) (mono_class_is_array (c))
 
 #define MONO_CLASS_HAS_STATIC_METADATA(klass) ((klass)->type_token && !(klass)->image->dynamic && !mono_class_is_ginst (klass))
 
@@ -281,7 +281,7 @@ struct _MonoClass {
 	guint16     idepth;
 
 	/* array dimension */
-	guint8     rank;          
+	guint8     rank;
 
 	int        instance_size; /* object instance size */
 
@@ -415,7 +415,9 @@ typedef struct {
 
 typedef struct {
 	MonoClass class;
+
 	guint32 method_count;
+	/* array dimension */
 	gint32 element_size; /* for array types */
 } MonoClassArray;
 
@@ -1508,6 +1510,12 @@ mono_class_get_ref_info_handle (MonoClass *class);
 
 guint32
 mono_class_set_ref_info_handle (MonoClass *class, guint32 value);
+
+guint8
+mono_class_get_array_rank (MonoClass *klass);
+
+void
+mono_class_set_array_rank (MonoClass *klass, guint8 rank);
 
 void
 mono_class_set_class_size (MonoClass *klass, guint32 class_size);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -361,12 +361,6 @@ struct _MonoClass {
 
 	MonoClass **interfaces;
 
-	union {
-		int class_size; /* size of area for static fields */
-		int element_size; /* for array types */
-		int generic_param_token; /* for generic param types, both var and mvar */
-	} sizes;
-
 	/*
 	 * Field information: Type and location from object base
 	 */
@@ -400,6 +394,7 @@ typedef struct {
 	guint32 method_count, field_count;
 	/* next element in the class_cache hash list (in MonoImage) */
 	MonoClass *next_class_cache;
+	guint32 class_size; /* size of area for static fields */
 } MonoClassDef;
 
 typedef struct {
@@ -410,15 +405,18 @@ typedef struct {
 typedef struct {
 	MonoClass class;
 	MonoGenericClass *generic_class;
+	guint32 class_size; /* size of area for static fields */
 } MonoClassGenericInst;
 
 typedef struct {
 	MonoClass class;
+	guint32 generic_param_token; /* for generic param types, both var and mvar */
 } MonoClassGenericParam;
 
 typedef struct {
 	MonoClass class;
 	guint32 method_count;
+	gint32 element_size; /* for array types */
 } MonoClassArray;
 
 typedef struct {
@@ -1510,6 +1508,24 @@ mono_class_get_ref_info_handle (MonoClass *class);
 
 guint32
 mono_class_set_ref_info_handle (MonoClass *class, guint32 value);
+
+void
+mono_class_set_class_size (MonoClass *klass, guint32 class_size);
+
+guint32
+mono_class_get_class_size (MonoClass *klass);
+
+void
+mono_class_set_generic_param_token (MonoClass *klass, guint32 generic_param_token);
+
+guint32
+mono_class_get_generic_param_token (MonoClass *klass);
+
+void
+mono_class_set_element_size (MonoClass *klass, gint32 element_size);
+
+gint32
+mono_class_get_element_size (MonoClass *klass);
 
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2250,20 +2250,22 @@ mono_class_setup_methods (MonoClass *klass)
 				return;				
 			}
 		}
-	} else if (klass->rank) {
+	} else if (mono_class_is_array (klass)) {
 		MonoError error;
 		MonoMethod *amethod;
 		MonoMethodSignature *sig;
 		int count_generic = 0, first_generic = 0;
 		int method_num = 0;
 		gboolean jagged_ctor = FALSE;
+		guint8 rank = mono_class_get_array_rank (klass);
 
-		count = 3 + (klass->rank > 1? 2: 1);
+
+		count = 3 + (rank > 1? 2: 1);
 
 		mono_class_setup_interfaces (klass, &error);
 		g_assert (mono_error_ok (&error)); /*FIXME can this fail for array types?*/
 
-		if (klass->rank == 1 && klass->element_class->rank) {
+		if (rank == 1 && mono_class_is_array(klass->element_class)) {
 			jagged_ctor = TRUE;
 			count ++;
 		}
@@ -2276,21 +2278,21 @@ mono_class_setup_methods (MonoClass *klass)
 
 		methods = (MonoMethod **)mono_class_alloc0 (klass, sizeof (MonoMethod*) * count);
 
-		sig = mono_metadata_signature_alloc (klass->image, klass->rank);
+		sig = mono_metadata_signature_alloc (klass->image, rank);
 		sig->ret = &mono_defaults.void_class->byval_arg;
 		sig->pinvoke = TRUE;
 		sig->hasthis = TRUE;
-		for (i = 0; i < klass->rank; ++i)
+		for (i = 0; i < rank; ++i)
 			sig->params [i] = &mono_defaults.int32_class->byval_arg;
 
 		amethod = create_array_method (klass, ".ctor", sig);
 		methods [method_num++] = amethod;
-		if (klass->rank > 1) {
-			sig = mono_metadata_signature_alloc (klass->image, klass->rank * 2);
+		if (rank > 1) {
+			sig = mono_metadata_signature_alloc (klass->image, rank * 2);
 			sig->ret = &mono_defaults.void_class->byval_arg;
 			sig->pinvoke = TRUE;
 			sig->hasthis = TRUE;
-			for (i = 0; i < klass->rank * 2; ++i)
+			for (i = 0; i < rank * 2; ++i)
 				sig->params [i] = &mono_defaults.int32_class->byval_arg;
 
 			amethod = create_array_method (klass, ".ctor", sig);
@@ -2299,40 +2301,40 @@ mono_class_setup_methods (MonoClass *klass)
 
 		if (jagged_ctor) {
 			/* Jagged arrays have an extra ctor in .net which creates an array of arrays */
-			sig = mono_metadata_signature_alloc (klass->image, klass->rank + 1);
+			sig = mono_metadata_signature_alloc (klass->image, rank + 1);
 			sig->ret = &mono_defaults.void_class->byval_arg;
 			sig->pinvoke = TRUE;
 			sig->hasthis = TRUE;
-			for (i = 0; i < klass->rank + 1; ++i)
+			for (i = 0; i < rank + 1; ++i)
 				sig->params [i] = &mono_defaults.int32_class->byval_arg;
 			amethod = create_array_method (klass, ".ctor", sig);
 			methods [method_num++] = amethod;
 		}
 
 		/* element Get (idx11, [idx2, ...]) */
-		sig = mono_metadata_signature_alloc (klass->image, klass->rank);
+		sig = mono_metadata_signature_alloc (klass->image, rank);
 		sig->ret = &klass->element_class->byval_arg;
 		sig->pinvoke = TRUE;
 		sig->hasthis = TRUE;
-		for (i = 0; i < klass->rank; ++i)
+		for (i = 0; i < rank; ++i)
 			sig->params [i] = &mono_defaults.int32_class->byval_arg;
 		amethod = create_array_method (klass, "Get", sig);
 		methods [method_num++] = amethod;
 		/* element& Address (idx11, [idx2, ...]) */
-		sig = mono_metadata_signature_alloc (klass->image, klass->rank);
+		sig = mono_metadata_signature_alloc (klass->image, rank);
 		sig->ret = &klass->element_class->this_arg;
 		sig->pinvoke = TRUE;
 		sig->hasthis = TRUE;
-		for (i = 0; i < klass->rank; ++i)
+		for (i = 0; i < rank; ++i)
 			sig->params [i] = &mono_defaults.int32_class->byval_arg;
 		amethod = create_array_method (klass, "Address", sig);
 		methods [method_num++] = amethod;
 		/* void Set (idx11, [idx2, ...], element) */
-		sig = mono_metadata_signature_alloc (klass->image, klass->rank + 1);
+		sig = mono_metadata_signature_alloc (klass->image, rank + 1);
 		sig->ret = &mono_defaults.void_class->byval_arg;
 		sig->pinvoke = TRUE;
 		sig->hasthis = TRUE;
-		for (i = 0; i < klass->rank; ++i)
+		for (i = 0; i < rank; ++i)
 			sig->params [i] = &mono_defaults.int32_class->byval_arg;
 		sig->params [i] = &klass->element_class->byval_arg;
 		amethod = create_array_method (klass, "Set", sig);
@@ -2466,7 +2468,7 @@ mono_class_get_vtable_entry (MonoClass *klass, int offset)
 {
 	MonoMethod *m;
 
-	if (klass->rank == 1) {
+	if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1) {
 		/* 
 		 * szarrays do not overwrite any methods of Array, so we can avoid
 		 * initializing their vtables in some cases.
@@ -3134,7 +3136,7 @@ get_implicit_generic_array_interfaces (MonoClass *klass, int *num, int *is_enume
 	}
 	internal_enumerator = FALSE;
 	eclass_is_valuetype = FALSE;
-	original_rank = eclass->rank;
+	original_rank = mono_class_is_array (eclass) ? mono_class_get_array_rank (eclass) : 0;
 	if (klass->byval_arg.type != MONO_TYPE_SZARRAY) {
 		MonoGenericClass *gklass = mono_class_try_get_generic_class (klass);
 		if (gklass && klass->nested_in == mono_defaults.array_class && strcmp (klass->name, "InternalEnumerator`1") == 0)	 {
@@ -3142,8 +3144,9 @@ get_implicit_generic_array_interfaces (MonoClass *klass, int *num, int *is_enume
 			 * For a Enumerator<T[]> we need to get the list of interfaces for T.
 			 */
 			eclass = mono_class_from_mono_type (gklass->context.class_inst->type_argv [0]);
-			original_rank = eclass->rank;
-			if (!eclass->rank)
+			gboolean is_arr = mono_class_is_array (eclass);
+			original_rank = is_arr ? mono_class_get_array_rank (eclass) : 0;
+			if (!is_arr)
 				eclass = eclass->element_class;
 			internal_enumerator = TRUE;
 			*is_enumerator = TRUE;
@@ -3157,7 +3160,7 @@ get_implicit_generic_array_interfaces (MonoClass *klass, int *num, int *is_enume
 	 * with this non-lazy impl we can't implement all the interfaces so we do just the minimal stuff
 	 * for deep levels of arrays of arrays (string[][] has all the interfaces, string[][][] doesn't)
 	 */
-	all_interfaces = eclass->rank && eclass->element_class->rank? FALSE: TRUE;
+	all_interfaces = mono_class_is_array (eclass) && mono_class_is_array (eclass->element_class)? FALSE: TRUE;
 
 	generic_icollection_class = mono_class_get_generic_icollection_class ();
 	generic_ienumerable_class = mono_class_get_generic_ienumerable_class ();
@@ -3217,7 +3220,7 @@ get_implicit_generic_array_interfaces (MonoClass *klass, int *num, int *is_enume
 			interface_count++;
 		else
 			interface_count += idepth;
-		if (eclass->rank && eclass->element_class->valuetype) {
+		if (mono_class_is_array (eclass) && eclass->element_class->valuetype) {
 			fill_valuetype_array_derived_types (valuetype_types, eclass->element_class, original_rank);
 			if (valuetype_types [1])
 				++interface_count;
@@ -4082,7 +4085,7 @@ check_interface_method_override (MonoClass *klass, MonoMethod *im, MonoMethod *c
 			TRACE_INTERFACE_VTABLE (printf ("[INJECTED METHOD REFUSED]"));
 			return FALSE;
 		}
-		if (cm->klass->rank == 0) {
+		if (!mono_class_is_array (cm->klass)) {
 			TRACE_INTERFACE_VTABLE (printf ("[RANK CHECK FAILED]"));
 			return FALSE;
 		}
@@ -4359,7 +4362,7 @@ verify_class_overrides (MonoClass *klass, MonoMethod **overrides, int onum)
 static gboolean
 mono_class_need_stelemref_method (MonoClass *klass)
 {
-	return klass->rank == 1 && MONO_TYPE_IS_REFERENCE (&klass->element_class->byval_arg);
+	return mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1 && MONO_TYPE_IS_REFERENCE (&klass->element_class->byval_arg);
 }
 
 /*
@@ -5200,7 +5203,7 @@ mono_class_init (MonoClass *klass)
 		vtable_size = cached_info.vtable_size;
 		ghcimpl = cached_info.ghcimpl;
 		has_cctor = cached_info.has_cctor;
-	} else if (klass->rank == 1 && klass->byval_arg.type == MONO_TYPE_SZARRAY) {
+	} else if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1 && klass->byval_arg.type == MONO_TYPE_SZARRAY) {
 		/* SZARRAY can have 2 vtable layouts, with and without the stelemref method.
 		 * The first slot if for array with.
 		 */
@@ -5276,8 +5279,8 @@ mono_class_init (MonoClass *klass)
 		}
 	}
 
-	if (klass->rank) {
-		array_method_count = 3 + (klass->rank > 1? 2: 1);
+	if (mono_class_is_array(klass)) {
+		array_method_count = 3 + (mono_class_get_array_rank (klass) > 1? 2: 1);
 
 		if (klass->interface_count) {
 			int count_generic = generic_array_methods (klass);
@@ -5323,7 +5326,7 @@ mono_class_init (MonoClass *klass)
 		klass->has_finalize = cached_info.has_finalize;
 		klass->has_finalize_inited = TRUE;
 	}
-	if (klass->rank)
+	if (mono_class_is_array (klass))
 		mono_class_set_method_count (klass, array_method_count);
 
 	mono_loader_unlock ();
@@ -5371,7 +5374,7 @@ mono_class_has_finalizer (MonoClass *klass)
 	if (!(MONO_CLASS_IS_INTERFACE (klass) || klass->valuetype)) {
 		MonoMethod *cmethod = NULL;
 
-		if (klass->rank == 1 && klass->byval_arg.type == MONO_TYPE_SZARRAY) {
+		if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1 && klass->byval_arg.type == MONO_TYPE_SZARRAY) {
 		} else if (mono_class_is_ginst (klass)) {
 			MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
 
@@ -6724,7 +6727,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		if ((rootlist = list = (GSList *)g_hash_table_lookup (image->array_cache, eclass))) {
 			for (; list; list = list->next) {
 				klass = (MonoClass *)list->data;
-				if ((klass->rank == rank) && (klass->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+				if ((mono_class_get_array_rank (klass) == rank) && (klass->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
 					mono_loader_unlock ();
 					return klass;
 				}
@@ -6793,7 +6796,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 
 	klass->has_references = MONO_TYPE_IS_REFERENCE (&eclass->byval_arg) || eclass->has_references? TRUE: FALSE;
 
-	klass->rank = rank;
+	mono_class_set_array_rank (klass, rank);
 	
 	if (eclass->enumtype)
 		klass->cast_class = eclass->element_class;
@@ -6960,7 +6963,7 @@ mono_class_data_size (MonoClass *klass)
 	/* in arrays, sizes.class_size is unioned with element_size
 	 * and arrays have no static fields
 	 */
-	if (klass->rank)
+	if (mono_class_is_array (klass))
 		return 0;
 	return mono_class_get_class_size (klass);
 }
@@ -8422,10 +8425,12 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 	} else if (klass->delegate) {
 		if (mono_class_has_variant_generic_params (klass) && mono_class_is_variant_compatible (klass, oklass, FALSE))
 			return TRUE;
-	}else if (klass->rank) {
+	}else if (mono_class_is_array (klass)) {
 		MonoClass *eclass, *eoclass;
 
-		if (oklass->rank != klass->rank)
+		if (!mono_class_is_array (oklass))
+			return FALSE;
+		if (mono_class_get_array_rank (oklass) != mono_class_get_array_rank (klass))
 			return FALSE;
 
 		/* vectors vs. one dimensional arrays */
@@ -8588,10 +8593,12 @@ mono_class_is_assignable_from_slow (MonoClass *target, MonoClass *candidate)
  	if (target->delegate && mono_class_has_variant_generic_params (target))
 		return mono_class_is_variant_compatible (target, candidate, FALSE);
 
-	if (target->rank) {
+	if (mono_class_is_array (target)) {
 		MonoClass *eclass, *eoclass;
 
-		if (target->rank != candidate->rank)
+		if (!mono_class_is_array (candidate))
+			return FALSE;
+		if (mono_class_get_array_rank (target) != mono_class_get_array_rank (candidate))
 			return FALSE;
 
 		/* vectors vs. one dimensional arrays */
@@ -9029,7 +9036,10 @@ mono_class_get_nesting_type (MonoClass *klass)
 int
 mono_class_get_rank (MonoClass *klass)
 {
-	return klass->rank;
+	if (mono_class_is_array (klass))
+		return mono_class_get_array_rank (klass);
+	else
+		return 0;
 }
 
 /**
@@ -10683,7 +10693,7 @@ mono_class_setup_interfaces (MonoClass *klass, MonoError *error)
 	if (klass->interfaces_inited)
 		return;
 
-	if (klass->rank == 1 && klass->byval_arg.type != MONO_TYPE_ARRAY) {
+	if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1 && klass->byval_arg.type != MONO_TYPE_ARRAY) {
 		MonoType *args [1];
 
 		/* generic IList, ICollection, IEnumerable */

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -142,6 +142,7 @@ mono_class_get_parent        (MonoClass *klass);
 MONO_API MonoClass*
 mono_class_get_nesting_type  (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API int
 mono_class_get_rank          (MonoClass *klass);
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -3338,7 +3338,7 @@ mono_marshal_safearray_create (MonoArray *input, gpointer *newsafearray, gpointe
 #endif
 
 	max_array_length = mono_array_length (input);
-	dim = ((MonoObject *)input)->vtable->klass->rank;
+	dim = mono_class_get_array_rank (mono_object_class (input));
 
 	*indices = g_malloc (dim * sizeof (int));
 	bounds = (SAFEARRAYBOUND *)alloca (dim * sizeof (SAFEARRAYBOUND));

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1221,7 +1221,7 @@ mono_custom_attrs_from_class_checked (MonoClass *klass, MonoError *error)
 		return lookup_custom_attr (klass->image, klass);
 
 	if (klass->byval_arg.type == MONO_TYPE_VAR || klass->byval_arg.type == MONO_TYPE_MVAR) {
-		idx = mono_metadata_token_index (klass->sizes.generic_param_token);
+		idx = mono_metadata_token_index (mono_class_get_generic_param_token(klass));
 		idx <<= MONO_CUSTOM_ATTR_BITS;
 		idx |= MONO_CUSTOM_ATTR_GENERICPAR;
 	} else {

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -941,11 +941,11 @@ mono_object_describe (MonoObject *obj)
 			g_print ("String at %p, length: %d, unable to decode UTF16\n", obj, mono_string_length ((MonoString*) obj));
 		}
 		g_free (utf8);
-	} else if (klass->rank) {
+	} else if (mono_class_is_array (klass)) {
 		MonoArray *array = (MonoArray*)obj;
 		sep = print_name_space (klass);
 		g_print ("%s%s", sep, klass->name);
-		g_print (" at %p, rank: %d, length: %d\n", obj, klass->rank, (int)mono_array_length (array));
+		g_print (" at %p, rank: %d, length: %d\n", obj, mono_class_get_array_rank (klass), (int)mono_array_length (array));
 	} else {
 		sep = print_name_space (klass);
 		g_print ("%s%s", sep, klass->name);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -727,7 +727,7 @@ ves_icall_System_GCHandle_GetAddrOfPinnedObject (guint32 handle)
 		MonoClass *klass = mono_object_class (obj);
 		if (klass == mono_defaults.string_class) {
 			return mono_string_chars ((MonoString*)obj);
-		} else if (klass->rank) {
+		} else if (mono_class_is_array (klass)) {
 			return mono_array_addr ((MonoArray*)obj, char, 0);
 		} else {
 			/* the C# code will check and throw the exception */

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -185,8 +185,9 @@ ves_icall_System_Array_GetValue (MonoArray *arr, MonoArray *idxs)
 	
 	ac = (MonoClass *)arr->obj.vtable->klass;
 
-	g_assert (ic->rank == 1);
-	if (io->bounds != NULL || io->max_length !=  ac->rank) {
+	g_assert (mono_class_get_array_rank(ic) == 1);
+	guint8 ac_rank = mono_class_get_array_rank (ac);
+	if (io->bounds != NULL || io->max_length !=  ac_rank) {
 		mono_set_pending_exception (mono_get_exception_argument (NULL, NULL));
 		return NULL;
 	}
@@ -202,7 +203,7 @@ ves_icall_System_Array_GetValue (MonoArray *arr, MonoArray *idxs)
 		return ves_icall_System_Array_GetValueImpl (arr, *ind);
 	}
 	
-	for (i = 0; i < ac->rank; i++) {
+	for (i = 0; i < ac_rank; i++) {
 		if ((ind [i] < arr->bounds [i].lower_bound) ||
 		    (ind [i] >=  (mono_array_lower_bound_t)arr->bounds [i].length + arr->bounds [i].lower_bound)) {
 			mono_set_pending_exception (mono_get_exception_index_out_of_range ());
@@ -211,7 +212,7 @@ ves_icall_System_Array_GetValue (MonoArray *arr, MonoArray *idxs)
 	}
 
 	pos = ind [0] - arr->bounds [0].lower_bound;
-	for (i = 1; i < ac->rank; i++)
+	for (i = 1; i < ac_rank; i++)
 		pos = pos * arr->bounds [i].length + ind [i] - 
 			arr->bounds [i].lower_bound;
 
@@ -520,8 +521,9 @@ ves_icall_System_Array_SetValue (MonoArray *arr, MonoObject *value,
 	ic = idxs->obj.vtable->klass;
 	ac = arr->obj.vtable->klass;
 
-	g_assert (ic->rank == 1);
-	if (idxs->bounds != NULL || idxs->max_length != ac->rank) {
+	g_assert (mono_class_get_array_rank (ic) == 1);
+	guint8 ac_rank = mono_class_get_array_rank (ac);
+	if (idxs->bounds != NULL || idxs->max_length != ac_rank) {
 		mono_set_pending_exception (mono_get_exception_argument (NULL, NULL));
 		return;
 	}
@@ -538,7 +540,7 @@ ves_icall_System_Array_SetValue (MonoArray *arr, MonoObject *value,
 		return;
 	}
 	
-	for (i = 0; i < ac->rank; i++)
+	for (i = 0; i < ac_rank; i++)
 		if ((ind [i] < arr->bounds [i].lower_bound) ||
 		    (ind [i] >= (mono_array_lower_bound_t)arr->bounds [i].length + arr->bounds [i].lower_bound)) {
 			mono_set_pending_exception (mono_get_exception_index_out_of_range ());
@@ -546,7 +548,7 @@ ves_icall_System_Array_SetValue (MonoArray *arr, MonoObject *value,
 		}
 
 	pos = ind [0] - arr->bounds [0].lower_bound;
-	for (i = 1; i < ac->rank; i++)
+	for (i = 1; i < ac_rank; i++)
 		pos = pos * arr->bounds [i].length + ind [i] - 
 			arr->bounds [i].lower_bound;
 
@@ -589,16 +591,17 @@ ves_icall_System_Array_CreateInstanceImpl (MonoReflectionType *type, MonoArray *
 
 	aklass = mono_bounded_array_class_get (klass, mono_array_length (lengths), bounded);
 
-	sizes = (uintptr_t *)alloca (aklass->rank * sizeof(intptr_t) * 2);
-	for (i = 0; i < aklass->rank; ++i) {
+	guint8 aklass_rank = mono_class_get_array_rank (aklass);
+	sizes = (uintptr_t *)alloca (aklass_rank * sizeof(intptr_t) * 2);
+	for (i = 0; i < aklass_rank; ++i) {
 		sizes [i] = mono_array_get (lengths, guint32, i);
 		if (bounds)
-			sizes [i + aklass->rank] = mono_array_get (bounds, gint32, i);
+			sizes [i + aklass_rank] = mono_array_get (bounds, gint32, i);
 		else
-			sizes [i + aklass->rank] = 0;
+			sizes [i + aklass_rank] = 0;
 	}
 
-	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, &error);
+	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass_rank, &error);
 	mono_error_set_pending_exception (&error);
 
 	return array;
@@ -641,16 +644,17 @@ ves_icall_System_Array_CreateInstanceImpl64 (MonoReflectionType *type, MonoArray
 
 	aklass = mono_bounded_array_class_get (klass, mono_array_length (lengths), bounded);
 
-	sizes = (uintptr_t *)alloca (aklass->rank * sizeof(intptr_t) * 2);
-	for (i = 0; i < aklass->rank; ++i) {
+	guint8 aklass_rank = mono_class_get_array_rank (aklass);
+	sizes = (uintptr_t *)alloca (aklass_rank * sizeof(intptr_t) * 2);
+	for (i = 0; i < aklass_rank; ++i) {
 		sizes [i] = mono_array_get (lengths, guint64, i);
 		if (bounds)
-			sizes [i + aklass->rank] = (mono_array_size_t) mono_array_get (bounds, guint64, i);
+			sizes [i + aklass_rank] = (mono_array_size_t) mono_array_get (bounds, guint64, i);
 		else
-			sizes [i + aklass->rank] = 0;
+			sizes [i + aklass_rank] = 0;
 	}
 
-	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, &error);
+	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass_rank, &error);
 	mono_error_set_pending_exception (&error);
 
 	return array;
@@ -659,13 +663,13 @@ ves_icall_System_Array_CreateInstanceImpl64 (MonoReflectionType *type, MonoArray
 ICALL_EXPORT gint32 
 ves_icall_System_Array_GetRank (MonoObject *arr)
 {
-	return arr->vtable->klass->rank;
+	return mono_class_get_array_rank (mono_object_class (arr));
 }
 
 ICALL_EXPORT gint32
 ves_icall_System_Array_GetLength (MonoArray *arr, gint32 dimension)
 {
-	gint32 rank = arr->obj.vtable->klass->rank;
+	gint32 rank = mono_class_get_array_rank (mono_object_class (arr));
 	uintptr_t length;
 
 	if ((dimension < 0) || (dimension >= rank)) {
@@ -690,7 +694,7 @@ ves_icall_System_Array_GetLength (MonoArray *arr, gint32 dimension)
 ICALL_EXPORT gint64
 ves_icall_System_Array_GetLongLength (MonoArray *arr, gint32 dimension)
 {
-	gint32 rank = arr->obj.vtable->klass->rank;
+	gint32 rank = mono_class_get_array_rank (mono_object_class (arr));
 
 	if ((dimension < 0) || (dimension >= rank)) {
 		mono_set_pending_exception (mono_get_exception_index_out_of_range ());
@@ -706,7 +710,7 @@ ves_icall_System_Array_GetLongLength (MonoArray *arr, gint32 dimension)
 ICALL_EXPORT gint32
 ves_icall_System_Array_GetLowerBound (MonoArray *arr, gint32 dimension)
 {
-	gint32 rank = arr->obj.vtable->klass->rank;
+	gint32 rank = mono_class_get_array_rank (mono_object_class (arr));
 
 	if ((dimension < 0) || (dimension >= rank)) {
 		mono_set_pending_exception (mono_get_exception_index_out_of_range ());
@@ -2710,7 +2714,7 @@ ves_icall_RuntimeTypeHandle_GetArrayRank (MonoReflectionType *type)
 
 	klass = mono_class_from_mono_type (type->type);
 
-	return klass->rank;
+	return mono_class_get_array_rank (klass);
 }
 
 static MonoArray*
@@ -3203,18 +3207,19 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 		return NULL;
 	}
 	
-	if (m->klass->rank && !strcmp (m->name, ".ctor")) {
+	if (mono_class_is_array (m->klass) && !strcmp (m->name, ".ctor")) {
 		MonoArray *arr;
 		int i;
 		uintptr_t *lengths;
 		intptr_t *lower_bounds;
+		guint8 rank = mono_class_get_array_rank (m->klass);
 		pcount = mono_array_length (params);
 		lengths = (uintptr_t *)alloca (sizeof (uintptr_t) * pcount);
 		/* Note: the synthetized array .ctors have int32 as argument type */
 		for (i = 0; i < pcount; ++i)
 			lengths [i] = *(int32_t*) ((char*)mono_array_get (params, gpointer, i) + sizeof (MonoObject));
 
-		if (m->klass->rank == 1 && sig->param_count == 2 && m->klass->element_class->rank) {
+		if (rank == 1 && sig->param_count == 2 && mono_class_is_array (m->klass->element_class)) {
 			/* This is a ctor for jagged arrays. MS creates an array of arrays. */
 			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, &error);
 			if (!mono_error_ok (&error)) {
@@ -3233,7 +3238,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 			return (MonoObject*)arr;
 		}
 
-		if (m->klass->rank == pcount) {
+		if (rank == pcount) {
 			/* Only lengths provided. */
 			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, &error);
 			if (!mono_error_ok (&error)) {
@@ -3243,7 +3248,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 
 			return (MonoObject*)arr;
 		} else {
-			g_assert (pcount == (m->klass->rank * 2));
+			g_assert (pcount == rank * 2);
 			/* The arguments are lower-bound-length pairs */
 			lower_bounds = (intptr_t *)g_alloca (sizeof (intptr_t) * pcount);
 
@@ -6321,7 +6326,7 @@ mono_array_get_byte_length (MonoArray *array)
 		length = array->max_length;
 	else {
 		length = 1;
-		for (i = 0; i < klass->rank; ++ i)
+		for (i = 0; i < mono_class_get_array_rank (klass); ++ i)
 			length *= array->bounds [i].length;
 	}
 
@@ -7055,8 +7060,8 @@ ves_icall_System_Runtime_Activation_ActivationServices_AllocateUninitializedClas
 		return NULL;
 	}
 
-	if (klass->rank >= 1) {
-		g_assert (klass->rank == 1);
+	if (mono_class_is_array (klass)) {
+		g_assert (mono_class_get_array_rank (klass) == 1);
 		ret = (MonoObject *) mono_array_new_checked (domain, klass->element_class, 0, &error);
 		mono_error_set_pending_exception (&error);
 		return ret;

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -363,7 +363,7 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 	mono_error_init (error);
 
 	/* FIXME: !mono_class_is_ginst (from_class) condition causes test failures. */
-	if (klass->type_token && !image_is_dynamic (klass->image) && !klass->methods && !klass->rank && klass == from_class && !mono_class_is_ginst (from_class)) {
+	if (klass->type_token && !image_is_dynamic (klass->image) && !klass->methods && !mono_class_is_array (klass) && klass == from_class && !mono_class_is_ginst (from_class)) {
 		int first_idx = mono_class_get_first_method_idx (klass);
 		int mcount = mono_class_get_method_count (klass);
 		for (i = 0; i < mcount; ++i) {
@@ -1949,7 +1949,7 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 		names [i] = "";
 
 	klass = method->klass;
-	if (klass->rank)
+	if (mono_class_is_array (klass))
 		return;
 
 	mono_class_init (klass);
@@ -2614,7 +2614,7 @@ mono_method_get_index (MonoMethod *method)
 	MonoClass *klass = method->klass;
 	int i;
 
-	if (klass->rank)
+	if (mono_class_is_array (klass))
 		/* constructed array methods are not in the MethodDef table */
 		return 0;
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -10389,7 +10389,7 @@ mono_marshal_get_array_address (int rank, int elem_size)
 	if (elem_size) {
 		mono_mb_emit_icon (mb, elem_size);
 	} else {
-		/* Load arr->vtable->klass->sizes.element_class */
+		/* Load ((MonoClassArray*)arr->vtable->klass)->element_class */
 		mono_mb_emit_ldarg (mb, 0);
 		mono_mb_emit_byte (mb, CEE_CONV_I);
 		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
@@ -10398,8 +10398,8 @@ mono_marshal_get_array_address (int rank, int elem_size)
 		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
 		mono_mb_emit_byte (mb, CEE_ADD);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		/* sizes is an union, so this reads sizes.element_size */
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, sizes));
+		/* expect to arr->vtable->klass to be a MonoClassArray, so this reads element_size */
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClassArray, element_size));
 		mono_mb_emit_byte (mb, CEE_ADD);
 		mono_mb_emit_byte (mb, CEE_LDIND_I4);
 	}

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -68,8 +68,9 @@ DECL_OFFSET(MonoClass, interface_id)
 DECL_OFFSET(MonoClass, max_interface_id)
 DECL_OFFSET(MonoClass, parent)
 DECL_OFFSET(MonoClass, rank)
-DECL_OFFSET(MonoClass, sizes)
 DECL_OFFSET(MonoClass, supertypes)
+
+DECL_OFFSET(MonoClassArray, element_size)
 
 DECL_OFFSET(MonoVTable, klass)
 DECL_OFFSET(MonoVTable, max_interface_id)

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -101,7 +101,7 @@ sgen_mono_array_size (GCVTable vtable, MonoArray *array, mword *bounds_size, mwo
 	if (G_UNLIKELY (array->bounds)) {
 		size += sizeof (mono_array_size_t) - 1;
 		size &= ~(sizeof (mono_array_size_t) - 1);
-		size += sizeof (MonoArrayBounds) * vtable->klass->rank;
+		size += sizeof (MonoArrayBounds) * mono_class_get_array_rank (vtable->klass);
 	}
 
 	if (bounds_size)
@@ -123,7 +123,7 @@ sgen_client_slow_object_get_size (GCVTable vtable, GCObject* o)
 	 */
 	if (klass == mono_defaults.string_class) {
 		return G_STRUCT_OFFSET (MonoString, chars) + 2 * mono_string_length_fast ((MonoString*) o) + 2;
-	} else if (klass->rank) {
+	} else if (mono_class_is_array (klass)) {
 		return sgen_mono_array_size (vtable, (MonoArray*)o, NULL, 0);
 	} else {
 		/* from a created object: the class must be inited already */

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -94,7 +94,7 @@ sgen_mono_array_size (GCVTable vtable, MonoArray *array, mword *bounds_size, mwo
 	if ((descr & DESC_TYPE_MASK) == DESC_TYPE_VECTOR)
 		element_size = ((descr) >> VECTOR_ELSIZE_SHIFT) & MAX_ELEMENT_SIZE;
 	else
-		element_size = vtable->klass->sizes.element_size;
+		element_size = mono_class_get_element_size (vtable->klass);
 
 	size_without_bounds = size = MONO_SIZEOF_MONO_ARRAY + element_size * mono_array_length_fast (array);
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -399,7 +399,7 @@ static GCVTable
 get_array_fill_vtable (void)
 {
 	if (!array_fill_vtable) {
-		static MonoClass klass;
+		static MonoClassArray klass;
 		static char _vtable[sizeof(MonoVTable)+8];
 		MonoVTable* vtable = (MonoVTable*) ALIGN_TO((mword)_vtable, 8);
 		gsize bmap;
@@ -407,13 +407,14 @@ get_array_fill_vtable (void)
 		MonoDomain *domain = mono_get_root_domain ();
 		g_assert (domain);
 
-		klass.element_class = mono_defaults.byte_class;
-		klass.rank = 1;
-		klass.instance_size = MONO_SIZEOF_MONO_ARRAY;
-		klass.sizes.element_size = 1;
-		klass.name = "array_filler_type";
+		klass.class.element_class = mono_defaults.byte_class;
+		klass.class.class_kind = MONO_CLASS_ARRAY;
+		klass.class.rank = 1;
+		klass.class.instance_size = MONO_SIZEOF_MONO_ARRAY;
+		klass.element_size = 1;
+		klass.class.name = "array_filler_type";
 
-		vtable->klass = &klass;
+		vtable->klass = &klass.class;
 		bmap = 0;
 		vtable->gc_descr = mono_gc_make_descr_for_array (TRUE, &bmap, 0, 1);
 		vtable->rank = 1;
@@ -1194,12 +1195,12 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 		clause = (MonoExceptionClause *)mono_image_alloc0 (mono_defaults.corlib, sizeof (MonoExceptionClause));
 		clause->try_offset = mono_mb_get_label (mb);
 
-		/* vtable->klass->sizes.element_size */
+		/* ((MonoClassArray*)vtable->klass)->element_size */
 		mono_mb_emit_ldarg (mb, 0);
 		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
 		mono_mb_emit_byte (mb, CEE_ADD);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, sizes));
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClassArray, element_size));
 		mono_mb_emit_byte (mb, CEE_ADD);
 		mono_mb_emit_byte (mb, CEE_LDIND_U4);
 		mono_mb_emit_byte (mb, CEE_CONV_I);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1457,7 +1457,7 @@ mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean know
 		return NULL;
 	if (mono_class_has_finalizer (klass) || mono_class_is_marshalbyref (klass))
 		return NULL;
-	if (klass->rank)
+	if (mono_class_is_array (klass))
 		return NULL;
 	if (mono_profiler_get_events () & MONO_PROFILE_ALLOCATIONS)
 		return NULL;
@@ -1477,7 +1477,7 @@ MonoMethod*
 mono_gc_get_managed_array_allocator (MonoClass *klass)
 {
 #ifdef MANAGED_ALLOCATION
-	if (klass->rank != 1)
+	if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) != 1)
 		return NULL;
 	if (!mono_runtime_has_tls_get ())
 		return NULL;
@@ -1638,7 +1638,7 @@ sgen_client_cardtable_scan_object (GCObject *obj, mword block_obj_size, guint8 *
 
 	SGEN_ASSERT (0, SGEN_VTABLE_HAS_REFERENCES (vt), "Why would we ever call this on reference-free objects?");
 
-	if (vt->rank) {
+	if (mono_class_is_array (klass)) {
 		MonoArray *arr = (MonoArray*)obj;
 		guint8 *card_data, *card_base;
 		guint8 *card_data_end;

--- a/mono/metadata/sgen-new-bridge.c
+++ b/mono/metadata/sgen-new-bridge.c
@@ -191,7 +191,7 @@ class_kind (MonoClass *klass)
 	}
 
 	/* Some arrays can be ignored */
-	if (klass->rank == 1) {
+	if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1) {
 		MonoClass *elem_class = klass->element_class;
 
 		/* FIXME the bridge check can be quite expensive, cache it at the class level. */

--- a/mono/metadata/sgen-tarjan-bridge.c
+++ b/mono/metadata/sgen-tarjan-bridge.c
@@ -57,7 +57,7 @@ class_kind (MonoClass *klass)
 	}
 
 	/* Some arrays can be ignored */
-	if (klass->rank == 1) {
+	if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1) {
 		MonoClass *elem_class = klass->element_class;
 
 		/* FIXME the bridge check can be quite expensive, cache it at the class level. */

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2013,7 +2013,7 @@ handle_type:
 			simple_type = MONO_TYPE_STRING;
 			*p++ = 0x0E;
 			goto handle_enum;
-		} else if (klass->rank == 1) {
+		} else if (mono_class_is_array (klass) && mono_class_get_array_rank (klass) == 1) {
 			*p++ = 0x1D;
 			if (klass->element_class->byval_arg.type == MONO_TYPE_OBJECT)
 				/* See Partition II, Appendix B3 */

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -2143,7 +2143,7 @@ verifier_class_is_assignable_from (MonoClass *target, MonoClass *candidate)
 			if (MONO_CLASS_IS_INTERFACE (candidate) && mono_class_is_variant_compatible (target, candidate, TRUE))
 				return TRUE;
 
-			if (candidate->rank == 1) {
+			if (mono_class_is_array (candidate) && mono_class_get_array_rank (candidate) == 1) {
 				if (verifier_inflate_and_check_compat (target, mono_defaults.generic_ilist_class, candidate->element_class))
 					return TRUE;
 				if (verifier_inflate_and_check_compat (target, get_icollection_class (), candidate->element_class))
@@ -2189,7 +2189,7 @@ verifier_class_is_assignable_from (MonoClass *target, MonoClass *candidate)
 	if (mono_class_is_assignable_from (target, candidate))
 		return TRUE;
 
-	if (!MONO_CLASS_IS_INTERFACE (target) || !mono_class_is_ginst (target) || candidate->rank != 1)
+	if (!MONO_CLASS_IS_INTERFACE (target) || !mono_class_is_ginst (target) || (mono_class_is_array (candidate) && mono_class_get_array_rank (candidate) != 1))
 		return FALSE;
 
 	iface_gtd = mono_class_get_generic_class (target)->container_class;
@@ -3287,7 +3287,7 @@ do_invoke_method (VerifyContext *ctx, int method_token, gboolean virtual_)
 		if (check_overflow (ctx)) {
 			value = stack_push (ctx);
 			set_stack_value (ctx, value, sig->ret, FALSE);
-			if ((ctx->prefix_set & PREFIX_READONLY) && method->klass->rank && !strcmp (method->name, "Address")) {
+			if ((ctx->prefix_set & PREFIX_READONLY) && mono_class_is_array (method->klass) && !strcmp (method->name, "Address")) {
 				ctx->prefix_set &= ~PREFIX_READONLY;
 				value->stype |= CMMP_MASK;
 			}

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -681,7 +681,7 @@ mono_array_new_va (MonoMethod *cm, ...)
 	int i, d;
 
 	pcount = mono_method_signature (cm)->param_count;
-	rank = cm->klass->rank;
+	rank = mono_class_get_array_rank (cm->klass);
 
 	va_start (ap, cm);
 	
@@ -728,7 +728,7 @@ mono_array_new_1 (MonoMethod *cm, guint32 length)
 	int rank;
 
 	pcount = mono_method_signature (cm)->param_count;
-	rank = cm->klass->rank;
+	rank = mono_class_get_array_rank (cm->klass);
 
 	lengths [0] = length;
 
@@ -763,7 +763,7 @@ mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2)
 	int rank;
 
 	pcount = mono_method_signature (cm)->param_count;
-	rank = cm->klass->rank;
+	rank = mono_class_get_array_rank (cm->klass);
 
 	lengths [0] = length1;
 	lengths [1] = length2;
@@ -799,7 +799,7 @@ mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 	int rank;
 
 	pcount = mono_method_signature (cm)->param_count;
-	rank = cm->klass->rank;
+	rank = mono_class_get_array_rank (cm->klass);
 
 	lengths [0] = length1;
 	lengths [1] = length2;
@@ -836,7 +836,7 @@ mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 	int rank;
 
 	pcount = mono_method_signature (cm)->param_count;
-	rank = cm->klass->rank;
+	rank = mono_class_get_array_rank (cm->klass);
 
 	lengths [0] = length1;
 	lengths [1] = length2;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1775,13 +1775,13 @@ mini_emit_castclass (MonoCompile *cfg, int obj_reg, int klass_reg, MonoClass *kl
 static void
 mini_emit_castclass_inst (MonoCompile *cfg, int obj_reg, int klass_reg, MonoClass *klass, MonoInst *klass_inst, MonoBasicBlock *object_is_null)
 {
-	if (klass->rank) {
+	if (mono_class_is_array (klass)) {
 		int rank_reg = alloc_preg (cfg);
 		int eclass_reg = alloc_preg (cfg);
 
 		g_assert (!klass_inst);
 		MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADU1_MEMBASE, rank_reg, klass_reg, MONO_STRUCT_OFFSET (MonoClass, rank));
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, rank_reg, klass->rank);
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, rank_reg, mono_class_get_array_rank (klass));
 		MONO_EMIT_NEW_COND_EXC (cfg, NE_UN, "InvalidCastException");
 		//		MONO_EMIT_NEW_LOAD_MEMBASE (cfg, klass_reg, vtable_reg, MONO_STRUCT_OFFSET (MonoVTable, klass));
 		MONO_EMIT_NEW_LOAD_MEMBASE (cfg, eclass_reg, klass_reg, MONO_STRUCT_OFFSET (MonoClass, cast_class));
@@ -1802,7 +1802,7 @@ mini_emit_castclass_inst (MonoCompile *cfg, int obj_reg, int klass_reg, MonoClas
 			mini_emit_castclass (cfg, -1, eclass_reg, klass->cast_class, object_is_null);
 		}
 
-		if ((klass->rank == 1) && (klass->byval_arg.type == MONO_TYPE_SZARRAY) && (obj_reg != -1)) {
+		if (mono_class_get_array_rank (klass) == 1 && (klass->byval_arg.type == MONO_TYPE_SZARRAY) && (obj_reg != -1)) {
 			/* Check that the object is a vector too */
 			int bounds_reg = alloc_preg (cfg);
 			MONO_EMIT_NEW_LOAD_MEMBASE (cfg, bounds_reg, obj_reg, MONO_STRUCT_OFFSET (MonoArray, bounds));
@@ -4092,7 +4092,7 @@ handle_unbox (MonoCompile *cfg, MonoClass *klass, MonoInst **sp, int context_use
 	MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADU1_MEMBASE, rank_reg, vtable_reg, MONO_STRUCT_OFFSET (MonoVTable, rank));
 
 	/* FIXME: generics */
-	g_assert (klass->rank == 0);
+	g_assert (!mono_class_is_array (klass));
 			
 	// Check rank == 0
 	MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, rank_reg, 0);
@@ -4105,7 +4105,7 @@ handle_unbox (MonoCompile *cfg, MonoClass *klass, MonoInst **sp, int context_use
 		MonoInst *element_class;
 
 		/* This assertion is from the unboxcast insn */
-		g_assert (klass->rank == 0);
+		g_assert (!mono_class_is_array (klass));
 
 		element_class = emit_get_rgctx_klass (cfg, context_used,
 				klass, MONO_RGCTX_INFO_ELEMENT_KLASS);
@@ -4496,7 +4496,7 @@ method_needs_stack_walk (MonoCompile *cfg, MonoMethod *cmethod)
 	return FALSE;
 }
 
-#define is_complex_isinst(klass) (mono_class_is_interface (klass) || klass->rank || mono_class_is_nullable (klass) || mono_class_is_marshalbyref (klass) || mono_class_is_sealed (klass) || klass->byval_arg.type == MONO_TYPE_VAR || klass->byval_arg.type == MONO_TYPE_MVAR)
+#define is_complex_isinst(klass) (mono_class_is_interface (klass) || mono_class_is_array (klass) || mono_class_is_nullable (klass) || mono_class_is_marshalbyref (klass) || mono_class_is_sealed (klass) || klass->byval_arg.type == MONO_TYPE_VAR || klass->byval_arg.type == MONO_TYPE_MVAR)
 
 static MonoInst*
 emit_isinst_with_cache (MonoCompile *cfg, MonoClass *klass, MonoInst **args)
@@ -4614,7 +4614,7 @@ handle_castclass (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context
 
 		MONO_EMIT_NEW_LOAD_MEMBASE (cfg, vtable_reg, obj_reg, MONO_STRUCT_OFFSET (MonoObject, vtable));
 
-		if (!klass->rank && !cfg->compile_aot && !(cfg->opt & MONO_OPT_SHARED) && mono_class_is_sealed (klass)) {
+		if (!mono_class_is_array (klass) && !cfg->compile_aot && !(cfg->opt & MONO_OPT_SHARED) && mono_class_is_sealed (klass)) {
 			/* the remoting code is broken, access the class for now */
 			if (0) { /*FIXME what exactly is broken? This change refers to r39380 from 2005 and mention some remoting fixes were due.*/
 				MonoVTable *vt = mono_class_vtable (cfg->domain, klass);
@@ -4694,13 +4694,13 @@ handle_isinst (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context_us
 	} else {
 		int klass_reg = alloc_preg (cfg);
 
-		if (klass->rank) {
+		if (mono_class_is_array (klass)) {
 			int rank_reg = alloc_preg (cfg);
 			int eclass_reg = alloc_preg (cfg);
 
 			g_assert (!context_used);
 			MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADU1_MEMBASE, rank_reg, vtable_reg, MONO_STRUCT_OFFSET (MonoVTable, rank));
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, rank_reg, klass->rank);
+			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, rank_reg, mono_class_get_array_rank (klass));
 			MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBNE_UN, false_bb);
 			MONO_EMIT_NEW_LOAD_MEMBASE (cfg, klass_reg, vtable_reg, MONO_STRUCT_OFFSET (MonoVTable, klass));
 			MONO_EMIT_NEW_LOAD_MEMBASE (cfg, eclass_reg, klass_reg, MONO_STRUCT_OFFSET (MonoClass, cast_class));
@@ -4720,7 +4720,7 @@ handle_isinst (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context_us
 			} else if (mono_class_is_interface (klass->cast_class)) {
 				mini_emit_iface_class_cast (cfg, eclass_reg, klass->cast_class, false_bb, is_null_bb);
 			} else {
-				if ((klass->rank == 1) && (klass->byval_arg.type == MONO_TYPE_SZARRAY)) {
+				if ((mono_class_get_array_rank (klass) == 1) && (klass->byval_arg.type == MONO_TYPE_SZARRAY)) {
 					/* Check that the object is a vector too */
 					int bounds_reg = alloc_preg (cfg);
 					MONO_EMIT_NEW_LOAD_MEMBASE (cfg, bounds_reg, obj_reg, MONO_STRUCT_OFFSET (MonoArray, bounds));
@@ -5860,7 +5860,9 @@ emit_array_unsafe_mov (MonoCompile *cfg, MonoMethodSignature *fsig, MonoInst **a
 		return args [0];
 
 	//Arrays of valuetypes that are semantically equivalent
-	if (param_klass->rank == 1 && return_klass->rank == 1 && is_unsafe_mov_compatible (cfg, param_klass->element_class, return_klass->element_class))
+	if (mono_class_is_array (param_klass) && mono_class_get_array_rank (param_klass) == 1 &&
+	    mono_class_is_array (return_klass) && mono_class_get_array_rank (return_klass) == 1 &&
+	    is_unsafe_mov_compatible (cfg, param_klass->element_class, return_klass->element_class))
 		return args [0];
 
 	return NULL;
@@ -9335,7 +9337,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				LOAD_ERROR;
 			if (cmethod->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL &&
 				mini_class_is_system_array (cmethod->klass)) {
-				array_rank = cmethod->klass->rank;
+				array_rank = mono_class_get_array_rank (cmethod->klass);
 			} else if ((cmethod->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) && icall_is_direct_callable (cfg, cmethod)) {
 				direct_icall = TRUE;
 			} else if (fsig->pinvoke) {
@@ -9806,7 +9808,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			 * patching gshared method addresses into a gsharedvt method.
 			 */
 			if (cfg->gsharedvt && (mini_is_gsharedvt_signature (fsig) || cmethod->is_inflated || mono_class_is_ginst (cmethod->klass)) &&
-				!(cmethod->klass->rank && cmethod->klass->byval_arg.type != MONO_TYPE_SZARRAY) &&
+			    !(mono_class_is_array (cmethod->klass) && cmethod->klass->byval_arg.type != MONO_TYPE_SZARRAY) &&
 				(!(cfg->llvm_only && virtual_ && (cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL)))) {
 				MonoRgctxInfoType info_type;
 

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2947,7 +2947,7 @@ mono_method_check_context_used (MonoMethod *method)
 
 	if (!method_context) {
 		/* It might be a method of an array of an open generic type */
-		if (method->klass->rank)
+		if (mono_class_is_array (method->klass))
 			context_used = mono_class_check_context_used (method->klass);
 	} else {
 		context_used = mono_generic_context_check_used (method_context);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2489,7 +2489,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		gpointer compiled_method;
 
 		callee = method;
-		if (method->klass->rank && (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) &&
+		if (mono_class_is_array (method->klass) && (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) &&
 			(method->iflags & METHOD_IMPL_ATTRIBUTE_NATIVE)) {
 			/*
 			 * Array Get/Set/Address methods. The JIT implements them using inline code


### PR DESCRIPTION
* Distribute the `sizes` union among the `MonoClass` subtypes:

  `element_size`, `generic_param_token` go to `MonoClassArray`,
  `MonoClassGenericParam`, respectively.

  `class_size` goes to each of `MonoClassDef`, `MonoClassGtd` and `MonoClassGenericInst`.

  This leaves `MonoClassPointer` without a sizes field.

* Move `rank` from `MonoClass` to `MonoClassArray`
  replace code like `if (klass->rank) ...` by `if (mono_class_is_array (klass))`
  replace use of `klass->rank` by `mono_class_get_array_rank`