### PR TITLE
[metadata] Fix special static field access

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -326,11 +326,6 @@ struct _MonoDomain {
 	/* hashtables for Reflection handles */
 	MonoGHashTable     *type_hash;
 	MonoGHashTable     *refobject_hash;
-	/*
-	 * A GC-tracked array to keep references to the static fields of types.
-	 * See note [Domain Static Data Array].
-	 */
-	gpointer           *static_data_array;
 	/* maps class -> type initialization exception object */
 	MonoGHashTable    *type_init_exception_hash;
 	/* maps delegate trampoline addr -> delegate object */
@@ -564,9 +559,6 @@ mono_assembly_name_parse (const char *name, MonoAssemblyName *aname);
 MonoImage *mono_assembly_open_from_bundle (const char *filename,
 					   MonoImageOpenStatus *status,
 					   gboolean refonly);
-
-MONO_API void
-mono_domain_add_class_static_data (MonoDomain *domain, MonoClass *klass, gpointer data, guint32 *bitmap);
 
 MonoAssembly *
 mono_try_assembly_resolve (MonoDomain *domain, const char *fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1968,7 +1968,6 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 			/*g_print ("bitmap 0x%x for %s.%s (size: %d)\n", bitmap [0], klass->name_space, klass->name, class_size);*/
 			statics_gc_descr = mono_gc_make_descr_from_bitmap (bitmap, max_set + 1);
 			vt->vtable [klass->vtable_size] = mono_gc_alloc_fixed (class_size, statics_gc_descr, MONO_ROOT_SOURCE_STATIC, "managed static variables");
-			mono_domain_add_class_static_data (domain, klass, vt->vtable [klass->vtable_size], NULL);
 			if (bitmap != default_bitmap)
 				g_free (bitmap);
 		} else {

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -888,11 +888,16 @@ mono_class_static_field_address (MonoDomain *domain, MonoClassField *field)
 
 	//printf ("SFLDA1 %p\n", (char*)vtable->data + field->offset);
 
-	if (domain->special_static_fields && (addr = g_hash_table_lookup (domain->special_static_fields, field)))
+	if (field->offset == -1) {
+		/* Special static */
+		g_assert (domain->special_static_fields);
+		mono_domain_lock (domain);
+		addr = g_hash_table_lookup (domain->special_static_fields, field);
+		mono_domain_unlock (domain);
 		addr = mono_get_special_static_data (GPOINTER_TO_UINT (addr));
-	else
+	} else {
 		addr = (char*)mono_vtable_get_static_field_data (vtable) + field->offset;
-	
+	}
 	return addr;
 }
 

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -595,7 +595,7 @@ mono_arch_code_chunk_destroy (void *chunk);
 #define MONO_TRAMPOLINE_UNWINDINFO_SIZE(max_code_count) (mono_arch_unwindinfo_get_size (max_code_count))
 #define MONO_MAX_TRAMPOLINE_UNWINDINFO_SIZE (MONO_TRAMPOLINE_UNWINDINFO_SIZE(3))
 
-inline gboolean
+static inline gboolean
 mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 {
 	guint current_size = mono_arch_unwindinfo_get_size (mono_arch_unwindinfo_get_code_count (unwind_ops));
@@ -607,7 +607,7 @@ mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 #define MONO_TRAMPOLINE_UNWINDINFO_SIZE(max_code_count) 0
 #define MONO_MAX_TRAMPOLINE_UNWINDINFO_SIZE 0
 
-inline gboolean
+static inline gboolean
 mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 {
 	return TRUE;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -344,6 +344,7 @@ TESTS_CS_SRC=		\
 	generic-static-methods.2.cs	\
 	generic-null-call.2.cs	\
 	generic-special.2.cs	\
+	generic-special2.2.cs	\
 	generic-exceptions.2.cs	\
 	generic-virtual2.2.cs	\
 	generic-valuetype-interface.2.cs	\
@@ -616,6 +617,7 @@ TESTS_GSHARED_SRC = \
 	generic-tailcall2.2.cs			\
 	generic-array-exc.2.cs	\
 	generic-special.2.cs			\
+	generic-special2.2.cs	\
 	generic-exceptions.2.cs	\
 	generic-delegate2.2.cs		\
 	generic-virtual2.2.cs	\

--- a/mono/tests/generic-special2.2.cs
+++ b/mono/tests/generic-special2.2.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Reflection;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+
+internal class GenericType<T> {
+	[ThreadStatic]
+	internal static object static_var;
+
+	public static void AccessStaticVar ()
+	{
+		if (static_var != null && static_var.GetType () != typeof (List<T>))
+			throw new Exception ("Corrupted static var");
+		GenericType<T>.static_var = new List<T> ();
+	}
+}
+
+public static class Program {
+	private static bool stress;
+
+	/* Create a lot of static vars */
+	private static void CreateVTables ()
+	{
+		Type[] nullArgs = new Type[0];
+		Assembly ass = Assembly.GetAssembly (typeof (int));
+		foreach (Type type in ass.GetTypes ()) {
+			try {
+				Type inst = typeof (GenericType<>).MakeGenericType (type);
+				Activator.CreateInstance (inst);
+			} catch {
+			}
+		}
+	}
+
+	private static void StressStaticFieldAddr ()
+	{
+		while (stress) {
+			GenericType<object>.AccessStaticVar ();
+		}
+	}
+
+	public static void Main (string[] args)
+	{
+		Thread thread = new Thread (StressStaticFieldAddr);
+
+		stress = true;
+		thread.Start ();
+		CreateVTables ();
+		stress = false;
+
+		thread.Join ();
+	}
+}

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -243,7 +243,6 @@ mono_dl_fallback_register
 mono_dl_fallback_unregister
 mono_dl_open
 mono_dllmap_insert
-mono_domain_add_class_static_data
 mono_domain_assembly_open
 mono_domain_create
 mono_domain_create_appdomain

--- a/msvc/monosgen.def
+++ b/msvc/monosgen.def
@@ -243,7 +243,6 @@ mono_dl_fallback_register
 mono_dl_fallback_unregister
 mono_dl_open
 mono_dllmap_insert
-mono_domain_add_class_static_data
 mono_domain_assembly_open
 mono_domain_create
 mono_domain_create_appdomain


### PR DESCRIPTION
Although I wasn't able to reliably repro XS crashes and check the fix, this is super likely the fix for it. The bug is probably present since forever, tested as far back as 4.8.