### PR TITLE
[system] Remove port number from TLS Server Name Identification (SNI). Fixes #46549

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -97,8 +97,15 @@ namespace Mono.Net.Security
 			sslStream = provider.CreateSslStream (networkStream, false, settings);
 
 			try {
+				var host = request.Host;
+				if (!string.IsNullOrEmpty (host)) {
+					var pos = host.IndexOf (':');
+					if (pos > 0)
+						host = host.Substring (0, pos);
+				}
+
 				sslStream.AuthenticateAsClient (
-					request.Host, request.ClientCertificates,
+					host, request.ClientCertificates,
 					(SslProtocols)ServicePointManager.SecurityProtocol,
 					ServicePointManager.CheckCertificateRevocationList);
 


### PR DESCRIPTION
The port number should not be included along the host name. Otherwise
the server will refuse the connection (and we'll throw). This is a
problem when servers are not using the default (443) SSL/TLS port.

ref: https://bugzilla.xamarin.com/show_bug.cgi?id=46549

The BTLS provider was fixed but the old MonoTLS (managed) provider had
the same issue.

Another PR will be made to fix AppleTLS in xamarin-macios repo [2]

[1] https://github.com/mono/mono/pull/3939
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=45994