### PR TITLE
Make System.Drawing unit tests use Assert.Throws instead of [ExpectedException]

### DIFF
--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
@@ -80,7 +80,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = null;
 					byte [] types = new byte [1];
-					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
+					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
 				}
 			}
 		}
@@ -93,7 +93,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = null;
-					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
+					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
 				}
 			}
 		}
@@ -106,7 +106,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = new byte [2];
-					Assert.Throws<ArgumentException>(() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
+					Assert.Throws<ArgumentException> (() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
 				}
 			}
 		}
@@ -119,7 +119,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = null;
 					byte [] types = new byte [2];
-					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
+					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
 				}
 			}
 		}
@@ -132,7 +132,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = null;
-					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
+					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
 				}
 			}
 		}
@@ -145,7 +145,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = new byte [2];
-					Assert.Throws<ArgumentException>(() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
+					Assert.Throws<ArgumentException> (() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
@@ -73,7 +73,6 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void CopyData_NullPoints ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
@@ -81,13 +80,12 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = null;
 					byte [] types = new byte [1];
-					Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1));
+					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void CopyData_NullTypes ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
@@ -95,13 +93,12 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = null;
-					Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1));
+					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void CopyData_DifferentSize ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
@@ -109,13 +106,12 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = new byte [2];
-					Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1));
+					Assert.Throws<ArgumentException>(() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Enumerate_NullPoints ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
@@ -123,13 +119,12 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = null;
 					byte [] types = new byte [2];
-					Assert.AreEqual (0, gpi.Enumerate (ref points, ref types));
+					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Enumerate_NullTypes ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
@@ -137,13 +132,12 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = null;
-					Assert.AreEqual (0, gpi.Enumerate (ref points, ref types));
+					Assert.Throws<NullReferenceException>(() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Enumerate_DifferentSize ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
@@ -151,7 +145,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = new byte [2];
-					Assert.AreEqual (0, gpi.Enumerate (ref points, ref types));
+					Assert.Throws<ArgumentException>(() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathIteratorTest.cs
@@ -80,7 +80,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = null;
 					byte [] types = new byte [1];
-					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
+					Assert.Throws<NullReferenceException> (() => gpi.CopyData (ref points, ref types, 0, 1));
 				}
 			}
 		}
@@ -93,7 +93,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = null;
-					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
+					Assert.Throws<NullReferenceException> (() =>gpi.CopyData (ref points, ref types, 0, 1));
 				}
 			}
 		}
@@ -106,7 +106,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = new byte [2];
-					Assert.Throws<ArgumentException> (() => Assert.AreEqual (0, gpi.CopyData (ref points, ref types, 0, 1)));
+					Assert.Throws<ArgumentException> (() => gpi.CopyData (ref points, ref types, 0, 1));
 				}
 			}
 		}
@@ -119,7 +119,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = null;
 					byte [] types = new byte [2];
-					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
+					Assert.Throws<NullReferenceException> (() => gpi.Enumerate (ref points, ref types));
 				}
 			}
 		}
@@ -132,7 +132,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = null;
-					Assert.Throws<NullReferenceException> (() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
+					Assert.Throws<NullReferenceException> (() => gpi.Enumerate (ref points, ref types));
 				}
 			}
 		}
@@ -145,7 +145,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				using (GraphicsPathIterator gpi = new GraphicsPathIterator (gp)) {
 					PointF [] points = new PointF [1];
 					byte [] types = new byte [2];
-					Assert.Throws<ArgumentException> (() => Assert.AreEqual (0, gpi.Enumerate (ref points, ref types)));
+					Assert.Throws<ArgumentException> (() => gpi.Enumerate (ref points, ref types));
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathTest.cs
@@ -637,8 +637,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddLines_Point_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddLines (new Point[0]);
-			Assert.Throws<ArgumentException> (() => CheckLine (gp));
+			Assert.Throws<ArgumentException> (() => gp.AddLines (new Point[0]));
 		}
 
 		[Test]
@@ -669,8 +668,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddLines_PointF_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddLines (new PointF[0]);
-			Assert.Throws<ArgumentException> (() => CheckLine (gp));
+			Assert.Throws<ArgumentException> (() => gp.AddLines (new PointF[0]));
 		}
 
 		[Test]
@@ -1069,8 +1067,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddRectangles_Int_Empty ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddRectangles (new Rectangle[0]);
-			Assert.Throws< ArgumentException> (() => CheckRectangle(gp, 4));
+			Assert.Throws<ArgumentException> (() => gp.AddRectangles (new Rectangle[0]));
 		}
 
 		[Test]
@@ -1092,8 +1089,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddRectangles_Float_Empty ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddRectangles ( new RectangleF[0]);
-			Assert.Throws<ArgumentException> (() => CheckRectangle (gp, 4));
+			Assert.Throws<ArgumentException> (() => gp.AddRectangles ( new RectangleF[0]));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathTest.cs
@@ -61,37 +61,37 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Constructor_Point_Null_Byte ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new GraphicsPath ((Point[]) null, new byte[1]));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ((Point[]) null, new byte[1]));
 		}
 
 		[Test]
 		public void Constructor_Point_Byte_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => new GraphicsPath (new Point[1], null));
+			Assert.Throws<NullReferenceException> (() => new GraphicsPath (new Point[1], null));
 		}
 
 		[Test]
 		public void Constructor_Point_Byte_LengthMismatch ()
 		{
-			Assert.Throws<ArgumentException>(() => new GraphicsPath (new Point[1], new byte [2]));
+			Assert.Throws<ArgumentException> (() => new GraphicsPath (new Point[1], new byte [2]));
 		}
 
 		[Test]
 		public void Constructor_PointF_Null_Byte ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ((PointF[])null, new byte [1]));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ((PointF[])null, new byte [1]));
 		}
 
 		[Test]
 		public void Constructor_PointF_Byte_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => new GraphicsPath ( new PointF[1], null));
+			Assert.Throws<NullReferenceException> (() => new GraphicsPath ( new PointF[1], null));
 		}
 
 		[Test]
 		public void Constructor_PointF_Byte_LengthMismatch ()
 		{
-			Assert.Throws<ArgumentException>(() => new GraphicsPath (new PointF[2], new byte [1]));
+			Assert.Throws<ArgumentException> (() => new GraphicsPath (new PointF[2], new byte [1]));
 		}
 
 		[Test]
@@ -112,13 +112,13 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void GraphicsPath_Empty_PathPoints ()
 		{
-			Assert.Throws<ArgumentException>(() => Assert.IsNull (new GraphicsPath ().PathPoints));
+			Assert.Throws<ArgumentException> (() => Assert.IsNull (new GraphicsPath ().PathPoints));
 		}
 
 		[Test]
 		public void GraphicsPath_Empty_PathTypes ()
 		{
-			Assert.Throws<ArgumentException>(() => Assert.IsNull (new GraphicsPath ().PathTypes));
+			Assert.Throws<ArgumentException> (() => Assert.IsNull (new GraphicsPath ().PathTypes));
 		}
 
 		[Test]
@@ -170,7 +170,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 			GraphicsPath gp = new GraphicsPath ((FillMode) Int32.MaxValue);
 			Assert.AreEqual (Int32.MaxValue, (int) gp.FillMode, "MaxValue");
 			// but you can't set the FillMode property to an invalid value ;-)
-			Assert.Throws<SC.InvalidEnumArgumentException>(() => gp.FillMode = (FillMode) Int32.MaxValue);
+			Assert.Throws<SC.InvalidEnumArgumentException> (() => gp.FillMode = (FillMode) Int32.MaxValue);
 		}
 
 		[Test]
@@ -381,14 +381,14 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddBeziers_Point_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddBeziers ((Point[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddBeziers ((Point[]) null));
 		}
 
 		[Test]
 		public void AddBeziers_3_Points ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddBeziers (new Point[3] { new Point (1, 1), new Point (2, 2), new Point (3, 3) }));
+			Assert.Throws<ArgumentException> (() => gp.AddBeziers (new Point[3] { new Point (1, 1), new Point (2, 2), new Point (3, 3) }));
 		}
 
 		[Test]
@@ -402,14 +402,14 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddBeziers_PointF_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddBeziers ((PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddBeziers ((PointF[]) null));
 		}
 
 		[Test]
 		public void AddBeziers_3_PointFs ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddBeziers (new PointF[3] { new PointF (1f, 1f), new PointF (2f, 2f), new PointF (3f, 3f) }));
+			Assert.Throws<ArgumentException> (() => gp.AddBeziers (new PointF[3] { new PointF (1f, 1f), new PointF (2f, 2f), new PointF (3f, 3f) }));
 		}
 
 		[Test]
@@ -630,7 +630,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddLines_Point_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddLines ((Point[])null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddLines ((Point[])null));
 		}
 
 		[Test]
@@ -638,7 +638,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddLines (new Point[0]);
-			Assert.Throws<ArgumentException>(() => CheckLine (gp));
+			Assert.Throws<ArgumentException> (() => CheckLine (gp));
 		}
 
 		[Test]
@@ -662,7 +662,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddLines_PointF_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddLines ((PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddLines ((PointF[]) null));
 		}
 
 		[Test]
@@ -670,7 +670,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddLines (new PointF[0]);
-			Assert.Throws<ArgumentException>(() => CheckLine (gp));
+			Assert.Throws<ArgumentException> (() => CheckLine (gp));
 		}
 
 		[Test]
@@ -831,27 +831,27 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddPolygon_Point_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddPolygon ((Point[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddPolygon ((Point[]) null));
 		}
 
 		[Test]
 		public void AddPolygon_Point_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new GraphicsPath ().AddPolygon (new Point[0]));
+			Assert.Throws<ArgumentException> (() => new GraphicsPath ().AddPolygon (new Point[0]));
 		}
 
 		[Test]
 		public void AddPolygon_Point_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new Point[1] { new Point (1, 1) }));
+			Assert.Throws<ArgumentException> (() => gp.AddPolygon (new Point[1] { new Point (1, 1) }));
 		}
 
 		[Test]
 		public void AddPolygon_Point_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new Point[2] { new Point (1, 1), new Point (2, 2) }));
+			Assert.Throws<ArgumentException> (() => gp.AddPolygon (new Point[2] { new Point (1, 1), new Point (2, 2) }));
 		}
 
 		[Test]
@@ -865,27 +865,27 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddPolygon_PointF_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddPolygon ((PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddPolygon ((PointF[]) null));
 		}
 
 		[Test]
 		public void AddPolygon_PointF_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new GraphicsPath ().AddPolygon (new PointF[0]));
+			Assert.Throws<ArgumentException> (() => new GraphicsPath ().AddPolygon (new PointF[0]));
 		}
 
 		[Test]
 		public void AddPolygon_PointF_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new PointF[1] { new PointF (1f, 1f) }));
+			Assert.Throws<ArgumentException> (() => gp.AddPolygon (new PointF[1] { new PointF (1f, 1f) }));
 		}
 
 		[Test]
 		public void AddPolygon_PointF_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }));
+			Assert.Throws<ArgumentException> (() => gp.AddPolygon (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }));
 		}
 
 		[Test]
@@ -1062,7 +1062,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddRectangles_Int_Null ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentNullException>(() => gp.AddRectangles ((Rectangle[]) null));
+			Assert.Throws<ArgumentNullException> (() => gp.AddRectangles ((Rectangle[]) null));
 		}
 
 		[Test]
@@ -1070,7 +1070,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddRectangles (new Rectangle[0]);
-			Assert.Throws< ArgumentException>(() => CheckRectangle(gp, 4));
+			Assert.Throws< ArgumentException> (() => CheckRectangle(gp, 4));
 		}
 
 		[Test]
@@ -1085,7 +1085,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddRectangles_Float_Null ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentNullException>(() => gp.AddRectangles ((RectangleF[]) null));
+			Assert.Throws<ArgumentNullException> (() => gp.AddRectangles ((RectangleF[]) null));
 		}
 
 		[Test]
@@ -1093,7 +1093,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddRectangles ( new RectangleF[0]);
-			Assert.Throws<ArgumentException>(() => CheckRectangle (gp, 4));
+			Assert.Throws<ArgumentException> (() => CheckRectangle (gp, 4));
 		}
 
 		[Test]
@@ -1136,7 +1136,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddPath_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddPath (null, false));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddPath (null, false));
 		}
 
 		[Test]
@@ -1171,28 +1171,28 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddClosedCurve_Point_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddClosedCurve ((Point[])null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddClosedCurve ((Point[])null));
 		}
 
 		[Test]
 		public void AddClosedCurve_Point_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new Point [0]));
+			Assert.Throws<ArgumentException> (() => gp.AddClosedCurve (new Point [0]));
 		}
 
 		[Test]
 		public void AddClosedCurve_Point_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new Point[1] { new Point (1, 1) }));
+			Assert.Throws<ArgumentException> (() => gp.AddClosedCurve (new Point[1] { new Point (1, 1) }));
 		}
 
 		[Test]
 		public void AddClosedCurve_Point_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new Point[2] { new Point (1, 1), new Point (2, 2) }));
+			Assert.Throws<ArgumentException> (() => gp.AddClosedCurve (new Point[2] { new Point (1, 1), new Point (2, 2) }));
 		}
 
 		[Test]
@@ -1206,28 +1206,28 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddClosedCurve_PointF_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddClosedCurve ((PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddClosedCurve ((PointF[]) null));
 		}
 
 		[Test]
 		public void AddClosedCurve_PointF_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new PointF[0]));
+			Assert.Throws<ArgumentException> (() => gp.AddClosedCurve (new PointF[0]));
 		}
 
 		[Test]
 		public void AddClosedCurve_PointF_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new PointF[1] { new PointF (1f, 1f) }));
+			Assert.Throws<ArgumentException> (() => gp.AddClosedCurve (new PointF[1] { new PointF (1f, 1f) }));
 		}
 
 		[Test]
 		public void AddClosedCurve_PointF_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }));
+			Assert.Throws<ArgumentException> (() => gp.AddClosedCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }));
 		}
 
 		[Test]
@@ -1296,21 +1296,21 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void AddCurve_Point_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddCurve ((Point[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddCurve ((Point[]) null));
 		}
 
 		[Test]
 		public void AddCurve_Point_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new Point[0]));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new Point[0]));
 		}
 
 		[Test]
 		public void AddCurve_Point_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new Point[1] { new Point (1, 1) }));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new Point[1] { new Point (1, 1) }));
 		}
 
 		[Test]
@@ -1337,28 +1337,28 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddCurve3_Point_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new Point[2] { new Point (1, 1), new Point (2, 2) }, 0, 2, 0.5f));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new Point[2] { new Point (1, 1), new Point (2, 2) }, 0, 2, 0.5f));
 			// adding only two points isn't supported by GdipAddCurve3I
 		}
 
 		[Test]
 		public void AddCurve_PointF_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddCurve ((PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().AddCurve ((PointF[]) null));
 		}
 
 		[Test]
 		public void AddCurve_PointF_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[0]));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new PointF[0]));
 		}
 
 		[Test]
 		public void AddCurve_PointF_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[1] { new PointF (1f, 1f) }));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new PointF[1] { new PointF (1f, 1f) }));
 		}
 
 		[Test]
@@ -1385,7 +1385,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddCurve3_PointF_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 2, 0.5f));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 2, 0.5f));
 			// adding only two points isn't supported by GdipAddCurve3
 		}
 
@@ -1402,21 +1402,21 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddCurve_ZeroSegments ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 0, 0.5f));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 0, 0.5f));
 		}
 
 		[Test]
 		public void AddCurve_NegativeSegments ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, -1, 0.5f));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, -1, 0.5f));
 		}
 
 		[Test]
 		public void AddCurve_OffsetTooLarge ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[3] { new PointF (1f, 1f), new PointF (0f, 20f), new PointF (20f, 0f) }, 1, 2, 0.5f));
+			Assert.Throws<ArgumentException> (() => gp.AddCurve (new PointF[3] { new PointF (1f, 1f), new PointF (0f, 20f), new PointF (20f, 0f) }, 1, 2, 0.5f));
 		}
 
 		[Test]
@@ -1527,7 +1527,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			FontFamily ff = GetFontFamily ();
-			Assert.Throws<NullReferenceException>(() => gp.AddString (null, ff, 0, 10, new Point (10, 10), StringFormat.GenericDefault));
+			Assert.Throws<NullReferenceException> (() => gp.AddString (null, ff, 0, 10, new Point (10, 10), StringFormat.GenericDefault));
 		}
 
 		[Test]
@@ -1543,7 +1543,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void AddString_NullFontFamily ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			Assert.Throws<ArgumentException>(() => gp.AddString ("mono", null, 0, 10, new Point (10, 10), StringFormat.GenericDefault));
+			Assert.Throws<ArgumentException> (() => gp.AddString ("mono", null, 0, 10, new Point (10, 10), StringFormat.GenericDefault));
 		}
 
 		[Test]
@@ -1730,7 +1730,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Transform_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Transform (null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().Transform (null));
 		}
 		[Test]
 		public void Transform_Empty ()
@@ -1926,13 +1926,13 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Warp_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Warp (null, new RectangleF ()));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().Warp (null, new RectangleF ()));
 		}
 
 		[Test]
 		public void Warp_NoPoints ()
 		{
-			Assert.Throws<ArgumentException>(() => new GraphicsPath ().Warp (new PointF[0], new RectangleF ()));
+			Assert.Throws<ArgumentException> (() => new GraphicsPath ().Warp (new PointF[0], new RectangleF ()));
 		}
 
 		[Test]
@@ -2409,7 +2409,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Widen_Pen_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Widen (null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().Widen (null));
 		}
 
 		[Test]
@@ -2467,7 +2467,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Widen_Pen_Null_Matrix ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Widen (null, new Matrix ()));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().Widen (null, new Matrix ()));
 		}
 
 		[Test]
@@ -2488,7 +2488,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 				gp.AddLines (new Point[1] { new Point (1, 1) });
 				// Special case - a line with a single point is valid
 				Assert.AreEqual (1, gp.PointCount, "PointCount");
-				Assert.Throws<OutOfMemoryException>(() => gp.Widen (Pens.Red));
+				Assert.Throws<OutOfMemoryException> (() => gp.Widen (Pens.Red));
 				// oops ;-)
 			}
 		}
@@ -2614,25 +2614,25 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void IsOutlineVisible_IntNull ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (1, 1, null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().IsOutlineVisible (1, 1, null));
 		}
 
 		[Test]
 		public void IsOutlineVisible_FloatNull ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (1.0f, 1.0f, null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().IsOutlineVisible (1.0f, 1.0f, null));
 		}
 
 		[Test]
 		public void IsOutlineVisible_PointNull ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (new Point (), null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().IsOutlineVisible (new Point (), null));
 		}
 
 		[Test]
 		public void IsOutlineVisible_PointFNull ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (new PointF (), null));
