### PR TITLE
[Windows] Reduce build warnings in Windows builds for InterlockedXXX functions.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2694,7 +2694,7 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 	/* printf ("UNLOAD STARTING FOR %s (%p) IN THREAD 0x%x.\n", domain->friendly_name, domain, mono_native_thread_id_get ()); */
 
 	/* Atomically change our state to UNLOADING */
-	prev_state = (MonoAppDomainState)InterlockedCompareExchange ((gint32*)&domain->state,
+	prev_state = (MonoAppDomainState)InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&domain->state),
 		MONO_APPDOMAIN_UNLOADING_START,
 		MONO_APPDOMAIN_CREATED);
 	if (prev_state != MONO_APPDOMAIN_CREATED) {

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2425,7 +2425,7 @@ cominterop_ccw_addref (MonoCCWInterface* ccwe)
 	MonoCCW* ccw = ccwe->ccw;
 	g_assert (ccw);
 	g_assert (ccw->gc_handle);
-	ref_count = InterlockedIncrement ((gint32*)&ccw->ref_count);
+	ref_count = InterlockedIncrement (TO_INTERLOCKED_INT32_ARGP (&ccw->ref_count));
 	if (ref_count == 1) {
 		guint32 oldhandle = ccw->gc_handle;
 		g_assert (oldhandle);
@@ -2443,7 +2443,7 @@ cominterop_ccw_release (MonoCCWInterface* ccwe)
 	MonoCCW* ccw = ccwe->ccw;
 	g_assert (ccw);
 	g_assert (ccw->ref_count > 0);
-	ref_count = InterlockedDecrement ((gint32*)&ccw->ref_count);
+	ref_count = InterlockedDecrement (TO_INTERLOCKED_INT32_ARGP (&ccw->ref_count));
 	if (ref_count == 0) {
 		/* allow gc of object */
 		guint32 oldhandle = ccw->gc_handle;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -167,7 +167,7 @@ lock_free_mempool_chunk_new (LockFreeMempool *mp, int len)
 	/* Add to list of chunks lock-free */
 	while (TRUE) {
 		prev = mp->chunks;
-		if (InterlockedCompareExchangePointer ((volatile gpointer*)&mp->chunks, chunk, prev) == prev)
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&mp->chunks), chunk, prev) == prev)
 			break;
 	}
 	chunk->prev = prev;

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -1089,7 +1089,7 @@ ref_list_remove_element (RefQueueEntry **prev, RefQueueEntry *element)
 		/* Guard if head is changed concurrently. */
 		while (*prev != element)
 			prev = &(*prev)->next;
-	} while (prev && InterlockedCompareExchangePointer ((volatile gpointer *)prev, element->next, element) != element);
+	} while (prev && InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (prev), element->next, element) != element);
 }
 
 static void
@@ -1100,7 +1100,7 @@ ref_list_push (RefQueueEntry **head, RefQueueEntry *value)
 		current = *head;
 		value->next = current;
 		STORE_STORE_FENCE; /*Must make sure the previous store is visible before the CAS. */
-	} while (InterlockedCompareExchangePointer ((volatile gpointer *)head, value, current) != current);
+	} while (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (head), value, current) != current);
 }
 
 static void

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -99,7 +99,7 @@ assign_assembly_parent_for_netmodule (MonoImage *image, MonoImage *assemblyImage
 			mono_error_set_bad_image (error, assemblyImage, "Attempted to load module %s which has already been loaded by assembly %s. This is not supported in Mono.", image->name, assemblyOld->image->name);
 			return FALSE;
 		}
-		gpointer result = InterlockedExchangePointer((gpointer *)&image->assembly, assembly);
+		gpointer result = InterlockedExchangePointer(TO_INTERLOCKED_POINTER_ARGP (&image->assembly), assembly);
 		if (result == assembly)
 			return TRUE;
 	}
@@ -2738,7 +2738,7 @@ mono_image_strdup (MonoImage *image, const char *s)
 	char *res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, strlen (s));
+	InterlockedAdd (&mono_perfcounters->loader_bytes, TO_INTERLOCKED_INT32_ARG (strlen (s)));
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_strdup (image->mempool, s);
@@ -2755,7 +2755,7 @@ mono_image_strdup_vprintf (MonoImage *image, const char *format, va_list args)
 	buf = mono_mempool_strdup_vprintf (image->mempool, format, args);
 	mono_image_unlock (image);
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, strlen (buf));
+	InterlockedAdd (&mono_perfcounters->loader_bytes, TO_INTERLOCKED_INT32_ARG (strlen (buf)));
 #endif
 	return buf;
 }

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -40,6 +40,7 @@
 #include <mono/metadata/marshal.h>
 #include <mono/metadata/lock-tracer.h>
 #include <mono/metadata/verify-internals.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-dl.h>
 #include <mono/utils/mono-membar.h>

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -9255,7 +9255,7 @@ mono_marshal_get_castclass_with_cache (void)
 	res = mono_mb_create (mb, sig, 8, info);
 	STORE_STORE_FENCE;
 
-	if (InterlockedCompareExchangePointer ((volatile gpointer *)&cached, res, NULL)) {
+	if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&cached), res, NULL)) {
 		mono_free_method (res);
 		mono_metadata_free_method_signature (sig);
 	}
