### PR TITLE
[remoting] Serialize exceptions between domains inside try/catch

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -458,6 +458,7 @@ TESTS_CS_SRC=		\
 	appdomain1.cs	\
 	appdomain2.cs	\
 	appdomain-exit.cs	\
+	appdomain-serialize-exception.cs \
 	assemblyresolve_event2.2.cs	\
 	appdomain-unload-callback.cs	\
 	appdomain-unload-doesnot-raise-pending-events.cs	\

--- a/mono/tests/appdomain-serialize-exception.cs
+++ b/mono/tests/appdomain-serialize-exception.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+public class UnserializableException : Exception
+{
+}
+
+public class TestOutput : MarshalByRefObject
+{
+	public void ThrowUnserializable ()
+	{
+		Console.WriteLine("Throwing Unserializable exception in AppDomain \"{0}\"", AppDomain.CurrentDomain.FriendlyName);
+		throw new UnserializableException ();
+	}
+}
+
+public class Example
+{
+	public static int Main ()
+	{
+		string original_domain = AppDomain.CurrentDomain.FriendlyName;
+
+		AppDomain ad = AppDomain.CreateDomain("subdomain");
+		try {
+			TestOutput remoteOutput = (TestOutput) ad.CreateInstanceAndUnwrap(
+				typeof (TestOutput).Assembly.FullName,
+				"TestOutput");
+			remoteOutput.ThrowUnserializable ();
+		} catch (SerializationException) {
+			Console.WriteLine ("Caught serialization exception");
+		} catch (Exception) {
+			Console.WriteLine ("Caught other exception");
+			Environment.Exit (1);
+		} finally {
+			Console.WriteLine ("Finally in domain {0}", AppDomain.CurrentDomain.FriendlyName);
+			if (original_domain != AppDomain.CurrentDomain.FriendlyName)
+				Environment.Exit (2);
+			AppDomain.Unload (ad);
+		}
+
+		Console.WriteLine ("All OK");
+		return 0;
+	}
+}


### PR DESCRIPTION
If a remote invoke in another domain throws an exception, the xdomain-dispatch wrapper will serialize the exception and pass it over to the calling domain so that it can be rethrown there. Serializing the exception object can itself throw an exception which we didn't properly catch, leading to unwinding to the caller domain without changing the domain state back and wreaking havoc.

If the serialization of the original exception throws a new exception, this new exception takes its place, being passed instead to the caller domain.