### PR TITLE
[configure.ac] Don't include the .build number in runtime-corlib version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
 MONO_CORLIB_COUNTER=0
-MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR $MONO_VERSION_BUILD $MONO_CORLIB_COUNTER`
+MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])
 AC_SUBST(MONO_CORLIB_VERSION)


### PR DESCRIPTION
It's causing unnecessary complexity because we need to create a new monolite when bumping the .build number in a major.minor.build version like from 5.2.0 -> 5.2.1

corlib version bumps are very rare in those cases and even then you can just increment the MONO_CORLIB_COUNTER variable.