### PR TITLE
[threadpool] Fix alignment of ThreadPoolWorker.counters field

### DIFF
--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -118,7 +118,11 @@ typedef union {
 		gint16 parked; /* parked */
 	} _;
 	gint64 as_gint64;
-} ThreadPoolWorkerCounter;
+} ThreadPoolWorkerCounter
+#ifdef __GNUC__
+__attribute__((aligned(64)))
+#endif
+;
 
 typedef struct {
 	MonoRefCount ref;


### PR DESCRIPTION
It is accessed with a 64bits atomic operation, so it needs to be 64bits aligned, even on a 32bits platform. A CPU exception EXC_ARM_DA_ALIGN triggers on armv7 32bits.

Fix https://bugzilla.xamarin.com/show_bug.cgi?id=56202