### PR TITLE
[CI] Update Clang's ThreadSanitizer blacklist

### DIFF
--- a/scripts/ci/clang-thread-sanitizer-blacklist
+++ b/scripts/ci/clang-thread-sanitizer-blacklist
@@ -1,50 +1,80 @@
-# ------------------------------------------------------------ #
-#   mono/eglib
-# ------------------------------------------------------------ #
+# --------------------------------------------------------------------------- #
+#   mono/eglib                                                                #
+# --------------------------------------------------------------------------- #
+
+# ghashtable.c #
 
 fun:monoeg_g_hash_table_iter_next
+fun:monoeg_g_hash_table_lookup_extended
 
-# ------------------------------------------------------------ #
-#   mono/metadata
-# ------------------------------------------------------------ #
+# sort.frag.h #
 
-# class.c #
+fun:init_sort_info
+fun:insert_list
+fun:merge_lists
 
-fun:inflate_generic_type
-fun:init_sizes_with_info
-fun:make_generic_param_class
-fun:mono_class_create_from_typedef
-fun:mono_class_from_generic_parameter_internal
-fun:mono_class_get_field_count
-fun:mono_class_get_method_from_name_flags
-fun:mono_class_get_methods
-fun:mono_class_has_failure
-fun:mono_class_has_finalizer
-fun:mono_class_inflate_generic_method_full_checked
-fun:mono_class_inflate_generic_type_no_copy
-fun:mono_class_inflate_generic_type_with_mempool
-fun:mono_class_init
-fun:mono_class_layout_fields
-fun:mono_class_setup_basic_field_info
-fun:mono_class_setup_fields
-fun:mono_class_setup_methods
-fun:mono_class_setup_vtable_full
-fun:mono_class_setup_vtable_general
-fun:mono_generic_class_get_class
-fun:mono_method_get_context_general
-fun:mono_type_get_basic_type_from_generic
-fun:mono_type_get_underlying_type
+# --------------------------------------------------------------------------- #
+#   mono/metadata                                                             #
+# --------------------------------------------------------------------------- #
 
 # class-accessors.c #
 
+fun:mono_class_get_first_method_idx
 fun:mono_class_get_flags
+fun:mono_class_get_generic_class
 fun:mono_class_get_method_count
+fun:mono_class_get_field_count
+fun:mono_class_set_first_method_idx
 fun:mono_class_set_method_count
 
 # class-inlines.h #
 
 fun:mono_class_is_ginst
 fun:mono_class_is_gtd
+
+# class-internals.h #
+
+fun:mono_class_has_parent
+fun:mono_class_has_parent_fast
+
+# class.c #
+
+fun:can_access_type
+fun:inflate_generic_context
+fun:inflate_generic_type
+fun:init_sizes_with_info
+fun:make_generic_param_class
+fun:mono_bounded_array_class_get
+fun:mono_class_create_from_typedef
+fun:mono_class_from_generic_parameter_internal
+fun:mono_class_from_mono_type
+fun:mono_class_get_cctor
+fun:mono_class_get_inflated_method
+fun:mono_class_get_method_from_name_flags
+fun:mono_class_get_methods
+fun:mono_class_get_vtable_entry
+fun:mono_class_has_failure
+fun:mono_class_has_finalizer
+fun:mono_class_inflate_generic_method_full_checked
+fun:mono_class_init
+fun:mono_class_instance_size
+fun:mono_class_is_assignable_from
+fun:mono_class_layout_fields
+fun:mono_class_setup_basic_field_info
+fun:mono_class_setup_fields
+fun:mono_class_setup_interfaces
+fun:mono_class_setup_methods
+fun:mono_class_setup_supertypes
+fun:mono_class_setup_vtable_full
+fun:mono_class_setup_vtable_general
+fun:mono_field_resolve_type
+fun:mono_generic_class_get_class
+fun:mono_method_get_context_general
+fun:mono_method_get_method_definition
+fun:mono_ptr_class_get
+fun:mono_type_get_basic_type_from_generic
+fun:mono_type_get_underlying_type
+fun:mono_type_has_exceptions
 
 # domain.c #
 
@@ -56,21 +86,26 @@ fun:finalize_domain_objects
 fun:finalizer_thread
 fun:mono_domain_finalize
 fun:mono_gc_cleanup
-
-# handle.h #
-
-fun:mono_stack_mark_pop
+fun:object_register_finalizer
 
 # handle.c #
 
 fun:mono_handle_new
 fun:mono_handle_stack_scan
 
