### PR TITLE
[interp] more fixes in order to run more tests in the mini regression suite

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -538,21 +538,6 @@ endif
 
 regtests = $(filter-out $(regtests_DISABLED),$(regtests_UNIVERSAL))
 
-iregtests = \
-	basic.exe \
-	basic-float.exe \
-	basic-long.exe \
-	basic-calls.exe \
-	objects.exe \
-	arrays.exe \
-	basic-math.exe \
-	exceptions.exe \
-	iltests.exe \
-	devirtualization.exe \
-	generics.exe \
-	basic-simd.exe \
-	basic-vectors.exe
-
 if X86
 arch_sources = $(x86_sources)
 arch_built=cpu-x86.h
@@ -762,8 +747,8 @@ rcheck-nunit: mono $(regtests)
 rcheck: mono $(regtests)
 	$(MINI_RUNTIME) --regression $(regtests)
 
-richeck: mono $(iregtests)
-	$(INTERP_RUNTIME) --regression $(iregtests)
+richeck: mono $(regtests)
+	$(INTERP_RUNTIME) --regression $(regtests)
 
 if ARM
 check-seq-points:

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -547,6 +547,7 @@ iregtests = \
 	arrays.exe \
 	basic-math.exe \
 	exceptions.exe \
+	iltests.exe \
 	devirtualization.exe \
 	generics.exe \
 	basic-simd.exe \

--- a/mono/mini/arrays.cs
+++ b/mono/mini/arrays.cs
@@ -779,7 +779,6 @@ class Tests
 	}
 
 	// #13544
