### PR TITLE
Clarifying the usage of the --library option

### DIFF
--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -177,7 +177,9 @@ same as for the compiler -lib: or -L flags.
 Embeds the dynamic library file pointed to by `PATH' and optionally
 give it the name `LIB' into the bundled executable.   This is used to
 ship native library dependencies that are unpacked at startup and
-loaded from the runtime.
+loaded from the runtime. Multiple libraries should be specified in
+dependency order, where later ones on the command line depend on
+earlier ones.
 .TP
 .I "--lists-targets"
 Lists all of the available local cross compilation targets available


### PR DESCRIPTION
I found that multiple libraries need to be specified in dependency order. That was not obvious from the man page. Make it explicit.

See https://bugzilla.xamarin.com/show_bug.cgi?id=59154