### PR TITLE
Fix bug 57918

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -1902,7 +1902,7 @@ m_Handle, buffer, offset + sent, size - sent, socketFlags, out nativeError, is_b
 				sockares.Size -= total;
 
 				if (sockares.socket.CleanedUp) {
-					sockares.Complete (total);
+					sockares.Complete (sent_so_far);
 					return;
 				}
 
@@ -1914,7 +1914,7 @@ m_Handle, buffer, offset + sent, size - sent, socketFlags, out nativeError, is_b
 				sockares.Total = sent_so_far;
 			}
 
-			sockares.Complete (total);
+			sockares.Complete (sent_so_far);
 		}
 
 		[CLSCompliant (false)]


### PR DESCRIPTION
Fix for issue where async Socket reads that need to perform multiple underlying read operations fail to return a correct total # of bytes read.

https://bugzilla.xamarin.com/show_bug.cgi?id=57918

I'm not sure there's a straightforward way to write a test for this, because loopback sockets don't behave the same way. The repro steps from the bug work consistently for me (on Windows you need to use the netcat implementation from nmap).