### PR TITLE
[profiler] Don't call mono_gc_base_init () before loading profilers.

### DIFF
--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -125,8 +125,6 @@ load_profiler_from_installation (const char *libname, const char *desc)
 void
 mono_profiler_load (const char *desc)
 {
-	mono_gc_base_init ();
-
 	if (!desc || !strcmp ("default", desc))
 		desc = "log:report";
 


### PR DESCRIPTION
Just putting this through CI to see what, if anything, breaks.