### PR TITLE
[acceptance-tests] Run shorter version of GCStress on PRs and update targets

### DIFF
--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -10,7 +10,7 @@
   {
     "name": "coreclr", 
     "url": "git://github.com/mono/coreclr.git", 
-    "rev": "d0e6a36f782f5ee1ca0b7d3ec0c55725c3571b1f", 
+    "rev": "83d8279997d8ce4ad344ff9b937b2d13d074dcaa", 
     "remote-branch": "origin/mono", 
     "branch": "mono", 
     "directory": "coreclr"

--- a/acceptance-tests/coreclr.mk
+++ b/acceptance-tests/coreclr.mk
@@ -32,7 +32,7 @@ coreclr-runtest-coremanglib: coreclr-validate test-runner.exe $(CORECLR_COREMANG
 check-coreclr: coreclr-compile-tests coreclr-runtest-basic coreclr-runtest-coremanglib
 
 coreclr-gcstress: coreclr-validate GCStressTests.exe $(CORECLR_STRESSTESTSI_CS)
-	BVT_ROOT=$(realpath $(CORECLR_PATH)/tests/src/GC/Stress/Tests) $(RUNTIME) GCStressTests.exe $(CORECLR_PATH)/tests/src/GC/Stress/testmix_gc.config; if [ $$? -ne 100 ]; then exit 1; fi
+	BVT_ROOT=$(realpath $(CORECLR_PATH)/tests/src/GC/Stress/Tests) $(RUNTIME) GCStressTests.exe $(CORECLR_PATH)/tests/src/GC/Stress/$(if $(CI_PR),testmix_gc_pr.config,testmix_gc.config); if [ $$? -ne 100 ]; then exit 1; fi
 
 # Output a variable in $(2) to the file $(1), separated by newline characters
 # we need to do it in groups of 100 entries to make sure we don't exceed shell char limits

--- a/scripts/ci/run-test-acceptance-tests.sh
+++ b/scripts/ci/run-test-acceptance-tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+# run the MS test suite
 LANG=en_US.UTF-8 ${TESTCMD} --label=check-ms-test-suite --timeout=10m make -C acceptance-tests check-ms-test-suite
 
 total_tests=$(find acceptance-tests/ -name TestResult*xml | xargs cat | grep -c "<test-case")
@@ -8,9 +9,13 @@ if [ "$total_tests" -lt "1600" ]
 	exit 1
 fi
 
+# run Roslyn tests
 ${TESTCMD} --label=check-roslyn --timeout=60m make -C acceptance-tests check-roslyn
 
-#${TESTCMD} --label=coreclr-compile-tests --timeout=80m --fatal make -C acceptance-tests coreclr-compile-tests
-${TESTCMD} --label=coreclr-runtest-basic --timeout=45m make -C acceptance-tests coreclr-runtest-basic
-${TESTCMD} --label=coreclr-runtest-coremanglib --timeout=90m make -C acceptance-tests coreclr-runtest-coremanglib
-#${TESTCMD} --label=coreclr-gcstress --timeout=1200m make -C acceptance-tests coreclr-gcstress
+# run CoreCLR managed tests, we precompile them in parallel so individual steps don't need to do it
+${TESTCMD} --label=coreclr-compile-tests --timeout=80m --fatal make -C acceptance-tests coreclr-compile-tests
+${TESTCMD} --label=coreclr-runtest-basic --timeout=10m make -C acceptance-tests coreclr-runtest-basic
+${TESTCMD} --label=coreclr-runtest-coremanglib --timeout=10m make -C acceptance-tests coreclr-runtest-coremanglib
+
+# run the GC stress tests (on PRs we only run a short version)
+${TESTCMD} --label=coreclr-gcstress --timeout=1200m make -C acceptance-tests coreclr-gcstress CI_PR=${ghprbPullId}


### PR DESCRIPTION
In 22f0977132c09c17bfc88c6e64b27c9eb1c91c50 it was disabled but we can actually just run a shorter version in PRs.

Also reenable the precompilation target for the managed CoreCLR tests.