### PR TITLE
[loader] If using strict strong names, recheck loaded assm before returning it.

### DIFF
--- a/mono/tests/testing_gac/Makefile.am
+++ b/mono/tests/testing_gac/Makefile.am
@@ -59,6 +59,8 @@ APP_V1_SRC = v1/app.cs v1/app-refl-load.cs
 
 APP_SIGNED_V1_EXE = app-v1.exe app-refl-load-v1.exe
 
+APP_BOTH_EXE = app-both.exe
+
 UNSIGNED_V1_DLL= unsigned_v1/gactestlib.dll
 UNSIGNED_V2_DLL= unsigned_v2/gactestlib.dll
 
@@ -96,8 +98,10 @@ EXTRA_DIST= README $(SIGNING_KEY) $(GACTESTLIB_SRCS)
 .PHONY: runtest compile-tests prereqs
 
 runtest:
+	true
 if !FULL_AOT_TESTS
 if !HYBRID_AOT_TESTS
+	$(MAKE) test-app-both
 	$(MAKE) test-signed-v1-app-mp-unsigned-v1
 	$(MAKE) test-signed-v1-app-mp-signed-v1
 	$(MAKE) test-signed-v1-app-mp-unsigned-v2-signed-v1
@@ -106,7 +110,7 @@ if !HYBRID_AOT_TESTS
 endif
 endif
 
-compile-tests: prereqs $(APP_SIGNED_V1_EXE) $(APP_SIGNED_V1_AOT)
+compile-tests: prereqs $(APP_SIGNED_V1_EXE) $(APP_BOTH_EXE) $(APP_SIGNED_V1_AOT)
 
 prereqs: $(GACTESTLIB_DLLS) $(GACTESTLIB_DLLS_AOT)
 	$(MAKE) gacinstall
@@ -126,6 +130,9 @@ $(SIGNED_V1_DLL): $(V1_SRC) $(SIGNING_KEY)
 $(SIGNED_V2_DLL): $(V2_SRC) $(SIGNING_KEY)
 	-mkdir -p $(@D)
 	$(MCS) -out:$@ $(SIGN) $< && $(TOOLS_RUNTIME) $(SN) -R $@ $(SIGNING_KEY)
+
+app-both.exe: app-both.cs $(SIGNED_V1_DLL) $(SIGNED_V2_DLL)
+	$(MCS) -target:exe -out:$@ -r:V1=$(SIGNED_V1_DLL) /r:V2=$(SIGNED_V2_DLL) $<
 
 %-v1.exe: v1/%.cs $(SIGNED_V1_DLL)
 	$(MCS) -target:exe -out:$@ -r:$(SIGNED_V1_DLL) $<
@@ -149,6 +156,10 @@ test-signed-v1-app-mp-unsigned-v2-signed-v1: $(APP_SIGNED_V1_EXE) prereqs
 
 test-signed-v1-app-mp-signed-v2-signed-v1: $(APP_SIGNED_V1_EXE) prereqs
 	$(TOOLS_RUNTIME) $(TEST_RUNNER) $(TEST_RUNNER_ARGS) --testsuite-name "testing_gac_$@" --mono-path "signed_v2$(PLATFORM_PATH_SEPARATOR)signed_v1$(PLATFORM_PATH_SEPARATOR)$(BASE_MONO_PATH)" $(APP_SIGNED_V1_EXE)
+
+# N.B. the path order is important - the test needs to load v1 successfully and then try to load v2 from the v1 directory.
+test-app-both: $(APP_BOTH_EXE) prereqs
+	$(TOOLS_RUNTIME) $(TEST_RUNNER) $(TEST_RUNNER_ARGS) --testsuite-name "testing_gac_$@" --mono-path "signed_v1$(PLATFORM_PATH_SEPARATOR)signed_v2$(PLATFORM_PATH_SEPARATOR)$(BASE_MONO_PATH)" app-both.exe
 
 # MONO_GAC_PREFIX tests
 

--- a/mono/tests/testing_gac/app-both.cs
+++ b/mono/tests/testing_gac/app-both.cs
@@ -1,0 +1,23 @@
+
+// reference both versions of gactestlib via extern aliases.
+
+// N.B. the order of the aliases is important - the compiler will emit
+// .assembly declarations in the IL file in order, and Mono will try to load the declarations in the same order.
+// The test relies on V1 being loaded first and then V2 being tried from V1's MONO_PATH directory.
+extern alias V1;
+extern alias V2;
+
+using System;
+
+public class AppBoth {
+	public static int Main (string[] args) {
+		// regression test that references two strongly named
+		// assemblies that have the same name but different versions.
+		V1.OnlyInV1.M ();
+		V2.OnlyInV2.M ();
+		if (typeof (V1.X).Assembly.GetName ().Version == typeof (V2.X).Assembly.GetName ().Version)
+			return 1;
+
+		return 0;
+	}
+}

--- a/mono/tests/testing_gac/v1/gactestlib.cs
+++ b/mono/tests/testing_gac/v1/gactestlib.cs
@@ -13,3 +13,7 @@ public class X
 	}
 
 }
+
+public class OnlyInV1 {
+	public static void M () { }
+}

--- a/mono/tests/testing_gac/v2/gactestlib.cs
+++ b/mono/tests/testing_gac/v2/gactestlib.cs
@@ -13,3 +13,7 @@ public class X
 	// {
 	// }
 }
+
+public class OnlyInV2 {
+	public static void M () { }
+}


### PR DESCRIPTION
Suppose we have two versions of an assembly: AsmA 1.0.0.0 and AsmA 2.0.0.0 that
we want to load into the same domain at the same time (for example we want to
load AsmB and AsmC that statically reference the two versions, respectively, or
maybe we used reflection).  Suppose version 1 got loaded first (and we found it
on our MONO_PATH in "somepathdir/AsmA.dll").  Now we want to load version 2.
The problem is that if version 1 is on MONO_PATH first, we'll find a filename
that matches ("somepathdir/AsmA.dll") and try to open that image.  Then we'll
end up here in mono_assembly_open_predicate() after the mono_image_open_a_lot()
call hits the image cache.  So we get back an image and image->assembly is
version 1.

The old behavior would just return any non-NULL image->assembly.  The new
behavior is to check the predicate and reject opening the propose file if the
predicate doesn't match.  (If we're not using the strict loader, or if there's
no predicate set, return the existing image->assembly as before).

----

TODO:
- [x] add a regression test
- [x] check that this also works when there are two separate domains involved.
- [x] check that it does something reasonable for `framework_assemblies`
- [x] check that it does something reasonable if either the previous or the new reference is going through rebinding via a .config file.