### PR TITLE
[arm{v7,64}]: de- and increment PC properly, so it is aligned with other PC manipulations

### DIFF
--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -482,8 +482,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~3);
 		}
 
-		/* we substract 1, so that the IP points into the call instruction */
-		new_ctx->pc--;
+		/* we substract one instruction, so that the IP points into the call instruction */
+		new_ctx->pc -= 4;
 
 		return TRUE;
 	} else if (*lmf) {
@@ -521,8 +521,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		new_ctx->regs [ARMREG_SP] = (*lmf)->gregs [MONO_ARCH_LMF_REG_SP];
 		new_ctx->pc = (*lmf)->pc;
 
-		/* we substract 1, so that the IP points into the call instruction */
-		new_ctx->pc--;
+		/* we substract one instruction, so that the IP points into the call instruction */
+		new_ctx->pc -= 4;
 
 		*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~3);
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2145,11 +2145,9 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 #if defined(TARGET_AMD64)
 						ctx->gregs [AMD64_RIP] ++;
 #elif defined(TARGET_ARM)
-						ctx->pc ++;
-						if (mono_arm_thumb_supported ())
-							ctx->pc |= 1;
+						ctx->pc += (ctx->pc & 1) ? 2 : 4;
 #elif defined(TARGET_ARM64)
-						ctx->pc ++;
+						ctx->pc += 4;
 #else
 						NOT_IMPLEMENTED;
 #endif


### PR DESCRIPTION
specifically with:

```
void
mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow)
{
    /* ... */

    /* Adjust pc so it points into the call instruction */
    pc -= 4;
```

(from #5425, in order to get work upstream)