### PR TITLE
Remove CodeDomConfigurationHandler from machine.config

### DIFF
--- a/data/net_4_5/machine.config
+++ b/data/net_4_5/machine.config
@@ -15,6 +15,7 @@
 		<section name="system.diagnostics" type="System.Diagnostics.SystemDiagnosticsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.runtime.remoting" type="System.Configuration.IgnoreSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowLocation="false"/>
 		<section name="system.windows.forms" type="System.Windows.Forms.WindowsFormsSection, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+		<section name="system.codedom" type="System.CodeDom.Compiler.CodeDomConfigurationHandler, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="windows" type="System.Configuration.IgnoreSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false" />
 		<section name="strongNames" type="System.Configuration.IgnoreSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowLocation="false"/>
 		<sectionGroup name="system.runtime.serialization" type="System.Runtime.Serialization.Configuration.SerializationSectionGroup, System.Runtime.Serialization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/data/net_4_5/machine.config
+++ b/data/net_4_5/machine.config
@@ -11,7 +11,6 @@
 		<section name="assemblyBinding"  type="System.Configuration.IgnoreSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false" />
 		<section name="satelliteassemblies" type="System.Configuration.IgnoreSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false" />
 		<section name="startup" type="System.Configuration.IgnoreSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false"/>
-		<section name="system.codedom" type="System.CodeDom.Compiler.CodeDomConfigurationHandler, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.data" type="System.Data.Common.DbProviderFactoriesConfigurationHandler, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.diagnostics" type="System.Diagnostics.SystemDiagnosticsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.runtime.remoting" type="System.Configuration.IgnoreSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowLocation="false"/>

--- a/mcs/class/System/System.CodeDom.Compiler/CodeDomConfigurationHandler.cs
+++ b/mcs/class/System/System.CodeDom.Compiler/CodeDomConfigurationHandler.cs
@@ -1,0 +1,81 @@
+//
+// System.Configuration.CodeDomConfigurationHandler
+//
+// Authors:
+//	Gonzalo Paniagua Javier (gonzalo@ximian.com)
+//
+// Copyright (c) 2005 Novell, Inc (http://www.novell.com)
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if CONFIGURATION_DEP
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+
+namespace System.CodeDom.Compiler
+{
+	internal sealed class CodeDomConfigurationHandler: ConfigurationSection
+	{
+		static ConfigurationPropertyCollection properties;
+		static ConfigurationProperty compilersProp;
+		static CompilerCollection default_compilers;
+
+		static CodeDomConfigurationHandler ()
+		{
+			default_compilers = new CompilerCollection ();
+			compilersProp = new ConfigurationProperty ("compilers", typeof (CompilerCollection), default_compilers);
+			properties = new ConfigurationPropertyCollection ();
+			properties.Add (compilersProp);
+		}
+
+		public CodeDomConfigurationHandler ()
+		{
+		}
+		
+		protected override void InitializeDefault ()
+		{
+			compilersProp = new ConfigurationProperty ("compilers", typeof (CompilerCollection), default_compilers);
+		}
+		
+		[MonoTODO]
+		protected override void PostDeserialize () => base.PostDeserialize ();
+
+		protected override object GetRuntimeObject () => this;
+
+		[ConfigurationProperty ("compilers")]
+		public CompilerCollection Compilers => (CompilerCollection) base [compilersProp];
+
+		public CompilerInfo[] CompilerInfos {
+			get {
+				var cc = (CompilerCollection) base [compilersProp];
+				return cc?.CompilerInfos;
+			}
+		}
+		
+		protected override ConfigurationPropertyCollection Properties => properties;
+	}
+}
+#endif

