### PR TITLE
[threadpool] Fix hang on threadpool cleanup

### DIFF
--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -333,6 +333,7 @@ mono_threadpool_worker_cleanup (MonoThreadPoolWorker *worker)
 	/* unpark all worker->parked_threads */
 	mono_coop_cond_broadcast (&worker->parked_threads_cond);
 
+#if 0
 	for (;;) {
 		ThreadPoolWorkerCounter counter;
 
@@ -349,6 +350,7 @@ mono_threadpool_worker_cleanup (MonoThreadPoolWorker *worker)
 
 		mono_coop_cond_wait (&worker->threads_exit_cond, &worker->threads_lock);
 	}
+#endif
 
 	mono_coop_mutex_unlock (&worker->threads_lock);
 

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -187,6 +187,7 @@ cleanup (void)
 
 	mono_coop_mutex_unlock (&threadpool->threads_lock);
 
+#if 0
 	/* give a chance to the other threads to exit */
 	mono_thread_info_yield ();
 
@@ -205,6 +206,7 @@ cleanup (void)
 	}
 
 	mono_coop_mutex_unlock (&threadpool->threads_lock);
+#endif
 
 	mono_threadpool_worker_cleanup (threadpool->worker);
 


### PR DESCRIPTION
Waiting for the threadpool threads to exit on shutdown triggers a hand. The simplest solution is to not wait for them, and let the OS clean them up.

This is not an ideal solution, but this is to fix a months-long chase for this bug, and to release a less-buggy monthly release.