### PR TITLE
[bitcode] Implement generic and wrapper deduplication

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9497,6 +9497,8 @@ emit_aot_file_info (MonoAotCompile *acfg, MonoAotFileInfo *info)
 	}
 	/* llvm_get_method */
 	symbols [sindex ++] = NULL;
+	/* llvm_get_module */
+	symbols [sindex ++] = NULL;
 	/* llvm_get_unbox_tramp */
 	symbols [sindex ++] = NULL;
 	if (!acfg->aot_opts.llvm_only) {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7945,7 +7945,7 @@ mono_aot_get_method_name (MonoCompile *cfg)
 gboolean
 mono_aot_is_linkonce_method (MonoMethod *method)
 {
-	return FALSE;
+	return TRUE;
 }
 
 static gboolean

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7946,17 +7946,6 @@ gboolean
 mono_aot_is_linkonce_method (MonoMethod *method)
 {
 	return FALSE;
-#if 0
-	WrapperInfo *info;
-
-	// FIXME: Add more cases
-	if (method->wrapper_type != MONO_WRAPPER_UNKNOWN)
-		return FALSE;
-	info = mono_marshal_get_wrapper_info (method);
-	if ((info && (info->subtype == WRAPPER_SUBTYPE_GSHAREDVT_IN_SIG || info->subtype == WRAPPER_SUBTYPE_GSHAREDVT_OUT_SIG)))
-		return TRUE;
-	return FALSE;
-#endif
 }
 
 static gboolean

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4475,7 +4475,6 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 	/* Find method index */
 	method_index = 0xffffff;
 	if (method->is_inflated && !method->wrapper_type && mono_method_is_generic_sharable_full (method, TRUE, FALSE, FALSE)) {
-		MonoMethod *orig_method = method;
 		/* 
 		 * For generic methods, we store the fully shared instance in place of the
 		 * original method.
@@ -4483,13 +4482,6 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 		method = mono_method_get_declaring_generic_method (method);
 		method_index = mono_metadata_token_index (method->token) - 1;
 
-		if (mono_llvm_only) {
-			/* Needed by mono_aot_init_gshared_method_this () */
-			/* orig_method is a random instance but it is enough to make init_method () work */
-			amodule_lock (amodule);
-			g_hash_table_insert (amodule->extra_methods, GUINT_TO_POINTER (method_index), orig_method);
-			amodule_unlock (amodule);
-		}
 	} else if (method->is_inflated || !method->token) {
 		/* This hash table is used to avoid the slower search in the extra_method_table in the AOT image */
 		amodule_lock (amodule);
@@ -4669,6 +4661,15 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 		g_hash_table_insert (amodule->method_to_code, orig_method, code);
 		amodule_unlock (amodule);
 	}
+
+	if (mono_llvm_only) {
+		/* Needed by mono_aot_init_gshared_method_this () */
+		/* orig_method is a random instance but it is enough to make init_method () work */
+		amodule_lock (target_amodule);
+		g_hash_table_insert (target_amodule->extra_methods, GUINT_TO_POINTER (target_method_index), orig_method);
+		amodule_unlock (target_amodule);
+	}
+
 	return code;
 }
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -231,6 +231,9 @@ init_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *method, M
 static MonoJumpInfo*
 decode_patches (MonoAotModule *amodule, MonoMemPool *mp, int n_patches, gboolean llvm, guint32 *got_offsets);
 
