### PR TITLE
[runtime] Rename atomic functions from the win32 style naming to mono_atomic_<op>_<type>, with a consistent signature on all platforms, including Windows implementation.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2498,7 +2498,7 @@ unload_data_unref (unload_data *data)
 			g_free (data);
 			return;
 		}
-	} while (InterlockedCompareExchange (&data->refcount, count - 1, count) != count);
+	} while (mono_atomic_cas_i32 (&data->refcount, count - 1, count) != count);
 }
 
 static void
@@ -2694,7 +2694,7 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 	/* printf ("UNLOAD STARTING FOR %s (%p) IN THREAD 0x%x.\n", domain->friendly_name, domain, mono_native_thread_id_get ()); */
 
 	/* Atomically change our state to UNLOADING */
-	prev_state = (MonoAppDomainState)InterlockedCompareExchange ((gint32*)&domain->state,
+	prev_state = (MonoAppDomainState)mono_atomic_cas_i32 ((gint32*)&domain->state,
 		MONO_APPDOMAIN_UNLOADING_START,
 		MONO_APPDOMAIN_CREATED);
 	if (prev_state != MONO_APPDOMAIN_CREATED) {

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1119,7 +1119,7 @@ assemblyref_public_tok (MonoImage *image, guint32 key_index, guint32 flags)
 void
 mono_assembly_addref (MonoAssembly *assembly)
 {
-	InterlockedIncrement (&assembly->ref_count);
+	mono_atomic_inc_i32 (&assembly->ref_count);
 }
 
 /*
@@ -3791,7 +3791,7 @@ mono_assembly_close_except_image_pools (MonoAssembly *assembly)
 		return FALSE;
 
 	/* Might be 0 already */
-	if (InterlockedDecrement (&assembly->ref_count) > 0)
+	if (mono_atomic_dec_i32 (&assembly->ref_count) > 0)
 		return FALSE;
 
 	MONO_PROFILER_RAISE (assembly_unloading, (assembly));

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -278,7 +278,7 @@ void
 mono_gc_collect (int generation)
 {
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->gc_induced);
+	mono_atomic_inc_i32 (&mono_perfcounters->gc_induced);
 #endif
 	GC_gcollect ();
 }
@@ -457,9 +457,9 @@ on_gc_notification (GC_EventType event)
 		MONO_GC_BEGIN (1);
 #ifndef DISABLE_PERFCOUNTERS
 		if (mono_perfcounters)
-			InterlockedIncrement (&mono_perfcounters->gc_collections0);
+			mono_atomic_inc_i32 (&mono_perfcounters->gc_collections0);
 #endif
-		InterlockedIncrement (&gc_stats.major_gc_count);
+		mono_atomic_inc_i32 (&gc_stats.major_gc_count);
 		gc_start_time = mono_100ns_ticks ();
 		break;
 
@@ -477,7 +477,7 @@ on_gc_notification (GC_EventType event)
 		if (mono_perfcounters) {
 			guint64 heap_size = GC_get_heap_size ();
 			guint64 used_size = heap_size - GC_get_free_bytes ();
-			/* FIXME: change these to InterlockedWrite64 () */
+			/* FIXME: change these to mono_atomic_store_i64 () */
 			UnlockedWrite64 (&mono_perfcounters->gc_total_bytes, used_size);
 			UnlockedWrite64 (&mono_perfcounters->gc_committed_bytes, heap_size);
 			UnlockedWrite64 (&mono_perfcounters->gc_reserved_bytes, heap_size);
@@ -523,7 +523,7 @@ on_gc_heap_resize (size_t new_size)
 	guint64 heap_size = GC_get_heap_size ();
 #ifndef DISABLE_PERFCOUNTERS
 	if (mono_perfcounters) {
-		/* FIXME: change these to InterlockedWrite64 () */
+		/* FIXME: change these to mono_atomic_store_i64 () */
 		UnlockedWrite64 (&mono_perfcounters->gc_committed_bytes, heap_size);
 		UnlockedWrite64 (&mono_perfcounters->gc_reserved_bytes, heap_size);
 		UnlockedWrite64 (&mono_perfcounters->gc_gen0size, heap_size);
@@ -861,7 +861,7 @@ mono_gc_wbarrier_generic_store (gpointer ptr, MonoObject* value)
 void
 mono_gc_wbarrier_generic_store_atomic (gpointer ptr, MonoObject *value)
 {
-	InterlockedWritePointer ((volatile gpointer *)ptr, value);
+	mono_atomic_store_ptr ((volatile gpointer *)ptr, value);
 }
 
 void
@@ -1738,7 +1738,7 @@ alloc_handle (HandleData *handles, MonoObject *obj, gboolean track)
 	}
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->gc_num_handles);
+	mono_atomic_inc_i32 (&mono_perfcounters->gc_num_handles);
 #endif
 	unlock_handles (handles);
 	res = MONO_GC_HANDLE (slot, handles->type);
@@ -1936,7 +1936,7 @@ mono_gchandle_free (guint32 gchandle)
 		/* print a warning? */
 	}
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedDecrement (&mono_perfcounters->gc_num_handles);
+	mono_atomic_dec_i32 (&mono_perfcounters->gc_num_handles);
 #endif
 	/*g_print ("freed entry %d of type %d\n", slot, handles->type);*/
 	unlock_handles (handles);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1719,7 +1719,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_ReleaseComObjectInternal (MonoO
 	if (proxy->ref_count == 0)
 		return -1;
 
-	ref_count = InterlockedDecrement (&proxy->ref_count);
+	ref_count = mono_atomic_dec_i32 (&proxy->ref_count);
 
 	g_assert (ref_count >= 0);
 
@@ -2458,7 +2458,7 @@ cominterop_ccw_addref (MonoCCWInterface* ccwe)
 	MonoCCW* ccw = ccwe->ccw;
 	g_assert (ccw);
 	g_assert (ccw->gc_handle);
-	ref_count = InterlockedIncrement ((gint32*)&ccw->ref_count);
+	ref_count = mono_atomic_inc_i32 ((gint32*)&ccw->ref_count);
 	if (ref_count == 1) {
 		guint32 oldhandle = ccw->gc_handle;
 		g_assert (oldhandle);
@@ -2476,7 +2476,7 @@ cominterop_ccw_release (MonoCCWInterface* ccwe)
 	MonoCCW* ccw = ccwe->ccw;
 	g_assert (ccw);
 	g_assert (ccw->ref_count > 0);
-	ref_count = InterlockedDecrement ((gint32*)&ccw->ref_count);
+	ref_count = mono_atomic_dec_i32 ((gint32*)&ccw->ref_count);
 	if (ref_count == 0) {
 		/* allow gc of object */
 		guint32 oldhandle = ccw->gc_handle;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -197,7 +197,7 @@ lock_free_mempool_alloc0 (LockFreeMempool *mp, guint size)
 	}
 
 	/* The code below is lock-free, 'chunk' is shared state */
-	oldpos = mono_atomic_xchg_i32Add (&chunk->pos, size);
+	oldpos = mono_atomic_xchg_add_i32 (&chunk->pos, size);
 	if (oldpos + size > chunk->size) {
 		chunk = lock_free_mempool_chunk_new (mp, size);
 		g_assert (chunk->pos + size <= chunk->size);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -197,7 +197,7 @@ lock_free_mempool_alloc0 (LockFreeMempool *mp, guint size)
 	}
 
 	/* The code below is lock-free, 'chunk' is shared state */
-	oldpos = mono_atomic_xchg_add_i32 (&chunk->pos, size);
+	oldpos = mono_atomic_fetch_add_i32 (&chunk->pos, size);
 	if (oldpos + size > chunk->size) {
 		chunk = lock_free_mempool_chunk_new (mp, size);
 		g_assert (chunk->pos + size <= chunk->size);
@@ -1172,7 +1172,7 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 	} else {
 #ifndef DISABLE_PERFCOUNTERS
 		/* FIXME: use an explicit subtraction method as soon as it's available */
-		mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (domain->mp));
+		mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (domain->mp));
 #endif
 		mono_mempool_destroy (domain->mp);
 		domain->mp = NULL;
@@ -1287,7 +1287,7 @@ mono_domain_alloc (MonoDomain *domain, guint size)
 
 	mono_domain_lock (domain);
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	res = mono_mempool_alloc (domain->mp, size);
 	mono_domain_unlock (domain);
@@ -1307,7 +1307,7 @@ mono_domain_alloc0 (MonoDomain *domain, guint size)
 
 	mono_domain_lock (domain);
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	res = mono_mempool_alloc0 (domain->mp, size);
 	mono_domain_unlock (domain);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -167,7 +167,7 @@ lock_free_mempool_chunk_new (LockFreeMempool *mp, int len)
 	/* Add to list of chunks lock-free */
 	while (TRUE) {
 		prev = mp->chunks;
-		if (InterlockedCompareExchangePointer ((volatile gpointer*)&mp->chunks, chunk, prev) == prev)
+		if (mono_atomic_cas_ptr ((volatile gpointer*)&mp->chunks, chunk, prev) == prev)
 			break;
 	}
 	chunk->prev = prev;
@@ -197,7 +197,7 @@ lock_free_mempool_alloc0 (LockFreeMempool *mp, guint size)
 	}
 
 	/* The code below is lock-free, 'chunk' is shared state */
-	oldpos = InterlockedExchangeAdd (&chunk->pos, size);
+	oldpos = mono_atomic_xchg_i32Add (&chunk->pos, size);
 	if (oldpos + size > chunk->size) {
 		chunk = lock_free_mempool_chunk_new (mp, size);
 		g_assert (chunk->pos + size <= chunk->size);
@@ -430,8 +430,8 @@ mono_domain_create (void)
 	mono_appdomains_unlock ();
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->loader_appdomains);
-	InterlockedIncrement (&mono_perfcounters->loader_total_appdomains);
+	mono_atomic_inc_i32 (&mono_perfcounters->loader_appdomains);
+	mono_atomic_inc_i32 (&mono_perfcounters->loader_total_appdomains);
 #endif
 
 	mono_debug_domain_create (domain);
@@ -1172,7 +1172,7 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 	} else {
 #ifndef DISABLE_PERFCOUNTERS
 		/* FIXME: use an explicit subtraction method as soon as it's available */
-		InterlockedAdd (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (domain->mp));
+		mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (domain->mp));
 #endif
 		mono_mempool_destroy (domain->mp);
 		domain->mp = NULL;
@@ -1219,7 +1219,7 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 	mono_gc_free_fixed (domain);
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedDecrement (&mono_perfcounters->loader_appdomains);
+	mono_atomic_dec_i32 (&mono_perfcounters->loader_appdomains);
 #endif
 
 	if (domain == mono_root_domain)
@@ -1287,7 +1287,7 @@ mono_domain_alloc (MonoDomain *domain, guint size)
 
 	mono_domain_lock (domain);
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	res = mono_mempool_alloc (domain->mp, size);
 	mono_domain_unlock (domain);
@@ -1307,7 +1307,7 @@ mono_domain_alloc0 (MonoDomain *domain, guint size)
 
 	mono_domain_lock (domain);
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	res = mono_mempool_alloc0 (domain->mp, size);
 	mono_domain_unlock (domain);

--- a/mono/metadata/file-mmap-posix.c
+++ b/mono/metadata/file-mmap-posix.c
@@ -118,7 +118,7 @@ file_mmap_init (void)
 retry:	
 	switch (mmap_init_state) {
 	case  0:
-		if (InterlockedCompareExchange (&mmap_init_state, 1, 0) != 0)
+		if (mono_atomic_cas_i32 (&mmap_init_state, 1, 0) != 0)
 			goto retry;
 		named_regions = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, NULL);
 		mono_coop_mutex_init (&named_regions_mutex);

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2173,7 +2173,7 @@ mono_image_close_finish (MonoImage *image)
 
 #ifndef DISABLE_PERFCOUNTERS
 	/* FIXME: use an explicit subtraction method as soon as it's available */
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (image->mempool));
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (image->mempool));
 #endif
 
 	if (!image_is_dynamic (image)) {
@@ -2708,7 +2708,7 @@ mono_image_alloc (MonoImage *image, guint size)
 	gpointer res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_alloc (image->mempool, size);
@@ -2723,7 +2723,7 @@ mono_image_alloc0 (MonoImage *image, guint size)
 	gpointer res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_alloc0 (image->mempool, size);
@@ -2738,7 +2738,7 @@ mono_image_strdup (MonoImage *image, const char *s)
 	char *res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, (gint32)strlen (s));
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, (gint32)strlen (s));
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_strdup (image->mempool, s);
@@ -2755,7 +2755,7 @@ mono_image_strdup_vprintf (MonoImage *image, const char *format, va_list args)
 	buf = mono_mempool_strdup_vprintf (image->mempool, format, args);
 	mono_image_unlock (image);
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, (gint32)strlen (buf));
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, (gint32)strlen (buf));
 #endif
 	return buf;
 }

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2738,7 +2738,7 @@ mono_image_strdup (MonoImage *image, const char *s)
 	char *res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, strlen (s));
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, (gint32)strlen (s));
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_strdup (image->mempool, s);
@@ -2755,7 +2755,7 @@ mono_image_strdup_vprintf (MonoImage *image, const char *format, va_list args)
 	buf = mono_mempool_strdup_vprintf (image->mempool, format, args);
 	mono_image_unlock (image);
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, strlen (buf));
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, (gint32)strlen (buf));
 #endif
 	return buf;
 }

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -99,7 +99,7 @@ assign_assembly_parent_for_netmodule (MonoImage *image, MonoImage *assemblyImage
 			mono_error_set_bad_image (error, assemblyImage, "Attempted to load module %s which has already been loaded by assembly %s. This is not supported in Mono.", image->name, assemblyOld->image->name);
 			return FALSE;
 		}
-		gpointer result = InterlockedExchangePointer((gpointer *)&image->assembly, assembly);
+		gpointer result = mono_atomic_xchg_ptr((gpointer *)&image->assembly, assembly);
 		if (result == assembly)
 			return TRUE;
 	}
@@ -1863,7 +1863,7 @@ free_array_cache_entry (gpointer key, gpointer val, gpointer user_data)
 void
 mono_image_addref (MonoImage *image)
 {
-	InterlockedIncrement (&image->ref_count);
+	mono_atomic_inc_i32 (&image->ref_count);
 }	
 
 void
@@ -1946,7 +1946,7 @@ mono_image_close_except_pools (MonoImage *image)
 	 */
 	mono_images_lock ();
 
-	if (InterlockedDecrement (&image->ref_count) > 0) {
+	if (mono_atomic_dec_i32 (&image->ref_count) > 0) {
 		mono_images_unlock ();
 		return FALSE;
 	}
@@ -2173,7 +2173,7 @@ mono_image_close_finish (MonoImage *image)
 
 #ifndef DISABLE_PERFCOUNTERS
 	/* FIXME: use an explicit subtraction method as soon as it's available */
-	InterlockedAdd (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (image->mempool));
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (image->mempool));
 #endif
 
 	if (!image_is_dynamic (image)) {
@@ -2708,7 +2708,7 @@ mono_image_alloc (MonoImage *image, guint size)
 	gpointer res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_alloc (image->mempool, size);
@@ -2723,7 +2723,7 @@ mono_image_alloc0 (MonoImage *image, guint size)
 	gpointer res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, size);
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, size);
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_alloc0 (image->mempool, size);
@@ -2738,7 +2738,7 @@ mono_image_strdup (MonoImage *image, const char *s)
 	char *res;
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, strlen (s));
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, strlen (s));
 #endif
 	mono_image_lock (image);
 	res = mono_mempool_strdup (image->mempool, s);
@@ -2755,7 +2755,7 @@ mono_image_strdup_vprintf (MonoImage *image, const char *format, va_list args)
 	buf = mono_mempool_strdup_vprintf (image->mempool, format, args);
 	mono_image_unlock (image);
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, strlen (buf));
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, strlen (buf));
 #endif
 	return buf;
 }

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -168,7 +168,7 @@ cache_memberref_sig (MonoImage *image, guint32 sig_idx, gpointer sig)
 	else {
 		g_hash_table_insert (image->memberref_signatures, GUINT_TO_POINTER (sig_idx), sig);
 		/* An approximation based on glib 2.18 */
-		mono_atomic_add_i32 (&memberref_sig_cache_size, sizeof (gpointer) * 4);
+		mono_atomic_fetch_add_i32 (&memberref_sig_cache_size, sizeof (gpointer) * 4);
 	}
 	mono_image_unlock (image);
 
@@ -737,7 +737,7 @@ mono_method_get_signature_checked (MonoMethod *method, MonoImage *image, guint32
 		if (cached != sig)
 			mono_metadata_free_inflated_signature (sig);
 		else
-			mono_atomic_add_i32 (&inflated_signatures_size, mono_metadata_signature_size (cached));
+			mono_atomic_fetch_add_i32 (&inflated_signatures_size, mono_metadata_signature_size (cached));
 		sig = cached;
 	}
 
@@ -1684,7 +1684,7 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 		result = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethodPInvoke));
 	} else {
 		result = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethod));
-		mono_atomic_add_i32 (&methods_size, sizeof (MonoMethod));
+		mono_atomic_fetch_add_i32 (&methods_size, sizeof (MonoMethod));
 	}
 
 	mono_atomic_inc_i32 (&mono_stats.method_count);
@@ -2423,7 +2423,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 		if (!mono_error_ok (error))
 			return NULL;
 
-		mono_atomic_add_i32 (&inflated_signatures_size, mono_metadata_signature_size (signature));
+		mono_atomic_fetch_add_i32 (&inflated_signatures_size, mono_metadata_signature_size (signature));
 
 		mono_image_lock (img);
 
@@ -2480,7 +2480,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 			mono_image_unlock (img);
 		}
 
-		mono_atomic_add_i32 (&signatures_size, mono_metadata_signature_size (signature));
+		mono_atomic_fetch_add_i32 (&signatures_size, mono_metadata_signature_size (signature));
 	}
 
 	/* Verify metadata consistency */

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -168,7 +168,7 @@ cache_memberref_sig (MonoImage *image, guint32 sig_idx, gpointer sig)
 	else {
 		g_hash_table_insert (image->memberref_signatures, GUINT_TO_POINTER (sig_idx), sig);
 		/* An approximation based on glib 2.18 */
-		InterlockedAdd (&memberref_sig_cache_size, sizeof (gpointer) * 4);
+		mono_atomic_add_i32 (&memberref_sig_cache_size, sizeof (gpointer) * 4);
 	}
 	mono_image_unlock (image);
 
@@ -737,7 +737,7 @@ mono_method_get_signature_checked (MonoMethod *method, MonoImage *image, guint32
 		if (cached != sig)
 			mono_metadata_free_inflated_signature (sig);
 		else
-			InterlockedAdd (&inflated_signatures_size, mono_metadata_signature_size (cached));
+			mono_atomic_add_i32 (&inflated_signatures_size, mono_metadata_signature_size (cached));
 		sig = cached;
 	}
 
@@ -1684,10 +1684,10 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 		result = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethodPInvoke));
 	} else {
 		result = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethod));
-		InterlockedAdd (&methods_size, sizeof (MonoMethod));
+		mono_atomic_add_i32 (&methods_size, sizeof (MonoMethod));
 	}
 
-	InterlockedIncrement (&mono_stats.method_count);
+	mono_atomic_inc_i32 (&mono_stats.method_count);
 
 	result->slot = -1;
 	result->klass = klass;
@@ -2423,7 +2423,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 		if (!mono_error_ok (error))
 			return NULL;
 
-		InterlockedAdd (&inflated_signatures_size, mono_metadata_signature_size (signature));
+		mono_atomic_add_i32 (&inflated_signatures_size, mono_metadata_signature_size (signature));
 
 		mono_image_lock (img);
 
@@ -2480,7 +2480,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 			mono_image_unlock (img);
 		}
 
-		InterlockedAdd (&signatures_size, mono_metadata_signature_size (signature));
+		mono_atomic_add_i32 (&signatures_size, mono_metadata_signature_size (signature));
 	}
 
 	/* Verify metadata consistency */

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -711,7 +711,7 @@ mono_delegate_free_ftnptr (MonoDelegate *delegate)
 
 	delegate_hash_table_remove (delegate);
 
-	ptr = (gpointer)InterlockedExchangePointer (&delegate->delegate_trampoline, NULL);
+	ptr = (gpointer)mono_atomic_xchg_ptr (&delegate->delegate_trampoline, NULL);
 
 	if (!delegate->target) {
 		/* The wrapper method is shared between delegates -> no need to free it */
@@ -9255,7 +9255,7 @@ mono_marshal_get_castclass_with_cache (void)
 	res = mono_mb_create (mb, sig, 8, info);
 	STORE_STORE_FENCE;
 
-	if (InterlockedCompareExchangePointer ((volatile gpointer *)&cached, res, NULL)) {
+	if (mono_atomic_cas_ptr ((volatile gpointer *)&cached, res, NULL)) {
 		mono_free_method (res);
 		mono_metadata_free_method_signature (sig);
 	}
@@ -9339,7 +9339,7 @@ mono_marshal_get_isinst_with_cache (void)
 	res = mono_mb_create (mb, sig, 8, info);
 	STORE_STORE_FENCE;
 
-	if (InterlockedCompareExchangePointer ((volatile gpointer *)&cached, res, NULL)) {
+	if (mono_atomic_cas_ptr ((volatile gpointer *)&cached, res, NULL)) {
 		mono_free_method (res);
 		mono_metadata_free_method_signature (sig);
 	}

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3171,7 +3171,7 @@ mono_metadata_get_canonical_generic_inst (MonoGenericInst *candidate)
 		int size = MONO_SIZEOF_GENERIC_INST + type_argc * sizeof (MonoType *);
 		ginst = (MonoGenericInst *)mono_image_set_alloc0 (set, size);
 #ifndef MONO_SMALL_CONFIG
-		ginst->id = InterlockedIncrement (&next_generic_inst_id);
+		ginst->id = mono_atomic_inc_i32 (&next_generic_inst_id);
 #endif
 		ginst->is_open = is_open;
 		ginst->type_argc = type_argc;
@@ -3411,7 +3411,7 @@ get_anonymous_container_for_image (MonoImage *image, gboolean is_mvar)
 
 		// If another thread already made a container, use that and leak this new one.
 		// (Technically it would currently be safe to just assign instead of CASing.)
-		MonoGenericContainer *exchange = (MonoGenericContainer *)InterlockedCompareExchangePointer ((volatile gpointer *)container_pointer, result, NULL);
+		MonoGenericContainer *exchange = (MonoGenericContainer *)mono_atomic_cas_ptr ((volatile gpointer *)container_pointer, result, NULL);
 		if (exchange)
 			result = exchange;
 	}

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -374,7 +374,7 @@ mon_finalize (MonoThreadsSync *mon)
 	mon->data = monitor_freelist;
 	monitor_freelist = mon;
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedDecrement (&mono_perfcounters->gc_sync_blocks);
+	mono_atomic_dec_i32 (&mono_perfcounters->gc_sync_blocks);
 #endif
 }
 
@@ -446,7 +446,7 @@ mon_new (gsize id)
 	new_->data = NULL;
 	
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->gc_sync_blocks);
+	mono_atomic_inc_i32 (&mono_perfcounters->gc_sync_blocks);
 #endif
 	return new_;
 }
