### PR TITLE
Revert "[jit] Throw the more specific OverflowException instead of ArithmeticException in the ldiv/lrem emulation functions. Fixes #60255."

### DIFF
--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -1664,7 +1664,7 @@ class Tests
 			val = d / q;
 		} catch (DivideByZeroException) {
 			/* wrong exception */
-		} catch (OverflowException) {
+		} catch (ArithmeticException) {
 			failed = false;
 		}
 		if (failed)
@@ -1677,7 +1677,7 @@ class Tests
 			val = d % q;
 		} catch (DivideByZeroException) {
 			/* wrong exception */
-		} catch (OverflowException) {
+		} catch (ArithmeticException) {
 			failed = false;
 		}
 		if (failed)

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -276,7 +276,7 @@ mono_lldiv (gint64 a, gint64 b)
 		return 0;
 	}
 	else if (b == -1 && a == (-9223372036854775807LL - 1LL)) {
-		mono_set_pending_exception (mono_get_exception_overflow ());
+		mono_set_pending_exception (mono_get_exception_arithmetic ());
 		return 0;
 	}
 #endif
@@ -292,7 +292,7 @@ mono_llrem (gint64 a, gint64 b)
 		return 0;
 	}
 	else if (b == -1 && a == (-9223372036854775807LL - 1LL)) {
-		mono_set_pending_exception (mono_get_exception_overflow ());
+		mono_set_pending_exception (mono_get_exception_arithmetic ());
 		return 0;
 	}
 #endif


### PR DESCRIPTION
This reverts commit eb9238c05e1b5959993be42cb788480f030b3b34.

Revert this as it causes test failures.