### PR TITLE
[C9][coop] Fix mono_stack_mark_pop

### DIFF
--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -91,9 +91,10 @@ static inline void
 mono_stack_mark_pop (MonoThreadInfo *info, HandleStackMark *stackmark)
 {
 	HandleStack *handles = (HandleStack *)info->handle_stack;
-	handles->top->size = stackmark->size;
+	HandleChunk *old_top = stackmark->chunk;
+	old_top->size = stackmark->size;
 	mono_memory_write_barrier ();
-	handles->top = stackmark->chunk;
+	handles->top = old_top;
 }
 
 /*


### PR DESCRIPTION
We need to restore the old size into the old top chunk, not the current
top chunk.