@@ -497,7 +497,7 @@ mono_monitor_inflate_owned (MonoObject *obj, int id)
 	nlw = lock_word_new_inflated (mon);
 
 	mono_memory_write_barrier ();
-	tmp_lw.sync = (MonoThreadsSync *)InterlockedCompareExchangePointer ((gpointer*)&obj->synchronisation, nlw.sync, old_lw.sync);
+	tmp_lw.sync = (MonoThreadsSync *)mono_atomic_cas_ptr ((gpointer*)&obj->synchronisation, nlw.sync, old_lw.sync);
 	if (tmp_lw.sync != old_lw.sync) {
 		/* Someone else inflated the lock in the meantime */
 		discard_mon (mon);
@@ -540,7 +540,7 @@ mono_monitor_inflate (MonoObject *obj)
 			mon->nest = lock_word_get_nest (old_lw);
 		}
 		mono_memory_write_barrier ();
-		tmp_lw.sync = (MonoThreadsSync *)InterlockedCompareExchangePointer ((gpointer*)&obj->synchronisation, nlw.sync, old_lw.sync);
+		tmp_lw.sync = (MonoThreadsSync *)mono_atomic_cas_ptr ((gpointer*)&obj->synchronisation, nlw.sync, old_lw.sync);
 		if (tmp_lw.sync == old_lw.sync) {
 			/* Successfully inflated the lock */
 			return;
@@ -596,7 +596,7 @@ mono_object_hash (MonoObject* obj)
 		LockWord old_lw;
 		lw = lock_word_new_thin_hash (hash);
 
-		old_lw.sync = (MonoThreadsSync *)InterlockedCompareExchangePointer ((gpointer*)&obj->synchronisation, lw.sync, NULL);
+		old_lw.sync = (MonoThreadsSync *)mono_atomic_cas_ptr ((gpointer*)&obj->synchronisation, lw.sync, NULL);
 		if (old_lw.sync == NULL) {
 			return hash;
 		}
@@ -680,7 +680,7 @@ mono_monitor_exit_inflated (MonoObject *obj)
 			new_status = mon_status_set_owner (old_status, 0);
 			if (have_waiters)
 				new_status = mon_status_decrement_entry_count (new_status);
-			tmp_status = InterlockedCompareExchange ((gint32*)&mon->status, new_status, old_status);
+			tmp_status = mono_atomic_cas_i32 ((gint32*)&mon->status, new_status, old_status);
 			if (tmp_status == old_status) {
 				if (have_waiters)
 					mono_coop_sem_post (mon->entry_sem);
@@ -712,7 +712,7 @@ mono_monitor_exit_flat (MonoObject *obj, LockWord old_lw)
 	else
 		new_lw.lock_word = 0;
 
-	tmp_lw.sync = (MonoThreadsSync *)InterlockedCompareExchangePointer ((gpointer*)&obj->synchronisation, new_lw.sync, old_lw.sync);
+	tmp_lw.sync = (MonoThreadsSync *)mono_atomic_cas_ptr ((gpointer*)&obj->synchronisation, new_lw.sync, old_lw.sync);
 	if (old_lw.sync != tmp_lw.sync) {
 		/* Someone inflated the lock in the meantime */
 		mono_monitor_exit_inflated (obj);
@@ -730,7 +730,7 @@ mon_decrement_entry_count (MonoThreadsSync *mon)
 	old_status = mon->status;
 	for (;;) {
 		new_status = mon_status_decrement_entry_count (old_status);
-		tmp_status = InterlockedCompareExchange ((gint32*)&mon->status, new_status, old_status);
+		tmp_status = mono_atomic_cas_i32 ((gint32*)&mon->status, new_status, old_status);
 		if (tmp_status == old_status) {
 			break;
 		}
@@ -774,7 +774,7 @@ retry:
 		* operation
 		*/
 		new_status = mon_status_set_owner (old_status, id);
-		tmp_status = InterlockedCompareExchange ((gint32*)&mon->status, new_status, old_status);
+		tmp_status = mono_atomic_cas_i32 ((gint32*)&mon->status, new_status, old_status);
 		if (G_LIKELY (tmp_status == old_status)) {
 			/* Success */
 			g_assert (mon->nest == 1);
@@ -793,7 +793,7 @@ retry:
 
 	/* The object must be locked by someone else... */
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->thread_contentions);
+	mono_atomic_inc_i32 (&mono_perfcounters->thread_contentions);
 #endif
 
 	/* If ms is 0 we don't block, but just fail straight away */
@@ -821,7 +821,7 @@ retry_contended:
 		* operation
 		*/
 		new_status = mon_status_set_owner (old_status, id);
-		tmp_status = InterlockedCompareExchange ((gint32*)&mon->status, new_status, old_status);
+		tmp_status = mono_atomic_cas_i32 ((gint32*)&mon->status, new_status, old_status);
 		if (G_LIKELY (tmp_status == old_status)) {
 			/* Success */
 			g_assert (mon->nest == 1);
@@ -844,7 +844,7 @@ retry_contended:
 		/* Create the semaphore */
 		sem = g_new0 (MonoCoopSem, 1);
 		mono_coop_sem_init (sem, 0);
-		if (InterlockedCompareExchangePointer ((gpointer*)&mon->entry_sem, sem, NULL) != NULL) {
+		if (mono_atomic_cas_ptr ((gpointer*)&mon->entry_sem, sem, NULL) != NULL) {
 			/* Someone else just put a handle here */
 			mono_coop_sem_destroy (sem);
 			g_free (sem);
@@ -861,7 +861,7 @@ retry_contended:
 			if (mon_status_get_owner (old_status) == 0)
 				goto retry_contended;
 			new_status = mon_status_increment_entry_count (old_status);
-			tmp_status = InterlockedCompareExchange ((gint32*)&mon->status, new_status, old_status);
+			tmp_status = mono_atomic_cas_i32 ((gint32*)&mon->status, new_status, old_status);
 			if (tmp_status == old_status) {
 				break;
 			}
@@ -875,8 +875,8 @@ retry_contended:
 	waitms = ms;
 	
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->thread_queue_len);
-	InterlockedIncrement (&mono_perfcounters->thread_queue_max);
+	mono_atomic_inc_i32 (&mono_perfcounters->thread_queue_len);
+	mono_atomic_inc_i32 (&mono_perfcounters->thread_queue_max);
 #endif
 	thread = mono_thread_internal_current ();
 
@@ -910,7 +910,7 @@ retry_contended:
 
 done_waiting:
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedDecrement (&mono_perfcounters->thread_queue_len);
+	mono_atomic_dec_i32 (&mono_perfcounters->thread_queue_len);
 #endif
 
 	if (wait_ret == MONO_SEM_TIMEDWAIT_RET_ALERTED && !allow_interruption) {
@@ -977,7 +977,7 @@ mono_monitor_try_enter_internal (MonoObject *obj, guint32 ms, gboolean allow_int
 
 	if (G_LIKELY (lock_word_is_free (lw))) {
 		LockWord nlw = lock_word_new_flat (id);
-		if (InterlockedCompareExchangePointer ((gpointer*)&obj->synchronisation, nlw.sync, NULL) == NULL) {
+		if (mono_atomic_cas_ptr ((gpointer*)&obj->synchronisation, nlw.sync, NULL) == NULL) {
 			return 1;
 		} else {
 			/* Someone acquired it in the meantime or put a hash */
@@ -994,7 +994,7 @@ mono_monitor_try_enter_internal (MonoObject *obj, guint32 ms, gboolean allow_int
 			} else {
 				LockWord nlw, old_lw;
 				nlw = lock_word_increment_nest (lw);
-				old_lw.sync = (MonoThreadsSync *)InterlockedCompareExchangePointer ((gpointer*)&obj->synchronisation, nlw.sync, lw.sync);
+				old_lw.sync = (MonoThreadsSync *)mono_atomic_cas_ptr ((gpointer*)&obj->synchronisation, nlw.sync, lw.sync);
 				if (old_lw.sync != lw.sync) {
 					/* Someone else inflated it in the meantime */
 					g_assert (lock_word_is_inflated (old_lw));

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1158,7 +1158,7 @@ predef_writable_update (ImplVtable *vtable, MonoBoolean do_incr, gint64 value)
 			if (value == -1)
 				return mono_atomic_dec_i32 (ptr);
 
-			return mono_atomic_add_i32(ptr, value);
+			return mono_atomic_add_i32 (ptr, (gint32)value);
 		}
 		/* this can be non-atomic */
 		*ptr = value;

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1074,52 +1074,52 @@ predef_writable_counter (ImplVtable *vtable, MonoBoolean only_value, MonoCounter
 	case CATEGORY_EXC:
 		switch (id) {
 		case COUNTER_EXC_THROWN:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->exceptions_thrown);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->exceptions_thrown);
 			return TRUE;
 		}
 		break;
 	case CATEGORY_ASPNET:
 		switch (id) {
 		case COUNTER_ASPNET_REQ_Q:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->aspnet_requests_queued);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->aspnet_requests_queued);
 			return TRUE;
 		case COUNTER_ASPNET_REQ_TOTAL:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->aspnet_requests);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->aspnet_requests);
 			return TRUE;
 		}
 		break;
 	case CATEGORY_THREADPOOL:
 		switch (id) {
 		case COUNTER_THREADPOOL_WORKITEMS:
-			sample->rawValue = InterlockedRead64 (&mono_perfcounters->threadpool_workitems);
+			sample->rawValue = mono_atomic_load_i64 (&mono_perfcounters->threadpool_workitems);
 			return TRUE;
 		case COUNTER_THREADPOOL_IOWORKITEMS:
-			sample->rawValue = InterlockedRead64 (&mono_perfcounters->threadpool_ioworkitems);
+			sample->rawValue = mono_atomic_load_i64 (&mono_perfcounters->threadpool_ioworkitems);
 			return TRUE;
 		case COUNTER_THREADPOOL_THREADS:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->threadpool_threads);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->threadpool_threads);
 			return TRUE;
 		case COUNTER_THREADPOOL_IOTHREADS:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->threadpool_iothreads);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->threadpool_iothreads);
 			return TRUE;
 		}
 		break;
 	case CATEGORY_JIT:
 		switch (id) {
 		case COUNTER_JIT_BYTES:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->jit_bytes);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->jit_bytes);
 			return TRUE;
 		case COUNTER_JIT_METHODS:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->jit_methods);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->jit_methods);
 			return TRUE;
 		case COUNTER_JIT_TIME:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->jit_time);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->jit_time);
 			return TRUE;
 		case COUNTER_JIT_BYTES_PSEC:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->jit_bytes);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->jit_bytes);
 			return TRUE;
 		case COUNTER_JIT_FAILURES:
-			sample->rawValue = InterlockedRead (&mono_perfcounters->jit_failures);
+			sample->rawValue = mono_atomic_load_i32 (&mono_perfcounters->jit_failures);
 			return TRUE;
 		}
 		break;
@@ -1154,11 +1154,11 @@ predef_writable_update (ImplVtable *vtable, MonoBoolean do_incr, gint64 value)
 	if (ptr) {
 		if (do_incr) {
 			if (value == 1)
-				return InterlockedIncrement (ptr);
+				return mono_atomic_inc_i32 (ptr);
 			if (value == -1)
-				return InterlockedDecrement (ptr);
+				return mono_atomic_dec_i32 (ptr);
 
-			return InterlockedAdd(ptr, value);
+			return mono_atomic_add_i32(ptr, value);
 		}
 		/* this can be non-atomic */
 		*ptr = value;
@@ -1166,11 +1166,11 @@ predef_writable_update (ImplVtable *vtable, MonoBoolean do_incr, gint64 value)
 	} else if (ptr64) {
 		if (do_incr) {
 			if (value == 1)
-				return UnlockedIncrement64 (ptr64); /* FIXME: use InterlockedIncrement64 () */
+				return UnlockedIncrement64 (ptr64); /* FIXME: use mono_atomic_inc_i64 () */
 			if (value == -1)
-				return UnlockedDecrement64 (ptr64); /* FIXME: use InterlockedDecrement64 () */
+				return UnlockedDecrement64 (ptr64); /* FIXME: use mono_atomic_dec_i64 () */
 
-			return UnlockedAdd64 (ptr64, value); /* FIXME: use InterlockedAdd64 () */
+			return UnlockedAdd64 (ptr64, value); /* FIXME: use mono_atomic_add_i64 () */
 		}
 		/* this can be non-atomic */
 		*ptr64 = value;

--- a/mono/metadata/null-gc-handles.c
+++ b/mono/metadata/null-gc-handles.c
@@ -220,7 +220,7 @@ alloc_handle (HandleData *handles, MonoObject *obj, gboolean track)
 	}
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->gc_num_handles);
+	mono_atomic_inc_i32 (&mono_perfcounters->gc_num_handles);
 #endif
 	unlock_handles (handles);
 	res = MONO_GC_HANDLE (slot, handles->type);
@@ -412,7 +412,7 @@ mono_gchandle_free (guint32 gchandle)
 		/* print a warning? */
 	}
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedDecrement (&mono_perfcounters->gc_num_handles);
+	mono_atomic_dec_i32 (&mono_perfcounters->gc_num_handles);
 #endif
 	/*g_print ("freed entry %d of type %d\n", slot, handles->type);*/
 	unlock_handles (handles);

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -254,7 +254,7 @@ mono_gc_wbarrier_generic_store (gpointer ptr, MonoObject* value)
 void
 mono_gc_wbarrier_generic_store_atomic (gpointer ptr, MonoObject *value)
 {
-	InterlockedWritePointer (ptr, value);
+	mono_atomic_store_ptr (ptr, value);
 }
 
 void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2565,7 +2565,7 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	rc->xdomain_vtable = NULL;
 	rc->proxy_class_name = name;
 #ifndef DISABLE_PERFCOUNTERS
-	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, mono_string_length (MONO_HANDLE_RAW (class_name)) + 1);
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, mono_string_length (MONO_HANDLE_RAW (class_name)) + 1);
 #endif
 
 	g_hash_table_insert (domain->proxy_vtable_hash, key, rc);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2565,7 +2565,7 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	rc->xdomain_vtable = NULL;
 	rc->proxy_class_name = name;
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedAdd (&mono_perfcounters->loader_bytes, mono_string_length (MONO_HANDLE_RAW (class_name)) + 1);
+	mono_atomic_add_i32 (&mono_perfcounters->loader_bytes, mono_string_length (MONO_HANDLE_RAW (class_name)) + 1);
 #endif
 
 	g_hash_table_insert (domain->proxy_vtable_hash, key, rc);

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -161,13 +161,13 @@ mono_profiler_create (MonoProfiler *prof)
 void
 mono_profiler_set_cleanup_callback (MonoProfilerHandle handle, MonoProfilerCleanupCallback cb)
 {
-	InterlockedWritePointer (&handle->cleanup_callback, (gpointer) cb);
+	mono_atomic_store_ptr (&handle->cleanup_callback, (gpointer) cb);
 }
 
 void
 mono_profiler_set_coverage_filter_callback (MonoProfilerHandle handle, MonoProfilerCoverageFilterCallback cb)
 {
-	InterlockedWritePointer (&handle->coverage_filter, (gpointer) cb);
+	mono_atomic_store_ptr (&handle->coverage_filter, (gpointer) cb);
 }
 
 mono_bool
@@ -402,7 +402,7 @@ mono_profiler_enable_allocations (void)
 void
 mono_profiler_set_call_instrumentation_filter_callback (MonoProfilerHandle handle, MonoProfilerCallInstrumentationFilterCallback cb)
 {
-	InterlockedWritePointer (&handle->call_instrumentation_filter, (gpointer) cb);
+	mono_atomic_store_ptr (&handle->call_instrumentation_filter, (gpointer) cb);
 }
 
 mono_bool
@@ -564,8 +564,8 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 	gpointer old;
 
 	do {
-		old = InterlockedReadPointer (location);
-	} while (InterlockedCompareExchangePointer (location, new_, old) != old);
+		old = mono_atomic_load_ptr (location);
+	} while (mono_atomic_cas_ptr (location, new_, old) != old);
 
 	/*
 	 * At this point, we could have installed a NULL callback while the counter
@@ -577,10 +577,10 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 	 */
 
 	if (old)
-		InterlockedDecrement (counter);
+		mono_atomic_dec_i32 (counter);
 
 	if (new_)
-		InterlockedIncrement (counter);
+		mono_atomic_inc_i32 (counter);
 }
 
 #define _MONO_PROFILER_EVENT(name, type) \

--- a/mono/metadata/property-bag.c
+++ b/mono/metadata/property-bag.c
@@ -51,7 +51,7 @@ retry:
 		cur = *prev;
 		if (!cur || cur->tag > tag) {
 			item->next = cur;
-			if (InterlockedCompareExchangePointer ((void*)prev, item, cur) == cur)
+			if (mono_atomic_cas_ptr ((void*)prev, item, cur) == cur)
 				return item;
 			goto retry;
 		} else if (cur->tag == tag) {

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -92,7 +92,7 @@ mono_runtime_fire_process_exit_event (void)
 gboolean
 mono_runtime_try_shutdown (void)
 {
-	if (InterlockedCompareExchange (&shutting_down_inited, TRUE, FALSE))
+	if (mono_atomic_cas_i32 (&shutting_down_inited, TRUE, FALSE))
 		return FALSE;
 
 	mono_runtime_fire_process_exit_event ();

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -297,9 +297,9 @@ sgen_client_binary_protocol_collection_begin (int minor_gc_count, int generation
 
 #ifndef DISABLE_PERFCOUNTERS
 	if (generation == GENERATION_NURSERY)
-		InterlockedIncrement (&mono_perfcounters->gc_collections0);
+		mono_atomic_inc_i32 (&mono_perfcounters->gc_collections0);
 	else
-		InterlockedIncrement (&mono_perfcounters->gc_collections1);
+		mono_atomic_inc_i32 (&mono_perfcounters->gc_collections1);
 #endif
 }
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2807,7 +2807,7 @@ void
 sgen_client_gchandle_created (int handle_type, GCObject *obj, guint32 handle)
 {
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->gc_num_handles);
+	mono_atomic_inc_i32 (&mono_perfcounters->gc_num_handles);
 #endif
 
 	MONO_PROFILER_RAISE (gc_handle_created, (handle, handle_type, obj));
@@ -2817,7 +2817,7 @@ void
 sgen_client_gchandle_destroyed (int handle_type, guint32 handle)
 {
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedDecrement (&mono_perfcounters->gc_num_handles);
+	mono_atomic_dec_i32 (&mono_perfcounters->gc_num_handles);
 #endif
 
 	MONO_PROFILER_RAISE (gc_handle_deleted, (handle, handle_type));
@@ -2886,14 +2886,14 @@ sgen_client_degraded_allocation (void)
 	static gint32 last_major_gc_warned = -1;
 	static gint32 num_degraded = 0;
 
-	gint32 major_gc_count = InterlockedRead (&gc_stats.major_gc_count);
-	if (InterlockedRead (&last_major_gc_warned) < major_gc_count) {
-		gint32 num = InterlockedIncrement (&num_degraded);
+	gint32 major_gc_count = mono_atomic_load_i32 (&gc_stats.major_gc_count);
+	if (mono_atomic_load_i32 (&last_major_gc_warned) < major_gc_count) {
+		gint32 num = mono_atomic_inc_i32 (&num_degraded);
 		if (num == 1 || num == 3)
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "Warning: Degraded allocation.  Consider increasing nursery-size if the warning persists.");
 		else if (num == 10)
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "Warning: Repeated degraded allocation.  Consider increasing nursery-size.");
-		InterlockedWrite (&last_major_gc_warned, major_gc_count);
+		mono_atomic_store_i32 (&last_major_gc_warned, major_gc_count);
 	}
 }
 

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -93,14 +93,14 @@ static ThreadPool threadpool;
 				g_error ("%s: counter._.starting = %d, but should be >= 0", __func__, counter._.starting); \
 			if (!(counter._.working >= 0)) \
 				g_error ("%s: counter._.working = %d, but should be >= 0", __func__, counter._.working); \
-		} while (InterlockedCompareExchange (&threadpool.counters.as_gint32, (var).as_gint32, __old.as_gint32) != __old.as_gint32); \
+		} while (mono_atomic_cas_i32 (&threadpool.counters.as_gint32, (var).as_gint32, __old.as_gint32) != __old.as_gint32); \
 	} while (0)
 
 static inline ThreadPoolCounter
 COUNTER_READ (void)
 {
 	ThreadPoolCounter counter;
-	counter.as_gint32 = InterlockedRead (&threadpool.counters.as_gint32);
+	counter.as_gint32 = mono_atomic_load_i32 (&threadpool.counters.as_gint32);
 	return counter;
 }
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -86,7 +86,7 @@ extern int tkill (pid_t tid, int signal);
 /*#define LIBGC_DEBUG(a) do { a; } while (0)*/
 #define LIBGC_DEBUG(a)
 
-#define SPIN_TRYLOCK(i) (InterlockedCompareExchange (&(i), 1, 0) == 0)
+#define SPIN_TRYLOCK(i) (mono_atomic_cas_i32 (&(i), 1, 0) == 0)
 #define SPIN_LOCK(i) do { \
 				if (SPIN_TRYLOCK (i)) \
 					break; \
