### PR TITLE
[reflection] Fix ves_icall_RuntimeTypeHandle_GetGenericTypeDefinition_impl

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
@@ -11248,5 +11248,18 @@ namespace MonoTests.System.Reflection.Emit
 			Assert.Throws<TypeLoadException> (delegate { var ft = r.GetField("sr").FieldType; });
 		}
 		
+		[Test]
+		public void GetGenericTypeDefinitionAfterCreateReturnsBuilder () {
+			var aname = new AssemblyName ("genericDefnAfterCreate");
+			var ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aname, AssemblyBuilderAccess.Run);
+			var mb = ab.DefineDynamicModule (aname.Name);
+			var buildX = mb.DefineType ("X", TypeAttributes.Public);
+			buildX.DefineGenericParameters ("T", "U");
+			var x = buildX.CreateType ();
+			var inst = x.MakeGenericType (typeof (string), typeof (int));
+			var defX = inst.GetGenericTypeDefinition ();
+
+			Assert.AreSame (buildX, defX);
+		}
 	}
 }

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -265,7 +265,7 @@ mono_gchandle_from_handle (MonoObjectHandle handle, mono_bool pinned)
 MonoObjectHandle
 mono_gchandle_get_target_handle (uint32_t gchandle)
 {
-	return MONO_HANDLE_NEW (MonoObject, mono_gchandle_get_target);
+	return MONO_HANDLE_NEW (MonoObject, mono_gchandle_get_target (gchandle));
 }
 
 gpointer

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2796,7 +2796,7 @@ ves_icall_RuntimeTypeHandle_GetGenericTypeDefinition_impl (MonoReflectionTypeHan
 	if (mono_class_is_ginst (klass)) {
 		MonoClass *generic_class = mono_class_get_generic_class (klass)->container_class;
 
-		guint32 ref_info_handle = mono_class_get_ref_info_handle (klass);
+		guint32 ref_info_handle = mono_class_get_ref_info_handle (generic_class);
 		
 		if (generic_class->wastypebuilder && ref_info_handle) {
 			MonoObjectHandle tb = mono_gchandle_get_target_handle (ref_info_handle);


### PR DESCRIPTION
- There was a typo in ea176c5 that inadvertantly replaced `generic_class` by `klass`.
- `mono_gchandle_get_target_handle` was just wrong (but fortunately it was dead code).
- Added a test case.