### PR TITLE
[Mono.Profiler.Log] Catch SecurityException for missing icalls.

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProfiler.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProfiler.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security;
 
 namespace Mono.Profiler.Log {
 
@@ -20,7 +21,7 @@ namespace Mono.Profiler.Log {
 				try {
 					GetMaxStackTraceFrames ();
 					return (bool) (_attached = true);
-				} catch (MissingMethodException) {
+				} catch (Exception e) when (e is MissingMethodException || e is SecurityException) {
 					return (bool) (_attached = false);
 				}
 			}


### PR DESCRIPTION
This is the exception that is thrown on .NET because icalls are not allowed in non-GAC assemblies.