### PR TITLE
[System] Fix ClientWebSocketTest to not throw exceptions in the constructor, but instead in the individual tests. Fixes #47167.

### DIFF
--- a/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
+++ b/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
@@ -17,7 +17,14 @@ namespace MonoTests.System.Net.WebSockets
 	public class ClientWebSocketTest
 	{
 		const string EchoServerUrl = "ws://corefx-net.cloudapp.net/WebSocket/EchoWebSocket.ashx";
-		int Port = NetworkHelpers.FindFreePort ();
+		int port;
+		int Port {
+			get {
+				if (port == 0)
+					port = NetworkHelpers.FindFreePort ();
+				return port;
+			}
+		}
 		HttpListener _listener;
 		HttpListener listener {
 			get {
@@ -158,7 +165,12 @@ namespace MonoTests.System.Net.WebSockets
 			Assert.AreEqual (WebSocketState.Closed, socket.State);
 		}
 
-		[Test, ExpectedException (typeof (InvalidOperationException))]
+		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#else
+		[ExpectedException (typeof (InvalidOperationException))]
+#endif
 		public void SendAsyncArgTest_NotConnected ()
 		{
 			socket.SendAsync (new ArraySegment<byte> (new byte[0]), WebSocketMessageType.Text, true, CancellationToken.None);
@@ -172,7 +184,11 @@ namespace MonoTests.System.Net.WebSockets
 			socket.SendAsync (new ArraySegment<byte> (), WebSocketMessageType.Text, true, CancellationToken.None);
 		}
 
-		[Test, ExpectedException (typeof (InvalidOperationException))]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#else
+		[ExpectedException (typeof (InvalidOperationException))]
+#endif
 		public void ReceiveAsyncArgTest_NotConnected ()
 		{
 			socket.ReceiveAsync (new ArraySegment<byte> (new byte[0]), CancellationToken.None);


### PR DESCRIPTION
Finding a free port on watchOS fails with a PlatformNotSupportedException, but
if the exception is thrown in the constructor, the ExpectedException attribute
isn't taken into account, causing the test to error out.

https://bugzilla.xamarin.com/show_bug.cgi?id=47167