### PR TITLE
Console.Error.WriteLine in System.Net.NetworkInformation

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
@@ -307,8 +307,6 @@ namespace System.Net.NetworkInformation {
 							} else if (sockaddr.sin_family == AF_PACKET) {
 								sockaddr_ll sockaddrll = (sockaddr_ll) Marshal.PtrToStructure (addr.ifa_addr, typeof (sockaddr_ll));
 								if (((int)sockaddrll.sll_halen) > sockaddrll.sll_addr.Length){
-									Console.Error.WriteLine ("Got a bad hardware address length for an AF_PACKET {0} {1}",
-												 sockaddrll.sll_halen, sockaddrll.sll_addr.Length);
 									next = addr.ifa_next;
 									continue;
 								}


### PR DESCRIPTION
Console.Error.WriteLine ("Got a bad hardware address length for an AF_PACKET {0} {1}",...

This Console.WriteLine interferes with Apache Storm that reads from the console I/O.

See bug: https://bugzilla.xamarin.com/show_bug.cgi?id=57887