### PR TITLE
Fixed issue 47425

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -2295,11 +2295,15 @@ m_Handle, buffer, offset + sent, size - sent, socketFlags, out nativeError, is_b
 				(is_blocking       ? 0 : SocketInformationOptions.NonBlocking) |
 				(useOverlappedIO ? SocketInformationOptions.UseOnlyOverlappedIO : 0);
 
-			si.ProtocolInformation = Mono.DataConverter.Pack ("iiiil", (int)addressFamily, (int)socketType, (int)protocolType, is_bound ? 1 : 0, (long)Handle);
-			GC.SuppressFinalize(m_Handle);
-			m_Handle = null;
+			MonoIOError error;
+			IntPtr duplicateHandle;
+			if (!MonoIO.DuplicateHandle (System.Diagnostics.Process.GetCurrentProcess ().Handle, Handle, new IntPtr (targetProcessId), out duplicateHandle, 0, 0, 0x00000002 /* DUPLICATE_SAME_ACCESS */, out error))
+				throw MonoIO.GetException (error);
 
-			return si;
+			si.ProtocolInformation = Mono.DataConverter.Pack ("iiiil", (int)addressFamily, (int)socketType, (int)protocolType, is_bound ? 1 : 0, (long)duplicateHandle);
+ 			m_Handle = null;
+ 
+ 			return si;
 		}
 
 #endregion

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -2296,6 +2296,7 @@ m_Handle, buffer, offset + sent, size - sent, socketFlags, out nativeError, is_b
 				(useOverlappedIO ? SocketInformationOptions.UseOnlyOverlappedIO : 0);
 
 			si.ProtocolInformation = Mono.DataConverter.Pack ("iiiil", (int)addressFamily, (int)socketType, (int)protocolType, is_bound ? 1 : 0, (long)Handle);
+			GC.SuppressFinalize(m_Handle);
 			m_Handle = null;
 
 			return si;


### PR DESCRIPTION
This fix simply ensures that the `m_Handle` value is not processed by the GC after a call to `DuplicateAndClose` as that causes the duplicated socket to close.

A potential issue is that this will leak sockets if the sockets are never re-created.