### PR TITLE
[cil-stripper] Mark stripped methods as noinline to prevent the JIT f…

### DIFF
--- a/mcs/tools/cil-strip/AssemblyStripper.cs
+++ b/mcs/tools/cil-strip/AssemblyStripper.cs
@@ -147,6 +147,8 @@ namespace Mono.CilStripper {
 			for (int i = 0; i < methodTable.Rows.Count; i++) {
 				MethodRow methodRow = methodTable[i];
 
+				methodRow.ImplFlags |= MethodImplAttributes.NoInlining;
+
 				MetadataToken methodToken = MetadataToken.FromMetadataRow (TokenType.Method, i);
 
 				MethodDefinition method = (MethodDefinition) assembly.MainModule.LookupByToken (methodToken);


### PR DESCRIPTION
…rom trying to inline them. Fixes #55041.