### PR TITLE
[SWF] Fix string drawing truncation in combo boxes

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
@@ -1564,8 +1564,8 @@ namespace System.Windows.Forms
 			Color back_color, fore_color;
 			Rectangle text_draw = e.Bounds;
 			StringFormat string_format = new StringFormat ();
-			string_format.FormatFlags = StringFormatFlags.LineLimit;
-			
+			string_format.FormatFlags = StringFormatFlags.LineLimit | StringFormatFlags.NoWrap;
+
 			if ((e.State & DrawItemState.Selected) == DrawItemState.Selected) {
 				back_color = ColorHighlight;
 				fore_color = ColorHighlightText;


### PR DESCRIPTION
This fixes Xamarin-10321. This change fixes the problem in SWF rather
than in libgdiplus which has the advantage that it works with both
Cairo and Pango renderers.

Without the additional NoWrap flag the text will wrap at a word boundary,
which results in the combo box showing lines with potentially a lot of
empty space at the end. With the NoWrap flag we render only one line,
displaying as many characters as possible in that one line.