### PR TITLE
Fix missing property-bag.c file in VS project

### DIFF
--- a/msvc/libmonoruntime.vcxproj
+++ b/msvc/libmonoruntime.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="..\mono\metadata\class.c" />
     <ClCompile Include="..\mono\metadata\cominterop.c" />
     <ClCompile Include="..\mono\metadata\console-win32.c" />
+    <ClCompile Include="..\mono\metadata\property-bag.c" />
     <ClCompile Include="..\mono\metadata\socket-io-windows.c" />
     <ClCompile Include="..\mono\metadata\file-io-windows.c" />
     <ClCompile Include="..\mono\metadata\icall-windows.c" />
@@ -142,6 +143,7 @@
     <ClInclude Include="..\mono\metadata\marshal-windows-internals.h" />
     <ClInclude Include="..\mono\metadata\mono-security-windows-internals.h" />
     <ClInclude Include="..\mono\metadata\number-ms.h" />
+    <ClInclude Include="..\mono\metadata\property-bag.h" />
     <ClInclude Include="..\mono\metadata\w32process.h" />
     <ClInclude Include="..\mono\metadata\w32process-internals.h" />
     <ClInclude Include="..\mono\metadata\w32process-win32-internals.h" />

--- a/msvc/libmonoruntime.vcxproj.filters
+++ b/msvc/libmonoruntime.vcxproj.filters
@@ -262,6 +262,9 @@
     <ClCompile Include="..\mono\metadata\class-accessors.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mono\metadata\property-bag.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\mono\metadata\appdomain.h">
@@ -544,6 +547,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\mono\metadata\mono-security-windows-internals.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\property-bag.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
PR #3936 adds the `mono/metadata/property-bag.c` file but doesn't add it to `msvc/libmonoruntime.vcxproj`, resulting in linking errors when building the VS solution.