### PR TITLE
[w32handle] Rename `statuscode` parameter to `abandoned`

### DIFF
--- a/mono/metadata/w32event-unix.c
+++ b/mono/metadata/w32event-unix.c
@@ -24,12 +24,12 @@ struct MonoW32HandleNamedEvent {
 	MonoW32HandleNamespace sharedns;
 };
 
-static gboolean event_handle_own (gpointer handle, MonoW32HandleType type, guint32 *statuscode)
+static gboolean event_handle_own (gpointer handle, MonoW32HandleType type, gboolean *abandoned)
 {
 	MonoW32HandleEvent *event_handle;
 	gboolean ok;
 
-	*statuscode = WAIT_OBJECT_0;
+	*abandoned = FALSE;
 
 	ok = mono_w32handle_lookup (handle, type, (gpointer *)&event_handle);
 	if (!ok) {
@@ -57,9 +57,9 @@ static void event_signal(gpointer handle)
 	ves_icall_System_Threading_Events_SetEvent_internal (handle);
 }
 
-static gboolean event_own (gpointer handle, guint32 *statuscode)
+static gboolean event_own (gpointer handle, gboolean *abandoned)
 {
-	return event_handle_own (handle, MONO_W32HANDLE_EVENT, statuscode);
+	return event_handle_own (handle, MONO_W32HANDLE_EVENT, abandoned);
 }
 
 static void namedevent_signal (gpointer handle)
@@ -68,9 +68,9 @@ static void namedevent_signal (gpointer handle)
 }
 
 /* NB, always called with the shared handle lock held */
-static gboolean namedevent_own (gpointer handle, guint32 *statuscode)
+static gboolean namedevent_own (gpointer handle, gboolean *abandoned)
 {
-	return event_handle_own (handle, MONO_W32HANDLE_NAMEDEVENT, statuscode);
+	return event_handle_own (handle, MONO_W32HANDLE_NAMEDEVENT, abandoned);
 }
 
 static void event_details (gpointer data)

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -55,10 +55,10 @@ typedef struct
 	/* Called by mono_w32handle_wait_one and mono_w32handle_wait_multiple,
 	 * with the handle locked (shared handles aren't locked.)
 	 * Returns TRUE if ownership was established, false otherwise.
-	 * If TRUE, *statuscode contains a status code such as
+	 * If TRUE, *abandoned contains a status code such as
 	 * WAIT_OBJECT_0 or WAIT_ABANDONED_0.
 	 */
-	gboolean (*own_handle)(gpointer handle, guint32 *statuscode);
+	gboolean (*own_handle)(gpointer handle, gboolean *abandoned);
 
 	/* Called by mono_w32handle_wait_one and mono_w32handle_wait_multiple, if the
 	 * handle in question is "ownable" (ie mutexes), to see if the current

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -24,11 +24,11 @@ struct MonoW32HandleNamedSemaphore {
 	MonoW32HandleNamespace sharedns;
 };
 
-static gboolean sem_handle_own (gpointer handle, MonoW32HandleType type, guint32 *statuscode)
+static gboolean sem_handle_own (gpointer handle, MonoW32HandleType type, gboolean *abandoned)
 {
 	MonoW32HandleSemaphore *sem_handle;
 
-	*statuscode = WAIT_OBJECT_0;
+	*abandoned = FALSE;
 
 	if (!mono_w32handle_lookup (handle, type, (gpointer *)&sem_handle)) {
 		g_warning ("%s: error looking up %s handle %p",
@@ -52,9 +52,9 @@ static void sema_signal(gpointer handle)
 	ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal(handle, 1, NULL);
 }
 
-static gboolean sema_own (gpointer handle, guint32 *statuscode)
+static gboolean sema_own (gpointer handle, gboolean *abandoned)
 {
-	return sem_handle_own (handle, MONO_W32HANDLE_SEM, statuscode);
+	return sem_handle_own (handle, MONO_W32HANDLE_SEM, abandoned);
 }
 
 static void namedsema_signal (gpointer handle)
@@ -63,9 +63,9 @@ static void namedsema_signal (gpointer handle)
 }
 
 /* NB, always called with the shared handle lock held */
-static gboolean namedsema_own (gpointer handle, guint32 *statuscode)
+static gboolean namedsema_own (gpointer handle, gboolean *abandoned)
 {
-	return sem_handle_own (handle, MONO_W32HANDLE_NAMEDSEM, statuscode);
+	return sem_handle_own (handle, MONO_W32HANDLE_NAMEDSEM, abandoned);
 }
 
 static void sema_details (gpointer data)


### PR DESCRIPTION
This parameter is only used to check if a mutex has been abandonned.