### PR TITLE
[loader] When loading the parent of a GTD fails. We must disable gclass recording for it.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5419,6 +5419,12 @@ mono_class_setup_supertypes (MonoClass *klass)
 }
 
 static gboolean
+discard_gclass_due_to_failure (MonoClass *gclass, void *user_data)
+{
+	return mono_class_get_generic_class (gclass)->container_class == user_data;
+}
+
+static gboolean
 fix_gclass_incomplete_instantiation (MonoClass *gclass, void *user_data)
 {
 	MonoClass *gtd = (MonoClass*)user_data;
@@ -5711,6 +5717,9 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 	return klass;
 
 parent_failure:
+	if (mono_class_is_gtd (klass))
+		disable_gclass_recording (discard_gclass_due_to_failure, klass);
+
 	mono_class_setup_mono_type (klass);
 	mono_loader_unlock ();
 	mono_profiler_class_loaded (klass, MONO_PROFILE_FAILED);


### PR DESCRIPTION
mono_class_create_from_typedef: When loading a GTD, we track what ginsts' of it were loaded in the meanwhile
so we can fix some information that will be wrong (such as if it's a VT or not).

Were not stopping the recording when a GTD type failed to load its parent. This would result in *A LOT* of ginsts
being captured and would cause issues during domain unload.