### PR TITLE
[runtime] Change the vtable->initialized bitfield into a byte so its …

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -475,8 +475,9 @@ struct MonoVTable {
 	guint8     *interface_bitmap;
 	guint32     max_interface_id;
 	guint8      rank;
+	/* Keep this a guint8, the jit depends on it */
+	guint8      initialized; /* cctor has been run */
 	guint remote          : 1; /* class is remotely activated */
-	guint initialized     : 1; /* cctor has been run */
 	guint init_failed     : 1; /* cctor execution failed */
 	guint has_static_fields : 1; /* pointer to the data stored at the end of the vtable array */
 	guint gc_bits         : MONO_VTABLE_AVAILABLE_GC_BITS; /* Those bits are reserved for the usaged of the GC */

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -76,6 +76,7 @@ DECL_OFFSET(MonoVTable, max_interface_id)
 DECL_OFFSET(MonoVTable, interface_bitmap)
 DECL_OFFSET(MonoVTable, vtable)
 DECL_OFFSET(MonoVTable, rank)
+DECL_OFFSET(MonoVTable, initialized)
 DECL_OFFSET(MonoVTable, type)
 DECL_OFFSET(MonoVTable, runtime_generic_context)
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3887,20 +3887,13 @@ emit_class_init (MonoCompile *cfg, MonoClass *klass)
 		ins->sreg1 = vtable_arg->dreg;
 		MONO_ADD_INS (cfg->cbb, ins);
 	} else {
-		static int byte_offset = -1;
-		static guint8 bitmask;
-		int bits_reg, inited_reg;
+		int inited_reg;
 		MonoBasicBlock *inited_bb;
 		MonoInst *args [16];
 
-		if (byte_offset < 0)
-			mono_marshal_find_bitfield_offset (MonoVTable, initialized, &byte_offset, &bitmask);
-
-		bits_reg = alloc_ireg (cfg);
 		inited_reg = alloc_ireg (cfg);
 
-		MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADU1_MEMBASE, bits_reg, vtable_arg->dreg, byte_offset);
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_IAND_IMM, inited_reg, bits_reg, bitmask);
+		MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADU1_MEMBASE, inited_reg, vtable_arg->dreg, MONO_STRUCT_OFFSET (MonoVTable, initialized));
 
 		NEW_BBLOCK (cfg, inited_bb);
 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -4883,16 +4883,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		}
 		case OP_GENERIC_CLASS_INIT: {
-			static int byte_offset = -1;
-			static guint8 bitmask;
 			guint8 *jump;
 
 			g_assert (ins->sreg1 == MONO_AMD64_ARG_REG1);
 
-			if (byte_offset < 0)
-				mono_marshal_find_bitfield_offset (MonoVTable, initialized, &byte_offset, &bitmask);
-
-			amd64_test_membase_imm_size (code, ins->sreg1, byte_offset, bitmask, 1);
+			amd64_test_membase_imm_size (code, ins->sreg1, MONO_STRUCT_OFFSET (MonoVTable, initialized), 1, 1);
 			jump = code;
 			amd64_branch8 (code, X86_CC_NZ, -1, 1);
 

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -5153,19 +5153,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		}
 		case OP_GENERIC_CLASS_INIT: {
-			static int byte_offset = -1;
-			static guint8 bitmask;
-			guint32 imm8;
+			int byte_offset;
 			guint8 *jump;
 
-			if (byte_offset < 0)
-				mono_marshal_find_bitfield_offset (MonoVTable, initialized, &byte_offset, &bitmask);
+			byte_offset = MONO_STRUCT_OFFSET (MonoVTable, initialized);
 
 			g_assert (arm_is_imm8 (byte_offset));
 			ARM_LDRSB_IMM (code, ARMREG_IP, ins->sreg1, byte_offset);
-			imm8 = mono_arm_is_rotated_imm8 (bitmask, &rot_amount);
-			g_assert (imm8 >= 0);
-			ARM_AND_REG_IMM (code, ARMREG_IP, ARMREG_IP, imm8, rot_amount);
 			ARM_CMP_REG_IMM (code, ARMREG_IP, 0, 0);
 			jump = code;
 			ARM_B_COND (code, ARMCOND_NE, 0);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4242,18 +4242,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 
 		case OP_GENERIC_CLASS_INIT: {
-			static int byte_offset = -1;
-			static guint8 bitmask;
+			int byte_offset;
 			guint8 *jump;
 
-			if (byte_offset < 0)
-				mono_marshal_find_bitfield_offset (MonoVTable, initialized, &byte_offset, &bitmask);
+			byte_offset = MONO_STRUCT_OFFSET (MonoVTable, initialized);
 
 			/* Load vtable->initialized */
 			arm_ldrsbx (code, ARMREG_IP0, sreg1, byte_offset);
-			// FIXME: No andx_imm yet */
-			code = mono_arm_emit_imm64 (code, ARMREG_IP1, bitmask);
-			arm_andx (code, ARMREG_IP0, ARMREG_IP0, ARMREG_IP1);
 			jump = code;
 			arm_cbnzx (code, ARMREG_IP0, 0);
 


### PR DESCRIPTION
…easier to load it from JITted code, the previous version was not using offsets infrastructure so it might not work when cross compiling.