### PR TITLE
[TSan] Unlock joinable_thread_count

### DIFF
--- a/mono/utils/unlocked.h
+++ b/mono/utils/unlocked.h
@@ -33,6 +33,13 @@ UnlockedIncrement (gint32 *val)
 
 MONO_UNLOCKED_ATTRS
 gint32
+UnlockedDecrement (gint32 *val)
+{
+	return --*val;
+}
+
+MONO_UNLOCKED_ATTRS
+gint32
 UnlockedAdd (gint32 *dest, gint32 add)
 {
 	return *dest += add;


### PR DESCRIPTION
Clang's ThreadSanitizer only complains about one (harmless) race with `joinable_thread_count`: the fastpath in `mono_threads_join_threads ()`. It would only be necessary to mark this operation with `Unlocked* ()`. To keep a consistent style, however, I think we should use `Unlocked* ()` for all operations on `joinable_thread_count`.