### PR TITLE
Remove lingering bits from removed prj2make tool

### DIFF
--- a/docs/mono-tools.config
+++ b/docs/mono-tools.config
@@ -37,7 +37,6 @@
   <manpage name="mono-xmltool(1)"       page="../man/mono-xmltool.1" />
   <manpage name="mozroots(1)"           page="../man/mozroots.1" />
   <manpage name="permview(1)"           page="../man/permview.1" />
-  <manpage name="prj2make(1)"           page="../man/prj2make.1" />
   <manpage name="resgen(1)"             page="../man/resgen.1" />
   <manpage name="secutil(1)"            page="../man/secutil.1" />
   <manpage name="setreg(1)"             page="../man/setreg.1" />

--- a/packaging/MacSDK/packaging/resources/whitelist.txt
+++ b/packaging/MacSDK/packaging/resources/whitelist.txt
@@ -109,7 +109,6 @@ pdb2mdb
 pedump
 permview
 peverify
-prj2make
 resgen
 resgen2
 secutil

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -72,7 +72,6 @@ scripts_4_0 = \
 	macpack$(SCRIPT_SUFFIX)			\
 	mdoc$(SCRIPT_SUFFIX)                    \
 	mono-cil-strip$(SCRIPT_SUFFIX)		\
-	prj2make$(SCRIPT_SUFFIX)		\
 	soapsuds$(SCRIPT_SUFFIX)		\
 	caspol$(SCRIPT_SUFFIX)			\
 	cert-sync$(SCRIPT_SUFFIX)		\


### PR DESCRIPTION
Closes https://bugzilla.xamarin.com/show_bug.cgi?id=13410

We had already removed the prj2make tool, we just did not remove the script that called it, the docs or the manifest.