### PR TITLE
Prevent use of threadpool when it has been cleaned up as part of runtime shutdown

### DIFF
--- a/mcs/class/System/System.Net/HttpListener.cs
+++ b/mcs/class/System/System.Net/HttpListener.cs
@@ -276,8 +276,10 @@ namespace System.Net {
 		void Close (bool force)
 		{
 			CheckDisposed ();
-			EndPointManager.RemoveListener (this);
-			Cleanup (force);
+			if (!Mono.Runtime.CheckRuntimeShutdown()) {
+				EndPointManager.RemoveListener (this);
+				Cleanup (force);
+			}
 		}
 
 		void Cleanup (bool close_existing)

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -60,6 +60,11 @@ namespace Mono {
 		}
 #endif
 
+		// Used to check if shutdown has started so that things like
+		// the threadpool are no longer accessed
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		public static extern bool CheckRuntimeShutdown ();
+
 		// Should not be removed intended for external use
 		// Safe to be called using reflection
 		// Format is undefined only for use as a string for reporting
@@ -73,6 +78,7 @@ namespace Mono {
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern string GetNativeStackTrace (Exception exception);
+
 
 		public static bool SetGCAllowSynchronousMajor (bool flag)
 		{

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -87,8 +87,10 @@ ICALL(COMPROX_2, "FindProxy", ves_icall_Mono_Interop_ComInteropProxy_FindProxy)
 ICALL_TYPE(TLS_PROVIDER_FACTORY, "Mono.Net.Security.MonoTlsProviderFactory", TLS_PROVIDER_FACTORY_1)
 ICALL(TLS_PROVIDER_FACTORY_1, "IsBtlsSupported", ves_icall_Mono_TlsProviderFactory_IsBtlsSupported)
 
+
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
-HANDLES(ICALL(RUNTIME_1, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
+HANDLES(ICALL(RUNTIME_1, "CheckRuntimeShutdown", ves_icall_Mono_Runtime_CheckShutdown))
+HANDLES(ICALL(RUNTIME_5, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
 HANDLES(ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace))
 
 ICALL_TYPE(RTCLASS, "Mono.RuntimeClassHandle", RTCLASS_1)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7922,6 +7922,13 @@ ves_icall_Mono_TlsProviderFactory_IsBtlsSupported (void)
 #endif
 }
 
+ICALL_EXPORT MonoBoolean
+ves_icall_Mono_Runtime_CheckShutdown (void)
+{
+	extern gboolean shutting_down_inited;
+	return shutting_down_inited;
+}
+
 #ifndef DISABLE_COM
 
 ICALL_EXPORT int

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -22,7 +22,7 @@
 #include <mono/metadata/marshal.h>
 #include <mono/utils/atomic.h>
 
-static gboolean shutting_down_inited = FALSE;
+gboolean shutting_down_inited = FALSE;
 static gboolean shutting_down = FALSE;
 
 /** 


### PR DESCRIPTION
During the mono runtime shutdown there is a window of opportunity for a thread ro request threadpool services after the threadpool has been cleaned up. 

https://bugzilla.xamarin.com/show_bug.cgi?id=51219

This PR is probably too simplistic and addresses these specific symptoms only but it is a starting point. It will check if runtime shutdown has been initialized before performing httplistener cleanup. Maybe it would be better during the shutdown phase for the threadpool code just to pretend that the calls to it are successful but just ignore them as the thread will eventually be killed as part of the shutdown.