### PR TITLE
[jit] Check method cache first in mono_get_method_constrained_checked.

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1887,7 +1887,7 @@ mono_get_method_constrained_checked (MonoImage *image, guint32 token, MonoClass 
 {
 	error_init (error);
 
-	*cil_method = mono_get_method_from_token (image, token, NULL, context, NULL, error);
+	*cil_method = mono_get_method_checked (image, token, NULL, context, error);
 	if (!*cil_method)
 		return NULL;
 


### PR DESCRIPTION
Check the image's method cache first. Allocate a new method structure only if it could not be found in the cache.
This change is meant to eliminate a memory leak occurring when multiple domains are created/unloaded.