### PR TITLE
[2017-02][sre-save] Handle ConstructorBuilder custom attribute constructors

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/CustomAttributeBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/CustomAttributeBuilderTest.cs
@@ -790,6 +790,61 @@ namespace MonoTests.System.Reflection.Emit
 			Assert.IsInstanceOfType (typeof (PublicVisibleCustomAttribute), attrs[1]);
 			Assert.IsInstanceOfType (typeof (PublicVisibleCustomAttribute), attrs[2]);
 		}
+
+		[Test]
+		public void CustomAttributeSameAssembly () {
+			// Regression test for 55681
+			//
+			// We build:
+			// class MyAttr : Attr { public MyAttr () { } }
+			// [assembly:MyAttr()]
+			//
+			// the important bit is that we pass the ConstructorBuilder to the CustomAttributeBuilder
+			var assemblyName = new AssemblyName ("Repro55681");
+			var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly (assemblyName, AssemblyBuilderAccess.Save, tempDir);
+			var moduleBuilder = assemblyBuilder.DefineDynamicModule ("Repro55681", "Repro55681.dll");
+			var typeBuilder = moduleBuilder.DefineType ("MyAttr", TypeAttributes.Public, typeof (Attribute));
+			ConstructorBuilder ctor = typeBuilder.DefineDefaultConstructor (MethodAttributes.Public);
+			typeBuilder.CreateType ();
+
+			assemblyBuilder.SetCustomAttribute (new CustomAttributeBuilder (ctor, new object [] { }));
+
+			assemblyBuilder.Save ("Repro55681.dll");
+		}
+
+		[Test]
+		public void CustomAttributeAcrossAssemblies () {
+			// Regression test for 55681
+			//
+			// We build:
+			// assembly1:
+			//   class MyAttr : Attr { public MyAttr () { } }
+			// assembly2:
+			//   class Dummy { }
+			//   [assembly:MyAttr()]
+			//
+ 			// the important bit is that we pass the ConstructorBuilder to the CustomAttributeBuilder
+			var assemblyName1 = new AssemblyName ("Repro55681-2a");
+			var assemblyBuilder1 = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName1, AssemblyBuilderAccess.Save, tempDir);
+			var moduleBuilder1 = assemblyBuilder1.DefineDynamicModule ("Repro55681-2a", "Repro55681-2a.dll");
+			var typeBuilder1 = moduleBuilder1.DefineType ("MyAttr", TypeAttributes.Public, typeof (Attribute));
+			ConstructorBuilder ctor = typeBuilder1.DefineDefaultConstructor (MethodAttributes.Public);
+			typeBuilder1.CreateType ();
+
+			var assemblyName2 = new AssemblyName ("Repro55681-2b");
+			var assemblyBuilder2 = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName2, AssemblyBuilderAccess.Save, tempDir);
+			var moduleBuilder2 = assemblyBuilder2.DefineDynamicModule ("Repro55681-2b", "Repro55681-2b.dll");
+
+			var typeBuilder2 = moduleBuilder2.DefineType ("Dummy", TypeAttributes.Public);
+			typeBuilder2.DefineDefaultConstructor (MethodAttributes.Public);
+			typeBuilder2.CreateType ();
+
+			assemblyBuilder2.SetCustomAttribute (new CustomAttributeBuilder (ctor, new object [] { }));
+
+			assemblyBuilder2.Save ("Repro55681-2b.dll");
+			assemblyBuilder1.Save ("Repro55681-2a.dll");
+		}
+		
 	}
 }
 

