### PR TITLE
Simplify MonoError and managed Exception creation

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -248,10 +248,6 @@
 		<type fullname="System.MissingMethodException">
 			<!-- mini.c (mono_jit_compiler_method_inner) mono_exception_from_name_msg -->
 			<method signature="System.Void .ctor(System.String)" />
-			<!-- exception.c (mono_get_exception_type_load) mono_exception_from_name_two_strings -->
-			<method signature="System.Void .ctor(System.String,System.String)" />
-			<!-- exception.c  mono_exception_from_name_four_strings -->
-			<method signature="System.Void .ctor(System.String,System.String,System.String,System.String)" />
 		</type>
 		
 		<!-- threadpool.c: mono_thread_pool_init (assert) -->

--- a/mcs/class/referencesource/mscorlib/system/missingmethodexception.cs
+++ b/mcs/class/referencesource/mscorlib/system/missingmethodexception.cs
@@ -48,19 +48,10 @@ namespace System {
                 if (ClassName == null) {
                     return base.Message;
                 } else {
-#if MONO
-                    string res = ClassName + "." + MemberName;
-                    if (!string.IsNullOrEmpty(signature))
-                        res = string.Format (CultureInfo.InvariantCulture, signature, res);
-                    if (!string.IsNullOrEmpty(_message))
-                        res += " Due to: " + _message;
-                    return res;
-#else
                     // do any desired fixups to classname here.
                     return Environment.GetResourceString("MissingMethod_Name",
                                                                        ClassName + "." + MemberName +
                                                                        (Signature != null ? " " + FormatSignature(Signature) : ""));
-#endif
                 }
             }
         }
@@ -82,17 +73,5 @@ namespace System {
         // If ClassName != null, Message will construct on the fly using it
         // and the other variables. This allows customization of the
         // format depending on the language environment.
-#if MONO
-        // Called from the EE
-        private MissingMethodException(String className, String methodName, String signature, String message) : base (message)
-        {
-            ClassName   = className;
-            MemberName  = methodName;
-            this.signature = signature;
-        }
-
-		[NonSerialized]
-        string signature;
-#endif
     }
 }

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2172,7 +2172,7 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoStringHandle fname, MonoBoole
 	
 	if (!ass) {
 		if (status == MONO_IMAGE_IMAGE_INVALID)
-			mono_error_set_bad_image_name (error, g_strdup (name), "");
+			mono_error_set_bad_image_by_name (error, name, "Invalid Image");
 		else
 			mono_error_set_assembly_load (error, g_strdup (name), "%s", "");
 		goto leave;
@@ -2214,7 +2214,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 	MonoImage *image = mono_image_open_from_data_full (assembly_data, raw_assembly_len, FALSE, NULL, refonly);
 
 	if (!image) {
-		mono_error_set_bad_image_name (error, g_strdup (""), "%s", "");
+		mono_error_set_bad_image_by_name (error, "In memory assembly", "0x%x", raw_data);
 		return refass;
 	}
 
@@ -2222,7 +2222,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 		guint32 symbol_len = mono_array_handle_length (raw_symbol_store);
 		uint32_t symbol_gchandle;
 		mono_byte *raw_symbol_data = (mono_byte*) MONO_ARRAY_HANDLE_PIN (raw_symbol_store, mono_byte, 0, &symbol_gchandle);
-		mono_debug_open_image_from_memory (image, raw_symbol_data, symbol_len);
+		mono_debug_open_image_from_memory (image, raw_symbol_data, raw_data);
 		mono_gchandle_free (symbol_gchandle);
 	}
 
@@ -2231,7 +2231,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 
 	if (!ass) {
 		mono_image_close (image);
-		mono_error_set_bad_image_name (error, g_strdup (""), "%s", "");
+		mono_error_set_bad_image_by_name (error, "In Memory assembly", "0x%x", assembly_data);
 		return refass; 
 	}
 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1230,7 +1230,7 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 
 	if (ret && !refonly && ret->ref_only) {
 		/* .NET Framework throws System.IO.FileNotFoundException in this case */
-		mono_error_set_file_not_found (error, "AssemblyResolveEvent handlers cannot return Assemblies loaded for reflection only");
+		mono_error_set_file_not_found (error, NULL, "AssemblyResolveEvent handlers cannot return Assemblies loaded for reflection only");
 		ret = NULL;
 		goto leave;
 	}
@@ -2174,7 +2174,7 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoStringHandle fname, MonoBoole
 		if (status == MONO_IMAGE_IMAGE_INVALID)
 			mono_error_set_bad_image_by_name (error, name, "Invalid Image");
 		else
-			mono_error_set_assembly_load (error, g_strdup (name), "%s", "");
+			mono_error_set_file_not_found (error, name, "Invalid Image");
 		goto leave;
 	}
 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2222,7 +2222,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 		guint32 symbol_len = mono_array_handle_length (raw_symbol_store);
 		uint32_t symbol_gchandle;
 		mono_byte *raw_symbol_data = (mono_byte*) MONO_ARRAY_HANDLE_PIN (raw_symbol_store, mono_byte, 0, &symbol_gchandle);
