### PR TITLE
[corlib] Fix cross-domain exception serialization under thread abortion.

### DIFF
--- a/mcs/class/corlib/System.Runtime.Remoting/RemotingServices.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting/RemotingServices.cs
@@ -810,6 +810,7 @@ namespace System.Runtime.Remoting
 		{
 			byte[] result = null;
 			try {
+				/* empty - we're only interested in the protected block */
 			} finally {
 				MemoryStream ms = new MemoryStream ();
 				_serializationFormatter.Serialize (ms, ex);

--- a/mcs/class/corlib/System.Runtime.Remoting/RemotingServices.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting/RemotingServices.cs
@@ -808,45 +808,14 @@ namespace System.Runtime.Remoting
 		[SecurityPermission (SecurityAction.Assert, SerializationFormatter = true)] // FIXME: to be reviewed
 		internal static byte[] SerializeExceptionData (Exception ex)
 		{
+			byte[] result = null;
 			try {
-				int retry = 4;
-				
-				do {
-					try {
-						MemoryStream ms = new MemoryStream ();
-						_serializationFormatter.Serialize (ms, ex);
-						return ms.ToArray ();
-					}
-					catch (Exception e) {
-						if (e is ThreadAbortException) {
-#if MONO_FEATURE_THREAD_ABORT
-							Thread.ResetAbort ();
-#endif
-							retry = 5;
-							ex = e;
-						}
-						else if (retry == 2) {
-							ex = new Exception ();
-							ex.SetMessage (e.Message);
-							ex.SetStackTrace (e.StackTrace);
-						}
-						else
-							ex = e;
-					}
-					retry--;
-				}
-				while (retry > 0);
-				
-				return null;
+			} finally {
+				MemoryStream ms = new MemoryStream ();
+				_serializationFormatter.Serialize (ms, ex);
+				result = ms.ToArray ();
 			}
-			catch (Exception tex)
-			{
-				byte[] data = SerializeExceptionData (tex);
-#if MONO_FEATURE_THREAD_ABORT
-				Thread.ResetAbort ();
-#endif
-				return data;
-			}
+			return result;
 		}
 		
 		internal static object GetDomainProxy(AppDomain domain) 


### PR DESCRIPTION
RemotingServices::SerializeExceptionData started to fail as TAE was being raised
from within the serialization code and this triggered the completely wrong abort protection code.

This happened because a recent change that made .cctors raise TAE at their end and the stack trace
code would hit System.Reflection.Module's cctor to fetch its GUID for the purpose of symbolification.

The fix is to use the correct protection against aborts, which is to run code from finally blocks.

This fixes multiple failures in the runtime test suite.