### PR TITLE
[x86] Fix a race in the single stepping seq point assembly, we were d…

### DIFF
--- a/mono/mini/cpu-x86.md
+++ b/mono/mini/cpu-x86.md
@@ -66,7 +66,7 @@ break: len:1
 call: dest:a clob:c len:17
 tailcall: len:120 clob:c
 br: len:5
-seq_point: len:24 clob:c
+seq_point: len:26 clob:c
 il_seq_point: len:0
 
 int_beq: len:6

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -2646,9 +2646,10 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				/* Load ss_tramp_var */
 				/* This is equal to &ss_trampoline */
 				x86_mov_reg_membase (code, X86_ECX, var->inst_basereg, var->inst_offset, sizeof (mgreg_t));
-				x86_alu_membase_imm (code, X86_CMP, X86_ECX, 0, 0);
+				x86_mov_reg_membase (code, X86_ECX, X86_ECX, 0, sizeof (mgreg_t));
+				x86_alu_reg_imm (code, X86_CMP, X86_ECX, 0);
 				br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
-				x86_call_membase (code, X86_ECX, 0);
+				x86_call_reg (code, X86_ECX);
 				x86_patch (br [0], code);
 			}
 


### PR DESCRIPTION
…oing a null check using cmp_membase, following by a call_membase, but the value could change between the two instructions, leading to a nullref. Fixes #50117.