### PR TITLE
[profiler] Ensure the profilers behave sensibly when loaded during AOT compilation.

### DIFF
--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -16,6 +16,7 @@
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/class-internals.h>
+#include <mono/mini/jit.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-os-mutex.h>
 #include <string.h>
@@ -166,6 +167,11 @@ mono_profiler_init_aot (const char *desc);
 void
 mono_profiler_init_aot (const char *desc)
 {
+	if (mono_jit_aot_compiling ()) {
+		mono_profiler_printf_err ("The AOT profiler is not meant to be run during AOT compilation.");
+		exit (1);
+	}
+
 	parse_args (desc [strlen ("aot")] == ':' ? desc + strlen ("aot") + 1 : "");
 
 	if (!aot_profiler.outfile_name)

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -75,6 +75,8 @@
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/metadata-internals.h>
 
+#include <mono/mini/jit.h>
+
 #include <mono/utils/atomic.h>
 #include <mono/utils/hazard-pointer.h>
 #include <mono/utils/lock-free-queue.h>
@@ -723,7 +725,7 @@ unref_coverage_assemblies (gpointer key, gpointer value, gpointer userdata)
 }
 
 static void
-log_shutdown (MonoProfiler *prof)
+cov_shutdown (MonoProfiler *prof)
 {
 	g_assert (prof == &coverage_profiler);
 
@@ -888,6 +890,11 @@ mono_profiler_init_coverage (const char *desc);
 void
 mono_profiler_init_coverage (const char *desc)
 {
+	if (mono_jit_aot_compiling ()) {
+		mono_profiler_printf_err ("The coverage profiler does not currently support instrumenting AOT code.");
+		exit (1);
+	}
+
 	GPtrArray *filters = NULL;
 
 	parse_args (desc [strlen("coverage")] == ':' ? desc + strlen ("coverage") + 1 : "");
@@ -934,13 +941,7 @@ mono_profiler_init_coverage (const char *desc)
 
 	MonoProfilerHandle handle = coverage_profiler.handle = mono_profiler_create (&coverage_profiler);
 
-	/*
-	 * Required callbacks. These are either necessary for the profiler itself
-	 * to function, or provide metadata that's needed if other events (e.g.
-	 * allocations, exceptions) are dynamically enabled/disabled.
-	 */
-
-	mono_profiler_set_runtime_shutdown_end_callback (handle, log_shutdown);
+	mono_profiler_set_runtime_shutdown_end_callback (handle, cov_shutdown);
 	mono_profiler_set_runtime_initialized_callback (handle, runtime_initialized);
 
 	mono_profiler_enable_coverage ();

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -20,6 +20,7 @@
 #include <mono/metadata/mono-gc.h>
 #include <mono/metadata/mono-perfcounters.h>
 #include <mono/metadata/tabledefs.h>
+#include <mono/mini/jit.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/hazard-pointer.h>
 #include <mono/utils/lock-free-alloc.h>
@@ -4612,19 +4613,11 @@ create_profiler (const char *args, const char *filename, GPtrArray *filters)
 		log_profiler.gzfile = gzdopen (fileno (log_profiler.file), "wb");
 #endif
 
-	/*
-	 * If you hit this assert while increasing MAX_FRAMES, you need to increase
-	 * SAMPLE_BLOCK_SIZE as well.
-	 */
-	g_assert (SAMPLE_SLOT_SIZE (MAX_FRAMES) * 2 < LOCK_FREE_ALLOC_SB_USABLE_SIZE (SAMPLE_BLOCK_SIZE));
-
 	// FIXME: We should free this stuff too.
 	mono_lock_free_allocator_init_size_class (&log_profiler.sample_size_class, SAMPLE_SLOT_SIZE (log_config.num_frames), SAMPLE_BLOCK_SIZE);
 	mono_lock_free_allocator_init_allocator (&log_profiler.sample_allocator, &log_profiler.sample_size_class, MONO_MEM_ACCOUNT_PROFILER);
 
 	mono_lock_free_queue_init (&log_profiler.sample_reuse_queue);
-
-	g_assert (sizeof (WriterQueueEntry) * 2 < LOCK_FREE_ALLOC_SB_USABLE_SIZE (WRITER_ENTRY_BLOCK_SIZE));
 
 	// FIXME: We should free this stuff too.
 	mono_lock_free_allocator_init_size_class (&log_profiler.writer_entry_size_class, sizeof (WriterQueueEntry), WRITER_ENTRY_BLOCK_SIZE);
@@ -4653,6 +4646,13 @@ mono_profiler_init_log (const char *desc);
 void
 mono_profiler_init_log (const char *desc)
 {
+	/*
+	 * If you hit this assert while increasing MAX_FRAMES, you need to increase
+	 * SAMPLE_BLOCK_SIZE as well.
+	 */
+	g_assert (SAMPLE_SLOT_SIZE (MAX_FRAMES) * 2 < LOCK_FREE_ALLOC_SB_USABLE_SIZE (SAMPLE_BLOCK_SIZE));
+	g_assert (sizeof (WriterQueueEntry) * 2 < LOCK_FREE_ALLOC_SB_USABLE_SIZE (WRITER_ENTRY_BLOCK_SIZE));
+
 	GPtrArray *filters = NULL;
 
 	proflog_parse_args (&log_config, desc [3] == ':' ? desc + 4 : "");
@@ -4666,6 +4666,18 @@ mono_profiler_init_log (const char *desc)
 		}
 	}
 
+	MonoProfilerHandle handle = log_profiler.handle = mono_profiler_create (&log_profiler);
+
+	if (log_config.enter_leave)
+		mono_profiler_set_call_instrumentation_filter_callback (handle, method_filter);
+
+	/*
+	 * If the runtime was invoked for the purpose of AOT compilation only, the
+	 * only thing we want to do is install the call instrumentation filter.
+	 */
+	if (mono_jit_aot_compiling ())
+		goto done;
+
 	init_time ();
 
 	PROF_TLS_INIT ();
@@ -4673,8 +4685,6 @@ mono_profiler_init_log (const char *desc)
 	create_profiler (desc, log_config.output_filename, filters);
 
 	mono_lls_init (&log_profiler.profiler_thread_list, NULL);
-
-	MonoProfilerHandle handle = log_profiler.handle = mono_profiler_create (&log_profiler);
 
 	/*
 	 * Required callbacks. These are either necessary for the profiler itself
@@ -4750,7 +4760,6 @@ mono_profiler_init_log (const char *desc)
 		mono_profiler_set_jit_code_buffer_callback (handle, code_buffer_new);
 
 	if (log_config.enter_leave) {
-		mono_profiler_set_call_instrumentation_filter_callback (handle, method_filter);
 		mono_profiler_set_method_enter_callback (handle, method_enter);
 		mono_profiler_set_method_leave_callback (handle, method_leave);
 		mono_profiler_set_method_tail_call_callback (handle, tail_call);
@@ -4772,4 +4781,7 @@ mono_profiler_init_log (const char *desc)
 	 */
 	if (!mono_profiler_set_sample_mode (handle, log_config.sampling_mode, log_config.sample_freq))
 		mono_profiler_printf_err ("Another profiler controls sampling parameters; the log profiler will not be able to modify them.");
+
+done:
+	;
 }


### PR DESCRIPTION
The AOT profiler is not meant to be loaded during AOT compilation.

The coverage profiler does not currently support instrumentation of AOT code.

The log profiler does support enter/leave instrumentation of AOT code, but no other functionality should be enabled in this case. We only want to set the call instrumentation filter callback and then return control to the runtime.