### PR TITLE
[configure] Fix docs for --with-libgc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ collector.
 both a `mono` binary and a `mono-sgen` binary. `mono` uses Boehm,
 while `mono-sgen` uses the Simple Generational GC.
 
-* `--with-gc=[included, boehm, none]` - Selects the default Boehm
+* `--with-libgc=[included, boehm, none]` - Selects the default Boehm
 garbage collector engine to use.
 
   * *included*: (*slightly modified Boehm GC*) This is the default

--- a/configure.ac
+++ b/configure.ac
@@ -1274,7 +1274,7 @@ dnl
 dnl Boehm GC configuration
 dnl
 
-AC_ARG_WITH(libgc,   [  --with-gc=included,none  Controls the Boehm GC config, default=included],[libgc=$with_gc],[libgc=included])
+AC_ARG_WITH(libgc,   [  --with-libgc=included,none  Controls the Boehm GC config, default=included],[libgc=$with_gc],[libgc=included])
 
 AC_ARG_ENABLE(boehm, [  --disable-boehm            Disable the Boehm GC.], support_boehm=$enableval,support_boehm=${support_boehm:-yes})
 AM_CONDITIONAL(SUPPORT_BOEHM, test x$support_boehm = xyes)
@@ -1322,7 +1322,7 @@ if test "x$support_boehm" = "xyes"; then
 			;;
 
 		xsgen)
-			AC_MSG_WARN("Use --with-sgen instead, --with-gc= controls Boehm configuration")
+			AC_MSG_WARN("Use --with-sgen instead, --with-libgc= controls Boehm configuration")
 			;;
 
 		xnone)
@@ -1332,7 +1332,7 @@ if test "x$support_boehm" = "xyes"; then
 			gc_msg="none"
 			;;
 		*)
-			AC_MSG_ERROR([Invalid argument to --with-gc.])
+			AC_MSG_ERROR([Invalid argument to --with-libgc.])
 			;;
 	esac
 


### PR DESCRIPTION
It was renamed from --with-gc to --with-libgc in 66ca91f10b0fdd61824e318f659b807cbf45aef3, but a few places were missed.