### PR TITLE
Default powerpc to mcs instead of roslyn

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -783,7 +783,10 @@ if test $csc_compiler = default; then
    if test $endian = big; then
       csc_compiler=mcs
    elif test $endian = little; then
-      csc_compiler=roslyn
+      case "$host" in
+        powerpc*) csc_compiler=mcs ;;
+        *) csc_compiler=roslyn ;;
+      esac
    else
       csc_compiler=mcs
    fi


### PR DESCRIPTION
It is crashing still way more than it works and now that the mcs configuration works again we should default to that to make our CI more pleasant.