### PR TITLE
[System.Windows.Forms] Proper padding and border width for DataGridViewTextBoxCell. Fixes #60514

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewTextBoxCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewTextBoxCell.cs
@@ -211,14 +211,19 @@ namespace System.Windows.Forms {
 				flags |= AlignmentToFlags (cellStyle.Alignment);
 
 				Rectangle contentbounds = cellBounds;
-				
-				contentbounds.Height -= 2;
-				contentbounds.Width -= 2;
-				
-				// If we are top aligned, give ourselves some padding from the top
-				if (((int)cellStyle.Alignment & 7) > 0) {
-					contentbounds.Offset (0, 2);
-					contentbounds.Height -= 2;
+
+				//Border widths
+				Rectangle borderWidths = BorderWidths(advancedBorderStyle);
+				contentbounds.Offset(borderWidths.X, borderWidths.Y);
+				contentbounds.Width -= borderWidths.Right;
+				contentbounds.Height -= borderWidths.Bottom;
+
+				//Padding
+				if (cellStyle.Padding != Padding.Empty)
+				{
+					contentbounds.Offset(cellStyle.Padding.Left, cellStyle.Padding.Top);
+					contentbounds.Width -= cellStyle.Padding.Horizontal;
+					contentbounds.Height -= cellStyle.Padding.Vertical;
 				}
 
 				if (formattedValue != null)


### PR DESCRIPTION
 Proper use padding and border width for DataGridViewTextBoxCell.