### PR TITLE
[mini] Fix amd64 checked build

### DIFF
--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -595,7 +595,7 @@ mono_arch_code_chunk_destroy (void *chunk);
 #define MONO_TRAMPOLINE_UNWINDINFO_SIZE(max_code_count) (mono_arch_unwindinfo_get_size (max_code_count))
 #define MONO_MAX_TRAMPOLINE_UNWINDINFO_SIZE (MONO_TRAMPOLINE_UNWINDINFO_SIZE(3))
 
-inline gboolean
+static inline gboolean
 mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 {
 	guint current_size = mono_arch_unwindinfo_get_size (mono_arch_unwindinfo_get_code_count (unwind_ops));
@@ -607,8 +607,8 @@ mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 #define MONO_TRAMPOLINE_UNWINDINFO_SIZE(max_code_count) 0
 #define MONO_MAX_TRAMPOLINE_UNWINDINFO_SIZE 0
 
-inline gboolean
-mono_arch_unwindinfo_validate_unwindinfo_size (GSList *unwind_ops, guint max_size)
+static inline gboolean
+mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 {
 	return TRUE;
 }


### PR DESCRIPTION
Typo in function name.

Also mark inline function definition in header with static