### PR TITLE
Fix crash on Windows in PInvoke UTF8 tests

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5815,7 +5815,7 @@ handle_enum:
 				*conv = MONO_MARSHAL_CONV_STR_TBSTR;
 				return MONO_NATIVE_TBSTR;
 			case MONO_NATIVE_UTF8STR:
-				*conv = MONO_MARSHAL_CONV_STR_LPTSTR;
+				*conv = MONO_MARSHAL_CONV_STR_UTF8STR;
 				return MONO_NATIVE_UTF8STR;
 			case MONO_NATIVE_BYVALTSTR:
 				if (unicode)

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -519,7 +519,7 @@ if X86
 
 if HOST_WIN32
 PLATFORM_DISABLED_TESTS=async-exc-compilation.exe finally_guard.exe finally_block_ending_in_dead_bb.exe \
-	bug-18026.exe monitor.exe threadpool-exceptions5.exe pinvoke-utf8.exe
+	bug-18026.exe monitor.exe threadpool-exceptions5.exe
 endif
 
 endif

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7250,7 +7250,7 @@ build_return_string(const char* pReturn)
 		return ret;
 
 	size_t strLength = strlen(pReturn);
-	ret = (char *)(malloc(sizeof(char)* (strLength + 1)));
+	ret = (char *)(marshal_alloc (sizeof(char)* (strLength + 1)));
 	memset(ret, '\0', strLength + 1);
 	strncpy(ret, pReturn, strLength);
 	return ret;
@@ -7268,7 +7268,7 @@ StringParameterRefOut(/*out*/ char **s, int index)
 {
 	char *pszTextutf8 = (char*)utf8Strings[index];
 	size_t strLength = strlen(pszTextutf8);
-	*s = (char *)(malloc(sizeof(char)* (strLength + 1)));
+	*s = (char *)(marshal_alloc (sizeof(char)* (strLength + 1)));
 	memcpy(*s, pszTextutf8, strLength);
 	(*s)[strLength] = '\0';
 }
@@ -7291,10 +7291,10 @@ StringParameterRef(/*ref*/ char **s, int index)
 
     if (*s)
     {
-       free(*s);
+       marshal_free (*s);
     }
     // overwrite the orginal 
-    *s = (char *)(malloc(sizeof(char)* (strLength + 1)));
+    *s = (char *)(marshal_alloc (sizeof(char)* (strLength + 1)));
     memcpy(*s, pszTextutf8, strLength);
     (*s)[strLength] = '\0';
 }
@@ -7401,7 +7401,7 @@ StringBuilderParameterReturn(int index)
 {
     char *pszTextutf8 = (char*)utf8Strings[index];
     size_t strLength = strlen(pszTextutf8);
-    char * ret = (char *)(malloc(sizeof(char)* (strLength + 1)));
+    char * ret = (char *)(marshal_alloc (sizeof(char)* (strLength + 1)));
     memcpy(ret, pszTextutf8, strLength);
     ret[strLength] = '\0';
 


### PR DESCRIPTION
This PR fix crashes introduced in https://github.com/mono/mono/pull/3776 and contains the following fixes:

* Making sure `marshal_alloc`and `marshal_free` is used in libtest.c so
memory is allocated/freed with `CoTaskMemAlloc`/`CoTaskMemFree`.
* Now returning correct type for `MONO_NATIVE_UTF8STR` in `mono_type_to_unmanaged`.