### PR TITLE
[runtime] Use ins->prev in mono_analyze_liveness.

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -590,6 +590,8 @@ extern const gint8 ins_sreg_counts [];
 
 #define MONO_BB_FOR_EACH_INS_SAFE(bb, n, ins) for ((ins) = (bb)->code, n = (ins) ? (ins)->next : NULL; (ins); (ins) = (n), (n) = (ins) ? (ins)->next : NULL)
 
+#define MONO_BB_FOR_EACH_INS_REVERSE(bb, ins) for ((ins) = (bb)->last_ins; (ins); (ins) = (ins)->prev)
+
 #define MONO_BB_FOR_EACH_INS_REVERSE_SAFE(bb, p, ins) for ((ins) = (bb)->last_ins, p = (ins) ? (ins)->prev : NULL; (ins); (ins) = (p), (p) = (ins) ? (ins)->prev : NULL)
 
 #define mono_bb_first_ins(bb) (bb)->code


### PR DESCRIPTION
Use ins->prev to navigate to the previous instruction in a basic block in mono_analyze_liveness().
As of now, a large array of pointers is allocated and then filled with instructions pointers in reverse order for each basic block, which is not as efficient or intuitive, and also causes unnecessary memory allocations.