### PR TITLE
Soft debugger invocations refactoring

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft-net_4_x.csproj
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft-net_4_x.csproj
@@ -13,7 +13,7 @@
     <IntermediateOutputPath>obj-net_4_x</IntermediateOutputPath>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>True</NoStdLib>
-    
+
     <NoConfig>True</NoConfig>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -91,6 +91,7 @@
     <Compile Include="Mono.Debugger.Soft\InterfaceMappingMirror.cs" />
     <Compile Include="Mono.Debugger.Soft\InvalidStackFrameException.cs" />
     <Compile Include="Mono.Debugger.Soft\InvocationException.cs" />
+    <Compile Include="Mono.Debugger.Soft\InvocationsAPI.cs" />
     <Compile Include="Mono.Debugger.Soft\InvokeOptions.cs" />
     <Compile Include="Mono.Debugger.Soft\ITargetProcess.cs" />
     <Compile Include="Mono.Debugger.Soft\LocalScope.cs" />
@@ -177,4 +178,3 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 </Project>
-

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft-net_4_x.csproj
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft-net_4_x.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Mono.Debugger.Soft\ExceptionEvent.cs" />
     <Compile Include="Mono.Debugger.Soft\ExceptionEventRequest.cs" />
     <Compile Include="Mono.Debugger.Soft\FieldInfoMirror.cs" />
+    <Compile Include="Mono.Debugger.Soft\IInvocableMethodOwnerMirror.cs" />
     <Compile Include="Mono.Debugger.Soft\IInvokeAsyncResult.cs" />
     <Compile Include="Mono.Debugger.Soft\ILExceptionHandler.cs" />
     <Compile Include="Mono.Debugger.Soft\ILInstruction.cs" />
@@ -130,7 +131,8 @@
     <Compile Include="Mono.Debugger.Soft\VMDisconnectedException.cs" />
     <Compile Include="Mono.Debugger.Soft\VMDisconnectEvent.cs" />
     <Compile Include="Mono.Debugger.Soft\VMMismatchException.cs" />
-    <Compile Include="Mono.Debugger.Soft\VMStartEvent.cs" />  </ItemGroup>
+    <Compile Include="Mono.Debugger.Soft\VMStartEvent.cs" />
+  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft.dll.sources
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft.dll.sources
@@ -20,6 +20,7 @@ Mono.Debugger.Soft/VMDisconnectedException.cs
 Mono.Debugger.Soft/Mirror.cs
 Mono.Debugger.Soft/EnumMirror.cs
 Mono.Debugger.Soft/FieldInfoMirror.cs
+Mono.Debugger.Soft/IInvocableMethodOwnerMirror.cs
 Mono.Debugger.Soft/TypeMirror.cs
 Mono.Debugger.Soft/CustomAttributeNamedArgumentMirror.cs
 Mono.Debugger.Soft/DataConverter.cs
@@ -31,6 +32,7 @@ Mono.Debugger.Soft/ExceptionEventRequest.cs
 Mono.Debugger.Soft/EventType.cs
 Mono.Debugger.Soft/StructMirror.cs
 Mono.Debugger.Soft/InvocationException.cs
+Mono.Debugger.Soft/InvocationsAPI.cs
 Mono.Debugger.Soft/IMirror.cs
 Mono.Debugger.Soft/VMDeathEvent.cs
 Mono.Debugger.Soft/MethodBodyMirror.cs

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/IInvocableMethodOwnerMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/IInvocableMethodOwnerMirror.cs
@@ -1,0 +1,20 @@
+namespace Mono.Debugger.Soft
+{
+	/// <summary>
+	/// Interface to mark a mirror that supports method invocation
+	/// </summary>
+	public interface IInvocableMethodOwnerMirror : IMirror
+	{
+		/// <summary>
+		/// Value that will be passed as 'this' reference when invoking a method (can be null e.g. for static methods)
+		/// </summary>
+		/// <returns>'this' reference</returns>
+		Value GetThisObject ();
+
+		/// <summary>
+		/// Make some additional processing of invocation result. See implementation in <see cref="StructMirror"/>
+		/// </summary>
+		/// <param name="result"></param>
+		void ProcessResult (InvokeResult result);
+	}
+}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/IInvocableMethodOwnerMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/IInvocableMethodOwnerMirror.cs
@@ -15,6 +15,6 @@ namespace Mono.Debugger.Soft
 		/// Make some additional processing of invocation result. See implementation in <see cref="StructMirror"/>
 		/// </summary>
 		/// <param name="result"></param>
