### PR TITLE
[loader] Ignore public key token in strong name match, if requested framework assembly was remapped

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1138,16 +1138,6 @@ mono_assembly_remap_version (MonoAssemblyName *aname, MonoAssemblyName *dest_ana
 		dest_aname->minor = vset->minor;
 		dest_aname->build = vset->build;
 		dest_aname->revision = vset->revision;
-		if (current_runtime->public_key_token != NULL &&
-		    dest_aname->public_key_token [0] != 0 &&
-		    !mono_public_tokens_are_equal (dest_aname->public_key_token, (const mono_byte *)current_runtime->public_key_token)) {
-			mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_ASSEMBLY,
-				    "The request for assembly name '%s' with PublicKeyToken=%s was remapped to PublicKeyToken=%s",
-				    dest_aname->name,
-				    dest_aname->public_key_token,
-				    current_runtime->public_key_token);
-			memcpy (dest_aname->public_key_token, current_runtime->public_key_token, MONO_PUBLIC_KEY_TOKEN_LENGTH);
-		}
 		if (vmap->new_assembly_name != NULL) {
 			dest_aname->name = vmap->new_assembly_name;
 			mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_ASSEMBLY,

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -428,7 +428,6 @@ typedef struct  {
 typedef struct  {
 	const char runtime_version [12];
 	const char framework_version [4];
-	const char *public_key_token;
 	const AssemblyVersionSet version_sets [5];
 } MonoRuntimeInfo;
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -99,9 +99,9 @@ static const MonoRuntimeInfo *current_runtime = NULL;
 /* This is the list of runtime versions supported by this JIT.
  */
 static const MonoRuntimeInfo supported_runtimes[] = {
-	{"v4.0.30319","4.5",               NULL, { {4,0,0,0}, {10,0,0,0}, {4,0,0,0}, {4,0,0,0}, {4,0,0,0} } },
-	{"mobile",    "2.1", "7cec85d7bea7798e", { {2,0,5,0}, {10,0,0,0}, {2,0,5,0}, {2,0,5,0}, {4,0,0,0} } },
-	{"moonlight", "2.1",               NULL, { {2,0,5,0}, { 9,0,0,0}, {3,5,0,0}, {3,0,0,0}, NOT_AVAIL } },
+	{"v4.0.30319","4.5", { {4,0,0,0}, {10,0,0,0}, {4,0,0,0}, {4,0,0,0}, {4,0,0,0} } },
+	{"mobile",    "2.1", { {2,0,5,0}, {10,0,0,0}, {2,0,5,0}, {2,0,5,0}, {4,0,0,0} } },
+	{"moonlight", "2.1", { {2,0,5,0}, { 9,0,0,0}, {3,5,0,0}, {3,0,0,0}, NOT_AVAIL } },
 };
 
 #undef NOT_AVAIL


### PR DESCRIPTION
This is followup work for [Bugzilla 49721](https://bugzilla.xamarin.com/show_bug.cgi?id=49721#c3)

When framework assemblies are compiled for the mobile runtime, they are generally signed with a different key than the normal desktop one. Unfortunately each assembly has different logic for which key is used (typically silverlight.pub or corefx.pub in place of ecma.pub), and short of hardcoding a table in the runtime, there's no good way to know.

This reverts commit af7195e (which hardcoded a single remapped key for the mobile runtime version in a mistaken belief that one key is enough).

(This is the `master` version of the same PR as #4679)