### PR TITLE
Add concurrent read version of MonoGHashTable and use it with MonoDomain::refobject

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -193,6 +193,7 @@ common_sources = \
 	mono-endian.c		\
 	mono-endian.h		\
 	mono-hash.h		\
+	mono-conc-hash.h		\
 	mono-mlist.c		\
 	mono-mlist.h		\
 	mono-perfcounters.c	\
@@ -280,6 +281,7 @@ gc_dependent_sources = \
 	gc.c		\
 	monitor.c	\
 	mono-hash.c	\
+	mono-conc-hash.c	\
 	object.c	\
 	dynamic-image.c	\
 	sre.c	\

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -12,6 +12,7 @@
 #include <mono/metadata/lock-tracer.h>
 #include <mono/utils/mono-codeman.h>
 #include <mono/metadata/mono-hash.h>
+#include <mono/metadata/mono-conc-hash.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-internal-hash.h>
 #include <mono/metadata/mempool-internals.h>
@@ -339,7 +340,7 @@ struct _MonoDomain {
 	MonoGHashTable     *ldstr_table;
 	/* hashtables for Reflection handles */
 	MonoGHashTable     *type_hash;
-	MonoGHashTable     *refobject_hash;
+	MonoConcGHashTable     *refobject_hash;
 	/* maps class -> type initialization exception object */
 	MonoGHashTable    *type_init_exception_hash;
 	/* maps delegate trampoline addr -> delegate object */

--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -1,0 +1,453 @@
+/**
+ * \file
+ * Conc GC aware Hashtable implementation
+ *
+ * Author:
+ *   Rodrigo Kumpera (kumpera@gmail.com)
+ *
+ */
+#include <config.h>
+#include <stdio.h>
+#include <math.h>
+#include <glib.h>
+#include "mono-conc-hash.h"
+#include "metadata/gc-internals.h"
+#include <mono/utils/checked-build.h>
+#include <mono/utils/mono-threads-coop.h>
+
+#ifdef HAVE_BOEHM_GC
+#define mg_new0(type,n)  ((type *) GC_MALLOC(sizeof(type) * (n)))
+#define mg_new(type,n)   ((type *) GC_MALLOC(sizeof(type) * (n)))
+#define mg_free(x)       do { } while (0)
+#else
+#define mg_new0(x,n)     g_new0(x,n)
+#define mg_new(type,n)   g_new(type,n)
+#define mg_free(x)       g_free(x)
+#endif
+
+#define INITIAL_SIZE 32
+#define LOAD_FACTOR 0.75f
+#define PTR_TOMBSTONE ((gpointer)(ssize_t)-1)
+/* Expand ration must be a power of two */
+#define EXPAND_RATIO 2
+
+typedef struct {
+	int table_size;
+	MonoGHashGCType gc_type;
+	void **keys;
+	void **values;
+} conc_table;
+
+struct _MonoConcGHashTable {
+	volatile conc_table *table; /* goes to HP0 */
+	GHashFunc hash_func;
+	GEqualFunc equal_func;
+	int element_count;
+	int overflow_count;
+	GDestroyNotify key_destroy_func;
+	GDestroyNotify value_destroy_func;
+	MonoGHashGCType gc_type;
+	MonoGCRootSource source;
+	const char *msg;
+};
+
+
+static conc_table*
+conc_table_new (MonoConcGHashTable *hash, int size)
+{
+#ifdef HAVE_SGEN_GC
+	conc_table *table = mg_new0 (conc_table, 1);
+#else
+	conc_table *table = mono_gc_alloc_fixed (sizeof (conc_table), MONO_GC_ROOT_DESCR_FOR_FIXED (sizeof (conc_table)), hash->source, hash->msg);
+#endif
+	
+	table->keys = mg_new0 (void*, size);
+	table->values = mg_new0 (void*, size);
+	table->table_size = size;
+	table->gc_type = hash->gc_type;
+
+#ifdef HAVE_SGEN_GC
+	if (hash->gc_type & MONO_HASH_KEY_GC)
+		mono_gc_register_root_wbarrier ((char*)table->keys, sizeof (MonoObject*) * size, mono_gc_make_vector_descr (), hash->source, hash->msg);
+	if (hash->gc_type & MONO_HASH_VALUE_GC)
+		mono_gc_register_root_wbarrier ((char*)table->values, sizeof (MonoObject*) * size, mono_gc_make_vector_descr (), hash->source, hash->msg);
+#endif
+
+	return table;
+}
+
+static void
+conc_table_free (gpointer ptr)
+{
+	conc_table *table = (conc_table *)ptr;
+#ifdef HAVE_SGEN_GC
+	if (table->gc_type & MONO_HASH_KEY_GC)
+		mono_gc_deregister_root ((char*)table->keys);
+	if (table->gc_type & MONO_HASH_VALUE_GC)
+		mono_gc_deregister_root ((char*)table->values);
+#endif
+
+	mg_free (table->keys);
+	mg_free (table->values);
+#ifdef HAVE_SGEN_GC
+	mg_free (table);
+#else
+	mono_gc_free_fixed (table);
+#endif
+}
+
+static void
+conc_table_lf_free (conc_table *table)
+{
+	mono_thread_hazardous_try_free (table, conc_table_free);
+}
+
+
+static gboolean
+key_is_tombstone (MonoConcGHashTable *hash, gpointer ptr)
+{
+	if (hash->gc_type & MONO_HASH_KEY_GC)
+		return ptr == mono_domain_get()->ephemeron_tombstone;
+	return ptr == PTR_TOMBSTONE;
+}
+
+/*
+A common problem with power of two hashtables is that it leads of bad clustering when dealing
+with aligned numbers.
+
+The solution here is to mix the bits from two primes plus the hash itself, it produces a better spread
+than just the numbers.
+*/
+
+static MONO_ALWAYS_INLINE int
+mix_hash (int hash)
+{
+	return ((hash * 215497) >> 16) ^ (hash * 1823231 + hash);
+}
+
+
+static inline void
+set_key (conc_table *table, int slot, gpointer key)
+{
+	gpointer *key_addr = &table->keys [slot];
+	if (table->gc_type & MONO_HASH_KEY_GC)
+		mono_gc_wbarrier_generic_store (key_addr, key);
+	else
+		*key_addr = key;
+}
+
+static inline void
+set_key_to_tombstone (conc_table *table, int slot)
+{
+	gpointer *key_addr = &table->keys [slot];
+	if (table->gc_type & MONO_HASH_KEY_GC)
+		mono_gc_wbarrier_generic_store (key_addr, mono_domain_get()->ephemeron_tombstone);
+	else
+		*key_addr = PTR_TOMBSTONE;
+}
+
+static inline void
+set_value (conc_table *table, int slot, gpointer value)
+{
+	gpointer *value_addr = &table->values [slot];
+	if (table->gc_type & MONO_HASH_VALUE_GC)
+		mono_gc_wbarrier_generic_store (value_addr, value);
+	else
+		*value_addr = value;
+}
+
+static MONO_ALWAYS_INLINE void
+insert_one_local (conc_table *table, GHashFunc hash_func, gpointer key, gpointer value)
+{
+	int table_mask = table->table_size - 1;
+	int hash = mix_hash (hash_func (key));
+	int i = hash & table_mask;
+
+	while (table->keys [i])
+		i = (i + 1) & table_mask;
+
+	set_key (table, i, key);
+	set_value (table, i, value);
+}
+
+static void
+expand_table (MonoConcGHashTable *hash_table)
+{
+	conc_table *old_table = (conc_table*)hash_table->table;
+	conc_table *new_table = conc_table_new (hash_table, old_table->table_size * EXPAND_RATIO);
+	int i;
+
+	for (i = 0; i < old_table->table_size; ++i) {
+		if (old_table->keys [i] && !key_is_tombstone (hash_table, old_table->keys [i]))
+			insert_one_local (new_table, hash_table->hash_func, old_table->keys [i], old_table->values [i]);
+	}
+
+	mono_memory_barrier ();
+	hash_table->table = new_table;
+	hash_table->overflow_count = (int)(new_table->table_size * LOAD_FACTOR);
+	conc_table_lf_free (old_table);	
+}
+
+
+MonoConcGHashTable *
+mono_conc_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, const char *msg)
+{
+	MonoConcGHashTable *hash;
+
+	if (!hash_func)
+		hash_func = g_direct_hash;
+
+	hash = g_new0 (MonoConcGHashTable, 1);
+	hash->hash_func = hash_func;
+	hash->equal_func = key_equal_func;
+
+	hash->table = conc_table_new (hash, INITIAL_SIZE);
+	hash->element_count = 0;
+	hash->overflow_count = (int)(INITIAL_SIZE * LOAD_FACTOR);
+
+	hash->gc_type = type;
+	hash->source = source;
+	hash->msg = msg;
+	if (type > MONO_HASH_KEY_VALUE_GC)
+		g_error ("wrong type for gc hashtable");
+
+	return hash;
+}
+
+gpointer
+mono_conc_g_hash_table_lookup (MonoConcGHashTable *hash, gconstpointer key)
+{
+	gpointer orig_key, value;
+
+	if (mono_conc_g_hash_table_lookup_extended (hash, key, &orig_key, &value))
+		return value;
+	else
+		return NULL;
+}
+
+gboolean
+mono_conc_g_hash_table_lookup_extended (MonoConcGHashTable *hash_table, gconstpointer key, gpointer *orig_key_ptr, gpointer *value_ptr)
+{
+	MonoThreadHazardPointers* hp;
+	conc_table *table;
+	int hash, i, table_mask;
+	hash = mix_hash (hash_table->hash_func (key));
+	hp = mono_hazard_pointer_get ();
+
+retry:
+	table = (conc_table *)mono_get_hazardous_pointer ((gpointer volatile*)&hash_table->table, hp, 0);
+	table_mask = table->table_size - 1;
+	i = hash & table_mask;
+
+	if (G_LIKELY (!hash_table->equal_func)) {
+		while (table->keys [i]) {
+			gpointer orig_key = table->keys [i];
+			if (key == orig_key) {
+				gpointer value;
+				/* The read of keys must happen before the read of values */
+				mono_memory_barrier ();
+				value = table->values [i];
+
+				/* We just read a value been deleted, try again. */
+				if (G_UNLIKELY (!value))
+					goto retry;
+
+				mono_hazard_pointer_clear (hp, 0);
+
+				*orig_key_ptr = orig_key;
+				*value_ptr = value;
+				return TRUE;
+			}
+			i = (i + 1) & table_mask;
+		}
+	} else {
+		GEqualFunc equal = hash_table->equal_func;
+
+		while (table->keys [i]) {
+			gpointer orig_key = table->keys [i];
+			if (!key_is_tombstone (hash_table, orig_key) && equal (key, orig_key)) {
+				gpointer value;
+				/* The read of keys must happen before the read of values */
+				mono_memory_barrier ();
+				value = table->values [i];
+
+				/* We just read a value been deleted, try again. */
+				if (G_UNLIKELY (!value))
+					goto retry;
+
+				mono_hazard_pointer_clear (hp, 0);
+				*orig_key_ptr = orig_key;
+				*value_ptr = value;
+				return TRUE;
+
+			}
+			i = (i + 1) & table_mask;
+		}
+	}
+
+	/* The table might have expanded and the value is now on the newer table */
+	mono_memory_barrier ();
+	if (hash_table->table != table)
+		goto retry;
+
+	mono_hazard_pointer_clear (hp, 0);
+
+	*orig_key_ptr = NULL;
+	*value_ptr = NULL;
+	return FALSE;
+}
+
+void
+mono_conc_g_hash_table_foreach (MonoConcGHashTable *hash_table, GHFunc func, gpointer user_data)
+{
+	int i;
+	conc_table *table = (conc_table*)hash_table->table;
+
+	for (i = 0; i < table->table_size; ++i) {
+		if (table->keys [i] && !key_is_tombstone (hash_table, table->keys [i])) {
+			func (table->keys [i], table->values [i], user_data);
+		}
+	}	
+}
+
+void
+mono_conc_g_hash_table_destroy (MonoConcGHashTable *hash_table)
+{
+	if (hash_table->key_destroy_func || hash_table->value_destroy_func) {
+		int i;
+		conc_table *table = (conc_table*)hash_table->table;
+
+		for (i = 0; i < table->table_size; ++i) {
+			if (table->keys [i] && !key_is_tombstone (hash_table, table->keys [i])) {
+				if (hash_table->key_destroy_func)
+					(hash_table->key_destroy_func) (table->keys [i]);
+				if (hash_table->value_destroy_func)
+					(hash_table->value_destroy_func) (table->values [i]);
+			}
+		}
+	}
+	conc_table_free ((gpointer)hash_table->table);
+	g_free (hash_table);
+}
+
+/* Return NULL on success or the old value in failure */
+gpointer
+mono_conc_g_hash_table_insert (MonoConcGHashTable *hash_table, gpointer key, gpointer value)
+{
+	conc_table *table;
+	int hash, i, table_mask;
+
+	g_assert (key != NULL);
+	g_assert (value != NULL);
+
+	hash = mix_hash (hash_table->hash_func (key));
+
+	if (hash_table->element_count >= hash_table->overflow_count)
+		expand_table (hash_table);
+
+	table = (conc_table*)hash_table->table;
+	table_mask = table->table_size - 1;
+	i = hash & table_mask;
+
+	if (!hash_table->equal_func) {
+		for (;;) {
+			gpointer cur_key = table->keys [i];
+			if (!cur_key || key_is_tombstone (hash_table, cur_key)) {
+				set_value (table, i, value);
+
+				/* The write to values must happen after the write to keys */
+				mono_memory_barrier ();
+				set_key (table, i, key);
+				++hash_table->element_count;
+				return NULL;
+			}
+			if (key == cur_key) {
+				gpointer value = table->values [i];
+				return value;
+			}
+			i = (i + 1) & table_mask;
+		}
+	} else {
+		GEqualFunc equal = hash_table->equal_func;
+		for (;;) {
+			gpointer cur_key = table->keys [i];
+			if (!cur_key || key_is_tombstone (hash_table, cur_key)) {
+				set_value (table, i, value);
+				/* The write to values must happen after the write to keys */
+				mono_memory_barrier ();
+				set_key (table, i, key);
+				++hash_table->element_count;
+				return NULL;
+			}
+			if (equal (key, cur_key)) {
+				gpointer value = table->values [i];
+				return value;
+			}
+			i = (i + 1) & table_mask;
+		}
+	}
+}
+
+gpointer
+mono_conc_g_hash_table_remove (MonoConcGHashTable *hash_table, gconstpointer key)
+{
+	conc_table *table;
+	int hash, i, table_mask;
+
+	g_assert (key != NULL);
+
+	hash = mix_hash (hash_table->hash_func (key));
+
+	table = (conc_table*)hash_table->table;
+	table_mask = table->table_size - 1;
+	i = hash & table_mask;
+
+	if (!hash_table->equal_func) {
+		for (;;) {
+			gpointer cur_key = table->keys [i];
+			if (!cur_key) {
+				return NULL; /*key not found*/
+			}
+
+			if (key == cur_key) {
+				gpointer value = table->values [i];
+				table->values [i] = NULL;
+				mono_memory_barrier ();
+				set_key_to_tombstone (table, i);
+
+				--hash_table->element_count;
+
+				if (hash_table->key_destroy_func != NULL)
+					(*hash_table->key_destroy_func) (cur_key);
+				if (hash_table->value_destroy_func != NULL)
+					(*hash_table->value_destroy_func) (value);
+
+				return value;
+			}
+			i = (i + 1) & table_mask;
+		}
+	} else {
+		GEqualFunc equal = hash_table->equal_func;
+		for (;;) {
+			gpointer cur_key = table->keys [i];
+			if (!cur_key) {
+				return NULL; /*key not found*/
+			}
+
+			if (!key_is_tombstone (hash_table, cur_key) && equal (key, cur_key)) {
+				gpointer value = table->values [i];
+				table->values [i] = NULL;
+				mono_memory_barrier ();
+				set_key_to_tombstone (table, i);
+
+				if (hash_table->key_destroy_func != NULL)
+					(*hash_table->key_destroy_func) (cur_key);
+				if (hash_table->value_destroy_func != NULL)
+					(*hash_table->value_destroy_func) (value);
+				return value;
+			}
+
+			i = (i + 1) & table_mask;
+		}
+	}
+}

