### PR TITLE
[runtime] Add a mono_marshal_get_runtime_invoke_full () function with…

### DIFF
--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -325,6 +325,9 @@ MonoMethod *
 mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt, gboolean static_method_with_first_arg_bound, MonoMethod *target_method);
 
 MonoMethod *
+mono_marshal_get_runtime_invoke_full (MonoMethod *method, gboolean virtual_, gboolean need_direct_wrapper);
+
+MonoMethod *
 mono_marshal_get_runtime_invoke (MonoMethod *method, gboolean is_virtual);
 
 MonoMethod*


### PR DESCRIPTION
… an extra need_direct_wrapper argument to allow generation of runtime-invoke wrappers which directly call a method without using the 'addr' argument.