### PR TITLE
[TSan] Unlock fastpath when checking domains_to_finalize

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -44,6 +44,7 @@
 #include <mono/utils/mono-coop-semaphore.h>
 #include <mono/utils/hazard-pointer.h>
 #include <mono/utils/w32api.h>
+#include <mono/utils/unlocked.h>
 
 #ifndef HOST_WIN32
 #include <pthread.h>
@@ -780,7 +781,7 @@ finalize_domain_objects (void)
 	DomainFinalizationReq *req = NULL;
 	MonoDomain *domain;
 
-	if (domains_to_finalize) {
+	if (UnlockedReadPointer ((gpointer)&domains_to_finalize)) {
 		mono_finalizer_lock ();
 		if (domains_to_finalize) {
 			req = (DomainFinalizationReq *)domains_to_finalize->data;

--- a/mono/utils/unlocked.h
+++ b/mono/utils/unlocked.h
@@ -122,4 +122,11 @@ UnlockedReadBool (gboolean *src)
 	return *src;
 }
 
+MONO_UNLOCKED_ATTRS
+gpointer
+UnlockedReadPointer (volatile gpointer *src)
+{
+	return *src;
+}
+
 #endif /* _UNLOCKED_H_ */


### PR DESCRIPTION
I understand that the affected line is a fastpath which seems absolutely fine to me as it is properly checked later. It is, however, rightfully, detected as a data race by Clang's ThreadSanitizer. I would, therefore, suggest using `UnlockedReadPointer ()` to mark this race as known + accepted.