### PR TITLE
Enable building the BCL with mcs from pre-4.8 mono installation

### DIFF
--- a/mcs/class/corlib/Makefile
+++ b/mcs/class/corlib/Makefile
@@ -11,10 +11,18 @@ LIB_MCS_FLAGS = $(REFERENCE_SOURCES_FLAGS) $(RESOURCE_FILES:%=-resource:%)
 #LIBRARY_USE_INTERMEDIATE_FILE = yes
 
 ifeq (2, $(FRAMEWORK_VERSION_MAJOR))
+ifdef MCS_MODE
+LIB_MCS_FLAGS += --runtime:v4
+else
 LIB_MCS_FLAGS += -runtimemetadataversion:v4.0.30319
+endif
 else
 ifeq (4, $(FRAMEWORK_VERSION_MAJOR))
+ifdef MCS_MODE
+LIB_MCS_FLAGS += --runtime:v4
+else
 LIB_MCS_FLAGS += -runtimemetadataversion:v4.0.30319
+endif
 else
 $(error Unknown framework version)
 endif


### PR DESCRIPTION
This skips passing -runtimemetadataversion when building the BCL with
--with-csc=mcs.