### PR TITLE
Add embedding API to expose empty string instance

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -187,6 +187,7 @@ create_domain_objects (MonoDomain *domain)
 	MonoString *empty_str = mono_string_intern_checked (mono_string_new (domain, ""), &error);
 	mono_error_assert_ok (&error);
 	mono_field_static_set_value (string_vt, string_empty_fld, empty_str);
+	domain->empty_string = empty_str;
 
 	/*
 	 * Create an instance early since we can't do it when there is no memory.

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -315,6 +315,7 @@ struct _MonoDomain {
 	MonoObject         *ephemeron_tombstone;
 	/* new MonoType [0] */
 	MonoArray          *empty_types;
+	MonoString         *empty_string;
 	/* 
 	 * The fields between FIRST_GC_TRACKED and LAST_GC_TRACKED are roots, but
 	 * not object references.

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1668,6 +1668,9 @@ mono_object_isinst_checked (MonoObject *obj, MonoClass *klass, MonoError *error)
 MonoObject *
 mono_object_isinst_mbyref_checked   (MonoObject *obj, MonoClass *klass, MonoError *error);
 
+MonoString*
+mono_string_empty_checked (MonoDomain *domain, MonoError *error);
+
 MonoString *
 mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1668,9 +1668,6 @@ mono_object_isinst_checked (MonoObject *obj, MonoClass *klass, MonoError *error)
 MonoObject *
 mono_object_isinst_mbyref_checked   (MonoObject *obj, MonoClass *klass, MonoError *error);
 
-MonoString*
-mono_string_empty_checked (MonoDomain *domain, MonoError *error);
-
 MonoString *
 mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5957,6 +5957,31 @@ ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n)
 }
 
 /**
+ * mono_string_empty_wrapper:
+ *
+ * Returns: The same empty string instance as the managed string.Empty
+ */
+MonoString*
+mono_string_empty_wrapper ()
+{
+	MonoDomain *domain = mono_domain_get ();
+	return mono_string_empty (domain);
+}
+
+/**
+ * mono_string_empty:
+ *
+ * Returns: The same empty string instance as the managed string.Empty
+ */
+MonoString*
+mono_string_empty (MonoDomain *domain)
+{
+	g_assert (domain);
+	g_assert (domain->empty_string);
+	return domain->empty_string;
+}
+
+/**
  * mono_string_new_utf16:
  * @text: a pointer to an utf16 string
  * @len: the length of the string
@@ -6076,36 +6101,32 @@ mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	if (len == 0 && domain->empty_string != NULL) {
-		return domain->empty_string;
-	} else {
-		MonoString *s;
-		MonoVTable *vtable;
-		size_t size;
+	MonoString *s;
+	MonoVTable *vtable;
+	size_t size;
 
-		mono_error_init (error);
+	mono_error_init (error);
 
-		/* check for overflow */
-		if (len < 0 || len > ((SIZE_MAX - G_STRUCT_OFFSET (MonoString, chars) - 8) / 2)) {
-			mono_error_set_out_of_memory (error, "Could not allocate %i bytes", -1);
-			return NULL;
-		}
-
-		size = (G_STRUCT_OFFSET (MonoString, chars) + (((size_t)len + 1) * 2));
-		g_assert (size > 0);
-
-		vtable = mono_class_vtable (domain, mono_defaults.string_class);
-		g_assert (vtable);
-
-		s = (MonoString *)mono_gc_alloc_string (vtable, size, len);
-
-		if (G_UNLIKELY (!s)) {
-			mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", size);
-			return NULL;
-		}
-
-		return s;
+	/* check for overflow */
+	if (len < 0 || len > ((SIZE_MAX - G_STRUCT_OFFSET (MonoString, chars) - 8) / 2)) {
+		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", -1);
+		return NULL;
 	}
