### PR TITLE
More informative g_error message

### DIFF
--- a/mono/eglib/gfile-unix.c
+++ b/mono/eglib/gfile-unix.c
@@ -87,6 +87,6 @@ g_mkdtemp (char *tmp_template)
 
 	return mkdtemp (template_copy);
 #else
-	g_error("Function not supported");
+	g_error("Function mkdtemp not supported");
 #endif
 }


### PR DESCRIPTION
Encountered this message while running the new mkbundle simple-cross functionality introduced recently. "Function not supported" is seen on both Mac OS X and Ubuntu. Will possibly file a separate bug since HAVE_MKDTEMP should be true... but it should be "Function mkdtemp not supported" in any case.