### PR TITLE
[AppleTls]: Use correct definition of `SecTrustResult`.

### DIFF
--- a/mcs/class/System/Mono.AppleTls/Enums.cs
+++ b/mcs/class/System/Mono.AppleTls/Enums.cs
@@ -15,8 +15,17 @@ namespace Mono.AppleTls {
 
 	// typedef uint32_t SecTrustResultType;
 	// values are defined in Security.framework/Headers/SecTrust.h 
-	enum SecTrustResult {
+	public enum SecTrustResult {
+		Invalid,
+		Proceed,
+
+		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9)]
+		Confirm,
+		Deny,
 		Unspecified,
+		RecoverableTrustFailure,
+		FatalTrustFailure,
+		ResultOtherError,
 	}
 }
 #endif

--- a/mcs/class/System/Mono.AppleTls/Enums.cs
+++ b/mcs/class/System/Mono.AppleTls/Enums.cs
@@ -1,4 +1,4 @@
-﻿#if MONO_FEATURE_APPLETLS
+#if MONO_FEATURE_APPLETLS
 // Copyright 2011-2015 Xamarin Inc. All rights reserved.
 
 using ObjCRuntime;

--- a/mcs/class/System/Mono.AppleTls/Enums.cs
+++ b/mcs/class/System/Mono.AppleTls/Enums.cs
@@ -1,4 +1,4 @@
-#if MONO_FEATURE_APPLETLS
+﻿#if MONO_FEATURE_APPLETLS
 // Copyright 2011-2015 Xamarin Inc. All rights reserved.
 
 using ObjCRuntime;
@@ -19,7 +19,6 @@ namespace Mono.AppleTls {
 		Invalid,
 		Proceed,
 
-		[Availability (Deprecated = Platform.iOS_7_0 | Platform.Mac_10_9)]
 		Confirm,
 		Deny,
 		Unspecified,

--- a/mcs/class/System/Mono.AppleTls/Enums.cs
+++ b/mcs/class/System/Mono.AppleTls/Enums.cs
@@ -15,7 +15,7 @@ namespace Mono.AppleTls {
 
 	// typedef uint32_t SecTrustResultType;
 	// values are defined in Security.framework/Headers/SecTrust.h 
-	public enum SecTrustResult {
+	enum SecTrustResult {
 		Invalid,
 		Proceed,
 


### PR DESCRIPTION
We need all the values in this enum because `SecTrustResult.Unspecified`
means success - which currently has an integer value of 4, not 0.