### PR TITLE
[sgen] Fix accidental triggering of degraded mode

### DIFF
--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -241,7 +241,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 						p = (void **)sgen_nursery_alloc (size);
 				}
 				if (!p)
-					return alloc_degraded (vtable, size, FALSE);
+					return alloc_degraded (vtable, size, TRUE);
 
 				zero_tlab_if_necessary (p, size);
 			} else {
@@ -258,7 +258,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 						p = (void **)sgen_nursery_alloc_range (tlab_size, size, &alloc_size);
 				}
 				if (!p)
-					return alloc_degraded (vtable, size, FALSE);
+					return alloc_degraded (vtable, size, TRUE);
 
 				/* Allocate a new TLAB from the current nursery fragment */
 				TLAB_START = (char*)p;


### PR DESCRIPTION
We trigger degraded mode when we are unable to properly build the nursery fragments due to excessive nursery pinning. This is done by initializing degraded_mode at the end of a minor. alloc_degraded is used to do allocation to major heap either as part of mature allocation or as part of degraded mode (when we bump the degraded_mode so we can detect when the next minor should be triggered).

When failing to allocate from the nursery after doing a minor (because the other threads might have already consumed the nursery) we need to do a mature allocation (as a fallback) instead of a degraded mode allocation so we don't uselessly enable the mode.