### PR TITLE
[runtime] Change the thread wait code to use cond variables instead o…

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -223,8 +223,10 @@ static mono_mutex_t interlocked_mutex;
 /* global count of thread interruptions requested */
 static gint32 thread_interruption_requested = 0;
 
+#ifdef HOST_WIN32
 /* Event signaled when a thread changes its background mode */
 static MonoOSEvent background_change_event;
+#endif
 
 static gboolean shutting_down = FALSE;
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -140,12 +140,12 @@ static StaticDataInfo context_static_info;
 /* The hash of existing threads (key is thread ID, value is
  * MonoInternalThread*) that need joining before exit
  */
-static MonoGHashTable *threads=NULL;
+static MonoGHashTable *threads;
 
 /* List of app context GC handles.
  * Added to from ves_icall_System_Runtime_Remoting_Contexts_Context_RegisterContext ().
  */
-static GHashTable *contexts = NULL;
+static GHashTable *contexts;
 
 /* Cleanup queue for contexts. */
 static MonoReferenceQueue *context_queue;
@@ -155,7 +155,7 @@ static MonoReferenceQueue *context_queue;
  * When mono_thread_attach_internal is called for a thread, it will be removed from this hash table.
  * Protected by mono_threads_lock ().
  */
-static MonoGHashTable *threads_starting_up = NULL;
+static MonoGHashTable *threads_starting_up;
 
 /* The TLS key that holds the MonoObject assigned to each thread */
 static MonoNativeTlsKey current_object_key;
@@ -164,6 +164,15 @@ static MonoNativeTlsKey current_object_key;
 /* Protected by the threads lock */
 static GHashTable *joinable_threads;
 static int joinable_thread_count;
+
+#define thread_wait_lock() mono_os_mutex_lock (&thread_wait_mutex)
+#define thread_wait_unlock() mono_os_mutex_unlock (&thread_wait_mutex)
+static mono_mutex_t thread_wait_mutex;
+/* Used to wait for a thread to be joined or to change state */
+/* Used to wait for njoined_threads to increase or for background_change to become true */
+static mono_cond_t thread_wait_cond;
+static int njoined_threads;
+static gboolean background_changed;
 
 #ifdef MONO_HAVE_FAST_TLS
 /* we need to use both the Tls* functions and __thread because
@@ -2072,6 +2081,16 @@ ves_icall_System_Threading_Thread_MemoryBarrier (void)
 	mono_memory_barrier ();
 }
 
+static void
+signal_background_change (void)
+{
+	thread_wait_lock ();
+	background_changed = TRUE;
+	mono_os_cond_signal (&thread_wait_cond);
+	thread_wait_unlock ();
+	mono_os_event_set (&background_change_event);
+}
+
 void
 ves_icall_System_Threading_Thread_ClrState (MonoInternalThread* this_obj, guint32 state)
 {
@@ -2082,7 +2101,7 @@ ves_icall_System_Threading_Thread_ClrState (MonoInternalThread* this_obj, guint3
 		 * be notified, since it has to rebuild the list of threads to
 		 * wait for.
 		 */
-		mono_os_event_set (&background_change_event);
+		signal_background_change ();
 	}
 }
 
@@ -2096,7 +2115,7 @@ ves_icall_System_Threading_Thread_SetState (MonoInternalThread* this_obj, guint3
 		 * be notified, since it has to rebuild the list of threads to
 		 * wait for.
 		 */
-		mono_os_event_set (&background_change_event);
+		signal_background_change ();
 	}
 }
 
@@ -2856,6 +2875,9 @@ void mono_thread_init (MonoThreadStartCB start_cb,
 
 	mono_os_mutex_init_recursive(&interlocked_mutex);
 	mono_os_mutex_init_recursive(&joinable_threads_mutex);
+
+	mono_os_mutex_init_recursive(&thread_wait_mutex);
+	mono_os_cond_init(&thread_wait_cond);
 	
 	mono_os_event_init (&background_change_event, FALSE);
 	
@@ -2919,19 +2941,56 @@ static void print_tids (gpointer key, gpointer value, gpointer user)
 	g_message ("Waiting for: %p", key);
 }
 
