### PR TITLE
Fix VS error due to missing mono_dl_open()/mono_loader_register_module()

### DIFF
--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -241,6 +241,7 @@ mono_disasm_code
 mono_disasm_code_one
 mono_dl_fallback_register
 mono_dl_fallback_unregister
+mono_dl_open
 mono_dllmap_insert
 mono_domain_add_class_static_data
 mono_domain_assembly_open
@@ -495,6 +496,7 @@ mono_ldstr
 mono_ldtoken
 mono_load_remote_field
 mono_load_remote_field_new
+mono_loader_register_module
 mono_lock_free_alloc
 mono_lock_free_allocator_check_consistency
 mono_lock_free_allocator_init_allocator

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -241,6 +241,7 @@ mono_disasm_code
 mono_disasm_code_one
 mono_dl_fallback_register
 mono_dl_fallback_unregister
+mono_dl_open
 mono_dllmap_insert
 mono_domain_add_class_static_data
 mono_domain_assembly_open
@@ -497,6 +498,7 @@ mono_ldstr
 mono_ldtoken
 mono_load_remote_field
 mono_load_remote_field_new
+mono_loader_register_module
 mono_lock_free_alloc
 mono_lock_free_allocator_check_consistency
 mono_lock_free_allocator_init_allocator


### PR DESCRIPTION
PR #3955 removes `mono_dl_open()` and `mono_loader_register_module()` from `msvc/mono.def` and `msvc/monosgen.def` which causes VS linking error. This change
readds the symbols to the def files as a temporary solution to get the VS
builds to build successfully again.