### PR TITLE
[TSan] Yet another idea about whitelisting data races

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -755,17 +755,17 @@ typedef struct {
 
 typedef struct {
 	guint64 new_object_count;
-	size_t initialized_class_count;
-	size_t generic_vtable_count;
+	gsize initialized_class_count;
+	gsize generic_vtable_count;
 	size_t used_class_count;
 	size_t method_count;
 	size_t class_vtable_size;
 	size_t class_static_data_size;
 	size_t generic_instance_count;
-	size_t generic_class_count;
-	size_t inflated_method_count;
+	gsize generic_class_count;
+	gsize inflated_method_count;
 	size_t inflated_method_count_2;
-	size_t inflated_type_count;
+	gsize inflated_type_count;
 	size_t generics_metadata_size;
 	size_t delegate_creations;
 	size_t imt_tables_size;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -46,6 +46,7 @@
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/atomic.h>
+#include <mono/utils/racing.h>
 #include <mono/utils/bsearch.h>
 #include <mono/utils/checked-build.h>
 
@@ -864,7 +865,7 @@ mono_class_inflate_generic_type_with_mempool (MonoImage *image, MonoType *type, 
 		}
 	}
 
-	mono_stats.inflated_type_count++;
+	RacingIncrementSize (&mono_stats.inflated_type_count);
 	return inflated;
 }
 
@@ -928,7 +929,7 @@ mono_class_inflate_generic_type_no_copy (MonoImage *image, MonoType *type, MonoG
 	if (!inflated)
 		return type;
 
-	mono_stats.inflated_type_count++;
+	RacingIncrementSize (&mono_stats.inflated_type_count);
 	return inflated;
 }
 
@@ -1089,7 +1090,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 		return (MonoMethod*)cached;
 	}
 
-	mono_stats.inflated_method_count++;
+	RacingIncrementSize (&mono_stats.inflated_method_count);
 
 	inflated_methods_size += sizeof (MonoMethodInflated);
 
@@ -3568,7 +3569,7 @@ mono_class_setup_vtable_full (MonoClass *klass, GList *in_setup)
 		return;
 	}
 
-	mono_stats.generic_vtable_count ++;
+	RacingIncrementSize (&mono_stats.generic_vtable_count);
 	in_setup = g_list_prepend (in_setup, klass);
 
 	if (mono_class_is_ginst (klass)) {
@@ -4902,7 +4903,7 @@ mono_class_init (MonoClass *klass)
 			goto leave;
 	}
 
-	mono_stats.initialized_class_count++;
+	RacingIncrementSize (&mono_stats.initialized_class_count);
 
 	if (mono_class_is_ginst (klass) && !mono_class_get_generic_class (klass)->is_dynamic) {
 		MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
@@ -5047,10 +5048,10 @@ mono_class_init (MonoClass *klass)
 		return !mono_class_has_failure (klass);
 	}
 
-	mono_stats.initialized_class_count++;
+	RacingIncrementSize (&mono_stats.initialized_class_count);
 
 	if (mono_class_is_ginst (klass) && !mono_class_get_generic_class (klass)->is_dynamic)
-		mono_stats.generic_class_count++;
+		RacingIncrementSize (&mono_stats.generic_class_count);
 
 	if (mono_class_is_ginst (klass) || image_is_dynamic (klass->image) || !klass->type_token || (has_cached_info && !cached_info.has_nested_classes))
 		klass->nested_classes_inited = TRUE;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -46,7 +46,7 @@
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/atomic.h>
-#include <mono/utils/racing.h>
+#include <mono/utils/unlocked.h>
 #include <mono/utils/bsearch.h>
 #include <mono/utils/checked-build.h>
 
@@ -865,7 +865,7 @@ mono_class_inflate_generic_type_with_mempool (MonoImage *image, MonoType *type, 
 		}
 	}
 
-	RacingIncrementSize (&mono_stats.inflated_type_count);
+	UnlockedIncrementSize (&mono_stats.inflated_type_count);
 	return inflated;
 }
 
@@ -929,7 +929,7 @@ mono_class_inflate_generic_type_no_copy (MonoImage *image, MonoType *type, MonoG
 	if (!inflated)
 		return type;
 
-	RacingIncrementSize (&mono_stats.inflated_type_count);
+	UnlockedIncrementSize (&mono_stats.inflated_type_count);
 	return inflated;
 }
 
@@ -1090,7 +1090,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 		return (MonoMethod*)cached;
 	}
 
-	RacingIncrementSize (&mono_stats.inflated_method_count);
+	UnlockedIncrementSize (&mono_stats.inflated_method_count);
 
 	inflated_methods_size += sizeof (MonoMethodInflated);
 
@@ -3569,7 +3569,7 @@ mono_class_setup_vtable_full (MonoClass *klass, GList *in_setup)
 		return;
 	}
 
