### PR TITLE
Fix assert in poll_event_wait() on WSAENOTSOCK on Windows #2

### DIFF
--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -1242,7 +1242,7 @@ ves_icall_System_Net_Sockets_Socket_Poll_internal (SOCKET sock, gint mode,
 
 	if (ret == -1) {
 #ifdef HOST_WIN32
-		*werror = errno > 0 && errno < WSABASEERR ? errno + WSABASEERR : errno;
+		*werror = (errno > 0 && errno < WSABASEERR) ? errno + WSABASEERR : errno;
 #else
 		*werror = errno_to_WSA (errno, __func__);
 #endif
@@ -1868,7 +1868,7 @@ ves_icall_System_Net_Sockets_Socket_Select_internal (MonoArray **sockets, gint32
 	
 	if (ret == -1) {
 #ifdef HOST_WIN32
-		*werror = errno > 0 && errno < WSABASEERR ? errno + WSABASEERR : errno;
+		*werror = (errno > 0 && errno < WSABASEERR) ? errno + WSABASEERR : errno;
 #else
 		*werror = errno_to_WSA (errno, __func__);
 #endif


### PR DESCRIPTION
PR #3998 fixes an error handling issue in poll_event_wait(). This new change
fixes a minor code style problem in that PR, the condition in a ternary wasn't
enclosed in parentheses.