### PR TITLE
[Mono.Options] Fix test and add suite to CI

### DIFF
--- a/mcs/class/Mono.Options/Test/Mono.Options/CommandSetTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/CommandSetTest.cs
@@ -228,7 +228,7 @@ namespace MonoTests.Mono.Options
 			e.Run = (args) => e.CommandSet.Out.WriteLine (string.Join (" ", args));
 
 			var o = new StringWriter ();
-			var c = new CommandSet ("set", output:o) {
+			var c = new CommandSet ("set", output:o, error: Console.Error) {
 				e,
 			};
 			Assert.AreEqual (0, c.Run (new [] { "help", "echo" }));

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionContextTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionContextTest.cs
@@ -56,7 +56,7 @@ namespace MonoTests.Mono.Options
 					c, v => { string ignore = v.OptionValues [0]; });
 			c.Option = p [0];
 			Utils.AssertException (typeof(ArgumentOutOfRangeException),
-					"Specified argument was out of the range of valid values.\nParameter name: index",
+					$"Specified argument was out of the range of valid values.{Environment.NewLine}Parameter name: index",
 					c, v => { string ignore = v.OptionValues [2]; });
 			c.OptionName = "-a";
 			Utils.AssertException (typeof(OptionException),

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
@@ -374,10 +374,10 @@ namespace MonoTests.Mono.Options
 					p, v => { v.Parse (_("-a", "-b")); });
 			Assert.AreEqual (a, "-b");
 			Utils.AssertException (typeof(ArgumentNullException),
-					"Value cannot be null.\nParameter name: option",
+					$"Value cannot be null.{Environment.NewLine}Parameter name: option",
 					p, v => { v.Add ((Option) null); });
 			Utils.AssertException (typeof(ArgumentNullException),
-					"Value cannot be null.\nParameter name: header",
+					$"Value cannot be null.{Environment.NewLine}Parameter name: header",
 					p, v => { v.Add ((string) null); });
 
 			// bad type
@@ -394,10 +394,10 @@ namespace MonoTests.Mono.Options
 					p, v => { v.Parse (_("-cz", "extra")); });
 
 			Utils.AssertException (typeof(ArgumentNullException), 
-					"Value cannot be null.\nParameter name: action",
+					$"Value cannot be null.{Environment.NewLine}Parameter name: action",
 					p, v => { v.Add ("foo", (Action<string>) null); });
 			Utils.AssertException (typeof(ArgumentException), 
-					"Cannot provide maxValueCount of 2 for OptionValueType.None.\nParameter name: maxValueCount",
+					$"Cannot provide maxValueCount of 2 for OptionValueType.None.{Environment.NewLine}Parameter name: maxValueCount",
 					p, v => { v.Add ("foo", (k, val) => {/* ignore */}); });
 		}
 
