### PR TITLE
[WIP] [w32handle] Refactor calls to mono_w32handle_lookup () to reduce code…

### DIFF
--- a/mono/metadata/w32event-unix.c
+++ b/mono/metadata/w32event-unix.c
@@ -51,17 +51,9 @@ static void event_handle_signal (gpointer handle, MonoW32HandleType type, MonoW3
 
 static gboolean event_handle_own (gpointer handle, MonoW32HandleType type, gboolean *abandoned)
 {
-	MonoW32HandleEvent *event_handle;
-	gboolean ok;
+	MonoW32HandleEvent *event_handle = MONO_W32HANDLE_LOOKUP (handle, type);
 
 	*abandoned = FALSE;
-
-	ok = mono_w32handle_lookup (handle, type, (gpointer *)&event_handle);
-	if (!ok) {
-		g_warning ("%s: error looking up %s handle %p",
-			__func__, mono_w32handle_get_typename (type), handle);
-		return FALSE;
-	}
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: owning %s handle %p",
 		__func__, mono_w32handle_get_typename (type), handle);
@@ -307,11 +299,6 @@ ves_icall_System_Threading_Events_SetEvent_internal (gpointer handle)
 	MonoW32HandleType type;
 	MonoW32HandleEvent *event_handle;
 
-	if (handle == NULL) {
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
-
 	switch (type = mono_w32handle_get_type (handle)) {
 	case MONO_W32HANDLE_EVENT:
 	case MONO_W32HANDLE_NAMEDEVENT:
@@ -321,11 +308,7 @@ ves_icall_System_Threading_Events_SetEvent_internal (gpointer handle)
 		return FALSE;
 	}
 
-	if (!mono_w32handle_lookup (handle, type, (gpointer *)&event_handle)) {
-		g_warning ("%s: error looking up %s handle %p",
-			__func__, mono_w32handle_get_typename (type), handle);
-		return FALSE;
-	}
+	event_handle = MONO_W32HANDLE_LOOKUP (handle, type);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: setting %s handle %p",
 		__func__, mono_w32handle_get_typename (type), handle);
@@ -352,11 +335,6 @@ ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle)
 
 	mono_w32error_set_last (ERROR_SUCCESS);
 
-	if (handle == NULL) {
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
-
 	switch (type = mono_w32handle_get_type (handle)) {
 	case MONO_W32HANDLE_EVENT:
 	case MONO_W32HANDLE_NAMEDEVENT:
@@ -366,11 +344,7 @@ ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle)
 		return FALSE;
 	}
 
