### PR TITLE
[arm] don't set MONO_ARCH_SOFT_DEBUG_SUPPORTED and MONO_ARCH_HAVE_INIT_LMF_EXT on android cross compiling

### DIFF
--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -329,7 +329,9 @@ typedef struct MonoCompileArch {
 #define MONO_ARCH_DYN_CALL_SUPPORTED 1
 #define MONO_ARCH_DYN_CALL_PARAM_AREA (DYN_CALL_STACK_ARGS * sizeof (mgreg_t))
 
+#if !(defined(TARGET_ANDROID) && defined(MONO_CROSS_COMPILE))
 #define MONO_ARCH_SOFT_DEBUG_SUPPORTED 1
+#endif
 
 #define MONO_ARCH_HAVE_EXCEPTIONS_INIT 1
 #define MONO_ARCH_HAVE_GET_TRAMPOLINES 1

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2798,6 +2798,9 @@ gboolean  mono_arch_is_breakpoint_event         (void *info, void *sigctx);
 void     mono_arch_skip_breakpoint              (MonoContext *ctx, MonoJitInfo *ji);
 void     mono_arch_skip_single_step             (MonoContext *ctx);
 gpointer mono_arch_get_seq_point_info           (MonoDomain *domain, guint8 *code);
+#endif
+
+#ifdef MONO_ARCH_HAVE_INIT_LMF_EXT
 void     mono_arch_init_lmf_ext                 (MonoLMFExt *ext, gpointer prev_lmf);
 #endif
 


### PR DESCRIPTION
follow up fix for https://github.com/mono/mono/pull/4956

this breaks the cross compiler on windows for android:

```
  [9:07:36]                       /bin/sh ../../libtool  --tag=CC   --mode=compile /Users/builder/android-toolchain/mxe/bin/i686-w64-mingw32.static-gcc -DHAVE_CONFIG_H -I. -I/U  sers/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini -I../..   -DWINVER=0x0600 -D_WIN32_WINNT=0x0600 -D_WIN32_IE=0x0501 -D_UNICODE -DUNICODE -  DWIN32_THREADS -DFD_SETSIZE=1024 -g -Wall -Wunused -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes  -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wno  -cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes -Wno-format-zero-length -D__ARM_EABI__ -DARM_FPU_VFP=1 -DNO_UNALIGNED_ACCESS -I/User  s/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono -I/Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/eglib/src -I../../eglib  /src -I/Users/builder/data/lanes/5000/ff452183/source/xamarin-android/build-tools/mono-runtimes/obj/Release//llvm/installed-win32/usr/include -DNDEBUG -D__NO_CTYPE_INLINE -D_  GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_API_VERSION=4 -O -I../arch/arm -fvisibility=hidden -DXAMARIN_PRODUCT_VERSION=0 -static   -static-libgcc -std=gnu99 -fno-strict-aliasing -fwrapv -DMONO_DLL_EXPORT -Wno-unused-but-set-variable -g -Wall -Wunused -Wmissing-prototypes -Wmissing-declarations -Wstrict-  prototypes  -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wno-cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes -Wno-format-ze  ro-length -mno-tls-direct-seg-refs -Werror-implicit-function-declaration -MT libmini_la-mini-arm-gsharedvt.lo -MD -MP -MF .deps/libmini_la-mini-arm-gsharedvt.Tpo -c -o libmin  i_la-mini-arm-gsharedvt.lo `test -f 'mini-arm-gsharedvt.c' || echo '/Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/'`mini-arm-gsharedv  t.c
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c: In function 'mono_arch_is_single_step_event  ':
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c:7242:2: error: unknown type name 'siginfo_t'
  [9:07:36]                         siginfo_t *sinfo = info;
  [9:07:36]                         ^
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c:7248:11: error: request for member 'si_addr'   in something not a structure or union
  [9:07:36]                         if (sinfo->si_addr >= ss_trigger_page && (guint8*)sinfo->si_addr <= (guint8*)ss_trigger_page + 128)
  [9:07:36]                                  ^
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c:7248:57: error: request for member 'si_addr'   in something not a structure or union
  [9:07:36]                         if (sinfo->si_addr >= ss_trigger_page && (guint8*)sinfo->si_addr <= (guint8*)ss_trigger_page + 128)
  [9:07:36]                                                                                ^
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c: In function 'mono_arch_is_breakpoint_event'  :
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c:7262:2: error: unknown type name 'siginfo_t'
  [9:07:36]                         siginfo_t *sinfo = info;
  [9:07:36]                         ^
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c:7267:11: error: request for member 'si_signo  ' in something not a structure or union
  [9:07:36]                         if (sinfo->si_signo == DBG_SIGNAL) {
  [9:07:36]                                  ^
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c:7269:12: error: request for member 'si_addr'   in something not a structure or union
  [9:07:36]                          if (sinfo->si_addr >= bp_trigger_page && (guint8*)sinfo->si_addr <= (guint8*)bp_trigger_page + 128)
  [9:07:36]                                   ^
  [9:07:36]                       /Users/builder/data/lanes/5000/ff452183/source/xamarin-android/external/mono/mono/mini/mini-arm.c:7269:58: error: request for member 'si_addr'   in something not a structure or union
  [9:07:36]                          if (sinfo->si_addr >= bp_trigger_page && (guint8*)sinfo->si_addr <= (guint8*)bp_trigger_page + 128)
```