@@ -772,7 +772,7 @@ namespace MonoTests.Mono.Options
 			Utils.AssertException (typeof(ArgumentException), "prototypes must be null!",
 					p, v => { v.Add ("N|NUM=", (int n) => {}); });
 			Utils.AssertException (typeof(ArgumentNullException),
-					"Value cannot be null.\nParameter name: option",
+					$"Value cannot be null.{Environment.NewLine}Parameter name: option",
 					p, v => { v.GetOptionForName (null); });
 		}
 

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionTest.cs
@@ -66,60 +66,60 @@ namespace MonoTests.Mono.Options
 		{
 			object p = null;
 			Utils.AssertException (typeof(ArgumentNullException), 
-					"Value cannot be null.\nParameter name: prototype", 
+					$"Value cannot be null.{Environment.NewLine}Parameter name: prototype", 
 					p, v => { new DefaultOption (null, null); });
 			Utils.AssertException (typeof(ArgumentException), 
-					"Cannot be the empty string.\nParameter name: prototype",
+					$"Cannot be the empty string.{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Empty option names are not supported.\nParameter name: prototype",
+					$"Empty option names are not supported.{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("a|b||c=", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Conflicting option types: '=' vs. ':'.\nParameter name: prototype",
+					$"Conflicting option types: '=' vs. ':'.{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("a=|b:", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"The default option handler '<>' cannot require values.\nParameter name: prototype",
+					$"The default option handler '<>' cannot require values.{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("<>=", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"The default option handler '<>' cannot require values.\nParameter name: prototype",
+					$"The default option handler '<>' cannot require values.{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("<>:", null); });
 			Utils.AssertException (null, null,
 					p, v => { new DefaultOption ("t|<>=", null, 1); });
 			Utils.AssertException (typeof(ArgumentException),
-					"The default option handler '<>' cannot require values.\nParameter name: prototype",
+					$"The default option handler '<>' cannot require values.{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("t|<>=", null, 2); });
 			Utils.AssertException (null, null,
 					p, v => { new DefaultOption ("a|b=", null, 2); });
 			Utils.AssertException (typeof(ArgumentOutOfRangeException),
-					"Specified argument was out of the range of valid values.\nParameter name: maxValueCount",
+					$"Specified argument was out of the range of valid values.{Environment.NewLine}Parameter name: maxValueCount",
 					p, v => { new DefaultOption ("a", null, -1); });
 			Utils.AssertException (typeof(ArgumentException),
 					"Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
-						"OptionValueType.Optional.\nParameter name: maxValueCount",
+						$"OptionValueType.Optional.{Environment.NewLine}Parameter name: maxValueCount",
 					p, v => { new DefaultOption ("a=", null, 0); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Ill-formed name/value separator found in \"a={\".\nParameter name: prototype",
+					"Ill-formed name/value separator found in \"a={\"." + Environment.NewLine + "Parameter name: prototype",
 					p, v => { new DefaultOption ("a={", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Ill-formed name/value separator found in \"a=}\".\nParameter name: prototype",
+					"Ill-formed name/value separator found in \"a=}\"." + Environment.NewLine + "Parameter name: prototype",
 					p, v => { new DefaultOption ("a=}", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Ill-formed name/value separator found in \"a={{}}\".\nParameter name: prototype",
+					"Ill-formed name/value separator found in \"a={{}}\"." + Environment.NewLine + "Parameter name: prototype",
 					p, v => { new DefaultOption ("a={{}}", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Ill-formed name/value separator found in \"a={}}\".\nParameter name: prototype",
+					"Ill-formed name/value separator found in \"a={}}\"." + Environment.NewLine + "Parameter name: prototype",
 					p, v => { new DefaultOption ("a={}}", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Ill-formed name/value separator found in \"a={}{\".\nParameter name: prototype",
+					"Ill-formed name/value separator found in \"a={}{\"." + Environment.NewLine + "Parameter name: prototype",
 					p, v => { new DefaultOption ("a={}{", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Cannot provide key/value separators for Options taking 1 value(s).\nParameter name: prototype",
+					$"Cannot provide key/value separators for Options taking 1 value(s).{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("a==", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Cannot provide key/value separators for Options taking 1 value(s).\nParameter name: prototype",
+					$"Cannot provide key/value separators for Options taking 1 value(s).{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("a={}", null); });
 			Utils.AssertException (typeof(ArgumentException),
-					"Cannot provide key/value separators for Options taking 1 value(s).\nParameter name: prototype",
+					$"Cannot provide key/value separators for Options taking 1 value(s).{Environment.NewLine}Parameter name: prototype",
 					p, v => { new DefaultOption ("a=+-*/", null); });
 			Utils.AssertException (null, null,
 					p, v => { new DefaultOption ("a", null, 0); });

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -50,6 +50,7 @@ ${TESTCMD} --label=Microsoft.Build.Framework --timeout=5m make -w -C mcs/class/M
 ${TESTCMD} --label=Microsoft.Build.Tasks --timeout=5m make -w -C mcs/class/Microsoft.Build.Tasks run-test
 ${TESTCMD} --label=Microsoft.Build.Utilities --timeout=5m make -w -C mcs/class/Microsoft.Build.Utilities run-test
 ${TESTCMD} --label=Mono.C5 --timeout=5m make -w -C mcs/class/Mono.C5 run-test
+${TESTCMD} --label=Mono.Options --timeout=5m make -w -C mcs/class/Mono.Options run-test
 ${TESTCMD} --label=Mono.Tasklets --timeout=5m make -w -C mcs/class/Mono.Tasklets run-test
 ${TESTCMD} --label=System.Configuration --timeout=5m make -w -C mcs/class/System.Configuration run-test
 ${TESTCMD} --label=System.Transactions --timeout=5m make -w -C mcs/class/System.Transactions run-test


### PR DESCRIPTION
We missed running Mono.Options tests on CI so we didn't catch this error which was introduced with: https://github.com/mono/mono/pull/4719

```
CSC     [net_4_x-darwin] net_4_x_Mono.Options_test.dll
Test/Mono.Options/CommandSetTest.cs(231,16): error CS7036: There is no argument given that corresponds to the required formal parameter 'error' of 'CommandSet.CommandSet(string, TextWriter, TextWriter, Converter<string, string>)'
```