### PR TITLE
Possibly fix hang in sgen-new-threads-collect.exe

### DIFF
--- a/mono/tests/sgen-new-threads-collect.cs
+++ b/mono/tests/sgen-new-threads-collect.cs
@@ -7,7 +7,7 @@ class Driver
 {
 	static DateTime targetTime;
 	static bool finished() {
-		DateTime now = DateTime.Now;
+		DateTime now = DateTime.UtcNow;
 		return now > targetTime;
 	}
 
@@ -15,7 +15,7 @@ class Driver
 	{
 		int gcCount = 0;
 		int joinCount = 0;
-		targetTime = DateTime.Now.AddSeconds(30);
+		targetTime = DateTime.UtcNow.AddSeconds(30);
 
 		Thread gcThread = new Thread (() => {
 			while (!finished()) {

--- a/mono/tests/sgen-new-threads-collect.cs
+++ b/mono/tests/sgen-new-threads-collect.cs
@@ -5,47 +5,60 @@ using System.Threading;
 
 class Driver
 {
+	static DateTime targetTime;
+	static bool finished() {
+		DateTime now = DateTime.Now;
+		return now > targetTime;
+	}
+
 	public static void Main ()
 	{
-		BlockingCollection<Thread> threads = new BlockingCollection<Thread> (new ConcurrentQueue<Thread> (), 128);
-
-		bool finished = false;
+		int gcCount = 0;
+		int joinCount = 0;
+		targetTime = DateTime.Now.AddSeconds(30);
 
 		Thread gcThread = new Thread (() => {
-			while (!finished) {
+			while (!finished()) {
 				GC.Collect ();
-				Thread.Yield ();
-			}
-		});
-
-		Thread joinThread = new Thread (() => {
-			for (int i = 0; ; ++i) {
-				Thread t = threads.Take ();
-				if (t == null)
-					break;
-				t.Join ();
-				if ((i + 1) % (50) == 0)
-					Console.Write (".");
-				if ((i + 1) % (50 * 50) == 0)
-					Console.WriteLine ();
+				gcCount++;
+				Thread.Sleep (1);
 			}
 		});
 
 		gcThread.Start ();
-		joinThread.Start ();
 
-		for (int i = 0; i < 10 * 1000; ++i) {
-			Thread t = new Thread (() => { Thread.Yield (); });
-			t.Start ();
+		// Create threads then join them for 30 seconds nonstop while GCs occur once per ms
+		while (!finished()) {
+			BlockingCollection<Thread> threads = new BlockingCollection<Thread> (new ConcurrentQueue<Thread> (), 128);
 
-			threads.Add (t);
+			Thread joinThread = new Thread (() => {
+				for (int i = 0; ; ++i) {
+					Thread t = threads.Take ();
+					if (t == null)
+						break;
+					t.Join ();
+
+					// Uncomment this and run with MONO_LOG_LEVEL=info MONO_LOG_MASK=gc
+					// to see GC/join balance in real time
+					//Console.Write ("*");
+				}
+			});
+			joinThread.Start ();
+			
+			const int makeThreads = 10*1000;
+			for (int i = 0; i < makeThreads; ++i) {
+				Thread t = new Thread (() => { Thread.Yield (); });
+				t.Start ();
+
+				threads.Add (t);
+			}
+
+			threads.Add (null);
+			joinThread.Join ();
+
+			joinCount += makeThreads;
+			Console.WriteLine("Performed {0} GCs, created {1} threads. Finished? {2}", gcCount, joinCount, finished());
 		}
-
-		threads.Add (null);
-
-		joinThread.Join ();
-
-		finished = true;
 		gcThread.Join ();
 	}
 }


### PR DESCRIPTION
This test is occasionally taking over 15 minutes to complete. This
could be a hang in the runtime, but the test has a scheduling fairness
issue which could also have the same result (if the GC thread wakes up
much more often than the join thread). Patch slows down the GC rate to
give the join thread a chance to work, and extends the test to a fixed
30 second runtime.