### PR TITLE
[sgen] SGen modes

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1304,10 +1304,19 @@ first generation (of two).  A larger nursery will usually speed up the
 program but will obviously use more memory.  The default nursery size
 4 MB.
 .TP
-\fBmajor=\fIcollector\fR Specifies which major collector to use.
-Options are `marksweep' for the Mark&Sweep collector, and
-`marksweep-conc' for concurrent Mark&Sweep.  The non-concurrent
-Mark&Sweep collector is the default.
+\fBmajor=\fIcollector\fR
+Specifies which major collector to use.
+Options are `marksweep' for the Mark&Sweep collector, `marksweep-conc'
+for concurrent Mark&Sweep and `marksweep-conc-par' for parallel and
+concurrent Mark&Sweep.  The concurrent Mark&Sweep collector is the default.
+.TP
+\fBmode=balanced|throughput|pause\fR[:\fImax-pause\fR]
+Specifies what should be the garbage collector's target. The `throughput'
+mode aims to reduce time spent in the garbage collector and improve
+application speed, the `pause' mode aims to keep pause times to a minimum
+and it receives the argument \fImax-pause\fR which specifies the maximum
+pause time in milliseconds that is acceptable and the `balanced' mode
+which is a general purpose optimal mode.
 .TP
 \fBsoft-heap-limit=\fIsize\fR
 Once the heap size gets larger than this size, ignore what the default
@@ -1370,9 +1379,11 @@ more memory when it reaches a stable size.
 This option is EXPERIMENTAL, so it might disappear in later versions of mono.
 .TP
 \fBminor=\fIminor-collector\fR
-Specifies which minor collector to use. Options are 'simple' which
-promotes all objects from the nursery directly to the old generation
-and 'split' which lets object stay longer on the nursery before promoting.
+Specifies which minor collector to use. Options are `simple' which
+promotes all objects from the nursery directly to the old generation,
+`simple-par' which has same promotion behavior as `simple' but using
+multiple workers and `split' which lets objects stay longer on the nursery
+before promoting.
 .TP
 \fBalloc-ratio=\fIratio\fR
 Specifies the ratio of memory from the nursery to be use by the alloc space.

--- a/mono/sgen/sgen-conf.h
+++ b/mono/sgen/sgen-conf.h
@@ -216,7 +216,10 @@ typedef mword SgenDescriptor;
  * sizing heuristics. We are keeping leeway in order to be prepared for work-load
  * variations.
  */
-#define SGEN_MAX_PAUSE_TIME 30
-#define SGEN_MAX_PAUSE_MARGIN 0.66f
+#define SGEN_DEFAULT_MAX_PAUSE_TIME 30
+#define SGEN_DEFAULT_MAX_PAUSE_MARGIN 0.66f
+
+
+#define SGEN_PAUSE_MODE_MAX_PAUSE_MARGIN 0.5f
 
 #endif


### PR DESCRIPTION
@kumpera Addressing comments from the <i>outdated review</i> from https://github.com/mono/mono/pull/4752

2. I removed all complications from handling both sgen modes and gc params simultaneously. Mode, major and minor configurations are parsed before the other gc params since they require initializing the major and minor collector. The other gc params are processed later and they can override defaults set by the mode. I didn't see the point of actively disabling this.

6. In theory I agree that for the throughput mode we would have parallel major. As of right now, the parallel major mode is only for the concurrent collector (aka it does the finishing pause using multiple workers). In practice, I don't think it would have good results for the non-concurrent version since its main advantage is card table parallelisation, which is not present in a serial major. The reason for using concurrent major for the throughput mode is that the overhead for the concurrent collector is relatively small and it achieves very good parallelisation between the collector and the mutator (likely better than we can ever hope to achieve between the workers during a collection). While it reduces pause times, because of this reason the concurrent collector significantly reduces wall clock time of an application (ex. http://xamarin.github.io/benchmarker/front-end/compare.html#ids=21443+21438)