### PR TITLE
[runtime] Fix MONO_ARCH_ENABLE_MONO_LMF_VAR

### DIFF
--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -7,7 +7,6 @@
  * Copyright 2013 Xamarin, Inc (http://www.xamarin.com)
  */
 
-#include <config.h>
 #include <mono/utils/mach-support.h>
 
 #include "mono-tls.h"
@@ -34,9 +33,6 @@
  * wrappers and managed allocators, both of which are not aot-ed by default.
  * So far, we never supported inlined fast tls on full-aot systems.
  */
-#ifdef HAVE_KW_THREAD
-#define USE_KW_THREAD
-#endif
 
 #ifdef USE_KW_THREAD
 
@@ -270,6 +266,7 @@ mono_tls_get_tls_setter (MonoTlsKey key, gboolean name)
 gpointer
 mono_tls_get_tls_addr (MonoTlsKey key)
 {
+#ifdef HAVE_GET_TLS_ADDR
 	if (key == TLS_KEY_LMF) {
 #if defined(USE_KW_THREAD)
 		return &mono_tls_lmf;
@@ -277,6 +274,7 @@ mono_tls_get_tls_addr (MonoTlsKey key)
 		return mono_mach_get_tls_address_from_thread (pthread_self (), mono_tls_key_lmf);
 #endif
 	}
+#endif
 	/* Implement if we ever need for other targets/keys */
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -12,6 +12,7 @@
 #ifndef __MONO_TLS_H__
 #define __MONO_TLS_H__
 
+#include <config.h>
 #include <glib.h>
 
 /* TLS entries used by the runtime */
@@ -26,6 +27,17 @@ typedef enum {
 	TLS_KEY_LMF_ADDR = 5,
 	TLS_KEY_NUM = 6
 } MonoTlsKey;
+
+#ifdef HAVE_KW_THREAD
+#define USE_KW_THREAD
+#endif
+
+#if defined(USE_KW_THREAD)
+#define HAVE_GET_TLS_ADDR
+#elif defined(TARGET_MACH) && (defined(TARGET_X86) || defined(TARGET_AMD64))
+/* mono_mach_get_tls_address_from_thread is untested for arm/arm64 */
+#define HAVE_GET_TLS_ADDR
+#endif
 
 #ifdef HOST_WIN32
 


### PR DESCRIPTION
Using MONO_ARCH_ENABLE_MONO_LMF_VAR requires that we have means of getting the address of a tls variable (which is always the case when using __thread, but not necessarily when using pthread). Make sure that using it is properly guarded.

In the future we might want to remove MONO_ARCH_ENABLE_LMF_VAR and always try to use a tls variable for the lmf. Additionally we should benchmark what combinations work best and stick to them on all platforms. (ex when using fast tls we might consider using lmf_get + lmf_set if possible, when using fallbacks we might always want to use the lmf_addr to void multiple calls, always use lmf_ir etc).