### PR TITLE
[bcl] Fix a regression introduced by 91c68de23f5067d00020719446681323…

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
+++ b/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
@@ -127,9 +127,12 @@ namespace System.Net.Sockets {
 		{
 			//If this NRE, we're in deep problems because Register Must have
 			lock (blocking_threads) {
-				blocking_threads.Remove (Thread.CurrentThread);
-				if (THROW_ON_ABORT_RETRIES)
-					threads_stacktraces.Remove (Thread.CurrentThread);
+				var current = Thread.CurrentThread;
+				blocking_threads.Remove (current);
+				if (THROW_ON_ABORT_RETRIES) {
+					if (blocking_threads.IndexOf (current) == -1)
+						threads_stacktraces.Remove (current);
+				}
 
 				if (in_cleanup && blocking_threads.Count == 0)
 					Monitor.Pulse (blocking_threads);


### PR DESCRIPTION
…9cda7866 which happens if a thread was added to the SafeSocketHandle.blocking_thread list twice.