### PR TITLE
Don't assume GetSection will always return a SystemDiagnosticsSection

### DIFF
--- a/mcs/class/referencesource/System/compmod/system/diagnostics/DiagnosticsConfiguration.cs
+++ b/mcs/class/referencesource/System/compmod/system/diagnostics/DiagnosticsConfiguration.cs
@@ -168,8 +168,10 @@ namespace System.Diagnostics {
         }
         
         private static SystemDiagnosticsSection GetConfigSection() {
-            SystemDiagnosticsSection configSection = (SystemDiagnosticsSection) PrivilegedConfigurationManager.GetSection("system.diagnostics");
-            return configSection;
+            object o = PrivilegedConfigurationManager.GetSection("system.diagnostics");
+            if (o is SystemDiagnosticsSection)
+                return (SystemDiagnosticsSection)o;
+            return null;
         }
 
         internal static bool IsInitializing() {


### PR DESCRIPTION
* In the Mono class library code, it is possible for `GetSection` implementations to return an instance of some other type.
* Since the code is not type safe, we should be defensive and only return an object if it is a `SystemDiagnosticsSection`.

I've not found a good way to add a unit test for this change. I'm open to suggestions though. The issue we have involves the `XmlSerializer` type, but that seems a little high level to use in a `System.Diagnostics` test.