### PR TITLE
[appdomain] Don't leak MonoReflectionAssemblyHandles firing events

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -276,6 +276,40 @@ mono_handle_stack_free (HandleStack *stack)
 	g_free (stack);
 }
 
+void
+mono_handle_stack_free_domain (HandleStack *stack, MonoDomain *domain)
+{
+	/* Called by the GC while clearing out objects of the given domain from the heap. */
+	/* If there are no handles-related bugs, there is nothing to do: if a
+	 * thread accessed objects from the domain it was aborted, so any
+	 * threads left alive cannot have any handles that point into the
+	 * unloading domain.  However if there is a handle leak, the handle stack is not */
+	if (!stack)
+		return;
+	/* Root domain only unloaded when mono is shutting down, don't need to check anything */
+	if (domain == mono_get_root_domain () || mono_runtime_is_shutting_down ())
+		return;
+	HandleChunk *cur = stack->bottom;
+	HandleChunk *last = stack->top;
+	if (!cur)
+		return;
+	while (cur) {
+		for (int idx = 0; idx < cur->size; ++idx) {
+			HandleChunkElem *elem = &cur->elems[idx];
+			if (!elem->o)
+				continue;
+			g_assert (mono_object_domain (elem->o) != domain);
+		}
+		if (cur == last)
+			break;
+		cur = cur->next;
+	}
+	/* We don't examine the interior pointers here because the GC treats
+	 * them conservatively and anyway we don't have enough information here to
+	 * find the object's vtable.
+	 */
+}
+
 static void
 check_handle_stack_monotonic (HandleStack *stack)
 {

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -252,7 +252,7 @@ mono_handle_stack_alloc (void)
 	mono_memory_write_barrier ();
 	stack->top = stack->bottom = chunk;
 	stack->interior = interior;
-#ifdef MONO_HANDLE_TRACK_OWNER
+#ifdef MONO_HANDLE_TRACK_SP
 	stack->stackmark_sp = NULL;
 #endif
 	return stack;

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -118,6 +118,7 @@ HandleStack* mono_handle_stack_alloc (void);
 void mono_handle_stack_free (HandleStack *handlestack);
 MonoRawHandle mono_stack_mark_pop_value (MonoThreadInfo *info, HandleStackMark *stackmark, MonoRawHandle value);
 void mono_stack_mark_record_size (MonoThreadInfo *info, HandleStackMark *stackmark, const char *func_name);
+void mono_handle_stack_free_domain (HandleStack *stack, MonoDomain *domain);
 
 #ifdef MONO_HANDLE_TRACK_SP
 void mono_handle_chunk_leak_check (HandleStack *handles);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -893,6 +893,10 @@ mono_gc_clear_domain (MonoDomain * domain)
 
 	sgen_clear_nursery_fragments ();
 
+	FOREACH_THREAD (info) {
+		mono_handle_stack_free_domain ((HandleStack*)info->client_info.info.handle_stack, domain);
+	} FOREACH_THREAD_END
+
 	if (sgen_mono_xdomain_checks && domain != mono_get_root_domain ()) {
 		sgen_scan_for_registered_roots_in_domain (domain, ROOT_TYPE_NORMAL);
 		sgen_scan_for_registered_roots_in_domain (domain, ROOT_TYPE_WBARRIER);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -463,6 +463,7 @@ TESTS_CS_SRC=		\
 	assemblyresolve_event2.2.cs	\
 	appdomain-unload-callback.cs	\
 	appdomain-unload-doesnot-raise-pending-events.cs	\
+	appdomain-unload-asmload.cs	\
 	unload-appdomain-on-shutdown.cs	\
 	bug-47295.cs	\
 	loader.cs	\

--- a/mono/tests/appdomain-unload-asmload.cs
+++ b/mono/tests/appdomain-unload-asmload.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+
+/* This is a regression test that checks that after an AssemblyLoad event fires
+ * in a domain, the domain can be unloaded.  In bug # 56694, a
+ * System.Reflection.Assembly object from the unloaded domain was kept alive
+ * and crashed the GC.  */
+namespace AppDomainUnloadAsmLoad
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			// Need some threads in play
+			new Program().Run().Wait();
+		}
+
+		private async Task Run()
+		{
+			var appDomain = AppDomain.CreateDomain("Test subdomain", null, AppDomain.CurrentDomain.SetupInformation);
+			try
+			{
+				var driver = (AppDomainTestDriver)appDomain.CreateInstanceAndUnwrap(typeof(AppDomainTestDriver).Assembly.FullName,
+												    typeof(AppDomainTestDriver).FullName);
+				driver.Test();
+			}
+			finally
+			{
+				AppDomain.Unload(appDomain);
+			}
+		}
+	}
+
+	class AppDomainTestDriver : MarshalByRefObject
+	{
+		static AppDomainTestDriver()
+		{
+			// Needs a callback so that the runtime fires the
+			// AssembyLoad event for this domain and materializes a System.Reflection.Assembly
+			AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+		}
+
+		private static void CurrentDomain_AssemblyLoad(object sender, AssemblyLoadEventArgs args)
+		{
+		}
+
+		internal void Test()
+		{
+			/* this can be any class from any assembly that hasn't
+			 * already been loaded into the test domain.
+			 * System.Xml.dll is good because all the tests link
+			 * against it, but it's not otherwise used by this
+			 * domain. */
+			var foo = default(System.Xml.XmlException);
+		}
+    }
+}


### PR DESCRIPTION
- Don't leak coop handles in `mono_try_assembly_resolve_handle ()` and `mono_domain_fire_assembly_load ()`

- assert during domain unloading that no thread has a handle to an object from the unloading domain.

- Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=56694