### PR TITLE
[bcl] Don't use DateTime.Now for measuring elapsed time

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Remoting.Channels.Unix/UnixConnectionPool.cs
+++ b/mcs/class/Mono.Posix/Mono.Remoting.Channels.Unix/UnixConnectionPool.cs
@@ -153,7 +153,7 @@ namespace Mono.Remoting.Channels.Unix
 			_pool = pool;
 			_client = client;
 			_stream = new BufferedStream (client.GetStream());
-			_controlTime = DateTime.Now;
+			_controlTime = DateTime.UtcNow;
 			_buffer = new byte[UnixMessageIO.DefaultStreamBufferSize];
 		}
 
@@ -270,7 +270,7 @@ namespace Mono.Remoting.Channels.Unix
 		{
 			lock (_pool)
 			{
-				entry.ControlTime = DateTime.Now;	// Initialize timeout
+				entry.ControlTime = DateTime.UtcNow;	// Initialize timeout
 				_pool.Add (entry);
 				Monitor.Pulse (_pool);
 			}
@@ -295,7 +295,7 @@ namespace Mono.Remoting.Channels.Unix
 				for (int n=0; n < _pool.Count; n++)
 				{
 					UnixConnection entry = (UnixConnection)_pool[n];
-					if ( (DateTime.Now - entry.ControlTime).TotalSeconds > UnixConnectionPool.KeepAliveSeconds)
+					if ( (DateTime.UtcNow - entry.ControlTime).TotalSeconds > UnixConnectionPool.KeepAliveSeconds)
 					{
 						CancelConnection (entry);
 						_pool.RemoveAt(n);

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixSignalTest.cs
@@ -10,6 +10,7 @@
 using NUnit.Framework;
 
 using System;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using Mono.Unix;
@@ -25,12 +26,12 @@ namespace MonoTests.Mono.Unix {
 		static Thread CreateWaitSignalThread (UnixSignal signal, int timeout)
 		{
 			Thread t1 = new Thread(delegate() {
-						DateTime start = DateTime.Now;
+						var sw = Stopwatch.StartNew ();
 						bool r = signal.WaitOne (timeout, false);
-						DateTime end = DateTime.Now;
+						sw.Stop ();
 						Assert.AreEqual (signal.Count, 1);
 						Assert.AreEqual (r, true);
-						if ((end - start) > new TimeSpan (0, 0, timeout/1000))
+						if (sw.Elapsed > new TimeSpan (0, 0, timeout/1000))
 							throw new InvalidOperationException ("Signal slept too long");
 					});
 			return t1;
@@ -248,12 +249,12 @@ namespace MonoTests.Mono.Unix {
 		{
 			Thread t1 = new Thread (delegate () {
 					using (UnixSignal a = new UnixSignal (Signum.SIGINT)) {
-						DateTime start = DateTime.Now;
+						var sw = Stopwatch.StartNew ();
 						bool r = a.WaitOne (5000, false);
-						DateTime end = DateTime.Now;
+						sw.Stop ();
 						Assert.AreEqual (a.Count, 1);
 						Assert.AreEqual (r, true);
-						if ((end - start) > new TimeSpan (0, 0, 5))
+						if (sw.Elapsed > new TimeSpan (0, 0, 5))
 							throw new InvalidOperationException ("Signal slept too long");
 					}
 			});
@@ -272,12 +273,12 @@ namespace MonoTests.Mono.Unix {
 		{
 			Thread t1 = new Thread (delegate () {
 					using (UnixSignal a = new UnixSignal (Signum.SIGINT)) {
-						DateTime start = DateTime.Now;
+						var sw = Stopwatch.StartNew ();
 						int idx = UnixSignal.WaitAny (new UnixSignal[]{a}, 5000);
-						DateTime end = DateTime.Now;
+						sw.Stop ();
 						Assert.AreEqual (idx, 0);
 						Assert.AreEqual (a.Count, 1);
-						if ((end - start) > new TimeSpan (0, 0, 5))
+						if (sw.Elapsed > new TimeSpan (0, 0, 5))
 							throw new InvalidOperationException ("Signal slept too long");
 					}
 			});
@@ -297,13 +298,13 @@ namespace MonoTests.Mono.Unix {
 			Thread t1 = new Thread (delegate () {
 					using (UnixSignal a = new UnixSignal (Signum.SIGINT))
 					using (UnixSignal b = new UnixSignal (Signum.SIGTERM)) {
-						DateTime start = DateTime.Now;
+						var sw = Stopwatch.StartNew ();
 						int idx = UnixSignal.WaitAny (new UnixSignal[]{a, b}, 5000);
-						DateTime end = DateTime.Now;
+						sw.Stop ();
 						Assert.AreEqual (idx, 1);
 						Assert.AreEqual (a.Count, 0);
 						Assert.AreEqual (b.Count, 1);
-						if ((end - start) > new TimeSpan (0, 0, 5))
+						if (sw.Elapsed > new TimeSpan (0, 0, 5))
 							throw new InvalidOperationException ("Signal slept too long");
 					}
 			});
@@ -321,12 +322,12 @@ namespace MonoTests.Mono.Unix {
 		public void TestNoEmit ()
 		{
 			using (UnixSignal u = new UnixSignal (Signum.SIGINT)) {
-				DateTime start = DateTime.Now;
+				var sw = Stopwatch.StartNew ();
 				bool r = u.WaitOne (5100, false);
 				Assert.AreEqual (r, false);
-				DateTime end = DateTime.Now;
-				if ((end - start) < new TimeSpan (0, 0, 5))
-					throw new InvalidOperationException ("Signal didn't block for 5s; blocked for " + (end-start).ToString());
+				sw.Stop ();
+				if (sw.Elapsed < new TimeSpan (0, 0, 5))
+					throw new InvalidOperationException ("Signal didn't block for 5s; blocked for " + sw.Elapsed.TotalSeconds.ToString());
 			}
 		}
 

--- a/mcs/class/System.ServiceModel.Discovery/System.ServiceModel.Discovery.Udp/UdpDuplexChannel.cs
+++ b/mcs/class/System.ServiceModel.Discovery/System.ServiceModel.Discovery.Udp/UdpDuplexChannel.cs
@@ -152,7 +152,7 @@ namespace System.ServiceModel.Discovery.Udp
 
 		public bool TryReceive (TimeSpan timeout, out Message msg)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			ThrowIfDisposedOrNotOpen ();
 			msg = null;
 
@@ -188,7 +188,7 @@ namespace System.ServiceModel.Discovery.Udp
 			msg = message_encoder.ReadMessage (new MemoryStream (bytes), int.MaxValue);
 			var id = msg.Headers.MessageId;
 			if (message_ids.Contains (id))
-				return TryReceive (timeout - (DateTime.Now - start), out msg);
+				return TryReceive (timeout - (DateTime.UtcNow - start), out msg);
 			if (id != null) {
 				message_ids.Enqueue (id);
 				if (message_ids.Count >= binding_element.TransportSettings.DuplicateMessageHistoryLength)

--- a/mcs/class/System.ServiceModel.Discovery/System.ServiceModel.Discovery/DiscoveryChannelDispatcher.cs
+++ b/mcs/class/System.ServiceModel.Discovery/System.ServiceModel.Discovery/DiscoveryChannelDispatcher.cs
@@ -86,7 +86,7 @@ namespace System.ServiceModel.Discovery
 			if (!handle_announce_online)
 				return; // Offline announcement is done by another DiscoveryChannelDispatcher
 
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			Communication.Open (timeout);
 
 			// and call AnnouncementOnline().
@@ -94,7 +94,7 @@ namespace System.ServiceModel.Discovery
 			// Published endpoints are added by DicoveryEndpointPublisherBehavior, which is added to each ServiceEndpoint in the primary (non-announcement) service.
 			if (dx != null) {
 				foreach (var edm in dx.PublishedEndpoints) {
-					client.InnerChannel.OperationTimeout = timeout - (DateTime.Now - start);
+					client.InnerChannel.OperationTimeout = timeout - (DateTime.UtcNow - start);
 					client.AnnounceOnline (edm);
 				}
 			}
@@ -115,19 +115,19 @@ namespace System.ServiceModel.Discovery
 			if (handle_announce_online)
 				return; // Offline announcement is done by another DiscoveryChannelDispatcher
 
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			// and call AnnouncementOnline().
 			var dx = host.Extensions.Find<DiscoveryServiceExtension> ();
 			// Published endpoints are added by DicoveryEndpointPublisherBehavior, which is added to each ServiceEndpoint in the primary (non-announcement) service.
 			if (dx != null) {
 				foreach (var edm in dx.PublishedEndpoints) {
-					client.InnerChannel.OperationTimeout = timeout - (DateTime.Now - start);
+					client.InnerChannel.OperationTimeout = timeout - (DateTime.UtcNow - start);
 					client.AnnounceOffline (edm);
 				}
 			}
 
 			// Then close the client.
-			Communication.Close (timeout - (DateTime.Now - start));
+			Communication.Close (timeout - (DateTime.UtcNow - start));
 		}
 
 		protected override IAsyncResult OnBeginClose (TimeSpan timeout, AsyncCallback callback, object state)

--- a/mcs/class/System.ServiceModel.Discovery/System.ServiceModel.Discovery/DiscoveryRequestChannel.cs
+++ b/mcs/class/System.ServiceModel.Discovery/System.ServiceModel.Discovery/DiscoveryRequestChannel.cs
@@ -107,9 +107,9 @@ namespace System.ServiceModel.Discovery
 		protected override void OnOpen (TimeSpan timeout)
 		{
 			// FIXME: use timeout
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			inner = CreateDiscoveryInnerChannel<TChannel> (factory);
-			((IChannel) inner).Open (timeout - (DateTime.Now - start));
+			((IChannel) inner).Open (timeout - (DateTime.UtcNow - start));
 		}
 
 		public Message Request (Message msg)

--- a/mcs/class/System.ServiceModel.Discovery/Test/System.ServiceModel.Discovery/DiscoveryClientBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel.Discovery/Test/System.ServiceModel.Discovery/DiscoveryClientBindingElementTest.cs
@@ -23,6 +23,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -176,9 +177,9 @@ namespace MonoTests.System.ServiceModel.Discovery
 			Assert.IsNull (cf.GetProperty<DiscoveryEndpoint> (), "#1");
 			var ch = cf.CreateChannel (DiscoveryClientBindingElement.DiscoveryEndpointAddress);
 			Assert.IsNull (ch.GetProperty<DiscoveryEndpoint> (), "#2");
-			DateTime start = DateTime.Now;
+			var sw = Stopwatch.StartNew ();
 			ch.Open (TimeSpan.FromSeconds (5));
-			Assert.IsTrue (DateTime.Now - start < TimeSpan.FromSeconds (15), "It is likely that FindCriteria.Duration is ignored");
+			Assert.IsTrue (sw.Elapsed < TimeSpan.FromSeconds (15), "It is likely that FindCriteria.Duration is ignored");
 		}
 
 		[Test]
@@ -193,9 +194,9 @@ namespace MonoTests.System.ServiceModel.Discovery
 			var cf = be.BuildChannelFactory<IDuplexSessionChannel> (bc);
 			cf.Open ();
 			var ch = cf.CreateChannel (DiscoveryClientBindingElement.DiscoveryEndpointAddress);
-			DateTime start = DateTime.Now;
+			var sw = Stopwatch.StartNew ();
 			ch.Open (TimeSpan.FromSeconds (5));
-			Assert.IsTrue (DateTime.Now - start < TimeSpan.FromSeconds (15), "It is likely that FindCriteria.Duration is ignored");
+			Assert.IsTrue (sw.Elapsed < TimeSpan.FromSeconds (15), "It is likely that FindCriteria.Duration is ignored");
 		}
 
 		[Test]

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpChannelListener.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpChannelListener.cs
@@ -87,15 +87,15 @@ namespace System.ServiceModel.Channels.Http
 		{
 			// HTTP channel could be accepted while there is no incoming request yet. The reply channel waits for the actual request.
 			// HTTP channel listeners do not accept more than one channel at a time.
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			TimeSpan waitTimeout;
 			if (timeout == TimeSpan.MaxValue)
 				waitTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 			else
-				waitTimeout = timeout - (DateTime.Now - start);
+				waitTimeout = timeout - (DateTime.UtcNow - start);
 			accept_channel_handle.WaitOne (waitTimeout);
 			accept_channel_handle.Reset (); 
-			TChannel ch = CreateChannel (timeout - (DateTime.Now - start));
+			TChannel ch = CreateChannel (timeout - (DateTime.UtcNow - start));
 			ch.Closed += delegate {
 				accept_channel_handle.Set ();
 			};

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpListenerManager.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpListenerManager.cs
@@ -94,7 +94,7 @@ namespace System.ServiceModel.Channels.Http
 
 		public bool TryDequeueRequest (ChannelDispatcher channel, TimeSpan timeout, out HttpContextInfo context)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 
 			context = null;
 			HttpChannelListenerEntry ce = null;
@@ -111,7 +111,7 @@ namespace System.ServiceModel.Channels.Http
 					if (timeout == TimeSpan.MaxValue)
 						waitTimeout = TimeSpan.FromMilliseconds (int.MaxValue);
 					bool ret = ce.WaitHandle.WaitOne (waitTimeout);
-					return ret && TryDequeueRequest (channel, waitTimeout - (DateTime.Now - start), out context); // recurse, am lazy :/
+					return ret && TryDequeueRequest (channel, waitTimeout - (DateTime.UtcNow - start), out context); // recurse, am lazy :/
 				}
 				context = q.Dequeue ();
 				return true;

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpReplyChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Http/HttpReplyChannel.cs
@@ -113,12 +113,12 @@ namespace System.ServiceModel.Channels.Http
 					return;
 				close_started = true;
 			}
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 
 			// FIXME: consider timeout
-			AbortConnections (timeout - (DateTime.Now - start));
+			AbortConnections (timeout - (DateTime.UtcNow - start));
 
-			base.OnClose (timeout - (DateTime.Now - start));
+			base.OnClose (timeout - (DateTime.UtcNow - start));
 		}
 
 		protected string GetHeaderItem (string raw)

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpChannelListener.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpChannelListener.cs
@@ -73,7 +73,7 @@ namespace System.ServiceModel.Channels.NetTcp
 
 		protected override TChannel OnAcceptChannel (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 
 			// Close channels that are incorrectly kept open first.
 			var l = new List<TcpDuplexSessionChannel> ();
@@ -83,9 +83,9 @@ namespace System.ServiceModel.Channels.NetTcp
 					l.Add (dch);
 			}
 			foreach (var dch in l)
-				dch.Close (timeout - (DateTime.Now - start));
+				dch.Close (timeout - (DateTime.UtcNow - start));
 
-			TcpClient client = AcceptTcpClient (timeout - (DateTime.Now - start));
+			TcpClient client = AcceptTcpClient (timeout - (DateTime.UtcNow - start));
 			if (client == null)
 				return null; // onclose
 
@@ -109,7 +109,7 @@ namespace System.ServiceModel.Channels.NetTcp
 		// TcpReplyChannel requires refreshed connection after each request processing.
 		internal TcpClient AcceptTcpClient (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 
 			TcpClient client = accepted_clients.Count == 0 ? null : accepted_clients.Dequeue ();
 			if (client == null) {
@@ -121,7 +121,7 @@ namespace System.ServiceModel.Channels.NetTcp
 				}
 				accept_handles.Remove (wait);
 				// recurse with new timeout, or return null if it's either being closed or timed out.
-				timeout -= (DateTime.Now - start);
+				timeout -= (DateTime.UtcNow - start);
 				return State == CommunicationState.Opened && timeout > TimeSpan.Zero ? AcceptTcpClient (timeout) : null;
 			}
 
@@ -132,7 +132,7 @@ namespace System.ServiceModel.Channels.NetTcp
 					continue;
 				if (((IPEndPoint) dch.TcpClient.Client.RemoteEndPoint).Equals (client.Client.RemoteEndPoint))
 					// ... then it should be handled in another BeginTryReceive/EndTryReceive loop in ChannelDispatcher.
-					return AcceptTcpClient (timeout - (DateTime.Now - start));
+					return AcceptTcpClient (timeout - (DateTime.UtcNow - start));
 			}
 
 			return client;

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpDuplexSessionChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpDuplexSessionChannel.cs
@@ -187,12 +187,12 @@ namespace System.ServiceModel.Channels.NetTcp
 			if (client.Available > 0)
 				return true;
 
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			do {
 				Thread.Sleep (50);
 				if (client.Available > 0)
 					return true;
-			} while (DateTime.Now - start < timeout);
+			} while (DateTime.UtcNow - start < timeout);
 			return false;
 		}
 		

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpReplyChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpReplyChannel.cs
@@ -58,8 +58,6 @@ namespace System.ServiceModel.Channels.NetTcp
 			if (timeout <= TimeSpan.Zero)
 				throw new ArgumentException (String.Format ("Timeout value must be positive value. It was {0}", timeout));
 
-			DateTime start = DateTime.Now;
-
 			// FIXME: use timeout
 			if (client == null)
 				client = ((TcpChannelListener<IReplyChannel>) Manager).AcceptTcpClient (timeout);
@@ -110,7 +108,6 @@ namespace System.ServiceModel.Channels.NetTcp
 			{
 				Logger.LogMessage (MessageLogSourceKind.TransportSend, ref message, owner.info.BindingElement.MaxReceivedMessageSize);
 
-				DateTime start = DateTime.Now;
 				owner.frame.WriteUnsizedMessage (message, timeout);
 				// FIXME: consider timeout here too.
 				owner.frame.WriteEndRecord ();
@@ -120,7 +117,6 @@ namespace System.ServiceModel.Channels.NetTcp
 		public override bool TryReceiveRequest (TimeSpan timeout, out RequestContext context)
 		{
 			try {
-				DateTime start = DateTime.Now;
 				context = ReceiveRequest (timeout);
 				return context != null;
 			} catch (Exception ex) {

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpRequestChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpRequestChannel.cs
@@ -82,7 +82,7 @@ namespace System.ServiceModel.Channels.NetTcp
 
 		public override Message Request (Message input, TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 
 			// FIXME: use timeouts.
 			frame.ProcessPreambleInitiator ();
@@ -95,13 +95,13 @@ namespace System.ServiceModel.Channels.NetTcp
 
 			Logger.LogMessage (MessageLogSourceKind.TransportSend, ref input, int.MaxValue); // It is not a receive buffer
 
-			frame.WriteUnsizedMessage (input, timeout - (DateTime.Now - start));
+			frame.WriteUnsizedMessage (input, timeout - (DateTime.UtcNow - start));
 
 			// LAMESPEC: it contradicts the protocol described at section 3.1.1.1.1 in [MC-NMF].
 			// Moving this WriteEndRecord() after ReadUnsizedMessage() causes TCP connection blocking.
 			frame.WriteEndRecord ();
 
-			var ret = frame.ReadUnsizedMessage (timeout - (DateTime.Now - start));
+			var ret = frame.ReadUnsizedMessage (timeout - (DateTime.UtcNow - start));
 
 			Logger.LogMessage (MessageLogSourceKind.TransportReceive, ref ret, info.BindingElement.MaxReceivedMessageSize);
 

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Security/SecurityReplyChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels.Security/SecurityReplyChannel.cs
@@ -77,7 +77,7 @@ namespace System.ServiceModel.Channels.Security
 
 		public override bool TryReceiveRequest (TimeSpan timeout, out RequestContext context)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 
 			if (!inner.TryReceiveRequest (timeout, out context))
 				return false;
@@ -95,14 +95,14 @@ namespace System.ServiceModel.Channels.Security
 				var support = Source.SecuritySupport;
 				var commAuth = support.TokenAuthenticator as CommunicationSecurityTokenAuthenticator;
 				if (commAuth != null)
-					res = commAuth.Communication.ProcessNegotiation (req, timeout - (DateTime.Now - start));
+					res = commAuth.Communication.ProcessNegotiation (req, timeout - (DateTime.UtcNow - start));
 				else
 					throw new MessageSecurityException ("This reply channel does not expect incoming WS-Trust requests");
 
-				context.Reply (res, timeout - (DateTime.Now - start));
-				context.Close (timeout - (DateTime.Now - start));
+				context.Reply (res, timeout - (DateTime.UtcNow - start));
+				context.Close (timeout - (DateTime.UtcNow - start));
 				// wait for another incoming message
-				return TryReceiveRequest (timeout - (DateTime.Now - start), out context);
+				return TryReceiveRequest (timeout - (DateTime.UtcNow - start), out context);
 
 				break;
 			}

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/ChannelFactoryBase.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/ChannelFactoryBase.cs
@@ -132,11 +132,11 @@ namespace System.ServiceModel.Channels
 
 		protected override void OnClose (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			// this implicitly premises: TChannel is IChannel
 			foreach (IChannel ch in channels)
-				ch.Close (timeout - (DateTime.Now - start));
-			base.OnClose (timeout - (DateTime.Now - start));
+				ch.Close (timeout - (DateTime.UtcNow - start));
+			base.OnClose (timeout - (DateTime.UtcNow - start));
 		}
 
 		protected override IAsyncResult OnBeginClose (TimeSpan timeout, AsyncCallback callback, object state)

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/NamedPipeChannelListener.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/NamedPipeChannelListener.cs
@@ -69,7 +69,6 @@ namespace System.ServiceModel.Channels
 		{
 Console.WriteLine ("NamedPipeChannelListener.OnAcceptChannel");
 
-			DateTime start = DateTime.Now;
 			if (active_server != null) {
 				try {
 					server_release_handle.WaitOne (timeout);

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/NamedPipeReplyChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/NamedPipeReplyChannel.cs
@@ -95,7 +95,6 @@ namespace System.ServiceModel.Channels
 				if (message.Headers.RelatesTo == null)
 					message.Headers.RelatesTo = request.Headers.MessageId;
 
-				DateTime start = DateTime.Now;
 				owner.frame.WriteUnsizedMessage (message, timeout);
 				owner.frame.WriteEndRecord ();
 				owner.server.Close ();
@@ -106,7 +105,6 @@ namespace System.ServiceModel.Channels
 		public override bool TryReceiveRequest (TimeSpan timeout, out RequestContext context)
 		{
 			try {
-				DateTime start = DateTime.Now;
 				context = ReceiveRequest (timeout);
 				return context != null;
 			} catch (TimeoutException) {
@@ -126,8 +124,6 @@ namespace System.ServiceModel.Channels
 
 		protected override void OnOpen (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
-
 			// FIXME: use timeout
 			frame = new TcpBinaryFrameManager (TcpBinaryFrameManager.SingletonUnsizedMode, server, true) { Encoder = this.Encoder };
 			frame.ProcessPreambleRecipient ();

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/NamedPipeRequestChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/NamedPipeRequestChannel.cs
@@ -78,7 +78,7 @@ namespace System.ServiceModel.Channels
 
 		public override Message Request (Message input, TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 
 			CreateClient (timeout);
 
@@ -87,11 +87,11 @@ namespace System.ServiceModel.Channels
 			if (input.Headers.MessageId == null)
 				input.Headers.MessageId = new UniqueId ();
 
-			frame.WriteUnsizedMessage (input, timeout - (DateTime.Now - start));
+			frame.WriteUnsizedMessage (input, timeout - (DateTime.UtcNow - start));
 
 			frame.WriteEndRecord ();
 
-			var ret = frame.ReadUnsizedMessage (timeout - (DateTime.Now - start));
+			var ret = frame.ReadUnsizedMessage (timeout - (DateTime.UtcNow - start));
 			frame.ReadEndRecord ();
 			return ret;
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/PeerChannelListener.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/PeerChannelListener.cs
@@ -70,11 +70,11 @@ namespace System.ServiceModel.Channels
 
 		protected override TChannel OnAcceptChannel (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			if (channel != null)
 				if (!accept_handle.WaitOne (timeout))
 					throw new TimeoutException ();
-			channel = PopulateChannel (timeout - (DateTime.Now - start));
+			channel = PopulateChannel (timeout - (DateTime.UtcNow - start));
 			((CommunicationObject) (object) channel).Closed += delegate {
 				this.channel = null;
 				accept_handle.Set ();

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
@@ -414,7 +414,7 @@ namespace System.ServiceModel.Dispatcher
 				if (loop_thread == null)
 					return;
 
-				close_started = DateTime.Now;
+				close_started = DateTime.UtcNow;
 				close_timeout = timeout;
 				loop = false;
 				creator_handle.Set ();
@@ -467,7 +467,7 @@ namespace System.ServiceModel.Dispatcher
 					}
 					else {
 						try {
-							ch.Close (close_timeout - (DateTime.Now - close_started));
+							ch.Close (close_timeout - (DateTime.UtcNow - close_started));
 						} catch (Exception ex) {
 							// FIXME: log it.
 							Logger.Error (String.Format ("Exception on closing channel ({0})", ch.GetType ()), ex);

--- a/mcs/class/System.ServiceModel/System.ServiceModel.PeerResolvers/LocalPeerResolverService.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.PeerResolvers/LocalPeerResolverService.cs
@@ -95,7 +95,7 @@ namespace System.ServiceModel.PeerResolvers
 			if (node == null)
 				return new RefreshResponseInfo () { Result = RefreshResult.RegistrationNotFound };
 			node.Refresh ();
-			return new RefreshResponseInfo () { Result = RefreshResult.Success, RegistrationLifetime = RefreshInterval - (DateTime.Now - node.LastRefreshTime) };
+			return new RefreshResponseInfo () { Result = RefreshResult.Success, RegistrationLifetime = RefreshInterval - (DateTime.UtcNow - node.LastRefreshTime) };
 		}
 
 		public RegisterResponseInfo Register (RegisterInfo registerInfo)
@@ -163,7 +163,7 @@ namespace System.ServiceModel.PeerResolvers
 			lock (mesh) {
 				var node = new Node () { ClientId = clientId, Address = addr };
 				mesh.Add (node);
-				node.LastRefreshTime = DateTime.Now;
+				node.LastRefreshTime = DateTime.UtcNow;
 				return node;
 			}
 		}
@@ -201,13 +201,13 @@ namespace System.ServiceModel.PeerResolvers
 
 		public void Refresh ()
 		{
-			LastRefreshTime = DateTime.Now;
+			LastRefreshTime = DateTime.UtcNow;
 		}
 
 		public void Update (PeerNodeAddress addr)
 		{
 			Address = addr;
-			LastRefreshTime = DateTime.Now;
+			LastRefreshTime = DateTime.UtcNow;
 		}
 	}
 }

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ClientRuntimeChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ClientRuntimeChannel.cs
@@ -383,7 +383,6 @@ namespace System.ServiceModel.MonoInternal
 
 		protected override void OnClose (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
 			if (channel.State == CommunicationState.Opened)
 				channel.Close (timeout);
 		}
@@ -593,9 +592,9 @@ namespace System.ServiceModel.MonoInternal
 			// FIXME: implement ConcurrencyMode check:
 			// if it is .Single && this instance for a callback channel && the operation is invoked inside service operation, then error.
 
-			DateTime startTime = DateTime.Now;
+			DateTime startTime = DateTime.UtcNow;
 			OutputChannel.Send (msg, timeout);
-			return ((IDuplexChannel) channel).Receive (timeout - (DateTime.Now - startTime));
+			return ((IDuplexChannel) channel).Receive (timeout - (DateTime.UtcNow - startTime));
 		}
 
 		internal IAsyncResult BeginRequest (Message msg, TimeSpan timeout, AsyncCallback callback, object state)

--- a/mcs/class/System.ServiceModel/System.ServiceModel/DuplexClientRuntimeChannel.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/DuplexClientRuntimeChannel.cs
@@ -115,12 +115,12 @@ namespace System.ServiceModel.MonoInternal
 
 		protected override void OnClose (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			base.OnClose (timeout);
 			loop = false;
-			if (!loop_handle.WaitOne (timeout - (DateTime.Now - start)))
+			if (!loop_handle.WaitOne (timeout - (DateTime.UtcNow - start)))
 				throw new TimeoutException ();
-			if (!finish_handle.WaitOne (timeout - (DateTime.Now - start)))
+			if (!finish_handle.WaitOne (timeout - (DateTime.UtcNow - start)))
 				throw new TimeoutException ();
 		}
 
@@ -204,7 +204,7 @@ namespace System.ServiceModel.MonoInternal
 		
 		internal override Message RequestCorrelated (Message msg, TimeSpan timeout, IOutputChannel channel)
 		{
-			DateTime startTime = DateTime.Now;
+			DateTime startTime = DateTime.UtcNow;
 			Message ret = null;
 			ManualResetEvent wait = new ManualResetEvent (false);
 			Action<Message> handler = delegate (Message reply) {
@@ -213,7 +213,7 @@ namespace System.ServiceModel.MonoInternal
 			};
 			ReplyHandlerQueue.Enqueue (handler);
 			channel.Send (msg, timeout);
-			if (ret == null && !wait.WaitOne (timeout - (DateTime.Now - startTime)))
+			if (ret == null && !wait.WaitOne (timeout - (DateTime.UtcNow - startTime)))
 				throw new TimeoutException ();
 			return ret;
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel/ServiceHostBase.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ServiceHostBase.cs
@@ -528,12 +528,12 @@ namespace System.ServiceModel
 		
 		void OnCloseOrAbort (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			ReleasePerformanceCounters ();
 			List<ChannelDispatcherBase> l = new List<ChannelDispatcherBase> (ChannelDispatchers);
 			foreach (ChannelDispatcherBase e in l) {
 				try {
-					TimeSpan ts = timeout - (DateTime.Now - start);
+					TimeSpan ts = timeout - (DateTime.UtcNow - start);
 					if (ts < TimeSpan.Zero)
 						e.Abort ();
 					else
@@ -547,7 +547,7 @@ namespace System.ServiceModel
 
 		protected override sealed void OnOpen (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			InitializeRuntime ();
 			for (int i = 0; i < ChannelDispatchers.Count; i++) {
 				// Skip ServiceMetadataExtension-based one. special case.
@@ -567,7 +567,7 @@ namespace System.ServiceModel
 				var wait = new ManualResetEvent (false);
 				cd.Opened += delegate { wait.Set (); };
 				waits.Add (wait);
-				cd.Open (timeout - (DateTime.Now - start));
+				cd.Open (timeout - (DateTime.UtcNow - start));
 			}
 
 			WaitHandle.WaitAll (waits.ToArray ());

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/OperationContractTester.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/OperationContractTester.cs
@@ -27,14 +27,13 @@ namespace MonoTests.Features.Serialization
 				sleepTime = 5 * 1000;
 				failTime = 2 * 1000;
 			}
-			DateTime start = DateTime.Now;
+			var sw = global::System.Diagnostics.Stopwatch.StartNew ();
 			Client.Sleep (sleepTime);
-			DateTime end = DateTime.Now;
-			TimeSpan diff = end.Subtract (start);
+			sw.Stop ();
 			TimeSpan max = TimeSpan.FromMilliseconds(failTime);
-			Assert.IsTrue (diff < max, "Sleep({0} milisec) must end in less than {1} seconds",sleepTime,failTime);
-			if (sleepTime > (int) diff.TotalMilliseconds)
-				Thread.Sleep (sleepTime - (int)diff.TotalMilliseconds); // wait for server thread to release itself
+			Assert.IsTrue (sw.Elapsed < max, "Sleep({0} milisec) must end in less than {1} seconds",sleepTime,failTime);
+			if (sleepTime > (int) sw.ElapsedMilliseconds)
+				Thread.Sleep (sleepTime - (int)sw.ElapsedMilliseconds); // wait for server thread to release itself
 		}
 
 		[Test]

--- a/mcs/class/System.ServiceModel/old-code/HttpChannelListener.cs
+++ b/mcs/class/System.ServiceModel/old-code/HttpChannelListener.cs
@@ -145,10 +145,10 @@ namespace System.ServiceModel.Channels
 		protected override TChannel OnAcceptChannel (TimeSpan timeout)
 		{
 			// HTTP channel listeners do not accept more than one channel at a time.
-			DateTime start = DateTime.Now;
-			accept_channel_handle.WaitOne (timeout - (DateTime.Now - start));
+			DateTime start = DateTime.UtcNow;
+			accept_channel_handle.WaitOne (timeout - (DateTime.UtcNow - start));
 			accept_channel_handle.Reset ();
-			TChannel ch = CreateChannel (timeout - (DateTime.Now - start));
+			TChannel ch = CreateChannel (timeout - (DateTime.UtcNow - start));
 			ch.Closed += delegate {
 				accept_channel_handle.Set ();
 			};

--- a/mcs/class/System.ServiceModel/old-code/HttpReplyChannel.cs
+++ b/mcs/class/System.ServiceModel/old-code/HttpReplyChannel.cs
@@ -85,14 +85,14 @@ namespace System.ServiceModel.Channels
 
 		protected override void OnClose (TimeSpan timeout)
 		{
-			DateTime start = DateTime.Now;
+			DateTime start = DateTime.UtcNow;
 			if (reqctx != null)
 				reqctx.Close (timeout);
 
 			// FIXME: consider timeout
-			AbortConnections (timeout - (DateTime.Now - start));
+			AbortConnections (timeout - (DateTime.UtcNow - start));
 
-			base.OnClose (timeout - (DateTime.Now - start));
+			base.OnClose (timeout - (DateTime.UtcNow - start));
 		}
 
 		public override bool TryReceiveRequest (TimeSpan timeout, out RequestContext context)

--- a/mcs/class/System/System.IO/DefaultWatcher.cs
+++ b/mcs/class/System/System.IO/DefaultWatcher.cs
@@ -127,7 +127,7 @@ namespace System.IO {
 				data = (DefaultWatcherData) watches [fsw];
 				if (data != null) {
 					data.Enabled = false;
-					data.DisabledTime = DateTime.Now;
+					data.DisabledTime = DateTime.UtcNow;
 				}
 			}
 		}
@@ -171,7 +171,7 @@ namespace System.IO {
 		{
 			if (!data.Enabled) {
 				return (data.DisabledTime != DateTime.MaxValue &&
-					(DateTime.Now - data.DisabledTime).TotalSeconds > 5);
+					(DateTime.UtcNow - data.DisabledTime).TotalSeconds > 5);
 			}
 
 			DoFiles (data, data.Directory, dispatch);

--- a/mcs/class/System/System.Net.NetworkInformation/Ping.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/Ping.cs
@@ -246,7 +246,7 @@ namespace System.Net.NetworkInformation {
 				s.SendBufferSize = bytes.Length;
 				s.SendTo (bytes, bytes.Length, SocketFlags.None, target);
 
-				DateTime sentTime = DateTime.Now;
+				var sw = Stopwatch.StartNew ();
 
 				// receive
 				bytes = new byte [100];
@@ -262,7 +262,7 @@ namespace System.Net.NetworkInformation {
 						}
 						throw new NotSupportedException (String.Format ("Unexpected socket error during ping request: {0}", error));
 					}
-					long rtt = (long) (DateTime.Now - sentTime).TotalMilliseconds;
+					long rtt = (long) sw.ElapsedMilliseconds;
 					int headerLength = (bytes [0] & 0xF) << 2;
 					int bodyLength = rc - headerLength;
 
@@ -294,7 +294,7 @@ namespace System.Net.NetworkInformation {
 		private PingReply SendUnprivileged (IPAddress address, int timeout, byte [] buffer, PingOptions options)
 		{
 #if MONO_FEATURE_PROCESS_START
-			DateTime sentTime = DateTime.UtcNow;
+			var sw = Stopwatch.StartNew ();
 
 			Process ping = new Process ();
 			string args = BuildPingArgs (address, timeout, options);
@@ -318,7 +318,7 @@ namespace System.Net.NetworkInformation {
 				string stderr = ping.StandardError.ReadToEnd ();
 #pragma warning restore 219
 				
-				trip_time = (long) (DateTime.UtcNow - sentTime).TotalMilliseconds;
+				trip_time = (long) sw.ElapsedMilliseconds;
 				if (!ping.WaitForExit (timeout) || (ping.HasExited && ping.ExitCode == 2))
 					status = IPStatus.TimedOut;
 				else if (ping.ExitCode == 0)

--- a/mcs/class/System/System.Net/DigestClient.cs
+++ b/mcs/class/System/System.Net/DigestClient.cs
@@ -204,7 +204,7 @@ namespace System.Net
 		public DigestSession () 
 		{
 			_nc = 1;
-			lastUse = DateTime.Now;
+			lastUse = DateTime.UtcNow;
 		}
 
 		public string Algorithm {
@@ -305,7 +305,7 @@ namespace System.Net
 			if (request == null)
 				return null;
 	
-			lastUse = DateTime.Now;
+			lastUse = DateTime.UtcNow;
 			NetworkCredential cred = credentials.GetCredential (request.RequestUri, "digest");
 			if (cred == null)
 				return null;
@@ -378,7 +378,7 @@ namespace System.Net
 				return;
 
 			DateTime t = DateTime.MaxValue;
-			DateTime now = DateTime.Now;
+			DateTime now = DateTime.UtcNow;
 			ArrayList list = null;
 			foreach (int key in cache.Keys) {
 				DigestSession elem = (DigestSession) cache [key];

--- a/mcs/class/System/Test/System.ComponentModel/standalone_tests/TypeDescriptorTest.cs
+++ b/mcs/class/System/Test/System.ComponentModel/standalone_tests/TypeDescriptorTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.ComponentModel;
 using System.Web.UI.WebControls;
 
@@ -14,9 +15,9 @@ class Test {
 
 	static void Main(string[] args) {
 		Console.WriteLine ("This test should normally take less than a second");
-		DateTime start = DateTime.Now;
+		var sw = Stopwatch.StartNew ();
 		DoTest ();
-		TimeSpan ts = DateTime.Now - start;
+		TimeSpan ts = sw.Elapsed;
 		Console.Write ("Time spent: ");
 		Console.WriteLine (ts.ToString());
 	}

--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -714,11 +714,11 @@ namespace MonoTests.System.Diagnostics
 			byte [] buffer = new byte [200];
 
 			// start async Read operation
-			DateTime start = DateTime.Now;
+			var sw = Stopwatch.StartNew ();
 			IAsyncResult ar = stdout.BeginRead (buffer, 0, buffer.Length,
 							    new AsyncCallback (Read), stdout);
 
-			Assert.IsTrue ((DateTime.Now - start).TotalMilliseconds < 1000, "#01 BeginRead was not async");
+			Assert.IsTrue (sw.ElapsedMilliseconds < 1000, "#01 BeginRead was not async");
 			p.WaitForExit ();
 			Assert.AreEqual (0, p.ExitCode, "#02 script failure");
 

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -1356,7 +1356,7 @@ namespace MonoTests.System.Net
 				req.Headers.Add (HttpRequestHeader.IfNoneMatch, "898bbr2347056cc2e096afc66e104653");
 				req.IfModifiedSince = new DateTime (2010, 01, 04);
 
-				DateTime start = DateTime.Now;
+				var sw = global::System.Diagnostics.Stopwatch.StartNew ();
 				HttpWebResponse response = null;
 
 				try {
@@ -1373,7 +1373,7 @@ namespace MonoTests.System.Net
 					Assert.AreEqual (0, bytesRead, "#3");
 				}
 
-				TimeSpan elapsed = DateTime.Now - start;
+				TimeSpan elapsed = sw.Elapsed;
 				Assert.IsTrue (elapsed.TotalMilliseconds < 2000, "#4");
 			}
 		}
@@ -1426,14 +1426,14 @@ namespace MonoTests.System.Net
 					var req = (HttpWebRequest) WebRequest.Create (url_to_test);
 					req.Timeout = TimeOutInMilliSeconds;
 
-					Start = DateTime.Now;
+					Start = DateTime.UtcNow;
 					using (var resp = (HttpWebResponse) req.GetResponse ())
 					{
 						var sr = new StreamReader (resp.GetResponseStream (), Encoding.UTF8);
 						Body = sr.ReadToEnd ();
 					}
 				} catch (Exception e) {
-					End = DateTime.Now;
+					End = DateTime.UtcNow;
 					Exception = e;
 				}
 			}

--- a/mcs/class/corlib/System.Runtime.Remoting.Lifetime/Lease.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting.Lifetime/Lease.cs
@@ -54,12 +54,12 @@ namespace System.Runtime.Remoting.Lifetime
 			_initialLeaseTime = LifetimeServices.LeaseTime;
 			_renewOnCallTime = LifetimeServices.RenewOnCallTime;
 			_sponsorshipTimeout = LifetimeServices.SponsorshipTimeout;
-			_leaseExpireTime = DateTime.Now + _initialLeaseTime;
+			_leaseExpireTime = DateTime.UtcNow + _initialLeaseTime;
 		}
 
 		public TimeSpan CurrentLeaseTime 
 		{ 
-			get { return _leaseExpireTime - DateTime.Now; }
+			get { return _leaseExpireTime - DateTime.UtcNow; }
 		}
 
 		public LeaseState CurrentState 
@@ -82,7 +82,7 @@ namespace System.Runtime.Remoting.Lifetime
 					throw new RemotingException ("InitialLeaseTime property can only be set when the lease is in initial state; state is " + _currentState + ".");
 
 				_initialLeaseTime = value; 
-				_leaseExpireTime = DateTime.Now + _initialLeaseTime;
+				_leaseExpireTime = DateTime.UtcNow + _initialLeaseTime;
 				if (value == TimeSpan.Zero) _currentState = LeaseState.Null;
 			}
 		}
@@ -130,7 +130,7 @@ namespace System.Runtime.Remoting.Lifetime
 
 		public TimeSpan Renew (TimeSpan renewalTime)
 		{
-			DateTime newTime = DateTime.Now + renewalTime;
+			DateTime newTime = DateTime.UtcNow + renewalTime;
 			if (newTime > _leaseExpireTime) _leaseExpireTime = newTime;
 			return CurrentLeaseTime;
 		}

--- a/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
+++ b/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
@@ -2512,7 +2512,7 @@ namespace MonoTests.Microsoft.Win32
 			string subKeyName = Guid.NewGuid ().ToString ();
 
 			try {
-				object rawValue = DateTime.Now;
+				object rawValue = DateTime.UtcNow;
 
 				using (RegistryKey createdKey = Registry.CurrentUser.CreateSubKey (subKeyName)) {
 					// we created a new subkey, so value should not exist

--- a/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryInfoTest.cs
@@ -978,7 +978,7 @@ namespace MonoTests.System.IO
 		public void LastAccessTimeUtc ()
 		{
 			DirectoryInfo info = new DirectoryInfo (TempFolder);
-			info.LastAccessTimeUtc = DateTime.Now;
+			info.LastAccessTimeUtc = DateTime.UtcNow;
 		}
 
 		[Test]
@@ -992,7 +992,7 @@ namespace MonoTests.System.IO
 		public void CreationTimeUtc ()
 		{
 			DirectoryInfo info = new DirectoryInfo (TempFolder);
-			info.CreationTimeUtc = DateTime.Now;
+			info.CreationTimeUtc = DateTime.UtcNow;
 		}
 
 		[Test]

--- a/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
@@ -27,6 +27,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using NUnit.Framework;
 
@@ -91,8 +92,8 @@ namespace MonoTests.System.Threading
 				else
 					ThreadPool.QueueUserWorkItem (_ => { Interlocked.Increment (ref sum); Interlocked.Increment (ref total); });
 			}
-			var start = DateTime.Now;
-			while ((total != n || sum != 0) && (DateTime.Now - start).TotalSeconds < 60)
+			var sw = Stopwatch.StartNew ();
+			while ((total != n || sum != 0) && sw.Elapsed.TotalSeconds < 60)
 				Thread.Sleep (1000);
 			Assert.IsTrue (total == n, "#1");
 			Assert.IsTrue (sum   == 0, "#2");
@@ -160,7 +161,7 @@ namespace MonoTests.System.Threading
 		public void GetAvailableThreads ()
 		{
 			ManualResetEvent mre = new ManualResetEvent (false);
-			DateTime start = DateTime.Now;
+			var sw = Stopwatch.StartNew ();
 			int i, workerThreads, completionPortThreads;
 
 			try {
@@ -173,7 +174,7 @@ namespace MonoTests.System.Threading
 
 					Console.WriteLine ("workerThreads = {0}, completionPortThreads = {1}", workerThreads, completionPortThreads);
 
-					if ((DateTime.Now - start).TotalSeconds >= 10)
+					if (sw.Elapsed.TotalSeconds >= 10)
 						Assert.Fail ("did not reach 0 available threads");
 
 					ThreadPool.QueueUserWorkItem (GetAvailableThreads_Callback, mre);

--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -1349,9 +1349,9 @@ namespace MonoTests.System.Threading
 		
 		public static void WhileAlive (Thread t, bool alive, string s)
 		{
-			DateTime ti = DateTime.Now;
+			var sw = SD.Stopwatch.StartNew ();
 			while (t.IsAlive == alive) {
-				if ((DateTime.Now - ti).TotalSeconds > 10) {
+				if (sw.Elapsed.TotalSeconds > 10) {
 					if (alive) Assert.Fail ("Timeout while waiting for not alive state. " + s);
 					else Assert.Fail ("Timeout while waiting for alive state. " + s);
 				}
@@ -1360,12 +1360,12 @@ namespace MonoTests.System.Threading
 
 		public static bool WhileAliveOrStop (Thread t, bool alive, string s)
 		{
-			DateTime ti = DateTime.Now;
+			var sw = SD.Stopwatch.StartNew ();
 			while (t.IsAlive == alive) {
 				if (t.ThreadState == ThreadState.Stopped)
 					return false;
 
-				if ((DateTime.Now - ti).TotalSeconds > 10) {
+				if (sw.Elapsed.TotalSeconds > 10) {
 					if (alive) Assert.Fail ("Timeout while waiting for not alive state. " + s);
 					else Assert.Fail ("Timeout while waiting for alive state. " + s);
 				}

--- a/mcs/class/corlib/Test/System.Threading/WaitHandleTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/WaitHandleTest.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -558,8 +559,8 @@ namespace MonoTests.System.Threading {
 
 				Thread.Sleep (10); // wait a bit so we enter mre.WaitOne
 
-				DateTime end = DateTime.Now.AddMilliseconds (500);
-				while (DateTime.Now < end) {
+				var sw = Stopwatch.StartNew ();
+				while (sw.ElapsedMilliseconds <= 500) {
 					thread.Suspend ();
 					thread.Resume ();
 				}
@@ -588,8 +589,8 @@ namespace MonoTests.System.Threading {
 
 				Thread.Sleep (10); // wait a bit so we enter WaitHandle.WaitAny ({mre1, mre2})
 
-				DateTime end = DateTime.Now.AddMilliseconds (500);
-				while (DateTime.Now < end) {
+				var sw = Stopwatch.StartNew ();
+				while (sw.ElapsedMilliseconds <= 500) {
 					thread.Suspend ();
 					thread.Resume ();
 				}
@@ -618,8 +619,8 @@ namespace MonoTests.System.Threading {
 
 				Thread.Sleep (10); // wait a bit so we enter WaitHandle.WaitAll ({mre1, mre2})
 
-				DateTime end = DateTime.Now.AddMilliseconds (500);
-				while (DateTime.Now < end) {
+				var sw = Stopwatch.StartNew ();
+				while (sw.ElapsedMilliseconds <= 500) {
 					thread.Suspend ();
 					thread.Resume ();
 				}


### PR DESCRIPTION
Use Stopwatch or DateTime.UtcNow instead which aren't affected by things like daylight saving time.