### PR TITLE
[interp] disable Test.System.Threading.ThreadTest.TestUndivisibleByPageSizeMaxStackSize

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -450,6 +450,7 @@ namespace MonoTests.System.Threading
 		}
 
 		[Test]
+		[Category ("InterpreterNotWorking")]
 		public void TestUndivisibleByPageSizeMaxStackSize ()
 		{
 			const int undivisible_stacksize = 1048573;


### PR DESCRIPTION
It fails _sometimes_ in a weird way, which is probably a bug in the
interpreter when executing `nunit`. Disable it until it is fixed.