### PR TITLE
[msvc] Fix MONO_CORLIB_VERSION to match configure.ac

### DIFF
--- a/msvc/winsetup.bat
+++ b/msvc/winsetup.bat
@@ -18,7 +18,7 @@ IF NOT %ERRORLEVEL% == 0 (
 	ECHO copy %WIN_CONFIG_H% %CONFIG_H%
 	copy %WIN_CONFIG_H% %CONFIG_H%
 	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "(Get-Content %CONFIG_H%) -replace '#MONO_VERSION#', (Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value | Set-Content %CONFIG_H%" 2>&1
-	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "$mono_version=[int[]](Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value.Split('.'); $corlib_counter=[int](Select-String -path %CONFIGURE_AC% -pattern 'MONO_CORLIB_COUNTER=(.*)').Matches[0].Groups[1].Value; (Get-Content %CONFIG_H%) -replace '#MONO_CORLIB_VERSION#',('1{0:00}{1:00}{2:00}{3:000}' -f $mono_version[0],$mono_version[1],$mono_version[2],$corlib_counter) | Set-Content %CONFIG_H%" 2>&1
+	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "$mono_version=[int[]](Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value.Split('.'); $corlib_counter=[int](Select-String -path %CONFIGURE_AC% -pattern 'MONO_CORLIB_COUNTER=(.*)').Matches[0].Groups[1].Value; (Get-Content %CONFIG_H%) -replace '#MONO_CORLIB_VERSION#',('1{0:00}{1:00}{2:00}{3:000}' -f $mono_version[0],$mono_version[1],0,$corlib_counter) | Set-Content %CONFIG_H%" 2>&1
 )
 
 SET VERSION_CONTENT="#define FULL_VERSION \"Visual Studio built mono\""


### PR DESCRIPTION
When I simplified MONO_CORLIB_VERSION to only include major.minor instead of major.minor.build in https://github.com/mono/mono/pull/5449 I forgot to apply the same change to the msvc copy of that logic.