### PR TITLE
[runtime] Fix the computation of token sizes in ppdb files, the PDB s…

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -594,6 +594,23 @@ load_tables (MonoImage *image)
 	/* They must be the same */
 	g_assert ((const void *) image->tables_base == (const void *) rows);
 
+	if (image->heap_pdb.size) {
+		/*
+		 * Obtain token sizes from the pdb stream.
+		 */
+		/* 24 = guid + entry point */
+		int pos = 24;
+		image->referenced_tables = read64 (image->heap_pdb.data + pos);
+		pos += 8;
+		image->referenced_table_rows = g_new0 (int, 64);
+		for (int i = 0; i < 64; ++i) {
+			if (image->referenced_tables & ((guint64)1 << i)) {
+				image->referenced_table_rows [i] = read32 (image->heap_pdb.data + pos);
+				pos += 4;
+			}
+		}
+	}
+
 	mono_metadata_compute_table_bases (image);
 	return TRUE;
 }

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -248,6 +248,10 @@ struct _MonoImage {
 			    
 	const char          *tables_base;
 
+	/* For PPDB files */
+	guint64 referenced_tables;
+	int *referenced_table_rows;
+
 	/**/
 	MonoTableInfo        tables [MONO_TABLE_NUM];
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -555,13 +555,19 @@ inverse of this mapping.
 static inline int
 idx_size (MonoImage *meta, int tableidx)
 {
-	return meta->tables [tableidx].rows < 65536 ? 2 : 4;
+	if (meta->referenced_tables && (meta->referenced_tables & ((guint64)1 << tableidx)))
+		return meta->referenced_table_rows [tableidx] < 65536 ? 2 : 4;
+	else
+		return meta->tables [tableidx].rows < 65536 ? 2 : 4;
 }
 
 static inline int
 get_nrows (MonoImage *meta, int tableidx)
 {
-	return meta->tables [tableidx].rows;
+	if (meta->referenced_tables && (meta->referenced_tables & ((guint64)1 << tableidx)))
+		return meta->referenced_table_rows [tableidx];
+	else
+		return meta->tables [tableidx].rows;
 }
 
 /* Reference: Partition II - 23.2.6 */


### PR DESCRIPTION
…tream has an additional table which contains the token sizes for the metadata tables referenced by the ppdb tables.