@@ -219,7 +219,7 @@ mono_threads_unlock (void)
 static guint32
 get_next_managed_thread_id (void)
 {
-	return InterlockedIncrement (&managed_thread_id_counter);
+	return mono_atomic_inc_i32 (&managed_thread_id_counter);
 }
 
 /*
@@ -261,11 +261,11 @@ mono_threads_begin_abort_protected_block (void)
 		g_assert (new_val < (1 << ABORT_PROT_BLOCK_BITS));
 
 		new_state = old_state + (1 << ABORT_PROT_BLOCK_SHIFT);
-	} while (InterlockedCompareExchangePointer ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
 	/* Defer async request since we won't be able to process until exiting the block */
 	if (new_val == 1 && (new_state & INTERRUPT_ASYNC_REQUESTED_BIT)) {
-		InterlockedDecrement (&thread_interruption_requested);
+		mono_atomic_dec_i32 (&thread_interruption_requested);
 		THREADS_INTERRUPT_DEBUG ("[%d] begin abort protected block old_state %ld new_state %ld, defer tir %d\n", thread->small_id, old_state, new_state, thread_interruption_requested);
 		if (thread_interruption_requested < 0)
 			g_warning ("bad thread_interruption_requested state");
@@ -303,10 +303,10 @@ mono_threads_end_abort_protected_block (void)
 		g_assert (new_val < (1 << ABORT_PROT_BLOCK_BITS));
 
 		new_state = old_state - (1 << ABORT_PROT_BLOCK_SHIFT);
-	} while (InterlockedCompareExchangePointer ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
 	if (new_val == 0 && (new_state & INTERRUPT_ASYNC_REQUESTED_BIT)) {
-		InterlockedIncrement (&thread_interruption_requested);
+		mono_atomic_inc_i32 (&thread_interruption_requested);
 		THREADS_INTERRUPT_DEBUG ("[%d] end abort protected block old_state %ld new_state %ld, restore tir %d\n", thread->small_id, old_state, new_state, thread_interruption_requested);
 	} else {
 		THREADS_INTERRUPT_DEBUG ("[%d] end abort protected block old_state %ld new_state %ld, tir %d\n", thread->small_id, old_state, new_state, thread_interruption_requested);
@@ -343,9 +343,9 @@ mono_thread_clear_interruption_requested (MonoInternalThread *thread)
 			new_state = old_state & ~INTERRUPT_SYNC_REQUESTED_BIT;
 		else
 			new_state = old_state & ~INTERRUPT_ASYNC_REQUESTED_BIT;
-	} while (InterlockedCompareExchangePointer ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
-	InterlockedDecrement (&thread_interruption_requested);
+	mono_atomic_dec_i32 (&thread_interruption_requested);
 	THREADS_INTERRUPT_DEBUG ("[%d] clear interruption old_state %ld new_state %ld, tir %d\n", thread->small_id, old_state, new_state, thread_interruption_requested);
 	if (thread_interruption_requested < 0)
 		g_warning ("bad thread_interruption_requested state");
@@ -371,10 +371,10 @@ mono_thread_set_interruption_requested (MonoInternalThread *thread)
 			new_state = old_state | INTERRUPT_SYNC_REQUESTED_BIT;
 		else
 			new_state = old_state | INTERRUPT_ASYNC_REQUESTED_BIT;
-	} while (InterlockedCompareExchangePointer ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
 	if (sync || !(new_state & ABORT_PROT_BLOCK_MASK)) {
-		InterlockedIncrement (&thread_interruption_requested);
+		mono_atomic_inc_i32 (&thread_interruption_requested);
 		THREADS_INTERRUPT_DEBUG ("[%d] set interruption on [%d] old_state %ld new_state %ld, tir %d\n", mono_thread_internal_current ()->small_id, thread->small_id, old_state, new_state, thread_interruption_requested);
 	} else {
 		THREADS_INTERRUPT_DEBUG ("[%d] set interruption on [%d] old_state %ld new_state %ld, tir deferred %d\n", mono_thread_internal_current ()->small_id, thread->small_id, old_state, new_state, thread_interruption_requested);
@@ -401,7 +401,7 @@ static void ensure_synch_cs_set (MonoInternalThread *thread)
 	synch_cs = g_new0 (MonoCoopMutex, 1);
 	mono_coop_mutex_init_recursive (synch_cs);
 
-	if (InterlockedCompareExchangePointer ((gpointer *)&thread->synch_cs,
+	if (mono_atomic_cas_ptr ((gpointer *)&thread->synch_cs,
 					       synch_cs, NULL) != NULL) {
 		/* Another thread must have installed this CS */
 		mono_coop_mutex_destroy (synch_cs);
@@ -930,7 +930,7 @@ static guint32 WINAPI start_wrapper_internal(StartInfo *start_info, gsize *stack
 
 		mono_coop_sem_post (&start_info->registered);
 
-		if (InterlockedDecrement (&start_info->ref) == 0) {
+		if (mono_atomic_dec_i32 (&start_info->ref) == 0) {
 			mono_coop_sem_destroy (&start_info->registered);
 			g_free (start_info);
 		}
@@ -965,7 +965,7 @@ static guint32 WINAPI start_wrapper_internal(StartInfo *start_info, gsize *stack
 	/* Let the thread that called Start() know we're ready */
 	mono_coop_sem_post (&start_info->registered);
 
-	if (InterlockedDecrement (&start_info->ref) == 0) {
+	if (mono_atomic_dec_i32 (&start_info->ref) == 0) {
 		mono_coop_sem_destroy (&start_info->registered);
 		g_free (start_info);
 	}
@@ -1134,7 +1134,7 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 		mono_threads_unlock ();
 		mono_error_set_execution_engine (error, "Couldn't create thread. Error 0x%x", mono_w32error_get_last());
 		/* ref is not going to be decremented in start_wrapper_internal */
-		InterlockedDecrement (&start_info->ref);
+		mono_atomic_dec_i32 (&start_info->ref);
 		ret = FALSE;
 		goto done;
 	}
@@ -1157,7 +1157,7 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 	ret = !start_info->failed;
 
 done:
-	if (InterlockedDecrement (&start_info->ref) == 0) {
+	if (mono_atomic_dec_i32 (&start_info->ref) == 0) {
 		mono_coop_sem_destroy (&start_info->registered);
 		g_free (start_info);
 	}
@@ -1363,7 +1363,7 @@ ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThread *this_obj)
 
 	internal->state = ThreadState_Unstarted;
 
-	InterlockedCompareExchangePointer ((volatile gpointer *)&this_obj->internal_thread, internal, NULL);
+	mono_atomic_cas_ptr ((volatile gpointer *)&this_obj->internal_thread, internal, NULL);
 }
 
 MonoThread *
@@ -1978,7 +1978,7 @@ ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (gpointer toSignal,
 
 gint32 ves_icall_System_Threading_Interlocked_Increment_Int (gint32 *location)
 {
-	return InterlockedIncrement (location);
+	return mono_atomic_inc_i32 (location);
 }
 
 gint64 ves_icall_System_Threading_Interlocked_Increment_Long (gint64 *location)
@@ -1993,12 +1993,12 @@ gint64 ves_icall_System_Threading_Interlocked_Increment_Long (gint64 *location)
 		return ret;
 	}
 #endif
-	return InterlockedIncrement64 (location);
+	return mono_atomic_inc_i64 (location);
 }
 
 gint32 ves_icall_System_Threading_Interlocked_Decrement_Int (gint32 *location)
 {
-	return InterlockedDecrement(location);
+	return mono_atomic_dec_i32(location);
 }
 
 gint64 ves_icall_System_Threading_Interlocked_Decrement_Long (gint64 * location)
@@ -2013,25 +2013,25 @@ gint64 ves_icall_System_Threading_Interlocked_Decrement_Long (gint64 * location)
 		return ret;
 	}
 #endif
-	return InterlockedDecrement64 (location);
+	return mono_atomic_dec_i64 (location);
 }
 
 gint32 ves_icall_System_Threading_Interlocked_Exchange_Int (gint32 *location, gint32 value)
 {
-	return InterlockedExchange(location, value);
+	return mono_atomic_xchg_i32(location, value);
 }
 
 MonoObject * ves_icall_System_Threading_Interlocked_Exchange_Object (MonoObject **location, MonoObject *value)
 {
 	MonoObject *res;
-	res = (MonoObject *) InterlockedExchangePointer((gpointer *) location, value);
+	res = (MonoObject *) mono_atomic_xchg_ptr((gpointer *) location, value);
 	mono_gc_wbarrier_generic_nostore (location);
 	return res;
 }
 
 gpointer ves_icall_System_Threading_Interlocked_Exchange_IntPtr (gpointer *location, gpointer value)
 {
-	return InterlockedExchangePointer(location, value);
+	return mono_atomic_xchg_ptr(location, value);
 }
 
 gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location, gfloat value)
@@ -2039,7 +2039,7 @@ gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location,
 	IntFloatUnion val, ret;
 
 	val.fval = value;
-	ret.ival = InterlockedExchange((gint32 *) location, val.ival);
+	ret.ival = mono_atomic_xchg_i32((gint32 *) location, val.ival);
 
 	return ret.fval;
 }
@@ -2057,7 +2057,7 @@ ves_icall_System_Threading_Interlocked_Exchange_Long (gint64 *location, gint64 v
 		return ret;
 	}
 #endif
-	return InterlockedExchange64 (location, value);
+	return mono_atomic_xchg_i64 (location, value);
 }
 
 gdouble 
@@ -2066,19 +2066,19 @@ ves_icall_System_Threading_Interlocked_Exchange_Double (gdouble *location, gdoub
 	LongDoubleUnion val, ret;
 
 	val.fval = value;
-	ret.ival = (gint64)InterlockedExchange64((gint64 *) location, val.ival);
+	ret.ival = (gint64)mono_atomic_xchg_i64((gint64 *) location, val.ival);
 
 	return ret.fval;
 }
 
 gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int(gint32 *location, gint32 value, gint32 comparand)
 {
-	return InterlockedCompareExchange(location, value, comparand);
+	return mono_atomic_cas_i32(location, value, comparand);
 }
 
 gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int_Success(gint32 *location, gint32 value, gint32 comparand, MonoBoolean *success)
 {
-	gint32 r = InterlockedCompareExchange(location, value, comparand);
+	gint32 r = mono_atomic_cas_i32(location, value, comparand);
 	*success = r == comparand;
 	return r;
 }
@@ -2086,14 +2086,14 @@ gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int_Success(gint32
 MonoObject * ves_icall_System_Threading_Interlocked_CompareExchange_Object (MonoObject **location, MonoObject *value, MonoObject *comparand)
 {
 	MonoObject *res;
-	res = (MonoObject *) InterlockedCompareExchangePointer((gpointer *) location, value, comparand);
+	res = (MonoObject *) mono_atomic_cas_ptr((gpointer *) location, value, comparand);
 	mono_gc_wbarrier_generic_nostore (location);
 	return res;
 }
 
 gpointer ves_icall_System_Threading_Interlocked_CompareExchange_IntPtr(gpointer *location, gpointer value, gpointer comparand)
 {
-	return InterlockedCompareExchangePointer(location, value, comparand);
+	return mono_atomic_cas_ptr(location, value, comparand);
 }
 
 gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *location, gfloat value, gfloat comparand)
@@ -2102,7 +2102,7 @@ gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *lo
 
 	val.fval = value;
 	cmp.fval = comparand;
-	ret.ival = InterlockedCompareExchange((gint32 *) location, val.ival, cmp.ival);
+	ret.ival = mono_atomic_cas_i32((gint32 *) location, val.ival, cmp.ival);
 
 	return ret.fval;
 }
@@ -2115,7 +2115,7 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Double (gdouble *location
 
 	val.fval = value;
 	comp.fval = comparand;
-	ret.ival = (gint64)InterlockedCompareExchangePointer((gpointer *) location, (gpointer)val.ival, (gpointer)comp.ival);
+	ret.ival = (gint64)mono_atomic_cas_ptr((gpointer *) location, (gpointer)val.ival, (gpointer)comp.ival);
 
 	return ret.fval;
 #else
@@ -2145,14 +2145,14 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Long (gint64 *location, g
 		return old;
 	}
 #endif
-	return InterlockedCompareExchange64 (location, value, comparand);
+	return mono_atomic_cas_i64 (location, value, comparand);
 }
 
 MonoObject*
 ves_icall_System_Threading_Interlocked_CompareExchange_T (MonoObject **location, MonoObject *value, MonoObject *comparand)
 {
 	MonoObject *res;
-	res = (MonoObject *)InterlockedCompareExchangePointer ((volatile gpointer *)location, value, comparand);
+	res = (MonoObject *)mono_atomic_cas_ptr ((volatile gpointer *)location, value, comparand);
 	mono_gc_wbarrier_generic_nostore (location);
 	return res;
 }
@@ -2162,7 +2162,7 @@ ves_icall_System_Threading_Interlocked_Exchange_T (MonoObject **location, MonoOb
 {
 	MonoObject *res;
 	MONO_CHECK_NULL (location, NULL);
-	res = (MonoObject *)InterlockedExchangePointer ((volatile gpointer *)location, value);
+	res = (MonoObject *)mono_atomic_xchg_ptr ((volatile gpointer *)location, value);
 	mono_gc_wbarrier_generic_nostore (location);
 	return res;
 }
@@ -2170,7 +2170,7 @@ ves_icall_System_Threading_Interlocked_Exchange_T (MonoObject **location, MonoOb
 gint32 
 ves_icall_System_Threading_Interlocked_Add_Int (gint32 *location, gint32 value)
 {
-	return InterlockedAdd (location, value);
+	return mono_atomic_add_i32 (location, value);
 }
 
 gint64 
@@ -2186,7 +2186,7 @@ ves_icall_System_Threading_Interlocked_Add_Long (gint64 *location, gint64 value)
 		return ret;
 	}
 #endif
-	return InterlockedAdd64 (location, value);
+	return mono_atomic_add_i64 (location, value);
 }
 
 gint64 
@@ -2201,7 +2201,7 @@ ves_icall_System_Threading_Interlocked_Read_Long (gint64 *location)
 		return ret;
 	}
 #endif
-	return InterlockedRead64 (location);
+	return mono_atomic_load_i64 (location);
 }
 
 void
@@ -2674,19 +2674,19 @@ ves_icall_System_Threading_Thread_VolatileReadFloat (void *ptr)
 gint8
 ves_icall_System_Threading_Volatile_Read1 (void *ptr)
 {
-	return InterlockedRead8 ((volatile gint8 *)ptr);
+	return mono_atomic_load_i8 ((volatile gint8 *)ptr);
 }
 
 gint16
 ves_icall_System_Threading_Volatile_Read2 (void *ptr)
 {
-	return InterlockedRead16 ((volatile gint16 *)ptr);
+	return mono_atomic_load_i16 ((volatile gint16 *)ptr);
 }
 
 gint32
 ves_icall_System_Threading_Volatile_Read4 (void *ptr)
 {
-	return InterlockedRead ((volatile gint32 *)ptr);
+	return mono_atomic_load_i32 ((volatile gint32 *)ptr);
 }
 
 gint64
@@ -2701,13 +2701,13 @@ ves_icall_System_Threading_Volatile_Read8 (void *ptr)
 		return val;
 	}
 #endif
-	return InterlockedRead64 ((volatile gint64 *)ptr);
+	return mono_atomic_load_i64 ((volatile gint64 *)ptr);
 }
 
 void *
 ves_icall_System_Threading_Volatile_ReadIntPtr (void *ptr)
 {
-	return InterlockedReadPointer ((volatile gpointer *)ptr);
+	return mono_atomic_load_ptr ((volatile gpointer *)ptr);
 }
 
 double
@@ -2725,7 +2725,7 @@ ves_icall_System_Threading_Volatile_ReadDouble (void *ptr)
 	}
 #endif
 
-	u.ival = InterlockedRead64 ((volatile gint64 *)ptr);
+	u.ival = mono_atomic_load_i64 ((volatile gint64 *)ptr);
 
 	return u.fval;
 }
@@ -2735,7 +2735,7 @@ ves_icall_System_Threading_Volatile_ReadFloat (void *ptr)
 {
 	IntFloatUnion u;
 
-	u.ival = InterlockedRead ((volatile gint32 *)ptr);
+	u.ival = mono_atomic_load_i32 ((volatile gint32 *)ptr);
 
 	return u.fval;
 }
@@ -2743,7 +2743,7 @@ ves_icall_System_Threading_Volatile_ReadFloat (void *ptr)
 MonoObject*
 ves_icall_System_Threading_Volatile_Read_T (void *ptr)
 {
-	return (MonoObject *)InterlockedReadPointer ((volatile gpointer *)ptr);
+	return (MonoObject *)mono_atomic_load_ptr ((volatile gpointer *)ptr);
 }
 
 void
@@ -2805,19 +2805,19 @@ ves_icall_System_Threading_Thread_VolatileWriteFloat (void *ptr, float value)
 void
 ves_icall_System_Threading_Volatile_Write1 (void *ptr, gint8 value)
 {
-	InterlockedWrite8 ((volatile gint8 *)ptr, value);
+	mono_atomic_store_i8 ((volatile gint8 *)ptr, value);
 }
 
 void
 ves_icall_System_Threading_Volatile_Write2 (void *ptr, gint16 value)
 {
-	InterlockedWrite16 ((volatile gint16 *)ptr, value);
+	mono_atomic_store_i16 ((volatile gint16 *)ptr, value);
 }
 
 void
 ves_icall_System_Threading_Volatile_Write4 (void *ptr, gint32 value)
 {
-	InterlockedWrite ((volatile gint32 *)ptr, value);
+	mono_atomic_store_i32 ((volatile gint32 *)ptr, value);
 }
 
 void
@@ -2832,13 +2832,13 @@ ves_icall_System_Threading_Volatile_Write8 (void *ptr, gint64 value)
 	}
 #endif
 
-	InterlockedWrite64 ((volatile gint64 *)ptr, value);
+	mono_atomic_store_i64 ((volatile gint64 *)ptr, value);
 }
 
 void
 ves_icall_System_Threading_Volatile_WriteIntPtr (void *ptr, void *value)
 {
-	InterlockedWritePointer ((volatile gpointer *)ptr, value);
+	mono_atomic_store_ptr ((volatile gpointer *)ptr, value);
 }
 
 void
@@ -2857,7 +2857,7 @@ ves_icall_System_Threading_Volatile_WriteDouble (void *ptr, double value)
 
 	u.fval = value;
 
-	InterlockedWrite64 ((volatile gint64 *)ptr, u.ival);
+	mono_atomic_store_i64 ((volatile gint64 *)ptr, u.ival);
 }
 
 void
@@ -2867,7 +2867,7 @@ ves_icall_System_Threading_Volatile_WriteFloat (void *ptr, float value)
 
 	u.fval = value;
 
-	InterlockedWrite ((volatile gint32 *)ptr, u.ival);
+	mono_atomic_store_i32 ((volatile gint32 *)ptr, u.ival);
 }
 
 void
@@ -5078,7 +5078,7 @@ mono_threads_add_joinable_runtime_thread (gpointer thread_info)
 	MonoThreadInfo *mono_thread_info = (MonoThreadInfo*)thread_info;
 
 	if (mono_thread_info->runtime_thread) {
-		if (InterlockedCompareExchange (&mono_thread_info->thread_pending_native_join, TRUE, FALSE) == FALSE)
+		if (mono_atomic_cas_i32 (&mono_thread_info->thread_pending_native_join, TRUE, FALSE) == FALSE)
 			mono_threads_add_joinable_thread ((gpointer)(MONO_UINT_TO_NATIVE_THREAD_ID (mono_thread_info_get_tid (mono_thread_info))));
 	}
 }

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -261,7 +261,7 @@ mono_threads_begin_abort_protected_block (void)
 		g_assert (new_val < (1 << ABORT_PROT_BLOCK_BITS));
 
 		new_state = old_state + (1 << ABORT_PROT_BLOCK_SHIFT);
-	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer *)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
 	/* Defer async request since we won't be able to process until exiting the block */
 	if (new_val == 1 && (new_state & INTERRUPT_ASYNC_REQUESTED_BIT)) {
@@ -303,7 +303,7 @@ mono_threads_end_abort_protected_block (void)
 		g_assert (new_val < (1 << ABORT_PROT_BLOCK_BITS));
 
 		new_state = old_state - (1 << ABORT_PROT_BLOCK_SHIFT);
-	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer *)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
 	if (new_val == 0 && (new_state & INTERRUPT_ASYNC_REQUESTED_BIT)) {
 		mono_atomic_inc_i32 (&thread_interruption_requested);
@@ -343,7 +343,7 @@ mono_thread_clear_interruption_requested (MonoInternalThread *thread)
 			new_state = old_state & ~INTERRUPT_SYNC_REQUESTED_BIT;
 		else
 			new_state = old_state & ~INTERRUPT_ASYNC_REQUESTED_BIT;
-	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer *)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
 	mono_atomic_dec_i32 (&thread_interruption_requested);
 	THREADS_INTERRUPT_DEBUG ("[%d] clear interruption old_state %ld new_state %ld, tir %d\n", thread->small_id, old_state, new_state, thread_interruption_requested);
@@ -371,7 +371,7 @@ mono_thread_set_interruption_requested (MonoInternalThread *thread)
 			new_state = old_state | INTERRUPT_SYNC_REQUESTED_BIT;
 		else
 			new_state = old_state | INTERRUPT_ASYNC_REQUESTED_BIT;
-	} while (mono_atomic_cas_ptr ((volatile gpointer)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
+	} while (mono_atomic_cas_ptr ((volatile gpointer *)&thread->thread_state, (gpointer)new_state, (gpointer)old_state) != (gpointer)old_state);
 
 	if (sync || !(new_state & ABORT_PROT_BLOCK_MASK)) {
 		mono_atomic_inc_i32 (&thread_interruption_requested);

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -523,7 +523,7 @@ mono_w32handle_ref_core (gpointer handle, MonoW32HandleBase *handle_data)
 			return FALSE;
 
 		new = old + 1;
-	} while (InterlockedCompareExchange ((gint32*) &handle_data->ref, new, old) != old);
+	} while (mono_atomic_cas_i32 ((gint32*) &handle_data->ref, new, old) != old);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_W32HANDLE, "%s: ref %s handle %p, ref: %d -> %d",
 		__func__, mono_w32handle_ops_typename (handle_data->type), handle, old, new);
@@ -545,7 +545,7 @@ mono_w32handle_unref_core (gpointer handle, MonoW32HandleBase *handle_data)
 			g_error ("%s: handle %p has ref %d, it should be >= 1", __func__, handle, old);
 
 		new = old - 1;
-	} while (InterlockedCompareExchange ((gint32*) &handle_data->ref, new, old) != old);
+	} while (mono_atomic_cas_i32 ((gint32*) &handle_data->ref, new, old) != old);
 
 	/* handle_data might contain invalid data from now on, if
 	 * another thread is unref'ing this handle at the same time */

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -523,7 +523,7 @@ mono_w32handle_ref_core (gpointer handle, MonoW32HandleBase *handle_data)
 			return FALSE;
 
 		new = old + 1;
-	} while (mono_atomic_cas_i32 ((gint32*) &handle_data->ref, new, old) != old);
+	} while (mono_atomic_cas_i32 ((gint32*) &handle_data->ref, (gint32)new, (gint32)old) != (gint32)old);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_W32HANDLE, "%s: ref %s handle %p, ref: %d -> %d",
 		__func__, mono_w32handle_ops_typename (handle_data->type), handle, old, new);
@@ -545,7 +545,7 @@ mono_w32handle_unref_core (gpointer handle, MonoW32HandleBase *handle_data)
 			g_error ("%s: handle %p has ref %d, it should be >= 1", __func__, handle, old);
 
 		new = old - 1;
