### PR TITLE
Replace usage of 'class' as identifier

### DIFF
--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -233,16 +233,16 @@ mono_class_set_field_count (MonoClass *klass, guint32 count)
 }
 
 MonoMarshalType*
-mono_class_get_marshal_info (MonoClass *class)
+mono_class_get_marshal_info (MonoClass *klass)
 {
-	return mono_property_bag_get (&class->infrequent_data, PROP_MARSHAL_INFO);
+	return mono_property_bag_get (&klass->infrequent_data, PROP_MARSHAL_INFO);
 }
 
 void
-mono_class_set_marshal_info (MonoClass *class, MonoMarshalType *marshal_info)
+mono_class_set_marshal_info (MonoClass *klass, MonoMarshalType *marshal_info)
 {
 	marshal_info->head.tag = PROP_MARSHAL_INFO;
-	mono_property_bag_add (&class->infrequent_data, marshal_info);
+	mono_property_bag_add (&klass->infrequent_data, marshal_info);
 }
 
 typedef struct {
@@ -251,26 +251,26 @@ typedef struct {
 } Uint32Property;
 
 guint32
-mono_class_get_ref_info_handle (MonoClass *class)
+mono_class_get_ref_info_handle (MonoClass *klass)
 {
-	Uint32Property *prop = mono_property_bag_get (&class->infrequent_data, PROP_REF_INFO_HANDLE);
+	Uint32Property *prop = mono_property_bag_get (&klass->infrequent_data, PROP_REF_INFO_HANDLE);
 	return prop ? prop->value : 0;
 }
 
 guint32
-mono_class_set_ref_info_handle (MonoClass *class, guint32 value)
+mono_class_set_ref_info_handle (MonoClass *klass, guint32 value)
 {
 	if (!value) {
-		Uint32Property *prop = mono_property_bag_get (&class->infrequent_data, PROP_REF_INFO_HANDLE);
+		Uint32Property *prop = mono_property_bag_get (&klass->infrequent_data, PROP_REF_INFO_HANDLE);
 		if (prop)
 			prop->value = 0;
 		return 0;
 	}
 
-	Uint32Property *prop = mono_class_alloc (class, sizeof (Uint32Property));
+	Uint32Property *prop = mono_class_alloc (klass, sizeof (Uint32Property));
 	prop->head.tag = PROP_REF_INFO_HANDLE;
 	prop->value = value;
-	prop = mono_property_bag_add (&class->infrequent_data, prop);
+	prop = mono_property_bag_add (&klass->infrequent_data, prop);
 	return prop->value;
 }
 
@@ -358,19 +358,19 @@ mono_class_set_field_def_values (MonoClass *klass, MonoFieldDefaultValue *values
 }
 
 guint32
-mono_class_get_declsec_flags (MonoClass *class)
+mono_class_get_declsec_flags (MonoClass *klass)
 {
-	Uint32Property *prop = mono_property_bag_get (&class->infrequent_data, PROP_DECLSEC_FLAGS);
+	Uint32Property *prop = mono_property_bag_get (&klass->infrequent_data, PROP_DECLSEC_FLAGS);
 	return prop ? prop->value : 0;
 }
 
 void
-mono_class_set_declsec_flags (MonoClass *class, guint32 value)
+mono_class_set_declsec_flags (MonoClass *klass, guint32 value)
 {
-	Uint32Property *prop = mono_class_alloc (class, sizeof (Uint32Property));
+	Uint32Property *prop = mono_class_alloc (klass, sizeof (Uint32Property));
 	prop->head.tag = PROP_DECLSEC_FLAGS;
 	prop->value = value;
-	mono_property_bag_add (&class->infrequent_data, prop);
+	mono_property_bag_add (&klass->infrequent_data, prop);
 }
 
 void

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -383,7 +383,7 @@ struct _MonoClass {
 };
 
 typedef struct {
-	MonoClass class;
+	MonoClass klass;
 	guint32	flags;
 	/*
 	 * From the TypeDef table
@@ -396,7 +396,7 @@ typedef struct {
 } MonoClassDef;
 
 typedef struct {
-	MonoClassDef class;
+	MonoClassDef klass;
 	MonoGenericContainer *generic_container;
 	/* The canonical GENERICINST where we instantiate a generic type definition with its own generic parameters.*/
 	/* Suppose we have class T`2<A,B> {...}.  canonical_inst is the GTD T`2 applied to A and B. */
@@ -404,21 +404,21 @@ typedef struct {
 } MonoClassGtd;
 
 typedef struct {
-	MonoClass class;
+	MonoClass klass;
 	MonoGenericClass *generic_class;
 } MonoClassGenericInst;
 
 typedef struct {
-	MonoClass class;
+	MonoClass klass;
 } MonoClassGenericParam;
 
 typedef struct {
-	MonoClass class;
+	MonoClass klass;
 	guint32 method_count;
 } MonoClassArray;
 
 typedef struct {
-	MonoClass class;
+	MonoClass klass;
 } MonoClassPointer;
 
 #ifdef COMPRESSED_INTERFACE_BITMAP
@@ -1476,16 +1476,16 @@ void
 mono_class_set_field_count (MonoClass *klass, guint32 count);
 
 MonoMarshalType*
-mono_class_get_marshal_info (MonoClass *class);
+mono_class_get_marshal_info (MonoClass *klass);
 
 void
-mono_class_set_marshal_info (MonoClass *class, MonoMarshalType *marshal_info);
+mono_class_set_marshal_info (MonoClass *klass, MonoMarshalType *marshal_info);
 
 guint32
-mono_class_get_ref_info_handle (MonoClass *class);
+mono_class_get_ref_info_handle (MonoClass *klass);
 
 guint32
-mono_class_set_ref_info_handle (MonoClass *class, guint32 value);
+mono_class_set_ref_info_handle (MonoClass *klass, guint32 value);
 
 MonoErrorBoxed*
 mono_class_get_exception_data (MonoClass *klass);
@@ -1518,10 +1518,10 @@ void
 mono_class_set_field_def_values (MonoClass *klass, MonoFieldDefaultValue *values);
 
 guint32
-mono_class_get_declsec_flags (MonoClass *class);
+mono_class_get_declsec_flags (MonoClass *klass);
 
 void
-mono_class_set_declsec_flags (MonoClass *class, guint32 value);
+mono_class_set_declsec_flags (MonoClass *klass, guint32 value);
 
 void
 mono_class_set_is_com_object (MonoClass *klass);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4244,7 +4244,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 	register const unsigned char *ip, *end;
 	const MonoOpcode *opcode;
 	MonoMethod *m;
-	MonoClass *class;
+	MonoClass *klass;
 	unsigned char *is_bb_start;
 	int in;
 	MonoVTable *method_class_vt;
@@ -4378,13 +4378,13 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 			break;
 		case MonoInlineType:
 			if (method->wrapper_type == MONO_WRAPPER_NONE) {
-				class = mini_get_class (method, read32 (ip + 1), generic_context);
-				mono_class_init (class);
+				klass = mini_get_class (method, read32 (ip + 1), generic_context);
+				mono_class_init (klass);
 				/* quick fix to not do this for the fake ptr classes - probably should not be getting the vtable at all here */
 #if 0
-				g_error ("FIXME: interface method lookup: %s (in method %s)", class->name, method->name);
-				if (!(class->flags & TYPE_ATTRIBUTE_INTERFACE) && class->interface_offsets != NULL)
-					mono_class_vtable (domain, class);
+				g_error ("FIXME: interface method lookup: %s (in method %s)", klass->name, method->name);
+				if (!(klass->flags & TYPE_ATTRIBUTE_INTERFACE) && klass->interface_offsets != NULL)
+					mono_class_vtable (domain, klass);
 #endif
 			}
 			ip += 5;


### PR DESCRIPTION
Replace 'class' identifier usage with 'klass' to avoid compile errors in C++