### PR TITLE
[seq points] emit more seq points with `--debug` when no symbols are available

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11382,6 +11382,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (sp [-1]->type != STACK_OBJ)
 				UNVERIFIED;
 
+			if (seq_points && !sym_seq_points && mono_debug_enabled ())
+				emit_seq_point (cfg, method, ip, FALSE, TRUE);
+
 			MONO_INST_NEW (cfg, ins, OP_THROW);
 			--sp;
 			ins->sreg1 = sp [0]->dreg;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6382,8 +6382,10 @@ get_basic_blocks (MonoCompile *cfg, MonoMethodHeader* header, guint real_offset,
 				bblock = cfg->cil_offset_to_bb [(bb_start) - start];
 				bb_start --;
 			}
+#if 0
 			if (bblock)
 				bblock->out_of_line = 1;
+#endif
 		}
 	}
 	return 0;
@@ -8466,10 +8468,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			//g_assert (!virtual_ || fsig->hasthis);
 
 			sp -= n;
-
+#if 0
 			if (cmethod && cmethod->klass->image == mono_defaults.corlib && !strcmp (cmethod->klass->name, "ThrowHelper"))
 				cfg->cbb->out_of_line = TRUE;
-
+#endif
 			/*
 			 * We have the `constrained.' prefix opcode.
 			 */
@@ -11389,7 +11391,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			--sp;
 			ins->sreg1 = sp [0]->dreg;
 			ip++;
+#if 0
 			cfg->cbb->out_of_line = TRUE;
+#endif
 			MONO_ADD_INS (cfg->cbb, ins);
 			MONO_INST_NEW (cfg, ins, OP_NOT_REACHED);
 			MONO_ADD_INS (cfg->cbb, ins);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -15,6 +15,7 @@ check-local:
 	$(MAKE) test-appdomain-unload || ok=false; \
 	$(MAKE) test-process-stress || ok=false; \
 	$(MAKE) test-pedump || ok=false; \
+	$(MAKE) test-il-offsets || ok=false; \
 	$(MAKE) test-internalsvisibleto || ok=false; \
 	$(MAKE) rm-empty-logs || ok=false; \
 	$(MAKE) runtest-gac-loading || ok=false; \
@@ -1795,6 +1796,13 @@ bug-324535.exe bug-324535-il.dll: $(srcdir)/bug-324535.cs $(srcdir)/bug-324535-i
 	$(ILASM) /dll /output:bug-324535-il.dll $(srcdir)/bug-324535-il.il
 	$(MCS) -r:bug-324535-il.dll -out:bug-324535.exe $(srcdir)/bug-324535.cs
 
+EXTRA_DIST += bug-43095-il.il bug-43095.cs
+
+bug-43095.exe$(PLATFORM_AOT_SUFFIX): bug-43095-il.dll$(PLATFORM_AOT_SUFFIX)
+bug-43095.exe bug-43095-il.dll: $(srcdir)/bug-43095.cs $(srcdir)/bug-43095-il.il
+	$(ILASM) /dll /output:bug-43095-il.dll $(srcdir)/bug-43095-il.il
+	$(MCS) -r:bug-43095-il.dll -out:bug-43095.exe $(srcdir)/bug-43095.cs
+
 EXTRA_DIST += custom-modifiers.2.cs custom-modifiers-lib.il
 
 custom-modifiers.2.exe$(PLATFORM_AOT_SUFFIX): custom-modifiers-lib.dll$(PLATFORM_AOT_SUFFIX)
@@ -1970,6 +1978,9 @@ test-console-output: console-output.exe
 
 test-pedump: test-runner.exe
 	$(with_mono_path) $(mono_build_root)/tools/pedump/pedump --verify error test-runner.exe
+
+test-il-offsets: bug-43095.exe test-runner.exe
+	$(RUNTIME) --debug $<
 
 .PHONY: test-gac-loading test-eglib-remap
 