-	} while (mono_atomic_cas_i32 ((gint32*) &handle_data->ref, new, old) != old);
+	} while (mono_atomic_cas_i32 ((gint32*) &handle_data->ref, (gint32)new, (gint32)old) != (gint32)old);
 
 	/* handle_data might contain invalid data from now on, if
 	 * another thread is unref'ing this handle at the same time */

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -712,7 +712,7 @@ processes_cleanup (void)
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s", __func__);
 
 	/* Ensure we're not in here in multiple threads at once, nor recursive. */
-	if (InterlockedCompareExchange (&cleaning_up, 1, 0) != 0)
+	if (mono_atomic_cas_i32 (&cleaning_up, 1, 0) != 0)
 		return;
 
 	/*
@@ -752,7 +752,7 @@ processes_cleanup (void)
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s done", __func__);
 
-	InterlockedExchange (&cleaning_up, 0);
+	mono_atomic_xchg_i32 (&cleaning_up, 0);
 }
 
 static void
@@ -766,7 +766,7 @@ process_close (gpointer handle, gpointer data)
 	g_free (process_handle->pname);
 	process_handle->pname = NULL;
 	if (process_handle->process)
-		InterlockedDecrement (&process_handle->process->handle_count);
+		mono_atomic_dec_i32 (&process_handle->process->handle_count);
 	processes_cleanup ();
 }
 

--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -65,7 +65,7 @@ lower_load (MonoCompile *cfg, MonoInst *load, MonoInst *ldaddr)
 	load->opcode = mono_type_to_regmove (cfg, type);
 	type_to_eval_stack_type (cfg, type, load);
 	load->sreg1 = var->dreg;
-	InterlockedIncrement (&mono_jit_stats.loads_eliminated);
+	mono_atomic_inc_i32 (&mono_jit_stats.loads_eliminated);
 	return TRUE;
 }
 
@@ -96,7 +96,7 @@ lower_store (MonoCompile *cfg, MonoInst *store, MonoInst *ldaddr)
 	store->opcode = mono_type_to_regmove (cfg, type);
 	type_to_eval_stack_type (cfg, type, store);
 	store->dreg = var->dreg;
-	InterlockedIncrement (&mono_jit_stats.stores_eliminated);
+	mono_atomic_inc_i32 (&mono_jit_stats.stores_eliminated);
 	return TRUE;
 }
 
@@ -142,7 +142,7 @@ lower_store_imm (MonoCompile *cfg, MonoInst *store, MonoInst *ldaddr)
 	default:
 		return FALSE;
 	}
-	InterlockedIncrement (&mono_jit_stats.stores_eliminated);
+	mono_atomic_inc_i32 (&mono_jit_stats.stores_eliminated);
 	return TRUE;
 }
 
@@ -309,8 +309,8 @@ recompute_aliased_variables (MonoCompile *cfg, int *restored_vars)
 	}
 	*restored_vars = adds;
 
-	InterlockedAdd (&mono_jit_stats.alias_found, kills);
-	InterlockedAdd (&mono_jit_stats.alias_removed, kills - adds);
+	mono_atomic_add_i32 (&mono_jit_stats.alias_found, kills);
+	mono_atomic_add_i32 (&mono_jit_stats.alias_removed, kills - adds);
 	if (kills > adds) {
 		if (cfg->verbose_level > 2) {
 			printf ("Method: %s\n", mono_method_full_name (cfg->method, 1));

--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -309,8 +309,8 @@ recompute_aliased_variables (MonoCompile *cfg, int *restored_vars)
 	}
 	*restored_vars = adds;
 
-	mono_atomic_add_i32 (&mono_jit_stats.alias_found, kills);
-	mono_atomic_add_i32 (&mono_jit_stats.alias_removed, kills - adds);
+	mono_atomic_fetch_add_i32 (&mono_jit_stats.alias_found, kills);
+	mono_atomic_fetch_add_i32 (&mono_jit_stats.alias_removed, kills - adds);
 	if (kills > adds) {
 		if (cfg->verbose_level > 2) {
 			printf ("Method: %s\n", mono_method_full_name (cfg->method, 1));

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7676,11 +7676,11 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	if (acfg->aot_opts.profile_only && !method->is_inflated && !g_hash_table_lookup (acfg->profile_methods, method))
 		return;
 
-	InterlockedIncrement (&acfg->stats.mcount);
+	mono_atomic_inc_i32 (&acfg->stats.mcount);
 
 #if 0
 	if (method->is_generic || mono_class_is_gtd (method->klass)) {
-		InterlockedIncrement (&acfg->stats.genericcount);
+		mono_atomic_inc_i32 (&acfg->stats.genericcount);
 		return;
 	}
 #endif
@@ -7712,7 +7712,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	if (cfg->exception_type == MONO_EXCEPTION_GENERIC_SHARING_FAILED) {
 		if (acfg->aot_opts.print_skipped_methods)
 			printf ("Skip (gshared failure): %s (%s)\n", mono_method_get_full_name (method), cfg->exception_message);
-		InterlockedIncrement (&acfg->stats.genericcount);
+		mono_atomic_inc_i32 (&acfg->stats.genericcount);
 		return;
 	}
 	if (cfg->exception_type != MONO_EXCEPTION_NONE) {
@@ -7726,7 +7726,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	if (cfg->disable_aot) {
 		if (acfg->aot_opts.print_skipped_methods)
 			printf ("Skip (disabled): %s\n", mono_method_get_full_name (method));
-		InterlockedIncrement (&acfg->stats.ocount);
+		mono_atomic_inc_i32 (&acfg->stats.ocount);
 		return;
 	}
 	cfg->method_index = index;
@@ -7768,7 +7768,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	if (skip) {
 		if (acfg->aot_opts.print_skipped_methods)
 			printf ("Skip (abs call): %s\n", mono_method_get_full_name (method));
-		InterlockedIncrement (&acfg->stats.abscount);
+		mono_atomic_inc_i32 (&acfg->stats.abscount);
 		return;
 	}
 
@@ -7901,7 +7901,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	}
 
 	if (!cfg->has_got_slots)
-		InterlockedIncrement (&acfg->stats.methods_without_got_slots);
+		mono_atomic_inc_i32 (&acfg->stats.methods_without_got_slots);
 
 	/* Add gsharedvt wrappers for signatures used by the method */
 	if (acfg->aot_opts.llvm_only) {
@@ -8007,7 +8007,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 
 	mono_acfg_unlock (acfg);
 
-	InterlockedIncrement (&acfg->stats.ccount);
+	mono_atomic_inc_i32 (&acfg->stats.ccount);
 }
  
 static mono_thread_start_return_t WINAPI

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2858,7 +2858,7 @@ alloc0_jit_info_data (MonoDomain *domain, int size, gboolean async_context)
 
 	if (async_context) {
 		res = mono_domain_alloc0_lock_free (domain, size);
-		mono_atomic_xchg_i32Add (&async_jit_info_size, size);
+		mono_atomic_xchg_add_i32 (&async_jit_info_size, size);
 	} else {
 		res = mono_domain_alloc0 (domain, size);
 	}

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2858,7 +2858,7 @@ alloc0_jit_info_data (MonoDomain *domain, int size, gboolean async_context)
 
 	if (async_context) {
 		res = mono_domain_alloc0_lock_free (domain, size);
-		mono_atomic_xchg_add_i32 (&async_jit_info_size, size);
+		mono_atomic_fetch_add_i32 (&async_jit_info_size, size);
 	} else {
 		res = mono_domain_alloc0 (domain, size);
 	}

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2858,7 +2858,7 @@ alloc0_jit_info_data (MonoDomain *domain, int size, gboolean async_context)
 
 	if (async_context) {
 		res = mono_domain_alloc0_lock_free (domain, size);
-		InterlockedExchangeAdd (&async_jit_info_size, size);
+		mono_atomic_xchg_i32Add (&async_jit_info_size, size);
 	} else {
 		res = mono_domain_alloc0 (domain, size);
 	}
@@ -3334,10 +3334,10 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 		for (i = 0; i < methods_len -1; ++i)
 			g_assert (methods [i] <= methods [i + 1]);
 		amodule->sorted_methods_len = methods_len;
-		if (InterlockedCompareExchangePointer ((gpointer*)&amodule->sorted_methods, methods, NULL) != NULL)
+		if (mono_atomic_cas_ptr ((gpointer*)&amodule->sorted_methods, methods, NULL) != NULL)
 			/* Somebody got in before us */
 			g_free (methods);
-		if (InterlockedCompareExchangePointer ((gpointer*)&amodule->sorted_method_indexes, method_indexes, NULL) != NULL)
+		if (mono_atomic_cas_ptr ((gpointer*)&amodule->sorted_method_indexes, method_indexes, NULL) != NULL)
 			/* Somebody got in before us */
 			g_free (method_indexes);
 	}
@@ -3486,7 +3486,7 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 			new_table [len].jinfo = jinfo;
 			/* Publish it */
 			mono_memory_barrier ();
