### PR TITLE
Adding instructions to recursively clone the repo with submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ If you don't have a working Mono installation, you can try a slightly
 more risky approach: getting the latest version of the 'monolite' distribution,
 which contains just enough to run the 'mcs' compiler. You do this with:
 
+    # git clone recursively to download even the submodules
+    git clone --recursive https://github.com/mono/mono.git
+
     # Run the following line after ./autogen.sh
     make get-monolite-latest
 


### PR DESCRIPTION
This patch will assist newbies to download the submodules using the
recursive option which would avoid them from worrying about missing
dependent files. Previously it would only download the mono repo but
not the submodules inside mono/external/