### PR TITLE
[aot] Do not mix amodule->shared_got and ELF-backed GOT lifetimes

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -230,7 +230,7 @@ static gboolean
 init_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *method, MonoClass *init_class, MonoGenericContext *context, MonoError *error);
 
 static MonoJumpInfo*
-decode_patches (MonoAotModule *amodule, MonoMemPool *mp, int n_patches, gboolean llvm, guint32 *got_offsets);
+decode_patches (MonoAotModule *amodule, MonoMemPool *mp, int n_patches, gboolean llvm, gboolean shared_got, guint32 *got_offsets);
 
 static inline void
 amodule_lock (MonoAotModule *amodule)
@@ -1879,7 +1879,7 @@ init_amodule_got (MonoAotModule *amodule)
 	npatches = amodule->info.nshared_got_entries;
 	for (i = 0; i < npatches; ++i)
 		got_offsets [i] = i;
-	patches = decode_patches (amodule, mp, npatches, FALSE, got_offsets);
+	patches = decode_patches (amodule, mp, npatches, FALSE, TRUE, got_offsets);
 	g_assert (patches);
 	for (i = 0; i < npatches; ++i) {
 		ji = &patches [i];
@@ -3796,7 +3796,7 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
  * MonoJumpInfo structures allocated from MP.
  */
 static MonoJumpInfo*
-decode_patches (MonoAotModule *amodule, MonoMemPool *mp, int n_patches, gboolean llvm, guint32 *got_offsets)
+decode_patches (MonoAotModule *amodule, MonoMemPool *mp, int n_patches, gboolean llvm, gboolean shared_got, guint32 *got_offsets)
 {
 	MonoJumpInfo *patches;
 	MonoJumpInfo *ji;
@@ -3809,7 +3809,7 @@ decode_patches (MonoAotModule *amodule, MonoMemPool *mp, int n_patches, gboolean
 		got = amodule->llvm_got;
 		got_info_offsets = (guint32 *)amodule->llvm_got_info_offsets;
 	} else {
-		got = amodule->got;
+		got = shared_got ? amodule->shared_got : amodule->got;
 		got_info_offsets = (guint32 *)amodule->got_info_offsets;
 	}
 
@@ -3849,7 +3849,7 @@ load_patch_info (MonoAotModule *amodule, MonoMemPool *mp, int n_patches,
 		(*got_slots)[pindex] = decode_value (p, &p);
 	}
 
-	patches = decode_patches (amodule, mp, n_patches, llvm, *got_slots);
+	patches = decode_patches (amodule, mp, n_patches, llvm, FALSE, *got_slots);
 	if (!patches) {
 		g_free (*got_slots);
 		*got_slots = NULL;


### PR DESCRIPTION
The AOT GOTs, 'amodule->got' and 'amodule->llvm_got', are backed by
the corresponding shared object's .bss section.

Unloading a domain causes its assemblies and images to be closed and
freed.  The shared object, however, is not closed; it--and its
GOTs--are kept around.

Loading a previously-unloaded assembly in a new domain can thus result
in a fresh module whose ELF GOT is already initialized while the
'shared_got' is empty.

This typically results in a crash: 'decode_patches' looks at the GOT
and silently ignores the patches, thinking they have already been
loaded, but 'init_amodule_got' then happily passes these zeroed data
structures to 'mono_resolve_patch_target'.

This patch adds a flag to 'decode_patches', to force it to use the
'shared_got'.  Another solution would perhaps be to initialize the
'shared_got' from the ELF GOT instead of zeroing it out.