### PR TITLE
[4.8] Fix broken Windows build due to missing mini-exceptions-native-unwinder.c

### DIFF
--- a/msvc/libmono-static.vcxproj
+++ b/msvc/libmono-static.vcxproj
@@ -96,7 +96,6 @@
     <ClCompile Include="..\mono\mini\mini-codegen.c" />
     <ClCompile Include="..\mono\mini\mini-cross-helpers.c" />
     <ClCompile Include="..\mono\mini\mini-exceptions.c" />
-    <ClCompile Include="..\mono\mini\mini-exceptions-native-unwinder.c" />
     <ClCompile Include="..\mono\mini\mini-trampolines.c  " />
     <ClCompile Include="..\mono\mini\tramp-amd64.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>


### PR DESCRIPTION
backport of #4178

/cc @ntherning 