### PR TITLE
[System.IO] Directory.Exists() now resolves the full path first. Fixe…

### DIFF
--- a/mcs/class/corlib/System.IO/Directory.cs
+++ b/mcs/class/corlib/System.IO/Directory.cs
@@ -195,11 +195,18 @@ namespace System.IO
 			// on Moonlight this does not throw but returns false
 			if (!SecurityManager.CheckElevatedPermissions ())
 				return false;
-				
+
+			string full_path;
+			try {
+				full_path = Path.GetFullPath (path);
+			} catch {
+				return false;
+			}
+
 			MonoIOError error;
 			bool exists;
-			
-			exists = MonoIO.ExistsDirectory (path, out error);
+
+			exists = MonoIO.ExistsDirectory (full_path, out error);
 			/* This should not throw exceptions */
 			return exists;
 		}

--- a/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DirectoryTest.cs
@@ -1748,6 +1748,45 @@ public class DirectoryTest
 		}
 	}
 
+	[Test]
+	public void ResolvePathBeforeDirectoryExists ()
+	{
+		if (!RunningOnUnix)
+			Assert.Ignore ("Not running on Unix.");
+
+		string cwd = Directory.GetCurrentDirectory ();
+
+		string root = Path.Combine (TempFolder, "test_ResolvePathBeforeExists");
+		string testPath = Path.Combine (root, "test");
+		string test2Path = Path.Combine (testPath, "test2");
+		string testFile = Path.Combine (test2Path, "test_file");
+		string symlinkPath = Path.Combine (root, "test3");
+		try 
+		{	
+			Directory.CreateDirectory (root);
+			Directory.SetCurrentDirectory (root);
+			Directory.CreateDirectory (testPath);
+			Directory.CreateDirectory (test2Path);
+			File.WriteAllText (testFile, "hello");
+
+			var info = new UnixFileInfo (test2Path);
+			info.CreateSymbolicLink (symlinkPath);
+
+			var partial_path_with_symlink = "test3/../test3"; // test3 is a symlink to test/test2
+
+			Assert.AreEqual (Directory.Exists (partial_path_with_symlink), true);
+		}
+		finally 
+		{
+			DeleteFile (symlinkPath);
+			DeleteFile (testFile);
+			DeleteDirectory (test2Path);
+			DeleteDirectory (testPath);
+			Directory.SetCurrentDirectory (cwd);
+			DeleteDirectory (root);
+		}
+	}
+
 	private void DeleteDirectory (string path)
 	{
 		if (Directory.Exists (path))


### PR DESCRIPTION
…s #60267

In Unix, assume our current directory contains:
`test`, a directory
`test/test2`, another directory
`test/test2/test_file`, a file
`test3`, a symbolic link pointing to `test/test2`

Then the path "test3/../test3" has two interpretations depending on the processor:

* The OS (the `lstat` syscall, `ls`, etc.) will find it invalid (as it evaluates to: enter `test/test2`, go up one level, try to enter `test3` which is another level down
* We (.NET, at least CoreCLR) should find it valid (enter `test3`, go up one level, enter `test3`).

This ensures that for Directory.Exists, we process the path `..`'s on the .NET level before passing it for native processing.