### PR TITLE
[System.Windows.Forms] Proper paint cell border and divider in DataGridView

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -512,6 +512,8 @@ namespace System.Windows.Forms {
 							border.All = DataGridViewAdvancedCellBorderStyle.Single;
 							break;
 						case DataGridViewCellBorderStyle.Raised:
+							border.All = DataGridViewAdvancedCellBorderStyle.Outset;
+							break;
 						case DataGridViewCellBorderStyle.RaisedVertical:
 							border.Bottom = DataGridViewAdvancedCellBorderStyle.None;
 							border.Top = DataGridViewAdvancedCellBorderStyle.None;
@@ -537,6 +539,9 @@ namespace System.Windows.Forms {
 							border.Right = DataGridViewAdvancedCellBorderStyle.Inset;
 							break;
 						case DataGridViewCellBorderStyle.SingleHorizontal:
+							border.All = DataGridViewAdvancedCellBorderStyle.None;
+							border.Bottom = DataGridViewAdvancedCellBorderStyle.Single;
+							break;
 						case DataGridViewCellBorderStyle.SunkenHorizontal:
 							border.Bottom = DataGridViewAdvancedCellBorderStyle.Inset;
 							border.Top = DataGridViewAdvancedCellBorderStyle.Inset;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCell.cs
@@ -1192,62 +1192,167 @@ namespace System.Windows.Forms {
 					PaintErrorIcon (graphics, clipBounds, cellBounds, ErrorText);
 		}
 
+		private void PaintDividers (Graphics graphics, ref Rectangle bounds, DataGridViewAdvancedBorderStyle advancedBorderStyle)
+		{
+			// Paint the vertical divider
+			int dividerWidth = OwningColumn != null ? OwningColumn.DividerWidth : 0;
+			if (dividerWidth > 0) {
+				if (dividerWidth > bounds.Width)
+					dividerWidth = bounds.Width;
+				Color color;
+				switch (advancedBorderStyle.Right) {
+					case DataGridViewAdvancedCellBorderStyle.Single:
+						color = DataGridView.GridColor;
+						break;
+					case DataGridViewAdvancedCellBorderStyle.Inset:
+						color = SystemColors.ControlLightLight;
+						break;
+					default:
+						color = SystemColors.ControlDark;
+						break;
+				}
+
+				graphics.FillRectangle (ThemeEngine.Current.ResPool.GetSolidBrush (color), bounds.Right - dividerWidth, bounds.Y, dividerWidth, bounds.Height);
+				bounds.Width -= dividerWidth;
+				if (bounds.Width <= 0)
+					return;
+			}
+
+			dividerWidth = OwningRow != null ? OwningRow.DividerHeight : 0;
+			if (dividerWidth > 0) {
+				if (dividerWidth > bounds.Height)
+					dividerWidth = bounds.Height;
+				Color color;
+				switch (advancedBorderStyle.Bottom) {
+					case DataGridViewAdvancedCellBorderStyle.Single:
+						color = DataGridView.GridColor;
+						break;
+					case DataGridViewAdvancedCellBorderStyle.Inset:
+						color = SystemColors.ControlLightLight;
+						break;
+					default:
+						color = SystemColors.ControlDark;
+						break;
+				}
+
+				graphics.FillRectangle (ThemeEngine.Current.ResPool.GetSolidBrush (color), bounds.X, bounds.Bottom - dividerWidth, bounds.Width, dividerWidth);
+				bounds.Height -= dividerWidth;
+			}
+		}
+
 		protected virtual void PaintBorder (Graphics graphics, Rectangle clipBounds, Rectangle bounds, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle)
 		{
-			Pen pen = new Pen (DataGridView.GridColor);
+			PaintDividers(graphics, ref bounds, advancedBorderStyle);
+			if (bounds.Height <= 0 || bounds.Width <= 0)
+				return;
+
+			if (advancedBorderStyle.All == DataGridViewAdvancedCellBorderStyle.None)
+				return;
+
+			Pen penGrid = ThemeEngine.Current.ResPool.GetPen (DataGridView.GridColor);
+			CPColor cpColor = ThemeEngine.Current.ResPool.GetCPColor (cellStyle.BackColor);
+			Pen penDark = ThemeEngine.Current.ResPool.GetPen (cpColor.Dark);
+			Pen penLight = ThemeEngine.Current.ResPool.GetPen (cpColor.LightLight);
+
+			int left = bounds.X;
+			int right = bounds.Right - 1;
+			int top = bounds.Y;
+			int bottom = bounds.Bottom - 1;
 
 			// Paint the left border, if any
 			switch (advancedBorderStyle.Left) {
 				case DataGridViewAdvancedCellBorderStyle.Single:
-					if (DataGridView.CellBorderStyle != DataGridViewCellBorderStyle.Single)
-						graphics.DrawLine (pen, bounds.X, bounds.Y, bounds.X, bounds.Y + bounds.Height - 1);
+					graphics.DrawLine (penGrid, left, top, left, bottom);
 					break;
+
 				case DataGridViewAdvancedCellBorderStyle.Outset:
-				case DataGridViewAdvancedCellBorderStyle.Inset:
-					graphics.DrawLine(pen, bounds.X, bounds.Y, bounds.X, bounds.Y + bounds.Height - 1);
+					graphics.DrawLine (penLight, left, top, left, bottom);
 					break;
+
+				case DataGridViewAdvancedCellBorderStyle.Inset:
+					graphics.DrawLine (penDark, left, top, left, bottom);
+					break;
+
 				case DataGridViewAdvancedCellBorderStyle.InsetDouble:
+					graphics.DrawLine(penLight, left, top, left, bottom);
+					graphics.DrawLine(penDark, left + 1, (advancedBorderStyle.Top != DataGridViewAdvancedCellBorderStyle.None)? top + 1 : top, left + 1, bottom);
+					break;
+
 				case DataGridViewAdvancedCellBorderStyle.OutsetDouble:
-					graphics.DrawLine(pen, bounds.X, bounds.Y, bounds.X, bounds.Y + bounds.Height - 1);
-					graphics.DrawLine(pen, bounds.X + 2, bounds.Y, bounds.X + 2, bounds.Y + bounds.Height - 1);
+					graphics.DrawLine(penDark, left, top, left, bottom);
+					graphics.DrawLine(penLight, left + 1, (advancedBorderStyle.Top != DataGridViewAdvancedCellBorderStyle.None)? top + 1 : top, left + 1, bottom);
 					break;
 			}
-			
+
 			// Paint the right border, if any
 			switch (advancedBorderStyle.Right) {
 				case DataGridViewAdvancedCellBorderStyle.Single:
-					graphics.DrawLine(pen, bounds.X + bounds.Width - 1, bounds.Y, bounds.X + bounds.Width - 1, bounds.Y + bounds.Height - 1);
+					graphics.DrawLine(penGrid, right, top, right, bottom);
 					break;
+
 				case DataGridViewAdvancedCellBorderStyle.Outset:
+					graphics.DrawLine (penDark, right, top, right, bottom);
+					break;
+
 				case DataGridViewAdvancedCellBorderStyle.Inset:
+					graphics.DrawLine (penLight, right, top, right, bottom);
+					break;
+
 				case DataGridViewAdvancedCellBorderStyle.InsetDouble:
+					graphics.DrawLine (penLight, right - 1, top, right - 1, bottom);
+					graphics.DrawLine (penDark, right, (advancedBorderStyle.Top != DataGridViewAdvancedCellBorderStyle.None)? top + 1 : top, right, bottom);
+					break;
+
 				case DataGridViewAdvancedCellBorderStyle.OutsetDouble:
-					graphics.DrawLine(pen, bounds.X + bounds.Width, bounds.Y, bounds.X + bounds.Width, bounds.Y + bounds.Height - 1);
+					graphics.DrawLine (penDark, right - 1, top, right - 1, bottom);
+					graphics.DrawLine (penLight, right, (advancedBorderStyle.Top != DataGridViewAdvancedCellBorderStyle.None)? top + 1 : top, right, bottom);
 					break;
 			}
-			
+
 			// Paint the top border, if any
 			switch (advancedBorderStyle.Top) {
 				case DataGridViewAdvancedCellBorderStyle.Single:
-					if (DataGridView.CellBorderStyle != DataGridViewCellBorderStyle.Single)
-						graphics.DrawLine(pen, bounds.X, bounds.Y, bounds.X + bounds.Width - 1, bounds.Y);
+					graphics.DrawLine(penGrid, left, top, right, top);
 					break;
-				case DataGridViewAdvancedCellBorderStyle.Outset:
-				case DataGridViewAdvancedCellBorderStyle.Inset:
+
+				case DataGridViewAdvancedCellBorderStyle.Outset: {
+						int _left = (advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.InsetDouble) || (advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.OutsetDouble) ? left + 1 : left;
+						int _right = (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Inset) || (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Outset) ? right - 1 : right;
+						graphics.DrawLine (penLight, _left, top, _right, top);
+					} break;
+
+				case DataGridViewAdvancedCellBorderStyle.Inset: {
+						int _left = (advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.InsetDouble) || (advancedBorderStyle.Left == DataGridViewAdvancedCellBorderStyle.OutsetDouble) ? left + 1 : left;
+						int _right = (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Inset) || (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.Outset) ? right - 1 : right;
+						graphics.DrawLine (penDark, _left, top, _right, top);
+					} break;
+
 				case DataGridViewAdvancedCellBorderStyle.InsetDouble:
+					graphics.DrawLine(penLight, left, top, right, top);
+					graphics.DrawLine(penDark, (advancedBorderStyle.Left != DataGridViewAdvancedCellBorderStyle.None)? left + 1 : left, top + 1,
+						(advancedBorderStyle.Right != DataGridViewAdvancedCellBorderStyle.None)? right -1 : right, top + 1);
+					break;
+
 				case DataGridViewAdvancedCellBorderStyle.OutsetDouble:
-					graphics.DrawLine(pen, bounds.X, bounds.Y, bounds.X + bounds.Width - 1, bounds.Y);
+					graphics.DrawLine(penDark, left, top, right, top);
+					graphics.DrawLine(penLight, (advancedBorderStyle.Left != DataGridViewAdvancedCellBorderStyle.None)? left + 1 : left, top + 1,
+						(advancedBorderStyle.Right != DataGridViewAdvancedCellBorderStyle.None)? right - 1 : right, top + 1);
 					break;
 			}
-			
+
 			// Paint the bottom border, if any
 			switch (advancedBorderStyle.Bottom) {
-				case DataGridViewAdvancedCellBorderStyle.Outset:
-				case DataGridViewAdvancedCellBorderStyle.Inset:
 				case DataGridViewAdvancedCellBorderStyle.Single:
-				case DataGridViewAdvancedCellBorderStyle.InsetDouble:
-				case DataGridViewAdvancedCellBorderStyle.OutsetDouble:
-					graphics.DrawLine(pen, bounds.X, bounds.Y + bounds.Height - 1, bounds.X + bounds.Width - 1, bounds.Y + bounds.Height - 1);
+					graphics.DrawLine(penGrid, left, bottom, right, bottom);
+					break;
+
+				case DataGridViewAdvancedCellBorderStyle.Outset: {
+						int _right = (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.InsetDouble) || (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.OutsetDouble) ? right - 1 : right;
+						graphics.DrawLine (penDark, left, bottom, _right, bottom);
+					} break;
+
+				case DataGridViewAdvancedCellBorderStyle.Inset:
+					graphics.DrawLine(penLight, left, bottom, (advancedBorderStyle.Right == DataGridViewAdvancedCellBorderStyle.InsetDouble)? right - 1: right, bottom);
 					break;
 			}
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCell.cs
@@ -432,6 +432,32 @@ namespace System.Windows.Forms {
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]
 		public virtual DataGridViewAdvancedBorderStyle AdjustCellBorderStyle (DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStyleInput,	DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStylePlaceholder, bool singleVerticalBorderAdded, bool singleHorizontalBorderAdded, bool isFirstDisplayedColumn, bool isFirstDisplayedRow) {
+			if (dataGridViewAdvancedBorderStyleInput.All == DataGridViewAdvancedCellBorderStyle.Single) {
+
+				dataGridViewAdvancedBorderStylePlaceholder.Left = (isFirstDisplayedColumn && singleVerticalBorderAdded) ? DataGridViewAdvancedCellBorderStyle.Single : DataGridViewAdvancedCellBorderStyle.None;
+				dataGridViewAdvancedBorderStylePlaceholder.Right = DataGridViewAdvancedCellBorderStyle.Single;
+				dataGridViewAdvancedBorderStylePlaceholder.Top = (isFirstDisplayedRow && singleHorizontalBorderAdded)? DataGridViewAdvancedCellBorderStyle.Single : DataGridViewAdvancedCellBorderStyle.None;
+				dataGridViewAdvancedBorderStylePlaceholder.Bottom = DataGridViewAdvancedCellBorderStyle.Single;
+				return dataGridViewAdvancedBorderStylePlaceholder;
+			}
+
+			if ((dataGridViewAdvancedBorderStyleInput.All == DataGridViewAdvancedCellBorderStyle.NotSet) && (DataGridView != null) && (DataGridView.AdvancedCellBorderStyle == dataGridViewAdvancedBorderStyleInput)) {
+				if (DataGridView.CellBorderStyle == DataGridViewCellBorderStyle.SingleVertical) {
+					dataGridViewAdvancedBorderStylePlaceholder.Left = (isFirstDisplayedColumn && singleVerticalBorderAdded) ? DataGridViewAdvancedCellBorderStyle.Single : DataGridViewAdvancedCellBorderStyle.None;
+					dataGridViewAdvancedBorderStylePlaceholder.Right = DataGridViewAdvancedCellBorderStyle.Single;
+					dataGridViewAdvancedBorderStylePlaceholder.Top = DataGridViewAdvancedCellBorderStyle.None;
+					dataGridViewAdvancedBorderStylePlaceholder.Bottom = DataGridViewAdvancedCellBorderStyle.None;
+					return dataGridViewAdvancedBorderStylePlaceholder;
+				}
+				if (DataGridView.CellBorderStyle == DataGridViewCellBorderStyle.SingleHorizontal) {
+					dataGridViewAdvancedBorderStylePlaceholder.Left = DataGridViewAdvancedCellBorderStyle.None;
+					dataGridViewAdvancedBorderStylePlaceholder.Right = DataGridViewAdvancedCellBorderStyle.None;
+					dataGridViewAdvancedBorderStylePlaceholder.Top = (isFirstDisplayedRow && singleHorizontalBorderAdded)? DataGridViewAdvancedCellBorderStyle.Single : DataGridViewAdvancedCellBorderStyle.None;
+					dataGridViewAdvancedBorderStylePlaceholder.Bottom = DataGridViewAdvancedCellBorderStyle.Single;
+					return dataGridViewAdvancedBorderStylePlaceholder;
+				}
+			}
+
 			return dataGridViewAdvancedBorderStyleInput;
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewRow.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewRow.cs
@@ -557,6 +557,9 @@ namespace System.Windows.Forms
 				bounds.X += DataGridView.RowHeadersWidth;
 				bounds.Width -= DataGridView.RowHeadersWidth;
 			}
+
+			bool singleVerticalBorderAdded = !DataGridView.RowHeadersVisible;
+			bool singleHorizontalBorderAdded = !DataGridView.ColumnHeadersVisible;
 			
 			for (int i = DataGridView.first_col_index; i < sortedColumns.Count; i++) {
 				DataGridViewColumn col = sortedColumns[i];
@@ -593,7 +596,7 @@ namespace System.Windows.Forms
 				}
 
 				DataGridViewAdvancedBorderStyle intermediateBorderStyle = (DataGridViewAdvancedBorderStyle)((ICloneable)DataGridView.AdvancedCellBorderStyle).Clone ();
-				DataGridViewAdvancedBorderStyle borderStyle = cell.AdjustCellBorderStyle (DataGridView.AdvancedCellBorderStyle, intermediateBorderStyle, true, true, cell.ColumnIndex == 0, cell.RowIndex == 0);
+				DataGridViewAdvancedBorderStyle borderStyle = cell.AdjustCellBorderStyle (DataGridView.AdvancedCellBorderStyle, intermediateBorderStyle, singleVerticalBorderAdded, singleHorizontalBorderAdded, cell.ColumnIndex == 0, cell.RowIndex == 0);
 				DataGridView.OnCellFormattingInternal (new DataGridViewCellFormattingEventArgs (cell.ColumnIndex, cell.RowIndex, value, cell.FormattedValueType, style));
 
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewTextBoxCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewTextBoxCell.cs
@@ -226,7 +226,15 @@ namespace System.Windows.Forms {
 					contentbounds.Height -= cellStyle.Padding.Vertical;
 				}
 
-				if (formattedValue != null)
+				const int textTopAdditionalPadding = 1;
+				const int textBottomAdditionalPadding = 2;
+				const int textLeftAdditionalPadding = 0;
+				const int textRightAdditionalPadding = 2;
+				contentbounds.Offset (textLeftAdditionalPadding, textTopAdditionalPadding);
+				contentbounds.Width -= textLeftAdditionalPadding + textRightAdditionalPadding;
+				contentbounds.Height -= textTopAdditionalPadding + textBottomAdditionalPadding;
+
+				if (formattedValue != null && contentbounds.Width > 0 && contentbounds.Height > 0)
 					TextRenderer.DrawText (graphics, formattedValue.ToString (), cellStyle.Font, contentbounds, color, flags);
 			}
 


### PR DESCRIPTION
- Some border styles fixed
- AjustCellBorderStyle - implemented edge/non-edge header/non-header row and column border styles fix
- Draw row & column divider and take it into account for drawing borders
- Implemented paint for all missing border styles
- Additional cell paddings in TextBoxCell:
  - 1 pixel for right and bottom to compensate cells CellBounds overlapping,
  - One more pixel for top, right and bottom to have one pixel gap between text and border. Left border had a good gap already (why?).
- No call DrawText for cell if there is no rectangle at all.
