### PR TITLE
[ward] Annotate SGen permissions.

### DIFF
--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -730,7 +730,7 @@ get_frame_pointer (MonoContext *ctx, int frame_reg)
  *
  *   Mark a thread stack conservatively and collect information needed by the precise pass.
  */
-static void
+static MONO_PERMIT (need (sgen_gc_locked, sgen_world_stopped)) void
 conservative_pass (TlsData *tls, guint8 *stack_start, guint8 *stack_end)
 {
 	MonoJitInfo *ji;
@@ -1242,7 +1242,7 @@ precise_pass (TlsData *tls, guint8 *stack_start, guint8 *stack_end, void *gc_dat
  * call, and TRUE at the second. USER_DATA points to a TlsData
  * structure filled up by thread_suspend_func. 
  */
-static void
+static MONO_PERMIT (need (sgen_gc_locked, sgen_world_stopped)) void
 thread_mark_func (gpointer user_data, guint8 *stack_start, guint8 *stack_end, gboolean precise, void *gc_data)
 {
 	TlsData *tls = user_data;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -58,7 +58,7 @@
  * can be linked into both mono and mono-sgen.
  */
 #if defined(HAVE_BOEHM_GC) || defined(HAVE_SGEN_GC)
-#error "The code in mini/ should not depend on these defines."
+#warning "The code in mini/ should not depend on these defines."
 #endif
 
 #ifndef __GNUC__

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -19,6 +19,7 @@
 #ifdef HAVE_SGEN_GC
 #include "mono/sgen/sgen-conf.h"
 #endif
+#include "mono/utils/ward.h"
 
 /* h indicates whether to hide or just tag.
  * (-!!h ^ p) is used instead of (h ? ~p : p) to avoid multiple mentions of p.
@@ -87,17 +88,21 @@ extern gboolean mono_gc_register_thread (void *baseptr);
 
 gboolean mono_gc_parse_environment_string_extract_number (const char *str, size_t *out);
 
-MonoGCDescriptor mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size);
-MonoGCDescriptor mono_gc_make_descr_for_array (int vector, gsize *elem_bitmap, int numbits, size_t elem_size);
+MonoGCDescriptor mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
+    MONO_PERMIT (need (sgen_lock_gc));
+MonoGCDescriptor mono_gc_make_descr_for_array (int vector, gsize *elem_bitmap, int numbits, size_t elem_size)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 /* simple interface for data structures needed in the runtime */
-MonoGCDescriptor mono_gc_make_descr_from_bitmap (gsize *bitmap, int numbits);
+MonoGCDescriptor mono_gc_make_descr_from_bitmap (gsize *bitmap, int numbits)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 /* Return a root descriptor for a vector with repeating refs bitmap */
 MonoGCDescriptor mono_gc_make_vector_descr (void);
 
 /* Return a root descriptor for a root with all refs */
-MonoGCDescriptor mono_gc_make_root_descr_all_refs (int numbits);
+MonoGCDescriptor mono_gc_make_root_descr_all_refs (int numbits)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 /* Return the bitmap encoded by a descriptor */
 gsize* mono_gc_get_bitmap_for_descr (MonoGCDescriptor descr, int *numbits);

--- a/mono/sgen/sgen-descriptor.c
+++ b/mono/sgen/sgen-descriptor.c
@@ -51,7 +51,7 @@ static guint64 stat_scanned_count_per_descriptor [DESC_TYPE_MAX];
 static guint64 stat_copied_count_per_descriptor [DESC_TYPE_MAX];
 #endif
 
-static int
+static MONO_PERMIT (need (sgen_lock_gc)) int
 alloc_complex_descriptor (gsize *bitmap, int numbits)
 {
 	int nwords, res, i;
@@ -82,8 +82,8 @@ alloc_complex_descriptor (gsize *bitmap, int numbits)
 				}
 			}
 			if (found) {
-				sgen_gc_unlock ();
-				return __index;
+				res = __index;
+				goto end;
 			}
 		}
 		/* Skip the bitmap words */
@@ -100,6 +100,7 @@ alloc_complex_descriptor (gsize *bitmap, int numbits)
 		descriptor [1 + i] = bitmap [i];
 		SGEN_LOG (6, "\tvalue: %p", (void*)descriptor [1 + i]);
 	}
