### PR TITLE
Remove the use of ExpectedException in Mono.Posix Tests

### DIFF
--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Native/RealTimeSignumTests.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Native/RealTimeSignumTests.cs
@@ -25,10 +25,10 @@ namespace MonoTests.Mono.Unix.Native {
 		[Test]
 		public void TestRealTimeOutOfRange ()
 		{
-			Assert.Throws<ArgumentOutOfRangeException> (() => {
-				if (!TestHelper.CanUseRealTimeSignals ())
-					return;
+			if (!TestHelper.CanUseRealTimeSignals ())
+				return;
 
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
 				RealTimeSignum rts = new RealTimeSignum (int.MaxValue);
 			});
 		}
@@ -36,10 +36,10 @@ namespace MonoTests.Mono.Unix.Native {
 		[Test]
 		public void TestRealTimeSignumNegativeOffset ()
 		{
-			Assert.Throws<ArgumentOutOfRangeException> (() => {
-				if (!TestHelper.CanUseRealTimeSignals ())
-					return;
+			if (!TestHelper.CanUseRealTimeSignals ())
+				return;
 
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
 				RealTimeSignum rts1 = new RealTimeSignum (-1);
 			});
 		}

--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Native/RealTimeSignumTests.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Native/RealTimeSignumTests.cs
@@ -23,21 +23,25 @@ namespace MonoTests.Mono.Unix.Native {
 	public class RealTimeSignumTest 
 	{
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void TestRealTimeOutOfRange ()
 		{
-			if (!TestHelper.CanUseRealTimeSignals ())
-				return;
-			RealTimeSignum rts = new RealTimeSignum (int.MaxValue);
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				if (!TestHelper.CanUseRealTimeSignals ())
+					return;
+
+				RealTimeSignum rts = new RealTimeSignum (int.MaxValue);
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void TestRealTimeSignumNegativeOffset ()
 		{
-			if (!TestHelper.CanUseRealTimeSignals ())
-				return;
-			RealTimeSignum rts1 = new RealTimeSignum (-1);
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				if (!TestHelper.CanUseRealTimeSignals ())
+					return;
+
+				RealTimeSignum rts1 = new RealTimeSignum (-1);
+			});
 		}
 
 		[Test]

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/StdioFileStreamTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/StdioFileStreamTest.cs
@@ -74,169 +74,180 @@ namespace MonoTests.System.IO
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void CtorArgumentException1 ()
 		{
-			StdioFileStream stream;
-			stream = new StdioFileStream ("", FileMode.Create);
-			stream.Close ();
-		}			
-
-		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
-		public void CtorArgumentNullException ()
-		{
-			StdioFileStream stream = new StdioFileStream (null, FileMode.Create);
-			stream.Close ();
+			Assert.Throws<ArgumentException> (() => {
+				StdioFileStream stream;
+				stream = new StdioFileStream ("", FileMode.Create);
+				stream.Close ();
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
-		public void CtorFileNotFoundException1 ()
+		public void CtorArgumentNullException ()
 		{
-			string path = TempFolder + DSC + "thisfileshouldnotexists.test";
-			DeleteFile (path);
-			StdioFileStream stream = null;
-			try {                		
-				stream = new StdioFileStream (path, FileMode.Open);
-			} finally {
-				if (stream != null)
-					stream.Close ();
-				DeleteFile (path);
-			}
-		}			
+			Assert.Throws<ArgumentNullException> (() => {
+				StdioFileStream stream = new StdioFileStream (null, FileMode.Create);
+				stream.Close ();
+			});
+		}
 
 		[Test]
-		[ExpectedException (typeof (FileNotFoundException))]
+		public void CtorFileNotFoundException1 ()
+		{
+			Assert.Throws<FileNotFoundException> (() => {
+				string path = TempFolder + DSC + "thisfileshouldnotexists.test";
+				DeleteFile (path);
+				StdioFileStream stream = null;
+				try {
+					stream = new StdioFileStream (path, FileMode.Open);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+					DeleteFile (path);
+				}
+			});
+		}
+
+		[Test]
 		public void CtorFileNotFoundException2 ()
 		{
-			string path = TempFolder + DSC + "thisfileshouldNOTexists.test";
-			DeleteFile (path);
-			StdioFileStream stream = null;
-
-			try {
-				stream = new StdioFileStream (path, FileMode.Truncate);
-			} finally {
-				if (stream != null)
-					stream.Close ();
-
+			Assert.Throws<FileNotFoundException> (() => {
+				string path = TempFolder + DSC + "thisfileshouldNOTexists.test";
 				DeleteFile (path);
-			}
+				StdioFileStream stream = null;
+
+				try {
+					stream = new StdioFileStream (path, FileMode.Truncate);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+
+					DeleteFile (path);
+				}
+			});
 		} 
 
 		[Test]
-		[ExpectedException (typeof (IOException))]
 		public void CtorIOException1 ()
 		{
-			string path = TempFolder + DSC + "thisfileshouldexists.test";
-			StdioFileStream stream = null;
-			DeleteFile (path);
-			try {
-				stream = new StdioFileStream (path, FileMode.CreateNew);
-				stream.Close ();
-				stream = null;
-				stream = new StdioFileStream (path, FileMode.CreateNew);
-			} finally {
-
-				if (stream != null)
-					stream.Close ();
+			Assert.Throws<IOException> (() => {
+				string path = TempFolder + DSC + "thisfileshouldexists.test";
+				StdioFileStream stream = null;
 				DeleteFile (path);
-			} 
+				try {
+					stream = new StdioFileStream (path, FileMode.CreateNew);
+					stream.Close ();
+					stream = null;
+					stream = new StdioFileStream (path, FileMode.CreateNew);
+				} finally {
+
+					if (stream != null)
+						stream.Close ();
+					DeleteFile (path);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void CtorArgumentOutOfRangeException1 ()
 		{
-			StdioFileStream stream = null;
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-			try {
-				stream = new StdioFileStream (path, FileMode.Append | FileMode.CreateNew);
-			} finally {
-				if (stream != null)
-					stream.Close ();
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				StdioFileStream stream = null;
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
 				DeleteFile (path);
-			}                	
-		}			
+				try {
+					stream = new StdioFileStream (path, FileMode.Append | FileMode.CreateNew);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+					DeleteFile (path);
+				}
+			});
+		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void CtorArgumentOutOfRangeException2 ()
 		{
-			StdioFileStream stream = null;
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-			try {
-				stream = new StdioFileStream ("test.test.test", FileMode.Append | FileMode.Open);
-			} finally {
-				if (stream != null)
-					stream.Close ();
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				StdioFileStream stream = null;
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
 				DeleteFile (path);
-			}                	
+				try {
+					stream = new StdioFileStream ("test.test.test", FileMode.Append | FileMode.Open);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+					DeleteFile (path);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (DirectoryNotFoundException))]
 		public void CtorDirectoryNotFoundException ()
 		{
-			string path = TempFolder + DSC + "thisDirectoryShouldNotExists";
-			if (Directory.Exists (path))
-				Directory.Delete (path, true);
-
-			StdioFileStream stream = null;				
-			try {
-				stream = new StdioFileStream (path + DSC + "eitherthisfile.test", FileMode.CreateNew);
-			} finally {
-
-				if (stream != null)
-					stream.Close ();
-
+			Assert.Throws<DirectoryNotFoundException> (() => {
+				string path = TempFolder + DSC + "thisDirectoryShouldNotExists";
 				if (Directory.Exists (path))
 					Directory.Delete (path, true);
-			}                		
+
+				StdioFileStream stream = null;
+				try {
+					stream = new StdioFileStream (path + DSC + "eitherthisfile.test", FileMode.CreateNew);
+				} finally {
+
+					if (stream != null)
+						stream.Close ();
+
+					if (Directory.Exists (path))
+						Directory.Delete (path, true);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void CtorArgumentException3 ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			StdioFileStream stream = null;
-
-			DeleteFile (path);
-
-			try {
-				stream = new StdioFileStream (".test.test.test.2", FileMode.Truncate, FileAccess.Read);
-			} finally {
-				if (stream != null)
-					stream.Close ();
+			Assert.Throws<ArgumentException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				StdioFileStream stream = null;
 
 				DeleteFile (path);
-			}                	
+
+				try {
+					stream = new StdioFileStream (".test.test.test.2", FileMode.Truncate, FileAccess.Read);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+
+					DeleteFile (path);
+				}
+			});
 		}
 
 		// StdioFileStream doesn't mimic the "no writing by another object" rule
-		[/* Test, */ ExpectedException(typeof(IOException))]
+		/* [Test] */
 		public void CtorIOException ()
-		{			
-			string path = TempFolder + DSC + "CTorIOException.Test";
-			StdioFileStream stream = null;
-			StdioFileStream stream2 = null;
-			DeleteFile (path);
-
-			try {
-				stream = new StdioFileStream (path, FileMode.CreateNew);
-
-				// used by an another process
-				stream2 = new StdioFileStream (path, FileMode.OpenOrCreate);
-			} finally {
-				if (stream != null)
-					stream.Close ();
-				if (stream2 != null)
-					stream2.Close ();
+		{
+			Assert.Throws<IOException> (() => {
+				string path = TempFolder + DSC + "CTorIOException.Test";
+				StdioFileStream stream = null;
+				StdioFileStream stream2 = null;
 				DeleteFile (path);
-			}
+
+				try {
+					stream = new StdioFileStream (path, FileMode.CreateNew);
+
+					// used by an another process
+					stream2 = new StdioFileStream (path, FileMode.OpenOrCreate);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+					if (stream2 != null)
+						stream2.Close ();
+					DeleteFile (path);
+				}
+			});
 		}
 
 		[Test]
@@ -586,24 +597,25 @@ namespace MonoTests.System.IO
 		/// <see cref="StdioFileStream.Write(byte[], int, int)" /> method is called.
 		/// </summary>
 		[Test]
-		[ExpectedException (typeof(NotSupportedException))]
 		public void TestWriteVerifyAccessMode ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-
-			StdioFileStream stream = null;
-			byte[] buffer;
-
-			try {
-				buffer = Encoding.ASCII.GetBytes ("test");
-				stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read);
-				stream.Write (buffer, 0, buffer.Length);
-			} finally {
-				if (stream != null)
-					stream.Close();
+			Assert.Throws<NotSupportedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
 				DeleteFile (path);
-			}
+
+				StdioFileStream stream = null;
+				byte[] buffer;
+
+				try {
+					buffer = Encoding.ASCII.GetBytes ("test");
+					stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read);
+					stream.Write (buffer, 0, buffer.Length);
+				} finally {
+					if (stream != null)
+						stream.Close();
+					DeleteFile (path);
+				}
+			});
 		}
 
 		/// <summary>
@@ -612,22 +624,23 @@ namespace MonoTests.System.IO
 		/// <see cref="StdioFileStream.WriteByte(byte)" /> method is called.
 		/// </summary>
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TestWriteByteVerifyAccessMode ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-
-			StdioFileStream stream = null;
-
-			try {
-				stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read);
-				stream.WriteByte (Byte.MinValue);
-			} finally {
-				if (stream != null)
-					stream.Close ();
+			Assert.Throws<NotSupportedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
 				DeleteFile (path);
-			}
+
+				StdioFileStream stream = null;
+
+				try {
+					stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read);
+					stream.WriteByte (Byte.MinValue);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+					DeleteFile (path);
+				}
+			});
 		}
 
 		/// <summary>
