### PR TITLE
[threadpool] Let the runtime abort and wait for threads on shutdown

### DIFF
--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -168,8 +168,6 @@ void mono_gc_wbarrier_set_root (gpointer ptr, MonoObject *value);
 	mono_gc_wbarrier_set_root (&((s)->fieldname), (MonoObject*)value); \
 } while (0)
 
-void  mono_gc_finalize_threadpool_threads (void);
-
 /* fast allocation support */
 
 typedef enum {

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -109,9 +109,6 @@ mono_runtime_try_shutdown (void)
 
 	mono_runtime_set_shutting_down ();
 
-	/* This will kill the tp threads which cannot be suspended */
-	mono_threadpool_cleanup ();
-
 	/*TODO move the follow to here:
 	mono_thread_suspend_all_other_threads (); OR  mono_thread_wait_all_other_threads
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -66,6 +66,7 @@
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/checked-build.h>
 #include <mono/metadata/w32handle.h>
+#include <mono/metadata/threadpool.h>
 
 #include "mini.h"
 #include "seq-points.h"
@@ -4105,6 +4106,8 @@ mini_cleanup (MonoDomain *domain)
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_cleanup (domain);
 #endif
+
+	mono_threadpool_cleanup ();
 
 	mono_profiler_shutdown ();
 

--- a/mono/utils/mono-lazy-init.h
+++ b/mono/utils/mono-lazy-init.h
@@ -52,7 +52,7 @@ enum {
 	MONO_LAZY_INIT_STATUS_CLEANED,
 };
 
-static inline void
+static inline gboolean
 mono_lazy_initialize (mono_lazy_init_t *lazy_init, void (*initialize) (void))
 {
 	gint32 status;
@@ -62,7 +62,7 @@ mono_lazy_initialize (mono_lazy_init_t *lazy_init, void (*initialize) (void))
 	status = *lazy_init;
 
 	if (status >= MONO_LAZY_INIT_STATUS_INITIALIZED)
-		return;
+		return status == MONO_LAZY_INIT_STATUS_INITIALIZED;
 	if (status == MONO_LAZY_INIT_STATUS_INITIALIZING
 	     || InterlockedCompareExchange (lazy_init, MONO_LAZY_INIT_STATUS_INITIALIZING, MONO_LAZY_INIT_STATUS_NOT_INITIALIZED)
 	         != MONO_LAZY_INIT_STATUS_NOT_INITIALIZED
@@ -70,12 +70,13 @@ mono_lazy_initialize (mono_lazy_init_t *lazy_init, void (*initialize) (void))
 		while (*lazy_init == MONO_LAZY_INIT_STATUS_INITIALIZING)
 			mono_thread_info_yield ();
 		g_assert (InterlockedRead (lazy_init) >= MONO_LAZY_INIT_STATUS_INITIALIZED);
-		return;
+		return status == MONO_LAZY_INIT_STATUS_INITIALIZED;
 	}
 
 	initialize ();
 
 	mono_atomic_store_release (lazy_init, MONO_LAZY_INIT_STATUS_INITIALIZED);
+	return TRUE;
 }
 
 static inline void


### PR DESCRIPTION
We would previously have the threadpool abort and wait for its threads during runtime shutdown, but it would tend to be buggy or leaky. The runtime already takes care of aborting and waiting all the other threads, so we simply also let it take care of the threadpool threads.