### PR TITLE
Fixing another confusing typo

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -659,7 +659,7 @@ class MakeBundle {
 			Console.WriteLine ("     Assembly: " + fname);
 			if (File.Exists (fname + ".config")){
 				maker.Add ("config:" + aname, fname + ".config");
-				Console.WriteLine ("       Config: " + runtime);
+				Console.WriteLine ("       Config: " + fname + ".config");
 			}
 		}
 		


### PR DESCRIPTION
The file being added is the config of the last assembly read, not the runtime name.