### PR TITLE
Partial fix for bug 10087 - Run ProcessExit events on the finalizer thread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=1
+MONO_CORLIB_COUNTER=2
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -17,6 +17,12 @@
 			<method name="InternalSetContext" />
 			<!-- System.Runtime.Remoting/RemotingServices.cs: GetDomainProxy(AppDomain domain) -->
 			<method name="GetMarshalledDomainObjRef" feature="remoting" />
+			<!-- runtime.c: mono_runtime_fire_process_exit_event -->
+			<method name="QueueProcessExitEvent" />
+			<method name="SetProcessExitEventQueueReady" />			
+			<method name="WaitForProcessExitEventQueueToDrain" />
+			<!-- runtime.c: mono_runtime_flush_appdomain_processexit_queue -->
+			<method name="InvokeQueuedProcessExitEvents" />
 		</type>
 
 		<!-- appdomain.c: mono_runtime_init -->

--- a/mcs/class/corlib/System/AppDomain.cs
+++ b/mcs/class/corlib/System/AppDomain.cs
@@ -1669,58 +1669,68 @@ namespace System {
 			get { throw new NotImplementedException (); }
 		}
 
-		static volatile int ProcessExitEventsQueued = 0;
-		static volatile int ProcessExitEventsInvoked = 0;
+		static readonly System.Collections.Queue invoke_process_exit_queue = 
+			new System.Collections.Queue ();
+		static volatile int process_exit_queue_ready = 0;
 
-		static readonly System.Collections.Queue InvokeProcessExitQueue = 
-			new System.Collections.Queue();
-		static GCHandle SignalPin;
-		static readonly ManualResetEventSlim ProcessExitEventsInvokedSignal =
-			new ManualResetEventSlim(false);
+		static GCHandle process_exit_signal_pin;
+		static readonly ManualResetEventSlim process_exit_events_invoked_signal =
+			new ManualResetEventSlim (false);
 
+		// The AppDomain.ProcessExit event documentation specifies that there is a configurable
+		//  time limit for the execution of all process exit event handlers combined.
 		const int ProcessExitEventTimeoutMs = 3000;
 
+		// The runtime invokes this method by name at shutdown.
 		static void WaitForProcessExitEventQueueToDrain ()
 		{
-			SignalPin = GCHandle.Alloc(ProcessExitEventsInvokedSignal);
-
-			var waitResult = ProcessExitEventsInvokedSignal.Wait(ProcessExitEventTimeoutMs);
+			var waitResult = process_exit_events_invoked_signal.Wait (ProcessExitEventTimeoutMs);
 
 			if (!waitResult)
-				throw new Exception("Timed out while waiting for ProcessExit events");
-			else if (ProcessExitEventsInvoked < ProcessExitEventsQueued)
-				throw new Exception("Wait ended before all ProcessExit events had been invoked");
+				throw new Exception ("Timed out while waiting for ProcessExit events");
 
-			SignalPin.Free();
+			process_exit_signal_pin.Free ();
 		}
 
