### PR TITLE
[remoting] Pass correct object to invoke of IRemotingTypeInfo.CanCastTo

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6404,6 +6404,8 @@ ICALL_EXPORT MonoReflectionType *
 ves_icall_Remoting_RealProxy_InternalGetProxyType (MonoTransparentProxy *tp)
 {
 	MonoError error;
+	g_assert (tp != NULL && mono_object_class (tp) == mono_defaults.transparent_proxy_class);
+	g_assert (tp->remote_class != NULL && tp->remote_class->proxy_class != NULL);
 	MonoReflectionType *ret = mono_type_get_object_checked (mono_object_domain (tp), &tp->remote_class->proxy_class->byval_arg, &error);
 	mono_error_set_pending_exception (&error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6578,7 +6578,7 @@ mono_object_handle_isinst_mbyref (MonoObjectHandle obj, MonoClass *klass, MonoEr
 
 		pa [0] = MONO_HANDLE_RAW (reftype);
 		pa [1] = MONO_HANDLE_RAW (obj);
-		MonoObject *res = mono_runtime_invoke_checked (im, rp, pa, error);
+		MonoObject *res = mono_runtime_invoke_checked (im, MONO_HANDLE_RAW (rp), pa, error);
 		if (!is_ok (error))
 			goto leave;
 


### PR DESCRIPTION
Pass the payload of the coop handle as the 'this' object, not the handle
itself.

Add asserts in ves_icall_Remoting_RealProxy_InternalGetProxyType that
remote_class and the proxy_class are non-NULL.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=53890