### PR TITLE
[runtime/corlib] Improve MissingMethodExceptions by including message and signature. Fixes #60505

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -250,6 +250,8 @@
 			<method signature="System.Void .ctor(System.String)" />
 			<!-- exception.c (mono_get_exception_type_load) mono_exception_from_name_two_strings -->
 			<method signature="System.Void .ctor(System.String,System.String)" />
+			<!-- exception.c  mono_exception_from_name_four_strings -->
+			<method signature="System.Void .ctor(System.String,System.String,System.String,System.String)" />
 		</type>
 		
 		<!-- threadpool.c: mono_thread_pool_init (assert) -->

--- a/mcs/class/referencesource/mscorlib/system/missingmethodexception.cs
+++ b/mcs/class/referencesource/mscorlib/system/missingmethodexception.cs
@@ -48,10 +48,19 @@ namespace System {
                 if (ClassName == null) {
                     return base.Message;
                 } else {
+#if MONO
+                    string res = ClassName + "." + MemberName;
+                    if (!string.IsNullOrEmpty(signature))
+                        res = string.Format (CultureInfo.InvariantCulture, signature, res);
+                    if (!string.IsNullOrEmpty(_message))
+                        res += " Due to: " + _message;
+                    return res;
+#else
                     // do any desired fixups to classname here.
                     return Environment.GetResourceString("MissingMethod_Name",
                                                                        ClassName + "." + MemberName +
                                                                        (Signature != null ? " " + FormatSignature(Signature) : ""));
+#endif
                 }
             }
         }
@@ -73,5 +82,17 @@ namespace System {
         // If ClassName != null, Message will construct on the fly using it
         // and the other variables. This allows customization of the
         // format depending on the language environment.
+#if MONO
+        // Called from the EE
+        private MissingMethodException(String className, String methodName, String signature, String message) : base (message)
+        {
+            ClassName   = className;
+            MemberName  = methodName;
+            this.signature = signature;
+        }
+
+		[NonSerialized]
+        string signature;
+#endif
     }
 }

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -286,6 +286,49 @@ mono_signature_full_name (MonoMethodSignature *sig)
 	return result;
 }
 
+/*
+ * Returns a string ready to be consumed by managed code when formating a string to include class + method name.
+ * IE, say you have void Foo:Bar(int). It will return "void {0}(int)".
+ * The reason for this is that managed exception constructors for missing members require a both class and member names to be provided independently of the signature.
+ */
+char*
+mono_signature_get_managed_fmt_string (MonoMethodSignature *sig)
+{
+	int i;
+	char *result;
+	GString *res;
+
+	if (!sig)
+		return g_strdup ("<invalid signature>");
+
+	res = g_string_new ("");
+
+	mono_type_get_desc (res, sig->ret, TRUE);
+
+	g_string_append (res, " {0}");
+
+	if (sig->generic_param_count) {
+		g_string_append_c (res, '<');
+		for (i = 0; i < sig->generic_param_count; ++i) {
+			if (i > 0)
+				g_string_append (res, ",");
+			g_string_append_printf (res, "!%d", i);
+		}
+		g_string_append_c (res, '>');
+	}
+
+	g_string_append_c (res, '(');
+	for (i = 0; i < sig->param_count; ++i) {
+		if (i > 0)
+			g_string_append_c (res, ',');
+		mono_type_get_desc (res, sig->params [i], TRUE);
+	}
+	g_string_append_c (res, ')');
+	result = res->str;
+	g_string_free (res, FALSE);
+	return result;
+}
+
 void
 mono_ginst_get_desc (GString *str, MonoGenericInst *ginst)
 {

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -30,6 +30,11 @@ mono_exception_from_token_two_strings_checked (MonoImage *image, uint32_t token,
 					       MonoString *a1, MonoString *a2,
 					       MonoError *error);
 
+MonoException *
+mono_exception_from_name_four_strings_checked (MonoImage *image, const char *name_space,
+				      const char *name, MonoString *a1, MonoString *a2, MonoString *a3, MonoString *a4,
+				      MonoError *error);
+
 
 typedef int (*MonoGetSeqPointFunc) (MonoDomain *domain, MonoMethod *method, gint32 native_offset);
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -954,5 +954,8 @@ mono_loader_set_strict_strong_names (gboolean enabled);
 gboolean
 mono_loader_get_strict_strong_names (void);
 
+char*
+mono_signature_get_managed_fmt_string (MonoMethodSignature *sig);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -32,8 +32,9 @@ typedef struct {
 	const char *full_message;
 	const char *full_message_with_fields;
 	const char *first_argument;
+	const char *member_signature;
 
-	void *padding [3];
+	void *padding [2];
 } MonoErrorInternal;
 
 /* Invariant: the error strings are allocated in the mempool of the given image */
@@ -87,7 +88,7 @@ void
 mono_error_set_type_load_name (MonoError *error, const char *type_name, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_method_load (MonoError *error, MonoClass *klass, const char *method_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
+mono_error_set_method_load (MonoError *oerror, MonoClass *klass, const char *method_name, const char *signature, const char *msg_format, ...);
 
 void
 mono_error_set_field_load (MonoError *error, MonoClass *klass, const char *field_name, const char *msg_format, ...)  MONO_ATTR_FORMAT_PRINTF(4,5);

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -53,7 +53,7 @@ mono_error_prepare (MonoErrorInternal *error)
 	if (error->error_code != MONO_ERROR_NONE)
 		return;
 
-	error->type_name = error->assembly_name = error->member_name = error->full_message = error->exception_name_space = error->exception_name = error->full_message_with_fields = error->first_argument = NULL;
+	error->type_name = error->assembly_name = error->member_name = error->full_message = error->exception_name_space = error->exception_name = error->full_message_with_fields = error->first_argument = error->member_signature = NULL;
 	error->exn.klass = NULL;
 }
 
@@ -150,7 +150,8 @@ mono_error_cleanup (MonoError *oerror)
 	g_free ((char*)error->exception_name_space);
 	g_free ((char*)error->exception_name);
 	g_free ((char*)error->first_argument);
-	error->type_name = error->assembly_name = error->member_name = error->exception_name_space = error->exception_name = error->first_argument = NULL;
+	g_free ((char*)error->member_signature);
+	error->type_name = error->assembly_name = error->member_name = error->exception_name_space = error->exception_name = error->first_argument = error->member_signature = NULL;
 	error->exn.klass = NULL;
 
 }
@@ -198,10 +199,11 @@ mono_error_get_message (MonoError *oerror)
 	if (error->full_message_with_fields)
 		return error->full_message_with_fields;
 
-	error->full_message_with_fields = g_strdup_printf ("%s assembly:%s type:%s member:%s",
+	error->full_message_with_fields = g_strdup_printf ("%s assembly:%s type:%s member:%s signature:%s",
 		error->full_message,
 		get_assembly_name (error),
 		get_type_name (error),
+		error->member_signature,
 		error->member_name ? error->member_name : "<none>");
 
 	return error->full_message_with_fields ? error->full_message_with_fields : error->full_message;
@@ -230,6 +232,7 @@ mono_error_dup_strings (MonoError *oerror, gboolean dup_strings)
 		DUP_STR (exception_name_space);
 		DUP_STR (exception_name);
 		DUP_STR (first_argument);
+		DUP_STR (member_signature);
 	}
 #undef DUP_STR
 }
