### PR TITLE
[mempool] Apply Unlocked* () functions

### DIFF
--- a/mono/utils/unlocked.h
+++ b/mono/utils/unlocked.h
@@ -39,4 +39,25 @@ UnlockedIncrementSize (gsize *val)
 	return ++*val;
 }
 
+MONO_UNLOCKED_ATTRS
+gint64
+UnlockedAdd64 (gint64 *dest, gint64 add)
+{
+	return *dest += add;
+}
+
+MONO_UNLOCKED_ATTRS
+gint64
+UnlockedSubtract64 (gint64 *dest, gint64 sub)
+{
+	return *dest -= sub;
+}
+
+MONO_UNLOCKED_ATTRS
+gint64
+UnlockedRead64 (gint64 *src)
+{
+	return *src;
+}
+
 #endif /* _UNLOCKED_H_ */


### PR DESCRIPTION
Finally, I can make peace with the past <sup>(x)</sup> and close this chapter :)

<sup>(x)</sup> While working on https://github.com/mono/mono/pull/5191, I realised that `MONO_NO_SANITIZE_THREAD` was not precise enough for most use cases. The first try to fix this (https://github.com/mono/mono/pull/5255) was not right for `mempool.c`, however, https://github.com/mono/mono/pull/5310 finally brought an applicable solution.