### PR TITLE
[corlib] FileStream::Name needs to include fully qualified

### DIFF
--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -188,6 +188,8 @@ namespace System.IO
 				throw new ArgumentException ("Name has invalid chars");
 			}
 
+			path = Path.InsecureGetFullPath (path);
+
 			if (Directory.Exists (path)) {
 				// don't leak the path information for isolated storage
 				string msg = Locale.GetText ("Access to the path '{0}' is denied.");
@@ -211,11 +213,7 @@ namespace System.IO
 
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
 
-			string dname;
-			if (Path.DirectorySeparatorChar != '/' && path.IndexOf ('/') >= 0)
-				dname = Path.GetDirectoryName (Path.GetFullPath (path));
-			else
-				dname = Path.GetDirectoryName (path);
+			string dname = Path.GetDirectoryName (path);
 			if (dname.Length > 0) {
 				string fp = Path.GetFullPath (dname);
 				if (!Directory.Exists (fp)) {

--- a/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileStreamTest.cs
@@ -1742,5 +1742,15 @@ namespace MonoTests.System.IO
 				DeleteFile (path);
 			}
 		}
+
+		[Test]
+		public void NamePropertyNormalization ()
+		{
+			string fname = TempFolder + DSC + ".." + DSC + "MonoTests.System.IO.Tests" + DSC + "tfile.txt";
+
+			using (var s = new FileStream (fname, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Delete)) {
+				Assert.AreEqual (TempFolder + DSC + "tfile.txt", s.Name);
+			}
+		}
 	}
 }


### PR DESCRIPTION
normalized name. Fixes #53231