### PR TITLE
[System] Add missing ConfigureAwait

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5684,12 +5684,19 @@ ves_icall_Mono_RuntimeMarshal_FreeAssemblyName (MonoAssemblyName *aname, gboolea
 		g_free (aname);
 }
 
-ICALL_EXPORT gboolean
-ves_icall_System_Reflection_AssemblyName_ParseAssemblyName (const char *name, MonoAssemblyName *aname, gboolean *is_version_definited, gboolean *is_token_defined)
+ICALL_EXPORT MonoBoolean
+ves_icall_System_Reflection_AssemblyName_ParseAssemblyName (const char *name, MonoAssemblyName *aname, MonoBoolean *is_version_defined_arg, MonoBoolean *is_token_defined_arg)
 {
-	*is_version_definited = *is_token_defined = FALSE;
+	gboolean is_version_defined = FALSE;
+	gboolean is_token_defined = FALSE;
+	gboolean result = FALSE;
 
-	return mono_assembly_name_parse_full (name, aname, TRUE, is_version_definited, is_token_defined);
+	result = mono_assembly_name_parse_full (name, aname, TRUE, &is_version_defined, &is_token_defined);
+
+	*is_version_defined_arg = (MonoBoolean)is_version_defined;
+	*is_token_defined_arg = (MonoBoolean)is_token_defined;
+
+	return result;
 }
 
 ICALL_EXPORT MonoReflectionTypeHandle


### PR DESCRIPTION
This is a candidate fix for:
https://bugzilla.xamarin.com/show_bug.cgi?id=60317

The bug was introduced by 1b5e0f73316ee7b83c8947bc738015443fabd7af.

Preliminary verification
========================

If I make just this _one_ change to a "bad" commit of Mono from after
commit 1b5e0f7, rebuild System.dll in the `xammac` profile, and then
overwrite that file in the MonoBundle directory of a Xamarin.Mac test
app, then I restore the old "good" behavior.  (I started with
38da0b3b4996357a7472e3202c575c9111469721 as the "bad" version for my
tests.)

I believe this confirms that the cause of bug 60317 was the usual
deadlocking issue when awaiting Tasks on the UI thread.  As discussed on
https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html, if
any Tasks awaited anywhere up the call stack are missing
`ConfigureAwait (false)`, then you can run into trouble on the UI
thread.

Additional little checks
========================

1. Do the other `await` statements in commit
1b5e0f73316ee7b83c8947bc738015443fabd7af all look OK?  Yes, it looks
like this was the only `await` statement that was missing
`ConfigureAwait (false)`:

```
$ git show 1b5e0f73316ee7b83c8947bc738015443fabd7af | grep await
+				await ProcessOperation (cancellationToken).ConfigureAwait (false);
+				var ret = await InnerRead (cancellationToken).ConfigureAwait (false);
+					await Parent.InnerWrite (RunSynchronously, cancellationToken);
+				var ret = await Parent.InnerRead (RunSynchronously, requestedSize, cancellationToken).ConfigureAwait (false);
+					result = await asyncRequest.StartOperation (CancellationToken.None).ConfigureAwait (false);
+				result = await asyncRequest.StartOperation (cancellationToken).ConfigureAwait (false);
+			var ret = await task.ConfigureAwait (false);
+			await task.ConfigureAwait (false);
```

2. Is it a concern that mcs/class/System did not contain any calls to
`ConfigureAwait ()` until commit 1b5e0f7:

```
$ git grep ConfigureAwait 1b5e0f73316ee7b83c8947bc738015443fabd7af^ -- mcs/class/System || echo 'None'
None
```

I do not think this is a concern.  For example,
System.Net.Http.HttpClient has been using `ConfigureAwait (false)` for
several years, so there is a precedent for it.