### PR TITLE
Bring in the new reference assemblies

### DIFF
--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -33,7 +33,7 @@ USE_MCS_FLAGS = /codepage:$(CODEPAGE) /nologo /noconfig /deterministic $(LOCAL_M
 USE_MBAS_FLAGS = /codepage:$(CODEPAGE) $(LOCAL_MBAS_FLAGS) $(PLATFORM_MBAS_FLAGS) $(PROFILE_MBAS_FLAGS) $(MBAS_FLAGS)
 USE_CFLAGS = $(LOCAL_CFLAGS) $(CFLAGS) $(CPPFLAGS)
 CSCOMPILE = $(Q_MCS) $(MCS) $(USE_MCS_FLAGS)
-CSC_RUNTIME_FLAGS = --aot-path=$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE) --gc-params=nursery-size=64m
+CSC_RUNTIME_FLAGS = --aot-path=$(abspath $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)) --gc-params=nursery-size=64m
 BASCOMPILE = $(MBAS) $(USE_MBAS_FLAGS)
 CCOMPILE = $(CC) $(USE_CFLAGS)
 BOOT_COMPILE = $(Q_MCS) $(BOOTSTRAP_MCS) $(USE_MCS_FLAGS)

--- a/mcs/class/reference-assemblies/Makefile
+++ b/mcs/class/reference-assemblies/Makefile
@@ -6,17 +6,41 @@ all-local:
 
 PROFILE_DIR=$(DESTDIR)$(mono_libdir)/mono
 
