### PR TITLE
[System] Ignore FtpWebRequestTest.DownloadFile2_v6 test when IPv6 isn't available

### DIFF
--- a/mcs/class/System/Test/System.Net/FtpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/FtpWebRequestTest.cs
@@ -389,6 +389,9 @@ namespace MonoTests.System.Net
 #endif
 		public void DownloadFile2_v6 ()
 		{
+			if (!Socket.OSSupportsIPv6)
+				Assert.Ignore ("IPv6 not supported.");
+
 			// Some embedded FTP servers in Industrial Automation Hardware report
 			// the PWD using backslashes, but allow forward slashes for CWD.
 			DownloadFile (new ServerDownload (@"\Users\someuser", "/Users/someuser/", null, true));


### PR DESCRIPTION
It fails on some systems otherwise. The other tests already had this check.