### PR TITLE
[System.IO] In some cases '/' is not a valid root directory - fixes 60138

### DIFF
--- a/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/AssignTargetPathTest.cs
+++ b/mcs/class/Microsoft.Build.Tasks/Test/Microsoft.Build.Tasks/AssignTargetPathTest.cs
@@ -85,7 +85,7 @@ namespace MonoTests.Microsoft.Build.Tasks
 				CheckTargetPath(
 					new string[] { "//a/b/abc.cs", "k/../k/def.cs", "/xyz.cs", "/different/xyz/foo.cs"},
 					new string[] { "a/b/abc.cs", Path.Combine (cur_dir_minus_root, "k/def.cs"), "xyz.cs", "different/xyz/foo.cs"},
-					"/", "A");
+					root, "A");
 			} else if (OS == OsType.Windows) {
 				CheckTargetPath(
 					new string[] { root + @"a\b\abc.cs", @"k\..\k\def.cs", root + @"xyz.cs", root + @"different\xyz\foo.cs"},
@@ -105,7 +105,7 @@ namespace MonoTests.Microsoft.Build.Tasks
 					new string[] { "xyz.cs", "rel/bar.resx" },
 					new string[] { Path.Combine (cur_dir_minus_root, "xyz.cs"),
 						Path.Combine (cur_dir_minus_root, "rel/bar.resx") },
-					"/", "A");
+					root, "A");
 			} else if (OS == OsType.Windows) {
 				CheckTargetPath(
 					new string[] { "xyz.cs", "rel\\bar.resx" },

--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -444,17 +444,20 @@ namespace System.IO {
 				return String.Empty;
 			
 			if (DirectorySeparatorChar == '/') { // UNIX
-				string rootDrive = string.Empty;
 				// Most likely the root path will be '/' but there are cases (see https://bugzilla.xamarin.com/show_bug.cgi?id=60138)
 				// when there is no such drive in Environment.GetLogicalDrives () 
-				// return the longest logical drive in this case
 				foreach (var drive in Environment.GetLogicalDrives ()) {
 					if (drive == DirectorySeparatorCharAsString) {
 						return DirectorySeparatorCharAsString;
 					}
+				}
 
-					if (AppendDirectorySeparator (path).Contains (AppendDirectorySeparator (drive)) && 
-						rootDrive.Length < drive.Length) {
+				// another foreach (to make the first one faster) -
+				// return the longest logical drive the path contains
+				string rootDrive = string.Empty;
+				foreach (var drive in Environment.GetLogicalDrives()) {
+					if (AppendDirectorySeparator(path).Contains(AppendDirectorySeparator(drive)) &&
+					    rootDrive.Length < drive.Length) {
 						rootDrive = drive;
 					}
 				}

--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -455,7 +455,7 @@ namespace System.IO {
 
 				// another foreach (to make the first one faster) -
 				// return the longest logical drive the path contains
-				string rootDrive = string.Empty;
+				string rootDrive = DirectorySeparatorCharAsString;
 				foreach (var drive in logicalDrives) {
 					if (AppendDirectorySeparator (path).Contains (AppendDirectorySeparator (drive)) &&
 						rootDrive.Length < drive.Length) {

--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -430,7 +430,7 @@ namespace System.IO {
 		}
 		
 		private static string AppendDirectorySeparator (string path) =>
-			path.EndsWith (DirectorySeparatorCharAsString) ? path : path + DirectorySeparatorCharAsString;
+			path.Length > 0 && path[path.Length - 1] == AltDirectorySeparatorChar ? path : path + DirectorySeparatorCharAsString;
 
 		public static string GetPathRoot (string path)
 		{
@@ -446,7 +446,8 @@ namespace System.IO {
 			if (DirectorySeparatorChar == '/') { // UNIX
 				// Most likely the root path will be '/' but there are cases (see https://bugzilla.xamarin.com/show_bug.cgi?id=60138)
 				// when there is no such drive in Environment.GetLogicalDrives () 
-				foreach (var drive in Environment.GetLogicalDrives ()) {
+				var logicalDrives = Environment.GetLogicalDrives ();
+				foreach (var drive in logicalDrives) {
 					if (drive == DirectorySeparatorCharAsString) {
 						return DirectorySeparatorCharAsString;
 					}
@@ -455,7 +456,7 @@ namespace System.IO {
 				// another foreach (to make the first one faster) -
 				// return the longest logical drive the path contains
 				string rootDrive = string.Empty;
-				foreach (var drive in Environment.GetLogicalDrives ()) {
+				foreach (var drive in logicalDrives) {
 					if (AppendDirectorySeparator (path).Contains (AppendDirectorySeparator (drive)) &&
 						rootDrive.Length < drive.Length) {
 						rootDrive = drive;

--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -455,9 +455,9 @@ namespace System.IO {
 				// another foreach (to make the first one faster) -
 				// return the longest logical drive the path contains
 				string rootDrive = string.Empty;
-				foreach (var drive in Environment.GetLogicalDrives()) {
-					if (AppendDirectorySeparator(path).Contains(AppendDirectorySeparator(drive)) &&
-					    rootDrive.Length < drive.Length) {
+				foreach (var drive in Environment.GetLogicalDrives ()) {
+					if (AppendDirectorySeparator (path).Contains (AppendDirectorySeparator (drive)) &&
+						rootDrive.Length < drive.Length) {
 						rootDrive = drive;
 					}
 				}

--- a/mcs/class/corlib/Test/System.IO/PathTest.cs
+++ b/mcs/class/corlib/Test/System.IO/PathTest.cs
@@ -801,7 +801,8 @@ namespace MonoTests.System.IO
 		{
 			string current;
 			string expected;
-			if (!Windows){
+			if (!Windows) {
+				Console.WriteLine ("Available drives:\n " + string.Join("\n ", Environment.GetLogicalDrives()));
 				current = Directory.GetCurrentDirectory ();
 				expected = current [0].ToString ();
 			} else {

--- a/mcs/class/corlib/Test/System.IO/PathTest.cs
+++ b/mcs/class/corlib/Test/System.IO/PathTest.cs
@@ -19,6 +19,7 @@
 using NUnit.Framework;
 using System.IO;
 using System;
+using System.Linq;
 using System.Text;
 
 namespace MonoTests.System.IO
@@ -802,9 +803,12 @@ namespace MonoTests.System.IO
 			string current;
 			string expected;
 			if (!Windows) {
-				Console.WriteLine ("Available drives:\n " + string.Join("\n ", Environment.GetLogicalDrives()));
 				current = Directory.GetCurrentDirectory ();
-				expected = current [0].ToString ();
+				var availableDrives = Environment.GetLogicalDrives ();
+				if (!availableDrives.Contains ("/")) {
+					return;
+				}
+				expected = "/";
 			} else {
 				current = @"J:\Some\Strange Directory\Name";
 				expected = "J:\\";


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=60138
if `Environment.GetLogicalDrives` doesn't contain '/' item - `Path.GetPathRoot` should return the longest suitable drive `Environment.GetLogicalDrives` contains (currently it always returns '/').

for example `Environment.GetLogicalDrives`:

- "/foo"
- "/foo/boo"
- "/tmp"

then

- `GetPathRoot("/foo/some/dir")` => "/foo"
- `GetPathRoot("/foo/boo")` => "/foo/boo"
- `GetPathRoot("/foo/booo")` => "/foo"

not sure how to test such fixes - I need to mock `Environment.GetLogicalDrives`.