### PR TITLE
[jit] Emit SQRTSD instead of FSQRT on AMD64 and use the libc sin/cos functions.

### DIFF
--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -368,7 +368,7 @@ cos: dest:f src1:f len:32
 abs: dest:f src1:f clob:1 len:32
 tan: dest:f src1:f len:59
 atan: dest:f src1:f len:9
-sqrt: dest:f src1:f len:32
+sqrt: dest:x src1:x len:32
 sext_i1: dest:i src1:i len:4
 sext_i2: dest:i src1:i len:4
 sext_i4: dest:i src1:i len:8

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -5349,7 +5349,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;		
 		}
 		case OP_SQRT:
-			EMIT_SSE2_FPFUNC (code, fsqrt, ins->dreg, ins->sreg1);
+			amd64_sse_sqrtsd_reg_reg (code, ins->dreg, ins->sreg1);
 			break;
 
 		case OP_RADD:

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -8176,11 +8176,15 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	int opcode = 0;
 
 	if (cmethod->klass == mono_defaults.math_class) {
+#if 0
+		/* Mono can emit Sin and Cos directly as fsin and fcos, but modern libc implementations should be faster. */
 		if (strcmp (cmethod->name, "Sin") == 0) {
 			opcode = OP_SIN;
 		} else if (strcmp (cmethod->name, "Cos") == 0) {
 			opcode = OP_COS;
-		} else if (strcmp (cmethod->name, "Sqrt") == 0) {
+                } else
+#endif
+		if (strcmp (cmethod->name, "Sqrt") == 0) {
 			opcode = OP_SQRT;
 		} else if (strcmp (cmethod->name, "Abs") == 0 && fsig->params [0]->type == MONO_TYPE_R8) {
 			opcode = OP_ABS;


### PR DESCRIPTION
This patch replaces the "old" x87 division that we currently emit for Math.Sqrt with a "new" SSE one.

The main reason for this is speed, since aside from longer execution time, one such FPU instruction amidst SSE code requires data conversion to/from the 80-bit format, as well.

CoreCLR uses SQRTSD, [too](https://github.com/dotnet/coreclr/blob/master/src/jit/instr.cpp#L3560).

Our benchmarking suite has [at least one test](https://github.com/xamarin/benchmarker/tree/master/tests/csgrande/GrandeTracer) where verification starts failing after this change. However, this is a problem with the test expecting too much (more than the standard requires) precision from the computations, and it's been failing on OS X for quite some time, too, due to similar overly strict precision requirements to another math function in libc.