### PR TITLE
Fix sporadic failures in MonoTests.System.Net.HttpRequestStreamTest on x64 Windows.

### DIFF
--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -208,7 +208,7 @@ mono_w32socket_close (SOCKET sock)
 {
 	gboolean ret;
 	MONO_ENTER_GC_SAFE;
-	ret = CloseHandle (sock);
+	ret = closesocket (sock);
 	MONO_EXIT_GC_SAFE;
 	return ret;
 }

--- a/mono/metadata/w32socket.h
+++ b/mono/metadata/w32socket.h
@@ -16,10 +16,10 @@
 
 #include <mono/metadata/object-internals.h>
 
+#ifndef HOST_WIN32
 #define INVALID_SOCKET ((SOCKET)(guint32)(~0))
 #define SOCKET_ERROR (-1)
 
-#ifndef HOST_WIN32
 typedef gint SOCKET;
 
 typedef struct {

--- a/msvc/libmonoruntime.vcxproj.filters
+++ b/msvc/libmonoruntime.vcxproj.filters
@@ -576,6 +576,9 @@
     <ClInclude Include="..\mono\metadata\cominterop-win32-internals.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\mono\metadata\appdomain-icalls.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">

--- a/msvc/libmonoutils.vcxproj.filters
+++ b/msvc/libmonoutils.vcxproj.filters
@@ -130,13 +130,7 @@
     <ClCompile Include="..\mono\utils\mono-threads-mach.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\mono\utils\mono-threads-mach-abort-syscall.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\mono\utils\mono-threads-posix.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mono\utils\mono-threads-posix-abort-syscall.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\mono\utils\mono-threads-posix-signals.c">
@@ -146,9 +140,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\mono\utils\mono-threads-windows.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mono\utils\mono-threads-windows-abort-syscall.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\mono\utils\mono-time.c">
@@ -197,6 +188,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\mono\utils\os-event-win32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\utils\mono-os-mutex.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -382,9 +376,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\mono\utils\mono-threads-coop.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\mono\utils\mono-threads-posix-signals.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\mono\utils\mono-time.h">


### PR DESCRIPTION
MonoTests.System.Net.HttpRequestStreamTest suite has sporadic failures on Windows x64 with following exception:

System.Net.Sockets.SocketException : An operation was attempted on something that is not a socket.

This happens due to a data type and constant size mismatch. w32socket.h defines INVALID_SOCKET and SOCKET_ERROR for all platforms. On Windows x64, SOCKET is defined by winsock2.h as 64-bit type as well as INVALID_SOCKET constant, but above code will define INVALID_SOCKET as a 32-bit constant value. This will in turn cause code to sporadically fail to detect invalid sockets as returned by win32 API's. This will in turn cause the socket exception when code continues to use socket as argument to win32 socket API’s.

Current “invalid” x64 codegen for expression:

if (sock == INVALID_SOCKET)

mov         eax,0FFFFFFFFh
cmp         rsi,rax

and with fixed defines, correct 64-bit cmp instruction:

cmp         rsi,0FFFFFFFFFFFFFFFFh

Fix makes sure we get the defines of INVALID_SOCKET and SOCKET_ERROR from winsock2.h on Windows platforms to be consistent with define of SOCKET type.

While working on repro of the above error I also trapped another problem in the debugger that trigger the second commit in this PR:

Invalid handle exception during WSACleanup on shutdown.

Running the  MonoTests.System.Net.HttpRequestStreamTest under debugger reveals this problem. WSACleanup is freeing an invalid handle as part of network shutdown.

This happens since mono_w32socket_close calls incorrect win32 API when closing sockets. It currently calls CloseHandle, while it should call closesocket. This probably cause problems in winsock book keeping of active sockets, and when closing the network layer, winsock will try to close handles that it still thinks are open, but since the handles have already been closed by incorrect call to CloseHandle, it will close an “invalid handle” either causing the exception or even worse, close a different handle currently in use, causing undefined behavior during the rest of mono shutdown.

Fix is to switch to correct API when closing sockets on Windows, closesocket instead of CloseHandle.

Last commit is just adding some new files into correct filter folders in Visual Studio project, piggy backed into this PR.