### PR TITLE
[sre] Handle typeref tokens in fixup_method (Fixes #58421)

### DIFF
--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1759,6 +1759,14 @@ fixup_method (MonoReflectionILGen *ilgen, gpointer value, MonoDynamicImage *asse
 				g_assert_not_reached ();
 			}
 			break;
+		case MONO_TABLE_TYPEREF:
+			g_assert (!strcmp (iltoken->member->vtable->klass->name, "RuntimeType"));
+			MonoClass *k = mono_class_from_mono_type (((MonoReflectionType*)iltoken->member)->type);
+			MonoObject *obj = mono_class_get_ref_info_raw (k); /* FIXME use handles */
+			g_assert (obj);
+			g_assert (!strcmp (mono_object_class (obj)->name, "TypeBuilder"));
+			g_assert (((MonoReflectionTypeBuilder*)obj)->module->dynamic_image != assembly);
+			continue;
 		case MONO_TABLE_MEMBERREF:
 			if (!strcmp (iltoken->member->vtable->klass->name, "MonoArrayMethod")) {
 				am = (MonoReflectionArrayMethod*)iltoken->member;


### PR DESCRIPTION
This may occur if there are two AssemblyBuilders in progress and one of them
refers to a TypeBuilder from the other.

https://bugzilla.xamarin.com/show_bug.cgi?id=58421