### PR TITLE
[jit] Fix memory leak in trampoline info registration. (redo)

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -484,7 +484,11 @@ mono_tramp_info_register_internal (MonoTrampInfo *info, MonoDomain *domain, gboo
 	if (!domain)
 		domain = mono_get_root_domain ();
 
-	copy = g_new0 (MonoTrampInfo, 1);
+	if (domain)
+		copy = mono_domain_alloc0 (domain, sizeof (MonoTrampInfo));
+	else
+		copy = g_new0 (MonoTrampInfo, 1);
+
 	copy->code = info->code;
 	copy->code_size = info->code_size;
 	copy->name = g_strdup (info->name);
@@ -498,10 +502,6 @@ mono_tramp_info_register_internal (MonoTrampInfo *info, MonoDomain *domain, gboo
 		copy->uw_info_len = info->uw_info_len;
 	}
 
-	mono_jit_lock ();
-	tramp_infos = g_slist_prepend (tramp_infos, copy);
-	mono_jit_unlock ();
-
 	mono_save_trampoline_xdebug_info (info);
 	mono_lldb_save_trampoline_info (info);
 
@@ -510,9 +510,15 @@ mono_tramp_info_register_internal (MonoTrampInfo *info, MonoDomain *domain, gboo
 		mono_arch_unwindinfo_install_tramp_unwind_info (info->unwind_ops, info->code, info->code_size);
 #endif
 
-	/* Only register trampolines that have unwind infos */
-	if (mono_get_root_domain () && copy->uw_info)
+	if (!domain) {
+		/* If no root domain has been created yet, postpone the registration. */
+		mono_jit_lock ();
+		tramp_infos = g_slist_prepend (tramp_infos, copy);
+		mono_jit_unlock ();
+	} else if (copy->uw_info) {
+		/* Only register trampolines that have unwind infos */
 		register_trampoline_jit_info (domain, copy);
+	}
 
 	if (mono_jit_map_is_enabled ())
 		mono_emit_jit_tramp (info->code, info->code_size, info->name);


### PR DESCRIPTION
Hello,
This is #4765 redone. The original PR had a bug (a concurrency issue due to accessing `mono_mempool_alloc()` directly), was accidentally merged, but then reverted. The original PR message is below.

This fixes two memory leaks in mono_tramp_info_register().
- One issue is related to the fact that the `tramp_infos` list was perpetually growing with addition of every trampoline, even though it isn't used anywhere after `mini_init()`. This is solved by only adding trampolines to the list that are created before the root domain has been fully initialised.
- Another leaky behaviour has to do with MonoTrampInfo not being freed upon domain destruction. This is solved by allocating that structure in the domain's memory pool if the domain has already been initialised.