### PR TITLE
Consider Facades in Provides: too. Version number challenges remain.

### DIFF
--- a/scripts/mono-find-provides.in
+++ b/scripts/mono-find-provides.in
@@ -14,7 +14,7 @@ IFS=$'\n'
 filelist=($(grep -Ev '/usr/doc/|/usr/share/doc/'))
 monolist=($(printf "%s\n" "${filelist[@]}" | egrep "\\.(exe|dll)\$"))
 
-# Only include files with /gac/ in path
+# Only include files with /gac/, /Facades/ or /4.5/ in path
 #  (Allows packages to contain private assemblies that don't conflict with other packages)
 monolist=($(printf "%s\n" "${monolist[@]}" | egrep "/(gac|Facades|4\\.5)/"))
 # Disabled... see ChangeLog

--- a/scripts/mono-find-provides.in
+++ b/scripts/mono-find-provides.in
@@ -16,7 +16,7 @@ monolist=($(printf "%s\n" "${filelist[@]}" | egrep "\\.(exe|dll)\$"))
 
 # Only include files with /gac/ in path
 #  (Allows packages to contain private assemblies that don't conflict with other packages)
-monolist=($(printf "%s\n" "${monolist[@]}" | egrep "/gac/"))
+monolist=($(printf "%s\n" "${monolist[@]}" | egrep "/(gac|Facades|4\\.5)/"))
 # Disabled... see ChangeLog
 
 # Set the prefix, unless it is overriden (used when building mono rpms)


### PR DESCRIPTION
rpm-find-provides is a mess, this makes it a bit less of a mess by adding not only stuff from the GAC, but also Facades and 4.5 directories. Doesn't help with version mismatches for facades though.