@@ -9339,7 +9339,7 @@ mono_marshal_get_isinst_with_cache (void)
 	res = mono_mb_create (mb, sig, 8, info);
 	STORE_STORE_FENCE;
 
-	if (InterlockedCompareExchangePointer ((volatile gpointer *)&cached, res, NULL)) {
+	if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&cached), res, NULL)) {
 		mono_free_method (res);
 		mono_metadata_free_method_signature (sig);
 	}

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3411,7 +3411,7 @@ get_anonymous_container_for_image (MonoImage *image, gboolean is_mvar)
 
 		// If another thread already made a container, use that and leak this new one.
 		// (Technically it would currently be safe to just assign instead of CASing.)
-		MonoGenericContainer *exchange = (MonoGenericContainer *)InterlockedCompareExchangePointer ((volatile gpointer *)container_pointer, result, NULL);
+		MonoGenericContainer *exchange = (MonoGenericContainer *)InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (container_pointer), result, NULL);
 		if (exchange)
 			result = exchange;
 	}

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1158,7 +1158,7 @@ predef_writable_update (ImplVtable *vtable, MonoBoolean do_incr, gint64 value)
 			if (value == -1)
 				return InterlockedDecrement (ptr);
 
-			return InterlockedAdd(ptr, value);
+			return InterlockedAdd(ptr, TO_INTERLOCKED_INT32_ARG (value));
 		}
 		/* this can be non-atomic */
 		*ptr = value;

--- a/mono/metadata/null-gc-handles.c
+++ b/mono/metadata/null-gc-handles.c
@@ -10,6 +10,7 @@
 #include <mono/metadata/profiler-private.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/metadata/null-gc-handles.h>
+#include <mono/utils/atomic.h>
 
 
 #ifdef HAVE_NULL_GC

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -40,6 +40,7 @@
 #include <mono/metadata/verify-internals.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/w32event.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-error-internals.h>

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -9,6 +9,7 @@
 #include <mono/metadata/mono-config-dirs.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/profiler-private.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-dl.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-logger-internals.h>

--- a/mono/metadata/property-bag.c
+++ b/mono/metadata/property-bag.c
@@ -51,7 +51,7 @@ retry:
 		cur = *prev;
 		if (!cur || cur->tag > tag) {
 			item->next = cur;
-			if (InterlockedCompareExchangePointer ((void*)prev, item, cur) == cur)
+			if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (prev), item, cur) == cur)
 				return item;
 			goto retry;
 		} else if (cur->tag == tag) {

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -10,6 +10,7 @@
 #ifdef SGEN_DEFINE_OBJECT_VTABLE
 
 #include "sgen/sgen-archdep.h"
+#include "utils/atomic.h"
 #include "utils/mono-threads.h"
 #include "utils/mono-mmap.h"
 #include "metadata/object-internals.h"

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -26,6 +26,7 @@
 #include "metadata/sgen-bridge-internals.h"
 #include "metadata/gc-internals.h"
 #include "metadata/handle.h"
+#include "utils/atomic.h"
 #include "utils/mono-memory-model.h"
 #include "utils/mono-logger-internals.h"
 #include "utils/mono-threads-coop.h"

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -523,7 +523,7 @@ mono_w32handle_ref_core (gpointer handle, MonoW32HandleBase *handle_data)
 			return FALSE;
 
 		new = old + 1;
-	} while (InterlockedCompareExchange ((gint32*) &handle_data->ref, new, old) != old);
+	} while (InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&handle_data->ref), TO_INTERLOCKED_INT32_ARG (new), TO_INTERLOCKED_INT32_ARG (old)) != TO_INTERLOCKED_INT32_ARG (old));
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_W32HANDLE, "%s: ref %s handle %p, ref: %d -> %d",
 		__func__, mono_w32handle_ops_typename (handle_data->type), handle, old, new);
@@ -545,7 +545,7 @@ mono_w32handle_unref_core (gpointer handle, MonoW32HandleBase *handle_data)
 			g_error ("%s: handle %p has ref %d, it should be >= 1", __func__, handle, old);
 
 		new = old - 1;
-	} while (InterlockedCompareExchange ((gint32*) &handle_data->ref, new, old) != old);
+	} while (InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&handle_data->ref), TO_INTERLOCKED_INT32_ARG (new), TO_INTERLOCKED_INT32_ARG (old)) != TO_INTERLOCKED_INT32_ARG (old));
 
 	/* handle_data might contain invalid data from now on, if
 	 * another thread is unref'ing this handle at the same time */

--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -15,6 +15,7 @@
 #include "ir-emit.h"
 #include "glib.h"
 #include <mono/utils/mono-compiler.h>
+#include <mono/utils/atomic.h>
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -49,6 +49,7 @@
 #include <mono/metadata/mempool-internals.h>
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/threads-types.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-time.h>

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -64,6 +64,7 @@
 #include <mono/metadata/verify-internals.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/w32socket.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-coop-mutex.h>
 #include <mono/utils/mono-coop-semaphore.h>
 #include <mono/utils/mono-error-internals.h>

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -31,6 +31,7 @@
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/gc-internals.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-memory-model.h>
@@ -1417,7 +1418,7 @@ mono_arch_get_iregs_clobbered_by_call (MonoCallInst *call)
 		regs = g_list_prepend (regs, (gpointer)AMD64_RCX);
 		regs = g_list_prepend (regs, (gpointer)AMD64_RAX);
 
