### PR TITLE
[C9][sre] Implement DynamicMethod.GetCustomAttributes() and IsDefined() (Fixes #49686)

### DIFF
--- a/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Call.cs
+++ b/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Call.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -293,6 +294,36 @@ namespace MonoTests.System.Linq.Expressions {
 				Expression.Call (GetType ().GetMethod ("DoAnotherThing"), i, s), i, s).Compile ();
 
 			Assert.AreEqual ("foo42", lamda (42, "foo"));
+		}
+
+		[Test]
+		public void CallDynamicMethod_ToString ()
+		{
+			// Regression test for #49686
+			var m = new DynamicMethod ("intIntId", typeof (int), new Type [] { typeof (int) });
+			var ilg = m.GetILGenerator ();
+			ilg.Emit (OpCodes.Ldarg_0);
+			ilg.Emit (OpCodes.Ret);
+
+			var i = Expression.Parameter (typeof (int), "i");
+			var e = Expression.Call (m, i);
+
+			Assert.IsNotNull (e.ToString ());
+		}
+
+		[Test]
+		public void CallDynamicMethod_CompileInvoke ()
+		{
+			var m = new DynamicMethod ("intIntId", typeof (int), new Type [] { typeof (int) });
+			var ilg = m.GetILGenerator ();
+			ilg.Emit (OpCodes.Ldarg_0);
+			ilg.Emit (OpCodes.Ret);
+
+			var i = Expression.Parameter (typeof (int), "i");
+			var e = Expression.Call (m, i);
+
+			var lambda = Expression.Lambda<Func<int, int>> (e, i).Compile ();
+			Assert.AreEqual (42, lambda (42));
 		}
 
 		public static int Bang (Expression i)

--- a/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
@@ -210,15 +210,20 @@ namespace System.Reflection.Emit {
 			return this;
 		}
 
-		[MonoTODO("Not implemented")]
 		public override object[] GetCustomAttributes (bool inherit) {
-			throw new NotImplementedException ();
+			// support for MethodImplAttribute PCA
+			return new Object[] { new MethodImplAttribute(GetMethodImplementationFlags()) };
 		}
 
-		[MonoTODO("Not implemented")]
 		public override object[] GetCustomAttributes (Type attributeType,
-													  bool inherit) {
-			throw new NotImplementedException ();
+							      bool inherit) {
+			if (attributeType == null)
+				throw new ArgumentNullException ("attributeType");
+
+			if (attributeType.IsAssignableFrom (typeof (MethodImplAttribute)))
+				return new Object[] { new MethodImplAttribute (GetMethodImplementationFlags()) };
+			else
+				return EmptyArray<Object>.Value;
 		}
 
 		public DynamicILInfo GetDynamicILInfo () {
@@ -244,7 +249,7 @@ namespace System.Reflection.Emit {
 		}		
 
 		public override MethodImplAttributes GetMethodImplementationFlags () {
-			return MethodImplAttributes.IL | MethodImplAttributes.Managed;
+			return MethodImplAttributes.IL | MethodImplAttributes.Managed | MethodImplAttributes.NoInlining;
 		}
 
 		public override ParameterInfo[] GetParameters ()
@@ -298,9 +303,14 @@ namespace System.Reflection.Emit {
 			}
 		}
 
-		[MonoTODO("Not implemented")]
 		public override bool IsDefined (Type attributeType, bool inherit) {
-			throw new NotImplementedException ();
+			if (attributeType == null)
+				throw new ArgumentNullException ("attributeType");
+
+			if (attributeType.IsAssignableFrom (typeof (MethodImplAttribute)))
+				return true;
+			else
+				return false;
 		}
 
 		public override string ToString () {


### PR DESCRIPTION
Do what the documentation says:
> Custom attributes are not currently supported on dynamic methods. The only attribute returned is `MethodImplAttribute`; you can get the method implementation flags more easily using the `GetMethodImplementationFlags` method.

and

> Currently, method implementation attributes for dynamic methods are always IL and NoInlining.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=49686

This is #4139 backported to `mono-4.8.0-branch`