### PR TITLE
[btls] Add MonoPInvokeCallback attribute on all full aot profiles

### DIFF
--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -33,7 +33,6 @@ using Mono.Security.Interface;
 
 using Mono.Net;
 using Mono.Net.Security;
-using Mono.Util;
 
 using ObjCRuntimeInternal;
 
@@ -682,7 +681,7 @@ namespace Mono.AppleTls
 		[DllImport (SecurityLibrary)]
 		extern static /* OSStatus */ SslStatus SSLSetIOFuncs (/* SSLContextRef */ IntPtr context, /* SSLReadFunc */ SslReadFunc readFunc, /* SSLWriteFunc */ SslWriteFunc writeFunc);
 
-		[MonoPInvokeCallback (typeof (SslReadFunc))]
+		[Mono.Util.MonoPInvokeCallback (typeof (SslReadFunc))]
 		static SslStatus NativeReadCallback (IntPtr ptr, IntPtr data, ref IntPtr dataLength)
 		{
 			var handle = GCHandle.FromIntPtr (ptr);
@@ -702,7 +701,7 @@ namespace Mono.AppleTls
 			}
 		}
 
-		[MonoPInvokeCallback (typeof (SslWriteFunc))]
+		[Mono.Util.MonoPInvokeCallback (typeof (SslWriteFunc))]
 		static SslStatus NativeWriteCallback (IntPtr ptr, IntPtr data, ref IntPtr dataLength)
 		{
 			var handle = GCHandle.FromIntPtr (ptr);

--- a/mcs/class/System/Mono.Btls/MonoBtlsBio.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsBio.cs
@@ -30,10 +30,6 @@ using System.Text;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#if MONOTOUCH
-using MonoTouch;
-#endif
-
 namespace Mono.Btls
 {
 	class MonoBtlsBio : MonoBtlsObject
@@ -308,9 +304,7 @@ namespace Mono.Btls
 			return ret;
 		}
 
-#if MONOTOUCH
-		[MonoPInvokeCallback (typeof (BioReadFunc))]
-#endif
+		[Mono.Util.MonoPInvokeCallback (typeof (BioReadFunc))]
 		static int OnRead (IntPtr instance, IntPtr data, int dataLength, out int wantMore)
 		{
 			var c = (MonoBtlsBioMono)GCHandle.FromIntPtr (instance).Target;
@@ -331,9 +325,7 @@ namespace Mono.Btls
 			return ok ? dataLength : -1;
 		}
 
-#if MONOTOUCH
-		[MonoPInvokeCallback (typeof (BioWriteFunc))]
-#endif
+		[Mono.Util.MonoPInvokeCallback (typeof (BioWriteFunc))]
 		static int OnWrite (IntPtr instance, IntPtr data, int dataLength)
 		{
 			var c = (MonoBtlsBioMono)GCHandle.FromIntPtr (instance).Target;
@@ -345,9 +337,7 @@ namespace Mono.Btls
 			}
 		}
 
