### PR TITLE
[2017-10][interp] allow unsigned i8 in pinvoke signature

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -824,11 +824,13 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		case MONO_TYPE_GENERICINST:
 #if SIZEOF_VOID_P == 8
 		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
 #endif
 			margs->ilen++;
 			break;
 #if SIZEOF_VOID_P == 4
 		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
 #ifdef TARGET_ARM
 			/* pairs begin at even registers */
 			if (i8_align == 8 && margs->ilen & 1)
@@ -896,6 +898,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		case MONO_TYPE_GENERICINST:
 #if SIZEOF_VOID_P == 8
 		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
 #endif
 			margs->iargs [int_i] = frame->stack_args [i].data.p;
 #if DEBUG_INTERP
@@ -904,7 +907,8 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 			int_i++;
 			break;
 #if SIZEOF_VOID_P == 4
-		case MONO_TYPE_I8: {
+		case MONO_TYPE_I8:
+		case MONO_TYPE_U8: {
 			stackval *sarg = &frame->stack_args [i];
 #ifdef TARGET_ARM
 			/* pairs begin at even registers */
@@ -958,6 +962,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		case MONO_TYPE_OBJECT:
 		case MONO_TYPE_STRING:
 		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
 		case MONO_TYPE_VALUETYPE:
 		case MONO_TYPE_GENERICINST:
 			margs->retval = &(frame->retval->data.p);


### PR DESCRIPTION
cherry-picked from https://github.com/mono/mono/pull/5911

needed for experimental interp option on Xamarin.iOS (+ https://github.com/mono/mono/pull/6112 needs to be backported).