### PR TITLE
[runtime] Fix regression in bugfix 38666

### DIFF
--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -114,7 +114,7 @@ get_boot_time (void)
 	if (uptime) {
 		double upt;
 		if (fscanf (uptime, "%lf", &upt) == 1) {
-			gint64 now = mono_100ns_datetime ();
+			gint64 now = mono_100ns_ticks ();
 			fclose (uptime);
 			return now - (gint64)(upt * MTICKS_PER_SEC);
 		}
@@ -133,7 +133,7 @@ mono_msec_boottime (void)
 	gint64 now;
 	if (!boot_time)
 		boot_time = get_boot_time ();
-	now = mono_100ns_datetime ();
+	now = mono_100ns_ticks ();
 	/*printf ("now: %llu (boot: %llu) ticks: %llu\n", (gint64)now, (gint64)boot_time, (gint64)(now - boot_time));*/
 	return (now - boot_time)/10000;
 }


### PR DESCRIPTION
When fixing bug 38666 in commit https://github.com/mono/mono/commit/71d181c3b39b754ca6b6849a0d7dfa30c9b22cf4 mono_100ns_ticks() was changed to mono_100ns_datetime().
This causes System.Threading.Tasks to timeout (too) early if the system time is changed when a task is running. Also related to comments in https://github.com/mono/mono/pull/4446.