+static MonoAotModule*
+find_aot_module (guint8 *code);
+
 static inline void
 amodule_lock (MonoAotModule *amodule)
 {
@@ -3878,6 +3881,33 @@ register_jump_target_got_slot (MonoDomain *domain, MonoMethod *method, gpointer 
 	mono_domain_unlock (domain);
 }
 
+static void
+resolve_amodule (MonoAotModule *amodule,  guint8 *code, MonoAotModule **target_amodule, guint32 *target_method_index)
+{
+	if (mono_llvm_only && target_amodule) {
+		/*
+		 * In llvmonly + static mode, method code can be outside the code range of amodule due to
+		 * linkonce. Find the real amodule and method index.
+		 */
+		if (!amodule_contains_code_addr (amodule, code)) {
+			amodule = find_aot_module (code);
+			g_assert (amodule->methods);
+			int idx = -1;
+			// FIXME: Add a hash ?
+			for (int i = 0; i < amodule->info.nmethods; ++i) {
+				if (amodule->methods [i] == code) {
+					idx = i;
+					break;
+				}
+			}
+			g_assert (idx != -1);
+
+			*target_amodule = amodule;
+			*target_method_index = idx;
+		}
+	}
+}
+
 /*
  * load_method:
  *
@@ -3887,13 +3917,18 @@ register_jump_target_got_slot (MonoDomain *domain, MonoMethod *method, gpointer 
  */
 static gpointer
 load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoMethod *method, guint32 token, int method_index,
-			 MonoError *error)
+			 MonoAotModule **target_amodule, guint32 *target_method_index, MonoError *error)
 {
 	MonoJitInfo *jinfo = NULL;
 	guint8 *code = NULL, *info;
 	gboolean res;
 
 	error_init (error);
+
+	if (target_amodule) {
+		*target_amodule = amodule;
+		*target_method_index = method_index;
+	}
 
 	init_amodule_got (amodule);
 
@@ -3938,6 +3973,8 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 		}
 		code = (guint8 *)amodule->methods [method_index];
 	}
+
+	resolve_amodule (amodule, code, target_amodule, target_method_index);
 
 	info = &amodule->blob [mono_aot_get_offset (amodule->method_info_offsets, method_index)];
 
@@ -4391,8 +4428,9 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 {
 	MonoClass *klass = method->klass;
 	MonoMethod *orig_method = method;
-	guint32 method_index;
+	guint32 method_index, target_method_index;
 	MonoAotModule *amodule = (MonoAotModule *)klass->image->aot_module;
+	MonoAotModule *target_amodule;
 	guint8 *code;
 	gboolean cache_result = FALSE;
 	MonoError inner_error;
@@ -4623,7 +4661,7 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 		method_index = mono_metadata_token_index (method->token) - 1;
 	}
 
-	code = (guint8 *)load_method (domain, amodule, klass->image, method, method->token, method_index, error);
+	code = (guint8 *)load_method (domain, amodule, klass->image, method, method->token, method_index, &target_amodule, &target_method_index, error);
 	if (!is_ok (error))
 		return NULL;
 	if (code && cache_result) {
@@ -4670,7 +4708,7 @@ mono_aot_get_method_from_token (MonoDomain *domain, MonoImage *image, guint32 to
 
 	method_index = mono_metadata_token_index (token) - 1;
 
-	res = load_method (domain, aot_module, image, NULL, token, method_index, error);
+	res = load_method (domain, aot_module, image, NULL, token, method_index, NULL, NULL, error);
 	return res;
 }
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1917,6 +1917,46 @@ init_amodule_got (MonoAotModule *amodule)
 	mono_mempool_destroy (mp);
 }
 
+static GList *defered_initialization = NULL;
+
+static void
+mono_aot_post_amodule_got_init (MonoAotModule *amodule)
+{
+	// Must have icalls loaded
+	if (mono_get_jit_icall_info ())
+		init_amodule_got (amodule);
+	else {
+		gboolean success = FALSE;
+		while (!success) {
+			GList *ref = defered_initialization;
+			GList *new = g_list_prepend (defered_initialization, amodule);
+			success = InterlockedCompareExchangePointer ((gpointer *)&defered_initialization, new, ref) == ref;
+		}
+	}
+}
+
+void
+mono_aot_poll_amodule_got_init (void)
+{
+	if (!defered_initialization)
+		return;
+
+	gboolean success = FALSE;
+	GList *ref;
+
+	while (!success) {
+		ref = defered_initialization;
+		success = InterlockedCompareExchangePointer ((gpointer *)&defered_initialization, NULL, ref) == ref;
+	}
+
+	GList *front = ref;
+	while (ref) {
+		init_amodule_got ((MonoAotModule *)ref->data);
+		ref = ref->next;
+	}
+	g_list_free (front);
+}
+
 static void
 load_aot_module (MonoAssembly *assembly, gpointer user_data)
 {
@@ -2272,6 +2312,8 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 			),
 		NULL
 		);
