### PR TITLE
[System.Data] Fix bug-53217 

### DIFF
--- a/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/TdsComm.cs
+++ b/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/TdsComm.cs
@@ -105,7 +105,7 @@ namespace Mono.Data.Tds.Protocol {
 			}
 
 			try {
-				socket = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+				socket = new Socket (endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 				IAsyncResult ares = socket.BeginConnect (endPoint, null, null);
 				int timeout_ms = timeout * 1000;
 				if (timeout > 0 && !ares.IsCompleted && !ares.AsyncWaitHandle.WaitOne (timeout_ms, false))


### PR DESCRIPTION
[Bug 53217](https://bugzilla.xamarin.com/show_bug.cgi?id=53217) - SqlException is thrown when connecting through IPv6 network 

Also, looks like https://github.com/mono/mono/blob/master/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs#L81 is also not ready for ipv6.