### PR TITLE
[corlib] Updated LinkerDescriptor

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -745,6 +745,11 @@
 		<!-- domain.c: mono_defaults.transparent_proxy_class / removed with DISABLE_REMOTING -->
 		<type fullname="System.Runtime.Remoting.Proxies.TransparentProxy" feature="remoting" />
 
+		<!-- object.c: mono_object_new_specific_checked -->
+		<type fullname="System.Runtime.Remoting.Activation.ActivationServices" >
+			<method name="CreateProxyForType"/>
+		</type>
+
 		<!-- exception.c (mono_get_exception_serialization) -->
 		<type fullname="System.Runtime.Serialization.SerializationException">
 			<!-- mono_exception_from_name_msg -->

--- a/mcs/tools/linker/Makefile
+++ b/mcs/tools/linker/Makefile
@@ -7,7 +7,8 @@ PROGRAM = monolinker.exe
 LIB_REFS = System System.Core System.Xml Mono.Cecil
 
 TEST_CASES = \
-	mscorlib/test-array.cs
+	mscorlib/test-array.cs \
+	mscorlib/test-remoting.cs
 
 ifndef AOT_FRIENDLY_PROFILE
 TEST_CASES += \

--- a/mcs/tools/linker/Tests/mscorlib/test-remoting.cs
+++ b/mcs/tools/linker/Tests/mscorlib/test-remoting.cs
@@ -1,0 +1,14 @@
+using System;
+
+public class MyObject : ContextBoundObject
+{
+}
+
+public class C
+{
+	public static int Main ()
+	{
+		var context = new MyObject ();
+		return 0;
+	}
+}


### PR DESCRIPTION
Preserve
`System.Runtime.Remoting.Activation.ActivationServices.CreateProxyForType`. It
is called from `object.c:mono_object_new_specific_checked` when
constructing remoting or com objects.

I didn't add `feature="remoting"` because it is used also for com
objects.

Added linker test. Without the LinkerDescriptor addition, it fails
like this:

    Unhandled Exception:
    System.NotSupportedException: Linked away.
      at (wrapper managed-to-native) System.Object.__icall_wrapper_ves_icall_object_new_specific(intptr)
      at C.Main () [0x00001] in /Users/rodo/git/mono/mcs/tools/linker/Tests/mscorlib/test-remoting.cs:11
    [ERROR] FATAL UNHANDLED EXCEPTION: System.NotSupportedException: Linked away.
      at (wrapper managed-to-native) System.Object.__icall_wrapper_ves_icall_object_new_specific(intptr)
      at C.Main () [0x00001] in /Users/rodo/git/mono/mcs/tools/linker/Tests/mscorlib/test-remoting.cs:11