### PR TITLE
Don't allow Join to return due to an APC

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1640,13 +1640,13 @@ ves_icall_System_Threading_Thread_Join_internal(MonoThread *this_obj, int ms)
 	mono_thread_set_state (cur_thread, ThreadState_WaitSleepJoin);
 
 	MONO_ENTER_GC_SAFE;
-	ret=mono_wait_uninterrupted (cur_thread, 1, &handle, FALSE, ms, &error);
+	ret=mono_join_uninterrupted (handle, ms, &error);
 	MONO_EXIT_GC_SAFE;
 
 	mono_thread_clr_state (cur_thread, ThreadState_WaitSleepJoin);
 
 	mono_error_set_pending_exception (&error);
-	
+
 	if(ret==MONO_THREAD_INFO_WAIT_RET_SUCCESS_0) {
 		THREAD_DEBUG (g_message ("%s: join successful", __func__));
 
@@ -1708,6 +1708,47 @@ mono_wait_uninterrupted (MonoInternalThread *thread, guint32 numhandles, gpointe
 		wait = ms - diff_ms;
 	} while (TRUE);
 	
+	return ret;
+}
+
+static MonoThreadInfoWaitRet
+mono_join_uninterrupted (MonoThreadHandle* thread_to_join, gint32 ms, MonoError *error)
+{
+	MonoException *exc;
+	MonoThreadInfoWaitRet ret;
+	gint64 start;
+	gint32 diff_ms;
+	gint32 wait = ms;
+
+	mono_error_init (error);
+
+	start = (ms == -1) ? 0 : mono_100ns_ticks ();
+	do {
+		MONO_ENTER_GC_SAFE;
+		ret = mono_thread_info_wait_one_handle (thread_to_join, ms, TRUE);
+		MONO_EXIT_GC_SAFE;
+
+		if (ret != MONO_THREAD_INFO_WAIT_RET_ALERTED)
+			break;
+
+		exc = mono_thread_execute_interruption ();
+		if (exc) {
+			mono_error_set_exception_instance (error, exc);
+			break;
+		}
+
+		if (ms == -1)
+			continue;
+
+		/* Re-calculate ms according to the time passed */
+		diff_ms = (gint32)((mono_100ns_ticks () - start) / 10000);
+		if (diff_ms >= ms) {
+			ret = MONO_THREAD_INFO_WAIT_RET_TIMEOUT;
+			break;
+		}
+		wait = ms - diff_ms;
+	} while (TRUE);
+
 	return ret;
 }
 


### PR DESCRIPTION
On Windows, Thread.Join does an alertable wait. If the thread calling
Join gets an APC during the call, Join will incorrectly return. Instead,
the code should handle the APC and continue waiting.