### PR TITLE
[coop handles] Handles for valuetype refs

### DIFF
--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -56,17 +56,21 @@ typedef struct _HandleChunk HandleChunk;
 /* #define MONO_HANDLE_TRACK_OWNER */
 
 typedef struct {
-	MonoObject *o; /* handle chunk ptr */
-	guint8 chunk_ptr; /* HANDLE_CHUNK_PTR_XXX */
+	gpointer o; /* MonoObject ptr or interior ptr */
 #ifdef MONO_HANDLE_TRACK_OWNER
 	const char *owner;
 #endif
 } HandleChunkElem;
 
+/* number of guint32's needed to store the interior pointers bitmap */
+#define INTERIOR_HANDLE_BITMAP_WORDS ((OBJECTS_PER_HANDLES_CHUNK + 31) / 32)
+
 struct _HandleChunk {
-	int size; //number of bytes
+	int size; //number of handles
+	/* bits in the range 0..size-1 of interior_bitmap are valid; rest are ignored. */
+	guint32 interior_bitmap [INTERIOR_HANDLE_BITMAP_WORDS];
 	HandleChunk *prev, *next;
-	HandleChunkElem objects [OBJECTS_PER_HANDLES_CHUNK];
+	HandleChunkElem elems [OBJECTS_PER_HANDLES_CHUNK];
 };
 
 typedef struct {

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -629,14 +629,14 @@ HANDLES(ICALL(MMETH_9, "get_name", ves_icall_MonoMethod_get_name))
 
 ICALL_TYPE(MMETHI, "System.Reflection.MonoMethodInfo", MMETHI_4)
 ICALL(MMETHI_4, "get_method_attributes", vell_icall_get_method_attributes)
-ICALL(MMETHI_1, "get_method_info", ves_icall_get_method_info)
+HANDLES(ICALL(MMETHI_1, "get_method_info", ves_icall_get_method_info))
 HANDLES(ICALL(MMETHI_2, "get_parameter_info", ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info))
 HANDLES(ICALL(MMETHI_3, "get_retval_marshal", ves_icall_System_MonoMethodInfo_get_retval_marshal))
 
 ICALL_TYPE(MPROPI, "System.Reflection.MonoPropertyInfo", MPROPI_1)
 HANDLES(ICALL(MPROPI_1, "GetTypeModifiers", ves_icall_MonoPropertyInfo_GetTypeModifiers))
 ICALL(MPROPI_3, "get_default_value", property_info_get_default_value)
-ICALL(MPROPI_2, "get_property_info", ves_icall_MonoPropertyInfo_get_property_info)
+HANDLES(ICALL(MPROPI_2, "get_property_info", ves_icall_MonoPropertyInfo_get_property_info))
 
 ICALL_TYPE(PARAMI, "System.Reflection.ParameterInfo", PARAMI_1)
 HANDLES(ICALL(PARAMI_1, "GetMetadataToken", ves_icall_reflection_get_token))

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -352,7 +352,7 @@ mono_marshal_init (void)
 		register_icall (mono_threads_detach_coop, "mono_threads_detach_coop", "void ptr ptr", TRUE);
 		register_icall (mono_icall_start, "mono_icall_start", "ptr ptr ptr", TRUE);
 		register_icall (mono_icall_end, "mono_icall_end", "void ptr ptr ptr", TRUE);
-		register_icall (mono_handle_new, "mono_handle_new", "ptr ptr", TRUE);
+		register_icall (mono_handle_new_full, "mono_handle_new_full", "ptr ptr bool", TRUE);
 
 		mono_cominterop_init ();
 		mono_remoting_init ();
@@ -7492,6 +7492,44 @@ emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 }
 
