### PR TITLE
[api] Remove dead mono_load_image API.

### DIFF
--- a/docs/sources/mono-api-image.html
+++ b/docs/sources/mono-api-image.html
@@ -27,7 +27,6 @@ typedef enum {
 
 <h3>Opening and closing MonoImages</h3>
 
-<h4><a name="api:mono_load_image">mono_load_image</a></h4>
 <h4><a name="api:mono_image_open">mono_image_open</a></h4>
 <h4><a name="api:mono_image_open_full">mono_image_open_full</a></h4>
 <h4><a name="api:mono_image_open_from_data">mono_image_open_from_data</a></h4>

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -51,9 +51,6 @@ mono_method_get_flags      (MonoMethod *method, uint32_t *iflags);
 MONO_API uint32_t
 mono_method_get_index      (MonoMethod *method);
 
-MONO_API MonoImage *
-mono_load_image            (const char *fname, MonoImageOpenStatus *status);
-
 MONO_API void
 mono_add_internal_call     (const char *name, const void* method);
 


### PR DESCRIPTION
This function doesn’t seem to be defined anywhere, so I hope this isn’t a breaking change.