### PR TITLE
[ci] Compile the class lib tests in a separate step

### DIFF
--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -45,21 +45,21 @@ COMPILE = \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(OUT_DIR); \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(LIB_PATH);
 
-check: test-local
+check: run-test
 
 AOT_SUPPORTED = $(shell $(MONO) --aot 2>&1 | grep -q "AOT compilation is not supported" && echo 0 || echo 1)
 
-test-local: test-without-aot test-with-aot test-with-aot-msym
+run-test-local: run-test-without-aot run-test-with-aot run-test-with-aot-msym
 
-test-without-aot: OUT_DIR = Test/without_aot
-test-without-aot: all
+run-test-without-aot: OUT_DIR = Test/without_aot
+run-test-without-aot: all
 	@echo "Checking $(TEST_EXE) without AOT in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
 	$(COMPILE)
 	$(CHECK_DIFF)
 
-test-with-aot: OUT_DIR = Test/with_aot
-test-with-aot: all
+run-test-with-aot: OUT_DIR = Test/with_aot
+run-test-with-aot: all
 ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
@@ -68,8 +68,8 @@ ifeq ($(AOT_SUPPORTED), 1)
 	$(CHECK_DIFF)
 endif
 
-test-with-aot-msym: OUT_DIR = Test/with_aot_msym
-test-with-aot-msym: all
+run-test-with-aot-msym: OUT_DIR = Test/with_aot_msym
+run-test-with-aot-msym: all
 ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT (using .msym) in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -5,6 +5,7 @@ if [[ ${label} == w* ]]
 then ${TESTCMD} --label=aot-test --skip;
 else ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot
 fi
+${TESTCMD} --label=compile-bcl-tests --timeout=40m make -i -w -C runtime -j4 test
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j4 tests
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1 CI_PR=${ghprbPullId}
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check


### PR DESCRIPTION
Compiling in parallel via -j should also be faster.

We had this on Wrench but it didn't make it over to Jenkins.