### PR TITLE
Specify Encoding.UTF8 when marshaling native runtime string. If not, …

### DIFF
--- a/mcs/class/corlib/Mono/RuntimeMarshal.cs
+++ b/mcs/class/corlib/Mono/RuntimeMarshal.cs
@@ -7,7 +7,20 @@ namespace Mono {
 		internal static string PtrToUtf8String (IntPtr ptr)
 		{
 			unsafe {
-				return new String ((sbyte*)ptr);
+				if (ptr == IntPtr.Zero)
+					return string.Empty;
+
+				byte* bytes = (byte*)ptr;
+				int length = 0;
+
+				try {
+					while (bytes++ [0] != 0)
+						length++;
+				} catch (NullReferenceException) {
+					throw new ArgumentOutOfRangeException ("ptr", "Value does not refer to a valid string.");
+				}
+
+				return new String ((sbyte*)ptr, 0, length, System.Text.Encoding.UTF8);
 			}
 		}
 


### PR DESCRIPTION
…string constructor accesses Encoding.Default which causes infinite recursion on Windows for codepages supported via I18N. While trying to load I18N assemblies, assembly names are marshaled in managed code now hitting this code path. Fixes Xamarin bug 43988.

FYI, this implementation is taken from string constructor (CreateString) except for specifying the Encoding as we know it's UTF8: https://github.com/mono/mono/blob/master/mcs/class/corlib/ReferenceSources/String.cs#L652