### PR TITLE
[w32handle] Don't enter GC SAFE around calls to w32handle_wait_{one,multiple}

### DIFF
--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -1386,13 +1386,13 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 	 * is private to this thread.  Therefore even if the event was
 	 * signalled before we wait, we still succeed.
 	 */
-	MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
+	MONO_ENTER_GC_SAFE;
 	ret = mono_w32handle_convert_wait_ret (mono_win32_wait_for_single_object_ex (event, ms, TRUE), 1);
+	MONO_EXIT_GC_SAFE;
 #else
 	ret = mono_w32handle_wait_one (event, ms, TRUE);
 #endif /* HOST_WIN32 */
-	MONO_EXIT_GC_SAFE;
 
 	/* Reset the thread state fairly early, so we don't have to worry
 	 * about the monitor error checking
@@ -1415,13 +1415,13 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 		/* Poll the event again, just in case it was signalled
 		 * while we were trying to regain the monitor lock
 		 */
-		MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
+		MONO_ENTER_GC_SAFE;
 		ret = mono_w32handle_convert_wait_ret (mono_win32_wait_for_single_object_ex (event, 0, FALSE), 1);
+		MONO_EXIT_GC_SAFE;
 #else
 		ret = mono_w32handle_wait_one (event, 0, FALSE);
 #endif /* HOST_WIN32 */
-		MONO_EXIT_GC_SAFE;
 	}
 
 	/* Pulse will have popped our event from the queue if it signalled

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -497,13 +497,13 @@ mono_threadpool_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, MonoObj
 			MONO_OBJECT_SETREF (ares, handle, (MonoObject*) wait_handle);
 		}
 		mono_monitor_exit ((MonoObject*) ares);
-		MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
+		MONO_ENTER_GC_SAFE;
 		mono_win32_wait_for_single_object_ex (wait_event, INFINITE, TRUE);
+		MONO_EXIT_GC_SAFE;
 #else
 		mono_w32handle_wait_one (wait_event, MONO_INFINITE_WAIT, TRUE);
 #endif
-		MONO_EXIT_GC_SAFE;
 	}
 
 	ac = (MonoAsyncCall*) ares->object_data;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1912,17 +1912,17 @@ ves_icall_System_Threading_WaitHandle_Wait_internal (gpointer *handles, gint32 n
 	timeoutLeft = timeout;
 
 	for (;;) {
-		MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
+		MONO_ENTER_GC_SAFE;
 		if (numhandles != 1)
 			ret = mono_w32handle_convert_wait_ret (mono_win32_wait_for_multiple_objects_ex(numhandles, handles, waitall, timeoutLeft, TRUE), numhandles);
 		else
 			ret = mono_w32handle_convert_wait_ret (mono_win32_wait_for_single_object_ex (handles [0], timeoutLeft, TRUE), 1);
+		MONO_EXIT_GC_SAFE;
 #else
 		/* mono_w32handle_wait_multiple optimizes the case for numhandles == 1 */
 		ret = mono_w32handle_wait_multiple (handles, numhandles, waitall, timeoutLeft, TRUE);
 #endif /* HOST_WIN32 */
-		MONO_EXIT_GC_SAFE;
 
 		if (ret != MONO_W32HANDLE_WAIT_RET_ALERTED)
 			break;
@@ -4459,7 +4459,9 @@ mono_thread_execute_interruption (void)
 
 	/* this will consume pending APC calls */
 #ifdef HOST_WIN32
+	MONO_ENTER_GC_SAFE;
 	mono_win32_wait_for_single_object_ex (GetCurrentThread (), 0, TRUE);
+	MONO_EXIT_GC_SAFE;
 #endif
 
 	/* Clear the interrupted flag of the thread so it can wait again */

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -134,7 +134,7 @@ typedef struct {
  */
 typedef struct _Process {
 	pid_t pid; /* the pid of the process. This value is only valid until the process has exited. */
-	MonoSemType exit_sem; /* this semaphore will be released when the process exits */
+	MonoCoopSem exit_sem; /* this semaphore will be released when the process exits */
 	int status; /* the exit status */
 	gint32 handle_count; /* the number of handles to this process instance */
 	/* we keep a ref to the creating _WapiHandle_process handle until
@@ -528,7 +528,7 @@ static mono_lazy_init_t process_sig_chld_once = MONO_LAZY_INIT_STATUS_NOT_INITIA
 static gchar *cli_launcher;
 
 static Process *processes;
-static mono_mutex_t processes_mutex;
+static MonoCoopMutex processes_mutex;
 
 static pid_t current_pid;
 static gpointer current_process;
@@ -645,16 +645,16 @@ process_wait (MonoW32Handle *handle_data, guint32 timeout, gboolean *alerted)
 		if (timeout != MONO_INFINITE_WAIT) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %" G_GUINT32_FORMAT "): waiting on semaphore for %" G_GINT64_FORMAT " ms...",
 				__func__, handle_data, timeout, timeout - (now - start));
-			ret = mono_os_sem_timedwait (&process->exit_sem, (timeout - (now - start)), alerted ? MONO_SEM_FLAGS_ALERTABLE : MONO_SEM_FLAGS_NONE);
+			ret = mono_coop_sem_timedwait (&process->exit_sem, (timeout - (now - start)), alerted ? MONO_SEM_FLAGS_ALERTABLE : MONO_SEM_FLAGS_NONE);
 		} else {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s (%p, %" G_GUINT32_FORMAT "): waiting on semaphore forever...",
 				__func__, handle_data, timeout);
-			ret = mono_os_sem_wait (&process->exit_sem, alerted ? MONO_SEM_FLAGS_ALERTABLE : MONO_SEM_FLAGS_NONE);
+			ret = mono_coop_sem_wait (&process->exit_sem, alerted ? MONO_SEM_FLAGS_ALERTABLE : MONO_SEM_FLAGS_NONE);
 		}
 
 		if (ret == MONO_SEM_TIMEDWAIT_RET_SUCCESS) {
 			/* Success, process has exited */
-			mono_os_sem_post (&process->exit_sem);
+			mono_coop_sem_post (&process->exit_sem);
 			break;
 		}
 
@@ -722,7 +722,7 @@ processes_cleanup (void)
 		}
 	}
 
