### PR TITLE
[threads] Fix leaking threads: SGen Worker and Finalizer

### DIFF
--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -292,6 +292,8 @@ sgen_thread_pool_start (void)
 void
 sgen_thread_pool_shutdown (void)
 {
+	int i;
+
 	if (!threads_num)
 		return;
 
@@ -305,6 +307,10 @@ sgen_thread_pool_shutdown (void)
 	mono_os_mutex_destroy (&lock);
 	mono_os_cond_destroy (&work_cond);
 	mono_os_cond_destroy (&done_cond);
+
+	for (i = 0; i < threads_num; i++) {
+		mono_threads_add_joinable_thread (threads [i]);
+	}
 }
 
 SgenThreadPoolJob*

--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -292,8 +292,6 @@ sgen_thread_pool_start (void)
 void
 sgen_thread_pool_shutdown (void)
 {
-	int i;
-
 	if (!threads_num)
 		return;
 
@@ -308,8 +306,8 @@ sgen_thread_pool_shutdown (void)
 	mono_os_cond_destroy (&work_cond);
 	mono_os_cond_destroy (&done_cond);
 
-	for (i = 0; i < threads_num; i++) {
-		mono_threads_add_joinable_thread (threads [i]);
+	for (int i = 0; i < threads_num; i++) {
+		mono_threads_add_joinable_thread ((gpointer)threads [i]);
 	}
 }
 


### PR DESCRIPTION
As @luhenry suggested in https://bugzilla.xamarin.com/show_bug.cgi?id=58317, I fixed two thread leaks.

The order of thread shutdowns is changed by moving `mono_gc_base_cleanup ()` up a little (there seems to be no downside to this). That way the finalizer can clean up (join) the SGen workers. I understand that this is best practice.

Additionally, `mono_threads_join_threads ()` is used to finally join the finalizer within `mono_gc_cleanup ()` and `mono_thread_join (GUINT_TO_POINTER (gc_thread->tid))` is not needed any more.