### PR TITLE
Bump msbuild to bring in fix for #60770

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',
-			revision = '98281e4fffa3b63746c16044a6d0162804480927')
+			revision = '5cf9eb2cc748907924342b32a3eefa78bb325de8')
 
 	def build (self):
 		self.sh ('./cibuild.sh --scope Compile --target Mono --host Mono --config Release')


### PR DESCRIPTION
This mainly applies to Linux packaging.

@monojenkins build pkg