### PR TITLE
cleanup MONO_DISABLE_SHM

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,16 +308,6 @@ should be used.
 
  * Or you can specify a path to a libgdiplus.
 
-* `--disable-shared-memory`
-
-  * Use this option to disable the use of shared memory in
-Mono (this is equivalent to setting the MONO_DISABLE_SHM
-environment variable, although this removes the feature
-completely).
-
-  * Disabling the shared memory support will disable certain
-features like cross-process named mutexes.
-
 * `--enable-minimal=LIST`
 
   * Use this feature to specify optional runtime

--- a/man/mono-service.1
+++ b/man/mono-service.1
@@ -26,11 +26,6 @@ and execution can be resumed by sending the SIGUSR2 signal.   The
 service can be cleanly shutdown by sending the SIGTERM signal to the
 process. 
 .PP
-Mono programs started with mono-service run with the 
-.B MONO_DISABLE_SHM
-variable set.    This means that certain Mono features that depend on
-it are not available to services.
-.PP
 The following options can be used to control the service:
 .TP
 .I "-d:DIRECTORY"

--- a/man/mono.1
+++ b/man/mono.1
@@ -1101,18 +1101,6 @@ internally disables managed collation functionality invoked via the
 members of System.Globalization.CompareInfo class. Collation is
 enabled by default.
 .TP
-\fBMONO_DISABLE_SHM\fR
-Unix only: If set, disables the shared memory files used for
-cross-process handles: process have only private handles.  This means
-that process and thread handles are not available to other processes,
-and named mutexes, named events and named semaphores are not visible
-between processes.
-.Sp
-This is can also be enabled by default by passing the
-"--disable-shared-handles" option to configure.
-.Sp
-This is the default from mono 2.8 onwards.
-.TP
 \fBMONO_DISABLE_SHARED_AREA\fR
 Unix only: If set, disable usage of shared memory for exposing
 performance counters. This means it will not be possible to both

--- a/scripts/mono-service.in
+++ b/scripts/mono-service.in
@@ -33,7 +33,6 @@ if test x$assembly = x; then
 	exit 1
 fi
 
-export MONO_DISABLE_SHM=1
 if $debug; then
    exec @bindir@/@mono_interp@ $MONO_OPTIONS @mono_instdir@/@framework_version@/mono-service.exe $args
 else


### PR DESCRIPTION
The environment variable MONO_DISABLE_SHM seems to be unused now.
Cleanup the leftovers.