### PR TITLE
[WIP] [interp] [arm] hack around callee save problem for r8 in interp_in trampoline

### DIFF
--- a/mono/cil/opcode.def
+++ b/mono/cil/opcode.def
@@ -322,6 +322,7 @@ OPDEF(CEE_MONO_ATOMIC_STORE_I4, "mono_atomic_store_i4", PopI+PopI, Push0, Inline
 OPDEF(CEE_MONO_GET_LAST_ERROR, "mono_get_last_error", Pop0, PushI, InlineNone, X, 2, 0xF0, 0x1B, NEXT)
 OPDEF(CEE_MONO_GET_RGCTX_ARG, "mono_get_rgctx_arg", Pop0, PushI, InlineNone, X, 2, 0xF0, 0x1C, NEXT)
 OPDEF(CEE_MONO_LDPTR_PROFILER_ALLOCATION_COUNT, "mono_ldptr_profiler_allocation_count", Pop0, PushI, InlineNone, X, 2, 0xF0, 0x1D, NEXT)
+OPDEF(CEE_MONO_SET_RGCTX_ARG, "mono_set_rgctx_arg", PopI, Push0, InlineNone, X, 2, 0xF0, 0x1E, NEXT)
 #ifndef OPALIAS
 #define _MONO_CIL_OPALIAS_DEFINED_
 #define OPALIAS(a,s,r)

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2171,6 +2171,9 @@ mono_interp_create_method_pointer (MonoMethod *method, MonoError *error)
 	MonoFtnDesc *ftndesc = g_new0 (MonoFtnDesc, 1);
 	ftndesc->addr = entry_func;
 	ftndesc->arg = rmethod;
+#ifdef TARGET_ARM
+	ftndesc->callee_save_reg = (gpointer) 0x13376677;
+#endif
 	mono_error_assert_ok (error);
 
 	/*
@@ -2181,7 +2184,7 @@ mono_interp_create_method_pointer (MonoMethod *method, MonoError *error)
 	if (mono_aot_only)
 		addr = mono_aot_get_static_rgctx_trampoline (ftndesc, jit_wrapper);
 	else
-		addr = mono_arch_get_static_rgctx_trampoline (ftndesc, jit_wrapper);
+		addr = mono_arch_get_interp_in_trampoline (ftndesc, jit_wrapper);
 
 	mono_memory_barrier ();
 	rmethod->jit_entry = addr;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12133,6 +12133,21 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				ip += 2;
 				*sp++ = ins;
 				break;
+			case CEE_MONO_SET_RGCTX_ARG:
+				CHECK_OPSIZE (2);
+				CHECK_STACK (1);
+
+				sp--;
+				mono_create_rgctx_var (cfg);
+
+				MONO_INST_NEW (cfg, ins, OP_MOVE);
+				ins->dreg = cfg->rgctx_var->dreg;
+				ins->sreg1= sp [0]->dreg;
+				ins->type = STACK_PTR;
+				MONO_ADD_INS (cfg->cbb, ins);
+
+				ip += 2;
+				break;
 			default:
 				g_error ("opcode 0x%02x 0x%02x not handled", MONO_CUSTOM_PREFIX, ip [1]);
 				break;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6007,6 +6007,22 @@ mono_arm_unaligned_stack (MonoMethod *method)
 
 #ifndef DISABLE_JIT
 
+static guint8 *
+mono_arch_store_rgctx_var (MonoCompile *cfg, guint8 *code)
+{
+	MonoInst *ins = cfg->rgctx_var;
+
+	g_assert (ins->opcode == OP_REGOFFSET);
+
+	if (arm_is_imm12 (ins->inst_offset)) {
+		ARM_STR_IMM (code, MONO_ARCH_RGCTX_REG, ins->inst_basereg, ins->inst_offset);
+	} else {
+		code = mono_arm_emit_load_imm (code, ARMREG_LR, ins->inst_offset);
+		ARM_STR_REG_REG (code, MONO_ARCH_RGCTX_REG, ins->inst_basereg, ARMREG_LR);
+	}
+	return code;
+}
+
 /*
  * Stack frame layout:
  * 
@@ -6174,16 +6190,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 
 	/* store runtime generic context */
 	if (cfg->rgctx_var) {
-		MonoInst *ins = cfg->rgctx_var;
-
-		g_assert (ins->opcode == OP_REGOFFSET);
-
-		if (arm_is_imm12 (ins->inst_offset)) {
-			ARM_STR_IMM (code, MONO_ARCH_RGCTX_REG, ins->inst_basereg, ins->inst_offset);
-		} else {
-			code = mono_arm_emit_load_imm (code, ARMREG_LR, ins->inst_offset);
-			ARM_STR_REG_REG (code, MONO_ARCH_RGCTX_REG, ins->inst_basereg, ARMREG_LR);
-		}
+		code = mono_arch_store_rgctx_var (cfg, code);
 	}
 
 	/* load arguments allocated to register from the stack */
@@ -6586,6 +6593,20 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 			regmask &= ~(1 << reg);
 			sp_adj += 4;
 			reg ++;
+		}
+		if (cfg->rgctx_var) {
+			if (regmask & (1 << ARMREG_R8)) {
+				sp_adj += 4;
+				regmask &= ~(1 << ARMREG_R8);
+			}
+			MonoInst *ins = cfg->rgctx_var;
+			if (arm_is_imm12 (ins->inst_offset)) {
+				ARM_LDR_IMM (code, MONO_ARCH_RGCTX_REG, ins->inst_basereg, ins->inst_offset);
+			} else {
+				g_error ("not yet");
+				code = mono_arm_emit_load_imm (code, ARMREG_LR, ins->inst_offset);
+				ARM_LDR_REG_REG (code, MONO_ARCH_RGCTX_REG, ins->inst_basereg, ARMREG_LR);
+			}
 		}
 		if (iphone_abi)
 			/* Restored later */

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -1436,7 +1436,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 	MonoMethod *res, *cached;
 	WrapperInfo *info;
 	MonoMethodSignature *csig, *entry_sig;
