### PR TITLE
[2017-06][sre] Resolve EnumBuilder tokens in managed (Fixes #58361)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=2
+MONO_CORLIB_COUNTER=3
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR $MONO_VERSION_BUILD $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/corlib/System.Reflection.Emit/EnumBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/EnumBuilder.cs
@@ -71,6 +71,9 @@ namespace System.Reflection.Emit {
 			return _tb.InternalResolve (); 
 		}
 
+		internal override Type RuntimeResolve () {
+			return _tb.RuntimeResolve ();
+		}
 
 		public override Assembly Assembly {
 			get {

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.cs
@@ -814,7 +814,7 @@ namespace System.Reflection.Emit {
 			make_room (6);
 			ll_emit (opcode);
 			int token = token_gen.GetToken (cls, opcode != OpCodes.Ldtoken);
-			if (cls is TypeBuilderInstantiation || cls is SymbolType || cls is TypeBuilder || cls is GenericTypeParameterBuilder)
+			if (cls is TypeBuilderInstantiation || cls is SymbolType || cls is TypeBuilder || cls is GenericTypeParameterBuilder || cls is EnumBuilder)
 				add_token_fixup (cls);
 			emit_int (token);
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs
@@ -749,6 +749,14 @@ namespace System.Reflection.Emit {
 					token = typedef_tokengen --;
 				else
 					token = typeref_tokengen --;
+			} else if (member is EnumBuilder) {
+				token = GetPseudoToken ((member as  EnumBuilder).GetTypeBuilder(), create_open_instance);
+				if (create_open_instance)
+					inst_tokens_open[member] = token;
+				else
+					inst_tokens[member] = token;
+				// n.b. don't register with the runtime, the TypeBuilder already did it.
+				return token;
 			} else if (member is ConstructorBuilder) {
 				if (member.Module == this && !(member as ConstructorBuilder).TypeBuilder.ContainsGenericParameters)
 					token = methoddef_tokengen --;
@@ -779,7 +787,8 @@ namespace System.Reflection.Emit {
 		}
 
 		internal int GetToken (MemberInfo member, bool create_open_instance) {
-			if (member is TypeBuilderInstantiation || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst || member is SymbolType || member is FieldBuilder || member is TypeBuilder || member is ConstructorBuilder || member is MethodBuilder || member is GenericTypeParameterBuilder)
+			if (member is TypeBuilderInstantiation || member is FieldOnTypeBuilderInst || member is ConstructorOnTypeBuilderInst || member is MethodOnTypeBuilderInst || member is SymbolType || member is FieldBuilder || member is TypeBuilder || member is ConstructorBuilder || member is MethodBuilder || member is GenericTypeParameterBuilder ||
+			    member is EnumBuilder)
 				return GetPseudoToken (member, create_open_instance);
 			return getToken (this, member, create_open_instance);
 		}
@@ -872,6 +881,8 @@ namespace System.Reflection.Emit {
 					finished = (member as FieldBuilder).RuntimeResolve ();
 				} else if (member is TypeBuilder) {
 					finished = (member as TypeBuilder).RuntimeResolve ();
+				} else if (member is EnumBuilder) {
+					finished = (member as EnumBuilder).RuntimeResolve ();
 				} else if (member is ConstructorBuilder) {
 					finished = (member as ConstructorBuilder).RuntimeResolve ();
 				} else if (member is MethodBuilder) {

--- a/mcs/class/corlib/Test/System.Reflection.Emit/EnumBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/EnumBuilderTest.cs
@@ -328,6 +328,61 @@ namespace MonoTests.System.Reflection.Emit
 				Assert.Fail ("Expected CreateInstance of a broken type to throw TLE");
 		}
 
+		[Test]
+		public void TestEnumBuilderTokenUsable () {
+			// Regression test for https://bugzilla.xamarin.com/show_bug.cgi?id=58361
+			// Create an EnumBuilder and use it in an ILGenerator that consumes its token.
+			var modBuilder = GenerateModule ();
+			EnumBuilder enumBuilder = GenerateEnum (modBuilder);
+
+			var tb = modBuilder.DefineType ("Foo", TypeAttributes.Public);
+
+			var cb = tb.DefineConstructor (MethodAttributes.Public, CallingConventions.Standard,
+						       Type.EmptyTypes);
+
+			var ilg = cb.GetILGenerator ();
+
+			ilg.Emit (OpCodes.Ldtoken, enumBuilder);
+			ilg.Emit (OpCodes.Pop);
+			ilg.Emit (OpCodes.Ret);
+
+			var t = tb.CreateType ();
+			enumBuilder.CreateType ();
+
+			var ci = t.GetConstructor (Type.EmptyTypes);
+			var x = ci.Invoke (null);
+			Assert.IsNotNull (x);
+		}
+
+		[Test]
+		public void TestEnumBuilderTokenUsableCrossAssembly () {
+			// Regression test for https://bugzilla.xamarin.com/show_bug.cgi?id=58361
+			// Create an EnumBuilder and use it in an ILGenerator that consumes its token in a different assembly.
+			var modBuilder = GenerateModule ();
+			var modBuilder2 = GenerateModule ();
+			EnumBuilder enumBuilder = GenerateEnum (modBuilder2);
+
+			// N.B. "tb" is in modBuilder but enumBuilder is in modBuilder2
+			var tb = modBuilder.DefineType ("Foo", TypeAttributes.Public);
+
+			var cb = tb.DefineConstructor (MethodAttributes.Public, CallingConventions.Standard,
+						       Type.EmptyTypes);
+
+			var ilg = cb.GetILGenerator ();
+
+			ilg.Emit (OpCodes.Ldtoken, enumBuilder);
+			ilg.Emit (OpCodes.Pop);
+			ilg.Emit (OpCodes.Ret);
+
+			var t = tb.CreateType ();
+			enumBuilder.CreateType ();
+
+			var ci = t.GetConstructor (Type.EmptyTypes);
+			var x = ci.Invoke (null);
+			Assert.IsNotNull (x);
+		}
+
+
 		private static void VerifyType (Type type)
 		{
 			Assert.IsNotNull (type.Assembly, "#V1");

--- a/mono/metadata/dynamic-image-internals.h
+++ b/mono/metadata/dynamic-image-internals.h
@@ -24,11 +24,17 @@ typedef struct {
 } MonoILT;
 
 
+typedef enum {
+	MONO_DYN_IMAGE_TOK_NEW, /* assert if same token is registered already */
+	MONO_DYN_IMAGE_TOK_SAME_OK, /* allow collision only with the same object */
+	MONO_DYN_IMAGE_TOK_REPLACE, /* keep the new object, always */
+} MonoDynamicImageTokCollision;
+
 void
 mono_dynamic_images_init (void);
 
 void
-mono_dynamic_image_register_token (MonoDynamicImage *assembly, guint32 token, MonoObjectHandle obj);
+mono_dynamic_image_register_token (MonoDynamicImage *assembly, guint32 token, MonoObjectHandle obj, int tok_collision);
 
 gboolean
 mono_dynamic_image_is_valid_token (MonoDynamicImage *image, guint32 token);

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -198,6 +198,7 @@ mono_dynamic_image_register_token (MonoDynamicImage *assembly, guint32 token, Mo
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	g_assert (!MONO_HANDLE_IS_NULL (obj));
+	g_assert (strcmp (mono_handle_class (obj)->name, "EnumBuilder"));
 	dynamic_image_lock (assembly);
 	MonoObject *prev = (MonoObject *)mono_g_hash_table_lookup (assembly->tokens, GUINT_TO_POINTER (token));
 	if (prev) {

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -793,7 +793,8 @@ mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *
 	if ((klass->image == &assembly->image) && (type->type != MONO_TYPE_VAR) && 
 			(type->type != MONO_TYPE_MVAR)) {
 		token = MONO_TYPEDEFORREF_TYPEDEF | (MONO_HANDLE_GETVAL (tb, table_idx) << MONO_TYPEDEFORREF_BITS);
-		mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, tb));
+		/* This function is called multiple times from sre and sre-save, so same object is okay */
+		mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, tb), MONO_DYN_IMAGE_TOK_SAME_OK);
 		goto leave;
 	}
 
@@ -816,7 +817,13 @@ mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *
 	token = MONO_TYPEDEFORREF_TYPEREF | (table->next_idx << MONO_TYPEDEFORREF_BITS); /* typeref */
 	g_hash_table_insert (assembly->typeref, type, GUINT_TO_POINTER(token));
 	table->next_idx ++;
-	mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, tb));
+
+
+	if (!MONO_HANDLE_IS_NULL (tb)) {
+		/* This function is called multiple times from sre and sre-save, so same object is okay */
+		mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, tb), MONO_DYN_IMAGE_TOK_SAME_OK);
+	}
+
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (token);
 }

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1193,11 +1193,6 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 		MonoReflectionSigHelperHandle s = MONO_HANDLE_CAST (MonoReflectionSigHelper, obj);
 		token = MONO_TOKEN_SIGNATURE | mono_image_get_sighelper_token (assembly, s, error);
 		return_val_if_nok (error, 0);
