### PR TITLE
[lldb] update `monobt` so it understands interpreter frames.

### DIFF
--- a/data/lldb/monobt.py
+++ b/data/lldb/monobt.py
@@ -9,16 +9,38 @@ def print_frames(thread, num_frames, current_thread):
 
     for frame in thread.frames[:+num_frames]:
         pc = str(frame.addr)
-        fmt = '  %c %s'
         var = frame
-        if pc[0] == '0':
+        function_name = frame.GetFunctionName()
+        if function_name == "ves_exec_method_with_context":
+            try:
+                s = 'frame->runtime_method->method'
+                klassname = frame.EvaluateExpression('(char*) ' + s + '->klass->name').summary[1:-1]
+                methodname = frame.EvaluateExpression('(char*) ' + s + '->name').summary[1:-1]
+
+                ipoffset = frame.EvaluateExpression('ip').GetValueAsUnsigned()
+                insn = ''
+                if ipoffset != 0:
+                    ipoffset -= frame.EvaluateExpression('rtm->code').GetValueAsUnsigned()
+                    insn = "\"" + frame.EvaluateExpression('mono_interp_opname [*ip]').summary[1:-1] + "\""
+                var = '%s::%s @ %d %s || %s' % (klassname, methodname, ipoffset, insn, frame)
+            except Exception as e:
+                print "DBG: execfail:" + str(e)
+        elif function_name == "mono_interp_transform_method":
+            try:
+                s = 'runtime_method->method'
+                klassname = frame.EvaluateExpression('(char*) ' + s + '->klass->name').summary[1:-1]
+                methodname = frame.EvaluateExpression('(char*) ' + s + '->name').summary[1:-1]
+                var = 'transforming %s::%s || %s' % (klassname, methodname, frame)
+            except Exception as e:
+                print "DBG: transformfail:" + str(e)
+        elif pc[0] == '0':
             try:
                 framestr = frame.EvaluateExpression('(char*)mono_pmip((void*)%s)' % pc).summary[1:-1]
                 var = 'frame #%i: %s%s' % (frame.idx, pc, framestr)
             except:
                 pass
 
-        print fmt % ('*' if current_thread and frame.idx == selected_frame.idx else ' ', var)
+        print '  %c %s' % ('*' if current_thread and frame.idx == selected_frame.idx else ' ', var)
 
 def monobt(debugger, command, result, dict):
     opts = {'all_bt': False, 'num_frames': None}
@@ -53,4 +75,5 @@ def __lldb_init_module (debugger, dict):
     # This initializer is being run from LLDB in the embedded command interpreter
     # Add any commands contained in this module to LLDB
     debugger.HandleCommand('command script add -f monobt.monobt monobt')
+    debugger.HandleCommand('command alias mbt monobt')
     print '"monobt" command installed'


### PR DESCRIPTION
Not sure if it's still relevant for the JIT, since @vargaz added lldb support to mono.  I might look into that as well, but I'm not sure if it makes sense for the interpreter (because it doesn't generate code).  For now, this makes debugging interpreter bugs more comfortable 🐛 🔫 

sample output:
```
(lldb) monobt
* thread #1
  * frame #0: 0x00000001001b236e mono-sgen`interp_transform_call(td=0x00007fff5fbfd080, method=0x0000000100915a90, target_method=0x0000000000000000, domain=0x000000010090b741
    frame #1: 0x00000001001a1c2e mono-sgen`generate(method=0x0000000100915a90, rtm=0x000000010382ac70, is_bb_start="\x01", generic_context=0x0000000100915ad0) + 9454 at tran8
    transforming TestMonoAsyncGenerics::AsyncWithAwait || frame #2: 0x000000010019f553 mono-sgen`mono_interp_transform_method(runtime_method=0x000000010382ac70, context=0x004
    TestMonoAsyncGenerics::AsyncWithAwait @ 0  || frame #3: 0x000000010018a178 mono-sgen`ves_exec_method_with_context(frame=0x00007fff5fbfe290, context=0x00007fff5fbfe3a8) +9
    TestMonoAsyncGenerics::Main @ 12 "pop" || frame #4: 0x000000010018b4b1 mono-sgen`ves_exec_method_with_context(frame=0x00007fff5fbfe420, context=0x00007fff5fbfe3a8) + 5081
    frame #5: 0x0000000100189e43 mono-sgen`mono_interp_runtime_invoke(method=0x000000010090ce38, obj=0x0000000000000000, params=0x00007fff5fbfea40, exc=0x0000000000000000, e0
    frame #6: 0x00000001000164a2 mono-sgen`mono_jit_runtime_invoke(method=0x000000010090ce38, obj=0x0000000000000000, params=0x00007fff5fbfea40, exc=0x0000000000000000, erro1
    frame #7: 0x000000010038b2b5 mono-sgen`do_runtime_invoke(method=0x000000010090ce38, obj=0x0000000000000000, params=0x00007fff5fbfea40, exc=0x0000000000000000, error=0x002
    frame #8: 0x0000000100384e97 mono-sgen`mono_runtime_invoke_checked(method=0x000000010090ce38, obj=0x0000000000000000, params=0x00007fff5fbfea40, error=0x00007fff5fbfeb000
    frame #9: 0x000000010038f335 mono-sgen`do_exec_main_checked(method=0x000000010090ce38, args=0x00000001020003c8, error=0x00007fff5fbfeb00) + 197 at object.c:4672
    frame #10: 0x000000010038dd5c mono-sgen`mono_runtime_exec_main_checked(method=0x000000010090ce38, args=0x00000001020003c8, error=0x00007fff5fbfeb00) + 76 at object.c:4773
    frame #11: 0x000000010038ddbf mono-sgen`mono_runtime_run_main_checked(method=0x000000010090ce38, argc=1, argv=0x00007fff5fbfef68, error=0x00007fff5fbfeb00) + 79 at objec2
    frame #12: 0x00000001000d9a33 mono-sgen`mono_jit_exec(domain=0x000000010090b740, assembly=0x0000000100913610, argc=1, argv=0x00007fff5fbfef68) + 403 at driver.c:1029
    frame #13: 0x00000001000dd9da mono-sgen`main_thread_handler(user_data=0x00007fff5fbfeea0) + 538 at driver.c:1098
    frame #14: 0x00000001000dc21c mono-sgen`mono_main(argc=3, argv=0x00007fff5fbfef58) + 8636 at driver.c:2163
    frame #15: 0x0000000100001b9e mono-sgen`mono_main_with_options(argc=3, argv=0x00007fff5fbfef58) + 46 at main.c:45
    frame #16: 0x00000001000012dd mono-sgen`main(argc=3, argv=0x00007fff5fbfef58) + 77 at main.c:338
    frame #17: 0x00007fffc2e66255 libdyld.dylib`start + 1
    frame #18: 0x00007fffc2e66255 libdyld.dylib`start + 1
```