### PR TITLE
[runtime] Don't insta-fail when a faulty COM type is encountered.

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -378,30 +378,33 @@ cominterop_get_method_interface (MonoMethod* method)
 		}
 	}
 
-	if (!ic) 
-		g_assert (ic);
-	g_assert (MONO_CLASS_IS_INTERFACE (ic));
-
 	return ic;
 }
 
 /**
  * cominterop_get_com_slot_for_method:
  * @method: a method
+ * @error: set on error
  *
  * Returns: the method's slot in the COM interface vtable
  */
 static int
-cominterop_get_com_slot_for_method (MonoMethod* method)
+cominterop_get_com_slot_for_method (MonoMethod* method, MonoError* error)
 {
 	guint32 slot = method->slot;
  	MonoClass *ic = method->klass;
+
+	error_init (error);
 
 	/* if method is on a class, we need to look up interface method exists on */
 	if (!MONO_CLASS_IS_INTERFACE(ic)) {
 		int offset = 0;
 		int i = 0;
 		ic = cominterop_get_method_interface (method);
+		if (!ic || !MONO_CLASS_IS_INTERFACE (ic)) {
+			mono_error_set_invalid_operation (error, "Method '%s' in ComImport class '%s' must implement an interface method.", method->name, method->klass->name);
+			return -1;
+		}
 		offset = mono_class_interface_offset (method->klass, ic);
 		g_assert(offset >= 0);
 		int mcount = mono_class_get_method_count (ic);
@@ -643,11 +646,20 @@ void
 mono_mb_emit_cominterop_get_function_pointer (MonoMethodBuilder *mb, MonoMethod *method)
 {
 #ifndef DISABLE_JIT
+	int slot;
+	MonoError error;
 	// get function pointer from 1st arg, the COM interface pointer
 	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_icon (mb, cominterop_get_com_slot_for_method (method));
-	mono_mb_emit_icall (mb, cominterop_get_function_pointer);
-	/* Leaves the function pointer on top of the stack */
+	slot = cominterop_get_com_slot_for_method (method, &error);
+	if (is_ok (&error)) {
+		mono_mb_emit_icon (mb, slot);
+		mono_mb_emit_icall (mb, cominterop_get_function_pointer);
+		/* Leaves the function pointer on top of the stack */
+	}
+	else {
+		mono_mb_emit_exception_for_error (mb, &error);
+	}
+	mono_error_cleanup (&error);
 #endif
 }
 
@@ -1706,7 +1718,10 @@ guint32
 ves_icall_System_Runtime_InteropServices_Marshal_GetComSlotForMethodInfoInternal (MonoReflectionMethod *m)
 {
 #ifndef DISABLE_COM
-	return cominterop_get_com_slot_for_method (m->method);
+	MonoError error;
+	int slot = cominterop_get_com_slot_for_method (m->method, &error);
+	mono_error_assert_ok (&error);
+	return slot;
 #else
 	g_assert_not_reached ();
 #endif

--- a/mono/metadata/method-builder.c
+++ b/mono/metadata/method-builder.c
@@ -654,6 +654,20 @@ mono_mb_emit_exception (MonoMethodBuilder *mb, const char *exc_name, const char 
 }
 
 /**
+ * mono_mb_emit_exception_for_error:
+ */
+void
+mono_mb_emit_exception_for_error (MonoMethodBuilder *mb, MonoError *error)
+{
+	/*
+	 * If at some point there is need to support other types of errors,
+	 * the behaviour should conform with mono_error_prepare_exception().
+	 */
+	g_assert (mono_error_get_error_code (error) == MONO_ERROR_GENERIC && "Unsupported error code.");
+	mono_mb_emit_exception_full (mb, "System", mono_error_get_exception_name (error), mono_error_get_message (error));
+}
+
+/**
  * mono_mb_emit_add_to_local:
  */
 void

--- a/mono/metadata/method-builder.h
+++ b/mono/metadata/method-builder.h
@@ -112,6 +112,9 @@ void
 mono_mb_emit_exception_full (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg);
 
 void
+mono_mb_emit_exception_for_error (MonoMethodBuilder *mb, MonoError *error);
+
+void
 mono_mb_emit_icon (MonoMethodBuilder *mb, gint32 value);
 
 void

--- a/mono/tests/bug-8477.cs
+++ b/mono/tests/bug-8477.cs
@@ -1,0 +1,42 @@
+// This test is meant to make sure Mono doesn't fail when invalid COM invocations are present but never reached.
+// See https://bugzilla.xamarin.com/show_bug.cgi?id=8477 for details.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+[ComImport, Guid("06A82D35-8946-4E2E-AE71-DADDE8341F5D")]
+class COMponent
+{
+    [MethodImpl(MethodImplOptions.InternalCall)] public static extern void InCOMplete1 ();
+    [MethodImpl(MethodImplOptions.InternalCall)] public extern void InCOMplete2 ();
+}
+
+class Test
+{
+    static void COMmunicate (COMponent c)
+    {
+	if (c != null)
+	    c.InCOMplete2 ();
+    }
+
+    static int Main()
+    {
+	// Check #1: An invocation of a ComImport class method w/o a corresponding interface method must lead to an exception.
+	try
+	{
+	    COMponent.InCOMplete1();
+	    // No exception has been thrown, something is wrong.
+	    return 1;
+	}
+	catch (InvalidOperationException)
+	{
+	    // An exception has been thrown and caught correctly.
+	}
+
+	// Check #2: Same as #1, but the method is not executed (i.e. it's located in a "cold" basic block). No exception should be thrown.
+	COMmunicate (null);
+
+	return 0;
+    }
+}

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -153,5 +153,7 @@ mono_error_box (const MonoError *error, MonoImage *image);
 gboolean
 mono_error_set_from_boxed (MonoError *error, const MonoErrorBoxed *from);
 
+const char*
+mono_error_get_exception_name (MonoError *oerror);
 
 #endif

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -176,6 +176,17 @@ mono_error_get_error_code (MonoError *error)
 	return error->error_code;
 }
 
+const char*
+mono_error_get_exception_name (MonoError *oerror)
+{
+	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
+
+	if (error->error_code == MONO_ERROR_NONE)
+		return NULL;
+
+	return error->exception_name;
+}
+
 /*Return a pointer to the internal error message, might be NULL.
 Caller should not release it.*/
 const char*


### PR DESCRIPTION
This patch is meant to fix bug 8477.
Currently if Mono encounters some managed code trying to interact with an invalid COM type, it will consider it a fatal error (g_assert).
However, that bad code may be hidden in a basic block that is never really executed.
This patch is meant to replace the compile-time assertion with a runtime safeguard for all invalid COM invocations it encounters. (That safeguard should never be reached either since if a COM object is invalid, an exception should be thrown during its creation.)