### PR TITLE
[corlib] Fix SRE.SaveTest error during teardown on Windows

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
@@ -83,10 +83,10 @@ public class SaveTest
 	protected void TearDown ()
 	{
 		try {
+			// This throws an exception under MS.NET, since the directory contains loaded
+			// assemblies.
 			Directory.Delete (tempDir, true);
-		} catch (DirectoryNotFoundException) {
-		} catch (IOException) {
-			// Can happen on Windows if assemblies from this dir are still used
+		} catch (Exception) {
 		}
 	}
 


### PR DESCRIPTION
When I added temp dir handling to SaveTest in https://github.com/mono/mono/pull/5727 I copied the Setup/TearDown from TypeBuilderTest.

However that class doesn't actually save+load the assemblies so it doesn't run into the issue on Windows where assemblies can't be deleted because they're still loaded in the AppDomain.

To fix this follow CustomAttributeBuilderTest and ModuleBuilderTest, i.e. just catch all Exception's in teardown...