### PR TITLE
[threads] Fix "[threads] Fix leaking threads: SGen Worker and Finalizer (#5284)"

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -995,7 +995,7 @@ mono_gc_cleanup (void)
 					ret = guarded_wait (gc_thread->handle, MONO_INFINITE_WAIT, FALSE);
 					g_assert (ret == MONO_THREAD_INFO_WAIT_RET_SUCCESS_0);
 
-					mono_thread_join (GUINT_TO_POINTER (gc_thread->tid));
+					mono_threads_add_joinable_thread (GUINT_TO_POINTER (gc_thread->tid));
 					break;
 				}
 
@@ -1020,7 +1020,7 @@ mono_gc_cleanup (void)
 
 					g_assert (ret == MONO_THREAD_INFO_WAIT_RET_SUCCESS_0);
 
-					mono_thread_join (GUINT_TO_POINTER (gc_thread->tid));
+					mono_threads_add_joinable_thread (GUINT_TO_POINTER (gc_thread->tid));
 					break;
 				}
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -973,11 +973,6 @@ mono_gc_cleanup (void)
 		return;
 
 	if (!gc_disabled) {
-
-		/* Stop all worker threads before signalling the finalizer to stop
-		 * That way the finalizer has a chance to clean up the worker threads */
-		mono_gc_base_cleanup ();
-
 		finished = TRUE;
 		if (mono_thread_internal_current () != gc_thread) {
 			int ret;
@@ -1000,8 +995,7 @@ mono_gc_cleanup (void)
 					ret = guarded_wait (gc_thread->handle, MONO_INFINITE_WAIT, FALSE);
 					g_assert (ret == MONO_THREAD_INFO_WAIT_RET_SUCCESS_0);
 
-					/* Clean up the finalizer (and other threads that might still wait to be joined) */
-					mono_threads_join_threads ();
+					mono_thread_join (GUINT_TO_POINTER (gc_thread->tid));
 					break;
 				}
 
@@ -1026,8 +1020,7 @@ mono_gc_cleanup (void)
 
 					g_assert (ret == MONO_THREAD_INFO_WAIT_RET_SUCCESS_0);
 
-					/* Clean up the finalizer (and other threads that might still wait to be joined) */
-					mono_threads_join_threads ();
+					mono_thread_join (GUINT_TO_POINTER (gc_thread->tid));
 					break;
 				}
 
@@ -1038,6 +1031,7 @@ mono_gc_cleanup (void)
 			}
 		}
 		gc_thread = NULL;
+		mono_gc_base_cleanup ();
 	}
 
 	mono_reference_queue_cleanup ();

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3037,6 +3037,8 @@ mono_thread_callbacks_init (void)
 void
 mono_thread_cleanup (void)
 {
+	mono_threads_join_threads ();
+
 #if !defined(RUN_IN_SUBTHREAD) && !defined(HOST_WIN32)
 	/* The main thread must abandon any held mutexes (particularly
 	 * important for named mutexes as they are shared across

--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -305,6 +305,10 @@ sgen_thread_pool_shutdown (void)
 	mono_os_mutex_destroy (&lock);
 	mono_os_cond_destroy (&work_cond);
 	mono_os_cond_destroy (&done_cond);
+
+	for (int i = 0; i < threads_num; i++) {
+		mono_threads_add_joinable_thread ((gpointer)threads [i]);
+	}
 }
 
 SgenThreadPoolJob*

--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -305,10 +305,6 @@ sgen_thread_pool_shutdown (void)
 	mono_os_mutex_destroy (&lock);
 	mono_os_cond_destroy (&work_cond);
 	mono_os_cond_destroy (&done_cond);
-
-	for (int i = 0; i < threads_num; i++) {
-		mono_threads_add_joinable_thread ((gpointer)threads [i]);
-	}
 }
 
 SgenThreadPoolJob*


### PR DESCRIPTION
The sgen-specific cleanup cannot be run before the sgen-agnostic cleanup