-	} else if (strcmp (klass->name, "EnumBuilder") == 0) {
-		MonoType *type = mono_reflection_type_handle_mono_type (MONO_HANDLE_CAST (MonoReflectionType, obj), error);
-		return_val_if_nok (error, 0);
-		token = mono_metadata_token_from_dor (
-			mono_image_typedef_or_ref (assembly, type));
 	} else {
 		g_error ("requested token for %s\n", klass->name);
 	}

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1022,7 +1022,7 @@ mono_image_insert_string (MonoReflectionModuleBuilderHandle ref_module, MonoStri
 	}
 
 	token = MONO_TOKEN_STRING | idx;
-	mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, str));
+	mono_dynamic_image_register_token (assembly, token, MONO_HANDLE_CAST (MonoObject, str), MONO_DYN_IMAGE_TOK_NEW);
 
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (token);
@@ -1092,7 +1092,7 @@ mono_image_create_method_token (MonoDynamicImage *assembly, MonoObjectHandle obj
 		g_error ("requested method token for %s\n", klass->name);
 	}
 
-	mono_dynamic_image_register_token (assembly, token, obj);
+	mono_dynamic_image_register_token (assembly, token, obj, MONO_DYN_IMAGE_TOK_NEW);
 	return token;
 fail:
 	g_assert (!mono_error_ok (error));
