### PR TITLE
[remoting] Set fRefine to false in call to Unmarshal(ObjRef) Fixes #49308

### DIFF
--- a/mcs/class/corlib/System.Runtime.Remoting/ObjRef.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting/ObjRef.cs
@@ -58,6 +58,8 @@ namespace System.Runtime.Remoting {
 		static int MarshalledObjectRef = 1;
 		static int WellKnowObjectRef = 2;
 		
+		static int ProxyAttribute = 8;
+
 		public ObjRef ()
 		{
 			// no idea why this needs to be public
@@ -115,6 +117,9 @@ namespace System.Runtime.Remoting {
 
 			uri = RemotingServices.GetObjectUri (o);
 			typeInfo = new TypeInfo (requestedType);
+
+			if (Attribute.IsDefined (requestedType, typeof(ProxyAttribute), true))
+				SetHasProxyAttribute ();
 
 			if (!requestedType.IsInstanceOfType (o))
 				throw new RemotingException ("The server object type cannot be cast to the requested type " + requestedType.FullName);
@@ -187,6 +192,16 @@ namespace System.Runtime.Remoting {
 		internal bool IsReferenceToWellKnow
 		{
 			get { return (flags & WellKnowObjectRef) > 0; }
+		}
+
+		internal bool HasProxyAttribute
+		{
+			get { return (flags & ProxyAttribute) > 0; }
+		}
+
+		internal void SetHasProxyAttribute()
+		{
+			flags |= ProxyAttribute;
 		}
 
 		public virtual IChannelInfo ChannelInfo {

--- a/mcs/class/corlib/System.Runtime.Remoting/RemotingServices.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting/RemotingServices.cs
@@ -257,11 +257,13 @@ namespace System.Runtime.Remoting
 
 		public static object Unmarshal (ObjRef objectRef)
 		{
-			return Unmarshal (objectRef, true);
+			return Unmarshal (objectRef, false);
 		}
 
 		public static object Unmarshal (ObjRef objectRef, bool fRefine)
 		{
+			if (objectRef.HasProxyAttribute)
+				fRefine = true;
 			Type classToProxy = fRefine ? objectRef.ServerType : typeof (MarshalByRefObject);
 			if (classToProxy == null) classToProxy = typeof (MarshalByRefObject);
 

--- a/mcs/class/corlib/System.Runtime.Remoting/ServerIdentity.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting/ServerIdentity.cs
@@ -95,6 +95,9 @@ namespace System.Runtime.Remoting
 			_objRef = new ObjRef ();
 			_objRef.TypeInfo = new TypeInfo(requestedType);
 			_objRef.URI = _objectUri;
+			if (Attribute.IsDefined (requestedType, typeof(ProxyAttribute), true)) {
+				_objRef.SetHasProxyAttribute ();
+			}
 
 			if (_envoySink != null && !(_envoySink is EnvoyTerminatorSink))
 				_objRef.EnvoyInfo = new EnvoyInfo (_envoySink);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -472,6 +472,7 @@ TESTS_CS_SRC=		\
 	appdomain-unload-asmload.cs	\
 	appdomain-unload-exception.cs	\
 	unload-appdomain-on-shutdown.cs	\
+	appdomain-marshalbyref-assemblyload.cs \
 	bug-47295.cs	\
 	loader.cs	\
 	pinvoke2.cs	\
@@ -806,6 +807,7 @@ PROFILE_DISABLED_TESTS += \
 	appdomain-unload-callback.exe	\
 	appdomain-unload-doesnot-raise-pending-events.exe	\
 	unload-appdomain-on-shutdown.exe	\
+	appdomain-marshalbyref-assemblyload.exe \
 	assemblyresolve_event2.2.exe	\
 	assemblyresolve_event6.exe	\
 	bug-544446.exe	\
@@ -1838,6 +1840,23 @@ generic-delegate2.2.exe: $(srcdir)/generic-delegate2.2.cs generic-delegate2-lib.
 bug-3903.exe: bug-3903.cs
 	$(MCS_NO_LIB)  $(srcdir)/bug-3903.cs -nostdlib -r:$(srcdir)/../../external/binary-reference-assemblies/v2.0/mscorlib.dll -r:$(srcdir)/../../external/binary-reference-assemblies/v2.0/System.Core.dll -out:$@
 
+EXTRA_DIST += appdomain-marshalbyref-assemblyload-MidAssembly.cs appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+
+LeafAssembly.dll: appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+	mkdir -p appdomain-marshalbyref-assemblyload1
+	$(MCS) -target:library -out:$@ $<
+
+appdomain-marshalbyref-assemblyload2/LeafAssembly.dll: appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+	mkdir -p appdomain-marshalbyref-assemblyload2
+	$(MCS) -target:library -out:$@ $< -define:UNDEFINE_OTHER_METHOD
+
+MidAssembly.dll: appdomain-marshalbyref-assemblyload-MidAssembly.cs LeafAssembly.dll
+	mkdir -p appdomain-marshalbyref-assemblyload1
+	$(MCS) -target:library -out:$@ $< -r:LeafAssembly.dll
+
+appdomain-marshalbyref-assemblyload.exe: appdomain-marshalbyref-assemblyload.cs MidAssembly.dll LeafAssembly.dll appdomain-marshalbyref-assemblyload2/LeafAssembly.dll
+	$(MCS) -out:$@ $< -r:MidAssembly.dll -r:LeafAssembly.dll
+
 gshared:
 	$(MAKE) test-generic-sharing
 
@@ -2075,4 +2094,4 @@ internalsvisibleto-correctcase-2-sign2048.dll internalsvisibleto-wrongcase-2-sig
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-compilertest-sign2048.exe -warn:0 -r:internalsvisibleto-correctcase-2-sign2048.dll -r:internalsvisibleto-wrongcase-2-sign2048.dll -d:SIGN2048 internalsvisibleto-compilertest.cs
 
 
-CLEANFILES = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat
+CLEANFILES = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat LeafAssembly.dll MidAssembly.dll appdomain-marshalbyref-assemblyload2/*.dll 

--- a/mono/tests/appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+++ b/mono/tests/appdomain-marshalbyref-assemblyload-LeafAssembly.cs
@@ -1,0 +1,30 @@
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Remoting.Proxies;
+
+namespace LeafAssembly {
+	public class Leaf : MarshalByRefObject {
+		static Leaf () {
+			Console.WriteLine ("Static leaf constructor called in {0}", AppDomain.CurrentDomain);
+		}
+		public Leaf () {
+			Console.WriteLine ("Created leaf in {0}", AppDomain.CurrentDomain);
+		}
+	}
+
+	public class OtherLeafClass {
+		/* We build this assembly twice: once into
+		 * appdomain-marshalbyref-assemblyload1/ with PublicMethod()
+		 * present, and once into appdomain-marshalbyref-assemblyload2/
+		 * without it.  The regression test tries to trick Mono into
+		 * loading from -assemblyload2/.
+		 */
+#if !UNDEFINE_OTHER_METHOD
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static void PublicMethod () {
+
+		}
+#endif
+	}
+}

--- a/mono/tests/appdomain-marshalbyref-assemblyload-MidAssembly.cs
+++ b/mono/tests/appdomain-marshalbyref-assemblyload-MidAssembly.cs
@@ -1,0 +1,33 @@
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace MidAssembly {
+	[Serializable]
+	public class MidClass : MarshalByRefObject {
+		public MidClass () {
+			Console.WriteLine ("Created mid in {0}", AppDomain.CurrentDomain);
+		}
+
+		public void MidMethod (object leaf) {
+			Console.WriteLine ("Called MidMethod in {0}", AppDomain.CurrentDomain);
+			var ad = AppDomain.CurrentDomain;
+			Console.WriteLine ("Domain {0} has loaded:", ad);
+			foreach (var assm in ad.GetAssemblies ()) {
+				Console.WriteLine (" - {0}", assm);
+				Console.WriteLine ("     with location: {0}", assm.Location);
+			}
+		}
+
+
+		public void ForceLoadFrom (string assmPath)
+		{
+			Console.WriteLine ($" loading from {assmPath} into {AppDomain.CurrentDomain}");
+			System.Reflection.Assembly.LoadFrom (assmPath);
+		}
+
+		public void DoSomeAction () {
+			LeafAssembly.OtherLeafClass.PublicMethod ();
+		}
+	}
+}

--- a/mono/tests/appdomain-marshalbyref-assemblyload.cs
+++ b/mono/tests/appdomain-marshalbyref-assemblyload.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Security.Policy;
+
+public class Test {
+	public static int Main ()
+	{
+		var dir1 = Path.GetDirectoryName (typeof (Test).Assembly.Location);
+		var dir2 = "appdomain-marshalbyref-assemblyload2";
+		var domain = CreateDomain (dir2);
+		var path1 = Path.Combine (dir1, "MidAssembly.dll");
+		object o = domain.CreateInstanceFromAndUnwrap (path1, "MidAssembly.MidClass");
+		var mc = o as MidAssembly.MidClass;
+		var l = new LeafAssembly.Leaf ();
+		/* passing Leaf to MidMethod should /not/ cause
+		 * place2/LeafAssembly.dll to be loaded in the new remote
+		 * domain */
+		mc.MidMethod (l);
+		/* this line will pre-load place1/LeafAssembly.dll into the
+		 * remote domain.
+		 */
+		mc.ForceLoadFrom (Path.Combine (dir1, "LeafAssembly.dll"));
+		/* This method calls a class from LeafAssembly (which is only
+		 * defined in the place1 version of the class), so if the
+		 * place2 version had been loaded instead, it will trigger a
+		 * MissingMethodException */
+		mc.DoSomeAction ();
+		return 0;
+	}
+
+	public static AppDomain CreateDomain (string newpath)
+	{
+		var appDomainSetup = new AppDomainSetup ();
+		appDomainSetup.ApplicationBase = newpath;
+		var appDomain = AppDomain.CreateDomain ("MyDomainName", new Evidence (), appDomainSetup);
+		return appDomain;
+	}
+
+}


### PR DESCRIPTION
However if the server type has a `ProxyAttribute` custom attribute, set `fRefine`
back to true.

This matches logic in `InternalUnmarshal` in
https://github.com/mono/mono/blob/master/mcs/class/referencesource/mscorlib/system/runtime/remoting/remotingservices.cs#L834

The issue is that we may deserialize an `ObjRef` in some domain (domain2) when a
`MarshalByRef` instance is passed as an argument to a method of a server object
running in domain2.  The observed .NET framework behavior is that this should
not cause domain2 to try to load the type (and consequently the assembly) of
the `MarshalByRef` object (except in the case where it's actually a
`ContextBoundObject` that has a `ProxyAttribute`).  (Note however that the
transparent proxy of the `MarshalByRef` instance in domain2 must be handled
lightly - as long as its treated as an opaque reference and just loaded/stored
from `System.Object` variables or members, the type won't be loaded).

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=49308