### PR TITLE
[unwinding on android] move large struct off the stack

### DIFF
--- a/mono/mini/mini-exceptions-native-unwinder.c
+++ b/mono/mini/mini-exceptions-native-unwinder.c
@@ -27,6 +27,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <mono/utils/mono-dl.h>
+#include <mono/utils/mono-mmap.h>
 
 #define UNW_LOCAL_ONLY
 #undef _U /* ctype.h apparently defines this and it screws up the libunwind headers. */
@@ -51,6 +52,8 @@ typedef int (*unw_get_reg_t) (unw_cursor_t *, int, unw_word_t *);
 typedef int (*unw_get_proc_name_t) (unw_cursor_t *, char *, size_t, unw_word_t *);
 typedef int (*unw_step_t) (unw_cursor_t *);
 
+#define ALIGN_UP_TO(val,align)	(((val) + (align - 1)) & ~(align - 1))
+
 static char *
 mono_extension_handle_native_sigsegv_libunwind (void *ctx, MONO_SIG_HANDLER_INFO_TYPE *info)
 {
@@ -62,7 +65,17 @@ mono_extension_handle_native_sigsegv_libunwind (void *ctx, MONO_SIG_HANDLER_INFO
 	unw_get_proc_name_t unw_get_proc_name_fn;
 	unw_step_t unw_step_fn;
 
-	unw_cursor_t cursor;
+	/* On Android, although mono does not register its signal handler with an
+	 * altstack, ART does and then chains into our handler. The altstack size
+	 * is 8k (or 16k on 64bit systems). The unw_cursor_t struct alone takes up
+	 * 16k. We can't malloc because it isn't async-safe, so we use mmap. */
+	int pagesize = mono_pagesize ();
+	size_t cursor_len = ALIGN_UP_TO (sizeof (unw_cursor_t), pagesize);
+	unw_cursor_t *cursor = mono_valloc (NULL, cursor_len, MONO_MMAP_READ|MONO_MMAP_WRITE);
+
+	if (!cursor) {
+		return g_strdup_printf ("mono_valloc failed");
+	}
 
 	size_t frames = 0;
 
@@ -76,9 +89,9 @@ mono_extension_handle_native_sigsegv_libunwind (void *ctx, MONO_SIG_HANDLER_INFO
 	LOAD_SYM (dl, dl_err, UNW_OBJ (get_proc_name), unw_get_proc_name_fn);
 	LOAD_SYM (dl, dl_err, UNW_OBJ (step), unw_step_fn);
 
-	if ((unw_err = unw_init_local_fn (&cursor, ctx))) {
+	if ((unw_err = unw_init_local_fn (cursor, ctx))) {
 		mono_dl_close (dl);
-
+		mono_vfree (cursor, cursor_len);
 		return g_strdup_printf ("unw_init_local () returned %d", unw_err);
 	}
 
@@ -88,19 +101,19 @@ mono_extension_handle_native_sigsegv_libunwind (void *ctx, MONO_SIG_HANDLER_INFO
 		unw_word_t ip, off;
 		char name [FUNC_NAME_LENGTH];
 
-		if ((reg_err = unw_get_reg_fn (&cursor, UNW_REG_IP, &ip))) {
+		if ((reg_err = unw_get_reg_fn (cursor, UNW_REG_IP, &ip))) {
 			mono_runtime_printf_err ("unw_get_reg (UNW_REG_IP) returned %d", reg_err);
 			break;
 		}
 
-		reg_err = unw_get_proc_name_fn (&cursor, name, FUNC_NAME_LENGTH, &off);
+		reg_err = unw_get_proc_name_fn (cursor, name, FUNC_NAME_LENGTH, &off);
 
 		if (reg_err == -UNW_ENOINFO)
 			strcpy (name, "???");
 
 		mono_runtime_printf_err (" at %s+%zu [0x%zx]", name, off, ip);
 
-		unw_err = unw_step_fn (&cursor);
+		unw_err = unw_step_fn (cursor);
 		frames++;
 	} while (unw_err > 0 && frames < FRAMES_TO_UNWIND);
 
@@ -108,6 +121,7 @@ mono_extension_handle_native_sigsegv_libunwind (void *ctx, MONO_SIG_HANDLER_INFO
 		mono_runtime_printf_err ("unw_step () returned %d", unw_err);
 
 	mono_dl_close (dl);
+	mono_vfree (cursor, cursor_len);
 
 	return NULL;
 }


### PR DESCRIPTION
I still don't understand why this is suddenly a problem, my best guess is that we were previously lucky when overflowing the stack.

```
f70a0000-f70a1000 ---p 00000000 00:00 0
f70a1000-f70a3000 rw-p 00000000 00:00 0                                  [stack:19870]
```

On the android device I have the page above the stack is mapped non-{read,write}able, so maybe it's some sort of new stack guard mechanism.

/cc @vargaz @jonpryor @alexrp 