### PR TITLE
[threads] Rework MonoThreadInfoCallbacks.thread_{register,detach,unregister} callbacks

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -57,9 +57,9 @@ static gboolean gc_initialized = FALSE;
 static mono_mutex_t mono_gc_lock;
 
 static void*
-boehm_thread_register (MonoThreadInfo* info);
+boehm_thread_attach (MonoThreadInfo* info);
 static void
-boehm_thread_unregister (MonoThreadInfo *p);
+boehm_thread_detach_with_lock (MonoThreadInfo *p);
 static void
 boehm_thread_detach (MonoThreadInfo *p);
 static void
@@ -238,9 +238,9 @@ mono_gc_base_init (void)
 	}
 
 	memset (&cb, 0, sizeof (cb));
-	cb.thread_register = boehm_thread_register;
-	cb.thread_unregister = boehm_thread_unregister;
+	cb.thread_attach = boehm_thread_attach;
 	cb.thread_detach = boehm_thread_detach;
+	cb.thread_detach_with_lock = boehm_thread_detach_with_lock;
 	cb.mono_method_is_critical = (gboolean (*)(void *))mono_runtime_is_critical_method;
 
 	mono_threads_init (&cb, sizeof (MonoThreadInfo));
@@ -376,7 +376,7 @@ mono_gc_is_gc_thread (void)
 }
 
 static void*
-boehm_thread_register (MonoThreadInfo* info)
+boehm_thread_attach (MonoThreadInfo* info)
 {
 	struct GC_stack_base sb;
 	int res;
@@ -393,7 +393,7 @@ boehm_thread_register (MonoThreadInfo* info)
 }
 
 static void
-boehm_thread_unregister (MonoThreadInfo *p)
+boehm_thread_detach_with_lock (MonoThreadInfo *p)
 {
 	MonoNativeThreadId tid;
 

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -375,12 +375,6 @@ mono_gc_is_gc_thread (void)
 	return GC_thread_is_registered ();
 }
 
