### PR TITLE
[2017-04][sre] FieldBuilder:RuntimeResolve shouldn't lookup by name (Fixes #57222)

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.cs
@@ -229,7 +229,9 @@ namespace System.Reflection.Emit {
 		}
 
 		internal FieldInfo RuntimeResolve () {
-			return typeb.CreateType ().GetField (this);
+			// typeb.CreateType() populates this.handle
+			var type_handle = new RuntimeTypeHandle (typeb.CreateType () as RuntimeType);
+			return FieldInfo.GetFieldFromHandle (handle, type_handle);
 		}
 
 		public override Module Module {

--- a/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
@@ -11271,5 +11271,63 @@ namespace MonoTests.System.Reflection.Emit
 
 			Assert.AreSame (buildX, defX);
 		}
+
+		[Test]
+		public void FieldsWithSameName () {
+			// Regression test for https://bugzilla.xamarin.com/show_bug.cgi?id=57222
+			string fileName = CreateTempAssembly ();
+
+			var assemblyName = new AssemblyName { Name = "test" };
+			var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly (assemblyName, AssemblyBuilderAccess.RunAndSave);
+			var dynamicModule = dynamicAssembly.DefineDynamicModule (assemblyName.Name, fileName);
+			var typeBuilder = dynamicModule.DefineType ("type1", TypeAttributes.Public | TypeAttributes.Class);
+
+			var mainMethod = typeBuilder.DefineMethod ("Main", MethodAttributes.Public | MethodAttributes.Static, typeof (int), new Type[0]);
+			var mainMethodIl = mainMethod.GetILGenerator ();
+
+			var f1 = typeBuilder.DefineField ("x", typeof (byte), FieldAttributes.Private | FieldAttributes.Static);
+			var f2 = typeBuilder.DefineField ("x", typeof (sbyte), FieldAttributes.Private | FieldAttributes.Static);
+
+			mainMethodIl.Emit (OpCodes.Ldsflda, f1);
+			mainMethodIl.Emit (OpCodes.Ldsflda, f2);
+			mainMethodIl.Emit (OpCodes.Pop);
+			mainMethodIl.Emit (OpCodes.Pop);
+			mainMethodIl.Emit (OpCodes.Ldc_I4_0);
+			mainMethodIl.Emit (OpCodes.Ret);
+
+			typeBuilder.CreateType ();
+			dynamicAssembly.SetEntryPoint (mainMethod);
+
+			dynamicAssembly.Save (fileName);
+		}
+		[Test]
+		public void FieldsWithSameNameAndType () {
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=57222
+			string fileName = CreateTempAssembly ();
+
+			var assemblyName = new AssemblyName { Name = "test" };
+			var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly (assemblyName, AssemblyBuilderAccess.RunAndSave);
+			var dynamicModule = dynamicAssembly.DefineDynamicModule (assemblyName.Name, fileName);
+			var typeBuilder = dynamicModule.DefineType ("type1", TypeAttributes.Public | TypeAttributes.Class);
+
+			var mainMethod = typeBuilder.DefineMethod ("Main", MethodAttributes.Public | MethodAttributes.Static, typeof (int), new Type[0]);
+			var mainMethodIl = mainMethod.GetILGenerator ();
+
+			var f1 = typeBuilder.DefineField ("x", typeof (sbyte), FieldAttributes.Private | FieldAttributes.Static);
+			var f2 = typeBuilder.DefineField ("x", typeof (sbyte), FieldAttributes.Private | FieldAttributes.Static);
+
+			mainMethodIl.Emit (OpCodes.Ldsflda, f1);
+			mainMethodIl.Emit (OpCodes.Ldsflda, f2);
+			mainMethodIl.Emit (OpCodes.Pop);
+			mainMethodIl.Emit (OpCodes.Pop);
+			mainMethodIl.Emit (OpCodes.Ldc_I4_0);
+			mainMethodIl.Emit (OpCodes.Ret);
+
+			typeBuilder.CreateType ();
+			dynamicAssembly.SetEntryPoint (mainMethod);
+
+			dynamicAssembly.Save (fileName);
+		}
+
 	}
 }


### PR DESCRIPTION
This is #4997 backported to `2017-04`