### PR TITLE
[interp] clear stack on resuming into the main loop

### DIFF
--- a/mcs/class/corlib/Test/System/DelegateTest.cs
+++ b/mcs/class/corlib/Test/System/DelegateTest.cs
@@ -851,6 +851,7 @@ namespace MonoTests.System
 		delegate object Boxer ();
 
 		[Test]
+		[Category ("InterpreterNotWorking")]
 		public void BoxingCovariance ()
 		{
 			var boxer = (Boxer) Delegate.CreateDelegate (
@@ -912,6 +913,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("InterpreterNotWorking")]
 		public void NullFirstArgumentOnStaticMethod ()
 		{
 			CallTarget call = (CallTarget) Delegate.CreateDelegate (
@@ -1025,6 +1027,7 @@ namespace MonoTests.System
 #if MONOTOUCH || FULL_AOT_RUNTIME
 		[Category ("NotWorking")] // #10539
 #endif
+		[Category ("InterpreterNotWorking")]
 		public void ClosedOverNullReferenceStaticMethod ()
 		{
 			var del = (Func<long?,long?>) Delegate.CreateDelegate (

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -208,6 +208,8 @@ set_resume_state (ThreadContext *context, InterpFrame *frame)
 /* Set the current execution state to the resume state in context */
 #define SET_RESUME_STATE(context) do { \
 		ip = (context)->handler_ip;						\
+		/* spec says stack should be empty at endfinally so it should be at the start too */ \
+		sp = frame->stack; \
 		if (frame->ex) { \
 		sp->data.p = frame->ex;											\
 		++sp;															\

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -210,6 +210,7 @@ set_resume_state (ThreadContext *context, InterpFrame *frame)
 		ip = (context)->handler_ip;						\
 		/* spec says stack should be empty at endfinally so it should be at the start too */ \
 		sp = frame->stack; \
+		vt_sp = (unsigned char *) sp + rtm->stack_size; \
 		if (frame->ex) { \
 		sp->data.p = frame->ex;											\
 		++sp;															\
@@ -5029,6 +5030,7 @@ array_constructed:
 			ip = finally_ips->data;
 			finally_ips = g_slist_remove (finally_ips, ip);
 			sp = frame->stack; /* spec says stack should be empty at endfinally so it should be at the start too */
+			vt_sp = (unsigned char *) sp + rtm->stack_size;
 			goto main_loop;
 		}
 
@@ -5069,6 +5071,7 @@ array_constructed:
 			ip = finally_ips->data;
 			finally_ips = g_slist_remove (finally_ips, ip);
 			sp = frame->stack; /* spec says stack should be empty at endfinally so it should be at the start too */
+			vt_sp = (unsigned char *) sp + rtm->stack_size;
 			goto main_loop;
 		}
 	}


### PR DESCRIPTION
fixes `System.Collections.Generic.DictionaryTest.IDictionary_Add3`.

The problem is that resuming into an handler requires the evaluation stack to
be emptied, which didn't happen with the new unified exception handling.

The frame layout looks like this in memory:

| sp | vt_sp | args | ... |
| ---|-------|-----|---|

If we don't empty `sp` properly, we will eventually overflow into the `vt_sp` area (which is the evaluation stack for value types). So things get funny if `sp == vt_sp` and you do stuff like this:

```c
  sp->data.p = vt_sp;
```

~Kind o amazing that it almost passed the whole test suite with that bug.~ It didn't, it only ran the first thousand tests or so and then the runtime crashed.