@@ -636,22 +649,23 @@ namespace MonoTests.System.IO
 		/// <see cref="StdioFileStream.Read(byte[], int, int)" /> method is called.
 		/// </summary>
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TestReadVerifyAccessMode ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<NotSupportedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			StdioFileStream stream = null;
-			byte[] buffer = new byte [100];
+				StdioFileStream stream = null;
+				byte[] buffer = new byte [100];
 
-			try {
-				stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
-				stream.Read (buffer, 0, buffer.Length);
-			} finally {
-				if (stream != null)
-					stream.Close ();
-			}
+				try {
+					stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
+					stream.Read (buffer, 0, buffer.Length);
+				} finally {
+					if (stream != null)
+						stream.Close ();
+				}
+			});
 		}
 
 		/// <summary>
@@ -660,22 +674,23 @@ namespace MonoTests.System.IO
 		/// <see cref="StdioFileStream.ReadByte()" /> method is called.
 		/// </summary>
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void TestReadByteVerifyAccessMode ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-
-			StdioFileStream stream = null;
-
-			try {
-				stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
-				int readByte = stream.ReadByte ();
-			} finally {
-				if (stream != null)
-					stream.Close();
+			Assert.Throws<NotSupportedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
 				DeleteFile (path);
-			}
+
+				StdioFileStream stream = null;
+
+				try {
+					stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
+					int readByte = stream.ReadByte ();
+				} finally {
+					if (stream != null)
+						stream.Close();
+					DeleteFile (path);
+				}
+			});
 		}
 
 		// Check that the stream is flushed even when it doesn't own the
