### PR TITLE
System.Drawing tests: Use MD5.Create () instead of new MD5CryptoServiceProvider()

### DIFF
--- a/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestBitmap.cs
@@ -608,7 +608,7 @@ namespace MonoTests.System.Drawing {
 				}				
 			}
 		
-			hash = new MD5CryptoServiceProvider().ComputeHash (pixels);
+			hash = MD5.Create ().ComputeHash (pixels);
 			return ByteArrayToString (hash);
 		}
 		public string RotateIndexedBmp (Bitmap src, RotateFlipType type)
@@ -658,7 +658,7 @@ namespace MonoTests.System.Drawing {
 			if (pixel_data == null)
 				return "--ERROR--";
 
-			byte[] hash = new MD5CryptoServiceProvider().ComputeHash (pixel_data);
+			byte[] hash = MD5.Create ().ComputeHash (pixel_data);
 			return ByteArrayToString (hash);
 		}
 		


### PR DESCRIPTION
The unit tests for System.Drawing used `MD5CryptoServiceProvider()` which is not supported on .NET Core; `MD5.Create ()` does work.

With this, 1715 unit tests pass and 18 fail for System.Drawing on .NET Core.