### PR TITLE
[genproj] Support setting /langversion in csproj

### DIFF
--- a/msvc/scripts/csproj.tmpl
+++ b/msvc/scripts/csproj.tmpl
@@ -9,6 +9,7 @@
     <ProjectGuid>@PROJECTGUID@</ProjectGuid>
     <OutputType>@OUTPUTTYPE@</OutputType>
     <NoWarn>@DISABLEDWARNINGS@</NoWarn>
+    <LangVersion>@LANGVERSION@</LangVersion>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Windows_NT'">win32</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix' and $([System.IO.File]::Exists('/usr/lib/libc.dylib'))">darwin</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -25,15 +25,6 @@ public enum Target {
 	Library, Exe, Module, WinExe
 }
 
-public enum LanguageVersion {
-	ISO_1 = 1,
-	Default_MCS = 2,
-	ISO_2 = 3,
-	LINQ = 4,
-	Future = 5,
-	Default = LINQ
-}
-
 class SlnGenerator {
 	public static readonly string NewLine = "\r\n"; //Environment.NewLine; // "\n"; 
 	public SlnGenerator (string formatVersion = "2012")
@@ -233,7 +224,7 @@ class MsbuildGenerator {
 	string OutputFile;
 	string StrongNameKeyContainer;
 	bool StrongNameDelaySign = false;
-	LanguageVersion Version = LanguageVersion.Default;
+	string LangVersion = "default";
 	string CodePage;
 
 	// Class directory, relative to 
@@ -538,23 +529,7 @@ class MsbuildGenerator {
 			return true;
 
 		case "/langversion":
-			switch (value.ToLower (CultureInfo.InvariantCulture)) {
-			case "iso-1":
-				Version = LanguageVersion.ISO_1;
-				return true;
-
-			case "default":
-				Version = LanguageVersion.Default;
-				return true;
-			case "iso-2":
-				Version = LanguageVersion.ISO_2;
-				return true;
-			case "future":
-				Version = LanguageVersion.Future;
-				return true;
-			}
-			Console.WriteLine ("Invalid option `{0}' for /langversion. It must be either `ISO-1', `ISO-2' or `Default'", value);
-			Environment.Exit (1);
+			LangVersion = value;
 			return true;
 
 		case "/codepage":
@@ -925,6 +900,7 @@ class MsbuildGenerator {
 			Replace ("@PROJECTGUID@", Csproj.projectGuid).
 			Replace ("@DEFINES@", defines.ToString ()).
 			Replace ("@DISABLEDWARNINGS@", string.Join (",", (from i in ignore_warning select i.ToString ()).ToArray ())).
+			Replace ("@LANGVERSION@", LangVersion).
 			//Replace("@NOSTDLIB@", (basic_or_build || (!StdLib)) ? "<NoStdLib>true</NoStdLib>" : string.Empty).
 			Replace ("@NOSTDLIB@", "<NoStdLib>" + (!StdLib).ToString () + "</NoStdLib>").
 			Replace ("@NOCONFIG@", "<NoConfig>" + (!load_default_config).ToString () + "</NoConfig>").


### PR DESCRIPTION
Fixes `Invalid option 'latest' for /langversion. It must be either 'ISO-1', 'ISO-2' or 'Default'`