@@ -705,111 +720,120 @@ namespace MonoTests.System.IO
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void Read_OffsetNegative ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
-				stream.Read (new byte[0], -1, 1);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
+					stream.Read (new byte[0], -1, 1);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Read_OffsetOverflow ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
-				stream.Read (new byte[0], Int32.MaxValue, 1);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
+					stream.Read (new byte[0], Int32.MaxValue, 1);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void Read_CountNegative ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
-				stream.Read (new byte[0], 1, -1);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
+					stream.Read (new byte[0], 1, -1);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Read_CountOverflow ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
-				stream.Read (new byte[0], 1, Int32.MaxValue);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
+					stream.Read (new byte[0], 1, Int32.MaxValue);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void Write_OffsetNegative ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
-				stream.Write (new byte[0], -1, 1);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
+					stream.Write (new byte[0], -1, 1);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Write_OffsetOverflow ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
-				stream.Write (new byte[0], Int32.MaxValue, 1);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
+					stream.Write (new byte[0], Int32.MaxValue, 1);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentOutOfRangeException))]
 		public void Write_CountNegative ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentOutOfRangeException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
-				stream.Write (new byte[0], 1, -1);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
+					stream.Write (new byte[0], 1, -1);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Write_CountOverflow ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
-				stream.Write (new byte[0], 1, Int32.MaxValue);
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write)) {
+					stream.Write (new byte[0], 1, Int32.MaxValue);
+				}
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentException))]
 		public void Seek_InvalidSeekOrigin () 
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
+			Assert.Throws<ArgumentException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
 
