### PR TITLE
[TSan] Reorganise / clean up counters logic in mini-generic-sharing.c

### DIFF
--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -150,7 +150,7 @@ register_internal (const char *name, int type, void *addr, int size)
 
 	for (counter = counters; counter; counter = counter->next) {
 		if (counter->addr == addr) {
-			g_warning ("you are registering twice the same counter address");
+			g_warning ("you are registering the same counter address twice: %s", name);
 			mono_os_mutex_unlock (&counters_mutex);
 			return;
 		}

--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -150,7 +150,7 @@ register_internal (const char *name, int type, void *addr, int size)
 
 	for (counter = counters; counter; counter = counter->next) {
 		if (counter->addr == addr) {
-			g_warning ("you are registering the same counter address twice: %s", name);
+			g_warning ("you are registering the same counter address twice: %s at %p", name, addr);
 			mono_os_mutex_unlock (&counters_mutex);
 			return;
 		}


### PR DESCRIPTION
Similar to what I have seen with more current versions of the counters, I moved all calls of `mono_counters_register ()` to `mono_generic_sharing_init ()`, and I had all counters have module visibility. Besides following a unified style, this also cleans up the functions themselves (readability!) and removes duplicate code.

If I understand things correctly, most of these counters can be interlocked, as there is no special urgency when calling any of these functions. However, some counters are used in locked environments already (or can be put into locked regions easily); interlocking them seems like overkill. I have marked these (unlocked) counters with short comments about dependent locks.

Some more details, besides the main changes:
- Using `gint32` instead of `int` should not cause any issues.
- I renamed all counters to match their output exactly; that way collisions of common names like `num_allocated` can be limited.