### PR TITLE
csharp: support command line arguments for scripts

### DIFF
--- a/man/csharp.1
+++ b/man/csharp.1
@@ -2,30 +2,21 @@
 .if t .sp .5v
 .if n .sp
 ..
-.TH csharp 1 "4 September 2008"
+.TH csharp 1 "22 March 2017"
 .SH NAME 
-csharp, gsharp \- Interactive C# Shell 
+csharp \- Interactive C# Shell and Scripting
 .SH SYNOPSIS
 .B csharp [--attach PID] [-e EXPRESSION] [file1 [file2]]
-[options] 
-.P
-.B gsharp [file1 [file2]]
+[compiler-options] [--|-s script-options]
 .SH DESCRIPTION
 The 
 .I csharp
-is an interactive C# shell that allows the user to enter and evaluate
-C# statements and expressions from the command line.   The regular 
+command is an interactive C# shell and scripting host that allows
+the user to enter and evaluate C# statements and expressions from
+the command line or execute C# scripts.
+The regular
 .I mcs
 command line options can be used in this version of the compiler. 
-.PP
-The 
-.I gsharp
-command is a GUI version of the C# interpreter that uses Gtk# and
-provides an area to attach widgets as well.      This version can be
-attached to other Gtk# applications in a safe way as it injects itself
-into the main loop of a Gtk# application, avoiding any problems
-arising from the multi-threaded nature of injecting itself into a
-target process.
 .PP
 Files specified in the command line will be loaded and executed as
 scripts.
@@ -35,9 +26,31 @@ Starting with Mono 2.10, the
 command can be used as an interpreter executed by executables flagged
 with the Unix execute attribute.   To do this, make the first line of
 your C# source code look like this:
+.PP
 .nf
-"#!/usr/bin/csharp" 
-Console.WriteLine ("Hello, World");
+  #!/usr/bin/csharp
+  Console.WriteLine ("Hello, World");
+.fi
+.PP
+Starting with Mono 5.0, command line arguments may now be passed
+to the
+.I csharp
+command by specifying either the
+.I -s
+or
+.I --
+(script) options.
+.PP
+The
+.I -s
+option is ideal for interpreting executable scripts that utilize
+shebang syntax (introduced in Mono 2.10). This allows command line
+arguments to be passed to and consumed cleanly by the script:
+.PP
+.nf
+  #!/usr/bin/csharp -s
+  foreach (var arg in Args)
+    Console.WriteLine ($"script argument: {arg}");
 .fi
 .SH OPTIONS
 The commands accept all of the commands that are available to the 
@@ -45,6 +58,23 @@ The commands accept all of the commands that are available to the
 command, so you can reference assemblies, specify paths, language
 level and so on from the command line.   In addition, the following
 command line options are supported:
+.TP
+.I "\-s" SCRIPT_FILE
+This option is ideal for authoring executable scripts that utilize
+the Unix shebang feature. Unix will implicitly append as an argument
+the path of the script to execute. When the executable is invoked,
+any arguments then passed to it will be available in the
+.I Args
+global. Example:
+.I "#!/usr/bin/env csharp -s"
+.TP
+.I "\-\-"
+Any arguments that follow will not be passed to the compiler driver,
+and instead will be made available in the
+.I Args
+global. Example:
+.I csharp -- a b c
+will result in Args = { "a", "b", "c" } in the interactive shell.
 .TP 
 .I "\-\-attach"
 This is an advanced option and should only be used if you have a deep
@@ -289,6 +319,15 @@ Since the methods and properties of the base class from where the
 statements and expressions are executed are static, they can be
 invoked directly from the shell.   These are the available properties
 and methods:
+.TP
+.I Args
+An easy to consume array of any arguments specified after either
+.I -s
+or
+.I --
+on the command line. Ideal for self-executing scripts utilizing the
+.I -s
+option.
 .TP
 .I void LoadAssembly(string assembly)
 Loads the given assembly.   This is equivalent to passing the compiler

