### PR TITLE
[runtime] Fix mono_image_load_module_checked () so it actually stores…

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -721,7 +721,7 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 					return NULL;
 				}
 
-				image->modules [idx - 1] = image;
+				image->modules [idx - 1] = moduleImage;
 
 #ifdef HOST_WIN32
 				if (image->modules [idx - 1]->is_module_handle)


### PR DESCRIPTION
… the loaded netmodule in image->modules, not the parent image itself. Fixes #47762.