+build-reference-assemblies:
+	$(MAKE) -C ../../../external/binary-reference-assemblies CSC="MONO_PATH=$(abspath $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)) $(INTERNAL_CSC)"
+
 install-local:
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/2.0-api
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/3.5-api
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.0-api
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.5-api
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.5.1-api
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.5.2-api
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.6-api
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.6.1-api
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.6.2-api
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.5-api/Facades
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.5.1-api/Facades
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.5.2-api/Facades
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.6-api/Facades
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.6.1-api/Facades
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.6.2-api/Facades
+
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v2.0/*.dll $(PROFILE_DIR)/2.0-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v3.5/*.dll $(PROFILE_DIR)/3.5-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.0/*.dll $(PROFILE_DIR)/4.0-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5/*.dll $(PROFILE_DIR)/4.5-api
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5.1/*.dll $(PROFILE_DIR)/4.5.1-api
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5.2/*.dll $(PROFILE_DIR)/4.5.2-api
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6/*.dll $(PROFILE_DIR)/4.6-api
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6.1/*.dll $(PROFILE_DIR)/4.6.1-api
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6.2/*.dll $(PROFILE_DIR)/4.6.2-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5/Facades/*.dll $(PROFILE_DIR)/4.5-api/Facades
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5.1/Facades/*.dll $(PROFILE_DIR)/4.5.1-api/Facades
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5.2/Facades/*.dll $(PROFILE_DIR)/4.5.2-api/Facades
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6/Facades/*.dll $(PROFILE_DIR)/4.6-api/Facades
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6.1/Facades/*.dll $(PROFILE_DIR)/4.6.1-api/Facades
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6.2/Facades/*.dll $(PROFILE_DIR)/4.6.2-api/Facades
 
 	# Unfortunately, a few programs (most notably NUnit and FSharp) have hardcoded checks for <prefix>/lib/mono/4.0/mscorlib.dll or Mono.Posix.dll,
 	# so we need to place something there or those tools break. We decided to symlink to the reference assembly for now.
@@ -25,6 +49,47 @@ install-local:
 	ln -sf ../4.0-api/mscorlib.dll $(PROFILE_DIR)/4.0/mscorlib.dll
 	ln -sf ../4.0-api/Mono.Posix.dll $(PROFILE_DIR)/4.0/Mono.Posix.dll
 
-DISTFILES = $(wildcard ../../../external/binary-reference-assemblies/v4.5/Facades/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v4.5/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v4.0/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v3.5/*.dll) $(wildcard ../../../external/binary-reference-assemblies/v2.0/*.dll) Makefile
+DISTFILES =	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.6.2/Facades/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.6.1/Facades/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.6/Facades/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.5.2/Facades/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.5.1/Facades/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.5/Facades/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.6.2/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.6.1/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.6/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.5.2/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.5.1/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.5/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.0/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v3.5/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v2.0/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6.2/Facades/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6.1/Facades/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6/Facades/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5.2/Facades/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5.1/Facades/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5/Facades/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6.2/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6.1/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5.2/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5.1/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.0/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v3.5/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v2.0/*.cs)	\
+	../../../external/binary-reference-assemblies/v4.6.2/Makefile	\
+	../../../external/binary-reference-assemblies/v4.6.1/Makefile	\
+	../../../external/binary-reference-assemblies/v4.6/Makefile	\
+	../../../external/binary-reference-assemblies/v4.5.2/Makefile	\
+	../../../external/binary-reference-assemblies/v4.5.1/Makefile	\
+	../../../external/binary-reference-assemblies/v4.5/Makefile	\
+	../../../external/binary-reference-assemblies/v4.0/Makefile	\
+	../../../external/binary-reference-assemblies/v3.5/Makefile	\
+	../../../external/binary-reference-assemblies/v2.0/Makefile	\
+	../../../external/binary-reference-assemblies/Makefile	\
+	Makefile
 
 dist-local: dist-default

--- a/mcs/mcs/ikvm.cs
+++ b/mcs/mcs/ikvm.cs
@@ -249,7 +249,12 @@ namespace Mono.CSharp
 			sdk_directory.Add ("4", new string[] { "4.0-api", "v4.0.30319" });
 			sdk_directory.Add ("4.0", new string[] { "4.0-api", "v4.0.30319" });
 			sdk_directory.Add ("4.5", new string[] { "4.5-api", "v4.0.30319" });
-			sdk_directory.Add ("4.6", new string [] { "4.5", "net_4_x", "v4.0.30319" });
+			sdk_directory.Add ("4.5.1", new string[] { "4.5.1-api", "v4.0.30319" });
+			sdk_directory.Add ("4.5.2", new string[] { "4.5.2-api", "v4.0.30319" });
+			sdk_directory.Add ("4.6", new string[] { "4.6-api", "v4.0.30319" });
+			sdk_directory.Add ("4.6.1", new string[] { "4.6.1-api", "v4.0.30319" });
+			sdk_directory.Add ("4.6.2", new string [] { "4.6.2-api", "v4.0.30319" });
+			sdk_directory.Add ("4.x", new string [] { "4.5", "net_4_x", "v4.0.30319" });
 		}
 
 		public StaticLoader (StaticImporter importer, CompilerContext compiler)
@@ -269,7 +274,7 @@ namespace Mono.CSharp
 
 				string sdk_path = null;
 
-				string sdk_version = compiler.Settings.SdkVersion ?? "4.6";
+				string sdk_version = compiler.Settings.SdkVersion ?? "4.x";
 				string[] sdk_sub_dirs;
 
 				if (!sdk_directory.TryGetValue (sdk_version, out sdk_sub_dirs))

--- a/mcs/tools/xbuild/frameworks/net_4.5.1.xml
+++ b/mcs/tools/xbuild/frameworks/net_4.5.1.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FileList  Name=".NET Framework 4.5.1" TargetFrameworkDirectory="..\..\..\..\4.5-api">
+<FileList  Name=".NET Framework 4.5.1" TargetFrameworkDirectory="..\..\..\..\4.5.1-api">
 </FileList>

--- a/mcs/tools/xbuild/frameworks/net_4.5.2.xml
+++ b/mcs/tools/xbuild/frameworks/net_4.5.2.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FileList  Name=".NET Framework 4.5.2" TargetFrameworkDirectory="..\..\..\..\4.5-api">
+<FileList  Name=".NET Framework 4.5.2" TargetFrameworkDirectory="..\..\..\..\4.5.2-api">
 </FileList>

--- a/mcs/tools/xbuild/frameworks/net_4.6.1.xml
+++ b/mcs/tools/xbuild/frameworks/net_4.6.1.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FileList  Name=".NET Framework 4.6.1" TargetFrameworkDirectory="..\..\..\..\4.5">
+<FileList  Name=".NET Framework 4.6.1" TargetFrameworkDirectory="..\..\..\..\4.6.1-api">
 </FileList>

--- a/mcs/tools/xbuild/frameworks/net_4.6.2.xml
+++ b/mcs/tools/xbuild/frameworks/net_4.6.2.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FileList  Name=".NET Framework 4.6.2" TargetFrameworkDirectory="..\..\..\..\4.5">
+<FileList  Name=".NET Framework 4.6.2" TargetFrameworkDirectory="..\..\..\..\4.6.2-api">
 </FileList>

--- a/mcs/tools/xbuild/frameworks/net_4.6.xml
+++ b/mcs/tools/xbuild/frameworks/net_4.6.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FileList  Name=".NET Framework 4.6" TargetFrameworkDirectory="..\..\..\..\4.5">
+<FileList  Name=".NET Framework 4.6" TargetFrameworkDirectory="..\..\..\..\4.6-api">
 </FileList>


### PR DESCRIPTION
This bumps the reference assemblies submodule so we can install the new assemblies (which were built from source).

@marek-safar could you please take a look if the mcs/mcs/ikvm.cs changes make sense?