### PR TITLE
[System] Fix NullReferenceException in Win32EventLog

### DIFF
--- a/mcs/class/System/System.Diagnostics/Win32EventLog.cs
+++ b/mcs/class/System/System.Diagnostics/Win32EventLog.cs
@@ -734,6 +734,9 @@ namespace System.Diagnostics
 
 		private void NotifyEventThread (ManualResetEvent resetEvent)
 		{
+			if (resetEvent == null)
+				return;
+
 			while (true) {
 				try {
 					resetEvent.WaitOne ();


### PR DESCRIPTION
This occasionally happens on Jenkins:

```
System.NullReferenceException : Object reference not set to an instance of an object
  at System.Diagnostics.Win32EventLog.NotifyEventThread (System.Threading.ManualResetEvent resetEvent) [0x00001] in D:\j\workspace\w\mcs\class\System\System.Diagnostics\Win32EventLog.cs:739
  at System.Diagnostics.Win32EventLog.<EnableNotification>b__44_0 () [0x00000] in D:\j\workspace\w\mcs\class\System\System.Diagnostics\Win32EventLog.cs:729
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in D:\j\workspace\w\mcs\class\referencesource\mscorlib\system\threading\thread.cs:68
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in D:\j\workspace\w\mcs\class\referencesource\mscorlib\system\threading\executioncontext.cs:957
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in D:\j\workspace\w\mcs\class\referencesource\mscorlib\system\threading\executioncontext.cs:904
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in D:\j\workspace\w\mcs\class\referencesource\mscorlib\system\threading\executioncontext.cs:893
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in D:\j\workspace\w\mcs\class\referencesource\mscorlib\system\threading\thread.cs:105
```

We'll get it because there's a race as the lamdba capturing _notifyResetEvent in EnableNotification() is outside of the _eventLock so _notifyResetEvent can be null by the time it is called.

We need to check for that case in NotifyEventThread().