@@ -259,6 +262,14 @@ mono_error_set_member_name (MonoError *oerror, const char *member_name)
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 
 	error->member_name = member_name;
+}
+
+static void
+mono_error_set_member_signature (MonoError *oerror, const char *member_signature)
+{
+	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
+
+	error->member_signature = member_signature;
 }
 
 static void
@@ -349,7 +360,7 @@ mono_error_set_type_load_name (MonoError *oerror, const char *type_name, const c
 }
 
 void
-mono_error_set_method_load (MonoError *oerror, MonoClass *klass, const char *method_name, const char *msg_format, ...)
+mono_error_set_method_load (MonoError *oerror, MonoClass *klass, const char *method_name, const char *signature, const char *msg_format, ...)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 	mono_error_prepare (error);
@@ -357,6 +368,7 @@ mono_error_set_method_load (MonoError *oerror, MonoClass *klass, const char *met
 	error->error_code = MONO_ERROR_MISSING_METHOD;
 	mono_error_set_class (oerror, klass);
 	mono_error_set_member_name (oerror, method_name);
+	mono_error_set_member_signature (oerror, signature);
 	set_error_message ();
 }
 
@@ -648,7 +660,24 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 				break;
 			}
 
-			exception = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "MissingMethodException", type_name, method_name, error_out);
+			MonoString *signature = NULL;
+			if (error->member_signature) {
+				signature = string_new_cleanup (domain, error->member_signature);
+				if (!signature) {
+					mono_error_set_out_of_memory (error_out, "Could not allocate signature");
+					break;
+				}
+			}
+
+			MonoString *message = NULL;
+			if (error->full_message && strlen (error->full_message) > 0) {
+				message = string_new_cleanup (domain, error->full_message);
+				if (!message) {
+					mono_error_set_out_of_memory (error_out, "Could not allocate message");
+					break;
+				}
+			}
+			exception = mono_exception_from_name_four_strings_checked (mono_defaults.corlib, "System", "MissingMethodException", type_name, method_name, signature, message, error_out);
 			if (exception)
 				set_message_on_exception (exception, error, error_out);
 		} else {
@@ -869,6 +898,7 @@ mono_error_box (const MonoError *ierror, MonoImage *image)
 	DUP_STR (full_message);
 	DUP_STR (full_message_with_fields);
 	DUP_STR (first_argument);
+	DUP_STR (member_signature);
 	to->exn.klass = from->exn.klass;
 
 #undef DUP_STR
@@ -915,6 +945,7 @@ mono_error_set_from_boxed (MonoError *oerror, const MonoErrorBoxed *box)
 	DUP_STR (full_message);
 	DUP_STR (full_message_with_fields);
 	DUP_STR (first_argument);
+	DUP_STR (member_signature);
 	to->exn.klass = from->exn.klass;
 		  
 #undef DUP_STR


### PR DESCRIPTION
This PR is missing the following and I'd love if someone could help me here.

Figure out serialization for MethodMissingException - and whether it's ok to break it?
Alternatively, I could use the existing byte[] signature field in MissingMemberException and store a utf8 version of the string currently stored in the new field.

Sort out linker support, this PR adds a dependency to a private constructor so we need the linker to special case it.