### PR TITLE
netstandard1.6 compatibility: Use GetTypeInfo () where required

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.Printing/MarginsConverter.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Printing/MarginsConverter.cs
@@ -103,7 +103,7 @@ namespace System.Drawing.Printing {
 			}
 			if (destinationType == typeof (InstanceDescriptor) && value is Margins) {
 				Margins c = (Margins) value;
-				ConstructorInfo ctor = typeof(Margins).GetConstructor (new Type[] {typeof(int), typeof(int), typeof(int), typeof(int)} );
+				ConstructorInfo ctor = typeof(Margins).GetTypeInfo ().GetConstructor (new Type[] {typeof(int), typeof(int), typeof(int), typeof(int)} );
 				return new InstanceDescriptor (ctor, new object[] {c.Left, c.Right, c.Top, c.Bottom});
 			}
 

--- a/mcs/class/System.Drawing/System.Drawing/ColorConverter.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ColorConverter.cs
@@ -205,13 +205,13 @@ namespace System.Drawing
 					return sb.ToString ();
 				} else if (destinationType == typeof (InstanceDescriptor)) {
 					if (color.IsEmpty) {
-						return new InstanceDescriptor (typeof (Color).GetField ("Empty"), null);
+						return new InstanceDescriptor (typeof (Color).GetTypeInfo ().GetField ("Empty"), null);
 					} else if (color.IsSystemColor) {
-						return new InstanceDescriptor (typeof (SystemColors).GetProperty (color.Name), null);
+						return new InstanceDescriptor (typeof (SystemColors).GetTypeInfo ().GetProperty (color.Name), null);
 					} else if (color.IsKnownColor){
-						return new InstanceDescriptor (typeof (Color).GetProperty (color.Name), null);
+						return new InstanceDescriptor (typeof (Color).GetTypeInfo ().GetProperty (color.Name), null);
 					} else {
-						MethodInfo met = typeof(Color).GetMethod ("FromArgb", new Type[] { typeof(int), typeof(int), typeof(int), typeof(int) } );
+						MethodInfo met = typeof(Color).GetTypeInfo ().GetMethod ("FromArgb", new Type[] { typeof(int), typeof(int), typeof(int), typeof(int) } );
 						return new InstanceDescriptor (met, new object[] {color.A, color.R, color.G, color.B });
 					}
 				}

--- a/mcs/class/System.Drawing/System.Drawing/ComIStreamMarshaler.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ComIStreamMarshaler.cs
@@ -105,7 +105,7 @@ namespace System.Drawing
 
 			private static readonly Guid IID_IUnknown = new Guid("00000000-0000-0000-C000-000000000046");
 			private static readonly Guid IID_IStream = new Guid("0000000C-0000-0000-C000-000000000046");
-			private static readonly MethodInfo exceptionGetHResult = typeof(Exception).GetProperty("HResult", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding, null, typeof(int), new Type[] {}, null).GetGetMethod(true);
+			private static readonly MethodInfo exceptionGetHResult = typeof(Exception).GetTypeInfo ().GetProperty("HResult", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding, null, typeof(int), new Type[] {}, null).GetGetMethod(true);
 			// Keeps delegates alive while they are marshaled
 			private static readonly IStreamVtbl managedVtable;
 			private static IntPtr comVtable;

--- a/mcs/class/System.Drawing/System.Drawing/FontConverter.cs
+++ b/mcs/class/System.Drawing/System.Drawing/FontConverter.cs
@@ -114,7 +114,7 @@ namespace System.Drawing
 
 			if ((destinationType == typeof (InstanceDescriptor)) && (value is Font)) {
 				Font font = (Font) value;
-				ConstructorInfo met = typeof(Font).GetConstructor (new Type[] {typeof(string), typeof(float), typeof(FontStyle), typeof(GraphicsUnit)});
+				ConstructorInfo met = typeof(Font).GetTypeInfo ().GetConstructor (new Type[] {typeof(string), typeof(float), typeof(FontStyle), typeof(GraphicsUnit)});
 				object[] args = new object[4];
 				args [0] = font.Name;
 				args [1] = font.Size;

--- a/mcs/class/System.Drawing/System.Drawing/ImageFormatConverter.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ImageFormatConverter.cs
@@ -154,9 +154,9 @@ namespace System.Drawing
 					return prop != null ? prop : c.ToString ();
 				} else if (destinationType == typeof (InstanceDescriptor)) {
 					if (prop != null){
-						return new InstanceDescriptor (typeof (ImageFormat).GetProperty (prop), null);
+						return new InstanceDescriptor (typeof (ImageFormat).GetTypeInfo ().GetProperty (prop), null);
 					} else {
-						ConstructorInfo ctor = typeof(ImageFormat).GetConstructor (new Type[] {typeof(Guid)} );
+						ConstructorInfo ctor = typeof(ImageFormat).GetTypeInfo ().GetConstructor (new Type[] {typeof(Guid)} );
 						return new InstanceDescriptor (ctor, new object[] {c.Guid});
 					}
 				}

--- a/mcs/class/System.Drawing/System.Drawing/ToolboxBitmapAttribute.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ToolboxBitmapAttribute.cs
@@ -33,6 +33,7 @@
 //
 
 using System;
+using System.Reflection;
 
 namespace System.Drawing
 {

--- a/mcs/class/System.Drawing/System.Drawing/ToolboxBitmapAttribute.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ToolboxBitmapAttribute.cs
@@ -116,7 +116,7 @@ namespace System.Drawing
 				imageName = t.Name + ".bmp";
 
 			try {
-				using (System.IO.Stream s = t.Assembly.GetManifestResourceStream (t.Namespace + "." + imageName)){
+				using (System.IO.Stream s = t.GetTypeInfo ().Assembly.GetManifestResourceStream (t.Namespace + "." + imageName)){
 					if (s == null) {
 						return null;
 					} else {

--- a/mcs/class/System.Drawing/System.Drawing/macFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/macFunctions.cs
@@ -52,7 +52,7 @@ namespace System.Drawing {
 				if (String.Equals (asm.GetName ().Name, "System.Windows.Forms")) {
 					Type driver_type = asm.GetType ("System.Windows.Forms.XplatUICarbon");
 					if (driver_type != null) {
-						hwnd_delegate = (Delegate) driver_type.GetField ("HwndDelegate", BindingFlags.NonPublic | BindingFlags.Static).GetValue (null);
+						hwnd_delegate = (Delegate) driver_type.GetTypeInfo() .GetField ("HwndDelegate", BindingFlags.NonPublic | BindingFlags.Static).GetValue (null);
 					}
 				}
 			}


### PR DESCRIPTION
A lot of methods have moved from Type to TypeInfo in netstandard1.6, add calls to GetTypeInfo ()
where required to support compiling System.Drawing on netstandard1.6