### PR TITLE
[mini] Introduce job control to the JIT. Limits by active and duplicate jobs.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -852,7 +852,7 @@ mono_jit_set_domain (MonoDomain *domain)
 static void
 mono_thread_abort (MonoObject *obj)
 {
-	/* MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id); */
+	/* MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_tls_get_jit_tls (); */
 
 	/* handle_remove should be eventually called for this thread, too
 	g_free (jit_tls);*/
@@ -1838,7 +1838,7 @@ add_current_thread (MonoJitTlsData *jit_tls)
 static gboolean
 should_wait_for_available_cpu_capacity (void)
 {
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_tls_get_jit_tls ();
 
 	//We can't suspend threads that are already JIT'ing something or we risk deadlocking
 	if (jit_tls->active_jit_methods > 0)
@@ -1858,7 +1858,7 @@ should_wait_for_available_cpu_capacity (void)
 static gboolean
 wait_or_register_method_to_compile (MonoMethod *method, MonoDomain *domain)
 {
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_tls_get_jit_tls ();
 	JitCompilationEntry *entry;
 
 
@@ -1921,7 +1921,7 @@ wait_or_register_method_to_compile (MonoMethod *method, MonoDomain *domain)
 static void
 unregister_method_for_compile (MonoMethod *method, MonoDomain *target_domain)
 {
-	MonoJitTlsData *jit_tls = mono_native_tls_get_value (mono_jit_tls_id);
+	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_tls_get_jit_tls ();
 
 	lock_compilation_data ();
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1202,6 +1202,12 @@ typedef struct {
 	 * the catch block that caught the ThreadAbortException).
 	 */
 	gpointer abort_exc_stack_threshold;
+
+
+	/*
+	 * List of methods being JIT'd in the current thread.
+	 */
+	int active_jit_methods;
 } MonoJitTlsData;
 
 /*


### PR DESCRIPTION
This shown up as a problem under parallel roslyn.

We hit frequently the case of multiple threads compiling the same method in parallel
and wasting all but one.

Another issue that happens, but infrequently, is having more threads JITing than there
are cores in the machine. Such thrashing doesn't help.

Test setup. 4/8 macbook pro compiling corlib.

Baseline:
real	0m7.665s
user	0m20.078s
sys	0m2.653s
Methods JITted using mono JIT       : 22422
Total time spent JITting (sec)      : 18.5365

With this patch:
real	0m6.149s
user	0m18.504s
sys	0m1.487s
Methods JITted using mono JIT       : 16619
Total time spent JITting (sec)      : 4.9420

New counters
JIT compile waited others           : 7681
JIT compile 1+ jobs                 : 1
JIT compile overload wait           : 67
JIT compile spurious wakeups        : 14469

This results in a 20% wall clock reduction but only a 8% reduction on user.

We JIT 26% less methods, with very few duplications. Showing this drastically improves the situation.

JIT compilation time metrics are bogus due to .cctors and other sources of interference. So take it with a grain of salt.

Future work:

Based on the new counters, it's clear that the current wakeup design is suboptimal and we could further improve it by cutting on spurious wakeups.