### PR TITLE
Callspec unit testing and a bugfix

### DIFF
--- a/mono/metadata/callspec.c
+++ b/mono/metadata/callspec.c
@@ -62,6 +62,8 @@ gboolean mono_callspec_eval (MonoMethod *method, const MonoCallSpec *spec)
 
 	for (i = 0; i < spec->len; i++) {
 		MonoTraceOperation *op = &spec->ops[i];
+		MonoMethodDesc *mdesc;
+		gboolean is_full;
 		int inc = 0;
 
 		switch (op->op) {
@@ -82,8 +84,12 @@ gboolean mono_callspec_eval (MonoMethod *method, const MonoCallSpec *spec)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_METHOD:
-			if (mono_method_desc_full_match (
-				(MonoMethodDesc *)op->data, method))
+			mdesc = op->data;
+			is_full = mono_method_desc_is_full (mdesc);
+			if (is_full &&
+			    mono_method_desc_full_match (mdesc, method))
+				inc = 1;
+			if (!is_full && mono_method_desc_match (mdesc, method))
 				inc = 1;
 			break;
 		case MONO_TRACEOP_CLASS:

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -490,6 +490,7 @@ static gboolean
 match_class (MonoMethodDesc *desc, int pos, MonoClass *klass)
 {
 	const char *p;
+	gboolean is_terminal = TRUE;
 
 	if (desc->klass_glob && !strcmp (desc->klass, "*"))
 		return TRUE;
@@ -497,9 +498,14 @@ match_class (MonoMethodDesc *desc, int pos, MonoClass *klass)
 	if (desc->klass_glob && g_pattern_match_simple (desc->klass, klass->name))
 		return TRUE;
 #endif
+	if (desc->klass[pos] == '/')
+		is_terminal = FALSE;
+
 	p = my_strrchr (desc->klass, '/', &pos);
 	if (!p) {
-		if (strncmp (desc->klass, klass->name, pos))
+		if (is_terminal && strcmp (desc->klass, klass->name))
+			return FALSE;
+		if (!is_terminal && strncmp (desc->klass, klass->name, pos))
 			return FALSE;
 		if (desc->name_space && strcmp (desc->name_space, klass->name_space))
 			return FALSE;
@@ -512,6 +518,15 @@ match_class (MonoMethodDesc *desc, int pos, MonoClass *klass)
 		return FALSE;
 
 	return match_class (desc, pos, klass->nested_in);
+}
+
+/**
+ * mono_method_desc_is_full:
+ */
+gboolean
+mono_method_desc_is_full (MonoMethodDesc *desc)
+{
+	return desc->klass && desc->klass[0] != '\0';
 }
 
 /**

--- a/mono/metadata/debug-helpers.h
+++ b/mono/metadata/debug-helpers.h
@@ -38,6 +38,7 @@ MONO_API MonoMethodDesc* mono_method_desc_new (const char *name, mono_bool inclu
 MONO_API MonoMethodDesc* mono_method_desc_from_method (MonoMethod *method);
 MONO_API void            mono_method_desc_free (MonoMethodDesc *desc);
 MONO_API mono_bool       mono_method_desc_match (MonoMethodDesc *desc, MonoMethod *method);
+MONO_API mono_bool       mono_method_desc_is_full (MonoMethodDesc *desc);
 MONO_API mono_bool       mono_method_desc_full_match (MonoMethodDesc *desc, MonoMethod *method);
 MONO_API MonoMethod*     mono_method_desc_search_in_class (MonoMethodDesc *desc, MonoClass *klass);
 MONO_API MonoMethod*     mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image);

--- a/mono/unit-tests/.gitignore
+++ b/mono/unit-tests/.gitignore
@@ -10,3 +10,4 @@
 /test-sgen-qsort
 /test-conc-hashtable
 /test-mono-handle
+/test-mono-callspec

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -1,5 +1,19 @@
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\"
 
+CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
+
+TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/mono-wrapper --aot-path=$(mcs_topdir)/class/lib/build
+
+MCS_NO_UNSAFE = $(TOOLS_RUNTIME) $(CSC) -debug:portable \
+	-noconfig -nologo \
+	-nowarn:0162 -nowarn:0168 -nowarn:0219 -nowarn:0414 -nowarn:0618 \
+	-nowarn:0169 -nowarn:1690 -nowarn:0649 -nowarn:0612 -nowarn:3021 \
+	-nowarn:0197 $(PROFILE_MCS_FLAGS)
+MCS_NO_LIB = $(MCS_NO_UNSAFE) -unsafe
+
+MCS = $(MCS_NO_LIB)
+
+
 test_cflags = $(AM_CFLAGS) $(SGEN_DEFINES)
 test_ldadd = libtestlib.la \
 	$(LIBGC_LIBS) $(GLIB_LIBS) -lm $(LIBICONV)
@@ -41,9 +55,19 @@ test_mono_handle_CFLAGS = $(test_cflags)
 test_mono_handle_LDADD = $(test_ldadd)
 test_mono_handle_LDFLAGS = $(test_ldflags)
 
-noinst_PROGRAMS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle
+test_mono_callspec_SOURCES = test-mono-callspec.c
+test_mono_callspec_CFLAGS = $(AM_CFLAGS)
+test_mono_callspec_LDADD = $(test_ldadd) ../mini/libmini.la
+test_mono_callspec_LDFLAGS = $(test_ldflags)
+test_mono_callspec_DEPENDENCIES = callspec.exe
 
-TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle
+check_PROGRAMS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle	\
+		 test-mono-callspec
+
+TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle \
+	test-mono-callspec
+
+AM_TESTS_ENVIRONMENT = export MONO_PATH=$(mcs_topdir)/class/lib/build;
 
 .NOTPARALLEL:
 
@@ -54,6 +78,12 @@ check-local:
 		if [ $$failures -ne 0 ]; then echo "<failure><message>"'<![CDATA[' >> TestResult-unit-tests.xml && cat test-suite.log >> TestResult-unit-tests.xml && echo "]]></message><stack-trace></stack-trace></failure>" >> TestResult-unit-tests.xml; fi; \
 		echo "</test-case></results></test-suite></test-results>" >> TestResult-unit-tests.xml; \
 	fi;
+
+clean-local:
+	rm -f callspec.exe callspec.pdb
+
+%.exe: %.cs
+	$(MCS) -r:$(CLASS)/System.dll -r:$(CLASS)/System.Xml.dll -r:$(CLASS)/System.Core.dll -out:$@ $<
 
 endif SUPPORT_SGEN
 endif SUPPORT_BOEHM

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -21,6 +21,13 @@ if HOST_DARWIN
 test_ldflags = -framework CoreFoundation -framework Foundation
 endif
 
+monodir=$(top_builddir)
+sgen_libs = \
+	$(monodir)/mono/metadata/libmonoruntimesgen.la	\
+	$(monodir)/mono/sgen/libmonosgen.la	\
+	$(monodir)/mono/utils/libmonoutils.la \
+	$(GLIB_LIBS) $(LIBICONV)
+
 if !CROSS_COMPILE
 if !HOST_WIN32
 if SUPPORT_BOEHM
@@ -57,7 +64,7 @@ test_mono_handle_LDFLAGS = $(test_ldflags)
 
 test_mono_callspec_SOURCES = test-mono-callspec.c
 test_mono_callspec_CFLAGS = $(AM_CFLAGS)
-test_mono_callspec_LDADD = $(test_ldadd) ../mini/libmini.la
+test_mono_callspec_LDADD = $(test_ldadd) ../mini/libmini.la $(sgen_libs)
 test_mono_callspec_LDFLAGS = $(test_ldflags)
 test_mono_callspec_DEPENDENCIES = callspec.exe
 

--- a/mono/unit-tests/callspec.cs
+++ b/mono/unit-tests/callspec.cs
@@ -1,0 +1,44 @@
+
+namespace Baz
+{
+    class Foo
+    {
+        public Foo()
+        {
+        }
+
+        public string Bar()
+        {
+            return "Hello, World!";
+		}
+
+        public string Bar(string who)
+        {
+            return "Hello, " + who + "!";
+        }
+	}
+
+    class Goo
+    {
+        public Goo()
+        {
+        }
+
+        public string Bar(string greet)
+        {
+            return greet + ", World!";
+        }
+    }
+
+    class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            var foo = new Foo();
+            System.Console.WriteLine(foo.Bar());
+            System.Console.WriteLine(foo.Bar("World"));
+            var goo = new Goo();
+            System.Console.WriteLine(goo.Bar("Hello"));
+        }
+    }
+}

--- a/mono/unit-tests/callspec.cs
+++ b/mono/unit-tests/callspec.cs
@@ -30,6 +30,18 @@ namespace Baz
         }
     }
 
+    class Foo2
+    {
+        public Foo2()
+        {
+        }
+
+        public string Bar(string greet)
+        {
+            return greet + ", World!!!";
+        }
+    }
+
     class MainClass
     {
         public static void Main(string[] args)
@@ -39,6 +51,8 @@ namespace Baz
             System.Console.WriteLine(foo.Bar("World"));
             var goo = new Goo();
             System.Console.WriteLine(goo.Bar("Hello"));
+            var foo2 = new Foo2();
+            System.Console.WriteLine(foo2.Bar("Hello"));
         }
     }
 }

--- a/mono/unit-tests/test-mono-callspec.c
+++ b/mono/unit-tests/test-mono-callspec.c
@@ -1,0 +1,238 @@
+/*
+ * test-mono-callspec.c: Unit test for the callspec parsing and evaluation.
+ *
+ * Copyright (C) 2017 vFunction, Inc.
+ *
+ */
+
+#include <glib.h>
+#include <mono/metadata/metadata.h>
+#include <mono/metadata/callspec.h>
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/appdomain.h>
+#include <mono/metadata/debug-helpers.h>
+
+#define TESTPROG "callspec.exe"
+
+GArray *test_methods = NULL;
+
+enum test_method_enums {
+	FOO_BAR,
+	FOO_BARP,
+	GOO_BAR,
+	CONSOLE_WRITELINE,
+};
+
+struct {
+	int method;
+	const char *callspec;
+	gboolean expect_match;
+} test_entries[] = {
+    /* program tests */
+    {FOO_BAR, "program", TRUE},
+    {CONSOLE_WRITELINE, "program", FALSE},
+    {FOO_BAR, "all,-program", FALSE},
+    {CONSOLE_WRITELINE, "all,-program", TRUE},
+
+    /* assembly tests */
+    {FOO_BAR, "mscorlib", FALSE},
+    {CONSOLE_WRITELINE, "mscorlib", TRUE},
+    {FOO_BAR, "all,-mscorlib", TRUE},
+    {CONSOLE_WRITELINE, "all,-mscorlib", FALSE},
+
+    /* class tests */
+    {FOO_BAR, "T:Baz.Foo", TRUE},
+    {CONSOLE_WRITELINE, "T:Baz.Foo", FALSE},
+    {FOO_BAR, "all,-T:Baz.Foo", FALSE},
+    {CONSOLE_WRITELINE, "all,-T:Baz.Foo", TRUE},
+
+    /* namespace tests */
+    {FOO_BAR, "N:Baz", TRUE},
+    {CONSOLE_WRITELINE, "N:Baz", FALSE},
+    {FOO_BAR, "all,-N:Baz", FALSE},
+    {CONSOLE_WRITELINE, "all,-N:Baz", TRUE},
+
+    /* method tests without parameters */
+    {FOO_BAR, "M:Baz.Foo:Bar", TRUE},
+    {FOO_BARP, "M:Baz.Foo:Bar", TRUE},
+    {GOO_BAR, "M:Baz.Foo:Bar", FALSE},
+    {CONSOLE_WRITELINE, "M:Baz.Foo:Bar", FALSE},
+    {FOO_BAR, "all,-M:Baz.Foo:Bar", FALSE},
+    {CONSOLE_WRITELINE, "all,-M:Baz.Foo:Bar", TRUE},
+
+    /* method tests without class */
+    {FOO_BAR, "M::Bar", TRUE},
+    {FOO_BARP, "M::Bar", TRUE},
+    {GOO_BAR, "M::Bar", TRUE},
+
+    {0, NULL, FALSE}};
+
+static int test_callspec (int test_idx,
+			  MonoMethod *method,
+			  const char *callspec,
+			  gboolean expect_match)
+{
+	int res = 0;
+	gboolean initialized = FALSE;
+	gboolean match;
+	MonoCallSpec spec = {0};
+	char *errstr;
+	char *method_name = mono_method_full_name (method, TRUE);
+	if (!method_name) {
+		printf ("FAILED getting method name in callspec test #%d\n",
+			test_idx);
+		res = 1;
+		goto out;
+	}
+
+	if (!mono_callspec_parse (callspec, &spec, &errstr)) {
+		printf ("FAILED parsing callspec '%s' - %s\n", callspec,
+			errstr);
+		g_free (errstr);
+		res = 1;
+		goto out;
+	}
+	initialized = TRUE;
+
+	match = mono_callspec_eval (method, &spec);
+
+	if (match && !expect_match) {
+		printf ("FAILED unexpected match '%s' against '%s'\n",
+			method_name, callspec);
+		res = 1;
+		goto out;
+	}
+	if (!match && expect_match) {
+		printf ("FAILED unexpected mismatch '%s' against '%s'\n",
+			method_name, callspec);
+		res = 1;
+		goto out;
+	}
+
+out:
+	if (initialized)
+		mono_callspec_cleanup(&spec);
+	if (method_name)
+		g_free (method_name);
+	return res;
+}
+
+static int test_all_callspecs (void)
+{
+	int idx;
+	for (idx = 0; test_entries[idx].callspec; ++idx) {
+		MonoMethod *meth = g_array_index (test_methods, MonoMethod *,
+						  test_entries[idx].method);
+		if (test_callspec (idx, meth, test_entries[idx].callspec,
+				   test_entries[idx].expect_match))
+			return 1;
+	}
+
+	return 0;
+}
+
+static MonoClass *test_mono_class_from_name (MonoImage *image,
+					     const char *name_space,
+					     const char *name)
+{
+	MonoError error;
+	MonoClass *klass;
+
+	klass = mono_class_from_name_checked (image, name_space, name, &error);
+	mono_error_cleanup (&error); /* FIXME Don't swallow the error */
+
+	return klass;
+}
+
+int
+main (void)
+{
+	int res = 0;
+	MonoDomain *domain = NULL;
+	MonoAssembly *assembly = NULL;
+	MonoImage *prog_image = NULL;
+	MonoImage *corlib = NULL;
+	MonoClass *prog_klass, *console_klass;
+	MonoMethod *meth;
+
+	test_methods = g_array_new (FALSE, TRUE, sizeof (MonoMethod *));
+	if (!test_methods) {
+		res = 1;
+		printf ("FAILED INITIALIZING METHODS ARRAY\n");
+		goto out;
+	}
+
+	domain = mono_init_from_assembly (TESTPROG, TESTPROG);
+	assembly = mono_assembly_open_predicate (TESTPROG, FALSE, FALSE, NULL, NULL, NULL);
+	if (!domain || !assembly) {
+		res = 1;
+		printf("FAILED LOADING TEST PROGRAM\n");
+		goto out;
+	}
+
+	mono_callspec_set_assembly(assembly);
+
+	prog_image = mono_assembly_get_image (assembly);
+
+	prog_klass = test_mono_class_from_name (prog_image, "Baz", "Foo");
+	if (!prog_klass) {
+		res = 1;
+		printf ("FAILED FINDING Baz.Foo\n");
+		goto out;
+	}
+	meth = mono_class_get_method_from_name (prog_klass, "Bar", 0);
+	if (!meth) {
+		res = 1;
+		printf ("FAILED FINDING Baz.Foo:Bar ()\n");
+		goto out;
+	}
+	g_array_append_val (test_methods, meth);
+	meth = mono_class_get_method_from_name (prog_klass, "Bar", 1);
+	if (!meth) {
+		res = 1;
+		printf ("FAILED FINDING Baz.Foo:Bar (string)\n");
+		goto out;
+	}
+	g_array_append_val (test_methods, meth);
+
+	prog_klass = test_mono_class_from_name (prog_image, "Baz", "Goo");
+	if (!prog_klass) {
+		res = 1;
+		printf ("FAILED FINDING Baz.Goo\n");
+		goto out;
+	}
+	meth = mono_class_get_method_from_name (prog_klass, "Bar", 1);
+	if (!meth) {
+		res = 1;
+		printf ("FAILED FINDING Baz.Goo:Bar (string)\n");
+		goto out;
+	}
+	g_array_append_val (test_methods, meth);
+
+	corlib = mono_get_corlib ();
+
+	console_klass = test_mono_class_from_name (corlib, "System", "Console");
+	if (!console_klass) {
+		res = 1;
+		printf ("FAILED FINDING System.Console\n");
+		goto out;
+	}
+	meth = mono_class_get_method_from_name (console_klass, "WriteLine", 1);
+	if (!meth) {
+		res = 1;
+		printf ("FAILED FINDING System.Console:WriteLine\n");
+		goto out;
+	}
+	g_array_append_val (test_methods, meth);
+
+	res = test_all_callspecs ();
+out:
+	if (assembly)
+		mono_assembly_close(assembly);
+	if (domain)
+		mono_domain_free (domain, TRUE);
+
+	return res;
+}

--- a/mono/unit-tests/test-mono-callspec.c
+++ b/mono/unit-tests/test-mono-callspec.c
@@ -13,6 +13,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/mini/jit.h>
 
 #define TESTPROG "callspec.exe"
 
@@ -159,6 +160,10 @@ main (void)
 	MonoImage *corlib = NULL;
 	MonoClass *prog_klass, *console_klass;
 	MonoMethod *meth;
+	MonoImageOpenStatus status;
+
+	//FIXME This is a fugly hack due to embedding simply not working from the tree
+	mono_set_assemblies_path ("../../mcs/class/lib/net_4_x");
 
 	test_methods = g_array_new (FALSE, TRUE, sizeof (MonoMethod *));
 	if (!test_methods) {
@@ -167,8 +172,8 @@ main (void)
 		goto out;
 	}
 
-	domain = mono_init_from_assembly (TESTPROG, TESTPROG);
-	assembly = mono_assembly_open_predicate (TESTPROG, FALSE, FALSE, NULL, NULL, NULL);
+	domain = mono_jit_init_version ("TEST RUNNER", "mobile");
+	assembly = mono_assembly_open (TESTPROG, &status);
 	if (!domain || !assembly) {
 		res = 1;
 		printf("FAILED LOADING TEST PROGRAM\n");
@@ -246,10 +251,5 @@ main (void)
 
 	res = test_all_callspecs ();
 out:
-	if (assembly)
-		mono_assembly_close(assembly);
-	if (domain)
-		mono_domain_free (domain, TRUE);
-
 	return res;
 }

--- a/mono/unit-tests/test-mono-callspec.c
+++ b/mono/unit-tests/test-mono-callspec.c
@@ -22,6 +22,7 @@ enum test_method_enums {
 	FOO_BAR,
 	FOO_BARP,
 	GOO_BAR,
+	FOO2_BAR,
 	CONSOLE_WRITELINE,
 };
 
@@ -58,6 +59,7 @@ struct {
     {FOO_BAR, "M:Baz.Foo:Bar", TRUE},
     {FOO_BARP, "M:Baz.Foo:Bar", TRUE},
     {GOO_BAR, "M:Baz.Foo:Bar", FALSE},
+    {FOO2_BAR, "M:Baz.Foo:Bar", FALSE},
     {CONSOLE_WRITELINE, "M:Baz.Foo:Bar", FALSE},
     {FOO_BAR, "all,-M:Baz.Foo:Bar", FALSE},
     {CONSOLE_WRITELINE, "all,-M:Baz.Foo:Bar", TRUE},
@@ -66,6 +68,7 @@ struct {
     {FOO_BAR, "M::Bar", TRUE},
     {FOO_BARP, "M::Bar", TRUE},
     {GOO_BAR, "M::Bar", TRUE},
+    {FOO2_BAR, "M::Bar", TRUE},
 
     {0, NULL, FALSE}};
 
@@ -207,6 +210,20 @@ main (void)
 	if (!meth) {
 		res = 1;
 		printf ("FAILED FINDING Baz.Goo:Bar (string)\n");
+		goto out;
+	}
+	g_array_append_val (test_methods, meth);
+
+	prog_klass = test_mono_class_from_name (prog_image, "Baz", "Foo2");
+	if (!prog_klass) {
+		res = 1;
+		printf ("FAILED FINDING Baz.Foo2\n");
+		goto out;
+	}
+	meth = mono_class_get_method_from_name (prog_klass, "Bar", 1);
+	if (!meth) {
+		res = 1;
+		printf ("FAILED FINDING Baz.Foo2:Bar (string)\n");
 		goto out;
 	}
 	g_array_append_val (test_methods, meth);


### PR DESCRIPTION
This patch set adds some unit tests for call specifications in --trace and log profiler, and fixes a bug.

The bug is that when specifying a method (e.g. --trace=M:NameSpace.Foo:Bar), it matches same method of a different class (e.g. NameSpace.Foo2:Bar) if the matched class's name begins with the callspec class name (e.g. Foo2 begins with Foo)

The first commit adds the test suite and some passing tests, the second commit fixes the bug, the third commit adds a test which could not pass without the bugfix.