### PR TITLE
[mini] Add new JIT flag JIT_FLAG_DISCARD_RESULTS to reduce the noise when profiling the jit with --compile-all.

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -956,7 +956,7 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 			g_print ("Compiling %d %s\n", count, desc);
 			g_free (desc);
 		}
-		cfg = mini_method_compile (method, mono_get_optimizations_for_method (method, args->opts), mono_get_root_domain (), (JitFlags)0, 0, -1);
+		cfg = mini_method_compile (method, mono_get_optimizations_for_method (method, args->opts), mono_get_root_domain (), (JitFlags)JIT_FLAG_DISCARD_RESULTS, 0, -1);
 		if (cfg->exception_type != MONO_EXCEPTION_NONE) {
 			printf ("Compilation of %s failed with exception '%s':\n", mono_method_full_name (cfg->method, TRUE), cfg->exception_message);
 			fail_count ++;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3895,7 +3895,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		g_free (id);
 	}
 
-	if (!cfg->compile_aot) {
+	if (!cfg->compile_aot && !(flags & JIT_FLAG_DISCARD_RESULTS)) {
 		mono_domain_lock (cfg->domain);
 		mono_jit_info_table_add (cfg->domain, cfg->jit_info);
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1527,7 +1527,9 @@ typedef enum {
 	/* Whenever to compile in llvm-only mode */
 	JIT_FLAG_LLVM_ONLY = (1 << 6),
 	/* Whenever calls to pinvoke functions are made directly */
-	JIT_FLAG_DIRECT_PINVOKE = (1 << 7)
+	JIT_FLAG_DIRECT_PINVOKE = (1 << 7),
+	/* Whenever this is a compile-all run and the result should be discarded */
+	JIT_FLAG_DISCARD_RESULTS = (1 << 8),
 } JitFlags;
 
 /* Bit-fields in the MonoBasicBlock.region */


### PR DESCRIPTION
JI registration dominates profiling as it has some perf issues itself.