### PR TITLE
configure.ac: import makedev() and friends from <sys/sysmacros.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,6 +432,10 @@ AC_HEADER_STDC
 AC_LIBTOOL_WIN32_DLL
 # This causes monodis to not link correctly
 #AC_DISABLE_FAST_INSTALL
+
+#lookup makedev() header
+AC_HEADER_MAJOR
+
 AM_PROG_LIBTOOL
 # Use dolt (http://dolt.freedesktop.org/) instead of libtool for building.
 DOLT

--- a/mono/metadata/w32process-unix-default.c
+++ b/mono/metadata/w32process-unix-default.c
@@ -17,6 +17,13 @@
 #endif
 #endif
 
+/* makedev() macro */
+#ifdef MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#elif defined MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
+
 #include "utils/mono-logger-internals.h"
 
 #ifndef MAXPATHLEN


### PR DESCRIPTION
Current glibc's <sys/types.h> headers are included into
many C standard headers.

The problem here is that makedev()/major()/minor() macros
defined in <sys/sysmacros.h> leak into C standard headers
and poison global namespace.

The plan is to get rid of <sys/sysmacros.h> inclusion
in <sys/types.h>:
    https://sourceware.org/ml/libc-alpha/2015-11/msg00253.html

On such system without implicit <sys/sysmacros.h> mono fails
to build as:

  CC       libmonoruntime_la-w32process-unix-default.lo
w32process-unix-default.c: In function 'mono_w32process_get_modules':
w32process-unix-default.c:225:12: error: implicit declaration of function 'makedev' [-Werror=implicit-function-declaration]
   device = makedev ((int)maj_dev, (int)min_dev);
            ^~~~~~~

autoconf has a AC_HEADER_MAJOR macro to autodetect
header for major() and friends.

This change switches to AC_HEADER_MAJOR.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>