### PR TITLE
Minor fixes / cleanups to tracing code

### DIFF
--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -338,8 +338,6 @@ mono_trace_parse_options (const char *options)
 	while ((token = (get_spec (&last_used))) != TOKEN_END){
 		if (token == TOKEN_ERROR)
 			return NULL;
-		if (token == TOKEN_SEPARATOR)
-			continue;
 	}
 	trace_spec.len = last_used;
 	cleanup ();

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -254,20 +254,23 @@ static int
 get_spec (int *last)
 {
 	int token = get_token ();
+	gboolean exclude = FALSE;
 	if (token == TOKEN_EXCLUDE){
-		token = get_spec (last);
-		if (token == TOKEN_EXCLUDE){
+		exclude = TRUE;
+		token = get_token ();
+		if (token == TOKEN_EXCLUDE || token == TOKEN_DISABLED) {
 			fprintf (stderr, "Expecting an expression");
 			return TOKEN_ERROR;
 		}
-		if (token == TOKEN_ERROR)
-			return token;
-		trace_spec.ops [(*last)-1].exclude = 1;
-		return TOKEN_SEPARATOR;
 	}
 	if (token == TOKEN_END || token == TOKEN_SEPARATOR || token == TOKEN_ERROR)
 		return token;
-	
+
+	if (token == TOKEN_DISABLED) {
+		trace_spec.enabled = FALSE;
+		return token;
+	}
+
 	if (token == TOKEN_METHOD){
 		MonoMethodDesc *desc = mono_method_desc_new (value, TRUE);
 		if (desc == NULL){
@@ -300,12 +303,14 @@ get_spec (int *last)
 	} else if (token == TOKEN_STRING){
 		trace_spec.ops [*last].op = MONO_TRACEOP_ASSEMBLY;
 		trace_spec.ops [*last].data = g_strdup (value);
-	} else if (token == TOKEN_DISABLED) {
-		trace_spec.enabled = FALSE;
 	} else {
 		fprintf (stderr, "Syntax error in trace option specification\n");
 		return TOKEN_ERROR;
 	}
+
+	if (exclude)
+		trace_spec.ops[*last].exclude = 1;
+
 	(*last)++;
 	return TOKEN_SEPARATOR;
 }


### PR DESCRIPTION
- Avoid creating an empty trace spec when encountering "disabled" as a trace spec
- Improve error handling around double "-"
- Remove code that has no effect - "continue" next to end of loop