### PR TITLE
[ci] Add Jenkins pipeline script for building OSX and Windows packages

### DIFF
--- a/packaging/MacSDKRelease/profile.py
+++ b/packaging/MacSDKRelease/profile.py
@@ -14,31 +14,11 @@ from bockbuild.util.util import *
 
 
 class MonoXamarinPackageProfile(MonoReleaseProfile):
-    description = 'The Mono Framework for MacOS (official release)'
+    description = 'The Mono Framework for macOS (official release)'
 
     def setup (self):
         MonoReleaseProfile.setup (self)
         bockbuild.packages_to_build.extend(['mono-extensions'])
-        if bockbuild.cmd_options.release_build:
-            self.setup_codesign()
-        else:
-            info("'--release' option not set, will not attempt to sign package!")
-
-        self.cache_host = 'http://xamarin-storage/bockbuild_cache/'
-
-    def setup_codesign(self):
-        self.identity = "Developer ID Installer: Xamarin Inc"
-
-        output = backtick("security -v find-identity")
-        if self.identity not in " ".join(output):
-            error("Identity '%s' was not found. You can create an unsigned package by removing '--release' to your command line." % self.identity)
-
-        password = os.getenv("CODESIGN_KEYCHAIN_PASSWORD")
-        if password:
-            print "Unlocking the keychain"
-            run_shell("security unlock-keychain -p %s" % password)
-        else:
-            error("CODESIGN_KEYCHAIN_PASSWORD needs to be defined.")
 
     def setup_release(self):
         MonoReleaseProfile.setup_release(self)
@@ -49,41 +29,5 @@ class MonoXamarinPackageProfile(MonoReleaseProfile):
     def run_pkgbuild(self, working_dir, package_type):
         output = MonoReleaseProfile.run_pkgbuild(
             self, working_dir, package_type)
-
-        output_unsigned = os.path.join(os.path.dirname(
-            output), os.path.basename(output).replace('.pkg', '.UNSIGNED.pkg'))
-        shutil.move(output, output_unsigned)
-
-        if not bockbuild.cmd_options.release_build:
-            return output_unsigned
-
-        productsign = "/usr/bin/productsign"
-        productsign_cmd = ' '.join([productsign,
-                                    "-s '%s'" % self.identity,
-                                    "'%s'" % output_unsigned,
-                                    "'%s'" % output])
-        run_shell(productsign_cmd)
-        os.remove(output_unsigned)
-        self.verify_codesign(output)
-
-        return output
-
-    def verify_codesign(self, pkg):
-        oldcwd = os.getcwd()
-        try:
-            name = os.path.basename(pkg)
-            pkgdir = os.path.dirname(pkg)
-            os.chdir(pkgdir)
-            spctl = "/usr/sbin/spctl"
-            spctl_cmd = ' '.join(
-                [spctl, "-vvv", "--assess", "--type install", name, "2>&1"])
-            output = backtick(spctl_cmd)
-
-            if "accepted" in " ".join(output):
-                warn("%s IS SIGNED" % pkg)
-            else:
-                error("%s IS NOT SIGNED:" % pkg)
-        finally:
-            os.chdir(oldcwd)
 
 MonoXamarinPackageProfile()

--- a/packaging/Windows/defs/gtksharp
+++ b/packaging/Windows/defs/gtksharp
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-REPO="https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.44.msi"
+REPO="https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.45.msi"
 REPODIR=$(dirname $(realpath $0))/../repos/gtksharp
 
 error()

