### PR TITLE
[tests] Remove test from runtime-invoke.cs

### DIFF
--- a/mono/tests/runtime-invoke.cs
+++ b/mono/tests/runtime-invoke.cs
@@ -29,11 +29,6 @@ enum Enum2
 	D
 }
 
-struct AStruct {
-	public int a1, a2, a3, a4, a5, a6, a7, a8, a9, a10;
-	public int a11, a12, a13, a14, a15, a16, a17, a18, a19, a20;
-}
-
 class Tests
 {
 	public static Enum1 return_enum1 () {
@@ -50,10 +45,6 @@ class Tests
 
 	public static ulong return_ulong () {
 		return UInt64.MaxValue - 5;
-	}
-
-	public static object return_t<T> (T t) {
-		return (object)t;
 	}
 
 	static int Main (string[] args)
@@ -288,19 +279,4 @@ class Tests
         else
             return 1;
     }
-
-	public static int test_0_large_arg ()
-	{
-		var arg = new AStruct ();
-		arg.a1 = 1;
-		arg.a2 = 2;
-		arg.a3 = 3;
-		arg.a20 = 20;
-		var res = typeof (Tests).GetMethod ("return_t").MakeGenericMethod (new Type [] { typeof (AStruct) }).Invoke (null, new object [] { arg });
-		var arg2 = (AStruct)res;
-		if (arg2.a20 == 20)
-			return 0;
-		else
-			return 1;
-	}
 }


### PR DESCRIPTION
It was added in a54603a60449865979f6a1f7ad97b7997548c0c8 but fails on ARM FullAOT at the moment: https://jenkins.mono-project.com/job/test-mono-mainline-fullaot/label=debian-8-armhf/461/testReport/MonoTests/runtime/runtime_invoke_exe/

According to @vargaz the test doesn't run on all platforms yet so we should just revert it.