### PR TITLE
[runtime] Fix Mach ARM assert.

### DIFF
--- a/mono/utils/mach-support-arm.c
+++ b/mono/utils/mach-support-arm.c
@@ -106,7 +106,7 @@ mono_mach_arch_get_thread_state_size ()
 int
 mono_mach_arch_get_thread_fpstate_size ()
 {
-	g_assert_not_reached ();
+	return sizeof (arm_neon_state_t);
 }
 
 kern_return_t

--- a/mono/utils/mach-support-arm64.c
+++ b/mono/utils/mach-support-arm64.c
@@ -106,7 +106,7 @@ mono_mach_arch_get_thread_state_size ()
 int
 mono_mach_arch_get_thread_fpstate_size ()
 {
-	g_assert_not_reached ();
+	return sizeof (arm_neon_state64_t);
 }
 
 kern_return_t


### PR DESCRIPTION
Re. @marek-safar’s comment here: https://github.com/mono/mono/commit/81b0032420fd6f1be3b24af69d393f9d10393133#commitcomment-19785694

This changes `mono_mach_arch_get_thread_fpstate_size` to return a value, rather than asserting. The actual float state isn't used yet. This also assumes NEON, which may not be correct.
