### PR TITLE
[corlib] Add more tests, embed linker descriptor xml in test assembly

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib_test.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib_test.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+	<assembly fullname="mscorlib">
+		<!-- Internal interface, needed by System.Security.Permission tests -->
+		<type fullname="System.Security.Permissions.UIPermission">
+			<method name="System.Security.Permissions.IBuiltInPermission.GetTokenIndex"/>
+		</type>
+	</assembly>
+</linker>

--- a/mcs/class/corlib/Makefile
+++ b/mcs/class/corlib/Makefile
@@ -108,7 +108,7 @@ endif
 
 # System.IO/DirectoryInfoTest.cs needs Mono.Posix
 TEST_MCS_FLAGS += -debug -nowarn:168,219,618,672 -unsafe \
-				 -define:MONO_DATACONVERTER_STATIC_METHODS $(TEST_RESX_RESOURCES:%=-resource:%)
+				 -define:MONO_DATACONVERTER_STATIC_METHODS $(TEST_RESX_RESOURCES:%=-resource:%) -resource:LinkerDescriptor/mscorlib_test.xml,$(test_lib:.dll=.xml)
 
 
 CC_PROFILE := $(filter monotouch% xammac, $(PROFILE))
@@ -144,7 +144,8 @@ EXTRA_DISTFILES = \
 	Test/resources/Fergie.GED		\
 	Test/resources/culture-*.cs		\
 	$(RESOURCE_FILES) \
-	$(TEST_RESOURCES:.resources=.resx)
+	$(TEST_RESOURCES:.resources=.resx) \
+	LinkerDescriptor/mscorlib_test.xml
 
 TEST_RESX_RESOURCES = \
 	Test/resources/Resources.resources

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/TypeForwardedFromAttributeTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/TypeForwardedFromAttributeTest.cs
@@ -1,0 +1,50 @@
+//
+// TypeForwardedFromAttributeTest.cs
+//
+// Authors:
+//  Alexander Köplinger (alkpli@microsoft.com)
+//
+// (c) 2017 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Threading;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+
+namespace MonoTests.System.Runtime.CompilerServices {
+
+	public class TypeForwardedFromAttributeTest
+	{
+		[Test]
+		public void CtorTest ()
+		{
+			var a = new TypeForwardedFromAttribute ("System.Web, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a");
+			Assert.AreEqual ("System.Web, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a", a.AssemblyFullName);
+
+			Assert.Throws<ArgumentNullException> ( () => new TypeForwardedFromAttribute (null) );
+		}
+	}
+}
+

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/TypeForwardedToAttributeTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/TypeForwardedToAttributeTest.cs
@@ -1,0 +1,51 @@
+//
+// TypeForwardedToAttributeTest.cs
+//
+// Authors:
+//  Alexander Köplinger (alkpli@microsoft.com)
+//
+// (c) 2017 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Threading;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+
+namespace MonoTests.System.Runtime.CompilerServices {
+
+	public class TypeForwardedToAttributeTest
+	{
+		[Test]
+		public void CtorTest ()
+		{
+			var a = new TypeForwardedToAttribute (typeof(Math));
+			Assert.AreEqual (typeof(Math), a.Destination);
+
+			a = new TypeForwardedToAttribute (null);
+			Assert.AreEqual (null, a.Destination);
+		}
+	}
+}
+

--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/StructLayoutAttributeTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/StructLayoutAttributeTest.cs
@@ -1,0 +1,62 @@
+//
+// StructLayoutAttributeTest.cs
+//
+// Authors:
+//  Alexander Köplinger (alkpli@microsoft.com)
+//
+// (c) 2017 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Threading;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+
+namespace MonoTests.System.Runtime.InteropServices {
+
+	[TestFixture]
+	public class StructLayoutAttributeTest
+	{
+		[Test]
+		public void CtorTest ()
+		{
+			var a = new StructLayoutAttribute (LayoutKind.Explicit);
+			Assert.AreEqual (LayoutKind.Explicit, a.Value);
+
+			a = new StructLayoutAttribute (LayoutKind.Auto);
+			Assert.AreEqual (LayoutKind.Auto, a.Value);
+		}
+
+		[Test]
+		public void FieldsTest ()
+		{
+			var a = new StructLayoutAttribute (LayoutKind.Explicit);
+
+			Assert.AreEqual ((CharSet)0, a.CharSet);
+			Assert.AreEqual (0, a.Pack);
+			Assert.AreEqual (0, a.Size);
+		}
+	}
+}
+

