### PR TITLE
[runtime] Fix Windows build break due to renamed mono_error_raise_exception

### DIFF
--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -206,7 +206,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	LocalFree (argvw);
 
 	mono_runtime_run_main_checked (method, argc, argv, &error);
-	mono_error_raise_exception (&error); /* OK, triggers unhandled exn handler */
+	mono_error_raise_exception_deprecated (&error); /* OK, triggers unhandled exn handler */
 	mono_thread_manage ();
 
 	mono_runtime_quit ();

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -849,7 +849,7 @@ mono_filesize_from_path (MonoString *string)
 	struct stat buf;
 	gint64 res;
 	char *path = mono_string_to_utf8_checked (string, &error);
-	mono_error_raise_exception (&error); /* OK to throw, external only without a good alternative */
+	mono_error_raise_exception_deprecated (&error); /* OK to throw, external only without a good alternative */
 
 	gint stat_res;
 	MONO_ENTER_GC_SAFE;

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -1580,7 +1580,7 @@ emit_call (MonoCompile *cfg, guint32 *code, guint32 patch_type, gconstpointer da
 		patch_info.data.target = data;
 
 		target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, &patch_info, FALSE, &error);
-		mono_error_raise_exception (&error); /* FIXME: don't raise here */
+		mono_error_raise_exception_deprecated (&error); /* FIXME: don't raise here */
 
 		/* FIXME: Add optimizations if the target is close enough */
 		sparc_set (code, target, sparc_o7);

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -144,9 +144,6 @@ MonoException*
 mono_error_convert_to_exception (MonoError *error);
 
 void
-mono_error_raise_exception (MonoError *error);
-
-void
 mono_error_move (MonoError *dest, MonoError *src);
 
 MonoErrorBoxed*


### PR DESCRIPTION
It was renamed in 91a10ffd016f24b96e90efe42d9ca661696e98b8 but some places which are only used on Windows were missed.