### PR TITLE
[sgen] Don't restart threads with invalid stack start

### DIFF
--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -117,7 +117,7 @@ restart_threads_until_none_in_managed_allocator (void)
 			if (info->client_info.skip || info->client_info.gc_disabled || info->client_info.suspend_done)
 				continue;
 			if (mono_thread_info_is_live (info) &&
-					(!info->client_info.stack_start || info->client_info.in_critical_region || info->client_info.info.inside_critical_region ||
+					(info->client_info.in_critical_region || info->client_info.info.inside_critical_region ||
 					is_ip_in_managed_allocator (info->client_info.stopped_domain, info->client_info.stopped_ip))) {
 				binary_protocol_thread_restart ((gpointer)mono_thread_info_get_tid (info));
 				SGEN_LOG (3, "thread %p resumed.", (void*) (size_t) info->client_info.info.native_handle);


### PR DESCRIPTION
After suspending a thread, the old sgen suspend mechanism leaves the stack_start to NULL if it is not in the expected range (stack_start_limit - stack_end) and it used to restart it until it encountered a valid stack pointer. This was used in ancient times to prevent suspending threads on an altstack, which is no longer relevant since SIGSEGV handler masks the suspend signal. It can deadlock though if the thread tries to unregister itself and waits for suspend lock.

If the thread has a NULL stack start, we follow the unified pattern and leave it suspended without scanning it.

Fixes #52300