### PR TITLE
[tests] Reenable mkbundle tests by adding pkgconfig to _tmpinst

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,6 @@ EXTRA_DIST= \
 	LICENSE 		\
 	autogen.sh 		\
 	mkinstalldirs 		\
-	mono-uninstalled.pc.in 	\
 	winconfig.h 		\
 	code_of_conduct.md 	\
 	external		\
@@ -46,8 +45,6 @@ dist-hook:
 	rm -f `find $(top_distdir)/external -path '*\.dll' -not -path '*/binary-reference-assemblies/*' -not -path '*/roslyn-binaries/*'`
 
 pkgconfigdir = $(libdir)/pkgconfig
-noinst_DATA = mono-uninstalled.pc
-DISTCLEANFILES= mono-uninstalled.pc
 
 # building with monolite
 .PHONY: get-monolite-latest 

--- a/configure.ac
+++ b/configure.ac
@@ -4570,7 +4570,6 @@ AC_CONFIG_COMMANDS([nolock-libtool], [sed -e 's/lock_old_archive_extraction=yes/
 
 AC_OUTPUT([
 Makefile
-mono-uninstalled.pc
 acceptance-tests/Makefile
 llvm/Makefile
 scripts/mono-find-provides
@@ -4642,6 +4641,7 @@ tools/sgen/Makefile
 tools/monograph/Makefile
 tools/pedump/Makefile
 runtime/Makefile
+runtime/mono-uninstalled.pc
 msvc/Makefile
 po/Makefile
 ])

--- a/mono-uninstalled.pc.in
+++ b/mono-uninstalled.pc.in
@@ -1,6 +1,0 @@
-Name: Mono
-Description: Mono Runtime
-Version: @VERSION@
-Requires: glib-2.0 gthread-2.0
-Libs: -L@mono_build_root@/mono/mini/.libs @export_ldflags@ -lmono @libmono_ldflags@
-Cflags: -I@abs_top_srcdir@ -I@abs_top_srcdir@/mono @libmono_cflags@

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -8,7 +8,9 @@ check-local:
 	$(MAKE) test-multi-netmodule || ok=false; \
 	$(MAKE) test-cattr-type-load || ok=false; \
 	$(MAKE) test-reflection-load-with-context || ok=false; \
-	$(MAKE) test-platform || ok=false; \
+	$(MAKE) test-iomap-regression || ok=false; \
+	$(MAKE) test-eglib-remap || ok=false; \
+	$(MAKE) test-bundle || ok=false; \
 	$(MAKE) test-console-output || ok=false; \
 	$(MAKE) test-env-options || ok=false; \
 	$(MAKE) test-unhandled-exception-2 || ok=false; \
@@ -58,7 +60,7 @@ RUNTIME = $(with_mono_path) $(top_builddir)/runtime/mono-wrapper
 TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/mono-wrapper --aot-path=$(mcs_topdir)/class/lib/build
 
 MKBUNDLE = \
-	PKG_CONFIG_PATH=$(top_builddir):$(PKG_CONFIG_PATH) \
+	PKG_CONFIG_PATH=$(top_builddir)/runtime/_tmpinst/lib/pkgconfig:$(PKG_CONFIG_PATH) \
 	$(RUNTIME) $(CLASS)/mkbundle.exe
 
 if FULL_AOT_TESTS
@@ -1138,34 +1140,12 @@ TestingReferenceReferenceAssembly.dll: TestingReferenceReferenceAssembly.cs Test
 %.dll$(PLATFORM_AOT_SUFFIX): %.dll 
 	$(RUNTIME) $(AOT_BUILD_FLAGS) $<
 
-# mkbundle works on ppc, but the pkg-config POC doesn't when run with make test
-if POWERPC
-test-platform:
-else
-# Can't use mkbundle on win32 since there is no static build there
-# Can't run test-unhandled-exception on Windows because of all the debug popups...
-if HOST_WIN32
-test-platform:
-else
-# mkbundle uses the installed mono-2.pc so it won't work if there is no system mono
-#test-platform:	testbundle test-iomap-regression
-test-platform:	test-iomap-regression
-endif
-endif
-
 # Target to precompile the test executables
 tests: compile-tests
 
 #
 # Test that no symbols are missed in eglib-remap.h
 #
-if HOST_LINUX
-test-platform: test-eglib-remap
-else
-if HOST_DARWIN
-test-platform: test-eglib-remap
-endif
-endif
 # The following regexp describes all symbols that start with "g_" but are not part of eglibc.
 # The optional underscore prepending symbol names may or may not appear depending on the
 # system and the state of the leading-underscore compiler flag.
@@ -1268,11 +1248,17 @@ stresstest: compile-tests
 	if [ $${failed} != 0 ]; then echo -e "\nFailed tests:\n"; \
 	  for i in $${failed_tests}; do echo $${i}; done; exit 1; fi
 
-testbundle: console.exe
+# Can't use mkbundle on win32 since there is no static build there
+# Can't use mkbundle on fullaot since it's not built there
+test-bundle: console.exe
+if !HOST_WIN32
+if !FULL_AOT_TESTS
 	@echo "Testing mkbundle..."
-	@$(MKBUNDLE) --static console.exe > mkbundle.stdout
+	@$(MKBUNDLE) -v --i18n none --static console.exe > mkbundle.stdout
 	@$(with_mono_path) MONO_CFG_DIR=$(mono_cfg_dir) ./a.out >> mkbundle.stdout
-	@- rm -rf a.out
+	@- rm -rf a.out*
+endif
+endif
 
 EXTRA_DIST += load-missing.il t-missing.cs load-exceptions.cs
 

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -12,3 +12,4 @@
 /_tmpinst
 /net_2_0
 /net_1_1
+/mono-uninstalled.pc

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -1,6 +1,7 @@
 tmpinst = _tmpinst
 
 noinst_SCRIPTS = mono-wrapper monodis-wrapper
+noinst_DATA = mono-uninstalled.pc
 
 etctmp = etc
 symlinks = etc/mono/1.0/machine.config etc/mono/2.0/machine.config etc/mono/2.0/web.config etc/mono/browscap.ini etc/mono/2.0/Browsers/Compat.browser
@@ -104,7 +105,7 @@ clean-local:
 
 endif BUILD_MCS
 
-TEST_SUPPORT_FILES = $(tmpinst)/bin/mono $(tmpinst)/bin/ilasm $(tmpinst)/bin/csc $(tmpinst)/bin/mcs $(tmpinst)/bin/al
+TEST_SUPPORT_FILES = $(tmpinst)/bin/mono $(tmpinst)/bin/ilasm $(tmpinst)/bin/csc $(tmpinst)/bin/mcs $(tmpinst)/bin/al $(tmpinst)/lib/pkgconfig/mono-2.pc
 
 mcs-do-test-profiles:
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' test-profiles
@@ -177,7 +178,7 @@ check-local: mcs-compileall mcs-do-test-profiles
 # Compile all mcs tests
 test: mcs-do-test-profiles
 
-CLEANFILES = etc/mono/config
+CLEANFILES = etc/mono/config $(tmpinst)/lib/pkgconfig/mono-2.pc
 
 # depend on $(symlinks) to ensure 'etc/mono' directory exists
 etc/mono/config: ../data/config Makefile $(symlinks)
@@ -218,6 +219,10 @@ $(tmpinst)/bin/al: $(tmpinst)/bin/mono Makefile
 	r=`pwd`; m=`cd $(mcs_topdir) && pwd`; \
 	echo 'exec "'"$$r/$(tmpinst)/bin/mono"'" "'"$$m/class/lib/$(net_profile)/al.exe"'" "$$@"' >> $@ ; \
 	chmod +x $@
+
+$(tmpinst)/lib/pkgconfig/mono-2.pc: mono-uninstalled.pc
+	$(mkinstalldirs) $(tmpinst)/lib/pkgconfig
+	cp $< $@
 
 test-support-files: $(TEST_SUPPORT_FILES)
 	@:

--- a/runtime/mono-uninstalled.pc.in
+++ b/runtime/mono-uninstalled.pc.in
@@ -1,0 +1,9 @@
+libdir=@mono_build_root@/mono/mini/.libs
+includedir=@abs_top_srcdir@
+
+Name: Mono
+Description: Mono Runtime
+Version: @VERSION@
+Requires: glib-2.0 gthread-2.0
+Libs: -L${libdir} @export_ldflags@ -lmono-@API_VER@ @libmono_ldflags@
+Cflags: -I${includedir} @libmono_cflags@

--- a/runtime/mono-uninstalled.pc.in
+++ b/runtime/mono-uninstalled.pc.in
@@ -4,6 +4,5 @@ includedir=@abs_top_srcdir@
 Name: Mono
 Description: Mono Runtime
 Version: @VERSION@
-Requires: glib-2.0 gthread-2.0
 Libs: -L${libdir} @export_ldflags@ -lmono-@API_VER@ @libmono_ldflags@
 Cflags: -I${includedir} @libmono_cflags@


### PR DESCRIPTION
The mkbundle test was disabled because mkbundle relies on pkg-config to find the mono library which would only work if system mono is installed (and then it resolves the wrong one):
https://github.com/mono/mono/commit/9e6c489b1499a311792c341f86cfa32d7a2acea2

However, we already have the mono-uninstalled.pc file which according to git history was added specifically for testing mkbundle in-tree: https://github.com/mono/mono/commit/dc2f86844b0be2cd99e375a664b2d694eea323ac

Reenable this logic by adding the resulting .pc file to _tmpinst so we can point pkg-config to it during tests.