### PR TITLE
[2017-04][loader] If using strict strong names, recheck loaded assm before returning it.

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1980,11 +1980,24 @@ mono_assembly_open_predicate (const char *filename, gboolean refonly,
 	}
 
 	if (image->assembly) {
-		/* Already loaded by another appdomain */
-		mono_assembly_invoke_load_hook (image->assembly);
-		mono_image_close (image);
-		g_free (fname);
-		return image->assembly;
+		/* We want to return the MonoAssembly that's already loaded,
+		 * but if we're using the strict assembly loader, we also need
+		 * to check that the previously loaded assembly matches the
+		 * predicate.  It could be that we previously loaded a
+		 * different version that happens to have the filename that
+		 * we're currently probing. */
+		if (mono_loader_get_strict_strong_names () &&
+		    predicate && !predicate (image->assembly, user_data)) {
+			mono_image_close (image);
+			g_free (fname);
+			return NULL;
+		} else {
+			/* Already loaded by another appdomain */
+			mono_assembly_invoke_load_hook (image->assembly);
+			mono_image_close (image);
+			g_free (fname);
+			return image->assembly;
+		}
 	}
 
 	ass = mono_assembly_load_from_predicate (image, fname, refonly, predicate, user_data, status);

--- a/mono/tests/testing_gac/Makefile.am
+++ b/mono/tests/testing_gac/Makefile.am
@@ -59,6 +59,8 @@ APP_V1_SRC = v1/app.cs v1/app-refl-load.cs
 
 APP_SIGNED_V1_EXE = app-v1.exe app-refl-load-v1.exe
 
+APP_BOTH_EXE = app-both.exe
+
 UNSIGNED_V1_DLL= unsigned_v1/gactestlib.dll
 UNSIGNED_V2_DLL= unsigned_v2/gactestlib.dll
 
@@ -105,7 +107,8 @@ endif
 endif
 
 # MONO_PATH tests
-MP_TESTS= test-signed-v1-app-mp-unsigned-v1 \
+MP_TESTS= test-app-both \
+	test-signed-v1-app-mp-unsigned-v1 \
 	test-signed-v1-app-mp-signed-v1 \
 	test-signed-v1-app-mp-unsigned-v2-signed-v1 \
 	test-signed-v1-app-mp-signed-v2-signed-v1
@@ -116,7 +119,7 @@ MP_TESTS= test-signed-v1-app-mp-unsigned-v1 \
 
 runtest: $(MP_TESTS) $(GAC_TESTS)
 
-compile-tests: prereqs $(APP_SIGNED_V1_EXE) $(APP_SIGNED_V1_AOT)
+compile-tests: prereqs $(APP_SIGNED_V1_EXE) $(APP_BOTH_EXE) $(APP_SIGNED_V1_AOT)
 
 prereqs: $(GACTESTLIB_DLLS) $(GACTESTLIB_DLLS_AOT) gacinstall
 
@@ -135,6 +138,9 @@ $(SIGNED_V1_DLL): $(V1_SRC) $(SIGNING_KEY)
 $(SIGNED_V2_DLL): $(V2_SRC) $(SIGNING_KEY)
 	-mkdir -p $(@D)
 	$(MCS) -out:$@ $(SIGN) $< && $(TOOLS_RUNTIME) $(SN) -R $@ $(SIGNING_KEY)
+
+app-both.exe: app-both.cs $(SIGNED_V1_DLL) $(SIGNED_V2_DLL)
+	$(MCS) -target:exe -out:$@ -r:V1=$(SIGNED_V1_DLL) /r:V2=$(SIGNED_V2_DLL) $<
 
 %-v1.exe: v1/%.cs $(SIGNED_V1_DLL)
 	$(MCS) -target:exe -out:$@ -r:$(SIGNED_V1_DLL) $<
@@ -159,6 +165,10 @@ test-signed-v1-app-mp-unsigned-v2-signed-v1: $(APP_SIGNED_V1_EXE) prereqs
 
 test-signed-v1-app-mp-signed-v2-signed-v1: $(APP_SIGNED_V1_EXE) prereqs
 	$(TOOLS_RUNTIME) $(TEST_RUNNER) $(TEST_RUNNER_ARGS) --testsuite-name "testing_gac_$@" --mono-path "signed_v2$(PLATFORM_PATH_SEPARATOR)signed_v1$(PLATFORM_PATH_SEPARATOR)$(BASE_MONO_PATH)" $(APP_SIGNED_V1_EXE)
+
+# N.B. the path order is important - the test needs to load v1 successfully and then try to load v2 from the v1 directory.
+test-app-both: $(APP_BOTH_EXE) prereqs
+	$(TOOLS_RUNTIME) $(TEST_RUNNER) $(TEST_RUNNER_ARGS) --testsuite-name "testing_gac_$@" --mono-path "signed_v1$(PLATFORM_PATH_SEPARATOR)signed_v2$(PLATFORM_PATH_SEPARATOR)$(BASE_MONO_PATH)" app-both.exe
 
 .PHONY: gacinstall
 

--- a/mono/tests/testing_gac/app-both.cs
+++ b/mono/tests/testing_gac/app-both.cs
@@ -1,0 +1,23 @@
+
+// reference both versions of gactestlib via extern aliases.
+
+// N.B. the order of the aliases is important - the compiler will emit
+// .assembly declarations in the IL file in order, and Mono will try to load the declarations in the same order.
+// The test relies on V1 being loaded first and then V2 being tried from V1's MONO_PATH directory.
+extern alias V1;
+extern alias V2;
+
+using System;
+
+public class AppBoth {
+	public static int Main (string[] args) {
+		// regression test that references two strongly named
+		// assemblies that have the same name but different versions.
+		V1.OnlyInV1.M ();
+		V2.OnlyInV2.M ();
+		if (typeof (V1.X).Assembly.GetName ().Version == typeof (V2.X).Assembly.GetName ().Version)
+			return 1;
+
+		return 0;
+	}
+}

--- a/mono/tests/testing_gac/v1/gactestlib.cs
+++ b/mono/tests/testing_gac/v1/gactestlib.cs
@@ -13,3 +13,7 @@ public class X
 	}
 
 }
+
+public class OnlyInV1 {
+	public static void M () { }
+}

--- a/mono/tests/testing_gac/v2/gactestlib.cs
+++ b/mono/tests/testing_gac/v2/gactestlib.cs
@@ -13,3 +13,7 @@ public class X
 	// {
 	// }
 }
+
+public class OnlyInV2 {
+	public static void M () { }
+}


### PR DESCRIPTION
This is #5020 backported to the `2017-04` branch.