### PR TITLE
[Microsoft.Build] Make BuildSubmissionTest.EndBuildWaitsForCompletion more reliable

### DIFF
--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs
@@ -81,35 +81,29 @@ namespace MonoTests.Microsoft.Build.Execution
 		[Test]
 		public void EndBuildWaitsForSubmissionCompletion ()
 		{
-			// Windows does not have useful sleep or alternative, so skip it
-			bool is_windows = true;
-			switch (Environment.OSVersion.Platform) {
-			case PlatformID.Unix:
-			case PlatformID.MacOSX:
-				is_windows = false;
-				break;
-			}
 			string project_xml = string.Format (@"<Project DefaultTargets='Wait1Sec' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
   <Target Name='Wait1Sec'>
     <Exec Command='{0}' />
   </Target>
-</Project>", is_windows ? "powershell -command \"Start-Sleep -s 1\"" : "/bin/sleep 1");
+</Project>", Environment.OSVersion.Platform == PlatformID.Win32NT ? "powershell -command \"Start-Sleep -s 1\"" : "/bin/sleep 1");
 			var xml = XmlReader.Create (new StringReader (project_xml));
 			var root = ProjectRootElement.Create (xml);
 			root.FullPath = "BuildSubmissionTest.EndBuildWaitsForSubmissionCompletion.proj";
 			var proj = new ProjectInstance (root);
 			var bm = new BuildManager ();
 			bm.BeginBuild (new BuildParameters ());
-			DateTime waitDone = DateTime.MinValue;
-			DateTime beforeExec = DateTime.UtcNow;
+			var waitDone = TimeSpan.MinValue;
+			var sw = System.Diagnostics.Stopwatch.StartNew ();
 			var sub = bm.PendBuildRequest (new BuildRequestData (proj, new string [] { "Wait1Sec" }));
-			sub.ExecuteAsync (delegate { waitDone = DateTime.UtcNow; }, null);
+			sub.ExecuteAsync (cb => waitDone = sw.Elapsed, null);
 			bm.EndBuild ();
 			Assert.AreEqual (BuildResultCode.Success, sub.BuildResult.OverallResult, "#1");
-			DateTime endBuildDone = DateTime.UtcNow;
-			AssertHelper.GreaterOrEqual (endBuildDone - beforeExec, TimeSpan.FromSeconds (1), "#2");
-			AssertHelper.GreaterOrEqual (waitDone, beforeExec, "#3");
+			var endBuildDone = sw.Elapsed;
+			AssertHelper.GreaterOrEqual (endBuildDone, TimeSpan.FromSeconds (1), "#2");
+			AssertHelper.GreaterOrEqual (waitDone, TimeSpan.FromSeconds (1), "#3");
 			AssertHelper.GreaterOrEqual (endBuildDone, waitDone, "#4");
+			AssertHelper.LessOrEqual (endBuildDone, TimeSpan.FromSeconds (1.5), "#5");
+			AssertHelper.LessOrEqual (waitDone, TimeSpan.FromSeconds (1.5), "#6");
 		}
 		
 		[Test]

--- a/mcs/class/test-helpers/NunitHelpers.cs
+++ b/mcs/class/test-helpers/NunitHelpers.cs
@@ -124,6 +124,21 @@ namespace NUnit.Framework
 			Assert.That(arg1, Is.LessThanOrEqualTo(arg2), message, args);
 		}
 
+		public static void LessOrEqual(long arg1, long arg2, string message = null, params object[] args)
+		{
+			Assert.That(arg1, Is.LessThanOrEqualTo(arg2), message, args);
+		}
+
+		public static void LessOrEqual(System.DateTime arg1, System.DateTime arg2, string message = null, params object[] args)
+		{
+			Assert.That(arg1, Is.LessThanOrEqualTo(arg2), message, args);
+		}
+
+		public static void LessOrEqual(System.TimeSpan arg1, System.TimeSpan arg2, string message = null, params object[] args)
+		{
+			Assert.That(arg1, Is.LessThanOrEqualTo(arg2), message, args);
+		}
+
 		public static void IsNotInstanceOfType(System.Type expected, object actual, string message, params object[] args )
 		{
 			Assert.IsFalse (actual.GetType ().IsInstanceOfType (expected), message, args);


### PR DESCRIPTION
We've seen this test failure a few times:

```
MESSAGE:
  #2
  Expected: greater than or equal to 00:00:01
  But was:  00:00:00.9544900

+++++++++++++++++++
STACK TRACE:
  at MonoTests.Microsoft.Build.Execution.BuildSubmissionTest.EndBuildWaitsForSubmissionCompletion () [0x000d8] in /mnt/jenkins/workspace/test-mono-mainline-linux/label/ubuntu-1404-amd64/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs:110
  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /mnt/jenkins/workspace/test-mono-mainline-linux/label/ubuntu-1404-amd64/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
```

Rewriting the test to use Stopwatch instead of DateTime for measuring elapsed time should make it more reliable.