### PR TITLE
Fix marking types inside custom attributes. Fixes #47064

### DIFF
--- a/mcs/tools/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/mcs/tools/linker/Mono.Linker.Steps/MarkStep.cs
@@ -372,7 +372,7 @@ namespace Mono.Linker.Steps {
 			// e.g. System.String[] -> System.String
 			var ts = (type as TypeSpecification);
 			if (ts != null) {
-				MarkWithResolvedScope (ts.GetElementType ());
+				MarkWithResolvedScope (ts.ElementType);
 				return;
 			}
 


### PR DESCRIPTION
The existing code for marking custom attributes was only marking the type
and the lowest element type, i.e. marking (1) would also mark (3) but
would miss (2).

1. [System.ServiceModel.ServiceKnownTypeAttribute(typeof(System.Collections.Generic.Dictionary<string, object>[][]))]
2. [System.ServiceModel.ServiceKnownTypeAttribute(typeof(System.Collections.Generic.Dictionary<string, object>[]))]
3. [System.ServiceModel.ServiceKnownTypeAttribute(typeof(System.Collections.Generic.Dictionary<string, object>))]

That's generally not an issue since the type is marked (elsewhere).
However, in the case of custom attributes, we need to update the Scope
to what was resolved (and that was missed).

That lack of updated Scope means that a PCL assembly would still keep
references to System.Runtime, which is something that the linker is
eliminating (causing a TypeLoadException at runtime)

reference:
* https://bugzilla.xamarin.com/show_bug.cgi?id=47064

Note: The linker is not in mono/master and there's a PR in the new
linker repo for the same https://github.com/mono/linker/pull/7