### PR TITLE
[jit] Always cache the latest image set in case of a cache miss.

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2556,8 +2556,11 @@ get_image_set (MonoImage **images, int nimages)
 			}
 
 			// If we iterated all the way through images without breaking, all items in images were found in set->images
-			if (j == nimages)
-				break; // Break on "found a set with equal members"
+			if (j == nimages) {
+				// Break on "found a set with equal members".
+				// This happens in case of a hash collision with a previously cached set.
+				break;
+			}
 		}
 
 		l = l->next;
@@ -2581,9 +2584,10 @@ get_image_set (MonoImage **images, int nimages)
 
 		g_ptr_array_add (image_sets, set);
 		++img_set_count;
-
-		img_set_cache_add (set);
 	}
+
+	/* Cache the set. If there was a cache collision, the previously cached value will be replaced. */
+	img_set_cache_add (set);
 
 	if (nimages == 1 && images [0] == mono_defaults.corlib) {
 		mono_memory_barrier ();


### PR DESCRIPTION
Currently the image set cache never replaces the cached value if a collision occurs. That may not be the most efficient way to do things if e.g. some image set is cached at startup, is never or seldom used later, and another "hot" image set is created that collides with it.
The patch is meant to fix that problem by replacing the old cached value with a new one in case of a collision.
According to the results I got from jitting a few Roslyn's dlls this change reduces the cache miss ratio tenfold on average and by 25 times for the worst-case scenario.