### PR TITLE
[runtime] Always expire a non-resolved hostname's cache

### DIFF
--- a/mcs/class/System/System.Net/ServicePoint.cs
+++ b/mcs/class/System/System.Net/ServicePoint.cs
@@ -361,7 +361,7 @@ namespace System.Net
 						return host;
 					}
 
-					if (!HasTimedOut)
+					if (!HasTimedOut && host != null)
 						return host;
 
 					lastDnsResolve = DateTime.UtcNow;


### PR DESCRIPTION
This addresses a regression here:

https://bugzilla.xamarin.com/show_bug.cgi?id=45761

The commits
97e51abfcfd87bb5ed12c04df030730a8590cbed and
d35b5d218894e15cec84273d77cf4a61985edb5f

changed control flow such that if the host can't be resolved
and host is set to null, then the later check will return null
for the duration that HasTimedOut is false.