### PR TITLE
Add SoapAction to Content-type for SOAP 1.2

### DIFF
--- a/mcs/class/System.Web.Services/System.Web.Services.Protocols/SoapHttpClientProtocol.cs
+++ b/mcs/class/System.Web.Services/System.Web.Services.Protocols/SoapHttpClientProtocol.cs
@@ -208,9 +208,12 @@ namespace System.Web.Services.Protocols
 			WebRequest request = GetWebRequest (uri);
 			request.Method = "POST";
 			WebHeaderCollection headers = request.Headers;
-			if (!message.IsSoap12)
-				headers.Add ("SOAPAction", "\"" + message.Action + "\"");
 			request.ContentType = message.ContentType + "; charset=utf-8";
+			if (!message.IsSoap12) {
+				headers.Add ("SOAPAction", "\"" + message.Action + "\"");
+			} else {
+				request.ContentType += "; action=\"" + message.Action + "\"";
+			}
 			return request;
 		}
 


### PR DESCRIPTION
For SOAP 1.2 it is necessary to have a action-tag in Content-Type of Http-Header