### PR TITLE
[Tests] Make Mono.Data.Sqlite tests more robust.

### DIFF
--- a/mcs/class/Mono.Data.Sqlite/Test/Bug27864.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/Bug27864.cs
@@ -20,13 +20,24 @@ namespace MonoTests.Mono.Data.Sqlite {
 	
 	[TestFixture]
 	public class SqliteiOS82BugTests {
-		readonly static string dbPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "adodemo.db3");
-		readonly static string connectionString = "Data Source=" + dbPath;
-		static SqliteConnection cnn = new SqliteConnection (connectionString);
+		string dbPath;
+		string connectionString;
+		SqliteConnection cnn;
 		
 		[SetUp]
 		public void Create()
 		{
+			dbPath = Path.GetTempFileName ();
+
+			// We want to start with a fresh db for each full run
+			// The database is created on the first open()
+			// but TempFile does create a file
+			if (File.Exists (dbPath))
+				File.Delete (dbPath);
+
+			connectionString = "Data Source=" + dbPath;
+			cnn = new SqliteConnection (connectionString);
+
 			try {
 				if(File.Exists(dbPath)) {
 					cnn.Dispose();
@@ -54,6 +65,13 @@ namespace MonoTests.Mono.Data.Sqlite {
 			finally {
 				cnn.Close();  
 			}
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			if (File.Exists (dbPath))
+				File.Delete (dbPath);
 		}
 
 		// Ref: https://bugzilla.xamarin.com/show_bug.cgi?id=27864

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteCommandUnitTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteCommandUnitTests.cs
@@ -16,9 +16,9 @@ namespace MonoTests.Mono.Data.Sqlite
 	[TestFixture]
 	public class SqliteCommandUnitTests
 	{
-		readonly static string _uri = Path.Combine (Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SqliteTest.db");
-		readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
-		static SqliteConnection _conn = new SqliteConnection (_connectionString);
+		string _uri;
+		string _connectionString;
+		SqliteConnection _conn;
 		readonly static string stringvalue = "my keyboard is better than yours : äöüß";
 
 		public SqliteCommandUnitTests()
@@ -28,6 +28,10 @@ namespace MonoTests.Mono.Data.Sqlite
 		[SetUp]
 		public void Create()
 		{
+			_uri = Path.GetTempFileName ();
+		  	_connectionString = "URI=file://" + _uri + ", version=3";
+			_conn = new SqliteConnection (_connectionString);
+
 			try
 			{
 				if(File.Exists(_uri))

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteCommandUnitTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteCommandUnitTests.cs
@@ -69,6 +69,13 @@ namespace MonoTests.Mono.Data.Sqlite
 			}
 		}
 		
+		[TearDown]
+ 		public void TearDown ()
+ 		{
+ 			if (File.Exists (_uri))
+ 				File.Delete (_uri);
+ 		}
+
 		[Test]	
 		public void Select()
 		{

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteConnectionTest.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteConnectionTest.cs
@@ -37,13 +37,33 @@ using NUnit.Framework;
 
 namespace MonoTests.Mono.Data.Sqlite
 {
-        [TestFixture]
-        public class SqliteConnectionTest
-        {
-                readonly static string _uri = Path.Combine (Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "test.db");
-                readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
-                SqliteConnection _conn = new SqliteConnection ();
+    [TestFixture]
+    public class SqliteConnectionTest
+    {
+        string _dataFolder;
+        string _uri;
+        string _connectionString;
+        SqliteConnection _conn;
 
+        [SetUp]
+        public void SetUp ()
+        {
+            _dataFolder = Path.GetTempFileName ();
+            if (File.Exists (_dataFolder))
+                File.Delete (_dataFolder);
+            Directory.CreateDirectory (_dataFolder);
+
+            _uri = Path.Combine (_dataFolder, "test.db");
+            _connectionString = "URI=file://" + _uri + ", version=3";
+            _conn = new SqliteConnection ();
+        }
+
+        [TearDown]
+        public void TeatDown ()
+        {
+            if (Directory.Exists (_dataFolder))
+                Directory.Delete (_dataFolder, true);
+        }
 		[Test]
 		public void ReleaseDatabaseFileHandles ()
 		{
@@ -64,49 +84,49 @@ namespace MonoTests.Mono.Data.Sqlite
 			File.Delete (_uri);
 		}
 
-                [Test]
-                [ExpectedException (typeof (ArgumentNullException))]
-                public void ConnectionStringTest_Null ()
-                {
-                        _conn.ConnectionString = null;
-                }
-
-                [Test]
-                [ExpectedException (typeof (InvalidOperationException))]
-                public void ConnectionStringTest_MustBeClosed ()
-                {
-                        _conn.ConnectionString = _connectionString;
-                        try {
-                    		_conn.Open ();
-                    		_conn.ConnectionString = _connectionString;
-                    	} finally {
-                    		_conn.Close ();
-                    	}
-                }
-
-				// behavior has changed, I guess
-                //[Test]
-                [Ignore ("opening a connection should not create db! though, leave for now")]
-                public void OpenTest ()
-                {
-                        try {
-                                _conn.ConnectionString = _connectionString;
-                                _conn.Open ();
-                                Assert.AreEqual (ConnectionState.Open, _conn.State, "#1 not opened");
-                                _conn.Close ();
-
-                                // negative test: try opening a non-existent file
-                                _conn.ConnectionString = "URI=file://abcdefgh.db, version=3";
-                                try {
-                                        _conn.Open ();
-                                        Assert.Fail ("#1 should have failed on opening a non-existent db");
-                                } catch (ArgumentException e) {Console.WriteLine (e);}
-                                
-                        } finally {
-                                if (_conn != null && _conn.State != ConnectionState.Closed)
-                                        _conn.Close ();
-                        }
-                }
-
+        [Test]
+        [ExpectedException (typeof (ArgumentNullException))]
+        public void ConnectionStringTest_Null ()
+        {
+            _conn.ConnectionString = null;
         }
+
+        [Test]
+        [ExpectedException (typeof (InvalidOperationException))]
+        public void ConnectionStringTest_MustBeClosed ()
+        {
+            _conn.ConnectionString = _connectionString;
+            try {
+                _conn.Open ();
+                _conn.ConnectionString = _connectionString;
+            } finally {
+                _conn.Close ();
+            }
+        }
+
+        // behavior has changed, I guess
+        //[Test]
+        [Ignore ("opening a connection should not create db! though, leave for now")]
+        public void OpenTest ()
+        {
+            try {
+                _conn.ConnectionString = _connectionString;
+                _conn.Open ();
+                Assert.AreEqual (ConnectionState.Open, _conn.State, "#1 not opened");
+                _conn.Close ();
+
+                // negative test: try opening a non-existent file
+                _conn.ConnectionString = "URI=file://abcdefgh.db, version=3";
+                try {
+                    _conn.Open ();
+                    Assert.Fail ("#1 should have failed on opening a non-existent db");
+                } catch (ArgumentException e) {Console.WriteLine (e);}
+                                
+            } finally {
+                if (_conn != null && _conn.State != ConnectionState.Closed)
+                    _conn.Close ();
+            }
+        }
+
+    }
 }

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteConnectionTest.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteConnectionTest.cs
@@ -37,33 +37,33 @@ using NUnit.Framework;
 
 namespace MonoTests.Mono.Data.Sqlite
 {
-    [TestFixture]
-    public class SqliteConnectionTest
-    {
-        string _dataFolder;
-        string _uri;
-        string _connectionString;
-        SqliteConnection _conn;
+	[TestFixture]
+	public class SqliteConnectionTest
+	{
+		string _dataFolder;
+		string _uri;
+		string _connectionString;
+		SqliteConnection _conn;
 
-        [SetUp]
-        public void SetUp ()
-        {
-            _dataFolder = Path.GetTempFileName ();
-            if (File.Exists (_dataFolder))
-                File.Delete (_dataFolder);
-            Directory.CreateDirectory (_dataFolder);
+		[SetUp]
+		public void SetUp ()
+		{
+			_dataFolder = Path.GetTempFileName ();
+			if (File.Exists (_dataFolder))
+				File.Delete (_dataFolder);
+			Directory.CreateDirectory (_dataFolder);
 
-            _uri = Path.Combine (_dataFolder, "test.db");
-            _connectionString = "URI=file://" + _uri + ", version=3";
-            _conn = new SqliteConnection ();
-        }
+			_uri = Path.Combine (_dataFolder, "test.db");
+			_connectionString = "URI=file://" + _uri + ", version=3";
+			_conn = new SqliteConnection ();
+		}
 
-        [TearDown]
-        public void TeatDown ()
-        {
-            if (Directory.Exists (_dataFolder))
-                Directory.Delete (_dataFolder, true);
-        }
+		[TearDown]
+		public void TeatDown ()
+		{
+			if (Directory.Exists (_dataFolder))
+				Directory.Delete (_dataFolder, true);
+		}
 		[Test]
 		public void ReleaseDatabaseFileHandles ()
 		{
@@ -84,49 +84,49 @@ namespace MonoTests.Mono.Data.Sqlite
 			File.Delete (_uri);
 		}
 
-        [Test]
-        [ExpectedException (typeof (ArgumentNullException))]
-        public void ConnectionStringTest_Null ()
-        {
-            _conn.ConnectionString = null;
-        }
+		[Test]
+		[ExpectedException (typeof (ArgumentNullException))]
+		public void ConnectionStringTest_Null ()
+		{
+			_conn.ConnectionString = null;
+		}
 
-        [Test]
-        [ExpectedException (typeof (InvalidOperationException))]
-        public void ConnectionStringTest_MustBeClosed ()
-        {
-            _conn.ConnectionString = _connectionString;
-            try {
-                _conn.Open ();
-                _conn.ConnectionString = _connectionString;
-            } finally {
-                _conn.Close ();
-            }
-        }
+		[Test]
+		[ExpectedException (typeof (InvalidOperationException))]
+		public void ConnectionStringTest_MustBeClosed ()
+		{
+			_conn.ConnectionString = _connectionString;
+			try {
+				_conn.Open ();
+				_conn.ConnectionString = _connectionString;
+			} finally {
+				_conn.Close ();
+			}
+		}
 
-        // behavior has changed, I guess
-        //[Test]
-        [Ignore ("opening a connection should not create db! though, leave for now")]
-        public void OpenTest ()
-        {
-            try {
-                _conn.ConnectionString = _connectionString;
-                _conn.Open ();
-                Assert.AreEqual (ConnectionState.Open, _conn.State, "#1 not opened");
-                _conn.Close ();
+		// behavior has changed, I guess
+		//[Test]
+		[Ignore ("opening a connection should not create db! though, leave for now")]
+		public void OpenTest ()
+		{
+			try {
+				_conn.ConnectionString = _connectionString;
+				_conn.Open ();
+				Assert.AreEqual (ConnectionState.Open, _conn.State, "#1 not opened");
+				_conn.Close ();
 
-                // negative test: try opening a non-existent file
-                _conn.ConnectionString = "URI=file://abcdefgh.db, version=3";
-                try {
-                    _conn.Open ();
-                    Assert.Fail ("#1 should have failed on opening a non-existent db");
-                } catch (ArgumentException e) {Console.WriteLine (e);}
-                                
-            } finally {
-                if (_conn != null && _conn.State != ConnectionState.Closed)
-                    _conn.Close ();
-            }
-        }
+				// negative test: try opening a non-existent file
+				_conn.ConnectionString = "URI=file://abcdefgh.db, version=3";
+				try {
+					_conn.Open ();
+					Assert.Fail ("#1 should have failed on opening a non-existent db");
+				} catch (ArgumentException e) {Console.WriteLine (e);}
+								
+			} finally {
+				if (_conn != null && _conn.State != ConnectionState.Closed)
+					_conn.Close ();
+			}
+		}
 
-    }
+	}
 }

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteDataAdapterUnitTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteDataAdapterUnitTests.cs
@@ -15,11 +15,26 @@ namespace MonoTests.Mono.Data.Sqlite
 	[TestFixture]
 	public class SqliteDataAdapterUnitTests
 	{
-		readonly static string _uri = "SqliteTest.db";
-		readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
-		static SqliteConnection _conn = new SqliteConnection (_connectionString);
+		string _uri;
+		string _connectionString;
+		SqliteConnection _conn;
         
-		static SqliteDataAdapter PrepareDataAdapter()
+        	[SetUp]
+        	public void SetUp ()
+        	{
+			_uri = Path.GetTempFileName ();
+			_connectionString = "URI=file://" + _uri + ", version=3";
+			_conn = new SqliteConnection (_connectionString);
+        	}
+
+        	[TearDown]
+        	public void TearDown ()
+        	{
+        		if (File.Exists (_uri))
+        			File.Delete (_uri);
+        	}
+
+		SqliteDataAdapter PrepareDataAdapter()
 		{
 			SqliteCommand select  = new SqliteCommand("SELECT t, f, i, b FROM t1",_conn);
 			SqliteCommand update = new SqliteCommand("UPDATE t1 SET t = :textP, f = :floatP, i = :integerP, n=:blobP WHERE t = :textP ");

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteExceptionUnitTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteExceptionUnitTests.cs
@@ -15,12 +15,23 @@ namespace MonoTests.Mono.Data.Sqlite
 	[TestFixture]
 	public class SqliteExceptionUnitTests
 	{
-		readonly static string _uri = "SqliteTest.db";
-		readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
-		static SqliteConnection _conn = new SqliteConnection (_connectionString);
+		static string _uri;
+		static string _connectionString;
+		SqliteConnection _conn;
 
-		public SqliteExceptionUnitTests()
+		[SetUp]
+		public void SetUp ()
 		{
+			_uri = Path.GetTempFileName ();
+			_connectionString = "URI=file://" + _uri + ", version=3";
+			_conn = new SqliteConnection (_connectionString);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			if (File.Exists (_uri))
+				File.Delete (_uri);
 		}
 		
 		[Test]

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteFunctionTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteFunctionTests.cs
@@ -20,7 +20,20 @@ namespace MonoTests.Mono.Data.Sqlite
 	[TestFixture]
 	public class SqliteFunctionTest
 	{
-		readonly static string uri = Path.Combine (Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "test.db");
+		string uri;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			uri = Path.GetTempFileName ();
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			if (File.Exists (uri))
+				File.Delete (uri);
+		}
 
 		[Test]
 		public void CollationTest()

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteParameterUnitTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteParameterUnitTests.cs
@@ -15,14 +15,24 @@ namespace MonoTests.Mono.Data.Sqlite
 	[TestFixture]
 	public class SqliteParameterUnitTests
 	{
-		readonly static string _uri = "SqliteTest.db";
-		readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
-		static SqliteConnection _conn = new SqliteConnection (_connectionString);
+		string _uri;
+		string _connectionString;
+		SqliteConnection _conn;
 
-		public SqliteParameterUnitTests()
+		[SetUp]
+		public void SetUp ()
 		{
+			_uri = Path.GetTempFileName ();
+			_connectionString = "URI=file://" + _uri + ", version=3";
+			_conn = new SqliteConnection (_connectionString);
 		}
-		
+
+		[TearDown]
+		public void TearDown ()
+		{
+			if (File.Exists (_uri))
+				File.Delete (_uri);
+		}
 		[Test]
 		[Category ("NotWorking")]
 		// fails randomly :)

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteTests.cs
@@ -38,17 +38,20 @@ namespace MonoTests.Mono.Data.Sqlite
 	[TestFixture]
 	public class SqliteTests
 	{
+		string _dataFolder;
 		string _databasePath;
 
 		[SetUp]
 		public void Setup ()
 		{
-			var dataFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "SqlTest");
+			_dataFolder = Path.GetTempFileName ();
+			if (File.Exists (_dataFolder))
+				File.Delete (_dataFolder);
 
-			_databasePath = Path.Combine (dataFolder, "database.db");
+			_databasePath = Path.Combine (_dataFolder, "database.db");
 
-			if (!Directory.Exists (dataFolder)) {
-				Directory.CreateDirectory (dataFolder);
+			if (!Directory.Exists (_dataFolder)) {
+				Directory.CreateDirectory (_dataFolder);
 			}
 
 			File.Delete (_databasePath);
@@ -57,10 +60,8 @@ namespace MonoTests.Mono.Data.Sqlite
 		[TearDown]
 		public void TearDown ()
 		{
-			try {
-				File.Delete (_databasePath);
-			} catch {
-			}
+			if (Directory.Exists (_dataFolder))
+				Directory.Delete (_dataFolder, true);
 		}
 
 		[Test]

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteTests.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteTests.cs
@@ -38,30 +38,21 @@ namespace MonoTests.Mono.Data.Sqlite
 	[TestFixture]
 	public class SqliteTests
 	{
-		string _dataFolder;
 		string _databasePath;
 
 		[SetUp]
 		public void Setup ()
 		{
-			_dataFolder = Path.GetTempFileName ();
-			if (File.Exists (_dataFolder))
-				File.Delete (_dataFolder);
 
-			_databasePath = Path.Combine (_dataFolder, "database.db");
-
-			if (!Directory.Exists (_dataFolder)) {
-				Directory.CreateDirectory (_dataFolder);
-			}
-
+			_databasePath =  Path.GetTempFileName ();
 			File.Delete (_databasePath);
 		}
 
 		[TearDown]
 		public void TearDown ()
 		{
-			if (Directory.Exists (_dataFolder))
-				Directory.Delete (_dataFolder, true);
+			if (File.Exists (_databasePath))
+				File.Delete (_databasePath);
 		}
 
 		[Test]


### PR DESCRIPTION
There are cases in which the tests are ran in parallel and the files
used for the db are written/read by several tests at the same time. This
changes ensures that we do have a diff test file per test case to ensure
that we do not have false negatives.

This is a cherry-pick from https://github.com/mono/mono/pull/5957