### PR TITLE
[eglib] (goutput.c) Revert Android logging host-target change

### DIFF
--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -137,7 +137,7 @@ g_assertion_message (const gchar *format, ...)
 	exit (0);
 }
 
-#if TARGET_ANDROID
+#if PLATFORM_ANDROID
 #include <android/log.h>
 
 static android_LogPriority


### PR DESCRIPTION
Revert part of 590473d01b3a3e11f87b9f2a8af3023926efca00 - the Android-specific
logging in eglib/goutput.c should be used when the host is Android, not the
target.

---- 

Cherrypick of #5340 to `master`