### PR TITLE
Profiler - inlining fixes

### DIFF
--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -167,7 +167,7 @@ MONO_API mono_bool mono_profiler_enable_allocations (void);
 
 typedef enum {
 	/* Do not instrument calls. */
-	MONO_PROFILER_CALL_INSTRUMENTATION_NONE = 1 << 0,
+	MONO_PROFILER_CALL_INSTRUMENTATION_NONE = 0,
 	/* Instrument method prologues. */
 	MONO_PROFILER_CALL_INSTRUMENTATION_PROLOGUE = 1 << 1,
 	/* Also capture a call context for prologues. */

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -20,6 +20,13 @@ mini_profiler_emit_instrumentation_call (MonoCompile *cfg, void *func, gboolean 
 {
 	gboolean instrument, capture;
 
+	/*
+	 * Do not instrument an inlined method - it becomes
+	 * part of the current method.
+	 */
+	if (cfg->current_method != cfg->method)
+		return;
+
 	if (entry) {
 		instrument = cfg->prof_flags & MONO_PROFILER_CALL_INSTRUMENTATION_PROLOGUE;
 		capture = cfg->prof_flags & MONO_PROFILER_CALL_INSTRUMENTATION_PROLOGUE_CONTEXT;
@@ -30,8 +37,6 @@ mini_profiler_emit_instrumentation_call (MonoCompile *cfg, void *func, gboolean 
 
 	if (!instrument)
 		return;
-
-	g_assert (cfg->current_method == cfg->method);
 
 	MonoInst *iargs [2];
 


### PR DESCRIPTION
Attached some inlining-related fixes to profiling code:
- First patch ensures that a function may get inlined if it is not being profiled
- Second patch fixes a crash that happens if non-profiled method B is inlined inside profiled method A