### PR TITLE
Make this method overrideable as well

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
@@ -236,7 +236,7 @@ namespace System.Net.Http
 			return SendAsync (request, HttpCompletionOption.ResponseContentRead, cancellationToken);
 		}
 
-		public Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+		public virtual Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
 		{
 			if (request == null)
 				throw new ArgumentNullException ("request");


### PR DESCRIPTION
Since the method is also `public`, it should also be marked `virtual` so to allow interception of it.
This method in line [239](https://github.com/mono/mono/compare/master...weitzhandler:master#diff-ecc48f55e2b9f7cf2fe4693a4d3f1908R239), has the potential of letting extension developers to skip the interception of the original base `virtual` method of line [234](https://github.com/mono/mono/compare/master...weitzhandler:master#diff-ecc48f55e2b9f7cf2fe4693a4d3f1908R239).

This last `SendAsync` method in chain, should have either been made private in first place, or at least make it `virtual`.