-		mono_debug_open_image_from_memory (image, raw_symbol_data, raw_data);
+		mono_debug_open_image_from_memory (image, raw_symbol_data, symbol_len);
 		mono_gchandle_free (symbol_gchandle);
 	}
 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2214,7 +2214,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 	MonoImage *image = mono_image_open_from_data_full (assembly_data, raw_assembly_len, FALSE, NULL, refonly);
 
 	if (!image) {
-		mono_error_set_bad_image_by_name (error, "In memory assembly", "0x%x", raw_data);
+		mono_error_set_bad_image_by_name (error, "In memory assembly", "0x%p", raw_data);
 		return refass;
 	}
 
@@ -2231,7 +2231,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 
 	if (!ass) {
 		mono_image_close (image);
-		mono_error_set_bad_image_by_name (error, "In Memory assembly", "0x%x", assembly_data);
+		mono_error_set_bad_image_by_name (error, "In Memory assembly", "0x%p", assembly_data);
 		return refass; 
 	}
 

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -12,6 +12,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/custom-attrs-internals.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/profiler-private.h>

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -22,6 +22,7 @@
 #include <mono/metadata/image-internals.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/assembly-internals.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/profiler-private.h>

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -192,7 +192,8 @@ mono_class_from_typeref_checked (MonoImage *image, guint32 type_token, MonoError
 		
 		mono_assembly_get_assemblyref (image, idx - 1, &aname);
 		human_name = mono_stringify_assembly_name (&aname);
-		mono_error_set_assembly_load_simple (error, human_name, image->assembly ? image->assembly->ref_only : FALSE);
+		mono_error_set_simple_file_not_found (error, human_name, image->assembly ? image->assembly->ref_only : FALSE);
+		g_free (human_name);
 		return NULL;
 	}
 

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -287,49 +287,6 @@ mono_signature_full_name (MonoMethodSignature *sig)
 	return result;
 }
 
-/*
- * Returns a string ready to be consumed by managed code when formating a string to include class + method name.
- * IE, say you have void Foo:Bar(int). It will return "void {0}(int)".
- * The reason for this is that managed exception constructors for missing members require a both class and member names to be provided independently of the signature.
- */
-char*
-mono_signature_get_managed_fmt_string (MonoMethodSignature *sig)
-{
-	int i;
-	char *result;
-	GString *res;
-
-	if (!sig)
-		return g_strdup ("<invalid signature>");
-
-	res = g_string_new ("");
-
-	mono_type_get_desc (res, sig->ret, TRUE);
-
-	g_string_append (res, " {0}");
-
-	if (sig->generic_param_count) {
-		g_string_append_c (res, '<');
-		for (i = 0; i < sig->generic_param_count; ++i) {
-			if (i > 0)
-				g_string_append (res, ",");
-			g_string_append_printf (res, "!%d", i);
-		}
-		g_string_append_c (res, '>');
-	}
-
-	g_string_append_c (res, '(');
-	for (i = 0; i < sig->param_count; ++i) {
-		if (i > 0)
-			g_string_append_c (res, ',');
-		mono_type_get_desc (res, sig->params [i], TRUE);
-	}
-	g_string_append_c (res, ')');
-	result = res->str;
-	g_string_free (res, FALSE);
-	return result;
-}
-
 void
 mono_ginst_get_desc (GString *str, MonoGenericInst *ginst)
 {

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -38,4 +38,13 @@ mono_install_get_seq_point (MonoGetSeqPointFunc func);
 void
 mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *reason, ...) MONO_ATTR_FORMAT_PRINTF(5,6);
 
