### PR TITLE
Fix broken Windows build due to missing mini-exceptions-native-unwinder.c

### DIFF
--- a/msvc/libmono-static.vcxproj
+++ b/msvc/libmono-static.vcxproj
@@ -97,7 +97,6 @@
     <ClCompile Include="..\mono\mini\mini-codegen.c" />
     <ClCompile Include="..\mono\mini\mini-cross-helpers.c" />
     <ClCompile Include="..\mono\mini\mini-exceptions.c" />
-    <ClCompile Include="..\mono\mini\mini-exceptions-native-unwinder.c" />
     <ClCompile Include="..\mono\mini\mini-trampolines.c  " />
     <ClCompile Include="..\mono\mini\tramp-amd64.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>


### PR DESCRIPTION
Commit 41272d634b5917f67c12fc4f7172d66242abe7d9 removed `mono/mini/mini-exceptions-native-unwinder.c` from the source tree but didn't update `msvc/libmono-static.vcxproj` accordingly causing the VS build to fail.