### PR TITLE
TimeSpan.FromMilliseconds(TimeSpan.MaxValue.TotalMilliseconds)

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/timespan.cs
+++ b/mcs/class/referencesource/mscorlib/system/timespan.cs
@@ -230,10 +230,10 @@ namespace System {
                 throw new ArgumentException(Environment.GetResourceString("Arg_CannotBeNaN"));
             Contract.EndContractBlock();
             double tmp = value * scale;
-            double millis = tmp + (value >= 0? 0.5: -0.5);
-            if ((millis > Int64.MaxValue / TicksPerMillisecond) || (millis < Int64.MinValue / TicksPerMillisecond))
+            double ticks = Math.Round(tmp * TicksPerMillisecond, 0);
+            if ((ticks > Int64.MaxValue) || (ticks < Int64.MinValue))
                 throw new OverflowException(Environment.GetResourceString("Overflow_TimeSpanTooLong"));
-            return new TimeSpan((long)millis * TicksPerMillisecond);
+            return new TimeSpan((long)ticks);
         }
 
         public static TimeSpan FromMilliseconds(double value) {


### PR DESCRIPTION
Exception fix.
The problem is discussed here: https://connect.microsoft.com/VisualStudio/feedback/details/542235/timespan-structure-incorrectly-handles-values-close-to-min-and-max-value
The existing overflow checks are ignorant and superfluous.