### PR TITLE
[2017-10][corlib] Fix SRE.SaveTest error during teardown on Windows

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
@@ -83,10 +83,10 @@ public class SaveTest
 	protected void TearDown ()
 	{
 		try {
+			// This throws an exception under MS.NET, since the directory contains loaded
+			// assemblies.
 			Directory.Delete (tempDir, true);
-		} catch (DirectoryNotFoundException) {
-		} catch (IOException) {
-			// Can happen on Windows if assemblies from this dir are still used
+		} catch (Exception) {
 		}
 	}
 


### PR DESCRIPTION
Backport of #5794 to 2017-10