### PR TITLE
Fix bug #58400 - incorrect implementation of LocalPath for file URLs

### DIFF
--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -502,20 +502,14 @@ namespace MonoTests.System
 
 			uri = new Uri ("file:////////cygwin/tmp/hello.txt");
 			Assert.AreEqual ("file://cygwin/tmp/hello.txt", uri.ToString (), "#3a");
-			if (isWin32)
-				Assert.AreEqual ("\\\\cygwin\\tmp\\hello.txt", uri.LocalPath, "#3b win32");
-			else
-				Assert.AreEqual ("/tmp/hello.txt", uri.LocalPath, "#3b *nix");
+			Assert.AreEqual ("\\\\cygwin\\tmp\\hello.txt", uri.LocalPath, "#3b win32");
 			Assert.AreEqual ("file", uri.Scheme, "#3c");
 			Assert.AreEqual ("cygwin", uri.Host, "#3d");
 			Assert.AreEqual ("/tmp/hello.txt", uri.AbsolutePath, "#3e");
 
 			uri = new Uri ("file://mymachine/cygwin/tmp/hello.txt");
 			Assert.AreEqual ("file://mymachine/cygwin/tmp/hello.txt", uri.ToString (), "#4a");
-			if (isWin32)
-				Assert.AreEqual ("\\\\mymachine\\cygwin\\tmp\\hello.txt", uri.LocalPath, "#4b win32");
-			else
-				Assert.AreEqual ("/cygwin/tmp/hello.txt", uri.LocalPath, "#4b *nix");
+			Assert.AreEqual ("\\\\mymachine\\cygwin\\tmp\\hello.txt", uri.LocalPath, "#4b win32");
 			Assert.AreEqual ("file", uri.Scheme, "#4c");
 			Assert.AreEqual ("mymachine", uri.Host, "#4d");
 			Assert.AreEqual ("/cygwin/tmp/hello.txt", uri.AbsolutePath, "#4e");
@@ -537,10 +531,7 @@ namespace MonoTests.System
 			Assert.AreEqual ("/", uri.AbsolutePath, "#6e");
 			Assert.AreEqual ("/", uri.PathAndQuery, "#6f");
 			Assert.AreEqual ("file://one_file.txt/", uri.GetLeftPart (UriPartial.Path), "#6g");
-			if (isWin32)
-				Assert.AreEqual ("\\\\one_file.txt", uri.LocalPath, "#6b");
-			else
-				Assert.AreEqual ("/", uri.LocalPath, "#6b");
+			Assert.AreEqual ("\\\\one_file.txt", uri.LocalPath, "#6b");
 			Assert.AreEqual ("file", uri.Scheme, "#6c");
 			Assert.AreEqual ("one_file.txt", uri.Host, "#6d");
 
@@ -551,10 +542,7 @@ namespace MonoTests.System
 			Assert.AreEqual ("/", uri.AbsolutePath, "#7e");
 			Assert.AreEqual ("/", uri.PathAndQuery, "#7f");
 			Assert.AreEqual ("file://one_file.txt/", uri.GetLeftPart (UriPartial.Path), "#7g");
-			if (isWin32)
-				Assert.AreEqual ("\\\\one_file.txt\\", uri.LocalPath, "#7b");
-			else
-				Assert.AreEqual ("/", uri.LocalPath, "#7b");
+			Assert.AreEqual ("\\\\one_file.txt\\", uri.LocalPath, "#7b");
 			Assert.AreEqual ("file", uri.Scheme, "#7c");
 			Assert.AreEqual ("one_file.txt", uri.Host, "#7d");
 		}

