### PR TITLE
[sgen] use memmove as src and dst can overlap

### DIFF
--- a/mono/sgen/sgen-qsort.c
+++ b/mono/sgen/sgen-qsort.c
@@ -15,7 +15,7 @@
 #define ELEM(i) \
 	(((unsigned char*)array) + ((i) * element_size))
 #define SET(i,j) \
-	do memcpy ((i), (j), element_size); while (0)
+	do memmove ((i), (j), element_size); while (0)
 #define SWAP(i,j) \
 	do { \
 		size_t __i = (i), __j = (j); \


### PR DESCRIPTION
valgrind said this on `mcs --version`:

```
==807== Thread 1:
==807== Source and destination overlap in memcpy(0x413f050, 0x413f050,
8)
==807==    at 0x4C32513: memcpy@@GLIBC_2.14 (in
/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==807==    by 0x7FB6DD: sgen_qsort_rec (sgen-qsort.c:76)
==807==    by 0x7FB8CC: sgen_qsort (sgen-qsort.c:118)
==807==    by 0x7ED834: major_free_swept_blocks (sgen-marksweep.c:2136)
==807==    by 0x7F0590: sgen_memgov_calculate_minor_collection_allowance
(sgen-memory-governor.c:114)
==807==    by 0x7F0D2E: sgen_memgov_major_collection_end
(sgen-memory-governor.c:278)
==807==    by 0x7A6C71: major_finish_collection (sgen-gc.c:2116)
==807==    by 0x7A6E23: major_do_collection (sgen-gc.c:2158)
==807==    by 0x7A7464: sgen_perform_collection (sgen-gc.c:2355)
==807==    by 0x7A85AF: sgen_gc_collect (sgen-gc.c:2854)
==807==    by 0x77C022: mono_gc_collect (sgen-mono.c:2574)
==807==    by 0x726A18: mono_domain_finalize (gc.c:439)
==807==
==807== Source and destination overlap in memcpy(0x413f078, 0x413f078,
8)
==807==    at 0x4C32513: memcpy@@GLIBC_2.14 (in
/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==807==    by 0x7FB6DD: sgen_qsort_rec (sgen-qsort.c:76)
==807==    by 0x7FB798: sgen_qsort_rec (sgen-qsort.c:92)
==807==    by 0x7FB8CC: sgen_qsort (sgen-qsort.c:118)
==807==    by 0x7ED834: major_free_swept_blocks (sgen-marksweep.c:2136)
==807==    by 0x7F0590: sgen_memgov_calculate_minor_collection_allowance
(sgen-memory-governor.c:114)
==807==    by 0x7F0D2E: sgen_memgov_major_collection_end
(sgen-memory-governor.c:278)
==807==    by 0x7A6C71: major_finish_collection (sgen-gc.c:2116)
==807==    by 0x7A6E23: major_do_collection (sgen-gc.c:2158)
==807==    by 0x7A7464: sgen_perform_collection (sgen-gc.c:2355)
==807==    by 0x7A85AF: sgen_gc_collect (sgen-gc.c:2854)
==807==    by 0x77C022: mono_gc_collect (sgen-mono.c:2574)
==807==
==807== Source and destination overlap in memcpy(0x413f088, 0x413f088,
8)
==807==    at 0x4C32513: memcpy@@GLIBC_2.14 (in
/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==807==    by 0x7FB6DD: sgen_qsort_rec (sgen-qsort.c:76)
==807==    by 0x7FB798: sgen_qsort_rec (sgen-qsort.c:92)
==807==    by 0x7FB798: sgen_qsort_rec (sgen-qsort.c:92)
==807==    by 0x7FB8CC: sgen_qsort (sgen-qsort.c:118)
==807==    by 0x7ED834: major_free_swept_blocks (sgen-marksweep.c:2136)
==807==    by 0x7F0590: sgen_memgov_calculate_minor_collection_allowance
(sgen-memory-governor.c:114)
==807==    by 0x7F0D2E: sgen_memgov_major_collection_end
(sgen-memory-governor.c:278)
==807==    by 0x7A6C71: major_finish_collection (sgen-gc.c:2116)
==807==    by 0x7A6E23: major_do_collection (sgen-gc.c:2158)
==807==    by 0x7A7464: sgen_perform_collection (sgen-gc.c:2355)
==807==    by 0x7A85AF: sgen_gc_collect (sgen-gc.c:2854)
```