### PR TITLE
Backport of #4376.

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/TimerTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/TimerTest.cs
@@ -37,6 +37,7 @@ namespace MonoTests.System.Threading {
 		}
 
 		[Test]
+		[Category ("NotWorking")]
 		public void TestDueTime ()
 		{
 			Bucket bucket = new Bucket();
@@ -55,6 +56,7 @@ namespace MonoTests.System.Threading {
 		}
 
 		[Test]
+		[Category ("NotWorking")]
 		public void TestChange ()
 		{
 			Bucket bucket = new Bucket();
@@ -71,6 +73,7 @@ namespace MonoTests.System.Threading {
 		}
 
 		[Test]
+		[Category ("NotWorking")]
 		public void TestZeroDueTime ()
 		{
 			Bucket bucket = new Bucket();
@@ -85,6 +88,7 @@ namespace MonoTests.System.Threading {
 		}
 
 		[Test]
+		[Category ("NotWorking")]
 		public void TestDispose ()
 		{	
 			Bucket bucket = new Bucket();

--- a/mcs/class/corlib/Test/System.Threading/TimerTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/TimerTest.cs
@@ -51,7 +51,7 @@ namespace MonoTests.System.Threading {
 			Bucket bucket = new Bucket();
 
 			using (Timer t = new Timer (o => Callback2 (o), bucket, 200, Timeout.Infinite)) {
-				bucket.mre.Wait (5000);
+				Assert.IsTrue (bucket.mre.Wait (5000), "#-1");
 				Assert.AreEqual (1, bucket.count, "#1");
 			}
 		}
@@ -62,7 +62,7 @@ namespace MonoTests.System.Threading {
 			Bucket bucket = new Bucket();
 
 			using (Timer t = new Timer (o => Callback2 (o), bucket, 10, 10)) {
-				bucket.mre.Wait (5000);
+				Assert.IsTrue (bucket.mre.Wait (5000), "#-1");
 			}
 			//If the callback is called after dispose, it will NRE and be reported
 			bucket.mre = null;
@@ -76,7 +76,7 @@ namespace MonoTests.System.Threading {
 			Bucket bucket = new Bucket();
 
 			using (Timer t = new Timer (o => Callback2 (o), bucket, 10, 10)) {
-				bucket.mre.Wait (5000);
+				Assert.IsTrue (bucket.mre.Wait (5000), "#-1");
 				int c = bucket.count;
 				Assert.IsTrue (c > 0, "#1 " + c);
 				t.Change (100000, 1000000);
@@ -92,11 +92,11 @@ namespace MonoTests.System.Threading {
 			Bucket bucket = new Bucket();
 
 			using (Timer t = new Timer (o => Callback2 (o), bucket, 0, Timeout.Infinite)) {
-				bucket.mre.Wait (5000);
+				Assert.IsTrue (bucket.mre.Wait (5000), "#-1");
 				bucket.mre.Reset ();
 				Assert.AreEqual (1, bucket.count, "#1");
 				t.Change (0, Timeout.Infinite);
-				bucket.mre.Wait (5000);
+				Assert.IsTrue (bucket.mre.Wait (5000), "#1.5");
 				Assert.AreEqual (2, bucket.count, "#2");
 			}
 		}

--- a/mcs/class/corlib/Test/System.Threading/TimerTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/TimerTest.cs
@@ -19,6 +19,7 @@ namespace MonoTests.System.Threading {
 		// this bucket is used to avoid non-theadlocal issues
 		class Bucket {
 			public int count;
+			public ManualResetEventSlim mre = new ManualResetEventSlim (false); 
 		}
 
 		[SetUp]
@@ -36,72 +37,68 @@ namespace MonoTests.System.Threading {
 		{
 		}
 
+		private void Callback2 (object foo)
+		{
+			Bucket b = foo as Bucket;
+			Interlocked.Increment (ref b.count);
+			b.mre.Set ();
+		}
+
+
 		[Test]
-		[Category ("NotWorking")]
 		public void TestDueTime ()
 		{
 			Bucket bucket = new Bucket();
 
-			using (Timer t = new Timer (o => Callback (o), bucket, 200, Timeout.Infinite)) {
-				Thread.Sleep (50);
-				Assert.AreEqual (0, bucket.count, "#1");
-				Thread.Sleep (200);
-				Assert.AreEqual (1, bucket.count, "#2");
-				Thread.Sleep (500);
-				Assert.AreEqual (1, bucket.count, "#3");
-				t.Change (10, 10);
-				Thread.Sleep (1000);
-				Assert.IsTrue(bucket.count > 20, "#4");
-			}
-		}
-
-		[Test]
-		[Category ("NotWorking")]
-		public void TestChange ()
-		{
-			Bucket bucket = new Bucket();
-
-			using (Timer t = new Timer (o => Callback (o), bucket, 10, 10)) {
-				Thread.Sleep (500);
-				int c = bucket.count;
-				Assert.IsTrue (c > 20, "#1 " + c.ToString ());
-				t.Change (100, 100);
-				c = bucket.count;
-				Thread.Sleep (500);
-				Assert.IsTrue (bucket.count <= c + 20, "#2 " + c.ToString ());
-			}
-		}
-
-		[Test]
-		[Category ("NotWorking")]
-		public void TestZeroDueTime ()
-		{
-			Bucket bucket = new Bucket();
-
-			using (Timer t = new Timer (o => Callback (o), bucket, 0, Timeout.Infinite)) {
-				Thread.Sleep (100);
+			using (Timer t = new Timer (o => Callback2 (o), bucket, 200, Timeout.Infinite)) {
+				bucket.mre.Wait (5000);
 				Assert.AreEqual (1, bucket.count, "#1");
-				t.Change (0, Timeout.Infinite);
-				Thread.Sleep (100);
-				Assert.AreEqual (2, bucket.count, "#2");
 			}
 		}
 
 		[Test]
-		[Category ("NotWorking")]
 		public void TestDispose ()
 		{	
 			Bucket bucket = new Bucket();
 
-			using (Timer t = new Timer (o => Callback (o), bucket, 10, 10)) {
-				Thread.Sleep (200);
+			using (Timer t = new Timer (o => Callback2 (o), bucket, 10, 10)) {
+				bucket.mre.Wait (5000);
 			}
-
-			Thread.Sleep (20);
+			//If the callback is called after dispose, it will NRE and be reported
+			bucket.mre = null;
 			int c = bucket.count;
-			Assert.IsTrue (bucket.count > 5, "#1");
-			Thread.Sleep (200);
-			Assert.AreEqual (c, bucket.count, "#2");
+			Assert.IsTrue (c > 0, "#1");
+		}
+
+		[Test]
+		public void TestChange ()
+		{
+			Bucket bucket = new Bucket();
+
+			using (Timer t = new Timer (o => Callback2 (o), bucket, 10, 10)) {
+				bucket.mre.Wait (5000);
+				int c = bucket.count;
+				Assert.IsTrue (c > 0, "#1 " + c);
+				t.Change (100000, 1000000);
+				c = bucket.count;
+				Thread.Sleep (500);
+				Assert.IsTrue (bucket.count <= c + 1, "#2 " + c);
+			}
+		}
+
+		[Test]
+		public void TestZeroDueTime ()
+		{
+			Bucket bucket = new Bucket();
+
+			using (Timer t = new Timer (o => Callback2 (o), bucket, 0, Timeout.Infinite)) {
+				bucket.mre.Wait (5000);
+				bucket.mre.Reset ();
+				Assert.AreEqual (1, bucket.count, "#1");
+				t.Change (0, Timeout.Infinite);
+				bucket.mre.Wait (5000);
+				Assert.AreEqual (2, bucket.count, "#2");
+			}
 		}
 
 		[Test] // bug #320950

--- a/mcs/class/corlib/Test/System/GCTest.cs
+++ b/mcs/class/corlib/Test/System/GCTest.cs
@@ -27,6 +27,7 @@
 //
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
@@ -57,7 +58,10 @@ namespace MonoTests.System {
 		[Test]
 		public void ReRegisterForFinalizeTest ()
 		{
-			Run_ReRegisterForFinalizeTest ();
+			var thread =  new Thread (Run_ReRegisterForFinalizeTest);
+			thread.Start ();
+			thread.Join ();
+
 			var t = Task.Factory.StartNew (() => {
 				do {
 					GC.Collect ();


### PR DESCRIPTION
Fix timer tests as reported in #52473.
Fix ReRegisterForFinalizeTest as reported in #52406.