### PR TITLE
[runtime] Ensure the field type is resolved before using it in RuntimeHelpers::InitializeArray. Fixes #56194

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -888,7 +888,12 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray (MonoAr
 		return;
 	}
 
-	if (!(field_handle->type->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA)) {
+
+	MonoType *field_type = mono_field_get_type_checked (field_handle, error);
+	if (!field_type)
+		return;
+
+	if (!(field_type->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA)) {
 		mono_error_set_argument (error, "field_handle", "Field '%s' doesn't have an RVA", mono_field_get_name (field_handle));
 		return;
 	}

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -520,7 +520,9 @@ TESTS_CS_SRC=		\
 	bug-58782-plain-throw.cs \
 	bug-58782-capture-and-throw.cs \
 	recursive-struct-arrays.cs \
-	bug-59281.cs
+	bug-59281.cs	\
+	init_array_with_lazy_type.cs
+
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/init_array_with_lazy_type.cs
+++ b/mono/tests/init_array_with_lazy_type.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+        int[] _testArray = { 3, 49, 40, 58, 32 };
+
+        static void Main(string[] args)
+        {
+            var arr = new int[5];
+            var type = Assembly.GetExecutingAssembly().GetTypes().Where(x => x.Name.Contains("<PrivateImplementationDetails>")).Single();
+            var fieldInfo = type.GetFields(BindingFlags.NonPublic | BindingFlags.Static).Single();
+            RuntimeHelpers.InitializeArray(arr, fieldInfo.FieldHandle);
+        }
+}


### PR DESCRIPTION
Field types are now lazily resolved and this breaks the RuntimeHelpers::InitializeArray icall.

The solution is to use mono_field_get_type_checked to ensure the type is there.