-gboolean
-mono_gc_register_thread (void)
-{
-	return mono_thread_info_attach () != NULL;
-}
-
 static void*
 boehm_thread_register (MonoThreadInfo* info)
 {

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -57,7 +57,7 @@ static gboolean gc_initialized = FALSE;
 static mono_mutex_t mono_gc_lock;
 
 static void*
-boehm_thread_register (MonoThreadInfo* info, void *baseptr);
+boehm_thread_register (MonoThreadInfo* info);
 static void
 boehm_thread_unregister (MonoThreadInfo *p);
 static void
@@ -110,7 +110,6 @@ mono_gc_base_init (void)
 {
 	MonoThreadInfoCallbacks cb;
 	const char *env;
-	int dummy;
 
 	if (gc_initialized)
 		return;
@@ -248,7 +247,7 @@ mono_gc_base_init (void)
 	mono_os_mutex_init (&mono_gc_lock);
 	mono_os_mutex_init_recursive (&handle_section);
 
-	mono_thread_info_attach (&dummy);
+	mono_thread_info_attach ();
 
 	GC_set_on_collection_event (on_gc_notification);
 	GC_on_heap_resize = on_gc_heap_resize;
@@ -377,19 +376,19 @@ mono_gc_is_gc_thread (void)
 }
 
 gboolean
-mono_gc_register_thread (void *baseptr)
+mono_gc_register_thread (void)
 {
-	return mono_thread_info_attach (baseptr) != NULL;
+	return mono_thread_info_attach () != NULL;
 }
 
 static void*
-boehm_thread_register (MonoThreadInfo* info, void *baseptr)
+boehm_thread_register (MonoThreadInfo* info)
 {
 	struct GC_stack_base sb;
 	int res;
 
 	/* TODO: use GC_get_stack_base instead of baseptr. */
-	sb.mem_base = baseptr;
+	sb.mem_base = info->stack_end;
 	res = GC_register_my_thread (&sb);
 	if (res == GC_UNIMPLEMENTED)
 	    return NULL; /* Cannot happen with GC v7+. */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -464,7 +464,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	MonoAssembly *ass = NULL;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
 	const MonoRuntimeInfo* runtimes [G_N_ELEMENTS (supported_runtimes) + 1] = { NULL };
-	int n, dummy;
+	int n;
 
 #ifdef DEBUG_DOMAIN_UNLOAD
 	debug_domain_unload = TRUE;
@@ -501,7 +501,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_counters_register ("Max HashTable Chain Length", MONO_COUNTER_INT|MONO_COUNTER_METADATA, &mono_g_hash_table_max_chain_length);
 
 	mono_gc_base_init ();
-	mono_thread_info_attach (&dummy);
+	mono_thread_info_attach ();
 
 	mono_coop_mutex_init_recursive (&appdomains_mutex);
 

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -93,12 +93,6 @@ mono_gc_is_gc_thread (void)
 	return TRUE;
 }
 
-gboolean
-mono_gc_register_thread (void)
-{
-	return TRUE;
-}
-
 int
 mono_gc_walk_heap (int flags, MonoGCReferences callback, void *data)
 {

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -23,7 +23,6 @@ void
 mono_gc_base_init (void)
 {
 	MonoThreadInfoCallbacks cb;
-	int dummy;
 
 	mono_counters_init ();
 
@@ -39,7 +38,7 @@ mono_gc_base_init (void)
 
 	mono_threads_init (&cb, sizeof (MonoThreadInfo));
 
-	mono_thread_info_attach (&dummy);
+	mono_thread_info_attach ();
 }
 
 void
@@ -95,7 +94,7 @@ mono_gc_is_gc_thread (void)
 }
 
 gboolean
-mono_gc_register_thread (void *baseptr)
+mono_gc_register_thread (void)
 {
 	return TRUE;
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2304,15 +2304,6 @@ sgen_thread_detach (SgenThreadInfo *p)
 }
 
 /**
- * mono_gc_register_thread:
- */
-gboolean
-mono_gc_register_thread (void)
-{
-	return mono_thread_info_attach () != NULL;
-}
-
-/**
  * mono_gc_is_gc_thread:
  */
 gboolean

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2209,7 +2209,7 @@ mono_gc_get_gc_callbacks ()
 }
 
 void
-sgen_client_thread_register (SgenThreadInfo* info)
+sgen_client_thread_attach (SgenThreadInfo* info)
 {
 	mono_tls_set_sgen_thread_info (info);
 
@@ -2235,7 +2235,7 @@ sgen_client_thread_register (SgenThreadInfo* info)
 }
 
 void
-sgen_client_thread_unregister (SgenThreadInfo *p)
+sgen_client_thread_detach_with_lock (SgenThreadInfo *p)
 {
 	MonoNativeThreadId tid;
 
@@ -2281,13 +2281,6 @@ static gboolean
 thread_in_critical_region (SgenThreadInfo *info)
 {
 	return info->client_info.in_critical_region;
-}
-
-static void
-sgen_thread_attach (SgenThreadInfo *info)
-{
-	if (mono_gc_get_gc_callbacks ()->thread_attach_func && !info->client_info.runtime_data)
-		info->client_info.runtime_data = mono_gc_get_gc_callbacks ()->thread_attach_func ();
 }
 
 static void
@@ -2866,10 +2859,9 @@ sgen_client_init (void)
 {
 	MonoThreadInfoCallbacks cb;
 
-	cb.thread_register = sgen_thread_register;
-	cb.thread_detach = sgen_thread_detach;
-	cb.thread_unregister = sgen_thread_unregister;
 	cb.thread_attach = sgen_thread_attach;
+	cb.thread_detach = sgen_thread_detach;
+	cb.thread_detach_with_lock = sgen_thread_detach_with_lock;
 	cb.mono_thread_in_critical_region = thread_in_critical_region;
 	cb.ip_in_critical_region = ip_in_critical_region;
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -72,7 +72,7 @@ ptr_on_stack (void *ptr)
 	gpointer stack_start = &stack_start;
 	SgenThreadInfo *info = mono_thread_info_current ();
 
-	if (ptr >= stack_start && ptr < (gpointer)info->client_info.stack_end)
+	if (ptr >= stack_start && ptr < (gpointer)info->client_info.info.stack_end)
 		return TRUE;
 	return FALSE;
 }
@@ -2209,11 +2209,8 @@ mono_gc_get_gc_callbacks ()
 }
 
 void
