### PR TITLE
[man] Remove outdated version numbers

### DIFF
--- a/man/gacutil.1
+++ b/man/gacutil.1
@@ -8,7 +8,7 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH gacutil "Mono 1.0"
+.TH Mono "gacutil"
 .SH NAME
 gacutil \- Global Assembly Cache management utility.
 .SH SYNOPSIS

--- a/man/lc.1
+++ b/man/lc.1
@@ -9,7 +9,7 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH lc "Mono 2.6"
+.TH Mono "lc"
 .SH NAME
 lc \- Mono License Compiler
 .SH SYNOPSIS

--- a/man/macpack.1
+++ b/man/macpack.1
@@ -8,7 +8,7 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH macpack "Mono 1.0"
+.TH Mono "macpack"
 .SH NAME
 macpack \- Macintosh OS X Packager for managed gui assemblies
 .SH SYNOPSIS

--- a/man/mdb2ppdb.1
+++ b/man/mdb2ppdb.1
@@ -1,8 +1,8 @@
 .\" 
-.\" mono manual page.
+.\" mdb2ppdb manual page.
 .\" Copyright 2017 Microsoft 
 .\"
-.TH Mono "Mono 4.8.0"
+.TH Mono "mdb2ppdb"
 .SH NAME
 mdb2ppdb \- Convert Mono's debug file format (MDB) to Portable Program
 Database (PPDB) file formatn

--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -8,7 +8,7 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH mkbundle "mkbundle 1.0"
+.TH Mono "mkbundle"
 .SH NAME
 mkbundle, mkbundle2 \- Creates a bundled executable.
 .SH SYNOPSIS

--- a/man/mono-config.5
+++ b/man/mono-config.5
@@ -5,7 +5,7 @@
 .\"   Miguel de Icaza (miguel@gnu.org)
 .\"   Paolo Molaro (lupus@ximian.com)
 .\"
-.TH Mono "Mono 1.0"
+.TH Mono "mono-config"
 .SH NAME
 mono-config \- Mono runtime file format configuration
 .SH DESCRIPTION

--- a/man/mono-service.1
+++ b/man/mono-service.1
@@ -8,7 +8,7 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH Mono "Mono 1.0"
+.TH Mono "mono-service"
 .SH NAME
 mono-service, mono-service2 \- Mono ServiceProcess host
 .SH SYNOPSIS

--- a/man/mono-xmltool.1
+++ b/man/mono-xmltool.1
@@ -9,7 +9,7 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH mono-xmltool "Mono 1.0"
+.TH Mono "mono-xmltool"
 .SH NAME
 mono-xmltool \- Mono XML validation and transformation tool. 
 .SH SYNOPSIS

--- a/man/mono.1
+++ b/man/mono.1
@@ -7,7 +7,7 @@
 .\" Author:
 .\"   Miguel de Icaza (miguel@gnu.org)
 .\"
-.TH Mono "Mono 4.7.0"
+.TH Mono "mono"
 .SH NAME
 mono \- Mono's ECMA-CLI native code generator (Just-in-Time and Ahead-of-Time)
 .SH SYNOPSIS

--- a/man/resgen.1
+++ b/man/resgen.1
@@ -8,7 +8,7 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH resgen "resgen 1.0"
+.TH Mono "resgen"
 .SH NAME
 resgen, resgen2 \- Mono/CLI Resource Generator
 .SH SYNOPSIS


### PR DESCRIPTION
We haven't been consistent in keeping those version numbers up to date as we bump Mono's version so it's less confusing to not show them in the manual pages.

`mono --version` is and has been the source of truth.