### PR TITLE
Fix bug 40705: OpenMappedWebConfiguration throws: System.IndexOutOfRangeException, when using RazorGenerator under mono

### DIFF
--- a/mcs/class/System.Web/System.Web.Configuration_2.0/WebConfigurationHost.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/WebConfigurationHost.cs
@@ -174,7 +174,11 @@ namespace System.Web.Configuration
 		{
 			string fullPath = (string) hostInitConfigurationParams [1];
 			map = (WebConfigurationFileMap) hostInitConfigurationParams [0];
-			bool inAnotherApp = (bool) hostInitConfigurationParams [7];
+			bool inAnotherApp = false;
+
+			if ((hostInitConfigurationParams.Length > 7)
+				&& (hostInitConfigurationParams[7] is bool))
+				inAnotherApp = (bool) hostInitConfigurationParams[7];
 
 			if (inAnotherApp)
 				appVirtualPath = fullPath;


### PR DESCRIPTION
This pull-req fixes bugzilla's 40705, in order to allow running software like RazorGenerator under mono. 

See: https://bugzilla.xamarin.com/show_bug.cgi?id=40705