+			Assert.Throws<ArgumentNullException> (() => new GraphicsPath ().IsOutlineVisible (new PointF (), null));
 		}
 
 		private void IsOutlineVisible_Line (Graphics graphics)

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/GraphicsPathTest.cs
@@ -59,45 +59,39 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_Point_Null_Byte ()
 		{
-			new GraphicsPath ((Point[]) null, new byte[1]);
+            Assert.Throws<ArgumentNullException>(() => new GraphicsPath ((Point[]) null, new byte[1]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Constructor_Point_Byte_Null ()
 		{
-			new GraphicsPath (new Point[1], null);
+			Assert.Throws<NullReferenceException>(() => new GraphicsPath (new Point[1], null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_Point_Byte_LengthMismatch ()
 		{
-			new GraphicsPath (new Point[1], new byte [2]);
+			Assert.Throws<ArgumentException>(() => new GraphicsPath (new Point[1], new byte [2]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_PointF_Null_Byte ()
 		{
-			new GraphicsPath ((PointF[])null, new byte [1]);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ((PointF[])null, new byte [1]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Constructor_PointF_Byte_Null ()
 		{
-			new GraphicsPath ( new PointF[1], null);
+			Assert.Throws<NullReferenceException>(() => new GraphicsPath ( new PointF[1], null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_PointF_Byte_LengthMismatch ()
 		{
-			new GraphicsPath (new PointF[2], new byte [1]);
+			Assert.Throws<ArgumentException>(() => new GraphicsPath (new PointF[2], new byte [1]));
 		}
 
 		[Test]
@@ -116,17 +110,15 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void GraphicsPath_Empty_PathPoints ()
 		{
-			Assert.IsNull (new GraphicsPath ().PathPoints);
+			Assert.Throws<ArgumentException>(() => Assert.IsNull (new GraphicsPath ().PathPoints));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void GraphicsPath_Empty_PathTypes ()
 		{
-			Assert.IsNull (new GraphicsPath ().PathTypes);
+			Assert.Throws<ArgumentException>(() => Assert.IsNull (new GraphicsPath ().PathTypes));
 		}
 
 		[Test]
@@ -172,14 +164,13 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (SC.InvalidEnumArgumentException))]
 		public void FillMode_Invalid ()
 		{
 			// constructor accept an invalid FillMode
 			GraphicsPath gp = new GraphicsPath ((FillMode) Int32.MaxValue);
 			Assert.AreEqual (Int32.MaxValue, (int) gp.FillMode, "MaxValue");
 			// but you can't set the FillMode property to an invalid value ;-)
-			gp.FillMode = (FillMode) Int32.MaxValue;
+			Assert.Throws<SC.InvalidEnumArgumentException>(() => gp.FillMode = (FillMode) Int32.MaxValue);
 		}
 
 		[Test]
@@ -388,18 +379,16 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddBeziers_Point_Null ()
 		{
-			new GraphicsPath ().AddBeziers ((Point[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddBeziers ((Point[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddBeziers_3_Points ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddBeziers (new Point[3] { new Point (1, 1), new Point (2, 2), new Point (3, 3) });
+			Assert.Throws<ArgumentException>(() => gp.AddBeziers (new Point[3] { new Point (1, 1), new Point (2, 2), new Point (3, 3) }));
 		}
 
 		[Test]
@@ -411,18 +400,16 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddBeziers_PointF_Null ()
 		{
-			new GraphicsPath ().AddBeziers ((PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddBeziers ((PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddBeziers_3_PointFs ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddBeziers (new PointF[3] { new PointF (1f, 1f), new PointF (2f, 2f), new PointF (3f, 3f) });
+			Assert.Throws<ArgumentException>(() => gp.AddBeziers (new PointF[3] { new PointF (1f, 1f), new PointF (2f, 2f), new PointF (3f, 3f) }));
 		}
 
 		[Test]
@@ -641,19 +628,17 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddLines_Point_Null ()
 		{
-			new GraphicsPath ().AddLines ((Point[])null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddLines ((Point[])null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddLines_Point_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddLines (new Point[0]);
-			CheckLine (gp);
+			Assert.Throws<ArgumentException>(() => CheckLine (gp));
 		}
 
 		[Test]
@@ -675,19 +660,17 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddLines_PointF_Null ()
 		{
-			new GraphicsPath ().AddLines ((PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddLines ((PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddLines_PointF_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddLines (new PointF[0]);
-			CheckLine (gp);
+			Assert.Throws<ArgumentException>(() => CheckLine (gp));
 		}
 
 		[Test]
@@ -846,33 +829,29 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddPolygon_Point_Null ()
 		{
-			new GraphicsPath ().AddPolygon ((Point[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddPolygon ((Point[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddPolygon_Point_Empty ()
 		{
-			new GraphicsPath ().AddPolygon (new Point[0]);
+			Assert.Throws<ArgumentException>(() => new GraphicsPath ().AddPolygon (new Point[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddPolygon_Point_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddPolygon (new Point[1] { new Point (1, 1) });
+			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new Point[1] { new Point (1, 1) }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddPolygon_Point_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddPolygon (new Point[2] { new Point (1, 1), new Point (2, 2) });
+			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new Point[2] { new Point (1, 1), new Point (2, 2) }));
 		}
 
 		[Test]
@@ -884,33 +863,29 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddPolygon_PointF_Null ()
 		{
-			new GraphicsPath ().AddPolygon ((PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddPolygon ((PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddPolygon_PointF_Empty ()
 		{
-			new GraphicsPath ().AddPolygon (new PointF[0]);
+			Assert.Throws<ArgumentException>(() => new GraphicsPath ().AddPolygon (new PointF[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddPolygon_PointF_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddPolygon (new PointF[1] { new PointF (1f, 1f) });
+			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new PointF[1] { new PointF (1f, 1f) }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddPolygon_PointF_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddPolygon (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) });
+			Assert.Throws<ArgumentException>(() => gp.AddPolygon (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }));
 		}
 
 		[Test]
@@ -1084,20 +1059,18 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddRectangles_Int_Null ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddRectangles ((Rectangle[]) null);
+			Assert.Throws<ArgumentNullException>(() => gp.AddRectangles ((Rectangle[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddRectangles_Int_Empty ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddRectangles (new Rectangle[0]);
-			CheckRectangle (gp, 4);
+			Assert.Throws< ArgumentException>(() => CheckRectangle(gp, 4));
 		}
 
 		[Test]
@@ -1109,20 +1082,18 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddRectangles_Float_Null ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddRectangles ((RectangleF[]) null);
+			Assert.Throws<ArgumentNullException>(() => gp.AddRectangles ((RectangleF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddRectangles_Float_Empty ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			gp.AddRectangles ( new RectangleF[0]);
-			CheckRectangle (gp, 4);
+			Assert.Throws<ArgumentException>(() => CheckRectangle (gp, 4));
 		}
 
 		[Test]
@@ -1163,10 +1134,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddPath_Null ()
 		{
-			new GraphicsPath ().AddPath (null, false);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddPath (null, false));
 		}
 
 		[Test]
@@ -1199,34 +1169,30 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddClosedCurve_Point_Null ()
 		{
-			new GraphicsPath ().AddClosedCurve ((Point[])null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddClosedCurve ((Point[])null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddClosedCurve_Point_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddClosedCurve (new Point [0]);
+			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new Point [0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddClosedCurve_Point_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddClosedCurve (new Point[1] { new Point (1, 1) });
+			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new Point[1] { new Point (1, 1) }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddClosedCurve_Point_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddClosedCurve (new Point[2] { new Point (1, 1), new Point (2, 2) });
+			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new Point[2] { new Point (1, 1), new Point (2, 2) }));
 		}
 
 		[Test]
@@ -1238,34 +1204,30 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddClosedCurve_PointF_Null ()
 		{
-			new GraphicsPath ().AddClosedCurve ((PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddClosedCurve ((PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddClosedCurve_PointF_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddClosedCurve (new PointF[0]);
+			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new PointF[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddClosedCurve_PointF_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddClosedCurve (new PointF[1] { new PointF (1f, 1f) });
+			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new PointF[1] { new PointF (1f, 1f) }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddClosedCurve_PointF_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddClosedCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) });
+			Assert.Throws<ArgumentException>(() => gp.AddClosedCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }));
 		}
 
 		[Test]
@@ -1332,26 +1294,23 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddCurve_Point_Null ()
 		{
-			new GraphicsPath ().AddCurve ((Point[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddCurve ((Point[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve_Point_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new Point[0]);
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new Point[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve_Point_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new Point[1] { new Point (1, 1) });
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new Point[1] { new Point (1, 1) }));
 		}
 
 		[Test]
@@ -1375,35 +1334,31 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve3_Point_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new Point[2] { new Point (1, 1), new Point (2, 2) }, 0, 2, 0.5f);
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new Point[2] { new Point (1, 1), new Point (2, 2) }, 0, 2, 0.5f));
 			// adding only two points isn't supported by GdipAddCurve3I
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddCurve_PointF_Null ()
 		{
-			new GraphicsPath ().AddCurve ((PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().AddCurve ((PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve_PointF_0 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new PointF[0]);
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve_PointF_1 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new PointF[1] { new PointF (1f, 1f) });
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[1] { new PointF (1f, 1f) }));
 		}
 
 		[Test]
@@ -1427,11 +1382,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve3_PointF_2 ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 2, 0.5f);
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 2, 0.5f));
 			// adding only two points isn't supported by GdipAddCurve3
 		}
 
@@ -1445,27 +1399,24 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve_ZeroSegments ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 0, 0.5f);
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, 0, 0.5f));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve_NegativeSegments ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, -1, 0.5f);
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[2] { new PointF (1f, 1f), new PointF (2f, 2f) }, 0, -1, 0.5f));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddCurve_OffsetTooLarge ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddCurve (new PointF[3] { new PointF (1f, 1f), new PointF (0f, 20f), new PointF (20f, 0f) }, 1, 2, 0.5f);
+			Assert.Throws<ArgumentException>(() => gp.AddCurve (new PointF[3] { new PointF (1f, 1f), new PointF (0f, 20f), new PointF (20f, 0f) }, 1, 2, 0.5f));
 		}
 
 		[Test]
@@ -1572,12 +1523,11 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void AddString_NullString ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
 			FontFamily ff = GetFontFamily ();
-			gp.AddString (null, ff, 0, 10, new Point (10, 10), StringFormat.GenericDefault);
+			Assert.Throws<NullReferenceException>(() => gp.AddString (null, ff, 0, 10, new Point (10, 10), StringFormat.GenericDefault));
 		}
 
 		[Test]
@@ -1590,11 +1540,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddString_NullFontFamily ()
 		{
 			GraphicsPath gp = new GraphicsPath ();
-			gp.AddString ("mono", null, 0, 10, new Point (10, 10), StringFormat.GenericDefault);
+			Assert.Throws<ArgumentException>(() => gp.AddString ("mono", null, 0, 10, new Point (10, 10), StringFormat.GenericDefault));
 		}
 
 		[Test]
@@ -1779,10 +1728,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Transform_Null ()
 		{
-			new GraphicsPath ().Transform (null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Transform (null));
 		}
 		[Test]
 		public void Transform_Empty ()
@@ -1976,17 +1924,15 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Warp_Null ()
 		{
-			new GraphicsPath ().Warp (null, new RectangleF ());
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Warp (null, new RectangleF ()));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Warp_NoPoints ()
 		{
-			new GraphicsPath ().Warp (new PointF[0], new RectangleF ());
+			Assert.Throws<ArgumentException>(() => new GraphicsPath ().Warp (new PointF[0], new RectangleF ()));
 		}
 
 		[Test]
@@ -2461,10 +2407,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Widen_Pen_Null ()
 		{
-			new GraphicsPath ().Widen (null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Widen (null));
 		}
 
 		[Test]
@@ -2520,10 +2465,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Widen_Pen_Null_Matrix ()
 		{
-			new GraphicsPath ().Widen (null, new Matrix ());
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().Widen (null, new Matrix ()));
 		}
 
 		[Test]
@@ -2538,14 +2482,13 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void Widen_SinglePoint ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (new Point[1] { new Point (1, 1) });
 				// Special case - a line with a single point is valid
 				Assert.AreEqual (1, gp.PointCount, "PointCount");
-				gp.Widen (Pens.Red);
+				Assert.Throws<OutOfMemoryException>(() => gp.Widen (Pens.Red));
 				// oops ;-)
 			}
 		}
@@ -2669,31 +2612,27 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsOutlineVisible_IntNull ()
 		{
-			new GraphicsPath ().IsOutlineVisible (1, 1, null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (1, 1, null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsOutlineVisible_FloatNull ()
 		{
-			new GraphicsPath ().IsOutlineVisible (1.0f, 1.0f, null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (1.0f, 1.0f, null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsOutlineVisible_PointNull ()
 		{
-			new GraphicsPath ().IsOutlineVisible (new Point (), null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (new Point (), null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsOutlineVisible_PointFNull ()
 		{
-			new GraphicsPath ().IsOutlineVisible (new PointF (), null);
+			Assert.Throws<ArgumentNullException>(() => new GraphicsPath ().IsOutlineVisible (new PointF (), null));
 		}
 
 		private void IsOutlineVisible_Line (Graphics graphics)

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
@@ -328,26 +328,26 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void InterpolationColors_Colors_InvalidBlend ()
 		{
 			// default Blend doesn't allow getting this property
-			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (default_brush.InterpolationColors.Colors));
+			Assert.Throws<ArgumentException> (() => Assert.IsNotNull (default_brush.InterpolationColors.Colors));
 		}
 
 		[Test]
 		public void InterpolationColors_Positions_InvalidBlend ()
 		{
 			// default Blend doesn't allow getting this property
-			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (default_brush.InterpolationColors.Positions));
+			Assert.Throws<ArgumentException> (() => Assert.IsNotNull (default_brush.InterpolationColors.Positions));
 		}
 
 		[Test]
 		public void LinearColors_Empty ()
 		{
-			Assert.Throws<IndexOutOfRangeException>(() => default_brush.LinearColors = new Color[0]);
+			Assert.Throws<IndexOutOfRangeException> (() => default_brush.LinearColors = new Color[0]);
 		}
 
 		[Test]
 		public void LinearColors_One ()
 		{
-			Assert.Throws<IndexOutOfRangeException>(() => default_brush.LinearColors = new Color[1]);
+			Assert.Throws<IndexOutOfRangeException> (() => default_brush.LinearColors = new Color[1]);
 		}
 
 		[Test]
@@ -398,7 +398,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Transform_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => default_brush.Transform = null);
+			Assert.Throws<ArgumentNullException> (() => default_brush.Transform = null);
 		}
 
 		[Test]
@@ -412,7 +412,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Transform_NonInvertible ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.Transform = new Matrix (123, 24, 82, 16, 47, 30));
+			Assert.Throws<ArgumentException> (() => default_brush.Transform = new Matrix (123, 24, 82, 16, 47, 30));
 		}
 
 		[Test]
@@ -432,13 +432,13 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void WrapMode_Clamp ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.WrapMode = WrapMode.Clamp);
+			Assert.Throws<ArgumentException> (() => default_brush.WrapMode = WrapMode.Clamp);
 		}
 
 		[Test]
 		public void WrapMode_Invalid ()
 		{
-			Assert.Throws<InvalidEnumArgumentException>(() => default_brush.WrapMode = (WrapMode) Int32.MinValue);
+			Assert.Throws<InvalidEnumArgumentException> (() => default_brush.WrapMode = (WrapMode) Int32.MinValue);
 		}
 
 
@@ -460,13 +460,13 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void MultiplyTransform1_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => default_brush.MultiplyTransform (null));
+			Assert.Throws<ArgumentNullException> (() => default_brush.MultiplyTransform (null));
 		}
 
 		[Test]
 		public void MultiplyTransform2_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => default_brush.MultiplyTransform (null, MatrixOrder.Append));
+			Assert.Throws<ArgumentNullException> (() => default_brush.MultiplyTransform (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -479,7 +479,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void MultiplyTransform_NonInvertible ()
 		{
 			Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30);
-			Assert.Throws<ArgumentException>(() => default_brush.MultiplyTransform (noninvertible));
+			Assert.Throws<ArgumentException> (() => default_brush.MultiplyTransform (noninvertible));
 		}
 
 		[Test]
@@ -542,7 +542,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void RotateTransform_InvalidOrder ()
 		{
 			LinearGradientBrush lgb = new LinearGradientBrush (pt1, pt2, c1, c2);
-			Assert.Throws<ArgumentException>(() => lgb.RotateTransform (720, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => lgb.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -594,7 +594,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void ScaleTransform_InvalidOrder ()
 		{
 			LinearGradientBrush lgb = new LinearGradientBrush (pt1, pt2, c1, c2);
-			Assert.Throws<ArgumentException>(() => lgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => lgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -632,25 +632,25 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void SetBlendTriangularShape_FocusTooSmall ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (-1));
+			Assert.Throws<ArgumentException> (() => default_brush.SetBlendTriangularShape (-1));
 		}
 
 		[Test]
 		public void SetBlendTriangularShape_FocusTooBig ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (1.01f));
+			Assert.Throws<ArgumentException> (() => default_brush.SetBlendTriangularShape (1.01f));
 		}
 
 		[Test]
 		public void SetBlendTriangularShape_ScaleTooSmall ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (1, -1));
+			Assert.Throws<ArgumentException> (() => default_brush.SetBlendTriangularShape (1, -1));
 		}
 
 		[Test]
 		public void SetBlendTriangularShape_ScaleTooBig ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (1, 1.01f));
+			Assert.Throws<ArgumentException> (() => default_brush.SetBlendTriangularShape (1, 1.01f));
 		}
 
 		[Test]
@@ -688,25 +688,25 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void SetSigmaBellShape_FocusTooSmall ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (-1));
+			Assert.Throws<ArgumentException> (() => default_brush.SetSigmaBellShape (-1));
 		}
 
 		[Test]
 		public void SetSigmaBellShape_FocusTooBig ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (1.01f));
+			Assert.Throws<ArgumentException> (() => default_brush.SetSigmaBellShape (1.01f));
 		}
 
 		[Test]
 		public void SetSigmaBellShape_ScaleTooSmall ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (1, -1));
+			Assert.Throws<ArgumentException> (() => default_brush.SetSigmaBellShape (1, -1));
 		}
 
 		[Test]
 		public void SetSigmaBellShape_ScaleTooBig ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (1, 1.01f));
+			Assert.Throws<ArgumentException> (() => default_brush.SetSigmaBellShape (1, 1.01f));
 		}
 
 		[Test]
@@ -737,7 +737,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void TranslateTransform_InvalidOrder ()
 		{
 			LinearGradientBrush lgb = new LinearGradientBrush (pt1, pt2, c1, c2);
-			Assert.Throws<ArgumentException>(() => lgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => lgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -855,19 +855,19 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void LinearColors_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => default_brush.LinearColors = null);
+			Assert.Throws<NullReferenceException> (() => default_brush.LinearColors = null);
 		}
 
 		[Test]
 		public void InterpolationColors_Null ()
 		{
-			Assert.Throws<ArgumentException>(() => default_brush.InterpolationColors = null);
+			Assert.Throws<ArgumentException> (() => default_brush.InterpolationColors = null);
 		}
 
 		[Test]
 		public void Blend_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => default_brush.Blend = null);
+			Assert.Throws<NullReferenceException> (() => default_brush.Blend = null);
 		}
 
 		[Test]
@@ -875,7 +875,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			Rectangle r = new Rectangle (10, 10, 0, 10);
 			Assert.AreEqual (0, r.Width, "Width");
-			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
+			Assert.Throws<ArgumentException> (() => new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
 		}
 
 		[Test]
@@ -883,7 +883,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			RectangleF r = new RectangleF (10.0f, 10.0f, 10.0f, 0.0f);
 			Assert.AreEqual (0.0f, r.Height, "Height");
-			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
+			Assert.Throws<ArgumentException> (() => new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
@@ -328,14 +328,14 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void InterpolationColors_Colors_InvalidBlend ()
 		{
 			// default Blend doesn't allow getting this property
-			Assert.Throws<ArgumentException> (() => Assert.IsNotNull (default_brush.InterpolationColors.Colors));
+			Assert.Throws<ArgumentException> (() => { var x = default_brush.InterpolationColors.Colors; });
 		}
 
 		[Test]
 		public void InterpolationColors_Positions_InvalidBlend ()
 		{
 			// default Blend doesn't allow getting this property
-			Assert.Throws<ArgumentException> (() => Assert.IsNotNull (default_brush.InterpolationColors.Positions));
+			Assert.Throws<ArgumentException> (() => { var x = default_brush.InterpolationColors.Positions; });
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
@@ -325,33 +325,29 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void InterpolationColors_Colors_InvalidBlend ()
 		{
 			// default Blend doesn't allow getting this property
-			Assert.IsNotNull (default_brush.InterpolationColors.Colors);
+			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (default_brush.InterpolationColors.Colors));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void InterpolationColors_Positions_InvalidBlend ()
 		{
 			// default Blend doesn't allow getting this property
-			Assert.IsNotNull (default_brush.InterpolationColors.Positions);
+			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (default_brush.InterpolationColors.Positions));
 		}
 
 		[Test]
-		[ExpectedException (typeof (IndexOutOfRangeException))]
 		public void LinearColors_Empty ()
 		{
-			default_brush.LinearColors = new Color[0];
+			Assert.Throws<IndexOutOfRangeException>(() => default_brush.LinearColors = new Color[0]);
 		}
 
 		[Test]
-		[ExpectedException (typeof (IndexOutOfRangeException))]
 		public void LinearColors_One ()
 		{
-			default_brush.LinearColors = new Color[1];
+			Assert.Throws<IndexOutOfRangeException>(() => default_brush.LinearColors = new Color[1]);
 		}
 
 		[Test]
@@ -400,10 +396,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Transform_Null ()
 		{
-			default_brush.Transform = null;
+			Assert.Throws<ArgumentNullException>(() => default_brush.Transform = null);
 		}
 
 		[Test]
@@ -415,10 +410,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Transform_NonInvertible ()
 		{
-			default_brush.Transform = new Matrix (123, 24, 82, 16, 47, 30);
+			Assert.Throws<ArgumentException>(() => default_brush.Transform = new Matrix (123, 24, 82, 16, 47, 30));
 		}
 
 		[Test]
@@ -436,17 +430,15 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void WrapMode_Clamp ()
 		{
-			default_brush.WrapMode = WrapMode.Clamp;
+			Assert.Throws<ArgumentException>(() => default_brush.WrapMode = WrapMode.Clamp);
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void WrapMode_Invalid ()
 		{
-			default_brush.WrapMode = (WrapMode) Int32.MinValue;
+			Assert.Throws<InvalidEnumArgumentException>(() => default_brush.WrapMode = (WrapMode) Int32.MinValue);
 		}
 
 
@@ -466,17 +458,15 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MultiplyTransform1_Null ()
 		{
-			default_brush.MultiplyTransform (null);
+			Assert.Throws<ArgumentNullException>(() => default_brush.MultiplyTransform (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MultiplyTransform2_Null ()
 		{
-			default_brush.MultiplyTransform (null, MatrixOrder.Append);
+			Assert.Throws<ArgumentNullException>(() => default_brush.MultiplyTransform (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -486,11 +476,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void MultiplyTransform_NonInvertible ()
 		{
 			Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30);
-			default_brush.MultiplyTransform (noninvertible);
+			Assert.Throws<ArgumentException>(() => default_brush.MultiplyTransform (noninvertible));
 		}
 
 		[Test]
@@ -550,11 +539,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void RotateTransform_InvalidOrder ()
 		{
 			LinearGradientBrush lgb = new LinearGradientBrush (pt1, pt2, c1, c2);
-			lgb.RotateTransform (720, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => lgb.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -603,11 +591,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ScaleTransform_InvalidOrder ()
 		{
 			LinearGradientBrush lgb = new LinearGradientBrush (pt1, pt2, c1, c2);
-			lgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => lgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -643,31 +630,27 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_FocusTooSmall ()
 		{
-			default_brush.SetBlendTriangularShape (-1);
+			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (-1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_FocusTooBig ()
 		{
-			default_brush.SetBlendTriangularShape (1.01f);
+			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (1.01f));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_ScaleTooSmall ()
 		{
-			default_brush.SetBlendTriangularShape (1, -1);
+			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (1, -1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_ScaleTooBig ()
 		{
-			default_brush.SetBlendTriangularShape (1, 1.01f);
+			Assert.Throws<ArgumentException>(() => default_brush.SetBlendTriangularShape (1, 1.01f));
 		}
 
 		[Test]
@@ -703,31 +686,27 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_FocusTooSmall ()
 		{
-			default_brush.SetSigmaBellShape (-1);
+			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (-1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_FocusTooBig ()
 		{
-			default_brush.SetSigmaBellShape (1.01f);
+			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (1.01f));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_ScaleTooSmall ()
 		{
-			default_brush.SetSigmaBellShape (1, -1);
+			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (1, -1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_ScaleTooBig ()
 		{
-			default_brush.SetSigmaBellShape (1, 1.01f);
+			Assert.Throws<ArgumentException>(() => default_brush.SetSigmaBellShape (1, 1.01f));
 		}
 
 		[Test]
@@ -755,11 +734,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TranslateTransform_InvalidOrder ()
 		{
 			LinearGradientBrush lgb = new LinearGradientBrush (pt1, pt2, c1, c2);
-			lgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => lgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -875,42 +853,37 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void LinearColors_Null ()
 		{
-			default_brush.LinearColors = null;
+			Assert.Throws<NullReferenceException>(() => default_brush.LinearColors = null);
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void InterpolationColors_Null ()
 		{
-			default_brush.InterpolationColors = null;
+			Assert.Throws<ArgumentException>(() => default_brush.InterpolationColors = null);
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Blend_Null ()
 		{
-			default_brush.Blend = null;
+			Assert.Throws<NullReferenceException>(() => default_brush.Blend = null);
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ZeroWidthRectangle ()
 		{
 			Rectangle r = new Rectangle (10, 10, 0, 10);
 			Assert.AreEqual (0, r.Width, "Width");
-			new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical);
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ZeroHeightRectangleF ()
 		{
 			RectangleF r = new RectangleF (10.0f, 10.0f, 10.0f, 0.0f);
 			Assert.AreEqual (0.0f, r.Height, "Height");
-			new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical);
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (r, Color.Red, Color.Blue, LinearGradientMode.Vertical));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/PathGradientBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/PathGradientBrushTest.cs
@@ -94,14 +94,14 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void Constructor_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (gp));
+			Assert.Throws<ArgumentNullException> (() => new PathGradientBrush (gp));
 		}
 
 		[Test]
 		public void Constructor_GraphicsPath_Empty ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
-				Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (gp));
+				Assert.Throws<OutOfMemoryException> (() => new PathGradientBrush (gp));
 			}
 		}
 
@@ -111,7 +111,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (new Point[1] { new Point (1, 1) });
 				// Special case - a line with a single point is valid
-				Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (gp));
+				Assert.Throws<OutOfMemoryException> (() => new PathGradientBrush (gp));
 			}
 		}
 
@@ -131,21 +131,21 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void Constructor_Point_Null ()
 		{
 			Point[] pts = null;
-			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (pts));
+			Assert.Throws<ArgumentNullException> (() => new PathGradientBrush (pts));
 		}
 
 		[Test]
 		public void Constructor_Point_Empty ()
 		{
 			Point[] pts = new Point [0];
-			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
+			Assert.Throws<OutOfMemoryException> (() => new PathGradientBrush (pts));
 		}
 
 		[Test]
 		public void Constructor_Point_One ()
 		{
 			Point[] pts = new Point[1] { new Point (1, 1) };
-			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
+			Assert.Throws<OutOfMemoryException> (() => new PathGradientBrush (pts));
 		}
 
 		[Test]
@@ -206,21 +206,21 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void Constructor_PointF_Null ()
 		{
 			PointF[] pts = null;
-			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (pts));
+			Assert.Throws<ArgumentNullException> (() => new PathGradientBrush (pts));
 		}
 
 		[Test]
 		public void Constructor_PointF_Empty ()
 		{
 			PointF[] pts = new PointF[0];
-			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
+			Assert.Throws<OutOfMemoryException> (() => new PathGradientBrush (pts));
 		}
 
 		[Test]
 		public void Constructor_PointF_One ()
 		{
 			PointF[] pts = new PointF[1] { new PointF (1, 1) };
-			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
+			Assert.Throws<OutOfMemoryException> (() => new PathGradientBrush (pts));
 		}
 
 		[Test]
@@ -235,7 +235,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Constructor_PointF_WrapMode_Invalid ()
 		{
-			Assert.Throws<InvalidEnumArgumentException>(() => new PathGradientBrush (pts_2f, (WrapMode)Int32.MinValue));
+			Assert.Throws<InvalidEnumArgumentException> (() => new PathGradientBrush (pts_2f, (WrapMode)Int32.MinValue));
 		}
 
 		[Test]
@@ -391,7 +391,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SurroundColors_Empty ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.TileFlipXY)) {
-				Assert.Throws<ArgumentException>(() => pgb.SurroundColors = new Color[0]);
+				Assert.Throws<ArgumentException> (() => pgb.SurroundColors = new Color[0]);
 			}
 		}
 
@@ -439,7 +439,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		[Test]
 		public void Transform_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (pts_2f, WrapMode.Clamp).Transform = null);
+			Assert.Throws<ArgumentNullException> (() => new PathGradientBrush (pts_2f, WrapMode.Clamp).Transform = null);
 		}
 
 		[Test]
@@ -455,7 +455,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void Transform_NonInvertible ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.Transform = new Matrix (123, 24, 82, 16, 47, 30));
+				Assert.Throws<ArgumentException> (() => pgb.Transform = new Matrix (123, 24, 82, 16, 47, 30));
 			}
 		}
 
@@ -474,7 +474,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void WrapMode_Invalid ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<InvalidEnumArgumentException>(() => pgb.WrapMode = (WrapMode) Int32.MinValue);
+				Assert.Throws<InvalidEnumArgumentException> (() => pgb.WrapMode = (WrapMode) Int32.MinValue);
 			}
 		}
 
@@ -496,7 +496,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void MultiplyTransform1_Null ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentNullException>(() => pgb.MultiplyTransform (null));
+				Assert.Throws<ArgumentNullException> (() => pgb.MultiplyTransform (null));
 			}
 		}
 
@@ -504,7 +504,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void MultiplyTransform2_Null ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentNullException>(() => pgb.MultiplyTransform (null, MatrixOrder.Append));
+				Assert.Throws<ArgumentNullException> (() => pgb.MultiplyTransform (null, MatrixOrder.Append));
 			}
 		}
 
@@ -521,7 +521,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		{
 			using (Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30)) {
 				using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-					Assert.Throws<ArgumentException>(() => pgb.MultiplyTransform (noninvertible));
+					Assert.Throws<ArgumentException> (() => pgb.MultiplyTransform (noninvertible));
 				}
 			}
 		}
@@ -593,7 +593,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void RotateTransform_InvalidOrder ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.RotateTransform (720, (MatrixOrder) Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => pgb.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 			}
 		}
 
@@ -634,7 +634,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void ScaleTransform_InvalidOrder ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => pgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 			}
 		}
 
@@ -676,7 +676,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetBlendTriangularShape_FocusTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (-1));
+				Assert.Throws<ArgumentException> (() => pgb.SetBlendTriangularShape (-1));
 			}
 		}
 
@@ -684,7 +684,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetBlendTriangularShape_FocusTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (1.01f));
+				Assert.Throws<ArgumentException> (() => pgb.SetBlendTriangularShape (1.01f));
 			}
 		}
 
@@ -692,7 +692,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetBlendTriangularShape_ScaleTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (1, -1));
+				Assert.Throws<ArgumentException> (() => pgb.SetBlendTriangularShape (1, -1));
 			}
 		}
 
@@ -700,7 +700,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetBlendTriangularShape_ScaleTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (1, 1.01f));
+				Assert.Throws<ArgumentException> (() => pgb.SetBlendTriangularShape (1, 1.01f));
 			}
 		}
 
@@ -742,7 +742,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetSigmaBellShape_FocusTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (-1));
+				Assert.Throws<ArgumentException> (() => pgb.SetSigmaBellShape (-1));
 			}
 		}
 
@@ -750,7 +750,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetSigmaBellShape_FocusTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (1.01f));
+				Assert.Throws<ArgumentException> (() => pgb.SetSigmaBellShape (1.01f));
 			}
 		}
 
@@ -758,7 +758,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetSigmaBellShape_ScaleTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (1, -1));
+				Assert.Throws<ArgumentException> (() => pgb.SetSigmaBellShape (1, -1));
 			}
 		}
 
@@ -766,7 +766,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void SetSigmaBellShape_ScaleTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (1, 1.01f));
+				Assert.Throws<ArgumentException> (() => pgb.SetSigmaBellShape (1, 1.01f));
 			}
 		}
 
@@ -799,7 +799,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		public void TranslateTransform_InvalidOrder ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				Assert.Throws<ArgumentException>(() => pgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => pgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 			}
 		}
 
@@ -854,7 +854,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (pts_2f);
 				using (PathGradientBrush pgb = new PathGradientBrush (gp)) {
-					Assert.Throws<NullReferenceException>(() => pgb.Blend = null);
+					Assert.Throws<NullReferenceException> (() => pgb.Blend = null);
 				}
 			}
 		}
@@ -865,7 +865,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (pts_2f);
 				using (PathGradientBrush pgb = new PathGradientBrush (gp)) {
-					Assert.Throws<NullReferenceException>(() => pgb.InterpolationColors = null);
+					Assert.Throws<NullReferenceException> (() => pgb.InterpolationColors = null);
 				}
 			}
 		}
@@ -876,7 +876,7 @@ namespace MonoTests.System.Drawing.Drawing2D {
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (pts_2f);
 				using (PathGradientBrush pgb = new PathGradientBrush (gp)) {
-					Assert.Throws<NullReferenceException>(() => pgb.SurroundColors = null);
+					Assert.Throws<NullReferenceException> (() => pgb.SurroundColors = null);
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/PathGradientBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/PathGradientBrushTest.cs
@@ -91,30 +91,27 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			new PathGradientBrush (gp);
+			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (gp));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void Constructor_GraphicsPath_Empty ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
-				new PathGradientBrush (gp);
+				Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (gp));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void Constructor_GraphicsPath_SinglePoint ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (new Point[1] { new Point (1, 1) });
 				// Special case - a line with a single point is valid
-				new PathGradientBrush (gp);
+				Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (gp));
 			}
 		}
 
@@ -131,27 +128,24 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_Point_Null ()
 		{
 			Point[] pts = null;
-			new PathGradientBrush (pts);
+			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (pts));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void Constructor_Point_Empty ()
 		{
 			Point[] pts = new Point [0];
-			new PathGradientBrush (pts);
+			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void Constructor_Point_One ()
 		{
 			Point[] pts = new Point[1] { new Point (1, 1) };
-			new PathGradientBrush (pts);
+			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
 		}
 
 		[Test]
@@ -209,27 +203,24 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_PointF_Null ()
 		{
 			PointF[] pts = null;
-			new PathGradientBrush (pts);
+			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (pts));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void Constructor_PointF_Empty ()
 		{
 			PointF[] pts = new PointF[0];
-			new PathGradientBrush (pts);
+			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void Constructor_PointF_One ()
 		{
 			PointF[] pts = new PointF[1] { new PointF (1, 1) };
-			new PathGradientBrush (pts);
+			Assert.Throws<OutOfMemoryException>(() => new PathGradientBrush (pts));
 		}
 
 		[Test]
@@ -242,10 +233,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void Constructor_PointF_WrapMode_Invalid ()
 		{
-			PathGradientBrush pgb = new PathGradientBrush (pts_2f, (WrapMode)Int32.MinValue);
+			Assert.Throws<InvalidEnumArgumentException>(() => new PathGradientBrush (pts_2f, (WrapMode)Int32.MinValue));
 		}
 
 		[Test]
@@ -398,11 +388,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SurroundColors_Empty ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.TileFlipXY)) {
-				pgb.SurroundColors = new Color[0];
+				Assert.Throws<ArgumentException>(() => pgb.SurroundColors = new Color[0]);
 			}
 		}
 
@@ -448,10 +437,9 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Transform_Null ()
 		{
-			new PathGradientBrush (pts_2f, WrapMode.Clamp).Transform = null;
+			Assert.Throws<ArgumentNullException>(() => new PathGradientBrush (pts_2f, WrapMode.Clamp).Transform = null);
 		}
 
 		[Test]
@@ -464,11 +452,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Transform_NonInvertible ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.Transform = new Matrix (123, 24, 82, 16, 47, 30);
+				Assert.Throws<ArgumentException>(() => pgb.Transform = new Matrix (123, 24, 82, 16, 47, 30));
 			}
 		}
 
@@ -484,11 +471,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void WrapMode_Invalid ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.WrapMode = (WrapMode) Int32.MinValue;
+				Assert.Throws<InvalidEnumArgumentException>(() => pgb.WrapMode = (WrapMode) Int32.MinValue);
 			}
 		}
 
@@ -507,20 +493,18 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MultiplyTransform1_Null ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.MultiplyTransform (null);
+				Assert.Throws<ArgumentNullException>(() => pgb.MultiplyTransform (null));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MultiplyTransform2_Null ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.MultiplyTransform (null, MatrixOrder.Append);
+				Assert.Throws<ArgumentNullException>(() => pgb.MultiplyTransform (null, MatrixOrder.Append));
 			}
 		}
 
@@ -533,12 +517,11 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void MultiplyTransform_NonInvertible ()
 		{
 			using (Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30)) {
 				using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-					pgb.MultiplyTransform (noninvertible);
+					Assert.Throws<ArgumentException>(() => pgb.MultiplyTransform (noninvertible));
 				}
 			}
 		}
@@ -607,11 +590,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void RotateTransform_InvalidOrder ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.RotateTransform (720, (MatrixOrder) Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => pgb.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 			}
 		}
 
@@ -649,11 +631,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ScaleTransform_InvalidOrder ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => pgb.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 			}
 		}
 
@@ -692,38 +673,34 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_FocusTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetBlendTriangularShape (-1);
+				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (-1));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_FocusTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetBlendTriangularShape (1.01f);
+				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (1.01f));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_ScaleTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetBlendTriangularShape (1, -1);
+				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (1, -1));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetBlendTriangularShape_ScaleTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetBlendTriangularShape (1, 1.01f);
+				Assert.Throws<ArgumentException>(() => pgb.SetBlendTriangularShape (1, 1.01f));
 			}
 		}
 
@@ -762,38 +739,34 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_FocusTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetSigmaBellShape (-1);
+				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (-1));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_FocusTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetSigmaBellShape (1.01f);
+				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (1.01f));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_ScaleTooSmall ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetSigmaBellShape (1, -1);
+				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (1, -1));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetSigmaBellShape_ScaleTooBig ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.SetSigmaBellShape (1, 1.01f);
+				Assert.Throws<ArgumentException>(() => pgb.SetSigmaBellShape (1, 1.01f));
 			}
 		}
 
@@ -823,11 +796,10 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TranslateTransform_InvalidOrder ()
 		{
 			using (PathGradientBrush pgb = new PathGradientBrush (pts_2f, WrapMode.Clamp)) {
-				pgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => pgb.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 			}
 		}
 
@@ -877,37 +849,34 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Blend_Null ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (pts_2f);
 				using (PathGradientBrush pgb = new PathGradientBrush (gp)) {
-					pgb.Blend = null;
+					Assert.Throws<NullReferenceException>(() => pgb.Blend = null);
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void InterpolationColors_Null ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (pts_2f);
 				using (PathGradientBrush pgb = new PathGradientBrush (gp)) {
-					pgb.InterpolationColors = null;
+					Assert.Throws<NullReferenceException>(() => pgb.InterpolationColors = null);
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void SurroundColors_Null ()
 		{
 			using (GraphicsPath gp = new GraphicsPath ()) {
 				gp.AddLines (pts_2f);
 				using (PathGradientBrush pgb = new PathGradientBrush (gp)) {
-					pgb.SurroundColors = null;
+					Assert.Throws<NullReferenceException>(() => pgb.SurroundColors = null);
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestColorBlend.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestColorBlend.cs
@@ -98,7 +98,7 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void ColorBlend_Negative ()
 		{
-			Assert.Throws<OverflowException>(() => new ColorBlend (-1));
+			Assert.Throws<OverflowException> (() => new ColorBlend (-1));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestColorBlend.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestColorBlend.cs
@@ -96,10 +96,9 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (OverflowException))]
 		public void ColorBlend_Negative ()
 		{
-			ColorBlend cb = new ColorBlend (-1);
+			Assert.Throws<OverflowException>(() => new ColorBlend (-1));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestMatrix.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestMatrix.cs
@@ -85,19 +85,19 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void Constructor_Int_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix (rect, null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix (rect, null));
 		}
 
 		[Test]
 		public void Constructor_Int_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix (rect, new Point[0]));
+			Assert.Throws<ArgumentException> (() => new Matrix (rect, new Point[0]));
 		}
 
 		[Test]
 		public void Constructor_Int_4Point ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix (rect, new Point[4]));
+			Assert.Throws<ArgumentException> (() => new Matrix (rect, new Point[4]));
 		}
 
 		[Test]
@@ -117,19 +117,19 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void Constructor_Float_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix (rectf, null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix (rectf, null));
 		}
 
 		[Test]
 		public void Constructor_Float_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix (rectf, new PointF[0]));
+			Assert.Throws<ArgumentException> (() => new Matrix (rectf, new PointF[0]));
 		}
 
 		[Test]
 		public void Constructor_Float_2PointF ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix (rectf, new PointF[2]));
+			Assert.Throws<ArgumentException> (() => new Matrix (rectf, new PointF[2]));
 		}
 
 		[Test]
@@ -328,7 +328,7 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void Rotate_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().Rotate (180, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => new Matrix ().Rotate (180, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -348,13 +348,13 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void RotateAt_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().RotateAt (180, new PointF (10, 10), (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => new Matrix ().RotateAt (180, new PointF (10, 10), (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
 		public void Multiply_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix (10, 20, 30, 40, 50, 60).Multiply (null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix (10, 20, 30, 40, 50, 60).Multiply (null));
 		}
 
 		[Test]
@@ -374,7 +374,7 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void Multiply_Null_Order ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix (10, 20, 30, 40, 50, 60).Multiply (null, MatrixOrder.Append));
+			Assert.Throws<ArgumentNullException> (() => new Matrix (10, 20, 30, 40, 50, 60).Multiply (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -409,7 +409,7 @@ namespace MonoTests.System.Drawing.Drawing2D
 		public void Multiply_InvalidOrder ()
 		{
 			Matrix matrix = new Matrix (10, 20, 30, 40, 50, 60);
-			Assert.Throws<ArgumentException>(() => matrix.Multiply (new Matrix (10, 20, 30, 40, 50, 60), (MatrixOrder)Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => matrix.Multiply (new Matrix (10, 20, 30, 40, 50, 60), (MatrixOrder)Int32.MinValue));
 		}
 
 		[Test]
@@ -504,7 +504,7 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void Scale_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().Scale (2, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => new Matrix ().Scale (2, 1, (MatrixOrder) Int32.MinValue));
 		}
 		
 		[Test]
@@ -534,7 +534,7 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void Shear_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().Shear (-1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => new Matrix ().Shear (-1, 1, (MatrixOrder) Int32.MinValue));
 		}
 		
 		[Test]
@@ -560,25 +560,25 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void TransformPoints_Point_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformPoints ((Point[]) null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix ().TransformPoints ((Point[]) null));
 		}
 
 		[Test]
 		public void TransformPoints_PointF_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformPoints ((PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix ().TransformPoints ((PointF[]) null));
 		}
 
 		[Test]
 		public void TransformPoints_Point_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().TransformPoints (new Point[0]));
+			Assert.Throws<ArgumentException> (() => new Matrix ().TransformPoints (new Point[0]));
 		}
 
 		[Test]
 		public void TransformPoints_PointF_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().TransformPoints (new PointF[0]));
+			Assert.Throws<ArgumentException> (() => new Matrix ().TransformPoints (new PointF[0]));
 		}
 		
 		[Test]
@@ -604,25 +604,25 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void TransformVectors_Point_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformVectors ((Point[]) null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix ().TransformVectors ((Point[]) null));
 		}
 
 		[Test]
 		public void TransformVectors_PointF_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformVectors ((PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix ().TransformVectors ((PointF[]) null));
 		}
 
 		[Test]
 		public void TransformVectors_Point_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().TransformVectors (new Point[0]));
+			Assert.Throws<ArgumentException> (() => new Matrix ().TransformVectors (new Point[0]));
 		}
 
 		[Test]
 		public void TransformVectors_PointF_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().TransformVectors (new PointF[0]));
+			Assert.Throws<ArgumentException> (() => new Matrix ().TransformVectors (new PointF[0]));
 		}
 
 		[Test]
@@ -642,19 +642,19 @@ namespace MonoTests.System.Drawing.Drawing2D
 		[Test]
 		public void Translate_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().Translate (-1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => new Matrix ().Translate (-1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
 		public void VectorTransformPoints_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Matrix ().VectorTransformPoints ((Point[]) null));
+			Assert.Throws<ArgumentNullException> (() => new Matrix ().VectorTransformPoints ((Point[]) null));
 		}
 
 		[Test]
 		public void VectorTransformPoints_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Matrix ().VectorTransformPoints (new Point[0]));
