### PR TITLE
Add an automated test that will fail if the list of feature names in CompilerServices.RuntimeFeature is changed

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
@@ -1,0 +1,53 @@
+//
+// RuntimeFeatureTest.cs
+//
+// Authors:
+//  Katelyn Gadd <kg@luminance.org>
+//
+// Copyright (c) 2017 Microsoft Corporation.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using NUnit.Framework;
+using System;
+using System.Runtime.CompilerServices;
+using System.Linq;
+
+namespace MonoTests.System.Runtime.CompilerServices
+{
+    [TestFixture]
+    public class RuntimeFeatureTest
+    {
+        readonly string[] KnownFeatureNames = new [] {
+            "PortablePdb"
+        };
+
+        [Test]
+        public void NoNewFeaturesAdded ()
+        {
+            var t = typeof (global::System.Runtime.CompilerServices.RuntimeFeature);
+            var featureNames = from field in t.GetFields()
+                where field.FieldType == typeof(string)
+                select field.Name;
+            Assert.AreEqual (featureNames.ToArray (), KnownFeatureNames);
+        }
+    }
+}

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
@@ -36,18 +36,22 @@ namespace MonoTests.System.Runtime.CompilerServices
     [TestFixture]
     public class RuntimeFeatureTest
     {
-        readonly string[] KnownFeatureNames = new [] {
-            "PortablePdb"
+        readonly (string, bool)[] ExpectedFeatures = new [] {
+            ("PortablePdb", true)
         };
 
         [Test]
         public void NoNewFeaturesAdded ()
         {
             var t = typeof (RuntimeFeature);
-            var featureNames = from field in t.GetFields()
-                where field.FieldType == typeof(string)
-                select field.Name;
-            Assert.AreEqual (KnownFeatureNames, featureNames.ToArray ());
+            var features = from field in t.GetFields()
+                where field.FieldType == typeof (string)
+                let value = field.GetValue (null)
+                select (
+                    field.Name,
+                    RuntimeFeature.IsSupported ((string)value)
+                );
+            Assert.AreEqual (ExpectedFeatures, features.ToArray ());
         }
     }
 }

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
@@ -43,11 +43,11 @@ namespace MonoTests.System.Runtime.CompilerServices
         [Test]
         public void NoNewFeaturesAdded ()
         {
-            var t = typeof (global::System.Runtime.CompilerServices.RuntimeFeature);
+            var t = typeof (RuntimeFeature);
             var featureNames = from field in t.GetFields()
                 where field.FieldType == typeof(string)
                 select field.Name;
-            Assert.AreEqual (featureNames.ToArray (), KnownFeatureNames);
+            Assert.AreEqual (KnownFeatureNames, featureNames.ToArray ());
         }
     }
 }

--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -185,6 +185,7 @@ System.Resources/ResourceWriterTest.cs
 System.Runtime.CompilerServices/ConditionalWeakTableTest.cs
 System.Runtime.CompilerServices/InternalsVisibleToAttributeTest.cs
 System.Runtime.CompilerServices/MethodImplAttributeTest.cs
+System.Runtime.CompilerServices/RuntimeFeatureTest.cs
 System.Runtime.CompilerServices/RuntimeHelpersTest.cs
 System.Runtime.CompilerServices/RuntimeWrappedExceptionTest.cs
 System.Runtime.CompilerServices/AsyncTaskMethodBuilderTest.cs


### PR DESCRIPTION
If the list of runtime feature names in corefx changes, we want to know so we can verify that it isn't asserting things (like support for new features or specific behaviors) that aren't currently true for mono.