### PR TITLE
[runtime] Make mono_set_pending_exception public.

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -622,8 +622,6 @@ typedef struct {
 	void (*mono_clear_abort_threshold) (void);
 } MonoRuntimeExceptionHandlingCallbacks;
 
-MONO_COLD void mono_set_pending_exception (MonoException *exc);
-
 /* remoting and async support */
 
 MonoAsyncResult *

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -242,6 +242,9 @@ mono_monitor_exit            (MonoObject *obj);
 MONO_API void
 mono_raise_exception	    (MonoException *ex);
 
+MONO_API void
+mono_set_pending_exception  (MonoException *exc);
+
 MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_runtime_object_init    (MonoObject *this_obj);


### PR DESCRIPTION
Xamarin.Mac uses mono_set_pending_exception to convert Objective-C exceptions
to managed exceptions.