### PR TITLE
Remove CAS attributes from System.Drawing

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.Design/CategoryNameCollection.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Design/CategoryNameCollection.cs
@@ -33,11 +33,9 @@
 //
 
 using System.Collections;
-using System.Security.Permissions;
 
 namespace System.Drawing.Design
 {
-	[PermissionSet (SecurityAction.LinkDemand, Unrestricted = true)]
 	public sealed class CategoryNameCollection : ReadOnlyCollectionBase
 	{
 		

--- a/mcs/class/System.Drawing/System.Drawing.Design/PaintValueEventArgs.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Design/PaintValueEventArgs.cs
@@ -30,12 +30,9 @@
 //
 
 using System.ComponentModel;
-using System.Security.Permissions;
 
 namespace System.Drawing.Design
 {
-	[PermissionSet (SecurityAction.LinkDemand, Unrestricted = true)]
-	[PermissionSet (SecurityAction.InheritanceDemand, Unrestricted = true)]
 	public class PaintValueEventArgs : EventArgs
 	{
 		private ITypeDescriptorContext context;

--- a/mcs/class/System.Drawing/System.Drawing.Design/PropertyValueItem.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Design/PropertyValueItem.cs
@@ -32,12 +32,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Security.Permissions;
-
 namespace System.Drawing.Design
 {
-	[PermissionSet (SecurityAction.LinkDemand, Unrestricted = true)]
-	[PermissionSet (SecurityAction.InheritanceDemand, Unrestricted = true)]
 	public class PropertyValueUIItem
 	{
 

--- a/mcs/class/System.Drawing/System.Drawing.Design/ToolboxComponentsCreatedEventArgs.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Design/ToolboxComponentsCreatedEventArgs.cs
@@ -31,12 +31,9 @@
 //
 
 using System.ComponentModel;
-using System.Security.Permissions;
 
 namespace System.Drawing.Design
 {
-	[PermissionSet (SecurityAction.LinkDemand, Unrestricted = true)]
-	[PermissionSet (SecurityAction.InheritanceDemand, Unrestricted = true)]
 	public class ToolboxComponentsCreatedEventArgs : EventArgs
 	{
 		private IComponent[] components;

--- a/mcs/class/System.Drawing/System.Drawing.Design/UITypeEditor.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Design/UITypeEditor.cs
@@ -30,13 +30,10 @@
 //
 
 using System.ComponentModel;
-using System.Security.Permissions;
 using System.Collections;
 
 namespace System.Drawing.Design
 {
-	[PermissionSet (SecurityAction.LinkDemand, Unrestricted = true)]
-	[PermissionSet (SecurityAction.InheritanceDemand, Unrestricted = true)]
 	public class UITypeEditor {
 
 		static UITypeEditor ()

--- a/mcs/class/System.Drawing/System.Drawing.Printing/InvalidPrinterException.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Printing/InvalidPrinterException.cs
@@ -31,7 +31,6 @@
 //
 
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace System.Drawing.Printing {
 
@@ -50,7 +49,6 @@ namespace System.Drawing.Printing {
 		{
 		}
 
-		[SecurityPermission (SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{
 			if (info == null)

--- a/mcs/class/System.Drawing/System.Drawing.Text/PrivateFontCollection.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Text/PrivateFontCollection.cs
@@ -30,7 +30,6 @@
 //
 
 using System.IO;
-using System.Security.Permissions;
 using System.Runtime.InteropServices;
 
 namespace System.Drawing.Text {
@@ -62,7 +61,6 @@ namespace System.Drawing.Text {
 			GDIPlus.CheckStatus (status);			
 		}
 
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 		public void AddMemoryFont (IntPtr memory, int length) 
 		{
 			// note: MS throw FileNotFoundException if something is bad with the data (except for a null pointer)

--- a/mcs/class/System.Drawing/System.Drawing/Bitmap.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Bitmap.cs
@@ -40,7 +40,6 @@ using System.Drawing.Imaging;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
-using System.Security.Permissions;
 
 namespace System.Drawing
 {
@@ -228,14 +227,12 @@ namespace System.Drawing
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public IntPtr GetHbitmap ()
 		{
 			return GetHbitmap(Color.Gray);
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public IntPtr GetHbitmap (Color background)
 		{
 			IntPtr HandleBmp;
@@ -247,7 +244,6 @@ namespace System.Drawing
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public IntPtr GetHicon ()
 		{
 			IntPtr HandleIcon;

--- a/mcs/class/System.Drawing/System.Drawing/BufferedGraphics.cs
+++ b/mcs/class/System.Drawing/System.Drawing/BufferedGraphics.cs
@@ -30,7 +30,6 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace System.Drawing
 {
@@ -106,7 +105,6 @@ namespace System.Drawing
 		}
 
 		[MonoTODO ("The targetDC parameter has no equivalent in libgdiplus.")]
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 	      	public void Render (IntPtr targetDC)
 		{
 			throw new NotImplementedException ();

--- a/mcs/class/System.Drawing/System.Drawing/BufferedGraphicsContext.cs
+++ b/mcs/class/System.Drawing/System.Drawing/BufferedGraphicsContext.cs
@@ -30,7 +30,6 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace System.Drawing
 {
@@ -54,7 +53,6 @@ namespace System.Drawing
 		}
 
 		[MonoTODO ("The targetDC parameter has no equivalent in libgdiplus.")]
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 		public BufferedGraphics Allocate (IntPtr targetDC, Rectangle targetRectangle)
 		{
 			throw new NotImplementedException ();

--- a/mcs/class/System.Drawing/System.Drawing/Font.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Font.cs
@@ -33,7 +33,6 @@
 
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
-using System.Security.Permissions;
 using System.ComponentModel;
 
 namespace System.Drawing
@@ -591,7 +590,6 @@ namespace System.Drawing
 			}
 		}
 
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 		public void ToLogFont (object logFont)
 		{
 			if (GDIPlus.RunningOnUnix ()) {
@@ -616,7 +614,6 @@ namespace System.Drawing
 			}
 		}
 
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 		public void ToLogFont (object logFont, Graphics graphics)
 		{
 			if (graphics == null)

--- a/mcs/class/System.Drawing/System.Drawing/Graphics.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Graphics.cs
@@ -35,7 +35,6 @@ using System.Drawing.Imaging;
 using System.Drawing.Text;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Security.Permissions;
 using System.Text;
 
 namespace System.Drawing
@@ -1692,7 +1691,6 @@ namespace System.Drawing
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public static Graphics FromHdcInternal (IntPtr hdc)
 		{
 			GDIPlus.Display = hdc;
@@ -1744,7 +1742,6 @@ namespace System.Drawing
 		}
 		
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public static Graphics FromHwndInternal (IntPtr hwnd)
 		{
 			return FromHwnd (hwnd);
@@ -2015,13 +2012,11 @@ namespace System.Drawing
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 		public void ReleaseHdc (IntPtr hdc)
 		{
 			ReleaseHdcInternal (hdc);
 		}
 
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public void ReleaseHdc ()
 		{
 			ReleaseHdcInternal (deviceContextHdc);
@@ -2029,7 +2024,6 @@ namespace System.Drawing
 
 		[MonoLimitation ("Can only be used when hdc was provided by Graphics.GetHdc() method")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public void ReleaseHdcInternal (IntPtr hdc)
 		{
 			Status status = Status.InvalidParameter;

--- a/mcs/class/System.Drawing/System.Drawing/Icon.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Icon.cs
@@ -38,7 +38,6 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
-using System.Security.Permissions;
 
 namespace System.Drawing
 {
@@ -338,7 +337,6 @@ namespace System.Drawing
 		}
 		
 #if !MONOTOUCH
-		[SecurityPermission (SecurityAction.LinkDemand, UnmanagedCode = true)]
 		public static Icon FromHandle (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)

--- a/mcs/class/System.Drawing/System.Drawing/Region.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Region.cs
@@ -30,7 +30,6 @@
 
 using System.Drawing.Drawing2D;
 using System.Runtime.InteropServices;
-using System.Security.Permissions;
 
 namespace System.Drawing
 {
@@ -510,7 +509,6 @@ namespace System.Drawing
 			return result;			
 		}
 		
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 		public static Region FromHrgn (IntPtr hrgn)
 		{
 			if (hrgn == IntPtr.Zero)
@@ -639,7 +637,6 @@ namespace System.Drawing
 			}
 		}
 		// why is this a instance method ? and not static ?
-		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
 		public void ReleaseHrgn (IntPtr regionHandle)		
 		{
 			if (regionHandle == IntPtr.Zero) 

--- a/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
@@ -46,7 +46,6 @@ namespace System.Drawing
 	/// <summary>
 	/// GDI+ API Functions
 	/// </summary>
-	[SuppressUnmanagedCodeSecurity]
 	internal static class GDIPlus {
 		public const int FACESIZE = 32;
 		public const int LANG_NEUTRAL = 0;

--- a/mcs/class/System.Drawing/System.Drawing/macFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/macFunctions.cs
@@ -34,7 +34,6 @@ using System.Security;
 
 namespace System.Drawing {
 
-	[SuppressUnmanagedCodeSecurity]
 	internal static class MacSupport {
 		internal static Hashtable contextReference = new Hashtable ();
 		internal static object lockobj = new object ();

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/EditorAttribute.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/EditorAttribute.cs
@@ -10,8 +10,7 @@ namespace System.ComponentModel {
     
     using System.Diagnostics;
     using System.Globalization;
-    using System.Security.Permissions;
-                                
+
     /// <devdoc>
     ///    <para>Specifies the editor to use to change a property. This class cannot be inherited.</para>
     /// </devdoc>

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/ExpandableObjectConverter.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/ExpandableObjectConverter.cs
@@ -9,7 +9,6 @@ namespace System.ComponentModel {
     using System.Collections;
     using System.ComponentModel.Design;
     using System.Diagnostics;
-    using System.Security.Permissions;
 
     /// <devdoc>
     ///    <para>Provides

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/ExpandableObjectConverter.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/ExpandableObjectConverter.cs
@@ -9,13 +9,18 @@ namespace System.ComponentModel {
     using System.Collections;
     using System.ComponentModel.Design;
     using System.Diagnostics;
+#if MONO_FEATURE_CAS
+    using System.Security.Permissions;
+#endif
 
     /// <devdoc>
     ///    <para>Provides
     ///       a type converter to convert expandable objects to and from various
     ///       other representations.</para>
     /// </devdoc>
+#if MONO_FEATURE_CAS
     [HostProtection(SharedState = true)]
+#endif
     public class ExpandableObjectConverter : TypeConverter {
     
         /// <devdoc>

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/InvalidEnumArgumentException.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/InvalidEnumArgumentException.cs
@@ -10,11 +10,16 @@ namespace System.ComponentModel {
     using System.Diagnostics;
     using System.Globalization;
     using System.Runtime.Serialization;
+#if MONO_FEATURE_CAS
+    using System.Security.Permissions;
+#endif
     
     /// <devdoc>
     ///    <para>The exception that is thrown when using invalid arguments that are enumerators.</para>
     /// </devdoc>
+#if MONO_FEATURE_CAS
     [HostProtection(SharedState = true)]
+#endif
     [Serializable]
     public class InvalidEnumArgumentException : ArgumentException {
 

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/InvalidEnumArgumentException.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/InvalidEnumArgumentException.cs
@@ -10,7 +10,6 @@ namespace System.ComponentModel {
     using System.Diagnostics;
     using System.Globalization;
     using System.Runtime.Serialization;
-    using System.Security.Permissions;
     
     /// <devdoc>
     ///    <para>The exception that is thrown when using invalid arguments that are enumerators.</para>

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/design/serialization/InstanceDescriptor.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/design/serialization/InstanceDescriptor.cs
@@ -10,15 +10,12 @@ namespace System.ComponentModel.Design.Serialization {
     using System.Collections;
     using System.Diagnostics;
     using System.Reflection;
-    using System.Security.Permissions;
 
     /// <devdoc>
     ///     EventArgs for the ResolveNameEventHandler.  This event is used
     ///     by the serialization process to match a name to an object
     ///     instance.
     /// </devdoc>
-    [HostProtection(SharedState = true)]
-    [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
     public sealed class InstanceDescriptor {
         private MemberInfo  member;
         private ICollection arguments;

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/design/serialization/InstanceDescriptor.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/design/serialization/InstanceDescriptor.cs
@@ -10,12 +10,19 @@ namespace System.ComponentModel.Design.Serialization {
     using System.Collections;
     using System.Diagnostics;
     using System.Reflection;
+#if MONO_FEATURE_CAS 
+    using System.Security.Permissions;
+#endif
 
     /// <devdoc>
     ///     EventArgs for the ResolveNameEventHandler.  This event is used
     ///     by the serialization process to match a name to an object
     ///     instance.
     /// </devdoc>
+#if MONO_FEATURE_CAS 
+    [HostProtection(SharedState = true)]		
+    [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
+#endif
     public sealed class InstanceDescriptor {
         private MemberInfo  member;
         private ICollection arguments;


### PR DESCRIPTION
Based on what I understand, CAS is deprecated in pretty much all of .NET and not implemented in Mono.

With all the PRs done to get System.Drawing running on .NET Core 2, I realized we're actually not too far from getting it to work on .NET Core 1.x as well.

This is a first step, happy to discuss.