### PR TITLE
[Sockets] Fix RemoteEndpoint with async+DualMode

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -901,12 +901,11 @@ namespace System.Net.Sockets
 				SocketAsyncResult ares;
 
 				if (!GetCheckedIPs (e, out addresses)) {
-					e.socket_async_result.EndPoint = e.RemoteEndPoint;
+					//NOTE: DualMode may cause Socket's RemoteEndpoint to differ in AddressFamily from the
+					// SocketAsyncEventArgs, but the SocketAsyncEventArgs itself is not changed
 					ares = (SocketAsyncResult) BeginConnect (e.RemoteEndPoint, ConnectAsyncCallback, e);
 				} else {
-					DnsEndPoint dep = (e.RemoteEndPoint as DnsEndPoint);
-					e.socket_async_result.Addresses = addresses;
-					e.socket_async_result.Port = dep.Port;
+					DnsEndPoint dep = (DnsEndPoint)e.RemoteEndPoint;
 					ares = (SocketAsyncResult) BeginConnect (addresses, dep.Port, ConnectAsyncCallback, e);
 				}
 
@@ -984,8 +983,8 @@ namespace System.Net.Sockets
 					sockares.Complete (new SocketException ((int) SocketError.AddressNotAvailable), true);
 					return sockares;
 				}
-				
-				end_point = RemapIPEndPoint (ep);
+
+				sockares.EndPoint = end_point = RemapIPEndPoint (ep);
 			}
 
 			int error = 0;

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -4622,6 +4622,8 @@ namespace MonoTests.System.Net.Sockets
 				client.DualMode = true;
 				var ar1 = client.BeginConnect (ep, BCCallback, client);
 				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#1");
+				Assert.AreEqual(server.AddressFamily, client.RemoteEndPoint.AddressFamily, "#2");
+				Assert.AreEqual(server.AddressFamily, client.LocalEndPoint.AddressFamily, "#3");
 				client.Disconnect (false);
 				client.Close ();
 
@@ -4629,7 +4631,9 @@ namespace MonoTests.System.Net.Sockets
 				client = new Socket (AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
 				client.DualMode = true;
 				var ar2 = client.BeginConnect (IPAddress.Loopback, ep.Port, BCCallback, client);
-				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#2");
+				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#4");
+				Assert.AreEqual(server.AddressFamily, client.RemoteEndPoint.AddressFamily, "#5");
+				Assert.AreEqual(server.AddressFamily, client.LocalEndPoint.AddressFamily, "#6");
 				client.Disconnect (false);
 				client.Close ();
 
@@ -4637,7 +4641,9 @@ namespace MonoTests.System.Net.Sockets
 				client = new Socket (AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
 				client.DualMode = true;
 				var ar3 = client.BeginConnect (new [] {IPAddress.Loopback}, ep.Port, BCCallback, client);
-				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#2");
+				Assert.IsTrue (BCCalledBack.WaitOne (10000), "#7");
+				Assert.AreEqual(server.AddressFamily, client.RemoteEndPoint.AddressFamily, "#8");
+				Assert.AreEqual(server.AddressFamily, client.LocalEndPoint.AddressFamily, "#9");
 				client.Disconnect (false);
 				client.Close();
 			}


### PR DESCRIPTION
Socket.RemoteEndPoint would throw an net_InvalidAddressFamily
error if the socket was dual-mode and the endpoint passed to
ConnectAsync or BeginConnect was not IPV6.

Fixes a blocking error in the Azure IoT client.

Test case: https://gist.github.com/mhutch/dbb2f8b8023f96bd2b5b79102486c117/

Also removes a couple apparently redundant assignments as
they were misleading when tracking this down.