### PR TITLE
[2017-06][sre] Handle typeref tokens in fixup_method (Fixes #58421)

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
@@ -11374,5 +11374,39 @@ namespace MonoTests.System.Reflection.Emit
 
 			assembly.Save (ASSEMBLY_NAME + ".dll");
 		}
+
+		[Test]
+		public void TwoAssembliesMidFlightTest () {
+			// Check that one AssemblyBuilder can refer to a TypeBuilder from another AssemblyBuilder.
+			// Regression test for https://bugzilla.xamarin.com/show_bug.cgi?id=58421
+			var name2 = "MonoTests.System.Reflection.Emit.TypeBuilderTest2";
+			var assemblyName2 = new AssemblyName (name2);
+			var assembly2 =
+				Thread.GetDomain ().DefineDynamicAssembly (
+					assemblyName2, AssemblyBuilderAccess.RunAndSave, tempDir);
+
+			var module2 = assembly2.DefineDynamicModule (name2, name2 + ".dll");
+
+			var tb = module.DefineType ("Foo", TypeAttributes.Public);
+			var tb2 = module2.DefineType ("Foo2", TypeAttributes.Public);
+
+			var cb = tb.DefineConstructor (MethodAttributes.Public, CallingConventions.Standard,
+						       Type.EmptyTypes);
+
+			var ilg = cb.GetILGenerator ();
+
+			ilg.Emit (OpCodes.Ldtoken, tb2); // N.B. type from the other AssemblyBuilder
+			ilg.Emit (OpCodes.Pop);
+			ilg.Emit (OpCodes.Ret);
+
+			var t = tb.CreateType ();
+			tb2.CreateType ();
+
+			var ci = t.GetConstructor (Type.EmptyTypes);
+			var x = ci.Invoke (null);
+			assembly.Save (ASSEMBLY_NAME + ".dll");
+			assembly2.Save (name2 + ".dll");
+		}
+
 	}
 }

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1759,6 +1759,14 @@ fixup_method (MonoReflectionILGen *ilgen, gpointer value, MonoDynamicImage *asse
 				g_assert_not_reached ();
 			}
 			break;
+		case MONO_TABLE_TYPEREF:
+			g_assert (!strcmp (iltoken->member->vtable->klass->name, "RuntimeType"));
+			MonoClass *k = mono_class_from_mono_type (((MonoReflectionType*)iltoken->member)->type);
+			MonoObject *obj = mono_class_get_ref_info_raw (k); /* FIXME use handles */
+			g_assert (obj);
+			g_assert (!strcmp (mono_object_class (obj)->name, "TypeBuilder"));
+			g_assert (((MonoReflectionTypeBuilder*)obj)->module->dynamic_image != assembly);
+			continue;
 		case MONO_TABLE_MEMBERREF:
 			if (!strcmp (iltoken->member->vtable->klass->name, "MonoArrayMethod")) {
 				am = (MonoReflectionArrayMethod*)iltoken->member;


### PR DESCRIPTION
cherrypick #5272 to `2017-06`

----

This may occur if there are two AssemblyBuilders in progress and one of them
refers to a TypeBuilder from the other.

https://bugzilla.xamarin.com/show_bug.cgi?id=58421