### PR TITLE
[runtime] Backoirt mono-dl.h fix.

### DIFF
--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -4,7 +4,6 @@
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/image.h>
 #include <mono/utils/mono-error.h>
-#include <mono/utils/mono-dl.h>
 
 MONO_BEGIN_DECLS
 
@@ -63,9 +62,6 @@ mono_lookup_internal_call (MonoMethod *method);
 
 void*
 mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles);
-
-void
-mono_loader_register_module (const char *name, MonoDl *module);
 
 MONO_API const char*
 mono_lookup_icall_symbol (MonoMethod *m);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -910,5 +910,8 @@ mono_image_set_description (MonoImageSet *);
 MonoImageSet *
 mono_find_image_set_owner (void *ptr);
 
+void
+mono_loader_register_module (const char *name, MonoDl *module);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -241,7 +241,6 @@ mono_disasm_code
 mono_disasm_code_one
 mono_dl_fallback_register
 mono_dl_fallback_unregister
-mono_dl_open
 mono_dllmap_insert
 mono_domain_add_class_static_data
 mono_domain_assembly_open
@@ -496,7 +495,6 @@ mono_ldstr
 mono_ldtoken
 mono_load_remote_field
 mono_load_remote_field_new
-mono_loader_register_module
 mono_lock_free_alloc
 mono_lock_free_allocator_check_consistency
 mono_lock_free_allocator_init_allocator

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -241,7 +241,6 @@ mono_disasm_code
 mono_disasm_code_one
 mono_dl_fallback_register
 mono_dl_fallback_unregister
-mono_dl_open
 mono_dllmap_insert
 mono_domain_add_class_static_data
 mono_domain_assembly_open
@@ -498,7 +497,6 @@ mono_ldstr
 mono_ldtoken
 mono_load_remote_field
 mono_load_remote_field_new
-mono_loader_register_module
 mono_lock_free_alloc
 mono_lock_free_allocator_check_consistency
 mono_lock_free_allocator_init_allocator


### PR DESCRIPTION
From Rodrigo Kumpera:

    [runtime] Don't add mono-dl.h to loader.h. Move the internal function to an internal header.

Backport from: 2df8d8091ef350c60fb801b17c44f65f7052e638

Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=47698