### PR TITLE
Upstreaming changes from mono/debugger-libs to Mono.Debugger.Soft

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -2214,7 +2214,7 @@ namespace Mono.Debugger.Soft
 		internal ValueImpl[] Type_GetValues (long id, long[] fields, long thread_id) {
 			int len = fields.Length;
 			PacketReader r;
-			if (thread_id != 0)
+			if (thread_id != 0 && Version.AtLeast(2, 3))
 				r = SendReceive (CommandSet.TYPE, (int)CmdType.GET_VALUES_2, new PacketWriter ().WriteId (id).WriteId (thread_id).WriteInt (len).WriteIds (fields));
 			else
 				r = SendReceive (CommandSet.TYPE, (int)CmdType.GET_VALUES, new PacketWriter ().WriteId (id).WriteInt (len).WriteIds (fields));

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILInterpreter.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILInterpreter.cs
@@ -30,6 +30,11 @@ namespace Mono.Debugger.Soft
 			if (args != null && args.Length != 0)
 				throw new NotSupportedException ();
 
+			//If method is virtual we can't optimize(execute IL) because it's maybe
+			//overriden... call runtime to invoke overriden version...
+			if (method.IsVirtual)
+				throw new NotSupportedException ();
+
 			if (method.IsStatic || method.DeclaringType.IsValueType || this_val == null || !(this_val is ObjectMirror))
 				throw new NotSupportedException ();
 
@@ -347,6 +352,12 @@ namespace Mono.Debugger.Soft
 								case "char": res = new PrimitiveValue (method.VirtualMachine, Convert.ToChar (primitive.Value)); break;
 								case "bool": res = new PrimitiveValue (method.VirtualMachine, Convert.ToBoolean (primitive.Value)); break;
 								}
+							} catch {
+								throw new NotSupportedException ();
+							}
+						} else if (method.ReturnType.IsEnum && primitive != null) {
+							try {
+								res = method.VirtualMachine.CreateEnumMirror (method.ReturnType, primitive);
 							} catch {
 								throw new NotSupportedException ();
 							}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -59,7 +59,7 @@ namespace Mono.Debugger.Soft
 				sb.Append (ReturnType.Name);
 				sb.Append (' ');
 				if (type_namespace != String.Empty)
-					sb.Append (type_namespace + ".");
+					sb.Append (type_namespace).Append (".");
 				sb.Append(type_name);
 				sb.Append(":");
 				sb.Append(Name);

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/StackFrame.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/StackFrame.cs
@@ -102,6 +102,18 @@ namespace Mono.Debugger.Soft
 			}
 		}
 
+		public int EndLineNumber {
+			get {
+				return Location.EndLineNumber;
+			}
+		}
+
+		public int EndColumnNumber {
+			get {
+				return Location.EndColumnNumber;
+			}
+		}
+
 		public bool IsDebuggerInvoke {
 			get {
 				return (flags & StackFrameFlags.DEBUGGER_INVOKE) != 0;

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ThreadMirror.cs
@@ -13,6 +13,8 @@ namespace Mono.Debugger.Soft
 		ManualResetEvent fetchingEvent = new ManualResetEvent (false);
 		ThreadInfo info;
 		StackFrame[] frames;
+		bool threadStateInvalid = true;
+		ThreadState threadState;
 
 		internal ThreadMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
@@ -30,6 +32,7 @@ namespace Mono.Debugger.Soft
 
 		internal void InvalidateFrames () {
 			cacheInvalid = true;
+			threadStateInvalid = true;
 		}
 
 		internal void FetchFrames (bool mustFetch = false) {
@@ -91,7 +94,11 @@ namespace Mono.Debugger.Soft
 
 		public ThreadState ThreadState {
 			get {
-				return (ThreadState)vm.conn.Thread_GetState (id);
+				if (threadStateInvalid) {
+					threadState = (ThreadState) vm.conn.Thread_GetState (id);
+					threadStateInvalid = false;
+				}
+				return threadState;
 			}
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -665,7 +665,7 @@ namespace Mono.Debugger.Soft
 			return res;
 		}
 
-		internal ValueImpl EncodeValue (Value v) {
+		internal ValueImpl EncodeValue (Value v, List<Value> duplicates = null) {
 			if (v is PrimitiveValue) {
 				object val = (v as PrimitiveValue).Value;
 				if (val == null)
@@ -675,16 +675,22 @@ namespace Mono.Debugger.Soft
 			} else if (v is ObjectMirror) {
 				return new ValueImpl { Type = ElementType.Object, Objid = (v as ObjectMirror).Id };
 			} else if (v is StructMirror) {
-				return new ValueImpl { Type = ElementType.ValueType, Klass = (v as StructMirror).Type.Id, Fields = EncodeValues ((v as StructMirror).Fields) };
+				if (duplicates == null)
+					duplicates = new List<Value> ();
+				if (duplicates.Contains (v))
+					return new ValueImpl { Type = (ElementType)ValueTypeId.VALUE_TYPE_ID_NULL, Objid = 0 };
+				duplicates.Add (v);
+
+				return new ValueImpl { Type = ElementType.ValueType, Klass = (v as StructMirror).Type.Id, Fields = EncodeValues ((v as StructMirror).Fields, duplicates) };
 			} else {
 				throw new NotSupportedException ();
 			}
 		}
 
-		internal ValueImpl[] EncodeValues (IList<Value> values) {
+		internal ValueImpl[] EncodeValues (IList<Value> values, List<Value> duplicates = null) {
 			ValueImpl[] res = new ValueImpl [values.Count];
 			for (int i = 0; i < values.Count; ++i)
-				res [i] = EncodeValue (values [i]);
+				res [i] = EncodeValue (values [i], duplicates);
 			return res;
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachineManager.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.Remoting.Messaging;
+using System.Text;
 
 namespace Mono.Debugger.Soft
 {
@@ -94,6 +95,9 @@ namespace Mono.Debugger.Soft
 			if (options != null && options.Valgrind)
 				info.FileName = "valgrind";
 			info.UseShellExecute = false;
+
+			info.StandardErrorEncoding = Encoding.UTF8;
+			info.StandardOutputEncoding = Encoding.UTF8;
 
 			ITargetProcess p;
 			if (options != null && options.CustomProcessLauncher != null)


### PR DESCRIPTION
https://github.com/mono/debugger-libs is keeping it's own version of Mono.Debugger.Soft which sometimes get some improvements and diverges... This PR is upstreaming changes done over time...

If any of changes is questionable I will investigate in debugger-libs and explain why it's done this way...