### PR TITLE
Fix method-access.exe test

### DIFF
--- a/mono/tests/method-access.il
+++ b/mono/tests/method-access.il
@@ -50,7 +50,7 @@
 			br fail
 		} catch [mscorlib]System.MethodAccessException {
 		  	call instance string [mscorlib]System.MethodAccessException::get_Message ()
-			ldstr "Method `MethFail:sfoo ()' is inaccessible from method `Test:call_sfoo ()'"
+			ldstr "Method `MethFail.sfoo()' is inaccessible from method `Test.call_sfoo()'"
 			call instance bool [mscorlib]System.String::Equals (string)
 			brfalse fail
 			br continue


### PR DESCRIPTION
The exception message of a MethodAccessException was changed in 7b8811573784a244de3ce559ad4512e913ab31aa.
This caused the method-access.exe test to fail since it checked for the old format.