### PR TITLE
[sre] Ensure generic_context is created before instantiating a TypeBuilder

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
@@ -11190,5 +11190,63 @@ namespace MonoTests.System.Reflection.Emit
 
 		interface IFoo {
 		}
+
+		[Test]
+		public void GenericFieldInCreatedType () {
+			/*
+			 * Regression test for #47867.
+			 * We construct the following, but only call CreateType on R.
+			 *
+			 * public class S<T> {
+			 *   public T t;
+			 * }
+			 * public class R {
+			 *   public static S<R> sr;
+			 * }
+			 */
+			var aname = new AssemblyName ("example1");
+			var ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aname, AssemblyBuilderAccess.Run);
+			var mb = ab.DefineDynamicModule (aname.Name);
+			var tbS = mb.DefineType ("S", TypeAttributes.Public);
+			tbS.DefineGenericParameters (new String [] { "T" });
+			var tbR = mb.DefineType ("R", TypeAttributes.Public);
+			tbR.DefineField ("sr", tbS.MakeGenericType(new Type[] { tbR }), FieldAttributes.Public | FieldAttributes.Static);
+
+			Type r = tbR.CreateType ();
+
+			Assert.IsNotNull  (r);
+		}
+
+		[Test]
+		public void GenericFieldInCreatedTypeIncompleteTypeTLE () {
+			/*
+			 * Regression test for #47867.
+			 * We construct the following, but only call CreateType on R.
+			 * Then we try to use R.sr which is expected throw a
+			 * TLE because S hasn't been created yet.
+			 *
+			 * public class S<T> {
+			 *   public T t;
+			 * }
+			 * public class R {
+			 *   public static S<R> sr;
+			 * }
+			 */
+			var aname = new AssemblyName ("example1");
+			var ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aname, AssemblyBuilderAccess.Run);
+			var mb = ab.DefineDynamicModule (aname.Name);
+			var tbS = mb.DefineType ("S", TypeAttributes.Public);
+			tbS.DefineGenericParameters (new String [] { "T" });
+			var tbR = mb.DefineType ("R", TypeAttributes.Public);
+			tbR.DefineField ("sr", tbS.MakeGenericType(new Type[] { tbR }), FieldAttributes.Public | FieldAttributes.Static);
+
+			Type r = tbR.CreateType ();
+
+			Assert.IsNotNull  (r);
+
+			// N.B.  tbS has not had CreateType called yet, so expect this to fail.
+			Assert.Throws<TypeLoadException> (delegate { var ft = r.GetField("sr").FieldType; });
+		}
+		
 	}
 }

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -2192,6 +2192,8 @@ mono_reflection_bind_generic_parameters (MonoReflectionType *type, int type_argc
 	if (mono_is_sre_type_builder (mono_object_class (type))) {
 		is_dynamic = TRUE;
 	} else if (mono_is_sre_generic_instance (mono_object_class (type))) {
+		/* Does this ever make sense?  what does instantiating a generic instance even mean? */
+		g_assert_not_reached ();
 		MonoReflectionGenericClass *rgi = (MonoReflectionGenericClass *) type;
 		MonoReflectionType *gtd = rgi->generic_type;
 


### PR DESCRIPTION
If TypeBuilders are used to construct the classes below and then `CreateType()` is called on the TypeBuilder for `R` but not the TypeBuilder for `S`, the runtime should not crash.
```csharp
class S<T> { ...}
class R {
  public S<int> SI;
}
```

Furthermore, if `var RType = RBuilder.CreateType()` then `RType.GetField("SI")` should not crash the runtime, but should throw a TLE.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=47867

---

I also added an assert in 979f07c that `mono_reflection_bind_generic_parameters` is never called on an `TypeBuilderInstantiation` because it seems like that should never happen.