### PR TITLE
[ci] Check if X server is available before running WinForms tests

### DIFF
--- a/mcs/class/System.Windows.Forms/Makefile
+++ b/mcs/class/System.Windows.Forms/Makefile
@@ -89,6 +89,7 @@ TEST_DISTFILES = \
 	Test/System.Resources/compat_1_1.resx \
 	Test/System.Resources/compat_2_0.resx \
 	Test/System.Windows.Forms/bitmaps/a.png \
+	Test/simple/Program.cs \
 	Test/DummyAssembly/AnotherSerializable.cs \
 	Test/DummyAssembly/Convertable.cs \
 	Test/DummyAssembly/Properties/AssemblyInfo.cs \
@@ -127,3 +128,9 @@ $(PREBUILT): %.prebuilt: %
 	cp $* $@
 
 dist-default: $(PREBUILT)
+
+simple-test.exe: Test/simple/Program.cs $(topdir)/class/lib/$(PROFILE)/System.Windows.Forms.dll
+	$(CSCOMPILE) -out:$@ Test/simple/Program.cs -r:$(topdir)/class/lib/$(PROFILE)/System.Windows.Forms.dll
+
+test-simple: simple-test.exe
+	$(TEST_RUNTIME) simple-test.exe

--- a/mcs/class/System.Windows.Forms/Test/simple/Program.cs
+++ b/mcs/class/System.Windows.Forms/Test/simple/Program.cs
@@ -1,0 +1,39 @@
+//
+// Program.cs
+//
+// Author:
+//	Alexander Köplinger (alexander.koeplinger@xamarin.com)
+// 
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace SimpleTest {
+	public static class Program {
+		public static int Main ()
+		{
+			// use the simplest WinForms code that invokes the XplatUI
+			// and causes the X connection to be established, if this fails
+			// then something is seriously wrong
+			System.Windows.Forms.Application.Idle += null;
+			return 0;
+		}
+	}
+}

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -24,7 +24,10 @@ else ${TESTCMD} --label=System.Drawing --timeout=5m make -w -C mcs/class/System.
 fi
 if [[ ${label} == osx-* ]] || [[ ${label} == w* ]]
 then ${TESTCMD} --label=Windows.Forms --skip;
-else ${TESTCMD} --label=Windows.Forms --timeout=5m make -w -C mcs/class/System.Windows.Forms run-test
+else
+    if make -C mcs/class/System.Windows.Forms test-simple;
+    then ${TESTCMD} --label=Windows.Forms --timeout=5m make -w -C mcs/class/System.Windows.Forms run-test
+    else echo "The simple test failed (maybe because of missing X server), skipping test suite." && ${TESTCMD} --label=Windows.Forms --skip; fi
 fi
 ${TESTCMD} --label=System.Data --timeout=5m make -w -C mcs/class/System.Data run-test
 if [[ ${label} == w* ]]; then ${TESTCMD} --label=Mono.Data.Sqlite --skip; else ${TESTCMD} --label=Mono.Data.Sqlite --timeout=5m make -w -C mcs/class/Mono.Data.Sqlite run-test; fi


### PR DESCRIPTION
This should hopefully "fix" the mass fails in the WinForms tests we sometimes see in CI.

We're using the simplest WinForms code that invokes the XplatUI and causes the X connection to be established, if this fails then something is seriously wrong and we skip the WinForms tests.