### PR TITLE
[aot] Add generic instances referenced by MONO_PATCH_INFO_METHOD_RGCTX patches. Fixes #60771.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7917,7 +7917,8 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 			switch (patch_info->type) {
 			case MONO_PATCH_INFO_RGCTX_FETCH:
 			case MONO_PATCH_INFO_RGCTX_SLOT_INDEX:
-			case MONO_PATCH_INFO_METHOD: {
+			case MONO_PATCH_INFO_METHOD:
+			case MONO_PATCH_INFO_METHOD_RGCTX: {
 				MonoMethod *m = NULL;
 
 				if (patch_info->type == MONO_PATCH_INFO_RGCTX_FETCH || patch_info->type == MONO_PATCH_INFO_RGCTX_SLOT_INDEX) {


### PR DESCRIPTION
Some generic instances were not generated because they were only referenced by METHOD_RGCTX patches, and the gsharedvt
fallback didn't work because the method in question Unsafe.Add<T> uses a sizeof opcode on a gsharedvt type which is currently
not supported.

Testcase:
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
using System;
using System.Runtime.CompilerServices;

public class Tests
{
        [MethodImplAttribute (MethodImplOptions.NoInlining)]
        public void Foo55<T> () {
            byte[] arr = new byte [10];
            ref byte data0 = ref arr [0];
            Unsafe.Add (ref data0, 0);
        }

        interface IFace {
            void Foo55 <T> ();
        }

        class AClass : IFace {
            public void Foo55 <T> () {
            byte[] arr = new byte [10];
            ref byte data0 = ref arr [0];
            Unsafe.Add (ref data0, 0);
            }
        }

    public static int Main () {
            IFace iface = new AClass ();
            iface.Foo55<int> ();
            return 0;
        }
}
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>