### PR TITLE
[corlib] Use AppContextSwitches implementation from RS. Fixes #54448

### DIFF
--- a/mcs/class/corlib/ReferenceSources/AppContextDefaultValues.cs
+++ b/mcs/class/corlib/ReferenceSources/AppContextDefaultValues.cs
@@ -13,8 +13,6 @@ namespace System
 		internal const string SwitchSetActorAsReferenceWhenCopyingClaimsIdentity = "Switch.System.Security.ClaimsIdentity.SetActorAsReferenceWhenCopyingClaimsIdentity";
 
 		public static void PopulateDefaultValues () {
-			//Defaults from mono 5.0
-			AppContext.DefineSwitchDefault (SwitchThrowExceptionIfDisposedCancellationTokenSource, true);
 		}
 
 		//TODO Use the values in app.config

--- a/mcs/class/corlib/ReferenceSources/AppContextDefaultValues.cs
+++ b/mcs/class/corlib/ReferenceSources/AppContextDefaultValues.cs
@@ -1,23 +1,30 @@
 using System;
 
-
 namespace System
 {
-    internal static class AppContextDefaultValues
-    {
-        internal static readonly string SwitchNoAsyncCurrentCulture = "Switch.System.Globalization.NoAsyncCurrentCulture";
-        internal static readonly string SwitchThrowExceptionIfDisposedCancellationTokenSource = "Switch.System.Threading.ThrowExceptionIfDisposedCancellationTokenSource";
-        internal static readonly string SwitchPreserveEventListnerObjectIdentity = "Switch.System.Diagnostics.EventSource.PreserveEventListnerObjectIdentity";
-        internal static readonly string SwitchUseLegacyPathHandling = "Switch.System.IO.UseLegacyPathHandling";
-        internal static readonly string SwitchBlockLongPaths = "Switch.System.IO.BlockLongPaths";
-        internal static readonly string SwitchDoNotAddrOfCspParentWindowHandle = "Switch.System.Security.Cryptography.DoNotAddrOfCspParentWindowHandle";
-        internal static readonly string SwitchSetActorAsReferenceWhenCopyingClaimsIdentity = "Switch.System.Security.ClaimsIdentity.SetActorAsReferenceWhenCopyingClaimsIdentity";
+	internal static class AppContextDefaultValues
+	{
+		internal const string SwitchNoAsyncCurrentCulture = "Switch.System.Globalization.NoAsyncCurrentCulture";
+		internal const string SwitchThrowExceptionIfDisposedCancellationTokenSource = "Switch.System.Threading.ThrowExceptionIfDisposedCancellationTokenSource";
+		internal const string SwitchPreserveEventListnerObjectIdentity = "Switch.System.Diagnostics.EventSource.PreserveEventListnerObjectIdentity";
+		internal const string SwitchUseLegacyPathHandling = "Switch.System.IO.UseLegacyPathHandling";
+		internal const string SwitchBlockLongPaths = "Switch.System.IO.BlockLongPaths";
+		internal const string SwitchDoNotAddrOfCspParentWindowHandle = "Switch.System.Security.Cryptography.DoNotAddrOfCspParentWindowHandle";
+		internal const string SwitchSetActorAsReferenceWhenCopyingClaimsIdentity = "Switch.System.Security.ClaimsIdentity.SetActorAsReferenceWhenCopyingClaimsIdentity";
 
-		static AppContextDefaultValues () {
+		public static void PopulateDefaultValues () {
 			//Defaults from mono 5.0
 			AppContext.DefineSwitchDefault (SwitchThrowExceptionIfDisposedCancellationTokenSource, true);
-			AppContext.DefineSwitchDefault (SwitchSetActorAsReferenceWhenCopyingClaimsIdentity, false);
-			AppContext.DefineSwitchDefault (SwitchNoAsyncCurrentCulture, false);
 		}
-    }
+
+		//TODO Use the values in app.config
+		public static bool TryGetSwitchOverride (string switchName, out bool overrideValue)
+		{
+			// The default value for a switch is 'false'
+			overrideValue = false;
+
+			return false;
+		}
+	}
 }
+

--- a/mcs/class/corlib/ReferenceSources/AppContextDefaultValues.cs
+++ b/mcs/class/corlib/ReferenceSources/AppContextDefaultValues.cs
@@ -1,0 +1,23 @@
+using System;
+
+
+namespace System
+{
+    internal static class AppContextDefaultValues
+    {
+        internal static readonly string SwitchNoAsyncCurrentCulture = "Switch.System.Globalization.NoAsyncCurrentCulture";
+        internal static readonly string SwitchThrowExceptionIfDisposedCancellationTokenSource = "Switch.System.Threading.ThrowExceptionIfDisposedCancellationTokenSource";
+        internal static readonly string SwitchPreserveEventListnerObjectIdentity = "Switch.System.Diagnostics.EventSource.PreserveEventListnerObjectIdentity";
+        internal static readonly string SwitchUseLegacyPathHandling = "Switch.System.IO.UseLegacyPathHandling";
+        internal static readonly string SwitchBlockLongPaths = "Switch.System.IO.BlockLongPaths";
+        internal static readonly string SwitchDoNotAddrOfCspParentWindowHandle = "Switch.System.Security.Cryptography.DoNotAddrOfCspParentWindowHandle";
+        internal static readonly string SwitchSetActorAsReferenceWhenCopyingClaimsIdentity = "Switch.System.Security.ClaimsIdentity.SetActorAsReferenceWhenCopyingClaimsIdentity";
+
+		static AppContextDefaultValues () {
+			//Defaults from mono 5.0
+			AppContext.DefineSwitchDefault (SwitchThrowExceptionIfDisposedCancellationTokenSource, true);
+			AppContext.DefineSwitchDefault (SwitchSetActorAsReferenceWhenCopyingClaimsIdentity, false);
+			AppContext.DefineSwitchDefault (SwitchNoAsyncCurrentCulture, false);
+		}
+    }
+}

--- a/mcs/class/corlib/ReferenceSources/AppContextSwitches.cs
+++ b/mcs/class/corlib/ReferenceSources/AppContextSwitches.cs
@@ -1,7 +1,0 @@
-namespace System {
-	static class AppContextSwitches {
-		public static readonly bool ThrowExceptionIfDisposedCancellationTokenSource = true;
-		public static readonly bool SetActorAsReferenceWhenCopyingClaimsIdentity = false;
-		public static readonly bool NoAsyncCurrentCulture = false;
-	}
-}

--- a/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
@@ -325,10 +325,14 @@ namespace MonoTests.System.Threading
 			} catch (ObjectDisposedException) {
 			}
 
