### PR TITLE
[loader] Don't assert on abstract methods in get_method_constrained

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1895,6 +1895,10 @@ get_method_constrained (MonoImage *image, MonoMethod *method, MonoClass *constra
 	g_assert (vtable_slot >= 0);
 
 	MonoMethod *res = mono_class_get_vtable_entry (constrained_class, vtable_slot);
+	if (res == NULL && mono_class_is_abstract (constrained_class) ) {
+		/* Constraining class is abstract, there may not be a refined method. */
+		return method;
+	}
 	g_assert (res != NULL);
 	if (inflated_generic_method) {
 		g_assert (res->is_generic);


### PR DESCRIPTION
One more follow-on fix for #6037 

If the constrained class is abstract, it might not implement the given method.
