### PR TITLE
[mcs] Add platform specific files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4555,8 +4555,13 @@ fi
     echo "MONO_CORLIB_VERSION = $MONO_CORLIB_VERSION" >> $mcs_topdir/build/config.make
 
     if test x$host_darwin = xyes; then
-      echo "PLATFORM = darwin" >> $mcs_topdir/build/config.make
+      echo "BUILD_PLATFORM = darwin" >> $mcs_topdir/build/config.make
+    elif test x$host_win32 = xyes; then
+      echo "BUILD_PLATFORM = win32" >> $mcs_topdir/build/config.make
+    else
+      echo "BUILD_PLATFORM = linux" >> $mcs_topdir/build/config.make
     fi
+
 
     if test "x$PLATFORM_AOT_SUFFIX" != "x"; then
       echo "PLATFORM_AOT_SUFFIX = $PLATFORM_AOT_SUFFIX" >> $mcs_topdir/build/config.make

--- a/configure.ac
+++ b/configure.ac
@@ -4562,6 +4562,13 @@ fi
       echo "BUILD_PLATFORM = linux" >> $mcs_topdir/build/config.make
     fi
 
+    if test x$host_darwin = xyes; then
+      echo "HOST_PLATFORM ?= darwin" >> $mcs_topdir/build/config.make
+    elif test x$host_win32 = xyes; then
+      echo "HOST_PLATFORM ?= win32" >> $mcs_topdir/build/config.make
+    else
+      echo "HOST_PLATFORM ?= linux" >> $mcs_topdir/build/config.make
+    fi
 
     if test "x$PLATFORM_AOT_SUFFIX" != "x"; then
       echo "PLATFORM_AOT_SUFFIX = $PLATFORM_AOT_SUFFIX" >> $mcs_topdir/build/config.make

--- a/mcs/build/README.configury
+++ b/mcs/build/README.configury
@@ -6,12 +6,12 @@ Peter Williams <peter@newton.cx>
 It's pretty easy. You can create two files in this directory to tweak
 settings: pre-config.make and config.make.
 
-pre-config.make is included before $(PLATFORM).make and
+pre-config.make is included before $(BUILD_PLATFORM).make and
 $(PROFILE).make, so you can set either of these variables if you want
 to change the default.
 
 Just about any other change should go in config.make, which is
-included after $(PLATFORM).make and $(PROFILE).make, so you can use
+included after $(BUILD_PLATFORM).make and $(PROFILE).make, so you can use
 the values defined in those files if you wish. For example,
 
     MCS_FLAGS = $(DEFAULT_MCS_FLAGS) /my-experimental-optimizer-flag

