### PR TITLE
[ci] Simplify run-jenkins.sh script variables

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
-TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
+export MONO_REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
+export TESTCMD=${MONO_REPO_ROOT}/scripts/ci/run-step.sh
 
 export TEST_HARNESS_VERBOSE=1
+
 if [[ ${label} == w* ]]; then
     # Passing -ggdb3 on Cygwin breaks linking against libmonosgen-x.y.dll
     export CFLAGS="-g -O2"
@@ -19,8 +21,8 @@ if [[ ${CI_TAGS} == *'mcs-compiler'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLA
 
 if [[ ${label} == 'osx-i386' ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib --build=i386-apple-darwin11.2.0"; fi
 if [[ ${label} == 'osx-amd64' ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib "; fi
-if [[ ${label} == 'w32' ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32 --with-csc=mcs"; export MONO_EXECUTABLE="`cygpath -u ${WORKSPACE}\\\msvc\\\build\\\sgen\\\Win32\\\bin\\\Release\\\mono-sgen.exe`"; fi
-if [[ ${label} == 'w64' ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm"; export MONO_EXECUTABLE="`cygpath -u ${WORKSPACE}\\\msvc\\\build\\\sgen\\\x64\\\bin\\\Release\\\mono-sgen.exe`"; fi
+if [[ ${label} == 'w32' ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32 --with-csc=mcs"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
+if [[ ${label} == 'w64' ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
 
 if [[ ${CI_TAGS} == *'aot_only'* ]];
     then
@@ -30,7 +32,7 @@ elif [[ ${CI_TAGS} == *'aot_preferred'* ]];
     EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=aot_preferred";
 elif [[ ${CI_TAGS} == *'acceptance-tests'* ]];
     then
-    EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --prefix=${WORKSPACE}/tmp/mono-acceptance-tests --with-sgen-default-concurrent=yes";
+    EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --prefix=${MONO_REPO_ROOT}/tmp/mono-acceptance-tests --with-sgen-default-concurrent=yes";
 elif [[ ${label} != w* ]] && [[ ${label} != 'debian-8-ppc64el' ]] && [[ ${label} != 'centos-s390x' ]] && [[ ${CI_TAGS} != *'monolite'* ]];
     then
     # only enable the concurrent collector by default on main unix archs

--- a/scripts/ci/run-test-acceptance-tests.sh
+++ b/scripts/ci/run-test-acceptance-tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
-
 make install  # Roslyn tests need a Mono installation
 
 LANG=en_US.UTF-8 ${TESTCMD} --label=check-ms-test-suite --timeout=30m make -C acceptance-tests check-ms-test-suite
@@ -13,7 +11,7 @@ if [ "$total_tests" -lt "1600" ]
 fi
 
 ${TESTCMD} --label=check-roslyn --timeout=30m make -C acceptance-tests check-roslyn PREFIX=${WORKSPACE}/tmp/mono-acceptance-tests
-rm -rf ${WORKSPACE}/tmp/mono-acceptance-tests  # cleanup the Mono installation used for Roslyn tests
+rm -rf ${MONO_REPO_ROOT}/tmp/mono-acceptance-tests  # cleanup the Mono installation used for Roslyn tests
 
 ${TESTCMD} --label=coreclr-compile-tests --timeout=80m --fatal make -C acceptance-tests coreclr-compile-tests
 ${TESTCMD} --label=coreclr-runtest-basic --timeout=10m make -C acceptance-tests coreclr-runtest-basic

--- a/scripts/ci/run-test-aot_hybrid.sh
+++ b/scripts/ci/run-test-aot_hybrid.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
-
 ${TESTCMD} --label=mini --timeout=25m make -j 4 -w -C mono/mini -k aotcheck
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1
 ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test

--- a/scripts/ci/run-test-aot_only.sh
+++ b/scripts/ci/run-test-aot_only.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
-
 if test -n "${MONO_LLVMONLY}";
 then
 ${TESTCMD} --label=mini --timeout=25m make -j 4 -w -C mono/mini -k llvmonlycheck

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
-
 ${TESTCMD} --label=mini --timeout=5m make -w -C mono/mini -k check check-seq-points EMIT_NUNIT=1
 if [[ ${label} == osx-* ]]
 then ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot

--- a/scripts/ci/run-test-profiler-stress-tests.sh
+++ b/scripts/ci/run-test-profiler-stress-tests.sh
@@ -1,5 +1,3 @@
 #!/bin/bash -e
 
-export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
-
 ${TESTCMD} --label=check-profiler-stress --timeout=24h make -C acceptance-tests check-profiler-stress


### PR DESCRIPTION
Get rid of WORKSPACE which is set by Jenkins, this allows one to more easily run the run-jenkins.sh script locally e.g. on cygwin.

The only thing that needs to be passed in is CI_TAGS and label.