### PR TITLE
[System]: Don't call OnCompleted(this) twice in SocketAsyncEventArgs.

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
@@ -262,7 +262,6 @@ namespace System.Net.Sockets
 			SetResults(SocketError.Success, bytesTransferred, flags);
 			current_socket = connectSocket;
 
-			Complete ();
 			OnCompleted (this);
 		}
 


### PR DESCRIPTION
[System]: Don't call OnCompleted(this) twice in SocketAsyncEventArgs.FinishWrapperConnectSuccess().