### PR TITLE
[2017-06][reflection] Convert correct MonoError to an exn in Assembly.GetTypes() (Fixes #57744)

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5418,7 +5418,7 @@ image_get_type (MonoDomain *domain, MonoImage *image, MonoTableInfo *tdef, int t
 
 		MONO_HANDLE_ARRAY_SETREF (res, count, rt);
 	} else {
-		MonoException *ex = mono_error_convert_to_exception (error);
+		MonoException *ex = mono_error_convert_to_exception (&klass_error);
 		MONO_HANDLE_ARRAY_SETRAW (exceptions, count, ex);
 	}
 	HANDLE_FUNCTION_RETURN ();


### PR DESCRIPTION
This is #5120 backported to `2017-06`

----

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57744