### PR TITLE
Fix xdebug

### DIFF
--- a/mono/mini/image-writer.c
+++ b/mono/mini/image-writer.c
@@ -120,31 +120,6 @@
 #define ALIGN_PTR_TO(ptr,align) (gpointer)((((gssize)(ptr)) + (align - 1)) & (~(align - 1)))
 #define ROUND_DOWN(VALUE,SIZE)	((VALUE) & ~((SIZE) - 1))
 
-#if defined(TARGET_AMD64) && !defined(HOST_WIN32) && !defined(__APPLE__)
-#define USE_ELF_WRITER 1
-#define USE_ELF_RELA 1
-#endif
-
-#if defined(TARGET_X86) && !defined(HOST_WIN32) && !defined(__APPLE__)
-#define USE_ELF_WRITER 1
-#endif
-
-#if defined(TARGET_ARM) && !defined(TARGET_MACH) && !defined(HOST_WIN32)
-//#define USE_ELF_WRITER 1
-#endif
-
-#if defined(__mips__)
-#define USE_ELF_WRITER 1
-#endif
-
-#if defined(TARGET_X86) && defined(__APPLE__)
-//#define USE_MACH_WRITER
-#endif
-
-#if defined(USE_ELF_WRITER) || defined(USE_MACH_WRITER)
-#define USE_BIN_WRITER 1
-#endif
-
 #ifdef USE_BIN_WRITER
 
 typedef struct _BinSymbol BinSymbol;

--- a/mono/mini/image-writer.h
+++ b/mono/mini/image-writer.h
@@ -22,6 +22,31 @@
 
 typedef struct _MonoImageWriter MonoImageWriter;
 
+#if defined(TARGET_AMD64) && !defined(HOST_WIN32) && !defined(__APPLE__)
+#define USE_ELF_WRITER 1
+#define USE_ELF_RELA 1
+#endif
+
+#if defined(TARGET_X86) && !defined(HOST_WIN32) && !defined(__APPLE__)
+#define USE_ELF_WRITER 1
+#endif
+
+#if defined(TARGET_ARM) && !defined(TARGET_MACH) && !defined(HOST_WIN32)
+//#define USE_ELF_WRITER 1
+#endif
+
+#if defined(__mips__)
+#define USE_ELF_WRITER 1
+#endif
+
+#if defined(TARGET_X86) && defined(__APPLE__)
+//#define USE_MACH_WRITER
+#endif
+
+#if defined(USE_ELF_WRITER) || defined(USE_MACH_WRITER)
+#define USE_BIN_WRITER 1
+#endif
+
 /* Relocation types */
 #define R_ARM_CALL 28
 #define R_ARM_JUMP24 29

--- a/mono/mini/xdebug.c
+++ b/mono/mini/xdebug.c
@@ -28,7 +28,6 @@
 #include <glib.h>
 #include "mini.h"
 
-#if !defined(DISABLE_AOT) && !defined(DISABLE_JIT) && USE_BIN_WRITER
 #include <sys/types.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -50,6 +49,9 @@
 #include <sys/stat.h>
 
 #include "image-writer.h"
+
+#if !defined(DISABLE_AOT) && !defined(DISABLE_JIT) && USE_BIN_WRITER
+
 #include "dwarfwriter.h"
 
 #include "mono/utils/mono-compiler.h"

--- a/mono/mini/xdebug.c
+++ b/mono/mini/xdebug.c
@@ -339,6 +339,10 @@ mono_save_xdebug_info (MonoCompile *cfg)
 void
 mono_save_trampoline_xdebug_info (MonoTrampInfo *info)
 {
+	const char *info_name = info->name;
+	if (info_name == NULL)
+		info_name = "";
+
 	if (use_gdb_interface) {
 		MonoImageWriter *w;
 		MonoDwarfWriter *dw;
@@ -348,7 +352,7 @@ mono_save_trampoline_xdebug_info (MonoTrampInfo *info)
 
 		xdebug_begin_emit (&w, &dw);
 
-		mono_dwarf_writer_emit_trampoline (dw, info->name, NULL, NULL, info->code, info->code_size, info->unwind_ops);
+		mono_dwarf_writer_emit_trampoline (dw, info_name, NULL, NULL, info->code, info->code_size, info->unwind_ops);
 
 		xdebug_end_emit (w, dw, NULL);
 		
@@ -358,7 +362,7 @@ mono_save_trampoline_xdebug_info (MonoTrampInfo *info)
 			return;
 
 		mono_loader_lock_if_inited ();
-		mono_dwarf_writer_emit_trampoline (xdebug_writer, info->name, NULL, NULL, info->code, info->code_size, info->unwind_ops);
+		mono_dwarf_writer_emit_trampoline (xdebug_writer, info_name, NULL, NULL, info->code, info->code_size, info->unwind_ops);
 		fflush (xdebug_fp);
 		mono_loader_unlock_if_inited ();
 	}


### PR DESCRIPTION
It looks like xdebug (extended gdb support for JIT-compiled code and some other goodies for gdb) has been disabled for a while. These patches re-enable it.