-			using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
-				stream.Seek (0, (SeekOrigin) (-1));
-			}
+				using (StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read)) {
+					stream.Seek (0, (SeekOrigin) (-1));
+				}
+			});
 		}
 
 		//
@@ -826,36 +850,39 @@ namespace MonoTests.System.IO
 		//}
 
 		[Test]
-		[ExpectedException (typeof (ObjectDisposedException))]
 		public void Position_Disposed () 
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-			StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read);
-			stream.Close ();
-			stream.Position = 0;
+			Assert.Throws<ObjectDisposedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
+				StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Read);
+				stream.Close ();
+				stream.Position = 0;
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ObjectDisposedException))]
 		public void Flush_Disposed () 
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-			StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
-			stream.Close ();
-			stream.Flush ();
+			Assert.Throws<ObjectDisposedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
+				StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
+				stream.Close ();
+				stream.Flush ();
+			});
 		}
 
 		[Test]
-		[ExpectedException (typeof (ObjectDisposedException))]
 		public void Seek_Disposed () 
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			DeleteFile (path);
-			StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
-			stream.Close ();
-			stream.Seek (0, SeekOrigin.Begin);
+			Assert.Throws<ObjectDisposedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				DeleteFile (path);
+				StdioFileStream stream = new StdioFileStream (path, FileMode.OpenOrCreate, FileAccess.Write);
+				stream.Close ();
+				stream.Seek (0, SeekOrigin.Begin);
+			});
 		}
 
 		[Test]
@@ -871,15 +898,16 @@ namespace MonoTests.System.IO
 		}
 
 		[Test]
