### PR TITLE
[System]: Fully stub-out SslStream on platforms where it's not supported

### DIFF
--- a/mcs/class/System/System.Net.Security/LocalCertificateSelectionCallback.cs
+++ b/mcs/class/System/System.Net.Security/LocalCertificateSelectionCallback.cs
@@ -28,7 +28,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-#if SECURITY_DEP
 
 using System.Security.Cryptography.X509Certificates;
 
@@ -41,4 +40,3 @@ namespace System.Net.Security
 		X509Certificate remoteCertificate,
 		string [] acceptableIssuers);
 }
-#endif

--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -39,6 +39,7 @@ using Mono.Security.Interface;
 using CipherAlgorithmType = System.Security.Authentication.CipherAlgorithmType;
 using HashAlgorithmType = System.Security.Authentication.HashAlgorithmType;
 using ExchangeAlgorithmType = System.Security.Authentication.ExchangeAlgorithmType;
+#endif
 
 using System.IO;
 using System.Net;
@@ -73,6 +74,7 @@ namespace System.Net.Security
 
 	public class SslStream : AuthenticatedStream
 	{
+#if SECURITY_DEP
 		MonoTlsProvider provider;
 		IMonoSslStream impl;
 
@@ -387,84 +389,257 @@ namespace System.Net.Security
 		{
 			Impl.EndWrite (asyncResult);
 		}
-	}
-}
 #else // !SECURITY_DEP
+		const string EXCEPTION_MESSAGE = "System.Net.Security.SslStream is not supported on the current platform.";
 