-sgen_client_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
+sgen_client_thread_register (SgenThreadInfo* info)
 {
-	size_t stsize = 0;
-	guint8 *staddr = NULL;
-
 	mono_tls_set_sgen_thread_info (info);
 
 	info->client_info.skip = 0;
@@ -2225,17 +2222,6 @@ sgen_client_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
 	info->client_info.signal = 0;
 #endif
 
-	mono_thread_info_get_stack_bounds (&staddr, &stsize);
-	if (staddr) {
-		info->client_info.stack_start_limit = staddr;
-		info->client_info.stack_end = staddr + stsize;
-	} else {
-		gsize stack_bottom = (gsize)stack_bottom_fallback;
-		stack_bottom += 4095;
-		stack_bottom &= ~4095;
-		info->client_info.stack_end = (char*)stack_bottom;
-	}
-
 	memset (&info->client_info.ctx, 0, sizeof (MonoContext));
 
 	if (mono_gc_get_gc_callbacks ()->thread_attach_func)
@@ -2243,7 +2229,7 @@ sgen_client_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
 
 	binary_protocol_thread_register ((gpointer)mono_thread_info_get_tid (info));
 
-	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)mono_thread_info_get_tid (info), info->client_info.stack_end);
+	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)mono_thread_info_get_tid (info), info->client_info.info.stack_end);
 
 	info->client_info.info.handle_stack = mono_handle_stack_alloc ();
 }
@@ -2321,9 +2307,9 @@ sgen_thread_detach (SgenThreadInfo *p)
  * mono_gc_register_thread:
  */
 gboolean
