### PR TITLE
[threads] Store MonoInternalThread in MonoThreadInfo for use when detaching

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -2038,7 +2038,7 @@ main (int argc, char *argv [])
 #ifndef HOST_WIN32
 	mono_w32handle_init ();
 #endif
-	mono_threads_runtime_init (&ticallbacks);
+	mono_thread_info_runtime_init (&ticallbacks);
 
 	mono_install_assembly_load_hook (monodis_assembly_load_hook, NULL);
 	mono_install_assembly_search_hook (monodis_assembly_search_hook, NULL);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -241,7 +241,7 @@ mono_gc_base_init (void)
 	cb.thread_attach = boehm_thread_attach;
 	cb.thread_detach = boehm_thread_detach;
 	cb.thread_detach_with_lock = boehm_thread_detach_with_lock;
-	cb.mono_method_is_critical = (gboolean (*)(void *))mono_runtime_is_critical_method;
+	cb.method_is_critical = (gboolean (*)(void *))mono_runtime_is_critical_method;
 
 	mono_threads_init (&cb, sizeof (MonoThreadInfo));
 	mono_os_mutex_init (&mono_gc_lock);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -243,7 +243,7 @@ mono_gc_base_init (void)
 	cb.thread_detach_with_lock = boehm_thread_detach_with_lock;
 	cb.method_is_critical = (gboolean (*)(void *))mono_runtime_is_critical_method;
 
-	mono_threads_init (&cb, sizeof (MonoThreadInfo));
+	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
 	mono_os_mutex_init (&mono_gc_lock);
 	mono_os_mutex_init_recursive (&handle_section);
 

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -241,7 +241,6 @@ mono_gc_base_init (void)
 	cb.thread_attach = boehm_thread_attach;
 	cb.thread_detach = boehm_thread_detach;
 	cb.thread_detach_with_lock = boehm_thread_detach_with_lock;
-	cb.method_is_critical = (gboolean (*)(void *))mono_runtime_is_critical_method;
 
 	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
 	mono_os_mutex_init (&mono_gc_lock);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -56,12 +56,6 @@ void *pthread_get_stackaddr_np(pthread_t);
 static gboolean gc_initialized = FALSE;
 static mono_mutex_t mono_gc_lock;
 
-static void*
-boehm_thread_attach (MonoThreadInfo* info);
-static void
-boehm_thread_detach_with_lock (MonoThreadInfo *p);
-static void
-boehm_thread_detach (MonoThreadInfo *p);
 static void
 register_test_toggleref_callback (void);
 
@@ -108,7 +102,6 @@ static void on_gc_heap_resize (size_t new_size);
 void
 mono_gc_base_init (void)
 {
-	MonoThreadInfoCallbacks cb;
 	const char *env;
 
 	if (gc_initialized)
@@ -237,12 +230,8 @@ mono_gc_base_init (void)
 		g_strfreev (opts);
 	}
 
-	memset (&cb, 0, sizeof (cb));
-	cb.thread_attach = boehm_thread_attach;
-	cb.thread_detach = boehm_thread_detach;
-	cb.thread_detach_with_lock = boehm_thread_detach_with_lock;
-
-	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
+	mono_thread_callbacks_init ();
+	mono_thread_info_init (sizeof (MonoThreadInfo));
 	mono_os_mutex_init (&mono_gc_lock);
 	mono_os_mutex_init_recursive (&handle_section);
 
@@ -374,8 +363,8 @@ mono_gc_is_gc_thread (void)
 	return GC_thread_is_registered ();
 }
 
-static void*
-boehm_thread_attach (MonoThreadInfo* info)
+gpointer
+mono_gc_thread_attach (MonoThreadInfo* info)
 {
 	struct GC_stack_base sb;
 	int res;
@@ -391,8 +380,8 @@ boehm_thread_attach (MonoThreadInfo* info)
 	return info;
 }
 
-static void
-boehm_thread_detach_with_lock (MonoThreadInfo *p)
+void
+mono_gc_thread_detach_with_lock (MonoThreadInfo *p)
 {
 	MonoNativeThreadId tid;
 
@@ -404,11 +393,10 @@ boehm_thread_detach_with_lock (MonoThreadInfo *p)
 	mono_handle_stack_free (p->handle_stack);
 }
 