-		InterlockedCompareExchangePointer ((gpointer*)&r, regs, NULL);
+		InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&r), regs, NULL);
 	}
 
 	return r;
@@ -1435,7 +1436,7 @@ mono_arch_get_fregs_clobbered_by_call (MonoCallInst *call)
 		for (i = 0; i < AMD64_XMM_NREG; ++i)
 			regs = g_list_prepend (regs, GINT_TO_POINTER (MONO_MAX_IREGS + i));
 
-		InterlockedCompareExchangePointer ((gpointer*)&r, regs, NULL);
+		InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&r), regs, NULL);
 	}
 
 	return r;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -64,6 +64,7 @@
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/environment.h>
 #include <mono/metadata/mono-mlist.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-error.h>

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -50,6 +50,7 @@
 #include <mono/metadata/runtime.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/monitor.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-counters.h>

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -48,6 +48,7 @@
 #include <mono/metadata/attach.h>
 #include <mono/metadata/runtime.h>
 #include <mono/metadata/attrdefs.h>
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-counters.h>
@@ -3887,14 +3888,14 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		if (code_size_ratio > InterlockedRead (&mono_jit_stats.biggest_method_size)) {
 			InterlockedWrite (&mono_jit_stats.biggest_method_size, code_size_ratio);
 			char *biggest_method = g_strdup_printf ("%s::%s)", method->klass->name, method->name);
-			biggest_method = InterlockedExchangePointer ((gpointer*)&mono_jit_stats.biggest_method, biggest_method);
+			biggest_method = InterlockedExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&mono_jit_stats.biggest_method), biggest_method);
 			g_free (biggest_method);
 		}
 		code_size_ratio = (code_size_ratio * 100) / header->code_size;
 		if (code_size_ratio > InterlockedRead (&mono_jit_stats.max_code_size_ratio)) {
 			InterlockedWrite (&mono_jit_stats.max_code_size_ratio, code_size_ratio);
 			char *max_ratio_method = g_strdup_printf ("%s::%s)", method->klass->name, method->name);
-			max_ratio_method = InterlockedExchangePointer ((gpointer*)&mono_jit_stats.max_ratio_method, max_ratio_method);
+			max_ratio_method = InterlockedExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&mono_jit_stats.max_ratio_method), max_ratio_method);
 			g_free (max_ratio_method);
 		}
 	}

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -24,6 +24,7 @@
 #include <mono/metadata/gc-internals.h>
 #include <mono/arch/amd64/amd64-codegen.h>
 
+#include <mono/utils/atomic.h>
 #include <mono/utils/memcheck.h>
 
 #include "mini.h"
@@ -145,7 +146,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 		if (code [-5] != 0xe8) {
 			if (can_write) {
 				g_assert ((guint64)(orig_code - 11) % 8 == 0);
-				InterlockedExchangePointer ((gpointer*)(orig_code - 11), addr);
+				InterlockedExchangePointer (TO_INTERLOCKED_POINTER_ARGP (orig_code - 11), addr);
 				VALGRIND_DISCARD_TRANSLATIONS (orig_code - 11, sizeof (gpointer));
 			}
 		} else {
@@ -166,7 +167,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 				MONO_PROFILER_RAISE (jit_code_buffer, (thunk_start, thunk_code - thunk_start, MONO_PROFILER_CODE_BUFFER_HELPER, NULL));
 			}
 			if (can_write) {
-				InterlockedExchange ((gint32*)(orig_code - 4), ((gint64)addr - (gint64)orig_code));
+				InterlockedExchange (TO_INTERLOCKED_INT32_ARGP (orig_code - 4), TO_INTERLOCKED_INT32_ARG ((gint64)addr - (gint64)orig_code));
 				VALGRIND_DISCARD_TRANSLATIONS (orig_code - 5, 4);
 			}
 		}

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -20,6 +20,7 @@
 #include <mono/metadata/gc-internals.h>
 #include <mono/arch/x86/x86-codegen.h>
 
+#include <mono/utils/atomic.h>
 #include <mono/utils/memcheck.h>
 
 #include "mini.h"
