### PR TITLE
[w32handle] Change refcounting to explicitly track handle state and version.

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3481,7 +3481,8 @@ mono_w32file_find_next (gpointer handle, WIN32_FIND_DATA *find_data)
 	time_t create_time;
 	glong bytes;
 	gboolean ret = FALSE;
-	
+	guint32 handle_version;
+
 	ok=mono_w32handle_lookup (handle, MONO_W32HANDLE_FIND,
 				(gpointer *)&find_handle);
 	if(ok==FALSE) {
@@ -3491,7 +3492,7 @@ mono_w32file_find_next (gpointer handle, WIN32_FIND_DATA *find_data)
 		return(FALSE);
 	}
 
-	mono_w32handle_lock_handle (handle);
+	mono_w32handle_lock_handle (handle, &handle_version);
 	
 retry:
 	if (find_handle->count >= find_handle->num) {
@@ -3591,7 +3592,7 @@ retry:
 	g_free (utf16_basename);
 
 cleanup:
-	mono_w32handle_unlock_handle (handle);
+	mono_w32handle_unlock_handle (handle, &handle_version);
 	
 	return(ret);
 }
@@ -3601,6 +3602,7 @@ mono_w32file_find_close (gpointer handle)
 {
 	MonoW32HandleFind *find_handle;
 	gboolean ok;
+	guint32 handle_version;
 
 	if (handle == NULL) {
 		mono_w32error_set_last (ERROR_INVALID_HANDLE);
@@ -3616,12 +3618,12 @@ mono_w32file_find_close (gpointer handle)
 		return(FALSE);
 	}
 
-	mono_w32handle_lock_handle (handle);
+	mono_w32handle_lock_handle (handle, &handle_version);
 	
 	g_strfreev (find_handle->namelist);
 	g_free (find_handle->dir_part);
 
-	mono_w32handle_unlock_handle (handle);
+	mono_w32handle_unlock_handle (handle, &handle_version);
 	
 	MONO_ENTER_GC_SAFE;
 	mono_w32handle_close (handle);

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -153,13 +153,13 @@ gboolean
 mono_w32handle_issignalled (gpointer handle);
 
 void
-mono_w32handle_lock_handle (gpointer handle);
+mono_w32handle_lock_handle (gpointer handle, guint32 *version);
 
 gboolean
-mono_w32handle_trylock_handle (gpointer handle);
+mono_w32handle_trylock_handle (gpointer handle, guint32 *version);
 
 void
-mono_w32handle_unlock_handle (gpointer handle);
+mono_w32handle_unlock_handle (gpointer handle, guint32 *version);
 
 MonoW32HandleWaitRet
 mono_w32handle_wait_one (gpointer handle, guint32 timeout, gboolean alertable);

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -161,6 +161,7 @@ static gpointer
 sem_handle_create (MonoW32HandleSemaphore *sem_handle, MonoW32HandleType type, gint32 initial, gint32 max)
 {
 	gpointer handle;
+	guint32 handle_version;
 
 	sem_handle->val = initial;
 	sem_handle->max = max;
@@ -173,12 +174,12 @@ sem_handle_create (MonoW32HandleSemaphore *sem_handle, MonoW32HandleType type, g
 		return NULL;
 	}
 
-	mono_w32handle_lock_handle (handle);
+	mono_w32handle_lock_handle (handle, &handle_version);
 
 	if (initial != 0)
 		mono_w32handle_set_signal_state (handle, TRUE, FALSE);
 
-	mono_w32handle_unlock_handle (handle);
+	mono_w32handle_unlock_handle (handle, &handle_version);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: created %s handle %p",
 		__func__, mono_w32handle_get_typename (type), handle);
@@ -281,6 +282,7 @@ ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle,
 	MonoW32HandleType type;
 	MonoW32HandleSemaphore *sem_handle;
 	MonoBoolean ret;
+	guint32 handle_version;
 
 	if (!handle) {
 		mono_w32error_set_last (ERROR_INVALID_HANDLE);
@@ -304,7 +306,7 @@ ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle,
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s: releasing %s handle %p",
 		__func__, mono_w32handle_get_typename (type), handle);
 
-	mono_w32handle_lock_handle (handle);
+	mono_w32handle_lock_handle (handle, &handle_version);
 
 	/* Do this before checking for count overflow, because overflowing
 	 * max is a listed technique for finding the current value */
@@ -327,7 +329,7 @@ ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle,
 		ret = TRUE;
 	}
 
-	mono_w32handle_unlock_handle (handle);
+	mono_w32handle_unlock_handle (handle, &handle_version);
 
 	return ret;
 }


### PR DESCRIPTION
This is a big debug helper change. It was used to find the GetProccess (int) bug.