### PR TITLE
[profiler] Clear events for all profilers on profiler shutdown. [2017-06]

### DIFF
--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -897,7 +897,10 @@ mono_profiler_shutdown (void)
 			prof->shutdown_callback (prof->profiler);
 	}
 
-	mono_profiler_set_events ((MonoProfileFlags)0);
+	/* Clear all events */
+	for (prof = prof_list; prof; prof = prof->next)
+		prof->events = (MonoProfileFlags)0;
+	mono_profiler_events = (MonoProfileFlags)0;
 }
 
 /**


### PR DESCRIPTION
…ously only the profiler which was added last had its events cleared. Fixes #59274.