+end:
 	sgen_gc_unlock ();
 	return res;
 }

--- a/mono/sgen/sgen-fin-weak-hash.c
+++ b/mono/sgen/sgen-fin-weak-hash.c
@@ -228,7 +228,7 @@ sgen_finalize_in_range (int generation, ScanCopyContext ctx)
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 register_for_finalization (GCObject *obj, void *user_data, int generation)
 {
 	SgenHashTable *hash_table = get_finalize_entry_hash_table (generation);
@@ -345,7 +345,7 @@ try_lock_stage_for_processing (int num_entries, volatile gint32 *next_entry)
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 process_stage_entries (int num_entries, volatile gint32 *next_entry, StageEntry *entries, void (*process_func) (GCObject*, void*, int))
 {
 	int i;
@@ -527,7 +527,7 @@ add_stage_entry (int num_entries, volatile gint32 *next_entry, StageEntry *entri
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 process_fin_stage_entry (GCObject *obj, void *user_data, int index)
 {
 	if (ptr_in_nursery (obj))
@@ -557,7 +557,7 @@ sgen_object_register_for_finalization (GCObject *obj, void *user_data)
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 finalize_with_predicate (SgenObjectPredicateFunc predicate, void *user_data, SgenHashTable *hash_table)
 {
 	GCObject *object;

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -30,6 +30,7 @@ typedef struct _SgenThreadInfo SgenThreadInfo;
 #include "mono/utils/atomic.h"
 #include "mono/utils/mono-os-mutex.h"
 #include "mono/utils/mono-coop-mutex.h"
+#include "mono/utils/ward.h"
 #include "mono/sgen/sgen-conf.h"
 #include "mono/sgen/sgen-hash-table.h"
 #include "mono/sgen/sgen-protocol.h"
@@ -305,7 +306,8 @@ enum {
 	SGEN_GC_BIT_FINALIZER_AWARE = 4,
 };
 
-void sgen_gc_init (void);
+void sgen_gc_init (void)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 void sgen_os_init (void);
 
@@ -405,8 +407,10 @@ enum {
 
 extern SgenHashTable roots_hash [ROOT_TYPE_NUM];
 
-int sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type, int source, const char *msg);
-void sgen_deregister_root (char* addr);
+int sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type, int source, const char *msg)
+    MONO_PERMIT (need (sgen_lock_gc));
+void sgen_deregister_root (char* addr)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 typedef void (*IterateObjectCallbackFunc) (GCObject*, size_t, void*);
 
@@ -808,27 +812,36 @@ void sgen_clear_togglerefs (char *start, char *end, ScanCopyContext ctx);
 void sgen_process_togglerefs (void);
 void sgen_register_test_toggleref_callback (void);
 
-void sgen_mark_bridge_object (GCObject *obj);
-void sgen_collect_bridge_objects (int generation, ScanCopyContext ctx);
+void sgen_mark_bridge_object (GCObject *obj)
+    MONO_PERMIT (need (sgen_gc_locked));
+void sgen_collect_bridge_objects (int generation, ScanCopyContext ctx)
+    MONO_PERMIT (need (sgen_gc_locked));
 
 typedef gboolean (*SgenObjectPredicateFunc) (GCObject *obj, void *user_data);
 
 void sgen_null_links_if (SgenObjectPredicateFunc predicate, void *data, int generation, gboolean track);
 
 gboolean sgen_gc_is_object_ready_for_finalization (GCObject *object);
-void sgen_gc_lock (void);
-void sgen_gc_unlock (void);
+void sgen_gc_lock (void)
+    MONO_PERMIT (need (sgen_lock_gc), grant (sgen_gc_locked), revoke (sgen_lock_gc));
+void sgen_gc_unlock (void)
+    MONO_PERMIT (need (sgen_gc_locked), revoke (sgen_gc_locked), grant (sgen_lock_gc));
 
 void sgen_queue_finalization_entry (GCObject *obj);
 const char* sgen_generation_name (int generation);
 
-void sgen_finalize_in_range (int generation, ScanCopyContext ctx);
-void sgen_null_link_in_range (int generation, ScanCopyContext ctx, gboolean track);
-void sgen_process_fin_stage_entries (void);
+void sgen_finalize_in_range (int generation, ScanCopyContext ctx)
+    MONO_PERMIT (need (sgen_gc_locked));
+void sgen_null_link_in_range (int generation, ScanCopyContext ctx, gboolean track)
+    MONO_PERMIT (need (sgen_gc_locked));
+void sgen_process_fin_stage_entries (void)
+    MONO_PERMIT (need (sgen_gc_locked));
 gboolean sgen_have_pending_finalizers (void);
-void sgen_object_register_for_finalization (GCObject *obj, void *user_data);
+void sgen_object_register_for_finalization (GCObject *obj, void *user_data)
+    MONO_PERMIT (need (sgen_lock_gc));
 
-void sgen_finalize_if (SgenObjectPredicateFunc predicate, void *user_data);
+void sgen_finalize_if (SgenObjectPredicateFunc predicate, void *user_data)
+    MONO_PERMIT (need (sgen_lock_gc));
 void sgen_remove_finalizers_if (SgenObjectPredicateFunc predicate, void *user_data, int generation);
 void sgen_set_suspend_finalizers (void);
 
@@ -850,19 +863,27 @@ enum {
 void sgen_pin_object (GCObject *object, SgenGrayQueue *queue);
 void sgen_set_pinned_from_failed_allocation (mword objsize);
 
-void sgen_ensure_free_space (size_t size, int generation);
-void sgen_gc_collect (int generation);
-void sgen_perform_collection (size_t requested_size, int generation_to_collect, const char *reason, gboolean wait_to_finish, gboolean stw);
+void sgen_ensure_free_space (size_t size, int generation)
+    MONO_PERMIT (need (sgen_stop_world, sgen_gc_locked));
+void sgen_gc_collect (int generation)
+    MONO_PERMIT (need (sgen_stop_world, sgen_lock_gc));
+int sgen_perform_collection (size_t requested_size, int generation_to_collect, const char *reason, gboolean wait_to_finish)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_world_stopped));
+int sgen_perform_collection_stw (size_t requested_size, int generation_to_collect, const char *reason, gboolean wait_to_finish)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
 
 int sgen_gc_collection_count (int generation);
 /* FIXME: what exactly does this return? */
-size_t sgen_gc_get_used_size (void);
+size_t sgen_gc_get_used_size (void)
+    MONO_PERMIT (need (sgen_lock_gc));
 size_t sgen_gc_get_total_heap_allocation (void);
 
 /* STW */
 
-void sgen_stop_world (int generation);
-void sgen_restart_world (int generation);
+void sgen_stop_world (int generation)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world), grant (sgen_world_stopped), revoke (sgen_stop_world));
+void sgen_restart_world (int generation)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_world_stopped), revoke (sgen_world_stopped), grant (sgen_stop_world));
 gboolean sgen_is_world_stopped (void);
 
 gboolean sgen_set_allow_synchronous_major (gboolean flag);
