### PR TITLE
Compile on amd64 Haiku

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,8 +339,6 @@ case "$host" in
 		AC_DEFINE(PTHREAD_POINTER_ID)
 		dnl Haiku does not support static TLS with __thread
 		with_tls=pthread
-		dnl Boehm is too much work to backport Haiku support for
-		support_boehm=no
 		libgc_threads=pthreads
 		use_sigposix=yes
 		;;

--- a/libgc/configure.ac
+++ b/libgc/configure.ac
@@ -104,6 +104,10 @@ case "$THREADS" in
 	AC_DEFINE(GC_AIX_THREADS)
 	AC_DEFINE(_REENTRANT)
 	;;
+     *-*-haiku*)
+	AC_DEFINE(GC_HAIKU_THREADS)
+	AC_DEFINE(_REENTRANT)
+	;;
      *-*-hpux*)
 	AC_MSG_WARN("Only HP/UX 11 threads are supported.")
 	AC_DEFINE(GC_HPUX_THREADS)

--- a/libgc/dyn_load.c
+++ b/libgc/dyn_load.c
@@ -59,7 +59,7 @@
     !(defined(FREEBSD) && defined(__ELF__)) && \
     !(defined(OPENBSD) && (defined(__ELF__) || defined(M68K))) && \
     !(defined(NETBSD) && defined(__ELF__)) && !defined(HURD) && \
-    !defined(DARWIN)
+    !defined(DARWIN) && !defined(HAIKU)
  --> We only know how to find data segments of dynamic libraries for the
  --> above.  Additional SVR4 variants might not be too
  --> hard to add.
@@ -1257,6 +1257,23 @@ GC_bool GC_register_main_static_data()
 }
 
 #endif /* DARWIN */
+
+#if defined(HAIKU)
+
+#include <kernel/image.h>
+
+void GC_register_dynamic_libraries()
+{
+    image_info info;
+    int32 cookie = 0;
+    while (get_next_image_info(0, &cookie, &info) == B_OK)
+    {
+        void *data = info.data;
+	GC_add_roots_inner(data, data + info.data_size, TRUE);
+    }
+}
+
+#endif /* HAIKU */
 
 #else /* !DYNAMIC_LOADING */
 

--- a/libgc/include/gc_config_macros.h
+++ b/libgc/include/gc_config_macros.h
@@ -57,7 +57,7 @@
 	defined(GC_HPUX_THREADS) || defined(GC_OSF1_THREADS) || \
 	defined(GC_DGUX386_THREADS) || defined(GC_DARWIN_THREADS) || \
 	defined(GC_AIX_THREADS) || defined(GC_NETBSD_THREADS) || \
-	defined(GC_OPENBSD_THREADS) || \
+	defined(GC_OPENBSD_THREADS) || defined(GC_HAIKU_THREADS) ||\
         (defined(GC_WIN32_THREADS) && defined(__CYGWIN32__))
 #   define GC_PTHREADS
 # endif

--- a/libgc/include/private/gcconfig.h
+++ b/libgc/include/private/gcconfig.h
@@ -238,6 +238,16 @@
 #    define BEOS
 #    define mach_type_known
 # endif
+# if defined(__HAIKU__) && defined(_X86_)
+#    define I386
+#    define HAIKU
+#    define mach_type_known
+# endif
+# if defined(__HAIKU__) && defined(__amd64__)
+#    define X86_64
+#    define HAIKU
+#    define mach_type_known
+# endif
 # if defined(LINUX) && (defined(i386) || defined(__i386__))
 #    define I386
 #    define mach_type_known
@@ -1163,6 +1173,15 @@
 #     define GETPAGESIZE() B_PAGE_SIZE
       extern int etext[];
 #     define DATASTART ((ptr_t)((((word) (etext)) + 0xfff) & ~0xfff))
+#   endif
+#   ifdef HAIKU
+#     define OS_TYPE "HAIKU"
+#     include <OS.h>
+#     define GETPAGESIZE() B_PAGE_SIZE
+      extern int etext[];
+#     define DATASTART ((ptr_t)((((word) (etext)) + 0xfff) & ~0xfff))
+#     define DYNAMIC_LOADING
+#     define MPROTECT_VDB
 #   endif
 #   ifdef SUNOS5
 #	define OS_TYPE "SUNOS5"
@@ -2134,6 +2153,15 @@
       /* There seems to be some issues with trylock hanging on darwin. This
          should be looked into some more */
 #   endif
