### PR TITLE
Add retrying of failed tests by default to reduce flaky tests

### DIFF
--- a/mcs/tools/nunit-lite/NUnitLite/nunitlite.dll.sources
+++ b/mcs/tools/nunit-lite/NUnitLite/nunitlite.dll.sources
@@ -184,6 +184,7 @@
 ../../../../external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/CommandStage.cs
 ../../../../external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/DelegatingTestCommand.cs
 ../../../../external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/ExpectedExceptionCommand.cs
+../../../../external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/FlakyTestRetriesCommand.cs
 ../../../../external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/ICommandDecorator.cs
 ../../../../external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/MaxTimeCommand.cs
 ../../../../external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/OneTimeSetUpCommand.cs


### PR DESCRIPTION
Whenever a test fails we retry it five times and then decide the overall result based on that. If three or more of the five retries fail too then the overall result is FAIL, two or lower means PASS.

We're modifying nunitlite here so this only works for those tests right now, we'd need to add it to the other test runners too.