### PR TITLE
Allow passing null to JsonArray.Add()

### DIFF
--- a/mcs/class/System.Json/System.Json/JsonArray.cs
+++ b/mcs/class/System.Json/System.Json/JsonArray.cs
@@ -45,9 +45,6 @@ namespace System.Json
 
 		public void Add (JsonValue item)
 		{
-			if (item == null)
-				throw new ArgumentNullException ("item");
-
 			list.Add (item);
 		}
 

--- a/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
+++ b/mcs/class/System.Json/Test/System.Json/JsonValueTest.cs
@@ -44,6 +44,9 @@ namespace MonoTests.System
 			Assert.AreEqual (JsonType.Array, j.JsonType, "type");
 			var str = j.ToString ();
 			Assert.AreEqual (str, "[1, 2, 3, null]");
+			((JsonArray) j).Add (null);
+			str = j.ToString ();
+			Assert.AreEqual (str, "[1, 2, 3, null, null]");
 		}
 
 		// Test that we correctly serialize JsonObject with null elements.


### PR DESCRIPTION
null is a valid value in a JSON array, so there is no reason forbid
adding null to the array. JsonArray.Save() already handles null values in
the array.