### PR TITLE
[bcl] Add API diff targets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "external/api-doc-tools"]
 	path = external/api-doc-tools
 	url = git://github.com/mono/api-doc-tools.git
+[submodule "external/api-snapshot"]
+	path = external/api-snapshot
+	url = git://github.com/mono/api-snapshot.git

--- a/mcs/.gitignore
+++ b/mcs/.gitignore
@@ -11,6 +11,7 @@ TestResult-*.log
 TestResult-*.xml
 TestResult*.xml
 .dep_dirs-*
+apidiff/*
 errors/*.log
 errors/dummy.xml
 class/Mono.Data.Sqlite/test.db

--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -159,3 +159,29 @@ monocharge-lite:
 	$(MAKE) -C class/Mono.CSharp.Debugger install DESTDIR="$$DESTDIR" || exit 1; \
 	tar cvjf "$$chargedir".tar.bz2 "$$chargedir" ; \
 	rm -rf "$$chargedir"
+
+# Targets for creating API diffs of the framework
+
+MONO_API_SNAPSHOT_PATH := $(topdir)../external/api-snapshot/
+GENAPI := $(MONO_API_SNAPSHOT_PATH)tools/genapi/GenAPI.exe
+MONO_API_SNAPSHOT_PROFILE_PATH := $(MONO_API_SNAPSHOT_PATH)profiles/$(PROFILE)/
+MONO_API_ASSEMBLIES_IGNORED := $(addprefix $(topdir)class/lib/$(PROFILE)/, SystemWebTestShim.dll standalone-runner-support.dll nunit.core.dll nunit.core.extensions.dll nunit.core.interfaces.dll nunit.framework.dll nunit.framework.extensions.dll nunit.mocks.dll nunit.util.dll nunit-console-runner.dll nunitlite.dll)
+MONO_API_ASSEMBLIES := $(filter-out $(MONO_API_ASSEMBLIES_IGNORED), $(wildcard $(topdir)class/lib/$(PROFILE)/*.dll)) $(wildcard $(topdir)class/lib/$(PROFILE)/Facades/*.dll)
+MONO_API_ASSEMBLIES_CS := $(MONO_API_ASSEMBLIES:$(topdir)class/lib/$(PROFILE)/%.dll=$(MONO_API_SNAPSHOT_PROFILE_PATH)%.cs)
+
+$(MONO_API_SNAPSHOT_PROFILE_PATH)%.cs: $(topdir)class/lib/$(PROFILE)/%.dll $(GENAPI) $(MONO_API_SNAPSHOT_PATH)profiles/license-header.txt
+	@mkdir -p $(dir $@)
+	$(Q) MONO_PATH=$(topdir)class/lib/$(BUILD_TOOLS_PROFILE) $(RUNTIME) $(GENAPI) -libPath:$(topdir)class/lib/$(PROFILE),$(topdir)class/lib/$(PROFILE)/Facades -out:$(dir $@) -headerFile:$(MONO_API_SNAPSHOT_PATH)profiles/license-header.txt -assemblyAttributes -typeForwardedTo -assemblyVersion -assembly:$< || echo "Couldn't process assembly." > $@
+
+mono-api-current: $(MONO_API_ASSEMBLIES_CS)
+
+mono-api-diff:
+	@echo "Regenerating API snapshot..."
+	$(Q) rm -rf "$(MONO_API_SNAPSHOT_PROFILE_PATH)"
+	$(Q) $(MAKE) mono-api-current
+	@echo "Checking public API differences..."
+	$(Q) cd $(MONO_API_SNAPSHOT_PATH); git add -A .
+	$(Q) cd $(MONO_API_SNAPSHOT_PATH); git diff --no-renames HEAD > $(abspath $(topdir))/temp.patch
+	@mkdir -p apidiff
+	$(Q) sed -e "/@diffdata@/r temp.patch" -e "/@diffdata@/d" -e "s/@title@/Public API Diff/g" -e "s/@description@/If the changes are intentional, run <code>make -C mcs mono-api-diff<\/code> locally and commit changes in external\/api-snapshot./g" diff.html.in > apidiff/index.html
+	$(Q) if [ -s temp.patch ]; then echo "Error: Found public API differences, see mcs/apidiff/index.html. If the changes are intentional, please go to external/api-snapshot and commit them."; rm -f temp.patch; exit 1; else echo "No differences found."; rm -f temp.patch; fi

--- a/mcs/class/Facades/subdirs.make
+++ b/mcs/class/Facades/subdirs.make
@@ -60,7 +60,7 @@ System.Runtime.Numerics System.Xml.XDocument System.Reflection.Extensions System
 System.Diagnostics.FileVersionInfo System.Security.Cryptography.Primitives System.Security.Cryptography.Algorithms System.ValueTuple \
 System.Text.Encoding.CodePages
 
-build_PARALLEL_SUBDIRS = $(basic_PARALLEL_SUBDIRS)
+build_PARALLEL_SUBDIRS = $(basic_PARALLEL_SUBDIRS) System.Text.RegularExpressions System.Diagnostics.Contracts
 
 monodroid_SUBDIRS = $(monotouch_SUBDIRS)
 monodroid_PARALLEL_SUBDIRS = $(monotouch_PARALLEL_SUBDIRS)

--- a/mcs/diff.html.in
+++ b/mcs/diff.html.in
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <title>@title@</title>
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/github.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.3.0/diff2html.min.css">
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Open+Sans' />
+  </head>
+  <body style="font-family: 'Open Sans'">
+    <h1>@title@</h1>
+    <p>@description@</p>
+    <div id="diff"><!--<![CDATA[
+@diffdata@
+]]>-->
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/languages/cs.min.js"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.3.0/diff2html.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.3.0/diff2html-ui.min.js"></script>
+
+    <script>
+    $(document).ready(function() {
+        var diff2htmlUi = new Diff2HtmlUI({diff: $("#diff")[0].childNodes[0].nodeValue});
+        diff2htmlUi.draw('#diff', {showFiles: true, matching: 'lines'});
+        diff2htmlUi.highlightCode('#diff');
+    });
+    </script>
+  </body>
+</html>

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -97,4 +97,12 @@ if [[ ${label} == osx-* ]]
 then ${TESTCMD} --label=ms-test-suite --timeout=30m make -w -C acceptance-tests check-ms-test-suite
 else ${TESTCMD} --label=ms-test-suite --skip;
 fi
+if [[ ${label} == 'ubuntu-1404-amd64' ]]; then
+    source ${MONO_REPO_ROOT}/scripts/ci/util.sh
+    if ${TESTCMD} --label=apidiff --timeout=15m --fatal make -w -C mcs -j4 mono-api-diff
+    then report_github_status "success" "API Diff" "No public API changes found."
+    else report_github_status "error" "API Diff" "The public API changed." "$BUILD_URL/Public_API_Diff/"
+    fi
+else ${TESTCMD} --label=apidiff --skip
+fi
 rm -fr /tmp/jenkins-temp-aspnet*

--- a/scripts/ci/util.sh
+++ b/scripts/ci/util.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+function report_github_status {
+    if [ -z "$1" ]; then echo "No status specified. Skipping GitHub manual status report."; return 1; fi;
+    if [ -z "$2" ]; then echo "No context specified. Skipping GitHub manual status report."; return 1; fi;
+    if [ -z "$3" ]; then echo "No description specified. Skipping GitHub manual status report."; return 1; fi;
+    if [ -z "${ghprbActualCommit}" ]; then echo "Not a pull request. Skipping GitHub manual status report."; return 1; fi;
+    if [ -z "${GITHUB_STATUS_AUTH_TOKEN}" ]; then echo "No auth token specified. Skipping GitHub manual status report."; return 1; fi;
+
+    wget -qO- --header "Content-Type: application/json" --post-data "{\"state\": \"$1\", \"context\":\"$2\", \"description\": \"$3\", \"target_url\": \"$4\"}" "https://api.github.com/repos/mono/mono/statuses/${ghprbActualCommit}?access_token=${GITHUB_STATUS_AUTH_TOKEN}"
+}


### PR DESCRIPTION
With these targets we can generate a snapshot of the current Mono API in C# source code form.

Whenever we make changes, we can rerun this to ensure we didn't inadvertently change the public API.