### PR TITLE
[runtime] Use no-op for SufficientExecutionStack on Linux

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1014,7 +1014,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStac
 {
 #if defined(TARGET_WIN32) || defined(HOST_WIN32)
 	// It does not work on win32
-#elif defined(TARGET_ANDROID)
+#elif defined(TARGET_ANDROID) || defined(__linux__)
 	// No need for now
 #else
 	guint8 *stack_addr;


### PR DESCRIPTION
We had previously responded to bad performance on android by stubbing out
ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStack
on android. This was necessary because the call to pthread_attr_getstack ()
will read /proc/self/maps. When used inside of a hot function, the performance is terrible.