### PR TITLE
[sre] Fix support for fields with the same name by iterating over the…

### DIFF
--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -806,5 +806,9 @@ namespace System
 				return false;
 			}
 		}
+
+		internal override Type RuntimeResolve () {
+			return this;
+		}
 	}
 }

--- a/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
@@ -229,7 +229,12 @@ namespace System.Reflection.Emit {
 		}
 
 		internal FieldInfo RuntimeResolve () {
-			return typeb.CreateType ().GetField (this);
+			var t = typeb.CreateType ();
+			foreach (var fi in t.GetFields (BindingFlags.Instance|BindingFlags.Static|BindingFlags.DeclaredOnly|BindingFlags.Public|BindingFlags.NonPublic)) {
+				if (fi.Name == Name && ((Type)fi.FieldType == (Type)ModuleBuilder.RuntimeResolve (FieldType)) && fi.IsStatic == IsStatic)
+					return fi;
+			}
+			throw new NotImplementedException (ToString ());
 		}
 
 		public override Module Module {


### PR DESCRIPTION
… fields and checking them one-by-one instead of calling GetField(string). Fixes #57222.