### PR TITLE
[utils] Add check for ANDROID_UNIFIED_HEADERS to mono-compiler.h

### DIFF
--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -134,7 +134,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 /* Used when building with Android NDK's unified headers */
-#if defined(HOST_ANDROID)
+#if defined(HOST_ANDROID) && defined (ANDROID_UNIFIED_HEADERS)
 #if __ANDROID_API__ < 21
 
 typedef int32_t __mono_off32_t;
@@ -163,7 +163,7 @@ ssize_t sendfile (int out_fd, int in_fd, __mono_off32_t* offset, size_t count);
 #endif /* !sendfile */
 
 #endif /* __ANDROID_API__ < 21 */
-#endif /* HOST_ANDROID */
+#endif /* HOST_ANDROID && ANDROID_UNIFIED_HEADERS */
 
 #endif /* __UTILS_MONO_COMPILER_H__*/
 


### PR DESCRIPTION
https://github.com/mono/mono/pull/5680 added mmap/sendfile prototypes but we should only use those when ANDROID_UNIFIED_HEADERS is defined to avoid getting errors like:

```
/Users/alexander/dev/xamarin-android/external/mono/mono/utils/mono-compiler.h:157:7: error: conflicting types for 'mmap'
void* mmap (void*, size_t, int, int, int, __mono_off32_t);
        ^
/Users/alexander/android-toolchain/toolchains/arm-linux-androideabi-clang/bin/../sysroot/usr/include/sys/mman.h:47:15: note: previous declaration is here
extern void*  mmap(void *, size_t, int, int, int, off_t);
                ^

/Users/alexander/dev/xamarin-android/external/mono/mono/utils/mono-compiler.h:166:9: error: conflicting types for 'sendfile'
ssize_t sendfile (int out_fd, int in_fd, __mono_off32_t* offset, size_t count);
        ^
/Users/alexander/android-toolchain/toolchains/arm-linux-androideabi-clang/bin/../sysroot/usr/include/sys/sendfile.h:36:16: note: previous declaration is here
extern ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count);
```