### PR TITLE
Cleanup and improve Makefile build logic.

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -28,11 +28,22 @@ LIB_MCS_FLAGS += $(patsubst %,-r:%.dll, $(subst =,=$(topdir)/class/lib/$(PROFILE
 
 sourcefile = $(LIBRARY).sources
 
+profile_library = $(PROFILE)_$(LIBRARY)
+
 # If the directory contains the per profile include file, generate list file.
-PROFILE_sources := $(wildcard $(PROFILE)_$(LIBRARY).sources)
+ifdef intermediate
+PROFILE_sources := $(wildcard $(PROFILE)_$(intermediate)_$(LIBRARY).sources)
 ifdef PROFILE_sources
-PROFILE_excludes = $(wildcard $(PROFILE)_$(LIBRARY).exclude.sources)
-sourcefile = $(depsdir)/$(PROFILE)_$(LIBRARY).sources
+profile_library = $(PROFILE)_$(intermediate)_$(LIBRARY)
+else
+PROFILE_sources := $(wildcard $(PROFILE)_$(LIBRARY).sources)
+endif
+else
+PROFILE_sources := $(wildcard $(PROFILE)_$(LIBRARY).sources)
+endif
+ifdef PROFILE_sources
+PROFILE_excludes = $(wildcard $(profile_library).exclude.sources)
+sourcefile = $(depsdir)/$(profile_library).sources
 library_CLEAN_FILES += $(sourcefile)
 
 # Note, gensources.sh can create a $(sourcefile).makefrag if it sees any '#include's
@@ -66,6 +77,7 @@ lib_dir = lib
 endif
 
 ifdef LIBRARY_SUBDIR
+profile_library = $(PROFILE)_$(LIBRARY_SUBDIR)_$(LIBRARY)
 the_libdir_base = $(topdir)/class/$(lib_dir)/$(PROFILE)/$(LIBRARY_SUBDIR)/
 else
 the_libdir_base = $(topdir)/class/$(lib_dir)/$(PROFILE)/
@@ -327,7 +339,7 @@ all-local-aot: $(the_lib)$(PLATFORM_AOT_SUFFIX)
 endif
 
 
-makefrag = $(depsdir)/$(PROFILE)_$(LIBRARY_SUBDIR)_$(LIBRARY).makefrag
+makefrag = $(depsdir)/$(profile_library).makefrag
 library_CLEAN_FILES += $(makefrag)
 $(makefrag): $(sourcefile)
 #	@echo Creating $@ ...

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -32,9 +32,10 @@ profile_library = $(PROFILE)_$(LIBRARY)
 
 # If the directory contains the per profile include file, generate list file.
 ifdef intermediate
-PROFILE_sources := $(wildcard $(PROFILE)_$(intermediate)_$(LIBRARY).sources)
+intermediate_name = $(patsubst %_,%,$(subst /,_,$(intermediate)))
+PROFILE_sources := $(wildcard $(PROFILE)_$(intermediate_name)_$(LIBRARY).sources)
 ifdef PROFILE_sources
-profile_library = $(PROFILE)_$(intermediate)_$(LIBRARY)
+profile_library = $(PROFILE)_$(intermediate_name)_$(LIBRARY)
 else
 PROFILE_sources := $(wildcard $(PROFILE)_$(LIBRARY).sources)
 endif

--- a/mcs/build/profiles/basic.make
+++ b/mcs/build/profiles/basic.make
@@ -66,8 +66,6 @@ post-profile-cleanup:
 PROFILE_EXE = $(depsdir)/basic-profile-check.exe
 PROFILE_OUT = $(PROFILE_EXE:.exe=.out)
 
-MAKE_Q=$(if $(V),,-s)
-
 do-profile-check: $(depsdir)/.stamp
 	@ok=:; \
 	rm -f $(PROFILE_EXE) $(PROFILE_OUT); \

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -25,6 +25,10 @@ Q=$(if $(V),,@)
 Q_MCS=$(if $(V),,@echo "$(if $(MCS_MODE),MCS,CSC)     [$(intermediate)$(PROFILE)] $(notdir $(@))";)
 Q_AOT=$(if $(V),,@echo "AOT     [$(intermediate)$(PROFILE)] $(notdir $(@))";)
 
+MAKE_Q=$(if $(V),,-s)
+MAKE_V=$(if $(V),V=1,)
+
+
 ifndef BUILD_TOOLS_PROFILE
 BUILD_TOOLS_PROFILE = build
 endif

--- a/mcs/class/System/Makefile
+++ b/mcs/class/System/Makefile
@@ -150,27 +150,27 @@ ifeq (bare/,$(intermediate))
 build-bare:
 else
 $(bare_libdir)/System.dll:
-	$(MAKE) intermediate=bare/ $(bare_libdir)/System.dll
+	$(MAKE) $(MAKE_V) intermediate=bare/ $(bare_libdir)/System.dll
 endif
 
 ifneq (secxml/,$(intermediate))
 $(secxml_libdir)/System.dll: $(bare_libdir)/System.dll $(bare_libdir)/System.Xml.dll $(MONO_SECURITY_DLL) $(bare_libdir)/System.dll
-	$(MAKE) intermediate=secxml/ $(secxml_libdir)/System.dll
+	$(MAKE) $(MAKE_V) intermediate=secxml/ $(secxml_libdir)/System.dll
 else
 build-sec:
 endif
 
 $(the_libdir_base)System.Xml.dll:
-	(cd ../System.XML; $(MAKE) $@)
+	(cd ../System.XML; $(MAKE) $(MAKE_V) $@)
 
 $(bare_libdir)/System.Xml.dll:
-	(cd ../System.XML; $(MAKE) $@)
+	(cd ../System.XML; $(MAKE) $(MAKE_V) $@)
 
 $(the_libdir_base)Mono.Security.dll: ../Mono.Security/Makefile
-	(cd ../Mono.Security; $(MAKE))
+	(cd ../Mono.Security; $(MAKE) $(MAKE_V))
 
 $(the_libdir_base)System.Configuration.dll:
-	(cd ../System.Configuration; $(MAKE))
+	(cd ../System.Configuration; $(MAKE) $(MAKE_V))
 
 $(build_lib): $(CYCLIC_DEP_FILES)
 
@@ -189,7 +189,7 @@ fresh: clean
 ifndef intermediate
 ifneq ($(PROFILE),basic)
 csproj-local:
-	$(MAKE) csproj-local intermediate=bare/
-	$(MAKE) csproj-local intermediate=secxml/
+	$(MAKE) $(MAKE_V) csproj-local intermediate=bare/
+	$(MAKE) $(MAKE_V) csproj-local intermediate=secxml/
 endif
 endif

--- a/mcs/class/System/net_4_x_bare_System.dll.sources
+++ b/mcs/class/System/net_4_x_bare_System.dll.sources
@@ -1,0 +1,2 @@
+#include net_4_x_System.dll.sources
+

--- a/mcs/class/System/net_4_x_secxml_System.dll.sources
+++ b/mcs/class/System/net_4_x_secxml_System.dll.sources
@@ -1,0 +1,2 @@
+#include net_4_x_System.dll.sources
+


### PR DESCRIPTION
We now use custom .sources file for intermediate builds, such as `System/net_4_x_bare_System.dll.sources` and `net_4_x_secxml_System.dll.sources`.

The goal is to get rid of the `SECURITY_DEP` and related conditionals to make it easier to use code from corefx.