### PR TITLE
[Mono.Posix] Fix some socket tests on monodroid

### DIFF
--- a/mcs/class/Mono.Posix/Test/Mono.Unix.Native/SocketTest.cs
+++ b/mcs/class/Mono.Posix/Test/Mono.Unix.Native/SocketTest.cs
@@ -176,6 +176,9 @@ namespace MonoTests.Mono.Unix.Native
 		}
 
 		[Test]
+#if MONODROID
+		[ExpectedException (typeof (ArgumentOutOfRangeException))] // IPPROTO_TCP not supported
+#endif
 		public void SockOptLinger ()
 		{
 			WithSockets (UnixAddressFamily.AF_INET, UnixSocketType.SOCK_STREAM, UnixSocketProtocol.IPPROTO_TCP, (so1, so2) => {
@@ -347,6 +350,9 @@ namespace MonoTests.Mono.Unix.Native
 		}
 
 		[Test]
+#if MONODROID
+		[ExpectedException (typeof (ArgumentOutOfRangeException))] // IPPROTO_UDP not supported
+#endif
 		public void BindConnect ()
 		{
 			WithSockets (UnixAddressFamily.AF_INET, UnixSocketType.SOCK_DGRAM, UnixSocketProtocol.IPPROTO_UDP, (so1, so2) => {
@@ -516,6 +522,9 @@ namespace MonoTests.Mono.Unix.Native
 
 		[Test]
 		[Category ("NotOnMac")]
+#if MONODROID
+		[ExpectedException (typeof (ArgumentOutOfRangeException))] // SOCK_NONBLOCK, SOCK_CLOEXEC not supported
+#endif
 		public void Accept4 ()
 		{
 			WithSockets (UnixAddressFamily.AF_UNIX, UnixSocketType.SOCK_STREAM, 0, (so1, so2) => {
@@ -553,6 +562,9 @@ namespace MonoTests.Mono.Unix.Native
 		}
 
 		[Test]
+#if MONODROID
+		[ExpectedException (typeof (ArgumentOutOfRangeException))] // IPPROTO_UDP not supported
+#endif
 		public void SendToRecvFrom ()
 		{
 			WithSockets (UnixAddressFamily.AF_INET, UnixSocketType.SOCK_DGRAM, UnixSocketProtocol.IPPROTO_UDP, (so1, so2) => {
@@ -643,6 +655,9 @@ namespace MonoTests.Mono.Unix.Native
 		}
 
 		[Test]
+#if MONODROID
+		[ExpectedException (typeof (ArgumentOutOfRangeException))] // IPPROTO_UDP not supported
+#endif
 		public unsafe void SendMsgRecvMsgAddress ()
 		{
 			WithSockets (UnixAddressFamily.AF_INET, UnixSocketType.SOCK_DGRAM, UnixSocketProtocol.IPPROTO_UDP, (so1, so2) => {


### PR DESCRIPTION
d9922895d42685f6c4022d710a1e7208da773f20 removed Mono.Unix.Native/SocketTest.cs from the exclude list on the monodroid profile.

It turns out that some tests don't work there however, they fail with an ArgumentOutOfRangeException on some socket options.