-	[Category ("!INTERPRETER")]
 	public static int test_0_newarr_ovf () {
 		if (!alloc_long (5000000000))
 			return 1;

--- a/mono/mini/arrays.cs
+++ b/mono/mini/arrays.cs
@@ -548,7 +548,6 @@ class Tests
 		return 0;
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_multidym_array_with_negative_lower_bound () {
 		int[,] x = (int[,]) Array.CreateInstance(typeof (int), new int[] { 2, 2 }, new int[] { -2, -3 });
 

--- a/mono/mini/arrays.cs
+++ b/mono/mini/arrays.cs
@@ -318,7 +318,6 @@ class Tests
 		return 0;
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_multi_dimension_arrays () {
 		int sum;
 

--- a/mono/mini/basic-math.cs
+++ b/mono/mini/basic-math.cs
@@ -257,6 +257,14 @@ class Tests
 		return 0;
 	}
 
+	public static int test_0_float_abs () {
+		float f = -1.0f;
+
+		if (Math.Abs (f) != 1.0f)
+			return 1;
+		return 0;
+	}
+
 	public static int test_0_round () {
 		if (Math.Round (5.0) != 5.0)
 			return 1;

--- a/mono/mini/basic-vectors.cs
+++ b/mono/mini/basic-vectors.cs
@@ -113,7 +113,6 @@ public class VectorTests {
 		return Vector2.Abs (v1);
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_vector2_abs () {
 		var v1 = new Vector2 (-1.0f, -2.0f);
 		var v2 = new Vector2 (1.0f, 2.0f);
@@ -351,7 +350,6 @@ public class VectorTests {
 		return Vector4.Abs (v1);
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_vector4_abs () {
 		var v1 = new Vector4 (-1.0f, -2.0f, -3.0f, -4.0f);
 		var v2 = new Vector4 (1.0f, 2.0f, 3.0f, 4.0f);
@@ -590,7 +588,6 @@ public class VectorTests {
 		return Vector3.Abs (v1);
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_vector3_abs () {
 		var v1 = new Vector3 (-1.0f, -2.0f, -3.0f);
 		var v2 = new Vector3 (1.0f, 2.0f, 3.0f);

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -1462,7 +1462,6 @@ class Tests
 		return 0;
 	}
 	
-	[Category ("!INTERPRETER")]
 	[Category ("NaClDisable")]
 	public static int test_0_div_zero () {
 		int d = 1;
@@ -1634,7 +1633,6 @@ class Tests
 		return 0;
 	}
 
-	[Category ("!INTERPRETER")]
 	[Category ("NaClDisable")]
 	public static int test_0_long_div_zero () {
 		long d = 1;

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -1878,7 +1878,6 @@ class Tests
 		o = "buddy";
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_2_array_mismatch () {
 		string[] a = { "hello", "world" };
 		object[] b = a;

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -2382,7 +2382,6 @@ class Tests
 		}
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_array_size () {
 		bool failed;
 

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -981,7 +981,6 @@ class Tests
 		return 0;
 	}
 	
-	[Category ("!INTERPRETER")]
 	public static int test_0_int_cast () {
 		int a;
 		long l;

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -1842,7 +1842,6 @@ class Tests
 		7, 0, 7, 1, 7, 2, 7, 3, 7, 4, 7, 5, 7, 6, 7, 7, 7, 8,
 	};
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_multi_dim_array_access () {
 		int [,] a = System.Array.CreateInstance (typeof (int),
 			new int [] {3,6}, new int [] {2,2 }) as int[,];

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -2230,7 +2230,6 @@ class Tests
 		}
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_exception_in_cctor () {
 		try {
 			Broken.DoSomething ();

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -2708,7 +2708,6 @@ class Tests
 		public static Foo* pFoo;
 	}
 
-	[Category ("!INTERPRETER")]
 	/* MS.NET doesn't seem to throw in this case */
 	public unsafe static int test_0_ldflda_null_pointer () {
 		int* pi = &Foo.pFoo->i;

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -1800,7 +1800,6 @@ class Tests
 		return 0;
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_3_checked_cast_un () {
                 ulong i = 0x8000000034000000;
                 long j;

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -1815,7 +1815,6 @@ class Tests
 		return 3;
 	}
 	
-	[Category ("!INTERPRETER")]
 	public static int test_4_checked_cast () {
                 long i;
                 ulong j;

--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -1066,7 +1066,6 @@ class Tests
 		}
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_1_regress_constrained_iface_call_7571 () {
         var r = new Record [10];
         Foo2<Record>.Extract (r);
@@ -1077,7 +1076,6 @@ class Tests
 		Val = 1
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_regress_constrained_iface_call_enum () {
 		var r = new ConstrainedEnum [10];
 		return Foo3<ConstrainedEnum>.CompareTo (r);

--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -1218,7 +1218,6 @@ class Tests
 		return t.GetHashCode ();
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_constrained_partial_sharing () {
 		string s;
 

--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -952,7 +952,6 @@ class Tests
 		}
 	}
 
-	[Category ("!INTERPRETER")]
 	[Category ("GSHAREDVT")]
 	static int test_0_synchronized_gshared () {
 		var c = new SyncClass<string> ();

--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -1135,7 +1135,6 @@ class Tests
 	}
 #endif
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_delegate_callvirt_fullaot () {
 		Func<string> f = delegate () { return "A"; };
         var f2 = (Func<Func<string>, string>)Delegate.CreateDelegate (typeof

--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -1014,7 +1014,6 @@ class Tests
     static List<A> sources = new List<A>();
 
 	// #6112
-	[Category ("!INTERPRETER")]
     public static int test_0_fullaot_imt () {
         sources.Add(null);
         sources.Add(null);
@@ -1036,7 +1035,6 @@ class Tests
 	class BClass : AClass {
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_fullaot_variant_iface () {
 		var arr = new BClass [10];
 		var enumerable = (IEnumerable<AClass>)arr;

--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -570,7 +570,6 @@ class Tests
 		}
 	}
 
-	[Category ("!INTERPRETER")]
 	public static int test_0_fullaot_linq () {
 		var allWords = new XElement [] { new XElement { Value = "one" } };
 		var filteredWords = allWords.Where(kw => kw.Value.StartsWith("T"));
@@ -988,7 +987,6 @@ class Tests
 	}
 
 	// #2155
-	[Category ("!INTERPRETER")]
 	[Category ("GSHAREDVT")]
 	public static int test_0_fullaot_sflda_cctor () {
 		List<Doc> documents = new List<Doc>();

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -1297,7 +1297,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_5_cpobj () {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 8
 		.locals init (  
 				valuetype Tests/TheStruct v_0, 
@@ -1354,7 +1353,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_1_cpobj_reference () {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 8
 		.locals init (  
 				object v_0, 

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -1211,7 +1211,6 @@ COND:   ldloc.0
    } // end of class xxx
 
 	.method public static int32 test_0_newobj_vtype () {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 6
 		.locals init (
 			valuetype Tests/xxx V_0

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -1373,7 +1373,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_1_initobj_reference () {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 8
 		.locals init (  
 				object v_0

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -2630,7 +2630,6 @@ END:
   	}
 
 	.method public static default int32 test_1_sizeof_gshared () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 	    call   int32 Tests::SizeOfT<int8>()
 		ldc.i4.1
 		ceq

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -1812,7 +1812,6 @@ HAS_VALUE:	ldc.i4.1
 
 	//Bug 372410
 	.method static public int32 test_0_array_address_type_check () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 		.locals init (object[] V_0,
 					  object[,] V_1)

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -158,6 +158,7 @@
 	// you should not see tons of register spilling.
 	//
 	.method static public int32 test_0_bytesreg1_free () il managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (
 			unsigned int8	   dest,
 			int32	           src,
@@ -219,6 +220,7 @@
 	
 	// this only happens with the managed pointer, not an unmanaged one.
 	.method static public int32 test_0_foo () il managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 	
 		.locals init (
 			int32&	buf
@@ -236,6 +238,7 @@
 	}
 
 	.method static public int32 test_0_localloc () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (native int, native int, native int, native int, int32)
 
 		ldc.i4 6
@@ -640,6 +643,7 @@ COND:   ldloc.0
 	}
 
 	.method static public int32 test_11_switch_with_nonempty_stack () il managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4.5
@@ -752,6 +756,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_0_conv_ovf_u_un () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4 1234
@@ -854,6 +859,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_0_lconv_ovf_u_un () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4 1234
@@ -886,6 +892,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_0_lconv_to_ovf_u8_un () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4 1234
@@ -902,6 +909,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_2_lconv_to_ovf_i4_un () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 		.locals init (int32 res)
 
@@ -1124,6 +1132,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_7_conv_ovf_u8_un () {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
     	.maxstack  2
         .locals    init (unsigned int64)
 
@@ -1210,6 +1219,7 @@ COND:   ldloc.0
    } // end of class xxx
 
 	.method public static int32 test_0_newobj_vtype () {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 6
 		.locals init (
 			valuetype Tests/xxx V_0
@@ -1247,7 +1257,8 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_1_filters () {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 08 21 42 49 54 43 4F 44 45 00 00 )          // ...!BITCODE..
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
+		// .custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 08 21 42 49 54 43 4F 44 45 00 00 )          // ...!BITCODE..
 		.maxstack 16
 		.locals init (
 			int32 res
@@ -1295,6 +1306,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_5_cpobj () {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 8
 		.locals init (  
 				valuetype Tests/TheStruct v_0, 
@@ -1351,6 +1363,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_1_cpobj_reference () {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 8
 		.locals init (  
 				object v_0, 
@@ -1371,6 +1384,7 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_1_initobj_reference () {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 8
 		.locals init (  
 				object v_0
@@ -1810,6 +1824,7 @@ HAS_VALUE:	ldc.i4.1
 
 	//Bug 372410
 	.method static public int32 test_0_array_address_type_check () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 		.locals init (object[] V_0,
 					  object[,] V_1)
@@ -2485,6 +2500,7 @@ OK_2:
 
 	.method public static int32 test_2_leave_multiple_blocks_from_end ()
 	{
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (int32 V_0)
 
 		.try {
@@ -2515,6 +2531,7 @@ END:
 
 	.method public static int32 test_3_leave_multiple_blocks_from_hole ()
 	{
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (int32 V_0)
 
 		.try {
@@ -2599,6 +2616,7 @@ END:
 
 	.method public static default int32 test_0_wrap_non_exception_throws () cil managed
 	{
+	  .custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 	  .try {
 	  	    newobj instance void class [mscorlib]System.Object::'.ctor'()
 			throw
@@ -2612,6 +2630,7 @@ END:
     }
 
 	.method public static default int32 test_0_typespec_modopt () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		ldtoken class Tests modopt (Tests)
 		pop
 		ldc.i4.0
@@ -2627,6 +2646,7 @@ END:
   	}
 
 	.method public static default int32 test_1_sizeof_gshared () cil managed {
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 	    call   int32 Tests::SizeOfT<int8>()
 		ldc.i4.1
 		ceq
@@ -2688,6 +2708,7 @@ END:
 	.method public static
 			default int32 test_0_llvm_regress_171 () cil managed
 	{
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (
 			int32 i
 		)
@@ -2710,6 +2731,7 @@ END:
 	.method public static
 			default int32 test_4_ldfld_stfld_static () cil managed
 	{
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		ldnull
 		ldc.i4 2
 		stfld int32 Tests::static_a

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -219,7 +219,6 @@
 	
 	// this only happens with the managed pointer, not an unmanaged one.
 	.method static public int32 test_0_foo () il managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 	
 		.locals init (
 			int32&	buf
@@ -237,7 +236,6 @@
 	}
 
 	.method static public int32 test_0_localloc () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (native int, native int, native int, native int, int32)
 
 		ldc.i4 6

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -753,7 +753,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_0_conv_ovf_u_un () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4 1234
@@ -856,7 +855,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_0_lconv_ovf_u_un () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4 1234
@@ -889,7 +887,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_0_lconv_to_ovf_u8_un () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4 1234
@@ -906,7 +903,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_2_lconv_to_ovf_i4_un () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 		.locals init (int32 res)
 
@@ -1129,7 +1125,6 @@ COND:   ldloc.0
 	}
 
 	.method public static int32 test_7_conv_ovf_u8_un () {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
     	.maxstack  2
         .locals    init (unsigned int64)
 

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -158,7 +158,6 @@
 	// you should not see tons of register spilling.
 	//
 	.method static public int32 test_0_bytesreg1_free () il managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (
 			unsigned int8	   dest,
 			int32	           src,

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -2695,7 +2695,6 @@ END:
 	.method public static
 			default int32 test_0_llvm_regress_171 () cil managed
 	{
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (
 			int32 i
 		)
@@ -2718,7 +2717,6 @@ END:
 	.method public static
 			default int32 test_4_ldfld_stfld_static () cil managed
 	{
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		ldnull
 		ldc.i4 2
 		stfld int32 Tests::static_a

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -2487,7 +2487,6 @@ OK_2:
 
 	.method public static int32 test_2_leave_multiple_blocks_from_end ()
 	{
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (int32 V_0)
 
 		.try {
@@ -2616,7 +2615,6 @@ END:
     }
 
 	.method public static default int32 test_0_typespec_modopt () cil managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		ldtoken class Tests modopt (Tests)
 		pop
 		ldc.i4.0

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -640,7 +640,6 @@ COND:   ldloc.0
 	}
 
 	.method static public int32 test_11_switch_with_nonempty_stack () il managed {
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.maxstack 16
 
 		ldc.i4.5

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -1249,7 +1249,7 @@ COND:   ldloc.0
 
 	.method public static int32 test_1_filters () {
 		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
-		// .custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 08 21 42 49 54 43 4F 44 45 00 00 )          // ...!BITCODE..
+		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 08 21 42 49 54 43 4F 44 45 00 00 )          // ...!BITCODE..
 		.maxstack 16
 		.locals init (
 			int32 res
@@ -2522,7 +2522,6 @@ END:
 
 	.method public static int32 test_3_leave_multiple_blocks_from_hole ()
 	{
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 		.locals init (int32 V_0)
 
 		.try {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1967,8 +1967,12 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 			child_frame.retval = sp;
 			/* decrement by the actual number of args */
 			sp -= child_frame.runtime_method->param_count;
-			if (child_frame.runtime_method->hasthis)
+			if (child_frame.runtime_method->hasthis) {
 				--sp;
+				MonoObject *this_arg = sp->data.p;
+				if (!this_arg)
+					THROW_EX (mono_get_exception_null_reference(), ip - 2);
+			}
 			child_frame.stack_args = sp;
 
 			if (child_frame.runtime_method->hasthis && !child_frame.runtime_method->method->klass->valuetype && mono_object_is_transparent_proxy (sp->data.p)) {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3931,12 +3931,19 @@ array_constructed:
 			ip += 4;
 			MINT_IN_BREAK;
 
-		MINT_IN_CASE(MINT_LOCALLOC)
+		MINT_IN_CASE(MINT_LOCALLOC) {
 			if (sp != frame->stack + 1) /*FIX?*/
 				THROW_EX (mono_get_exception_execution_engine (NULL), ip);
-			sp [-1].data.p = alloca (sp [-1].data.i);
+
+			int len = sp [-1].data.i;
+			sp [-1].data.p = alloca (len);
+			MonoMethodHeader *header = mono_method_get_header_checked (frame->runtime_method->method, &error);
+			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+			if (header->init_locals)
+				memset (sp [-1].data.p, 0, len);
 			++ip;
 			MINT_IN_BREAK;
+		}
 #if 0
 		MINT_IN_CASE(MINT_ENDFILTER) ves_abort(); MINT_IN_BREAK;
 #endif

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2907,6 +2907,11 @@ array_constructed:
 				sp->data.p = mono_get_exception_null_reference ();
 			THROW_EX ((MonoException *)sp->data.p, ip);
 			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_LDFLDA_UNSAFE)
+			o = sp [-1].data.p;
+			sp[-1].data.p = (char *)o + * (guint16 *)(ip + 1);
+			ip += 2;
+			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDFLDA)
 			o = sp [-1].data.p;
 			if (!o)

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -311,7 +311,8 @@ get_virtual_method (MonoDomain *domain, RuntimeMethod *runtime_method, MonoObjec
 	if (mono_class_is_interface (m->klass)) {
 		g_assert (obj->vtable->klass != m->klass);
 		/* TODO: interface offset lookup is slow, go through IMT instead */
-		slot += mono_class_interface_offset (obj->vtable->klass, m->klass);
+		gboolean non_exact_match;
+		slot += mono_class_interface_offset_with_variance (obj->vtable->klass, m->klass, &non_exact_match);
 	}
 
 	MonoMethod *virtual_method = obj->vtable->klass->vtable [slot];

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2559,11 +2559,15 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 		MINT_IN_CASE(MINT_REM_I4)
 			if (sp [-1].data.i == 0)
 				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+			if (sp [-1].data.i == (-1))
+				THROW_EX (mono_get_exception_overflow (), ip);
 			BINOP(i, %);
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_REM_I8)
 			if (sp [-1].data.l == 0)
 				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+			if (sp [-1].data.l == (-1))
+				THROW_EX (mono_get_exception_overflow (), ip);
 			BINOP(l, %);
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_REM_R8)

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -277,8 +277,8 @@ mono_interp_get_runtime_method (MonoDomain *domain, MonoMethod *method, MonoErro
 	return rtm;
 }
 
-static gpointer
-interp_create_trampoline (MonoDomain *domain, MonoMethod *method, MonoError *error)
+gpointer
+mono_interp_create_trampoline (MonoDomain *domain, MonoMethod *method, MonoError *error)
 {
 	if (method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
 		method = mono_marshal_get_synchronized_wrapper (method);
@@ -937,9 +937,8 @@ ves_pinvoke_method (MonoInvocation *frame, MonoMethodSignature *sig, MonoFuncV a
 void
 mono_interp_init_delegate (MonoDelegate *del)
 {
-	g_assert (!del->method);
-	del->method = ((RuntimeMethod *) del->method_ptr)->method;
-	g_assert (del->method);
+	if (!del->method)
+		del->method = ((RuntimeMethod *) del->method_ptr)->method;
 }
 
 /*

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3198,6 +3198,9 @@ array_constructed:
 		}
 		MINT_IN_CASE(MINT_NEWARR)
 			sp [-1].data.p = (MonoObject*) mono_array_new_checked (context->domain, rtm->data_items[*(guint16 *)(ip + 1)], sp [-1].data.i, &error);
+			if (!mono_error_ok (&error)) {
+				THROW_EX (mono_error_convert_to_exception (&error), ip);
+			}
 			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 			ip += 2;
 			/*if (profiling_classes) {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -4054,8 +4054,7 @@ array_constructed:
 							goto handle_finally;
 						}
 					} else {
-						/* FIXME: handle filter clauses */
-						g_assert (0);
+						g_error ("FIXME: handle filter clause");
 					}
 				}
 			}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3421,7 +3421,13 @@ array_constructed:
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I4_I8)
-			if (sp [-1].data.l <= MYGINT32_MIN || sp [-1].data.l > MYGINT32_MAX)
+			if (sp [-1].data.l < MYGINT32_MIN || sp [-1].data.l > MYGINT32_MAX)
+				THROW_EX (mono_get_exception_overflow (), ip);
+			sp [-1].data.i = (gint32) sp [-1].data.l;
+			++ip;
+			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_CONV_OVF_I4_U8)
+			if (sp [-1].data.l < 0 || sp [-1].data.l > MYGINT32_MAX)
 				THROW_EX (mono_get_exception_overflow (), ip);
 			sp [-1].data.i = (gint32) sp [-1].data.l;
 			++ip;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1669,16 +1669,19 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 
 	rtm = frame->runtime_method;
 	frame->args = alloca (rtm->alloca_size);
+	memset (frame->args, 0, rtm->alloca_size);
+
 	sp = frame->stack = (stackval *)((char *)frame->args + rtm->args_size);
-#if DEBUG_INTERP
-	if (tracing > 1)
-		memset(sp, 0, rtm->stack_size);
-#endif
+	memset (sp, 0, rtm->stack_size);
+
 	vt_sp = (unsigned char *) sp + rtm->stack_size;
+	memset (vt_sp, 0, rtm->vt_stack_size);
 #if DEBUG_INTERP
 	vtalloc = vt_sp;
 #endif
+
 	locals = (unsigned char *) vt_sp + rtm->vt_stack_size;
+	memset (vt_sp, 0, rtm->locals_size);
 
 	child_frame.parent = frame;
 
@@ -2823,11 +2826,11 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 			 */
 			if (newobj_class->valuetype) {
 				MonoType *t = &newobj_class->byval_arg;
+				memset (&valuetype_this, 0, sizeof (stackval));
 				if (!newobj_class->enumtype && (t->type == MONO_TYPE_VALUETYPE || (t->type == MONO_TYPE_GENERICINST && mono_type_generic_inst_is_valuetype (t)))) {
 					sp->data.p = vt_sp;
 					valuetype_this.data.p = vt_sp;
 				} else {
-					memset (&valuetype_this, 0, sizeof (stackval));
 					sp->data.p = &valuetype_this;
 				}
 			} else {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1930,7 +1930,7 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 				 * An exception occurred, need to run finally, fault and catch handlers..
 				 */
 				frame->ex = child_frame.ex;
-				goto handle_finally;
+				goto handle_exception;;
 			}
 
 			/* need to handle typedbyref ... */

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2767,20 +2767,16 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 		}
 #endif
 		MINT_IN_CASE(MINT_LDOBJ) {
-			int size;
 			void *p;
 			c = rtm->data_items[* (guint16 *)(ip + 1)];
 			ip += 2;
-			if (c->byval_arg.type != MONO_TYPE_VALUETYPE || c->byval_arg.data.klass->enumtype) {
-				p = sp [-1].data.p;
-				stackval_from_data (&c->byval_arg, &sp [-1], p, FALSE);
-			} else {
-				size = mono_class_value_size (c, NULL);
-				p = sp [-1].data.p;
+			p = sp [-1].data.p;
+			if (c->byval_arg.type == MONO_TYPE_VALUETYPE && !c->enumtype) {
+				int size = mono_class_value_size (c, NULL);
 				sp [-1].data.p = vt_sp;
-				memcpy(vt_sp, p, size);
 				vt_sp += (size + 7) & ~7;
 			}
+			stackval_from_data (&c->byval_arg, &sp [-1], p, FALSE);
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_LDSTR)
@@ -2919,12 +2915,7 @@ array_constructed:
 			if (!(isinst_obj || ((o->vtable->klass->rank == 0) && (o->vtable->klass->element_class == c->element_class))))
 				THROW_EX (mono_get_exception_invalid_cast (), ip);
 
-			if (c->byval_arg.type == MONO_TYPE_VALUETYPE && !c->enumtype) {
-				int size = mono_class_native_size (c, NULL);
-				sp [-1].data.p = vt_sp;
-				vt_sp += (size + 7) & ~7;
-			}
-			stackval_from_data (&c->byval_arg, &sp [-1], mono_object_unbox (o), FALSE);
+			sp [-1].data.p = mono_object_unbox (o);
 			ip += 2;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_THROW)

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1654,7 +1654,7 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 	if (!frame->runtime_method->transformed) {
 		context->managed_code = 0;
 #if DEBUG_INTERP
-		char *mn = mono_method_full_name (frame->runtime_method->method, FALSE);
+		char *mn = mono_method_full_name (frame->runtime_method->method, TRUE);
 		g_print ("(%p) Transforming %s\n", mono_thread_internal_current (), mn);
 		g_free (mn);
 #endif

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3168,6 +3168,11 @@ array_constructed:
 			sp [-1].data.l = sp [-1].data.i;
 			++ip;
 			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_CONV_OVF_U8_I8)
+			if (sp [-1].data.l < 0)
+				THROW_EX (mono_get_exception_overflow (), ip);
+			++ip;
+			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I8_U8)
 			if ((guint64) sp [-1].data.l > MYGINT64_MAX)
 				THROW_EX (mono_get_exception_overflow (), ip);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -796,13 +796,19 @@ static MethodArguments* build_args_from_sig (MonoMethodSignature *sig, MonoInvoc
 		case MONO_TYPE_GENERICINST:
 			margs->iargs [int_i] = frame->stack_args [i].data.p;
 #if DEBUG_INTERP
-			g_print ("build_args_from_sig: margs->iargs[%d]: %p (frame @ %d)\n", int_i, margs->iargs[int_i], i);
+			g_print ("build_args_from_sig: margs->iargs [%d]: %p (frame @ %d)\n", int_i, margs->iargs [int_i], i);
 #endif
 			int_i++;
 			break;
 		case MONO_TYPE_R4:
 		case MONO_TYPE_R8:
-			margs->fargs [int_f] = frame->stack_args [i].data.f;
+			if (ptype == MONO_TYPE_R4)
+				* (float *) &(margs->fargs [int_f]) = (float) frame->stack_args [i].data.f;
+			else
+				margs->fargs [int_f] = frame->stack_args [i].data.f;
+#if DEBUG_INTERP
+			g_print ("build_args_from_sig: margs->fargs [%d]: %p (%f) (frame @ %d)\n", int_f, margs->fargs [int_f], margs->fargs [int_f], i);
+#endif
 			int_f++;
 			break;
 		default:

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3432,7 +3432,7 @@ array_constructed:
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I4_I8)
-			if (sp [-1].data.l < MYGINT32_MIN || sp [-1].data.l > MYGINT32_MAX)
+			if (sp [-1].data.l <= MYGINT32_MIN || sp [-1].data.l > MYGINT32_MAX)
 				THROW_EX (mono_get_exception_overflow (), ip);
 			sp [-1].data.i = (gint32) sp [-1].data.l;
 			++ip;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3168,9 +3168,14 @@ array_constructed:
 			sp [-1].data.l = sp [-1].data.i;
 			++ip;
 			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_CONV_OVF_I8_U8)
+			if ((guint64) sp [-1].data.l > MYGINT64_MAX)
+				THROW_EX (mono_get_exception_overflow (), ip);
+			++ip;
+			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_U8_R8)
 		MINT_IN_CASE(MINT_CONV_OVF_I8_UN_R8)
-			if (sp [-1].data.f < 0 || sp [-1].data.f > 9223372036854775807LL)
+			if (sp [-1].data.f < 0 || sp [-1].data.f > MYGINT64_MAX)
 				THROW_EX (mono_get_exception_overflow (), ip);
 			sp [-1].data.l = (guint64)sp [-1].data.f;
 			++ip;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2758,17 +2758,14 @@ ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 			sp [-1].data.l = (guint64)sp [-1].data.f;
 			++ip;
 			MINT_IN_BREAK;
-#if 0
 		MINT_IN_CASE(MINT_CPOBJ) {
-			MonoClass *vtklass;
-			++ip;
-			vtklass = rtm->data_items[READ32 (ip)];
+			c = rtm->data_items[* (guint16 *)(ip + 1)];
+			g_assert (c->byval_arg.type == MONO_TYPE_VALUETYPE);
+			stackval_from_data (&c->byval_arg, &sp [-2], sp [-1].data.p, FALSE);
 			ip += 2;
 			sp -= 2;
-			memcpy (sp [0].data.p, sp [1].data.p, mono_class_value_size (vtklass, NULL));
 			MINT_IN_BREAK;
 		}
-#endif
 		MINT_IN_CASE(MINT_LDOBJ) {
 			void *p;
 			c = rtm->data_items[* (guint16 *)(ip + 1)];

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3345,6 +3345,7 @@ array_constructed:
 		}
 		MINT_IN_CASE(MINT_STELEM_I)  /* fall through */
 		MINT_IN_CASE(MINT_STELEM_I1) /* fall through */ 
+		MINT_IN_CASE(MINT_STELEM_U1) /* fall through */
 		MINT_IN_CASE(MINT_STELEM_I2) /* fall through */
 		MINT_IN_CASE(MINT_STELEM_I4) /* fall through */
 		MINT_IN_CASE(MINT_STELEM_I8) /* fall through */
@@ -3370,6 +3371,9 @@ array_constructed:
 				break;
 			case MINT_STELEM_I1:
 				mono_array_set ((MonoArray *)o, gint8, aindex, sp [2].data.i);
+				break;
+			case MINT_STELEM_U1:
+				mono_array_set ((MonoArray *) o, guint8, aindex, sp [2].data.i);
 				break;
 			case MINT_STELEM_I2:
 				mono_array_set ((MonoArray *)o, gint16, aindex, sp [2].data.i);

--- a/mono/mini/interp/interp.h
+++ b/mono/mini/interp/interp.h
@@ -17,6 +17,9 @@ mono_interp_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoOb
 void
 mono_interp_init_delegate (MonoDelegate *del);
 
+gpointer
+mono_interp_create_trampoline (MonoDomain *domain, MonoMethod *method, MonoError *error);
+
 void
 interp_walk_stack_with_ctx (MonoInternalStackWalk func, MonoContext *ctx, MonoUnwindOptions options, void *user_data);
 #endif /* __MONO_MINI_INTERPRETER_H__ */

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -298,6 +298,7 @@ OPDEF(MINT_LDELEM_REF, "ldelem.ref", 1, MintOpNoArgs)
 OPDEF(MINT_LDELEM_VT, "ldelem.vt", 4, MintOpShortAndInt)
 
 OPDEF(MINT_LDELEMA, "ldelema", 2, MintOpClassToken)
+OPDEF(MINT_LDELEMA_TC, "ldelema.tc", 2, MintOpClassToken)
 
 OPDEF(MINT_STELEM_I, "stelem.i", 1, MintOpNoArgs)
 OPDEF(MINT_STELEM_I1, "stelem.i1", 1, MintOpNoArgs)

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -455,6 +455,7 @@ OPDEF(MINT_CONV_OVF_U4_I4, "conv.ovf.u4.i4", 1, MintOpNoArgs)
 OPDEF(MINT_CONV_OVF_U4_I8, "conv.ovf.u4.i8", 1, MintOpNoArgs)
 OPDEF(MINT_CONV_OVF_U4_R8, "conv.ovf.u4.r8", 1, MintOpNoArgs)
 
+OPDEF(MINT_CONV_OVF_I8_U8, "conv.ovf.i8.u8", 1, MintOpNoArgs)
 OPDEF(MINT_CONV_OVF_I8_R8, "conv.ovf.i8.r8", 1, MintOpNoArgs)
 
 OPDEF(MINT_CONV_OVF_I8_UN_R8, "conv.ovf.i8.un.r8", 1, MintOpNoArgs)

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -276,6 +276,7 @@ OPDEF(MINT_UNBOX, "unbox", 2, MintOpClassToken)
 OPDEF(MINT_LDTOKEN, "ldtoken", 2, MintOpClassToken) /* not really */
 OPDEF(MINT_LDFTN, "ldftn", 2, MintOpMethodToken) 
 OPDEF(MINT_LDVIRTFTN, "ldvirtftn", 2, MintOpMethodToken) 
+OPDEF(MINT_CPOBJ, "cpobj", 2, MintOpClassToken)
 OPDEF(MINT_LDOBJ, "ldobj", 2, MintOpClassToken) 
 OPDEF(MINT_STOBJ, "stobj", 2, MintOpClassToken) 
 OPDEF(MINT_STOBJ_VT, "stobj.vt", 2, MintOpClassToken) 

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -94,6 +94,7 @@ OPDEF(MINT_LDRMFLD, "ldrmfld", 2, MintOpFieldToken)
 OPDEF(MINT_LDRMFLD_VT, "ldrmfld.vt", 4, MintOpShortAndInt)
 
 OPDEF(MINT_LDFLDA, "ldflda", 2, MintOpUShortInt)
+OPDEF(MINT_LDFLDA_UNSAFE, "ldflda.unsafe", 2, MintOpUShortInt)
 
 OPDEF(MINT_STFLD_I1, "stfld.i1", 2, MintOpUShortInt)
 OPDEF(MINT_STFLD_U1, "stfld.u1", 2, MintOpUShortInt)

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -303,6 +303,7 @@ OPDEF(MINT_LDELEMA_TC, "ldelema.tc", 3, MintOpTwoShorts)
 
 OPDEF(MINT_STELEM_I, "stelem.i", 1, MintOpNoArgs)
 OPDEF(MINT_STELEM_I1, "stelem.i1", 1, MintOpNoArgs)
+OPDEF(MINT_STELEM_U1, "stelem.u1", 1, MintOpNoArgs)
 OPDEF(MINT_STELEM_I2, "stelem.i2", 1, MintOpNoArgs)
 OPDEF(MINT_STELEM_I4, "stelem.i4", 1, MintOpNoArgs)
 OPDEF(MINT_STELEM_I8, "stelem.i8", 1, MintOpNoArgs)

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -461,6 +461,7 @@ OPDEF(MINT_CONV_OVF_I8_R8, "conv.ovf.i8.r8", 1, MintOpNoArgs)
 OPDEF(MINT_CONV_OVF_I8_UN_R8, "conv.ovf.i8.un.r8", 1, MintOpNoArgs)
 
 OPDEF(MINT_CONV_OVF_U8_I4, "conv.ovf.u8.i4", 1, MintOpNoArgs)
+OPDEF(MINT_CONV_OVF_U8_I8, "conv.ovf.u8.i8", 1, MintOpNoArgs)
 OPDEF(MINT_CONV_OVF_U8_R8, "conv.ovf.u8.r8", 1, MintOpNoArgs)
 
 OPDEF(MINT_CEQ_I4, "ceq.i4", 1, MintOpNoArgs)

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -298,8 +298,8 @@ OPDEF(MINT_LDELEM_R8, "ldelem.r8", 1, MintOpNoArgs)
 OPDEF(MINT_LDELEM_REF, "ldelem.ref", 1, MintOpNoArgs)
 OPDEF(MINT_LDELEM_VT, "ldelem.vt", 4, MintOpShortAndInt)
 
-OPDEF(MINT_LDELEMA, "ldelema", 2, MintOpClassToken)
-OPDEF(MINT_LDELEMA_TC, "ldelema.tc", 2, MintOpClassToken)
+OPDEF(MINT_LDELEMA, "ldelema", 3, MintOpTwoShorts)
+OPDEF(MINT_LDELEMA_TC, "ldelema.tc", 3, MintOpTwoShorts)
 
 OPDEF(MINT_STELEM_I, "stelem.i", 1, MintOpNoArgs)
 OPDEF(MINT_STELEM_I1, "stelem.i1", 1, MintOpNoArgs)

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -445,6 +445,7 @@ OPDEF(MINT_CONV_OVF_U2_R8, "conv.ovf.u2.r8", 1, MintOpNoArgs)
 
 OPDEF(MINT_CONV_OVF_I4_U4, "conv.ovf.i4.u4", 1, MintOpNoArgs)
 OPDEF(MINT_CONV_OVF_I4_I8, "conv.ovf.i4.i8", 1, MintOpNoArgs)
+OPDEF(MINT_CONV_OVF_I4_U8, "conv.ovf.i4.u8", 1, MintOpNoArgs)
 OPDEF(MINT_CONV_OVF_I4_R8, "conv.ovf.i4.r8", 1, MintOpNoArgs)
 
 OPDEF(MINT_CONV_OVF_I4_UN_I8, "conv.ovf.i4.un.i8", 1, MintOpNoArgs)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2685,6 +2685,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				ADD_CODE(&td, MINT_CONV_OVF_U8_I4);
 				break;
 			case STACK_TYPE_I8:
+				ADD_CODE (&td, MINT_CONV_OVF_U8_I8);
 				break;
 			default:
 				g_assert_not_reached ();

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3291,7 +3291,6 @@ mono_interp_transform_method (RuntimeMethod *runtime_method, ThreadContext *cont
 		mono_os_mutex_lock(&calc_section);
 		if (runtime_method->transformed) {
 			mono_os_mutex_unlock(&calc_section);
-			g_error ("FIXME: no jit info?");
 			mono_profiler_method_end_jit (method, NULL, MONO_PROFILE_OK);
 			return NULL;
 		}

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -936,12 +936,11 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 		td.stack_height [c->handler_offset] = 0;
 		td.vt_stack_size [c->handler_offset] = 0;
 		td.is_bb_start [c->handler_offset] = 1;
-		if (c->flags == MONO_EXCEPTION_CLAUSE_NONE) {
-			td.stack_height [c->handler_offset] = 1;
-			td.stack_state [c->handler_offset] = g_malloc0(sizeof(StackInfo));
-			td.stack_state [c->handler_offset][0].type = STACK_TYPE_O;
-			td.stack_state [c->handler_offset][0].klass = NULL; /*FIX*/
-		}
+
+		td.stack_height [c->handler_offset] = 1;
+		td.stack_state [c->handler_offset] = g_malloc0(sizeof(StackInfo));
+		td.stack_state [c->handler_offset][0].type = STACK_TYPE_O;
+		td.stack_state [c->handler_offset][0].klass = NULL; /*FIX*/
 	}
 
 	td.ip = header->code;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1793,17 +1793,23 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			++td.ip;
 			SET_SIMPLE_TYPE(td.sp - 1, STACK_TYPE_I8);
 			break;
-#if 0
 		case CEE_CPOBJ: {
-			MonoClass *vtklass;
-			++ip;
-			vtklass = mono_class_get_full (image, read32 (ip), generic_context);
-			ip += 4;
-			sp -= 2;
-			memcpy (sp [0].data.p, sp [1].data.p, mono_class_value_size (vtklass, NULL));
+			CHECK_STACK (&td, 2);
+
+			token = read32 (td.ip + 1);
+			klass = mono_class_get_full (image, token, generic_context);
+
+			if (klass->valuetype) {
+				ADD_CODE (&td, MINT_CPOBJ);
+				ADD_CODE (&td, get_data_item_index(&td, klass));
+			} else {
+				ADD_CODE (&td, MINT_LDIND_REF);
+				ADD_CODE (&td, MINT_STIND_REF);
+			}
+			td.ip += 5;
+			td.sp -= 2;
 			break;
 		}
-#endif
 		case CEE_LDOBJ: {
 			int size;
 			CHECK_STACK (&td, 1);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -965,7 +965,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 
 	for (i = 0; i < header->num_locals; i++) {
 		int mt = mint_type(header->locals [i]);
-		if (mt == MINT_TYPE_VT || mt == MINT_TYPE_O) {
+		if (mt == MINT_TYPE_VT || mt == MINT_TYPE_O || mt == MINT_TYPE_P) {
 			ADD_CODE(&td, MINT_INITLOCALS);
 			break;
 		}

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1953,7 +1953,11 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				int mt = mint_type (&klass->byval_arg);
 				ADD_CODE (&td, MINT_UNBOX);
 				ADD_CODE (&td, get_data_item_index (&td, klass));
+
+				ADD_CODE (&td, MINT_LDOBJ);
+				ADD_CODE (&td, get_data_item_index(&td, klass));
 				SET_TYPE (td.sp - 1, stack_type [mt], klass);
+
 				if (mt == MINT_TYPE_VT) {
 					int size = mono_class_value_size (klass, NULL);
 					PUSH_VT (&td, size);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2502,6 +2502,9 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				case MINT_TYPE_I4:
 					SIMPLE_OP (td, MINT_STELEM_I4);
 					break;
+				case MINT_TYPE_I8:
+					SIMPLE_OP (td, MINT_STELEM_I8);
+					break;
 				case MINT_TYPE_O:
 					SIMPLE_OP (td, MINT_STELEM_REF);
 					break;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2175,6 +2175,8 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				ADD_CODE(&td, MINT_CONV_OVF_I8_UN_R8);
 				break;
 			case STACK_TYPE_I8:
+				if (*td.ip == CEE_CONV_OVF_I8_UN)
+					ADD_CODE (&td, MINT_CONV_OVF_I8_U8);
 				break;
 			case STACK_TYPE_I4:
 				ADD_CODE(&td, MINT_CONV_I8_U4);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2098,6 +2098,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			break;
 		}
 		case CEE_CONV_OVF_I_UN:
+		case CEE_CONV_OVF_U_UN:
 			CHECK_STACK (&td, 1);
 			switch (td.sp [-1].type) {
 			case STACK_TYPE_R8:
@@ -2108,7 +2109,9 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 #endif
 				break;
 			case STACK_TYPE_I8:
-				/*FIX*/
+#if SIZEOF_VOID_P == 4
+				ADD_CODE (&td, MINT_CONV_OVF_I4_UN_I8);
+#endif
 				break;
 			case STACK_TYPE_I4:
 #if SIZEOF_VOID_P == 8
@@ -2123,6 +2126,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			++td.ip;
 			break;
 		case CEE_CONV_OVF_I8_UN:
+		case CEE_CONV_OVF_U8_UN:
 			CHECK_STACK (&td, 1);
 			switch (td.sp [-1].type) {
 			case STACK_TYPE_R8:

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -784,11 +784,6 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			for (i = csignature->param_count - 1; i >= 0; --i)
 				store_arg (td, i + csignature->hasthis);
 
-			if (csignature->hasthis) {
-				g_error ("STTHIS removal");
-				// ADD_CODE(td, MINT_STTHIS);
-				--td->sp;
-			}
 			ADD_CODE(td, MINT_BR_S);
 			offset = body_start_offset - ((td->new_ip - 1) - td->new_code);
 			ADD_CODE(td, offset);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2688,14 +2688,16 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			} else {
 				handle = mono_ldtoken (image, token, &klass, generic_context);
 			}
-			mt = mint_type(&klass->byval_arg);
+			mt = mint_type (&klass->byval_arg);
 			g_assert (mt == MINT_TYPE_VT);
 			size = mono_class_value_size (klass, NULL);
 			g_assert (size == sizeof(gpointer));
-			PUSH_VT(&td, sizeof(gpointer));
-			ADD_CODE(&td, MINT_LDTOKEN);
-			ADD_CODE(&td, get_data_item_index (&td, handle));
-			PUSH_SIMPLE_TYPE(&td, stack_type [mt]);
+			PUSH_VT (&td, sizeof(gpointer));
+			ADD_CODE (&td, MINT_LDTOKEN);
+			ADD_CODE (&td, get_data_item_index (&td, handle));
+
+			SET_TYPE (td.sp, stack_type [mt], klass);
+			td.sp++;
 			td.ip += 5;
 			break;
 		}

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -496,11 +496,11 @@ store_arg(TransformData *td, int n)
 	mt = mint_type (type);
 	if (mt == MINT_TYPE_VT) {
 		gint32 size;
-		g_error ("data.klass");
+		MonoClass *klass = mono_class_from_mono_type (type);
 		if (mono_method_signature (td->method)->pinvoke)
-			size = mono_class_native_size (type->data.klass, NULL);
+			size = mono_class_native_size (klass, NULL);
 		else
-			size = mono_class_value_size (type->data.klass, NULL);
+			size = mono_class_value_size (klass, NULL);
 		ADD_CODE(td, MINT_STARG_VT);
 		ADD_CODE(td, n);
 		WRITE32(td, &size);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3198,6 +3198,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 	g_free (td.stack_height);
 	g_free (td.vt_stack_size);
 	g_free (td.data_items);
+	g_free (td.stack);
 	g_hash_table_destroy (td.data_hash);
 }
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1995,7 +1995,12 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				ADD_CODE (&td, MINT_LDSFLDA);
 				ADD_CODE (&td, get_data_item_index (&td, field));
 			} else {
-				ADD_CODE (&td, MINT_LDFLDA);
+				if ((td.sp - 1)->type == STACK_TYPE_O) {
+					ADD_CODE (&td, MINT_LDFLDA);
+				} else {
+					g_assert ((td.sp -1)->type == STACK_TYPE_MP);
+					ADD_CODE (&td, MINT_LDFLDA_UNSAFE);
+				}
 				ADD_CODE (&td, klass->valuetype ? field->offset - sizeof (MonoObject) : field->offset);
 			}
 			td.ip += 5;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -686,16 +686,15 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 					op = MINT_ARRAY_RANK;
 				else if (strcmp (target_method->name, "get_Length") == 0)
 					op = MINT_LDLEN;
+			} else if (target_method && generic_context) {
+				csignature = mono_inflate_generic_signature (csignature, generic_context, &error);
+				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				target_method = mono_class_inflate_generic_method_checked (target_method, generic_context, &error);
+				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 			}
 		}
 	} else {
 		csignature = mono_method_signature (target_method);
-	}
-
-	/* TODO: that's oddly specific? */
-	if (generic_context && target_method && !strcmp ("Invoke", target_method->name) && target_method->klass->parent == mono_defaults.multicastdelegate_class) {
-		csignature = mono_inflate_generic_signature (csignature, generic_context, &error);
-		mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 	}
 
 	if (constrained_class) {

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -929,7 +929,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 	td.new_ip = td.new_code;
 	td.last_new_ip = NULL;
 
-	td.stack = g_malloc0(header->max_stack * sizeof(td.stack[0]));
+	td.stack = g_malloc0 ((header->max_stack + 1) * sizeof (td.stack [0]));
 	td.sp = td.stack;
 	td.max_stack_height = 0;
 
@@ -3168,6 +3168,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			printf("\n");
 		}
 	}
+	g_assert (td.max_stack_height <= (header->max_stack + 1));
 
 	rtm->clauses = mono_mempool_alloc (domain->mp, header->num_clauses * sizeof(MonoExceptionClause));
 	memcpy (rtm->clauses, header->clauses, header->num_clauses * sizeof(MonoExceptionClause));

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3024,9 +3024,14 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				CHECK_STACK(&td, 1);
 				token = read32 (td.ip + 1);
 				klass = mono_class_get_full (image, token, generic_context);
-				ADD_CODE(&td, MINT_INITOBJ);
-				i32 = mono_class_value_size (klass, NULL);
-				WRITE32(&td, &i32);
+				if (klass->valuetype) {
+					ADD_CODE (&td, MINT_INITOBJ);
+					i32 = mono_class_value_size (klass, NULL);
+					WRITE32 (&td, &i32);
+				} else {
+					ADD_CODE (&td, MINT_LDNULL);
+					ADD_CODE (&td, MINT_STIND_REF);
+				}
 				td.ip += 5;
 				--td.sp;
 				break;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1952,7 +1952,10 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			klass = mono_class_get_full (image, token, generic_context);
 
 			if (mini_type_is_reference (&klass->byval_arg)) {
-				g_error ("unbox_any: generic class is reference type");
+				ADD_CODE (&td, MINT_CASTCLASS);
+				ADD_CODE (&td, get_data_item_index (&td, klass));
+				SET_TYPE (td.sp - 1, stack_type [mt], klass);
+				td.ip += 5;
 			} else if (mono_class_is_nullable (klass)) {
 				MonoMethod *target_method = mono_class_get_method_from_name (klass, "Unbox", 1);
 				/* td.ip is incremented by interp_transform_call */

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3110,19 +3110,19 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				gint32 size;
 				token = read32 (td.ip + 1);
 				td.ip += 5;
-				if (mono_metadata_token_table (token) == MONO_TABLE_TYPESPEC) {
+				if (mono_metadata_token_table (token) == MONO_TABLE_TYPESPEC && !image_is_dynamic (method->klass->image) && !generic_context) {
 					int align;
 					MonoType *type = mono_type_create_from_typespec (image, token);
 					size = mono_type_size (type, &align);
 				} else {
-					guint32 align;
+					int align;
 					MonoClass *szclass = mono_class_get_full (image, token, generic_context);
 					mono_class_init (szclass);
 #if 0
 					if (!szclass->valuetype)
 						THROW_EX (mono_exception_from_name (mono_defaults.corlib, "System", "InvalidProgramException"), ip - 5);
 #endif
-					size = mono_class_value_size (szclass, &align);
+					size = mono_type_size (&szclass->byval_arg, &align);
 				} 
 				ADD_CODE(&td, MINT_LDC_I4);
 				WRITE32(&td, &size);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2616,7 +2616,10 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 					ADD_CODE(&td, MINT_CONV_OVF_I4_U4);
 				break;
 			case STACK_TYPE_I8:
-				ADD_CODE(&td, MINT_CONV_OVF_I4_I8);
+				if (*td.ip == CEE_CONV_OVF_I4_UN)
+					ADD_CODE (&td, MINT_CONV_OVF_I4_U8);
+				else
+					ADD_CODE (&td, MINT_CONV_OVF_I4_I8);
 				break;
 			default:
 				g_assert_not_reached ();

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2482,6 +2482,9 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			token = read32 (td.ip + 1);
 			klass = mono_class_get_full (image, token, generic_context);
 			switch (mint_type (&klass->byval_arg)) {
+				case MINT_TYPE_U1:
+					SIMPLE_OP (td, MINT_STELEM_U1);
+					break;
 				case MINT_TYPE_I4:
 					SIMPLE_OP (td, MINT_STELEM_I4);
 					break;

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -20,6 +20,10 @@
 #include "mini.h"
 #include "lldb.h"
 
+#ifdef ENABLE_INTERPRETER
+#include "interp/interp.h"
+#endif
+
 /*
  * Address of the trampoline code.  This is used by the debugger to check
  * whether a method is a trampoline.
@@ -1458,6 +1462,15 @@ mono_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean ad
 	guint32 code_size = 0;
 
 	error_init (error);
+
+#ifdef ENABLE_INTERPRETER
+	if (mono_use_interpreter) {
+		gpointer ret = mono_interp_create_trampoline (domain, method, error);
+		if (!mono_error_ok (error))
+			return NULL;
+		return ret;
+	}
+#endif
 
 	code = mono_jit_find_compiled_method_with_jit_info (domain, method, &ji);
 	/*


### PR DESCRIPTION
I realized that I didn't add `iltests.exe` yet to the interpreter regression suite. That uncovered a lot of minor issues regarding the spec. Other stuff worth mentioning:

* I had two test cases still failing in `generics.cs`, but it was somewhere deep in localization code of the BCL. I moved on to the IL tests, and one test there pinned down an issue in `initobj` that turned out to be the same problem for the tests in `generics.cs`. Looking at a method with five bytecodes identifying the problem is slightly easier; Hooray for great tests! 🙂 
* Who decided that you can read static fields with the instance field bytecodes? _sigh_
* refactored `Array.{Set,Get,Address}` runtime methods and throw IOB exceptions properly.
* Some overflow checks were missing in conversion code and also allocation stuff (in some cases the exception wasn't propagated properly from the runtime to the interpreter).
* On "longer running" programs (e.g. `mcs.exe --version`), data structures for metadata would get corrupted. Turned out the transform phase of the interpreter wrote beyond its allocated memory. `valgrind` was very helpful tracking this issue down.
* The interpreter can run Roslyn now.  Okay Okay, don't get too excited: it's just `-version` 🙂  still, that's _alot_ of code, the tracing file is around 120mb big. Fun fact: It can print the version number in half the time of the JIT 😁  (fair side note: runtime compiled with `-O0 -g`). However, both, roslyn and mcs, fail to compile a simple` hello.cs`, having problems somewhere in reflection code. I didn't look into it yet.

remaining issues regarding the regression suite:

* implement `rethrow` properly (moderate effort)
* implement filter clauses (kinda complicated)
* respect `System.Runtime.CompilerServices.RuntimeWrappedException`  (should be easy)


Here is the current state of `make richeck`:

```
MONO_PATH=/Users/bernhardu/work/mono/mcs/class/lib/net_4_x ../../runtime/mono-wrapper  --interpreter --regression basic.exe basic-float.exe basic-long.exe basic-calls.exe objects.exe arrays.exe basic-math.exe exceptions.exe iltests.exe devirtualization.exe generics.exe basic-simd.exe basic-vectors.exe
Test run: image=/Users/bernhardu/work/mono/mono/mini/basic.exe
Results: total tests: 134, all pass
Elapsed time: 0.001550 secs (0.001550, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/basic-float.exe
Results: total tests: 54, all pass
Elapsed time: 0.000487 secs (0.000487, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/basic-long.exe
Results: total tests: 97, all pass
Elapsed time: 0.000767 secs (0.000767, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/basic-calls.exe
Results: total tests: 27, all pass
Elapsed time: 0.000440 secs (0.000440, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/objects.exe
Results: total tests: 90, all pass
Elapsed time: 0.120985 secs (0.120985, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/arrays.exe
Results: total tests: 33, all pass
Elapsed time: 0.017747 secs (0.017747, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/basic-math.exe
Results: total tests: 21, all pass
Elapsed time: 0.000799 secs (0.000799, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/exceptions.exe
skip test_0_rethrow_stacktrace...
Results: total tests: 78, all pass
Elapsed time: 0.028701 secs (0.028701, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/iltests.exe
ret: more values on stack: 1
skip test_1_filters...
Tests.test_0_initblk_3_regress_481458: CEE_RET: more values on stack: 1
ret: more values on stack: 1
skip test_0_wrap_non_exception_throws...
Results: total tests: 103, all pass
Elapsed time: 0.007754 secs (0.007754, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/devirtualization.exe
Results: total tests: 6, all pass
Elapsed time: 0.000612 secs (0.000612, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/generics.exe
Results: total tests: 72, all pass
Elapsed time: 0.081848 secs (0.081848, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/basic-simd.exe
Results: total tests: 183, all pass
Elapsed time: 0.009165 secs (0.009165, 0.000000)

Test run: image=/Users/bernhardu/work/mono/mono/mini/basic-vectors.exe
Results: total tests: 98, all pass
Elapsed time: 0.076789 secs (0.076789, 0.000000)

Overall results: tests: 996, 100% pass

```
