### PR TITLE
[bcl] Dispose Cecil AssemblyDefinition after usage

### DIFF
--- a/mcs/class/Mono.CodeContracts/Mono.CodeContracts.Rewrite/Rewriter.cs
+++ b/mcs/class/Mono.CodeContracts/Mono.CodeContracts.Rewrite/Rewriter.cs
@@ -67,33 +67,34 @@ namespace Mono.CodeContracts.Rewrite {
 			if (options.Debug && options.WritePdbFile)
 				readerParameters.ReadSymbols = true;
 
-			var assembly = this.options.Assembly.IsFilename ?
+			using (var assembly = this.options.Assembly.IsFilename ?
 				AssemblyDefinition.ReadAssembly (options.Assembly.Filename, readerParameters) :
-				AssemblyDefinition.ReadAssembly (options.Assembly.Streams.Assembly, readerParameters);
+				AssemblyDefinition.ReadAssembly (options.Assembly.Streams.Assembly, readerParameters)) {
 			
-			if (this.options.ForceAssemblyRename != null) {
-				assembly.Name.Name = this.options.ForceAssemblyRename;
-			} else if (this.options.OutputFile.IsSet && this.options.OutputFile.IsFilename) {
-				assembly.Name.Name = Path.GetFileNameWithoutExtension(this.options.OutputFile.Filename);
-			}
+				if (this.options.ForceAssemblyRename != null) {
+					assembly.Name.Name = this.options.ForceAssemblyRename;
+				} else if (this.options.OutputFile.IsSet && this.options.OutputFile.IsFilename) {
+					assembly.Name.Name = Path.GetFileNameWithoutExtension(this.options.OutputFile.Filename);
+				}
 
-			var output = this.options.OutputFile.IsSet ? this.options.OutputFile : this.options.Assembly;
-			var writerParameters = new WriterParameters ();
-			if (options.WritePdbFile) {
-				if (!options.Debug) {
-					return RewriterResults.Error ("Must specify -debug if using -writePDBFile.");
+				var output = this.options.OutputFile.IsSet ? this.options.OutputFile : this.options.Assembly;
+				var writerParameters = new WriterParameters ();
+				if (options.WritePdbFile) {
+					if (!options.Debug) {
+						return RewriterResults.Error ("Must specify -debug if using -writePDBFile.");
+					}
+					
+					writerParameters.WriteSymbols = true;
 				}
 				
-				writerParameters.WriteSymbols = true;
-			}
-			
-			PerformRewrite rewriter = new PerformRewrite (this.options);
-			rewriter.Rewrite (assembly);
+				PerformRewrite rewriter = new PerformRewrite (this.options);
+				rewriter.Rewrite (assembly);
 
-			if (output.IsFilename) {
-				assembly.Write (output.Filename, writerParameters);
-			} else {
-				assembly.Write (output.Streams.Assembly, writerParameters);
+				if (output.IsFilename) {
+					assembly.Write (output.Filename, writerParameters);
+				} else {
+					assembly.Write (output.Streams.Assembly, writerParameters);
+				}
 			}
 		
 			return new RewriterResults (warnings, errors);

--- a/mcs/class/Mono.CodeContracts/Mono.CodeContracts.Static.AST/AssemblyNode.cs
+++ b/mcs/class/Mono.CodeContracts/Mono.CodeContracts.Static.AST/AssemblyNode.cs
@@ -72,7 +72,7 @@ namespace Mono.CodeContracts.Static.AST {
 
 		public static AssemblyNode ReadAssembly (string filename)
 		{
-			var readerParameters = new ReaderParameters ();
+			var readerParameters = new ReaderParameters () { InMemory = true };
 			AssemblyDefinition definition = AssemblyDefinition.ReadAssembly (filename, readerParameters);
 
 			return new AssemblyNode (definition);

--- a/mcs/tools/corcompare/AssemblyResolver.cs
+++ b/mcs/tools/corcompare/AssemblyResolver.cs
@@ -44,7 +44,7 @@ namespace GuiCompare {
 		AssemblyDefinition ProcessFile (string file)
 		{
 			AddSearchDirectory (Path.GetDirectoryName (file));
-			var assembly = AssemblyDefinition.ReadAssembly (file, new ReaderParameters { AssemblyResolver = this });
+			var assembly = AssemblyDefinition.ReadAssembly (file, new ReaderParameters { AssemblyResolver = this, InMemory = true });
 			RegisterAssembly (assembly);
 
 			return assembly;

--- a/mcs/tools/mdbdump/mdbdump.cs
+++ b/mcs/tools/mdbdump/mdbdump.cs
@@ -15,10 +15,11 @@ public class MdbDump
 			return 1;
 		}
 
-		var assembly = AssemblyDefinition.ReadAssembly (args[0]);
+		using (var assembly = AssemblyDefinition.ReadAssembly (args[0])) {
 
-		var f = MonoSymbolFile.ReadSymbolFile (args[0] + ".mdb");
-		DumpSymbolFile (assembly, f, Console.Out);
+			var f = MonoSymbolFile.ReadSymbolFile (args[0] + ".mdb");
+			DumpSymbolFile (assembly, f, Console.Out);
+		}
 
 		return 0;
 	}

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -107,10 +107,11 @@ namespace Mono
 						continue;
 					}
 
-					var assembly = AssemblyDefinition.ReadAssembly (assemblyPath);
-
-					var mvid = assembly.MainModule.Mvid.ToString ("N");
-					var mvidDir = Path.Combine (msymDir, mvid);
+					string mvidDir;
+					using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
+						var mvid = assembly.MainModule.Mvid.ToString ("N");
+						mvidDir = Path.Combine (msymDir, mvid);
+					}
 
 					if (Directory.Exists (mvidDir)) {
 						try {

--- a/mcs/tools/security/permview.cs
+++ b/mcs/tools/security/permview.cs
@@ -375,28 +375,29 @@ namespace Mono.Tools {
 					return 0;
 
 				string assemblyName = args [args.Length - 1];
-				AssemblyDefinition ad = AssemblyDefinition.ReadAssembly (assemblyName);
-				if (ad != null) {
-					bool complete = false;
-					
-					if (declarative) {
-						// full output (assembly+classes+methods)
-						complete = ProcessAssemblyComplete (tw, ad);
-					} else if (xmloutput) {
-						// full output in XML (for easier diffs after c14n)
-						complete = ProcessAssemblyXml (tw, ad);
-					} else {
-						// default (assembly only)
-						complete = ProcessAssemblyOnly (tw, ad);
-					}
+				using (AssemblyDefinition ad = AssemblyDefinition.ReadAssembly (assemblyName)) {
+					if (ad != null) {
+						bool complete = false;
 
-					if (!complete) {
-						Console.Error.WriteLine ("Couldn't reflect informations.");
-						return 1;
+						if (declarative) {
+							// full output (assembly+classes+methods)
+							complete = ProcessAssemblyComplete (tw, ad);
+						} else if (xmloutput) {
+							// full output in XML (for easier diffs after c14n)
+							complete = ProcessAssemblyXml (tw, ad);
+						} else {
+							// default (assembly only)
+							complete = ProcessAssemblyOnly (tw, ad);
+						}
+
+						if (!complete) {
+							Console.Error.WriteLine ("Couldn't reflect informations.");
+							return 1;
+						}
+					} else {
+						Console.Error.WriteLine ("Couldn't load assembly '{0}'.", assemblyName);
+						return 2;
 					}
-				} else {
-					Console.Error.WriteLine ("Couldn't load assembly '{0}'.", assemblyName);
-					return 2;
 				}
 				tw.Close ();
 			}


### PR DESCRIPTION
Follow-up to https://github.com/mono/mono/pull/4899. I audited all the places in BCL where we made use of Cecil's AssemblyDefinition and made sure we're properly disposing them and not keeping files unnecessarily open.

I used InMemory=true in cases where tracking the lifetime would be complicated. There are also some tests in mcs/tests which I didn't bother to fix.

It's probably best to review this with [?w=1](https://github.com/mono/mono/pull/4900/files?w=1).