### PR TITLE
Ensuring TextBox is properly updated upon setting/clearing password char

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TextBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TextBox.cs
@@ -450,6 +450,7 @@ namespace System.Windows.Forms {
 						document.PasswordChar = PasswordChar.ToString ();
 					else
 						document.PasswordChar = string.Empty;
+					this.CalculateDocument();
 					Invalidate ();
 				}
 			}
@@ -504,6 +505,7 @@ namespace System.Windows.Forms {
 						document.PasswordChar = string.Empty;
 					}
 					this.CalculateDocument();
+					Invalidate();
 				}
 			}
 		}


### PR DESCRIPTION
When TextBox control is created with UseSystemPasswordChar=true, is using proportional font, and its value is set to something wider than asterisk chracter (e.g. 12345678901234567890), upon clearing UseSystemPasswordChar resulting text is incorrectly clipped.
![passwordcharclipping](https://user-images.githubusercontent.com/8540228/32420055-be3f5b26-c239-11e7-9af6-8f3a78360437.png)
(all characters were selected in example above although it looks as a partial selection; in case of white background, the last four characters are neither selectable nor visible)

This is due to document not being recalculated when its display text changes due to change of UseSystemPasswordChar property; i.e. missing this.CalculateDocument() after setting document's password character. PasswordChar property has that code but it is missing call to Invalidate().

Following is minimal example of the issue:
```
using System;
using System.Windows.Forms;

namespace Test
{
	public static class App
	{
		static void Main()
		{
			using (var frm = new Form ())
			using (var textBox = new TextBox () { UseSystemPasswordChar = true, Text = "12345678901234567890", Width = 200, HideSelection = false })
			using (var button = new Button() { Top = 40, Text = "Toggle" })
			{
				frm.Controls.Add (textBox);
				frm.Controls.Add (button);
				button.Click += delegate(object sender, EventArgs e) {
					textBox.UseSystemPasswordChar = !textBox.UseSystemPasswordChar;					
				};

				Application.Run (frm);
			}
		}

	}
}
```