### PR TITLE
[pdb2mdb] Dispose Cecil AssemblyDefinition on pdb2mdb

### DIFF
--- a/mcs/tools/pdb2mdb/Driver.cs
+++ b/mcs/tools/pdb2mdb/Driver.cs
@@ -28,20 +28,21 @@ namespace Pdb2Mdb {
 
 		public static void Convert (string filename)
 		{
-			var asm = AssemblyDefinition.ReadAssembly (filename);
+			using (var asm = AssemblyDefinition.ReadAssembly (filename)) {
 
-			var pdb = asm.Name.Name + ".pdb";
-			pdb = Path.Combine (Path.GetDirectoryName (filename), pdb);
+				var pdb = asm.Name.Name + ".pdb";
+				pdb = Path.Combine (Path.GetDirectoryName (filename), pdb);
 
-			if (!File.Exists (pdb))
-				throw new FileNotFoundException ("PDB file doesn't exist: " + pdb);
+				if (!File.Exists (pdb))
+					throw new FileNotFoundException ("PDB file doesn't exist: " + pdb);
 
-			using (var stream = File.OpenRead (pdb)) {
-				if (IsPortablePdb (stream))
-					throw new PortablePdbNotSupportedException ();
+				using (var stream = File.OpenRead (pdb)) {
+					if (IsPortablePdb (stream))
+						throw new PortablePdbNotSupportedException ();
 
-				var funcs = PdbFile.LoadFunctions (stream, true);
-				Converter.Convert (asm, funcs, new MonoSymbolWriter (filename));
+					var funcs = PdbFile.LoadFunctions (stream, true);
+					Converter.Convert (asm, funcs, new MonoSymbolWriter (filename));
+				}
 			}
 		}
 


### PR DESCRIPTION
Recent Cecil 0.10 changed to not reading the assembly in memory but instead reads directly from the underlying stream [0]. This however means that the file handle is not freed until the AssemblyDefinition is disposed.

Xamarin.Android is using the pdb2mdb source as part of Xamarin.Android.Build.Tasks.dll and hit an issue where the file would be locked inside of VS.

[0] http://cecil.pe/post/149243207656/mono-cecil-010-beta-1