+# handle.h #
+
+fun:mono_stack_mark_init
+fun:mono_stack_mark_pop
+
 # icall.c #
 
+fun:vell_icall_get_method_attributes
+fun:ves_icall_InternalInvoke
+fun:ves_icall_RuntimeTypeHandle_IsArray
+fun:ves_icall_RuntimeType_GetConstructors_native
 fun:ves_icall_System_Array_FastCopy
 fun:ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info
-fun:ves_icall_RuntimeType_GetConstructors_native
 
 # image.c #
 
@@ -82,79 +117,101 @@ fun:mono_image_strdup
 
 fun:jit_info_table_add
 fun:jit_info_table_chunk_index
+fun:jit_info_table_copy_and_split_chunk
 fun:jit_info_table_find
 fun:jit_info_table_index
-fun:mono_jit_compile_method_with_opt
+fun:jit_info_table_split_chunk
 fun:mono_jit_info_init
-fun:mono_jit_info_table_find_internal
 
 # loader.c #
 
 fun:cache_memberref_sig
-fun:mon_new
+fun:inflate_generic_signature_checked
 fun:mono_get_method_from_token
 fun:mono_method_get_signature_checked
 fun:mono_method_signature_checked
 
 # marshal.c #
 
+fun:mono_icall_start
 fun:mono_marshal_get_native_wrapper
 fun:mono_marshal_isinst_with_cache
 
 # metadata.c #
 
-fun:img_set_cache_get
 fun:_mono_metadata_generic_class_equal
+fun:collect_method_images
+fun:do_mono_metadata_parse_type
+fun:img_set_cache_get
+fun:mono_metadata_decode_row
+fun:mono_metadata_get_canonical_generic_inst
 fun:mono_metadata_lookup_generic_class
+fun:mono_metadata_parse_type_internal
+fun:mono_type_get_class
 fun:mono_type_get_type
 fun:mono_type_is_struct
 
 # monitor.c #
 
+fun:mon_new
 fun:mono_monitor_ensure_owned
+fun:mono_monitor_enter_v4_fast
 fun:mono_monitor_exit_inflated
+fun:mono_monitor_inflate
 fun:mono_monitor_try_enter_inflated
 fun:mono_monitor_try_enter_internal
 fun:mono_object_hash
 fun:ves_icall_System_Threading_Monitor_Monitor_pulse_all
 fun:ves_icall_System_Threading_Monitor_Monitor_test_synchronised
+fun:ves_icall_System_Threading_Monitor_Monitor_try_enter_with_atomic_var
 fun:ves_icall_System_Threading_Monitor_Monitor_wait
 
 # mono-conc-hash.c #
 
+fun:expand_table
 fun:mono_conc_g_hash_table_lookup_extended
 fun:set_key
 
 # mono-hash.c #
 
 fun:mono_g_hash_table_find_slot
-fun:mono_g_hash_table_max_chain_length
 
 # object.c #
 
 fun:mono_class_compute_gc_descriptor
 fun:mono_class_create_runtime_vtable
 fun:mono_class_vtable_full
-fun:mono_delegate_ctor_with_method
+fun:mono_object_handle_get_virtual_method
 fun:mono_object_handle_isinst
+fun:mono_object_isinst_checked
+fun:mono_object_new_alloc_specific_checked
+fun:mono_object_new_specific_checked
 fun:mono_runtime_class_init_full
+fun:mono_runtime_invoke_array_checked
+fun:mono_runtime_try_invoke_array
+fun:mono_string_new_size_checked
+
+# reflection-cache.h #
+
+fun:cache_object_handle
 
 # reflection.c #
 
 fun:method_object_construct
 fun:reflected_equal
 
-# reflection-cache.h #
-
-fun:cache_object_handle
-
 # runtime.c #
 
 fun:mono_runtime_is_shutting_down
 fun:mono_runtime_try_shutdown
 
+# sgen-client-mono.h #
+
+fun:SGEN_LOAD_VTABLE_UNCHECKED
+
 # sgen-mono.c #
 
+fun:mono_gchandle_free
 fun:mono_gc_alloc_string
 fun:mono_gc_alloc_vector
 fun:mono_gc_thread_in_critical_region
@@ -162,18 +219,22 @@ fun:mono_gc_wbarrier_set_arrayref
 fun:sgen_client_gchandle_created
 fun:sgen_client_gchandle_destroyed
 