@@ -885,7 +906,8 @@ extern mword los_memory_usage;
 extern mword los_memory_usage_total;
 
 void sgen_los_free_object (LOSObject *obj);
-void* sgen_los_alloc_large_inner (GCVTable vtable, size_t size);
+void* sgen_los_alloc_large_inner (GCVTable vtable, size_t size)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
 void sgen_los_sweep (void);
 gboolean sgen_ptr_is_in_los (char *ptr, char **start);
 void sgen_los_iterate_objects (IterateObjectCallbackFunc cb, void *user_data);
@@ -923,8 +945,10 @@ void sgen_nursery_alloc_prepare_for_major (void);
 
 GCObject* sgen_alloc_for_promotion (GCObject *obj, size_t objsize, gboolean has_references);
 
-GCObject* sgen_alloc_obj_nolock (GCVTable vtable, size_t size);
-GCObject* sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size);
+GCObject* sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
+GCObject* sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size)
+    MONO_PERMIT (need (sgen_stop_world));
 
 /* Threads */
 
@@ -969,13 +993,15 @@ sgen_is_object_alive_for_current_gen (GCObject *object)
 	return sgen_major_is_object_alive (object);
 }
 
-int sgen_gc_invoke_finalizers (void);
+int sgen_gc_invoke_finalizers (void)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 /* GC handles */
 
 void sgen_init_gchandles (void);
 
