### PR TITLE
[interp] use GC aware memcpy for storing value types to fields

### DIFF
--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -106,15 +106,15 @@ OPDEF(MINT_STFLD_R4, "stfld.r4", 2, MintOpUShortInt)
 OPDEF(MINT_STFLD_R8, "stfld.r8", 2, MintOpUShortInt)
 OPDEF(MINT_STFLD_O, "stfld.o", 2, MintOpUShortInt)
 OPDEF(MINT_STFLD_P, "stfld.p", 2, MintOpUShortInt)
-OPDEF(MINT_STFLD_VT, "stfld.vt", 4, MintOpShortAndInt)
+OPDEF(MINT_STFLD_VT, "stfld.vt", 3, MintOpTwoShorts)
 
 OPDEF(MINT_STRMFLD, "strmfld", 2, MintOpFieldToken)
-OPDEF(MINT_STRMFLD_VT, "strmfld.vt", 4, MintOpShortAndInt)
+OPDEF(MINT_STRMFLD_VT, "strmfld.vt", 2, MintOpUShortInt)
 
 OPDEF(MINT_LDSFLD, "ldsfld", 2, MintOpFieldToken)
 OPDEF(MINT_LDSFLD_VT, "ldsfld.vt", 4, MintOpShortAndInt)
 OPDEF(MINT_STSFLD, "stsfld", 2, MintOpUShortInt)
-OPDEF(MINT_STSFLD_VT, "stsfld.vt", 4, MintOpShortAndInt)
+OPDEF(MINT_STSFLD_VT, "stsfld.vt", 2, MintOpUShortInt)
 OPDEF(MINT_LDSFLDA, "ldsflda", 2, MintOpUShortInt)
 
 OPDEF(MINT_LDLOC_I1, "ldloc.i1", 2, MintOpUShortInt)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2954,13 +2954,14 @@ generate (MonoMethod *method, InterpMethod *rtm, unsigned char *is_bb_start, Mon
 				} else {
 					ADD_CODE (td, MINT_STFLD_I1 + mt - MINT_TYPE_I1);
 					ADD_CODE (td, klass->valuetype ? field->offset - sizeof(MonoObject) : field->offset);
+					if (mt == MINT_TYPE_VT)
+						ADD_CODE (td, get_data_item_index (td, field));
 				}
 			}
 			if (mt == MINT_TYPE_VT) {
 				MonoClass *klass = mono_class_from_mono_type (field->type);
 				int size = mono_class_value_size (klass, NULL);
-				POP_VT(td, size);
-				WRITE32(td, &size);
+				POP_VT (td, size);
 			}
 			td->ip += 5;
 			td->sp -= 2;
@@ -3005,7 +3006,6 @@ generate (MonoMethod *method, InterpMethod *rtm, unsigned char *is_bb_start, Mon
 				MonoClass *klass = mono_class_from_mono_type (field->type);
 				int size = mono_class_value_size (klass, NULL);
 				POP_VT (td, size);
-				WRITE32 (td, &size);
 			}
 			td->ip += 5;
 			--td->sp;


### PR DESCRIPTION
value types can contain references, and therefore GC write barriers are
required.

(from #5425, in order to get work upstream)