### PR TITLE
[tests] Add disabled regression test for #49308

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -475,6 +475,7 @@ TESTS_CS_SRC=		\
 	appdomain-unload-asmload.cs	\
 	appdomain-unload-exception.cs	\
 	unload-appdomain-on-shutdown.cs	\
+	appdomain-marshalbyref-assemblyload.cs \
 	bug-47295.cs	\
 	loader.cs	\
 	pinvoke2.cs	\
@@ -818,6 +819,7 @@ PROFILE_DISABLED_TESTS += \
 	appdomain-unload-callback.exe	\
 	appdomain-unload-doesnot-raise-pending-events.exe	\
 	unload-appdomain-on-shutdown.exe	\
+	appdomain-marshalbyref-assemblyload.exe \
 	assemblyresolve_event2.2.exe	\
 	assemblyresolve_event6.exe	\
 	bug-544446.exe	\
@@ -1808,6 +1810,23 @@ generic-delegate2.2.exe: $(srcdir)/generic-delegate2.2.cs generic-delegate2-lib.
 bug-3903.exe: bug-3903.cs
 	$(MCS_NO_LIB)  $(srcdir)/bug-3903.cs -nostdlib -r:$(srcdir)/../../external/binary-reference-assemblies/v2.0/mscorlib.dll -r:$(srcdir)/../../external/binary-reference-assemblies/v2.0/System.Core.dll -out:$@
 
+EXTRA_DIST += appdomain-marshalbyref-assemblyload-MidAssembly.cs appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+
+LeafAssembly.dll: appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+	mkdir -p appdomain-marshalbyref-assemblyload1
+	$(MCS) -target:library -out:$@ $<
+
+appdomain-marshalbyref-assemblyload2/LeafAssembly.dll: appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+	mkdir -p appdomain-marshalbyref-assemblyload2
+	$(MCS) -target:library -out:$@ $< -define:UNDEFINE_OTHER_METHOD
+
+MidAssembly.dll: appdomain-marshalbyref-assemblyload-MidAssembly.cs LeafAssembly.dll
+	mkdir -p appdomain-marshalbyref-assemblyload1
+	$(MCS) -target:library -out:$@ $< -r:LeafAssembly.dll
+
+appdomain-marshalbyref-assemblyload.exe: appdomain-marshalbyref-assemblyload.cs MidAssembly.dll LeafAssembly.dll appdomain-marshalbyref-assemblyload2/LeafAssembly.dll
+	$(MCS) -out:$@ $< -r:MidAssembly.dll -r:LeafAssembly.dll
+
 gshared:
 	$(MAKE) test-generic-sharing
 
@@ -2045,4 +2064,4 @@ internalsvisibleto-correctcase-2-sign2048.dll internalsvisibleto-wrongcase-2-sig
 	$(Q) $(MCS_NO_UNSAFE) -out:internalsvisibleto-compilertest-sign2048.exe -warn:0 -r:internalsvisibleto-correctcase-2-sign2048.dll -r:internalsvisibleto-wrongcase-2-sign2048.dll -d:SIGN2048 internalsvisibleto-compilertest.cs
 
 
-CLEANFILES = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat
+CLEANFILES = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat LeafAssembly.dll MidAssembly.dll appdomain-marshalbyref-assemblyload2/*.dll 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -939,12 +939,14 @@ LLVM = $(filter --llvm, $(MONO_ENV_OPTIONS))
 # reverted.
 # bug-Xamarin-5278.exe got broken by 5d26590e79da139a284459299aee95c25f4cd835
 # appdomain-thread-abort.exe: https://bugzilla.xamarin.com/show_bug.cgi?id=47054
+# appdomain-marshalbyref-assemblyload.exe: https://bugzilla.xamarin.com/show_bug.cgi?id=49308
 KNOWN_FAILING_TESTS = \
 	delegate-async-exception.exe	\
 	bug-348522.2.exe	\
 	bug-459094.exe \
 	delegate-invoke.exe \
-	bug-Xamarin-5278.exe
+	bug-Xamarin-5278.exe \
+	appdomain-marshalbyref-assemblyload.exe
 
 DISABLED_TESTS = \
 	$(KNOWN_FAILING_TESTS) \

--- a/mono/tests/appdomain-marshalbyref-assemblyload-LeafAssembly.cs
+++ b/mono/tests/appdomain-marshalbyref-assemblyload-LeafAssembly.cs
@@ -1,0 +1,30 @@
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Remoting.Proxies;
+
+namespace LeafAssembly {
+	public class Leaf : MarshalByRefObject {
+		static Leaf () {
+			Console.WriteLine ("Static leaf constructor called in {0}", AppDomain.CurrentDomain);
+		}
+		public Leaf () {
+			Console.WriteLine ("Created leaf in {0}", AppDomain.CurrentDomain);
+		}
+	}
+
+	public class OtherLeafClass {
+		/* We build this assembly twice: once into
+		 * appdomain-marshalbyref-assemblyload1/ with PublicMethod()
+		 * present, and once into appdomain-marshalbyref-assemblyload2/
+		 * without it.  The regression test tries to trick Mono into
+		 * loading from -assemblyload2/.
+		 */
+#if !UNDEFINE_OTHER_METHOD
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static void PublicMethod () {
+
+		}
+#endif
+	}
+}

