### PR TITLE
[mono-api-html] Print ref/out modifiers on parameters. Fixes #59430.

### DIFF
--- a/mcs/tools/mono-api-html/ConstructorComparer.cs
+++ b/mcs/tools/mono-api-html/ConstructorComparer.cs
@@ -133,10 +133,15 @@ namespace Xamarin.ApiDiff {
 			if (parameters != null) {
 				var list = new List<string> ();
 				foreach (var p in parameters.Elements ("parameter")) {
-					var pTypeName   = p.GetTypeName ("type");
-					list.Add (State.IgnoreParameterNameChanges
-						? pTypeName
-						: pTypeName + " " + p.GetAttribute ("name"));
+					var param = p.GetTypeName ("type");
+					if (!State.IgnoreParameterNameChanges)
+						param += " " + p.GetAttribute ("name");
+
+					var direction = p.GetAttribute ("direction");
+					if (direction?.Length > 0)
+						param = direction + " " + param;
+						
+					list.Add (param);
 				}
 				sb.Append (String.Join (", ", list));
 			}


### PR DESCRIPTION
Print ref/out modifiers on parameters, so that any changes in ref/out are detected.

https://bugzilla.xamarin.com/show_bug.cgi?id=59430