### PR TITLE
[sre] Fix the signature of the create_dynamic_method () icall, make i…

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
@@ -131,7 +131,7 @@ namespace System.Reflection.Emit {
 		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		private extern void create_dynamic_method (DynamicMethod m);
+		private static extern void create_dynamic_method (DynamicMethod m);
 
 		private void CreateDynMethod () {
 			if (mhandle.Value == IntPtr.Zero) {


### PR DESCRIPTION
…t static since the C implementation only takes two parameters, this only caused problems if the icall set the error, since it overwrite the DynamicMethod object instead. Fixes #57301.