### PR TITLE
[Tests] Fix flaky IO tests due to parrallel execution on Mac bots.

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -25,13 +25,14 @@ namespace MonoTests.System.IO
 	public class FileTest
 	{
 		CultureInfo old_culture;
-		static string TempFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
+		string tmpFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
 
 		[SetUp]
 		public void SetUp ()
 		{
-			DeleteDirectory (TempFolder);
-			Directory.CreateDirectory (TempFolder);
+			tmpFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
+			DeleteDirectory (tmpFolder);
+			Directory.CreateDirectory (tmpFolder);
 			old_culture = Thread.CurrentThread.CurrentCulture;
 			Thread.CurrentThread.CurrentCulture = new CultureInfo ("en-US", false);
 		}
@@ -39,7 +40,7 @@ namespace MonoTests.System.IO
 		[TearDown]
 		public void TearDown ()
 		{
-			DeleteDirectory (TempFolder);
+			DeleteDirectory (tmpFolder);
 			Thread.CurrentThread.CurrentCulture = old_culture;
 		}
 
@@ -65,7 +66,7 @@ namespace MonoTests.System.IO
 		public void TestExists ()
 		{
 			FileStream s = null;
-			string path = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
 			try {
 				Assert.IsFalse (File.Exists (null), "#1");
 				Assert.IsFalse (File.Exists (string.Empty), "#2");
@@ -74,7 +75,7 @@ namespace MonoTests.System.IO
 				s = File.Create (path);
 				s.Close ();
 				Assert.IsTrue (File.Exists (path), "#4");
-				Assert.IsFalse (File.Exists (TempFolder + Path.DirectorySeparatorChar + "doesnotexist"), "#5");
+				Assert.IsFalse (File.Exists (tmpFolder + Path.DirectorySeparatorChar + "doesnotexist"), "#5");
 			} finally {
 				if (s != null)
 					s.Close ();
@@ -112,7 +113,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Create_Path_Directory ()
 		{
-			string path = Path.Combine (TempFolder, "foo");
+			string path = Path.Combine (tmpFolder, "foo");
 			Directory.CreateDirectory (path);
 			try {
 				File.Create (path);
@@ -146,7 +147,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Create_Path_ReadOnly ()
 		{
-			string path = Path.Combine (TempFolder, "foo");
+			string path = Path.Combine (tmpFolder, "foo");
 			File.Create (path).Close ();
 			File.SetAttributes (path, FileAttributes.ReadOnly);
 			try {
@@ -182,7 +183,7 @@ namespace MonoTests.System.IO
 		public void Create_Directory_DoesNotExist ()
 		{
 			FileStream stream = null;
-			string path = TempFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo";
 			
 			try {
 				stream = File.Create (path);
@@ -207,7 +208,7 @@ namespace MonoTests.System.IO
 			string path = null;
 
 			/* positive test: create resources/foo */
-			path = TempFolder + Path.DirectorySeparatorChar + "foo";
+			path = tmpFolder + Path.DirectorySeparatorChar + "foo";
 			try {
 
 				stream = File.Create (path);
@@ -222,7 +223,7 @@ namespace MonoTests.System.IO
 			stream = null;
 
 			/* positive test: repeat test above again to test for overwriting file */
-			path = TempFolder + Path.DirectorySeparatorChar + "foo";
+			path = tmpFolder + Path.DirectorySeparatorChar + "foo";
 			try {
 				stream = File.Create (path);
 				Assert.IsTrue (File.Exists (path), "#2");
@@ -339,8 +340,8 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Copy_DestFileName_AlreadyExists ()
 		{
-			string source = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
-			string dest = TempFolder + Path.DirectorySeparatorChar + "bar";
+			string source = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			string dest = tmpFolder + Path.DirectorySeparatorChar + "bar";
 			DeleteFile (source);
 			DeleteFile (dest);
 			try {
@@ -365,7 +366,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Copy_SourceFileName_DestFileName_Same ()
 		{
-			string source = TempFolder + Path.DirectorySeparatorChar + "SameFile.txt";
+			string source = tmpFolder + Path.DirectorySeparatorChar + "SameFile.txt";
 			DeleteFile (source);
 			try {
 				// new empty file
@@ -386,8 +387,8 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Copy ()
 		{
-			string path1 = TempFolder + Path.DirectorySeparatorChar + "bar";
-			string path2 = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			string path1 = tmpFolder + Path.DirectorySeparatorChar + "bar";
+			string path2 = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
 			/* positive test: copy resources/AFile.txt to resources/bar */
 			try {
 				DeleteFile (path1);
@@ -455,7 +456,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Delete_Directory_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo";
 			if (Directory.Exists (path))
 				Directory.Delete (path, true);
 
@@ -474,7 +475,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Delete ()
 		{
-			string foopath = TempFolder + Path.DirectorySeparatorChar + "foo";
+			string foopath = tmpFolder + Path.DirectorySeparatorChar + "foo";
 			DeleteFile (foopath);
 			try {
 				File.Create (foopath).Close ();
@@ -490,7 +491,7 @@ namespace MonoTests.System.IO
 		[Category ("NotWorking")]
 		public void Delete_FileLock ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "DeleteOpenStreamException";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "DeleteOpenStreamException";
 			DeleteFile (path);
 			FileStream stream = null;
 			try {
@@ -520,7 +521,7 @@ namespace MonoTests.System.IO
 			if (RunningOnUnix)
 				Assert.Ignore ("ReadOnly files can be deleted on unix since fdef50957f508627928c7876a905d5584da45748.");
 
-			string path = TempFolder + Path.DirectorySeparatorChar + "DeleteReadOnly";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "DeleteReadOnly";
 			DeleteFile (path);
 			try {
 				File.Create (path).Close ();
@@ -546,7 +547,7 @@ namespace MonoTests.System.IO
 
 			FileAttributes attrs;
 
-			string path = Path.Combine (TempFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -565,7 +566,7 @@ namespace MonoTests.System.IO
 			if (RunningOnUnix)
 				Assert.Ignore ("bug #325181: FileAttributes.Archive has no effect on Unix.");
 
-			string path = Path.Combine (TempFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
 			File.Create (path).Close ();
 
 			FileAttributes attrs = File.GetAttributes (path);
@@ -581,7 +582,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetAttributes_Default_Directory ()
 		{
-			FileAttributes attrs = File.GetAttributes (TempFolder);
+			FileAttributes attrs = File.GetAttributes (tmpFolder);
 
 			Assert.IsFalse ((attrs & FileAttributes.Archive) != 0, "#1");
 			Assert.IsTrue ((attrs & FileAttributes.Directory) != 0, "#2");
@@ -594,16 +595,16 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetAttributes_Directory ()
 		{
-			FileAttributes attrs = File.GetAttributes (TempFolder);
+			FileAttributes attrs = File.GetAttributes (tmpFolder);
 
 			Assert.IsTrue ((attrs & FileAttributes.Directory) != 0, "#1");
 
 			attrs &= ~FileAttributes.Directory;
-			File.SetAttributes (TempFolder, attrs);
+			File.SetAttributes (tmpFolder, attrs);
 
 			Assert.IsFalse ((attrs & FileAttributes.Directory) != 0, "#2");
 
-			string path = Path.Combine (TempFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -618,7 +619,7 @@ namespace MonoTests.System.IO
 		{
 			FileAttributes attrs;
 
-			string path = Path.Combine (TempFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -643,7 +644,7 @@ namespace MonoTests.System.IO
 
 			FileAttributes attrs;
 
-			string path = Path.Combine (TempFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -659,7 +660,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetAttributes_Path_DoesNotExist ()
 		{
-			string path = Path.Combine (TempFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
 			try {
 				File.GetAttributes (path);
 				Assert.Fail ("#1");
@@ -791,7 +792,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Move_SourceFileName_DoesNotExist ()
 		{
-			string file = TempFolder + Path.DirectorySeparatorChar + "doesnotexist";
+			string file = tmpFolder + Path.DirectorySeparatorChar + "doesnotexist";
 			DeleteFile (file);
 			try {
 				File.Move (file, "b");
@@ -807,8 +808,8 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Move_DestFileName_DirectoryDoesNotExist ()
 		{
-			string sourceFile = TempFolder + Path.DirectorySeparatorChar + "foo";
-			string destFile = Path.Combine (Path.Combine (TempFolder, "doesnotexist"), "b");
+			string sourceFile = tmpFolder + Path.DirectorySeparatorChar + "foo";
+			string destFile = Path.Combine (Path.Combine (tmpFolder, "doesnotexist"), "b");
 			DeleteFile (sourceFile);
 			try {
 				File.Create (sourceFile).Close ();
@@ -830,13 +831,13 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Move_DestFileName_AlreadyExists ()
 		{
-			string sourceFile = TempFolder + Path.DirectorySeparatorChar + "foo";
+			string sourceFile = tmpFolder + Path.DirectorySeparatorChar + "foo";
 			string destFile;
 
 			// move to same directory
 			File.Create (sourceFile).Close ();
 			try {
-				File.Move (sourceFile, TempFolder);
+				File.Move (sourceFile, tmpFolder);
 				Assert.Fail ("#A1");
 			} catch (IOException ex) {
 				// Cannot create a file when that file already exists
@@ -844,14 +845,14 @@ namespace MonoTests.System.IO
 				Assert.IsNull (ex.InnerException, "#A3");
 				Assert.IsNotNull (ex.Message, "#A4");
 				Assert.IsFalse (ex.Message.IndexOf (sourceFile) != -1, "#A5");
-				Assert.IsFalse (ex.Message.IndexOf (TempFolder) != -1, "#A6");
+				Assert.IsFalse (ex.Message.IndexOf (tmpFolder) != -1, "#A6");
 			} finally {
 				DeleteFile (sourceFile);
 			}
 
 			// move to exist file
 			File.Create (sourceFile).Close ();
-			destFile = TempFolder + Path.DirectorySeparatorChar + "bar";
+			destFile = tmpFolder + Path.DirectorySeparatorChar + "bar";
 			File.Create (destFile).Close ();
 			try {
 				File.Move (sourceFile, destFile);
@@ -870,7 +871,7 @@ namespace MonoTests.System.IO
 
 			// move to existing directory
 			File.Create (sourceFile).Close ();
-			destFile = TempFolder + Path.DirectorySeparatorChar + "bar";
+			destFile = tmpFolder + Path.DirectorySeparatorChar + "bar";
 			Directory.CreateDirectory (destFile);
 			try {
 				File.Move (sourceFile, destFile);
@@ -891,8 +892,8 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Move ()
 		{
-			string bar = TempFolder + Path.DirectorySeparatorChar + "bar";
-			string baz = TempFolder + Path.DirectorySeparatorChar + "baz";
+			string bar = tmpFolder + Path.DirectorySeparatorChar + "bar";
+			string baz = tmpFolder + Path.DirectorySeparatorChar + "baz";
 			if (!File.Exists (bar)) {
 				FileStream f = File.Create(bar);
 				f.Close();
@@ -904,8 +905,8 @@ namespace MonoTests.System.IO
 			Assert.IsTrue (File.Exists (baz), "#3");
 
 			// Test moving of directories
-			string dir = Path.Combine (TempFolder, "dir");
-			string dir2 = Path.Combine (TempFolder, "dir2");
+			string dir = Path.Combine (tmpFolder, "dir");
+			string dir2 = Path.Combine (tmpFolder, "dir2");
 			string dir_foo = Path.Combine (dir, "foo");
 			string dir2_foo = Path.Combine (dir2, "foo");
 
@@ -965,7 +966,7 @@ namespace MonoTests.System.IO
 			string path = null;
 			FileStream stream = null;
 
-			path = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			path = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
 			try {
 				if (!File.Exists (path))
 					stream = File.Create (path);
@@ -1009,7 +1010,7 @@ namespace MonoTests.System.IO
 			stream = null;
 
 			/* Exception tests */
-			path = TempFolder + Path.DirectorySeparatorChar + "filedoesnotexist";
+			path = tmpFolder + Path.DirectorySeparatorChar + "filedoesnotexist";
 			try {
 				stream = File.Open (path, FileMode.Open);
 				Assert.Fail ("#D1");
@@ -1028,10 +1029,10 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Open_CreateNewMode_ReadAccess ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
 			FileStream stream = null;
 			try {
-				stream = File.Open (TempFolder + Path.DirectorySeparatorChar + "AFile.txt", FileMode.CreateNew, FileAccess.Read);
+				stream = File.Open (tmpFolder + Path.DirectorySeparatorChar + "AFile.txt", FileMode.CreateNew, FileAccess.Read);
 				Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Combining FileMode: CreateNew with FileAccess: Read is invalid
@@ -1049,7 +1050,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Open_AppendMode_ReadAccess ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
 			FileStream s = null;
 			if (!File.Exists (path))
 				File.Create (path).Close ();
@@ -1072,7 +1073,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void OpenRead ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
 			if (!File.Exists (path))
 				File.Create (path).Close ();
 			FileStream stream = null;
@@ -1092,7 +1093,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void OpenWrite ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
 			if (!File.Exists (path))
 				File.Create (path).Close ();
 			FileStream stream = null;
@@ -1113,7 +1114,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void TestGetCreationTime ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "baz";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "baz";
 			DeleteFile (path);
 
 			try {
@@ -1170,7 +1171,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void LastAccessTime ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "lastAccessTime";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "lastAccessTime";
 			if (File.Exists (path))
 				File.Delete (path);
 			FileStream stream = null;
@@ -1217,7 +1218,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void LastWriteTime ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "lastWriteTime";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "lastWriteTime";
 			if (File.Exists (path))
 				File.Delete (path);
 			FileStream stream = null;
@@ -1293,7 +1294,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetCreationTime_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "GetCreationTimeException3";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "GetCreationTimeException3";
 			DeleteFile (path);
 
 			DateTime time = File.GetCreationTime (path);
@@ -1368,7 +1369,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetCreationTimeUtc_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "GetCreationTimeUtcException3";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "GetCreationTimeUtcException3";
 			DeleteFile (path);
 
 			DateTime time = File.GetCreationTimeUtc (path);
@@ -1442,7 +1443,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetLastAccessTime_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "GetLastAccessTimeException3";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "GetLastAccessTimeException3";
 			DeleteFile (path);
 
 			DateTime time = File.GetLastAccessTime (path);
@@ -1517,7 +1518,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetLastAccessTimeUtc_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "GetLastAccessTimeUtcException3";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "GetLastAccessTimeUtcException3";
 			DeleteFile (path);
 
 			DateTime time = File.GetLastAccessTimeUtc (path);
@@ -1591,7 +1592,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetLastWriteTime_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "GetLastAccessTimeUtcException3";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "GetLastAccessTimeUtcException3";
 			DeleteFile (path);
 
 			DateTime time = File.GetLastWriteTime (path);
@@ -1666,7 +1667,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetLastWriteTimeUtc_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "GetLastWriteTimeUtcException3";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "GetLastWriteTimeUtcException3";
 			DeleteFile (path);
 
 			DateTime time = File.GetLastWriteTimeUtc (path);
@@ -1711,7 +1712,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void FileStreamClose ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "FileStreamClose";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "FileStreamClose";
 			FileStream stream = null;
 			try {
 				stream = File.Create (path);
@@ -1792,7 +1793,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetCreationTime_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetCreationTimeFileNotFoundException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetCreationTimeFileNotFoundException1";
 			DeleteFile (path);
 			
 			try {
@@ -1810,7 +1811,7 @@ namespace MonoTests.System.IO
 //		[ExpectedException(typeof (ArgumentOutOfRangeException))]
 //		public void SetCreationTimeArgumentOutOfRangeException1 ()
 //		{
-//			string path = TempFolder + Path.DirectorySeparatorChar + "SetCreationTimeArgumentOutOfRangeException1";
+//			string path = tmpFolder + Path.DirectorySeparatorChar + "SetCreationTimeArgumentOutOfRangeException1";
 //			FileStream stream = null;
 //			DeleteFile (path);
 //			try {
@@ -1827,7 +1828,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetCreationTime_FileLock ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "CreationTimeIOException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "CreationTimeIOException1";
 			DeleteFile (path);
 			FileStream stream = null;
 			try {
@@ -1916,7 +1917,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetCreationTimeUtc_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetCreationTimeUtcFileNotFoundException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetCreationTimeUtcFileNotFoundException1";
 			DeleteFile (path);
 
 			try {
@@ -1934,7 +1935,7 @@ namespace MonoTests.System.IO
 //		[ExpectedException(typeof (ArgumentOutOfRangeException))]
 //		public void SetCreationTimeUtcArgumentOutOfRangeException1 ()
 //		{
-//			string path = TempFolder + Path.DirectorySeparatorChar + "SetCreationTimeUtcArgumentOutOfRangeException1";
+//			string path = tmpFolder + Path.DirectorySeparatorChar + "SetCreationTimeUtcArgumentOutOfRangeException1";
 //			DeleteFile (path);
 //			FileStream stream = null;
 //			try {
@@ -1951,7 +1952,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetCreationTimeUtc_FileLock ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetCreationTimeUtcIOException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetCreationTimeUtcIOException1";
 			DeleteFile (path);
 			FileStream stream = null;
 			try {
@@ -2042,7 +2043,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastAccessTime_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeFileNotFoundException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeFileNotFoundException1";
 			DeleteFile (path);
 
 			try {
@@ -2060,7 +2061,7 @@ namespace MonoTests.System.IO
 //		[ExpectedException(typeof (ArgumentOutOfRangeException))]
 //		public void SetLastAccessTimeArgumentOutOfRangeException1 ()
 //		{
-//			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastTimeArgumentOutOfRangeException1";
+//			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastTimeArgumentOutOfRangeException1";
 //			DeleteFile (path);
 //			FileStream stream = null;
 //			try {
@@ -2077,7 +2078,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastAccessTime_FileLock ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "LastAccessIOException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "LastAccessIOException1";
 			DeleteFile (path);
 			FileStream stream = null;
 			try {
@@ -2166,7 +2167,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastAccessTimeUtc_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeUtcFileNotFoundException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeUtcFileNotFoundException1";
 			DeleteFile (path);
 
 			try {
@@ -2184,7 +2185,7 @@ namespace MonoTests.System.IO
 //		[ExpectedException(typeof (ArgumentOutOfRangeException))]
 //		public void SetLastAccessTimeUtcArgumentOutOfRangeException1 ()
 //		{
-//			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeUtcArgumentOutOfRangeException1";
+//			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeUtcArgumentOutOfRangeException1";
 //			DeleteFile (path);
 //			FileStream stream = null;
 //			try {
@@ -2201,7 +2202,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastAccessTimeUtc_FileLock ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeUtcIOException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastAccessTimeUtcIOException1";
 			DeleteFile (path);
 			FileStream stream = null;
 			try {
@@ -2292,7 +2293,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastWriteTime_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeFileNotFoundException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeFileNotFoundException1";
 			DeleteFile (path);
 
 			try {
@@ -2310,7 +2311,7 @@ namespace MonoTests.System.IO
 //		[ExpectedException(typeof (ArgumentOutOfRangeException))]
 //		public void SetLastWriteTimeArgumentOutOfRangeException1 ()
 //		{
-//			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeArgumentOutOfRangeException1";
+//			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeArgumentOutOfRangeException1";
 //			DeleteFile (path);
 //			FileStream stream = null;
 //			try {
@@ -2327,7 +2328,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastWriteTime_FileLock ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "LastWriteTimeIOException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "LastWriteTimeIOException1";
 			DeleteFile (path);
 			FileStream stream = null;
 			try {
@@ -2416,7 +2417,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastWriteTimeUtc_Path_DoesNotExist ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeUtcFileNotFoundException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeUtcFileNotFoundException1";
 			DeleteFile (path);
 
 			try {
@@ -2434,7 +2435,7 @@ namespace MonoTests.System.IO
 //		[ExpectedException(typeof (ArgumentOutOfRangeException))]
 //		public void SetLastWriteTimeUtcArgumentOutOfRangeException1 ()
 //		{
-//			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeUtcArgumentOutOfRangeException1";
+//			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeUtcArgumentOutOfRangeException1";
 //			DeleteFile (path);
 //			FileStream stream = null;
 //			try {
@@ -2451,7 +2452,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void SetLastWriteTimeUtc_FileLock ()
 		{
-			string path = TempFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeUtcIOException1";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "SetLastWriteTimeUtcIOException1";
 			DeleteFile (path);
 			FileStream stream = null;
 			try {
@@ -2580,7 +2581,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void ReplaceTest ()
 		{
-			string tmp = Path.Combine (TempFolder, "ReplaceTest");
+			string tmp = Path.Combine (tmpFolder, "ReplaceTest");
 			Directory.CreateDirectory (tmp);
 			string origFile = Path.Combine (tmp, "origFile");
 			string replaceFile = Path.Combine (tmp, "replaceFile");

--- a/mcs/class/corlib/Test/System.IO/StreamReaderTest.cs
+++ b/mcs/class/corlib/Test/System.IO/StreamReaderTest.cs
@@ -18,15 +18,18 @@ namespace MonoTests.System.IO
 [TestFixture]
 public class StreamReaderTest
 {
-	static string TempFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
-	private string _codeFileName = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
+	private string _tmpFolder;
+	private string _codeFileName;
 	private const string TestString = "Hello World!";
 
 	[SetUp]
 	public void SetUp ()
 	{	
-		if (!Directory.Exists (TempFolder))
-			Directory.CreateDirectory (TempFolder);
+		_tmpFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
+		_codeFileName = _tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
+
+		if (!Directory.Exists (_tmpFolder))
+			Directory.CreateDirectory (_tmpFolder);
 		
 		if (!File.Exists (_codeFileName))
 			File.Create (_codeFileName).Close ();
@@ -35,8 +38,8 @@ public class StreamReaderTest
 	[TearDown]
 	public void TearDown ()
 	{
-		if (Directory.Exists (TempFolder))
-			Directory.Delete (TempFolder, true);
+		if (Directory.Exists (_tmpFolder))
+			Directory.Delete (_tmpFolder, true);
 	}
 
 
@@ -245,7 +248,7 @@ public class StreamReaderTest
 		{
 			bool errorThrown = false;
 			try {
-				new StreamReader(TempFolder + "/nonexistentfile", false);
+				new StreamReader(_tmpFolder + "/nonexistentfile", false);
 			} catch (FileNotFoundException) {
 				errorThrown = true;
 			} catch (Exception e) {
@@ -256,7 +259,7 @@ public class StreamReaderTest
 		{
 			bool errorThrown = false;
 			try {
-				new StreamReader(TempFolder + "/nonexistentdir/file", false);
+				new StreamReader(_tmpFolder + "/nonexistentdir/file", false);
 			} catch (DirectoryNotFoundException) {
 				errorThrown = true;
 			} catch (Exception e) {
@@ -310,7 +313,7 @@ public class StreamReaderTest
 		{
 			bool errorThrown = false;
 			try {
-				new StreamReader(TempFolder + "/nonexistentfile", true);
+				new StreamReader(_tmpFolder + "/nonexistentfile", true);
 			} catch (FileNotFoundException) {
 				errorThrown = true;
 			} catch (Exception e) {
@@ -321,7 +324,7 @@ public class StreamReaderTest
 		{
 			bool errorThrown = false;
 			try {
-				new StreamReader(TempFolder + "/nonexistentdir/file", true);
+				new StreamReader(_tmpFolder + "/nonexistentdir/file", true);
 			} catch (DirectoryNotFoundException) {
 				errorThrown = true;
 			} catch (Exception e) {

--- a/mcs/class/corlib/Test/System.IO/StreamWriterTest.cs
+++ b/mcs/class/corlib/Test/System.IO/StreamWriterTest.cs
@@ -95,16 +95,20 @@ namespace MonoTests.System.IO
 			}
 		}
 
-	static string TempFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
-	private string _codeFileName = TempFolder + Path.DirectorySeparatorChar + "AFile.txt";
-	private string _thisCodeFileName = TempFolder + Path.DirectorySeparatorChar + "StreamWriterTest.temp";
+	private string _tmpFolder;
+	private string _codeFileName;
+	private string _thisCodeFileName;
 
 	[SetUp]
 	public void SetUp ()
 	{
-		if (Directory.Exists (TempFolder))
-			Directory.Delete (TempFolder, true);
-		Directory.CreateDirectory (TempFolder);
+		_tmpFolder = Path.Combine (Path.GetTempPath (), "MonoTests.System.IO.Tests");
+		_codeFileName = _tmpFolder + Path.DirectorySeparatorChar + "AFile.txt";
+		_thisCodeFileName = _tmpFolder + Path.DirectorySeparatorChar + "StreamWriterTest.temp";
+
+		if (Directory.Exists (_tmpFolder))
+			Directory.Delete (_tmpFolder, true);
+		Directory.CreateDirectory (_tmpFolder);
 
 		if (!File.Exists (_thisCodeFileName)) 
 			File.Create (_thisCodeFileName).Close ();
@@ -113,8 +117,8 @@ namespace MonoTests.System.IO
 	[TearDown]
 	public void TearDown ()
 	{
-		if (Directory.Exists (TempFolder))
-			Directory.Delete (TempFolder, true);
+		if (Directory.Exists (_tmpFolder))
+			Directory.Delete (_tmpFolder, true);
 	}
 
 	[Test] // .ctor (Stream)
@@ -182,7 +186,7 @@ namespace MonoTests.System.IO
 	[Test] // .ctor (String)
 	public void Constructor2_Path_DirectoryNotFound ()
 	{
-		Directory.Delete (TempFolder, true);
+		Directory.Delete (_tmpFolder, true);
 
 		try {
 			new StreamWriter (_codeFileName);
@@ -192,7 +196,7 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#2");
 			Assert.IsNull (ex.InnerException, "#3");
 			Assert.IsNotNull (ex.Message, "#4");
-			Assert.IsTrue (ex.Message.IndexOf (TempFolder) != -1, "#5");
+			Assert.IsTrue (ex.Message.IndexOf (_tmpFolder) != -1, "#5");
 		}
 	}
 
@@ -328,7 +332,7 @@ namespace MonoTests.System.IO
 	[Test] // .ctor (String, Boolean)
 	public void Constructor4_Path_DirectoryNotFound ()
 	{
-		Directory.Delete (TempFolder, true);
+		Directory.Delete (_tmpFolder, true);
 
 		try {
 			new StreamWriter (_codeFileName, false);
@@ -338,7 +342,7 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#A2");
 			Assert.IsNull (ex.InnerException, "#A3");
 			Assert.IsNotNull (ex.Message, "#A4");
-			Assert.IsTrue (ex.Message.IndexOf (TempFolder) != -1, "#A5");
+			Assert.IsTrue (ex.Message.IndexOf (_tmpFolder) != -1, "#A5");
 		}
 
 		try {
@@ -349,7 +353,7 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#B2");
 			Assert.IsNull (ex.InnerException, "#B3");
 			Assert.IsNotNull (ex.Message, "#B4");
-			Assert.IsTrue (ex.Message.IndexOf (TempFolder) != -1, "#B5");
+			Assert.IsTrue (ex.Message.IndexOf (_tmpFolder) != -1, "#B5");
 		}
 	}
 
@@ -579,7 +583,7 @@ namespace MonoTests.System.IO
 	[Test] // .ctor (String, Boolean, Encoding)
 	public void Constructor6_Path_DirectoryNotFound ()
 	{
-		Directory.Delete (TempFolder, true);
+		Directory.Delete (_tmpFolder, true);
 
 		try {
 			new StreamWriter (_codeFileName, false, Encoding.UTF8);
@@ -589,7 +593,7 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#A2");
 			Assert.IsNull (ex.InnerException, "#A3");
 			Assert.IsNotNull (ex.Message, "#A4");
-			Assert.IsTrue (ex.Message.IndexOf (TempFolder) != -1, "#A5");
+			Assert.IsTrue (ex.Message.IndexOf (_tmpFolder) != -1, "#A5");
 		}
 
 		try {
@@ -600,7 +604,7 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#B2");
 			Assert.IsNull (ex.InnerException, "#B3");
 			Assert.IsNotNull (ex.Message, "#B4");
-			Assert.IsTrue (ex.Message.IndexOf (TempFolder) != -1, "#B5");
+			Assert.IsTrue (ex.Message.IndexOf (_tmpFolder) != -1, "#B5");
 		}
 	}
 
@@ -759,7 +763,7 @@ namespace MonoTests.System.IO
 	[Test] // .ctor (String, Boolean, Encoding, Int32)
 	public void Constructor7_Path_DirectoryNotFound ()
 	{
-		Directory.Delete (TempFolder, true);
+		Directory.Delete (_tmpFolder, true);
 
 		try {
 			new StreamWriter (_codeFileName, false, Encoding.UTF8, 10);
@@ -769,7 +773,7 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#A2");
 			Assert.IsNull (ex.InnerException, "#A3");
 			Assert.IsNotNull (ex.Message, "#A4");
-			Assert.IsTrue (ex.Message.IndexOf (TempFolder) != -1, "#A5");
+			Assert.IsTrue (ex.Message.IndexOf (_tmpFolder) != -1, "#A5");
 		}
 
 		try {
@@ -780,7 +784,7 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#B2");
 			Assert.IsNull (ex.InnerException, "#B3");
 			Assert.IsNotNull (ex.Message, "#B4");
-			Assert.IsTrue (ex.Message.IndexOf (TempFolder) != -1, "#B5");
+			Assert.IsTrue (ex.Message.IndexOf (_tmpFolder) != -1, "#B5");
 		}
 	}
 


### PR DESCRIPTION
Some of the IO tests do not create a diff temp file per test but per
fixture. This is problematic when the test cases are ran in parallel.
Moving the creation of the tmp dirs to the SetUp to ensure that each
test case has its own path.

An example of the failures can be found here: https://jenkins.mono-project.com/job/xamarin-macios-pr-builder/5474/Test_Report/

You can see that tests that pass in sequential order will fail if they are executed in parallel.