### PR TITLE
[threads] Rely on MonoThreadInfo.stack_start_limit and MonoThreadInfo.stack_end instead of calling mono_thread_info_get_stack_bounds which is very slow

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1017,33 +1017,24 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStac
 #elif defined(TARGET_ANDROID)
 	// No need for now
 #else
-	guint8 *stack_addr;
-	guint8 *current;
-	size_t stack_size;
-	int min_size;
-	MonoInternalThread *thread;
+	guint8 *stack_start;
+	guint8 *stack_current;
+	gsize stack_size;
+	MonoThreadInfo *info;
 
-	mono_thread_info_get_stack_bounds (&stack_addr, &stack_size);
-	/* if we have no info we are optimistic and assume there is enough room */
-	if (!stack_addr)
+	info = mono_thread_info_current ();
+	stack_start = info->stack_start_limit;
+	stack_size = info->stack_end - info->stack_start_limit;
+
+	stack_current = (guint8 *)&stack_start;
+
+	/* Some platforms support dynamic stack resizing */
+	if (stack_current < stack_start)
 		return TRUE;
 
-	thread = mono_thread_internal_current ();
-	// .net seems to check that at least 50% of stack is available
-	min_size = thread->stack_size / 2;
-
-	// TODO: It's not always set
-	if (!min_size)
-		return TRUE;
-
-	current = (guint8 *)&stack_addr;
-	if (current > stack_addr) {
-		if ((current - stack_addr) < min_size)
-			return FALSE;
-	} else {
-		if (current - (stack_addr - stack_size) < min_size)
-			return FALSE;
-	}
+	/* .net seems to check that at least 50% of stack is available */
+	if (stack_current < stack_start + stack_size / 2)
+		return FALSE;
 #endif
 	return TRUE;
 }

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -714,7 +714,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
  * \param ctx saved processor state
  * \param obj the exception object
  */
-gboolean
+void
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
 #if defined(MONO_ARCH_USE_SIGACTION)
@@ -733,8 +733,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	mctx = jit_tls->ex_ctx;
 	mono_arch_setup_async_callback (&mctx, handle_signal_exception, obj);
 	mono_monoctx_to_sigctx (&mctx, sigctx);
-
-	return TRUE;
 #else
 	MonoContext mctx;
 
@@ -743,8 +741,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	mono_handle_exception (&mctx, obj);
 
 	mono_monoctx_to_sigctx (&mctx, sigctx);
-
-	return TRUE;
 #endif
 }
 

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -554,7 +554,7 @@ get_handle_signal_exception_addr (void)
 /*
  * This is the function called from the signal handler
  */
-gboolean
+void
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
 #if defined(MONO_CROSS_COMPILE) || !defined(MONO_ARCH_HAVE_SIGCTX_TO_MONOCTX)
@@ -587,20 +587,16 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 		/* Transition to ARM */
 		UCONTEXT_REG_CPSR (sigctx) &= ~(1 << 5);
 #endif
-
-	return TRUE;
 #else
 	MonoContext mctx;
-	gboolean result;
 
 	mono_sigctx_to_monoctx (ctx, &mctx);
 
-	result = mono_handle_exception (&mctx, obj);
+	mono_handle_exception (&mctx, obj);
 	/* restore the context so that returning from the signal handler will invoke
 	 * the catch clause 
 	 */
 	mono_monoctx_to_sigctx (&mctx, ctx);
-	return result;
 #endif
 }
 

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -549,7 +549,7 @@ handle_signal_exception (gpointer obj)
 /*
  * This is the function called from the signal handler
  */
-gboolean
+void
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
 #if defined(MONO_CROSS_COMPILE)
@@ -571,8 +571,6 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 	UCONTEXT_REG_PC (sigctx) = (gsize)handle_signal_exception;
 	UCONTEXT_REG_SP (sigctx) = UCONTEXT_REG_SP (sigctx) - MONO_ARCH_REDZONE_SIZE;
 #endif
