### PR TITLE
[checked] Fix asserts in w32file-unix.c in checked mode

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3651,7 +3651,9 @@ mono_w32file_find_close (gpointer handle)
 
 	mono_w32handle_unlock_handle (handle);
 	
+	MONO_ENTER_GC_SAFE;
 	mono_w32handle_unref (handle);
+	MONO_EXIT_GC_SAFE;
 	
 	return(TRUE);
 }
@@ -4032,9 +4034,10 @@ mono_w32file_create_pipe (gpointer *readpipe, gpointer *writepipe, guint32 size)
 					    &pipe_write_handle);
 	if (write_handle == INVALID_HANDLE_VALUE) {
 		g_warning ("%s: error creating pipe write handle", __func__);
+
+		MONO_ENTER_GC_SAFE;
 		mono_w32handle_unref (read_handle);
 		
-		MONO_ENTER_GC_SAFE;
 		close (filedes[0]);
 		close (filedes[1]);
 		MONO_EXIT_GC_SAFE;

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -1099,7 +1099,7 @@ static void _wapi_set_last_path_error_from_errno (const gchar *dir,
  */
 static void file_close (gpointer handle, gpointer data)
 {
-	MONO_REQ_GC_SAFE_MODE; /* FIXME: after mono_w32handle_close is coop-aware, change this to UNSAFE_MODE and switch to SAFE around close() below */
+	/* FIXME: after mono_w32handle_close is coop-aware, change this to MONO_REQ_GC_UNSAFE_MODE and leave just the switch to SAFE around close() below */
 	MONO_ENTER_GC_UNSAFE;
 	MonoW32HandleFile *file_handle = (MonoW32HandleFile *)data;
 	gint fd = file_handle->fd;
@@ -1839,7 +1839,7 @@ static gboolean file_setfiletime(gpointer handle,
 
 static void console_close (gpointer handle, gpointer data)
 {
-	MONO_REQ_GC_SAFE_MODE; /* FIXME: after mono_w32handle_close is coop-aware, change this to UNSAFE_MODE and switch to SAFE around close() below */
+	/* FIXME: after mono_w32handle_close is coop-aware, change this to MONO_REQ_GC_UNSAFE_MODE and leave just the switch to SAFE around close() below */
 	MONO_ENTER_GC_UNSAFE;
 	MonoW32HandleFile *console_handle = (MonoW32HandleFile *)data;
 	gint fd = console_handle->fd;
@@ -1998,7 +1998,7 @@ static gsize find_typesize (void)
 
 static void pipe_close (gpointer handle, gpointer data)
 {
-	MONO_REQ_GC_SAFE_MODE; /* FIXME: after mono_w32handle_close is coop-aware, change this to UNSAFE_MODE and switch to SAFE around close() below */
+	/* FIXME: after mono_w32handle_close is coop-aware, change this to MONO_REQ_GC_UNSAFE_MODE and leave just the switch to SAFE around close() below */
 	MONO_ENTER_GC_UNSAFE;
 	MonoW32HandleFile *pipe_handle = (MonoW32HandleFile*)data;
 	gint fd = pipe_handle->fd;

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -2682,11 +2682,7 @@ ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoString *f
 		return FALSE;
 	}
 
-	MONO_ENTER_GC_SAFE;
-
 	mono_w32file_close (file);
-
-	MONO_EXIT_GC_SAFE;
 
 	if (*werror)
 		return FALSE;

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -245,7 +245,7 @@ mono_fatal_with_history (const char *msg, ...)
 #ifdef ENABLE_CHECKED_BUILD_GC
 
 void
-assert_gc_safe_mode (void)
+assert_gc_safe_mode (const char *file, int lineno)
 {
 	if (!mono_check_mode_enabled (MONO_CHECK_MODE_GC))
 		return;
@@ -254,19 +254,19 @@ assert_gc_safe_mode (void)
 	int state;
 
 	if (!cur)
-		mono_fatal_with_history ("Expected GC Safe mode but thread is not attached");
+		mono_fatal_with_history ("%s:%d: Expected GC Safe mode but thread is not attached", file, lineno);
 
 	switch (state = mono_thread_info_current_state (cur)) {
 	case STATE_BLOCKING:
 	case STATE_BLOCKING_AND_SUSPENDED:
 		break;
 	default:
-		mono_fatal_with_history ("Expected GC Safe mode but was in %s state", mono_thread_state_name (state));
+		mono_fatal_with_history ("%s:%d: Expected GC Safe mode but was in %s state", file, lineno, mono_thread_state_name (state));
 	}
 }
 
 void
-assert_gc_unsafe_mode (void)
+assert_gc_unsafe_mode (const char *file, int lineno)
 {
 	if (!mono_check_mode_enabled (MONO_CHECK_MODE_GC))
 		return;
@@ -275,7 +275,7 @@ assert_gc_unsafe_mode (void)
 	int state;
 
 	if (!cur)
-		mono_fatal_with_history ("Expected GC Unsafe mode but thread is not attached");
+		mono_fatal_with_history ("%s:%d: Expected GC Unsafe mode but thread is not attached", file, lineno);
 
 	switch (state = mono_thread_info_current_state (cur)) {
 	case STATE_RUNNING:
@@ -283,12 +283,12 @@ assert_gc_unsafe_mode (void)
 	case STATE_SELF_SUSPEND_REQUESTED:
 		break;
 	default:
-		mono_fatal_with_history ("Expected GC Unsafe mode but was in %s state", mono_thread_state_name (state));
+		mono_fatal_with_history ("%s:%d: Expected GC Unsafe mode but was in %s state", file, lineno, mono_thread_state_name (state));
 	}
 }
 
 void
-assert_gc_neutral_mode (void)
+assert_gc_neutral_mode (const char *file, int lineno)
 {
 	if (!mono_check_mode_enabled (MONO_CHECK_MODE_GC))
 		return;
@@ -297,7 +297,7 @@ assert_gc_neutral_mode (void)
 	int state;
 
 	if (!cur)
-		mono_fatal_with_history ("Expected GC Neutral mode but thread is not attached");
+		mono_fatal_with_history ("%s:%d: Expected GC Neutral mode but thread is not attached", file, lineno);
 
 	switch (state = mono_thread_info_current_state (cur)) {
 	case STATE_RUNNING:
@@ -307,7 +307,7 @@ assert_gc_neutral_mode (void)
 	case STATE_BLOCKING_AND_SUSPENDED:
 		break;
 	default:
-		mono_fatal_with_history ("Expected GC Neutral mode but was in %s state", mono_thread_state_name (state));
+		mono_fatal_with_history ("%s:%d: Expected GC Neutral mode but was in %s state", file, lineno, mono_thread_state_name (state));
 	}
 }
 

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -106,15 +106,15 @@ Functions that can be called from both coop or preept modes.
 */
 
 #define MONO_REQ_GC_SAFE_MODE do {	\
-	assert_gc_safe_mode ();	\
+	assert_gc_safe_mode (__FILE__, __LINE__);	\
 } while (0);
 
 #define MONO_REQ_GC_UNSAFE_MODE do {	\
-	assert_gc_unsafe_mode ();	\
+	assert_gc_unsafe_mode (__FILE__, __LINE__);	\
 } while (0);
 
 #define MONO_REQ_GC_NEUTRAL_MODE do {	\
-	assert_gc_neutral_mode ();	\
+	assert_gc_neutral_mode (__FILE__, __LINE__);	\
 } while (0);
 
 /* In a GC critical region, the thread is not allowed to switch to GC safe mode.
@@ -140,9 +140,9 @@ Functions that can be called from both coop or preept modes.
 		assert_in_gc_critical_region();	\
 	} while(0)
 
-void assert_gc_safe_mode (void);
-void assert_gc_unsafe_mode (void);
-void assert_gc_neutral_mode (void);
+void assert_gc_safe_mode (const char *file, int lineno);
+void assert_gc_unsafe_mode (const char *file, int lineno);
+void assert_gc_neutral_mode (const char *file, int lineno);
 
 void* critical_gc_region_begin(void);
 void critical_gc_region_end(void* token);


### PR DESCRIPTION
Until w32handle is coop aware, we don't actually know when these callbacks might be called, so asserting that we're in GC safe mode on callback entry is wrong.