### PR TITLE
[corlib] Throw exception on using disposed Timer object. Fixes #60028

### DIFF
--- a/mcs/class/corlib/System.Threading/Timer.cs
+++ b/mcs/class/corlib/System.Threading/Timer.cs
@@ -139,7 +139,7 @@ namespace System.Threading
 				throw new ArgumentOutOfRangeException ("period");
 
 			if (disposed)
-				return false;
+				throw new ObjectDisposedException (null, Environment.GetResourceString ("ObjectDisposed_Generic"));
 
 			due_time_ms = dueTime;
 			period_ms = period;

--- a/mcs/class/corlib/Test/System.Threading/TimerTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/TimerTest.cs
@@ -325,5 +325,14 @@ namespace MonoTests.System.Threading {
 				t.Change (new TimeSpan (UInt32.MaxValue), new TimeSpan (UInt32.MaxValue));
 			}
 		}
+
+		[Test]
+		[ExpectedException (typeof (ObjectDisposedException))]
+		public void Change_After_Dispose ()
+		{
+			var t = new Timer (o => DoNothing (o), null, 0, 0);
+			t.Dispose ();
+			t.Change (1, 1);
+		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=60028