### PR TITLE
[runtime] Fix the reflected type of Delegate.Method if the method is …

### DIFF
--- a/mcs/class/corlib/Test/System/DelegateTest.cs
+++ b/mcs/class/corlib/Test/System/DelegateTest.cs
@@ -1453,6 +1453,26 @@ namespace MonoTests.System
 			Delegate.CreateDelegate(typeof(Action), this, m);
 		}
 
+		[Test]
+		public void ReflectedTypeInheritedVirtualMethod ()
+		{
+			var a = new DerivedClass ();
+
+			Action m = a.MyMethod;
+			Assert.AreEqual (typeof (BaseClass), m.Method.ReflectedType);
+		}
+
+		class BaseClass
+		{
+			public virtual void MyMethod() {
+				Console.WriteLine ("Base method");
+			}
+		}
+
+		class DerivedClass : BaseClass
+		{
+		}
+
 		public void AnyGenericMethod<T>()
 		{
 		}

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6239,7 +6239,10 @@ ves_icall_System_Delegate_GetVirtualMethod_internal (MonoDelegate *delegate)
 {
 	MonoReflectionMethod *ret = NULL;
 	MonoError error;
-	ret = mono_method_get_object_checked (mono_domain_get (), mono_object_get_virtual_method (delegate->target, delegate->method), mono_object_class (delegate->target), &error);
+	MonoMethod *m;
+
+	m = mono_object_get_virtual_method (delegate->target, delegate->method);
+	ret = mono_method_get_object_checked (mono_domain_get (), m, m->klass, &error);
 	mono_error_set_pending_exception (&error);
 	return ret;
 }


### PR DESCRIPTION
…an inherited virtual method. Fixes #39444.