### PR TITLE
[2017-08][threads] Use designated initializer syntax in MAKE_SPECIAL_STATIC_OFFSET

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -462,8 +462,8 @@ typedef union {
 #define SPECIAL_STATIC_OFFSET_TYPE_THREAD 0
 #define SPECIAL_STATIC_OFFSET_TYPE_CONTEXT 1
 
-#define MAKE_SPECIAL_STATIC_OFFSET(index, offset, type) \
-	((SpecialStaticOffset) { .fields = { (index), (offset), (type) } }.raw)
+#define MAKE_SPECIAL_STATIC_OFFSET(idx, off, ty) \
+	((SpecialStaticOffset) { .fields = { .index = (idx), .offset = (off), .type = (ty) } }.raw)
 #define ACCESS_SPECIAL_STATIC_OFFSET(x,f) \
 	(((SpecialStaticOffset *) &(x))->fields.f)
 


### PR DESCRIPTION
Cherrypick #5398 to `2017-08`

----


Originally we used a C90-style struct initializer `{ (index), (offset), (type)
}`.  Unfortunately, SpecialStaticOffset is defined with fields in a different
order on big-endian and little-endian machines.  Using a designated
initializer, we don't have to care about the order.