-# threadpool.c #
-
-fun:worker_callback
-
 # threadpool-worker-default.c #
 
 fun:heuristic_adjust
 fun:heuristic_notify_work_completed
 fun:heuristic_should_adjust
+fun:hill_climbing_change_thread_count
+fun:hill_climbing_force_change
 fun:hill_climbing_update
 fun:monitor_should_keep_running
 fun:monitor_thread
+fun:monitor_sufficient_delay_since_last_dequeue
+
+# threadpool.c #
+
+fun:try_invoke_perform_wait_callback
+fun:worker_callback
 
 # threads.c #
 
@@ -181,40 +242,69 @@ fun:build_wait_tids
 fun:create_thread
 fun:mono_thread_clr_state
 fun:mono_thread_detach_internal
+fun:mono_thread_set_name_internal
 fun:mono_threads_add_joinable_thread
 fun:mono_threads_join_threads
 fun:remove_and_abort_threads
+fun:request_thread_abort
 
 # w32handle.c #
 
-fun:mono_w32handle_init_handle
+fun:mono_w32handle_lookup
 fun:mono_w32handle_lookup_data
+fun:mono_w32handle_new_internal
+fun:mono_w32handle_ref_core
 fun:mono_w32handle_unref_core
 
-# ------------------------------------------------------------ #
-#   mono/mini
-# ------------------------------------------------------------ #
+# --------------------------------------------------------------------------- #
+#   mono/mini                                                                 #
+# --------------------------------------------------------------------------- #
 
 # alias-analysis.c #
 
 fun:recompute_aliased_variables
 
+# aot-runtime.c #
+
+fun:mono_aot_get_cached_class_info
+fun:mono_aot_get_method_from_vt_slot
+
+# decompose.c #
+
+fun:mono_decompose_vtype_opts
+
+# linear-scan.c #
+
+fun:mono_linear_scan
+
+# liveness.c #
+
+fun:mono_analyze_liveness
+fun:mono_liveness_handle_exception_clauses
+
 # method-to-ir.c #
 
+fun:check_call_signature
+fun:emit_init_rvar
+fun:inline_method
+fun:mono_method_check_inlining
 fun:mono_method_to_ir
-
-# mini.c #
-
-fun:mini_method_compile
-fun:mono_allocate_stack_slots
-fun:mono_jit_compile_method_inner
-fun:mono_save_seq_point_info
-fun:mono_time_track_end
-fun:mono_type_to_load_membase
+fun:mono_spill_global_vars
 
 # mini-amd64.c #
 
+fun:get_call_info
+fun:mono_arch_allocate_vars
+fun:mono_arch_emit_epilog
+fun:mono_arch_emit_prolog
 fun:mono_arch_get_delegate_invoke_impl
+fun:mono_arch_lowering_pass
+fun:mono_arch_peephole_pass_2
+
+# mini-codegen.c #
+
+fun:mono_local_regalloc
+fun:mono_peephole_ins
 
 # mini-exceptions.c #
 
@@ -222,12 +312,23 @@ fun:mono_thread_state_init_from_sigctx
 
 # mini-generic-sharing.c #
 
+fun:alloc_template
+fun:class_get_rgctx_template_oti
+fun:get_info_templates
+fun:inflate_info
+fun:inst_check_context_used
 fun:mini_get_basic_type_from_generic
 fun:mini_is_gsharedvt_type
 fun:mini_type_get_underlying_type
 fun:mono_class_fill_runtime_generic_context
 fun:mono_generic_context_check_used
 fun:mono_method_check_context_used
+fun:mono_method_fill_runtime_generic_context
+fun:mono_method_get_declaring_generic_method
+fun:mono_method_is_generic_impl
+fun:mono_method_needs_static_rgctx_invoke
+fun:rgctx_template_set_slot
+fun:set_info_templates
 
 # mini-native-types.c #
 
@@ -235,21 +336,52 @@ fun:mini_native_type_replace_type
 
 # mini-runtime.c #
 
+fun:create_runtime_invoke_info
+fun:mini_imt_entry_inited
+fun:mono_jit_compile_method_with_opt
 fun:mono_jit_find_compiled_method_with_jit_info
+fun:mono_jit_runtime_invoke
 
 # mini-trampolines.c #
 
 fun:common_call_trampoline
+fun:mini_add_method_trampoline
 fun:mini_resolve_imt_method
+fun:mono_create_delegate_trampoline_info
 fun:mono_create_jit_trampoline
