### PR TITLE
[corlib] Make Marshal.BufferToBSTR(Array, int) non-public again

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -1239,7 +1239,7 @@ namespace System.Runtime.InteropServices
 
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		public extern static IntPtr BufferToBSTR (Array ptr, int slen);
+		extern static IntPtr BufferToBSTR (Array ptr, int slen);
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		public extern static IntPtr UnsafeAddrOfPinnedArrayElement (Array arr, int index);


### PR DESCRIPTION
It was accidentally made public in https://github.com/mono/mono/commit/c5cdfaec1e0973ced3f97ef589cd0bece56067ad.

Unfortunately this was before we had the API diff check on Mono and the manual checks in XI/XA integration didn't catch it either.