+			Assert.Throws<ArgumentException> (() => new Matrix ().VectorTransformPoints (new Point[0]));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestMatrix.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestMatrix.cs
@@ -83,24 +83,21 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_Int_Null ()
 		{
-			new Matrix (rect, null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix (rect, null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_Int_Empty ()
 		{
-			new Matrix (rect, new Point[0]);
+			Assert.Throws<ArgumentException>(() => new Matrix (rect, new Point[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_Int_4Point ()
 		{
-			new Matrix (rect, new Point[4]);
+			Assert.Throws<ArgumentException>(() => new Matrix (rect, new Point[4]));
 		}
 
 		[Test]
@@ -118,24 +115,21 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_Float_Null ()
 		{
-			new Matrix (rectf, null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix (rectf, null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_Float_Empty ()
 		{
-			new Matrix (rectf, new PointF[0]);
+			Assert.Throws<ArgumentException>(() => new Matrix (rectf, new PointF[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_Float_2PointF ()
 		{
-			new Matrix (rectf, new PointF[2]);
+			Assert.Throws<ArgumentException>(() => new Matrix (rectf, new PointF[2]));
 		}
 
 		[Test]
@@ -332,10 +326,9 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Rotate_InvalidOrder ()
 		{
-			new Matrix ().Rotate (180, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => new Matrix ().Rotate (180, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -353,17 +346,15 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void RotateAt_InvalidOrder ()
 		{
-			new Matrix ().RotateAt (180, new PointF (10, 10), (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => new Matrix ().RotateAt (180, new PointF (10, 10), (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Multiply_Null ()
 		{
-			new Matrix (10, 20, 30, 40, 50, 60).Multiply (null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix (10, 20, 30, 40, 50, 60).Multiply (null));
 		}
 
 		[Test]
@@ -381,10 +372,9 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Multiply_Null_Order ()
 		{
-			new Matrix (10, 20, 30, 40, 50, 60).Multiply (null, MatrixOrder.Append);
+			Assert.Throws<ArgumentNullException>(() => new Matrix (10, 20, 30, 40, 50, 60).Multiply (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -416,11 +406,10 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Multiply_InvalidOrder ()
 		{
 			Matrix matrix = new Matrix (10, 20, 30, 40, 50, 60);
-			matrix.Multiply (new Matrix (10, 20, 30, 40, 50, 60), (MatrixOrder)Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => matrix.Multiply (new Matrix (10, 20, 30, 40, 50, 60), (MatrixOrder)Int32.MinValue));
 		}
 
 		[Test]
@@ -513,10 +502,9 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Scale_InvalidOrder ()
 		{
-			new Matrix ().Scale (2, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => new Matrix ().Scale (2, 1, (MatrixOrder) Int32.MinValue));
 		}
 		
 		[Test]
@@ -544,10 +532,9 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Shear_InvalidOrder ()
 		{
-			new Matrix ().Shear (-1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => new Matrix ().Shear (-1, 1, (MatrixOrder) Int32.MinValue));
 		}
 		
 		[Test]
@@ -571,31 +558,27 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TransformPoints_Point_Null ()
 		{
-			new Matrix ().TransformPoints ((Point[]) null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformPoints ((Point[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TransformPoints_PointF_Null ()
 		{
-			new Matrix ().TransformPoints ((PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformPoints ((PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TransformPoints_Point_Empty ()
 		{
-			new Matrix ().TransformPoints (new Point[0]);
+			Assert.Throws<ArgumentException>(() => new Matrix ().TransformPoints (new Point[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TransformPoints_PointF_Empty ()
 		{
-			new Matrix ().TransformPoints (new PointF[0]);
+			Assert.Throws<ArgumentException>(() => new Matrix ().TransformPoints (new PointF[0]));
 		}
 		
 		[Test]
@@ -619,31 +602,27 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TransformVectors_Point_Null ()
 		{
-			new Matrix ().TransformVectors ((Point[]) null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformVectors ((Point[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void TransformVectors_PointF_Null ()
 		{
-			new Matrix ().TransformVectors ((PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix ().TransformVectors ((PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TransformVectors_Point_Empty ()
 		{
-			new Matrix ().TransformVectors (new Point[0]);
+			Assert.Throws<ArgumentException>(() => new Matrix ().TransformVectors (new Point[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TransformVectors_PointF_Empty ()
 		{
-			new Matrix ().TransformVectors (new PointF[0]);
+			Assert.Throws<ArgumentException>(() => new Matrix ().TransformVectors (new PointF[0]));
 		}
 
 		[Test]
@@ -661,24 +640,21 @@ namespace MonoTests.System.Drawing.Drawing2D
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Translate_InvalidOrder ()
 		{
-			new Matrix ().Translate (-1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => new Matrix ().Translate (-1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void VectorTransformPoints_Null ()
 		{
-			new Matrix ().VectorTransformPoints ((Point[]) null);
+			Assert.Throws<ArgumentNullException>(() => new Matrix ().VectorTransformPoints ((Point[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void VectorTransformPoints_Empty ()
 		{
-			new Matrix ().VectorTransformPoints (new Point[0]);
+			Assert.Throws<ArgumentException>(() => new Matrix ().VectorTransformPoints (new Point[0]));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/MetafileTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/MetafileTest.cs
@@ -57,32 +57,28 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_Stream_Null ()
 		{
-			new Metafile ((Stream)null);
+			Assert.Throws<ArgumentException>(() => new Metafile ((Stream)null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Metafile_String_Null ()
 		{
-			new Metafile ((string) null);
+			Assert.Throws<ArgumentNullException>(() => new Metafile ((string) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_String_Empty ()
 		{
-			new Metafile (String.Empty);
+			Assert.Throws<ArgumentException>(() => new Metafile (String.Empty));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ExternalException))]
 		public void Metafile_String_FileDoesNotExists ()
 		{
 			string filename = getInFile ("telescope_02.wmf");
-			new Metafile (filename);
+			Assert.Throws<ExternalException>(() => new Metafile (filename));
 		}
 
 		[Test]
@@ -94,10 +90,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ExternalException))]
 		public void GetMetafileHeader_Bitmap ()
 		{
-			new Metafile (getInFile (Bitmap));
+			Assert.Throws<ExternalException>(() => new Metafile (getInFile (Bitmap)));
 		}
 
 		static public void Check_MetaHeader_WmfPlaceable (MetaHeader mh)
@@ -284,10 +279,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Static_GetMetafileHeader_Stream_Null ()
 		{
-			MetafileHeader header = Metafile.GetMetafileHeader ((Stream)null);
+			Assert.Throws<NullReferenceException>(() => Metafile.GetMetafileHeader ((Stream)null));
 		}
 
 		[Test]
@@ -301,10 +295,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Static_GetMetafileHeader_Filename_Null ()
 		{
-			MetafileHeader header = Metafile.GetMetafileHeader ((string) null);
+			Assert.Throws<ArgumentNullException>(() => Metafile.GetMetafileHeader ((string) null));
 		}
 
 		[Test]
@@ -332,14 +325,12 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Static_GetMetafileHeader_IntPtr_Zero ()
 		{
-			Metafile.GetMetafileHeader (IntPtr.Zero);
+			Assert.Throws<ArgumentException>(() => Metafile.GetMetafileHeader (IntPtr.Zero));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Static_GetMetafileHeader_IntPtr ()
 		{
 			string filename = MetafileTest.getInFile (MetafileTest.WmfPlaceable);
@@ -348,22 +339,20 @@ namespace MonoTests.System.Drawing.Imaging {
 				IntPtr hemf = mf.GetHenhmetafile ();
 				Assert.IsTrue (hemf != IntPtr.Zero, "GetHenhmetafile");
 
-				Metafile.GetMetafileHeader (hemf);
+				Assert.Throws<ArgumentException>(() => Metafile.GetMetafileHeader (hemf));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_IntPtrBool_Zero ()
 		{
-			new Metafile (IntPtr.Zero, false);
+			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, false));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_IntPtrEmfType_Zero ()
 		{
-			new Metafile (IntPtr.Zero, EmfType.EmfOnly);
+			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, EmfType.EmfOnly));
 		}
 
 		private void CheckEmptyHeader (Metafile mf, EmfType type)
@@ -407,10 +396,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_IntPtrEmfType_Invalid ()
 		{
-			Metafile_IntPtrEmfType ((EmfType)Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => Metafile_IntPtrEmfType ((EmfType)Int32.MinValue));
 		}
 
 		[Test]
@@ -432,10 +420,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_IntPtrRectangle_Zero ()
 		{
-			new Metafile (IntPtr.Zero, new Rectangle (1, 2, 3, 4));
+			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, new Rectangle (1, 2, 3, 4)));
 		}
 
 		[Test]
@@ -456,10 +443,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_IntPtrRectangleF_Zero ()
 		{
-			new Metafile (IntPtr.Zero, new RectangleF (1, 2, 3, 4));
+			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, new RectangleF (1, 2, 3, 4)));
 		}
 
 		[Test]
@@ -496,10 +482,9 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Metafile_StreamIntPtrEmfType_Null ()
 		{
-			Metafile_StreamEmfType (null, EmfType.EmfOnly);
+			Assert.Throws<NullReferenceException>(() => Metafile_StreamEmfType (null, EmfType.EmfOnly));
 		}
 
 		[Test]
@@ -511,11 +496,10 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Metafile_StreamIntPtrEmfType_Invalid ()
 		{
 			using (MemoryStream ms = new MemoryStream ()) {
-				Metafile_StreamEmfType (ms, (EmfType)Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => Metafile_StreamEmfType (ms, (EmfType)Int32.MinValue));
 			}
 		}
 
@@ -575,24 +559,21 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void CreateFilename_MultipleGraphics_EmfOnly ()
 		{
-			CreateFilename (EmfType.EmfOnly, false);
+			Assert.Throws<OutOfMemoryException>(() => CreateFilename (EmfType.EmfOnly, false));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void CreateFilename_MultipleGraphics_EmfPlusDual ()
 		{
-			CreateFilename (EmfType.EmfPlusDual, false);
+			Assert.Throws<OutOfMemoryException>(() => CreateFilename (EmfType.EmfPlusDual, false));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void CreateFilename_MultipleGraphics_EmfPlusOnly ()
 		{
-			CreateFilename (EmfType.EmfPlusOnly, false);
+			Assert.Throws<OutOfMemoryException>(() => CreateFilename (EmfType.EmfPlusOnly, false));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/MetafileTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/MetafileTest.cs
@@ -59,26 +59,26 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Metafile_Stream_Null ()
 		{
-			Assert.Throws<ArgumentException>(() => new Metafile ((Stream)null));
+			Assert.Throws<ArgumentException> (() => new Metafile ((Stream)null));
 		}
 
 		[Test]
 		public void Metafile_String_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Metafile ((string) null));
+			Assert.Throws<ArgumentNullException> (() => new Metafile ((string) null));
 		}
 
 		[Test]
 		public void Metafile_String_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => new Metafile (String.Empty));
+			Assert.Throws<ArgumentException> (() => new Metafile (String.Empty));
 		}
 
 		[Test]
 		public void Metafile_String_FileDoesNotExists ()
 		{
 			string filename = getInFile ("telescope_02.wmf");
-			Assert.Throws<ExternalException>(() => new Metafile (filename));
+			Assert.Throws<ExternalException> (() => new Metafile (filename));
 		}
 
 		[Test]
@@ -92,7 +92,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void GetMetafileHeader_Bitmap ()
 		{
-			Assert.Throws<ExternalException>(() => new Metafile (getInFile (Bitmap)));
+			Assert.Throws<ExternalException> (() => new Metafile (getInFile (Bitmap)));
 		}
 
 		static public void Check_MetaHeader_WmfPlaceable (MetaHeader mh)
@@ -281,7 +281,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Static_GetMetafileHeader_Stream_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => Metafile.GetMetafileHeader ((Stream)null));
+			Assert.Throws<NullReferenceException> (() => Metafile.GetMetafileHeader ((Stream)null));
 		}
 
 		[Test]
@@ -297,7 +297,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Static_GetMetafileHeader_Filename_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => Metafile.GetMetafileHeader ((string) null));
+			Assert.Throws<ArgumentNullException> (() => Metafile.GetMetafileHeader ((string) null));
 		}
 
 		[Test]
@@ -327,7 +327,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Static_GetMetafileHeader_IntPtr_Zero ()
 		{
-			Assert.Throws<ArgumentException>(() => Metafile.GetMetafileHeader (IntPtr.Zero));
+			Assert.Throws<ArgumentException> (() => Metafile.GetMetafileHeader (IntPtr.Zero));
 		}
 
 		[Test]
@@ -339,20 +339,20 @@ namespace MonoTests.System.Drawing.Imaging {
 				IntPtr hemf = mf.GetHenhmetafile ();
 				Assert.IsTrue (hemf != IntPtr.Zero, "GetHenhmetafile");
 
-				Assert.Throws<ArgumentException>(() => Metafile.GetMetafileHeader (hemf));
+				Assert.Throws<ArgumentException> (() => Metafile.GetMetafileHeader (hemf));
 			}
 		}
 
 		[Test]
 		public void Metafile_IntPtrBool_Zero ()
 		{
-			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, false));
+			Assert.Throws<ArgumentException> (() => new Metafile (IntPtr.Zero, false));
 		}
 
 		[Test]
 		public void Metafile_IntPtrEmfType_Zero ()
 		{
-			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, EmfType.EmfOnly));
+			Assert.Throws<ArgumentException> (() => new Metafile (IntPtr.Zero, EmfType.EmfOnly));
 		}
 
 		private void CheckEmptyHeader (Metafile mf, EmfType type)
@@ -398,7 +398,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Metafile_IntPtrEmfType_Invalid ()
 		{
-			Assert.Throws<ArgumentException>(() => Metafile_IntPtrEmfType ((EmfType)Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => Metafile_IntPtrEmfType ((EmfType)Int32.MinValue));
 		}
 
 		[Test]
@@ -422,7 +422,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Metafile_IntPtrRectangle_Zero ()
 		{
-			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, new Rectangle (1, 2, 3, 4)));
+			Assert.Throws<ArgumentException> (() => new Metafile (IntPtr.Zero, new Rectangle (1, 2, 3, 4)));
 		}
 
 		[Test]
@@ -445,7 +445,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Metafile_IntPtrRectangleF_Zero ()
 		{
-			Assert.Throws<ArgumentException>(() => new Metafile (IntPtr.Zero, new RectangleF (1, 2, 3, 4)));
+			Assert.Throws<ArgumentException> (() => new Metafile (IntPtr.Zero, new RectangleF (1, 2, 3, 4)));
 		}
 
 		[Test]
@@ -484,7 +484,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Metafile_StreamIntPtrEmfType_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => Metafile_StreamEmfType (null, EmfType.EmfOnly));
+			Assert.Throws<NullReferenceException> (() => Metafile_StreamEmfType (null, EmfType.EmfOnly));
 		}
 
 		[Test]
@@ -499,7 +499,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void Metafile_StreamIntPtrEmfType_Invalid ()
 		{
 			using (MemoryStream ms = new MemoryStream ()) {
-				Assert.Throws<ArgumentException>(() => Metafile_StreamEmfType (ms, (EmfType)Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => Metafile_StreamEmfType (ms, (EmfType)Int32.MinValue));
 			}
 		}
 
@@ -561,19 +561,19 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void CreateFilename_MultipleGraphics_EmfOnly ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => CreateFilename (EmfType.EmfOnly, false));
+			Assert.Throws<OutOfMemoryException> (() => CreateFilename (EmfType.EmfOnly, false));
 		}
 
 		[Test]
 		public void CreateFilename_MultipleGraphics_EmfPlusDual ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => CreateFilename (EmfType.EmfPlusDual, false));
+			Assert.Throws<OutOfMemoryException> (() => CreateFilename (EmfType.EmfPlusDual, false));
 		}
 
 		[Test]
 		public void CreateFilename_MultipleGraphics_EmfPlusOnly ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => CreateFilename (EmfType.EmfPlusOnly, false));
+			Assert.Throws<OutOfMemoryException> (() => CreateFilename (EmfType.EmfPlusOnly, false));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
@@ -42,19 +42,19 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Constructor_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => new ColorMatrix (null));
+			Assert.Throws<NullReferenceException> (() => new ColorMatrix (null));
 		}
 
 		[Test]
 		public void Constructor_TooSmallArraySize ()
 		{
-			Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix (new float[][] { }));
+			Assert.Throws<IndexOutOfRangeException> (() => new ColorMatrix (new float[][] { }));
 		}
 
 		[Test]
 		public void Constructor_TooWideArraySize ()
 		{
-			Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix (new float[][] {
+			Assert.Throws<IndexOutOfRangeException> (() => new ColorMatrix (new float[][] {
 				new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f }
 			}));
 		}
@@ -62,7 +62,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		[Test]
 		public void Constructor_TooTallArraySize ()
 		{
-			Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix (new float[][] {
+			Assert.Throws<IndexOutOfRangeException> (() => new ColorMatrix (new float[][] {
 				new float[] { 0.0f },
 				new float[] { 1.0f },
 				new float[] { 2.0f },
@@ -122,7 +122,7 @@ namespace MonoTests.System.Drawing.Imaging {
 				new float[] { 4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f },
 				new float[] { 5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f }
 			});
-			Assert.Throws<IndexOutOfRangeException>(() => Assert.AreEqual (5.5f, cm[5,5], "out"));
+			Assert.Throws<IndexOutOfRangeException> (() => Assert.AreEqual (5.5f, cm[5,5], "out"));
 		}
 
 		[Test]
@@ -164,10 +164,10 @@ namespace MonoTests.System.Drawing.Imaging {
 		{
 			ColorMatrix cm = new ColorMatrix (new float[][] {
 				new float[] {0.393f, 0.349f, 0.272f, 0, 0},
-			        new float[] {0.769f, 0.686f, 0.534f, 0, 0},
-			        new float[] {0.189f, 0.168f, 0.131f, 0, 0},
-			        new float[] {     0,      0,      0, 1, 0},
-			        new float[] {     0,      0,      0, 0, 1}
+					new float[] {0.769f, 0.686f, 0.534f, 0, 0},
+					new float[] {0.189f, 0.168f, 0.131f, 0, 0},
+					new float[] {	 0,	  0,	  0, 1, 0},
+					new float[] {	 0,	  0,	  0, 0, 1}
 			});
 
 			Assert.AreEqual (0.393f, cm.Matrix00, "00");

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
@@ -40,40 +40,36 @@ namespace MonoTests.System.Drawing.Imaging {
 	public class ColorMatrixTest {
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Constructor_Null ()
 		{
-			new ColorMatrix (null);
+			Assert.Throws<NullReferenceException>(() => new ColorMatrix (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (IndexOutOfRangeException))]
 		public void Constructor_TooSmallArraySize ()
 		{
-			new ColorMatrix (new float[][] { });
+			Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix (new float[][] { }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (IndexOutOfRangeException))]
 		public void Constructor_TooWideArraySize ()
 		{
-			new ColorMatrix (new float[][] {
+			Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix (new float[][] {
 				new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f }
-			});
+			}));
 		}
 
 		[Test]
-		[ExpectedException (typeof (IndexOutOfRangeException))]
 		public void Constructor_TooTallArraySize ()
 		{
-			new ColorMatrix (new float[][] {
+			Assert.Throws<IndexOutOfRangeException>(() => new ColorMatrix (new float[][] {
 				new float[] { 0.0f },
 				new float[] { 1.0f },
 				new float[] { 2.0f },
 				new float[] { 3.0f },
 				new float[] { 4.0f },
 				new float[] { 5.0f }
-			});
+			}));
 		}
 
 		[Test]
@@ -116,7 +112,6 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (IndexOutOfRangeException))]
 		public void TooBigItems ()
 		{
 			ColorMatrix cm = new ColorMatrix (new float[][] {
@@ -127,7 +122,7 @@ namespace MonoTests.System.Drawing.Imaging {
 				new float[] { 4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f },
 				new float[] { 5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f }
 			});
-			Assert.AreEqual (5.5f, cm[5,5], "out");
+			Assert.Throws<IndexOutOfRangeException>(() => Assert.AreEqual (5.5f, cm[5,5], "out"));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
@@ -164,10 +164,10 @@ namespace MonoTests.System.Drawing.Imaging {
 		{
 			ColorMatrix cm = new ColorMatrix (new float[][] {
 				new float[] {0.393f, 0.349f, 0.272f, 0, 0},
-					new float[] {0.769f, 0.686f, 0.534f, 0, 0},
-					new float[] {0.189f, 0.168f, 0.131f, 0, 0},
-					new float[] {	 0,	  0,	  0, 1, 0},
-					new float[] {	 0,	  0,	  0, 0, 1}
+				new float[] {0.769f, 0.686f, 0.534f, 0, 0},
+				new float[] {0.189f, 0.168f, 0.131f, 0, 0},
+				new float[] {     0,      0,      0, 1, 0},
+				new float[] {     0,      0,      0, 0, 1}
 			});
 
 			Assert.AreEqual (0.393f, cm.Matrix00, "00");

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestColorMatrix.cs
@@ -122,7 +122,7 @@ namespace MonoTests.System.Drawing.Imaging {
 				new float[] { 4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f },
 				new float[] { 5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f }
 			});
-			Assert.Throws<IndexOutOfRangeException> (() => Assert.AreEqual (5.5f, cm[5,5], "out"));
+			Assert.Throws<IndexOutOfRangeException> (() => { var x = cm[5, 5]; });
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
@@ -177,7 +177,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_Null ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (null));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (null));
 			}
 		}
 
@@ -198,7 +198,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_Default_Any ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Any));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Any));
 			}
 		}
 
@@ -206,7 +206,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_Default_Count ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Count));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Count));
 			}
 		}
 
@@ -214,7 +214,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays));
 			}
 		}
 
@@ -222,7 +222,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays_Any ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Any));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Any));
 			}
 		}
 
@@ -230,7 +230,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays_Bitmap ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Bitmap));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Bitmap));
 			}
 		}
 
@@ -238,7 +238,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays_Brush ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Brush));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Brush));
 			}
 		}
 
@@ -246,7 +246,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays_Count ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Count));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Count));
 			}
 		}
 
@@ -254,7 +254,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays_Default ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Default));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Default));
 			}
 		}
 
@@ -262,7 +262,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays_Pen ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Pen));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Pen));
 			}
 		}
 
@@ -270,7 +270,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_AltGrays_Text ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Text));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Text));
 			}
 		}
 
@@ -291,7 +291,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_SkipGrays_Any ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Any));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Any));
 			}
 		}
 
@@ -299,7 +299,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_SkipGrays_Count ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Count));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Count));
 			}
 		}
 
@@ -307,7 +307,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_InvalidFlag ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, (ColorMatrixFlag) Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, (ColorMatrixFlag) Int32.MinValue));
 			}
 		}
 
@@ -315,7 +315,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_InvalidType()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType)Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType)Int32.MinValue));
 			}
 		}
 
@@ -323,7 +323,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrices_Null_ColorMatrix ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (null, global_color_matrix));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrices (null, global_color_matrix));
 			}
 		}
 
@@ -341,7 +341,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrices_ColorMatrix_Null_AltGrays ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (global_color_matrix, null, ColorMatrixFlag.AltGrays));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrices (global_color_matrix, null, ColorMatrixFlag.AltGrays));
 			}
 		}
 
@@ -386,7 +386,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrices_InvalidFlags ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (global_color_matrix, global_color_matrix, (ColorMatrixFlag) Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrices (global_color_matrix, global_color_matrix, (ColorMatrixFlag) Int32.MinValue));
 			}
 		}
 
@@ -394,7 +394,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrices_InvalidType ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (global_color_matrix, global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType) Int32.MinValue));
+				Assert.Throws<ArgumentException> (() => ia.SetColorMatrices (global_color_matrix, global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType) Int32.MinValue));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
@@ -291,7 +291,7 @@ namespace MonoTests.System.Drawing.Imaging {
 		public void SetColorMatrix_SkipGrays_Any ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				Assert.Throws<ArgumentException<(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Any));
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Any));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
@@ -174,11 +174,10 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_Null ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (null);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (null));
 			}
 		}
 
@@ -196,92 +195,82 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_Default_Any ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Any);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Any));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_Default_Count ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Count);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, ColorAdjustType.Count));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays_Any ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Any);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Any));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays_Bitmap ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Bitmap);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Bitmap));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays_Brush ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Brush);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Brush));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays_Count ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Count);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Count));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays_Default ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Default);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Default));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays_Pen ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Pen);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Pen));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_AltGrays_Text ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Text);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.AltGrays, ColorAdjustType.Text));
 			}
 		}
 
@@ -299,47 +288,42 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_SkipGrays_Any ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Any);
+				Assert.Throws<ArgumentException<(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Any));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_SkipGrays_Count ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Count);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.SkipGrays, ColorAdjustType.Count));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_InvalidFlag ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, (ColorMatrixFlag) Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, (ColorMatrixFlag) Int32.MinValue));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrix_InvalidType()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType)Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrix (global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType)Int32.MinValue));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrices_Null_ColorMatrix ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrices (null, global_color_matrix);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (null, global_color_matrix));
 			}
 		}
 
@@ -354,11 +338,10 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrices_ColorMatrix_Null_AltGrays ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrices (global_color_matrix, null, ColorMatrixFlag.AltGrays);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (global_color_matrix, null, ColorMatrixFlag.AltGrays));
 			}
 		}
 
@@ -400,20 +383,18 @@ namespace MonoTests.System.Drawing.Imaging {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrices_InvalidFlags ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrices (global_color_matrix, global_color_matrix, (ColorMatrixFlag) Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (global_color_matrix, global_color_matrix, (ColorMatrixFlag) Int32.MinValue));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetColorMatrices_InvalidType ()
 		{
 			using (ImageAttributes ia = new ImageAttributes ()) {
-				ia.SetColorMatrices (global_color_matrix, global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType) Int32.MinValue);
+				Assert.Throws<ArgumentException>(() => ia.SetColorMatrices (global_color_matrix, global_color_matrix, ColorMatrixFlag.Default, (ColorAdjustType) Int32.MinValue));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionCas.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionCas.cs
@@ -52,31 +52,28 @@ namespace MonoCasTests.System.Drawing.Text {
 		// TODO - tests for AddFontFile
 
 		[Test]
-		[ExpectedException (typeof (SecurityException))]
 		[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 		public void AddMemoryFont_Deny_UnmanagedCode () 
 		{
-			new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024);
+			Assert.Throws<SecurityException>(() => new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[SecurityPermission (SecurityAction.PermitOnly, UnmanagedCode = true)]
 		public void AddMemoryFont_PermitOnly_UnmanagedCode ()
 		{
-			new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024);
+			Assert.Throws<ArgumentException>(() => new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024));
 		}
 
 		// yes, that fails with FileNotFoundException ;-)
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
 		[SecurityPermission (SecurityAction.PermitOnly, UnmanagedCode = true)]
 		public void AddMemoryFont_NegativeLength ()
 		{
 			IntPtr ptr = Marshal.AllocHGlobal (1024);
 			try {
-				new PrivateFontCollection ().AddMemoryFont (ptr, -1024);
+				Assert.Throws<FileNotFoundException>(() => new PrivateFontCollection ().AddMemoryFont (ptr, -1024));
 			}
 			finally {
 				Marshal.FreeHGlobal (ptr);
@@ -84,13 +81,12 @@ namespace MonoCasTests.System.Drawing.Text {
 		}
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
 		[SecurityPermission (SecurityAction.PermitOnly, UnmanagedCode = true)]
 		public void AddMemoryFont_InvalidData ()
 		{
 			IntPtr ptr = Marshal.AllocHGlobal (1024);
 			try {
-				new PrivateFontCollection ().AddMemoryFont (ptr, 1024);
+				Assert.Throws<FileNotFoundException>(() => new PrivateFontCollection ().AddMemoryFont (ptr, 1024));
 			}
 			finally {
 				Marshal.FreeHGlobal (ptr);

--- a/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionCas.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionCas.cs
@@ -55,14 +55,14 @@ namespace MonoCasTests.System.Drawing.Text {
 		[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 		public void AddMemoryFont_Deny_UnmanagedCode () 
 		{
-			Assert.Throws<SecurityException>(() => new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024));
+			Assert.Throws<SecurityException> (() => new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024));
 		}
 
 		[Test]
 		[SecurityPermission (SecurityAction.PermitOnly, UnmanagedCode = true)]
 		public void AddMemoryFont_PermitOnly_UnmanagedCode ()
 		{
-			Assert.Throws<ArgumentException>(() => new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024));
+			Assert.Throws<ArgumentException> (() => new PrivateFontCollection ().AddMemoryFont (IntPtr.Zero, 1024));
 		}
 
 		// yes, that fails with FileNotFoundException ;-)
@@ -73,7 +73,7 @@ namespace MonoCasTests.System.Drawing.Text {
 		{
 			IntPtr ptr = Marshal.AllocHGlobal (1024);
 			try {
-				Assert.Throws<FileNotFoundException>(() => new PrivateFontCollection ().AddMemoryFont (ptr, -1024));
+				Assert.Throws<FileNotFoundException> (() => new PrivateFontCollection ().AddMemoryFont (ptr, -1024));
 			}
 			finally {
 				Marshal.FreeHGlobal (ptr);
@@ -86,7 +86,7 @@ namespace MonoCasTests.System.Drawing.Text {
 		{
 			IntPtr ptr = Marshal.AllocHGlobal (1024);
 			try {
-				Assert.Throws<FileNotFoundException>(() => new PrivateFontCollection ().AddMemoryFont (ptr, 1024));
+				Assert.Throws<FileNotFoundException> (() => new PrivateFontCollection ().AddMemoryFont (ptr, 1024));
 			}
 			finally {
 				Marshal.FreeHGlobal (ptr);

--- a/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
@@ -51,14 +51,14 @@ namespace MonoTests.System.Drawing.Text {
 		[Test]
 		public void AddFontFile_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new PrivateFontCollection ().AddFontFile (null));
+			Assert.Throws<ArgumentNullException> (() => new PrivateFontCollection ().AddFontFile (null));
 		}
 
 		[Test]
 		public void AddFontFile_Empty ()
 		{
 			// badly formetted filename
-			Assert.Throws<ArgumentException>(() => new PrivateFontCollection ().AddFontFile (String.Empty));
+			Assert.Throws<ArgumentException> (() => new PrivateFontCollection ().AddFontFile (String.Empty));
 		}
 
 		[Test]
@@ -68,7 +68,7 @@ namespace MonoTests.System.Drawing.Text {
 			string file = Path.GetTempFileName ();
 			Assert.IsTrue (File.Exists (file), "Exists");
 			// even if the file exists....
-			Assert.Throws<FileNotFoundException>(() => new PrivateFontCollection ().AddFontFile (file));
+			Assert.Throws<FileNotFoundException> (() => new PrivateFontCollection ().AddFontFile (file));
 		}
 
 		// tests for AddMemoryFont are available in the CAS unit tests
@@ -78,7 +78,7 @@ namespace MonoTests.System.Drawing.Text {
 		{
 			PrivateFontCollection pfc = new PrivateFontCollection ();
 			pfc.Dispose ();
-			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (pfc.Families));
+			Assert.Throws<ArgumentException> (() => Assert.IsNotNull (pfc.Families));
 			// no it's not a ObjectDisposedException
 		}
 	}

--- a/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
@@ -49,40 +49,36 @@ namespace MonoTests.System.Drawing.Text {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void AddFontFile_Null ()
 		{
-			new PrivateFontCollection ().AddFontFile (null);
+			Assert.Throws<ArgumentNullException>(() => new PrivateFontCollection ().AddFontFile (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void AddFontFile_Empty ()
 		{
 			// badly formetted filename
-			new PrivateFontCollection ().AddFontFile (String.Empty);
+			Assert.Throws<ArgumentException>(() => new PrivateFontCollection ().AddFontFile (String.Empty));
 		}
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
 		[Category ("NotWorking")] // it seems fontconfig doesn't validate on add...
 		public void AddFontFile_NotAFontFile ()
 		{
 			string file = Path.GetTempFileName ();
 			Assert.IsTrue (File.Exists (file), "Exists");
 			// even if the file exists....
-			new PrivateFontCollection ().AddFontFile (file);
+			Assert.Throws<FileNotFoundException>(() => new PrivateFontCollection ().AddFontFile (file));
 		}
 
 		// tests for AddMemoryFont are available in the CAS unit tests
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_Family ()
 		{
 			PrivateFontCollection pfc = new PrivateFontCollection ();
 			pfc.Dispose ();
-			Assert.IsNotNull (pfc.Families);
+			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (pfc.Families));
 			// no it's not a ObjectDisposedException
 		}
 	}

--- a/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
@@ -78,7 +78,7 @@ namespace MonoTests.System.Drawing.Text {
 		{
 			PrivateFontCollection pfc = new PrivateFontCollection ();
 			pfc.Dispose ();
-			Assert.Throws<ArgumentException> (() => Assert.IsNotNull (pfc.Families));
+			Assert.Throws<ArgumentException> (() => { var x = pfc.Families; });
 			// no it's not a ObjectDisposedException
 		}
 	}

--- a/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
@@ -167,72 +167,63 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFrom_x1 ()
 		{
-				colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "10, 20");
+				Assert.Throws<ArgumentException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "10, 20"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFrom_x2 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "-10, 20, 30");
+			Assert.Throws<ArgumentException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "-10, 20, 30"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFrom_x3 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
-					"1, 1, 1, 1, 1");
+			Assert.Throws<ArgumentException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+					"1, 1, 1, 1, 1"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (Exception))]
 		public void ConvertFrom_x4 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
-				"*1, 1");
+			Assert.Throws<Exception>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+				"*1, 1"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_x5 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
-					new Point (10, 10));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+					new Point (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_x6 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
-					new PointF (10, 10));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+					new PointF (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_x7 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
-					new Size (10, 10));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+					new Size (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_x8 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
-					new SizeF (10, 10));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+					new SizeF (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_x9 ()
 		{
-			colconv.ConvertFrom (null, CultureInfo.InvariantCulture, 0x10);
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, 0x10));
 		}
 
 		[Test]
@@ -264,43 +255,38 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_x1 ()
 		{
-			colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
-					typeof (Color));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+					typeof (Color)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_x2 ()
 		{
-			colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
-					typeof (SizeF));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+					typeof (SizeF)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_x3 ()
 		{
-			colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
-					typeof (Point));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+					typeof (Point)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_x4 ()
 		{
-			colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
-					typeof (PointF));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+					typeof (PointF)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_x5 ()
 		{
-			colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
-					typeof (int));
+			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+					typeof (int)));
 		}
 
 		[Test]
@@ -351,10 +337,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromInvariantString_InvalidComponentCount ()
 		{
-			colconv.ConvertFromInvariantString ("1, 2, 3, 4, 5");
+			Assert.Throws<ArgumentException>(() => colconv.ConvertFromInvariantString ("1, 2, 3, 4, 5"));
 		}
 
 		[Test]
@@ -378,12 +363,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromString_InvalidComponentCount ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			colconv.ConvertFromString (string.Format (culture,
-				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator[0]));
+			Assert.Throws<ArgumentException>(() => colconv.ConvertFromString (string.Format (culture,
+				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator[0])));
 		}
 
 		[Test]
@@ -428,10 +412,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (Exception))]
 		public void ConvertFromString_FromHtml_PoundTooLarge ()
 		{
-			colconv.ConvertFromString ("#100000000");
+			Assert.Throws<Exception>(() => colconv.ConvertFromString ("#100000000"));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
@@ -169,61 +169,61 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void ConvertFrom_x1 ()
 		{
-				Assert.Throws<ArgumentException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "10, 20"));
+				Assert.Throws<ArgumentException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "10, 20"));
 		}
 
 		[Test]
 		public void ConvertFrom_x2 ()
 		{
-			Assert.Throws<ArgumentException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "-10, 20, 30"));
+			Assert.Throws<ArgumentException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "-10, 20, 30"));
 		}
 
 		[Test]
 		public void ConvertFrom_x3 ()
 		{
-			Assert.Throws<ArgumentException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+			Assert.Throws<ArgumentException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
 					"1, 1, 1, 1, 1"));
 		}
 
 		[Test]
 		public void ConvertFrom_x4 ()
 		{
-			Assert.Throws<Exception>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+			Assert.Throws<Exception> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
 				"*1, 1"));
 		}
 
 		[Test]
 		public void ConvertFrom_x5 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
 					new Point (10, 10)));
 		}
 
 		[Test]
 		public void ConvertFrom_x6 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
 					new PointF (10, 10)));
 		}
 
 		[Test]
 		public void ConvertFrom_x7 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
 					new Size (10, 10)));
 		}
 
 		[Test]
 		public void ConvertFrom_x8 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture,
 					new SizeF (10, 10)));
 		}
 
 		[Test]
 		public void ConvertFrom_x9 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, 0x10));
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, 0x10));
 		}
 
 		[Test]
