### PR TITLE
[btls]: Partial merge of #4318 and #4337. (#4345)

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -207,16 +207,6 @@ namespace Mono.Btls
 			isAuthenticated = true;
 		}
 
-		void SetupCertificateStore ()
-		{
-			MonoBtlsProvider.SetupCertificateStore (ctx.CertificateStore);
-
-			if (Settings != null && Settings.TrustAnchors != null) {
-				var trust = IsServer ? MonoBtlsX509TrustKind.TRUST_CLIENT : MonoBtlsX509TrustKind.TRUST_SERVER;
-				ctx.CertificateStore.AddCollection (Settings.TrustAnchors, trust);
-			}
-		}
-
 		void InitializeConnection ()
 		{
 			ctx = new MonoBtlsSslCtx ();
@@ -226,7 +216,7 @@ namespace Mono.Btls
 			ctx.SetDebugBio (errbio);
 #endif
 
-			SetupCertificateStore ();
+			MonoBtlsProvider.SetupCertificateStore (ctx.CertificateStore, Settings, IsServer);
 
 			if (!IsServer || AskForClientCertificate)
 				ctx.SetVerifyCallback (VerifyCallback, false);

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -150,7 +150,7 @@ namespace Mono.Btls
 			using (var nativeChain = MonoBtlsProvider.GetNativeChain (certificates))
 			using (var param = GetVerifyParam (targetHost, serverMode))
 			using (var storeCtx = new MonoBtlsX509StoreCtx ()) {
-				SetupCertificateStore (store);
+				SetupCertificateStore (store, validator.Settings, serverMode);
 
 				storeCtx.Initialize (store, nativeChain);
 
@@ -201,19 +201,45 @@ namespace Mono.Btls
 			}
 		}
 
+		internal static void SetupCertificateStore (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
+		{
+			AddTrustedRoots (store, settings, server);
+			SetupCertificateStore (store);
+		}
+
 		internal static void SetupCertificateStore (MonoBtlsX509Store store)
 		{
 #if MONODROID
 			store.SetDefaultPaths ();
 			store.AddAndroidLookup ();
 #else
+			AddUserStore (store);
+			AddMachineStore (store);
+#endif
+		}
+
+#if !MONODROID
+		static void AddUserStore (MonoBtlsX509Store store)
+		{
 			var userPath = MonoBtlsX509StoreManager.GetStorePath (MonoBtlsX509StoreType.UserTrustedRoots);
 			if (Directory.Exists (userPath))
 				store.AddDirectoryLookup (userPath, MonoBtlsX509FileType.PEM);
+		}
+
+		static void AddMachineStore (MonoBtlsX509Store store)
+		{
 			var machinePath = MonoBtlsX509StoreManager.GetStorePath (MonoBtlsX509StoreType.MachineTrustedRoots);
 			if (Directory.Exists (machinePath))
 				store.AddDirectoryLookup (machinePath, MonoBtlsX509FileType.PEM);
+		}
 #endif
+
+		static void AddTrustedRoots (MonoBtlsX509Store store, MonoTlsSettings settings, bool server)
+		{
+			if (settings?.TrustAnchors == null)
+				return;
+			var trust = server ? MonoBtlsX509TrustKind.TRUST_CLIENT : MonoBtlsX509TrustKind.TRUST_SERVER;
+			store.AddCollection (settings.TrustAnchors, trust);
 		}
 
 		public static string GetSystemStoreLocation ()

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509Store.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509Store.cs
@@ -159,8 +159,7 @@ namespace Mono.Btls
 
 		internal void AddTrustedRoots ()
 		{
-			var systemRoot = MonoBtlsProvider.GetSystemStoreLocation ();
-			LoadLocations (null, systemRoot);
+			MonoBtlsProvider.SetupCertificateStore (this);
 		}
 
 		public MonoBtlsX509Lookup AddLookup (MonoBtlsX509LookupType type)


### PR DESCRIPTION
* [btls]: Partial merge of #4318 and #4337.

Partially merged commits 4ecb683 and 4c6c6f0 from master without adding
'MonoTlsSettings.CertificateSearchPath'.

* Add MonoBtlsProvider.SetupCertificateStore(MonoBtlsX509Store,MonoTlsSettings,bool)
  overload, which adds 'settings.TrustAnchors' if applicable.

* MonoBtlsContext: call it instead of having our own custom implementation.

* [btls]: Fix MonoBtlsX509Store.cs.AddTrustedRoots(). (#4340)

This internal method is only called from Mono.Btls.Interface.BtlsStore
and used by the web-tests.

Call MonoBtlsProvider.SetupCertificateStore(store) to make its
behavior consistent with the internal implementation.
(cherry picked from commit 8b18c8428913c655087929903e830abdbd0bf01c)

* [btls]: Partial merge of #4318, #4337 and #4340.

Partially merged commits 4ecb683, 4c6c6f0 and 8b18c84 from master
(without adding 'MonoTlsSettings.CertificateSearchPath').

* Add MonoBtlsProvider.SetupCertificateStore(MonoBtlsX509Store,MonoTlsSettings,bool)
  overload, which adds 'settings.TrustAnchors' if applicable.

* MonoBtlsContext: call it instead of having our own custom implementation.

* Fix MonoBtlsX509Store.cs.AddTrustedRoots(). (#4340)

  This internal method is only called from Mono.Btls.Interface.BtlsStore
  and used by the web-tests. Call MonoBtlsProvider.SetupCertificateStore(store)
  to make its behavior consistent with the internal implementation.

(cherry picked from commit 50c26943d4286818ba44033983727a168edd69d0)