### PR TITLE
[interp] disable broken test cases on CI

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -967,6 +967,7 @@ INTERP_DISABLED_TESTS = \
 	bug-335131.2.exe \
 	bug-415577.exe \
 	bug-45841-fpstack-exceptions.exe \
+	bug-48015.exe \
 	bug-58782-capture-and-throw.exe \
 	bug-58782-plain-throw.exe \
 	bug-81673.exe \
@@ -981,6 +982,7 @@ INTERP_DISABLED_TESTS = \
 	delegate9.exe \
 	dynamic-method-stack-traces.exe \
 	even-odd.exe \
+	exception18.exe \
 	field-access.exe \
 	finally_block_ending_in_dead_bb.exe \
 	generic-marshalbyref.2.exe \


### PR DESCRIPTION
they do not always fail.

exception18.exe fails with:

```
Unhandled Exception:
System.Exception: Exception carried 3 frames along with it when it should have reported one.
-0: 0x00020 throw      in C:Main () () at Main:32 // (TODO: proper stacktrace)
-1: 0x00037 vcall      in (wrapper runtime-invoke) object:runtime_invoke_direct_void (object,intptr,intptr,intptr) ([0x0] [0x7fff5907bab0] [0x0] [0x7ffdf8e05308] ) at runtime_invoke_direct_void:55 // (TODO: proper stacktrace)
```

bug-48015.exe fails with:

```
Unhandled Exception:
System.NullReferenceException: Object reference not set to an instance of an object.
-0: 0x00063 vcallvirt  in System.Runtime.Remoting.Proxies.RemotingProxy:Invoke (System.Runtime.Remoting.Messaging.IMessage) ([0x10e407930] [0x10e4081d0] ) at Invoke:99 // (TODO: proper stacktrace)
-1: 0x00077 callvirt   in System.Runtime.Remoting.Proxies.RealProxy:PrivateInvoke (System.Runtime.Remoting.Proxies.RealProxy,System.Runtime.Remoting.Messaging.IMessage,System.Exception&,object[]&) ([0x10e407930] [0x10e4081d0] [0x7fff522b36e8] [0x7fff522b36e0] ) at PrivateInvoke:119 // (TODO: proper stacktrace)
-2: 0x00034 call       in (wrapper runtime-invoke) <Module>:runtime_invoke_direct_object_RealProxy_IMessage_Exception&_object[]& (object,intptr,intptr,intptr) ([0x0] [0x7fff522b3640] [0x7fff522b36e8] [0x7fd8dc85ff28] ) at runtime_invoke_direct_object_RealProxy_IMessage_Exception&_object[]&:52 // (TODO: proper stacktrace)
-3: 0x00000            in (wrapper remoting-invoke) object:Equals (object) ([0x10e4081a8] [0x10e4081a8] )
-4: 0x0000d callvirt   in Driver:Main (string[]) ([0x10e4003e8] ) at Main:13 // (TODO: proper stacktrace)
-5: 0x0003d vcall      in (wrapper runtime-invoke) <Module>:runtime_invoke_direct_void_string[] (object,intptr,intptr,intptr) ([0x0] [0x7fff522b5ab0] [0x0] [0x7fd8da40d408] ) at runtime_invoke_direct_void_string[]:61 // (TODO: proper stacktrace)
```

partial revert of: https://github.com/mono/mono/pull/5861