### PR TITLE
[System] Use 'ObjCRuntimeInternal' as the namespace instead of 'ObjCRuntime'.

### DIFF
--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -35,7 +35,7 @@ using Mono.Net;
 using Mono.Net.Security;
 using Mono.Util;
 
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 
 namespace Mono.AppleTls
 {

--- a/mcs/class/System/Mono.AppleTls/Certificate.cs
+++ b/mcs/class/System/Mono.AppleTls/Certificate.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using Mono.Net;
 
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 
 namespace Mono.AppleTls {
 

--- a/mcs/class/System/Mono.AppleTls/Enums.cs
+++ b/mcs/class/System/Mono.AppleTls/Enums.cs
@@ -1,7 +1,7 @@
 #if MONO_FEATURE_APPLETLS
 // Copyright 2011-2015 Xamarin Inc. All rights reserved.
 
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 
 namespace Mono.AppleTls {
 

--- a/mcs/class/System/Mono.AppleTls/INativeObject.cs
+++ b/mcs/class/System/Mono.AppleTls/INativeObject.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ObjCRuntime {
+namespace ObjCRuntimeInternal {
 
 	internal interface INativeObject {
 		IntPtr Handle { 

--- a/mcs/class/System/Mono.AppleTls/ImportExport.cs
+++ b/mcs/class/System/Mono.AppleTls/ImportExport.cs
@@ -31,7 +31,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 using Mono.Net;
 
 #if MONO_FEATURE_BTLS

--- a/mcs/class/System/Mono.AppleTls/Items.cs
+++ b/mcs/class/System/Mono.AppleTls/Items.cs
@@ -34,7 +34,7 @@
 using System;
 using System.Collections;
 using System.Runtime.InteropServices;
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 using Mono.Net;
 
 namespace Mono.AppleTls {

--- a/mcs/class/System/Mono.AppleTls/Policy.cs
+++ b/mcs/class/System/Mono.AppleTls/Policy.cs
@@ -30,7 +30,7 @@
 //
 using System;
 using System.Runtime.InteropServices;
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 using Mono.Net;
 
 namespace Mono.AppleTls {

--- a/mcs/class/System/Mono.AppleTls/Trust.cs
+++ b/mcs/class/System/Mono.AppleTls/Trust.cs
@@ -32,7 +32,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 using Mono.Net;
 
 namespace Mono.AppleTls {

--- a/mcs/class/System/System.Net/MacProxy.cs
+++ b/mcs/class/System/System.Net/MacProxy.cs
@@ -29,7 +29,7 @@ using System.Net;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
-using ObjCRuntime;
+using ObjCRuntimeInternal;
 
 namespace Mono.Net
 {


### PR DESCRIPTION
Use 'ObjCRuntimeInternal' as the namespace instead of 'ObjCRuntime' to avoid
these compiler-warnings when building xamarin-macios assemblies (which defines
the same types in the ObjCRuntime namespace, and to whom System.dll has an
InternalsVisibleTo attribute):

```
xamarin-macios/src/build/watch/watch/Foundation/NSExtensionRequestHandling.g.cs(28,49): warning CS0436: The type `ObjCRuntime.INativeObject' conflicts with the imported type of same name'. Ignoring the imported type definition
xamarin-macios/src/ObjCRuntime/INativeObject.cs(6,19): (Location of the symbol related to previous warning)
xamarin-macios/_ios-build/Library/Frameworks/Xamarin.iOS.framework/Versions/git/lib/mono/Xamarin.WatchOS/repl/System.dll (Location of the symbol related to previous warning)
```