--- a/mcs/class/corlib/Test/System/ConsoleKeyInfoTest.cs
+++ b/mcs/class/corlib/Test/System/ConsoleKeyInfoTest.cs
@@ -1,0 +1,65 @@
+//
+// ConsoleKeyInfoTest.cs
+//
+// Authors:
+//  Alexander Köplinger (alkpli@microsoft.com)
+//
+// (c) 2017 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Text;
+
+namespace MonoTests.System
+{
+	[TestFixture]
+	public class ConsoleKeyInfoTest
+	{
+		[Test]
+		public void CtorTest()
+		{
+			var cki = new ConsoleKeyInfo ('A', ConsoleKey.A, true, false, true);
+
+			Assert.AreEqual ('A', cki.KeyChar, "#1");
+			Assert.AreEqual (ConsoleKey.A, cki.Key, "#2");
+			Assert.AreEqual ((ConsoleModifiers.Shift | ConsoleModifiers.Control) , cki.Modifiers, "#3");
+		}
+
+		[Test]
+		public void EqualTest()
+		{
+			var ckiA = new ConsoleKeyInfo ('a', ConsoleKey.A, false, false, false);
+			var ckiB = new ConsoleKeyInfo ('b', ConsoleKey.B, false, false, false);
+			var ckiA2 = new ConsoleKeyInfo ('a', ConsoleKey.A, false, false, false);
+
+			Assert.IsFalse (ckiA == ckiB, "#1");
+			Assert.IsTrue (ckiA != ckiB, "#2");
+			Assert.IsFalse (ckiA.Equals (ckiB), "#3");
+
+			Assert.IsTrue (ckiA == ckiA2, "#4");
+			Assert.IsFalse (ckiA != ckiA2, "#5");
+			Assert.IsTrue (ckiA.Equals (ckiA2), "#6");
+		}
+	}
+}

--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -54,6 +54,7 @@ System.Collections.ObjectModel/CollectionTest.cs
 System.Collections.ObjectModel/KeyedCollectionTest.cs
 System.Collections.ObjectModel/ReadOnlyCollectionTest.cs
 System/ConsoleTest.cs
+System/ConsoleKeyInfoTest.cs
 System/ConvertTest.cs
 System/DateTimeOffsetTest.cs
 System/DateTimeOffsetTestCoreFx.cs
@@ -204,6 +205,8 @@ System.Runtime.CompilerServices/AsyncTaskMethodBuilderTest.cs
 System.Runtime.CompilerServices/AsyncVoidMethodBuilderTest.cs
 System.Runtime.CompilerServices/TaskAwaiterTest.cs
 System.Runtime.CompilerServices/TaskAwaiterTest_T.cs
+System.Runtime.CompilerServices/TypeForwardedFromAttributeTest.cs
+System.Runtime.CompilerServices/TypeForwardedToAttributeTest.cs
 System.Runtime.CompilerServices/YieldAwaitableTest.cs
 System.Runtime.ExceptionServices/ExceptionDispatchInfoTest.cs
 System.Runtime.InteropServices/DllImportAttributeTest.cs
@@ -213,6 +216,7 @@ System.Runtime.InteropServices/MarshalAsAttributeTest.cs
 System.Runtime.InteropServices/MarshalTest.cs
 System.Runtime.InteropServices/RuntimeEnvironmentTest.cs
 System.Runtime.InteropServices/SafeHandleTest.cs
+System.Runtime.InteropServices/StructLayoutAttributeTest.cs
 System.Runtime.Remoting/ContextTest.cs
 System.Runtime.Remoting/SoapServicesTest.cs
 System.Runtime.Remoting/SynchronizationAttributeTest.cs


### PR DESCRIPTION
This enables us to remove [LinkerDescription.xml](https://github.com/xamarin/xamarin-android/blob/e0c0c2bae53f15f8949bef5eda64d1018455ab59/tests/Xamarin.Android.Bcl-Tests/Resources/LinkerDescription.xml) from xamarin-android.