### PR TITLE
[threads] Guarantee we abort all threads before shutdown

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3235,8 +3235,6 @@ abort_threads (gpointer key, gpointer value, gpointer user)
 
 	if ((thread->flags & MONO_THREAD_FLAG_DONT_MANAGE))
 		return;
-	if (!(thread->state & ThreadState_Background))
-		return;
 
 	wait->handles[wait->num] = mono_threads_open_thread_handle (thread->handle);
 	wait->threads[wait->num] = thread;


### PR DESCRIPTION
We want to guarantee we abort ALL running threads at shutdown, expect for some very specific cases: finaliser and DONT_MANAGE threads (ex: debugger).

These changes guarantees that by making sure we do not remove a thread before it actually is detached, and by also making sure we do not miss some threads that switched to background in a racy way.