@@ -257,35 +257,35 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void ConvertTo_x1 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
 					typeof (Color)));
 		}
 
 		[Test]
 		public void ConvertTo_x2 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
 					typeof (SizeF)));
 		}
 
 		[Test]
 		public void ConvertTo_x3 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
 					typeof (Point)));
 		}
 
 		[Test]
 		public void ConvertTo_x4 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
 					typeof (PointF)));
 		}
 
 		[Test]
 		public void ConvertTo_x5 ()
 		{
-			Assert.Throws<NotSupportedException>(() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
+			Assert.Throws<NotSupportedException> (() => colconv.ConvertTo (null, CultureInfo.InvariantCulture, col,
 					typeof (int)));
 		}
 
@@ -339,7 +339,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void ConvertFromInvariantString_InvalidComponentCount ()
 		{
-			Assert.Throws<ArgumentException>(() => colconv.ConvertFromInvariantString ("1, 2, 3, 4, 5"));
+			Assert.Throws<ArgumentException> (() => colconv.ConvertFromInvariantString ("1, 2, 3, 4, 5"));
 		}
 
 		[Test]
@@ -366,7 +366,7 @@ namespace MonoTests.System.Drawing {
 		public void ConvertFromString_InvalidComponentCount ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			Assert.Throws<ArgumentException>(() => colconv.ConvertFromString (string.Format (culture,
+			Assert.Throws<ArgumentException> (() => colconv.ConvertFromString (string.Format (culture,
 				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator[0])));
 		}
 
@@ -414,7 +414,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void ConvertFromString_FromHtml_PoundTooLarge ()
 		{
-			Assert.Throws<Exception>(() => colconv.ConvertFromString ("#100000000"));
+			Assert.Throws<Exception> (() => colconv.ConvertFromString ("#100000000"));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
@@ -169,7 +169,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void ConvertFrom_x1 ()
 		{
-				Assert.Throws<ArgumentException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "10, 20"));
+			Assert.Throws<ArgumentException> (() => colconv.ConvertFrom (null, CultureInfo.InvariantCulture, "10, 20"));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/ColorTranslator.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/ColorTranslator.cs
@@ -84,24 +84,21 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (Exception))]
 		public void FromHtml_PoundNegative ()
 		{
-			ColorTranslator.FromHtml ("#-1");
+            Assert.Throws<Exception>(() => ColorTranslator.FromHtml ("#-1"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (Exception))]
 		public void FromHtml_PoundTooLarge ()
 		{
-			ColorTranslator.FromHtml ("#100000000");
+			Assert.Throws<Exception>(() => ColorTranslator.FromHtml ("#100000000"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (Exception))]
 		public void FromHtml_Unknown ()
 		{
-			ColorTranslator.FromHtml ("unknown-color-test");
+			Assert.Throws<Exception>(() => ColorTranslator.FromHtml ("unknown-color-test"));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/ColorTranslator.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/ColorTranslator.cs
@@ -86,19 +86,19 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void FromHtml_PoundNegative ()
 		{
-            Assert.Throws<Exception>(() => ColorTranslator.FromHtml ("#-1"));
+			Assert.Throws<Exception> (() => ColorTranslator.FromHtml ("#-1"));
 		}
 
 		[Test]
 		public void FromHtml_PoundTooLarge ()
 		{
-			Assert.Throws<Exception>(() => ColorTranslator.FromHtml ("#100000000"));
+			Assert.Throws<Exception> (() => ColorTranslator.FromHtml ("#100000000"));
 		}
 
 		[Test]
 		public void FromHtml_Unknown ()
 		{
-			Assert.Throws<Exception>(() => ColorTranslator.FromHtml ("unknown-color-test"));
+			Assert.Throws<Exception> (() => ColorTranslator.FromHtml ("unknown-color-test"));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
@@ -61,14 +61,14 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void FontFamily_String_Null ()
 		{
-			Assert.Throws<ArgumentException>(() => new FontFamily (null));
+			Assert.Throws<ArgumentException> (() => new FontFamily (null));
 		}
 
 		[Test]
 		[Category ("NotWorking")] // libgdiplus/fontconfig always return something
 		public void FontFamily_String_Empty ()
 		{
-            Assert.Throws<ArgumentException>(() => new FontFamily (String.Empty));
+			Assert.Throws<ArgumentException> (() => new FontFamily (String.Empty));
 		}
 
 		private void CheckMono (FontFamily ff)
@@ -110,7 +110,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void FontFamily_String_PrivateFontCollection ()
 		{
-            Assert.Throws<ArgumentException>(() => new FontFamily (name, new PrivateFontCollection ()));
+			Assert.Throws<ArgumentException> (() => new FontFamily (name, new PrivateFontCollection ()));
 		}
 
 		[Test]
@@ -178,7 +178,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void GetFamilies_Null ()
 		{
-            Assert.Throws<ArgumentNullException>(() => FontFamily.GetFamilies (null));
+			Assert.Throws<ArgumentNullException> (() => FontFamily.GetFamilies (null));
 		}
 
 		[Test]
@@ -201,7 +201,7 @@ namespace MonoTests.System.Drawing {
 		{
 			FontFamily ff = FontFamily.GenericMonospace;
 			ff.Dispose ();
-            Assert.Throws<ArgumentException>(() => Assert.AreEqual (name, ff.Name, "Name"));
+			Assert.Throws<ArgumentException> (() => Assert.AreEqual (name, ff.Name, "Name"));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
@@ -201,7 +201,7 @@ namespace MonoTests.System.Drawing {
 		{
 			FontFamily ff = FontFamily.GenericMonospace;
 			ff.Dispose ();
-			Assert.Throws<ArgumentException> (() => Assert.AreEqual (name, ff.Name, "Name"));
+			Assert.Throws<ArgumentException> (() => { var x = ff.Name; });
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
@@ -59,18 +59,16 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FontFamily_String_Null ()
 		{
-			new FontFamily (null);
+			Assert.Throws<ArgumentException>(() => new FontFamily (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[Category ("NotWorking")] // libgdiplus/fontconfig always return something
 		public void FontFamily_String_Empty ()
 		{
-			new FontFamily (String.Empty);
+            Assert.Throws<ArgumentException>(() => new FontFamily (String.Empty));
 		}
 
 		private void CheckMono (FontFamily ff)
@@ -110,10 +108,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FontFamily_String_PrivateFontCollection ()
 		{
-			new FontFamily (name, new PrivateFontCollection ());
+            Assert.Throws<ArgumentException>(() => new FontFamily (name, new PrivateFontCollection ()));
 		}
 
 		[Test]
@@ -179,10 +176,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void GetFamilies_Null ()
 		{
-			FontFamily.GetFamilies (null);
+            Assert.Throws<ArgumentNullException>(() => FontFamily.GetFamilies (null));
 		}
 
 		[Test]
@@ -201,12 +197,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_UseAfter ()
 		{
 			FontFamily ff = FontFamily.GenericMonospace;
 			ff.Dispose ();
-			Assert.AreEqual (name, ff.Name, "Name");
+            Assert.Throws<ArgumentException>(() => Assert.AreEqual (name, ff.Name, "Name"));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
@@ -911,7 +911,6 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
 		public void GdipLoadImageFromFile_FileNotFound ()
 		{
 			string filename = "filenotfound";
@@ -921,11 +920,10 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (IntPtr.Zero, image, "image handle");
 
 			// this doesn't throw a OutOfMemoryException
-			Image.FromFile (filename);
+			Assert.Throws<FileNotFoundException>(() => Image.FromFile (filename));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void GdipCreateBitmapFromFile_FileNotFound ()
 		{
 			string filename = "filenotfound";
@@ -934,7 +932,7 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (Status.InvalidParameter, GDIPlus.GdipCreateBitmapFromFile (filename, out bitmap), "GdipCreateBitmapFromFile");
 			Assert.AreEqual (IntPtr.Zero, bitmap, "bitmap handle");
 
-			new Bitmap (filename);
+			Assert.Throws<ArgumentException>(() => new Bitmap (filename));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
@@ -920,7 +920,7 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (IntPtr.Zero, image, "image handle");
 
 			// this doesn't throw a OutOfMemoryException
-			Assert.Throws<FileNotFoundException>(() => Image.FromFile (filename));
+			Assert.Throws<FileNotFoundException> (() => Image.FromFile (filename));
 		}
 
 		[Test]
@@ -932,7 +932,7 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (Status.InvalidParameter, GDIPlus.GdipCreateBitmapFromFile (filename, out bitmap), "GdipCreateBitmapFromFile");
 			Assert.AreEqual (IntPtr.Zero, bitmap, "bitmap handle");
 
-			Assert.Throws<ArgumentException>(() => new Bitmap (filename));
+			Assert.Throws<ArgumentException> (() => new Bitmap (filename));
 		}
 
 		[Test]
@@ -1181,7 +1181,7 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (Status.Ok,
 					 GDIPlus.GdipDrawCurveI (graphics, pen,
 								 new Point [] { new Point (1, 1),
-										new Point (2, 2) }, 2),
+									new Point (2, 2) }, 2),
 					 "DrawCurve with 2 pts");
 
 			// DrawClosedCurve
@@ -1191,12 +1191,12 @@ namespace MonoTests.System.Drawing {
 					 "DrawClosedCurve with no pts");
 			Assert.AreEqual (Status.InvalidParameter,
 					 GDIPlus.GdipDrawClosedCurveI (graphics, pen,
-								       new Point [] { new Point (1, 1) }, 1),
+										new Point [] { new Point (1, 1) }, 1),
 					 "DrawClosedCurve with 1 pt");
 			Assert.AreEqual (Status.InvalidParameter,
 					 GDIPlus.GdipDrawClosedCurveI (graphics, pen,
-								       new Point [] { new Point (1, 1),
-										      new Point (2, 2) }, 2),
+										new Point [] { new Point (1, 1),
+											new Point (2, 2) }, 2),
 					 "DrawClosedCurve with 2 pt2");
 
 			// DrawPolygon
@@ -1206,7 +1206,7 @@ namespace MonoTests.System.Drawing {
 					 "DrawPolygon with no pts");
 			Assert.AreEqual (Status.InvalidParameter,
 					 GDIPlus.GdipDrawPolygonI (graphics, pen,
-								   new Point [] { new Point (1, 1) }, 1),
+										new Point [] { new Point (1, 1) }, 1),
 					 "DrawPolygon with only one pt");
 
 			GDIPlus.GdipDeletePen (pen);			
@@ -1222,12 +1222,12 @@ namespace MonoTests.System.Drawing {
 					 "FillClosedCurve with no pts");
 			Assert.AreEqual (Status.Ok,
 					 GDIPlus.GdipFillClosedCurveI (graphics, brush, 
-								       new Point [] { new Point (1, 1) }, 1),
+									   new Point [] { new Point (1, 1) }, 1),
 					 "FillClosedCurve with 1 pt");
 			Assert.AreEqual (Status.Ok,
 					 GDIPlus.GdipFillClosedCurveI (graphics, brush,
-								       new Point [] { new Point (1, 1),
-										      new Point (2, 2) }, 2),
+									   new Point [] { new Point (1, 1),
+											  new Point (2, 2) }, 2),
 					 "FillClosedCurve with 2 pts");
 			
 			GDIPlus.GdipDeleteBrush (brush);

--- a/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
@@ -1180,8 +1180,8 @@ namespace MonoTests.System.Drawing {
 					 "DrawCurve with 1 pt");
 			Assert.AreEqual (Status.Ok,
 					 GDIPlus.GdipDrawCurveI (graphics, pen,
-								 new Point [] { new Point (1, 1),
-									new Point (2, 2) }, 2),
+					                         new Point [] { new Point (1, 1),
+					                                        new Point (2, 2) }, 2),
 					 "DrawCurve with 2 pts");
 
 			// DrawClosedCurve
@@ -1191,12 +1191,12 @@ namespace MonoTests.System.Drawing {
 					 "DrawClosedCurve with no pts");
 			Assert.AreEqual (Status.InvalidParameter,
 					 GDIPlus.GdipDrawClosedCurveI (graphics, pen,
-										new Point [] { new Point (1, 1) }, 1),
+					                               new Point [] { new Point (1, 1) }, 1),
 					 "DrawClosedCurve with 1 pt");
 			Assert.AreEqual (Status.InvalidParameter,
 					 GDIPlus.GdipDrawClosedCurveI (graphics, pen,
-										new Point [] { new Point (1, 1),
-											new Point (2, 2) }, 2),
+					                               new Point [] { new Point (1, 1),
+					                                              new Point (2, 2) }, 2),
 					 "DrawClosedCurve with 2 pt2");
 
 			// DrawPolygon
@@ -1206,7 +1206,7 @@ namespace MonoTests.System.Drawing {
 					 "DrawPolygon with no pts");
 			Assert.AreEqual (Status.InvalidParameter,
 					 GDIPlus.GdipDrawPolygonI (graphics, pen,
-										new Point [] { new Point (1, 1) }, 1),
+					                           new Point [] { new Point (1, 1) }, 1),
 					 "DrawPolygon with only one pt");
 
 			GDIPlus.GdipDeletePen (pen);			
@@ -1222,12 +1222,12 @@ namespace MonoTests.System.Drawing {
 					 "FillClosedCurve with no pts");
 			Assert.AreEqual (Status.Ok,
 					 GDIPlus.GdipFillClosedCurveI (graphics, brush, 
-									   new Point [] { new Point (1, 1) }, 1),
+												new Point [] { new Point (1, 1) }, 1),
 					 "FillClosedCurve with 1 pt");
 			Assert.AreEqual (Status.Ok,
 					 GDIPlus.GdipFillClosedCurveI (graphics, brush,
-									   new Point [] { new Point (1, 1),
-											  new Point (2, 2) }, 2),
+					                               new Point [] { new Point (1, 1),
+					                                              new Point (2, 2) }, 2),
 					 "FillClosedCurve with 2 pts");
 			
 			GDIPlus.GdipDeleteBrush (brush);

--- a/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
@@ -124,7 +124,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Constructor_Brush_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Pen ((Brush) null));
+			Assert.Throws<ArgumentNullException> (() => new Pen ((Brush) null));
 		}
 
 		[Test]
@@ -139,7 +139,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Constructor_Brush_Float_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Pen ((Brush) null, Single.MaxValue));
+			Assert.Throws<ArgumentNullException> (() => new Pen ((Brush) null, Single.MaxValue));
 		}
 
 		[Test]
@@ -212,7 +212,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Alignment_Invalid ()
 		{
-			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.Alignment = (PenAlignment) Int32.MinValue);
+			Assert.Throws<SC.InvalidEnumArgumentException> (() => default_pen.Alignment = (PenAlignment) Int32.MinValue);
 		}
 
 		[Test]
@@ -234,7 +234,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Brush_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => default_pen.Brush = null);
+			Assert.Throws<ArgumentNullException> (() => default_pen.Brush = null);
 		}
 
 		[Test]
@@ -252,7 +252,7 @@ namespace MonoTests.System.Drawing {
 		[Category ("NotWorking")] // not supported by libgdiplus
 		public void CustomEndCap_Default ()
 		{
-			Assert.Throws<ArgumentException>(() => { var x = default_pen.CustomEndCap; });
+			Assert.Throws<ArgumentException> (() => { var x = default_pen.CustomEndCap; });
 		}
 
 		[Test]
@@ -270,7 +270,7 @@ namespace MonoTests.System.Drawing {
 		[Category ("NotWorking")] // not supported by libgdiplus
 		public void CustomStartCap_Default ()
 		{
-			Assert.Throws<ArgumentException>(() => { var x = default_pen.CustomStartCap; });
+			Assert.Throws<ArgumentException> (() => { var x = default_pen.CustomStartCap; });
 		}
 
 		[Test]
@@ -289,7 +289,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void DashCap_Invalid ()
 		{
-			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.DashCap = (DashCap) Int32.MinValue);
+			Assert.Throws<SC.InvalidEnumArgumentException> (() => default_pen.DashCap = (DashCap) Int32.MinValue);
 		}
 
 		[Test]
@@ -319,7 +319,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void DashPattern_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => default_pen.DashPattern = new float[0]);
+			Assert.Throws<ArgumentException> (() => default_pen.DashPattern = new float[0]);
 		}
 
 		[Test]
@@ -336,7 +336,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void DashStyle_Invalid ()
 		{
-			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.DashStyle = (DashStyle) Int32.MinValue);
+			Assert.Throws<SC.InvalidEnumArgumentException> (() => default_pen.DashStyle = (DashStyle) Int32.MinValue);
 		}
 
 		[Test]
@@ -422,7 +422,7 @@ namespace MonoTests.System.Drawing {
 		[Category ("NotWorking")] // MS bug reported as FDBK50053
 		public void DashPattern_Default ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => { var x = default_pen.DashPattern; });
+			Assert.Throws<OutOfMemoryException> (() => { var x = default_pen.DashPattern; });
 		}
 
 		[Test]
@@ -439,7 +439,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void EndCap_Invalid ()
 		{
-			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.EndCap = (LineCap) Int32.MinValue);
+			Assert.Throws<SC.InvalidEnumArgumentException> (() => default_pen.EndCap = (LineCap) Int32.MinValue);
 		}
 
 		[Test]
@@ -456,7 +456,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void LineJoin_Invalid ()
 		{
-			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.LineJoin = (LineJoin) Int32.MinValue);
+			Assert.Throws<SC.InvalidEnumArgumentException> (() => default_pen.LineJoin = (LineJoin) Int32.MinValue);
 		}
 
 		[Test]
@@ -486,20 +486,20 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void StartCap_Invalid ()
 		{
-			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.StartCap = (LineCap) Int32.MinValue);
+			Assert.Throws<SC.InvalidEnumArgumentException> (() => default_pen.StartCap = (LineCap) Int32.MinValue);
 		}
 
 		[Test]
 		public void Transform_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => default_pen.Transform = null);
+			Assert.Throws<ArgumentNullException> (() => default_pen.Transform = null);
 		}
 
 		[Test]
 		public void Transform_NonInvertible ()
 		{
 			using (Pen p = new Pen (Brushes.Snow, Single.MaxValue)) {
-				Assert.Throws<ArgumentException>(() => p.Transform = new Matrix (123, 24, 82, 16, 47, 30));
+				Assert.Throws<ArgumentException> (() => p.Transform = new Matrix (123, 24, 82, 16, 47, 30));
 			}
 		}
 
@@ -530,7 +530,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Pen p = new Pen (Brushes.Red);
 			p.Dispose ();
-            Assert.Throws<ArgumentException>(() => p.Alignment = PenAlignment.Center);
+			Assert.Throws<ArgumentException> (() => p.Alignment = PenAlignment.Center);
 			// exception but not an ObjectDisposedException
 		}
 
@@ -592,14 +592,14 @@ namespace MonoTests.System.Drawing {
 		//[ExpectedException (typeof (ArgumentNullException))] // reported as FDBK50058
 		public void MultiplyTransform1_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => default_pen.MultiplyTransform (null));
+			Assert.Throws<NullReferenceException> (() => default_pen.MultiplyTransform (null));
 		}
 
 		[Test]
 		//[ExpectedException (typeof (ArgumentNullException))] // reported as FDBK50058
 		public void MultiplyTransform2_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => default_pen.MultiplyTransform (null, MatrixOrder.Append));
+			Assert.Throws<NullReferenceException> (() => default_pen.MultiplyTransform (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -629,7 +629,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30)) {
 				using (Pen p = new Pen (Brushes.Red)) {
-					Assert.Throws<ArgumentException>(() => p.MultiplyTransform (noninvertible));
+					Assert.Throws<ArgumentException> (() => p.MultiplyTransform (noninvertible));
 				}
 			}
 		}
@@ -668,7 +668,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void RotateTransform_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => default_pen.RotateTransform (720, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => default_pen.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -707,7 +707,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void ScaleTransform_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => default_pen.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => default_pen.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -737,7 +737,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void TranslateTransform_InvalidOrder ()
 		{
-			Assert.Throws<ArgumentException>(() => default_pen.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => default_pen.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
@@ -122,10 +122,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_Brush_Null ()
 		{
-			new Pen ((Brush) null);
+			Assert.Throws<ArgumentNullException>(() => new Pen ((Brush) null));
 		}
 
 		[Test]
@@ -138,10 +137,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_Brush_Float_Null ()
 		{
-			new Pen ((Brush) null, Single.MaxValue);
+			Assert.Throws<ArgumentNullException>(() => new Pen ((Brush) null, Single.MaxValue));
 		}
 
 		[Test]
@@ -212,10 +210,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (SC.InvalidEnumArgumentException))]
 		public void Alignment_Invalid ()
 		{
-			default_pen.Alignment = (PenAlignment) Int32.MinValue;
+			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.Alignment = (PenAlignment) Int32.MinValue);
 		}
 
 		[Test]
@@ -235,10 +232,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Brush_Null ()
 		{
-			default_pen.Brush = null;
+			Assert.Throws<ArgumentNullException>(() => default_pen.Brush = null);
 		}
 
 		[Test]
@@ -253,11 +249,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[Category ("NotWorking")] // not supported by libgdiplus
 		public void CustomEndCap_Default ()
 		{
-			CustomLineCap clc = default_pen.CustomEndCap;
+			Assert.Throws<ArgumentException>(() => default_pen.CustomEndCap);
 		}
 
 		[Test]
@@ -272,11 +267,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[Category ("NotWorking")] // not supported by libgdiplus
 		public void CustomStartCap_Default ()
 		{
-			CustomLineCap clc = default_pen.CustomStartCap;
+			Assert.Throws<ArgumentException>(() => default_pen.CustomStartCap);
 		}
 
 		[Test]
@@ -293,10 +287,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (SC.InvalidEnumArgumentException))]
 		public void DashCap_Invalid ()
 		{
-			default_pen.DashCap = (DashCap) Int32.MinValue;
+			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.DashCap = (DashCap) Int32.MinValue);
 		}
 
 		[Test]
@@ -324,10 +317,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DashPattern_Empty ()
 		{
-			default_pen.DashPattern = new float[0];
+			Assert.Throws<ArgumentException>(() => default_pen.DashPattern = new float[0]);
 		}
 
 		[Test]
@@ -342,10 +334,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (SC.InvalidEnumArgumentException))]
 		public void DashStyle_Invalid ()
 		{
-			default_pen.DashStyle = (DashStyle) Int32.MinValue;
+			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.DashStyle = (DashStyle) Int32.MinValue);
 		}
 
 		[Test]
@@ -428,11 +419,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		[Category ("NotWorking")] // MS bug reported as FDBK50053
 		public void DashPattern_Default ()
 		{
-			float[] pattern = default_pen.DashPattern;
+			Assert.Throws<OutOfMemoryException>(() => default_pen.DashPattern);
 		}
 
 		[Test]
@@ -447,10 +437,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (SC.InvalidEnumArgumentException))]
 		public void EndCap_Invalid ()
 		{
-			default_pen.EndCap = (LineCap) Int32.MinValue;
+			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.EndCap = (LineCap) Int32.MinValue);
 		}
 
 		[Test]
@@ -465,10 +454,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (SC.InvalidEnumArgumentException))]
 		public void LineJoin_Invalid ()
 		{
-			default_pen.LineJoin = (LineJoin) Int32.MinValue;
+			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.LineJoin = (LineJoin) Int32.MinValue);
 		}
 
 		[Test]
@@ -496,25 +484,22 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (SC.InvalidEnumArgumentException))]
 		public void StartCap_Invalid ()
 		{
-			default_pen.StartCap = (LineCap) Int32.MinValue;
+			Assert.Throws<SC.InvalidEnumArgumentException>(() => default_pen.StartCap = (LineCap) Int32.MinValue);
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Transform_Null ()
 		{
-			default_pen.Transform = null;
+			Assert.Throws<ArgumentNullException>(() => default_pen.Transform = null);
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Transform_NonInvertible ()
 		{
 			using (Pen p = new Pen (Brushes.Snow, Single.MaxValue)) {
-				p.Transform = new Matrix (123, 24, 82, 16, 47, 30);
+				Assert.Throws<ArgumentException>(() => p.Transform = new Matrix (123, 24, 82, 16, 47, 30));
 			}
 		}
 
@@ -541,12 +526,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose ()
 		{
 			Pen p = new Pen (Brushes.Red);
 			p.Dispose ();
-			p.Alignment = PenAlignment.Center;
+            Assert.Throws<ArgumentException>(() => p.Alignment = PenAlignment.Center);
 			// exception but not an ObjectDisposedException
 		}
 
@@ -606,18 +590,16 @@ namespace MonoTests.System.Drawing {
 
 		[Test]
 		//[ExpectedException (typeof (ArgumentNullException))] // reported as FDBK50058
-		[ExpectedException (typeof (NullReferenceException))]
 		public void MultiplyTransform1_Null ()
 		{
-			default_pen.MultiplyTransform (null);
+			Assert.Throws<NullReferenceException>(() => default_pen.MultiplyTransform (null));
 		}
 
 		[Test]
 		//[ExpectedException (typeof (ArgumentNullException))] // reported as FDBK50058
-		[ExpectedException (typeof (NullReferenceException))]
 		public void MultiplyTransform2_Null ()
 		{
-			default_pen.MultiplyTransform (null, MatrixOrder.Append);
+			Assert.Throws<NullReferenceException>(() => default_pen.MultiplyTransform (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -643,12 +625,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void MultiplyTransform_NonInvertible ()
 		{
 			using (Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30)) {
 				using (Pen p = new Pen (Brushes.Red)) {
-					p.MultiplyTransform (noninvertible);
+					Assert.Throws<ArgumentException>(() => p.MultiplyTransform (noninvertible));
 				}
 			}
 		}
@@ -685,10 +666,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void RotateTransform_InvalidOrder ()
 		{
-			default_pen.RotateTransform (720, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => default_pen.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -725,10 +705,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ScaleTransform_InvalidOrder ()
 		{
-			default_pen.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => default_pen.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -756,10 +735,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TranslateTransform_InvalidOrder ()
 		{
-			default_pen.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => default_pen.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
@@ -252,7 +252,7 @@ namespace MonoTests.System.Drawing {
 		[Category ("NotWorking")] // not supported by libgdiplus
 		public void CustomEndCap_Default ()
 		{
-			Assert.Throws<ArgumentException>(() => default_pen.CustomEndCap);
+			Assert.Throws<ArgumentException>(() => { var x = default_pen.CustomEndCap; });
 		}
 
 		[Test]
@@ -270,7 +270,7 @@ namespace MonoTests.System.Drawing {
 		[Category ("NotWorking")] // not supported by libgdiplus
 		public void CustomStartCap_Default ()
 		{
-			Assert.Throws<ArgumentException>(() => default_pen.CustomStartCap);
+			Assert.Throws<ArgumentException>(() => { var x = default_pen.CustomStartCap; });
 		}
 
 		[Test]
@@ -422,7 +422,7 @@ namespace MonoTests.System.Drawing {
 		[Category ("NotWorking")] // MS bug reported as FDBK50053
 		public void DashPattern_Default ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => default_pen.DashPattern);
+			Assert.Throws<OutOfMemoryException>(() => { var x = default_pen.DashPattern; });
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/RegionDataTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/RegionDataTest.cs
@@ -58,13 +58,12 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void RegionData_Null ()
 		{
 			RegionData data = new Region ().GetRegionData ();
 			data.Data = null;
 			Assert.IsNull (data.Data, "Data");
-			Region region = new Region (data);
+			Assert.Throws<NullReferenceException>(() => new Region (data));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/RegionDataTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/RegionDataTest.cs
@@ -63,7 +63,7 @@ namespace MonoTests.System.Drawing {
 			RegionData data = new Region ().GetRegionData ();
 			data.Data = null;
 			Assert.IsNull (data.Data, "Data");
-			Assert.Throws<NullReferenceException>(() => new Region (data));
+			Assert.Throws<NullReferenceException> (() => new Region (data));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/SolidBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/SolidBrushTest.cs
@@ -62,7 +62,7 @@ namespace MonoTests.System.Drawing {
 		{
 			SolidBrush sb = new SolidBrush (Color.Transparent);
 			sb.Dispose ();
-			Assert.Throws<ArgumentException>(() => sb.Clone ());
+			Assert.Throws<ArgumentException> (() => sb.Clone ());
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/SolidBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/SolidBrushTest.cs
@@ -58,12 +58,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_Clone ()
 		{
 			SolidBrush sb = new SolidBrush (Color.Transparent);
 			sb.Dispose ();
-			sb.Clone ();
+			Assert.Throws<ArgumentException>(() => sb.Clone ());
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/SystemFontsTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/SystemFontsTest.cs
@@ -130,13 +130,12 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_Instance ()
 		{
 			Font f1 = SystemFonts.CaptionFont;
 			float height = f1.GetHeight (72f);
 			f1.Dispose ();
-			f1.GetHeight (72f);
+			Assert.Throws<ArgumentException>(() => f1.GetHeight (72f));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/SystemFontsTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/SystemFontsTest.cs
@@ -135,7 +135,7 @@ namespace MonoTests.System.Drawing {
 			Font f1 = SystemFonts.CaptionFont;
 			float height = f1.GetHeight (72f);
 			f1.Dispose ();
-			Assert.Throws<ArgumentException>(() => f1.GetHeight (72f));
+			Assert.Throws<ArgumentException> (() => f1.GetHeight (72f));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/SystemIconsTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/SystemIconsTest.cs
@@ -68,7 +68,7 @@ namespace MonoTests.System.Drawing {
 			Icon app = SystemIcons.Application;
 			Icon clone = (Icon) app.Clone ();
 			clone.Dispose ();
-			Assert.Throws<ObjectDisposedException> (() => Assert.IsNotNull (clone.ToBitmap ()));
+			Assert.Throws<ObjectDisposedException> (() => clone.ToBitmap ());
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/SystemIconsTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/SystemIconsTest.cs
@@ -62,14 +62,13 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ObjectDisposedException))]
 		public void Clone_Dispose ()
 		{
 			// Clones of SystemIcons icon's can be disposed
 			Icon app = SystemIcons.Application;
 			Icon clone = (Icon) app.Clone ();
 			clone.Dispose ();
-			Assert.IsNotNull (clone.ToBitmap ());
+            Assert.Throws<ObjectDisposedException>(() => Assert.IsNotNull (clone.ToBitmap ()));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/SystemIconsTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/SystemIconsTest.cs
@@ -68,7 +68,7 @@ namespace MonoTests.System.Drawing {
 			Icon app = SystemIcons.Application;
 			Icon clone = (Icon) app.Clone ();
 			clone.Dispose ();
-            Assert.Throws<ObjectDisposedException>(() => Assert.IsNotNull (clone.ToBitmap ()));
+			Assert.Throws<ObjectDisposedException> (() => Assert.IsNotNull (clone.ToBitmap ()));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
@@ -121,30 +121,23 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void LockBits_IndexedWrite_NonIndexed ()
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format8bppIndexed)) {
 				Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
-				bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
+				Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void LockBits_NonIndexedWrite_ToIndexed ()
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb)) {
 				Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
-				BitmapData bd = new BitmapData ();
-				try {
-					bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed, bd);
-				}
-				catch (ArgumentException) {
-					// test to see if there's a leak or not in this case
-					Assert.AreEqual (IntPtr.Zero, bd.Scan0, "Scan0");
-					throw;
-				}
+				Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed, bd));
+
+				// test to see if there's a leak or not in this case
+				Assert.AreEqual (IntPtr.Zero, bd.Scan0, "Scan0");
 			}
 		}
 
@@ -182,14 +175,13 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidOperationException))]
 		public void LockBits_Double ()
 		{
 			using (Bitmap bmp = new Bitmap (10, 10, PixelFormat.Format24bppRgb)) {
 				Rectangle r = new Rectangle (4, 4, 4, 4);
 				BitmapData data = bmp.LockBits (r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
 				try {
-					bmp.LockBits (r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+                    Assert.Throws<InvalidOperationException>(() => bmp.LockBits (r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb));
 				}
 				finally {
 					bmp.UnlockBits (data);
@@ -198,17 +190,15 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void LockBits_Disposed ()
 		{
 			Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb);
 			Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
 			bmp.Dispose ();
-			bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb);
+            Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[Category ("Valgrind")] // this test is known to leak memory (API design limitation)
 		public void UnlockBits_Disposed ()
 		{
@@ -216,26 +206,24 @@ namespace MonoTests.System.Drawing {
 			Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
 			BitmapData data = bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppRgb);
 			bmp.Dispose ();
-			bmp.UnlockBits (data);
+            Assert.Throws<ArgumentException>(() => bmp.UnlockBits (data));
 			// and that results in something like this when executed under Valgrind 
 			// "40,000 bytes in 1 blocks are possibly lost in loss record 88 of 92"
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void UnlockBits_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb)) {
-				bmp.UnlockBits (null);
+                Assert.Throws<ArgumentException>(() => bmp.UnlockBits (null));
 			}
 		}
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void LockBits_BitmapData_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb)) {
 				Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
-				bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb, null);
+                Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb, null));
 			}
 		}
 
@@ -300,46 +288,42 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidOperationException))]
 		public void Format1bppIndexed ()
 		{
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format1bppIndexed)) {
 				Color c = bmp.GetPixel (0, 0);
 				Assert.AreEqual (-16777216, c.ToArgb (), "Color");
-				bmp.SetPixel (0, 0, c);
+                Assert.Throws<InvalidOperationException>(() => bmp.SetPixel (0, 0, c));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidOperationException))]
 		public void Format4bppIndexed ()
 		{
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format4bppIndexed)) {
 				Color c = bmp.GetPixel (0, 0);
 				Assert.AreEqual (-16777216, c.ToArgb (), "Color");
-				bmp.SetPixel (0, 0, c);
+				Assert.Throws<InvalidOperationException>(() => bmp.SetPixel (0, 0, c));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidOperationException))]
 		public void Format8bppIndexed ()
 		{
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format8bppIndexed)) {
 				Color c = bmp.GetPixel (0, 0);
 				Assert.AreEqual (-16777216, c.ToArgb (), "Color");
-				bmp.SetPixel (0, 0, c);
+				Assert.Throws<InvalidOperationException>(() => bmp.SetPixel (0, 0, c));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[Category ("NotWorking")] // libgdiplus doesn't support this format
 		public void Format16bppGrayScale ()
 		{
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format16bppGrayScale)) {
 				// and MS GDI+ support seems quite limited too
-				bmp.GetPixel (0, 0);
+				Assert.Throws<ArgumentException>(() => bmp.GetPixel (0, 0));
 			}
 		}
 
