### PR TITLE
[runtime] Avoid an assert in mono_thread_detach_internal () when thre…

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -885,7 +885,8 @@ done:
 	SET_CURRENT_OBJECT (NULL);
 	mono_domain_unset ();
 
-	mono_thread_info_unset_internal_thread_gchandle ((MonoThreadInfo*) thread->thread_info);
+	if ((MonoThreadInfo*) thread->thread_info)
+		mono_thread_info_unset_internal_thread_gchandle ((MonoThreadInfo*) thread->thread_info);
 
 	/* Don't need to close the handle to this thread, even though we took a
 	 * reference in mono_thread_attach (), because the GC will do it


### PR DESCRIPTION
…ad->thread_info is NULL.