### PR TITLE
[tests] Fix the mcs-compileall target in runtime/

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -121,32 +121,37 @@ cur_dir_cmd = pwd
 PLATFORM_PATH_SEPARATOR = :
 endif
 
+# assemblies which are excluded from testing in mcs-compileall below
+VERIFY_TESTS_FILTER =
+
+if HOST_WIN32
+# Mono.WebBrowser.dll fails to verify on Windows
+VERIFY_TESTS_FILTER += Mono.WebBrowser.dll
+endif
+
 if FULL_AOT_TESTS
 #  ILASM.exe has features which a testing_aot_full runtime will not support.
 #  It is invoked with an external mono when used in the runtime.
 #  We skip it here because otherwise it will fail to verify.
-FULL_AOT_TESTS_FILTER=grep -v ilasm
-else
-FULL_AOT_TESTS_FILTER=echo
+VERIFY_TESTS_FILTER += ilasm.exe
 endif
 
 # Compile all assemblies with the verifier turned on. Code must be valid but not verifiable.
 # TODO it would be nice to split assemblies without unsafe code to use the verifier with verifiable mode.
 # Skip binary_reference_assemblies because they contain metadata only
 mcs-compileall: mono-wrapper etc/mono/config
-	export verifiable_files=`ls "$(mcs_topdir)/class/lib/$$profile/" | grep -E '\.(dll|exe)$$' | $(FULL_AOT_TESTS_FILTER)` ; \
 	save_MONO_PATH=$$MONO_PATH; mcs_topdir=`cd $(mcs_topdir) && $(cur_dir_cmd)`; ok=:; \
 	for profile in $(test_profiles); do \
 	  if [ "binary_reference_assemblies" = "$$profile" ]; then \
           continue; \
-      fi; \
-	  if [ "xbuild_12" = "$$profile" ]; then \
+	  elif [ "xbuild_12" = "$$profile" ]; then \
 		  MONO_PATH="$$mcs_topdir/class/lib/$$profile$(PLATFORM_PATH_SEPARATOR)$$mcs_topdir/class/lib/net_4_x$(PLATFORM_PATH_SEPARATOR)$$save_MONO_PATH"; \
 	  elif [ "xbuild_14" = "$$profile" ]; then \
 		  MONO_PATH="$$mcs_topdir/class/lib/$$profile$(PLATFORM_PATH_SEPARATOR)$$mcs_topdir/class/lib/net_4_x$(PLATFORM_PATH_SEPARATOR)$$save_MONO_PATH"; \
 	  else \
 		  MONO_PATH="$$mcs_topdir/class/lib/$$profile$(PLATFORM_PATH_SEPARATOR)$$save_MONO_PATH"; \
 	  fi; \
+	  export verifiable_files=`ls "$(mcs_topdir)/class/lib/$$profile/" | grep -E '\.(dll|exe)$$' $(foreach asm,$(VERIFY_TESTS_FILTER), | grep -v $(asm))` ; \
 	  export MONO_PATH; \
 	  for stub in $$verifiable_files; do \
 	  i=$(mcs_topdir)/class/lib/$$profile/$$stub ; \


### PR DESCRIPTION
It is used as the "verify" step on Jenkins/Wrench and I noticed it didn't run recently.

Looks like it was broken a while ago by 695e8f53ae7d2139.
Moving the verifiable_files variable at the top is wrong since the $$profile variable is only defined inside the for loop and so we'd get an empty list.

When that was fixed it still didn't work as piping to `echo` doesn't work, we need to pipe to `cat` instead.