### PR TITLE
Fix DateTime.Now and CurrentTimeToUtc during DST transition time

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -811,7 +811,7 @@ namespace System
 					return tz.BaseUtcOffset;
 			}
 
-			if (tzRule != null && tz.IsInDST (tzRule, stdUtcDateTime)) {
+			if (tzRule != null && tz.IsInDST (tzRule, dateTime)) {
 				// Replicate what .NET does when given a time which falls into the hour which is lost when
 				// DST starts. isDST should always be true but the offset should be BaseUtcOffset without the
 				// DST delta while in that hour.
@@ -868,7 +868,7 @@ namespace System
 			AdjustmentRule rule = GetApplicableRule (dateTime);
 			if (rule != null) {
 				DateTime tpoint = TransitionPoint (rule.DaylightTransitionEnd, dateTime.Year);
-				if (dateTime > tpoint - rule.DaylightDelta  && dateTime <= tpoint)
+				if (dateTime > tpoint - rule.DaylightDelta && dateTime <= tpoint)
 					return true;
 			}
 				
@@ -898,7 +898,6 @@ namespace System
 				DST_start -= BaseUtcOffset;
 				DST_end -= (BaseUtcOffset + rule.DaylightDelta);
 			}
-
 			return (dateTime >= DST_start && dateTime < DST_end);
 		}
 		
@@ -1184,31 +1183,16 @@ namespace System
 					return false;
 			}
 
-			var inDelta = false;
-			for (var i =  transitions.Count - 1; i >= 0; i--) {
-				var pair = transitions [i];
-				DateTime ttime = pair.Key;
-				TimeType ttype = pair.Value;
-
-				var delta =  new TimeSpan (0, 0, ttype.Offset) - BaseUtcOffset;
-
-				if ((ttime + delta) > date) {
-					inDelta = ttime <= date;
-					continue;
+			AdjustmentRule current = GetApplicableRule(date);
+			if (current != null) {
+				DateTime tStart = TransitionPoint(current.DaylightTransitionStart, date.Year);
+				DateTime tEnd = TransitionPoint(current.DaylightTransitionEnd, date.Year);
+				if ((date >= tStart) && (date <= tEnd)) {
+					offset = baseUtcOffset + current.DaylightDelta; 
+					isDst = true;
+					return true;
 				}
-
-				offset =  new TimeSpan (0, 0, ttype.Offset);
-				if (inDelta) {
-					// Replicate what .NET does when given a time which falls into the hour which is lost when
-					// DST starts. isDST should be true but the offset should be the non-DST offset.
-					isDst = transitions [i - 1].Value.IsDst;
-				} else {
-					isDst = ttype.IsDst;
-				}
-
-				return true;
 			}
-
 			return false;
 		}
 
@@ -1498,7 +1482,7 @@ namespace System
 
 			if (zone.IsAmbiguousTime (time)) {
 				isAmbiguousLocalDst = true;
-				return baseOffset;
+//				return baseOffset;
 			}
 
 			return zone.GetUtcOffset (time, out isDaylightSavings);

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -300,7 +300,7 @@ namespace MonoTests.System
 			}
 		
 			[Test]
-			public void DSTTransisions ()
+			public void DSTTransitions ()
 			{
 				DateTime beforeDST = new DateTime (2007, 03, 25, 0, 59, 59, DateTimeKind.Unspecified);
 				DateTime startDST = new DateTime (2007, 03, 25, 2, 0, 0, DateTimeKind.Unspecified);
@@ -308,12 +308,12 @@ namespace MonoTests.System
 				DateTime afterDST = new DateTime (2007, 10, 28, 2, 0, 0, DateTimeKind.Unspecified);
 				Assert.IsFalse (london.IsDaylightSavingTime (beforeDST), "Just before DST");
 				Assert.IsTrue (london.IsDaylightSavingTime (startDST), "the first seconds of DST");
-				Assert.IsFalse (london.IsDaylightSavingTime (endDST), "The last seconds of DST");
+				Assert.IsTrue (london.IsDaylightSavingTime (endDST), "The last seconds of DST");
 				Assert.IsFalse (london.IsDaylightSavingTime (afterDST), "Just after DST");
 			}
 		
 			[Test]
-			public void DSTTransisionsUTC ()
+			public void DSTTransitionsUTC ()
 			{
 				DateTime beforeDST = new DateTime (2007, 03, 25, 0, 59, 59, DateTimeKind.Utc);
 				DateTime startDST = new DateTime (2007, 03, 25, 1, 0, 0, DateTimeKind.Utc);
@@ -1179,8 +1179,8 @@ namespace MonoTests.System
 
 				d = dst1End.Add (-dstOffset);
 				Assert.AreEqual(dstUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,0,0,-1))));
-				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d));
-				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,0,0, 1))));
+				Assert.AreEqual(dstUtcOffset, cairo.GetUtcOffset (d));
+				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,1,0, 1))));
 
 				d = dst2Start.Add (dstOffset);
 				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,0,0,-1))));
@@ -1189,8 +1189,8 @@ namespace MonoTests.System
 
 				d = dst2End.Add (-dstOffset);
 				Assert.AreEqual(dstUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,0,0,-1))));
-				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d));
-				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,0,0, 1))));
+				Assert.AreEqual(dstUtcOffset, cairo.GetUtcOffset (d));
+				Assert.AreEqual(baseUtcOffset, cairo.GetUtcOffset (d.Add (new TimeSpan(0,1,0, 1))));
 			}
 
 		  [Test]


### PR DESCRIPTION
During the ambiguous hour .NET will return the DST version of the time whereas mono is returning the base time. Rather than use the transitions array we look up the Adjustment rules (which are created from the transition rules in the first place).

In addition, CurrentTimeToUtc() also has problems around the transition time.

Added test and fixed another.

Fixes #43805.