### PR TITLE
[amd64] Make more inline functions in header static

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1481,7 +1481,7 @@ mono_arch_unwindinfo_find_rt_func_in_table (const gpointer code, gsize code_size
 	return found_rt_func;
 }
 
-inline PRUNTIME_FUNCTION
+static inline PRUNTIME_FUNCTION
 mono_arch_unwindinfo_find_pc_rt_func_in_table (const gpointer pc)
 {
 	return mono_arch_unwindinfo_find_rt_func_in_table (pc, 0);

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -558,7 +558,7 @@ typedef struct _UNWIND_INFO {
  *	OPTIONAL ULONG ExceptionData[]; */
 } UNWIND_INFO, *PUNWIND_INFO;
 
-inline guint
+static inline guint
 mono_arch_unwindinfo_get_size (guchar code_count)
 {
 	// Returned size will be used as the allocated size for unwind data trailing the memory used by compiled method.


### PR DESCRIPTION
Related: commit 00c6a94a

When [Xamarin.Android attempts to build with mono/2017-04][0], the
build breaks when cross-linking Windows code via MXE due to the
presence of an undefined `inline`d function:

	./.libs/libmini.a(libmini_la-tramp-amd64.o):…/xamarin-android/external/mono/mono/mini/tramp-amd64.c:746:
	undefined reference to `mono_arch_unwindinfo_get_size'

Turn `mono_arch_unwindinfo_find_pc_rt_func_in_table()` and
`mono_arch_unwindinfo_get_size()` into `static inline` functions so
that they don't cause "undefined reference" linker errors.

Additionally, audit the rest of `mono` to ensure there aren't any
other `inline` functions that aren't `static`:

	$ git grep '\<inline\>' mono | grep -v static | grep -E '(\.c|\.h):'
	# ~50 matches, all of which are in comments or otherwise not relevant.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/388/