### PR TITLE
[class] Two generic parameter cleanups

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2926,6 +2926,10 @@ collect_implemented_interfaces_aux (MonoClass *klass, GPtrArray **res, GHashTabl
 			*ifaces = g_hash_table_new (NULL, NULL);
 		if (g_hash_table_lookup (*ifaces, ic))
 			continue;
+		/* A gparam is not an implemented interface for the purposes of
+		 * mono_class_get_implemented_interfaces */
+		if (mono_class_is_gparam (ic))
+			continue;
 		g_ptr_array_add (*res, ic);
 		g_hash_table_insert (*ifaces, ic, ic);
 		mono_class_init (ic);
@@ -3316,7 +3320,9 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 		for (i = 0; i < k->interface_count; i++) {
 			ic = k->interfaces [i];
 
-			mono_class_init (ic);
+			/* A gparam does not have any interface_id set. */
+			if (! mono_class_is_gparam (ic))
+				mono_class_init (ic);
 
 			if (max_iid < ic->interface_id)
 				max_iid = ic->interface_id;

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -45,6 +45,7 @@ mono_class_from_typeref    (MonoImage *image, uint32_t type_token);
 MONO_API MonoClass *
 mono_class_from_typeref_checked (MonoImage *image, uint32_t type_token, MonoError *error);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClass *
 mono_class_from_generic_parameter (MonoGenericParam *param, MonoImage *image, mono_bool is_mvar);
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -2897,7 +2897,7 @@ encode_klass_ref_inner (MonoAotCompile *acfg, MonoClass *klass, guint8 *buf, gui
 		if (par->gshared_constraint) {
 			MonoGSharedGenericParam *gpar = (MonoGSharedGenericParam*)par;
 			encode_type (acfg, par->gshared_constraint, p, &p);
-			encode_klass_ref (acfg, mono_class_from_generic_parameter (gpar->parent, NULL, klass->byval_arg.type == MONO_TYPE_MVAR), p, &p);
+			encode_klass_ref (acfg, mono_class_from_generic_parameter_internal (gpar->parent), p, &p);
 		} else {
 			encode_value (klass->byval_arg.type, p, &p);
 			encode_value (mono_type_get_generic_param_num (&klass->byval_arg), p, &p);


### PR DESCRIPTION
1. Mark `mono_class_from_generic_parameter` external only.  Runtime should use   `mono_class_from_generic_parameter_internal`


2. Short circuit a couple of traversals that look for implemented interfaces when we come to a generic 
  parameter:
  
   A gparam is never a real interface so we can just short circuit if we see a gparam during interface collection.  (A gparam may be instantiated with an interface --- but ginst interface offsets are processed anew when the ginst is initialized in `mono_class_init`, not somehow extracted from the gtd and the `MonoGenericContext`).