### PR TITLE
[jit] Extends an array in mono_spill_global_vars () instead of assert…

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -13801,7 +13801,7 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 	int orig_next_vreg;
 	guint32 *vreg_to_lvreg;
 	guint32 *lvregs;
-	guint32 i, lvregs_len;
+	guint32 i, lvregs_len, lvregs_size;
 	gboolean dest_has_lvreg = FALSE;
 	MonoStackType stacktypes [128];
 	MonoInst **live_range_start, **live_range_end;
@@ -13874,7 +13874,8 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 	 */
 	orig_next_vreg = cfg->next_vreg;
 	vreg_to_lvreg = (guint32 *)mono_mempool_alloc0 (cfg->mempool, sizeof (guint32) * cfg->next_vreg);
-	lvregs = (guint32 *)mono_mempool_alloc (cfg->mempool, sizeof (guint32) * 1024);
+	lvregs_size = 1024;
+	lvregs = (guint32 *)mono_mempool_alloc (cfg->mempool, sizeof (guint32) * lvregs_size);
 	lvregs_len = 0;
 
 	/* 
@@ -14257,7 +14258,12 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 								}
 								g_assert (sreg != -1);
 								vreg_to_lvreg [var->dreg] = sreg;
-								g_assert (lvregs_len < 1024);
+								if (lvregs_len >= lvregs_size) {
+									guint32 *new_lvregs = mono_mempool_alloc0 (cfg->mempool, sizeof (guint32) * lvregs_size * 2);
+									memcpy (new_lvregs, lvregs, sizeof (guint32) * lvregs_size);
+									lvregs = new_lvregs;
+									lvregs_size *= 2;
+								}
 								lvregs [lvregs_len ++] = var->dreg;
 							}
 						}
@@ -14304,7 +14310,12 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 			if (dest_has_lvreg) {
 				g_assert (ins->dreg != -1);
 				vreg_to_lvreg [prev_dreg] = ins->dreg;
-				g_assert (lvregs_len < 1024);
+				if (lvregs_len >= lvregs_size) {
+					guint32 *new_lvregs = mono_mempool_alloc0 (cfg->mempool, sizeof (guint32) * lvregs_size * 2);
+					memcpy (new_lvregs, lvregs, sizeof (guint32) * lvregs_size);
+					lvregs = new_lvregs;
+					lvregs_size *= 2;
+				}
 				lvregs [lvregs_len ++] = prev_dreg;
 				dest_has_lvreg = FALSE;
 			}


### PR DESCRIPTION
…ing. Fixes #50789.