--- a/mcs/class/System/System.CodeDom.Compiler/Compiler.cs
+++ b/mcs/class/System/System.CodeDom.Compiler/Compiler.cs
@@ -1,0 +1,127 @@
+//
+// System.Web.Configuration.CompilerCollection
+//
+// Authors:
+//	Chris Toshok (toshok@ximian.com)
+//
+// (C) 2005 Novell, Inc (http://www.novell.com)
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if CONFIGURATION_DEP
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration;
+
+namespace System.CodeDom.Compiler
+{
+	internal sealed class Compiler : ConfigurationElement
+	{
+		static ConfigurationProperty compilerOptionsProp;
+		static ConfigurationProperty extensionProp;
+		static ConfigurationProperty languageProp;
+		static ConfigurationProperty typeProp;
+		static ConfigurationProperty warningLevelProp;
+		static ConfigurationProperty providerOptionsProp;
+		
+		static ConfigurationPropertyCollection properties;
+
+		static Compiler ()
+		{
+			compilerOptionsProp = new ConfigurationProperty("compilerOptions", typeof (string), "");
+			extensionProp = new ConfigurationProperty("extension", typeof (string), "");
+			languageProp = new ConfigurationProperty("language", typeof (string), "", ConfigurationPropertyOptions.IsRequired | ConfigurationPropertyOptions.IsKey);
+			typeProp = new ConfigurationProperty("type", typeof (string), "", ConfigurationPropertyOptions.IsRequired);
+			warningLevelProp = new ConfigurationProperty("warningLevel", typeof (int), 0,
+								     TypeDescriptor.GetConverter (typeof (int)),
+								     new IntegerValidator (0, 4),
+								     ConfigurationPropertyOptions.None);
+			providerOptionsProp = new ConfigurationProperty ("", typeof (CompilerProviderOptionsCollection), null, null, null,
+									 ConfigurationPropertyOptions.IsDefaultCollection);
+			
+			properties = new ConfigurationPropertyCollection ();
+			properties.Add (compilerOptionsProp);
+			properties.Add (extensionProp);
+			properties.Add (languageProp);
+			properties.Add (typeProp);
+			properties.Add (warningLevelProp);
+			properties.Add (providerOptionsProp);
+		}
+
+		internal Compiler ()
+		{
+		}
+
+		public Compiler (string compilerOptions, string extension, string language, string type, int warningLevel)
+		{
+			this.CompilerOptions = compilerOptions;
+			this.Extension = extension;
+			this.Language = language;
+			this.Type = type;
+			this.WarningLevel = warningLevel;
+		}
+
+		[ConfigurationProperty ("compilerOptions", DefaultValue = "")]
+		public string CompilerOptions {
+			get { return (string) base[compilerOptionsProp]; }
+			internal set { base[compilerOptionsProp] = value; }
+		}
+
+		[ConfigurationProperty ("extension", DefaultValue = "")]
+		public string Extension {
+			get { return (string) base[extensionProp]; }
+			internal set { base[extensionProp] = value; }
+		}
+
+		[ConfigurationProperty ("language", DefaultValue = "", Options = ConfigurationPropertyOptions.IsRequired | ConfigurationPropertyOptions.IsKey)]
+		public string Language {
+			get { return (string) base[languageProp]; }
+			internal set { base[languageProp] = value; }
+		}
+
+		[ConfigurationProperty ("type", DefaultValue = "", Options = ConfigurationPropertyOptions.IsRequired)]
+		public string Type {
+			get { return (string) base[typeProp]; }
+			internal set { base[typeProp] = value; }
+		}
+
+		[IntegerValidator (MinValue = 0, MaxValue = 4)]
+		[ConfigurationProperty ("warningLevel", DefaultValue = "0")]
+		public int WarningLevel {
+			get { return (int) base[warningLevelProp]; }
+			internal set { base[warningLevelProp] = value; }
+		}
+
+		[ConfigurationProperty ("", Options = ConfigurationPropertyOptions.IsDefaultCollection)]
+		public CompilerProviderOptionsCollection ProviderOptions {
+			get { return (CompilerProviderOptionsCollection) base [providerOptionsProp]; }
+			internal set { base [providerOptionsProp] = value; }
+		}
+
+		public Dictionary <string, string> ProviderOptionsDictionary => ProviderOptions.ProviderOptions;
+
+		protected override ConfigurationPropertyCollection Properties => properties;
+	}
+}
+#endif

