### PR TITLE
[System.Windows.Forms] Proper operation order. Fixes #59393.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/MonthCalendar.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/MonthCalendar.cs
@@ -1601,7 +1601,7 @@ namespace System.Windows.Forms {
 			}
 				
 			// Only set if we re actually getting a different range (avoid an extra DateChanged event)
-			if (range != null && range.Start != selection_range.Start || range.End != selection_range.End)
+			if (range != null && (range.Start != selection_range.Start || range.End != selection_range.End))
 				SelectionRange = range;
 		}
 


### PR DESCRIPTION
This fixes bug #[59393](https://bugzilla.xamarin.com/show_bug.cgi?id=59393), where NullReferenceException thrown when MonthCalendar clicked out of min/max date. 