### PR TITLE
Limit max possible threads in ThreadPool (SetMaxThreads)

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
@@ -158,20 +158,20 @@ namespace MonoTests.System.Threading
 		}
 		
 		[Test]
-		public void SetMaxPossibleThreads()
+		public void SetMaxPossibleThreads ()
 		{
 			var maxPossibleThreads = 0x7fff;
 			int maxWt, macCpt;
-			
-			ThreadPool.SetMaxThreads(maxPossibleThreads, maxPossibleThreads);
-			ThreadPool.GetMaxThreads(out maxWt, out macCpt);
-			Assert.AreEqual(maxPossibleThreads, maxWt);
-			Assert.AreEqual(maxPossibleThreads, macCpt);
 
-			ThreadPool.SetMaxThreads(maxPossibleThreads + 1, maxPossibleThreads + 1);
-			ThreadPool.GetMaxThreads(out maxWt, out macCpt);
-			Assert.AreEqual(maxPossibleThreads, maxWt);
-			Assert.AreEqual(maxPossibleThreads, macCpt);
+			ThreadPool.SetMaxThreads (maxPossibleThreads, maxPossibleThreads);
+			ThreadPool.GetMaxThreads (out maxWt, out macCpt);
+			Assert.AreEqual (maxPossibleThreads, maxWt);
+			Assert.AreEqual (maxPossibleThreads, macCpt);
+
+			ThreadPool.SetMaxThreads (maxPossibleThreads + 1, maxPossibleThreads + 1);
+			ThreadPool.GetMaxThreads (out maxWt, out macCpt);
+			Assert.AreEqual (maxPossibleThreads, maxWt);
+			Assert.AreEqual (maxPossibleThreads, macCpt);
 		}
 
 		[Test]

--- a/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
@@ -156,6 +156,23 @@ namespace MonoTests.System.Threading
 			Assert.IsTrue (workerThreads == workerThreads_new, "#3");
 			Assert.IsTrue (completionPortThreads == completionPortThreads_new, "#4");
 		}
+		
+		[Test]
+		public void SetMaxPossibleThreads()
+		{
+			var maxPossibleThreads = 0x7fff;
+			int maxWt, macCpt;
+			
+			ThreadPool.SetMaxThreads(maxPossibleThreads, maxPossibleThreads);
+			ThreadPool.GetMaxThreads(out maxWt, out macCpt);
+			Assert.AreEqual(maxPossibleThreads, maxWt);
+			Assert.AreEqual(maxPossibleThreads, macCpt);
+
+			ThreadPool.SetMaxThreads(maxPossibleThreads + 1, maxPossibleThreads + 1);
+			ThreadPool.GetMaxThreads(out maxWt, out macCpt);
+			Assert.AreEqual(maxPossibleThreads, maxWt);
+			Assert.AreEqual(maxPossibleThreads, macCpt);
+		}
 
 		[Test]
 		public void GetAvailableThreads ()

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -688,8 +688,8 @@ ves_icall_System_Threading_ThreadPool_SetMinThreadsNative (gint32 worker_threads
 MonoBoolean
 ves_icall_System_Threading_ThreadPool_SetMaxThreadsNative (gint32 worker_threads, gint32 completion_port_threads)
 {
-	worker_threads = min (worker_threads, MAX_POSSIBLE_THREADS);
-	completion_port_threads = min (completion_port_threads, MAX_POSSIBLE_THREADS);
+	worker_threads = MIN (worker_threads, MAX_POSSIBLE_THREADS);
+	completion_port_threads = MIN (completion_port_threads, MAX_POSSIBLE_THREADS);
 
 	gint cpu_count = mono_cpu_count ();
 

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -48,6 +48,9 @@
 #include <mono/utils/refcount.h>
 #include <mono/utils/mono-os-wait.h>
 
+// consistency with coreclr https://github.com/dotnet/coreclr/blob/master/src/vm/win32threadpool.h#L111
+#define MAX_POSSIBLE_THREADS 0x7fff
+
 typedef struct {
 	MonoDomain *domain;
 	/* Number of outstanding jobs */
@@ -685,6 +688,9 @@ ves_icall_System_Threading_ThreadPool_SetMinThreadsNative (gint32 worker_threads
 MonoBoolean
 ves_icall_System_Threading_ThreadPool_SetMaxThreadsNative (gint32 worker_threads, gint32 completion_port_threads)
 {
+	worker_threads = min(worker_threads, MAX_POSSIBLE_THREADS);
+	completion_port_threads = min(completion_port_threads, MAX_POSSIBLE_THREADS);
+
 	gint cpu_count = mono_cpu_count ();
 
 	if (completion_port_threads < threadpool.limit_io_min || completion_port_threads < cpu_count)

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -48,7 +48,7 @@
 #include <mono/utils/refcount.h>
 #include <mono/utils/mono-os-wait.h>
 
-// consistency with coreclr https://github.com/dotnet/coreclr/blob/master/src/vm/win32threadpool.h#L111
+// consistency with coreclr https://github.com/dotnet/coreclr/blob/643b09f966e68e06d5f0930755985a01a2a2b096/src/vm/win32threadpool.h#L111
 #define MAX_POSSIBLE_THREADS 0x7fff
 
 typedef struct {
@@ -688,8 +688,8 @@ ves_icall_System_Threading_ThreadPool_SetMinThreadsNative (gint32 worker_threads
 MonoBoolean
 ves_icall_System_Threading_ThreadPool_SetMaxThreadsNative (gint32 worker_threads, gint32 completion_port_threads)
 {
-	worker_threads = min(worker_threads, MAX_POSSIBLE_THREADS);
-	completion_port_threads = min(completion_port_threads, MAX_POSSIBLE_THREADS);
+	worker_threads = min (worker_threads, MAX_POSSIBLE_THREADS);
+	completion_port_threads = min (completion_port_threads, MAX_POSSIBLE_THREADS);
 
 	gint cpu_count = mono_cpu_count ();
 


### PR DESCRIPTION
to 0x7fff like CoreCLR does:
https://github.com/dotnet/coreclr/blob/master/src/vm/win32threadpool.h#L111
https://github.com/dotnet/coreclr/blob/master/src/vm/win32threadpool.cpp#L530

I was trying to port tests from corefx to mono (for ThreadPool) and one of them tests this.
https://github.com/dotnet/corefx/blob/master/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs#L123-L124

Bugzilla: https://bugzilla.xamarin.com/show_bug.cgi?id=60027