### PR TITLE
[WIP][corlib] Fix 44255: Inconsistent results in the serialization of TimeZoneInfo. 

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.Serialization.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.Serialization.cs
@@ -42,12 +42,14 @@ namespace System
 			var displayName = DeserializeString (ref input);
 			var standardName = DeserializeString (ref input);
 			var daylightName = DeserializeString (ref input);
-			var rules = new List<TimeZoneInfo.AdjustmentRule> ();
+			List<TimeZoneInfo.AdjustmentRule> rules = null;
 			while (input [0] != ';') {
+				if (rules == null)
+					rules = new List<TimeZoneInfo.AdjustmentRule>();
 				rules.Add (DeserializeAdjustmentRule (ref input));
 			}
 			var offsetSpan = TimeSpan.FromMinutes (offset);
-			return TimeZoneInfo.CreateCustomTimeZone (tzId, offsetSpan, displayName, standardName, daylightName, rules.ToArray ());
+			return TimeZoneInfo.CreateCustomTimeZone (tzId, offsetSpan, displayName, standardName, daylightName, rules?.ToArray ());
 		}
 
 		public string ToSerializedString ()

--- a/mcs/class/corlib/System/TimeZoneInfo.Serialization.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.Serialization.cs
@@ -45,7 +45,7 @@ namespace System
 			List<TimeZoneInfo.AdjustmentRule> rules = null;
 			while (input [0] != ';') {
 				if (rules == null)
-					rules = new List<TimeZoneInfo.AdjustmentRule>();
+					rules = new List<TimeZoneInfo.AdjustmentRule> ();
 				rules.Add (DeserializeAdjustmentRule (ref input));
 			}
 			var offsetSpan = TimeSpan.FromMinutes (offset);

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -624,7 +624,7 @@ namespace System
 			else
 				ParseRegTzi(adjustmentRules, 1, 9999, reg_tzi);
 
-			return CreateCustomTimeZone (id, baseUtcOffset, display_name, standard_name, daylight_name, ValidateRules (adjustmentRules).ToArray ());
+			return CreateCustomTimeZone (id, baseUtcOffset, display_name, standard_name, daylight_name, ValidateRules (adjustmentRules));
 		}
 
 		private static void ParseRegTzi (List<AdjustmentRule> adjustmentRules, int start_year, int end_year, byte [] buffer)
@@ -1231,8 +1231,11 @@ namespace System
 			return new DateTime (year, transition.Month, day) + transition.TimeOfDay.TimeOfDay;
 		}
 
-		static List<AdjustmentRule> ValidateRules (List<AdjustmentRule> adjustmentRules)
+		static AdjustmentRule[] ValidateRules (List<AdjustmentRule> adjustmentRules)
 		{
+			if (adjustmentRules == null || adjustmentRules.Count == 0)
+				return null;
+
 			AdjustmentRule prev = null;
 			foreach (AdjustmentRule current in adjustmentRules.ToArray ()) {
 				if (prev != null && prev.DateEnd > current.DateStart) {
@@ -1240,7 +1243,7 @@ namespace System
 				}
 				prev = current;
 			}
-			return adjustmentRules;
+			return adjustmentRules.ToArray();
 		}
 
 #if LIBC || MONOTOUCH