-	int i, pindex, retval_var = 0;
+	int i, pindex, retval_var = 0, hidden_arg = 0;
 	static GHashTable *cache;
 	const char *name;
 	gboolean generic = FALSE;
@@ -1512,6 +1512,21 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 	if (sig->ret->type != MONO_TYPE_VOID)
 		retval_var = mono_mb_add_local (mb, sig->ret);
 
+	hidden_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_GET_RGCTX_ARG);
+	mono_mb_emit_stloc (mb, hidden_arg);
+
+#ifdef TARGET_ARM
+	/* restore r8 value */
+	mono_mb_emit_ldloc (mb, hidden_arg);
+	mono_mb_emit_icon (mb, 2 * sizeof (gpointer));
+	mono_mb_emit_byte (mb, CEE_ADD);
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_SET_RGCTX_ARG);
+#endif
+
 	/* Make the call */
 	if (generic) {
 		/* Collect arguments */
@@ -1555,14 +1570,12 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 		}
 	}
 	/* Extra arg */
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_GET_RGCTX_ARG);
+	mono_mb_emit_ldloc (mb, hidden_arg);
 	mono_mb_emit_icon (mb, sizeof (gpointer));
 	mono_mb_emit_byte (mb, CEE_ADD);
 	mono_mb_emit_byte (mb, CEE_LDIND_I);
 	/* Method to call */
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_GET_RGCTX_ARG);
+	mono_mb_emit_ldloc (mb, hidden_arg);
 	mono_mb_emit_byte (mb, CEE_LDIND_I);
 	mono_mb_emit_calli (mb, entry_sig);
 	if (sig->ret->type != MONO_TYPE_VOID)

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1373,6 +1373,9 @@ typedef struct
 {
 	gpointer addr;
 	gpointer arg;
+#ifdef TARGET_ARM
+	gpointer callee_save_reg;
+#endif
 } MonoFtnDesc;
 
 typedef enum {
@@ -2865,6 +2868,7 @@ void     mono_arch_save_unwind_info             (MonoCompile *cfg);
 void     mono_arch_register_lowlevel_calls      (void);
 gpointer mono_arch_get_unbox_trampoline         (MonoMethod *m, gpointer addr);
 gpointer mono_arch_get_static_rgctx_trampoline  (gpointer arg, gpointer addr);
+gpointer mono_arch_get_interp_in_trampoline     (gpointer arg, gpointer addr);
 gpointer  mono_arch_get_llvm_imt_trampoline     (MonoDomain *domain, MonoMethod *method, int vt_offset);
 gpointer mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpointer addr);
 void     mono_arch_patch_callsite               (guint8 *method_start, guint8 *code, guint8 *addr);

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -114,9 +114,15 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_GENERICS_TRAMPOLINE, NULL));
 
