### PR TITLE
[ASan] introduce MONO_NO_SANITIZE_ADDRESS macro and mark sgen pin object scanning function as such

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -792,6 +792,7 @@ sgen_sort_addresses (void **array, size_t size)
  * to the area between start_nursery and end_nursery for later consideration.
  * Typically used for thread stacks.
  */
+MONO_NO_SANITIZE_ADDRESS
 void
 sgen_conservatively_pin_objects_from (void **start, void **end, void *start_nursery, void *end_nursery, int pin_type)
 {

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -117,13 +117,22 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #if defined(__has_feature)
+
 #if __has_feature(thread_sanitizer)
 #define MONO_HAS_CLANG_THREAD_SANITIZER 1
 #else
 #define MONO_HAS_CLANG_THREAD_SANITIZER 0
 #endif
+
+#if __has_feature(address_sanitizer)
+#define MONO_HAS_CLANG_ADDRESS_SANITIZER 1
+#else
+#define MONO_HAS_CLANG_ADDRESS_SANITIZER 0
+#endif
+
 #else
 #define MONO_HAS_CLANG_THREAD_SANITIZER 0
+#define MONO_HAS_CLANG_ADDRESS_SANITIZER 0
 #endif
 
 /* Used to tell Clang's ThreadSanitizer to not report data races that occur within a certain function */
@@ -131,6 +140,13 @@ typedef SSIZE_T ssize_t;
 #define MONO_NO_SANITIZE_THREAD __attribute__ ((no_sanitize("thread")))
 #else
 #define MONO_NO_SANITIZE_THREAD
+#endif
+
+/* Used to tell Clang's AddressSanitizer to turn off instrumentation for a certain function */
+#if MONO_HAS_CLANG_ADDRESS_SANITIZER
+#define MONO_NO_SANITIZE_ADDRESS __attribute__ ((no_sanitize("address")))
+#else
+#define MONO_NO_SANITIZE_ADDRESS
 #endif
 
 /* Used when building with Android NDK's unified headers */


### PR DESCRIPTION
ASan has very few false-positives, quoting the ASan documentation
(https://github.com/google/sanitizers/wiki/AddressSanitizer#turning-off-instrumentation):

> In some cases a particular function should be ignored (not instrumented)
> by AddressSanitizer:
>
>  [...]
> * Ignore a function that does some low-level magic (e.g. walking through
>   the thread's stack bypassing the frame boundaries).
> 
>  [...]

This is the only function that needs to be ignored in order to run the interpreter without ASan reports. The JIT needs some more investigation, but it's a start.