### PR TITLE
[corlib] Fix 38054: CspProviderFlags.UseNonExportableKey doesn't prevent private key from being retreived

### DIFF
--- a/mcs/class/corlib/System.Security.Cryptography/DSACryptoServiceProvider.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/DSACryptoServiceProvider.cs
@@ -114,6 +114,7 @@ namespace System.Security.Cryptography {
 				persisted = true;
 				this.FromXmlString (store.KeyValue);
 			}
+			privateKeyExportable = (parameters.Flags & CspProviderFlags.UseNonExportableKey) == 0;
 		}
 
 		~DSACryptoServiceProvider ()

--- a/mcs/class/corlib/System.Security.Cryptography/RSACryptoServiceProvider.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/RSACryptoServiceProvider.cs
@@ -111,6 +111,7 @@ namespace System.Security.Cryptography {
 			store = new KeyPairPersistence (p);
 			bool exists = store.Load ();
 			bool required = (p.Flags & CspProviderFlags.UseExistingKey) != 0;
+			privateKeyExportable = (p.Flags & CspProviderFlags.UseNonExportableKey) == 0;
 
 			if (required && !exists)
 				throw new CryptographicException ("Keyset does not exist");

--- a/mcs/class/corlib/Test/System.Security.Cryptography/DSACryptoServiceProviderTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/DSACryptoServiceProviderTest.cs
@@ -1046,6 +1046,16 @@ public class DSACryptoServiceProviderTest {
 		dsa = new DSACryptoServiceProvider (minKeySize);
 		dsa.ImportCspBlob (blob);
 	}
+
+	[Test] //bug 38054
+	public void NonExportableKeysAreNonExportable ()
+	{
+		var cspParams = new CspParameters (13, null, "Mono1024");
+		cspParams.KeyContainerName = "TestDSAKey";
+		cspParams.Flags = CspProviderFlags.UseNonExportableKey;
+		var rsa = new DSACryptoServiceProvider(cspParams);
+		Assert.Throws<CryptographicException>(() => rsa.ExportParameters(true));
+	}
 }
 
 }

--- a/mcs/class/corlib/Test/System.Security.Cryptography/RSACryptoServiceProviderTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/RSACryptoServiceProviderTest.cs
@@ -1403,6 +1403,16 @@ public class RSACryptoServiceProviderTest {
 		rsa = new RSACryptoServiceProvider (minKeySize);
 		rsa.ImportCspBlob (blob);
 	}
+
+	[Test] //bug 38054
+	public void NonExportableKeysAreNonExportable ()
+	{
+		var cspParams = new CspParameters();
+		cspParams.KeyContainerName = "TestRSAKey";
+		cspParams.Flags = CspProviderFlags.UseNonExportableKey;
+		var rsa = new RSACryptoServiceProvider(cspParams);
+		Assert.Throws<CryptographicException>(() => rsa.ExportParameters(true));
+	}
 }
 
 }


### PR DESCRIPTION
privateKeyExportable field was never assigned.
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=38054