### PR TITLE
[w32file] Add 'kbfuse' filesystem type to known drive types array.

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4256,6 +4256,7 @@ static _wapi_drive_type _wapi_drive_types[] = {
 	{ DRIVE_REMOTE, "ftp" },
 	{ DRIVE_FIXED, "hfs" },
 	{ DRIVE_FIXED, "apfs" },
+	{ DRIVE_REMOTE, "kbfuse" },
 	{ DRIVE_FIXED, "msdos" },
 	{ DRIVE_REMOTE, "nfs" },
 	{ DRIVE_FIXED, "ntfs" },


### PR DESCRIPTION
It's the https://keybase.io desktop client filesystem