### PR TITLE
[btls]: Cleanup certificate store initialization

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // MonoTlsSettings.cs
 //
 // Author:
@@ -62,6 +62,13 @@ namespace Mono.Security.Interface
 		public bool CallbackNeedsCertificateChain {
 			get { return callbackNeedsChain; }
 			set { callbackNeedsChain = value; }
+		}
+
+		/*
+		 * Use custom time for certificate expiration checks
+		 */
+		public DateTime? CertificateValidationTime {
+			get; set;
 		}
 
 		/*
@@ -165,6 +172,7 @@ namespace Mono.Security.Interface
 			UserSettings = other.UserSettings;
 			EnabledProtocols = other.EnabledProtocols;
 			EnabledCiphers = other.EnabledCiphers;
+			CertificateValidationTime = other.CertificateValidationTime;
 			if (other.TrustAnchors != null)
 				TrustAnchors = new X509CertificateCollection (other.TrustAnchors);
 			if (other.CertificateSearchPaths != null) {

--- a/mcs/class/System/Mono.AppleTls/AppleCertificateHelper.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleCertificateHelper.cs
@@ -139,6 +139,12 @@ namespace Mono.AppleTls
 				trust.SetAnchorCertificatesOnly (false);
 			}
 
+			if (validator.Settings.CertificateValidationTime != null) {
+				var status = trust.SetVerifyDate (validator.Settings.CertificateValidationTime.Value);
+				if (status != SecStatusCode.Success)
+					throw new InvalidOperationException (status.ToString ());
+			}
+
 			var result = trust.Evaluate ();
 			if (result == SecTrustResult.Unspecified)
 				return true;

--- a/mcs/class/System/Mono.AppleTls/AppleCertificateHelper.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleCertificateHelper.cs
@@ -36,7 +36,7 @@ namespace Mono.AppleTls
 			 */
 			var certificate2 = certificate as X509Certificate2;
 			if (certificate2 != null)
-				return SecIdentity.Import (certificate2);
+				return SecImportExport.ItemImport (certificate2);
 
 			/*
 			 * Reading Certificates from the Mac Keychain

--- a/mcs/class/System/Mono.AppleTls/Trust.cs
+++ b/mcs/class/System/Mono.AppleTls/Trust.cs
@@ -159,6 +159,15 @@ namespace Mono.AppleTls {
 			return SecTrustSetAnchorCertificatesOnly (handle, anchorCertificatesOnly);
 		}
 
+		[DllImport (AppleTlsContext.SecurityLibrary)]
+		extern static SecStatusCode /* OSStatus */ SecTrustSetVerifyDate (IntPtr /* SecTrustRef */ trust, IntPtr /* CFDateRef */ date);
+
+		public SecStatusCode SetVerifyDate (DateTime date)
+		{
+			using (var nativeDate = CFDate.Create (date))
+				return SecTrustSetVerifyDate (handle, nativeDate.Handle);
+		}
+
 		~SecTrust ()
 		{
 			Dispose (false);

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -234,7 +234,7 @@ namespace Mono.Btls
 			if (!IsServer)
 				ctx.SetSelectCallback (SelectCallback);
 
-			ctx.SetVerifyParam (MonoBtlsProvider.GetVerifyParam (ServerName, IsServer));
+			ctx.SetVerifyParam (MonoBtlsProvider.GetVerifyParam (Settings, ServerName, IsServer));
 
 			TlsProtocolCode minProtocol, maxProtocol;
 			GetProtocolVersions (out minProtocol, out maxProtocol);

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509Store.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509Store.cs
@@ -24,12 +24,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 #if SECURITY_DEP && MONO_FEATURE_BTLS
+#if MONO_SECURITY_ALIAS
+extern alias MonoSecurity;
+#endif
 using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
+
+#if MONO_SECURITY_ALIAS
+using MonoSecurity::Mono.Security.Interface;
+#else
+using Mono.Security.Interface;
+#endif
 
 namespace Mono.Btls
 {
@@ -159,7 +168,7 @@ namespace Mono.Btls
 
 		internal void AddTrustedRoots ()
 		{
-			MonoBtlsProvider.SetupCertificateStore (this);
+			MonoBtlsProvider.SetupCertificateStore (this, MonoTlsSettings.DefaultSettings, false);
 		}
 
 		public MonoBtlsX509Lookup AddLookup (MonoBtlsX509LookupType type)

--- a/mcs/class/System/System.Net/MacProxy.cs
+++ b/mcs/class/System/System.Net/MacProxy.cs
@@ -1341,4 +1341,54 @@ namespace Mono.Net
 		}
 	}
 
+	internal class CFDate : INativeObject, IDisposable {
+		IntPtr handle;
+
+		internal CFDate (IntPtr handle, bool owns)
+		{
+			this.handle = handle;
+			if (!owns)
+				CFObject.CFRetain (handle);
+		}
+
+		~CFDate ()
+		{
+			Dispose (false);
+		}
+
+		[DllImport (CFObject.CoreFoundationLibrary)]
+		extern static IntPtr CFDateCreate (IntPtr allocator, /* CFAbsoluteTime */ double at);
+
+		public static CFDate Create (DateTime date)
+		{
+			var referenceTime = new DateTime (2001, 1, 1);
+			var difference = (date - referenceTime).TotalSeconds;
+			var handle = CFDateCreate (IntPtr.Zero, difference);
+			if (handle == IntPtr.Zero)
+				throw new NotSupportedException ();
+			return new CFDate (handle, true);
+		}
+
+		public IntPtr Handle {
+			get {
+				return handle;
+			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if (handle != IntPtr.Zero) {
+				CFObject.CFRelease (handle);
+				handle = IntPtr.Zero;
+			}
+		}
+
+	}
+
 }


### PR DESCRIPTION
* Kill unused MonoBtlsX509Store.AddTrustedRoots().

* In server-mode, MonoBtlsProvider.SetupCertificateStore() now only adds
  certificates explicitly trused via MonoTlsSettings.TrustAnchors.

* MonoTlsProvider.ValidateCertificate() - which is called from
  X509Certificate2.Verify() via X509CertificateImplBtls.Verify() - now
  uses MonoTlsSettings.DefaultSettings and assumes client-mode.

* Add new MonoTlsSettings.CertificateValidationTime property to allow
  setting a custom time for certificate expiration checks.