### PR TITLE
[System]: Fix minor leaks in AppleTls. (#5369)

### DIFF
--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -235,32 +235,41 @@ namespace Mono.AppleTls
 			 * 
 			 */
 
-			var trust = GetPeerTrust (!IsServer);
-			X509CertificateCollection certificates;
-
-			if (trust == null || trust.Count == 0) {
-				remoteCertificate = null;
-				if (!IsServer)
-					throw new TlsException (AlertDescription.CertificateUnknown);
-				certificates = null;
-			} else {
-				if (trust.Count > 1)
-					Debug ("WARNING: Got multiple certificates in SecTrust!");
-
-				certificates = new X509CertificateCollection ();
-				for (int i = 0; i < trust.Count; i++)
-					certificates.Add (trust [(IntPtr)i].ToX509Certificate ());
-
-				remoteCertificate = certificates [0];
-				Debug ("Got peer trust: {0}", remoteCertificate);
-			}
-
 			bool ok;
+			SecTrust trust = null;
+			X509CertificateCollection certificates = null;
+
 			try {
+				trust = GetPeerTrust (!IsServer);
+
+				if (trust == null || trust.Count == 0) {
+					remoteCertificate = null;
+					if (!IsServer)
+						throw new TlsException (AlertDescription.CertificateUnknown);
+					certificates = null;
+				} else {
+					if (trust.Count > 1)
+						Debug ("WARNING: Got multiple certificates in SecTrust!");
+
+					certificates = new X509CertificateCollection ();
+					for (int i = 0; i < trust.Count; i++)
+						certificates.Add (trust.GetCertificate (i));
+
+					remoteCertificate = new X509Certificate (certificates [0]);
+					Debug ("Got peer trust: {0}", remoteCertificate);
+				}
+
 				ok = ValidateCertificate (certificates);
 			} catch (Exception ex) {
 				Debug ("Certificate validation failed: {0}", ex);
 				throw new TlsException (AlertDescription.CertificateUnknown, "Certificate validation threw exception.");
+			} finally {
+				if (trust != null)
+					trust.Dispose ();
+				if (certificates != null) {
+					for (int i = 0; i < certificates.Count; i++)
+						certificates [i].Dispose ();
+				}
 			}
 
 			if (!ok)

--- a/mcs/class/System/Mono.AppleTls/Trust.cs
+++ b/mcs/class/System/Mono.AppleTls/Trust.cs
@@ -66,6 +66,8 @@ namespace Mono.AppleTls {
 			foreach (var certificate in certificates)
 				array [i++] = new SecCertificate (certificate);
 			Initialize (array, policy);
+			for (i = 0; i < array.Length; i++)
+				array [i].Dispose ();
 		}
 
 		void Initialize (SecCertificate[] array, SecPolicy policy)
@@ -120,6 +122,17 @@ namespace Mono.AppleTls {
 
 				return new SecCertificate (SecTrustGetCertificateAtIndex (handle, index));
 			}
+		}
+
+		internal X509Certificate GetCertificate (int index)
+		{
+			if (handle == IntPtr.Zero)
+				throw new ObjectDisposedException ("SecTrust");
+			if (index < 0 || index >= Count)
+				throw new ArgumentOutOfRangeException ("index");
+
+			var ptr = SecTrustGetCertificateAtIndex (handle, (IntPtr)index);
+			return new X509Certificate (ptr);
 		}
 
 		[DllImport (AppleTlsContext.SecurityLibrary)]

--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -56,7 +56,6 @@ namespace System.Net
 		object socketLock = new object ();
 		IWebConnectionState state;
 		WebExceptionStatus status;
-		WaitCallback initConn;
 		bool keepAlive;
 		byte [] buffer;
 		static AsyncCallback readDoneDelegate = new AsyncCallback (ReadDone);

--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -56,6 +56,7 @@ namespace System.Net
 		object socketLock = new object ();
 		IWebConnectionState state;
 		WebExceptionStatus status;
+		WaitCallback initConn;
 		bool keepAlive;
 		byte [] buffer;
 		static AsyncCallback readDoneDelegate = new AsyncCallback (ReadDone);


### PR DESCRIPTION
These should be automatically collected by the GC, but explicitly disposing
will keep memory usage more stable over time and keep pressure off the GC.

(cherry picked from commit 093915cf834e7a3242529acae76d11d8a10c7c3d)
(cherry picked from commit 9b8bb0edbef4f3e3f8dda52965c42307caf0f888)