### PR TITLE
[System.Core] Implement MemoryMappedFile.OpenExisting

### DIFF
--- a/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedFile.cs
+++ b/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedFile.cs
@@ -310,19 +310,20 @@ namespace System.IO.MemoryMappedFiles
 		[MonoLimitation ("Named mappings scope is process local")]
 		public static MemoryMappedFile OpenExisting (string mapName)
 		{
-			throw new NotImplementedException ();
+			return OpenExisting (mapName, MemoryMappedFileRights.ReadWrite);
 		}
 
 		[MonoLimitation ("Named mappings scope is process local")]
 		public static MemoryMappedFile OpenExisting (string mapName, MemoryMappedFileRights desiredAccessRights)
 		{
-			throw new NotImplementedException ();
+			return OpenExisting (mapName, desiredAccessRights, HandleInheritability.None);
 		}
 
 		[MonoLimitation ("Named mappings scope is process local")]
 		public static MemoryMappedFile OpenExisting (string mapName, MemoryMappedFileRights desiredAccessRights, HandleInheritability inheritability)
 		{
-			throw new NotImplementedException ();
+			// FIXME: Actually use desiredAccessRights
+			return CoreShmCreate (mapName, 0, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, null, inheritability, FileMode.Open);
 		}
 
 		public MemoryMappedViewStream CreateViewStream ()
@@ -393,10 +394,9 @@ namespace System.IO.MemoryMappedFiles
 			throw new NotImplementedException ();
 		}
 
-		[MonoTODO]
 		public SafeMemoryMappedFileHandle SafeMemoryMappedFileHandle {
 			get {
-				throw new NotImplementedException ();
+				return handle;
 			}
 		}
 

--- a/mcs/class/System.Core/Test/System.IO.MemoryMappedFiles/MemoryMappedFileTest.cs
+++ b/mcs/class/System.Core/Test/System.IO.MemoryMappedFiles/MemoryMappedFileTest.cs
@@ -301,9 +301,12 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 			var name = MkNamedMapping ();
 			using (var m0 = MemoryMappedFile.CreateNew(name, 4096, MemoryMappedFileAccess.ReadWrite)) {
 				using (var m1 = MemoryMappedFile.CreateOrOpen (name, 4096, MemoryMappedFileAccess.ReadWrite)) {
-					using (MemoryMappedViewAccessor v0 = m0.CreateViewAccessor (), v1 = m1.CreateViewAccessor ()) {
-						v0.Write (10, 0x12345);
-						Assert.AreEqual (0x12345, v1.ReadInt32 (10));
+					using (var m2 = MemoryMappedFile.OpenExisting (name)) {
+						using (MemoryMappedViewAccessor v0 = m0.CreateViewAccessor (), v1 = m1.CreateViewAccessor (), v2 = m2.CreateViewAccessor ()) {
+							v0.Write (10, 0x12345);
+							Assert.AreEqual (0x12345, v1.ReadInt32 (10));
+							Assert.AreEqual (0x12345, v2.ReadInt32 (10));
+						}
 					}
 				}
 			}
@@ -465,6 +468,14 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 					}
 				}
 			}
+		}
+
+		[Test]
+		public void OpenExistingWithNoExistingThrows()
+		{
+			Assert.Throws<FileNotFoundException>(() => {
+				MemoryMappedFile.OpenExisting (MkNamedMapping ());
+			});
 		}
 	}
 }

--- a/mono/metadata/file-mmap-posix.c
+++ b/mono/metadata/file-mmap-posix.c
@@ -303,7 +303,7 @@ static void*
 open_memory_map (const char *c_mapName, int mode, gint64 *capacity, int access, int options, int *ioerror)
 {
 	MmapHandle *handle;
-	if (*capacity <= 0) {
+	if (*capacity <= 0 && mode != FILE_MODE_OPEN) {
 		*ioerror = CAPACITY_MUST_BE_POSITIVE;
 		return NULL;
 	}

--- a/mono/metadata/file-mmap-windows.c
+++ b/mono/metadata/file-mmap-windows.c
@@ -140,7 +140,7 @@ static void *open_handle (void *handle, MonoString *mapName, int mode, gint64 *c
 	HANDLE result = NULL;
 
 	if (handle == INVALID_HANDLE_VALUE) {
-		if (*capacity <= 0) {
+		if (*capacity <= 0 && mode != FILE_MODE_OPEN) {
 			*error = CAPACITY_MUST_BE_POSITIVE;
 			return NULL;
 		}


### PR DESCRIPTION
Reuse the existing icall infrastructure to give the same handle back.

This PR implements all OpenExisting methods (with the access rights parameter discarded) and the SafeHandle property.
In the runtime, we don't check the capacity parameter if we try to open a mmap file, and we fallthrough the handle refcount case.