### PR TITLE
Initial set of Ward sgen annotations

### DIFF
--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -593,7 +593,7 @@ typedef struct {
 static EphemeronLinkNode *ephemeron_list;
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 null_ephemerons_for_domain (MonoDomain *domain)
 {
 	EphemeronLinkNode *current = ephemeron_list, *prev = NULL;

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -82,17 +82,21 @@ typedef void* MonoGCDescriptor;
 
 gboolean mono_gc_parse_environment_string_extract_number (const char *str, size_t *out);
 
-MonoGCDescriptor mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size);
-MonoGCDescriptor mono_gc_make_descr_for_array (int vector, gsize *elem_bitmap, int numbits, size_t elem_size);
+MonoGCDescriptor mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
+    MONO_PERMIT (need (sgen_lock_gc));
+MonoGCDescriptor mono_gc_make_descr_for_array (int vector, gsize *elem_bitmap, int numbits, size_t elem_size)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 /* simple interface for data structures needed in the runtime */
-MonoGCDescriptor mono_gc_make_descr_from_bitmap (gsize *bitmap, int numbits);
+MonoGCDescriptor mono_gc_make_descr_from_bitmap (gsize *bitmap, int numbits)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 /* Return a root descriptor for a vector with repeating refs bitmap */
 MonoGCDescriptor mono_gc_make_vector_descr (void);
 
 /* Return a root descriptor for a root with all refs */
-MonoGCDescriptor mono_gc_make_root_descr_all_refs (int numbits);
+MonoGCDescriptor mono_gc_make_root_descr_all_refs (int numbits)
+    MONO_PERMIT (need (sgen_lock_gc));
 
 /* Return the bitmap encoded by a descriptor */
 gsize* mono_gc_get_bitmap_for_descr (MonoGCDescriptor descr, int *numbits);

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -14,6 +14,7 @@
 #include <glib.h>
 #include <stdio.h>
 
+#include "mono/utils/ward.h"
 #include "mono/utils/mono-compiler.h"
 #include "mono/utils/parse.h"
 #include "mono/utils/memfuncs.h"

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -69,13 +69,15 @@ void sgen_client_finalize_notify (void);
  * Returns TRUE if no ephemerons have been marked.  Will be called again if it returned
  * FALSE.  If ephemerons are not supported, just return TRUE.
  */
-gboolean sgen_client_mark_ephemerons (ScanCopyContext ctx);
+gboolean sgen_client_mark_ephemerons (ScanCopyContext ctx)
+    MONO_PERMIT (need (sgen_gc_locked));
 
 /*
  * Clear ephemeron pairs with unreachable keys.
  * We pass the copy func so we can figure out if an array was promoted or not.
  */
-void sgen_client_clear_unreachable_ephemerons (ScanCopyContext ctx);
+void sgen_client_clear_unreachable_ephemerons (ScanCopyContext ctx)
+    MONO_PERMIT (need (sgen_gc_locked));
 
 /*
  * May return NULL.  Must be an aligned pointer.
@@ -174,8 +176,10 @@ void sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gbool
  * Stop and restart the world, i.e., all threads that interact with the managed heap.  For
  * single-threaded programs this is a nop.
  */
-void sgen_client_stop_world (int generation);
-void sgen_client_restart_world (int generation, gint64 *stw_time);
+void sgen_client_stop_world (int generation)
+    MONO_PERMIT (need (sgen_gc_locked));
+void sgen_client_restart_world (int generation, gint64 *stw_time)
+    MONO_PERMIT (need (sgen_gc_locked));
 
 /*
  * Must return FALSE.  The bridge is not supported outside of Mono.

--- a/mono/sgen/sgen-fin-weak-hash.c
+++ b/mono/sgen/sgen-fin-weak-hash.c
@@ -229,7 +229,7 @@ sgen_finalize_in_range (int generation, ScanCopyContext ctx)
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 register_for_finalization (GCObject *obj, void *user_data, int generation)
 {
 	SgenHashTable *hash_table = get_finalize_entry_hash_table (generation);
@@ -346,7 +346,7 @@ try_lock_stage_for_processing (int num_entries, volatile gint32 *next_entry)
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 process_stage_entries (int num_entries, volatile gint32 *next_entry, StageEntry *entries, void (*process_func) (GCObject*, void*, int))
 {
 	int i;
@@ -528,7 +528,7 @@ add_stage_entry (int num_entries, volatile gint32 *next_entry, StageEntry *entri
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 process_fin_stage_entry (GCObject *obj, void *user_data, int index)
 {
 	if (ptr_in_nursery (obj))
@@ -558,7 +558,7 @@ sgen_object_register_for_finalization (GCObject *obj, void *user_data)
 }
 
 /* LOCKING: requires that the GC lock is held */
-static void
+static MONO_PERMIT (need (sgen_gc_locked)) void
 finalize_with_predicate (SgenObjectPredicateFunc predicate, void *user_data, SgenHashTable *hash_table)
 {
 	GCObject *object;

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -852,11 +852,11 @@ void sgen_pin_object (GCObject *object, SgenGrayQueue *queue);
 void sgen_set_pinned_from_failed_allocation (mword objsize);
 
 void sgen_ensure_free_space (size_t size, int generation)
-	MONO_PERMIT (need (sgen_gc_locked));
+	MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
 void sgen_gc_collect (int generation)
-	MONO_PERMIT (need (sgen_lock_gc));
+	MONO_PERMIT (need (sgen_lock_gc, sgen_stop_world));
 void sgen_perform_collection (size_t requested_size, int generation_to_collect, const char *reason, gboolean wait_to_finish, gboolean stw)
-	MONO_PERMIT (need (sgen_gc_locked));
+	MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
 
 int sgen_gc_collection_count (int generation);
 /* FIXME: what exactly does this return? */
@@ -867,9 +867,9 @@ size_t sgen_gc_get_total_heap_allocation (void);
 /* STW */
 
 void sgen_stop_world (int generation)
-	MONO_PERMIT (need (sgen_gc_locked), grant (sgen_world_stopped));
+	MONO_PERMIT (need (sgen_gc_locked), use (sgen_stop_world), grant (sgen_world_stopped), revoke (sgen_stop_world));
 void sgen_restart_world (int generation)
-	MONO_PERMIT (need (sgen_gc_locked), use (sgen_world_stopped), revoke (sgen_world_stopped));
+	MONO_PERMIT (need (sgen_gc_locked), use (sgen_world_stopped), revoke (sgen_world_stopped), grant (sgen_stop_world));
 gboolean sgen_is_world_stopped (void);
 
 gboolean sgen_set_allow_synchronous_major (gboolean flag);
@@ -893,7 +893,7 @@ extern mword los_memory_usage_total;
 
 void sgen_los_free_object (LOSObject *obj);
 void* sgen_los_alloc_large_inner (GCVTable vtable, size_t size)
-	MONO_PERMIT (need (sgen_gc_locked));
+	MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
 void sgen_los_sweep (void);
 gboolean sgen_ptr_is_in_los (char *ptr, char **start);
 void sgen_los_iterate_objects (IterateObjectCallbackFunc cb, void *user_data);
@@ -932,7 +932,7 @@ void sgen_nursery_alloc_prepare_for_major (void);
 GCObject* sgen_alloc_for_promotion (GCObject *obj, size_t objsize, gboolean has_references);
 
 GCObject* sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
-	MONO_PERMIT (need (sgen_gc_locked));
+	MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
 GCObject* sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size);
 
 /* Threads */
@@ -1043,11 +1043,11 @@ typedef enum {
 void sgen_clear_tlabs (void);
 
 GCObject* sgen_alloc_obj (GCVTable vtable, size_t size)
-	MONO_PERMIT (need (sgen_lock_gc));
+	MONO_PERMIT (need (sgen_lock_gc, sgen_stop_world));
 GCObject* sgen_alloc_obj_pinned (GCVTable vtable, size_t size)
-	MONO_PERMIT (need (sgen_lock_gc));
+	MONO_PERMIT (need (sgen_lock_gc, sgen_stop_world));
 GCObject* sgen_alloc_obj_mature (GCVTable vtable, size_t size)
-	MONO_PERMIT (need (sgen_lock_gc));
+	MONO_PERMIT (need (sgen_lock_gc, sgen_stop_world));
 
 /* Debug support */
 
@@ -1056,7 +1056,7 @@ void sgen_check_mod_union_consistency (void);
 void sgen_check_major_refs (void);
 void sgen_check_whole_heap (gboolean allow_missing_pinning);
 void sgen_check_whole_heap_stw (void)
-	MONO_PERMIT (need (sgen_gc_locked));
+	MONO_PERMIT (need (sgen_gc_locked, sgen_stop_world));
 void sgen_check_objref (char *obj);
 void sgen_check_heap_marked (gboolean nursery_must_be_pinned);
 void sgen_check_nursery_objects_pinned (gboolean pinned);

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -180,7 +180,8 @@ monoutils_sources = \
 	os-event.h \
 	refcount.h	\
 	w32api.h	\
-	unlocked.h
+	unlocked.h	\
+	ward.h
 
 arch_sources = 
 

--- a/mono/utils/ward.h
+++ b/mono/utils/ward.h
@@ -1,0 +1,6 @@
+#ifndef WARD_H
+#define WARD_H
+
+#define MONO_PERMIT(...) __attribute__ ((ward (__VA_ARGS__)))
+
+#endif

--- a/mono/utils/ward.h
+++ b/mono/utils/ward.h
@@ -1,6 +1,20 @@
 #ifndef WARD_H
 #define WARD_H
 
+/*
+ * Ward is a static analysis tool that can be used to check for the presense of
+ * a certain class of bugs in C code.
+ *
+ * See https://github.com/evincarofautumn/Ward#annotating-your-code for the Ward
+ * permission annotations syntax.
+ *
+ * The Mono permissions are defined in
+ * https://github.com/evincarofautumn/Ward/blob/prod/mono.config
+ */
+#if defined(__WARD__)
 #define MONO_PERMIT(...) __attribute__ ((ward (__VA_ARGS__)))
+#else
+#define MONO_PERMIT(...) /*empty*/
+#endif
 
 #endif


### PR DESCRIPTION
Initial round of [Ward](https://github.com/evincarofautumn/Ward) annotations for Mono.

The [nightly static analysis Jenkins job](https://jenkins.mono-project.com/job/test-mono-mainline-staticanalysis/) has a [Ward report](https://jenkins.mono-project.com/job/test-mono-mainline-staticanalysis/Ward_Report/) (currently an expensive no-op since there are no annotations).

This PR primarily focuses on checking the state of the sgen GC lock and the global "stop-the-world" state.