@@ -108,7 +109,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 	orig_code -= 6;
 	if (code [1] == 0xe8) {
 		if (can_write) {
-			InterlockedExchange ((gint32*)(orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
+			InterlockedExchange (TO_INTERLOCKED_INT32_ARGP (orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
 
 			/* Tell valgrind to recompile the patched code */
 			VALGRIND_DISCARD_TRANSLATIONS (orig_code + 2, 4);
@@ -116,7 +117,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 	} else if (code [1] == 0xe9) {
 		/* A PLT entry: jmp <DISP> */
 		if (can_write)
-			InterlockedExchange ((gint32*)(orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
+			InterlockedExchange (TO_INTERLOCKED_INT32_ARGP (orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
 	} else {
 		printf ("Invalid trampoline sequence: %x %x %x %x %x %x %x\n", code [0], code [1], code [2], code [3],
 				code [4], code [5], code [6]);

--- a/mono/sgen/sgen-array-list.c
+++ b/mono/sgen/sgen-array-list.c
@@ -46,12 +46,12 @@ sgen_array_list_grow (SgenArrayList *array, guint32 old_capacity)
 	 * the new bucket pointer.
 	 */
 	mono_memory_write_barrier ();
-	if (InterlockedCompareExchangePointer ((volatile gpointer *)&array->entries [new_bucket], entries, NULL) == NULL) {
+	if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&array->entries [new_bucket]), entries, NULL) == NULL) {
 		/*
 		 * It must not be the case that we succeeded in setting the bucket
 		 * pointer, while someone else succeeded in changing the capacity.
 		 */
-		if (InterlockedCompareExchange ((volatile gint32 *)&array->capacity, new_capacity, old_capacity) != old_capacity)
+		if (InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&array->capacity), TO_INTERLOCKED_INT32_ARG (new_capacity), TO_INTERLOCKED_INT32_ARG (old_capacity)) != TO_INTERLOCKED_INT32_ARG (old_capacity))
 			g_assert_not_reached ();
 		array->slot_hint = old_capacity;
 		return;
@@ -109,7 +109,7 @@ sgen_array_list_update_next_slot (SgenArrayList *array, guint32 new_index)
 			old_next_slot = array->next_slot;
 			if (new_index < old_next_slot)
 				break;
-		} while (InterlockedCompareExchange ((volatile gint32 *)&array->next_slot, new_index + 1, old_next_slot) != old_next_slot);
+		} while (InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&array->next_slot), TO_INTERLOCKED_INT32_ARG (new_index + 1), TO_INTERLOCKED_INT32_ARG (old_next_slot)) != TO_INTERLOCKED_INT32_ARG (old_next_slot));
 	}
 }
 

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -100,7 +100,7 @@ extern MonoCoopMutex sgen_interruption_mutex;
 		size_t __old_x;                                            \
 		do {                                                    \
 			__old_x = (x);                                  \
-		} while (InterlockedCompareExchangePointer ((void**)&(x), (void*)(__old_x + (i)), (void*)__old_x) != (void*)__old_x); \
+		} while (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&(x)), TO_INTERLOCKED_POINTER_ARG (__old_x + (i)), TO_INTERLOCKED_POINTER_ARG (__old_x)) != TO_INTERLOCKED_POINTER_ARG (__old_x)); \
 	} while (0)
 
 #ifdef HEAVY_STATISTICS
@@ -260,7 +260,7 @@ sgen_get_nursery_end (void)
 		if (final_fw_addr)						\
 			break;							\
 		new_vtable_word = SGEN_POINTER_TAG_FORWARDED ((fw_addr));	\
-		old_vtable_word = InterlockedCompareExchangePointer ((gpointer*)obj, new_vtable_word, old_vtable_word); \
+		old_vtable_word = InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (obj), new_vtable_word, old_vtable_word); \
 		final_fw_addr = SGEN_VTABLE_IS_FORWARDED (old_vtable_word);	\
 		if (!final_fw_addr)						\
 			final_fw_addr = (fw_addr);				\

--- a/mono/sgen/sgen-gchandles.c
+++ b/mono/sgen/sgen-gchandles.c
@@ -153,7 +153,7 @@ alloc_handle (HandleData *handles, GCObject *obj, gboolean track)
 	 */
 	index = sgen_array_list_add (array, obj, handles->type, TRUE);
 #ifdef HEAVY_STATISTICS
-	InterlockedIncrement ((volatile gint32 *)&stat_gc_handles_allocated);
+	InterlockedIncrement (TO_INTERLOCKED_INT32_ARGP (&stat_gc_handles_allocated));
 	if (stat_gc_handles_allocated > stat_gc_handles_max_allocated)
 		stat_gc_handles_max_allocated = stat_gc_handles_allocated;
 #endif
@@ -196,7 +196,7 @@ sgen_gchandle_iterate (GCHandleType handle_type, int max_generation, SgenGCHandl
 		if (result)
 			SGEN_ASSERT (0, MONO_GC_HANDLE_OCCUPIED (result), "Why did the callback return an unoccupied entry?");
 		else
-			HEAVY_STAT (InterlockedDecrement ((volatile gint32 *)&stat_gc_handles_allocated));
+			HEAVY_STAT (InterlockedDecrement (TO_INTERLOCKED_INT32_ARGP (&stat_gc_handles_allocated)));
 		protocol_gchandle_update (handle_type, (gpointer)slot, hidden, result);
 		*slot = result;
 	} SGEN_ARRAY_LIST_END_FOREACH_SLOT;
@@ -353,7 +353,7 @@ sgen_gchandle_free (guint32 gchandle)
 	if (index < handles->entries_array.capacity && MONO_GC_HANDLE_OCCUPIED (entry)) {
 		*slot = NULL;
 		protocol_gchandle_update (handles->type, (gpointer)slot, entry, NULL);
-		HEAVY_STAT (InterlockedDecrement ((volatile gint32 *)&stat_gc_handles_allocated));
+		HEAVY_STAT (InterlockedDecrement (TO_INTERLOCKED_INT32_ARGP (&stat_gc_handles_allocated)));
 	} else {
 		/* print a warning? */
 	}

