### PR TITLE
[System]: Fix minor leaks in AppleTls.

### DIFF
--- a/mcs/class/System/Mono.AppleTls/Trust.cs
+++ b/mcs/class/System/Mono.AppleTls/Trust.cs
@@ -66,6 +66,8 @@ namespace Mono.AppleTls {
 			foreach (var certificate in certificates)
 				array [i++] = new SecCertificate (certificate);
 			Initialize (array, policy);
+			for (i = 0; i < array.Length; i++)
+				array [i].Dispose ();
 		}
 
 		void Initialize (SecCertificate[] array, SecPolicy policy)
@@ -120,6 +122,17 @@ namespace Mono.AppleTls {
 
 				return new SecCertificate (SecTrustGetCertificateAtIndex (handle, index));
 			}
+		}
+
+		internal X509Certificate GetCertificate (int index)
+		{
+			if (handle == IntPtr.Zero)
+				throw new ObjectDisposedException ("SecTrust");
+			if (((long)index < 0) || ((long)index >= Count))
+				throw new ArgumentOutOfRangeException ("index");
+
+			var ptr = SecTrustGetCertificateAtIndex (handle, (IntPtr)index);
+			return new X509Certificate (ptr);
 		}
 
 		[DllImport (AppleTlsContext.SecurityLibrary)]


### PR DESCRIPTION
These should be automatically collected by the GC, but explicitly disposing
will keep memory usage more stable over time and keep pressure off the GC.