### PR TITLE
[threadpool] Fix `MonoTests.runtime.unload-appdomain-on-shutdown.exe`

### DIFF
--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -607,7 +607,9 @@ mono_threadpool_remove_domain_jobs (MonoDomain *domain, int timeout)
 	 * The is_unloading () check in worker_request () ensures that
 	 * no new jobs are added after we enter the lock below.
 	 */
-	mono_lazy_initialize (&status, initialize);
+
+	if (!mono_lazy_is_initialized (&status))
+		return TRUE;
 
 	mono_refcount_inc (threadpool);
 

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -608,11 +608,15 @@ mono_threadpool_remove_domain_jobs (MonoDomain *domain, int timeout)
 	 * no new jobs are added after we enter the lock below.
 	 */
 	mono_lazy_initialize (&status, initialize);
+
+	mono_refcount_inc (threadpool);
+
 	domains_lock ();
 
 	tpdomain = tpdomain_get (domain, FALSE);
 	if (!tpdomain) {
 		domains_unlock ();
+		mono_refcount_dec (threadpool);
 		return TRUE;
 	}
 
@@ -646,6 +650,8 @@ mono_threadpool_remove_domain_jobs (MonoDomain *domain, int timeout)
 
 	mono_coop_cond_destroy (&tpdomain->cleanup_cond);
 	tpdomain_free (tpdomain);
+
+	mono_refcount_dec (threadpool);
 
 	return ret;
 }


### PR DESCRIPTION
This fixes `MonoTests.runtime.unload-appdomain-on-shutdown.exe`