### PR TITLE
[profiler] Remove class unload events.

### DIFF
--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -258,7 +258,8 @@ static MonoLinkedListSet profiler_thread_list;
  *
  * type metadata format:
  * type: TYPE_METADATA
- * exinfo: one of: TYPE_END_LOAD, TYPE_END_UNLOAD (optional for TYPE_THREAD and TYPE_DOMAIN)
+ * exinfo: one of: TYPE_END_LOAD, TYPE_END_UNLOAD (optional for TYPE_THREAD and TYPE_DOMAIN,
+ * doesn't occur for TYPE_CLASS)
  * [mtype: byte] metadata type, one of: TYPE_CLASS, TYPE_IMAGE, TYPE_ASSEMBLY, TYPE_DOMAIN,
  * TYPE_THREAD, TYPE_CONTEXT
  * [pointer: sleb128] pointer of the metadata type depending on mtype
@@ -1990,42 +1991,6 @@ class_loaded (MonoProfiler *prof, MonoClass *klass, int result)
 	);
 
 	emit_event (logbuffer, TYPE_END_LOAD | TYPE_METADATA);
-	emit_byte (logbuffer, TYPE_CLASS);
-	emit_ptr (logbuffer, klass);
-	emit_ptr (logbuffer, image);
-	memcpy (logbuffer->cursor, name, nlen);
-	logbuffer->cursor += nlen;
-
-	EXIT_LOG;
-
-	if (runtime_inited)
-		mono_free (name);
-	else
-		g_free (name);
-}
-
-static void
-class_unloaded (MonoProfiler *prof, MonoClass *klass)
-{
-	char *name;
-
-	if (InterlockedRead (&runtime_inited))
-		name = mono_type_get_name (mono_class_get_type (klass));
-	else
-		name = type_name (klass);
-
-	int nlen = strlen (name) + 1;
-	MonoImage *image = mono_class_get_image (klass);
-
-	ENTER_LOG (&class_unloads_ctr, logbuffer,
-		EVENT_SIZE /* event */ +
-		BYTE_SIZE /* type */ +
-		LEB128_SIZE /* klass */ +
-		LEB128_SIZE /* image */ +
-		nlen /* name */
-	);
-
-	emit_event (logbuffer, TYPE_END_UNLOAD | TYPE_METADATA);
 	emit_byte (logbuffer, TYPE_CLASS);
 	emit_ptr (logbuffer, klass);
 	emit_ptr (logbuffer, image);
@@ -4756,7 +4721,7 @@ mono_profiler_startup (const char *desc)
 
 	if (config.effective_mask & PROFLOG_CLASS_EVENTS) {
 		events |= MONO_PROFILE_CLASS_EVENTS;
-		mono_profiler_install_class (NULL, class_loaded, class_unloaded, NULL);
+		mono_profiler_install_class (NULL, class_loaded, NULL, NULL);
 	}
 
 	if (config.effective_mask & PROFLOG_JIT_COMPILATION_EVENTS) {

--- a/mono/profiler/log.h
+++ b/mono/profiler/log.h
@@ -66,6 +66,7 @@
                changed address field in TYPE_SAMPLE_UBIN to be based on ptr_base
                added an image pointer field to assembly load events
                added an exception object field to TYPE_CLAUSE
+               class unload events no longer exist (they were never emitted)
  */
 
 enum {

--- a/mono/profiler/mprof-report.c
+++ b/mono/profiler/mprof-report.c
@@ -2480,8 +2480,7 @@ decode_buffer (ProfContext *ctx)
 					decode_uleb128 (p, &p); /* flags */
 				if (debug)
 					fprintf (outfile, "%s class %p (%s in %p) at %llu\n", load_str, (void*)(ptr_base + ptrdiff), p, (void*)(ptr_base + imptrdiff), (unsigned long long) time_base);
-				if (subtype == TYPE_END_LOAD)
-					add_class (ptr_base + ptrdiff, (char*)p);
+				add_class (ptr_base + ptrdiff, (char*)p);
 				while (*p) p++;
 				p++;
 			} else if (mtype == TYPE_IMAGE) {


### PR DESCRIPTION
These are never actually emitted by the profiler API because they make no sense in the context of Mono's metadata layer.