### PR TITLE
[mcs] Ignore constraints on enumerator generic methods. Fixes #51506

### DIFF
--- a/mcs/mcs/field.cs
+++ b/mcs/mcs/field.cs
@@ -257,7 +257,8 @@ namespace Mono.CSharp
 				Report.Error (625, Location, "`{0}': Instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute", GetSignatureForError ());
 			}
 
-			ConstraintChecker.Check (this, member_type, type_expr.Location);
+			if (!IsCompilerGenerated)
+				ConstraintChecker.Check (this, member_type, type_expr.Location);
 
 			base.Emit ();
 		}

--- a/mcs/tests/gtest-643.cs
+++ b/mcs/tests/gtest-643.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+	public static void Main()
+	{
+	}
+
+	private static IEnumerable<float> FindIntersections<TVector>(
+		IBezier<TVector> bezier,
+		Ray<TVector> ray,
+		float epsilon,
+		Range<float> t1,
+		int depth) where TVector : IVector<TVector>
+	{
+		var bounds = bezier.GetBounds();
+		if (Intersect.s(ray, bounds))
+		{
+			var intersections1 = new float[] { };
+			var intersections2 = new float[] { };
+			foreach (var t in intersections1) { yield return t; }
+			foreach (var t in intersections2) { yield return t; }
+		}
+	}
+
+	public static class Intersect
+	{
+		public static bool s<TVector>(Ray<TVector> ray, BoundingBoxN<TVector> box) where TVector : IVector<TVector>
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	public struct Range<T>
+	{
+	}
+
+	public class Ray<TVector> where TVector : IVector<TVector>
+	{
+	}
+
+	public interface IBezier<TVector>
+		where TVector : IVector<TVector>
+	{
+		BoundingBoxN<TVector> GetBounds();
+	}
+
+	public interface IVector<T> : IEpsilonEquatable<T, float>
+		where T : IVector<T>
+	{
+	}
+
+	public interface IEpsilonEquatable<TType, TEpsilon> // ReSharper enable TypeParameterCanBeVariant
+	{
+	}
+
+	public struct BoundingBoxN<T>
+		where T : IVector<T>
+	{
+	}
+}

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -20035,6 +20035,55 @@
       </method>
     </type>
   </test>
+  <test name="gtest-643.cs">
+    <type name="Program">
+      <method name="Void Main()" attrs="150">
+        <size>2</size>
+      </method>
+      <method name="System.Collections.Generic.IEnumerable`1[System.Single] FindIntersections[TVector](IBezier`1, Ray`1, Single, Range`1, Int32)" attrs="145">
+        <size>37</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Program+Intersect">
+      <method name="Boolean s[TVector](Ray`1, BoundingBoxN`1)" attrs="150">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Program+Ray`1[TVector]">
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Program+&lt;FindIntersections&gt;c__Iterator0`1[TVector]">
+      <method name="Boolean MoveNext()" attrs="486">
+        <size>336</size>
+      </method>
+      <method name="Single System.Collections.Generic.IEnumerator&lt;float&gt;.get_Current()" attrs="2529">
+        <size>14</size>
+      </method>
+      <method name="System.Object System.Collections.IEnumerator.get_Current()" attrs="2529">
+        <size>19</size>
+      </method>
+      <method name="Void Dispose()" attrs="486">
+        <size>15</size>
+      </method>
+      <method name="Void Reset()" attrs="486">
+        <size>6</size>
+      </method>
+      <method name="System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()" attrs="481">
+        <size>14</size>
+      </method>
+      <method name="System.Collections.Generic.IEnumerator`1[System.Single] System.Collections.Generic.IEnumerable&lt;float&gt;.GetEnumerator()" attrs="481">
+        <size>52</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
   <test name="gtest-anontype-01.cs">
     <type name="Test">
       <method name="Int32 Main()" attrs="150">


### PR DESCRIPTION
This is similar to the change at 30f6c9933a6c0595a5d1d5cf681be39b4367446e