-using System.IO;
-using System.Threading.Tasks;
-
-namespace System.Net.Security
-{
-	public class SslStream : Stream
-	{
-		public SslStream (object innerStream)
+		public SslStream (Stream innerStream)
+			: this (innerStream, false)
 		{
 		}
 
-		public override bool CanRead {
-			get {
-				throw new NotImplementedException ();
-			}
+		public SslStream (Stream innerStream, bool leaveInnerStreamOpen)
+			: base (innerStream, leaveInnerStreamOpen)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public SslStream (Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback)
+			: this (innerStream, leaveInnerStreamOpen)
+		{
+		}
+
+		public SslStream (Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback, LocalCertificateSelectionCallback userCertificateSelectionCallback)
+			: this (innerStream, leaveInnerStreamOpen)
+		{
+		}
+
+		public SslStream (Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback, LocalCertificateSelectionCallback userCertificateSelectionCallback, EncryptionPolicy encryptionPolicy)
+			: this (innerStream, leaveInnerStreamOpen)
+		{
+		}
+
+		public virtual void AuthenticateAsClient (string targetHost)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual void AuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual IAsyncResult BeginAuthenticateAsClient (string targetHost, AsyncCallback asyncCallback, object asyncState)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual IAsyncResult BeginAuthenticateAsClient (string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual void EndAuthenticateAsClient (IAsyncResult asyncResult)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual void AuthenticateAsServer (X509Certificate serverCertificate)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual void AuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, AsyncCallback asyncCallback, object asyncState)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, bool clientCertificateRequired, SslProtocols enabledSslProtocols, bool checkCertificateRevocation, AsyncCallback asyncCallback, object asyncState)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual void EndAuthenticateAsServer (IAsyncResult asyncResult)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public TransportContext TransportContext {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual Task AuthenticateAsClientAsync (string targetHost)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual Task AuthenticateAsClientAsync (string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual Task AuthenticateAsServerAsync (X509Certificate serverCertificate)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public virtual Task AuthenticateAsServerAsync (X509Certificate serverCertificate, bool clientCertificateRequired, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override bool IsAuthenticated {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override bool IsMutuallyAuthenticated {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override bool IsEncrypted {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override bool IsSigned {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override bool IsServer {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual SslProtocols SslProtocol {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual bool CheckCertRevocationStatus {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual X509Certificate LocalCertificate {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual X509Certificate RemoteCertificate {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual CipherAlgorithmType CipherAlgorithm {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual int CipherStrength {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual HashAlgorithmType HashAlgorithm {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual int HashStrength {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual ExchangeAlgorithmType KeyExchangeAlgorithm {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public virtual int KeyExchangeStrength {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 		}
 
 		public override bool CanSeek {
-			get {
-				throw new NotImplementedException ();
-			}
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override bool CanRead {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override bool CanTimeout {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 		}
 
 		public override bool CanWrite {
-			get {
-				throw new NotImplementedException ();
-			}
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override int ReadTimeout {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override int WriteTimeout {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 		}
 
 		public override long Length {
-			get {
-				throw new NotImplementedException ();
-			}
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 		}
 
 		public override long Position {
-			get {
-				throw new NotImplementedException ();
-			}
-
-			set {
-				throw new NotImplementedException ();
-			}
-		}
-
-		public override void Flush ()
-		{
-			throw new NotImplementedException ();
-		}
-
-		public override int Read (System.Byte [] buffer, int offset, int count)
-		{
-			throw new NotImplementedException ();
-		}
-
-		public override long Seek (long offset, SeekOrigin origin)
-		{
-			throw new NotImplementedException ();
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 		}
 
 		public override void SetLength (long value)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
 		}
 
-		public override void Write (System.Byte [] buffer, int offset, int count)
+		public override long Seek (long offset, SeekOrigin origin)
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
 		}
 
-		public virtual Task AuthenticateAsClientAsync (string targetHost, object clientCertificates, object enabledSslProtocols, bool checkCertificateRevocation)
+		public override void Flush ()
 		{
-			throw new NotImplementedException ();
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+		}
+
+		public override int Read (byte[] buffer, int offset, int count)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public void Write (byte[] buffer)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override void Write (byte[] buffer, int offset, int count)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override int EndRead (IAsyncResult asyncResult)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override void EndWrite (IAsyncResult asyncResult)
+		{
+			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+#endif
 	}
 }
-#endif

--- a/mcs/class/System/System.Net.Security/SslStream.platformnotsupported.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.platformnotsupported.cs
@@ -32,7 +32,7 @@ using System.Threading.Tasks;
 namespace System.Net.Security
 {
 	/*
-	 * These two are defined by the referencesource; add them heere to make
+	 * These two are defined by the referencesource; add them here to make
 	 * it easy to switch between the two implementations.
 	 */
 

--- a/mcs/class/System/System.Net.Security/SslStream.platformnotsupported.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.platformnotsupported.cs
@@ -31,6 +31,23 @@ using System.Threading.Tasks;
 
 namespace System.Net.Security
 {
+	/*
+	 * These two are defined by the referencesource; add them heere to make
+	 * it easy to switch between the two implementations.
+	 */
+
+	internal delegate bool RemoteCertValidationCallback (
+		string host,
+		X509Certificate certificate,
+		X509Chain chain,
+		SslPolicyErrors sslPolicyErrors);
+
+	internal delegate X509Certificate LocalCertSelectionCallback (
+		string targetHost,
+		X509CertificateCollection localCertificates,
+		X509Certificate remoteCertificate,
+		string[] acceptableIssuers);
+
 	public class SslStream : AuthenticatedStream
 	{
 		const string EXCEPTION_MESSAGE = "System.Net.Security.SslStream is not supported on the current platform.";
@@ -51,7 +68,6 @@ namespace System.Net.Security
 		{
 		}
 
-#if SECURITY_DEP
 		public SslStream (Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback, LocalCertificateSelectionCallback userCertificateSelectionCallback)
 			: this (innerStream, leaveInnerStreamOpen)
 		{
@@ -61,7 +77,6 @@ namespace System.Net.Security
 			: this (innerStream, leaveInnerStreamOpen)
 		{
 		}
-#endif
 
 		public virtual void AuthenticateAsClient (string targetHost)
 		{


### PR DESCRIPTION
* Remove 'SECURITY_DEP' conditional from LocalCertificateSelectionCallback.

* Add the internal delegates and remove 'SECURITY_DEP' from SslStream.platformnotsupported.cs.

* In SslStream.cs, we now provide the full API when '!SECURITY_DEP' using the
PlatformNotSupportedException()-based implementation from SslStream.platformnotsupported.cs