### PR TITLE
Clear the recording list when a domain is unloaded.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2566,6 +2566,8 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 		}
 	}
 
+	mono_clear_gclass_recording ();
+
 	mono_domain_set (domain, FALSE);
 	/* Notify OnDomainUnload listeners */
 	method = mono_class_get_method_from_name (domain->domain->mbr.obj.vtable->klass, "DoDomainUnload", -1);	

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -163,6 +163,28 @@ disable_gclass_recording (gclass_record_func func, void *user_data)
 }
 
 /**
+* mono_clear_gclass_recording:
+*
+* Removes all entries from the glcass_recorded_list and resets the number
+* of instantiations. This is necessary when an app domain is unloaded,
+* so that data from that app domain is not used later (via this list) when
+* it is no longer valid.
+*/
+void
+mono_clear_gclass_recording ()
+{
+	mono_loader_lock ();
+
+	if (gclass_recorded_list) {
+		g_slist_free (gclass_recorded_list);
+		gclass_recorded_list = NULL;
+		record_gclass_instantiation = 0;
+	}
+
+	mono_loader_unlock ();
+}
+
+/**
  * mono_class_from_typeref:
  * @image: a MonoImage
  * @type_token: a TypeRef token

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -268,6 +268,9 @@ mono_method_can_access_field (MonoMethod *method, MonoClassField *field);
 MONO_API mono_bool
 mono_method_can_access_method (MonoMethod *method, MonoMethod *called);
 
+void
+mono_clear_gclass_recording ();
+
 MONO_END_DECLS
 
 #endif /* _MONO_CLI_CLASS_H_ */


### PR DESCRIPTION
Anything left on the recording list when a domain is unloaded won't be
valid after the domain unload, so clear this list. This prevents a crash
when the Unity editor unloads the domain to load certain projects.