### PR TITLE
[corlib] Fix Empty generic enumerator equality

### DIFF
--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -68,7 +68,10 @@ namespace System
 
 		internal IEnumerator<T> InternalArray__IEnumerable_GetEnumerator<T> ()
 		{
-			return new InternalEnumerator<T> (this);
+			if (Length == 0)
+				return EmptyInternalEnumerator<T>.Value;
+			else
+				return new InternalEnumerator<T> (this);
 		}
 
 		internal void InternalArray__ICollection_Clear ()
@@ -269,6 +272,38 @@ namespace System
 			[ReliabilityContractAttribute (Consistency.WillNotCorruptState, Cer.Success)]
 			get {
 				return this.GetRank ();
+			}
+		}
+
+		internal class EmptyInternalEnumerator<T> : IEnumerator<T>
+		{
+			public static readonly EmptyInternalEnumerator<T> Value = new EmptyInternalEnumerator<T> ();
+
+			public void Dispose ()
+			{
+				return;
+			}
+
+			public bool MoveNext ()
+			{
+				return false;
+			}
+
+			public T Current {
+				get {
+					throw new InvalidOperationException ("Enumeration has not started. Call MoveNext");
+				}
+			}
+
+			object IEnumerator.Current {
+				get {
+					return Current;
+				}
+			}
+
+			void IEnumerator.Reset ()
+			{
+				return;
 			}
 		}
 

--- a/mcs/class/corlib/Test/System/ArrayTest.cs
+++ b/mcs/class/corlib/Test/System/ArrayTest.cs
@@ -3669,6 +3669,20 @@ public class ArrayTest
 		Assert.AreEqual (3, c.Counter);		
 	}
 
+	[Test]
+	public void EnumeratorsEquality ()
+	{
+		int [] normalBase = new int [0];
+		IEnumerable<int> specialBase = new int [0];
+
+		var firstSpecial = specialBase.GetEnumerator ();
+		var secondSpecial = specialBase.GetEnumerator ();
+		var firstNormal = normalBase.GetEnumerator ();
+		var secondNormal = normalBase.GetEnumerator ();
+
+		Assert.IsFalse (object.ReferenceEquals (firstNormal, secondNormal));
+		Assert.IsTrue (object.ReferenceEquals (firstSpecial, secondSpecial));
+	}
 
 	[Test]
 	public void JaggedArrayCtor ()


### PR DESCRIPTION
On the CLR, two enumerators containing zero elements will
have reference equality if they are inflated with the same
generic type.

If comparing two enumerators which are not inflated (Array.Empty, for
instance), they are not equal when they contain zero elements.

This reference equality behavior is not compatible with treating
the enumerators as structs, as value types will not have reference
equality.