--- a/scripts/ci/pipeline/osx-package.groovy
+++ b/scripts/ci/pipeline/osx-package.groovy
@@ -1,0 +1,89 @@
+def jobName = "build-package-osx-mono"
+def windowsJobName = "build-package-win-mono"
+def isReleaseJob = (BRANCH_NAME ==~ /201\d-\d\d/) // check if we're on a 2017-xx branch, i.e. release
+def packageFileName = null
+def commitHash = null
+
+node ("osx-amd64") {
+    ws ("workspace/${jobName}/${BRANCH_NAME}") {
+        timestamps {
+            stage('Checkout') {
+                // clone and checkout repo
+                checkout scm
+
+                // remove old stuff
+                sh 'git clean -xdff'
+
+                // get current commit sha
+                commitHash = sh (script: 'git rev-parse HEAD', returnStdout: true).trim()
+                currentBuild.displayName = "${commitHash.substring(0,7)}"
+            }
+            stage('Build') {
+                // show which xcode will be used to build
+                sh 'xcodebuild -version'
+
+                // install openssl for .net core (remove once msbuild uses a 2.x version which doesn't rely on openssl)
+                sh 'brew update && brew install openssl'
+                sh 'mkdir -p /usr/local/lib'
+                sh 'rm /usr/local/lib/libcrypto.1.0.0.dylib || true'
+                sh 'rm /usr/local/lib/libssl.1.0.0.dylib || true'
+                sh 'ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/'
+                sh 'ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/'
+
+
+                // workaround for libtiff issue
+                sh 'make -C external/bockbuild/builds/tiff-4.0.8-x86 clean || true'
+                sh 'make -C external/bockbuild/builds/tiff-4.0.8-x64 clean || true'
+
+                // build the .pkg
+                timeout (time: 420, unit: 'MINUTES') {
+                    withEnv (["MONO_BRANCH=${BRANCH_NAME}"]) {
+                        sshagent (credentials: ['mono-extensions-ssh']) {
+                            sh "external/bockbuild/bb MacSDKRelease --arch darwin-universal --verbose --package ${isReleaseJob ? '--release' : ''}"
+                        }
+                    }
+                }
+
+                // move .pkg to the workspace root
+                sh 'mv packaging/MacSDKRelease/MonoFramework-MDK-*.pkg .'
+                packageFileName = findFiles (glob: "MonoFramework-MDK-*.pkg")[0]
+            }
+            stage('Upload .pkg to Azure') {
+                step([
+                    $class: 'WAStoragePublisher',
+                    allowAnonymousAccess: true,
+                    cleanUpContainer: false,
+                    cntPubAccess: true,
+                    containerName: "${jobName}",
+                    doNotFailIfArchivingReturnsNothing: false,
+                    doNotUploadIndividualFiles: false,
+                    doNotWaitForPreviousBuild: true,
+                    excludeFilesPath: '',
+                    filesPath: "${packageFileName}",
+                    storageAccName: 'credential for xamjenkinsartifact',
+                    storageCredentialId: 'fbd29020e8166fbede5518e038544343',
+                    uploadArtifactsOnlyIfSuccessful: true,
+                    uploadZips: false,
+                    virtualPath: "${BRANCH_NAME}/${BUILD_NUMBER}/"
+                ])
+                currentBuild.description = "<hr/><h2>DOWNLOAD: <a href=\"https://xamjenkinsartifact.azureedge.net/${jobName}/${BRANCH_NAME}/${BUILD_NUMBER}/${packageFileName}\">${packageFileName}</a></h2><hr/>"
+            }
+        }
+    }
+}
+
+if (isReleaseJob) {
+    stage("Signing") {
+        timeout(time: 30, unit: 'MINUTES') {
+            // waits until the signing job posts completion signal to this pipeline input
+            input id: 'FinishedSigning', message: 'Waiting for signing to finish...', submitter: 'monojenkins'
+            echo "Signing done."
+        }
+    }
+}
+else {
+    echo "Not a release job, skipping signing."
+}
+
+// trigger the Windows build
+build(job: "${windowsJobName}/${BRANCH_NAME}", wait: false)

