### PR TITLE
Temporary disable adding thread to joinable threads on none Windows platforms.

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -768,7 +768,9 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 	* runtime but not identified as runtime threads needs to make sure thread detach calls won't
 	* race with runtime shutdown.
 	*/
+#ifdef HOST_WIN32
 	mono_threads_add_joinable_runtime_thread (thread->thread_info);
+#endif
 
 	/*
 	 * thread->synch_cs can be NULL if this was called after


### PR DESCRIPTION
Race only observed on Windows and current solution adds dependency between detach and finalizer thread. Disable on none Windows platforms until we have an alternative solution to the race condition. Keep on Windows until we have alternative solution since race is manifesting itself on Jenkins builds.