-		void ProcessResult (InvokeResult result);
+		void ProcessResult (IInvokeResult result);
 	}
 }

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/InvocationsAPI.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/InvocationsAPI.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Debugger.Soft
+{
+	/// <summary>
+	/// A bunch of extension methods to <see cref="IInvocableMethodOwnerMirror"/> to perform invocations on objects
+	/// </summary>
+	public static class InvocationsAPI
+	{
+		public static Value InvokeMethod (this IInvocableMethodOwnerMirror mirror, ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options = InvokeOptions.None) {
+			return InvokeMethod (mirror, mirror.VirtualMachine, thread, method, mirror.GetThisObject (), arguments, options);
+		}
+
+		[Obsolete ("Use the overload without the 'vm' argument")]
+		public static IAsyncResult BeginInvokeMethod (this IInvocableMethodOwnerMirror mirror, VirtualMachine vm, ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options, AsyncCallback callback, object state) {
+			return BeginInvokeMethod (vm, thread, method, mirror.GetThisObject (), arguments, options, callback, state);
+		}
+
+		public static IAsyncResult BeginInvokeMethod (this IInvocableMethodOwnerMirror mirror, ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options, AsyncCallback callback, object state) {
+			return BeginInvokeMethod (mirror.VirtualMachine, thread, method, mirror.GetThisObject (), arguments, options, callback, state);
+		}
+
+		public static Value EndInvokeMethod (this IInvocableMethodOwnerMirror mirror, IAsyncResult asyncResult) {
+			return EndInvokeMethodInternal (mirror, asyncResult);
+		}
+
+		public static InvokeResult EndInvokeMethodWithResult (this IInvocableMethodOwnerMirror mirror, IAsyncResult asyncResult) {
+			return  EndInvokeMethodInternalWithResult (mirror, asyncResult);
+		}
+
+		public static Task<Value> InvokeMethodAsync (this IInvocableMethodOwnerMirror mirror, ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options = InvokeOptions.None) {
+			var tcs = new TaskCompletionSource<Value> ();
+			BeginInvokeMethod (mirror, thread, method, arguments, options, iar =>
+			{
+				try {
+					tcs.SetResult (EndInvokeMethod (mirror, iar));
+				} catch (OperationCanceledException) {
+					tcs.TrySetCanceled ();
+				} catch (Exception ex) {
+					tcs.TrySetException (ex);
+				}
+			}, null);
+			return tcs.Task;
+		}
+
+		public static Task<InvokeResult> InvokeMethodAsyncWithResult (this IInvocableMethodOwnerMirror mirror, ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options = InvokeOptions.None) {
+			var tcs = new TaskCompletionSource<InvokeResult> ();
+			BeginInvokeMethod (mirror, thread, method, arguments, options, iar =>
+			{
+				try {
+					tcs.SetResult (EndInvokeMethodInternalWithResult (mirror, iar));
+				} catch (OperationCanceledException) {
+					tcs.TrySetCanceled ();
+				} catch (Exception ex) {
+					tcs.TrySetException (ex);
+				}
+			}, null);
+			return tcs.Task;
+		}
+
+		/// <summary>
+		/// Invoke the members of METHODS one-by-one, calling CALLBACK after each invoke was finished. The IAsyncResult will be marked as completed after all invokes have
+		/// finished. The callback will be called with a different IAsyncResult that represents one method invocation.
+		/// From protocol version 2.22.
+		/// </summary>
+		public static IAsyncResult BeginInvokeMultiple (this IInvocableMethodOwnerMirror mirror, ThreadMirror thread, MethodMirror[] methods, IList<IList<Value>> arguments, InvokeOptions options, AsyncCallback callback, object state) {
+			return BeginInvokeMultiple (mirror.VirtualMachine, thread, methods, mirror.GetThisObject (), arguments, options, callback, state);
+		}
+
+		public static void EndInvokeMultiple (IAsyncResult asyncResult) {
+			EndInvokeMultipleInternal (asyncResult);
+		}
+
+		/*
+		 * Common implementation for invokes
+		 */
+
+		class InvokeAsyncResult : IInvokeAsyncResult {
+
+			public object AsyncState {
+				get; set;
+			}
+
+			public WaitHandle AsyncWaitHandle {
+				get; set;
+			}
+
+			public bool CompletedSynchronously {
+				get {
+					return false;
+				}
+			}
+
+			public bool IsCompleted {
+				get; set;
+			}
+
+			public AsyncCallback Callback {
+				get; set;
+			}
+
+			public ErrorCode ErrorCode {
+				get; set;
+			}
+
+			public VirtualMachine VM {
+				get; set;
+			}
+
+			public ThreadMirror Thread {
+				get; set;
+			}
+
+			public ValueImpl Value {
+				get; set;
+			}
+
+			public ValueImpl OutThis {
+				get; set;
+			}
+
+			public ValueImpl[] OutArgs {
+				get; set;
+			}
+
+			public ValueImpl Exception {
+				get; set;
+			}
+
+			public int ID {
+				get; set;
+			}
+
+			public bool IsMultiple {
+				get; set;
+			}
+
+			public int NumPending;
+
+			public void Abort ()
+			{
+				if (ID == 0) // Ooops
+					return;
+
+				AbortInvoke (VM, Thread, ID);
+			}
+		}
+
+		static IInvokeAsyncResult BeginInvokeMethod (VirtualMachine vm, ThreadMirror thread, MethodMirror method, Value this_obj, IList<Value> arguments, InvokeOptions options, AsyncCallback callback, object state) {
+			if (thread == null)
+				throw new ArgumentNullException ("thread");
+			if (method == null)
+				throw new ArgumentNullException ("method");
+			if (arguments == null)
+				arguments = new Value [0];
+
+			InvokeFlags f = InvokeFlags.NONE;
+
+			if ((options & InvokeOptions.DisableBreakpoints) != 0)
+				f |= InvokeFlags.DISABLE_BREAKPOINTS;
+			if ((options & InvokeOptions.SingleThreaded) != 0)
+				f |= InvokeFlags.SINGLE_THREADED;
+			if ((options & InvokeOptions.ReturnOutThis) != 0)
+				f |= InvokeFlags.OUT_THIS;
+			if ((options & InvokeOptions.ReturnOutArgs) != 0)
+				f |= InvokeFlags.OUT_ARGS;
+			if ((options & InvokeOptions.Virtual) != 0)
+				f |= InvokeFlags.VIRTUAL;
+
+			InvokeAsyncResult r = new InvokeAsyncResult { AsyncState = state, AsyncWaitHandle = new ManualResetEvent (false), VM = vm, Thread = thread, Callback = callback };
+			thread.InvalidateFrames ();
+			r.ID = vm.conn.VM_BeginInvokeMethod (thread.Id, method.Id, this_obj != null ? vm.EncodeValue (this_obj) : vm.EncodeValue (vm.CreateValue (null)), vm.EncodeValues (arguments), f, InvokeCB, r);
+
+			return r;
+		}
+
+		// This is called when the result of an invoke is received
+		static void InvokeCB (ValueImpl v, ValueImpl exc, ValueImpl out_this, ValueImpl[] out_args, ErrorCode error, object state) {
+			InvokeAsyncResult r = (InvokeAsyncResult)state;
+
+			if (error != 0) {
+				r.ErrorCode = error;
+			} else {
+				r.Value = v;
+				r.Exception = exc;
+			}
+
+			r.OutThis = out_this;
+			r.OutArgs = out_args;
+
+			r.IsCompleted = true;
+			((ManualResetEvent)r.AsyncWaitHandle).Set ();
+
+			if (r.Callback != null)
+				r.Callback.BeginInvoke (r, null, null);
+		}
+
+		static InvokeResult EndInvokeMethodInternalWithResult (IInvocableMethodOwnerMirror mirror, IAsyncResult asyncResult) {
+			var result = EndInvokeMethodInternalWithResultImpl (asyncResult);
+			mirror.ProcessResult (result);
+			return result;
+		}
+
+		static InvokeResult EndInvokeMethodInternalWithResultImpl (IAsyncResult asyncResult) {
+			if (asyncResult == null)
+				throw new ArgumentNullException ("asyncResult");
+
+			InvokeAsyncResult r = (InvokeAsyncResult)asyncResult;
+
+			if (!r.IsCompleted)
+				r.AsyncWaitHandle.WaitOne ();
+
+			if (r.ErrorCode != 0) {
+				try {
+					r.VM.ErrorHandler (null, new ErrorHandlerEventArgs () { ErrorCode = r.ErrorCode });
+				} catch (CommandException ex) {
+					if (ex.ErrorCode == ErrorCode.INVALID_ARGUMENT)
+						throw new ArgumentException ("Incorrect number or types of arguments", "arguments");
+
+					throw;
+				}
+				throw new NotImplementedException ();
+			} else {
+				if (r.Exception != null)
+					throw new InvocationException ((ObjectMirror)r.VM.DecodeValue (r.Exception));
+
+				Value out_this = null;
+				if (r.OutThis != null)
+					out_this = r.VM.DecodeValue (r.OutThis);
+				Value[] out_args = null;
+				if (r.OutArgs != null)
+					out_args = r.VM.DecodeValues (r.OutArgs);
+
+				return new InvokeResult () { Result = r.VM.DecodeValue (r.Value), OutThis = out_this, OutArgs = out_args };
+			}
+		}
+
+		static Value EndInvokeMethodInternal (IInvocableMethodOwnerMirror mirror, IAsyncResult asyncResult) {
+			InvokeResult res = EndInvokeMethodInternalWithResult (mirror, asyncResult);
+			return res.Result;
+		}
+
+		static void EndInvokeMultipleInternal (IAsyncResult asyncResult) {
+			if (asyncResult == null)
+				throw new ArgumentNullException ("asyncResult");
+
+			InvokeAsyncResult r = (InvokeAsyncResult)asyncResult;
+
+			if (!r.IsCompleted)
+				r.AsyncWaitHandle.WaitOne ();
+		}
+
+		static Value InvokeMethod (IInvocableMethodOwnerMirror mirror, VirtualMachine vm, ThreadMirror thread, MethodMirror method, Value this_obj, IList<Value> arguments, InvokeOptions options) {
+			return EndInvokeMethodInternal (mirror, BeginInvokeMethod (vm, thread, method, this_obj, arguments, options, null, null));
+		}
+
+		static void AbortInvoke (VirtualMachine vm, ThreadMirror thread, int id)
+		{
+			vm.conn.VM_AbortInvoke (thread.Id, id);
+		}
+
+		//
+		// Implementation of InvokeMultiple
+		//
+
+		static IInvokeAsyncResult BeginInvokeMultiple (VirtualMachine vm, ThreadMirror thread, MethodMirror[] methods, Value this_obj, IList<IList<Value>> arguments, InvokeOptions options, AsyncCallback callback, object state) {
+			if (thread == null)
+				throw new ArgumentNullException ("thread");
+			if (methods == null)
+				throw new ArgumentNullException ("methods");
+			foreach (var m in methods)
+				if (m == null)
+					throw new ArgumentNullException ("method");
+			if (arguments == null) {
+				arguments = new List<IList<Value>> ();
+				for (int i = 0; i < methods.Length; ++i)
+					arguments.Add (new Value [0]);
+			} else {
+				// FIXME: Not needed for property evaluation
+				throw new NotImplementedException ();
+			}
+			if (callback == null)
+				throw new ArgumentException ("A callback argument is required for this method.", "callback");
+
+			InvokeFlags f = InvokeFlags.NONE;
+
+			if ((options & InvokeOptions.DisableBreakpoints) != 0)
+				f |= InvokeFlags.DISABLE_BREAKPOINTS;
+			if ((options & InvokeOptions.SingleThreaded) != 0)
+				f |= InvokeFlags.SINGLE_THREADED;
+
+			InvokeAsyncResult r = new InvokeAsyncResult { AsyncState = state, AsyncWaitHandle = new ManualResetEvent (false), VM = vm, Thread = thread, Callback = callback, NumPending = methods.Length, IsMultiple = true };
+
+			var mids = new long [methods.Length];
+			for (int i = 0; i < methods.Length; ++i)
+				mids [i] = methods [i].Id;
+			var args = new List<ValueImpl[]> ();
+			for (int i = 0; i < methods.Length; ++i)
+				args.Add (vm.EncodeValues (arguments [i]));
+			thread.InvalidateFrames ();
+			r.ID = vm.conn.VM_BeginInvokeMethods (thread.Id, mids, this_obj != null ? vm.EncodeValue (this_obj) : vm.EncodeValue (vm.CreateValue (null)), args, f, InvokeMultipleCB, r);
+
+			return r;
+		}
+
+		// This is called when the result of an invoke is received
+		static void InvokeMultipleCB (ValueImpl v, ValueImpl exc, ValueImpl out_this, ValueImpl[] out_args, ErrorCode error, object state) {
+			var r = (InvokeAsyncResult)state;
+
+			Interlocked.Decrement (ref r.NumPending);
+
+			if (error != 0)
+				r.ErrorCode = error;
+
+			if (r.NumPending == 0) {
+				r.IsCompleted = true;
+				((ManualResetEvent)r.AsyncWaitHandle).Set ();
+			}
+
+			// Have to pass another asyncresult to the callback since multiple threads can execute it concurrently with results of multiple invocations
+			var r2 = new InvokeAsyncResult { AsyncState = r.AsyncState, AsyncWaitHandle = null, VM = r.VM, Thread = r.Thread, Callback = r.Callback, IsCompleted = true };
+
+			if (error != 0) {
+				r2.ErrorCode = error;
+			} else {
+				r2.Value = v;
+				r2.Exception = exc;
+			}
+
+			r.Callback.BeginInvoke (r2, null, null);
+		}
+
+	}
+}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ObjectMirror.cs
@@ -1,26 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Mono.Debugger.Soft
 {
-	public class InvokeResult {
-		public Value Result { get; set; }
-		//
-		// The value of the receiver after the call for calls to valuetype methods or null.
-		// Only set when using the InvokeOptions.ReturnOutThis flag.
-		// Since protocol version 2.35
-		//
-		public Value OutThis { get; set; }
-		//
-		// The value of the arguments after the call
-		// Only set when using the InvokeOptions.ReturnOutArgs flag.
-		// Since protocol version 2.35
-		//
-		public Value[] OutArgs { get; set; }
-	}
-
 	public class ObjectMirror : Value, IInvocableMethodOwnerMirror {
 		TypeMirror type;
 		AppDomainMirror domain;
@@ -145,7 +127,7 @@ namespace Mono.Debugger.Soft
 			return this;
 		}
 
-		void IInvocableMethodOwnerMirror.ProcessResult (InvokeResult result)
+		void IInvocableMethodOwnerMirror.ProcessResult (IInvokeResult result)
 		{
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PrimitiveValue.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PrimitiveValue.cs
@@ -35,7 +35,7 @@ namespace Mono.Debugger.Soft
 			return this;
 		}
 
-		void IInvocableMethodOwnerMirror.ProcessResult (InvokeResult result)
+		void IInvocableMethodOwnerMirror.ProcessResult (IInvokeResult result)
 		{
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PrimitiveValue.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PrimitiveValue.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-
 namespace Mono.Debugger.Soft
 {
 	/*
 	 * Represents a value of a primitive type in the debuggee
 	 */
-	public class PrimitiveValue : Value {
+	public class PrimitiveValue : Value, IInvocableMethodOwnerMirror {
 		object value;
 
 		public PrimitiveValue (VirtualMachine vm, object value) : base (vm, 0) {
@@ -34,30 +31,18 @@ namespace Mono.Debugger.Soft
 			return base.GetHashCode ();
 		}
 
+		Value IInvocableMethodOwnerMirror.GetThisObject () {
+			return this;
+		}
+
+		void IInvocableMethodOwnerMirror.ProcessResult (InvokeResult result)
+		{
+		}
+
 		public override string ToString () {
 			object v = Value;
 
 			return "PrimitiveValue<" + (v != null ? v.ToString () : "(null)") + ">";
-		}
-
-		public Value InvokeMethod (ThreadMirror thread, MethodMirror method, IList<Value> arguments) {
-			return ObjectMirror.InvokeMethod (vm, thread, method, this, arguments, InvokeOptions.None);
-		}
-
-		public Value InvokeMethod (ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options) {
-			return ObjectMirror.InvokeMethod (vm, thread, method, this, arguments, options);
-		}
-
-		public IAsyncResult BeginInvokeMethod (ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options, AsyncCallback callback, object state) {
-			return ObjectMirror.BeginInvokeMethod (vm, thread, method, this, arguments, options, callback, state);
-		}
-
-		public Value EndInvokeMethod (IAsyncResult asyncResult) {
-			return ObjectMirror.EndInvokeMethodInternal (asyncResult);
-		}
-
-		public InvokeResult EndInvokeMethodWithResult (IAsyncResult asyncResult) {
-			return  ObjectMirror.EndInvokeMethodInternalWithResult (asyncResult);
 		}
 	}
 }

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/StructMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/StructMirror.cs
@@ -68,7 +68,7 @@ namespace Mono.Debugger.Soft
 			return this;
 		}
 
-		void IInvocableMethodOwnerMirror.ProcessResult (InvokeResult result)
+		void IInvocableMethodOwnerMirror.ProcessResult (IInvokeResult result)
 		{
 			var outThis = result.OutThis as StructMirror;
 			if (outThis != null) {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -866,7 +866,7 @@ namespace Mono.Debugger.Soft
 			return null;
 		}
 
-		void IInvocableMethodOwnerMirror.ProcessResult (InvokeResult result)
+		void IInvocableMethodOwnerMirror.ProcessResult (IInvokeResult result)
 		{
 		}
 	}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using C = Mono.Cecil;
-using Mono.Cecil.Metadata;
-using System.Threading.Tasks;
 
 namespace Mono.Debugger.Soft
 {
@@ -12,7 +10,7 @@ namespace Mono.Debugger.Soft
 	 * It might be better to make this a subclass of Type, but that could be
 	 * difficult as some of our methods like GetMethods () return Mirror objects.
 	 */
-	public class TypeMirror : Mirror
+	public class TypeMirror : Mirror, IInvocableMethodOwnerMirror
 	{
 		MethodMirror[] methods;
 		AssemblyMirror ass;
@@ -783,46 +781,6 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
-		public Value InvokeMethod (ThreadMirror thread, MethodMirror method, IList<Value> arguments) {
-			return ObjectMirror.InvokeMethod (vm, thread, method, null, arguments, InvokeOptions.None);
-		}
-
-		public Value InvokeMethod (ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options) {
-			return ObjectMirror.InvokeMethod (vm, thread, method, null, arguments, options);
-		}
-
-		[Obsolete ("Use the overload without the 'vm' argument")]
-		public IAsyncResult BeginInvokeMethod (VirtualMachine vm, ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options, AsyncCallback callback, object state) {
-			return ObjectMirror.BeginInvokeMethod (vm, thread, method, null, arguments, options, callback, state);
-		}
-
-		public IAsyncResult BeginInvokeMethod (ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options, AsyncCallback callback, object state) {
-			return ObjectMirror.BeginInvokeMethod (vm, thread, method, null, arguments, options, callback, state);
-		}
-
-		public Value EndInvokeMethod (IAsyncResult asyncResult) {
-			return ObjectMirror.EndInvokeMethodInternal (asyncResult);
-		}
-
-		public InvokeResult EndInvokeMethodWithResult (IAsyncResult asyncResult) {
-			return  ObjectMirror.EndInvokeMethodInternalWithResult (asyncResult);
-		}
-
-		public Task<Value> InvokeMethodAsync (ThreadMirror thread, MethodMirror method, IList<Value> arguments, InvokeOptions options = InvokeOptions.None) {
-			var tcs = new TaskCompletionSource<Value> ();
-			BeginInvokeMethod (thread, method, arguments, options, iar =>
-					{
-						try {
-							tcs.SetResult (EndInvokeMethod (iar));
-						} catch (OperationCanceledException) {
-							tcs.TrySetCanceled ();
-						} catch (Exception ex) {
-							tcs.TrySetException (ex);
-						}
-					}, null);
-			return tcs.Task;
-		}
-
 		public Value NewInstance (ThreadMirror thread, MethodMirror method, IList<Value> arguments) {
 			return NewInstance (thread, method, arguments, InvokeOptions.None);
 		}			
@@ -834,7 +792,7 @@ namespace Mono.Debugger.Soft
 			if (!method.IsConstructor)
 				throw new ArgumentException ("The method must be a constructor.", "method");
 
-			return ObjectMirror.InvokeMethod (vm, thread, method, null, arguments, options);
+			return ObjectMirror.InvokeMethod (this, thread, method, arguments, options);
 		}
 
 		// Since protocol version 2.31
@@ -903,5 +861,13 @@ namespace Mono.Debugger.Soft
 				return inited;
 			}
 		}
-    }
+
+		Value IInvocableMethodOwnerMirror.GetThisObject () {
+			return null;
+		}
+
+		void IInvocableMethodOwnerMirror.ProcessResult (InvokeResult result)
+		{
+		}
+	}
 }

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -792,7 +792,7 @@ namespace Mono.Debugger.Soft
 			if (!method.IsConstructor)
 				throw new ArgumentException ("The method must be a constructor.", "method");
 
-			return ObjectMirror.InvokeMethod (this, thread, method, arguments, options);
+			return this.InvokeMethod (thread, method, arguments, options);
 		}
 
 		// Since protocol version 2.31


### PR DESCRIPTION
New IInvocableMethodOwnerMirror interface to avoid duplicating of Invoke*, BeginInvoke*, EndInvoke* methods in invocable mirrors. All the API is now static methods taking IInvocableMethodOwnerMirror as the 1st parameter. This refactoring allows to avoid multiple 'if (obj is *) else' in SoftDebuggerAdaptor.

This PR already merged in MonoDevelop/debugger-libs
https://github.com/mono/debugger-libs/pull/84