### PR TITLE
[TSan] Unlock mono_g_hash_table_max_chain_length

### DIFF
--- a/mono/metadata/mono-hash.h
+++ b/mono/metadata/mono-hash.h
@@ -22,7 +22,7 @@ typedef enum {
 	MONO_HASH_KEY_VALUE_GC = MONO_HASH_KEY_GC | MONO_HASH_VALUE_GC,
 } MonoGHashGCType;
 
-extern int mono_g_hash_table_max_chain_length;
+extern gint32 mono_g_hash_table_max_chain_length;
 
 typedef struct _MonoGHashTable MonoGHashTable;
 


### PR DESCRIPTION
I would suggest using `Unlocked* ()` here. `mono_g_hash_table_find_slot ()` is called relatively often and, unlike increment or add operations, read and write operations (without a global surrounding lock) do not gain much (if anything) by being interlocked as long as they can be read and written by one instruction. That should be true for 32-bit integers and Mono's supported platforms.