### PR TITLE
Fix issues found with flint

### DIFF
--- a/mono/arch/s390x/s390x-codegen.h
+++ b/mono/arch/s390x/s390x-codegen.h
@@ -268,7 +268,7 @@ typedef struct {
 	char	xx : 4;
 	char	r3 : 4;
 	char	r4 : 4;
-} __attribute__ ((packed)) RRD_Format;
+} __attribute__ ((__packed__)) RRD_Format;
 
 typedef struct {
 	short	op;
@@ -346,7 +346,7 @@ typedef struct {
 	int 	b2 : 4;
 	int	d2 : 20;
 	char	op2;
-} __attribute__ ((packed)) RXY_Format;
+} __attribute__ ((__packed__)) RXY_Format;
 
 typedef struct {
 	char 	op;
@@ -381,7 +381,7 @@ typedef struct {
 	short	dl2 : 12;
 	char	dh2;
 	char 	op2;
-} __attribute__ ((packed)) RSY_Format_1;
+} __attribute__ ((__packed__)) RSY_Format_1;
 
 typedef struct {
 	char 	op1;
@@ -391,7 +391,7 @@ typedef struct {
 	short	dl2 : 12;
 	char	dh2;
 	char 	op2;
-} __attribute__ ((packed)) RSY_Format_2;
+} __attribute__ ((__packed__)) RSY_Format_2;
 
 typedef struct {
 	char 	op1;
@@ -401,21 +401,21 @@ typedef struct {
 	short	d1 : 12;
 	char	yy;
 	char 	op2;
-} __attribute__ ((packed)) RSL_Format;
+} __attribute__ ((__packed__)) RSL_Format;
 
 typedef struct {
 	char 	op;
 	char	r1 : 4;
 	char	r3 : 4;
 	short	i2;
-} __attribute__ ((packed)) RSI_Format;
+} __attribute__ ((__packed__)) RSI_Format;
 
 typedef struct {
 	char 	op1;
 	char	m1 : 4;
 	char	op2 : 4;
 	short	i2;
-} __attribute__ ((packed)) RI_Format;
+} __attribute__ ((__packed__)) RI_Format;
 
 typedef struct {
 	char 	op1;
@@ -424,7 +424,7 @@ typedef struct {
 	short	i2;
 	char	xx;
 	char	op2;
-} __attribute__ ((packed)) RIE_Format_1;
+} __attribute__ ((__packed__)) RIE_Format_1;
 
 typedef struct {
 	char 	op1;
@@ -434,7 +434,7 @@ typedef struct {
 	char	m2 : 4;
 	char    xx : 4;
 	char	op2;
-} __attribute__ ((packed)) RIE_Format_2;
+} __attribute__ ((__packed__)) RIE_Format_2;
 
 typedef struct {
 	char 	op1;
@@ -443,7 +443,7 @@ typedef struct {
 	short	d;
 	char	i;
 	char	op2;
-} __attribute__ ((packed)) RIE_Format_3;
+} __attribute__ ((__packed__)) RIE_Format_3;
 
 typedef struct {
 	char 	op1;
@@ -453,7 +453,7 @@ typedef struct {
 	char	m3 : 4;
 	char	xx : 4;
 	char	op2;
-} __attribute__ ((packed)) RIE_Format_4;
+} __attribute__ ((__packed__)) RIE_Format_4;
 
 typedef struct {
 	char 	op1;
@@ -462,7 +462,7 @@ typedef struct {
 	short	ri2;
 	char	xx;
 	char	op2;
-} __attribute__ ((packed)) RIE_Format_5;
+} __attribute__ ((__packed__)) RIE_Format_5;
 
 typedef struct {
 	char 	op1;
@@ -472,7 +472,7 @@ typedef struct {
 	char	i4;
 	char	i5;
 	char	op2;
-} __attribute__ ((packed)) RIE_Format_6;
+} __attribute__ ((__packed__)) RIE_Format_6;
 
 typedef struct {
 	char 	op1;
@@ -481,7 +481,7 @@ typedef struct {
 	short	i2;
 	char	xx;
 	char	op2;
-} __attribute__ ((packed)) RIE_Format_7;
+} __attribute__ ((__packed__)) RIE_Format_7;
 
 typedef struct {
 	char	op1;
@@ -491,21 +491,21 @@ typedef struct {
 	int	d4 : 12;
 	char	i2;
 	char	op2;
-} __attribute__ ((packed)) RIS_Format;
+} __attribute__ ((__packed__)) RIS_Format;
 
 typedef struct {
 	char 	op1;
 	char	r1 : 4;
 	char	op2 : 4;
 	int	i2;
-} __attribute__ ((packed)) RIL_Format_1;
+} __attribute__ ((__packed__)) RIL_Format_1;
 
 typedef struct {
 	char 	op1;
 	char	m1 : 4;
 	char	op2 : 4;
 	int	i2;
-} __attribute__ ((packed)) RIL_Format_2;
+} __attribute__ ((__packed__)) RIL_Format_2;
 
 typedef struct {
 	short	op1;
@@ -516,21 +516,21 @@ typedef struct {
 	char	m3 : 4;
 	char	xx : 4;
 	char	op2;
-} __attribute__ ((packed)) RXE_Format;
+} __attribute__ ((__packed__)) RXE_Format;
 
 typedef struct {
 	char	op;
 	char	i2;
 	short	b1 : 4;
 	short	d1 : 12;
-} __attribute__ ((packed)) SI_Format;
+} __attribute__ ((__packed__)) SI_Format;
 
 typedef struct {
 	short	op;
 	char	b1 : 4;
 	short	d1 : 12;
 	short	i2;
-} __attribute__ ((packed)) SIL_Format;
+} __attribute__ ((__packed__)) SIL_Format;
 
 typedef struct {
 	char	op1;
@@ -538,7 +538,7 @@ typedef struct {
 	char	b1 : 4;
 	int	d1 : 20;
 	char	op2;
-} __attribute__ ((packed)) SIY_Format;
+} __attribute__ ((__packed__)) SIY_Format;
 
 typedef struct {
 	char	op1;
@@ -547,13 +547,13 @@ typedef struct {
 	short	b3 : 4;
 	short	d3 : 12;
 	short	ri2;
-} __attribute__ ((packed)) SMI_Format;
+} __attribute__ ((__packed__)) SMI_Format;
 
 typedef struct {
 	short	op;
 	short	b2 : 4;
 	short	d2 : 12;
-} __attribute__ ((packed)) S_Format;
+} __attribute__ ((__packed__)) S_Format;
 
 typedef struct {
 	char	op;
@@ -562,7 +562,7 @@ typedef struct {
 	short	d1 : 12;
 	short	b2 : 4;
 	short	d2 : 12;
-} __attribute__ ((packed)) SS_Format_1;
+} __attribute__ ((__packed__)) SS_Format_1;
 
 typedef struct {
 	char	op;
@@ -572,7 +572,7 @@ typedef struct {
 	short	d1 : 12;
 	short	b2 : 4;
 	short	d2 : 12;
-} __attribute__ ((packed)) SS_Format_2;
+} __attribute__ ((__packed__)) SS_Format_2;
 
 typedef struct {
 	char	op;
@@ -582,7 +582,7 @@ typedef struct {
 	short	d1 : 12;
 	short	b2 : 4;
 	short	d2 : 12;
-} __attribute__ ((packed)) SS_Format_3;	
+} __attribute__ ((__packed__)) SS_Format_3;	
 
 typedef struct {
 	char	op;
@@ -592,7 +592,7 @@ typedef struct {
 	short	d2 : 12;
 	short	b4 : 4;
 	short	d4 : 12;
-} __attribute__ ((packed)) SS_Format_4;	
+} __attribute__ ((__packed__)) SS_Format_4;	
 
 typedef struct {
 	short	op;
@@ -600,7 +600,7 @@ typedef struct {
 	short	d1 : 12;
 	short	b2 : 4;
 	short	d2 : 12;
-} __attribute__ ((packed)) SSE_Format;
+} __attribute__ ((__packed__)) SSE_Format;
 
 typedef struct {
 	short	op;
@@ -610,7 +610,7 @@ typedef struct {
 	short	d1 : 12;
 	short	b2 : 4;
 	short	d2 : 12;
-} __attribute__ ((packed)) SSF_Format;
+} __attribute__ ((__packed__)) SSF_Format;
 
 typedef struct {
 	short	op1;
@@ -620,7 +620,7 @@ typedef struct {
 	char	m3 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRIa_Format;
+} __attribute__ ((__packed__)) VRIa_Format;
 
 typedef struct {
 	short	op1;
@@ -631,7 +631,7 @@ typedef struct {
 	char	m4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRIb_Format;
+} __attribute__ ((__packed__)) VRIb_Format;
 
 typedef struct {
 	short	op1;
@@ -641,7 +641,7 @@ typedef struct {
 	char	m4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRIc_Format;
+} __attribute__ ((__packed__)) VRIc_Format;
 
 typedef struct {
 	short	op1;
@@ -653,7 +653,7 @@ typedef struct {
 	char	m5 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRId_Format;
+} __attribute__ ((__packed__)) VRId_Format;
 
 typedef struct {
 	short	op1;
@@ -664,7 +664,7 @@ typedef struct {
 	char	m4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRIe_Format;
+} __attribute__ ((__packed__)) VRIe_Format;
 
 typedef struct {
 	short	op1;
@@ -676,7 +676,7 @@ typedef struct {
 	char	m3 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRRa_Format;
+} __attribute__ ((__packed__)) VRRa_Format;
 
 typedef struct {
 	short	op1;
@@ -689,7 +689,7 @@ typedef struct {
 	char	m4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRRb_Format;
+} __attribute__ ((__packed__)) VRRb_Format;
 
 typedef struct {
 	short	op1;
@@ -702,7 +702,7 @@ typedef struct {
 	char	m3 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRRc_Format;
+} __attribute__ ((__packed__)) VRRc_Format;
 
 typedef struct {
 	short	op1;
@@ -715,7 +715,7 @@ typedef struct {
 	char	v4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRRd_Format;
+} __attribute__ ((__packed__)) VRRd_Format;
 
 typedef struct {
 	short	op1;
@@ -728,7 +728,7 @@ typedef struct {
 	char	v4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRRe_Format;
+} __attribute__ ((__packed__)) VRRe_Format;
 
 typedef struct {
 	short	op1;
@@ -738,7 +738,7 @@ typedef struct {
 	short	xx;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRRf_Format;
+} __attribute__ ((__packed__)) VRRf_Format;
 
 typedef struct {
 	short	op1;
@@ -749,7 +749,7 @@ typedef struct {
 	char	m4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRSa_Format;
+} __attribute__ ((__packed__)) VRSa_Format;
 
 typedef struct {
 	short	op1;
@@ -760,7 +760,7 @@ typedef struct {
 	char	m4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRSb_Format;
+} __attribute__ ((__packed__)) VRSb_Format;
 
 typedef struct {
 	short	op1;
@@ -771,7 +771,7 @@ typedef struct {
 	char	m4 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRSc_Format;
+} __attribute__ ((__packed__)) VRSc_Format;
 
 typedef struct {
 	short	op1;
@@ -782,7 +782,7 @@ typedef struct {
 	char	m3 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRV_Format;
+} __attribute__ ((__packed__)) VRV_Format;
 
 typedef struct {
 	short	op1;
@@ -793,7 +793,7 @@ typedef struct {
 	char	m3 : 4;
 	char	rxb : 4;
 	char	op2;
-} __attribute__ ((packed)) VRX_Format;
+} __attribute__ ((__packed__)) VRX_Format;
 
 #define s390_emit16(c, x) do 			\
 {						\

--- a/mono/arch/s390x/tramp.c
+++ b/mono/arch/s390x/tramp.c
@@ -62,7 +62,7 @@ typedef struct {
 } size_data;	
 
 /*========================= End of Typedefs ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- add_general                                       */
@@ -95,7 +95,7 @@ add_general (guint *gr, size_data *sz, gboolean simple)
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- calculate_sizes                                   */
@@ -299,7 +299,7 @@ enum_retvalue:
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- emit_prolog                                       */
@@ -337,7 +337,7 @@ emit_prolog (guint8 *p, MonoMethodSignature *sig, size_data *sz)
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- emit_save_parameters                              */
@@ -534,7 +534,7 @@ emit_save_parameters (guint8 *p, MonoMethodSignature *sig, size_data *sz)
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- alloc_code_memory				    */
@@ -562,7 +562,7 @@ alloc_code_memory (guint code_size)
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- emit_call_and_store_retval			    */
@@ -664,7 +664,7 @@ printf("Returning %d bytes for type %d (%d)\n",retSize,simpletype,sig->pinvoke);
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- emit_epilog                                       */
@@ -687,7 +687,7 @@ emit_epilog (guint8 *p, MonoMethodSignature *sig, size_data *sz)
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- mono_arch_create_trampoline.			    */
@@ -726,7 +726,7 @@ mono_arch_create_trampoline (MonoMethodSignature *sig, gboolean string_ctor)
 }
 
 /*========================= End of Function ========================*/
-
+
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* Name		- mono_arch_create_method_pointer		    */

--- a/mono/btls/btls-util.h
+++ b/mono/btls/btls-util.h
@@ -22,7 +22,7 @@
 #else
 
 #ifdef __GNUC__
-#define MONO_API __attribute__ ((visibility ("default")))
+#define MONO_API __attribute__ ((__visibility__ ("default")))
 #else
 #define MONO_API
 #endif

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -130,9 +130,9 @@ get_shadow_assembly_location_base (MonoDomain *domain, MonoError *error);
 static MonoLoadFunc load_function = NULL;
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (assembly, System.Reflection, "Assembly");
+static GENERATE_GET_CLASS_WITH_CACHE (assembly, "System.Reflection", "Assembly");
 
-static GENERATE_GET_CLASS_WITH_CACHE (appdomain, System, "AppDomain");
+static GENERATE_GET_CLASS_WITH_CACHE (appdomain, "System", "AppDomain");
 
 static MonoDomain *
 mono_domain_from_appdomain_handle (MonoAppDomainHandle appdomain);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -131,9 +131,9 @@ get_shadow_assembly_location_base (MonoDomain *domain, MonoError *error);
 static MonoLoadFunc load_function = NULL;
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (assembly, System.Reflection, Assembly);
+static GENERATE_GET_CLASS_WITH_CACHE (assembly, System.Reflection, "Assembly");
 
-static GENERATE_GET_CLASS_WITH_CACHE (appdomain, System, AppDomain);
+static GENERATE_GET_CLASS_WITH_CACHE (appdomain, System, "AppDomain");
 
 static MonoDomain *
 mono_domain_from_appdomain_handle (MonoAppDomainHandle appdomain);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -44,7 +44,6 @@
 #include <mono/metadata/threads.h>
 #include <mono/metadata/threadpool.h>
 #include <mono/metadata/tabledefs.h>
-#include <mono/metadata/gc-internals.h>
 #include <mono/metadata/mono-gc.h>
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/marshal-internals.h>

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -217,7 +217,7 @@ static mono_mutex_t assembly_binding_mutex;
 static GSList *loaded_assembly_bindings = NULL;
 
 /* Class lazy loading functions */
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (internals_visible, System.Runtime.CompilerServices, InternalsVisibleToAttribute)
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (internals_visible, System.Runtime.CompilerServices, "InternalsVisibleToAttribute")
 static MonoAssembly*
 mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload);
 static MonoAssembly*

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2826,7 +2826,7 @@ mono_assembly_load_publisher_policy (MonoAssemblyName *aname)
 	if (strstr (aname->name, ".dll")) {
 		len = strlen (aname->name) - 4;
 		name = (gchar *)g_malloc (len + 1);
-		strncpy (name, aname->name, len);
+		memcpy (name, aname->name, len);
 		name[len] = 0;
 	} else
 		name = g_strdup (aname->name);
@@ -3143,7 +3143,7 @@ mono_assembly_load_from_gac (MonoAssemblyName *aname,  gchar *filename, MonoImag
 	if (strstr (aname->name, ".dll")) {
 		len = strlen (filename) - 4;
 		name = (gchar *)g_malloc (len + 1);
-		strncpy (name, aname->name, len);
+		memcpy (name, aname->name, len);
 		name[len] = 0;
 	} else {
 		name = g_strdup (aname->name);

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -217,7 +217,7 @@ static mono_mutex_t assembly_binding_mutex;
 static GSList *loaded_assembly_bindings = NULL;
 
 /* Class lazy loading functions */
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (internals_visible, System.Runtime.CompilerServices, "InternalsVisibleToAttribute")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (internals_visible, "System.Runtime.CompilerServices", "InternalsVisibleToAttribute")
 static MonoAssembly*
 mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload);
 static MonoAssembly*

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -24,8 +24,6 @@
 #include <sys/stat.h>
 #include <sys/un.h>
 #include <netinet/in.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <pwd.h>

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1129,21 +1129,21 @@ MonoClass* mono_class_get_##shortname##_class (void);
 #define GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(shortname) \
 MonoClass* mono_class_try_get_##shortname##_class (void);
 
-#define GENERATE_GET_CLASS_WITH_CACHE(shortname,namespace,name) \
+#define GENERATE_GET_CLASS_WITH_CACHE(shortname,name_space,name) \
 MonoClass*	\
 mono_class_get_##shortname##_class (void)	\
 {	\
 	static MonoClass *tmp_class;	\
 	MonoClass *klass = tmp_class;	\
 	if (!klass) {	\
-		klass = mono_class_load_from_name (mono_defaults.corlib, #namespace, name);	\
+		klass = mono_class_load_from_name (mono_defaults.corlib, name_space, name);	\
 		mono_memory_barrier ();	\
 		tmp_class = klass;	\
 	}	\
 	return klass;	\
 }
 
-#define GENERATE_TRY_GET_CLASS_WITH_CACHE(shortname,namespace,name) \
+#define GENERATE_TRY_GET_CLASS_WITH_CACHE(shortname,name_space,name) \
 MonoClass*	\
 mono_class_try_get_##shortname##_class (void)	\
 {	\
@@ -1152,7 +1152,7 @@ mono_class_try_get_##shortname##_class (void)	\
 	MonoClass *klass = (MonoClass *)tmp_class;	\
 	mono_memory_barrier ();	\
 	if (!inited) {	\
-		klass = mono_class_try_load_from_name (mono_defaults.corlib, #namespace, name);	\
+		klass = mono_class_try_load_from_name (mono_defaults.corlib, name_space, name);	\
 		tmp_class = klass;	\
 		mono_memory_barrier ();	\
 		inited = TRUE;	\

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1136,7 +1136,7 @@ mono_class_get_##shortname##_class (void)	\
 	static MonoClass *tmp_class;	\
 	MonoClass *klass = tmp_class;	\
 	if (!klass) {	\
-		klass = mono_class_load_from_name (mono_defaults.corlib, #namespace, #name);	\
+		klass = mono_class_load_from_name (mono_defaults.corlib, #namespace, name);	\
 		mono_memory_barrier ();	\
 		tmp_class = klass;	\
 	}	\
@@ -1152,7 +1152,7 @@ mono_class_try_get_##shortname##_class (void)	\
 	MonoClass *klass = (MonoClass *)tmp_class;	\
 	mono_memory_barrier ();	\
 	if (!inited) {	\
-		klass = mono_class_try_load_from_name (mono_defaults.corlib, #namespace, #name);	\
+		klass = mono_class_try_load_from_name (mono_defaults.corlib, #namespace, name);	\
 		tmp_class = klass;	\
 		mono_memory_barrier ();	\
 		inited = TRUE;	\

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -10593,7 +10593,7 @@ mono_class_full_name (MonoClass *klass)
 }
 
 /* Declare all shared lazy type lookup functions */
-GENERATE_TRY_GET_CLASS_WITH_CACHE (safehandle, System.Runtime.InteropServices, SafeHandle)
+GENERATE_TRY_GET_CLASS_WITH_CACHE (safehandle, System.Runtime.InteropServices, "SafeHandle")
 
 /**
  * mono_method_get_base_method:

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -10593,7 +10593,7 @@ mono_class_full_name (MonoClass *klass)
 }
 
 /* Declare all shared lazy type lookup functions */
-GENERATE_TRY_GET_CLASS_WITH_CACHE (safehandle, System.Runtime.InteropServices, "SafeHandle")
+GENERATE_TRY_GET_CLASS_WITH_CACHE (safehandle, "System.Runtime.InteropServices", "SafeHandle")
 
 /**
  * mono_method_get_base_method:

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -32,7 +32,6 @@
 #include "mono/metadata/threads-types.h"
 #include "mono/metadata/string-icalls.h"
 #include "mono/metadata/attrdefs.h"
-#include "mono/metadata/gc-internals.h"
 #include "mono/utils/mono-counters.h"
 #include "mono/utils/strenc.h"
 #include "mono/utils/atomic.h"

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -104,15 +104,15 @@ static mono_mutex_t cominterop_mutex;
 #define STDCALL
 #endif
 
-GENERATE_GET_CLASS_WITH_CACHE (interop_proxy, Mono.Interop, ComInteropProxy)
-GENERATE_GET_CLASS_WITH_CACHE (idispatch,     Mono.Interop, IDispatch)
-GENERATE_GET_CLASS_WITH_CACHE (iunknown,      Mono.Interop, IUnknown)
+GENERATE_GET_CLASS_WITH_CACHE (interop_proxy, Mono.Interop, "ComInteropProxy")
+GENERATE_GET_CLASS_WITH_CACHE (idispatch,     Mono.Interop, "IDispatch")
+GENERATE_GET_CLASS_WITH_CACHE (iunknown,      Mono.Interop, "IUnknown")
 
-GENERATE_GET_CLASS_WITH_CACHE (com_object, System, __ComObject)
-GENERATE_GET_CLASS_WITH_CACHE (variant,    System, Variant)
+GENERATE_GET_CLASS_WITH_CACHE (com_object, System, "__ComObject")
+GENERATE_GET_CLASS_WITH_CACHE (variant,    System, "Variant")
 
-static GENERATE_GET_CLASS_WITH_CACHE (interface_type_attribute, System.Runtime.InteropServices, InterfaceTypeAttribute)
-static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, System.Runtime.InteropServices, GuidAttribute)
+static GENERATE_GET_CLASS_WITH_CACHE (interface_type_attribute, System.Runtime.InteropServices, "InterfaceTypeAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, System.Runtime.InteropServices, "GuidAttribute")
 
 /* Upon creation of a CCW, only allocate a weak handle and set the
  * reference count to 0. If the unmanaged client code decides to addref and

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -103,15 +103,15 @@ static mono_mutex_t cominterop_mutex;
 #define STDCALL
 #endif
 
-GENERATE_GET_CLASS_WITH_CACHE (interop_proxy, Mono.Interop, "ComInteropProxy")
-GENERATE_GET_CLASS_WITH_CACHE (idispatch,     Mono.Interop, "IDispatch")
-GENERATE_GET_CLASS_WITH_CACHE (iunknown,      Mono.Interop, "IUnknown")
+GENERATE_GET_CLASS_WITH_CACHE (interop_proxy, "Mono.Interop", "ComInteropProxy")
+GENERATE_GET_CLASS_WITH_CACHE (idispatch,     "Mono.Interop", "IDispatch")
+GENERATE_GET_CLASS_WITH_CACHE (iunknown,      "Mono.Interop", "IUnknown")
 
-GENERATE_GET_CLASS_WITH_CACHE (com_object, System, "__ComObject")
-GENERATE_GET_CLASS_WITH_CACHE (variant,    System, "Variant")
+GENERATE_GET_CLASS_WITH_CACHE (com_object, "System", "__ComObject")
+GENERATE_GET_CLASS_WITH_CACHE (variant,    "System", "Variant")
 
-static GENERATE_GET_CLASS_WITH_CACHE (interface_type_attribute, System.Runtime.InteropServices, "InterfaceTypeAttribute")
-static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, System.Runtime.InteropServices, "GuidAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (interface_type_attribute, "System.Runtime.InteropServices", "InterfaceTypeAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, "System.Runtime.InteropServices", "GuidAttribute")
 
 /* Upon creation of a CCW, only allocate a weak handle and set the
  * reference count to 0. If the unmanaged client code decides to addref and

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -39,8 +39,8 @@
 
 static gboolean type_is_reference (MonoType *type);
 
-static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_typed_argument, System.Reflection, "CustomAttributeTypedArgument");
-static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_named_argument, System.Reflection, "CustomAttributeNamedArgument");
+static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_typed_argument, "System.Reflection", "CustomAttributeTypedArgument");
+static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_named_argument, "System.Reflection", "CustomAttributeNamedArgument");
 
 /*
  * LOCKING: Acquires the loader lock. 

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -39,8 +39,8 @@
 
 static gboolean type_is_reference (MonoType *type);
 
-static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_typed_argument, System.Reflection, CustomAttributeTypedArgument);
-static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_named_argument, System.Reflection, CustomAttributeNamedArgument);
+static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_typed_argument, System.Reflection, "CustomAttributeTypedArgument");
+static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_named_argument, System.Reflection, "CustomAttributeNamedArgument");
 
 /*
  * LOCKING: Acquires the loader lock. 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -34,7 +34,6 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/metadata-internals.h>
-#include <mono/metadata/gc-internals.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/mono-debug-debugger.h>
 #include <mono/metadata/mono-config.h>

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -16,7 +16,6 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/sgen/gc-internal-agnostic.h>
-#include <mono/utils/gc_wrapper.h>
 
 #define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&(domain)->finalizable_objects_hash_lock);
 #define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&(domain)->finalizable_objects_hash_lock);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -28,7 +28,6 @@
 #include <mono/sgen/sgen-conf.h>
 #include <mono/sgen/sgen-gc.h>
 #include <mono/utils/mono-logger-internals.h>
-#include <mono/metadata/gc-internals.h>
 #include <mono/metadata/marshal.h> /* for mono_delegate_free_ftnptr () */
 #include <mono/metadata/attach.h>
 #include <mono/metadata/console-io.h>

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -111,12 +111,12 @@ extern MonoString* ves_icall_System_Environment_GetOSVersionString (void);
 ICALL_EXPORT MonoReflectionAssemblyHandle ves_icall_System_Reflection_Assembly_GetCallingAssembly (MonoError *error);
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (system_version, System, Version)
-static GENERATE_GET_CLASS_WITH_CACHE (assembly_name, System.Reflection, AssemblyName)
-static GENERATE_GET_CLASS_WITH_CACHE (constructor_info, System.Reflection, ConstructorInfo)
-static GENERATE_GET_CLASS_WITH_CACHE (property_info, System.Reflection, PropertyInfo)
-static GENERATE_GET_CLASS_WITH_CACHE (event_info, System.Reflection, EventInfo)
-static GENERATE_GET_CLASS_WITH_CACHE (module, System.Reflection, Module)
+static GENERATE_GET_CLASS_WITH_CACHE (system_version, System, "Version")
+static GENERATE_GET_CLASS_WITH_CACHE (assembly_name, System.Reflection, "AssemblyName")
+static GENERATE_GET_CLASS_WITH_CACHE (constructor_info, System.Reflection, "ConstructorInfo")
+static GENERATE_GET_CLASS_WITH_CACHE (property_info, System.Reflection, "PropertyInfo")
+static GENERATE_GET_CLASS_WITH_CACHE (event_info, System.Reflection, "EventInfo")
+static GENERATE_GET_CLASS_WITH_CACHE (module, System.Reflection, "Module")
 
 static MonoArrayHandle
 type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoError *error);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -111,12 +111,12 @@ extern MonoString* ves_icall_System_Environment_GetOSVersionString (void);
 ICALL_EXPORT MonoReflectionAssemblyHandle ves_icall_System_Reflection_Assembly_GetCallingAssembly (MonoError *error);
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (system_version, System, "Version")
-static GENERATE_GET_CLASS_WITH_CACHE (assembly_name, System.Reflection, "AssemblyName")
-static GENERATE_GET_CLASS_WITH_CACHE (constructor_info, System.Reflection, "ConstructorInfo")
-static GENERATE_GET_CLASS_WITH_CACHE (property_info, System.Reflection, "PropertyInfo")
-static GENERATE_GET_CLASS_WITH_CACHE (event_info, System.Reflection, "EventInfo")
-static GENERATE_GET_CLASS_WITH_CACHE (module, System.Reflection, "Module")
+static GENERATE_GET_CLASS_WITH_CACHE (system_version, "System", "Version")
+static GENERATE_GET_CLASS_WITH_CACHE (assembly_name, "System.Reflection", "AssemblyName")
+static GENERATE_GET_CLASS_WITH_CACHE (constructor_info, "System.Reflection", "ConstructorInfo")
+static GENERATE_GET_CLASS_WITH_CACHE (property_info, "System.Reflection", "PropertyInfo")
+static GENERATE_GET_CLASS_WITH_CACHE (event_info, "System.Reflection", "EventInfo")
+static GENERATE_GET_CLASS_WITH_CACHE (module, "System.Reflection", "Module")
 
 static MonoArrayHandle
 type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoError *error);

--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -34,7 +34,6 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/metadata-internals.h>
-#include <mono/metadata/gc-internals.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/mono-debug-debugger.h>
 #include <mono/metadata/mono-config.h>

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -56,7 +56,7 @@ static const CultureInfoEntry* culture_info_entry_from_lcid (int lcid);
 static const RegionInfoEntry* region_info_entry_from_lcid (int lcid);
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (culture_info, System.Globalization, CultureInfo)
+static GENERATE_GET_CLASS_WITH_CACHE (culture_info, System.Globalization, "CultureInfo")
 
 static int
 culture_lcid_locator (const void *a, const void *b)

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -56,7 +56,7 @@ static const CultureInfoEntry* culture_info_entry_from_lcid (int lcid);
 static const RegionInfoEntry* region_info_entry_from_lcid (int lcid);
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (culture_info, System.Globalization, "CultureInfo")
+static GENERATE_GET_CLASS_WITH_CACHE (culture_info, "System.Globalization", "CultureInfo")
 
 static int
 culture_lcid_locator (const void *a, const void *b)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -215,11 +215,11 @@ static void
 mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *error);
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (string_builder, System.Text, "StringBuilder");
-static GENERATE_GET_CLASS_WITH_CACHE (date_time, System, "DateTime");
-static GENERATE_GET_CLASS_WITH_CACHE (fixed_buffer_attribute, System.Runtime.CompilerServices, "FixedBufferAttribute");
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, System.Runtime.InteropServices, "UnmanagedFunctionPointerAttribute");
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, System.Runtime.InteropServices, "ICustomMarshaler");
+static GENERATE_GET_CLASS_WITH_CACHE (string_builder, "System.Text", "StringBuilder");
+static GENERATE_GET_CLASS_WITH_CACHE (date_time, "System", "DateTime");
+static GENERATE_GET_CLASS_WITH_CACHE (fixed_buffer_attribute, "System.Runtime.CompilerServices", "FixedBufferAttribute");
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, "System.Runtime.InteropServices", "UnmanagedFunctionPointerAttribute");
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, "System.Runtime.InteropServices", "ICustomMarshaler");
 
 /* MonoMethod pointers to SafeHandle::DangerousAddRef and ::DangerousRelease */
 static MonoMethod *sh_dangerous_add_ref;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -36,7 +36,6 @@
 #include "mono/metadata/threads-types.h"
 #include "mono/metadata/string-icalls.h"
 #include "mono/metadata/attrdefs.h"
-#include "mono/metadata/gc-internals.h"
 #include "mono/metadata/cominterop.h"
 #include "mono/metadata/remoting.h"
 #include "mono/metadata/reflection-internals.h"

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -216,11 +216,11 @@ static void
 mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *error);
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (string_builder, System.Text, StringBuilder);
-static GENERATE_GET_CLASS_WITH_CACHE (date_time, System, DateTime);
-static GENERATE_GET_CLASS_WITH_CACHE (fixed_buffer_attribute, System.Runtime.CompilerServices, FixedBufferAttribute);
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, System.Runtime.InteropServices, UnmanagedFunctionPointerAttribute);
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, System.Runtime.InteropServices, ICustomMarshaler);
+static GENERATE_GET_CLASS_WITH_CACHE (string_builder, System.Text, "StringBuilder");
+static GENERATE_GET_CLASS_WITH_CACHE (date_time, System, "DateTime");
+static GENERATE_GET_CLASS_WITH_CACHE (fixed_buffer_attribute, System.Runtime.CompilerServices, "FixedBufferAttribute");
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, System.Runtime.InteropServices, "UnmanagedFunctionPointerAttribute");
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, System.Runtime.InteropServices, "ICustomMarshaler");
 
 /* MonoMethod pointers to SafeHandle::DangerousAddRef and ::DangerousRelease */
 static MonoMethod *sh_dangerous_add_ref;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -71,11 +71,11 @@ static MonoMethod*
 class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is_proxy, MonoError *error);
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (pointer, System.Reflection, Pointer)
-static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, System.Runtime.Remoting, RemotingServices)
-static GENERATE_GET_CLASS_WITH_CACHE (unhandled_exception_event_args, System, UnhandledExceptionEventArgs)
-static GENERATE_GET_CLASS_WITH_CACHE (sta_thread_attribute, System, STAThreadAttribute)
-static GENERATE_GET_CLASS_WITH_CACHE (activation_services, System.Runtime.Remoting.Activation, ActivationServices)
+static GENERATE_GET_CLASS_WITH_CACHE (pointer, System.Reflection, "Pointer")
+static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, System.Runtime.Remoting, "RemotingServices")
+static GENERATE_GET_CLASS_WITH_CACHE (unhandled_exception_event_args, System, "UnhandledExceptionEventArgs")
+static GENERATE_GET_CLASS_WITH_CACHE (sta_thread_attribute, System, "STAThreadAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (activation_services, System.Runtime.Remoting.Activation, "ActivationServices")
 
 
 #define ldstr_lock() mono_os_mutex_lock (&ldstr_section)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -31,14 +31,12 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/marshal.h>
 #include "mono/metadata/debug-helpers.h"
-#include "mono/metadata/marshal.h"
 #include <mono/metadata/threads.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/environment.h>
 #include "mono/metadata/profiler-private.h"
 #include "mono/metadata/security-manager.h"
 #include "mono/metadata/mono-debug-debugger.h"
-#include <mono/metadata/gc-internals.h>
 #include <mono/metadata/verify-internals.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/w32event.h>

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -69,11 +69,11 @@ static MonoMethod*
 class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is_proxy, MonoError *error);
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (pointer, System.Reflection, "Pointer")
-static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, System.Runtime.Remoting, "RemotingServices")
-static GENERATE_GET_CLASS_WITH_CACHE (unhandled_exception_event_args, System, "UnhandledExceptionEventArgs")
-static GENERATE_GET_CLASS_WITH_CACHE (sta_thread_attribute, System, "STAThreadAttribute")
-static GENERATE_GET_CLASS_WITH_CACHE (activation_services, System.Runtime.Remoting.Activation, "ActivationServices")
+static GENERATE_GET_CLASS_WITH_CACHE (pointer, "System.Reflection", "Pointer")
+static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, "System.Runtime.Remoting", "RemotingServices")
+static GENERATE_GET_CLASS_WITH_CACHE (unhandled_exception_event_args, "System", "UnhandledExceptionEventArgs")
+static GENERATE_GET_CLASS_WITH_CACHE (sta_thread_attribute, "System", "STAThreadAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (activation_services, "System.Runtime.Remoting.Activation", "ActivationServices")
 
 
 #define ldstr_lock() mono_os_mutex_lock (&ldstr_section)

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -52,20 +52,20 @@ static void get_default_param_value_blobs (MonoMethod *method, char **blobs, gui
 static MonoType* mono_reflection_get_type_with_rootimage (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve, MonoError *error);
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (mono_assembly, System.Reflection, MonoAssembly)
-static GENERATE_GET_CLASS_WITH_CACHE (mono_module, System.Reflection, MonoModule)
-static GENERATE_GET_CLASS_WITH_CACHE (mono_method, System.Reflection, MonoMethod);
-static GENERATE_GET_CLASS_WITH_CACHE (mono_cmethod, System.Reflection, MonoCMethod);
-static GENERATE_GET_CLASS_WITH_CACHE (mono_field, System.Reflection, MonoField);
-static GENERATE_GET_CLASS_WITH_CACHE (mono_event, System.Reflection, MonoEvent);
-static GENERATE_GET_CLASS_WITH_CACHE (mono_property, System.Reflection, MonoProperty);
-static GENERATE_GET_CLASS_WITH_CACHE (mono_parameter_info, System.Reflection, MonoParameterInfo);
-static GENERATE_GET_CLASS_WITH_CACHE (missing, System.Reflection, Missing);
-static GENERATE_GET_CLASS_WITH_CACHE (method_body, System.Reflection, MethodBody);
-static GENERATE_GET_CLASS_WITH_CACHE (local_variable_info, System.Reflection, LocalVariableInfo);
-static GENERATE_GET_CLASS_WITH_CACHE (exception_handling_clause, System.Reflection, ExceptionHandlingClause);
-static GENERATE_GET_CLASS_WITH_CACHE (type_builder, System.Reflection.Emit, TypeBuilder);
-static GENERATE_GET_CLASS_WITH_CACHE (dbnull, System, DBNull);
+static GENERATE_GET_CLASS_WITH_CACHE (mono_assembly, System.Reflection, "MonoAssembly")
+static GENERATE_GET_CLASS_WITH_CACHE (mono_module, System.Reflection, "MonoModule")
+static GENERATE_GET_CLASS_WITH_CACHE (mono_method, System.Reflection, "MonoMethod");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_cmethod, System.Reflection, "MonoCMethod");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_field, System.Reflection, "MonoField");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_event, System.Reflection, "MonoEvent");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_property, System.Reflection, "MonoProperty");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_parameter_info, System.Reflection, "MonoParameterInfo");
+static GENERATE_GET_CLASS_WITH_CACHE (missing, System.Reflection, "Missing");
+static GENERATE_GET_CLASS_WITH_CACHE (method_body, System.Reflection, "MethodBody");
+static GENERATE_GET_CLASS_WITH_CACHE (local_variable_info, System.Reflection, "LocalVariableInfo");
+static GENERATE_GET_CLASS_WITH_CACHE (exception_handling_clause, System.Reflection, "ExceptionHandlingClause");
+static GENERATE_GET_CLASS_WITH_CACHE (type_builder, System.Reflection.Emit, "TypeBuilder");
+static GENERATE_GET_CLASS_WITH_CACHE (dbnull, System, "DBNull");
 
 
 static int class_ref_info_handle_count;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -52,20 +52,20 @@ static void get_default_param_value_blobs (MonoMethod *method, char **blobs, gui
 static MonoType* mono_reflection_get_type_with_rootimage (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve, MonoError *error);
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (mono_assembly, System.Reflection, "MonoAssembly")
-static GENERATE_GET_CLASS_WITH_CACHE (mono_module, System.Reflection, "MonoModule")
-static GENERATE_GET_CLASS_WITH_CACHE (mono_method, System.Reflection, "MonoMethod");
-static GENERATE_GET_CLASS_WITH_CACHE (mono_cmethod, System.Reflection, "MonoCMethod");
-static GENERATE_GET_CLASS_WITH_CACHE (mono_field, System.Reflection, "MonoField");
-static GENERATE_GET_CLASS_WITH_CACHE (mono_event, System.Reflection, "MonoEvent");
-static GENERATE_GET_CLASS_WITH_CACHE (mono_property, System.Reflection, "MonoProperty");
-static GENERATE_GET_CLASS_WITH_CACHE (mono_parameter_info, System.Reflection, "MonoParameterInfo");
-static GENERATE_GET_CLASS_WITH_CACHE (missing, System.Reflection, "Missing");
-static GENERATE_GET_CLASS_WITH_CACHE (method_body, System.Reflection, "MethodBody");
-static GENERATE_GET_CLASS_WITH_CACHE (local_variable_info, System.Reflection, "LocalVariableInfo");
-static GENERATE_GET_CLASS_WITH_CACHE (exception_handling_clause, System.Reflection, "ExceptionHandlingClause");
-static GENERATE_GET_CLASS_WITH_CACHE (type_builder, System.Reflection.Emit, "TypeBuilder");
-static GENERATE_GET_CLASS_WITH_CACHE (dbnull, System, "DBNull");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_assembly, "System.Reflection", "MonoAssembly")
+static GENERATE_GET_CLASS_WITH_CACHE (mono_module, "System.Reflection", "MonoModule")
+static GENERATE_GET_CLASS_WITH_CACHE (mono_method, "System.Reflection", "MonoMethod");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_cmethod, "System.Reflection", "MonoCMethod");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_field, "System.Reflection", "MonoField");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_event, "System.Reflection", "MonoEvent");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_property, "System.Reflection", "MonoProperty");
+static GENERATE_GET_CLASS_WITH_CACHE (mono_parameter_info, "System.Reflection", "MonoParameterInfo");
+static GENERATE_GET_CLASS_WITH_CACHE (missing, "System.Reflection", "Missing");
+static GENERATE_GET_CLASS_WITH_CACHE (method_body, "System.Reflection", "MethodBody");
+static GENERATE_GET_CLASS_WITH_CACHE (local_variable_info, "System.Reflection", "LocalVariableInfo");
+static GENERATE_GET_CLASS_WITH_CACHE (exception_handling_clause, "System.Reflection", "ExceptionHandlingClause");
+static GENERATE_GET_CLASS_WITH_CACHE (type_builder, "System.Reflection.Emit", "TypeBuilder");
+static GENERATE_GET_CLASS_WITH_CACHE (dbnull, "System", "DBNull");
 
 
 static int class_ref_info_handle_count;

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -70,9 +70,9 @@ static MonoReflectionType *
 type_from_handle (MonoType *handle);
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, System.Runtime.Remoting, "RemotingServices")
-static GENERATE_GET_CLASS_WITH_CACHE (call_context, System.Runtime.Remoting.Messaging, "CallContext")
-static GENERATE_GET_CLASS_WITH_CACHE (context, System.Runtime.Remoting.Contexts, "Context")
+static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, "System.Runtime.Remoting", "RemotingServices")
+static GENERATE_GET_CLASS_WITH_CACHE (call_context, "System.Runtime.Remoting.Messaging", "CallContext")
+static GENERATE_GET_CLASS_WITH_CACHE (context, "System.Runtime.Remoting.Contexts", "Context")
 
 static mono_mutex_t remoting_mutex;
 static gboolean remoting_mutex_inited;

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -70,9 +70,9 @@ static MonoReflectionType *
 type_from_handle (MonoType *handle);
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, System.Runtime.Remoting, RemotingServices)
-static GENERATE_GET_CLASS_WITH_CACHE (call_context, System.Runtime.Remoting.Messaging, CallContext)
-static GENERATE_GET_CLASS_WITH_CACHE (context, System.Runtime.Remoting.Contexts, Context)
+static GENERATE_GET_CLASS_WITH_CACHE (remoting_services, System.Runtime.Remoting, "RemotingServices")
+static GENERATE_GET_CLASS_WITH_CACHE (call_context, System.Runtime.Remoting.Messaging, "CallContext")
+static GENERATE_GET_CLASS_WITH_CACHE (context, System.Runtime.Remoting.Contexts, "Context")
 
 static mono_mutex_t remoting_mutex;
 static gboolean remoting_mutex_inited;

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -124,8 +124,8 @@ mono_security_core_clr_is_platform_image (MonoImage *image)
 #ifndef DISABLE_SECURITY
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (security_critical, System.Security, "SecurityCriticalAttribute")
-static GENERATE_GET_CLASS_WITH_CACHE (security_safe_critical, System.Security, "SecuritySafeCriticalAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (security_critical, "System.Security", "SecurityCriticalAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (security_safe_critical, "System.Security", "SecuritySafeCriticalAttribute")
 
 static MonoClass*
 security_critical_attribute (void)

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -124,8 +124,8 @@ mono_security_core_clr_is_platform_image (MonoImage *image)
 #ifndef DISABLE_SECURITY
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (security_critical, System.Security, SecurityCriticalAttribute)
-static GENERATE_GET_CLASS_WITH_CACHE (security_safe_critical, System.Security, SecuritySafeCriticalAttribute)
+static GENERATE_GET_CLASS_WITH_CACHE (security_critical, System.Security, "SecurityCriticalAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (security_safe_critical, System.Security, "SecuritySafeCriticalAttribute")
 
 static MonoClass*
 security_critical_attribute (void)

--- a/mono/metadata/security-manager.c
+++ b/mono/metadata/security-manager.c
@@ -11,8 +11,8 @@
 #include "security-manager.h"
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (security_manager, System.Security, SecurityManager)
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (execution_context, System.Threading, ExecutionContext)
+static GENERATE_GET_CLASS_WITH_CACHE (security_manager, System.Security, "SecurityManager")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (execution_context, System.Threading, "ExecutionContext")
 
 static MonoSecurityMode mono_security_mode = MONO_SECURITY_MODE_NONE;
 

--- a/mono/metadata/security-manager.c
+++ b/mono/metadata/security-manager.c
@@ -11,8 +11,8 @@
 #include "security-manager.h"
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (security_manager, System.Security, "SecurityManager")
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (execution_context, System.Threading, "ExecutionContext")
+static GENERATE_GET_CLASS_WITH_CACHE (security_manager, "System.Security", "SecurityManager")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (execution_context, "System.Threading", "ExecutionContext")
 
 static MonoSecurityMode mono_security_mode = MONO_SECURITY_MODE_NONE;
 

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -112,7 +112,7 @@ sgen_mono_array_size (GCVTable vtable, MonoArray *array, mword *bounds_size, mwo
 #define SGEN_CLIENT_OBJECT_HEADER_SIZE		(sizeof (GCObject))
 #define SGEN_CLIENT_MINIMUM_OBJECT_SIZE		SGEN_CLIENT_OBJECT_HEADER_SIZE
 
-static mword /*__attribute__((noinline)) not sure if this hint is a good idea*/
+static mword /*__attribute__ ((__noinline__)) not sure if this hint is a good idea*/
 sgen_client_slow_object_get_size (GCVTable vtable, GCObject* o)
 {
 	MonoClass *klass = ((MonoVTable*)vtable)->klass;

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -28,7 +28,6 @@
 #include "utils/mono-memory-model.h"
 #include "utils/mono-logger-internals.h"
 #include "utils/mono-threads-coop.h"
-#include "sgen/sgen-thread-pool.h"
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -36,8 +36,8 @@
 #include "mono/utils/mono-digest.h"
 #include "mono/utils/w32api.h"
 
-static GENERATE_GET_CLASS_WITH_CACHE (marshal_as_attribute, System.Runtime.InteropServices, "MarshalAsAttribute");
-static GENERATE_GET_CLASS_WITH_CACHE (module_builder, System.Reflection.Emit, "ModuleBuilder");
+static GENERATE_GET_CLASS_WITH_CACHE (marshal_as_attribute, "System.Runtime.InteropServices", "MarshalAsAttribute");
+static GENERATE_GET_CLASS_WITH_CACHE (module_builder, "System.Reflection.Emit", "ModuleBuilder");
 
 static char* string_to_utf8_image_raw (MonoImage *image, MonoString *s, MonoError *error);
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -36,8 +36,8 @@
 #include "mono/utils/mono-digest.h"
 #include "mono/utils/w32api.h"
 
-static GENERATE_GET_CLASS_WITH_CACHE (marshal_as_attribute, System.Runtime.InteropServices, MarshalAsAttribute);
-static GENERATE_GET_CLASS_WITH_CACHE (module_builder, System.Reflection.Emit, ModuleBuilder);
+static GENERATE_GET_CLASS_WITH_CACHE (marshal_as_attribute, System.Runtime.InteropServices, "MarshalAsAttribute");
+static GENERATE_GET_CLASS_WITH_CACHE (module_builder, System.Reflection.Emit, "ModuleBuilder");
 
 static char* string_to_utf8_image_raw (MonoImage *image, MonoString *s, MonoError *error);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -206,7 +206,7 @@ static gboolean shutting_down = FALSE;
 static gint32 managed_thread_id_counter = 0;
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, System, "AppDomainUnloadedException")
+static GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
 
 static void
 mono_threads_lock (void)

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -41,7 +41,6 @@
 #include <mono/utils/mono-tls.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-memory-model.h>
-#include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/os-event.h>
 #include <mono/utils/mono-threads-debug.h>
@@ -49,7 +48,6 @@
 #include <mono/metadata/w32event.h>
 #include <mono/metadata/w32mutex.h>
 
-#include <mono/metadata/gc-internals.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/abi-details.h>
 #include <mono/metadata/w32error.h>

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -208,7 +208,7 @@ static gboolean shutting_down = FALSE;
 static gint32 managed_thread_id_counter = 0;
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, System, AppDomainUnloadedException)
+static GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, System, "AppDomainUnloadedException")
 
 static void
 mono_threads_lock (void)

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -2080,10 +2080,10 @@ init_stack_with_value_at_exception_boundary (VerifyContext *ctx, ILCodeDesc *cod
 		code->stack->stype |= BOXED_MASK;
 }
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (ienumerable, System.Collections.Generic, IEnumerable`1)
-static GENERATE_GET_CLASS_WITH_CACHE (icollection, System.Collections.Generic, ICollection`1)
-static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_list, System.Collections.Generic, IReadOnlyList`1)
-static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_collection, System.Collections.Generic, IReadOnlyCollection`1)
+static GENERATE_GET_CLASS_WITH_CACHE (ienumerable, System.Collections.Generic, "IEnumerable`1")
+static GENERATE_GET_CLASS_WITH_CACHE (icollection, System.Collections.Generic, "ICollection`1")
+static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_list, System.Collections.Generic, "IReadOnlyList`1")
+static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_collection, System.Collections.Generic, "IReadOnlyCollection`1")
 
 
 static MonoClass*

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -28,7 +28,6 @@
 #include <mono/metadata/tokentype.h>
 #include <mono/metadata/mono-basic-block.h>
 #include <mono/metadata/attrdefs.h>
