### PR TITLE
[Tests] Fix Mono.Data.Tds tests on iOS

### DIFF
--- a/mcs/class/Mono.Data.Tds/Test/bug-4786.cs
+++ b/mcs/class/Mono.Data.Tds/Test/bug-4786.cs
@@ -100,6 +100,7 @@ namespace MonoTests.Mono.Data.Tds
 
 	pool.ReleaseConnection(tds);
 
+	Listener.Stop ();
 	//exit
     }
   }

--- a/mcs/class/Mono.Data.Tds/Test/bug-4786.cs
+++ b/mcs/class/Mono.Data.Tds/Test/bug-4786.cs
@@ -51,13 +51,10 @@ namespace MonoTests.Mono.Data.Tds
 	//require at this point: a listener on port 1433...
 
 	try{
-		Socket Listener = new Socket(AddressFamily.InterNetwork, 
-                                         SocketType.Stream,
-                                         ProtocolType.Tcp);
 		IPAddress hostIP =Dns.GetHostEntry("localhost").AddressList[0];
-        	IPEndPoint ep = new IPEndPoint(hostIP, 1433);
-		Listener.Bind(ep); 
-        	Listener.Listen(1);
+        IPEndPoint ep = new IPEndPoint(hostIP, 1433);
+        TcpListener Listener = new TcpListener (ep);
+        Listener.Start ();
 	} catch (Exception){
 		//ignore
 	}


### PR DESCRIPTION
The modified tests failed on iOS following PR:
https://github.com/xamarin/xamarin-macios/pull/2580 that adds support
for Xharness to run the Mono.Data.Tds on Xamarin.iOS. With the changes
the tests run a expected.