### PR TITLE
[mempool] A new (atomic) way to deal with data races

### DIFF
--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -20,7 +20,7 @@
 
 #include "mempool.h"
 #include "mempool-internals.h"
-#include "utils/mono-compiler.h"
+#include "utils/atomic.h"
 
 /*
  * MonoMemPool is for fast allocation of memory. We free
@@ -94,18 +94,9 @@ mono_mempool_new (void)
 /**
  * mono_mempool_new_size:
  *
- *   clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
- *     * mono_mempool_alloc
- *     * mono_mempool_new_size
- *     * mono_mempool_destroy
- *   while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
- *   the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
- *   https://bugzilla.xamarin.com/show_bug.cgi?id=57936
- *
  * \param initial_size the amount of memory to initially reserve for the memory pool.
  * \returns a new memory pool with a specific initial memory reservation.
  */
-MONO_NO_SANITIZE_THREAD
 MonoMemPool *
 mono_mempool_new_size (int initial_size)
 {
@@ -125,32 +116,23 @@ mono_mempool_new_size (int initial_size)
 	pool->pos = (guint8*)pool + SIZEOF_MEM_POOL; // Start after header
 	pool->end = (guint8*)pool + initial_size;    // End at end of allocated space 
 	pool->d.allocated = pool->size = initial_size;
-	total_bytes_allocated += initial_size;
+	InterlockedAdd64 ((gint64*)&total_bytes_allocated, (gint64)initial_size);
 	return pool;
 }
 
 /**
  * mono_mempool_destroy:
  *
- *   clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
- *     * mono_mempool_alloc
- *     * mono_mempool_new_size
- *     * mono_mempool_destroy
- *   while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
- *   the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
- *   https://bugzilla.xamarin.com/show_bug.cgi?id=57936
- *
  * \param pool the memory pool to destroy
  *
  * Free all memory associated with this pool.
  */
-MONO_NO_SANITIZE_THREAD
 void
 mono_mempool_destroy (MonoMemPool *pool)
 {
 	MonoMemPool *p, *n;
 
-	total_bytes_allocated -= pool->d.allocated;
+	InterlockedSubtract64 ((gint64*)&total_bytes_allocated, (gint64)pool->d.allocated);
 
 	p = pool;
 	while (p) {
@@ -273,14 +255,6 @@ get_next_size (MonoMemPool *pool, int size)
 /**
  * mono_mempool_alloc:
  *
- *   clang's ThreadSanitizer detects races of total_bytes_allocated and pool->d.allocated throughout the functions
- *     * mono_mempool_alloc
- *     * mono_mempool_new_size
- *     * mono_mempool_destroy
- *   while these races could lead to wrong values, total_bytes_allocated is just used for debugging / reporting and since
- *   the mempool.c functions are called quite often, a discussion led the the conclusion of ignoring these races:
- *   https://bugzilla.xamarin.com/show_bug.cgi?id=57936
- *
  * \param pool the memory pool to use
  * \param size size of the memory block
  *
@@ -288,7 +262,6 @@ get_next_size (MonoMemPool *pool, int size)
  *
  * \returns the address of a newly allocated memory block.
  */
-MONO_NO_SANITIZE_THREAD
 gpointer
 mono_mempool_alloc (MonoMemPool *pool, guint size)
 {
@@ -318,7 +291,7 @@ mono_mempool_alloc (MonoMemPool *pool, guint size)
 			np->size = new_size;
 			pool->next = np;
 			pool->d.allocated += new_size;
-			total_bytes_allocated += new_size;
+			InterlockedAdd64 ((gint64*)&total_bytes_allocated, (gint64)new_size);
 
 			rval = (guint8*)np + SIZEOF_MEM_POOL;
 		} else {
@@ -332,7 +305,7 @@ mono_mempool_alloc (MonoMemPool *pool, guint size)
 			pool->pos = (guint8*)np + SIZEOF_MEM_POOL;
 			pool->end = (guint8*)np + new_size;
 			pool->d.allocated += new_size;
-			total_bytes_allocated += new_size;
+			InterlockedAdd64 ((gint64*)&total_bytes_allocated, (gint64)new_size);
 
 			rval = pool->pos;
 			pool->pos += size;
@@ -462,5 +435,5 @@ mono_mempool_get_allocated (MonoMemPool *pool)
 long
 mono_mempool_get_bytes_allocated (void)
 {
-	return total_bytes_allocated;
+	return InterlockedRead64 ((gint64*)&total_bytes_allocated);
 }


### PR DESCRIPTION
While slowly discovering all the secrets of Mono, I also discovered atomic.h which provides extremely useful functions to deal with a ton of Mono's currently known data races. I know, only recently did I ask to blacklist the reporting counter races in mempool.c (https://github.com/mono/mono/pull/5191). However, having atomic.h at hand, I think it's way better to fix the races (lock-free) than simply blacklisting them (and their surroundings)?

In addition, I added `InterlockedSubtract ()` as well as `InterlockedSubtract64 ()` to `atomic.h` as these functions do not seem to exist but, IMO, they would really help with the readability. E.g. when converting races like `foo -= bar` we could use `InterlockedSubtract (&foo, bar)` instead of using `InterlockedAdd (&foo, -1 * bar)`). I tried my best to research all (cross-platform) aspects and compared everything to `InterlockedAdd ()` and `InterlockedAdd64 ()`. However, of course, I would very much appreciate it, if experts in this field have a close look at this.

As soon as these `InterlockedSubtract* ()` functions are approved, I will add a follow-up PR where I can finally tackle a large amount of data races - in a clean and very satisfactory way.