@@ -587,10 +571,9 @@ namespace MonoTests.System.Drawing {
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FileDoesNotExists ()
 		{			
-			Bitmap	bmp = new Bitmap ("FileDoesNotExists.jpg");			
+			Assert.Throws<ArgumentException>(() => new Bitmap ("FileDoesNotExists.jpg"));			
 		}
 
 		static string ByteArrayToString(byte[] arrInput)
@@ -1513,87 +1496,75 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void BitmapImageCtor ()
 		{
-			new Bitmap ((Image) null);
+            Assert.Throws<NullReferenceException>(() => new Bitmap ((Image) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BitmapImageSizeCtor ()
 		{
-			new Bitmap ((Image) null, Size.Empty);
+			Assert.Throws<ArgumentException>(() => new Bitmap ((Image) null, Size.Empty));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BitmapImageIntIntCtor ()
 		{
-			new Bitmap ((Image) null, Int32.MinValue, Int32.MaxValue);
+			Assert.Throws<ArgumentException>(() => new Bitmap ((Image) null, Int32.MinValue, Int32.MaxValue));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BitmapIntIntCtor ()
 		{
-			new Bitmap (Int32.MinValue, Int32.MaxValue);
+			Assert.Throws<ArgumentException>(() => new Bitmap (Int32.MinValue, Int32.MaxValue));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void BitmapIntIntGraphicCtor ()
 		{
-			new Bitmap (1, 1, null);
+			Assert.Throws<ArgumentNullException>(() => new Bitmap (1, 1, null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BitmapIntIntPixelFormatCtor ()
 		{
-			new Bitmap (Int32.MinValue, Int32.MaxValue, PixelFormat.Format1bppIndexed);
+			Assert.Throws<ArgumentException>(() => new Bitmap (Int32.MinValue, Int32.MaxValue, PixelFormat.Format1bppIndexed));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BitmapStreamCtor ()
 		{
-			new Bitmap ((Stream) null);
+			Assert.Throws<ArgumentException>(() => new Bitmap ((Stream) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BitmapStreamBoolCtor ()
 		{
-			new Bitmap ((Stream) null, true);
+			Assert.Throws<ArgumentException>(() => new Bitmap ((Stream) null, true));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void BitmapStringCtor ()
 		{
-			new Bitmap ((string) null);
+			Assert.Throws<ArgumentNullException>(() => new Bitmap ((string) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void BitmapStringBoolCtor ()
 		{
-			new Bitmap ((string) null, false);
+			Assert.Throws<ArgumentNullException>(() => new Bitmap ((string) null, false));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void BitmapTypeStringCtor1 ()
 		{
-			new Bitmap ((Type) null, "mono");
+			Assert.Throws<NullReferenceException>(() => new Bitmap ((Type) null, "mono"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BitmapTypeStringCtor2 ()
 		{
-			new Bitmap (typeof (Bitmap), null);
+			Assert.Throws<ArgumentException>(() => new Bitmap (typeof (Bitmap), null));
 		}
 
 		private void SetResolution (float x, float y)
@@ -1604,24 +1575,21 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetResolution_Zero ()
 		{
-			SetResolution (0.0f, 0.0f);
+			Assert.Throws<ArgumentException>(() => SetResolution (0.0f, 0.0f));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetResolution_Negative_X ()
 		{
-			SetResolution (-1.0f, 1.0f);
+			Assert.Throws<ArgumentException>(() => SetResolution (-1.0f, 1.0f));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetResolution_Negative_Y ()
 		{
-			SetResolution (1.0f, -1.0f);
+			Assert.Throws<ArgumentException>(() => SetResolution (1.0f, -1.0f));
 		}
 
 		[Test]
@@ -1637,17 +1605,15 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetResolution_NaN ()
 		{
-			SetResolution (Single.NaN, Single.NaN);
+			Assert.Throws<ArgumentException>(() => SetResolution (Single.NaN, Single.NaN));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void SetResolution_NegativeInfinity ()
 		{
-			SetResolution (Single.NegativeInfinity, Single.NegativeInfinity);
+			Assert.Throws<ArgumentException>(() => SetResolution (Single.NegativeInfinity, Single.NegativeInfinity));
 		}
 	}
 
@@ -1710,13 +1676,12 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[Category ("NotWorking")] // libgdiplus has lost track of the original 1bpp state
 		public void Hicon48 ()
 		{
 			using (Icon icon = new Icon (TestBitmap.getInFile ("bitmaps/48x48x1.ico"))) {
 				// looks like 1bbp icons aren't welcome as bitmaps ;-)
-				Bitmap.FromHicon (icon.Handle);
+				Assert.Throws<ArgumentException>(() => Bitmap.FromHicon (icon.Handle));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
@@ -694,9 +694,9 @@ namespace MonoTests.System.Drawing {
 				Assert.Ignore("This does not work with Microsoft's GDIPLUS.DLL due to off-by-1 errors in their GdipBitmapRotateFlip function.");
 
 			string[] files = {
-							   getInFile ("bitmaps/1bit.png"),
-							   getInFile ("bitmaps/4bit.png")
-							 };
+			                   getInFile ("bitmaps/1bit.png"),
+			                   getInFile ("bitmaps/4bit.png")
+			                 };
 
 			StringBuilder md5s = new StringBuilder();
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
@@ -133,6 +133,7 @@ namespace MonoTests.System.Drawing {
 		public void LockBits_NonIndexedWrite_ToIndexed ()
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb)) {
+ 				BitmapData bd = new BitmapData ();
 				Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
 				Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed, bd));
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
@@ -125,7 +125,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format8bppIndexed)) {
 				Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
-				Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
+				Assert.Throws<ArgumentException> (() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
 			}
 		}
 
@@ -135,7 +135,7 @@ namespace MonoTests.System.Drawing {
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb)) {
  				BitmapData bd = new BitmapData ();
 				Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
-				Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed, bd));
+				Assert.Throws<ArgumentException> (() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed, bd));
 
 				// test to see if there's a leak or not in this case
 				Assert.AreEqual (IntPtr.Zero, bd.Scan0, "Scan0");
@@ -182,7 +182,7 @@ namespace MonoTests.System.Drawing {
 				Rectangle r = new Rectangle (4, 4, 4, 4);
 				BitmapData data = bmp.LockBits (r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
 				try {
-                    Assert.Throws<InvalidOperationException>(() => bmp.LockBits (r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb));
+					Assert.Throws<InvalidOperationException> (() => bmp.LockBits (r, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb));
 				}
 				finally {
 					bmp.UnlockBits (data);
@@ -196,7 +196,7 @@ namespace MonoTests.System.Drawing {
 			Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb);
 			Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
 			bmp.Dispose ();
-            Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
+			Assert.Throws<ArgumentException> (() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb));
 		}
 
 		[Test]
@@ -207,7 +207,7 @@ namespace MonoTests.System.Drawing {
 			Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
 			BitmapData data = bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppRgb);
 			bmp.Dispose ();
-            Assert.Throws<ArgumentException>(() => bmp.UnlockBits (data));
+			Assert.Throws<ArgumentException> (() => bmp.UnlockBits (data));
 			// and that results in something like this when executed under Valgrind 
 			// "40,000 bytes in 1 blocks are possibly lost in loss record 88 of 92"
 		}
@@ -216,7 +216,7 @@ namespace MonoTests.System.Drawing {
 		public void UnlockBits_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb)) {
-                Assert.Throws<ArgumentException>(() => bmp.UnlockBits (null));
+				Assert.Throws<ArgumentException> (() => bmp.UnlockBits (null));
 			}
 		}
 		[Test]
@@ -224,7 +224,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (100, 100, PixelFormat.Format32bppRgb)) {
 				Rectangle rect = new Rectangle (0, 0, bmp.Width, bmp.Height);
-                Assert.Throws<ArgumentException>(() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb, null));
+				Assert.Throws<ArgumentException> (() => bmp.LockBits (rect, ImageLockMode.ReadWrite, PixelFormat.Format24bppRgb, null));
 			}
 		}
 
@@ -294,7 +294,7 @@ namespace MonoTests.System.Drawing {
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format1bppIndexed)) {
 				Color c = bmp.GetPixel (0, 0);
 				Assert.AreEqual (-16777216, c.ToArgb (), "Color");
-                Assert.Throws<InvalidOperationException>(() => bmp.SetPixel (0, 0, c));
+				Assert.Throws<InvalidOperationException> (() => bmp.SetPixel (0, 0, c));
 			}
 		}
 
@@ -304,7 +304,7 @@ namespace MonoTests.System.Drawing {
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format4bppIndexed)) {
 				Color c = bmp.GetPixel (0, 0);
 				Assert.AreEqual (-16777216, c.ToArgb (), "Color");
-				Assert.Throws<InvalidOperationException>(() => bmp.SetPixel (0, 0, c));
+				Assert.Throws<InvalidOperationException> (() => bmp.SetPixel (0, 0, c));
 			}
 		}
 
@@ -314,7 +314,7 @@ namespace MonoTests.System.Drawing {
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format8bppIndexed)) {
 				Color c = bmp.GetPixel (0, 0);
 				Assert.AreEqual (-16777216, c.ToArgb (), "Color");
-				Assert.Throws<InvalidOperationException>(() => bmp.SetPixel (0, 0, c));
+				Assert.Throws<InvalidOperationException> (() => bmp.SetPixel (0, 0, c));
 			}
 		}
 
@@ -324,7 +324,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (1, 1, PixelFormat.Format16bppGrayScale)) {
 				// and MS GDI+ support seems quite limited too
-				Assert.Throws<ArgumentException>(() => bmp.GetPixel (0, 0));
+				Assert.Throws<ArgumentException> (() => bmp.GetPixel (0, 0));
 			}
 		}
 
@@ -574,7 +574,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void FileDoesNotExists ()
 		{			
-			Assert.Throws<ArgumentException>(() => new Bitmap ("FileDoesNotExists.jpg"));			
+			Assert.Throws<ArgumentException> (() => new Bitmap ("FileDoesNotExists.jpg"));			
 		}
 
 		static string ByteArrayToString(byte[] arrInput)
@@ -694,9 +694,9 @@ namespace MonoTests.System.Drawing {
 				Assert.Ignore("This does not work with Microsoft's GDIPLUS.DLL due to off-by-1 errors in their GdipBitmapRotateFlip function.");
 
 			string[] files = {
-			                   getInFile ("bitmaps/1bit.png"),
-			                   getInFile ("bitmaps/4bit.png")
-			                 };
+							   getInFile ("bitmaps/1bit.png"),
+							   getInFile ("bitmaps/4bit.png")
+							 };
 
 			StringBuilder md5s = new StringBuilder();
 
@@ -1499,73 +1499,73 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void BitmapImageCtor ()
 		{
-            Assert.Throws<NullReferenceException>(() => new Bitmap ((Image) null));
+			Assert.Throws<NullReferenceException> (() => new Bitmap ((Image) null));
 		}
 
 		[Test]
 		public void BitmapImageSizeCtor ()
 		{
-			Assert.Throws<ArgumentException>(() => new Bitmap ((Image) null, Size.Empty));
+			Assert.Throws<ArgumentException> (() => new Bitmap ((Image) null, Size.Empty));
 		}
 
 		[Test]
 		public void BitmapImageIntIntCtor ()
 		{
-			Assert.Throws<ArgumentException>(() => new Bitmap ((Image) null, Int32.MinValue, Int32.MaxValue));
+			Assert.Throws<ArgumentException> (() => new Bitmap ((Image) null, Int32.MinValue, Int32.MaxValue));
 		}
 
 		[Test]
 		public void BitmapIntIntCtor ()
 		{
-			Assert.Throws<ArgumentException>(() => new Bitmap (Int32.MinValue, Int32.MaxValue));
+			Assert.Throws<ArgumentException> (() => new Bitmap (Int32.MinValue, Int32.MaxValue));
 		}
 
 		[Test]
 		public void BitmapIntIntGraphicCtor ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Bitmap (1, 1, null));
+			Assert.Throws<ArgumentNullException> (() => new Bitmap (1, 1, null));
 		}
 
 		[Test]
 		public void BitmapIntIntPixelFormatCtor ()
 		{
-			Assert.Throws<ArgumentException>(() => new Bitmap (Int32.MinValue, Int32.MaxValue, PixelFormat.Format1bppIndexed));
+			Assert.Throws<ArgumentException> (() => new Bitmap (Int32.MinValue, Int32.MaxValue, PixelFormat.Format1bppIndexed));
 		}
 
 		[Test]
 		public void BitmapStreamCtor ()
 		{
-			Assert.Throws<ArgumentException>(() => new Bitmap ((Stream) null));
+			Assert.Throws<ArgumentException> (() => new Bitmap ((Stream) null));
 		}
 
 		[Test]
 		public void BitmapStreamBoolCtor ()
 		{
-			Assert.Throws<ArgumentException>(() => new Bitmap ((Stream) null, true));
+			Assert.Throws<ArgumentException> (() => new Bitmap ((Stream) null, true));
 		}
 
 		[Test]
 		public void BitmapStringCtor ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Bitmap ((string) null));
+			Assert.Throws<ArgumentNullException> (() => new Bitmap ((string) null));
 		}
 
 		[Test]
 		public void BitmapStringBoolCtor ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Bitmap ((string) null, false));
+			Assert.Throws<ArgumentNullException> (() => new Bitmap ((string) null, false));
 		}
 
 		[Test]
 		public void BitmapTypeStringCtor1 ()
 		{
-			Assert.Throws<NullReferenceException>(() => new Bitmap ((Type) null, "mono"));
+			Assert.Throws<NullReferenceException> (() => new Bitmap ((Type) null, "mono"));
 		}
 
 		[Test]
 		public void BitmapTypeStringCtor2 ()
 		{
-			Assert.Throws<ArgumentException>(() => new Bitmap (typeof (Bitmap), null));
+			Assert.Throws<ArgumentException> (() => new Bitmap (typeof (Bitmap), null));
 		}
 
 		private void SetResolution (float x, float y)
@@ -1578,19 +1578,19 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void SetResolution_Zero ()
 		{
-			Assert.Throws<ArgumentException>(() => SetResolution (0.0f, 0.0f));
+			Assert.Throws<ArgumentException> (() => SetResolution (0.0f, 0.0f));
 		}
 
 		[Test]
 		public void SetResolution_Negative_X ()
 		{
-			Assert.Throws<ArgumentException>(() => SetResolution (-1.0f, 1.0f));
+			Assert.Throws<ArgumentException> (() => SetResolution (-1.0f, 1.0f));
 		}
 
 		[Test]
 		public void SetResolution_Negative_Y ()
 		{
-			Assert.Throws<ArgumentException>(() => SetResolution (1.0f, -1.0f));
+			Assert.Throws<ArgumentException> (() => SetResolution (1.0f, -1.0f));
 		}
 
 		[Test]
@@ -1608,13 +1608,13 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void SetResolution_NaN ()
 		{
-			Assert.Throws<ArgumentException>(() => SetResolution (Single.NaN, Single.NaN));
+			Assert.Throws<ArgumentException> (() => SetResolution (Single.NaN, Single.NaN));
 		}
 
 		[Test]
 		public void SetResolution_NegativeInfinity ()
 		{
-			Assert.Throws<ArgumentException>(() => SetResolution (Single.NegativeInfinity, Single.NegativeInfinity));
+			Assert.Throws<ArgumentException> (() => SetResolution (Single.NegativeInfinity, Single.NegativeInfinity));
 		}
 	}
 
@@ -1682,7 +1682,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Icon icon = new Icon (TestBitmap.getInFile ("bitmaps/48x48x1.ico"))) {
 				// looks like 1bbp icons aren't welcome as bitmaps ;-)
-				Assert.Throws<ArgumentException>(() => Bitmap.FromHicon (icon.Handle));
+				Assert.Throws<ArgumentException> (() => Bitmap.FromHicon (icon.Handle));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBrushes.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBrushes.cs
@@ -52,7 +52,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Brushes.YellowGreen.Dispose ();
 			// a "normal" SolidBrush would throw an ArgumentException here
-			Assert.Throws<ArgumentException>(() => Brushes.YellowGreen.Clone ());
+			Assert.Throws<ArgumentException> (() => Brushes.YellowGreen.Clone ());
 			// and it is! so watch your brushes ;-)
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBrushes.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBrushes.cs
@@ -48,12 +48,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose ()
 		{
 			Brushes.YellowGreen.Dispose ();
 			// a "normal" SolidBrush would throw an ArgumentException here
-			Brushes.YellowGreen.Clone ();
+			Assert.Throws<ArgumentException>(() => Brushes.YellowGreen.Clone ());
 			// and it is! so watch your brushes ;-)
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestColor.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestColor.cs
@@ -1019,115 +1019,99 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidAlpha1 ()
 		{
-			Color.FromArgb (-1, Color.Red);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (-1, Color.Red));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidAlpha2 ()
 		{
-			Color.FromArgb (256, Color.Red);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (256, Color.Red));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidAlpha3 ()
 		{
-			Color.FromArgb (-1, 0, 0, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (-1, 0, 0, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidAlpha4 ()
 		{
-			Color.FromArgb (256, 0, 0, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (256, 0, 0, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidRed1 ()
 		{
-			Color.FromArgb (-1, 0, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (-1, 0, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidRed2 ()
 		{
-			Color.FromArgb (256, 0, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (256, 0, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidRed3 ()
 		{
-			Color.FromArgb (0, -1, 0, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, -1, 0, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidRed4 ()
 		{
-			Color.FromArgb (0, 256, 0, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 256, 0, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidGreen1 ()
 		{
-			Color.FromArgb (0, -1, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, -1, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidGreen2 ()
 		{
-			Color.FromArgb (0, 256, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 256, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidGreen3 ()
 		{
-			Color.FromArgb (0, 0, -1, 0);
+			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, -1, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidGreen4 ()
 		{
-			Color.FromArgb (0, 0, 256, 0);
+            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 256, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidBlue1 ()
 		{
-			Color.FromArgb (0, 0, -1);
+            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, -1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidBlue2 ()
 		{
-			Color.FromArgb (0, 0, 256);
+            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 256));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidBlue3 ()
 		{
-			Color.FromArgb (0, 0, 0, -1);
+            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 0, -1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromArgb_InvalidBlue4 ()
 		{
-			Color.FromArgb (0, 0, 0, 256);
+            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 0, 256));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestColor.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestColor.cs
@@ -908,12 +908,12 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (1.0f, Color.White.GetBrightness (), "BrightnessWhite");
 		
 			Color c1 = Color.FromArgb (0, 13, 45, 7); //just some random color
-			Assert.IsTrue (       FloatsAlmostEqual (110.5263f, c1.GetHue ()), "Hue1");
+			Assert.IsTrue (FloatsAlmostEqual (110.5263f, c1.GetHue ()), "Hue1");
 			Assert.IsTrue (FloatsAlmostEqual (0.1019608f, c1.GetBrightness ()), "Brightness1");
 			Assert.IsTrue (FloatsAlmostEqual (0.7307692f, c1.GetSaturation ()), "Saturation1");
 	
 			Color c2 = Color.FromArgb (0, 112, 75, 29); //another random color
-			Assert.IsTrue (       FloatsAlmostEqual (33.25302f, c2.GetHue ()), "Hue2");
+			Assert.IsTrue (FloatsAlmostEqual (33.25302f, c2.GetHue ()), "Hue2");
 			Assert.IsTrue (FloatsAlmostEqual (0.2764706f, c2.GetBrightness ()), "Brightness2");
 			Assert.IsTrue (FloatsAlmostEqual (0.5886525f, c2.GetSaturation ()), "Saturation2");
 		}
@@ -1021,97 +1021,97 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void FromArgb_InvalidAlpha1 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (-1, Color.Red));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (-1, Color.Red));
 		}
 
 		[Test]
 		public void FromArgb_InvalidAlpha2 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (256, Color.Red));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (256, Color.Red));
 		}
 
 		[Test]
 		public void FromArgb_InvalidAlpha3 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (-1, 0, 0, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (-1, 0, 0, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidAlpha4 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (256, 0, 0, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (256, 0, 0, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidRed1 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (-1, 0, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (-1, 0, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidRed2 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (256, 0, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (256, 0, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidRed3 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, -1, 0, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, -1, 0, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidRed4 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 256, 0, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 256, 0, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidGreen1 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, -1, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, -1, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidGreen2 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 256, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 256, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidGreen3 ()
 		{
-			Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, -1, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 0, -1, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidGreen4 ()
 		{
-            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 256, 0));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 0, 256, 0));
 		}
 
 		[Test]
 		public void FromArgb_InvalidBlue1 ()
 		{
-            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, -1));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 0, -1));
 		}
 
 		[Test]
 		public void FromArgb_InvalidBlue2 ()
 		{
-            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 256));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 0, 256));
 		}
 
 		[Test]
 		public void FromArgb_InvalidBlue3 ()
 		{
-            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 0, -1));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 0, 0, -1));
 		}
 
 		[Test]
 		public void FromArgb_InvalidBlue4 ()
 		{
-            Assert.Throws<ArgumentException>(() => Color.FromArgb (0, 0, 0, 256));
+			Assert.Throws<ArgumentException> (() => Color.FromArgb (0, 0, 0, 256));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
@@ -129,7 +129,7 @@ namespace MonoTests.System.Drawing{
 			lf = new LOGFONT();
 			f = new Font("Arial", 10);
 
-			Assert.Throws<SecurityException>(() => f.ToLogFont(lf));
+			Assert.Throws<SecurityException> (() => f.ToLogFont(lf));
 		}
 
 		[Test]
@@ -170,7 +170,7 @@ namespace MonoTests.System.Drawing{
 		{
 			Font f = new Font ("Arial", 10);
 			object o = new object ();
-			Assert.Throws<ArgumentException>(() => f.ToLogFont (o));
+			Assert.Throws<ArgumentException> (() => f.ToLogFont (o));
 			// no PInvoke conversion exists !?!?
 		}
 
@@ -180,7 +180,7 @@ namespace MonoTests.System.Drawing{
 		{
 			Font f = new Font ("Arial", 10);
 			int i = 1;
-			Assert.Throws<AccessViolationException>(() => f.ToLogFont (i));
+			Assert.Throws<AccessViolationException> (() => f.ToLogFont (i));
 			Assert.AreEqual (1, i);
 		}
 
@@ -189,7 +189,7 @@ namespace MonoTests.System.Drawing{
 		public void ToLogFont_Null ()
 		{
 			Font f = new Font ("Arial", 10);
-			Assert.Throws<AccessViolationException>(() => f.ToLogFont (null));
+			Assert.Throws<AccessViolationException> (() => f.ToLogFont (null));
 		}
 		[Test]
 		public void Font_StringNull_Float ()
@@ -259,7 +259,7 @@ namespace MonoTests.System.Drawing{
 		[Test]
 		public void Font_String_Float_FontStyle_GraphicsUnit_Display ()
 		{
-			Assert.Throws<ArgumentException>(() => new Font (name, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
+			Assert.Throws<ArgumentException> (() => new Font (name, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
 		}
 
 		[Test]
@@ -302,14 +302,14 @@ namespace MonoTests.System.Drawing{
 		public void Font_FontFamilyNull_Float ()
 		{
 			FontFamily ff = null;
-			Assert.Throws<ArgumentNullException>(() => new Font (ff, 12.5f));
+			Assert.Throws<ArgumentNullException> (() => new Font (ff, 12.5f));
 		}
 
 		[Test]
 		public void Font_FontNull_FontStyle ()
 		{
 			Font f = null;
-			Assert.Throws<NullReferenceException>(() => new Font (f, FontStyle.Bold));
+			Assert.Throws<NullReferenceException> (() => new Font (f, FontStyle.Bold));
 		}
 
 		[Test]
@@ -369,7 +369,7 @@ namespace MonoTests.System.Drawing{
 		[Test]
 		public void Font_FontFamily_Float_FontStyle_GraphicsUnit_Display ()
 		{
-			Assert.Throws<ArgumentException>(() => new Font (FontFamily.GenericMonospace, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
+			Assert.Throws<ArgumentException> (() => new Font (FontFamily.GenericMonospace, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
 		}
 
 		[Test]
@@ -432,7 +432,7 @@ namespace MonoTests.System.Drawing{
 		{
 			Font f = new Font (name, 12.5f);
 			f.Dispose ();
-			Assert.Throws<ArgumentException>(() => Assert.AreEqual (0, f.Height, "Name"));
+			Assert.Throws<ArgumentException> (() => Assert.AreEqual (0, f.Height, "Name"));
 		}
 
 		[Test]
@@ -441,7 +441,7 @@ namespace MonoTests.System.Drawing{
 			Font f = new Font (name, 12.5f);
 			f.Dispose ();
 			LOGFONT	lf = new LOGFONT();
-			Assert.Throws<ArgumentException>(() => f.ToLogFont (lf));
+			Assert.Throws<ArgumentException> (() => f.ToLogFont (lf));
 		}
 
 		[Test]
@@ -498,7 +498,7 @@ namespace MonoTests.System.Drawing{
 		{
 			Font f = new Font (name, 12.5f);
 			f.Dispose ();
-			Assert.Throws<ArgumentException>(() => f.ToHfont ());
+			Assert.Throws<ArgumentException> (() => f.ToHfont ());
 		}
 		
 		[Test]
@@ -507,7 +507,7 @@ namespace MonoTests.System.Drawing{
 		{
 			// Marked NotWorking because it is dependent on what fonts/styles are available
 			// on the OS.  This test is written for Windows.
-			Assert.Throws<ArgumentException>(() => new Font ("Monotype Corsiva", 8, FontStyle.Regular));
+			Assert.Throws<ArgumentException> (() => new Font ("Monotype Corsiva", 8, FontStyle.Regular));
 		}
 
 		[Test]
@@ -539,7 +539,7 @@ namespace MonoTests.System.Drawing{
 		public void GetHeight_Graphics_Null ()
 		{
 			using (Font f = new Font (name, 12.5f)) {
-				Assert.Throws<ArgumentNullException>(() => Assert.AreEqual (0, f.GetHeight (null), "0"));
+				Assert.Throws<ArgumentNullException> (() => Assert.AreEqual (0, f.GetHeight (null), "0"));
 			}
 		}
 
@@ -554,36 +554,36 @@ namespace MonoTests.System.Drawing{
 			Assert.IsFalse (f1.GetHashCode () == f3.GetHashCode (), "2) Fonts with different styles should have different HashCodes");
 		}
 
-        [Test]
-        public void GetHashCode_UnitDiffers_HashesNotEqual()
-        {
-            Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
-            Font f2 = new Font("Arial", 8.25F, GraphicsUnit.Pixel);
+		[Test]
+		public void GetHashCode_UnitDiffers_HashesNotEqual()
+		{
+			Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
+			Font f2 = new Font("Arial", 8.25F, GraphicsUnit.Pixel);
 
-            Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
-                "Hashcodes should differ if _unit member differs");
-        }
+			Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
+				"Hashcodes should differ if _unit member differs");
+		}
 
-        [Test]
-        public void GetHashCode_NameDiffers_HashesNotEqual()
-        {
-            Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
-            Font f2 = new Font("Courier New", 8.25F, GraphicsUnit.Point);
+		[Test]
+		public void GetHashCode_NameDiffers_HashesNotEqual()
+		{
+			Font f1 = new Font("Arial", 8.25F, GraphicsUnit.Point);
+			Font f2 = new Font("Courier New", 8.25F, GraphicsUnit.Point);
 
 			if (f1.Name != f2.Name) {
 				Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
 							   "Hashcodes should differ if _name member differs");
 			}
-        }
+		}
 
-        [Test]
-        public void GetHashCode_StyleEqualsGdiCharSet_HashesNotEqual()
-        {
-            Font f1 = new Font("Arial", 8.25F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
-            Font f2 = new Font("Arial", 8.25F, FontStyle.Bold, GraphicsUnit.Point, ((byte)(1)));
+		[Test]
+		public void GetHashCode_StyleEqualsGdiCharSet_HashesNotEqual()
+		{
+			Font f1 = new Font("Arial", 8.25F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
+			Font f2 = new Font("Arial", 8.25F, FontStyle.Bold, GraphicsUnit.Point, ((byte)(1)));
 
-            Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
-                "Hashcodes should differ if _style member differs");
-        }
+			Assert.IsFalse(f1.GetHashCode() == f2.GetHashCode(),
+				"Hashcodes should differ if _style member differs");
+		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
@@ -432,7 +432,7 @@ namespace MonoTests.System.Drawing{
 		{
 			Font f = new Font (name, 12.5f);
 			f.Dispose ();
-			Assert.Throws<ArgumentException> (() => Assert.AreEqual (0, f.Height, "Name"));
+			Assert.Throws<ArgumentException> (() => { var x = f.Height; });
 		}
 
 		[Test]
@@ -539,7 +539,7 @@ namespace MonoTests.System.Drawing{
 		public void GetHeight_Graphics_Null ()
 		{
 			using (Font f = new Font (name, 12.5f)) {
-				Assert.Throws<ArgumentNullException> (() => Assert.AreEqual (0, f.GetHeight (null), "0"));
+				Assert.Throws<ArgumentNullException> (() => f.GetHeight (null));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
@@ -120,7 +120,6 @@ namespace MonoTests.System.Drawing{
 
 		[Test]
 		[Category ("CAS")]
-		[ExpectedException (typeof (SecurityException))]
 		[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 		public void ToLogFont_DenyUnmanagedCode ()
 		{
@@ -130,7 +129,7 @@ namespace MonoTests.System.Drawing{
 			lf = new LOGFONT();
 			f = new Font("Arial", 10);
 
-			f.ToLogFont(lf);
+			Assert.Throws<SecurityException>(() => f.ToLogFont(lf));
 		}
 
 		[Test]
@@ -167,12 +166,11 @@ namespace MonoTests.System.Drawing{
 
 		[Test]
 		[SecurityPermission (SecurityAction.Assert, UnmanagedCode = true)]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ToLogFont_TooSmall ()
 		{
 			Font f = new Font ("Arial", 10);
 			object o = new object ();
-			f.ToLogFont (o);
+			Assert.Throws<ArgumentException>(() => f.ToLogFont (o));
 			// no PInvoke conversion exists !?!?
 		}
 
@@ -182,17 +180,16 @@ namespace MonoTests.System.Drawing{
 		{
 			Font f = new Font ("Arial", 10);
 			int i = 1;
-			f.ToLogFont (i);
+			Assert.Throws<AccessViolationException>(() => f.ToLogFont (i));
 			Assert.AreEqual (1, i);
 		}
 
 		[Test]
 		[SecurityPermission (SecurityAction.Assert, UnmanagedCode = true)]
-		[ExpectedException (typeof (AccessViolationException))]
 		public void ToLogFont_Null ()
 		{
 			Font f = new Font ("Arial", 10);
-			f.ToLogFont (null);
+			Assert.Throws<AccessViolationException>(() => f.ToLogFont (null));
 		}
 		[Test]
 		public void Font_StringNull_Float ()
@@ -260,10 +257,9 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Font_String_Float_FontStyle_GraphicsUnit_Display ()
 		{
-			new Font (name, 12.5f, FontStyle.Italic, GraphicsUnit.Display);
+			Assert.Throws<ArgumentException>(() => new Font (name, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
 		}
 
 		[Test]
@@ -303,19 +299,17 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Font_FontFamilyNull_Float ()
 		{
 			FontFamily ff = null;
-			new Font (ff, 12.5f);
+			Assert.Throws<ArgumentNullException>(() => new Font (ff, 12.5f));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Font_FontNull_FontStyle ()
 		{
 			Font f = null;
-			new Font (f, FontStyle.Bold);
+			Assert.Throws<NullReferenceException>(() => new Font (f, FontStyle.Bold));
 		}
 
 		[Test]
@@ -373,10 +367,9 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Font_FontFamily_Float_FontStyle_GraphicsUnit_Display ()
 		{
-			new Font (FontFamily.GenericMonospace, 12.5f, FontStyle.Italic, GraphicsUnit.Display);
+			Assert.Throws<ArgumentException>(() => new Font (FontFamily.GenericMonospace, 12.5f, FontStyle.Italic, GraphicsUnit.Display));
 		}
 
 		[Test]
@@ -435,22 +428,20 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_Height ()
 		{
 			Font f = new Font (name, 12.5f);
 			f.Dispose ();
-			Assert.AreEqual (0, f.Height, "Name");
+			Assert.Throws<ArgumentException>(() => Assert.AreEqual (0, f.Height, "Name"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_ToLogFont ()
 		{
 			Font f = new Font (name, 12.5f);
 			f.Dispose ();
 			LOGFONT	lf = new LOGFONT();
-			f.ToLogFont (lf);
+			Assert.Throws<ArgumentException>(() => f.ToLogFont (lf));
 		}
 
 		[Test]
@@ -503,22 +494,20 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_ToHFont ()
 		{
 			Font f = new Font (name, 12.5f);
 			f.Dispose ();
-			f.ToHfont ();
+			Assert.Throws<ArgumentException>(() => f.ToHfont ());
 		}
 		
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		[Category ("NotWorking")]
 		public void UnavailableStyleException ()
 		{
 			// Marked NotWorking because it is dependent on what fonts/styles are available
 			// on the OS.  This test is written for Windows.
-			Font f = new Font ("Monotype Corsiva", 8, FontStyle.Regular);
+			Assert.Throws<ArgumentException>(() => new Font ("Monotype Corsiva", 8, FontStyle.Regular));
 		}
 
 		[Test]
@@ -547,11 +536,10 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void GetHeight_Graphics_Null ()
 		{
 			using (Font f = new Font (name, 12.5f)) {
-				Assert.AreEqual (0, f.GetHeight (null), "0");
+				Assert.Throws<ArgumentNullException>(() => Assert.AreEqual (0, f.GetHeight (null), "0"));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFont.cs
@@ -180,7 +180,7 @@ namespace MonoTests.System.Drawing{
 		{
 			Font f = new Font ("Arial", 10);
 			int i = 1;
-			Assert.Throws<AccessViolationException> (() => f.ToLogFont (i));
+			f.ToLogFont (i);
 			Assert.AreEqual (1, i);
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFontConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFontConverter.cs
@@ -52,14 +52,14 @@ namespace MonoTests.System.Drawing{
 		public void ExTestConvertFrom ()
 		{
 			FontConverter.FontNameConverter f = new FontConverter.FontNameConverter ();
-			Assert.Throws<NotSupportedException>(() => f.ConvertFrom (null));
+			Assert.Throws<NotSupportedException> (() => f.ConvertFrom (null));
 		}
 
 		[Test]
 		public void ExTestConvertFrom2 ()
 		{
 			FontConverter.FontNameConverter f = new FontConverter.FontNameConverter ();
-			Assert.Throws<NotSupportedException>(() => f.ConvertFrom (1));
+			Assert.Throws<NotSupportedException> (() => f.ConvertFrom (1));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestFontConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestFontConverter.cs
@@ -47,21 +47,19 @@ namespace MonoTests.System.Drawing{
 			Assert.IsTrue (f.GetStandardValuesSupported (), "standard values supported");
 			Assert.IsFalse (f.GetStandardValuesExclusive (), "standard values exclusive");
 		}
-		
-		[ExpectedException (typeof (NotSupportedException))]
+
 		[Test]
 		public void ExTestConvertFrom ()
 		{
 			FontConverter.FontNameConverter f = new FontConverter.FontNameConverter ();
-			f.ConvertFrom (null);
+			Assert.Throws<NotSupportedException>(() => f.ConvertFrom (null));
 		}
 
-		[ExpectedException (typeof (NotSupportedException))]
 		[Test]
 		public void ExTestConvertFrom2 ()
 		{
 			FontConverter.FontNameConverter f = new FontConverter.FontNameConverter ();
-			f.ConvertFrom (1);
+			Assert.Throws<NotSupportedException>(() => f.ConvertFrom (1));
 		}
 	}
 }

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
@@ -386,14 +386,14 @@ namespace MonoTests.System.Drawing {
 			// note: file is misnamed (it's a 4bpp bitmap)
 			using (Image img = Image.FromFile (sInFile)) {
 				Assert.AreEqual (PixelFormat.Format4bppIndexed, img.PixelFormat, "PixelFormat");
-				Assert.Throws<Exception>(() => Graphics.FromImage (img));
+				Assert.Throws<Exception> (() => Graphics.FromImage (img));
 			}
 		}
 
 		[Test]
 		public void FromImage ()
 		{
-			Assert.Throws<ArgumentNullException>(() => Graphics.FromImage (null));
+			Assert.Throws<ArgumentNullException> (() => Graphics.FromImage (null));
 		}
 
 		private Graphics Get (int w, int h)
@@ -461,7 +461,7 @@ namespace MonoTests.System.Drawing {
 			Matrix matrix = new Matrix (123, 24, 82, 16, 47, 30);
 			Assert.IsFalse (matrix.IsInvertible, "IsInvertible");
 			Graphics g = Get (16, 16);
-			Assert.Throws<ArgumentException>(() => g.Transform = matrix);
+			Assert.Throws<ArgumentException> (() => g.Transform = matrix);
 		}
 
 
@@ -471,14 +471,14 @@ namespace MonoTests.System.Drawing {
 			Matrix matrix = new Matrix (123, 24, 82, 16, 47, 30);
 			Assert.IsFalse (matrix.IsInvertible, "IsInvertible");
 			Graphics g = Get (16, 16);
-			Assert.Throws<ArgumentException>(() => g.MultiplyTransform (matrix));
+			Assert.Throws<ArgumentException> (() => g.MultiplyTransform (matrix));
 		}
 
 		[Test]
 		public void Multiply_Null ()
 		{
 			Graphics g = Get (16, 16);
-			Assert.Throws<ArgumentNullException>(() => g.MultiplyTransform (null));
+			Assert.Throws<ArgumentNullException> (() => g.MultiplyTransform (null));
 		}
 
 		private void CheckBounds (string msg, RectangleF bounds, float x, float y, float w, float h)
@@ -755,14 +755,14 @@ namespace MonoTests.System.Drawing {
 		public void ScaleTransform_X0 ()
 		{
 			Graphics g = Get (16, 16);
-			Assert.Throws<ArgumentException>(() => g.ScaleTransform (0, 1));
+			Assert.Throws<ArgumentException> (() => g.ScaleTransform (0, 1));
 		}
 
 		[Test]
 		public void ScaleTransform_Y0 ()
 		{
 			Graphics g = Get (16, 16);
-			Assert.Throws<ArgumentException>(() => g.ScaleTransform (1, 0));
+			Assert.Throws<ArgumentException> (() => g.ScaleTransform (1, 0));
 		}
 
 		[Test]
@@ -811,7 +811,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentNullException>(() => g.DrawCurve (null, SmallCurveF));
+			Assert.Throws<ArgumentNullException> (() => g.DrawCurve (null, SmallCurveF));
 		}
 
 		[Test]
@@ -819,7 +819,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentNullException>(() => g.DrawCurve (Pens.Black, (PointF[]) null));
+			Assert.Throws<ArgumentNullException> (() => g.DrawCurve (Pens.Black, (PointF[]) null));
 		}
 
 		[Test]
@@ -827,7 +827,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentNullException>(() => g.DrawCurve (Pens.Black, (Point[]) null));
+			Assert.Throws<ArgumentNullException> (() => g.DrawCurve (Pens.Black, (Point[]) null));
 		}
 
 		[Test]
@@ -849,7 +849,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, new Point[1] { new Point (10, 10) }, 0.5f));
+			Assert.Throws<ArgumentException> (() => g.DrawCurve (Pens.Black, new Point[1] { new Point (10, 10) }, 0.5f));
 			// a single point isn't enough
 		}
 
@@ -858,7 +858,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, TooSmallCurve, 0, 2, 0.5f));
+			Assert.Throws<ArgumentException> (() => g.DrawCurve (Pens.Black, TooSmallCurve, 0, 2, 0.5f));
 			// aha, this is API dependent
 		}
 
@@ -904,7 +904,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, SmallCurveF, 0, 0));
+			Assert.Throws<ArgumentException> (() => g.DrawCurve (Pens.Black, SmallCurveF, 0, 0));
 		}
 
 		[Test]
@@ -912,7 +912,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, SmallCurveF, 0, -1));
+			Assert.Throws<ArgumentException> (() => g.DrawCurve (Pens.Black, SmallCurveF, 0, -1));
 		}
 
 		[Test]
@@ -921,7 +921,7 @@ namespace MonoTests.System.Drawing {
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
 			// starting offset 1 doesn't give 3 points to make a curve
-			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, SmallCurveF, 1, 2));
+			Assert.Throws<ArgumentException> (() => g.DrawCurve (Pens.Black, SmallCurveF, 1, 2));
 			// and in this case 2 points aren't enough to draw something
 		}
 
@@ -1192,7 +1192,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void BeginContainer_GraphicsUnit_Display ()
 		{
-			Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit(GraphicsUnit.Display));
+			Assert.Throws<ArgumentException> (() => BeginContainer_GraphicsUnit(GraphicsUnit.Display));
 		}
 
 		[Test]
@@ -1208,13 +1208,13 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void BeginContainer_GraphicsUnit_World ()
 		{
-			Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit(GraphicsUnit.World));
+			Assert.Throws<ArgumentException> (() => BeginContainer_GraphicsUnit(GraphicsUnit.World));
 		}
 
 		[Test]
 		public void BeginContainer_GraphicsUnit_Bad ()
 		{
-			Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit((GraphicsUnit) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => BeginContainer_GraphicsUnit((GraphicsUnit) Int32.MinValue));
 		}
 
 		[Test]
@@ -1222,7 +1222,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<ArgumentNullException>(() => g.EndContainer (null));
+			Assert.Throws<ArgumentNullException> (() => g.EndContainer (null));
 		}
 
 		[Test]
@@ -1271,7 +1271,7 @@ namespace MonoTests.System.Drawing {
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			Assert.Throws<NullReferenceException>(() => g.Restore (null));
+			Assert.Throws<NullReferenceException> (() => g.Restore (null));
 		}
 
 		[Test]
@@ -1279,7 +1279,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (null, new Rectangle[1]));
+					Assert.Throws<ArgumentNullException> (() => g.FillRectangles (null, new Rectangle[1]));
 				}
 			}
 		}
@@ -1289,7 +1289,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (Brushes.Red, (Rectangle[]) null));
+					Assert.Throws<ArgumentNullException> (() => g.FillRectangles (Brushes.Red, (Rectangle[]) null));
 				}
 			}
 		}
@@ -1299,7 +1299,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentException>(() => g.FillRectangles (Brushes.Red, new Rectangle[0]));
+					Assert.Throws<ArgumentException> (() => g.FillRectangles (Brushes.Red, new Rectangle[0]));
 				}
 			}
 		}
@@ -1309,7 +1309,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (null, new RectangleF[1]));
+					Assert.Throws<ArgumentNullException> (() => g.FillRectangles (null, new RectangleF[1]));
 				}
 			}
 		}
@@ -1319,7 +1319,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (Brushes.Red, (RectangleF[]) null));
+					Assert.Throws<ArgumentNullException> (() => g.FillRectangles (Brushes.Red, (RectangleF[]) null));
 				}
 			}
 		}
@@ -1329,7 +1329,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentException>(() => g.FillRectangles (Brushes.Red, new RectangleF[0]));
+					Assert.Throws<ArgumentException> (() => g.FillRectangles (Brushes.Red, new RectangleF[0]));
 				}
 			}
 		}
@@ -1838,7 +1838,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentNullException>(() => g.MeasureString ("a", null));
+					Assert.Throws<ArgumentNullException> (() => g.MeasureString ("a", null));
 				}
 			}
 		}
@@ -2134,7 +2134,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentNullException>(() => g.MeasureCharacterRanges ("a", null, new RectangleF (), null));
+					Assert.Throws<ArgumentNullException> (() => g.MeasureCharacterRanges ("a", null, new RectangleF (), null));
 				}
 			}
 		}