--- a/mono/sgen/sgen-gray.c
+++ b/mono/sgen/sgen-gray.c
@@ -28,7 +28,7 @@ guint64 stat_gray_queue_dequeue_slow_path;
 #ifdef SGEN_CHECK_GRAY_OBJECT_SECTIONS
 #define STATE_TRANSITION(s,o,n)	do {					\
 		int __old = (o);					\
-		if (InterlockedCompareExchange ((volatile int*)&(s)->state, (n), __old) != __old) \
+		if (InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&(s)->state), (n), __old) != __old) \
 			g_assert_not_reached ();			\
 	} while (0)
 #define STATE_SET(s,v)		(s)->state = (v)

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -738,9 +738,9 @@ sgen_los_pin_object_par (GCObject *data)
 	if (old_size & 1)
 		return FALSE;
 #if SIZEOF_VOID_P == 4
-	old_size = InterlockedCompareExchange ((volatile gint32*)&obj->size, old_size | 1, old_size);
+	old_size = InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&obj->size), old_size | 1, old_size);
 #else
-	old_size = InterlockedCompareExchange64 ((volatile gint64*)&obj->size, old_size | 1, old_size);
+	old_size = InterlockedCompareExchange64 (TO_INTERLOCKED_INT64_ARGP (&obj->size), old_size | 1, old_size);
 #endif
 	if (old_size & 1)
 		return FALSE;

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -148,7 +148,7 @@ typedef struct {
 		first = FALSE;						\
 		while (!(tmp_mark_word & (ONE_P << (b)))) {		\
 			old_mark_word = tmp_mark_word;			\
-			tmp_mark_word = InterlockedCompareExchange ((volatile gint32*)&(bl)->mark_words [w], old_mark_word | (ONE_P << (b)), old_mark_word); \
+			tmp_mark_word = InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&(bl)->mark_words [w]), old_mark_word | (ONE_P << (b)), old_mark_word); \
 			if (tmp_mark_word == old_mark_word) {		\
 				first = TRUE;				\
 				break;					\

--- a/mono/sgen/sgen-pinning.c
+++ b/mono/sgen/sgen-pinning.c
@@ -333,7 +333,7 @@ sgen_cement_lookup_or_register (GCObject *obj)
 
 	if (!hash [i].obj) {
 		GCObject *old_obj;
-		old_obj = InterlockedCompareExchangePointer ((gpointer*)&hash [i].obj, obj, NULL);
+		old_obj = InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&hash [i].obj), obj, NULL);
 		/* Check if the slot was occupied by some other object */
 		if (old_obj != NULL && old_obj != obj)
 			return FALSE;
@@ -344,7 +344,7 @@ sgen_cement_lookup_or_register (GCObject *obj)
 	if (hash [i].count >= SGEN_CEMENT_THRESHOLD)
 		return TRUE;
 
-	if (InterlockedIncrement ((gint32*)&hash [i].count) == SGEN_CEMENT_THRESHOLD) {
+	if (InterlockedIncrement (TO_INTERLOCKED_INT32_ARGP (&hash [i].count)) == SGEN_CEMENT_THRESHOLD) {
 		SGEN_ASSERT (9, sgen_get_current_collection_generation () >= 0, "We can only cement objects when we're in a collection pause.");
 		SGEN_ASSERT (9, SGEN_OBJECT_IS_PINNED (obj), "Can only cement pinned objects");
 		SGEN_CEMENT_OBJECT (obj);

--- a/mono/sgen/sgen-protocol.c
+++ b/mono/sgen/sgen-protocol.c
@@ -328,7 +328,7 @@ binary_protocol_get_buffer (int length)
 	new_buffer->next = buffer;
 	new_buffer->index = 0;
 
-	if (InterlockedCompareExchangePointer ((void**)&binary_protocol_buffers, new_buffer, buffer) != buffer) {
+	if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&binary_protocol_buffers), new_buffer, buffer) != buffer) {
 		sgen_free_os_memory (new_buffer, sizeof (BinaryProtocolBuffer), SGEN_ALLOC_INTERNAL, MONO_MEM_ACCOUNT_SGEN_BINARY_PROTOCOL);
 		goto retry;
 	}

--- a/mono/utils/lock-free-alloc.c
+++ b/mono/utils/lock-free-alloc.c
@@ -171,10 +171,10 @@ desc_alloc (MonoMemAccountType type)
 	for (;;) {
 		gboolean success;
 
-		desc = (Descriptor *) mono_get_hazardous_pointer ((gpointer * volatile)&desc_avail, hp, 1);
+		desc = (Descriptor *) mono_get_hazardous_pointer (TO_INTERLOCKED_POINTER_ARGP (&desc_avail), hp, 1);
 		if (desc) {
 			Descriptor *next = desc->next;
-			success = (InterlockedCompareExchangePointer ((gpointer * volatile)&desc_avail, next, desc) == desc);
+			success = (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&desc_avail), next, desc) == desc);
 		} else {
 			size_t desc_size = sizeof (Descriptor);
 			Descriptor *d;
@@ -193,7 +193,7 @@ desc_alloc (MonoMemAccountType type)
 
 			mono_memory_write_barrier ();
 
-			success = (InterlockedCompareExchangePointer ((gpointer * volatile)&desc_avail, desc->next, NULL) == NULL);
+			success = (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&desc_avail), desc->next, NULL) == NULL);
 
 			if (!success)
 				mono_vfree (desc, desc_size * NUM_DESC_BATCH, type);