--- a/scripts/ci/pipeline/win-package.groovy
+++ b/scripts/ci/pipeline/win-package.groovy
@@ -1,0 +1,80 @@
+def jobName = "build-package-win-mono"
+def macJobName = "build-package-osx-mono"
+def isReleaseJob = (BRANCH_NAME ==~ /201\d-\d\d/) // check if we're on a 2017-xx branch, i.e. release
+def commitHash = null
+
+node ("w64") {
+    ws ("workspace/${jobName}/${BRANCH_NAME}") {
+        timestamps {
+            stage('Checkout') {
+                // clone and checkout repo
+                checkout scm
+
+                // get current commit sha
+                commitHash = sh (script: 'git rev-parse HEAD', returnStdout: true).trim()
+                currentBuild.displayName = "${commitHash.substring(0,7)}"
+            }
+            stage('Download Mac .pkg from Azure') {
+                step([
+                    $class: 'AzureStorageBuilder',
+                    downloadType: [value: 'project', containerName: '', projectName: "${macJobName}/${BRANCH_NAME}",
+                                buildSelector: [$class: 'TriggeredBuildSelector', upstreamFilterStrategy: 'UseGlobalSetting', allowUpstreamDependencies: false, fallbackToLastSuccessful: false]],
+                    includeFilesPattern: '**/*.pkg',
+                    excludeFilesPattern: '',
+                    downloadDirLoc: '',
+                    flattenDirectories: true,
+                    includeArchiveZips: false,
+                    strAccName: 'credential for xamjenkinsartifact',
+                    storageCredentialId: 'fbd29020e8166fbede5518e038544343'
+                ])
+            }
+            stage('Build') {
+                // build the .msi
+                timeout (time: 420, unit: 'MINUTES') {
+                    def macPackageName = sh (script: "ls MonoFramework-MDK-*.pkg", returnStdout: true).trim()
+                    def macPackageNameAbs = sh (script: "realpath ${macPackageName}", returnStdout: true).trim()
+                    def threePartVersion =  sh (script: "echo ${macPackageName} | sed 's#.*MDK-##; s#\\.macos10.*##; s#.*-dirty-##' | cut -f1-3 -d'.'", returnStdout: true).trim()
+
+                    sh "sed -i \"s/\\(MONO_VERSION=\\).*/\\1${threePartVersion}/\" packaging/Windows/resources/build.bat"
+                    sh "sed -i \"s/\\(MONO_VERSION=\\).*/\\1${threePartVersion}/\" packaging/Windows/resources/build64.bat"
+                    sh "sed -i \"s/\\(echo Mono version \\).*/\\1${threePartVersion}/\" packaging/Windows/resources/bat/setmonopath.bat"
+
+                    withEnv (["PATH+TOOLS=/usr/bin:/usr/local/bin:/cygdrive/c/Program Files (x86)/Mono/bin", "mdk=${macPackageNameAbs}"]) {
+                        // build x86 MSI
+                        dir ('packaging/Windows') { sh "./mono-MDK-windows" }
+
+                        sh "git clean -xdff --exclude MonoForWindows-x86.msi --exclude ${macPackageName}"
+                        sh "git submodule foreach git clean -xdff"
+
+                        // build x64 MSI
+                        dir ('packaging/Windows') { sh "./mono-MDK-windows-x64" }
+                    }
+                }
+
+                // move .msi files to the workspace root
+                sh 'mv packaging/Windows/resources/bin/Release/MonoForWindows-x86.msi .'
+                sh 'mv packaging/Windows/resources/bin/Release/MonoForWindows-x64.msi .'
+            }
+            stage('Upload .msi to Azure') {
+                step([
+                    $class: 'WAStoragePublisher',
+                    allowAnonymousAccess: true,
+                    cleanUpContainer: false,
+                    cntPubAccess: true,
+                    containerName: "${jobName}",
+                    doNotFailIfArchivingReturnsNothing: false,
+                    doNotUploadIndividualFiles: false,
+                    doNotWaitForPreviousBuild: true,
+                    excludeFilesPath: '',
+                    filesPath: "MonoForWindows-x86.msi,MonoForWindows-x64.msi",
+                    storageAccName: 'credential for xamjenkinsartifact',
+                    storageCredentialId: 'fbd29020e8166fbede5518e038544343',
+                    uploadArtifactsOnlyIfSuccessful: true,
+                    uploadZips: false,
+                    virtualPath: "${BRANCH_NAME}/${BUILD_NUMBER}/"
+                ])
+                currentBuild.description = "<hr/><h2>DOWNLOAD: <a href=\"https://xamjenkinsartifact.azureedge.net/${jobName}/${BRANCH_NAME}/${BUILD_NUMBER}/MonoForWindows-x86.msi\">MonoForWindows-x86.msi</a> -- <a href=\"https://xamjenkinsartifact.azureedge.net/${jobName}/${BRANCH_NAME}/${BUILD_NUMBER}/MonoForWindows-x64.msi\">MonoForWindows-x64.msi</a></h2><hr/>"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This replaces the current Jenkins freestyle jobs.

We no longer need the signing inside of the MacSDKRelease profile since we're now signing on a separate service and having the signing certificates locally is discouraged anyway.