### PR TITLE
[tls] Use host name without port for the Server Name Indication (SNI). Bug #46549.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -35,6 +35,7 @@ namespace Mono.Net.Security
 		MobileAuthenticatedStream parent;
 		bool serverMode;
 		string targetHost;
+		string serverName;
 		SslProtocols enabledProtocols;
 		X509Certificate serverCertificate;
 		X509CertificateCollection clientCertificates;
@@ -53,6 +54,13 @@ namespace Mono.Net.Security
 			this.serverCertificate = serverCertificate;
 			this.clientCertificates = clientCertificates;
 			this.askForClientCert = askForClientCert;
+
+			serverName = targetHost;
+			if (!string.IsNullOrEmpty (serverName)) {
+				var pos = serverName.IndexOf (':');
+				if (pos > 0)
+					serverName = serverName.Substring (0, pos);
+			}
 
 			certificateValidator = CertificateValidationHelper.GetDefaultValidator (
 				parent.Settings, parent.Provider);
@@ -90,6 +98,10 @@ namespace Mono.Net.Security
 
 		protected string TargetHost {
 			get { return targetHost; }
+		}
+
+		protected string ServerName {
+			get { return serverName; }
 		}
 
 		protected bool AskForClientCertificate {


### PR DESCRIPTION
Partial (no BTLS) backport of master/cycle9 to allow backporting the fix
for #45994 (AppleTLS on XI / XM). Another backport will be needed for
MonoTLS (pending [3])

[1] https://github.com/mono/mono/commit/20e0914e0319078e02a53be2fb4700e39d85347d
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=45994
[3] https://github.com/mono/mono/pull/4120