### PR TITLE
[btls] Create a native BTLS key handle for X509CertificateImplBtls.PrivateKey

### DIFF
--- a/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
+++ b/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
@@ -47,7 +47,7 @@ namespace Mono.Btls
 	class X509CertificateImplBtls : X509Certificate2Impl
 	{
 		MonoBtlsX509 x509;
-		MonoBtlsKey privateKey;
+		MonoBtlsKey nativePrivateKey;
 		X500DistinguishedName subjectName;
 		X500DistinguishedName issuerName;
 		X509CertificateImplCollection intermediateCerts;
@@ -70,7 +70,8 @@ namespace Mono.Btls
 		{
 			disallowFallback = other.disallowFallback;
 			x509 = other.x509 != null ? other.x509.Copy () : null;
-			privateKey = other.privateKey != null ? other.privateKey.Copy () : null;
+			nativePrivateKey = other.nativePrivateKey != null ? other.nativePrivateKey.Copy () : null;
+			fallback = other.fallback != null ? (X509Certificate2Impl)other.fallback.Clone () : null;
 			if (other.intermediateCerts != null)
 				intermediateCerts = other.intermediateCerts.Clone ();
 		}
@@ -104,7 +105,13 @@ namespace Mono.Btls
 		internal MonoBtlsKey NativePrivateKey {
 			get {
 				ThrowIfContextInvalid ();
-				return privateKey;
+				if (nativePrivateKey == null && FallbackImpl.HasPrivateKey) {
+					var key = FallbackImpl.PrivateKey as RSA;
+					if (key == null)
+						throw new NotSupportedException ("Currently only supports RSA private keys.");
+					nativePrivateKey = MonoBtlsKey.CreateFromRSAPrivateKey (key);
+				}
+				return nativePrivateKey;
 			}
 		}
 
@@ -270,7 +277,7 @@ namespace Mono.Btls
 		}
 
 		public override bool HasPrivateKey {
-			get { return privateKey != null; }
+			get { return nativePrivateKey != null || FallbackImpl.HasPrivateKey; }
 		}
 
 		public override X500DistinguishedName IssuerName {
@@ -290,12 +297,15 @@ namespace Mono.Btls
 
 		public override AsymmetricAlgorithm PrivateKey {
 			get {
-				if (privateKey == null || !privateKey.IsRsa)
-					return null;
-				var bytes = privateKey.GetBytes (true);
+				if (nativePrivateKey == null || !nativePrivateKey.IsRsa)
+					return FallbackImpl.PrivateKey;
+				var bytes = nativePrivateKey.GetBytes (true);
 				return PKCS8.PrivateKeyInfo.DecodeRSA (bytes);
 			}
-			set { FallbackImpl.PrivateKey = value; }
+			set {
+				nativePrivateKey = null;
+				FallbackImpl.PrivateKey = value;
+			}
 		}
 
 		public override PublicKey PublicKey {
@@ -400,7 +410,7 @@ namespace Mono.Btls
 
 				x509 = pkcs12.GetCertificate (0);
 				if (pkcs12.HasPrivateKey)
-					privateKey = pkcs12.GetPrivateKey ();
+					nativePrivateKey = pkcs12.GetPrivateKey ();
 				if (pkcs12.Count > 1) {
 					intermediateCerts = new X509CertificateImplCollection ();
 					for (int i = 0; i < pkcs12.Count; i++) {
@@ -477,9 +487,8 @@ namespace Mono.Btls
 				x509.Dispose ();
 				x509 = null;
 			}
-			if (privateKey != null) {
-				privateKey = null;
-				privateKey = null;
+			if (nativePrivateKey != null) {
+				nativePrivateKey = null;
 			}
 			subjectName = null;
 			issuerName = null;

--- a/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
+++ b/mcs/class/System/Mono.Btls/X509CertificateImplBtls.cs
@@ -343,6 +343,7 @@ namespace Mono.Btls
 
 		public override void Import (byte[] data, string password, X509KeyStorageFlags keyStorageFlags)
 		{
+			Reset ();
 			if (password == null) {
 				try {
 					Import (data);

--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -94,9 +94,7 @@ namespace System.Net.Security
 
 		static MonoTlsProvider GetProvider ()
 		{
-#pragma warning disable 612
-			return MonoTlsProviderFactory.GetDefaultProvider ();
-#pragma warning restore 612
+			return MonoTlsProviderFactory.GetProvider ();
 		}
 
 		public SslStream (Stream innerStream)

--- a/mono/btls/btls-key.c
+++ b/mono/btls/btls-key.c
@@ -8,6 +8,12 @@
 
 #include <btls-key.h>
 
+MONO_API EVP_PKEY *
+mono_btls_key_new ()
+{
+	return EVP_PKEY_new ();
+}
+
 MONO_API void
 mono_btls_key_free (EVP_PKEY *pkey)
 {
@@ -30,6 +36,19 @@ MONO_API int
 mono_btls_key_is_rsa (EVP_PKEY *pkey)
 {
 	return pkey->type == EVP_PKEY_RSA;
+}
+
+MONO_API int
+mono_btls_key_assign_rsa_private_key (EVP_PKEY *pkey, uint8_t **der_data, size_t der_length)
+{
+	RSA *rsa;
+	int ret;
+
+	rsa = RSA_private_key_from_bytes (der_data, der_length);
+	if (!rsa)
+		return 0;
+
+	return EVP_PKEY_assign_RSA (pkey, rsa);
 }
 
 MONO_API int

--- a/mono/btls/btls-key.c
+++ b/mono/btls/btls-key.c
@@ -54,6 +54,8 @@ mono_btls_key_get_bytes (EVP_PKEY *pkey, uint8_t **buffer, int *size, int includ
 	else
 		ret = RSA_public_key_to_bytes (buffer, &len, rsa);
 
+	RSA_free (rsa);
+
 	if (ret != 1)
 		return 0;
 

--- a/mono/btls/btls-key.h
+++ b/mono/btls/btls-key.h
@@ -13,6 +13,9 @@
 #include <btls-ssl.h>
 #include <btls-x509.h>
 
+EVP_PKEY *
+mono_btls_key_new ();
+
 void
 mono_btls_key_free (EVP_PKEY *pkey);
 


### PR DESCRIPTION
When setting X509CertificateImplBtls.PrivateKey we'd previously just update the fallback instance. This causes problems if other code internal to System.dll like MonoBtlsContext.SetPrivateCertificate() tries to fetch the NativePrivateKey since it'd be null at that point.

This scenario happens e.g. with HttpListener, it supports a special directory in ~/.config/.mono/httplistener which contains `<port>.cer` and `<port>.pvk` files (public and private key) that will be used as the server certificate. In that code we're reading the private key from the file and assigning it to X509CertificateImplBtls.PrivateKey without ever having a native BTLS handle.

The fix is to create such a native BTLS handle from the managed private key when needed.

Note that we can't simply always do this e.g. in the PrivateKey setter because the setter will be used with instances that don't actually contain a private key. We can't throw in those cases so instead we do it only when NativePrivateKey is accessed.

To make the code clearer and easier to read, `privateKey` was renamed to `nativePrivateKey` in X509CertificateImplBtls.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=46602

--

I included a few easy fixes for issues that I stumbled over while investigating this too, but the main commit is the last one.