### PR TITLE
[ci] Run aot-test on more platforms

### DIFF
--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -3,7 +3,10 @@
 export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
 
 ${TESTCMD} --label=mini --timeout=5m make -w -C mono/mini -k check check-seq-points EMIT_NUNIT=1
-${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot
+if [[ ${label} == w* ]]
+then ${TESTCMD} --label=aot-test --skip;
+else ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot
+fi
 ${TESTCMD} --label=compile-runtime-tests --timeout=20m make -w -C mono/tests -j4 tests
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1 CI_PR=${ghprbPullId}
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -3,10 +3,7 @@
 export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
 
 ${TESTCMD} --label=mini --timeout=5m make -w -C mono/mini -k check check-seq-points EMIT_NUNIT=1
-if [[ ${label} == osx-* ]]
-then ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot
-else ${TESTCMD} --label=aot-test --skip;
-fi
+${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot
 ${TESTCMD} --label=compile-runtime-tests --timeout=20m make -w -C mono/tests -j4 tests
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1 CI_PR=${ghprbPullId}
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check


### PR DESCRIPTION
Now that https://github.com/mono/mono/pull/4096 is merged, we should be able to run it on Linux too.