### PR TITLE
Make monolite profile directory versioned

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,10 +44,6 @@ dist-hook:
 	rm -rf `find $(top_distdir)/external -path '*\.git'`
 	rm -f `find $(top_distdir)/external -path '*\.exe' -not -path '*/roslyn-binaries/*'`
 	rm -f `find $(top_distdir)/external -path '*\.dll' -not -path '*/binary-reference-assemblies/*' -not -path '*/roslyn-binaries/*'`
-	cp mcs/class/lib/basic/System.Configuration.dll mcs/class/lib/monolite/
-	cp mcs/class/lib/basic/System.Security.dll mcs/class/lib/monolite/
-# Disable this for now because it is very slow and causes wrench to timeout:
-#	test ! -d $(GIT_DIR) || ./scripts/commits-to-changelog.py --root=$(distdir) last-commit-with-compulsory-changelog-entry
 
 pkgconfigdir = $(libdir)/pkgconfig
 noinst_DATA = mono-uninstalled.pc
@@ -55,16 +51,13 @@ DISTCLEANFILES= mono-uninstalled.pc
 
 # building with monolite
 mcslib = $(mcs_topdir)/class/lib
-monolite = $(mcslib)/monolite
 monolite_url = https://download.mono-project.com/monolite/monolite-$(MONO_CORLIB_VERSION)-latest.tar.gz
 .PHONY: get-monolite-latest 
 get-monolite-latest:
-	-rm -fr $(mcslib)/monolite-*
-	-mkdir -p $(mcslib)
-	test ! -d $(monolite) || test ! -d $(monolite).old || rm -fr $(monolite).old
-	test ! -d $(monolite) || mv -f $(monolite) $(monolite).old
+	-rm -fr $(mcslib)/monolite/$(MONO_CORLIB_VERSION)
+	-mkdir -p $(mcslib)/monolite
 	cd $(mcslib) && { (wget -O- $(monolite_url) || curl -L $(monolite_url)) | gzip -d | tar xf - ; }
-	cd $(mcslib) && mv -f monolite-* monolite
+	cd $(mcslib) && mv -f monolite-* monolite/$(MONO_CORLIB_VERSION)
 
 if BITCODE
 BITCODE_CHECK=yes

--- a/mcs/build/profiles/basic.make
+++ b/mcs/build/profiles/basic.make
@@ -1,15 +1,17 @@
 # -*- makefile -*-
 
-with_mono_path_monolite = MONO_PATH="$(topdir)/class/lib/monolite$(PLATFORM_PATH_SEPARATOR)$(topdir)/class/lib/monolite/Facades$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH"
+monolite_path := $(topdir)/class/lib/monolite/$(MONO_CORLIB_VERSION)
+
+with_mono_path_monolite = MONO_PATH="$(monolite_path)$(PLATFORM_PATH_SEPARATOR)$(monolite_path)/Facades$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH"
 
 monolite_flag := $(depsdir)/use-monolite
 use_monolite := $(wildcard $(monolite_flag))
 
-MONOLITE_MSCORLIB = $(topdir)/class/lib/monolite/mscorlib.dll
+MONOLITE_MSCORLIB = $(monolite_path)/mscorlib.dll
 
 ifdef use_monolite
 ifdef MCS_MODE
-	CSC_LOCATION = $(topdir)/class/lib/monolite/mcs.exe
+	CSC_LOCATION = $(monolite_path)/mcs.exe
 endif
 
 PROFILE_RUNTIME = $(with_mono_path_monolite) $(RUNTIME)
@@ -79,8 +81,7 @@ do-profile-check: $(depsdir)/.stamp
 		$(MAKE) $(MAKE_Q) do-profile-check-monolite ; \
 	    else \
 		echo "*** The runtime '$(PROFILE_RUNTIME)' doesn't appear to be usable." 1>&2; \
-                echo "*** You need Mono version 4.8 or better installed to build MCS" 1>&2 ; \
-                echo "*** Check mono README for information on how to bootstrap a Mono installation." 1>&2 ; \
+                echo "*** Check README for information on how to bootstrap a Mono installation." 1>&2 ; \
 	        exit 1; fi; fi
 
 
@@ -89,7 +90,7 @@ ifdef use_monolite
 do-get-monolite:
 
 do-profile-check-monolite:
-	@echo "*** The contents of your 'monolite' directory may be out-of-date" 1>&2
+	@echo "*** The contents of your 'monolite/$(MONO_CORLIB_VERSION)' directory may be out-of-date" 1>&2
 	@echo "*** You may want to try 'make get-monolite-latest'" 1>&2
 	rm -f $(monolite_flag)
 	exit 1
@@ -97,12 +98,12 @@ do-profile-check-monolite:
 else
 
 do-get-monolite:
-	@echo "*** Downloading bootstrap required 'monolite'" 1>&2
+	@echo "*** Downloading bootstrap required 'monolite/$(MONO_CORLIB_VERSION)'" 1>&2
 	$(MAKE) $(MAKE_Q) -C $(mono_build_root) get-monolite-latest
 
 do-profile-check-monolite: $(depsdir)/.stamp
 	@echo "*** The runtime '$(PROFILE_RUNTIME)' doesn't appear to be usable." 1>&2
-	@echo "*** Trying the 'monolite' directory." 1>&2
+	@echo "*** Trying the 'monolite/$(MONO_CORLIB_VERSION)' directory." 1>&2
 	@echo dummy > $(monolite_flag)
 	$(MAKE) do-profile-check
 

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -391,7 +391,7 @@ all-local $(STD_TARGETS:=-local):
 
 all-local-aot:
 
-monolite_dir := monolite
+monolite_dir := monolite/$(MONO_CORLIB_VERSION)
 
 # Files needed to bootstrap C# compiler
 build_files = mscorlib.dll System.dll System.Xml.dll Mono.Security.dll System.Core.dll System.Security.dll System.Configuration.dll \


### PR DESCRIPTION
If you're building with monolite currently the build system checks for the existence of `mcs/class/lib/monolite` and just uses it in that case.

It becomes a problem when bumping corlib version since if you pull the update and try to build it'll use the old monolite and you'll hit the "corlib version not in sync" error.

By making the monolite directory include the version this can be avoided and everything works out of the box.

Also removed the confusing "You need Mono version 4.8 or better" message since we actually require a newer version in basic-profile-check.cs now and keeping them in sync is error prone.