--- a/mcs/class/System/System.CodeDom.Compiler/CompilerCollection.cs
+++ b/mcs/class/System/System.CodeDom.Compiler/CompilerCollection.cs
@@ -1,0 +1,217 @@
+//
+// System.Web.Configuration.CompilerCollection
+//
+// Authors:
+//	Chris Toshok (toshok@ximian.com)
+//
+// (C) 2005 Novell, Inc (http://www.novell.com)
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if CONFIGURATION_DEP
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+
+namespace System.CodeDom.Compiler
+{
+	[ConfigurationCollection (typeof (Compiler), AddItemName = "compiler", CollectionType = ConfigurationElementCollectionType.BasicMap)]
+	internal sealed class CompilerCollection : ConfigurationElementCollection
+	{
+		static readonly string defaultCompilerVersion = "3.5";
+		static ConfigurationPropertyCollection properties;
+		static List <CompilerInfo> compiler_infos;
+		static Dictionary <string, CompilerInfo> compiler_languages;
+		static Dictionary <string, CompilerInfo> compiler_extensions;
+		
+		static CompilerCollection ()
+		{
+			properties = new ConfigurationPropertyCollection ();
+			compiler_infos = new List <CompilerInfo> ();
+			compiler_languages = new Dictionary <string, CompilerInfo> (16, StringComparer.OrdinalIgnoreCase);
+			compiler_extensions = new Dictionary <string, CompilerInfo> (6, StringComparer.OrdinalIgnoreCase);
+				
+			CompilerInfo compiler = new CompilerInfo (null, "Microsoft.CSharp.CSharpCodeProvider, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", 
+				new [] { ".cs" }, new [] { "c#", "cs", "csharp" });
+			compiler.ProviderOptions ["CompilerVersion"] = defaultCompilerVersion;
+			AddCompilerInfo (compiler);
+
+			compiler = new CompilerInfo (null, "Microsoft.VisualBasic.VBCodeProvider, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", 
+				new [] { ".vb" }, new [] { "vb", "vbs", "visualbasic", "vbscript" });
+			compiler.ProviderOptions ["CompilerVersion"] = defaultCompilerVersion;
+			AddCompilerInfo (compiler);
+
+			compiler = new CompilerInfo (null, "Microsoft.JScript.JScriptCodeProvider, Microsoft.JScript, Version=8.0.1100.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", 
+				new [] { ".js" }, new [] { "js", "jscript", "javascript" });
+			compiler.ProviderOptions ["CompilerVersion"] = defaultCompilerVersion;
+			AddCompilerInfo (compiler);
+
+			compiler = new CompilerInfo (null, "Microsoft.VJSharp.VJSharpCodeProvider, VJSharpCodeProvider, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", 
+				new [] { ".jsl", ".java" }, new [] { "vj#", "vjs", "vjsharp" });
+			compiler.ProviderOptions ["CompilerVersion"] = defaultCompilerVersion;
+			AddCompilerInfo (compiler);
+
+			compiler = new CompilerInfo (null, "Microsoft.VisualC.CppCodeProvider, CppCodeProvider, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", 
+				new [] { ".h" }, new [] { "c++", "mc", "cpp" });
+			compiler.ProviderOptions ["CompilerVersion"] = defaultCompilerVersion;
+			AddCompilerInfo (compiler);
+		}
+
+		public CompilerCollection () { }
+
+		static void AddCompilerInfo (CompilerInfo ci)
+		{
+			ci.CreateProvider();
+			compiler_infos.Add (ci);
+
+			string[] languages = ci.GetLanguages ();
+			if (languages != null)
+				foreach (string language in languages)
+					compiler_languages [language] = ci;
+			
+			string[] extensions = ci.GetExtensions ();
+			if (extensions != null)
+				foreach (string extension in extensions)
+					compiler_extensions [extension] = ci;
+		}
+
+		static void AddCompilerInfo (Compiler compiler)
+		{
+			CompilerInfo ci = new CompilerInfo (null, compiler.Type, new [] { compiler.Extension }, new [] { compiler.Language });
+			ci.CompilerParams.CompilerOptions = compiler.CompilerOptions;
+			ci.CompilerParams.WarningLevel = compiler.WarningLevel;
+			AddCompilerInfo (ci);
+		}
+		
+		protected override void BaseAdd (ConfigurationElement element)
+		{
+			Compiler compiler = element as Compiler;
+			if (compiler != null)
+				AddCompilerInfo (compiler);
+			base.BaseAdd (element);
+		}
+		
+		protected override bool ThrowOnDuplicate {
+			get { return false; }
+		}
+		
+		protected override ConfigurationElement CreateNewElement ()
+		{
+			return new Compiler ();
+		}
+
+		public CompilerInfo GetCompilerInfoForLanguage (string language)
+		{
+			if (compiler_languages.Count == 0)
+				return null;
+			
+			CompilerInfo ci;
+			if (compiler_languages.TryGetValue (language, out ci))
+				return ci;
+			
+			return null;
+		}
+
+		public CompilerInfo GetCompilerInfoForExtension (string extension)
+		{
+			if (compiler_extensions.Count == 0)
+				return null;
+			
+			CompilerInfo ci;
+			if (compiler_extensions.TryGetValue (extension, out ci))
+				return ci;
+			
+			return null;
+		}
+
+		public string GetLanguageFromExtension (string extension)
+		{
+			CompilerInfo ci = GetCompilerInfoForExtension (extension);
+			if (ci == null)
+				return null;
+			string[] languages = ci.GetLanguages ();
+			if (languages != null && languages.Length > 0)
+				return languages [0];
+			return null;
+		}
+		
+		public Compiler Get (int index)
+		{
+			return (Compiler) BaseGet (index);
+		}
+
+		public Compiler Get (string language)
+		{
+			return (Compiler) BaseGet (language);
+		}
+
+		protected override object GetElementKey (ConfigurationElement element)
+		{
+			return ((Compiler)element).Language;
+		}
+
+		public string GetKey (int index)
+		{
+			return (string)BaseGetKey (index);
+		}
+
+		public string[] AllKeys {
+			get {
+				var keys = new string [compiler_infos.Count];
+				for (int i = 0; i < Count; i++)
+					keys[i] = string.Join(";", compiler_infos[i].GetLanguages ());
+				return keys;
+			}
+		}
+		
+		public override ConfigurationElementCollectionType CollectionType {
+			get { return ConfigurationElementCollectionType.BasicMap; }
+		}
+
+		protected override string ElementName {
+			get { return "compiler"; }
+		}
+
+		protected override ConfigurationPropertyCollection Properties {
+			get { return properties; }
+		}
+
+		public Compiler this[int index] {
+			get { return (Compiler) BaseGet (index); }
+		}
+
+		public new CompilerInfo this[string language] {
+			get {
+				return GetCompilerInfoForLanguage (language);
+			}
+		}
+
+		public CompilerInfo[] CompilerInfos {
+			get {
+				return compiler_infos.ToArray ();
+			}
+		}
+	}
+}
+#endif

