### PR TITLE
[2017-08][profiler] Revert the root_type field back to uleb128.

### DIFF
--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -1219,7 +1219,7 @@ gc_roots (MonoProfiler *prof, MonoObject *const *objects, const MonoProfilerGCRo
 
 	for (int i = 0; i < num; ++i) {
 		emit_obj (logbuffer, objects [i]);
-		emit_byte (logbuffer, root_types [i]);
+		emit_value (logbuffer, root_types [i]);
 		emit_value (logbuffer, extra_info [i]);
 	}
 

--- a/mono/profiler/log.h
+++ b/mono/profiler/log.h
@@ -70,6 +70,7 @@
                class unload events no longer exist (they were never emitted)
                removed type field from TYPE_SAMPLE_HIT
                removed MONO_GC_EVENT_{MARK,RECLAIM}_{START,END}
+               reverted the root_type field back to uleb128
  */
 
 /*
@@ -265,7 +266,7 @@
  * 	[num_roots: uleb128] number of root references
  * 	[num_gc: uleb128] number of major gcs
  * 	[object: sleb128] the object as a difference from obj_base
- * 	[root_type: byte] the root_type: MonoProfileGCRootType (profiler.h)
+ * 	[root_type: uleb128] the root_type: MonoProfileGCRootType (profiler.h)
  * 	[extra_info: uleb128] the extra_info value
  * 	object, root_type and extra_info are repeated num_roots times
  *

--- a/mono/profiler/mprof-report.c
+++ b/mono/profiler/mprof-report.c
@@ -2703,7 +2703,7 @@ decode_buffer (ProfContext *ctx)
 				for (i = 0; i < num; ++i) {
 					intptr_t objdiff = decode_sleb128 (p, &p);
 					int root_type;
-					if (ctx->data_version > 12)
+					if (ctx->data_version == 13)
 						root_type = *p++;
 					else
 						root_type = decode_uleb128 (p, &p);


### PR DESCRIPTION
It's actually a 32-bit value.