### PR TITLE
[TSan] Unlock shutting_down in runtime.c

### DIFF
--- a/mono/utils/unlocked.h
+++ b/mono/utils/unlocked.h
@@ -88,6 +88,13 @@ UnlockedWrite64 (gint64 *dest, gint64 val)
 }
 
 MONO_UNLOCKED_ATTRS
+void
+UnlockedWriteBool (gboolean *dest, gboolean val)
+{
+	*dest = val;
+}
+
+MONO_UNLOCKED_ATTRS
 gint32
 UnlockedRead (gint32 *src)
 {
@@ -97,6 +104,13 @@ UnlockedRead (gint32 *src)
 MONO_UNLOCKED_ATTRS
 gint64
 UnlockedRead64 (gint64 *src)
+{
+	return *src;
+}
+
+MONO_UNLOCKED_ATTRS
+gboolean
+UnlockedReadBool (gboolean *src)
 {
 	return *src;
 }


### PR DESCRIPTION
There is no need to interlock this data race, marking it unlocked should suffice. However, I removed the duplicate instruction to set `shutting_down = TRUE` (`mono_runtime_set_shutting_down ()` does exactly that). Once it is `TRUE`, it never gets changed back to `FALSE`.