--- a/mono/tests/bug-43095-il.il
+++ b/mono/tests/bug-43095-il.il
@@ -1,0 +1,68 @@
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly 'bug-43095-il'
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module 'bug-43095.exe'
+// MVID: {BBBBFE99-8258-45F1-89C3-C9A3AF34CC9B}
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public auto ansi beforefieldinit Bug43095
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Bug43095::.ctor
+
+  .method public hidebysig static void  Main(string[] args) cil managed
+  {
+    .entrypoint
+    // Code size       11 (0xb)
+    .maxstack  8
+    IL_0000:  ldstr      "bla"
+    IL_0005:  call       void Bug43095::ThrowArgumentNullException(string)
+    IL_000a:  ret
+  } // end of method Bug43095::Main
+
+  .method public hidebysig static void  ThrowArgumentNullException(string a) cil managed noinlining
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  nop
+    IL_0002:  nop
+    IL_0003:  nop
+    IL_0004:  nop
+    IL_0005:  ldarg.0
+    IL_0006:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
+    IL_000b:  throw
+  } // end of method Bug43095::ThrowArgumentNullException
+
+} // end of class Bug43095
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/mono/tests/bug-43095.cs
+++ b/mono/tests/bug-43095.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.CompilerServices;
+
+class C {
+	public static void Main () {
+		/* depends on running with --debug */
+		try {
+			Bug43095.ThrowArgumentNullException ("sup");
+		} catch (Exception ex) {
+			string expected_offset = "[0x0000b]";
+			string[] frames = ex.StackTrace.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+
+			if (!frames [0].Contains (expected_offset))
+				throw new Exception (String.Format ("Exception should be thrown at IL offset {0}, but was: {1}", expected_offset, frames [0]));
+		}
+	}
+}
+


### PR DESCRIPTION
This gives us more preciese IL offsets in stack traces by trading it
with more metadata for compiled methods (which is fine for `--debug`).
Consider this example:

```
// Metadata version: v4.0.30319
.assembly extern mscorlib
{
  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
  .ver 4:0:0:0
}
.assembly 'bug-43095'
{
  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
  .hash algorithm 0x00008004
  .ver 0:0:0:0
}
.module 'bug-43095.exe'
// MVID: {BBBBFE99-8258-45F1-89C3-C9A3AF34CC9B}
.imagebase 0x00400000
.file alignment 0x00000200
.stackreserve 0x00100000
.subsystem 0x0003       // WINDOWS_CUI
.corflags 0x00000001    //  ILONLY

// =============== CLASS MEMBERS DECLARATION ===================

.class private auto ansi beforefieldinit Bug
       extends [mscorlib]System.Object
{
  .method public hidebysig specialname rtspecialname
          instance void  .ctor() cil managed
  {
    // Code size       7 (0x7)
    .maxstack  8
    IL_0000:  ldarg.0
    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
    IL_0006:  ret
  } // end of method Bug::.ctor

  .method public hidebysig static void  Main(string[] args) cil managed
  {
    .entrypoint
    // Code size       11 (0xb)
    .maxstack  8
    IL_0000:  ldstr      "bla"
    IL_0005:  call       void Bug::ThrowArgumentNullException(string)
    IL_000a:  ret
  } // end of method Bug::Main

  .method public hidebysig static void  ThrowArgumentNullException(string a) cil managed noinlining
  {
    // Code size       7 (0x7)
    .maxstack  8
	IL_0000:  nop
	IL_0001:  nop
	IL_0002:  nop
	IL_0003:  nop
	IL_0004:  nop
    IL_0005:  ldarg.0
    IL_0006:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
    IL_000b:  throw
  } // end of method Bug::ThrowArgumentNullException

} // end of class Bug

// =============================================================

// *********** DISASSEMBLY COMPLETE ***********************
```

```
% ../mini/mono-sgen bug-43095.exe

Unhandled Exception:
System.ArgumentNullException: Value cannot be null.
Parameter name: bla
  at Bug.ThrowArgumentNullException (System.String a) [0x00005] in <908602df2af146b4831faef20d928bd7>:0
  at Bug.Main (System.String[] args) [0x00000] in <908602df2af146b4831faef20d928bd7>:0
```

vs.

```
% ../mini/mono-sgen --debug bug-43095.exe

Unhandled Exception:
System.ArgumentNullException: Value cannot be null.
Parameter name: bla
  at Bug.ThrowArgumentNullException (System.String a) [0x0000b] in <908602df2af146b4831faef20d928bd7>:0
  at Bug.Main (System.String[] args) [0x00005] in <908602df2af146b4831faef20d928bd7>:0
```

Context: https://bugzilla.xamarin.com/show_bug.cgi?id=43095