### PR TITLE
[unwinding] set DUMPABLE, so debuggerd can ptrace us

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2508,6 +2508,13 @@ mono_handle_native_sigsegv (int signal, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *i
 #endif
  }
 #else
+#ifdef PLATFORM_ANDROID
+	/* set DUMPABLE for this process so debuggerd can attach with ptrace(2), see:
+	 * https://android.googlesource.com/platform/bionic/+/151da681000c07da3c24cd30a3279b1ca017f452/linker/debugger.cpp#206
+	 * this has changed on later versions of Android.  Also, we don't want to
+	 * set this on start-up as DUMPABLE has security implications. */
+	prctl (PR_SET_DUMPABLE, 1);
+#endif
 	mono_exception_native_unwind (ctx, info);
 #endif
 


### PR DESCRIPTION
... so instead of:
```
E/mono-rt ( 6242): =================================================================
E/mono-rt ( 6242): Got a SIGSEGV while executing native code. This usually indicates
E/mono-rt ( 6242): a fatal error in the mono runtime or one of the native libraries 
E/mono-rt ( 6242): used by your application.
E/mono-rt ( 6242): =================================================================
E/mono-rt ( 6242): 
--------- beginning of crash
F/libc    ( 6242): Fatal signal 11 (SIGSEGV), code 1, fault addr 0x0 in tid 6242 (artup.lulzcrash)
I/libc    ( 6242): Suppressing debuggerd output because prctl(PR_GET_DUMPABLE)==0
I/WindowState(  543): WIN DEATH: Window{2de4f5ea u0 com.xamarin.nativecrashonstartup.lulzcrash/md57ffdd9e14125b1458fc6920cc9970e0f.MainActivity}
W/SurfaceFlinger(  177): couldn't log to binary event log: overflow.
I/Zygote  (  195): Process 6242 exited due to signal (11)
```

we get
```
E/mono-rt ( 7010): =================================================================
E/mono-rt ( 7010): Got a SIGSEGV while executing native code. This usually indicates
E/mono-rt ( 7010): a fatal error in the mono runtime or one of the native libraries 
E/mono-rt ( 7010): used by your application.
E/mono-rt ( 7010): =================================================================
E/mono-rt ( 7010): 
--------- beginning of crash
F/libc    ( 7010): Fatal signal 11 (SIGSEGV), code 1, fault addr 0x0 in tid 7010 (artup.lulzcrash)
I/DEBUG   (  181): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
I/DEBUG   (  181): Build fingerprint: 'google/razor/flo:5.0.2/LRX22G/1649326:user/release-keys'
I/DEBUG   (  181): Revision: '0'
I/DEBUG   (  181): ABI: 'arm'
I/DEBUG   (  181): pid: 7010, tid: 7010, name: artup.lulzcrash  >>> com.xamarin.nativecrashonstartup.lulzcrash <<<
I/DEBUG   (  181): signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
I/DEBUG   (  181):     r0 00000000  r1 00000000  r2 00000000  r3 00000000
I/DEBUG   (  181):     r4 0000002f  r5 12e05430  r6 a241a238  r7 74d9bb80
I/DEBUG   (  181):     r8 a18630b0  r9 b5007800  sl 00000000  fp be9ba1b0
I/DEBUG   (  181):     ip b6f42b1d  sp be9ba028  lr a441f4ec  pc b6f42b1e  cpsr 60070030
I/DEBUG   (  181): 
I/DEBUG   (  181): backtrace:
I/DEBUG   (  181):     #00 pc 00013b1e  /system/lib/libc.so (strcpy+1)
I/DEBUG   (  181):     #01 pc 000074e8  <unknown>
W/ActivityManager(  547): Error in app com.xamarin.nativecrashonstartup.lulzcrash running instrumentation ComponentInfo{com.xamarin.nativecrashonstartup.lulzcrash.test/sh.calaba.instrumentationbackend.CalabashInstrumentationTestRunner}:
W/ActivityManager(  547):   Native crash
W/ActivityManager(  547):   Native crash: Segmentation fault
I/DEBUG   (  181): 
I/DEBUG   (  181): Tombstone written to: /data/tombstones/tombstone_00
D/AndroidRuntime( 6996): Shutting down VM
```

behaviour seen and fixed on:
* Asus Google Nexus 7 (2013), Android 5.0.2
* HTC Nexus 9, Android 5.0.1
* HTC One M9, Android 5.0.2
* LG Nexus 4, Android 5.1.1
* Motorola Moto X, Android 5.1

/cc @jonpryor @alexrp