### PR TITLE
[cecil] Bump external/cecil to the current head

### DIFF
--- a/mcs/tools/corcompare/mono-api-info.cs
+++ b/mcs/tools/corcompare/mono-api-info.cs
@@ -200,7 +200,7 @@ namespace CorCompare
 				if (File.Exists (assembly))
 					return TypeHelper.Resolver.ResolveFile (assembly);
 
-				return TypeHelper.Resolver.Resolve (assembly);
+				return TypeHelper.Resolver.Resolve (AssemblyNameReference.Parse (assembly), new ReaderParameters ());
 			} catch (Exception e) {
 				Console.WriteLine (e);
 				return null;


### PR DESCRIPTION
xamarin-macios/cycle9 needs this to fix #51336 [1] and handle broken
.mdb [2]

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=51336
[2] https://github.com/mono/cecil/commit/045b0f9729905dd456d46e33436a2dadc9e2a52d