### PR TITLE
Bug 55148 - Debugger checks type which is possibly never used

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4698,21 +4698,16 @@ get_this_async_id (StackFrame *frame)
 	return get_objid (get_this (frame));
 }
 
-static MonoMethod* set_notification_method_cache = NULL;
-
 static MonoMethod*
-get_set_notification_method ()
+get_set_notification_method (MonoClass* async_builder_class)
 {
-	if(set_notification_method_cache != NULL)
-		return set_notification_method_cache;
 	MonoError error;
-	MonoClass* async_builder_class = mono_class_load_from_name (mono_defaults.corlib, "System.Runtime.CompilerServices", "AsyncTaskMethodBuilder");
 	GPtrArray* array = mono_class_get_methods_by_name (async_builder_class, "SetNotificationForWaitCompletion", 0x24, FALSE, FALSE, &error);
 	mono_error_assert_ok (&error);
 	g_assert (array->len == 1);
-	set_notification_method_cache = (MonoMethod *)g_ptr_array_index (array, 0);
+	MonoMethod* set_notification_method = (MonoMethod *)g_ptr_array_index (array, 0);
 	g_ptr_array_free (array, TRUE);
-	return set_notification_method_cache;
+	return set_notification_method;
 }
 
 static void
@@ -4731,7 +4726,7 @@ set_set_notification_for_wait_completion_flag (StackFrame *frame)
 	void* args [1];
 	gboolean arg = TRUE;
 	args [0] = &arg;
-	mono_runtime_invoke_checked (get_set_notification_method(), mono_object_unbox (builder), args, &error);
+	mono_runtime_invoke_checked (get_set_notification_method (builder->vtable->klass), mono_object_unbox (builder), args, &error);
 	mono_error_assert_ok (&error);
 	mono_field_set_value (obj, builder_field, mono_object_unbox (builder));
 }


### PR DESCRIPTION
I removed caching since it would make code complicated with changing builder class + method is called relatively rarely.

I will port to master & 2017-04, once its accepted here.