### PR TITLE
[bcl] Implement Thread.CurrentThread using an icall which calls mono_…

### DIFF
--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -293,11 +293,14 @@ namespace System.Threading {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static InternalThread CurrentInternalThread_internal();
 
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private extern static Thread GetCurrentThread ();
+
 		public static Thread CurrentThread {
 			[ReliabilityContract (Consistency.WillNotCorruptState, Cer.MayFail)]
 			get {
 				if (current_thread == null)
-					current_thread = new Thread (CurrentInternalThread_internal ());
+					current_thread = GetCurrentThread ();
 				return current_thread;
 			}
 		}

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -294,9 +294,11 @@ namespace System.Threading {
 		public static Thread CurrentThread {
 			[ReliabilityContract (Consistency.WillNotCorruptState, Cer.MayFail)]
 			get {
-				if (current_thread == null)
-					current_thread = GetCurrentThread ();
-				return current_thread;
+				Thread current = current_thread;
+				if (current != null)
+					return current;
+				// This will set the current_thread tls variable
+				return GetCurrentThread ();
 			}
 		}
 

--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -288,11 +288,6 @@ namespace System.Threading {
 			}
 		}
 
-		// Looks up the object associated with the current thread
-		// this is called by the JIT directly, too
-		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		private extern static InternalThread CurrentInternalThread_internal();
-
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern static Thread GetCurrentThread ();
 

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -933,7 +933,6 @@ ICALL(THREAD_1a, "ByteArrayToCurrentDomain(byte[])", ves_icall_System_Threading_
 ICALL(THREAD_1b, "ByteArrayToRootDomain(byte[])", ves_icall_System_Threading_Thread_ByteArrayToRootDomain)
 ICALL(THREAD_2, "ClrState(System.Threading.InternalThread,System.Threading.ThreadState)", ves_icall_System_Threading_Thread_ClrState)
 ICALL(THREAD_2a, "ConstructInternalThread", ves_icall_System_Threading_Thread_ConstructInternalThread)
-ICALL(THREAD_3, "CurrentInternalThread_internal", mono_thread_internal_current)
 ICALL(THREAD_55, "GetAbortExceptionState", ves_icall_System_Threading_Thread_GetAbortExceptionState)
 ICALL(THREAD_60, "GetCurrentThread", ves_icall_System_Threading_Thread_GetCurrentThread)
 ICALL(THREAD_7, "GetDomainID", ves_icall_System_Threading_Thread_GetDomainID)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -935,6 +935,7 @@ ICALL(THREAD_2, "ClrState(System.Threading.InternalThread,System.Threading.Threa
 ICALL(THREAD_2a, "ConstructInternalThread", ves_icall_System_Threading_Thread_ConstructInternalThread)
 ICALL(THREAD_3, "CurrentInternalThread_internal", mono_thread_internal_current)
 ICALL(THREAD_55, "GetAbortExceptionState", ves_icall_System_Threading_Thread_GetAbortExceptionState)
+ICALL(THREAD_60, "GetCurrentThread", ves_icall_System_Threading_Thread_GetCurrentThread)
 ICALL(THREAD_7, "GetDomainID", ves_icall_System_Threading_Thread_GetDomainID)
 ICALL(THREAD_8, "GetName_internal(System.Threading.InternalThread)", ves_icall_System_Threading_Thread_GetName_internal)
 ICALL(THREAD_57, "GetPriorityNative", ves_icall_System_Threading_Thread_GetPriority)

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -83,6 +83,7 @@ MonoObject* ves_icall_System_Threading_Thread_GetCachedCurrentCulture (MonoInter
 void ves_icall_System_Threading_Thread_SetCachedCurrentCulture (MonoThread *this_obj, MonoObject *culture);
 MonoObject* ves_icall_System_Threading_Thread_GetCachedCurrentUICulture (MonoInternalThread *this_obj);
 void ves_icall_System_Threading_Thread_SetCachedCurrentUICulture (MonoThread *this_obj, MonoObject *culture);
+MonoThread *ves_icall_System_Threading_Thread_GetCurrentThread (void);
 
 gint32 ves_icall_System_Threading_WaitHandle_WaitAll_internal(MonoArray *mono_handles, gint32 ms);
 gint32 ves_icall_System_Threading_WaitHandle_WaitAny_internal(MonoArray *mono_handles, gint32 ms);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1216,6 +1216,12 @@ ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThread *this_obj)
 	InterlockedCompareExchangePointer ((volatile gpointer *)&this_obj->internal_thread, internal, NULL);
 }
 
+MonoThread *
+ves_icall_System_Threading_Thread_GetCurrentThread (void)
+{
+	return mono_thread_current ();
+}
+
 HANDLE
 ves_icall_System_Threading_Thread_Thread_internal (MonoThread *this_obj,
 												   MonoObject *start)


### PR DESCRIPTION
…thread_current () to avoid creating duplicate Thread objects.