-#include <mono/metadata/class-internals.h>
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/monobitset.h>
 #include <string.h>

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -2079,10 +2079,10 @@ init_stack_with_value_at_exception_boundary (VerifyContext *ctx, ILCodeDesc *cod
 		code->stack->stype |= BOXED_MASK;
 }
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (ienumerable, System.Collections.Generic, "IEnumerable`1")
-static GENERATE_GET_CLASS_WITH_CACHE (icollection, System.Collections.Generic, "ICollection`1")
-static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_list, System.Collections.Generic, "IReadOnlyList`1")
-static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_collection, System.Collections.Generic, "IReadOnlyCollection`1")
+static GENERATE_GET_CLASS_WITH_CACHE (ienumerable, "System.Collections.Generic", "IEnumerable`1")
+static GENERATE_GET_CLASS_WITH_CACHE (icollection, "System.Collections.Generic", "ICollection`1")
+static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_list, "System.Collections.Generic", "IReadOnlyList`1")
+static GENERATE_GET_CLASS_WITH_CACHE (ireadonly_collection, "System.Collections.Generic", "IReadOnlyCollection`1")
 
 
 static MonoClass*

--- a/mono/mini/cfgdump.c
+++ b/mono/mini/cfgdump.c
@@ -21,7 +21,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <arpa/inet.h>
-#include <errno.h>
 
 #if 0
 #define CFG_DEBUG

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -830,9 +830,10 @@ parse_address (char *address, char **host, int *port)
 	if (pos == NULL || pos == address)
 		return 1;
 
