### PR TITLE
[mkbundle] Fixes the embedding of dependency assemblies + test

### DIFF
--- a/mcs/tools/mkbundle/Makefile
+++ b/mcs/tools/mkbundle/Makefile
@@ -24,10 +24,11 @@ test-simple: simple.exe
 	mono --debug $(the_lib) --cross default simple.exe -o foo && ./foo
 	mono --debug $(the_lib) --sdk `dirname \`which mono\``/.. simple.exe -o foo && ./foo
 	-rm DEMO.zip
-	mono-package-runtime `dirname \`which mono\``/.. DEMO
+	$(topdir)/../scripts/mono-package-runtime `dirname \`which mono\``/.. DEMO
 	mkdir -p ~/.mono/targets/DEMO
 	unzip -d ~/.mono/targets/DEMO DEMO.zip
-	mono --debug $(the_lib) --cross DEMO simple.exe -o foo && ./foo
+	mono --debug $(the_lib) --cross DEMO simple.exe -o foo | grep "Assembly.*mscorlib.dll"
+	./foo
 
 simple.exe: Makefile
 	echo 'class X { static void Main () { System.Console.WriteLine ("OK");}}' > simple.cs && mcs simple.cs

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -1082,14 +1082,14 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 	static void LoadLocalizedAssemblies (List<string> assemblies)
 	{
 		var other = i18n.Select (x => "I18N." + x + (x.Length > 0 ? "." : "") + "dll");
-		bool error = false;
+		string error = null;
 
 		foreach (string name in other) {
 			try {
 				Assembly a = LoadAssembly (name);
 
 				if (a == null) {
-					error = true;
+					error = "Failed to load " + name;
 					continue;
 				}
 
@@ -1105,8 +1105,8 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			}
 		}
 
-		if (error) {
-			Error ("Couldn't load one or more of the i18n assemblies.");
+		if (error != null) {
+			Error ("Couldn't load one or more of the i18n assemblies: " + error);
 			Environment.Exit (1);
 		}
 	}
@@ -1158,7 +1158,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			Assembly a = universe.LoadFile (path);
 
 			foreach (AssemblyName an in a.GetReferencedAssemblies ()) {
-				LoadAssembly (an.FullName);
+				a = universe.Load (an.FullName);
 				if (!QueueAssembly (files, a.CodeBase))
 					return false;
 			}
@@ -1220,7 +1220,6 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 	static void Error (string msg, params object [] args)
 	{
 		Console.Error.WriteLine ("ERROR: {0}", string.Format (msg, args));
-		throw new Exception ();
 		Environment.Exit (1);
 	}
 


### PR DESCRIPTION
Mkbundle was not including the dependencies (like mscorlib.dll) due to the wrong method being called to fetch the assembly, so we kept trying to add the same assembly, instead of trying to add the dependency assembly.

Includes a test for "test-simple" target.