--- a/mcs/class/System/System.CodeDom.Compiler/CompilerProviderOption.cs
+++ b/mcs/class/System/System.CodeDom.Compiler/CompilerProviderOption.cs
@@ -1,0 +1,69 @@
+// System.Web.Configuration.CompilerProviderOptionsCollection.cs
+//
+// Authors:
+//	Marek Habersack (mhabersack@novell.com)
+//
+// (C) 2007 Novell, Inc (http://www.novell.com)
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if CONFIGURATION_DEP
+using System;
+using System.Configuration;
+
+namespace System.CodeDom.Compiler
+{
+	internal sealed class CompilerProviderOption : ConfigurationElement
+	{
+		static ConfigurationProperty nameProp;
+		static ConfigurationProperty valueProp;
+		static ConfigurationPropertyCollection properties;
+		
+		static CompilerProviderOption ()
+		{
+			nameProp = new ConfigurationProperty ("name", typeof (string), "",
+							      ConfigurationPropertyOptions.IsRequired | ConfigurationPropertyOptions.IsKey);
+			valueProp = new ConfigurationProperty ("value", typeof (string), "",
+							       ConfigurationPropertyOptions.IsRequired);
+
+			properties = new ConfigurationPropertyCollection ();
+			properties.Add (nameProp);
+			properties.Add (valueProp);
+		}
+
+		[ConfigurationProperty ("name", DefaultValue = "", Options = ConfigurationPropertyOptions.IsRequired | ConfigurationPropertyOptions.IsKey)]
+		public string Name {
+			get { return (string) base [nameProp]; }
+			set { base [nameProp] = value; }
+		}
+
+		[ConfigurationProperty ("value", DefaultValue = "", Options = ConfigurationPropertyOptions.IsRequired)]
+		public string Value {
+			get { return (string) base [valueProp]; }
+			set { base [valueProp] = value; }
+		}
+
+		protected override ConfigurationPropertyCollection Properties => properties;
+	}
+}
+#endif

