### PR TITLE
[bcl] Use RuntimeHelpers.GetHashCode () for getting the hash code of …

### DIFF
--- a/mcs/class/corlib/System/Delegate.cs
+++ b/mcs/class/corlib/System/Delegate.cs
@@ -499,7 +499,7 @@ namespace System
 
 			m = Method;
 
-			return (m != null ? m.GetHashCode () : GetType ().GetHashCode ()) ^ (m_target != null ? RuntimeHelpers.GetHashCode (m_target) : 0);
+			return (m != null ? m.GetHashCode () : GetType ().GetHashCode ()) ^ RuntimeHelpers.GetHashCode (m_target);
 		}
 
 		protected virtual MethodInfo GetMethodImpl ()

--- a/mcs/class/corlib/System/Delegate.cs
+++ b/mcs/class/corlib/System/Delegate.cs
@@ -499,7 +499,7 @@ namespace System
 
 			m = Method;
 
-			return (m != null ? m.GetHashCode () : GetType ().GetHashCode ()) ^ (m_target != null ? m_target.GetHashCode () : 0);
+			return (m != null ? m.GetHashCode () : GetType ().GetHashCode ()) ^ (m_target != null ? RuntimeHelpers.GetHashCode (m_target) : 0);
 		}
 
 		protected virtual MethodInfo GetMethodImpl ()

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -304,6 +304,7 @@ TESTS_CS_SRC=		\
 	delegate-async-exit.cs	\
 	delegate-delegate-exit.cs	\
 	delegate-exit.cs	\
+	delegate-disposed-hashcode.cs	\
 	finalizer-abort.cs	\
 	finalizer-exception.cs	\
 	finalizer-exit.cs	\

--- a/mono/tests/delegate-disposed-hashcode.cs
+++ b/mono/tests/delegate-disposed-hashcode.cs
@@ -1,0 +1,38 @@
+using System;
+
+// Regression test for bug #59235
+
+public static class Program {
+	delegate void MyDel (int i, int j);
+
+	public static void Main (string[] args) {
+		var o = new MyTarget ();
+		Console.WriteLine ("Hashcode1: " + o.GetHashCode ());
+
+		MyDel d = o.DoStuff;
+		Console.WriteLine ("Hashcode2: " + d.GetHashCode ());
+		Console.WriteLine ("Hashcode3: " + o.GetHashCode ());
+
+		o.Dispose ();
+		Console.WriteLine ("Hashcode4: " + d.GetHashCode ());
+	}
+
+	class MyTarget : IDisposable {
+		public int counter = 0;
+		bool avail = true;
+
+		public void DoStuff (int i, int j) {
+			counter += i + j;
+		}
+
+		public void Dispose () {
+			avail = false;
+		}
+
+		public override int GetHashCode () {
+			if (!avail)
+				throw new ObjectDisposedException ("MyTarget is dead");
+			return counter.GetHashCode ();
+		}
+	}
+}


### PR DESCRIPTION
…the delegate target to avoid calling user defined hash code implementations which can throw exceptions. Fixes a regression introduced by a48bc439850869e565833d7fe6330c289beffe40.