### PR TITLE
Fix bug 57938 - FullName not returning null for certain generic types

### DIFF
--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -783,6 +783,10 @@ namespace System
 
 		public override string FullName {
 			get {
+				// https://bugzilla.xamarin.com/show_bug.cgi?id=57938
+				if (IsGenericType && ContainsGenericParameters && !IsGenericTypeDefinition)
+					return null;
+
 				string fullName;
 				// This doesn't need locking
 				if (type_info == null)

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -4854,6 +4854,27 @@ namespace MonoTests.System
 			{
 			}
 		}
+
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=57938
+		[Test]
+		public void NullFullNameForSpecificGenericTypes()
+		{
+			var ft = typeof(Bug59738Class<>).GetFields()[0].FieldType;
+
+			Assert.AreEqual(
+				"Bug59738Interface`1", ft.Name
+			);
+			Assert.AreEqual(
+				null, ft.FullName
+			);
+		}
+
+		interface Bug59738Interface<T> {
+		}
+
+		class Bug59738Class<U> {
+			public Bug59738Interface<U> Iface;
+		}
 	}
 
 	class UserType : Type

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -4859,14 +4859,31 @@ namespace MonoTests.System
 		[Test]
 		public void NullFullNameForSpecificGenericTypes()
 		{
-			var ft = typeof(Bug59738Class<>).GetFields()[0].FieldType;
+			var expected = new [] {
+				(
+					typeof(Bug59738Class<>).GetFields()[0].FieldType,
+					"Bug59738Interface`1", (string)null, 
+					"MonoTests.System.TypeTest+Bug59738Interface`1[U]"
+				),
+				(
+					typeof(Bug59738Derived<>).BaseType,
+					"Bug59738Class`1", (string)null, 
+					"MonoTests.System.TypeTest+Bug59738Class`1[U]"
+				),
+				(
+					typeof(Bug59738Class<int>),
+					"Bug59738Class`1", 
+					"MonoTests.System.TypeTest+Bug59738Class`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", 
+					"MonoTests.System.TypeTest+Bug59738Class`1[System.Int32]"
+				)
+			};
 
-			Assert.AreEqual(
-				"Bug59738Interface`1", ft.Name
-			);
-			Assert.AreEqual(
-				null, ft.FullName
-			);
+			for (var i = 0; i < expected.Length; i++) {
+				var (t, name, fullname, tostring) = expected[i];
+				Assert.AreEqual(name, t.Name, $"{i}.Name");
+				Assert.AreEqual(fullname, t.FullName, $"{i}.FullName");
+				Assert.AreEqual(tostring, t.ToString(), $"{i}.ToString()");
+			}
 		}
 
 		interface Bug59738Interface<T> {
@@ -4874,6 +4891,9 @@ namespace MonoTests.System
 
 		class Bug59738Class<U> {
 			public Bug59738Interface<U> Iface;
+		}
+
+		class Bug59738Derived<U> : Bug59738Class<U> {
 		}
 	}
 


### PR DESCRIPTION
This fixes bug 57938 (https://bugzilla.xamarin.com/show_bug.cgi?id=57938) where we don't return null for the FullName of certain generic types (non-definitions containing parameters).

This can't be merged yet because it unfortunately breaks our implementation of MethodInfo.ToString - I think this is because MonoMethod.ToString uses FormatTypeName and that goes through the normal name-generation path, but what we actually need to do is bypass the return-null logic somehow. I suspect there are other cases that will break as a result of this change but I only saw one other test failure, so our coverage here may be inadequate.