### PR TITLE
[allocation] prefetch memory into caches that just got allocated for an object

### DIFF
--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -608,6 +608,18 @@ typedef union {
 	amd64_codegen_post(inst); \
 } while (0)
 
+#define amd64_prefetch2(inst,reg) do { \
+	*(inst)++ = 0x0f; \
+	*(inst)++ = 0x18; \
+	{   \
+		const int style = 3; \
+		guint8 val = ((style << 3) | ((reg) & 0x7)); \
+		*(inst)++ = val; \
+	} \
+} while (0)
+
+/* x86_reg_emit ((inst),1,(reg) & 0x7); */
+
 /* From the AMD64 Software Optimization Manual */
 #define amd64_padding_size(inst,size) \
     do { \

--- a/mono/cil/opcode.def
+++ b/mono/cil/opcode.def
@@ -322,6 +322,7 @@ OPDEF(CEE_MONO_ATOMIC_STORE_I4, "mono_atomic_store_i4", PopI+PopI, Push0, Inline
 OPDEF(CEE_MONO_GET_LAST_ERROR, "mono_get_last_error", Pop0, PushI, InlineNone, X, 2, 0xF0, 0x1B, NEXT)
 OPDEF(CEE_MONO_GET_RGCTX_ARG, "mono_get_rgctx_arg", Pop0, PushI, InlineNone, X, 2, 0xF0, 0x1C, NEXT)
 OPDEF(CEE_MONO_LDPTR_PROFILER_ALLOCATION_COUNT, "mono_ldptr_profiler_allocation_count", Pop0, PushI, InlineNone, X, 2, 0xF0, 0x1D, NEXT)
+OPDEF(CEE_MONO_PREFETCH, "mono_prefetch", Pop1, Push0, InlineNone, X, 2, 0xF0, 0x1E, NEXT)
 #ifndef OPALIAS
 #define _MONO_CIL_OPALIAS_DEFINED_
 #define OPALIAS(a,s,r)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -1306,7 +1306,12 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 	mono_mb_emit_ldloc (mb, tlab_next_addr_var);
 	mono_mb_emit_byte (mb, CEE_LDIND_I);
 	mono_mb_emit_stloc (mb, p_var);
-	
+
+	/* __builtin_prefetch (p); */
+	mono_mb_emit_ldloc (mb, p_var);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_PREFETCH);
+
 	/* new_next = (char*)p + size; */
 	new_next_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
 	mono_mb_emit_ldloc (mb, p_var);

--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -441,6 +441,7 @@ int_ble: len:8
 int_ble_un: len:8
 
 card_table_wbarrier: src1:a src2:i clob:d len:56
+prefetch: src1:i len:3
 
 relaxed_nop: len:2
 hard_nop: len:1

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12027,6 +12027,17 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				ip += 2;
 				*sp++ = ins;
 				break;
+			case CEE_MONO_PREFETCH: {
+				MonoInst *prefetch;
+				CHECK_STACK (1);
+				sp -= 1;
+
+				MONO_INST_NEW (cfg, prefetch, OP_PREFETCH);
+				prefetch->sreg1 = sp[0]->dreg;
+				MONO_ADD_INS (cfg->cbb, prefetch);
+				ip += 2;
+				break;
+			}
 			default:
 				g_error ("opcode 0x%02x 0x%02x not handled", MONO_CUSTOM_PREFIX, ip [1]);
 				break;

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -5686,6 +5686,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				x86_mfence (code);
 			break;
 		}
+		case OP_PREFETCH:
+			amd64_prefetch2 (code, ins->sreg1);
+			break;
 		case OP_CARD_TABLE_WBARRIER: {
 			int ptr = ins->sreg1;
 			int value = ins->sreg2;

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -722,6 +722,9 @@ MINI_OP(OP_RESTORE_LMF, "restore_lmf", NONE, NONE, NONE)
 /* write barrier */
 MINI_OP(OP_CARD_TABLE_WBARRIER, "card_table_wbarrier", NONE, IREG, IREG)
 
+/* base addr, size */
+MINI_OP(OP_PREFETCH, "prefetch", NONE, IREG, NONE)
+
 /* arch-dep tls access */
 MINI_OP(OP_TLS_GET,            "tls_get", IREG, NONE, NONE)
 MINI_OP(OP_TLS_GET_REG,        "tls_get_reg", IREG, IREG, NONE)


### PR DESCRIPTION
the idea is that allocation is a hard to predict access pattern for the CPU. not sure if it's worth exploring.