### PR TITLE
Skip unwind info functions on Windows when JIT is disabled

### DIFF
--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -476,7 +476,7 @@ mono_amd64_get_tls_gs_offset (void) MONO_LLVM_INTERNAL;
 gpointer
 mono_amd64_handler_block_trampoline_helper (void);
 
-#ifdef TARGET_WIN32
+#if defined(TARGET_WIN32) && !defined(DISABLE_JIT)
 
 void mono_arch_unwindinfo_add_push_nonvol (gpointer* monoui, gpointer codebegin, gpointer nextip, guchar reg );
 void mono_arch_unwindinfo_add_set_fpreg (gpointer* monoui, gpointer codebegin, gpointer nextip, guchar reg );


### PR DESCRIPTION
mono_arch_code_chunk_new()/mono_arch_code_chunk_destroy() are not compiled in on Windows when DISABLED_JIT is defined. code_manager_chunk_new()/code_manager_chunk_destroy() in mini-runtime.c, which use these functions, will however be compiled in on Windows regardless of
whether DISABLED_JIT is defined or not. This causes linking failures due to missing mono_arch_code_chunk_new()/mono_arch_code_chunk_destroy() symbols when
building on Windows and DISABLE_JIT is defined.