### PR TITLE
[System] Add missing configuration properties to the list of properties

### DIFF
--- a/mcs/class/System/System.Net.Configuration/DefaultProxySection.cs
+++ b/mcs/class/System/System.Net.Configuration/DefaultProxySection.cs
@@ -61,6 +61,7 @@ namespace System.Net.Configuration
 			properties = new ConfigurationPropertyCollection ();
 
 			properties.Add (bypassListProp);
+			properties.Add (enabledProp);
 			properties.Add (moduleProp);
 			properties.Add (proxyProp);
 			properties.Add (useDefaultCredentialsProp);

--- a/mcs/class/System/System.Net.Configuration/ProxyElement.cs
+++ b/mcs/class/System/System.Net.Configuration/ProxyElement.cs
@@ -62,6 +62,7 @@ namespace System.Net.Configuration
 
 			properties = new ConfigurationPropertyCollection ();
 								    
+			properties.Add (autoDetectProp);
 			properties.Add (bypassOnLocalProp);
 			properties.Add (proxyAddressProp);
 			properties.Add (scriptLocationProp);


### PR DESCRIPTION
After looking at https://github.com/mono/mono/pull/4949 I did a quick pass through the other config sections and found two more cases where we missed adding to the properties list.