-	RacingIncrementSize (&mono_stats.generic_vtable_count);
+	UnlockedIncrementSize (&mono_stats.generic_vtable_count);
 	in_setup = g_list_prepend (in_setup, klass);
 
 	if (mono_class_is_ginst (klass)) {
@@ -4903,7 +4903,7 @@ mono_class_init (MonoClass *klass)
 			goto leave;
 	}
 
-	RacingIncrementSize (&mono_stats.initialized_class_count);
+	UnlockedIncrementSize (&mono_stats.initialized_class_count);
 
 	if (mono_class_is_ginst (klass) && !mono_class_get_generic_class (klass)->is_dynamic) {
 		MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
@@ -5048,10 +5048,10 @@ mono_class_init (MonoClass *klass)
 		return !mono_class_has_failure (klass);
 	}
 
-	RacingIncrementSize (&mono_stats.initialized_class_count);
+	UnlockedIncrementSize (&mono_stats.initialized_class_count);
 
 	if (mono_class_is_ginst (klass) && !mono_class_get_generic_class (klass)->is_dynamic)
-		RacingIncrementSize (&mono_stats.generic_class_count);
+		UnlockedIncrementSize (&mono_stats.generic_class_count);
 
 	if (mono_class_is_ginst (klass) || image_is_dynamic (klass->image) || !klass->type_token || (has_cached_info && !cached_info.has_nested_classes))
 		klass->nested_classes_inited = TRUE;

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -175,7 +175,8 @@ monoutils_sources = \
 	checked-build.h \
 	os-event.h \
 	refcount.h	\
-	w32api.h
+	w32api.h	\
+	racing.h
 
 arch_sources = 
 

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -176,7 +176,7 @@ monoutils_sources = \
 	os-event.h \
 	refcount.h	\
 	w32api.h	\
-	racing.h
+	unlocked.h
 
 arch_sources = 
 

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -113,13 +113,19 @@ typedef SSIZE_T ssize_t;
 #define MONO_GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
-/* Used to tell clang's ThreadSanitizer to not report data races that occur within a certain function */
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
-#define MONO_NO_SANITIZE_THREAD __attribute__ ((no_sanitize("thread")))
+#define MONO_HAS_CLANG_THREAD_SANITIZER 1
 #else
-#define MONO_NO_SANITIZE_THREAD
+#define MONO_HAS_CLANG_THREAD_SANITIZER 0
 #endif
+#else
+#define MONO_HAS_CLANG_THREAD_SANITIZER 0
+#endif
+
+/* Used to tell Clang's ThreadSanitizer to not report data races that occur within a certain function */
+#if MONO_HAS_CLANG_THREAD_SANITIZER
+#define MONO_NO_SANITIZE_THREAD __attribute__ ((no_sanitize("thread")))
 #else
 #define MONO_NO_SANITIZE_THREAD
 #endif

--- a/mono/utils/racing.h
+++ b/mono/utils/racing.h
@@ -1,0 +1,46 @@
+/**
+ * \file
+ * Contains inline functions to explicitly mark data races that should not be changed.
+ * This way, instruments like Clang's ThreadSanitizer can be told to ignore very specific instructions.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#ifndef _RACING_H_
+#define _RACING_H_
+
+#include <glib.h>
+#include <mono/utils/mono-compiler.h>
+
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define MONO_RACING_ATTRS MONO_NO_SANITIZE_THREAD static
+#else
+#define MONO_RACING_ATTRS MONO_ALWAYS_INLINE static inline
+#endif
+#else
+#define MONO_RACING_ATTRS MONO_ALWAYS_INLINE static inline
+#endif
+
+MONO_RACING_ATTRS
+gint32
+RacingIncrement (gint32 *val)
+{
+	return ++*val;
+}
+
+MONO_RACING_ATTRS
+gint64
+RacingIncrement64 (gint64 *val)
+{
+	return ++*val;
+}
+
+MONO_RACING_ATTRS
+gsize
+RacingIncrementSize (gsize *val)
+{
+	return ++*val;
+}
+
+#endif /* _RACING_H_ */

--- a/mono/utils/unlocked.h
+++ b/mono/utils/unlocked.h
@@ -6,41 +6,37 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
-#ifndef _RACING_H_
-#define _RACING_H_
+#ifndef _UNLOCKED_H_
+#define _UNLOCKED_H_
 
 #include <glib.h>
 #include <mono/utils/mono-compiler.h>
 
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-#define MONO_RACING_ATTRS MONO_NO_SANITIZE_THREAD static
+#if MONO_HAS_CLANG_THREAD_SANITIZER
+#define MONO_UNLOCKED_ATTRS MONO_NO_SANITIZE_THREAD MONO_NEVER_INLINE static
 #else
-#define MONO_RACING_ATTRS MONO_ALWAYS_INLINE static inline
-#endif
-#else
-#define MONO_RACING_ATTRS MONO_ALWAYS_INLINE static inline
+#define MONO_UNLOCKED_ATTRS MONO_ALWAYS_INLINE static inline
 #endif
 
-MONO_RACING_ATTRS
+MONO_UNLOCKED_ATTRS
 gint32
