### PR TITLE
Add install of Visual Basic compiler

### DIFF
--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -10,6 +10,9 @@ ROSLYN_FILES_FOR_MONO = \
 	$(ROSLYN_CSC_DIR)/csi.exe				\
 	$(ROSLYN_CSC_DIR)/csi.exe.config			\
 	$(ROSLYN_CSC_DIR)/csi.rsp				\
+	$(ROSLYN_CSC_DIR)/vbc.exe				\
+	$(ROSLYN_CSC_DIR)/vbc.exe.config			\
+	$(ROSLYN_CSC_DIR)/vbc.rsp				\
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.CSharp.dll	\
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.CSharp.Scripting.dll \
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.VisualBasic.dll \

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -87,6 +87,7 @@
 /sgen1
 /signcode
 /csc
+/vbc
 /sn
 /soapsuds
 /sqlmetal

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -36,7 +36,8 @@ bin_SCRIPTS = \
 	mono-test-install	\
 	peverify		\
 	mcs			\
-	csc					\
+	csc			\
+	vbc			\
 	csi			\
 	mono-package-runtime	\
 	mono-heapviz		\
@@ -207,6 +208,10 @@ mcs: mcs.in Makefile
 
 csc: csc.in Makefile
 	$(REWRITE_COMMON) $(srcdir)/csc.in > $@.tmp
+	mv -f $@.tmp $@
+
+vbc: vbc.in Makefile
+	$(REWRITE_COMMON) $(srcdir)/vbc.in > $@.tmp
 	mv -f $@.tmp $@
 
 dmcs: dmcs.in Makefile

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -158,6 +158,7 @@ EXTRA_DIST =			\
 	update_submodules.sh	\
 	mcs.in				\
 	csc.in				\
+	vbc.in				\
 	dmcs.in				\
 	csi.in			\
 	mono-package-runtime	\

--- a/scripts/vbc.in
+++ b/scripts/vbc.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec @bindir@/mono --gc-params=nursery-size=64m $MONO_OPTIONS @mono_instdir@/4.5/vbc.exe "$@"


### PR DESCRIPTION
This is a follow on to https://github.com/mono/roslyn-binaries/pull/3 which adds the Roslyn VB.NET compiler to the roslyn-binaries repo. This will then install the binaries to the mono installation.