### PR TITLE
Include <config.h> in C files that include mono headers

### DIFF
--- a/mono/metadata/callspec.c
+++ b/mono/metadata/callspec.c
@@ -11,6 +11,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full
  * license information.
  */
+#include <config.h>
 #include "metadata.h"
 #include "callspec.h"
 #include "assembly.h"

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -3,6 +3,7 @@
  * Copyright 2016 Microsoft
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
+#include <config.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/tabledefs.h>
 

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -8,6 +8,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+#include <config.h>
 #include <string.h>
 #include "mono/metadata/tokentype.h"
 #include "mono/metadata/opcodes.h"

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -9,6 +9,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+#include <config.h>
 #include "mono/metadata/mono-mlist.h"
 #include "mono/metadata/appdomain.h"
 #include "mono/metadata/class-internals.h"

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -4,6 +4,7 @@
  * See the LICENSE file in the project root for more information.
  */
 
+#include <config.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/mono-config-dirs.h>

--- a/mono/metadata/rand.c
+++ b/mono/metadata/rand.c
@@ -12,6 +12,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+#include <config.h>
 #include <glib.h>
 
 #include "object.h"

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -10,6 +10,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+#include <config.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/security-manager.h>
 #include <mono/metadata/assembly.h>
@@ -18,6 +19,7 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/exception.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/metadata/reflection-internals.h>
 #include <mono/utils/mono-logger-internals.h>
 
 #include "security-core-clr.h"
@@ -933,8 +935,10 @@ mono_security_core_clr_level_from_cinfo (MonoCustomAttrInfo *cinfo, MonoImage *i
 static MonoSecurityCoreCLRLevel
 mono_security_core_clr_class_level_no_platform_check (MonoClass *klass)
 {
+	MonoError error;
 	MonoSecurityCoreCLRLevel level = MONO_SECURITY_CORE_CLR_TRANSPARENT;
-	MonoCustomAttrInfo *cinfo = mono_custom_attrs_from_class (klass);
+	MonoCustomAttrInfo *cinfo = mono_custom_attrs_from_class_checked (klass, &error);
+	mono_error_cleanup (&error);
 	if (cinfo) {
 		level = mono_security_core_clr_level_from_cinfo (cinfo, klass->image);
 		mono_custom_attrs_free (cinfo);
@@ -972,6 +976,7 @@ mono_security_core_clr_class_level (MonoClass *klass)
 MonoSecurityCoreCLRLevel
 mono_security_core_clr_field_level (MonoClassField *field, gboolean with_class_level)
 {
+	MonoError error;
 	MonoCustomAttrInfo *cinfo;
 	MonoSecurityCoreCLRLevel level = MONO_SECURITY_CORE_CLR_TRANSPARENT;
 
@@ -983,7 +988,8 @@ mono_security_core_clr_field_level (MonoClassField *field, gboolean with_class_l
 	if (!mono_security_core_clr_test && !mono_security_core_clr_is_platform_image (field->parent->image))
 		return level;
 
-	cinfo = mono_custom_attrs_from_field (field->parent, field);
+	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, &error);
+	mono_error_cleanup (&error);
 	if (cinfo) {
 		level = mono_security_core_clr_level_from_cinfo (cinfo, field->parent->image);
 		mono_custom_attrs_free (cinfo);
@@ -1006,6 +1012,7 @@ mono_security_core_clr_field_level (MonoClassField *field, gboolean with_class_l
 MonoSecurityCoreCLRLevel
 mono_security_core_clr_method_level (MonoMethod *method, gboolean with_class_level)
 {
+	MonoError error;
 	MonoCustomAttrInfo *cinfo;
 	MonoSecurityCoreCLRLevel level = MONO_SECURITY_CORE_CLR_TRANSPARENT;
 
@@ -1017,7 +1024,8 @@ mono_security_core_clr_method_level (MonoMethod *method, gboolean with_class_lev
 	if (!mono_security_core_clr_test && !mono_security_core_clr_is_platform_image (method->klass->image))
 		return level;
 
-	cinfo = mono_custom_attrs_from_method (method);
+	cinfo = mono_custom_attrs_from_method_checked (method, &error);
+	mono_error_cleanup (&error);
 	if (cinfo) {
 		level = mono_security_core_clr_level_from_cinfo (cinfo, method->klass->image);
 		mono_custom_attrs_free (cinfo);

--- a/mono/metadata/security-manager.c
+++ b/mono/metadata/security-manager.c
@@ -9,6 +9,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+#include <config.h>
 #include "security-manager.h"
 
 /* Class lazy loading functions */

--- a/mono/mini/abcremoval.c
+++ b/mono/mini/abcremoval.c
@@ -7,6 +7,7 @@
  *
  * (C) 2004 Ximian, Inc.  http://www.ximian.com
  */
+#include <config.h>
 #include <string.h>
 #include <stdio.h>
 

--- a/mono/mini/dominators.c
+++ b/mono/mini/dominators.c
@@ -10,6 +10,7 @@
  * Copyright 2011 Xamarin, Inc (http://www.xamarin.com)
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
+#include <config.h>
 #include <string.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/mempool.h>

--- a/support/supportw.c
+++ b/support/supportw.c
@@ -9,6 +9,7 @@
  * (C) 2005 Novell, Inc.
  *
  */
+#include <config.h>
 #include <glib.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Any translation unit that includes a Mono header should include `<config.h>`
first to ensure that all of our configuration defines are available.

In particular, `config.h` defines `MONO_INSIDE_RUNTIME` which, in `mono-publib.h` causes
`MONO_RT_EXTERNAL_ONLY` to be defined to an attribute that causes a compilation
error if you use a function that is internally deprecated for the runtime.

Also change a couple of places that used non-_checked functions.