### PR TITLE
[Tests] Ensure that only a subset of the System.Security tests are ran on mobile platforms.

### DIFF
--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/CmsSignerTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/CmsSignerTest.cs
@@ -26,7 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -291,4 +291,4 @@ namespace MonoTests.System.Security.Cryptography.Pkcs {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/PkitsTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/PkitsTest.cs
@@ -27,7 +27,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -160,4 +160,4 @@ namespace MonoTests.System.Security.Cryptography.Pkcs {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/Pkits_4_01_SignatureVerification.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/Pkits_4_01_SignatureVerification.cs
@@ -26,7 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -236,4 +236,4 @@ namespace MonoTests.System.Security.Cryptography.Pkcs {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SignedCmsTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SignedCmsTest.cs
@@ -26,6 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 
 
 using NUnit.Framework;
@@ -452,4 +453,4 @@ namespace MonoTests.System.Security.Cryptography.Pkcs {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SignerInfoCollectionTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SignerInfoCollectionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -134,4 +134,4 @@ namespace MonoTests.System.Security.Cryptography.Pkcs {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SignerInfoTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SignerInfoTest.cs
@@ -26,7 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -102,4 +102,5 @@ namespace MonoTests.System.Security.Cryptography.Pkcs {
 		}
 	}
 }
+#endif
 

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SubjectIdentifierTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Pkcs/SubjectIdentifierTest.cs
@@ -26,7 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -85,4 +85,4 @@ namespace MonoTests.System.Security.Cryptography.Pkcs {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.X509Certificates/X509Certificate2UICas.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.X509Certificates/X509Certificate2UICas.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 
 
 using NUnit.Framework;
@@ -203,4 +204,4 @@ namespace MonoCasTests.System.Security.Cryptography.X509Certificates {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.X509Certificates/X509Certificate2UITest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.X509Certificates/X509Certificate2UITest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -128,4 +128,4 @@ namespace MonoTests.System.Security.Cryptography.X509Certificates {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/DSAKeyValueTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/DSAKeyValueTest.cs
@@ -6,6 +6,7 @@
 //
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -76,3 +77,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/DataObjectTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/DataObjectTest.cs
@@ -8,6 +8,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // (C) 2004 Novell Inc.
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -190,3 +191,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/DataReferenceTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/DataReferenceTest.cs
@@ -27,6 +27,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -51,4 +52,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/EncryptedXmlTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/EncryptedXmlTest.cs
@@ -6,7 +6,7 @@
 //
 // Copyright (C) 2006 Novell, Inc (http://www.novell.com)
 //
-
+#if !MOBILE
 
 using System;
 using System.Collections;
@@ -295,3 +295,4 @@ namespace MonoTests.System.Security.Cryptography.Xml
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoNameTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoNameTest.cs
@@ -6,6 +6,7 @@
 //
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -73,3 +74,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoNodeTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoNodeTest.cs
@@ -6,6 +6,7 @@
 //
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -66,3 +67,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoRetrievalMethodTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoRetrievalMethodTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2005 Novell, Inc (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -82,3 +83,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -192,3 +193,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoX509DataTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/KeyInfoX509DataTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2005 Novell, Inc (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.IO;
@@ -339,3 +340,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/RSAKeyValueTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/RSAKeyValueTest.cs
@@ -6,6 +6,7 @@
 //
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -72,3 +73,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/ReferenceTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/ReferenceTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // (C) 2004 Novell (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -235,3 +236,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/SignatureTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/SignatureTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -80,3 +81,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/SignedInfoTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/SignedInfoTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2005, 2009 Novell, Inc (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -212,3 +213,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/SignedXmlTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/SignedXmlTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2004-2005, 2008 Novell, Inc (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.Globalization;
@@ -1770,3 +1771,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/TransformChainTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/TransformChainTest.cs
@@ -6,6 +6,7 @@
 //
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 //
+#if !MOBILE
 
 using System;
 using System.Security.Cryptography;
@@ -65,3 +66,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/TransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/TransformTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -82,3 +83,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDecryptionTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDecryptionTransformTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -68,4 +68,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigBase64TransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigBase64TransformTest.cs
@@ -7,6 +7,7 @@
 // (C) 2002 Motus Technologies Inc. (http://www.motus.com)
 // (C) 2004 Novell (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.IO;
@@ -179,3 +180,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigC14NTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigC14NTransformTest.cs
@@ -9,6 +9,7 @@
 // (C) 2003 Aleksey Sanin (aleksey@aleksey.com)
 // (C) 2004 Novell (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.IO;
@@ -530,3 +531,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}    
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransformTest.cs
@@ -8,6 +8,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.IO;
@@ -407,3 +408,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		    	    "<e1 xmlns=\"http://www.ietf.org\" xmlns:w3c=\"http://www.w3.org\"><e3 xmlns=\"\" id=\"E3\" xml:space=\"preserve\"></e3></e1>";   
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigEnvelopedSignatureTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigEnvelopedSignatureTransformTest.cs
@@ -6,6 +6,7 @@
 //
 // (C) 2004 Novell Inc.
 //
+#if !MOBILE
 
 using System;
 using System.IO;
@@ -143,3 +144,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigExcC14NTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigExcC14NTransformTest.cs
@@ -18,6 +18,7 @@
 //	This file is simply replaced C14N->ExcC14N, and then replaced expected
 //	output XML. So, they are *not* from c14n specification.
 //
+#if !MOBILE
 
 
 using System;
@@ -594,4 +595,5 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}    
 }
+#endif
 

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigExcC14NWithCommentsTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigExcC14NWithCommentsTransformTest.cs
@@ -13,7 +13,7 @@
 // (C) 2004 Novell (http://www.novell.com)
 // (C) 2008 Gert Driesen
 //
-
+#if !MOBILE
 
 using System;
 using System.IO;
@@ -138,4 +138,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigXPathTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigXPathTransformTest.cs
@@ -7,7 +7,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
 //
-
+#if !MOBILE
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -291,3 +291,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigXsltTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlDsigXsltTransformTest.cs
@@ -8,6 +8,7 @@
 // (C) 2002, 2003 Motus Technologies Inc. (http://www.motus.com)
 // (C) 2004 Novell (http://www.novell.com)
 //
+#if !MOBILE
 
 using System;
 using System.Collections;
@@ -286,3 +287,5 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlLicenseTransformTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography.Xml/XmlLicenseTransformTest.cs
@@ -12,7 +12,7 @@
 // (C) 2004 Novell (http://www.novell.com)
 // (C) 2008 Gert Driesen
 //
-
+#if !MOBILE
 
 using System;
 using System.IO;
@@ -88,4 +88,4 @@ namespace MonoTests.System.Security.Cryptography.Xml {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedDataCas.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedDataCas.cs
@@ -26,7 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -169,4 +169,4 @@ namespace MonoCasTests.System.Security.Cryptography {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedDataTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedDataTest.cs
@@ -67,6 +67,7 @@ namespace MonoTests.System.Security.Cryptography {
 			ProtectUnprotect (notMuchEntropy, DataProtectionScope.LocalMachine);
 		}
 
+#if !MOBILE // System.PlatformNotSupportedException: Operation is not supported on this platform.
 		[Test] // https://bugzilla.xamarin.com/show_bug.cgi?id=38933
 		public void ProtectCurrentUserMultiThread ()
 		{
@@ -91,6 +92,7 @@ namespace MonoTests.System.Security.Cryptography {
 			foreach (var t in tasks) t.Start ();
 			Task.WaitAll (tasks.ToArray ());
 		}
+#endif
 
 		[Test]
 		public void DataProtectionScope_All ()

--- a/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedMemoryCas.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedMemoryCas.cs
@@ -26,7 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -165,4 +165,4 @@ namespace MonoCasTests.System.Security.Cryptography {
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedMemoryTest.cs
+++ b/mcs/class/System.Security/Test/System.Security.Cryptography/ProtectedMemoryTest.cs
@@ -7,7 +7,7 @@
 // (C) 2003 Motus Technologies Inc. (http://www.motus.com)
 // Copyright (C) 2005 Novell, Inc (http://www.novell.com)
 //
-
+#if !MOBILE
 
 using NUnit.Framework;
 
@@ -140,4 +140,4 @@ namespace MonoTests.System.Security.Cryptography {
 		}
 	}
 }
-
+#endif


### PR DESCRIPTION
As with the Mono.CSharp tests, we want to be able to run the correct subset of the System.Security tests on xamarin-macions PRs.  The related xamarin-macios pr is https://github.com/xamarin/xamarin-macios/pull/2939