### PR TITLE
[System.Net.Http]: Close request stream when HttpClientHandler.SendAs…

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -375,8 +375,9 @@ namespace System.Net.Http
 
 						wrequest.ResendContentFactory = content.CopyTo;
 
-						var stream = await wrequest.GetRequestStreamAsync ().ConfigureAwait (false);
-						await request.Content.CopyToAsync (stream).ConfigureAwait (false);
+						using (var stream = await wrequest.GetRequestStreamAsync ().ConfigureAwait (false)) {
+							await request.Content.CopyToAsync (stream).ConfigureAwait (false);
+						}
 					} else if (HttpMethod.Post.Equals (request.Method) || HttpMethod.Put.Equals (request.Method) || HttpMethod.Delete.Equals (request.Method)) {
 						// Explicitly set this to make sure we're sending a "Content-Length: 0" header.
 						// This fixes the issue that's been reported on the forums:


### PR DESCRIPTION
…ync() is done writing data. (#5226) (#5231)

(cherry picked from commit d1555c7c72e280bcdc1b61ea42266042107dc749)