### PR TITLE
[runtime] Convert a lot of hashtables to be concurrent.

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1832,9 +1832,9 @@ mono_image_close_except_pools (MonoImage *image)
 	}
 
 	if (image->method_cache)
-		g_hash_table_destroy (image->method_cache);
+		mono_conc_hashtable_destroy (image->method_cache);
 	if (image->methodref_cache)
-		g_hash_table_destroy (image->methodref_cache);
+		mono_conc_hashtable_destroy (image->methodref_cache);
 	mono_internal_hash_table_destroy (&image->class_cache);
 	mono_conc_hashtable_destroy (image->field_cache);
 	if (image->array_cache) {

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -785,6 +785,9 @@ mono_image_init (MonoImage *image)
 	image->method_signatures = g_hash_table_new (NULL, NULL);
 
 	image->property_hash = mono_property_hash_new ();
+
+	image->method_cache = mono_conc_hashtable_new (NULL, NULL);
+	image->methodref_cache = mono_conc_hashtable_new (NULL, NULL);
 }
 
 #if G_BYTE_ORDER != G_LITTLE_ENDIAN

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -780,7 +780,7 @@ mono_image_init (MonoImage *image)
 	image->field_cache = mono_conc_hashtable_new (NULL, NULL);
 
 	image->typespec_cache = mono_conc_hashtable_new (NULL, NULL);
-	image->memberref_signatures = g_hash_table_new (NULL, NULL);
+	image->memberref_signatures = mono_conc_hashtable_new (NULL, NULL);
 	image->helper_signatures = g_hash_table_new (g_str_hash, g_str_equal);
 	image->method_signatures = g_hash_table_new (NULL, NULL);
 
@@ -1876,7 +1876,7 @@ mono_image_close_except_pools (MonoImage *image)
 	g_free (image->gshared_types);
 
 	/* The ownership of signatures is not well defined */
-	g_hash_table_destroy (image->memberref_signatures);
+	mono_conc_hashtable_destroy (image->memberref_signatures);
 	g_hash_table_destroy (image->helper_signatures);
 	g_hash_table_destroy (image->method_signatures);
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -779,7 +779,7 @@ mono_image_init (MonoImage *image)
 				       class_next_value);
 	image->field_cache = mono_conc_hashtable_new (NULL, NULL);
 
-	image->typespec_cache = g_hash_table_new (NULL, NULL);
+	image->typespec_cache = mono_conc_hashtable_new (NULL, NULL);
 	image->memberref_signatures = g_hash_table_new (NULL, NULL);
 	image->helper_signatures = g_hash_table_new (g_str_hash, g_str_equal);
 	image->method_signatures = g_hash_table_new (NULL, NULL);
@@ -1867,7 +1867,7 @@ mono_image_close_except_pools (MonoImage *image)
 	free_hash (image->pinvoke_scopes);
 	free_hash (image->pinvoke_scope_filenames);
 	free_hash (image->native_func_wrapper_cache);
-	free_hash (image->typespec_cache);
+	mono_conc_hashtable_destroy (image->typespec_cache);
 
 	mono_wrapper_caches_free (&image->wrapper_caches);
 

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1727,6 +1727,16 @@ mono_get_method_full (MonoImage *image, guint32 token, MonoClass *klass,
 	return result;
 }
 
