### PR TITLE
[custom_attrs] Add bounds checking to custom attribute parsing

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1180,7 +1180,7 @@ mono_metadata_decode_row_col (const MonoTableInfo *t, int idx, guint col)
  * \param ptr pointer to a blob object
  * \param rptr the new position of the pointer
  *
- * This decodes a compressed size as described by 23.1.4 (a blob or user string object)
+ * This decodes a compressed size as described by 24.2.4 (#US and #Blob a blob or user string object)
  *
  * \returns the size of the blob object
  */


### PR DESCRIPTION
In principle, `mono_verifier_verify_cattr_content` should prevent malformed custom
attribute blobs from being passed in here.

In practice:

1. The verifier is not on by default

2. System.Reflection.Emit allows an arbitrary `byte[]` to be passed in which
   means that code like this can cause mono to read past the end of the array.

   ```
   // "1 1-byte constructor argument and then 65280 named properties follow"
   assembly.SetCustomAttribute(constructor, new byte[] { 1, 0, 1, 0x00, 0xFF });
   var attributes = assembly.GetCustomAttributes(true);
   ```
