### PR TITLE
[2017-08][eglib] (goutput.c) Revert Android logging host-target change

### DIFF
--- a/eglib/src/goutput.c
+++ b/eglib/src/goutput.c
@@ -137,7 +137,7 @@ g_assertion_message (const gchar *format, ...)
 	exit (0);
 }
 
-#if TARGET_ANDROID
+#if PLATFORM_ANDROID
 #include <android/log.h>
 
 static android_LogPriority


### PR DESCRIPTION
Revert part of 590473d01b3a3e11f87b9f2a8af3023926efca00 - the Android-specific
logging in eglib/goutput.c should be used when the host is Android, not the
target.