+void
+mono_error_set_bad_image (MonoError *error, MonoImage *image, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
+
+void
+mono_error_set_bad_image_by_name (MonoError *error, const char *image_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
+
+MonoException *
+mono_corlib_exception_new_with_args (const char *name_space, const char *name, const char *arg_0, const char *arg_1, MonoError *error);
+
 #endif

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -44,6 +44,12 @@ mono_error_set_bad_image (MonoError *error, MonoImage *image, const char *msg_fo
 void
 mono_error_set_bad_image_by_name (MonoError *error, const char *image_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
+void
+mono_error_set_file_not_found (MonoError *oerror, const char *file_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
+
+void
+mono_error_set_simple_file_not_found (MonoError *oerror, const char *assembly_name, gboolean refection_only);
+
 MonoException *
 mono_corlib_exception_new_with_args (const char *name_space, const char *name, const char *arg_0, const char *arg_1, MonoError *error);
 

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -35,7 +35,7 @@ typedef int (*MonoGetSeqPointFunc) (MonoDomain *domain, MonoMethod *method, gint
 void
 mono_install_get_seq_point (MonoGetSeqPointFunc func);
 
-char*
-mono_exception_create_missing_method_message (MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *msg, ...);
+void
+mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *reason, ...) MONO_ATTR_FORMAT_PRINTF(5,6);
 
 #endif

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -30,15 +30,12 @@ mono_exception_from_token_two_strings_checked (MonoImage *image, uint32_t token,
 					       MonoString *a1, MonoString *a2,
 					       MonoError *error);
 
-MonoException *
-mono_exception_from_name_four_strings_checked (MonoImage *image, const char *name_space,
-				      const char *name, MonoString *a1, MonoString *a2, MonoString *a3, MonoString *a4,
-				      MonoError *error);
-
-
 typedef int (*MonoGetSeqPointFunc) (MonoDomain *domain, MonoMethod *method, gint32 native_offset);
 
 void
 mono_install_get_seq_point (MonoGetSeqPointFunc func);
+
+char*
+mono_exception_create_missing_method_message (MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *msg, ...);
 
 #endif

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -39,6 +39,9 @@ void
 mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *reason, ...) MONO_ATTR_FORMAT_PRINTF(5,6);
 
 void
+mono_error_set_field_missing (MonoError *oerror, MonoClass *klass, const char *field_name, MonoType *sig, const char *reason, ...) MONO_ATTR_FORMAT_PRINTF(5,6);
+
+void
 mono_error_set_bad_image (MonoError *error, MonoImage *image, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1120,12 +1120,10 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 }
 
 /*
- * Returns a string ready to be consumed by managed code when formating a string to include class + method name.
- * IE, say you have void Foo:Bar(int). It will return "void {0}(int)".
- * The reason for this is that managed exception constructors for missing members require a both class and member names to be provided independently of the signature.
+ * Sets @error to a method missing error.
  */
-char *
-mono_exception_create_missing_method_message (MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *reason, ...)
+void
+mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *method_name, MonoMethodSignature *sig, const char *reason, ...)
 {
 	int i;
 	char *result;
@@ -1187,5 +1185,6 @@ mono_exception_create_missing_method_message (MonoClass *klass, const char *meth
 	}
 	result = res->str;
 	g_string_free (res, FALSE);
-	return result;
+
+	mono_error_set_specific (error, MONO_ERROR_MISSING_METHOD, result);
 }

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1135,6 +1135,52 @@ mono_corlib_exception_new_with_args (const char *name_space, const char *name, c
 	return mono_exception_from_name_two_strings_checked (mono_defaults.corlib, name_space, name, str_0, str_1, error);
 }
 
+void
+mono_error_set_field_missing (MonoError *error, MonoClass *klass, const char *field_name, MonoType *sig, const char *reason, ...)
+{
+	char *result;
+	GString *res;
+
+	res = g_string_new ("Field not found: ");
+
+
+	if (sig) {
+		mono_type_get_desc (res, sig, TRUE);
+		g_string_append_c (res, ' ');
+	}
+
+	if (klass) {
+		if (klass->name_space) {
+			g_string_append (res, klass->name_space);
+			g_string_append_c (res, '.');
+		}
+		g_string_append (res, klass->name);
+	}
+	else {
+		g_string_append (res, "<unknown type>");
+	}
+
+	g_string_append_c (res, '.');
+
+	if (field_name)
+		g_string_append (res, field_name);
+	else
+		g_string_append (res, "<unknown field>");
+
+	if (reason && *reason) {
+		va_list args;
+		va_start (args, reason);
+
+		g_string_append (res, " Due to: ");
+		g_string_append_vprintf (res, reason, args);
+		va_end (args);
+	}
+	result = res->str;
+	g_string_free (res, FALSE);
+
+	mono_error_set_specific (error, MONO_ERROR_MISSING_FIELD, result);
+}
+
 /*
  * Sets @error to a method missing error.
  */
@@ -1256,4 +1302,3 @@ mono_error_set_simple_file_not_found (MonoError *error, const char *file_name, g
 	else
 		mono_error_set_file_not_found (error, file_name, "Could not load file or assembly '%s' or one of its dependencies.", file_name);
 }
-

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1236,3 +1236,24 @@ mono_error_set_bad_image (MonoError *error, MonoImage *image, const char *msg_fo
 	if (image)
 		mono_error_set_first_argument (error, mono_image_get_name (image));
 }
+
+void
+mono_error_set_file_not_found (MonoError *error, const char *file_name, const char *msg_format, ...)
+{
+	char *str;
+	SET_ERROR_MSG (str, msg_format);
+
+	mono_error_set_specific (error, MONO_ERROR_FILE_NOT_FOUND, str);
+	if (file_name)
+		mono_error_set_first_argument (error, file_name);
+}
+
+void
+mono_error_set_simple_file_not_found (MonoError *error, const char *file_name, gboolean refection_only)
+{
+	if (refection_only)
+		mono_error_set_file_not_found (error, file_name, "Cannot resolve dependency to assembly because it has not been preloaded. When using the ReflectionOnly APIs, dependent assemblies must be pre-loaded or loaded on demand through the ReflectionOnlyAssemblyResolve event.");
+	else
+		mono_error_set_file_not_found (error, file_name, "Could not load file or assembly '%s' or one of its dependencies.", file_name);
+}
+

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5400,7 +5400,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 
 	if (!image){
 		if (status == MONO_IMAGE_IMAGE_INVALID)
-			mono_error_set_bad_image_name (error, g_strdup (filename), "%s", "");
+			mono_error_set_bad_image_by_name (error, filename, "Invalid Image", "");
 		else
 			mono_error_set_assembly_load (error, g_strdup (filename), "%s", "");
 		g_free (filename);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4970,7 +4970,7 @@ get_manifest_resource_info_internal (MonoReflectionAssemblyHandle assembly_h, Mo
 			i = cols [MONO_MANIFEST_IMPLEMENTATION] >> MONO_IMPLEMENTATION_BITS;
 			mono_assembly_load_reference (assembly->image, i - 1);
 			if (assembly->image->references [i - 1] == REFERENCE_MISSING) {
-				mono_error_set_assembly_load (error, NULL, "Assembly %d referenced from assembly %s not found ", i - 1, assembly->image->name);
+				mono_error_set_file_not_found (error, NULL, "Assembly %d referenced from assembly %s not found ", i - 1, assembly->image->name);
 				goto leave;
 			}
 			MonoReflectionAssemblyHandle assm_obj = mono_assembly_get_object_handle (mono_domain_get (), assembly->image->references [i - 1], error);
@@ -5103,7 +5103,7 @@ add_file_to_modules_array (MonoDomain *domain, MonoArrayHandle dest, int dest_id
 		goto_if_nok (error, leave);
 		if (!m) {
 			const char *filename = mono_metadata_string_heap (image, cols [MONO_FILE_NAME]);
-			mono_error_set_assembly_load (error, g_strdup (filename), "%s", "");
+			mono_error_set_file_not_found (error, filename, "%s", "");
 			goto leave;
 		}
 		MonoReflectionModuleHandle rm = mono_module_get_object_handle (domain, m, error);
@@ -5400,9 +5400,9 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 
 	if (!image){
 		if (status == MONO_IMAGE_IMAGE_INVALID)
-			mono_error_set_bad_image_by_name (error, filename, "Invalid Image", "");
+			mono_error_set_bad_image_by_name (error, filename, "Invalid Image");
 		else
-			mono_error_set_assembly_load (error, g_strdup (filename), "%s", "");
+			mono_error_set_file_not_found (error, filename, "%s", "");
 		g_free (filename);
 		return;
 	}

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -28,6 +28,7 @@
 #include "loader.h"
 #include "marshal.h"
 #include "coree.h"
+#include <mono/metadata/exception-internals.h>
 #include <mono/utils/checked-build.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-path.h>

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -226,7 +226,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 	/* we may want to check the signature here... */
 
 	if (*ptr++ != 0x6) {
-		mono_error_set_field_load (error, klass, fname, "Bad field signature class token %08x field name %s token %08x", class_index, fname, token);
+		mono_error_set_field_missing (error, klass, fname, NULL, "Bad field signature class token %08x field token %08x", class_index, token);
 		return NULL;
 	}
 
@@ -240,7 +240,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 		ERROR_DECL_VALUE (inner_error);
 		sig_type = mono_metadata_parse_type_checked (image, NULL, 0, FALSE, ptr, &ptr, &inner_error);
 		if (sig_type == NULL) {
-			mono_error_set_field_load (error, klass, fname, "Could not parse field '%s' signature %08x due to: %s", fname, token, mono_error_get_message (&inner_error));
+			mono_error_set_field_missing (error, klass, fname, NULL, "Could not parse field signature %08x due to: %s", token, mono_error_get_message (&inner_error));
 			mono_error_cleanup (&inner_error);
 			return NULL;
 		}
@@ -253,7 +253,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 	field = mono_class_get_field_from_name_full (klass, fname, sig_type);
 
 	if (!field) {
-		mono_error_set_field_load (error, klass, fname, "Could not find field '%s'", fname);
+		mono_error_set_field_missing (error, klass, fname, sig_type, "Could not find field in class");
 	}
 
 	return field;

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -525,7 +525,7 @@ find_method (MonoClass *in_class, MonoClass *ic, const char* name, MonoMethodSig
 
 	//we did not find the method
 	if (!result && mono_error_ok (error))
-		mono_error_set_method_load (error, mono_exception_create_missing_method_message (initial_class, name, sig, NULL));
+		mono_error_set_method_missing (error, initial_class, name, sig, NULL);
 		
  out:
 	g_free (class_name);
@@ -841,7 +841,7 @@ method_from_memberref (MonoImage *image, guint32 idx, MonoGenericContext *typesp
 	sig_idx = cols [MONO_MEMBERREF_SIGNATURE];
 
 	if (!mono_verifier_verify_memberref_method_signature (image, sig_idx, NULL)) {
-		mono_error_set_method_load (error, mono_exception_create_missing_method_message (klass, mname, NULL, "Verifier rejected method signature"));
+		mono_error_set_method_missing (error, klass, mname, NULL, "Verifier rejected method signature");
 		goto fail;
 	}
 
@@ -884,7 +884,7 @@ method_from_memberref (MonoImage *image, guint32 idx, MonoGenericContext *typesp
 	}
 
 	if (!method && mono_error_ok (error))
-		mono_error_set_method_load (error, mono_exception_create_missing_method_message (klass, mname, sig, "Failed to load due to unknown reasons"));
+		mono_error_set_method_missing (error, klass, mname, sig, "Failed to load due to unknown reasons");
 
 	return method;
 
@@ -2505,15 +2505,15 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 	/* Verify metadata consistency */
 	if (signature->generic_param_count) {
 		if (!container || !container->is_method) {
-			mono_error_set_method_load (error, mono_exception_create_missing_method_message (m->klass, m->name, signature, "Signature claims method has generic parameters, but generic_params table says it doesn't for method 0x%08x from image %s", idx, img->name));
+			mono_error_set_method_missing (error, m->klass, m->name, signature, "Signature claims method has generic parameters, but generic_params table says it doesn't for method 0x%08x from image %s", idx, img->name);
 			return NULL;
 		}
 		if (container->type_argc != signature->generic_param_count) {
-			mono_error_set_method_load (error, mono_exception_create_missing_method_message (m->klass, m->name, signature, "Inconsistent generic parameter count.  Signature says %d, generic_params table says %d for method 0x%08x from image %s", signature->generic_param_count, container->type_argc, idx, img->name));
+			mono_error_set_method_missing (error, m->klass, m->name, signature, "Inconsistent generic parameter count.  Signature says %d, generic_params table says %d for method 0x%08x from image %s", signature->generic_param_count, container->type_argc, idx, img->name);
 			return NULL;
 		}
 	} else if (container && container->is_method && container->type_argc) {
-		mono_error_set_method_load (error, mono_exception_create_missing_method_message (m->klass, m->name, signature, "generic_params table claims method has generic parameters, but signature says it doesn't for method 0x%08x from image %s", idx, img->name));
+		mono_error_set_method_missing (error, m->klass, m->name, signature, "generic_params table claims method has generic parameters, but signature says it doesn't for method 0x%08x from image %s", idx, img->name);
 		return NULL;
 	}
 	if (m->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) {
@@ -2550,7 +2550,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 		case PINVOKE_ATTRIBUTE_CALL_CONV_GENERIC:
 		case PINVOKE_ATTRIBUTE_CALL_CONV_GENERICINST:
 		default: {
-			mono_error_set_method_load (error, mono_exception_create_missing_method_message (m->klass, m->name, signature, "Unsupported calling convention : 0x%04x for method 0x%08x from image %s", piinfo->piflags, idx, img->name));
+			mono_error_set_method_missing (error, m->klass, m->name, signature, "Unsupported calling convention : 0x%04x for method 0x%08x from image %s", piinfo->piflags, idx, img->name);
 		}
 			return NULL;
 		}

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -9,6 +9,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 #include <config.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/verify.h>
 #include <mono/metadata/verify-internals.h>

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -28,6 +28,7 @@
 #include "marshal.h"
 #include "debug-helpers.h"
 #include "abi-details.h"
+#include <mono/metadata/exception-internals.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/bsearch.h>
 #include <mono/utils/atomic.h>

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -387,6 +387,8 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 		MONO_ADD_INS (cfg->cbb, store);
 
 		mini_emit_write_barrier (cfg, dest, src);
+		return;
+
 	} else if (cfg->gen_write_barriers && (klass->has_references || size_ins) && !native) { 	/* if native is true there should be no references in the struct */
 		/* Avoid barriers when storing to the stack */
 		if (!((dest->opcode == OP_ADD_IMM && dest->sreg1 == cfg->frame_reg) ||

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4519,7 +4519,7 @@ emit_array_generic_access (MonoCompile *cfg, MonoMethodSignature *fsig, MonoInst
 
 
 static gboolean
-generic_class_is_reference_type (MonoCompile *cfg, MonoClass *klass)
+mini_class_is_reference (MonoClass *klass)
 {
 	return mini_type_is_reference (&klass->byval_arg);
 }
@@ -4527,7 +4527,7 @@ generic_class_is_reference_type (MonoCompile *cfg, MonoClass *klass)
 static MonoInst*
 emit_array_store (MonoCompile *cfg, MonoClass *klass, MonoInst **sp, gboolean safety_checks)
 {
-	if (safety_checks && generic_class_is_reference_type (cfg, klass) &&
+	if (safety_checks && mini_class_is_reference (klass) &&
 		!(MONO_INS_IS_PCONST_NULL (sp [2]))) {
 		MonoClass *obj_array = mono_array_class_get_cached (mono_defaults.object_class, 1);
 		MonoMethod *helper = mono_marshal_get_virtual_stelemref (obj_array);
@@ -4571,7 +4571,7 @@ emit_array_store (MonoCompile *cfg, MonoClass *klass, MonoInst **sp, gboolean sa
 		} else {
 			MonoInst *addr = mini_emit_ldelema_1_ins (cfg, klass, sp [0], sp [1], safety_checks);
 			EMIT_NEW_STORE_MEMBASE_TYPE (cfg, ins, &klass->byval_arg, addr->dreg, 0, sp [2]->dreg);
-			if (generic_class_is_reference_type (cfg, klass))
+			if (mini_class_is_reference (klass))
 				mini_emit_write_barrier (cfg, addr, sp [2]);
 		}
 		return ins;
@@ -10088,7 +10088,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (mini_is_gsharedvt_klass (klass)) {
 				res = handle_unbox_gsharedvt (cfg, klass, *sp);
 				inline_costs += 2;
-			} else if (generic_class_is_reference_type (cfg, klass)) {
+			} else if (mini_class_is_reference (klass)) {
 				if (MONO_INS_IS_PCONST_NULL (*sp)) {
 					EMIT_NEW_PCONST (cfg, res, NULL);
 					res->type = STACK_OBJ;
@@ -10132,7 +10132,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			context_used = mini_class_check_context_used (cfg, klass);
 
-			if (generic_class_is_reference_type (cfg, klass)) {
+			if (mini_class_is_reference (klass)) {
 				*sp++ = val;
 				ip += 5;
 				break;
@@ -12551,7 +12551,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				token = read32 (ip + 2);
 				klass = mini_get_class (method, token, generic_context);
 				CHECK_TYPELOAD (klass);
-				if (generic_class_is_reference_type (cfg, klass))
+				if (mini_class_is_reference (klass))
 					MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STORE_MEMBASE_IMM, sp [0]->dreg, 0, 0);
 				else
 					mini_emit_initobj (cfg, *sp, NULL, klass);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -10580,7 +10580,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			context_used = mini_class_check_context_used (cfg, klass);
 
 			if (ftype->attrs & FIELD_ATTRIBUTE_LITERAL) {
-				mono_error_set_field_load (&cfg->error, field->parent, field->name, "Using static instructions with literal field");
+				mono_error_set_field_missing (&cfg->error, field->parent, field->name, NULL, "Using static instructions with literal field");
 				CHECK_CFG_ERROR;
 			}
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -45,6 +45,7 @@
 #include <mono/metadata/class.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/exception.h>
+#include <mono/metadata/exception-internals.h>
 #include <mono/metadata/opcodes.h>
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/tokentype.h>

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9763,7 +9763,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			}
 
 			/* Optimize the ldobj+stobj combination */
-			if (((ip [5] == CEE_STOBJ) && ip_in_bb (cfg, cfg->cbb, ip + 5) && read32 (ip + 6) == token) && !generic_class_is_reference_type (cfg, klass)) {
+			if (((ip [5] == CEE_STOBJ) && ip_in_bb (cfg, cfg->cbb, ip + 5) && read32 (ip + 6) == token)) {
 				CHECK_STACK (1);
 
 				sp --;

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -150,12 +150,6 @@ void
 mono_error_set_error (MonoError *error, int error_code, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_assembly_load (MonoError *error, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
-
-void
-mono_error_set_assembly_load_simple (MonoError *error, const char *assembly_name, gboolean refection_only);
-
-void
 mono_error_set_type_load_class (MonoError *error, MonoClass *klass, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
@@ -193,9 +187,6 @@ mono_error_set_not_supported (MonoError *error, const char *msg_format, ...) MON
 
 void
 mono_error_set_invalid_operation (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
-
-void
-mono_error_set_file_not_found (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
 mono_error_set_exception_instance (MonoError *error, MonoException *exc);

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -165,9 +165,6 @@ void
 mono_error_set_type_load_name (MonoError *error, const char *type_name, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_method_load (MonoError *oerror, const char *missing_method);
-
-void
 mono_error_set_field_load (MonoError *error, MonoClass *klass, const char *field_name, const char *msg_format, ...)  MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
@@ -232,5 +229,8 @@ mono_error_set_from_boxed (MonoError *error, const MonoErrorBoxed *from);
 
 const char*
 mono_error_get_exception_name (MonoError *oerror);
+
+void
+mono_error_set_specific (MonoError *oerror, int error_code, const char *missing_method);
 
 #endif

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -168,12 +168,6 @@ void
 mono_error_set_field_load (MonoError *error, MonoClass *klass, const char *field_name, const char *msg_format, ...)  MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_bad_image (MonoError *error, MonoImage *image, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
-
-void
-mono_error_set_bad_image_name (MonoError *error, const char *file_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
-
-void
 mono_error_set_out_of_memory (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
@@ -231,6 +225,9 @@ const char*
 mono_error_get_exception_name (MonoError *oerror);
 
 void
-mono_error_set_specific (MonoError *oerror, int error_code, const char *missing_method);
+mono_error_set_specific (MonoError *error, int error_code, const char *missing_method);
+
+void
+mono_error_set_first_argument (MonoError *oerror, const char *first_argument);
 
 #endif

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -159,9 +159,6 @@ void
 mono_error_set_type_load_name (MonoError *error, const char *type_name, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_field_load (MonoError *error, MonoClass *klass, const char *field_name, const char *msg_format, ...)  MONO_ATTR_FORMAT_PRINTF(4,5);
-
-void
 mono_error_set_out_of_memory (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -32,9 +32,8 @@ typedef struct {
 	const char *full_message;
 	const char *full_message_with_fields;
 	const char *first_argument;
-	const char *member_signature;
 
-	void *padding [2];
+	void *padding [3];
 } MonoErrorInternal;
 
 /* Invariant: the error strings are allocated in the mempool of the given image */
@@ -166,7 +165,7 @@ void
 mono_error_set_type_load_name (MonoError *error, const char *type_name, const char *assembly_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(4,5);
 
 void
-mono_error_set_method_load (MonoError *oerror, MonoClass *klass, const char *method_name, const char *signature, const char *msg_format, ...);
+mono_error_set_method_load (MonoError *oerror, const char *missing_method);
 
 void
 mono_error_set_field_load (MonoError *error, MonoClass *klass, const char *field_name, const char *msg_format, ...)  MONO_ATTR_FORMAT_PRINTF(4,5);

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -344,13 +344,18 @@ mono_error_set_type_load_name (MonoError *oerror, const char *type_name, const c
 	set_error_message ();
 }
 
+/*
+ * Sets @error to be of type @error_code with message @message
+ * XXX only works for MONO_ERROR_MISSING_METHOD for now
+*/
+
 void
-mono_error_set_method_load (MonoError *oerror, const char *message)
+mono_error_set_specific (MonoError *oerror, int error_code, const char *message)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 	mono_error_prepare (error);
 
-	error->error_code = MONO_ERROR_MISSING_METHOD;
+	error->error_code = error_code;
 	error->full_message = message;
 }
 

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -190,12 +190,13 @@ mono_error_get_message (MonoError *oerror)
 	if (error->full_message_with_fields)
 		return error->full_message_with_fields;
 
-	error->full_message_with_fields = g_strdup_printf ("%s assembly:%s type:%s member:%s signature:%s",
+	error->full_message_with_fields = g_strdup_printf ("%s assembly:%s type:%s member:%s%s%s",
 		error->full_message,
 		get_assembly_name (error),
 		get_type_name (error),
-		error->member_signature,
-		error->member_name ? error->member_name : "<none>");
+		error->member_name ? error->member_name : "<none>",
+		error->member_signature ? " signature:" : "",
+		error->member_signature);
 
 	return error->full_message_with_fields ? error->full_message_with_fields : error->full_message;
 }

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -53,7 +53,7 @@ mono_error_prepare (MonoErrorInternal *error)
 	if (error->error_code != MONO_ERROR_NONE)
 		return;
 
-	error->type_name = error->assembly_name = error->member_name = error->full_message = error->exception_name_space = error->exception_name = error->full_message_with_fields = error->first_argument = error->member_signature = NULL;
+	error->type_name = error->assembly_name = error->member_name = error->full_message = error->exception_name_space = error->exception_name = error->full_message_with_fields = error->first_argument = NULL;
 	error->exn.klass = NULL;
 }
 
@@ -150,8 +150,7 @@ mono_error_cleanup (MonoError *oerror)
 	g_free ((char*)error->exception_name_space);
 	g_free ((char*)error->exception_name);
 	g_free ((char*)error->first_argument);
-	g_free ((char*)error->member_signature);
-	error->type_name = error->assembly_name = error->member_name = error->exception_name_space = error->exception_name = error->first_argument = error->member_signature = NULL;
+	error->type_name = error->assembly_name = error->member_name = error->exception_name_space = error->exception_name = error->first_argument = NULL;
 	error->exn.klass = NULL;
 
 }
@@ -187,16 +186,19 @@ mono_error_get_message (MonoError *oerror)
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 	if (error->error_code == MONO_ERROR_NONE)
 		return NULL;
+
+	//MME is a simplified error
+	if (error->error_code == MONO_ERROR_MISSING_METHOD)
+		return error->full_message;
+
 	if (error->full_message_with_fields)
 		return error->full_message_with_fields;
 
-	error->full_message_with_fields = g_strdup_printf ("%s assembly:%s type:%s member:%s%s%s",
+	error->full_message_with_fields = g_strdup_printf ("%s assembly:%s type:%s member:%s",
 		error->full_message,
 		get_assembly_name (error),
 		get_type_name (error),
-		error->member_name ? error->member_name : "<none>",
-		error->member_signature ? " signature:" : "",
-		error->member_signature);
+		error->member_name);
 
 	return error->full_message_with_fields ? error->full_message_with_fields : error->full_message;
 }
@@ -224,7 +226,6 @@ mono_error_dup_strings (MonoError *oerror, gboolean dup_strings)
 		DUP_STR (exception_name_space);
 		DUP_STR (exception_name);
 		DUP_STR (first_argument);
-		DUP_STR (member_signature);
 	}
 #undef DUP_STR
 }
@@ -254,14 +255,6 @@ mono_error_set_member_name (MonoError *oerror, const char *member_name)
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 
 	error->member_name = member_name;
-}
-
-static void
-mono_error_set_member_signature (MonoError *oerror, const char *member_signature)
-{
-	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
-
-	error->member_signature = member_signature;
 }
 
 static void
@@ -352,16 +345,13 @@ mono_error_set_type_load_name (MonoError *oerror, const char *type_name, const c
 }
 
 void
-mono_error_set_method_load (MonoError *oerror, MonoClass *klass, const char *method_name, const char *signature, const char *msg_format, ...)
+mono_error_set_method_load (MonoError *oerror, const char *message)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 	mono_error_prepare (error);
 
 	error->error_code = MONO_ERROR_MISSING_METHOD;
-	mono_error_set_class (oerror, klass);
-	mono_error_set_member_name (oerror, method_name);
-	mono_error_set_member_signature (oerror, signature);
-	set_error_message ();
+	error->full_message = message;
 }
 
 void
@@ -631,7 +621,7 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 
 	MonoException* exception = NULL;
-	MonoString *assembly_name = NULL, *type_name = NULL, *method_name = NULL, *field_name = NULL, *msg = NULL;
+	MonoString *assembly_name = NULL, *type_name = NULL, *field_name = NULL, *msg = NULL;
 	MonoDomain *domain = mono_domain_get ();
 
 	error_init (error_out);
@@ -641,40 +631,10 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 		return NULL;
 
 	case MONO_ERROR_MISSING_METHOD:
-		if ((error->type_name || error->exn.klass) && error->member_name) {
-			type_name = get_type_name_as_mono_string (error, domain, error_out);
-			if (!mono_error_ok (error_out))
-				break;
-
-			method_name = string_new_cleanup (domain, error->member_name);
-			if (!method_name) {
-				mono_error_set_out_of_memory (error_out, "Could not allocate method name");
-				break;
-			}
-
-			MonoString *signature = NULL;
-			if (error->member_signature) {
-				signature = string_new_cleanup (domain, error->member_signature);
-				if (!signature) {
-					mono_error_set_out_of_memory (error_out, "Could not allocate signature");
-					break;
-				}
-			}
-
-			MonoString *message = NULL;
-			if (error->full_message && strlen (error->full_message) > 0) {
-				message = string_new_cleanup (domain, error->full_message);
-				if (!message) {
-					mono_error_set_out_of_memory (error_out, "Could not allocate message");
-					break;
-				}
-			}
-			exception = mono_exception_from_name_four_strings_checked (mono_defaults.corlib, "System", "MissingMethodException", type_name, method_name, signature, message, error_out);
-			if (exception)
-				set_message_on_exception (exception, error, error_out);
-		} else {
+		if (error->full_message)
 			exception = mono_exception_from_name_msg (mono_defaults.corlib, "System", "MissingMethodException", error->full_message);
-		}
+		else
+			exception = mono_exception_from_name_msg (mono_defaults.corlib, "System", "MissingMethodException", "Unknown Error");
 		break;
 
 	case MONO_ERROR_MISSING_FIELD:
@@ -890,7 +850,6 @@ mono_error_box (const MonoError *ierror, MonoImage *image)
 	DUP_STR (full_message);
 	DUP_STR (full_message_with_fields);
 	DUP_STR (first_argument);
-	DUP_STR (member_signature);
 	to->exn.klass = from->exn.klass;
 
 #undef DUP_STR
@@ -937,7 +896,6 @@ mono_error_set_from_boxed (MonoError *oerror, const MonoErrorBoxed *box)
 	DUP_STR (full_message);
 	DUP_STR (full_message_with_fields);
 	DUP_STR (first_argument);
-	DUP_STR (member_signature);
 	to->exn.klass = from->exn.klass;
 		  
 #undef DUP_STR

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -338,6 +338,7 @@ mono_error_set_specific (MonoError *oerror, int error_code, const char *message)
 
 	error->error_code = error_code;
 	error->full_message = message;
+	error->flags |= MONO_ERROR_FREE_STRINGS;
 }
 
 void
@@ -802,4 +803,5 @@ mono_error_set_first_argument (MonoError *oerror, const char *first_argument)
 {
 	MonoErrorInternal* to = (MonoErrorInternal*)oerror;
 	to->first_argument = g_strdup (first_argument);
+	to->flags |= MONO_ERROR_FREE_STRINGS;
 }


### PR DESCRIPTION
MonoError is simplified for MME by having the error message eagerly created, which simplifies things A LOT.
Managed Exception creation is simplified by only setting Message, as it's done by other runtimes.

The idea of this PR is gather feedback on this approach and the way it was implemenented. If it's good, I'll do for other errors.