### PR TITLE
ilasm: Add stub parsing for .data cil attribute

### DIFF
--- a/mcs/class/PEAPI/Metadata.cs
+++ b/mcs/class/PEAPI/Metadata.cs
@@ -95,6 +95,11 @@ namespace PEAPI {
 		Synchronised = 0x0020, Synchronized = 0x0020, NoInLining = 0x0008, Optil = 0x0002}
 
 	/// <summary>
+	/// Storage location for initial field data
+	/// </summary>
+	public enum DataSegment { Data, TLS, CIL }
+
+	/// <summary>
 	/// Modes for a parameter
 	/// </summary>
 	public enum ParamAttr { Default, In, Out, Opt = 16, HasDefault = 0x1000, HasFieldMarshal = 0x2000 }

--- a/mcs/ilasm/codegen/DataDef.cs
+++ b/mcs/ilasm/codegen/DataDef.cs
@@ -15,14 +15,14 @@ namespace Mono.ILASM {
         public class DataDef {
 
                 private string name;
-                private bool is_tls;
+                private PEAPI.DataSegment segment;
 
                 private PEAPI.Constant constant;
 
-                public DataDef (string name, bool is_tls)
+                public DataDef (string name, PEAPI.DataSegment segment)
                 {
                         this.name = name;
-                        this.is_tls = is_tls;
+                        this.segment = segment;
                 }
 
                 public PEAPI.Constant PeapiConstant {

--- a/mcs/ilasm/parser/ILParser.jay
+++ b/mcs/ilasm/parser/ILParser.jay
@@ -1716,18 +1716,19 @@ data_decl		: data_head data_body
                           }
 			;
 
-data_head		: D_DATA tls id ASSIGN
+data_head		: D_DATA data_attr id ASSIGN
                           {
-                                $$ = new DataDef ((string) $3, (bool) $2);    
+                                $$ = new DataDef ((string) $3, (DataSegment) $2);
                           } 
-			| D_DATA tls
+			| D_DATA data_attr
                           {
-                                $$ = new DataDef (String.Empty, (bool) $2);
+                                $$ = new DataDef (String.Empty, (DataSegment) $2);
                           }
 			;
 
-tls			: /* EMPTY */   { $$ = false; }
-			| K_TLS         { $$ = true; }
+data_attr		: /* EMPTY */                   { $$ = DataSegment.Data; }
+			| K_TLS                         { $$ = DataSegment.TLS; }
+			| K_CIL                         { $$ = DataSegment.CIL; }
 			;
 
 data_body		: OPEN_BRACE dataitem_list CLOSE_BRACE

--- a/mcs/ilasm/tests/test-35.il
+++ b/mcs/ilasm/tests/test-35.il
@@ -1,0 +1,2 @@
+.assembly extern mscorlib { }
+.data cil test = bytearray ( 01 02 03 )


### PR DESCRIPTION
The "cil" attribute seems to indicate that the data should be placed in the .text section, along with the code.

Like the tls attribute, the cil attribute is only implemented insofar as to recognize it as a valid keyword that can occur in a .data declaration.

This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=48257.

*edited out CLA signing link to protect personal data*

Couldn't figure out how to run the tests in `mcs/ilasm/tests`, so I just added a file there.