### PR TITLE
[Mono.Posix] Use TestHelper code from monodroid repo

### DIFF
--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Android/TestHelper.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Android/TestHelper.cs
@@ -1,11 +1,31 @@
+using System;
+using System.Reflection;
+
+using NUnit.Framework;
+
 namespace Mono.Unix.Android
 {
-	// Another version of this class is used by the Xamarin.Android test suite
-	// It is here to keep the test code #ifdef free as much as possible
 	public class TestHelper
 	{
+		static bool areRealTimeSignalsSafe;
+
+		static TestHelper ()
+		{
+#if MONODROID
+			var method = typeof (Mono.Unix.Native.NativeConvert).Assembly.GetType ("Mono.Unix.Android.AndroidUtils").GetMethod ("AreRealTimeSignalsSafe", BindingFlags.Public | BindingFlags.Static);
+			areRealTimeSignalsSafe = (bool)method.Invoke (null, null);
+#else
+			areRealTimeSignalsSafe = true;
+#endif
+		}
+
 		public static bool CanUseRealTimeSignals ()
 		{
+			if (!areRealTimeSignalsSafe) {
+				Assert.Ignore ("Real-time signals aren't supported on this Android architecture");
+				return false;
+			}
+
 			return true;
 		}
 	}


### PR DESCRIPTION
We need this because XA is now starting to use the test assemblies we build in the Mono repo instead of using the .cs source directly and this would conflict.