### PR TITLE
[bcl] Add API diff for monotouch/monodroid profiles

### DIFF
--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -175,10 +175,17 @@ $(MONO_API_SNAPSHOT_PROFILE_PATH)%.cs: $(topdir)class/lib/$(PROFILE)/%.dll $(GEN
 
 mono-api-current: $(MONO_API_ASSEMBLIES_CS)
 
+mono-api-current-clean:
+	$(Q) rm -rf "$(MONO_API_SNAPSHOT_PROFILE_PATH)"
+
 mono-api-diff:
 	@echo "Regenerating API snapshot..."
-	$(Q) rm -rf "$(MONO_API_SNAPSHOT_PROFILE_PATH)"
-	$(Q) $(MAKE) mono-api-current
+	$(Q) $(MAKE) mono-api-current-clean PROFILE=net_4_x
+	$(Q) $(MAKE) mono-api-current-clean PROFILE=monotouch
+	$(Q) $(MAKE) mono-api-current-clean PROFILE=monodroid
+	$(Q) $(MAKE) mono-api-current PROFILE=net_4_x
+	$(Q) $(MAKE) mono-api-current PROFILE=monotouch
+	$(Q) $(MAKE) mono-api-current PROFILE=monodroid
 	@echo "Checking public API differences..."
 	$(Q) cd $(MONO_API_SNAPSHOT_PATH); git add -A .
 	$(Q) cd $(MONO_API_SNAPSHOT_PATH); git diff --no-renames HEAD > $(abspath $(topdir))/temp.patch

--- a/mcs/diff.html.in
+++ b/mcs/diff.html.in
@@ -12,10 +12,13 @@
   <body style="font-family: 'Open Sans'">
     <h1>@title@</h1>
     <p>@description@</p>
-    <div id="diff"><!--<![CDATA[
+    <p>Download <a id="patchdownload" href="#">changes.patch</a> which can be applied with <code>git apply changes.patch</code>.</p>
+
+    <div id="diffsource" style="display:none"><!--<![CDATA[
 @diffdata@
 ]]>-->
     </div>
+    <div id="diff">Loading ...</div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
@@ -24,11 +27,28 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.3.0/diff2html.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/diff2html/2.3.0/diff2html-ui.min.js"></script>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.min.js"></script>
+
     <script>
     $(document).ready(function() {
-        var diff2htmlUi = new Diff2HtmlUI({diff: $("#diff")[0].childNodes[0].nodeValue});
-        diff2htmlUi.draw('#diff', {showFiles: true, matching: 'lines'});
-        diff2htmlUi.highlightCode('#diff');
+        var diffText = $("#diffsource")[0].childNodes[0].nodeValue;
+        $("#diffsource").remove();
+        diffText = diffText.substring(10, diffText.length - 3);
+        if (diffText.length == 0) {
+          $("#diff").text("No changes found.");
+          return;
+        }
+
+        $("#patchdownload").click(function() {
+          var blob = new Blob([diffText], { type: "text/plain;charset=utf-8;" });
+          saveAs(blob, "changes.patch");
+        });
+
+        var diff2htmlUi = new Diff2HtmlUI({diff: diffText});
+        diff2htmlUi.draw('#diff', {showFiles: true, matching: 'none'});
+        setTimeout(function() {
+          diff2htmlUi.highlightCode('#diff');
+        }, 100);
     });
     </script>
   </body>


### PR DESCRIPTION
This runs the API diff against the monotouch and monodroid profiles in addition to net_4_x to help us catch mistakes that only affect the mobile profiles.

To make updating the API snapshot in case of an intentional change easier without needing to build those profiles locally I added a way to download the diff as a .patch file. You can just download the file from the API diff Jenkins generates and apply it locally.