### PR TITLE
[2017-08][class] Use constraints of gparam T2 in T1.IsAssignableFrom (T2)

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3619,6 +3619,38 @@ namespace MonoTests.System
 			public int field;
 		}
 
+		[Test]
+		public void IsAssignableFromGenericArgumentsWithConstraints ()
+		{
+			// Regression test for #58809
+
+			// Generic Parameters of a gtd should have their
+			// constraints respected even when those constraints
+			// are other generic parameters themselves.
+
+			var ps = typeof (GenericWithParamConstraints<,,>).GetGenericArguments ();
+
+			var a = ps[0];
+			var b = ps[1];
+			var c = ps[2];
+
+			// Foo<C>
+			var fooOfC = typeof (Foo<>).MakeGenericType (c);
+
+			// constraint B : Foo <C>
+			Assert.IsTrue (fooOfC.IsAssignableFrom (b), "#1");
+
+			// constraint A : B
+			Assert.IsTrue (b.IsAssignableFrom (a), "#2");
+
+			// A : Foo<C> since A : B and B : Foo<C>
+			Assert.IsTrue (fooOfC.IsAssignableFrom (a), "#3");
+		}
+
+		class GenericWithParamConstraints<A, B, C> where B : Foo<C> where A : B
+		{
+		}
+
 		[Test] // Bug #612780
 		public void CannotMakeDerivedTypesFromTypedByRef ()
 		{

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -8219,21 +8219,30 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 		return mono_gparam_is_assignable_from (klass, oklass);
 	}
 
-	if (MONO_CLASS_IS_INTERFACE (klass)) {
-		if ((oklass->byval_arg.type == MONO_TYPE_VAR) || (oklass->byval_arg.type == MONO_TYPE_MVAR)) {
-			MonoGenericParam *gparam = oklass->byval_arg.data.generic_param;
-			MonoClass **constraints = mono_generic_container_get_param_info (gparam->owner, gparam->num)->constraints;
-			int i;
+	/* This can happen if oklass is a tyvar that has a constraint which is another tyvar which in turn
+	 * has a constraint which is a class type:
+	 *
+	 *  class Foo { }
+	 *  class G<T1, T2> where T1 : T2 where T2 : Foo { }
+	 *
+	 * In this case, Foo is assignable from T1.
+	 */
+	if ((oklass->byval_arg.type == MONO_TYPE_VAR) || (oklass->byval_arg.type == MONO_TYPE_MVAR)) {
+		MonoGenericParam *gparam = oklass->byval_arg.data.generic_param;
+		MonoClass **constraints = mono_generic_container_get_param_info (gparam->owner, gparam->num)->constraints;
+		int i;
 
-			if (constraints) {
-				for (i = 0; constraints [i]; ++i) {
-					if (mono_class_is_assignable_from (klass, constraints [i]))
-						return TRUE;
-				}
+		if (constraints) {
+			for (i = 0; constraints [i]; ++i) {
+				if (mono_class_is_assignable_from (klass, constraints [i]))
+					return TRUE;
 			}
-
-			return FALSE;
 		}
+
+		return mono_class_has_parent (oklass, klass);
+	}
+
+	if (MONO_CLASS_IS_INTERFACE (klass)) {
 
 		/* interface_offsets might not be set for dynamic classes */
 		if (mono_class_get_ref_info_handle (oklass) && !oklass->interface_bitmap) {


### PR DESCRIPTION
Cherrypick #5611 to `2017-08`


----

Suppose we want to know C.IsAssignableFrom (T1):
```
  class C { }
  class G<T1, T2> where T1 : T2, T2 : C { }
```

Previously, we would get `False`, because we only checked the constraints of `T1`
if `C` was an interface or another gparam.  Now instead we always consider the
constraints in `A.IsAssignableFrom (B)` whenever `B` is a gparam.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58809