### PR TITLE
[2017-06] [llvm] Map byref types to the same type as the this argument so they …

### DIFF
--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -2896,4 +2896,25 @@ END:
     IL_0018:  ldloc.0
 	ret
 	}
+
+	.method public static bool llvm_regress_59436 () {
+		// Code size	   41 (0x29)
+		.maxstack  3
+		.locals init (float64 V_0,
+					  float64 V_1,
+					  valuetype [mscorlib]System.Decimal V_2)
+		IL_0000:  ldc.r8	 1
+		IL_0009:  stloc.0
+		IL_000a:  ldc.r8	 2
+		IL_0013:  stloc.1
+		IL_0014:  ldloc.0
+		IL_0015:  newobj	 instance void [mscorlib]System.Decimal::.ctor(float64)
+		IL_001a:  ldloca.s   V_2
+		IL_001c:  ldloc.1
+		IL_001d:  call	   instance void [mscorlib]System.Decimal::.ctor(float64)
+		IL_0022:  ldloc.2
+		IL_0023:  call	   bool [mscorlib]System.Decimal::op_LessThanOrEqual(valuetype [mscorlib]System.Decimal,
+																			   valuetype [mscorlib]System.Decimal)
+		IL_0028:  ret
+	}
 }

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -467,6 +467,9 @@ create_llvm_type_for_type (MonoLLVMModule *module, MonoClass *klass)
 static LLVMTypeRef
 type_to_llvm_type (EmitContext *ctx, MonoType *t)
 {
+	if (t->byref)
+		return ThisType ();
+
 	t = mini_get_underlying_type (t);
 
 	switch (t->type) {
@@ -1226,10 +1229,10 @@ sig_to_llvm_sig_no_cinfo (EmitContext *ctx, MonoMethodSignature *sig)
 	int i, pindex;
 	MonoType *rtype;
 
-	rtype = mini_get_underlying_type (sig->ret);
-	ret_type = type_to_llvm_type (ctx, rtype);
+	ret_type = type_to_llvm_type (ctx, sig->ret);
 	if (!ctx_ok (ctx))
 		return NULL;
+	rtype = mini_get_underlying_type (sig->ret);
 
 	param_types = g_new0 (LLVMTypeRef, (sig->param_count * 8) + 3);
 	pindex = 0;
@@ -1269,10 +1272,10 @@ sig_to_llvm_sig_full (EmitContext *ctx, MonoMethodSignature *sig, LLVMCallInfo *
 	if (!cinfo)
 		return sig_to_llvm_sig_no_cinfo (ctx, sig);
 
-	rtype = mini_get_underlying_type (sig->ret);
-	ret_type = type_to_llvm_type (ctx, rtype);
+	ret_type = type_to_llvm_type (ctx, sig->ret);
 	if (!ctx_ok (ctx))
 		return NULL;
+	rtype = mini_get_underlying_type (sig->ret);
 
 	switch (cinfo->ret.storage) {
 	case LLVMArgVtypeInReg:


### PR DESCRIPTION
…are called using the same signature if the this argument is passed explicitly. Fixes #59436. (#5572)