### PR TITLE
Backport fde1280c21d2fdd79245c05629799321779599dd

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -152,7 +152,7 @@ namespace System
 #if !MONODROID && !MONOTOUCH && !XAMMAC
 		static TimeZoneInfo CreateLocal ()
 		{
-#if (!FULL_AOT_DESKTOP || WIN_PLATFORM) && !XAMMAC_4_5
+#if WIN_PLATFORM
 			if (IsWindows && LocalZoneKey != null) {
 				string name = (string)LocalZoneKey.GetValue ("TimeZoneKeyName");
 				if (name == null)
@@ -206,7 +206,7 @@ namespace System
 
 		static void GetSystemTimeZonesCore (List<TimeZoneInfo> systemTimeZones)
 		{
-#if (!FULL_AOT_DESKTOP || WIN_PLATFORM) && !XAMMAC_4_5
+#if WIN_PLATFORM
 			if (TimeZoneKey != null) {
 				foreach (string id in TimeZoneKey.GetSubKeyNames ()) {
 					try {


### PR DESCRIPTION
Backport https://github.com/mono/mono/pull/5110 to fix the testing_hybrid_aot build