### PR TITLE
[profiler] add a test for selectively profiling inlined code

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -30,6 +30,9 @@ lib_LTLIBRARIES = \
 suppressiondir = $(datadir)/mono-$(API_VER)/mono/profiler
 suppression_DATA = mono-profiler-log.suppression
 
+check_LTLIBRARIES = \
+	libmono-profiler-testinline.la
+
 if PLATFORM_DARWIN
 if BITCODE
 prof_ldflags = -no-undefined
@@ -50,7 +53,7 @@ endif
 
 # FIXME fix the profiler tests to work with coop.
 if !ENABLE_COOP
-check_targets = testlog
+check_targets = testlog testinline
 endif
 
 endif
@@ -94,12 +97,23 @@ libmono_profiler_vtune_static_la_CFLAGS = $(VTUNE_CFLAGS)
 libmono_profiler_vtune_static_la_LIBADD = $(VTUNE_LIBS)
 endif
 
+libmono_profiler_testinline_la_SOURCES = test_inline.c
+libmono_profiler_testinline_la_LIBADD = $(libmono_dep) $(GLIB_LIBS) $(LIBICONV)
+#the rpath hack coerces libtool into producing a shared lib for a test
+#it basically specifies to libtool where the library will eventually
+#be installed, but since it's a test lib, we don't install it. Without
+#-rpath, libtool does not create a shared library.
+libmono_profiler_testinline_la_LDFLAGS = $(prof_ldflags) -rpath /dev/null
+
 mprof_report_SOURCES = mprof-report.c
 mprof_report_LDADD = $(Z_LIBS) $(GLIB_LIBS) $(LIBICONV)
 
 PLOG_TESTS_SRC=test-alloc.cs test-busy.cs test-monitor.cs test-excleave.cs \
 	test-heapshot.cs test-traces.cs
 PLOG_TESTS=$(PLOG_TESTS_SRC:.cs=.exe)
+
+PINLINE_TESTS_SRC=test-prof-inline.cs
+PINLINE_TESTS=$(PINLINE_TESTS_SRC:.cs=.exe)
 
 CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
 
@@ -111,6 +125,10 @@ MCS = $(TOOLS_RUNTIME) $(CSC) -lib:$(CLASS) -unsafe -nologo -noconfig -nowarn:01
 
 testlog: $(PLOG_TESTS)
 	MONO_PATH=$(CLASS) perl $(srcdir)/ptestrunner.pl $(top_builddir)
+
+testinline: $(PINLINE_TESTS) libmono-profiler-testinline.la
+	MONO_PATH=$(CLASS) $(srcdir)/profile_test_runner.sh $(top_builddir)/mono/mini/mono testinline:bar:1 test-prof-inline.exe
+	MONO_PATH=$(CLASS) $(srcdir)/profile_test_runner.sh $(top_builddir)/mono/mini/mono testinline:foo:2 test-prof-inline.exe
 
 check-local: $(check_targets)
 

--- a/mono/profiler/profile_test_runner.sh
+++ b/mono/profiler/profile_test_runner.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Blackbox test for running test profilers. The success of the
+# test depends on successfully running the .exe with loaded
+# profiler. Either the C# program or the profiler can fail
+# the test.
+#
+
+if [ $# -lt 3 ]; then
+cat <<EOF
+Usage: $0 MONO PROFILE-STRING PROGRAM [PROG-ARGS]
+EOF
+exit 1;
+fi
+
+MONO=${1}
+PROFILE_STRING=${2}
+PROGRAM=${3}
+shift 3
+PROGARGS="$*"
+
+echo "Checking $PROGRAM with profiler $PROFILE_STRING ..."
+$MONO --profile="$PROFILE_STRING" $PROGRAM $PROGARGS

--- a/mono/profiler/test-prof-inline.cs
+++ b/mono/profiler/test-prof-inline.cs
@@ -1,0 +1,19 @@
+using System;
+
+class T {
+    static int foo(int x)
+    {
+        return x+1;
+    }
+
+    static int bar(int x)
+    {
+        return foo(x);
+    }
+
+    static void Main (string[] args)
+    {
+        bar(5);
+        foo(1);
+    }
+}

--- a/mono/profiler/test_inline.c
+++ b/mono/profiler/test_inline.c
@@ -1,0 +1,70 @@
+/*
+ * test_inline.c: A test profiler for Mono.
+ *
+ * Copyright 2017 vFunction, Inc.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <glib.h>
+#include <mono/metadata/loader.h>
+#include <mono/metadata/profiler.h>
+
+struct _MonoProfiler {
+	char **parsed_params;
+	char *method_name;
+	int expected_ncalls;
+	uint64_t ncalls;
+};
+
+/* called at the end of the program */
+static void testinline_shutdown(MonoProfiler *prof)
+{
+	if (prof->ncalls != (uint64_t)prof->expected_ncalls) {
+		g_printf("Expected %d calls, got %" PRIu64 "\n",
+			 prof->expected_ncalls, prof->ncalls);
+		exit(1);
+	}
+}
+
+static void testinline_method_enter(MonoProfiler *prof,
+				    MonoMethod *method,
+				    MonoProfilerCallContext *ctx)
+{
+	prof->ncalls++;
+}
+
+static MonoProfilerCallInstrumentationFlags
+testinline_instrumentation_filter(MonoProfiler *prof, MonoMethod *method)
+{
+	if (strcmp(mono_method_get_name(method), prof->method_name) == 0)
+		return MONO_PROFILER_CALL_INSTRUMENTATION_PROLOGUE;
+	return 0;
+}
+
+/* the entry point */
+void mono_profiler_init_testinline(const char *desc);
+
+void mono_profiler_init_testinline(const char *desc)
+{
+	MonoProfiler *prof = g_new0(MonoProfiler, 1);
+	prof->parsed_params = g_strsplit(desc, ":", -1);
+	if (prof->parsed_params[0] == NULL || prof->parsed_params[1] == NULL ||
+	    prof->parsed_params[2] == NULL) {
+		g_printf("usage: "
+			 "--profile=testinline:<method-to-profile>:<expected-"
+			 "ncalls>\n");
+		exit(1);
+	}
+	prof->method_name = prof->parsed_params[1];
+	prof->expected_ncalls = atoi(prof->parsed_params[2]);
+
+	MonoProfilerHandle handle = mono_profiler_create(prof);
+	mono_profiler_set_runtime_shutdown_end_callback(handle,
+							testinline_shutdown);
+	mono_profiler_set_call_instrumentation_filter_callback(
+	    handle, testinline_instrumentation_filter);
+	mono_profiler_set_method_enter_callback(handle,
+						testinline_method_enter);
+}


### PR DESCRIPTION
This test includes a custom profiler that decides at JIT time
which code to profile, base on method name. It then counts
numeber of invocations and compares with expected value.

The main objective of the test is to check that code that otherwise
would be inlined can be profiled, and that profiled code can have
non-profiled inlined code inside it.
If the first commit of PR#5321 is applied, fixing the inlining in general, then this test fails without the second commit.