### PR TITLE
Make System.Drawing code compatible with .NET Core

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.Printing/InvalidPrinterException.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Printing/InvalidPrinterException.cs
@@ -58,7 +58,7 @@ namespace System.Drawing.Printing {
 
 			base.GetObjectData (info, context);
 		}
-		
+
 		private static string GetMessage(PrinterSettings settings)
 		{
 			if (settings.PrinterName == null || settings.PrinterName == String.Empty)

--- a/mcs/class/System.Drawing/System.Drawing/Bitmap.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Bitmap.cs
@@ -37,6 +37,7 @@
 
 using System.IO;
 using System.Drawing.Imaging;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
@@ -133,7 +134,7 @@ namespace System.Drawing
 			if (resource == null)
 				throw new ArgumentException ("resource");
 
-			Stream s = type.Assembly.GetManifestResourceStream (type, resource);
+			Stream s = type.GetTypeInfo ().Assembly.GetManifestResourceStream (type, resource);
 			if (s == null) {
 				string msg = Locale.GetText ("Resource '{0}' was not found.", resource);
 				throw new FileNotFoundException (msg);

--- a/mcs/class/System.Drawing/System.Drawing/Bitmap.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Bitmap.cs
@@ -134,6 +134,10 @@ namespace System.Drawing
 			if (resource == null)
 				throw new ArgumentException ("resource");
 
+			// For compatibility with the .NET Framework
+			if (type == null)
+				throw new NullReferenceException();
+
 			Stream s = type.GetTypeInfo ().Assembly.GetManifestResourceStream (type, resource);
 			if (s == null) {
 				string msg = Locale.GetText ("Resource '{0}' was not found.", resource);

--- a/mcs/class/System.Drawing/System.Drawing/Font.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Font.cs
@@ -31,6 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
@@ -428,10 +429,7 @@ namespace System.Drawing
 		[Browsable(false)]
 		public bool IsSystemFont {
 			get {
-				if (systemFontName == null)
-					return false;
-
-				return StringComparer.InvariantCulture.Compare (systemFontName, string.Empty) != 0;
+				return !string.IsNullOrEmpty (systemFontName);
 			}
 		}
 
@@ -627,7 +625,7 @@ namespace System.Drawing
 			}
 
 			Type st = logFont.GetType ();
-			if (!st.IsLayoutSequential)
+			if (!st.GetTypeInfo ().IsLayoutSequential)
 				throw new ArgumentException ("logFont", Locale.GetText ("Layout must be sequential."));
 
 			// note: there is no exception if 'logFont' isn't big enough

--- a/mcs/class/System.Drawing/System.Drawing/Icon.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Icon.cs
@@ -231,6 +231,10 @@ namespace System.Drawing
 			if (resource == null)
 				throw new ArgumentException ("resource");
 
+			// For compatibility with the .NET Framework
+			if (type == null)
+				throw new NullReferenceException();
+
 			using (Stream s = type.GetTypeInfo ().Assembly.GetManifestResourceStream (type, resource)) {
 				if (s == null) {
 					string msg = Locale.GetText ("Resource '{0}' was not found.", resource);

--- a/mcs/class/System.Drawing/System.Drawing/Icon.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Icon.cs
@@ -36,6 +36,7 @@ using System.Collections;
 using System.ComponentModel;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
@@ -230,7 +231,7 @@ namespace System.Drawing
 			if (resource == null)
 				throw new ArgumentException ("resource");
 
-			using (Stream s = type.Assembly.GetManifestResourceStream (type, resource)) {
+			using (Stream s = type.GetTypeInfo ().Assembly.GetManifestResourceStream (type, resource)) {
 				if (s == null) {
 					string msg = Locale.GetText ("Resource '{0}' was not found.", resource);
 					throw new FileNotFoundException (msg);
@@ -262,7 +263,7 @@ namespace System.Drawing
 
 		internal Icon (string resourceName, bool undisposable)
 		{
-			using (Stream s = typeof (Icon).Assembly.GetManifestResourceStream (resourceName)) {
+			using (Stream s = typeof (Icon).GetTypeInfo ().Assembly.GetManifestResourceStream (resourceName)) {
 				if (s == null) {
 					string msg = Locale.GetText ("Resource '{0}' was not found.", resourceName);
 					throw new FileNotFoundException (msg);
@@ -861,10 +862,10 @@ Console.WriteLine ("\tbih.biClrImportant: {0}", bih.biClrImportant);
 				}
 				
 				imageData [j] = iidata;
-				bihReader.Close();
+				bihReader.Dispose ();
 			}			
 
-			reader.Close();
+			reader.Dispose ();
 		}
 	}
 }

--- a/mcs/class/System.Drawing/System.Drawing/Image.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Image.cs
@@ -794,7 +794,7 @@ public abstract class Image : MarshalByRefObject, IDisposable , ICloneable, ISer
 			Status status = GDIPlus.GdipDisposeImage (nativeObject);
 			// dispose the stream (set under Win32 only if SD owns the stream) and ...
 			if (stream != null) {
-				stream.Close ();
+				stream.Dispose ();
 				stream = null;
 			}
 			// ... set nativeObject to null before (possibly) throwing an exception

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/EditorAttribute.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/EditorAttribute.cs
@@ -36,7 +36,7 @@ namespace System.ComponentModel {
         ///    name of the editor.</para>
         /// </devdoc>
         public EditorAttribute(string typeName, string baseTypeName) {
-            string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
+            string temp = typeName.ToUpperInvariant ();
             Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + typeName + " . Please remove the .dll extension");
             this.typeName = typeName;
             this.baseTypeName = baseTypeName;
@@ -46,7 +46,7 @@ namespace System.ComponentModel {
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.EditorAttribute'/> class.</para>
         /// </devdoc>
         public EditorAttribute(string typeName, Type baseType) {
-            string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
+            string temp = typeName.ToUpperInvariant ();
             Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + typeName + " . Please remove the .dll extension");
             this.typeName = typeName;
             this.baseTypeName = baseType.AssemblyQualifiedName;


### PR DESCRIPTION
Some low hanging fruit which makes the System.Drawing code "more" compatible with .NET Core.