### PR TITLE
[runtime] Remove ves_icall_object_new_fast (), its only a bit faster …

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1171,11 +1171,8 @@ mono_gc_is_critical_method (MonoMethod *method)
  * @klass. The method will typically have an thread-local inline allocation sequence.
  * The signature of the called method is:
  * 	object allocate (MonoVTable *vtable)
- * Some of the logic here is similar to mono_class_get_allocation_ftn () i object.c,
- * keep in sync.
  * The thread local alloc logic is taken from libgc/pthread_support.c.
  */
-
 MonoMethod*
 mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean known_instance_size)
 {

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -71,7 +71,7 @@ mono_mlist_alloc_checked (MonoObject *data, MonoError *error)
 		monolist_item_vtable = mono_class_vtable (mono_get_root_domain (), klass);
 		g_assert (monolist_item_vtable);
 	}
-	res = (MonoMList*)mono_object_new_fast_checked (monolist_item_vtable, error);
+	res = (MonoMList*)mono_object_new_specific_checked (monolist_item_vtable, error);
 	return_val_if_nok (error, NULL);
 	MONO_OBJECT_SETREF (res, data, data);
 	return res;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -683,9 +683,6 @@ mono_delegate_ctor_with_method (MonoObjectHandle this_obj, MonoObjectHandle targ
 gboolean
 mono_delegate_ctor	    (MonoObjectHandle this_obj, MonoObjectHandle target, gpointer addr, MonoError *error);
 
-void*
-mono_class_get_allocation_ftn (MonoVTable *vtable, gboolean for_box, gboolean *pass_size_in_words);
-
 void
 mono_runtime_free_method    (MonoDomain *domain, MonoMethod *method);
 
@@ -1812,9 +1809,6 @@ mono_object_new_mature (MonoVTable *vtable, MonoError *error);
 
 MonoObject*
 mono_object_new_fast_checked (MonoVTable *vtable, MonoError *error);
-
-MonoObject *
-ves_icall_object_new_fast (MonoVTable *vtable);
 
 MonoObject *
 mono_object_clone_checked (MonoObject *obj, MonoError *error);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -117,7 +117,7 @@
 #endif
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 140
+#define MONO_AOT_FILE_VERSION 141
 
 //TODO: This is x86/amd64 specific.
 #define mono_simd_shuffle_mask(a,b,c,d) ((a) | ((b) << 2) | ((c) << 4) | ((d) << 6))


### PR DESCRIPTION
…than object_new_specific (), fast allocation is done by the managed allocators. Also remove mono_class_get_allocation_ftn () which is not needed anymore.