### PR TITLE
[corlib] Override virtual DSA.HashData() methods in DSACryptoServiceProvider

### DIFF
--- a/mcs/class/corlib/System.Security.Cryptography/DSACryptoServiceProvider.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/DSACryptoServiceProvider.cs
@@ -231,6 +231,28 @@ namespace System.Security.Cryptography {
 			return dsa.VerifySignature (rgbHash, rgbSignature);
 		}
 
+		protected override byte[] HashData (byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+		{
+			if (hashAlgorithm != HashAlgorithmName.SHA1)
+			{
+				throw new CryptographicException(Environment.GetResourceString("Cryptography_UnknownHashAlgorithm", hashAlgorithm.Name));
+			}
+
+			var hash = HashAlgorithm.Create (hashAlgorithm.Name);
+			return hash.ComputeHash (data, offset, count);
+		}
+
+		protected override byte[] HashData (System.IO.Stream data, HashAlgorithmName hashAlgorithm)
+		{
+			if (hashAlgorithm != HashAlgorithmName.SHA1)
+			{
+				throw new CryptographicException(Environment.GetResourceString("Cryptography_UnknownHashAlgorithm", hashAlgorithm.Name));
+			}
+
+			var hash = HashAlgorithm.Create (hashAlgorithm.Name);
+			return hash.ComputeHash (data);
+		}
+
 		protected override void Dispose (bool disposing) 
 		{
 			if (!m_disposed) {


### PR DESCRIPTION
The methods were added in .NET 4.6 but couldn't be done abstract so instead they were added virtual which just throws an exception telling you to override it in the subclass.

We implemented this for RSACryptoServiceProvider in #3770 (the methods were already overriden in that case because we moved to referencesource) but DSACryptoServiceProvider is still using the Mono code so we need to implement it there too.

Uncovered as part of https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/548