### PR TITLE
w32handle: double the available slots

### DIFF
--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -25,7 +25,7 @@
 
 #undef DEBUG_REFS
 
-#define SLOT_MAX		(1024 * 16)
+#define SLOT_MAX		(1024 * 32)
 
 /* must be a power of 2 */
 #define HANDLE_PER_SLOT	(256)


### PR DESCRIPTION
Mono crashes if the system has more than ~128G of RAM.  Doubling the
number of slots fixes the SIGSEGV error on FreeBSD.