### PR TITLE
[coop] mono_threads_detach_coop shouldn't restore domain to NULL.

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5190,9 +5190,11 @@ mono_threads_detach_coop (gpointer cookie, gpointer *dummy)
 	}
 
 	if (orig != domain) {
-		if (!orig)
-			mono_domain_unset ();
-		else
+		/* Match what the JIT does for CEE_MONO_JIT_DETACH via
+		 * mono_jit_set_domain(): only restore the domain if it was
+		 * originally non-NULL.
+		 */
+		if (orig)
 			mono_domain_set (orig, TRUE);
 	}
 }


### PR DESCRIPTION
Match the behavior of what the JIT does for CEE_MONO_JIT_DETACH via
mono_jit_set_domain(): only restore the domain if it was originally non-NULL.

Fixes bug-58782-plain-throw.cs and bug-58782-capture-and-throw.cs (introduced by 7c9f9853d45fda0b135ad7cffc469b8587bd8916) under coop.