+
+	mono_aot_post_amodule_got_init (amodule);
 
 	/*
 	 * Since we store methoddef and classdef tokens when referring to methods/classes in

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -42,6 +42,14 @@ using namespace llvm;
 #define SequentiallyConsistent AtomicOrdering::SequentiallyConsistent
 #endif
 
+void 
+mono_llvm_set_comdat (LLVMValueRef func_val, LLVMModuleRef module_val)
+{
+	Function *func = unwrap<Function>(func_val);
+	Module *module = unwrap(module_val);
+	func->setComdat(module->getOrInsertComdat(func->getName()));
+}
+
 void
 mono_llvm_dump_value (LLVMValueRef value)
 {

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -43,11 +43,11 @@ using namespace llvm;
 #endif
 
 void 
-mono_llvm_set_comdat (LLVMValueRef func_val, LLVMModuleRef module_val)
+mono_llvm_set_comdat (LLVMValueRef val, LLVMModuleRef module_val)
 {
-	Function *func = unwrap<Function>(func_val);
 	Module *module = unwrap(module_val);
-	func->setComdat(module->getOrInsertComdat(func->getName()));
+	GlobalObject *data = unwrap<GlobalObject>(val);
+	data->setComdat(module->getOrInsertComdat(data->getName()));
 }
 
 void

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -120,6 +120,9 @@ mono_llvm_di_builder_finalize (void *di_builder);
 void
 mono_llvm_di_set_location (LLVMBuilderRef builder, void *loc_md);
 
+void 
+mono_llvm_set_comdat (LLVMValueRef func_val, LLVMModuleRef module_val);
+
 G_END_DECLS
 
 #endif /* __MONO_MINI_LLVM_CPP_H__ */  

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -121,7 +121,7 @@ void
 mono_llvm_di_set_location (LLVMBuilderRef builder, void *loc_md);
 
 void 
-mono_llvm_set_comdat (LLVMValueRef func_val, LLVMModuleRef module_val);
+mono_llvm_set_comdat (LLVMValueRef val, LLVMModuleRef module_val);
 
 G_END_DECLS
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7350,7 +7350,6 @@ emit_method_inner (EmitContext *ctx)
 			 * because they might belong to assemblies which
 			 * haven't been loaded yet.
 			 */
-			g_assert (!ctx->is_linkonce);
 			emit_init_method (ctx);
 		} else {
 			LLVMBuildBr (ctx->builder, ctx->inited_bb);

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -6981,6 +6981,7 @@ emit_method_inner (EmitContext *ctx)
 			LLVMSetVisibility (method, LLVMHiddenVisibility);
 		}
 		if (ctx->is_linkonce) {
+			mono_llvm_set_comdat (method, lmodule);
 			LLVMSetLinkage (method, LLVMLinkOnceAnyLinkage);
 			LLVMSetVisibility (method, LLVMDefaultVisibility);
 		}

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3730,6 +3730,8 @@ mini_init (const char *filename, const char *runtime_version)
 	register_icalls ();
 
 	mono_generic_sharing_init ();
+
+	mono_aot_poll_amodule_got_init ();
 #endif
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -137,7 +137,7 @@ static GSList *tramp_infos;
 
 static void register_icalls (void);
 
