### PR TITLE
System.Drawing netstandard1.6 compat: Update P/Invoke declarations

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/ComIStreamMarshaler.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ComIStreamMarshaler.cs
@@ -58,7 +58,7 @@ namespace System.Drawing
 		private delegate int WriteDelegate(IntPtr @this, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] pv, int cb, IntPtr pcbWritten);
 		private delegate int SeekDelegate(IntPtr @this, long dlibMove, int dwOrigin, IntPtr plibNewPosition);
 		private delegate int SetSizeDelegate(IntPtr @this, long libNewSize);
-		private delegate int CopyToDelegate(IntPtr @this, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten);
+		private delegate int CopyToDelegate(IntPtr @this, [MarshalAs(GDIPlus.GdiPlusCustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten);
 		private delegate int CommitDelegate(IntPtr @this, int grfCommitFlags);
 		private delegate int RevertDelegate(IntPtr @this);
 		private delegate int LockRegionDelegate(IntPtr @this, long libOffset, long cb, int dwLockType);

--- a/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
@@ -49,10 +49,8 @@ namespace System.Drawing
 	internal static class GDIPlus {
 
 #if NETSTANDARD1_6
-		public const CharSet GdiPlusCharSet = CharSet.Unicode;
 		public const UnmanagedType GdiPlusCustomMarshaler = UnmanagedType.Interface;
 #else
-		public const CharSet GdiPlusCharSet = CharSet.Auto;
 		public const UnmanagedType GdiPlusCustomMarshaler = UnmanagedType.CustomMarshaler;
 #endif
 
@@ -996,7 +994,7 @@ namespace System.Drawing
 		internal static extern Status GdipBitmapSetPixel (IntPtr bmp, int x, int y, int argb);
 
 		// Image functions
-		[DllImport(GdiPlus, CharSet=GdiPlusCharSet)]
+		[DllImport(GdiPlus, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipLoadImageFromFile ( [MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr image );
 
 #if !TEST
@@ -1011,7 +1009,7 @@ namespace System.Drawing
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipCloneImage(IntPtr image, out IntPtr imageclone);
 
-		[DllImport(GdiPlus, CharSet=GDIPlus.GdiPlusCharSet)]
+		[DllImport(GdiPlus, CharSet=GDIPlus.CharSet.Unicode)]
 		internal static extern Status GdipLoadImageFromFileICM ( [MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr image );
 
 		[DllImport(GdiPlus)]
@@ -1176,10 +1174,10 @@ namespace System.Drawing
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipCreateHBITMAPFromBitmap (IntPtr bmp, out IntPtr HandleBmp, int clrbackground);
 
-		[DllImport(GdiPlus, CharSet=GdiPlusCharSet)]
+		[DllImport(GdiPlus, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipCreateBitmapFromFile ([MarshalAs (UnmanagedType.LPWStr)] string filename, out IntPtr bitmap);
 
-		[DllImport(GdiPlus, CharSet= GdiPlusCharSet)]
+		[DllImport(GdiPlus, CharSet= CharSet.Unicode)]
 		internal static extern Status GdipCreateBitmapFromFileICM ([MarshalAs (UnmanagedType.LPWStr)] string filename, out IntPtr bitmap);
 
 		[DllImport(GdiPlus)]
@@ -1424,7 +1422,7 @@ namespace System.Drawing
 		internal static extern Status GdipSetImageAttributesOutputChannel (IntPtr imageattr,
 			ColorAdjustType type, bool enableFlag, 	ColorChannelFlag channelFlags);
 
-		[DllImport (GdiPlus, CharSet=GdiPlusCharSet)]
+		[DllImport (GdiPlus, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipSetImageAttributesOutputChannelColorProfile (IntPtr imageattr,
 			ColorAdjustType type, bool enableFlag, [MarshalAs (UnmanagedType.LPWStr)] string profileName);
 
@@ -1453,12 +1451,12 @@ namespace System.Drawing
 		internal static extern Status GdipCreateFont (IntPtr fontFamily, float emSize, FontStyle style, GraphicsUnit unit, out IntPtr font);
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipDeleteFont (IntPtr font);
-		[DllImport(GdiPlus, CharSet=GdiPlusCharSet)]
+		[DllImport(GdiPlus, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipGetLogFont(IntPtr font, IntPtr graphics, [MarshalAs(UnmanagedType.AsAny), Out] object logfontA);
 
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipCreateFontFromDC(IntPtr hdc, out IntPtr font);
-		[DllImport(GdiPlus, SetLastError=true, CharSet=GdiPlusCharSet)]
+		[DllImport(GdiPlus, SetLastError=true, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipCreateFontFromLogfont(IntPtr hdc, ref LOGFONT lf, out IntPtr ptr);
 
 		// These are our private functions, they exists in our own libgdiplus library, this way we
@@ -1467,7 +1465,7 @@ namespace System.Drawing
 		internal static extern Status GdipCreateFontFromHfont(IntPtr hdc, out IntPtr font, ref LOGFONT lf);
 
 		// This is win32/gdi, not gdiplus, but it's easier to keep in here, also see above comment
-		[DllImport("gdi32.dll", CallingConvention=CallingConvention.StdCall, CharSet = GdiPlusCharSet)]
+		[DllImport("gdi32.dll", CallingConvention=CallingConvention.StdCall, CharSet = CharSet.Unicode)]
 		internal static extern IntPtr CreateFontIndirect (ref LOGFONT logfont);
 		[DllImport("user32.dll", EntryPoint="GetDC", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
 		internal static extern IntPtr GetDC(IntPtr hwnd);
@@ -1548,7 +1546,7 @@ namespace System.Drawing
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipDeletePrivateFontCollection (ref IntPtr collection);
 
-		[DllImport (GdiPlus, CharSet=GdiPlusCharSet)]
+		[DllImport (GdiPlus, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipPrivateAddFontFile (IntPtr collection,
 				[MarshalAs (UnmanagedType.LPWStr)] string fileName );
 
@@ -1556,7 +1554,7 @@ namespace System.Drawing
 		internal static extern Status GdipPrivateAddMemoryFont (IntPtr collection, IntPtr mem, int length);
 
 		//FontFamily
-		[DllImport (GdiPlus, CharSet=GdiPlusCharSet)]
+		[DllImport (GdiPlus, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipCreateFontFamilyFromName (
 			[MarshalAs(UnmanagedType.LPWStr)] string fName, IntPtr collection, out IntPtr fontFamily);
 
@@ -1646,13 +1644,13 @@ namespace System.Drawing
 		internal static extern Status GdipGetStringFormatTabStops(IntPtr format, int count, out float firstTabOffset, [In, Out] float [] tabStops);
 
 		// metafile
-		[DllImport (GdiPlus, CharSet = GdiPlusCharSet)]
+		[DllImport (GdiPlus, CharSet = CharSet.Unicode)]
 		internal static extern Status GdipCreateMetafileFromFile ([MarshalAs (UnmanagedType.LPWStr)] string filename, out IntPtr metafile);
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipCreateMetafileFromEmf (IntPtr hEmf, bool deleteEmf, out IntPtr metafile);
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipCreateMetafileFromWmf (IntPtr hWmf, bool deleteWmf, WmfPlaceableFileHeader wmfPlaceableFileHeader, out IntPtr metafile);
-		[DllImport (GdiPlus, CharSet = GdiPlusCharSet)]
+		[DllImport (GdiPlus, CharSet = CharSet.Unicode)]
 		internal static extern Status GdipGetMetafileHeaderFromFile ([MarshalAs (UnmanagedType.LPWStr)] string filename, IntPtr header);
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipGetMetafileHeaderFromMetafile (IntPtr metafile, IntPtr header);

--- a/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
@@ -1009,7 +1009,7 @@ namespace System.Drawing
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipCloneImage(IntPtr image, out IntPtr imageclone);
 
-		[DllImport(GdiPlus, CharSet=GDIPlus.CharSet.Unicode)]
+		[DllImport(GdiPlus, CharSet=CharSet.Unicode)]
 		internal static extern Status GdipLoadImageFromFileICM ( [MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr image );
 
 		[DllImport(GdiPlus)]
@@ -1451,7 +1451,7 @@ namespace System.Drawing
 		internal static extern Status GdipCreateFont (IntPtr fontFamily, float emSize, FontStyle style, GraphicsUnit unit, out IntPtr font);
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipDeleteFont (IntPtr font);
-		[DllImport(GdiPlus, CharSet=CharSet.Unicode)]
+		[DllImport(GdiPlus, CharSet=CharSet.Auto)]
 		internal static extern Status GdipGetLogFont(IntPtr font, IntPtr graphics, [MarshalAs(UnmanagedType.AsAny), Out] object logfontA);
 
 		[DllImport(GdiPlus)]

--- a/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
@@ -47,6 +47,15 @@ namespace System.Drawing
 	/// GDI+ API Functions
 	/// </summary>
 	internal static class GDIPlus {
+
+#if NETSTANDARD1_6
+		public const CharSet GdiPlusCharSet = CharSet.Unicode;
+		public const UnmanagedType GdiPlusCustomMarshaler = UnmanagedType.Interface;
+#else
+		public const CharSet GdiPlusCharSet = CharSet.Auto;
+		public const UnmanagedType GdiPlusCustomMarshaler = UnmanagedType.CustomMarshaler;
+#endif
+
 		public const int FACESIZE = 32;
 		public const int LANG_NEUTRAL = 0;
 		public static IntPtr Display = IntPtr.Zero;
@@ -987,22 +996,22 @@ namespace System.Drawing
 		internal static extern Status GdipBitmapSetPixel (IntPtr bmp, int x, int y, int argb);
 
 		// Image functions
-		[DllImport(GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport(GdiPlus, CharSet=GdiPlusCharSet)]
 		internal static extern Status GdipLoadImageFromFile ( [MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr image );
 
 #if !TEST
 		// Stream functions for Win32 (original Win32 ones)
 		[DllImport(GdiPlus, ExactSpelling=true, CharSet=CharSet.Unicode)]
-		internal static extern Status GdipLoadImageFromStream([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, out IntPtr image);
+		internal static extern Status GdipLoadImageFromStream([MarshalAs(GdiPlusCustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, out IntPtr image);
 
 		[DllImport(GdiPlus, ExactSpelling=true, CharSet=CharSet.Unicode)]
-		internal static extern Status GdipSaveImageToStream(HandleRef image, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, [In()] ref Guid clsidEncoder, HandleRef encoderParams);
+		internal static extern Status GdipSaveImageToStream(HandleRef image, [MarshalAs(GdiPlusCustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, [In()] ref Guid clsidEncoder, HandleRef encoderParams);
 #endif
 
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipCloneImage(IntPtr image, out IntPtr imageclone);
 
-		[DllImport(GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport(GdiPlus, CharSet=GDIPlus.GdiPlusCharSet)]
 		internal static extern Status GdipLoadImageFromFileICM ( [MarshalAs(UnmanagedType.LPWStr)] string filename, out IntPtr image );
 
 		[DllImport(GdiPlus)]
@@ -1167,10 +1176,10 @@ namespace System.Drawing
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipCreateHBITMAPFromBitmap (IntPtr bmp, out IntPtr HandleBmp, int clrbackground);
 
-		[DllImport(GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport(GdiPlus, CharSet=GdiPlusCharSet)]
 		internal static extern Status GdipCreateBitmapFromFile ([MarshalAs (UnmanagedType.LPWStr)] string filename, out IntPtr bitmap);
 
-		[DllImport(GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport(GdiPlus, CharSet= GdiPlusCharSet)]
 		internal static extern Status GdipCreateBitmapFromFileICM ([MarshalAs (UnmanagedType.LPWStr)] string filename, out IntPtr bitmap);
 
 		[DllImport(GdiPlus)]
@@ -1415,7 +1424,7 @@ namespace System.Drawing
 		internal static extern Status GdipSetImageAttributesOutputChannel (IntPtr imageattr,
 			ColorAdjustType type, bool enableFlag, 	ColorChannelFlag channelFlags);
 
-		[DllImport (GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport (GdiPlus, CharSet=GdiPlusCharSet)]
 		internal static extern Status GdipSetImageAttributesOutputChannelColorProfile (IntPtr imageattr,
 			ColorAdjustType type, bool enableFlag, [MarshalAs (UnmanagedType.LPWStr)] string profileName);
 
@@ -1444,12 +1453,12 @@ namespace System.Drawing
 		internal static extern Status GdipCreateFont (IntPtr fontFamily, float emSize, FontStyle style, GraphicsUnit unit, out IntPtr font);
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipDeleteFont (IntPtr font);
-		[DllImport(GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport(GdiPlus, CharSet=GdiPlusCharSet)]
 		internal static extern Status GdipGetLogFont(IntPtr font, IntPtr graphics, [MarshalAs(UnmanagedType.AsAny), Out] object logfontA);
 
 		[DllImport(GdiPlus)]
 		internal static extern Status GdipCreateFontFromDC(IntPtr hdc, out IntPtr font);
-		[DllImport(GdiPlus, SetLastError=true, CharSet=CharSet.Auto)]
+		[DllImport(GdiPlus, SetLastError=true, CharSet=GdiPlusCharSet)]
 		internal static extern Status GdipCreateFontFromLogfont(IntPtr hdc, ref LOGFONT lf, out IntPtr ptr);
 
 		// These are our private functions, they exists in our own libgdiplus library, this way we
@@ -1458,7 +1467,7 @@ namespace System.Drawing
 		internal static extern Status GdipCreateFontFromHfont(IntPtr hdc, out IntPtr font, ref LOGFONT lf);
 
 		// This is win32/gdi, not gdiplus, but it's easier to keep in here, also see above comment
-		[DllImport("gdi32.dll", CallingConvention=CallingConvention.StdCall, CharSet = CharSet.Auto)]
+		[DllImport("gdi32.dll", CallingConvention=CallingConvention.StdCall, CharSet = GdiPlusCharSet)]
 		internal static extern IntPtr CreateFontIndirect (ref LOGFONT logfont);
 		[DllImport("user32.dll", EntryPoint="GetDC", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
 		internal static extern IntPtr GetDC(IntPtr hwnd);
@@ -1539,7 +1548,7 @@ namespace System.Drawing
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipDeletePrivateFontCollection (ref IntPtr collection);
 
-		[DllImport (GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport (GdiPlus, CharSet=GdiPlusCharSet)]
 		internal static extern Status GdipPrivateAddFontFile (IntPtr collection,
 				[MarshalAs (UnmanagedType.LPWStr)] string fileName );
 
@@ -1547,7 +1556,7 @@ namespace System.Drawing
 		internal static extern Status GdipPrivateAddMemoryFont (IntPtr collection, IntPtr mem, int length);
 
 		//FontFamily
-		[DllImport (GdiPlus, CharSet=CharSet.Auto)]
+		[DllImport (GdiPlus, CharSet=GdiPlusCharSet)]
 		internal static extern Status GdipCreateFontFamilyFromName (
 			[MarshalAs(UnmanagedType.LPWStr)] string fName, IntPtr collection, out IntPtr fontFamily);
 
@@ -1637,13 +1646,13 @@ namespace System.Drawing
 		internal static extern Status GdipGetStringFormatTabStops(IntPtr format, int count, out float firstTabOffset, [In, Out] float [] tabStops);
 
 		// metafile
-		[DllImport (GdiPlus, CharSet = CharSet.Auto)]
+		[DllImport (GdiPlus, CharSet = GdiPlusCharSet)]
 		internal static extern Status GdipCreateMetafileFromFile ([MarshalAs (UnmanagedType.LPWStr)] string filename, out IntPtr metafile);
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipCreateMetafileFromEmf (IntPtr hEmf, bool deleteEmf, out IntPtr metafile);
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipCreateMetafileFromWmf (IntPtr hWmf, bool deleteWmf, WmfPlaceableFileHeader wmfPlaceableFileHeader, out IntPtr metafile);
-		[DllImport (GdiPlus, CharSet = CharSet.Auto)]
+		[DllImport (GdiPlus, CharSet = GdiPlusCharSet)]
 		internal static extern Status GdipGetMetafileHeaderFromFile ([MarshalAs (UnmanagedType.LPWStr)] string filename, IntPtr header);
 		[DllImport (GdiPlus)]
 		internal static extern Status GdipGetMetafileHeaderFromMetafile (IntPtr metafile, IntPtr header);
@@ -1674,15 +1683,15 @@ namespace System.Drawing
 			ref Rectangle frameRect, MetafileFrameUnit frameUnit, [MarshalAs (UnmanagedType.LPWStr)] string description, out IntPtr metafile);
 #if !TEST
 		[DllImport(GdiPlus, ExactSpelling=true, CharSet=CharSet.Unicode)]
-		internal static extern Status GdipCreateMetafileFromStream([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, out IntPtr metafile);
+		internal static extern Status GdipCreateMetafileFromStream([MarshalAs(GdiPlusCustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, out IntPtr metafile);
 		[DllImport(GdiPlus, ExactSpelling=true, CharSet=CharSet.Unicode)]
-		internal static extern Status GdipGetMetafileHeaderFromStream([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, IntPtr header);
+		internal static extern Status GdipGetMetafileHeaderFromStream([MarshalAs(GdiPlusCustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, IntPtr header);
 
 		[DllImport (GdiPlus)]
-		internal static extern Status GdipRecordMetafileStream ([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, IntPtr hdc,
+		internal static extern Status GdipRecordMetafileStream ([MarshalAs(GdiPlusCustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, IntPtr hdc,
 			EmfType type, ref RectangleF frameRect, MetafileFrameUnit frameUnit, [MarshalAs (UnmanagedType.LPWStr)] string description, out IntPtr metafile);
 		[DllImport (GdiPlus)]
-		internal static extern Status GdipRecordMetafileStreamI ([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, IntPtr hdc,
+		internal static extern Status GdipRecordMetafileStreamI ([MarshalAs(GdiPlusCustomMarshaler, MarshalTypeRef=typeof(ComIStreamMarshaler))] IStream stream, IntPtr hdc,
 			EmfType type, ref Rectangle frameRect, MetafileFrameUnit frameUnit, [MarshalAs (UnmanagedType.LPWStr)] string description, out IntPtr metafile);
 #endif
 		//ImageCodecInfo functions

--- a/mcs/class/System.Drawing/System.Drawing/gdipStructs.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipStructs.cs
@@ -81,7 +81,7 @@ namespace System.Drawing
     		internal int to;
 	}
 
-	[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
+	[StructLayout(LayoutKind.Sequential, CharSet=GDIPlus.GdiPlusCharSet)]
 	internal struct LOGFONT
 	{
 		internal int    lfHeight;

--- a/mcs/class/System.Drawing/System.Drawing/gdipStructs.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipStructs.cs
@@ -81,7 +81,7 @@ namespace System.Drawing
     		internal int to;
 	}
 
-	[StructLayout(LayoutKind.Sequential, CharSet=GDIPlus.GdiPlusCharSet)]
+	[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
 	internal struct LOGFONT
 	{
 		internal int    lfHeight;

--- a/mcs/class/System.Drawing/System.Drawing/gdipStructs.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipStructs.cs
@@ -81,7 +81,7 @@ namespace System.Drawing
     		internal int to;
 	}
 
-	[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+	[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
 	internal struct LOGFONT
 	{
 		internal int    lfHeight;


### PR DESCRIPTION
The P/Invoke declarations for GDI+ use `CharSet.Auto` and `UnmanagedType.CustomMarshaler`, which are not available on `netstandard1.6`.

To enable basic support for `netstandard1.6`, define these values as constants, keep the current values on non-`netstandard1.6` and use fallback values on `netstandard1.6`.