### PR TITLE
[profiler] Make profiler arg parsing more compatible with previous version.

### DIFF
--- a/mono/profiler/log-args.c
+++ b/mono/profiler/log-args.c
@@ -10,6 +10,7 @@
 typedef struct {
 	const char *event_name;
 	const int mask;
+	const int compat_mask;
 } NameAndMask;
 
 static NameAndMask event_list[] = {
@@ -24,7 +25,7 @@ static NameAndMask event_list[] = {
 	{ "counter", PROFLOG_COUNTER_EVENTS },
 	{ "jit", PROFLOG_JIT_EVENTS },
 
-	{ "alloc", PROFLOG_ALLOC_ALIAS },
+	{ "alloc", PROFLOG_ALLOC_ALIAS, PROFLOG_ALLOC_ALIAS | PROFLOG_GC_ROOT_EVENTS },
 	{ "legacy", PROFLOG_LEGACY_ALIAS },
 };
 
@@ -52,10 +53,24 @@ match_option (const char *arg, const char *opt_name, const char **rval)
 	}
 }
 
+static gboolean compat_args_parsing;
+
 static void
 parse_arg (const char *arg, ProfilerConfig *config)
 {
 	const char *val;
+
+	static gboolean first_processed;
+
+	if (!first_processed) {
+		first_processed = TRUE;
+		if (match_option (arg, "nodefaults", NULL)) {
+			//enables new style of default events, IE, nothing.
+		} else {
+			config->enable_mask = PROFLOG_EXCEPTION_EVENTS | PROFLOG_COUNTER_EVENTS;
+			compat_args_parsing = TRUE;
+		}
+	}
 
 	if (match_option (arg, "help", NULL)) {
 		usage ();
@@ -65,8 +80,11 @@ parse_arg (const char *arg, ProfilerConfig *config)
 		config->do_debug = TRUE;
 	} else if (match_option (arg, "heapshot", &val)) {
 		set_hsmode (config, val);
-		if (config->hs_mode != MONO_PROFILER_HEAPSHOT_NONE)
+		if (config->hs_mode != MONO_PROFILER_HEAPSHOT_NONE) {
 			config->enable_mask |= PROFLOG_HEAPSHOT_ALIAS;
+			if (compat_args_parsing)
+				config->enable_mask |= PROFLOG_GC_MOVE_EVENTS;
+		}
 	} else if (match_option (arg, "heapshot-on-shutdown", NULL)) {
 		config->hs_on_shutdown = TRUE;
 		config->enable_mask |= PROFLOG_HEAPSHOT_ALIAS;
@@ -80,6 +98,9 @@ parse_arg (const char *arg, ProfilerConfig *config)
 		config->enable_mask |= PROFLOG_SAMPLE_EVENTS;
 	} else if (match_option (arg, "calls", NULL)) {
 		config->enter_leave = TRUE;
+	} else if (match_option (arg, "nocalls", NULL)) {
+		if (!compat_args_parsing)
+			mono_profiler_printf_err ("Could not parse argument: %s", arg);
 	} else if (match_option (arg, "coverage", NULL)) {
 		g_warning ("the log profiler support for code coverage is obsolete, use the \"coverage\" profiler");
 		config->collect_coverage = TRUE;
@@ -130,11 +151,14 @@ parse_arg (const char *arg, ProfilerConfig *config)
 		int i;
 
 		for (i = 0; i < G_N_ELEMENTS (event_list); ++i){
+			int mask = event_list [i].mask;
+			if (compat_args_parsing && event_list [i].compat_mask)
+				mask = event_list [i].compat_mask;
 			if (!strcmp (arg, event_list [i].event_name)) {
-				config->enable_mask |= event_list [i].mask;
+				config->enable_mask |= mask;
 				break;
 			} else if (!strncmp (arg, "no", 2) && !strcmp (arg + 2, event_list [i].event_name)) {
-				config->disable_mask |= event_list [i].mask;
+				config->disable_mask |= mask;
 				break;
 			}
 		}
@@ -252,19 +276,35 @@ set_hsmode (ProfilerConfig *config, const char* val)
 static void
 set_sample_freq (ProfilerConfig *config, const char *val)
 {
+	int freq;
+
 	if (!val)
 		return;
 
-	char *end;
+	const char *p = val;
 
-	int freq = strtoul (val, &end, 10);
+	// Is it only the frequency (new option style)?
+	if (isdigit (*p))
+		goto parse;
 
-	if (val == end) {
-		usage ();
-		return;
+	// Skip the sample type for backwards compatibility.
+	while (isalpha (*p))
+		p++;
+
+	// Skip the forward slash only if we got a sample type.
+	if (p != val && *p == '/') {
+		p++;
+
+		char *end;
+
+parse:
+		freq = strtoul (p, &end, 10);
+
+		if (p == end)
+			usage ();
+		else
+			config->sample_freq = freq;
 	}
-
-	config->sample_freq = freq;
 }
 
 static void
@@ -280,6 +320,7 @@ usage (void)
 	for (int i = 0; i < G_N_ELEMENTS (event_list); i++)
 		mono_profiler_printf ("\t                         %s", event_list [i].event_name);
 
+	mono_profiler_printf ("\tnodefaults           disable legacy rules for enabling extra events");
 	mono_profiler_printf ("\t[no]alloc            enable/disable recording allocation info");
 	mono_profiler_printf ("\t[no]legacy           enable/disable pre Mono 5.6 default profiler events");
 	mono_profiler_printf ("\tsample[-real][=FREQ] enable/disable statistical sampling of threads");
@@ -290,6 +331,7 @@ usage (void)
 	mono_profiler_printf ("\theapshot-on-shutdown do a heapshot on runtime shutdown");
 	mono_profiler_printf ("\t                     this option is independent of the above option");
 	mono_profiler_printf ("\tcalls                enable recording enter/leave method events (very heavy)");
+	mono_profiler_printf ("\tnocalls              compat switch with previous versions of the profiler, does nothing");
 	mono_profiler_printf ("\tcoverage             enable collection of code coverage data");
 	mono_profiler_printf ("\tcovfilter=ASSEMBLY   add ASSEMBLY to the code coverage filters");
 	mono_profiler_printf ("\t                     prefix a + to include the assembly or a - to exclude it");

--- a/mono/profiler/log-args.c
+++ b/mono/profiler/log-args.c
@@ -25,6 +25,7 @@ static NameAndMask event_list[] = {
 	{ "counter", PROFLOG_COUNTER_EVENTS },
 	{ "jit", PROFLOG_JIT_EVENTS },
 
+	{ "counters", PROFLOG_COUNTER_EVENTS },
 	{ "alloc", PROFLOG_ALLOC_ALIAS, PROFLOG_ALLOC_ALIAS | PROFLOG_GC_ROOT_EVENTS },
 	{ "legacy", PROFLOG_LEGACY_ALIAS },
 };
@@ -92,7 +93,7 @@ parse_arg (const char *arg, ProfilerConfig *config)
 		set_sample_freq (config, val);
 		config->sampling_mode = MONO_PROFILER_SAMPLE_MODE_PROCESS;
 		config->enable_mask |= PROFLOG_SAMPLE_EVENTS;
-	} else if (match_option (arg, "sample-real", &val)) {
+	} else if (match_option (arg, "sample-real", &val) || (compat_args_parsing && match_option (arg, "sampling-real", &val))) {
 		set_sample_freq (config, val);
 		config->sampling_mode = MONO_PROFILER_SAMPLE_MODE_REAL;
 		config->enable_mask |= PROFLOG_SAMPLE_EVENTS;


### PR DESCRIPTION
This introduces the following changes.

By default, enable more events. Exceptions and Counters are on by default.
By default, if alloc or heapshot are enabled, we emit root events as well.

New `nodefaults` argument that disables the above changes to default arg processing.

Added "nocalls" argument for compat only purposes.

Restored "cycles/" prefix to sample frequency argument. It was already a dead argument, but kept for compat.
We restored that as existing clients pass that flag.