### PR TITLE
[runtime] Implement lazy interface implementation for arrays.

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -317,6 +317,7 @@ struct _MonoClass {
 	guint has_finalize_inited    : 1; /* has_finalize is initialized */
 	guint fields_inited : 1; /* setup_fields () has finished */
 	guint has_failure : 1; /* See mono_class_get_exception_data () for a MonoErrorBoxed with the details */
+	guint is_array_special_interface : 1;
 
 	MonoClass  *parent;
 	MonoClass  *nested_in;
@@ -1101,6 +1102,8 @@ typedef struct {
 	MonoClass *argumenthandle_class;
 	MonoClass *monitor_class;
 	MonoClass *generic_ilist_class;
+	MonoClass *generic_icollection_class;
+	MonoClass *generic_ienumerable_class;
 	MonoClass *generic_nullable_class;
 	MonoClass *handleref_class;
 	MonoClass *attribute_class;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1103,8 +1103,6 @@ typedef struct {
 	MonoClass *argumenthandle_class;
 	MonoClass *monitor_class;
 	MonoClass *generic_ilist_class;
-	MonoClass *generic_icollection_class;
-	MonoClass *generic_ienumerable_class;
 	MonoClass *generic_nullable_class;
 	MonoClass *handleref_class;
 	MonoClass *attribute_class;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -284,6 +284,8 @@ struct _MonoClass {
 	guint blittable       : 1; /* class is blittable */
 	guint unicode         : 1; /* class uses unicode char when marshalled */
 	guint wastypebuilder  : 1; /* class was created at runtime from a TypeBuilder */
+	guint is_array_special_interface : 1; /* gtd or ginst of once of the magic interfaces that arrays implement */
+
 	/* next byte */
 	guint8 min_align;
 
@@ -317,7 +319,6 @@ struct _MonoClass {
 	guint has_finalize_inited    : 1; /* has_finalize is initialized */
 	guint fields_inited : 1; /* setup_fields () has finished */
 	guint has_failure : 1; /* See mono_class_get_exception_data () for a MonoErrorBoxed with the details */
-	guint is_array_special_interface : 1;
 
 	MonoClass  *parent;
 	MonoClass  *nested_in;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -673,6 +673,13 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.uint64_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "UInt64");
 
+	//XXX find a better place, which kinda doesn't exists as those types depend on each other.
+	mono_defaults.uint32_class->cast_class = mono_defaults.int32_class;
+	mono_defaults.uint16_class->cast_class = mono_defaults.int16_class;
+	mono_defaults.sbyte_class->cast_class = mono_defaults.byte_class;
+	mono_defaults.uint64_class->cast_class = mono_defaults.int64_class;
+
+
 	mono_defaults.single_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "Single");
 
@@ -801,10 +808,27 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_class_init (mono_defaults.array_class);
 	mono_defaults.generic_nullable_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Nullable`1");
-	mono_defaults.generic_ilist_class = mono_class_load_from_name (
-	        mono_defaults.corlib, "System.Collections.Generic", "IList`1");
 	mono_defaults.generic_ireadonlylist_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IReadOnlyList`1");
+
+	//IList, ICollection, IEnumerable
+	mono_defaults.generic_ilist_class = mono_class_load_from_name (
+	        mono_defaults.corlib, "System.Collections.Generic", "IList`1");
+	mono_defaults.generic_icollection_class = mono_class_load_from_name (
+	        mono_defaults.corlib, "System.Collections.Generic", "ICollection`1");
+	mono_defaults.generic_ienumerable_class = mono_class_load_from_name (
+	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerable`1");
+
+	//XXX This is a hack, there's probably a better place to do this. Probably in mono_class_create_from_typedef
+	mono_defaults.generic_ilist_class->is_array_special_interface = 1;
+	mono_defaults.generic_icollection_class->is_array_special_interface = 1;
+	mono_defaults.generic_ienumerable_class->is_array_special_interface = 1;
+
+	//FIXME IEnumerator needs to be special because GetEnumerator uses magic under the hood
+	MonoClass *tmp = mono_class_load_from_name (
+	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
+	tmp->is_array_special_interface = 1;
+
 
 	mono_defaults.threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -673,13 +673,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.uint64_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "UInt64");
 
-	//XXX find a better place, which kinda doesn't exists as those types depend on each other.
-	mono_defaults.uint32_class->cast_class = mono_defaults.int32_class;
-	mono_defaults.uint16_class->cast_class = mono_defaults.int16_class;
-	mono_defaults.sbyte_class->cast_class = mono_defaults.byte_class;
-	mono_defaults.uint64_class->cast_class = mono_defaults.int64_class;
-
-
 	mono_defaults.single_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "Single");
 
@@ -808,27 +801,10 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_class_init (mono_defaults.array_class);
 	mono_defaults.generic_nullable_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Nullable`1");
-	mono_defaults.generic_ireadonlylist_class = mono_class_load_from_name (
-	        mono_defaults.corlib, "System.Collections.Generic", "IReadOnlyList`1");
-
-	//IList, ICollection, IEnumerable
 	mono_defaults.generic_ilist_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IList`1");
-	mono_defaults.generic_icollection_class = mono_class_load_from_name (
-	        mono_defaults.corlib, "System.Collections.Generic", "ICollection`1");
-	mono_defaults.generic_ienumerable_class = mono_class_load_from_name (
-	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerable`1");
-
-	//XXX This is a hack, there's probably a better place to do this. Probably in mono_class_create_from_typedef
-	mono_defaults.generic_ilist_class->is_array_special_interface = 1;
-	mono_defaults.generic_icollection_class->is_array_special_interface = 1;
-	mono_defaults.generic_ienumerable_class->is_array_special_interface = 1;
-
-	//FIXME IEnumerator needs to be special because GetEnumerator uses magic under the hood
-	MonoClass *tmp = mono_class_load_from_name (
-	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
-	tmp->is_array_special_interface = 1;
-
+	mono_defaults.generic_ireadonlylist_class = mono_class_load_from_name (
+	        mono_defaults.corlib, "System.Collections.Generic", "IReadOnlyList`1");
 
 	mono_defaults.threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6477,15 +6477,6 @@ mono_object_isinst_mbyref_checked (MonoObject *obj, MonoClass *klass, MonoError 
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoVTable *vt;
-	static gboolean inited = FALSE;
-	static int special_array_iface_tests, special_array_iface_tests_fails;
-	if (!inited) {
-		inited = TRUE;
-		mono_counters_register ("Special array interfaces type tests",
-				MONO_COUNTER_METADATA | MONO_COUNTER_INT, &special_array_iface_tests);
-		mono_counters_register ("Special array interface type tests fails",
-				MONO_COUNTER_METADATA | MONO_COUNTER_INT, &special_array_iface_tests_fails);
-	}
 
 	mono_error_init (error);
 
@@ -6501,11 +6492,8 @@ mono_object_isinst_mbyref_checked (MonoObject *obj, MonoClass *klass, MonoError 
 
 		/* casting an array one of the invariant interfaces that must act as such */
 		if (klass->is_array_special_interface) {
-			++special_array_iface_tests;
 			if (mono_class_is_assignable_from (klass, vt->klass))
 				return obj;
-			else
-				++special_array_iface_tests_fails;
 		}
 
 		/*If the above check fails we are in the slow path of possibly raising an exception. So it's ok to it this way.*/

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -15152,7 +15152,7 @@ mono_decompose_typecheck (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins)
 	NEW_BBLOCK (cfg, first_bb);
 	cfg->cbb = first_bb;
 
-	if (!context_used && mini_class_has_reference_variant_generic_argument (cfg, klass, context_used)) {
+	if (!context_used && (mini_class_has_reference_variant_generic_argument (cfg, klass, context_used) || klass->is_array_special_interface)) {
 		if (is_isinst)
 			ret = emit_isinst_with_cache_nonshared (cfg, source, klass);
 		else


### PR DESCRIPTION
We have the following set of problems:

Arrays implement interfaces that are invariant but behave like covariant.
Those are IList\`1, ICollection\`1, IEnumerable\`1

Arrays of primitive types are type equivalent based on their underlying type.
This means int[], uint[] and IntEnum[] are all interchangeable. And so is casting among their interfaces.
Meaning this is valid: `(IList<IntEnum>)(object)new int[1]`.

Finally, the way we implement IEnumerator\`1 for arrays forces it to behave just like the other 3 interfaces.

Implementation:

Introduce MonoClass::is_array_special_interface, set for all the above interfaces. This allow fast checking of the interfaces in question.

mono_class_is_assignable_from now includes the array casting rules.

Change mono_class_interface_offset_with_variance to take arrays into account when looking for a candidate iface.

The JIT implements casting of those interfaces using the cast with cache wrapper.

Finally, to handle the weird primitive rules, set the cast_class of sbyte, ushort, uint and ulong to their same-size buddies.
This makes it easier for the casting code to resolve this problem.

Problems:

Casting performance is terrible, anywhere from 60% to 1000% slower on a micro-benchmark.
	Can be improved by extending our casting wrapper to handle those interfaces (probably would have to give up inlining as they would be huge)

The code in domain.c is icky, but not sure where to put it otherwise.

IEnumerator could be solved in Array.cs by not forcing it to be magic as well. Meaning the folowing

```
object array = new int[1];
var a = array as IList<int>;
var b = array as IList<uint>;

a.GetEnumerator().GetType () != b.GetEnumerator().GetType ();
```

The last line is false today but it's harmless to change it to avoid the casting penalty for such central type.