### PR TITLE
[loader] Rework get_method_constrained (Fixes #60545)

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -219,6 +219,7 @@ TESTS_CS_SRC=		\
 	iface3.cs		\
 	iface4.cs		\
 	iface-large.cs		\
+	iface-contravariant1.cs \
 	virtual-method.cs	\
 	intptrcast.cs		\
 	indexer.cs		\

--- a/mono/tests/iface-contravariant1.cs
+++ b/mono/tests/iface-contravariant1.cs
@@ -1,0 +1,60 @@
+using System;
+
+/* Test of constrained.callvirt resolution for contravariant interfaces */
+
+
+public interface I<in T>
+{
+		string F (T t);
+}
+
+public class C : I<object>
+{
+	public string F (object t)
+	{
+		return t.GetType().Name;
+	}
+}
+
+/* U should be instantiated by a valuetype because we don't want the generic
+ * sharing codepath */
+public class G<T, TI, U>
+	where TI : I<T>
+{
+	public G(TI i)
+	{
+		_i = i;
+	}
+
+	public string Do (T t)
+	{
+		// we want to get this in IL:
+		//
+		// constrained. !1
+		// callvirt I`1<!T>::F(!0)
+		//
+		return _i.F (t);
+	}
+	
+	private readonly TI _i;
+}
+
+public class Driver
+{
+	public static int Main ()
+	{
+		var c = new C();
+		// instantiate with: T=string because we want to be
+		// contravariant with object; U=int because we need a valuetype
+		// to not end up in the generic sharing codepath.
+		var h = new G<string, C, int>(c);
+		var s = h.Do ("abc");
+		var expected = typeof(string).Name;
+		if (s == expected)
+			return 0;
+		else {
+			Console.Error.WriteLine ("Got '{0}', expected '{1}'", s, expected);
+			return 1;
+		}
+	}
+}


### PR DESCRIPTION
This is #6037 cherrypicked to `2017-10`

----

Instead of using `find_method` which relies on method name and exact signature
matching (and thus can't work for variant interfaces), use the vtable and the
interface offset to find the constrained method.

Terminology:
 -  base method - a method of the base class to be called
 -  base class - some general class or interface that declares a method
 -  constraint class - a more specific class that also implements the method.
 -  constrained method - the version of the base method in the constraint class.

To find the constrained method given the base method:

- if the base class is a class:
  the constraint class can't be an interface. it's either the base class or
  some subclass of it.  If the base method isn't virtual there's nothing to do
  the constrained method is the same one.
  If the base method is virtual, get its vtable slot and find the corresponding
  method in the constraint class's vtable.
- if the base class is an interface:
  in this case the constraint class is either another interface or a class.
  if the constraint class is an interface, since interfaces can't have
  implementations, there's nothing to do.
  if the constraint class is a class, then to find the constrained method
  get the interface slot offset of the base method and find the base interface offset
  of the base interface and look in the constrained class vtable.
  (the base interface offset gives the starting vtable slot for the base
  interface in the constraint class vtable; the slot offsets go consecutively
  for each of the methods of the interface).

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60545