### PR TITLE
Use eglib g_* allocators rather than malloc/calloc

### DIFF
--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -686,7 +686,7 @@ mono_set_config_dir (const char *dir)
 	/* If this environment variable is set, overrides the directory computed */
 	char *env_mono_cfg_dir = g_getenv ("MONO_CFG_DIR");
 	if (env_mono_cfg_dir == NULL && dir != NULL)
-		env_mono_cfg_dir = strdup (dir);
+		env_mono_cfg_dir = g_strdup (dir);
 
 	mono_cfg_dir = env_mono_cfg_dir;
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1158,7 +1158,7 @@ mono_method_get_imt_slot (MonoMethod *method)
 
 	sig = mono_method_signature (method);
 	hashes_count = sig->param_count + 4;
-	hashes_start = (guint32 *)malloc (hashes_count * sizeof (guint32));
+	hashes_start = (guint32 *)g_malloc (hashes_count * sizeof (guint32));
 	hashes = hashes_start;
 
 	if (! MONO_CLASS_IS_INTERFACE (method->klass)) {
@@ -1310,7 +1310,7 @@ imt_sort_slot_entries (MonoImtBuilderEntry *entries) {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
 	int number_of_entries = entries->children + 1;
-	MonoImtBuilderEntry **sorted_array = (MonoImtBuilderEntry **)malloc (sizeof (MonoImtBuilderEntry*) * number_of_entries);
+	MonoImtBuilderEntry **sorted_array = (MonoImtBuilderEntry **)g_malloc (sizeof (MonoImtBuilderEntry*) * number_of_entries);
 	GPtrArray *result = g_ptr_array_new ();
 	MonoImtBuilderEntry *current_entry;
 	int i;
@@ -1375,7 +1375,7 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, MonoDomain *domain, gpointer*
 	int i;
 	GSList *list_item;
 	guint32 imt_collisions_bitmap = 0;
-	MonoImtBuilderEntry **imt_builder = (MonoImtBuilderEntry **)calloc (MONO_IMT_SIZE, sizeof (MonoImtBuilderEntry*));
+	MonoImtBuilderEntry **imt_builder = (MonoImtBuilderEntry **)g_calloc (MONO_IMT_SIZE, sizeof (MonoImtBuilderEntry*));
 	int method_count = 0;
 	gboolean record_method_count_for_max_collisions = FALSE;
 	gboolean has_generic_virtual = FALSE, has_variant_iface = FALSE;


### PR DESCRIPTION
The mismatch between system allocators and eglib g_free causes problems if users override the allocation functions.