### PR TITLE
[w32socket]: WSL does not support IP_PMTUDISC_DO.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1712,9 +1712,11 @@ if test x$host_win32 = xno; then
 		int level = IP_MTU_DISCOVER;
 	], [
 		# Yes, we have it...
+		have_mtu_discover=yes
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_IP_MTU_DISCOVER, 1, [Have IP_MTU_DISCOVER])
 	], [
+		have_mtu_discover=no
 		AC_MSG_RESULT(no)
 	])
 
@@ -1726,9 +1728,11 @@ if test x$host_win32 = xno; then
 		int level = IP_PMTUDISC_DO;
 	], [
 		# Yes, we have it...
+		have_pmtudisc_do=yes
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_IP_PMTUDISC_DO, 1, [Have IP_PMTUDISC_DO])
 	], [
+		have_pmtudisc_do=no
 		AC_MSG_RESULT(no)
 	])
 
@@ -1759,6 +1763,30 @@ if test x$host_win32 = xno; then
 			AC_MSG_RESULT(no)
 		])
 	])
+
+	dnl **********************************
+	dnl Check whether IP_PMTUDISC_DO works
+	dnl **********************************
+
+	if test "x$have_mtu_discover" = "xyes" -a "x$have_pmtudisc_do" = "xyes"; then
+		AC_MSG_CHECKING(whether IP_PMTUDISC_DO works)
+
+		AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+						#include <sys/socket.h>
+						#include <netinet/in.h>]], [[
+						int sock, val, ret;
+						sock = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
+						val = IP_PMTUDISC_DO;
+						return setsockopt (sock, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof (val));
+		]])], [
+			AC_MSG_RESULT([yes])
+			AC_DEFINE(SUPPORTS_IP_PMTUDISC_DO, 1, [IP_PMTUDISC_DO is supported.])
+		], [
+			AC_MSG_RESULT([no])
+		], [
+			AC_MSG_RESULT([cross-compiling])
+		])
+	fi
 	
 	dnl **********************************
 	dnl *** Check for getaddrinfo ***

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -2393,12 +2393,18 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 			break;
 		case SocketOptionName_DontFragment:
 #ifdef HAVE_IP_MTU_DISCOVER
+#ifdef SUPPORTS_IP_PMTUDISC_DO
 			/* Fiddle with the value slightly if we're
 			 * turning DF on
 			 */
 			if (int_val == 1)
 				int_val = IP_PMTUDISC_DO;
 			/* Fall through */
+#else
+			/* WSL (Ubuntu Bash on Windows) does not support this. */
+			ret = 0;
+			break;
+#endif
 #endif
 			
 		default:


### PR DESCRIPTION
Add a configure check to determine whether IP_PMTUDISC_DO is
actually supported and silently ignore it if not.

On WSL (Ubuntu Bash on Windows), Socket's managed .ctor would throw
inside Socket.SocketDefaults() while attempting to set 'DontFragment'.