### PR TITLE
[llvm] Fix intrinsic Selector.GetHandle support.

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5810,8 +5810,19 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			const char *name = (const char*)ins->inst_p0;
 			LLVMValueRef var;
 
-			if (!ctx->module->objc_selector_to_var)
+			if (!ctx->module->objc_selector_to_var) {
 				ctx->module->objc_selector_to_var = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+				LLVMValueRef info_var = LLVMAddGlobal (ctx->lmodule, LLVMArrayType (LLVMInt8Type (), 8), "@OBJC_IMAGE_INFO");
+				int32_t objc_imageinfo [] = { 0, 16 };
+				LLVMSetInitializer (info_var, mono_llvm_create_constant_data_array ((uint8_t *) &objc_imageinfo, 8));
+				LLVMSetLinkage (info_var, LLVMPrivateLinkage);
+				LLVMSetExternallyInitialized (info_var, TRUE);
+				LLVMSetSection (info_var, "__DATA, __objc_imageinfo,regular,no_dead_strip");
+				LLVMSetAlignment (info_var, sizeof (mgreg_t));
+				mark_as_used (ctx->module, info_var);
+			}
+
 			var = g_hash_table_lookup (ctx->module->objc_selector_to_var, name);
 			if (!var) {
 				LLVMValueRef indexes [16];


### PR DESCRIPTION
An OBJC_IMAGE_INFO section must be emitted when we emit the native equivalent
of @selector for Selector.GetHandle, otherwise the Objective-C runtime will
not process the selectors in this image at runtime (and we may end up with
duplicate selectors in memory).

The AOT compiler already does this here: https://github.com/mono/mono/blob/2eda626316fd8f70cd98947af2f89b7ca9b0ebe5/mono/mini/aot-compiler.c#L9657-L9661