### PR TITLE
[runtime] Set the pinvoke bit for handles-using icall callsites.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -7970,6 +7970,8 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 					ret->params [i] = csig->params [i];
 			}
 			ret->params [csig->param_count] = &mono_get_intptr_class ()->byval_arg;
+			ret->pinvoke = csig->pinvoke;
+
 			call_sig = ret;
 		}
 


### PR DESCRIPTION
The `MonoMethodSignature:pinvoke` bit causes the IR translation to clear the
upper bits of return values that are smaller than a register. (See
`mono_emit_widen_call_res`)

Without this change, any icall that `uses_handles` and that returns a boolean (8 bits on .NET) might have
non-zero upper bits which will cause branches to misbehave.