### PR TITLE
[Syndication]Fix Runtime crash when parsing pubTime in RFC822 format

### DIFF
--- a/mcs/class/System.ServiceModel.Web/System.ServiceModel.Syndication/Rss20ItemFormatter.cs
+++ b/mcs/class/System.ServiceModel.Web/System.ServiceModel.Syndication/Rss20ItemFormatter.cs
@@ -649,6 +649,7 @@ namespace System.ServiceModel.Syndication
 
 		string [] rfc822formats = new string [] {
 			"ddd, dd MMM yyyy HH:mm:ss 'Z'",
+			"ddd, dd MMM yyyy HH:mm:ss 'GMT'",
 			"ddd, dd MMM yyyy HH:mm:ss zzz",
 			"ddd, dd MMM yyyy HH:mm:ss"};
 


### PR DESCRIPTION
It will cause runtime crash when reading a RSS2.0 Feed,which store pubDate with "ddd, dd MMM yyyy HH:mm:ss 'GMT'"(equivalent to "ddd, dd MMM yyyy HH:mm:ss 'Z'")  format.