### PR TITLE
Only prepend ? if user omits it, preventing erroneous double ?? from UriBuilder

### DIFF
--- a/mcs/class/referencesource/System/net/System/uribuilder.cs
+++ b/mcs/class/referencesource/System/net/System/uribuilder.cs
@@ -274,7 +274,7 @@ namespace System {
                 if (value == null) {
                     value = String.Empty;
                 }
-                if (value.Length > 0) {
+                if (value.Length > 0 && value[0] != '?') {
                     value = '?' + value;
                 }
                 m_query = value;


### PR DESCRIPTION
This brings it in line with the implementation in .NET Core 1.1.1.