-
-	return TRUE;
 }
 
 gpointer

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -514,7 +514,7 @@ handle_signal_exception (gpointer obj)
 /*
  * This is the function called from the signal handler
  */
-gboolean
+void
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
 #if defined(MONO_CROSS_COMPILE)
@@ -540,20 +540,16 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 	UCONTEXT_GREGS (sigctx)[mips_sp] = sp;
 
 	UCONTEXT_REG_PC (sigctx) = (gsize)handle_signal_exception;
-
-	return TRUE;
 #else
 	MonoContext mctx;
-	gboolean result;
 
 	mono_sigctx_to_monoctx (ctx, &mctx);
 
-	result = mono_handle_exception (&mctx, obj);
+	mono_handle_exception (&mctx, obj);
 	/* restore the context so that returning from the signal handler will invoke
 	 * the catch clause 
 	 */
 	mono_monoctx_to_sigctx (&mctx, ctx);
-	return result;
 #endif
 }
 

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -754,7 +754,7 @@ setup_ucontext_return (void *uc, gpointer func)
 #endif
 }
 
-gboolean
+void
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
 #if defined(MONO_ARCH_USE_SIGACTION) && defined(UCONTEXT_REG_Rn)
@@ -783,20 +783,16 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 	sp = (mgreg_t)(sp - frame_size);
 	UCONTEXT_REG_Rn(uc, 1) = (mgreg_t)sp;
 	setup_ucontext_return (uc, handle_signal_exception);
-
-	return TRUE;
 #else
 	MonoContext mctx;
-	gboolean result;
 
 	mono_sigctx_to_monoctx (ctx, &mctx);
 
-	result = mono_handle_exception (&mctx, obj);
+	mono_handle_exception (&mctx, obj);
 	/* restore the context so that returning from the signal handler will invoke
 	 * the catch clause 
 	 */
 	mono_monoctx_to_sigctx (&mctx, ctx);
-	return result;
 #endif
 }
 

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -554,7 +554,7 @@ handle_signal_exception (gpointer obj)
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-gboolean
+void
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
 	MonoContext mctx;
@@ -572,8 +572,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	mctx = jit_tls->ex_ctx;
 	mono_arch_setup_async_callback (&mctx, handle_signal_exception, obj);
 	mono_monoctx_to_sigctx (&mctx, sigctx);
-
-	return TRUE;
 }
 
 /*========================= End of Function ========================*/

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -390,7 +390,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 #ifdef __linux__
 
-gboolean
+void
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
        MonoContext mctx;
@@ -422,8 +422,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 
        window = (gpointer*)(((guint8*)mctx.sp) + MONO_SPARC_STACK_BIAS);
        window [sparc_fp - 16] = mctx.fp;
-
-       return TRUE;
 }
 
 gpointer
@@ -443,7 +441,7 @@ mono_arch_ip_from_context (void *sigctx)
 
 #else /* !__linux__ */
 
-gboolean
+void
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
 	MonoContext mctx;
@@ -470,8 +468,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	ctx->uc_mcontext.gregs [REG_SP] = mctx.sp;
 	window = (gpointer*)(((guint8*)mctx.sp) + MONO_SPARC_STACK_BIAS);
 	window [sparc_fp - 16] = mctx.fp;
-
-	return TRUE;
 }
 
 gpointer

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -1002,7 +1002,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 	ctx->eip = (mgreg_t)signal_exception_trampoline;
 }
 
-gboolean
+void
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
 #if defined(MONO_ARCH_USE_SIGACTION)
@@ -1022,8 +1022,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	mctx = jit_tls->ex_ctx;
 	mono_setup_async_callback (&mctx, handle_signal_exception, obj);
 	mono_monoctx_to_sigctx (&mctx, sigctx);
-
-	return TRUE;
 #elif defined (TARGET_WIN32)
 	MonoContext mctx;
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
@@ -1034,8 +1032,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	mctx = jit_tls->ex_ctx;
 	mono_setup_async_callback (&mctx, handle_signal_exception, obj);
 	mono_monoctx_to_sigctx (&mctx, sigctx);