+#   ifdef HAIKU
+#     define OS_TYPE "HAIKU"
+#     include <OS.h>
+#     define GETPAGESIZE() B_PAGE_SIZE
+      extern int etext[];
+#     define DATASTART ((ptr_t)((((word) (etext)) + 0xfff) & ~0xfff))
+#     define DYNAMIC_LOADING
+#     define MPROTECT_VDB
+#   endif
 #   ifdef FREEBSD
 #	define OS_TYPE "FREEBSD"
 #	ifndef GC_FREEBSD_THREADS
@@ -2251,7 +2279,7 @@
 # if defined(SVR4) || defined(LINUX) || defined(IRIX5) || defined(HPUX) \
 	    || defined(OPENBSD) || defined(NETBSD) || defined(FREEBSD) \
 	    || defined(DGUX) || defined(BSD) || defined(SUNOS4) \
-	    || defined(_AIX) || defined(DARWIN) || defined(OSF1)
+	    || defined(_AIX) || defined(DARWIN) || defined(OSF1) || defined(HAIKU)
 #   define UNIX_LIKE   /* Basic Unix-like system calls work.	*/
 # endif
 
@@ -2507,6 +2535,9 @@
 #           if defined(SN_TARGET_PS3)
 	           extern void *ps3_get_mem (size_t size);
 #              define GET_MEM(bytes) (struct hblk*) ps3_get_mem (bytes)
+#           elif defined(HAIKU)
+              ptr_t GC_haiku_get_mem(GC_word bytes);
+#             define GET_MEM(bytes) (struct  hblk*)GC_haiku_get_mem(bytes)
 #           else
 		extern ptr_t GC_unix_get_mem(word size);
 #               define GET_MEM(bytes) (struct hblk *)GC_unix_get_mem(bytes)

--- a/libgc/pthread_support.c
+++ b/libgc/pthread_support.c
@@ -1135,7 +1135,7 @@ void GC_thr_init()
 #       if defined(GC_HPUX_THREADS)
 	  GC_nprocs = pthread_num_processors_np();
 #       endif
