### PR TITLE
[finalizer] Suspend finalizer thread after shutdown timeout

### DIFF
--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -178,6 +178,7 @@ void mono_thread_internal_check_for_interruption_critical (MonoInternalThread *t
 
 void mono_thread_internal_stop (MonoInternalThread *thread);
 void mono_thread_internal_abort (MonoInternalThread *thread);
+void mono_thread_internal_suspend_for_shutdown (MonoInternalThread *thread);
 
 gboolean mono_thread_internal_has_appdomain_ref (MonoInternalThread *thread, MonoDomain *domain);
 


### PR DESCRIPTION
This copies the way it's done in CoreCLR (see https://github.com/dotnet/coreclr/blob/5c47caa806e6907df81e7a96864984df4d0f38cd/src/vm/ceemain.cpp#L1911)

Fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=52429