### PR TITLE
Fix path to embedded glob.c implementation.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -46,7 +46,7 @@ embeddable runtime:
 
 * mono/utils/bsearch.c: BSD license.
 
-* mono/io-layer/wapi_glob.h, wapi_glob.c: BSD license
+* mono/metadata/w32file-unix-glob.c, w32file-unix-glob.h: BSD license
 
 Class Library code
 ==================


### PR DESCRIPTION
Was moved in https://github.com/mono/mono/commit/f23f72c9de0cb7d03e5db68623440af9dcb19d6c and LICENSE should reflect where these embedded dependencies are found.