### PR TITLE
System.Drawing: Various netstandard1.6 compat fixes

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.Printing/InvalidPrinterException.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Printing/InvalidPrinterException.cs
@@ -44,6 +44,7 @@ namespace System.Drawing.Printing {
 //			this.settings = settings;
 		}
 
+#if !NETSTANDARD1_6
 		protected InvalidPrinterException (SerializationInfo info, StreamingContext context)
 			: base (info, context)
 		{
@@ -56,6 +57,7 @@ namespace System.Drawing.Printing {
 
 			base.GetObjectData (info, context);
 		}
+#endif
 
 		private static string GetMessage(PrinterSettings settings)
 		{

--- a/mcs/class/System.Drawing/System.Drawing/IconConverter.cs
+++ b/mcs/class/System.Drawing/System.Drawing/IconConverter.cs
@@ -82,9 +82,10 @@ namespace System.Drawing {
 				return "(none)";
 			else if (CanConvertTo (null, destinationType)) {
 				//came here means destType is byte array ;
-				MemoryStream ms = new MemoryStream ();
-				((Icon) value).Save (ms);
-				return ms.GetBuffer ();
+				using (MemoryStream ms = new MemoryStream ()) {
+					((Icon) value).Save (ms);
+					return ms.ToArray ();
+				}
 			}else
 				return new NotSupportedException ("IconConverter can not convert from " + value.GetType ());				
 		}

--- a/mcs/class/System.Drawing/System.Drawing/ImageConverter.cs
+++ b/mcs/class/System.Drawing/System.Drawing/ImageConverter.cs
@@ -85,9 +85,10 @@ namespace System.Drawing
 					return value.ToString ();
 				} else if (CanConvertTo (null, destinationType)) {
 					//came here means destinationType is byte array ;
-					MemoryStream ms = new MemoryStream ();
-					((Image)value).Save (ms, ((Image)value).RawFormat);
-					return ms.GetBuffer ();
+					using (MemoryStream ms = new MemoryStream ()) {
+						((Image)value).Save (ms, ((Image)value).RawFormat);
+						return ms.ToArray ();
+					}
 				}
 			}
 

--- a/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
@@ -92,8 +92,14 @@ namespace System.Drawing
 
 		static GDIPlus ()
 		{
+#if NETSTANDARD1_6
+			bool isUnix = !RuntimeInformation.IsOSPlatform (OSPlatform.Windows);
+#else
 			int platform = (int) Environment.OSVersion.Platform;
-			if ((platform == 4) || (platform == 6) || (platform == 128)) {
+			bool isUnix = (platform == 4) || (platform == 6) || (platform == 128);
+#endif
+
+			if (isUnix) {
 				if (Environment.GetEnvironmentVariable ("not_supported_MONO_MWF_USE_NEW_X11_BACKEND") != null || Environment.GetEnvironmentVariable ("MONO_MWF_MAC_FORCE_X11") != null) {
 					UseX11Drawable = true;
 				} else {
@@ -127,7 +133,9 @@ namespace System.Drawing
 			}
 
 			// under MS 1.x this event is raised only for the default application domain
+#if !NETSTANDARD1_6
 			AppDomain.CurrentDomain.ProcessExit += new EventHandler (ProcessExit);
+#endif
 		}
 
 		static public bool RunningOnWindows ()
@@ -1891,7 +1899,7 @@ namespace System.Drawing
 
 			public void StreamCloseImpl ()
 			{
-				stream.Close ();
+				stream.Dispose ();
 			}
 
 			public StreamCloseDelegate CloseDelegate {

--- a/mcs/class/System.Drawing/System.Drawing/macFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/macFunctions.cs
@@ -48,6 +48,7 @@ namespace System.Drawing {
 #endif
 
 		static MacSupport () {
+#if !NETSTANDARD1_6
 			foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies ()) {
 				if (String.Equals (asm.GetName ().Name, "System.Windows.Forms")) {
 					Type driver_type = asm.GetType ("System.Windows.Forms.XplatUICarbon");
@@ -56,6 +57,7 @@ namespace System.Drawing {
 					}
 				}
 			}
+#endif
 		}
 
 		internal static CocoaContext GetCGContextForNSView (IntPtr handle) {


### PR DESCRIPTION
Minor fixes which make System.Drawing compatible with netstandard1.6:
- Use MemoryStream.ToArray instead of .GetBuffer
- Use RuntimeInformation.IsOSPlatform to determine the operating system
- Use Stream.Dispose instead of Stream.Close
- Disable serialization support for exceptions
- Don't use AppDomain