### PR TITLE
Include Mono version in corlib version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,15 +56,14 @@ DISTCLEANFILES= mono-uninstalled.pc
 # building with monolite
 mcslib = $(mcs_topdir)/class/lib
 monolite = $(mcslib)/monolite
-mono_corlib_version = $(shell sed -n "s/\#define MONO_CORLIB_VERSION //p" $(srcdir)/mono/metadata/appdomain.c)
-monolite_url = http://download.mono-project.com/monolite/monolite-$(mono_corlib_version)-latest.tar.gz
+monolite_url = https://download.mono-project.com/monolite/monolite-$(MONO_CORLIB_VERSION)-latest.tar.gz
 .PHONY: get-monolite-latest 
 get-monolite-latest:
 	-rm -fr $(mcslib)/monolite-*
 	-mkdir -p $(mcslib)
 	test ! -d $(monolite) || test ! -d $(monolite).old || rm -fr $(monolite).old
 	test ! -d $(monolite) || mv -f $(monolite) $(monolite).old
-	cd $(mcslib) && { (wget -O- $(monolite_url) || curl $(monolite_url)) | gzip -d | tar xf - ; }
+	cd $(mcslib) && { (wget -O- $(monolite_url) || curl -L $(monolite_url)) | gzip -d | tar xf - ; }
 	cd $(mcslib) && mv -f monolite-* monolite
 
 if BITCODE

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,24 @@ AC_PROG_LN_S
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+MONO_VERSION_MAJOR=`echo $VERSION | cut -d . -f 1`
+MONO_VERSION_MINOR=`echo $VERSION | cut -d . -f 2`
+MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
+
+# This is the version number of the corlib-runtime interface. When
+# making changes to this interface (by changing the layout
+# of classes the runtime knows about, changing icall signature or
+# semantics etc), increment this variable.
+#
+# This can be reset to 0 when Mono's version number is bumped
+# since it's part of the corlib version (the prefix '1' in the full
+# version number is to ensure the number isn't treated as octal in C)
+MONO_CORLIB_COUNTER=0
+MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR $MONO_VERSION_BUILD $MONO_CORLIB_COUNTER`
+
+AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])
+AC_SUBST(MONO_CORLIB_VERSION)
+
 case $host_os in
 *cygwin* )
 		 echo "Run configure using ./configure --host=i686-pc-mingw32"
@@ -4535,6 +4553,7 @@ fi
     }')]
 
     echo "MONO_VERSION = $myver" >> $mcs_topdir/build/config.make
+    echo "MONO_CORLIB_VERSION = $MONO_CORLIB_VERSION" >> $mcs_topdir/build/config.make
 
     if test x$host_darwin = xyes; then
       echo "PLATFORM = darwin" >> $mcs_topdir/build/config.make

--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -12,7 +12,8 @@ clean-local:
 
 common/Consts.cs: common/Consts.cs.in $(wildcard config.make)
 	test -n '$(MONO_VERSION)'
-	sed -e 's,@''MONO_VERSION@,$(MONO_VERSION),' $< > $@
+	test -n '$(MONO_CORLIB_VERSION)'
+	sed -e 's,@''MONO_VERSION@,$(MONO_VERSION),' -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@
 
 PLATFORMS = darwin linux win32
 PROFILES = \

--- a/mcs/build/common/Consts.cs.in
+++ b/mcs/build/common/Consts.cs.in
@@ -38,6 +38,7 @@ static class Consts
 	public const string MonoCompany = "Mono development team";
 	public const string MonoProduct = "Mono Common Language Infrastructure";
 	public const string MonoCopyright = "(c) Various Mono authors";
+	public const int MonoCorlibVersion = @MONO_CORLIB_VERSION@;
 
 #if MOBILE
 	// Versions of .NET Framework for Silverlight 4.0

--- a/mcs/class/.gitignore
+++ b/mcs/class/.gitignore
@@ -1,2 +1,3 @@
 /lib
 /compat/
+monolite-*.tar.gz

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -425,6 +425,11 @@ $(build_files:%=lib/build/%):
 
 dist-monolite: $(monolite_files) lib/$(monolite_dir)/mcs.exe
 
+package-monolite-latest:
+	MONOLITE=monolite-$(MONO_CORLIB_VERSION)-latest; \
+	$(MAKE) dist-monolite monolite_dir=$$MONOLITE; \
+	tar zcvpf $$MONOLITE.tar.gz --directory=lib $$MONOLITE/
+
 dist-default: dist-monolite
 
 dist-local: dist-default

--- a/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap.dll.sources
+++ b/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap.dll.sources
@@ -1,5 +1,5 @@
 Novell.Directory.Ldap/AssemblyInfo.cs
-../../build/common/Consts.cs.in
+../../build/common/Consts.cs
 Novell.Directory.Ldap/SupportClass.cs
 Novell.Directory.Ldap.Utilclass/Base64.cs
 Novell.Directory.Ldap.Utilclass/DN.cs

--- a/mcs/class/System.Data/mobile_System.Data.dll.sources
+++ b/mcs/class/System.Data/mobile_System.Data.dll.sources
@@ -1,5 +1,5 @@
 Assembly/AssemblyInfo.cs
-../../build/common/Consts.cs.in
+../../build/common/Consts.cs
 ../../build/common/Locale.cs
 ../../build/common/SR.cs
 ../../build/common/MonoTODOAttribute.cs

--- a/mcs/class/System.DirectoryServices/System.DirectoryServices.dll.sources
+++ b/mcs/class/System.DirectoryServices/System.DirectoryServices.dll.sources
@@ -1,5 +1,5 @@
 Assembly/AssemblyInfo.cs
-../../build/common/Consts.cs.in
+../../build/common/Consts.cs
 ../../build/common/Locale.cs
 System.DirectoryServices/ActiveDirectoryAccessRule.cs
 System.DirectoryServices/ActiveDirectoryAuditRule.cs

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -48,16 +48,11 @@ namespace System {
 	public static partial class Environment {
 
 		/*
-		 * This is the version number of the corlib-runtime interface. When
-		 * making changes to this interface (by changing the layout
-		 * of classes the runtime knows about, changing icall signature or
-		 * semantics etc), increment this variable. Also increment the
-		 * pair of this variable in the runtime in metadata/appdomain.c.
-		 * Changes which are already detected at runtime, like the addition
-		 * of icalls, do not require an increment.
+		 * This is the version number of the corlib-runtime interface.
+		 * It is defined in configure.ac.
 		 */
 #pragma warning disable 169
-		private const int mono_corlib_version = 164;
+		private const int mono_corlib_version = Consts.MonoCorlibVersion;
 #pragma warning restore 169
 
 		[ComVisible (true)]

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -76,19 +76,6 @@
 #include <direct.h>
 #endif
 
-/*
- * This is the version number of the corlib-runtime interface. When
- * making changes to this interface (by changing the layout
- * of classes the runtime knows about, changing icall signature or
- * semantics etc), increment this variable. Also increment the
- * pair of this variable in mscorlib in:
- *       mcs/class/corlib/System/Environment.cs
- *
- * Changes which are already detected at runtime, like the addition
- * of icalls, do not require an increment.
- */
-#define MONO_CORLIB_VERSION 164
-
 typedef struct
 {
 	int runtime_count;

--- a/msvc/winsetup.bat
+++ b/msvc/winsetup.bat
@@ -22,6 +22,7 @@ IF NOT %ERRORLEVEL% == 0 (
 	ECHO copy %WIN_CONFIG_H% %CONFIG_H%
 	copy %WIN_CONFIG_H% %CONFIG_H%
 	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "(Get-Content %CONFIG_H%) -replace '#MONO_VERSION#', (Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value | Set-Content %CONFIG_H%" 2>&1
+	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "$mono_version=[int[]](Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value.Split('.'); $corlib_counter=[int](Select-String -path %CONFIGURE_AC% -pattern 'MONO_CORLIB_COUNTER=(.*)').Matches[0].Groups[1].Value; (Get-Content %CONFIG_H%) -replace '#MONO_CORLIB_VERSION#',('1{0:00}{1:00}{2:00}{3:000}' -f $mono_version[0],$mono_version[1],$mono_version[2],$corlib_counter) | Set-Content %CONFIG_H%" 2>&1
 )
 
 %windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File compare-config-files.ps1 %EGLIB_WIN_CONFIG_H% %EGLIB_CONFIG_H% 2>&1

--- a/winconfig.h
+++ b/winconfig.h
@@ -672,4 +672,8 @@
 
 /* Version number of package */
 #define VERSION "#MONO_VERSION#"
+
+/* Version of the corlib-runtime interface */
+#define MONO_CORLIB_VERSION #MONO_CORLIB_VERSION#
+
 #endif


### PR DESCRIPTION
This makes it possible to version the runtime<->corlib interface for each version branch independently and fixes the problem of monolite getting overwritten by changes in different branches when corlib version is still the same.

*Note: I pushed this to 2017-02 already to fix the build there but happy to incorporate feedback from this PR. The PR build will fail due to missing monolite, that's expected.*