-	mono_os_mutex_lock (&processes_mutex);
+	mono_coop_mutex_lock (&processes_mutex);
 
 	for (process = processes; process;) {
 		Process *next = process->next;
@@ -735,7 +735,7 @@ processes_cleanup (void)
 			else
 				prev->next = process->next;
 
-			mono_os_sem_destroy (&process->exit_sem);
+			mono_coop_sem_destroy (&process->exit_sem);
 			g_free (process);
 		} else {
 			prev = process;
@@ -743,7 +743,7 @@ processes_cleanup (void)
 		process = next;
 	}
 
-	mono_os_mutex_unlock (&processes_mutex);
+	mono_coop_mutex_unlock (&processes_mutex);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER, "%s done", __func__);
 
@@ -827,7 +827,7 @@ mono_w32process_init (void)
 	current_process = mono_w32handle_new (MONO_W32TYPE_PROCESS, &process_handle);
 	g_assert (current_process != INVALID_HANDLE_VALUE);
 
-	mono_os_mutex_init (&processes_mutex);
+	mono_coop_mutex_init (&processes_mutex);
 }
 
 void
@@ -1413,7 +1413,7 @@ mono_w32process_signal_finished (void)
 		if (pid <= 0)
 			break;
 
-		mono_os_mutex_lock (&processes_mutex);
+		mono_coop_mutex_lock (&processes_mutex);
 
 		for (process = processes; process; process = process->next) {
 			if (process->pid != pid)
@@ -1423,11 +1423,11 @@ mono_w32process_signal_finished (void)
 
 			process->signalled = TRUE;
 			process->status = status;
-			mono_os_sem_post (&process->exit_sem);
+			mono_coop_sem_post (&process->exit_sem);
 			break;
 		}
 
-		mono_os_mutex_unlock (&processes_mutex);
+		mono_coop_mutex_unlock (&processes_mutex);
 	} while (1);
 }
 
@@ -2026,7 +2026,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		process = (Process *) g_malloc0 (sizeof (Process));
 		process->pid = pid;
 		process->handle_count = 1;
-		mono_os_sem_init (&process->exit_sem, 0);
+		mono_coop_sem_init (&process->exit_sem, 0);
 
 		process_handle.process = process;
 
@@ -2034,7 +2034,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		if (handle == INVALID_HANDLE_VALUE) {
 			g_warning ("%s: error creating process handle", __func__);
 
-			mono_os_sem_destroy (&process->exit_sem);
+			mono_coop_sem_destroy (&process->exit_sem);
 			g_free (process);
 
 			mono_w32error_set_last (ERROR_OUTOFMEMORY);
@@ -2052,11 +2052,11 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		 * exits so that the information in the handle isn't lost. */
 		process->handle = mono_w32handle_duplicate (handle_data);
 
-		mono_os_mutex_lock (&processes_mutex);
+		mono_coop_mutex_lock (&processes_mutex);
 		process->next = processes;
 		mono_memory_barrier ();
 		processes = process;
-		mono_os_mutex_unlock (&processes_mutex);
+		mono_coop_mutex_unlock (&processes_mutex);
 
 		if (process_info != NULL) {
 			process_info->process_handle = handle;

--- a/mono/tests/assembly_append_ordering.cs
+++ b/mono/tests/assembly_append_ordering.cs
@@ -32,6 +32,7 @@ class Driver {
 		return 0;
 	}
 
+	[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
 	static Assembly TriggerLoadingSystemCore ()
 	{
 		int[] x = new int[] { 1,2,3};


### PR DESCRIPTION
On non-Win32, the `mono_w32handle_wait_{one,multiple}` implementation is
coop-aware, so there's no need to enter/exit GC Safe.

On Win32, `mono_win32_wait_for_{single_object,multiple_objects}_ex` is not coop
aware (and can't be - because it's called from `utils/os-event-win32.c` which is
not supposed to use coop machinery), so do GC transitions around these calls.

Fixes cooperative GC regression due to f5fc77351251abb01a196781b7a76f6b5b7e0e7a