### PR TITLE
[2017-04][appdomain] Don't leak MonoReflectionAssemblyHandles firing events

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1109,6 +1109,7 @@ leave:
 MonoAssembly*
 mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error)
 {
+	HANDLE_FUNCTION_ENTER ();
 	MonoAssembly *ret = NULL;
 	MonoMethod *method;
 	MonoBoolean isrefonly;
@@ -1117,7 +1118,7 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 	error_init (error);
 
 	if (mono_runtime_get_no_exec ())
-		return ret;
+		goto leave;
 
 	g_assert (domain != NULL && !MONO_HANDLE_IS_NULL (fname));
 
@@ -1128,14 +1129,16 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 	MonoReflectionAssemblyHandle requesting_handle;
 	if (requesting) {
 		requesting_handle = mono_assembly_get_object_handle (domain, requesting, error);
-		return_val_if_nok (error, ret);
+		if (!is_ok (error))
+			goto leave;
 	}
 	params [0] = MONO_HANDLE_RAW (fname);
 	params[1] = requesting ? MONO_HANDLE_RAW (requesting_handle) : NULL;
 	params [2] = &isrefonly;
 	MonoReflectionAssemblyHandle result = MONO_HANDLE_NEW (MonoReflectionAssembly, mono_runtime_invoke_checked (method, domain->domain, params, error));
 	ret = !MONO_HANDLE_IS_NULL (result) ? MONO_HANDLE_GETVAL (result, assembly) : NULL;
-	return ret;
+leave:
+	HANDLE_FUNCTION_RETURN_VAL (ret);
 }
 
 MonoAssembly *
