### PR TITLE
Fix xunit tests on windows

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -212,7 +212,7 @@ run-xunit-test: run-xunit-test-local
 xunit-test-local: $(xunit_test_lib)
 run-xunit-test-local: run-xunit-test-lib
 
-# ln -s is a HACK for xunit runner to require xunit.execution.desktop.dll file in local folder on .net only
+# cp -rf is a HACK for xunit runner to require xunit.execution.desktop.dll file in local folder on .net only
 run-xunit-test-lib: xunit-test-local
 	@cp -rf $(XTEST_HARNESS_PATH)/xunit.execution.desktop.dll xunit.execution.desktop.dll
 	ok=:; \

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -214,7 +214,7 @@ run-xunit-test-local: run-xunit-test-lib
 
 # ln -s is a HACK for xunit runner to require xunit.execution.desktop.dll file in local folder on .net only
 run-xunit-test-lib: xunit-test-local
-	@ln -fs $(XTEST_HARNESS_PATH)/xunit.execution.desktop.dll xunit.execution.desktop.dll
+	@cp -rf $(XTEST_HARNESS_PATH)/xunit.execution.desktop.dll xunit.execution.desktop.dll
 	ok=:; \
 	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" $(TEST_RUNTIME) $(RUNTIME_FLAGS) $(AOT_RUN_FLAGS) $(XTEST_HARNESS) $(xunit_test_lib) $(XTEST_HARNESS_FLAGS) $(XTEST_TRAIT) || ok=false; \
 	$$ok


### PR DESCRIPTION
Currently `make run-xunit-tests` on windows fails with System.BadImageException
it seems it doesn't like a link to xunit.execution.desktop.dll
if I just copy this file to my working dir - everything will work fine.
The file will be deleted from the directory once tests are finished.