### PR TITLE
[Mono.Profiler.Log] Support MLPD version 13

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
@@ -174,9 +174,13 @@ namespace Mono.Profiler.Log {
 		PostStartWorld = 9,
 		PostStartWorldUnlocked = 11,
 		// Following are v13 and older only
+		[Obsolete ("This event is no longer produced.")]
 		MarkBegin = 1,
+		[Obsolete ("This event is no longer produced.")]
 		MarkEnd = 2,
+		[Obsolete ("This event is no longer produced.")]
 		ReclaimBegin = 3,
+		[Obsolete ("This event is no longer produced.")]
 		ReclaimEnd = 4
 	}
 

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
@@ -173,6 +173,11 @@ namespace Mono.Profiler.Log {
 		PreStartWorld = 8,
 		PostStartWorld = 9,
 		PostStartWorldUnlocked = 11,
+		// Following are v13 and older only
+		MarkBegin = 1,
+		MarkEnd = 2,
+		ReclaimBegin = 3,
+		ReclaimEnd = 4
 	}
 
 	// mono/metadata/mono-gc.h : MonoGCHandleType

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
@@ -230,13 +230,13 @@ namespace Mono.Profiler.Log {
 					if (load) {
 						ev = new AssemblyLoadEvent {
 							AssemblyPointer = ReadPointer (),
-							ImagePointer = ReadPointer (),
+							ImagePointer = StreamHeader.FormatVersion >= 14 ? ReadPointer () : 0,
 							Name = Reader.ReadCString (),
 						};
 					} else if (unload) {
 						ev = new AssemblyUnloadEvent {
 							AssemblyPointer = ReadPointer (),
-							ImagePointer = ReadPointer (),
+							ImagePointer = StreamHeader.FormatVersion >= 14 ? ReadPointer () : 0,
 							Name = Reader.ReadCString (),
 						};
 					} else
@@ -336,7 +336,7 @@ namespace Mono.Profiler.Log {
 						Type = (LogExceptionClause) Reader.ReadByte (),
 						Index = (long) Reader.ReadULeb128 (),
 						MethodPointer = ReadMethod (),
-						ObjectPointer = ReadObject (),
+						ObjectPointer = StreamHeader.FormatVersion >= 14 ? ReadObject () : 0,
 					};
 					break;
 				default:
@@ -344,11 +344,20 @@ namespace Mono.Profiler.Log {
 				}
 				break;
 			case LogEventType.Monitor:
+				if (StreamHeader.FormatVersion < 14) {
+					if (extType.HasFlag (LogEventType.MonitorBacktrace)) {
+						extType = LogEventType.MonitorBacktrace;
+					} else {
+						extType = LogEventType.MonitorNoBacktrace;
+					}
+				}
 				switch (extType) {
 				case LogEventType.MonitorNoBacktrace:
 				case LogEventType.MonitorBacktrace:
 					ev = new MonitorEvent {
-						Event = (LogMonitorEvent) Reader.ReadByte (),
+						Event = StreamHeader.FormatVersion >= 14 ?
+						                    (LogMonitorEvent) Reader.ReadByte () :
+						                    (LogMonitorEvent) ((((byte) type & 0xf0) >> 4) & 0x3),
 						ObjectPointer = ReadObject (),
 						Backtrace = ReadBacktrace (extType == LogEventType.MonitorBacktrace),
 					};
@@ -397,7 +406,7 @@ namespace Mono.Profiler.Log {
 					for (var i = 0; i < list.Length; i++) {
 						list [i] = new HeapRootsEvent.HeapRoot {
 							ObjectPointer = ReadObject (),
-							Attributes = (LogHeapRootAttributes) Reader.ReadULeb128 (),
+							Attributes = StreamHeader.FormatVersion == 13 ? (LogHeapRootAttributes) Reader.ReadByte () : (LogHeapRootAttributes) Reader.ReadULeb128 (),
 							ExtraInfo = (long) Reader.ReadULeb128 (),
 						};
 					}
@@ -414,9 +423,13 @@ namespace Mono.Profiler.Log {
 			case LogEventType.Sample:
 				switch (extType) {
 				case LogEventType.SampleHit:
+					if (StreamHeader.FormatVersion < 14) {
+						// Read SampleType (always set to .Cycles) for versions < 14
+						Reader.ReadByte ();
+					}
 					ev = new SampleHitEvent {
 						ThreadId = ReadPointer (),
-						UnmanagedBacktrace = ReadBacktrace (true, false),
+						UnmanagedBacktrace = ReadBacktrace (true, false), // FIXME: isn't this reversed?
 						ManagedBacktrace = ReadBacktrace (true),
 					};
 					break;
@@ -429,7 +442,7 @@ namespace Mono.Profiler.Log {
 					break;
 				case LogEventType.SampleUnmanagedBinary:
 					ev = new UnmanagedBinaryEvent {
-						SegmentPointer = ReadPointer (),
+						SegmentPointer = StreamHeader.FormatVersion >= 14 ? ReadPointer () : Reader.ReadSLeb128 (),
 						SegmentOffset = (long) Reader.ReadULeb128 (),
 						SegmentSize = (long) Reader.ReadULeb128 (),
 						FileName = Reader.ReadCString (),

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
@@ -429,8 +429,8 @@ namespace Mono.Profiler.Log {
 					}
 					ev = new SampleHitEvent {
 						ThreadId = ReadPointer (),
-						UnmanagedBacktrace = ReadBacktrace (true, false), // FIXME: isn't this reversed?
-						ManagedBacktrace = ReadBacktrace (true),
+						UnmanagedBacktrace = ReadBacktrace (true, false),
+						ManagedBacktrace = ReadBacktrace (true).Reverse ().ToArray (),
 					};
 					break;
 				case LogEventType.SampleUnmanagedSymbol:

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogStreamHeader.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogStreamHeader.cs
@@ -7,8 +7,9 @@ using System;
 namespace Mono.Profiler.Log {
 
 	public sealed class LogStreamHeader {
-		const int MinimumMLPDSupportedVersion = 13;
-		const int MaximumMLPDSupportedVersion = 14;
+		
+		const int MinVersion = 13;
+		const int MaxVersion = 14;
 
 		const int Id = 0x4d505a01;
 
@@ -44,8 +45,8 @@ namespace Mono.Profiler.Log {
 			Version = new Version (reader.ReadByte (), reader.ReadByte ());
 			FormatVersion = reader.ReadByte ();
 
-			if (FormatVersion < MinimumMLPDSupportedVersion || FormatVersion > MaximumMLPDSupportedVersion)
-				throw new LogException ($"Unsupported MLPD version {FormatVersion}. Should be >= {MinimumMLPDSupportedVersion} and <= {MaximumMLPDSupportedVersion}");
+			if (FormatVersion < MinVersion || FormatVersion > MaxVersion)
+				throw new LogException ($"Unsupported MLPD version {FormatVersion}. Should be >= {MinVersion} and <= {MaxVersion}.");
 			
 			PointerSize = reader.ReadByte ();
 			StartupTime = reader.ReadUInt64 ();

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogStreamHeader.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogStreamHeader.cs
@@ -7,6 +7,8 @@ using System;
 namespace Mono.Profiler.Log {
 
 	public sealed class LogStreamHeader {
+		const int MinimumMLPDSupportedVersion = 13;
+		const int MaximumMLPDSupportedVersion = 14;
 
 		const int Id = 0x4d505a01;
 
@@ -41,6 +43,10 @@ namespace Mono.Profiler.Log {
 
 			Version = new Version (reader.ReadByte (), reader.ReadByte ());
 			FormatVersion = reader.ReadByte ();
+
+			if (FormatVersion < MinimumMLPDSupportedVersion || FormatVersion > MaximumMLPDSupportedVersion)
+				throw new LogException ($"Unsupported MLPD version {FormatVersion}. Should be >= {MinimumMLPDSupportedVersion} and <= {MaximumMLPDSupportedVersion}");
+			
 			PointerSize = reader.ReadByte ();
 			StartupTime = reader.ReadUInt64 ();
 			TimerOverhead = reader.ReadInt32 ();


### PR DESCRIPTION
The differences from v14 are small, and given it is the current "stable"
MLPD version, it's worth supporting it. The differences are:

* ImagePointer field not present in v13 Assembly*Event's
* In MonitorEvent, LogMonitorEvent is not in a separate field, but included
  as a flag in the extType field.
* SampleHitEvent's have a type field in v13, which was removed in v14, because
  only cycles samples are emitted.
* MONO_GC_EVENT_{MARK,RECLAIM}_{START,END} were removed in v14
* SampleUnmanagedBinary's SegmentPointer is not based on ptr_base in v13

