### PR TITLE
Added support to build libmono with disabled JIT on Windows.

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -19,8 +19,6 @@
 
 #ifndef DISABLE_JIT
 
-/* FIXME: This conflicts with the definition in mini.c, so it cannot be moved to mini.h */
-MONO_API MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
 void mini_emit_stobj (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, gboolean native);
 void mini_emit_initobj (MonoCompile *cfg, MonoInst *dest, const guchar *ip, MonoClass *klass);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -13,6 +13,7 @@
 
 #include <config.h>
 #include <mono/utils/mono-compiler.h>
+#include "mini.h"
 
 #ifndef DISABLE_JIT
 
@@ -35,7 +36,6 @@
 #endif
 
 #include <mono/utils/memcheck.h>
-#include "mini.h"
 #include <mono/metadata/abi-details.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/attrdefs.h>
@@ -143,8 +143,6 @@ static int stind_to_store_membase (int opcode);
 
 int mono_op_to_op_imm (int opcode);
 int mono_op_to_op_imm_noemul (int opcode);
-
-MONO_API MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
 
 static int inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **sp,
 						  guchar *ip, guint real_offset, gboolean inline_always);
@@ -14549,6 +14547,9 @@ NOTES
 
 #else /* !DISABLE_JIT */
 
-MONO_EMPTY_SOURCE_FILE (method_to_ir);
+void
+mono_set_break_policy (MonoBreakPolicyFunc policy_callback)
+{
+}
 
 #endif /* !DISABLE_JIT */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2398,7 +2398,7 @@ void      mono_print_code                   (MonoCompile *cfg, const char *msg);
 MONO_API void      mono_print_method_from_ip         (void *ip);
 MONO_API char     *mono_pmip                         (void *ip);
 gboolean  mono_debug_count                  (void);
-MONO_API const char* mono_inst_name                  (int op);
+MONO_LLVM_INTERNAL const char* mono_inst_name                  (int op);
 int       mono_op_to_op_imm                 (int opcode);
 int       mono_op_imm_to_op                 (int opcode);
 int       mono_load_membase_to_load_mem     (int opcode);
@@ -2449,6 +2449,7 @@ MonoInst* mono_emit_jit_icall (MonoCompile *cfg, gconstpointer func, MonoInst **
 MonoInst* mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *info, MonoInst **args);
 MonoInst* mono_emit_method_call (MonoCompile *cfg, MonoMethod *method, MonoInst **args, MonoInst *this_ins);
 void      mono_create_helper_signatures (void);
+MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
 
 gboolean  mini_class_is_system_array (MonoClass *klass);
 MonoMethodSignature *mono_get_element_address_signature (int arity);
@@ -2543,7 +2544,7 @@ void      mono_draw_graph                   (MonoCompile *cfg, MonoGraphOptions 
 void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst);
 gpointer  mono_create_ftnptr                (MonoDomain *domain, gpointer addr);
 
-MONO_API void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
+void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
 
 int               mono_find_method_opcode      (MonoMethod *method);
 MonoJitICallInfo *mono_register_jit_icall      (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean is_save);

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -969,7 +969,6 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 
 	return buf;
 }
-#endif /* !DISABLE_JIT */
 
 /*
  * mono_arch_get_enter_icall_trampoline:
@@ -1068,6 +1067,7 @@ mono_arch_get_enter_icall_trampoline (MonoTrampInfo **info)
 	return NULL;
 #endif /* ENABLE_INTERPRETER */
 }
+#endif /* !DISABLE_JIT */
 
 #ifdef DISABLE_JIT
 gpointer

--- a/mono/mini/type-checking.c
+++ b/mono/mini/type-checking.c
@@ -802,4 +802,7 @@ mini_emit_class_check (MonoCompile *cfg, int klass_reg, MonoClass *klass)
 	mini_emit_class_check_inst (cfg, klass_reg, klass, NULL);
 }
 
+#else
+
+MONO_EMPTY_SOURCE_FILE (type_checking);
 #endif

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -264,7 +264,6 @@ mono_domain_set_internal
 mono_domain_try_type_resolve
 mono_domain_try_unload
 mono_domain_unload
-mono_emit_native_call
 mono_environment_exitcode_get
 mono_environment_exitcode_set
 mono_error_cleanup
@@ -465,7 +464,6 @@ mono_images_init
 mono_init
 mono_init_from_assembly
 mono_init_version
-mono_inst_name
 mono_install_assembly_load_hook
 mono_install_assembly_postload_refonly_search_hook
 mono_install_assembly_postload_search_hook
@@ -754,7 +752,6 @@ mono_register_bundled_assemblies
 mono_register_config_for_assembly
 mono_register_machine_config
 mono_register_symfile_for_assembly
-mono_replace_ins
 mono_runtime_class_init
 mono_runtime_cleanup
 mono_runtime_delegate_invoke

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -264,7 +264,6 @@ mono_domain_set_internal
 mono_domain_try_type_resolve
 mono_domain_try_unload
 mono_domain_unload
-mono_emit_native_call
 mono_environment_exitcode_get
 mono_environment_exitcode_set
 mono_error_cleanup
@@ -467,7 +466,6 @@ mono_images_init
 mono_init
 mono_init_from_assembly
 mono_init_version
-mono_inst_name
 mono_install_assembly_load_hook
 mono_install_assembly_postload_refonly_search_hook
 mono_install_assembly_postload_search_hook
@@ -756,7 +754,6 @@ mono_register_bundled_assemblies
 mono_register_config_for_assembly
 mono_register_machine_config
 mono_register_symfile_for_assembly
-mono_replace_ins
 mono_runtime_class_init
 mono_runtime_cleanup
 mono_runtime_delegate_invoke


### PR DESCRIPTION
Current mono build on (at least Windows) fails if build with disabled JIT since the .def file used when building libmono, mono-2.0-sgen.dll, exports a couple of symbols missing when DISABLE_JIT is defined.

Turns out that these methods have been incorrectly exported and should not be part of the public API surface. This commit removes MONO_API for the methods incorrectly marked:

mono_emit_native_call
mono_inst_name
mono_replace_ins

It also removes them from the .def files so they won't be exported in the mono runtime DLL on Windows.

For mono_set_break_policy an empty stub will be added since it is considered being a public API.

The above support is primarily used on none desktop Windows platforms when building mono runtime module without JIT support.

This commit also fix a problem introduced in tramp-amd64.c by commit 4281399 causing it to get duplicated definitions of mono_arch_get_enter_icall_trampoline when DISABLE_JIT has been defined.