### PR TITLE
[packaging] Remove git_branch from msbuild and mono-extensions

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,8 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15.3',
-			revision = 'f7dcc3900c808775adad970f047202b4de34e986',
-			git_branch = 'xplat-master')
+			revision = 'f7dcc3900c808775adad970f047202b4de34e986')
 
 	def build (self):
 		self.sh ('./cibuild.sh --scope Compile --target Mono --host Mono --config Release')

--- a/packaging/MacSDKRelease/mono-extensions.py
+++ b/packaging/MacSDKRelease/mono-extensions.py
@@ -6,16 +6,9 @@ class MonoExtensionsPackage(Package):
     def __init__(self):
         Package.__init__(self, 'mono-extensions', None,
                          sources=['git@github.com:xamarin/mono-extensions.git'],
-                         git_branch=self.profile.release_packages[
-                             'mono'].git_branch,
                          revision='07ad37d63e0e9dcf7c879a72bc14c5d6c794f7b6'
                          )
         self.source_dir_name = 'mono-extensions'
-
-        # Mono pull requests won't have mono-extensions branches
-        if not self.git_branch or 'pull/' in self.git_branch:
-            warn('Using master branch for mono_extensions')
-            self.git_branch = 'master'
 
     def build(self):
         pass


### PR DESCRIPTION
We're checking out a specific commit for both now so the git branch is no longer required.

Also fixes warnings that a 2017-06 branch doesn't exist in mono-extensions.