### PR TITLE
[runtime] Call error_init instead of mono_error_init

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -268,7 +268,7 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 	MonoAppDomain *ad;
 	MonoClass *klass;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_portability_helpers_init ();
 	
@@ -393,7 +393,7 @@ mono_context_init_checked (MonoDomain *domain, MonoError *error)
 	MonoClass *klass;
 	MonoAppContext *context;
 
-	mono_error_init (error);
+	error_init (error);
 
 	klass = mono_class_load_from_name (mono_defaults.corlib, "System.Runtime.Remoting.Contexts", "Context");
 	context = (MonoAppContext *) mono_object_new_pinned (domain, klass, error);
@@ -478,7 +478,7 @@ MonoDomain *
 mono_domain_create_appdomain_checked (char *friendly_name, char *configuration_file, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *result = NULL;
 
 	MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System", "AppDomainSetup");
@@ -531,7 +531,7 @@ copy_app_domain_setup (MonoDomain *domain, MonoAppDomainSetupHandle setup, MonoE
 	MonoClass *ads_class;
 	MonoAppDomainSetupHandle result = MONO_HANDLE_NEW (MonoAppDomainSetup, NULL);
 
-	mono_error_init (error);
+	error_init (error);
 
 	caller_domain = mono_domain_get ();
 	ads_class = mono_class_load_from_name (mono_defaults.corlib, "System", "AppDomainSetup");
@@ -595,7 +595,7 @@ mono_domain_create_appdomain_internal (char *friendly_name, MonoAppDomainSetupHa
 	MonoClass *adclass;
 	MonoDomain *data;
 
-	mono_error_init (error);
+	error_init (error);
 
 	adclass = mono_class_get_appdomain_class ();
 
@@ -717,7 +717,7 @@ mono_domain_try_type_resolve_checked (MonoDomain *domain, char *name, MonoObject
 	MonoReflectionAssembly *ret;
 	void *params [1];
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (domain != NULL && ((name != NULL) || (tb != NULL)));
 
@@ -782,7 +782,7 @@ mono_domain_set (MonoDomain *domain, gboolean force)
 MonoObjectHandle
 ves_icall_System_AppDomain_GetData (MonoAppDomainHandle ad, MonoStringHandle name, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	if (MONO_HANDLE_IS_NULL (name)) {
 		mono_error_set_argument_null (error, "name", "");
@@ -830,7 +830,7 @@ ves_icall_System_AppDomain_GetData (MonoAppDomainHandle ad, MonoStringHandle nam
 void
 ves_icall_System_AppDomain_SetData (MonoAppDomainHandle ad, MonoStringHandle name, MonoObjectHandle data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	if (MONO_HANDLE_IS_NULL (name)) {
 		mono_error_set_argument_null (error, "name", "");
@@ -851,7 +851,7 @@ ves_icall_System_AppDomain_SetData (MonoAppDomainHandle ad, MonoStringHandle nam
 MonoAppDomainSetupHandle
 ves_icall_System_AppDomain_getSetup (MonoAppDomainHandle ad, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	g_assert (!MONO_HANDLE_IS_NULL (ad));
 	MonoDomain *domain = MONO_HANDLE_GETVAL (ad, data);
 	g_assert (domain);
@@ -862,7 +862,7 @@ ves_icall_System_AppDomain_getSetup (MonoAppDomainHandle ad, MonoError *error)
 MonoStringHandle
 ves_icall_System_AppDomain_getFriendlyName (MonoAppDomainHandle ad, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	g_assert (!MONO_HANDLE_IS_NULL (ad));
 	MonoDomain *domain = MONO_HANDLE_GETVAL (ad, data);
 	g_assert (domain);
@@ -873,7 +873,7 @@ ves_icall_System_AppDomain_getFriendlyName (MonoAppDomainHandle ad, MonoError *e
 MonoAppDomainHandle
 ves_icall_System_AppDomain_getCurDomain (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *add = mono_domain_get ();
 
 	return MONO_HANDLE_NEW (MonoAppDomain, add->domain);
@@ -882,7 +882,7 @@ ves_icall_System_AppDomain_getCurDomain (MonoError *error)
 MonoAppDomainHandle
 ves_icall_System_AppDomain_getRootDomain (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *root = mono_get_root_domain ();
 
 	return MONO_HANDLE_NEW (MonoAppDomain, root->domain);
@@ -1038,7 +1038,7 @@ mono_domain_set_options_from_config (MonoDomain *domain)
 MonoAppDomainHandle
 ves_icall_System_AppDomain_createDomain (MonoStringHandle friendly_name, MonoAppDomainSetupHandle setup, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoAppDomainHandle ad = MONO_HANDLE_NEW (MonoAppDomain, NULL);
 
 #ifdef DISABLE_APPDOMAINS
@@ -1058,7 +1058,7 @@ static gboolean
 add_assembly_to_array (MonoDomain *domain, MonoArrayHandle dest, int dest_idx, MonoAssembly* assm, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionAssemblyHandle assm_obj = mono_assembly_get_object_handle (domain, assm, error);
 	if (!is_ok (error))
 		goto leave;
@@ -1070,7 +1070,7 @@ leave:
 MonoArrayHandle
 ves_icall_System_AppDomain_GetAssemblies (MonoAppDomainHandle ad, MonoBoolean refonly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_GETVAL (ad, data);
 	MonoAssembly* ass;
 	GSList *tmp;
@@ -1111,7 +1111,7 @@ MonoAssembly*
 mono_try_assembly_resolve (MonoDomain *domain, const char *fname_raw, MonoAssembly *requesting, gboolean refonly, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoAssembly *result = NULL;
 	MonoStringHandle fname = mono_string_new_handle (domain, fname_raw, error);
 	if (!is_ok (error))
@@ -1129,7 +1129,7 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 	MonoBoolean isrefonly;
 	gpointer params [3];
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (mono_runtime_get_no_exec ())
 		return ret;
@@ -1455,7 +1455,7 @@ mono_is_shadow_copy_enabled (MonoDomain *domain, const gchar *dir_name)
 char *
 mono_make_shadow_copy (const char *filename, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return (char *) filename;
 }
 #else
@@ -1530,7 +1530,7 @@ get_shadow_assembly_location_base (MonoDomain *domain, MonoError *error)
 	char *userdir;
 	char *location;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	setup = domain->setup;
 	if (setup->cache_path != NULL && setup->application_name != NULL) {
@@ -1574,7 +1574,7 @@ get_shadow_assembly_location (const char *filename, MonoError *error)
 	char *location, *tmploc;
 	MonoDomain *domain = mono_domain_get ();
 
-	mono_error_init (error);
+	error_init (error);
 	
 	hash = get_cstring_hash (bname);
 	hash2 = get_cstring_hash (dirname);
@@ -1759,7 +1759,7 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 	char *shadow_dir;
 	gint32 copy_error;
 
-	mono_error_init (oerror);
+	error_init (oerror);
 
 	set_domain_search_path (domain);
 
@@ -2036,7 +2036,7 @@ mono_domain_assembly_search (MonoAssemblyName *aname,
 MonoReflectionAssemblyHandle
 ves_icall_System_Reflection_Assembly_LoadFrom (MonoStringHandle fname, MonoBoolean refOnly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get ();
 	char *name, *filename;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
@@ -2078,7 +2078,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 					    MonoBoolean refonly,
 					    MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoAssembly *ass;
 	MonoReflectionAssemblyHandle refass = MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
 	MonoDomain *domain = MONO_HANDLE_GETVAL(ad, data);
@@ -2130,7 +2130,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 MonoReflectionAssemblyHandle
 ves_icall_System_AppDomain_LoadAssembly (MonoAppDomainHandle ad, MonoStringHandle assRef, MonoObjectHandle evidence, MonoBoolean refOnly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_GETVAL (ad, data);
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
 	MonoAssembly *ass;
@@ -2191,7 +2191,7 @@ fail:
 void
 ves_icall_System_AppDomain_InternalUnload (gint32 domain_id, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain * domain = mono_domain_get_by_id (domain_id);
 
 	if (NULL == domain) {
@@ -2223,7 +2223,7 @@ ves_icall_System_AppDomain_InternalUnload (gint32 domain_id, MonoError *error)
 gboolean
 ves_icall_System_AppDomain_InternalIsFinalizingForUnload (gint32 domain_id, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get_by_id (domain_id);
 
 	if (!domain)
@@ -2243,7 +2243,7 @@ ves_icall_System_AppDomain_ExecuteAssembly (MonoAppDomainHandle ad,
 					    MonoReflectionAssemblyHandle refass, MonoArrayHandle args,
 					    MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoImage *image;
 	MonoMethod *method;
 
@@ -2276,7 +2276,7 @@ ves_icall_System_AppDomain_GetIDFromDomain (MonoAppDomain * ad)
 MonoAppDomainHandle
 ves_icall_System_AppDomain_InternalSetDomain (MonoAppDomainHandle ad, MonoError* error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *old_domain = mono_domain_get ();
 
 	if (!mono_domain_set (MONO_HANDLE_GETVAL (ad, data), FALSE)) {
@@ -2304,14 +2304,14 @@ ves_icall_System_AppDomain_InternalSetDomainByID (gint32 domainid, MonoError *er
 void
 ves_icall_System_AppDomain_InternalPushDomainRef (MonoAppDomainHandle ad, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	mono_thread_push_appdomain_ref (MONO_HANDLE_GETVAL (ad, data));
 }
 
 void
 ves_icall_System_AppDomain_InternalPushDomainRefByID (gint32 domain_id, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get_by_id (domain_id);
 
 	if (!domain) {
@@ -2329,7 +2329,7 @@ ves_icall_System_AppDomain_InternalPushDomainRefByID (gint32 domain_id, MonoErro
 void
 ves_icall_System_AppDomain_InternalPopDomainRef (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	mono_thread_pop_appdomain_ref ();
 }
 
@@ -2358,7 +2358,7 @@ ves_icall_System_AppDomain_InternalSetContext (MonoAppContext *mc)
 MonoStringHandle
 ves_icall_System_AppDomain_InternalGetProcessGuid (MonoStringHandle newguid, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain* mono_root_domain = mono_get_root_domain ();
 	mono_domain_lock (mono_root_domain);
 	if (process_guid_set) {

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1889,7 +1889,7 @@ has_reference_assembly_attribute_iterator (MonoImage *image, guint32 typeref_sco
 gboolean
 mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	/*
 	 * This might be called during assembly loading, so do everything using the low-level
@@ -3261,7 +3261,7 @@ static MonoAssembly*
 prevent_reference_assembly_from_running (MonoAssembly* candidate, gboolean refonly)
 {
 	MonoError refasm_error;
-	mono_error_init (&refasm_error);
+	error_init (&refasm_error);
 	if (candidate && !refonly && mono_assembly_has_reference_assembly_attribute (candidate, &refasm_error)) {
 		candidate = NULL;
 	}

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -204,7 +204,7 @@ mono_class_from_typeref_checked (MonoImage *image, guint32 type_token, MonoError
 	MonoClass *res = NULL;
 	MonoImage *module;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_verifier_verify_typeref_row (image, (type_token & 0xffffff) - 1, error))
 		return NULL;
@@ -693,7 +693,7 @@ is_valid_generic_argument (MonoType *type)
 static MonoType*
 inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *context, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	switch (type->type) {
 	case MONO_TYPE_MVAR: {
@@ -849,7 +849,7 @@ MonoType*
 mono_class_inflate_generic_type_with_mempool (MonoImage *image, MonoType *type, MonoGenericContext *context, MonoError *error)
 {
 	MonoType *inflated = NULL;
-	mono_error_init (error);
+	error_init (error);
 
 	if (context)
 		inflated = inflate_generic_type (image, type, context, error);
@@ -921,7 +921,7 @@ mono_class_inflate_generic_type_no_copy (MonoImage *image, MonoType *type, MonoG
 {
 	MonoType *inflated = NULL; 
 
-	mono_error_init (error);
+	error_init (error);
 	if (context) {
 		inflated = inflate_generic_type (image, type, context, error);
 		return_val_if_nok (error, NULL);
@@ -961,7 +961,7 @@ inflate_generic_context (MonoGenericContext *context, MonoGenericContext *inflat
 	MonoGenericInst *method_inst = NULL;
 	MonoGenericContext res = { NULL, NULL };
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (context->class_inst) {
 		class_inst = mono_metadata_inflate_generic_inst (context->class_inst, inflate_with, error);
@@ -1033,7 +1033,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 	MonoMethodSignature *sig;
 	MonoGenericContext tmp_context;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* The `method' has already been instantiated before => we need to peel out the instantiation and create a new context */
 	while (method->is_inflated) {
@@ -1285,7 +1285,7 @@ mono_class_find_enum_basetype (MonoClass *klass, MonoError *error)
 
 	g_assert (klass->enumtype);
 
-	mono_error_init (error);
+	error_init (error);
 
 	container = mono_class_try_get_generic_container (klass);
 	if (mono_class_is_ginst (klass)) {
@@ -1494,7 +1494,7 @@ mono_class_set_type_load_failure_causedby_class (MonoClass *klass, const MonoCla
 {
 	if (mono_class_has_failure (caused_by)) {
 		MonoError cause_error;
-		mono_error_init (&cause_error);
+		error_init (&cause_error);
 		mono_error_set_for_class_failure (&cause_error, caused_by);
 		mono_class_set_type_load_failure (klass, "%s, due to: %s", msg, mono_error_get_message (&cause_error));
 		mono_error_cleanup (&cause_error);
@@ -1860,7 +1860,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 					mono_class_setup_fields (field_class);
 					if (mono_class_has_failure (field_class)) {
 						MonoError field_error;
-						mono_error_init (&field_error);
+						error_init (&field_error);
 						mono_error_set_for_class_failure (&field_error, field_class);
 						mono_class_set_type_load_failure (klass, "Could not set up field '%s' due to: %s", field->name, mono_error_get_message (&field_error));
 						mono_error_cleanup (&field_error);
@@ -2700,7 +2700,7 @@ mono_class_setup_events (MonoClass *klass)
 			MonoEvent *event = &events [i];
 			MonoEvent *gevent = &ginfo->events [i];
 
-			mono_error_init (&error); //since we do conditional calls, we must ensure the default value is ok
+			error_init (&error); //since we do conditional calls, we must ensure the default value is ok
 
 			event->parent = klass;
 			event->name = gevent->name;
@@ -5466,7 +5466,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 	guint32 field_last, method_last;
 	guint32 nesting_tokeen;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (mono_metadata_token_table (type_token) != MONO_TABLE_TYPEDEF || tidx > tt->rows) {
 		mono_error_set_bad_image (error, image, "Invalid typedef token %x", type_token);
@@ -6514,7 +6514,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	if (eclass->byval_arg.type == MONO_TYPE_TYPEDBYREF || eclass->byval_arg.type == MONO_TYPE_VOID) {
 		/*Arrays of those two types are invalid.*/
 		MonoError prepared_error;
-		mono_error_init (&prepared_error);
+		error_init (&prepared_error);
 		mono_error_set_invalid_program (&prepared_error, "Arrays of void or System.TypedReference types are invalid.");
 		mono_class_set_failure (klass, mono_error_box (&prepared_error, klass->image));
 		mono_error_cleanup (&prepared_error);
@@ -7200,7 +7200,7 @@ mono_class_get_and_inflate_typespec_checked (MonoImage *image, guint32 type_toke
 {
 	MonoClass *klass;
 
-	mono_error_init (error);
+	error_init (error);
 	klass = mono_class_get_checked (image, type_token, error);
 
 	if (klass && context && mono_metadata_token_table (type_token) == MONO_TABLE_TYPESPEC)
@@ -7221,7 +7221,7 @@ mono_class_get_checked (MonoImage *image, guint32 type_token, MonoError *error)
 {
 	MonoClass *klass = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (image)) {
 		int table = mono_metadata_token_table (type_token);
@@ -7277,7 +7277,7 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 	MonoType *type = NULL;
 	gboolean inflated = FALSE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	//FIXME: this will not fix the very issue for which mono_type_get_full exists -but how to do it then?
 	if (image_is_dynamic (image)) {
@@ -7520,7 +7520,7 @@ mono_class_from_name_case_checked (MonoImage *image, const char *name_space, con
 	const char *nspace;
 	guint32 i, visib;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (image)) {
 		guint32 token = 0;
@@ -7602,7 +7602,7 @@ search_modules (MonoImage *image, const char *name_space, const char *name, Mono
 	MonoClass *klass;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* 
 	 * The EXPORTEDTYPES table only contains public types, so have to search the
@@ -7638,7 +7638,7 @@ mono_class_from_name_checked_aux (MonoImage *image, const char* name_space, cons
 	char *nested;
 	char buf [1024];
 
-	mono_error_init (error);
+	error_init (error);
 
 	// Checking visited images avoids stack overflows when cyclic references exist.
 	if (g_hash_table_lookup (visited_images, image))
@@ -8572,7 +8572,7 @@ gpointer
 mono_ldtoken_checked (MonoImage *image, guint32 token, MonoClass **handle_class,
 	      MonoGenericContext *context, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (image)) {
 		MonoClass *tmp_handle_class;
@@ -8662,7 +8662,7 @@ gpointer
 mono_lookup_dynamic_token (MonoImage *image, guint32 token, MonoGenericContext *context, MonoError *error)
 {
 	MonoClass *handle_class;
-	mono_error_init (error);
+	error_init (error);
 	return mono_reflection_lookup_dynamic_token (image, token, TRUE, &handle_class, context, error);
 }
 
@@ -9375,7 +9375,7 @@ mono_field_get_type (MonoClassField *field)
 MonoType*
 mono_field_get_type_checked (MonoClassField *field, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (!field->type)
 		mono_field_resolve_type (field, error);
 	return field->type;
@@ -9784,7 +9784,7 @@ mono_class_set_type_load_failure (MonoClass *klass, const char * fmt, ...)
 	if (mono_class_has_failure (klass))
 		return FALSE;
 	
-	mono_error_init (&prepare_error);
+	error_init (&prepare_error);
 	
 	va_start (args, fmt);
 	mono_error_vset_type_load_class (&prepare_error, klass, fmt, args);
@@ -9859,7 +9859,7 @@ mono_class_get_exception_for_failure (MonoClass *klass)
 	if (!mono_class_has_failure (klass))
 		return NULL;
 	MonoError unboxed_error;
-	mono_error_init (&unboxed_error);
+	error_init (&unboxed_error);
 	mono_error_set_for_class_failure (&unboxed_error, klass);
 	return mono_error_convert_to_exception (&unboxed_error);
 }
@@ -10407,7 +10407,7 @@ mono_class_setup_interfaces (MonoClass *klass, MonoError *error)
 	int i, interface_count;
 	MonoClass **interfaces;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (klass->interfaces_inited)
 		return;
@@ -10468,7 +10468,7 @@ mono_field_resolve_type (MonoClassField *field, MonoError *error)
 	MonoType *ftype;
 	int field_idx = field - klass->fields;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (gtd) {
 		MonoClassField *gfield = &gtd->fields [field_idx];

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -517,7 +517,7 @@ cominterop_get_interface_checked (MonoComObject* obj, MonoClass* ic, MonoError *
 	g_assert (ic);
 	g_assert (MONO_CLASS_IS_INTERFACE (ic));
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_cominterop_lock ();
 	if (obj->itf_hash)
@@ -1522,7 +1522,7 @@ static gboolean cominterop_can_support_dispatch (MonoClass* klass)
 static void*
 cominterop_get_idispatch_for_object (MonoObject* object, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (!object)
 		return NULL;
 
@@ -1942,7 +1942,7 @@ cominterop_get_ccw_checked (MonoObject* object, MonoClass* itf, MonoError *error
 	GList *ccw_list, *ccw_list_item;
 	MonoCustomAttrInfo *cinfo = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	if (!object)
 		return NULL;
@@ -2446,7 +2446,7 @@ static const IID MONO_IID_IMarshal = {0x3, 0x0, 0x0, {0xC0, 0x0, 0x0, 0x0, 0x0, 
 static int
 cominterop_ccw_getfreethreadedmarshaler (MonoCCW* ccw, MonoObject* object, gpointer* ppv, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 #ifdef HOST_WIN32
 	if (!ccw->free_marshaler) {
 		int ret = 0;
@@ -2817,7 +2817,7 @@ mono_string_from_bstr_checked (gpointer bstr, MonoError *error)
 {
 	MonoString * res = NULL;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	if (!bstr)
 		return NULL;
@@ -3586,7 +3586,7 @@ MonoString *
 mono_string_from_bstr_checked (gpointer bstr, MonoError *error)
 {
 	MonoString *res = NULL;
-	mono_error_init (error);
+	error_init (error);
 	if (!bstr)
 		return NULL;
 #ifdef HOST_WIN32

--- a/mono/metadata/console-win32-uwp.c
+++ b/mono/metadata/console-win32-uwp.c
@@ -16,7 +16,7 @@ MonoBoolean
 ves_icall_System_ConsoleDriver_Isatty (HANDLE handle)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
 
@@ -32,7 +32,7 @@ MonoBoolean
 ves_icall_System_ConsoleDriver_SetEcho (MonoBoolean want_echo)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
 
@@ -48,7 +48,7 @@ MonoBoolean
 ves_icall_System_ConsoleDriver_SetBreak (MonoBoolean want_break)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
 
@@ -64,7 +64,7 @@ gint32
 ves_icall_System_ConsoleDriver_InternalKeyAvailable (gint32 timeout)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
 
@@ -80,7 +80,7 @@ MonoBoolean
 ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardown, MonoArray **control_chars, int **size)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
 

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -187,7 +187,7 @@ load_cattr_enum_type (MonoImage *image, const char *p, const char **end, MonoErr
 	MonoType *t;
 	int slen = mono_metadata_decode_value (p, &p);
 
-	mono_error_init (error);
+	error_init (error);
 
 	n = (char *)g_memdup (p, slen + 1);
 	n [slen] = 0;
@@ -205,7 +205,7 @@ load_cattr_value (MonoImage *image, MonoType *t, const char *p, const char **end
 	int slen, type = t->type;
 	MonoClass *tklass = t->data.klass;
 
-	mono_error_init (error);
+	error_init (error);
 
 handle_enum:
 	switch (type) {
@@ -447,7 +447,7 @@ handle_type:
 static MonoObject*
 load_cattr_value_boxed (MonoDomain *domain, MonoImage *image, MonoType *t, const char* p, const char** end, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	gboolean is_ref = type_is_reference (t);
 
@@ -473,7 +473,7 @@ create_cattr_typed_arg (MonoType *t, MonoObject *val, MonoError *error)
 	MonoObject *retval;
 	void *params [2], *unboxed;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!ctor)
 		ctor = mono_class_get_method_from_name (mono_class_get_custom_attribute_typed_argument_class (), ".ctor", 2);
@@ -499,7 +499,7 @@ create_cattr_named_arg (void *minfo, MonoObject *typedarg, MonoError *error)
 	MonoObject *retval;
 	void *unboxed, *params [2];
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!ctor)
 		ctor = mono_class_get_method_from_name (mono_class_get_custom_attribute_named_argument_class (), ".ctor", 2);
@@ -578,7 +578,7 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 	void **params = NULL;
 	MonoMethodSignature *sig;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_class_init (method->klass);
 
@@ -759,7 +759,7 @@ mono_reflection_create_custom_attr_data_args (MonoImage *image, MonoMethod *meth
 	*named_args = NULL;
 	*named_arg_info = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_verifier_verify_cattr_content (image, method, data, len, NULL)) {
 		mono_error_set_generic_error (error, "System.Reflection", "CustomAttributeFormatException", "Binary format of the specified custom attribute was invalid.");
@@ -888,7 +888,7 @@ reflection_resolve_custom_attribute_data (MonoReflectionMethod *ref_method, Mono
 	CattrNamedArg *arginfo = NULL;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	*ctor_args = NULL;
 	*named_args = NULL;
@@ -970,7 +970,7 @@ create_custom_attr_data_handle (MonoImage *image, MonoCustomAttrEntry *cattr, Mo
 	MonoDomain *domain;
 	void *params [4];
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (image->assembly);
 
@@ -1015,7 +1015,7 @@ mono_custom_attrs_construct_by_type (MonoCustomAttrInfo *cinfo, MonoClass *attr_
 	MonoObject *attr;
 	int i, n;
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (i = 0; i < cinfo->num_attrs; ++i) {
 		MonoCustomAttrEntry *centry = &cinfo->attrs[i];
@@ -1072,7 +1072,7 @@ mono_custom_attrs_data_construct (MonoCustomAttrInfo *cinfo, MonoError *error)
 	MonoObject *attr;
 	int i;
 	
-	mono_error_init (error);
+	error_init (error);
 	result = mono_array_new_checked (mono_domain_get (), mono_defaults.customattribute_data_class, cinfo->num_attrs, error);
 	return_val_if_nok (error, NULL);
 	for (i = 0; i < cinfo->num_attrs; ++i) {
@@ -1112,7 +1112,7 @@ mono_custom_attrs_from_index_checked (MonoImage *image, guint32 idx, gboolean ig
 	const char *data;
 	MonoCustomAttrEntry* attr;
 
-	mono_error_init (error);
+	error_init (error);
 
 	ca = &image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
 
@@ -1152,7 +1152,7 @@ mono_custom_attrs_from_index_checked (MonoImage *image, guint32 idx, gboolean ig
 			g_warning ("Can't find custom attr constructor image: %s mtoken: 0x%08x due to: %s", image->name, mtoken, mono_error_get_message (error));
 			if (ignore_missing) {
 				mono_error_cleanup (error);
-				mono_error_init (error);
+				error_init (error);
 			} else {
 				g_list_free (list);
 				g_free (ainfo);
@@ -1190,7 +1190,7 @@ mono_custom_attrs_from_method_checked (MonoMethod *method, MonoError *error)
 {
 	guint32 idx;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/*
 	 * An instantiated method has the same cattrs as the generic method definition.
@@ -1228,7 +1228,7 @@ mono_custom_attrs_from_class_checked (MonoClass *klass, MonoError *error)
 {
 	guint32 idx;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (mono_class_is_ginst (klass))
 		klass = mono_class_get_generic_class (klass)->container_class;
@@ -1262,7 +1262,7 @@ mono_custom_attrs_from_assembly_checked (MonoAssembly *assembly, gboolean ignore
 {
 	guint32 idx;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (assembly->image))
 		return lookup_custom_attr (assembly->image, assembly);
@@ -1346,7 +1346,7 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_field_checked (MonoClass *klass, MonoClassField *field, MonoError *error)
 {
 	guint32 idx;
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (klass->image)) {
 		field = mono_metadata_get_corresponding_field_from_generic_type_definition (field);
@@ -1395,7 +1395,7 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 	MonoImage *image;
 	MonoReflectionMethodAux *aux;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/*
 	 * An instantiated method has the same cattrs as the generic method definition.
@@ -1486,7 +1486,7 @@ mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_k
 
 	g_assert (attr_klass != NULL);
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (i = 0; i < ainfo->num_attrs; ++i) {
 		centry = &ainfo->attrs[i];
@@ -1538,7 +1538,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObject *obj, MonoError *error
 	MonoClass *klass;
 	MonoCustomAttrInfo *cinfo = NULL;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	klass = obj->vtable->klass;
 	if (klass == mono_defaults.runtimetype_class) {
@@ -1650,7 +1650,7 @@ mono_reflection_get_custom_attrs_by_type (MonoObject *obj, MonoClass *attr_klass
 	MonoArray *result;
 	MonoCustomAttrInfo *cinfo;
 
-	mono_error_init (error);
+	error_init (error);
 
 	cinfo = mono_reflection_get_custom_attrs_info_checked (obj, error);
 	return_val_if_nok (error, NULL);
@@ -1716,7 +1716,7 @@ mono_reflection_get_custom_attrs_data_checked (MonoObject *obj, MonoError *error
 	MonoArray *result;
 	MonoCustomAttrInfo *cinfo;
 
-	mono_error_init (error);
+	error_init (error);
 
 	cinfo = mono_reflection_get_custom_attrs_info_checked (obj, error);
 	return_val_if_nok (error, NULL);

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -256,7 +256,7 @@ mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean 
 	MonoObject *obj;
 	MonoClass *klass;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	obj = lookup_dyn_token (assembly, token);
 	if (!obj) {
@@ -277,7 +277,7 @@ mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean 
 gpointer
 mono_reflection_lookup_dynamic_token (MonoImage *image, guint32 token, gboolean valid_token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return NULL;
 }
 #endif /* DISABLE_REFLECTION_EMIT */

--- a/mono/metadata/dynamic-stream.c
+++ b/mono/metadata/dynamic-stream.c
@@ -76,7 +76,7 @@ mono_dynstream_insert_mstring (MonoDynamicStream *sh, MonoString *str, MonoError
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	char *name = mono_string_to_utf8_checked (str, error);
 	return_val_if_nok (error, -1);
 	guint32 idx;

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -208,7 +208,7 @@ mono_exception_from_name_two_strings_checked (MonoImage *image, const char *name
 {
 	MonoClass *klass;
 
-	mono_error_init (error);
+	error_init (error);
 	klass = mono_class_load_from_name (image, name_space, name);
 
 	return create_exception_two_strings (klass, a1, a2, error);
@@ -269,7 +269,7 @@ mono_exception_from_token_two_strings_checked (MonoImage *image, guint32 token,
 {
 	MonoClass *klass;
 
-	mono_error_init (error);
+	error_init (error);
 
 	klass = mono_class_get_checked (image, token, error);
 	mono_error_assert_ok (error); /* FIXME handle the error. */
@@ -867,7 +867,7 @@ mono_get_exception_reflection_type_load_checked (MonoArrayHandle types, MonoArra
 	MonoMethod *method;
 	gpointer iter;
 
-	mono_error_init (error);
+	error_init (error);
 
 	klass = mono_class_load_from_name (mono_get_corlib (), "System.Reflection", "ReflectionTypeLoadException");
 
@@ -1017,7 +1017,7 @@ ves_icall_Mono_Runtime_GetNativeStackTrace (MonoExceptionHandle exc, MonoError *
 {
 	char *trace;
 	MonoStringHandle res;
-	mono_error_init (error);
+	error_init (error);
 
 	if (!exc) {
 		mono_error_set_argument_null (error, "exception", "");

--- a/mono/metadata/icall-windows-uwp.c
+++ b/mono/metadata/icall-windows-uwp.c
@@ -30,7 +30,7 @@ MonoArray *
 mono_icall_get_logical_drives (void)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetLogicalDriveStrings");
 
@@ -46,7 +46,7 @@ void
 mono_icall_broadcast_setting_change (void)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("SendMessageTimeout");
 
@@ -62,7 +62,7 @@ guint32
 mono_icall_drive_info_get_drive_type (MonoString *root_path_name)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetDriveType");
 
@@ -76,7 +76,7 @@ gint32
 mono_icall_wait_for_input_idle (gpointer handle, gint32 milliseconds)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("WaitForInputIdle");
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -130,7 +130,7 @@ is_generic_parameter (MonoType *type)
 static void
 mono_class_init_checked (MonoClass *klass, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_class_init (klass))
 		mono_error_set_for_class_failure (error, klass);
@@ -232,7 +232,7 @@ ves_icall_System_Array_SetValueImpl (MonoArray *arr, MonoObject *value, guint32 
 	gint64 i64 = 0;
 	gdouble r64 = 0;
 
-	mono_error_init (&error);
+	error_init (&error);
 
 	if (value)
 		vc = value->vtable->klass;
@@ -844,7 +844,7 @@ ves_icall_System_Array_SetGenericValueImpl (MonoArray *arr, guint32 pos, gpointe
 ICALL_EXPORT void
 ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray (MonoArrayHandle array, MonoClassField *field_handle, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoClass *klass = mono_handle_class (array);
 	guint32 size = mono_array_element_size (klass);
@@ -1216,7 +1216,7 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_System_Object_GetType (MonoObjectHandle obj, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (obj);
 	MonoClass *klass = mono_handle_class (obj);
 #ifndef DISABLE_REMOTING
@@ -1313,7 +1313,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase, MonoAsse
 	gboolean type_resolve = FALSE;
 	MonoImage *rootimage = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/*
 	 * We must compute the calling assembly as type loading must happen under a metadata context.
@@ -1402,7 +1402,7 @@ ves_icall_System_Type_internal_from_name (MonoStringHandle name,
 					  MonoBoolean ignoreCase,
 					  MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoTypeNameParse info;
 	gboolean parsedOk;
 	MonoAssembly *caller_assembly;
@@ -1460,7 +1460,7 @@ leave:
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_System_Type_internal_from_handle (MonoType *handle, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get (); 
 
 	return mono_type_get_object_handle (domain, handle, error);
@@ -1518,7 +1518,7 @@ typedef enum {
 ICALL_EXPORT guint32
 ves_icall_type_GetTypeCodeInternal (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	int t = type->type;
 
@@ -1612,7 +1612,7 @@ mono_type_get_underlying_type_ignore_byref (MonoType *type)
 ICALL_EXPORT guint32
 ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle ref_type, MonoReflectionTypeHandle ref_c, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (!MONO_HANDLE_IS_NULL (ref_type));
 	
@@ -1652,7 +1652,7 @@ ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle re
 ICALL_EXPORT guint32
 ves_icall_RuntimeTypeHandle_IsInstanceOfType (MonoReflectionTypeHandle ref_type, MonoObjectHandle obj, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
 	mono_class_init_checked (klass, error);
@@ -1665,7 +1665,7 @@ ves_icall_RuntimeTypeHandle_IsInstanceOfType (MonoReflectionTypeHandle ref_type,
 ICALL_EXPORT guint32
 ves_icall_RuntimeTypeHandle_GetAttributes (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
 	return mono_class_get_flags (klass);
@@ -1674,7 +1674,7 @@ ves_icall_RuntimeTypeHandle_GetAttributes (MonoReflectionTypeHandle ref_type, Mo
 ICALL_EXPORT MonoReflectionMarshalAsAttributeHandle
 ves_icall_System_Reflection_FieldInfo_get_marshal_info (MonoReflectionFieldHandle field_h, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (field_h);
 	MonoClassField *field = MONO_HANDLE_GETVAL (field_h, field);
 	MonoClass *klass = field->parent;
@@ -1710,7 +1710,7 @@ ves_icall_System_Reflection_FieldInfo_internal_from_handle_type (MonoClassField 
 
 	g_assert (handle);
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!type) {
 		klass = handle->parent;
@@ -1734,7 +1734,7 @@ ves_icall_System_Reflection_EventInfo_internal_from_handle_type (MonoEvent *hand
 
 	g_assert (handle);
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!type) {
 		klass = handle->parent;
@@ -1754,7 +1754,7 @@ ves_icall_System_Reflection_EventInfo_internal_from_handle_type (MonoEvent *hand
 ICALL_EXPORT MonoReflectionPropertyHandle
 ves_icall_System_Reflection_PropertyInfo_internal_from_handle_type (MonoProperty *handle, MonoType *type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass;
 
 	g_assert (handle);
@@ -1776,7 +1776,7 @@ ves_icall_System_Reflection_PropertyInfo_internal_from_handle_type (MonoProperty
 ICALL_EXPORT MonoArrayHandle
 ves_icall_System_Reflection_FieldInfo_GetTypeModifiers (MonoReflectionFieldHandle field_h, MonoBoolean optional, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoClassField *field = MONO_HANDLE_GETVAL (field_h, field);
 
 	MonoType *type = mono_field_get_type_checked (field, error);
@@ -1838,7 +1838,7 @@ ves_icall_get_method_info (MonoMethod *method, MonoMethodInfo *info)
 ICALL_EXPORT MonoArrayHandle
 ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info (MonoMethod *method, MonoReflectionMethodHandle member, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get (); 
 
 	MonoReflectionTypeHandle reftype = MONO_HANDLE_NEW (MonoReflectionType, NULL);
@@ -1852,7 +1852,7 @@ ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info (MonoMethod *metho
 ICALL_EXPORT MonoReflectionMarshalAsAttributeHandle
 ves_icall_System_MonoMethodInfo_get_retval_marshal (MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get (); 
 	MonoReflectionMarshalAsAttributeHandle res = MONO_HANDLE_NEW (MonoReflectionMarshalAsAttribute, NULL);
 
@@ -1886,7 +1886,7 @@ ves_icall_MonoField_GetFieldOffset (MonoReflectionField *field)
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_MonoField_GetParentType (MonoReflectionFieldHandle field, MonoBoolean declaring, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (field);
 	MonoClass *parent;
 
@@ -2152,7 +2152,7 @@ ves_icall_MonoField_GetRawConstantValue (MonoReflectionField *rfield)
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_MonoField_ResolveType (MonoReflectionFieldHandle ref_field, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_field);
 	MonoClassField *field = MONO_HANDLE_GETVAL (ref_field, field);
 	MonoType *type = mono_field_get_type_checked (field, error);
@@ -2377,7 +2377,7 @@ get_interfaces_hash (gconstpointer v1)
 ICALL_EXPORT MonoArrayHandle
 ves_icall_RuntimeType_GetInterfaces (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
 
@@ -2437,7 +2437,7 @@ static gboolean
 set_interface_map_data_method_object (MonoDomain *domain, MonoMethod *method, MonoClass *iclass, int ioffset, MonoClass *klass, MonoArrayHandle targets, MonoArrayHandle methods, int i, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionMethodHandle member = mono_method_get_object_handle (domain, method, iclass, error);
 	if (!is_ok (error))
 		goto leave;
@@ -2457,7 +2457,7 @@ leave:
 ICALL_EXPORT void
 ves_icall_RuntimeType_GetInterfaceMapData (MonoReflectionTypeHandle ref_type, MonoReflectionTypeHandle ref_iface, MonoArrayHandleOut targets, MonoArrayHandleOut methods, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
 	MonoType *iface = MONO_HANDLE_GETVAL (ref_iface, type);
@@ -2498,7 +2498,7 @@ ves_icall_RuntimeType_GetInterfaceMapData (MonoReflectionTypeHandle ref_type, Mo
 ICALL_EXPORT void
 ves_icall_RuntimeType_GetPacking (MonoReflectionTypeHandle ref_type, guint32 *packing, guint32 *size, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
 
@@ -2518,7 +2518,7 @@ ves_icall_RuntimeType_GetPacking (MonoReflectionTypeHandle ref_type, guint32 *pa
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
@@ -2547,7 +2547,7 @@ ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, M
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeTypeHandle_GetBaseType (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
@@ -2565,7 +2565,7 @@ ves_icall_RuntimeTypeHandle_GetBaseType (MonoReflectionTypeHandle ref_type, Mono
 ICALL_EXPORT MonoBoolean
 ves_icall_RuntimeTypeHandle_IsPointer (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	return type->type == MONO_TYPE_PTR;
 }
@@ -2573,7 +2573,7 @@ ves_icall_RuntimeTypeHandle_IsPointer (MonoReflectionTypeHandle ref_type, MonoEr
 ICALL_EXPORT MonoBoolean
 ves_icall_RuntimeTypeHandle_IsPrimitive (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	return (!type->byref && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U)));
 }
@@ -2581,7 +2581,7 @@ ves_icall_RuntimeTypeHandle_IsPrimitive (MonoReflectionTypeHandle ref_type, Mono
 ICALL_EXPORT MonoBoolean
 ves_icall_RuntimeTypeHandle_IsByRef (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	return type->byref;
 }
@@ -2589,7 +2589,7 @@ ves_icall_RuntimeTypeHandle_IsByRef (MonoReflectionTypeHandle ref_type, MonoErro
 ICALL_EXPORT MonoBoolean
 ves_icall_RuntimeTypeHandle_IsComObject (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
 	mono_class_init_checked (klass, error);
@@ -2602,14 +2602,14 @@ ves_icall_RuntimeTypeHandle_IsComObject (MonoReflectionTypeHandle ref_type, Mono
 ICALL_EXPORT guint32
 ves_icall_reflection_get_token (MonoObjectHandle obj, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return mono_reflection_get_token_checked (obj, error);
 }
 
 ICALL_EXPORT MonoReflectionModuleHandle
 ves_icall_RuntimeTypeHandle_GetModule (MonoReflectionTypeHandle type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (type);
 	MonoType *t = MONO_HANDLE_GETVAL (type, type);
 	MonoClass *klass = mono_class_from_mono_type (t);
@@ -2619,7 +2619,7 @@ ves_icall_RuntimeTypeHandle_GetModule (MonoReflectionTypeHandle type, MonoError 
 ICALL_EXPORT MonoReflectionAssemblyHandle
 ves_icall_RuntimeTypeHandle_GetAssembly (MonoReflectionTypeHandle type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get (); 
 	MonoType *t = MONO_HANDLE_GETVAL (type, type);
 	MonoClass *klass = mono_class_from_mono_type (t);
@@ -2629,7 +2629,7 @@ ves_icall_RuntimeTypeHandle_GetAssembly (MonoReflectionTypeHandle type, MonoErro
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeType_get_DeclaringType (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass;
@@ -2689,7 +2689,7 @@ ves_icall_RuntimeType_get_Namespace (MonoReflectionTypeHandle type, MonoError *e
 ICALL_EXPORT gint32
 ves_icall_RuntimeTypeHandle_GetArrayRank (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	if (type->type != MONO_TYPE_ARRAY && type->type != MONO_TYPE_SZARRAY) {
@@ -2712,7 +2712,7 @@ static gboolean
 set_type_object_in_array (MonoDomain *domain, MonoType *type, MonoArrayHandle dest, int i, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, type, error);
 	if (!is_ok (error))
 		goto leave;
@@ -2726,7 +2726,7 @@ leave:
 ICALL_EXPORT MonoArrayHandle
 ves_icall_RuntimeType_GetGenericArguments (MonoReflectionTypeHandle ref_type, MonoBoolean runtimeTypeArray, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
 
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
@@ -2763,7 +2763,7 @@ leave:
 ICALL_EXPORT gboolean
 ves_icall_RuntimeTypeHandle_IsGenericTypeDefinition (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	if (!IS_MONOTYPE (MONO_HANDLE_RAW(ref_type)))
 		return FALSE;
@@ -2779,7 +2779,7 @@ ves_icall_RuntimeTypeHandle_IsGenericTypeDefinition (MonoReflectionTypeHandle re
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeTypeHandle_GetGenericTypeDefinition_impl (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoReflectionTypeHandle ret = MONO_HANDLE_NEW (MonoReflectionType, NULL);
@@ -2815,7 +2815,7 @@ leave:
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeType_MakeGenericType (MonoReflectionTypeHandle reftype, MonoArrayHandle type_array, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (reftype);
 
 	g_assert (IS_MONOTYPE_HANDLE (reftype));
@@ -2853,7 +2853,7 @@ ves_icall_RuntimeType_MakeGenericType (MonoReflectionTypeHandle reftype, MonoArr
 ICALL_EXPORT gboolean
 ves_icall_RuntimeTypeHandle_HasInstantiation (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass;
 
 	if (!IS_MONOTYPE (MONO_HANDLE_RAW (ref_type)))
@@ -2870,7 +2870,7 @@ ves_icall_RuntimeTypeHandle_HasInstantiation (MonoReflectionTypeHandle ref_type,
 ICALL_EXPORT gint32
 ves_icall_RuntimeType_GetGenericParameterPosition (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (!IS_MONOTYPE_HANDLE (ref_type))
 		return -1;
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
@@ -2883,7 +2883,7 @@ ves_icall_RuntimeType_GetGenericParameterPosition (MonoReflectionTypeHandle ref_
 ICALL_EXPORT MonoGenericParamInfo *
 ves_icall_RuntimeTypeHandle_GetGenericParameterInfo (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	return mono_generic_param_info (type->data.generic_param);
 }
@@ -2900,7 +2900,7 @@ ves_icall_RuntimeType_GetCorrespondingInflatedMethod (MonoReflectionTypeHandle r
 						      MonoReflectionMethodHandle generic,
 						      MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
@@ -2928,7 +2928,7 @@ ves_icall_RuntimeType_GetCorrespondingInflatedMethod (MonoReflectionTypeHandle r
 ICALL_EXPORT MonoReflectionMethodHandle
 ves_icall_RuntimeType_get_DeclaringMethod (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoReflectionMethodHandle ret = MONO_HANDLE_NEW (MonoReflectionMethod, NULL);
 
@@ -2952,7 +2952,7 @@ leave:
 ICALL_EXPORT MonoBoolean
 ves_icall_System_RuntimeType_IsTypeExportedToWindowsRuntime (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	mono_error_set_not_implemented (error, "%s", "");
 	return FALSE;
 }
@@ -2960,7 +2960,7 @@ ves_icall_System_RuntimeType_IsTypeExportedToWindowsRuntime (MonoError *error)
 ICALL_EXPORT MonoBoolean
 ves_icall_System_RuntimeType_IsWindowsRuntimeObjectType (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	mono_error_set_not_implemented (error, "%s", "");
 	return FALSE;
 }
@@ -2980,7 +2980,7 @@ ves_icall_MonoMethod_GetPInvoke (MonoReflectionMethodHandle ref_method, int* fla
 	const char *import = NULL;
 	const char *scope = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (image)) {
 		MonoReflectionMethodAux *method_aux = 
@@ -3015,7 +3015,7 @@ ves_icall_MonoMethod_GetPInvoke (MonoReflectionMethodHandle ref_method, int* fla
 ICALL_EXPORT MonoReflectionMethodHandle
 ves_icall_MonoMethod_GetGenericMethodDefinition (MonoReflectionMethodHandle ref_method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *method = MONO_HANDLE_GETVAL (ref_method, method);
 
 	if (method->is_generic)
@@ -3076,7 +3076,7 @@ static gboolean
 set_array_generic_argument_handle_inflated (MonoDomain *domain, MonoGenericInst *inst, int i, MonoArrayHandle arr, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, inst->type_argv [i], error);
 	if (!is_ok (error))
 		goto leave;
@@ -3089,7 +3089,7 @@ static gboolean
 set_array_generic_argument_handle_gparam (MonoDomain *domain, MonoGenericContainer *container, int i, MonoArrayHandle arr, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoGenericParam *param = mono_generic_container_get_param (container, i);
 	MonoClass *pklass = mono_class_from_generic_parameter_internal (param);
 	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &pklass->byval_arg, error);
@@ -3103,7 +3103,7 @@ leave:
 ICALL_EXPORT MonoArrayHandle
 ves_icall_MonoMethod_GetGenericArguments (MonoReflectionMethodHandle ref_method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_method);
 	MonoMethod *method = MONO_HANDLE_GETVAL (ref_method, method);
 
@@ -3665,7 +3665,7 @@ ves_icall_System_Enum_get_hashcode (MonoObject *eobj)
 static void
 get_enum_field (MonoDomain *domain, MonoArrayHandle names, MonoArrayHandle values, int base_type, MonoClassField *field, guint* j, guint64 *previous_value, gboolean *sorted, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	HANDLE_FUNCTION_ENTER();
 	guint64 field_value;
 	const char *p;
@@ -3709,7 +3709,7 @@ ves_icall_System_Enum_GetEnumValuesAndNames (MonoReflectionTypeHandle type, Mono
 	guint64 previous_value = 0;
 	gboolean sorted = TRUE;
 
-	mono_error_init (error);
+	error_init (error);
 	mono_class_init_checked (enumc, error);
 	return_val_if_nok (error, FALSE);
 
@@ -3759,7 +3759,7 @@ enum {
 ICALL_EXPORT GPtrArray*
 ves_icall_RuntimeType_GetFields_native (MonoReflectionTypeHandle ref_type, char *utf8_name, guint32 bflags, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	if (type->byref) {
@@ -3855,7 +3855,7 @@ mono_class_get_methods_by_name (MonoClass *klass, const char *name, guint32 bfla
 
 	array = g_ptr_array_new ();
 	startklass = klass;
-	mono_error_init (error);
+	error_init (error);
 
 	if (name != NULL)
 		compare_func = (ignore_case) ? mono_utf8_strcasecmp : strcmp;
@@ -3952,7 +3952,7 @@ loader_error:
 ICALL_EXPORT GPtrArray*
 ves_icall_RuntimeType_GetMethodsByName_native (MonoReflectionTypeHandle ref_type, const char *mname, guint32 bflags, MonoBoolean ignore_case, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoClass *klass = mono_class_from_mono_type (type);
@@ -3966,7 +3966,7 @@ ves_icall_RuntimeType_GetMethodsByName_native (MonoReflectionTypeHandle ref_type
 ICALL_EXPORT GPtrArray*
 ves_icall_RuntimeType_GetConstructors_native (MonoReflectionTypeHandle ref_type, guint32 bflags, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	if (type->byref) {
 		return g_ptr_array_new ();
@@ -4083,7 +4083,7 @@ property_accessor_nonpublic (MonoMethod* accessor, gboolean start_klass)
 ICALL_EXPORT GPtrArray*
 ves_icall_RuntimeType_GetPropertiesByName_native (MonoReflectionTypeHandle ref_type, gchar *propname, guint32 bflags, MonoBoolean ignore_case, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 
@@ -4189,7 +4189,7 @@ event_equal (MonoEvent *event1, MonoEvent *event2)
 ICALL_EXPORT GPtrArray*
 ves_icall_RuntimeType_GetEvents_native (MonoReflectionTypeHandle ref_type, char *utf8_name, guint32 bflags, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	if (type->byref) {
@@ -4281,7 +4281,7 @@ failure:
 ICALL_EXPORT GPtrArray *
 ves_icall_RuntimeType_GetNestedTypes_native (MonoReflectionTypeHandle ref_type, char *str, guint32 bflags, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	if (type->byref) {
@@ -4331,7 +4331,7 @@ static MonoType*
 get_type_from_module_builder_module (MonoArrayHandle modules, int i, MonoTypeNameParse *info, MonoBoolean ignoreCase, gboolean *type_resolve, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = NULL;
 	MonoReflectionModuleBuilderHandle mb = MONO_HANDLE_NEW (MonoReflectionModuleBuilder, NULL);
 	MONO_HANDLE_ARRAY_GETREF (mb, modules, i);
@@ -4344,7 +4344,7 @@ static MonoType*
 get_type_from_module_builder_loaded_modules (MonoArrayHandle loaded_modules, int i, MonoTypeNameParse *info, MonoBoolean ignoreCase, gboolean *type_resolve, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = NULL;
 	MonoReflectionModuleHandle mod = MONO_HANDLE_NEW (MonoReflectionModule, NULL);
 	MONO_HANDLE_ARRAY_GETREF (mod, loaded_modules, i);
@@ -4356,7 +4356,7 @@ get_type_from_module_builder_loaded_modules (MonoArrayHandle loaded_modules, int
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHandle assembly_h, MonoReflectionModuleHandle module, MonoStringHandle name, MonoBoolean throwOnError, MonoBoolean ignoreCase, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoTypeNameParse info;
 	gboolean type_resolve;
@@ -4522,7 +4522,7 @@ replace_shadow_path (MonoDomain *domain, gchar *dirname, gchar **filename)
 ICALL_EXPORT MonoStringHandle
 ves_icall_System_Reflection_Assembly_get_code_base (MonoReflectionAssemblyHandle assembly, MonoBoolean escaped, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly);
 	MonoAssembly *mass = MONO_HANDLE_GETVAL (assembly, assembly);
 	gchar *absolute;
@@ -4564,7 +4564,7 @@ ves_icall_System_Reflection_Assembly_get_code_base (MonoReflectionAssemblyHandle
 ICALL_EXPORT MonoBoolean
 ves_icall_System_Reflection_Assembly_get_global_assembly_cache (MonoReflectionAssemblyHandle assembly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoAssembly *mass = MONO_HANDLE_GETVAL (assembly,assembly);
 
 	return mass->in_gac;
@@ -4602,7 +4602,7 @@ ves_icall_System_Reflection_Assembly_get_location (MonoReflectionAssemblyHandle 
 ICALL_EXPORT MonoBoolean
 ves_icall_System_Reflection_Assembly_get_ReflectionOnly (MonoReflectionAssemblyHandle assembly_h, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	return assembly->ref_only;
 }
@@ -4619,7 +4619,7 @@ ves_icall_System_Reflection_Assembly_InternalImageRuntimeVersion (MonoReflection
 ICALL_EXPORT MonoReflectionMethodHandle
 ves_icall_System_Reflection_Assembly_get_EntryPoint (MonoReflectionAssemblyHandle assembly_h, MonoError *error) 
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly_h);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	MonoMethod *method;
@@ -4641,7 +4641,7 @@ leave:
 ICALL_EXPORT MonoReflectionModuleHandle
 ves_icall_System_Reflection_Assembly_GetManifestModuleInternal (MonoReflectionAssemblyHandle assembly, MonoError *error) 
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly);
 	MonoAssembly *a = MONO_HANDLE_GETVAL (assembly, assembly);
 	return mono_module_get_object_handle (domain, a->image, error);
@@ -4651,7 +4651,7 @@ static gboolean
 add_manifest_resource_name_to_array (MonoDomain *domain, MonoImage *image, MonoTableInfo *table, int i, MonoArrayHandle dest, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	const char *val = mono_metadata_string_heap (image, mono_metadata_decode_row_col (table, i, MONO_MANIFEST_NAME));
 	MonoStringHandle str = mono_string_new_handle (domain, val, error);
 	if (!is_ok (error))
@@ -4664,7 +4664,7 @@ leave:
 ICALL_EXPORT MonoArrayHandle
 ves_icall_System_Reflection_Assembly_GetManifestResourceNames (MonoReflectionAssemblyHandle assembly_h, MonoError *error) 
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly_h);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	MonoTableInfo *table = &assembly->image->tables [MONO_TABLE_MANIFESTRESOURCE];
@@ -4696,7 +4696,7 @@ ves_icall_System_Reflection_Assembly_GetAotId (MonoError *error)
 static MonoAssemblyName*
 create_referenced_assembly_name (MonoDomain *domain, MonoImage *image, MonoTableInfo *t, int i, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoAssemblyName *aname = g_new0 (MonoAssemblyName, 1);
 
 	mono_assembly_get_assemblyref (image, i, aname);
@@ -4719,7 +4719,7 @@ create_referenced_assembly_name (MonoDomain *domain, MonoImage *image, MonoTable
 ICALL_EXPORT GPtrArray*
 ves_icall_System_Reflection_Assembly_InternalGetReferencedAssemblies (MonoReflectionAssemblyHandle assembly, MonoError *error) 
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly);
 	MonoAssembly *ass = MONO_HANDLE_GETVAL(assembly, assembly);
 	MonoImage *image = ass->image;
@@ -4758,7 +4758,7 @@ g_concat_dir_and_file (const char *dir, const char *file)
 ICALL_EXPORT void *
 ves_icall_System_Reflection_Assembly_GetManifestResourceInternal (MonoReflectionAssemblyHandle assembly_h, MonoStringHandle name, gint32 *size, MonoReflectionModuleHandleOut ref_module, MonoError *error) 
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly_h);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	MonoTableInfo *table = &assembly->image->tables [MONO_TABLE_MANIFESTRESOURCE];
@@ -4887,7 +4887,7 @@ leave:
 ICALL_EXPORT gboolean
 ves_icall_System_Reflection_Assembly_GetManifestResourceInfoInternal (MonoReflectionAssemblyHandle assembly_h, MonoStringHandle name, MonoManifestResourceInfoHandle info_h, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return get_manifest_resource_info_internal (assembly_h, name, info_h, error);
 }
 
@@ -4895,7 +4895,7 @@ static gboolean
 add_filename_to_files_array (MonoDomain *domain, MonoAssembly * assembly, MonoTableInfo *table, int i, MonoArrayHandle dest, int dest_idx, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER();
-	mono_error_init (error);
+	error_init (error);
 	const char *val = mono_metadata_string_heap (assembly->image, mono_metadata_decode_row_col (table, i, MONO_FILE_NAME));
 	char *n = g_concat_dir_and_file (assembly->basedir, val);
 	MonoStringHandle str = mono_string_new_handle (domain, n, error);
@@ -4910,7 +4910,7 @@ leave:
 ICALL_EXPORT MonoObjectHandle
 ves_icall_System_Reflection_Assembly_GetFilesInternal (MonoReflectionAssemblyHandle assembly_h, MonoStringHandle name, MonoBoolean resource_modules, MonoError *error) 
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly_h);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	MonoTableInfo *table = &assembly->image->tables [MONO_TABLE_FILE];
@@ -4965,7 +4965,7 @@ static gboolean
 add_module_to_modules_array (MonoDomain *domain, MonoArrayHandle dest, int *dest_idx, MonoImage* module, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	if (module) {
 		MonoReflectionModuleHandle rm = mono_module_get_object_handle (domain, module, error);
 		if (!is_ok (error))
@@ -4983,7 +4983,7 @@ static gboolean
 add_file_to_modules_array (MonoDomain *domain, MonoArrayHandle dest, int dest_idx, MonoImage *image, MonoTableInfo *table, int table_idx,  MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 
 	guint32 cols [MONO_FILE_SIZE];
 	mono_metadata_decode_row (table, table_idx, cols, MONO_FILE_SIZE);
@@ -5014,7 +5014,7 @@ leave:
 ICALL_EXPORT MonoArrayHandle
 ves_icall_System_Reflection_Assembly_GetModulesInternal (MonoReflectionAssemblyHandle assembly_h, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get();
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	MonoClass *klass;
@@ -5067,7 +5067,7 @@ fail:
 ICALL_EXPORT MonoReflectionMethodHandle
 ves_icall_GetCurrentMethod (MonoError *error) 
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoMethod *m = mono_method_get_last_managed ();
 
@@ -5124,7 +5124,7 @@ mono_method_get_equivalent_method (MonoMethod *method, MonoClass *klass)
 ICALL_EXPORT MonoReflectionMethodHandle
 ves_icall_System_Reflection_MethodBase_GetMethodFromHandleInternalType_native (MonoMethod *method, MonoType *type, MonoBoolean generic_check, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass;
 	if (type && generic_check) {
 		klass = mono_class_from_mono_type (type);
@@ -5146,14 +5146,14 @@ ves_icall_System_Reflection_MethodBase_GetMethodFromHandleInternalType_native (M
 ICALL_EXPORT MonoReflectionMethodBodyHandle
 ves_icall_System_Reflection_MethodBase_GetMethodBodyInternal (MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return mono_method_body_get_object_handle (mono_domain_get (), method, error);
 }
 
 ICALL_EXPORT MonoReflectionAssemblyHandle
 ves_icall_System_Reflection_Assembly_GetExecutingAssembly (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoMethod *dest = NULL;
 	mono_stack_walk_no_il (get_executing, &dest);
@@ -5165,7 +5165,7 @@ ves_icall_System_Reflection_Assembly_GetExecutingAssembly (MonoError *error)
 ICALL_EXPORT MonoReflectionAssemblyHandle
 ves_icall_System_Reflection_Assembly_GetEntryAssembly (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDomain* domain = mono_domain_get ();
 
@@ -5178,7 +5178,7 @@ ves_icall_System_Reflection_Assembly_GetEntryAssembly (MonoError *error)
 ICALL_EXPORT MonoReflectionAssemblyHandle
 ves_icall_System_Reflection_Assembly_GetCallingAssembly (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *m;
 	MonoMethod *dest;
 
@@ -5230,7 +5230,7 @@ ves_icall_System_RuntimeType_getFullName (MonoReflectionTypeHandle object, gbool
 ICALL_EXPORT int
 vell_icall_RuntimeType_get_core_clr_security_level (MonoReflectionTypeHandle rfield, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (rfield, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
 
@@ -5250,7 +5250,7 @@ ves_icall_MonoField_get_core_clr_security_level (MonoReflectionField *rfield)
 ICALL_EXPORT int
 ves_icall_MonoMethod_get_core_clr_security_level (MonoReflectionMethodHandle rfield, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *method = MONO_HANDLE_GETVAL (rfield, method);
 	return mono_security_core_clr_method_level (method, TRUE);
 }
@@ -5258,7 +5258,7 @@ ves_icall_MonoMethod_get_core_clr_security_level (MonoReflectionMethodHandle rfi
 ICALL_EXPORT MonoStringHandle
 ves_icall_System_Reflection_Assembly_get_fullName (MonoReflectionAssemblyHandle assembly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (assembly);
 	MonoAssembly *mass = MONO_HANDLE_GETVAL (assembly, assembly);
 	gchar *name;
@@ -5285,7 +5285,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 	MonoImage *image;
 	char *dirname;
 
-	mono_error_init (error);
+	error_init (error);
 
 	filename = mono_string_handle_to_utf8 (fname, error);
 	return_if_nok (error);
@@ -5337,7 +5337,7 @@ ICALL_EXPORT MonoBoolean
 ves_icall_System_Reflection_Assembly_LoadPermissions (MonoReflectionAssemblyHandle assembly_h,
 						      char **minimum, guint32 *minLength, char **optional, guint32 *optLength, char **refused, guint32 *refLength, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
 	MonoBoolean result = FALSE;
 	MonoDeclSecurityEntry entry;
@@ -5382,7 +5382,7 @@ mono_module_type_is_visible (MonoTableInfo *tdef, MonoImage *image, int type)
 static void
 image_get_type (MonoDomain *domain, MonoImage *image, MonoTableInfo *tdef, int table_idx, int count, MonoArrayHandle res, MonoArrayHandle exceptions, MonoBoolean exportedOnly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	HANDLE_FUNCTION_ENTER ();
 	MonoError klass_error;
 	MonoClass *klass = mono_class_get_checked (image, table_idx | MONO_TOKEN_TYPE_DEF, &klass_error);
@@ -5405,7 +5405,7 @@ mono_module_get_types (MonoDomain *domain, MonoImage *image, MonoArrayHandleOut 
 	MonoTableInfo *tdef = &image->tables [MONO_TABLE_TYPEDEF];
 	int i, count;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* we start the count from 1 because we skip the special type <Module> */
 	if (exportedOnly) {
@@ -5437,7 +5437,7 @@ static void
 append_module_types (MonoDomain *domain, MonoArrayHandleOut res, MonoArrayHandleOut exceptions, MonoImage *image, MonoBoolean exportedOnly, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoArrayHandle ex2 = MONO_HANDLE_NEW (MonoArray, NULL);
 	MonoArrayHandle res2 = mono_module_get_types (domain, image, ex2, exportedOnly, error);
 	if (!is_ok (error))
@@ -5475,7 +5475,7 @@ set_class_failure_in_array (MonoArrayHandle exl, int i, MonoClass *klass)
 {
 	HANDLE_FUNCTION_ENTER ();
 	MonoError unboxed_error;
-	mono_error_init (&unboxed_error);
+	error_init (&unboxed_error);
 	mono_error_set_for_class_failure (&unboxed_error, klass);
 
 	MonoExceptionHandle exc = MONO_HANDLE_NEW (MonoException, mono_error_convert_to_exception (&unboxed_error));
@@ -5668,7 +5668,7 @@ ves_icall_System_Reflection_Module_GetMDStreamVersion (MonoImage *image, MonoErr
 ICALL_EXPORT MonoArrayHandle
 ves_icall_System_Reflection_Module_InternalGetTypes (MonoReflectionModuleHandle module, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoImage *image = MONO_HANDLE_GETVAL (module, image);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (module);
@@ -5760,7 +5760,7 @@ static MonoType*
 module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type_args, MonoArrayHandle method_args, MonoResolveTokenError *resolve_error, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoType *result = NULL;
 	MonoClass *klass;
 	int table = mono_metadata_token_table (token);
@@ -5821,7 +5821,7 @@ static MonoMethod*
 module_resolve_method_token (MonoImage *image, guint32 token, MonoArrayHandle type_args, MonoArrayHandle method_args, MonoResolveTokenError *resolve_error, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *method = NULL;
 	int table = mono_metadata_token_table (token);
 	int index = mono_metadata_token_index (token);
@@ -5920,7 +5920,7 @@ module_resolve_field_token (MonoImage *image, guint32 token, MonoArrayHandle typ
 	MonoGenericContext context;
 	MonoClassField *field = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 	*resolve_error = ResolveTokenError_Other;
 
 	/* Validate token */
@@ -5976,7 +5976,7 @@ ves_icall_System_Reflection_Module_ResolveMemberToken (MonoImage *image, guint32
 {
 	int table = mono_metadata_token_table (token);
 
-	mono_error_init (merror);
+	error_init (merror);
 	*error = ResolveTokenError_Other;
 
 	switch (table) {
@@ -6034,7 +6034,7 @@ ves_icall_System_Reflection_Module_ResolveMemberToken (MonoImage *image, guint32
 ICALL_EXPORT MonoArrayHandle
 ves_icall_System_Reflection_Module_ResolveSignature (MonoImage *image, guint32 token, MonoResolveTokenError *resolve_error, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	int table = mono_metadata_token_table (token);
 	int idx = mono_metadata_token_index (token);
 	MonoTableInfo *tables = image->tables;
@@ -6071,7 +6071,7 @@ ves_icall_System_Reflection_Module_ResolveSignature (MonoImage *image, guint32 t
 ICALL_EXPORT MonoBoolean
 ves_icall_RuntimeTypeHandle_IsArray (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoBoolean res = !type->byref && (type->type == MONO_TYPE_ARRAY || type->type == MONO_TYPE_SZARRAY);
@@ -6084,7 +6084,7 @@ check_for_invalid_type (MonoClass *klass, MonoError *error)
 {
 	char *name;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (klass->byval_arg.type != MONO_TYPE_TYPEDBYREF)
 		return;
@@ -6095,7 +6095,7 @@ check_for_invalid_type (MonoClass *klass, MonoError *error)
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeType_make_array_type (MonoReflectionTypeHandle ref_type, int rank, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoClass *klass = mono_class_from_mono_type (type);
@@ -6116,7 +6116,7 @@ ves_icall_RuntimeType_make_array_type (MonoReflectionTypeHandle ref_type, int ra
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeType_make_byref_type (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoClass *klass = mono_class_from_mono_type (type);
@@ -6135,7 +6135,7 @@ ves_icall_RuntimeType_make_byref_type (MonoReflectionTypeHandle ref_type, MonoEr
 ICALL_EXPORT MonoReflectionTypeHandle
 ves_icall_RuntimeType_MakePointerType (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
@@ -6344,7 +6344,7 @@ ves_icall_System_Buffer_BlockCopyInternal (MonoArray *src, gint32 src_offset, Mo
 ICALL_EXPORT MonoObjectHandle
 ves_icall_Remoting_RealProxy_GetTransparentProxy (MonoObjectHandle this_obj, MonoStringHandle class_name, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (this_obj);
 	MonoRealProxyHandle rp = MONO_HANDLE_CAST (MonoRealProxy, this_obj);
 
@@ -7180,7 +7180,7 @@ ves_icall_System_Web_Util_ICalls_get_machine_install_dir (void)
 ICALL_EXPORT gboolean
 ves_icall_get_resources_ptr (MonoReflectionAssemblyHandle assembly, gpointer *result, gint32 *size, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoPEResourceDataEntry *entry;
 	MonoImage *image;
 
@@ -7245,7 +7245,7 @@ ves_icall_System_Diagnostics_DefaultTraceListener_WriteWindowsDebugString (MonoS
 ICALL_EXPORT MonoObjectHandle
 ves_icall_System_Activator_CreateInstanceInternal (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass = mono_class_from_mono_type (type);
@@ -7264,7 +7264,7 @@ ves_icall_System_Activator_CreateInstanceInternal (MonoReflectionTypeHandle ref_
 ICALL_EXPORT MonoReflectionMethodHandle
 ves_icall_MonoMethod_get_base_method (MonoReflectionMethodHandle m, gboolean definition, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *method = MONO_HANDLE_GETVAL (m, method);
 
 	MonoMethod *base = mono_method_get_base_method (method, definition, error);
@@ -7278,7 +7278,7 @@ ves_icall_MonoMethod_get_base_method (MonoReflectionMethodHandle m, gboolean def
 ICALL_EXPORT MonoStringHandle
 ves_icall_MonoMethod_get_name (MonoReflectionMethodHandle m, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *method = MONO_HANDLE_GETVAL (m, method);
 
 	MonoStringHandle s = mono_string_new_handle (MONO_HANDLE_DOMAIN (m), method->name, error);
@@ -7456,7 +7456,7 @@ prelink_method (MonoMethod *method, MonoError *error)
 {
 	const char *exc_class, *exc_arg;
 
-	mono_error_init (error);
+	error_init (error);
 	if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 		return;
 	mono_lookup_pinvoke_call (method, &exc_class, &exc_arg);
@@ -7517,7 +7517,7 @@ static gboolean
 add_modifier_to_array (MonoDomain *domain, MonoImage *image, MonoCustomMod *modifier, MonoArrayHandle dest, int dest_idx, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass = mono_class_get_checked (image, modifier->token, error);
 	if (!is_ok (error))
 		goto leave;
@@ -7541,7 +7541,7 @@ type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoE
 	int i, count = 0;
 	MonoDomain *domain = mono_domain_get ();
 
-	mono_error_init (error);
+	error_init (error);
 	for (i = 0; i < type->num_mods; ++i) {
 		if ((optional && !type->modifiers [i].required) || (!optional && type->modifiers [i].required))
 			count++;
@@ -7568,7 +7568,7 @@ fail:
 ICALL_EXPORT MonoArrayHandle
 ves_icall_ParameterInfo_GetTypeModifiers (MonoReflectionParameterHandle param, MonoBoolean optional, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionTypeHandle rt = MONO_HANDLE_NEW (MonoReflectionType, NULL);
 	MONO_HANDLE_GET (rt, param, ClassImpl);
 	MonoType *type = MONO_HANDLE_GETVAL (rt, type);
@@ -7622,7 +7622,7 @@ get_property_type (MonoProperty *prop)
 ICALL_EXPORT MonoArrayHandle
 ves_icall_MonoPropertyInfo_GetTypeModifiers (MonoReflectionPropertyHandle property, MonoBoolean optional, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoProperty *prop = MONO_HANDLE_GETVAL (property, property);
 	MonoClass *klass = MONO_HANDLE_GETVAL (property, klass);
 	MonoType *type = get_property_type (prop);
@@ -7747,7 +7747,7 @@ ves_icall_Mono_Runtime_GetDisplayName (MonoError *error)
 	char *info;
 	MonoStringHandle display_name;
 
-	mono_error_init (error);
+	error_init (error);
 	info = mono_get_runtime_callbacks ()->get_runtime_build_info ();
 	display_name = mono_string_new_handle (mono_domain_get (), info, error);
 	g_free (info);

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -691,7 +691,7 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 	GList *list_iter, *valid_modules = NULL;
 	MonoImageOpenStatus status;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if ((image->module_count == 0) || (idx > image->module_count || idx <= 0))
 		return NULL;
@@ -2347,7 +2347,7 @@ mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError
 	const char *fname;
 	guint32 fname_id;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (fileidx < 1 || fileidx > t->rows)
 		return NULL;

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -185,7 +185,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 	const char *ptr;
 	guint32 idx = mono_metadata_token_index (token);
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_metadata_decode_row (&tables [MONO_TABLE_MEMBERREF], idx-1, cols, MONO_MEMBERREF_SIZE);
 	nindex = cols [MONO_MEMBERREF_CLASS] >> MONO_MEMBERREF_PARENT_BITS;
@@ -274,7 +274,7 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 	guint32 type;
 	MonoClassField *field;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (image)) {
 		MonoClassField *result;
@@ -360,7 +360,7 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
  	int i;
 
 	/* Search directly in the metadata to avoid calling setup_methods () */
-	mono_error_init (error);
+	error_init (error);
 
 	/* FIXME: !mono_class_is_ginst (from_class) condition causes test failures. */
 	if (klass->type_token && !image_is_dynamic (klass->image) && !klass->methods && !klass->rank && klass == from_class && !mono_class_is_ginst (from_class)) {
@@ -448,7 +448,7 @@ find_method (MonoClass *in_class, MonoClass *ic, const char* name, MonoMethodSig
 	MonoMethod *result = NULL;
 	MonoClass *initial_class = in_class;
 
-	mono_error_init (error);
+	error_init (error);
 	is_interface = MONO_CLASS_IS_INTERFACE (in_class);
 
 	if (ic) {
@@ -530,7 +530,7 @@ inflate_generic_signature_checked (MonoImage *image, MonoMethodSignature *sig, M
 	gboolean is_open;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 	if (!context)
 		return sig;
 
@@ -608,7 +608,7 @@ inflate_generic_header (MonoMethodHeader *header, MonoGenericContext *context, M
 
 	res->is_transient = TRUE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (int i = 0; i < header->num_locals; ++i) {
 		res->locals [i] = mono_class_inflate_generic_type_checked (header->locals [i], context, error);
@@ -655,7 +655,7 @@ mono_method_get_signature_checked (MonoMethod *method, MonoImage *image, guint32
 	MonoMethodSignature *sig;
 	const char *ptr;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* !table is for wrappers: we should really assign their own token to them */
 	if (!table || table == MONO_TABLE_METHOD)
@@ -776,7 +776,7 @@ method_from_memberref (MonoImage *image, guint32 idx, MonoGenericContext *typesp
 	MonoMethodSignature *sig;
 	const char *ptr;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_metadata_decode_row (&tables [MONO_TABLE_MEMBERREF], idx-1, cols, 3);
 	nindex = cols [MONO_MEMBERREF_CLASS] >> MONO_MEMBERREF_PARENT_BITS;
@@ -905,7 +905,7 @@ method_from_methodspec (MonoImage *image, MonoGenericContext *context, guint32 i
 	guint32 cols [MONO_METHODSPEC_SIZE];
 	guint32 token, nindex, param_count;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_metadata_decode_row (&tables [MONO_TABLE_METHODSPEC], idx - 1, cols, MONO_METHODSPEC_SIZE);
 	token = cols [MONO_METHODSPEC_METHOD];
@@ -1594,7 +1594,7 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 	const char *sig = NULL;
 	guint32 cols [MONO_TYPEDEF_SIZE];
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (image)) {
 		MonoClass *handle_class;
@@ -1735,7 +1735,7 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 
 	/* We do everything inside the lock to prevent creation races */
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_image_lock (image);
 
@@ -1791,7 +1791,7 @@ get_method_constrained (MonoImage *image, MonoMethod *method, MonoClass *constra
 	MonoGenericContext *method_context = NULL;
 	MonoMethodSignature *sig, *original_sig;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_class_init (constrained_class);
 	original_sig = sig = mono_method_signature_checked (method, error);
@@ -1873,7 +1873,7 @@ mono_get_method_constrained (MonoImage *image, guint32 token, MonoClass *constra
 MonoMethod *
 mono_get_method_constrained_checked (MonoImage *image, guint32 token, MonoClass *constrained_class, MonoGenericContext *context, MonoMethod **cil_method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	*cil_method = mono_get_method_from_token (image, token, NULL, context, NULL, error);
 	if (!*cil_method)
@@ -2345,7 +2345,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 
 	/* We need memory barriers below because of the double-checked locking pattern */ 
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (m->signature)
 		return m->signature;
@@ -2534,7 +2534,7 @@ mono_method_get_header_checked (MonoMethod *method, MonoError *error)
 	gpointer loc;
 	MonoGenericContainer *container;
 
-	mono_error_init (error);
+	error_init (error);
 	img = method->klass->image;
 
 	if ((method->flags & METHOD_ATTRIBUTE_ABSTRACT) || (method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME) || (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) || (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -97,7 +97,7 @@ create_group_sizes_array (const gint *gs, gint ml, MonoError *error)
 	MonoArray *ret;
 	int i, len = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (i = 0; i < ml; i++) {
 		if (gs [i] == -1)
@@ -122,7 +122,7 @@ create_names_array_idx (const guint16 *names, int ml, MonoError *error)
 	MonoDomain *domain;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (names == NULL)
 		return NULL;
@@ -145,7 +145,7 @@ create_names_array_idx_dynamic (const guint16 *names, int ml, MonoError *error)
 	MonoDomain *domain;
 	int i, len = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (names == NULL)
 		return NULL;
@@ -329,7 +329,7 @@ construct_culture (MonoCultureInfo *this_obj, const CultureInfoEntry *ci, MonoEr
 {
 	MonoDomain *domain = mono_domain_get ();
 
-	mono_error_init (error);
+	error_init (error);
 
 	this_obj->lcid = ci->lcid;
 	MONO_OBJECT_SETREF (this_obj, name, mono_string_new (domain, idx2string (ci->name)));

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -8673,7 +8673,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 	EmitMarshalContext m;
 
 	g_assert (method != NULL);
-	mono_error_init (error);
+	error_init (error);
 
 	if (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
 		mono_error_set_invalid_program (error, "Failed because method (%s) marked PInvokeCallback (managed method) and extern (unmanaged) simultaneously.", mono_method_full_name (method, TRUE));
@@ -10556,7 +10556,7 @@ mono_marshal_alloc (gulong size, MonoError *error)
 {
 	gpointer res;
 
-	mono_error_init (error);
+	error_init (error);
 
 	res = mono_marshal_alloc_co_task_mem (size);
 	if (!res)
@@ -10739,7 +10739,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (char *ptr,
 {
 	MonoError error;
 	MonoString *result = NULL;
-	mono_error_init (&error);
+	error_init (&error);
 	if (ptr == NULL)
 		mono_error_set_argument_null (&error, "ptr", "");
 	else
@@ -10778,7 +10778,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (guint16 *pt
 	MonoString *res = NULL;
 	MonoDomain *domain = mono_domain_get (); 
 
-	mono_error_init (&error);
+	error_init (&error);
 
 	if (ptr == NULL) {
 		res = NULL;
@@ -10859,7 +10859,7 @@ ptr_to_structure (gpointer src, MonoObject *dst, MonoError *error)
 	MonoMethod *method;
 	gpointer pa [2];
 
-	mono_error_init (error);
+	error_init (error);
 
 	method = mono_marshal_get_ptr_to_struct (dst->vtable->klass);
 
@@ -12087,7 +12087,7 @@ mono_icall_start (HandleStackMark *stackmark, MonoError *error)
 	MonoThreadInfo *info = mono_thread_info_current ();
 
 	mono_stack_mark_init (info, stackmark);
-	mono_error_init (error);
+	error_init (error);
 	return info;
 }
 

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -4055,7 +4055,7 @@ mono_verifier_verify_method_signature (MonoImage *image, guint32 offset, MonoErr
 {
 	VerifyContext ctx;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_verifier_is_enabled_for_image (image))
 		return TRUE;
@@ -4245,7 +4245,7 @@ mono_verifier_verify_typeref_row (MonoImage *image, guint32 row, MonoError *erro
 	MonoTableInfo *table = &image->tables [MONO_TABLE_TYPEREF];
 	guint32 data [MONO_TYPEREF_SIZE];
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_verifier_is_enabled_for_image (image))
 		return TRUE;
@@ -4288,7 +4288,7 @@ mono_verifier_verify_methodimpl_row (MonoImage *image, guint32 row, MonoError *e
 	MonoTableInfo *table = &image->tables [MONO_TABLE_METHODIMPL];
 	guint32 data [MONO_METHODIMPL_SIZE];
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_verifier_is_enabled_for_image (image))
 		return TRUE;
@@ -4371,7 +4371,7 @@ mono_verifier_verify_method_header (MonoImage *image, guint32 offset, GSList **e
 gboolean
 mono_verifier_verify_method_signature (MonoImage *image, guint32 offset, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return TRUE;
 }
 
@@ -4421,14 +4421,14 @@ mono_verifier_is_sig_compatible (MonoImage *image, MonoMethod *method, MonoMetho
 gboolean
 mono_verifier_verify_typeref_row (MonoImage *image, guint32 row, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return TRUE;
 }
 
 gboolean
 mono_verifier_verify_methodimpl_row (MonoImage *image, guint32 row, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return TRUE;
 }
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1701,7 +1701,7 @@ mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container
 	int count = 0; // Number of mod arguments
 	gboolean found;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/*
 	 * According to the spec, custom modifiers should come before the byref
@@ -1944,7 +1944,7 @@ MonoMethodSignature*
 mono_metadata_parse_signature_checked (MonoImage *image, guint32 token, MonoError *error)
 {
 
-	mono_error_init (error);
+	error_init (error);
 	MonoTableInfo *tables = image->tables;
 	guint32 idx = mono_metadata_token_index (token);
 	guint32 sig;
@@ -2121,7 +2121,7 @@ mono_metadata_parse_method_signature_full (MonoImage *m, MonoGenericContainer *c
 	guint32 gen_param_count = 0;
 	gboolean is_open = FALSE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (*ptr & 0x10)
 		gen_param_count = 1;
@@ -3135,7 +3135,7 @@ mono_metadata_inflate_generic_inst (MonoGenericInst *ginst, MonoGenericContext *
 	MonoGenericInst *nginst = NULL;
 	int i, count = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!ginst->is_open)
 		return ginst;
@@ -3167,7 +3167,7 @@ mono_metadata_parse_generic_inst (MonoImage *m, MonoGenericContainer *container,
 	MonoGenericInst *ginst;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 	type_argv = g_new0 (MonoType*, count);
 
 	for (i = 0; i < count; i++) {
@@ -3198,7 +3198,7 @@ do_mono_metadata_parse_generic_class (MonoType *type, MonoImage *m, MonoGenericC
 	MonoType *gtype;
 	int count;
 
-	mono_error_init (error);
+	error_init (error);
 
 	// XXX how about transient?
 	gtype = mono_metadata_parse_type_checked (m, NULL, 0, FALSE, ptr, &ptr, error);
@@ -3294,7 +3294,7 @@ mono_metadata_parse_generic_param (MonoImage *m, MonoGenericContainer *generic_c
 	if (rptr)
 		*rptr = ptr;
 
-	mono_error_init (error);
+	error_init (error);
 
 	generic_container = select_container (generic_container, type);
 	if (!generic_container) {
@@ -3368,7 +3368,7 @@ mono_metadata_get_shared_type (MonoType *type)
 static gboolean
 compare_type_literals (MonoImage *image, int class_type, int type_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	/* byval_arg.type can be zero if we're decoding a type that references a class been loading.
 	 * See mcs/test/gtest-440. and #650936.
@@ -3418,7 +3418,7 @@ compare_type_literals (MonoImage *image, int class_type, int type_type, MonoErro
 static gboolean
 verify_var_type_and_container (MonoImage *image, int var_type, MonoGenericContainer *container, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (var_type == MONO_TYPE_MVAR) {
 		if (!container->is_method) { //MVAR and a method container
 			mono_error_set_bad_image (error, image, "MVAR parsed in a context without a method container");
@@ -3459,7 +3459,7 @@ static gboolean
 do_mono_metadata_parse_type (MonoType *type, MonoImage *m, MonoGenericContainer *container,
 							 gboolean transient, const char *ptr, const char **rptr, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	type->type = (MonoTypeEnum)mono_metadata_decode_value (ptr, &ptr);
 	
@@ -3628,7 +3628,7 @@ parse_section_data (MonoImage *m, int *num_clauses, const unsigned char *ptr, Mo
 	guint32 sect_data_len;
 	MonoExceptionClause* clauses = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	while (1) {
 		/* align on 32-bit boundary */
@@ -3796,7 +3796,7 @@ mono_metadata_parse_mh_full (MonoImage *m, MonoGenericContainer *container, cons
 	MonoTableInfo *t = &m->tables [MONO_TABLE_STANDALONESIG];
 	guint32 cols [MONO_STAND_ALONE_SIGNATURE_SIZE];
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!ptr) {
 		mono_error_set_bad_image (error, m, "Method header with null pointer");
@@ -4334,7 +4334,7 @@ mono_metadata_interfaces_from_typedef_full (MonoImage *meta, guint32 index, Mono
 	*interfaces = NULL;
 	*count = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!tdef->base)
 		return TRUE;
@@ -5690,7 +5690,7 @@ mono_type_create_from_typespec_checked (MonoImage *image, guint32 type_spec, Mon
 	const char *ptr;
 	MonoType *type, *type2;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_image_lock (image);
 	type = (MonoType *)g_hash_table_lookup (image->typespec_cache, GUINT_TO_POINTER (type_spec));
@@ -6068,7 +6068,7 @@ method_from_method_def_or_ref (MonoImage *m, guint32 tok, MonoGenericContext *co
 	MonoMethod *result = NULL;
 	guint32 idx = tok >> MONO_METHODDEFORREF_BITS;
 
-	mono_error_init (error);
+	error_init (error);
 
 	switch (tok & MONO_METHODDEFORREF_MASK) {
 	case MONO_METHODDEFORREF_METHODDEF:
@@ -6211,7 +6211,7 @@ get_constraints (MonoImage *image, int owner, MonoClass ***constraints, MonoGene
 	GSList *cons = NULL, *tmp;
 	MonoGenericContext *context = &container->context;
 
-	mono_error_init (error);
+	error_init (error);
 
 	*constraints = NULL;
 	found = 0;
@@ -6303,7 +6303,7 @@ mono_metadata_load_generic_param_constraints_checked (MonoImage *image, guint32 
 {
 
 	guint32 start_row, i, owner;
-	mono_error_init (error);
+	error_init (error);
 
 	if (! (start_row = mono_metadata_get_generic_param_row (image, token, &owner)))
 		return TRUE;

--- a/mono/metadata/mono-basic-block.c
+++ b/mono/metadata/mono-basic-block.c
@@ -240,7 +240,7 @@ bb_split (MonoSimpleBasicBlock *first, MonoSimpleBasicBlock *hint, MonoSimpleBas
 {
 	MonoSimpleBasicBlock *res, *bb = first;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (bb_idx_is_contained (hint, target)) {
 		first = hint;
@@ -338,7 +338,7 @@ bb_formation_il_pass (const unsigned char *start, const unsigned char *end, Mono
 	MonoSimpleBasicBlock *branch, *next, *current;
 	const MonoOpcode *opcode;
 
-	mono_error_init (error);
+	error_init (error);
 
 	current = bb;
 
@@ -469,7 +469,7 @@ bb_formation_eh_pass (MonoMethodHeader *header, MonoSimpleBasicBlock *bb, MonoSi
 	int i;
 	int end = header->code_size;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/*We must split at all points to verify for targets in the middle of an instruction*/
 	for (i = 0; i < header->num_clauses; ++i) {
@@ -527,7 +527,7 @@ mono_basic_block_split (MonoMethod *method, MonoError *error, MonoMethodHeader *
 	MonoSimpleBasicBlock *bb, *root;
 	const unsigned char *start, *end;
 
-	mono_error_init (error);
+	error_init (error);
 
 	start = header->code;
 	end = start + header->code_size;

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -65,7 +65,7 @@ mono_mlist_alloc (MonoObject *data)
 MonoMList*
 mono_mlist_alloc_checked (MonoObject *data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMList* res;
 	if (!monolist_item_vtable) {
 		MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System", "MonoListItem");
@@ -197,7 +197,7 @@ mono_mlist_prepend (MonoMList* list, MonoObject *data)
 MonoMList*
 mono_mlist_prepend_checked (MonoMList* list, MonoObject *data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMList* res = mono_mlist_alloc_checked (data, error);
 	return_val_if_nok (error, NULL);
 
@@ -238,7 +238,7 @@ mono_mlist_append (MonoMList* list, MonoObject *data)
 MonoMList*
 mono_mlist_append_checked (MonoMList* list, MonoObject *data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMList* res = mono_mlist_alloc_checked (data, error);
 	return_val_if_nok (error, NULL);
 

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1295,7 +1295,7 @@ custom_get_impl (SharedCategory *cat, MonoString *counter, MonoString* instance,
 	SharedInstance* inst;
 	char *name;
 
-	mono_error_init (error);
+	error_init (error);
 	scounter = find_custom_counter (cat, counter);
 	if (!scounter)
 		return NULL;
@@ -1689,7 +1689,7 @@ get_string_array (void **array, int count, gboolean is_process, MonoError *error
 {
 	int i;
 	MonoDomain *domain = mono_domain_get ();
-	mono_error_init (error);
+	error_init (error);
 	MonoArray * res = mono_array_new_checked (mono_domain_get (), mono_get_string_class (), count, error);
 	return_val_if_nok (error, NULL);
 	for (i = 0; i < count; ++i) {
@@ -1714,7 +1714,7 @@ get_string_array_of_strings (void **array, int count, MonoError *error)
 {
 	int i;
 	MonoDomain *domain = mono_domain_get ();
-	mono_error_init (error);
+	error_init (error);
 	MonoArray * res = mono_array_new_checked (mono_domain_get (), mono_get_string_class (), count, error);
 	return_val_if_nok (error, NULL);
 	for (i = 0; i < count; ++i) {
@@ -1732,7 +1732,7 @@ get_mono_instances (MonoError *error)
 	int res;
 	void **buf = NULL;
 	MonoArray *array;
-	mono_error_init (error);
+	error_init (error);
 	do {
 		count *= 2;
 		g_free (buf);
@@ -1750,7 +1750,7 @@ get_cpu_instances (MonoError *error)
 	void **buf = NULL;
 	int i, count;
 	MonoArray *array;
-	mono_error_init (error);
+	error_init (error);
 	count = mono_cpu_count () + 1; /* +1 for "_Total" */
 	buf = g_new (void*, count);
 	for (i = 0; i < count; ++i)
@@ -1767,7 +1767,7 @@ get_processes_instances (MonoError *error)
 	MonoArray *array;
 	int count = 0;
 	void **buf = mono_process_list (&count);
-	mono_error_init (error);
+	error_init (error);
 	if (!buf)
 		return get_string_array (NULL, 0, FALSE, error);
 	array = get_string_array (buf, count, TRUE, error);
@@ -1780,7 +1780,7 @@ get_networkinterface_instances (MonoError *error)
 {
 	MonoArray *array;
 	int count = 0;
-	mono_error_init (error);
+	error_init (error);
 	void **buf = mono_networkinterface_list (&count);
 	if (!buf)
 		return get_string_array_of_strings (NULL, 0, error);
@@ -1793,7 +1793,7 @@ static MonoArray*
 get_custom_instances (MonoString *category, MonoError *error)
 {
 	SharedCategory *scat;
-	mono_error_init (error);
+	error_init (error);
 	scat = find_custom_category (category);
 	if (scat) {
 		GSList *list = get_custom_instances_list (scat);

--- a/mono/metadata/mono-security-windows-uwp.c
+++ b/mono/metadata/mono-security-windows-uwp.c
@@ -16,7 +16,7 @@ gpointer
 ves_icall_System_Security_Principal_WindowsIdentity_GetCurrentToken (void)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("OpenThreadToken, OpenProcessToken");
 
@@ -32,7 +32,7 @@ MonoArray*
 ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetTokenInformation");
 
@@ -48,7 +48,7 @@ gpointer
 ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken (gpointer token)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("DuplicateToken");
 
@@ -64,7 +64,7 @@ gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_SetCurrentToken (gpointer token)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("ImpersonateLoggedOnUser");
 
@@ -80,7 +80,7 @@ gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_RevertToSelf (void)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("RevertToSelf");
 
@@ -96,7 +96,7 @@ gint32
 mono_security_win_get_token_name (gpointer token, gunichar2 ** uniname)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetTokenInformation");
 
@@ -112,7 +112,7 @@ gboolean
 mono_security_win_is_machine_protected (gunichar2 *path)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetNamedSecurityInfo, LocalFree");
 
@@ -128,7 +128,7 @@ gboolean
 mono_security_win_is_user_protected (gunichar2 *path)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetNamedSecurityInfo, LocalFree");
 
@@ -144,7 +144,7 @@ gboolean
 mono_security_win_protect_machine (gunichar2 *path)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("BuildTrusteeWithSid, SetEntriesInAcl, SetNamedSecurityInfo, LocalFree, FreeSid");
 
@@ -160,7 +160,7 @@ gboolean
 mono_security_win_protect_user (gunichar2 *path)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("BuildTrusteeWithSid, SetEntriesInAcl, SetNamedSecurityInfo, LocalFree");
 

--- a/mono/metadata/mono-security-windows.c
+++ b/mono/metadata/mono-security-windows.c
@@ -111,7 +111,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetTokenName (gpointer token
 	gunichar2 *uniname = NULL;
 	gint32 size = 0;
 
-	mono_error_init (&error);
+	error_init (&error);
 
 	size = mono_security_win_get_token_name (token, &uniname);
 

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -226,7 +226,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetTokenName (gpointer token
 	gunichar2 *uniname = NULL;
 	gint32 size = 0;
 
-	mono_error_init (&error);
+	error_init (&error);
 
 	size = internal_get_token_name (token, &uniname);
 
@@ -551,7 +551,7 @@ ves_icall_Mono_Security_Cryptography_KeyPairPersistence_ProtectUser (MonoString 
 MonoBoolean
 ves_icall_System_Security_Policy_Evidence_IsAuthenticodePresent (MonoReflectionAssemblyHandle refass, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (MONO_HANDLE_IS_NULL (refass))
 		return FALSE;
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (refass, assembly);
@@ -587,7 +587,7 @@ void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolea
 	MonoMethod *method;
 	void *params [2];
 
-	mono_error_init (error);
+	error_init (error);
 	
 	if (system_security_assembly == NULL) {
 		system_security_assembly = mono_image_loaded ("System.Security");

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -113,7 +113,7 @@ mono_runtime_object_init_checked (MonoObject *this_obj, MonoError *error)
 	MonoMethod *method = NULL;
 	MonoClass *klass = this_obj->vtable->klass;
 
-	mono_error_init (error);
+	error_init (error);
 	method = mono_class_get_method_from_name (klass, ".ctor", 0);
 	if (!method)
 		g_error ("Could not lookup zero argument constructor for class %s", mono_type_get_full_name (klass));
@@ -358,7 +358,7 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 	MonoDomain *last_domain = NULL;
 	MonoException * pending_tae = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (vtable->initialized)
 		return TRUE;
@@ -477,7 +477,7 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 		else
 			mono_error_cleanup (error);
 
-		mono_error_init (error);
+		error_init (error);
 
 		/* If the initialization failed, mark the class as unusable. */
 		/* Avoid infinite loops */
@@ -665,7 +665,7 @@ mono_compile_method_checked (MonoMethod *method, MonoError *error)
 
 	MONO_REQ_GC_NEUTRAL_MODE
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (callbacks.compile_method);
 	res = callbacks.compile_method (method, error);
@@ -679,7 +679,7 @@ mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gbo
 
 	MONO_REQ_GC_NEUTRAL_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	res = callbacks.create_jump_trampoline (domain, method, add_sync_wrapper, error);
 	return res;
 }
@@ -1778,7 +1778,7 @@ mono_class_vtable_full (MonoDomain *domain, MonoClass *klass, MonoError *error)
 
 	MonoClassRuntimeInfo *runtime_info;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (klass);
 
@@ -1856,7 +1856,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 	gpointer iter;
 	gpointer *interface_offsets;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_loader_lock (); /*FIXME mono_class_init acquires it*/
 	mono_domain_lock (domain);
@@ -2214,7 +2214,7 @@ mono_class_proxy_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mono
 	int bcsize;
 #endif
 
-	mono_error_init (error);
+	error_init (error);
 
 	vt = mono_class_vtable (domain, klass);
 	g_assert (vt); /*FIXME property handle failure*/
@@ -2523,7 +2523,7 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	gpointer* key, *mp_key;
 	char *name;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	key = create_remote_class_key (NULL, proxy_class);
 	
@@ -2632,7 +2632,7 @@ mono_remote_class_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mon
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_loader_lock (); /*FIXME mono_class_from_mono_type and mono_class_proxy_vtable take it*/
 	mono_domain_lock (domain);
@@ -2686,7 +2686,7 @@ mono_upgrade_remote_class (MonoDomain *domain, MonoObjectHandle proxy_object, Mo
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoTransparentProxyHandle tproxy = MONO_HANDLE_CAST (MonoTransparentProxy, proxy_object);
 	MonoRemoteClass *remote_class = MONO_HANDLE_GETVAL (tproxy, remote_class);
@@ -2754,7 +2754,7 @@ mono_object_get_virtual_method (MonoObject *obj_raw, MonoMethod *method)
 MonoMethod*
 mono_object_handle_get_virtual_method (MonoObjectHandle obj, MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	gboolean is_proxy = FALSE;
 	MonoClass *klass = mono_handle_class (obj);
@@ -2769,7 +2769,7 @@ mono_object_handle_get_virtual_method (MonoObjectHandle obj, MonoMethod *method,
 static MonoMethod*
 class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is_proxy, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 
 	if (!is_proxy && ((method->flags & METHOD_ATTRIBUTE_FINAL) || !(method->flags & METHOD_ATTRIBUTE_VIRTUAL)))
@@ -2842,7 +2842,7 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 
 	g_assert (callbacks.runtime_invoke);
 
-	mono_error_init (error);
+	error_init (error);
 	
 	if (mono_profiler_get_events () & MONO_PROFILE_METHOD_EVENTS)
 		mono_profiler_method_start_invoke (method);
@@ -3343,7 +3343,7 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoObject *o;
 	MonoClass *klass;
@@ -3488,7 +3488,7 @@ mono_get_constant_value_from_blob (MonoDomain* domain, MonoTypeEnum type, const 
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	int retval = 0;
 	const char *p = blob;
 	mono_metadata_decode_blob_size (p, &p);
@@ -3539,7 +3539,7 @@ get_default_field_value (MonoDomain* domain, MonoClassField *field, void *value,
 	MonoTypeEnum def_type;
 	const char* data;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	data = mono_class_get_field_default_value (field, &def_type);
 	mono_get_constant_value_from_blob (domain, def_type, data, value, error);
@@ -3552,7 +3552,7 @@ mono_field_static_get_value_for_thread (MonoInternalThread *thread, MonoVTable *
 
 	void *src;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_return_if_fail (field->type->attrs & FIELD_ATTRIBUTE_STATIC);
 	
@@ -3674,7 +3674,7 @@ mono_property_set_value_checked (MonoProperty *prop, void *obj, void **params, M
 
 	MonoObject *exc;
 
-	mono_error_init (error);
+	error_init (error);
 	do_runtime_invoke (prop->set, obj, params, &exc, error);
 	if (exc != NULL && is_ok (error))
 		mono_error_set_exception_instance (error, (MonoException*)exc);
@@ -3797,7 +3797,7 @@ mono_nullable_box (guint8 *buf, MonoClass *klass, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *param_class = klass->cast_class;
 
 	mono_class_setup_fields (klass);
@@ -3938,7 +3938,7 @@ mono_runtime_delegate_try_invoke (MonoObject *delegate, void **params, MonoObjec
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *im;
 	MonoClass *klass = delegate->vtable->klass;
 	MonoObject *o;
@@ -3970,7 +3970,7 @@ mono_runtime_delegate_try_invoke (MonoObject *delegate, void **params, MonoObjec
 MonoObject*
 mono_runtime_delegate_invoke_checked (MonoObject *delegate, void **params, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return mono_runtime_delegate_try_invoke (delegate, params, NULL, error);
 }
 
@@ -4006,7 +4006,7 @@ mono_runtime_get_main_args_checked (MonoError *error)
 	int i;
 	MonoDomain *domain = mono_domain_get ();
 
-	mono_error_init (error);
+	error_init (error);
 
 	res = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, num_main_args, error);
 	return_val_if_nok (error, NULL);
@@ -4215,7 +4215,7 @@ int
 mono_runtime_run_main_checked (MonoMethod *method, int argc, char* argv[],
 			       MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoArray *args = prepare_run_main (method, argc, argv);
 	return mono_runtime_exec_main_checked (method, args, error);
 }
@@ -4329,7 +4329,7 @@ make_transparent_proxy (MonoObject *obj, MonoError *error)
 	MonoReflectionType *reflection_type;
 	MonoTransparentProxy *transparent_proxy;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!get_proxy_method)
 		get_proxy_method = mono_class_get_method_from_name (mono_defaults.real_proxy_class, "GetTransparentProxy", 0);
@@ -4373,7 +4373,7 @@ mono_object_xdomain_representation (MonoObject *obj, MonoDomain *target_domain, 
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoObject *deserialized = NULL;
 
 #ifndef DISABLE_REMOTING
@@ -4408,7 +4408,7 @@ create_unhandled_exception_eventargs (MonoObject *exc, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass;
 	gpointer args [2];
 	MonoMethod *method = NULL;
@@ -4659,7 +4659,7 @@ do_exec_main_checked (MonoMethod *method, MonoArray *args, MonoError *error)
 	gpointer pa [1];
 	int rval;
 
-	mono_error_init (error);
+	error_init (error);
 	g_assert (args);
 
 	pa [0] = args;
@@ -4766,7 +4766,7 @@ mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 int
 mono_runtime_exec_main_checked (MonoMethod *method, MonoArray *args, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	prepare_thread_to_exec_main (mono_object_domain (args), method);
 	return do_exec_main_checked (method, args, error);
 }
@@ -4803,7 +4803,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, gboolean* 
 {
 	MonoType *t_orig = t;
 	gpointer result = NULL;
-	mono_error_init (error);
+	error_init (error);
 		again:
 			switch (t->type) {
 			case MONO_TYPE_U1:
@@ -4984,7 +4984,7 @@ MonoObject*
 mono_runtime_invoke_array_checked (MonoMethod *method, void *obj, MonoArray *params,
 				   MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return mono_runtime_try_invoke_array (method, obj, params, NULL, error);
 }
 
@@ -5033,7 +5033,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoMethodSignature *sig = mono_method_signature (method);
 	gpointer *pa = NULL;
@@ -5229,7 +5229,7 @@ mono_object_new_pinned (MonoDomain *domain, MonoClass *klass, MonoError *error)
 
 	MonoVTable *vtable;
 
-	mono_error_init (error);
+	error_init (error);
 
 	vtable = mono_class_vtable (domain, klass);
 	g_assert (vtable); /* FIXME don't swallow the error */
@@ -5268,7 +5268,7 @@ mono_object_new_specific_checked (MonoVTable *vtable, MonoError *error)
 
 	MonoObject *o;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* check for is_com_object for COM Interop */
 	if (mono_vtable_is_remote (vtable) || mono_class_is_com_object (vtable->klass))
@@ -5362,7 +5362,7 @@ mono_object_new_alloc_specific_checked (MonoVTable *vtable, MonoError *error)
 
 	MonoObject *o;
 
-	mono_error_init (error);
+	error_init (error);
 
 	o = (MonoObject *)mono_gc_alloc_obj (vtable, vtable->klass->instance_size);
 
@@ -5423,7 +5423,7 @@ mono_object_new_fast_checked (MonoVTable *vtable, MonoError *error)
 
 	MonoObject *o;
 
-	mono_error_init (error);
+	error_init (error);
 
 	o = mono_gc_alloc_obj (vtable, vtable->klass->instance_size);
 
@@ -5450,7 +5450,7 @@ mono_object_new_mature (MonoVTable *vtable, MonoError *error)
 
 	MonoObject *o;
 
-	mono_error_init (error);
+	error_init (error);
 
 	o = mono_gc_alloc_mature (vtable, vtable->klass->instance_size);
 
@@ -5554,7 +5554,7 @@ mono_object_clone_checked (MonoObject *obj, MonoError *error)
 	MonoObject *o;
 	int size;
 
-	mono_error_init (error);
+	error_init (error);
 
 	size = obj->vtable->klass->instance_size;
 
@@ -5635,7 +5635,7 @@ mono_array_clone_in_domain (MonoDomain *domain, MonoArrayHandle array_handle, Mo
 	uintptr_t size = 0;
 	MonoClass *klass = mono_handle_class (array_handle);
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* Pin source array here - if bounds is non-NULL, it's a pointer into the object data */
 	uint32_t src_handle = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, array_handle), TRUE);
@@ -5704,7 +5704,7 @@ mono_array_clone_checked (MonoArray *array_raw, MonoError *error)
 	MONO_REQ_GC_UNSAFE_MODE;
 	HANDLE_FUNCTION_ENTER ();
 	/* FIXME: callers of mono_array_clone_checked should use handles */
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoArray, array);
 	MonoArrayHandle result = mono_array_clone_in_domain (MONO_HANDLE_DOMAIN (array), array, error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -5781,7 +5781,7 @@ mono_array_new_full_checked (MonoDomain *domain, MonoClass *array_class, uintptr
 	MonoVTable *vtable;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!array_class->inited)
 		mono_class_init (array_class);
@@ -5896,7 +5896,7 @@ mono_array_new_checked (MonoDomain *domain, MonoClass *eclass, uintptr_t n, Mono
 {
 	MonoClass *ac;
 
-	mono_error_init (error);
+	error_init (error);
 
 	ac = mono_array_class_get (eclass, 1);
 	g_assert (ac);
@@ -5943,7 +5943,7 @@ mono_array_new_specific_checked (MonoVTable *vtable, uintptr_t n, MonoError *err
 	MonoObject *o;
 	uintptr_t byte_len;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (G_UNLIKELY (n > MONO_ARRAY_MAX_INDEX)) {
 		mono_error_set_generic_error (error, "System", "OverflowException", "");
@@ -6035,7 +6035,7 @@ mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 l
 
 	MonoString *s;
 	
-	mono_error_init (error);
+	error_init (error);
 	
 	s = mono_string_new_size_checked (domain, len, error);
 	if (s != NULL)
@@ -6078,7 +6078,7 @@ mono_string_new_utf32_checked (MonoDomain *domain, const mono_unichar4 *text, gi
 	GError *gerror = NULL;
 	glong items_written;
 	
-	mono_error_init (error);
+	error_init (error);
 	utf16_output = g_ucs4_to_utf16 (text, len, NULL, &items_written, &gerror);
 	
 	if (gerror)
@@ -6138,7 +6138,7 @@ mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error)
 	MonoVTable *vtable;
 	size_t size;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* check for overflow */
 	if (len < 0 || len > ((SIZE_MAX - G_STRUCT_OFFSET (MonoString, chars) - 8) / 2)) {
@@ -6194,7 +6194,7 @@ mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length,
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	GError *eg_error = NULL;
 	MonoString *o = NULL;
@@ -6252,7 +6252,7 @@ mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *error)
     glong items_written;
     int l;
 
-    mono_error_init (error);
+    error_init (error);
 
     l = strlen (text);
    
@@ -6346,7 +6346,7 @@ mono_value_box_checked (MonoDomain *domain, MonoClass *klass, gpointer value, Mo
 	int size;
 	MonoVTable *vtable;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (klass->valuetype);
 	if (mono_class_is_nullable (klass))
@@ -6544,7 +6544,7 @@ mono_object_isinst_checked (MonoObject *obj_raw, MonoClass *klass, MonoError *er
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	MonoObjectHandle result = mono_object_handle_isinst (obj, klass, error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -6562,7 +6562,7 @@ mono_object_isinst_checked (MonoObject *obj_raw, MonoClass *klass, MonoError *er
 MonoObjectHandle
 mono_object_handle_isinst (MonoObjectHandle obj, MonoClass *klass, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	
 	if (!klass->inited)
 		mono_class_init (klass);
@@ -6594,7 +6594,7 @@ mono_object_isinst_mbyref (MonoObject *obj_raw, MonoClass *klass)
 MonoObjectHandle
 mono_object_handle_isinst_mbyref (MonoObjectHandle obj, MonoClass *klass, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoObjectHandle result = MONO_HANDLE_NEW (MonoObject, NULL);
 
@@ -6726,7 +6726,7 @@ mono_string_get_pinned (MonoString *str, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* We only need to make a pinned version of a string if this is a moving GC */
 	if (!mono_gc_is_moving ())
@@ -6753,7 +6753,7 @@ mono_string_is_interned_lookup (MonoString *str, int insert, MonoError *error)
 	MonoString *s, *res;
 	MonoDomain *domain;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	domain = ((MonoObject *)str)->vtable->domain;
 	ldstr_table = domain->ldstr_table;
@@ -6845,7 +6845,7 @@ mono_string_intern_checked (MonoString *str, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	return mono_string_is_interned_lookup (str, TRUE, error);
 }
@@ -6883,7 +6883,7 @@ MonoString*
 mono_ldstr_checked (MonoDomain *domain, MonoImage *image, guint32 idx, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
-	mono_error_init (error);
+	error_init (error);
 
 	if (image->dynamic) {
 		MonoString *str = (MonoString *)mono_lookup_dynamic_token (image, MONO_TOKEN_STRING | idx, NULL, error);
@@ -6910,7 +6910,7 @@ mono_ldstr_metadata_sig (MonoDomain *domain, const char* sig, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	const char *str = sig;
 	MonoString *o, *interned;
 	size_t len2;
@@ -6965,7 +6965,7 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 	char *as;
 	GError *gerror = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_verifier_verify_string_signature (image, idx, NULL))
 		return NULL; /*FIXME we should probably be raising an exception here*/
@@ -7034,7 +7034,7 @@ mono_string_to_utf8_checked (MonoString *s, MonoError *error)
 	char *as;
 	GError *gerror = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (s == NULL)
 		return NULL;
@@ -7222,7 +7222,7 @@ mono_string_from_utf16_checked (gunichar2 *data, MonoError *error)
 
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get ();
 	int len = 0;
 
@@ -7265,7 +7265,7 @@ mono_string_from_utf32_checked (mono_unichar4 *data, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoString* result = NULL;
 	mono_unichar2 *utf16_output = NULL;
 	GError *gerror = NULL;
@@ -7409,7 +7409,7 @@ mono_wait_handle_new (MonoDomain *domain, HANDLE handle, MonoError *error)
 	gpointer params [1];
 	static MonoMethod *handle_set;
 
-	mono_error_init (error);
+	error_init (error);
 	res = (MonoWaitHandle *)mono_object_new_checked (domain, mono_defaults.manualresetevent_class, error);
 	return_val_if_nok (error, NULL);
 
@@ -7448,7 +7448,7 @@ mono_runtime_capture_context (MonoDomain *domain, MonoError *error)
 
 	RuntimeInvokeFunction runtime_invoke;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!domain->capture_context_runtime_invoke || !domain->capture_context_method) {
 		MonoMethod *method = mono_get_context_capture_method ();
@@ -7484,7 +7484,7 @@ mono_async_result_new (MonoDomain *domain, HANDLE handle, MonoObject *state, gpo
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoAsyncResult *res = (MonoAsyncResult *)mono_object_new_checked (domain, mono_defaults.asyncresult_class, error);
 	return_val_if_nok (error, NULL);
 	MonoObject *context = mono_runtime_capture_context (domain, error);
@@ -7554,7 +7554,7 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 		if (wait_event != NULL)
 			mono_w32event_set (wait_event);
 
-		mono_error_init (&error); //the else branch would leave it in an undefined state
+		error_init (&error); //the else branch would leave it in an undefined state
 		if (ac->cb_method)
 			mono_runtime_invoke_checked (ac->cb_method, ac->cb_target, (gpointer*) &ares, &error);
 
@@ -7583,7 +7583,7 @@ mono_message_init (MonoDomain *domain,
 		g_assert (init_message_method != NULL);
 	}
 
-	mono_error_init (error);
+	error_init (error);
 	/* FIXME set domain instead? */
 	g_assert (domain == mono_domain_get ());
 	
@@ -7622,7 +7622,7 @@ mono_remoting_invoke (MonoObject *real_proxy, MonoMethodMessage *msg, MonoObject
 
 	g_assert (exc);
 
-	mono_error_init (error);
+	error_init (error);
 
 	/*static MonoObject *(*invoke) (gpointer, gpointer, MonoObject **, MonoArray **) = NULL;*/
 
@@ -7654,7 +7654,7 @@ mono_message_invoke (MonoObject *target, MonoMethodMessage *msg,
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	static MonoClass *object_array_klass;
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDomain *domain; 
 	MonoMethod *method;
@@ -7784,7 +7784,7 @@ mono_object_to_string (MonoObject *obj, MonoObject **exc)
 MonoString *
 mono_object_to_string_checked (MonoObject *obj, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	void *target;
 	MonoMethod *method = prepare_to_string_method (obj, &target);
 	return (MonoString*) mono_runtime_invoke_checked (method, target, NULL, error);
@@ -7804,7 +7804,7 @@ MonoString *
 mono_object_try_to_string (MonoObject *obj, MonoObject **exc, MonoError *error)
 {
 	g_assert (exc);
-	mono_error_init (error);
+	error_init (error);
 	void *target;
 	MonoMethod *method = prepare_to_string_method (obj, &target);
 	return (MonoString*) mono_runtime_try_invoke (method, target, NULL, exc, error);
@@ -7906,7 +7906,7 @@ mono_delegate_ctor_with_method (MonoObject *this_obj, MonoObject *target, gpoint
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoDelegate *delegate = (MonoDelegate *)this_obj;
 
 	g_assert (this_obj);
@@ -7954,7 +7954,7 @@ mono_delegate_ctor (MonoObject *this_obj, MonoObject *target, gpointer addr, Mon
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitInfo *ji;
 	MonoMethod *method = NULL;
@@ -7991,7 +7991,7 @@ mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDomain *domain = mono_domain_get ();
 	MonoMethodSignature *sig = mono_method_signature (method);
@@ -8055,7 +8055,7 @@ mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoAr
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoMethodSignature *sig = mono_method_signature (method);
 	int i, j, type, size, out_len;
@@ -8149,7 +8149,7 @@ mono_load_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoClas
 
 	static MonoMethod *getter = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDomain *domain = mono_domain_get ();
 	MonoTransparentProxy *tp = (MonoTransparentProxy *) this_obj;
@@ -8246,7 +8246,7 @@ mono_load_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, Mono
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	static MonoMethod *tp_load = NULL;
 
@@ -8308,7 +8308,7 @@ mono_store_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoCla
 	
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDomain *domain = mono_domain_get ();
 	MonoClass *field_class;
@@ -8362,7 +8362,7 @@ mono_store_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, Mon
 
 	static MonoMethod *tp_store = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (mono_object_is_transparent_proxy (this_obj));
 
@@ -8495,7 +8495,7 @@ mono_glist_to_array (GList *list, MonoClass *eclass, MonoError *error)
 	MonoArray *res;
 	int len, i;
 
-	mono_error_init (error);
+	error_init (error);
 	if (!list)
 		return NULL;
 

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -109,7 +109,7 @@ typedef MonoObjectHandle (*ReflectionCacheConstructFunc_handle) (MonoDomain*, Mo
 static inline MonoObjectHandle
 check_or_construct_handle (MonoDomain *domain, MonoClass *klass, gpointer item, gpointer user_data, MonoError *error, ReflectionCacheConstructFunc_handle construct)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoObjectHandle obj = check_object_handle (domain, klass, item);
 	if (!MONO_HANDLE_IS_NULL (obj))
 		return obj;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -229,7 +229,7 @@ mono_assembly_get_object (MonoDomain *domain, MonoAssembly *assembly)
 static MonoReflectionAssemblyHandle
 assembly_object_construct (MonoDomain *domain, MonoClass *unused_klass, MonoAssembly *assembly, gpointer user_data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionAssemblyHandle res = MONO_HANDLE_NEW (MonoReflectionAssembly, mono_object_new_checked (domain, mono_class_get_mono_assembly_class (), error));
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE));
 	MONO_HANDLE_SETVAL (res, assembly, MonoAssembly*, assembly);
@@ -246,7 +246,7 @@ assembly_object_construct (MonoDomain *domain, MonoClass *unused_klass, MonoAsse
 MonoReflectionAssemblyHandle
 mono_assembly_get_object_handle (MonoDomain *domain, MonoAssembly *assembly, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionAssemblyHandle, assembly, NULL, assembly_object_construct, NULL);
 }
 
@@ -265,7 +265,7 @@ module_object_construct (MonoDomain *domain, MonoClass *unused_klass, MonoImage 
 {
 	char* basename;
 	
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionModuleHandle res = MONO_HANDLE_NEW (MonoReflectionModule, mono_object_new_checked (domain, mono_class_get_mono_module_class (), error));
 	if (!is_ok (error))
 		goto fail;
@@ -312,7 +312,7 @@ fail:
 MonoReflectionModuleHandle
 mono_module_get_object_handle (MonoDomain *domain, MonoImage *image, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionModuleHandle, image, NULL, module_object_construct, NULL);
 }
 
@@ -335,7 +335,7 @@ mono_module_file_get_object_handle (MonoDomain *domain, MonoImage *image, int ta
 	guint32 i, name_idx;
 	const char *val;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	MonoReflectionModuleHandle res = MONO_HANDLE_NEW (MonoReflectionModule, mono_object_new_checked (domain, mono_class_get_mono_module_class (), error));
 	if (!is_ok (error))
@@ -445,7 +445,7 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	MonoReflectionType *res;
 	MonoClass *klass;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (type != NULL);
 	klass = mono_class_from_mono_type (type);
@@ -579,7 +579,7 @@ mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refcl
 static MonoReflectionMethodHandle
 method_object_construct (MonoDomain *domain, MonoClass *refclass, MonoMethod *method, gpointer user_data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	g_assert (refclass != NULL);
 	/*
 	 * We use the same C representation for methods and constructors, but the type 
@@ -587,7 +587,7 @@ method_object_construct (MonoDomain *domain, MonoClass *refclass, MonoMethod *me
 	 */
 	MonoClass *klass;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (*method->name == '.' && (strcmp (method->name, ".ctor") == 0 || strcmp (method->name, ".cctor") == 0)) {
 		klass = mono_class_get_mono_cmethod_class ();
@@ -625,7 +625,7 @@ fail:
 MonoReflectionMethodHandle
 mono_method_get_object_handle (MonoDomain *domain, MonoMethod *method, MonoClass *refclass, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (!refclass)
 		refclass = method->klass;
 
@@ -696,7 +696,7 @@ mono_field_get_object (MonoDomain *domain, MonoClass *klass, MonoClassField *fie
 static MonoReflectionFieldHandle
 field_object_construct (MonoDomain *domain, MonoClass *klass, MonoClassField *field, gpointer user_data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoReflectionFieldHandle res = MONO_HANDLE_NEW (MonoReflectionField, mono_object_new_checked (domain, mono_class_get_mono_field_class (), error));
 	if (!is_ok (error))
@@ -734,7 +734,7 @@ fail:
 MonoReflectionFieldHandle
 mono_field_get_object_handle (MonoDomain *domain, MonoClass *klass, MonoClassField *field, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionFieldHandle, field, klass, field_object_construct, NULL);
 }
 
@@ -779,7 +779,7 @@ mono_property_get_object (MonoDomain *domain, MonoClass *klass, MonoProperty *pr
 static MonoReflectionPropertyHandle
 property_object_construct (MonoDomain *domain, MonoClass *klass, MonoProperty *property, gpointer user_data, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	MonoReflectionPropertyHandle res = MONO_HANDLE_NEW (MonoReflectionProperty, mono_object_new_checked (domain, mono_class_get_mono_property_class (), error));
 	if (!is_ok (error))
@@ -848,7 +848,7 @@ static MonoReflectionEventHandle
 event_object_construct (MonoDomain *domain, MonoClass *klass, MonoEvent *event, gpointer user_data, MonoError *error)
 {
 
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionMonoEventHandle mono_event = MONO_HANDLE_NEW (MonoReflectionMonoEvent, mono_object_new_checked (domain, mono_class_get_mono_event_class (), error));
 	if (!is_ok (error))
 		return MONO_HANDLE_CAST (MonoReflectionEvent, NULL_HANDLE);
@@ -870,7 +870,7 @@ event_object_construct (MonoDomain *domain, MonoClass *klass, MonoEvent *event, 
 MonoReflectionEventHandle
 mono_event_get_object_handle (MonoDomain *domain, MonoClass *klass, MonoEvent *event, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionEventHandle, event, klass, event_object_construct, NULL);
 }
 
@@ -909,7 +909,7 @@ get_dbnull_object (MonoDomain *domain, MonoError *error)
 {
 	static MonoClassField *dbnull_value_field = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!dbnull_value_field) {
 		MonoClass *dbnull_klass;
@@ -925,7 +925,7 @@ get_dbnull_object (MonoDomain *domain, MonoError *error)
 static MonoObjectHandle
 get_dbnull (MonoDomain *domain, MonoObjectHandle dbnull, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (MONO_HANDLE_IS_NULL (dbnull))
 		MONO_HANDLE_ASSIGN (dbnull, get_dbnull_object (domain, error));
 	return dbnull;
@@ -943,7 +943,7 @@ static gboolean
 add_parameter_object_to_array (MonoDomain *domain, MonoMethod *method, MonoObjectHandle member, int idx, const char *name, MonoType *sig_param, guint32 blob_type_enum, const char *blob, MonoMarshalSpec *mspec, MonoObjectHandle missing, MonoObjectHandle dbnull, MonoArrayHandle dest,  MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionParameterHandle param = MONO_HANDLE_NEW (MonoReflectionParameter, mono_object_new_checked (domain, mono_class_get_mono_parameter_info_class (), error));
 	if (!is_ok (error))
 		goto leave;
@@ -1030,7 +1030,7 @@ param_objects_construct (MonoDomain *domain, MonoClass *refclass, MonoMethodSign
 	MonoMarshalSpec **mspecs = NULL;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	MonoReflectionMethodHandle member = mono_method_get_object_handle (domain, method, refclass, error);
 	if (!is_ok (error))
@@ -1096,7 +1096,7 @@ leave:
 MonoArrayHandle
 mono_param_get_objects_internal (MonoDomain *domain, MonoMethod *method, MonoClass *refclass, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	/* side-effect: sets method->signature non-NULL on success */
 	MonoMethodSignature *sig = mono_method_signature_checked (method, error);
@@ -1133,7 +1133,7 @@ static gboolean
 add_local_var_info_to_array (MonoDomain *domain, MonoMethodHeader *header, int idx, MonoArrayHandle dest, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionLocalVariableInfoHandle info = MONO_HANDLE_NEW (MonoReflectionLocalVariableInfo, mono_object_new_checked (domain, mono_class_get_local_variable_info_class (), error));
 	if (!is_ok (error))
 		goto leave;
@@ -1157,7 +1157,7 @@ static gboolean
 add_exception_handling_clause_to_array (MonoDomain *domain, MonoMethodHeader *header, int idx, MonoArrayHandle dest, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionExceptionHandlingClauseHandle info = MONO_HANDLE_NEW (MonoReflectionExceptionHandlingClause, mono_object_new_checked (domain, mono_class_get_exception_handling_clause_class (), error));
 	if (!is_ok (error))
 		goto leave;
@@ -1210,7 +1210,7 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	unsigned char format, flags;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* for compatibility with .net */
 	if (method_is_dynamic (method)) {
@@ -1308,7 +1308,7 @@ fail:
 MonoReflectionMethodBodyHandle
 mono_method_body_get_object_handle (MonoDomain *domain, MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionMethodBodyHandle, method, NULL, method_body_object_construct, NULL);
 }
 
@@ -1406,7 +1406,7 @@ mono_get_object_from_blob (MonoDomain *domain, MonoType *type, const char *blob,
 	MonoObject *object;
 	MonoType *basetype = type;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!blob)
 		return NULL;
@@ -1841,7 +1841,7 @@ _mono_reflection_get_type_from_info (MonoTypeNameParse *info, MonoImage *image, 
 	MonoType *type;
 	MonoImage *rootimage = image;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (info->assembly.name) {
 		MonoAssembly *assembly = mono_assembly_loaded (&info->assembly);
@@ -1866,7 +1866,7 @@ _mono_reflection_get_type_from_info (MonoTypeNameParse *info, MonoImage *image, 
 	if (type == NULL && !info->assembly.name && image != mono_defaults.corlib) {
 		/* ignore the error and try again */
 		mono_error_cleanup (error);
-		mono_error_init (error);
+		error_init (error);
 		image = mono_defaults.corlib;
 		type = mono_reflection_get_type_with_rootimage (rootimage, image, info, ignorecase, &type_resolve, error);
 	}
@@ -1887,7 +1887,7 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 	int modval;
 	gboolean bounded = FALSE;
 	
-	mono_error_init (error);
+	error_init (error);
 	if (!image)
 		image = mono_defaults.corlib;
 
@@ -2041,7 +2041,7 @@ mono_reflection_get_type (MonoImage* image, MonoTypeNameParse *info, gboolean ig
  */
 MonoType*
 mono_reflection_get_type_checked (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve, MonoError *error) {
-	mono_error_init (error);
+	error_init (error);
 	return mono_reflection_get_type_with_rootimage (rootimage, image, info, ignorecase, type_resolve, error);
 }
 
@@ -2050,7 +2050,7 @@ static MonoType*
 module_builder_array_get_type (MonoArrayHandle module_builders, int i, MonoImage *rootimage, MonoTypeNameParse *info, gboolean ignorecase, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = NULL;
 	MonoReflectionModuleBuilderHandle mb = MONO_HANDLE_NEW (MonoReflectionModuleBuilder, NULL);
 	MONO_HANDLE_ARRAY_GETREF (mb, module_builders, i);
@@ -2063,7 +2063,7 @@ static MonoType*
 module_array_get_type (MonoArrayHandle modules, int i, MonoImage *rootimage, MonoTypeNameParse *info, gboolean ignorecase, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoType *type = NULL;
 	MonoReflectionModuleHandle mod = MONO_HANDLE_NEW (MonoReflectionModule, NULL);
 	MONO_HANDLE_ARRAY_GETREF (mod, modules, i);
@@ -2079,7 +2079,7 @@ mono_reflection_get_type_internal_dynamic (MonoImage *rootimage, MonoAssembly *a
 	MonoType *type = NULL;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 	g_assert (assembly_is_dynamic (assembly));
 	MonoReflectionAssemblyBuilderHandle abuilder = MONO_HANDLE_CAST (MonoReflectionAssemblyBuilder, mono_assembly_get_object_handle (((MonoDynamicAssembly*)assembly)->domain, assembly, error));
 	if (!is_ok (error))
@@ -2125,7 +2125,7 @@ mono_reflection_get_type_with_rootimage (MonoImage *rootimage, MonoImage* image,
 	GString *fullName;
 	GList *mod;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (image && image_is_dynamic (image))
 		type = mono_reflection_get_type_internal_dynamic (rootimage, image->assembly, info, ignorecase, error);
@@ -2232,7 +2232,7 @@ mono_reflection_type_from_name_checked (char *name, MonoImage *image, MonoError 
 	MonoTypeNameParse info;
 	char *tmp;
 
-	mono_error_init (error);
+	error_init (error);
 	/* Make a copy since parse_type modifies its argument */
 	tmp = g_strdup (name);
 	
@@ -2281,7 +2281,7 @@ mono_reflection_get_token_checked (MonoObjectHandle obj, MonoError *error)
 {
 	guint32 token = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoClass *klass = mono_handle_class (obj);
 
@@ -2380,7 +2380,7 @@ mono_reflection_bind_generic_parameters (MonoReflectionTypeHandle reftype, int t
 	gboolean is_dynamic = FALSE;
 	MonoClass *geninst;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	mono_loader_lock ();
 
@@ -2446,7 +2446,7 @@ static MonoGenericInst*
 generic_inst_from_type_array_handle (MonoArrayHandle types, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoGenericInst *ginst = NULL;
 	int count = mono_array_handle_length (types);
 	MonoType **type_argv = g_new0 (MonoType *, count);
@@ -2471,7 +2471,7 @@ reflection_bind_generic_method_parameters (MonoMethod *method, MonoArrayHandle t
 	MonoMethod *inflated;
 	MonoGenericContext tmp_context;
 
-	mono_error_init (error);
+	error_init (error);
 
 	klass = method->klass;
 
@@ -2504,7 +2504,7 @@ reflection_bind_generic_method_parameters (MonoMethod *method, MonoArrayHandle t
 MonoReflectionMethodHandle
 ves_icall_MonoMethod_MakeGenericMethod_impl (MonoReflectionMethodHandle rmethod, MonoArrayHandle types, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	g_assert (0 != strcmp (mono_handle_class (rmethod)->name, "MethodBuilder"));
 
 	MonoMethod *method = MONO_HANDLE_GETVAL (rmethod, method);
@@ -2959,7 +2959,7 @@ mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, Mono
 	void *params [1];
 	static MonoMethod *method = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (method == NULL) {
 		method = mono_class_get_method_from_name (mono_class_get_type_builder_class (), "IsAssignableTo", 1);

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -413,7 +413,7 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 		goto fail;
 
 	if (exc) {
-		mono_error_init (&error);
+		error_init (&error);
 		mono_error_set_exception_instance (&error, (MonoException *)exc);
 		goto fail;
 	}
@@ -1917,7 +1917,7 @@ static gboolean
 xdomain_copy_array_element_inplace (MonoArrayHandle arr, int i, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoObjectHandle item = MONO_HANDLE_NEW (MonoObject, NULL);
 	MONO_HANDLE_ARRAY_GETREF (item, arr, i);
 	
@@ -1940,7 +1940,7 @@ leave:
 MonoObjectHandle
 mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoObjectHandle result = MONO_HANDLE_NEW (MonoObject, NULL);
 	if (MONO_HANDLE_IS_NULL (val))
 		goto leave;

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -631,7 +631,7 @@ get_method_access_exception (const char *format, MonoMethod *caller, MonoMethod 
 gboolean
 mono_security_core_clr_ensure_reflection_access_field (MonoClassField *field, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *caller = get_reflection_caller ();
 	/* CoreCLR restrictions applies to Transparent code/caller */
 	if (mono_security_core_clr_method_level (caller, TRUE) != MONO_SECURITY_CORE_CLR_TRANSPARENT)
@@ -672,7 +672,7 @@ mono_security_core_clr_ensure_reflection_access_field (MonoClassField *field, Mo
 gboolean
 mono_security_core_clr_ensure_reflection_access_method (MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoMethod *caller = get_reflection_caller ();
 	/* CoreCLR restrictions applies to Transparent code/caller */
 	if (mono_security_core_clr_method_level (caller, TRUE) != MONO_SECURITY_CORE_CLR_TRANSPARENT)
@@ -748,7 +748,7 @@ mono_security_core_clr_ensure_delegate_creation (MonoMethod *method, MonoError *
 {
 	MonoMethod *caller;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* note: mscorlib creates delegates to avoid reflection (optimization), we ignore those cases */
 	if (can_avoid_corlib_reflection_delegate_optimization (method))
@@ -1061,21 +1061,21 @@ mono_security_core_clr_require_elevated_permissions (void)
 gboolean
 mono_security_core_clr_ensure_reflection_access_field (MonoClassField *field, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return TRUE;
 }
 
 gboolean
 mono_security_core_clr_ensure_reflection_access_method (MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return TRUE;
 }
 
 gboolean
 mono_security_core_clr_ensure_delegate_creation (MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return TRUE;
 }
 

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -236,7 +236,7 @@ encode_reflection_type (MonoDynamicImage *assembly, MonoReflectionTypeHandle typ
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!type) {
 		sigbuffer_add_value (buf, MONO_TYPE_VOID);
@@ -252,7 +252,7 @@ static void
 encode_reflection_type_raw (MonoDynamicImage *assembly, MonoReflectionType* type_raw, SigBuffer *buf, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER (); /* FIXME callers of encode_reflection_type_raw should use handles */
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoReflectionType, type);
 	encode_reflection_type (assembly, type, buf, error);
 	HANDLE_FUNCTION_RETURN ();
@@ -267,7 +267,7 @@ encode_custom_modifiers (MonoDynamicImage *assembly, MonoArrayHandle modreq, Mon
 
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!MONO_HANDLE_IS_NULL (modreq)) {
 		for (i = 0; i < mono_array_handle_length (modreq); ++i) {
@@ -295,7 +295,7 @@ static void
 encode_custom_modifiers_raw (MonoDynamicImage *assembly, MonoArray *modreq_raw, MonoArray *modopt_raw, SigBuffer *buf, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER (); /* FIXME callers of encode_custom_modifiers_raw should use handles */
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoArray, modreq);
 	MONO_HANDLE_DCL (MonoArray, modopt);
 	encode_custom_modifiers (assembly, modreq, modopt, buf, error);
@@ -354,7 +354,7 @@ mono_dynimage_encode_method_builder_signature (MonoDynamicImage *assembly, Refle
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/*
 	 * FIXME: reuse code from method_encode_signature().
@@ -424,7 +424,7 @@ mono_dynimage_encode_locals (MonoDynamicImage *assembly, MonoReflectionILGen *il
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDynamicTable *table;
 	guint32 *values;
@@ -623,7 +623,7 @@ mono_dynimage_encode_field_signature (MonoDynamicImage *assembly, MonoReflection
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	SigBuffer buf;
 	guint32 idx;
@@ -858,7 +858,7 @@ static gboolean
 encode_sighelper_arg (MonoDynamicImage *assembly, int i, MonoArrayHandle helper_arguments, MonoArrayHandle helper_modreqs, MonoArrayHandle helper_modopts, SigBuffer* buf, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER();
-	mono_error_init (error);
+	error_init (error);
 	MonoArrayHandle modreqs = MONO_HANDLE_NEW (MonoArray, NULL);
 	MonoArrayHandle modopts = MONO_HANDLE_NEW (MonoArray, NULL);
 
@@ -886,7 +886,7 @@ mono_dynimage_encode_reflection_sighelper (MonoDynamicImage *assembly, MonoRefle
 	guint32 nargs;
 	guint32 i, idx;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!assembly->save)
 		return 0;
@@ -957,7 +957,7 @@ reflection_sighelper_get_signature_local (MonoReflectionSigHelper *sig, MonoErro
 	MonoArray *result;
 	SigBuffer buf;
 
-	mono_error_init (error);
+	error_init (error);
 
 	sigbuffer_init (&buf, 32);
 
@@ -991,7 +991,7 @@ reflection_sighelper_get_signature_field (MonoReflectionSigHelper *sig, MonoErro
 	MonoArray *result;
 	SigBuffer buf;
 
-	mono_error_init (error);
+	error_init (error);
 
 	sigbuffer_init (&buf, 32);
 
@@ -1029,7 +1029,7 @@ mono_dynimage_save_encode_marshal_blob (MonoDynamicImage *assembly, MonoReflecti
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	char *str;
 	SigBuffer buf;
@@ -1127,7 +1127,7 @@ mono_dynimage_save_encode_property_signature (MonoDynamicImage *assembly, MonoRe
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	SigBuffer buf;
 	guint32 nparams = 0;

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -180,7 +180,7 @@ static guint32
 image_create_token_raw  (MonoDynamicImage *assembly, MonoObject* obj_raw, gboolean create_methodspec, gboolean register_token, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER (); /* FIXME callers of image_create_token_raw should use handles */
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	guint32 result = mono_image_create_token (assembly, obj, create_methodspec, register_token, error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
@@ -203,7 +203,7 @@ mono_image_add_cattrs (MonoDynamicImage *assembly, guint32 idx, guint32 type, Mo
 	char blob_size [6];
 	char *p = blob_size;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	/* it is legal to pass a NULL cattrs: we avoid to use the if in a lot of places */
 	if (!cattrs)
@@ -329,7 +329,7 @@ method_encode_code (MonoDynamicImage *assembly, ReflectionMethodBuilder *mb, Mon
 	guint32 header_size = 12;
 	MonoArray *code;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if ((mb->attrs & (METHOD_ATTRIBUTE_PINVOKE_IMPL | METHOD_ATTRIBUTE_ABSTRACT)) ||
 			(mb->iattrs & (METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL | METHOD_IMPL_ATTRIBUTE_RUNTIME)))
@@ -491,7 +491,7 @@ mono_image_basic_method (ReflectionMethodBuilder *mb, MonoDynamicImage *assembly
 	guint32 *values;
 	guint i, count;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* room in this table is already allocated */
 	table = &assembly->tables [MONO_TABLE_METHOD];
@@ -579,7 +579,7 @@ mono_image_add_methodimpl (MonoDynamicImage *assembly, MonoReflectionMethodBuild
 	MonoReflectionMethod *m;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mb->override_methods)
 		return TRUE;
@@ -624,7 +624,7 @@ mono_image_get_method_info (MonoReflectionMethodBuilder *mb, MonoDynamicImage *a
 	ReflectionMethodBuilder rmb;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_reflection_methodbuilder_from_method_builder (&rmb, mb, error) ||
 	    !mono_image_basic_method (&rmb, assembly, error))
@@ -701,7 +701,7 @@ mono_image_get_field_info (MonoReflectionFieldBuilder *fb, MonoDynamicImage *ass
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDynamicTable *table;
 	guint32 *values;
@@ -772,7 +772,7 @@ mono_image_get_property_info (MonoReflectionPropertyBuilder *pb, MonoDynamicImag
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDynamicTable *table;
 	guint32 *values;
@@ -898,7 +898,7 @@ encode_constraints (MonoReflectionGenericParam *gparam, guint32 owner, MonoDynam
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoDynamicTable *table;
 	guint32 num_constraints, i;
@@ -971,7 +971,7 @@ write_generic_param_entry (MonoDynamicImage *assembly, GenericParamTableEntry *e
 	guint32 *values;
 	guint32 table_idx;
 
-	mono_error_init (error);
+	error_init (error);
 
 	table = &assembly->tables [MONO_TABLE_GENERICPARAM];
 	table_idx = table->next_idx ++;
@@ -1028,7 +1028,7 @@ static gboolean
 params_add_cattrs (MonoDynamicImage *assembly, MonoArray *pinfo, MonoError *error) {
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 	if (!pinfo)
 		return TRUE;
 	for (i = 0; i < mono_array_length (pinfo); ++i) {
@@ -1047,7 +1047,7 @@ static gboolean
 type_add_cattrs (MonoDynamicImage *assembly, MonoReflectionTypeBuilder *tb, MonoError *error) {
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	if (!mono_image_add_cattrs (assembly, tb->table_idx, MONO_CUSTOM_ATTR_TYPEDEF, tb->cattrs, error))
 		return FALSE;
@@ -1110,7 +1110,7 @@ module_add_cattrs (MonoDynamicImage *assembly, MonoReflectionModuleBuilder *modu
 {
 	int i;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	if (!mono_image_add_cattrs (assembly, moduleb->table_idx, MONO_CUSTOM_ATTR_MODULE, moduleb->cattrs, error))
 		return FALSE;
@@ -1152,7 +1152,7 @@ mono_image_fill_file_table (MonoDomain *domain, MonoReflectionModule *module, Mo
 	char *b = blob_size;
 	char *dir, *path;
 
-	mono_error_init (error);
+	error_init (error);
 
 	table = &assembly->tables [MONO_TABLE_FILE];
 	table->rows++;
@@ -1185,7 +1185,7 @@ mono_image_fill_module_table (MonoDomain *domain, MonoReflectionModuleBuilder *m
 	MonoDynamicTable *table;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	table = &assembly->tables [MONO_TABLE_MODULE];
 	mb->table_idx = table->next_idx ++;
@@ -1247,7 +1247,7 @@ mono_image_fill_export_table (MonoDomain *domain, MonoReflectionTypeBuilder *tb,
 	MonoClass *klass;
 	guint32 idx, i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoType *t = mono_reflection_type_get_handle ((MonoReflectionType*)tb, error);
 	return_if_nok (error);
@@ -1479,7 +1479,7 @@ build_compressed_metadata (MonoDynamicImage *assembly, MonoError *error)
 	unsigned char *p;
 	struct StreamDesc stream_desc [5];
 
-	mono_error_init (error);
+	error_init (error);
 
 	qsort (assembly->gen_params->pdata, assembly->gen_params->len, sizeof (gpointer), compare_genericparam);
 	for (i = 0; i < assembly->gen_params->len; i++) {
@@ -1855,7 +1855,7 @@ assembly_add_resource_manifest (MonoReflectionModuleBuilder *mb, MonoDynamicImag
 	MonoDynamicTable *table;
 	guint32 *values;
 
-	mono_error_init (error);
+	error_init (error);
 
 	table = &assembly->tables [MONO_TABLE_MANIFESTRESOURCE];
 	table->rows++;
@@ -1881,7 +1881,7 @@ assembly_add_resource (MonoReflectionModuleBuilder *mb, MonoDynamicImage *assemb
 	char *name, *sname;
 	guint32 idx, offset;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (rsrc->filename) {
 		name = mono_string_to_utf8_checked (rsrc->filename, error);
@@ -1941,7 +1941,7 @@ set_version_from_string (MonoString *version, guint32 *values, MonoError *error)
 	gchar *ver, *p, *str;
 	guint32 i;
 	
-	mono_error_init (error);
+	error_init (error);
 
 	values [MONO_ASSEMBLY_MAJOR_VERSION] = 0;
 	values [MONO_ASSEMBLY_MINOR_VERSION] = 0;
@@ -2015,7 +2015,7 @@ mono_image_emit_manifest (MonoReflectionModuleBuilder *moduleb, MonoError *error
 	int i;
 	guint32 module_index;
 
-	mono_error_init (error);
+	error_init (error);
 
 	assemblyb = moduleb->assemblyb;
 	assembly = moduleb->dynamic_image;
@@ -2107,7 +2107,7 @@ mono_image_get_type_info (MonoDomain *domain, MonoReflectionTypeBuilder *tb, Mon
 	int i, is_object = 0, is_system = 0;
 	char *n;
 
-	mono_error_init (error);
+	error_init (error);
 
 	table = &assembly->tables [MONO_TABLE_TYPEDEF];
 	values = table->values + tb->table_idx * MONO_TYPEDEF_SIZE;
@@ -2298,7 +2298,7 @@ mono_image_build_metadata (MonoReflectionModuleBuilder *moduleb, MonoError *erro
 	guint32 *values;
 	int i, j;
 
-	mono_error_init (error);
+	error_init (error);
 
 	assemblyb = moduleb->assemblyb;
 	assembly = moduleb->dynamic_image;
@@ -2776,7 +2776,7 @@ mono_image_create_pefile (MonoReflectionModuleBuilder *mb, HANDLE file, MonoErro
 		0x6d, 0x6f, 0x64, 0x65, 0x2e, 0x0d, 0x0d, 0x0a,  0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
 
-	mono_error_init (error);
+	error_init (error);
 
 	assemblyb = mb->assemblyb;
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -90,7 +90,7 @@ string_to_utf8_image_raw (MonoImage *image, MonoString *s_raw, MonoError *error)
 	/* FIXME all callers to string_to_utf8_image_raw should use handles */
 	HANDLE_FUNCTION_ENTER ();
 	char* result = NULL;
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoString, s);
 	result = mono_string_to_utf8_image (image, s, error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
@@ -296,7 +296,7 @@ method_encode_clauses (MonoImage *image, MonoDynamicImage *assembly, MonoReflect
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoExceptionClause *clauses;
 	MonoExceptionClause *clause;
@@ -454,7 +454,7 @@ mono_reflection_methodbuilder_from_method_builder (ReflectionMethodBuilder *rmb,
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	mono_error_init (error);
+	error_init (error);
 	memset (rmb, 0, sizeof (ReflectionMethodBuilder));
 
 	rmb->ilgen = mb->ilgen;
@@ -501,7 +501,7 @@ mono_reflection_methodbuilder_from_ctor_builder (ReflectionMethodBuilder *rmb, M
 
 	const char *name = mb->attrs & METHOD_ATTRIBUTE_STATIC ? ".cctor": ".ctor";
 
-	mono_error_init (error);
+	error_init (error);
 
 	memset (rmb, 0, sizeof (ReflectionMethodBuilder));
 
@@ -848,7 +848,7 @@ mono_image_get_sighelper_token (MonoDynamicImage *assembly, MonoReflectionSigHel
 	MonoDynamicTable *table;
 	guint32 *values;
 
-	mono_error_init (error);
+	error_init (error);
 
 	table = &assembly->tables [MONO_TABLE_STANDALONESIG];
 	idx = table->next_idx ++;
@@ -898,7 +898,7 @@ mono_image_get_array_token (MonoDynamicImage *assembly, MonoReflectionArrayMetho
 	MonoMethodSignature *sig = NULL;
 	char *name = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoArrayHandle parameters = MONO_HANDLE_NEW_GET (MonoArray, m, parameters);
 	guint32 nparams = mono_array_handle_length (parameters);
@@ -1066,7 +1066,7 @@ mono_image_create_method_token (MonoDynamicImage *assembly, MonoObjectHandle obj
 {
 	guint32 token = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoClass *klass = mono_handle_class (obj);
 	if (strcmp (klass->name, "MonoMethod") == 0 || strcmp (klass->name, "MonoCMethod") == 0) {
@@ -1107,7 +1107,7 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 {
 	guint32 token = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	MonoClass *klass = mono_handle_class (obj);
 
@@ -1303,7 +1303,7 @@ register_module (MonoDomain *domain, MonoReflectionModuleBuilderHandle res, Mono
 static gboolean
 image_module_basic_init (MonoReflectionModuleBuilderHandle moduleb, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (moduleb);
 	MonoDynamicImage *image = MONO_HANDLE_GETVAL (moduleb, dynamic_image);
 	MonoReflectionAssemblyBuilderHandle ab = MONO_HANDLE_NEW (MonoReflectionAssemblyBuilder, NULL);
@@ -1351,7 +1351,7 @@ image_module_basic_init (MonoReflectionModuleBuilderHandle moduleb, MonoError *e
 static gboolean
 mono_image_module_basic_init (MonoReflectionModuleBuilderHandle moduleb, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return image_module_basic_init (moduleb, error);
 }
 
@@ -1379,7 +1379,7 @@ MonoType*
 mono_type_array_get_and_resolve (MonoArrayHandle array, int idx, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER();
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionTypeHandle t = MONO_HANDLE_NEW (MonoReflectionType, NULL);
 	MONO_HANDLE_ARRAY_GETREF (t, array, idx);
 	MonoType *result = mono_reflection_type_handle_mono_type (t, error);
@@ -1466,7 +1466,7 @@ mono_reflection_type_get_underlying_system_type (MonoReflectionTypeHandle t, Mon
 	static MonoMethod *method_get_underlying_system_type = NULL;
 	HANDLE_FUNCTION_ENTER ();
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!method_get_underlying_system_type)
 		method_get_underlying_system_type = mono_class_get_method_from_name (mono_defaults.systemtype_class, "get_UnderlyingSystemType", 0);
@@ -1487,7 +1487,7 @@ MonoType*
 mono_reflection_type_get_handle (MonoReflectionType* ref_raw, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoReflectionType, ref);
 	MonoType *result = mono_reflection_type_handle_mono_type (ref, error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
@@ -1539,7 +1539,7 @@ static MonoType*
 reflection_param_handle_mono_type (MonoReflectionGenericParamHandle ref_gparam, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoType *result = NULL;
 
 
@@ -1596,7 +1596,7 @@ static MonoType*
 mono_type_array_get_and_resolve_raw (MonoArray* array_raw, int idx, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER(); /* FIXME callers of mono_type_array_get_and_resolve_raw should use handles */
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoArray, array);
 	MonoType *result = mono_type_array_get_and_resolve (array, idx, error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
@@ -1606,7 +1606,7 @@ MonoType*
 mono_reflection_type_handle_mono_type (MonoReflectionTypeHandle ref, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 
 	MonoType* result = NULL;
 
@@ -1694,7 +1694,7 @@ parameters_to_signature (MonoImage *image, MonoArrayHandle parameters, MonoError
 	MonoMethodSignature *sig;
 	int count, i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	count = MONO_HANDLE_IS_NULL (parameters) ? 0 : mono_array_handle_length (parameters);
 
@@ -1718,7 +1718,7 @@ static MonoMethodSignature*
 ctor_builder_to_signature (MonoImage *image, MonoReflectionCtorBuilderHandle ctor, MonoError *error) {
 	MonoMethodSignature *sig;
 
-	mono_error_init (error);
+	error_init (error);
 
 	sig = parameters_to_signature (image, MONO_HANDLE_NEW_GET (MonoArray, ctor, parameters), error);
 	return_val_if_nok (error, NULL);
@@ -1741,7 +1741,7 @@ static MonoMethodSignature*
 method_builder_to_signature (MonoImage *image, MonoReflectionMethodBuilderHandle method, MonoError *error) {
 	MonoMethodSignature *sig;
 
-	mono_error_init (error);
+	error_init (error);
 
 	sig = parameters_to_signature (image, MONO_HANDLE_NEW_GET(MonoArray, method, parameters), error);
 	return_val_if_nok (error, NULL);
@@ -1766,7 +1766,7 @@ dynamic_method_to_signature (MonoReflectionDynamicMethodHandle method, MonoError
 	HANDLE_FUNCTION_ENTER ();
 	MonoMethodSignature *sig = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	sig = parameters_to_signature (NULL, MONO_HANDLE_NEW_GET (MonoArray, method, parameters), error);
 	if (!is_ok (error))
@@ -1791,7 +1791,7 @@ leave:
 static void
 get_prop_name_and_type (MonoObject *prop, char **name, MonoType **type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass = mono_object_class (prop);
 	if (strcmp (klass->name, "PropertyBuilder") == 0) {
 		MonoReflectionPropertyBuilder *pb = (MonoReflectionPropertyBuilder *)prop;
@@ -1811,7 +1811,7 @@ get_prop_name_and_type (MonoObject *prop, char **name, MonoType **type, MonoErro
 static void
 get_field_name_and_type (MonoObject *field, char **name, MonoType **type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass = mono_object_class (field);
 	if (strcmp (klass->name, "FieldBuilder") == 0) {
 		MonoReflectionFieldBuilder *fb = (MonoReflectionFieldBuilder *)field;
@@ -1923,7 +1923,7 @@ encode_cattr_value (MonoAssembly *assembly, char *buffer, char *p, char **retbuf
 {
 	MonoTypeEnum simple_type;
 	
-	mono_error_init (error);
+	error_init (error);
 	if ((p-buffer) + 10 >= *buflen) {
 		char *newbuf;
 		*buflen *= 2;
@@ -2177,7 +2177,7 @@ encode_named_val (MonoReflectionAssembly *assembly, char *buffer, char *p, char 
 {
 	int len;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* Preallocate a large enough buffer */
 	if (type->type == MONO_TYPE_VALUETYPE && type->data.klass->enumtype) {
@@ -2259,7 +2259,7 @@ mono_reflection_get_custom_attrs_blob_checked (MonoReflectionAssembly *assembly,
 	char *buffer, *p;
 	guint32 buflen, i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (strcmp (ctor->vtable->klass->name, "MonoCMethod")) {
 		/* sig is freed later so allocate it in the heap */
@@ -2351,7 +2351,7 @@ static gboolean
 reflection_setup_internal_class (MonoReflectionTypeBuilderHandle ref_tb, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 
 	mono_loader_lock ();
 
@@ -2493,7 +2493,7 @@ reflection_create_generic_class (MonoReflectionTypeBuilderHandle ref_tb, MonoErr
 {
 	HANDLE_FUNCTION_ENTER ();
 
-	mono_error_init (error);
+	error_init (error);
 
 	reflection_setup_internal_class (ref_tb, error);
 	if (!is_ok (error))
@@ -2548,7 +2548,7 @@ mono_marshal_spec_from_builder (MonoImage *image, MonoAssembly *assembly,
 {
 	MonoMarshalSpec *res;
 
-	mono_error_init (error);
+	error_init (error);
 
 	res = image_g_new0 (image, MonoMarshalSpec, 1);
 	res->native = (MonoMarshalNative)minfo->type;
@@ -2604,7 +2604,7 @@ MonoReflectionMarshalAsAttributeHandle
 mono_reflection_marshal_as_attribute_from_marshal_spec (MonoDomain *domain, MonoClass *klass,
 							MonoMarshalSpec *spec, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	
 	MonoReflectionMarshalAsAttributeHandle minfo = MONO_HANDLE_NEW (MonoReflectionMarshalAsAttribute, mono_object_new_checked (domain, mono_class_get_marshal_as_attribute_class (), error));
 	if (!is_ok (error))
@@ -2676,7 +2676,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 	gboolean dynamic;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 	/*
 	 * Methods created using a MethodBuilder should have their memory allocated
 	 * inside the image mempool, while dynamic methods should have their memory
@@ -2976,7 +2976,7 @@ methodbuilder_to_mono_method (MonoClass *klass, MonoReflectionMethodBuilderHandl
 	ReflectionMethodBuilder rmb;
 	MonoMethodSignature *sig;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_loader_lock ();
 
@@ -3004,7 +3004,7 @@ static MonoMethod*
 methodbuilder_to_mono_method_raw (MonoClass *klass, MonoReflectionMethodBuilder* mb_raw, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER (); /* FIXME change callers of methodbuilder_to_mono_method_raw to use handles */
-	mono_error_init (error);
+	error_init (error);
 	MONO_HANDLE_DCL (MonoReflectionMethodBuilder, mb);
 	MonoMethod *result = methodbuilder_to_mono_method (klass, mb, error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
@@ -3032,7 +3032,7 @@ fix_partial_generic_class (MonoClass *klass, MonoError *error)
 	MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (klass->wastypebuilder)
 		return TRUE;
@@ -3121,7 +3121,7 @@ ensure_generic_class_runtime_vtable (MonoClass *klass, MonoError *error)
 {
 	MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!ensure_runtime_vtable (gklass, error))
 		return FALSE;
@@ -3143,7 +3143,7 @@ ensure_runtime_vtable (MonoClass *klass, MonoError *error)
 	MonoReflectionTypeBuilder *tb = (MonoReflectionTypeBuilder *)mono_class_get_ref_info_raw (klass); /* FIXME use handles */
 	int i, num, j;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!image_is_dynamic (klass->image) || (!tb && !mono_class_is_ginst (klass)) || klass->wastypebuilder)
 		return TRUE;
@@ -3222,7 +3222,7 @@ ensure_runtime_vtable (MonoClass *klass, MonoError *error)
 static MonoMethod*
 mono_reflection_method_get_handle (MonoObject *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	MonoClass *klass = mono_object_class (method);
 	if (is_sr_mono_method (klass)) {
 		MonoReflectionMethod *sr_method = (MonoReflectionMethod*)method;
@@ -3252,7 +3252,7 @@ mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides
 	int i, j, onum;
 	MonoReflectionMethod *m;
 
-	mono_error_init (error);
+	error_init (error);
 	*overrides = NULL;
 	*num_overrides = 0;
 
@@ -3324,7 +3324,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 	int fcount = tb->num_fields;
 	mono_class_set_field_count (klass, fcount);
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (tb->class_size) {
 		packing_size = tb->packing_size;
@@ -3399,7 +3399,7 @@ typebuilder_setup_properties (MonoClass *klass, MonoError *error)
 	MonoClassPropertyInfo *info;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	info = mono_class_get_property_info (klass);
 	if (!info) {
@@ -3453,7 +3453,7 @@ typebuilder_setup_events (MonoClass *klass, MonoError *error)
 	MonoClassEventInfo *info;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	info = mono_class_alloc0 (klass, sizeof (MonoClassEventInfo));
 	mono_class_set_event_info (klass, info);
@@ -3529,7 +3529,7 @@ remove_instantiations_of_and_ensure_contents (gpointer key,
 MonoReflectionTypeHandle
 ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_tb, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	reflection_create_generic_class (ref_tb, error);
 	mono_error_assert_ok (error);
@@ -3704,7 +3704,7 @@ reflection_create_dynamic_method (MonoReflectionDynamicMethodHandle ref_mb, Mono
 	GSList *l;
 	int i;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (mono_runtime_is_shutting_down ()) {
 		mono_error_set_generic_error (error, "System", "InvalidOperationException", "");
@@ -3843,7 +3843,7 @@ mono_reflection_lookup_signature (MonoImage *image, MonoMethod *method, guint32 
 	MonoMethodSignature *sig;
 	g_assert (image_is_dynamic (image));
 
-	mono_error_init (error);
+	error_init (error);
 
 	sig = (MonoMethodSignature *)g_hash_table_lookup (((MonoDynamicImage*)image)->vararg_aux_hash, GUINT_TO_POINTER (token));
 	if (sig)
@@ -3863,7 +3863,7 @@ mono_reflection_lookup_signature (MonoImage *image, MonoMethod *method, guint32 
 static void
 ensure_complete_type (MonoClass *klass, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	if (image_is_dynamic (klass->image) && !klass->wastypebuilder && mono_class_has_ref_info (klass)) {
 		MonoReflectionTypeBuilder *tb = (MonoReflectionTypeBuilder *)mono_class_get_ref_info_raw (klass); /* FIXME use handles */
@@ -3892,7 +3892,7 @@ mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **h
 	MonoClass *oklass = obj->vtable->klass;
 	gpointer result = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (strcmp (oklass->name, "String") == 0) {
 		result = mono_string_intern_checked ((MonoString*)obj, error);
@@ -4120,7 +4120,7 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 void
 mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides, int *num_overrides, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	*overrides = NULL;
 	*num_overrides = 0;
 }
@@ -4135,13 +4135,13 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle tb, 
 void 
 ves_icall_DynamicMethod_create_dynamic_method (MonoReflectionDynamicMethodHandle mb, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 }
 
 MonoType*
 mono_reflection_type_get_handle (MonoReflectionType* ref, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (!ref)
 		return NULL;
 	return ref->type;
@@ -4150,7 +4150,7 @@ mono_reflection_type_get_handle (MonoReflectionType* ref, MonoError *error)
 MonoType*
 mono_reflection_type_handle_mono_type (MonoReflectionTypeHandle ref, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (MONO_HANDLE_IS_NULL (ref))
 		return NULL;
 	return MONO_HANDLE_GETVAL (ref, type);
@@ -4169,7 +4169,7 @@ mono_sre_generic_param_table_entry_free (GenericParamTableEntry *entry)
 gint32
 ves_icall_ModuleBuilder_getToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, gboolean create_open_instance, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (MONO_HANDLE_IS_NULL (obj)) {
 		mono_error_set_argument_null (error, "obj", "");
 		return 0;
@@ -4183,7 +4183,7 @@ ves_icall_ModuleBuilder_getMethodToken (MonoReflectionModuleBuilderHandle mb,
 					MonoArrayHandle opt_param_types,
 					MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	if (MONO_HANDLE_IS_NULL (method)) {
 		mono_error_set_argument_null (error, "method", "");
 		return 0;
@@ -4211,7 +4211,7 @@ ves_icall_ModuleBuilder_build_metadata (MonoReflectionModuleBuilder *mb)
 void
 ves_icall_ModuleBuilder_RegisterToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, guint32 token, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	mono_dynamic_image_register_token (MONO_HANDLE_GETVAL (mb, dynamic_image), token, obj);
 }
 
@@ -4254,7 +4254,7 @@ ves_icall_EnumBuilder_setup_enum_type (MonoReflectionType *enumtype,
 void
 ves_icall_ModuleBuilder_basic_init (MonoReflectionModuleBuilderHandle moduleb, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	mono_image_module_basic_init (moduleb, error);
 }
 

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -154,7 +154,7 @@ mono_threadpool_enqueue_work_item (MonoDomain *domain, MonoObject *work_item, Mo
 	MonoBoolean f;
 	gpointer args [2];
 
-	mono_error_init (error);
+	error_init (error);
 	g_assert (work_item);
 
 	if (!threadpool_class)
@@ -270,7 +270,7 @@ static MonoObject*
 try_invoke_perform_wait_callback (MonoObject** exc, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
-	mono_error_init (error);
+	error_init (error);
 	MonoObject *res = mono_runtime_try_invoke (mono_defaults.threadpool_perform_wait_callback_method, NULL, NULL, exc, error);
 	HANDLE_FUNCTION_RETURN_VAL (res);
 }
@@ -420,7 +420,7 @@ mono_threadpool_begin_invoke (MonoDomain *domain, MonoObject *target, MonoMethod
 	if (!async_call_klass)
 		async_call_klass = mono_class_load_from_name (mono_defaults.corlib, "System", "MonoAsyncCall");
 
-	mono_error_init (error);
+	error_init (error);
 
 	message = mono_method_call_message_new (method, params, mono_get_delegate_invoke (method->klass), (params != NULL) ? (&async_callback) : NULL, (params != NULL) ? (&state) : NULL, error);
 	return_val_if_nok (error, NULL);
@@ -451,7 +451,7 @@ mono_threadpool_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, MonoObj
 {
 	MonoAsyncCall *ac;
 
-	mono_error_init (error);
+	error_init (error);
 	g_assert (exc);
 	g_assert (out_args);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -915,7 +915,7 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 	 */
 	mono_threads_join_threads ();
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_threads_lock ();
 	if (shutting_down) {
@@ -1018,7 +1018,7 @@ mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, gb
 	MonoInternalThread *internal;
 	gboolean res;
 
-	mono_error_init (error);
+	error_init (error);
 
 	internal = create_internal_thread_object ();
 
@@ -1550,7 +1550,7 @@ ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThread *this_obj
 	MonoError error;
 	MonoString* str;
 
-	mono_error_init (&error);
+	error_init (&error);
 
 	LOCK_THREAD (this_obj);
 	
@@ -1572,7 +1572,7 @@ mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, g
 {
 	LOCK_THREAD (this_obj);
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (reset) {
 		this_obj->flags &= ~MONO_THREAD_FLAG_NAME_SET;
@@ -1662,7 +1662,7 @@ byte_array_to_domain (MonoArray *arr, MonoDomain *domain, MonoError *error)
 {
 	MonoArray *copy;
 
-	mono_error_init (error);
+	error_init (error);
 	if (!arr)
 		return NULL;
 
@@ -1743,7 +1743,7 @@ mono_join_uninterrupted (MonoThreadHandle* thread_to_join, gint32 ms, MonoError 
 	gint32 diff_ms;
 	gint32 wait = ms;
 
-	mono_error_init (error);
+	error_init (error);
 
 	start = (ms == -1) ? 0 : mono_msec_ticks ();
 	for (;;) {
@@ -1852,7 +1852,7 @@ mono_wait_uninterrupted (MonoInternalThread *thread, guint32 numhandles, gpointe
 	gint32 diff_ms;
 	gint32 wait = ms;
 
-	mono_error_init (error);
+	error_init (error);
 
 	start = (ms == -1) ? 0 : mono_100ns_ticks ();
 	do {
@@ -3661,7 +3661,7 @@ mono_threads_get_thread_dump (MonoArray **out_threads, MonoArray **out_stack_fra
 	MonoDebugSourceLocation *location;
 	int tindex, nthreads;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	*out_threads = NULL;
 	*out_stack_frames = NULL;
@@ -4903,7 +4903,7 @@ self_abort_internal (MonoError *error)
 {
 	MonoException *exc;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* FIXME this is insanely broken, it doesn't cause interruption to happen synchronously
 	 * since passing FALSE to mono_thread_request_interruption makes sure it returns NULL */

--- a/mono/metadata/w32file-win32-uwp.c
+++ b/mono/metadata/w32file-win32-uwp.c
@@ -117,7 +117,7 @@ HANDLE
 mono_w32file_get_console_output (void)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_OUTPUT_HANDLE)");
 
@@ -133,7 +133,7 @@ HANDLE
 mono_w32file_get_console_input (void)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_INPUT_HANDLE)");
 
@@ -149,7 +149,7 @@ HANDLE
 mono_w32file_get_console_error (void)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_ERROR_HANDLE)");
 

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -596,7 +596,7 @@ ves_icall_System_IO_MonoIO_GetCurrentDirectory (gint32 *io_error)
 	len = MAX_PATH + 1; /*FIXME this is too smal under most unix systems.*/
 	buf = g_new (gunichar2, len);
 	
-	mono_error_init (&error);
+	error_init (&error);
 	*io_error=ERROR_SUCCESS;
 	result = NULL;
 

--- a/mono/metadata/w32process-win32-uwp.c
+++ b/mono/metadata/w32process-win32-uwp.c
@@ -29,7 +29,7 @@ HANDLE
 ves_icall_System_Diagnostics_Process_GetProcess_internal (guint32 pid)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("OpenProcess");
 
@@ -46,7 +46,7 @@ mono_w32process_get_fileversion (MonoObject *filever, gunichar2 *filename, MonoE
 {
 	g_unsupported_api ("GetFileVersionInfoSize, GetFileVersionInfo, VerQueryValue, VerLanguageName");
 
-	mono_error_init (error);
+	error_init (error);
 	mono_error_set_not_supported (error, G_UNSUPPORTED_API, "GetFileVersionInfoSize, GetFileVersionInfo, VerQueryValue, VerLanguageName");
 
 	SetLastError (ERROR_NOT_SUPPORTED);
@@ -57,7 +57,7 @@ process_add_module (HANDLE process, HMODULE mod, gunichar2 *filename, gunichar2 
 {
 	g_unsupported_api ("GetModuleInformation");
 
-	mono_error_init (error);
+	error_init (error);
 	mono_error_set_not_supported (error, G_UNSUPPORTED_API, "GetModuleInformation");
 
 	SetLastError (ERROR_NOT_SUPPORTED);
@@ -69,7 +69,7 @@ MonoArray *
 ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, HANDLE process)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("EnumProcessModules, GetModuleBaseName, GetModuleFileNameEx");
 
@@ -85,7 +85,7 @@ MonoBoolean
 ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStartInfo *proc_start_info, MonoW32ProcessInfo *process_info)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("ShellExecuteEx");
 
@@ -144,7 +144,7 @@ mono_process_create_process (MonoW32ProcessInfo *mono_process_info, MonoString *
 	memset (&process_info, 0, sizeof (PROCESS_INFORMATION));
 	g_unsupported_api (api_name);
 
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 	mono_error_set_not_supported (&mono_error, G_UNSUPPORTED_API, api_name);
 	mono_error_set_pending_exception (&mono_error);
 
@@ -157,7 +157,7 @@ MonoBoolean
 mono_icall_get_process_working_set_size (gpointer handle, gsize *min, gsize *max)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetProcessWorkingSetSize");
 
@@ -173,7 +173,7 @@ MonoBoolean
 mono_icall_set_process_working_set_size (gpointer handle, gsize min, gsize max)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("SetProcessWorkingSetSize");
 
@@ -189,7 +189,7 @@ gint32
 mono_icall_get_priority_class (gpointer handle)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("GetPriorityClass");
 
@@ -205,7 +205,7 @@ MonoBoolean
 mono_icall_set_priority_class (gpointer handle, gint32 priorityClass)
 {
 	MonoError mono_error;
-	mono_error_init (&mono_error);
+	error_init (&mono_error);
 
 	g_unsupported_api ("SetPriorityClass");
 

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -143,7 +143,7 @@ process_set_field_string (MonoObject *obj, const gchar *fieldname, const gunicha
 	MonoClassField *field;
 	MonoString *string;
 
-	mono_error_init (error);
+	error_init (error);
 
 	LOGDEBUG (g_message ("%s: Setting field %s to [%s]", __func__, fieldname, g_utf16_to_utf8 (val, len, NULL, NULL, NULL)));
 
@@ -281,7 +281,7 @@ process_module_string_read (MonoObject *filever, gpointer data, const gchar *fie
 	gunichar2 *lang_key, *buffer;
 	UINT chars;
 
-	mono_error_init (error);
+	error_init (error);
 
 	lang_key_utf8 = g_strdup_printf (key, lang_lo, lang_hi, 0x04, 0xb0);
 
@@ -325,7 +325,7 @@ mono_w32process_get_fileversion (MonoObject *filever, gunichar2 *filename, MonoE
 	gunichar2 lang_buf[128];
 	guint32 lang, lang_count;
 
-	mono_error_init (error);
+	error_init (error);
 
 	datalen = mono_w32process_get_fileversion_info_size (filename, &verinfohandle);
 	if (datalen) {
@@ -464,7 +464,7 @@ process_add_module (HANDLE process, HMODULE mod, gunichar2 *filename, gunichar2 
 	MODULEINFO modinfo;
 	BOOL ok;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* Build a System.Diagnostics.ProcessModule with the data. */
 	item = mono_object_new_checked (domain, proc_class, error);
@@ -513,7 +513,7 @@ process_get_module (MonoAssembly *assembly, MonoClass *proc_class, MonoError *er
 	gchar *filename;
 	const gchar *modulename;
 
-	mono_error_init (error);
+	error_init (error);
 
 	domain = mono_domain_get ();
 

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -825,7 +825,7 @@ create_object_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 *werror
 	MonoArray *data;
 	MonoAddressFamily family;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* Build a System.Net.SocketAddress object instance */
 	if (!domain->sockaddr_class)
@@ -1058,7 +1058,7 @@ create_sockaddr_from_object (MonoObject *saddr_obj, socklen_t *sa_size, gint32 *
 	gint32 family;
 	int len;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!domain->sockaddr_class)
 		domain->sockaddr_class = mono_class_load_from_name (get_socket_assembly (), "System.Net", "SocketAddress");
@@ -2406,7 +2406,7 @@ addrinfo_to_IPHostEntry (MonoAddressInfo *info, MonoString **h_name, MonoArray *
 	int addr_index;
 	MonoDomain *domain = mono_domain_get ();
 
-	mono_error_init (error);
+	error_init (error);
 	addr_index = 0;
 	*h_aliases = mono_array_new_checked (domain, mono_get_string_class (), 0, error);
 	return_val_if_nok (error, FALSE);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -257,7 +257,7 @@ load_image (MonoAotModule *amodule, int index, MonoError *error)
 
 	g_assert (index < amodule->image_table_len);
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (amodule->image_table [index])
 		return amodule->image_table [index];
@@ -374,7 +374,7 @@ decode_generic_inst (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoEr
 	MonoGenericInst *inst;
 	guint8 *p = buf;
 
-	mono_error_init (error);
+	error_init (error);
 	type_argc = decode_value (p, &p);
 	type_argv = g_new0 (MonoType*, type_argc);
 
@@ -401,7 +401,7 @@ decode_generic_context (MonoAotModule *module, MonoGenericContext *ctx, guint8 *
 	guint8 *p = buf;
 	guint8 *p2;
 	int argc;
-	mono_error_init (error);
+	error_init (error);
 
 	p2 = p;
 	argc = decode_value (p, &p);
@@ -433,7 +433,7 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError
 	guint8 *p = buf;
 	int reftype;
 
-	mono_error_init (error);
+	error_init (error);
 	reftype = decode_value (p, &p);
 	if (reftype == 0) {
 		*endbuf = p;
@@ -621,7 +621,7 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 	MonoType *t;
 
 	t = (MonoType *)g_malloc0 (sizeof (MonoType));
-	mono_error_init (error);
+	error_init (error);
 
 	while (TRUE) {
 		if (*p == MONO_TYPE_PINNED) {
@@ -852,7 +852,7 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 	guint8 *p = buf;
 
 	memset (ref, 0, sizeof (MethodRef));
-	mono_error_init (error);
+	error_init (error);
 
 	value = decode_value (p, &p);
 	image_index = value >> 24;
@@ -1340,7 +1340,7 @@ decode_resolve_method_ref_with_target (MonoAotModule *module, MonoMethod *target
 {
 	MethodRef ref;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!decode_method_ref_with_target (module, &ref, target, buf, endbuf, error))
 		return NULL;
@@ -2432,7 +2432,7 @@ mono_aot_get_method_from_vt_slot (MonoDomain *domain, MonoVTable *vtable, int sl
 	gpointer addr;
 	MonoError inner_error;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (MONO_CLASS_IS_INTERFACE (klass) || klass->rank || !amodule)
 		return NULL;
@@ -3851,7 +3851,7 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 	guint8 *code = NULL, *info;
 	gboolean res;
 
-	mono_error_init (error);
+	error_init (error);
 
 	init_amodule_got (amodule);
 
@@ -4144,7 +4144,7 @@ init_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *method, M
 	MonoJitInfo *jinfo = NULL;
 	guint8 *code, *info;
 
-	mono_error_init (error);
+	error_init (error);
 
 	code = (guint8 *)amodule->methods [method_index];
 	info = &amodule->blob [mono_aot_get_offset (amodule->method_info_offsets, method_index)];
@@ -4355,7 +4355,7 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 	gboolean cache_result = FALSE;
 	MonoError inner_error;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (domain != mono_get_root_domain ())
 		/* Non shared AOT code can't be used in other appdomains */
@@ -4621,7 +4621,7 @@ mono_aot_get_method_from_token (MonoDomain *domain, MonoImage *image, guint32 to
 	int method_index;
 	gpointer res;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!aot_module)
 		return NULL;
@@ -4740,7 +4740,7 @@ mono_aot_plt_resolve (gpointer aot_module, guint32 plt_info_offset, guint8 *code
 	MonoMemPool *mp;
 	gboolean using_gsharedvt = FALSE;
 
-	mono_error_init (error);
+	error_init (error);
 
 	//printf ("DYN: %p %d\n", aot_module, plt_info_offset);
 
@@ -5839,7 +5839,7 @@ gpointer
 mono_aot_get_method_checked (MonoDomain *domain,
 							 MonoMethod *method, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return NULL;
 }
 
@@ -5870,7 +5870,7 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 gpointer
 mono_aot_get_method_from_token (MonoDomain *domain, MonoImage *image, guint32 token, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 	return NULL;
 }
 
@@ -5894,7 +5894,7 @@ mono_aot_patch_plt_entry (guint8 *code, guint8 *plt_entry, gpointer *got, mgreg_
 gpointer
 mono_aot_get_method_from_vt_slot (MonoDomain *domain, MonoVTable *vtable, int slot, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	return NULL;
 }

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4150,7 +4150,7 @@ insert_breakpoint (MonoSeqPointInfo *seq_points, MonoDomain *domain, MonoJitInfo
 	gboolean it_has_sp = FALSE;
 
 	if (error)
-		mono_error_init (error);
+		error_init (error);
 
 	mono_seq_point_iterator_init (&it, seq_points);
 	while (mono_seq_point_iterator_next (&it)) {
@@ -4350,7 +4350,7 @@ set_bp_in_method (MonoDomain *domain, MonoMethod *method, MonoSeqPointInfo *seq_
 	MonoJitInfo *ji;
 
 	if (error)
-		mono_error_init (error);
+		error_init (error);
 
 	code = mono_jit_find_compiled_method_with_jit_info (domain, method, &ji);
 	if (!code) {
@@ -4396,7 +4396,7 @@ set_breakpoint (MonoMethod *method, long il_offset, EventRequest *req, MonoError
 	int i;
 
 	if (error)
-		mono_error_init (error);
+		error_init (error);
 
 	// FIXME:
 	// - suspend/resume the vm to prevent code patching problems
@@ -8008,7 +8008,7 @@ get_assembly_object_command (MonoDomain *domain, MonoAssembly *ass, Buffer *buf,
 {
 	HANDLE_FUNCTION_ENTER();
 	ErrorCode err = ERR_NONE;
-	mono_error_init (error);
+	error_init (error);
 	MonoReflectionAssemblyHandle o = mono_assembly_get_object_handle (domain, ass, error);
 	if (MONO_HANDLE_IS_NULL (o)) {
 		err = ERR_INVALID_OBJECT;
@@ -8659,7 +8659,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 		MonoError error;
 		GPtrArray *array;
 
-		mono_error_init (&error);
+		error_init (&error);
 		array = mono_class_get_methods_by_name (klass, name, flags & ~BINDING_FLAGS_IGNORE_CASE, (flags & BINDING_FLAGS_IGNORE_CASE) != 0, TRUE, &error);
 		if (!is_ok (&error)) {
 			mono_error_cleanup (&error);

--- a/mono/mini/interpreter/interp.c
+++ b/mono/mini/interpreter/interp.c
@@ -259,7 +259,7 @@ RuntimeMethod*
 mono_interp_get_runtime_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 {
 	RuntimeMethod *rtm;
-	mono_error_init (error);
+	error_init (error);
 
 	mono_os_mutex_lock (&runtime_method_lookup_section);
 	if ((rtm = mono_internal_hash_table_lookup (&domain->jit_code_hash, method))) {
@@ -1230,7 +1230,7 @@ mono_interp_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoOb
 	MonoInvocation *old_frame = NULL;
 	jmp_buf env;
 
-	mono_error_init (error);
+	error_init (error);
 
 	frame.ex = NULL;
 

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1332,7 +1332,7 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
 	MonoMethod *m;
 	int vt_slot, iface_offset;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (mono_class_is_interface (klass)) {
 		MonoObject *this_obj;
@@ -1504,7 +1504,7 @@ resolve_iface_call (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, 
 	gpointer addr, compiled_method, aot_addr;
 	gboolean need_rgctx_tramp = FALSE, need_unbox_tramp = FALSE;
 
-	mono_error_init (error);
+	error_init (error);
 	if (!this_obj)
 		/* The caller will handle it */
 		return NULL;
@@ -1588,7 +1588,7 @@ resolve_vcall (MonoVTable *vt, int slot, MonoMethod *imt_method, gpointer *out_a
 	gpointer addr, compiled_method;
 	gboolean need_unbox_tramp = FALSE;
 
-	mono_error_init (error);
+	error_init (error);
 	/* Same as in common_call_trampoline () */
 
 	/* Avoid loading metadata or creating a generic vtable if possible */
@@ -1915,7 +1915,7 @@ mono_throw_method_access (MonoMethod *callee, MonoMethod *caller)
 	char *caller_name = mono_method_full_name (caller, 1);
 	MonoError error;
 
-	mono_error_init (&error);
+	error_init (&error);
 	mono_error_set_generic_error (&error, "System", "MethodAccessException", "Method `%s' is inaccessible from method `%s'\n", callee_name, caller_name);
 	mono_error_set_pending_exception (&error);
 	g_free (callee_name);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6708,7 +6708,7 @@ mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, Mono
 {
 	MonoMethod *method;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (m->wrapper_type != MONO_WRAPPER_NONE) {
 		method = (MonoMethod *)mono_method_get_wrapper_data (m, token);
@@ -6765,7 +6765,7 @@ mini_get_signature (MonoMethod *method, guint32 token, MonoGenericContext *conte
 {
 	MonoMethodSignature *fsig;
 
-	mono_error_init (error);
+	error_init (error);
 	if (method->wrapper_type != MONO_WRAPPER_NONE) {
 		fsig = (MonoMethodSignature *)mono_method_get_wrapper_data (method, token);
 	} else {
@@ -11585,7 +11585,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 							tclass, MONO_RGCTX_INFO_REFLECTION_TYPE);
 					} else if (cfg->compile_aot) {
 						if (method->wrapper_type) {
-							mono_error_init (&error); //got to do it since there are multiple conditionals below
+							error_init (&error); //got to do it since there are multiple conditionals below
 							if (mono_class_get_checked (tclass->image, tclass->type_token, &error) == tclass && !generic_context) {
 								/* Special case for static synchronized wrappers */
 								EMIT_NEW_TYPE_FROM_HANDLE_CONST (cfg, ins, tclass->image, tclass->type_token, generic_context);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1375,7 +1375,7 @@ wrap_non_exception_throws (MonoMethod *m)
 static MonoArray*
 build_native_trace (MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 /* This puppy only makes sense on mobile, IOW, ARM. */
 #if defined (HAVE_BACKTRACE_SYMBOLS) && defined (TARGET_ARM)
 	MonoArray *res;
@@ -1638,7 +1638,7 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, MonoObject *obj, gi
 				}
 
 				MonoError isinst_error;
-				mono_error_init (&isinst_error);
+				error_init (&isinst_error);
 				if (ei->flags == MONO_EXCEPTION_CLAUSE_NONE && mono_object_isinst_checked (ex_obj, catch_class, &error)) {
 					setup_stack_trace (mono_ex, dynamic_methods, &trace_ips);
 					g_slist_free (dynamic_methods);
@@ -1946,7 +1946,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 					filter_idx ++;
 				}
 
-				mono_error_init (&error);
+				error_init (&error);
 				if ((ei->flags == MONO_EXCEPTION_CLAUSE_NONE && 
 				     mono_object_isinst_checked (ex_obj, catch_class, &error)) || filtered) {
 					/*

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -870,7 +870,7 @@ class_get_rgctx_template_oti (MonoClass *klass, int type_argc, guint32 slot, gbo
 static gpointer
 class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_type, MonoError *error)
 {
-	mono_error_init (error);
+	error_init (error);
 
 	switch (info_type) {
 	case MONO_RGCTX_INFO_STATIC_DATA: {
@@ -1538,7 +1538,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 	gpointer data;
 	gboolean temporary;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (!oti->data)
 		return NULL;
@@ -2320,7 +2320,7 @@ fill_runtime_generic_context (MonoVTable *class_vtable, MonoRuntimeGenericContex
 	int rgctx_index;
 	gboolean do_free;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (rgctx);
 
@@ -2408,7 +2408,7 @@ mono_class_fill_runtime_generic_context (MonoVTable *class_vtable, guint32 slot,
 	MonoRuntimeGenericContext *rgctx;
 	gpointer info;
 
-	mono_error_init (error);
+	error_init (error);
 
 	mono_domain_lock (domain);
 

--- a/mono/mini/mini-ia64.c
+++ b/mono/mini/mini-ia64.c
@@ -3782,7 +3782,7 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain, 
 {
 	MonoJumpInfo *patch_info;
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (patch_info = ji; patch_info; patch_info = patch_info->next) {
 		unsigned char *ip = patch_info->ip.i + code;

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -4539,7 +4539,7 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain, 
 {
 	MonoJumpInfo *patch_info;
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (patch_info = ji; patch_info; patch_info = patch_info->next) {
 		unsigned char *ip = patch_info->ip.i + code;

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4689,7 +4689,7 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain, 
 	MonoJumpInfo *patch_info;
 	gboolean compile_aot = !run_cctors;
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (patch_info = ji; patch_info; patch_info = patch_info->next) {
 		unsigned char *ip = patch_info->ip.i + code;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1289,7 +1289,7 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 	unsigned char *ip = patch_info->ip.i + code;
 	gconstpointer target = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	switch (patch_info->type) {
 	case MONO_PATCH_INFO_BB:
@@ -1770,7 +1770,7 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, MonoError *er
 	MonoJitICallInfo *callinfo = NULL;
 	WrapperInfo *winfo = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 #ifdef ENABLE_INTERPRETER
 	if (mono_use_interpreter)
@@ -2278,7 +2278,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 	gpointer *param_refs;
 	int i, pindex;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (info->gsharedvt_invoke);
 
@@ -2367,7 +2367,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		return mono_interp_runtime_invoke (method, obj, params, exc, error);
 #endif
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (obj == NULL && !(method->flags & METHOD_ATTRIBUTE_STATIC) && !method->string_ctor && (method->wrapper_type == 0)) {
 		g_warning ("Ignoring invocation of an instance method on a NULL instance.\n");
@@ -2908,7 +2908,7 @@ mono_jit_create_remoting_trampoline (MonoDomain *domain, MonoMethod *method, Mon
 	MonoMethod *nm;
 	guint8 *addr = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if ((method->flags & METHOD_ATTRIBUTE_VIRTUAL) && mono_method_signature (method)->generic_param_count) {
 		return mono_create_specific_trampoline (method, MONO_TRAMPOLINE_GENERIC_VIRTUAL_REMOTING,

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -5429,7 +5429,7 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain,
 {
 	MonoJumpInfo *patch_info;
 
-	mono_error_init (error);
+	error_init (error);
 
 	for (patch_info = ji; patch_info; patch_info = patch_info->next) {
 		unsigned char *ip = patch_info->ip.i + code;

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -3682,7 +3682,7 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain, 
 {
 	MonoJumpInfo *patch_info;
 
-	mono_error_init (error);
+	error_init (error);
 
 	/* FIXME: Move part of this to arch independent code */
 	for (patch_info = ji; patch_info; patch_info = patch_info->next) {

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -167,7 +167,7 @@ mini_resolve_imt_method (MonoVTable *vt, gpointer *vtable_slot, MonoMethod *imt_
 
 	g_assert (imt_slot < MONO_IMT_SIZE);
 
-	mono_error_init (error);
+	error_init (error);
 	/* This has to be variance aware since imt_method can be from an interface that vt->klass doesn't directly implement */
 	interface_offset = mono_class_interface_offset_with_variance (vt->klass, imt_method->klass, &variance_used);
 	if (interface_offset < 0)
@@ -523,7 +523,7 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
 	gpointer *orig_vtable_slot, *vtable_slot_to_patch = NULL;
 	MonoJitInfo *ji = NULL;
 
-	mono_error_init (error);
+	error_init (error);
 
 	virtual_ = vt && (gpointer)vtable_slot > (gpointer)vt;
 	imt_call = vt && (gpointer)vtable_slot < (gpointer)vt;
@@ -1133,7 +1133,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 		if (!is_remote) {
 			sig = tramp_info->sig;
 			if (!(sig && method == tramp_info->method)) {
-				mono_error_init (&err);
+				error_init (&err);
 				sig = mono_method_signature_checked (method, &err);
 				if (!sig) {
 					mono_error_set_pending_exception (&err);
@@ -1167,7 +1167,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	if (method) {
 		sig = tramp_info->sig;
 		if (!(sig && method == tramp_info->method)) {
-			mono_error_init (&err);
+			error_init (&err);
 			sig = mono_method_signature_checked (method, &err);
 			if (!sig) {
 				mono_error_set_pending_exception (&err);
@@ -1457,7 +1457,7 @@ mono_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean ad
 	gpointer code;
 	guint32 code_size = 0;
 
-	mono_error_init (error);
+	error_init (error);
 
 	code = mono_jit_find_compiled_method_with_jit_info (domain, method, &ji);
 	/*
@@ -1515,7 +1515,7 @@ mono_create_jit_trampoline (MonoDomain *domain, MonoMethod *method, MonoError *e
 {
 	gpointer tramp;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (mono_aot_only) {
 		if (mono_llvm_only && method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
@@ -1609,7 +1609,7 @@ mono_create_delegate_trampoline_info (MonoDomain *domain, MonoClass *klass, Mono
 	tramp_info->impl_nothis = mono_arch_get_delegate_invoke_impl (mono_method_signature (invoke), FALSE);
 	tramp_info->method = method;
 	if (method) {
-		mono_error_init (&error);
+		error_init (&error);
 		tramp_info->sig = mono_method_signature_checked (method, &error);
 		tramp_info->need_rgctx_tramp = mono_method_needs_static_rgctx_invoke (method, FALSE);
 	}

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3236,7 +3236,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 
 	if (cfg->gen_seq_points)
 		cfg->seq_points = g_ptr_array_new ();
-	mono_error_init (&cfg->error);
+	error_init (&cfg->error);
 
 	if (cfg->compile_aot && !try_generic_shared && (method->is_generic || mono_class_is_gtd (method->klass) || method_is_gshared)) {
 		cfg->exception_type = MONO_EXCEPTION_GENERIC_SHARING_FAILED;
@@ -3278,7 +3278,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	}
 	cfg->method_to_register = method_to_register;
 
-	mono_error_init (&err);
+	error_init (&err);
 	sig = mono_method_signature_checked (cfg->method, &err);	
 	if (!sig) {
 		cfg->exception_type = MONO_EXCEPTION_TYPE_LOAD;
@@ -4066,7 +4066,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 	GTimer *jit_timer;
 	MonoMethod *prof_method, *shared;
 
-	mono_error_init (error);
+	error_init (error);
 
 	if ((method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) ||
 	    (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -584,7 +584,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 	MonoString *assembly_name = NULL, *type_name = NULL, *method_name = NULL, *field_name = NULL, *msg = NULL;
 	MonoDomain *domain = mono_domain_get ();
 
-	mono_error_init (error_out);
+	error_init (error_out);
 
 	switch (error->error_code) {
 	case MONO_ERROR_NONE:
@@ -780,7 +780,7 @@ void
 mono_error_move (MonoError *dest, MonoError *src)
 {
 	memcpy (dest, src, sizeof (MonoErrorInternal));
-	mono_error_init (src);
+	error_init (src);
 }
 
 /**

--- a/mono/utils/mono-rand-windows.c
+++ b/mono/utils/mono-rand-windows.c
@@ -127,7 +127,7 @@ mono_rand_try_get_bytes (gpointer *handle, guchar *buffer, gint buffer_size, Mon
 {
 	MONO_WIN32_CRYPT_PROVIDER_HANDLE provider;
 
-	mono_error_init (error);
+	error_init (error);
 
 	g_assert (handle);
 	provider = (MONO_WIN32_CRYPT_PROVIDER_HANDLE) *handle;

--- a/mono/utils/mono-rand.c
+++ b/mono/utils/mono-rand.c
@@ -51,7 +51,7 @@ get_entropy_from_egd (const char *path, guchar *buffer, int buffer_size, MonoErr
 	guint offset = 0;
 	int err = 0;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	socket_fd = socket (PF_UNIX, SOCK_STREAM, 0);
 	if (socket_fd < 0) {
@@ -155,7 +155,7 @@ mono_rand_try_get_bytes (gpointer *handle, guchar *buffer, gint buffer_size, Mon
 {
 	g_assert (handle);
 
-	mono_error_init (error);
+	error_init (error);
 
 	if (use_egd) {
 		const char *socket_path = g_getenv ("MONO_EGD_SOCKET");
@@ -224,7 +224,7 @@ mono_rand_try_get_bytes (gpointer *handle, guchar *buffer, gint buffer_size, Mon
 {
 	gint count = 0;
 
-	mono_error_init (error);
+	error_init (error);
 	
 	do {
 		if (buffer_size - count >= sizeof (gint32) && RAND_MAX >= 0xFFFFFFFF) {


### PR DESCRIPTION
Use the error_init macro instead of the mono_error_init function to avoid the
function call overhead.