### PR TITLE
[utils] Fix CppCheck warning in mono-threads-posix.c

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -157,6 +157,7 @@ mono_threads_pthread_kill (MonoThreadInfo *info, int signum)
 #elif defined (HAVE_PTHREAD_KILL)
 	result = pthread_kill (mono_thread_info_get_tid (info), signum);
 #else
+	result = -1;
 	g_error ("pthread_kill () is not supported by this platform");
 #endif
 


### PR DESCRIPTION
After the refactoring in 9aaa0083d0def5b940372dbd9375336b036249fd CppCheck complained about using 'result' uninitialized (looks like it can't deduce that g_error will abort the process anyway).