@@ -224,7 +224,7 @@ desc_enqueue_avail (gpointer _desc)
 		old_head = desc_avail;
 		desc->next = old_head;
 		mono_memory_write_barrier ();
-	} while (InterlockedCompareExchangePointer ((gpointer * volatile)&desc_avail, desc, old_head) != old_head);
+	} while (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&desc_avail), desc, old_head) != old_head);
 }
 
 static void
@@ -343,7 +343,7 @@ alloc_from_active_or_partial (MonoLockFreeAllocator *heap)
  retry:
 	desc = heap->active;
 	if (desc) {
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, NULL, desc) != desc)
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&heap->active), NULL, desc) != desc)
 			goto retry;
 	} else {
 		desc = heap_get_partial (heap);
@@ -380,7 +380,7 @@ alloc_from_active_or_partial (MonoLockFreeAllocator *heap)
 
 	/* If the desc is partial we have to give it back. */
 	if (new_anchor.data.state == STATE_PARTIAL) {
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&heap->active), desc, NULL) != NULL)
 			heap_put_partial (desc);
 	}
 
@@ -418,7 +418,7 @@ alloc_from_new_sb (MonoLockFreeAllocator *heap)
 	mono_memory_write_barrier ();
 
 	/* Make it active or free it again. */
-	if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, desc, NULL) == NULL) {
+	if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&heap->active), desc, NULL) == NULL) {
 		return desc->sb;
 	} else {
 		desc->anchor.data.state = STATE_EMPTY;
@@ -477,7 +477,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 	if (new_anchor.data.state == STATE_EMPTY) {
 		g_assert (old_anchor.data.state != STATE_EMPTY);
 
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, NULL, desc) == desc) {
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&heap->active), NULL, desc) == desc) {
 			/*
 			 * We own desc, check if it's still empty, in which case we retire it.
 			 * If it's partial we need to put it back either on the active slot or
@@ -486,7 +486,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 			if (desc->anchor.data.state == STATE_EMPTY) {
 				desc_retire (desc);
 			} else if (desc->anchor.data.state == STATE_PARTIAL) {
-				if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
+				if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&heap->active), desc, NULL) != NULL)
 					heap_put_partial (desc);
 
 			}
@@ -505,7 +505,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 
 		g_assert (new_anchor.data.state == STATE_PARTIAL);
 
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&desc->heap->active, desc, NULL) != NULL)
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&desc->heap->active), desc, NULL) != NULL)
 			heap_put_partial (desc);
 	}
 }

--- a/mono/utils/lock-free-array-queue.c
+++ b/mono/utils/lock-free-array-queue.c
@@ -68,7 +68,7 @@ mono_lock_free_array_nth (MonoLockFreeArray *arr, int index)
 	if (!arr->chunk_list) {
 		chunk = alloc_chunk (arr);
 		mono_memory_write_barrier ();
-		if (InterlockedCompareExchangePointer ((volatile gpointer *)&arr->chunk_list, chunk, NULL) != NULL)
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&arr->chunk_list), chunk, NULL) != NULL)
 			free_chunk (chunk, arr->account_type);
 	}
 
@@ -80,7 +80,7 @@ mono_lock_free_array_nth (MonoLockFreeArray *arr, int index)
 		if (!next) {
 			next = alloc_chunk (arr);
 			mono_memory_write_barrier ();
-			if (InterlockedCompareExchangePointer ((volatile gpointer *) &chunk->next, next, NULL) != NULL) {
+			if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&chunk->next), next, NULL) != NULL) {
 				free_chunk (next, arr->account_type);
 				next = chunk->next;
 				g_assert (next);

--- a/mono/utils/lock-free-queue.c
+++ b/mono/utils/lock-free-queue.c
@@ -156,11 +156,11 @@ mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node)
 				 * might append to a node that isn't
 				 * in the queue anymore here.
 				 */
-				if (InterlockedCompareExchangePointer ((gpointer volatile*)&tail->next, node, END_MARKER) == END_MARKER)
+				if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&tail->next), node, END_MARKER) == END_MARKER)
 					break;
 			} else {
 				/* Try to advance tail */
-				InterlockedCompareExchangePointer ((gpointer volatile*)&q->tail, next, tail);
+				InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&q->tail), next, tail);
 			}
 		}
 
@@ -169,7 +169,7 @@ mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node)
 	}
 
 	/* Try to advance tail */
-	InterlockedCompareExchangePointer ((gpointer volatile*)&q->tail, node, tail);
+	InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&q->tail), node, tail);
 
 	mono_memory_write_barrier ();
 	mono_hazard_pointer_clear (hp, 0);
@@ -275,11 +275,11 @@ mono_lock_free_queue_dequeue (MonoLockFreeQueue *q)
 				}
 
 				/* Try to advance tail */
