### PR TITLE
[c9][aot] fix linker invocation for llvm mode on linux

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9974,7 +9974,7 @@ compile_asm (MonoAotCompile *acfg)
 		wrap_path (tmp_outfile_name), wrap_path (llvm_ofile),
 		wrap_path (g_strdup_printf ("%s.o", acfg->tmpfname)), ld_flags);
 
-	if (acfg->llvm) {
+	if (acfg->aot_opts.llvm_only) {
 		command = g_strdup_printf ("clang++ %s", args);
 	} else {
 		command = g_strdup_printf ("\"%sld\" %s", tool_prefix, args);


### PR DESCRIPTION
backport of https://github.com/mono/mono/pull/4147


