### PR TITLE
[2017-06][remoting] transparent proxy GetType of an interface should return the interface Type, not MarshalByRefObject. (Fixes #17325)

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.Remoting.Proxies/RealProxyTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Remoting.Proxies/RealProxyTest.cs
@@ -1,0 +1,76 @@
+//
+// MonoTests.System.Runtime.Remoting.Proxies.RealProxyTest.cs
+//
+//
+
+using System;
+using System.Runtime.Remoting.Messaging;
+using System.Runtime.Remoting.Proxies;
+using NUnit.Framework;
+
+namespace MonoTests.System.Runtime.Remoting.Proxies {
+	[TestFixture]
+	public class RealProxyTest {
+
+		public class ExampleInterfaceProxy : RealProxy {
+			public bool Called;
+
+			public ExampleInterfaceProxy () : base (typeof(IComparable))
+			{
+				Called = false;
+			}
+
+			public override IMessage Invoke (IMessage msg)
+			{
+				Called = true;
+				return new ReturnMessage (typeof(IComparable), null, 0, null, null);
+			}
+		}
+
+		[Test]
+		public void InterfaceProxyGetTypeOkay ()
+		{
+			// Regression test for #17325
+			// Check that GetType () for a proxy of an interface
+			// returns the interface.
+			var prox = new ExampleInterfaceProxy ();
+			var tprox = prox.GetTransparentProxy ();
+
+			Assert.IsNotNull (tprox, "#1");
+
+			var tproxType = tprox.GetType ();
+
+			Assert.IsFalse (prox.Called, "#2"); // this is true on .NET Framework, but false on Mono.
+
+			Assert.IsNotNull (tproxType, "#3");
+			Assert.IsTrue (tproxType.IsAssignableFrom (typeof(IComparable)), "#4");
+		}
+
+		[Test]
+		public void InterfaceProxyGetTypeViaReflectionOkay ()
+		{
+			// Regression test for #17325
+			// Check that GetType () for a proxy of an interface
+			// returns the interface.
+			//
+			// This versions calls GetType using reflection, which
+			// avoids the fast path in the JIT.
+			var prox = new ExampleInterfaceProxy ();
+			var tprox = prox.GetTransparentProxy ();
+
+			Assert.IsNotNull (tprox, "#1");
+
+
+			var m = typeof(object).GetMethod ("GetType");
+
+			var tproxType = m.Invoke (tprox, null);
+
+			Assert.IsTrue (prox.Called, "#2");
+
+			Assert.IsNotNull (tproxType, "#3");
+			Assert.IsTrue (tproxType is Type, "#4");
+			Assert.IsTrue ((tproxType as Type).IsAssignableFrom (typeof(IComparable)), "#5");
+		}
+
+	}
+}

--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -203,6 +203,7 @@ System.Runtime.Remoting.Channels/ChannelServicesTest.cs
 System.Runtime.Remoting.Contexts/SynchronizationAttributeTest.cs
 System.Runtime.Remoting.Messaging/CallContextTest.cs
 System.Runtime.Remoting.Metadata.W3cXsd2001/SoapHexBinaryTest.cs
+System.Runtime.Remoting.Proxies/RealProxyTest.cs
 System.Runtime.Serialization/FormatterServicesTests.cs
 System.Runtime.Serialization/ObjectIDGeneratorTests.cs
 System.Runtime.Serialization/SerializationBinderTest.cs

--- a/mcs/class/corlib/testing_aot_full_corlib_test.dll.exclude.sources
+++ b/mcs/class/corlib/testing_aot_full_corlib_test.dll.exclude.sources
@@ -39,6 +39,7 @@ System.Runtime.Remoting.Channels/ChannelServicesTest.cs
 System.Runtime.Remoting.Contexts/SynchronizationAttributeTest.cs
 System.Runtime.Remoting.Messaging/CallContextTest.cs
 System.Runtime.Remoting.Metadata.W3cXsd2001/SoapHexBinaryTest.cs
+System.Runtime.Remoting.Proxies/RealProxyTest.cs
 System.Security.AccessControl/AuthorizationRuleTest.cs
 System.Security.AccessControl/CommonAceTest.cs
 System.Security.AccessControl/CommonAclTest.cs

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1222,7 +1222,13 @@ ves_icall_System_Object_GetType (MonoObjectHandle obj, MonoError *error)
 	if (mono_class_is_transparent_proxy (klass)) {
 		MonoTransparentProxyHandle proxy_obj = MONO_HANDLE_CAST (MonoTransparentProxy, obj);
 		MonoRemoteClass *remote_class = MONO_HANDLE_GETVAL (proxy_obj, remote_class);
-		MonoType *proxy_type = &remote_class->proxy_class->byval_arg;
+		/* If it's a transparent proxy for an interface, return the
+		 * interface type, not the unhelpful proxy_class class (which
+		 * is just MarshalByRefObject). */
+		MonoType *proxy_type =
+			mono_remote_class_is_interface_proxy (remote_class) ?
+			&remote_class->interfaces[0]->byval_arg :
+			&remote_class->proxy_class->byval_arg;
 		return mono_type_get_object_handle (domain, proxy_type, error);
 	} else
 #endif

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1542,6 +1542,9 @@ ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n);
 MonoRemoteClass*
 mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *proxy_class, MonoError *error);
 
