### PR TITLE
Remove partial path for ml.exe and ml64.exe in mono VS runtime builds.

### DIFF
--- a/msvc/masm.fixed.props
+++ b/msvc/masm.fixed.props
@@ -15,8 +15,8 @@
       <PackAlignmentBoundary>0</PackAlignmentBoundary>
       <CallingConvention>0</CallingConvention>
       <ErrorReporting>0</ErrorReporting>
-      <CommandLineTemplate Condition="'$(Platform)' == 'Win32'">"$(VCInstallDir)bin\ml.exe" /c [AllOptions] [AdditionalOptions] /Ta[Inputs]</CommandLineTemplate>
-      <CommandLineTemplate Condition="'$(Platform)' == 'X64'">"$(VCInstallDir)bin\amd64\ml64.exe" /c [AllOptions] [AdditionalOptions] /Ta[Inputs]</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' == 'Win32'">"ml.exe" /c [AllOptions] [AdditionalOptions] /Ta[Inputs]</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' == 'X64'">"ml64.exe" /c [AllOptions] [AdditionalOptions] /Ta[Inputs]</CommandLineTemplate>
       <CommandLineTemplate Condition="'$(Platform)' != 'Win32' and '$(Platform)' != 'X64'">echo MASM not supported on this platform</CommandLineTemplate>
       <ExecutionDescription>Assembling %(Identity)...</ExecutionDescription>
     </MASM>


### PR DESCRIPTION
Location of ml.exe and ml64.exe is different in VS2017 compared to VS2015.
By removing the partial path from the command, the VS environment will locate
the tool depending on selected build configuration and VS version.

This should work for both VS2015 and VS2017.