### PR TITLE
[runtime] Fix compile error in mono_domain_from_appdomain when DISABLE_REMOTING is defined

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1816,7 +1816,7 @@ mono_domain_from_appdomain (MonoAppDomain *appdomain)
 	if (appdomain == NULL)
 		return NULL;
 
-	if (appdomain->mbr.obj.vtable->klass == mono_defaults.transparent_proxy_class) {
+	if (mono_object_is_transparent_proxy (&appdomain->mbr.obj)) {
 		MonoTransparentProxy *tp = (MonoTransparentProxy*)appdomain;
 		return mono_domain_get_by_id (tp->rp->target_domain_id);
 	}

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1117,12 +1117,12 @@ typedef struct {
 #ifdef DISABLE_REMOTING
 #define mono_class_is_transparent_proxy(klass) (FALSE)
 #define mono_class_is_real_proxy(klass) (FALSE)
-#define mono_object_is_transparent_proxy(object) (FALSE)
 #else
 #define mono_class_is_transparent_proxy(klass) ((klass) == mono_defaults.transparent_proxy_class)
 #define mono_class_is_real_proxy(klass) ((klass) == mono_defaults.real_proxy_class)
-#define mono_object_is_transparent_proxy(object) (((MonoObject*)object)->vtable->klass == mono_defaults.transparent_proxy_class)
 #endif
+
+#define mono_object_is_transparent_proxy(object) (mono_class_is_transparent_proxy (mono_object_class (object)))
 
 
 #define GENERATE_GET_CLASS_WITH_CACHE_DECL(shortname) \

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1219,7 +1219,7 @@ ves_icall_System_Object_GetType (MonoObjectHandle obj, MonoError *error)
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (obj);
 	MonoClass *klass = mono_handle_class (obj);
 #ifndef DISABLE_REMOTING
-	if (klass == mono_defaults.transparent_proxy_class) {
+	if (mono_class_is_transparent_proxy (klass)) {
 		MonoTransparentProxyHandle proxy_obj = MONO_HANDLE_CAST (MonoTransparentProxy, obj);
 		MonoRemoteClass *remote_class = MONO_HANDLE_GETVAL (proxy_obj, remote_class);
 		MonoType *proxy_type = &remote_class->proxy_class->byval_arg;
@@ -3289,16 +3289,16 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 
 	if (m->klass == mono_defaults.object_class) {
 		if (!strcmp (m->name, "FieldGetter")) {
-			MonoClass *k = this_arg->vtable->klass;
+			MonoClass *k = mono_object_class (this_arg);
 			MonoString *name;
 			char *str;
 			
 			/* If this is a proxy, then it must be a CBO */
-			if (k == mono_defaults.transparent_proxy_class) {
+			if (mono_class_is_transparent_proxy (k)) {
 				MonoTransparentProxy *tp = (MonoTransparentProxy*) this_arg;
 				this_arg = tp->rp->unwrapped_server;
 				g_assert (this_arg);
-				k = this_arg->vtable->klass;
+				k = mono_object_class (this_arg);
 			}
 			
 			name = mono_array_get (params, MonoString *, 1);
@@ -3332,18 +3332,18 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 			g_assert_not_reached ();
 
 		} else if (!strcmp (m->name, "FieldSetter")) {
-			MonoClass *k = this_arg->vtable->klass;
+			MonoClass *k = mono_object_class (this_arg);
 			MonoString *name;
 			guint32 size;
 			gint32 align;
 			char *str;
 			
 			/* If this is a proxy, then it must be a CBO */
-			if (k == mono_defaults.transparent_proxy_class) {
+			if (mono_class_is_transparent_proxy (k)) {
 				MonoTransparentProxy *tp = (MonoTransparentProxy*) this_arg;
 				this_arg = tp->rp->unwrapped_server;
 				g_assert (this_arg);
-				k = this_arg->vtable->klass;
+				k = mono_object_class (this_arg);
 			}
 			
 			name = mono_array_get (params, MonoString *, 1);
@@ -6876,7 +6876,7 @@ ves_icall_IsTransparentProxy (MonoObject *proxy)
 	if (!proxy)
 		return 0;
 
-	if (proxy->vtable->klass == mono_defaults.transparent_proxy_class)
+	if (mono_object_is_transparent_proxy (proxy))
 		return 1;
 
 	return 0;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -2406,7 +2406,7 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 	}
 
 #ifndef DISABLE_REMOTING
-	if (delegate->target && mono_object_class (delegate->target) == mono_defaults.transparent_proxy_class) {
+	if (delegate->target && mono_object_is_transparent_proxy (delegate->target)) {
 		MonoTransparentProxy* tp = (MonoTransparentProxy *)delegate->target;
 		if (!mono_class_is_contextbound (tp->remote_class->proxy_class) || tp->rp->context != (MonoObject *) mono_context_get ()) {
 			/* If the target is a proxy, make a direct call. Is proxy's work
@@ -9043,10 +9043,8 @@ mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *ca
 	if (mono_error_set_pending_exception (&error))
 		return NULL;
 
-#ifndef DISABLE_REMOTING
-	if (obj->vtable->klass == mono_defaults.transparent_proxy_class)
+	if (mono_object_is_transparent_proxy (obj))
 		return isinst;
-#endif
 
 	uintptr_t cache_update = (uintptr_t)obj->vtable;
 	if (!isinst)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2731,13 +2731,11 @@ mono_object_handle_get_virtual_method (MonoObjectHandle obj, MonoMethod *method,
 
 	gboolean is_proxy = FALSE;
 	MonoClass *klass = mono_handle_class (obj);
-#ifndef DISABLE_REMOTING
-	if (klass == mono_defaults.transparent_proxy_class) {
+	if (mono_class_is_transparent_proxy (klass)) {
 		MonoRemoteClass *remote_class = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoTransparentProxy, obj), remote_class);
 		klass = remote_class->proxy_class;
 		is_proxy = TRUE;
 	}
-#endif
 	return class_get_virtual_method (klass, method, is_proxy, error);
 }
 
@@ -5044,7 +5042,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			mono_error_assert_ok (error);
 			g_assert (obj); /*maybe we should raise a TLE instead?*/
 #ifndef DISABLE_REMOTING
-			if (mono_object_class(obj) == mono_defaults.transparent_proxy_class) {
+			if (mono_object_is_transparent_proxy (obj)) {
 				method = mono_marshal_get_remoting_invoke (method->slot == -1 ? method : method->klass->vtable [method->slot]);
 			}
 #endif
@@ -6596,7 +6594,7 @@ mono_object_handle_isinst_mbyref (MonoObjectHandle obj, MonoClass *klass, MonoEr
 		}
 	}
 #ifndef DISABLE_REMOTING
-	if (vt->klass == mono_defaults.transparent_proxy_class) 
+	if (mono_class_is_transparent_proxy (vt->klass)) 
 	{
 		MonoBoolean custom_type_info =  MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoTransparentProxy, obj), custom_type_info);
 		if (!custom_type_info)
@@ -7880,7 +7878,7 @@ mono_delegate_ctor_with_method (MonoObject *this_obj, MonoObject *target, gpoint
 	mono_stats.delegate_creations++;
 
 #ifndef DISABLE_REMOTING
-	if (target && target->vtable->klass == mono_defaults.transparent_proxy_class) {
+	if (target && mono_object_is_transparent_proxy (target)) {
 		g_assert (method);
 		method = mono_marshal_get_remoting_invoke (method);
 		delegate->method_ptr = mono_compile_method_checked (method, error);

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -364,7 +364,7 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 	this_obj = *((MonoTransparentProxy **)params [0]);
 
 	g_assert (this_obj);
-	g_assert (((MonoObject *)this_obj)->vtable->klass == mono_defaults.transparent_proxy_class);
+	g_assert (mono_object_is_transparent_proxy (this_obj));
 	
 	/* skip the this pointer */
 	params++;

--- a/mono/mini/interpreter/interp.c
+++ b/mono/mini/interpreter/interp.c
@@ -303,7 +303,7 @@ get_virtual_method (MonoDomain *domain, RuntimeMethod *runtime_method, MonoObjec
 
 	if ((m->flags & METHOD_ATTRIBUTE_FINAL) || !(m->flags & METHOD_ATTRIBUTE_VIRTUAL)) {
 		RuntimeMethod *ret = NULL;
-		if (obj->vtable->klass == mono_defaults.transparent_proxy_class) {
+		if (mono_object_is_transparent_proxy (obj)) {
 			ret = mono_interp_get_runtime_method (domain, mono_marshal_get_remoting_invoke (m), &error);
 			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 		} else if (m->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
@@ -895,7 +895,7 @@ interp_delegate_ctor (MonoDomain *domain, MonoObject *this, MonoObject *target, 
 	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 	delegate->target = target;
 
-	if (target && target->vtable->klass == mono_defaults.transparent_proxy_class) {
+	if (target && mono_object_is_transparent_proxy (target)) {
 		MonoMethod *method = mono_marshal_get_remoting_invoke (runtime_method->method);
 		delegate->method_ptr = mono_interp_get_runtime_method (domain, method, &error);
 		mono_error_cleanup (&error); /* FIXME: don't swallow the error */
@@ -1800,7 +1800,7 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 			} else {
 				child_frame.obj = NULL;
 			}
-			if (csignature->hasthis && ((MonoObject *)child_frame.obj)->vtable->klass == mono_defaults.transparent_proxy_class) {
+			if (csignature->hasthis && mono_object_is_transparent_proxy (child_frame.obj)) {
 				child_frame.runtime_method = mono_interp_get_runtime_method (context->domain, mono_marshal_get_remoting_invoke (child_frame.runtime_method->method), &error);
 				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 			} else if (child_frame.runtime_method->method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
@@ -1893,7 +1893,7 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 			} else {
 				child_frame.obj = NULL;
 			}
-			if (child_frame.runtime_method->hasthis && !child_frame.runtime_method->valuetype && ((MonoObject *)child_frame.obj)->vtable->klass == mono_defaults.transparent_proxy_class) {
+			if (child_frame.runtime_method->hasthis && !child_frame.runtime_method->valuetype && mono_object_is_transparent_proxy (child_frame.obj)) {
 				child_frame.runtime_method = mono_interp_get_runtime_method (context->domain, mono_marshal_get_remoting_invoke (child_frame.runtime_method->method), &error);
 				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 			}
@@ -1932,7 +1932,7 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 				child_frame.obj = NULL;
 			}
 
-			if (child_frame.runtime_method->hasthis && !child_frame.runtime_method->valuetype && ((MonoObject *)child_frame.obj)->vtable->klass == mono_defaults.transparent_proxy_class) {
+			if (child_frame.runtime_method->hasthis && !child_frame.runtime_method->valuetype && mono_object_is_transparent_proxy (child_frame.obj)) {
 				child_frame.runtime_method = mono_interp_get_runtime_method (context->domain, mono_marshal_get_remoting_invoke (child_frame.runtime_method->method), &error);
 				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 			}
@@ -2970,7 +2970,7 @@ array_constructed:
 				THROW_EX (mono_get_exception_null_reference (), ip);
 			field = rtm->data_items[* (guint16 *)(ip + 1)];
 			ip += 2;
-			if (o->vtable->klass == mono_defaults.transparent_proxy_class) {
+			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
 
 				addr = mono_load_remote_field_checked (o, klass, field, &tmp, &error);
@@ -2994,7 +2994,7 @@ array_constructed:
 			field = rtm->data_items[* (guint16 *)(ip + 1)];
 			i32 = READ32(ip + 2);
 			ip += 4;
-			if (o->vtable->klass == mono_defaults.transparent_proxy_class) {
+			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
 				addr = mono_load_remote_field_checked (o, klass, field, &tmp, &error);
 				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
@@ -3049,7 +3049,7 @@ array_constructed:
 			field = rtm->data_items[* (guint16 *)(ip + 1)];
 			ip += 2;
 
-			if (o->vtable->klass == mono_defaults.transparent_proxy_class) {
+			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
 				mono_store_remote_field_checked (o, klass, field, &sp [-1].data, &error);
 				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
@@ -3069,7 +3069,7 @@ array_constructed:
 			i32 = READ32(ip + 2);
 			ip += 4;
 
-			if (o->vtable->klass == mono_defaults.transparent_proxy_class) {
+			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
 				mono_store_remote_field_checked (o, klass, field, &sp [-1].data, &error);
 				mono_error_cleanup (&error); /* FIXME: don't swallow the error */

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1121,7 +1121,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 		 * delegate->method).
 		 */
 #ifndef DISABLE_REMOTING
-		if (delegate->target && delegate->target->vtable->klass == mono_defaults.transparent_proxy_class) {
+		if (delegate->target && mono_object_is_transparent_proxy (delegate->target)) {
 			is_remote = TRUE;
 #ifndef DISABLE_COM
 			if (((MonoTransparentProxy *)delegate->target)->remote_class->proxy_class != mono_class_get_com_object_class () &&


### PR DESCRIPTION


`mono_defaults.transparent_proxy_class` is #ifdef'd out when remoting is disabled.