### PR TITLE
[Marshal.IsComObject] Make this predicate return false instead of throwing an exception

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -741,7 +741,7 @@ namespace System.Runtime.InteropServices
 #else
 		public static bool IsComObject (object o)
 		{
-			throw new PlatformNotSupportedException ();
+			return false;
 		}
 #endif
 


### PR DESCRIPTION
The code is called from System.Linq.Expressions to determine if the COM APIs must be called.

Do not throw an exception on mobile (where COM is not supported), instead return false.   Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57919