@@ -1128,12 +1128,18 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 		return 0;
 	}
 
+	/* This function is called from ModuleBuilder:getToken multiple times for the same objects */
+	int how_collide = MONO_DYN_IMAGE_TOK_SAME_OK;
+
 	if (strcmp (klass->name, "RuntimeType") == 0) {
 		MonoType *type = mono_reflection_type_handle_mono_type (MONO_HANDLE_CAST (MonoReflectionType, obj), error);
 		return_val_if_nok (error, 0);
 		MonoClass *mc = mono_class_from_mono_type (type);
 		token = mono_metadata_token_from_dor (
 			mono_dynimage_encode_typedef_or_ref_full (assembly, type, !mono_class_is_gtd (mc) || create_open_instance));
+		/* If it's a RuntimeType now, we could have registered a
+		 * TypeBuilder for it before, so replacing is okay. */
+		how_collide = MONO_DYN_IMAGE_TOK_REPLACE;
 	} else if (strcmp (klass->name, "MonoCMethod") == 0 ||
 			   strcmp (klass->name, "MonoMethod") == 0) {
 		MonoReflectionMethodHandle m = MONO_HANDLE_CAST (MonoReflectionMethod, obj);
@@ -1152,6 +1158,7 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 				 * FIXME: do the equivalent for Fields.
 				 */
 				token = method->token;
+				how_collide = MONO_DYN_IMAGE_TOK_REPLACE;
 			} else {
 				/*
 				 * Each token should have a unique index, but the indexes are
@@ -1160,6 +1167,7 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 				 */
 				method_table_idx --;
 				token = MONO_TOKEN_METHOD_DEF | method_table_idx;
+				how_collide = MONO_DYN_IMAGE_TOK_NEW;
 			}
 		} else {
 			token = mono_image_get_methodref_token (assembly, method, create_open_instance);
@@ -1172,6 +1180,7 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 			static guint32 field_table_idx = 0xffffff;
 			field_table_idx --;
 			token = MONO_TOKEN_FIELD_DEF | field_table_idx;
+			how_collide = MONO_DYN_IMAGE_TOK_NEW;
 		} else {
 			token = mono_image_get_fieldref_token (assembly, obj, field);
 		}
@@ -1194,7 +1203,7 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 	}
 
 	if (register_token)
-		mono_dynamic_image_register_token (assembly, token, obj);
+		mono_dynamic_image_register_token (assembly, token, obj, how_collide);
 
 	return token;
 }
@@ -2479,7 +2488,7 @@ reflection_setup_internal_class_internal (MonoReflectionTypeBuilderHandle ref_tb
 	*/
 	mono_image_append_class_to_reflection_info_set (klass);
 
-	mono_dynamic_image_register_token (dynamic_image, MONO_TOKEN_TYPE_DEF | table_idx, MONO_HANDLE_CAST (MonoObject, ref_tb));
+	mono_dynamic_image_register_token (dynamic_image, MONO_TOKEN_TYPE_DEF | table_idx, MONO_HANDLE_CAST (MonoObject, ref_tb), MONO_DYN_IMAGE_TOK_NEW);
 
 	if ((!strcmp (klass->name, "ValueType") && !strcmp (klass->name_space, "System")) ||
 			(!strcmp (klass->name, "Object") && !strcmp (klass->name_space, "System")) ||
@@ -4342,7 +4351,9 @@ void
 ves_icall_ModuleBuilder_RegisterToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, guint32 token, MonoError *error)
 {
 	error_init (error);
-	mono_dynamic_image_register_token (MONO_HANDLE_GETVAL (mb, dynamic_image), token, obj);
+	/* This function may be called by ModuleBuilder.FixupTokens to update
+	 * an existing token, so replace is okay here. */
+	mono_dynamic_image_register_token (MONO_HANDLE_GETVAL (mb, dynamic_image), token, obj, MONO_DYN_IMAGE_TOK_REPLACE);
 }
 
 MonoObjectHandle


### PR DESCRIPTION
Cherrypick #5271 to `2017-06`

----

In particular, delegate to the TypeBuilder within the EnumBuilder.

Also do not register the EnumBuilder object with the runtime.  (Fixes
https://bugzilla.xamarin.com/show_bug.cgi?id=58361)

----

Add MonoDynamicImageTokCollision arg to mono_dynamic_image_register_token

The new argument controls what should happen when the given token is already
present.

In some situations it's expected that we either see the same object, or we
unconditionally want to replace it (for example if we previously registered a
TypeBuilder or a MethodBuilder, after the type or method is created, we will
re-register the RuntimeType or MonoMethod in its place).  In other cases (for
example when a module references a MonoMethod from a different assembly), we
may still call `mono_image_create_token()` multiple times but we expect to see
the same MonoMethod object.