### PR TITLE
[corlib] When parsing the ECMA key, don't produce a public key. Fixes #58637

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/AssemblyNameTest.cs
@@ -1862,6 +1862,26 @@ public class AssemblyNameTest {
 
 		Assert.AreEqual ("", an.CultureName);
 	}
+
+	[Test]
+	public void TestDecodingEcmaKey ()
+	{
+        var x = new AssemblyName( "System, PublicKey=00000000000000000400000000000000" );
+		Assert.IsNull (x.GetPublicKey (), "#1");
+		Assert.IsNotNull (x.GetPublicKeyToken (), "#2");
+
+		var t = x.GetPublicKeyToken ();
+		Assert.AreEqual (8, t.Length, "#3");
+
+		Assert.AreEqual (0xB7, t [0], "#4.0");
+		Assert.AreEqual (0x7A, t [1], "#4.1");
+		Assert.AreEqual (0x5C, t [2], "#4.2");
+		Assert.AreEqual (0x56, t [3], "#4.3");
+		Assert.AreEqual (0x19, t [4], "#4.4");
+		Assert.AreEqual (0x34, t [5], "#4.5");
+		Assert.AreEqual (0xE0, t [6], "#4.6");
+		Assert.AreEqual (0x89, t [7], "#4.7");
+	}
 }
 
 }

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2372,17 +2372,18 @@ parse_public_key (const gchar *key, gchar** pubkey, gboolean *is_ecma)
 	const gchar *pkey;
 	gchar header [16], val, *arr, *endp;
 	gint i, j, offset, bitlen, keylen, pkeylen;
-	
+
+	//both pubkey and is_ecma are required arguments
+	g_assert (pubkey && is_ecma);
+
 	keylen = strlen (key) >> 1;
 	if (keylen < 1)
 		return FALSE;
 
 	/* allow the ECMA standard key */
 	if (strcmp (key, "00000000000000000400000000000000") == 0) {
-		if (pubkey) {
-			*pubkey = g_strdup (key);
-			*is_ecma = TRUE;
-		}
+		*pubkey = g_strdup (key);
+		*is_ecma = TRUE;
 		return TRUE;
 	}
 	*is_ecma = FALSE;
@@ -2427,10 +2428,6 @@ parse_public_key (const gchar *key, gchar** pubkey, gboolean *is_ecma)
 	bitlen = read32 (header + 12) >> 3;
 	if ((bitlen + 16 + 4) != pkeylen)
 		return FALSE;
-
-	/* parsing is OK and the public key itself is not requested back */
-	if (!pubkey)
-		return TRUE;
 		
 	arr = (gchar *)g_malloc (keylen + 4);
 	/* Encode the size of the blob */
@@ -2509,10 +2506,8 @@ build_assembly_name (const char *name, const char *version, const char *culture,
 		}
 
 		if (is_ecma) {
-			if (save_public_key)
-				aname->public_key = (guint8*)pkey;
-			else
-				g_free (pkey);
+			aname->public_key = NULL;
+			g_free (pkey);
 			g_strlcpy ((gchar*)aname->public_key_token, "b77a5c561934e089", MONO_PUBLIC_KEY_TOKEN_LENGTH);
 			return TRUE;
 		}

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2382,7 +2382,7 @@ parse_public_key (const gchar *key, gchar** pubkey, gboolean *is_ecma)
 
 	/* allow the ECMA standard key */
 	if (strcmp (key, "00000000000000000400000000000000") == 0) {
-		*pubkey = g_strdup (key);
+		*pubkey = NULL;
 		*is_ecma = TRUE;
 		return TRUE;
 	}
@@ -2450,7 +2450,7 @@ build_assembly_name (const char *name, const char *version, const char *culture,
 	gint major, minor, build, revision;
 	gint len;
 	gint version_parts;
-	gchar *pkey, *pkeyptr, *encoded, tok [8];
+	gchar *pkeyptr, *encoded, tok [8];
 
 	memset (aname, 0, sizeof (MonoAssemblyName));
 
@@ -2499,15 +2499,16 @@ build_assembly_name (const char *name, const char *version, const char *culture,
 	}
 
 	if (key) {
-		gboolean is_ecma;
+		gboolean is_ecma = FALSE;
+		gchar *pkey = NULL;
 		if (strcmp (key, "null") == 0 || !parse_public_key (key, &pkey, &is_ecma)) {
 			mono_assembly_name_free (aname);
 			return FALSE;
 		}
 
 		if (is_ecma) {
+			g_assert (pkey == NULL);
 			aname->public_key = NULL;
-			g_free (pkey);
 			g_strlcpy ((gchar*)aname->public_key_token, "b77a5c561934e089", MONO_PUBLIC_KEY_TOKEN_LENGTH);
 			return TRUE;
 		}


### PR DESCRIPTION
The key was incorrectly encoded and triggered heap corruption.