### PR TITLE
[interp] Make the interpreter use the JIT exception handling code.

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -130,6 +130,7 @@ struct _InterpFrame {
 	const unsigned short  *ip;
 	MonoException     *ex;
 	MonoExceptionClause *ex_handler;
+	MonoDomain *domain;
 };
 
 typedef struct {

--- a/mono/mini/interp/interp-stubs.c
+++ b/mono/mini/interp/interp-stubs.c
@@ -82,7 +82,7 @@ mono_interp_set_resume_state (MonoJitTlsData *jit_tls, MonoException *ex, MonoJi
 	g_assert_not_reached ();
 }
 
-void
+gboolean
 mono_interp_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip)
 {
 	g_assert_not_reached ();

--- a/mono/mini/interp/interp.h
+++ b/mono/mini/interp/interp.h
@@ -68,7 +68,7 @@ interp_walk_stack_with_ctx (MonoInternalStackWalk func, MonoContext *ctx, MonoUn
 void
 mono_interp_set_resume_state (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExceptionInfo *ei, MonoInterpFrameHandle interp_frame, gpointer handler_ip);
 
-void
+gboolean
 mono_interp_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip);
 
 gboolean

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -168,8 +168,10 @@ OPDEF(MINT_STIND_REF, "stind.ref", 1, MintOpNoArgs)
 
 OPDEF(MINT_BR, "br", 3, MintOpBranch)
 OPDEF(MINT_LEAVE, "leave", 3, MintOpBranch)
+OPDEF(MINT_LEAVE_CHECK, "leave.check", 3, MintOpBranch)
 OPDEF(MINT_BR_S, "br.s", 2, MintOpShortBranch)
 OPDEF(MINT_LEAVE_S, "leave.s", 2, MintOpShortBranch)
+OPDEF(MINT_LEAVE_S_CHECK, "leave.s.check", 2, MintOpShortBranch)
 
 OPDEF(MINT_THROW, "throw", 1, MintOpNoArgs)
 OPDEF(MINT_RETHROW, "rethrow", 2, MintOpUShortInt)

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11438,7 +11438,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					 * Currently, we always rethrow the abort exception, despite the 
 					 * fact that this is not correct. See thread6.cs for an example. 
 					 * But propagating the abort exception is more important than 
-					 * getting the sematics right.
+					 * getting the semantics right.
 					 */
 					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, exc_ins->dreg, 0);
 					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBEQ, dont_throw);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2284,10 +2284,13 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 						return 0;
 					} else {
 						mini_set_abort_threshold (ctx);
-						if (in_interp)
-							mono_interp_run_finally (&frame, i, ei->handler_start);
-						else
+						if (in_interp) {
+							gboolean has_ex = mono_interp_run_finally (&frame, i, ei->handler_start);
+							if (has_ex)
+								return 0;
+						} else {
 							call_filter (ctx, ei->handler_start);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This removes the duplicate code from the interpreter and makes it possible to support exception debugging.

Also fix the the basic block construction code so CEE_THROW begins a new bblock.