### PR TITLE
[llvm] Disable an optimization in LLVM where we deleted and recompute…

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7114,19 +7114,6 @@ emit_method_inner (EmitContext *ctx)
 	}
 
 	/*
-	 * The INDIRECT flag added by OP_LDADDR inhibits optimizations, even if the LDADDR
-	 * was later optimized away, so clear these flags, and add them back for the still
-	 * present OP_LDADDR instructions.
-	 */
-	for (i = 0; i < cfg->next_vreg; ++i) {
-		MonoInst *ins;
-
-		ins = get_vreg_to_inst (cfg, i);
-		if (ins && ins != cfg->rgctx_var)
-			ins->flags &= ~MONO_INST_INDIRECT;
-	}
-
-	/*
 	 * Make a first pass over the code to precreate PHI nodes/set INDIRECT flags.
 	 */
 	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2077,8 +2077,11 @@ mono_compile_create_vars (MonoCompile *cfg)
 	if (cfg->verbose_level > 2)
 		g_print ("creating locals\n");
 
-	for (i = 0; i < header->num_locals; ++i)
+	for (i = 0; i < header->num_locals; ++i) {
+		if (cfg->verbose_level > 2)
+			g_print ("\tlocal [%d]: ", i);
 		cfg->locals [i] = mono_compile_create_var (cfg, header->locals [i], OP_LOCAL);
+	}
 
 	if (cfg->verbose_level > 2)
 		g_print ("locals done\n");


### PR DESCRIPTION
…d the MONO_INST_INDIRECT flags during codegen. This doesn't work since the INDIRECT flag prohibits the insertion of phi nodes, so its later removal leads to the generation of LLVM IR which is missing phi nodes.