-void sgen_null_links_if (SgenObjectPredicateFunc predicate, void *data, int generation, gboolean track);
+void sgen_null_links_if (SgenObjectPredicateFunc predicate, void *data, int generation, gboolean track)
+    MONO_PERMIT (need (sgen_gc_locked));
 
 typedef gpointer (*SgenGCHandleIterateCallback) (gpointer hidden, GCHandleType handle_type, int max_generation, gpointer user);
 
@@ -1024,29 +1050,37 @@ typedef enum {
 
 void sgen_clear_tlabs (void);
 
-GCObject* sgen_alloc_obj (GCVTable vtable, size_t size);
-GCObject* sgen_alloc_obj_pinned (GCVTable vtable, size_t size);
-GCObject* sgen_alloc_obj_mature (GCVTable vtable, size_t size);
+GCObject* sgen_alloc_obj (GCVTable vtable, size_t size)
+    MONO_PERMIT (need (sgen_lock_gc, sgen_stop_world));
+GCObject* sgen_alloc_obj_pinned (GCVTable vtable, size_t size)
+    MONO_PERMIT (need (sgen_lock_gc, sgen_stop_world));
+GCObject* sgen_alloc_obj_mature (GCVTable vtable, size_t size)
+    MONO_PERMIT (need (sgen_lock_gc, sgen_stop_world));
 
 /* Debug support */
 
-void sgen_check_remset_consistency (void);
+void sgen_check_remset_consistency (void)
+    MONO_PERMIT (need (sgen_world_stopped));
 void sgen_check_mod_union_consistency (void);
 void sgen_check_major_refs (void);
 void sgen_check_whole_heap (gboolean allow_missing_pinning);
-void sgen_check_whole_heap_stw (void);
+void sgen_check_whole_heap_stw (void)
+    MONO_PERMIT (need (sgen_stop_world, sgen_gc_locked));
 void sgen_check_objref (char *obj);
 void sgen_check_heap_marked (gboolean nursery_must_be_pinned);
 void sgen_check_nursery_objects_pinned (gboolean pinned);
-void sgen_check_for_xdomain_refs (void);
+void sgen_check_for_xdomain_refs (void)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_world_stopped));
 GCObject* sgen_find_object_for_ptr (char *ptr);
 
-void mono_gc_scan_for_specific_ref (GCObject *key, gboolean precise);
+void mono_gc_scan_for_specific_ref (GCObject *key, gboolean precise)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_world_stopped));
 
 void sgen_debug_enable_heap_dump (const char *filename);
 void sgen_debug_dump_heap (const char *type, int num, const char *reason);
 
-void sgen_debug_verify_nursery (gboolean do_dump_nursery_content);
+void sgen_debug_verify_nursery (gboolean do_dump_nursery_content)
+    MONO_PERMIT (need (sgen_gc_locked, sgen_world_stopped));
 void sgen_debug_check_nursery_is_clean (void);
 
 /* Environment variable parsing */

--- a/mono/sgen/sgen-gchandles.c
+++ b/mono/sgen/sgen-gchandles.c
@@ -89,7 +89,7 @@ try_occupy_slot (volatile gpointer *slot, gpointer obj, int data)
 	return try_set_slot (slot, (GCObject *)obj, NULL, (GCHandleType)data) != NULL;
 }
 
-static void
+static void MONO_PERMIT (need (sgen_lock_gc))
 bucket_alloc_callback (gpointer *bucket, guint32 new_bucket_size, gboolean alloc)
 {
 	if (alloc)

--- a/mono/sgen/sgen-nursery-allocator.c
+++ b/mono/sgen/sgen-nursery-allocator.c
@@ -649,11 +649,17 @@ sgen_clear_range (char *start, char *end)
 	}
 }
 
