### PR TITLE
[Mono.Security]: Add 'MonoTlsProvider.SupportsCleanShutdown' and 'MonoTlsSettings.SendCloseNotify'. (#5465).

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProvider.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProvider.cs
@@ -163,5 +163,14 @@ namespace Mono.Security.Interface
 			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
 			ref MonoSslPolicyErrors errors, ref int status11);
 #endregion
+
+#region Misc
+
+		internal abstract bool SupportsCleanShutdown {
+			get;
+		}
+
+#endregion
+
 	}
 }

--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
@@ -87,6 +87,13 @@ namespace Mono.Security.Interface
 		}
 
 		/*
+		 * This is only supported if MonoTlsProvider.SupportsCleanShutdown is true.
+		 */
+		internal bool SendCloseNotify {
+			get; set;
+		}
+
+		/*
 		 * If you set this here, then it will override 'ServicePointManager.SecurityProtocol'.
 		 */
 		public TlsProtocols? EnabledProtocols {
@@ -173,6 +180,7 @@ namespace Mono.Security.Interface
 			EnabledProtocols = other.EnabledProtocols;
 			EnabledCiphers = other.EnabledCiphers;
 			CertificateValidationTime = other.CertificateValidationTime;
+			SendCloseNotify = other.SendCloseNotify;
 			if (other.TrustAnchors != null)
 				TrustAnchors = new X509CertificateCollection (other.TrustAnchors);
 			if (other.CertificateSearchPaths != null) {

--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -859,24 +859,7 @@ namespace Mono.AppleTls
 
 		public override void Shutdown ()
 		{
-			if (Interlocked.Exchange (ref pendingIO, 1) == 1)
-				throw new InvalidOperationException ();
-
-			Debug ("Shutdown");
-
-			lastException = null;
-
-			try {
-				if (closed || disposed)
-					return;
-
-				var status = SSLClose (Handle);
-				Debug ("Shutdown done: {0}", status);
-				CheckStatusAndThrow (status);
-			} finally {
-				closed = true;
-				pendingIO = 0;
-			}
+			closed = true;
 		}
 
 		#endregion

--- a/mcs/class/System/Mono.AppleTls/AppleTlsProvider.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsProvider.cs
@@ -65,6 +65,10 @@ namespace Mono.AppleTls
 			get { return true; }
 		}
 
+		internal override bool SupportsCleanShutdown {
+			get { return false; }
+		}
+
 		public override SslProtocols SupportedProtocols {
 			get { return SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls; }
 		}

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -364,7 +364,8 @@ namespace Mono.Btls
 		public override void Shutdown ()
 		{
 			Debug ("Shutdown!");
-//			ssl.SetQuietShutdown ();
+			if (Settings == null || !Settings.SendCloseNotify)
+				ssl.SetQuietShutdown ();
 			ssl.Shutdown ();
 		}
 

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -75,6 +75,10 @@ namespace Mono.Btls
 			get { return true; }
 		}
 
+		internal override bool SupportsCleanShutdown {
+			get { return true; }
+		}
+
 		public override SslProtocols SupportedProtocols {
 			get { return SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls; }
 		}

--- a/mcs/class/System/Mono.Net.Security/LegacyTlsProvider.cs
+++ b/mcs/class/System/Mono.Net.Security/LegacyTlsProvider.cs
@@ -68,6 +68,10 @@ namespace Mono.Net.Security
 			get { return false; }
 		}
 
+		internal override bool SupportsCleanShutdown {
+			get { return false; }
+		}
+
 		public override SslProtocols SupportedProtocols {
 			get { return SslProtocols.Tls; }
 		}


### PR DESCRIPTION
Backporting PR #5465:
[Mono.Security]: Add 'MonoTlsProvider.SupportsCleanShutdown' and 'MonoTlsSettings.SendCloseNotify'. (#5465).

Only send close_notify when using BTLS and explicitly requested via 'MonoTlsSettings.SendCloseNotify'.
(cherry picked from commit 4a79280b3bef8d5f15da9ddd2a2af3a03e194b03)