### PR TITLE
[mkbundle] Print error message when assemblies couldn't be loaded

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -1071,9 +1071,11 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			}
 		}
 
-		if (error)
+		if (error) {
+			Error ("Couldn't load one or more of the assemblies.");
 			Environment.Exit (1);
-		
+		}
+
 		return assemblies;
 	}
 
@@ -1103,8 +1105,10 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			}
 		}
 
-		if (error)
+		if (error) {
+			Error ("Couldn't load one or more of the i18n assemblies.");
 			Environment.Exit (1);
+		}
 	}
 
 	


### PR DESCRIPTION
There were two places in mkbundle where it'd simply exit without printing anything, leading to confusion such as in https://bugzilla.xamarin.com/show_bug.cgi?id=46479.