### PR TITLE
[mono-sha1] make SHA1Transform thread-safe

### DIFF
--- a/mono/utils/mono-sha1.c
+++ b/mono/utils/mono-sha1.c
@@ -147,7 +147,7 @@ typedef union {
 } CHAR64LONG16;
 CHAR64LONG16* block;
 #ifdef SHA1HANDSOFF
-static unsigned char workspace[64];
+    unsigned char workspace[64];
     block = (CHAR64LONG16*)workspace;
     memcpy(block, buffer, 64);
 #else


### PR DESCRIPTION
should fix https://bugzilla.xamarin.com/show_bug.cgi?id=41133

The bug exposed itself as System.MethodAccessExceptionMethod which is
thrown when a method isn't allowed to call another method.  Several
things are checked for this: Among other things, the runtime checks if
the public key in the friend list of the caller assembly matches the
public key in the callee assembly.

The issue here was that two threads computed the SHA1 at the same time,
using the same buffer and therefore computing garbage.