### PR TITLE
[Facades] Use same assembly company/product/copyright attributes as other BCL assemblies

### DIFF
--- a/mcs/class/Facades/Microsoft.Win32.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/Microsoft.Win32.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("Microsoft.Win32.Primitives.dll")]
-[assembly: AssemblyDescription ("Microsoft.Win32.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("Microsoft.Win32.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("Microsoft.Win32.Primitives")]
+[assembly: AssemblyDescription ("Microsoft.Win32.Primitives")]
+[assembly: AssemblyDefaultAlias ("Microsoft.Win32.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/Microsoft.Win32.Registry.AccessControl/AssemblyInfo.cs
+++ b/mcs/class/Facades/Microsoft.Win32.Registry.AccessControl/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("Microsoft.Win32.Registry.AccessControl.dll")]
-[assembly: AssemblyDescription ("Microsoft.Win32.Registry.AccessControl.dll")]
-[assembly: AssemblyDefaultAlias ("Microsoft.Win32.Registry.AccessControl.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("Microsoft.Win32.Registry.AccessControl")]
+[assembly: AssemblyDescription ("Microsoft.Win32.Registry.AccessControl")]
+[assembly: AssemblyDefaultAlias ("Microsoft.Win32.Registry.AccessControl")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/Microsoft.Win32.Registry/AssemblyInfo.cs
+++ b/mcs/class/Facades/Microsoft.Win32.Registry/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("Microsoft.Win32.Registry.dll")]
-[assembly: AssemblyDescription ("Microsoft.Win32.Registry.dll")]
-[assembly: AssemblyDefaultAlias ("Microsoft.Win32.Registry.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("Microsoft.Win32.Registry")]
+[assembly: AssemblyDescription ("Microsoft.Win32.Registry")]
+[assembly: AssemblyDefaultAlias ("Microsoft.Win32.Registry")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.AppContext/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.AppContext/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.AppContext.dll")]
-[assembly: AssemblyDescription ("System.AppContext.dll")]
-[assembly: AssemblyDefaultAlias ("System.AppContext.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.AppContext")]
+[assembly: AssemblyDescription ("System.AppContext")]
+[assembly: AssemblyDefaultAlias ("System.AppContext")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Collections.Concurrent/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Collections.Concurrent/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Collections.Concurrent.dll")]
-[assembly: AssemblyDescription ("System.Collections.Concurrent.dll")]
-[assembly: AssemblyDefaultAlias ("System.Collections.Concurrent.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Collections.Concurrent")]
+[assembly: AssemblyDescription ("System.Collections.Concurrent")]
+[assembly: AssemblyDefaultAlias ("System.Collections.Concurrent")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Collections.NonGeneric/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Collections.NonGeneric/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Collections.NonGeneric.dll")]
-[assembly: AssemblyDescription ("System.Collections.NonGeneric.dll")]
-[assembly: AssemblyDefaultAlias ("System.Collections.NonGeneric.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Collections.NonGeneric")]
+[assembly: AssemblyDescription ("System.Collections.NonGeneric")]
+[assembly: AssemblyDefaultAlias ("System.Collections.NonGeneric")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Collections.Specialized/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Collections.Specialized/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Collections.Specialized.dll")]
-[assembly: AssemblyDescription ("System.Collections.Specialized.dll")]
-[assembly: AssemblyDefaultAlias ("System.Collections.Specialized.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Collections.Specialized")]
+[assembly: AssemblyDescription ("System.Collections.Specialized")]
+[assembly: AssemblyDefaultAlias ("System.Collections.Specialized")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Collections/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Collections/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Collections.dll")]
-[assembly: AssemblyDescription ("System.Collections.dll")]
-[assembly: AssemblyDefaultAlias ("System.Collections.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Collections")]
+[assembly: AssemblyDescription ("System.Collections")]
+[assembly: AssemblyDefaultAlias ("System.Collections")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ComponentModel.Annotations/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ComponentModel.Annotations/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ComponentModel.Annotations.dll")]
-[assembly: AssemblyDescription ("System.ComponentModel.Annotations.dll")]
-[assembly: AssemblyDefaultAlias ("System.ComponentModel.Annotations.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ComponentModel.Annotations")]
+[assembly: AssemblyDescription ("System.ComponentModel.Annotations")]
+[assembly: AssemblyDefaultAlias ("System.ComponentModel.Annotations")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ComponentModel.EventBasedAsync/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ComponentModel.EventBasedAsync/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ComponentModel.EventBasedAsync.dll")]
-[assembly: AssemblyDescription ("System.ComponentModel.EventBasedAsync.dll")]
-[assembly: AssemblyDefaultAlias ("System.ComponentModel.EventBasedAsync.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ComponentModel.EventBasedAsync")]
+[assembly: AssemblyDescription ("System.ComponentModel.EventBasedAsync")]
+[assembly: AssemblyDefaultAlias ("System.ComponentModel.EventBasedAsync")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ComponentModel.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ComponentModel.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ComponentModel.Primitives.dll")]
-[assembly: AssemblyDescription ("System.ComponentModel.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.ComponentModel.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ComponentModel.Primitives")]
+[assembly: AssemblyDescription ("System.ComponentModel.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.ComponentModel.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ComponentModel.TypeConverter/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ComponentModel.TypeConverter/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ComponentModel.TypeConverter.dll")]
-[assembly: AssemblyDescription ("System.ComponentModel.TypeConverter.dll")]
-[assembly: AssemblyDefaultAlias ("System.ComponentModel.TypeConverter.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ComponentModel.TypeConverter")]
+[assembly: AssemblyDescription ("System.ComponentModel.TypeConverter")]
+[assembly: AssemblyDefaultAlias ("System.ComponentModel.TypeConverter")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ComponentModel/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ComponentModel/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ComponentModel.dll")]
-[assembly: AssemblyDescription ("System.ComponentModel.dll")]
-[assembly: AssemblyDefaultAlias ("System.ComponentModel.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ComponentModel")]
+[assembly: AssemblyDescription ("System.ComponentModel")]
+[assembly: AssemblyDefaultAlias ("System.ComponentModel")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Console/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Console/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Console.dll")]
-[assembly: AssemblyDescription ("System.Console.dll")]
-[assembly: AssemblyDefaultAlias ("System.Console.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Console")]
+[assembly: AssemblyDescription ("System.Console")]
+[assembly: AssemblyDefaultAlias ("System.Console")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Data.Common/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Data.Common/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Data.Common.dll")]
-[assembly: AssemblyDescription ("System.Data.Common.dll")]
-[assembly: AssemblyDefaultAlias ("System.Data.Common.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Data.Common")]
+[assembly: AssemblyDescription ("System.Data.Common")]
+[assembly: AssemblyDefaultAlias ("System.Data.Common")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Data.SqlClient/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Data.SqlClient/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Data.SqlClient.dll")]
-[assembly: AssemblyDescription ("System.Data.SqlClient.dll")]
-[assembly: AssemblyDefaultAlias ("System.Data.SqlClient.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Data.SqlClient")]
+[assembly: AssemblyDescription ("System.Data.SqlClient")]
+[assembly: AssemblyDefaultAlias ("System.Data.SqlClient")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.Contracts/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.Contracts/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.Contracts.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.Contracts.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.Contracts.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.Contracts")]
+[assembly: AssemblyDescription ("System.Diagnostics.Contracts")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.Contracts")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.Debug/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.Debug/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.Debug.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.Debug.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.Debug.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.Debug")]
+[assembly: AssemblyDescription ("System.Diagnostics.Debug")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.Debug")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.FileVersionInfo/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.FileVersionInfo/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.FileVersionInfo.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.FileVersionInfo.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.FileVersionInfo.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.FileVersionInfo")]
+[assembly: AssemblyDescription ("System.Diagnostics.FileVersionInfo")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.FileVersionInfo")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.Process/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.Process/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.Process.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.Process.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.Process.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.Process")]
+[assembly: AssemblyDescription ("System.Diagnostics.Process")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.Process")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.StackTrace/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.StackTrace/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.StackTrace.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.StackTrace.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.StackTrace.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.StackTrace")]
+[assembly: AssemblyDescription ("System.Diagnostics.StackTrace")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.StackTrace")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.TextWriterTraceListener/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.TextWriterTraceListener/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.TextWriterTraceListener.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.TextWriterTraceListener.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.TextWriterTraceListener.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.TextWriterTraceListener")]
+[assembly: AssemblyDescription ("System.Diagnostics.TextWriterTraceListener")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.TextWriterTraceListener")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.Tools/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.Tools/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.Tools.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.Tools.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.Tools.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.Tools")]
+[assembly: AssemblyDescription ("System.Diagnostics.Tools")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.Tools")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.TraceEvent/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.TraceEvent/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.TraceEvent.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.TraceEvent.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.TraceEvent.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.TraceEvent")]
+[assembly: AssemblyDescription ("System.Diagnostics.TraceEvent")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.TraceEvent")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.TraceSource/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.TraceSource/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.TraceSource.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.TraceSource.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.TraceSource.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.TraceSource")]
+[assembly: AssemblyDescription ("System.Diagnostics.TraceSource")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.TraceSource")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Diagnostics.Tracing/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Diagnostics.Tracing/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Diagnostics.Tracing.dll")]
-[assembly: AssemblyDescription ("System.Diagnostics.Tracing.dll")]
-[assembly: AssemblyDefaultAlias ("System.Diagnostics.Tracing.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Diagnostics.Tracing")]
+[assembly: AssemblyDescription ("System.Diagnostics.Tracing")]
+[assembly: AssemblyDefaultAlias ("System.Diagnostics.Tracing")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Drawing.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Drawing.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Drawing.Primitives.dll")]
-[assembly: AssemblyDescription ("System.Drawing.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.Drawing.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Drawing.Primitives")]
+[assembly: AssemblyDescription ("System.Drawing.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.Drawing.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Dynamic.Runtime/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Dynamic.Runtime/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Dynamic.Runtime.dll")]
-[assembly: AssemblyDescription ("System.Dynamic.Runtime.dll")]
-[assembly: AssemblyDefaultAlias ("System.Dynamic.Runtime.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Dynamic.Runtime")]
+[assembly: AssemblyDescription ("System.Dynamic.Runtime")]
+[assembly: AssemblyDefaultAlias ("System.Dynamic.Runtime")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Globalization.Calendars/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Globalization.Calendars/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Globalization.Calendars.dll")]
-[assembly: AssemblyDescription ("System.Globalization.Calendars.dll")]
-[assembly: AssemblyDefaultAlias ("System.Globalization.Calendars.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Globalization.Calendars")]
+[assembly: AssemblyDescription ("System.Globalization.Calendars")]
+[assembly: AssemblyDefaultAlias ("System.Globalization.Calendars")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Globalization.Extensions/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Globalization.Extensions/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Globalization.Extensions.dll")]
-[assembly: AssemblyDescription ("System.Globalization.Extensions.dll")]
-[assembly: AssemblyDefaultAlias ("System.Globalization.Extensions.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Globalization.Extensions")]
+[assembly: AssemblyDescription ("System.Globalization.Extensions")]
+[assembly: AssemblyDefaultAlias ("System.Globalization.Extensions")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Globalization/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Globalization/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Globalization.dll")]
-[assembly: AssemblyDescription ("System.Globalization.dll")]
-[assembly: AssemblyDefaultAlias ("System.Globalization.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Globalization")]
+[assembly: AssemblyDescription ("System.Globalization")]
+[assembly: AssemblyDefaultAlias ("System.Globalization")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.Compression.ZipFile/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.Compression.ZipFile/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.Compression.ZipFile.dll")]
-[assembly: AssemblyDescription ("System.IO.Compression.ZipFile.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.Compression.ZipFile.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.Compression.ZipFile")]
+[assembly: AssemblyDescription ("System.IO.Compression.ZipFile")]
+[assembly: AssemblyDefaultAlias ("System.IO.Compression.ZipFile")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.FileSystem.AccessControl/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.FileSystem.AccessControl/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.FileSystem.AccessControl.dll")]
-[assembly: AssemblyDescription ("System.IO.FileSystem.AccessControl.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.AccessControl.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.FileSystem.AccessControl")]
+[assembly: AssemblyDescription ("System.IO.FileSystem.AccessControl")]
+[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.AccessControl")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.FileSystem.DriveInfo/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.FileSystem.DriveInfo/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.FileSystem.DriveInfo.dll")]
-[assembly: AssemblyDescription ("System.IO.FileSystem.DriveInfo.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.DriveInfo.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.FileSystem.DriveInfo")]
+[assembly: AssemblyDescription ("System.IO.FileSystem.DriveInfo")]
+[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.DriveInfo")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.FileSystem.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.FileSystem.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.FileSystem.Primitives.dll")]
-[assembly: AssemblyDescription ("System.IO.FileSystem.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.FileSystem.Primitives")]
+[assembly: AssemblyDescription ("System.IO.FileSystem.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.FileSystem.Watcher/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.FileSystem.Watcher/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.FileSystem.Watcher.dll")]
-[assembly: AssemblyDescription ("System.IO.FileSystem.Watcher.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.Watcher.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.FileSystem.Watcher")]
+[assembly: AssemblyDescription ("System.IO.FileSystem.Watcher")]
+[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.Watcher")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.FileSystem/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.FileSystem/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.FileSystem.dll")]
-[assembly: AssemblyDescription ("System.IO.FileSystem.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.FileSystem.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.FileSystem")]
+[assembly: AssemblyDescription ("System.IO.FileSystem")]
+[assembly: AssemblyDefaultAlias ("System.IO.FileSystem")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.IsolatedStorage/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.IsolatedStorage/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.IsolatedStorage.dll")]
-[assembly: AssemblyDescription ("System.IO.IsolatedStorage.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.IsolatedStorage.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.IsolatedStorage")]
+[assembly: AssemblyDescription ("System.IO.IsolatedStorage")]
+[assembly: AssemblyDefaultAlias ("System.IO.IsolatedStorage")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.MemoryMappedFiles/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.MemoryMappedFiles/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.MemoryMappedFiles.dll")]
-[assembly: AssemblyDescription ("System.IO.MemoryMappedFiles.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.MemoryMappedFiles.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.MemoryMappedFiles")]
+[assembly: AssemblyDescription ("System.IO.MemoryMappedFiles")]
+[assembly: AssemblyDefaultAlias ("System.IO.MemoryMappedFiles")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.Pipes/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.Pipes/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.Pipes.dll")]
-[assembly: AssemblyDescription ("System.IO.Pipes.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.Pipes.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.Pipes")]
+[assembly: AssemblyDescription ("System.IO.Pipes")]
+[assembly: AssemblyDefaultAlias ("System.IO.Pipes")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO.UnmanagedMemoryStream/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO.UnmanagedMemoryStream/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.UnmanagedMemoryStream.dll")]
-[assembly: AssemblyDescription ("System.IO.UnmanagedMemoryStream.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.UnmanagedMemoryStream.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO.UnmanagedMemoryStream")]
+[assembly: AssemblyDescription ("System.IO.UnmanagedMemoryStream")]
+[assembly: AssemblyDefaultAlias ("System.IO.UnmanagedMemoryStream")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.IO/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.IO/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.IO.dll")]
-[assembly: AssemblyDescription ("System.IO.dll")]
-[assembly: AssemblyDefaultAlias ("System.IO.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.IO")]
+[assembly: AssemblyDescription ("System.IO")]
+[assembly: AssemblyDefaultAlias ("System.IO")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Linq.Expressions/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Linq.Expressions/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Linq.Expressions.dll")]
-[assembly: AssemblyDescription ("System.Linq.Expressions.dll")]
-[assembly: AssemblyDefaultAlias ("System.Linq.Expressions.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Linq.Expressions")]
+[assembly: AssemblyDescription ("System.Linq.Expressions")]
+[assembly: AssemblyDefaultAlias ("System.Linq.Expressions")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Linq.Parallel/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Linq.Parallel/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Linq.Parallel.dll")]
-[assembly: AssemblyDescription ("System.Linq.Parallel.dll")]
-[assembly: AssemblyDefaultAlias ("System.Linq.Parallel.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Linq.Parallel")]
+[assembly: AssemblyDescription ("System.Linq.Parallel")]
+[assembly: AssemblyDefaultAlias ("System.Linq.Parallel")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Linq.Queryable/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Linq.Queryable/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Linq.Queryable.dll")]
-[assembly: AssemblyDescription ("System.Linq.Queryable.dll")]
-[assembly: AssemblyDefaultAlias ("System.Linq.Queryable.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Linq.Queryable")]
+[assembly: AssemblyDescription ("System.Linq.Queryable")]
+[assembly: AssemblyDefaultAlias ("System.Linq.Queryable")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Linq/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Linq/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Linq.dll")]
-[assembly: AssemblyDescription ("System.Linq.dll")]
-[assembly: AssemblyDefaultAlias ("System.Linq.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Linq")]
+[assembly: AssemblyDescription ("System.Linq")]
+[assembly: AssemblyDefaultAlias ("System.Linq")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.AuthenticationManager/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.AuthenticationManager/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.AuthenticationManager.dll")]
-[assembly: AssemblyDescription ("System.Net.AuthenticationManager.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.AuthenticationManager.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.AuthenticationManager")]
+[assembly: AssemblyDescription ("System.Net.AuthenticationManager")]
+[assembly: AssemblyDefaultAlias ("System.Net.AuthenticationManager")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Cache/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Cache/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Cache.dll")]
-[assembly: AssemblyDescription ("System.Net.Cache.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Cache.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Cache")]
+[assembly: AssemblyDescription ("System.Net.Cache")]
+[assembly: AssemblyDefaultAlias ("System.Net.Cache")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.HttpListener/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.HttpListener/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.HttpListener.dll")]
-[assembly: AssemblyDescription ("System.Net.HttpListener.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.HttpListener.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.HttpListener")]
+[assembly: AssemblyDescription ("System.Net.HttpListener")]
+[assembly: AssemblyDefaultAlias ("System.Net.HttpListener")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Mail/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Mail/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Mail.dll")]
-[assembly: AssemblyDescription ("System.Net.Mail.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Mail.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Mail")]
+[assembly: AssemblyDescription ("System.Net.Mail")]
+[assembly: AssemblyDefaultAlias ("System.Net.Mail")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.NameResolution/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.NameResolution/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.NameResolution.dll")]
-[assembly: AssemblyDescription ("System.Net.NameResolution.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.NameResolution.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.NameResolution")]
+[assembly: AssemblyDescription ("System.Net.NameResolution")]
+[assembly: AssemblyDefaultAlias ("System.Net.NameResolution")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.NetworkInformation/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.NetworkInformation/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.NetworkInformation.dll")]
-[assembly: AssemblyDescription ("System.Net.NetworkInformation.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.NetworkInformation.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.NetworkInformation")]
+[assembly: AssemblyDescription ("System.Net.NetworkInformation")]
+[assembly: AssemblyDefaultAlias ("System.Net.NetworkInformation")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Ping/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Ping/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Ping.dll")]
-[assembly: AssemblyDescription ("System.Net.Ping.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Ping.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Ping")]
+[assembly: AssemblyDescription ("System.Net.Ping")]
+[assembly: AssemblyDefaultAlias ("System.Net.Ping")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Primitives.dll")]
-[assembly: AssemblyDescription ("System.Net.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Primitives")]
+[assembly: AssemblyDescription ("System.Net.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.Net.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Requests/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Requests/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Requests.dll")]
-[assembly: AssemblyDescription ("System.Net.Requests.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Requests.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Requests")]
+[assembly: AssemblyDescription ("System.Net.Requests")]
+[assembly: AssemblyDefaultAlias ("System.Net.Requests")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Security/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Security/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Security.dll")]
-[assembly: AssemblyDescription ("System.Net.Security.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Security.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Security")]
+[assembly: AssemblyDescription ("System.Net.Security")]
+[assembly: AssemblyDefaultAlias ("System.Net.Security")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.ServicePoint/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.ServicePoint/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.ServicePoint.dll")]
-[assembly: AssemblyDescription ("System.Net.ServicePoint.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.ServicePoint.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.ServicePoint")]
+[assembly: AssemblyDescription ("System.Net.ServicePoint")]
+[assembly: AssemblyDefaultAlias ("System.Net.ServicePoint")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Sockets/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Sockets/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Sockets.dll")]
-[assembly: AssemblyDescription ("System.Net.Sockets.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Sockets.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Sockets")]
+[assembly: AssemblyDescription ("System.Net.Sockets")]
+[assembly: AssemblyDefaultAlias ("System.Net.Sockets")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Utilities/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Utilities/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.Utilities.dll")]
-[assembly: AssemblyDescription ("System.Net.Utilities.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.Utilities.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.Utilities")]
+[assembly: AssemblyDescription ("System.Net.Utilities")]
+[assembly: AssemblyDefaultAlias ("System.Net.Utilities")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.WebHeaderCollection/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.WebHeaderCollection/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.WebHeaderCollection.dll")]
-[assembly: AssemblyDescription ("System.Net.WebHeaderCollection.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.WebHeaderCollection.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.WebHeaderCollection")]
+[assembly: AssemblyDescription ("System.Net.WebHeaderCollection")]
+[assembly: AssemblyDefaultAlias ("System.Net.WebHeaderCollection")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.WebSockets.Client/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.WebSockets.Client/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.WebSockets.Client.dll")]
-[assembly: AssemblyDescription ("System.Net.WebSockets.Client.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.WebSockets.Client.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.WebSockets.Client")]
+[assembly: AssemblyDescription ("System.Net.WebSockets.Client")]
+[assembly: AssemblyDefaultAlias ("System.Net.WebSockets.Client")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.WebSockets/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.WebSockets/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Net.WebSockets.dll")]
-[assembly: AssemblyDescription ("System.Net.WebSockets.dll")]
-[assembly: AssemblyDefaultAlias ("System.Net.WebSockets.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Net.WebSockets")]
+[assembly: AssemblyDescription ("System.Net.WebSockets")]
+[assembly: AssemblyDefaultAlias ("System.Net.WebSockets")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ObjectModel/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ObjectModel/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ObjectModel.dll")]
-[assembly: AssemblyDescription ("System.ObjectModel.dll")]
-[assembly: AssemblyDefaultAlias ("System.ObjectModel.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ObjectModel")]
+[assembly: AssemblyDescription ("System.ObjectModel")]
+[assembly: AssemblyDefaultAlias ("System.ObjectModel")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection.DispatchProxy/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection.DispatchProxy/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.DispatchProxy.dll")]
-[assembly: AssemblyDescription ("System.Reflection.DispatchProxy.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.DispatchProxy.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection.DispatchProxy")]
+[assembly: AssemblyDescription ("System.Reflection.DispatchProxy")]
+[assembly: AssemblyDefaultAlias ("System.Reflection.DispatchProxy")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.3.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.dll.sources
+++ b/mcs/class/Facades/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.dll.sources
@@ -1,3 +1,3 @@
 ../../../build/common/MonoTODOAttribute.cs
-Assembly/AssemblyInfo.cs
+AssemblyInfo.cs
 System.Reflection/DispatchProxy.cs

--- a/mcs/class/Facades/System.Reflection.Emit.ILGeneration/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection.Emit.ILGeneration/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.Emit.ILGeneration.dll")]
-[assembly: AssemblyDescription ("System.Reflection.Emit.ILGeneration.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.Emit.ILGeneration.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection.Emit.ILGeneration")]
+[assembly: AssemblyDescription ("System.Reflection.Emit.ILGeneration")]
+[assembly: AssemblyDefaultAlias ("System.Reflection.Emit.ILGeneration")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection.Emit.Lightweight/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection.Emit.Lightweight/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.Emit.Lightweight.dll")]
-[assembly: AssemblyDescription ("System.Reflection.Emit.Lightweight.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.Emit.Lightweight.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection.Emit.Lightweight")]
+[assembly: AssemblyDescription ("System.Reflection.Emit.Lightweight")]
+[assembly: AssemblyDefaultAlias ("System.Reflection.Emit.Lightweight")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection.Emit/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection.Emit/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.Emit.dll")]
-[assembly: AssemblyDescription ("System.Reflection.Emit.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.Emit.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection.Emit")]
+[assembly: AssemblyDescription ("System.Reflection.Emit")]
+[assembly: AssemblyDefaultAlias ("System.Reflection.Emit")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection.Extensions/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection.Extensions/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.Extensions.dll")]
-[assembly: AssemblyDescription ("System.Reflection.Extensions.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.Extensions.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection.Extensions")]
+[assembly: AssemblyDescription ("System.Reflection.Extensions")]
+[assembly: AssemblyDefaultAlias ("System.Reflection.Extensions")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.Primitives.dll")]
-[assembly: AssemblyDescription ("System.Reflection.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection.Primitives")]
+[assembly: AssemblyDescription ("System.Reflection.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.Reflection.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection.TypeExtensions/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection.TypeExtensions/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.TypeExtensions.dll")]
-[assembly: AssemblyDescription ("System.Reflection.TypeExtensions.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.TypeExtensions.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection.TypeExtensions")]
+[assembly: AssemblyDescription ("System.Reflection.TypeExtensions")]
+[assembly: AssemblyDefaultAlias ("System.Reflection.TypeExtensions")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Reflection/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Reflection/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Reflection.dll")]
-[assembly: AssemblyDescription ("System.Reflection.dll")]
-[assembly: AssemblyDefaultAlias ("System.Reflection.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Reflection")]
+[assembly: AssemblyDescription ("System.Reflection")]
+[assembly: AssemblyDefaultAlias ("System.Reflection")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Resources.ReaderWriter/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Resources.ReaderWriter/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Resources.ReaderWriter.dll")]
-[assembly: AssemblyDescription ("System.Resources.ReaderWriter.dll")]
-[assembly: AssemblyDefaultAlias ("System.Resources.ReaderWriter.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Resources.ReaderWriter")]
+[assembly: AssemblyDescription ("System.Resources.ReaderWriter")]
+[assembly: AssemblyDefaultAlias ("System.Resources.ReaderWriter")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Resources.ResourceManager/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Resources.ResourceManager/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Resources.ResourceManager.dll")]
-[assembly: AssemblyDescription ("System.Resources.ResourceManager.dll")]
-[assembly: AssemblyDefaultAlias ("System.Resources.ResourceManager.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Resources.ResourceManager")]
+[assembly: AssemblyDescription ("System.Resources.ResourceManager")]
+[assembly: AssemblyDefaultAlias ("System.Resources.ResourceManager")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.CompilerServices.VisualC/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.CompilerServices.VisualC/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.CompilerServices.VisualC.dll")]
-[assembly: AssemblyDescription ("System.Runtime.CompilerServices.VisualC.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.CompilerServices.VisualC.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.CompilerServices.VisualC")]
+[assembly: AssemblyDescription ("System.Runtime.CompilerServices.VisualC")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.CompilerServices.VisualC")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Extensions/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Extensions/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Extensions.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Extensions.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Extensions.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Extensions")]
+[assembly: AssemblyDescription ("System.Runtime.Extensions")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Extensions")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Handles/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Handles/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Handles.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Handles.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Handles.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Handles")]
+[assembly: AssemblyDescription ("System.Runtime.Handles")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Handles")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/AssemblyInfo.cs
@@ -32,13 +32,13 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.InteropServices.RuntimeInformation.dll")]
-[assembly: AssemblyDescription ("System.Runtime.InteropServices.RuntimeInformation.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.InteropServices.RuntimeInformation.dll")]
+[assembly: AssemblyTitle ("System.Runtime.InteropServices.RuntimeInformation")]
+[assembly: AssemblyDescription ("System.Runtime.InteropServices.RuntimeInformation")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.InteropServices.RuntimeInformation")]
 
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.3.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/System.Runtime.InteropServices.RuntimeInformation.dll.sources
+++ b/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/System.Runtime.InteropServices.RuntimeInformation.dll.sources
@@ -1,4 +1,4 @@
-Assembly/AssemblyInfo.cs
+AssemblyInfo.cs
 System.Runtime.InteropServices/RuntimeInformation.cs
 
 corefx/SR.cs

--- a/mcs/class/Facades/System.Runtime.InteropServices.WindowsRuntime/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.InteropServices.WindowsRuntime/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.InteropServices.WindowsRuntime.dll")]
-[assembly: AssemblyDescription ("System.Runtime.InteropServices.WindowsRuntime.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.InteropServices.WindowsRuntime.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.InteropServices.WindowsRuntime")]
+[assembly: AssemblyDescription ("System.Runtime.InteropServices.WindowsRuntime")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.InteropServices.WindowsRuntime")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.InteropServices/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.InteropServices/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.InteropServices.dll")]
-[assembly: AssemblyDescription ("System.Runtime.InteropServices.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.InteropServices.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.InteropServices")]
+[assembly: AssemblyDescription ("System.Runtime.InteropServices")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.InteropServices")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Loader/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Loader/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Loader.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Loader.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Loader.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Loader")]
+[assembly: AssemblyDescription ("System.Runtime.Loader")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Loader")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Numerics/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Numerics/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Numerics.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Numerics.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Numerics.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Numerics")]
+[assembly: AssemblyDescription ("System.Runtime.Numerics")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Numerics")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Serialization.Formatters/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Serialization.Formatters/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Serialization.Formatters.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Serialization.Formatters.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Formatters.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Serialization.Formatters")]
+[assembly: AssemblyDescription ("System.Runtime.Serialization.Formatters")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Formatters")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Serialization.Json/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Serialization.Json/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Serialization.Json.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Serialization.Json.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Json.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Serialization.Json")]
+[assembly: AssemblyDescription ("System.Runtime.Serialization.Json")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Json")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Serialization.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Serialization.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Serialization.Primitives.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Serialization.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Serialization.Primitives")]
+[assembly: AssemblyDescription ("System.Runtime.Serialization.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime.Serialization.Xml/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime.Serialization.Xml/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.Serialization.Xml.dll")]
-[assembly: AssemblyDescription ("System.Runtime.Serialization.Xml.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Xml.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime.Serialization.Xml")]
+[assembly: AssemblyDescription ("System.Runtime.Serialization.Xml")]
+[assembly: AssemblyDefaultAlias ("System.Runtime.Serialization.Xml")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Runtime/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Runtime/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Runtime.dll")]
-[assembly: AssemblyDescription ("System.Runtime.dll")]
-[assembly: AssemblyDefaultAlias ("System.Runtime.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Runtime")]
+[assembly: AssemblyDescription ("System.Runtime")]
+[assembly: AssemblyDefaultAlias ("System.Runtime")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.AccessControl/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.AccessControl/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.AccessControl.dll")]
-[assembly: AssemblyDescription ("System.Security.AccessControl.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.AccessControl.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.AccessControl")]
+[assembly: AssemblyDescription ("System.Security.AccessControl")]
+[assembly: AssemblyDefaultAlias ("System.Security.AccessControl")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Claims/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Claims/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Claims.dll")]
-[assembly: AssemblyDescription ("System.Security.Claims.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Claims.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Claims")]
+[assembly: AssemblyDescription ("System.Security.Claims")]
+[assembly: AssemblyDefaultAlias ("System.Security.Claims")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Algorithms/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Algorithms/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Algorithms.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Algorithms.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Algorithms.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.3.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Cng/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Cng/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Cng.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Cng.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Cng.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Cng")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Cng")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Cng")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Csp/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Csp/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Csp.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Csp.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Csp.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Csp")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Csp")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Csp")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.DeriveBytes/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.DeriveBytes/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.DeriveBytes.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.DeriveBytes.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.DeriveBytes.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.DeriveBytes")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.DeriveBytes")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.DeriveBytes")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Encoding/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Encoding/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Encoding.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Encoding.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encoding.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Encoding")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Encoding")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encoding")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Encryption.Aes/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Encryption.Aes/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption.Aes.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption.Aes.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption.Aes.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption.Aes")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption.Aes")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption.Aes")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Encryption.ECDiffieHellman/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Encryption.ECDiffieHellman/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption.ECDiffieHellman.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption.ECDiffieHellman.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption.ECDiffieHellman.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption.ECDiffieHellman")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption.ECDiffieHellman")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption.ECDiffieHellman")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Encryption.ECDsa/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Encryption.ECDsa/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption.ECDsa.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption.ECDsa.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption.ECDsa.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption.ECDsa")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption.ECDsa")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption.ECDsa")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Encryption/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Encryption/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Encryption")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Encryption")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Encryption")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Hashing.Algorithms/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Hashing.Algorithms/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Hashing.Algorithms.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Hashing.Algorithms.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Hashing.Algorithms.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Hashing.Algorithms")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Hashing.Algorithms")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Hashing.Algorithms")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Hashing/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Hashing/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Hashing.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Hashing.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Hashing.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Hashing")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Hashing")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Hashing")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.OpenSsl/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.OpenSsl/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.OpenSsl.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.OpenSsl.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.OpenSsl.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.OpenSsl")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.OpenSsl")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.OpenSsl")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Pkcs/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Pkcs/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Pkcs.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Pkcs.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Pkcs.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.Primitives.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.Primitives")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.ProtectedData/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.ProtectedData/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.ProtectedData.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.ProtectedData.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.ProtectedData.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.RSA/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.RSA/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.RSA.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.RSA.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.RSA.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.RSA")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.RSA")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.RSA")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.RandomNumberGenerator/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.RandomNumberGenerator/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.RandomNumberGenerator.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.RandomNumberGenerator.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.RandomNumberGenerator.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.RandomNumberGenerator")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.RandomNumberGenerator")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.RandomNumberGenerator")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Cryptography.X509Certificates/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.X509Certificates/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Cryptography.X509Certificates.dll")]
-[assembly: AssemblyDescription ("System.Security.Cryptography.X509Certificates.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.X509Certificates.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Cryptography.X509Certificates")]
+[assembly: AssemblyDescription ("System.Security.Cryptography.X509Certificates")]
+[assembly: AssemblyDefaultAlias ("System.Security.Cryptography.X509Certificates")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Principal.Windows/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Principal.Windows/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Principal.Windows.dll")]
-[assembly: AssemblyDescription ("System.Security.Principal.Windows.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Principal.Windows.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Principal.Windows")]
+[assembly: AssemblyDescription ("System.Security.Principal.Windows")]
+[assembly: AssemblyDefaultAlias ("System.Security.Principal.Windows")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.Principal/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.Principal/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.Principal.dll")]
-[assembly: AssemblyDescription ("System.Security.Principal.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.Principal.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.Principal")]
+[assembly: AssemblyDescription ("System.Security.Principal")]
+[assembly: AssemblyDefaultAlias ("System.Security.Principal")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Security.SecureString/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Security.SecureString/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Security.SecureString.dll")]
-[assembly: AssemblyDescription ("System.Security.SecureString.dll")]
-[assembly: AssemblyDefaultAlias ("System.Security.SecureString.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Security.SecureString")]
+[assembly: AssemblyDescription ("System.Security.SecureString")]
+[assembly: AssemblyDefaultAlias ("System.Security.SecureString")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ServiceModel.Duplex/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ServiceModel.Duplex/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyDescription ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyDefaultAlias ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ServiceModel.Http")]
+[assembly: AssemblyDescription ("System.ServiceModel.Http")]
+[assembly: AssemblyDefaultAlias ("System.ServiceModel.Http")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.3.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ServiceModel.Http/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ServiceModel.Http/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyDescription ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyDefaultAlias ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ServiceModel.Http")]
+[assembly: AssemblyDescription ("System.ServiceModel.Http")]
+[assembly: AssemblyDefaultAlias ("System.ServiceModel.Http")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ServiceModel.NetTcp/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ServiceModel.NetTcp/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyDescription ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyDefaultAlias ("System.ServiceModel.Http.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ServiceModel.Http")]
+[assembly: AssemblyDescription ("System.ServiceModel.Http")]
+[assembly: AssemblyDefaultAlias ("System.ServiceModel.Http")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ServiceModel.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ServiceModel.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ServiceModel.Primitives.dll")]
-[assembly: AssemblyDescription ("System.ServiceModel.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.ServiceModel.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ServiceModel.Primitives")]
+[assembly: AssemblyDescription ("System.ServiceModel.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.ServiceModel.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ServiceModel.Security/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ServiceModel.Security/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ServiceModel.Security.dll")]
-[assembly: AssemblyDescription ("System.ServiceModel.Security.dll")]
-[assembly: AssemblyDefaultAlias ("System.ServiceModel.Security.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ServiceModel.Security")]
+[assembly: AssemblyDescription ("System.ServiceModel.Security")]
+[assembly: AssemblyDefaultAlias ("System.ServiceModel.Security")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ServiceProcess.ServiceController/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ServiceProcess.ServiceController/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ServiceProcess.ServiceController.dll")]
-[assembly: AssemblyDescription ("System.ServiceProcess.ServiceController.dll")]
-[assembly: AssemblyDefaultAlias ("System.ServiceProcess.ServiceController.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ServiceProcess.ServiceController")]
+[assembly: AssemblyDescription ("System.ServiceProcess.ServiceController")]
+[assembly: AssemblyDefaultAlias ("System.ServiceProcess.ServiceController")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.2.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Text.Encoding.CodePages/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Text.Encoding.CodePages/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Text.Encoding.CodePages.dll")]
-[assembly: AssemblyDescription ("System.Text.Encoding.CodePages.dll")]
-[assembly: AssemblyDefaultAlias ("System.Text.Encoding.CodePages.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Text.Encoding.CodePages")]
+[assembly: AssemblyDescription ("System.Text.Encoding.CodePages")]
+[assembly: AssemblyDefaultAlias ("System.Text.Encoding.CodePages")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Text.Encoding.Extensions/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Text.Encoding.Extensions/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Text.Encoding.Extensions.dll")]
-[assembly: AssemblyDescription ("System.Text.Encoding.Extensions.dll")]
-[assembly: AssemblyDefaultAlias ("System.Text.Encoding.Extensions.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Text.Encoding.Extensions")]
+[assembly: AssemblyDescription ("System.Text.Encoding.Extensions")]
+[assembly: AssemblyDefaultAlias ("System.Text.Encoding.Extensions")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Text.Encoding/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Text.Encoding/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Text.Encoding.dll")]
-[assembly: AssemblyDescription ("System.Text.Encoding.dll")]
-[assembly: AssemblyDefaultAlias ("System.Text.Encoding.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Text.Encoding")]
+[assembly: AssemblyDescription ("System.Text.Encoding")]
+[assembly: AssemblyDefaultAlias ("System.Text.Encoding")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Text.RegularExpressions/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Text.RegularExpressions/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Text.RegularExpressions.dll")]
-[assembly: AssemblyDescription ("System.Text.RegularExpressions.dll")]
-[assembly: AssemblyDefaultAlias ("System.Text.RegularExpressions.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Text.RegularExpressions")]
+[assembly: AssemblyDescription ("System.Text.RegularExpressions")]
+[assembly: AssemblyDefaultAlias ("System.Text.RegularExpressions")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading.AccessControl/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading.AccessControl/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.AccessControl.dll")]
-[assembly: AssemblyDescription ("System.Threading.AccessControl.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.AccessControl.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading.AccessControl")]
+[assembly: AssemblyDescription ("System.Threading.AccessControl")]
+[assembly: AssemblyDefaultAlias ("System.Threading.AccessControl")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading.Overlapped/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading.Overlapped/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.Overlapped.dll")]
-[assembly: AssemblyDescription ("System.Threading.Overlapped.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.Overlapped.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading.Overlapped")]
+[assembly: AssemblyDescription ("System.Threading.Overlapped")]
+[assembly: AssemblyDefaultAlias ("System.Threading.Overlapped")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading.Tasks.Parallel/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading.Tasks.Parallel/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.Tasks.Parallel.dll")]
-[assembly: AssemblyDescription ("System.Threading.Tasks.Parallel.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.Tasks.Parallel.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading.Tasks.Parallel")]
+[assembly: AssemblyDescription ("System.Threading.Tasks.Parallel")]
+[assembly: AssemblyDefaultAlias ("System.Threading.Tasks.Parallel")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading.Tasks/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading.Tasks/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.Tasks.dll")]
-[assembly: AssemblyDescription ("System.Threading.Tasks.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.Tasks.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading.Tasks")]
+[assembly: AssemblyDescription ("System.Threading.Tasks")]
+[assembly: AssemblyDefaultAlias ("System.Threading.Tasks")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading.Thread/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading.Thread/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.Thread.dll")]
-[assembly: AssemblyDescription ("System.Threading.Thread.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.Thread.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading.Thread")]
+[assembly: AssemblyDescription ("System.Threading.Thread")]
+[assembly: AssemblyDefaultAlias ("System.Threading.Thread")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading.ThreadPool/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading.ThreadPool/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.ThreadPool.dll")]
-[assembly: AssemblyDescription ("System.Threading.ThreadPool.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.ThreadPool.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading.ThreadPool")]
+[assembly: AssemblyDescription ("System.Threading.ThreadPool")]
+[assembly: AssemblyDefaultAlias ("System.Threading.ThreadPool")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading.Timer/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading.Timer/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.Timer.dll")]
-[assembly: AssemblyDescription ("System.Threading.Timer.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.Timer.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading.Timer")]
+[assembly: AssemblyDescription ("System.Threading.Timer")]
+[assembly: AssemblyDefaultAlias ("System.Threading.Timer")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Threading/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Threading/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Threading.dll")]
-[assembly: AssemblyDescription ("System.Threading.dll")]
-[assembly: AssemblyDefaultAlias ("System.Threading.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Threading")]
+[assembly: AssemblyDescription ("System.Threading")]
+[assembly: AssemblyDefaultAlias ("System.Threading")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.ValueTuple/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.ValueTuple/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.ValueTuple.dll")]
-[assembly: AssemblyDescription ("System.ValueTuple.dll")]
-[assembly: AssemblyDefaultAlias ("System.ValueTuple.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.ValueTuple")]
+[assembly: AssemblyDescription ("System.ValueTuple")]
+[assembly: AssemblyDefaultAlias ("System.ValueTuple")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.3.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.ReaderWriter/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.ReaderWriter/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.ReaderWriter.dll")]
-[assembly: AssemblyDescription ("System.Xml.ReaderWriter.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.ReaderWriter.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.ReaderWriter")]
+[assembly: AssemblyDescription ("System.Xml.ReaderWriter")]
+[assembly: AssemblyDefaultAlias ("System.Xml.ReaderWriter")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.XDocument/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.XDocument/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.XDocument.dll")]
-[assembly: AssemblyDescription ("System.Xml.XDocument.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.XDocument.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.XDocument")]
+[assembly: AssemblyDescription ("System.Xml.XDocument")]
+[assembly: AssemblyDefaultAlias ("System.Xml.XDocument")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.XPath.XDocument/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.XPath.XDocument/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.XPath.XDocument.dll")]
-[assembly: AssemblyDescription ("System.Xml.XPath.XDocument.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.XPath.XDocument.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.XPath.XDocument")]
+[assembly: AssemblyDescription ("System.Xml.XPath.XDocument")]
+[assembly: AssemblyDefaultAlias ("System.Xml.XPath.XDocument")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.1.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.XPath.XmlDocument/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.XPath.XmlDocument/AssemblyInfo.cs
@@ -33,12 +33,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.XPath.XmlDocument.dll")]
-[assembly: AssemblyDescription ("System.Xml.XPath.XmlDocument.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.XPath.XmlDocument.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.XPath.XmlDocument")]
+[assembly: AssemblyDescription ("System.Xml.XPath.XmlDocument")]
+[assembly: AssemblyDefaultAlias ("System.Xml.XPath.XmlDocument")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.2.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.XPath.XmlDocument/System.Xml.XPath.XmlDocument.dll.sources
+++ b/mcs/class/Facades/System.Xml.XPath.XmlDocument/System.Xml.XPath.XmlDocument.dll.sources
@@ -1,3 +1,3 @@
 ../../../build/common/MonoTODOAttribute.cs
-Assembly/AssemblyInfo.cs
+AssemblyInfo.cs
 System.Xml/XmlDocumentXPathExtensions.cs

--- a/mcs/class/Facades/System.Xml.XPath/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.XPath/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.XPath.dll")]
-[assembly: AssemblyDescription ("System.Xml.XPath.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.XPath.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.XPath")]
+[assembly: AssemblyDescription ("System.Xml.XPath")]
+[assembly: AssemblyDefaultAlias ("System.Xml.XPath")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.XmlDocument/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.XmlDocument/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.XmlDocument.dll")]
-[assembly: AssemblyDescription ("System.Xml.XmlDocument.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.XmlDocument.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.XmlDocument")]
+[assembly: AssemblyDescription ("System.Xml.XmlDocument")]
+[assembly: AssemblyDefaultAlias ("System.Xml.XmlDocument")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.1.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.XmlSerializer/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.XmlSerializer/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.XmlSerializer.dll")]
-[assembly: AssemblyDescription ("System.Xml.XmlSerializer.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.XmlSerializer.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.XmlSerializer")]
+[assembly: AssemblyDescription ("System.Xml.XmlSerializer")]
+[assembly: AssemblyDefaultAlias ("System.Xml.XmlSerializer")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.10.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Xml.Xsl.Primitives/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Xml.Xsl.Primitives/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("System.Xml.Xsl.Primitives.dll")]
-[assembly: AssemblyDescription ("System.Xml.Xsl.Primitives.dll")]
-[assembly: AssemblyDefaultAlias ("System.Xml.Xsl.Primitives.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("System.Xml.Xsl.Primitives")]
+[assembly: AssemblyDescription ("System.Xml.Xsl.Primitives")]
+[assembly: AssemblyDefaultAlias ("System.Xml.Xsl.Primitives")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("4.0.0.0")]
 [assembly: AssemblyInformationalVersion ("4.0.0.0")]
 [assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/netstandard/AssemblyInfo.cs
+++ b/mcs/class/Facades/netstandard/AssemblyInfo.cs
@@ -24,12 +24,12 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("netstandard.dll")]
-[assembly: AssemblyDescription ("netstandard.dll")]
-[assembly: AssemblyDefaultAlias ("netstandard.dll")]
-[assembly: AssemblyCompany ("Xamarin, Inc.")]
+[assembly: AssemblyTitle ("netstandard")]
+[assembly: AssemblyDescription ("netstandard")]
+[assembly: AssemblyDefaultAlias ("netstandard")]
+[assembly: AssemblyCompany ("Mono development team")]
 [assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
-[assembly: AssemblyCopyright ("Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
 [assembly: AssemblyVersion ("2.0.0.0")]
 [assembly: AssemblyInformationalVersion ("2.0.0.0")]
 [assembly: AssemblyFileVersion ("2.0.0.0")]


### PR DESCRIPTION
We can't use Consts.cs since it'd bloat up the facades too much.

Also remove ".dll" suffix from AssemblyTitle/Description to match what the Facades in the .NET Framework Reference Assemblies pack are using.

This makes the scripts I use for diffing much easier.