-static void
-boehm_thread_detach (MonoThreadInfo *p)
+gboolean
+mono_gc_thread_in_critical_region (MonoThreadInfo *info)
 {
-	if (mono_thread_internal_current_is_attached ())
-		mono_thread_detach_internal (mono_thread_internal_current ());
+	return FALSE;
 }
 
 gboolean

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -351,6 +351,12 @@ void mono_gc_register_altstack (gpointer stack, gint32 stack_size, gpointer alts
 
 gboolean mono_gc_is_critical_method (MonoMethod *method);
 
+gpointer mono_gc_thread_attach (THREAD_INFO_TYPE *info);
+
+void mono_gc_thread_detach_with_lock (THREAD_INFO_TYPE *info);
+
+gboolean mono_gc_thread_in_critical_region (THREAD_INFO_TYPE *info);
+
 /* If set, print debugging messages around finalizers. */
 extern gboolean log_finalizers;
 

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -34,7 +34,7 @@ mono_gc_base_init (void)
 	/* TODO: This casts away an incompatible pointer type warning in the same
 	         manner that boehm-gc does it. This is probably worth investigating
 	         more carefully. */
-	cb.mono_method_is_critical = (gpointer)mono_runtime_is_critical_method;
+	cb.method_is_critical = (gpointer)mono_runtime_is_critical_method;
 
 	mono_threads_init (&cb, sizeof (MonoThreadInfo));
 

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -36,7 +36,7 @@ mono_gc_base_init (void)
 	         more carefully. */
 	cb.method_is_critical = (gpointer)mono_runtime_is_critical_method;
 
-	mono_threads_init (&cb, sizeof (MonoThreadInfo));
+	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
 
 	mono_thread_info_attach ();
 }

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -31,10 +31,6 @@ mono_gc_base_init (void)
 #endif
 
 	memset (&cb, 0, sizeof (cb));
-	/* TODO: This casts away an incompatible pointer type warning in the same
-	         manner that boehm-gc does it. This is probably worth investigating
-	         more carefully. */
-	cb.method_is_critical = (gpointer)mono_runtime_is_critical_method;
 
 	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
 

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -22,17 +22,14 @@
 void
 mono_gc_base_init (void)
 {
-	MonoThreadInfoCallbacks cb;
-
 	mono_counters_init ();
 
 #ifndef HOST_WIN32
 	mono_w32handle_init ();
 #endif
 
-	memset (&cb, 0, sizeof (cb));
-
-	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
+	mono_thread_callbacks_init ();
+	mono_thread_info_init (sizeof (MonoThreadInfo));
 
 	mono_thread_info_attach ();
 }
@@ -288,6 +285,23 @@ mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
 
 gboolean
 mono_gc_is_critical_method (MonoMethod *method)
+{
+	return FALSE;
+}
+
+gpointer
+mono_gc_thread_attach (MonoThreadInfo* info)
+{
+	return info;
+}
+
+void
+mono_gc_thread_detach_with_lock (MonoThreadInfo *p)
+{
+}
+
+gboolean
+mono_gc_thread_in_critical_region (MonoThreadInfo *info)
 {
 	return FALSE;
 }

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -114,13 +114,6 @@ mono_runtime_try_shutdown (void)
 	return TRUE;
 }
 
