### PR TITLE
Put strict strong name checking behind a configure flag and runtime option (2017-04)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1173,6 +1173,8 @@ fi
 if test "x$mono_feature_disable_assembly_remapping" = "xyes"; then
 	AC_DEFINE(DISABLE_ASSEMBLY_REMAPPING, 1, [Disable assembly remapping.])
 	AC_MSG_NOTICE([Disabled Assembly remapping.])
+	AC_DEFINE(DISABLE_STRICT_STRONG_NAMES, 1, [Disable strict strong name checking.])
+	AC_MSG_NOTICE([Disabled strict strong name checking.])
 fi
 
 if test "x$mono_feature_disable_shared_perfcounters" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1049,7 +1049,7 @@ fi
 
 AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsystems.
      LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, 
-     reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, simd, soft_debug, perfcounters, normalization, assembly_remapping, shared_perfcounters, remoting,
+     reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting,
 	 security, lldb, mdb, sgen_remset, sgen_marksweep_par, sgen_marksweep_fixed, sgen_marksweep_fixed_par, sgen_copying.],
 [
 	for feature in `echo "$enable_minimal" | sed -e "s/,/ /g"`; do
@@ -1170,11 +1170,10 @@ if test "x$mono_feature_disable_normalization" = "xyes"; then
 	AC_MSG_NOTICE([Disabled String normalization support.])
 fi
 
-if test "x$mono_feature_disable_assembly_remapping" = "xyes"; then
-	AC_DEFINE(DISABLE_ASSEMBLY_REMAPPING, 1, [Disable assembly remapping.])
-	AC_MSG_NOTICE([Disabled Assembly remapping.])
-	AC_DEFINE(DISABLE_STRICT_STRONG_NAMES, 1, [Disable strict strong name checking.])
-	AC_MSG_NOTICE([Disabled strict strong name checking.])
+#TODO: remove assembly_remapping feature name once everyone is using desktop_loader
+if test "x$mono_feature_disable_assembly_remapping" = "xyes" || "x$mono_feature_disable_desktop_loader" = "xyes"; then
+	AC_DEFINE(DISABLE_DESKTOP_LOADER, 1, [Disable desktop assembly loader semantics.])
+	AC_MSG_NOTICE([Disabled desktop assembly loader semantics.])
 fi
 
 if test "x$mono_feature_disable_shared_perfcounters" = "xyes"; then

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1991,7 +1991,7 @@ mono_domain_assembly_preload (MonoAssemblyName *aname,
 
 	MonoAssemblyCandidatePredicate predicate = NULL;
 	void* predicate_ud = NULL;
-#if !defined(DISABLE_STRICT_STRONG_NAMES)
+#if !defined(DISABLE_DESKTOP_LOADER)
 	if (G_LIKELY (mono_loader_get_strict_strong_names ())) {
 		predicate = &mono_assembly_candidate_predicate_sn_same_name;
 		predicate_ud = aname;

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1989,6 +1989,12 @@ mono_domain_assembly_preload (MonoAssemblyName *aname,
 
 	set_domain_search_path (domain);
 
+	MonoAssemblyCandidatePredicate predicate = NULL;
+	void* predicate_ud = NULL;
+#if !defined(DISABLE_STRICT_STRONG_NAMES)
+	predicate = &mono_assembly_candidate_predicate_sn_same_name;
+	predicate_ud = aname;
+#endif
 	if (domain->search_path && domain->search_path [0] != NULL) {
 		if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY)) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Domain %s search path is:", domain->friendly_name);
@@ -1998,11 +2004,11 @@ mono_domain_assembly_preload (MonoAssemblyName *aname,
 			}
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "End of domain %s search path.", domain->friendly_name);			
 		}
-		result = real_load (domain->search_path, aname->culture, aname->name, refonly, &mono_assembly_candidate_predicate_sn_same_name, aname);
+		result = real_load (domain->search_path, aname->culture, aname->name, refonly, predicate, predicate_ud);
 	}
 
 	if (result == NULL && assemblies_path && assemblies_path [0] != NULL) {
-		result = real_load (assemblies_path, aname->culture, aname->name, refonly, &mono_assembly_candidate_predicate_sn_same_name, aname);
+		result = real_load (assemblies_path, aname->culture, aname->name, refonly, predicate, predicate_ud);
 	}
 
 	return result;

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1992,8 +1992,10 @@ mono_domain_assembly_preload (MonoAssemblyName *aname,
 	MonoAssemblyCandidatePredicate predicate = NULL;
 	void* predicate_ud = NULL;
 #if !defined(DISABLE_STRICT_STRONG_NAMES)
-	predicate = &mono_assembly_candidate_predicate_sn_same_name;
-	predicate_ud = aname;
+	if (G_LIKELY (mono_loader_get_strict_strong_names ())) {
+		predicate = &mono_assembly_candidate_predicate_sn_same_name;
+		predicate_ud = aname;
+	}
 #endif
 	if (domain->search_path && domain->search_path [0] != NULL) {
 		if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY)) {

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3533,7 +3533,7 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 	g_free (corlib_file);
 
 return_corlib_and_facades:
-	if (corlib)
+	if (corlib && !strcmp (runtime->framework_version, "4.5"))  // FIXME: stop hardcoding 4.5 here
 		default_path [1] = g_strdup_printf ("%s/Facades", corlib->basedir);
 		
 	return corlib;

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -89,7 +89,7 @@ static char **assemblies_path = NULL;
 /* Contains the list of directories that point to auxiliary GACs */
 static char **extra_gac_paths = NULL;
 
-#ifndef DISABLE_ASSEMBLY_REMAPPING
+#ifndef DISABLE_DESKTOP_LOADER
 
 #define FACADE_ASSEMBLY(str) {str, 0, NULL, FALSE, TRUE}
 
@@ -967,7 +967,7 @@ mono_assemblies_init (void)
 	mono_os_mutex_init_recursive (&assemblies_mutex);
 	mono_os_mutex_init (&assembly_binding_mutex);
 
-#ifndef DISABLE_ASSEMBLY_REMAPPING
+#ifndef DISABLE_DESKTOP_LOADER
 	assembly_remapping_table = g_hash_table_new (g_str_hash, g_str_equal);
 
 	int i;
@@ -1257,7 +1257,7 @@ mono_assembly_remap_version (MonoAssemblyName *aname, MonoAssemblyName *dest_ana
 		return dest_aname;
 	}
 	
-#ifndef DISABLE_ASSEMBLY_REMAPPING
+#ifndef DISABLE_DESKTOP_LOADER
 	const AssemblyVersionMap *vmap = (AssemblyVersionMap *)g_hash_table_lookup (assembly_remapping_table, aname->name);
 	if (vmap) {
 		const AssemblyVersionSet* vset;
@@ -3600,7 +3600,7 @@ exact_sn_match (MonoAssemblyName *wanted_name, MonoAssemblyName *candidate_name)
 gboolean
 framework_assembly_sn_match (MonoAssemblyName *wanted_name, MonoAssemblyName *candidate_name)
 {
-#ifndef DISABLE_ASSEMBLY_REMAPPING
+#ifndef DISABLE_DESKTOP_LOADER
 	const AssemblyVersionMap *vmap = (AssemblyVersionMap *)g_hash_table_lookup (assembly_remapping_table, wanted_name->name);
 	if (vmap) {
 		if (!vmap->framework_facade_assembly) {
@@ -3659,7 +3659,7 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 
 	MonoAssemblyCandidatePredicate predicate = NULL;
 	void* predicate_ud = NULL;
-#if !defined(DISABLE_STRICT_STRONG_NAMES)
+#if !defined(DISABLE_DESKTOP_LOADER)
 	if (G_LIKELY (mono_loader_get_strict_strong_names ())) {
 		predicate = &mono_assembly_candidate_predicate_sn_same_name;
 		predicate_ud = aname;

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3657,6 +3657,13 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 		return mono_assembly_load_corlib (mono_get_runtime_info (), status);
 	}
 
+	MonoAssemblyCandidatePredicate predicate = NULL;
+	void* predicate_ud = NULL;
+#if !defined(DISABLE_STRICT_STRONG_NAMES)
+	predicate = &mono_assembly_candidate_predicate_sn_same_name;
+	predicate_ud = aname;
+#endif
+
 	len = strlen (aname->name);
 	for (ext_index = 0; ext_index < 2; ext_index ++) {
 		ext = ext_index == 0 ? ".dll" : ".exe";
@@ -3676,7 +3683,7 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 
 		if (basedir) {
 			fullpath = g_build_filename (basedir, filename, NULL);
-			result = mono_assembly_open_predicate (fullpath, refonly, FALSE, &mono_assembly_candidate_predicate_sn_same_name, aname, status);
+			result = mono_assembly_open_predicate (fullpath, refonly, FALSE, predicate, predicate_ud, status);
 			g_free (fullpath);
 			if (result) {
 				result->in_gac = FALSE;
@@ -3685,7 +3692,7 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 			}
 		}
 
-		result = load_in_path (filename, default_path, status, refonly, &mono_assembly_candidate_predicate_sn_same_name, aname);
+		result = load_in_path (filename, default_path, status, refonly, predicate, predicate_ud);
 		if (result)
 			result->in_gac = FALSE;
 		g_free (filename);

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3660,8 +3660,10 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 	MonoAssemblyCandidatePredicate predicate = NULL;
 	void* predicate_ud = NULL;
 #if !defined(DISABLE_STRICT_STRONG_NAMES)
-	predicate = &mono_assembly_candidate_predicate_sn_same_name;
-	predicate_ud = aname;
+	if (G_LIKELY (mono_loader_get_strict_strong_names ())) {
+		predicate = &mono_assembly_candidate_predicate_sn_same_name;
+		predicate_ud = aname;
+	}
 #endif
 
 	len = strlen (aname->name);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -943,5 +943,11 @@ mono_assembly_is_problematic_version (const char *name, guint16 major, guint16 m
 void
 mono_ginst_get_desc (GString *str, MonoGenericInst *ginst);
 
+void
+mono_loader_set_strict_strong_names (gboolean enabled);
+
+gboolean
+mono_loader_get_strict_strong_names (void);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -515,6 +515,13 @@ mono_tables_names [] = {
 
 #endif
 
+/* If TRUE (but also see DISABLE_STICT_STRONG_NAMES #define), Mono will check
+ * that the public key token and version of a candidate assembly matches the
+ * requested strong name.  If FALSE, as long as the name matches, the candidate
+ * will be allowed.
+ */
+static gboolean check_strong_names_strictly = TRUE;
+
 // Amount initially reserved in each imageset's mempool.
 // FIXME: This number is arbitrary, a more practical number should be found
 #define INITIAL_IMAGE_SET_SIZE    1024
@@ -6793,4 +6800,16 @@ mono_find_image_set_owner (void *ptr)
 	image_sets_unlock ();
 
 	return owner;
+}
+
+void
+mono_loader_set_strict_strong_names (gboolean enabled)
+{
+	check_strong_names_strictly = enabled;
+}
+
+gboolean
+mono_loader_get_strict_strong_names (void)
+{
+	return check_strong_names_strictly;
 }

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1941,6 +1941,14 @@ mono_main (int argc, char* argv[])
 		} else if (strcmp (argv [i], "--nacl-null-checks-off") == 0){
 			nacl_null_checks_off = TRUE;
 #endif
+		} else if (strncmp (argv [i], "--assembly-loader=", strlen("--assembly-loader=")) == 0) {
+			gchar *arg = argv [i] + strlen ("--assembly-loader=");
+			if (strcmp (arg, "strict") == 0)
+				mono_loader_set_strict_strong_names (TRUE);
+			else if (strcmp (arg, "legacy") == 0)
+				mono_loader_set_strict_strong_names (FALSE);
+			else
+				fprintf (stderr, "Warning: unknown argument to --assembly-loader. Should be \"strict\" or \"legacy\"\n");
 		} else if (strncmp (argv [i], MONO_HANDLERS_ARGUMENT, MONO_HANDLERS_ARGUMENT_LEN) == 0) {
 			//Install specific custom handlers.
 			if (!mono_runtime_install_custom_handlers (argv[i] + MONO_HANDLERS_ARGUMENT_LEN)) {


### PR DESCRIPTION
This is #4759 backported to the `2017-04` branch

---

* `--enable-minimal=desktop_loader` configure flag that replaces `--enable-minimal=assembly_remapping` and sets `DISABLE_DESKTOP_LOADER` define (replacing `DISABLE_ASSEMBLY_REMAPPING`).
* silently we keep accepting `assembly_remapping` as an alias of `desktop_loader`.
* Add `--assembly-loader=[strict,legacy]` command line option.  Default: strict.  Relevant only if `!defined(DISABLE_DESKTOP_LOADER)`
* If strict we will refuse to load any assembly in application base or MONO_PATH that has the right file name but doesn't match the public key token and version number.  If legacy, use old mono behavior (if we find a file with the right name, go with it).