### PR TITLE
[jit] Mark bblocks making calls to the corlib ThrowHelper class as ou…

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8734,6 +8734,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			sp -= n;
 
+			if (cmethod && cmethod->klass->image == mono_defaults.corlib && !strcmp (cmethod->klass->name, "ThrowHelper"))
+				cfg->cbb->out_of_line = TRUE;
+
 			/*
 			 * We have the `constrained.' prefix opcode.
 			 */


### PR DESCRIPTION
…t of line.