### PR TITLE
Fix UnixSignal.WaitOne for zero timeout.

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixSignal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixSignal.cs
@@ -188,6 +188,8 @@ namespace Mono.Unix {
 			AssertValid ();
 			if (exitContext)
 				throw new InvalidOperationException ("exitContext is not supported");
+			if (millisecondsTimeout == 0)
+				return IsSet;		
 			return WaitAny (new UnixSignal[]{this}, millisecondsTimeout) == 0;
 		}
 		#endregion


### PR DESCRIPTION
For timeouts of 0 milliseconds, `UnixSignal.WaitOne` may produce incorrect results. In case of timeout, the result of `WaitAny` denotes the amount of milliseconds that have timed out. `WaitOne` relies on WaitAny and interprets the result falsely as the index of the completed handle. This change introduces a check on the timeout and returns `IsSet` when the handle is not allowed to block.

This is in accordance to Microsofts [documentation of WaitOne](https://msdn.microsoft.com/de-de/library/cc189983(v=vs.110).aspx) which states "If millisecondsTimeout is zero, the method does not block. It tests the state of the wait handles and returns immediately.". 

[Here](https://github.com/StephenCleary/AsyncEx.Interop.WaitHandles/blob/master/src/Nito.AsyncEx.Interop.WaitHandles/WaitHandleInterop.cs#L51) is an example of some code relying on correct output of `WaitOne(0)` that is effectively broken by the current behaviour.