### PR TITLE
[ci] MSBuild related fixes

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -2,7 +2,7 @@ import fileinput
 
 class MSBuild (GitHubPackage):
 	def __init__ (self):
-		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',
+		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
 			revision = '5bb588162eadfc68c6af8895397f4f65f8008b24')
 
 	def build (self):

--- a/packaging/Windows/defs/managed-components
+++ b/packaging/Windows/defs/managed-components
@@ -19,9 +19,9 @@ download()
 	report "Downloading Xar"
 	wget --quiet -O ${REPODIR}/xar.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/xar/xar-1.5.2.tar.gz || error "*** Could not download Xar ***"
 	report "Downloading x64 hostfxr.dll"
-	wget --quiet -O ${REPODIR}/hostfxr-x64.zip https://www.nuget.org/api/v2/package/runtime.win-x64.Microsoft.NETCore.DotNetHostResolver/2.0.0-preview2-25407-01 || error "*** Could not download 64bit hostfxr.dll ***"
+	wget --quiet -O ${REPODIR}/hostfxr-x64.zip https://www.nuget.org/api/v2/package/runtime.win-x64.Microsoft.NETCore.DotNetHostResolver/2.0.0 || error "*** Could not download 64bit hostfxr.dll ***"
 	report "Downloading x86 hostfxr.dll"
-	wget --quiet -O ${REPODIR}/hostfxr-x86.zip https://www.nuget.org/api/v2/package/runtime.win-x86.Microsoft.NETCore.DotNetHostResolver/2.0.0-preview2-25407-01 || error "*** Could not download 32bit hostfxr.dll ***"
+	wget --quiet -O ${REPODIR}/hostfxr-x86.zip https://www.nuget.org/api/v2/package/runtime.win-x86.Microsoft.NETCore.DotNetHostResolver/2.0.0 || error "*** Could not download 32bit hostfxr.dll ***"
 	report "Copying Mono MDK for Mac"
 	cp $1 ${REPODIR}/mono.xar
 }
@@ -82,10 +82,10 @@ install()
 	fi
 	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/nuget				${REPODIR}/../../tmp/mono/lib/mono/
 	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild-frameworks			${REPODIR}/../../tmp/mono/lib/mono/
-	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/Microsoft/NuGet/Microsoft.NuGet*					${REPODIR}/../../tmp/mono/lib/mono/xbuild/  # note: we can't copy the symlink in xbuild/ so we copy the file it points to
-	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/NuGet*					${REPODIR}/../../tmp/mono/lib/mono/xbuild/
-	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/Newtonsoft.Json*					${REPODIR}/../../tmp/mono/lib/mono/xbuild/
+	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/deniedAssembliesList.txt				${REPODIR}/../../tmp/mono/lib/mono/xbuild/
 	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/15.0					${REPODIR}/../../tmp/mono/lib/mono/xbuild/
+	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/Microsoft/Microsoft.NET.Build.Extensions					${REPODIR}/../../tmp/mono/lib/mono/xbuild/Microsoft/
+	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/Microsoft/NuGet					${REPODIR}/../../tmp/mono/lib/mono/xbuild/Microsoft/
 	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/Microsoft/Portable/VisualStudio					${REPODIR}/../../tmp/mono/lib/mono/xbuild/Microsoft/Portable/
 	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/Microsoft/VisualStudio/v/FSharp					${REPODIR}/../../tmp/mono/lib/mono/xbuild/Microsoft/VisualStudio/v/
 	rsync -a --copy-links ${REPODIR}/mono-mac/lib/mono/xbuild/Microsoft/VisualStudio/v11.0/FSharp				${REPODIR}/../../tmp/mono/lib/mono/xbuild/Microsoft/VisualStudio/v11.0/
@@ -152,7 +152,7 @@ install()
 	rsync -a --copy-links lib/mono/4.5/FSharp.Core.*data lib/mono/gac/FSharp.Core/4.3.0.0__*/
 
 	# make sure we didn't miss any files with Mac paths
-	if grep -R 'Mono\.framework' . --exclude=xbuild.1 --exclude=MSBuild.dll.config; then
+	if grep -R 'Mono\.framework' . --exclude=xbuild.1 --exclude=MSBuild.dll.config --exclude=macpack.exe; then
 		echo "Found Mac paths in files, please make sure they're fixed."
 		exit 1
 	fi

--- a/scripts/ci/run-test-mac-sdk.sh
+++ b/scripts/ci/run-test-mac-sdk.sh
@@ -6,7 +6,7 @@ ${TESTCMD} --label=bockbuild --timeout=180m ${MONO_REPO_ROOT}/scripts/mac-sdk-pa
 export PATH=${MONO_REPO_ROOT}/external/bockbuild/stage/bin:$PATH
 
 # Bundled MSBuild
-cd ${MONO_REPO_ROOT}/external/bockbuild/builds/msbuild-15.4/
+cd ${MONO_REPO_ROOT}/external/bockbuild/builds/msbuild-15/
 ${TESTCMD} --label="msbuild-tests" --timeout=180m ./cibuild.sh --scope Test --host Mono --target Mono
 
 # Bundled LLVM


### PR DESCRIPTION
* [ci] Fix testing of msbuild in run-test-mac-sdk.sh 

It contained the old version number and failed on bots that didn't
have leftover old build result.

* [ci] Fix msbuild paths in Windows packaging 

They changed with 73bd521.