### PR TITLE
[corlib] Don't include time of day in adjustment rule dates.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -657,15 +657,13 @@ namespace System
 			DateTime start_timeofday = new DateTime (1, 1, 1, daylight_hour, daylight_minute, daylight_second, daylight_millisecond);
 			TransitionTime start_transition_time;
 
+			start_date = new DateTime (start_year, 1, 1);
 			if (daylight_year == 0) {
-				start_date = new DateTime (start_year, 1, 1);
 				start_transition_time = TransitionTime.CreateFloatingDateRule (
 					start_timeofday, daylight_month, daylight_day,
 					(DayOfWeek) daylight_dayofweek);
 			}
 			else {
-				start_date = new DateTime (daylight_year, daylight_month, daylight_day,
-					daylight_hour, daylight_minute, daylight_second, daylight_millisecond);
 				start_transition_time = TransitionTime.CreateFixedDateRule (
 					start_timeofday, daylight_month, daylight_day);
 			}
@@ -674,15 +672,13 @@ namespace System
 			DateTime end_timeofday = new DateTime (1, 1, 1, standard_hour, standard_minute, standard_second, standard_millisecond);
 			TransitionTime end_transition_time;
 
+			end_date = new DateTime (end_year, 12, 31);
 			if (standard_year == 0) {
-				end_date = new DateTime (end_year, 12, 31);
 				end_transition_time = TransitionTime.CreateFloatingDateRule (
 					end_timeofday, standard_month, standard_day,
 					(DayOfWeek) standard_dayofweek);
 			}
 			else {
-				end_date = new DateTime (standard_year, standard_month, standard_day,
-					standard_hour, standard_minute, standard_second, standard_millisecond);
 				end_transition_time = TransitionTime.CreateFixedDateRule (
 					end_timeofday, standard_month, standard_day);
 			}

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -209,9 +209,12 @@ namespace System
 #if WIN_PLATFORM
 			if (TimeZoneKey != null) {
 				foreach (string id in TimeZoneKey.GetSubKeyNames ()) {
-					try {
-						systemTimeZones.Add (FindSystemTimeZoneById (id));
-					} catch {}
+					using (RegistryKey subkey = TimeZoneKey.OpenSubKey (id))
+					{
+						if (subkey == null || subkey.GetValue ("TZI") == null)
+							continue;
+					}
+					systemTimeZones.Add (FindSystemTimeZoneById (id));
 				}
 
 				return;

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -978,6 +978,15 @@ namespace MonoTests.System
 		#endif
 
 			[Test]
+			public void FindIsraelStandardTime ()
+			{
+				if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+					Assert.Ignore ("Only applies to Windows.");
+
+				TimeZoneInfo.FindSystemTimeZoneById ("Israel Standard Time");
+			}
+
+			[Test]
 			public void SubminuteDSTOffsets ()
 			{
 				if (Environment.OSVersion.Platform != PlatformID.Unix)


### PR DESCRIPTION
This fixes creation of TimeZoneInfo for some time zones on Wine (such
as Israel Standard Time) and probably also Windows.