### PR TITLE
[corlib][Test] Ignore FileTest.SymLinkLoop until bug #59239 is fixed.

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -2694,6 +2694,9 @@ namespace MonoTests.System.IO
 		public static extern int symlink (string oldpath, string newpath);
 
 		[Test]
+#if __TVOS__
+		[Ignore ("See bug #59239")]
+#endif
 		public void SymLinkLoop ()
 		{
 			if (!RunningOnUnix)


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=59239