### PR TITLE
[System.URI] Don't reset host string processing on Unicode paths. Fix…

### DIFF
--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -2071,5 +2071,16 @@ namespace MonoTests.System
 			var uri = new Uri ("https://_foo/bar.html");
 			Assert.AreEqual ("https", uri.Scheme);
 		}
+
+		[Test]
+		public void ImplicitUnixFileWithUnicodeGetAbsoluleUri ()
+		{
+			if (isWin32)
+				Assert.Ignore ();
+
+			string escFilePath = "/Users/Текст.txt";
+			string escUrl = new Uri (escFilePath, UriKind.Absolute).AbsoluteUri;
+			Assert.AreEqual ("file:///Users/%D0%A2%D0%B5%D0%BA%D1%81%D1%82.txt", escUrl);
+		}
 	}
 }

--- a/mcs/class/referencesource/System/net/System/URI.cs
+++ b/mcs/class/referencesource/System/net/System/URI.cs
@@ -3969,13 +3969,6 @@ namespace System {
                 if (hasUnicode && iriParsing && hostNotUnicodeNormalized){
                     flags |= Flags.HostUnicodeNormalized;// no host
 
-#if MONO
-                    // I am not certain this is the best fix but for Unix implicit paths with
-                    // unicode characters the host must be valid (null or non-empty) as
-                    // CreateUriInfo assumes. This should happen only for paths like /foo/path-with-unicode
-                    if (newHost.Length == 0 && (flags & Flags.BasicHostType) != 0)
-                        newHost = null;
-#endif
                 }
 
                  return idx;


### PR DESCRIPTION
…es #56003

https://bugzilla.xamarin.com/show_bug.cgi?id=56003

This may not be the final fix; the Mono-only workaround was introduced in b5dc9a4951bd35b61b29faa4df93bca3c31bfa3e to fix a crash with Unicode paths in TryCreate. However the test case for that issue now succeeds without the workaround.