### PR TITLE
[System][Test] Only Xamarin.iOS has a synchronization context by default.

### DIFF
--- a/mcs/class/System/Test/System.ComponentModel/AsyncOperationManagerTest.cs
+++ b/mcs/class/System/Test/System.ComponentModel/AsyncOperationManagerTest.cs
@@ -26,7 +26,7 @@ namespace MonoTests.System.ComponentModel
 			SynchronizationContext sc1 = new SynchronizationContext ();
 			SynchronizationContext sc2 = new SynchronizationContext ();
 
-#if MONOTOUCH || XAMMAC
+#if MONOTOUCH
 			Assert.IsNotNull (SynchronizationContext.Current, "A1");
 #else
 			Assert.IsNull (SynchronizationContext.Current, "A1");


### PR DESCRIPTION
This shows up when Xamarin.Mac tests start defining XAMMAC [1]

[1] https://github.com/xamarin/xamarin-macios/pull/3034