### PR TITLE
[Windows] Build fixes for none Windows desktop platforms.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8727,7 +8727,7 @@ execute_system (const char * command)
 {
 	int status = 0;
 
-#if defined(HOST_WIN32)
+#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) && defined(HOST_WIN32)
 	// We need an extra set of quotes around the whole command to properly handle commands 
 	// with spaces since internally the command is called through "cmd /c.
 	char * quoted_command = g_strdup_printf ("\"%s\"", command);

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -582,5 +582,7 @@ mini_emit_memory_copy (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClas
 		mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_SEQ);
 	}
 }
+#else /* !DISABLE_JIT */
 
+MONO_EMPTY_SOURCE_FILE (memory_access);
 #endif

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -14342,5 +14342,7 @@ NOTES
 - Instead of the to_end stuff in the old JIT, simply call the function handling
   the values on the stack before emitting the last instruction of the bb.
 */
+#else /* !DISABLE_JIT */
 
+MONO_EMPTY_SOURCE_FILE (method_to_ir);
 #endif /* !DISABLE_JIT */

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -8,6 +8,7 @@
  * (C) 2015 Xamarin
  */
 #include <config.h>
+#include <mono/utils/mono-compiler.h>
 
 #ifdef ENABLE_CHECKED_BUILD
 
@@ -708,5 +709,7 @@ check_metadata_store_local (void *from, void *to)
 }
 
 #endif /* defined(ENABLE_CHECKED_BUILD_METADATA) */
+#else /* ENABLE_CHECKED_BUILD */
 
+MONO_EMPTY_SOURCE_FILE (checked_build);
 #endif /* ENABLE_CHECKED_BUILD */

--- a/mono/utils/mono-os-wait-win32-uwp.c
+++ b/mono/utils/mono-os-wait-win32-uwp.c
@@ -1,0 +1,27 @@
+/**
+ * \file
+ * UWP OS wait support for Mono.
+ *
+ * Copyright 2017 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+#include <config.h>
+#include <glib.h>
+#include "mono/utils/mono-compiler.h"
+
+#if G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT)
+#include <windows.h>
+
+DWORD
+mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags)
+{
+	g_unsupported_api ("MsgWaitForMultipleObjectsEx");
+	SetLastError (ERROR_NOT_SUPPORTED);
+
+	return WAIT_FAILED;
+}
+
+#else /* G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT) */
+
+MONO_EMPTY_SOURCE_FILE (mono_os_wait_win32_uwp);
+#endif /* G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT) */

--- a/mono/utils/mono-os-wait-win32.c
+++ b/mono/utils/mono-os-wait-win32.c
@@ -173,6 +173,7 @@ mono_win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout
 	return result;
 }
 
+#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 DWORD
 mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags)
 {
@@ -194,6 +195,7 @@ mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles,
 
 	return result;
 }
+#endif
 
 DWORD
 mono_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable)

--- a/mono/utils/networking-fallback.c
+++ b/mono/utils/networking-fallback.c
@@ -10,6 +10,7 @@
 
 #include <mono/utils/networking.h>
 #include <glib.h>
+#include <mono/utils/mono-compiler.h>
 
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
@@ -78,5 +79,7 @@ mono_get_address_info (const char *hostname, int port, int flags, MonoAddressInf
 }
 
 #endif /* defined (HAVE_GETHOSTBYNAME) || defined (HAVE_GETHOSTBYNAME2) */
+#else /* !defined (HAVE_GETADDRINFO) */
 
+MONO_EMPTY_SOURCE_FILE (networking_fallback);
 #endif /* !defined (HAVE_GETADDRINFO) */

--- a/msvc/eglib.targets
+++ b/msvc/eglib.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="eglib-common.targets" />
-  <Import Project="eglib-win32.targets" />
-  <Import Project="eglib-posix.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)eglib-common.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)eglib-win32.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)eglib-posix.targets" />
 </Project>

--- a/msvc/eglib.targets.filters
+++ b/msvc/eglib.targets.filters
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="eglib-common.targets.filters" />
-  <Import Project="eglib-win32.targets.filters" />
-  <Import Project="eglib-posix.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)eglib-common.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)eglib-win32.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)eglib-posix.targets.filters" />
   <ItemGroup Condition="'$(EGLibFilterSubFolder)'!=''">
     <Filter Include="Source Files$(EGLibFilterSubFolder)">
       <UniqueIdentifier>{8B3E0DAF-48EA-4B5F-B573-4E8ED8525134}</UniqueIdentifier>

