### PR TITLE
[w32handle] Fix race in foreach and unref

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -476,7 +476,8 @@ BASE_TEST_CS_SRC=		\
 	generic-unloading.2.cs	\
 	namedmutex-destroy-race.cs	\
 	thread6.cs	\
-	appdomain-threadpool-unload.cs
+	appdomain-threadpool-unload.cs	\
+	process-unref-race.cs
 
 TEST_CS_SRC_DIST=	\
 	$(BASE_TEST_CS_SRC)	\
@@ -587,7 +588,7 @@ if X86
 
 if HOST_WIN32
 PLATFORM_DISABLED_TESTS=async-exc-compilation.exe finally_guard.exe finally_block_ending_in_dead_bb.exe \
-	bug-18026.exe monitor.exe threadpool-exceptions5.exe
+	bug-18026.exe monitor.exe threadpool-exceptions5.exe process-unref-race.exe
 endif
 
 endif

--- a/mono/tests/process-unref-race.cs
+++ b/mono/tests/process-unref-race.cs
@@ -1,0 +1,52 @@
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+class Driver
+{
+	static IEnumerable<int> UntilTimeout (uint ms)
+	{
+		DateTime start = DateTime.UtcNow;
+		for (int i = 0; (DateTime.UtcNow - start).TotalMilliseconds < ms ; i++)
+			yield return i;
+	}
+
+	public static void Main ()
+	{
+		object count_lock = new object ();
+		int count = 0;
+
+		ParallelOptions options = new ParallelOptions {
+			MaxDegreeOfParallelism = Environment.ProcessorCount * 4,
+		};
+
+		Thread t1 = new Thread (() => {
+			Parallel.ForEach (UntilTimeout (15 * 1000), options, _ => {
+				using (Process p = Process.Start ("cat", "/dev/null")) {
+					p.WaitForExit ();
+				}
+
+				lock (count_lock) {
+					count += 1;
+
+					if (count % (10) == 0)
+						Console.Write (".");
+					if (count % (10 * 50) == 0)
+						Console.WriteLine ();
+				}
+			});
+		});
+
+		t1.Start ();
+
+		while (!t1.Join (0)) {
+			try {
+				using (Process p = Process.GetProcessById (1));
+			} catch (ArgumentException) {
+			}
+		}
+	}
+}


### PR DESCRIPTION
It could happen that we unref a handle that we are currently looping over. This could be the case if we are calling Process.GetProcessById (which loops over all handles) and mono_w32handle_unref on a MonoW32HandleProcess handle.

We need to make the `scan_mutex` and recursive mutex, as we could call `mono_w32handle_unref` which could destroy the handle, while in `mono_w32handle_foreach`.