### PR TITLE
[sgen] Add option to dump heap on OOM.

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -232,6 +232,7 @@ static gboolean disable_minor_collections = FALSE;
 static gboolean disable_major_collections = FALSE;
 static gboolean do_verify_nursery = FALSE;
 static gboolean do_dump_nursery_content = FALSE;
+static gboolean do_dump_on_oom = FALSE;
 static gboolean enable_nursery_canaries = FALSE;
 
 static gboolean precleaning_enabled = TRUE;
@@ -321,6 +322,12 @@ gboolean
 nursery_canaries_enabled (void)
 {
 	return enable_nursery_canaries;
+}
+
+gboolean
+dump_on_oom_enabled (void)
+{
+	return do_dump_on_oom;
 }
 
 #define safe_object_get_size	sgen_safe_object_get_size
@@ -3087,6 +3094,8 @@ sgen_gc_init (void)
 				do_concurrent_checks = TRUE;
 			} else if (!strcmp (opt, "dump-nursery-at-minor-gc")) {
 				do_dump_nursery_content = TRUE;
+			} else if (!strcmp (opt, "dump-on-oom")) {
+				do_dump_on_oom = TRUE;
 			} else if (!strcmp (opt, "disable-minor")) {
 				disable_minor_collections = TRUE;
 			} else if (!strcmp (opt, "disable-major")) {
@@ -3126,6 +3135,7 @@ sgen_gc_init (void)
 				fprintf (stderr, "  verify-before-collections\n");
 				fprintf (stderr, "  verify-nursery-at-minor-gc\n");
 				fprintf (stderr, "  dump-nursery-at-minor-gc\n");
+				fprintf (stderr, "  dump-on-oom\n");
 				fprintf (stderr, "  disable-minor\n");
 				fprintf (stderr, "  disable-major\n");
 				fprintf (stderr, "  check-concurrent\n");

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -1035,6 +1035,8 @@ void sgen_env_var_error (const char *env_var, const char *fallback, const char *
 void sgen_qsort (void *array, size_t count, size_t element_size, int (*compare) (const void*, const void*));
 gint64 sgen_timestamp (void);
 
+gboolean dump_on_oom_enabled (void);
+
 /*
  * Canary (guard word) support
  * Notes:


### PR DESCRIPTION
Tiny proof of concept, currently requires running with `MONO_GC_DEBUG=heap-dump=<path>,dump-on-oom`. This doesn’t dump much useful information—I was thinking of trying to get a heap snapshot, but I don’t yet know how easy that will be.