### PR TITLE
[System.Process] Consider `open`'s exit code when using it to start a process. Fixes #19503 

### DIFF
--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -207,12 +207,6 @@ namespace MonoTests.System.Diagnostics
 				Assert.AreEqual (2, ex.NativeErrorCode, "#B6");
 			}
 
-			if (RunningOnUnix)
-				Assert.Ignore ("On Unix and Mac OS X, we try " +
-					"to open any file (using xdg-open, ...)" +
-					" and we do not report an exception " +
-					"if this fails.");
-
 			// absolute path, shell
 			process.StartInfo.FileName = exe;
 			process.StartInfo.UseShellExecute = true;


### PR DESCRIPTION
… process. Fixes #19503
The other Unix launchers may need to have this behavior enabled also in order for the tests to pass in non-Mac Unix.