### PR TITLE
2017-02 [reflection] Set correct reflected type in MonoMethod.get_base_method (Fixes #53690)

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -287,12 +287,28 @@ namespace MonoTests.System.Reflection
 		class GBD_D : GBD_C { public new virtual void f () {} }
 		class GBD_E : GBD_D { public override    void f () {} }
 
+		class GBD_E2 : GBD_D { }
+		class GBD_F : GBD_E { }
+
+
 		[Test]
 		public void GetBaseDefinition ()
 		{
 			Assert.AreEqual (typeof (GBD_A), typeof (GBD_C).GetMethod ("f").GetBaseDefinition ().DeclaringType);
+			Assert.AreEqual (typeof (GBD_A), typeof (GBD_C).GetMethod ("f").GetBaseDefinition ().ReflectedType, "#1r");
+
 			Assert.AreEqual (typeof (GBD_D), typeof (GBD_D).GetMethod ("f").GetBaseDefinition ().DeclaringType);
+			Assert.AreEqual (typeof (GBD_D), typeof (GBD_D).GetMethod ("f").GetBaseDefinition ().ReflectedType, "#2r");
+
 			Assert.AreEqual (typeof (GBD_D), typeof (GBD_E).GetMethod ("f").GetBaseDefinition ().DeclaringType);
+			Assert.AreEqual (typeof (GBD_D), typeof (GBD_E).GetMethod ("f").GetBaseDefinition ().ReflectedType, "#3r");
+
+			Assert.AreEqual (typeof (GBD_D), typeof (GBD_E2).GetMethod ("f").GetBaseDefinition ().DeclaringType, "#4");
+			Assert.AreEqual (typeof (GBD_D), typeof (GBD_E2).GetMethod ("f").GetBaseDefinition ().ReflectedType, "#4r");
+
+			Assert.AreEqual (typeof (GBD_D), typeof (GBD_F).GetMethod ("f").GetBaseDefinition ().DeclaringType, "#5");
+			Assert.AreEqual (typeof (GBD_D), typeof (GBD_F).GetMethod ("f").GetBaseDefinition ().ReflectedType, "#5r");
+
 		}
 
 		class GenericBase<T,H> {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7269,10 +7269,20 @@ ves_icall_MonoMethod_get_base_method (MonoReflectionMethodHandle m, gboolean def
 
 	MonoMethod *base = mono_method_get_base_method (method, definition, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionMethod, NULL_HANDLE));
-	if (base == method)
-		return m;
-	else
-		return mono_method_get_object_handle (mono_domain_get (), base, NULL, error);
+	if (base == method) {
+		/* we want to short-circuit and return 'm' here. But we should
+		   return the same method object that
+		   mono_method_get_object_handle, below would return.  Since
+		   that call takes NULL for the reftype argument, it will take
+		   base->klass as the reflected type for the MonoMethod.  So we
+		   need to check that m also has base->klass as the reflected
+		   type. */
+		MonoReflectionTypeHandle orig_reftype = MONO_HANDLE_NEW_GET (MonoReflectionType, m, reftype);
+		MonoClass *orig_klass = mono_class_from_mono_type (MONO_HANDLE_GETVAL (orig_reftype, type));
+		if (base->klass == orig_klass)
+			return m;
+	}
+	return mono_method_get_object_handle (mono_domain_get (), base, NULL, error);
 }
 
 ICALL_EXPORT MonoStringHandle


### PR DESCRIPTION
This is a backport of #4575 to the `2017-02` branch

Fixes [bugzilla #53690](https://bugzilla.xamarin.com/show_bug.cgi?id=53690)