### PR TITLE
[runtime] Get mono/tests running on bitcode/arm

### DIFF
--- a/mono/tests/assemblyresolve/Makefile.am
+++ b/mono/tests/assemblyresolve/Makefile.am
@@ -2,6 +2,8 @@ CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
 
 RUNTIME = $(top_builddir)/runtime/mono-wrapper --debug
 TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(RUNTIME)
+MCS = MONO_PATH=$(mcs_topdir)/class/lib/build $(RUNTIME) $(CSC) -noconfig -nologo -debug:portable -target:library
+CLASS = $(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
 
 MCS = $(TOOLS_RUNTIME) $(CSC) -noconfig -nologo -debug:portable -target:library
 

--- a/mono/tests/gc-descriptors/Makefile.am
+++ b/mono/tests/gc-descriptors/Makefile.am
@@ -3,6 +3,12 @@ CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
 TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/mono-wrapper
 MCS = $(TOOLS_RUNTIME) $(CSC) -lib:$(CLASS) -noconfig -unsafe -nowarn:0162 -nowarn:0168 -nowarn:0219 -debug:portable
 
+if INSTALL_TESTING_AOT_FULL
+
+check-local:
+
+else
+
 check-local: test
 
 test : descriptor-tests.exe
@@ -13,6 +19,8 @@ descriptor-tests.exe : descriptor-tests.cs
 descriptor-tests.cs : descriptor-tests-driver.cs descriptor-tests-prefix.cs gen-descriptor-tests.py
 	if [ "$(srcdir)" != "$(builddir)" ]; then cp $^ .; fi
 	$(srcdir)/gen-descriptor-tests.py >descriptor-tests.cs
+
+endif
 
 EXTRA_DIST = descriptor-tests-driver.cs descriptor-tests-prefix.cs gen-descriptor-tests.py
 


### PR DESCRIPTION
This fixes up some bitrot on fullaot mono/tests test execution and disables a test that crashes the runtime on ARM and doesn't seem to be expected to be working.