### PR TITLE
[x86] Implement OP_EXPAND_I1 by lowering instead of directly to avoid…

### DIFF
--- a/mono/mini/cpu-x86.md
+++ b/mono/mini/cpu-x86.md
@@ -638,7 +638,6 @@ xconv_r8_to_i4: dest:y src1:x len:7
 
 prefetch_membase: src1:b len:4
 
-expand_i1: dest:x src1:y len:17 clob:1
 expand_i2: dest:x src1:i len:15
 expand_i4: dest:x src1:i len:9
 expand_r4: dest:x src1:f len:20


### PR DESCRIPTION
… register allocation problems. Increase stack size when simd types are used.

[simd] Avoid nullifying the OP_LDADDR opcodes used by SIMD, the null checks emitted by 'explicit-null-checks' depend on them.