### PR TITLE
[marshal] Only copy the minimum of size/length, not the full size

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1158,7 +1158,7 @@ mono_string_to_byvalwstr (gpointer dst, MonoString *src, int size)
 	}
 
 	len = MIN (size, (mono_string_length (src)));
-	memcpy (dst, mono_string_chars (src), size * 2);
+	memcpy (dst, mono_string_chars (src), len * 2);
 	if (size <= mono_string_length (src))
 		len--;
 	*((gunichar2 *) dst + len) = 0;


### PR DESCRIPTION
Fixes #46288

```
memcpy (dst, mono_string_chars (src), len * 2);
```

If we use "size" we might try to access memory beyond the length of the string. 
