### PR TITLE
[acceptance-tests] Reenable ms-test-suite test after Mono bug was fixed

### DIFF
--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -18,7 +18,7 @@
   {
     "name": "ms-test-suite", 
     "url": "git@github.com:xamarin/ms-test-suite.git", 
-    "rev": "25f495326e141163d59e52ef499227a2f38fe036", 
+    "rev": "67f29dfc0741b5311dd746c75760963a2915e648", 
     "remote-branch": "origin/master", 
     "branch": "master", 
     "directory": "ms-test-suite"


### PR DESCRIPTION
Fix went in with https://github.com/mono/mono/pull/5751