-#	if defined(GC_OSF1_THREADS) || defined(GC_AIX_THREADS)
+#	if defined(GC_OSF1_THREADS) || defined(GC_AIX_THREADS) || defined(GC_HAIKU_THREADS)
 	  GC_nprocs = sysconf(_SC_NPROCESSORS_ONLN);
 	  if (GC_nprocs <= 0) GC_nprocs = 1;
 #	endif

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -335,7 +335,7 @@ typedef struct {
  */
 #define MONO_ARCH_VARARG_ICALLS 1
 
-#if !defined( HOST_WIN32 ) && defined (HAVE_SIGACTION)
+#if !defined( HOST_WIN32 ) && !defined(__HAIKU__) && defined (HAVE_SIGACTION)
 
 #define MONO_ARCH_USE_SIGACTION 1
 

--- a/mono/utils/mono-context.c
+++ b/mono/utils/mono-context.c
@@ -210,6 +210,27 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 	mctx->gregs [AMD64_R13] = context->R13;
 	mctx->gregs [AMD64_R14] = context->R14;
 	mctx->gregs [AMD64_R15] = context->R15;
+#elif defined(__HAIKU__)
+	// Haiku uses sigcontext because there's no ucontext
+	struct sigcontext *ctx = (struct sigcontext *)sigctx;
+
+	mctx->gregs [AMD64_RIP] = ctx->regs.rip;
+	mctx->gregs [AMD64_RAX] = ctx->regs.rax;
+	mctx->gregs [AMD64_RCX] = ctx->regs.rcx;
+	mctx->gregs [AMD64_RDX] = ctx->regs.rdx;
+	mctx->gregs [AMD64_RBX] = ctx->regs.rbx;
+	mctx->gregs [AMD64_RSP] = ctx->regs.rsp;
+	mctx->gregs [AMD64_RBP] = ctx->regs.rbp;
+	mctx->gregs [AMD64_RSI] = ctx->regs.rsi;
+	mctx->gregs [AMD64_RDI] = ctx->regs.rdi;
+	mctx->gregs [AMD64_R8] = ctx->regs.r8;
+	mctx->gregs [AMD64_R9] = ctx->regs.r9;
+	mctx->gregs [AMD64_R10] = ctx->regs.r10;
+	mctx->gregs [AMD64_R11] = ctx->regs.r11;
+	mctx->gregs [AMD64_R12] = ctx->regs.r12;
+	mctx->gregs [AMD64_R13] = ctx->regs.r13;
+	mctx->gregs [AMD64_R14] = ctx->regs.r14;
+	mctx->gregs [AMD64_R15] = ctx->regs.r15;
 #else
 	g_assert_not_reached ();
 #endif
@@ -284,6 +305,27 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 	context->R13 = mctx->gregs [AMD64_R13];
 	context->R14 = mctx->gregs [AMD64_R14];
 	context->R15 = mctx->gregs [AMD64_R15];
+#elif defined(__HAIKU__)
+	// Haiku uses sigcontext because there's no ucontext
+	struct sigcontext *ctx = (struct sigcontext *)sigctx;
+
+	ctx->regs.rip = mctx->gregs [AMD64_RIP];
+	ctx->regs.rax = mctx->gregs [AMD64_RAX];
+	ctx->regs.rcx = mctx->gregs [AMD64_RCX];
+	ctx->regs.rdx = mctx->gregs [AMD64_RDX];
+	ctx->regs.rbx = mctx->gregs [AMD64_RBX];
+	ctx->regs.rsp = mctx->gregs [AMD64_RSP];
+	ctx->regs.rbp = mctx->gregs [AMD64_RBP];
+	ctx->regs.rsi = mctx->gregs [AMD64_RSI];
+	ctx->regs.rdi = mctx->gregs [AMD64_RDI];
+	ctx->regs.r8 = mctx->gregs [AMD64_R8];
+	ctx->regs.r9 = mctx->gregs [AMD64_R9];
+	ctx->regs.r10 = mctx->gregs [AMD64_R10];
+	ctx->regs.r11 = mctx->gregs [AMD64_R11];
+	ctx->regs.r12 = mctx->gregs [AMD64_R12];
+	ctx->regs.r13 = mctx->gregs [AMD64_R13];
+	ctx->regs.r14 = mctx->gregs [AMD64_R14];
+	ctx->regs.r15 = mctx->gregs [AMD64_R15];
 #else
 	g_assert_not_reached ();
 #endif

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -214,10 +214,21 @@ typedef struct {
 
 #if !defined( HOST_WIN32 ) && !defined(__native_client__) && !defined(__native_client_codegen__)
 
-#if defined(HAVE_SIGACTION) || defined(__APPLE__)  // the __APPLE__ check is required for the tvos simulator, which has ucontext_t but not sigaction
+// the __APPLE__ check is required for the tvos simulator, which has ucontext_t but not sigaction
+#if defined(HAVE_SIGACTION) || defined(__APPLE__)
 #define MONO_SIGNAL_USE_UCONTEXT_T 1
 #endif
 
+#endif
+
+#ifdef __HAIKU__
+/* sigcontext surrogate */
+struct sigcontext {
+	vregs regs;
+};
+
+// Haiku doesn't support this
+#undef MONO_SIGNAL_USE_UCONTEXT_T
 #endif
 
 typedef struct {

--- a/support/sys-time.c
+++ b/support/sys-time.c
@@ -10,6 +10,9 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <string.h>
+#ifdef __HAIKU__
+#include <os/kernel/OS.h>
+#endif
 
 #include "map.h"
 #include "mph.h"
@@ -47,11 +50,6 @@ Mono_Posix_Syscall_settimeofday (
 	struct Mono_Posix_Timeval *tv,
 	struct Mono_Posix_Timezone *tz)
 {
-#if defined(__HAIKU__)
-	/* FIXME: Haiku doesn't support this either, consider
-           using set_real_time_clock instead? */
-	return -1;
-#else
 	struct timeval _tv   = {0};
 	struct timeval *ptv  = NULL;
 	struct timezone _tz  = {0};
@@ -69,10 +67,14 @@ Mono_Posix_Syscall_settimeofday (
 		ptz = &_tz;
 	}
 
+#ifdef __HAIKU__
+	set_real_time_clock(ptv->tv_sec);
+	r = 0;
+#else
 	r = settimeofday (ptv, ptz);
+#endif
 
 	return r;
-#endif
 }
 
 static inline struct timeval*


### PR DESCRIPTION
Mono can now compile on 64-bi Haiku, by using sigcontext (somewhat like win32, or x86). On amd64, Haiku doesn't have issues with marshalling 64-bit values, but it currently does have issues with SGen either causing a stall or a core dump. As such, while it can compile the stdlib (further than x86 got), it's still a work in progress.

To elaborate on the commit message, it appears to be crashing on sgen-marksweep.c L937 with a divison error. [Full log](http://ix.io/nXA).