### PR TITLE
[runtime] Mark mono_error_init external only.

### DIFF
--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -57,6 +57,7 @@ typedef struct _MonoErrorBoxed MonoErrorBoxed;
 
 MONO_BEGIN_DECLS
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_error_init (MonoError *error);
 


### PR DESCRIPTION
Runtime should use the error_init() from mono/utils/mono-error-internals.h