### PR TITLE
[runtime] Use mono_debug_method_lookup_location () instead of mono_de…

### DIFF
--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -1147,7 +1147,7 @@ mono_profiler_coverage_get (MonoProfiler *prof, MonoMethod *method, MonoProfileC
 			if (debug_minfo) {
 				MonoDebugSourceLocation *location;
 
-				location = mono_debug_symfile_lookup_location (debug_minfo, offset);
+				location = mono_debug_method_lookup_location (debug_minfo, offset);
 				if (location) {
 					entry.line = location->row;
 					entry.col = location->column;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -5246,11 +5246,11 @@ compute_line_numbers (MonoMethod *method, int code_size, MonoDebugMethodJitInfo 
 		if (il_offset == -1 || il_offset == prev_il_offset)
 			continue;
 		prev_il_offset = il_offset;
-		loc = mono_debug_symfile_lookup_location (minfo, il_offset);
+		loc = mono_debug_method_lookup_location (minfo, il_offset);
 		if (!(loc && loc->source_file))
 			continue;
 		if (loc->row == prev_line) {
-			mono_debug_symfile_free_location (loc);
+			mono_debug_free_source_location (loc);
 			continue;
 		}
 		prev_line = loc->row;
@@ -5349,7 +5349,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 				options = "";
 			prologue_end = TRUE;
 			fprintf (acfg->fp, ".loc %d %d 0%s\n", findex, loc->row, options);
-			mono_debug_symfile_free_location (loc);
+			mono_debug_free_source_location (loc);
 		}
 
 		skip = FALSE;

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -152,7 +152,7 @@ mono_debug_add_vg_method (MonoMethod *method, MonoDebugMethodJitInfo *jit)
 		for (i = 0; i < header->code_size; ++i) {
 			MonoDebugSourceLocation *location;
 
-			location = mono_debug_symfile_lookup_location (minfo, i);
+			location = mono_debug_method_lookup_location (minfo, i);
 			if (!location)
 				continue;
 

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -21,7 +21,6 @@
 #endif
 
 #include <mono/metadata/mono-endian.h>
-#include <mono/metadata/debug-mono-symfile.h>
 #include <mono/metadata/mono-debug-debugger.h>
 
 #ifndef HOST_WIN32
@@ -1581,11 +1580,11 @@ emit_line_number_info (MonoDwarfWriter *w, MonoMethod *method,
 
 		prev_il_offset = il_offset;
 
-		loc = mono_debug_symfile_lookup_location (minfo, il_offset);
+		loc = mono_debug_method_lookup_location (minfo, il_offset);
 		if (!loc)
 			continue;
 		if (!loc->source_file) {
-			mono_debug_symfile_free_location (loc);
+			mono_debug_free_source_location (loc);
 			continue;
 		}
 
@@ -1633,7 +1632,7 @@ emit_line_number_info (MonoDwarfWriter *w, MonoMethod *method,
 			prev_native_offset = i;
 		}
 
-		mono_debug_symfile_free_location (loc);
+		mono_debug_free_source_location (loc);
 		first = FALSE;
 	}
 
@@ -1797,7 +1796,7 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 
 	minfo = mono_debug_lookup_method (method);
 	if (minfo)
-		loc = mono_debug_symfile_lookup_location (minfo, 0);
+		loc = mono_debug_method_lookup_location (minfo, 0);
 
 	/* Subprogram */
 	names = g_new0 (char *, sig->param_count);
@@ -1818,7 +1817,7 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 		emit_uleb128 (w, file_index + 1);
 		emit_uleb128 (w, loc->row);
 
-		mono_debug_symfile_free_location (loc);
+		mono_debug_free_source_location (loc);
 		loc = NULL;
 	} else {
 		emit_uleb128 (w, 0);

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9116,7 +9116,7 @@ emit_dbg_loc (EmitContext *ctx, LLVMBuilderRef builder, const unsigned char *cil
 		MonoDebugSourceLocation *loc;
 		LLVMValueRef loc_md;
 
-		loc = mono_debug_symfile_lookup_location (ctx->minfo, cil_code - cfg->header->code);
+		loc = mono_debug_method_lookup_location (ctx->minfo, cil_code - cfg->header->code);
 
 		if (loc) {
 #if LLVM_API_VERSION > 100
@@ -9134,7 +9134,7 @@ emit_dbg_loc (EmitContext *ctx, LLVMBuilderRef builder, const unsigned char *cil
 			loc_md = LLVMMDNode (md_args, nmd_args);
 			LLVMSetCurrentDebugLocation (builder, loc_md);
 #endif
-			mono_debug_symfile_free_location (loc);
+			mono_debug_free_source_location (loc);
 		}
 	}
 }


### PR DESCRIPTION
…bug_symfile_lookup_location (), the latter doesn't support portable pdb files. Use mono_debug_free_source_location () for freeing. Fixes #52899.