### PR TITLE
[socket] Fix bad parameter passed to select

### DIFF
--- a/mono/utils/mono-poll.c
+++ b/mono/utils/mono-poll.c
@@ -60,7 +60,7 @@ mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 			return 1;
 		}
 #else
-		if (fd > FD_SETSIZE) {
+		if (fd >= FD_SETSIZE) {
 			ufds [i].revents = MONO_POLLNVAL;
 			return 1;
 		}


### PR DESCRIPTION
If fd is equals to FD_SETSIZE, then we pass (FD_SETSIZE + 1) as first parameter to select, making it return EINVAL.