### PR TITLE
[sgen] Make sure workers process jobs only if they are running

### DIFF
--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -314,7 +314,7 @@ should_work_func (void *data_untyped)
 	WorkerData *data = (WorkerData*)data_untyped;
 	int current_worker = (int) (data - workers_data);
 
-	return started && current_worker < active_workers_num;
+	return started && current_worker < active_workers_num && state_is_working_or_enqueued (data->state);
 }
 
 static void


### PR DESCRIPTION
This simplifies logic and prevents serial context being used by multiple workers at the same time.