### PR TITLE
[btls] Check return value of asn1_generalizedtime_to_tm ()

### DIFF
--- a/mono/btls/btls-util.c
+++ b/mono/btls/btls-util.c
@@ -27,13 +27,19 @@ mono_btls_util_asn1_time_to_ticks (ASN1_TIME *time)
 	ASN1_GENERALIZEDTIME *gtime;
 	struct tm tm;
 	int64_t epoch;
+	int ret;
 	
 	memset (&tm, 0, sizeof (tm));
 
 	gtime = ASN1_TIME_to_generalizedtime (time, NULL);
-	/* FIXME: check return value of  asn1_generalizedtime_to_tm () */
-	asn1_generalizedtime_to_tm (&tm, gtime);
+	ret = asn1_generalizedtime_to_tm (&tm, gtime);
 	ASN1_GENERALIZEDTIME_free (gtime);
+
+	/* FIXME: check the return value in managed code */
+	if (ret == 0) {
+		return 0;
+	}
+
 	epoch = btls_timegm64 (&tm);
 
 	return epoch;


### PR DESCRIPTION
As requested by @baulig and suggested by @lewurm, this is the follow-up to #5064 to check the return value of asn1_generalizedtime_to_tm () and return 0 on failure.