### PR TITLE
Implement mono_gc_alloc_fixed/mono_gc_free_fixed on Boehm to match SGen

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -259,9 +259,6 @@ mono_gc_base_init (void)
 	GC_set_on_collection_event (on_gc_notification);
 	GC_on_heap_resize = on_gc_heap_resize;
 
-	MONO_GC_REGISTER_ROOT_FIXED (gc_handles [HANDLE_NORMAL].entries, MONO_ROOT_SOURCE_GC_HANDLE, "gc handles table");
-	MONO_GC_REGISTER_ROOT_FIXED (gc_handles [HANDLE_PINNED].entries, MONO_ROOT_SOURCE_GC_HANDLE, "gc handles table");
-
 	gc_initialized = TRUE;
 }
 
@@ -538,6 +535,12 @@ mono_gc_register_root (char *start, size_t size, void *descr, MonoGCRootSource s
 	return TRUE;
 }
 
+int
+mono_gc_register_root_wbarrier (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg)
+{
+	return mono_gc_register_root (start, size, descr, source, msg);
+}
+
 void
 mono_gc_deregister_root (char* addr)
 {
@@ -623,25 +626,13 @@ mono_gc_make_root_descr_all_refs (int numbits)
 void*
 mono_gc_alloc_fixed (size_t size, void *descr, MonoGCRootSource source, const char *msg)
 {
-	/* To help track down typed allocation bugs */
-	/*
-	static int count;
-	count ++;
-	if (count == atoi (g_getenv ("COUNT2")))
-		printf ("HIT!\n");
-	if (count > atoi (g_getenv ("COUNT2")))
-		return GC_MALLOC (size);
-	*/
-
-	if (descr)
-		return GC_MALLOC_EXPLICITLY_TYPED (size, (GC_descr)descr);
-	else
-		return GC_MALLOC (size);
+	return GC_MALLOC_UNCOLLECTABLE (size);
 }
 
 void
 mono_gc_free_fixed (void* addr)
 {
+	GC_FREE (addr);
 }
 
 void *

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -383,13 +383,7 @@ mono_domain_create (void)
 	mono_appdomains_unlock ();
 
 #ifdef HAVE_BOEHM_GC
-	/*
-	 * Boehm doesn't like roots inside GC allocated objects, and alloc_fixed returns
-	 * a GC_MALLOC-ed object, contrary to the api docs. This causes random crashes when
-	 * running the corlib test suite.
-	 * To solve this, we pass a NULL descriptor, and don't register roots.
-	 */
-	domain = (MonoDomain *)mono_gc_alloc_fixed (sizeof (MonoDomain), NULL, MONO_ROOT_SOURCE_DOMAIN, "domain object");
+	domain = (MonoDomain *)mono_gc_alloc_fixed (sizeof (MonoDomain), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, "domain object");
 #else
 	domain = (MonoDomain *)mono_gc_alloc_fixed (sizeof (MonoDomain), domain_gc_desc, MONO_ROOT_SOURCE_DOMAIN, "domain object");
 	mono_gc_register_root ((char*)&(domain->MONO_DOMAIN_FIRST_GC_TRACKED), G_STRUCT_OFFSET (MonoDomain, MONO_DOMAIN_LAST_GC_TRACKED) - G_STRUCT_OFFSET (MonoDomain, MONO_DOMAIN_FIRST_GC_TRACKED), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, "misc domain fields");
@@ -513,9 +507,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_loader_init ();
 	mono_reflection_init ();
 	mono_runtime_init_tls ();
-
-	/* FIXME: When should we release this memory? */
-	MONO_GC_REGISTER_ROOT_FIXED (appdomains_list, MONO_ROOT_SOURCE_DOMAIN, "domains list");
 
 	domain = mono_domain_create ();
 	mono_root_domain = domain;

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -27,16 +27,6 @@
 #define MONO_GC_UNREGISTER_ROOT(x) mono_gc_deregister_root ((char*)&(x))
 
 /*
- * Register a memory location as a root pointing to memory allocated using
- * mono_gc_alloc_fixed (). This includes MonoGHashTable.
- */
-/* The result of alloc_fixed () is not GC tracked memory */
-#define MONO_GC_REGISTER_ROOT_FIXED(x,src,msg) do { \
-	if (!mono_gc_is_moving ())				\
-		MONO_GC_REGISTER_ROOT_PINNING ((x),(src),(msg)); \
-	} while (0)
-
-/*
  * Return a GC descriptor for an array containing N pointers to memory allocated
  * by mono_gc_alloc_fixed ().
  */
