### PR TITLE
[runtime] A pair of small fixes for the ignore assembly work.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5286,7 +5286,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 	replace_shadow_path (mono_domain_get (), dirname, &filename);
 	g_free (dirname);
 
-	image = mono_image_open (filename, &status);
+	image = mono_image_open_full (filename, &status, TRUE);
 
 	if (!image){
 		if (status == MONO_IMAGE_IMAGE_INVALID)

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1229,7 +1229,7 @@ do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
 	if (!mono_image_load_cli_data (image))
 		goto invalid_image;
 
-	if (is_problematic_image (image)) {
+	if (!image->ref_only && is_problematic_image (image)) {
 		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Denying load of problematic image %s", image->name);
 		*status = MONO_IMAGE_IMAGE_INVALID;
 		goto invalid_image;


### PR DESCRIPTION
image.c (do_mono_image_load): Ignore refonly images when checking for ignorable assemblies.

icall.c (ves_icall_System_Reflection_Assembly_InternalGetAssemblyName): Load the image in ref only mode.