-
-gboolean
-mono_runtime_is_critical_method (MonoMethod *method)
-{
-	return FALSE;
-}
-
 /*
 Coordinate the creation of all remaining TLS slots in the runtime.
 No further TLS slots should be created after this function finishes.

--- a/mono/metadata/runtime.h
+++ b/mono/metadata/runtime.h
@@ -18,7 +18,6 @@
 
 MONO_BEGIN_DECLS
 
-gboolean mono_runtime_is_critical_method (MonoMethod *method);
 gboolean mono_runtime_try_shutdown (void);
 
 void mono_runtime_init_tls (void);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -236,7 +236,7 @@ ip_in_critical_region (MonoDomain *domain, gpointer ip)
 
 	method = mono_jit_info_get_method (ji);
 
-	return mono_runtime_is_critical_method (method) || sgen_is_critical_method (method);
+	return sgen_is_critical_method (method);
 }
 
 gboolean

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2862,7 +2862,7 @@ sgen_client_init (void)
 	cb.thread_attach = sgen_thread_attach;
 	cb.thread_detach = sgen_thread_detach;
 	cb.thread_detach_with_lock = sgen_thread_detach_with_lock;
-	cb.mono_thread_in_critical_region = thread_in_critical_region;
+	cb.thread_in_critical_region = thread_in_critical_region;
 	cb.ip_in_critical_region = ip_in_critical_region;
 
 	mono_threads_init (&cb, sizeof (SgenThreadInfo));

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2865,7 +2865,7 @@ sgen_client_init (void)
 	cb.thread_in_critical_region = thread_in_critical_region;
 	cb.ip_in_critical_region = ip_in_critical_region;
 
-	mono_threads_init (&cb, sizeof (SgenThreadInfo));
+	mono_thread_info_init (&cb, sizeof (SgenThreadInfo));
 
 	///* Keep this the default for now */
 	/* Precise marking is broken on all supported targets. Disable until fixed. */

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -219,26 +219,6 @@ sgen_has_critical_method (void)
 	return sgen_has_managed_allocator ();
 }
 
-static gboolean
-ip_in_critical_region (MonoDomain *domain, gpointer ip)
-{
-	MonoJitInfo *ji;
-	MonoMethod *method;
-
-	/*
-	 * We pass false for 'try_aot' so this becomes async safe.
-	 * It won't find aot methods whose jit info is not yet loaded,
-	 * so we preload their jit info in the JIT.
-	 */
-	ji = mono_jit_info_table_find_internal (domain, ip, FALSE, FALSE);
-	if (!ji)
-		return FALSE;
-
-	method = mono_jit_info_get_method (ji);
-
-	return sgen_is_critical_method (method);
-}
-
 gboolean
 mono_gc_is_critical_method (MonoMethod *method)
 {
@@ -2208,6 +2188,12 @@ mono_gc_get_gc_callbacks ()
 	return &gc_callbacks;
 }
 
+gpointer
+mono_gc_thread_attach (SgenThreadInfo *info)
+{
+	return sgen_thread_attach (info);
+}
+
 void
 sgen_client_thread_attach (SgenThreadInfo* info)
 {
@@ -2232,6 +2218,12 @@ sgen_client_thread_attach (SgenThreadInfo* info)
 	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)mono_thread_info_get_tid (info), info->client_info.info.stack_end);
 
 	info->client_info.info.handle_stack = mono_handle_stack_alloc ();
+}
+
+void
+mono_gc_thread_detach_with_lock (SgenThreadInfo *info)
+{
+	return sgen_thread_detach_with_lock (info);
 }
 
 void
@@ -2277,23 +2269,10 @@ mono_gc_set_skip_thread (gboolean skip)
 	}
 }
 
-static gboolean
-thread_in_critical_region (SgenThreadInfo *info)
+gboolean
+mono_gc_thread_in_critical_region (SgenThreadInfo *info)
 {
 	return info->client_info.in_critical_region;
-}
-
-static void
-sgen_thread_detach (SgenThreadInfo *p)
-{
-	/* If a delegate is passed to native code and invoked on a thread we dont
-	 * know about, marshal will register it with mono_threads_attach_coop, but
-	 * we have no way of knowing when that thread goes away.  SGen has a TSD
-	 * so we assume that if the domain is still registered, we can detach
-	 * the thread
-	 */
-	if (mono_thread_internal_current_is_attached ())
-		mono_thread_detach_internal (mono_thread_internal_current ());
 }
 
 /**
@@ -2857,15 +2836,8 @@ sgen_client_vtable_get_name (MonoVTable *vt)
 void
 sgen_client_init (void)
 {
-	MonoThreadInfoCallbacks cb;
-
-	cb.thread_attach = sgen_thread_attach;
-	cb.thread_detach = sgen_thread_detach;
-	cb.thread_detach_with_lock = sgen_thread_detach_with_lock;
-	cb.thread_in_critical_region = thread_in_critical_region;
-	cb.ip_in_critical_region = ip_in_critical_region;
-
-	mono_thread_info_init (&cb, sizeof (SgenThreadInfo));
+	mono_thread_callbacks_init ();
+	mono_thread_info_init (sizeof (SgenThreadInfo));
 
 	///* Keep this the default for now */
 	/* Precise marking is broken on all supported targets. Disable until fixed. */

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -59,6 +59,9 @@ typedef void (*MonoThreadCleanupFunc) (MonoNativeThreadId tid);
 /* INFO has type MonoThreadInfo* */
 typedef void (*MonoThreadNotifyPendingExcFunc) (gpointer info);
 
