### PR TITLE
WIP: [bcl] Grab free ports in batches in NetworkHelpers

### DIFF
--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 
@@ -6,14 +7,34 @@ namespace MonoTests.Helpers {
 
 	public static class NetworkHelpers
 	{
+		const int POOLSIZE = 50;
+		static Queue<TcpListener> listenerPool = new Queue<TcpListener> (POOLSIZE);
+
+		private static void PopulatePool ()
+		{
+			for (int i = 0; i < POOLSIZE; i++) {
+				TcpListener l = new TcpListener (IPAddress.Loopback, 0);
+				l.Start ();
+				listenerPool.Enqueue (l);
+			}
+		}
+
 		public static int FindFreePort ()
 		{
-			TcpListener l = new TcpListener(IPAddress.Loopback, 0);
-			l.Start();
-			int port = ((IPEndPoint)l.LocalEndpoint).Port;
-			l.Stop();
+			TcpListener listener;
+
+			lock (listenerPool) {
+				if (listenerPool.Count == 0)
+					PopulatePool ();
+				
+				listener = listenerPool.Dequeue ();
+			}
+
+			int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+			listener.Stop ();
 			return port;
 		}
+
 		public static IPEndPoint LocalEphemeralEndPoint ()
 		{
 			return new IPEndPoint (IPAddress.Loopback, FindFreePort());


### PR DESCRIPTION
We're frequently seeing "address already in use" errors on Jenkins.

The theory is that when we're running tests and grab the next free
port via our custom NetworkHelpers we're getting a port which will
also be returned to a simultaneously running test (e.g. another chroot)
because we're closing the TcpListener and thus releasing the port until
we start using it in actual test code. By that time the other test
might've already opened the port, causing our test to fail.

Grabbing free ports in batches and keeping the TcpListener opened
in a queue until a test requests a port should solve this.

Testing to see whether Jenkins likes this.