### PR TITLE
[aot] fix linker invocation for llvm mode on linux

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -10102,7 +10102,7 @@ compile_asm (MonoAotCompile *acfg)
 									  wrap_path (tmp_outfile_name), wrap_path (llvm_ofile),
 									  wrap_path (g_strdup_printf ("%s." AS_OBJECT_FILE_SUFFIX, acfg->tmpfname)), ld_flags);
 
-		if (acfg->llvm) {
+		if (acfg->aot_opts.llvm_only) {
 			command = g_strdup_printf ("clang++ %s", args);
 		} else {
 			command = g_strdup_printf ("\"%sld\" %s", tool_prefix, args);


### PR DESCRIPTION
clang++ should only be used for llvm_only (aka. bitcode) mode.

this is a follow up fix for:
https://github.com/mono/mono/commit/7d238ddd5edeeb42cec5e07b6d6527d16332f921
and
https://github.com/mono/mono/commit/fc5305d2af1b6891b05cb82342bf92d4659546e1

fixes https://bugzilla.xamarin.com/show_bug.cgi?id=46375



/cc @vargaz @alexanderkyte 