-mono_gc_register_thread (void *baseptr)
+mono_gc_register_thread (void)
 {
-	return mono_thread_info_attach (baseptr) != NULL;
+	return mono_thread_info_attach () != NULL;
 }
 
 /**
@@ -2393,20 +2379,20 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 		void *aligned_stack_start;
 
 		if (info->client_info.skip) {
-			SGEN_LOG (3, "Skipping dead thread %p, range: %p-%p, size: %zd", info, info->client_info.stack_start, info->client_info.stack_end, (char*)info->client_info.stack_end - (char*)info->client_info.stack_start);
+			SGEN_LOG (3, "Skipping dead thread %p, range: %p-%p, size: %zd", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start);
 			skip_reason = 1;
 		} else if (info->client_info.gc_disabled) {
-			SGEN_LOG (3, "GC disabled for thread %p, range: %p-%p, size: %zd", info, info->client_info.stack_start, info->client_info.stack_end, (char*)info->client_info.stack_end - (char*)info->client_info.stack_start);
+			SGEN_LOG (3, "GC disabled for thread %p, range: %p-%p, size: %zd", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start);
 			skip_reason = 2;
 		} else if (!mono_thread_info_is_live (info)) {
-			SGEN_LOG (3, "Skipping non-running thread %p, range: %p-%p, size: %zd (state %x)", info, info->client_info.stack_start, info->client_info.stack_end, (char*)info->client_info.stack_end - (char*)info->client_info.stack_start, info->client_info.info.thread_state);
+			SGEN_LOG (3, "Skipping non-running thread %p, range: %p-%p, size: %zd (state %x)", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, info->client_info.info.thread_state);
 			skip_reason = 3;
 		} else if (!info->client_info.stack_start) {
 			SGEN_LOG (3, "Skipping starting or detaching thread %p", info);
 			skip_reason = 4;
 		}
 
-		binary_protocol_scan_stack ((gpointer)mono_thread_info_get_tid (info), info->client_info.stack_start, info->client_info.stack_end, skip_reason);
+		binary_protocol_scan_stack ((gpointer)mono_thread_info_get_tid (info), info->client_info.stack_start, info->client_info.info.stack_end, skip_reason);
 
 		if (skip_reason) {
 			if (precise) {
@@ -2421,7 +2407,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 		}
 
 		g_assert (info->client_info.stack_start);
-		g_assert (info->client_info.stack_end);
+		g_assert (info->client_info.info.stack_end);
 
 		aligned_stack_start = (void*)(mword) ALIGN_TO ((mword)info->client_info.stack_start, SIZEOF_VOID_P);
 #ifdef HOST_WIN32
@@ -2441,16 +2427,16 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 #endif
 
 		g_assert (info->client_info.suspend_done);
-		SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %zd, pinned=%zd", info, info->client_info.stack_start, info->client_info.stack_end, (char*)info->client_info.stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
+		SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %zd, pinned=%zd", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
 		if (mono_gc_get_gc_callbacks ()->thread_mark_func && !conservative_stack_mark) {
-			mono_gc_get_gc_callbacks ()->thread_mark_func (info->client_info.runtime_data, (guint8 *)aligned_stack_start, (guint8 *)info->client_info.stack_end, precise, &ctx);
+			mono_gc_get_gc_callbacks ()->thread_mark_func (info->client_info.runtime_data, (guint8 *)aligned_stack_start, (guint8 *)info->client_info.info.stack_end, precise, &ctx);
 		} else if (!precise) {
 			if (!conservative_stack_mark) {
 				fprintf (stderr, "Precise stack mark not supported - disabling.\n");
 				conservative_stack_mark = TRUE;
 			}
 			//FIXME we should eventually use the new stack_mark from coop
-			sgen_conservatively_pin_objects_from ((void **)aligned_stack_start, (void **)info->client_info.stack_end, start_nursery, end_nursery, PIN_TYPE_STACK);
+			sgen_conservatively_pin_objects_from ((void **)aligned_stack_start, (void **)info->client_info.info.stack_end, start_nursery, end_nursery, PIN_TYPE_STACK);
 		}
 
 		if (!precise) {
@@ -2460,7 +2446,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 			{
 				// This is used on Coop GC for platforms where we cannot get the data for individual registers.
 				// We force a spill of all registers into the stack and pass a chunk of data into sgen.
-				//FIXME under coop, for now, what we need to ensure is that we scan any extra memory from info->client_info.stack_end to stack_mark
+				//FIXME under coop, for now, what we need to ensure is that we scan any extra memory from info->client_info.info.stack_end to stack_mark
 				MonoThreadUnwindState *state = &info->client_info.info.thread_saved_state [SELF_SUSPEND_STATE_INDEX];
 				if (state && state->gc_stackdata) {
 					sgen_conservatively_pin_objects_from ((void **)state->gc_stackdata, (void**)((char*)state->gc_stackdata + state->gc_stackdata_size),
@@ -2501,8 +2487,8 @@ mono_gc_set_stack_end (void *stack_end)
 	LOCK_GC;
 	info = mono_thread_info_current ();
 	if (info) {
-		SGEN_ASSERT (0, stack_end < info->client_info.stack_end, "Can only lower stack end");
-		info->client_info.stack_end = stack_end;
+		SGEN_ASSERT (0, stack_end < info->client_info.info.stack_end, "Can only lower stack end");
+		info->client_info.info.stack_end = stack_end;
 	}
 	UNLOCK_GC;
 }
@@ -2887,7 +2873,6 @@ sgen_client_vtable_get_name (MonoVTable *vt)
 void
 sgen_client_init (void)
 {
-	int dummy;
 	MonoThreadInfoCallbacks cb;
 
 	cb.thread_register = sgen_thread_register;
@@ -2909,7 +2894,7 @@ sgen_client_init (void)
 
 	mono_tls_init_gc_keys ();
 
-	mono_gc_register_thread (&dummy);
+	mono_thread_info_attach ();
 }
 
 gboolean

--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -66,7 +66,7 @@ update_current_thread_stack (void *start)
 
 	info->client_info.stack_start = align_pointer (&stack_guard);
 	g_assert (info->client_info.stack_start);
-	g_assert (info->client_info.stack_start >= info->client_info.stack_start_limit && info->client_info.stack_start < info->client_info.stack_end);
+	g_assert (info->client_info.stack_start >= info->client_info.info.stack_start_limit && info->client_info.stack_start < info->client_info.info.stack_end);
 
 #if !defined(MONO_CROSS_COMPILE) && MONO_ARCH_HAS_MONO_CONTEXT
 	MONO_CONTEXT_GET_CURRENT (info->client_info.ctx);
@@ -360,8 +360,8 @@ sgen_unified_suspend_stop_world (void)
 		/* Once we remove the old suspend code, we should move sgen to directly access the state in MonoThread */
 		info->client_info.stack_start = (gpointer) ((char*)MONO_CONTEXT_GET_SP (&info->client_info.ctx) - REDZONE_SIZE);
 
