### PR TITLE
Use correct path separator for satellite assemblies in cross builds

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -1126,10 +1126,10 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 	
 	static readonly Universe universe = new Universe ();
 	static readonly Dictionary<string, string> loaded_assemblies = new Dictionary<string, string> ();
-	static readonly string resourcePathSeparator = (Path.DirectorySeparatorChar == '\\') ? $"\\{Path.DirectorySeparatorChar}" : $"{Path.DirectorySeparatorChar}";
 
 	public static string GetAssemblyName (string path)
 	{
+		string resourcePathSeparator = style == "windows" ? "\\\\" : "/";
 		string name = Path.GetFileName (path);
 
 		// A bit of a hack to support satellite assemblies. They all share the same name but


### PR DESCRIPTION
When creating a bundle on Windows to run on Android, macOS/iOS or Linux we need
to use the target system's path separator when storing satellite assemblies in
the bundle instead of the host system's one. Failing to do so will embed (on
Windows) the satellite assemblies with paths like

   `fr_FR\myassembly.resources.dll`

while at runtime Mono will try to look up the assembly by

   `fr_FR/myassembly.resources.dll`

and fail to find it, obviously. The `--style` parameter is now consulted to see
what path separator character should be used.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=55603