### PR TITLE
Fix major AppleTLS memory leak

### DIFF
--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -665,7 +665,7 @@ namespace Mono.AppleTls
 				if (value == IntPtr.Zero)
 					throw new TlsException (AlertDescription.CertificateUnknown);
 			}
-			return (value == IntPtr.Zero) ? null : new SecTrust (value);
+			return (value == IntPtr.Zero) ? null : new SecTrust (value, true);
 		}
 
 		#endregion
@@ -867,6 +867,7 @@ namespace Mono.AppleTls
 			} finally {
 				closed = true;
 				pendingIO = 0;
+				handle.Free ();
 			}
 		}
 


### PR DESCRIPTION
- AppleTlsContext were not being collected due to a GCHandle being left open
- Most of https://bugzilla.xamarin.com/show_bug.cgi?id=56814