-
-	return TRUE;
 #else
 	MonoContext mctx;
 
@@ -1044,8 +1040,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	mono_handle_exception (&mctx, obj);
 
 	mono_monoctx_to_sigctx (&mctx, sigctx);
-
-	return TRUE;
 #endif
 }
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1796,7 +1796,7 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, MonoObject *obj, gi
  * \param obj the exception object
  * \param resume whenever to resume unwinding based on the state in \c MonoJitTlsData.
  */
-static gboolean
+static void
 mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resume, MonoJitInfo **out_ji)
 {
 	MonoError error;
@@ -2180,7 +2180,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 					if (obj == (MonoObject *)domain->stack_overflow_ex)
 						jit_tls->handling_stack_ovf = FALSE;
 
-					return 0;
+					return;
 				}
 				mono_error_cleanup (&error);
 				if (ei->flags == MONO_EXCEPTION_CLAUSE_FAULT) {
@@ -2221,7 +2221,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 						jit_tls->resume_state.filter_idx = filter_idx;
 						mini_set_abort_threshold (ctx);
 						MONO_CONTEXT_SET_IP (ctx, ei->handler_start);
-						return 0;
+						return;
 					} else {
 						mini_set_abort_threshold (ctx);
 						if (in_interp)
@@ -2290,10 +2290,9 @@ mono_debugger_run_finally (MonoContext *start_ctx)
  * \param ctx saved processor state
  * \param obj the exception object
  *
- *   Handle the exception OBJ starting from the state CTX. Modify CTX to point to the handler clause if the exception is caught, and
- * return TRUE.
+ *   Handle the exception OBJ starting from the state CTX. Modify CTX to point to the handler clause if the exception is caught.
  */
-gboolean
+void
 mono_handle_exception (MonoContext *ctx, MonoObject *obj)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
@@ -2302,7 +2301,7 @@ mono_handle_exception (MonoContext *ctx, MonoObject *obj)
 	mono_perfcounters->exceptions_thrown++;
 #endif
 
-	return mono_handle_exception_internal (ctx, obj, FALSE, NULL);
+	mono_handle_exception_internal (ctx, obj, FALSE, NULL);
 }
 
 #ifdef MONO_ARCH_SIGSEGV_ON_ALTSTACK

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2840,7 +2840,7 @@ gpointer  mono_arch_get_throw_exception         (MonoTrampInfo **info, gboolean 
 gpointer  mono_arch_get_rethrow_exception       (MonoTrampInfo **info, gboolean aot);
 gpointer  mono_arch_get_throw_corlib_exception  (MonoTrampInfo **info, gboolean aot);
 gpointer  mono_arch_get_throw_pending_exception (MonoTrampInfo **info, gboolean aot);
-gboolean mono_arch_handle_exception             (void *sigctx, gpointer obj);
+void     mono_arch_handle_exception             (void *sigctx, gpointer obj);
 void     mono_arch_handle_altstack_exception    (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf);
 gboolean mono_handle_soft_stack_ovf             (MonoJitTlsData *jit_tls, MonoJitInfo *ji, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, guint8* fault_addr);
 void     mono_handle_hard_stack_ovf             (MonoJitTlsData *jit_tls, MonoJitInfo *ji, void *ctx, guint8* fault_addr);
@@ -2892,7 +2892,7 @@ mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo 
 typedef gboolean (*MonoJitStackWalk)            (StackFrameInfo *frame, MonoContext *ctx, gpointer data);
 
 void     mono_exceptions_init                   (void);
-gboolean mono_handle_exception                  (MonoContext *ctx, MonoObject *obj);
+void     mono_handle_exception                  (MonoContext *ctx, MonoObject *obj);
 void     mono_handle_native_crash               (const char *signal, void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo);
 MONO_API void     mono_print_thread_dump                 (void *sigctx);
 MONO_API void     mono_print_thread_dump_from_ctx        (MonoContext *ctx);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58911