### PR TITLE
[Facades] bump version numbers

### DIFF
--- a/mcs/class/Facades/System.IO.FileSystem.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.FileSystem.Primitives/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCompany ("Xamarin, Inc.")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
 [assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
-[assembly: AssemblyVersion ("4.0.1.0")]
+[assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.FileSystem/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.FileSystem/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCompany ("Xamarin, Inc.")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
 [assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
-[assembly: AssemblyVersion ("4.0.1.0")]
+[assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Primitives/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCompany ("Xamarin, Inc.")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
 [assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
-[assembly: AssemblyVersion ("4.0.0.0")]
+[assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.ReaderWriter/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.ReaderWriter/AssemblyInfo.cs
@@ -30,6 +30,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCompany ("Xamarin, Inc.")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
 [assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
-[assembly: AssemblyVersion ("4.0.10.0")]
+[assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]


### PR DESCRIPTION
Roslyn 2.1 (from 6784c6120fcf495443a6acebb2b8ce60477ec94d) seems to need newer versions of a couple of facades before I can merge https://github.com/mono/mono/pull/4730