+static void
+create_conc_hash_table_if_needed (MonoConcurrentHashTable **ptr)
+{
+	MonoConcurrentHashTable *val = mono_conc_hashtable_new (NULL, NULL);
+	mono_memory_barrier ();
+
+	if (InterlockedCompareExchangePointer ((volatile void*)ptr, val, NULL))
+		mono_conc_hashtable_destroy (val); //someone else won setting up
+}
+
 MonoMethod *
 mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, MonoGenericContext *context, MonoError *error)
 {
@@ -1737,48 +1747,45 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 
 	mono_error_init (error);
 
-	mono_image_lock (image);
-
 	if (mono_metadata_token_table (token) == MONO_TABLE_METHOD) {
-		if (!image->method_cache)
-			image->method_cache = g_hash_table_new (NULL, NULL);
-		result = (MonoMethod *)g_hash_table_lookup (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)));
+		if (image->method_cache)
+			result = (MonoMethod *)mono_conc_hashtable_lookup (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)));
 	} else if (!image_is_dynamic (image)) {
-		if (!image->methodref_cache)
-			image->methodref_cache = g_hash_table_new (NULL, NULL);
-		result = (MonoMethod *)g_hash_table_lookup (image->methodref_cache, GINT_TO_POINTER (token));
+		if (image->methodref_cache)
+			result = (MonoMethod *)mono_conc_hashtable_lookup (image->methodref_cache, GINT_TO_POINTER (token));
 	}
-	mono_image_unlock (image);
 
 	if (result)
 		return result;
-
 
 	result = mono_get_method_from_token (image, token, klass, context, &used_context, error);
 	if (!result)
 		return NULL;
 
-	mono_image_lock (image);
 	if (!used_context && !result->is_inflated) {
 		MonoMethod *result2 = NULL;
 
 		if (mono_metadata_token_table (token) == MONO_TABLE_METHOD)
-			result2 = (MonoMethod *)g_hash_table_lookup (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)));
+			create_conc_hash_table_if_needed (&image->method_cache);
 		else if (!image_is_dynamic (image))
-			result2 = (MonoMethod *)g_hash_table_lookup (image->methodref_cache, GINT_TO_POINTER (token));
+			create_conc_hash_table_if_needed (&image->methodref_cache);
 
-		if (result2) {
-			mono_image_unlock (image);
-			return result2;
-		}
+		mono_image_lock (image);
 
 		if (mono_metadata_token_table (token) == MONO_TABLE_METHOD)
-			g_hash_table_insert (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)), result);
+			result2 = (MonoMethod *)mono_conc_hashtable_insert (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)), result);
 		else if (!image_is_dynamic (image))
-			g_hash_table_insert (image->methodref_cache, GINT_TO_POINTER (token), result);
+			result2 = (MonoMethod *)mono_conc_hashtable_insert (image->methodref_cache, GINT_TO_POINTER (token), result);
+
+		mono_image_unlock (image);
+
+		if (!result2)
+			result2 = result;
+
+		return result2;
+
 	}
 