+void
+mono_thread_callbacks_init (void);
+
 typedef enum {
 	MONO_THREAD_CREATE_FLAGS_NONE         = 0x0,
 	MONO_THREAD_CREATE_FLAGS_THREADPOOL   = 0x1,

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -239,9 +239,6 @@ void mono_threads_perform_thread_dump (void);
 gboolean
 mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, MonoError *error);
 
-MonoThread *
-mono_thread_attach_full (MonoDomain *domain, gboolean force_attach);
-
 /* Can't include utils/mono-threads.h because of the THREAD_INFO_TYPE wizardry */
 void mono_threads_add_joinable_thread (gpointer tid);
 void mono_threads_join_threads (void);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1077,18 +1077,7 @@ mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, Mon
 	return (NULL != mono_thread_create_internal (domain, func, arg, MONO_THREAD_CREATE_FLAGS_NONE, error));
 }
 
-/**
- * mono_thread_attach:
- */
-MonoThread *
-mono_thread_attach (MonoDomain *domain)
-{
-	MonoThread *thread = mono_thread_attach_full (domain, FALSE);
-
-	return thread;
-}
-
-MonoThread *
+static MonoThread *
 mono_thread_attach_full (MonoDomain *domain, gboolean force_attach)
 {
 	MonoInternalThread *internal;
@@ -1129,6 +1118,15 @@ mono_thread_attach_full (MonoDomain *domain, gboolean force_attach)
 		mono_profiler_thread_start (MONO_NATIVE_THREAD_ID_TO_UINT (tid));
 
 	return thread;
+}
+
+/**
+ * mono_thread_attach:
+ */
+MonoThread *
+mono_thread_attach (MonoDomain *domain)
+{
+	return mono_thread_attach_full (domain, FALSE);
 }
 
 void

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2081,7 +2081,7 @@ lookup_start:
 		if ((code = mono_aot_get_method_checked (domain, method, error))) {
 			MonoVTable *vtable;
 
-			if (mono_runtime_is_critical_method (method) || mono_gc_is_critical_method (method)) {
+			if (mono_gc_is_critical_method (method)) {
 				/*
 				 * The suspend code needs to be able to lookup these methods by ip in async context,
 				 * so preload their jit info.

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3852,7 +3852,7 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_w32handle_init ();
 #endif
 
-	mono_threads_runtime_init (&ticallbacks);
+	mono_thread_info_runtime_init (&ticallbacks);
 
 	if (g_hasenv ("MONO_DEBUG")) {
 		mini_parse_debug_options ();
@@ -3917,7 +3917,7 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_set_generic_sharing_supported (TRUE);
 #endif
 
-	mono_threads_signals_init ();
+	mono_thread_info_signals_init ();
 
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_install_handlers ();

--- a/mono/unit-tests/test-conc-hashtable.c
+++ b/mono/unit-tests/test-conc-hashtable.c
@@ -332,10 +332,10 @@ main (void)
 	int res = 0;
 
 	CHECKED_MONO_INIT ();
-	mono_threads_init (&cb, sizeof (MonoThreadInfo));
+	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
 	memset (&ticallbacks, 0, sizeof (ticallbacks));
 	ticallbacks.thread_state_init = thread_state_init;
-	mono_threads_runtime_init (&ticallbacks);
+	mono_thread_info_runtime_init (&ticallbacks);
 #ifndef HOST_WIN32
 	mono_w32handle_init ();
 #endif

--- a/mono/unit-tests/test-conc-hashtable.c
+++ b/mono/unit-tests/test-conc-hashtable.c
@@ -327,12 +327,11 @@ thread_state_init (MonoThreadUnwindState *ctx)
 int
 main (void)
 {
-	MonoThreadInfoCallbacks cb = { NULL };
 	MonoThreadInfoRuntimeCallbacks ticallbacks;
 	int res = 0;
 
 	CHECKED_MONO_INIT ();
-	mono_thread_info_init (&cb, sizeof (MonoThreadInfo));
+	mono_thread_info_init (sizeof (MonoThreadInfo));
 	memset (&ticallbacks, 0, sizeof (ticallbacks));
 	ticallbacks.thread_state_init = thread_state_init;
 	mono_thread_info_runtime_init (&ticallbacks);

--- a/mono/unit-tests/test-mono-linked-list-set.c
+++ b/mono/unit-tests/test-mono-linked-list-set.c
@@ -116,15 +116,12 @@ int
 main (int argc, char *argv [])
 {
 	int primes [] = { 1, 2, 3, 5, 7, 11, 13, 17 };
-	MonoThreadInfoCallbacks thread_callbacks;
 	thread_data_t thread_data [NUM_THREADS];
 	int i;
 
-	memset (&thread_callbacks, 0, sizeof (thread_callbacks));
-
 	mono_metadata_init ();
 
-	mono_thread_info_init (&thread_callbacks, 0);
+	mono_thread_info_init (0);
 
 	mono_lls_init (&lls, free_node);
 

--- a/mono/unit-tests/test-mono-linked-list-set.c
+++ b/mono/unit-tests/test-mono-linked-list-set.c
@@ -124,7 +124,7 @@ main (int argc, char *argv [])
 
 	mono_metadata_init ();
 
-	mono_threads_init (&thread_callbacks, 0);
+	mono_thread_info_init (&thread_callbacks, 0);
 
 	mono_lls_init (&lls, free_node);
 

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -380,6 +380,8 @@ register_thread (MonoThreadInfo *info)
 
 	info->stackdata = g_byte_array_new ();
 
+	info->internal_thread_gchandle = G_MAXUINT32;
+
 	mono_threads_suspend_register (info);
 
 	THREADS_DEBUG ("registering info %p tid %p small id %x\n", info, mono_thread_info_get_tid (info), info->small_id);
@@ -652,6 +654,33 @@ mono_thread_info_detach (void)
 		THREADS_DEBUG ("detaching %p\n", info);
 		unregister_thread (info);
 	}
+}
+
+gboolean
+mono_thread_info_try_get_internal_thread_gchandle (MonoThreadInfo *info, guint32 *gchandle)
+{
+	g_assert (info);
+
+	if (info->internal_thread_gchandle == G_MAXUINT32)
+		return FALSE;
+
+	*gchandle = info->internal_thread_gchandle;
+	return TRUE;
+}
+
+void
+mono_thread_info_set_internal_thread_gchandle (MonoThreadInfo *info, guint32 gchandle)
+{
+	g_assert (info);
+	g_assert (gchandle != G_MAXUINT32);
+	info->internal_thread_gchandle = gchandle;
+}
+
+void
+mono_thread_info_unset_internal_thread_gchandle (THREAD_INFO_TYPE *info)
+{
+	g_assert (info);
+	info->internal_thread_gchandle = G_MAXUINT32;
 }
 
 /*

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -610,7 +610,7 @@ mono_thread_info_attach (void)
 	{
 		/* This can happen from DllMain(DLL_THREAD_ATTACH) on Windows, if a
 		 * thread is created before an embedding API user initialized Mono. */
-		THREADS_DEBUG ("mono_thread_info_attach called before mono_threads_init\n");
+		THREADS_DEBUG ("mono_thread_info_attach called before mono_thread_info_init\n");
 		return NULL;
 	}
 #endif
@@ -640,7 +640,7 @@ mono_thread_info_detach (void)
 	{
 		/* This can happen from DllMain(THREAD_DETACH) on Windows, if a thread
 		 * is created before an embedding API user initialized Mono. */
-		THREADS_DEBUG ("mono_thread_info_detach called before mono_threads_init\n");
+		THREADS_DEBUG ("mono_thread_info_detach called before mono_thread_info_init\n");
 		return;
 	}
 #endif
@@ -685,7 +685,7 @@ thread_info_key_dtor (void *arg)
 #endif
 
 void
-mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
+mono_thread_info_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 {
 	gboolean res;
 	threads_callbacks = *callbacks;
@@ -737,13 +737,13 @@ mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 }
 
 void
-mono_threads_signals_init (void)
+mono_thread_info_signals_init (void)
 {
 	mono_threads_suspend_init_signals ();
 }
 
 void
-mono_threads_runtime_init (MonoThreadInfoRuntimeCallbacks *callbacks)
+mono_thread_info_runtime_init (MonoThreadInfoRuntimeCallbacks *callbacks)
 {
 	runtime_callbacks = *callbacks;
 }

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -685,10 +685,9 @@ thread_info_key_dtor (void *arg)
 #endif
 
 void
-mono_thread_info_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
+mono_thread_info_init (size_t info_size)
 {
 	gboolean res;
-	threads_callbacks = *callbacks;
 	thread_info_size = info_size;
 	char *sleepLimit;
 #ifdef HOST_WIN32
@@ -734,6 +733,12 @@ mono_thread_info_init (MonoThreadInfoCallbacks *callbacks, size_t info_size)
 	mono_threads_inited = TRUE;
 
 	g_assert (sizeof (MonoNativeThreadId) <= sizeof (uintptr_t));
+}
+
+void
+mono_thread_info_callbacks_init (MonoThreadInfoCallbacks *callbacks)
+{
+	threads_callbacks = *callbacks;
 }
 
 void

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -841,8 +841,6 @@ WB trampoline. Another option is to encode wb ranges in MonoJitInfo, but that is
 static gboolean
 is_thread_in_critical_region (MonoThreadInfo *info)
 {
-	MonoMethod *method;
-	MonoJitInfo *ji;
 	gpointer stack_start;
 	MonoThreadUnwindState *state;
 
@@ -871,16 +869,7 @@ is_thread_in_critical_region (MonoThreadInfo *info)
 	if (threads_callbacks.ip_in_critical_region)
 		return threads_callbacks.ip_in_critical_region ((MonoDomain *) state->unwind_data [MONO_UNWIND_DATA_DOMAIN], (char *) MONO_CONTEXT_GET_IP (&state->ctx));
 
-	ji = mono_jit_info_table_find (
-		(MonoDomain *) state->unwind_data [MONO_UNWIND_DATA_DOMAIN],
-		(char *) MONO_CONTEXT_GET_IP (&state->ctx));
-
-	if (!ji)
-		return FALSE;
-
-	method = mono_jit_info_get_method (ji);
-
-	return threads_callbacks.method_is_critical (method);
+	return FALSE;
 }
 
 gboolean

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -854,7 +854,7 @@ is_thread_in_critical_region (MonoThreadInfo *info)
 		return TRUE;
 
 	/* Are we inside a GC critical region? */
-	if (threads_callbacks.mono_thread_in_critical_region && threads_callbacks.mono_thread_in_critical_region (info)) {
+	if (threads_callbacks.thread_in_critical_region && threads_callbacks.thread_in_critical_region (info)) {
 		return TRUE;
 	}
 
@@ -880,7 +880,7 @@ is_thread_in_critical_region (MonoThreadInfo *info)
 
 	method = mono_jit_info_get_method (ji);
 
-	return threads_callbacks.mono_method_is_critical (method);
+	return threads_callbacks.method_is_critical (method);
 }
 
 gboolean

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -237,7 +237,6 @@ typedef struct {
 	SMR remains functional as its small_id has not been reclaimed.
 	*/
 	void (*thread_detach_with_lock)(THREAD_INFO_TYPE *info);
-	gboolean (*method_is_critical) (void *method);
 	gboolean (*ip_in_critical_region) (MonoDomain *domain, gpointer ip);
 	gboolean (*thread_in_critical_region) (THREAD_INFO_TYPE *info);
 } MonoThreadInfoCallbacks;

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -219,6 +219,9 @@ typedef struct {
 
 	/* Stack mark for targets that explicitly require one */
 	gpointer stack_mark;
+
+	/* GCHandle to MonoInternalThread */
+	guint32 internal_thread_gchandle;
 } MonoThreadInfo;
 
 typedef struct {
@@ -319,6 +322,15 @@ mono_thread_info_attach (void);
 
 MONO_API void
 mono_thread_info_detach (void);
+
+gboolean
+mono_thread_info_try_get_internal_thread_gchandle (THREAD_INFO_TYPE *info, guint32 *gchandle);
+
+void
+mono_thread_info_set_internal_thread_gchandle (THREAD_INFO_TYPE *info, guint32 gchandle);
+
+void
+mono_thread_info_unset_internal_thread_gchandle (THREAD_INFO_TYPE *info);
 
 gboolean
 mono_thread_info_is_exiting (void);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -297,7 +297,10 @@ mono_thread_info_set_tid (THREAD_INFO_TYPE *info, MonoNativeThreadId tid)
  * a single block with info from both camps. 
  */
 void
-mono_thread_info_init (MonoThreadInfoCallbacks *callbacks, size_t thread_info_size);
+mono_thread_info_init (size_t thread_info_size);
+
+void
+mono_thread_info_callbacks_init (MonoThreadInfoCallbacks *callbacks);
 
 void
 mono_thread_info_signals_init (void);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -298,13 +298,13 @@ mono_thread_info_set_tid (THREAD_INFO_TYPE *info, MonoNativeThreadId tid)
  * a single block with info from both camps. 
  */
 void
-mono_threads_init (MonoThreadInfoCallbacks *callbacks, size_t thread_info_size);
+mono_thread_info_init (MonoThreadInfoCallbacks *callbacks, size_t thread_info_size);
 
 void
-mono_threads_signals_init (void);
+mono_thread_info_signals_init (void);
 
 void
-mono_threads_runtime_init (MonoThreadInfoRuntimeCallbacks *callbacks);
+mono_thread_info_runtime_init (MonoThreadInfoRuntimeCallbacks *callbacks);
 
 MonoThreadInfoRuntimeCallbacks *
 mono_threads_get_runtime_callbacks (void);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -237,9 +237,9 @@ typedef struct {
 	SMR remains functional as its small_id has not been reclaimed.
 	*/
 	void (*thread_detach_with_lock)(THREAD_INFO_TYPE *info);
-	gboolean (*mono_method_is_critical) (void *method);
+	gboolean (*method_is_critical) (void *method);
 	gboolean (*ip_in_critical_region) (MonoDomain *domain, gpointer ip);
-	gboolean (*mono_thread_in_critical_region) (THREAD_INFO_TYPE *info);
+	gboolean (*thread_in_critical_region) (THREAD_INFO_TYPE *info);
 } MonoThreadInfoCallbacks;
 
 typedef struct {

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -671,7 +671,7 @@ main (int argc, char *argv [])
 #ifndef HOST_WIN32
 	mono_w32handle_init ();
 #endif
-	mono_threads_runtime_init (&ticallbacks);
+	mono_thread_info_runtime_init (&ticallbacks);
 
 	mono_metadata_init ();
 	mono_images_init ();


### PR DESCRIPTION
When the native thread would exit, the TLS keys are destroyed. There is a TLS destructor for MonoThreadInfo, but not for MonoInternalThread. If MonoInternalThread is destroyed before MonoThreadInfo, then MonoThreadInfoCallbacks.thread_detach wouldn't successfully detach the current MonoInternalThread as mono_thread_internal_current would return NULL. This would lead to MonoInternalThread still laying around, while their corresponding MonoThreadInfo has already been destroyed. This fixes this problem, since we now rely on MonoThreadInfo to store the MonoInternalThread for detach.