### PR TITLE
[interp] fix LMF popping during exception handling

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5190,8 +5190,20 @@ die_on_ex:
 			++sp;
 			goto main_loop;
 		}
-		goto exit_frame;
+		goto check_lmf;
 	}
+
+check_lmf:
+	{
+		/* make sure we don't miss to pop a LMF */
+		MonoLMF *lmf= mono_get_lmf ();
+		if (lmf && (gsize) lmf->previous_lmf & 2) {
+			MonoLMFExt *ext = (MonoLMFExt *) lmf;
+			if (ext->interp_exit && ext->interp_exit_data == frame->parent)
+				interp_pop_lmf (ext);
+		}
+	}
+
 exit_frame:
 
 	if (!frame->ex && MONO_PROFILER_ENABLED (method_leave) &&


### PR DESCRIPTION
Assume you have something like this:

```
$ cat invokecrasher.cs
using System;
using System.Reflection;

public class InvokeCrasher {
        readonly static object[] default_args = new object[1] { new string[] {} };
        public static void Main (string []args) {
                Assembly assembly = Assembly.LoadFile ("crasher.exe");
                try {
                        assembly.EntryPoint.Invoke (null, default_args);
                } catch {
                }

                assembly.EntryPoint.Invoke (null, default_args);
        }
}
```

```
$  cat crasher.cs
using System;

public class Crasher {
        unsafe public static void Main (string []args) {
                int i = 1337;
                CrashMe (&i);
                throw new Exception ();
        }

        unsafe static void CrashMe (int *p) {
                // p = (int *) 0;
                *p = 0;
        }
}
```

On the first `Invoke ()` the interpreter goes through `ves_pinvoke_method`:

```
      interp_push_lmf (&ext, frame);

      mono_interp_enter_icall_trampoline (addr, margs);

      interp_pop_lmf (&ext);
```

The LMF is needed for unwinding by mini. In this situation though,
`Crasher` throws an exception and goes through the exception handling machinery
of the interpreter which leads to missing out of the `interp_pop_lmf ()` call.

On the second `Invoke` we would therefore push the same address as an LMF
again, which leads to a LMF that points to itself as `previous_lmf`. If we
encounter a native crash in this state (as hinted with `p = (int *) 0; *p = 0;`),
the unwinding machinery would end up in an infinite loop.


(from #5425, in order to get work upstream)