### PR TITLE
[runtime] Allocate the temporary vtable array using g_malloc in mono_…

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4395,7 +4395,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 {
 	MonoError error;
 	MonoClass *k, *ic;
-	MonoMethod **vtable;
+	MonoMethod **vtable = NULL;
 	int i, max_vtsize = 0, cur_slot = 0;
 	guint32 max_iid;
 	GPtrArray *ifaces = NULL;
@@ -4449,9 +4449,6 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		++cur_slot;
 	}
 
-	vtable = (MonoMethod **)alloca (sizeof (gpointer) * max_vtsize);
-	memset (vtable, 0, sizeof (gpointer) * max_vtsize);
-
 	/* printf ("METAINIT %s.%s\n", klass->name_space, klass->name); */
 
 	cur_slot = setup_interface_offsets (klass, cur_slot, TRUE);
@@ -4497,6 +4494,8 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 
 		return;
 	}
+
+	vtable = (MonoMethod **)g_malloc0 (sizeof (gpointer) * max_vtsize);
 
 	if (klass->parent && klass->parent->vtable_size) {
 		MonoClass *parent = klass->parent;
@@ -4553,7 +4552,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 			dslot = mono_method_get_vtable_slot (decl);
 			if (dslot == -1) {
 				mono_class_set_type_load_failure (klass, "");
-				return;
+				goto fail;
 			}
 
 			dslot += mono_class_interface_offset (klass, decl->klass);
@@ -4837,6 +4836,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 				mono_class_set_type_load_failure (klass, "Type %s has invalid vtable method slot %d with method %s", type_name, i, method_name);
 				g_free (type_name);
 				g_free (method_name);
+				g_free (vtable);
 				return;
 			}
 		}
@@ -4912,6 +4912,8 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		}
 	}
 
+	g_free (vtable);
+
 	VERIFY_INTERFACE_VTABLE (mono_class_verify_vtable (klass));
 	return;
 
@@ -4920,6 +4922,7 @@ fail:
 	char *name = mono_type_get_full_name (klass);
 	mono_class_set_type_load_failure (klass, "VTable setup of type %s failed", name);
 	g_free (name);
+	g_free (vtable);
 	if (override_map)
 		g_hash_table_destroy (override_map);
 	if (virt_methods)


### PR DESCRIPTION
…class_setup_vtable (), alloca can overflow for large vtable sizes. Hopefully fixes #45140.