### PR TITLE
[msbuild] Update packaging/msbuild.py to use branch HEAD

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -2,8 +2,7 @@ import fileinput
 
 class MSBuild (GitHubPackage):
 	def __init__ (self):
-		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15.3',
-			revision = 'f7dcc3900c808775adad970f047202b4de34e986')
+		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15.5', git_branch = 'xplat-master')
 
 	def build (self):
 		self.sh ('./cibuild.sh --scope Compile --target Mono --host Mono --config Release')


### PR DESCRIPTION
.. and bump version from 15.3 to 15.5, which is only really used by
bockbuild itself.