### PR TITLE
[runtime] Avoid building a separate static library, use the shared ob…

### DIFF
--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -5,10 +5,10 @@ export HOST_CC
 endif
 
 if SUPPORT_SGEN
-metadata_lib=$(top_builddir)/mono/metadata/libmonoruntimesgen-static.la
-gc_lib=$(top_builddir)/mono/sgen/libmonosgen-static.la
+metadata_lib=$(top_builddir)/mono/metadata/libmonoruntimesgen.la
+gc_lib=$(top_builddir)/mono/sgen/libmonosgen.la
 else
-metadata_lib=$(top_builddir)/mono/metadata/libmonoruntime-static.la
+metadata_lib=$(top_builddir)/mono/metadata/libmonoruntime.la
 gc_lib=$(LIBGC_STATIC_LIBS)
 endif
 

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -63,10 +63,6 @@ if PLATFORM_ANDROID
 platform_sources += ../../support/libm/complex.c
 endif
 
-#
-# libtool is not capable of creating static/shared versions of the same
-# convenience lib, so we have to do it ourselves
-#
 if SUPPORT_SGEN
 if DISABLE_EXECUTABLES
 shared_sgen_libraries = libmonoruntimesgen.la 
@@ -75,7 +71,7 @@ if SHARED_MONO
 shared_sgen_libraries = libmonoruntimesgen.la 
 endif
 endif
-sgen_libraries = $(shared_sgen_libraries) libmonoruntimesgen-static.la 
+sgen_libraries = $(shared_sgen_libraries)
 endif
 
 if SUPPORT_BOEHM
@@ -86,7 +82,7 @@ if SHARED_MONO
 shared_boehm_libraries = libmonoruntime.la
 endif
 endif
-boehm_libraries = $(shared_boehm_libraries) libmonoruntime-static.la
+boehm_libraries = $(shared_boehm_libraries)
 endif
 
 if DISABLE_EXECUTABLES
@@ -316,16 +312,6 @@ libmonoruntime_la_LIBADD = libmonoruntime-config.la
 libmonoruntimesgen_la_SOURCES = $(common_sources) $(gc_dependent_sources) $(sgen_sources)
 libmonoruntimesgen_la_CFLAGS = $(SGEN_DEFINES)
 libmonoruntimesgen_la_LIBADD = libmonoruntime-config.la
-
-libmonoruntime_static_la_SOURCES = $(libmonoruntime_la_SOURCES)
-libmonoruntime_static_la_LDFLAGS = -static
-libmonoruntime_static_la_CFLAGS = $(BOEHM_DEFINES)
-libmonoruntime_static_la_LIBADD = $(bundle_obj) libmonoruntime-config.la
-
-libmonoruntimesgen_static_la_SOURCES = $(libmonoruntimesgen_la_SOURCES)
-libmonoruntimesgen_static_la_LDFLAGS = -static
-libmonoruntimesgen_static_la_CFLAGS = $(SGEN_DEFINES)
-libmonoruntimesgen_static_la_LIBADD = libmonoruntime-config.la
 
 libmonoruntimeincludedir = $(includedir)/mono-$(API_VER)/mono/metadata
 

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -30,18 +30,6 @@ sgen_libs = \
 	$(monodir)/mono/utils/libmonoutils.la \
 	$(GLIB_LIBS) $(LIBICONV)
 
-boehm_static_libs=	\
-	$(monodir)/mono/metadata/libmonoruntime-static.la	\
-	$(monodir)/mono/utils/libmonoutils.la \
-	$(GLIB_LIBS) $(LIBICONV) \
-	$(libgc_static_libs)
-
-sgen_static_libs = \
-	$(monodir)/mono/metadata/libmonoruntimesgen-static.la	\
-	$(monodir)/mono/sgen/libmonosgen-static.la	\
-	$(monodir)/mono/utils/libmonoutils.la \
-	$(GLIB_LIBS) $(LIBICONV)
-
 if FULL_AOT_TESTS
 # if the tests are going to run with framework assemblies compiled with
 # -d:MOBILE, tell the runtime to remap framework assemblies using the mobile
@@ -97,12 +85,12 @@ endif
 if SUPPORT_SGEN
 sgen_binaries = mono-sgen
 sgen_libraries = libmonosgen-2.0.la
-sgen_static_libraries = libmini-static.la $(sgen_static_libs)
+sgen_static_libraries = libmini.la $(sgen_libs)
 endif
 
 if SUPPORT_BOEHM
 boehm_libraries = libmonoboehm-2.0.la
-boehm_static_libraries = libmini-static.la $(boehm_static_libs)
+boehm_static_libraries = libmini.la $(boehm_libs)
 boehm_binaries  = mono-boehm
 endif
 
@@ -161,7 +149,7 @@ endif
 if DISABLE_EXECUTABLES
 noinst_LTLIBRARIES = $(mini_common_lib)
 else
-noinst_LTLIBRARIES = $(mini_common_lib) libmini-static.la
+noinst_LTLIBRARIES = $(mini_common_lib)
 endif
 
 if LOADED_LLVM
@@ -195,20 +183,12 @@ mono_sgen_CFLAGS = $(AM_CFLAGS)
 # We build this after libmono was built so it contains the date when the final
 # link was done
 if SUPPORT_BOEHM
