### PR TITLE
[offsets-tool] Make sure to re-clone when the hash for the cpp binaries changes.

### DIFF
--- a/tools/offsets-tool/.gitignore
+++ b/tools/offsets-tool/.gitignore
@@ -1,4 +1,4 @@
-.stamp-clone
+.stamp-clone-*
 CppSharp
 *.exe
 *.h

--- a/tools/offsets-tool/Makefile
+++ b/tools/offsets-tool/Makefile
@@ -36,12 +36,12 @@ SRC_ROOT = ../..
 
 MONO_OPTIONS_SRC = $(SRC_ROOT)/mcs/class/Mono.Options/Mono.Options/Options.cs
 
-.stamp-clone:
-	@if [ ! -d $(CPPSHARP_BASE_DIR) ]; then \
-		git clone -b 60f763a9 --depth 1 git://github.com/xamarin/CppSharpBinaries.git $(CPPSHARP_BASE_DIR) && touch $@; \
-	fi
+HASH=60f763a9
+.stamp-clone-$(HASH):
+	rm -Rf $(CPPSHARP_BASE_DIR)
+	git clone -b $(HASH) --depth 1 git://github.com/xamarin/CppSharpBinaries.git $(CPPSHARP_BASE_DIR) && touch $@
 
-MonoAotOffsetsDumper.exe: .stamp-clone MonoAotOffsetsDumper.cs $(MONO_OPTIONS_SRC)
+MonoAotOffsetsDumper.exe: .stamp-clone-$(HASH) MonoAotOffsetsDumper.cs $(MONO_OPTIONS_SRC)
 	mcs MonoAotOffsetsDumper.cs /debug /nowarn:0436 $(MONO_OPTIONS_SRC) $(CPPSHARP_REFS)
 
 .PHONY: clean


### PR DESCRIPTION
This is the same as PR #3953, but for mono-4.8.0-branch.