### PR TITLE
[eglib] check if result is set

### DIFF
--- a/mono/eglib/gmisc-unix.c
+++ b/mono/eglib/gmisc-unix.c
@@ -127,7 +127,7 @@ get_pw_data (void)
 {
 #ifdef HAVE_GETPWUID_R
 	struct passwd pw;
-	struct passwd *result;
+	struct passwd *result = NULL;
 	char buf [4096];
 #endif
 
@@ -145,7 +145,7 @@ get_pw_data (void)
 
 #ifdef HAVE_GETPWUID_R
 	if (home_dir == NULL || user_name == NULL) {
-		if (getpwuid_r (getuid (), &pw, buf, 4096, &result) == 0) {
+		if (getpwuid_r (getuid (), &pw, buf, 4096, &result) == 0 && result) {
 			if (home_dir == NULL)
 				home_dir = g_strdup (pw.pw_dir);
 			if (user_name == NULL)


### PR DESCRIPTION
quote from the darwin man page:

> The functions getpwnam_r(), getpwuid_r(), and getpwuuid_r()
> return 0 if no error occurred, or an error number to indicate
> failure.  It is not an error if a matching entry is not found.
> (Thus, if result is NULL and the return value is 0, no
> matching entry exists.)


fixes a failure on tvOS