### PR TITLE
[Windows] Fix random failures in sgen stress tests on Windows due to mono_thread_is_gc_unsafe_mode assert.

### DIFF
--- a/mono/mini/mini-darwin.c
+++ b/mono/mini/mini-darwin.c
@@ -95,7 +95,7 @@ mono_runtime_install_handlers (void)
 }
 
 gboolean
-mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info)
+mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, void *sigctx)
 {
 	kern_return_t ret;
 	mach_msg_type_number_t num_state, num_fpstate;

--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -635,7 +635,7 @@ thread_suspend_func (gpointer user_data, void *sigctx, MonoContext *ctx)
 #ifdef TARGET_WIN32
 		return;
 #else
-		res = mono_thread_state_init_from_handle (&tls->unwind_state, tls->info);
+		res = mono_thread_state_init_from_handle (&tls->unwind_state, tls->info, NULL);
 #endif
 	} else {
 		tls->unwind_state.unwind_data [MONO_UNWIND_DATA_LMF] = mono_get_lmf ();

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -887,7 +887,7 @@ exec:
 #if !defined (__MACH__)
 
 gboolean
-mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info)
+mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, void *sigctx)
 {
 	g_error ("Posix systems don't support mono_thread_state_init_from_handle");
 	return FALSE;

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -157,7 +157,7 @@ mono_runtime_cleanup_handlers (void)
 }
 
 gboolean
-mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info)
+mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, void *sigctx)
 {
 	g_error ("WASM systems don't support mono_thread_state_init_from_handle");
 	return FALSE;

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -369,12 +369,11 @@ mono_setup_thread_context(DWORD thread_id, MonoContext *mono_context)
 	CloseHandle (handle);
 	return TRUE;
 }
-#endif /* G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT) */
+#endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 
 gboolean
-mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info)
+mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, void *sigctx)
 {
-	DWORD id = mono_thread_info_get_tid (info);
 	MonoJitTlsData *jit_tls;
 	void *domain;
 	MonoLMF *lmf = NULL;
@@ -385,7 +384,14 @@ mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo 
 	tctx->unwind_data [MONO_UNWIND_DATA_LMF] = NULL;
 	tctx->unwind_data [MONO_UNWIND_DATA_JIT_TLS] = NULL;
 
-	mono_setup_thread_context(id, &tctx->ctx);
+	if (sigctx == NULL) {
+		DWORD id = mono_thread_info_get_tid (info);
+		mono_setup_thread_context (id, &tctx->ctx);
+	} else {
+		g_assert (((CONTEXT *)sigctx)->ContextFlags & CONTEXT_INTEGER);
+		g_assert (((CONTEXT *)sigctx)->ContextFlags & CONTEXT_CONTROL);
+		mono_sigctx_to_monoctx (sigctx, &tctx->ctx);
+	}
 
 	/* mono_set_jit_tls () sets this */
 	jit_tls = mono_thread_info_tls_get (info, TLS_KEY_JIT_TLS);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2892,7 +2892,7 @@ void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data);
 
 gboolean
-mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info);
+mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, /*optional*/ void *sigctx);
 
 
 /* Exception handling */

--- a/mono/utils/mono-threads-mach.c
+++ b/mono/utils/mono-threads-mach.c
@@ -87,7 +87,7 @@ mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interru
 		return TRUE;
 	}
 	info->suspend_can_continue = mono_threads_get_runtime_callbacks ()->
-		thread_state_init_from_handle (&info->thread_saved_state [ASYNC_SUSPEND_STATE_INDEX], info);
+		thread_state_init_from_handle (&info->thread_saved_state [ASYNC_SUSPEND_STATE_INDEX], info, NULL);
 	THREADS_SUSPEND_DEBUG ("thread state %p -> %d\n", (gpointer)(gsize)info->native_handle, ret);
 	if (info->suspend_can_continue) {
 		if (interrupt_kernel)

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -262,7 +262,7 @@ typedef struct {
 typedef struct {
 	void (*setup_async_callback) (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data);
 	gboolean (*thread_state_init_from_sigctx) (MonoThreadUnwindState *state, void *sigctx);
-	gboolean (*thread_state_init_from_handle) (MonoThreadUnwindState *tctx, MonoThreadInfo *info);
+	gboolean (*thread_state_init_from_handle) (MonoThreadUnwindState *tctx, MonoThreadInfo *info, /*optional*/ void *sigctx);
 	void (*thread_state_init) (MonoThreadUnwindState *tctx);
 } MonoThreadInfoRuntimeCallbacks;
 


### PR DESCRIPTION
Random failures in Jenkins tests, more frequent in sgen stress test due to the following assert:

Assertion at ..\mono\mini\mini-trampolines.c:842, condition `mono_thread_is_gc_unsafe_mode ()' not met

When investigating this a little deeper revealed a race when switching thread states from ASYNC_SUSPENDED to RUNNING. The assert would fire on a running thread due to having a ASYNC_SUSPENDED state, but when thread state was inspected in debugger it was showing correct RUNNING state.

Looking through the code indicated that this should not be possible, since caller would suspend thread before setting ASYNC_SUSPENDED using atomic ops and set back to RUNNING before thread was resumed using atomic ops.

So based on this the only way to get wrong state and fire assert would be if the thread was not immediately suspended when Win32 SuspendThread API returned, and read the ASYNC_SUSPEND value before really suspended by the kernel. Nothing in the API documentation indicates that the SuspendThread actually behaves this way, but current implementation assumes that SuspendThread actually suspends the thread and only return when no more user mode code is executed by the thread.

Turns out that this is not 100% accurate and SuspendThread is just a suspend request to the scheduler, so when SuspendThread call returns the “suspended” thread might still execute user mode code and that breaks the assumption in current implementation opening up for the observed race condition triggering the assert. This behavior of SuspendThread has been described in this article, https://blogs.msdn.microsoft.com/oldnewthing/20150205-00/?p=44743/.

The fix is to make sure thread is really suspended before continue executing. The way to do so is by requesting the threads context right away after SuspendThread call returns. This will force the kernel to wait until thread has really been suspended since it need to return back a valid context record to the caller.

Fix also includes a smaller optimization. Since we retrieved the context later in the execution of mono_threads_suspend_begin_async_suspend, the fix opens the possibility to pass a sigctx to thread_state_init_from_handle and then the implementation of thread_state_init_from_handle
could use passed sigctx in its work instead of request it again (if passed in). Since we need to get the context early on Windows, we could reuse that, passing it into thread_state_init_from_handle aving us from several unnecessary kernel mode context switches otherwise needed to open thread and get thread context. NOTE, this optimization is only used on Windows and other platforms will use default behavior.