### PR TITLE
Separate the eglib source and build instructions

### DIFF
--- a/msvc/eglib-common.targets
+++ b/msvc/eglib-common.targets
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\garray.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gbytearray.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gerror.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\ghashtable.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\giconv.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\glist.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmarkup.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmem.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\goutput.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpattern.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gptrarray.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqsort.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqueue.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gshell.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gslist.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gspawn.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstr.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstring.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gutf8.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\glib.h" />
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule.h" />
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\sort.frag.h" />
+  </ItemGroup>
+</Project>

--- a/msvc/eglib-common.targets.filters
+++ b/msvc/eglib-common.targets.filters
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\garray.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gbytearray.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gerror.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\ghashtable.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\giconv.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\glist.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmarkup.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmem.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\goutput.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpattern.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gptrarray.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqsort.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqueue.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gshell.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gslist.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gspawn.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstr.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstring.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gutf8.c">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\glib.h">
+      <Filter>Header Files\Common</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule.h">
+      <Filter>Header Files\Common</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\sort.frag.h">
+      <Filter>Header Files\Common</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/msvc/eglib-posix.targets
+++ b/msvc/eglib-posix.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-posix.c" />
+  </ItemGroup>
+</Project>

--- a/msvc/eglib-posix.targets.filters
+++ b/msvc/eglib-posix.targets.filters
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-posix.c">
+      <Filter>Source Files\Posix</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/msvc/eglib-win32.targets
+++ b/msvc/eglib-win32.targets
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdate-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdir-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmisc-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmodule-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpath.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gtimer-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode-win32.c" />
+   </ItemGroup>
+   <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule-win32-internals.h" />
+  </ItemGroup>
+</Project>

--- a/msvc/eglib-win32.targets.filters
+++ b/msvc/eglib-win32.targets.filters
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdate-win32.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdir-win32.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-win32.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmisc-win32.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmodule-win32.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpath.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gtimer-win32.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode-win32.c">
+      <Filter>Source Files\Win32</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule-win32-internals.h">
+      <Filter>Header Files\Win32</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/msvc/eglib.vcxproj
+++ b/msvc/eglib.vcxproj
@@ -150,44 +150,9 @@
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClCompile Include="..\eglib\src\garray.c" />
-    <ClCompile Include="..\eglib\src\gbytearray.c" />
-    <ClCompile Include="..\eglib\src\gdate-win32.c" />
-    <ClCompile Include="..\eglib\src\gdir-win32.c" />
-    <ClCompile Include="..\eglib\src\gerror.c" />
-    <ClCompile Include="..\eglib\src\gfile-posix.c" />
-    <ClCompile Include="..\eglib\src\gfile-win32.c" />
-    <ClCompile Include="..\eglib\src\gfile.c" />
-    <ClCompile Include="..\eglib\src\ghashtable.c" />
-    <ClCompile Include="..\eglib\src\giconv.c" />
-    <ClCompile Include="..\eglib\src\glist.c" />
-    <ClCompile Include="..\eglib\src\gmarkup.c" />
-    <ClCompile Include="..\eglib\src\gmem.c" />
-    <ClCompile Include="..\eglib\src\gmisc-win32.c" />
-    <ClCompile Include="..\eglib\src\gmodule-win32.c" />
-    <ClCompile Include="..\eglib\src\goutput.c" />
-    <ClCompile Include="..\eglib\src\gpath.c" />
-    <ClCompile Include="..\eglib\src\gpattern.c" />
-    <ClCompile Include="..\eglib\src\gptrarray.c" />
-    <ClCompile Include="..\eglib\src\gqsort.c" />
-    <ClCompile Include="..\eglib\src\gqueue.c" />
-    <ClCompile Include="..\eglib\src\gshell.c" />
-    <ClCompile Include="..\eglib\src\gslist.c" />
-    <ClCompile Include="..\eglib\src\gspawn.c" />
-    <ClCompile Include="..\eglib\src\gstr.c" />
-    <ClCompile Include="..\eglib\src\gstring.c" />
-    <ClCompile Include="..\eglib\src\gtimer-win32.c" />
-    <ClCompile Include="..\eglib\src\gunicode-win32.c" />
-    <ClCompile Include="..\eglib\src\gunicode.c" />
-    <ClCompile Include="..\eglib\src\gutf8.c" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\eglib\src\glib.h" />
-    <ClInclude Include="..\eglib\src\gmodule-win32-internals.h" />
-    <ClInclude Include="..\eglib\src\gmodule.h" />
-    <ClInclude Include="..\eglib\src\sort.frag.h" />
-  </ItemGroup>
+  <Import Project="eglib-common.targets" />
+  <Import Project="eglib-win32.targets" />
+  <Import Project="eglib-posix.targets" />
   <ItemGroup>
     <ProjectReference Include="build-init.vcxproj">
       <Project>{92ae7622-5f58-4234-9a26-9ec71876b3f4}</Project>

