### PR TITLE
Fix the Windows build with IPv6 config checks

### DIFF
--- a/support/map.c
+++ b/support/map.c
@@ -5237,7 +5237,7 @@ Mono_Posix_ToSockaddrIn (struct sockaddr_in *from, struct Mono_Posix_SockaddrIn 
 #endif /* ndef HAVE_STRUCT_SOCKADDR_IN */
 
 
-#ifdef HAVE_STRUCT_SOCKADDR_IN6
+#if defined(HAVE_STRUCT_SOCKADDR_IN6) && !defined(WINDOWS)
 int
 Mono_Posix_FromSockaddrIn6 (struct Mono_Posix_SockaddrIn6 *from, struct sockaddr_in6 *to)
 {
@@ -5259,7 +5259,7 @@ Mono_Posix_FromSockaddrIn6 (struct Mono_Posix_SockaddrIn6 *from, struct sockaddr
 #endif /* ndef HAVE_STRUCT_SOCKADDR_IN6 */
 
 
-#ifdef HAVE_STRUCT_SOCKADDR_IN6
+#if defined(HAVE_STRUCT_SOCKADDR_IN6) && !defined(WINDOWS)
 int
 Mono_Posix_ToSockaddrIn6 (struct sockaddr_in6 *from, struct Mono_Posix_SockaddrIn6 *to)
 {

--- a/winconfig.h
+++ b/winconfig.h
@@ -586,6 +586,9 @@
 /* Define to 1 if you have the <wchar.h> header file. */
 #define HAVE_WCHAR_H 1
 
+/* Define to 1 if you have IPv6 support. */
+#define HAVE_STRUCT_SOCKADDR_IN6 1
+
 /* Have a working sigaltstack */
 /* #undef HAVE_WORKING_SIGALTSTACK */
 


### PR DESCRIPTION
Define HAVE_STRUCT_SOCKADDR_IN6 on Windows to ensure that IPv6 support
will be enabled.