### PR TITLE
[tools] Fix colors in binprot.

### DIFF
--- a/tools/sgen/sgen-grep-binprot.c
+++ b/tools/sgen/sgen-grep-binprot.c
@@ -241,7 +241,7 @@ static int
 index_color (int index, int num_nums, int *match_indices)
 {
 	int result;
-	for (result = 0; result < num_nums + 1; ++result)
+	for (result = 0; result < num_nums; ++result)
 		if (index == match_indices [result])
 			return result;
 	return NO_COLOR;


### PR DESCRIPTION
This is a trivial fix of the coloring problem in sgen-grep-binprot. Currently it iterates one more time than the number of addresses that we've provided and always colors 0x0 as the result.