+		// The runtime invokes this method by name on the finalizer thread.
 		static void InvokeQueuedProcessExitEvents () 
 		{
-			Monitor.Enter(InvokeProcessExitQueue);
+			if (process_exit_queue_ready != 1)
+				return;
 
-			while (InvokeProcessExitQueue.Count > 0) {
-				var appDomain = (AppDomain)InvokeProcessExitQueue.Dequeue();
-				Monitor.Exit(InvokeProcessExitQueue);
+			Monitor.Enter (invoke_process_exit_queue);
+
+			while (invoke_process_exit_queue.Count > 0) {
+				var appDomain = (AppDomain)invoke_process_exit_queue.Dequeue ();
+				Monitor.Exit (invoke_process_exit_queue);
 
 				if (appDomain.ProcessExit != null)
-					appDomain.ProcessExit(appDomain, EventArgs.Empty);
+					appDomain.ProcessExit (appDomain, EventArgs.Empty);
 
-				Interlocked.Increment(ref ProcessExitEventsInvoked);
-
-				Monitor.Enter(InvokeProcessExitQueue);
+				Monitor.Enter (invoke_process_exit_queue);
 			}
 
-			if (ProcessExitEventsQueued <= ProcessExitEventsInvoked)
-				ProcessExitEventsInvokedSignal.Set();
+			process_exit_events_invoked_signal.Set ();
 
-			Monitor.Exit(InvokeProcessExitQueue);
+			Monitor.Exit (invoke_process_exit_queue);
 		}
 
-		private void QueueProcessExitEvent () 
+		// The runtime invokes this method by name at shutdown.
+		void QueueProcessExitEvent () 
 		{
-			Interlocked.Increment(ref ProcessExitEventsQueued);
-			lock (InvokeProcessExitQueue)
-				InvokeProcessExitQueue.Enqueue(this);
+			lock (invoke_process_exit_queue)
+				invoke_process_exit_queue.Enqueue (this);
+		}
+
+		// The runtime invokes this method by name at shutdown.
+		static void SetProcessExitEventQueueReady () 
+		{
+			// System.Threading.MemoryBarrier ();
+			lock (invoke_process_exit_queue) {
+				// Without this the signal can get collected by the GC during the wait operation.
+				process_exit_signal_pin = GCHandle.Alloc (process_exit_events_invoked_signal);
+				process_exit_queue_ready = 1;
+			}
 		}
 	}
 }

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -91,6 +91,8 @@ static void reference_queue_proccess_all (void);
 static void mono_reference_queue_cleanup (void);
 static void reference_queue_clear_for_domain (MonoDomain *domain);
 
+void mono_runtime_flush_appdomain_processexit_queue (void);
+
 
 static MonoThreadInfoWaitRet
 guarded_wait (MonoThreadHandle *thread_handle, guint32 timeout, gboolean alertable)
@@ -872,6 +874,8 @@ finalizer_thread (gpointer unused)
 		mono_console_handle_async_ops ();
 
 		mono_attach_maybe_start ();
+
+		mono_runtime_flush_appdomain_processexit_queue ();
 
 		finalize_domain_objects ();
 

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -59,10 +59,6 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 		0, METHOD_ATTRIBUTE_PRIVATE
 	);
 
-	// FIXME: The assert causes a crash during make... maybe because mscorlib is old?
-	if (!method)
-		return;
-
 	g_assert (method);
 
 	MonoError error;
@@ -93,11 +89,11 @@ mono_runtime_fire_process_exit_event (void)
 	MonoError error;
 	MonoObject * exc = NULL;
 
-	if (method) {
-		// This operation can't fail
-		mono_runtime_try_invoke (method, NULL, NULL, &exc, &error);
-		exc = NULL;
-	}
+	g_assert(method);
+
+	// This operation can't fail
+	mono_runtime_try_invoke (method, NULL, NULL, &exc, &error);
+	exc = NULL;
 
 	mono_gc_finalize_notify ();
 
@@ -106,10 +102,7 @@ mono_runtime_fire_process_exit_event (void)
 		0, METHOD_ATTRIBUTE_PRIVATE | METHOD_ATTRIBUTE_STATIC
 	);
 
-	// If mscorlib is outdated this method doesn't exist, and requiring it
-	//  will cause builds to fail before they can update mscorlib.
-	if (!method)
-		return;
+	g_assert(method);
 
 	mono_runtime_try_invoke (method, NULL, NULL, &exc, &error);
 
@@ -132,10 +125,7 @@ void mono_runtime_flush_appdomain_processexit_queue (void)
 		0, METHOD_ATTRIBUTE_PRIVATE | METHOD_ATTRIBUTE_STATIC
 	);
 
-	// If mscorlib is outdated this method doesn't exist, and requiring it
-	//  will cause builds to fail before they can update mscorlib.
-	if (!method)
-		return;
+	g_assert(method);
 
 	MonoError error;
 	MonoObject * exc = NULL;

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -78,26 +78,6 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 
 	if (exc)
 		mono_print_unhandled_exception (exc);
