### PR TITLE
[amd64] Make more inline functions in header static

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1477,7 +1477,7 @@ mono_arch_unwindinfo_find_rt_func_in_table (const gpointer code, gsize code_size
 	return found_rt_func;
 }
 
-inline PRUNTIME_FUNCTION
+static inline PRUNTIME_FUNCTION
 mono_arch_unwindinfo_find_pc_rt_func_in_table (const gpointer pc)
 {
 	return mono_arch_unwindinfo_find_rt_func_in_table (pc, 0);

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -557,7 +557,7 @@ typedef struct _UNWIND_INFO {
  *	OPTIONAL ULONG ExceptionData[]; */
 } UNWIND_INFO, *PUNWIND_INFO;
 
-inline guint
+static inline guint
 mono_arch_unwindinfo_get_size (guchar code_count)
 {
 	// Returned size will be used as the allocated size for unwind data trailing the memory used by compiled method.
@@ -597,7 +597,7 @@ mono_arch_code_chunk_destroy (void *chunk);
 #define MONO_TRAMPOLINE_UNWINDINFO_SIZE(max_code_count) (mono_arch_unwindinfo_get_size (max_code_count))
 #define MONO_MAX_TRAMPOLINE_UNWINDINFO_SIZE (MONO_TRAMPOLINE_UNWINDINFO_SIZE(3))
 
-inline gboolean
+static inline gboolean
 mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 {
 	guint current_size = mono_arch_unwindinfo_get_size (mono_arch_unwindinfo_get_code_count (unwind_ops));
@@ -609,7 +609,7 @@ mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 #define MONO_TRAMPOLINE_UNWINDINFO_SIZE(max_code_count) 0
 #define MONO_MAX_TRAMPOLINE_UNWINDINFO_SIZE 0
 
-inline gboolean
+static inline gboolean
 mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 {
 	return TRUE;


### PR DESCRIPTION
When [Xamarin.Android attempts to build with mono/2017-04][0], the
build breaks when cross-linking Windows code via MXE due to the
presence of an undefined `inline`d function:

	./.libs/libmini.a(libmini_la-tramp-amd64.o):…/xamarin-android/external/mono/mono/mini/tramp-amd64.c:746:
	undefined reference to `mono_arch_unwindinfo_get_size'

Turn `mono_arch_unwindinfo_find_pc_rt_func_in_table()` and
`mono_arch_unwindinfo_get_size()` into `static inline` functions so
that they don't cause "undefined reference" linker errors.

Additionally, audit the rest of `mono` to ensure there aren't any
other `inline` functions that aren't `static`:

	$ git grep '\<inline\>' mono | grep -v static | grep -E '(\.c|\.h):'
	# ~50 matches, all of which are in comments or otherwise not relevant.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/388/