### PR TITLE
[TSan] Unlock mini-trampolines.c

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -17,6 +17,7 @@
 #include <mono/utils/mono-membar.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-threads-coop.h>
+#include <mono/utils/unlocked.h>
 
 #include "mini.h"
 #include "lldb.h"
@@ -33,7 +34,13 @@ guint8* mono_trampoline_code [MONO_TRAMPOLINE_NUM];
 
 static GHashTable *rgctx_lazy_fetch_trampoline_hash;
 static GHashTable *rgctx_lazy_fetch_trampoline_hash_addr;
-static guint32 trampoline_calls, jit_trampolines, unbox_trampolines, static_rgctx_trampolines;
+
+static gint32 trampoline_calls;
+static gint32 jit_trampolines;
+static gint32 unbox_trampolines;
+static gint32 static_rgctx_trampolines;
+static gint32 rgctx_unmanaged_lookups;
+static gint32 rgctx_num_lazy_fetch_trampolines;
 
 #define mono_trampolines_lock() mono_os_mutex_lock (&trampolines_mutex)
 #define mono_trampolines_unlock() mono_os_mutex_unlock (&trampolines_mutex)
@@ -128,9 +135,9 @@ mono_create_static_rgctx_trampoline (MonoMethod *m, gpointer addr)
 	info->m = m;
 	info->addr = addr;
 	g_hash_table_insert (domain_jit_info (domain)->static_rgctx_trampoline_hash, info, res);
-	mono_domain_unlock (domain);
 
-	static_rgctx_trampolines ++;
+	UnlockedIncrement (&static_rgctx_trampolines);
+	mono_domain_unlock (domain);
 
 	return res;
 }
@@ -834,7 +841,7 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 
 	g_assert (mono_thread_is_gc_unsafe_mode ());
 
-	trampoline_calls ++;
+	UnlockedIncrement (&trampoline_calls);
 
 	res = common_call_trampoline (regs, code, (MonoMethod *)arg, NULL, NULL, &error);
 	if (!is_ok (&error)) {
@@ -862,7 +869,7 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 	MonoError error;
 	gpointer addr, res = NULL;
 
-	trampoline_calls ++;
+	UnlockedIncrement (&trampoline_calls);
 
 	/*
 	 * We need to obtain the following pieces of information:
@@ -936,7 +943,7 @@ mono_generic_virtual_remoting_trampoline (mgreg_t *regs, guint8 *code, MonoMetho
 	MonoMethod *imt_method, *declaring;
 	gpointer addr;
 
-	trampoline_calls ++;
+	UnlockedIncrement (&trampoline_calls);
 
 	g_assert (m->is_generic);
 
@@ -988,7 +995,7 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
 	guint8 *plt_entry;
 	MonoError error;
 
-	trampoline_calls ++;
+	UnlockedIncrement (&trampoline_calls);
 
 	image = (MonoImage *)*(gpointer*)(gpointer)token_info;
 	token_info += sizeof (gpointer);
@@ -1032,7 +1039,7 @@ mono_aot_plt_trampoline (mgreg_t *regs, guint8 *code, guint8 *aot_module,
 	gpointer res;
 	MonoError error;
 
-	trampoline_calls ++;
+	UnlockedIncrement (&trampoline_calls);
 
 	res = mono_aot_plt_resolve (aot_module, plt_info_offset, code, &error);
 	if (!res) {
@@ -1053,8 +1060,6 @@ mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, gu
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	static gboolean inited = FALSE;
-	static int num_lookups = 0;
 	guint32 slot = GPOINTER_TO_UINT (data);
 	mgreg_t *r = (mgreg_t*)regs;
 	gpointer arg = (gpointer)(gssize)r [MONO_ARCH_VTABLE_REG];
@@ -1063,14 +1068,8 @@ mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, gu
 	MonoError error;
 	gpointer res;
 
-	trampoline_calls ++;
-
-	if (!inited) {
-		mono_counters_register ("RGCTX unmanaged lookups", MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &num_lookups);
-		inited = TRUE;
-	}
-
-	num_lookups++;
+	UnlockedIncrement (&trampoline_calls);
+	UnlockedIncrement (&rgctx_unmanaged_lookups);
 
 	if (mrgctx)
 		res = mono_method_fill_runtime_generic_context ((MonoMethodRuntimeGenericContext *)arg, index, &error);
@@ -1113,7 +1112,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	gpointer addr, compiled_method;
 	gboolean is_remote = FALSE;
 
-	trampoline_calls ++;
+	UnlockedIncrement (&trampoline_calls);
 
 	/* Obtain the delegate object according to the calling convention */
 	delegate = (MonoDelegate *)mono_arch_get_this_arg_from_call (regs, code);
@@ -1352,6 +1351,8 @@ mono_trampolines_init (void)
 	mono_counters_register ("JIT trampolines", MONO_COUNTER_JIT | MONO_COUNTER_INT, &jit_trampolines);
 	mono_counters_register ("Unbox trampolines", MONO_COUNTER_JIT | MONO_COUNTER_INT, &unbox_trampolines);
 	mono_counters_register ("Static rgctx trampolines", MONO_COUNTER_JIT | MONO_COUNTER_INT, &static_rgctx_trampolines);
+	mono_counters_register ("RGCTX unmanaged lookups", MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &rgctx_unmanaged_lookups);
+	mono_counters_register ("RGCTX num lazy fetch trampolines", MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &rgctx_num_lazy_fetch_trampolines);
 }
 
 void