-#if MONOTOUCH
-		[MonoPInvokeCallback (typeof (BioControlFunc))]
-#endif
+		[Mono.Util.MonoPInvokeCallback (typeof (BioControlFunc))]
 		static long Control (IntPtr instance, ControlCommand command, long arg)
 		{
 			var c = (MonoBtlsBioMono)GCHandle.FromIntPtr (instance).Target;

--- a/mcs/class/System/Mono.Btls/MonoBtlsSsl.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsSsl.cs
@@ -30,10 +30,6 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
-#if MONOTOUCH
-using MonoTouch;
-#endif
-
 namespace Mono.Btls
 {
 	delegate int MonoBtlsVerifyCallback (MonoBtlsX509StoreCtx ctx);
@@ -250,9 +246,7 @@ namespace Mono.Btls
 
 		delegate int PrintErrorsCallbackFunc (IntPtr str, IntPtr len, IntPtr ctx);
 
-#if MONOTOUCH
-		[MonoPInvokeCallback (typeof (PrintErrorsCallbackFunc))]
-#endif
+		[Mono.Util.MonoPInvokeCallback (typeof (PrintErrorsCallbackFunc))]
 		static int PrintErrorsCallback (IntPtr str, IntPtr len, IntPtr ctx)
 		{
 			var sb = (StringBuilder)GCHandle.FromIntPtr (ctx).Target;

--- a/mcs/class/System/Mono.Btls/MonoBtlsSslCtx.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsSslCtx.cs
@@ -28,10 +28,6 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#if MONOTOUCH
-using MonoTouch;
-#endif
-
 namespace Mono.Btls
 {
 	class MonoBtlsSslCtx : MonoBtlsObject
@@ -141,9 +137,7 @@ namespace Mono.Btls
 			return 0;
 		}
 
-#if MONOTOUCH
-		[MonoPInvokeCallback (typeof (NativeVerifyFunc))]
-#endif
+		[Mono.Util.MonoPInvokeCallback (typeof (NativeVerifyFunc))]
 		static int NativeVerifyCallback (IntPtr instance, int preverify_ok, IntPtr store_ctx)
 		{
 			var c = (MonoBtlsSslCtx)GCHandle.FromIntPtr (instance).Target;
@@ -164,9 +158,7 @@ namespace Mono.Btls
 			return 1;
 		}
 
-#if MONOTOUCH
-		[MonoPInvokeCallback (typeof (NativeSelectFunc))]
-#endif
+		[Mono.Util.MonoPInvokeCallback (typeof (NativeSelectFunc))]
 		static int NativeSelectCallback (IntPtr instance)
 		{
 			var c = (MonoBtlsSslCtx)GCHandle.FromIntPtr (instance).Target;

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509LookupMono.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509LookupMono.cs
@@ -93,9 +93,7 @@ namespace Mono.Btls
 
 		protected abstract MonoBtlsX509 OnGetBySubject (MonoBtlsX509Name name);
 
-#if MONOTOUCH
-		[MonoTouch.MonoPInvokeCallback (typeof (BySubjectFunc))]
-#endif
+		[Mono.Util.MonoPInvokeCallback (typeof (BySubjectFunc))]
 		static int OnGetBySubject (IntPtr instance, IntPtr name_ptr, out IntPtr x509_ptr)
 		{
 			try {


### PR DESCRIPTION
It was #ifdef'ed to only be available on monotouch before, but the testing_aot_full profile in CI runs into this test failure:

```
MESSAGE:
System.ExecutionEngineException : Attempting to JIT compile method '(wrapper native-to-managed) Mono.Btls.MonoBtlsSslCtx:NativeVerifyCallback (intptr,int,intptr)' while running in aot-only mode. See https://developer.xamarin.com/guides/ios/advanced_topics/limitations/ for more information.

+++++++++++++++++++
STACK TRACE:
  at (wrapper managed-to-native) System.Object:__icall_wrapper_mono_thread_interruption_checkpoint ()
  at (wrapper managed-to-native) System.Runtime.InteropServices.Marshal:GetFunctionPointerForDelegateInternal (System.Delegate)
  at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate[TDelegate] (TDelegate d) [0x00013] in <fa55a8c31ba0490383239e5850d81686>:0
  at Mono.Btls.MonoBtlsSslCtx..ctor (Mono.Btls.MonoBtlsSslCtx+BoringSslCtxHandle handle) [0x00059] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Btls.MonoBtlsSslCtx..ctor () [0x0000b] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Btls.MonoBtlsContext.InitializeConnection () [0x00000] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Btls.MonoBtlsContext.StartHandshake () [0x00000] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Net.Security.MobileAuthenticatedStream.ProcessHandshake (Mono.Net.Security.AsyncProtocolRequest asyncRequest, Mono.Net.Security.AsyncOperationStatus status) [0x00004] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Net.Security.AsyncProtocolRequest.ProcessOperation (Mono.Net.Security.AsyncOperationStatus status) [0x0006b] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Net.Security.AsyncProtocolRequest.ProcessOperation () [0x0000d] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Net.Security.AsyncProtocolRequest.StartOperation () [0x0003c] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Net.Security.AsyncProtocolRequest.StartOperation (Mono.Net.Security.AsyncOperation operation) [0x00024] in <18810f39bffc41dcb0263eb2043cc10e>:0
  at Mono.Net.Security.MobileAuthenticatedStream.ProcessAuthentication (System.Net.LazyAsyncResult lazyResult) [0x00057] in <18810f39bffc41dcb0263eb2043cc10e>:0
```

The attribute itself is already conditional on MONOTOUCH and FULL_AOT_RUNTIME so simply removing the ifdef should fix the issue.