### PR TITLE
[image] follow up fix for 62bc1b229ee0501b706f3ea39524180c0ae7fc26

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1122,7 +1122,7 @@ typedef enum {
 	SYS_NET_HTTP = 3, //System.Net.Http
 	SYS_TEXT_ENC_CODEPAGES = 4, //System.Text.Encoding.CodePages
 	SYS_REF_DISP_PROXY = 5, //System.Reflection.DispatchProxy
-	SYS_THREADING_OVERLAPPED = 7, //System.Threading.Overlapped
+	SYS_THREADING_OVERLAPPED = 6, //System.Threading.Overlapped
 } IgnoredAssemblyNames;
 
 typedef struct {


### PR DESCRIPTION
otherwise we try to access `ignored_assemblies_names` out of bounds