### PR TITLE
Adding support to get test results back from TestDriver.

### DIFF
--- a/mono/mini/TestDriver.cs
+++ b/mono/mini/TestDriver.cs
@@ -13,10 +13,22 @@ public class CategoryAttribute : Attribute
 		get; set;
 	}
 }
+public class TestDriverReporter
+{
+	public int FailedTests { get; private set; }
+	public int SkippedTests { get; private set; }
+	public int ExecutedTests { get; private set; }
+
+	public void ReportResults (int executed, int skipped, int failed) {
+		ExecutedTests = executed;
+		SkippedTests = skipped;
+		FailedTests = failed;
+	}
+};
 
 public class TestDriver {
 
-	static public int RunTests (Type type, string[] args) {
+	static public int RunTests(Type type, string[] args, TestDriverReporter reporter) {
 		int failed = 0, ran = 0;
 		int result, expected;
 		int i, j, iterations;
@@ -135,11 +147,20 @@ public class TestDriver {
 			}
 		}
 
+		if (reporter != null) {
+			reporter.ReportResults (ran, nskipped, failed);
+		}
+
 		//Console.WriteLine ("Regression tests: {0} ran, {1} failed in [{2}]{3}", ran, failed, type.Assembly.GetName().Name, type);
 		return failed;
 	}
+
+	static public int RunTests (Type type, string[] args) {
+		return RunTests (type, args, null);
+	}
+
 	static public int RunTests (Type type) {
-		return RunTests (type, null);
+		return RunTests (type, null, null);
 	}
 }
 


### PR DESCRIPTION
Add support in TestDriver to pass in an instance of a TestDriverReporter class when running tests. If an instance of TestDriverReporter is passed to TestDriver it will get a call to ReportResults with the number of executed, skipped and failed tests before TestDriver returns. This information is very useful for external runners that would like to present the result of TestDriver executed tests and not only the number of failed tests that it currently returns.

Since TestDriver is static, passing in an instance of a separate class will keep the static behavior of TestDriver. Current clients using TestDriver should be unaffected by this change. This new feature is used by some external embedders using TestDriver to run mono mini regression tests on platforms lacking console support.