### PR TITLE
[profiler] Remove the type field from TYPE_SAMPLE_HIT.

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
@@ -138,16 +138,6 @@ namespace Mono.Profiler.Log {
 		ExceptionHandling = 10,
 	}
 
-	// mono/profiler/log.h : SAMPLE_*
-	public enum LogSampleHitType {
-		Cycles = 1,
-		Instructions = 2,
-		CacheMisses = 3,
-		CacheHits = 4,
-		Branches = 5,
-		BranchMisses = 6,
-	}
-
 	// mono/metadata/profiler.h : MonoProfilerGCRootType
 	[Flags]
 	public enum LogHeapRootAttributes {

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEvents.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEvents.cs
@@ -443,8 +443,6 @@ namespace Mono.Profiler.Log {
 
 	public sealed class SampleHitEvent : LogEvent {
 
-		public LogSampleHitType Type { get; internal set; }
-
 		public long ThreadId { get; internal set; }
 
 		public IReadOnlyList<long> UnmanagedBacktrace { get; internal set; }

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
@@ -380,7 +380,6 @@ namespace Mono.Profiler.Log {
 				switch (extType) {
 				case LogEventType.SampleHit:
 					return new SampleHitEvent {
-						Type = (LogSampleHitType) Reader.ReadByte (),
 						ThreadId = ReadPointer (),
 						UnmanagedBacktrace = ReadBacktrace (true, false),
 						ManagedBacktrace = ReadBacktrace (true),

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -4384,7 +4384,6 @@ handle_dumper_queue_entry (MonoProfiler *prof)
 		);
 
 		emit_event_time (logbuffer, TYPE_SAMPLE | TYPE_SAMPLE_HIT, sample->time);
-		emit_byte (logbuffer, SAMPLE_CYCLES);
 		emit_ptr (logbuffer, (void *) sample->tid);
 		emit_value (logbuffer, 1);
 

--- a/mono/profiler/log.h
+++ b/mono/profiler/log.h
@@ -67,6 +67,7 @@
                added an image pointer field to assembly load events
                added an exception object field to TYPE_CLAUSE
                class unload events no longer exist (they were never emitted)
+               removed type field from TYPE_SAMPLE_HIT
  */
 
 enum {
@@ -160,19 +161,6 @@ enum {
 	MONO_PROFILER_GC_HANDLE_CREATED,
 	MONO_PROFILER_GC_HANDLE_DESTROYED,
 };
-
-// Sampling sources
-// Unless you have compiled with --enable-perf-events, only SAMPLE_CYCLES is available
-enum {
-	SAMPLE_CYCLES = 1,
-	SAMPLE_INSTRUCTIONS,
-	SAMPLE_CACHE_MISSES,
-	SAMPLE_CACHE_REFS,
-	SAMPLE_BRANCHES,
-	SAMPLE_BRANCH_MISSES,
-	SAMPLE_LAST
-};
-
 
 // If you alter MAX_FRAMES, you may need to alter SAMPLE_BLOCK_SIZE too.
 #define MAX_FRAMES 32

--- a/mono/profiler/mprof-report.c
+++ b/mono/profiler/mprof-report.c
@@ -896,6 +896,16 @@ lookup_unmanaged_binary (uintptr_t addr)
 	return NULL;
 }
 
+// For backwards compatibility.
+enum {
+	SAMPLE_CYCLES = 1,
+	SAMPLE_INSTRUCTIONS,
+	SAMPLE_CACHE_MISSES,
+	SAMPLE_CACHE_REFS,
+	SAMPLE_BRANCHES,
+	SAMPLE_BRANCH_MISSES,
+};
+
 static const char*
 sample_type_name (int type)
 {
@@ -2895,7 +2905,10 @@ decode_buffer (ProfContext *ctx)
 					uint64_t tdiff = decode_uleb128 (p + 1, &p);
 					LOG_TIME (time_base, tdiff);
 					time_base += tdiff;
-					sample_type = *p++;
+					if (ctx->data_version < 14)
+						sample_type = *p++;
+					else
+						sample_type = SAMPLE_CYCLES;
 					tstamp = time_base;
 				} else {
 					sample_type = decode_uleb128 (p + 1, &p);


### PR DESCRIPTION
It's unlikely that we'll add support for other kinds of sampling in the future as we've dropped support for `perf` on Linux.