### PR TITLE
Handle windows paths in ResXFileRef, for conversion to string case

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Resources/ResXFileRef.cs
+++ b/mcs/class/System.Windows.Forms/System.Resources/ResXFileRef.cs
@@ -68,6 +68,10 @@ namespace System.Resources {
 				if (parts.Length == 1)
 					throw new ArgumentException ("value");
 
+				string filename = parts [0];
+				if (Path.DirectorySeparatorChar == '/')
+					filename = filename.Replace ("\\", "/");
+
 				Type type = Type.GetType (parts [1]);
 				if (type == typeof(string)) {
 					Encoding encoding;
@@ -77,14 +81,10 @@ namespace System.Resources {
 						encoding = Encoding.Default;
 					}
 
-					using (TextReader reader = new StreamReader(parts [0], encoding)) {
+					using (TextReader reader = new StreamReader(filename, encoding)) {
 						return reader.ReadToEnd();
 					}
 				}
-
-				string filename = parts [0];
-				if (Path.DirectorySeparatorChar == '/')
-					filename = filename.Replace ("\\", "/");
 
 				using (FileStream file = new FileStream (filename, FileMode.Open, FileAccess.Read, FileShare.Read)) {
 					buffer = new byte [file.Length];

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXFileRefTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXFileRefTest.cs
@@ -230,7 +230,6 @@ namespace MonoTests.System.Resources
 		}
 
 		[Test]
-		[Category ("NotWorking")]
 		public void ConvertFrom_Type_String_FilePathWithBackslashes ()
 		{
 			if (Path.DirectorySeparatorChar == '\\')


### PR DESCRIPTION
- convert the path a little earlier to handle the case for conversion to
  string
- Fixes earlier commit a3195b79f6fdba3a8d59f0de5a881f90dcf7d458
- And enable the corresponding test