### PR TITLE
[runtime] Add support for using COM types from corlib. Backport of #4931

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1090,7 +1090,7 @@ mono_cominterop_get_invoke (MonoMethod *method)
 	for (i = 1; i <= sig->param_count; i++)
 		mono_mb_emit_ldarg (mb, i);
 
-	if (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) {
+	if ((method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) || mono_class_is_interface (method->klass)) {
 		MonoMethod * native_wrapper = mono_cominterop_get_native_wrapper(method);
 		mono_mb_emit_managed_call (mb, native_wrapper, NULL);
 	}

--- a/mono/tests/cominterop.cs
+++ b/mono/tests/cominterop.cs
@@ -533,6 +533,9 @@ public class Tests
 			if (TestITestDelegate (itest) != 0)
 				return 174;
 
+			if (TestIfaceNoIcall (itest as ITestPresSig) != 0)
+				return 201;
+
 			itest = new TestClass ();
 
 			if (TestITest (itest) != 0)
@@ -542,6 +545,7 @@ public class Tests
 
 			if (TestITest (itest) != 0)
 				return 176;
+
 
 #endif
 
@@ -775,6 +779,7 @@ public class Tests
 		void ITestIn ([MarshalAs (UnmanagedType.Interface)]ITest val);
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		void ITestOut ([MarshalAs (UnmanagedType.Interface)]out ITest val);
+		int Return22NoICall();
 	}
 
 	[ComImport ()]
@@ -826,6 +831,8 @@ public class Tests
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		[PreserveSig ()]
 		int ITestOut ([MarshalAs (UnmanagedType.Interface)]out ITestPresSig val);
+		[PreserveSig ()]
+		int Return22NoICall();
 	}
 
 	[System.Runtime.InteropServices.GuidAttribute ("00000000-0000-0000-0000-000000000002")]
@@ -865,6 +872,9 @@ public class Tests
 		public virtual extern void ITestIn ([MarshalAs (UnmanagedType.Interface)]ITest val);
 		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		public virtual extern void ITestOut ([MarshalAs (UnmanagedType.Interface)]out ITest val);
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		public virtual extern int Return22NoICall();
 	}
 
 	[System.Runtime.InteropServices.GuidAttribute ("00000000-0000-0000-0000-000000000002")]
@@ -1004,6 +1014,11 @@ public class Tests
 			val = new ManagedTestPresSig ();
 			return 0;
 		}
+
+		public int Return22NoICall()
+		{
+			return 88;
+		}
 	}
 
 	public class ManagedTest : ITest
@@ -1092,6 +1107,11 @@ public class Tests
 			{
 				return new ManagedTest ();
 			}
+		}
+
+		public int Return22NoICall()
+		{
+			return 99;
 		}
 	}
 
@@ -1305,6 +1325,10 @@ public class Tests
 			return 1;
 		}
 		return 0;
+	}
+
+	public static int TestIfaceNoIcall (ITestPresSig itest) {
+		return itest.Return22NoICall () == 22 ? 0 : 1;
 	}
 }
 

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -3337,6 +3337,7 @@ typedef struct
 	int (STDCALL *DoubleIn)(MonoComObject* pUnk, double a);
 	int (STDCALL *ITestIn)(MonoComObject* pUnk, MonoComObject* pUnk2);
 	int (STDCALL *ITestOut)(MonoComObject* pUnk, MonoComObject* *ppUnk);
+	int (STDCALL *Return22NoICall)(MonoComObject* pUnk);
 } MonoIUnknown;
 
 struct MonoComObject
@@ -3453,6 +3454,13 @@ ITestOut(MonoComObject* pUnk, MonoComObject* *ppUnk)
 	return S_OK;
 }
 
+LIBTEST_API int STDCALL
+Return22NoICall(MonoComObject* pUnk)
+{
+	return 22;
+}
+
+
 static void create_com_object (MonoComObject** pOut);
 
 LIBTEST_API int STDCALL 
@@ -3484,6 +3492,7 @@ static void create_com_object (MonoComObject** pOut)
 	(*pOut)->vtbl->ITestIn = ITestIn;
 	(*pOut)->vtbl->ITestOut = ITestOut;
 	(*pOut)->vtbl->get_ITest = get_ITest;
+	(*pOut)->vtbl->Return22NoICall = Return22NoICall;
 }
 
 static MonoComObject* same_object = NULL;


### PR DESCRIPTION
This can be reproduced by trying to load a type that implements a COM interface corlib ships.