-		if (info->client_info.stack_start < info->client_info.stack_start_limit
-			 || info->client_info.stack_start >= info->client_info.stack_end) {
+		if (info->client_info.stack_start < info->client_info.info.stack_start_limit
+			 || info->client_info.stack_start >= info->client_info.info.stack_end) {
 			/*
 			 * Thread context is in unhandled state, most likely because it is
 			 * dying. We don't scan it.
@@ -375,7 +375,7 @@ sgen_unified_suspend_stop_world (void)
 		binary_protocol_thread_suspend ((gpointer) mono_thread_info_get_tid (info), stopped_ip);
 
 		THREADS_STW_DEBUG ("[GC-STW-SUSPEND-END] thread %p is suspended, stopped_ip = %p, stack = %p -> %p\n",
-			mono_thread_info_get_tid (info), stopped_ip, info->client_info.stack_start, info->client_info.stack_start ? info->client_info.stack_end : NULL);
+			mono_thread_info_get_tid (info), stopped_ip, info->client_info.stack_start, info->client_info.stack_start ? info->client_info.info.stack_end : NULL);
 	} FOREACH_THREAD_END
 }
 

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -80,12 +80,6 @@ typedef void* MonoGCDescriptor;
 #define MONO_GC_DESCRIPTOR_NULL NULL
 #endif
 
-/*
- * Try to register a foreign thread with the GC, if we fail or the backend
- * can't cope with this concept - we return FALSE.
- */
-extern gboolean mono_gc_register_thread (void);
-
 gboolean mono_gc_parse_environment_string_extract_number (const char *str, size_t *out);
 
 MonoGCDescriptor mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size);

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -84,7 +84,7 @@ typedef void* MonoGCDescriptor;
  * Try to register a foreign thread with the GC, if we fail or the backend
  * can't cope with this concept - we return FALSE.
  */
-extern gboolean mono_gc_register_thread (void *baseptr);
+extern gboolean mono_gc_register_thread (void);
 
 gboolean mono_gc_parse_environment_string_extract_number (const char *str, size_t *out);
 

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -153,11 +153,11 @@ void sgen_client_pre_collection_checks (void);
  * Must set the thread's thread info to `info`.  If the thread's small ID was not already
  * initialized in `sgen_client_init()` (for the main thread, usually), it must be done here.
  *
- * `stack_bottom_fallback` is the value passed through via `sgen_thread_register()`.
+ * `stack_bottom_fallback` is the value passed through via `sgen_thread_attach()`.
  */
-void sgen_client_thread_register (SgenThreadInfo* info);
+void sgen_client_thread_attach (SgenThreadInfo* info);
 
-void sgen_client_thread_unregister (SgenThreadInfo *p);
+void sgen_client_thread_detach_with_lock (SgenThreadInfo *p);
 
 /*
  * Called on each worker thread when it starts up.  Must initialize the thread's small ID.

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -155,7 +155,7 @@ void sgen_client_pre_collection_checks (void);
  *
  * `stack_bottom_fallback` is the value passed through via `sgen_thread_register()`.
  */
-void sgen_client_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback);
+void sgen_client_thread_register (SgenThreadInfo* info);
 
 void sgen_client_thread_unregister (SgenThreadInfo *p);
 

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -502,9 +502,9 @@ find_pinning_ref_from_thread (char *obj, size_t size)
 		char **start = (char**)info->client_info.stack_start;
 		if (info->client_info.skip || info->client_info.gc_disabled)
 			continue;
