### PR TITLE
[TSan] Unlock sgen-fin-weak-hash.c

### DIFF
--- a/mono/utils/unlocked.h
+++ b/mono/utils/unlocked.h
@@ -7,7 +7,8 @@
  *  * Increment, Decrement, Add, Subtract, Write, Read
  *  * gint32 (""), guint32 ("Unsigned"),
  *      gint64 ("64"), guint64 ("Unsigned64"),
- *      gsize ("Size"), gboolean ("Bool")
+ *      gsize ("Size"), gboolean ("Bool"),
+ *      gpointer ("Pointer")
  *
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
@@ -28,98 +29,105 @@
 
 MONO_UNLOCKED_ATTRS
 gint32
-UnlockedIncrement (gint32 *val)
+UnlockedIncrement (volatile gint32 *val)
 {
 	return ++*val;
 }
 
 MONO_UNLOCKED_ATTRS
 gint64
-UnlockedIncrement64 (gint64 *val)
+UnlockedIncrement64 (volatile gint64 *val)
 {
 	return ++*val;
 }
 
 MONO_UNLOCKED_ATTRS
 gint64
-UnlockedDecrement64 (gint64 *val)
+UnlockedDecrement64 (volatile gint64 *val)
 {
 	return --*val;
 }
 
 MONO_UNLOCKED_ATTRS
 gint32
-UnlockedDecrement (gint32 *val)
+UnlockedDecrement (volatile gint32 *val)
 {
 	return --*val;
 }
 
 MONO_UNLOCKED_ATTRS
 gint32
-UnlockedAdd (gint32 *dest, gint32 add)
+UnlockedAdd (volatile gint32 *dest, gint32 add)
 {
 	return *dest += add;
 }
 
 MONO_UNLOCKED_ATTRS
 gint64
-UnlockedAdd64 (gint64 *dest, gint64 add)
+UnlockedAdd64 (volatile gint64 *dest, gint64 add)
 {
 	return *dest += add;
 }
 
 MONO_UNLOCKED_ATTRS
 gdouble
-UnlockedAddDouble (gdouble *dest, gdouble add)
+UnlockedAddDouble (volatile gdouble *dest, gdouble add)
 {
 	return *dest += add;
 }
 
 MONO_UNLOCKED_ATTRS
 gint64
-UnlockedSubtract64 (gint64 *dest, gint64 sub)
+UnlockedSubtract64 (volatile gint64 *dest, gint64 sub)
 {
 	return *dest -= sub;
 }
 
 MONO_UNLOCKED_ATTRS
 void
-UnlockedWrite (gint32 *dest, gint32 val)
+UnlockedWrite (volatile gint32 *dest, gint32 val)
 {
 	*dest = val;
 }
 
 MONO_UNLOCKED_ATTRS
 void
-UnlockedWrite64 (gint64 *dest, gint64 val)
+UnlockedWrite64 (volatile gint64 *dest, gint64 val)
 {
 	*dest = val;
 }
 
 MONO_UNLOCKED_ATTRS
 void
-UnlockedWriteBool (gboolean *dest, gboolean val)
+UnlockedWriteBool (volatile gboolean *dest, gboolean val)
+{
+	*dest = val;
+}
+
+MONO_UNLOCKED_ATTRS
+void
+UnlockedWritePointer (volatile gpointer *dest, gpointer val)
 {
 	*dest = val;
 }
 
 MONO_UNLOCKED_ATTRS
 gint32
-UnlockedRead (gint32 *src)
+UnlockedRead (volatile gint32 *src)
 {
 	return *src;
 }
 
 MONO_UNLOCKED_ATTRS
 gint64
-UnlockedRead64 (gint64 *src)
+UnlockedRead64 (volatile gint64 *src)
 {
 	return *src;
 }
 
 MONO_UNLOCKED_ATTRS
 gboolean
-UnlockedReadBool (gboolean *src)
+UnlockedReadBool (volatile gboolean *src)
 {
 	return *src;
 }


### PR DESCRIPTION
There are two different kinds of races within `sgen-fin-weak-hash.c`: simple counter races and races of two global variables that are important logic-wise:

- The counter races (defined within `#ifdef HEAVY_STATISTICS ... #endif`) are typical counter races; since this seems to be a rather busy part of Mono, I decided to unlock (but not interlock) them.

- `next_fin_stage_entry` and `fin_stage_entries` also take part in data races as `add_stage_entry ()` is designed to be run concurrently without blocking. From what I can tell, all important operations are properly interlocked but unimportant operations are left racy. I wrapped them in `Unlocked* ()` functions to mark the races explicitly and stop TSan instrumentation on them. This only occurs within `add_stage_entry ()` as `process_stage_entries ()` (and everything connected to it) is always used with the `GC lock`.