### PR TITLE
Fixes a file handle leak in mono_mmap_open_file() on Windows

### DIFF
--- a/mcs/class/System.Core/Test/System.IO.MemoryMappedFiles/MemoryMappedFileTest.cs
+++ b/mcs/class/System.Core/Test/System.IO.MemoryMappedFiles/MemoryMappedFileTest.cs
@@ -451,5 +451,20 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 			}
 		}
 
+		[Test]
+		public void OpenSameFileMultipleTimes ()
+		{
+			// See bug 56493 - https://bugzilla.xamarin.com/show_bug.cgi?id=56493
+			for (var iteration = 0; iteration < 5; iteration++) {
+				using (var mmf = MemoryMappedFile.CreateFromFile(fname, FileMode.Open)) {
+					using (var accessor = mmf.CreateViewAccessor(0, 5)) {
+						var a = new byte [5];
+						accessor.ReadArray (0, a, 0, a.Length);
+						var s = new string (Array.ConvertAll (a, b => (char) b));
+						Assert.AreEqual ("Hello", s);
+					}
+				}
+			}
+		}
 	}
 }

--- a/mono/metadata/file-mmap-windows.c
+++ b/mono/metadata/file-mmap-windows.c
@@ -271,6 +271,8 @@ void *mono_mmap_open_file (MonoString *path, int mode, MonoString *mapName, gint
 	result = open_handle (hFile, mapName, mode, capacity, access, options, error);
 
 done:
+	if (hFile != INVALID_HANDLE_VALUE)
+		CloseHandle (hFile);
 	if (!result && delete_on_error)
 		DeleteFileW (w_path);
 	if (w_path)


### PR DESCRIPTION
See https://bugzilla.xamarin.com/show_bug.cgi?id=56493.