### PR TITLE
Remove CAS attributes from System.Drawing unit tests

### DIFF
--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/PathGradientBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/PathGradientBrushTest.cs
@@ -36,7 +36,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Drawing2D {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class PathGradientBrushTest {
 
 		private Point[] pts_2i;

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestHatchBrush.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/TestHatchBrush.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Drawing2D
 {
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class HatchBrushTest {
 		Graphics gr;
 		Bitmap bmp;

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/GifCodecTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/GifCodecTest.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class GifCodecTest {
 
 		/* Get suffix to add to the filename */

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/IconCodecTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/IconCodecTest.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class IconCodecTest {
 
 		/* Get suffix to add to the filename */

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/MetafileTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/MetafileTest.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class MetafileTest {
 
 		public const string Bitmap = "bitmaps/non-inverted.bmp";

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/PngCodecTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/PngCodecTest.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class PngCodecTest {
 
 		/* Get suffix to add to the filename */

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestBmpCodec.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestBmpCodec.cs
@@ -40,7 +40,6 @@ using System.Text;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class BmpCodecTest {
 		
 		/* Get suffix to add to the filename */

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestImageAttributes.cs
@@ -36,7 +36,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class ImageAttributesTest {
 
 		static ColorMatrix global_color_matrix = new ColorMatrix (new float[][] {

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestJpegCodec.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestJpegCodec.cs
@@ -38,7 +38,6 @@ using System.Security.Permissions;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class JpegCodecTest {
 
 		/* Get suffix to add to the filename */

--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TiffCodecTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TiffCodecTest.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Imaging {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class TiffCodecTest {
 
 		[TestFixtureSetUp]

--- a/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Text/PrivateFontCollectionTest.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing.Text {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class PrivateFontCollectionTest {
 
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/ColorConverter.cs
@@ -36,7 +36,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class ColorConverterTest {
 
 		Color col;

--- a/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/FontFamilyTest.cs
@@ -36,7 +36,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class FontFamilyTest {
 
 		private Bitmap bitmap;

--- a/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/PenTest.cs
@@ -36,7 +36,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class PenTest {
 
 		private Pen default_pen;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
@@ -48,7 +48,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class TestBitmap {
 		
 		[Test]

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestGraphics.cs
@@ -40,7 +40,6 @@ using System.Security.Permissions;
 namespace MonoTests.System.Drawing {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class GraphicsTest {
 
 		private RectangleF[] rects;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
@@ -40,7 +40,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing {
 
 	[TestFixture]	
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class IconTest {
 		
 		Icon icon;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestIconConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestIconConverter.cs
@@ -42,7 +42,6 @@ using System.Security.Permissions;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class IconConverterTest
 	{
 		Icon icon;		

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestImage.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestImage.cs
@@ -40,7 +40,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing{
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class ImageTest {
 
 		private string fname;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestImageConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestImageConverter.cs
@@ -41,7 +41,6 @@ using System.Security.Permissions;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class ImageConverterTest 
 	{
 		Image image;		

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestImageFormatConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestImageFormatConverter.cs
@@ -39,7 +39,6 @@ using System.Security.Permissions;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class ImageFormatConverterTest
 	{
 		ImageFormat imageFmt;		

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestPointConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestPointConverter.cs
@@ -41,7 +41,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]	
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class PointConverterTest
 	{
 		Point pt;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestPointF.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestPointF.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]	
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class PointFTest
 	{
 		PointF pt11_99;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestRectangleConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestRectangleConverter.cs
@@ -42,7 +42,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class RectangleConverterTest
 	{
 		Rectangle rect;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestSizeConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestSizeConverter.cs
@@ -42,7 +42,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class SizeConverterTest
 	{
 		Size sz;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestSizeF.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestSizeF.cs
@@ -39,7 +39,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing 
 {
 	[TestFixture]	
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class SizeFTest
 	{
 		SizeF sz11_99;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestSizeFConverter.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestSizeFConverter.cs
@@ -43,7 +43,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing
 {
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class SizeFConverterTest
 	{
 		SizeF sz;

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestStringFormat.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestStringFormat.cs
@@ -38,7 +38,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing{
 
 	[TestFixture]	
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class StringFormatTest {
 
 		private void CheckDefaults (StringFormat sf)

--- a/mcs/class/System.Drawing/Test/System.Drawing/TextureBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TextureBrushTest.cs
@@ -37,7 +37,6 @@ using NUnit.Framework;
 namespace MonoTests.System.Drawing {
 
 	[TestFixture]
-	[SecurityPermission (SecurityAction.Deny, UnmanagedCode = true)]
 	public class TextureBrushTest {
 
 		private Image image;


### PR DESCRIPTION
The `SecurityAction.Deny` stack modifier is obsolete in .NET 4.0 and above, so trying to run these tests on .NET 4.0 would cause runtime exceptions.

Being able to run the unit tests on .NET 4.0/Windows helps with troubleshooting some libgdiplus issues.