### PR TITLE
[bcl] bringing back InetAccess test category

### DIFF
--- a/mcs/class/System.DirectoryServices/Test/System.DirectoryServices/DirectoryServicesDirectoryEntryTest.cs
+++ b/mcs/class/System.DirectoryServices/Test/System.DirectoryServices/DirectoryServicesDirectoryEntryTest.cs
@@ -13,6 +13,7 @@ using System.DirectoryServices;
 namespace MonoTests.System.DirectoryServices 
 {
 	[TestFixture]
+	[Category ("InetAccess")]
 	public class DirectoryServicesDirectoryEntryTest
 	{
 		#region Fields

--- a/mcs/class/System.DirectoryServices/Test/System.DirectoryServices/DirectoryServicesDirectorySearcherTest.cs
+++ b/mcs/class/System.DirectoryServices/Test/System.DirectoryServices/DirectoryServicesDirectorySearcherTest.cs
@@ -15,6 +15,7 @@ using System.Threading;
 namespace MonoTests.System.DirectoryServices 
 {
 	[TestFixture]
+	[Category ("InetAccess")]
 	public class DirectoryServicesDirectorySearcherTest
 	{
 		#region Fields

--- a/mcs/class/System.DirectoryServices/Test/System.DirectoryServices/DirectoryServicesSearchResultTest.cs
+++ b/mcs/class/System.DirectoryServices/Test/System.DirectoryServices/DirectoryServicesSearchResultTest.cs
@@ -13,6 +13,7 @@ using System.DirectoryServices;
 namespace MonoTests.System.DirectoryServices 
 {
 	[TestFixture]
+	[Category ("InetAccess")]
 	public class DirectoryServicesSearchResultTest
 	{
 		#region Fields

--- a/mcs/class/System.Web.Services/Test/System.Web.Services.Discovery/DiscoveryClientProtocolTest.cs
+++ b/mcs/class/System.Web.Services/Test/System.Web.Services.Discovery/DiscoveryClientProtocolTest.cs
@@ -19,6 +19,7 @@ namespace MonoTests.System.Web.Services.Discovery {
 
 		[Test] // Covers #36116
 		[Category ("NotWorking")]
+		[Category ("InetAccess")]
 		public void ReadWriteTest ()
 		{
 			string directory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());

--- a/mcs/class/System/Test/System.Net.NetworkInformation/IPInterfacePropertiesTest.cs
+++ b/mcs/class/System/Test/System.Net.NetworkInformation/IPInterfacePropertiesTest.cs
@@ -74,6 +74,7 @@ namespace MonoTests.System.Net.NetworkInformation
 		}
 	
 		[Test]
+		[Category ("InetAccess")]
 		public void AtLeastOneGatewayAddress ()
 		{
 			int numGatewayAddresses = 0;

--- a/mcs/class/System/Test/System.Net.Sockets/NetworkStreamCas.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/NetworkStreamCas.cs
@@ -97,6 +97,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncRead ()
 		{
 			message = "AsyncRead";
@@ -135,6 +136,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncWrite ()
 		{
 			message = "AsyncWrite";

--- a/mcs/class/System/Test/System.Net.Sockets/NetworkStreamTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/NetworkStreamTest.cs
@@ -16,6 +16,7 @@ using NUnit.Framework;
 namespace MonoTests.System.Net.Sockets
 {
 	[TestFixture]
+	[Category ("InetAccess")]
 	public class NetworkStreamTest
 	{
 	        [Test]

--- a/mcs/class/System/Test/System.Net.Sockets/SocketCas.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketCas.cs
@@ -78,6 +78,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncAccept ()
 		{
 			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 16279);
@@ -117,6 +118,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncConnect ()
 		{
 			message = "AsyncConnect";
@@ -150,6 +152,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncReceive ()
 		{
 			message = "AsyncReceive";
@@ -188,6 +191,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncReceiveFrom ()
 		{
 			message = "AsyncReceiveFrom";
@@ -226,6 +230,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncSend ()
 		{
 			message = "AsyncSend";
@@ -260,6 +265,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncSendTo ()
 		{
 			message = "AsyncSendTo";

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -86,6 +86,7 @@ namespace MonoTests.System.Net.Sockets
 
 		[Test]
 		[Category ("NotWorking")]
+		[Category ("InetAccess")]
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif

--- a/mcs/class/System/Test/System.Net.Sockets/TcpClientCas.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/TcpClientCas.cs
@@ -70,6 +70,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncConnect_StringIntAsyncCallbackObject ()
 		{
 			TcpClient s = new TcpClient ();
@@ -84,6 +85,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncConnect_IPAddressIntAsyncCallbackObject ()
 		{
 			IPHostEntry host = Dns.Resolve ("www.google.com");
@@ -99,6 +101,7 @@ namespace MonoCasTests.System.Net.Sockets {
 
 		[Test]
 		[EnvironmentPermission (SecurityAction.Deny, Read = "USERNAME")]
+		[Category ("InetAccess")]
 		public void AsyncConnect_IPAddressArrayIntAsyncCallbackObject ()
 		{
 			IPHostEntry host = Dns.Resolve ("www.google.com");

--- a/mcs/class/System/Test/System.Net/DnsTest.cs
+++ b/mcs/class/System/Test/System.Net/DnsTest.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 namespace MonoTests.System.Net
 {
 	[TestFixture]
+	[Category ("InetAccess")]
 	public class DnsTest
 	{
 		private String site1Name = "google-public-dns-a.google.com",

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -63,6 +63,7 @@ namespace MonoTests.System.Net
 		}
 
 		[Test]
+		[Category("InetAccess")]
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
@@ -134,6 +135,7 @@ namespace MonoTests.System.Net
 		}
 
 		[Test]
+		[Category("InetAccess")]
 		[Category ("NotWorking")] // Disabled until a server that meets requirements is found
 		public void Cookies1 ()
 		{

--- a/mcs/class/System/Test/System.Net/ServicePointManagerTest.cs
+++ b/mcs/class/System/Test/System.Net/ServicePointManagerTest.cs
@@ -48,6 +48,7 @@ public class ServicePointManagerTest
 
         [Test, ExpectedException (typeof (InvalidOperationException))]
 		[Category ("NotWorking")]
+		[Category ("InetAccess")]
         public void MaxServicePointManagers ()
         {
 		Assert.AreEqual (0, ServicePointManager.MaxServicePoints, "#1");
@@ -85,7 +86,8 @@ public class ServicePointManagerTest
 		//WriteServicePoint (sp);
 	}
 	
-        [Test]
+	[Test]
+	[Category ("InetAccess")]
 #if FEATURE_NO_BSD_SOCKETS
 	[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -46,6 +46,7 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (WebException))] // Something catches the PlatformNotSupportedException and re-throws an WebException
 #endif
+		[Category ("InetAccess")]
 		public void DownloadTwice ()
 		{
 			WebClient wc = new WebClient();

--- a/mcs/class/System/Test/System.Net/WebClientTestAsync.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTestAsync.cs
@@ -82,6 +82,7 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (AggregateException))] // Something catches the PlatformNotSupportedException and re-throws an AggregateException
 #endif
+		[Category("InetAccess")]
 		public void DownloadFileTaskAsync ()
 		{
 			WebClient wc = new WebClient ();
@@ -96,6 +97,7 @@ namespace MonoTests.System.Net
 
 		[Test]
 		[Category ("NotWorking")] // Fails when ran as part of the entire BCL test suite. Works when only this fixture is ran
+		[Category("InetAccess")]
 		public void Cancellation ()
 		{
 			WebClient wc = new WebClient ();
@@ -123,6 +125,7 @@ namespace MonoTests.System.Net
 
 		[Test]
 		[Category ("NotWorking")] // Fails when ran as part of the entire BCL test suite. Works when only this fixture is ran
+		[Category("InetAccess")]
 		public void DownloadMultiple ()
 		{
 			WebClient wc = new WebClient ();
@@ -140,6 +143,7 @@ namespace MonoTests.System.Net
 		}
 
 		[Test]
+		[Category ("InetAccess")]
 		[Category ("NotWorking")] // Fails when ran as part of the entire BCL test suite. Works when only this fixture is ran
 		public void DownloadMultiple2 ()
 		{
@@ -152,6 +156,7 @@ namespace MonoTests.System.Net
 		}
 
 		[Test]
+		[Category ("InetAccess")]
 		[Category ("NotWorking")] // Fails when ran as part of the entire BCL test suite. Works when only this fixture is ran
 		public void DownloadMultiple3 ()
 		{

--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509ChainTest.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509ChainTest.cs
@@ -205,6 +205,7 @@ namespace MonoTests.System.Security.Cryptography.X509Certificates {
 		}
 
 		[Test]
+		[Category ("InetAccess")]
 		public void Build_Cert1_X509RevocationMode_Online ()
 		{
 			X509Chain c = new X509Chain ();


### PR DESCRIPTION
This partially reverts 9b4b6d621101fdf06e41b0f76b1ad50b0d1149f2

Xamarin.Android’s QA team has a need to run on-device tests in cases
where the device does not have an internet connection.

I also marked a few tests with `InetAccess` indicated from a past test
run here:
http://xqa.blob.core.windows.net/gist/log-1481cb7679ce4db0a305a551ff7f4e18.txt