--- a/mcs/tools/csharp/repl.cs
+++ b/mcs/tools/csharp/repl.cs
@@ -38,9 +38,15 @@ namespace Mono {
 		static string target_host;
 		static int target_port;
 		static string agent;
+		static string [] script_args;
+
+		public static string [] ScriptArgs => script_args;
 		
 		static int Main (string [] args)
 		{
+			if (!SplitDriverAndScriptArguments (ref args, out script_args))
+				return 1;
+
 			var cmd = new CommandLineParser (Console.Out);
 			cmd.UnknownOptionHandler += HandleExtraArguments;
 
@@ -88,6 +94,55 @@ namespace Mono {
 				shell = new CSharpShell (eval);
 
 			return shell.Run (startup_files);
+		}
+
+		static bool SplitDriverAndScriptArguments (ref string [] driver_args, out string [] script_args)
+		{
+			// split command line arguments into two groups:
+			// - anything before '--' or '-s' goes to the mcs driver, which may
+			//   call back into the csharp driver for further processing
+			// - anything after '--' or '-s' is made available to the REPL/script
+			//   via the 'Args' global, similar to csi.
+			// - if '-s' is used, the argument immediately following it will
+			//   also be processed by the mcs driver (e.g. a source file)
+
+			int driver_args_count = 0;
+			int script_args_offset = 0;
+			string script_file = null;
+
+			while (driver_args_count < driver_args.Length && script_args_offset == 0) {
+				switch (driver_args [driver_args_count]) {
+				case "--":
+					script_args_offset = driver_args_count + 1;
+					break;
+				case "-s":
+					if (driver_args_count + 1 >= driver_args.Length) {
+						script_args = null;
+						Console.Error.WriteLine ("usage is: -s SCRIPT_FILE");
+						return false;
+					}
+					driver_args_count++;
+					script_file = driver_args [driver_args_count];
+					script_args_offset = driver_args_count + 1;
+					break;
+				default:
+					driver_args_count++;
+					break;
+				}
+			}
+
+			if (script_args_offset > 0) {
+				int script_args_count = driver_args.Length - script_args_offset;
+				script_args = new string [script_args_count];
+				Array.Copy (driver_args, script_args_offset, script_args, 0, script_args_count);
+			} else
+				script_args = Array.Empty<string> ();
+
+			Array.Resize (ref driver_args, driver_args_count);
+			if (script_file != null)
+				driver_args [driver_args_count - 1] = script_file;
+
+			return true;
 		}
 
 		static int HandleExtraArguments (string [] args, int pos)
@@ -163,9 +218,13 @@ namespace Mono {
 		public static new string help {
 			get {
 				return InteractiveBase.help +
-					"  TabAtStartCompletes      - Whether tab will complete even on empty lines\n";
+					"  TabAtStartCompletes      - Whether tab will complete even on empty lines\n" +
+					"  Args                     - Any command line arguments passed to csharp\n" +
+					"                             after the '--' (stop processing) argument";
 			}
 		}
+
+		public static string [] Args => Driver.ScriptArgs;
 	}
 	
 	public class CSharpShell {


### PR DESCRIPTION
This adds a command line argument preprocessor that splits command line arguments into two groups, delimited by the "standard" `--` "stop processing" argument, or by the `-s` argument which can be used with Unix shebang syntax (where the path of the file being executed will be appended to the command line specified on the shebang line).

- anything _before_ `--` or `-s` will be passed to the driver as usual
  - when `-s` is used, the argument after it will be passed to the driver as well 
- anything _after_ `--` or `-s` will _not_ be processed by the driver, and will be made available in an `Args` global, like Roslyn's `csi`

This _finally_ (after almost 10 years) allows `csharp` to be used for proper script authoring!

## Example: REPL

### Invocation:

```bash
$ csharp -sdk:2 -- one two three
```

### REPL Session:

```
Mono C# Shell, type "help;" for help

Enter statements below.
csharp> Args
{ "one", "two", "three" }
csharp> Environment.GetCommandLineArgs ()
{ "csharp.exe", "-sdk:2", "--", "one", "two", "three" }
csharp> |
```

## Example: `cs-script`

### Script:

```csharp
#!/usr/bin/env csharp -s

Args
```

### Invocation:

```bash
$ ./cs-script a b c
```

### Output:

```csharp
{ "a", "b", "c" }
```