### PR TITLE
[mini] Initialize profiler in mini_init

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2007,8 +2007,7 @@ mono_main (int argc, char* argv[])
 	mono_set_rootdir ();
 
 	if (enable_profile) {
-		mono_profiler_load (profile_options);
-		mono_profiler_thread_name (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main");
+		mini_profiler_enable_with_options (profile_options);
 	}
 
 	mono_attach_parse_options (attach_options);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -123,9 +123,15 @@ int valgrind_register;
 #endif
 GList* mono_aot_paths;
 
+static gboolean mini_enable_profiler = FALSE;
+static char* mini_profiler_options = NULL;
+
 static GSList *tramp_infos;
 
 static void register_icalls (void);
+
+static gboolean mini_profiler_enabled (void) { return mini_enable_profiler; }
+static const char* mini_profiler_get_options (void) {  return mini_profiler_options;  }
 
 gboolean
 mono_running_on_valgrind (void)
@@ -3462,6 +3468,13 @@ mini_llvm_init (void)
 #endif
 }
 
+void
+mini_profiler_enable_with_options (const char* profile_options)
+{
+	mini_enable_profiler = TRUE;
+	mini_profiler_options = g_strdup (profile_options);
+}
+
 MonoDomain *
 mini_init (const char *filename, const char *runtime_version)
 {
@@ -3618,6 +3631,11 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_install_get_cached_class_info (mono_aot_get_cached_class_info);
 	mono_install_get_class_from_name (mono_aot_get_class_from_name);
 	mono_install_jit_info_find_in_aot (mono_aot_find_jit_info);
+
+	if (mini_profiler_enabled ()) {
+		mono_profiler_load (mini_profiler_get_options ());
+		mono_profiler_thread_name (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main");
+	}
 
 	if (debug_options.collect_pagefault_stats)
 		mono_aot_set_make_unreadable (TRUE);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2332,6 +2332,7 @@ MonoDomain* mini_init                      (const char *filename, const char *ru
 void        mini_cleanup                   (MonoDomain *domain);
 MONO_API MonoDebugOptions *mini_get_debug_options   (void);
 MONO_API gboolean    mini_parse_debug_option (const char *option);
+void        mini_profiler_enable_with_options (const char *profile_options);
 
 /* graph dumping */
 void mono_cfg_dump_create_context (MonoCompile *cfg);


### PR DESCRIPTION
Fixes segfault when cooperative GC is enabled.