### PR TITLE
Remove Content-Encoding header after doing automatic decompression

### DIFF
--- a/mcs/class/System/System.Net/HttpWebResponse.cs
+++ b/mcs/class/System/System.Net/HttpWebResponse.cs
@@ -86,10 +86,14 @@ namespace System.Net
 			}
 
 			string content_encoding = webHeaders ["Content-Encoding"];
-			if (content_encoding == "gzip" && (data.request.AutomaticDecompression & DecompressionMethods.GZip) != 0)
+			if (content_encoding == "gzip" && (data.request.AutomaticDecompression & DecompressionMethods.GZip) != 0) {
 				stream = new GZipStream (stream, CompressionMode.Decompress);
-			else if (content_encoding == "deflate" && (data.request.AutomaticDecompression & DecompressionMethods.Deflate) != 0)
+				webHeaders.Remove (HttpRequestHeader.ContentEncoding);
+			}
+			else if (content_encoding == "deflate" && (data.request.AutomaticDecompression & DecompressionMethods.Deflate) != 0) {
 				stream = new DeflateStream (stream, CompressionMode.Decompress);
+				webHeaders.Remove (HttpRequestHeader.ContentEncoding);
+			}
 		}
 
 		[Obsolete ("Serialization is obsoleted for this type", false)]


### PR DESCRIPTION
Match the .NET Framework behaviour by removing the Content-Encoding
header after doing automatic decompression.