### PR TITLE
fix a massive memory leak in MonoBtlsContext

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -365,7 +365,23 @@ namespace Mono.Btls
 		public override void Close ()
 		{
 			Debug ("Close!");
-			ssl.Dispose ();
+
+			if (ssl != null) {
+				ssl.Dispose ();
+				ssl = null;
+			}
+			if (ctx != null) {
+				ctx.Dispose ();
+				ctx = null;
+			}
+			if (bio != null) {
+				bio.Dispose ();
+				bio = null;
+			}
+			if (errbio != null) {
+				errbio.Dispose ();
+				errbio = null;
+			}
 		}
 
 		void Dispose<T> (ref T disposable)


### PR DESCRIPTION
Fix a memory leak originally reported in #45687

An isolated sample that triggers the bug:
http://shell.jkry.org/~keitsi/misc/mono_btls_memleak.cs.txt

When running unpatched code, the following happens:
$ MONO_TLS_PROVIDER=btls mono sample.exe
GC.Collect: Before=2784
GC.Collect: After=4645808
GC.Collect: Before=4645808
GC.Collect: After=4682008
GC.Collect: Before=4682008
GC.Collect: After=4718208
GC.Collect: Before=4718208
GC.Collect: After=4754408
GC.Collect: Before=4754408
GC.Collect: After=4790608
GC.Collect: Before=4790608
GC.Collect: After=4826808
GC.Collect: Before=4826808
GC.Collect: After=4863008
GC.Collect: Before=4863008
GC.Collect: After=4899208
GC.Collect: Before=4899208
GC.Collect: After=4935408
GC.Collect: Before=4935408
GC.Collect: After=4971608
GC.Collect: Before=4971608
GC.Collect: After=5007808
GC.Collect: Before=5007808

After applying this patch, here's what happens:
$ MONO_TLS_PROVIDER=btls mono sample.exe
GC.Collect: Before=2784
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848
GC.Collect: After=4644848
GC.Collect: Before=4644848