### PR TITLE
[mkbundle] Don't use Path.GetDirectoryName on `directory`

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -372,7 +372,7 @@ class MakeBundle {
 		if (fetch_target != null){
 			var directory = Path.Combine (targets_dir, fetch_target);
 			var zip_download = Path.Combine (directory, "sdk.zip");
-			Directory.CreateDirectory (Path.GetDirectoryName (directory));
+			Directory.CreateDirectory (directory);
 			var wc = new WebClient ();
 			var uri = new Uri ($"{target_server}{fetch_target}");
 			try {


### PR DESCRIPTION
`directory` is already a directory. It's in the name.

`Path.GetDirectoryName ("/path/to/a/thing")` returns `"/path/to/a"`, whether `thing` is a directory or not. If there's a trailing `/` then it returns the directory, not the parent - but we don't have a trailing `/`.

This fixes an issue where the path needs to be created by hand before an SDK can be downloaded.