### PR TITLE
[runtime] Remove System.ValueTuple from denied assemblies.

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1122,7 +1122,6 @@ typedef enum {
 	SYS_NET_HTTP = 3, //System.Net.Http
 	SYS_TEXT_ENC_CODEPAGES = 4, //System.Text.Encoding.CodePages
 	SYS_REF_DISP_PROXY = 5, //System.Reflection.DispatchProxy
-	SYS_VALUE_TUPLE = 6, //System.ValueTuple
 	SYS_THREADING_OVERLAPPED = 7, //System.Threading.Overlapped
 } IgnoredAssemblyNames;
 
@@ -1144,8 +1143,7 @@ const char *ignored_assemblies_file_names[] = {
 	"System.Net.Http.dll",
 	"System.Text.Encoding.CodePages.dll",
 	"System.Reflection.DispatchProxy.dll",
-	"System.Threading.Overlapped.dll",
-	"System.ValueTuple.dll"
+	"System.Threading.Overlapped.dll"
 };
 
 #define IGNORED_ASSEMBLY(HASH, NAME, GUID, VER_STR)	{ .hash = HASH, .assembly_name = NAME, .guid = GUID }
@@ -1169,8 +1167,7 @@ static const IgnoredAssembly ignored_assemblies [] = {
 	IGNORED_ASSEMBLY (0xFA686A38, SYS_TEXT_ENC_CODEPAGES, "FD178CD4-EF4F-44D5-9C3F-812B1E25126B", "4.3.0 net46"),
 	IGNORED_ASSEMBLY (0xAA21986B, SYS_THREADING_OVERLAPPED, "9F5D4F09-787A-458A-BA08-553AA71470F1", "4.0.0 net46"),
 	IGNORED_ASSEMBLY (0x7D927C2A, SYS_THREADING_OVERLAPPED, "FCBD003B-2BB4-4940-BAEF-63AF520C2336", "4.0.1 net46"),
-	IGNORED_ASSEMBLY (0x6FE03EE2, SYS_THREADING_OVERLAPPED, "87697E71-D192-4F0B-BAD4-02BBC7793005", "4.3.0 net46"),
-	IGNORED_ASSEMBLY (0x75B4B041, SYS_VALUE_TUPLE, "F81A4140-A898-4E2B-B6E9-55CE78C273EC", "4.3.0 netstandard1.0"),
+	IGNORED_ASSEMBLY (0x6FE03EE2, SYS_THREADING_OVERLAPPED, "87697E71-D192-4F0B-BAD4-02BBC7793005", "4.3.0 net46")
 };
 
 
@@ -1181,8 +1178,7 @@ const char *ignored_assemblies_names[] = {
 	"System.Net.Http",
 	"System.Text.Encoding.CodePages",
 	"System.Reflection.DispatchProxy",
-	"System.Threading.Overlapped",
-	"System.ValueTuple"
+	"System.Threading.Overlapped"
 };
 
 #define IGNORED_ASM_VER(NAME, MAJOR, MINOR, BUILD, REVISION) { .assembly_name = NAME, .major = MAJOR, .minor = MINOR, .build = BUILD, .revision = REVISION }
@@ -1206,7 +1202,6 @@ static const IgnoredAssemblyVersion ignored_assembly_versions [] = {
 	IGNORED_ASM_VER (SYS_THREADING_OVERLAPPED, 4, 0, 0, 0),
 	IGNORED_ASM_VER (SYS_THREADING_OVERLAPPED, 4, 0, 1, 0),
 	IGNORED_ASM_VER (SYS_THREADING_OVERLAPPED, 4, 0, 2, 0),
-	IGNORED_ASM_VER (SYS_VALUE_TUPLE, 4, 0, 1, 0),
 };
 
 gboolean

--- a/tools/nuget-hash-extractor/download.sh
+++ b/tools/nuget-hash-extractor/download.sh
@@ -31,9 +31,6 @@ wget https://www.nuget.org/api/v2/package/System.Reflection.DispatchProxy/4.3.0 
 wget https://www.nuget.org/api/v2/package/System.Reflection.DispatchProxy/4.0.1 -O nugets/system.reflection.dispatchproxy.4.0.1.nupkg
 wget https://www.nuget.org/api/v2/package/System.Reflection.DispatchProxy/4.0.0 -O nugets/system.reflection.dispatchproxy.4.0.0.nupkg
 
-#System.ValueTuple
-wget https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0 -O nugets/system.valuetuple.4.3.0.nupkg
-
 #System.Threading.Overlapped
 wget https://www.nuget.org/api/v2/package/System.Threading.Overlapped/4.3.0 -O nugets/system.threading.overlapped.4.3.0.nupkg
 wget https://www.nuget.org/api/v2/package/System.Threading.Overlapped/4.0.1 -O nugets/system.threading.overlapped.4.0.1.nupkg

--- a/tools/nuget-hash-extractor/nuget-hash-extractor.cs
+++ b/tools/nuget-hash-extractor/nuget-hash-extractor.cs
@@ -83,7 +83,6 @@ class DoParse : MarshalByRefObject {
 		case "System.Text.Encoding.CodePages.dll": return "SYS_TEXT_ENC_CODEPAGES";
 		case "System.Reflection.DispatchProxy.dll": return "SYS_REF_DISP_PROXY";
 		case "System.Threading.Overlapped.dll": return "SYS_THREADING_OVERLAPPED";
-		case "System.ValueTuple.dll": return "SYS_VALUE_TUPLE";
 		default: throw new Exception ($"No idea what to do with {name}");
 		}
 	}


### PR DESCRIPTION
It's not needed anymore because we have reference assemblies and it didn't work for mobile tools (e.g. linker) anyway