### PR TITLE
[corlib] fix bug-60031 Thread doesn't throw ThreadStateException when it should

### DIFF
--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -326,13 +326,12 @@ namespace System.Threading {
 		[Obsolete ("Deprecated in favor of GetApartmentState, SetApartmentState and TrySetApartmentState.")]
 		public ApartmentState ApartmentState {
 			get {
-				if ((ThreadState & ThreadState.Stopped) != 0)
-					throw new ThreadStateException ("Thread is dead; state can not be accessed.");
-
+				ValidateThreadState ();
 				return (ApartmentState)Internal.apartment_state;
 			}
 
 			set {
+				ValidateThreadState ();
 				TrySetApartmentState (value);
 			}
 		}
@@ -368,14 +367,12 @@ namespace System.Threading {
 
 		public bool IsBackground {
 			get {
-				ThreadState thread_state = GetState (Internal);
-				if ((thread_state & ThreadState.Stopped) != 0)
-					throw new ThreadStateException ("Thread is dead; state can not be accessed.");
-
-				return (thread_state & ThreadState.Background) != 0;
+				var state = ValidateThreadState ();
+				return (state & ThreadState.Background) != 0;
 			}
 			
 			set {
+				ValidateThreadState ();
 				if (value) {
 					SetState (Internal, ThreadState.Background);
 				} else {
@@ -649,6 +646,7 @@ namespace System.Threading {
 
 		public ApartmentState GetApartmentState ()
 		{
+			ValidateThreadState ();
 			return (ApartmentState)Internal.apartment_state;
 		}
 
@@ -711,6 +709,14 @@ namespace System.Threading {
 		public void DisableComObjectEagerCleanup ()
 		{
 			throw new PlatformNotSupportedException ();
+		}
+
+		ThreadState ValidateThreadState ()
+		{
+			var state = GetState (Internal);
+			if ((state & ThreadState.Stopped) != 0)
+				throw new ThreadStateException ("Thread is dead; state can not be accessed.");
+			return state;
 		}
 	}
 }

--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -1020,9 +1020,9 @@ namespace MonoTests.System.Threading
 		[Test] // bug #60031
 		public void StoppedThreadsThrowThreadStateException ()
 		{
-			var t = new Thread(() => { });
-			t.Start();
-			t.Join();
+			var t = new Thread (() => { });
+			t.Start ();
+			t.Join ();
 
 			Assert.Throws<ThreadStateException> (() => { var isb = t.IsBackground; }, "IsBackground getter");
 			Assert.Throws<ThreadStateException> (() => { var isb = t.ApartmentState; }, "ApartmentState getter");

--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -1016,6 +1016,25 @@ namespace MonoTests.System.Threading
 				Assert.IsNotNull (ex.Message, "#B8");
 			}
 		}
+
+		[Test] // bug #60031
+		public void StoppedThreadsThrowThreadStateException ()
+		{
+			var t = new Thread(() => { });
+			t.Start();
+			t.Join();
+
+			Assert.Throws<ThreadStateException> (() => { var isb = t.IsBackground; }, "IsBackground getter");
+			Assert.Throws<ThreadStateException> (() => { var isb = t.ApartmentState; }, "ApartmentState getter");
+			Assert.Throws<ThreadStateException> (() => t.ApartmentState = ApartmentState.MTA, "ApartmentState setter");
+			Assert.Throws<ThreadStateException> (() => t.IsBackground = false, "IsBackground setter");
+			Assert.Throws<ThreadStateException> (() => t.Start (), "Start ()");
+			Assert.Throws<ThreadStateException> (() => t.Resume (), "Resume ()");
+			Assert.Throws<ThreadStateException> (() => t.Suspend (), "Suspend ()");
+			Assert.Throws<ThreadStateException> (() => t.GetApartmentState (), "GetApartmentState ()");
+			Assert.Throws<ThreadStateException> (() => t.SetApartmentState (ApartmentState.MTA), "SetApartmentState ()");
+			Assert.Throws<ThreadStateException> (() => t.TrySetApartmentState (ApartmentState.MTA), "TrySetApartmentState ()");
+		}
 	}
 
 	[TestFixture]


### PR DESCRIPTION
A trivial fix for https://bugzilla.xamarin.com/show_bug.cgi?id=60031 needed to pass a test in https://github.com/mono/mono/pull/5762