### PR TITLE
Handle a file ref, with backslashes, in a .resx, on a non-windows system

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Resources/ResXFileRef.cs
+++ b/mcs/class/System.Windows.Forms/System.Resources/ResXFileRef.cs
@@ -82,7 +82,11 @@ namespace System.Resources {
 					}
 				}
 
-				using (FileStream file = new FileStream (parts [0], FileMode.Open, FileAccess.Read, FileShare.Read)) {
+				string filename = parts [0];
+				if (Path.DirectorySeparatorChar == '/')
+					filename = filename.Replace ("\\", "/");
+
+				using (FileStream file = new FileStream (filename, FileMode.Open, FileAccess.Read, FileShare.Read)) {
 					buffer = new byte [file.Length];
 					file.Read(buffer, 0, (int) file.Length);
 				}
@@ -90,7 +94,7 @@ namespace System.Resources {
 				if (type == typeof(System.Byte[]))
 					return buffer;
 
-				if (type == typeof (Bitmap) && Path.GetExtension (parts [0]) == ".ico") {
+				if (type == typeof (Bitmap) && Path.GetExtension (filename) == ".ico") {
 					MemoryStream ms = new MemoryStream (buffer);
 					return new Icon (ms).ToBitmap ();
 				}

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXFileRefTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXFileRefTest.cs
@@ -230,6 +230,26 @@ namespace MonoTests.System.Resources
 		}
 
 		[Test]
+		public void ConvertFrom_Type_String_FilePathWithBackslashes ()
+		{
+			if (Path.DirectorySeparatorChar == '\\')
+				// non-windows test
+				return;
+
+			string fileContents = "foobar";
+			string fileName = "foo.txt";
+			string filePath = Path.Combine (_tempDirectory, fileName);
+			File.WriteAllText (filePath, fileContents);
+
+			filePath = _tempDirectory + "\\.\\" + filename;
+
+			string fileRef = filePath + ";" + typeof (string).AssemblyQualifiedName;
+			string result = _converter.ConvertFrom (fileRef) as string;
+			Assert.IsNotNull (result, "#A1");
+			Assert.AreEqual (result, fileContents, "#A2");
+		}
+
+		[Test]
 		public void ConvertFrom_Type_StreamReader ()
 		{
 			// read UTF-7 content without setting encoding


### PR DESCRIPTION
File ref of the form:

```xml
  <data name="foo" type="System.Resources.ResXFileRef, System.Windows.Forms">
    <value>..\Resources\foo.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
  </data>
```