### PR TITLE
[profiler] Don't link against libmono on Linux.

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -43,7 +43,11 @@ endif
 if TARGET_OSX
 libmono_dep =
 else
+if HOST_LINUX
+libmono_dep =
+else
 libmono_dep = $(monodir)/mono/mini/$(LIBMONO_LA)
+endif
 endif
 
 if HOST_ANDROID


### PR DESCRIPTION
This patch makes it so that the profiler is not linked against libmono on any architecture, thus fixing the broken --enable-llvm build on Linux.
I'm not quite certain if there's any architecture out there actually using that dependency, but I think it would be safe to conclude there is none if the testing passes. Linking the profiler against libmono has been disabled on OSX for quite some time with no negative effects to my knowledge.
This change may help in fixing [bug 57742](https://bugzilla.xamarin.com/show_bug.cgi?id=57742).