### PR TITLE
[threads] Fix conflicting signal with boehm

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3717,6 +3717,8 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_set_generic_sharing_supported (TRUE);
 #endif
 
+	mono_threads_signals_init ();
+
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_install_handlers ();
 #endif

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -708,7 +708,6 @@ mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 	mono_lls_init (&thread_list, NULL);
 	mono_thread_smr_init ();
 	mono_threads_suspend_init ();
-	mono_threads_suspend_init_signals ();
 	mono_threads_coop_init ();
 
 #if defined(__MACH__)
@@ -718,6 +717,12 @@ mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 	mono_threads_inited = TRUE;
 
 	g_assert (sizeof (MonoNativeThreadId) <= sizeof (uintptr_t));
+}
+
+void
+mono_threads_signals_init (void)
+{
+	mono_threads_suspend_init_signals ();
 }
 
 void

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -299,6 +299,9 @@ void
 mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t thread_info_size);
 
 void
+mono_threads_signals_init (void);
+
+void
 mono_threads_runtime_init (MonoThreadInfoRuntimeCallbacks *callbacks);
 
 MonoThreadInfoRuntimeCallbacks *


### PR DESCRIPTION
Boehm would use SIGPWR on linux 32/64bits for its suspend signal, but that would conflict with utils/threads suspend signal.

The fix consists in looking for an available realtime signal in utils/threads, and fallback to the default SIGXFSZ, SIGPWR and SIGXCPU