### PR TITLE
[ppc] Save all the registers in the context

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -786,10 +786,7 @@ if test $csc_compiler = default; then
    if test $endian = big; then
       csc_compiler=mcs
    elif test $endian = little; then
-      case "$host" in
-        powerpc*) csc_compiler=mcs;;
-        *) csc_compiler=roslyn;;
-      esac
+      csc_compiler=roslyn
    else
       csc_compiler=mcs
    fi

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -5810,9 +5810,7 @@ mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 	if (reg == ppc_r1)
 		return (mgreg_t)MONO_CONTEXT_GET_SP (ctx);
 
-	g_assert (reg >= ppc_r13);
-
-	return ctx->regs [reg - ppc_r13];
+	return ctx->regs [reg];
 }
 
 guint32

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -19,6 +19,9 @@
 #define MONO_SAVED_GREGS 19
 #define MONO_SAVED_FREGS 18
 
+#define MONO_PPC_FIRST_SAVED_GREG ppc_r13
+#define MONO_PPC_FIRST_SAVED_FREG ppc_f14
+
 #define MONO_ARCH_FRAME_ALIGNMENT 16
 
 /* fixme: align to 16byte instead of 32byte (we align to 32byte to get 

--- a/mono/utils/mono-context.c
+++ b/mono/utils/mono-context.c
@@ -452,8 +452,9 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 
 	mctx->sc_ir = UCONTEXT_REG_NIP(uc);
 	mctx->sc_sp = UCONTEXT_REG_Rn(uc, 1);
-	memcpy (&mctx->regs, &UCONTEXT_REG_Rn(uc, 13), sizeof (mgreg_t) * MONO_SAVED_GREGS);
-	memcpy (&mctx->fregs, &UCONTEXT_REG_FPRn(uc, 14), sizeof (double) * MONO_SAVED_FREGS);
+
+	memcpy (&mctx->regs, &UCONTEXT_REG_Rn(uc, 0), sizeof (mgreg_t) * MONO_MAX_IREGS);
+	memcpy (&mctx->fregs, &UCONTEXT_REG_FPRn(uc, 0), sizeof (double) * MONO_MAX_FREGS);
 }
 
 void
@@ -461,10 +462,12 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 {
 	os_ucontext *uc = sigctx;
 
+	memcpy (&UCONTEXT_REG_Rn(uc, 0), &mctx->regs, sizeof (mgreg_t) * MONO_MAX_IREGS);
+	memcpy (&UCONTEXT_REG_FPRn(uc, 0), &mctx->fregs, sizeof (double) * MONO_MAX_FREGS);
+
+	/* The valid values for pc and sp are stored here and not in regs array */
 	UCONTEXT_REG_NIP(uc) = mctx->sc_ir;
 	UCONTEXT_REG_Rn(uc, 1) = mctx->sc_sp;
-	memcpy (&UCONTEXT_REG_Rn(uc, 13), &mctx->regs, sizeof (mgreg_t) * MONO_SAVED_GREGS);
-	memcpy (&UCONTEXT_REG_FPRn(uc, 14), &mctx->fregs, sizeof (double) * MONO_SAVED_FREGS);
 }
 
 #endif /* #if defined(__i386__) */

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -493,7 +493,7 @@ typedef struct {
 #define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (gulong)sp; } while (0);
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->sc_ir))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ppc_r31-13]))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ppc_r31]))
 #define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->sc_sp))
 
 #define MONO_CONTEXT_GET_CURRENT(ctx)	\
@@ -584,7 +584,7 @@ typedef struct {
 #define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (mgreg_t)sp; } while (0);
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->sc_ir))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ppc_r31-13]))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ppc_r31]))
 #define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->sc_sp))
 
 #define MONO_CONTEXT_GET_CURRENT(ctx)	\


### PR DESCRIPTION
When suspending a thread, we were only saving the callee save registers in the context. Therefore SGen was failing to pin some objects.