### PR TITLE
[tools] Install pdb files for security tools

### DIFF
--- a/mcs/tools/security/Makefile
+++ b/mcs/tools/security/Makefile
@@ -40,6 +40,7 @@ install-local: $(SECURITY_TARGETS)
 	for p in $(SECURITY_TARGETS) ; do \
 	    $(INSTALL_BIN) $$p $(DESTDIR)$(PROGRAM_INSTALL_DIR) ; \
 	    test ! -f $$p.mdb || $(INSTALL_BIN) $$p.mdb $(DESTDIR)$(PROGRAM_INSTALL_DIR) ; \
+	    test ! -f $${p%.exe}.pdb || $(INSTALL_BIN) $${p%.exe}.pdb $(DESTDIR)$(PROGRAM_INSTALL_DIR) ; \
 	done
 
 uninstall-local:


### PR DESCRIPTION
We don't use the global executable.make install logic for the tools
in security so we missed updating this to copy .pdb's as well.