### PR TITLE
less allocation in Socket

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -2681,14 +2681,12 @@ m_Handle, buffer, offset + sent, size - sent, socketFlags, out nativeError, is_b
 
 		void QueueIOSelectorJob (SemaphoreSlim sem, IntPtr handle, IOSelectorJob job)
 		{
-			sem.WaitAsync ().ContinueWith (t => {
-				if (CleanedUp) {
-					job.MarkDisposed ();
-					return;
-				}
-
-				IOSelector.Add (handle, job);
-			});
+			sem.Wait();
+			if (CleanedUp) {
+				job.MarkDisposed ();
+				return;
+			}
+			IOSelector.Add (handle, job);
 		}
 
 		void InitSocketAsyncEventArgs (SocketAsyncEventArgs e, AsyncCallback callback, object state, SocketOperation operation)

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -2697,7 +2697,7 @@ m_Handle, buffer, offset + sent, size - sent, socketFlags, out nativeError, is_b
 						job.MarkDisposed ();
 						return;
 					}
-					IOSelect.Add(handle, job);
+					IOSelector.Add(handle, job);
 				});
 			}
 		}

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -2697,6 +2697,7 @@ m_Handle, buffer, offset + sent, size - sent, socketFlags, out nativeError, is_b
 						job.MarkDisposed ();
 						return;
 					}
+					IOSelect.Add(handle, job);
 				});
 			}
 		}

--- a/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
@@ -133,11 +133,6 @@ namespace System.Net.Sockets
 			}
 		}
 
-		static WaitCallback WorkItemCallback = new WaitCallback((object state) => {
-			SocketAsyncResult ar = (SocketAsyncResult) state;
-			ar.AsyncCallback(ar);
-		});
-
 		internal override void CompleteDisposed ()
 		{
 			Complete ();

--- a/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
@@ -133,6 +133,11 @@ namespace System.Net.Sockets
 			}
 		}
 
+		static WaitCallback WorkItemCallback = new WaitCallback((object state) => {
+			SocketAsyncResult ar = (SocketAsyncResult) state;
+			ar.AsyncCallback(ar);
+		});
+
 		internal override void CompleteDisposed ()
 		{
 			Complete ();
@@ -153,9 +158,8 @@ namespace System.Net.Sockets
 			Socket completedSocket = socket;
 			SocketOperation completedOperation = operation;
 
-			AsyncCallback callback = AsyncCallback;
-			if (callback != null) {
-				ThreadPool.UnsafeQueueUserWorkItem (_ => callback (this), null);
+			if (this.AsyncCallback != null) {
+				ThreadPool.UnsafeQueueUserWorkItem (WorkItemCallback, this);
 			}
 
 			/* Warning: any field on the current SocketAsyncResult might have changed, as the callback might have

--- a/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
@@ -158,8 +158,13 @@ namespace System.Net.Sockets
 			Socket completedSocket = socket;
 			SocketOperation completedOperation = operation;
 
-			if (this.AsyncCallback != null) {
-				ThreadPool.UnsafeQueueUserWorkItem (WorkItemCallback, this);
+			AsyncCallback callback = AsyncCallback;
+			if (callback != null) {
+				QueueUserWorkItemCallback workItemCallback = (object state) => {
+					SocketAsyncResult ar = (SocketAsyncResult) state;
+					ar.AsyncCallback(ar);
+				};
+				ThreadPool.UnsafeQueueUserWorkItem (workItemCallback, this);
 			}
 
 			/* Warning: any field on the current SocketAsyncResult might have changed, as the callback might have

--- a/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
@@ -154,7 +154,7 @@ namespace System.Net.Sockets
 			SocketOperation completedOperation = operation;
 
 			if (this.AsyncCallback != null) {
-				ThreadPool.UnsafeQueueUserWorkItem(state => ((SocketAsyncResult)state).AsyncCallback(state), this);
+				ThreadPool.UnsafeQueueUserWorkItem(state => ((SocketAsyncResult)state).AsyncCallback((SocketAsyncResult)state), this);
 			}
 
 			/* Warning: any field on the current SocketAsyncResult might have changed, as the callback might have

--- a/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs
@@ -153,13 +153,8 @@ namespace System.Net.Sockets
 			Socket completedSocket = socket;
 			SocketOperation completedOperation = operation;
 
-			AsyncCallback callback = AsyncCallback;
-			if (callback != null) {
-				QueueUserWorkItemCallback workItemCallback = (object state) => {
-					SocketAsyncResult ar = (SocketAsyncResult) state;
-					ar.AsyncCallback(ar);
-				};
-				ThreadPool.UnsafeQueueUserWorkItem (workItemCallback, this);
+			if (this.AsyncCallback != null) {
+				ThreadPool.UnsafeQueueUserWorkItem(state => ((SocketAsyncResult)state).AsyncCallback(state), this);
 			}
 
 			/* Warning: any field on the current SocketAsyncResult might have changed, as the callback might have


### PR DESCRIPTION
1. avoid allocating `System.Threading.QueueUserWorkItemCallback` in `SocketAsyncResult.Complete`
2. avoid allocating `Task` and anonymous function in `Socket.QueueIOSelectorJob`