--- a/mcs/build/README.makefiles
+++ b/mcs/build/README.makefiles
@@ -119,8 +119,8 @@ Configuration variables are given defaults in `config-default.make';
 `rules.make' optionally includes `$(topdir)/build/config.make', so you
 can customize your build without CVS trying to commit your modified
 `config-default.make' all the time.  Platform-specific variables are
-defined in `$(topdir)/build/platforms/$(PLATFORM).make', where
-$(PLATFORM) is detected in config-default.make. (Currently, the only
+defined in `$(topdir)/build/platforms/$(BUILD_PLATFORM).make', where
+$(BUILD_PLATFORM) is detected in config-default.make. (Currently, the only
 choices are linux.make and win32.make.)
 
 The best way to learn what the configuration variables are is to read

--- a/mcs/build/config-default.make
+++ b/mcs/build/config-default.make
@@ -10,7 +10,7 @@
 CODEPAGE = 65001
 
 RUNTIME_FLAGS =
-TEST_HARNESS = $(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)nunit-lite-console.exe
+TEST_HARNESS = $(topdir)/class/lib/$(PROFILE_DIRECTORY)/$(PARENT_PROFILE)nunit-lite-console.exe
 PLATFORM_DEBUG_FLAGS = /debug:portable
 MCS_FLAGS = 
 MBAS_FLAGS = -debug
@@ -24,7 +24,7 @@ mono_libdir = $(exec_prefix)/lib
 sysconfdir = $(prefix)/etc
 #RUNTIME = mono
 RUNTIME = false
-TEST_RUNTIME = MONO_PATH="./$(PLATFORM_PATH_SEPARATOR)$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$(TEST_MONO_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) --debug
+TEST_RUNTIME = MONO_PATH="./$(PLATFORM_PATH_SEPARATOR)$(topdir)/class/lib/$(PROFILE_DIRECTORY)$(PLATFORM_PATH_SEPARATOR)$(TEST_MONO_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) --debug
 
 # In case you want to add MCS_FLAGS, this lets you not have to
 # keep track of the default value

--- a/mcs/build/executable.make
+++ b/mcs/build/executable.make
@@ -19,7 +19,7 @@ executable_CLEAN_FILES += $(response)
 endif
 
 ifndef the_libdir
-the_libdir = $(topdir)/class/lib/$(PROFILE)/
+the_libdir = $(topdir)/class/lib/$(PROFILE_DIRECTORY)/
 ifdef PROGRAM_USE_INTERMEDIATE_FILE
 build_libdir = $(the_libdir)tmp/
 else
@@ -42,8 +42,8 @@ executable_CLEAN_FILES += $(build_lib) $(build_lib).so $(build_lib).mdb $(build_
 
 makefrag = $(depsdir)/$(PROFILE)_$(base_prog).makefrag
 
-MCS_REFERENCES = $(patsubst %,-r:$(topdir)/class/lib/$(PROFILE)/%.dll,$(LIB_REFS))
-MCS_REFERENCES += $(patsubst %,-r:$(topdir)/class/lib/$(PROFILE)/%.exe,$(EXE_REFS))
+MCS_REFERENCES = $(patsubst %,-r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/%.dll,$(LIB_REFS))
+MCS_REFERENCES += $(patsubst %,-r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/%.exe,$(EXE_REFS))
 
 ifndef NO_BUILD
 all-local: $(the_lib) $(PROGRAM_config)
@@ -117,7 +117,12 @@ ifndef PROGRAM_COMPILE
 PROGRAM_COMPILE = $(CSCOMPILE)
 endif
 
-$(the_lib): $(the_libdir)/.stamp
+$(the_lib): $(the_libdir)/.stamp $(if $(PROFILE_PLATFORM),$(if $(filter $(HOST_PLATFORM),$(BUILD_PLATFORM)),$(topdir)/class/lib/$(PROFILE)/.stamp))
+
+ifdef PROFILE_PLATFORM
+$(topdir)/class/lib/$(PROFILE)/.stamp: | $(topdir)/class/lib/$(PROFILE)-$(HOST_PLATFORM)/.stamp
+	$(if $(filter $(HOST_PLATFORM),$(BUILD_PLATFORM)),$(if $(filter $(BUILD_PLATFORM),win32),CYGWIN=winsymlinks:nativestrict) ln -s $(abspath $(topdir)/class/lib/$(PROFILE)-$(BUILD_PLATFORM)) $(abspath $(topdir)/class/lib/$(PROFILE)))
+endif
 
 $(build_lib): $(BUILT_SOURCES) $(EXTRA_SOURCES) $(response) $(build_libdir:=/.stamp)
 	$(PROGRAM_COMPILE) $(MCS_REFERENCES) -target:exe -out:$@ $(BUILT_SOURCES) $(EXTRA_SOURCES) @$(response)

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -42,7 +42,7 @@ $(sourcefile): $(PROFILE_sources) $(PROFILE_excludes) $(topdir)/build/gensources
 	$(SHELL) $(topdir)/build/gensources.sh $@ '$(PROFILE_sources)' '$(PROFILE_excludes)'
 endif
 
-PLATFORM_excludes := $(wildcard $(LIBRARY).$(PLATFORM)-excludes)
+PLATFORM_excludes := $(wildcard $(LIBRARY).$(BUILD_PLATFORM)-excludes)
 
 ifndef PLATFORM_excludes
 ifeq (cat,$(PLATFORM_CHANGE_SEPARATOR_CMD))
@@ -110,7 +110,7 @@ SN = MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARA
 endif
 endif
 
-ifeq ($(PLATFORM), win32)
+ifeq ($(BUILD_PLATFORM), win32)
 GACDIR = `cygpath -w $(mono_libdir)`
 GACROOT = `cygpath -w $(DESTDIR)$(mono_libdir)`
 test_flags += -d:WINDOWS

--- a/mcs/build/profiles/net_4_x.make
+++ b/mcs/build/profiles/net_4_x.make
@@ -5,6 +5,8 @@ BOOTSTRAP_PROFILE = build
 BOOTSTRAP_MCS = MONO_PATH="$(topdir)/class/lib/$(BOOTSTRAP_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(INTERNAL_CSC)
 MCS = $(BOOTSTRAP_MCS)
 
+PLATFORMS = darwin linux win32
+
 # nuttzing!
 
 profile-check:

--- a/mcs/build/profiles/net_4_x.make
+++ b/mcs/build/profiles/net_4_x.make
@@ -12,7 +12,7 @@ PLATFORMS = darwin linux win32
 profile-check:
 	@:
 
-DEFAULT_REFERENCES = -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll
+DEFAULT_REFERENCES = -r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/mscorlib.dll
 PROFILE_MCS_FLAGS = -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:WIN_PLATFORM -d:MULTIPLEX_OS -nowarn:1699 -nostdlib $(DEFAULT_REFERENCES) $(PLATFORM_DEBUG_FLAGS)
 
 FRAMEWORK_VERSION = 4.5

--- a/mcs/build/profiles/xbuild_12.make
+++ b/mcs/build/profiles/xbuild_12.make
@@ -2,8 +2,8 @@
 
 include $(topdir)/build/profiles/net_4_x.make
 
-PARENT_PROFILE = ../net_4_x/
-DEFAULT_REFERENCES = -r:$(topdir)/class/lib/net_4_x/mscorlib.dll
+PARENT_PROFILE = ../net_4_x$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))/
+DEFAULT_REFERENCES = -r:$(topdir)/class/lib/net_4_x$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))/mscorlib.dll
 PROFILE_MCS_FLAGS += -d:XBUILD_12
 
 XBUILD_VERSION = 12.0

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -22,8 +22,8 @@ VERSION = 0.93
 
 Q=$(if $(V),,@)
 # echo -e "\\t" does not work on some systems, so use 5 spaces
-Q_MCS=$(if $(V),,@echo "$(if $(MCS_MODE),MCS,CSC)     [$(intermediate)$(PROFILE)] $(notdir $(@))";)
-Q_AOT=$(if $(V),,@echo "AOT     [$(intermediate)$(PROFILE)] $(notdir $(@))";)
+Q_MCS=$(if $(V),,@echo "$(if $(MCS_MODE),MCS,CSC)     [$(intermediate)$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
+Q_AOT=$(if $(V),,@echo "AOT     [$(intermediate)$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
 
 ifndef BUILD_TOOLS_PROFILE
 BUILD_TOOLS_PROFILE = build
@@ -83,6 +83,8 @@ include $(topdir)/build/config-default.make
 # Platform config
 
 include $(topdir)/build/platforms/$(BUILD_PLATFORM).make
+
+PROFILE_PLATFORM = $(if $(PLATFORMS),$(if $(filter $(PLATFORMS),$(HOST_PLATFORM)),$(HOST_PLATFORM),$(error Unknown platform "$(HOST_PLATFORM)" for profile "$(PROFILE)")))
 
 ifdef PLATFORM_CORLIB
 corlib = $(PLATFORM_CORLIB)
@@ -307,6 +309,8 @@ dist-default:
 
 ## Documentation stuff
 
-Q_MDOC =$(if $(V),,@echo "MDOC    [$(PROFILE)] $(notdir $(@))";)
+Q_MDOC =$(if $(V),,@echo "MDOC    [$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
 MDOC   =$(Q_MDOC) MONO_PATH="$(topdir)/class/lib/$(DEFAULT_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(topdir)/class/lib/$(DEFAULT_PROFILE)/mdoc.exe
 
+Q_MDOC_UP=$(if $(V),,@echo "MDOC-UP [$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
+MDOC_UP  =$(Q_MDOC_UP) MONO_PATH="$(topdir)/class/lib/$(DEFAULT_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(topdir)/class/lib/$(DEFAULT_PROFILE)/mdoc.exe update --delete -o Documentation/en

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -22,8 +22,8 @@ VERSION = 0.93
 
 Q=$(if $(V),,@)
 # echo -e "\\t" does not work on some systems, so use 5 spaces
-Q_MCS=$(if $(V),,@echo "$(if $(MCS_MODE),MCS,CSC)     [$(intermediate)$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
-Q_AOT=$(if $(V),,@echo "AOT     [$(intermediate)$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
+Q_MCS=$(if $(V),,@echo "$(if $(MCS_MODE),MCS,CSC)     [$(intermediate)$(PROFILE_DIRECTORY)] $(notdir $(@))";)
+Q_AOT=$(if $(V),,@echo "AOT     [$(intermediate)$(PROFILE_DIRECTORY)] $(notdir $(@))";)
 
 ifndef BUILD_TOOLS_PROFILE
 BUILD_TOOLS_PROFILE = build
@@ -85,6 +85,7 @@ include $(topdir)/build/config-default.make
 include $(topdir)/build/platforms/$(BUILD_PLATFORM).make
 
 PROFILE_PLATFORM = $(if $(PLATFORMS),$(if $(filter $(PLATFORMS),$(HOST_PLATFORM)),$(HOST_PLATFORM),$(error Unknown platform "$(HOST_PLATFORM)" for profile "$(PROFILE)")))
+PROFILE_DIRECTORY = $(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))
 
 ifdef PLATFORM_CORLIB
 corlib = $(PLATFORM_CORLIB)
@@ -309,8 +310,8 @@ dist-default:
 
 ## Documentation stuff
 
-Q_MDOC =$(if $(V),,@echo "MDOC    [$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
+Q_MDOC =$(if $(V),,@echo "MDOC    [$(PROFILE_DIRECTORY)] $(notdir $(@))";)
 MDOC   =$(Q_MDOC) MONO_PATH="$(topdir)/class/lib/$(DEFAULT_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(topdir)/class/lib/$(DEFAULT_PROFILE)/mdoc.exe
 
-Q_MDOC_UP=$(if $(V),,@echo "MDOC-UP [$(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))] $(notdir $(@))";)
+Q_MDOC_UP=$(if $(V),,@echo "MDOC-UP [$(PROFILE_DIRECTORY)] $(notdir $(@))";)
 MDOC_UP  =$(Q_MDOC_UP) MONO_PATH="$(topdir)/class/lib/$(DEFAULT_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(topdir)/class/lib/$(DEFAULT_PROFILE)/mdoc.exe update --delete -o Documentation/en

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -56,7 +56,6 @@ depsdir = $(topdir)/build/deps
 
 # Make sure these propagate if set manually
 
-export PLATFORM
 export PROFILE
 export MCS
 export MCS_FLAGS
@@ -75,31 +74,15 @@ export RESGEN
 default: all
 
 # Get initial configuration. pre-config is so that the builder can
-# override PLATFORM or PROFILE
+# override BUILD_PLATFORM or PROFILE
 
 include $(topdir)/build/config-default.make
 -include $(topdir)/build/pre-config.make
 -include $(topdir)/build/config.make
 
-# Default PLATFORM and PROFILE if they're not already defined.
-
-ifndef PLATFORM
-ifeq ($(OS),Windows_NT)
-ifneq ($(V),)
-$(info *** Assuming PLATFORM is 'win32'.)
-endif
-PLATFORM = win32
-else
-ifneq ($(V),)
-$(info *** Assuming PLATFORM is 'linux'.)
-endif
-PLATFORM = linux
-endif
-endif
-
 # Platform config
 
-include $(topdir)/build/platforms/$(PLATFORM).make
+include $(topdir)/build/platforms/$(BUILD_PLATFORM).make
 
 ifdef PLATFORM_CORLIB
 corlib = $(PLATFORM_CORLIB)

--- a/mcs/class/System.Web.Extensions/Makefile
+++ b/mcs/class/System.Web.Extensions/Makefile
@@ -86,7 +86,7 @@ $(STANDALONE_TEST_ASSEMBLY): $(the_assembly) Test/standalone-tests/Consts.cs
 	$(CSCOMPILE) $(STANDALONE_TEST_MCS_FLAGS) -out:$@ -target:library @System.Web.Extensions_standalone_test.dll.sources
 
 Test/standalone-tests/Consts.cs: Test/standalone-tests/Consts.cs.in
-ifeq ($(PLATFORM), win32)
+ifeq ($(BUILD_PLATFORM), win32)
 	@sed 's,@SystemWebExtensionsClassDir@,$(shell cygpath -a -m .),' $< > $@
 else
 	@sed 's,@SystemWebExtensionsClassDir@,$(shell pwd),' $< > $@

--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -62,7 +62,7 @@ MONO = \
 
 DIFF = diff -rup
 DIFF_QUIET = diff --brief
-ifeq ($(PLATFORM), win32)
+ifeq ($(BUILD_PLATFORM), win32)
 DIFF = diff -rupZ
 DIFF_QUIET = diff --brief -Z
 endif

--- a/mcs/tools/mono-service/Makefile
+++ b/mcs/tools/mono-service/Makefile
@@ -14,7 +14,7 @@ LIB_REFS = System.ServiceProcess Mono.Posix System
 # Copied from library.make
 
 # -- begin --
-ifeq ($(PLATFORM), win32)
+ifeq ($(BUILD_PLATFORM), win32)
 GACDIR = `cygpath -w $(mono_libdir)`
 GACROOT = `cygpath -w $(DESTDIR)$(mono_libdir)`
 test_flags += -d:WINDOWS


### PR DESCRIPTION
This is to support adding corefx platform specific files. To do that, we now support mcs/class/corlib/linux_net_4_x_corlib.dll.sources for example, on top of mcs/class/corlib/net_4_x_corlib.dll.sources and mcs/class/corlib/corlib.dll.sources.

The 3 platforms that are supported are: linux, darwin and win32.

This replace https://github.com/mono/mono/pull/4783