### PR TITLE
[2017-06][bcl] Use RuntimeHelpers.GetHashCode () for getting the hash code of …

### DIFF
--- a/mcs/class/corlib/System/Delegate.cs
+++ b/mcs/class/corlib/System/Delegate.cs
@@ -499,7 +499,7 @@ namespace System
 
 			m = Method;
 
-			return (m != null ? m.GetHashCode () : GetType ().GetHashCode ()) ^ (m_target != null ? m_target.GetHashCode () : 0);
+			return (m != null ? m.GetHashCode () : GetType ().GetHashCode ()) ^ RuntimeHelpers.GetHashCode (m_target);
 		}
 
 		protected virtual MethodInfo GetMethodImpl ()

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -303,6 +303,7 @@ TESTS_CS_SRC=		\
 	delegate-async-exit.cs	\
 	delegate-delegate-exit.cs	\
 	delegate-exit.cs	\
+	delegate-disposed-hashcode.cs	\
 	finalizer-abort.cs	\
 	finalizer-exception.cs	\
 	finalizer-exit.cs	\

--- a/mono/tests/delegate-disposed-hashcode.cs
+++ b/mono/tests/delegate-disposed-hashcode.cs
@@ -1,0 +1,38 @@
+using System;
+
+// Regression test for bug #59235
+
+public static class Program {
+	delegate void MyDel (int i, int j);
+
+	public static void Main (string[] args) {
+		var o = new MyTarget ();
+		Console.WriteLine ("Hashcode1: " + o.GetHashCode ());
+
+		MyDel d = o.DoStuff;
+		Console.WriteLine ("Hashcode2: " + d.GetHashCode ());
+		Console.WriteLine ("Hashcode3: " + o.GetHashCode ());
+
+		o.Dispose ();
+		Console.WriteLine ("Hashcode4: " + d.GetHashCode ());
+	}
+
+	class MyTarget : IDisposable {
+		public int counter = 0;
+		bool avail = true;
+
+		public void DoStuff (int i, int j) {
+			counter += i + j;
+		}
+
+		public void Dispose () {
+			avail = false;
+		}
+
+		public override int GetHashCode () {
+			if (!avail)
+				throw new ObjectDisposedException ("MyTarget is dead");
+			return counter.GetHashCode ();
+		}
+	}
+}


### PR DESCRIPTION
backport of https://github.com/mono/mono/pull/5511