### PR TITLE
[linker-analyzer] added --flat option

### DIFF
--- a/mcs/tools/linker-analyzer/ConsoleDependencyGraph.cs
+++ b/mcs/tools/linker-analyzer/ConsoleDependencyGraph.cs
@@ -49,12 +49,12 @@ namespace LinkerAnalyzer
 
 			foreach (var d in flatDeps) {
 				if (first) {
-					Console.WriteLine ($"Distance | {d.vertex.value} [total deps: {flatDeps.Count}]");
+					Console.WriteLine ($"Distance | {d.Item1.value} [total deps: {flatDeps.Count}]");
 					Line ();
 					first = false;
 					continue;
 				}
-				Console.WriteLine ($"{string.Format ("{0,8}", d.distance)} | {d.vertex.value}");
+				Console.WriteLine ($"{string.Format ("{0,8}", d.Item2)} | {d.Item1.value}");
 			}
 		}
 

--- a/mcs/tools/linker-analyzer/ConsoleDependencyGraph.cs
+++ b/mcs/tools/linker-analyzer/ConsoleDependencyGraph.cs
@@ -16,6 +16,7 @@ namespace LinkerAnalyzer
 	public class ConsoleDependencyGraph : DependencyGraph
 	{
 		public bool Tree = false;
+		public bool FlatDeps;
 
 		public void ShowDependencies (string raw, List<VertexData> verticesList, string searchString)
 		{
@@ -39,8 +40,32 @@ namespace LinkerAnalyzer
 				ShowDependencies (vertex);
 		}
 
+		void ShowFlatDependencies (VertexData vertex)
+		{
+			bool first = true;
+			var flatDeps = GetAllDependencies (vertex);
+
+			Console.WriteLine ();
+
+			foreach (var d in flatDeps) {
+				if (first) {
+					Console.WriteLine ($"Distance | {d.vertex.value} [total deps: {flatDeps.Count}]");
+					Line ();
+					first = false;
+					continue;
+				}
+				Console.WriteLine ($"{string.Format ("{0,8}", d.distance)} | {d.vertex.value}");
+			}
+		}
+
 		public void ShowDependencies (VertexData vertex)
 		{
+			if (FlatDeps) {
+				ShowFlatDependencies (vertex);
+
+				return;
+			}
+
 			Header ("{0} dependencies", vertex.value);
 			if (vertex.parentIndexes == null) {
 				Console.WriteLine ("Root dependency");
@@ -133,14 +158,19 @@ namespace LinkerAnalyzer
 			ShowDependencies ("TypeDef:" + raw, Types, raw);
 		}
 
+		static readonly string line = new string ('-', 72);
+
+		void Line ()
+		{
+			Console.Write (line);
+			Console.WriteLine ();
+		}
+
 		void Header (string header, params object[] values)
 		{
 			string formatted = string.Format (header, values);
 			Console.WriteLine ();
-			Console.Write ("--- {0} ", formatted);
-			for (int i=0; i< Math.Max (3, 64 - formatted.Length); i++)
-				Console.Write ('-');
-			Console.WriteLine ();
+			Console.WriteLine ($"--- {formatted} {new string ('-', Math.Max (3, 67 - formatted.Length))}");
 		}
 	}
 }

--- a/mcs/tools/linker-analyzer/LinkerAnalyzerCore/DependencyGraph.cs
+++ b/mcs/tools/linker-analyzer/LinkerAnalyzerCore/DependencyGraph.cs
@@ -114,5 +114,28 @@ namespace LinkerAnalyzer.Core
 		{
 			return vertices [index];
 		}
+
+		IEnumerable<(VertexData vertex, int distance)> AddDependencies (VertexData vertex, HashSet<int> reachedVertices, int depth)
+		{
+			reachedVertices.Add (vertex.index);
+			yield return (vertex, depth);
+
+			if (vertex.parentIndexes == null)
+				yield break;
+
+			foreach (var pi in vertex.parentIndexes) {
+				var parent = Vertex (pi);
+				if (reachedVertices.Contains (parent.index))
+					continue;
+
+				foreach (var d in AddDependencies (parent, reachedVertices, depth + 1))
+					yield return d;
+			}
+		}
+
+		public List<(VertexData vertex, int distance)> GetAllDependencies (VertexData vertex)
+		{
+			return new List<(VertexData vertex, int distance)> (AddDependencies (vertex, new HashSet<int> (), 0));
+		}
 	}
 }

--- a/mcs/tools/linker-analyzer/LinkerAnalyzerCore/DependencyGraph.cs
+++ b/mcs/tools/linker-analyzer/LinkerAnalyzerCore/DependencyGraph.cs
@@ -115,10 +115,10 @@ namespace LinkerAnalyzer.Core
 			return vertices [index];
 		}
 
