### PR TITLE
[System]: Cleanup debugging and use the same technique from the new web stack.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/AsyncProtocolRequest.cs
+++ b/mcs/class/System/Mono.Net.Security/AsyncProtocolRequest.cs
@@ -158,7 +158,7 @@ namespace Mono.Net.Security
 			RunSynchronously = sync;
 		}
 
-		[SD.Conditional ("MARTIN_DEBUG")]
+		[SD.Conditional ("MONO_TLS_DEBUG")]
 		protected void Debug (string message, params object[] args)
 		{
 			Parent.Debug ("{0}({1}:{2}): {3}", Name, Parent.ID, ID, string.Format (message, args));
@@ -226,6 +226,7 @@ namespace Mono.Net.Security
 
 				if (Interlocked.Exchange (ref WriteRequested, 0) != 0) {
 					// Flush the write queue.
+					Debug ("ProcessOperation - flushing write queue");
 					await Parent.InnerWrite (RunSynchronously, cancellationToken);
 				}
 

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -384,10 +384,10 @@ namespace Mono.Net.Security
 		static int nextId;
 		internal readonly int ID = ++nextId;
 
-		[SD.Conditional ("MARTIN_DEBUG")]
+		[SD.Conditional ("MONO_TLS_DEBUG")]
 		protected internal void Debug (string message, params object[] args)
 		{
-			Console.Error.WriteLine ("MobileAuthenticatedStream({0}): {1}", ID, string.Format (message, args));
+			MonoTlsProviderFactory.Debug ("MobileAuthenticatedStream({0}): {1}", ID, string.Format (message, args));
 		}
 
 #region Called back from native code via SslConnection

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -78,10 +78,10 @@ namespace Mono.Net.Security
 			get { return parent.Provider; }
 		}
 
-		[SD.Conditional ("MARTIN_DEBUG")]
+		[SD.Conditional ("MONO_TLS_DEBUG")]
 		protected void Debug (string message, params object[] args)
 		{
-			Console.Error.WriteLine ("{0}: {1}", GetType ().Name, string.Format (message, args));
+			parent.Debug ("{0}: {1}", GetType ().Name, string.Format (message, args));
 		}
 
 		public abstract bool HasContext {

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -38,6 +38,7 @@ using System.Security.Cryptography.X509Certificates;
 
 using System;
 using System.Net;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -192,6 +193,25 @@ namespace Mono.Net.Security
 			}
 		}
 
+#if MONO_TLS_DEBUG
+		static bool enableDebug;
+
+		static void InitializeDebug ()
+		{
+			if (Environment.GetEnvironmentVariable ("MONO_TLS_DEBUG") != null)
+				enableDebug = true;
+		}
+#endif
+
+		[Conditional ("MONO_TLS_DEBUG")]
+		internal static void Debug (string message, params object[] args)
+		{
+#if MONO_TLS_DEBUG
+			if (enableDebug)
+				Console.Error.WriteLine (message, args);
+#endif
+		}
+
 #endregion
 
 		internal static readonly Guid AppleTlsId = new Guid ("981af8af-a3a3-419a-9f01-a518e3a17c1c");
@@ -203,6 +223,11 @@ namespace Mono.Net.Security
 			lock (locker) {
 				if (providerRegistration != null)
 					return;
+
+#if MONO_TLS_DEBUG
+				InitializeDebug ();
+#endif
+
 				providerRegistration = new Dictionary<string,Tuple<Guid,string>> ();
 				providerCache = new Dictionary<Guid,MSI.MonoTlsProvider> ();
 

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -193,23 +193,20 @@ namespace Mono.Net.Security
 			}
 		}
 
-#if MONO_TLS_DEBUG
 		static bool enableDebug;
 
+		[Conditional ("MONO_TLS_DEBUG")]
 		static void InitializeDebug ()
 		{
 			if (Environment.GetEnvironmentVariable ("MONO_TLS_DEBUG") != null)
 				enableDebug = true;
 		}
-#endif
 
 		[Conditional ("MONO_TLS_DEBUG")]
 		internal static void Debug (string message, params object[] args)
 		{
-#if MONO_TLS_DEBUG
 			if (enableDebug)
 				Console.Error.WriteLine (message, args);
-#endif
 		}
 
 #endregion
@@ -224,9 +221,7 @@ namespace Mono.Net.Security
 				if (providerRegistration != null)
 					return;
 
-#if MONO_TLS_DEBUG
 				InitializeDebug ();
-#endif
 
 				providerRegistration = new Dictionary<string,Tuple<Guid,string>> ();
 				providerCache = new Dictionary<Guid,MSI.MonoTlsProvider> ();


### PR DESCRIPTION
* The MARTIN_DEBUG conditional has been renamed into MONO_TLS_DEBUG.

* Moved the actual implementation into MNS.MonoTlsProviderFactory.

* We now use an environment variable called 'MONO_TLS_DEBUG' to
  enable debugging (so to get debugging, you need to both compile with
  -define:MONO_TLS_DEBUG and set that environment variable).

The new web stack has a conditional and environment variable called
'MARTIN_WEB_DEBUG'.