### PR TITLE
[metadata] expand uninstantiated generic type definitions used as generic type args

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3271,6 +3271,38 @@ namespace MonoTests.System
 			Assert.AreSame (expectedType, r, "#2");
 		}
 
+		public class BConstrained<Y> where Y : BConstrained<Y> {
+		}
+
+		public class AConstrained<X> : BConstrained<AConstrained<X>> {
+		}
+
+		[Test] // Bug https://bugzilla.xamarin.com/show_bug.cgi?id=54485
+		public void MakeGenericType_GTD_Constraint ()
+		{
+			// This is pretty weird, but match .NET behavior (note
+			// that typeof(BConstrained<AConstrained<>>) is a
+			// compile-time error with roslyn, but it's apparently
+			// an ok thing to make with reflection.
+			var tb = typeof (BConstrained<>);
+			var ta = typeof (AConstrained<>);
+			var result = tb.MakeGenericType (ta);
+			Assert.IsNotNull (result, "#1");
+			// lock down the answer to match what .NET makes
+			Assert.IsTrue (result.IsGenericType, "#2");
+			Assert.AreEqual (tb, result.GetGenericTypeDefinition (), "#3");
+			var bargs = result.GetGenericArguments ();
+			Assert.AreEqual (1, bargs.Length, "#4");
+			var arg = bargs [0];
+			Assert.IsTrue (arg.IsGenericType, "#5");
+			// N.B. evidently AConstrained`1 and AConstrained`1<!0> are the same type
+			Assert.IsTrue (arg.IsGenericTypeDefinition, "#6");
+			Assert.AreEqual (ta, arg.GetGenericTypeDefinition (), "#7");
+			var aargs = arg.GetGenericArguments ();
+			Assert.AreEqual (1, aargs.Length, "#8");
+			Assert.AreEqual (ta.GetGenericArguments () [0], aargs [0], "#9");
+		}
+
 	[Test]
 	public void EqualsUserType () {
 		UserType2 t1 = new UserType2(null);

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -382,3 +382,10 @@ mono_class_set_is_com_object (MonoClass *klass)
 	mono_loader_unlock ();
 #endif
 }
+
+MonoType*
+mono_class_gtd_get_canonical_inst (MonoClass *klass)
+{
+	g_assert (mono_class_is_gtd (klass));
+	return &((MonoClassGtd*)klass)->canonical_inst;
+}

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -390,6 +390,9 @@ typedef struct {
 typedef struct {
 	MonoClassDef class;
 	MonoGenericContainer *generic_container;
+	/* The canonical GENERICINST where we instantiate a generic type definition with its own generic parameters.*/
+	/* Suppose we have class T`2<A,B> {...}.  canonical_inst is the GTD T`2 applied to A and B. */
+	MonoType canonical_inst;
 } MonoClassGtd;
 
 typedef struct {
@@ -1443,6 +1446,9 @@ mono_class_try_get_generic_container (MonoClass *klass);
 
 void
 mono_class_set_generic_container (MonoClass *klass, MonoGenericContainer *container);
+
+MonoType*
+mono_class_gtd_get_canonical_inst (MonoClass *klass);
 
 guint32
 mono_class_get_first_method_idx (MonoClass *klass);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5574,6 +5574,9 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		generic_container->is_anonymous = FALSE; // Owner class is now known, container is no longer anonymous
 		context = &generic_container->context;
 		mono_class_set_generic_container (klass, generic_container);
+		MonoType *canonical_inst = &((MonoClassGtd*)klass)->canonical_inst;
+		canonical_inst->type = MONO_TYPE_GENERICINST;
+		canonical_inst->data.generic_class = mono_metadata_lookup_generic_class (klass, context->class_inst, FALSE);
 		enable_gclass_recording ();
 	}
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3073,6 +3073,18 @@ mono_metadata_get_image_set_for_method (MonoMethodInflated *method)
 	return set;
 }
 
+static gboolean
+type_is_gtd (MonoType *type)
+{
+	switch (type->type) {
+	case MONO_TYPE_CLASS:
+	case MONO_TYPE_VALUETYPE:
+		return mono_class_is_gtd (type->data.klass);
+	default:
+		return FALSE;
+	}
+}
+
 /*
  * mono_metadata_get_generic_inst:
  *
@@ -3099,6 +3111,13 @@ mono_metadata_get_generic_inst (int type_argc, MonoType **type_argv)
 	ginst->is_open = is_open;
 	ginst->type_argc = type_argc;
 	memcpy (ginst->type_argv, type_argv, type_argc * sizeof (MonoType *));
+
+	for (i = 0; i < type_argc; ++i) {
+		MonoType *t = ginst->type_argv [i];
+		if (type_is_gtd (t)) {
+			ginst->type_argv [i] = mono_class_gtd_get_canonical_inst (t->data.klass);
+		}
+	}
 
 	return mono_metadata_get_canonical_generic_inst (ginst);
 }

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2537,6 +2537,11 @@ reflection_create_generic_class (MonoReflectionTypeBuilderHandle ref_tb, MonoErr
 	}
 
 	generic_container->context.class_inst = mono_get_shared_generic_inst (generic_container);
+	MonoGenericContext* context = &generic_container->context;
+	MonoType *canonical_inst = &((MonoClassGtd*)klass)->canonical_inst;
+	canonical_inst->type = MONO_TYPE_GENERICINST;
+	canonical_inst->data.generic_class = mono_metadata_lookup_generic_class (klass, context->class_inst, FALSE);
+
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (is_ok (error));
 }


### PR DESCRIPTION
Consider

```csharp
class Foo<Y> where Y : Foo<Y> { }
class Bar<X> : Foo<Bar<X>> { }
```

`typeof (Foo<>).MakeGenericType (typeof (Bar<>))` ought to make something like `Foo<Bar<X>>` where `X` is a parameter of `Bar<>`.

(Pretty surprising, but that's what .NET Framework does, apparently).

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=54485

The failure in the bug is due to a GTD appearing as a type argument in a `MonoGenericInst`.  That makes `Foo<Bar'1>` and `Foo<Bar<X>>` be different `MonoClass*` objects and as a result a subtype check fails while verifying the constraint on `Y`

----

We fix the problem by changing `mono_metadata_get_generic_inst ()` to replace uninstantiated GTDs that appear in generic instantiation argument lists by their "canonical open instantiation" which is just the GTD applied to its own generic parameters.  For example, if someone tried to make `Foo<Bar'1>` we would instead give them `Foo <Bar <X> >`.

We store the `canonical_inst` `MonoType` right in the `MonoClassGtd`.  (It might seem that we could just allocate a temporary MonoType that holds the canonical open instantiation to replace the ones coming in as arguments to `mono_metadata_get_generic_inst()`, but we can't because we wouldn't have enough information to know when it will be okay to de-allocate such a temporary MonoType.  So instead we tie its lifetime to the lifetime of the `MonoClassGtd`.)