+fun:mono_create_jump_trampoline
 fun:mono_delegate_trampoline
 fun:mono_magic_trampoline
 fun:mono_rgctx_lazy_fetch_trampoline
 fun:mono_vcall_trampoline
 
-# ------------------------------------------------------------ #
-#   mono/sgen
-# ------------------------------------------------------------ #
+# mini.c #
+
+fun:mini_method_compile
+fun:mono_allocate_stack_slots
+fun:mono_codegen
+fun:mono_compile_create_vars
+fun:mono_insert_branches_between_bblocks
+fun:mono_jit_compile_method_inner
+fun:mono_time_track_end
+fun:mono_type_to_load_membase
+fun:mono_type_to_store_membase
+
+# seq-points.c #
+
+fun:mono_save_seq_point_info
+
+# tramp-amd64.c #
+
+fun:mono_arch_patch_callsite
+
+# unwind.c #
+
+fun:mono_unwind_ops_encode_full
+
+# --------------------------------------------------------------------------- #
+#   mono/sgen                                                                 #
+# --------------------------------------------------------------------------- #
 
 # sgen-alloc.c #
 
@@ -257,14 +389,18 @@ fun:sgen_alloc_obj
 fun:sgen_clear_tlabs
 fun:sgen_try_alloc_obj_nolock
 
-# sgen-array-list.h #
-
-fun:sgen_array_list_bucketize
-
 # sgen-array-list.c #
 
 fun:sgen_array_list_add
 fun:sgen_array_list_find_unset
+
+# sgen-array-list.h #
+
+fun:sgen_array_list_bucketize
+
+# sgen-cardtable.c #
+
+fun:sgen_card_table_wbarrier_range_copy
 
 # sgen-cardtable.h #
 
@@ -274,25 +410,24 @@ fun:sgen_card_table_mark_address
 
 fun:add_stage_entry
 
-# sgen-gc.h #
-
-fun:sgen_set_nursery_scan_start
-
 # sgen-gc.c #
 
 fun:mono_gc_wbarrier_generic_store
-fun:sgen_conservatively_pin_objects_from
+
+# sgen-gc.h #
+
+fun:sgen_set_nursery_scan_start
 
 # sgen-gchandles.c #
 
 fun:is_slot_set
 fun:link_get
-fun:mono_gchandle_free
 fun:sgen_gchandle_iterate
 
 # sgen-marksweep.c #
 
 fun:ensure_block_is_checked_for_sweeping
+fun:ensure_can_access_block_free_list
 fun:major_finish_sweep_checking
 fun:set_block_state
 fun:sweep_block
@@ -306,14 +441,20 @@ fun:sgen_fragment_allocator_alloc
 fun:sgen_fragment_allocator_par_range_alloc
 fun:sgen_fragment_allocator_release
 
-# ------------------------------------------------------------ #
-#   mono/utils
-# ------------------------------------------------------------ #
+# --------------------------------------------------------------------------- #
+#   mono/utils                                                                #
+# --------------------------------------------------------------------------- #
 
 # hazard-pointer.c #
 
 fun:is_pointer_hazardous
 fun:mono_get_hazardous_pointer
+fun:mono_thread_small_id_alloc
+
+# lock-free-array-queue.c #
+
+fun:mono_lock_free_array_queue_pop
+fun:mono_lock_free_array_queue_push
 
 # memfuncs.c #
 
@@ -322,15 +463,26 @@ fun:mono_gc_memmove_aligned
 
 # mono-conc-hashtable.c #
 
+fun:expand_table
+fun:mono_conc_hashtable_insert
 fun:mono_conc_hashtable_lookup
 
 # mono-context.c #
 
 fun:mono_sigctx_to_monoctx
 
+# mono-error.c #
+
+fun:mono_error_cleanup
+
 # mono-lazy-init.h #
 
 fun:mono_lazy_initialize
+
+# mono-linked-list-set.c #
+
+fun:mono_lls_find
+fun:mono_lls_get_hazardous_pointer_with_mask
 
 # mono-threads-posix-signals.c #
 
@@ -341,6 +493,10 @@ fun:suspend_signal_handler
 
 fun:check_thread_state
 fun:mono_threads_transition_finish_async_suspend
+
+# mono-threads.c #
+
+fun:mono_thread_info_uninstall_interrupt
 
 # os-event-unix.c #
 


### PR DESCRIPTION
- added more racy functions to the list
- removed some racy functions that have been fixed
- removed one racy function that is, in fact, a static variable
- also expanded the header rows to 80 chars