### PR TITLE
[coop handles] Implement various SetValue methods

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -552,6 +552,16 @@ mono_string_handle_pin_chars (MonoStringHandle handle, uint32_t *gchandle)
 	return mono_string_chars (raw);
 }
 
+gpointer
+mono_object_handle_pin_unbox (MonoObjectHandle obj, uint32_t *gchandle)
+{
+	g_assert (!MONO_HANDLE_IS_NULL (obj));
+	MonoClass *klass = mono_handle_class (obj);
+	g_assert (klass->valuetype);
+	*gchandle = mono_gchandle_from_handle (obj, TRUE);
+	return mono_object_unbox (MONO_HANDLE_RAW (obj));
+}
+
 void
 mono_array_handle_memcpy_refs (MonoArrayHandle dest, uintptr_t dest_idx, MonoArrayHandle src, uintptr_t src_idx, uintptr_t len)
 {

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -497,6 +497,9 @@ mono_array_handle_pin_with_size (MonoArrayHandle handle, int size, uintptr_t ind
 gunichar2 *
 mono_string_handle_pin_chars (MonoStringHandle s, uint32_t *gchandle_out);
 
+gpointer
+mono_object_handle_pin_unbox (MonoObjectHandle boxed_valuetype_obj, uint32_t *gchandle_out);
+
 void
 mono_error_set_exception_handle (MonoError *error, MonoExceptionHandle exc);
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -423,6 +423,13 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 		*(TYPE*)(mono_handle_unsafe_field_addr (__obj, __field)) = __value; \
 	} while (0)
 
+#define MONO_HANDLE_SET_FIELD_REF(HANDLE,FIELD,VALH) do {		\
+		MonoObjectHandle __obj = MONO_HANDLE_CAST (MonoObject, (HANDLE)); \
+		MonoClassField *__field = (FIELD);			\
+		MonoObjectHandle __value = MONO_HANDLE_CAST (MonoObject, (VALH)); \
+		mono_gc_wbarrier_generic_store (mono_handle_unsafe_field_addr (__obj, __field), MONO_HANDLE_RAW (__value)); \
+	} while (0)
+
 /* Baked typed handles we all want */
 TYPED_HANDLE_DECL (MonoString);
 TYPED_HANDLE_DECL (MonoArray);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -612,7 +612,7 @@ HANDLES(ICALL(MFIELD_2, "GetParentType", ves_icall_MonoField_GetParentType))
 ICALL(MFIELD_5, "GetRawConstantValue", ves_icall_MonoField_GetRawConstantValue)
 ICALL(MFIELD_3, "GetValueInternal", ves_icall_MonoField_GetValueInternal)
 HANDLES(ICALL(MFIELD_6, "ResolveType", ves_icall_MonoField_ResolveType))
-ICALL(MFIELD_4, "SetValueInternal", ves_icall_MonoField_SetValueInternal)
+HANDLES(ICALL(MFIELD_4, "SetValueInternal", ves_icall_MonoField_SetValueInternal))
 ICALL(MFIELD_7, "get_core_clr_security_level", ves_icall_MonoField_get_core_clr_security_level)
 
 ICALL_TYPE(MMETH, "System.Reflection.MonoMethod", MMETH_2)
