### PR TITLE
[amd64] Get xmm registers only when on glibc

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -29,7 +29,7 @@ typedef struct __darwin_xmm_reg MonoContextSimdReg;
 #elif defined(TARGET_AMD64)
 #if defined(__APPLE__)
 typedef struct __darwin_xmm_reg MonoContextSimdReg;
-#elif defined(__linux__)
+#elif defined(__linux__) && defined(__GLIBC__)
 typedef struct _libc_xmmreg MonoContextSimdReg;
 #endif
 #elif defined(TARGET_ARM64)
@@ -247,7 +247,7 @@ typedef struct {
 
 typedef struct {
 	mgreg_t gregs [AMD64_NREG];
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__))
 	MonoContextSimdReg fregs [AMD64_XMM_NREG];
 #else
 	double fregs [AMD64_XMM_NREG];

--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -260,6 +260,7 @@ typedef struct ucontext {
 	#define UCONTEXT_REG_R15(ctx) (((ucontext_t*)(ctx))->sc_r15)
 #elif !defined(HOST_WIN32)
 	#define UCONTEXT_GREGS(ctx)	((guint64*)&(((ucontext_t*)(ctx))->uc_mcontext.gregs))
+#if defined(__GLIBC__)
 	/*
 	 * Ordinarily, ctx->uc_mcontext.fpregs is a pointer to somewhere in
 	 * ctx->__fpregs_mem and is the preferred way to access the fpstate.
@@ -275,6 +276,7 @@ typedef struct ucontext {
 	 */
 	#define UCONTEXT_HAS_FREGS(ctx) (!!((ucontext_t *) (ctx))->uc_mcontext.fpregs)
 	#define UCONTEXT_FREGS(ctx)	(((ucontext_t *) (ctx))->uc_mcontext.fpregs->_xmm)
+#endif
 #endif
 
 #ifdef UCONTEXT_GREGS


### PR DESCRIPTION
Other libc's like on alpine, have different ucontext_t format.