### PR TITLE
[threads] Check if thread ids are != NULL (0)

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -4999,6 +4999,11 @@ mono_threads_add_joinable_thread (gpointer tid)
 	 * 2fd16f60/r114307. So we collect them and join them when
 	 * we have time (in he finalizer thread).
 	 */
+	if (tid == NULL) {
+		g_warning ("Invalid thread: %p", tid);
+		return;
+	}
+
 	joinable_threads_lock ();
 	if (!joinable_threads)
 		joinable_threads = g_hash_table_new (NULL, NULL);


### PR DESCRIPTION
I would like to propose this fix to avoid https://bugzilla.xamarin.com/show_bug.cgi?id=59371 and similar issues in the future. It only targets a part of the whole issue but I think it's really important to have these checks; independent of how [#59371](https://bugzilla.xamarin.com/show_bug.cgi?id=59371) is being fixed.