-	*host = (char *)g_malloc (pos - address + 1);
-	strncpy (*host, address, pos - address);
-	(*host) [pos - address] = '\0';
+	size_t len = pos - address;
+	*host = (char *)g_malloc (len + 1);
+	memcpy (*host, address, len);
+	(*host) [len] = '\0';
 
 	*port = atoi (pos + 1);
 

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -23,7 +23,6 @@
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/debug-mono-symfile.h>
 #include <mono/metadata/mono-debug-debugger.h>
-#include <mono/utils/mono-compiler.h>
 
 #ifndef HOST_WIN32
 #include <mono/utils/freebsd-elf32.h>

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -163,8 +163,8 @@ static MonoMethodSignature *helper_sig_get_tls_tramp;
 static MonoMethodSignature *helper_sig_set_tls_tramp;
 
 /* type loading helpers */
-static GENERATE_GET_CLASS_WITH_CACHE (runtime_helpers, System.Runtime.CompilerServices, "RuntimeHelpers")
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (debuggable_attribute, System.Diagnostics, "DebuggableAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (runtime_helpers, "System.Runtime.CompilerServices", "RuntimeHelpers")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (debuggable_attribute, "System.Diagnostics", "DebuggableAttribute")
 
 /*
  * Instruction metadata

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -60,7 +60,6 @@
 #include <mono/metadata/profiler.h>
 #include <mono/metadata/monitor.h>
 #include <mono/metadata/debug-mono-symfile.h>
-#include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/metadata/mono-basic-block.h>

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -164,8 +164,8 @@ static MonoMethodSignature *helper_sig_get_tls_tramp;
 static MonoMethodSignature *helper_sig_set_tls_tramp;
 
 /* type loading helpers */
-static GENERATE_GET_CLASS_WITH_CACHE (runtime_helpers, System.Runtime.CompilerServices, RuntimeHelpers)
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (debuggable_attribute, System.Diagnostics, DebuggableAttribute)
+static GENERATE_GET_CLASS_WITH_CACHE (runtime_helpers, System.Runtime.CompilerServices, "RuntimeHelpers")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (debuggable_attribute, System.Diagnostics, "DebuggableAttribute")
 
 /*
  * Instruction metadata

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -53,7 +53,7 @@ static gpointer bp_trampoline;
 
 static gboolean ios_abi;
 
-static __attribute__((warn_unused_result)) guint8* emit_load_regset (guint8 *code, guint64 regs, int basereg, int offset);
+static __attribute__ ((__warn_unused_result__)) guint8* emit_load_regset (guint8 *code, guint64 regs, int basereg, int offset);
 
 const char*
 mono_arch_regname (int reg)
@@ -328,7 +328,7 @@ emit_imm64_template (guint8 *code, int dreg)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_addw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -340,7 +340,7 @@ emit_addw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_addx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -352,7 +352,7 @@ emit_addx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_subw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -364,7 +364,7 @@ emit_subw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_subx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -377,7 +377,7 @@ emit_subx_imm (guint8 *code, int dreg, int sreg, int imm)
 }
 
 /* Emit sp+=imm. Clobbers ip0/ip1 */
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_addx_sp_imm (guint8 *code, int imm)
 {
 	code = emit_imm (code, ARMREG_IP0, imm);
@@ -388,7 +388,7 @@ emit_addx_sp_imm (guint8 *code, int imm)
 }
 
 /* Emit sp-=imm. Clobbers ip0/ip1 */
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_subx_sp_imm (guint8 *code, int imm)
 {
 	code = emit_imm (code, ARMREG_IP0, imm);
@@ -398,7 +398,7 @@ emit_subx_sp_imm (guint8 *code, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_andw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -408,7 +408,7 @@ emit_andw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_andx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -418,7 +418,7 @@ emit_andx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_orrw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -428,7 +428,7 @@ emit_orrw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_orrx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -438,7 +438,7 @@ emit_orrx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_eorw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -448,7 +448,7 @@ emit_eorw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_eorx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -458,7 +458,7 @@ emit_eorx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_cmpw_imm (guint8 *code, int sreg, int imm)
 {
 	if (imm == 0) {
@@ -472,7 +472,7 @@ emit_cmpw_imm (guint8 *code, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_cmpx_imm (guint8 *code, int sreg, int imm)
 {
 	if (imm == 0) {
@@ -486,7 +486,7 @@ emit_cmpx_imm (guint8 *code, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_strb (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strb_imm (imm)) {
@@ -500,7 +500,7 @@ emit_strb (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_strh (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strh_imm (imm)) {
@@ -514,7 +514,7 @@ emit_strh (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_strw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strw_imm (imm)) {
@@ -528,7 +528,7 @@ emit_strw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_strfpw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strw_imm (imm)) {
@@ -542,7 +542,7 @@ emit_strfpw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_strfpx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strx_imm (imm)) {
@@ -556,7 +556,7 @@ emit_strfpx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_strx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strx_imm (imm)) {
@@ -570,7 +570,7 @@ emit_strx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrb (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 1)) {
@@ -584,7 +584,7 @@ emit_ldrb (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrsbx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 1)) {
@@ -598,7 +598,7 @@ emit_ldrsbx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrh (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 2)) {
@@ -612,7 +612,7 @@ emit_ldrh (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrshx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 2)) {
@@ -626,7 +626,7 @@ emit_ldrshx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrswx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 4)) {
@@ -640,7 +640,7 @@ emit_ldrswx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 4)) {
@@ -653,7 +653,7 @@ emit_ldrw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 8)) {
@@ -666,7 +666,7 @@ emit_ldrx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrfpw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 4)) {
@@ -680,7 +680,7 @@ emit_ldrfpw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrfpx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 8)) {
@@ -790,7 +790,7 @@ emit_tls_set (guint8 *code, int sreg, int tls_offset)
  * - ldrp [fp, lr], [sp], !stack_offfset
  * Clobbers TEMP_REGS.
  */
-__attribute__((warn_unused_result)) guint8*
+__attribute__ ((__warn_unused_result__)) guint8*
 mono_arm_emit_destroy_frame (guint8 *code, int stack_offset, guint64 temp_regs)
 {
 	arm_movspx (code, ARMREG_SP, ARMREG_FP);
@@ -2854,7 +2854,7 @@ opcode_to_armcond (int opcode)
 }
 
 /* This clobbers LR */
-static inline __attribute__((warn_unused_result)) guint8*
+static inline __attribute__ ((__warn_unused_result__)) guint8*
 emit_cond_exc (MonoCompile *cfg, guint8 *code, int opcode, const char *exc_name)
 {
 	int cond;
@@ -4483,7 +4483,7 @@ emit_move_args (MonoCompile *cfg, guint8 *code)
  *   Emit code to store the registers in REGS into the appropriate elements of
  * the register array at BASEREG+OFFSET.
  */
-static __attribute__((warn_unused_result)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_store_regarray (guint8 *code, guint64 regs, int basereg, int offset)
 {
 	int i;
@@ -4510,7 +4510,7 @@ emit_store_regarray (guint8 *code, guint64 regs, int basereg, int offset)
  *   Emit code to load the registers in REGS from the appropriate elements of
  * the register array at BASEREG+OFFSET.
  */
-static __attribute__((warn_unused_result)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_load_regarray (guint8 *code, guint64 regs, int basereg, int offset)
 {
 	int i;
@@ -4541,7 +4541,7 @@ emit_load_regarray (guint8 *code, guint64 regs, int basereg, int offset)
  *   Emit code to store the registers in REGS into consecutive memory locations starting
  * at BASEREG+OFFSET.
  */
-static __attribute__((warn_unused_result)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_store_regset (guint8 *code, guint64 regs, int basereg, int offset)
 {
 	int i, pos;
@@ -4571,7 +4571,7 @@ emit_store_regset (guint8 *code, guint64 regs, int basereg, int offset)
  *   Emit code to load the registers in REGS from consecutive memory locations starting
  * at BASEREG+OFFSET.
  */
-static __attribute__((warn_unused_result)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_load_regset (guint8 *code, guint64 regs, int basereg, int offset)
 {
 	int i, pos;
@@ -4594,19 +4594,19 @@ emit_load_regset (guint8 *code, guint64 regs, int basereg, int offset)
 	return code;
 }
 
-__attribute__((warn_unused_result)) guint8*
+__attribute__ ((__warn_unused_result__)) guint8*
 mono_arm_emit_load_regarray (guint8 *code, guint64 regs, int basereg, int offset)
 {
 	return emit_load_regarray (code, regs, basereg, offset);
 }
 
-__attribute__((warn_unused_result)) guint8*
+__attribute__ ((__warn_unused_result__)) guint8*
 mono_arm_emit_store_regarray (guint8 *code, guint64 regs, int basereg, int offset)
 {
 	return emit_store_regarray (code, regs, basereg, offset);
 }
 
-__attribute__((warn_unused_result)) guint8*
+__attribute__ ((__warn_unused_result__)) guint8*
 mono_arm_emit_store_regset (guint8 *code, guint64 regs, int basereg, int offset)
 {
 	return emit_store_regset (code, regs, basereg, offset);
@@ -4614,7 +4614,7 @@ mono_arm_emit_store_regset (guint8 *code, guint64 regs, int basereg, int offset)
 
 /* Same as emit_store_regset, but emit unwind info too */
 /* CFA_OFFSET is the offset between the CFA and basereg */
-static __attribute__((warn_unused_result)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_store_regset_cfa (MonoCompile *cfg, guint8 *code, guint64 regs, int basereg, int offset, int cfa_offset, guint64 no_cfa_regset)
 {
 	int i, j, pos, nregs;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1301,7 +1301,7 @@ mini_jit_info_table_find (MonoDomain *domain, char *addr, MonoDomain **out_domai
 }
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (runtime_compat_attr, System.Runtime.CompilerServices, "RuntimeCompatibilityAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (runtime_compat_attr, "System.Runtime.CompilerServices", "RuntimeCompatibilityAttribute")
 
 /*
  * wrap_non_exception_throws:

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1301,7 +1301,7 @@ mini_jit_info_table_find (MonoDomain *domain, char *addr, MonoDomain **out_domai
 }
 
 /* Class lazy loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (runtime_compat_attr, System.Runtime.CompilerServices, RuntimeCompatibilityAttribute)
+static GENERATE_GET_CLASS_WITH_CACHE (runtime_compat_attr, System.Runtime.CompilerServices, "RuntimeCompatibilityAttribute")
 
 /*
  * wrap_non_exception_throws:

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2673,7 +2673,7 @@ mini_method_is_open (MonoMethod *method)
 }
 
 /* Lazy class loading functions */
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (iasync_state_machine, System.Runtime.CompilerServices, IAsyncStateMachine)
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (iasync_state_machine, System.Runtime.CompilerServices, "IAsyncStateMachine")
 
 static G_GNUC_UNUSED gboolean
 is_async_state_machine_class (MonoClass *klass)

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2673,7 +2673,7 @@ mini_method_is_open (MonoMethod *method)
 }
 
 /* Lazy class loading functions */
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (iasync_state_machine, System.Runtime.CompilerServices, "IAsyncStateMachine")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (iasync_state_machine, "System.Runtime.CompilerServices", "IAsyncStateMachine")
 
 static G_GNUC_UNUSED gboolean
 is_async_state_machine_class (MonoClass *klass)

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -242,7 +242,7 @@ mono_pmip (void *ip)
  */
 #ifdef __GNUC__
 /* Prevent the linker from optimizing this away in embedding setups to help debugging */
- __attribute__((used))
+ __attribute__ ((__used__))
 #endif
 void
 mono_print_method_from_ip (void *ip)

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -352,7 +352,7 @@ typedef struct {
 typedef struct {
 	gint64	gr[5];		/* R2-R6			    */
 	gdouble fp[3];		/* F0-F2			    */
-} __attribute__ ((packed)) RegParm;
+} __attribute__ ((__packed__)) RegParm;
 
 typedef struct {
 	RR_Format  basr;
@@ -360,7 +360,7 @@ typedef struct {
 	void	   *pTrigger;
 	RXY_Format lg;
 	RXY_Format trigger;
-} __attribute__ ((packed)) breakpoint_t;
+} __attribute__ ((__packed__)) breakpoint_t;
 
 /*========================= End of Typedefs ========================*/
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -43,14 +43,10 @@
 #include "jit.h"
 #include "cfgdump.h"
 
-#include "mono/metadata/class-internals.h"
-#include "mono/metadata/domain-internals.h"
-#include "mono/metadata/object.h"
 #include "mono/metadata/tabledefs.h"
 #include "mono/metadata/marshal.h"
 #include "mono/metadata/security-manager.h"
 #include "mono/metadata/exception.h"
-#include "mono/utils/mono-compiler.h"
 
 #ifdef __native_client_codegen__
 #include <nacl/nacl_dyncode.h>

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -166,9 +166,10 @@ static void get_string (void)
 	}
 	if (value != NULL)
 		g_free (value);
-	value = (char *)g_malloc (input - start + 1);
-	strncpy (value, start, input-start);
-	value [input-start] = 0;
+	size_t len = input - start;
+	value = (char *)g_malloc (len + 1);
+	memcpy (value, start, len);
+	value [len] = 0;
 }
 
 enum Token {

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -182,7 +182,6 @@
 #include "mono/sgen/sgen-protocol.h"
 #include "mono/sgen/sgen-memory-governor.h"
 #include "mono/sgen/sgen-hash-table.h"
-#include "mono/sgen/sgen-cardtable.h"
 #include "mono/sgen/sgen-pinning.h"
 #include "mono/sgen/sgen-workers.h"
 #include "mono/sgen/sgen-client.h"

--- a/mono/sgen/sgen-protocol.h
+++ b/mono/sgen/sgen-protocol.h
@@ -83,7 +83,7 @@ enum {
 #define PROTOCOL_PACK_STRUCTS
 
 #if defined(__GNUC__)
-#define PROTOCOL_STRUCT_ATTR __attribute__ ((packed))
+#define PROTOCOL_STRUCT_ATTR __attribute__ ((__packed__))
 #else
 #define PROTOCOL_STRUCT_ATTR
 #endif

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -1132,7 +1132,7 @@ mono_test_marshal_stringbuilder (char *s, int n)
 
 	if (strcmp (s, "ABCD") != 0)
 		return 1;
-	strncpy(s, m, n);
+	memcpy(s, m, n);
 	s [n] = '\0';
 	return 0;
 }
@@ -1158,7 +1158,7 @@ mono_test_marshal_stringbuilder_default (char *s, int n)
 {
 	const char m[] = "This is my message.  Isn't it nice?";
 
-	strncpy(s, m, n);
+	memcpy(s, m, n);
 	s [n] = '\0';
 	return 0;
 }
@@ -7283,8 +7283,8 @@ build_return_string(const char* pReturn)
 
 	size_t strLength = strlen(pReturn);
 	ret = (char *)(marshal_alloc (sizeof(char)* (strLength + 1)));
-	memset(ret, '\0', strLength + 1);
-	strncpy(ret, pReturn, strLength);
+	memcpy(ret, pReturn, strLength);
+	ret [strLength] = '\0';
 	return ret;
 }
 

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -34,7 +34,7 @@ typedef int (STDCALL *SimpleDelegate) (int a);
 #if defined(WIN32) && defined (_MSC_VER)
 #define LIBTEST_API __declspec(dllexport)
 #elif defined(__GNUC__)
-#define LIBTEST_API  __attribute__ ((visibility ("default")))
+#define LIBTEST_API  __attribute__ ((__visibility__ ("default")))
 #else
 #define LIBTEST_API
 #endif
@@ -3577,7 +3577,7 @@ mono_test_marshal_ccw_itest (MonoComObject *pUnk)
  */
 
 #if defined(__GNUC__) && ((defined(__i386__) && (defined(__linux__) || defined (__APPLE__)) || defined (__FreeBSD__) || defined(__OpenBSD__)) || (defined(__ppc__) && defined(__APPLE__)))
-#define ALIGN(size) __attribute__ ((aligned(size)))
+#define ALIGN(size) __attribute__ ((__aligned__(size)))
 #else
 #define ALIGN(size)
 #endif

--- a/mono/utils/atomic.c
+++ b/mono/utils/atomic.c
@@ -524,7 +524,7 @@ InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
  * so we have to roll our own...
  */
 
-gint64 InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp) __attribute__ ((naked));
+gint64 InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp) __attribute__ ((__naked__));
 
 gint64
 InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -8,13 +8,13 @@
 #include <config.h>
 
 #ifdef __GNUC__
-#define MONO_ATTR_USED __attribute__ ((used))
+#define MONO_ATTR_USED __attribute__ ((__used__))
 #else
 #define MONO_ATTR_USED
 #endif
 
 #ifdef __GNUC__
-#define MONO_ATTR_FORMAT_PRINTF(fmt_pos,arg_pos) __attribute__((format(printf,fmt_pos,arg_pos)))
+#define MONO_ATTR_FORMAT_PRINTF(fmt_pos,arg_pos) __attribute__ ((__format__(__printf__,fmt_pos,arg_pos)))
 #else
 #define MONO_ATTR_FORMAT_PRINTF(fmt_pos,arg_pos)
 #endif
@@ -84,7 +84,7 @@ typedef SSIZE_T ssize_t;
 #define MONO_PROFILER_API MONO_API
 
 #ifdef __GNUC__
-#define MONO_ALWAYS_INLINE __attribute__((always_inline))
+#define MONO_ALWAYS_INLINE __attribute__ ((__always_inline__))
 #elif defined(_MSC_VER)
 #define MONO_ALWAYS_INLINE __forceinline
 #else
@@ -92,7 +92,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #ifdef __GNUC__
-#define MONO_NEVER_INLINE __attribute__((noinline))
+#define MONO_NEVER_INLINE __attribute__ ((__noinline__))
 #elif defined(_MSC_VER)
 #define MONO_NEVER_INLINE __declspec(noinline)
 #else
@@ -100,7 +100,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #ifdef __GNUC__
-#define MONO_COLD __attribute__((cold))
+#define MONO_COLD __attribute__ ((__cold__))
 #else
 #define MONO_COLD
 #endif

--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -505,7 +505,7 @@ sample_internal (MonoCounter *counter, void *buffer, int buffer_size)
 				size = 0;
 			} else {
 				size = counter->size;
-				strncpy ((char *) buffer, strval, size - 1);
+				memcpy ((char *) buffer, strval, size - 1);
 				((char*)buffer)[size - 1] = '\0';
 			}
 		}

--- a/mono/utils/mono-hwcap-s390x.c
+++ b/mono/utils/mono-hwcap-s390x.c
@@ -114,7 +114,7 @@ typedef struct {
 	uint8_t	sccm:1;		// 142 - Store CPU counter multiple
 	uint8_t ibm13:1;	// 143 - Assigned to IBM
 	uint8_t x015[14];	// 144-256 Undefined
-} __attribute__ ((packed)) __attribute__ ((aligned(8))) facilityList_t;
+} __attribute__ ((__packed__)) __attribute__ ((__aligned__(8))) facilityList_t;
 
 void
 mono_hwcap_arch_init (void)

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -218,7 +218,7 @@ get_pid_status_item_buf (int pid, const char *item, char *rbuf, int blen, MonoPr
 		while (g_ascii_isspace (*s)) s++;
 		fclose (f);
 		len = strlen (s);
-		strncpy (rbuf, s, MIN (len, blen));
+		memcpy (rbuf, s, MIN (len, blen));
 		rbuf [MIN (len, blen) - 1] = 0;
 		if (error)
 			*error = MONO_PROCESS_ERROR_NONE;
@@ -289,7 +289,7 @@ mono_process_get_name (gpointer pid, char *buf, int len)
 	memset (buf, 0, len);
 
 	if (sysctl_kinfo_proc (pid, &processi))
-		strncpy (buf, processi.kinfo_name_member, len - 1);
+		memcpy (buf, processi.kinfo_name_member, len - 1);
 
 	return buf;
 #else

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -45,7 +45,7 @@ typedef unsigned __int64	uint64_t;
 #include <stdint.h>
 
 #ifdef __GNUC__
-#define MONO_API_EXPORT __attribute__ ((visibility ("default")))
+#define MONO_API_EXPORT __attribute__ ((__visibility__ ("default")))
 #else
 #define MONO_API_EXPORT
 #endif
@@ -105,9 +105,9 @@ mono_set_allocator_vtable (MonoAllocatorVTable* vtable);
 #if defined (MONO_INSIDE_RUNTIME)
 
 #if defined (__clang__)
-#define MONO_RT_EXTERNAL_ONLY __attribute__ ((unavailable("The mono runtime must not call this function")))
+#define MONO_RT_EXTERNAL_ONLY __attribute__ ((__unavailable__ ("The mono runtime must not call this function")))
 #elif defined (__GNUC__)
-#define MONO_RT_EXTERNAL_ONLY __attribute__ ((error("The mono runtime must not call this function")))
+#define MONO_RT_EXTERNAL_ONLY __attribute__ ((__error__ ("The mono runtime must not call this function")))
 #else
 #define MONO_RT_EXTERNAL_ONLY
 #endif /* __clang__ */
@@ -117,7 +117,7 @@ mono_set_allocator_vtable (MonoAllocatorVTable* vtable);
 #endif /* MONO_INSIDE_RUNTIME */
 
 #ifdef __GNUC__
-#define _MONO_DEPRECATED __attribute__ ((deprecated))
+#define _MONO_DEPRECATED __attribute__ ((__deprecated__))
 #elif defined (_MSC_VER)
 #define _MONO_DEPRECATED __declspec (deprecated)
 #else

--- a/mono/utils/mono-rand.c
+++ b/mono/utils/mono-rand.c
@@ -59,7 +59,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, int buffer_size, MonoErr
 		err = errno;
 	} else {
 		egd_addr.sun_family = AF_UNIX;
-		strncpy (egd_addr.sun_path, path, sizeof (egd_addr.sun_path) - 1);
+		memcpy (egd_addr.sun_path, path, sizeof (egd_addr.sun_path) - 1);
 		egd_addr.sun_path [sizeof (egd_addr.sun_path) - 1] = '\0';
 		ret = connect (socket_fd, (struct sockaddr*) &egd_addr, sizeof (egd_addr));
 		err = errno;

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -41,7 +41,7 @@
 #ifdef KRAIT_IT_BUG_WORKAROUND
 #define MONO_SIGNAL_HANDLER_FUNC(access, name, arglist)		\
 	static void __krait_ ## name arglist;	\
-	__attribute__ ((naked)) access void				\
+	__attribute__ ((__naked__)) access void				\
 	name arglist							\
 	{								\
 		asm volatile (						\
@@ -52,7 +52,7 @@
 				  "b __krait_" # name			\
 				  "\n\t");						\
 	}	\
-	static __attribute__((used)) void __krait_ ## name arglist
+	static __attribute__ ((__used__)) void __krait_ ## name arglist
 #endif
 
 /* Don't use this */

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -240,8 +240,8 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 	} else {
 		char n [63];
 
-		strncpy (n, name, 63);
-		n [62] = '\0';
+		memcpy (n, name, sizeof (n) - 1);
+		n [sizeof (n) - 1] = '\0';
 		pthread_setname_np (n);
 	}
 #elif defined (__NetBSD__)
@@ -250,8 +250,8 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 	} else {
 		char n [PTHREAD_MAX_NAMELEN_NP];
 
-		strncpy (n, name, PTHREAD_MAX_NAMELEN_NP);
-		n [PTHREAD_MAX_NAMELEN_NP - 1] = '\0';
+		memcpy (n, name, sizeof (n) - 1);
+		n [sizeof (n) - 1] = '\0';
 		pthread_setname_np (tid, "%s", (void*)n);
 	}
 #elif defined (HAVE_PTHREAD_SETNAME_NP)
@@ -260,8 +260,8 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 	} else {
 		char n [16];
 
-		strncpy (n, name, 16);
-		n [15] = '\0';
+		memcpy (n, name, sizeof (n) - 1);
+		n [sizeof (n) - 1] = '\0';
 		pthread_setname_np (tid, n);
 	}
 #endif

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -58,7 +58,7 @@
 #if defined(PIC)
 
 #ifdef PIC_INITIAL_EXEC
-#define MONO_TLS_FAST __attribute__((tls_model("initial-exec")))
+#define MONO_TLS_FAST __attribute__ ((__tls_model__("initial-exec")))
 #else
 #if defined (__powerpc__)
 /* local dynamic requires a call to __tls_get_addr to look up the
@@ -70,13 +70,13 @@
    For now we will disable this. */
 #define MONO_TLS_FAST
 #else
-#define MONO_TLS_FAST __attribute__((tls_model("local-dynamic")))
+#define MONO_TLS_FAST __attribute__ ((__tls_model__("local-dynamic")))
 #endif
 #endif
 
 #else
 
-#define MONO_TLS_FAST __attribute__((tls_model("local-exec")))
+#define MONO_TLS_FAST __attribute__ ((__tls_model__("local-exec")))
 
 #endif
 

--- a/mono/utils/valgrind.h
+++ b/mono/utils/valgrind.h
@@ -6214,7 +6214,7 @@ typedef
 /* Modern GCC will optimize the static routine out if unused,
    and unused attribute will shut down warnings about it.  */
 static int VALGRIND_PRINTF(const char *format, ...)
-   __attribute__((format(__printf__, 1, 2), __unused__));
+   __attribute__ ((__format__(__printf__, 1, 2), __unused__));
 #endif
 static int
 #if defined(_MSC_VER)
@@ -6252,7 +6252,7 @@ VALGRIND_PRINTF(const char *format, ...)
 
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) && !defined(_MSC_VER)
 static int VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
-   __attribute__((format(__printf__, 1, 2), __unused__));
+   __attribute__ ((__format__(__printf__, 1, 2), __unused__));
 #endif
 static int
 #if defined(_MSC_VER)


### PR DESCRIPTION
[`flint`](https://github.com/facebookarchive/flint) is a C++ linter that is (was?) used at Facebook. These changes can be cherry-picked if not all of them are desirable.

* Remove unquoted <code>\`</code> and `^L` because compilers are not required to support them.

* Remove duplicate `#include` lines.

* Use `__attribute__ ((__foo__))` instead of `__attribute__ ((foo))` so that we can “use them in header files without being concerned about a possible macro of the same name” ([GCC manual](https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html#Attribute-Syntax)).

* Avoid `strncpy` because [somebody said so](http://meyering.net/crusade-to-eliminate-strncpy/).
