### PR TITLE
Don't allocate memory when sorting a list with a comparison

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs
+++ b/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs
@@ -997,8 +997,7 @@ namespace System.Collections.Generic {
             Contract.EndContractBlock();
 
             if( _size > 0) {
-                IComparer<T> comparer = new Array.FunctorComparer<T>(comparison);
-                Array.Sort(_items, 0, _size, comparer);
+                ArraySortHelper<T>.Sort(_items, 0, _size, comparison);
             }
         }
 

--- a/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs
+++ b/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs
@@ -997,7 +997,12 @@ namespace System.Collections.Generic {
             Contract.EndContractBlock();
 
             if( _size > 0) {
+#if MONO
                 ArraySortHelper<T>.Sort(_items, 0, _size, comparison);
+#else
+                IComparer<T> comparer = new Array.FunctorComparer<T>(comparison);
+                Array.Sort(_items, 0, _size, comparer);
+#endif
             }
         }
 


### PR DESCRIPTION
Our users noticed that sorting a list with the upgraded mono runtime would cause allocations. After investigating I've found that the new classlibs are allocating by creating an IComparer wrapper object around the Comparison. We could however instead call the array sort method that accepts a comparison object. In our downstream mono 5.0 branch I added an internal Sort function to the Array class and reference that function from list...upstream it would appear things have been refactored to use the corert Array libraries which includes refactoring the array sort functions into an ArraySortHelper class. Similar to my downstream changes we can call the ArraySortHelper function that accepts a comparision object instead of allocating.