### PR TITLE
[WIP] Improvements in handling input of (volatile) w32handle array in the S.T.WaitHandle icalls

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -257,6 +257,8 @@ typedef struct {
 	MonoMarshalByRefObject object;
 	gpointer     handle;
 } MonoWaitHandle;
+/* Safely access System.Threading.WaitHandle from native code */
+TYPED_HANDLE_DECL (MonoWaitHandle);
 
 /* This is a copy of System.Runtime.Remoting.Messaging.CallType */
 typedef enum {
@@ -648,6 +650,9 @@ mono_wait_handle_new	    (MonoDomain *domain, gpointer handle, MonoError *error)
 
 gpointer
 mono_wait_handle_get_handle (MonoWaitHandle *handle);
+
+gpointer
+mono_wait_handle_get_safe_handle_from_coop_handle (MonoWaitHandleHandle handle);
 
 gboolean
 mono_message_init	    (MonoDomain *domain, MonoMethodMessage *this_obj, 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7364,6 +7364,23 @@ mono_wait_handle_get_handle (MonoWaitHandle *handle)
 	return sh->handle;
 }
 
+HANDLE
+mono_wait_handle_get_safe_handle_from_coop_handle (MonoWaitHandleHandle handle)
+{
+	static MonoClassField *f_safe_handle = NULL;
+
+	if (!f_safe_handle) {
+		f_safe_handle = mono_class_get_field_from_name (mono_defaults.manualresetevent_class, "safeWaitHandle");
+		g_assert (f_safe_handle);
+	}
+	MonoSafeHandleHandle sh = MONO_HANDLE_NEW_GET_FIELD (handle, MonoSafeHandle, f_safe_handle);
+
+	if (MONO_HANDLE_IS_NULL (sh))
+		return -1;
+
+	return (HANDLE) MONO_HANDLE_GETVAL (sh, handle);
+}
+
 
 static MonoObject*
 mono_runtime_capture_context (MonoDomain *domain, MonoError *error)

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -12,6 +12,8 @@
 #include <windows.h>
 #endif
 
+#include <mono/metadata/object-internals.h>
+
 #ifndef INVALID_HANDLE_VALUE
 #define INVALID_HANDLE_VALUE (gpointer)-1
 #endif
@@ -163,6 +165,12 @@ mono_w32handle_trylock_handle (gpointer handle);
 
 void
 mono_w32handle_unlock_handle (gpointer handle);
+
+uintptr_t
+mono_w32handle_load_from_monoarray (MonoArrayHandle source, gpointer *dest, uintptr_t buffer_size, MonoError *error);
+
+gboolean
+mono_w32handle_unload (gpointer *buffer, uintptr_t numhandles);
 
 MonoW32HandleWaitRet
 mono_w32handle_wait_one (gpointer handle, guint32 timeout, gboolean alertable);


### PR DESCRIPTION
The changes came from trying to pin down a pthread resource/w32handle related runtime crash hitting recent Monos. Lack of synchronization when accessing the w32handle pool caused broken operation from corrupt data when under I/O stress.

