### PR TITLE
[socket] Do not invoke callback on threadpool

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
@@ -147,7 +147,7 @@ namespace System.Net.Sockets
 
 			AsyncCallback callback = AsyncCallback;
 			if (callback != null) {
-				ThreadPool.UnsafeQueueUserWorkItem (_ => callback (this), null);
+				callback (this);
 			}
 
 			switch (operation) {


### PR DESCRIPTION
We might run in a race condition if we invoke the callback on the threadpool: if we have a thread looping over AcceptAsync for example, we can call the AcceptAsync callback twice, while only one socket is available.