### PR TITLE
[4.6] Remove exception when using SO_REUSEADDR on Linux (#3856)

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -3193,9 +3193,6 @@ namespace System.Net.Sockets
 		{
 			ThrowIfDisposedAndClosed ();
 
-			if (optionLevel == SocketOptionLevel.Socket && optionName == SocketOptionName.ReuseAddress && optionValue != 0 && !SupportsPortReuse (protocol_type))
-				throw new SocketException ((int) SocketError.OperationNotSupported, "Operating system sockets do not support ReuseAddress.\nIf your socket is not intended to bind to the same address and port multiple times remove this option, otherwise you should ignore this exception inside a try catch and check that ReuseAddress is true before binding to the same address and port multiple times.");
-
 			int error;
 			SetSocketOption_internal (safe_handle, optionLevel, optionName, null, null, optionValue, out error);
 


### PR DESCRIPTION
SO_REUSEADDR and SO_REUSEPORT are fundamentally different. This
exception seems to have been put in place to address the lack of
the latter on older Linux kernels for TCP. However, the change in
fact raises an exception when SO_REUSEADDR is used, which causes
failures in server applications, which may use SO_REUSEADDR to
avoid WAIT state timeouts.

Description of SO_REUSEADDR and SO_REUSEPORT differences:

http://stackoverflow.com/questions/14388706/socket-options-so-reuseaddr-and-so-reuseport-how-do-they-differ-do-they-mean-t

Some problems caused by raising this exception:

https://github.com/zeromq/netmq/issues/623
https://github.com/zeromq/netmq/issues/592
https://github.com/fsprojects/IfSharp/issues/90