### PR TITLE
[configure] avoid 'no symbols' warnings on darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,11 @@ case "$host" in
 		target_mach=yes
 		CPPFLAGS="$CPPFLAGS -D_THREAD_SAFE -DGC_MACOSX_THREADS -DPLATFORM_MACOSX -DUSE_MMAP -DUSE_MUNMAP"
 		libmono_cflags="-D_THREAD_SAFE"
+
+		# avoid AR calling ranlib, libtool calls it anyway. suppress no symbols warning.
+		AR_FLAGS="Scru"
+		RANLIB="ranlib -no_warning_for_no_symbols"
+
 		need_link_unlink=yes
 		AC_DEFINE(PTHREAD_POINTER_ID)
 		AC_DEFINE(USE_MACH_SEMA, 1, [...])


### PR DESCRIPTION
This helps to get rid of the messages like these:

```
/Applications/Xcode8.1-beta1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libmonosgen-2.0.a(libmonoruntimesgen_la-coree.o) has no symbols
/Applications/Xcode8.1-beta1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libmonosgen-2.0.a(libmonoruntimesgen_la-file-mmap-windows.o) has no symbols
/Applications/Xcode8.1-beta1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libmonosgen-2.0.a(libmonoruntimesgen_la-lock-tracer.o) has no symbols
/Applications/Xcode8.1-beta1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libmonosgen-2.0.a(libmonoruntimesgen_la-mono-endian.o) has no symbols
[...]
```

That is what is in `libtool`:

```
# Commands used to build an old-style archive.
old_archive_cmds="\$AR \$AR_FLAGS \$oldlib\$oldobjs~\$RANLIB \$tool_oldlib"
```

`ar` is calling `ranlib`, and then `libtool` calls `ranlib` again. We
cannot control how `ar` calls `ranlib` (that is, we can't tell it to
pass `-no_warning_for_no_symbols`), but we can control to not call it
at all.  Let's to that then.

As a reference, source code of `ar`:
https://opensource.apple.com/source/cctools/cctools-895/ar/ar.c.auto.html



I'm not sure if this is the correct way to hack it into `configure.ac`. Who are the autotools the wizards? :)