### PR TITLE
[docs] fixes to log profiler manpage

### DIFF
--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -183,9 +183,6 @@ and time, then do according to \f[I]OUTSPEC\f[]:
 If \f[I]OUTSPEC\f[] begins with a \f[I]|\f[] character, execute the
 rest as a program and feed the data to its standard input.
 .IP \[bu] 2
-if \f[I]OUTSPEC\f[] begins with a \f[I]-\f[] character, use the
-rest of OUTSPEC as the filename, but force overwrite any existing
-file by that name
 .IP \[bu] 2
 otherwise write the data the the named file: note that is a file by
 that name already exists, a warning is issued and profiling is

--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -185,8 +185,7 @@ rest as a program and feed the data to its standard input.
 .IP \[bu] 2
 .IP \[bu] 2
 otherwise write the data the the named file: note that is a file by
-that name already exists, a warning is issued and profiling is
-disabled.
+that name already exists, it is truncated.
 .RE
 .IP \[bu] 2
 \f[I]report\f[]: the profiling data is sent to mprof-report, which

--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -146,6 +146,9 @@ instruction pointer.
 This is equivalent to the value \[lq]100\[rq].
 A value of zero for \f[I]FREQ\f[] effectively disables sampling.
 .IP \[bu] 2
+\f[I]heapshot-on-shutdown\f[]: collect heap shot data when the runtime
+shuts down.
+.IP \[bu] 2
 \f[I]maxframes=NUM\f[]: when a stack trace needs to be performed,
 collect \f[I]NUM\f[] frames at the most.
 The default is 32.

--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -180,8 +180,8 @@ with the current process id and \f[I]%t\f[] with the current date
 and time, then do according to \f[I]OUTSPEC\f[]:
 .RS 2
 .IP \[bu] 2
-if \f[I]OUTSPEC\f[] begins with a \f[I]|\f[] character, execute the
-rest as a program and feed the data to its standard input
+If \f[I]OUTSPEC\f[] begins with a \f[I]|\f[] character, execute the
+rest as a program and feed the data to its standard input.
 .IP \[bu] 2
 if \f[I]OUTSPEC\f[] begins with a \f[I]-\f[] character, use the
 rest of OUTSPEC as the filename, but force overwrite any existing

--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -216,10 +216,6 @@ counters, which is normally done every 1 second.
 .IP \[bu] 2
 \f[I]coverage\f[]: collect code coverage data. This implies enabling
 the \f[I]calls\f[] option.
-.IP \[bu] 2
-\f[I]onlycoverage\f[]: can only be used with \f[I]coverage\f[]. This
-disables most other events so that the profiler mostly only collects
-coverage data.
 .RE
 .SS Analyzing the profile data
 .PP

--- a/man/mprof-report.1
+++ b/man/mprof-report.1
@@ -183,6 +183,9 @@ and time, then do according to \f[I]OUTSPEC\f[]:
 If \f[I]OUTSPEC\f[] begins with a \f[I]|\f[] character, execute the
 rest as a program and feed the data to its standard input.
 .IP \[bu] 2
+If \f[I]OUTSPEC\f[] begins with a \f[I]#\f[] character, parse the
+rest as a file descriptor number, and feed the data to this file
+descriptor.
 .IP \[bu] 2
 otherwise write the data the the named file: note that is a file by
 that name already exists, it is truncated.


### PR DESCRIPTION
Following are some fixes to the mprof-report manpage, regarding the documentation of the log profiler. They can probably be squashed into one commit, the split hopefully makes them easier to review.
Thanks
Uri