-	mono_tramp_info_register (mono_tramp_info_create (NULL, start, code - start, NULL, unwind_ops), domain);
+	mono_tramp_info_register (mono_tramp_info_create ("static_rgctx_trampoline", start, code - start, NULL, unwind_ops), domain);
 
 	return start;
+}
+
+gpointer
+mono_arch_get_interp_in_trampoline (gpointer arg, gpointer addr)
+{
+	return mono_arch_get_static_rgctx_trampoline (arg, addr);
 }
 #endif /* !DISABLE_JIT */
 
@@ -1094,6 +1100,13 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 
 gpointer
 mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_get_interp_in_trampoline (gpointer arg, gpointer addr)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -529,7 +529,52 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_GENERICS_TRAMPOLINE, NULL));
 
-	mono_tramp_info_register (mono_tramp_info_create (NULL, start, code - start, NULL, unwind_ops), domain);
+	mono_tramp_info_register (mono_tramp_info_create ("static_rgctx_trampoline", start, code - start, NULL, unwind_ops), domain);
+
+	return start;
+}
+
+gpointer
+mono_arch_get_interp_in_trampoline (gpointer arg, gpointer addr)
+{
+	guint8 *code, *start, *label;
+	GSList *unwind_ops;
+	int buf_len = 40;
+	MonoDomain *domain = mono_domain_get ();
+
+	start = code = mono_domain_code_reserve (domain, buf_len);
+
+	unwind_ops = mono_arch_get_cie_program ();
+
+	g_assert (MONO_ARCH_RGCTX_REG != ARMREG_R7);
+
+	ARM_PUSH (code, 1 << ARMREG_R7);
+
+	ARM_LDR_IMM (code, ARMREG_R7, ARMREG_PC, 0);
+	label = code;
+	ARM_B_COND (code, ARMCOND_AL, 0);
+	*(guint32 *)code = (guint32) arg;
+	code += 4;
+	arm_patch (label, code);
+
+	ARM_STR_IMM (code, MONO_ARCH_RGCTX_REG, ARMREG_R7, 8 /* TODO */);
+	ARM_POP (code, 1 << ARMREG_R7);
+
+
+	ARM_LDR_IMM (code, MONO_ARCH_RGCTX_REG, ARMREG_PC, 0);
+	ARM_LDR_IMM (code, ARMREG_PC, ARMREG_PC, 0);
+	/* never reached */
+	*(guint32 *)code = (guint32) arg;
+	code += 4;
+	*(guint32 *)code = (guint32) addr;
+	code += 4;
+
+	g_assert ((code - start) <= buf_len);
+
+	mono_arch_flush_icache (start, code - start);
+	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_GENERICS_TRAMPOLINE, NULL));
+
+	mono_tramp_info_register (mono_tramp_info_create ("interp_in_trampoline", start, code - start, NULL, unwind_ops), domain);
 
 	return start;
 }
@@ -953,6 +998,13 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 
 gpointer
 mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_get_interp_in_trampoline (gpointer arg, gpointer addr)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -380,6 +380,12 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 }
 
 gpointer
+mono_arch_get_interp_in_trampoline (gpointer arg, gpointer addr)
+{
+	return mono_arch_get_static_rgctx_trampoline (arg, addr);
+}
+
+gpointer
 mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info, gboolean aot)
 {
 	guint8 *code, *buf;
@@ -790,6 +796,13 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 
 gpointer
 mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+gpointer
+mono_arch_get_interp_in_trampoline (gpointer arg, gpointer addr)
 {
 	g_assert_not_reached ();
 	return NULL;


### PR DESCRIPTION
TODO:
- [ ] make it MT-safe
- [ ] only restore if `mono_set_rgctx_arg` is actually used
- [ ] make it work for AOT case