+/* How the arguments of an icall should be wrapped */
+typedef enum {
+	/* Don't wrap at all, pass the argument as is */
+	ICALL_HANDLES_WRAP_NONE,
+	/* Wrap the argument in an object handle, pass the handle to the icall */
+	ICALL_HANDLES_WRAP_OBJ,
+	/* Wrap the argument in an object handle, pass the handle to the icall,
+	   write the value out from the handle when the icall returns */
+	ICALL_HANDLES_WRAP_OBJ_INOUT,
+	/* Wrap the argument (a valuetype reference) in a handle to pin its enclosing object,
+	   but pass the raw reference to the icall */
+	ICALL_HANDLES_WRAP_VALUETYPE_REF,
+} IcallHandlesWrap;
+
+typedef struct {
+	IcallHandlesWrap wrap;
+	/* if wrap is NONE or OBJ or VALUETYPE_REF, this is not meaningful.
+	   if wrap is OBJ_INOUT it's the local var that holds the MonoObjectHandle.
+	*/
+	int handle;
+}  IcallHandlesLocal;
+
+/*
+ * Describes how to wrap the given parameter.
+ *
+ */
+static IcallHandlesWrap
+signature_param_uses_handles (MonoMethodSignature *sig, int param)
+{
+	if (MONO_TYPE_IS_REFERENCE (sig->params [param])) {
+		return mono_signature_param_is_out (sig, param) ? ICALL_HANDLES_WRAP_OBJ_INOUT : ICALL_HANDLES_WRAP_OBJ;
+	} else if (mono_type_is_byref (sig->params [param]))
+		return ICALL_HANDLES_WRAP_VALUETYPE_REF;
+	else
+		return ICALL_HANDLES_WRAP_NONE;
+}
+
+
 #ifndef DISABLE_JIT
 /**
  * mono_marshal_emit_native_wrapper:
@@ -7944,8 +7982,8 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 		int thread_info_var = -1, stack_mark_var = -1, error_var = -1;
 		MonoMethodSignature *call_sig = csig;
 		gboolean uses_handles = FALSE;
-		gboolean has_outarg_handles = FALSE;
-		int *outarg_handle = NULL;
+		gboolean save_handles_to_locals = FALSE;
+		IcallHandlesLocal *handles_locals = NULL;
 		(void) mono_lookup_internal_call_full (method, &uses_handles);
 
 
@@ -7955,21 +7993,33 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 		if (uses_handles) {
 			MonoMethodSignature *ret;
 
-			/* Add a MonoError argument */
+			/* Add a MonoError argument and figure out which args need to be wrapped in handles */
 			// FIXME: The stuff from mono_metadata_signature_dup_internal_with_padding ()
 			ret = mono_metadata_signature_alloc (method->klass->image, csig->param_count + 1);
 
 			ret->param_count = csig->param_count + 1;
 			ret->ret = csig->ret;
+
+			handles_locals = g_new0 (IcallHandlesLocal, csig->param_count);
 			for (int i = 0; i < csig->param_count; ++i) {
-				if (MONO_TYPE_IS_REFERENCE (csig->params[i])) {
+				IcallHandlesWrap w = signature_param_uses_handles (csig, i);
+				handles_locals [i].wrap = w;
+				switch (w) {
+				case ICALL_HANDLES_WRAP_OBJ:
+				case ICALL_HANDLES_WRAP_OBJ_INOUT:
 					ret->params [i] = mono_class_get_byref_type (mono_class_from_mono_type(csig->params[i]));
-					if (mono_signature_param_is_out (csig, i)) {
-						has_outarg_handles = TRUE;
-					}
-				} else
+					if (w == ICALL_HANDLES_WRAP_OBJ_INOUT)
+						save_handles_to_locals = TRUE;
+					break;
+				case ICALL_HANDLES_WRAP_NONE:
+				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
 					ret->params [i] = csig->params [i];
+					break;
+				default:
+					g_assert_not_reached ();
+				}
 			}
+			/* Add MonoError* param */
 			ret->params [csig->param_count] = &mono_get_intptr_class ()->byval_arg;
 			ret->pinvoke = csig->pinvoke;
 
@@ -7984,15 +8034,22 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 			stack_mark_var = mono_mb_add_local (mb, &handle_stack_mark_class->byval_arg);
 			error_var = mono_mb_add_local (mb, &error_class->byval_arg);
 
-			if (has_outarg_handles) {
-				outarg_handle = g_new0 (int, sig->param_count);
-
+			if (save_handles_to_locals) {
 				/* add a local var to hold the handles for each out arg */
 				for (int i = 0; i < sig->param_count; ++i) {
-					if (mono_signature_param_is_out (sig, i) && MONO_TYPE_IS_REFERENCE (sig->params[i])) {
-						outarg_handle[i] = mono_mb_add_local (mb, sig->params[i]);
-					} else if (outarg_handle != NULL)
-						outarg_handle[i] = -1;
+					int j = i + sig->hasthis;
+					switch (handles_locals[j].wrap) {
+					case ICALL_HANDLES_WRAP_NONE:
+					case ICALL_HANDLES_WRAP_OBJ:
+					case ICALL_HANDLES_WRAP_VALUETYPE_REF:
+						handles_locals [j].handle = -1;
+						break;
+					case ICALL_HANDLES_WRAP_OBJ_INOUT:
+						handles_locals [j].handle = mono_mb_add_local (mb, sig->params [i]);
+						break;
+					default:
+						g_assert_not_reached ();
+					}
 				}
 			}
 		}
