### PR TITLE
[interp] fix domain unloading

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -4027,12 +4027,6 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 	gboolean void_ret = FALSE;
 	gboolean string_ctor = method && method->string_ctor;
 
-	/* to make it work with our special string constructors */
-	if (!string_dummy) {
-		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, "dummy marshal string");
-		string_dummy = mono_string_new_wrapper ("dummy");
-	}
-
 	if (virtual_) {
 		g_assert (sig->hasthis);
 		g_assert (method->flags & METHOD_ATTRIBUTE_VIRTUAL);
@@ -4040,6 +4034,12 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 
 	if (sig->hasthis) {
 		if (string_ctor) {
+			/* to make it work with our special string constructors */
+			if (!string_dummy) {
+				MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, "dummy marshal string");
+				string_dummy = mono_string_new_wrapper ("dummy");
+			}
+
 			if (mono_gc_is_moving ()) {
 				mono_mb_emit_ptr (mb, &string_dummy);
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -94,6 +94,7 @@ typedef struct _RuntimeMethod
 	MonoType *rtype;
 	MonoType **param_types;
 	MonoJitInfo *jinfo;
+	MonoDomain *domain;
 } RuntimeMethod;
 
 struct _MonoInvocation {
@@ -114,7 +115,6 @@ struct _MonoInvocation {
 };
 
 typedef struct {
-	MonoDomain *domain;
 	MonoDomain *original_domain;
 	MonoInvocation *base_frame;
 	MonoInvocation *current_frame;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -337,16 +337,18 @@ get_virtual_method (RuntimeMethod *runtime_method, MonoObject *obj)
 {
 	MonoMethod *m = runtime_method->method;
 	MonoDomain *domain = runtime_method->domain;
+	RuntimeMethod *ret = NULL;
 	MonoError error;
 
-	if ((m->flags & METHOD_ATTRIBUTE_FINAL) || !(m->flags & METHOD_ATTRIBUTE_VIRTUAL)) {
-		RuntimeMethod *ret = NULL;
 #ifndef DISABLE_REMOTING
-		if (mono_object_is_transparent_proxy (obj)) {
-			ret = mono_interp_get_runtime_method (domain, mono_marshal_get_remoting_invoke (m), &error);
-			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
-		} else
+	if (mono_object_is_transparent_proxy (obj)) {
+		ret = mono_interp_get_runtime_method (domain, mono_marshal_get_remoting_invoke (m), &error);
+		mono_error_assert_ok (&error);
+		return ret;
+	}
 #endif
+
+	if ((m->flags & METHOD_ATTRIBUTE_FINAL) || !(m->flags & METHOD_ATTRIBUTE_VIRTUAL)) {
 		if (m->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
 			ret = mono_interp_get_runtime_method (domain, mono_marshal_get_synchronized_wrapper (m), &error);
 			mono_error_cleanup (&error); /* FIXME: don't swallow the error */

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1327,7 +1327,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 	MonoMethodHeader *header = mono_method_get_header (method);
 	MonoMethodSignature *signature = mono_method_signature (method);
 	MonoImage *image = method->klass->image;
-	MonoDomain *domain = mono_domain_get ();
+	MonoDomain *domain = rtm->domain;
 	MonoClass *constrained_class = NULL;
 	MonoError error;
 	int offset, mt, i, i32;
@@ -3921,12 +3921,12 @@ mono_interp_transform_method (RuntimeMethod *runtime_method, ThreadContext *cont
 	const MonoOpcode *opcode;
 	MonoMethod *m;
 	MonoClass *class;
-	MonoDomain *domain = mono_domain_get ();
 	unsigned char *is_bb_start;
 	int in;
 	MonoVTable *method_class_vt;
 	int backwards;
 	MonoGenericContext *generic_context = NULL;
+	MonoDomain *domain = runtime_method->domain;
 
 	// g_printerr ("TRANSFORM(0x%016lx): begin %s::%s\n", mono_thread_current (), method->klass->name, method->name);
 	method_class_vt = mono_class_vtable (domain, runtime_method->method->klass);


### PR DESCRIPTION
fixes appdomain unloading in the interpreter.

```c
#include <mono/metadata/mono-debug.h>
#include <mono/metadata/debug-helpers.h>

#include <mono/utils/mono-publib.h>

#include "mono/jit/jit.h"
#include "mono/metadata/appdomain.h"
#include "mono/metadata/assembly.h"
#include "mono/metadata/environment.h"
#include "mono/metadata/image.h"
#include "mono/metadata/metadata.h"
#include "mono/metadata/mono-gc.h"
#include "mono/metadata/object.h"
#include "mono/metadata/threads.h"

int main (void)
{

        char *mono_path = "/home/lewurm/work/mono/b/lib";
        mono_set_assemblies_path (".");
        mono_set_dirs (mono_path, mono_path);
        mono_debug_init(MONO_DEBUG_FORMAT_MONO);

        MonoDomain *root_domain = mono_jit_init_version ("RootDomain", "v4.0.30319");

        /* setup appdomain */
        MonoDomain *woot_domain = mono_domain_create_appdomain ("WootDomain", NULL);
        mono_thread_set_main (mono_thread_current ());
        mono_domain_set (woot_domain, 1);

        /* domain shutdown */
        mono_domain_set (root_domain, 1);

        mono_domain_unload (woot_domain);
        return 0;
}
```