--- a/mono/metadata/sre-internals.h
+++ b/mono/metadata/sre-internals.h
@@ -137,5 +137,8 @@ mono_dynimage_save_encode_marshal_blob (MonoDynamicImage *assembly, MonoReflecti
 guint32
 mono_dynimage_save_encode_property_signature (MonoDynamicImage *assembly, MonoReflectionPropertyBuilder *fb, MonoError *error);
 
+guint32
+mono_image_get_methodref_token (MonoDynamicImage *assembly, MonoMethod *method, gboolean create_typespec);
+
 #endif  /* __MONO_METADATA_SRE_INTERNALS_H__ */
 

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -218,8 +218,18 @@ mono_image_add_cattrs (MonoDynamicImage *assembly, guint32 idx, guint32 type, Mo
 	for (i = 0; i < count; ++i) {
 		cattr = (MonoReflectionCustomAttr*)mono_array_get (cattrs, gpointer, i);
 		values [MONO_CUSTOM_ATTR_PARENT] = idx;
-		token = image_create_token_raw (assembly, (MonoObject*)cattr->ctor, FALSE, FALSE, error); /* FIXME use handles */
-		if (!mono_error_ok (error)) goto fail;
+		g_assert (cattr->ctor != NULL);
+		if (mono_is_sre_ctor_builder (mono_object_class (cattr->ctor))) {
+			MonoReflectionCtorBuilder *ctor = (MonoReflectionCtorBuilder*)cattr->ctor;
+			MonoMethod *method = ctor->mhandle;
+			if (method->klass->image == &assembly->image)
+				token = MONO_TOKEN_METHOD_DEF | ((MonoReflectionCtorBuilder*)cattr->ctor)->table_idx;
+			else
+				token = mono_image_get_methodref_token (assembly, method, FALSE);
+		} else {
+			token = image_create_token_raw (assembly, (MonoObject*)cattr->ctor, FALSE, FALSE, error); /* FIXME use handles */
+			if (!mono_error_ok (error)) goto fail;
+		}
 		type = mono_metadata_token_index (token);
 		type <<= MONO_CUSTOM_ATTR_TYPE_BITS;
 		switch (mono_metadata_token_table (token)) {

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -42,7 +42,6 @@ static GENERATE_GET_CLASS_WITH_CACHE (module_builder, "System.Reflection.Emit", 
 static char* string_to_utf8_image_raw (MonoImage *image, MonoString *s, MonoError *error);
 
 #ifndef DISABLE_REFLECTION_EMIT
-static guint32 mono_image_get_methodref_token (MonoDynamicImage *assembly, MonoMethod *method, gboolean create_typespec);
 static guint32 mono_image_get_sighelper_token (MonoDynamicImage *assembly, MonoReflectionSigHelperHandle helper, MonoError *error);
 static gboolean ensure_runtime_vtable (MonoClass *klass, MonoError  *error);
 static void reflection_methodbuilder_from_dynamic_method (ReflectionMethodBuilder *rmb, MonoReflectionDynamicMethod *mb);
@@ -640,7 +639,7 @@ mono_image_get_memberref_token (MonoDynamicImage *assembly, MonoType *type, cons
 }
 
 
-static guint32
+guint32
 mono_image_get_methodref_token (MonoDynamicImage *assembly, MonoMethod *method, gboolean create_typespec)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
@@ -721,6 +720,14 @@ mono_image_get_varargs_method_token (MonoDynamicImage *assembly, guint32 origina
 	return token;
 }
 
+#else /* DISABLE_REFLECTION_EMIT */
+
+guint32
+mono_image_get_methodref_token (MonoDynamicImage *assembly, MonoMethod *method, gboolean create_typespec)
+{
+	g_assert_not_reached ();
+	return -1;
+}
 #endif
 
 static gboolean


### PR DESCRIPTION
This is a backport of #4767 to `2017-02`.

----

The code expected that a custom attribute was specified as a MonoCMethod and
was calling mono_image_create_token().  However that function expects to be
called from the managed S.R.E.ModuleBuilder:GetToken (MemberInfo) which handles
all the builders in managed code.  Consequently mono_image_create_token () was
asserting.

So now we encode the token for a ConstructorBuilder in place.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=55681
This should resolve fsharp/FAKE#1533