### PR TITLE
[Mono.Security] Bugfix of bug 23153

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Protocol.Tls.Handshake.Client/TlsClientCertificate.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Protocol.Tls.Handshake.Client/TlsClientCertificate.cs
@@ -137,7 +137,7 @@ namespace Mono.Security.Protocol.Tls.Handshake.Client
 				return null;
 
 			foreach (X509Certificate certificate in this.Context.ClientSettings.Certificates) {
-				if (cert.GetName () == cert.GetIssuerName ())
+				if (certificate.GetName () == cert.GetIssuerName ())
 					return certificate;
 			}
 			return null;


### PR DESCRIPTION
There is an obvious bug in the FindParentCertificate method of the TlsClientCertificate class. The current client certificates are enumerated, but the provided input certificate is used in the equation instead of the current indexed client certificate.