### PR TITLE
[F#] Reinstate _DebugFileExt as it's needed for mobile debugging.

### DIFF
--- a/packaging/MacSDK/patches/fsharp-portable-pdb.patch
+++ b/packaging/MacSDK/patches/fsharp-portable-pdb.patch
@@ -2,7 +2,7 @@ diff --git a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets b/src/fsharp/FShar
 index 34d716485..ec99e87ed 100644
 --- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
 +++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
-@@ -41,6 +41,16 @@ this file.
+@@ -41,6 +41,21 @@ this file.
          <RootNamespace Condition="'$(RootNamespace)'==''">RootNamespace</RootNamespace>
          <Actual32Bit Condition="'$(TargetFrameworkVersion)'=='v2.0' or '$(TargetFrameworkVersion)'=='v3.0' or '$(TargetFrameworkVersion)'=='v3.5' or '$(TargetFrameworkVersion)'=='v4.0'">false</Actual32Bit>
          <Actual32Bit Condition="!('$(TargetFrameworkVersion)'=='v2.0' or '$(TargetFrameworkVersion)'=='v3.0' or '$(TargetFrameworkVersion)'=='v3.5' or '$(TargetFrameworkVersion)'=='v4.0')">$(Prefer32Bit)</Actual32Bit>
@@ -15,7 +15,12 @@ index 34d716485..ec99e87ed 100644
 +        <_ConfigurationNameTmp>$(ConfigurationName)</_ConfigurationNameTmp>
 +        <_ConfigurationNameTmp Condition="'$(ConfigurationName)' == ''">$(Configuration)</_ConfigurationNameTmp>
 +
++        <!-- _DebugFileExt is not an upstream msbuild feature yet -->
++        <_DebugFileExt>.pdb</_DebugFileExt>
++        <_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
++
 +        <DebugType Condition="'$(OS)' != 'Windows_NT' And ('$(DebugSymbols)'=='True' or ('$(DebugSymbols)'=='' And '$(_ConfigurationNameTmp)'=='Debug'))">portable</DebugType>
++        <DebugType Condition="'$(FscDebugType)' != ''">$(FscDebugType)</DebugType>
      </PropertyGroup>
  
      <!--


### PR DESCRIPTION
Also added a mechanism for users to override DebugType