-RacingIncrement (gint32 *val)
+UnlockedIncrement (gint32 *val)
 {
 	return ++*val;
 }
 
-MONO_RACING_ATTRS
+MONO_UNLOCKED_ATTRS
 gint64
-RacingIncrement64 (gint64 *val)
+UnlockedIncrement64 (gint64 *val)
 {
 	return ++*val;
 }
 
-MONO_RACING_ATTRS
+MONO_UNLOCKED_ATTRS
 gsize
-RacingIncrementSize (gsize *val)
+UnlockedIncrementSize (gsize *val)
 {
 	return ++*val;
 }
 
-#endif /* _RACING_H_ */
+#endif /* _UNLOCKED_H_ */

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -189,7 +189,7 @@
     <ClInclude Include="..\mono\utils\strenc.h" />
     <ClInclude Include="..\mono\utils\valgrind.h" />
     <ClInclude Include="..\mono\utils\atomic.h" />
-    <ClInclude Include="..\mono\utils\racing.h" />
+    <ClInclude Include="..\mono\utils\unlocked.h" />
     <ClInclude Include="..\mono\utils\mono-hwcap.h" />
     <ClInclude Include="..\mono\utils\mono-hwcap-x86.h" />
     <ClInclude Include="..\mono\utils\bsearch.h" />

--- a/msvc/libmonoutils.vcxproj
+++ b/msvc/libmonoutils.vcxproj
@@ -189,6 +189,7 @@
     <ClInclude Include="..\mono\utils\strenc.h" />
     <ClInclude Include="..\mono\utils\valgrind.h" />
     <ClInclude Include="..\mono\utils\atomic.h" />
+    <ClInclude Include="..\mono\utils\racing.h" />
     <ClInclude Include="..\mono\utils\mono-hwcap.h" />
     <ClInclude Include="..\mono\utils\mono-hwcap-x86.h" />
     <ClInclude Include="..\mono\utils\bsearch.h" />

--- a/msvc/libmonoutils.vcxproj.filters
+++ b/msvc/libmonoutils.vcxproj.filters
@@ -426,7 +426,7 @@
     <ClInclude Include="..\mono\utils\os-event.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\mono\utils\racing.h">
+    <ClInclude Include="..\mono\utils\unlocked.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msvc/libmonoutils.vcxproj.filters
+++ b/msvc/libmonoutils.vcxproj.filters
@@ -426,6 +426,9 @@
     <ClInclude Include="..\mono\utils\os-event.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\mono\utils\racing.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">


### PR DESCRIPTION
I would like to propose another idea about how to deal with the instrumentation of data races. Inspired by atomic.h and the `G_UNLIKELY` macro, a (maybe *the*) solution might be to use `inline` functions that wrap around increments, additions, ...

**The Main Problem**:
* Any kind of locking and synchronisation (like using the functions of [atomic.h](https://github.com/mono/mono/blob/master/mono/utils/atomic.h)) is no option in performance critical situations like [mempool.c](https://github.com/mono/mono/blob/master/mono/metadata/mempool.c).
* TSan instrumentation can only be blocked on a function level; TSan can be told to ignore whole functions, however, it can not be told to ignore single instructions.
* Big functions might contain "harmless" *and* harmful data races. By "harmless" I mean things like counters that are only used for debugging / reporting.
* There are a lot of data races (> 30) that are simple reporting / debugging counters (e.g. the whole of `mono_stats` in [class-internals.h](https://github.com/mono/mono/blob/master/mono/metadata/class-internals.h)).
* Once a function is blacklisted, any alteration that produces a harmful data race in combination with that blacklisted function will not be detected. In fact, *that* is my main concern when blacklisting whole functions!

**The Idea**:

Using inline functions that follow the exact same interface like the functions in [atomic.h](https://github.com/mono/mono/blob/master/mono/utils/atomic.h).

* Known data races can be documented in the code, *exactly* where they occur (no documentation is needed as it is extremely readable / transparent).
* Due to inlining, the original machine instructions are not altered if TSan is not activated. Thus, there is no performance impact.
* `RacingIncrement ()` can be quickly changed to `InterlockedIncrement ()`, should the need arise.

To demonstrate the idea, I used `mono_stats` in class.c as a specimen. I also tested proper function inlining on Fedora 26 with `gcc 7.1.1` and `clang 4.0.0` (both with `-O2`) and all results were as expected: The code was exactly the same - with `RacingIncrementSize (&mono_stats.foo)` and with `++mono_stats.foo`.

I really hope that this idea gets accepted by the community since I would love to finally have the possibility of blacklisting single racy instructions. Detecting actual (harmuful) data races would be a lot more precise and reliable. If accepted, I would of course expand these function family (we will need things like `RacingExchange ()`, `RacingAdd ()`, `RacingSub ()` and more) to tackle all races that are connected to debugging / reporting.

As we talked about this topic before, I would kindly ask at least @luhenry, @vargaz, @alexrp and @lambdageek about thoughts and opinions.