### PR TITLE
Fix TimeZoneInfo rule population for WinRT

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.WinRT.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.WinRT.cs
@@ -242,7 +242,7 @@ namespace System
 			//
 
 			try {
-				if (GetDynamicTimeZoneInformationEffectiveYears (ref timeZoneInformation, out firstYear, out lastYear) == 0) {
+				if (GetDynamicTimeZoneInformationEffectiveYears (ref timeZoneInformation, out firstYear, out lastYear) != 0) {
 					firstYear = lastYear = 0;
 				}
 			} catch {


### PR DESCRIPTION
The return value of GetDynamicTimeZoneInformationEffectiveYears in the successful case is ERROR_SUCCESS (0). Adjust failure case to be for return values non 0.