### PR TITLE
Added compile target option as library in remarked documentation. No source change

### DIFF
--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -32,8 +32,8 @@
 //
 
 // Compile With:
-//   mcs -debug+ -r:System.Core Options.cs -o:Mono.Options.dll
-//   mcs -debug+ -d:LINQ -r:System.Core Options.cs -o:Mono.Options.dll
+//   mcs -debug+ -r:System.Core Options.cs -o:Mono.Options.dll -t:library
+//   mcs -debug+ -d:LINQ -r:System.Core Options.cs -o:Mono.Options.dll -t:library
 //
 // The LINQ version just changes the implementation of
 // OptionSet.Parse(IEnumerable<string>), and confers no semantic changes.


### PR DESCRIPTION
Added -t:library since mcd does not interpret output filename for dll suffix.
Without -t:library option, it fails to compile.

```
mono$ mcs -debug+ -r:System.Core Options.cs -o:Mono.Options.dll
error CS5001: Program `Options.exe' does not contain a static `Main' method suitable for an entry point
Compilation failed: 1 error(s), 0 warnings
```