### PR TITLE
[WindowsBase] Fix exception type in *ValueSerializer.ConvertFromString with null parameter

### DIFF
--- a/mcs/class/WindowsBase/System.Windows.Converters/Int32RectValueSerializer.cs
+++ b/mcs/class/WindowsBase/System.Windows.Converters/Int32RectValueSerializer.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Converters {
 		public override object ConvertFromString (string value, IValueSerializerContext context)
 		{
 			if (value == null)
-				throw new ArgumentNullException ("value");
+				throw new NotSupportedException ("value != null");
 			return Int32Rect.Parse (value);
 		}
 

--- a/mcs/class/WindowsBase/System.Windows.Converters/PointValueSerializer.cs
+++ b/mcs/class/WindowsBase/System.Windows.Converters/PointValueSerializer.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Converters {
 		public override object ConvertFromString (string value, IValueSerializerContext context)
 		{
 			if (value == null)
-				throw new ArgumentNullException ("value");
+				throw new NotSupportedException ("value != null");
 			return Point.Parse (value);
 		}
 

--- a/mcs/class/WindowsBase/System.Windows.Converters/RectValueSerializer.cs
+++ b/mcs/class/WindowsBase/System.Windows.Converters/RectValueSerializer.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Converters {
 		public override object ConvertFromString (string value, IValueSerializerContext context)
 		{
 			if (value == null)
-				throw new ArgumentNullException ("value");
+				throw new NotSupportedException ("value != null");
 			return Rect.Parse (value);
 		}
 

--- a/mcs/class/WindowsBase/System.Windows.Converters/SizeValueSerializer.cs
+++ b/mcs/class/WindowsBase/System.Windows.Converters/SizeValueSerializer.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Converters {
 		public override object ConvertFromString (string value, IValueSerializerContext context)
 		{
 			if (value == null)
-				throw new ArgumentNullException ("value");
+				throw new NotSupportedException ("value != null");
 			return Size.Parse (value);
 		}
 

--- a/mcs/class/WindowsBase/System.Windows.Converters/VectorValueSerializer.cs
+++ b/mcs/class/WindowsBase/System.Windows.Converters/VectorValueSerializer.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Converters {
 		public override object ConvertFromString (string value, IValueSerializerContext context)
 		{
 			if (value == null)
-				throw new ArgumentNullException ("value");
+				throw new NotSupportedException ("value != null");
 			return Vector.Parse (value);
 		}
 

--- a/mcs/class/WindowsBase/Test/System.Windows.Media/MatrixConverterTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows.Media/MatrixConverterTest.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using System.Globalization;
 using System.Windows.Media;
 
 namespace MonoTests.System.Windows.Media {
@@ -56,7 +57,7 @@ namespace MonoTests.System.Windows.Media {
 		{
 			var conv = new MatrixConverter ();
 			var matrix = new Matrix (1, 2, 3, 4, 5, 6);
-			object obj = conv.ConvertTo (matrix, typeof (string));
+			object obj = conv.ConvertTo (null, CultureInfo.InvariantCulture, matrix, typeof (string));
 			Assert.AreEqual (typeof (string), obj.GetType ());
 			Assert.AreEqual ("1,2,3,4,5,6", (string)obj);
 		}

--- a/mcs/class/WindowsBase/Test/System.Windows.Media/MatrixTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows.Media/MatrixTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -347,7 +348,7 @@ namespace MonoTests.System.Windows.Media {
 		public void ToStringTest ()
 		{
 			Matrix m = new Matrix (1, 2, 3, 4, 5, 6);
-			Assert.AreEqual ("1,2,3,4,5,6", m.ToString());
+			Assert.AreEqual ("1,2,3,4,5,6", m.ToString(CultureInfo.InvariantCulture));
 			m = Matrix.Identity;
 			Assert.AreEqual ("Identity", m.ToString());
 		}

--- a/mcs/class/WindowsBase/Test/System.Windows/Int32RectConverterTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/Int32RectConverterTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -88,14 +89,13 @@ namespace MonoTests.System.Windows {
 		}
 
 		[Test]
-		[Category ("NotWorking")]
 		public void ConvertTo ()
 		{
 			Int32RectConverter r = new Int32RectConverter ();
 
 			Int32Rect rect = new Int32Rect (0, 0, 1, 2);
 
-			object o = r.ConvertTo (rect, typeof (string));
+			object o = r.ConvertTo (null, CultureInfo.InvariantCulture, rect, typeof (string));
 			
 			Assert.AreEqual (typeof (string), o.GetType());
 			Assert.AreEqual ("0,0,1,2", (string)o);

--- a/mcs/class/WindowsBase/Test/System.Windows/Int32RectTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/Int32RectTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -136,7 +137,7 @@ namespace MonoTests.System.Windows {
 		public void ToStringTest ()
 		{
 			Int32Rect r = new Int32Rect (1, 2, 3, 4);
-			Assert.AreEqual ("1,2,3,4", r.ToString());
+			Assert.AreEqual ("1,2,3,4", r.ToString(CultureInfo.InvariantCulture));
 
 			Assert.AreEqual ("Empty", Int32Rect.Empty.ToString());
 		}

--- a/mcs/class/WindowsBase/Test/System.Windows/Int32RectValueSerializerTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/Int32RectValueSerializerTest.cs
@@ -50,7 +50,7 @@ namespace MonoTests.System.Windows {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
+		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFromStringShouldThrowExceptionWhenStringIsNull ()
 		{
 			var serializer = new Int32RectValueSerializer ();

--- a/mcs/class/WindowsBase/Test/System.Windows/PointConverterTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/PointConverterTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -82,7 +83,7 @@ namespace MonoTests.System.Windows {
 
 			Point rect = new Point (1, 2);
 
-			object o = r.ConvertTo (rect, typeof (string));
+			object o = r.ConvertTo (null, CultureInfo.InvariantCulture, rect, typeof (string));
 			
 			Assert.AreEqual (typeof (string), o.GetType());
 			Assert.AreEqual ("1,2", (string)o);

--- a/mcs/class/WindowsBase/Test/System.Windows/PointValueSerializerTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/PointValueSerializerTest.cs
@@ -50,7 +50,7 @@ namespace MonoTests.System.Windows {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
+		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFromStringShouldThrowExceptionWhenStringIsNull ()
 		{
 			var serializer = new PointValueSerializer ();

--- a/mcs/class/WindowsBase/Test/System.Windows/RectConverterTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/RectConverterTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -92,7 +93,7 @@ namespace MonoTests.System.Windows {
 
 			Rect rect = new Rect (0, 0, 1, 2);
 
-			object o = r.ConvertTo (rect, typeof (string));
+			object o = r.ConvertTo (null, CultureInfo.InvariantCulture, rect, typeof (string));
 			
 			Assert.AreEqual (typeof (string), o.GetType());
 			Assert.AreEqual ("0,0,1,2", (string)o);

--- a/mcs/class/WindowsBase/Test/System.Windows/RectValueSerializerTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/RectValueSerializerTest.cs
@@ -50,7 +50,7 @@ namespace MonoTests.System.Windows {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
+		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFromStringShouldThrowExceptionWhenStringIsNull ()
 		{
 			var serializer = new RectValueSerializer ();

--- a/mcs/class/WindowsBase/Test/System.Windows/SizeConverterTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/SizeConverterTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -86,7 +87,7 @@ namespace MonoTests.System.Windows {
 
 			Size rect = new Size (1, 2);
 
-			object o = r.ConvertTo (rect, typeof (string));
+			object o = r.ConvertTo (null, CultureInfo.InvariantCulture, rect, typeof (string));
 			
 			Assert.AreEqual (typeof (string), o.GetType());
 			Assert.AreEqual ("1,2", (string)o);

--- a/mcs/class/WindowsBase/Test/System.Windows/SizeTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/SizeTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -158,7 +159,7 @@ namespace MonoTests.System.Windows {
 		[Test]
 		public void ToStringTest ()
 		{
-			Assert.AreEqual ("1,2", (new Size (1, 2)).ToString ());
+			Assert.AreEqual ("1,2", (new Size (1, 2)).ToString (CultureInfo.InvariantCulture));
 		}
 
 		[Test]

--- a/mcs/class/WindowsBase/Test/System.Windows/SizeValueSerializerTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/SizeValueSerializerTest.cs
@@ -50,7 +50,7 @@ namespace MonoTests.System.Windows {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
+		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFromStringShouldThrowExceptionWhenStringIsNull ()
 		{
 			var serializer = new SizeValueSerializer ();

--- a/mcs/class/WindowsBase/Test/System.Windows/VectorConverterTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/VectorConverterTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -82,7 +83,7 @@ namespace MonoTests.System.Windows {
 
 			Vector rect = new Vector (1, 2);
 
-			object o = r.ConvertTo (rect, typeof (string));
+			object o = r.ConvertTo (null, CultureInfo.InvariantCulture, rect, typeof (string));
 			
 			Assert.AreEqual (typeof (string), o.GetType());
 			Assert.AreEqual ("1,2", (string)o);

--- a/mcs/class/WindowsBase/Test/System.Windows/VectorTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/VectorTest.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using NUnit.Framework;
@@ -56,7 +57,7 @@ namespace MonoTests.System.Windows {
 		public void ToStringTest ()
 		{
 			Vector v = new Vector (4, 5);
-			Assert.AreEqual ("4,5", v.ToString());
+			Assert.AreEqual ("4,5", v.ToString(CultureInfo.InvariantCulture));
 		}
 
 		[Test]

--- a/mcs/class/WindowsBase/Test/System.Windows/VectorValueSerializerTest.cs
+++ b/mcs/class/WindowsBase/Test/System.Windows/VectorValueSerializerTest.cs
@@ -50,7 +50,7 @@ namespace MonoTests.System.Windows {
 		}
 
 		[Test]
-		[ExpectedException (typeof (ArgumentNullException))]
+		[ExpectedException (typeof (NotSupportedException))]
 		public void ConvertFromStringShouldThrowExceptionWhenStringIsNull ()
 		{
 			var serializer = new VectorValueSerializer ();


### PR DESCRIPTION
ArgumentNullException was introduced by #5593 but it should be NotSupportedException instead to match with Windows .NET.

Similar change to what was noticed during review of https://github.com/mono/mono/pull/5343#discussion_r132166426 /cc @mfilippov

While I was at it I also fixed a few culture test issues that popped up in de_DE