### PR TITLE
Fix - invoking method via reflection with a by-value null param will modify param after return

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4830,10 +4830,12 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, gboolean* 
 						*has_byref_nullables = TRUE;
 				} else {
 					/* MS seems to create the objects if a null is passed in */
+					gboolean was_null = FALSE;
 					if (!mono_array_get (params, MonoObject*, i)) {
 						MonoObject *o = mono_object_new_checked (mono_domain_get (), mono_class_from_mono_type (t_orig), error);
 						return_val_if_nok (error, NULL);
 						mono_array_setref (params, i, o); 
+						was_null = TRUE;
 					}
 
 					if (t->byref) {
@@ -4851,6 +4853,8 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, gboolean* 
 					}
 						
 					result = mono_object_unbox (mono_array_get (params, MonoObject*, i));
+					if (!t->byref && was_null)
+						mono_array_setref (params, i, NULL);
 				}
 				break;
 			case MONO_TYPE_STRING:

--- a/mono/tests/runtime-invoke.cs
+++ b/mono/tests/runtime-invoke.cs
@@ -265,4 +265,18 @@ class Tests
 		return 0;
 	}
 
+	private static void method_invoke_no_modify_by_value_arg_helper (int dummy)
+    {
+    }
+
+    public static int test_0_method_invoke_no_modify_by_value_arg ()
+    {
+        var args = new object[] { null };
+        var method = typeof (Tests).GetMethod ("method_invoke_no_modify_by_value_arg_helper", BindingFlags.NonPublic | BindingFlags.Static);
+        method.Invoke (null, args);
+        if (args[0] == null)
+            return 0;
+        else
+            return 1;
+    }
 }


### PR DESCRIPTION
invoke_array_extract_argument() will create objects and set them in the parameters array when it detects a null parameter, but when we return a by-value parameter may no longer be null, which is an error.  This fix detects the change and sets the parameter back to null for by-value parameters before we return.