### PR TITLE
[DO NOT MERGE] Experiment on how low "timeout" values can cause tests to fail in corlib mono_w32handle_timedwait_signal_naked().

### DIFF
--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -1205,7 +1205,7 @@ mono_w32handle_wait_one (gpointer handle, guint32 timeout, gboolean alertable)
 				goto done;
 			}
 
-			waited = mono_w32handle_timedwait_signal_handle (handle, timeout - elapsed, FALSE, alertable ? &alerted : NULL);
+			waited = mono_w32handle_timedwait_signal_handle (handle, 1, FALSE, alertable ? &alerted : NULL);
 		}
 
 		if (alerted) {


### PR DESCRIPTION
 I was suspecting that these were causing the "Invalid Argument" error in pthread_cond_timedwait() (since the timespec passed to it may already be in the past, which is indeed illegal, and all four stack traces I am looking at have single-digit timeout values!), but while testing I found this also cause corlib test failures. This is to help me understand them, since these do not end up in g_error() like the failure I was looking at.