### PR TITLE
[runtime] Introduce new runtime API function mono_runtime_atexit.

### DIFF
--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -58,6 +58,10 @@ mono_runtime_set_shutting_down (void);
 MONO_API mono_bool
 mono_runtime_is_shutting_down (void);
 
+typedef void (*MonoAtExitCallback) (void *user_data);
+MONO_API void
+mono_runtime_atexit (MonoAtExitCallback callback, void *user_data);
+
 MONO_API const char*
 mono_check_corlib_version (void);
 

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -22,6 +22,15 @@
 #include <mono/metadata/marshal.h>
 #include <mono/utils/atomic.h>
 
+
+struct _MonoAtExitData {
+	MonoAtExitCallback cb;
+	void * user_data;
+	struct _MonoAtExitData *next;
+};
+typedef struct _MonoAtExitData MonoAtExitData;
+
+static MonoAtExitData *mono_atexit = NULL;
 static gboolean shutting_down_inited = FALSE;
 static gboolean shutting_down = FALSE;
 
@@ -83,6 +92,38 @@ mono_runtime_fire_process_exit_event (void)
 #endif
 }
 
+static void
+mono_runtime_call_atexit (void)
+{
+	MonoAtExitData *at;
+	for (at = mono_atexit; at; at = at->next)
+		at->cb (at->user_data);
+}
+
+/**
+ * mono_runtime_atexit:
+ *
+ * Register a callback to be invoked when the runtime begins to shutdown.
+ *
+ * This will be invoked both for active (calling Environment::Exit) and passive shutdown (all threads gone).
+ *
+ * The runtime will be functional at the time the callback is invoked but managed code will already have begun
+ * to cleanup. This means the callback must not block or depend on execution of managed code.
+ *
+ */
+void
+mono_runtime_atexit (MonoAtExitCallback callback, void *user_data)
+{
+	MonoAtExitData *at = g_new (MonoAtExitData, 1);
+	MonoAtExitData *old;
+
+	at->cb = callback;
+	at->user_data = user_data;
+	do {
+		old = mono_atexit;
+		at->next = old;
+	} while (InterlockedCompareExchangePointer ((void*)&mono_atexit, at, old) != old);
+}
 
 /**
  * mono_runtime_try_shutdown:
@@ -98,6 +139,8 @@ mono_runtime_try_shutdown (void)
 {
 	if (InterlockedCompareExchange (&shutting_down_inited, TRUE, FALSE))
 		return FALSE;
+
+	mono_runtime_call_atexit ();
 
 	mono_runtime_fire_process_exit_event ();
 


### PR DESCRIPTION
This provides the embedder with a similar callback that libc's atexist does.

It is called at the time the runtime begins to shutdown before anything is cleared.