### PR TITLE
Allow all finalizer threads the same time as .NET to complete

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -1019,11 +1019,12 @@ mono_gc_cleanup (void)
 		if (mono_thread_internal_current () != gc_thread) {
 			int ret;
 			gint64 start_ticks = mono_msec_ticks ();
-			gint64 end_ticks = start_ticks + 2000;
+			gint64 end_ticks = start_ticks + 40000;
 
 			mono_gc_finalize_notify ();
 			/* Finishing the finalizer thread, so wait a little bit... */
-			/* MS seems to wait for about 2 seconds */
+			/* MS seems to wait for about 2 seconds per finalizer thread */
+			/* and 40 seconds for all finalizers to finish */
 			while (!finalizer_thread_exited) {
 				gint64 current_ticks = mono_msec_ticks ();
 				guint32 timeout;


### PR DESCRIPTION
.NET allows each finalizer thread up to 2 seconds to complete and 40 seconds for all threads to complete. However, mono just allows 2 seconds for all finalizers. Some complex applications easily exceed this and this results in thread aborts to be invoked. This fix is simplistic as it simply replaces the 2 seconds with 40 without addressing the 2 seconds per finalizer thread. This problem is more complex but this fix will circumvent the problem until a final option is designed and implemented.