### PR TITLE
[class] relax assumption about origin of a class (can come from an dynamic image)

### DIFF
--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -117,7 +117,7 @@ mono_class_set_generic_container (MonoClass *klass, MonoGenericContainer *contai
 guint32
 mono_class_get_first_method_idx (MonoClass *klass)
 {
-	g_assert (mono_class_has_static_metadata (klass));
+	g_assert (mono_class_has_metadata (klass));
 
 	return ((MonoClassDef*)klass)->first_method_idx;
 }
@@ -125,7 +125,7 @@ mono_class_get_first_method_idx (MonoClass *klass)
 void
 mono_class_set_first_method_idx (MonoClass *klass, guint32 idx)
 {
-	g_assert (mono_class_has_static_metadata (klass));
+	g_assert (mono_class_has_metadata (klass));
 
 	((MonoClassDef*)klass)->first_method_idx = idx;
 }
@@ -136,7 +136,7 @@ mono_class_get_first_field_idx (MonoClass *klass)
 	if (mono_class_is_ginst (klass))
 		return mono_class_get_first_field_idx (mono_class_get_generic_class (klass)->container_class);
 
-	g_assert (mono_class_has_static_metadata (klass));
+	g_assert (mono_class_has_metadata (klass));
 
 	return ((MonoClassDef*)klass)->first_field_idx;
 }
@@ -144,7 +144,7 @@ mono_class_get_first_field_idx (MonoClass *klass)
 void
 mono_class_set_first_field_idx (MonoClass *klass, guint32 idx)
 {
-	g_assert (mono_class_has_static_metadata (klass));
+	g_assert (mono_class_has_metadata (klass));
 
 	((MonoClassDef*)klass)->first_field_idx = idx;
 }

--- a/mono/metadata/class-inlines.h
+++ b/mono/metadata/class-inlines.h
@@ -88,9 +88,9 @@ mono_class_is_public (MonoClass *klass)
 }
 
 static inline gboolean
-mono_class_has_static_metadata (MonoClass *klass)
+mono_class_has_metadata (MonoClass *klass)
 {
-	return klass->type_token && !klass->image->dynamic && !mono_class_is_ginst (klass);
+	return klass->type_token && !mono_class_is_ginst (klass);
 }
 
 #endif

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -17,8 +17,6 @@
 
 #define MONO_CLASS_IS_ARRAY(c) ((c)->rank)
 
-#define MONO_CLASS_HAS_STATIC_METADATA(klass) ((klass)->type_token && !(klass)->image->dynamic && !mono_class_is_ginst (klass))
-
 #define MONO_DEFAULT_SUPERTABLE_SIZE 6
 
 extern gboolean mono_print_vtable;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1453,7 +1453,7 @@ mono_class_setup_basic_field_info (MonoClass *klass)
 	/*
 	 * Fetch all the field information.
 	 */
