### PR TITLE
[TSan] Remove racy debugging code in mini.c

### DIFF
--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1380,9 +1380,8 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 				printf ("LAST: %s\n", mono_method_full_name (cfg->method, TRUE));
 			if (count > atoi (g_getenv ("COUNT3")))
 				slot = 0xffffff;
-			else {
+			else
 				mono_print_ins (inst);
-				}
 		}
 #endif
 
@@ -1614,20 +1613,19 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 			}
 		}
 
+#if 0
 		{
 			static int count = 0;
 			count ++;
 
-			/*
 			if (count == atoi (g_getenv ("COUNT")))
 				printf ("LAST: %s\n", mono_method_full_name (cfg->method, TRUE));
 			if (count > atoi (g_getenv ("COUNT")))
 				slot = 0xffffff;
-			else {
+			else
 				mono_print_ins (inst);
-				}
-			*/
 		}
+#endif
 
 		if (inst->flags & MONO_INST_LMF) {
 			/*


### PR DESCRIPTION
The following (racy) debugging code looks like it was left there accidentally:

```c
static int count = 0;
count ++;
```

Instead of expanding the `/* ... */` comment, I used `#if 0 ... #endif` like it is being used already with similar code above. In addition, I removed the curly brackets to match the style of these lines.