+gboolean
+mono_remote_class_is_interface_proxy (MonoRemoteClass *remote_class);
+
 MonoObject *
 mono_remoting_invoke (MonoObject *real_proxy, MonoMethodMessage *msg, MonoObject **exc, MonoArray **out_args, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2169,6 +2169,22 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 
 #ifndef DISABLE_REMOTING
 /**
+ * mono_remote_class_is_interface_proxy:
+ * \param remote_class
+ *
+ * Returns TRUE if the given remote class is a proxying an interface (as
+ * opposed to a class deriving from MarshalByRefObject).
+ */
+gboolean
+mono_remote_class_is_interface_proxy (MonoRemoteClass *remote_class)
+{
+	/* This if condition is taking advantage of how mono_remote_class ()
+	 * works: if that code changes, this needs to change too. */
+	return (remote_class->interface_count >= 1 &&
+		remote_class->proxy_class == mono_defaults.marshalbyrefobject_class);
+}
+
+/**
  * mono_class_proxy_vtable:
  * \param domain the application domain
  * \param remove_class the remote class
@@ -2261,6 +2277,18 @@ mono_class_proxy_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mono
 	pvt->klass = mono_defaults.transparent_proxy_class;
 	/* we need to keep the GC descriptor for a transparent proxy or we confuse the precise GC */
 	pvt->gc_descr = mono_defaults.transparent_proxy_class->gc_descr;
+
+	if (mono_remote_class_is_interface_proxy (remote_class)) {
+		/* If it's a transparent proxy for an interface, set the
+		 * MonoVTable:type to the interface type, not the placeholder
+		 * MarshalByRefObject class.  This is used when mini JITs calls
+		 * to Object.GetType ()
+		 */
+		MonoType *itf_proxy_type = &remote_class->interfaces[0]->byval_arg;
+		pvt->type = mono_type_get_object_checked (domain, itf_proxy_type, error);
+		if (!is_ok (error))
+			goto failure;
+	}
 
 	/* initialize vtable */
 	mono_class_setup_vtable (klass);
@@ -2529,6 +2557,12 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	key = mp_key;
 
 	if (mono_class_is_interface (proxy_class)) {
+		/* If we need to proxy an interface, we use this stylized
+		 * representation (interface_count >= 1, proxy_class is
+		 * MarshalByRefObject).  The code in
+		 * mono_remote_class_is_interface_proxy () depends on being
+		 * able to detect that we're doing this, so if this
+		 * representation changes, change GetType, too. */
 		rc = (MonoRemoteClass *)mono_domain_alloc (domain, MONO_SIZEOF_REMOTE_CLASS + sizeof(MonoClass*));
 		rc->interface_count = 1;
 		rc->interfaces [0] = proxy_class;


### PR DESCRIPTION
Cherrypick #5350 to `2017-06`

----

If a `RealProxy` instance is created (using the protected `RealProxy(Type)`
constructor) for an interface, mono internally sets up a `MonoRemoteClass` which
looks like a proxy for a `MarshalByRefObject` instance that happens to implement
the given interface.  However `mono_class_proxy_vtable` just does a `memcpy()` to
setup the `MonoVTable:type` field of the transparent proxy's vtable.  That type
field is hit by the JIT when `System.Object.GetType()` is called - and on .NET
Framework `GetType` for a transparent proxy of an interface returns the interface
not (as Mono used to) `typeof(MarshalByRefObject)`.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=17325