### PR TITLE
[2017-06][sre] Pass declaring type to GetMethodFromHandle in GenericTypeParameterBuilder:InternalResolve (Fixes #58454)

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.cs
@@ -87,7 +87,7 @@ namespace System.Reflection.Emit
 		internal override Type InternalResolve ()
 		{
 			if (mbuilder != null)
-				return MethodBase.GetMethodFromHandle (mbuilder.MethodHandleInternal).GetGenericArguments () [index];
+				return MethodBase.GetMethodFromHandle (mbuilder.MethodHandleInternal, mbuilder.TypeBuilder.InternalResolve ().TypeHandle).GetGenericArguments () [index];
 			return tbuilder.InternalResolve ().GetGenericArguments () [index];
 		}
 


### PR DESCRIPTION
This is #5288 cherrypicked to `2017-06`

----

When the parameter belongs to a method builder, we need to pass the declaring
type (appropriately resolved) to GetMethodFromHandle to avoid an
ArgumentException.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58454