### PR TITLE
Ignore disconnected interfaces in HttpListenerRequestTest.HttpRequestIsLocal

### DIFF
--- a/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
@@ -211,6 +211,8 @@ namespace MonoTests.System.Net
 			var ips = new List<IPAddress> ();
 			ips.Add (IPAddress.Loopback);
 			foreach (var adapter in NetworkInterface.GetAllNetworkInterfaces ()) {
+				if (adapter.OperationalStatus != OperationalStatus.Up)
+					continue;
 				foreach (var ip in adapter.GetIPProperties ().UnicastAddresses) {
 					ips.Add (ip.Address);
 				}


### PR DESCRIPTION
This test creates an HttpListener for every IP address of all network interfaces. On Windows disconnected network interfaces have unroutable IP addresses (169.254.XXX.XXX) and this test fails when it tries to listen to such an IP address. This patch adds a check to the test to ignore network
interfaces which don't have OperationalStatus == Up.