@@ -2191,14 +2191,14 @@ namespace MonoTests.System.Drawing {
 		public void MeasureCharacterRanges_FirstTooFar ()
 		{
 			string text = "this\nis a test";
-			Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, text.Length, 1));
+			Assert.Throws<ArgumentException> (() => MeasureCharacterRanges(text, text.Length, 1));
 		}
 
 		[Test]
 		public void MeasureCharacterRanges_LengthTooLong ()
 		{
 			string text = "this\nis a test";
-			Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, 0, text.Length + 1));
+			Assert.Throws<ArgumentException> (() => MeasureCharacterRanges(text, 0, text.Length + 1));
 		}
 
 		[Test]
@@ -2247,7 +2247,7 @@ namespace MonoTests.System.Drawing {
 
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					Assert.Throws<ArgumentException>(() => g.MeasureCharacterRanges ("Mono", font, new RectangleF (), null));
+					Assert.Throws<ArgumentException> (() => g.MeasureCharacterRanges ("Mono", font, new RectangleF (), null));
 				}
 			}
 		}
@@ -2581,7 +2581,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap b = new Bitmap (10, 10)) {
 				using (Graphics g = Graphics.FromImage (b)) {
-					Assert.Throws<ArgumentException>(() => g.ReleaseHdcInternal (IntPtr.Zero));
+					Assert.Throws<ArgumentException> (() => g.ReleaseHdcInternal (IntPtr.Zero));
 				}
 			}
 		}
@@ -2593,7 +2593,7 @@ namespace MonoTests.System.Drawing {
 				using (Graphics g = Graphics.FromImage (b)) {
 					IntPtr hdc = g.GetHdc ();
 					g.ReleaseHdcInternal (hdc);
-					Assert.Throws<ArgumentException>(() => g.ReleaseHdcInternal (hdc));
+					Assert.Throws<ArgumentException> (() => g.ReleaseHdcInternal (hdc));
 				}
 			}
 		}
@@ -2616,7 +2616,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap b = new Bitmap (10, 10)) {
 				using (Graphics g = Graphics.FromImage (b)) {
-					Assert.Throws<ArgumentException>(() => g.ReleaseHdc ());
+					Assert.Throws<ArgumentException> (() => g.ReleaseHdc ());
 				}
 			}
 		}
@@ -2628,7 +2628,7 @@ namespace MonoTests.System.Drawing {
 				using (Graphics g = Graphics.FromImage (b)) {
 					g.GetHdc ();
 					g.ReleaseHdc ();
-					Assert.Throws<ArgumentException>(() => g.ReleaseHdc ());
+					Assert.Throws<ArgumentException> (() => g.ReleaseHdc ());
 				}
 			}
 		}
@@ -2771,7 +2771,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawIcon (null, new Rectangle (0, 0, 32, 32)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawIcon (null, new Rectangle (0, 0, 32, 32)));
 				}
 			}
 		}
@@ -2799,7 +2799,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawIcon (null, 4, 2));
+					Assert.Throws<ArgumentNullException> (() => g.DrawIcon (null, 4, 2));
 				}
 			}
 		}
@@ -2820,7 +2820,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawIconUnstretched (null, new Rectangle (0, 0, 40, 20)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawIconUnstretched (null, new Rectangle (0, 0, 40, 20)));
 				}
 			}
 		}
@@ -2848,7 +2848,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new RectangleF (0, 0, 0, 0)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, new RectangleF (0, 0, 0, 0)));
 				}
 			}
 		}
@@ -2871,7 +2871,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new PointF (0, 0)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, new PointF (0, 0)));
 				}
 			}
 		}
@@ -2891,7 +2891,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new PointF[0]));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, new PointF[0]));
 				}
 			}
 		}
@@ -2901,7 +2901,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (bmp, (PointF[]) null));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (bmp, (PointF[]) null));
 				}
 			}
 		}
@@ -2911,7 +2911,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentException>(() => g.DrawImage (bmp, new PointF[0]));
+					Assert.Throws<ArgumentException> (() => g.DrawImage (bmp, new PointF[0]));
 				}
 			}
 		}
@@ -2932,7 +2932,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Rectangle (0, 0, 0, 0)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, new Rectangle (0, 0, 0, 0)));
 				}
 			}
 		}
@@ -2959,7 +2959,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Point (0, 0)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, new Point (0, 0)));
 				}
 			}
 		}
@@ -2979,7 +2979,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Point[0]));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, new Point[0]));
 				}
 			}
 		}
@@ -2989,7 +2989,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (bmp, (Point[]) null));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (bmp, (Point[]) null));
 				}
 			}
 		}
@@ -2999,7 +2999,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentException>(() => g.DrawImage (bmp, new Point[0]));
+					Assert.Throws<ArgumentException> (() => g.DrawImage (bmp, new Point[0]));
 				}
 			}
 		}
@@ -3020,7 +3020,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, Int32.MaxValue, Int32.MinValue));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, Int32.MaxValue, Int32.MinValue));
 				}
 			}
 		}
@@ -3030,7 +3030,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<OverflowException>(() => g.DrawImage (bmp, Int32.MaxValue, Int32.MinValue));
+					Assert.Throws<OverflowException> (() => g.DrawImage (bmp, Int32.MaxValue, Int32.MinValue));
 				}
 			}
 		}
@@ -3050,7 +3050,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, Single.MaxValue, Single.MinValue));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, Single.MaxValue, Single.MinValue));
 				}
 			}
 		}
@@ -3060,7 +3060,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<OverflowException>(() => g.DrawImage (bmp, Single.MaxValue, Single.MinValue));
+					Assert.Throws<OverflowException> (() => g.DrawImage (bmp, Single.MaxValue, Single.MinValue));
 				}
 			}
 		}
@@ -3080,7 +3080,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Rectangle (), new Rectangle (), GraphicsUnit.Display));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, new Rectangle (), new Rectangle (), GraphicsUnit.Display));
 				}
 			}
 		}
@@ -3098,25 +3098,25 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Display ()
 		{
-			Assert.Throws<ArgumentException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Display));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Display));
 		}
 
 		[Test]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Document ()
 		{
-			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Document));
+			Assert.Throws<NotImplementedException> (() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Document));
 		}
 
 		[Test]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Inch ()
 		{
-			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Inch));
+			Assert.Throws<NotImplementedException> (() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Inch));
 		}
 
 		[Test]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Millimeter ()
 		{
-			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Millimeter));
+			Assert.Throws<NotImplementedException> (() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Millimeter));
 		}
 
 		[Test]
@@ -3129,13 +3129,13 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Point ()
 		{
-			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Point));
+			Assert.Throws<NotImplementedException> (() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Point));
 		}
 
 		[Test]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_World ()
 		{
-			Assert.Throws<ArgumentException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.World));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.World));
 		}
 
 		[Test]
@@ -3145,7 +3145,7 @@ namespace MonoTests.System.Drawing {
 			Point[] pts = new Point[3] { new Point (1, 1), new Point (2, 2), new Point (3, 3) };
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, pts, r, GraphicsUnit.Pixel));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, pts, r, GraphicsUnit.Pixel));
 				}
 			}
 		}
@@ -3163,27 +3163,27 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void DrawImage_ImageNullRectangleGraphicsUnit ()
 		{
-			Assert.Throws<ArgumentNullException>(() => DrawImage_ImagePointRectangleGraphicsUnit (null));
+			Assert.Throws<ArgumentNullException> (() => DrawImage_ImagePointRectangleGraphicsUnit (null));
 		}
 
 		[Test]
 		public void DrawImage_ImagePoint0RectangleGraphicsUnit ()
 		{
-			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[0]));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[0]));
 		}
 
 		[Test]
 		public void DrawImage_ImagePoint1RectangleGraphicsUnit ()
 		{
 			Point p = new Point (1, 1);
-			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[1] { p }));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[1] { p }));
 		}
 
 		[Test]
 		public void DrawImage_ImagePoint2RectangleGraphicsUnit ()
 		{
 			Point p = new Point (1, 1);
-			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[2] { p, p }));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[2] { p, p }));
 		}
 
 		[Test]
@@ -3197,7 +3197,7 @@ namespace MonoTests.System.Drawing {
 		public void DrawImage_ImagePoint4RectangleGraphicsUnit ()
 		{
 			Point p = new Point (1, 1);
-			Assert.Throws<NotImplementedException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[4] { p, p, p, p }));
+			Assert.Throws<NotImplementedException> (() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[4] { p, p, p, p }));
 		}
 
 		[Test]
@@ -3207,7 +3207,7 @@ namespace MonoTests.System.Drawing {
 			PointF[] pts = new PointF[3] { new PointF (1, 1), new PointF (2, 2), new PointF (3, 3) };
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, pts, r, GraphicsUnit.Pixel));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImage (null, pts, r, GraphicsUnit.Pixel));
 				}
 			}
 		}
@@ -3225,27 +3225,27 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void DrawImage_ImageNullFRectangleGraphicsUnit ()
 		{
-			Assert.Throws<ArgumentNullException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (null));
+			Assert.Throws<ArgumentNullException> (() => DrawImage_ImagePointFRectangleGraphicsUnit (null));
 		}
 
 		[Test]
 		public void DrawImage_ImagePointF0RectangleGraphicsUnit ()
 		{
-			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[0]));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[0]));
 		}
 
 		[Test]
 		public void DrawImage_ImagePointF1RectangleGraphicsUnit ()
 		{
 			PointF p = new PointF (1, 1);
-			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[1] { p }));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[1] { p }));
 		}
 
 		[Test]
 		public void DrawImage_ImagePointF2RectangleGraphicsUnit ()
 		{
 			PointF p = new PointF (1, 1);
-			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[2] { p, p }));
+			Assert.Throws<ArgumentException> (() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[2] { p, p }));
 		}
 
 		[Test]
@@ -3259,7 +3259,7 @@ namespace MonoTests.System.Drawing {
 		public void DrawImage_ImagePointF4RectangleGraphicsUnit ()
 		{
 			PointF p = new PointF (1, 1);
-			Assert.Throws<NotImplementedException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[4] { p, p, p, p }));
+			Assert.Throws<NotImplementedException> (() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[4] { p, p, p, p }));
 		}
 
 		[Test]
@@ -3294,7 +3294,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, new Point (0, 0)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImageUnscaled (null, new Point (0, 0)));
 				}
 			}
 		}
@@ -3314,7 +3314,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, new Rectangle (0, 0, -1, -1)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImageUnscaled (null, new Rectangle (0, 0, -1, -1)));
 				}
 			}
 		}
@@ -3334,7 +3334,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, 0, 0));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImageUnscaled (null, 0, 0));
 				}
 			}
 		}
@@ -3354,7 +3354,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, 0, 0, -1, -1));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImageUnscaled (null, 0, 0, -1, -1));
 				}
 			}
 		}
@@ -3373,7 +3373,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaledAndClipped (null, new Rectangle (0, 0, 0, 0)));
+					Assert.Throws<ArgumentNullException> (() => g.DrawImageUnscaledAndClipped (null, new Rectangle (0, 0, 0, 0)));
 				}
 			}
 		}
@@ -3405,7 +3405,7 @@ namespace MonoTests.System.Drawing {
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
 					using (GraphicsPath path = new GraphicsPath ()) {
-						Assert.Throws<ArgumentNullException>(() => g.DrawPath (null, path));
+						Assert.Throws<ArgumentNullException> (() => g.DrawPath (null, path));
 					}
 				}
 			}
@@ -3416,7 +3416,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.DrawPath (Pens.Black, null));
+					Assert.Throws<ArgumentNullException> (() => g.DrawPath (Pens.Black, null));
 				}
 			}
 		}
@@ -3456,7 +3456,7 @@ namespace MonoTests.System.Drawing {
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
 					using (GraphicsPath path = new GraphicsPath ()) {
-						Assert.Throws<ArgumentNullException>(() => g.FillPath (null, path));
+						Assert.Throws<ArgumentNullException> (() => g.FillPath (null, path));
 					}
 				}
 			}
@@ -3467,7 +3467,7 @@ namespace MonoTests.System.Drawing {
 		{
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					Assert.Throws<ArgumentNullException>(() => g.FillPath (Brushes.Black, null));
+					Assert.Throws<ArgumentNullException> (() => g.FillPath (Brushes.Black, null));
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
@@ -379,7 +379,6 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (Exception))]
 		public void LoadIndexed_BmpFile ()
 		{
 			// Tests that we can load an indexed file, but...
@@ -387,15 +386,14 @@ namespace MonoTests.System.Drawing {
 			// note: file is misnamed (it's a 4bpp bitmap)
 			using (Image img = Image.FromFile (sInFile)) {
 				Assert.AreEqual (PixelFormat.Format4bppIndexed, img.PixelFormat, "PixelFormat");
-				Graphics.FromImage (img);
+				Assert.Throws<Exception>(() => Graphics.FromImage (img));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FromImage ()
 		{
-			Graphics g = Graphics.FromImage (null);
+			Assert.Throws<ArgumentNullException>(() => Graphics.FromImage (null));
 		}
 
 		private Graphics Get (int w, int h)
@@ -458,32 +456,29 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Transform_NonInvertibleMatrix ()
 		{
 			Matrix matrix = new Matrix (123, 24, 82, 16, 47, 30);
 			Assert.IsFalse (matrix.IsInvertible, "IsInvertible");
 			Graphics g = Get (16, 16);
-			g.Transform = matrix;
+			Assert.Throws<ArgumentException>(() => g.Transform = matrix);
 		}
 
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Multiply_NonInvertibleMatrix ()
 		{
 			Matrix matrix = new Matrix (123, 24, 82, 16, 47, 30);
 			Assert.IsFalse (matrix.IsInvertible, "IsInvertible");
 			Graphics g = Get (16, 16);
-			g.MultiplyTransform (matrix);
+			Assert.Throws<ArgumentException>(() => g.MultiplyTransform (matrix));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Multiply_Null ()
 		{
 			Graphics g = Get (16, 16);
-			g.MultiplyTransform (null);
+			Assert.Throws<ArgumentNullException>(() => g.MultiplyTransform (null));
 		}
 
 		private void CheckBounds (string msg, RectangleF bounds, float x, float y, float w, float h)
@@ -757,19 +752,17 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ScaleTransform_X0 ()
 		{
 			Graphics g = Get (16, 16);
-			g.ScaleTransform (0, 1);
+			Assert.Throws<ArgumentException>(() => g.ScaleTransform (0, 1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ScaleTransform_Y0 ()
 		{
 			Graphics g = Get (16, 16);
-			g.ScaleTransform (1, 0);
+			Assert.Throws<ArgumentException>(() => g.ScaleTransform (1, 0));
 		}
 
 		[Test]
@@ -814,30 +807,27 @@ namespace MonoTests.System.Drawing {
 		static PointF[] LargeCurveF = new PointF[4] { new PointF (0, 0), new PointF (15, 5), new PointF (5, 15), new PointF (0, 20) };
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawCurve_PenNull ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.DrawCurve (null, SmallCurveF);
+			Assert.Throws<ArgumentNullException>(() => g.DrawCurve (null, SmallCurveF));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawCurve_PointFNull ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.DrawCurve (Pens.Black, (PointF[]) null);
+			Assert.Throws<ArgumentNullException>(() => g.DrawCurve (Pens.Black, (PointF[]) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawCurve_PointNull ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.DrawCurve (Pens.Black, (Point[]) null);
+			Assert.Throws<ArgumentNullException>(() => g.DrawCurve (Pens.Black, (Point[]) null));
 		}
 
 		[Test]
@@ -855,22 +845,20 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawCurve_SinglePoint ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.DrawCurve (Pens.Black, new Point[1] { new Point (10, 10) }, 0.5f);
+			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, new Point[1] { new Point (10, 10) }, 0.5f));
 			// a single point isn't enough
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawCurve3_NotEnoughPoints ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.DrawCurve (Pens.Black, TooSmallCurve, 0, 2, 0.5f);
+			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, TooSmallCurve, 0, 2, 0.5f));
 			// aha, this is API dependent
 		}
 
@@ -912,31 +900,28 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawCurve_ZeroSegments ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.DrawCurve (Pens.Black, SmallCurveF, 0, 0);
+			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, SmallCurveF, 0, 0));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawCurve_NegativeSegments ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.DrawCurve (Pens.Black, SmallCurveF, 0, -1);
+			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, SmallCurveF, 0, -1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawCurve_OffsetTooLarge ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
 			// starting offset 1 doesn't give 3 points to make a curve
-			g.DrawCurve (Pens.Black, SmallCurveF, 1, 2);
+			Assert.Throws<ArgumentException>(() => g.DrawCurve (Pens.Black, SmallCurveF, 1, 2));
 			// and in this case 2 points aren't enough to draw something
 		}
 
@@ -1205,10 +1190,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BeginContainer_GraphicsUnit_Display ()
 		{
-			BeginContainer_GraphicsUnit (GraphicsUnit.Display);
+			Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit(GraphicsUnit.Display));
 		}
 
 		[Test]
@@ -1222,26 +1206,23 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BeginContainer_GraphicsUnit_World ()
 		{
-			BeginContainer_GraphicsUnit (GraphicsUnit.World);
+			Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit(GraphicsUnit.World));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void BeginContainer_GraphicsUnit_Bad ()
 		{
-			BeginContainer_GraphicsUnit ((GraphicsUnit) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit((GraphicsUnit) Int32.MinValue));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void EndContainer_Null ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.EndContainer (null);
+			Assert.Throws<ArgumentNullException>(() => g.EndContainer (null));
 		}
 
 		[Test]
@@ -1286,76 +1267,69 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Restore_Null ()
 		{
 			Bitmap bitmap = new Bitmap (20, 20);
 			Graphics g = Graphics.FromImage (bitmap);
-			g.Restore (null);
+			Assert.Throws<NullReferenceException>(() => g.Restore (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FillRectangles_BrushNull_Rectangle ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.FillRectangles (null, new Rectangle[1]);
+					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (null, new Rectangle[1]));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FillRectangles_Rectangle_Null ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.FillRectangles (Brushes.Red, (Rectangle[]) null);
+					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (Brushes.Red, (Rectangle[]) null));
 				}
 			}
 		}
 
 		[Test] // see bug #78408
-		[ExpectedException (typeof (ArgumentException))]
 		public void FillRectanglesZeroRectangle ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.FillRectangles (Brushes.Red, new Rectangle[0]);
+					Assert.Throws<ArgumentException>(() => g.FillRectangles (Brushes.Red, new Rectangle[0]));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FillRectangles_BrushNull_RectangleF ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.FillRectangles (null, new RectangleF[1]);
+					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (null, new RectangleF[1]));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FillRectangles_RectangleF_Null ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.FillRectangles (Brushes.Red, (RectangleF[]) null);
+					Assert.Throws<ArgumentNullException>(() => g.FillRectangles (Brushes.Red, (RectangleF[]) null));
 				}
 			}
 		}
 
 		[Test] // see bug #78408
-		[ExpectedException (typeof (ArgumentException))]
 		public void FillRectanglesZeroRectangleF ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.FillRectangles (Brushes.Red, new RectangleF[0]);
+					Assert.Throws<ArgumentException>(() => g.FillRectangles (Brushes.Red, new RectangleF[0]));
 				}
 			}
 		}
@@ -1860,12 +1834,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MeasureString_StringFont_Null ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.MeasureString ("a", null);
+					Assert.Throws<ArgumentNullException>(() => g.MeasureString ("a", null));
 				}
 			}
 		}
@@ -2157,12 +2130,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MeasureCharacterRanges_FontNull ()
 		{
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.MeasureCharacterRanges ("a", null, new RectangleF (), null);
+					Assert.Throws<ArgumentNullException>(() => g.MeasureCharacterRanges ("a", null, new RectangleF (), null));
 				}
 			}
 		}
@@ -2216,19 +2188,17 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void MeasureCharacterRanges_FirstTooFar ()
 		{
 			string text = "this\nis a test";
-			MeasureCharacterRanges (text, text.Length, 1);
+			Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, text.Length, 1));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void MeasureCharacterRanges_LengthTooLong ()
 		{
 			string text = "this\nis a test";
-			MeasureCharacterRanges (text, 0, text.Length + 1);
+			Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, 0, text.Length + 1));
 		}
 
 		[Test]
@@ -2270,7 +2240,6 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void MeasureCharacterRanges_NullStringFormat ()
 		{
 			if (font == null)
@@ -2278,7 +2247,7 @@ namespace MonoTests.System.Drawing {
 
 			using (Bitmap bitmap = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bitmap)) {
-					g.MeasureCharacterRanges ("Mono", font, new RectangleF (), null);
+					Assert.Throws<ArgumentException>(() => g.MeasureCharacterRanges ("Mono", font, new RectangleF (), null));
 				}
 			}
 		}
