### PR TITLE
[remoting] Check for transparent proxy in ves_icall_MonoField_{Get,Set}ValueInternal

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/FieldInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/FieldInfoTest.cs
@@ -1362,6 +1362,63 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual ("B", fields.str);
 		}
 
+		[Test]
+		public void GetValueContextBoundObject ()
+		{
+			var instance = new CBOTest ();
+
+			var field1 = typeof (CBOTest).GetField ("d1");
+			var d1 = field1.GetValue (instance);
+			Assert.AreEqual ((double)d1, 14.0, "d1");
+
+			var field2 = typeof (CBOTest).GetField ("d2");
+			var d2 = field2.GetValue (instance);
+			Assert.AreEqual ((double)d2, -20, "d2");
+
+			var field3 = typeof (CBOTest).GetField ("s1");
+			var s1 = field3.GetValue (instance);
+			Assert.AreEqual (s1, "abcd", "s1");
+
+			var field4 = typeof (CBOTest).GetField ("s2");
+			var s2 = field4.GetValue (instance);
+			Assert.AreEqual (s2, "hijkl", "s2");
+		}
+
+		[Test]
+		public void SetValueContextBoundObject ()
+		{
+			var instance = new CBOTest ();
+
+			var field1 = typeof (CBOTest).GetField ("d1");
+			field1.SetValue (instance, 90.3);
+			var d1 = field1.GetValue (instance);
+			Assert.AreEqual ((double)d1, 90.3, "d1");
+
+			var field2 = typeof (CBOTest).GetField ("d2");
+			field2.SetValue (instance, 1);
+			var d2 = field2.GetValue (instance);
+			Assert.AreEqual ((double)d2, 1, "d2");
+
+			var field3 = typeof (CBOTest).GetField ("s1");
+			field3.SetValue (instance, "//////");
+			var s1 = field3.GetValue (instance);
+			Assert.AreEqual (s1, "//////", "s1");
+
+			var field4 = typeof (CBOTest).GetField ("s2");
+			field4.SetValue (instance, "This is a string");
+			var s2 = field4.GetValue (instance);
+			Assert.AreEqual (s2, "This is a string", "s2");
+
+		}
+
+		class CBOTest : ContextBoundObject {
+			public double d1 = 14.0;
+			public double d2 = -20.0;
+			public string s1 = "abcd";
+			public string s2 = "hijkl";
+		}
+
+
 		public IntEnum PPP;
 
 		public class Foo<T>

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1945,6 +1945,18 @@ ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *ob
 		return NULL;
 	}
 
+#ifndef DISABLE_REMOTING
+	if (G_UNLIKELY (obj != NULL && mono_class_is_transparent_proxy (mono_object_class (obj)))) {
+		/* We get here if someone used a
+		 * System.Reflection.FieldInfo:GetValue on a
+		 * ContextBoundObject's or cross-domain MarshalByRefObject's
+		 * transparent proxy. */
+		MonoObject *result = mono_load_remote_field_new_checked (obj, fklass, cf, &error);
+		mono_error_set_pending_exception (&error);
+		return result;
+	}
+#endif
+
 	MonoObject * result = mono_field_get_value_object_checked (domain, cf, obj, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1965,6 +1977,20 @@ ves_icall_MonoField_SetValueInternal (MonoReflectionFieldHandle field, MonoObjec
 	    !mono_security_core_clr_ensure_reflection_access_field (cf, error)) {
 		return;
 	}
+
+#ifndef DISABLE_REMOTING
+	if (G_UNLIKELY (!MONO_HANDLE_IS_NULL (obj) && mono_class_is_transparent_proxy (mono_handle_class (obj)))) {
+		/* We get here if someone used a
+		 * System.Reflection.FieldInfo:SetValue on a
+		 * ContextBoundObject's or cross-domain MarshalByRefObject's
+		 * transparent proxy. */
+		/* FIXME: use handles for mono_store_remote_field_new_checked */
+		MonoObject *v = MONO_HANDLE_RAW (value);
+		MonoObject *o = MONO_HANDLE_RAW (obj);
+		mono_store_remote_field_new_checked (o, field_klass, cf, v, error);
+		return;
+	}
+#endif
 
 	MonoType *type = mono_field_get_type_checked (cf, error);
 	return_if_nok (error);


### PR DESCRIPTION
Cherrypick #5970 to `2017-10`

----

Cover the case where System.Reflection.TypeInfo:GetValue or
System.Reflection.TypeInfo:SetValue are passed a transparent proxy as the
object.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60245