-				InterlockedCompareExchangePointer ((gpointer volatile*)&q->tail, next, tail);
+				InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&q->tail), next, tail);
 			} else {
 				g_assert (next != END_MARKER);
 				/* Try to dequeue head */
-				if (InterlockedCompareExchangePointer ((gpointer volatile*)&q->head, next, head) == head)
+				if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&q->head), next, head) == head)
 					break;
 			}
 		}

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -77,6 +77,16 @@ typedef SSIZE_T ssize_t;
 #define MONO_EMPTY_SOURCE_FILE(x)
 #endif
 
+#ifdef _MSC_VER
+#define MONO_PRAGMA_WARNING_PUSH() __pragma(warning(push))
+#define MONO_PRAGMA_WARNING_DISABLE(x) __pragma(warning(disable:x))
+#define MONO_PRAGMA_WARNING_POP() __pragma(warning(pop))
+#else
+#define MONO_PRAGMA_WARNING_PUSH()
+#define MONO_PRAGMA_WARNING_DISABLE(x)
+#define MONO_PRAGMA_WARNING_POP()
+#endif
+
 #if !defined(_MSC_VER) && !defined(HOST_SOLARIS) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(MONOTOUCH) && HAVE_VISIBILITY_HIDDEN
 #if MONO_LLVM_LOADED
 #define MONO_LLVM_INTERNAL MONO_API

--- a/mono/utils/mono-linked-list-set.c
+++ b/mono/utils/mono-linked-list-set.c
@@ -115,7 +115,7 @@ try_again:
 			mono_hazard_pointer_set (hp, 2, cur);
 		} else {
 			next = (MonoLinkedListSetNode *) mono_lls_pointer_unmask (next);
-			if (InterlockedCompareExchangePointer ((volatile gpointer*)prev, next, cur) == cur) {
+			if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (prev), next, cur) == cur) {
 				/* The hazard pointer must be cleared after the CAS. */
 				mono_memory_write_barrier ();
 				mono_hazard_pointer_clear (hp, 1);
@@ -153,7 +153,7 @@ mono_lls_insert (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLink
 		mono_hazard_pointer_set (hp, 0, value);
 		/* The CAS must happen after setting the hazard pointer. */
 		mono_memory_write_barrier ();
-		if (InterlockedCompareExchangePointer ((volatile gpointer*)prev, value, cur) == cur)
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (prev), value, cur) == cur)
 			return TRUE;
 	}
 }
@@ -177,11 +177,11 @@ mono_lls_remove (MonoLinkedListSet *list, MonoThreadHazardPointers *hp, MonoLink
 
 		g_assert (cur == value);
 
-		if (InterlockedCompareExchangePointer ((volatile gpointer*)&cur->next, mask (next, 1), next) != next)
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&cur->next), mask (next, 1), next) != next)
 			continue;
 		/* The second CAS must happen before the first. */
 		mono_memory_write_barrier ();
-		if (InterlockedCompareExchangePointer ((volatile gpointer*)prev, mono_lls_pointer_unmask (next), cur) == cur) {
+		if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (prev), mono_lls_pointer_unmask (next), cur) == cur) {
 			/* The CAS must happen before the hazard pointer clear. */
 			mono_memory_write_barrier ();
 			mono_hazard_pointer_clear (hp, 1);

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -11,6 +11,7 @@
 #ifndef __MONO_SPLIT_ORDERED_LIST_H__
 #define __MONO_SPLIT_ORDERED_LIST_H__
 
+#include <mono/utils/atomic.h>
 #include <mono/utils/hazard-pointer.h>
 #include <mono/utils/mono-membar.h>
 
@@ -148,7 +149,7 @@ mono_lls_filter_accept_all (gpointer elem)
 					mono_hazard_pointer_set (hp__, 2, cur__); \
 				} else { \
 					next__ = (MonoLinkedListSetNode *) mono_lls_pointer_unmask (next__); \
-					if (InterlockedCompareExchangePointer ((volatile gpointer *) prev__, next__, cur__) == cur__) { \
+					if (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (prev__), next__, cur__) == cur__) { \
 						mono_memory_write_barrier (); \
 						mono_hazard_pointer_clear (hp__, 1); \
 						if (list__->free_node_func) { \

--- a/mono/utils/mono-os-wait-win32.c
+++ b/mono/utils/mono-os-wait-win32.c
@@ -8,6 +8,7 @@
 * Licensed under the MIT license. See LICENSE file in the project root for full license information.
 */
 
+#include <mono/utils/atomic.h>
 #include <mono/utils/mono-os-wait.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-threads-debug.h>

--- a/mono/utils/mono-threads-debug.h
+++ b/mono/utils/mono-threads-debug.h
@@ -9,7 +9,7 @@
 #define MOSTLY_ASYNC_SAFE_PRINTF(...) do { \
 	char __buff[1024];	__buff [0] = '\0'; \
 	g_snprintf (__buff, sizeof (__buff), __VA_ARGS__);	\
-	write (1, __buff, strlen (__buff));	\
+	write (1, __buff, (guint32)strlen (__buff));	\
 } while (0)
 
 #if 1

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1456,7 +1456,7 @@ mono_thread_info_install_interrupt (void (*callback) (gpointer data), gpointer d
 	token->callback = callback;
 	token->data = data;
 
-	previous_token = (MonoThreadInfoInterruptToken *)InterlockedCompareExchangePointer ((gpointer*) &info->interrupt_token, token, NULL);
+	previous_token = (MonoThreadInfoInterruptToken *)InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&info->interrupt_token), token, NULL);
 
 	if (previous_token) {
 		if (previous_token != INTERRUPT_STATE)
@@ -1483,7 +1483,7 @@ mono_thread_info_uninstall_interrupt (gboolean *interrupted)
 	info = mono_thread_info_current ();
 	g_assert (info);
 
-	previous_token = (MonoThreadInfoInterruptToken *)InterlockedExchangePointer ((gpointer*) &info->interrupt_token, NULL);
+	previous_token = (MonoThreadInfoInterruptToken *)InterlockedExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&info->interrupt_token), NULL);
 
 	/* only the installer can uninstall the token */
 	g_assert (previous_token);
