### PR TITLE
[configure] Test AOT+LLVM if mono was configured to support both.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -974,13 +974,6 @@ else
    with_profile4_x_default=yes
 fi
 
-if test "x$AOT_BUILD_FLAGS" != "x"; then :
-   AC_SUBST(AOT_BUILD_FLAGS)
-   AC_SUBST(AOT_RUN_FLAGS)
-   # For llvmonlycheck + fullaotcheck
-   AC_SUBST(INVARIANT_AOT_OPTIONS)
-fi
-
 AC_SUBST(TEST_PROFILE)
 
 if test "x$with_profile4_x" = "xdefault"; then
@@ -2938,6 +2931,11 @@ if test "x$enable_llvm" = "xyes"; then
       fi
    fi
 
+   if test x$with_runtime_preset != xbitcode; then
+      AOT_BUILD_FLAGS="$AOT_BUILD_FLAGS,llvm"
+      AOT_RUN_FLAGS="$AOT_RUN_FLAGS --llvm"
+   fi
+
    llvm_codegen="x86codegen"
    case "$target" in
    arm*)
@@ -3053,6 +3051,13 @@ if test "x$enable_llvm_runtime" = "xyes"; then
    AC_DEFINE(ENABLE_LLVM_RUNTIME, 1, [Runtime support code for llvm enabled])
 fi
 AM_CONDITIONAL(ENABLE_LLVM_RUNTIME, [test x$enable_llvm_runtime = xyes])
+
+if test "x$AOT_BUILD_FLAGS" != "x"; then :
+   AC_SUBST(AOT_BUILD_FLAGS)
+   AC_SUBST(AOT_RUN_FLAGS)
+   # For llvmonlycheck + fullaotcheck
+   AC_SUBST(INVARIANT_AOT_OPTIONS)
+fi
 
 TARGET="unknown"
 ACCESS_UNALIGNED="yes"


### PR DESCRIPTION
As it stands right now, if we have an aot+llvm build and we run the test suite on it, the non-LLVM AOT mode will be tested instead.

This behaviour is counterintuitive and seems unintentional. It may get especially confusing with Jenkins if one runs `make check-ci` on the `fullaot_llvm` configuration expecting to get testing results for AOT+LLVM, and yet LLVM does not actually get tested.