### PR TITLE
Install Roslyn binaries, including msbuild tasks to msbuild/Roslyn

### DIFF
--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -3,24 +3,55 @@ include ../build/rules.make
 
 ROSLYN_CSC_DIR = $(dir $(CSC_LOCATION))
 
-ROSLYN_FILES = \
+ROSLYN_FILES_FOR_MONO = \
 	$(ROSLYN_CSC_DIR)/csc.exe				\
 	$(ROSLYN_CSC_DIR)/csc.rsp				\
 	$(ROSLYN_CSC_DIR)/csc.exe.config			\
+	$(ROSLYN_CSC_DIR)/csi.exe				\
+	$(ROSLYN_CSC_DIR)/csi.exe.config			\
+	$(ROSLYN_CSC_DIR)/csi.rsp				\
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.CSharp.dll	\
+	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.CSharp.Scripting.dll \
+	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.VisualBasic.dll \
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.dll		\
+	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.Scripting.dll \
 	$(ROSLYN_CSC_DIR)/System.Collections.Immutable.dll	\
-	$(ROSLYN_CSC_DIR)/System.Reflection.Metadata.dll
+	$(ROSLYN_CSC_DIR)/System.Reflection.Metadata.dll	\
+	$(ROSLYN_CSC_DIR)/VBCSCompiler.exe			\
+	$(ROSLYN_CSC_DIR)/VBCSCompiler.exe.config
 
-DISTFILES = $(ROSLYN_FILES)
+ROSLYN_FILES_TO_COPY_FOR_MSBUILD = \
+	$(ROSLYN_CSC_DIR)/Microsoft.Build.Tasks.CodeAnalysis.dll \
+	$(ROSLYN_CSC_DIR)/Microsoft.CSharp.Core.targets 	 \
+	$(ROSLYN_CSC_DIR)/Microsoft.VisualBasic.Core.targets
+
+ROSLYN_FILES_TO_LINK_FOR_MSBUILD = \
+	csi.exe						\
+	csi.exe.config					\
+	csi.rsp						\
+	Microsoft.CodeAnalysis.dll			\
+	Microsoft.CodeAnalysis.CSharp.dll		\
+	Microsoft.CodeAnalysis.CSharp.Scripting.dll 	\
+	Microsoft.CodeAnalysis.Scripting.dll 		\
+	System.Collections.Immutable.dll		\
+	System.Reflection.Metadata.dll			\
+	VBCSCompiler.exe				\
+	VBCSCompiler.exe.config
+
+DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD)
 
 ifeq ($(PROFILE), $(DEFAULT_PROFILE))
 
 TARGET_DIR = $(DESTDIR)$(mono_libdir)/mono/$(FRAMEWORK_VERSION)
+MSBUILD_ROSLYN_DIR = $(DESTDIR)$(mono_libdir)/mono/msbuild/15.0/bin/Roslyn
 
 install-local:
 	$(MKINSTALLDIRS) $(TARGET_DIR)
-	$(INSTALL_LIB) $(ROSLYN_FILES) $(TARGET_DIR)
+	$(INSTALL_LIB) $(ROSLYN_FILES_FOR_MONO) $(TARGET_DIR)
+	$(MKINSTALLDIRS) $(MSBUILD_ROSLYN_DIR)
+	$(INSTALL_LIB) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) $(MSBUILD_ROSLYN_DIR)
+
+	(cd $(MSBUILD_ROSLYN_DIR); for asm in $(ROSLYN_FILES_TO_LINK_FOR_MSBUILD); do ln -fs ../../../../$(FRAMEWORK_VERSION)/$$asm . ; done)
 
 endif
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -37,6 +37,7 @@ bin_SCRIPTS = \
 	peverify		\
 	mcs			\
 	csc					\
+	csi			\
 	mono-package-runtime	\
 	mono-heapviz		\
 	$(scripts_mono_configuration_crypto)
@@ -159,6 +160,7 @@ EXTRA_DIST =			\
 	mcs.in				\
 	csc.in				\
 	dmcs.in				\
+	csi.in			\
 	mono-package-runtime	\
 	mono-test-install	\
 	mono-heapviz		\
@@ -209,6 +211,10 @@ csc: csc.in Makefile
 
 dmcs: dmcs.in Makefile
 	$(REWRITE_COMMON) $(srcdir)/dmcs.in > $@.tmp
+	mv -f $@.tmp $@
+
+csi: csi.in Makefile
+	$(REWRITE_COMMON) $(srcdir)/csi.in > $@.tmp
 	mv -f $@.tmp $@
 
 mono-service: mono-service.in Makefile

--- a/scripts/csi.in
+++ b/scripts/csi.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/csi.exe "$@"


### PR DESCRIPTION
.. directory, which is `$mono_prefix/lib/mono/msbuild/15.0/bin/Roslyn/`

Mono installs `csc.exe` but the corresponding
`Microsoft.Build.Tasks.CodeAnalysis.dll` required for supporting msbuild C#
projects is installed by msbuild. But these two can get out of sync,
like they did and had to be worked around in
mono/msbuild#19 .

Instead, we now install all the relevant roslyn bits (C# and VB) from the same
source. Only the msbuild specific files are copied to the Roslyn folder.
VBCSCompiler, csi and their dependencies are symlinked from `lib/mono/4.5`.

Also:

- csi.exe is included since the tool is surfaced as an msbuild task,
  and that requires the *Scripting.dll assemblies.
- VBCSCompiler* - shared compiler is installed
- vbc.exe doesn't work on mono currently, so skipping that
- And `Microsoft.DiaSymReader.Native.{amd64,x86}.dll` are dropped.