### PR TITLE
Add g_ptr_array_capacity function

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -129,6 +129,7 @@
 #define g_printerr monoeg_g_printerr
 #define g_propagate_error monoeg_g_propagate_error
 #define g_ptr_array_add monoeg_g_ptr_array_add
+#define g_ptr_array_capacity monoeg_g_ptr_array_capacity
 #define g_ptr_array_foreach monoeg_g_ptr_array_foreach
 #define g_ptr_array_free monoeg_g_ptr_array_free
 #define g_ptr_array_new monoeg_g_ptr_array_new

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -524,6 +524,7 @@ void       g_ptr_array_sort_with_data     (GPtrArray *array, GCompareDataFunc co
 void       g_ptr_array_set_size           (GPtrArray *array, gint length);
 gpointer  *g_ptr_array_free               (GPtrArray *array, gboolean free_seg);
 void       g_ptr_array_foreach            (GPtrArray *array, GFunc func, gpointer user_data);
+guint      g_ptr_array_capacity           (GPtrArray *array);
 #define    g_ptr_array_index(array,index) (array)->pdata[(index)]
 
 /*

--- a/mono/eglib/gptrarray.c
+++ b/mono/eglib/gptrarray.c
@@ -225,3 +225,8 @@ g_ptr_array_sort_with_data (GPtrArray *array, GCompareDataFunc compare, gpointer
 	g_qsort_with_data (array->pdata, array->len, sizeof (gpointer), compare, user_data);
 }
 
+guint
+g_ptr_array_capacity (GPtrArray *array)
+{
+	return ((GPtrArrayPriv *)array)->size;
+}


### PR DESCRIPTION
Add g_ptr_array_capacity to retrieve current size of GPtrArray. Allows clients to know if future additions will cause (re)allocations.