### PR TITLE
[profiler] Correctly encode counter type/unit/variance values.

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogProcessor.cs
@@ -373,8 +373,8 @@ namespace Mono.Profiler.Log {
 				case LogEventType.MonitorBacktrace:
 					ev = new MonitorEvent {
 						Event = StreamHeader.FormatVersion >= 14 ?
-						                    (LogMonitorEvent) _reader.ReadByte () :
-						                    (LogMonitorEvent) ((((byte) type & 0xf0) >> 4) & 0x3),
+						        (LogMonitorEvent) _reader.ReadByte () :
+						        (LogMonitorEvent) ((((byte) type & 0xf0) >> 4) & 0x3),
 						ObjectPointer = ReadObject (),
 						Backtrace = ReadBacktrace (extType == LogEventType.MonitorBacktrace),
 					};
@@ -476,9 +476,9 @@ namespace Mono.Profiler.Log {
 							Section = section,
 							SectionName = section == LogCounterSection.User ? _reader.ReadCString () : null,
 							CounterName = _reader.ReadCString (),
-							Type = (LogCounterType) _reader.ReadByte (),
-							Unit = (LogCounterUnit) _reader.ReadByte (),
-							Variance = (LogCounterVariance) _reader.ReadByte (),
+							Type = StreamHeader.FormatVersion < 15 ? (LogCounterType) _reader.ReadByte () : (LogCounterType) _reader.ReadULeb128 (),
+							Unit = StreamHeader.FormatVersion < 15 ? (LogCounterUnit) _reader.ReadByte () : (LogCounterUnit) _reader.ReadULeb128 (),
+							Variance = StreamHeader.FormatVersion < 15 ? (LogCounterVariance) _reader.ReadByte () : (LogCounterVariance) _reader.ReadULeb128 (),
 							Index = (long) _reader.ReadULeb128 (),
 						};
 					}
@@ -498,7 +498,7 @@ namespace Mono.Profiler.Log {
 						if (index == 0)
 							break;
 
-						var counterType = (LogCounterType) _reader.ReadByte ();
+						var counterType = StreamHeader.FormatVersion < 15 ? (LogCounterType) _reader.ReadByte () : (LogCounterType) _reader.ReadULeb128 ();
 
 						object value = null;
 

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -2657,9 +2657,9 @@ counters_emit (void)
 		name = mono_counter_get_name (agent->counter);
 		emit_value (logbuffer, mono_counter_get_section (agent->counter));
 		emit_string (logbuffer, name, strlen (name) + 1);
-		emit_byte (logbuffer, mono_counter_get_type (agent->counter));
-		emit_byte (logbuffer, mono_counter_get_unit (agent->counter));
-		emit_byte (logbuffer, mono_counter_get_variance (agent->counter));
+		emit_value (logbuffer, mono_counter_get_type (agent->counter));
+		emit_value (logbuffer, mono_counter_get_unit (agent->counter));
+		emit_value (logbuffer, mono_counter_get_variance (agent->counter));
 		emit_value (logbuffer, agent->index);
 
 		agent->emitted = TRUE;
@@ -2746,7 +2746,7 @@ counters_sample (uint64_t timestamp)
 		}
 
 		emit_uvalue (logbuffer, agent->index);
-		emit_byte (logbuffer, type);
+		emit_value (logbuffer, type);
 		switch (type) {
 		case MONO_COUNTER_INT:
 #if SIZEOF_VOID_P == 4

--- a/mono/profiler/log.h
+++ b/mono/profiler/log.h
@@ -10,7 +10,7 @@
 #define LOG_HEADER_ID 0x4D505A01
 #define LOG_VERSION_MAJOR 2
 #define LOG_VERSION_MINOR 0
-#define LOG_DATA_VERSION 14
+#define LOG_DATA_VERSION 15
 
 /*
  * Changes in major/minor versions:
@@ -72,6 +72,7 @@
                removed type field from TYPE_SAMPLE_HIT
                removed MONO_GC_EVENT_{MARK,RECLAIM}_{START,END}
                reverted the root_type field back to uleb128
+ * version 15: reverted the type, unit, and variance fields back to uleb128
  */
 
 /*
@@ -297,16 +298,16 @@
  * 		if section == MONO_COUNTER_PERFCOUNTERS:
  * 			[section_name: string] section name of counter
  * 		[name: string] name of counter
- * 		[type: byte] type of counter
- * 		[unit: byte] unit of counter
- * 		[variance: byte] variance of counter
+ * 		[type: uleb128] type of counter
+ * 		[unit: uleb128] unit of counter
+ * 		[variance: uleb128] variance of counter
  * 		[index: uleb128] unique index of counter
  * if exinfo == TYPE_SAMPLE_COUNTERS
  * 	while true:
  * 		[index: uleb128] unique index of counter
  * 		if index == 0:
  * 			break
- * 		[type: byte] type of counter value
+ * 		[type: uleb128] type of counter value
  * 		if type == string:
  * 			if value == null:
  * 				[0: byte] 0 -> value is null

--- a/mono/profiler/mprof-report.c
+++ b/mono/profiler/mprof-report.c
@@ -3003,7 +3003,7 @@ decode_buffer (ProfContext *ctx)
 					}
 					name = pstrdup ((char*)p);
 					while (*p++);
-					if (ctx->data_version > 12) {
+					if (ctx->data_version > 12 && ctx->data_version < 15) {
 						type = *p++;
 						unit = *p++;
 						variance = *p++;
@@ -3040,7 +3040,7 @@ decode_buffer (ProfContext *ctx)
 						}
 					}
 
-					if (ctx->data_version > 12)
+					if (ctx->data_version > 12 && ctx->data_version < 15)
 						type = *p++;
 					else
 						type = decode_uleb128 (p, &p);


### PR DESCRIPTION
The change to encode these fields as byte was incorrect.

Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=60920