-	mono_image_unlock (image);
 
 	return result;
 }

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -420,7 +420,8 @@ typedef struct {
 	MonoImage **images;
 
 	// Generic-specific caches
-	GHashTable *gclass_cache, *ginst_cache, *gmethod_cache, *gsignature_cache;
+	GHashTable *ginst_cache, *gmethod_cache, *gsignature_cache;
+	MonoConcurrentHashTable *gclass_cache;
 
 	MonoWrapperCaches wrapper_caches;
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -420,7 +420,8 @@ typedef struct {
 	MonoImage **images;
 
 	// Generic-specific caches
-	GHashTable *ginst_cache, *gmethod_cache, *gsignature_cache;
+	GHashTable *gmethod_cache, *gsignature_cache;
+	MonoConcurrentHashTable *ginst_cache;
 	MonoConcurrentHashTable *gclass_cache;
 
 	MonoWrapperCaches wrapper_caches;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -283,11 +283,11 @@ struct _MonoImage {
 	/*
 	 * Indexed by method tokens and typedef tokens.
 	 */
-	GHashTable *method_cache; /*protected by the image lock*/
+	MonoConcurrentHashTable *method_cache; /*protected by the image lock*/
 	MonoInternalHashTable class_cache;
 
 	/* Indexed by memberref + methodspec tokens */
-	GHashTable *methodref_cache; /*protected by the image lock*/
+	MonoConcurrentHashTable *methodref_cache; /*protected by the image lock*/
 
 	/*
 	 * Indexed by fielddef and memberref tokens

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -295,7 +295,7 @@ struct _MonoImage {
 	MonoConcurrentHashTable *field_cache; /*protected by the image lock*/
 
 	/* indexed by typespec tokens. */
-	GHashTable *typespec_cache; /* protected by the image lock */
+	MonoConcurrentHashTable *typespec_cache; /* protected by the image lock */
 	/* indexed by token */
 	GHashTable *memberref_signatures;
 	GHashTable *helper_signatures;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -297,7 +297,7 @@ struct _MonoImage {
 	/* indexed by typespec tokens. */
 	MonoConcurrentHashTable *typespec_cache; /* protected by the image lock */
 	/* indexed by token */
-	GHashTable *memberref_signatures;
+	MonoConcurrentHashTable *memberref_signatures;
 	GHashTable *helper_signatures;
 
 	/* Indexed by blob heap indexes */

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5683,9 +5683,7 @@ mono_type_create_from_typespec_checked (MonoImage *image, guint32 type_spec, Mon
 
 	mono_error_init (error);
 
-	mono_image_lock (image);
-	type = (MonoType *)g_hash_table_lookup (image->typespec_cache, GUINT_TO_POINTER (type_spec));
-	mono_image_unlock (image);
+	type = (MonoType *)mono_conc_hashtable_lookup (image->typespec_cache, GUINT_TO_POINTER (type_spec));
 	if (type)
 		return type;
 
@@ -5709,12 +5707,12 @@ mono_type_create_from_typespec_checked (MonoImage *image, guint32 type_spec, Mon
 	mono_metadata_free_type (type);
 
 	mono_image_lock (image);
-	type = (MonoType *)g_hash_table_lookup (image->typespec_cache, GUINT_TO_POINTER (type_spec));
+
 	/* We might leak some data in the image mempool if found */
-	if (!type) {
-		g_hash_table_insert (image->typespec_cache, GUINT_TO_POINTER (type_spec), type2);
+	type = mono_conc_hashtable_insert (image->typespec_cache, GUINT_TO_POINTER (type_spec), type2);
+	if (!type)
 		type = type2;
-	}
+
 	mono_image_unlock (image);
 
 	return type;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2474,7 +2474,7 @@ get_image_set (MonoImage **images, int nimages)
 		for (i = 0; i < nimages; ++i)
 			set->images [i] = images [i];
 		set->gclass_cache = mono_conc_hashtable_new_full (mono_generic_class_hash, mono_generic_class_equal, NULL, (GDestroyNotify)free_generic_class);
-		set->ginst_cache = g_hash_table_new_full (mono_metadata_generic_inst_hash, mono_metadata_generic_inst_equal, NULL, (GDestroyNotify)free_generic_inst);
+		set->ginst_cache = mono_conc_hashtable_new_full (mono_metadata_generic_inst_hash, mono_metadata_generic_inst_equal, NULL, (GDestroyNotify)free_generic_inst);
 		set->gmethod_cache = g_hash_table_new_full (inflated_method_hash, inflated_method_equal, NULL, (GDestroyNotify)free_inflated_method);
 		set->gsignature_cache = g_hash_table_new_full (inflated_signature_hash, inflated_signature_equal, NULL, (GDestroyNotify)free_inflated_signature);
 
@@ -2503,7 +2503,7 @@ delete_image_set (MonoImageSet *set)
 	int i;
 
 	mono_conc_hashtable_destroy (set->gclass_cache);
-	g_hash_table_destroy (set->ginst_cache);
+	mono_conc_hashtable_destroy (set->ginst_cache);
 	g_hash_table_destroy (set->gmethod_cache);
 	g_hash_table_destroy (set->gsignature_cache);
 
@@ -2864,7 +2864,7 @@ mono_metadata_clean_for_image (MonoImage *image)
 
 		mono_image_set_lock (set);
 		mono_conc_hashtable_foreach_steal (set->gclass_cache, steal_gclass_in_image, &gclass_data);
-		g_hash_table_foreach_steal (set->ginst_cache, steal_ginst_in_image, &ginst_data);
+		mono_conc_hashtable_foreach_steal (set->ginst_cache, steal_ginst_in_image, &ginst_data);
 		g_hash_table_foreach_remove (set->gmethod_cache, inflated_method_in_image, image);
 		g_hash_table_foreach_remove (set->gsignature_cache, inflated_signature_in_image, image);
 		mono_image_set_unlock (set);
@@ -3019,25 +3019,30 @@ mono_metadata_get_generic_inst (int type_argc, MonoType **type_argv)
 
 	collect_data_free (&data);
 
-	mono_image_set_lock (set);
+	ginst = (MonoGenericInst *)mono_conc_hashtable_lookup (set->ginst_cache, ginst);
+	if (ginst)
+		return ginst;
 
-	ginst = (MonoGenericInst *)g_hash_table_lookup (set->ginst_cache, ginst);
-	if (!ginst) {
-		ginst = (MonoGenericInst *)mono_image_set_alloc0 (set, size);
+	ginst = (MonoGenericInst *)mono_image_set_alloc0 (set, size);
 #ifndef MONO_SMALL_CONFIG
-		ginst->id = ++next_generic_inst_id;
+	ginst->id = InterlockedIncrement (&next_generic_inst_id);
 #endif
-		ginst->is_open = is_open;
-		ginst->type_argc = type_argc;
+	ginst->is_open = is_open;
+	ginst->type_argc = type_argc;
 
-		for (i = 0; i < type_argc; ++i)
-			ginst->type_argv [i] = mono_metadata_type_dup (NULL, type_argv [i]);
+	for (i = 0; i < type_argc; ++i)
+		ginst->type_argv [i] = mono_metadata_type_dup (NULL, type_argv [i]);
 
-		g_hash_table_insert (set->ginst_cache, ginst, ginst);
-	}
-
+	mono_image_set_lock (set);
+	MonoGenericInst *ginst2 = (MonoGenericInst *)mono_conc_hashtable_insert (set->ginst_cache, ginst, ginst);
 	mono_image_set_unlock (set);
-	return ginst;
+
+	if (!ginst2)
+		 ginst2 = ginst;
+	else
+		free_generic_inst (ginst);
+
+	return ginst2;
 }
 
 static gboolean

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -30,6 +30,10 @@
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/bsearch.h>
 #include <mono/utils/atomic.h>
+#include <mono/utils/mono-counters.h>
+
+static int img_set_cache_hit, img_set_cache_miss, img_set_count;
+
 
 /* Auxiliary structure used for caching inflated signatures */
 typedef struct {
@@ -1555,6 +1559,10 @@ mono_metadata_init (void)
 		g_hash_table_insert (type_cache, (gpointer) &builtin_types [i], (gpointer) &builtin_types [i]);
 
 	mono_os_mutex_init_recursive (&image_sets_mutex);
+
+	mono_counters_register ("ImgSet Cache Hit", MONO_COUNTER_METADATA | MONO_COUNTER_INT, &img_set_cache_hit);
+	mono_counters_register ("ImgSet Cache Miss", MONO_COUNTER_METADATA | MONO_COUNTER_INT, &img_set_cache_miss);
+	mono_counters_register ("ImgSet Count", MONO_COUNTER_METADATA | MONO_COUNTER_INT, &img_set_count);
 }
 
 /**
@@ -2306,6 +2314,95 @@ image_sets_unlock (void)
 	mono_os_mutex_unlock (&image_sets_mutex);
 }
 
+static int
+compare_pointers (const void *a, const void *b)
+{
+	return (size_t)a - (size_t)b;
+}
+
+//1103, 1327, 1597
+#define HASH_TABLE_SIZE 1103
+static MonoImageSet *img_set_cache [HASH_TABLE_SIZE];
+
+static guint32
+mix_hash (uintptr_t source)
+{
+	unsigned int hash = source;
+
+	// Actual hash
+	hash = (((hash * 215497) >> 16) ^ ((hash * 1823231) + hash));
+
+	// Mix in highest bits on 64-bit systems only
+	if (sizeof (source) > 4)
+		hash = hash ^ (source >> 32);
+
+	return hash;
+}
+
+static guint32
+hash_images (MonoImage **images, int nimages)
+{
+	guint32 res = 0;
+	int i;
+	for (i = 0; i < nimages; ++i)
+		res += mix_hash ((size_t)images [i]);
+
+	return res;
+}
+
+static gboolean
+compare_img_set (MonoImageSet *set, MonoImage **images, int nimages)
+{
+	int j, k;
+
+	if (set->nimages != nimages)
+		return FALSE;
+
+	for (j = 0; j < nimages; ++j) {
+		for (k = 0; k < nimages; ++k)
+			if (set->images [k] == images [j])
+				break; // Break on match
+
+		// If we iterated all the way through set->images, images[j] was *not* found.
+		if (k == nimages)
+			break; // Break on "image not found"
+	}
+
+	// If we iterated all the way through images without breaking, all items in images were found in set->images
+	return j == nimages;
+}
+
+
+static MonoImageSet*
+img_set_cache_get (MonoImage **images, int nimages)
+{
+	guint32 hash_code = hash_images (images, nimages);
+	int index = hash_code % HASH_TABLE_SIZE;
+	MonoImageSet *img = img_set_cache [index];
+	if (!img || !compare_img_set (img, images, nimages)) {
+		++img_set_cache_miss;
+		return NULL;
+	}
+	++img_set_cache_hit;
+	return img;
+}
+
+static void
+img_set_cache_add (MonoImageSet *set)
+{
+	guint32 hash_code = hash_images (set->images, set->nimages);
+	int index = hash_code % HASH_TABLE_SIZE;
+	img_set_cache [index] = set;	
+}
+
+static void
+img_set_cache_remove (MonoImageSet *is)
+{
+	guint32 hash_code = hash_images (is->images, is->nimages);
+	int index = hash_code % HASH_TABLE_SIZE;
+	if (img_set_cache [index] == is)
+		img_set_cache [index] = NULL;
+}
 /*
  * get_image_set:
  *
@@ -2326,6 +2423,10 @@ get_image_set (MonoImage **images, int nimages)
 	// FIXME: Is corlib the correct thing to return here? If so, why? This may be an artifact of generic instances previously defaulting to allocating from corlib.
 	if (nimages == 0)
 		return mscorlib_image_set;
+
+	set = img_set_cache_get (images, nimages);
+	if (set)
+		return set;
 
 	image_sets_lock ();
 
@@ -2381,6 +2482,9 @@ get_image_set (MonoImage **images, int nimages)
 			set->images [i]->image_sets = g_slist_prepend (set->images [i]->image_sets, set);
 
 		g_ptr_array_add (image_sets, set);
+		++img_set_count;
+
+		img_set_cache_add (set);
 	}
 
 	if (nimages == 1 && images [0] == mono_defaults.corlib) {
@@ -2413,6 +2517,8 @@ delete_image_set (MonoImageSet *set)
 	g_ptr_array_remove (image_sets, set);
 
 	image_sets_unlock ();
+
+	img_set_cache_remove (set);
 
 	if (set->mempool)
 		mono_mempool_destroy (set->mempool);

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2473,7 +2473,7 @@ get_image_set (MonoImage **images, int nimages)
 		mono_os_mutex_init_recursive (&set->lock);
 		for (i = 0; i < nimages; ++i)
 			set->images [i] = images [i];
-		set->gclass_cache = g_hash_table_new_full (mono_generic_class_hash, mono_generic_class_equal, NULL, (GDestroyNotify)free_generic_class);
+		set->gclass_cache = mono_conc_hashtable_new_full (mono_generic_class_hash, mono_generic_class_equal, NULL, (GDestroyNotify)free_generic_class);
 		set->ginst_cache = g_hash_table_new_full (mono_metadata_generic_inst_hash, mono_metadata_generic_inst_equal, NULL, (GDestroyNotify)free_generic_inst);
 		set->gmethod_cache = g_hash_table_new_full (inflated_method_hash, inflated_method_equal, NULL, (GDestroyNotify)free_inflated_method);
 		set->gsignature_cache = g_hash_table_new_full (inflated_signature_hash, inflated_signature_equal, NULL, (GDestroyNotify)free_inflated_signature);
@@ -2502,7 +2502,7 @@ delete_image_set (MonoImageSet *set)
 {
 	int i;
 
-	g_hash_table_destroy (set->gclass_cache);
+	mono_conc_hashtable_destroy (set->gclass_cache);
 	g_hash_table_destroy (set->ginst_cache);
 	g_hash_table_destroy (set->gmethod_cache);
 	g_hash_table_destroy (set->gsignature_cache);
@@ -2863,7 +2863,7 @@ mono_metadata_clean_for_image (MonoImage *image)
 		MonoImageSet *set = (MonoImageSet *)l->data;
 
 		mono_image_set_lock (set);
-		g_hash_table_foreach_steal (set->gclass_cache, steal_gclass_in_image, &gclass_data);
+		mono_conc_hashtable_foreach_steal (set->gclass_cache, steal_gclass_in_image, &gclass_data);
 		g_hash_table_foreach_steal (set->ginst_cache, steal_ginst_in_image, &ginst_data);
 		g_hash_table_foreach_remove (set->gmethod_cache, inflated_method_in_image, image);
 		g_hash_table_foreach_remove (set->gsignature_cache, inflated_signature_in_image, image);
@@ -3081,17 +3081,13 @@ mono_metadata_lookup_generic_class (MonoClass *container_class, MonoGenericInst 
 
 	collect_data_free (&data);
 
-	mono_image_set_lock (set);
-
-	gclass = (MonoGenericClass *)g_hash_table_lookup (set->gclass_cache, &helper);
+	gclass = (MonoGenericClass *)mono_conc_hashtable_lookup (set->gclass_cache, &helper);
 
 	/* A tripwire just to keep us honest */
 	g_assert (!helper.cached_class);
 
-	if (gclass) {
-		mono_image_set_unlock (set);
+	if (gclass)
 		return gclass;
-	}
 
 	gclass = mono_image_set_new0 (set, MonoGenericClass, 1);
 	if (is_dynamic)
@@ -3105,11 +3101,17 @@ mono_metadata_lookup_generic_class (MonoClass *container_class, MonoGenericInst 
 	if (inst == mono_class_get_generic_container (container_class)->context.class_inst && !is_tb_open)
 		gclass->cached_class = container_class;
 
-	g_hash_table_insert (set->gclass_cache, gclass, gclass);
+	mono_image_set_lock (set);
+
+	MonoGenericClass *gclass2 = mono_conc_hashtable_insert (set->gclass_cache, gclass, gclass);
+	if (!gclass2)
+		gclass2 = gclass;
+
+	// g_hash_table_insert (set->gclass_cache, gclass, gclass);
 
 	mono_image_set_unlock (set);
 
-	return gclass;
+	return gclass2;
 }
 
 /*

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -372,8 +372,8 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 
 	/* fixme: ugly hack - delete all previously compiled methods */
 	if (domain_jit_info (domain)) {
-		g_hash_table_destroy (domain_jit_info (domain)->jit_trampoline_hash);
-		domain_jit_info (domain)->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
+		mono_conc_hashtable_destroy (domain_jit_info (domain)->jit_trampoline_hash);
+		domain_jit_info (domain)->jit_trampoline_hash = mono_conc_hashtable_new (mono_aligned_addr_hash, NULL);
 		mono_internal_hash_table_destroy (&(domain->jit_code_hash));
 		mono_jit_code_hash_init (&(domain->jit_code_hash));
 	}

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -180,7 +180,7 @@ get_method_from_ip (void *ip)
 		user_data.ip = ip;
 		user_data.method = NULL;
 		mono_domain_lock (domain);
-		g_hash_table_foreach (domain_jit_info (domain)->jit_trampoline_hash, find_tramp, &user_data);
+		mono_conc_hashtable_foreach (domain_jit_info (domain)->jit_trampoline_hash, find_tramp, &user_data);
 		mono_domain_unlock (domain);
 		if (user_data.method) {
 			char *mname = mono_method_full_name (user_data.method, TRUE);
@@ -267,7 +267,7 @@ mono_print_method_from_ip (void *ip)
 		user_data.ip = ip;
 		user_data.method = NULL;
 		mono_domain_lock (domain);
-		g_hash_table_foreach (domain_jit_info (domain)->jit_trampoline_hash, find_tramp, &user_data);
+		mono_conc_hashtable_foreach (domain_jit_info (domain)->jit_trampoline_hash, find_tramp, &user_data);
 		mono_domain_unlock (domain);
 
 		if (user_data.method) {
@@ -3442,7 +3442,7 @@ mini_create_jit_domain_info (MonoDomain *domain)
 	MonoJitDomainInfo *info = g_new0 (MonoJitDomainInfo, 1);
 
 	info->jump_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
-	info->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
+	info->jit_trampoline_hash = mono_conc_hashtable_new (mono_aligned_addr_hash, NULL);
 	info->delegate_trampoline_hash = g_hash_table_new (class_method_pair_hash, class_method_pair_equal);
 	info->llvm_vcall_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	info->runtime_invoke_hash = mono_conc_hashtable_new_full (mono_aligned_addr_hash, NULL, NULL, runtime_invoke_info_free);
@@ -3511,7 +3511,7 @@ mini_free_jit_domain_info (MonoDomain *domain)
 	if (info->method_code_hash)
 		g_hash_table_destroy (info->method_code_hash);
 	g_hash_table_destroy (info->jump_trampoline_hash);
-	g_hash_table_destroy (info->jit_trampoline_hash);
+	mono_conc_hashtable_destroy (info->jit_trampoline_hash);
 	g_hash_table_destroy (info->delegate_trampoline_hash);
 	if (info->static_rgctx_trampoline_hash)
 		g_hash_table_destroy (info->static_rgctx_trampoline_hash);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1530,21 +1530,21 @@ mono_create_jit_trampoline (MonoDomain *domain, MonoMethod *method, MonoError *e
 		}
 	}
 
-	mono_domain_lock (domain);
-	tramp = g_hash_table_lookup (domain_jit_info (domain)->jit_trampoline_hash, method);
-	mono_domain_unlock (domain);
+	tramp = mono_conc_hashtable_lookup (domain_jit_info (domain)->jit_trampoline_hash, method);
 	if (tramp)
 		return tramp;
 
 	tramp = mono_create_specific_trampoline (method, MONO_TRAMPOLINE_JIT, domain, NULL);
 	
 	mono_domain_lock (domain);
-	g_hash_table_insert (domain_jit_info (domain)->jit_trampoline_hash, method, tramp);
+	gpointer tramp2 = mono_conc_hashtable_insert (domain_jit_info (domain)->jit_trampoline_hash, method, tramp);
 	mono_domain_unlock (domain);
+	if (!tramp2)
+		tramp2 = tramp;
 
 	jit_trampolines++;
 
-	return tramp;
+	return tramp2;
 }	
 
 gpointer

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -344,7 +344,7 @@ typedef struct
 	/* Maps methods/klasses to the address of the given type of trampoline */
 	GHashTable *class_init_trampoline_hash;
 	GHashTable *jump_trampoline_hash;
-	GHashTable *jit_trampoline_hash;
+	MonoConcurrentHashTable *jit_trampoline_hash;
 	GHashTable *delegate_trampoline_hash;
 	/* Maps ClassMethodPair -> MonoDelegateTrampInfo */
 	GHashTable *static_rgctx_trampoline_hash;

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -246,6 +246,7 @@ mono_conc_hashtable_remove (MonoConcurrentHashTable *hash_table, gpointer key)
 				kvs [i].value = NULL;
 				mono_memory_barrier ();
 				kvs [i].key = TOMBSTONE;
+				--hash_table->element_count;
 
 				if (hash_table->key_destroy_func != NULL)
 					(*hash_table->key_destroy_func) (key);
@@ -358,6 +359,31 @@ mono_conc_hashtable_foreach (MonoConcurrentHashTable *hash_table, GHFunc func, g
 	for (i = 0; i < table->table_size; ++i) {
 		if (kvs [i].key && kvs [i].key != TOMBSTONE) {
 			func (kvs [i].key, kvs [i].value, userdata);
+		}
+	}
+}
+
+/**
+ * mono_conc_hashtable_foreach_steal:
+ *
+ * Calls @func for each entry in the hashtable, if @func returns true, remove from the hashtable. Requires external locking.
+ * Same semantics as g_hash_table_foreach_steal.
+ */
+void
+mono_conc_hashtable_foreach_steal (MonoConcurrentHashTable *hash_table, GHRFunc func, gpointer userdata)
+{
+	int i;
+	conc_table *table = (conc_table*)hash_table->table;
+	key_value_pair *kvs = table->kvs;
+
+	for (i = 0; i < table->table_size; ++i) {
+		if (kvs [i].key && kvs [i].key != TOMBSTONE) {
+			if (func (kvs [i].key, kvs [i].value, userdata)) {
+				kvs [i].value = NULL;
+				mono_memory_barrier ();
+				kvs [i].key = TOMBSTONE;
+				--hash_table->element_count;
+			}
 		}
 	}
 }

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -286,6 +286,17 @@ mono_conc_hashtable_remove (MonoConcurrentHashTable *hash_table, gpointer key)
  * mono_conc_hashtable_insert:
  * 
  * Insert a value into the hashtable. Requires external locking.
+ * Unlike other hashtables, insert doesn't replace an existing value, but simply returns it. The rationale for this behavior
+ * is that this will be used with data that can't be safely freed in case of a duplicated key.
+ * The pattern to use when inserting is the following:
+ *
+ * lock ();
+ * gpointer val2 = mono_conc_hashtable_insert (hash, key, val);
+ * unlock ();
+ * if (!val2)
+ *   val2 = val;
+ * return val2;
+ *
  * @Returns the old value if key is already present or null
  */
 gpointer

--- a/mono/utils/mono-conc-hashtable.h
+++ b/mono/utils/mono-conc-hashtable.h
@@ -24,6 +24,6 @@ MONO_API gpointer mono_conc_hashtable_lookup (MonoConcurrentHashTable *hash_tabl
 MONO_API gpointer mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, gpointer value);
 MONO_API gpointer mono_conc_hashtable_remove (MonoConcurrentHashTable *hash_table, gpointer key);
 MONO_API void mono_conc_hashtable_foreach (MonoConcurrentHashTable *hashtable, GHFunc func, gpointer userdata);
-
+MONO_API void mono_conc_hashtable_foreach_steal (MonoConcurrentHashTable *hashtable, GHRFunc func, gpointer userdata);
 
 #endif


### PR DESCRIPTION
This significantly reduces Roslyn contention when JIT'ing.