### PR TITLE
[profiler] On OSX, don't link against libmonosgen.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3553,9 +3553,10 @@ if test "x$target_mach" = "xyes"; then
           BTLS_SUPPORTED=no
        ])
 	fi
-	AM_CONDITIONAL(TARGET_OSX, test x$target_osx = xyes)
    AC_DEFINE(TARGET_MACH,1,[The JIT/AOT targets Apple platforms])
 fi
+
+AM_CONDITIONAL(TARGET_OSX, test x$target_osx = xyes)
 
 if test "x$sizeof_register" = "x4"; then
    AC_DEFINE(SIZEOF_REGISTER,4,[size of machine integer registers])

--- a/configure.ac
+++ b/configure.ac
@@ -3545,6 +3545,7 @@ if test "x$target_mach" = "xyes"; then
 	   	  AC_DEFINE(TARGET_OSX,1,[The JIT/AOT targets OSX])
           CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_OSX"
           CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_OSX"
+          target_osx=yes
        ], [
           AC_DEFINE(TARGET_IOS,1,[The JIT/AOT targets iOS])
           CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_IOS"
@@ -3552,6 +3553,7 @@ if test "x$target_mach" = "xyes"; then
           BTLS_SUPPORTED=no
        ])
 	fi
+	AM_CONDITIONAL(TARGET_OSX, test x$target_osx = xyes)
    AC_DEFINE(TARGET_MACH,1,[The JIT/AOT targets Apple platforms])
 fi
 

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -38,6 +38,12 @@ prof_ldflags = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
 endif
 endif
 
+if TARGET_OSX
+libmono_dep =
+else
+libmono_dep = $(monodir)/mono/mini/$(LIBMONO_LA)
+endif
+
 if PLATFORM_ANDROID
 prof_ldflags = -avoid-version
 endif
@@ -62,19 +68,19 @@ monodir=$(top_builddir)
 # functionality, so create a separate static version of the library.
 
 libmono_profiler_aot_la_SOURCES = mono-profiler-aot.c
-libmono_profiler_aot_la_LIBADD =  $(monodir)/mono/mini/$(LIBMONO_LA) $(GLIB_LIBS) $(LIBICONV)
+libmono_profiler_aot_la_LIBADD =  $(libmono_dep) $(GLIB_LIBS) $(LIBICONV)
 libmono_profiler_aot_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_aot_static_la_SOURCES = mono-profiler-aot.c
 libmono_profiler_aot_static_la_LDFLAGS = -static
 
 libmono_profiler_iomap_la_SOURCES = mono-profiler-iomap.c
-libmono_profiler_iomap_la_LIBADD = $(monodir)/mono/mini/$(LIBMONO_LA) $(GLIB_LIBS) $(LIBICONV)
+libmono_profiler_iomap_la_LIBADD = $(libmono_dep) $(GLIB_LIBS) $(LIBICONV)
 libmono_profiler_iomap_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_iomap_static_la_SOURCES = mono-profiler-iomap.c
 libmono_profiler_iomap_static_la_LDFLAGS = -static
 
 libmono_profiler_log_la_SOURCES = mono-profiler-log.c
-libmono_profiler_log_la_LIBADD = $(monodir)/mono/mini/$(LIBMONO_LA) $(GLIB_LIBS) $(Z_LIBS)
+libmono_profiler_log_la_LIBADD = $(libmono_dep) $(GLIB_LIBS) $(Z_LIBS)
 libmono_profiler_log_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_log_static_la_SOURCES = mono-profiler-log.c
 libmono_profiler_log_static_la_LDFLAGS = -static


### PR DESCRIPTION
This prevents in-three usage of the profiler.