@@ -2458,10 +2427,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		static CharacterRange [] ranges = new CharacterRange [] {
-                    new CharacterRange (0, 1),
-                    new CharacterRange (1, 1),
-                    new CharacterRange (2, 1)
-                };
+					new CharacterRange (0, 1),
+					new CharacterRange (1, 1),
+					new CharacterRange (2, 1)
+				};
 
 		Region [] Measure (Graphics gfx, RectangleF rect)
 		{
@@ -2608,25 +2577,23 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ReleaseHdcInternal_IntPtrZero ()
 		{
 			using (Bitmap b = new Bitmap (10, 10)) {
 				using (Graphics g = Graphics.FromImage (b)) {
-					g.ReleaseHdcInternal (IntPtr.Zero);
+					Assert.Throws<ArgumentException>(() => g.ReleaseHdcInternal (IntPtr.Zero));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ReleaseHdcInternal_TwoTimes ()
 		{
 			using (Bitmap b = new Bitmap (10, 10)) {
 				using (Graphics g = Graphics.FromImage (b)) {
 					IntPtr hdc = g.GetHdc ();
 					g.ReleaseHdcInternal (hdc);
-					g.ReleaseHdcInternal (hdc);
+					Assert.Throws<ArgumentException>(() => g.ReleaseHdcInternal (hdc));
 				}
 			}
 		}
@@ -2645,25 +2612,23 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestReleaseHdcException ()
 		{
 			using (Bitmap b = new Bitmap (10, 10)) {
 				using (Graphics g = Graphics.FromImage (b)) {
-					g.ReleaseHdc ();
+					Assert.Throws<ArgumentException>(() => g.ReleaseHdc ());
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestReleaseHdcException2 ()
 		{
 			using (Bitmap b = new Bitmap (10, 10)) {
 				using (Graphics g = Graphics.FromImage (b)) {
 					g.GetHdc ();
 					g.ReleaseHdc ();
-					g.ReleaseHdc ();
+					Assert.Throws<ArgumentException>(() => g.ReleaseHdc ());
 				}
 			}
 		}
@@ -2802,12 +2767,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawIcon_NullRectangle ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawIcon (null, new Rectangle (0, 0, 32, 32));
+					Assert.Throws<ArgumentNullException>(() => g.DrawIcon (null, new Rectangle (0, 0, 32, 32)));
 				}
 			}
 		}
@@ -2831,12 +2795,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawIcon_NullIntInt ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawIcon (null, 4, 2);
+					Assert.Throws<ArgumentNullException>(() => g.DrawIcon (null, 4, 2));
 				}
 			}
 		}
@@ -2853,12 +2816,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawIconUnstretched_NullRectangle ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawIconUnstretched (null, new Rectangle (0, 0, 40, 20));
+					Assert.Throws<ArgumentNullException>(() => g.DrawIconUnstretched (null, new Rectangle (0, 0, 40, 20)));
 				}
 			}
 		}
@@ -2882,12 +2844,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullRectangleF ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, new RectangleF (0, 0, 0, 0));
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new RectangleF (0, 0, 0, 0)));
 				}
 			}
 		}
@@ -2906,12 +2867,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullPointF ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, new PointF (0, 0));
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new PointF (0, 0)));
 				}
 			}
 		}
@@ -2927,34 +2887,31 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullPointFArray ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, new PointF[0]);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new PointF[0]));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_ImagePointFArrayNull ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (bmp, (PointF[]) null);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (bmp, (PointF[]) null));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePointFArrayEmpty ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (bmp, new PointF[0]);
+					Assert.Throws<ArgumentException>(() => g.DrawImage (bmp, new PointF[0]));
 				}
 			}
 		}
@@ -2971,12 +2928,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullRectangle ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, new Rectangle (0, 0, 0, 0));
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Rectangle (0, 0, 0, 0)));
 				}
 			}
 		}
@@ -2999,12 +2955,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullPoint ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, new Point (0, 0));
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Point (0, 0)));
 				}
 			}
 		}
@@ -3020,34 +2975,31 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullPointArray ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, new Point[0]);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Point[0]));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_ImagePointArrayNull ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (bmp, (Point[]) null);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (bmp, (Point[]) null));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePointArrayEmpty ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (bmp, new Point[0]);
+					Assert.Throws<ArgumentException>(() => g.DrawImage (bmp, new Point[0]));
 				}
 			}
 		}
@@ -3064,23 +3016,21 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullIntInt ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, Int32.MaxValue, Int32.MinValue);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, Int32.MaxValue, Int32.MinValue));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (OverflowException))]
 		public void DrawImage_ImageIntInt_Overflow ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (bmp, Int32.MaxValue, Int32.MinValue);
+					Assert.Throws<OverflowException>(() => g.DrawImage (bmp, Int32.MaxValue, Int32.MinValue));
 				}
 			}
 		}
@@ -3096,23 +3046,21 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullFloat ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, Single.MaxValue, Single.MinValue);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, Single.MaxValue, Single.MinValue));
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (OverflowException))]
 		public void DrawImage_ImageFloatFloat_Overflow ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (bmp, Single.MaxValue, Single.MinValue);
+					Assert.Throws<OverflowException>(() => g.DrawImage (bmp, Single.MaxValue, Single.MinValue));
 				}
 			}
 		}
@@ -3128,12 +3076,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullRectangleRectangleGraphicsUnit ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, new Rectangle (), new Rectangle (), GraphicsUnit.Display);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, new Rectangle (), new Rectangle (), GraphicsUnit.Display));
 				}
 			}
 		}
@@ -3149,31 +3096,27 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Display ()
 		{
-			DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Display);
+			Assert.Throws<ArgumentException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Display));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotImplementedException))]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Document ()
 		{
-			DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Document);
+			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Document));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotImplementedException))]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Inch ()
 		{
-			DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Inch);
+			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Inch));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotImplementedException))]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Millimeter ()
 		{
-			DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Millimeter);
+			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Millimeter));
 		}
 
 		[Test]
@@ -3184,28 +3127,25 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotImplementedException))]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_Point ()
 		{
-			DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Point);
+			Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.Point));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImageRectangleRectangleGraphicsUnit_World ()
 		{
-			DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.World);
+			Assert.Throws<ArgumentException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit (GraphicsUnit.World));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullPointRectangleGraphicsUnit ()
 		{
 			Rectangle r = new Rectangle (1, 2, 3, 4);
 			Point[] pts = new Point[3] { new Point (1, 1), new Point (2, 2), new Point (3, 3) };
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, pts, r, GraphicsUnit.Pixel);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, pts, r, GraphicsUnit.Pixel));
 				}
 			}
 		}
@@ -3221,33 +3161,29 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_ImageNullRectangleGraphicsUnit ()
 		{
-			DrawImage_ImagePointRectangleGraphicsUnit (null);
+			Assert.Throws<ArgumentNullException>(() => DrawImage_ImagePointRectangleGraphicsUnit (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePoint0RectangleGraphicsUnit ()
 		{
-			DrawImage_ImagePointRectangleGraphicsUnit (new Point[0]);
+			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePoint1RectangleGraphicsUnit ()
 		{
 			Point p = new Point (1, 1);
-			DrawImage_ImagePointRectangleGraphicsUnit (new Point[1] { p });
+			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[1] { p }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePoint2RectangleGraphicsUnit ()
 		{
 			Point p = new Point (1, 1);
-			DrawImage_ImagePointRectangleGraphicsUnit (new Point[2] { p, p });
+			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[2] { p, p }));
 		}
 
 		[Test]
@@ -3258,22 +3194,20 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotImplementedException))]
 		public void DrawImage_ImagePoint4RectangleGraphicsUnit ()
 		{
 			Point p = new Point (1, 1);
-			DrawImage_ImagePointRectangleGraphicsUnit (new Point[4] { p, p, p, p });
+			Assert.Throws<NotImplementedException>(() => DrawImage_ImagePointRectangleGraphicsUnit (new Point[4] { p, p, p, p }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_NullPointFRectangleGraphicsUnit ()
 		{
 			Rectangle r = new Rectangle (1, 2, 3, 4);
 			PointF[] pts = new PointF[3] { new PointF (1, 1), new PointF (2, 2), new PointF (3, 3) };
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImage (null, pts, r, GraphicsUnit.Pixel);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImage (null, pts, r, GraphicsUnit.Pixel));
 				}
 			}
 		}
@@ -3289,33 +3223,29 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImage_ImageNullFRectangleGraphicsUnit ()
 		{
-			DrawImage_ImagePointFRectangleGraphicsUnit (null);
+			Assert.Throws<ArgumentNullException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePointF0RectangleGraphicsUnit ()
 		{
-			DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[0]);
+			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[0]));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePointF1RectangleGraphicsUnit ()
 		{
 			PointF p = new PointF (1, 1);
-			DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[1] { p });
+			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[1] { p }));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void DrawImage_ImagePointF2RectangleGraphicsUnit ()
 		{
 			PointF p = new PointF (1, 1);
-			DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[2] { p, p });
+			Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[2] { p, p }));
 		}
 
 		[Test]
@@ -3326,11 +3256,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotImplementedException))]
 		public void DrawImage_ImagePointF4RectangleGraphicsUnit ()
 		{
 			PointF p = new PointF (1, 1);
-			DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[4] { p, p, p, p });
+			Assert.Throws<NotImplementedException>(() => DrawImage_ImagePointFRectangleGraphicsUnit (new PointF[4] { p, p, p, p }));
 		}
 
 		[Test]
@@ -3361,12 +3290,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImageUnscaled_NullPoint ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImageUnscaled (null, new Point (0, 0));
+					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, new Point (0, 0)));
 				}
 			}
 		}
@@ -3382,12 +3310,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImageUnscaled_NullRectangle ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImageUnscaled (null, new Rectangle (0, 0, -1, -1));
+					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, new Rectangle (0, 0, -1, -1)));
 				}
 			}
 		}
@@ -3403,12 +3330,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImageUnscaled_NullIntInt ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImageUnscaled (null, 0, 0);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, 0, 0));
 				}
 			}
 		}
@@ -3424,12 +3350,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImageUnscaled_NullIntIntIntInt ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImageUnscaled (null, 0, 0, -1, -1);
+					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaled (null, 0, 0, -1, -1));
 				}
 			}
 		}
@@ -3444,12 +3369,11 @@ namespace MonoTests.System.Drawing {
 			}
 		}
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawImageUnscaledAndClipped_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (40, 40)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawImageUnscaledAndClipped (null, new Rectangle (0, 0, 0, 0));
+					Assert.Throws<ArgumentNullException>(() => g.DrawImageUnscaledAndClipped (null, new Rectangle (0, 0, 0, 0)));
 				}
 			}
 		}
@@ -3476,25 +3400,23 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawPath_Pen_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
 					using (GraphicsPath path = new GraphicsPath ()) {
-						g.DrawPath (null, path);
+						Assert.Throws<ArgumentNullException>(() => g.DrawPath (null, path));
 					}
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void DrawPath_Path_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.DrawPath (Pens.Black, null);
+					Assert.Throws<ArgumentNullException>(() => g.DrawPath (Pens.Black, null));
 				}
 			}
 		}
@@ -3529,25 +3451,23 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FillPath_Brush_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
 					using (GraphicsPath path = new GraphicsPath ()) {
-						g.FillPath (null, path);
+						Assert.Throws<ArgumentNullException>(() => g.FillPath (null, path));
 					}
 				}
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void FillPath_Path_Null ()
 		{
 			using (Bitmap bmp = new Bitmap (20, 20)) {
 				using (Graphics g = Graphics.FromImage (bmp)) {
-					g.FillPath (Brushes.Black, null);
+					Assert.Throws<ArgumentNullException>(() => g.FillPath (Brushes.Black, null));
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
@@ -93,10 +93,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_IconNull_Int_Int ()
 		{
-			new Icon ((Icon)null, 32, 32);
+			Assert.Throws<ArgumentException>(() => new Icon ((Icon)null, 32, 32));
 		}
 
 		[Test]
@@ -108,10 +107,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_IconNull_Size ()
 		{
-			new Icon ((Icon) null, new Size (32, 32));
+			Assert.Throws<ArgumentException>(() => new Icon ((Icon) null, new Size (32, 32)));
 		}
 
 		[Test]
@@ -173,58 +171,50 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_StreamNull ()
 		{
-			new Icon ((Stream) null);
+			Assert.Throws<ArgumentException>(() => new Icon ((Stream) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_StreamNull_Int_Int ()
 		{
-			new Icon ((Stream) null, 32, 32);
+			Assert.Throws<ArgumentException>(() => new Icon ((Stream) null, 32, 32));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_StringNull ()
 		{
-			new Icon ((string) null);
+			Assert.Throws<ArgumentNullException>(() => new Icon ((string) null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Constructor_TypeNull_String ()
 		{
-			new Icon ((Type) null, "mono.ico");
+			Assert.Throws<NullReferenceException>(() => new Icon ((Type) null, "mono.ico"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_Type_StringNull ()
 		{
-			new Icon (typeof (Icon), null);
+			Assert.Throws<ArgumentException>(() => new Icon (typeof (Icon), null));
 		}
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Constructor_StreamNull_Size ()
 		{
-			new Icon ((Stream) null, new Size (32, 32));
+			Assert.Throws<ArgumentException>(() => new Icon ((Stream) null, new Size (32, 32)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_StringNull_Size ()
 		{
-			new Icon ((string) null, new Size (32, 32));
+			Assert.Throws<ArgumentNullException>(() => new Icon ((string) null, new Size (32, 32)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_StringNull_Int_Int ()
 		{
-			new Icon ((string) null, 32, 32);
+			Assert.Throws<ArgumentNullException>(() => new Icon ((string) null, 32, 32));
 		}
 
 		[Test]
@@ -380,10 +370,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void Save_Null ()
 		{
-			icon.Save (null);
+			Assert.Throws<NullReferenceException>(() => icon.Save (null));
 		}
 
 		[Test]
@@ -499,34 +488,31 @@ namespace MonoTests.System.Drawing {
 			}
 		}
 
-		[Test, ExpectedException ()] //ToDo: System.ComponentModel.Win32Exception
+		[Test] //ToDo: System.ComponentModel.Win32Exception
 		public void Only256InFile ()
 		{
 			using (FileStream fs = File.OpenRead (TestBitmap.getInFile ("bitmaps/only256.ico"))) {
-				Icon icon = new Icon (fs, 0, 0);
+				Assert.Throws(() => new Icon (fs, 0, 0));
 			}
 		}
 
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ExtractAssociatedIcon_Null ()
 		{
-			Icon.ExtractAssociatedIcon (null);
+			Assert.Throws<ArgumentException>(() => Icon.ExtractAssociatedIcon (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ExtractAssociatedIcon_Empty ()
 		{
-			Icon.ExtractAssociatedIcon (String.Empty);
+			Assert.Throws<ArgumentException>(() => Icon.ExtractAssociatedIcon (String.Empty));
 		}
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
 		public void ExtractAssociatedIcon_DoesNotExists ()
 		{
-			Icon.ExtractAssociatedIcon ("does-not-exists.png");
+			Assert.Throws<FileNotFoundException>(() => Icon.ExtractAssociatedIcon ("does-not-exists.png"));
 		}
 
 		private static bool RunningOnUnix {

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
@@ -492,7 +492,7 @@ namespace MonoTests.System.Drawing {
 		public void Only256InFile ()
 		{
 			using (FileStream fs = File.OpenRead (TestBitmap.getInFile ("bitmaps/only256.ico"))) {
-				Assert.Throws(() => new Icon (fs, 0, 0));
+				Assert.Throws<Exception>(() => new Icon (fs, 0, 0));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
@@ -29,6 +29,7 @@
 //
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -488,11 +489,11 @@ namespace MonoTests.System.Drawing {
 			}
 		}
 
-		[Test] //ToDo: System.ComponentModel.Win32Exception
+		[Test]
 		public void Only256InFile ()
 		{
 			using (FileStream fs = File.OpenRead (TestBitmap.getInFile ("bitmaps/only256.ico"))) {
-				Assert.Throws<Exception> (() => new Icon (fs, 0, 0));
+				Assert.Throws<Win32Exception> (() => new Icon (fs, 0, 0));
 			}
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
@@ -95,7 +95,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Constructor_IconNull_Int_Int ()
 		{
-			Assert.Throws<ArgumentException>(() => new Icon ((Icon)null, 32, 32));
+			Assert.Throws<ArgumentException> (() => new Icon ((Icon)null, 32, 32));
 		}
 
 		[Test]
@@ -109,7 +109,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Constructor_IconNull_Size ()
 		{
-			Assert.Throws<ArgumentException>(() => new Icon ((Icon) null, new Size (32, 32)));
+			Assert.Throws<ArgumentException> (() => new Icon ((Icon) null, new Size (32, 32)));
 		}
 
 		[Test]
@@ -173,48 +173,48 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Constructor_StreamNull ()
 		{
-			Assert.Throws<ArgumentException>(() => new Icon ((Stream) null));
+			Assert.Throws<ArgumentException> (() => new Icon ((Stream) null));
 		}
 
 		[Test]
 		public void Constructor_StreamNull_Int_Int ()
 		{
-			Assert.Throws<ArgumentException>(() => new Icon ((Stream) null, 32, 32));
+			Assert.Throws<ArgumentException> (() => new Icon ((Stream) null, 32, 32));
 		}
 
 		[Test]
 		public void Constructor_StringNull ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Icon ((string) null));
+			Assert.Throws<ArgumentNullException> (() => new Icon ((string) null));
 		}
 
 		[Test]
 		public void Constructor_TypeNull_String ()
 		{
-			Assert.Throws<NullReferenceException>(() => new Icon ((Type) null, "mono.ico"));
+			Assert.Throws<NullReferenceException> (() => new Icon ((Type) null, "mono.ico"));
 		}
 
 		[Test]
 		public void Constructor_Type_StringNull ()
 		{
-			Assert.Throws<ArgumentException>(() => new Icon (typeof (Icon), null));
+			Assert.Throws<ArgumentException> (() => new Icon (typeof (Icon), null));
 		}
 		[Test]
 		public void Constructor_StreamNull_Size ()
 		{
-			Assert.Throws<ArgumentException>(() => new Icon ((Stream) null, new Size (32, 32)));
+			Assert.Throws<ArgumentException> (() => new Icon ((Stream) null, new Size (32, 32)));
 		}
 
 		[Test]
 		public void Constructor_StringNull_Size ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Icon ((string) null, new Size (32, 32)));
+			Assert.Throws<ArgumentNullException> (() => new Icon ((string) null, new Size (32, 32)));
 		}
 
 		[Test]
 		public void Constructor_StringNull_Int_Int ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new Icon ((string) null, 32, 32));
+			Assert.Throws<ArgumentNullException> (() => new Icon ((string) null, 32, 32));
 		}
 
 		[Test]
@@ -372,7 +372,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void Save_Null ()
 		{
-			Assert.Throws<NullReferenceException>(() => icon.Save (null));
+			Assert.Throws<NullReferenceException> (() => icon.Save (null));
 		}
 
 		[Test]
@@ -492,7 +492,7 @@ namespace MonoTests.System.Drawing {
 		public void Only256InFile ()
 		{
 			using (FileStream fs = File.OpenRead (TestBitmap.getInFile ("bitmaps/only256.ico"))) {
-				Assert.Throws<Exception>(() => new Icon (fs, 0, 0));
+				Assert.Throws<Exception> (() => new Icon (fs, 0, 0));
 			}
 		}
 
@@ -500,19 +500,19 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void ExtractAssociatedIcon_Null ()
 		{
-			Assert.Throws<ArgumentException>(() => Icon.ExtractAssociatedIcon (null));
+			Assert.Throws<ArgumentException> (() => Icon.ExtractAssociatedIcon (null));
 		}
 
 		[Test]
 		public void ExtractAssociatedIcon_Empty ()
 		{
-			Assert.Throws<ArgumentException>(() => Icon.ExtractAssociatedIcon (String.Empty));
+			Assert.Throws<ArgumentException> (() => Icon.ExtractAssociatedIcon (String.Empty));
 		}
 
 		[Test]
 		public void ExtractAssociatedIcon_DoesNotExists ()
 		{
-			Assert.Throws<FileNotFoundException>(() => Icon.ExtractAssociatedIcon ("does-not-exists.png"));
+			Assert.Throws<FileNotFoundException> (() => Icon.ExtractAssociatedIcon ("does-not-exists.png"));
 		}
 
 		private static bool RunningOnUnix {

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestImage.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestImage.cs
@@ -69,10 +69,9 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
 		public void FileDoesNotExists ()
 		{
-			Image.FromFile ("FileDoesNotExists.jpg");
+			Assert.Throws<FileNotFoundException>(() => Image.FromFile ("FileDoesNotExists.jpg"));
 		}
 
 		private bool CallbackTrue ()
@@ -101,20 +100,18 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void GetThumbnailImage_Height_Zero ()
 		{
 			using (Bitmap bmp = new Bitmap (10, 10)) {
-				Image tn = bmp.GetThumbnailImage (5, 0, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero);
+				Assert.Throws<OutOfMemoryException>(() => bmp.GetThumbnailImage (5, 0, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void GetThumbnailImage_Width_Negative ()
 		{
 			using (Bitmap bmp = new Bitmap (10, 10)) {
-				Image tn = bmp.GetThumbnailImage (-5, 5, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero);
+				Assert.Throws<OutOfMemoryException>(() => bmp.GetThumbnailImage (-5, 5, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero));
 			}
 		}
 
@@ -245,13 +242,12 @@ namespace MonoTests.System.Drawing{
 
 		[Test]
 		[Category ("NotWorking")] // https://bugzilla.novell.com/show_bug.cgi?id=338779
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromStream_Metafile_Wmf_NotOrigin ()
 		{
 			string filename = TestBitmap.getInFile ("bitmaps/telescope_01.wmf");
 			using (FileStream fs = File.OpenRead (filename)) {
 				fs.Position = fs.Length / 2;
-				Image.FromStream (fs);
+				Assert.Throws<ArgumentException>(() => Image.FromStream (fs));
 			}
 		}
 
@@ -287,31 +283,28 @@ namespace MonoTests.System.Drawing{
 
 		[Test]
 		[Category ("NotWorking")] // https://bugzilla.novell.com/show_bug.cgi?id=338779
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromStream_Metafile_Emf_NotOrigin ()
 		{
 			string filename = TestBitmap.getInFile ("bitmaps/milkmateya01.emf");
 			using (FileStream fs = File.OpenRead (filename)) {
 				fs.Position = fs.Length / 2;
-				Image.FromStream (fs);
+				Assert.Throws<ArgumentException>(() => Image.FromStream (fs));
 			}
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void FromFile_Invalid ()
 		{
 			string filename = Assembly.GetExecutingAssembly ().Location;
-			Image.FromFile (filename);
+			Assert.Throws<OutOfMemoryException>(() => Image.FromFile (filename));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromStream_Invalid ()
 		{
 			string filename = Assembly.GetExecutingAssembly ().Location;
 			using (FileStream fs = File.OpenRead (filename)) {
-				Image.FromStream (fs);
+				Assert.Throws<ArgumentException>(() => Image.FromStream (fs));
 			}
 		}
 
@@ -350,7 +343,6 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void StreamJunkSaveLoad ()
 		{
 			using (MemoryStream ms = new MemoryStream ()) {
@@ -363,7 +355,7 @@ namespace MonoTests.System.Drawing{
 					bmp.Save (ms, ImageFormat.Bmp);
 					Assert.IsTrue (ms.Position > 2, "Position-2");
 					// exception here
-					Image.FromStream (ms);
+					Assert.Throws<ArgumentException>(() => Image.FromStream (ms));
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestImage.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestImage.cs
@@ -71,7 +71,7 @@ namespace MonoTests.System.Drawing{
 		[Test]
 		public void FileDoesNotExists ()
 		{
-			Assert.Throws<FileNotFoundException>(() => Image.FromFile ("FileDoesNotExists.jpg"));
+			Assert.Throws<FileNotFoundException> (() => Image.FromFile ("FileDoesNotExists.jpg"));
 		}
 
 		private bool CallbackTrue ()
@@ -103,7 +103,7 @@ namespace MonoTests.System.Drawing{
 		public void GetThumbnailImage_Height_Zero ()
 		{
 			using (Bitmap bmp = new Bitmap (10, 10)) {
-				Assert.Throws<OutOfMemoryException>(() => bmp.GetThumbnailImage (5, 0, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero));
+				Assert.Throws<OutOfMemoryException> (() => bmp.GetThumbnailImage (5, 0, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero));
 			}
 		}
 
@@ -111,7 +111,7 @@ namespace MonoTests.System.Drawing{
 		public void GetThumbnailImage_Width_Negative ()
 		{
 			using (Bitmap bmp = new Bitmap (10, 10)) {
-				Assert.Throws<OutOfMemoryException>(() => bmp.GetThumbnailImage (-5, 5, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero));
+				Assert.Throws<OutOfMemoryException> (() => bmp.GetThumbnailImage (-5, 5, new Image.GetThumbnailImageAbort (CallbackFalse), IntPtr.Zero));
 			}
 		}
 
@@ -247,7 +247,7 @@ namespace MonoTests.System.Drawing{
 			string filename = TestBitmap.getInFile ("bitmaps/telescope_01.wmf");
 			using (FileStream fs = File.OpenRead (filename)) {
 				fs.Position = fs.Length / 2;
-				Assert.Throws<ArgumentException>(() => Image.FromStream (fs));
+				Assert.Throws<ArgumentException> (() => Image.FromStream (fs));
 			}
 		}
 
@@ -288,7 +288,7 @@ namespace MonoTests.System.Drawing{
 			string filename = TestBitmap.getInFile ("bitmaps/milkmateya01.emf");
 			using (FileStream fs = File.OpenRead (filename)) {
 				fs.Position = fs.Length / 2;
-				Assert.Throws<ArgumentException>(() => Image.FromStream (fs));
+				Assert.Throws<ArgumentException> (() => Image.FromStream (fs));
 			}
 		}
 
@@ -296,7 +296,7 @@ namespace MonoTests.System.Drawing{
 		public void FromFile_Invalid ()
 		{
 			string filename = Assembly.GetExecutingAssembly ().Location;
-			Assert.Throws<OutOfMemoryException>(() => Image.FromFile (filename));
+			Assert.Throws<OutOfMemoryException> (() => Image.FromFile (filename));
 		}
 
 		[Test]
@@ -304,7 +304,7 @@ namespace MonoTests.System.Drawing{
 		{
 			string filename = Assembly.GetExecutingAssembly ().Location;
 			using (FileStream fs = File.OpenRead (filename)) {
-				Assert.Throws<ArgumentException>(() => Image.FromStream (fs));
+				Assert.Throws<ArgumentException> (() => Image.FromStream (fs));
 			}
 		}
 
@@ -355,7 +355,7 @@ namespace MonoTests.System.Drawing{
 					bmp.Save (ms, ImageFormat.Bmp);
 					Assert.IsTrue (ms.Position > 2, "Position-2");
 					// exception here
-					Assert.Throws<ArgumentException>(() => Image.FromStream (ms));
+					Assert.Throws<ArgumentException> (() => Image.FromStream (ms));
 				}
 			}
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestImageConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestImageConverter.cs
@@ -159,73 +159,73 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void ConvertFrom_BadString ()
 		{
-			Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom ("System.Drawing.String"));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertFrom ("System.Drawing.String"));
 		}
 
 		[Test]
 		public void ConvertFrom_BadString_WithCulture ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String"));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String"));
 		}
 
 		[Test]
 		public void ConvertFrom_Bitmap ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20)));
 		}
 
 		[Test]
 		public void ConvertFrom_Point ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10)));
 		}
 
 		[Test]
 		public void ConvertFrom_SizeF ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10)));
 		}
 
 		[Test]
 		public void ConvertFrom_Object ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ()));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ()));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertFrom_BadString ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom ("System.Drawing.String"));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertFrom ("System.Drawing.String"));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertFrom_BadString_Culture ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String"));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String"));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertFrom_Bitmap ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertFrom_Point ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertFrom_SizeF ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertFrom_Object ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ()));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ()));
 		}
 
 		[Test]
@@ -268,97 +268,97 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void ConvertTo_Rectangle ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle)));
 		}
 
 		[Test]
 		public void ConvertTo_Image ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ()));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ()));
 		}
 
 		[Test]
 		public void ConvertTo_Size ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size)));
 		}
 
 		[Test]
 		public void ConvertTo_Bitmap ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap)));
 		}
 
 		[Test]
 		public void ConvertTo_Point ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point)));
 		}
 
 		[Test]
 		public void ConvertTo_Metafile ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile)));
 		}
 
 		[Test]
 		public void ConvertTo_Object ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object)));
 		}
 
 		[Test]
 		public void ConvertTo_Int ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int)));
