### PR TITLE
Move <sys/types.h> higher for integer types

### DIFF
--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include <sys/socket.h>
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
@@ -27,7 +28,6 @@
 #endif
 #include <errno.h>
 #include <fcntl.h>
-#include <sys/types.h>
 #ifdef HAVE_SYS_UIO_H
 #include <sys/uio.h>
 #endif


### PR DESCRIPTION
Fix build on FreeBSD 8 and maybe others
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198404#c6