### PR TITLE
[reflection] Throw TLE for Type.GetType("", ...) (Fixes #59664)

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Type.cs
+++ b/mcs/class/corlib/ReferenceSources/Type.cs
@@ -43,22 +43,12 @@ namespace System
 
 		public static Type GetType(string typeName)
 		{
-			if (typeName == null)
-				throw new ArgumentNullException ("TypeName");
-
-			return internal_from_name (typeName, false, false);
+			return GetType (typeName, false, false);
 		}
 
 		public static Type GetType(string typeName, bool throwOnError)
 		{
-			if (typeName == null)
-				throw new ArgumentNullException ("TypeName");
-
-			Type type = internal_from_name (typeName, throwOnError, false);
-			if (throwOnError && type == null)
-				throw new TypeLoadException ("Error loading '" + typeName + "'");
-
-			return type;
+			return GetType (typeName, throwOnError, false);
 		}
 
 		public static Type GetType(string typeName, bool throwOnError, bool ignoreCase)
@@ -66,6 +56,11 @@ namespace System
 			if (typeName == null)
 				throw new ArgumentNullException ("TypeName");
 
+			if (typeName == String.Empty)
+				if (throwOnError)
+					throw new TypeLoadException ("A null or zero length string does not represent a valid Type.");
+				else
+					return null;
 			Type t = internal_from_name (typeName, throwOnError, ignoreCase);
 			if (throwOnError && t == null)
 				throw new TypeLoadException ("Error loading '" + typeName + "'");
@@ -82,6 +77,8 @@ namespace System
 		{
 			if (typeName == null)
 				throw new ArgumentNullException ("typeName");
+			if (typeName == String.Empty && throwIfNotFound)
+				throw new TypeLoadException ("A null or zero length string does not represent a valid Type");
 			int idx = typeName.IndexOf (',');
 			if (idx < 0 || idx == 0 || idx == typeName.Length - 1)
 				throw new ArgumentException ("Assembly qualifed type name is required", "typeName");

--- a/mcs/class/corlib/System/TypeSpec.cs
+++ b/mcs/class/corlib/System/TypeSpec.cs
@@ -455,7 +455,9 @@ namespace System {
 			}
 
 			if (name_start < pos)
-				data.AddName (name.Substring (name_start, pos - name_start));		
+				data.AddName (name.Substring (name_start, pos - name_start));
+			else if (name_start == pos)
+				data.AddName (String.Empty);
 
 			if (in_modifiers) {
 				for (; pos < name.Length; ++pos) {

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -2788,6 +2788,41 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		public void GetType1_TypeName_Empty_nothrow ()
+		{
+			var t = Type.GetType ("");
+			Assert.IsNull (t);
+		}
+
+		[Test]
+		[ExpectedException (typeof (TypeLoadException))]
+		public void GetType2_TypeName_Empty ()
+		{
+			Type.GetType ("", true);
+		}
+
+		[Test]
+		public void GetType2_TypeName_Empty_nothrow ()
+		{
+			var t = Type.GetType ("", false);
+			Assert.IsNull (t);
+		}
+
+		[Test]
+		[ExpectedException (typeof (TypeLoadException))]
+		public void GetType3_TypeName_Empty ()
+		{
+			Type.GetType ("", true, false);
+		}
+
+		[Test]
+		public void GetType3_TypeName_Empty_nothrow ()
+		{
+			var t = Type.GetType ("", false, false);
+			Assert.IsNull (t);
+		}
+
+		[Test]
 		public void GetTypeArray_Args_Null ()
 		{
 			try {
@@ -4291,6 +4326,7 @@ namespace MonoTests.System
 		[Test]
 		public void NewGetTypeErrors () {
 			MustANE (null);
+			MustTLE ("");
 			MustAE ("!@#$%^&*");
 			MustAE (string.Format ("{0}[{1}&]", typeof (Foo<>).FullName, typeof (MyRealEnum).FullName));
 			MustAE (string.Format ("{0}[{1}*]", typeof (Foo<>).FullName, typeof (MyRealEnum).FullName));

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1443,7 +1443,7 @@ ves_icall_System_Type_internal_from_name (MonoStringHandle name,
 {
 	error_init (error);
 	MonoTypeNameParse info;
-	gboolean parsedOk;
+	gboolean free_info = FALSE;
 	MonoAssembly *caller_assembly;
 	MonoReflectionTypeHandle type = MONO_HANDLE_NEW (MonoReflectionType, NULL);
 
@@ -1451,22 +1451,16 @@ ves_icall_System_Type_internal_from_name (MonoStringHandle name,
 	if (!is_ok (error))
 		goto leave;
 
-	parsedOk = mono_reflection_parse_type (str, &info);
+	free_info = TRUE;
+	if (!mono_reflection_parse_type_checked (str, &info, error))
+		goto leave;
 
 	/* mono_reflection_parse_type() mangles the string */
-	if (!parsedOk) {
-		mono_reflection_free_type_info (&info);
-		if (throwOnError)
-			mono_error_set_argument (error, "typeName", "failed parse: %s", str);
-		goto leave;
-	}
 
 	MONO_HANDLE_ASSIGN (type, type_from_parsed_name (&info, ignoreCase, &caller_assembly, error));
 
-	if (!is_ok (error)) {
-		mono_reflection_free_type_info (&info);
+	if (!is_ok (error))
 		goto leave;
-	}
 
 	if (MONO_HANDLE_IS_NULL (type)) {
 		if (throwOnError) {
@@ -1480,19 +1474,21 @@ ves_icall_System_Type_internal_from_name (MonoStringHandle name,
 				aname = g_strdup ("");
 			mono_error_set_type_load_name (error, tname, aname, "");
 		}
-		mono_reflection_free_type_info (&info);
 		goto leave;
 	}
 	
 leave:
+	if (free_info)
+		mono_reflection_free_type_info (&info);
 	g_free (str);
 	if (!is_ok (error)) {
-		if (!throwOnError)
+		if (!throwOnError) {
 			mono_error_cleanup (error);
+			error_init (error);
+		}
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
-	}
-
-	return type;
+	} else
+		return type;
 }
 
 
@@ -4446,9 +4442,11 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHand
 		goto fail;
 
 	/*g_print ("requested type %s in %s\n", str, assembly->assembly->aname.name);*/
-	if (!mono_reflection_parse_type (str, &info)) {
+	MonoError parse_error;
+	if (!mono_reflection_parse_type_checked (str, &info, &parse_error)) {
 		g_free (str);
 		mono_reflection_free_type_info (&info);
+		mono_error_cleanup (&parse_error);
 		if (throwOnError) {
 			mono_error_set_argument (error, "name", "failed to parse the type");
 			goto fail;

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -14,6 +14,9 @@
 #include <mono/utils/mono-error.h>
 
 gboolean
+mono_reflection_parse_type_checked (char *name, MonoTypeNameParse *info, MonoError *error);
+
+gboolean
 mono_reflection_is_usertype (MonoReflectionTypeHandle ref);
 
 MonoReflectionType*

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1546,12 +1546,7 @@ _mono_reflection_parse_type (char *name, char **endptr, gboolean is_recursed,
 
 	start = p = w = name;
 
-	//FIXME could we just zero the whole struct? memset (&info, 0, sizeof (MonoTypeNameParse))
-	memset (&info->assembly, 0, sizeof (MonoAssemblyName));
-	info->name = info->name_space = NULL;
-	info->nested = NULL;
-	info->modifiers = NULL;
-	info->type_arguments = NULL;
+	memset (info, 0, sizeof (MonoTypeNameParse));
 
 	/* last_point separates the namespace from the name */
 	last_point = NULL;

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -46,6 +46,7 @@ typedef enum {
 	ResolveTokenError_Other
 } MonoResolveTokenError;
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API int           mono_reflection_parse_type (char *name, MonoTypeNameParse *info);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoType*     mono_reflection_get_type   (MonoImage* image, MonoTypeNameParse *info, mono_bool ignorecase, mono_bool *type_resolve);


### PR DESCRIPTION
The throwing versions of `System.Type.GetType()` apparently must throw a `TypeLoadException` when passed the empty string as an input.

Fixes [#59664](https://bugzilla.xamarin.com/show_bug.cgi?id=59664)