### PR TITLE
[System]: SslStream.Flush() now flushes the underlying stream.  Bug #57528.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/IMonoSslStream.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/IMonoSslStream.cs
@@ -71,8 +71,6 @@ namespace Mono.Security.Interface
 
 		Task AuthenticateAsServerAsync (X509Certificate serverCertificate, bool clientCertificateRequired, SSA.SslProtocols enabledSslProtocols, bool checkCertificateRevocation);
 
-		void Flush ();
-
 		int Read (byte[] buffer, int offset, int count);
 
 		void Write (byte[] buffer);

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -707,7 +707,7 @@ namespace Mono.Net.Security
 
 		public override void Flush ()
 		{
-			// Write() automatically flushes the underlying stream.
+			InnerStream.Flush ();
 		}
 
 		public SslProtocols SslProtocol {

--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -293,15 +293,15 @@ namespace System.Net.Security
 		}
 
 		public override bool CanRead {
-			get { return Impl.CanRead; }
+			get { return impl != null && impl.CanRead; }
 		}
 
 		public override bool CanTimeout {
-			get { return Impl.CanTimeout; }
+			get { return InnerStream.CanTimeout; }
 		}
 
 		public override bool CanWrite {
-			get { return Impl.CanWrite; }
+			get { return impl != null && impl.CanWrite; }
 		}
 
 		public override int ReadTimeout {
@@ -337,7 +337,7 @@ namespace System.Net.Security
 
 		public override void Flush ()
 		{
-			Impl.Flush ();
+			InnerStream.Flush ();
 		}
 
 		void CheckDisposed ()


### PR DESCRIPTION

* Mono.Security.Interface.IMonoSslStream: removed Flush().

* Mono.Net.Security.MobileAuthenticatedStream: Flush() now calls `InnerStream.Flush ()'.

* System.Net.Security.SslStream: Flush() now calls `InnerStream.Flush ()'.

* System.Net.Security.SslStream: fix `CanRead`, `CanWrite` and `CanTimeout` logic.