### PR TITLE
[bcl] Implement RuntimeHelpers.IsReferenceOrContainsReferences () as …

### DIFF
--- a/mcs/class/corlib/System.Runtime.CompilerServices/RuntimeHelpers.cs
+++ b/mcs/class/corlib/System.Runtime.CompilerServices/RuntimeHelpers.cs
@@ -185,10 +185,10 @@ namespace System.Runtime.CompilerServices
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern void RunModuleConstructor (IntPtr module);
 
-		[MonoTODO]
+		// This is implemented as a JIT intrinsic
 		public static bool IsReferenceOrContainsReferences<T>()
 		{
-			return true;
+			return !typeof (T).IsValueType || RuntimeTypeHandle.HasReferences ((typeof (T) as RuntimeType));
 		}
 	}
 }

--- a/mcs/class/corlib/System/RuntimeTypeHandle.cs
+++ b/mcs/class/corlib/System/RuntimeTypeHandle.cs
@@ -188,6 +188,9 @@ namespace System
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal extern static bool IsPrimitive (RuntimeType type);
 
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal extern static bool HasReferences (RuntimeType type);
+
 		internal static bool IsComObject (RuntimeType type, bool isGenericCOM)
 		{
 			return isGenericCOM ? false : IsComObject (type);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -808,6 +808,7 @@ HANDLES(ICALL(RTH_6, "GetGenericTypeDefinition_impl", ves_icall_RuntimeTypeHandl
 HANDLES(ICALL(RTH_7, "GetMetadataToken", ves_icall_reflection_get_token))
 HANDLES(ICALL(RTH_8, "GetModule", ves_icall_RuntimeTypeHandle_GetModule))
 HANDLES(ICALL(RTH_9, "HasInstantiation", ves_icall_RuntimeTypeHandle_HasInstantiation))
+HANDLES(ICALL(RTH_20, "HasReferences", ves_icall_RuntimeTypeHandle_HasReferences))
 HANDLES(ICALL(RTH_10, "IsArray", ves_icall_RuntimeTypeHandle_IsArray))
 HANDLES(ICALL(RTH_11, "IsByRef", ves_icall_RuntimeTypeHandle_IsByRef))
 HANDLES(ICALL(RTH_12, "IsComObject", ves_icall_RuntimeTypeHandle_IsComObject))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2572,6 +2572,18 @@ ves_icall_RuntimeTypeHandle_IsPrimitive (MonoReflectionTypeHandle ref_type, Mono
 }
 
 ICALL_EXPORT MonoBoolean
+ves_icall_RuntimeTypeHandle_HasReferences (MonoReflectionTypeHandle ref_type, MonoError *error)
+{
+	error_init (error);
+	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
+	MonoClass *klass;
+
+	klass = mono_class_from_mono_type (type);
+	mono_class_init (klass);
+	return klass->has_references;
+}
+
+ICALL_EXPORT MonoBoolean
 ves_icall_RuntimeTypeHandle_IsByRef (MonoReflectionTypeHandle ref_type, MonoError *error)
 {
 	error_init (error);


### PR DESCRIPTION
…an icall, so it works even if the intrinsic is disabled.