### PR TITLE
Fix InternalsVisibleTo being case-sensitive & fix internal access checks not applying to constructors

### DIFF
--- a/mcs/mcs/import.cs
+++ b/mcs/mcs/import.cs
@@ -1706,7 +1706,7 @@ namespace Mono.CSharp
 				token = null;
 
 			foreach (var internals in internals_visible_to) {
-				if (internals.Name != assembly.Name)
+				if (!String.Equals(internals.Name, assembly.Name, StringComparison.OrdinalIgnoreCase))
 					continue;
 
 				if (token == null && assembly is AssemblyDefinition) {

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -10025,7 +10025,7 @@ can_access_internals (MonoAssembly *accessing, MonoAssembly* accessed)
 		/* Be conservative with checks */
 		if (!friend_->name)
 			continue;
-		if (strcmp (accessing->aname.name, friend_->name))
+		if (g_ascii_strcasecmp (accessing->aname.name, friend_->name))
 			continue;
 		if (friend_->public_key_token [0]) {
 			if (!accessing->aname.public_key_token [0])

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -10199,6 +10199,20 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				TYPE_LOAD_ERROR (cmethod->klass);
 
 			context_used = mini_method_check_context_used (cfg, cmethod);
+					
+			if (!dont_verify && !cfg->skip_visibility) {
+				MonoMethod *cil_method = cmethod;
+				MonoMethod *target_method = cil_method;
+
+				if (method->is_inflated) {
+					target_method = mini_get_method_allow_open (method, token, NULL, &(mono_method_get_generic_container (method_definition)->context), &cfg->error);
+					CHECK_CFG_ERROR;
+				}
+				
+				if (!mono_method_can_access_method (method_definition, target_method) &&
+					!mono_method_can_access_method (method, cil_method))
+					emit_method_access_failure (cfg, method, cil_method);
+			}
 
 			if (mono_security_core_clr_enabled ())
 				ensure_method_is_allowed_to_call_method (cfg, method, cmethod);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -15,6 +15,7 @@ check-local:
 	$(MAKE) test-appdomain-unload || ok=false; \
 	$(MAKE) test-process-stress || ok=false; \
 	$(MAKE) test-pedump || ok=false; \
+	$(MAKE) test-internalsvisibleto || ok=false; \
 	$(MAKE) rm-empty-logs || ok=false; \
 	$(MAKE) runtest-gac-loading || ok=false; \
 	$$ok
@@ -2099,5 +2100,21 @@ libtest_la_LDFLAGS = -rpath `pwd`
 endif
 libtest_la_SOURCES = libtest.c
 libtest_la_LIBADD = $(GLIB_LIBS) $(LIBICONV)
+
+test-internalsvisibleto: internalsvisibleto-runtimetest.exe internalsvisibleto-compilertest.exe internalsvisibleto-library.dll
+	$(Q) $(RUNTIME) internalsvisibleto-runtimetest.exe 1>internalsvisibleto-runtimetest.exe.stdout 2>internalsvisibleto-runtimetest.exe.stderr
+	$(Q) $(RUNTIME) internalsvisibleto-compilertest.exe 1>internalsvisibleto-compilertest.exe.stdout 2>internalsvisibleto-compilertest.exe.stderr
+
+internalsvisibleto-runtimetest.exe: internalsvisibleto-runtimetest.cs internalsvisibleto-library.cs
+	$(Q) $(MCS) -out:internalsvisibleto-correctcase.dll -target:library -d:CORRECT_CASE -d:PERMISSIVE internalsvisibleto-library.cs	
+	$(Q) $(MCS) -out:internalsvisibleto-wrongcase.dll -target:library -d:WRONG_CASE -d:PERMISSIVE internalsvisibleto-library.cs
+	$(Q) $(MCS) -out:internalsvisibleto-runtimetest.exe -warn:0 -r:internalsvisibleto-correctcase.dll -r:internalsvisibleto-wrongcase.dll internalsvisibleto-runtimetest.cs
+	$(Q) $(MCS) -out:internalsvisibleto-correctcase.dll -target:library -d:CORRECT_CASE internalsvisibleto-library.cs	
+	$(Q) $(MCS) -out:internalsvisibleto-wrongcase.dll -target:library -d:WRONG_CASE internalsvisibleto-library.cs
+
+internalsvisibleto-compilertest.exe: internalsvisibleto-compilertest.cs internalsvisibleto-library.cs
+	$(Q) $(MCS) -out:internalsvisibleto-correctcase-2.dll -target:library -d:CORRECT_CASE internalsvisibleto-library.cs	
+	$(Q) $(MCS) -out:internalsvisibleto-wrongcase-2.dll -target:library -d:WRONG_CASE internalsvisibleto-library.cs
+	$(Q) $(MCS) -out:internalsvisibleto-compilertest.exe -warn:0 -r:internalsvisibleto-correctcase-2.dll -r:internalsvisibleto-wrongcase-2.dll internalsvisibleto-compilertest.cs
 
 CLEANFILES = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat

--- a/mono/tests/internalsvisibleto-compilertest.cs
+++ b/mono/tests/internalsvisibleto-compilertest.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace InternalsVisibleTo {
+    class Program {
+        static void Main (string[] args) {
+            var failCount = 0;
+
+            Console.WriteLine("-- Correct case --");
+
+            try {
+                var a = new CorrectCaseFriendAssembly.InternalClass(@internal: 0);
+                Console.WriteLine("Access internal class internal ctor: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal ctor: Fail");
+            }
+
+            Console.WriteLine("-- Wrong case --");
+
+            try {
+                var a = new WrongCaseFriendAssembly.InternalClass(@internal: 0);
+                Console.WriteLine("Access internal class internal ctor: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal ctor: Fail");
+            }
+
+            try {
+                // This also works in the Windows CLR. Huh.
+                WrongCaseFriendAssembly.InternalClass.PrivateStaticMethod();
+                Console.WriteLine("Access friend private static method: OK");
+            } catch (MemberAccessException) {
+                Console.WriteLine("Access friend private static method: Fail");
+                failCount += 1;
+            }
+
+            try {
+                WrongCaseFriendAssembly.InternalClass.InternalStaticMethod();
+                Console.WriteLine("Access friend internal static method: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal static method: Fail");
+            }
+
+            try {
+                WrongCaseFriendAssembly.PublicClass.InternalStaticMethod();
+                Console.WriteLine("Access public internal static method: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access public internal static method: Fail");
+            }
+
+            if (System.Diagnostics.Debugger.IsAttached)
+                Console.ReadLine();
+
+            Console.WriteLine("Incorrect results: {0}", failCount);
+            Environment.ExitCode = failCount;
+        }
+    }
+}

--- a/mono/tests/internalsvisibleto-library.cs
+++ b/mono/tests/internalsvisibleto-library.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+#if CORRECT_CASE
+[assembly: InternalsVisibleTo("internalsvisibleto-runtimetest")]
+[assembly: InternalsVisibleTo("internalsvisibleto-compilertest")]
+#else
+[assembly: InternalsVisibleTo("iNtErnAlsVisibLETo-RUntimeTesT")]
+[assembly: InternalsVisibleTo("iNtErnAlsVisibLETo-COmpilerTesT")]
+#endif
+
+#if CORRECT_CASE
+namespace CorrectCaseFriendAssembly {
+#else
+namespace WrongCaseFriendAssembly {
+#endif
+
+#if PERMISSIVE
+    public
+#else
+    internal 
+#endif
+     class InternalClass
+    {
+        public InternalClass (char @public) {
+            Console.WriteLine("InternalClass(public)");
+        }
+
+#if PERMISSIVE
+        public
+#else
+        internal 
+#endif
+         InternalClass (int @internal) {
+            Console.WriteLine("InternalClass(internal)");
+        }
+
+#if PERMISSIVE
+        public
+#else
+        private
+#endif
+         InternalClass (bool @private) {
+            Console.WriteLine("InternalClass(private)");
+        }
+
+        public static void PrivateStaticMethod () {
+            Console.WriteLine("InternalClass.PrivateStaticMethod");
+        }
+
+#if PERMISSIVE
+        public
+#else
+        internal 
+#endif
+         static void InternalStaticMethod () {
+            Console.WriteLine("InternalClass.InternalStaticMethod");
+        }
+
+#if PERMISSIVE
+        public
+#else
+        internal 
+#endif
+         void InternalMethod () {
+            Console.WriteLine("InternalClass.InternalMethod");
+        }
+
+        public static void PublicStaticMethod () {
+            Console.WriteLine("PublicStaticMethod");
+        }
+
+        public void PublicMethod () {
+            Console.WriteLine("PublicMethod");
+        }
+    }
+
+    public class PublicClass {
+
+#if PERMISSIVE
+        public
+#else
+        internal 
+#endif
+         PublicClass () {
+        }
+
+#if PERMISSIVE
+        public
+#else
+        internal 
+#endif
+         static void InternalStaticMethod () {
+            Console.WriteLine("PublicClass.InternalStaticMethod");
+        }
+
+#if PERMISSIVE
+        public
+#else
+        internal 
+#endif
+         void InternalMethod () {
+            Console.WriteLine("PublicClass.InternalMethod");
+        }
+    }
+}

--- a/mono/tests/internalsvisibleto-runtimetest.cs
+++ b/mono/tests/internalsvisibleto-runtimetest.cs
@@ -1,0 +1,100 @@
+﻿using System;
+
+namespace InternalsVisibleTo {
+    class Program {
+        static void Main (string[] args) {
+            var failCount = 0;
+
+            Console.WriteLine("-- Correct case --");
+
+            try {
+                var a = new CorrectCaseFriendAssembly.InternalClass(@private: false);
+                Console.WriteLine("Access internal class private ctor: OK");
+                // Microsoft behaves this way
+            } catch (MemberAccessException) {
+                Console.WriteLine("Access internal class private ctor: Fail");
+                // FIXME: Mono behaves this way
+                // failCount += 1;
+            }
+
+            try {
+                var a = new CorrectCaseFriendAssembly.InternalClass(@internal: 0);
+                Console.WriteLine("Access internal class internal ctor: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal ctor: Fail");
+            }
+
+            try {
+                var b = new CorrectCaseFriendAssembly.InternalClass(@public: 'a');
+                Console.WriteLine("Access internal class public ctor: OK");
+                b.InternalMethod();
+                Console.WriteLine("Access friend internal method: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal method with wrong case: Fail");
+            }
+
+            Console.WriteLine("-- Wrong case --");
+
+            try {
+                var a = new WrongCaseFriendAssembly.InternalClass(@private: false);
+                // Microsoft behaves this way
+                Console.WriteLine("Access internal class private ctor: OK");
+            } catch (MemberAccessException) {
+                // FIXME: Mono behaves this way
+                Console.WriteLine("Access internal class private ctor: Fail");
+                // failCount += 1;
+            }
+
+            try {
+                var a = new WrongCaseFriendAssembly.InternalClass(@internal: 0);
+                Console.WriteLine("Access internal class internal ctor: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal ctor: Fail");
+            }
+
+            try {
+                var b = new WrongCaseFriendAssembly.InternalClass(@public: 'a');
+                Console.WriteLine("Access internal class public ctor: OK");
+                b.InternalMethod();
+                Console.WriteLine("Access friend internal method: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal method: Fail");
+            }
+
+            try {
+                // Surprisingly this works in the Windows CLR, even though it seems like it shouldn't
+                WrongCaseFriendAssembly.InternalClass.PrivateStaticMethod();
+                Console.WriteLine("Access friend private static method: OK");
+            } catch (MemberAccessException) {
+                Console.WriteLine("Access friend private static method: Fail");
+                failCount += 1;
+            }
+
+            try {
+                WrongCaseFriendAssembly.InternalClass.InternalStaticMethod();
+                Console.WriteLine("Access friend internal static method: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access friend internal static method: Fail");
+            }
+
+            try {
+                WrongCaseFriendAssembly.PublicClass.InternalStaticMethod();
+                Console.WriteLine("Access public internal static method: OK");
+            } catch (MemberAccessException) {
+                failCount += 1;
+                Console.WriteLine("Access public internal static method: Fail");
+            }
+
+            if (System.Diagnostics.Debugger.IsAttached)
+                Console.ReadLine();
+
+            Console.WriteLine("Incorrect results: {0}", failCount);
+            Environment.ExitCode = failCount;
+        }
+    }
+}


### PR DESCRIPTION
Presently on Windows the Microsoft CLR ignores case when checking InternalsVisibleTo attributes against the currently executing assembly. Roslyn matches this behavior.
On the other hand, mono and mcs both treat this attribute as case-sensitive.

This PR changes mcs & the mono runtime to use case insensitive comparisons when matching the attributes so that behavior matches the MS CLR.

This PR also fixes a bug in the JIT where internal access checks were not being performed for constructor invocations (NEWOBJ), only method invocations.

PR still preliminary/draft quality so happy to revise based on feedback.