### PR TITLE
Bugfix: 1.5 stop bits for serial port should set the posix stop bit flag

### DIFF
--- a/support/serial.c
+++ b/support/serial.c
@@ -334,7 +334,8 @@ set_attributes (int fd, int baud_rate, MonoParity parity, int dataBits, MonoStop
 		newtio.c_cflag |= CSTOPB;
 		break;
 	case OnePointFive: /* OnePointFive */
-		/* XXX unhandled */
+		/* 8250 UART handles stop bit flag as 1.5 stop bits for 5 data bits */
+		newtio.c_cflag |= CSTOPB;
 		break;
 	}
 


### PR DESCRIPTION
1.5 stop bits have not been handled at all.
According to this documentation of the 8250 UART:
http://stanislavs.org/helppc/8250.html

a set bit 2 in the LCR register means stop bits = 1.5 for 5 bit words or 2 for 6, 7 or 8 bit words.
That is the reason why pyserial also sets the bit:
https://github.com/pyserial/pyserial/blob/master/serial/serialposix.py#L377