-
-	/*
-	MonoError error;
-	MonoClassField *field;
-	gpointer pa [2];
-	MonoObject *delegate, *exc;
-
-	field = mono_class_get_field_from_name (mono_defaults.appdomain_class, "ProcessExit");
-	g_assert (field);
-
-	delegate = *(MonoObject **)(((char *)domain->domain) + field->offset);
-	if (delegate == NULL)
-		return;
-
-	pa [0] = domain;
-	pa [1] = NULL;
-	mono_runtime_delegate_try_invoke (delegate, pa, &exc, &error);
-	mono_error_cleanup (&error);
-	/*
-	*/
 }
 
 static void
@@ -106,21 +86,31 @@ mono_runtime_fire_process_exit_event (void)
 #ifndef MONO_CROSS_COMPILE
 	mono_domain_foreach (fire_process_exit_event, NULL);
 
+	MonoMethod * method = mono_class_get_method_from_name_flags (
+		mono_defaults.appdomain_class, "SetProcessExitEventQueueReady", 
+		0, METHOD_ATTRIBUTE_PRIVATE | METHOD_ATTRIBUTE_STATIC
+	);
+	MonoError error;
+	MonoObject * exc = NULL;
+
+	if (method) {
+		// This operation can't fail
+		mono_runtime_try_invoke (method, NULL, NULL, &exc, &error);
+		exc = NULL;
+	}
+
 	mono_gc_finalize_notify ();
 
-	MonoMethod * method = mono_class_get_method_from_name_flags (
+	method = mono_class_get_method_from_name_flags (
 		mono_defaults.appdomain_class, "WaitForProcessExitEventQueueToDrain", 
 		0, METHOD_ATTRIBUTE_PRIVATE | METHOD_ATTRIBUTE_STATIC
 	);
 
-	// FIXME: The assert causes a crash during make... maybe because mscorlib is old?
+	// If mscorlib is outdated this method doesn't exist, and requiring it
+	//  will cause builds to fail before they can update mscorlib.
 	if (!method)
 		return;
 
-	g_assert (method);
-
-	MonoError error;
-	MonoObject * exc = NULL;
 	mono_runtime_try_invoke (method, NULL, NULL, &exc, &error);
 
 	if (!mono_error_ok (&error)) {
@@ -142,11 +132,10 @@ void mono_runtime_flush_appdomain_processexit_queue (void)
 		0, METHOD_ATTRIBUTE_PRIVATE | METHOD_ATTRIBUTE_STATIC
 	);
 
-	// FIXME: The assert causes a crash during make... maybe because mscorlib is old?
+	// If mscorlib is outdated this method doesn't exist, and requiring it
+	//  will cause builds to fail before they can update mscorlib.
 	if (!method)
 		return;
-
-	g_assert (method);
 
 	MonoError error;
 	MonoObject * exc = NULL;


### PR DESCRIPTION
This is a partial fix for bug 10087. Right now if a ```ProcessExit``` event handler stalls, mono will never shut down. This moves the event handlers onto the finalizer thread so that they are interruptible - right now we interrupt the finalizer thread after 40 seconds at shutdown so the process will eventually exit no matter what. The MS CLR aborts ```ProcessExit``` events after a total of 2 seconds, which would be ideal, but this at least takes one step in that direction and could be used as a foundation for a lower timeout.

This PR currently alerts if it takes more than 3 seconds to run the ProcessExit events, but doesn't do anything to halt them if that occurs - I couldn't find a clean way to do it that didn't make the runtime crash. So I could update this to halt the events (how?) or I can remove that part and just reduce it to run them on the finalizer thread. Would appreciate thoughts on which of the two is appropriate here.

I had to do some weird stuff to get this to work (see use of ```GCHandle.Alloc```) because it seems like the GC enters a weird state by the time we start running ```ProcessExit``` event handlers. Would appreciate guidance on the right way to do this so that it's robust without being complicated.