### PR TITLE
[runtime] Fix test makefrag to accomodate moved tests

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -240,7 +240,7 @@ $(test_response): $(test_response_preprocessed)
 
 $(test_makefrag): $(test_response)
 #	@echo Creating $@ ...
-	@sed 's,^,$(test_lib): ,' $< >$@
+	@sed 's,^,$(test_lib_output): ,' $< >$@
 
 -include $(test_makefrag)
 


### PR DESCRIPTION
After moving the tests, the makefile system no longer updates them when the source files are fixed. This is due to the makefrags baking in a non-absolute path to the test assembly (trying to resolve it in the bcl dir). I've fixed that here.