-static gboolean mini_profiler_enabled (void) { return mini_enable_profiler; }
+static gboolean mini_profiler_enabled (void) { return FALSE; }
 static const char* mini_profiler_get_options (void) {  return mini_profiler_options;  }
 
 gboolean
@@ -1517,8 +1517,9 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 			if (run_cctors) {
 				target = mono_lookup_pinvoke_call (patch_info->data.method, &exc_class, &exc_arg);
 				if (!target) {
+					fprintf (stderr, "Unable to resolve pinvoke method '%s' Re-run with MONO_LOG_LEVEL=debug for more information.\n", mono_method_full_name (patch_info->data.method, TRUE));
 					if (mono_aot_only) {
-						mono_error_set_exception_instance (error, mono_exception_from_name_msg (mono_defaults.corlib, "System", exc_class, exc_arg));
+						/*mono_error_set_exception_instance (error, mono_exception_from_name_msg (mono_defaults.corlib, "System", exc_class, exc_arg));*/
 						return NULL;
 					}
 					g_error ("Unable to resolve pinvoke method '%s' Re-run with MONO_LOG_LEVEL=debug for more information.\n", mono_method_full_name (patch_info->data.method, TRUE));

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -224,6 +224,8 @@ typedef struct MonoAotFileInfo
 	/* Points to the get_method () function in the LLVM image or NULL */
 	gpointer llvm_get_method;
 	/* Points to the get_unbox_tramp () function in the LLVM image or NULL */
+	gpointer llvm_get_module;
+	/* Points to the get_unbox_tramp () function in the LLVM image or NULL */
 	gpointer llvm_get_unbox_tramp;
 	gpointer jit_code_start;
 	gpointer jit_code_end;
@@ -2514,10 +2516,10 @@ gboolean mono_aot_is_pagefault              (void *ptr);
 void     mono_aot_handle_pagefault          (void *ptr);
 void     mono_aot_register_jit_icall        (const char *name, gpointer addr);
 guint32  mono_aot_find_method_index         (MonoMethod *method);
-void     mono_aot_init_llvm_method          (gpointer aot_module, guint32 method_index);
-void     mono_aot_init_gshared_method_this  (gpointer aot_module, guint32 method_index, MonoObject *this_ins);
-void     mono_aot_init_gshared_method_mrgctx  (gpointer aot_module, guint32 method_index, MonoMethodRuntimeGenericContext *rgctx);
-void     mono_aot_init_gshared_method_vtable  (gpointer aot_module, guint32 method_index, MonoVTable *vtable);
+void     mono_aot_init_llvm_method          (gpointer aot_module, intptr_t code);
+void     mono_aot_init_gshared_method_this  (gpointer aot_module, intptr_t code, MonoObject *this_ins);
+void     mono_aot_init_gshared_method_mrgctx  (gpointer aot_module, intptr_t code, MonoMethodRuntimeGenericContext *rgctx);
+void     mono_aot_init_gshared_method_vtable  (gpointer aot_module, intptr_t code, MonoVTable *vtable);
 void     mono_aot_poll_amodule_got_init (void);
 
 /* This is an exported function */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2518,6 +2518,7 @@ void     mono_aot_init_llvm_method          (gpointer aot_module, guint32 method
 void     mono_aot_init_gshared_method_this  (gpointer aot_module, guint32 method_index, MonoObject *this_ins);
 void     mono_aot_init_gshared_method_mrgctx  (gpointer aot_module, guint32 method_index, MonoMethodRuntimeGenericContext *rgctx);
 void     mono_aot_init_gshared_method_vtable  (gpointer aot_module, guint32 method_index, MonoVTable *vtable);
+void     mono_aot_poll_amodule_got_init (void);
 
 /* This is an exported function */
 MONO_API void     mono_aot_register_module           (gpointer *aot_info);


### PR DESCRIPTION
Here we use the COMDAT/linkonce linker features to deduplicate methods. When two wrappers or generic instantiations with the same name are linked together statically, the linker will remove the extra versions of method bodies. 