### PR TITLE
Enforce restrictions on pinned GCHandle objects

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/GCHandleTest.cs
@@ -197,7 +197,241 @@ namespace MonoTests.System.Runtime.InteropServices
 			private readonly string _assemblyName;
 		}
 #endif
-	}
 
+		class AnyClass
+		{
+		}
+
+		struct StructWithReferenceTypeInside
+		{
+			public string myStr;
+		}
+
+		struct GenericStruct<T>
+		{
+			public T myItem;
+		}
+
+		class GenericClass<T>
+		{
+			public T myItem;
+		}
+
+		struct StructWithIntInside
+		{
+			public int myInt;
+		}
+
+		[StructLayout (LayoutKind.Explicit)]
+		struct StructWithIntInsideExplicitLayout
+		{
+			[FieldOffset (0)]
+			public int myInt;
+		}
+
+		[StructLayout (LayoutKind.Auto)]
+		struct StructWithIntInsideAutoLayout
+		{
+			public int myInt;
+		}
+
+		struct StructWithChar
+		{
+			public char value;
+		}
+
+		struct StructWithBool
+		{
+			public bool value;
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnArrayOfStrings ()
+		{
+			var arrayOfStrings = new string[] { "a", "B" };
+			GCHandle.Alloc (arrayOfStrings, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnArrayOfIntArrays ()
+		{
+			var arrayOfIntArrays = new int[][] { new int[] {1, 2}, new int[] {3, 4, 5} };
+			GCHandle.Alloc (arrayOfIntArrays, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnObject ()
+		{
+			GCHandle.Alloc (new object (), GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAClass ()
+		{
+			GCHandle.Alloc (new AnyClass (), GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAGenericClass ()
+		{
+			GCHandle.Alloc (new GenericClass<int> (), GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToANonBlittableStruct ()
+		{
+			var nonBlittableStruct = default (StructWithReferenceTypeInside);
+			GCHandle.Alloc(nonBlittableStruct, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAGenericStruct ()
+		{
+			var nonBlittableGenericStruct = default (GenericStruct<string>);
+			GCHandle.Alloc (nonBlittableGenericStruct, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToADateTime ()
+		{
+			GCHandle.Alloc (default (DateTime), GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAPinnedGCHandleToAnAutoLayoutStruct ()
+		{
+			GCHandle.Alloc (default (StructWithIntInsideAutoLayout), GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocAllocPinnedHandleForArrayOfStructWithChar ()
+		{
+			var array = new StructWithChar[]
+			{
+				new StructWithChar () { value = 'd' },
+				new StructWithChar () { value = 'f' },
+				new StructWithChar () { value = '2' },
+				new StructWithChar () { value = '-' },
+			};
+
+			GCHandle.Alloc (array, GCHandleType.Pinned);
+		}
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CannotAllocPinnedHandleForArrayOfStructWithBool ()
+		{
+			var array = new StructWithBool[]
+			{
+				new StructWithBool () { value = true },
+				new StructWithBool () { value = false },
+				new StructWithBool () { value = false },
+				new StructWithBool () { value = true },
+			};
+
+			GCHandle.Alloc (array, GCHandleType.Pinned);
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForNull ()
+		{
+			var gcHandle = GCHandle.Alloc (null, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForArray ()
+		{
+			var array = new int[] { 1, 2, 3, 4567, 8416415 };
+			var gcHandle = GCHandle.Alloc (array, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForMultidimensionalArray ()
+		{
+			var multiDimensionalArray = new int[2, 3]
+			{
+				{ 2, 3, 4 },
+				{ 2, 3, 5 }
+			};
+
+			var gcHandle = GCHandle.Alloc (multiDimensionalArray, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForCharArray ()
+		{
+			var array = new char[] { 'a', 'b', '9', 'z' };
+			var gcHandle = GCHandle.Alloc (array, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForBoolArray ()
+		{
+			var array = new bool[] { false, true, true, false };
+			var gcHandle = GCHandle.Alloc (array, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForString ()
+		{
+			string myObj = "Hello, world!";
+			var gcHandle = GCHandle.Alloc (myObj, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForStruct ()
+		{
+			var obj = default (StructWithIntInside);
+			obj.myInt = 489794165;
+
+			var gcHandle = GCHandle.Alloc (obj, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForStructWithExplicitLayout ()
+		{
+			var obj = default (StructWithIntInsideExplicitLayout);
+			obj.myInt = 489794165;
+
+			var gcHandle = GCHandle.Alloc (obj, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+
+		[Test]
+		public void CanAllocPinnedHandleForGenericStruct ()
+		{
+			var obj = default (GenericStruct<int>);
+			obj.myItem = 489794165;
+
+			var gcHandle = GCHandle.Alloc (obj, GCHandleType.Pinned);
+			Assert.IsNotNull (gcHandle);
+			gcHandle.Free ();
+		}
+	}
 }
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -23,6 +23,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/mono-mlist.h>
+#include <mono/metadata/object-internals.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/threadpool.h>
 #include <mono/sgen/sgen-conf.h>
@@ -640,6 +641,33 @@ ves_icall_System_GCHandle_GetTarget (guint32 handle)
 	return mono_gchandle_get_target (handle);
 }
 
+static gboolean
+is_object_pinnable (MonoObject *obj)
+{
+	if (obj == NULL)
+		return TRUE;
+
+	MonoClass *klass = obj->vtable->klass;
+	MonoTypeEnum type = klass->byval_arg.type;
+
+	if (type == MONO_TYPE_CHAR || type == MONO_TYPE_BOOLEAN || type == MONO_TYPE_STRING)
+		return TRUE;
+
+	if (type == MONO_TYPE_ARRAY || type == MONO_TYPE_SZARRAY) {
+		MonoTypeEnum element_type = klass->element_class->byval_arg.type;
+		if (element_type == MONO_TYPE_ARRAY || element_type == MONO_TYPE_SZARRAY)
+			return FALSE;
+		return klass->element_class->blittable ||
+			klass->element_class->byval_arg.type == MONO_TYPE_CHAR ||
+			klass->element_class->byval_arg.type == MONO_TYPE_BOOLEAN;
+	}
+
+	if (MONO_TYPE_IS_REFERENCE (&klass->byval_arg))
+		return FALSE;
+
+	return klass->blittable;
+}
+
 /*
  * if type == -1, change the target of the handle, otherwise allocate a new handle.
  */
@@ -659,6 +687,11 @@ ves_icall_System_GCHandle_GetTargetHandle (MonoObject *obj, guint32 handle, gint
 	case HANDLE_NORMAL:
 		return mono_gchandle_new (obj, FALSE);
 	case HANDLE_PINNED:
+		if (!is_object_pinnable (obj)) {
+			mono_set_pending_exception (mono_get_exception_argument ("value", "Object contains non-primitive or non-blittable data."));
+			return 0;
+		}
+
 		return mono_gchandle_new (obj, TRUE);
 	default:
 		g_assert_not_reached ();


### PR DESCRIPTION
* A pinned GCHandle should not be allowed for some types.
* The GCHandle.Alloc method should throw an ArgumentException in these cases.
* This change corrects bug https://bugzilla.xamarin.com/show_bug.cgi?id=46660.

This pull request is a follow-on to a previous PR: https://github.com/mono/mono/pull/3929