### PR TITLE
mkbundle: avoid NREs and print useful errors

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -1169,9 +1169,18 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			return true;
 		try {
 			Assembly a = universe.LoadFile (path);
+			if (a == null) {
+				Error ("Unable to to load assembly `{0}'", path);
+				return false;
+			}
 
 			foreach (AssemblyName an in a.GetReferencedAssemblies ()) {
 				a = LoadAssembly (an.Name);
+				if (a == null) {
+					Error ("Unable to load assembly `{0}' referenced by `{1}'", an.Name, path);
+					return false;
+				}
+
 				if (!QueueAssembly (files, a.CodeBase))
 					return false;
 			}


### PR DESCRIPTION
When scanning for references, emit an error when loading the assembly into the universe fails or when loading a referenced assembly by name fails.

Previously a very unhelpful NRE would be thrown.