### PR TITLE
[runtime] Disable a test which asserts because of an abi break in rec…

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -676,11 +676,6 @@ PLATFORM_DISABLED_TESTS += async-exc-compilation.exe finally_guard.exe finally_b
 	unhandled-exception-5.exe unhandled-exception-6.exe unhandled-exception-7.exe unhandled-exception-8.exe
 endif
 
-if HOST_DARWIN
-# TODO: remove once https://bugzilla.xamarin.com/show_bug.cgi?id=58901 is fixed
-PLATFORM_DISABLED_TESTS += pinvoke2.exe
-endif
-
 endif
 
 if POWERPC

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -1356,7 +1356,10 @@ mono_test_return_empty_struct (int a)
 
 	memset (&s, 0, sizeof (s));
 
+#if !(defined(__i386__) && defined(__clang__))
+	/* https://bugzilla.xamarin.com/show_bug.cgi?id=58901 */
 	g_assert (a == 42);
+#endif
 
 	return s;
 }


### PR DESCRIPTION
…ent xcode/clang versions. Works around #58901.