### PR TITLE
[jit] Cleanup the signature of the mono_arch_get_static_rgctx_trampol…

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -120,7 +120,7 @@ mono_create_static_rgctx_trampoline (MonoMethod *m, gpointer addr)
 	if (mono_aot_only)
 		res = mono_aot_get_static_rgctx_trampoline (ctx, addr);
 	else
-		res = mono_arch_get_static_rgctx_trampoline (m, (MonoMethodRuntimeGenericContext *)ctx, addr);
+		res = mono_arch_get_static_rgctx_trampoline (ctx, addr);
 
 	mono_domain_lock (domain);
 	/* Duplicates inserted while we didn't hold the lock are OK */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2799,7 +2799,7 @@ void     mono_arch_create_vars                  (MonoCompile *cfg) MONO_LLVM_INT
 void     mono_arch_save_unwind_info             (MonoCompile *cfg);
 void     mono_arch_register_lowlevel_calls      (void);
 gpointer mono_arch_get_unbox_trampoline         (MonoMethod *m, gpointer addr);
-gpointer mono_arch_get_static_rgctx_trampoline  (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr);
+gpointer mono_arch_get_static_rgctx_trampoline  (gpointer arg, gpointer addr);
 gpointer  mono_arch_get_llvm_imt_trampoline     (MonoDomain *domain, MonoMethod *method, int vt_offset);
 gpointer mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpointer addr);
 void     mono_arch_patch_callsite               (guint8 *method_start, guint8 *code, guint8 *addr);

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -77,10 +77,10 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 /*
  * mono_arch_get_static_rgctx_trampoline:
  *
- *   Create a trampoline which sets RGCTX_REG to MRGCTX, then jumps to ADDR.
+ *   Create a trampoline which sets RGCTX_REG to ARG, then jumps to ADDR.
  */
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	guint8 *code, *start;
 	GSList *unwind_ops;
@@ -102,7 +102,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericCo
 
 	unwind_ops = mono_arch_get_cie_program ();
 
-	amd64_mov_reg_imm (code, MONO_ARCH_RGCTX_REG, mrgctx);
+	amd64_mov_reg_imm (code, MONO_ARCH_RGCTX_REG, arg);
 	amd64_jump_code (code, addr);
 	g_assert ((code - start) < buf_len);
 	g_assert_checked (mono_arch_unwindinfo_validate_size (unwind_ops, MONO_TRAMPOLINE_UNWINDINFO_SIZE(0)));
@@ -1170,7 +1170,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 }
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -509,7 +509,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 }
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	guint8 *code, *start;
 	GSList *unwind_ops;
@@ -522,7 +522,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericCo
 
 	ARM_LDR_IMM (code, MONO_ARCH_RGCTX_REG, ARMREG_PC, 0);
 	ARM_LDR_IMM (code, ARMREG_PC, ARMREG_PC, 0);
-	*(guint32*)code = (guint32)mrgctx;
+	*(guint32*)code = (guint32)arg;
 	code += 4;
 	*(guint32*)code = (guint32)addr;
 	code += 4;
@@ -852,7 +852,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 }
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -364,14 +364,14 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 }
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	guint8 *code, *start;
 	guint32 buf_len = 32;
 	MonoDomain *domain = mono_domain_get ();
 
 	start = code = mono_domain_code_reserve (domain, buf_len);
-	code = mono_arm_emit_imm64 (code, MONO_ARCH_RGCTX_REG, (guint64)mrgctx);
+	code = mono_arm_emit_imm64 (code, MONO_ARCH_RGCTX_REG, (guint64)arg);
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	arm_brx (code, ARMREG_IP0);
 
@@ -690,7 +690,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 }
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/mini/tramp-mips.c
+++ b/mono/mini/tramp-mips.c
@@ -307,7 +307,7 @@ mono_arch_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_ty
 }
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	guint8 *code, *start;
 	int buf_len;
@@ -318,7 +318,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericCo
 
 	start = code = mono_domain_code_reserve (domain, buf_len);
 
-	mips_load (code, MONO_ARCH_RGCTX_REG, mrgctx);
+	mips_load (code, MONO_ARCH_RGCTX_REG, arg);
 	mips_load (code, mips_at, addr);
 	mips_jr (code, mips_at);
 	mips_nop (code);

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -113,10 +113,10 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 /*
  * mono_arch_get_static_rgctx_trampoline:
  *
- *   Create a trampoline which sets RGCTX_REG to MRGCTX, then jumps to ADDR.
+ *   Create a trampoline which sets RGCTX_REG to ARG, then jumps to ADDR.
  */
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	guint8 *code, *start, *p;
 	guint8 imm_buf [128];
@@ -129,7 +129,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericCo
 
 	/* Compute size of code needed to emit mrgctx */
 	p = imm_buf;
-	ppc_load_ptr (p, MONO_ARCH_RGCTX_REG, mrgctx);
+	ppc_load_ptr (p, MONO_ARCH_RGCTX_REG, arg);
 	imm_size = p - imm_buf;
 
 	mono_domain_lock (domain);

--- a/mono/mini/tramp-s390x.c
+++ b/mono/mini/tramp-s390x.c
@@ -553,20 +553,18 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 /*                                                                  */
 /* Name    	- mono_arch_get_static_rgctx_trampoline		    */
 /*                                                                  */
-/* Function	- Create a trampoline which sets RGCTX_REG to MRGCTX*/
+/* Function	- Create a trampoline which sets RGCTX_REG to ARG       */
 /*		  then jumps to ADDR.				    */
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, 
-					MonoMethodRuntimeGenericContext *mrgctx, 
-					gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg,
+									   gpointer addr)
 {
 	guint8 *code, *start;
 	gint32 displace;
 	int buf_len;
-	char trampName[128];
 
 	MonoDomain *domain = mono_domain_get ();
 
@@ -574,7 +572,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m,
 
 	start = code = mono_domain_code_reserve (domain, buf_len);
 
-	S390_SET  (code, MONO_ARCH_RGCTX_REG, mrgctx);
+	S390_SET  (code, MONO_ARCH_RGCTX_REG, arg);
 	displace = ((uintptr_t) addr - (uintptr_t) code) / 2;
 	s390_jg   (code, displace);
 	g_assert ((code - start) < buf_len);
@@ -582,9 +580,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m,
 	mono_arch_flush_icache (start, code - start);
 	mono_profiler_code_buffer_new (start, code - start, MONO_PROFILER_CODE_BUFFER_HELPER, NULL);
 
-	snprintf(trampName, sizeof(trampName), "%s_rgctx_trampoline", m->name);
-
-	mono_tramp_info_register (mono_tramp_info_create (trampName, start, code - start, NULL, NULL), domain);
+	mono_tramp_info_register (mono_tramp_info_create (NULL, start, code - start, NULL, NULL), domain);
 
 	return(start);
 }	

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -62,7 +62,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 }
 
 gpointer
-mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericContext *mrgctx, gpointer addr)
+mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
 	guint8 *code, *start;
 	int buf_len;
@@ -76,7 +76,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMethod *m, MonoMethodRuntimeGenericCo
 
 	unwind_ops = mono_arch_get_cie_program ();
 
-	x86_mov_reg_imm (code, MONO_ARCH_RGCTX_REG, mrgctx);
+	x86_mov_reg_imm (code, MONO_ARCH_RGCTX_REG, arg);
 	x86_jump_code (code, addr);
 	g_assert ((code - start) <= buf_len);
 


### PR DESCRIPTION
…ine () function.

Remove the unused MonoMethod argument, and rename the 'mrgctx' argument to 'arg', since it can be any value, not just
an mrgctx.