### PR TITLE
[btls]: Fix MonoBtlsProvider.SetupCertificateStore(MonoTlsSettings,bool)

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -218,16 +218,6 @@ namespace Mono.Btls
 			isAuthenticated = true;
 		}
 
-		void SetupCertificateStore ()
-		{
-			MonoBtlsProvider.SetupCertificateStore (ctx.CertificateStore, Settings, IsServer);
-
-			if (Settings != null && Settings.TrustAnchors != null) {
-				var trust = IsServer ? MonoBtlsX509TrustKind.TRUST_CLIENT : MonoBtlsX509TrustKind.TRUST_SERVER;
-				ctx.CertificateStore.AddCollection (Settings.TrustAnchors, trust);
-			}
-		}
-
 		void InitializeConnection ()
 		{
 			ctx = new MonoBtlsSslCtx ();
@@ -237,7 +227,7 @@ namespace Mono.Btls
 			ctx.SetDebugBio (errbio);
 #endif
 
-			SetupCertificateStore ();
+			MonoBtlsProvider.SetupCertificateStore (ctx.CertificateStore, Settings, IsServer);
 
 			if (!IsServer || AskForClientCertificate)
 				ctx.SetVerifyCallback (VerifyCallback, false);

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -203,11 +203,13 @@ namespace Mono.Btls
 
 		internal static void SetupCertificateStore (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
 		{
+			if (settings?.CertificateSearchPaths == null)
+				AddTrustedRoots (store, settings, server);
+
 #if MONODROID
 			SetupCertificateStore (store);
 			return;
 #else
-
 			if (settings?.CertificateSearchPaths == null) {
 				SetupCertificateStore (store);
 				return;
@@ -265,6 +267,7 @@ namespace Mono.Btls
 			if (Directory.Exists (machinePath))
 				store.AddDirectoryLookup (machinePath, MonoBtlsX509FileType.PEM);
 		}
+#endif
 
 		static void AddTrustedRoots (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
 		{
@@ -273,7 +276,6 @@ namespace Mono.Btls
 			var trust = server ? MonoBtlsX509TrustKind.TRUST_CLIENT : MonoBtlsX509TrustKind.TRUST_SERVER;
 			store.AddCollection (settings.TrustAnchors, trust);
 		}
-#endif
 
 		public static string GetSystemStoreLocation ()
 		{


### PR DESCRIPTION
* When 'settings != null' and 'settings.CertificateSearchPaths == null',
  then we add the default paths, including the 'settings.TrustAnchors'.
  This applies to all platforms, including Android.

* In MonoBtlsContext, we can now simply call
  MonoTlsProvider.SetupCertificateStore(MonoTlsSettings,bool) instead of
  having a custom version of it.