### PR TITLE
[eglib] Replace strerror with strerror_r as the former is not thread safe.

### DIFF
--- a/eglib/configure.ac
+++ b/eglib/configure.ac
@@ -141,7 +141,7 @@ AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(void *)
 AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(long long)
-AC_CHECK_FUNCS(strlcpy stpcpy strtok_r rewinddir vasprintf)
+AC_CHECK_FUNCS(strlcpy stpcpy strtok_r rewinddir vasprintf strerror_r)
 AC_CHECK_FUNCS(getrlimit)
 AC_CHECK_FUNCS(fork execv execve)
 

--- a/eglib/src/gstr.c
+++ b/eglib/src/gstr.c
@@ -36,6 +36,8 @@
 #include <pthread.h>
 #endif
 
+#include <errno.h>
+
 /* 
  * g_strndup and g_vasprintf need to allocate memory with g_malloc if 
  * ENABLE_OVERRIDABLE_ALLOCATORS is defined so that it can be safely freed with g_free 


### PR DESCRIPTION
This change would be nicer if the code was moved to the runtime so we could use our PAL.