@@ -1496,9 +1497,8 @@ mono_create_jit_trampoline (MonoDomain *domain, MonoMethod *method, MonoError *e
 	
 	mono_domain_lock (domain);
 	g_hash_table_insert (domain_jit_info (domain)->jit_trampoline_hash, method, tramp);
+	UnlockedIncrement (&jit_trampolines);
 	mono_domain_unlock (domain);
-
-	jit_trampolines++;
 
 	return tramp;
 }	
@@ -1519,7 +1519,7 @@ mono_create_jit_trampoline_from_token (MonoImage *image, guint32 token)
 
 	tramp = mono_create_specific_trampoline (start, MONO_TRAMPOLINE_AOT, domain, NULL);
 
-	jit_trampolines++;
+	UnlockedIncrement (&jit_trampolines);
 
 	return tramp;
 }	
@@ -1602,10 +1602,7 @@ mono_create_delegate_virtual_trampoline (MonoDomain *domain, MonoClass *klass, M
 gpointer
 mono_create_rgctx_lazy_fetch_trampoline (guint32 offset)
 {
-	static gboolean inited = FALSE;
-	static int num_trampolines = 0;
 	MonoTrampInfo *info;
-
 	gpointer tramp, ptr;
 
 	mono_trampolines_lock ();
@@ -1633,14 +1630,8 @@ mono_create_rgctx_lazy_fetch_trampoline (guint32 offset)
 	g_hash_table_insert (rgctx_lazy_fetch_trampoline_hash, GUINT_TO_POINTER (offset), ptr);
 	g_assert (offset != -1);
 	g_hash_table_insert (rgctx_lazy_fetch_trampoline_hash_addr, ptr, GUINT_TO_POINTER (offset + 1));
+	rgctx_num_lazy_fetch_trampolines ++;
 	mono_trampolines_unlock ();
-
-	if (!inited) {
-		mono_counters_register ("RGCTX num lazy fetch trampolines",
-				MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &num_trampolines);
-		inited = TRUE;
-	}
-	num_trampolines++;
 
 	return ptr;
 }


### PR DESCRIPTION
- `guint32 -> gint32`: nothing changes since the counters were registered as `MONO_COUNTER_INT` before. Additionally, by using `gint32`, existing `Interlocked* ()` and `Unlocked* ()` functions can be used.

- Avoid "function `static`" counters and initialise all counters in `mono_trampolines_init ()`: that matches the current (more modern) approach of dealing with counters and it also helps with readability and produces less duplicate code.

- I think that `Interlocked* ()` is no option when calling trampolines which is why I used `Unlocked* ()` everywhere; sometimes, however, it can be bundled with other locks (domain and trampolines) to interlock some counters implicitly.