### PR TITLE
enable some tests for System.Text.UnicodeEncoding

### DIFF
--- a/mcs/class/corlib/Test/System.Text/UnicodeEncodingTest.cs
+++ b/mcs/class/corlib/Test/System.Text/UnicodeEncodingTest.cs
@@ -219,7 +219,6 @@ namespace MonoTests.System.Text
 		}
 
 		[Test]
-		[Category ("NotWorking")]
 		public void GetString_Odd_Count_0 ()
 		{
 			byte [] array = new byte [3];
@@ -231,7 +230,6 @@ namespace MonoTests.System.Text
 		}
 
 		[Test]
-		[Category ("NotWorking")]
 		public void GetString_Odd_Count_ff ()
 		{
 			byte [] array = new byte [3] { 0xff, 0xff, 0xff };


### PR DESCRIPTION
Remove attribute Category ("NotWorking") from tests GetString_Odd_Count_0
and GetString_Odd_Count_ff as they are working now (after the switch to referencesource).