### PR TITLE
[btls]: Fix MonoBtlsX509Store.cs.AddTrustedRoots().

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsX509Store.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509Store.cs
@@ -159,8 +159,7 @@ namespace Mono.Btls
 
 		internal void AddTrustedRoots ()
 		{
-			var systemRoot = MonoBtlsProvider.GetSystemStoreLocation ();
-			LoadLocations (null, systemRoot);
+			MonoBtlsProvider.SetupCertificateStore (this);
 		}
 
 		public MonoBtlsX509Lookup AddLookup (MonoBtlsX509LookupType type)


### PR DESCRIPTION
This internal method is only called from Mono.Btls.Interface.BtlsStore
and used by the web-tests.

Call MonoBtlsProvider.SetupCertificateStore(store) to make its
behavior consistent with the internal implementation.