### PR TITLE
[libtest] Complete the function prototype

### DIFF
--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7488,7 +7488,7 @@ mono_test_marshal_pointer_array (int *arr[])
 
 #ifndef WIN32
 
-typedef void (*NativeToManagedExceptionRethrowFunc) ();
+typedef void (*NativeToManagedExceptionRethrowFunc) (void);
 
 void *mono_test_native_to_managed_exception_rethrow_thread (void *arg)
 {


### PR DESCRIPTION
Found this info from Clang and I think there is a quick solution: `libtest.c:7491:53: warning: this function declaration is not a prototype [-Wstrict-prototypes]`.