### PR TITLE
[w32handle] Only own first handle if doing WaitHandle.WaitAny

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -518,7 +518,8 @@ TESTS_CS_SRC=		\
 	imt_big_iface_test.cs \
 	bug-58782-plain-throw.cs \
 	bug-58782-capture-and-throw.cs \
-	recursive-struct-arrays.cs
+	recursive-struct-arrays.cs \
+	bug-59281.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/bug-59281.cs
+++ b/mono/tests/bug-59281.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+
+class Driver
+{
+
+	static readonly Mutex[] mutexes = new Mutex[2];
+
+	public static void Main(string[] args)
+	{
+		for (int i = 0; i < mutexes.Length; i++) {
+			mutexes [i] = new Mutex();
+		}
+
+		Thread thread1 = new Thread(() => {
+			for (int i = 0; i < 1; i++) {
+				int idx = -1;
+				try {
+					idx = WaitHandle.WaitAny (mutexes);
+					Console.WriteLine($"Thread 1 iter: {i} with mutex: {idx}");
+				} finally {
+					if (idx != -1)
+						mutexes [idx].ReleaseMutex();
+				}
+			}
+
+			Console.WriteLine("Thread 1 ended");
+		});
+
+		thread1.Start();
+		thread1.Join();
+
+		Thread thread2 = new Thread(() => {
+			for (int i = 0; i < 1000; i++) {
+				int idx = -1;
+				try {
+					idx = WaitHandle.WaitAny (mutexes);
+					Console.WriteLine($"Thread 2 iter: {i} with mutex: {idx}");
+				} finally {
+					if (idx != -1)
+						mutexes [idx].ReleaseMutex();
+				}
+			}
+
+			Console.WriteLine("Thread 2 ended");
+		});
+
+		thread2.Start();
+		thread2.Join();
+	}
+}


### PR DESCRIPTION
This is the behaviour on .NET, even if it goes against the documentation at https://msdn.microsoft.com/en-us/library/tdykks7z(v=vs.110).aspx#Anchor_2

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59281