### PR TITLE
[mempool] Annotate functions for clang's ThreadSanitizer

### DIFF
--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -93,16 +93,18 @@ mono_mempool_new (void)
 
 /**
  * mono_mempool_new_size:
+ *
+ *   clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
+ *     * mono_mempool_alloc
+ *     * mono_mempool_new_size
+ *     * mono_mempool_destroy
+ *   while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
+ *   the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
+ *   https://bugzilla.xamarin.com/show_bug.cgi?id=57936
+ *
  * \param initial_size the amount of memory to initially reserve for the memory pool.
  * \returns a new memory pool with a specific initial memory reservation.
  */
-// clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
-//   * mono_mempool_alloc
-//   * mono_mempool_new_size
-//   * mono_mempool_destroy
-// while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
-// the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
-// https://bugzilla.xamarin.com/show_bug.cgi?id=57936
 MONO_NO_SANITIZE_THREAD
 MonoMemPool *
 mono_mempool_new_size (int initial_size)
@@ -129,17 +131,19 @@ mono_mempool_new_size (int initial_size)
 
 /**
  * mono_mempool_destroy:
+ *
+ *   clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
+ *     * mono_mempool_alloc
+ *     * mono_mempool_new_size
+ *     * mono_mempool_destroy
+ *   while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
+ *   the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
+ *   https://bugzilla.xamarin.com/show_bug.cgi?id=57936
+ *
  * \param pool the memory pool to destroy
  *
  * Free all memory associated with this pool.
  */
-// clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
-//   * mono_mempool_alloc
-//   * mono_mempool_new_size
-//   * mono_mempool_destroy
-// while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
-// the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
-// https://bugzilla.xamarin.com/show_bug.cgi?id=57936
 MONO_NO_SANITIZE_THREAD
 void
 mono_mempool_destroy (MonoMemPool *pool)
@@ -268,6 +272,15 @@ get_next_size (MonoMemPool *pool, int size)
 
 /**
  * mono_mempool_alloc:
+ *
+ *   clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
+ *     * mono_mempool_alloc
+ *     * mono_mempool_new_size
+ *     * mono_mempool_destroy
+ *   while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
+ *   the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
+ *   https://bugzilla.xamarin.com/show_bug.cgi?id=57936
+ *
  * \param pool the memory pool to use
  * \param size size of the memory block
  *
@@ -275,13 +288,6 @@ get_next_size (MonoMemPool *pool, int size)
  *
  * \returns the address of a newly allocated memory block.
  */
-// clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
-//   * mono_mempool_alloc
-//   * mono_mempool_new_size
-//   * mono_mempool_destroy
-// while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
-// the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
-// https://bugzilla.xamarin.com/show_bug.cgi?id=57936
 MONO_NO_SANITIZE_THREAD
 gpointer
 mono_mempool_alloc (MonoMemPool *pool, guint size)

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -95,6 +95,18 @@ mono_mempool_new (void)
  * \param initial_size the amount of memory to initially reserve for the memory pool.
  * \returns a new memory pool with a specific initial memory reservation.
  */
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+// clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
+//   * mono_mempool_alloc
+//   * mono_mempool_new_size
+//   * mono_mempool_destroy
+// while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
+// the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
+// https://bugzilla.xamarin.com/show_bug.cgi?id=57936
+__attribute__ ((no_sanitize("thread")))
+#endif
+#endif
 MonoMemPool *
 mono_mempool_new_size (int initial_size)
 {
@@ -124,6 +136,18 @@ mono_mempool_new_size (int initial_size)
  *
  * Free all memory associated with this pool.
  */
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+// clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
+//   * mono_mempool_alloc
+//   * mono_mempool_new_size
+//   * mono_mempool_destroy
+// while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
+// the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
+// https://bugzilla.xamarin.com/show_bug.cgi?id=57936
+__attribute__ ((no_sanitize("thread")))
+#endif
+#endif
 void
 mono_mempool_destroy (MonoMemPool *pool)
 {
@@ -258,6 +282,18 @@ get_next_size (MonoMemPool *pool, int size)
  *
  * \returns the address of a newly allocated memory block.
  */
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+// clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
+//   * mono_mempool_alloc
+//   * mono_mempool_new_size
+//   * mono_mempool_destroy
+// while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
+// the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
+// https://bugzilla.xamarin.com/show_bug.cgi?id=57936
+__attribute__ ((no_sanitize("thread")))
+#endif
+#endif
 gpointer
 mono_mempool_alloc (MonoMemPool *pool, guint size)
 {

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -20,6 +20,7 @@
 
 #include "mempool.h"
 #include "mempool-internals.h"
+#include "utils/mono-compiler.h"
 
 /*
  * MonoMemPool is for fast allocation of memory. We free
@@ -95,8 +96,6 @@ mono_mempool_new (void)
  * \param initial_size the amount of memory to initially reserve for the memory pool.
  * \returns a new memory pool with a specific initial memory reservation.
  */
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
 // clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
 //   * mono_mempool_alloc
 //   * mono_mempool_new_size
@@ -104,9 +103,7 @@ mono_mempool_new (void)
 // while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
 // the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
 // https://bugzilla.xamarin.com/show_bug.cgi?id=57936
-__attribute__ ((no_sanitize("thread")))
-#endif
-#endif
+MONO_NO_SANITIZE_THREAD
 MonoMemPool *
 mono_mempool_new_size (int initial_size)
 {
@@ -136,8 +133,6 @@ mono_mempool_new_size (int initial_size)
  *
  * Free all memory associated with this pool.
  */
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
 // clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
 //   * mono_mempool_alloc
 //   * mono_mempool_new_size
@@ -145,9 +140,7 @@ mono_mempool_new_size (int initial_size)
 // while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
 // the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
 // https://bugzilla.xamarin.com/show_bug.cgi?id=57936
-__attribute__ ((no_sanitize("thread")))
-#endif
-#endif
+MONO_NO_SANITIZE_THREAD
 void
 mono_mempool_destroy (MonoMemPool *pool)
 {
@@ -282,8 +275,6 @@ get_next_size (MonoMemPool *pool, int size)
  *
  * \returns the address of a newly allocated memory block.
  */
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
 // clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
 //   * mono_mempool_alloc
 //   * mono_mempool_new_size
@@ -291,9 +282,7 @@ get_next_size (MonoMemPool *pool, int size)
 // while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
 // the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
 // https://bugzilla.xamarin.com/show_bug.cgi?id=57936
-__attribute__ ((no_sanitize("thread")))
-#endif
-#endif
+MONO_NO_SANITIZE_THREAD
 gpointer
 mono_mempool_alloc (MonoMemPool *pool, guint size)
 {

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -113,5 +113,16 @@ typedef SSIZE_T ssize_t;
 #define MONO_GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
+/* Used to tell clang's ThreadSanitizer to not report data races that occur within a certain function */
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define MONO_NO_SANITIZE_THREAD __attribute__ ((no_sanitize("thread")))
+#else
+#define MONO_NO_SANITIZE_THREAD
+#endif
+#else
+#define MONO_NO_SANITIZE_THREAD
+#endif
+
 #endif /* __UTILS_MONO_COMPILER_H__*/
 


### PR DESCRIPTION
As discussed (https://bugzilla.xamarin.com/show_bug.cgi?id=57936) and suggested by @luhenry and @vargaz, I whitelisted three functions of mempool.c in order to hide race reports of clang's ThreadSanitizer.