--- a/mcs/class/System/Test/System/UriTest2.cs
+++ b/mcs/class/System/Test/System/UriTest2.cs
@@ -875,7 +875,7 @@ TextWriter sw = Console.Out;
 			if (IriParsing)	{
 				Assert.AreEqual ("/dir/subdir/file", uri.AbsolutePath, "AbsolutePath");
 				Assert.AreEqual ("file://host/dir/subdir/file?this-is-not-a-query#but-this-is-a-fragment", uri.AbsoluteUri, "AbsoluteUri");
-				Assert.AreEqual (isWin32 ? "\\\\host\\dir\\subdir\\file" : "/dir/subdir/file", uri.LocalPath, "LocalPath");
+				Assert.AreEqual ("\\\\host\\dir\\subdir\\file", uri.LocalPath, "LocalPath");
 				Assert.AreEqual ("/dir/subdir/file?this-is-not-a-query", uri.PathAndQuery, "PathAndQuery");
 				Assert.AreEqual ("?this-is-not-a-query", uri.Query, "Query");
 				Assert.AreEqual ("file", uri.Segments [3], "Segments [3]");

--- a/mcs/class/System/Test/System/UriTest3.cs
+++ b/mcs/class/System/Test/System/UriTest3.cs
@@ -701,28 +701,27 @@ namespace MonoTests.System
         [Test]
         public static void Test_LocalPath_Bug58400()
         {
-            var uriAndExpected = new global::System.Collections.Generic.Dictionary<string, string> 
+            var uriAndExpected = new [] 
             {
-                {"file://host/directory/filename", @"\\host\directory\filename"},
-                {"file://host/directory/", @"\\host\directory\"},
-                {"file://host/filename", @"\\host\filename"},
-                {"file://host/", @"\\host\"},
-                {"file://host", @"\\host"},
-                {"file:///directory/filename", "/directory/filename"},
-                {"file:///directory/", "/directory/"},
-                {"file:///filename", "/filename"},
-                {"file:///", "/"},
+                ("file://host/directory/filename", @"\\host\directory\filename"),
+                ("file://host/directory/", @"\\host\directory\"),
+                ("file://host/filename", @"\\host\filename"),
+                ("file://host/", @"\\host\"),
+                ("file://host", @"\\host"),
+                ("file:///directory/filename", "/directory/filename"),
+                ("file:///directory/", "/directory/"),
+                ("file:///filename", "/filename"),
+                ("file:///", "/"),
                 // This is an invalid URI, technically
-                {"file://", "/"},
-	            {"file://////hello/world", @"\\hello\world"},
-            	{"file://hello/////world", @"\\hello\\\\\world"},
+                ("file://", "/"),
+	            ("file://////hello/world", @"\\hello\world"),
+            	("file://hello/////world", @"\\hello\\\\\world"),
             };
 
-            var pairs = global::System.Linq.Enumerable.OrderBy(uriAndExpected, kvp => kvp.Key);
-            foreach (var pair in pairs) 
+            foreach (var tup in uriAndExpected) 
             {
-                var originalUri = pair.Key;
-                var expectedLocalPath = pair.Value;
+                var originalUri = tup.Item1;
+                var expectedLocalPath = tup.Item2;
                 var uri = new Uri (originalUri);
                 var localPath = uri.LocalPath;
 

--- a/mcs/class/System/Test/System/UriTest3.cs
+++ b/mcs/class/System/Test/System/UriTest3.cs
@@ -696,6 +696,39 @@ namespace MonoTests.System
 			type = Uri.CheckHostName ("3.141592653589793238462643383279502884197169399375105820974944592._om");
 			Assert.AreEqual (UriHostNameType.Unknown, type, "DomainLabelLength#3");
 		}
+
+        // https://bugzilla.xamarin.com/show_bug.cgi?id=58400
+        [Test]
+        public static void Test_LocalPath_Bug58400()
+        {
+            var uriAndExpected = new global::System.Collections.Generic.Dictionary<string, string> 
+            {
+                {"file://host/directory/filename", @"\\host\directory\filename"},
+                {"file://host/directory/", @"\\host\directory\"},
+                {"file://host/filename", @"\\host\filename"},
+                {"file://host/", @"\\host\"},
+                {"file://host", @"\\host"},
+                {"file:///directory/filename", "/directory/filename"},
+                {"file:///directory/", "/directory/"},
+                {"file:///filename", "/filename"},
+                {"file:///", "/"},
+                // This is an invalid URI, technically
+                {"file://", "/"},
+	            {"file://////hello/world", @"\\hello\world"},
+            	{"file://hello/////world", @"\\hello\\\\\world"},
+            };
+
+            var pairs = global::System.Linq.Enumerable.OrderBy(uriAndExpected, kvp => kvp.Key);
+            foreach (var pair in pairs) 
+            {
+                var originalUri = pair.Key;
+                var expectedLocalPath = pair.Value;
+                var uri = new Uri (originalUri);
+                var localPath = uri.LocalPath;
+
+                Assert.AreEqual (expectedLocalPath, localPath, originalUri);
+            }
+        }
 	}
 }
 

--- a/mcs/class/referencesource/System/net/System/URI.cs
+++ b/mcs/class/referencesource/System/net/System/URI.cs
@@ -1123,12 +1123,10 @@ namespace System {
 
                 // Do we have a valid local path right in m_string?
                 if (
-                    NotAny(Flags.HostNotCanonical|Flags.PathNotCanonical|Flags.ShouldBeCompressed) && 
+                    NotAny(Flags.HostNotCanonical|Flags.PathNotCanonical|Flags.ShouldBeCompressed)
 #if MONO
                     // This branch drops the host name so we can't use it
-                    !isFileUrlWithHost
-#else
-                    true
+                    && !isFileUrlWithHost
 #endif
                 ) {
 


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=58400

Uri.LocalPath should return a windows-style UNC path (```\\host\dir\filename```) for file URLs that have a hostname in them. Currently we have weird logic to return unix-style paths that intentionally (?) omits the hostname in most cases, which is extremely incorrect. This assumption was baked into some of our automated tests as well. There are a few corner cases involved that need to be handled to match Windows and .NET Core, for example that ```file://localhost/x/y``` is formally equivalent to ```file:///x/y``` in this case.

I considered that it might be more appropriate to try to return linux and OS X specific equivalents, because the MSDN documentation suggests that LocalPath is appropriate for the current OS. But Linux appears to have no UNC path equivalent, and OS X's ```smb://host/x/y``` is a weird and probably not appropriate thing to convert a file URI into. So I decided to just match Windows and .NET Core (on linux) behavior here.