-if DISABLE_EXECUTABLES
-buildver-boehm.h: libmini-static.la $(monodir)/mono/metadata/libmonoruntime.la
-else
-buildver-boehm.h: libmini-static.la $(monodir)/mono/metadata/libmonoruntime-static.la
-endif
+buildver-boehm.h: libmini.la $(monodir)/mono/metadata/libmonoruntime.la
 	@echo "const char *build_date = \"`date`\";" > buildver-boehm.h
 mono_boehm-main.$(OBJEXT): buildver-boehm.h
 endif
 
-if DISABLE_EXECUTABLES
-buildver-sgen.h: libmini-static.la $(monodir)/mono/metadata/libmonoruntimesgen.la $(monodir)/mono/sgen/libmonosgen.la
-else
-buildver-sgen.h: libmini-static.la $(monodir)/mono/metadata/libmonoruntimesgen-static.la $(monodir)/mono/sgen/libmonosgen-static.la
-endif
+buildver-sgen.h: libmini.la $(monodir)/mono/metadata/libmonoruntimesgen.la $(monodir)/mono/sgen/libmonosgen.la
 	@echo "const char *build_date = \"`date`\";" > buildver-sgen.h
 mono_sgen-main-sgen.$(OBJEXT): buildver-sgen.h
 main-sgen.$(OBJEXT): buildver-sgen.h
@@ -620,6 +600,10 @@ os_sources = $(darwin_sources) $(posix_sources)
 monobin_platform_ldflags=-framework CoreFoundation -framework Foundation
 endif
 
+#
+# This library is shared between mono and mono-sgen, since the code in mini/ doesn't contain
+# compile time dependencies on boehm/sgen.
+#
 libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(interp_sources) $(arch_sources) $(os_sources)
 libmini_la_CFLAGS = $(mono_CFLAGS)
 
@@ -632,15 +616,6 @@ libmonosgen_2_0_la_SOURCES =
 libmonosgen_2_0_la_CFLAGS = $(mono_sgen_CFLAGS)
 libmonosgen_2_0_la_LIBADD = libmini.la $(sgen_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
 libmonosgen_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags)
-
-#
-# This library is shared between mono and mono-sgen, since the code in mini/ doesn't contain
-# compile time dependencies on boehm/sgen.
-#
-libmini_static_la_SOURCES = $(libmini_la_SOURCES)
-libmini_static_la_CFLAGS = $(AM_CFLAGS)
-libmini_static_la_LDFLAGS = -static
-libmini_static_la_LIBADD = $(MONO_DTRACE_OBJECT)
 
 libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -552,7 +552,7 @@ extern MonoMethodDesc *mono_break_at_bb_method;
 extern int mono_break_at_bb_bb_num;
 extern gboolean mono_verify_all;
 extern gboolean mono_do_x86_stack_align;
-extern const char *mono_build_date;
+extern MONO_API const char *mono_build_date;
 extern gboolean mono_do_signal_chaining;
 extern gboolean mono_do_crash_chaining;
 extern MONO_API gboolean mono_use_llvm;

--- a/mono/sgen/Makefile.am
+++ b/mono/sgen/Makefile.am
@@ -8,7 +8,7 @@ if SHARED_MONO
 shared_libraries = libmonosgen.la
 endif
 endif
-libraries = $(shared_libraries) libmonosgen-static.la
+libraries = $(shared_libraries)
 endif
 
 if DISABLE_EXECUTABLES
@@ -72,7 +72,3 @@ monosgen_sources = \
 
 libmonosgen_la_SOURCES = $(monosgen_sources)
 libmonosgen_la_CFLAGS = $(SGEN_DEFINES)
-
-libmonosgen_static_la_SOURCES = $(libmonosgen_la_SOURCES)
-libmonosgen_static_la_CFLAGS = $(SGEN_DEFINES)
-libmonosgen_static_la_LDFLAGS = -static

--- a/tools/monograph/Makefile.am
+++ b/tools/monograph/Makefile.am
@@ -7,7 +7,7 @@ if DISABLE_EXECUTABLES
 runtime_lib=$(top_builddir)/mono/mini/$(LIBMONO_LA) $(static_libs)
 else
 static_libs=	\
-	$(top_builddir)/mono/metadata/libmonoruntimesgen-static.la	\
+	$(top_builddir)/mono/metadata/libmonoruntimesgen.la	\
 	$(top_builddir)/mono/utils/libmonoutils.la \
 	$(GLIB_LIBS) $(LIBICONV) \
 	$(LIBGC_STATIC_LIBS)

--- a/tools/pedump/Makefile.am
+++ b/tools/pedump/Makefile.am
@@ -17,8 +17,8 @@ pedump_SOURCES =		\
 	pedump.c
 
 pedump_LDADD = 			\
-	$(top_builddir)/mono/metadata/libmonoruntimesgen-static.la \
-	$(top_builddir)/mono/sgen/libmonosgen-static.la \
+	$(top_builddir)/mono/metadata/libmonoruntimesgen.la \
+	$(top_builddir)/mono/sgen/libmonosgen.la \
 	$(top_builddir)/mono/utils/libmonoutils.la \
 	$(LLVM_LIBS)			\
 	$(LLVM_LDFLAGS)			\


### PR DESCRIPTION
…ject files for the static library as well.