### PR TITLE
[mono-threads-posix] Fix a buffer overflow (rather an information leak / over-read)

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -205,7 +205,7 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 		pthread_setname_np ("");
 	} else {
 		size_t len = 63;
-		char n [len];
+		char *n = alloca (len);
 
 		strncpy (n, name, len - 1);
 		n [len - 1] = '\0';
@@ -216,7 +216,7 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 		pthread_setname_np (tid, "%s", (void*)"");
 	} else {
 		size_t len = PTHREAD_MAX_NAMELEN_NP;
-		char n [len];
+		char *n = alloca (len);
 
 		strncpy (n, name, len - 1);
 		n [len - 1] = '\0';
@@ -227,7 +227,7 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 		pthread_setname_np (tid, "");
 	} else {
 		size_t len = 16;
-		char n [len];
+		char *n = alloca (len);
 
 		strncpy (n, name, len - 1);
 		n [len - 1] = '\0';

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -204,30 +204,33 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 	if (!name) {
 		pthread_setname_np ("");
 	} else {
-		char n [63];
+		size_t len = 63;
+		char n [len];
 
-		memcpy (n, name, sizeof (n) - 1);
-		n [sizeof (n) - 1] = '\0';
+		strncpy (n, name, len - 1);
+		n [len - 1] = '\0';
 		pthread_setname_np (n);
 	}
 #elif defined (__NetBSD__)
 	if (!name) {
 		pthread_setname_np (tid, "%s", (void*)"");
 	} else {
-		char n [PTHREAD_MAX_NAMELEN_NP];
+		size_t len = PTHREAD_MAX_NAMELEN_NP;
+		char n [len];
 
-		memcpy (n, name, sizeof (n) - 1);
-		n [sizeof (n) - 1] = '\0';
+		strncpy (n, name, len - 1);
+		n [len - 1] = '\0';
 		pthread_setname_np (tid, "%s", (void*)n);
 	}
 #elif defined (HAVE_PTHREAD_SETNAME_NP)
 	if (!name) {
 		pthread_setname_np (tid, "");
 	} else {
-		char n [16];
+		size_t len = 16;
+		char n [len];
 
-		memcpy (n, name, sizeof (n) - 1);
-		n [sizeof (n) - 1] = '\0';
+		strncpy (n, name, len - 1);
+		n [len - 1] = '\0';
 		pthread_setname_np (tid, n);
 	}
 #endif

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -204,33 +204,30 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 	if (!name) {
 		pthread_setname_np ("");
 	} else {
-		size_t len = 63;
-		char *n = alloca (len);
+		char n [63];
 
-		strncpy (n, name, len - 1);
-		n [len - 1] = '\0';
+		strncpy (n, name, sizeof (n) - 1);
+		n [sizeof (n) - 1] = '\0';
 		pthread_setname_np (n);
 	}
 #elif defined (__NetBSD__)
 	if (!name) {
 		pthread_setname_np (tid, "%s", (void*)"");
 	} else {
-		size_t len = PTHREAD_MAX_NAMELEN_NP;
-		char *n = alloca (len);
+		char n [PTHREAD_MAX_NAMELEN_NP];
 
-		strncpy (n, name, len - 1);
-		n [len - 1] = '\0';
+		strncpy (n, name, sizeof (n) - 1);
+		n [sizeof (n) - 1] = '\0';
 		pthread_setname_np (tid, "%s", (void*)n);
 	}
 #elif defined (HAVE_PTHREAD_SETNAME_NP)
 	if (!name) {
 		pthread_setname_np (tid, "");
 	} else {
-		size_t len = 16;
-		char *n = alloca (len);
+		char n [16];
 
-		strncpy (n, name, len - 1);
-		n [len - 1] = '\0';
+		strncpy (n, name, sizeof (n) - 1);
+		n [sizeof (n) - 1] = '\0';
 		pthread_setname_np (tid, n);
 	}
 #endif


### PR DESCRIPTION
While testing Clang's AddressSanitizer, I found and fixed a buffer overflow.

Up for discussion: it might be worth importing `strlcpy` (http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/string/strlcpy.c?rev=1.11) for similar purposes as it provides additional safety and also helps with the readability?