--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -201,13 +201,14 @@ mono_conc_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func,
 	hash->hash_func = hash_func;
 	hash->equal_func = key_equal_func;
 
-	hash->table = conc_table_new (hash, INITIAL_SIZE);
 	hash->element_count = 0;
 	hash->overflow_count = (int)(INITIAL_SIZE * LOAD_FACTOR);
-
 	hash->gc_type = type;
 	hash->source = source;
 	hash->msg = msg;
+
+	hash->table = conc_table_new (hash, INITIAL_SIZE);
+
 	if (type > MONO_HASH_KEY_VALUE_GC)
 		g_error ("wrong type for gc hashtable");
 

--- a/mono/metadata/mono-conc-hash.h
+++ b/mono/metadata/mono-conc-hash.h
@@ -1,0 +1,22 @@
+/**
+ * \file
+ * GC-aware concurrent hashtable, based on utils/mono-conc-hashtable
+ */
+
+#ifndef __MONO_CONC_G_HASH_H__
+#define __MONO_CONC_G_HASH_H__
+
+#include <mono/metadata/mono-hash.h>
+
+
+typedef struct _MonoConcGHashTable MonoConcGHashTable;
+
+MonoConcGHashTable * mono_conc_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, const char *msg);
+gpointer mono_conc_g_hash_table_lookup (MonoConcGHashTable *hash, gconstpointer key);
+gboolean mono_conc_g_hash_table_lookup_extended (MonoConcGHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value);
+void mono_conc_g_hash_table_foreach (MonoConcGHashTable *hash, GHFunc func, gpointer user_data);
+void mono_conc_g_hash_table_destroy (MonoConcGHashTable *hash);
+gpointer mono_conc_g_hash_table_insert (MonoConcGHashTable *h, gpointer k, gpointer v);
+gpointer mono_conc_g_hash_table_remove (MonoConcGHashTable *hash, gconstpointer key);
+
+#endif /* __MONO_CONC_G_HASH_H__ */

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -48,16 +48,17 @@ cache_object (MonoDomain *domain, MonoClass *klass, gpointer item, MonoObject* o
 	ReflectedEntry pe;
 	pe.item = item;
 	pe.refclass = klass;
+
 	mono_domain_lock (domain);
 	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection objects table");
+		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection objects table");
 
-	obj = (MonoObject*) mono_g_hash_table_lookup (domain->refobject_hash, &pe);
+	obj = (MonoObject*) mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe);
 	if (obj == NULL) {
 		ReflectedEntry *e = ALLOC_REFENTRY;
 		e->item = item;
 		e->refclass = klass;
-		mono_g_hash_table_insert (domain->refobject_hash, e, o);
+		mono_conc_g_hash_table_insert (domain->refobject_hash, e, o);
 		obj = o;
 	}
 	mono_domain_unlock (domain);