-		while (start < (char**)info->client_info.stack_end) {
+		while (start < (char**)info->client_info.info.stack_end) {
 			if (*start >= obj && *start < endobj)
-				SGEN_LOG (0, "Object %p referenced in thread %p (id %p) at %p, stack: %p-%p", obj, info, (gpointer)mono_thread_info_get_tid (info), start, info->client_info.stack_start, info->client_info.stack_end);
+				SGEN_LOG (0, "Object %p referenced in thread %p (id %p) at %p, stack: %p-%p", obj, info, (gpointer)mono_thread_info_get_tid (info), start, info->client_info.stack_start, info->client_info.info.stack_end);
 			start++;
 		}
 

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -2831,11 +2831,11 @@ sgen_get_current_collection_generation (void)
 }
 
 void*
-sgen_thread_register (SgenThreadInfo* info, void *stack_bottom_fallback)
+sgen_thread_register (SgenThreadInfo* info)
 {
 	info->tlab_start = info->tlab_next = info->tlab_temp_end = info->tlab_real_end = NULL;
 
-	sgen_client_thread_register (info, stack_bottom_fallback);
+	sgen_client_thread_register (info);
 
 	return info;
 }

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -2831,19 +2831,19 @@ sgen_get_current_collection_generation (void)
 }
 
 void*
-sgen_thread_register (SgenThreadInfo* info)
+sgen_thread_attach (SgenThreadInfo* info)
 {
 	info->tlab_start = info->tlab_next = info->tlab_temp_end = info->tlab_real_end = NULL;
 
-	sgen_client_thread_register (info);
+	sgen_client_thread_attach (info);
 
 	return info;
 }
 
 void
-sgen_thread_unregister (SgenThreadInfo *p)
+sgen_thread_detach_with_lock (SgenThreadInfo *p)
 {
-	sgen_client_thread_unregister (p);
+	sgen_client_thread_detach_with_lock (p);
 }
 
 /*

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -918,8 +918,8 @@ GCObject* sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size);
 
 /* Threads */
 
-void* sgen_thread_register (SgenThreadInfo* info);
-void sgen_thread_unregister (SgenThreadInfo *p);
+void* sgen_thread_attach (SgenThreadInfo* info);
+void sgen_thread_detach_with_lock (SgenThreadInfo *p);
 
 /* Finalization/ephemeron support */
 

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -918,7 +918,7 @@ GCObject* sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size);
 
 /* Threads */
 
-void* sgen_thread_register (SgenThreadInfo* info, void *addr);
+void* sgen_thread_register (SgenThreadInfo* info);
 void sgen_thread_unregister (SgenThreadInfo *p);
 
 /* Finalization/ephemeron support */