+static inline void
+minor_collector_clear_fragments (void)
+{
+	sgen_minor_collector.clear_fragments ();
+}
+
 void
 sgen_nursery_allocator_prepare_for_pinning (void)
 {
 	sgen_clear_allocator_fragments (&mutator_allocator);
-	sgen_minor_collector.clear_fragments ();
+	minor_collector_clear_fragments ();
 }
 
 static mword fragment_total = 0;
@@ -895,6 +901,12 @@ sgen_nursery_alloc_prepare_for_major (void)
 	sgen_minor_collector.prepare_to_space (sgen_space_bitmap, sgen_space_bitmap_size);
 }
 
+static inline void
+minor_collector_init_nursery (SgenFragmentAllocator *allocator, char *start, char *end)
+{
+	sgen_minor_collector.init_nursery (allocator, start, end);
+}
+
 void
 sgen_nursery_allocator_set_nursery_bounds (char *start, char *end)
 {
@@ -910,7 +922,7 @@ sgen_nursery_allocator_set_nursery_bounds (char *start, char *end)
 	sgen_space_bitmap = (char *)g_malloc0 (sgen_space_bitmap_size);
 
 	/* Setup the single first large fragment */
-	sgen_minor_collector.init_nursery (&mutator_allocator, start, end);
+	minor_collector_init_nursery (&mutator_allocator, start, end);
 }
 
 #endif

--- a/mono/utils/ward.h
+++ b/mono/utils/ward.h
@@ -1,0 +1,12 @@
+#ifndef MONO_UTILS_WARD_H
+#define MONO_UTILS_WARD_H
+
+#ifdef __WARD__
+#define MONO_PERMIT(...) __attribute__ ((permission (__VA_ARGS__)))
+#else
+#define MONO_PERMIT(...)
+#endif
+
+/* Add Ward permissions for external functions (e.g., libc, glib) here. */
+
+#endif


### PR DESCRIPTION
This introduces the following [Ward](https://github.com/evincarofautumn/Ward) permission annotations in SGen:

| Permission | Meaning |
| --- | --- |
| `sgen_stop_world` | Allows stopping the world. |
| `sgen_world_stopped` | Requires the world to be stopped. |
| `sgen_lock_gc` | Allows taking the GC lock. |
| `sgen_gc_locked` | Requires the GC lock to be held. |

Mainly getting this out for visibility. I have started annotating other parts of the code, but the SGen bits happen to be fairly small and self-contained. I plan to use this PR to test running Ward as part of the static analysis CI.

Questions:

* Is the annotation burden too high? I know @kumpera was concerned about this. @lambdageek, do you have any thoughts on how to safely reduce the number of required annotations? I’m happy to do the grunt work if necessary, and Ward could be extended to add annotations interactively to make that easier. However, we don’t want to infer everything, because it may mask legitimate errors.

* Should Ward handle indirect calls, or are we fine with wrapping such calls in annotated functions? I’ve done some such wrapping in this PR, e.g., `major_collector_iterate_objects` instead of `major_collector.iterate_objects`, but Ward still gives several warnings about unhandled calls.

* Should Ward handle conditional permissions? Previously, `sgen_perform_collection` took a Boolean indicating whether to stop the world; in order for Ward to check this, I had to split it into two functions: one that assumes the world is stopped, and a `_stw` variant that stops the world and calls the original. (I think this is better style anyway.)

* More generally, what do we want to enforce? What has relatively high value for relatively low annotation cost? Ward should be able to handle things like:

  * Locking (e.g., loader, image, AOT) to make our `LOCKING:` comments machine-verified
  * Async signal safety—we would need to differentiate sync from async signals
  * Allocation—enforcing who can call `malloc` or allocate on the GC heap
  * Program phases—enforcing which functions are allowed/required to run during init, shutdown, &c.

In particular, the loader lock is used *everywhere*, directly and indirectly, and so requires significant annotation work. I don’t know how much value this would have, especially because it’s already a recursive mutex, so we don’t need to prevent nesting.