@@ -71,16 +72,17 @@ cache_object_handle (MonoDomain *domain, MonoClass *klass, gpointer item, MonoOb
 	ReflectedEntry pe;
 	pe.item = item;
 	pe.refclass = klass;
+
 	mono_domain_lock (domain);
 	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection objects table");
+		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection objects table");
 
-	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_g_hash_table_lookup (domain->refobject_hash, &pe));
+	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe));
 	if (MONO_HANDLE_IS_NULL (obj)) {
 		ReflectedEntry *e = ALLOC_REFENTRY;
 		e->item = item;
 		e->refclass = klass;
-		mono_g_hash_table_insert (domain->refobject_hash, e, MONO_HANDLE_RAW (o));
+		mono_conc_g_hash_table_insert (domain->refobject_hash, e, MONO_HANDLE_RAW (o));
 		MONO_HANDLE_ASSIGN (obj, o);
 	}
 	mono_domain_unlock (domain);
@@ -96,11 +98,11 @@ check_object_handle (MonoDomain* domain, MonoClass *klass, gpointer item)
 	ReflectedEntry e;
 	e.item = item;
 	e.refclass = klass;
-	mono_domain_lock (domain);
-	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection objects table");
-	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_g_hash_table_lookup (domain->refobject_hash, &e));
-	mono_domain_unlock (domain);
+	MonoConcGHashTable *hash = domain->refobject_hash;
+	if (!hash)
+		return MONO_HANDLE_NEW (MonoObject, NULL);
+
+	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_conc_g_hash_table_lookup (hash, &e));
 	return obj;
 }
 

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -118,6 +118,8 @@ check_or_construct_handle (MonoDomain *domain, MonoClass *klass, gpointer item, 
 		return obj;
 	MONO_HANDLE_ASSIGN (obj, construct (domain, klass, item, user_data, error));
 	return_val_if_nok (error, NULL);
+	if (MONO_HANDLE_IS_NULL (obj))
+		return obj;
 	/* note no caching if there was an error in construction */
 	return cache_object_handle (domain, klass, item, obj);
 }

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1210,6 +1210,7 @@ mono_method_body_get_object (MonoDomain *domain, MonoMethod *method)
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
+/* WARNING: This method can return NULL on sucess */
 static MonoReflectionMethodBodyHandle
 method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoMethod *method, gpointer user_data, MonoError *error)
 {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -186,8 +186,9 @@ clear_cached_object (MonoDomain *domain, gpointer o, MonoClass *klass)
 
 		pe.item = o;
 		pe.refclass = klass;
-		if (mono_g_hash_table_lookup_extended (domain->refobject_hash, &pe, &orig_pe, &orig_value)) {
-			mono_g_hash_table_remove (domain->refobject_hash, &pe);
+
+		if (mono_conc_g_hash_table_lookup_extended (domain->refobject_hash, &pe, &orig_pe, &orig_value)) {
+			mono_conc_g_hash_table_remove (domain->refobject_hash, &pe);
 			FREE_REFENTRY (orig_pe);
 		}
 	}
@@ -208,9 +209,9 @@ mono_reflection_cleanup_domain (MonoDomain *domain)
 	if (domain->refobject_hash) {
 /*let's avoid scanning the whole hashtable if not needed*/
 #ifdef REFENTRY_REQUIRES_CLEANUP
-		mono_g_hash_table_foreach (domain->refobject_hash, cleanup_refobject_hash, NULL);
+		mono_conc_g_hash_table_foreach (domain->refobject_hash, cleanup_refobject_hash, NULL);
 #endif
-		mono_g_hash_table_destroy (domain->refobject_hash);
+		mono_conc_g_hash_table_destroy (domain->refobject_hash);
 		domain->refobject_hash = NULL;
 	}
 }