+			Assert.Throws<NotSupportedException> (() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Rectangle ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Image ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ()));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ()));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Size ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Bitmap ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Point ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Metafile ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Object ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object)));
 		}
 
 		[Test]
 		public void TypeDescriptor_ConvertTo_Int ()
 		{
-            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int)));
+			Assert.Throws<NotSupportedException> (() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int)));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestImageConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestImageConverter.cs
@@ -157,87 +157,75 @@ namespace MonoTests.System.Drawing
 		}
 		
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_BadString ()
 		{
-			imgConv.ConvertFrom ("System.Drawing.String");
+			Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom ("System.Drawing.String"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_BadString_WithCulture ()
 		{
-			imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String");
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_Bitmap ()
 		{
-			imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_Point ()
 		{
-			imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_SizeF ()
 		{
-			imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFrom_Object ()
 		{
-			imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ());
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ()));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertFrom_BadString ()
 		{
-			imgConvFrmTD.ConvertFrom ("System.Drawing.String");
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom ("System.Drawing.String"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertFrom_BadString_Culture ()
 		{
-			imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String");
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, "System.Drawing.String"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertFrom_Bitmap ()
 		{
-			imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Bitmap (20, 20)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertFrom_Point ()
 		{
-			imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Point (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertFrom_SizeF ()
 		{
-			imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new SizeF (10, 10)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertFrom_Object ()
 		{
-			imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ());
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertFrom (null, CultureInfo.InvariantCulture, new Object ()));
 		}
 
 		[Test]
@@ -278,115 +266,99 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Rectangle ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Image ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ());
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ()));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Size ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Bitmap ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Point ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Metafile ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Object ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertTo_Int ()
 		{
-			imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int));
+            Assert.Throws<NotSupportedException>(() => imgConv.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Rectangle ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Rectangle)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Image ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ());
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, image.GetType ()));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Size ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Size)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Bitmap ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Bitmap)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Point ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Point)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Metafile ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Metafile)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Object ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (Object)));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TypeDescriptor_ConvertTo_Int ()
 		{
-			imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int));
+            Assert.Throws<NotSupportedException>(() => imgConvFrmTD.ConvertTo (null, CultureInfo.InvariantCulture, image, typeof (int)));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestPointConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestPointConverter.cs
@@ -253,13 +253,12 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateInstance_CaseSensitive ()
 		{
 			Hashtable ht = new Hashtable ();
 			ht.Add ("x", 2);
 			ht.Add ("Y", 3);
-			ptconv.CreateInstance (null, ht);
+			Assert.Throws<ArgumentException>(() => ptconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -305,10 +304,9 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			ptconv.ConvertFromInvariantString ("1");
+			Assert.Throws<ArgumentException>(() => ptconv.ConvertFromInvariantString ("1"));
 		}
 
 		[Test]
@@ -341,10 +339,9 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromString_string_exc_1 ()
 		{
-			ptconv.ConvertFromString ("1");
+			Assert.Throws<ArgumentException>(() => ptconv.ConvertFromString ("1"));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestPointConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestPointConverter.cs
@@ -258,7 +258,7 @@ namespace MonoTests.System.Drawing
 			Hashtable ht = new Hashtable ();
 			ht.Add ("x", 2);
 			ht.Add ("Y", 3);
-			Assert.Throws<ArgumentException>(() => ptconv.CreateInstance (null, ht));
+			Assert.Throws<ArgumentException> (() => ptconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -306,7 +306,7 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			Assert.Throws<ArgumentException>(() => ptconv.ConvertFromInvariantString ("1"));
+			Assert.Throws<ArgumentException> (() => ptconv.ConvertFromInvariantString ("1"));
 		}
 
 		[Test]
@@ -341,7 +341,7 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void ConvertFromString_string_exc_1 ()
 		{
-			Assert.Throws<ArgumentException>(() => ptconv.ConvertFromString ("1"));
+			Assert.Throws<ArgumentException> (() => ptconv.ConvertFromString ("1"));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestRectangleConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestRectangleConverter.cs
@@ -312,7 +312,7 @@ namespace MonoTests.System.Drawing
 			ht.Add ("Y", -10);
 			ht.Add ("Width", 20);
 			ht.Add ("Height", 30);
-			Assert.Throws<ArgumentException>(() => rconv.CreateInstance (null, ht));
+			Assert.Throws<ArgumentException> (() => rconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -375,7 +375,7 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			Assert.Throws<ArgumentException>(() => rconv.ConvertFromInvariantString ("1, 2, 3"));
+			Assert.Throws<ArgumentException> (() => rconv.ConvertFromInvariantString ("1, 2, 3"));
 		}
 
 		[Test]
@@ -411,7 +411,7 @@ namespace MonoTests.System.Drawing
 		public void ConvertFromString_string_exc_1 ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			Assert.Throws<ArgumentException>(() => rconv.ConvertFromString (string.Format(culture,
+			Assert.Throws<ArgumentException> (() => rconv.ConvertFromString (string.Format(culture,
 				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator)));
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestRectangleConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestRectangleConverter.cs
@@ -305,7 +305,6 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateInstance_CaseSensitive ()
 		{
 			Hashtable ht = new Hashtable ();
@@ -313,7 +312,7 @@ namespace MonoTests.System.Drawing
 			ht.Add ("Y", -10);
 			ht.Add ("Width", 20);
 			ht.Add ("Height", 30);
-			rconv.CreateInstance (null, ht);
+			Assert.Throws<ArgumentException>(() => rconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -374,10 +373,9 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			rconv.ConvertFromInvariantString ("1, 2, 3");
+			Assert.Throws<ArgumentException>(() => rconv.ConvertFromInvariantString ("1, 2, 3"));
 		}
 
 		[Test]
@@ -410,12 +408,11 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromString_string_exc_1 ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			rconv.ConvertFromString (string.Format(culture,
-				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator));
+			Assert.Throws<ArgumentException>(() => rconv.ConvertFromString (string.Format(culture,
+				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator)));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestRegion.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestRegion.cs
@@ -1048,35 +1048,31 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			Region r = new Region (gp);
+			Assert.Throws<ArgumentNullException>(() => new Region (gp));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Constructor_RegionData_Null ()
 		{
 			RegionData rd = null;
-			Region r = new Region (rd);
+            Assert.Throws<ArgumentNullException>(() => new Region (rd));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Union_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			new Region ().Union (gp);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Union (gp));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Union_Region_Null ()
 		{
 			Region r = null;
-			new Region ().Union (r);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Union (r));
 		}
 
 		[Test]
@@ -1091,74 +1087,65 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Intersect_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			new Region ().Intersect (gp);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Intersect (gp));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Intersect_Region_Null ()
 		{
 			Region r = null;
-			new Region ().Intersect (r);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Intersect (r));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Complement_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			new Region ().Complement (gp);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Complement (gp));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Complement_Region_Null ()
 		{
 			Region r = null;
-			new Region ().Complement (r);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Complement (r));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Exclude_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			new Region ().Exclude (gp);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Exclude (gp));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Exclude_Region_Null ()
 		{
 			Region r = null;
-			new Region ().Exclude (r);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Exclude (r));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Xor_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			new Region ().Xor (gp);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Xor (gp));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Xor_Region_Null ()
 		{
 			Region r = null;
-			new Region ().Xor (r);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Xor (r));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void GetBounds_Null ()
 		{
-			new Region ().GetBounds (null);
+            Assert.Throws<ArgumentNullException>(() => new Region ().GetBounds (null));
 		}
 
 		[Test]
@@ -1214,53 +1201,46 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsEmpty_Null ()
 		{
-			new Region ().IsEmpty (null);
+            Assert.Throws<ArgumentNullException>(() => new Region ().IsEmpty (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void IsInfinite_Null ()
 		{
-			new Region ().IsInfinite (null);
+            Assert.Throws<ArgumentNullException>(() => new Region ().IsInfinite (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Equals_NullGraphics ()
 		{
-			new Region ().Equals (null, Graphics.FromImage (new Bitmap (10, 10)));
+            Assert.Throws<ArgumentNullException>(() => new Region ().Equals (null, Graphics.FromImage (new Bitmap (10, 10))));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Equals_RegionNull ()
 		{
-			new Region ().Equals (new Region (), null);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Equals (new Region (), null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		[Category ("NotWorking")] // caused regression in SWF
 		public void GetHrgn_Null ()
 		{
-			new Region ().GetHrgn (null);
+            Assert.Throws<ArgumentNullException>(() => new Region ().GetHrgn (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void GetRegionScans_Null ()
 		{
-			new Region ().GetRegionScans (null);
+            Assert.Throws<ArgumentNullException>(() => new Region ().GetRegionScans (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Transform_Null ()
 		{
-			new Region ().Transform (null);
+            Assert.Throws<ArgumentNullException>(() => new Region ().Transform (null));
 		}
 
 		// an "empty ctor" Region is infinite
@@ -1575,17 +1555,15 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void FromHrgn_Zero ()
 		{
-			Region.FromHrgn (IntPtr.Zero);
+            Assert.Throws<ArgumentException>(() => Region.FromHrgn (IntPtr.Zero));
 		}
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void ReleaseHrng_Zero ()
 		{
 			Region r = new Region (new GraphicsPath ());
-			r.ReleaseHrgn (IntPtr.Zero);
+            Assert.Throws<ArgumentNullException>(() => r.ReleaseHrgn (IntPtr.Zero));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestRegion.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestRegion.cs
@@ -1051,28 +1051,28 @@ namespace MonoTests.System.Drawing
 		public void Constructor_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-			Assert.Throws<ArgumentNullException>(() => new Region (gp));
+			Assert.Throws<ArgumentNullException> (() => new Region (gp));
 		}
 
 		[Test]
 		public void Constructor_RegionData_Null ()
 		{
 			RegionData rd = null;
-            Assert.Throws<ArgumentNullException>(() => new Region (rd));
+			Assert.Throws<ArgumentNullException> (() => new Region (rd));
 		}
 
 		[Test]
 		public void Union_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Union (gp));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Union (gp));
 		}
 
 		[Test]
 		public void Union_Region_Null ()
 		{
 			Region r = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Union (r));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Union (r));
 		}
 
 		[Test]
@@ -1090,62 +1090,62 @@ namespace MonoTests.System.Drawing
 		public void Intersect_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Intersect (gp));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Intersect (gp));
 		}
 
 		[Test]
 		public void Intersect_Region_Null ()
 		{
 			Region r = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Intersect (r));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Intersect (r));
 		}
 
 		[Test]
 		public void Complement_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Complement (gp));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Complement (gp));
 		}
 
 		[Test]
 		public void Complement_Region_Null ()
 		{
 			Region r = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Complement (r));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Complement (r));
 		}
 
 		[Test]
 		public void Exclude_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Exclude (gp));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Exclude (gp));
 		}
 
 		[Test]
 		public void Exclude_Region_Null ()
 		{
 			Region r = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Exclude (r));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Exclude (r));
 		}
 
 		[Test]
 		public void Xor_GraphicsPath_Null ()
 		{
 			GraphicsPath gp = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Xor (gp));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Xor (gp));
 		}
 
 		[Test]
 		public void Xor_Region_Null ()
 		{
 			Region r = null;
-            Assert.Throws<ArgumentNullException>(() => new Region ().Xor (r));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Xor (r));
 		}
 
 		[Test]
 		public void GetBounds_Null ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().GetBounds (null));
+			Assert.Throws<ArgumentNullException> (() => new Region ().GetBounds (null));
 		}
 
 		[Test]
@@ -1203,44 +1203,44 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void IsEmpty_Null ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().IsEmpty (null));
+			Assert.Throws<ArgumentNullException> (() => new Region ().IsEmpty (null));
 		}
 
 		[Test]
 		public void IsInfinite_Null ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().IsInfinite (null));
+			Assert.Throws<ArgumentNullException> (() => new Region ().IsInfinite (null));
 		}
 
 		[Test]
 		public void Equals_NullGraphics ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().Equals (null, Graphics.FromImage (new Bitmap (10, 10))));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Equals (null, Graphics.FromImage (new Bitmap (10, 10))));
 		}
 
 		[Test]
 		public void Equals_RegionNull ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().Equals (new Region (), null));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Equals (new Region (), null));
 		}
 
 		[Test]
 		[Category ("NotWorking")] // caused regression in SWF
 		public void GetHrgn_Null ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().GetHrgn (null));
+			Assert.Throws<ArgumentNullException> (() => new Region ().GetHrgn (null));
 		}
 
 		[Test]
 		public void GetRegionScans_Null ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().GetRegionScans (null));
+			Assert.Throws<ArgumentNullException> (() => new Region ().GetRegionScans (null));
 		}
 
 		[Test]
 		public void Transform_Null ()
 		{
-            Assert.Throws<ArgumentNullException>(() => new Region ().Transform (null));
+			Assert.Throws<ArgumentNullException> (() => new Region ().Transform (null));
 		}
 
 		// an "empty ctor" Region is infinite
@@ -1557,13 +1557,13 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void FromHrgn_Zero ()
 		{
-            Assert.Throws<ArgumentException>(() => Region.FromHrgn (IntPtr.Zero));
+			Assert.Throws<ArgumentException> (() => Region.FromHrgn (IntPtr.Zero));
 		}
 		[Test]
 		public void ReleaseHrng_Zero ()
 		{
 			Region r = new Region (new GraphicsPath ());
-            Assert.Throws<ArgumentNullException>(() => r.ReleaseHrgn (IntPtr.Zero));
+			Assert.Throws<ArgumentNullException> (() => r.ReleaseHrgn (IntPtr.Zero));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestSizeConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestSizeConverter.cs
@@ -261,7 +261,7 @@ namespace MonoTests.System.Drawing
 			Hashtable ht = new Hashtable ();
 			ht.Add ("width", 20);
 			ht.Add ("Height", 30);
-			Assert.Throws<ArgumentException>(() => szconv.CreateInstance (null, ht));
+			Assert.Throws<ArgumentException> (() => szconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -311,7 +311,7 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			Assert.Throws<ArgumentException>(() => szconv.ConvertFromInvariantString ("1, 2, 3"));
+			Assert.Throws<ArgumentException> (() => szconv.ConvertFromInvariantString ("1, 2, 3"));
 		}
 
 		[Test]
@@ -347,7 +347,7 @@ namespace MonoTests.System.Drawing
 		public void ConvertFromString_string_exc_1 ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			Assert.Throws<ArgumentException>(() => szconv.ConvertFromString (string.Format(culture,
+			Assert.Throws<ArgumentException> (() => szconv.ConvertFromString (string.Format(culture,
 				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator)));
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestSizeConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestSizeConverter.cs
@@ -256,13 +256,12 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TestCreateInstance_CaseSensitive ()
 		{
 			Hashtable ht = new Hashtable ();
 			ht.Add ("width", 20);
 			ht.Add ("Height", 30);
-			szconv.CreateInstance (null, ht);
+			Assert.Throws<ArgumentException>(() => szconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -310,10 +309,9 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			szconv.ConvertFromInvariantString ("1, 2, 3");
+			Assert.Throws<ArgumentException>(() => szconv.ConvertFromInvariantString ("1, 2, 3"));
 		}
 
 		[Test]
@@ -346,12 +344,11 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromString_string_exc_1 ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			szconv.ConvertFromString (string.Format(culture,
-				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator));
+			Assert.Throws<ArgumentException>(() => szconv.ConvertFromString (string.Format(culture,
+				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator)));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestSizeFConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestSizeFConverter.cs
@@ -250,23 +250,21 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidCastException))]
 		public void TestCreateInstance_Int ()
 		{
 			Hashtable ht = new Hashtable ();
 			ht.Add ("Width", 10);
 			ht.Add ("Height", 20);
-			szconv.CreateInstance (null, ht);
+			Assert.Throws<InvalidCastException>(() => szconv.CreateInstance (null, ht));
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void TestCreateInstance_CaseSensitive ()
 		{
 			Hashtable ht = new Hashtable ();
 			ht.Add ("width", 20);
 			ht.Add ("Height", 30);
-			szconv.CreateInstance (null, ht);
+			Assert.Throws<NullReferenceException>(() => szconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -314,10 +312,9 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			szconv.ConvertFromInvariantString ("1, 2, 3");
+			Assert.Throws<ArgumentException>(() => szconv.ConvertFromInvariantString ("1, 2, 3"));
 		}
 
 		[Test]
@@ -350,12 +347,11 @@ namespace MonoTests.System.Drawing
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ConvertFromString_string_exc_1 ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			szconv.ConvertFromString (string.Format(culture,
-				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator));
+			Assert.Throws<ArgumentException>(() => szconv.ConvertFromString (string.Format(culture,
+				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator)));
 		}
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestSizeFConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestSizeFConverter.cs
@@ -255,7 +255,7 @@ namespace MonoTests.System.Drawing
 			Hashtable ht = new Hashtable ();
 			ht.Add ("Width", 10);
 			ht.Add ("Height", 20);
-			Assert.Throws<InvalidCastException>(() => szconv.CreateInstance (null, ht));
+			Assert.Throws<InvalidCastException> (() => szconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -264,7 +264,7 @@ namespace MonoTests.System.Drawing
 			Hashtable ht = new Hashtable ();
 			ht.Add ("width", 20);
 			ht.Add ("Height", 30);
-			Assert.Throws<NullReferenceException>(() => szconv.CreateInstance (null, ht));
+			Assert.Throws<NullReferenceException> (() => szconv.CreateInstance (null, ht));
 		}
 
 		[Test]
@@ -314,7 +314,7 @@ namespace MonoTests.System.Drawing
 		[Test]
 		public void ConvertFromInvariantString_string_exc_1 ()
 		{
-			Assert.Throws<ArgumentException>(() => szconv.ConvertFromInvariantString ("1, 2, 3"));
+			Assert.Throws<ArgumentException> (() => szconv.ConvertFromInvariantString ("1, 2, 3"));
 		}
 
 		[Test]
@@ -350,7 +350,7 @@ namespace MonoTests.System.Drawing
 		public void ConvertFromString_string_exc_1 ()
 		{
 			CultureInfo culture = CultureInfo.CurrentCulture;
-			Assert.Throws<ArgumentException>(() => szconv.ConvertFromString (string.Format(culture,
+			Assert.Throws<ArgumentException> (() => szconv.ConvertFromString (string.Format(culture,
 				"1{0} 2{0} 3{0} 4{0} 5", culture.TextInfo.ListSeparator)));
 		}
 

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestStringFormat.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestStringFormat.cs
@@ -66,19 +66,17 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Default_Dispose ()
 		{
 			StringFormat sf = new StringFormat ();
 			sf.Dispose ();
-			sf.ToString ();
+			Assert.Throws<ArgumentException>(() => sf.ToString ());
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void ctor_StringFormat_Null ()
 		{
-			new StringFormat (null);
+			Assert.Throws<ArgumentNullException>(() => new StringFormat (null));
 		}
 
 		[Test]
@@ -120,12 +118,11 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void GenericDefault_Local_Dispose ()
 		{
 			StringFormat sf = StringFormat.GenericDefault;
 			sf.Dispose (); // can't be cached
-			CheckDefaults (sf);
+			Assert.Throws<ArgumentException>(() => CheckDefaults (sf));
 		}
 
 		private void CheckTypographic (StringFormat sf)
@@ -155,12 +152,11 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void GenericTypographic_Local_Dispose ()
 		{
 			StringFormat sf = StringFormat.GenericTypographic;
 			sf.Dispose (); // can't be cached
-			CheckTypographic (sf);
+			Assert.Throws<ArgumentException>(() => CheckTypographic (sf));
 		}
 
 		[Test]
@@ -175,11 +171,10 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void Alignment_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				sf.Alignment = (StringAlignment) Int32.MinValue;
+				Assert.Throws<InvalidEnumArgumentException>(() => sf.Alignment = (StringAlignment) Int32.MinValue);
 			}
 		}
 
@@ -195,11 +190,10 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void HotkeyPrefix_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				sf.HotkeyPrefix = (HotkeyPrefix) Int32.MinValue;
+				Assert.Throws<InvalidEnumArgumentException>(() => sf.HotkeyPrefix = (HotkeyPrefix) Int32.MinValue);
 			}
 		}
 
@@ -215,11 +209,10 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void LineAlignment_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				sf.LineAlignment = (StringAlignment) Int32.MinValue;
+				Assert.Throws<InvalidEnumArgumentException>(() => sf.LineAlignment = (StringAlignment) Int32.MinValue);
 			}
 		}
 
@@ -235,11 +228,10 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void Trimming_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				sf.Trimming = (StringTrimming) Int32.MinValue;
+				Assert.Throws<InvalidEnumArgumentException>(() => sf.Trimming = (StringTrimming) Int32.MinValue);
 			}
 		}
 
@@ -311,11 +303,10 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void SetTabStops_Null ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				sf.SetTabStops (Single.NaN, null);
+				Assert.Throws<NullReferenceException>(() => sf.SetTabStops (Single.NaN, null));
 			}
 		}
 
@@ -330,11 +321,10 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (NullReferenceException))]
 		public void SetMeasurableCharacterRanges_Null ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				sf.SetMeasurableCharacterRanges (null);
+				Assert.Throws<NullReferenceException>(() => sf.SetMeasurableCharacterRanges (null));
 			}
 		}
 
@@ -357,12 +347,11 @@ namespace MonoTests.System.Drawing{
 		}
 
 		[Test]
-		[ExpectedException (typeof (OverflowException))]
 		public void SetMeasurableCharacterRanges_TooBig ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
 				CharacterRange[] range = new CharacterRange[33];
-				sf.SetMeasurableCharacterRanges (range);
+				Assert.Throws<OverflowException>(() => sf.SetMeasurableCharacterRanges (range));
 			}
 		}
 	}

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestStringFormat.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestStringFormat.cs
@@ -70,13 +70,13 @@ namespace MonoTests.System.Drawing{
 		{
 			StringFormat sf = new StringFormat ();
 			sf.Dispose ();
-			Assert.Throws<ArgumentException>(() => sf.ToString ());
+			Assert.Throws<ArgumentException> (() => sf.ToString ());
 		}
 
 		[Test]
 		public void ctor_StringFormat_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new StringFormat (null));
+			Assert.Throws<ArgumentNullException> (() => new StringFormat (null));
 		}
 
 		[Test]
@@ -122,7 +122,7 @@ namespace MonoTests.System.Drawing{
 		{
 			StringFormat sf = StringFormat.GenericDefault;
 			sf.Dispose (); // can't be cached
-			Assert.Throws<ArgumentException>(() => CheckDefaults (sf));
+			Assert.Throws<ArgumentException> (() => CheckDefaults (sf));
 		}
 
 		private void CheckTypographic (StringFormat sf)
@@ -156,7 +156,7 @@ namespace MonoTests.System.Drawing{
 		{
 			StringFormat sf = StringFormat.GenericTypographic;
 			sf.Dispose (); // can't be cached
-			Assert.Throws<ArgumentException>(() => CheckTypographic (sf));
+			Assert.Throws<ArgumentException> (() => CheckTypographic (sf));
 		}
 
 		[Test]
@@ -174,7 +174,7 @@ namespace MonoTests.System.Drawing{
 		public void Alignment_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				Assert.Throws<InvalidEnumArgumentException>(() => sf.Alignment = (StringAlignment) Int32.MinValue);
+				Assert.Throws<InvalidEnumArgumentException> (() => sf.Alignment = (StringAlignment) Int32.MinValue);
 			}
 		}
 
@@ -193,7 +193,7 @@ namespace MonoTests.System.Drawing{
 		public void HotkeyPrefix_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				Assert.Throws<InvalidEnumArgumentException>(() => sf.HotkeyPrefix = (HotkeyPrefix) Int32.MinValue);
+				Assert.Throws<InvalidEnumArgumentException> (() => sf.HotkeyPrefix = (HotkeyPrefix) Int32.MinValue);
 			}
 		}
 
@@ -212,7 +212,7 @@ namespace MonoTests.System.Drawing{
 		public void LineAlignment_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				Assert.Throws<InvalidEnumArgumentException>(() => sf.LineAlignment = (StringAlignment) Int32.MinValue);
+				Assert.Throws<InvalidEnumArgumentException> (() => sf.LineAlignment = (StringAlignment) Int32.MinValue);
 			}
 		}
 
@@ -231,7 +231,7 @@ namespace MonoTests.System.Drawing{
 		public void Trimming_Invalid ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				Assert.Throws<InvalidEnumArgumentException>(() => sf.Trimming = (StringTrimming) Int32.MinValue);
+				Assert.Throws<InvalidEnumArgumentException> (() => sf.Trimming = (StringTrimming) Int32.MinValue);
 			}
 		}
 
@@ -306,7 +306,7 @@ namespace MonoTests.System.Drawing{
 		public void SetTabStops_Null ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				Assert.Throws<NullReferenceException>(() => sf.SetTabStops (Single.NaN, null));
+				Assert.Throws<NullReferenceException> (() => sf.SetTabStops (Single.NaN, null));
 			}
 		}
 
@@ -324,7 +324,7 @@ namespace MonoTests.System.Drawing{
 		public void SetMeasurableCharacterRanges_Null ()
 		{
 			using (StringFormat sf = new StringFormat ()) {
-				Assert.Throws<NullReferenceException>(() => sf.SetMeasurableCharacterRanges (null));
+				Assert.Throws<NullReferenceException> (() => sf.SetMeasurableCharacterRanges (null));
 			}
 		}
 
@@ -351,7 +351,7 @@ namespace MonoTests.System.Drawing{
 		{
 			using (StringFormat sf = new StringFormat ()) {
 				CharacterRange[] range = new CharacterRange[33];
-				Assert.Throws<OverflowException>(() => sf.SetMeasurableCharacterRanges (range));
+				Assert.Throws<OverflowException> (() => sf.SetMeasurableCharacterRanges (range));
 			}
 		}
 	}

--- a/mcs/class/System.Drawing/Test/System.Drawing/TextureBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TextureBrushTest.cs
@@ -69,7 +69,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImage_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (null));
 		}
 
 		[Test]
@@ -82,7 +82,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImage_Null_WrapMode ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, WrapMode.Clamp));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (null, WrapMode.Clamp));
 		}
 
 		[Test]
@@ -97,19 +97,19 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImageWrapMode_Invalid ()
 		{
-			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image, (WrapMode) Int32.MinValue));
+			Assert.Throws<InvalidEnumArgumentException> (() => new TextureBrush (image, (WrapMode) Int32.MinValue));
 		}
 
 		[Test]
 		public void CtorImage_Null_Rectangle ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rect));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (null, rect));
 		}
 
 		[Test]
 		public void CtorImageRectangle_Empty ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new Rectangle ()));
+			Assert.Throws<OutOfMemoryException> (() => new TextureBrush (image, new Rectangle ()));
 		}
 
 		[Test]
@@ -122,13 +122,13 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImage_Null_RectangleF ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rectf));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (null, rectf));
 		}
 
 		[Test]
 		public void CtorImageRectangleF_Empty ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new RectangleF ()));
+			Assert.Throws<OutOfMemoryException> (() => new TextureBrush (image, new RectangleF ()));
 		}
 
 		[Test]
@@ -141,13 +141,13 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImage_Null_RectangleAttributes ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rect, attr));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (null, rect, attr));
 		}
 
 		[Test]
 		public void CtorImageRectangle_Empty_Attributes ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new Rectangle (), attr));
+			Assert.Throws<OutOfMemoryException> (() => new TextureBrush (image, new Rectangle (), attr));
 		}
 
 		[Test]
@@ -167,13 +167,13 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImage_Null_RectangleFAttributes ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rectf, attr));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (null, rectf, attr));
 		}
 
 		[Test]
 		public void CtorImageRectangleF_Empty_Attributes ()
 		{
-			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new RectangleF ()));
+			Assert.Throws<OutOfMemoryException> (() => new TextureBrush (image, new RectangleF ()));
 		}
 
 		[Test]
@@ -202,7 +202,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImageWrapMode_Invalid_Rectangle ()
 		{
-			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image, (WrapMode) Int32.MinValue, rect));
+			Assert.Throws<InvalidEnumArgumentException> (() => new TextureBrush (image, (WrapMode) Int32.MinValue, rect));
 		}
 
 		[Test]
@@ -217,7 +217,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void CtorImageWrapMode_Invalid_RectangleF ()
 		{
-			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image, (WrapMode) Int32.MinValue, rectf));
+			Assert.Throws<InvalidEnumArgumentException> (() => new TextureBrush (image, (WrapMode) Int32.MinValue, rectf));
 		}
 
 		[Test]
@@ -241,13 +241,13 @@ namespace MonoTests.System.Drawing {
 			Rectangle r = new Rectangle (50, 50, 50, 50);
 			Assert.IsFalse (r.Y + r.Height <= bmp.Height, "Height");
 			Assert.IsFalse (r.X + r.Width <= bmp.Width, "Width");
-			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (bmp, r));
+			Assert.Throws<OutOfMemoryException> (() => new TextureBrush (bmp, r));
 		}
 
 		[Test]
 		public void Transform_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (image).Transform = null);
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (image).Transform = null);
 		}
 
 		[Test]
@@ -272,7 +272,7 @@ namespace MonoTests.System.Drawing {
 		[Test]
 		public void WrapMode_Invalid ()
 		{
-			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image).WrapMode = (WrapMode)Int32.MinValue);
+			Assert.Throws<InvalidEnumArgumentException> (() => new TextureBrush (image).WrapMode = (WrapMode)Int32.MinValue);
 		}
 
 		[Test]
@@ -288,7 +288,7 @@ namespace MonoTests.System.Drawing {
 		{
 			TextureBrush t = new TextureBrush (image);
 			t.Dispose ();
-			Assert.Throws<ArgumentException>(() => t.Clone ());
+			Assert.Throws<ArgumentException> (() => t.Clone ());
 		}
 
 		[Test]
@@ -305,19 +305,19 @@ namespace MonoTests.System.Drawing {
 		{
 			TextureBrush t = new TextureBrush (image);
 			t.Dispose ();
-			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (t.Image, "Image"));
+			Assert.Throws<ArgumentException> (() => Assert.IsNotNull (t.Image, "Image"));
 		}
 
 		[Test]
 		public void MultiplyTransform_Null ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (image).MultiplyTransform (null));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (image).MultiplyTransform (null));
 		}
 
 		[Test]
 		public void MultiplyTransform_Null_Order ()
 		{
-			Assert.Throws<ArgumentNullException>(() => new TextureBrush (image).MultiplyTransform (null, MatrixOrder.Append));
+			Assert.Throws<ArgumentNullException> (() => new TextureBrush (image).MultiplyTransform (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -332,7 +332,7 @@ namespace MonoTests.System.Drawing {
 		{
 			TextureBrush t = new TextureBrush (image);
 			Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30);
-			Assert.Throws<ArgumentException>(() => t.MultiplyTransform (noninvertible));
+			Assert.Throws<ArgumentException> (() => t.MultiplyTransform (noninvertible));
 		}
 
 		[Test]
@@ -366,7 +366,7 @@ namespace MonoTests.System.Drawing {
 		public void RotateTransform_InvalidOrder ()
 		{
 			TextureBrush t = new TextureBrush (image);
-			Assert.Throws<ArgumentException>(() => t.RotateTransform (720, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => t.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -404,7 +404,7 @@ namespace MonoTests.System.Drawing {
 		public void ScaleTransform_InvalidOrder ()
 		{
 			TextureBrush t = new TextureBrush (image);
-			Assert.Throws<ArgumentException>(() => t.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => t.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -434,7 +434,7 @@ namespace MonoTests.System.Drawing {
 		public void TranslateTransform_InvalidOrder ()
 		{
 			TextureBrush t = new TextureBrush (image);
-			Assert.Throws<ArgumentException>(() => t.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
+			Assert.Throws<ArgumentException> (() => t.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		private void Alpha_81828 (WrapMode mode, bool equals)

--- a/mcs/class/System.Drawing/Test/System.Drawing/TextureBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TextureBrushTest.cs
@@ -67,10 +67,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CtorImage_Null ()
 		{
-			new TextureBrush (null);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null));
 		}
 
 		[Test]
@@ -81,10 +80,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CtorImage_Null_WrapMode ()
 		{
-			new TextureBrush (null, WrapMode.Clamp);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, WrapMode.Clamp));
 		}
 
 		[Test]
@@ -97,24 +95,21 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void CtorImageWrapMode_Invalid ()
 		{
-			new TextureBrush (image, (WrapMode) Int32.MinValue);
+			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image, (WrapMode) Int32.MinValue));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CtorImage_Null_Rectangle ()
 		{
-			new TextureBrush (null, rect);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rect));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void CtorImageRectangle_Empty ()
 		{
-			new TextureBrush (image, new Rectangle ());
+			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new Rectangle ()));
 		}
 
 		[Test]
@@ -125,17 +120,15 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CtorImage_Null_RectangleF ()
 		{
-			new TextureBrush (null, rectf);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rectf));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void CtorImageRectangleF_Empty ()
 		{
-			new TextureBrush (image, new RectangleF ());
+			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new RectangleF ()));
 		}
 
 		[Test]
@@ -146,17 +139,15 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CtorImage_Null_RectangleAttributes ()
 		{
-			new TextureBrush (null, rect, attr);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rect, attr));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void CtorImageRectangle_Empty_Attributes ()
 		{
-			new TextureBrush (image, new Rectangle (), attr);
+			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new Rectangle (), attr));
 		}
 
 		[Test]
@@ -174,17 +165,15 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void CtorImage_Null_RectangleFAttributes ()
 		{
-			new TextureBrush (null, rectf, attr);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (null, rectf, attr));
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void CtorImageRectangleF_Empty_Attributes ()
 		{
-			new TextureBrush (image, new RectangleF ());
+			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (image, new RectangleF ()));
 		}
 
 		[Test]
@@ -211,10 +200,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void CtorImageWrapMode_Invalid_Rectangle ()
 		{
-			new TextureBrush (image, (WrapMode) Int32.MinValue, rect);
+			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image, (WrapMode) Int32.MinValue, rect));
 		}
 
 		[Test]
@@ -227,10 +215,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void CtorImageWrapMode_Invalid_RectangleF ()
 		{
-			new TextureBrush (image, (WrapMode) Int32.MinValue, rectf);
+			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image, (WrapMode) Int32.MinValue, rectf));
 		}
 
 		[Test]
@@ -249,20 +236,18 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (OutOfMemoryException))]
 		public void TextureBush_RectangleOutsideBitmap ()
 		{
 			Rectangle r = new Rectangle (50, 50, 50, 50);
 			Assert.IsFalse (r.Y + r.Height <= bmp.Height, "Height");
 			Assert.IsFalse (r.X + r.Width <= bmp.Width, "Width");
-			new TextureBrush (bmp, r);
+			Assert.Throws<OutOfMemoryException>(() => new TextureBrush (bmp, r));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void Transform_Null ()
 		{
-			new TextureBrush (image).Transform = null;
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (image).Transform = null);
 		}
 
 		[Test]
@@ -285,10 +270,9 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidEnumArgumentException))]
 		public void WrapMode_Invalid ()
 		{
-			new TextureBrush (image).WrapMode = (WrapMode)Int32.MinValue;
+			Assert.Throws<InvalidEnumArgumentException>(() => new TextureBrush (image).WrapMode = (WrapMode)Int32.MinValue);
 		}
 
 		[Test]
@@ -300,12 +284,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_Clone ()
 		{
 			TextureBrush t = new TextureBrush (image);
 			t.Dispose ();
-			t.Clone ();
+			Assert.Throws<ArgumentException>(() => t.Clone ());
 		}
 
 		[Test]
@@ -318,26 +301,23 @@ namespace MonoTests.System.Drawing {
 
 		[Test]
 		[NUnit.Framework.Category ("NotDotNet")] // AccessViolationException under 2.0
-		[ExpectedException (typeof (ArgumentException))]
 		public void Dispose_Image ()
 		{
 			TextureBrush t = new TextureBrush (image);
 			t.Dispose ();
-			Assert.IsNotNull (t.Image, "Image");
+			Assert.Throws<ArgumentException>(() => Assert.IsNotNull (t.Image, "Image"));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MultiplyTransform_Null ()
 		{
-			new TextureBrush (image).MultiplyTransform (null);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (image).MultiplyTransform (null));
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
 		public void MultiplyTransform_Null_Order ()
 		{
-			new TextureBrush (image).MultiplyTransform (null, MatrixOrder.Append);
+			Assert.Throws<ArgumentNullException>(() => new TextureBrush (image).MultiplyTransform (null, MatrixOrder.Append));
 		}
 
 		[Test]
@@ -348,12 +328,11 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void MultiplyTransform_NonInvertible ()
 		{
 			TextureBrush t = new TextureBrush (image);
 			Matrix noninvertible = new Matrix (123, 24, 82, 16, 47, 30);
-			t.MultiplyTransform (noninvertible);
+			Assert.Throws<ArgumentException>(() => t.MultiplyTransform (noninvertible));
 		}
 
 		[Test]
@@ -384,11 +363,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void RotateTransform_InvalidOrder ()
 		{
 			TextureBrush t = new TextureBrush (image);
-			t.RotateTransform (720, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => t.RotateTransform (720, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -423,11 +401,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void ScaleTransform_InvalidOrder ()
 		{
 			TextureBrush t = new TextureBrush (image);
-			t.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => t.ScaleTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		[Test]
@@ -454,11 +431,10 @@ namespace MonoTests.System.Drawing {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void TranslateTransform_InvalidOrder ()
 		{
 			TextureBrush t = new TextureBrush (image);
-			t.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue);
+			Assert.Throws<ArgumentException>(() => t.TranslateTransform (1, 1, (MatrixOrder) Int32.MinValue));
 		}
 
 		private void Alpha_81828 (WrapMode mode, bool equals)


### PR DESCRIPTION
This PR changes the unit tests for System.Drawing to use NUnit's `Assert.Throws` construct instead of the `[ExpectedException]` attribute.

`[ExpectedException]` is no available in NUnit 3, whereas `Assert.Throws` is available in NUnit 2.x.

Background - I maintain [CoreCompat.System.Drawing](https://www.nuget.org/packages/CoreCompat.System.Drawing/1.0.0-beta006), a port of Mono's System.Drawing to .NET Core.

Mono's System.Drawing compiles almost natively on netstandard2.0 (compared to all the work needed to make it work on netstandard1.3 - see #3013). The only blocker at this point is that to only NUnit 3 is available on .NET Core. Net, this change is requried to get the unit tests up and running on .NET Core.