### PR TITLE
[Mono.Security]: Add 'MonoTlsProvider.SupportsCleanShutdown' and 'MonoTlsSettings.SendCloseNotify'.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProvider.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProvider.cs
@@ -163,5 +163,14 @@ namespace Mono.Security.Interface
 			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
 			ref MonoSslPolicyErrors errors, ref int status11);
 #endregion
+
+#region Misc
+
+		internal abstract bool SupportsCleanShutdown {
+			get;
+		}
+
+#endregion
+
 	}
 }

--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
@@ -87,6 +87,13 @@ namespace Mono.Security.Interface
 		}
 
 		/*
+		 * This is only supported if MonoTlsProvider.SupportsCleanShutdown is true.
+		 */
+		internal bool SendCloseNotify {
+			get; set;
+		}
+
+		/*
 		 * If you set this here, then it will override 'ServicePointManager.SecurityProtocol'.
 		 */
 		public TlsProtocols? EnabledProtocols {
@@ -173,6 +180,7 @@ namespace Mono.Security.Interface
 			EnabledProtocols = other.EnabledProtocols;
 			EnabledCiphers = other.EnabledCiphers;
 			CertificateValidationTime = other.CertificateValidationTime;
+			SendCloseNotify = other.SendCloseNotify;
 			if (other.TrustAnchors != null)
 				TrustAnchors = new X509CertificateCollection (other.TrustAnchors);
 			if (other.CertificateSearchPaths != null) {

--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -848,24 +848,7 @@ namespace Mono.AppleTls
 
 		public override void Shutdown ()
 		{
-			if (Interlocked.Exchange (ref pendingIO, 1) == 1)
-				throw new InvalidOperationException ();
-
-			Debug ("Shutdown");
-
-			lastException = null;
-
-			try {
-				if (closed || disposed)
-					return;
-
-				var status = SSLClose (Handle);
-				Debug ("Shutdown done: {0}", status);
-				CheckStatusAndThrow (status);
-			} finally {
-				closed = true;
-				pendingIO = 0;
-			}
+			closed = true;
 		}
 
 		#endregion

--- a/mcs/class/System/Mono.AppleTls/AppleTlsProvider.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsProvider.cs
@@ -65,6 +65,10 @@ namespace Mono.AppleTls
 			get { return true; }
 		}
 
+		internal override bool SupportsCleanShutdown {
+			get { return false; }
+		}
+
 		public override SslProtocols SupportedProtocols {
 			get { return SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls; }
 		}

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -357,7 +357,8 @@ namespace Mono.Btls
 		public override void Shutdown ()
 		{
 			Debug ("Shutdown!");
-//			ssl.SetQuietShutdown ();
+			if (Settings == null || !Settings.SendCloseNotify)
+				ssl.SetQuietShutdown ();
 			ssl.Shutdown ();
 		}
 

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -75,6 +75,10 @@ namespace Mono.Btls
 			get { return true; }
 		}
 
+		internal override bool SupportsCleanShutdown {
+			get { return true; }
+		}
+
 		public override SslProtocols SupportedProtocols {
 			get { return SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls; }
 		}

--- a/mcs/class/System/Mono.Net.Security/LegacyTlsProvider.cs
+++ b/mcs/class/System/Mono.Net.Security/LegacyTlsProvider.cs
@@ -68,6 +68,10 @@ namespace Mono.Net.Security
 			get { return false; }
 		}
 
+		internal override bool SupportsCleanShutdown {
+			get { return false; }
+		}
+
 		public override SslProtocols SupportedProtocols {
 			get { return SslProtocols.Tls; }
 		}


### PR DESCRIPTION
[Mono.Security]: Add `MonoTlsProvider.SupportsCleanShutdown` and `MonoTlsSettings.SendCloseNotify`.

Only send close_notify when using BTLS and explicitly requested via 'MonoTlsSettings.SendCloseNotify'.

Clean Shutdown in TLS 1.2
===================

According to the [TLS 1.2 Spec](https://tools.ietf.org/html/rfc4346#section-7.2.1), a close_notify alert should be send prior to closing the connection.

Originally added as a way to prevent truncation attacks, it is no longer necessary when the application level protocol (such as HTTP 1.0+) has a way of tracking connection closure.

The reality is that a large amount of HTTP browsers and servers either don't send the close_notify alert or don't send a close_notify reply upon receiving it.

This [article](https://security.stackexchange.com/questions/82028/ssl-tls-is-a-server-always-required-to-respond-to-a-close-notify) has some interesting details.

For HTTP, we don't need it because the protocol has a reliable way of detecting the end of a connection.  The only situation where it could be useful is when you're trying to mix TLS and unencrypted traffic on the same connection.

When using AppleTls (which is based on Apple's SecureTransport), there is a problem with the way they implement SSLClose():

Calling SSLClose() sends the close_notify alert, then sets and internal flag which marks the connection as closed for both reading and writing.  The next time you call SSLRead(), it'll immediately return telling you the connection has been closed gracefully.

This means - should the remote reply by sending a close_notify back - there's no way of reading it, thus leaving you with some blob of encrypted data.

Therefor, we do not send any close_notify alerts anymore by default, but there is an internal API to explicitly enable them when using BTLS.
