### PR TITLE
Fix Microsoft.Build.Engine fail when built with mcs

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Makefile
+++ b/mcs/class/Microsoft.Build.Engine/Makefile
@@ -28,7 +28,9 @@ test-local: compile-resources
 
 compile-resources: Test/resources/TestTasks-$(PROFILE).dll
 	cp Test/resources/TestTasks-$(PROFILE).dll Test/resources/TestTasks.dll
+ifndef MCS_MODE
 	cp Test/resources/TestTasks-$(PROFILE).pdb Test/resources/TestTasks.pdb
+endif
 
 include $(XBUILD_DIR)/xbuild_test.make
 include ../../build/library.make


### PR DESCRIPTION
Fixes the Makefile to not fail if the compiler hasn't generated a pdb file for
the TestTasks dll.