### PR TITLE
Add code manager callbacks so JIT can track memory chunk ranges and r…

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1090,6 +1090,8 @@ MONO_GET_RUNTIME_FUNCTION_CALLBACK ( DWORD64 ControlPc, IN PVOID Context )
 	
 	targetinfo = (PMonoUnwindInfo)ALIGN_TO (pos, 8);
 
+	targetinfo->runtimeFunction.BeginAddress = ((DWORD64)ji->code_start) - ((DWORD64)Context);
+	targetinfo->runtimeFunction.EndAddress = pos - ((DWORD64)Context);
 	targetinfo->runtimeFunction.UnwindData = ((DWORD64)&targetinfo->unwindInfo) - ((DWORD64)Context);
 
 	return &targetinfo->runtimeFunction;
@@ -1121,8 +1123,19 @@ mono_arch_unwindinfo_install_unwind_info (gpointer* monoui, gpointer code, guint
 
 	g_free (unwindinfo);
 	*monoui = 0;
+}
 
-	RtlInstallFunctionTableCallback (((DWORD64)code) | 0x3, (DWORD64)code, code_size, MONO_GET_RUNTIME_FUNCTION_CALLBACK, code, NULL);
+void
+mono_arch_code_chunk_new (void *chunk, int size)
+{
+	BOOLEAN success = RtlInstallFunctionTableCallback (((DWORD64)chunk) | 0x3, (DWORD64)chunk, size, MONO_GET_RUNTIME_FUNCTION_CALLBACK, chunk, NULL);
+	g_assert (success);
+}
+
+void mono_arch_code_chunk_destroy (void *chunk)
+{
+	BOOLEAN success = RtlDeleteFunctionTable ((PRUNTIME_FUNCTION)((DWORD64)chunk | 0x03));
+	g_assert (success);
 }
 
 #endif /* defined(TARGET_WIN32) !defined(DISABLE_JIT) */

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -485,6 +485,10 @@ guint mono_arch_unwindinfo_get_size (gpointer monoui);
 void mono_arch_unwindinfo_install_unwind_info (gpointer* monoui, gpointer code, guint code_size);
 
 #define MONO_ARCH_HAVE_UNWIND_TABLE 1
+
+void mono_arch_code_chunk_new (void *chunk, int size);
+void mono_arch_code_chunk_destroy (void *chunk);
+#define MONO_ARCH_HAVE_CODE_CHUNK_TRACKING 1
 #endif
 
 CallInfo* mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);

--- a/mono/utils/mono-codeman.c
+++ b/mono/utils/mono-codeman.c
@@ -28,6 +28,7 @@ static uintptr_t code_memory_used = 0;
 static size_t dynamic_code_alloc_count;
 static size_t dynamic_code_bytes_count;
 static size_t dynamic_code_frees_count;
+static MonoCodeManagerCallbacks code_manager_callbacks;
 
 /*
  * AMD64 processors maintain icache coherency only for pages which are 
@@ -174,6 +175,12 @@ mono_code_manager_cleanup (void)
 	codechunk_cleanup ();
 }
 
+void
+mono_code_manager_install_callbacks (MonoCodeManagerCallbacks* callbacks)
+{
+	code_manager_callbacks = *callbacks;
+}
+
 /**
  * mono_code_manager_new:
  *
@@ -226,6 +233,8 @@ free_chunklist (CodeChunk *chunk)
 	for (; chunk; ) {
 		dead = chunk;
 		mono_profiler_code_chunk_destroy ((gpointer) dead->data);
+		if (code_manager_callbacks.chunk_destroy)
+			code_manager_callbacks.chunk_destroy ((gpointer)dead->data);
 		chunk = chunk->next;
 		if (dead->flags == CODE_FLAG_MMAP) {
 			codechunk_vfree (dead->data, dead->size);
@@ -413,6 +422,8 @@ new_codechunk (CodeChunk *last, int dynamic, int size)
 	chunk->flags = flags;
 	chunk->pos = bsize;
 	chunk->bsize = bsize;
+	if (code_manager_callbacks.chunk_new)
+		code_manager_callbacks.chunk_new ((gpointer)chunk->data, chunk->size);
 	mono_profiler_code_chunk_new((gpointer) chunk->data, chunk->size);
 
 	code_memory_used += chunk_size;

--- a/mono/utils/mono-codeman.h
+++ b/mono/utils/mono-codeman.h
@@ -5,6 +5,11 @@
 
 typedef struct _MonoCodeManager MonoCodeManager;
 
+typedef struct {
+	void (*chunk_new) (void *chunk, int size);
+	void (*chunk_destroy) (void *chunk);
+} MonoCodeManagerCallbacks;
+
 MONO_API MonoCodeManager* mono_code_manager_new     (void);
 MONO_API MonoCodeManager* mono_code_manager_new_dynamic (void);
 MONO_API void             mono_code_manager_destroy (MonoCodeManager *cman);
@@ -18,6 +23,7 @@ MONO_API void             mono_code_manager_commit  (MonoCodeManager *cman, void
 MONO_API int              mono_code_manager_size    (MonoCodeManager *cman, int *used_size);
 MONO_API void             mono_code_manager_init (void);
 MONO_API void             mono_code_manager_cleanup (void);
+MONO_API void             mono_code_manager_install_callbacks (MonoCodeManagerCallbacks* callbacks);
 
 /* find the extra block allocated to resolve branches close to code */
 typedef int    (*MonoCodeManagerFunc)      (void *data, int csize, int size, void *user_data);


### PR DESCRIPTION
…egister stack walk handlers on Win64.

Unregister function table on Win64 when chunk is freed. This avoids OS asking us to walk stack for JIT memory that has been unmapped after a domain reload.