@@ -763,7 +763,7 @@ ICALL(RVH_1, "GetRuntimeId", ves_icall_System_Runtime_Versioning_VersioningHelpe
 
 ICALL_TYPE(RFH, "System.RuntimeFieldHandle", RFH_1)
 ICALL(RFH_1, "SetValueDirect", ves_icall_System_RuntimeFieldHandle_SetValueDirect)
-ICALL(RFH_2, "SetValueInternal", ves_icall_MonoField_SetValueInternal)
+HANDLES(ICALL(RFH_2, "SetValueInternal", ves_icall_MonoField_SetValueInternal))
 
 ICALL_TYPE(MHAN, "System.RuntimeMethodHandle", MHAN_1)
 HANDLES(ICALL(MHAN_1, "GetFunctionPointer", ves_icall_RuntimeMethodHandle_GetFunctionPointer))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -158,7 +158,7 @@ ICALL(ARRAY_8, "GetRank",          ves_icall_System_Array_GetRank)
 ICALL(ARRAY_9, "GetValue",         ves_icall_System_Array_GetValue)
 ICALL(ARRAY_10, "GetValueImpl",     ves_icall_System_Array_GetValueImpl)
 ICALL(ARRAY_11, "SetGenericValueImpl", ves_icall_System_Array_SetGenericValueImpl)
-ICALL(ARRAY_12, "SetValue",         ves_icall_System_Array_SetValue)
+HANDLES(ICALL(ARRAY_12, "SetValue",         ves_icall_System_Array_SetValue))
 HANDLES(ICALL(ARRAY_13, "SetValueImpl",     ves_icall_System_Array_SetValueImpl))
 
 ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -159,7 +159,7 @@ ICALL(ARRAY_9, "GetValue",         ves_icall_System_Array_GetValue)
 ICALL(ARRAY_10, "GetValueImpl",     ves_icall_System_Array_GetValueImpl)
 ICALL(ARRAY_11, "SetGenericValueImpl", ves_icall_System_Array_SetGenericValueImpl)
 ICALL(ARRAY_12, "SetValue",         ves_icall_System_Array_SetValue)
-ICALL(ARRAY_13, "SetValueImpl",     ves_icall_System_Array_SetValueImpl)
+HANDLES(ICALL(ARRAY_13, "SetValueImpl",     ves_icall_System_Array_SetValueImpl))
 
 ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)
 ICALL(BUFFER_1, "InternalBlockCopy", ves_icall_System_Buffer_BlockCopyInternal)

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1594,6 +1594,9 @@ mono_get_addr_from_ftnptr (gpointer descr);
 void
 mono_nullable_init (guint8 *buf, MonoObject *value, MonoClass *klass);
 
+void
+mono_nullable_init_from_handle (guint8 *buf, MonoObjectHandle value, MonoClass *klass);
+
 MonoObject *
 mono_value_box_checked (MonoDomain *domain, MonoClass *klass, void* val, MonoError *error);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -160,6 +160,19 @@ struct _MonoString {
 		mono_gc_wbarrier_arrayref_copy (__p, __s, (count));	\
 	} while (0)
 
+static inline gboolean
+mono_handle_array_has_bounds (MonoArrayHandle arr)
+{
+	return MONO_HANDLE_GETVAL (arr, bounds) != NULL;
+}
+
+static inline void
+mono_handle_array_get_bounds_dim (MonoArrayHandle arr, gint32 dim, MonoArrayBounds *bounds)
+{
+	MonoArrayBounds *src = MONO_HANDLE_GETVAL (arr, bounds);
+	memcpy (bounds, &src[dim], sizeof (MonoArrayBounds));
+}
+
 
 typedef struct {
 	MonoObject obj;

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -129,6 +129,9 @@ mono_error_set_exception_instance (MonoError *error, MonoException *exc);
 void
 mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
+void
+mono_error_set_invalid_cast (MonoError *oerror);
+
 MonoException*
 mono_error_prepare_exception (MonoError *error, MonoError *error_out);
 

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -470,6 +470,17 @@ mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...)
 	set_error_message ();
 }
 
+/**
+ * mono_error_set_invalid_cast:
+ *
+ * System.InvalidCastException
+ */
+void
+mono_error_set_invalid_cast (MonoError *oerror)
+{
+        mono_error_set_generic_error (oerror, "System", "InvalidCastException", "");
+}
+
 void
 mono_error_set_exception_instance (MonoError *oerror, MonoException *exc)
 {


### PR DESCRIPTION
Use coop handles in these 3 icalls:

* `System.Array.SetValue (object, int[])`
* `System.Array.SetValueImpl (object, int)`
* `System.Reflection.MonoField.SetValueInternal` / `System.RuntimeFieldHandle.SetValueInternal`

Added new functions/macros for working with boxed valuetypes and nullables.

* `mono_object_handle_pin_unbox` - unbox a boxed valuetype. Pins it with a GCHandle and return a pointer to the payload
* `MONO_HANDLE_SET_FIELD_REF (h, cf, v)` - given a `MonoClassField*` (must be a field of reference type) sets that field in object `h` to value `v`
* `mono_handle_array_has_bounds` / `mono_handle_array_get_bounds_dim` - find out if array has `MonoArrayBounds*` or get the bounds for a given dimension.
* `mono_nullable_init_from_handle (buf, h, T)` - given `buf` which a pointer to the payload of a `Nullable<T>` (either on the stack, or pinned in the heap) and a boxed value handle `h`, initializes the nullable from the boxed value.

It seems like the basic usage for valuetypes/nullables is to pin them while unboxing.