### PR TITLE
[jit] Don't emit a redundant move in lazy fetch trampolines on AMD64.

### DIFF
--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -710,8 +710,10 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 
 	g_free (rgctx_null_jumps);
 
-	/* move the rgctx pointer to the VTABLE register */
-	amd64_mov_reg_reg (code, MONO_ARCH_VTABLE_REG, AMD64_ARG_REG1, sizeof(gpointer));
+	if (MONO_ARCH_VTABLE_REG != AMD64_ARG_REG1) {
+		/* move the rgctx pointer to the VTABLE register */
+		amd64_mov_reg_reg (code, MONO_ARCH_VTABLE_REG, AMD64_ARG_REG1, sizeof(gpointer));
+	}
 
 	if (aot) {
 		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));


### PR DESCRIPTION
Hello,

This simple patch is meant to remove meaningless `movq   %rdi, %rdi` instructions generated in rgctx fetch trampolines.
For instance, jitting `csc.exe` would cause 37 such moves to appear.

A more general approach would be making `*_mov_reg_reg` skip on move construction if it sees the source and the destination are the same, but I'm cautious that some of the existing code may be somehow relying on the expectation that a dummy instruction will always be built. (it doesn't appear so, though)