### PR TITLE
[2017-06][interp] add --aot=interp, so we can run `mono --full-aot --interpreter`

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1015,6 +1015,8 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 				ref->method = mono_marshal_get_gsharedvt_in_wrapper ();
 			} else if (subtype == WRAPPER_SUBTYPE_GSHAREDVT_OUT) {
 				ref->method = mono_marshal_get_gsharedvt_out_wrapper ();
+			} else if (subtype == WRAPPER_SUBTYPE_INTERP_IN) {
+				ref->method = mini_get_interp_in_wrapper (target->signature);
 			} else if (subtype == WRAPPER_SUBTYPE_GSHAREDVT_IN_SIG) {
 				MonoMethodSignature *sig = decode_signature (module, p, &p);
 				if (!sig)
@@ -2017,7 +2019,7 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 			}
 		}
 		if (!sofile) {
-			if (mono_aot_only && assembly->image->tables [MONO_TABLE_METHOD].rows) {
+			if (mono_aot_only && !mono_use_interpreter && assembly->image->tables [MONO_TABLE_METHOD].rows) {
 				aot_name = g_strdup_printf ("%s%s", assembly->image->name, MONO_SOLIB_EXT);
 				g_error ("Failed to load AOT module '%s' in aot-only mode.\n", aot_name);
 				g_free (aot_name);
@@ -2061,7 +2063,7 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 	}
 
 	if (!usable) {
-		if (mono_aot_only) {
+		if (mono_aot_only && !mono_use_interpreter) {
 			g_error ("Failed to load AOT module '%s' while running in aot-only mode: %s.\n", found_aot_name, msg);
 		} else {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_AOT, "AOT: module %s is unusable: %s.", found_aot_name, msg);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -992,10 +992,14 @@ ves_pinvoke_method (MonoInvocation *frame, MonoMethodSignature *sig, MonoFuncV a
 
 	g_assert (!frame->runtime_method);
 	if (!mono_interp_enter_icall_trampoline) {
-		MonoTrampInfo *info;
-		mono_interp_enter_icall_trampoline = mono_arch_get_enter_icall_trampoline (&info);
-		// TODO:
-		// mono_tramp_info_register (info, NULL);
+		if (mono_aot_only) {
+			mono_interp_enter_icall_trampoline = mono_aot_get_trampoline ("enter_icall_trampoline");
+		} else {
+			MonoTrampInfo *info;
+			mono_interp_enter_icall_trampoline = mono_arch_get_enter_icall_trampoline (&info);
+			// TODO:
+			// mono_tramp_info_register (info, NULL);
+		}
 	}
 
 	InterpMethodArguments *margs = build_args_from_sig (sig, frame);
@@ -2036,9 +2040,10 @@ mono_interp_create_method_pointer (MonoMethod *method, MonoError *error)
 	 * rgctx register using a trampoline.
 	 */
 
-	// FIXME: AOT
-	g_assert (!mono_aot_only);
-	addr = mono_arch_get_static_rgctx_trampoline (ftndesc, jit_wrapper);
+	if (mono_aot_only)
+		addr = mono_aot_get_static_rgctx_trampoline (ftndesc, jit_wrapper);
+	else
+		addr = mono_arch_get_static_rgctx_trampoline (ftndesc, jit_wrapper);
 
 	mono_memory_barrier ();
 	rmethod->jit_entry = addr;


### PR DESCRIPTION
forgot to cherry-pick this commit in https://github.com/mono/mono/pull/4992