### PR TITLE
[btls] Fix a small memleak in btls-x509-lookup.c

### DIFF
--- a/mono/btls/btls-x509-lookup.c
+++ b/mono/btls/btls-x509-lookup.c
@@ -48,8 +48,10 @@ mono_btls_x509_lookup_new (MonoBtlsX509Store *store, MonoBtlsX509LookupType type
 		return NULL;
 
 	store_lookup = X509_STORE_add_lookup (mono_btls_x509_store_peek_store (store), method);
-	if (!store_lookup)
+	if (!store_lookup) {
+		OPENSSL_free (lookup);
 		return NULL;
+	}
 
 	memset (lookup, 0, sizeof(MonoBtlsX509Lookup));
 	// The X509_STORE owns the X509_LOOKUP.


### PR DESCRIPTION
Noticed this while looking at the Clang Analysis Report[1] as the only memory leak in the report and thought why not fix it :)

[1] https://jenkins.mono-project.com/job/test-mono-mainline-staticanalysis/Clang_Analysis_Report/