### PR TITLE
[sgen] Collect major after user requested minor collections

### DIFF
--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -3089,6 +3089,9 @@ sgen_gc_collect (int generation)
 	if (generation > 1)
 		generation = 1;
 	sgen_perform_collection (0, generation, "user request", TRUE, TRUE);
+	/* Make sure we don't exceed heap size allowance by promoting */
+	if (generation == GENERATION_NURSERY && sgen_need_major_collection (0))
+		sgen_perform_collection (0, GENERATION_OLD, "Minor allowance", FALSE, TRUE);
 	UNLOCK_GC;
 }
 


### PR DESCRIPTION
After a user requested minor collection we need to check if the new size of the heap exceeds the allowance, in which case we need to also do a major collection.

Fixes bug (#60168) where, if user triggers minors repeatedly, we never get to collect the major space (which is normally checked after the nursery is full, which never happens in this case)