### PR TITLE
[Posix] Optimize string marshal code by using unsafe code

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixEncoding.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixEncoding.cs
@@ -279,6 +279,36 @@ public class UnixEncoding : Encoding
 		return InternalGetBytes (chars, charIndex, charCount, bytes, byteIndex, ref leftOver, true);
 	}
 
+	// Convenience wrappers for "GetBytes".
+	public override int GetBytes (String s, int charIndex, int charCount,
+								 byte[] bytes, int byteIndex)
+	{
+		// Validate the parameters.
+		if (s == null) {
+			throw new ArgumentNullException ("s");
+		}
+		if (bytes == null) {
+			throw new ArgumentNullException ("bytes");
+		}
+		if (charIndex < 0 || charIndex > s.Length) {
+			throw new ArgumentOutOfRangeException ("charIndex", _("ArgRange_StringIndex"));
+		}
+		if (charCount < 0 || charCount > (s.Length - charIndex)) {
+			throw new ArgumentOutOfRangeException ("charCount", _("ArgRange_StringRange"));
+		}
+		if (byteIndex < 0 || byteIndex > bytes.Length) {
+			throw new ArgumentOutOfRangeException ("byteIndex", _("ArgRange_Array"));
+		}
+
+		unsafe {
+			fixed (char *p = s) {
+				fixed (byte *b = bytes) {
+					return GetBytes(p + charIndex, charCount, b + byteIndex, bytes.Length - byteIndex);
+				}
+			}
+		}
+	}
+
 	public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
 	{
 		if (bytes == null || chars == null)
@@ -354,36 +384,6 @@ public class UnixEncoding : Encoding
 
 		// Return the final count to the caller.
 		return posn;
-	}
-
-	// Convenience wrappers for "GetBytes".
-	public override int GetBytes (String s, int charIndex, int charCount,
-								 byte[] bytes, int byteIndex)
-	{
-		// Validate the parameters.
-		if (s == null) {
-			throw new ArgumentNullException ("s");
-		}
-		if (bytes == null) {
-			throw new ArgumentNullException ("bytes");
-		}
-		if (charIndex < 0 || charIndex > s.Length) {
-			throw new ArgumentOutOfRangeException ("charIndex", _("ArgRange_StringIndex"));
-		}
-		if (charCount < 0 || charCount > (s.Length - charIndex)) {
-			throw new ArgumentOutOfRangeException ("charCount", _("ArgRange_StringRange"));
-		}
-		if (byteIndex < 0 || byteIndex > bytes.Length) {
-			throw new ArgumentOutOfRangeException ("byteIndex", _("ArgRange_Array"));
-		}
-
-		unsafe {
-			fixed (char *p = s) {
-				fixed (byte *b = bytes) {
-					return GetBytes(p + charIndex, charCount, b + byteIndex, bytes.Length - byteIndex);
-				}
-			}
-		}
 	}
 
 	// Internal version of "GetCharCount" which can handle a rolling

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixEncoding.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixEncoding.cs
@@ -301,9 +301,9 @@ public class UnixEncoding : Encoding
 		}
 
 		unsafe {
-			fixed (char *p = s) {
-				fixed (byte *b = bytes) {
-					return GetBytes(p + charIndex, charCount, b + byteIndex, bytes.Length - byteIndex);
+			fixed (char* p = s) {
+				fixed (byte* b = bytes) {
+					return GetBytes (p + charIndex, charCount, b + byteIndex, bytes.Length - byteIndex);
 				}
 			}
 		}
@@ -312,10 +312,10 @@ public class UnixEncoding : Encoding
 	public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
 	{
 		if (bytes == null || chars == null)
-			throw new ArgumentNullException(bytes == null ? "bytes" : "chars");
+			throw new ArgumentNullException (bytes == null ? "bytes" : "chars");
 
 		if (charCount < 0 || byteCount < 0)
-			throw new ArgumentOutOfRangeException((charCount < 0 ? "charCount" : "byteCount"));
+			throw new ArgumentOutOfRangeException (charCount < 0 ? "charCount" : "byteCount");
 			
 		// Convert the characters into bytes.
 		char ch;
@@ -325,7 +325,7 @@ public class UnixEncoding : Encoding
 		int charIndex = 0;
 		while (charCount > 0) {
 			// Fetch the next UTF-16 character pair value.
-			ch = chars[charIndex++];
+			ch = chars [charIndex++];
 			if (ch >= '\uD800' && ch <= '\uDBFF' && charCount > 1) {
 				// This may be the start of a surrogate pair.
 				pair = (uint)(chars[charIndex]);
@@ -344,7 +344,7 @@ public class UnixEncoding : Encoding
 				}
 				charCount -= 2;
 				if (charCount >= 0) {
-					bytes[posn++] = (byte) chars [charIndex++];
+					bytes[posn++] = (byte)chars [charIndex++];
 				}
 				continue;
 			} else {
@@ -412,7 +412,7 @@ public class UnixEncoding : Encoding
 		uint leftSoFar = (leftOverCount & (uint)0x0F);
 		uint leftSize = ((leftOverCount >> 4) & (uint)0x0F);
 		while (count > 0) {
-			ch = (uint)(bytes[index++]);
+			ch = (uint)(bytes [index++]);
 			++next_raw;
 			--count;
 			if (leftSize == 0) {

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -334,7 +334,7 @@ namespace Mono.Unix {
 
 			int null_terminator_count = encoding.GetMaxByteCount(1);
 			int length_without_null = encoding.GetByteCount(s);
-			int marshalLength = length_without_null + null_terminator_count;
+			int marshalLength = checked (length_without_null + null_terminator_count);
 
 			IntPtr mem = AllocHeap (marshalLength);
 			if (mem == IntPtr.Zero)

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -326,7 +326,8 @@ namespace Mono.Unix {
 				throw new ArgumentNullException ("encoding");
 
 			int null_terminator_count = encoding.GetMaxByteCount (1);
-			int marshalLength = encoding.GetByteCount (s) + null_terminator_count;
+			int lengthWithoutNull = encoding.GetByteCount(s);
+			int marshalLength = lengthWithoutNull + null_terminator_count;
 
 			IntPtr mem = AllocHeap (marshalLength);
 			if (mem == IntPtr.Zero)
@@ -344,11 +345,11 @@ namespace Mono.Unix {
 					byte* marshal = (byte*)mem;
 					int bytes_copied = encoding.GetBytes (p + index, count, marshal, marshalLength);
 
-					if (bytes_copied != (marshalLength - null_terminator_count)) {
+					if (bytes_copied != lengthWithoutNull) {
 						FreeHeap (mem);
 						throw new NotSupportedException ("encoding.GetBytes() doesn't equal encoding.GetByteCount()!");
 					}
-					marshal += marshalLength - null_terminator_count;
+					marshal += lengthWithoutNull;
 					for (int i = 0; i < null_terminator_count; ++i)
 						marshal[i] = 0;
 				}

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -325,20 +325,20 @@ namespace Mono.Unix {
 			if (encoding == null)
 				throw new ArgumentNullException ("encoding");
 
-			int null_terminator_count = encoding.GetMaxByteCount (1);
-			int lengthWithoutNull = encoding.GetByteCount(s);
-			int marshalLength = lengthWithoutNull + null_terminator_count;
-
-			IntPtr mem = AllocHeap (marshalLength);
-			if (mem == IntPtr.Zero)
-				throw new UnixIOException (Native.Errno.ENOMEM);
-
 			if (index < 0 || count < 0)
 				throw new ArgumentOutOfRangeException ((index < 0 ? "index" : "count"),
 					 "Non - negative number required.");
 
 			if (s.Length - index < count)
 				throw new ArgumentOutOfRangeException ("s", "Index and count must refer to a location within the string.");
+
+			int null_terminator_count = encoding.GetMaxByteCount (1);
+			int lengthWithoutNull = encoding.GetByteCount(s);
+			int marshalLength = lengthWithoutNull + 1;
+
+			IntPtr mem = AllocHeap (marshalLength);
+			if (mem == IntPtr.Zero)
+				throw new UnixIOException (Native.Errno.ENOMEM);
 
 			unsafe {
 				fixed (char* p = s) {

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -325,8 +325,8 @@ namespace Mono.Unix {
 			if (encoding == null)
 				throw new ArgumentNullException ("encoding");
 
-			int min_byte_count = encoding.GetMaxByteCount (1);
-			int marshalLength = encoding.GetByteCount (s) + min_byte_count;
+			int null_terminator_count = encoding.GetMaxByteCount (1);
+			int marshalLength = encoding.GetByteCount (s) + null_terminator_count;
 
 			IntPtr mem = AllocHeap (marshalLength);
 			if (mem == IntPtr.Zero)
@@ -344,12 +344,12 @@ namespace Mono.Unix {
 					byte* marshal = (byte*)mem;
 					int bytes_copied = encoding.GetBytes (p + index, count, marshal, marshalLength);
 
-					if (bytes_copied != (marshalLength - min_byte_count)) {
+					if (bytes_copied != (marshalLength - null_terminator_count)) {
 						FreeHeap (mem);
 						throw new NotSupportedException ("encoding.GetBytes() doesn't equal encoding.GetByteCount()!");
 					}
-					marshal += marshalLength - min_byte_count;
-					for (int i = 0; i < min_byte_count; ++i)
+					marshal += marshalLength - null_terminator_count;
+					for (int i = 0; i < null_terminator_count; ++i)
 						marshal[i] = 0;
 				}
 			}

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -343,12 +343,20 @@ namespace Mono.Unix {
 			unsafe {
 				fixed (char* p = s) {
 					byte* marshal = (byte*)mem;
-					int bytes_copied = encoding.GetBytes (p + index, count, marshal, marshalLength);
+					int bytes_copied;
+
+					try {
+						bytes_copied = encoding.GetBytes (p + index, count, marshal, marshalLength);
+					} catch {
+						FreeHeap (mem);
+						throw;
+					}
 
 					if (bytes_copied != length_without_null) {
 						FreeHeap (mem);
 						throw new NotSupportedException ("encoding.GetBytes() doesn't equal encoding.GetByteCount()!");
 					}
+
 					marshal += length_without_null;
 					for (int i = 0; i < null_terminator_count; ++i)
 						marshal[i] = 0;

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -332,8 +332,8 @@ namespace Mono.Unix {
 			if (s.Length - index < count)
 				throw new ArgumentOutOfRangeException ("s", "Index and count must refer to a location within the string.");
 
-			int null_terminator_count = encoding.GetMaxByteCount(1);
-			int length_without_null = encoding.GetByteCount(s);
+			int null_terminator_count = encoding.GetMaxByteCount (1);
+			int length_without_null = encoding.GetByteCount (s);
 			int marshalLength = checked (length_without_null + null_terminator_count);
 
 			IntPtr mem = AllocHeap (marshalLength);

--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -331,8 +331,7 @@ namespace Mono.Unix {
 
 			if (s.Length - index < count)
 				throw new ArgumentOutOfRangeException ("s", "Index and count must refer to a location within the string.");
-
-			int null_terminator_count = encoding.GetMaxByteCount (1);
+			
 			int lengthWithoutNull = encoding.GetByteCount(s);
 			int marshalLength = lengthWithoutNull + 1;
 
@@ -349,9 +348,7 @@ namespace Mono.Unix {
 						FreeHeap (mem);
 						throw new NotSupportedException ("encoding.GetBytes() doesn't equal encoding.GetByteCount()!");
 					}
-					marshal += lengthWithoutNull;
-					for (int i = 0; i < null_terminator_count; ++i)
-						marshal[i] = 0;
+					marshal[lengthWithoutNull] = 0;
 				}
 			}
 


### PR DESCRIPTION
Get rid of the allocation of the char array and the byte array. Whilst the BCL offers an overload which gets rid of the char array allocation, the byte array allocation can't be removed without using unsafe code.
This was hit a lot in allocations done by Visual Studio for Mac, as we use Gettext extensively for all the strings in the UI. Added argument checking that's similar to Encoding.GetBytes and refactored the code so it only pins the string where should.