### PR TITLE
[runtime] Remove System.ValueTuple from denied assemblies.

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1114,8 +1114,7 @@ typedef enum {
 	SYS_IO_COMPRESSION = 2, //System.IO.Compression
 	SYS_NET_HTTP = 3, //System.Net.Http
 	SYS_TEXT_ENC_CODEPAGES = 4, //System.Text.Encoding.CodePages
-	SYS_REF_DISP_PROXY = 5, //System.Reflection.DispatchProxy
-	SYS_VALUE_TUPLE = 6, //System.ValueTuple
+	SYS_REF_DISP_PROXY = 5 //System.Reflection.DispatchProxy
 } IgnoredAssemblyNames;
 
 typedef struct {
@@ -1136,7 +1135,6 @@ const char *ignored_assemblies_file_names[] = {
 	"System.Net.Http.dll",
 	"System.Text.Encoding.CodePages.dll",
 	"System.Reflection.DispatchProxy.dll",
-	"System.ValueTuple.dll"
 };
 
 #define IGNORED_ASSEMBLY(HASH, NAME, GUID, VER_STR)	{ .hash = HASH, .assembly_name = NAME, .guid = GUID }
@@ -1158,7 +1156,6 @@ static const IgnoredAssembly ignored_assemblies [] = {
 	IGNORED_ASSEMBLY (0xD07383BB, SYS_RT_INTEROP_RUNTIME_INFO, "DD91439F-3167-478E-BD2C-BF9C036A1395", "4.3.0 net45"),
 	IGNORED_ASSEMBLY (0x911D9EC3, SYS_TEXT_ENC_CODEPAGES, "C142254F-DEB5-46A7-AE43-6F10320D1D1F", "4.0.1 net46"),
 	IGNORED_ASSEMBLY (0xFA686A38, SYS_TEXT_ENC_CODEPAGES, "FD178CD4-EF4F-44D5-9C3F-812B1E25126B", "4.3.0 net46"),
-	IGNORED_ASSEMBLY (0x75B4B041, SYS_VALUE_TUPLE, "F81A4140-A898-4E2B-B6E9-55CE78C273EC", "4.3.0 netstandard1.0"),
 };
 
 
@@ -1168,8 +1165,7 @@ const char *ignored_assemblies_names[] = {
 	"System.IO.Compression",
 	"System.Net.Http",
 	"System.Text.Encoding.CodePages",
-	"System.Reflection.DispatchProxy",
-	"System.ValueTuple"
+	"System.Reflection.DispatchProxy"
 };
 
 #define IGNORED_ASM_VER(NAME, MAJOR, MINOR, BUILD, REVISION) { .assembly_name = NAME, .major = MAJOR, .minor = MINOR, .build = BUILD, .revision = REVISION }
@@ -1189,8 +1185,7 @@ static const IgnoredAssemblyVersion ignored_assembly_versions [] = {
 	IGNORED_ASM_VER (SYS_RT_INTEROP_RUNTIME_INFO, 4, 0, 0, 0),
 	IGNORED_ASM_VER (SYS_RT_INTEROP_RUNTIME_INFO, 4, 0, 1, 0),
 	IGNORED_ASM_VER (SYS_TEXT_ENC_CODEPAGES, 4, 0, 1, 0),
-	IGNORED_ASM_VER (SYS_TEXT_ENC_CODEPAGES, 4, 0, 2, 0),
-	IGNORED_ASM_VER (SYS_VALUE_TUPLE, 4, 0, 1, 0),
+	IGNORED_ASM_VER (SYS_TEXT_ENC_CODEPAGES, 4, 0, 2, 0)
 };
 
 gboolean

--- a/tools/nuget-hash-extractor/download.sh
+++ b/tools/nuget-hash-extractor/download.sh
@@ -31,9 +31,6 @@ wget https://www.nuget.org/api/v2/package/System.Reflection.DispatchProxy/4.3.0 
 wget https://www.nuget.org/api/v2/package/System.Reflection.DispatchProxy/4.0.1 -O nugets/system.reflection.dispatchproxy.4.0.1.nupkg
 wget https://www.nuget.org/api/v2/package/System.Reflection.DispatchProxy/4.0.0 -O nugets/system.reflection.dispatchproxy.4.0.0.nupkg
 
-#System.ValueTuple
-wget https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0 -O nugets/system.valuetuple.4.3.0.nupkg
-
 #System.Security.Cryptography.OpenSsl when .net 4.6.2 + 1 is out
 
 touch .download_stamp_file

--- a/tools/nuget-hash-extractor/nuget-hash-extractor.cs
+++ b/tools/nuget-hash-extractor/nuget-hash-extractor.cs
@@ -82,7 +82,6 @@ class DoParse : MarshalByRefObject {
 		case "System.Net.Http.dll": return "SYS_NET_HTTP";
 		case "System.Text.Encoding.CodePages.dll": return "SYS_TEXT_ENC_CODEPAGES";
 		case "System.Reflection.DispatchProxy.dll": return "SYS_REF_DISP_PROXY";
-		case "System.ValueTuple.dll": return "SYS_VALUE_TUPLE";
 		default: throw new Exception ($"No idea what to do with {name}");
 		}
 	}


### PR DESCRIPTION
It's not needed anymore because we have reference assemblies and it didn't work for mobile tools (e.g. linker)