### PR TITLE
[tools] Fix .apps generated by MacPack not running when Mono 5 is installed on macOS

### DIFF
--- a/mcs/tools/macpack/LOADER
+++ b/mcs/tools/macpack/LOADER
@@ -10,6 +10,7 @@
 X11_MODE=%X11_MODE%
 MWF_MODE=%MWF_MODE%
 COCOASHARP_MODE=%COCOASHARP_MODE%
+MONO_ARGS=%MONO_ARGS%
 
 PWD=`pwd`
 # Fetch the path relative to the launch point where this shell script exists.
@@ -44,13 +45,13 @@ if [ "$X11_MODE" -eq "1" ]; then
 # elif: Keep compatibility with previous code
 elif [ -f "$mono4_path" ]; then
         DIR=$(cd "$(dirname "$0")"; pwd)
-        "$mono4_path" $DIR/../Resources/"$ASSEMBLY"
+        "$mono4_path" $MONO_ARGS $DIR/../Resources/"$ASSEMBLY"
 elif [ -f "$mono5_path" ]; then
         DIR=$(cd "$(dirname "$0")"; pwd)
-        "$mono5_path" $DIR/../Resources/"$ASSEMBLY"
+        "$mono5_path" $MONO_ARGS $DIR/../Resources/"$ASSEMBLY"
 else
 	if [ ! -d "./bin" ]; then mkdir bin ; fi
 	if [ -f "./bin/$APP_NAME" ]; then rm -f "./bin/$APP_NAME" ; fi
 	ln -s `which mono` "./bin/$APP_NAME" 
-	"./bin/$APP_NAME" "$ASSEMBLY"
+	"./bin/$APP_NAME" $MONO_ARGS "$ASSEMBLY"
 fi

--- a/mcs/tools/macpack/LOADER
+++ b/mcs/tools/macpack/LOADER
@@ -33,16 +33,21 @@ fi
 
 cd "$APP_PATH/Contents/Resources"
 
+mono4_path=/usr/local/bin/mono
+mono5_path=/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono
+
 if [ "$X11_MODE" -eq "1" ]; then
 	open-x11 "$APP_NAME"
 
 # rcruzs00
 # El Capitan FIX: `which` wont work (system-integrity-protection)
 # elif: Keep compatibility with previous code
-elif [ -f /usr/local/bin/mono ]; then
+elif [ -f "$mono4_path" ]; then
         DIR=$(cd "$(dirname "$0")"; pwd)
-        /usr/local/bin/mono $DIR/../Resources/"$ASSEMBLY"
-
+        "$mono4_path" $DIR/../Resources/"$ASSEMBLY"
+elif [ -f "$mono5_path" ]; then
+        DIR=$(cd "$(dirname "$0")"; pwd)
+        "$mono5_path" $DIR/../Resources/"$ASSEMBLY"
 else
 	if [ ! -d "./bin" ]; then mkdir bin ; fi
 	if [ -f "./bin/$APP_NAME" ]; then rm -f "./bin/$APP_NAME" ; fi

--- a/mcs/tools/macpack/MacPack.cs
+++ b/mcs/tools/macpack/MacPack.cs
@@ -112,23 +112,33 @@ namespace Mac {
 					script = script.Replace ("%MWF_MODE%", "0");
 					script = script.Replace ("%COCOASHARP_MODE%", "0");
 					script = script.Replace ("%X11_MODE%", "0");
+					script = script.Replace ("%MONO_ARGS%", "");
 					break;
 				case 1:
 					script = script.Replace ("%MWF_MODE%", "1");
 					script = script.Replace ("%COCOASHARP_MODE%", "0");
 					script = script.Replace ("%X11_MODE%", "0");
+					// no WinForms support in 64-bit Mono - pass --arch=32 to the mono executable
+					// see XplatUICarbon.Initialize(): 
+					//     WARNING: The Carbon driver has not been ported to 64bits, and very few parts 
+					//     of Windows.Forms will work properly, or at all
+					script = script.Replace ("%MONO_ARGS%", "--arch=32");
+
 					break;
 				case 2:
 					script = script.Replace ("%MWF_MODE%", "0");
 					script = script.Replace ("%COCOASHARP_MODE%", "1");
 					script = script.Replace ("%X11_MODE%", "0");
+					script = script.Replace ("%MONO_ARGS%", "");
 					break;
 				case 3:
 					script = script.Replace ("%MWF_MODE%", "0");
 					script = script.Replace ("%COCOASHARP_MODE%", "0");
 					script = script.Replace ("%X11_MODE%", "1");
+					script = script.Replace ("%MONO_ARGS%", "");
 					break;
 			}
