### PR TITLE
[runtime] Abcrem fixes.

### DIFF
--- a/mono/mini/abcremoval.c
+++ b/mono/mini/abcremoval.c
@@ -1299,9 +1299,21 @@ mono_perform_abc_removal (MonoCompile *cfg)
 
 		for (ins = bb->code; ins; ins = ins->next) {
 			const char *spec = INS_INFO (ins->opcode);
+			gint32 idx, *reg;
 			
 			if (spec [MONO_INST_DEST] == ' ' || MONO_IS_STORE_MEMBASE (ins))
 				continue;
+
+			MONO_INS_FOR_EACH_REG (ins, idx, reg) {
+				MonoInst *var = get_vreg_to_inst (cfg, *reg);
+				if (var && (!MONO_VARINFO (cfg, var->inst_c0)->def))
+						break;
+			}
+			if (idx < MONO_INST_LEN) {
+				if (TRACE_ABC_REMOVAL)
+					printf ("Global register %d is not in the SSA form, skipping.\n", *reg);
+				continue;
+			}
 
 			if (spec [MONO_INST_DEST] == 'i') {
 				MonoIntegerValueKind effective_value_kind;

--- a/mono/mini/abcremoval.c
+++ b/mono/mini/abcremoval.c
@@ -904,7 +904,7 @@ evaluate_relation_with_target_variable (MonoVariableRelationsEvaluationArea *are
 			
 			current_context = father_context;
 			while (current_context != last_context) {
-				int index = father_context - area->contexts;
+				int index = current_context - area->contexts;
 				MonoRelationsEvaluationStatus *current_status = &(area->statuses [index]);
 				*current_status = (MonoRelationsEvaluationStatus)(*current_status | recursive_status);
 				current_context = current_context->father;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -593,6 +593,20 @@ extern const gint8 ins_sreg_counts [];
 
 #define mono_bb_first_ins(bb) (bb)->code
 
+/*
+ * Iterate through all used registers in the instruction.
+ * Relies on the existing order of the MONO_INST enum: MONO_INST_{DREG,SREG1,SREG2,SREG3,LEN}
+ * INS is the instruction, IDX is the register index, REG is the pointer to a register.
+ */
+#define MONO_INS_FOR_EACH_REG(ins, idx, reg) for ((idx) = INS_INFO ((ins)->opcode)[MONO_INST_DEST] != ' ' ? MONO_INST_DEST : \
+							  (mono_inst_get_num_src_registers (ins) ? MONO_INST_SRC1 : MONO_INST_LEN); \
+						  (reg) = (idx) == MONO_INST_DEST ? &(ins)->dreg : \
+							  ((idx) == MONO_INST_SRC1 ? &(ins)->sreg1 : \
+							   ((idx) == MONO_INST_SRC2 ? &(ins)->sreg2 : \
+							    ((idx) == MONO_INST_SRC3 ? &(ins)->sreg3 : NULL))), \
+							  idx < MONO_INST_LEN; \
+						  (idx) = (idx) > mono_inst_get_num_src_registers (ins) + (INS_INFO ((ins)->opcode)[MONO_INST_DEST] != ' ') ? MONO_INST_LEN : (idx) + 1)
+
 struct MonoSpillInfo {
 	int offset;
 };

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -992,7 +992,7 @@ tests: $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la prereqs $(GSHARED_TESTS)
 #
 # Test that no symbols are missed in eglib-remap.h
 #
-OK_G_SYMBOLS='g_list\|g_slist\|g_concat_dir_and_file\|g_Ctoc\'
+OK_G_SYMBOLS='g_list\|g_slist\|g_concat_dir_and_file\|g_Ctoc'
 if NACL_CODEGEN
 test-eglib-remap:
 else


### PR DESCRIPTION
This PR is meant to fix the Array bounds check elimination phase.

Right now there are 2 problems.
1) A regression was introduced in commit 1796ad4 that resulted in contexts for recursive definitions not updating correctly. As the result it prevented Abcrem from identifying "good" cases. Commit 2c0490c should fix the problem.
2) The phase was presuming that all variables are in the SSA form, which is not correct. Commit 0560744 makes Abcrem skip all instructions that work with non-SSA variables, hence avoiding incorrect optimisations. Commit a1913ef introduces a new macro MONO_INS_FOR_EACH_REG which is used by the previous commit. It's not very pretty, but I think is still useful enough to have around to avoid code duplication caused by separate processing of dreg and sregs.

Also there's a one line fix for the test suite which was confusing Emacs' syntax highlighting on that makefile.