### PR TITLE
Fix MonoContextSimdReg usage on Linux amd64

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -36,6 +36,9 @@ typedef struct _libc_xmmreg MonoContextSimdReg;
 typedef __m128d MonoContextSimdReg;
 #elif defined(HOST_ANDROID)
 typedef struct _libc_xmmreg MonoContextSimdReg;
+#elif defined(__linux__)
+#include <emmintrin.h>
+typedef __m128d MonoContextSimdReg;
 #endif
 #elif defined(TARGET_ARM64)
 typedef __uint128_t MonoContextSimdReg;


### PR DESCRIPTION
Include emmintrin.h and use __m128d for MonoContextSimdReg on Linux.

Fixes breakage on Alpine Linux introduced in https://github.com/mono/mono/pull/5764