### PR TITLE
[2017-02][runtime] Use handle macros to fix handle leaks

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1882,10 +1882,12 @@ _mono_reflection_get_type_from_info (MonoTypeNameParse *info, MonoImage *image, 
 static MonoType*
 mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, MonoError *error)
 {
+	HANDLE_FUNCTION_ENTER ();
 	MonoClass *klass;
 	GList *mod;
 	int modval;
 	gboolean bounded = FALSE;
+	MonoType* type = NULL;
 	
 	mono_error_init (error);
 	if (!image)
@@ -1900,7 +1902,7 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 		klass = mono_class_from_name_checked (image, info->name_space, info->name, error);
 
 	if (!klass)
-		return NULL;
+		goto leave;
 
 	for (mod = info->nested; mod; mod = mod->next) {
 		gpointer iter = NULL;
@@ -1960,7 +1962,7 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 			break;
 	}
 	if (!klass)
-		return NULL;
+		goto leave;
 
 	if (info->type_arguments) {
 		MonoType **type_args = g_new0 (MonoType *, info->type_arguments->len);
@@ -1974,20 +1976,20 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 			type_args [i] = _mono_reflection_get_type_from_info (subinfo, rootimage, ignorecase, error);
 			if (!type_args [i]) {
 				g_free (type_args);
-				return NULL;
+				goto leave;
 			}
 		}
 
 		the_type = mono_type_get_object_handle (mono_domain_get (), &klass->byval_arg, error);
 		if (!is_ok (error) || MONO_HANDLE_IS_NULL (the_type))
-			return NULL;
+			goto leave;
 
 		instance = mono_reflection_bind_generic_parameters (
 			the_type, info->type_arguments->len, type_args, error);
 
 		g_free (type_args);
 		if (!instance)
-			return NULL;
+			goto leave;
 
 		klass = mono_class_from_mono_type (instance);
 	}
@@ -1995,7 +1997,8 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 	for (mod = info->modifiers; mod; mod = mod->next) {
 		modval = GPOINTER_TO_UINT (mod->data);
 		if (!modval) { /* byref: must be last modifier */
-			return &klass->this_arg;
+			type = &klass->this_arg;
+			goto leave;
 		} else if (modval == -1) {
 			klass = mono_ptr_class_get (&klass->byval_arg);
 		} else if (modval == -2) {
@@ -2005,7 +2008,10 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 		}
 	}
 
-	return &klass->byval_arg;
+	type = &klass->byval_arg;
+
+leave:
+	HANDLE_FUNCTION_RETURN_VAL (type);
 }
 
 /*


### PR DESCRIPTION
This is #4853  backported to `2017-02`

----

This was leaving object handles in the HandleStack of threads, causing crashes when using appdomains that left objects to be scanned from unloaded appdomains.

* in `mono_reflection_get_type_internal` the result of `mono_type_get_object_handle` (thanks @joncham )
* in `mono_dynimage_encode_typedef_or_ref_full` the result of `mono_class_get_ref_info`

Fixes  [bugzilla #56322](https://bugzilla.xamarin.com/show_bug.cgi?id=56322)
