### PR TITLE
[runtime] Store implmap_idx as a guint32 to avoid overflows if the im…

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -111,7 +111,7 @@ struct _MonoMethodPInvoke {
 	gpointer addr;
 	/* add marshal info */
 	guint16 piflags;  /* pinvoke flags */
-	guint16 implmap_idx;  /* index into IMPLMAP */
+	guint32 implmap_idx;  /* index into IMPLMAP */
 };
 
 /* 


### PR DESCRIPTION
…plmap table has more than 64k rows. Fixes #59881.