-struct wait_data 
-{
+typedef struct {
+	int njoined;
 	MonoThreadHandle *handles[MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
 	MonoInternalThread *threads[MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
 	guint32 num;
-};
+} WaitData;
 
+/*
+ * wait_for_tids:
+ *
+ * Wait until either:
+ * - wait->num threads are joined
+ * - @check_state_change is TRUE and a thread changes background state
+ * - timeout elapses
+ */
 static void
-wait_for_tids (struct wait_data *wait, guint32 timeout, gboolean check_state_change)
+wait_for_tids (WaitData *wait, guint32 timeout, gboolean check_state_change)
 {
+#ifndef HOST_WIN32
+	/*
+	 * Its is complicated to wait for a given set of threads, so we wait for a given
+	 * number of threads instead, the caller needs to call us until the set of threads
+	 * it is waiting for are terminated.
+	 */
+	gboolean finished = FALSE;
+	gint64 start = mono_msec_ticks ();
+	while (!finished) {
+		thread_wait_lock ();
+		if (njoined_threads >= wait->njoined + wait->num || (check_state_change && background_changed)) {
+			finished = TRUE;
+		} else {
+			int res = mono_os_cond_timedwait (&thread_wait_cond, &thread_wait_mutex, timeout);
+			if (res)
+				finished = TRUE;
+			if (timeout != INFINITE) {
+				gint64 now = mono_msec_ticks ();
+				if (now - start >= timeout) {
+					finished = TRUE;
+				} else {
+					timeout -= now - start;
+					start = now;
+				}
+			}
+		}
+		thread_wait_unlock ();
+	}
+#else
 	guint32 i;
 	MonoThreadInfoWaitRet ret;
-	
+
 	THREAD_DEBUG (g_message("%s: %d threads to wait for in this batch", __func__, wait->num));
 
 	/* Add the thread state change event, so it wakes
@@ -2966,65 +3025,85 @@ wait_for_tids (struct wait_data *wait, guint32 timeout, gboolean check_state_cha
 			g_error ("%s: failed to call mono_thread_detach_internal on thread %p, InternalThread: %p", __func__, internal->tid, internal);
 		mono_threads_unlock ();
 	}
+#endif
 }
 
-static void build_wait_tids (gpointer key, gpointer value, gpointer user)
+static void
+init_wait_data (WaitData *wait)
 {
-	struct wait_data *wait=(struct wait_data *)user;
+	/* This is used calculate the number of joined threads in wait_for_tids () */
+	wait->njoined = njoined_threads;
+	mono_memory_barrier ();
+	wait->num = 0;
+	/* We must zero all InternalThread pointers to avoid making the GC unhappy. */
+	memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
+}
 
-	if(wait->num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS - 1) {
-		MonoInternalThread *thread=(MonoInternalThread *)value;
+static void
+add_wait_thread (WaitData *wait, MonoInternalThread *thread)
+{
+#ifdef HOST_WIN32
+	/* These are not used by the wait_for_tids () code on unix */
+	wait->handles [wait->num] = mono_threads_open_thread_handle (thread->handle);
+#endif
+	wait->threads [wait->num] = thread;
+	wait->num++;
+}
 
-		/* Ignore background threads, we abort them later */
-		/* Do not lock here since it is not needed and the caller holds threads_lock */
-		if (thread->state & ThreadState_Background) {
-			THREAD_DEBUG (g_message ("%s: ignoring background thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
-			return; /* just leave, ignore */
-		}
-		
-		if (mono_gc_is_finalizer_internal_thread (thread)) {
-			THREAD_DEBUG (g_message ("%s: ignoring finalizer thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
-			return;
-		}
+static void
+build_wait_tids (gpointer key, gpointer value, gpointer user)
+{
+	WaitData *wait = (WaitData *)user;
+	MonoInternalThread *thread = (MonoInternalThread *)value;
 
-		if (thread == mono_thread_internal_current ()) {
-			THREAD_DEBUG (g_message ("%s: ignoring current thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
-			return;
-		}
-
-		if (mono_thread_get_main () && (thread == mono_thread_get_main ()->internal_thread)) {
-			THREAD_DEBUG (g_message ("%s: ignoring main thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
-			return;
-		}
-
-		if (thread->flags & MONO_THREAD_FLAG_DONT_MANAGE) {
-			THREAD_DEBUG (g_message ("%s: ignoring thread %" G_GSIZE_FORMAT "with DONT_MANAGE flag set.", __func__, (gsize)thread->tid));
-			return;
-		}
-
-		THREAD_DEBUG (g_message ("%s: Invoking mono_thread_manage callback on thread %p", __func__, thread));
-		if ((thread->manage_callback == NULL) || (thread->manage_callback (thread->root_domain_thread) == TRUE)) {
-			wait->handles[wait->num]=mono_threads_open_thread_handle (thread->handle);
-			wait->threads[wait->num]=thread;
-			wait->num++;
-
-			THREAD_DEBUG (g_message ("%s: adding thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
-		} else {
-			THREAD_DEBUG (g_message ("%s: ignoring (because of callback) thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
-		}
-		
-		
-	} else {
+	if (wait->num >= MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS - 1) {
 		/* Just ignore the rest, we can't do anything with
 		 * them yet
 		 */
+		return;
+	}
+
+	/* Ignore background threads, we abort them later */
+	/* Do not lock here since it is not needed and the caller holds threads_lock */
+	if (thread->state & ThreadState_Background) {
+		THREAD_DEBUG (g_message ("%s: ignoring background thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
+		return; /* just leave, ignore */
+	}
+		
+	if (mono_gc_is_finalizer_internal_thread (thread)) {
+		THREAD_DEBUG (g_message ("%s: ignoring finalizer thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
+		return;
+	}
+
+	if (thread == mono_thread_internal_current ()) {
+		THREAD_DEBUG (g_message ("%s: ignoring current thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
+		return;
+	}
+
+	if (mono_thread_get_main () && (thread == mono_thread_get_main ()->internal_thread)) {
+		THREAD_DEBUG (g_message ("%s: ignoring main thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
+		return;
+	}
+
+	if (thread->flags & MONO_THREAD_FLAG_DONT_MANAGE) {
+		THREAD_DEBUG (g_message ("%s: ignoring thread %" G_GSIZE_FORMAT "with DONT_MANAGE flag set.", __func__, (gsize)thread->tid));
+		return;
+	}
+
+	THREAD_DEBUG (g_message ("%s: Invoking mono_thread_manage callback on thread %p", __func__, thread));
+	if ((thread->manage_callback == NULL) || (thread->manage_callback (thread->root_domain_thread) == TRUE)) {
+		add_wait_thread (wait, thread);
+
+		THREAD_DEBUG (g_message ("%s: adding thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
+	} else {
+		THREAD_DEBUG (g_message ("%s: ignoring (because of callback) thread %"G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
 	}
 }
 
 static gboolean
 remove_and_abort_threads (gpointer key, gpointer value, gpointer user)
 {
-	struct wait_data *wait=(struct wait_data *)user;
+	WaitData *wait = (WaitData *)user;
 	MonoNativeThreadId self = mono_native_thread_id_get ();
 	MonoInternalThread *thread = (MonoInternalThread *)value;
 
@@ -3034,11 +3113,8 @@ remove_and_abort_threads (gpointer key, gpointer value, gpointer user)
 	/* The finalizer thread is not a background thread */
 	if (!mono_native_thread_id_equals (thread_get_tid (thread), self)
 	     && (thread->state & ThreadState_Background) != 0
-	     && (thread->flags & MONO_THREAD_FLAG_DONT_MANAGE) == 0
-	) {
-		wait->handles[wait->num] = mono_threads_open_thread_handle (thread->handle);
-		wait->threads[wait->num] = thread;
-		wait->num++;
+		&& (thread->flags & MONO_THREAD_FLAG_DONT_MANAGE) == 0) {
+		add_wait_thread (wait, thread);
 
 		THREAD_DEBUG (g_print ("%s: Aborting id: %"G_GSIZE_FORMAT"\n", __func__, (gsize)thread->tid));
 		mono_thread_internal_abort (thread);
@@ -3092,18 +3168,19 @@ mono_threads_set_shutting_down (void)
 		 * interrupt the main thread if it is waiting for all
 		 * the other threads.
 		 */
-		mono_os_event_set (&background_change_event);
+		signal_background_change ();
 		
 		mono_threads_unlock ();
 	}
 }
 
-void mono_thread_manage (void)
+void
+mono_thread_manage (void)
 {
-	struct wait_data wait_data;
-	struct wait_data *wait = &wait_data;
+	WaitData wait_data;
+	WaitData *wait = &wait_data;
 
-	memset (wait, 0, sizeof (struct wait_data));
+	memset (wait, 0, sizeof (WaitData));
 	/* join each thread that's still running */
 	THREAD_DEBUG (g_message ("%s: Joining each running thread...", __func__));
 	
@@ -3126,16 +3203,15 @@ void mono_thread_manage (void)
 			mono_g_hash_table_foreach (threads, print_tids, NULL));
 	
 		mono_os_event_reset (&background_change_event);
-		wait->num=0;
-		/* We must zero all InternalThread pointers to avoid making the GC unhappy. */
-		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
+		background_changed = FALSE;
+		init_wait_data (wait);
 		mono_g_hash_table_foreach (threads, build_wait_tids, wait);
 		mono_threads_unlock ();
 		if (wait->num > 0)
 			/* Something to wait for */
 			wait_for_tids (wait, INFINITE, TRUE);
 		THREAD_DEBUG (g_message ("%s: I have %d threads after waiting.", __func__, wait->num));
-	} while(wait->num>0);
+	} while (wait->num > 0);
 
 	/* Mono is shutting down, so just wait for the end */
 	if (!mono_runtime_try_shutdown ()) {
@@ -3151,9 +3227,7 @@ void mono_thread_manage (void)
 	do {
 		mono_threads_lock ();
 
-		wait->num = 0;
-		/*We must zero all InternalThread pointers to avoid making the GC unhappy.*/
-		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
+		init_wait_data (wait);
 		mono_g_hash_table_foreach_remove (threads, remove_and_abort_threads, wait);
 
 		mono_threads_unlock ();
@@ -3177,7 +3251,7 @@ static void
 collect_threads_for_suspend (gpointer key, gpointer value, gpointer user_data)
 {
 	MonoInternalThread *thread = (MonoInternalThread*)value;
-	struct wait_data *wait = (struct wait_data*)user_data;
+	WaitData *wait = (WaitData*)user_data;
 
 	/* 
 	 * We try to exclude threads early, to avoid running into the MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS
@@ -3188,9 +3262,9 @@ collect_threads_for_suspend (gpointer key, gpointer value, gpointer user_data)
 		(thread->state & ThreadState_Stopped) != 0)
 		return;
 
-	if (wait->num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-		wait->handles [wait->num] = mono_threads_open_thread_handle (thread->handle);
-		wait->threads [wait->num] = thread;
+	if (wait->num < MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
+		wait->handles[wait->num] = mono_threads_open_thread_handle (thread->handle);
+		wait->threads[wait->num] = thread;
 		wait->num++;
 	}
 }
@@ -3201,16 +3275,17 @@ collect_threads_for_suspend (gpointer key, gpointer value, gpointer user_data)
  *  Suspend all managed threads except the finalizer thread and this thread. It is
  * not possible to resume them later.
  */
-void mono_thread_suspend_all_other_threads (void)
+void
+mono_thread_suspend_all_other_threads (void)
 {
-	struct wait_data wait_data;
-	struct wait_data *wait = &wait_data;
+	WaitData wait_data;
+	WaitData *wait = &wait_data;
 	int i;
 	MonoNativeThreadId self = mono_native_thread_id_get ();
 	guint32 eventidx = 0;
 	gboolean starting, finished;
 
-	memset (wait, 0, sizeof (struct wait_data));
+	memset (wait, 0, sizeof (WaitData));
 	/*
 	 * The other threads could be in an arbitrary state at this point, i.e.
 	 * they could be starting up, shutting down etc. This means that there could be
@@ -3236,9 +3311,7 @@ void mono_thread_suspend_all_other_threads (void)
 		 * Make a copy of the hashtable since we can't do anything with
 		 * threads while threads_mutex is held.
 		 */
-		wait->num = 0;
-		/*We must zero all InternalThread pointers to avoid making the GC unhappy.*/
-		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
+		init_wait_data (wait);
 		mono_threads_lock ();
 		mono_g_hash_table_foreach (threads, collect_threads_for_suspend, wait);
 		mono_threads_unlock ();
@@ -3702,7 +3775,7 @@ mono_thread_has_appdomain_ref (MonoThread *thread, MonoDomain *domain)
 }
 
 typedef struct abort_appdomain_data {
-	struct wait_data wait;
+	WaitData wait;
 	MonoDomain *domain;
 } abort_appdomain_data;
 
@@ -3716,10 +3789,8 @@ collect_appdomain_thread (gpointer key, gpointer value, gpointer user_data)
 	if (mono_thread_internal_has_appdomain_ref (thread, domain)) {
 		/* printf ("ABORTING THREAD %p BECAUSE IT REFERENCES DOMAIN %s.\n", thread->tid, domain->friendly_name); */
 
-		if(data->wait.num<MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
-			data->wait.handles [data->wait.num] = mono_threads_open_thread_handle (thread->handle);
-			data->wait.threads [data->wait.num] = thread;
-			data->wait.num++;
+		if (data->wait.num < MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS) {
+			add_wait_thread (&data->wait, thread);
 		} else {
 			/* Just ignore the rest, we can't do anything with
 			 * them yet
@@ -3752,7 +3823,7 @@ mono_threads_abort_appdomain_threads (MonoDomain *domain, int timeout)
 		mono_threads_lock ();
 
 		user_data.domain = domain;
-		user_data.wait.num = 0;
+		init_wait_data (&user_data.wait);
 		/* This shouldn't take any locks */
 		mono_g_hash_table_foreach (threads, collect_appdomain_thread, &user_data);
 		mono_threads_unlock ();
@@ -4919,6 +4990,10 @@ mono_threads_join_threads (void)
 				/* This shouldn't block */
 				mono_native_thread_join (thread);
 				MONO_EXIT_GC_SAFE;
+				thread_wait_lock ();
+				njoined_threads ++;
+				mono_os_cond_signal (&thread_wait_cond);
+				thread_wait_unlock ();
 			}
 		} else {
 			break;


### PR DESCRIPTION
…f events.

Instead of waiting for the thread handles to be signalled, wait for a cond variable signalled which is signalled by the code which calls pthread_join ().