-			try {
-				token.Register (() => { });
-				Assert.Fail ("#3");
-			} catch (ObjectDisposedException) {
+			bool throwOnDispose = false;
+			AppContext.TryGetSwitch ("Switch.System.Threading.ThrowExceptionIfDisposedCancellationTokenSource", out throwOnDispose);
+			if (throwOnDispose) { 
+				try {
+					token.Register (() => { });
+					Assert.Fail ("#3");
+				} catch (ObjectDisposedException) {
+				}
 			}
 
 			try {
@@ -337,10 +341,12 @@ namespace MonoTests.System.Threading
 			} catch (ObjectDisposedException) {
 			}
 
-			try {
-				CancellationTokenSource.CreateLinkedTokenSource (token);
-				Assert.Fail ("#5");
-			} catch (ObjectDisposedException) {
+			if (throwOnDispose) {
+				try {
+					CancellationTokenSource.CreateLinkedTokenSource (token);
+					Assert.Fail ("#5");
+				} catch (ObjectDisposedException) {
+				}
 			}
 
 			try {

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -871,7 +871,6 @@ System.Threading.Tasks/DecoupledTask.cs
 ../Mono.Parallel/Mono.Threading/AtomicBoolean.cs
 
 ReferenceSources/__ConsoleStream.cs
-ReferenceSources/AppContextSwitches.cs
 ReferenceSources/Array.cs
 ReferenceSources/BCLDebug.cs
 ReferenceSources/CalendarData.cs
@@ -1054,6 +1053,8 @@ ReferenceSources/Type.cs
 ../referencesource/mscorlib/system/version.cs
 
 ../referencesource/mscorlib/system/AppContext/AppContext.cs
+../referencesource/mscorlib/system/AppContext/AppContextSwitches.cs
+ReferenceSources/AppContextDefaultValues.cs
 
 ../referencesource/mscorlib/system/collections/arraylist.cs
 ../referencesource/mscorlib/system/collections/bitarray.cs

--- a/mcs/class/referencesource/mscorlib/system/AppContext/AppContext.cs
+++ b/mcs/class/referencesource/mscorlib/system/AppContext/AppContext.cs
@@ -79,10 +79,8 @@ namespace System
             {
                 if (s_defaultsInitialized == false)
                 {
-#if !MONO
                     // populate the AppContext with the default set of values
                     AppContextDefaultValues.PopulateDefaultValues();
-#endif
                     s_defaultsInitialized = true;
                 }
             }
@@ -142,7 +140,6 @@ namespace System
                     {
                         return true;
                     }
-#if !MONO
                     // 3. The switch has a valid value, but we need to check for overrides.
                     // Regardless of whether or not the switch has an override, we need to update the value to reflect
                     // the fact that we checked for overrides. 
@@ -152,7 +149,6 @@ namespace System
                         // we found an override!
                         isEnabled = overrideValue;
                     }
-#endif
                     // Update the switch in the dictionary to mark it as 'checked for override'
                     s_switchMap[switchName] = (isEnabled ? SwitchValueState.HasTrueValue : SwitchValueState.HasFalseValue)
                                                 | SwitchValueState.HasLookedForOverride;
@@ -172,7 +168,6 @@ namespace System
                     //    In this case, we want to capture the fact that we looked for a value and found nothing by adding 
                     //    an entry in the dictionary with the 'sentinel' value of 'SwitchValueState.UnknownValue'.
                     //    Example: This will prevent us from trying to find overrides for values that we don't have in the dictionary
-#if !MONO
                     // 1. The value has an override specified.
                     bool overrideValue;
                     if (AppContextDefaultValues.TryGetSwitchOverride(switchName, out overrideValue))
@@ -185,7 +180,6 @@ namespace System
 
                         return true;
                     }
-#endif
                     // 2. The value does not have an override.
                     s_switchMap[switchName] = SwitchValueState.UnknownValue;
                 }

