### PR TITLE
Provide a special implementation of ReadToEnd for CStreamReader to fix Console.In.ReadToEnd not echoing input characters.

### DIFF
--- a/mcs/class/corlib/System/CStreamReader.cs
+++ b/mcs/class/corlib/System/CStreamReader.cs
@@ -97,7 +97,7 @@ namespace System.IO {
 		public override string ReadToEnd ()
 		{
 			try {
-				return (base.ReadToEnd ());
+				return driver.ReadToEnd ();
 			} catch (IOException) {
 			}
 

--- a/mcs/class/corlib/System/TermInfoDriver.cs
+++ b/mcs/class/corlib/System/TermInfoDriver.cs
@@ -1103,6 +1103,16 @@ namespace System {
 
 		public string ReadLine ()
  		{
+			return ReadUntilConditionInternal (true);
+ 		}
+
+		public string ReadToEnd ()
+ 		{
+			return ReadUntilConditionInternal (false);
+ 		}
+
+		private string ReadUntilConditionInternal (bool haltOnNewLine)
+ 		{
 			if (!inited)
 				Init ();
 
@@ -1120,6 +1130,8 @@ namespace System {
 			rl_starty = cursorTop;
 			char eof = (char) control_characters [ControlCharacters.EOF];
 
+			bool treatAsEnterKey;
+
 			do {
 				key = ReadKeyInternal (out fresh);
 				echo = echo || fresh;
@@ -1128,7 +1140,9 @@ namespace System {
 				if (c == eof && c != 0 && builder.Length == 0)
 					return null;
 
-				if (key.Key != ConsoleKey.Enter) {
+				treatAsEnterKey = haltOnNewLine && (key.Key == ConsoleKey.Enter);
+
+				if (!treatAsEnterKey) {
 					if (key.Key != ConsoleKey.Backspace) {
 						builder.Append (c);
 					} else if (builder.Length > 0) {
@@ -1142,7 +1156,7 @@ namespace System {
 				// echo fresh keys back to the console
 				if (echo)
 					Echo (key);
-			} while (key.Key != ConsoleKey.Enter);
+			} while (!treatAsEnterKey);
 
 			EchoFlush ();
 


### PR DESCRIPTION
This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40699.

If TermInfoDriver is initialized, input characters are not echoed during ReadToEnd because CStreamReader uses StreamReader.ReadToEnd (instead of a custom implementation like ReadLine). This is fixed by adding a custom ReadToEnd implementation that mirrors ReadLine's.

Operations like setting a CancelKeyPress handler or reading the width of the console cause TermInfoDriver to be automatically initialized, at which point echoing behavior changes. A simple repro:

```csharp
using System;

class Program
{
    static void Main(string[] args)
    {
        var bufferWidth = Console.BufferWidth;
        Console.WriteLine("Type something:");
        var got = Console.In.ReadLine();
        Console.WriteLine("Got: {0}", got); 
        got = Console.In.ReadToEnd();
        Console.WriteLine("Got: {0}", got); 
    }
}
```

Before this fix, echoing works correctly for the first ReadLine operation but not for the second ReadToEnd operation. This fix results in echoing for both.

Assorted notes:
Canceling ReadToEnd on the console exits the process for us, which doesn't match Windows .NET Framework. I'm not sure if it should in these circumstances.
Maybe we should change underlying CStreamReader operations to all provide echoing, instead of just ReadLine and ReadToEnd?