### PR TITLE
Fix bug 60568: SynchronizationContext.Wait not implemented or invoked by runtime

### DIFF
--- a/mcs/class/System/System_test.dll.sources
+++ b/mcs/class/System/System_test.dll.sources
@@ -501,6 +501,7 @@ System.Threading/SemaphoreFullExceptionCas.cs
 System.Threading/SemaphoreTest.cs
 System.Threading/BarrierTest.cs
 System.Threading/ThreadExceptionEventArgsCas.cs
+System.Threading/WaitHandleTests.cs
 System.Timers/TimersDescriptionAttributeCas.cs
 System.Timers/ElapsedEventArgsCas.cs
 System.Timers/TimerCas.cs

--- a/mcs/class/System/Test/System.Threading/WaitHandleTests.cs
+++ b/mcs/class/System/Test/System.Threading/WaitHandleTests.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+
+using System;
+using System.Security.AccessControl;
+using System.Threading;
+
+namespace MonoTests.System.Threading {
+    [TestFixture]
+    public class WaitHandleTests {
+        SynchronizationContext OriginalContext;
+        TestSynchronizationContext TestContext;
+
+        [SetUp]
+        public void SetUp ()
+        {
+            OriginalContext = SynchronizationContext.Current;
+            TestContext = new TestSynchronizationContext();
+            TestContext.SetWaitNotificationRequired();
+            SynchronizationContext.SetSynchronizationContext(TestContext);
+        }
+
+        [TearDown]
+        public void TearDown ()
+        {
+            SynchronizationContext.SetSynchronizationContext(OriginalContext);
+        }
+
+        [Test]
+        public void WaitHandle_WaitOne_SynchronizationContext ()
+        {
+            var e = new ManualResetEvent(false);
+            TestContext.WaitAction = () => e.Set();
+            Assert.IsTrue(e.WaitOne(0));
+        }
+
+        [Test]
+        public void WaitHandle_WaitAll_SynchronizationContext ()
+        {
+            var e1 = new ManualResetEvent(false);
+            var e2 = new ManualResetEvent(false);
+            TestContext.WaitAction = () => {
+                e1.Set();
+                e2.Set();
+            };
+            Assert.IsTrue(WaitHandle.WaitAll(new[] { e1, e2 }, 0));
+        }
+    }
+
+    class TestSynchronizationContext : SynchronizationContext
+    {
+        public Action WaitAction { get; set; }
+
+        public new void SetWaitNotificationRequired ()
+        {
+            base.SetWaitNotificationRequired();
+        }
+
+        public override int Wait (IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
+        {
+            WaitAction?.Invoke();
+            return base.Wait(waitHandles, waitAll, millisecondsTimeout);
+        }
+    }
+}
+

--- a/mcs/class/corlib/System.Threading/WaitHandle.cs
+++ b/mcs/class/corlib/System.Threading/WaitHandle.cs
@@ -65,9 +65,12 @@ namespace System.Threading
 			//  wait method.
 			// Another option would be to check whether this context uses the default Wait implementation,
 			//  but I don't know of a cheap way to do this that handles derived types correctly.
-			if (context.IsWaitNotificationRequired()) {
+			// If the thread does not have a synchronization context set at all, we can safely just
+			//  jump directly to invoking WaitSingle.
+			if ((context != null) && context.IsWaitNotificationRequired ()) {
 				bool release = false;
 				waitableSafeHandle.DangerousAddRef(ref release);
+
 				try {
 #if !DISABLE_REMOTING
 					if (exitContext)
@@ -92,6 +95,7 @@ namespace System.Threading
 					if (exitContext)
 						SynchronizationAttribute.EnterContext ();
 #endif
+
 				}
 			} else {
 				return WaitSingle (waitableSafeHandle, millisecondsTimeout, hasThreadAffinity, exitContext);

--- a/mcs/class/referencesource/mscorlib/system/threading/synchronizationcontext.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/synchronizationcontext.cs
@@ -173,7 +173,11 @@ namespace System.Threading
 #if MONO
         protected static int WaitHelper(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
         {
-            throw new NotImplementedException ();
+            unsafe {
+                fixed (IntPtr * pWaitHandles = waitHandles) {
+                    return System.Threading.WaitHandle.Wait_internal (pWaitHandles, waitHandles.Length, waitAll, millisecondsTimeout);
+                }
+            }
         }
 #else
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
This PR fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60568.

Presently SynchronizationContext.Wait is not implemented, and user-implemented overrides of it are never invoked by the mono. This PR modifies our implementation of WaitOneNative so that it will go through SynchronizationContext.Wait if a synchronization context is set for the current thread and it provides a custom implementation of Wait.

There are some remaining TODO items on this.
I think maybe it needs some additional test coverage, but I'm not sure what tests would be best for this.
I think we probably also need to modify some parts of corlib to ensure that waits on multiple handles also go through the synchronization context, but it is super unclear to me what to change - the documentation is extremely imprecise about how synchronization contexts are involved in WaitHandle operations, when it mentions them at all. I was genuinely surprised to find out that WaitHandle.WaitOne would delegate to the current synchronization context (but it makes sense that it does.)
I'm also a little concerned that there is a potential for previously-working code to become infinitely recursive here if a SynchronizationContext.Wait implementation invokes WaitOne. I'm not sure what should happen in that case.