### PR TITLE
[2017-10] [metadata] make get_darwin_locale thread-safe

### DIFF
--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -448,7 +448,8 @@ region_info_entry_from_lcid (int lcid)
 static gchar*
 get_darwin_locale (void)
 {
-	static gchar *darwin_locale = NULL;
+	static gchar *cached_locale = NULL;
+	gchar *darwin_locale = NULL;
 	CFLocaleRef locale = NULL;
 	CFStringRef locale_language = NULL;
 	CFStringRef locale_country = NULL;
@@ -459,8 +460,8 @@ get_darwin_locale (void)
 	CFIndex len;
 	int i;
 
-	if (darwin_locale != NULL)
-		return g_strdup (darwin_locale);
+	if (cached_locale != NULL)
+		return g_strdup (cached_locale);
 
 	locale = CFLocaleCopyCurrent ();
 
@@ -502,7 +503,7 @@ get_darwin_locale (void)
 				if (!CFStringGetCString (locale_cfstr, darwin_locale, len, kCFStringEncodingMacRoman)) {
 					g_free (darwin_locale);
 					CFRelease (locale);
-					darwin_locale = NULL;
+					cached_locale = NULL;
 					return NULL;
 				}
 
@@ -515,7 +516,9 @@ get_darwin_locale (void)
 		CFRelease (locale);
 	}
 
-	return g_strdup (darwin_locale);
+	mono_memory_barrier ();
+	cached_locale = darwin_locale;
+	return g_strdup (cached_locale);
 }
 #endif
 


### PR DESCRIPTION
fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59916

backport of https://github.com/mono/mono/pull/6009