### PR TITLE
Bump timeout for TaskTests.Delay_Simple

### DIFF
--- a/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/TaskTest.cs
@@ -1258,7 +1258,7 @@ namespace MonoTests.System.Threading.Tasks
 		{
 			var t = Task.Delay (300);
 			Assert.IsTrue (TaskStatus.WaitingForActivation == t.Status || TaskStatus.Running == t.Status, "#1");
-			Assert.IsTrue (t.Wait (400), "#2");
+			Assert.IsTrue (t.Wait (1200), "#2");
 		}
 
 		[Test]


### PR DESCRIPTION
Should be reverted once https://bugzilla.xamarin.com/show_bug.cgi?id=58877 is investigated and fixed.