### PR TITLE
[loader] Rework get_method_constrained (Fixes #60545)

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1816,63 +1816,71 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 	return result;
 }
 
-static MonoMethod *
+static MonoMethod*
 get_method_constrained (MonoImage *image, MonoMethod *method, MonoClass *constrained_class, MonoGenericContext *context, MonoError *error)
 {
-	MonoMethod *result;
-	MonoClass *ic = NULL;
-	MonoGenericContext *method_context = NULL;
-	MonoMethodSignature *sig, *original_sig;
+	MonoClass *base_class = method->klass;
 
 	error_init (error);
 
-	mono_class_init (constrained_class);
-	original_sig = sig = mono_method_signature_checked (method, error);
-	if (sig == NULL) {
+	if (!mono_class_is_assignable_from (base_class, constrained_class)) {
+		char *base_class_name = mono_type_get_full_name (base_class);
+		char *constrained_class_name = mono_type_get_full_name (constrained_class);
+		mono_error_set_invalid_operation (error, "constrained call: %s is not assignable from %s", base_class_name, constrained_class_name);
+		g_free (base_class_name);
+		g_free (constrained_class_name);
 		return NULL;
 	}
 
-	if (method->is_inflated && sig->generic_param_count) {
-		MonoMethodInflated *imethod = (MonoMethodInflated *) method;
-		sig = mono_method_signature_checked (imethod->declaring, error); /*We assume that if the inflated method signature is valid, the declaring method is too*/
-		if (!sig)
-			return NULL;
-		method_context = mono_method_get_context (method);
+	/* If the constraining class is actually an interface, we don't learn
+	 * anything new by constraining.
+	 */
+	if (MONO_CLASS_IS_INTERFACE (constrained_class))
+		return method;
 
-		original_sig = sig;
-		/*
-		 * We must inflate the signature with the class instantiation to work on
-		 * cases where a class inherit from a generic type and the override replaces
-		 * any type argument which a concrete type. See #325283.
-		 */
-		if (method_context->class_inst) {
-			MonoGenericContext ctx;
-			ctx.method_inst = NULL;
-			ctx.class_inst = method_context->class_inst;
-			/*Fixme, property propagate this error*/
-			sig = inflate_generic_signature_checked (method->klass->image, sig, &ctx, error);
-			if (!sig)
-				return NULL;
+	mono_class_setup_vtable (base_class);
+	if (mono_class_has_failure (base_class)) {
+		mono_error_set_for_class_failure (error, base_class);
+		return NULL;
+	}
+
+	int vtable_slot = 0;
+	if (!MONO_CLASS_IS_INTERFACE (base_class)) {
+		/*if the base class isn't an interface and the method isn't
+		 * virtual, there's nothing to do, we're already on the method
+		 * we want to call. */
+		if ((method->flags & METHOD_ATTRIBUTE_VIRTUAL) == 0)
+			return method;
+		/* if this isn't an interface method, get the vtable slot and
+		 * find the corresponding method in the constrained class,
+		 * which is a subclass of the base class. */
+		vtable_slot = mono_method_get_vtable_index (method);
+
+		mono_class_setup_vtable (constrained_class);
+		if (mono_class_has_failure (constrained_class)) {
+			mono_error_set_for_class_failure (error, constrained_class);
+			return NULL;
 		}
-	}
-
-	if ((constrained_class != method->klass) && (MONO_CLASS_IS_INTERFACE (method->klass)))
-		ic = method->klass;
-
-	result = find_method (constrained_class, ic, method->name, sig, constrained_class, error);
-	if (sig != original_sig)
-		mono_metadata_free_inflated_signature (sig);
-
-	if (!result)
-		return NULL;
-
-	if (method_context) {
-		result = mono_class_inflate_generic_method_checked (result, method_context, error);
-		if (!result)
+	} else {
+		mono_class_setup_vtable (constrained_class);
+		if (mono_class_has_failure (constrained_class)) {
+			mono_error_set_for_class_failure (error, constrained_class);
 			return NULL;
+		}
+			
+		/* Get the slot of the method in the interface.  Then get the
+		 * interface base in constrained_class */
+		int itf_slot = mono_method_get_vtable_index (method);
+		g_assert (itf_slot >= 0);
+		gboolean variant = FALSE;
+		int itf_base = mono_class_interface_offset_with_variance (constrained_class, base_class, &variant);
+		vtable_slot = itf_slot + itf_base;
 	}
+	g_assert (vtable_slot >= 0);
 
-	return result;
+	MonoMethod *res = mono_class_get_vtable_entry (constrained_class, vtable_slot);
+	g_assert (res != NULL);
+	return res;
 }
 
 MonoMethod *

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -222,6 +222,7 @@ TESTS_CS_SRC=		\
 	iface3.cs		\
 	iface4.cs		\
 	iface-large.cs		\
+	iface-contravariant1.cs \
 	virtual-method.cs	\
 	intptrcast.cs		\
 	indexer.cs		\

--- a/mono/tests/iface-contravariant1.cs
+++ b/mono/tests/iface-contravariant1.cs
@@ -1,0 +1,60 @@
+using System;
+
+/* Test of constrained.callvirt resolution for contravariant interfaces */
+
+
+public interface I<in T>
+{
+		string F (T t);
+}
+
+public class C : I<object>
+{
+	public string F (object t)
+	{
+		return t.GetType().Name;
+	}
+}
+
+/* U should be instantiated by a valuetype because we don't want the generic
+ * sharing codepath */
+public class G<T, TI, U>
+	where TI : I<T>
+{
+	public G(TI i)
+	{
+		_i = i;
+	}
+
+	public string Do (T t)
+	{
+		// we want to get this in IL:
+		//
+		// constrained. !1
+		// callvirt I`1<!T>::F(!0)
+		//
+		return _i.F (t);
+	}
+	
+	private readonly TI _i;
+}
+
+public class Driver
+{
+	public static int Main ()
+	{
+		var c = new C();
+		// instantiate with: T=string because we want to be
+		// contravariant with object; U=int because we need a valuetype
+		// to not end up in the generic sharing codepath.
+		var h = new G<string, C, int>(c);
+		var s = h.Do ("abc");
+		var expected = typeof(string).Name;
+		if (s == expected)
+			return 0;
+		else {
+			Console.Error.WriteLine ("Got '{0}', expected '{1}'", s, expected);
+			return 1;
+		}
+	}
+}


### PR DESCRIPTION
Instead of using `find_method` which relies on method name and exact signature
matching (and thus can't work for variant interfaces), use the vtable and the
interface offset to find the constrained method.

Terminology:
 -  base method - a method of the base class to be called
 -  base class - some general class or interface that declares a method
 -  constraint class - a more specific class that also implements the method.
 -  constrained method - the version of the base method in the constraint class.

To find the constrained method given the base method:

- if the base class is a class:
  the constraint class can't be an interface. it's either the base class or
  some subclass of it.  If the base method isn't virtual there's nothing to do
  the constrained method is the same one.
  If the base method is virtual, get its vtable slot and find the corresponding
  method in the constraint class's vtable.
- if the base class is an interface:
  in this case the constraint class is either another interface or a class.
  if the constraint class is an interface, since interfaces can't have
  implementations, there's nothing to do.
  if the constraint class is a class, then to find the constrained method
  get the interface slot offset of the base method and find the base interface offset
  of the base interface and look in the constrained class vtable.
  (the base interface offset gives the starting vtable slot for the base
  interface in the constraint class vtable; the slot offsets go consecutively
  for each of the methods of the interface).

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60545