### PR TITLE
[ServiceModel.Web] Fix test by adding WebHttpBehavior to WebChannelFactory endpoint on MOBILE

### DIFF
--- a/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebInvokeAttributeTest.cs
+++ b/mcs/class/System.ServiceModel.Web/Test/System.ServiceModel.Web/WebInvokeAttributeTest.cs
@@ -57,10 +57,15 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 
 		[Test]
-		[ExpectedException (typeof (InvalidOperationException))]
 		public void RejectTwoParametersWhenNotWrapped ()
 		{
-			new WebChannelFactory<IBogusService1> (new WebHttpBinding (), new Uri ("http://localhost:37564")).CreateChannel ();
+			var factory = new WebChannelFactory<IBogusService1> (new WebHttpBinding (), new Uri ("http://localhost:37564"));
+
+#if MOBILE
+			factory.Endpoint.Behaviors.Add (new WebHttpBehavior ());
+#endif
+
+			Assert.Throws<InvalidOperationException> (() => factory.CreateChannel ());
 		}
 
 		[ServiceContract]


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59909

WebChannelFactory doesn't add the WebHttpBehavior on mobile:
https://github.com/mono/mono/blob/4272b68b769951c221ec39d3e844f8f715e1df62/mcs/class/System.ServiceModel.Web/System.ServiceModel.Web/WebChannelFactory.cs#L87-L90

This makes the `WebInvokeAttributeTest.RejectTwoParametersWhenNotWrapped()` test fail on mobile since it doesn't reach the normal validation method where it'd fail with InvalidOperationException, e.g. here's the expected stack trace on net_4_x profile:

```
System.InvalidOperationException : Operation 'Join' has multiple message body parts. Add parameters to the UriTemplate or change the BodyStyle to 'Wrapped' or 'WrappedRequest' on the WebInvoke/WebGet attribute.
  at System.ServiceModel.Description.WebHttpBehavior.ValidateOperation (System.ServiceModel.Description.OperationDescription operation) [0x000f9] in /Users/alexander/dev/mono/mcs/class/System.ServiceModel.Web/System.ServiceModel.Description/WebHttpBehavior.cs:249
  at System.ServiceModel.Description.WebHttpBehavior.Validate (System.ServiceModel.Description.ServiceEndpoint endpoint) [0x00028] in /Users/alexander/dev/mono/mcs/class/System.ServiceModel.Web/System.ServiceModel.Description/WebHttpBehavior.cs:268
  at System.ServiceModel.Description.ServiceEndpoint.Validate () [0x0007f] in /Users/alexander/dev/mono/mcs/class/System.ServiceModel/System.ServiceModel.Description/ServiceEndpoint.cs:129
  at System.ServiceModel.ChannelFactory`1[TChannel].CreateChannel (System.ServiceModel.EndpointAddress address, System.Uri via) [0x0002b] in /Users/alexander/dev/mono/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory_1.cs:148
  at System.ServiceModel.ChannelFactory`1[TChannel].CreateChannel (System.ServiceModel.EndpointAddress address) [0x00000] in /Users/alexander/dev/mono/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory_1.cs:115
  at System.ServiceModel.ChannelFactory`1[TChannel].CreateChannel () [0x00006] in /Users/alexander/dev/mono/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory_1.cs:110
```

We can fix this by adding the WebHttpBehavior in the test manually.

NB: I'm actually not sure why this isn't done by default on MOBILE? According to [the docs](https://docs.microsoft.com/en-us/dotnet/api/system.servicemodel.web.webchannelfactory-1?view=netframework-4.7.1#Remarks) it should.