### PR TITLE
[2017-06] Remove unrefing of handles on shutdown

### DIFF
--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -285,28 +285,10 @@ mono_w32handle_init (void)
 void
 mono_w32handle_cleanup (void)
 {
-	int i, j, k;
+	int i;
 
 	g_assert (!shutting_down);
 	shutting_down = TRUE;
-
-	/* Every shared handle we were using ought really to be closed
-	 * by now, but to make sure just blow them all away.  The
-	 * exiting finalizer thread in particular races us to the
-	 * program exit and doesn't always win, so it can be left
-	 * cluttering up the shared file.  Anything else left over is
-	 * really a bug.
-	 */
-	for(i = SLOT_INDEX (0); private_handles[i] != NULL; i++) {
-		for(j = SLOT_OFFSET (0); j < HANDLE_PER_SLOT; j++) {
-			MonoW32HandleBase *handle_data = &private_handles[i][j];
-			gpointer handle = GINT_TO_POINTER (i*HANDLE_PER_SLOT+j);
-
-			for(k = handle_data->ref; k > 0; k--) {
-				mono_w32handle_unref (handle);
-			}
-		}
-	}
 
 	for (i = 0; i < SLOT_MAX; ++i)
 		g_free (private_handles [i]);


### PR DESCRIPTION
Cherry pick one commit from #5106 for `2017-06`

----

If one of the handle is a file handle for example, then w32file has already be cleaned up, so we cannot guarantee that the handle we are going to close is not going to call into w32file code.