### PR TITLE
[btls]: Add option to specify the certificate search paths.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
@@ -75,6 +75,10 @@ namespace Mono.Security.Interface
 			get; set;
 		}
 
+		public string[] CertificateSearchPaths {
+			get; set;
+		}
+
 		/*
 		 * If you set this here, then it will override 'ServicePointManager.SecurityProtocol'.
 		 */
@@ -161,7 +165,13 @@ namespace Mono.Security.Interface
 			UserSettings = other.UserSettings;
 			EnabledProtocols = other.EnabledProtocols;
 			EnabledCiphers = other.EnabledCiphers;
-			TrustAnchors = other.TrustAnchors;
+			if (other.TrustAnchors != null)
+				TrustAnchors = new X509CertificateCollection (other.TrustAnchors);
+			if (other.CertificateSearchPaths != null) {
+				CertificateSearchPaths = new string [other.CertificateSearchPaths.Length];
+				other.CertificateSearchPaths.CopyTo (CertificateSearchPaths, 0);
+			}
+
 			cloned = true;
 		}
 

--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
@@ -75,7 +75,7 @@ namespace Mono.Security.Interface
 			get; set;
 		}
 
-		public string[] CertificateSearchPaths {
+		internal string[] CertificateSearchPaths {
 			get; set;
 		}
 

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -209,7 +209,7 @@ namespace Mono.Btls
 
 		void SetupCertificateStore ()
 		{
-			MonoBtlsProvider.SetupCertificateStore (ctx.CertificateStore);
+			MonoBtlsProvider.SetupCertificateStore (ctx.CertificateStore, Settings, IsServer);
 
 			if (Settings != null && Settings.TrustAnchors != null) {
 				var trust = IsServer ? MonoBtlsX509TrustKind.TRUST_CLIENT : MonoBtlsX509TrustKind.TRUST_SERVER;

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -150,7 +150,7 @@ namespace Mono.Btls
 			using (var nativeChain = MonoBtlsProvider.GetNativeChain (certificates))
 			using (var param = GetVerifyParam (targetHost, serverMode))
 			using (var storeCtx = new MonoBtlsX509StoreCtx ()) {
-				SetupCertificateStore (store);
+				SetupCertificateStore (store, validator.Settings, serverMode);
 
 				storeCtx.Initialize (store, nativeChain);
 
@@ -201,20 +201,79 @@ namespace Mono.Btls
 			}
 		}
 
+		internal static void SetupCertificateStore (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
+		{
+#if MONODROID
+				SetupCertificateStore (store);
+				return;
+#else
+
+			if (settings == null || settings.CertificateSearchPaths == null) {
+				SetupCertificateStore (store);
+				return;
+			}
+
+			foreach (var path in settings.CertificateSearchPaths) {
+				if (string.Equals (path, "@default", StringComparison.Ordinal)) {
+					AddTrustedRoots (store, settings, server);
+					AddUserStore (store);
+					AddMachineStore (store);
+				} else if (string.Equals (path, "@user", StringComparison.Ordinal))
+					AddUserStore (store);
+				else if (string.Equals (path, "@machine", StringComparison.Ordinal))
+					AddMachineStore (store);
+				else if (string.Equals (path, "@trusted", StringComparison.Ordinal))
+					AddTrustedRoots (store, settings, server);
+				else if (path.StartsWith ("@pem:", StringComparison.Ordinal)) {
+					var realPath = path.Substring (5);
+					if (Directory.Exists (realPath))
+						store.AddDirectoryLookup (realPath, MonoBtlsX509FileType.PEM);
+				} else if (path.StartsWith ("@der:", StringComparison.Ordinal)) {
+					var realPath = path.Substring (5);
+					if (Directory.Exists (realPath))
+						store.AddDirectoryLookup (realPath, MonoBtlsX509FileType.ASN1);
+				} else {
+					if (Directory.Exists (path))
+						store.AddDirectoryLookup (path, MonoBtlsX509FileType.PEM);
+				}
+			}
+#endif
+		}
+
 		internal static void SetupCertificateStore (MonoBtlsX509Store store)
 		{
 #if MONODROID
 			store.SetDefaultPaths ();
 			store.AddAndroidLookup ();
 #else
+			AddUserStore (store);
+			AddMachineStore (store);
+#endif
+		}
+
+#if !MONODROID
+		static void AddUserStore (MonoBtlsX509Store store)
+		{
 			var userPath = MonoBtlsX509StoreManager.GetStorePath (MonoBtlsX509StoreType.UserTrustedRoots);
 			if (Directory.Exists (userPath))
 				store.AddDirectoryLookup (userPath, MonoBtlsX509FileType.PEM);
+		}
+
+		static void AddMachineStore (MonoBtlsX509Store store)
+		{
 			var machinePath = MonoBtlsX509StoreManager.GetStorePath (MonoBtlsX509StoreType.MachineTrustedRoots);
 			if (Directory.Exists (machinePath))
 				store.AddDirectoryLookup (machinePath, MonoBtlsX509FileType.PEM);
-#endif
 		}
+
+		static void AddTrustedRoots (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
+		{
+			if (settings == null || settings.TrustAnchors == null)
+				return;
+			var trust = server ? MonoBtlsX509TrustKind.TRUST_CLIENT : MonoBtlsX509TrustKind.TRUST_SERVER;
+			store.AddCollection (settings.TrustAnchors, trust);
+		}
+#endif
 
 		public static string GetSystemStoreLocation ()
 		{

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -208,7 +208,7 @@ namespace Mono.Btls
 			return;
 #else
 
-			if (settings == null || settings.CertificateSearchPaths == null) {
+			if (settings?.CertificateSearchPaths == null) {
 				SetupCertificateStore (store);
 				return;
 			}
@@ -268,7 +268,7 @@ namespace Mono.Btls
 
 		static void AddTrustedRoots (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
 		{
-			if (settings == null || settings.TrustAnchors == null)
+			if (settings?.TrustAnchors == null)
 				return;
 			var trust = server ? MonoBtlsX509TrustKind.TRUST_CLIENT : MonoBtlsX509TrustKind.TRUST_SERVER;
 			store.AddCollection (settings.TrustAnchors, trust);

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -204,8 +204,8 @@ namespace Mono.Btls
 		internal static void SetupCertificateStore (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
 		{
 #if MONODROID
-				SetupCertificateStore (store);
-				return;
+			SetupCertificateStore (store);
+			return;
 #else
 
 			if (settings == null || settings.CertificateSearchPaths == null) {


### PR DESCRIPTION
* MonoTlsSettings.CertificateSearchPaths: new property.

Valid values are

- @default - add default search paths
- @user - add default user search path
- @machine - add default machine search path
- @trust - add 'MonoTlsSettings.TrustedRoots'
- @pem:<directory> - custom directory containing certificates in PEM format
- @der:<directory> - same, in DER format