### PR TITLE
Update GdipGetImageDimensions tests to pass against Windows GDI+

### DIFF
--- a/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
@@ -1590,11 +1590,6 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (4127, bounds.Height, "bounds.Height");
 			Assert.AreEqual (GraphicsUnit.Pixel, unit, "uint");
 
-			float width, height;
-			Assert.AreEqual (Status.Ok, GDIPlus.GdipGetImageDimension (image, out width, out height), "GdipGetImageDimension");
-			Assert.AreEqual (12976.6328f, width, 0.001f, "GdipGetImageDimension/Width");
-			Assert.AreEqual (17297.9863f, height, 0.001f, "GdipGetImageDimension/Height");
-
 			ImageType type;
 			Assert.AreEqual (Status.Ok, GDIPlus.GdipGetImageType (image, out type), "GdipGetImageType");
 			Assert.AreEqual (ImageType.Metafile, type, "Metafile");

--- a/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
@@ -1590,6 +1590,11 @@ namespace MonoTests.System.Drawing {
 			Assert.AreEqual (4127, bounds.Height, "bounds.Height");
 			Assert.AreEqual (GraphicsUnit.Pixel, unit, "uint");
 
+			float width, height;
+			Assert.AreEqual (Status.Ok, GDIPlus.GdipGetImageDimension (image, out width, out height), "GdipGetImageDimension");
+			Assert.AreEqual (12976.6328f, width, 0.001f, "GdipGetImageDimension/Width");
+			Assert.AreEqual (17297.9863f, height, 0.02f, "GdipGetImageDimension/Height");
+
 			ImageType type;
 			Assert.AreEqual (Status.Ok, GDIPlus.GdipGetImageType (image, out type), "GdipGetImageType");
 			Assert.AreEqual (ImageType.Metafile, type, "Metafile");


### PR DESCRIPTION
These fail against windows and cause errors when fixed in https://github.com/mono/libgdiplus/pull/121