### PR TITLE
Fixed unhandled exceptions in EndPointListener.cs

### DIFF
--- a/mcs/class/System/System.Net/EndPointListener.cs
+++ b/mcs/class/System/System.Net/EndPointListener.cs
@@ -112,7 +112,13 @@ namespace System.Net {
 				accepted.Close ();
 				return;
 			}
-			HttpConnection conn = new HttpConnection (accepted, epl, epl.secure, epl.cert);
+            HttpConnection conn;
+            try {
+                conn = new HttpConnection (accepted, epl, epl.secure, epl.cert);
+            } catch {
+                accepted.Close ();
+                return;
+            }
 			lock (epl.unregistered) {
 				epl.unregistered [conn] = conn;
 			}

--- a/mcs/class/System/System.Net/EndPointListener.cs
+++ b/mcs/class/System/System.Net/EndPointListener.cs
@@ -112,13 +112,13 @@ namespace System.Net {
 				accepted.Close ();
 				return;
 			}
-            HttpConnection conn;
-            try {
-                conn = new HttpConnection (accepted, epl, epl.secure, epl.cert);
-            } catch {
-                accepted.Close ();
-                return;
-            }
+			HttpConnection conn;
+			try {
+				conn = new HttpConnection (accepted, epl, epl.secure, epl.cert);
+			} catch {
+				accepted.Close ();
+				return;
+			}
 			lock (epl.unregistered) {
 				epl.unregistered [conn] = conn;
 			}


### PR DESCRIPTION
Application hosting self-hosted website over https crashes when attempting to access a webpage over http. The patch described in the bug report below resolves the crash, and the commit in this pull request implements the fix.

https://bugzilla.xamarin.com/show_bug.cgi?id=52675