--- a/mcs/class/System/System.CodeDom.Compiler/CompilerProviderOptionsCollection.cs
+++ b/mcs/class/System/System.CodeDom.Compiler/CompilerProviderOptionsCollection.cs
@@ -1,0 +1,128 @@
+//
+// System.Web.Configuration.CompilerProviderOptionsCollection.cs
+//
+// Authors:
+//	Marek Habersack (mhabersack@novell.com)
+//
+// (C) 2007 Novell, Inc (http://www.novell.com)
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if CONFIGURATION_DEP
+using System;
+using System.Configuration;
+using System.Collections.Generic;
+
+namespace System.CodeDom.Compiler
+{
+	[ConfigurationCollection (typeof (CompilerProviderOption), CollectionType = ConfigurationElementCollectionType.BasicMap, AddItemName = "providerOption")]
+	internal sealed class CompilerProviderOptionsCollection : ConfigurationElementCollection
+	{
+		static ConfigurationPropertyCollection properties;
+
+		static CompilerProviderOptionsCollection ()
+		{
+			properties = new ConfigurationPropertyCollection ();
+		}
+
+		public CompilerProviderOptionsCollection ()
+		{
+		}
+
+		protected override ConfigurationElement CreateNewElement ()
+		{
+			return new CompilerProviderOption ();
+		}
+
+		public CompilerProviderOption Get (int index)
+		{
+			return (CompilerProviderOption) BaseGet (index);
+		}
+
+		public CompilerProviderOption Get (string name)
+		{
+			return (CompilerProviderOption) BaseGet (name);
+		}
+
+		protected override object GetElementKey (ConfigurationElement element)
+		{
+			return ((CompilerProviderOption) element).Name;
+		}
+
+		public string GetKey (int index)
+		{
+			return (string) BaseGetKey (index);
+		}
+
+		public string[] AllKeys {
+			get {
+				int count = Count;
+				string[] keys = new string [count];
+				for (int i = 0; i < count; i++)
+					keys [i] = this [i].Name;
+
+				return keys;
+			}
+		}
+
+		protected override string ElementName {
+			get { return "providerOption"; }
+		}
+
+		protected override ConfigurationPropertyCollection Properties {
+			get { return properties; }
+		}
+
+		public Dictionary <string, string> ProviderOptions {
+			get {
+				int count = Count;
+
+				if (count == 0)
+					return null;
+
+				Dictionary <string, string> ret = new Dictionary <string, string> (count);
+				CompilerProviderOption opt;
+				
+				for (int i = 0; i < count; i++) {
+					opt = this [i];
+					ret.Add (opt.Name, opt.Value);
+				}
+
+				return ret;
+			}
+		}
+		
+		public CompilerProviderOption this [int index] => (CompilerProviderOption) BaseGet (index);
+
+		public new CompilerProviderOption this [string name] {
+			get {
+				foreach (CompilerProviderOption c in this) {
+					if (c.Name == name)
+						return c;
+				}
+				return null;
+			}
+		}
+	}
+}
+#endif

--- a/mcs/class/System/net_4_x_System.dll.sources
+++ b/mcs/class/System/net_4_x_System.dll.sources
@@ -27,7 +27,7 @@ Microsoft.Win32/UserPreferenceChangingEventHandler.cs
 
 System/MonoToolsLocator.cs
 
-System.CodeDom.Compiler/Executor.cs
+System.CodeDom.Compiler/*.cs
 System.Configuration/ApplicationScopedSettingAttribute.cs
 System.Configuration/ApplicationSettingsBase.cs
 System.Configuration/ApplicationSettingsGroup.cs

--- a/sdks/android/machine.config
+++ b/sdks/android/machine.config
@@ -11,7 +11,6 @@
 		<section name="assemblyBinding"  type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false" />
 		<section name="satelliteassemblies" type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false" />
 		<section name="startup" type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false"/>
-		<section name="system.codedom" type="System.CodeDom.Compiler.CodeDomConfigurationHandler, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.data" type="System.Data.Common.DbProviderFactoriesConfigurationHandler, System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.diagnostics" type="System.Diagnostics.DiagnosticsConfigurationHandler, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.runtime.remoting" type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowLocation="false"/>

--- a/sdks/android/machine.config
+++ b/sdks/android/machine.config
@@ -11,6 +11,7 @@
 		<section name="assemblyBinding"  type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false" />
 		<section name="satelliteassemblies" type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false" />
 		<section name="startup" type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" allowLocation="false"/>
+		<section name="system.codedom" type="System.CodeDom.Compiler.CodeDomConfigurationHandler, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.data" type="System.Data.Common.DbProviderFactoriesConfigurationHandler, System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.diagnostics" type="System.Diagnostics.DiagnosticsConfigurationHandler, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		<section name="system.runtime.remoting" type="System.Configuration.IgnoreSection, System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowLocation="false"/>


### PR DESCRIPTION
CodeDomConfigurationHandler and its dependencies were removed in 2ac4e6a5c8860c8a9a8429370463d959a65a089d as part of "[System] CodeDom from CoreFX" PR
But the entity is still alive in machine.config and causes https://bugzilla.xamarin.com/show_bug.cgi?id=59200

Also, found an issue with DbProviderFactoriesConfigurationHandler from System.Data but I'll create a separate PR for it once I figure out how to fix it.