### PR TITLE
[bcl] Fix compiling nunitlite when PARENT_PROFILE is defined

### DIFF
--- a/mcs/build/profiles/xbuild_12.make
+++ b/mcs/build/profiles/xbuild_12.make
@@ -4,8 +4,9 @@ include $(topdir)/build/profiles/net_4_x.make
 
 PLATFORMS:=
 
-PARENT_PROFILE = ../net_4_x$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))/
-DEFAULT_REFERENCES = -r:$(topdir)/class/lib/net_4_x$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))/mscorlib.dll
+PARENT_PROFILE_NAME = net_4_x$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))
+PARENT_PROFILE = ../$(PARENT_PROFILE_NAME)/
+DEFAULT_REFERENCES = -r:$(topdir)/class/lib/$(PARENT_PROFILE_NAME)/mscorlib.dll
 PROFILE_MCS_FLAGS += -d:XBUILD_12
 
 XBUILD_VERSION = 12.0

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -79,16 +79,14 @@ HAVE_CS_XTESTS := $(wildcard $(xtest_sourcefile))
 endif # !NO_TEST
 
 ifndef NO_TEST
-$(test_nunit_dep): $(topdir)/build/deps/nunit-$(PROFILE).stamp
-	@if test -f $@; then :; else rm -f $<; $(MAKE) $<; fi
+NUNITLITE_PROFILE=$(if $(PARENT_PROFILE_NAME),$(PARENT_PROFILE_NAME),$(PROFILE))
+$(test_nunit_dep): $(topdir)/build/deps/nunitlite-$(NUNITLITE_PROFILE).stamp
 
-$(topdir)/build/deps/nunit-$(PROFILE).stamp:
-ifndef PARENT_PROFILE
-	cd ${topdir}/tools/nunit-lite && $(MAKE)
-endif
+$(topdir)/build/deps/nunitlite-$(NUNITLITE_PROFILE).stamp:
+	cd ${topdir}/tools/nunit-lite && $(MAKE) PROFILE=$(NUNITLITE_PROFILE)
 	echo "stamp" >$@
 
-tests_CLEAN_FILES += $(topdir)/build/deps/nunit-$(PROFILE).stamp
+tests_CLEAN_FILES += $(topdir)/build/deps/nunitlite-$(NUNITLITE_PROFILE).stamp
 
 endif
 
@@ -122,15 +120,15 @@ LABELS_ARG = -labels
 endif
 
 ifdef ALWAYS_AOT
-test-local-aot-compile: $(topdir)/build/deps/nunit-$(PROFILE).stamp
+test-local-aot-compile: $(topdir)/build/deps/nunitlite-$(NUNITLITE_PROFILE).stamp
 	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(AOT_BUILD_FLAGS) $(test_assemblies)
 
 else
-test-local-aot-compile: $(topdir)/build/deps/nunit-$(PROFILE).stamp
+test-local-aot-compile: $(topdir)/build/deps/nunitlite-$(NUNITLITE_PROFILE).stamp
 
 endif # ALWAYS_AOT
 
-NUNITLITE_CONFIG_FILE=$(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)nunit-lite-console.exe.config
+NUNITLITE_CONFIG_FILE=$(topdir)/class/lib/$(NUNITLITE_PROFILE)/nunit-lite-console.exe.config
 
 patch-nunitlite-appconfig:
 	cp -f $(topdir)/tools/nunit-lite/nunit-lite-console/nunit-lite-console.exe.config.tmpl $(NUNITLITE_CONFIG_FILE)

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -5,7 +5,7 @@ if [[ ${label} == w* ]]
 then ${TESTCMD} --label=aot-test --skip;
 else ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot
 fi
-${TESTCMD} --label=compile-bcl-tests --timeout=40m make -i -w -C runtime -j4 test
+${TESTCMD} --label=compile-bcl-tests --timeout=40m make -w -C runtime -j4 test
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j4 tests
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1 CI_PR=${ghprbPullId}
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check


### PR DESCRIPTION
In this case we relied on nunitlite to be compiled when the parent
profile is compiled. That doesn't work however if we compile the
child profile first (e.g. during a parallel make) since it'll
complain about missing nunitlite.dll.

Instead we now have a proper dependency setup so even if we have a
child profile we'll still compile nunitlite for the parent profile.