### PR TITLE
[threads] Don't ignore abort requests in abort protected blocks

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -4844,13 +4844,6 @@ async_abort_critical (MonoThreadInfo *info, gpointer ud)
 	if (mono_get_eh_callbacks ()->mono_install_handler_block_guard (mono_thread_info_get_suspend_state (info)))
 		return MonoResumeThread;
 
-	/*
-	The target thread is running at least one protected block, which must not be interrupted, so we give up.
-	The protected block code will give them a chance when appropriate.
-	*/
-	if (mono_thread_get_abort_prot_block_count (thread) > 0)
-		return MonoResumeThread;
-
 	/*someone is already interrupting it*/
 	if (!mono_thread_set_interruption_requested (thread))
 		return MonoResumeThread;


### PR DESCRIPTION
Either interrupt or set the interrupt_deferred flag, so the thread can handle the request later in the future. Otherwise we are left with a thread that has an AbortRequested set on its state that it is never processed and future abort requests are ignored due to the presence of this flag.

@kumpera @ludovic-henry This code looks like it should have been removed sometime during recent thread abort changes. Could you please review and confirm if it is the case. Seems to solve some domain unload hangs that we've seen lately.