### PR TITLE
[System] Add useDefaultCredentialsProp to the list of properties.

### DIFF
--- a/mcs/class/System/System.Net.Configuration/DefaultProxySection.cs
+++ b/mcs/class/System/System.Net.Configuration/DefaultProxySection.cs
@@ -63,6 +63,7 @@ namespace System.Net.Configuration
 			properties.Add (bypassListProp);
 			properties.Add (moduleProp);
 			properties.Add (proxyProp);
+			properties.Add (useDefaultCredentialsProp);
 		}
 
 		public DefaultProxySection ()


### PR DESCRIPTION
Trying to configure an assembly's `defaultProxy` causes exceptions like the following:

```
Error: 'System.Configuration.ConfigurationErrorsException: Error deserializing configuration section defaultProxy: Unrecognized attribute 'useDefaultCredentials'. (/Users/cody/xam/new-servicehub/monodevelop/main/build/bin/ServiceHub/Services/IdentityService/Microsoft.Developer.IdentityService.dll.config line 1)
  at System.Configuration.ConfigurationSection.DeserializeSection (System.Xml.XmlReader reader) [0x0000a] in /private/tmp/source-mono-2017-04/bockbuild-2017-04/profiles/mono-mac-xamarin/build-root/mono-x64/mcs/class/System.Configuration/System.Configuration/ConfigurationSection.cs:195
  at System.Configuration.Configuration.GetSectionInstance (System.Configuration.SectionInfo config, System.Boolean createDefaultInstance) [0x000c6] in /private/tmp/source-mono-2017-04/bockbuild-2017-04/profiles/mono-mac-xamarin/build-root/mono-x64/mcs/class/System.Configuration/System.Configuration/Configuration.cs:309
  at System.Configuration.ConfigurationSectionCollection.get_Item (System.String name) [0x0002c] in /private/tmp/source-mono-2017-04/bockbuild-2017-04/profiles/mono-mac-xamarin/build-root/mono-x64/mcs/class/System.Configuration/System.Configuration/ConfigurationSectionCollection.cs:68
  at System.Configuration.Configuration.GetSection (System.String sectionName) [0x0005b] in /private/tmp/source-mono-2017-04/bockbuild-2017-04/profiles/mono-mac-xamarin/build-root/mono-x64/mcs/class/System.Configuration/System.Configuration/Configuration.cs:265
  at System.Configuration.ClientConfigurationSystem.System.Configuration.Internal.IInternalConfigSystem.GetSection (System.String configKey) [0x00000] in /private/tmp/source-mono-2017-04/bockbuild-2017-04/profiles/mono-mac-xamarin/build-root/mono-x64/mcs/class/System.Configuration/System.Configuration/ClientConfigurationSystem.cs
```

This seems to fix it in my local testing. However, I'm not behind a proxy so I don't know yet how to verify that the property actually works as expected.