### PR TITLE
[corlib] Use temp directory for assemblies in SaveTest.Save()

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
@@ -67,9 +67,31 @@ public class SaveTest
 		0x79, 0xC0, 0x9B, 0x5F, 0x34, 0x86, 0xB2, 0xDE, 0xC4, 0x19, 0x84, 0x5F, 
 		0x0E, 0xED, 0x9B, 0xB8, 0xD3, 0x17, 0xDA, 0x78 };
 
+	string tempDir = Path.Combine (Path.GetTempPath (), typeof (SaveTest).FullName);
+
+	[SetUp]
+	protected void SetUp ()
+	{
+		var rand = new Random ();
+		string basePath = tempDir;
+		while (Directory.Exists (tempDir))
+			tempDir = Path.Combine (basePath, rand.Next ().ToString ());
+		Directory.CreateDirectory (tempDir);
+	}
+
+	[TearDown]
+	protected void TearDown ()
+	{
+		try {
+			Directory.Delete (tempDir, true);
+		} catch (DirectoryNotFoundException) {
+		} catch (IOException) {
+			// Can happen on Windows if assemblies from this dir are still used
+		}
+	}
+
 	[Test]
 	public void Save () {
-		// FIXME: Temp dir etc.
 
 		//
 		// Create a test assembly, write it to disk, then read it back
@@ -81,9 +103,9 @@ public class SaveTest
 		aname.CultureInfo = new CultureInfo ("en");
 		aname.Flags = AssemblyNameFlags.Retargetable;
 		aname.HashAlgorithm = AssemblyHashAlgorithm.SHA256;
-		var ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aname, AssemblyBuilderAccess.RunAndSave);
+		var ab = AppDomain.CurrentDomain.DefineDynamicAssembly (aname, AssemblyBuilderAccess.RunAndSave, tempDir);
 
-		string strongfile = "strongname.snk";
+		string strongfile = Path.Combine (tempDir, "strongname.snk");
 		using (FileStream fs = File.OpenWrite (strongfile)) {
 			fs.Write (strongName, 0, strongName.Length);
 			fs.Close ();
@@ -264,7 +286,7 @@ public class SaveTest
 		ab.Save ("h.exe");
 
 		// Read the assembly and check data
-		Assembly a = Assembly.LoadFrom ("h.exe");
+		Assembly a = Assembly.LoadFrom (Path.Combine (tempDir, "h.exe"));
 		Assert.IsTrue (a != ab);
 		CheckAssembly (a);
 	}


### PR DESCRIPTION
It was writing to the current working directory before which doesn't work on platforms where that directory is read-only.

Using the same setup/teardown methods as TypeBuilderTest we instead create a directory in the temporary location and put the files there.