### PR TITLE
[cecil][linker] Bump cecil (cycle9 branch) and use the new setter for ExportedType.Scope. Fixes #51805

### DIFF
--- a/mcs/tools/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/mcs/tools/linker/Mono.Linker.Steps/SweepStep.cs
@@ -165,6 +165,7 @@ namespace Mono.Linker.Steps {
 					if ((td != null) && Annotations.IsMarked (td)) {
 						scope = assembly.MainModule.ImportReference (td).Scope;
 						hash.Add (td, scope);
+						et.Scope = scope;
 					}
 				}
 			}


### PR DESCRIPTION
Older Cecil (0.9) were saving the scope of the actual type. This changed
with Cecil 0.10 where the ExportedType.Scope is saved, which could lead
to invalid assemblies being saved with the current linker code (which
could not update the scope without the cecil bump)

reference:
https://bugzilla.xamarin.com/show_bug.cgi?id=51805