### PR TITLE
[profiler] Improve NUnit xml reporting

### DIFF
--- a/mono/profiler/ptestrunner.pl
+++ b/mono/profiler/ptestrunner.pl
@@ -9,6 +9,8 @@ my @errors = ();
 my $total_errors = 0; # this is reset before each test
 my $global_errors = 0;
 my $report;
+my $nunit_testcase_name;
+my $nunit_testcase_xml;
 
 my $profbuilddir = $builddir . "/mono/profiler";
 my $minibuilddir = $builddir . "/mono/mini";
@@ -25,6 +27,7 @@ check_report_basics ($report);
 check_report_calls ($report, "T:Main (string[])" => 1);
 check_report_allocation ($report, "System.Object" => 1000000);
 report_errors ();
+add_nunit_testcase_result ();
 # test additional named threads and method calls
 $report = run_test ("test-busy.exe", "report,legacy,calls,alloc");
 check_report_basics ($report);
@@ -32,6 +35,7 @@ check_report_calls ($report, "T:Main (string[])" => 1);
 check_report_threads ($report, "BusyHelper");
 check_report_calls ($report, "T:test ()" => 10, "T:test3 ()" => 10, "T:test2 ()" => 1);
 report_errors ();
+add_nunit_testcase_result ();
 # test with the sampling profiler
 $report = run_test ("test-busy.exe", "report,legacy,sample");
 check_report_basics ($report);
@@ -40,6 +44,7 @@ check_report_threads ($report, "BusyHelper");
 # This seems to fail on osx, where the main thread gets the majority of SIGPROF signals
 #check_report_samples ($report, "T:test ()" => 40, "T:test3 ()" => 40);
 report_errors ();
+add_nunit_testcase_result ();
 # test lock events
 $report = run_test ("test-monitor.exe", "report,legacy,calls,alloc");
 check_report_basics ($report);
@@ -47,12 +52,14 @@ check_report_calls ($report, "T:Main (string[])" => 1);
 # we hope for at least some contention, this is not entirely reliable
 check_report_locks ($report, 1, 1);
 report_errors ();
+add_nunit_testcase_result ();
 # test exceptions
 $report = run_test ("test-excleave.exe", "report,legacy,calls");
 check_report_basics ($report);
 check_report_calls ($report, "T:Main (string[])" => 1, "T:throw_ex ()" => 1000);
 check_report_exceptions ($report, 1000, 1000, 1000);
 report_errors ();
+add_nunit_testcase_result ();
 # test heapshot
 $report = run_test_sgen ("test-heapshot.exe", "report,heapshot,legacy");
 if ($report ne "missing binary") {
@@ -60,6 +67,7 @@ if ($report ne "missing binary") {
 	check_report_heapshot ($report, 0, {"T" => 5000});
 	check_report_heapshot ($report, 1, {"T" => 5023});
 	report_errors ();
+	add_nunit_testcase_result ();
 }
 # test heapshot traces
 $report = run_test_sgen ("test-heapshot.exe", "heapshot,output=traces.mlpd,legacy", "--traces traces.mlpd");
@@ -74,6 +82,7 @@ if ($report ne "missing binary") {
 		T => [5022, "T"]
 	);
 	report_errors ();
+	add_nunit_testcase_result ();
 }
 # test traces
 $report = run_test ("test-traces.exe", "legacy,calls,alloc,output=traces.mlpd", "--maxframes=7 --traces traces.mlpd");
@@ -91,6 +100,7 @@ check_alloc_traces ($report,
 	T => [1010, "T:Main (string[])", "T:level3 (int)", "T:level2 (int)", "T:level1 (int)", "T:level0 (int)"]
 );
 report_errors ();
+add_nunit_testcase_result ();
 # test traces without enter/leave events
 $report = run_test ("test-traces.exe", "legacy,alloc,output=traces.mlpd", "--traces traces.mlpd");
 check_report_basics ($report);
@@ -102,6 +112,7 @@ check_alloc_traces ($report,
 	T => [1010, "T:Main (string[])", "T:level3 (int)", "T:level2 (int)", "T:level1 (int)", "T:level0 (int)"]
 );
 report_errors ();
+add_nunit_testcase_result ();
 
 emit_nunit_report();
 
@@ -138,6 +149,7 @@ sub run_test_bin
 	@errors = ();
 	$total_errors = 0;
 	print "Checking $test_name with $option ...";
+	$nunit_testcase_name = "$test_name($option)";
 	unless (-x $bin) {
 		print "missing $bin, skipped.\n";
 		return "missing binary";
@@ -159,6 +171,34 @@ sub report_errors
 	}
 	print "Total errors: $total_errors\n" if $total_errors;
 	#print $report;
+}
+
+sub add_nunit_testcase_result
+{
+	my $successbool;
+	if ($total_errors > 0) {
+		$successbool = "False";
+	} else {
+		$successbool = "True";
+	}
+
+	$nunit_testcase_xml .= "              <test-case name=\"MonoTests.profiler.$nunit_testcase_name\" executed=\"True\" success=\"$successbool\" time=\"0\" asserts=\"0\"";
+	if ($total_errors > 0) {
+		$nunit_testcase_xml .=  ">\n";
+		$nunit_testcase_xml .=  "                <failure>\n";
+		$nunit_testcase_xml .=  "                  <message><![CDATA[";
+		foreach my $e (@errors) {
+			$nunit_testcase_xml .= "Error: $e\n";
+		}
+		$nunit_testcase_xml .= "]]></message>\n";
+		$nunit_testcase_xml .=  "                  <stack-trace><![CDATA[";
+		$nunit_testcase_xml .=  $report;
+		$nunit_testcase_xml .=  "]]></stack-trace>\n";
+		$nunit_testcase_xml .=  "                </failure>\n";
+		$nunit_testcase_xml .=  "              </test-case>\n";
+	} else {
+		$nunit_testcase_xml .= " />\n";
+	}
 }
 
 sub emit_nunit_report
@@ -192,20 +232,7 @@ sub emit_nunit_report
 	print $nunitxml "        <results>\n";
 	print $nunitxml "          <test-suite name=\"profiler\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
 	print $nunitxml "            <results>\n";
-	print $nunitxml "              <test-case name=\"MonoTests.profiler.100percentsuccess\" executed=\"True\" success=\"$successbool\" time=\"0\" asserts=\"0\"";
-	if ( $failed > 0) {
-	print $nunitxml ">\n";
-	print $nunitxml "                <failure>\n";
-	print $nunitxml "                  <message><![CDATA[";
-	print $nunitxml "The profiler tests returned an error. Check the log for more details.";
-	print $nunitxml "]]></message>\n";
-	print $nunitxml "                  <stack-trace>\n";
-	print $nunitxml "                  </stack-trace>\n";
-	print $nunitxml "                </failure>\n";
-	print $nunitxml "              </test-case>\n";
-	} else {
-	print $nunitxml " />\n";
-	}
+	print $nunitxml $nunit_testcase_xml;
 	print $nunitxml "            </results>\n";
 	print $nunitxml "          </test-suite>\n";
 	print $nunitxml "        </results>\n";


### PR DESCRIPTION
We were only recording whether the tests passed or failed overall, but not individual results of tests cases.

This adds that capability.