-	int first_field_idx = mono_class_has_static_metadata (klass) ? mono_class_get_first_field_idx (klass) : 0;
+	int first_field_idx = mono_class_has_metadata (klass) ? mono_class_get_first_field_idx (klass) : 0;
 	for (i = 0; i < top; i++) {
 		field = &fields [i];
 		field->parent = klass;
@@ -1587,7 +1587,7 @@ mono_class_setup_fields (MonoClass *klass)
 	/*
 	 * Fetch all the field information.
 	 */
-	int first_field_idx = mono_class_has_static_metadata (klass) ? mono_class_get_first_field_idx (klass) : 0;
+	int first_field_idx = mono_class_has_metadata (klass) ? mono_class_get_first_field_idx (klass) : 0;
 	for (i = 0; i < top; i++) {
 		int idx = first_field_idx + i;
 		field = &klass->fields [i];
@@ -1907,7 +1907,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	 */
 	field_offsets = g_new0 (int, top);
 	fields_has_references = g_new0 (gboolean, top);
-	int first_field_idx = mono_class_has_static_metadata (klass) ? mono_class_get_first_field_idx (klass) : 0;
+	int first_field_idx = mono_class_has_metadata (klass) ? mono_class_get_first_field_idx (klass) : 0;
 	switch (layout) {
 	case TYPE_ATTRIBUTE_AUTO_LAYOUT:
 	case TYPE_ATTRIBUTE_SEQUENTIAL_LAYOUT:
@@ -2382,7 +2382,7 @@ mono_class_setup_methods (MonoClass *klass)
 		for (i = 0; i < klass->interface_count; i++)
 			setup_generic_array_ifaces (klass, klass->interfaces [i], methods, first_generic + i * count_generic, cache);
 		g_hash_table_destroy (cache);
-	} else if (mono_class_has_static_metadata (klass)) {
+	} else if (mono_class_has_metadata (klass)) {
 		MonoError error;
 		int first_idx = mono_class_get_first_method_idx (klass);
 
@@ -3113,7 +3113,7 @@ count_virtual_methods (MonoClass *klass)
 	guint32 flags;
 	klass = mono_class_get_generic_type_definition (klass); /*We can find this information by looking at the GTD*/
 
-	if (klass->methods || !MONO_CLASS_HAS_STATIC_METADATA (klass)) {
+	if (klass->methods || !mono_class_has_metadata (klass)) {
 		mono_class_setup_methods (klass);
 		if (mono_class_has_failure (klass))
 			return -1;
@@ -9163,7 +9163,7 @@ mono_class_get_virtual_methods (MonoClass* klass, gpointer *iter)
 	if ((gsize)(*iter) & 1)
 		static_iter = TRUE;
 	/* Use the static metadata only if klass->methods is not yet initialized */
-	if (!static_iter && !(klass->methods || !MONO_CLASS_HAS_STATIC_METADATA (klass)))
+	if (!static_iter && !(klass->methods || !mono_class_has_metadata (klass)))
 		static_iter = TRUE;
 
 	if (!static_iter) {
@@ -9835,7 +9835,7 @@ mono_class_get_method_from_name_flags (MonoClass *klass, const char *name, int p
 		return res;
 	}
 
-	if (klass->methods || !MONO_CLASS_HAS_STATIC_METADATA (klass)) {
+	if (klass->methods || !mono_class_has_metadata (klass)) {
 		mono_class_setup_methods (klass);
 		/*
 		We can't fail lookup of methods otherwise the runtime will burst in flames on all sort of places.

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -858,6 +858,7 @@ PROFILE_DISABLED_TESTS += \
 	bug-389886-2.exe	\
 	bug-349190.2.exe	\
 	bug-389886-sre-generic-interface-instances.exe	\
+	bug-41130.exe	\
 	bug-462592.exe	\
 	bug-575941.exe	\
 	bug-389886-3.exe	\

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -297,6 +297,7 @@ TESTS_CS_SRC=		\
 	bug-27420.cs		\
 	bug-46781.cs		\
 	bug-42136.cs		\
+	bug-41130.cs		\
 	bug-59286.cs		\
 	bug-70561.cs		\
 	bug-78311.cs		\

--- a/mono/tests/bug-41130.cs
+++ b/mono/tests/bug-41130.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Reflection;
+using System.Reflection.Emit;
+
+public class Tests
+{
+	public static int Main (String[] args) {
+		AssemblyName an = new AssemblyName ("dynamicAssembly");
+		var ab = AppDomain.CurrentDomain.DefineDynamicAssembly (an, AssemblyBuilderAccess.Run);
+		ModuleBuilder mb = ab.DefineDynamicModule ("mainModule.dll");
+
+		// define a generic class Foo<T> with public field T value
+		TypeBuilder foob = mb.DefineType ("Foo", TypeAttributes.Public);
+		GenericTypeParameterBuilder t = foob.DefineGenericParameters ("T")[0];
+		FieldBuilder fb = foob.DefineField ("value", t, FieldAttributes.Public);
+
+		Type foo = foob.CreateType ();
+		var f = foo.GetField ("value");
+
+		// define a static class Bar with generic method Bar.Get : Foo<'a> -> 'a
+		TypeBuilder barb = mb.DefineType ("Bar", TypeAttributes.Public);
+
+		var getB = barb.DefineMethod ("Get", MethodAttributes.Public | MethodAttributes.Static);
+		GenericTypeParameterBuilder a = getB.DefineGenericParameters ("a")[0];
+		getB.SetReturnType (a);
+		Type fooT = foo.MakeGenericType ((Type) a);
+		getB.SetParameters (fooT);
+
+
+		// emit method body
+		var ilGen = getB.GetILGenerator ();
+
+		ilGen.Emit (OpCodes.Ldarg_0);
+		ilGen.Emit (OpCodes.Ldfld, TypeBuilder.GetField (fooT, f));
+		ilGen.Emit (OpCodes.Ret);
+
+		var bar = barb.CreateType ();
+
+		// emission complete
+		var ga = bar.GetMethod ("Get").GetGenericArguments ()[0];
+		var field = foo.MakeGenericType (ga).GetField ("value");
+
+		Console.WriteLine ("Name: {0}", field.Name);
+		Console.WriteLine ("Token: {0}", field.MetadataToken);
+
+		return 0;
+	}
+}
+


### PR DESCRIPTION
check got introduced with ffc3aaa95c45fe6888f64572df35e3fe7ba4f8ac (in most places).

fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41130