### PR TITLE
Bump to 4.8.2.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 #AC_PREREQ([2.62])
 
 # when bumping version number below, keep it in sync with man/mono.1 too
-AC_INIT(mono, [4.8.1],
+AC_INIT(mono, [4.8.2],
         [http://bugzilla.xamarin.com/enter_bug.cgi?classification=Mono])
 
 AC_CONFIG_SRCDIR([README.md])


### PR DESCRIPTION
The new policy is to bump version on a branch when a version hits stable (to avoid forgetting to do it). 4.8.1 just hit stable, so...