### PR TITLE
Fixing on WriteContentType when extension is empty.

### DIFF
--- a/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
@@ -226,14 +226,9 @@ namespace System.IO.Packaging {
 				var extension = Path.GetExtension (part.Uri.OriginalString);
 				if (extension.Length > 0)
 					extension = extension.Substring (1);
-				
-				if (extension.Length == 0) {
-					// If extension is empty string (no extension), can possible goes here,
-					// So to avoid that, we give a condition, only having extension will go here.
-					continue;
-				}
 
-				if (!mimes.TryGetValue (extension, out existingMimeType)) {
+				if (!mimes.TryGetValue (extension, out existingMimeType) && extension.Length != 0) {
+					// we should only get here when we have an extension (non-empty string)
 					node = doc.CreateNode (XmlNodeType.Element, "Default", ContentNamespace);
 					
 					XmlAttribute ext = doc.CreateAttribute ("Extension");

--- a/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
@@ -226,14 +226,15 @@ namespace System.IO.Packaging {
 				var extension = Path.GetExtension (part.Uri.OriginalString);
 				if (extension.Length > 0)
 					extension = extension.Substring (1);
+				
+				if (extension.Length == 0) {
+					// If extension is empty string (no extension), can possible goes here,
+					// So to avoid that, we give a condition, only having extension will go here.
+					continue;
+				}
 
-                if (extension.Length > 0 &&
-                    !mimes.TryGetValue(extension, out existingMimeType))
-                {
-                    // If extension is empty string (no extension), can possible goes here,
-                    // So to avoid that, we give a condition, only having extension will go here.
-
-                    node = doc.CreateNode (XmlNodeType.Element, "Default", ContentNamespace);
+				if (!mimes.TryGetValue (extension, out existingMimeType)) {
+					node = doc.CreateNode (XmlNodeType.Element, "Default", ContentNamespace);
 					
 					XmlAttribute ext = doc.CreateAttribute ("Extension");
 					ext.Value = extension;

--- a/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
@@ -226,9 +226,14 @@ namespace System.IO.Packaging {
 				var extension = Path.GetExtension (part.Uri.OriginalString);
 				if (extension.Length > 0)
 					extension = extension.Substring (1);
-				
-				if (!mimes.TryGetValue (extension, out existingMimeType)) {
-					node = doc.CreateNode (XmlNodeType.Element, "Default", ContentNamespace);
+
+                if (extension.Length > 0 &&
+                    !mimes.TryGetValue(extension, out existingMimeType))
+                {
+                    // If extension is empty string (no extension), can possible goes here,
+                    // So to avoid that, we give a condition, only having extension will go here.
+
+                    node = doc.CreateNode (XmlNodeType.Element, "Default", ContentNamespace);
 					
 					XmlAttribute ext = doc.CreateAttribute ("Extension");
 					ext.Value = extension;

--- a/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
+++ b/mcs/class/WindowsBase/Test/System.IO.Packaging/PackagePartTest.cs
@@ -121,7 +121,23 @@ namespace MonoTests.System.IO.Packaging {
             Assert.AreEqual (package, part.Package, "Wrong package3");
             Assert.AreEqual ("/third", part.Uri.ToString (), "Wrong package selected3");
         }
-		
+
+		[Test]
+		public void CheckPartExtensions ()
+		{
+			package.CreatePart (new Uri ("/first", UriKind.Relative), "my/a");
+			package.CreatePart (new Uri ("/second", UriKind.Relative), "my/b", CompressionOption.Maximum);
+			package.CreatePart (new Uri ("/third", UriKind.Relative), "test/c", CompressionOption.SuperFast);
+			package.CreatePart (new Uri ("/fourth.txt", UriKind.Relative), "test/d");
+			package.Close ();
+			using (var archive = new global::System.IO.Compression.ZipArchive (stream, global::System.IO.Compression.ZipArchiveMode.Read)) {
+				var contentTypes = archive.GetEntry ("[Content_Types].xml");
+				var reader = new StreamReader (contentTypes.Open ());
+				var expected = "<?xml version=\"1.0\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Override ContentType=\"my/a\" PartName=\"/first\" /><Override ContentType=\"my/b\" PartName=\"/second\" /><Override ContentType=\"test/c\" PartName=\"/third\" /><Default ContentType=\"test/d\" Extension=\"txt\" /></Types>";
+				Assert.AreEqual (expected, reader.ReadToEnd ());
+			}
+		}
+
 		[Test]
 		public void SameExtensionDifferentContentTypeTest ()
 		{


### PR DESCRIPTION
When I create package the result should be like Windows result. Linux Result is not correct.
So to correct it, I added a condition in the code.

![xml result](https://cloud.githubusercontent.com/assets/28587808/26567052/52c49378-4522-11e7-8bfc-f3dfa966b9b5.png)

