### PR TITLE
Add missing InternalsVisibleTo attributes on mscorlib.

### DIFF
--- a/mcs/class/corlib/Assembly/AssemblyInfo.cs
+++ b/mcs/class/corlib/Assembly/AssemblyInfo.cs
@@ -78,6 +78,9 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo ("System.Numerics, PublicKey=00000000000000000400000000000000")]
 
+[assembly: InternalsVisibleTo ("System.Runtime.WindowsRuntime, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo ("System.Runtime.WindowsRuntime.UI.Xaml, PublicKey=00000000000000000400000000000000")]
+
 #if MONOTOUCH
 #if MONOTOUCH_TV
 [assembly: InternalsVisibleTo ("Xamarin.TVOS, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]


### PR DESCRIPTION
This change adds two missing InternalsVisibleTo attributes to mscorlib.dll. It makes these assemblies (from CoreFX) buildable against Mono mscorlib.