@@ -8018,27 +8075,47 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 
 			if (sig->hasthis) {
 				mono_mb_emit_byte (mb, CEE_LDARG_0);
-				mono_mb_emit_icall (mb, mono_handle_new);
+				/* TODO support adding wrappers to non-static struct methods */
+				g_assert (!mono_class_is_valuetype(mono_method_get_class (method)));
+				mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+				mono_mb_emit_icall (mb, mono_handle_new_full);
 			}
 			for (i = 0; i < sig->param_count; i++) {
-				/* load each argument. object reference arguments get wrapped in handles */
-
-				if (!MONO_TYPE_IS_REFERENCE (sig->params [i])) {
-					mono_mb_emit_ldarg (mb, i + sig->hasthis);
-				} else {
-					if (outarg_handle && outarg_handle[i] != -1) {
-						/* handleI = argI = mono_handle_new (NULL) */
-						mono_mb_emit_byte (mb, CEE_LDNULL);
-						mono_mb_emit_icall (mb, mono_handle_new);
-						/* tmp = argI */
-						mono_mb_emit_byte (mb, CEE_DUP);
-						/* handleI = tmp */
-						mono_mb_emit_stloc (mb, outarg_handle[i]);
-					} else {
-						/* argI = mono_handle_new (argI_raw) */
-						mono_mb_emit_ldarg (mb, i + sig->hasthis);
-						mono_mb_emit_icall (mb, mono_handle_new);
-					}
+				/* load each argument. references into the managed heap get wrapped in handles */
+				int j = i + sig->hasthis;
+				switch (handles_locals[j].wrap) {
+				case ICALL_HANDLES_WRAP_NONE:
+					mono_mb_emit_ldarg (mb, j);
+					break;
+				case ICALL_HANDLES_WRAP_OBJ:
+					/* argI = mono_handle_new_full (argI_raw, FALSE) */
+					mono_mb_emit_ldarg (mb, j);
+					mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+					mono_mb_emit_icall (mb, mono_handle_new_full);
+					break;
+				case ICALL_HANDLES_WRAP_OBJ_INOUT:
+					/* handleI = argI = mono_handle_new_full (NULL, FALSE) */
+					mono_mb_emit_byte (mb, CEE_LDNULL);
+					mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+					mono_mb_emit_icall (mb, mono_handle_new_full);
+					/* tmp = argI */
+					mono_mb_emit_byte (mb, CEE_DUP);
+					/* handleI = tmp */
+					mono_mb_emit_stloc (mb, handles_locals[j].handle);
+					break;
+				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
+					/* (void) mono_handle_new_full (argI, TRUE); argI */
+					mono_mb_emit_ldarg (mb, j);
+					mono_mb_emit_byte (mb, CEE_DUP);
+					mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+					mono_mb_emit_icall (mb, mono_handle_new_full);
+					mono_mb_emit_byte (mb, CEE_POP);
+#if 0
+					fprintf (stderr, " Method %s.%s.%s has byref valuetype argument %d\n", method->klass->name_space, method->klass->name, method->name, i);
+#endif
+					break;
+				default:
+					g_assert_not_reached ();
 				}
 			}
 			mono_mb_emit_ldloc_addr (mb, error_var);
@@ -8069,25 +8146,34 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 				mono_mb_patch_branch (mb, pos);
 			}
