### PR TITLE
[mkbundle] Link against Objective-C runtime and Foundation framework on OSX

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -1009,6 +1009,7 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			else
 			{
 				string zlib = (compress ? "-lz" : "");
+				string objc = (style == "osx" ? "-framework CoreFoundation -lobjc" : "");
 				string debugging = "-g";
 				string cc = GetEnv("CC", "cc");
 				string cmd = null;
@@ -1022,16 +1023,16 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 						smonolib = "`pkg-config --variable=libdir mono-2`/libmono-2.0.a ";
 					else
 						smonolib = "-Wl,-Bstatic -lmono-2.0 -Wl,-Bdynamic ";
-					cmd = String.Format("{4} -o '{2}' -Wall `pkg-config --cflags mono-2` {0} {3} " +
+					cmd = String.Format("{4} -o '{2}' -Wall {5} `pkg-config --cflags mono-2` {0} {3} " +
 						"`pkg-config --libs-only-L mono-2` " + smonolib +
 						"`pkg-config --libs-only-l mono-2 | sed -e \"s/\\-lmono-2.0 //\"` {1}",
-						temp_c, temp_o, output, zlib, cc);
+						temp_c, temp_o, output, zlib, cc, objc);
 				}
 				else
 				{
 
-					cmd = String.Format("{4} " + debugging + " -o '{2}' -Wall {0} `pkg-config --cflags --libs mono-2` {3} {1}",
-						temp_c, temp_o, output, zlib, cc);
+					cmd = String.Format("{4} " + debugging + " -o '{2}' -Wall {5} {0} `pkg-config --cflags --libs mono-2` {3} {1}",
+						temp_c, temp_o, output, zlib, cc, objc);
 				}
 				Execute (cmd);
 			}


### PR DESCRIPTION
Without it you get errors like the following in old-style mkbundle:

```
Undefined symbols for architecture x86_64:
  "_CFLocaleCopyCurrent", referenced from:
      _ves_icall_System_Globalization_CultureInfo_get_current_locale_name in libmono-2.0.a(libmonoruntimesgen_la-locales.o)
  "_CFLocaleGetIdentifier", referenced from:
      _ves_icall_System_Globalization_CultureInfo_get_current_locale_name in libmono-2.0.a(libmonoruntimesgen_la-locales.o)
  "_CFLocaleGetValue", referenced from:
      _ves_icall_System_Globalization_CultureInfo_get_current_locale_name in libmono-2.0.a(libmonoruntimesgen_la-locales.o)
  "_CFRelease", referenced from:
      _ves_icall_System_Globalization_CultureInfo_get_current_locale_name in libmono-2.0.a(libmonoruntimesgen_la-locales.o)
...
```

We actually documented this in the 3.4 release notes: http://www.mono-project.com/docs/about-mono/releases/3.4.0/#breaking-changes

However this means that you had to use the "-c" mkbundle option to only generate the .c stub so you could pass those additional libraries.