### PR TITLE
Fix gdb render

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -925,6 +925,7 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 	return;
 
 exec:
+	fclose (commands);
 	execv (argv [0], (char**)argv);
 
 	_exit (-1);

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -899,7 +899,7 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 
 	commands = fopen (commands_filename, "w");
 	if (!commands) {
-	unlink (commands_filename);
+		unlink (commands_filename);
 		return;
 	}
 


### PR DESCRIPTION
close file stream before `exec`ing into GDB/LLDB otherwise it isn't ensured that the content is written to the file.

/cc @ludovic-henry @kumpera 