### PR TITLE
[2017-10][interp] fix using conv.u with string

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2503,6 +2503,7 @@ generate (MonoMethod *method, InterpMethod *rtm, unsigned char *is_bb_start, Mon
 #endif
 				break;
 			case STACK_TYPE_MP:
+			case STACK_TYPE_O:
 				break;
 			default:
 				g_assert_not_reached ();


### PR DESCRIPTION
backport from https://github.com/mono/mono/pull/5683

it didn't made it with the backport for the JIT: https://github.com/mono/mono/pull/6020