### PR TITLE
[sgen] Fix xmm scanning on mac x86

### DIFF
--- a/mono/utils/mono-context.c
+++ b/mono/utils/mono-context.c
@@ -60,6 +60,16 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 	mctx->esi = UCONTEXT_REG_ESI (ctx);
 	mctx->edi = UCONTEXT_REG_EDI (ctx);
 	mctx->eip = UCONTEXT_REG_EIP (ctx);
+#ifdef UCONTEXT_REG_XMM
+	mctx->fregs [0] = UCONTEXT_REG_XMM0 (ctx);
+	mctx->fregs [1] = UCONTEXT_REG_XMM1 (ctx);
+	mctx->fregs [2] = UCONTEXT_REG_XMM2 (ctx);
+	mctx->fregs [3] = UCONTEXT_REG_XMM3 (ctx);
+	mctx->fregs [4] = UCONTEXT_REG_XMM4 (ctx);
+	mctx->fregs [5] = UCONTEXT_REG_XMM5 (ctx);
+	mctx->fregs [6] = UCONTEXT_REG_XMM6 (ctx);
+	mctx->fregs [7] = UCONTEXT_REG_XMM7 (ctx);
+#endif
 #elif defined(HOST_WIN32)
 	CONTEXT *context = (CONTEXT*)sigctx;
 
@@ -106,6 +116,16 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 	UCONTEXT_REG_ESI (ctx) = mctx->esi;
 	UCONTEXT_REG_EDI (ctx) = mctx->edi;
 	UCONTEXT_REG_EIP (ctx) = mctx->eip;
+#ifdef UCONTEXT_REG_XMM
+	UCONTEXT_REG_XMM0 (ctx) = mctx->fregs [0];
+	UCONTEXT_REG_XMM1 (ctx) = mctx->fregs [1];
+	UCONTEXT_REG_XMM2 (ctx) = mctx->fregs [2];
+	UCONTEXT_REG_XMM3 (ctx) = mctx->fregs [3];
+	UCONTEXT_REG_XMM4 (ctx) = mctx->fregs [4];
+	UCONTEXT_REG_XMM5 (ctx) = mctx->fregs [5];
+	UCONTEXT_REG_XMM6 (ctx) = mctx->fregs [6];
+	UCONTEXT_REG_XMM7 (ctx) = mctx->fregs [7];
+#endif
 #elif defined(HOST_WIN32)
 	CONTEXT *context = (CONTEXT*)sigctx;
 

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -192,7 +192,7 @@ typedef struct {
 				[xmm4] MONO_CONTEXT_OFFSET (fregs, X86_XMM4, MonoContextSimdReg), \
 				[xmm5] MONO_CONTEXT_OFFSET (fregs, X86_XMM5, MonoContextSimdReg), \
 				[xmm6] MONO_CONTEXT_OFFSET (fregs, X86_XMM6, MonoContextSimdReg), \
-				[xmm7] MONO_CONTEXT_OFFSET (fregs, X86_XMM7, MonoContextSimdReg), \
+				[xmm7] MONO_CONTEXT_OFFSET (fregs, X86_XMM7, MonoContextSimdReg)); \
 	} while (0)
 #else
 #define MONO_CONTEXT_GET_CURRENT_FREGS(ctx)

--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -45,6 +45,15 @@
 	#define UCONTEXT_REG_ESI(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__esi)
 	#define UCONTEXT_REG_EDI(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__edi)
 	#define UCONTEXT_REG_EIP(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__eip)
+	#define UCONTEXT_REG_XMM
+	#define UCONTEXT_REG_XMM0(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm0)
+	#define UCONTEXT_REG_XMM1(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm1)
+	#define UCONTEXT_REG_XMM2(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm2)
+	#define UCONTEXT_REG_XMM3(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm3)
+	#define UCONTEXT_REG_XMM4(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm4)
+	#define UCONTEXT_REG_XMM5(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm5)
+	#define UCONTEXT_REG_XMM6(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm6)
+	#define UCONTEXT_REG_XMM7(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__fs.__fpu_xmm7)
 #  else
 	#define UCONTEXT_REG_EAX(ctx) (((ucontext_t*)(ctx))->uc_mcontext->ss.eax)
 	#define UCONTEXT_REG_EBX(ctx) (((ucontext_t*)(ctx))->uc_mcontext->ss.ebx)


### PR DESCRIPTION
The MonoContext (which sgen scans) did not have its fpregs populated, even though we were fetching the fpstate.