### PR TITLE
Fix mono build with disabled sgen

### DIFF
--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -8,7 +8,7 @@ if SUPPORT_SGEN
 metadata_lib=$(top_builddir)/mono/metadata/libmonoruntimesgen-static.la
 gc_lib=$(top_builddir)/mono/sgen/libmonosgen-static.la
 else
-metadata_lib=$(top_builddir)/mono/metadata/libmonoruntime-static.a
+metadata_lib=$(top_builddir)/mono/metadata/libmonoruntime-static.la
 gc_lib=$(LIBGC_STATIC_LIBS)
 endif
 

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -10,6 +10,7 @@ endif
 if !CROSS_COMPILE
 if !HOST_WIN32
 if SUPPORT_BOEHM
+if SUPPORT_SGEN
 
 noinst_LTLIBRARIES = libtestlib.la
 libtestlib_la_SOURCES =
@@ -54,6 +55,7 @@ check-local:
 		echo "</test-case></results></test-suite></test-results>" >> TestResult-unit-tests.xml; \
 	fi;
 
+endif SUPPORT_SGEN
 endif SUPPORT_BOEHM
 endif !HOST_WIN32
 endif !CROSS_COMPILE


### PR DESCRIPTION
Build of the mono-4.8.0 fails now with the Boehm GC only (without of SGEN)
if it configured like this: --with-gc=included --with-sgen=no