### PR TITLE
[Mono.Unix] Fix crasher in StringToHeap

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix/UnixMarshal.cs
@@ -309,6 +309,9 @@ namespace Mono.Unix {
 
 		public static IntPtr StringToHeap (string s, Encoding encoding)
 		{
+			if (s == null)
+				return IntPtr.Zero;
+
 			return StringToHeap (s, 0, s.Length, encoding);
 		}
 

--- a/mcs/class/Mono.Posix/Test/Mono.Unix/UnixMarshalTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix/UnixMarshalTest.cs
@@ -41,6 +41,13 @@ namespace MonoTests.Mono.Unix {
 #endif
 
 		[Test]
+		public void BXC10074 ()
+		{
+			var result = UnixMarshal.StringToHeap (null, Encoding.ASCII);
+			Assert.AreEqual (IntPtr.Zero, result, "This used to crash due to a NullReferenceException");
+		}
+
+		[Test]
 		public void TestStringToHeap ()
 		{
 			object[] data = {


### PR DESCRIPTION
In case StringToHeap (string, Encoding) was called with a null string, it would unconditionally reference the string when trying to query the string's length.

Bug 10074 - Error while updating status of command: MonoDevelop.Ide.Commands.ViewCommands.LayoutList