### PR TITLE
[swf] Fix pasting of Unicode text

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -2790,7 +2790,7 @@ namespace System.Windows.Forms {
 			//else if (format == "PenData" ) return 10;
 			//else if (format == "RiffAudio" ) return 11;
 			//else if (format == "WaveAudio" ) return 12;
-			else if (format == "UnicodeText" ) return UTF16_STRING.ToInt32();
+			else if (format == "UnicodeText" ) return UTF8_STRING.ToInt32();
 			//else if (format == "EnhancedMetafile" ) return 14;
 			//else if (format == "FileDrop" ) return 15;
 			//else if (format == "Locale" ) return 16;


### PR DESCRIPTION
Previously pasting of Unicode text, e.g. from LibreOffice, resulted in question marks being displayed.

This fixes [Xamarin-7359](https://bugzilla.xamarin.com/show_bug.cgi?id=7359).