+
 			data = Encoding.ASCII.GetBytes (script);
 			writer.Write (data, 0, data.Length);
 			writer.Close ();


### PR DESCRIPTION
This PR addresses two issues when running an .app packaged with `MacPack.exe` on macOS with Mono 5:

1. Launching an app on macOS with Mono 5 and System Integrity Protection enabled fails with the following output:

````
LSOpenURLsWithRole() failed with error -10810 for the file FooBar.app.
````

This is due to the `LOADER` script not checking the new / updated location for the mono executable on macOS. The solution in this PR builds on the existing script to detect a Mono 5 installation.

2. Launching a WinForms app on 64-bit macOS with Mono 5 crashes on startup with the following stack trace:

```
WARNING: The Carbon driver has not been ported to 64bits, and very few parts of Windows.Forms will work properly, or at all
Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.Windows.Forms.XplatUICarbon.CGDisplayBounds (intptr) [0x00002] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.XplatUICarbon.get_WorkingArea () [0x00005] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.XplatUICarbon.get_VirtualScreen () [0x00000] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.XplatUI.get_VirtualScreen () [0x00000] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Screen..cctor () [0x00034] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at (wrapper runtime-invoke) object.runtime_invoke_void (object,intptr,intptr,intptr) [0x0001e] in <ac812cae460544af83bd6cf54c5eee87>:0
  at <unknown> <0xffffffff>
  at System.Windows.Forms.Hwnd.GetNextStackedFormLocation (System.Windows.Forms.CreateParams,System.Windows.Forms.Hwnd) [0x00064] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.XplatUICarbon.CreateWindow (System.Windows.Forms.CreateParams) [0x000c5] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.XplatUI.CreateWindow (System.Windows.Forms.CreateParams) [0x00000] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.NativeWindow.CreateHandle (System.Windows.Forms.CreateParams) [0x00009] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Control.CreateHandle () [0x00031] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Form.CreateHandle () [0x00000] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Control.CreateControl () [0x00039] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Control.SetVisibleCore (bool) [0x0003a] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Form.SetVisibleCore (bool) [0x00065] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Control.set_Visible (bool) [0x00009] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control.set_Visible (bool) [0x00032] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Application.RunLoop (bool,System.Windows.Forms.ApplicationContext) [0x00059] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Application.Run (System.Windows.Forms.ApplicationContext) [0x00011] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at System.Windows.Forms.Application.Run (System.Windows.Forms.Form) [0x00006] in <919c0e29d1ee4130aa56b0f95d0b6c84>:0
  at FooBar.Program.RunApplication () [0x0005f] in <99a28ba958684309a2e3c3c76001acd0>:0
  at FooBar.Program.Main () [0x00048] in <99a28ba958684309a2e3c3c76001acd0>:0
  at (wrapper runtime-invoke) object.runtime_invoke_void (object,intptr,intptr,intptr) [0x0004c] in <ac812cae460544af83bd6cf54c5eee87>:0
```

This is due to the latest Mono on macOS defaulting to 64-bit (mono64) which is not compatible with WinForms apps. The solution in this PR passes `--arch=32` to the `mono` executable if the user is packaging a WinForms app using `MacPack.exe`.