### PR TITLE
[System] Disable SocketTest.SendAsyncFile for now

### DIFF
--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -4551,6 +4551,7 @@ namespace MonoTests.System.Net.Sockets
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
+		[Ignore ("https://bugzilla.xamarin.com/show_bug.cgi?id=43172")]
 		public void SendAsyncFile ()
 		{
 			Socket serverSocket = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
It's one of the flaky tests that we have had for a very long time.

There's work in progress fixing it as part of https://github.com/mono/mono/pull/5345 and https://bugzilla.xamarin.com/show_bug.cgi?id=43172 but I think we should disable it in the meantime for clean CI.