@@ -131,8 +121,6 @@ gboolean mono_gc_user_markers_supported (void);
  * The memory is non-moving and it will be explicitly deallocated.
  * size bytes will be available from the returned address (ie, descr
  * must not be stored in the returned memory)
- * NOTE: Under Boehm, this returns memory allocated using GC_malloc, so the result should
- * be stored into a location registered using MONO_GC_REGISTER_ROOT_FIXED ().
  */
 void* mono_gc_alloc_fixed            (size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg);
 void  mono_gc_free_fixed             (void* addr);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -748,18 +748,11 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 
 			type = mono_type_get_underlying_type (field->type);
 			switch (type->type) {
+			case MONO_TYPE_U:
 			case MONO_TYPE_I:
 			case MONO_TYPE_PTR:
 			case MONO_TYPE_FNPTR:
 				break;
-			/* only UIntPtr is allowed to be GC-tracked and only in mscorlib */
-			case MONO_TYPE_U:
-#ifdef HAVE_SGEN_GC
-				break;
-#else
-				if (klass->image != mono_defaults.corlib)
-					break;
-#endif
 			case MONO_TYPE_STRING:
 			case MONO_TYPE_SZARRAY:
 			case MONO_TYPE_CLASS:

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -538,7 +538,6 @@ mono_thread_attach_internal (MonoThread *thread, gboolean force_attach, gboolean
 	}
 
 	if (!threads) {
-		MONO_GC_REGISTER_ROOT_FIXED (threads, MONO_ROOT_SOURCE_THREADING, "threads table");
 		threads = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_THREADING, "threads table");
 	}
 
@@ -762,7 +761,6 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 		return FALSE;
 	}
 	if (threads_starting_up == NULL) {
-		MONO_GC_REGISTER_ROOT_FIXED (threads_starting_up, MONO_ROOT_SOURCE_THREADING, "starting threads table");
 		threads_starting_up = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_THREADING, "starting threads table");
 	}
 	mono_g_hash_table_insert (threads_starting_up, thread, thread);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -993,13 +993,10 @@ mono_debugger_agent_init (void)
 	mono_gc_base_init ();
 
 	thread_to_tls = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, "thread-to-tls table");
-	MONO_GC_REGISTER_ROOT_FIXED (thread_to_tls, MONO_ROOT_SOURCE_DEBUGGER, "thread-to-tls table");
 
 	tid_to_thread = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread table");
-	MONO_GC_REGISTER_ROOT_FIXED (tid_to_thread, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread table");
 
 	tid_to_thread_obj = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread object table");
-	MONO_GC_REGISTER_ROOT_FIXED (tid_to_thread_obj, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread object table");
 
 	pending_assembly_loads = g_ptr_array_new ();
 	domains = g_hash_table_new (mono_aligned_addr_hash, NULL);
@@ -1937,7 +1934,6 @@ objrefs_init (void)
 	objrefs = g_hash_table_new_full (NULL, NULL, NULL, free_objref);
 	obj_to_objref = g_hash_table_new (NULL, NULL);
 	suspended_objs = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, "suspended objects table");
-	MONO_GC_REGISTER_ROOT_FIXED (suspended_objs, MONO_ROOT_SOURCE_DEBUGGER, "suspended objects table");
 }
 
 static void


### PR DESCRIPTION
Implement mono_gc_alloc_fixed on Boehm to be uncollectable. This matches SGen behavior and avoids needing to register fixed allocated memory as a root.