### PR TITLE
Mono 4.8.0 use btls

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -168,7 +168,6 @@ namespace Mono.Net.Security
 				if (btls_supported)
 					providerRegistration.Add ("btls", BtlsProviderTypeName);
 
-				Console.WriteLine ("PROBING: {0}", btls_supported);
 				providerRegistration.Add ("default", btls_supported ? BtlsProviderTypeName : LegacyProviderTypeName);
 					
 				X509Helper2.Initialize ();

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -153,16 +153,24 @@ namespace Mono.Net.Security
 			}
 		}
 
+		const string LegacyProviderTypeName = "Mono.Net.Security.LegacyTlsProvider";
+		const string BtlsProviderTypeName = "Mono.Btls.MonoBtlsProvider";
+			
 		static void InitializeProviderRegistration ()
 		{
 			lock (locker) {
 				if (providerRegistration != null)
 					return;
 				providerRegistration = new Dictionary<string,string> ();
-				providerRegistration.Add ("legacy", "Mono.Net.Security.LegacyTlsProvider");
-				providerRegistration.Add ("default", "Mono.Net.Security.LegacyTlsProvider");
-				if (IsBtlsSupported ())
-					providerRegistration.Add ("btls", "Mono.Btls.MonoBtlsProvider");
+				providerRegistration.Add ("legacy", LegacyProviderTypeName);
+				
+				bool btls_supported = IsBtlsSupported ();
+				if (btls_supported)
+					providerRegistration.Add ("btls", BtlsProviderTypeName);
+
+				Console.WriteLine ("PROBING: {0}", btls_supported);
+				providerRegistration.Add ("default", btls_supported ? BtlsProviderTypeName : LegacyProviderTypeName);
+					
 				X509Helper2.Initialize ();
 			}
 		}


### PR DESCRIPTION
This changes it so that "default" becomes "btls" on systems that support it.