### PR TITLE
System.Drawing: netstandard1.6 compatibility: String fixes

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/ColorTranslator.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ColorTranslator.cs
@@ -123,7 +123,7 @@ namespace System.Drawing {
 				case KnownColor.Window:
 				case KnownColor.WindowFrame:
 				case KnownColor.WindowText:
-					return KnownColors.GetName (kc).ToLower (CultureInfo.InvariantCulture);
+					return KnownColors.GetName (kc).ToLowerInvariant ();
 
 				case KnownColor.ActiveCaptionText:
 					return "captiontext";

--- a/mcs/class/System.Drawing/System.Drawing/ImageFormatConverter.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ImageFormatConverter.cs
@@ -99,25 +99,25 @@ namespace System.Drawing
 					return ImageFormat.Wmf;
 			} else {
 				// case #3, this is probably a short format
-				if (String.Compare (strFormat, "Bmp", true, CultureInfo.InvariantCulture) == 0)
+				if (String.Compare (strFormat, "Bmp", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Bmp;
-				else if (String.Compare (strFormat, "Emf", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Emf", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Emf;
-				else if (String.Compare (strFormat, "Exif", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Exif", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Exif;
-				else if (String.Compare (strFormat, "Gif", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Gif", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Gif;
-				else if (String.Compare (strFormat, "Icon", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Icon", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Icon;
-				else if (String.Compare (strFormat, "Jpeg", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Jpeg", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Jpeg;
-				else if (String.Compare (strFormat, "MemoryBmp", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "MemoryBmp", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.MemoryBmp;
-				else if (String.Compare (strFormat, "Png", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Png", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Png;
-				else if (String.Compare (strFormat, "Tiff", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Tiff", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Tiff;
-				else if (String.Compare (strFormat, "Wmf", true, CultureInfo.InvariantCulture) == 0)
+				else if (String.Compare (strFormat, "Wmf", StringComparison.OrdinalIgnoreCase) == 0)
 					return ImageFormat.Wmf;
 			}
 			// last case, this is an unknown string


### PR DESCRIPTION
- ImageFormatConverter uses string.Compare to compare extensions for known file types. It uses CultureInfo.InvariantCulture,
  which is not available on netstandard1.6. Because all the extensions use ASCII-characters, StringCOmparsion.OrdinalIgnoreCase
  can be used, which is equivalent.
- Replace ToLower (CultureInfo.InvariantCulture) with .ToLowerInvariant ()