### PR TITLE
local-dist: ignore quick syntax to exclude files

### DIFF
--- a/mcs/tools/removecomments.sh
+++ b/mcs/tools/removecomments.sh
@@ -13,7 +13,13 @@ for f in $source_files ; do
 	for f in `cat $f` ; do
 		case $f in
 			\#*) ;;
-			*) echo $f ;;
+			*)
+			# some lines in .sources may contain quick syntax to exclude files i.e.:
+			# ../dir/*.cs:File1.cs,File2.cs (include everything except File1.cs and File2.cs)
+			# let's drop that ":files" suffix
+			for line in `echo $f | cut -d \: -f 1` ; do
+				echo $line
+			done
 		esac
 	done
 	OIFS=$IFS


### PR DESCRIPTION
https://github.com/mono/mono/pull/5762 introduced a new syntax to exclude files:
`../dir/*.cs:FileToExclude1.cs,FileToExclude2.cs`
this PR makes local-dist rule to correctly handle them