### PR TITLE
[bcl] Grab free ports randomly in NetworkHelpers

### DIFF
--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -15,20 +15,16 @@ namespace MonoTests.Helpers {
 
 		public static IPEndPoint LocalEphemeralEndPoint ()
 		{
-			bool success = false;
-
-			do {
+			while (true) {
 				var ep = new IPEndPoint (IPAddress.Loopback, rndPort.Next (10000, 60000));
 				var socket = new Socket (ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
 				try {
 					socket.Bind (ep);
 					socket.Close ();
-					success = true;
+					return ep;
 				} catch (SocketException) { }
-
-				return ep;
-			} while (!success);
+			}
 		}
 	}
 }

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -6,17 +6,29 @@ namespace MonoTests.Helpers {
 
 	public static class NetworkHelpers
 	{
+		static Random rndPort = new Random ();
+
 		public static int FindFreePort ()
 		{
-			TcpListener l = new TcpListener(IPAddress.Loopback, 0);
-			l.Start();
-			int port = ((IPEndPoint)l.LocalEndpoint).Port;
-			l.Stop();
-			return port;
+			return LocalEphemeralEndPoint ().Port;
 		}
+
 		public static IPEndPoint LocalEphemeralEndPoint ()
 		{
-			return new IPEndPoint (IPAddress.Loopback, FindFreePort());
+			bool success = false;
+
+			do {
+				var ep = new IPEndPoint (IPAddress.Loopback, rndPort.Next (10000, 60000));
+				var socket = new Socket (ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+				try {
+					socket.Bind (ep);
+					socket.Close ();
+					success = true;
+				} catch (SocketException) { }
+
+				return ep;
+			} while (!success);
 		}
 	}
 }


### PR DESCRIPTION
(this is an alternative, simpler approach to #5290)

We're frequently seeing "address already in use" errors on Jenkins.

The theory is that when we're running tests and grab the next free
port via our custom NetworkHelpers we're getting a port which will
also be returned to a simultaneously running test (e.g. another chroot)
because we're closing the TcpListener and thus releasing the port until
we start using it in actual test code. By that time the other test
might've already opened the port, causing our test to fail.

Instead we now try to use a random port in the range 10000-60000
and try if it's available. This doesn't completely fix the inherent
race but should hopefully make it way less likely.