### PR TITLE
[bcl] Fix csi to work on Mono

### DIFF
--- a/mcs/packages/.gitignore
+++ b/mcs/packages/.gitignore
@@ -1,1 +1,2 @@
 Microsoft.Net.Compilers*
+csi-test-output.txt

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -38,7 +38,7 @@ ROSLYN_FILES_TO_LINK_FOR_MSBUILD = \
 	VBCSCompiler.exe				\
 	VBCSCompiler.exe.config
 
-DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD)
+DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) csi-test.csx
 
 ifeq ($(PROFILE), $(DEFAULT_PROFILE))
 
@@ -52,6 +52,13 @@ install-local:
 	$(INSTALL_LIB) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) $(MSBUILD_ROSLYN_DIR)
 
 	(cd $(MSBUILD_ROSLYN_DIR); for asm in $(ROSLYN_FILES_TO_LINK_FOR_MSBUILD); do ln -fs ../../../../$(FRAMEWORK_VERSION)/$$asm . ; done)
+
+run-test-local: test-csi
+
+test-csi:
+	MONO_PATH="$(topdir)/class/lib/$(PROFILE)" $(RUNTIME) $(ROSLYN_CSC_DIR)/csi.exe csi-test.csx > csi-test-output.txt
+	cat csi-test-output.txt && grep -q "hello world" csi-test-output.txt
+	rm csi-test-output.txt
 
 endif
 

--- a/mcs/packages/csi-test.csx
+++ b/mcs/packages/csi-test.csx
@@ -1,0 +1,1 @@
+Console.WriteLine ("hello world: " + DateTime.Now)

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -98,6 +98,7 @@ ${TESTCMD} --label=Microsoft.Build.Utilities-14 --timeout=60m make -w -C mcs/cla
 ${TESTCMD} --label=System.IO.Compression --timeout=5m make -w -C mcs/class/System.IO.Compression run-test
 if [[ ${label} == w* ]]; then ${TESTCMD} --label=symbolicate --skip; else ${TESTCMD} --label=symbolicate --timeout=60m make -w -C mcs/tools/mono-symbolicate check; fi
 ${TESTCMD} --label=monolinker --timeout=10m make -w -C mcs/tools/linker check
+${TESTCMD} --label=csi --timeout=10m make -w -C mcs/packages run-test
 
 if [[ $CI_TAGS == *'ms-test-suite'* ]]
 then ${TESTCMD} --label=ms-test-suite --timeout=30m make -w -C acceptance-tests check-ms-test-suite


### PR DESCRIPTION
It'd fail to find System.Runtime.dll and System.ValueTuple.dll.
Changed the csi.rsp to include those from the Facades/ dir and added a test.

Workaround for https://bugzilla.xamarin.com/show_bug.cgi?id=58965