### PR TITLE
[Mono.Options] Write to NULL if we are building for PCL/NetStandard

### DIFF
--- a/mcs/class/Mono.Options/Documentation/en/Mono.Options/CommandSet.xml
+++ b/mcs/class/Mono.Options/Documentation/en/Mono.Options/CommandSet.xml
@@ -250,8 +250,8 @@ commands: Use `commands help` for usage.
   </Docs>
   <Members>
     <Member MemberName=".ctor">
-      <MemberSignature Language="C#" Value="public CommandSet (string suite, Converter&lt;string,string&gt; localizer = null, System.IO.TextWriter output = null, System.IO.TextWriter error = null);" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string suite, class System.Converter`2&lt;string, string&gt; localizer, class System.IO.TextWriter output, class System.IO.TextWriter error) cil managed" />
+      <MemberSignature Language="C#" Value="public CommandSet (string suite, Converter&lt;string,string&gt; localizer = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string suite, class System.Converter`2&lt;string, string&gt; localizer) cil managed" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.2.3.0</AssemblyVersion>
@@ -259,8 +259,6 @@ commands: Use `commands help` for usage.
       <Parameters>
         <Parameter Name="suite" Type="System.String" />
         <Parameter Name="localizer" Type="System.Converter&lt;System.String,System.String&gt;" />
-        <Parameter Name="output" Type="System.IO.TextWriter" />
-        <Parameter Name="error" Type="System.IO.TextWriter" />
       </Parameters>
       <Docs>
         <param name="suite">
@@ -272,15 +270,57 @@ commands: Use `commands help` for usage.
           instance that will be used to translate strings.
           If <see langword="null" />, then no localization is performed.
         </param>
+        <summary>
+          Creates and initializes a new <c>CommandSet</c> instance.
+        </summary>
+        <remarks>
+          <para>
+            This constructor initializes
+            the <see cref="P:Mono.Options.CommandSet.Suite" /> property
+            of the new instance using <paramref name="suite" />,
+            the <see cref="P:Mono.Options.CommandSet.MessageLocalizer" /> property
+            of the new instance using <paramref name="localizer" />,
+            the <see cref="P:Mono.Options.CommandSet.Out" /> property
+            to <see cref="P:System.Console.Out" />, and
+            the <see cref="P:Mono.Options.CommandSet.Error" /> property
+            to <see cref="P:System.Console.Error" />.
+          </para>
+        </remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="suite" /> is <see langword="null" />.
+        </exception>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public CommandSet (string suite, System.IO.TextWriter output, System.IO.TextWriter error, Converter&lt;string,string&gt; localizer = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string suite, class System.IO.TextWriter output, class System.IO.TextWriter error, class System.Converter`2&lt;string, string&gt; localizer) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.2.3.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="suite" Type="System.String" />
+        <Parameter Name="output" Type="System.IO.TextWriter" />
+        <Parameter Name="error" Type="System.IO.TextWriter" />
+        <Parameter Name="localizer" Type="System.Converter&lt;System.String,System.String&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="suite">
+          A <see cref="T:System.String" /> containing the name of the suite.
+          This value is used in default <c>help</c> text output.
+        </param>
         <param name="output">
           A <see cref="T:System.IO.TextWriter" /> where output messages will be
-          written to. If <see langword="null" />, then the
-          <see cref="P:System.Console.Out" /> property will be used.
+          written to.
         </param>
         <param name="error">
           A <see cref="T:System.IO.TextWriter" /> where error messages will be
-          written to. If <see langword="null" />, then the
-          <see cref="P:System.Console.Error" /> property will be used.
+          written to.
+        </param>
+        <param name="localizer">
+          A <see cref="T:System.Converter{System.String,System.String}" />
+          instance that will be used to translate strings.
+          If <see langword="null" />, then no localization is performed.
         </param>
         <summary>
           Creates and initializes a new <c>CommandSet</c> instance.
@@ -300,6 +340,12 @@ commands: Use `commands help` for usage.
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="suite" /> is <see langword="null" />.
+        </exception>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="output" /> is <see langword="null" />.
+        </exception>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="error" /> is <see langword="null" />.
         </exception>
       </Docs>
     </Member>

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -1586,19 +1586,26 @@ namespace Mono.Options
 
 		internal    OptionSet       Options     => options;
 
-		public CommandSet (string suite, MessageLocalizerConverter localizer = null, TextWriter output = null, TextWriter error = null)
+#if !PCL || NETSTANDARD1_3
+		public CommandSet(string suite, MessageLocalizerConverter localizer = null)
+			: this(suite, Console.Out, Console.Error, localizer)
+		{
+		}
+#endif
+		
+		public CommandSet (string suite, TextWriter output, TextWriter error, MessageLocalizerConverter localizer = null)
 		{
 			if (suite == null)
 				throw new ArgumentNullException (nameof (suite));
+			if (output == null)
+				throw new ArgumentNullException (nameof (output));
+			if (error == null)
+				throw new ArgumentNullException (nameof (error));
+
 			this.suite  = suite;
 			options     = new CommandOptionSet (this, localizer);
-#if PCL && !NETSTANDARD1_3
-			outWriter   = output    ?? TextWriter.Null;
-			errorWriter = error     ?? TextWriter.Null;
-#else
-			outWriter   = output    ?? Console.Out;
-			errorWriter = error     ?? Console.Error;
-#endif
+			outWriter   = output;
+			errorWriter = error;
 		}
 
 		public  string                          Suite               => suite;

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -162,10 +162,10 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
-using System.Runtime.Serialization;
 #if PCL
 using System.Reflection;
 #else
+using System.Runtime.Serialization;
 using System.Security.Permissions;
 #endif
 using System.Text;
@@ -1592,8 +1592,13 @@ namespace Mono.Options
 				throw new ArgumentNullException (nameof (suite));
 			this.suite  = suite;
 			options     = new CommandOptionSet (this, localizer);
+#if PCL
+			outWriter   = output    ?? TextWriter.Null;
+			errorWriter = error     ?? TextWriter.Null;
+#else
 			outWriter   = output    ?? Console.Out;
 			errorWriter = error     ?? Console.Error;
+#endif
 		}
 
 		public  string                          Suite               => suite;

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -634,7 +634,7 @@ namespace Mono.Options
 		public abstract string Description { get; }
 		public abstract bool GetArguments (string value, out IEnumerable<string> replacement);
 
-#if !PCL
+#if !PCL || NETSTANDARD1_3
 		public static IEnumerable<string> GetArgumentsFromFile (string file)
 		{
 			return GetArguments (File.OpenText (file), true);
@@ -690,7 +690,7 @@ namespace Mono.Options
 		}
 	}
 
-#if !PCL
+#if !PCL || NETSTANDARD1_3
 	public class ResponseFileSource : ArgumentSource {
 
 		public override string[] GetNames ()

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -1592,7 +1592,7 @@ namespace Mono.Options
 				throw new ArgumentNullException (nameof (suite));
 			this.suite  = suite;
 			options     = new CommandOptionSet (this, localizer);
-#if PCL
+#if PCL && !NETSTANDARD1_3
 			outWriter   = output    ?? TextWriter.Null;
 			errorWriter = error     ?? TextWriter.Null;
 #else


### PR DESCRIPTION
Mono.Options is built for:
 - net4
 - pcl/portable
 - netstandard/netcore

In the cross-platform instances, `System.Console` is not always available. This PR makes this "optional" by requiring the user to specify a writer. 