### PR TITLE
[System]: Add private '_internalLock' field to HttpListener.

### DIFF
--- a/mcs/class/System/System.Net/HttpListener.Mono.cs
+++ b/mcs/class/System/System.Net/HttpListener.Mono.cs
@@ -60,7 +60,7 @@ namespace System.Net {
 
 		internal X509Certificate LoadCertificateAndKey (IPAddress addr, int port)
 		{
-			lock (registry) {
+			lock (_internalLock) {
 				if (certificate != null)
 					return certificate;
 
@@ -89,7 +89,7 @@ namespace System.Net {
 
 		internal SslStream CreateSslStream (Stream innerStream, bool ownsStream, RemoteCertificateValidationCallback callback)
 		{
-			lock (registry) {
+			lock (_internalLock) {
 				if (tlsProvider == null)
 					tlsProvider = MSI.MonoTlsProviderFactory.GetProvider ();
 				if (tlsSettings == null)

--- a/mcs/class/System/System.Net/HttpListener.cs
+++ b/mcs/class/System/System.Net/HttpListener.cs
@@ -50,6 +50,8 @@ namespace System.Net {
 		bool listening;
 		bool disposed;
 
+		readonly object _internalLock; // don't rename to match CoreFx
+
 		Hashtable registry;   // Dictionary<HttpListenerContext,HttpListenerContext> 
 		ArrayList ctx_queue;  // List<HttpListenerContext> ctx_queue;
 		ArrayList wait_queue; // List<ListenerAsyncResult> wait_queue;
@@ -63,6 +65,7 @@ namespace System.Net {
 
 		public HttpListener ()
 		{
+			_internalLock = new object ();
 			prefixes = new HttpListenerPrefixCollection (this);
 			registry = new Hashtable ();
 			connections = Hashtable.Synchronized (new Hashtable ());
@@ -218,7 +221,7 @@ namespace System.Net {
 
 		void Cleanup (bool close_existing)
 		{
-			lock (registry) {
+			lock (_internalLock) {
 				if (close_existing) {
 					// Need to copy this since closing will call UnregisterContext
 					ICollection keys = registry.Keys;
@@ -374,7 +377,7 @@ namespace System.Net {
 
 		internal void RegisterContext (HttpListenerContext context)
 		{
-			lock (registry)
+			lock (_internalLock)
 				registry [context] = context;
 
 			ListenerAsyncResult ares = null;
@@ -393,7 +396,7 @@ namespace System.Net {
 
 		internal void UnregisterContext (HttpListenerContext context)
 		{
-			lock (registry)
+			lock (_internalLock)
 				registry.Remove (context);
 			lock (ctx_queue) {
 				int idx = ctx_queue.IndexOf (context);


### PR DESCRIPTION
After switching to the CoreFx version, HttpListener.Mono.cs will remain,
so it needs to use the proper locking object.