### PR TITLE
[monodroid] Fix Mono.Posix tests build (#5697)

### DIFF
--- a/mcs/class/Mono.Posix/monodroid_Mono.Posix_test.dll.exclude.sources
+++ b/mcs/class/Mono.Posix/monodroid_Mono.Posix_test.dll.exclude.sources
@@ -1,2 +1,1 @@
 #include monodroid_Mono.Posix_test.dll.new-exclude.sources
-Mono.Unix.Android/TestHelper.cs


### PR DESCRIPTION
TestHelper was previously excluded because the XA tests weren't built
as part of Mono but rather as part of XA test suite which included
its own version of the helper. Now, however (https://github.com/xamarin/xamarin-android/commit/e9daf5ea35709ce1bc6ba81c7c37d72d385bace2),
XA uses BCL+friends test assemblies built by Mono itself and so
we need to restore TestHelper in the build.