--- a/msvc/libmonoruntime.vcxproj
+++ b/msvc/libmonoruntime.vcxproj
@@ -75,6 +75,7 @@
     <ClCompile Include="..\mono\metadata\mono-debug.c" />
     <ClCompile Include="..\mono\metadata\mono-endian.c" />
     <ClCompile Include="..\mono\metadata\mono-hash.c" />
+    <ClCompile Include="..\mono\metadata\mono-conc-hash.c" />
     <ClCompile Include="..\mono\metadata\mono-mlist.c" />
     <ClCompile Include="..\mono\metadata\mono-perfcounters.c" />
     <ClCompile Include="..\mono\metadata\nacl-stub.c" />
@@ -181,6 +182,7 @@
     <ClInclude Include="..\mono\metadata\mono-debug.h" />
     <ClInclude Include="..\mono\metadata\mono-endian.h" />
     <ClInclude Include="..\mono\metadata\mono-hash.h" />
+    <ClInclude Include="..\mono\metadata\mono-conc-hash.h" />
     <ClInclude Include="..\mono\metadata\mono-mlist.h" />
     <ClInclude Include="..\mono\metadata\mono-perfcounters-def.h" />
     <ClInclude Include="..\mono\metadata\mono-perfcounters.h" />

--- a/msvc/libmonoruntime.vcxproj.filters
+++ b/msvc/libmonoruntime.vcxproj.filters
@@ -199,6 +199,9 @@
     <ClCompile Include="..\mono\metadata\mono-hash.c">
       <Filter>Source Files\gc</Filter>
     </ClCompile>