--- a/mono/tests/appdomain-marshalbyref-assemblyload-MidAssembly.cs
+++ b/mono/tests/appdomain-marshalbyref-assemblyload-MidAssembly.cs
@@ -1,0 +1,33 @@
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace MidAssembly {
+	[Serializable]
+	public class MidClass : MarshalByRefObject {
+		public MidClass () {
+			Console.WriteLine ("Created mid in {0}", AppDomain.CurrentDomain);
+		}
+
+		public void MidMethod (object leaf) {
+			Console.WriteLine ("Called MidMethod in {0}", AppDomain.CurrentDomain);
+			var ad = AppDomain.CurrentDomain;
+			Console.WriteLine ("Domain {0} has loaded:", ad);
+			foreach (var assm in ad.GetAssemblies ()) {
+				Console.WriteLine (" - {0}", assm);
+				Console.WriteLine ("     with location: {0}", assm.Location);
+			}
+		}
+
+
+		public void ForceLoadFrom (string assmPath)
+		{
+			Console.WriteLine ($" loading from {assmPath} into {AppDomain.CurrentDomain}");
+			System.Reflection.Assembly.LoadFrom (assmPath);
+		}
+
+		public void DoSomeAction () {
+			LeafAssembly.OtherLeafClass.PublicMethod ();
+		}
+	}
+}

--- a/mono/tests/appdomain-marshalbyref-assemblyload.cs
+++ b/mono/tests/appdomain-marshalbyref-assemblyload.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Security.Policy;
+
+public class Test {
+	public static int Main ()
+	{
+		var dir1 = Path.GetDirectoryName (typeof (Test).Assembly.Location);
+		var dir2 = "appdomain-marshalbyref-assemblyload2";
+		var domain = CreateDomain (dir2);
+		var path1 = Path.Combine (dir1, "MidAssembly.dll");
+		object o = domain.CreateInstanceFromAndUnwrap (path1, "MidAssembly.MidClass");
+		var mc = o as MidAssembly.MidClass;
+		var l = new LeafAssembly.Leaf ();
+		/* passing Leaf to MidMethod should /not/ cause
+		 * place2/LeafAssembly.dll to be loaded in the new remote
+		 * domain */
+		mc.MidMethod (l);
+		/* this line will pre-load place1/LeafAssembly.dll into the
+		 * remote domain.
+		 */
+		mc.ForceLoadFrom (Path.Combine (dir1, "LeafAssembly.dll"));
+		/* This method calls a class from LeafAssembly (which is only
+		 * defined in the place1 version of the class), so if the
+		 * place2 version had been loaded instead, it will trigger a
+		 * MissingMethodException */
+		mc.DoSomeAction ();
+		return 0;
+	}
+
+	public static AppDomain CreateDomain (string newpath)
+	{
+		var appDomainSetup = new AppDomainSetup ();
+		appDomainSetup.ApplicationBase = newpath;
+		var appDomain = AppDomain.CreateDomain ("MyDomainName", new Evidence (), appDomainSetup);
+		return appDomain;
+	}
+
+}


### PR DESCRIPTION
When [Bugzilla #49308](https://bugzilla.xamarin.com/show_bug.cgi?id=49308) is fixed, the test should be enabled.

See [Comment 4](https://bugzilla.xamarin.com/show_bug.cgi?id=49308#c4) for what's needed to get this working.