### PR TITLE
[interp] disassembler for mint instructions should return a string instead of printing char by char

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2213,11 +2213,11 @@ static int opcode_counts[512];
 		sp->data.l = 0; \
 		output_indent (); \
 		char *mn = mono_method_full_name (frame->imethod->method, FALSE); \
-		g_print ("(%p) %s -> ", mono_thread_internal_current (), mn); \
+		char *disasm = mono_interp_dis_mintop(rtm->code, ip); \
+		g_print ("(%p) %s -> %s\t%d:%s\n", mono_thread_internal_current (), mn, disasm, vt_sp - vtalloc, ins); \
 		g_free (mn); \
-		mono_interp_dis_mintop(rtm->code, ip); \
-		g_print ("\t%d:%s\n", vt_sp - vtalloc, ins); \
 		g_free (ins); \
+		g_free (disasm); \
 	}
 #else
 #define DUMP_INSTR()

--- a/mono/mini/interp/mintops.c
+++ b/mono/mini/interp/mintops.c
@@ -35,12 +35,11 @@ MintOpArgType mono_interp_opargtype[] = {
 };
 #undef OPDEF
 
-const guint16 *
-mono_interp_dis_mintop(const guint16 *base, const guint16 *ip)
+const guint16*
+mono_interp_dis_mintop_len (const guint16 *ip)
 {
 	int len = mono_interp_oplen [*ip];
-	guint32 token;
-	int target;
+
 	if (len < 0 || len > 10) {
 		g_print ("op %d len %d\n", *ip, len);
 		g_assert_not_reached ();
@@ -49,73 +48,83 @@ mono_interp_dis_mintop(const guint16 *base, const guint16 *ip)
 		len = 3 + n * 2;
 	}
 
-	g_print ("IL_%04x: %-10s", ip - base, mono_interp_opname [*ip]);
+	return ip + len;
+}
+
+char *
+mono_interp_dis_mintop(const guint16 *base, const guint16 *ip)
+{
+	GString *str = g_string_new ("");
+	guint32 token;
+	int target;
+
+	g_string_append_printf (str, "IL_%04x: %-10s", ip - base, mono_interp_opname [*ip]);
 	switch (mono_interp_opargtype [*ip]) {
 	case MintOpNoArgs:
 		break;
 	case MintOpUShortInt:
-		g_print (" %u", * (guint16 *)(ip + 1));
+		g_string_append_printf (str, " %u", * (guint16 *)(ip + 1));
 		break;
 	case MintOpTwoShorts:
-		g_print (" %u,%u", * (guint16 *)(ip + 1), * (guint16 *)(ip + 2));
+		g_string_append_printf (str, " %u,%u", * (guint16 *)(ip + 1), * (guint16 *)(ip + 2));
 		break;
 	case MintOpShortAndInt:
-		g_print (" %u,%u", * (guint16 *)(ip + 1), (guint32)READ32(ip + 2));
+		g_string_append_printf (str, " %u,%u", * (guint16 *)(ip + 1), (guint32)READ32(ip + 2));
 		break;
 	case MintOpShortInt:
-		g_print (" %d", * (short *)(ip + 1));
+		g_string_append_printf (str, " %d", * (short *)(ip + 1));
 		break;
 	case MintOpClassToken:
 	case MintOpMethodToken:
 	case MintOpFieldToken:
 		token = * (guint16 *)(ip + 1);
-		g_print (" %u", token);
+		g_string_append_printf (str, " %u", token);
 		break;
 	case MintOpInt:
-		g_print (" %d", (gint32)READ32 (ip + 1));
+		g_string_append_printf (str, " %d", (gint32)READ32 (ip + 1));
 		break;
 	case MintOpLongInt:
-		g_print (" %lld", (gint64)READ64 (ip + 1));
+		g_string_append_printf (str, " %lld", (gint64)READ64 (ip + 1));
 		break;
 	case MintOpFloat: {
 		gint32 tmp = READ32 (ip + 1);
-		g_print (" %g", * (float *)&tmp);
+		g_string_append_printf (str, " %g", * (float *)&tmp);
 		break;
 	}
 	case MintOpDouble: {
 		gint64 tmp = READ64 (ip + 1);
-		g_print (" %g", * (double *)&tmp);
+		g_string_append_printf (str, " %g", * (double *)&tmp);
 		break;
 	}
 	case MintOpShortBranch:
 		target = ip + * (short *)(ip + 1) - base;
-		g_print (" IL_%04x", target);
+		g_string_append_printf (str, " IL_%04x", target);
 		break;
 	case MintOpBranch:
 		target = ip + (gint32)READ32 (ip + 1) - base;
-		g_print (" IL_%04x", target);
+		g_string_append_printf (str, " IL_%04x", target);
 		break;
 	case MintOpSwitch: {
 		const guint16 *p = ip + 1;
 		int sval = (gint32)READ32 (p);
 		int i;
 		p += 2;
-		g_print ("(");
+		g_string_append_printf (str, "(");
 		for (i = 0; i < sval; ++i) {
 			int offset;
 			if (i > 0)
-				g_print (", ");
+				g_string_append_printf (str, ", ");
 			offset = (gint32)READ32 (p);
-			g_print ("IL_%04x", p + offset - base);
+			g_string_append_printf (str, "IL_%04x", p + offset - base);
 			p += 2;
 		}
-		g_print (")");
+		g_string_append_printf (str, ")");
 		break;
 	}
 	default:
-		g_print("unknown arg type\n");
+		g_string_append_printf (str, "unknown arg type\n");
 	}
 
-	return ip + len;
+	return g_string_free (str, FALSE);
 }
 

--- a/mono/mini/interp/mintops.h
+++ b/mono/mini/interp/mintops.h
@@ -56,7 +56,8 @@ enum {
 extern const char *mono_interp_opname[];
 extern unsigned char mono_interp_oplen[];
 extern MintOpArgType mono_interp_opargtype[];
-extern const guint16 *mono_interp_dis_mintop(const unsigned short *base, const guint16 *ip);
+extern char* mono_interp_dis_mintop(const unsigned short *base, const guint16 *ip);
+extern const guint16* mono_interp_dis_mintop_len (const guint16 *ip);
 
 #endif
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4190,6 +4190,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 		while (p < td->new_ip) {
 			char *ins = mono_interp_dis_mintop (td->new_code, p);
 			g_print ("%s\n", ins);
+			g_free (ins);
 			p = mono_interp_dis_mintop_len (p);
 		}
 	}

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4188,8 +4188,9 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 		g_print ("Runtime method: %s %p, VT stack size: %d\n", mono_method_full_name (method, TRUE), rtm, td->max_vt_sp);
 		g_print ("Calculated stack size: %d, stated size: %d\n", td->max_stack_height, header->max_stack);
 		while (p < td->new_ip) {
-			p = mono_interp_dis_mintop(td->new_code, p);
-			g_print ("\n");
+			char *ins = mono_interp_dis_mintop (td->new_code, p);
+			g_print ("%s\n", ins);
+			p = mono_interp_dis_mintop_len (p);
 		}
 	}
 	g_assert (td->max_stack_height <= (header->max_stack + 1));


### PR DESCRIPTION
otherwise logs are unreadable on products like XI