### PR TITLE
[runtime] Add a workaround for #50529 by locking around pthread_creat…

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2521,7 +2521,13 @@ mono_gc_deregister_root (char* addr)
 int
 mono_gc_pthread_create (pthread_t *new_thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg)
 {
-	return pthread_create (new_thread, attr, start_routine, arg);
+	int res;
+
+	mono_threads_join_lock ();
+	res = pthread_create (new_thread, attr, start_routine, arg);
+	mono_threads_join_unlock ();
+
+	return res;
 }
 #endif
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5085,7 +5085,9 @@ mono_threads_join_threads (void)
 			if (thread != pthread_self ()) {
 				MONO_ENTER_GC_SAFE;
 				/* This shouldn't block */
+				mono_threads_join_lock ();
 				mono_native_thread_join (thread);
+				mono_threads_join_unlock ();
 				MONO_EXIT_GC_SAFE;
 			}
 		} else {

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -613,4 +613,7 @@ mono_thread_info_wait_one_handle (MonoThreadHandle *handle, guint32 timeout, gbo
 MonoThreadInfoWaitRet
 mono_thread_info_wait_multiple_handle (MonoThreadHandle **thread_handles, gsize nhandles, MonoOSEvent *background_change_event, gboolean waitall, guint32 timeout, gboolean alertable);
 
+void mono_threads_join_lock (void);
+void mono_threads_join_unlock (void);
+
 #endif /* __MONO_THREADS_H__ */


### PR DESCRIPTION
…e()/pthread_join () calls so they can't happen at the same time.