-		IEnumerable<(VertexData vertex, int distance)> AddDependencies (VertexData vertex, HashSet<int> reachedVertices, int depth)
+		IEnumerable<Tuple<VertexData, int>> AddDependencies (VertexData vertex, HashSet<int> reachedVertices, int depth)
 		{
 			reachedVertices.Add (vertex.index);
-			yield return (vertex, depth);
+			yield return new Tuple<VertexData, int> (vertex, depth);
 
 			if (vertex.parentIndexes == null)
 				yield break;
@@ -133,9 +133,9 @@ namespace LinkerAnalyzer.Core
 			}
 		}
 
-		public List<(VertexData vertex, int distance)> GetAllDependencies (VertexData vertex)
+		public List<Tuple<VertexData, int>> GetAllDependencies (VertexData vertex)
 		{
-			return new List<(VertexData vertex, int distance)> (AddDependencies (vertex, new HashSet<int> (), 0));
+			return new List<Tuple<VertexData, int>> (AddDependencies (vertex, new HashSet<int> (), 0));
 		}
 	}
 }

--- a/mcs/tools/linker-analyzer/Main.cs
+++ b/mcs/tools/linker-analyzer/Main.cs
@@ -28,6 +28,7 @@ namespace LinkerAnalyzer
 			bool showTypes = false;
 			bool reduceToTree = false;
 			bool verbose = false;
+			bool flatDeps = false;
 
 			var optionsParser = new OptionSet () {
 				{ "a|alldeps", "show all dependencies", v => { showAllDeps = v != null; } },
@@ -39,6 +40,7 @@ namespace LinkerAnalyzer
 				{ "types", "show all types dependencies.", v => showTypes = v != null },
 				{ "t|typedeps=", "show type dependencies. The VALUE can be regular expression", v => { showTypeDeps = v != null; typeName = v; } },
 				//{ "u|spaceusage", "show space analysis.", v => showSpaceUsage = v != null },
+				{ "f|flat", "show all dependencies per vertex and their distance", v => flatDeps = v != null },
 				{ "v|verbose", "be more verbose. Enables stat and roots options.", v => verbose = v != null },
 			};
 
@@ -56,7 +58,7 @@ namespace LinkerAnalyzer
 
 			string dependencyFile = args [args.Length - 1];
 
-			ConsoleDependencyGraph deps = new ConsoleDependencyGraph () { Tree = reduceToTree };
+			ConsoleDependencyGraph deps = new ConsoleDependencyGraph () { Tree = reduceToTree, FlatDeps = flatDeps };
 			deps.Load (dependencyFile);
 
 			if (showSpaceUsage) {

--- a/mcs/tools/linker-analyzer/Makefile
+++ b/mcs/tools/linker-analyzer/Makefile
@@ -4,7 +4,7 @@ include ../../build/rules.make
 
 PROGRAM = linkeranalyzer.exe
 
-LIB_REFS = System System.Xml
+LIB_REFS = System System.Xml System.Core
 LOCAL_MCS_FLAGS =
 
 include ../../build/executable.make

--- a/mcs/tools/linker-analyzer/README.md
+++ b/mcs/tools/linker-analyzer/README.md
@@ -121,5 +121,6 @@ Options:
       --types                show all types dependencies.
   -t, --typedeps=VALUE       show type dependencies. The VALUE can be regular
                                expression
+  -f, --flat                 show all dependencies per vertex and their distance
   -v, --verbose              be more verbose. Enables stat and roots options.
 ```

--- a/mcs/tools/linker-analyzer/linkeranalyzer-net_4_x.csproj
+++ b/mcs/tools/linker-analyzer/linkeranalyzer-net_4_x.csproj
@@ -86,6 +86,10 @@
       <Project>{2762E921-91A8-4C87-91E9-BA628013F753}</Project>
       <Name>System-net_4_x</Name>
     </ProjectReference>
+    <ProjectReference Include="../../class/System.Core/System.Core-net_4_x.csproj">
+      <Project>{359142A1-D80F-401E-AA64-7167C9317649}</Project>
+      <Name>System.Core-net_4_x</Name>
+    </ProjectReference>
     <ProjectReference Include="../../class/System.XML/System.Xml-net_4_x.csproj">
       <Project>{87FD2F0F-5222-4AE6-BD63-2D4975E11E5B}</Project>
       <Name>System.Xml-net_4_x</Name>


### PR DESCRIPTION
This options allows to see all dependencies per vertex at once, with
displayed distance in the graph between the vertex and dependent
vertex.

An example of flat output:

    Loading dependency tree from: linker-dependencies.xml.gz

    --- Type dependencies: 'Android.App.Activity' --------------------------

    Distance | TypeDef:Android.App.Activity [total deps: 7]
    ------------------------------------------------------------------------
           1 | TypeDef:XA.App.MainActivity
           2 | Assembly:XA.App, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
           3 | Other:Mono.Linker.Steps.ResolveFromAssemblyStep
           3 | Other:Mono.Tuner.CustomizeActions
           3 | Other:MonoDroid.Tuner.MonoDroidMarkStep
           2 | TypeDef:XA.App.MainActivity/<>c__DisplayClass1_0