### PR TITLE
[interp] fix build on windows

### DIFF
--- a/msvc/libmini-interp.targets
+++ b/msvc/libmini-interp.targets
@@ -7,17 +7,13 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\interp\hacks.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\interp\interp.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\interp\interp-internals.h" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\interp.c">
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\interp.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\interp-stubs.c">
       <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\interp-stubs.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\interp\mintops.h" />
     <None Include="$(MonoSourceLocation)\mono\mini\interp\mintops.def" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\mintops.c">
-      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\transform.c">
-      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\mintops.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\interp\transform.c" />
   </ItemGroup>
 </Project>

--- a/winconfig.h
+++ b/winconfig.h
@@ -94,7 +94,7 @@
 /* #undef DISABLE_SSA */
 
 /* Disable interpreter */
-#define DISABLE_INTERPRETER 1
+/* #undef DISABLE_INTERPRETER */
 
 /* Enable DTrace probes */
 /* #undef ENABLE_DTRACE */


### PR DESCRIPTION
it was fine on CI, but developers can run into build errors if they
don't follow a strict order (due to autotools fighting with
`winconfig.h`).

`basic.exe` passes, but everything involving native transitions crashes.

/cc @EgorBo @akoeplinger 