--- a/msvc/eglib.vcxproj.filters
+++ b/msvc/eglib.vcxproj.filters
@@ -1,111 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\garray.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gbytearray.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdate-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdir-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gerror.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-posix.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\ghashtable.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\giconv.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\glist.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmarkup.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmem.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmisc-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmodule-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\goutput.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpath.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpattern.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gptrarray.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqsort.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqueue.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gshell.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gslist.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gspawn.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstr.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstring.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gtimer-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gutf8.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="$(MonoSourceLocation)\eglib\src\glib.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule-win32-internals.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MonoSourceLocation)\eglib\src\sort.frag.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-  </ItemGroup>
+  <Import Project="eglib-common.targets.filters" />
+  <Import Project="eglib-win32.targets.filters" />
+  <Import Project="eglib-posix.targets.filters" />
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{d16b81e3-5093-424e-a5d4-e7dd8da49dce}</UniqueIdentifier>
@@ -115,6 +12,21 @@
     </Filter>
     <Filter Include="Resource Files">
       <UniqueIdentifier>{38a39ff1-842b-431b-b54b-24094e8283eb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Common">
+      <UniqueIdentifier>{04853f35-873a-4b07-990a-61dc8ebd5105}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Win32">
+      <UniqueIdentifier>{80953075-5d05-41b9-be90-82497081b11c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Common">
+      <UniqueIdentifier>{7a01f670-6a6a-4837-b3ac-cd6c08075b4e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Win32">
+      <UniqueIdentifier>{c6e3ed6c-6b52-4823-bc4f-2dc9f84e3f5d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Posix">
+      <UniqueIdentifier>{3c958a68-b6a1-40d3-834c-b50be09cb819}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/msvc/eglib.vcxproj.filters
+++ b/msvc/eglib.vcxproj.filters
@@ -1,108 +1,108 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="..\eglib\src\garray.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\garray.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gbytearray.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gbytearray.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gdate-win32.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdate-win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gdir-win32.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gdir-win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gerror.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gerror.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gfile.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gfile-posix.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-posix.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gfile-win32.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gfile-win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\ghashtable.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\ghashtable.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\giconv.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\giconv.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\glist.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\glist.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gmarkup.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmarkup.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gmem.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmem.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gmisc-win32.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmisc-win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gqueue.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gmodule-win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gmodule-win32.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\goutput.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\goutput.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpath.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gpath.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gpattern.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gpattern.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gptrarray.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gptrarray.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqsort.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gqsort.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gqueue.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gshell.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gshell.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gslist.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gslist.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gspawn.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gspawn.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gstr.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstr.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gstring.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gstring.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gtimer-win32.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gtimer-win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gunicode.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gutf8.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gunicode-win32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\eglib\src\gunicode-win32.c">
+    <ClCompile Include="$(MonoSourceLocation)\eglib\src\gutf8.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\eglib\src\glib.h">
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\glib.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\eglib\src\gmodule.h">
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\eglib\src\sort.frag.h">
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule-win32-internals.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\eglib\src\gmodule-win32-internals.h">
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\sort.frag.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -17,7 +17,8 @@
     <MONO_USE_STATIC_LIBMONO>false</MONO_USE_STATIC_LIBMONO>
   </PropertyGroup>
   <PropertyGroup Label="MonoDirectories">
-    <top_srcdir>$(MSBuildProjectDirectory)/..</top_srcdir>
+    <MonoSourceLocation Condition="'$(MonoSourceLocation)' == '' ">..</MonoSourceLocation>
+    <top_srcdir>$(MSBuildProjectDirectory)/$(MonoSourceLocation)</top_srcdir>
     <MONO_DIR>$(top_srcdir)</MONO_DIR>
     <MONO_INCLUDE_DIR>$(MONO_DIR)/mono</MONO_INCLUDE_DIR>
     <MONO_EGLIB_INCLUDE_DIR>$(MONO_DIR)/eglib;$(MONO_DIR)/eglib/include;$(MONO_DIR)/eglib/test</MONO_EGLIB_INCLUDE_DIR>


### PR DESCRIPTION
This change extracts the eglib source files from the build instuctions
for builds via MSVC on Windows. It also separates the source files into
platform-specific and common .targets files. This provides more
flexibility for builds from MSVC in a few important ways:

1. We can do MSVC-based builds for platforms that will not be pushed to
public repos by checking out the Mono code externally and importing the
.targets files into a custom .vcxproj for the platform.
2. We can replace the platform specific .targets files with a custom set
of source files to implement a different platform abstraction layer
that will not be public without the need to merge changes to the
.vcxproj from the public repo.

This allows for ease of synchronizing changes to the public Mono
repo with private forks, while _not_ changing the behavior of the code
in the public repo.

If this approach is acceptable, I'll plan to make similar changes to the libmonoutils.vcxproj and the libmonoruntime.vcxproj.