### PR TITLE
[mono-api-html] Allow `-r` to ignore class removals

### DIFF
--- a/mcs/tools/mono-api-html/ClassComparer.cs
+++ b/mcs/tools/mono-api-html/ClassComparer.cs
@@ -252,7 +252,12 @@ namespace Xamarin.ApiDiff {
 
 		public override void Removed (XElement source)
 		{
-			Output.Write ("<h3>Removed Type <span class='breaking' data-is-breaking>{0}.{1}</span></h3>", State.Namespace, GetTypeName (source));
+			string name = State.Namespace + "." + GetTypeName (source);
+
+			if (State.IgnoreRemoved.Any (re => re.IsMatch (name)))
+				return;
+
+			Output.Write ("<h3>Removed Type <span class='breaking' data-is-breaking>{0}</span></h3>", name);
 		}
 
 		public virtual string GetTypeName (XElement type)

--- a/mcs/tools/mono-api-html/NamespaceComparer.cs
+++ b/mcs/tools/mono-api-html/NamespaceComparer.cs
@@ -91,6 +91,10 @@ namespace Xamarin.ApiDiff {
 		public override void Removed (XElement source)
 		{
 			var name = source.Attribute ("name").Value;
+
+			if (State.IgnoreRemoved.Any (re => re.IsMatch (name)))
+				return;
+
 			Output.WriteLine ("<!-- start namespace {0} --> <div>", name);
 			Output.WriteLine ("<h2>Removed Namespace {0}</h2>", name);
 			Output.WriteLine ();


### PR DESCRIPTION
Allow `mono-api-html -r REGEX` to be used to silence messages
regarding class and namespace removals in addition to member removals.