### PR TITLE
[C8][system] Remove port number from TLS Server Name Identification (SNI)

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -96,8 +96,15 @@ namespace Mono.Net.Security
 			sslStream = provider.CreateSslStream (networkStream, false, settings);
 
 			try {
+				var host = request.Host;
+				if (!string.IsNullOrEmpty (host)) {
+					var pos = host.IndexOf (':');
+					if (pos > 0)
+						host = host.Substring (0, pos);
+				}
+
 				sslStream.AuthenticateAsClient (
-					request.Host, request.ClientCertificates,
+					host, request.ClientCertificates,
 					(SslProtocols)ServicePointManager.SecurityProtocol,
 					ServicePointManager.CheckCertificateRevocationList);
 


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/4120 to C8.