### PR TITLE
[bcl] Make monolite platform specific

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,14 +50,9 @@ noinst_DATA = mono-uninstalled.pc
 DISTCLEANFILES= mono-uninstalled.pc
 
 # building with monolite
-mcslib = $(mcs_topdir)/class/lib
-monolite_url = https://download.mono-project.com/monolite/monolite-$(MONO_CORLIB_VERSION)-latest.tar.gz
 .PHONY: get-monolite-latest 
 get-monolite-latest:
-	-rm -fr $(mcslib)/monolite/$(MONO_CORLIB_VERSION)
-	-mkdir -p $(mcslib)/monolite
-	cd $(mcslib) && { (wget -O- $(monolite_url) || curl -L $(monolite_url)) | gzip -d | tar xf - ; }
-	cd $(mcslib) && mv -f monolite-* monolite/$(MONO_CORLIB_VERSION)
+	$(MAKE) -C $(mcs_topdir)/class get-monolite-latest
 
 if BITCODE
 BITCODE_CHECK=yes

--- a/mcs/build/profiles/basic.make
+++ b/mcs/build/profiles/basic.make
@@ -1,6 +1,6 @@
 # -*- makefile -*-
 
-monolite_path := $(topdir)/class/lib/monolite/$(MONO_CORLIB_VERSION)
+monolite_path := $(topdir)/class/lib/monolite-$(BUILD_PLATFORM)/$(MONO_CORLIB_VERSION)
 
 with_mono_path_monolite = MONO_PATH="$(monolite_path)$(PLATFORM_PATH_SEPARATOR)$(monolite_path)/Facades$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH"
 
@@ -90,7 +90,7 @@ ifdef use_monolite
 do-get-monolite:
 
 do-profile-check-monolite:
-	@echo "*** The contents of your 'monolite/$(MONO_CORLIB_VERSION)' directory may be out-of-date" 1>&2
+	@echo "*** The contents of your 'monolite-$(BUILD_PLATFORM)/$(MONO_CORLIB_VERSION)' directory may be out-of-date" 1>&2
 	@echo "*** You may want to try 'make get-monolite-latest'" 1>&2
 	rm -f $(monolite_flag)
 	exit 1
@@ -98,12 +98,12 @@ do-profile-check-monolite:
 else
 
 do-get-monolite:
-	@echo "*** Downloading bootstrap required 'monolite/$(MONO_CORLIB_VERSION)'" 1>&2
-	$(MAKE) $(MAKE_Q) -C $(mono_build_root) get-monolite-latest
+	@echo "*** Downloading bootstrap required 'monolite-$(BUILD_PLATFORM)/$(MONO_CORLIB_VERSION)'" 1>&2
+	$(MAKE) $(MAKE_Q) -C $(topdir)/class get-monolite-latest
 
 do-profile-check-monolite: $(depsdir)/.stamp
 	@echo "*** The runtime '$(PROFILE_RUNTIME)' doesn't appear to be usable." 1>&2
-	@echo "*** Trying the 'monolite/$(MONO_CORLIB_VERSION)' directory." 1>&2
+	@echo "*** Trying the 'monolite-$(BUILD_PLATFORM)/$(MONO_CORLIB_VERSION)' directory." 1>&2
 	@echo dummy > $(monolite_flag)
 	$(MAKE) do-profile-check
 

--- a/mcs/build/profiles/build.make
+++ b/mcs/build/profiles/build.make
@@ -6,12 +6,14 @@ BUILD_TOOLS_PROFILE = basic
 BOOTSTRAP_MCS = MONO_PATH="$(topdir)/class/lib/$(BOOTSTRAP_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(INTERNAL_CSC)
 MCS = $(BOOTSTRAP_MCS)
 
+PLATFORMS = darwin linux win32
+
 # nuttzing!
 
 profile-check:
 	@:
 
-DEFAULT_REFERENCES = -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll
+DEFAULT_REFERENCES = -r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/mscorlib.dll
 PROFILE_MCS_FLAGS = -d:NET_4_0 -d:NET_4_5 -d:MONO -d:WIN_PLATFORM -nowarn:1699 -nostdlib $(DEFAULT_REFERENCES)
 
 NO_SIGN_ASSEMBLY = yes

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -381,8 +381,7 @@ DISTFILES = \
 	MicrosoftAjaxLibrary/License.htm	\
 	test-helpers/NetworkHelpers.cs	\
 	test-helpers/SocketResponder.cs	\
