### PR TITLE
Bug 44974 - [pdb] stepping over is not working

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -608,7 +608,6 @@ public class DebuggerTests
 	}
 
 	[Test]
-	[Category ("NotWorking")] // https://bugzilla.xamarin.com/show_bug.cgi?id=44974
 	public void SingleStepping () {
 		Event e = run_until ("single_stepping");
 
@@ -751,6 +750,14 @@ public class DebuggerTests
 		e = step_over ();
 		assert_location (e, "ss_nested");
 		e = step_into ();
+		assert_location (e, "ss_nested_2");
+		e = step_into ();
+		assert_location (e, "ss_nested_2");
+		e = step_into ();
+		assert_location (e, "ss_nested_2");
+		e = step_into ();
+		assert_location (e, "ss_nested");
+		e = step_into ();
 		assert_location (e, "ss_nested_1");
 		e = step_into ();
 		assert_location (e, "ss_nested_1");
@@ -819,6 +826,7 @@ public class DebuggerTests
 				req.Size = StepSize.Line;
 
 				e = step_out ();
+				e = step_over ();//Stepout gets us to ss_recursive2_trap ();, move to ss_recursive2 (next); line
 				assert_location (e, "ss_recursive2");
 
 				// Stack should consist of Main + single_stepping + (1 ss_recursive2 frame per loop iteration)


### PR DESCRIPTION
mcs.exe didn’t emit some NOPs after method calls needed when doing StepOut, now that Roslyn emits this we correctly step out to line that called hence, some unit tests needed correcting

Is there a way to disable specific test in case user set mcs.exe as compiler, since this test will fail on mcs.exe now?