-			if (InterlockedCompareExchangePointer ((volatile gpointer *)&amodule->async_jit_info_table, new_table, old_table) == old_table)
+			if (mono_atomic_cas_ptr ((volatile gpointer *)&amodule->async_jit_info_table, new_table, old_table) == old_table)
 				break;
 		}
 	} else {
@@ -3957,7 +3957,7 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 		return code;
 
 	if (mono_last_aot_method != -1) {
-		gint32 methods_aot = InterlockedRead (&mono_jit_stats.methods_aot);
+		gint32 methods_aot = mono_atomic_load_i32 (&mono_jit_stats.methods_aot);
 		if (methods_aot >= mono_last_aot_method)
 			return NULL;
 		else if (methods_aot == mono_last_aot_method - 1) {
@@ -4005,7 +4005,7 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 
 	init_plt (amodule);
 
-	InterlockedIncrement (&mono_jit_stats.methods_aot);
+	mono_atomic_inc_i32 (&mono_jit_stats.methods_aot);
 
 	if (method && method->wrapper_type)
 		g_hash_table_insert (amodule->method_to_code, method, code);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1079,7 +1079,7 @@ finish_agent_init (gboolean on_startup)
 {
 	int res;
 
-	if (InterlockedCompareExchange (&inited, 1, 0) == 1)
+	if (mono_atomic_cas_i32 (&inited, 1, 0) == 1)
 		return;
 
 	if (agent_config.launch) {
@@ -1830,7 +1830,7 @@ send_packet (int command_set, int command, Buffer *data)
 	int len, id;
 	gboolean res;
 
-	id = InterlockedIncrement (&packet_id);
+	id = mono_atomic_inc_i32 (&packet_id);
 
 	len = data->p - data->buf + 11;
 	buffer_init (&buf, len);
@@ -2019,7 +2019,7 @@ get_objref (MonoObject *obj)
 	}
 
 	ref = g_new0 (ObjRef, 1);
-	ref->id = InterlockedIncrement (&objref_id);
+	ref->id = mono_atomic_inc_i32 (&objref_id);
 	ref->handle = mono_gchandle_new_weakref (obj, FALSE);
 
 	g_hash_table_insert (objrefs, GINT_TO_POINTER (ref->id), ref);
@@ -3271,7 +3271,7 @@ compute_frame_info (MonoInternalThread *thread, DebuggerTlsData *tls)
 		}
 
 		if (i >= tls->frame_count)
-			f->id = InterlockedIncrement (&frame_id);
+			f->id = mono_atomic_inc_i32 (&frame_id);
 
 		new_frames [findex ++] = f;
 	}
@@ -5409,7 +5409,7 @@ static void
 start_single_stepping (void)
 {
 #ifdef MONO_ARCH_SOFT_DEBUG_SUPPORTED
-	int val = InterlockedIncrement (&ss_count);
+	int val = mono_atomic_inc_i32 (&ss_count);
 
 	if (val == 1) {
 		mono_arch_start_single_stepping ();
@@ -5424,7 +5424,7 @@ static void
 stop_single_stepping (void)
 {
 #ifdef MONO_ARCH_SOFT_DEBUG_SUPPORTED
-	int val = InterlockedDecrement (&ss_count);
+	int val = mono_atomic_dec_i32 (&ss_count);
 
 	if (val == 0) {
 		mono_arch_stop_single_stepping ();
@@ -7895,7 +7895,7 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		nmodifiers = decode_byte (p, &p, end);
 
 		req = (EventRequest *)g_malloc0 (sizeof (EventRequest) + (nmodifiers * sizeof (Modifier)));
-		req->id = InterlockedIncrement (&event_request_id);
+		req->id = mono_atomic_inc_i32 (&event_request_id);
 		req->event_kind = event_kind;
 		req->suspend_policy = suspend_policy;
 		req->nmodifiers = nmodifiers;

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1421,8 +1421,8 @@ mono_jit_parse_options (int argc, char * argv[])
 			opt->break_on_exc = TRUE;
 		} else if (strcmp (argv [i], "--stats") == 0) {
 			mono_counters_enable (-1);
-			InterlockedWriteBool (&mono_stats.enabled, TRUE);
-			InterlockedWriteBool (&mono_jit_stats.enabled, TRUE);
+			mono_atomic_store_bool (&mono_stats.enabled, TRUE);
+			mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
 		} else if (strcmp (argv [i], "--break") == 0) {
 			if (i+1 >= argc){
 				fprintf (stderr, "Missing method name in --break command line option\n");
@@ -1768,8 +1768,8 @@ mono_main (int argc, char* argv[])
 			mono_print_vtable = TRUE;
 		} else if (strcmp (argv [i], "--stats") == 0) {
 			mono_counters_enable (-1);
-			InterlockedWriteBool (&mono_stats.enabled, TRUE);
-			InterlockedWriteBool (&mono_jit_stats.enabled, TRUE);
+			mono_atomic_store_bool (&mono_stats.enabled, TRUE);
+			mono_atomic_store_bool (&mono_jit_stats.enabled, TRUE);
 #ifndef DISABLE_AOT
 		} else if (strcmp (argv [i], "--aot") == 0) {
 			error_if_aot_unsupported ();

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3208,7 +3208,7 @@ ves_exec_method_with_context (InterpFrame *frame, ThreadContext *context, unsign
 		MINT_IN_CASE(MINT_MONO_ATOMIC_STORE_I4)
 			++ip;
 			sp -= 2;
-			InterlockedWrite ((gint32 *) sp->data.p, sp [1].data.i);
+			mono_atomic_store_i32 ((gint32 *) sp->data.p, sp [1].data.i);
 			MINT_IN_BREAK;
 #define BINOP(datamem, op) \
 	--sp; \

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1514,7 +1514,7 @@ save_seq_points (TransformData *td)
 	}
 
 	info = mono_seq_point_info_new (array->len, TRUE, array->data, TRUE, &seq_info_size);
-	mono_atomic_add_i32 (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
+	mono_atomic_fetch_add_i32 (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
 
 	g_byte_array_free (array, TRUE);
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1514,7 +1514,7 @@ save_seq_points (TransformData *td)
 	}
 
 	info = mono_seq_point_info_new (array->len, TRUE, array->data, TRUE, &seq_info_size);
-	InterlockedAdd (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
+	mono_atomic_add_i32 (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
 
 	g_byte_array_free (array, TRUE);
 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1417,7 +1417,7 @@ mono_arch_get_iregs_clobbered_by_call (MonoCallInst *call)
 		regs = g_list_prepend (regs, (gpointer)AMD64_RCX);
 		regs = g_list_prepend (regs, (gpointer)AMD64_RAX);
 
-		InterlockedCompareExchangePointer ((gpointer*)&r, regs, NULL);
+		mono_atomic_cas_ptr ((gpointer*)&r, regs, NULL);
 	}
 
 	return r;
@@ -1435,7 +1435,7 @@ mono_arch_get_fregs_clobbered_by_call (MonoCallInst *call)
 		for (i = 0; i < AMD64_XMM_NREG; ++i)
 			regs = g_list_prepend (regs, GINT_TO_POINTER (MONO_MAX_IREGS + i));
 
-		InterlockedCompareExchangePointer ((gpointer*)&r, regs, NULL);
+		mono_atomic_cas_ptr ((gpointer*)&r, regs, NULL);
 	}
 
 	return r;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1705,7 +1705,7 @@ mono_handle_exception_internal_first_pass (MonoContext *ctx, MonoObject *obj, gi
 
 				if (ei->flags == MONO_EXCEPTION_CLAUSE_FILTER) {
 #ifndef DISABLE_PERFCOUNTERS
-					InterlockedIncrement (&mono_perfcounters->exceptions_filters);
+					mono_atomic_inc_i32 (&mono_perfcounters->exceptions_filters);
 #endif
 
 #ifndef MONO_CROSS_COMPILE
@@ -2158,7 +2158,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 					}
 					mono_set_lmf (lmf);
 #ifndef DISABLE_PERFCOUNTERS
-					InterlockedAdd (&mono_perfcounters->exceptions_depth, frame_count);
+					mono_atomic_add_i32 (&mono_perfcounters->exceptions_depth, frame_count);
 #endif
 					if (obj == (MonoObject *)domain->stack_overflow_ex)
 						jit_tls->handling_stack_ovf = FALSE;
@@ -2180,7 +2180,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 					MONO_PROFILER_RAISE (exception_clause, (method, i, ei->flags, ex_obj));
 					jit_tls->orig_ex_ctx_set = FALSE;
 #ifndef DISABLE_PERFCOUNTERS
-					InterlockedIncrement (&mono_perfcounters->exceptions_finallys);
+					mono_atomic_inc_i32 (&mono_perfcounters->exceptions_finallys);
 #endif
 				}
 				if (ei->flags == MONO_EXCEPTION_CLAUSE_FAULT || ei->flags == MONO_EXCEPTION_CLAUSE_FINALLY) {
@@ -2282,7 +2282,7 @@ mono_handle_exception (MonoContext *ctx, MonoObject *obj)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->exceptions_thrown);
+	mono_atomic_inc_i32 (&mono_perfcounters->exceptions_thrown);
 #endif
 
 	return mono_handle_exception_internal (ctx, obj, FALSE, NULL);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2158,7 +2158,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 					}
 					mono_set_lmf (lmf);
 #ifndef DISABLE_PERFCOUNTERS
-					mono_atomic_add_i32 (&mono_perfcounters->exceptions_depth, frame_count);
+					mono_atomic_fetch_add_i32 (&mono_perfcounters->exceptions_depth, frame_count);
 #endif
 					if (obj == (MonoObject *)domain->stack_overflow_ex)
 						jit_tls->handling_stack_ovf = FALSE;

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -367,8 +367,8 @@ alloc_template (MonoClass *klass)
 {
 	gint32 size = sizeof (MonoRuntimeGenericContextTemplate);
 
-	InterlockedIncrement (&rgctx_template_num_allocated);
-	InterlockedAdd(&rgctx_template_bytes_allocated, size);
+	mono_atomic_inc_i32 (&rgctx_template_num_allocated);
+	mono_atomic_add_i32(&rgctx_template_bytes_allocated, size);
 
 	return (MonoRuntimeGenericContextTemplate *)mono_image_alloc0 (klass->image, size);
 }
@@ -379,8 +379,8 @@ alloc_oti (MonoImage *image)
 {
 	gint32 size = sizeof (MonoRuntimeGenericContextInfoTemplate);
 
-	InterlockedIncrement (&rgctx_oti_num_allocated);
-	InterlockedAdd (&rgctx_oti_bytes_allocated, size);
+	mono_atomic_inc_i32 (&rgctx_oti_num_allocated);
+	mono_atomic_add_i32 (&rgctx_oti_bytes_allocated, size);
 
 	return (MonoRuntimeGenericContextInfoTemplate *)mono_image_alloc0 (image, size);
 }
@@ -1691,7 +1691,7 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 	else
 		addr = mono_arch_get_gsharedvt_arg_trampoline (mono_domain_get (), info, addr);
 
-	InterlockedIncrement (&gsharedvt_num_trampolines);
+	mono_atomic_inc_i32 (&gsharedvt_num_trampolines);
 
 	/* Cache it */
 	tramp_info = (GSharedVtTrampInfo *)mono_domain_alloc0 (domain, sizeof (GSharedVtTrampInfo));

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -368,7 +368,7 @@ alloc_template (MonoClass *klass)
 	gint32 size = sizeof (MonoRuntimeGenericContextTemplate);
 
 	mono_atomic_inc_i32 (&rgctx_template_num_allocated);
-	mono_atomic_add_i32(&rgctx_template_bytes_allocated, size);
+	mono_atomic_fetch_add_i32 (&rgctx_template_bytes_allocated, size);
 
 	return (MonoRuntimeGenericContextTemplate *)mono_image_alloc0 (klass->image, size);
 }
@@ -380,7 +380,7 @@ alloc_oti (MonoImage *image)
 	gint32 size = sizeof (MonoRuntimeGenericContextInfoTemplate);
 
 	mono_atomic_inc_i32 (&rgctx_oti_num_allocated);
-	mono_atomic_add_i32 (&rgctx_oti_bytes_allocated, size);
+	mono_atomic_fetch_add_i32 (&rgctx_oti_bytes_allocated, size);
 
 	return (MonoRuntimeGenericContextInfoTemplate *)mono_image_alloc0 (image, size);
 }

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -3853,7 +3853,7 @@ get_mono_personality (EmitContext *ctx)
 	if (!use_debug_personality) {
 		if (ctx->cfg->compile_aot) {
 				personality = get_intrinsic (ctx, default_personality_name);
-		} else if (InterlockedCompareExchange (&mapping_inited, 1, 0) == 0) {
+		} else if (mono_atomic_cas_i32 (&mapping_inited, 1, 0) == 0) {
 				personality = LLVMAddFunction (ctx->lmodule, default_personality_name, personality_type);
 				LLVMAddGlobalMapping (ctx->module->ee, personality, personality);
 		}
@@ -4028,7 +4028,7 @@ emit_handler_start (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef builder
 
 		personality = LLVMGetNamedFunction (lmodule, "mono_personality");
 
-		if (InterlockedCompareExchange (&mapping_inited, 1, 0) == 0)
+		if (mono_atomic_cas_i32 (&mapping_inited, 1, 0) == 0)
 			LLVMAddGlobalMapping (ctx->module->ee, personality, (gpointer)mono_personality);
 #endif
 	}

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2051,7 +2051,7 @@ lookup_start:
 		if (! ((domain != target_domain) && !info->domain_neutral)) {
 			MonoVTable *vtable;
 
-			InterlockedIncrement (&mono_jit_stats.methods_lookups);
+			mono_atomic_inc_i32 (&mono_jit_stats.methods_lookups);
 			vtable = mono_class_vtable_full (domain, method->klass, error);
 			if (!is_ok (error))
 				return NULL;
@@ -2304,7 +2304,7 @@ mono_jit_find_compiled_method_with_jit_info (MonoDomain *domain, MonoMethod *met
 	if (info) {
 		/* We can't use a domain specific method in another domain */
 		if (! ((domain != target_domain) && !info->domain_neutral)) {
-			InterlockedIncrement (&mono_jit_stats.methods_lookups);
+			mono_atomic_inc_i32 (&mono_jit_stats.methods_lookups);
 			if (ji)
 				*ji = info;
 			return info->code_start;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3879,11 +3879,11 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	/* collect statistics */
 #ifndef DISABLE_PERFCOUNTERS
 	mono_atomic_inc_i32 (&mono_perfcounters->jit_methods);
-	mono_atomic_add_i32 (&mono_perfcounters->jit_bytes, header->code_size);
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->jit_bytes, header->code_size);
 #endif
 	gint32 code_size_ratio = cfg->code_len;
-	mono_atomic_add_i32 (&mono_jit_stats.allocated_code_size, code_size_ratio);
-	mono_atomic_add_i32 (&mono_jit_stats.native_code_size, code_size_ratio);
+	mono_atomic_fetch_add_i32 (&mono_jit_stats.allocated_code_size, code_size_ratio);
+	mono_atomic_fetch_add_i32 (&mono_jit_stats.native_code_size, code_size_ratio);
 	/* FIXME: use an explicit function to read booleans */
 	if ((gboolean)mono_atomic_load_i32 ((gint32*)&mono_jit_stats.enabled)) {
 		if (code_size_ratio > mono_atomic_load_i32 (&mono_jit_stats.biggest_method_size)) {

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3087,7 +3087,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	static gboolean verbose_method_inited;
 	static char *verbose_method_name;
 
-	InterlockedIncrement (&mono_jit_stats.methods_compiled);
+	mono_atomic_inc_i32 (&mono_jit_stats.methods_compiled);
 	MONO_PROFILER_RAISE (jit_begin, (method));
 	if (MONO_METHOD_COMPILE_BEGIN_ENABLED ())
 		MONO_PROBE_METHOD_COMPILE_BEGIN (method);
@@ -3126,9 +3126,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 
 	if (opts & MONO_OPT_GSHARED) {
 		if (try_generic_shared)
-			InterlockedIncrement (&mono_stats.generics_sharable_methods);
+			mono_atomic_inc_i32 (&mono_stats.generics_sharable_methods);
 		else if (mono_method_is_generic_impl (method))
-			InterlockedIncrement (&mono_stats.generics_unsharable_methods);
+			mono_atomic_inc_i32 (&mono_stats.generics_unsharable_methods);
 	}
 
 #ifdef ENABLE_LLVM
@@ -3834,9 +3834,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	}
 
 	if (COMPILE_LLVM (cfg))
-		InterlockedIncrement (&mono_jit_stats.methods_with_llvm);
+		mono_atomic_inc_i32 (&mono_jit_stats.methods_with_llvm);
 	else
-		InterlockedIncrement (&mono_jit_stats.methods_without_llvm);
+		mono_atomic_inc_i32 (&mono_jit_stats.methods_without_llvm);
 
 	MONO_TIME_TRACK (mono_jit_stats.jit_create_jit_info, cfg->jit_info = create_jit_info (cfg, method_to_compile));
 
@@ -3878,25 +3878,25 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 
 	/* collect statistics */
 #ifndef DISABLE_PERFCOUNTERS
-	InterlockedIncrement (&mono_perfcounters->jit_methods);
-	InterlockedAdd (&mono_perfcounters->jit_bytes, header->code_size);
+	mono_atomic_inc_i32 (&mono_perfcounters->jit_methods);
+	mono_atomic_add_i32 (&mono_perfcounters->jit_bytes, header->code_size);
 #endif
 	gint32 code_size_ratio = cfg->code_len;
-	InterlockedAdd (&mono_jit_stats.allocated_code_size, code_size_ratio);
-	InterlockedAdd (&mono_jit_stats.native_code_size, code_size_ratio);
+	mono_atomic_add_i32 (&mono_jit_stats.allocated_code_size, code_size_ratio);
+	mono_atomic_add_i32 (&mono_jit_stats.native_code_size, code_size_ratio);
 	/* FIXME: use an explicit function to read booleans */
-	if ((gboolean)InterlockedRead ((gint32*)&mono_jit_stats.enabled)) {
-		if (code_size_ratio > InterlockedRead (&mono_jit_stats.biggest_method_size)) {
-			InterlockedWrite (&mono_jit_stats.biggest_method_size, code_size_ratio);
+	if ((gboolean)mono_atomic_load_i32 ((gint32*)&mono_jit_stats.enabled)) {
+		if (code_size_ratio > mono_atomic_load_i32 (&mono_jit_stats.biggest_method_size)) {
+			mono_atomic_store_i32 (&mono_jit_stats.biggest_method_size, code_size_ratio);
 			char *biggest_method = g_strdup_printf ("%s::%s)", method->klass->name, method->name);
-			biggest_method = InterlockedExchangePointer ((gpointer*)&mono_jit_stats.biggest_method, biggest_method);
+			biggest_method = mono_atomic_xchg_ptr ((gpointer*)&mono_jit_stats.biggest_method, biggest_method);
 			g_free (biggest_method);
 		}
 		code_size_ratio = (code_size_ratio * 100) / header->code_size;
-		if (code_size_ratio > InterlockedRead (&mono_jit_stats.max_code_size_ratio)) {
-			InterlockedWrite (&mono_jit_stats.max_code_size_ratio, code_size_ratio);
+		if (code_size_ratio > mono_atomic_load_i32 (&mono_jit_stats.max_code_size_ratio)) {
+			mono_atomic_store_i32 (&mono_jit_stats.max_code_size_ratio, code_size_ratio);
 			char *max_ratio_method = g_strdup_printf ("%s::%s)", method->klass->name, method->name);
-			max_ratio_method = InterlockedExchangePointer ((gpointer*)&mono_jit_stats.max_ratio_method, max_ratio_method);
+			max_ratio_method = mono_atomic_xchg_ptr ((gpointer*)&mono_jit_stats.max_ratio_method, max_ratio_method);
 			g_free (max_ratio_method);
 		}
 	}
@@ -4254,16 +4254,16 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 		code = cfg->native_code;
 
 		if (cfg->gshared && mono_method_is_generic_sharable (method, FALSE))
-			InterlockedIncrement (&mono_stats.generics_shared_methods);
+			mono_atomic_inc_i32 (&mono_stats.generics_shared_methods);
 		if (cfg->gsharedvt)
-			InterlockedIncrement (&mono_stats.gsharedvt_methods);
+			mono_atomic_inc_i32 (&mono_stats.gsharedvt_methods);
 	}
 
 	jinfo = cfg->jit_info;
 
 	/*
 	 * Update global stats while holding a lock, instead of doing many
-	 * InterlockedIncrement operations during JITting.
+	 * mono_atomic_inc_i32 operations during JITting.
 	 */
 	mono_update_jit_stats (cfg);
 

--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -230,7 +230,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 		g_free (next);
 
 	cfg->seq_point_info = mono_seq_point_info_new (array->len, TRUE, array->data, has_debug_data, &seq_info_size);
-	InterlockedAdd (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
+	mono_atomic_add_i32 (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
 
 	g_byte_array_free (array, TRUE);
 

--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -230,7 +230,7 @@ mono_save_seq_point_info (MonoCompile *cfg)
 		g_free (next);
 
 	cfg->seq_point_info = mono_seq_point_info_new (array->len, TRUE, array->data, has_debug_data, &seq_info_size);
-	mono_atomic_add_i32 (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
+	mono_atomic_fetch_add_i32 (&mono_jit_stats.allocated_seq_points_size, seq_info_size);
 
 	g_byte_array_free (array, TRUE);
 

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -133,7 +133,7 @@ mono_trace_enter_method (MonoMethod *method, char *ebp)
 	if (!trace_spec.enabled)
 		return;
 
-	while (output_lock != 0 || InterlockedCompareExchange (&output_lock, 1, 0) != 0)
+	while (output_lock != 0 || mono_atomic_cas_i32 (&output_lock, 1, 0) != 0)
 		mono_thread_info_yield ();
 
 	fname = mono_method_full_name (method, TRUE);
@@ -304,7 +304,7 @@ mono_trace_leave_method (MonoMethod *method, ...)
 	if (!trace_spec.enabled)
 		return;
 
-	while (output_lock != 0 || InterlockedCompareExchange (&output_lock, 1, 0) != 0)
+	while (output_lock != 0 || mono_atomic_cas_i32 (&output_lock, 1, 0) != 0)
 		mono_thread_info_yield ();
 
 	va_start(ap, method);

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -145,7 +145,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 		if (code [-5] != 0xe8) {
 			if (can_write) {
 				g_assert ((guint64)(orig_code - 11) % 8 == 0);
-				InterlockedExchangePointer ((gpointer*)(orig_code - 11), addr);
+				mono_atomic_xchg_ptr ((gpointer*)(orig_code - 11), addr);
 				VALGRIND_DISCARD_TRANSLATIONS (orig_code - 11, sizeof (gpointer));
 			}
 		} else {
@@ -166,7 +166,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 				MONO_PROFILER_RAISE (jit_code_buffer, (thunk_start, thunk_code - thunk_start, MONO_PROFILER_CODE_BUFFER_HELPER, NULL));
 			}
 			if (can_write) {
-				InterlockedExchange ((gint32*)(orig_code - 4), ((gint64)addr - (gint64)orig_code));
+				mono_atomic_xchg_i32 ((gint32*)(orig_code - 4), ((gint64)addr - (gint64)orig_code));
 				VALGRIND_DISCARD_TRANSLATIONS (orig_code - 5, 4);
 			}
 		}
@@ -175,7 +175,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 		/* call *<OFFSET>(%rip) */
 		gpointer *got_entry = (gpointer*)((guint8*)orig_code + (*(guint32*)(orig_code - 4)));
 		if (can_write) {
-			InterlockedExchangePointer (got_entry, addr);
+			mono_atomic_xchg_ptr (got_entry, addr);
 			VALGRIND_DISCARD_TRANSLATIONS (orig_code - 5, sizeof (gpointer));
 		}
 	}
@@ -217,7 +217,7 @@ mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *a
 
 	plt_jump_table_entry = (gpointer*)(code + 6 + disp);
 
-	InterlockedExchangePointer (plt_jump_table_entry, addr);
+	mono_atomic_xchg_ptr (plt_jump_table_entry, addr);
 }
 
 #ifndef DISABLE_JIT

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -108,7 +108,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 	orig_code -= 6;
 	if (code [1] == 0xe8) {
 		if (can_write) {
-			InterlockedExchange ((gint32*)(orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
+			mono_atomic_xchg_i32 ((gint32*)(orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
 
 			/* Tell valgrind to recompile the patched code */
 			VALGRIND_DISCARD_TRANSLATIONS (orig_code + 2, 4);
@@ -116,7 +116,7 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 	} else if (code [1] == 0xe9) {
 		/* A PLT entry: jmp <DISP> */
 		if (can_write)
-			InterlockedExchange ((gint32*)(orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
+			mono_atomic_xchg_i32 ((gint32*)(orig_code + 2), (guint)addr - ((guint)orig_code + 1) - 5);
 	} else {
 		printf ("Invalid trampoline sequence: %x %x %x %x %x %x %x\n", code [0], code [1], code [2], code [3],
 				code [4], code [5], code [6]);

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -238,7 +238,7 @@ process_id (void)
 			buffer_lock (); \
 		g_assert (!thread__->busy && "Why are we trying to write a new event while already writing one?"); \
 		thread__->busy = TRUE; \
-		InterlockedIncrement ((COUNTER)); \
+		mono_atomic_inc_i32 ((COUNTER)); \
 		LogBuffer *BUFFER = ensure_logbuf_unsafe (thread__, (SIZE))
 
 #define EXIT_LOG_EXPLICIT(SEND) \
@@ -474,7 +474,7 @@ create_buffer (uintptr_t tid, int bytes)
 {
 	LogBuffer* buf = (LogBuffer *) alloc_buffer (MAX (BUFFER_SIZE, bytes));
 
-	InterlockedIncrement (&buffer_allocations_ctr);
+	mono_atomic_inc_i32 (&buffer_allocations_ctr);
 
 	buf->size = BUFFER_SIZE;
 	buf->time_base = current_time ();
@@ -629,7 +629,7 @@ buffer_lock (void)
 	 * the exclusive lock in the gc_event () callback when the world
 	 * is about to stop.
 	 */
-	if (InterlockedRead (&log_profiler.buffer_lock_state) != get_thread ()->small_id << 16) {
+	if (mono_atomic_load_i32 (&log_profiler.buffer_lock_state) != get_thread ()->small_id << 16) {
 		MONO_ENTER_GC_SAFE;
 
 		gint32 old, new_;
@@ -637,10 +637,10 @@ buffer_lock (void)
 		do {
 		restart:
 			// Hold off if a thread wants to take the exclusive lock.
-			while (InterlockedRead (&log_profiler.buffer_lock_exclusive_intent))
+			while (mono_atomic_load_i32 (&log_profiler.buffer_lock_exclusive_intent))
 				mono_thread_info_yield ();
 
-			old = InterlockedRead (&log_profiler.buffer_lock_state);
+			old = mono_atomic_load_i32 (&log_profiler.buffer_lock_state);
 
 			// Is a thread holding the exclusive lock?
 			if (old >> 16) {
@@ -649,7 +649,7 @@ buffer_lock (void)
 			}
 
 			new_ = old + 1;
-		} while (InterlockedCompareExchange (&log_profiler.buffer_lock_state, new_, old) != old);
+		} while (mono_atomic_cas_i32 (&log_profiler.buffer_lock_state, new_, old) != old);
 
 		MONO_EXIT_GC_SAFE;
 	}
@@ -662,7 +662,7 @@ buffer_unlock (void)
 {
 	mono_memory_barrier ();
 
-	gint32 state = InterlockedRead (&log_profiler.buffer_lock_state);
+	gint32 state = mono_atomic_load_i32 (&log_profiler.buffer_lock_state);
 
 	// See the comment in buffer_lock ().
 	if (state == PROF_TLS_GET ()->small_id << 16)
@@ -671,7 +671,7 @@ buffer_unlock (void)
 	g_assert (state && "Why are we decrementing a zero reader count?");
 	g_assert (!(state >> 16) && "Why is the exclusive lock held?");
 
-	InterlockedDecrement (&log_profiler.buffer_lock_state);
+	mono_atomic_dec_i32 (&log_profiler.buffer_lock_state);
 }
 
 static void
@@ -679,13 +679,13 @@ buffer_lock_excl (void)
 {
 	gint32 new_ = get_thread ()->small_id << 16;
 
-	g_assert (InterlockedRead (&log_profiler.buffer_lock_state) != new_ && "Why are we taking the exclusive lock twice?");
+	g_assert (mono_atomic_load_i32 (&log_profiler.buffer_lock_state) != new_ && "Why are we taking the exclusive lock twice?");
 
-	InterlockedIncrement (&log_profiler.buffer_lock_exclusive_intent);
+	mono_atomic_inc_i32 (&log_profiler.buffer_lock_exclusive_intent);
 
 	MONO_ENTER_GC_SAFE;
 
-	while (InterlockedCompareExchange (&log_profiler.buffer_lock_state, new_, 0))
+	while (mono_atomic_cas_i32 (&log_profiler.buffer_lock_state, new_, 0))
 		mono_thread_info_yield ();
 
 	MONO_EXIT_GC_SAFE;
@@ -698,15 +698,15 @@ buffer_unlock_excl (void)
 {
 	mono_memory_barrier ();
 
-	gint32 state = InterlockedRead (&log_profiler.buffer_lock_state);
+	gint32 state = mono_atomic_load_i32 (&log_profiler.buffer_lock_state);
 	gint32 excl = state >> 16;
 
 	g_assert (excl && "Why is the exclusive lock not held?");
 	g_assert (excl == PROF_TLS_GET ()->small_id && "Why does another thread hold the exclusive lock?");
 	g_assert (!(state & 0xFFFF) && "Why are there readers when the exclusive lock is held?");
 
-	InterlockedWrite (&log_profiler.buffer_lock_state, 0);
-	InterlockedDecrement (&log_profiler.buffer_lock_exclusive_intent);
+	mono_atomic_store_i32 (&log_profiler.buffer_lock_state, 0);
+	mono_atomic_dec_i32 (&log_profiler.buffer_lock_exclusive_intent);
 }
 
 static void
@@ -1032,7 +1032,7 @@ free_thread (gpointer p)
 		 * threads. We need to synthesize a thread end event.
 		 */
 
-		InterlockedIncrement (&thread_ends_ctr);
+		mono_atomic_inc_i32 (&thread_ends_ctr);
 
 		LogBuffer *buf = ensure_logbuf_unsafe (thread,
 			EVENT_SIZE /* event */ +
@@ -1124,7 +1124,7 @@ send_log_unsafe (gboolean if_needed)
 static void
 sync_point_flush (void)
 {
-	g_assert (InterlockedRead (&log_profiler.buffer_lock_state) == PROF_TLS_GET ()->small_id << 16 && "Why don't we hold the exclusive lock?");
+	g_assert (mono_atomic_load_i32 (&log_profiler.buffer_lock_state) == PROF_TLS_GET ()->small_id << 16 && "Why don't we hold the exclusive lock?");
 
 	MONO_LLS_FOREACH_SAFE (&log_profiler.profiler_thread_list, MonoProfilerThread, thread) {
 		g_assert (thread->attached && "Why is a thread in the LLS not attached?");
@@ -1138,7 +1138,7 @@ sync_point_flush (void)
 static void
 sync_point_mark (MonoProfilerSyncPointType type)
 {
-	g_assert (InterlockedRead (&log_profiler.buffer_lock_state) == PROF_TLS_GET ()->small_id << 16 && "Why don't we hold the exclusive lock?");
+	g_assert (mono_atomic_load_i32 (&log_profiler.buffer_lock_state) == PROF_TLS_GET ()->small_id << 16 && "Why don't we hold the exclusive lock?");
 
 	ENTER_LOG (&sync_points_ctr, logbuffer,
 		EVENT_SIZE /* event */ +
@@ -1230,7 +1230,7 @@ gc_roots (MonoProfiler *prof, MonoObject *const *objects, const MonoProfilerGCRo
 static void
 trigger_on_demand_heapshot (void)
 {
-	if (InterlockedRead (&log_profiler.heapshot_requested))
+	if (mono_atomic_load_i32 (&log_profiler.heapshot_requested))
 		mono_gc_collect (mono_gc_max_generation ());
 }
 
@@ -1263,7 +1263,7 @@ gc_event (MonoProfiler *profiler, MonoProfilerGCEvent ev, uint32_t generation)
 			log_profiler.do_heap_walk = generation == mono_gc_max_generation ();
 			break;
 		case MONO_PROFILER_HEAPSHOT_ON_DEMAND:
-			log_profiler.do_heap_walk = InterlockedRead (&log_profiler.heapshot_requested);
+			log_profiler.do_heap_walk = mono_atomic_load_i32 (&log_profiler.heapshot_requested);
 			break;
 		case MONO_PROFILER_HEAPSHOT_X_GC:
 			log_profiler.do_heap_walk = !(log_profiler.gc_count % log_config.hs_freq_gc);
@@ -1282,7 +1282,7 @@ gc_event (MonoProfiler *profiler, MonoProfilerGCEvent ev, uint32_t generation)
 		 * switch above, so check it here and override any decision we made
 		 * above.
 		 */
-		if (InterlockedRead (&log_profiler.heapshot_requested))
+		if (mono_atomic_load_i32 (&log_profiler.heapshot_requested))
 			log_profiler.do_heap_walk = TRUE;
 
 		if (ENABLED (PROFLOG_GC_ROOT_EVENTS) && log_profiler.do_heap_walk)
@@ -1340,7 +1340,7 @@ gc_event (MonoProfiler *profiler, MonoProfilerGCEvent ev, uint32_t generation)
 			log_profiler.do_heap_walk = FALSE;
 			log_profiler.last_hs_time = current_time ();
 
-			InterlockedWrite (&log_profiler.heapshot_requested, 0);
+			mono_atomic_store_i32 (&log_profiler.heapshot_requested, 0);
 		}
 
 		/*
@@ -1423,7 +1423,7 @@ emit_bt (LogBuffer *logbuffer, FrameData *data)
 static void
 gc_alloc (MonoProfiler *prof, MonoObject *obj)
 {
-	int do_bt = (!log_config.enter_leave && InterlockedRead (&log_profiler.runtime_inited) && log_config.num_frames) ? TYPE_ALLOC_BT : 0;
+	int do_bt = (!log_config.enter_leave && mono_atomic_load_i32 (&log_profiler.runtime_inited) && log_config.num_frames) ? TYPE_ALLOC_BT : 0;
 	FrameData data;
 	uintptr_t len = mono_object_get_size (obj);
 	/* account for object alignment in the heap */
@@ -1480,7 +1480,7 @@ gc_moves (MonoProfiler *prof, MonoObject *const *objects, uint64_t num)
 static void
 gc_handle (MonoProfiler *prof, int op, MonoGCHandleType type, uint32_t handle, MonoObject *obj)
 {
-	int do_bt = !log_config.enter_leave && InterlockedRead (&log_profiler.runtime_inited) && log_config.num_frames;
+	int do_bt = !log_config.enter_leave && mono_atomic_load_i32 (&log_profiler.runtime_inited) && log_config.num_frames;
 	FrameData data;
 
 	if (do_bt)
@@ -1728,7 +1728,7 @@ class_loaded (MonoProfiler *prof, MonoClass *klass)
 {
 	char *name;
 
-	if (InterlockedRead (&log_profiler.runtime_inited))
+	if (mono_atomic_load_i32 (&log_profiler.runtime_inited))
 		name = mono_type_get_name (mono_class_get_type (klass));
 	else
 		name = type_name (klass);
@@ -1753,7 +1753,7 @@ class_loaded (MonoProfiler *prof, MonoClass *klass)
 
 	EXIT_LOG;
 
-	if (InterlockedRead (&log_profiler.runtime_inited))
+	if (mono_atomic_load_i32 (&log_profiler.runtime_inited))
 		mono_free (name);
 	else
 		g_free (name);
@@ -1876,7 +1876,7 @@ code_buffer_new (MonoProfiler *prof, const mono_byte *buffer, uint64_t size, Mon
 static void
 throw_exc (MonoProfiler *prof, MonoObject *object)
 {
-	int do_bt = (!log_config.enter_leave && InterlockedRead (&log_profiler.runtime_inited) && log_config.num_frames) ? TYPE_THROW_BT : 0;
+	int do_bt = (!log_config.enter_leave && mono_atomic_load_i32 (&log_profiler.runtime_inited) && log_config.num_frames) ? TYPE_THROW_BT : 0;
 	FrameData data;
 
 	if (do_bt)
@@ -1925,7 +1925,7 @@ clause_exc (MonoProfiler *prof, MonoMethod *method, uint32_t clause_num, MonoExc
 static void
 monitor_event (MonoProfiler *profiler, MonoObject *object, MonoProfilerMonitorEvent ev)
 {
-	int do_bt = (!log_config.enter_leave && InterlockedRead (&log_profiler.runtime_inited) && log_config.num_frames) ? TYPE_MONITOR_BT : 0;
+	int do_bt = (!log_config.enter_leave && mono_atomic_load_i32 (&log_profiler.runtime_inited) && log_config.num_frames) ? TYPE_MONITOR_BT : 0;
 	FrameData data;
 
 	if (do_bt)
@@ -2179,7 +2179,7 @@ mono_sample_hit (MonoProfiler *profiler, const mono_byte *ip, const void *contex
 	 * invoking runtime functions, which is not async-signal-safe.
 	 */
 
-	if (InterlockedRead (&log_profiler.in_shutdown))
+	if (mono_atomic_load_i32 (&log_profiler.in_shutdown))
 		return;
 
 	SampleHit *sample = (SampleHit *) mono_lock_free_queue_dequeue (&profiler->sample_reuse_queue);
@@ -2189,13 +2189,13 @@ mono_sample_hit (MonoProfiler *profiler, const mono_byte *ip, const void *contex
 		 * If we're out of reusable sample events and we're not allowed to
 		 * allocate more, we have no choice but to drop the event.
 		 */
-		if (InterlockedRead (&sample_allocations_ctr) >= log_config.max_allocated_sample_hits)
+		if (mono_atomic_load_i32 (&sample_allocations_ctr) >= log_config.max_allocated_sample_hits)
 			return;
 
 		sample = mono_lock_free_alloc (&profiler->sample_allocator);
 		mono_lock_free_queue_node_init (&sample->node, TRUE);
 
-		InterlockedIncrement (&sample_allocations_ctr);
+		mono_atomic_inc_i32 (&sample_allocations_ctr);
 	}
 
 	sample->count = 0;
@@ -2538,7 +2538,7 @@ dump_unmanaged_coderefs (void)
 static void
 counters_add_agent (MonoCounter *counter)
 {
-	if (InterlockedRead (&log_profiler.in_shutdown))
+	if (mono_atomic_load_i32 (&log_profiler.in_shutdown))
 		return;
 
 	MonoCounterAgent *agent, *item;
@@ -3524,7 +3524,7 @@ static void
 log_early_shutdown (MonoProfiler *prof)
 {
 	if (log_config.hs_on_shutdown) {
-		InterlockedWrite (&log_profiler.heapshot_requested, 1);
+		mono_atomic_store_i32 (&log_profiler.heapshot_requested, 1);
 		mono_gc_collect (mono_gc_max_generation ());
 	}
 }
@@ -3532,7 +3532,7 @@ log_early_shutdown (MonoProfiler *prof)
 static void
 log_shutdown (MonoProfiler *prof)
 {
-	InterlockedWrite (&log_profiler.in_shutdown, 1);
+	mono_atomic_store_i32 (&log_profiler.in_shutdown, 1);
 
 	if (ENABLED (PROFLOG_COUNTER_EVENTS))
 		counters_and_perfcounters_sample ();
@@ -3584,12 +3584,12 @@ log_shutdown (MonoProfiler *prof)
 	 */
 	mono_thread_hazardous_try_free_all ();
 
-	InterlockedWrite (&prof->run_dumper_thread, 0);
+	mono_atomic_store_i32 (&prof->run_dumper_thread, 0);
 	mono_os_sem_post (&prof->dumper_queue_sem);
 	mono_native_thread_join (prof->dumper_thread);
 	mono_os_sem_destroy (&prof->dumper_queue_sem);
 
-	InterlockedWrite (&prof->run_writer_thread, 0);
+	mono_atomic_store_i32 (&prof->run_writer_thread, 0);
 	mono_os_sem_post (&prof->writer_queue_sem);
 	mono_native_thread_join (prof->writer_thread);
 	mono_os_sem_destroy (&prof->writer_queue_sem);
@@ -3610,7 +3610,7 @@ log_shutdown (MonoProfiler *prof)
 	 */
 	mono_thread_hazardous_try_free_all ();
 
-	gint32 state = InterlockedRead (&log_profiler.buffer_lock_state);
+	gint32 state = mono_atomic_load_i32 (&log_profiler.buffer_lock_state);
 
 	g_assert (!(state & 0xFFFF) && "Why is the reader count still non-zero?");
 	g_assert (!(state >> 16) && "Why is the exclusive lock still held?");
@@ -3801,7 +3801,7 @@ helper_thread (void *arg)
 
 			if (log_config.hs_mode == MONO_PROFILER_HEAPSHOT_ON_DEMAND && !strcmp (buf, "heapshot\n")) {
 				// Rely on the finalization callback triggering a GC.
-				InterlockedWrite (&log_profiler.heapshot_requested, 1);
+				mono_atomic_store_i32 (&log_profiler.heapshot_requested, 1);
 				mono_gc_finalize_notify ();
 			}
 		}
@@ -3991,7 +3991,7 @@ writer_thread (void *arg)
 
 	MonoProfilerThread *thread = init_thread (FALSE);
 
-	while (InterlockedRead (&log_profiler.run_writer_thread)) {
+	while (mono_atomic_load_i32 (&log_profiler.run_writer_thread)) {
 		mono_os_sem_wait (&log_profiler.writer_queue_sem, MONO_SEM_FLAGS_NONE);
 		handle_writer_queue_entry ();
 	}
@@ -4010,7 +4010,7 @@ writer_thread (void *arg)
 static void
 start_writer_thread (void)
 {
-	InterlockedWrite (&log_profiler.run_writer_thread, 1);
+	mono_atomic_store_i32 (&log_profiler.run_writer_thread, 1);
 
 	if (!mono_native_thread_create (&log_profiler.writer_thread, writer_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler writer thread");
@@ -4096,7 +4096,7 @@ dumper_thread (void *arg)
 
 	MonoProfilerThread *thread = init_thread (FALSE);
 
-	while (InterlockedRead (&log_profiler.run_dumper_thread)) {
+	while (mono_atomic_load_i32 (&log_profiler.run_dumper_thread)) {
 		/*
 		 * Flush samples every second so it doesn't seem like the profiler is
 		 * not working if the program is mostly idle.
@@ -4121,7 +4121,7 @@ dumper_thread (void *arg)
 static void
 start_dumper_thread (void)
 {
-	InterlockedWrite (&log_profiler.run_dumper_thread, 1);
+	mono_atomic_store_i32 (&log_profiler.run_dumper_thread, 1);
 
 	if (!mono_native_thread_create (&log_profiler.dumper_thread, dumper_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler dumper thread");
@@ -4457,7 +4457,7 @@ proflog_icall_SetJitEvents (MonoBoolean value)
 static void
 runtime_initialized (MonoProfiler *profiler)
 {
-	InterlockedWrite (&log_profiler.runtime_inited, 1);
+	mono_atomic_store_i32 (&log_profiler.runtime_inited, 1);
 
 	register_counter ("Sample events allocated", &sample_allocations_ctr);
 	register_counter ("Log buffers allocated", &buffer_allocations_ctr);

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -138,7 +138,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 
 	if (G_UNLIKELY (has_per_allocation_action)) {
 		static int alloc_count;
-		int current_alloc = InterlockedIncrement (&alloc_count);
+		int current_alloc = mono_atomic_inc_i32 (&alloc_count);
 
 		if (collect_before_allocs) {
 			if (((current_alloc % collect_before_allocs) == 0) && nursery_section) {
@@ -393,7 +393,7 @@ sgen_alloc_obj (GCVTable vtable, size_t size)
 
 	if (G_UNLIKELY (has_per_allocation_action)) {
 		static int alloc_count;
-		int current_alloc = InterlockedIncrement (&alloc_count);
+		int current_alloc = mono_atomic_inc_i32 (&alloc_count);
 
 		if (verify_before_allocs) {
 			if ((current_alloc % verify_before_allocs) == 0) {

--- a/mono/sgen/sgen-array-list.c
+++ b/mono/sgen/sgen-array-list.c
@@ -46,12 +46,12 @@ sgen_array_list_grow (SgenArrayList *array, guint32 old_capacity)
 	 * the new bucket pointer.
 	 */
 	mono_memory_write_barrier ();
-	if (InterlockedCompareExchangePointer ((volatile gpointer *)&array->entries [new_bucket], entries, NULL) == NULL) {
+	if (mono_atomic_cas_ptr ((volatile gpointer *)&array->entries [new_bucket], entries, NULL) == NULL) {
 		/*
 		 * It must not be the case that we succeeded in setting the bucket
 		 * pointer, while someone else succeeded in changing the capacity.
 		 */
-		if (InterlockedCompareExchange ((volatile gint32 *)&array->capacity, new_capacity, old_capacity) != old_capacity)
+		if (mono_atomic_cas_i32 ((volatile gint32 *)&array->capacity, new_capacity, old_capacity) != old_capacity)
 			g_assert_not_reached ();
 		array->slot_hint = old_capacity;
 		return;
@@ -109,7 +109,7 @@ sgen_array_list_update_next_slot (SgenArrayList *array, guint32 new_index)
 			old_next_slot = array->next_slot;
 			if (new_index < old_next_slot)
 				break;
-		} while (InterlockedCompareExchange ((volatile gint32 *)&array->next_slot, new_index + 1, old_next_slot) != old_next_slot);
+		} while (mono_atomic_cas_i32 ((volatile gint32 *)&array->next_slot, new_index + 1, old_next_slot) != old_next_slot);
 	}
 }
 
@@ -196,7 +196,7 @@ sgen_array_list_find (SgenArrayList *array, gpointer ptr)
 gboolean
 sgen_array_list_default_cas_setter (volatile gpointer *slot, gpointer ptr, int data)
 {
-	if (InterlockedCompareExchangePointer (slot, ptr, NULL) == NULL)
+	if (mono_atomic_cas_ptr (slot, ptr, NULL) == NULL)
 		return TRUE;
 	return FALSE;
 }

--- a/mono/sgen/sgen-array-list.c
+++ b/mono/sgen/sgen-array-list.c
@@ -51,7 +51,7 @@ sgen_array_list_grow (SgenArrayList *array, guint32 old_capacity)
 		 * It must not be the case that we succeeded in setting the bucket
 		 * pointer, while someone else succeeded in changing the capacity.
 		 */
-		if (mono_atomic_cas_i32 ((volatile gint32 *)&array->capacity, new_capacity, old_capacity) != old_capacity)
+		if (mono_atomic_cas_i32 ((volatile gint32 *)&array->capacity, (gint32)new_capacity, (gint32)old_capacity) != (gint32)old_capacity)
 			g_assert_not_reached ();
 		array->slot_hint = old_capacity;
 		return;
@@ -109,7 +109,7 @@ sgen_array_list_update_next_slot (SgenArrayList *array, guint32 new_index)
 			old_next_slot = array->next_slot;
 			if (new_index < old_next_slot)
 				break;
-		} while (mono_atomic_cas_i32 ((volatile gint32 *)&array->next_slot, new_index + 1, old_next_slot) != old_next_slot);
+		} while (mono_atomic_cas_i32 ((volatile gint32 *)&array->next_slot, (gint32)(new_index + 1), (gint32)old_next_slot) != (gint32)old_next_slot);
 	}
 }
 

--- a/mono/sgen/sgen-los.c
+++ b/mono/sgen/sgen-los.c
@@ -738,9 +738,9 @@ sgen_los_pin_object_par (GCObject *data)
 	if (old_size & 1)
 		return FALSE;
 #if SIZEOF_VOID_P == 4
-	old_size = InterlockedCompareExchange ((volatile gint32*)&obj->size, old_size | 1, old_size);
+	old_size = mono_atomic_cas_i32 ((volatile gint32*)&obj->size, old_size | 1, old_size);
 #else
-	old_size = InterlockedCompareExchange64 ((volatile gint64*)&obj->size, old_size | 1, old_size);
+	old_size = mono_atomic_cas_i64 ((volatile gint64*)&obj->size, old_size | 1, old_size);
 #endif
 	if (old_size & 1)
 		return FALSE;

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -148,7 +148,7 @@ typedef struct {
 		first = FALSE;						\
 		while (!(tmp_mark_word & (ONE_P << (b)))) {		\
 			old_mark_word = tmp_mark_word;			\
-			tmp_mark_word = InterlockedCompareExchange ((volatile gint32*)&(bl)->mark_words [w], old_mark_word | (ONE_P << (b)), old_mark_word); \
+			tmp_mark_word = mono_atomic_cas_i32 ((volatile gint32*)&(bl)->mark_words [w], old_mark_word | (ONE_P << (b)), old_mark_word); \
 			if (tmp_mark_word == old_mark_word) {		\
 				first = TRUE;				\
 				break;					\

--- a/mono/sgen/sgen-pinning.c
+++ b/mono/sgen/sgen-pinning.c
@@ -333,7 +333,7 @@ sgen_cement_lookup_or_register (GCObject *obj)
 
 	if (!hash [i].obj) {
 		GCObject *old_obj;
-		old_obj = InterlockedCompareExchangePointer ((gpointer*)&hash [i].obj, obj, NULL);
+		old_obj = mono_atomic_cas_ptr ((gpointer*)&hash [i].obj, obj, NULL);
 		/* Check if the slot was occupied by some other object */
 		if (old_obj != NULL && old_obj != obj)
 			return FALSE;
@@ -344,7 +344,7 @@ sgen_cement_lookup_or_register (GCObject *obj)
 	if (hash [i].count >= SGEN_CEMENT_THRESHOLD)
 		return TRUE;
 
-	if (InterlockedIncrement ((gint32*)&hash [i].count) == SGEN_CEMENT_THRESHOLD) {
+	if (mono_atomic_inc_i32 ((gint32*)&hash [i].count) == SGEN_CEMENT_THRESHOLD) {
 		SGEN_ASSERT (9, sgen_get_current_collection_generation () >= 0, "We can only cement objects when we're in a collection pause.");
 		SGEN_ASSERT (9, SGEN_OBJECT_IS_PINNED (obj), "Can only cement pinned objects");
 		SGEN_CEMENT_OBJECT (obj);

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -57,7 +57,7 @@ set_state (WorkerData *data, State old_state, State new_state)
 	else if (new_state == STATE_WORKING)
 		SGEN_ASSERT (0, old_state == STATE_WORK_ENQUEUED, "We can only transition to WORKING from WORK ENQUEUED");
 
-	return InterlockedCompareExchange (&data->state, new_state, old_state) == old_state;
+	return mono_atomic_cas_i32 (&data->state, new_state, old_state) == old_state;
 }
 
 static gboolean

--- a/mono/unit-tests/test-mono-linked-list-set.c
+++ b/mono/unit-tests/test-mono-linked-list-set.c
@@ -73,7 +73,7 @@ worker (void *arg)
 			mono_thread_hazardous_try_free_some ();
 			break;
 		case STATE_OUT:
-			if (InterlockedCompareExchange (&nodes [i].state, STATE_BUSY, STATE_OUT) == STATE_OUT) {
+			if (mono_atomic_cas_i32 (&nodes [i].state, STATE_BUSY, STATE_OUT) == STATE_OUT) {
 				result = mono_lls_find (&lls, hp, i);
 				assert (!result);
 				mono_hazard_pointer_clear_all (hp, -1);
@@ -88,7 +88,7 @@ worker (void *arg)
 			}
 			break;
 		case STATE_IN:
-			if (InterlockedCompareExchange (&nodes [i].state, STATE_BUSY, STATE_IN) == STATE_IN) {
+			if (mono_atomic_cas_i32 (&nodes [i].state, STATE_BUSY, STATE_IN) == STATE_IN) {
 				result = mono_lls_find (&lls, hp, i);
 				assert (result);
 				assert (mono_hazard_pointer_get_val (hp, 1) == &nodes [i].node);

--- a/mono/utils/atomic.c
+++ b/mono/utils/atomic.c
@@ -264,7 +264,7 @@ gpointer mono_atomic_xchg_ptr(volatile gpointer *dest, gpointer exch)
 	return(ret);
 }
 
-gint32 mono_atomic_xchg_i32Add(volatile gint32 *dest, gint32 add)
+gint32 mono_atomic_xchg_add_i32(volatile gint32 *dest, gint32 add)
 {
 	gint32 ret;
 	int thr_ret;
@@ -285,7 +285,7 @@ gint32 mono_atomic_xchg_i32Add(volatile gint32 *dest, gint32 add)
 	return(ret);
 }
 
-gint64 mono_atomic_xchg_i32Add64(volatile gint64 *dest, gint64 add)
+gint64 mono_atomic_xchg_add_i64(volatile gint64 *dest, gint64 add)
 {
 	gint64 ret;
 	int thr_ret;

--- a/mono/utils/atomic.c
+++ b/mono/utils/atomic.c
@@ -27,7 +27,7 @@ static pthread_mutex_t spin G_GNUC_UNUSED = PTHREAD_MUTEX_INITIALIZER;
 
 #ifdef WAPI_NO_ATOMIC_ASM
 
-gint32 InterlockedCompareExchange(volatile gint32 *dest, gint32 exch,
+gint32 mono_atomic_cas_i32(volatile gint32 *dest, gint32 exch,
 				  gint32 comp)
 {
 	gint32 old;
@@ -51,7 +51,7 @@ gint32 InterlockedCompareExchange(volatile gint32 *dest, gint32 exch,
 	return(old);
 }
 
-gpointer InterlockedCompareExchangePointer(volatile gpointer *dest,
+gpointer mono_atomic_cas_ptr(volatile gpointer *dest,
 					   gpointer exch, gpointer comp)
 {
 	gpointer old;
@@ -75,7 +75,7 @@ gpointer InterlockedCompareExchangePointer(volatile gpointer *dest,
 	return(old);
 }
 
-gint32 InterlockedAdd(volatile gint32 *dest, gint32 add)
+gint32 mono_atomic_add_i32(volatile gint32 *dest, gint32 add)
 {
 	gint32 ret;
 	int thr_ret;
@@ -96,7 +96,7 @@ gint32 InterlockedAdd(volatile gint32 *dest, gint32 add)
 	return(ret);
 }
 
-gint64 InterlockedAdd64(volatile gint64 *dest, gint64 add)
+gint64 mono_atomic_add_i64(volatile gint64 *dest, gint64 add)
 {
 	gint64 ret;
 	int thr_ret;
@@ -117,7 +117,7 @@ gint64 InterlockedAdd64(volatile gint64 *dest, gint64 add)
 	return(ret);
 }
 
-gint32 InterlockedIncrement(volatile gint32 *dest)
+gint32 mono_atomic_inc_i32(volatile gint32 *dest)
 {
 	gint32 ret;
 	int thr_ret;
@@ -138,7 +138,7 @@ gint32 InterlockedIncrement(volatile gint32 *dest)
 	return(ret);
 }
 
-gint64 InterlockedIncrement64(volatile gint64 *dest)
+gint64 mono_atomic_inc_i64(volatile gint64 *dest)
 {
 	gint64 ret;
 	int thr_ret;
@@ -159,7 +159,7 @@ gint64 InterlockedIncrement64(volatile gint64 *dest)
 	return(ret);
 }
 
-gint32 InterlockedDecrement(volatile gint32 *dest)
+gint32 mono_atomic_dec_i32(volatile gint32 *dest)
 {
 	gint32 ret;
 	int thr_ret;
@@ -180,7 +180,7 @@ gint32 InterlockedDecrement(volatile gint32 *dest)
 	return(ret);
 }
 
-gint64 InterlockedDecrement64(volatile gint64 *dest)
+gint64 mono_atomic_dec_i64(volatile gint64 *dest)
 {
 	gint64 ret;
 	int thr_ret;
@@ -201,7 +201,7 @@ gint64 InterlockedDecrement64(volatile gint64 *dest)
 	return(ret);
 }
 
-gint32 InterlockedExchange(volatile gint32 *dest, gint32 exch)
+gint32 mono_atomic_xchg_i32(volatile gint32 *dest, gint32 exch)
 {
 	gint32 ret;
 	int thr_ret;
@@ -222,7 +222,7 @@ gint32 InterlockedExchange(volatile gint32 *dest, gint32 exch)
 	return(ret);
 }
 
-gint64 InterlockedExchange64(volatile gint64 *dest, gint64 exch)
+gint64 mono_atomic_xchg_i64(volatile gint64 *dest, gint64 exch)
 {
 	gint64 ret;
 	int thr_ret;
@@ -243,7 +243,7 @@ gint64 InterlockedExchange64(volatile gint64 *dest, gint64 exch)
 	return(ret);
 }
 
-gpointer InterlockedExchangePointer(volatile gpointer *dest, gpointer exch)
+gpointer mono_atomic_xchg_ptr(volatile gpointer *dest, gpointer exch)
 {
 	gpointer ret;
 	int thr_ret;
@@ -264,7 +264,7 @@ gpointer InterlockedExchangePointer(volatile gpointer *dest, gpointer exch)
 	return(ret);
 }
 
-gint32 InterlockedExchangeAdd(volatile gint32 *dest, gint32 add)
+gint32 mono_atomic_xchg_i32Add(volatile gint32 *dest, gint32 add)
 {
 	gint32 ret;
 	int thr_ret;
@@ -285,7 +285,7 @@ gint32 InterlockedExchangeAdd(volatile gint32 *dest, gint32 add)
 	return(ret);
 }
 
-gint64 InterlockedExchangeAdd64(volatile gint64 *dest, gint64 add)
+gint64 mono_atomic_xchg_i32Add64(volatile gint64 *dest, gint64 add)
 {
 	gint64 ret;
 	int thr_ret;
@@ -306,7 +306,7 @@ gint64 InterlockedExchangeAdd64(volatile gint64 *dest, gint64 add)
 	return(ret);
 }
 
-gint8 InterlockedRead8(volatile gint8 *src)
+gint8 mono_atomic_load_i8(volatile gint8 *src)
 {
 	gint8 ret;
 	int thr_ret;
@@ -326,7 +326,7 @@ gint8 InterlockedRead8(volatile gint8 *src)
 	return(ret);
 }
 
-gint16 InterlockedRead16(volatile gint16 *src)
+gint16 mono_atomic_load_i16(volatile gint16 *src)
 {
 	gint16 ret;
 	int thr_ret;
@@ -346,7 +346,7 @@ gint16 InterlockedRead16(volatile gint16 *src)
 	return(ret);
 }
 
-gint32 InterlockedRead(volatile gint32 *src)
+gint32 mono_atomic_load_i32(volatile gint32 *src)
 {
 	gint32 ret;
 	int thr_ret;
@@ -366,7 +366,7 @@ gint32 InterlockedRead(volatile gint32 *src)
 	return(ret);
 }
 
-gint64 InterlockedRead64(volatile gint64 *src)
+gint64 mono_atomic_load_i64(volatile gint64 *src)
 {
 	gint64 ret;
 	int thr_ret;
@@ -386,7 +386,7 @@ gint64 InterlockedRead64(volatile gint64 *src)
 	return(ret);
 }
 
-gpointer InterlockedReadPointer(volatile gpointer *src)
+gpointer mono_atomic_load_ptr(volatile gpointer *src)
 {
 	gpointer ret;
 	int thr_ret;
@@ -406,7 +406,7 @@ gpointer InterlockedReadPointer(volatile gpointer *src)
 	return(ret);
 }
 
-void InterlockedWrite8(volatile gint8 *dst, gint8 val)
+void mono_atomic_store_i8(volatile gint8 *dst, gint8 val)
 {
 	int thr_ret;
 	
@@ -423,7 +423,7 @@ void InterlockedWrite8(volatile gint8 *dst, gint8 val)
 	pthread_cleanup_pop (0);
 }
 
-void InterlockedWrite16(volatile gint16 *dst, gint16 val)
+void mono_atomic_store_i16(volatile gint16 *dst, gint16 val)
 {
 	int thr_ret;
 	
@@ -440,7 +440,7 @@ void InterlockedWrite16(volatile gint16 *dst, gint16 val)
 	pthread_cleanup_pop (0);
 }
 
-void InterlockedWrite(volatile gint32 *dst, gint32 val)
+void mono_atomic_store_i32(volatile gint32 *dst, gint32 val)
 {
 	int thr_ret;
 	
@@ -457,7 +457,7 @@ void InterlockedWrite(volatile gint32 *dst, gint32 val)
 	pthread_cleanup_pop (0);
 }
 
-void InterlockedWrite64(volatile gint64 *dst, gint64 val)
+void mono_atomic_store_i64(volatile gint64 *dst, gint64 val)
 {
 	int thr_ret;
 	
@@ -474,7 +474,7 @@ void InterlockedWrite64(volatile gint64 *dst, gint64 val)
 	pthread_cleanup_pop (0);
 }
 
-void InterlockedWritePointer(volatile gpointer *dst, gpointer val)
+void mono_atomic_store_ptr(volatile gpointer *dst, gpointer val)
 {
 	int thr_ret;
 	
@@ -500,7 +500,7 @@ void InterlockedWritePointer(volatile gpointer *dst, gpointer val)
 /* The compiler breaks if this code is in the header... */
 
 gint64
-InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
+mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp)
 {
 	return __sync_val_compare_and_swap (dest, comp, exch);
 }
@@ -514,7 +514,7 @@ InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
 #endif
 
 gint64
-InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
+mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp)
 {
 	return  __sync_val_compare_and_swap (dest, comp, exch);
 }
@@ -525,10 +525,10 @@ InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
  * so we have to roll our own...
  */
 
-gint64 InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp) __attribute__ ((__naked__));
+gint64 mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp) __attribute__ ((__naked__));
 
 gint64
-InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
+mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp)
 {
 	__asm__ (
 		"push		{r4, r5, r6, r7}\n"
@@ -560,7 +560,7 @@ InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
 #else
 
 gint64
-InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
+mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp)
 {
 	gint64 old;
 	int ret;

--- a/mono/utils/atomic.c
+++ b/mono/utils/atomic.c
@@ -264,7 +264,7 @@ gpointer mono_atomic_xchg_ptr(volatile gpointer *dest, gpointer exch)
 	return(ret);
 }
 
-gint32 mono_atomic_xchg_add_i32(volatile gint32 *dest, gint32 add)
+gint32 mono_atomic_fetch_add_i32(volatile gint32 *dest, gint32 add)
 {
 	gint32 ret;
 	int thr_ret;
@@ -285,7 +285,7 @@ gint32 mono_atomic_xchg_add_i32(volatile gint32 *dest, gint32 add)
 	return(ret);
 }
 
-gint64 mono_atomic_xchg_add_i64(volatile gint64 *dest, gint64 add)
+gint64 mono_atomic_fetch_add_i64(volatile gint64 *dest, gint64 add)
 {
 	gint64 ret;
 	int thr_ret;

--- a/mono/utils/atomic.h
+++ b/mono/utils/atomic.h
@@ -214,33 +214,33 @@ static inline void InterlockedWrite16(volatile gint16 *dst, gint16 val)
 #define gcc_sync_fetch_and_add(a, b) __sync_fetch_and_add (a, b)
 #endif
 
-static inline gint32 InterlockedCompareExchange(volatile gint32 *dest,
+static inline gint32 mono_atomic_cas_i32(volatile gint32 *dest,
 						gint32 exch, gint32 comp)
 {
 	return gcc_sync_val_compare_and_swap (dest, comp, exch);
 }
 
-static inline gpointer InterlockedCompareExchangePointer(volatile gpointer *dest, gpointer exch, gpointer comp)
+static inline gpointer mono_atomic_cas_ptr(volatile gpointer *dest, gpointer exch, gpointer comp)
 {
 	return gcc_sync_val_compare_and_swap (dest, comp, exch);
 }
 
-static inline gint32 InterlockedAdd(volatile gint32 *dest, gint32 add)
+static inline gint32 mono_atomic_add_i32(volatile gint32 *dest, gint32 add)
 {
 	return gcc_sync_add_and_fetch (dest, add);
 }
 
-static inline gint32 InterlockedIncrement(volatile gint32 *val)
+static inline gint32 mono_atomic_inc_i32(volatile gint32 *val)
 {
 	return gcc_sync_add_and_fetch (val, 1);
 }
 
-static inline gint32 InterlockedDecrement(volatile gint32 *val)
+static inline gint32 mono_atomic_dec_i32(volatile gint32 *val)
 {
 	return gcc_sync_sub_and_fetch (val, 1);
 }
 
-static inline gint32 InterlockedExchange(volatile gint32 *val, gint32 new_val)
+static inline gint32 mono_atomic_xchg_i32(volatile gint32 *val, gint32 new_val)
 {
 	gint32 old_val;
 	do {
@@ -249,7 +249,7 @@ static inline gint32 InterlockedExchange(volatile gint32 *val, gint32 new_val)
 	return old_val;
 }
 
-static inline gpointer InterlockedExchangePointer(volatile gpointer *val,
+static inline gpointer mono_atomic_xchg_ptr(volatile gpointer *val,
 						  gpointer new_val)
 {
 	gpointer old_val;
@@ -259,29 +259,29 @@ static inline gpointer InterlockedExchangePointer(volatile gpointer *val,
 	return old_val;
 }
 
-static inline gint32 InterlockedExchangeAdd(volatile gint32 *val, gint32 add)
+static inline gint32 mono_atomic_xchg_i32Add(volatile gint32 *val, gint32 add)
 {
 	return gcc_sync_fetch_and_add (val, add);
 }
 
-static inline gint8 InterlockedRead8(volatile gint8 *src)
+static inline gint8 mono_atomic_load_i8(volatile gint8 *src)
 {
 	/* Kind of a hack, but GCC doesn't give us anything better, and it's
 	 * certainly not as bad as using a CAS loop. */
 	return gcc_sync_fetch_and_add (src, 0);
 }
 
-static inline gint16 InterlockedRead16(volatile gint16 *src)
+static inline gint16 mono_atomic_load_i16(volatile gint16 *src)
 {
 	return gcc_sync_fetch_and_add (src, 0);
 }
 
-static inline gint32 InterlockedRead(volatile gint32 *src)
+static inline gint32 mono_atomic_load_i32(volatile gint32 *src)
 {
 	return gcc_sync_fetch_and_add (src, 0);
 }
 
-static inline void InterlockedWrite8(volatile gint8 *dst, gint8 val)
+static inline void mono_atomic_store_i8(volatile gint8 *dst, gint8 val)
 {
 	/* Nothing useful from GCC at all, so fall back to CAS. */
 	gint8 old_val;
@@ -290,7 +290,7 @@ static inline void InterlockedWrite8(volatile gint8 *dst, gint8 val)
 	} while (gcc_sync_val_compare_and_swap (dst, old_val, val) != old_val);
 }
 
-static inline void InterlockedWrite16(volatile gint16 *dst, gint16 val)
+static inline void mono_atomic_store_i16(volatile gint16 *dst, gint16 val)
 {
 	gint16 old_val;
 	do {
@@ -298,7 +298,7 @@ static inline void InterlockedWrite16(volatile gint16 *dst, gint16 val)
 	} while (gcc_sync_val_compare_and_swap (dst, old_val, val) != old_val);
 }
 
-static inline void InterlockedWrite(volatile gint32 *dst, gint32 val)
+static inline void mono_atomic_store_i32(volatile gint32 *dst, gint32 val)
 {
 	/* Nothing useful from GCC at all, so fall back to CAS. */
 	gint32 old_val;
@@ -313,32 +313,32 @@ static inline void InterlockedWrite(volatile gint32 *dst, gint32 val)
 
 #if !defined (BROKEN_64BIT_ATOMICS_INTRINSIC)
 
-static inline gint64 InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp)
+static inline gint64 mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp)
 {
 	return gcc_sync_val_compare_and_swap (dest, comp, exch);
 }
 
-static inline gint64 InterlockedAdd64(volatile gint64 *dest, gint64 add)
+static inline gint64 mono_atomic_add_i64(volatile gint64 *dest, gint64 add)
 {
 	return gcc_sync_add_and_fetch (dest, add);
 }
 
-static inline gint64 InterlockedIncrement64(volatile gint64 *val)
+static inline gint64 mono_atomic_inc_i64(volatile gint64 *val)
 {
 	return gcc_sync_add_and_fetch (val, 1);
 }
 
-static inline gint64 InterlockedDecrement64(volatile gint64 *val)
+static inline gint64 mono_atomic_dec_i64(volatile gint64 *val)
 {
 	return gcc_sync_sub_and_fetch (val, 1);
 }
 
-static inline gint64 InterlockedExchangeAdd64(volatile gint64 *val, gint64 add)
+static inline gint64 mono_atomic_xchg_i32Add64(volatile gint64 *val, gint64 add)
 {
 	return gcc_sync_fetch_and_add (val, add);
 }
 
-static inline gint64 InterlockedRead64(volatile gint64 *src)
+static inline gint64 mono_atomic_load_i64(volatile gint64 *src)
 {
 	/* Kind of a hack, but GCC doesn't give us anything better. */
 	return gcc_sync_fetch_and_add (src, 0);
@@ -347,130 +347,130 @@ static inline gint64 InterlockedRead64(volatile gint64 *src)
 #else
 
 /* Implement 64-bit cmpxchg by hand or emulate it. */
-extern gint64 InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp);
+extern gint64 mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp);
 
 /* Implement all other 64-bit atomics in terms of a specialized CAS
  * in this case, since chances are that the other 64-bit atomic
  * intrinsics are broken too.
  */
 
-static inline gint64 InterlockedExchangeAdd64(volatile gint64 *dest, gint64 add)
+static inline gint64 mono_atomic_xchg_i32Add64(volatile gint64 *dest, gint64 add)
 {
 	gint64 old_val;
 	do {
 		old_val = *dest;
-	} while (InterlockedCompareExchange64 (dest, old_val + add, old_val) != old_val);
+	} while (mono_atomic_cas_i64 (dest, old_val + add, old_val) != old_val);
 	return old_val;
 }
 
-static inline gint64 InterlockedIncrement64(volatile gint64 *val)
+static inline gint64 mono_atomic_inc_i64(volatile gint64 *val)
 {
 	gint64 get, set;
 	do {
 		get = *val;
 		set = get + 1;
-	} while (InterlockedCompareExchange64 (val, set, get) != get);
+	} while (mono_atomic_cas_i64 (val, set, get) != get);
 	return set;
 }
 
-static inline gint64 InterlockedDecrement64(volatile gint64 *val)
+static inline gint64 mono_atomic_dec_i64(volatile gint64 *val)
 {
 	gint64 get, set;
 	do {
 		get = *val;
 		set = get - 1;
-	} while (InterlockedCompareExchange64 (val, set, get) != get);
+	} while (mono_atomic_cas_i64 (val, set, get) != get);
 	return set;
 }
 
-static inline gint64 InterlockedAdd64(volatile gint64 *dest, gint64 add)
+static inline gint64 mono_atomic_add_i64(volatile gint64 *dest, gint64 add)
 {
 	gint64 get, set;
 	do {
 		get = *dest;
 		set = get + add;
-	} while (InterlockedCompareExchange64 (dest, set, get) != get);
+	} while (mono_atomic_cas_i64 (dest, set, get) != get);
 	return set;
 }
 
-static inline gint64 InterlockedRead64(volatile gint64 *src)
+static inline gint64 mono_atomic_load_i64(volatile gint64 *src)
 {
-	return InterlockedCompareExchange64 (src, 0, 0);
+	return mono_atomic_cas_i64 (src, 0, 0);
 }
 
 #endif
 
-static inline gpointer InterlockedReadPointer(volatile gpointer *src)
+static inline gpointer mono_atomic_load_ptr(volatile gpointer *src)
 {
-	return InterlockedCompareExchangePointer (src, NULL, NULL);
+	return mono_atomic_cas_ptr (src, NULL, NULL);
 }
 
-static inline void InterlockedWritePointer(volatile gpointer *dst, gpointer val)
+static inline void mono_atomic_store_ptr(volatile gpointer *dst, gpointer val)
 {
-	InterlockedExchangePointer (dst, val);
+	mono_atomic_xchg_ptr (dst, val);
 }
 
 /* We always implement this in terms of a 64-bit cmpxchg since
  * GCC doesn't have an intrisic to model it anyway. */
-static inline gint64 InterlockedExchange64(volatile gint64 *val, gint64 new_val)
+static inline gint64 mono_atomic_xchg_i64(volatile gint64 *val, gint64 new_val)
 {
 	gint64 old_val;
 	do {
 		old_val = *val;
-	} while (InterlockedCompareExchange64 (val, new_val, old_val) != old_val);
+	} while (mono_atomic_cas_i64 (val, new_val, old_val) != old_val);
 	return old_val;
 }
 
-static inline void InterlockedWrite64(volatile gint64 *dst, gint64 val)
+static inline void mono_atomic_store_i64(volatile gint64 *dst, gint64 val)
 {
 	/* Nothing useful from GCC at all, so fall back to CAS. */
-	InterlockedExchange64 (dst, val);
+	mono_atomic_xchg_i64 (dst, val);
 }
 
 #else
 
 #define WAPI_NO_ATOMIC_ASM
 
-extern gint32 InterlockedCompareExchange(volatile gint32 *dest, gint32 exch, gint32 comp);
-extern gint64 InterlockedCompareExchange64(volatile gint64 *dest, gint64 exch, gint64 comp);
-extern gpointer InterlockedCompareExchangePointer(volatile gpointer *dest, gpointer exch, gpointer comp);
-extern gint32 InterlockedAdd(volatile gint32 *dest, gint32 add);
-extern gint64 InterlockedAdd64(volatile gint64 *dest, gint64 add);
-extern gint32 InterlockedIncrement(volatile gint32 *dest);
-extern gint64 InterlockedIncrement64(volatile gint64 *dest);
-extern gint32 InterlockedDecrement(volatile gint32 *dest);
-extern gint64 InterlockedDecrement64(volatile gint64 *dest);
-extern gint32 InterlockedExchange(volatile gint32 *dest, gint32 exch);
-extern gint64 InterlockedExchange64(volatile gint64 *dest, gint64 exch);
-extern gpointer InterlockedExchangePointer(volatile gpointer *dest, gpointer exch);
-extern gint32 InterlockedExchangeAdd(volatile gint32 *dest, gint32 add);
-extern gint64 InterlockedExchangeAdd64(volatile gint64 *dest, gint64 add);
-extern gint8 InterlockedRead8(volatile gint8 *src);
-extern gint16 InterlockedRead16(volatile gint16 *src);
-extern gint32 InterlockedRead(volatile gint32 *src);
-extern gint64 InterlockedRead64(volatile gint64 *src);
-extern gpointer InterlockedReadPointer(volatile gpointer *src);
-extern void InterlockedWrite8(volatile gint8 *dst, gint8 val);
-extern void InterlockedWrite16(volatile gint16 *dst, gint16 val);
-extern void InterlockedWrite(volatile gint32 *dst, gint32 val);
-extern void InterlockedWrite64(volatile gint64 *dst, gint64 val);
-extern void InterlockedWritePointer(volatile gpointer *dst, gpointer val);
+extern gint32 mono_atomic_cas_i32(volatile gint32 *dest, gint32 exch, gint32 comp);
+extern gint64 mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp);
+extern gpointer mono_atomic_cas_ptr(volatile gpointer *dest, gpointer exch, gpointer comp);
+extern gint32 mono_atomic_add_i32(volatile gint32 *dest, gint32 add);
+extern gint64 mono_atomic_add_i64(volatile gint64 *dest, gint64 add);
+extern gint32 mono_atomic_inc_i32(volatile gint32 *dest);
+extern gint64 mono_atomic_inc_i64(volatile gint64 *dest);
+extern gint32 mono_atomic_dec_i32(volatile gint32 *dest);
+extern gint64 mono_atomic_dec_i64(volatile gint64 *dest);
+extern gint32 mono_atomic_xchg_i32(volatile gint32 *dest, gint32 exch);
+extern gint64 mono_atomic_xchg_i64(volatile gint64 *dest, gint64 exch);
+extern gpointer mono_atomic_xchg_ptr(volatile gpointer *dest, gpointer exch);
+extern gint32 mono_atomic_xchg_i32Add(volatile gint32 *dest, gint32 add);
+extern gint64 mono_atomic_xchg_i32Add64(volatile gint64 *dest, gint64 add);
+extern gint8 mono_atomic_load_i8(volatile gint8 *src);
+extern gint16 mono_atomic_load_i16(volatile gint16 *src);
+extern gint32 mono_atomic_load_i32(volatile gint32 *src);
+extern gint64 mono_atomic_load_i64(volatile gint64 *src);
+extern gpointer mono_atomic_load_ptr(volatile gpointer *src);
+extern void mono_atomic_store_i8(volatile gint8 *dst, gint8 val);
+extern void mono_atomic_store_i16(volatile gint16 *dst, gint16 val);
+extern void mono_atomic_store_i32(volatile gint32 *dst, gint32 val);
+extern void mono_atomic_store_i64(volatile gint64 *dst, gint64 val);
+extern void mono_atomic_store_ptr(volatile gpointer *dst, gpointer val);
 
 #endif
 
 #if SIZEOF_VOID_P == 4
-#define InterlockedAddP(p,add) InterlockedAdd ((volatile gint32*)p, (gint32)add)
+#define mono_atomic_add_size_t(p,add) mono_atomic_add_i32 ((volatile gint32*)p, (gint32)add)
 #else
-#define InterlockedAddP(p,add) InterlockedAdd64 ((volatile gint64*)p, (gint64)add)
+#define mono_atomic_add_size_t(p,add) mono_atomic_add_i64 ((volatile gint64*)p, (gint64)add)
 #endif
 
 /* The following functions cannot be found on any platform, and thus they can be declared without further existence checks */
 
 static inline void
-InterlockedWriteBool (volatile gboolean *dest, gboolean val)
+mono_atomic_store_bool (volatile gboolean *dest, gboolean val)
 {
 	/* both, gboolean and gint32, are int32_t; the purpose of these casts is to make things explicit */
-	InterlockedWrite ((volatile gint32 *)dest, (gint32)val);
+	mono_atomic_store_i32 ((volatile gint32 *)dest, (gint32)val);
 }
 
 #endif /* _WAPI_ATOMIC_H_ */

--- a/mono/utils/atomic.h
+++ b/mono/utils/atomic.h
@@ -103,13 +103,11 @@ mono_atomic_xchg_ptr (volatile gpointer *dest, gpointer exch)
 	return InterlockedExchangePointer ((PVOID volatile *)dest, (PVOID)exch);
 }
 
-
 static inline gint32
 mono_atomic_fetch_add_i32 (volatile gint32 *dest, gint32 add)
 {
 	return InterlockedExchangeAdd ((LONG volatile *)dest, (LONG)add);
 }
-
 
 static inline gint64
 mono_atomic_fetch_add_i64 (volatile gint64 *dest, gint64 add)
@@ -120,37 +118,60 @@ mono_atomic_fetch_add_i64 (volatile gint64 *dest, gint64 add)
 static inline gint8
 mono_atomic_load_i8 (volatile gint8 *src)
 {
-	return *src;
+	gint8 loaded_value = *src;
+	_ReadWriteBarrier ();
+
+	return loaded_value;
 }
 
 static inline gint16
 mono_atomic_load_i16 (volatile gint16 *src)
 {
-	return *src;
+	gint16 loaded_value = *src;
+	_ReadWriteBarrier ();
+
+	return loaded_value;
 }
 
 static inline gint32 mono_atomic_load_i32 (volatile gint32 *src)
 {
-	return InterlockedCompareExchange ((LONG volatile *)src, 0, 0);
+	gint32 loaded_value = *src;
+	_ReadWriteBarrier ();
+
+	return loaded_value;
 }
 
 static inline gint64
 mono_atomic_load_i64 (volatile gint64 *src)
 {
+#if defined(TARGET_AMD64)
+	gint64 loaded_value = *src;
+	_ReadWriteBarrier ();
+
+	return loaded_value;
+#else
 	return InterlockedCompareExchange64 ((LONG64 volatile *)src, 0, 0);
+#endif
 }
 
 static inline gpointer
 mono_atomic_load_ptr (volatile gpointer *src)
 {
-	return InterlockedCompareExchangePointer ((PVOID volatile *)src, NULL, NULL);
+	gpointer loaded_value = *src;
+	_ReadWriteBarrier ();
+
+	return loaded_value;
 }
 
 static inline void
 mono_atomic_store_i8 (volatile gint8 *dst, gint8 val)
 {
+#if (_MSC_VER >= 1600)
+	InterlockedExchange8 ((CHAR volatile *)dst, (CHAR)val);
+#else
 	*dst = val;
 	mono_memory_barrier ();
+#endif
 }
 
 static inline void

--- a/mono/utils/hazard-pointer.c
+++ b/mono/utils/hazard-pointer.c
@@ -241,7 +241,7 @@ mono_hazard_pointer_save_for_signal_handler (void)
 	 */
 	g_assert (small_id < HAZARD_TABLE_OVERFLOW);
 
-	if (InterlockedCompareExchange (&overflow_busy [small_id], 1, 0) != 0)
+	if (mono_atomic_cas_i32 (&overflow_busy [small_id], 1, 0) != 0)
 		goto search;
 
 	hp_overflow = &hazard_table [small_id];
@@ -327,7 +327,7 @@ mono_thread_hazardous_queue_free (gpointer p, MonoHazardousFreeFunc free_func)
 {
 	DelayedFreeItem item = { p, free_func };
 
-	InterlockedIncrement (&hazardous_pointer_count);
+	mono_atomic_inc_i32 (&hazardous_pointer_count);
 
 	mono_lock_free_array_queue_push (&delayed_free_queue, &item);
 

--- a/mono/utils/lock-free-alloc.c
+++ b/mono/utils/lock-free-alloc.c
@@ -171,10 +171,10 @@ desc_alloc (MonoMemAccountType type)
 	for (;;) {
 		gboolean success;
 
-		desc = (Descriptor *) mono_get_hazardous_pointer ((gpointer * volatile)&desc_avail, hp, 1);
+		desc = (Descriptor *) mono_get_hazardous_pointer ((volatile gpointer *)&desc_avail, hp, 1);
 		if (desc) {
 			Descriptor *next = desc->next;
-			success = (mono_atomic_cas_ptr ((gpointer * volatile)&desc_avail, next, desc) == desc);
+			success = (mono_atomic_cas_ptr ((volatile gpointer *)&desc_avail, next, desc) == desc);
 		} else {
 			size_t desc_size = sizeof (Descriptor);
 			Descriptor *d;
@@ -193,7 +193,7 @@ desc_alloc (MonoMemAccountType type)
 
 			mono_memory_write_barrier ();
 
-			success = (mono_atomic_cas_ptr ((gpointer * volatile)&desc_avail, desc->next, NULL) == NULL);
+			success = (mono_atomic_cas_ptr ((volatile gpointer *)&desc_avail, desc->next, NULL) == NULL);
 
 			if (!success)
 				mono_vfree (desc, desc_size * NUM_DESC_BATCH, type);
@@ -224,7 +224,7 @@ desc_enqueue_avail (gpointer _desc)
 		old_head = desc_avail;
 		desc->next = old_head;
 		mono_memory_write_barrier ();
-	} while (mono_atomic_cas_ptr ((gpointer * volatile)&desc_avail, desc, old_head) != old_head);
+	} while (mono_atomic_cas_ptr ((volatile gpointer *)&desc_avail, desc, old_head) != old_head);
 }
 
 static void
@@ -343,7 +343,7 @@ alloc_from_active_or_partial (MonoLockFreeAllocator *heap)
  retry:
 	desc = heap->active;
 	if (desc) {
-		if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, NULL, desc) != desc)
+		if (mono_atomic_cas_ptr ((volatile gpointer *)&heap->active, NULL, desc) != desc)
 			goto retry;
 	} else {
 		desc = heap_get_partial (heap);
@@ -380,7 +380,7 @@ alloc_from_active_or_partial (MonoLockFreeAllocator *heap)
 
 	/* If the desc is partial we have to give it back. */
 	if (new_anchor.data.state == STATE_PARTIAL) {
-		if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
+		if (mono_atomic_cas_ptr ((volatile gpointer *)&heap->active, desc, NULL) != NULL)
 			heap_put_partial (desc);
 	}
 
@@ -418,7 +418,7 @@ alloc_from_new_sb (MonoLockFreeAllocator *heap)
 	mono_memory_write_barrier ();
 
 	/* Make it active or free it again. */
-	if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, desc, NULL) == NULL) {
+	if (mono_atomic_cas_ptr ((volatile gpointer *)&heap->active, desc, NULL) == NULL) {
 		return desc->sb;
 	} else {
 		desc->anchor.data.state = STATE_EMPTY;
@@ -477,7 +477,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 	if (new_anchor.data.state == STATE_EMPTY) {
 		g_assert (old_anchor.data.state != STATE_EMPTY);
 
-		if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, NULL, desc) == desc) {
+		if (mono_atomic_cas_ptr ((volatile gpointer *)&heap->active, NULL, desc) == desc) {
 			/*
 			 * We own desc, check if it's still empty, in which case we retire it.
 			 * If it's partial we need to put it back either on the active slot or
@@ -486,7 +486,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 			if (desc->anchor.data.state == STATE_EMPTY) {
 				desc_retire (desc);
 			} else if (desc->anchor.data.state == STATE_PARTIAL) {
-				if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
+				if (mono_atomic_cas_ptr ((volatile gpointer *)&heap->active, desc, NULL) != NULL)
 					heap_put_partial (desc);
 
 			}
@@ -505,7 +505,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 
 		g_assert (new_anchor.data.state == STATE_PARTIAL);
 
-		if (mono_atomic_cas_ptr ((gpointer * volatile)&desc->heap->active, desc, NULL) != NULL)
+		if (mono_atomic_cas_ptr ((volatile gpointer *)&desc->heap->active, desc, NULL) != NULL)
 			heap_put_partial (desc);
 	}
 }

--- a/mono/utils/lock-free-alloc.c
+++ b/mono/utils/lock-free-alloc.c
@@ -174,7 +174,7 @@ desc_alloc (MonoMemAccountType type)
 		desc = (Descriptor *) mono_get_hazardous_pointer ((gpointer * volatile)&desc_avail, hp, 1);
 		if (desc) {
 			Descriptor *next = desc->next;
-			success = (InterlockedCompareExchangePointer ((gpointer * volatile)&desc_avail, next, desc) == desc);
+			success = (mono_atomic_cas_ptr ((gpointer * volatile)&desc_avail, next, desc) == desc);
 		} else {
 			size_t desc_size = sizeof (Descriptor);
 			Descriptor *d;
@@ -193,7 +193,7 @@ desc_alloc (MonoMemAccountType type)
 
 			mono_memory_write_barrier ();
 
-			success = (InterlockedCompareExchangePointer ((gpointer * volatile)&desc_avail, desc->next, NULL) == NULL);
+			success = (mono_atomic_cas_ptr ((gpointer * volatile)&desc_avail, desc->next, NULL) == NULL);
 
 			if (!success)
 				mono_vfree (desc, desc_size * NUM_DESC_BATCH, type);
@@ -224,7 +224,7 @@ desc_enqueue_avail (gpointer _desc)
 		old_head = desc_avail;
 		desc->next = old_head;
 		mono_memory_write_barrier ();
-	} while (InterlockedCompareExchangePointer ((gpointer * volatile)&desc_avail, desc, old_head) != old_head);
+	} while (mono_atomic_cas_ptr ((gpointer * volatile)&desc_avail, desc, old_head) != old_head);
 }
 
 static void
@@ -330,7 +330,7 @@ set_anchor (Descriptor *desc, Anchor old_anchor, Anchor new_anchor)
 	if (old_anchor.data.state == STATE_EMPTY)
 		g_assert (new_anchor.data.state == STATE_EMPTY);
 
-	return InterlockedCompareExchange (&desc->anchor.value, new_anchor.value, old_anchor.value) == old_anchor.value;
+	return mono_atomic_cas_i32 (&desc->anchor.value, new_anchor.value, old_anchor.value) == old_anchor.value;
 }
 
 static gpointer
@@ -343,7 +343,7 @@ alloc_from_active_or_partial (MonoLockFreeAllocator *heap)
  retry:
 	desc = heap->active;
 	if (desc) {
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, NULL, desc) != desc)
+		if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, NULL, desc) != desc)
 			goto retry;
 	} else {
 		desc = heap_get_partial (heap);
@@ -380,7 +380,7 @@ alloc_from_active_or_partial (MonoLockFreeAllocator *heap)
 
 	/* If the desc is partial we have to give it back. */
 	if (new_anchor.data.state == STATE_PARTIAL) {
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
+		if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
 			heap_put_partial (desc);
 	}
 
@@ -418,7 +418,7 @@ alloc_from_new_sb (MonoLockFreeAllocator *heap)
 	mono_memory_write_barrier ();
 
 	/* Make it active or free it again. */
-	if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, desc, NULL) == NULL) {
+	if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, desc, NULL) == NULL) {
 		return desc->sb;
 	} else {
 		desc->anchor.data.state = STATE_EMPTY;
@@ -477,7 +477,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 	if (new_anchor.data.state == STATE_EMPTY) {
 		g_assert (old_anchor.data.state != STATE_EMPTY);
 
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, NULL, desc) == desc) {
+		if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, NULL, desc) == desc) {
 			/*
 			 * We own desc, check if it's still empty, in which case we retire it.
 			 * If it's partial we need to put it back either on the active slot or
@@ -486,7 +486,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 			if (desc->anchor.data.state == STATE_EMPTY) {
 				desc_retire (desc);
 			} else if (desc->anchor.data.state == STATE_PARTIAL) {
-				if (InterlockedCompareExchangePointer ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
+				if (mono_atomic_cas_ptr ((gpointer * volatile)&heap->active, desc, NULL) != NULL)
 					heap_put_partial (desc);
 
 			}
@@ -505,7 +505,7 @@ mono_lock_free_free (gpointer ptr, size_t block_size)
 
 		g_assert (new_anchor.data.state == STATE_PARTIAL);
 
-		if (InterlockedCompareExchangePointer ((gpointer * volatile)&desc->heap->active, desc, NULL) != NULL)
+		if (mono_atomic_cas_ptr ((gpointer * volatile)&desc->heap->active, desc, NULL) != NULL)
 			heap_put_partial (desc);
 	}
 }

--- a/mono/utils/lock-free-queue.c
+++ b/mono/utils/lock-free-queue.c
@@ -156,11 +156,11 @@ mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node)
 				 * might append to a node that isn't
 				 * in the queue anymore here.
 				 */
-				if (InterlockedCompareExchangePointer ((gpointer volatile*)&tail->next, node, END_MARKER) == END_MARKER)
+				if (mono_atomic_cas_ptr ((gpointer volatile*)&tail->next, node, END_MARKER) == END_MARKER)
 					break;
 			} else {
 				/* Try to advance tail */
-				InterlockedCompareExchangePointer ((gpointer volatile*)&q->tail, next, tail);
+				mono_atomic_cas_ptr ((gpointer volatile*)&q->tail, next, tail);
 			}
 		}
 
@@ -169,7 +169,7 @@ mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node)
 	}
 
 	/* Try to advance tail */
-	InterlockedCompareExchangePointer ((gpointer volatile*)&q->tail, node, tail);
+	mono_atomic_cas_ptr ((gpointer volatile*)&q->tail, node, tail);
 
 	mono_memory_write_barrier ();
 	mono_hazard_pointer_clear (hp, 0);
@@ -195,7 +195,7 @@ get_dummy (MonoLockFreeQueue *q)
 		if (dummy->in_use)
 			continue;
 
-		if (InterlockedCompareExchange (&dummy->in_use, 1, 0) == 0)
+		if (mono_atomic_cas_i32 (&dummy->in_use, 1, 0) == 0)
 			return dummy;
 	}
 	return NULL;
@@ -219,7 +219,7 @@ try_reenqueue_dummy (MonoLockFreeQueue *q)
 	if (!dummy)
 		return FALSE;
 
-	if (InterlockedCompareExchange (&q->has_dummy, 1, 0) != 0) {
+	if (mono_atomic_cas_i32 (&q->has_dummy, 1, 0) != 0) {
 		dummy->in_use = 0;
 		return FALSE;
 	}
@@ -275,11 +275,11 @@ mono_lock_free_queue_dequeue (MonoLockFreeQueue *q)
 				}
 
 				/* Try to advance tail */
-				InterlockedCompareExchangePointer ((gpointer volatile*)&q->tail, next, tail);
+				mono_atomic_cas_ptr ((gpointer volatile*)&q->tail, next, tail);
 			} else {
 				g_assert (next != END_MARKER);
 				/* Try to dequeue head */
-				if (InterlockedCompareExchangePointer ((gpointer volatile*)&q->head, next, head) == head)
+				if (mono_atomic_cas_ptr ((gpointer volatile*)&q->head, next, head) == head)
 					break;
 			}
 		}

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -77,6 +77,16 @@ typedef SSIZE_T ssize_t;
 #define MONO_EMPTY_SOURCE_FILE(x)
 #endif
 
+#ifdef _MSC_VER
+#define MONO_PRAGMA_WARNING_PUSH() __pragma(warning (push))
+#define MONO_PRAGMA_WARNING_DISABLE(x) __pragma(warning (disable:x))
+#define MONO_PRAGMA_WARNING_POP() __pragma(warning (pop))
+#else
+#define MONO_PRAGMA_WARNING_PUSH()
+#define MONO_PRAGMA_WARNING_DISABLE(x)
+#define MONO_PRAGMA_WARNING_POP()
+#endif
+
 #if !defined(_MSC_VER) && !defined(HOST_SOLARIS) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(MONOTOUCH) && HAVE_VISIBILITY_HIDDEN
 #if MONO_LLVM_LOADED
 #define MONO_LLVM_INTERNAL MONO_API

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -148,7 +148,7 @@ mono_lls_filter_accept_all (gpointer elem)
 					mono_hazard_pointer_set (hp__, 2, cur__); \
 				} else { \
 					next__ = (MonoLinkedListSetNode *) mono_lls_pointer_unmask (next__); \
-					if (InterlockedCompareExchangePointer ((volatile gpointer *) prev__, next__, cur__) == cur__) { \
+					if (mono_atomic_cas_ptr ((volatile gpointer *) prev__, next__, cur__) == cur__) { \
 						mono_memory_write_barrier (); \
 						mono_hazard_pointer_clear (hp__, 1); \
 						if (list__->free_node_func) { \

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -88,8 +88,8 @@ static size_t alloc_limit;
 void
 account_mem (MonoMemAccountType type, ssize_t size)
 {
-	InterlockedAddP (&allocation_count [type], size);
-	InterlockedAddP (&total_allocation_count, size);
+	mono_atomic_add_size_t (&allocation_count [type], size);
+	mono_atomic_add_size_t (&total_allocation_count, size);
 }
 
 void

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -88,8 +88,8 @@ static size_t alloc_limit;
 void
 account_mem (MonoMemAccountType type, ssize_t size)
 {
-	mono_atomic_add_size_t (&allocation_count [type], size);
-	mono_atomic_add_size_t (&total_allocation_count, size);
+	mono_atomic_fetch_add_word (&allocation_count [type], size);
+	mono_atomic_fetch_add_word (&total_allocation_count, size);
 }
 
 void

--- a/mono/utils/mono-rand.c
+++ b/mono/utils/mono-rand.c
@@ -122,7 +122,7 @@ gboolean
 mono_rand_open (void)
 {
 	static gint32 status = 0;
-	if (status != 0 || InterlockedCompareExchange (&status, 1, 0) != 0) {
+	if (status != 0 || mono_atomic_cas_i32 (&status, 1, 0) != 0) {
 		while (status != 2)
 			mono_thread_info_yield ();
 		return TRUE;
@@ -201,7 +201,7 @@ gboolean
 mono_rand_open (void)
 {
 	static gint32 status = 0;
-	if (status != 0 || InterlockedCompareExchange (&status, 1, 0) != 0) {
+	if (status != 0 || mono_atomic_cas_i32 (&status, 1, 0) != 0) {
 		while (status != 2)
 			mono_thread_info_yield ();
 		return TRUE;

--- a/mono/utils/mono-threads-debug.h
+++ b/mono/utils/mono-threads-debug.h
@@ -9,7 +9,7 @@
 #define MOSTLY_ASYNC_SAFE_PRINTF(...) do { \
 	char __buff[1024];	__buff [0] = '\0'; \
 	g_snprintf (__buff, sizeof (__buff), __VA_ARGS__);	\
-	write (1, __buff, strlen (__buff));	\
+	write (1, __buff, (guint32)strlen (__buff));	\
 } while (0)
 
 #if 1

--- a/mono/utils/os-event-unix.c
+++ b/mono/utils/os-event-unix.c
@@ -107,7 +107,7 @@ signal_and_unref (gpointer user_data)
 	data = (OSEventWaitData*) user_data;
 
 	mono_os_event_set (&data->event);
-	if (InterlockedDecrement ((gint32*) &data->ref) == 0) {
+	if (mono_atomic_dec_i32 ((gint32*) &data->ref) == 0) {
 		mono_os_event_destroy (&data->event);
 		g_free (data);
 	}
@@ -220,7 +220,7 @@ done:
 	if (alertable) {
 		mono_thread_info_uninstall_interrupt (&alerted);
 		if (alerted) {
-			if (InterlockedDecrement ((gint32*) &data->ref) == 0) {
+			if (mono_atomic_dec_i32 ((gint32*) &data->ref) == 0) {
 				mono_os_event_destroy (&data->event);
 				g_free (data);
 			}

--- a/mono/utils/refcount.h
+++ b/mono/utils/refcount.h
@@ -49,7 +49,7 @@ mono_refcount_tryincrement (MonoRefCount *refcount)
 			return FALSE;
 
 		newref = oldref + 1;
-	} while (mono_atomic_cas_i32 ((gint32*) &refcount->ref, newref, oldref) != oldref);
+	} while (mono_atomic_cas_i32 ((gint32*) &refcount->ref, (gint32)newref, (gint32)oldref) != (gint32)oldref);
 
 	return TRUE;
 }
@@ -74,7 +74,7 @@ mono_refcount_decrement (MonoRefCount *refcount)
 			g_error ("%s: cannot decrement a ref with value 0", __func__);
 
 		newref = oldref - 1;
-	} while (mono_atomic_cas_i32 ((gint32*) &refcount->ref, newref, oldref) != oldref);
+	} while (mono_atomic_cas_i32 ((gint32*) &refcount->ref, (gint32)newref, (gint32)oldref) != (gint32)oldref);
 
 	if (newref == 0 && refcount->destructor)
 		refcount->destructor ((gpointer) refcount);

--- a/mono/utils/refcount.h
+++ b/mono/utils/refcount.h
@@ -49,7 +49,7 @@ mono_refcount_tryincrement (MonoRefCount *refcount)
 			return FALSE;
 
 		newref = oldref + 1;
-	} while (InterlockedCompareExchange ((gint32*) &refcount->ref, newref, oldref) != oldref);
+	} while (mono_atomic_cas_i32 ((gint32*) &refcount->ref, newref, oldref) != oldref);
 
 	return TRUE;
 }
@@ -74,7 +74,7 @@ mono_refcount_decrement (MonoRefCount *refcount)
 			g_error ("%s: cannot decrement a ref with value 0", __func__);
 
 		newref = oldref - 1;
-	} while (InterlockedCompareExchange ((gint32*) &refcount->ref, newref, oldref) != oldref);
+	} while (mono_atomic_cas_i32 ((gint32*) &refcount->ref, newref, oldref) != oldref);
 
 	if (newref == 0 && refcount->destructor)
 		refcount->destructor ((gpointer) refcount);

--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -93,8 +93,8 @@
     <ClCompile>
       <DllExportPreprocessorDefinitions>MONO_DLL_EXPORT</DllExportPreprocessorDefinitions>
       <DllImportPreprocessorDefinitions>MONO_DLL_IMPORT</DllImportPreprocessorDefinitions>
-      <PreprocessorDefinitions>__default_codegen__;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;HAVE_CONFIG_H;GC_NOT_DLL;WIN32_THREADS;WINVER=0x0600;_WIN32_WINNT=0x0600;_WIN32_IE=0x0501;_UNICODE;UNICODE;FD_SETSIZE=1024;%(PreprocessorDefinitions);</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4273;4005</DisableSpecificWarnings>
+      <PreprocessorDefinitions>__default_codegen__;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;HAVE_CONFIG_H;GC_NOT_DLL;WIN32_THREADS;WINVER=0x0600;_WIN32_WINNT=0x0600;_WIN32_IE=0x0501;_UNICODE;UNICODE;FD_SETSIZE=1024;NVALGRIND;%(PreprocessorDefinitions);</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4273;4005;4152;4221;4214;4204;4201</DisableSpecificWarnings>
       <RuntimeLibrary>$(MONO_C_RUNTIME)</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/support/signal.c
+++ b/support/signal.c
@@ -115,12 +115,12 @@ int Mono_Posix_FromRealTimeSignum (int offset, int *r)
 // We can still use atomic.h because that's all inline functions--
 // unless WAPI_NO_ATOMIC_ASM is defined, in which case atomic.h calls linked functions.
 #ifndef WAPI_NO_ATOMIC_ASM
-	#define mph_int_get(p)     InterlockedExchangeAdd ((p), 0)
-	#define mph_int_inc(p)     InterlockedIncrement ((p))
-	#define mph_int_dec_test(p)     (InterlockedDecrement ((p)) == 0)
-	#define mph_int_set(p,n) InterlockedExchange ((p), (n))
+	#define mph_int_get(p)     mono_atomic_xchg_add_i32 ((p), 0)
+	#define mph_int_inc(p)     mono_atomic_inc_i32 ((p))
+	#define mph_int_dec_test(p)     (mono_atomic_dec_i32 ((p)) == 0)
+	#define mph_int_set(p,n) mono_atomic_xchg_i32 ((p), (n))
 	// Pointer, original, new
-	#define mph_int_test_and_set(p,o,n) (o == InterlockedCompareExchange ((p), (n), (o)))
+	#define mph_int_test_and_set(p,o,n) (o == mono_atomic_cas_i32 ((p), (n), (o)))
 #elif GLIB_CHECK_VERSION(2,4,0)
 	#define mph_int_get(p) g_atomic_int_get ((p))
  	#define mph_int_inc(p) do {g_atomic_int_inc ((p));} while (0)

--- a/support/signal.c
+++ b/support/signal.c
@@ -115,7 +115,7 @@ int Mono_Posix_FromRealTimeSignum (int offset, int *r)
 // We can still use atomic.h because that's all inline functions--
 // unless WAPI_NO_ATOMIC_ASM is defined, in which case atomic.h calls linked functions.
 #ifndef WAPI_NO_ATOMIC_ASM
-	#define mph_int_get(p)     mono_atomic_xchg_add_i32 ((p), 0)
+	#define mph_int_get(p)     mono_atomic_fetch_add_i32 ((p), 0)
 	#define mph_int_inc(p)     mono_atomic_inc_i32 ((p))
 	#define mph_int_dec_test(p)     (mono_atomic_dec_i32 ((p)) == 0)
 	#define mph_int_set(p,n) mono_atomic_xchg_i32 ((p), (n))


### PR DESCRIPTION
There is currently a small mismatch between the signatures used by atomic.h interlocked functions and corresponding Win32 functions. This will trigger a bunch of warnings when building with higher log level. On none desktop Windows platforms, even compile errors.

Current design has issues on none desktop Windows platforms where incorrect interlocked  implementation will be picked up when interlocked methods are real functions instead of defines.

This PR makes sure new naming in atomic.h is used by the runtime not colliding with the Interlocked* OS naming on Windows.

Commit eliminates a couple of additional warnings as well. On Windows MSVC build it disables
some of the extension warnings, like C4152, C4221, C4214, C4204, C4201.

This PR extends https://github.com/mono/mono/pull/5723 and obsoletes, https://github.com/mono/mono/pull/5707.