### PR TITLE
Fix monodis

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -2027,6 +2027,7 @@ main (int argc, char *argv [])
 
 	CHECKED_MONO_INIT ();
 	mono_counters_init ();
+	mono_tls_init_runtime_keys ();
 	memset (&ticallbacks, 0, sizeof (ticallbacks));
 	ticallbacks.thread_state_init = thread_state_init;
 #ifndef HOST_WIN32


### PR DESCRIPTION
monodis was not calling the mono_tls_init_runtime_keys function, which was causing it to crash the first time it attempted to access the current domain (ie almost immediately).