### PR TITLE
[interp] fix flakey behaviour in stack walking code; some improvements regarding runtime_invoke

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1284,6 +1284,8 @@ mono_interp_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoOb
 		ret = mono_object_unbox (retval);
 		if (!sig->ret->data.klass->enumtype)
 			result.data.vt = ret;
+		else
+			result.data.vt = alloca (mono_class_instance_size (klass));
 		break;
 	case MONO_TYPE_GENERICINST:
 		if (!MONO_TYPE_IS_REFERENCE (sig->ret)) {
@@ -1291,6 +1293,8 @@ mono_interp_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoOb
 			ret = mono_object_unbox (retval);
 			if (!sig->ret->data.klass->enumtype)
 				result.data.vt = ret;
+			else
+				result.data.vt = alloca (mono_class_instance_size (klass));
 		} else {
 			isobject = 1;
 		}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1593,23 +1593,13 @@ static int opcode_counts[512];
 #define MINT_IN_DEFAULT default:
 #endif
 
-/* 
- * Defining this causes register allocation errors in some versions of gcc:
- * error: unable to find a register to spill in class `SIREG'
- */
-/* #define MINT_USE_DEDICATED_IP_REG */
-
 static void 
 ves_exec_method_with_context (MonoInvocation *frame, ThreadContext *context)
 {
 	MonoInvocation child_frame;
 	GSList *finally_ips = NULL;
 	const unsigned short *endfinally_ip = NULL;
-#if defined(__GNUC__) && defined (i386) && defined (MINT_USE_DEDICATED_IP_REG)
-	register const unsigned short *ip asm ("%esi");
-#else
-	register const unsigned short *ip;
-#endif
+	const unsigned short *ip = NULL;
 	register stackval *sp;
 	RuntimeMethod *rtm;
 #if DEBUG_INTERP

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -938,6 +938,15 @@ ves_runtime_method (MonoInvocation *frame, ThreadContext *context)
 
 	mono_class_init (method->klass);
 
+	if (method->klass == mono_defaults.array_class) {
+		if (!strcmp (method->name, "UnsafeMov")) {
+			/* TODO: layout checks */
+			MonoType *mt = mono_method_signature (method)->ret;
+			stackval_from_data (mt, frame->retval, (char *) frame->stack_args, FALSE);
+			return;
+		}
+	}
+
 	isinst_obj = mono_object_isinst_checked (obj, mono_defaults.array_class, &error);
 	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 	if (obj && isinst_obj) {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -4077,8 +4077,9 @@ array_constructed:
 		}
 die_on_ex:
 		ex_obj = (MonoObject*)frame->ex;
-		mono_unhandled_exception (ex_obj);
-		exit (1);
+		MonoJitTlsData *jit_tls = (MonoJitTlsData *) mono_tls_get_jit_tls ();
+		jit_tls->abort_func (ex_obj);
+		g_assert_not_reached ();
 	}
 	handle_finally:
 	{

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1281,9 +1281,13 @@ mono_interp_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoOb
 		break;
 	case MONO_TYPE_VALUETYPE:
 		retval = mono_object_new_checked (context->domain, klass, error);
-		ret = ((char*)retval) + sizeof (MonoObject);
+		ret = mono_object_unbox (retval);
 		if (!sig->ret->data.klass->enumtype)
 			result.data.vt = ret;
+		break;
+	case MONO_TYPE_PTR:
+		retval = mono_object_new_checked (context->domain, mono_defaults.int_class, error);
+		ret = mono_object_unbox (retval);
 		break;
 	default:
 		retval = mono_object_new_checked (context->domain, klass, error);
@@ -1338,6 +1342,7 @@ handle_enum:
 			}
 			break;
 		case MONO_TYPE_STRING:
+		case MONO_TYPE_PTR:
 		case MONO_TYPE_CLASS:
 		case MONO_TYPE_ARRAY:
 		case MONO_TYPE_SZARRAY:

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1285,13 +1285,24 @@ mono_interp_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoOb
 		if (!sig->ret->data.klass->enumtype)
 			result.data.vt = ret;
 		break;
+	case MONO_TYPE_GENERICINST:
+		if (!MONO_TYPE_IS_REFERENCE (sig->ret)) {
+			retval = mono_object_new_checked (context->domain, klass, error);
+			ret = mono_object_unbox (retval);
+			if (!sig->ret->data.klass->enumtype)
+				result.data.vt = ret;
+		} else {
+			isobject = 1;
+		}
+		break;
+
 	case MONO_TYPE_PTR:
 		retval = mono_object_new_checked (context->domain, mono_defaults.int_class, error);
 		ret = mono_object_unbox (retval);
 		break;
 	default:
 		retval = mono_object_new_checked (context->domain, klass, error);
