### PR TITLE
[runtime] Use TARGET_WIN32 instead of HOST_WIN32 when setting calling…

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8542,7 +8542,7 @@ mono_create_icall_signature (const char *sigstr)
 	res = mono_metadata_signature_alloc (corlib, len - 1);
 	res->pinvoke = 1;
 
-#ifdef HOST_WIN32
+#ifdef TARGET_WIN32
 	/* 
 	 * Under windows, the default pinvoke calling convention is STDCALL but
 	 * we need CDECL.

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2436,7 +2436,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 	}
 	if (m->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) {
 		signature->pinvoke = 1;
-#ifdef HOST_WIN32
+#ifdef TARGET_WIN32
 		/*
 		 * On Windows the default pinvoke calling convention is STDCALL but
 		 * we need CDECL since this is actually an icall.


### PR DESCRIPTION
… conventions, so cross compilers running on windows do the right thing.