### PR TITLE
Add new version of SocketTest.ConnectedProperty that works on all platforms

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -3718,30 +3718,84 @@ namespace MonoTests.System.Net.Sockets
 			}
 		}
 
+		// Test case for https://bugzilla.novell.com/show_bug.cgi?id=443346
+		// See also https://bugzilla.xamarin.com/show_bug.cgi?id=52157
 		[Test]
-		[Category ("NotOnMac")]
-#if FULL_AOT_DESKTOP
-		[Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=52157")]
-#endif
 		public void ConnectedProperty ()
 		{
-			TcpListener listener = new TcpListener (IPAddress.Loopback, NetworkHelpers.FindFreePort ());
+			var port = NetworkHelpers.FindFreePort ();
+			var listener = new TcpListener (IPAddress.Loopback, port);
 			listener.Start();
 
-			Socket client = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-			client.Connect (IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
-			Socket server = listener.AcceptSocket ();
+			var client = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+			client.Connect (IPAddress.Loopback, port);
+			var server = listener.AcceptSocket ();
 
-			try {
-				server.EndSend(server.BeginSend (new byte[10], 0, 10, SocketFlags.None, null, null));
+			const int blobSize = 2048;
+
+			// Small send/recv buffers so that our send operation will fill them
+			server.ReceiveBufferSize = server.SendBufferSize = 256;
+			client.ReceiveBufferSize = client.SendBufferSize = 256;
+
+			// Setting this linger state causes shutdown to be a hard close (RST if send data is pending)
+			server.LingerState = client.LingerState = new LingerOption (true, 0);
+
+			// KeepAlive being set introduces another opportunity for a RST according to some documentation
+			server.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+			client.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+
+			try 
+			{
+				// Fill the send buffer
+				client.Send (new byte[blobSize]);
+				// Now shut down the socket. Because of the linger state this will hard close and send RST.
+				client.Shutdown (SocketShutdown.Both);
 				client.Close ();
-				try {
-					server.EndReceive (server.BeginReceive (new byte[10], 0, 10, SocketFlags.None, null, null));
-				} catch {
+
+				Assert.IsFalse (client.Connected);
+				Assert.IsTrue (server.Connected);
+
+				var isDead = false;
+
+				try 
+				{
+					// On Windows this BeginSend succeeds... it really shouldn't and a sync send fails.
+					// On Linux this fails with a ConnectionReset.
+					var ar = server.BeginSend (new byte[blobSize], 0, blobSize, SocketFlags.None, null, null);
+					// On Mac we get an erroneous WSAESHUTDOWN (10058) here
+					server.EndSend (ar);
+				} 
+				catch (SocketException se) 
+				{
+					isDead = true;
+
+					if (
+						(se.SocketErrorCode != SocketError.ConnectionReset) &&
+						(se.SocketErrorCode != SocketError.Shutdown)
+					)
+						throw;
+				} 
+
+				if (!isDead) 
+				{
+					try 
+					{
+						// On Windows this second send operation will fail with a ConnectionReset.
+						var ar = server.BeginSend (new byte[blobSize], 0, blobSize, SocketFlags.None, null, null);
+						server.EndSend (ar);
+					} 
+					catch (SocketException se) 
+					{
+						if (se.SocketErrorCode != SocketError.ConnectionReset)
+							throw;
+					} 
 				}
-				Assert.IsTrue (!client.Connected);
-				Assert.IsTrue (!server.Connected);
-			} finally {
+
+				Assert.IsFalse (client.Connected);
+				Assert.IsFalse (server.Connected);
+			} 
+			finally 
+			{
 				listener.Stop ();
 				client.Close ();
 				server.Close ();


### PR DESCRIPTION
The current ```SocketTest.ConnectedProperty``` test is broken on Linux FullAOT (see https://bugzilla.xamarin.com/show_bug.cgi?id=52157). This appears to be a timing sensitivity issue, as inserting enough ```WriteLine``` calls in ```Socket``` functions causes it to pass, and the test itself appears to be timing-sensitive. The test is already disabled on Mac.

This PR attempts to add a new test that is not timing sensitive and produces the desired behavior (a socket error occurring inside a ```Begin```/```End``` socket operation) on all platforms. Unfortunately, nobody can agree on how sockets actually work, so the test is a bit complicated.

In my local testing this works as desired on windows, mac and linux, but I suspect jenkins will find something wrong with it.

One thing I'm undecided on: Should unexpected socket errors cause the test to fail? A problem with the previous test is that it was written such that it would silently pass in any number of failure conditions.