### PR TITLE
[runtime] Mark array types with more than 32 dimensions as invalid. M…

### DIFF
--- a/mcs/class/corlib/Test/System/ArrayTest.cs
+++ b/mcs/class/corlib/Test/System/ArrayTest.cs
@@ -780,6 +780,14 @@ public class ArrayTest
 	}
 
 	[Test]
+	public void CreateInstanceVoid ()
+	{
+		Assert.Throws<NotSupportedException> (delegate () {
+				Array.CreateInstance (typeof (void), 1);
+			});
+	}
+
+	[Test]
 	public void TestGetEnumerator() {
 		String[] s1 = {"this", "is", "a", "test"};
 		IEnumerator en = s1.GetEnumerator ();

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3068,6 +3068,14 @@ namespace MonoTests.System
 			object o = Array.CreateInstance (typeof (global::System.TypedReference), 1);
 		}
 
+		[Test]
+		public void MakeArrayTypeLargeRank ()
+		{
+			Assert.Throws<TypeLoadException> (delegate () {
+					typeof (int).MakeArrayType (33);
+				});
+		}
+
 		[ComVisible (true)]
 		public class ComFoo<T> {
 		}


### PR DESCRIPTION
…ove the check for arrays of void into Array.CreateInstance (), since typeof (void).MakeArrayType () is valid. Fixes #53131.