### PR TITLE
[mono-symbolicate/mdoc] Don't fail tests in mcs mode

### DIFF
--- a/mcs/tools/mdoc/Makefile
+++ b/mcs/tools/mdoc/Makefile
@@ -55,6 +55,11 @@ DIFF = diff -rupZ
 DIFF_QUIET = diff --brief -Z
 endif
 
+ifdef MCS_MODE
+DIFF = echo "WARNING: running in mcs mode, tests are specific to roslyn and would fail. Skipping diff check."
+DIFF_QUIET = $(DIFF)
+endif
+
 dist-local: dist-default dist-tests
 
 dist-tests:

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -35,6 +35,10 @@ CHECK_DIFF = @\
 		exit 1; \
 	fi
 
+ifdef MCS_MODE
+CHECK_DIFF = @echo "WARNING: running in mcs mode, tests are specific to roslyn and would fail. Skipping diff check."
+endif
+
 PREPARE_OUTDIR = @\
 	rm -rf $(OUT_DIR); \
 	mkdir -p $(OUT_DIR); \


### PR DESCRIPTION
The checked in test files which the test suites in mono-symbolicate and mdoc verify their output against have a few roslyn-specific things in them and would fail when running in mcs mode.

While in theory we could check in both mcs- and roslyn-specific test files it seems not worth the effort and we should just skip the tests in mcs mode so we get greener builds on platforms where we still use mcs by default.