### PR TITLE
Encode directory separator character on Windows

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -1114,6 +1114,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 	
 	static readonly Universe universe = new Universe ();
 	static readonly Dictionary<string, string> loaded_assemblies = new Dictionary<string, string> ();
+	static readonly string resourcePathSeparator = (Path.DirectorySeparatorChar == '\\') ? $"\\{Path.DirectorySeparatorChar}" : $"{Path.DirectorySeparatorChar}";
 
 	public static string GetAssemblyName (string path)
 	{
@@ -1126,7 +1127,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			string dir = Path.GetDirectoryName (path);
 			int idx = dir.LastIndexOf (Path.DirectorySeparatorChar);
 			if (idx >= 0) {
-				name = dir.Substring (idx + 1) + Path.DirectorySeparatorChar + name;
+				name = dir.Substring (idx + 1) + resourcePathSeparator + name;
 				Console.WriteLine ($"Storing satellite assembly '{path}' with name '{name}'");
 			} else if (!quiet)
 				Console.WriteLine ($"Warning: satellite assembly {path} doesn't have locale path prefix, name conflicts possible");


### PR DESCRIPTION
When storing satellite assemblies, mkbundle prefixes their names with a
directory name derived from the language/locale of the assembly. It uses the
platform's default directory separator character which on Windows defaults to
`'\'` and that causes problems when building such a bundle on Windows since `\` is
an escape sequence prefix inside strings and not escaping it with another `\`
leads to gcc errors when building the genrated source.

This commit fixes the problem by quoting the directory separator character
properly on Windows.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52845