+    <ClCompile Include="..\mono\metadata\mono-conc-hash.c">
+      <Filter>Source Files\gc</Filter>
+    </ClCompile>
     <ClCompile Include="..\mono\metadata\object.c">
       <Filter>Source Files\gc</Filter>
     </ClCompile>
@@ -394,6 +397,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\mono\metadata\mono-hash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mono\metadata\mono-conc-hash.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\mono\metadata\mono-mlist.h">


### PR DESCRIPTION
This improves reflection scalability, a bottleneck that XS is hitting.

Given this benchmark and my 4 cores laptop:

```
const int T_C = 4;
var list = new List<Thread> ();
bool done = false;
int count = 0;
for (int i = 0; i < T_C; ++i) {
	var t = new Thread(() => {
		while (!done) {
			typeof (Driver)
				.GetMethods (
					BindingFlags.Public | BindingFlags.NonPublic |
					BindingFlags.Instance | BindingFlags.Static);
			Interlocked.Increment (ref count);
		}
	});
	t.Start ();
	list.Add (t);
}

Thread.Sleep (5000);
done = true;
foreach (var t in list)
	t.Join ();
Console.WriteLine ("Got {0} lists done", count);
```

This change makes us go from 166.725 queries/s to 5.140.821 queries/s. Or 30x faster.