### PR TITLE
[runtime] Fix memory leak in mono_save_seq_point_info().

### DIFF
--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -223,6 +223,8 @@ mono_save_seq_point_info (MonoCompile *cfg)
 		}
 	}
 
+	g_free (seq_points);
+
 	if (has_debug_data)
 		g_free (next);
 


### PR DESCRIPTION
Hello,
This one-liner fixes a memory leak in mono_save_seq_point_info() by freeing the temporary `seq_points` array after its use.