### PR TITLE
[btls] Add "desktop" ARM Linux configurations (for IoT, mostly)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3228,6 +3228,11 @@ case "$host" in
 		CPPFLAGS="$CPPFLAGS -D__ARM_EABI__"
 		BTLS_SUPPORTED=yes
 		BTLS_PLATFORM=arm
+		case "$target" in
+		arm*-linux*-gnueabi)
+			BTLS_PLATFORM=armsoft
+			;;
+		esac
 		;;
 	arm*-netbsd*-eabi*)
 		TARGET=ARM;
@@ -4116,6 +4121,10 @@ if test "x$enable_btls" = "xyes"; then
 		;;
 	arm)
 		btls_arch=arm
+		;;
+	armsoft)
+		btls_arch=arm
+		btls_cflags="-DOPENSSL_NO_ASM=1"
 		;;
 	aarch64)
 		btls_arch=aarch64

--- a/configure.ac
+++ b/configure.ac
@@ -3226,6 +3226,8 @@ case "$host" in
 		ACCESS_UNALIGNED="no"
 		AOT_SUPPORTED="yes"
 		CPPFLAGS="$CPPFLAGS -D__ARM_EABI__"
+		BTLS_SUPPORTED=yes
+		BTLS_PLATFORM=arm
 		;;
 	arm*-netbsd*-eabi*)
 		TARGET=ARM;
@@ -3246,6 +3248,8 @@ case "$host" in
 		arch_target=arm64
 		boehm_supported=false
 		AOT_SUPPORTED="yes"
+		BTLS_SUPPORTED=yes
+		BTLS_PLATFORM=aarch64
 		;;
 	s390x-*-linux*)
 		TARGET=S390X;
@@ -4109,6 +4113,12 @@ if test "x$enable_btls" = "xyes"; then
 		;;
 	x86_64)
 		btls_arch=x86_64
+		;;
+	arm)
+		btls_arch=arm
+		;;
+	aarch64)
+		btls_arch=aarch64
 		;;
 	android-armv5)
 		BTLS_CMAKE_ARGS="-DANDROID_ABI=\"armeabi\" -DANDROID_NATIVE_API_LEVEL=12"


### PR DESCRIPTION
In theory this is sufficient to add BTLS support to non-Android ARM configurations. This is needed for BTLS on IoT. Arch names from https://github.com/mono/boringssl/blob/c06ac6b33d3e7442ad878488b9d1100127eff998/CMakeLists.txt#L164 & https://github.com/mono/boringssl/blob/c06ac6b33d3e7442ad878488b9d1100127eff998/CMakeLists.txt#L166