+
+	size = (G_STRUCT_OFFSET (MonoString, chars) + (((size_t)len + 1) * 2));
+	g_assert (size > 0);
+
+	vtable = mono_class_vtable (domain, mono_defaults.string_class);
+	g_assert (vtable);
+
+	s = (MonoString *)mono_gc_alloc_string (vtable, size, len);
+
+	if (G_UNLIKELY (!s)) {
+		mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", size);
+		return NULL;
+	}
+
+	return s;
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5964,12 +5964,8 @@ ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n)
 MonoString*
 mono_string_empty_wrapper ()
 {
-	MonoError error;
-	MonoString *res = NULL;
 	MonoDomain *domain = mono_domain_get ();
-	res = mono_string_empty_checked (domain, &error);
-	mono_error_cleanup (&error);
-	return res;
+	return mono_string_empty (domain);
 }
 
 /**
@@ -5980,23 +5976,6 @@ mono_string_empty_wrapper ()
 MonoString*
 mono_string_empty (MonoDomain *domain)
 {
-	MonoError error;
-	MonoString *res = NULL;
-	res = mono_string_empty_checked (domain, &error);
-	mono_error_cleanup (&error);
-	return res;
-}
-
-/**
- * mono_string_empty_checked:
- *
- * Returns: The same empty string instance as the managed string.Empty
- */
-MonoString*
-mono_string_empty_checked (MonoDomain *domain, MonoError *error)
-{
-	mono_error_init (error);
-
 	g_assert (domain);
 	g_assert (domain->empty_string);
 	return domain->empty_string;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5964,8 +5964,12 @@ ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n)
 MonoString*
 mono_string_empty_wrapper ()
 {
+	MonoError error;
+	MonoString *res = NULL;
 	MonoDomain *domain = mono_domain_get ();
-	return mono_string_empty (domain);
+	res = mono_string_empty_checked (domain, &error);
+	mono_error_cleanup (&error);
+	return res;
 }
 
 /**
@@ -5976,6 +5980,23 @@ mono_string_empty_wrapper ()
 MonoString*
 mono_string_empty (MonoDomain *domain)
 {
+	MonoError error;
+	MonoString *res = NULL;
+	res = mono_string_empty_checked (domain, &error);
+	mono_error_cleanup (&error);
+	return res;
+}
+
+/**
+ * mono_string_empty_checked:
+ *
+ * Returns: The same empty string instance as the managed string.Empty
+ */
+MonoString*
+mono_string_empty_checked (MonoDomain *domain, MonoError *error)
+{
+	mono_error_init (error);
+
 	g_assert (domain);
 	g_assert (domain->empty_string);
 	return domain->empty_string;

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -112,7 +112,6 @@ mono_array_addr_with_size   (MonoArray *array, int size, uintptr_t idx);
 MONO_API uintptr_t
 mono_array_length           (MonoArray *array);
 
-MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
 mono_string_empty	      (MonoDomain *domain);
 

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -114,6 +114,14 @@ mono_array_length           (MonoArray *array);
 
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoString*
+mono_string_empty	      (MonoDomain *domain);
+
+MONO_RT_EXTERNAL_ONLY
+MONO_API MonoString*
+mono_string_empty_wrapper   ();
+
+MONO_RT_EXTERNAL_ONLY
+MONO_API MonoString*
 mono_string_new_utf16	    (MonoDomain *domain, const mono_unichar2 *text, int32_t len);
 
 MONO_RT_EXTERNAL_ONLY

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -824,6 +824,8 @@ mono_string_hash
 mono_string_intern
 mono_string_is_interned
 mono_string_length
+mono_string_empty
+mono_string_empty_wrapper
 mono_string_new
 mono_string_new_len
 mono_string_new_size

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -826,6 +826,8 @@ mono_string_hash
 mono_string_intern
 mono_string_is_interned
 mono_string_length
+mono_string_empty
+mono_string_empty_wrapper
 mono_string_new
 mono_string_new_len
 mono_string_new_size


### PR DESCRIPTION
The previous PR was https://github.com/mono/mono/pull/4047 and had build issues on linux due to mono_string_empty_wrapper calling mono_string_empty.

This PR adds a mono_string_empty_checked.