@@ -1204,6 +1207,7 @@ add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 static void
 mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 {
+	HANDLE_FUNCTION_ENTER ();
 	static MonoClassField *assembly_load_field;
 	static MonoMethod *assembly_load_method;
 	MonoError error;
@@ -1214,7 +1218,7 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 
 	if (!domain->domain)
 		/* This can happen during startup */
-		return;
+		goto leave;
 #ifdef ASSEMBLY_LOAD_DEBUG
 	fprintf (stderr, "Loading %s into domain %s\n", assembly->aname.name, domain->friendly_name);
 #endif
@@ -1232,7 +1236,7 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 	mono_field_get_value ((MonoObject*) domain->domain, assembly_load_field, &load_value);
 	if (load_value == NULL) {
 		/* No events waiting to be triggered */
-		return;
+		goto leave;
 	}
 
 	MonoReflectionAssemblyHandle ref_assembly = mono_assembly_get_object_handle (domain, assembly, &error);
@@ -1247,6 +1251,8 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 
 	mono_runtime_invoke_checked (assembly_load_method, domain->domain, params, &error);
 	mono_error_cleanup (&error);
+leave:
+	HANDLE_FUNCTION_RETURN ();
 }
 
 /*

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -269,6 +269,42 @@ mono_handle_stack_free (HandleStack *stack)
 }
 
 void
+mono_handle_stack_free_domain (HandleStack *stack, MonoDomain *domain)
+{
+	/* Called by the GC while clearing out objects of the given domain from the heap. */
+	/* If there are no handles-related bugs, there is nothing to do: if a
+	 * thread accessed objects from the domain it was aborted, so any
+	 * threads left alive cannot have any handles that point into the
+	 * unloading domain.  However if there is a handle leak, the handle stack is not */
+	if (!stack)
+		return;
+	/* Root domain only unloaded when mono is shutting down, don't need to check anything */
+	if (domain == mono_get_root_domain () || mono_runtime_is_shutting_down ())
+		return;
+	HandleChunk *cur = stack->bottom;
+	HandleChunk *last = stack->top;
+	if (!cur)
+		return;
+	while (cur) {
+		for (int idx = 0; idx < cur->size; ++idx) {
+			HandleChunkElem *elem = &cur->elems[idx];
+			if (chunk_element_kind (cur, idx) == HANDLE_CHUNK_PTR_INTERIOR)
+				continue;
+			if (!elem->o)
+				continue;
+			g_assert (mono_object_domain (elem->o) != domain);
+		}
+		if (cur == last)
+			break;
+		cur = cur->next;
+	}
+	/* We don't examine the interior pointers here because the GC treats
+	 * them conservatively and anyway we don't have enough information here to
+	 * find the object's vtable.
+	 */
+}
+
+void
 mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, gboolean precise)
 {
 	/*

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -104,6 +104,7 @@ HandleStack* mono_handle_stack_alloc (void);
 void mono_handle_stack_free (HandleStack *handlestack);
 MonoRawHandle mono_stack_mark_pop_value (MonoThreadInfo *info, HandleStackMark *stackmark, MonoRawHandle value);
 void mono_stack_mark_record_size (MonoThreadInfo *info, HandleStackMark *stackmark, const char *func_name);
+void mono_handle_stack_free_domain (HandleStack *stack, MonoDomain *domain);
 
 static inline void
 mono_stack_mark_init (MonoThreadInfo *info, HandleStackMark *stackmark)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -887,6 +887,10 @@ mono_gc_clear_domain (MonoDomain * domain)
 
 	sgen_clear_nursery_fragments ();
 
+	FOREACH_THREAD (info) {
+		mono_handle_stack_free_domain ((HandleStack*)info->client_info.info.handle_stack, domain);
+	} FOREACH_THREAD_END
+
 	if (sgen_mono_xdomain_checks && domain != mono_get_root_domain ()) {
 		sgen_scan_for_registered_roots_in_domain (domain, ROOT_TYPE_NORMAL);
 		sgen_scan_for_registered_roots_in_domain (domain, ROOT_TYPE_WBARRIER);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -440,6 +440,7 @@ BASE_TEST_CS_SRC=		\
 	assemblyresolve_event2.2.cs	\
 	appdomain-unload-callback.cs	\
 	appdomain-unload-doesnot-raise-pending-events.cs	\
+	appdomain-unload-asmload.cs	\
 	unload-appdomain-on-shutdown.cs	\
 	bug-47295.cs	\
 	loader.cs	\

--- a/mono/tests/appdomain-unload-asmload.cs
+++ b/mono/tests/appdomain-unload-asmload.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+
+/* This is a regression test that checks that after an AssemblyLoad event fires
+ * in a domain, the domain can be unloaded.  In bug # 56694, a
+ * System.Reflection.Assembly object from the unloaded domain was kept alive
+ * and crashed the GC.  */
+namespace AppDomainUnloadAsmLoad
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			// Need some threads in play
+			new Program().Run().Wait();
+		}
+
+		private async Task Run()
+		{
+			var appDomain = AppDomain.CreateDomain("Test subdomain", null, AppDomain.CurrentDomain.SetupInformation);
+			try
+			{
+				var driver = (AppDomainTestDriver)appDomain.CreateInstanceAndUnwrap(typeof(AppDomainTestDriver).Assembly.FullName,
+												    typeof(AppDomainTestDriver).FullName);
+				driver.Test();
+			}
+			finally
+			{
+				AppDomain.Unload(appDomain);
+			}
+		}
+	}
+
+	class AppDomainTestDriver : MarshalByRefObject
+	{
+		static AppDomainTestDriver()
+		{
+			// Needs a callback so that the runtime fires the
+			// AssembyLoad event for this domain and materializes a System.Reflection.Assembly
+			AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+		}
+
+		private static void CurrentDomain_AssemblyLoad(object sender, AssemblyLoadEventArgs args)
+		{
+		}
+
+		internal void Test()
+		{
+			/* this can be any class from any assembly that hasn't
+			 * already been loaded into the test domain.
+			 * System.Xml.dll is good because all the tests link
+			 * against it, but it's not otherwise used by this
+			 * domain. */
+			var foo = default(System.Xml.XmlException);
+		}
+    }
+}


### PR DESCRIPTION
This is #4923 backported to `2017-04`

----

- Don't leak coop handles in `mono_try_assembly_resolve_handle ()` and `mono_domain_fire_assembly_load ()`

- assert during domain unloading that no thread has a handle to an object from the unloading domain.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=56694