### PR TITLE
[sgen] Don't assert when suspending detaching thread

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2871,7 +2871,6 @@ mono_thread_state_init_from_sigctx (MonoThreadUnwindState *ctx, void *sigctx)
 	MonoThreadInfo *thread = mono_thread_info_current_unchecked ();
 	if (!thread) {
 		ctx->valid = FALSE;
-		g_error ("Invoked mono_thread_state_init_from_sigctx from non-Mono thread");
 		return FALSE;
 	}
 


### PR DESCRIPTION
This means that the thread will be part of the stw (not skipped), so if the stack pointer is not between the expected ranges we don't scan the thread. In other parts of the runtime, suspending here is handled by the suspend_can_continue flag.