-	if (!mono_w32handle_lookup (handle, type, (gpointer *)&event_handle)) {
-		g_warning ("%s: error looking up %s handle %p",
-			__func__, mono_w32handle_get_typename (type), handle);
-		return FALSE;
-	}
+	event_handle = MONO_W32HANDLE_LOOKUP (handle, type);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: resetting %s handle %p",
 		__func__, mono_w32handle_get_typename (type), handle);

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -1147,18 +1147,10 @@ static gboolean
 file_read(gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	gint fd, ret;
 	MonoThreadInfo *info = mono_thread_info_current ();
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 
 	fd = file_handle->fd;
 	if(bytesread!=NULL) {
@@ -1201,19 +1193,11 @@ static gboolean
 file_write(gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	gint ret, fd;
 	off_t current_pos = 0;
 	MonoThreadInfo *info = mono_thread_info_current ();
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 
 	fd = file_handle->fd;
 	
@@ -1283,17 +1267,9 @@ file_write(gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byt
 static gboolean file_flush(gpointer handle)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	gint ret, fd;
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 
 	fd = file_handle->fd;
 
@@ -1323,19 +1299,11 @@ static guint32 file_seek(gpointer handle, gint32 movedistance,
 			 gint32 *highmovedistance, gint method)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	gint64 offset, newpos;
 	gint whence, fd;
 	guint32 ret;
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(INVALID_SET_FILE_POINTER);
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 	
 	fd = file_handle->fd;
 
@@ -1424,20 +1392,12 @@ static guint32 file_seek(gpointer handle, gint32 movedistance,
 static gboolean file_setendoffile(gpointer handle)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	struct stat statbuf;
 	off_t pos;
 	gint ret, fd;
 	MonoThreadInfo *info = mono_thread_info_current ();
-	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 	fd = file_handle->fd;
 	
 	if(!(file_handle->fileaccess & GENERIC_WRITE) &&
@@ -1541,20 +1501,12 @@ static gboolean file_setendoffile(gpointer handle)
 static guint32 file_getfilesize(gpointer handle, guint32 *highsize)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	struct stat statbuf;
 	guint32 size;
 	gint ret;
 	gint fd;
-	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(INVALID_FILE_SIZE);
-	}
+
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 	fd = file_handle->fd;
 	
 	if(!(file_handle->fileaccess & GENERIC_READ) &&
@@ -1634,19 +1586,11 @@ static gboolean file_getfiletime(gpointer handle, FILETIME *create_time,
 				 FILETIME *write_time)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	struct stat statbuf;
 	guint64 create_ticks, access_ticks, write_ticks;
 	gint ret, fd;
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 	fd = file_handle->fd;
 
 	if(!(file_handle->fileaccess & GENERIC_READ) &&
@@ -1717,20 +1661,12 @@ static gboolean file_setfiletime(gpointer handle,
 				 const FILETIME *write_time)
 {
 	MonoW32HandleFile *file_handle;
-	gboolean ok;
 	struct utimbuf utbuf;
 	struct stat statbuf;
 	guint64 access_ticks, write_ticks;
 	gint ret, fd;
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE,
-				(gpointer *)&file_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up file handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 	fd = file_handle->fd;
 	
 	if(!(file_handle->fileaccess & GENERIC_WRITE) &&
@@ -1871,18 +1807,10 @@ static gboolean
 console_read(gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread)
 {
 	MonoW32HandleFile *console_handle;
-	gboolean ok;
 	gint ret, fd;
 	MonoThreadInfo *info = mono_thread_info_current ();
 
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_CONSOLE,
-				(gpointer *)&console_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up console handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	console_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_CONSOLE);
 	fd = console_handle->fd;
 	
 	if(bytesread!=NULL) {
@@ -1923,18 +1851,10 @@ static gboolean
 console_write(gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten)
 {
 	MonoW32HandleFile *console_handle;
-	gboolean ok;
 	gint ret, fd;
 	MonoThreadInfo *info = mono_thread_info_current ();
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_CONSOLE,
-				(gpointer *)&console_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up console handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	console_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_CONSOLE);
 	fd = console_handle->fd;
 	
 	if(byteswritten!=NULL) {
@@ -2029,18 +1949,10 @@ static gboolean
 pipe_read (gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread)
 {
 	MonoW32HandleFile *pipe_handle;
-	gboolean ok;
 	gint ret, fd;
 	MonoThreadInfo *info = mono_thread_info_current ();
 
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_PIPE,
-				(gpointer *)&pipe_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up pipe handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	pipe_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_PIPE);
 	fd = pipe_handle->fd;
 
 	if(bytesread!=NULL) {
@@ -2091,18 +2003,10 @@ static gboolean
 pipe_write(gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten)
 {
 	MonoW32HandleFile *pipe_handle;
-	gboolean ok;
 	gint ret, fd;
 	MonoThreadInfo *info = mono_thread_info_current ();
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_PIPE,
-				(gpointer *)&pipe_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up pipe handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	pipe_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_PIPE);
 	fd = pipe_handle->fd;
 	
 	if(byteswritten!=NULL) {
@@ -3469,7 +3373,6 @@ gboolean
 mono_w32file_find_next (gpointer handle, WIN32_FIND_DATA *find_data)
 {
 	MonoW32HandleFind *find_handle;
-	gboolean ok;
 	struct stat buf, linkbuf;
 	gint result;
 	gchar *filename;
@@ -3479,14 +3382,7 @@ mono_w32file_find_next (gpointer handle, WIN32_FIND_DATA *find_data)
 	glong bytes;
 	gboolean ret = FALSE;
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FIND,
-				(gpointer *)&find_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up find handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	find_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FIND);
 
 	mono_w32handle_lock_handle (handle);
 	
@@ -3597,21 +3493,8 @@ gboolean
 mono_w32file_find_close (gpointer handle)
 {
 	MonoW32HandleFind *find_handle;
-	gboolean ok;
-
-	if (handle == NULL) {
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
 	
-	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FIND,
-				(gpointer *)&find_handle);
-	if(ok==FALSE) {
-		g_warning ("%s: error looking up find handle %p", __func__,
-			   handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return(FALSE);
-	}
+	find_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FIND);
 
 	mono_w32handle_lock_handle (handle);
 	
@@ -4951,11 +4834,7 @@ LockFile (gpointer handle, guint32 offset_low, guint32 offset_high, guint32 leng
 	MonoW32HandleFile *file_handle;
 	off_t offset, length;
 
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE, (gpointer *)&file_handle)) {
-		g_warning ("%s: error looking up file handle %p", __func__, handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 
 	if (!(file_handle->fileaccess & GENERIC_READ) && !(file_handle->fileaccess & GENERIC_WRITE) && !(file_handle->fileaccess & GENERIC_ALL)) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);
@@ -4988,11 +4867,7 @@ UnlockFile (gpointer handle, guint32 offset_low, guint32 offset_high, guint32 le
 	MonoW32HandleFile *file_handle;
 	off_t offset, length;
 
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_FILE, (gpointer *)&file_handle)) {
-		g_warning ("%s: error looking up file handle %p", __func__, handle);
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
+	file_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_FILE);
 
 	if (!(file_handle->fileaccess & GENERIC_READ) && !(file_handle->fileaccess & GENERIC_WRITE) && !(file_handle->fileaccess & GENERIC_ALL)) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: handle %p doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, handle, file_handle->fileaccess);

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -517,6 +517,18 @@ mono_w32handle_lookup (gpointer handle, MonoW32HandleType type,
 	return(TRUE);
 }
 
+gpointer
+mono_w32handle_lookup_debug (gpointer handle, MonoW32HandleType type, const char *caller)
+{
+	gpointer handle_data;
+	gboolean res;
+
+	res = mono_w32handle_lookup (handle, type, &handle_data);
+	if (!res)
+		g_error ("%s: error looking up handle %p of type %s", caller, handle, mono_w32handle_get_typename (type));
+	return handle_data;
+}
+
 static gboolean
 mono_w32handle_ref_core (gpointer handle, MonoW32HandleBase *handle_data);
 

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -22,6 +22,11 @@
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
 #endif
 
+/*
+ * Look up HANDLE asserting that it exists and its of type HANDLE_TYPE.
+ */
+#define MONO_W32HANDLE_LOOKUP(handle, handle_type) mono_w32handle_lookup_debug ((handle), (handle_type), __func__)
+
 typedef enum {
 	MONO_W32HANDLE_UNUSED = 0,
 	MONO_W32HANDLE_FILE,
@@ -127,6 +132,9 @@ mono_w32handle_get_typename (MonoW32HandleType type);
 
 gboolean
 mono_w32handle_lookup (gpointer handle, MonoW32HandleType type, gpointer *handle_specific);
+
+gpointer
+mono_w32handle_lookup_debug (gpointer handle, MonoW32HandleType type, const char *caller);
 
 void
 mono_w32handle_foreach (gboolean (*on_each)(gpointer handle, gpointer data, gpointer user_data), gpointer user_data);

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -47,15 +47,9 @@ static void sem_handle_signal (gpointer handle, MonoW32HandleType type, MonoW32H
 
 static gboolean sem_handle_own (gpointer handle, MonoW32HandleType type, gboolean *abandoned)
 {
-	MonoW32HandleSemaphore *sem_handle;
+	MonoW32HandleSemaphore *sem_handle = MONO_W32HANDLE_LOOKUP (handle, type);
 
 	*abandoned = FALSE;
-
-	if (!mono_w32handle_lookup (handle, type, (gpointer *)&sem_handle)) {
-		g_warning ("%s: error looking up %s handle %p",
-			__func__, mono_w32handle_get_typename (type), handle);
-		return FALSE;
-	}
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: owning %s handle %p",
 		__func__, mono_w32handle_get_typename (type), handle);
@@ -282,11 +276,6 @@ ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle,
 	MonoW32HandleSemaphore *sem_handle;
 	MonoBoolean ret;
 
-	if (!handle) {
-		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return FALSE;
-	}
-
 	switch (type = mono_w32handle_get_type (handle)) {
 	case MONO_W32HANDLE_SEM:
 	case MONO_W32HANDLE_NAMEDSEM:
@@ -296,10 +285,7 @@ ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle,
 		return FALSE;
 	}
 
-	if (!mono_w32handle_lookup (handle, type, (gpointer *)&sem_handle)) {
-		g_warning ("%s: error looking up sem handle %p", __func__, handle);
-		return FALSE;
-	}
+	sem_handle = MONO_W32HANDLE_LOOKUP (handle, type);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: releasing %s handle %p",
 		__func__, mono_w32handle_get_typename (type), handle);

--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -165,10 +165,7 @@ mono_w32socket_accept (SOCKET sock, struct sockaddr *addr, socklen_t *addrlen, g
 	}
 
 	handle = GUINT_TO_POINTER (sock);
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_SOCKET, (gpointer *)&socket_handle)) {
-		mono_w32socket_set_last_error (WSAENOTSOCK);
-		return INVALID_SOCKET;
-	}
+	socket_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_SOCKET);
 
 	info = mono_thread_info_current ();
 
@@ -219,10 +216,7 @@ mono_w32socket_connect (SOCKET sock, const struct sockaddr *addr, int addrlen, g
 	MonoW32HandleSocket *socket_handle;
 
 	handle = GUINT_TO_POINTER (sock);
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_SOCKET, (gpointer *)&socket_handle)) {
-		mono_w32socket_set_last_error (WSAENOTSOCK);
-		return SOCKET_ERROR;
-	}
+	socket_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_SOCKET);
 
 	if (connect (sock, addr, addrlen) == -1) {
 		MonoThreadInfo *info;
@@ -309,10 +303,7 @@ mono_w32socket_recvfrom (SOCKET sock, char *buf, int len, int flags, struct sock
 	MonoThreadInfo *info;
 
 	handle = GUINT_TO_POINTER (sock);
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_SOCKET, (gpointer *)&socket_handle)) {
-		mono_w32socket_set_last_error (WSAENOTSOCK);
-		return SOCKET_ERROR;
-	}
+	socket_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_SOCKET);
 
 	info = mono_thread_info_current ();
 
@@ -387,10 +378,7 @@ mono_w32socket_recvbuffers (SOCKET sock, WSABUF *buffers, guint32 count, guint32
 	g_assert (complete == NULL);
 
 	handle = GUINT_TO_POINTER (sock);
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_SOCKET, (gpointer *)&socket_handle)) {
-		mono_w32socket_set_last_error (WSAENOTSOCK);
-		return SOCKET_ERROR;
-	}
+	socket_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_SOCKET);
 
 	info = mono_thread_info_current ();
 
@@ -773,10 +761,7 @@ mono_w32socket_getsockopt (SOCKET sock, gint level, gint optname, gpointer optva
 	MonoW32HandleSocket *socket_handle;
 
 	handle = GUINT_TO_POINTER (sock);
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_SOCKET, (gpointer *)&socket_handle)) {
-		mono_w32socket_set_last_error (WSAENOTSOCK);
-		return SOCKET_ERROR;
-	}
+	socket_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_SOCKET);
 
 	tmp_val = optval;
 	if (level == SOL_SOCKET &&
@@ -906,10 +891,7 @@ mono_w32socket_shutdown (SOCKET sock, gint how)
 	gint ret;
 
 	handle = GUINT_TO_POINTER (sock);
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_SOCKET, (gpointer *)&socket_handle)) {
-		mono_w32socket_set_last_error (WSAENOTSOCK);
-		return SOCKET_ERROR;
-	}
+	socket_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_SOCKET);
 
 	if (how == SHUT_RD || how == SHUT_RDWR)
 		socket_handle->still_readable = 0;
@@ -940,10 +922,7 @@ mono_w32socket_disconnect (SOCKET sock, gboolean reuse)
 	 * if we really wanted to */
 
 	handle = GUINT_TO_POINTER (sock);
-	if (!mono_w32handle_lookup (handle, MONO_W32HANDLE_SOCKET, (gpointer *)&socket_handle)) {
-		mono_w32socket_set_last_error (WSAENOTSOCK);
-		return SOCKET_ERROR;
-	}
+	socket_handle = MONO_W32HANDLE_LOOKUP (handle, MONO_W32HANDLE_SOCKET);
 
 	newsock = socket (socket_handle->domain, socket_handle->type, socket_handle->protocol);
 	if (newsock == -1) {


### PR DESCRIPTION
… duplication. Assert instead of returning an error if the handle doesn't exist or its not the proper type.