### PR TITLE
[class] Fix resolution of interface implementation for 'special inter…

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1565,17 +1565,35 @@ mono_class_interface_offset_with_variance (MonoClass *klass, MonoClass *itf, gbo
 	*non_exact_match = FALSE;
 	if (i >= 0)
 		return i;
-	
+
 	if (itf->is_array_special_interface && klass->rank < 2) {
 		MonoClass *gtd = mono_class_get_generic_type_definition (itf);
+		int found = -1;
+
+		for (i = 0; i < klass->interface_offsets_count; i++) {
+			if (mono_class_is_variant_compatible (itf, klass->interfaces_packed [i], FALSE)) {
+				found = i;
+				*non_exact_match = TRUE;
+				break;
+			}
+
+		}
+		if (found != -1)
+			return klass->interface_offsets_packed [found];
 
 		for (i = 0; i < klass->interface_offsets_count; i++) {
 			// printf ("\t%s\n", mono_type_get_full_name (klass->interfaces_packed [i]));
 			if (mono_class_get_generic_type_definition (klass->interfaces_packed [i]) == gtd) {
+				found = i;
 				*non_exact_match = TRUE;
-				return klass->interface_offsets_packed [i];
+				break;
 			}
 		}
+
+		if (found == -1)
+			return -1;
+
+		return klass->interface_offsets_packed [found];
 	}
 
 	if (!mono_class_has_variant_generic_params (itf))

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -533,7 +533,8 @@ TESTS_CS_SRC=		\
 	weak-fields.cs \
 	threads-leak.cs	\
 	threads-init.cs \
-	bug-60848.cs
+	bug-60848.cs \
+	bug-59400.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/bug-59400.cs
+++ b/mono/tests/bug-59400.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace MonoBug
+{
+	interface IValue<out TValue>
+	{
+		TValue Value { get; }
+	}
+
+	struct ValueHolder<TValue>
+		: IValue<TValue>
+	{
+		public TValue Value { get; }
+
+		public ValueHolder(TValue value)
+		{
+			Value = value;
+		}
+	}
+
+	interface IPair<TKey, out TValue>
+	{
+		TKey Key { get; }
+		TValue Value { get; }
+	}
+
+	struct Pair<TKey, TValue>
+		: IPair<TKey, TValue>
+		where TValue : class
+	{
+		public TKey Key { get; }
+		public TValue Value { get; }
+
+		public Pair(TKey key, TValue value)
+		{
+			Key = key;
+			Value = value;
+		}
+	}
+
+	struct IncorrectEnumerator1<TValue>
+		: IEnumerator<ValueHolder<TValue>>, IEnumerator<IValue<TValue>>
+		where TValue : class
+	{
+		object IEnumerator.Current => null;
+
+		IValue<TValue> IEnumerator<IValue<TValue>>.Current
+		{
+			get
+			{
+				Console.WriteLine("IEnumerator<IValue<TValue>>.Current is called (correct)");
+				Program.exit_code = 0;
+				return new ValueHolder<TValue>(default(TValue));
+			}
+		}
+
+		ValueHolder<TValue> IEnumerator<ValueHolder<TValue>>.Current
+		{
+			get
+			{
+				Console.WriteLine("IEnumerator<ValueHolder<TValue>>.Current is called (incorrect)");
+				Program.exit_code = 1;
+				return new ValueHolder<TValue>(default(TValue));
+			}
+		}
+
+
+		public bool MoveNext() => true;
+		public void Reset() { }
+		public void Dispose() { }
+	}
+
+
+	class ValueBase
+	{ }
+
+	class Value
+		: ValueBase
+	{ }
+
+	class Program
+	{
+		internal static int exit_code;
+		static int Main(string[] args)
+		{
+			IEnumerator<IValue<ValueBase>> it1 = new IncorrectEnumerator1<Value>();
+
+			var v1 = it1.Current;
+			var v2 = it1.Current;
+
+			return Program.exit_code;
+		}
+	}
+}


### PR DESCRIPTION
Assume a class implementing multiple generic ``I`1`` interfaces. If a virtual call invocation is trying to resolve the correct interface using object `O` implementing ``I`1`` also , the interface is resolved using a set of rules (not fully implemented in Mono), but a requirement is that the chosen interface is "variant-compatible" with object `O`, that is its generic parameters are set to the same types.

This last requirement is relaxed as an implementation-specific detail when ``I`1`` is ``IEnumerator`1``, in which case e.g. a virtual call on a class implementing ``IEnumerator<byte>`` can happen with an object of type ``IEnumerator<sbyte>`` by way of sharing ``IEnumerator`1`` as a generic interface they define. Here, clearly the interfaces are not "variant-compatible", and this is allowed.

Resolution of classes implementing ``IEnumerator`` should still attempt to select a compatible interface using the standard rules before attempting to apply this special rule.