### PR TITLE
Fix bug in SessionStateModule when session data is deleted (bugzilla #54793)

### DIFF
--- a/mcs/class/System.Web/System.Web.SessionState_2.0/SessionStateModule.cs
+++ b/mcs/class/System.Web/System.Web.SessionState_2.0/SessionStateModule.cs
@@ -290,8 +290,8 @@ namespace System.Web.SessionState
 					handler.ResetItemTimeout (context, container.SessionID);
 				}
 				else {
-					handler.ReleaseItemExclusive (context, container.SessionID, storeLockId);
 					handler.RemoveItem (context, container.SessionID, storeLockId, storeData);
+					handler.ReleaseItemExclusive (context, container.SessionID, storeLockId);
 					if (supportsExpiration)
 						// Make sure the expiration handler is not called after we will have raised
 						// the session end event.


### PR DESCRIPTION
# Title
Fix bug in SessionStateModule (namespace: System.Web.SessionState) when session data is deleted

# Description
When the Session.Abandon() method is called, the session data is not deleted. I am using the Microsoft.Web.RedisSessionStateProvider provider.

The flow is as follows:
* In action controller I call the Session.Abandon() method
* In SessionStateModule class:
  * The property IsAbandoned is checked as true
  * When OnReleaseRequestState is called then session items will be deleted

**The problem is that the call to release is made before deleting resources.**

I have been reviewing the Microsoft documentation about the same class and it does not call the release method. [Doc. Microsoft](https://referencesource.microsoft.com/#System.Web/State/SessionStateModule.cs,70c779c55ecdc3d7,references)

# Web.config sessionState section
```xml
<sessionState mode="Custom" customProvider="SessionStateRedis">
      <providers>
        	<add name="SessionStateRedis"
             	  type="Microsoft.Web.Redis.RedisSessionStateProvider"
             	  connectionString="session-state-redis"/>
      </providers>
</sessionState>
```