-	lib/$(monolite_dir)/mcs.exe   \
-	$(monolite_files)
+	$(foreach HOST_PLATFORM,darwin linux win32,lib/$(monolite_dir)/mcs.exe $(monolite_files))
 
 .PHONY: all-local $(STD_TARGETS:=-local)
 all-local $(STD_TARGETS:=-local):
@@ -390,7 +389,7 @@ all-local $(STD_TARGETS:=-local):
 
 all-local-aot:
 
-monolite_dir := monolite/$(MONO_CORLIB_VERSION)
+monolite_dir = monolite-$(HOST_PLATFORM)/$(MONO_CORLIB_VERSION)
 
 # Files needed to bootstrap C# compiler
 build_files = mscorlib.dll System.dll System.Xml.dll Mono.Security.dll System.Core.dll System.Security.dll System.Configuration.dll \
@@ -413,24 +412,42 @@ lib/$(monolite_dir)/Facades:
 
 $(monolite_files): | lib/$(monolite_dir)
 $(monolite_files): | lib/$(monolite_dir)/Facades
-$(monolite_files): lib/$(monolite_dir)/%: lib/build/%
+$(monolite_files): lib/$(monolite_dir)/%: lib/build-$(HOST_PLATFORM)/%
 	cp -p $< $@
 
 lib/$(monolite_dir)/mcs.exe:
 	$(MAKE) -C ../mcs PROFILE=build
-	cp -p lib/build/mcs.exe lib/$(monolite_dir)
+	cp -p lib/build-$(HOST_PLATFORM)/mcs.exe lib/$(monolite_dir)
 
-$(build_files:%=lib/build/%):
+$(build_files:%=lib/build-$(HOST_PLATFORM)/%):
 	cd $(topdir) && $(MAKE) profile-do--build--all NO_DIR_CHECK=1 SKIP_AOT=1
 
 dist-monolite: $(monolite_files) lib/$(monolite_dir)/mcs.exe
 
+dist-monolite-all-platforms:
+	$(MAKE) dist-monolite HOST_PLATFORM=darwin
+	$(MAKE) dist-monolite HOST_PLATFORM=linux
+	$(MAKE) dist-monolite HOST_PLATFORM=win32
+
 package-monolite-latest:
-	MONOLITE=monolite-$(MONO_CORLIB_VERSION)-latest; \
+	MONOLITE=monolite-$(HOST_PLATFORM)-$(MONO_CORLIB_VERSION)-latest; \
 	$(MAKE) dist-monolite monolite_dir=$$MONOLITE; \
 	tar zcvpf $$MONOLITE.tar.gz --directory=lib $$MONOLITE/
 
-dist-default: dist-monolite
+package-monolite-latest-all-platforms:
+	$(MAKE) package-monolite-latest HOST_PLATFORM=darwin
+	$(MAKE) package-monolite-latest HOST_PLATFORM=linux
+	$(MAKE) package-monolite-latest HOST_PLATFORM=win32
+
+monolite_url = https://download.mono-project.com/monolite/monolite-$(BUILD_PLATFORM)-$(MONO_CORLIB_VERSION)-latest.tar.gz
+
+get-monolite-latest:
+	-rm -fr lib/monolite-$(BUILD_PLATFORM)/$(MONO_CORLIB_VERSION)
+	-mkdir -p lib/monolite-$(BUILD_PLATFORM)
+	cd lib && { (wget -O- $(monolite_url) || curl -L $(monolite_url)) | gzip -d | tar xf - ; }
+	cd lib && mv -f monolite-$(BUILD_PLATFORM)-$(MONO_CORLIB_VERSION)-latest monolite-$(BUILD_PLATFORM)/$(MONO_CORLIB_VERSION)
+
+dist-default: dist-monolite-all-platforms
 
 dist-local: dist-default
 


### PR DESCRIPTION
mscorlib.dll etc will be platform specific in the future. This also means that we need to adapt monolite since it'll become platform specific once we start the divergence.

monolite is essentially a repackaging of the "build" profile which means we need to turn that profile into multi-platform profile like net_4_x. We'll still have a symlink from build -> build-darwin and the monolite which is downloaded or packaged in the tarball is still expanded into mcs/lib/monolite depending on the platform you're building on.

I had to move the get-monolite-latest target from the top-level Makefile.am into mcs/class/Makefile so it has access to HOST_PLATFORM, but it arguably should've been there anyway before.