### PR TITLE
Boehm GC Fixes - SRE and Handle Stack

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -408,6 +408,8 @@ boehm_thread_unregister (MonoThreadInfo *p)
 
 	if (p->runtime_thread)
 		mono_threads_add_joinable_thread ((gpointer)tid);
+
+	mono_handle_stack_free (p->handle_stack);
 }
 
 static void

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -314,12 +314,7 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 	else
 		version = mono_get_runtime_info ()->runtime_version;
 
-#if HAVE_BOEHM_GC
-	/* The MonoGHashTable's need GC tracking */
-	image = (MonoDynamicImage *)GC_MALLOC (sizeof (MonoDynamicImage));
-#else
 	image = g_new0 (MonoDynamicImage, 1);
-#endif
 
 	mono_profiler_module_event (&image->image, MONO_PROFILE_START_LOAD);
 	
@@ -549,10 +544,5 @@ mono_dynamic_image_free (MonoDynamicImage *image)
 void
 mono_dynamic_image_free_image (MonoDynamicImage *image)
 {
-	/* See create_dynamic_mono_image () */
-#if HAVE_BOEHM_GC
-	/* Allocated using GC_MALLOC */
-#else
 	g_free (image);
-#endif
 }

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -69,6 +69,55 @@ Combine: MonoDefaults, GENERATE_GET_CLASS_WITH_CACHE, TYPED_HANDLE_DECL and frie
  * points to a valid value.
  */
 
+#ifdef HAVE_BOEHM_GC
+static HandleStack*
+new_handle_stack ()
+{
+	return (HandleStack *)mono_gc_alloc_fixed (sizeof (HandleStack), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_HANDLE, "Thread Handle Stack");
+}
+
+static void
+free_handle_stack (HandleStack *stack)
+{
+	mono_gc_free_fixed (stack);
+}
+
+static HandleChunk*
+new_handle_chunk ()
+{
+	return (HandleChunk *)GC_MALLOC (sizeof (HandleChunk));
+}
+
+static void
+free_handle_chunk (HandleChunk *chunk)
+{
+}
+#else
+static HandleStack*
+new_handle_stack ()
+{
+	return g_new (HandleStack, 1);
+}
+
+static void
+free_handle_stack (HandleStack *stack)
+{
+	g_free (stack);
+}
+
+static HandleChunk*
+new_handle_chunk ()
+{
+	return g_new (HandleChunk, 1);
+}
+
+static void
+free_handle_chunk (HandleChunk *chunk)
+{
+	g_free (chunk);
+}
+#endif
+
 const MonoObjectHandle mono_null_value_handle = NULL;
 
 #define THIS_IS_AN_OK_NUMBER_OF_HANDLES 100
@@ -197,7 +246,7 @@ retry:
 		handles->top = top;
 		goto retry;
 	}
-	HandleChunk *new_chunk = g_new (HandleChunk, 1);
+	HandleChunk *new_chunk = new_handle_chunk ();
 	new_chunk->size = 0;
 	new_chunk->prev = top;
 	new_chunk->next = NULL;
@@ -245,9 +294,9 @@ mono_handle_new_interior (gpointer rawptr, const char *owner)
 HandleStack*
 mono_handle_stack_alloc (void)
 {
-	HandleStack *stack = g_new0 (HandleStack, 1);
-	HandleChunk *chunk = g_new0 (HandleChunk, 1);
-	HandleChunk *interior = g_new0 (HandleChunk, 1);
+	HandleStack *stack = new_handle_stack ();
+	HandleChunk *chunk = new_handle_chunk ();
+	HandleChunk *interior = new_handle_chunk ();
 
 	mono_memory_write_barrier ();
 	stack->top = stack->bottom = chunk;
@@ -268,12 +317,12 @@ mono_handle_stack_free (HandleStack *stack)
 	mono_memory_write_barrier ();
 	while (c) {
 		HandleChunk *next = c->next;
-		g_free (c);
+		free_handle_chunk (c);
 		c = next;
 	}
-	g_free (c);
-	g_free (stack->interior);
-	g_free (stack);
+	free_handle_chunk (c);
+	free_handle_chunk (stack->interior);
+	free_handle_stack (stack);
 }
 
 void

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -298,6 +298,10 @@ mono_handle_stack_alloc (void)
 	HandleChunk *chunk = new_handle_chunk ();
 	HandleChunk *interior = new_handle_chunk ();
 
+	chunk->prev = chunk->next = NULL;
+	chunk->size = 0;
+	interior->prev = interior->next = NULL;
+	interior->size = 0;
 	mono_memory_write_barrier ();
 	stack->top = stack->bottom = chunk;
 	stack->interior = interior;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1222,12 +1222,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 	if (assemblyb->dynamic_assembly)
 		return;
 
-#if HAVE_BOEHM_GC
-	/* assembly->assembly.image might be GC allocated */
-	assembly = assemblyb->dynamic_assembly = (MonoDynamicAssembly *)GC_MALLOC (sizeof (MonoDynamicAssembly));
-#else
 	assembly = assemblyb->dynamic_assembly = g_new0 (MonoDynamicAssembly, 1);
-#endif
 
 	mono_profiler_assembly_event (&assembly->assembly, MONO_PROFILE_START_LOAD);
 	

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1029,16 +1029,21 @@ STW to make sure no unsafe pending suspend is in progress.
 static void
 mono_thread_info_suspend_lock_with_info (MonoThreadInfo *info)
 {
-	g_assert (info);
-	g_assert (mono_thread_info_is_current (info));
-	g_assert (mono_thread_info_is_live (info));
+	if (mono_threads_is_coop_enabled ()) {
+		g_assert (info);
+		g_assert (mono_thread_info_is_current (info));
+		g_assert (mono_thread_info_is_live (info));
 
-	MONO_ENTER_GC_SAFE_WITH_INFO(info);
+		MONO_ENTER_GC_SAFE_WITH_INFO(info);
 
-	int res = mono_os_sem_wait (&global_suspend_semaphore, MONO_SEM_FLAGS_NONE);
-	g_assert (res != -1);
+		int res = mono_os_sem_wait (&global_suspend_semaphore, MONO_SEM_FLAGS_NONE);
+		g_assert (res != -1);
 
-	MONO_EXIT_GC_SAFE_WITH_INFO;
+		MONO_EXIT_GC_SAFE_WITH_INFO;
+	} else {
+		int res = mono_os_sem_wait (&global_suspend_semaphore, MONO_SEM_FLAGS_NONE);
+		g_assert (res != -1);
+	}
 }
 
 void


### PR DESCRIPTION
The contained GC tracked hash tables are now themselves roots since https://github.com/mono/mono/pull/4248

Fixes crash due to MonoDynamicAssembly or MonoDynamicImage being collected under Boehm as they were unreferenced GC memory.