-		ret = ((char*)retval) + sizeof (MonoObject);
+		ret = mono_object_unbox (retval);
 		break;
 	}
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -696,8 +696,6 @@ interp_walk_stack_with_ctx (MonoInternalStackWalk func, MonoContext *ctx, MonoUn
 			return;
 		frame = frame->parent;
 	}
-
-	g_assert (0);
 }
 
 static MonoPIFunc mono_interp_enter_icall_trampoline = NULL;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -502,7 +502,7 @@ store_arg(TransformData *td, int n)
 		else
 			size = mono_class_value_size (klass, NULL);
 		ADD_CODE(td, MINT_STARG_VT);
-		ADD_CODE(td, n);
+		ADD_CODE(td, td->rtm->arg_offsets [n]);
 		WRITE32(td, &size);
 		if (td->sp [-1].type == STACK_TYPE_VT)
 			POP_VT(td, size);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3308,7 +3308,7 @@ mono_interp_transform_method (RuntimeMethod *runtime_method, ThreadContext *cont
 				} else if (*name == 'E' && (strcmp (name, "EndInvoke") == 0)) {
 					nm = mono_marshal_get_delegate_end_invoke (method);
 				}
-			} 
+			}
 			if (nm == NULL) {
 				runtime_method->code = g_malloc(sizeof(short));
 				runtime_method->code[0] = MINT_CALLRUN;
@@ -3325,6 +3325,24 @@ mono_interp_transform_method (RuntimeMethod *runtime_method, ThreadContext *cont
 		method = nm;
 		header = mono_method_get_header (nm);
 		mono_os_mutex_unlock(&calc_section);
+	} else if (method->klass == mono_defaults.array_class) {
+		if (!strcmp (method->name, "UnsafeMov")) {
+			mono_os_mutex_lock (&calc_section);
+			if (!runtime_method->transformed) {
+				runtime_method->code = g_malloc (sizeof (short));
+				runtime_method->code[0] = MINT_CALLRUN;
+				runtime_method->stack_size = sizeof (stackval); /* for tracing */
+				runtime_method->alloca_size = runtime_method->stack_size;
+				runtime_method->transformed = TRUE;
+			}
+			mono_os_mutex_unlock(&calc_section);
+			mono_profiler_method_end_jit (method, NULL, MONO_PROFILE_OK);
+			return NULL;
+		} else if (!strcmp (method->name, "UnsafeStore)")) {
+			g_error ("TODO");
+		} else if (!strcmp (method->name, "UnsafeLoad)")) {
+			g_error ("TODO");
+		}
 	}
 	g_assert ((signature->param_count + signature->hasthis) < 1000);
 	g_assert (header->max_stack < 10000);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1003,11 +1003,9 @@ INTERP_DISABLED_TESTS = \
 	invalid-token.exe \
 	invalid_generic_instantiation.exe \
 	invoke-string-ctors.exe \
-	invoke.exe \
 	ldfld_missing_class.exe \
 	ldfld_missing_field.exe \
 	ldftn-access.exe \
-	loader.exe \
 	marshal-valuetypes.exe \
 	marshal.exe \
 	marshal2.exe \
@@ -1047,7 +1045,6 @@ INTERP_DISABLED_TESTS = \
 	runtime-invoke.gen.exe \
 	safehandle.2.exe \
 	shared-generic-synchronized.2.exe \
-	sleep.exe \
 	stackframes-async.2.exe \
 	static-constructor.exe \
 	test-inline-call-stack.exe \

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -973,7 +973,6 @@ INTERP_DISABLED_TESTS = \
 	delegate-delegate-exit.exe \
 	delegate-exit.exe \
 	delegate-with-null-target.exe \
-	delegate.exe \
 	delegate1.exe \
 	delegate3.exe \
 	delegate5.exe \
@@ -984,7 +983,6 @@ INTERP_DISABLED_TESTS = \
 	dynamic-method-finalize.2.exe \
 	dynamic-method-resurrection.exe \
 	dynamic-method-stack-traces.exe \
-	enum.exe \
 	even-odd.exe \
 	exception18.exe \
 	field-access.exe \

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1039,7 +1039,6 @@ INTERP_DISABLED_TESTS = \
 	remoting3.exe \
 	remoting4.exe \
 	remoting5.exe \
-	runtime-invoke.exe \
 	runtime-invoke.gen.exe \
 	safehandle.2.exe \
 	shared-generic-synchronized.2.exe \


### PR DESCRIPTION
* `gsharing-valuetype-layout.exe` crashes sometimes on Jenkins due to a wrong assert in stack walking code.
* improvement on shutdown
* handling some corner cases around `runtime_invoke`