### PR TITLE
[btls] Pass CC and CXX to the BTLS CMake and disable BTLS on older GCC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3037,6 +3037,7 @@ case "$host" in
 			AOT_SUPPORTED="yes"
 			BTLS_SUPPORTED=yes
 			BTLS_PLATFORM=i386
+			AC_CHECK_HEADER(stdalign.h,[],[BTLS_SUPPORTED=no])
 			;;
 		  darwin*)
 			AOT_SUPPORTED="yes"
@@ -3059,6 +3060,7 @@ case "$host" in
 			AOT_SUPPORTED="yes"
 			BTLS_SUPPORTED=yes
 			BTLS_PLATFORM=x86_64
+			AC_CHECK_HEADER(stdalign.h,[],[BTLS_SUPPORTED=no])
 			;;
 		  darwin*)
 			AOT_SUPPORTED="yes"

--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -45,14 +45,14 @@ all-local: build-shared/libmono-btls-shared$(libsuffix) build-static/libmono-btl
 
 build-shared/Makefile:
 	-mkdir -p build-shared
-	(cd build-shared && $(CMAKE) $(CMAKE_ARGS) $(BTLS_CMAKE_ARGS) -DBUILD_SHARED_LIBS=1 $(abs_top_srcdir)/mono/btls)
+	(cd build-shared && CC="$(CC)" CXX="$(CXX)" $(CMAKE) $(CMAKE_ARGS) $(BTLS_CMAKE_ARGS) -DBUILD_SHARED_LIBS=1 $(abs_top_srcdir)/mono/btls)
 
 build-shared/libmono-btls-shared$(libsuffix): build-shared/Makefile
 	$(MAKE) -C build-shared $(CMAKE_VERBOSE)
 
 build-static/Makefile:
 	-mkdir -p build-static
-	(cd build-static && $(CMAKE) $(CMAKE_ARGS) $(BTLS_CMAKE_ARGS) $(abs_top_srcdir)/mono/btls)
+	(cd build-static && CC="$(CC)" CXX="$(CXX)" $(CMAKE) $(CMAKE_ARGS) $(BTLS_CMAKE_ARGS) $(abs_top_srcdir)/mono/btls)
 
 build-static/libmono-btls-static.a: build-static/Makefile
 	$(MAKE) -C build-static $(CMAKE_VERBOSE)


### PR DESCRIPTION
CMake doesn't pick up the compiler from the PATH by default, it only looks in default locations so without this we might end up using a different compiler for BTLS than for the main Mono build which we don't want.

BTLS also requires a fairly new GCC which includes C++11 features, added a quick check for stdalign.h which BTLS requires and disable it if the header isn't found.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=46712