--- a/mcs/class/referencesource/mscorlib/system/AppContext/AppContextSwitches.cs
+++ b/mcs/class/referencesource/mscorlib/system/AppContext/AppContextSwitches.cs
@@ -12,7 +12,7 @@ namespace System
     internal static class AppContextSwitches
     {
 #if MOBILE
-		public static readonly bool ThrowExceptionIfDisposedCancellationTokenSource = true;
+		public static readonly bool ThrowExceptionIfDisposedCancellationTokenSource = false;
 		public static readonly bool SetActorAsReferenceWhenCopyingClaimsIdentity = false;
 		public static readonly bool NoAsyncCurrentCulture = false;
 #else

--- a/mcs/class/referencesource/mscorlib/system/AppContext/AppContextSwitches.cs
+++ b/mcs/class/referencesource/mscorlib/system/AppContext/AppContextSwitches.cs
@@ -11,6 +11,11 @@ namespace System
 
     internal static class AppContextSwitches
     {
+#if MOBILE
+		public static readonly bool ThrowExceptionIfDisposedCancellationTokenSource = true;
+		public static readonly bool SetActorAsReferenceWhenCopyingClaimsIdentity = false;
+		public static readonly bool NoAsyncCurrentCulture = false;
+#else
         private static int _noAsyncCurrentCulture;
         public static bool NoAsyncCurrentCulture
         {
@@ -130,5 +135,6 @@ namespace System
             switchValue = isSwitchEnabled ? 1 /*true*/ : -1 /*false*/;
             return isSwitchEnabled;
         }
+#endif
     }
 }


### PR DESCRIPTION
This change makes AppContextSwitches usable which allow backwards incompatible settings to be actually toggled.