### PR TITLE
[xbuild] Disable pre-2.0 csc hack to use /debug:portable

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/ManagedCompiler.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Microsoft.Build.Tasks/ManagedCompiler.cs
@@ -58,11 +58,7 @@ namespace Microsoft.Build.Tasks {
 			if (Bag ["CodePage"] != null)
 				commandLine.AppendSwitchIfNotNull ("/codepage:", CodePage.ToString ());
 
-			var dtype = DebugType;
-			if (string.Equals (dtype, "full", StringComparison.OrdinalIgnoreCase) || string.Equals (dtype, "pdbonly", StringComparison.OrdinalIgnoreCase))
-				dtype = "portable";
-
-			commandLine.AppendSwitchIfNotNull ("/debug:", dtype);
+			commandLine.AppendSwitchIfNotNull ("/debug:", DebugType);
 
 			if (Bag ["DelaySign"] != null)
 				if (DelaySign)


### PR DESCRIPTION
This hack should not be required now, as roslyn emits the correct debug
files with /debug:full and /debug:pdbonly, on non-windows platform.

This manifested as https://bugzilla.xamarin.com/show_bug.cgi?id=50710 ,
where the Xamarin.Mac targets override `$(CscToolExe)` to use `mcs`, but
xbuild's `ManagedCompiler` *always* converts `DebugType={full,pdbonly}`
to `/debug:portable`, which would cause mcs to complain.