@@ -1519,7 +1519,7 @@ set_interrupt_state (MonoThreadInfo *info)
 		}
 
 		token = previous_token;
-	} while (InterlockedCompareExchangePointer ((gpointer*) &info->interrupt_token, INTERRUPT_STATE, previous_token) != previous_token);
+	} while (InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&info->interrupt_token), INTERRUPT_STATE, previous_token) != previous_token);
 
 	return token;
 }
@@ -1592,7 +1592,7 @@ mono_thread_info_clear_self_interrupt ()
 	info = mono_thread_info_current ();
 	g_assert (info);
 
-	previous_token = (MonoThreadInfoInterruptToken *)InterlockedCompareExchangePointer ((gpointer*) &info->interrupt_token, NULL, INTERRUPT_STATE);
+	previous_token = (MonoThreadInfoInterruptToken *)InterlockedCompareExchangePointer (TO_INTERLOCKED_POINTER_ARGP (&info->interrupt_token), NULL, INTERRUPT_STATE);
 	g_assert (previous_token == NULL || previous_token == INTERRUPT_STATE);
 
 	THREADS_INTERRUPT_DEBUG ("interrupt clear self tid %p previous_token %p\n", mono_thread_info_get_tid (info), previous_token);

--- a/mono/utils/refcount.h
+++ b/mono/utils/refcount.h
@@ -49,7 +49,7 @@ mono_refcount_tryincrement (MonoRefCount *refcount)
 			return FALSE;
 
 		newref = oldref + 1;
-	} while (InterlockedCompareExchange ((gint32*) &refcount->ref, newref, oldref) != oldref);
+	} while (InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&refcount->ref), TO_INTERLOCKED_INT32_ARG (newref), TO_INTERLOCKED_INT32_ARG (oldref)) != TO_INTERLOCKED_INT32_ARG (oldref));
 
 	return TRUE;
 }
@@ -74,7 +74,7 @@ mono_refcount_decrement (MonoRefCount *refcount)
 			g_error ("%s: cannot decrement a ref with value 0", __func__);
 
 		newref = oldref - 1;
-	} while (InterlockedCompareExchange ((gint32*) &refcount->ref, newref, oldref) != oldref);
+	} while (InterlockedCompareExchange (TO_INTERLOCKED_INT32_ARGP (&refcount->ref), TO_INTERLOCKED_INT32_ARG (newref), TO_INTERLOCKED_INT32_ARG (oldref)) != TO_INTERLOCKED_INT32_ARG (oldref));
 
 	if (newref == 0 && refcount->destructor)
 		refcount->destructor ((gpointer) refcount);

--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -94,7 +94,7 @@
       <DllExportPreprocessorDefinitions>MONO_DLL_EXPORT</DllExportPreprocessorDefinitions>
       <DllImportPreprocessorDefinitions>MONO_DLL_IMPORT</DllImportPreprocessorDefinitions>
       <PreprocessorDefinitions>__default_codegen__;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;HAVE_CONFIG_H;GC_NOT_DLL;WIN32_THREADS;WINVER=0x0600;_WIN32_WINNT=0x0600;_WIN32_IE=0x0501;_UNICODE;UNICODE;FD_SETSIZE=1024;%(PreprocessorDefinitions);</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4273;4005</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4273;4005;4152;4221;4214;4204;4201</DisableSpecificWarnings>
       <RuntimeLibrary>$(MONO_C_RUNTIME)</RuntimeLibrary>
     </ClCompile>
     <Link>


### PR DESCRIPTION
There is currently a small mismatch between the signatures used by atomic.h interlocked functions and corresponding Win32 functions. This will trigger a bunch of warnings when building with higher log level. On none desktop Windows platforms, even compile errors.

Current design has issues on none desktop Windows platforms where incorrect interlocked implementation will be picked up when interlocked methods are real functions instead of defines.

This commit makes sure InterlockedXXX used from atomic.h have the same signature as other platforms. Wrapper implementations also switch to use intrinsic versions of the InterlockedXXX functions.

The commit also adds a couple of helper macros to correctly cast the arguments when calling Interlocked
methods. Codebase has been swept to replace custom casts with macro. In cases when current calls caused signed/unsigned warnings, the macros have been used to make this intent clearer.

Since the Win32 Interlocked API's are redefined in atomic.h the commit also adds explicit includes of
atomic.h in sources using Interlocked methods.

Commit eliminates a couple of additional warnings as well. On Windows MSVC build it disables
some of the extension warnings, like C4152, C4221, C4214, C4204, C4201.