### PR TITLE
[runtime] Use handle macros to fix handle leaks

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1888,10 +1888,12 @@ _mono_reflection_get_type_from_info (MonoTypeNameParse *info, MonoImage *image, 
 static MonoType*
 mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, MonoError *error)
 {
+	HANDLE_FUNCTION_ENTER ();
 	MonoClass *klass;
 	GList *mod;
 	int modval;
 	gboolean bounded = FALSE;
+	MonoType* type = NULL;
 	
 	error_init (error);
 	if (!image)
@@ -1906,7 +1908,7 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 		klass = mono_class_from_name_checked (image, info->name_space, info->name, error);
 
 	if (!klass)
-		return NULL;
+		goto leave;
 
 	for (mod = info->nested; mod; mod = mod->next) {
 		gpointer iter = NULL;
@@ -1966,7 +1968,7 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 			break;
 	}
 	if (!klass)
-		return NULL;
+		goto leave;
 
 	if (info->type_arguments) {
 		MonoType **type_args = g_new0 (MonoType *, info->type_arguments->len);
@@ -1980,20 +1982,20 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 			type_args [i] = _mono_reflection_get_type_from_info (subinfo, rootimage, ignorecase, error);
 			if (!type_args [i]) {
 				g_free (type_args);
-				return NULL;
+				goto leave;
 			}
 		}
 
 		the_type = mono_type_get_object_handle (mono_domain_get (), &klass->byval_arg, error);
 		if (!is_ok (error) || MONO_HANDLE_IS_NULL (the_type))
-			return NULL;
+			goto leave;
 
 		instance = mono_reflection_bind_generic_parameters (
 			the_type, info->type_arguments->len, type_args, error);
 
 		g_free (type_args);
 		if (!instance)
-			return NULL;
+			goto leave;
 
 		klass = mono_class_from_mono_type (instance);
 	}
@@ -2001,7 +2003,8 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 	for (mod = info->modifiers; mod; mod = mod->next) {
 		modval = GPOINTER_TO_UINT (mod->data);
 		if (!modval) { /* byref: must be last modifier */
-			return &klass->this_arg;
+			type = &klass->this_arg;
+			goto leave;
 		} else if (modval == -1) {
 			klass = mono_ptr_class_get (&klass->byval_arg);
 		} else if (modval == -2) {
@@ -2011,7 +2014,10 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 		}
 	}
 
-	return &klass->byval_arg;
+	type = &klass->byval_arg;
+
+leave:
+	HANDLE_FUNCTION_RETURN_VAL (type);
 }
 
 /**

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -771,6 +771,7 @@ guint32
 mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *type, gboolean try_typespec)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
+	HANDLE_FUNCTION_ENTER ();
 
 	MonoDynamicTable *table;
 	guint32 *values;
@@ -779,10 +780,10 @@ mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *
 
 	/* if the type requires a typespec, we must try that first*/
 	if (try_typespec && (token = create_typespec (assembly, type)))
-		return token;
+		goto leave;
 	token = GPOINTER_TO_UINT (g_hash_table_lookup (assembly->typeref, type));
 	if (token)
-		return token;
+		goto leave;
 	klass = mono_class_from_mono_type (type);
 
 	MonoReflectionTypeBuilderHandle tb = MONO_HANDLE_CAST (MonoReflectionTypeBuilder, mono_class_get_ref_info (klass));
@@ -793,7 +794,7 @@ mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *
 			(type->type != MONO_TYPE_MVAR)) {
 		token = MONO_TYPEDEFORREF_TYPEDEF | (MONO_HANDLE_GETVAL (tb, table_idx) << MONO_TYPEDEFORREF_BITS);
 		mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, tb));
-		return token;
+		goto leave;
 	}
 
 	if (klass->nested_in) {
@@ -816,7 +817,8 @@ mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *
 	g_hash_table_insert (assembly->typeref, type, GUINT_TO_POINTER(token));
 	table->next_idx ++;
 	mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, tb));
-	return token;
+leave:
+	HANDLE_FUNCTION_RETURN_VAL (token);
 }
 
 /*


### PR DESCRIPTION
This was leaving object handles in the HandleStack of threads, causing crashes when using appdomains that left objects to be scanned from unloaded appdomains.

* in `mono_reflection_get_type_internal` the result of `mono_type_get_object_handle` (thanks @joncham )
* in `mono_dynimage_encode_typedef_or_ref_full` the result of `mono_class_get_ref_info`

Fixes  [bugzilla #56322](https://bugzilla.xamarin.com/show_bug.cgi?id=56322)

(This is #4852 but with an additional leak plugged)