### PR TITLE
[runtime] Make RuntimeHelpers:SufficientExecutionStack () a no-op on …

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -980,6 +980,8 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStac
 {
 #if defined(TARGET_WIN32) || defined(HOST_WIN32)
 	// It does not work on win32
+#elif defined(TARGET_ANDROID)
+	// No need for now
 #else
 	guint8 *stack_addr;
 	guint8 *current;


### PR DESCRIPTION
…android for now. Fixes #56240.