### PR TITLE
[BTLS]: Improve error handling.

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -156,9 +156,20 @@ namespace Mono.Btls
 
 		static Exception GetException (MonoBtlsSslError status)
 		{
-			var error = MonoBtlsError.GetError ();
+			string file;
+			int line;
+			var error = MonoBtlsError.GetError (out file, out line);
+			if (error == null)
+				return new MonoBtlsException (status);
+
 			var text = MonoBtlsError.GetErrorString (error);
-			return new MonoBtlsException ("{0} {1}", status, text);
+
+			string message;
+			if (file != null)
+				message = string.Format ("{0} {1}\n  at {2}:{3}", status, text, file, line);
+			else
+				message = string.Format ("{0} {1}", status, text);
+			return new MonoBtlsException (message);
 		}
 
 		public override bool ProcessHandshake ()

--- a/mcs/class/System/Mono.Btls/MonoBtlsError.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsError.cs
@@ -48,6 +48,12 @@ namespace Mono.Btls
 		extern static void mono_btls_error_clear_error ();
 
 		[DllImport (MonoBtlsObject.BTLS_DYLIB)]
+		extern static int mono_btls_error_peek_error_line (out IntPtr file, out int line);
+
+		[DllImport (MonoBtlsObject.BTLS_DYLIB)]
+		extern static int mono_btls_error_get_error_line (out IntPtr file, out int line);
+
+		[DllImport (MonoBtlsObject.BTLS_DYLIB)]
 		extern static void mono_btls_error_get_error_string_n (int error, IntPtr buf, int len);
 
 		public static int PeekError ()
@@ -77,6 +83,28 @@ namespace Mono.Btls
 			} finally {
 				Marshal.FreeHGlobal (buffer);
 			}
+		}
+
+		public static int PeekError (out string file, out int line)
+		{
+			IntPtr filePtr;
+			var error = mono_btls_error_peek_error_line (out filePtr, out line);
+			if (filePtr != IntPtr.Zero)
+				file = Marshal.PtrToStringAnsi (filePtr);
+			else
+				file = null;
+			return error;
+		}
+
+		public static int GetError (out string file, out int line)
+		{
+			IntPtr filePtr;
+			var error = mono_btls_error_get_error_line (out filePtr, out line);
+			if (filePtr != IntPtr.Zero)
+				file = Marshal.PtrToStringAnsi (filePtr);
+			else
+				file = null;
+			return error;
 		}
 	}
 }

--- a/mono/btls/btls-error.c
+++ b/mono/btls/btls-error.c
@@ -22,6 +22,18 @@ mono_btls_error_get_error (void)
 	return ERR_get_error ();
 }
 
+MONO_API int
+mono_btls_error_peek_error_line (const char **file, int *line)
+{
+	return ERR_peek_error_line (file, line);
+}
+
+MONO_API int
+mono_btls_error_get_error_line (const char **file, int *line)
+{
+	return ERR_get_error_line (file, line);
+}
+
 MONO_API void
 mono_btls_error_clear_error (void)
 {

--- a/mono/btls/btls-error.h
+++ b/mono/btls/btls-error.h
@@ -23,6 +23,12 @@ mono_btls_error_get_error (void);
 void
 mono_btls_error_clear_error (void);
 
+int
+mono_btls_error_peek_error_line (const char **file, int *line);
+
+int
+mono_btls_error_get_error_line (const char **file, int *line);
+
 void
 mono_btls_error_get_error_string_n (int error, char *buf, int len);
 


### PR DESCRIPTION
* Add new native mono_btls_error_peek_error_line() and
  mono_btls_error_get_error_line().

* Add `MonoBtlsError.PeekError(out string, out int)` and
  `MonoBtlsError.GetError(out string, out int)` overloads.

* MonoBtlsContext.GetException(): use it here.