### PR TITLE
[MacSDK] Bump libgdiplus to latest

### DIFF
--- a/packaging/MacSDK/libgdiplus.py
+++ b/packaging/MacSDK/libgdiplus.py
@@ -1,8 +1,8 @@
 GitHubTarballPackage(
     'mono',
     'libgdiplus',
-    '2.11',
-    '4e7ab0f555a13a6b2f954c714c4ee5213954ff79',
+    '5.4',
+    '350eb49a45ca5a7383c01d49df72438347a5dbc9',
     configure='CFLAGS="%{gcc_flags} %{local_gcc_flags} -I/opt/X11/include" ./autogen.sh --prefix="%{package_prefix}"',
     override_properties={
         'make': 'C_INCLUDE_PATH="" make'})


### PR DESCRIPTION
We were using a very old commit of libgdiplus. This brings in the latest changes.