--- a/msvc/libmini-arch.targets
+++ b/msvc/libmini-arch.targets
@@ -2,9 +2,13 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ExcludeFromWindowsBuild>true</ExcludeFromWindowsBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ExcludeFromWindows32Build)'==''">
     <ExcludeFromWindows32Build>false</ExcludeFromWindows32Build>
-    <ExcludeFromWindows64Build>false</ExcludeFromWindows64Build>
     <ExcludeFromWindows32Build Condition="'$(Platform)'=='Win32'">true</ExcludeFromWindows32Build>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ExcludeFromWindows64Build)'==''">
+    <ExcludeFromWindows64Build>false</ExcludeFromWindows64Build>
     <ExcludeFromWindows64Build Condition="'$(Platform)'=='x64'">true</ExcludeFromWindows64Build>
   </PropertyGroup>
   <ItemGroup Label="arch_wasm_sources">

--- a/msvc/libmini.targets
+++ b/msvc/libmini.targets
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="libmini-common.targets" />
-  <Import Project="libmini-win32.targets" />
-  <Import Project="libmini-posix.targets" />
-  <Import Project="libmini-arch.targets" />
-  <Import Project="libmini-interp.targets" />
-  <Import Project="libmini-llvm.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-common.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-win32.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-posix.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-arch.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-interp.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-llvm.targets" />
 </Project>

--- a/msvc/libmini.targets.filters
+++ b/msvc/libmini.targets.filters
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="libmini-common.targets.filters" />
-  <Import Project="libmini-win32.targets.filters" />
-  <Import Project="libmini-posix.targets.filters" />
-  <Import Project="libmini-arch.targets.filters" />
-  <Import Project="libmini-interp.targets.filters" />
-  <Import Project="libmini-llvm.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-common.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-win32.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-posix.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-arch.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-interp.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmini-llvm.targets.filters" />
   <ItemGroup Condition="'$(MonoMiniFilterSubFolder)'!=''">
     <Filter Include="Header Files$(MonoMiniFilterSubFolder)">
       <UniqueIdentifier>{b64924de-7e02-416b-9779-4cc7fe0270e6}</UniqueIdentifier>

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ExcludeFromWindowsBuild>true</ExcludeFromWindowsBuild>
+  </PropertyGroup>
   <ItemGroup Label="common_sources">
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\appdomain.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\domain.c" />
@@ -74,7 +77,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-perfcounters.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-perfcounters-def.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-ptr-array.h" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\mono-route.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\mono-route.c">
+      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-route.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\monitor.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\normalization-tables.h" />
@@ -128,7 +133,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\custom-attrs-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sre-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\reflection-internals.h" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\file-mmap-posix.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\file-mmap-posix.c">
+      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\file-mmap-windows.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\file-mmap.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\object-offsets.h" />
@@ -142,7 +149,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32semaphore.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32event.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32handle-namespace.h" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32handle-namespace.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32handle-namespace.c">
+      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32handle.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32handle.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32error.h" />
@@ -164,7 +173,7 @@
   </ItemGroup>
   <ItemGroup Label="null_sources">
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\console-null.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
+      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
   <ItemGroup Label="null_gc_sources">

--- a/msvc/libmonoruntime.targets
+++ b/msvc/libmonoruntime.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="libmonoruntime-common.targets" />
-  <Import Project="libmonoruntime-win32.targets" />
-  <Import Project="libmonoruntime-posix.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoruntime-common.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoruntime-win32.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoruntime-posix.targets" />
 </Project>

--- a/msvc/libmonoruntime.targets.filters
+++ b/msvc/libmonoruntime.targets.filters
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="libmonoruntime-common.targets.filters" />
-  <Import Project="libmonoruntime-win32.targets.filters" />
-  <Import Project="libmonoruntime-posix.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoruntime-common.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoruntime-win32.targets.filters" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoruntime-posix.targets.filters" />
   <ItemGroup Condition="'$(MonoRuntimeFilterSubFolder)'!=''">
     <Filter Include="Header Files$(MonoRuntimeFilterSubFolder)">
       <UniqueIdentifier>{992766FD-0584-4B49-A4F7-B59947CD8488}</UniqueIdentifier>

