### PR TITLE
remove redundant duplicate word 'not'

### DIFF
--- a/support/supportw.c
+++ b/support/supportw.c
@@ -52,7 +52,7 @@ get_function (const char *name)
 			compare_names);
 
 	if (ptr == NULL) {
-		g_warning ("Function '%s' not not found.", name);
+		g_warning ("Function '%s' not found.", name);
 		return NULL;
 	}
 


### PR DESCRIPTION
Found a consecutive 'not' pair while searching the code for somethng else.