### PR TITLE
[nullgc] When building nullgc, don't try to link Boehm libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1336,6 +1336,7 @@ if test "x$support_boehm" = "xyes"; then
 	AC_SUBST(BOEHM_DEFINES)
 
 fi
+AM_CONDITIONAL(SUPPORT_NULLGC, test "x$libgc" = "xnone")
 
 dnl
 dnl End of Boehm GC Configuration

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -10,8 +10,13 @@ PLATFORM_PATH_SEPARATOR=:
 endif
 
 # This is needed for automake dependency generation
+if SUPPORT_NULLGC
+libgc_libs=
+libgc_static_libs=
+else
 libgc_libs=$(monodir)/libgc/libmonogc.la
 libgc_static_libs=$(monodir)/libgc/libmonogc-static.la
+endif
 
 boehm_libs=	\
 	$(monodir)/mono/metadata/libmonoruntime.la	\


### PR DESCRIPTION
Previous nullgc commit (52d9a55a861527ed4027f8e10a97e3cc880baf4a) didn't actually work in a clean tree.