--- a/msvc/libmonoutils-arch.targets
+++ b/msvc/libmonoutils-arch.targets
@@ -2,10 +2,17 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ExcludeFromWindowsBuild>true</ExcludeFromWindowsBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ExcludeFromWindows32Build)'==''">
     <ExcludeFromWindows32Build>false</ExcludeFromWindows32Build>
-    <ExcludeFromWindows64Build>false</ExcludeFromWindows64Build>
     <ExcludeFromWindows32Build Condition="'$(Platform)'=='Win32'">true</ExcludeFromWindows32Build>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ExcludeFromWindows64Build)'==''">
+    <ExcludeFromWindows64Build>false</ExcludeFromWindows64Build>
     <ExcludeFromWindows64Build Condition="'$(Platform)'=='x64'">true</ExcludeFromWindows64Build>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ExcludeMASMFromWindowsBuild)'==''">
+    <ExcludeMASMFromWindowsBuild>false</ExcludeMASMFromWindowsBuild>
   </PropertyGroup>
   <ItemGroup Label="arch_x86_sources">
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mach-support-x86.c">
@@ -17,7 +24,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mach-support-amd64.c">
       <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
     </ClCompile>
-    <MASM Include="$(MonoSourceLocation)\mono\utils\win64.asm">
+    <MASM Include="$(MonoSourceLocation)\mono\utils\win64.asm" Condition="'$(ExcludeMASMFromWindowsBuild)'=='false'">
       <FileType>Document</FileType>
       <ExcludedFromBuild>$(ExcludeFromWindows32Build)</ExcludedFromBuild>
       <PreprocessorDefinitions>X64</PreprocessorDefinitions>
@@ -75,7 +82,7 @@
     </ClCompile>
   </ItemGroup>
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="$(MonoSourceLocation)\msvc\masm.fixed.props" />
+    <Import Project="$(MSBuildThisFileDirectory)masm.fixed.props" />
     <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
   </ImportGroup>
 </Project>

--- a/msvc/libmonoutils-arch.targets.filters
+++ b/msvc/libmonoutils-arch.targets.filters
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(ExcludeMASMFromWindowsBuild)'==''">
+    <ExcludeMASMFromWindowsBuild>false</ExcludeMASMFromWindowsBuild>
+  </PropertyGroup>
   <ItemGroup Label="arch_x86_sources">
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mach-support-x86.c">
       <Filter>Source Files$(MonoUtilsFilterSubFolder)\arch\x86</Filter>
@@ -12,7 +15,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mach-support-amd64.c">
       <Filter>Source Files$(MonoUtilsFilterSubFolder)\arch\amd64</Filter>
     </ClCompile>
-    <MASM Include="$(MonoSourceLocation)\mono\utils\win64.asm">
+    <MASM Include="$(MonoSourceLocation)\mono\utils\win64.asm" Condition="'$(ExcludeMASMFromWindowsBuild)'=='false'">
       <Filter>Resource Files$(MonoUtilsFilterSubFolder)\arch\amd64</Filter>
     </MASM>
   </ItemGroup>

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -51,7 +51,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-mmap-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-mmap-windows-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-os-mutex.h" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-os-mutex.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-os-mutex.c">
+      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-os-wait.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-coop-mutex.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-once.h" />
@@ -98,7 +100,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-uri.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-stdlib.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\valgrind.h" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mach-support.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mach-support.c">
+      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mach-support.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\memcheck.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-context.c" />

--- a/msvc/libmonoutils.targets
+++ b/msvc/libmonoutils.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="libmonoutils-common.targets" />
-  <Import Project="libmonoutils-win32.targets" />
-  <Import Project="libmonoutils-posix.targets" />
-  <Import Project="libmonoutils-arch.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoutils-common.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoutils-win32.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoutils-posix.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)libmonoutils-arch.targets" />
 </Project>


### PR DESCRIPTION
* Exclude a couple of sources currently not building anything useful on Windows.
* Added MONO_EMTPY_SOURCE_FILE to a couple of source files ending up empty by default.
* Excluded API's not included on UWP targets.
* Explicitly declared import project paths in target files.
* Added support to define x64 MASM build outside default targets file.