### PR TITLE
Call `g_utf8_to_utf16` with a proper argument

### DIFF
--- a/mono/utils/strenc.c
+++ b/mono/utils/strenc.c
@@ -90,8 +90,10 @@ mono_unicode_from_external (const gchar *in, gsize *bytes)
 	g_strfreev (encodings);
 	
 	if(g_utf8_validate (in, -1, NULL)) {
-		gunichar2 *unires=g_utf8_to_utf16 (in, -1, NULL, (glong *)bytes, NULL);
-		*bytes *= 2;
+		glong items_written;
+		gunichar2 *unires=g_utf8_to_utf16 (in, -1, NULL, &items_written, NULL);
+		items_written *= 2;
+		*bytes = items_written;
 		return(unires);
 	}
 


### PR DESCRIPTION
* The sizes of `glong` and `gsize` differ on 64-bit Windows.
* In order to avoid uninitialized data in the high four bytes of the `bytes` argument to `mono_unicode_from_external`, call `g_utf8_to_utf16` with a `glong`, then copy the result.

This replaces https://github.com/mono/mono/pull/5468 and fixes the same issue with a much smaller change.