### PR TITLE
[Test] Fix System.IO.Compression.FileSystem tests on iOS devices.

### DIFF
--- a/mcs/class/System.IO.Compression.FileSystem/Test/System.IO.Compression.FileSystem/ZipTest.cs
+++ b/mcs/class/System.IO.Compression.FileSystem/Test/System.IO.Compression.FileSystem/ZipTest.cs
@@ -36,22 +36,29 @@ namespace MonoTests.System.IO.Compression.FileSystem
 	[TestFixture]
 	public class ZipArchiveTests
 	{
+		string tmpFile;
+		[SetUp]
+		public void SetUp ()
+		{
+			tmpFile = Path.GetTempFileName ();
+		}
+
 		[TearDown]
 		public void Dispose()
 		{
-			File.Delete ("foo.zip");
+			File.Delete (tmpFile);
 		}
 
 		[Test]
 		public void ZipCreateFromDirectory()
 		{
-			if (File.Exists ("foo.zip"))
-				File.Delete ("foo.zip");
+			if (File.Exists (tmpFile))
+				File.Delete (tmpFile);
 
-			ZipFile.CreateFromDirectory ("foo", "foo.zip");
-			Assert.IsTrue(File.Exists("foo.zip"));
+			ZipFile.CreateFromDirectory ("foo", tmpFile);
+			Assert.IsTrue(File.Exists(tmpFile));
 
-			using (var archive = new ZipArchive (File.Open ("foo.zip", FileMode.Open),
+			using (var archive = new ZipArchive (File.Open (tmpFile, FileMode.Open),
 				ZipArchiveMode.Read))
 			{
 				Assert.IsNotNull (archive.GetEntry ("foo.txt"));
@@ -65,14 +72,14 @@ namespace MonoTests.System.IO.Compression.FileSystem
 		[Test]
 		public void ZipCreateFromDirectoryIncludeBase()
 		{
-			if (File.Exists ("foo.zip"))
-				File.Delete ("foo.zip");
+			if (File.Exists (tmpFile))
+				File.Delete (tmpFile);
 
-			ZipFile.CreateFromDirectory ("foo", "foo.zip", CompressionLevel.Fastest,
+			ZipFile.CreateFromDirectory ("foo", tmpFile, CompressionLevel.Fastest,
 				includeBaseDirectory: true);
-			Assert.IsTrue (File.Exists ("foo.zip"));
+			Assert.IsTrue (File.Exists (tmpFile));
 
-			using (var archive = new ZipArchive (File.Open ("foo.zip", FileMode.Open),
+			using (var archive = new ZipArchive (File.Open (tmpFile, FileMode.Open),
 				ZipArchiveMode.Read))
 			{
 				Assert.IsNotNull (archive.GetEntry ("foo/foo.txt"));
@@ -86,34 +93,35 @@ namespace MonoTests.System.IO.Compression.FileSystem
 		[Test]
 		public void ZipExtractToDirectory()
 		{
-			if (Directory.Exists ("extract"))
-				Directory.Delete ("extract", true);
+			var extractDir = Path.Combine (Path.GetTempPath (), "extract");
+			if (Directory.Exists (extractDir))
+				Directory.Delete (extractDir, true);
 
-			if (File.Exists ("foo.zip"))
-				File.Delete ("foo.zip");
+			if (File.Exists (tmpFile))
+				File.Delete (tmpFile);
 
-			ZipFile.CreateFromDirectory ("foo", "foo.zip");
+			ZipFile.CreateFromDirectory ("foo", tmpFile);
 
-			ZipFile.ExtractToDirectory ("foo.zip", "extract");
-			Assert.IsTrue(Directory.Exists ("extract"));
+			ZipFile.ExtractToDirectory (tmpFile, extractDir);
+			Assert.IsTrue(Directory.Exists (extractDir));
 
-			Assert.IsTrue (File.Exists ("extract/foo.txt"));
-			Assert.IsTrue (File.Exists ("extract/bar.txt"));
-			Assert.IsTrue (Directory.Exists ("extract/foobar"));
-			Assert.IsTrue (File.Exists ("extract/foobar/foo.txt"));
-			Assert.IsTrue (File.Exists ("extract/foobar/bar.txt"));
+			Assert.IsTrue (File.Exists (Path.Combine (extractDir, "foo.txt")), Path.Combine (extractDir, "foo.txt"));
+			Assert.IsTrue (File.Exists (Path.Combine (extractDir, "bar.txt")), Path.Combine (extractDir, "bar.txt"));
+			Assert.IsTrue (Directory.Exists (Path.Combine (extractDir, "foobar")), Path.Combine (extractDir, "foobar"));
+			Assert.IsTrue (File.Exists (Path.Combine (extractDir, "foobar", "foo.txt")), Path.Combine (extractDir, "foobar", "foo.txt"));
+			Assert.IsTrue (File.Exists (Path.Combine (extractDir, "foobar", "bar.txt")), Path.Combine (extractDir, "foobar", "bar.txt"));
 
-			Directory.Delete ("extract", true);
+			Directory.Delete (extractDir, true);
 		}
 
 		[Test]
 		public void ZipCreateFromEntryChangeTimestamp()
 		{
-			if (File.Exists ("foo.zip"))
-				File.Delete ("foo.zip");
+			if (File.Exists (tmpFile))
+				File.Delete (tmpFile);
 
 			var file = "foo/foo.txt";
-			using (var archive = new ZipArchive(File.Open("foo.zip", FileMode.Create),
+			using (var archive = new ZipArchive(File.Open(tmpFile, FileMode.Create),
 				ZipArchiveMode.Update))
 			{
 				archive.CreateEntryFromFile(file, file);
@@ -121,7 +129,7 @@ namespace MonoTests.System.IO.Compression.FileSystem
 
 			var date = File.GetLastWriteTimeUtc(file);
 
-			using (var archive = new ZipArchive (File.Open ("foo.zip", FileMode.Open),
+			using (var archive = new ZipArchive (File.Open (tmpFile, FileMode.Open),
 				ZipArchiveMode.Read))
 			{
 				var entry = archive.GetEntry (file);


### PR DESCRIPTION
Not using a temp file returns in an exception on iOS devices as per bug
60482.

Cherry picked from https://github.com/mono/mono/pull/5929