@@ -1404,8 +1407,7 @@ namespace System
 				}
 				tz = CreateCustomTimeZone (id, baseUtcOffset, id, standardDisplayName);
 			} else {
-				var rules = adjustmentRules.Count == 0 ? null : ValidateRules (adjustmentRules).ToArray ();
-				tz = CreateCustomTimeZone (id, baseUtcOffset, id, standardDisplayName, daylightDisplayName, rules);
+				tz = CreateCustomTimeZone (id, baseUtcOffset, id, standardDisplayName, daylightDisplayName, ValidateRules (adjustmentRules));
 			}
 
 			if (storeTransition && transitions.Count > 0) {

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1404,7 +1404,8 @@ namespace System
 				}
 				tz = CreateCustomTimeZone (id, baseUtcOffset, id, standardDisplayName);
 			} else {
-				tz = CreateCustomTimeZone (id, baseUtcOffset, id, standardDisplayName, daylightDisplayName, ValidateRules (adjustmentRules).ToArray ());
+				var rules = adjustmentRules.Count == 0 ? null : ValidateRules (adjustmentRules).ToArray ();
+				tz = CreateCustomTimeZone (id, baseUtcOffset, id, standardDisplayName, daylightDisplayName, rules);
 			}
 
 			if (storeTransition && transitions.Count > 0) {

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1412,8 +1412,8 @@ namespace System
 
 			if (storeTransition && transitions.Count > 0) {
 				tz.transitions = transitions;
-				tz.supportsDaylightSavingTime = true;
 			}
+			tz.supportsDaylightSavingTime = adjustmentRules.Count > 0;
 
 			return tz;
 		}

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -1243,7 +1243,7 @@ namespace System
 				}
 				prev = current;
 			}
-			return adjustmentRules.ToArray();
+			return adjustmentRules.ToArray ();
 		}
 
 #if LIBC || MONOTOUCH

--- a/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
@@ -24,6 +24,16 @@ namespace MonoTests.System
 			Assert.AreEqual (0, utc.GetAdjustmentRules ().Length);
 		}
 
+		[Test] // Bug-44255
+		public void SystemTimeZoneSerializationTests ()
+		{
+            foreach (var tmz in TimeZoneInfo.GetSystemTimeZones())
+            {
+                var tmzClone = TimeZoneInfo.FromSerializedString(tmz.ToSerializedString());
+				Assert.AreEqual(tmz, tmzClone);
+            }
+		}
+
 		[Test]
 		public void SerializeCustomUtcZoneWithOddNaming ()
 		{

--- a/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
@@ -28,10 +28,14 @@ namespace MonoTests.System
 		[Test] // Bug-44255
 		public void SystemTimeZoneSerializationTests ()
 		{
-			foreach (var tmz in TimeZoneInfo.GetSystemTimeZones())
+			foreach (var tmz in TimeZoneInfo.GetSystemTimeZones ())
 			{
-				var tmzClone = TimeZoneInfo.FromSerializedString(tmz.ToSerializedString());
-				Assert.AreEqual(tmz, tmzClone);
+				var tmzClone = TimeZoneInfo.FromSerializedString (tmz.ToSerializedString ());
+				Assert.AreEqual (tmz, tmzClone);
+				Assert.AreEqual (tmz.DisplayName, tmzClone.DisplayName);
+				Assert.AreEqual (tmz.StandardName, tmzClone.StandardName);
+				Assert.AreEqual (tmz.SupportsDaylightSavingTime, tmzClone.SupportsDaylightSavingTime);
+				Assert.AreEqual (tmz.DaylightName, tmzClone.DaylightName);
 			}
 		}
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
@@ -27,11 +27,11 @@ namespace MonoTests.System
 		[Test] // Bug-44255
 		public void SystemTimeZoneSerializationTests ()
 		{
-            foreach (var tmz in TimeZoneInfo.GetSystemTimeZones())
-            {
-                var tmzClone = TimeZoneInfo.FromSerializedString(tmz.ToSerializedString());
+			foreach (var tmz in TimeZoneInfo.GetSystemTimeZones())
+			{
+				var tmzClone = TimeZoneInfo.FromSerializedString(tmz.ToSerializedString());
 				Assert.AreEqual(tmz, tmzClone);
-            }
+			}
 		}
 
 		[Test]

--- a/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfo.SerializationTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 
 namespace MonoTests.System


### PR DESCRIPTION
Inner field `adjustedRules` should be null when empty (.NET's behavior).
It fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44255 however still not all of the internal fields are equal after Serialize+Deserialize+Compare. Those fields are not involved in `Equals` but it doesn't sound good.