--- a/mono/unit-tests/test-conc-hashtable.c
+++ b/mono/unit-tests/test-conc-hashtable.c
@@ -69,7 +69,7 @@ static void*
 pw_sr_thread (void *arg)
 {
 	int i, idx = 1000 * GPOINTER_TO_INT (arg);
-	mono_thread_info_attach ((gpointer)&arg);
+	mono_thread_info_attach ();
 
 	for (i = 0; i < 1000; ++i) {
 		mono_os_mutex_lock (&global_mutex);
@@ -118,7 +118,7 @@ static void*
 pr_sw_thread (void *arg)
 {
 	int i = 0, idx = 100 * GPOINTER_TO_INT (arg);
-	mono_thread_info_attach ((gpointer)&arg);
+	mono_thread_info_attach ();
 
 	while (i < 100) {
 		gpointer res = mono_conc_hashtable_lookup (hash, GINT_TO_POINTER (i + idx + 1));
@@ -178,7 +178,7 @@ static void*
 pw_pr_r_thread (void *arg)
 {
 	int key, val, i;
-	mono_thread_info_attach ((gpointer)&arg);
+	mono_thread_info_attach ();
 
 	/* i will not be incremented as long as running is set to 1, this guarantee that
 	   we loop over all the keys at least once after the writer threads have finished */
@@ -200,7 +200,7 @@ pw_pr_w_add_thread (void *arg)
 {
 	int i, idx = 1000 * GPOINTER_TO_INT (arg);
 
-	mono_thread_info_attach ((gpointer)&arg);
+	mono_thread_info_attach ();
 
 	for (i = idx; i < idx + 1000; i++) {
 		mono_os_mutex_lock (&global_mutex);
@@ -215,7 +215,7 @@ pw_pr_w_del_thread (void *arg)
 {
 	int i, idx = 1000 * GPOINTER_TO_INT (arg);
 
-	mono_thread_info_attach ((gpointer)&arg);
+	mono_thread_info_attach ();
 
 	for (i = idx; i < idx + 1000; i++) {
 		mono_os_mutex_lock (&global_mutex);
@@ -340,7 +340,7 @@ main (void)
 	mono_w32handle_init ();
 #endif
 
-	mono_thread_info_attach ((gpointer)&cb);
+	mono_thread_info_attach ();
 
 	// benchmark_conc ();
 	// benchmark_glib ();

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -222,7 +222,7 @@ typedef struct {
 } MonoThreadInfo;
 
 typedef struct {
-	void* (*thread_register)(THREAD_INFO_TYPE *info, void *baseaddr);
+	void* (*thread_register)(THREAD_INFO_TYPE *info);
 	/*
 	This callback is called with @info still on the thread list.
 	This call is made while holding the suspend lock, so don't do callbacks.
@@ -314,7 +314,7 @@ int
 mono_thread_info_register_small_id (void);
 
 THREAD_INFO_TYPE *
-mono_thread_info_attach (void *baseptr);
+mono_thread_info_attach (void);
 
 MONO_API void
 mono_thread_info_detach (void);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -222,22 +222,21 @@ typedef struct {
 } MonoThreadInfo;
 
 typedef struct {
-	void* (*thread_register)(THREAD_INFO_TYPE *info);
+	void* (*thread_attach)(THREAD_INFO_TYPE *info);
+	/*
+	This callback is called right before thread_detach_with_lock. This is called
+	without any locks held so it's the place for complicated cleanup.
+
+	The thread must remain operational between this call and thread_detach_with_lock.
+	It must be possible to successfully suspend it after thread_detach completes.
+	*/
+	void (*thread_detach)(THREAD_INFO_TYPE *info);
 	/*
 	This callback is called with @info still on the thread list.
 	This call is made while holding the suspend lock, so don't do callbacks.
 	SMR remains functional as its small_id has not been reclaimed.
 	*/
-	void (*thread_unregister)(THREAD_INFO_TYPE *info);
-	/*
-	This callback is called right before thread_unregister. This is called
-	without any locks held so it's the place for complicated cleanup.
-
-	The thread must remain operational between this call and thread_unregister.
-	It must be possible to successfully suspend it after thread_unregister completes.
-	*/
-	void (*thread_detach)(THREAD_INFO_TYPE *info);
-	void (*thread_attach)(THREAD_INFO_TYPE *info);
+	void (*thread_detach_with_lock)(THREAD_INFO_TYPE *info);
 	gboolean (*mono_method_is_critical) (void *method);
 	gboolean (*ip_in_critical_region) (MonoDomain *domain, gpointer ip);
 	gboolean (*mono_thread_in_critical_region) (THREAD_INFO_TYPE *info);


### PR DESCRIPTION
We now have only 3 callbacks for thread attach/detach lifecycle:

 - attach: called before the thread is added to the list of runtime threads
 - detach: called before the thread is removed from the list of runtime threads (note: the thread still needs to be valid, as it may still be suspended)
 - detach_with_lock: called while holding the suspend_lock