### PR TITLE
Reenable MonoTests.Remoting.IpcChannelTest.Bug609381

### DIFF
--- a/mcs/class/System.Runtime.Remoting/Test/IpcChannelTest.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/IpcChannelTest.cs
@@ -28,7 +28,6 @@ namespace MonoTests.Remoting
 		}
 
 		[Test]
-		[Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=36634")]
 		public void Bug609381 ()
 		{
 			string portName = "ipc" + Guid.NewGuid ().ToString ("N");


### PR DESCRIPTION
Fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=36634