### PR TITLE
[Windows] Windows x64 full AOT native unwind info support.

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1763,6 +1763,21 @@ mono_arch_unwindinfo_get_code_count (GSList *unwind_ops)
 	return unwindinfo.CountOfCodes;
 }
 
+PUNWIND_INFO
+mono_arch_unwindinfo_alloc_unwind_info (GSList *unwind_ops)
+{
+	if (!unwind_ops)
+		return NULL;
+
+	return initialize_unwind_info_internal (unwind_ops);
+}
+
+void
+mono_arch_unwindinfo_free_unwind_info (PUNWIND_INFO unwind_info)
+{
+	g_free (unwind_info);
+}
+
 guint
 mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg)
 {
@@ -1812,7 +1827,7 @@ mono_arch_unwindinfo_install_method_unwind_info (gpointer *monoui, gpointer code
 	}
 #endif /* ENABLE_CHECKED_BUILD_UNWINDINFO */
 
-	g_free (unwindinfo);
+	mono_arch_unwindinfo_free_unwind_info (unwindinfo);
 	*monoui = 0;
 
 	// Register unwind info in table.

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -568,6 +568,12 @@ mono_arch_unwindinfo_get_size (guchar code_count)
 guchar
 mono_arch_unwindinfo_get_code_count (GSList *unwind_ops);
 
+PUNWIND_INFO
+mono_arch_unwindinfo_alloc_unwind_info (GSList *unwind_ops);
+
+void
+mono_arch_unwindinfo_free_unwind_info (PUNWIND_INFO unwind_info);
+
 guint
 mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg);
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2268,7 +2268,8 @@ mono_codegen (MonoCompile *cfg)
 	/* fixme: align to MONO_ARCH_CODE_ALIGNMENT */
 
 #ifdef MONO_ARCH_HAVE_UNWIND_TABLE
-	unwindlen = mono_arch_unwindinfo_init_method_unwind_info (cfg);
+	if (!cfg->compile_aot)
+		unwindlen = mono_arch_unwindinfo_init_method_unwind_info (cfg);
 #endif
 
 	if (cfg->method->dynamic) {
@@ -2386,7 +2387,8 @@ mono_codegen (MonoCompile *cfg)
 	mono_debug_close_method (cfg);
 
 #ifdef MONO_ARCH_HAVE_UNWIND_TABLE
-	mono_arch_unwindinfo_install_method_unwind_info (&cfg->arch.unwindinfo, cfg->native_code, cfg->code_len);
+	if (!cfg->compile_aot)
+		mono_arch_unwindinfo_install_method_unwind_info (&cfg->arch.unwindinfo, cfg->native_code, cfg->code_len);
 #endif
 }
 


### PR DESCRIPTION
Emit needed sections when building Windows x64 full AOT targeting Clang for MS codegen in order for linker to include entries in process unwind tables for full AOT:ed managed functions and trampolines. Implementation also includes a cache used to minimize the number of duplicated unwind data section in each object file, reducing final image size.

PR also includes implementation to emit very basic codeview information into full AOT builds on Windows x64. The codeview information is far from complete and is currently just initial work needed to get function symbol names to appear in native callstack that includes managed functions. Described functions does not include parameters, local variables or line info at the moment, but could be extended in the future.

Fix also make sure linker will emit PDB files including information that can be picked up by debuggers. It is possible to disable codeview info by passing "nodebug" to AOT compiler, this will also disable the generation of PDB files, if a DLL would have been build.

Example of callstack in Visual Studio native debugger running full AOT version of basic.exe test:

```
basic.exe.dll!Tests:test_0_signed_ct_div()	C#
mscorlib.dll.dll!(wrapper runtime-invoke) object:runtime_invoke_dynamic()	C#
mono-2.0-sgen.dll!mono_jit_runtime_invoke(_MonoMethod * method, void * obj, void * * params, _MonoObject * * exc, _MonoError * error) Line 2777	C
mono-2.0-sgen.dll!do_runtime_invoke(_MonoMethod * method, void * obj, void * * params, _MonoObject * * exc, _MonoError * error) Line 2851	C
mono-2.0-sgen.dll!mono_runtime_invoke_checked(_MonoMethod * method, void * obj, void * * params, _MonoError * error) Line 3003	C
...
```

