### PR TITLE
[sre] Use coop handles for parts of sre.c

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilderInstantiation.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilderInstantiation.cs
@@ -50,7 +50,7 @@ namespace System.Reflection.Emit
 	sealed class TypeBuilderInstantiation :
 		TypeInfo
 	{
-		#region Keep in sync with object-internals.h
+		#region Keep in sync with object-internals.h MonoReflectionGenericClass
 #pragma warning disable 649
 		internal Type generic_type;
 		Type[] type_arguments;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -8284,7 +8284,7 @@ mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 
 		/*A TypeBuilder can have more interfaces on tb->interfaces than on candidate->interfaces*/
 		if (image_is_dynamic (candidate->image) && !candidate->wastypebuilder) {
-			MonoReflectionTypeBuilder *tb = (MonoReflectionTypeBuilder *)mono_class_get_ref_info (candidate);
+			MonoReflectionTypeBuilder *tb = (MonoReflectionTypeBuilder *)mono_class_get_ref_info_raw (candidate); /* FIXME use handles */
 			int j;
 			if (tb && tb->interfaces) {
 				for (j = mono_array_length (tb->interfaces) - 1; j >= 0; --j) {

--- a/mono/metadata/dynamic-image-internals.h
+++ b/mono/metadata/dynamic-image-internals.h
@@ -7,6 +7,7 @@
 
 #include <mono/metadata/object.h>
 #include <mono/metadata/metadata-internals.h>
+#include <mono/metadata/object-internals.h>
 
 typedef struct {
 	guint32 import_lookup_table;
@@ -26,7 +27,7 @@ void
 mono_dynamic_images_init (void);
 
 void
-mono_dynamic_image_register_token (MonoDynamicImage *assembly, guint32 token, MonoObject *obj);
+mono_dynamic_image_register_token (MonoDynamicImage *assembly, guint32 token, MonoObjectHandle obj);
 
 gboolean
 mono_dynamic_image_is_valid_token (MonoDynamicImage *image, guint32 token);

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -311,6 +311,8 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 		mono_gc_wbarrier_generic_store (&__dest->__obj,  (MonoObject*)(MONO_HANDLE_RAW(HANDLE)->FIELD)); \
 	} while (0)
 
+#define MONO_HANDLE_NEW_GET(TYPE,HANDLE,FIELD) (MONO_HANDLE_NEW(TYPE,MONO_HANDLE_RAW(HANDLE)->FIELD))
+
 #define MONO_HANDLE_GETVAL(HANDLE, FIELD) (MONO_HANDLE_RAW(HANDLE)->FIELD)
 
 /* VS doesn't support typeof :( :( :( */

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -543,20 +543,20 @@ ICALL(CATTRB_1, "GetBlob", ves_icall_CustomAttributeBuilder_GetBlob)
 #endif
 
 ICALL_TYPE(DYNM, "System.Reflection.Emit.DynamicMethod", DYNM_1)
-ICALL(DYNM_1, "create_dynamic_method", ves_icall_DynamicMethod_create_dynamic_method)
+HANDLES(ICALL(DYNM_1, "create_dynamic_method", ves_icall_DynamicMethod_create_dynamic_method))
 
 ICALL_TYPE(ENUMB, "System.Reflection.Emit.EnumBuilder", ENUMB_1)
 ICALL(ENUMB_1, "setup_enum_type", ves_icall_EnumBuilder_setup_enum_type)
 
 ICALL_TYPE(MODULEB, "System.Reflection.Emit.ModuleBuilder", MODULEB_10)
 ICALL(MODULEB_10, "GetRegisteredToken", ves_icall_ModuleBuilder_GetRegisteredToken)
-ICALL(MODULEB_8, "RegisterToken", ves_icall_ModuleBuilder_RegisterToken)
+HANDLES(ICALL(MODULEB_8, "RegisterToken", ves_icall_ModuleBuilder_RegisterToken))
 ICALL(MODULEB_1, "WriteToFile", ves_icall_ModuleBuilder_WriteToFile)
-ICALL(MODULEB_2, "basic_init", ves_icall_ModuleBuilder_basic_init)
+HANDLES(ICALL(MODULEB_2, "basic_init", ves_icall_ModuleBuilder_basic_init))
 ICALL(MODULEB_3, "build_metadata", ves_icall_ModuleBuilder_build_metadata)
-ICALL(MODULEB_5, "getMethodToken", ves_icall_ModuleBuilder_getMethodToken)
-ICALL(MODULEB_6, "getToken", ves_icall_ModuleBuilder_getToken)
-ICALL(MODULEB_7, "getUSIndex", ves_icall_ModuleBuilder_getUSIndex)
+HANDLES(ICALL(MODULEB_5, "getMethodToken", ves_icall_ModuleBuilder_getMethodToken))
+HANDLES(ICALL(MODULEB_6, "getToken", ves_icall_ModuleBuilder_getToken))
+HANDLES(ICALL(MODULEB_7, "getUSIndex", ves_icall_ModuleBuilder_getUSIndex))
 ICALL(MODULEB_9, "set_wrappers_type", ves_icall_ModuleBuilder_set_wrappers_type)
 
 ICALL_TYPE(SIGH, "System.Reflection.Emit.SignatureHelper", SIGH_1)
@@ -564,7 +564,7 @@ ICALL(SIGH_1, "get_signature_field", ves_icall_SignatureHelper_get_signature_fie
 ICALL(SIGH_2, "get_signature_local", ves_icall_SignatureHelper_get_signature_local)
 
 ICALL_TYPE(TYPEB, "System.Reflection.Emit.TypeBuilder", TYPEB_1)
-ICALL(TYPEB_1, "create_runtime_class", ves_icall_TypeBuilder_create_runtime_class)
+HANDLES(ICALL(TYPEB_1, "create_runtime_class", ves_icall_TypeBuilder_create_runtime_class))
 
 ICALL_TYPE(EVENTI, "System.Reflection.EventInfo", EVENTI_1)
 HANDLES(ICALL(EVENTI_1, "internal_from_handle_type", ves_icall_System_Reflection_EventInfo_internal_from_handle_type))
@@ -786,7 +786,7 @@ HANDLES(ICALL(RT_15, "GetPropertiesByName_native", ves_icall_RuntimeType_GetProp
 HANDLES(ICALL(RT_16, "GetTypeCodeImplInternal", ves_icall_type_GetTypeCodeInternal))
 HANDLES(ICALL(RT_28, "IsTypeExportedToWindowsRuntime", ves_icall_System_RuntimeType_IsTypeExportedToWindowsRuntime))
 HANDLES(ICALL(RT_29, "IsWindowsRuntimeObjectType", ves_icall_System_RuntimeType_IsWindowsRuntimeObjectType))
-ICALL(RT_17, "MakeGenericType", ves_icall_RuntimeType_MakeGenericType)
+HANDLES(ICALL(RT_17, "MakeGenericType", ves_icall_RuntimeType_MakeGenericType))
 HANDLES(ICALL(RT_18, "MakePointerType", ves_icall_RuntimeType_MakePointerType))
 HANDLES(ICALL(RT_19, "getFullName", ves_icall_System_RuntimeType_getFullName))
 HANDLES(ICALL(RT_21, "get_DeclaringMethod", ves_icall_RuntimeType_get_DeclaringMethod))

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1055,6 +1055,9 @@ typedef struct {
 	guint32 call_conv;
 } MonoReflectionArrayMethod;
 
+/* Safely access System.Reflection.Emit.MonoArrayMethod from native code */
+TYPED_HANDLE_DECL (MonoReflectionArrayMethod);
+
 typedef struct {
 	MonoArray *data;
 	MonoString *name;
@@ -1213,13 +1216,19 @@ TYPED_HANDLE_DECL (MonoReflectionTypeBuilder);
 typedef struct {
 	MonoReflectionType type;
 	MonoReflectionType *element_type;
-	int rank;
+	gint32 rank;
 } MonoReflectionArrayType;
+
+/* Safely access System.Reflection.Emit.ArrayType (in DerivedTypes.cs) from native code */
+TYPED_HANDLE_DECL (MonoReflectionArrayType);
 
 typedef struct {
 	MonoReflectionType type;
 	MonoReflectionType *element_type;
 } MonoReflectionDerivedType;
+
+/* Safely access System.Reflection.Emit.SymbolType and subclasses (in DerivedTypes.cs) from native code */
+TYPED_HANDLE_DECL (MonoReflectionDerivedType);
 
 typedef struct {
 	MonoReflectionType type;
@@ -1233,10 +1242,16 @@ typedef struct {
 	guint32 attrs;
 } MonoReflectionGenericParam;
 
+/* Safely access System.Reflection.Emit.GenericTypeParameterBuilder from native code */
+TYPED_HANDLE_DECL (MonoReflectionGenericParam);
+
 typedef struct {
 	MonoReflectionType type;
 	MonoReflectionTypeBuilder *tb;
 } MonoReflectionEnumBuilder;
+
+/* Safely access System.Reflection.Emit.EnumBuilder from native code */
+TYPED_HANDLE_DECL (MonoReflectionEnumBuilder);
 
 typedef struct _MonoReflectionGenericClass MonoReflectionGenericClass;
 struct _MonoReflectionGenericClass {
@@ -1244,6 +1259,9 @@ struct _MonoReflectionGenericClass {
 	MonoReflectionType *generic_type; /*Can be either a MonoType or a TypeBuilder*/
 	MonoArray *type_arguments;
 };
+
+/* Safely access System.Reflection.Emit.TypeBuilderInstantiation from native code */
+TYPED_HANDLE_DECL (MonoReflectionGenericClass);
 
 typedef struct {
 	MonoObject  obj;
@@ -1333,6 +1351,9 @@ typedef struct {
 	MonoReflectionType *owner;
 } MonoReflectionDynamicMethod;	
 
+/* Safely access System.Reflection.Emit.DynamicMethod from native code */
+TYPED_HANDLE_DECL (MonoReflectionDynamicMethod);
+
 typedef struct {
 	MonoObject object;
 	MonoReflectionModuleBuilder *module;
@@ -1344,6 +1365,9 @@ typedef struct {
 	MonoArray *modreqs;
 	MonoArray *modopts;
 } MonoReflectionSigHelper;
+
+/* Safely access System.Reflection.Emit.SignatureHelper from native code */
+TYPED_HANDLE_DECL (MonoReflectionSigHelper);
 
 typedef struct {
 	MonoObject object;
@@ -1393,10 +1417,8 @@ typedef struct {
 } CattrNamedArg;
 
 gboolean          mono_image_create_pefile (MonoReflectionModuleBuilder *module, gpointer file, MonoError *error);
-guint32       mono_image_insert_string (MonoReflectionModuleBuilder *module, MonoString *str);
-guint32       mono_image_create_token  (MonoDynamicImage *assembly, MonoObject *obj, gboolean create_methodspec, gboolean register_token, MonoError *error);
-guint32       mono_image_create_method_token (MonoDynamicImage *assembly, MonoObject *obj, MonoArray *opt_param_types, MonoError *error);
-void          mono_image_register_token (MonoDynamicImage *assembly, guint32 token, MonoObject *obj);
+guint32       mono_image_insert_string (MonoReflectionModuleBuilderHandle module, MonoStringHandle str, MonoError *error);
+guint32       mono_image_create_token  (MonoDynamicImage *assembly, MonoObjectHandle obj, gboolean create_methodspec, gboolean register_token, MonoError *error);
 void          mono_dynamic_image_free (MonoDynamicImage *image);
 void          mono_dynamic_image_free_image (MonoDynamicImage *image);
 void          mono_dynamic_image_release_gc_roots (MonoDynamicImage *image);
@@ -1420,7 +1442,7 @@ MonoArrayHandle mono_param_get_objects_internal  (MonoDomain *domain, MonoMethod
 MonoClass*
 mono_class_bind_generic_parameters (MonoClass *klass, int type_argc, MonoType **types, gboolean is_dynamic);
 MonoType*
-mono_reflection_bind_generic_parameters (MonoReflectionType *type, int type_argc, MonoType **types, MonoError *error);
+mono_reflection_bind_generic_parameters (MonoReflectionTypeHandle type, int type_argc, MonoType **types, MonoError *error);
 void
 mono_reflection_generic_class_initialize (MonoReflectionGenericClass *type, MonoArray *fields);
 
@@ -1464,7 +1486,7 @@ char *
 mono_string_to_utf8_mp	(MonoMemPool *mp, MonoString *s, MonoError *error);
 
 char *
-mono_string_to_utf8_image (MonoImage *image, MonoString *s, MonoError *error);
+mono_string_to_utf8_image (MonoImage *image, MonoStringHandle s, MonoError *error);
 
 
 MonoArray*
@@ -1628,11 +1650,17 @@ mono_class_is_reflection_method_or_constructor (MonoClass *klass);
 MonoObject *
 mono_get_object_from_blob (MonoDomain *domain, MonoType *type, const char *blob, MonoError *error);
 
-gpointer
+MonoObjectHandle
 mono_class_get_ref_info (MonoClass *klass);
 
+gboolean
+mono_class_has_ref_info (MonoClass *klass);
+
+MonoObject*
+mono_class_get_ref_info_raw (MonoClass *klass);
+
 void
-mono_class_set_ref_info (MonoClass *klass, gpointer obj);
+mono_class_set_ref_info (MonoClass *klass, MonoObjectHandle obj);
 
 void
 mono_class_free_ref_info (MonoClass *klass);
@@ -1813,12 +1841,13 @@ MonoReflectionMethod*
 ves_icall_MonoMethod_MakeGenericMethod_impl (MonoReflectionMethod *rmethod, MonoArray *types);
 
 gint32
-ves_icall_ModuleBuilder_getToken (MonoReflectionModuleBuilder *mb, MonoObject *obj, gboolean create_open_instance);
+ves_icall_ModuleBuilder_getToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, gboolean create_open_instance, MonoError *error);
 
 gint32
-ves_icall_ModuleBuilder_getMethodToken (MonoReflectionModuleBuilder *mb,
-										MonoReflectionMethod *method,
-										MonoArray *opt_param_types);
+ves_icall_ModuleBuilder_getMethodToken (MonoReflectionModuleBuilderHandle mb,
+					MonoReflectionMethodHandle method,
+					MonoArrayHandle opt_param_types,
+					MonoError *error);
 
 void
 ves_icall_ModuleBuilder_WriteToFile (MonoReflectionModuleBuilder *mb, gpointer file);
@@ -1827,7 +1856,7 @@ void
 ves_icall_ModuleBuilder_build_metadata (MonoReflectionModuleBuilder *mb);
 
 void
-ves_icall_ModuleBuilder_RegisterToken (MonoReflectionModuleBuilder *mb, MonoObject *obj, guint32 token);
+ves_icall_ModuleBuilder_RegisterToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, guint32 token, MonoError *error);
 
 MonoObject*
 ves_icall_ModuleBuilder_GetRegisteredToken (MonoReflectionModuleBuilder *mb, guint32 token);
@@ -1842,20 +1871,20 @@ MonoArray*
 ves_icall_CustomAttributeBuilder_GetBlob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues);
 
 void
-ves_icall_DynamicMethod_create_dynamic_method (MonoReflectionDynamicMethod *mb);
+ves_icall_DynamicMethod_create_dynamic_method (MonoReflectionDynamicMethodHandle mb, MonoError *error);
 
-MonoReflectionType*
-ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilder *tb);
+MonoReflectionTypeHandle
+ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle tb, MonoError *error);
 
 void
 ves_icall_EnumBuilder_setup_enum_type (MonoReflectionType *enumtype,
 									   MonoReflectionType *t);
 
 void
-ves_icall_ModuleBuilder_basic_init (MonoReflectionModuleBuilder *moduleb);
+ves_icall_ModuleBuilder_basic_init (MonoReflectionModuleBuilderHandle moduleb, MonoError *error);
 
 guint32
-ves_icall_ModuleBuilder_getUSIndex (MonoReflectionModuleBuilder *module, MonoString *str);
+ves_icall_ModuleBuilder_getUSIndex (MonoReflectionModuleBuilderHandle module, MonoStringHandle str, MonoError *error);
 
 void
 ves_icall_ModuleBuilder_set_wrappers_type (MonoReflectionModuleBuilder *moduleb, MonoReflectionType *type);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7285,11 +7285,11 @@ mono_string_to_utf8_internal (MonoMemPool *mp, MonoImage *image, MonoString *s, 
  * Same as mono_string_to_utf8, but allocate the string from the image mempool.
  */
 char *
-mono_string_to_utf8_image (MonoImage *image, MonoString *s, MonoError *error)
+mono_string_to_utf8_image (MonoImage *image, MonoStringHandle s, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	return mono_string_to_utf8_internal (NULL, image, s, FALSE, error);
+	return mono_string_to_utf8_internal (NULL, image, MONO_HANDLE_RAW (s), FALSE, error); /* FIXME pin the string */
 }
 
 /**

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -87,6 +87,7 @@ cache_object_handle (MonoDomain *domain, MonoClass *klass, gpointer item, MonoOb
 }
 
 #define CACHE_OBJECT(t,p,o,k) ((t) (cache_object (domain, (k), (p), (o))))
+#define CACHE_OBJECT_HANDLE(t,p,o,k) ((t) (cache_object_handle (domain, (k), (p), (o))))
 
 static inline MonoObjectHandle
 check_object_handle (MonoDomain* domain, MonoClass *klass, gpointer item)

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -13,10 +13,13 @@
 #include <mono/utils/mono-error.h>
 
 gboolean
-mono_reflection_is_usertype (MonoReflectionType *ref);
+mono_reflection_is_usertype (MonoReflectionTypeHandle ref);
 
 MonoReflectionType*
 mono_reflection_type_resolve_user_types (MonoReflectionType *type, MonoError *error);
+
+MonoType *
+mono_reflection_type_handle_mono_type (MonoReflectionTypeHandle ref_type, MonoError *error);
 
 MonoType*
 mono_reflection_get_type_checked (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, mono_bool ignorecase, mono_bool *type_resolve, MonoError *error);

--- a/mono/metadata/sre-internals.h
+++ b/mono/metadata/sre-internals.h
@@ -42,7 +42,7 @@ typedef struct {
 	/* for PInvoke */
 	int charset, extra_flags, native_cc;
 	MonoString *dll, *dllentry;
-} ReflectionMethodBuilder;
+} ReflectionMethodBuilder; /* FIXME raw pointers to managed objects */
 
 void
 mono_reflection_emit_init (void);
@@ -76,6 +76,8 @@ mono_is_sr_mono_property (MonoClass *klass);
 
 gpointer
 mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
+
+MonoType* mono_type_array_get_and_resolve (MonoArrayHandle array, int idx, MonoError* error);
 
 void
 mono_sre_array_method_free (ArrayMethod *am);
@@ -124,7 +126,7 @@ guint32
 mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *type, gboolean try_typespec);
 
 guint32
-mono_dynimage_encode_reflection_sighelper (MonoDynamicImage *assembly, MonoReflectionSigHelper *helper,
+mono_dynimage_encode_reflection_sighelper (MonoDynamicImage *assembly, MonoReflectionSigHelperHandle helper,
 					   MonoError *error);
 
 /* sre-encode, without DISABLE_REFLECTION_EMIT_SAVE (o.w. g_assert_not_reached ()) */


### PR DESCRIPTION
* Convert ves_icall_RuntimeType_MakeGenericType to use handles.
* The above necessitates converting mono_reflection_bind_generic_parameters and
  mono_reflection_type_get_handle (renamed to
  mono_reflection_type_handle_mono_type) to use handles.
* From there we have to touch a lot of builder internals:
  - ves_icall_DynamicMethod_create_dynamic_method
  - ves_icall_ModuleBuilder_RegisterToken
  - ves_icall_ModuleBuilder_basic_init
  - ves_icall_ModuleBuilder_getMethodToken
  - ves_icall_ModuleBuilder_getToken
  - ves_icall_ModuleBuilder_getUSIndex
  - ves_icall_TypeBuilder_create_runtime_class
* As well as runtime functions
  - mono_image_insert_string
  - mono_image_create_token
  - mono_class_{get,has,set}_ref_info
  - mono_reflection_is_usertype
  - mono_dynimage_encode_reflection_sighelper
  - mono_dynamic_image_register_token
