### PR TITLE
[SWF] Allow to compile without X11 installed (Xamarin-59496)

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.Layout/TableLayoutSettingsTypeConverter.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.Layout/TableLayoutSettingsTypeConverter.cs
@@ -118,7 +118,7 @@ namespace System.Windows.Forms.Layout
 
 			XmlDocument xmldoc = new XmlDocument();
 			xmldoc.LoadXml (value as string);
-			TableLayoutSettings settings = new TableLayoutSettings(new TableLayoutPanel());
+			TableLayoutSettings settings = new TableLayoutSettings(null);
 			int count = ParseControl (xmldoc, settings);
 			ParseColumnStyle (xmldoc, settings);
 			ParseRowStyle (xmldoc, settings);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TableLayoutStyleCollection.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TableLayoutStyleCollection.cs
@@ -38,9 +38,6 @@ namespace System.Windows.Forms {
 		
 		internal TableLayoutStyleCollection (TableLayoutPanel table)
 		{
-			if (table == null)
-				throw new ArgumentNullException("table");
-			
 			this.table = table;
 		}
 		
@@ -54,7 +51,8 @@ namespace System.Windows.Forms {
 			foreach (TableLayoutStyle style in al)
 				style.Owner = null;
 			al.Clear ();
-			table.PerformLayout ();
+			if (table != null)
+				table.PerformLayout ();
 		}
 		
 		public int Count {
@@ -65,7 +63,8 @@ namespace System.Windows.Forms {
 		{
 			((TableLayoutStyle)al[index]).Owner = null;
 			al.RemoveAt (index);
-			table.PerformLayout ();
+			if (table != null)
+				table.PerformLayout ();
 		}
 		
 #region IList methods
@@ -103,14 +102,16 @@ namespace System.Windows.Forms {
 				throw new ArgumentException ("Style is already owned");
 			((TableLayoutStyle)style).Owner = table;
 			al.Insert (index, (TableLayoutStyle) style);
-			table.PerformLayout ();
+			if (table != null)
+				table.PerformLayout ();
 		}
 
 		void IList.Remove (object style)
 		{
 			((TableLayoutStyle)style).Owner = null;
 			al.Remove ((TableLayoutStyle) style);
-			table.PerformLayout ();
+			if (table != null)
+				table.PerformLayout ();
 		}
 
 		bool IList.IsFixedSize {
@@ -134,7 +135,8 @@ namespace System.Windows.Forms {
 					throw new ArgumentException ("Style is already owned");
 				((TableLayoutStyle)value).Owner = table;
 				al [index] = value;
-				table.PerformLayout ();
+				if (table != null)
+					table.PerformLayout ();
 			}
 		}
 #endregion


### PR DESCRIPTION
This change fixes a crash we get in resgen when building without
X11 installed. The bug got introduced when fixing Xamarin-395.