-			if (outarg_handle != NULL) {
+			if (save_handles_to_locals) {
 				for (i = 0; i < sig->param_count; i++) {
-					if (outarg_handle[i] != -1) {
+					int j = i + sig->hasthis;
+					switch (handles_locals [j].wrap) {
+					case ICALL_HANDLES_WRAP_NONE:
+					case ICALL_HANDLES_WRAP_OBJ:
+					case ICALL_HANDLES_WRAP_VALUETYPE_REF:
+						break;
+					case ICALL_HANDLES_WRAP_OBJ_INOUT:
 						/* *argI_raw = MONO_HANDLE_RAW (handleI) */
 
 						/* argI_raw */
-						mono_mb_emit_ldarg (mb, i + sig->hasthis);
+						mono_mb_emit_ldarg (mb, j);
 						/* handleI */
-						mono_mb_emit_ldloc (mb, outarg_handle[i]);
+						mono_mb_emit_ldloc (mb, handles_locals [j].handle);
 						/* MONO_HANDLE_RAW(handleI) */
 						mono_mb_emit_ldflda (mb, MONO_HANDLE_PAYLOAD_OFFSET (MonoObject));
 						mono_mb_emit_byte (mb, CEE_LDIND_REF);
 						/* *argI_raw = MONO_HANDLE_RAW(handleI) */
 						mono_mb_emit_byte (mb, CEE_STIND_REF);
+						break;
+					default:
+						g_assert_not_reached ();
 					}
 				}
-				g_free (outarg_handle);
-				outarg_handle = NULL;
 			}
+			g_free (handles_locals);
+
 			mono_mb_emit_ldloc (mb, thread_info_var);
 			mono_mb_emit_ldloc_addr (mb, stack_mark_var);
 			mono_mb_emit_ldloc_addr (mb, error_var);

--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -56,7 +56,7 @@ DECL_SIZE(gpointer)
 DECL_OFFSET(MonoObject, vtable)
 DECL_OFFSET(MonoObject, synchronisation)
 
-DECL_OFFSET(MonoObjectHandlePayload, __obj)
+DECL_OFFSET(MonoObjectHandlePayload, __raw)
 
 DECL_OFFSET(MonoClass, interface_bitmap)
 DECL_OFFSET(MonoClass, byval_arg)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2376,6 +2376,22 @@ mono_gc_scan_object (void *obj, void *gc_data)
 	return obj;
 }
 
+typedef struct {
+	void **start_nursery;
+	void **end_nursery;
+} PinHandleStackInteriorPtrData;
+
+/* Called when we're scanning the handle stack imprecisely and we encounter a pointer into the
+   middle of an object.
+ */
+static void
+pin_handle_stack_interior_ptrs (void **ptr_slot, void *user_data)
+{
+	PinHandleStackInteriorPtrData *ud = (PinHandleStackInteriorPtrData *)user_data;
+	sgen_conservatively_pin_objects_from (ptr_slot, ptr_slot+1, ud->start_nursery, ud->end_nursery, PIN_TYPE_STACK);
+}
+
+
 /*
  * Mark from thread stacks and registers.
  */
@@ -2465,8 +2481,21 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 				}
 			}
 		}
-		if (precise && info->client_info.info.handle_stack) {
-			mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, (GcScanFunc)ctx.ops->copy_or_mark_object, ctx.queue);
+		if (info->client_info.info.handle_stack) {
+			/*
+			  Make two passes over the handle stack.  On the imprecise pass, pin all
+			  objects where the handle points into the interior of the object. On the
+			  precise pass, copy or mark all the objects that have handles to the
+			  beginning of the object.
+			*/
+			if (precise)
+				mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, (GcScanFunc)ctx.ops->copy_or_mark_object, ctx.queue, precise);
+			else {
+				PinHandleStackInteriorPtrData ud = { .start_nursery = start_nursery,
+								     .end_nursery = end_nursery,
+				};
+				mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, pin_handle_stack_interior_ptrs, &ud, precise);
+			}
 		}
 	} FOREACH_THREAD_END
 }


### PR DESCRIPTION
Coop handles
---------------
 There are now 2 kinds of coop handles:
1. Ordinary handles that wrap a pointer to the beginning of a reference object in the managed heap.  This is what we had before.  Nothing changes about how these work.
2. "Interior pointer" handles that wrap a reference to a valuetype that is either on the stack or in the middle of a managed object.

The GC scans the handle stack of each thread twice: the "imprecise pass" and the "precise pass"
1. The precise pass is responsible for the ordinary handles - they are handled as before.
2. The imprecise pass is responsible for the interior pointer handles - if they point into the heap, they are added to the pin queue.

Automatic wrapping of icall arguments
---------------------------------------
There are 4 sorts of icall arguments:
  1. Plain old values like `int`, `bool`, etc.  Passed from the wrapper to the
     icall as is.
  2. Class type arguments in the managed heap.  Passed using ordinary coop handles.
  3. `out` arguments of class type in the managed heap.  A NULL ordinary coop handle is passed in
     and its final value is written back out to the caller's out argument.
  4. Value types passed by `ref` or `out`.  An interior coop handle is created which has
     the effect of pinning the object into which the ref points (if it points
     to the stack, nothign happens).  The argument is passed to the icall as a
     raw reference (`MonoFoo*`, not `MonoFooHandle`).  The ref will be unpinned
     when the icall wrapper returns.
(Only 4 is new, but I took the opportunity to clarify the code a bit)