### PR TITLE
Implement stack overflow handling on Win64 - Version 2

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1217,6 +1217,10 @@ typedef struct {
 	int active_jit_methods;
 
 	gpointer interp_context;
+
+#if defined(TARGET_WIN32)
+	MonoContext stack_restore_ctx;
+#endif
 } MonoJitTlsData;
 
 /*


### PR DESCRIPTION
Call _resetstkoflw to restore stack protection before calling handler, and then jump to handler via a cached MonoContext.

This is a simpler implementation than https://github.com/mono/mono/pull/5137