-		[ExpectedException (typeof (NotSupportedException))]
 		public void SetLengthWithClosedBaseStream ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "temp";
-			StdioFileStream fs = new StdioFileStream (path, FileMode.Create);
-			BufferedStream bs = new BufferedStream (fs);
-			fs.Close ();
+			Assert.Throws<NotSupportedException> (() => {
+				string path = TempFolder + Path.DirectorySeparatorChar + "temp";
+				StdioFileStream fs = new StdioFileStream (path, FileMode.Create);
+				BufferedStream bs = new BufferedStream (fs);
+				fs.Close ();
 
-			bs.SetLength (1000);
+				bs.SetLength (1000);
+			});
 		}
 	}
 }

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
@@ -142,7 +142,7 @@ namespace MonoTests.Mono.Unix {
 			if (!TestHelper.CanUseRealTimeSignals ())
 				return;
 
-			Assert.Throws<ArgumentException> (() => {
+			Assert.Throws<InvalidOperationException> (() => {
 				UnixSignal signal1 = new UnixSignal (new RealTimeSignum (0));
 				Signum s = signal1.Signum;
 			});

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
@@ -139,9 +139,10 @@ namespace MonoTests.Mono.Unix {
 		[Category ("NotOnMac")]
 		public void TestSignumPropertyThrows ()
 		{
+			if (!TestHelper.CanUseRealTimeSignals ())
+				return;
+
 			Assert.Throws<ArgumentException> (() => {
-				if (!TestHelper.CanUseRealTimeSignals ())
-					return;
 				UnixSignal signal1 = new UnixSignal (new RealTimeSignum (0));
 				Signum s = signal1.Signum;
 			});
@@ -162,9 +163,10 @@ namespace MonoTests.Mono.Unix {
 		[Category ("NotOnMac")]
 		public void TestRealTimePropertyThrows ()
 		{
-			Assert.Throws<InvalidOperationException> (() => {
-				if (!TestHelper.CanUseRealTimeSignals ())
+			if (!TestHelper.CanUseRealTimeSignals ())
 					return;
+
+			Assert.Throws<InvalidOperationException> (() => {
 				UnixSignal signal1 = new UnixSignal (Signum.SIGSEGV);
 				RealTimeSignum s = signal1.RealTimeSignum;
 			});

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
@@ -136,14 +136,15 @@ namespace MonoTests.Mono.Unix {
 		}
 
 		[Test]
-		[ExpectedException]
 		[Category ("NotOnMac")]
 		public void TestSignumPropertyThrows ()
 		{
-			if (!TestHelper.CanUseRealTimeSignals ())
-				return;
-			UnixSignal signal1 = new UnixSignal (new RealTimeSignum (0));
-			Signum s = signal1.Signum;
+			Assert.Throws<ArgumentException> (() => {
+				if (!TestHelper.CanUseRealTimeSignals ())
+					return;
+				UnixSignal signal1 = new UnixSignal (new RealTimeSignum (0));
+				Signum s = signal1.Signum;
+			});
 		}
 
 		[Test]
@@ -158,14 +159,15 @@ namespace MonoTests.Mono.Unix {
 		}
 	
 		[Test]
-		[ExpectedException]
 		[Category ("NotOnMac")]
 		public void TestRealTimePropertyThrows ()
 		{
-			if (!TestHelper.CanUseRealTimeSignals ())
-				return;
-			UnixSignal signal1 = new UnixSignal (Signum.SIGSEGV);
-			RealTimeSignum s = signal1.RealTimeSignum;
+			Assert.Throws<InvalidOperationException> (() => {
+				if (!TestHelper.CanUseRealTimeSignals ())
+					return;
+				UnixSignal signal1 = new UnixSignal (Signum.SIGSEGV);
+				RealTimeSignum s = signal1.RealTimeSignum;
+			});
 		}
 
 		[Test]


### PR DESCRIPTION
ExpectedException is not available in later versions of
NUnit.  To test the NetCore 2.0 version of Mono.Posix I
need a newer version of NUnit that does not contain ExpectedException.

Using Assert.Throws should be equivalent.