### PR TITLE
[xbuild] Show the deprecation notice with logo, and so hide it with

### DIFF
--- a/mcs/tools/xbuild/Main.cs
+++ b/mcs/tools/xbuild/Main.cs
@@ -82,12 +82,13 @@ namespace Mono.XBuild.CommandLine {
 					throw;
 				}
 
-				ShowDeprecationNotice ();
 				show_stacktrace = (parameters.LoggerVerbosity == LoggerVerbosity.Detailed ||
 					parameters.LoggerVerbosity == LoggerVerbosity.Diagnostic);
 				
-				if (!parameters.NoLogo)
+				if (!parameters.NoLogo) {
+					ShowDeprecationNotice ();
 					ErrorUtilities.ShowVersion (false);
+				}
 				
 				engine  = Engine.GlobalEngine;
 				if (!String.IsNullOrEmpty (parameters.ToolsVersion)) {
@@ -175,13 +176,11 @@ namespace Mono.XBuild.CommandLine {
 
 		void ShowDeprecationNotice ()
 		{
-			if (parameters.LoggerVerbosity != LoggerVerbosity.Minimal && parameters.LoggerVerbosity != LoggerVerbosity.Quiet) {
-				Console.ForegroundColor = ConsoleColor.DarkRed;
-				Console.WriteLine ();
-				Console.WriteLine (">>>> xbuild tool is deprecated and will be removed in future updates, use msbuild instead <<<<");
-				Console.WriteLine ();
-				Console.ResetColor ();
-			}
+			Console.ForegroundColor = ConsoleColor.DarkRed;
+			Console.WriteLine ();
+			Console.WriteLine (">>>> xbuild tool is deprecated and will be removed in future updates, use msbuild instead <<<<");
+			Console.WriteLine ();
+			Console.ResetColor ();
 		}
 	}
 


### PR DESCRIPTION
`/nologo`. It is not controlled by logging levels now.
But we also show the deprecation notice if we couldn't parse
the arguments, which would be more likely to be noticed by a user.