### PR TITLE
[4.8][runtime] Don't add mono-dl.h to loader.h. Move the internal function…

### DIFF
--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -4,7 +4,6 @@
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/image.h>
 #include <mono/utils/mono-error.h>
-#include <mono/utils/mono-dl.h>
 
 MONO_BEGIN_DECLS
 
@@ -63,9 +62,6 @@ mono_lookup_internal_call (MonoMethod *method);
 
 void*
 mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles);
-
-void
-mono_loader_register_module (const char *name, MonoDl *module);
 
 MONO_API const char*
 mono_lookup_icall_symbol (MonoMethod *m);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -910,5 +910,8 @@ mono_image_set_description (MonoImageSet *);
 MonoImageSet *
 mono_find_image_set_owner (void *ptr);
 
+void
+mono_loader_register_module (const char *name, MonoDl *module);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 


### PR DESCRIPTION
… to an internal header.

(cherry picked from commit 2df8d8091ef350c60fb801b17c44f65f7052e638)

/cc @kumpera 