### PR TITLE
Fix LinearGradientMode parameter validation to match corefx

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing.Drawing2D/LinearGradientBrush.cs
+++ b/mcs/class/System.Drawing/System.Drawing.Drawing2D/LinearGradientBrush.cs
@@ -67,6 +67,14 @@ namespace System.Drawing.Drawing2D {
 
 		public LinearGradientBrush (Rectangle rect, Color color1, Color color2, LinearGradientMode linearGradientMode)
 		{
+			if (linearGradientMode < LinearGradientMode.Horizontal || linearGradientMode > LinearGradientMode.BackwardDiagonal) {
+				throw new InvalidEnumArgumentException (nameof (linearGradientMode), unchecked ((int)linearGradientMode), typeof (LinearGradientMode));
+			}
+
+			if (rect.Width == 0 || rect.Height == 0) {
+				throw new ArgumentException( string.Format ("Rectangle '{0}' cannot have a width or height equal to 0.", rect.ToString ()));
+			}
+
 			IntPtr nativeObject;
 			Status status = GDIPlus.GdipCreateLineBrushFromRectI (ref rect, color1.ToArgb (), color2.ToArgb (), linearGradientMode, WrapMode.Tile, out nativeObject);
 			GDIPlus.CheckStatus (status);
@@ -81,6 +89,14 @@ namespace System.Drawing.Drawing2D {
 
 		public LinearGradientBrush (RectangleF rect, Color color1, Color color2, LinearGradientMode linearGradientMode)
 		{
+			if (linearGradientMode < LinearGradientMode.Horizontal || linearGradientMode > LinearGradientMode.BackwardDiagonal) {
+				throw new InvalidEnumArgumentException (nameof (linearGradientMode), unchecked ((int)linearGradientMode), typeof (LinearGradientMode));
+			}
+
+			if (rect.Width == 0.0 || rect.Height == 0.0) {
+				throw new ArgumentException (string.Format ("Rectangle '{0}' cannot have a width or height equal to 0.", rect.ToString ()));
+			}
+
 			IntPtr nativeObject;
 			Status status = GDIPlus.GdipCreateLineBrushFromRect (ref rect, color1.ToArgb (), color2.ToArgb (), linearGradientMode, WrapMode.Tile, out nativeObject);
 			GDIPlus.CheckStatus (status);
@@ -95,6 +111,10 @@ namespace System.Drawing.Drawing2D {
 
 		public LinearGradientBrush (Rectangle rect, Color color1, Color color2, float angle, bool isAngleScaleable)
 		{
+			if (rect.Width == 0 || rect.Height == 0) {
+				throw new ArgumentException (string.Format ("Rectangle '{0}' cannot have a width or height equal to 0.", rect.ToString ()));
+			}
+
 			IntPtr nativeObject;
 			Status status = GDIPlus.GdipCreateLineBrushFromRectWithAngleI (ref rect, color1.ToArgb (), color2.ToArgb (), angle, isAngleScaleable, WrapMode.Tile, out nativeObject);
 			GDIPlus.CheckStatus (status);
@@ -105,6 +125,10 @@ namespace System.Drawing.Drawing2D {
 
 		public LinearGradientBrush (RectangleF rect, Color color1, Color color2, float angle, bool isAngleScaleable)
 		{
+			if (rect.Width == 0 || rect.Height == 0) {
+				throw new ArgumentException (string.Format ("Rectangle '{0}' cannot have a width or height equal to 0.", rect.ToString ()));
+			}
+
 			IntPtr nativeObject;
 			Status status = GDIPlus.GdipCreateLineBrushFromRectWithAngle (ref rect, color1.ToArgb (), color2.ToArgb (), angle, isAngleScaleable, WrapMode.Tile, out nativeObject);
 			GDIPlus.CheckStatus (status);

--- a/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Drawing2D/LinearGradientBrushTest.cs
@@ -325,6 +325,42 @@ namespace MonoTests.System.Drawing.Drawing2D {
 		}
 
 		[Test]
+		public void Constructor_Rectangle_InvalidWidthHeight ()
+		{
+			var emptyWidth = new Rectangle (0, 0, 0, 1);
+			var emptyHeight = new Rectangle (0, 0, 0, 1);
+
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyWidth, Color.Empty, Color.Empty, 1));
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyHeight, Color.Empty, Color.Empty, 1));
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyWidth, Color.Empty, Color.Empty, LinearGradientMode.BackwardDiagonal));
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyHeight, Color.Empty, Color.Empty, LinearGradientMode.BackwardDiagonal));
+		}
+
+		[Test]
+		public void Constructor_RectangleF_InvalidWidthHeight ()
+		{
+			var emptyWidth = new RectangleF (0, 0, 0, 1);
+			var emptyHeight = new RectangleF (0, 0, 0, 1);
+
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyWidth, Color.Empty, Color.Empty, 1));
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyHeight, Color.Empty, Color.Empty, 1));
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyWidth, Color.Empty, Color.Empty, LinearGradientMode.BackwardDiagonal));
+			Assert.Throws<ArgumentException>(() => new LinearGradientBrush (emptyHeight, Color.Empty, Color.Empty, LinearGradientMode.BackwardDiagonal));
+		}
+
+		[Test]
+		public void Constructor_LinearGradientMode_InvalidMode ()
+		{
+			var rect = new Rectangle (0, 0, 1, 1);
+			var rectf = new RectangleF (0, 0, 1, 1);
+
+			Assert.Throws<InvalidEnumArgumentException>(() => new LinearGradientBrush (rect, Color.Empty, Color.Empty, LinearGradientMode.Horizontal - 1));
+			Assert.Throws<InvalidEnumArgumentException>(() => new LinearGradientBrush (rectf, Color.Empty, Color.Empty, LinearGradientMode.Horizontal - 1));
+			Assert.Throws<InvalidEnumArgumentException>(() => new LinearGradientBrush (rect, Color.Empty, Color.Empty, LinearGradientMode.BackwardDiagonal + 1));
+			Assert.Throws<InvalidEnumArgumentException>(() => new LinearGradientBrush (rectf, Color.Empty, Color.Empty, LinearGradientMode.BackwardDiagonal + 1));
+		}
+
+		[Test]
 		public void InterpolationColors_Colors_InvalidBlend ()
 		{
 			// default Blend doesn't allow getting this property


### PR DESCRIPTION
E.g. https://github.com/dotnet/corefx/blob/master/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs#L46-L54

This is needed to fix things like https://github.com/mono/libgdiplus/blob/76918a6218fbb112f9eeba1dfd50cc8d1f87e485/tests/testlineargradientbrush.c#L168-L171