### PR TITLE
[profiler] Rework GC roots reporting.

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Makefile
+++ b/mcs/class/Mono.Profiler.Log/Makefile
@@ -6,7 +6,7 @@ LIBRARY_SNK = ../mono.snk
 
 LIB_REFS = System System.Core
 KEYFILE = $(LIBRARY_SNK)
-LIB_MCS_FLAGS = /unsafe /publicsign
+LIB_MCS_FLAGS = /unsafe /publicsign /nowarn:0618
 
 LIBRARY_WARN_AS_ERROR = yes
 

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs
@@ -54,6 +54,8 @@ namespace Mono.Profiler.Log {
 		HeapEnd = 1 << 4,
 		HeapObject = 2 << 4,
 		HeapRoots = 3 << 4,
+		HeapRootRegister = 4 << 4,
+		HeapRootUnregister = 5 << 4,
 
 		SampleHit = 0 << 4,
 		SampleUnmanagedSymbol = 1 << 4,
@@ -74,6 +76,7 @@ namespace Mono.Profiler.Log {
 		AppDomain = 4,
 		Thread = 5,
 		Context = 6,
+		VTable = 7,
 	}
 
 	// mono/utils/mono-counters.h : MONO_COUNTER_*
@@ -133,6 +136,7 @@ namespace Mono.Profiler.Log {
 
 	// mono/metadata/profiler.h : MonoProfilerGCRootType
 	[Flags]
+	[Obsolete ("The event field using this enum is no longer produced.")]
 	public enum LogHeapRootAttributes {
 		Pinning = 1 << 8,
 		WeakReference = 2 << 8,
@@ -145,6 +149,25 @@ namespace Mono.Profiler.Log {
 		Miscellaneous = 1 << 4,
 
 		TypeMask = 0xff,
+	}
+
+	// mono/metadata/mono-gc.h : MonoGCRootSource
+	public enum LogHeapRootSource {
+		External = 0,
+		Stack = 1,
+		FinalizerQueue = 2,
+		Static = 3,
+		ThreadStatic = 4,
+		ContextStatic = 5,
+		GCHandle = 6,
+		Jit = 7,
+		Threading = 8,
+		AppDomain = 9,
+		Reflection = 10,
+		Marshal = 11,
+		ThreadPool = 12,
+		Debugger = 13,
+		Handle = 14,
 	}
 
 	// mono/profiler/log.h : MonoProfilerMonitorEvent

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEventVisitor.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEventVisitor.cs
@@ -66,6 +66,10 @@ namespace Mono.Profiler.Log {
 		{
 		}
 
+		public virtual void Visit (VTableLoadEvent ev)
+		{
+		}
+
 		public virtual void Visit (JitEvent ev)
 		{
 		}
@@ -91,6 +95,14 @@ namespace Mono.Profiler.Log {
 		}
 
 		public virtual void Visit (HeapRootsEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapRootRegisterEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapRootUnregisterEvent ev)
 		{
 		}
 

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEvents.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEvents.cs
@@ -161,6 +161,20 @@ namespace Mono.Profiler.Log {
 		}
 	}
 
+	public sealed class VTableLoadEvent : LogEvent {
+
+		public long VTablePointer { get; internal set; }
+
+		public long AppDomainId { get; internal set; }
+
+		public long ClassPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
 	public sealed class JitEvent : LogEvent {
 
 		public long MethodPointer { get; internal set; }
@@ -195,7 +209,10 @@ namespace Mono.Profiler.Log {
 
 	public sealed class AllocationEvent : LogEvent {
 
+		[Obsolete ("This field is no longer produced.")]
 		public long ClassPointer { get; internal set; }
+
+		public long VTablePointer { get; internal set; }
 
 		public long ObjectPointer { get; internal set; }
 
@@ -236,7 +253,10 @@ namespace Mono.Profiler.Log {
 
 		public long ObjectPointer { get; internal set; }
 
+		[Obsolete ("This field is no longer produced.")]
 		public long ClassPointer { get; internal set; }
+
+		public long VTablePointer { get; internal set; }
 
 		public long ObjectSize { get; internal set; }
 
@@ -252,16 +272,49 @@ namespace Mono.Profiler.Log {
 
 		public struct HeapRoot {
 
+			public long AddressPointer { get; internal set; }
+
 			public long ObjectPointer { get; internal set; }
 
+			[Obsolete ("This field is no longer produced.")]
 			public LogHeapRootAttributes Attributes { get; internal set; }
 
+			[Obsolete ("This field is no longer produced.")]
 			public long ExtraInfo { get; internal set; }
 		}
 
+		[Obsolete ("This field is no longer produced.")]
 		public long MaxGenerationCollectionCount { get; internal set; }
 
 		public IReadOnlyList<HeapRoot> Roots { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapRootRegisterEvent : LogEvent {
+
+		public long RootPointer { get; internal set; }
+
+		public long RootSize { get; internal set; }
+
+		public LogHeapRootSource Source { get; internal set; }
+
+		public long Key { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapRootUnregisterEvent : LogEvent {
+
+		public long RootPointer { get; internal set; }
 
 		internal override void Accept (LogEventVisitor visitor)
 		{

--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogStreamHeader.cs
+++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogStreamHeader.cs
@@ -9,7 +9,7 @@ namespace Mono.Profiler.Log {
 	public sealed class LogStreamHeader {
 		
 		const int MinVersion = 13;
-		const int MaxVersion = 14;
+		const int MaxVersion = 15;
 
 		const int Id = 0x4d505a01;
 

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -761,7 +761,7 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 		memset (params, 0, sizeof (void*) * sig->param_count);
 	} else {
 		/* Allocate using GC so it gets GC tracking */
-		params = (void **)mono_gc_alloc_fixed (sig->param_count * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_REFLECTION, "custom attribute parameters");
+		params = (void **)mono_gc_alloc_fixed (sig->param_count * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Custom Attribute Parameters");
 	}
 
 	/* skip prolog */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -292,6 +292,24 @@ mono_ptrarray_hash (gpointer *s)
 	return hash;	
 }
 
+//g_malloc on sgen and mono_gc_alloc_fixed on boehm
+static void*
+gc_alloc_fixed_non_heap_list (size_t size)
+{
+	if (mono_gc_is_moving ())
+		return g_malloc0 (size);
+	else
+		return mono_gc_alloc_fixed (appdomain_list_size * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, NULL, "Domain List");
+}
+
+static void
+gc_free_fixed_non_heap_list (void *ptr)
+{
+	if (mono_gc_is_moving ())
+		return g_free (ptr);
+	else
+		return mono_gc_free_fixed (ptr);
+}
 /*
  * Allocate an id for domain and set domain->domain_id.
  * LOCKING: must be called while holding appdomains_mutex.
@@ -306,7 +324,8 @@ domain_id_alloc (MonoDomain *domain)
 	int id = -1, i;
 	if (!appdomains_list) {
 		appdomain_list_size = 2;
-		appdomains_list = (MonoDomain **)mono_gc_alloc_fixed (appdomain_list_size * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, "domains list");
+		appdomains_list = (MonoDomain **)gc_alloc_fixed_non_heap_list (appdomain_list_size * sizeof (void*));
+
 	}
 	for (i = appdomain_next; i < appdomain_list_size; ++i) {
 		if (!appdomains_list [i]) {
@@ -328,9 +347,9 @@ domain_id_alloc (MonoDomain *domain)
 		if (new_size >= (1 << 16))
 			g_assert_not_reached ();
 		id = appdomain_list_size;
-		new_list = (MonoDomain **)mono_gc_alloc_fixed (new_size * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, "domains list");
+		new_list = (MonoDomain **)gc_alloc_fixed_non_heap_list (new_size * sizeof (void*));
 		memcpy (new_list, appdomains_list, appdomain_list_size * sizeof (void*));
-		mono_gc_free_fixed (appdomains_list);
+		gc_free_fixed_non_heap_list (appdomains_list);
 		appdomains_list = new_list;
 		appdomain_list_size = new_size;
 	}
@@ -386,12 +405,11 @@ mono_domain_create (void)
 	}
 	mono_appdomains_unlock ();
 
-	if (!mono_gc_is_moving ()) {
-		domain = (MonoDomain *)mono_gc_alloc_fixed (sizeof (MonoDomain), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, "domain object");
-	} else {
-		domain = (MonoDomain *)mono_gc_alloc_fixed (sizeof (MonoDomain), domain_gc_desc, MONO_ROOT_SOURCE_DOMAIN, "domain object");
-		mono_gc_register_root ((char*)&(domain->MONO_DOMAIN_FIRST_GC_TRACKED), G_STRUCT_OFFSET (MonoDomain, MONO_DOMAIN_LAST_GC_TRACKED) - G_STRUCT_OFFSET (MonoDomain, MONO_DOMAIN_FIRST_GC_TRACKED), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, "misc domain fields");
-	}
+	if (!mono_gc_is_moving ())
+		domain = (MonoDomain *)mono_gc_alloc_fixed (sizeof (MonoDomain), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, NULL, "Domain Structure");
+	else
+		domain = (MonoDomain *)mono_gc_alloc_fixed (sizeof (MonoDomain), domain_gc_desc, MONO_ROOT_SOURCE_DOMAIN, NULL, "Domain Structure");
+
 	domain->shadow_serial = shadow_serial;
 	domain->domain = NULL;
 	domain->setup = NULL;
@@ -403,14 +421,14 @@ mono_domain_create (void)
 	domain->mp = mono_mempool_new ();
 	domain->code_mp = mono_code_manager_new ();
 	domain->lock_free_mp = lock_free_mempool_new ();
-	domain->env = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash, (GCompareFunc)mono_string_equal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain environment variables table");
+	domain->env = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash, (GCompareFunc)mono_string_equal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Environment Variable Table");
 	domain->domain_assemblies = NULL;
 	domain->assembly_bindings = NULL;
 	domain->assembly_bindings_parsed = FALSE;
 	domain->class_vtable_array = g_ptr_array_new ();
 	domain->proxy_vtable_hash = g_hash_table_new ((GHashFunc)mono_ptrarray_hash, (GCompareFunc)mono_ptrarray_equal);
 	mono_jit_code_hash_init (&domain->jit_code_hash);
-	domain->ldstr_table = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash, (GCompareFunc)mono_string_equal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain string constants table");
+	domain->ldstr_table = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash, (GCompareFunc)mono_string_equal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain String Pool Table");
 	domain->num_jit_info_tables = 1;
 	domain->jit_info_table = mono_jit_info_table_new (domain);
 	domain->jit_info_free_queue = NULL;
@@ -952,7 +970,7 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 	 */
 	mono_appdomains_lock ();
 	size = appdomain_list_size;
-	copy = (MonoDomain **)mono_gc_alloc_fixed (appdomain_list_size * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, "temporary domains list");
+	copy = (MonoDomain **)gc_alloc_fixed_non_heap_list (appdomain_list_size * sizeof (void*));
 	memcpy (copy, appdomains_list, appdomain_list_size * sizeof (void*));
 	mono_appdomains_unlock ();
 
@@ -961,7 +979,7 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 			func (copy [i], user_data);
 	}
 
-	mono_gc_free_fixed (copy);
+	gc_free_fixed_non_heap_list (copy);
 }
 
 /* FIXME: maybe we should integrate this with mono_assembly_open? */

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -352,19 +352,19 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 
 	mono_image_init (&image->image);
 
-	image->token_fixups = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_REFLECTION, "dynamic module token fixups table");
+	image->token_fixups = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Token Fixup Table");
 	image->method_to_table_idx = g_hash_table_new (NULL, NULL);
 	image->field_to_table_idx = g_hash_table_new (NULL, NULL);
 	image->method_aux_hash = g_hash_table_new (NULL, NULL);
 	image->vararg_aux_hash = g_hash_table_new (NULL, NULL);
 	image->handleref = g_hash_table_new (NULL, NULL);
-	image->tokens = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_REFLECTION, "dynamic module tokens table");
-	image->generic_def_objects = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_REFLECTION, "dynamic module generic definitions table");
+	image->tokens = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Token Table");
+	image->generic_def_objects = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Generic Definition Table");
 	image->typespec = g_hash_table_new ((GHashFunc)mono_metadata_type_hash, (GCompareFunc)mono_metadata_type_equal);
 	image->typeref = g_hash_table_new ((GHashFunc)mono_metadata_type_hash, (GCompareFunc)mono_metadata_type_equal);
 	image->blob_cache = g_hash_table_new ((GHashFunc)mono_blob_entry_hash, (GCompareFunc)mono_blob_entry_equal);
 	image->gen_params = g_ptr_array_new ();
-	image->remapped_tokens = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_REFLECTION, "dynamic module remapped tokens table");
+	image->remapped_tokens = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Remapped Token Table");
 
 	/*g_print ("string heap create for image %p (%s)\n", image, module_name);*/
 	string_heap_init (&image->sheap);

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -35,7 +35,6 @@ Add counters for:
 Actually do something in mono_handle_verify
 
 Shrink the handles stack in mono_handle_stack_scan
-Properly report it to the profiler.
 Add a boehm implementation
 
 TODO (things to explore):
@@ -382,10 +381,11 @@ check_handle_stack_monotonic (HandleStack *stack)
 }
 
 void
-mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, gboolean precise)
+mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, gboolean precise, gboolean check)
 {
-	if (precise) /* run just once (per handle stack) per GC */
+	if (check) /* run just once (per handle stack) per GC */
 		check_handle_stack_monotonic (stack);
+
 	/*
 	  We're called twice - on the imprecise pass we call func to pin the
 	  objects where the handle points to its interior.  On the precise

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -132,7 +132,7 @@ MonoRawHandle mono_handle_new_full (gpointer rawptr, gboolean interior, const ch
 MonoRawHandle mono_handle_new_interior (gpointer rawptr, const char *owner);
 #endif
 
-void mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, gboolean precise);
+void mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, gboolean precise, gboolean check);
 gboolean mono_handle_stack_is_empty (HandleStack *stack);
 HandleStack* mono_handle_stack_alloc (void);
 void mono_handle_stack_free (HandleStack *handlestack);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -4022,7 +4022,7 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 	/* to make it work with our special string constructors */
 	if (!string_dummy) {
 		MonoError error;
-		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, "dummy marshal string");
+		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, NULL, "Marshal Dummy String");
 		string_dummy = mono_string_new_checked (mono_get_root_domain (), "dummy", &error);
 		mono_error_assert_ok (&error);
 	}

--- a/mono/metadata/mono-conc-hash.h
+++ b/mono/metadata/mono-conc-hash.h
@@ -11,7 +11,7 @@
 
 typedef struct _MonoConcGHashTable MonoConcGHashTable;
 
-MonoConcGHashTable * mono_conc_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, const char *msg);
+MonoConcGHashTable * mono_conc_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, void *key, const char *msg);
 gpointer mono_conc_g_hash_table_lookup (MonoConcGHashTable *hash, gconstpointer key);
 gboolean mono_conc_g_hash_table_lookup_extended (MonoConcGHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value);
 void mono_conc_g_hash_table_foreach (MonoConcGHashTable *hash, GHFunc func, gpointer user_data);

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -12,36 +12,85 @@ MONO_BEGIN_DECLS
 
 typedef int (*MonoGCReferences) (MonoObject *obj, MonoClass *klass, uintptr_t size, uintptr_t num, MonoObject **refs, uintptr_t *offsets, void *data);
 
+/**
+ * This enum is used by the profiler API when reporting root registration.
+ */
 typedef enum {
-	// Roots external to Mono.  Embedders may only use this value.
+	/**
+	 * Roots external to Mono. Embedders may only use this value.
+	 */
 	MONO_ROOT_SOURCE_EXTERNAL = 0,
-	// Thread stack.  Must not be used to register roots.
+	/**
+	 * Thread call stack.
+	 *
+	 * The \c key parameter is a thread ID as a \c uintptr_t.
+	 */
 	MONO_ROOT_SOURCE_STACK = 1,
-	// Roots in the finalizer queue.  Must not be used to register roots.
+	/**
+	 * Roots in the finalizer queue. This is a pseudo-root.
+	 */
 	MONO_ROOT_SOURCE_FINALIZER_QUEUE = 2,
-	// Managed static variables.
+	/**
+	 * Managed \c static variables.
+	 *
+	 * The \c key parameter is a \c MonoVTable pointer.
+	 */
 	MONO_ROOT_SOURCE_STATIC = 3,
-	// Static variables with ThreadStaticAttribute.
+	/**
+	 * Managed \c static variables with \c ThreadStaticAttribute.
+	 *
+	 * The \c key parameter is a thread ID as a \c uintptr_t.
+	 */
 	MONO_ROOT_SOURCE_THREAD_STATIC = 4,
-	// Static variables with ContextStaticAttribute.
+	/**
+	 * Managed \c static variables with \c ContextStaticAttribute.
+	 *
+	 * The \c key parameter is a \c MonoAppContext pointer.
+	 */
 	MONO_ROOT_SOURCE_CONTEXT_STATIC = 5,
-	// GCHandle structures.
+	/**
+	 * \c GCHandle structures.
+	 */
 	MONO_ROOT_SOURCE_GC_HANDLE = 6,
-	// Roots in the just-in-time compiler.
+	/**
+	 * Roots in the just-in-time compiler.
+	 */
 	MONO_ROOT_SOURCE_JIT = 7,
-	// Roots in the threading subsystem.
+	/**
+	 * Roots in the threading subsystem.
+	 *
+	 * The \c key parameter, if not \c NULL, is a thread ID as a \c uintptr_t.
+	 */
 	MONO_ROOT_SOURCE_THREADING = 8,
-	// Roots in application domains.
+	/**
+	 * Roots in application domains.
+	 *
+	 * The \c key parameter, if not \c NULL, is a \c MonoDomain pointer.
+	 */
 	MONO_ROOT_SOURCE_DOMAIN = 9,
-	// Roots in reflection code.
+	/**
+	 * Roots in reflection code.
+	 *
+	 * The \c key parameter, if not \c NULL, is a \c MonoVTable pointer.
+	 */
 	MONO_ROOT_SOURCE_REFLECTION = 10,
-	// Roots from P/Invoke or other marshaling.
+	/**
+	 * Roots from P/Invoke or other marshaling infrastructure.
+	 */
 	MONO_ROOT_SOURCE_MARSHAL = 11,
-	// Roots in the thread pool data structures.
+	/**
+	 * Roots in the thread pool data structures.
+	 */
 	MONO_ROOT_SOURCE_THREAD_POOL = 12,
-	// Roots in the debugger agent.
+	/**
+	 * Roots in the debugger agent.
+	 */
 	MONO_ROOT_SOURCE_DEBUGGER = 13,
-	// Handle structures, used for object passed to internal functions
+	/**
+	 * Roots in the runtime handle stack. This is a pseudo-root.
+	 *
+	 * The \c key parameter is a thread ID as a \c uintptr_t.
+	 */
 	MONO_ROOT_SOURCE_HANDLE = 14,
 } MonoGCRootSource;
 

--- a/mono/metadata/mono-hash.h
+++ b/mono/metadata/mono-hash.h
@@ -26,7 +26,7 @@ extern gint32 mono_g_hash_table_max_chain_length;
 
 typedef struct _MonoGHashTable MonoGHashTable;
 
-MONO_API MonoGHashTable *mono_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, const char *msg);
+MONO_API MonoGHashTable *mono_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, void *key, const char *msg);
 MONO_API guint    mono_g_hash_table_size            (MonoGHashTable *hash);
 MONO_API gpointer mono_g_hash_table_lookup          (MonoGHashTable *hash, gconstpointer key);
 MONO_API gboolean mono_g_hash_table_lookup_extended (MonoGHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value);

--- a/mono/metadata/mono-ptr-array.h
+++ b/mono/metadata/mono-ptr-array.h
@@ -25,18 +25,20 @@ typedef struct {
 	int size;
 	int capacity;
 	MonoGCRootSource source;
+	void *key;
 	const char *msg;
 } MonoPtrArray;
 
 #define MONO_PTR_ARRAY_MAX_ON_STACK (16)
 
-#define mono_ptr_array_init(ARRAY, INITIAL_SIZE, SOURCE, MSG) do {\
+#define mono_ptr_array_init(ARRAY, INITIAL_SIZE, SOURCE, KEY, MSG) do {\
 	(ARRAY).size = 0; \
 	(ARRAY).capacity = MAX (INITIAL_SIZE, MONO_PTR_ARRAY_MAX_ON_STACK); \
 	(ARRAY).source = SOURCE; \
+	(ARRAY).key = KEY; \
 	(ARRAY).msg = MSG; \
 	(ARRAY).data = INITIAL_SIZE > MONO_PTR_ARRAY_MAX_ON_STACK \
-		? (void **)mono_gc_alloc_fixed (sizeof (void*) * INITIAL_SIZE, mono_gc_make_root_descr_all_refs (INITIAL_SIZE), SOURCE, MSG) \
+		? (void **)mono_gc_alloc_fixed (sizeof (void*) * INITIAL_SIZE, mono_gc_make_root_descr_all_refs (INITIAL_SIZE), SOURCE, NULL, MSG) \
 		: g_newa (void*, MONO_PTR_ARRAY_MAX_ON_STACK); \
 } while (0)
 
@@ -47,7 +49,7 @@ typedef struct {
 
 #define mono_ptr_array_append(ARRAY, VALUE) do { \
 	if ((ARRAY).size >= (ARRAY).capacity) {\
-	void **__tmp = (void **)mono_gc_alloc_fixed (sizeof (void*) * (ARRAY).capacity * 2, mono_gc_make_root_descr_all_refs ((ARRAY).capacity * 2), (ARRAY).source, (ARRAY).msg); \
+	void **__tmp = (void **)mono_gc_alloc_fixed (sizeof (void*) * (ARRAY).capacity * 2, mono_gc_make_root_descr_all_refs ((ARRAY).capacity * 2), (ARRAY).source, (ARRAY).key, (ARRAY).msg); \
 		mono_gc_memmove_aligned ((void *)__tmp, (ARRAY).data, (ARRAY).capacity * sizeof (void*)); \
 		if ((ARRAY).capacity > MONO_PTR_ARRAY_MAX_ON_STACK)	\
 			mono_gc_free_fixed ((ARRAY).data);	\

--- a/mono/metadata/null-gc-handles.c
+++ b/mono/metadata/null-gc-handles.c
@@ -116,7 +116,7 @@ handle_data_alloc_entries (HandleData *handles)
 		handles->entries = (void **)g_malloc0 (sizeof (*handles->entries) * handles->size);
 		handles->domain_ids = (guint16 *)g_malloc0 (sizeof (*handles->domain_ids) * handles->size);
 	} else {
-		handles->entries = (void **)mono_gc_alloc_fixed (sizeof (*handles->entries) * handles->size, NULL, MONO_ROOT_SOURCE_GC_HANDLE, "gc handles table");
+		handles->entries = (void **)mono_gc_alloc_fixed (sizeof (*handles->entries) * handles->size, NULL, MONO_ROOT_SOURCE_GC_HANDLE, "GC Handle Table (Null)");
 	}
 	handles->bitmap = (guint32 *)g_malloc0 (handles->size / CHAR_BIT);
 }
@@ -183,7 +183,7 @@ handle_data_grow (HandleData *handles, gboolean track)
 		handles->domain_ids = domain_ids;
 	} else {
 		gpointer *entries;
-		entries = (void **)mono_gc_alloc_fixed (sizeof (*handles->entries) * new_size, NULL, MONO_ROOT_SOURCE_GC_HANDLE, "gc handles table");
+		entries = (void **)mono_gc_alloc_fixed (sizeof (*handles->entries) * new_size, NULL, MONO_ROOT_SOURCE_GC_HANDLE, "GC Handle Table (Null)");
 		mono_gc_memmove_aligned (entries, handles->entries, sizeof (*handles->entries) * handles->size);
 		mono_gc_free_fixed (handles->entries);
 		handles->entries = entries;

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -110,10 +110,17 @@ mono_object_is_alive (MonoObject* o)
 }
 
 int
-mono_gc_register_root (char *start, size_t size, void *descr, MonoGCRootSource source, const char *msg)
+mono_gc_register_root (char *start, size_t size, void *descr, MonoGCRootSource source, void *key, const char *msg)
 {
 	return TRUE;
 }
+
+int
+mono_gc_register_root_wbarrier (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg)
+{
+	return TRUE;
+}
+
 
 void
 mono_gc_deregister_root (char* addr)
@@ -157,7 +164,7 @@ mono_gc_make_root_descr_all_refs (int numbits)
 }
 
 void*
-mono_gc_alloc_fixed (size_t size, void *descr, MonoGCRootSource source, const char *msg)
+mono_gc_alloc_fixed (size_t size, void *descr, MonoGCRootSource source, void *key, const char *msg)
 {
 	return g_malloc0 (size);
 }
@@ -523,6 +530,13 @@ BOOL APIENTRY mono_gc_dllmain (HMODULE module_handle, DWORD reason, LPVOID reser
 	return TRUE;
 }
 #endif
+
+MonoVTable *
+mono_gc_get_vtable (MonoObject *obj)
+{
+	// No pointer tagging.
+	return obj->vtable;
+}
 
 guint
 mono_gc_get_vtable_bits (MonoClass *klass)

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -200,6 +200,9 @@ mono_value_copy             (void* dest, void* src, MonoClass *klass);
 MONO_API void
 mono_value_copy_array       (MonoArray *dest, int dest_idx, void* src, int count);
 
+MONO_API MonoVTable *
+mono_object_get_vtable      (MonoObject *obj);
+
 MONO_API MonoDomain*
 mono_object_get_domain      (MonoObject *obj);
 
@@ -255,6 +258,12 @@ mono_runtime_object_init    (MonoObject *this_obj);
 MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_runtime_class_init	    (MonoVTable *vtable);
+
+MONO_API MonoDomain *
+mono_vtable_domain          (MonoVTable *vtable);
+
+MONO_API MonoClass *
+mono_vtable_class           (MonoVTable *vtable);
 
 MONO_API MonoMethod*
 mono_object_get_virtual_method (MonoObject *obj, MonoMethod *method);

--- a/mono/metadata/profiler-events.h
+++ b/mono/metadata/profiler-events.h
@@ -12,6 +12,7 @@
  * MONO_PROFILER_EVENT_2(name, type, arg1_type, arg1_name, arg2_type, arg2_name)
  * MONO_PROFILER_EVENT_3(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name)
  * MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name)
+ * MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name)
  *
  * To add new callbacks to the API, simply add a line in this file and use
  * MONO_PROFILER_RAISE to raise the event wherever.
@@ -22,10 +23,14 @@
  * to prevent errors in existing code, you must add something like this at the
  * beginning of this file:
  *
- * #ifndef MONO_PROFILER_EVENT_5
- * #define MONO_PROFILER_EVENT_5(...) # Do nothing.
+ * #ifndef MONO_PROFILER_EVENT_6
+ * #define MONO_PROFILER_EVENT_6(...) # Do nothing.
  * #endif
  */
+
+#ifndef MONO_PROFILER_EVENT_5
+#define MONO_PROFILER_EVENT_5(...)
+#endif
 
 MONO_PROFILER_EVENT_0(runtime_initialized, RuntimeInitialized)
 MONO_PROFILER_EVENT_0(runtime_shutdown_begin, RuntimeShutdownBegin)
@@ -50,6 +55,10 @@ MONO_PROFILER_EVENT_4(jit_code_buffer, JitCodeBuffer, const mono_byte *, buffer,
 MONO_PROFILER_EVENT_1(class_loading, ClassLoading, MonoClass *, klass)
 MONO_PROFILER_EVENT_1(class_failed, ClassFailed, MonoClass *, klass)
 MONO_PROFILER_EVENT_1(class_loaded, ClassLoaded, MonoClass *, klass)
+
+MONO_PROFILER_EVENT_1(vtable_loading, VTableLoading, MonoVTable *, vtable)
+MONO_PROFILER_EVENT_1(vtable_failed, VTableFailed, MonoVTable *, vtable)
+MONO_PROFILER_EVENT_1(vtable_loaded, VTableLoaded, MonoVTable *, vtable)
 
 MONO_PROFILER_EVENT_1(image_loading, ModuleLoading, MonoImage *, image)
 MONO_PROFILER_EVENT_1(image_failed, ModuleFailed, MonoImage *, image)
@@ -83,18 +92,9 @@ MONO_PROFILER_EVENT_0(gc_finalizing, GCFinalizing)
 MONO_PROFILER_EVENT_0(gc_finalized, GCFinalized)
 MONO_PROFILER_EVENT_1(gc_finalizing_object, GCFinalizingObject, MonoObject *, object)
 MONO_PROFILER_EVENT_1(gc_finalized_object, GCFinalizedObject, MonoObject *, object)
-
-/*
- * This callback provides very low quality data and doesn't really match how
- * roots are actually handled in the runtime. It will be replaced with a more
- * sensible callback in the future. **This will be a breaking change.**
- *
- * In the meantime, you must define MONO_PROFILER_UNSTABLE_GC_ROOTS to be able
- * to use this interface.
- */
-#ifdef MONO_PROFILER_UNSTABLE_GC_ROOTS
-MONO_PROFILER_EVENT_4(gc_roots, GCRoots, MonoObject *const *, roots, const MonoProfilerGCRootType *, types, const uintptr_t *, extra, uint64_t, count)
-#endif
+MONO_PROFILER_EVENT_5(gc_root_register, RootRegister, const mono_byte *, start, uintptr_t, size, MonoGCRootSource, source, const void *, key, const char *, name)
+MONO_PROFILER_EVENT_1(gc_root_unregister, RootUnregister, const mono_byte *, start)
+MONO_PROFILER_EVENT_3(gc_roots, GCRoots, uint64_t, count, const mono_byte *const *, addresses, MonoObject *const *, objects)
 
 MONO_PROFILER_EVENT_1(monitor_contention, MonitorContention, MonoObject *, object)
 MONO_PROFILER_EVENT_1(monitor_failed, MonitorFailed, MonoObject *, object)

--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -8,7 +8,6 @@
 #define __MONO_PROFILER_PRIVATE_H__
 
 #include <mono/metadata/class-internals.h>
-#define MONO_PROFILER_UNSTABLE_GC_ROOTS
 #include <mono/metadata/profiler.h>
 #include <mono/utils/mono-context.h>
 #include <mono/utils/mono-os-mutex.h>
@@ -33,12 +32,15 @@ struct _MonoProfilerDesc {
 	_MONO_PROFILER_EVENT(name)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name) \
+	_MONO_PROFILER_EVENT(name)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 };
 
@@ -78,12 +80,15 @@ typedef struct {
 	_MONO_PROFILER_EVENT(name)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name) \
+	_MONO_PROFILER_EVENT(name)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 } MonoProfilerState;
 
@@ -150,12 +155,15 @@ mono_profiler_allocations_enabled (void)
 	_MONO_PROFILER_EVENT(name, arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name, arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name, arg4_type arg4_name)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name) \
+	_MONO_PROFILER_EVENT(name, arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name, arg4_type arg4_name, arg5_type arg5_name)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
 /* These are the macros the rest of the runtime should use. */

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -774,12 +774,15 @@ mono_profiler_cleanup (void)
 	_MONO_PROFILER_EVENT(name)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name) \
+	_MONO_PROFILER_EVENT(name)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 	}
 
@@ -795,12 +798,15 @@ mono_profiler_cleanup (void)
 	_MONO_PROFILER_EVENT(name, type)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name, type)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name)	\
+		_MONO_PROFILER_EVENT(name, type)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
 	MonoProfilerHandle head = mono_profiler_state.profilers;
@@ -877,12 +883,15 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 	_MONO_PROFILER_EVENT(name, type)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name, type)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name)	\
+	_MONO_PROFILER_EVENT(name, type)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
 #define _MONO_PROFILER_EVENT(name, type, params, args) \
@@ -905,12 +914,15 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 	_MONO_PROFILER_EVENT(name, type, (arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name), (h->prof, arg1_name, arg2_name, arg3_name))
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name, type, (arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name, arg4_type arg4_name), (h->prof, arg1_name, arg2_name, arg3_name, arg4_name))
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name)	\
+	_MONO_PROFILER_EVENT(name, type, (arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name, arg4_type arg4_name, arg5_type arg5_name), (h->prof, arg1_name, arg2_name, arg3_name, arg4_name, arg5_name))
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
 /*

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -112,24 +112,6 @@ MONO_API void *mono_profiler_call_context_get_local (MonoProfilerCallContext *co
 MONO_API void *mono_profiler_call_context_get_result (MonoProfilerCallContext *context);
 MONO_API void mono_profiler_call_context_free_buffer (void *buffer);
 
-#ifdef MONO_PROFILER_UNSTABLE_GC_ROOTS
-typedef enum {
-	/* Upper 2 bytes. */
-	MONO_PROFILER_GC_ROOT_PINNING = 1 << 8,
-	MONO_PROFILER_GC_ROOT_WEAKREF = 2 << 8,
-	MONO_PROFILER_GC_ROOT_INTERIOR = 4 << 8,
-
-	/* Lower 2 bytes (flags). */
-	MONO_PROFILER_GC_ROOT_STACK = 1 << 0,
-	MONO_PROFILER_GC_ROOT_FINALIZER = 1 << 1,
-	MONO_PROFILER_GC_ROOT_HANDLE = 1 << 2,
-	MONO_PROFILER_GC_ROOT_OTHER = 1 << 3,
-	MONO_PROFILER_GC_ROOT_MISC = 1 << 4,
-
-	MONO_PROFILER_GC_ROOT_TYPEMASK = 0xff,
-} MonoProfilerGCRootType;
-#endif
-
 typedef enum {
 	/**
 	 * The \c data parameter is a \c MonoMethod pointer.
@@ -205,12 +187,15 @@ typedef enum {
 		_MONO_PROFILER_EVENT(type, MonoProfiler *prof, arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 		_MONO_PROFILER_EVENT(type, MonoProfiler *prof, arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name, arg4_type arg4_name)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name) \
+		_MONO_PROFILER_EVENT(type, MonoProfiler *prof, arg1_type arg1_name, arg2_type arg2_name, arg3_type arg3_name, arg4_type arg4_name, arg5_type arg5_name)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
 #define _MONO_PROFILER_EVENT(name, type) \
@@ -225,12 +210,15 @@ typedef enum {
 	_MONO_PROFILER_EVENT(name, type)
 #define MONO_PROFILER_EVENT_4(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name) \
 	_MONO_PROFILER_EVENT(name, type)
+#define MONO_PROFILER_EVENT_5(name, type, arg1_type, arg1_name, arg2_type, arg2_name, arg3_type, arg3_name, arg4_type, arg4_name, arg5_type, arg5_name) \
+	_MONO_PROFILER_EVENT(name, type)
 #include <mono/metadata/profiler-events.h>
 #undef MONO_PROFILER_EVENT_0
 #undef MONO_PROFILER_EVENT_1
 #undef MONO_PROFILER_EVENT_2
 #undef MONO_PROFILER_EVENT_3
 #undef MONO_PROFILER_EVENT_4
+#undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
 MONO_END_DECLS

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -56,7 +56,7 @@ cache_object (MonoDomain *domain, MonoClass *klass, gpointer item, MonoObject* o
 
 	mono_domain_lock (domain);
 	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection objects table");
+		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
 
 	obj = (MonoObject*) mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe);
 	if (obj == NULL) {
@@ -80,7 +80,7 @@ cache_object_handle (MonoDomain *domain, MonoClass *klass, gpointer item, MonoOb
 
 	mono_domain_lock (domain);
 	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection objects table");
+		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
 
 	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe));
 	if (MONO_HANDLE_IS_NULL (obj)) {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -472,7 +472,7 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	mono_domain_lock (domain);
 	if (!domain->type_hash)
 		domain->type_hash = mono_g_hash_table_new_type ((GHashFunc)mono_metadata_type_hash, 
-				(GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, "domain reflection types table");
+				(GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Type Table");
 	if ((res = (MonoReflectionType *)mono_g_hash_table_lookup (domain->type_hash, type))) {
 		mono_domain_unlock (domain);
 		mono_loader_unlock ();

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -288,28 +288,11 @@ sgen_client_binary_protocol_collection_requested (int generation, size_t request
 	MONO_GC_REQUESTED (generation, requested_size, force);
 }
 
-static void G_GNUC_UNUSED
-sgen_client_binary_protocol_collection_begin (int minor_gc_count, int generation)
-{
-	MONO_GC_BEGIN (generation);
+void
+sgen_client_binary_protocol_collection_begin (int minor_gc_count, int generation);
 
-	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_START, generation));
-
-#ifndef DISABLE_PERFCOUNTERS
-	if (generation == GENERATION_NURSERY)
-		mono_atomic_inc_i32 (&mono_perfcounters->gc_collections0);
-	else
-		mono_atomic_inc_i32 (&mono_perfcounters->gc_collections1);
-#endif
-}
-
-static void G_GNUC_UNUSED
-sgen_client_binary_protocol_collection_end (int minor_gc_count, int generation, long long num_objects_scanned, long long num_unique_objects_scanned)
-{
-	MONO_GC_END (generation);
-
-	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_END, generation));
-}
+void
+sgen_client_binary_protocol_collection_end (int minor_gc_count, int generation, long long num_objects_scanned, long long num_unique_objects_scanned);
 
 static void G_GNUC_UNUSED
 sgen_client_binary_protocol_concurrent_start (void)
@@ -684,6 +667,18 @@ sgen_client_binary_protocol_header (long long check, int version, int ptr_size, 
 static void G_GNUC_UNUSED
 sgen_client_binary_protocol_pin_stats (int objects_pinned_in_nursery, size_t bytes_pinned_in_nursery, int objects_pinned_in_major, size_t bytes_pinned_in_major)
 {
+}
+
+static void G_GNUC_UNUSED
+sgen_client_root_registered (char *start, size_t size, int source, void *key, const char *msg)
+{
+	MONO_PROFILER_RAISE (gc_root_register, ((const mono_byte *) start, size, source, key, msg));
+}
+
+static void G_GNUC_UNUSED
+sgen_client_root_deregistered (char *start)
+{
+	MONO_PROFILER_RAISE (gc_root_unregister, ((const mono_byte *) start));
 }
 
 static void G_GNUC_UNUSED

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -443,6 +443,13 @@ sgen_client_zero_array_fill_header (void *p, size_t size)
 	}
 }
 
+MonoVTable *
+mono_gc_get_vtable (MonoObject *obj)
+{
+	// See sgen/sgen-tagged-pointer.h.
+	return SGEN_LOAD_VTABLE (obj);
+}
+
 /*
  * Finalization
  */
@@ -979,13 +986,13 @@ mono_gc_alloc_mature (MonoVTable *vtable, size_t size)
  * mono_gc_alloc_fixed:
  */
 void*
-mono_gc_alloc_fixed (size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg)
+mono_gc_alloc_fixed (size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg)
 {
 	/* FIXME: do a single allocation */
 	void *res = g_calloc (1, size);
 	if (!res)
 		return NULL;
-	if (!mono_gc_register_root ((char *)res, size, descr, source, msg)) {
+	if (!mono_gc_register_root ((char *)res, size, descr, source, key, msg)) {
 		g_free (res);
 		res = NULL;
 	}
@@ -1875,11 +1882,13 @@ mono_gc_set_string_length (MonoString *str, gint32 new_length)
  */
 
 #define GC_ROOT_NUM 32
+#define SPECIAL_ADDRESS_FIN_QUEUE ((void*)1)
+#define SPECIAL_ADDRESS_CRIT_FIN_QUEUE ((void*)2)
+
 typedef struct {
 	int count;		/* must be the first field */
+	void *addresses [GC_ROOT_NUM];
 	void *objects [GC_ROOT_NUM];
-	int root_types [GC_ROOT_NUM];
-	uintptr_t extra_info [GC_ROOT_NUM];
 } GCRootReport;
 
 static void
@@ -1887,63 +1896,34 @@ notify_gc_roots (GCRootReport *report)
 {
 	if (!report->count)
 		return;
-	MONO_PROFILER_RAISE (gc_roots, ((MonoObject **) report->objects, (MonoProfilerGCRootType *) report->root_types, report->extra_info, report->count));
+	MONO_PROFILER_RAISE (gc_roots, (report->count, (const mono_byte *const *)report->addresses, (MonoObject *const *) report->objects));
 	report->count = 0;
 }
 
 static void
-add_profile_gc_root (GCRootReport *report, void *object, int rtype, uintptr_t extra_info)
+report_gc_root (GCRootReport *report, void *address, void *object)
 {
 	if (report->count == GC_ROOT_NUM)
 		notify_gc_roots (report);
+	report->addresses [report->count] = address;
 	report->objects [report->count] = object;
-	report->root_types [report->count] = rtype;
-	report->extra_info [report->count++] = (uintptr_t)SGEN_LOAD_VTABLE (object)->klass;
+	report->count++;
 }
-
-void
-sgen_client_nursery_objects_pinned (void **definitely_pinned, int count)
-{
-	if (MONO_PROFILER_ENABLED (gc_roots)) {
-		GCRootReport report;
-		int idx;
-		report.count = 0;
-		for (idx = 0; idx < count; ++idx)
-			add_profile_gc_root (&report, definitely_pinned [idx], MONO_PROFILER_GC_ROOT_PINNING | MONO_PROFILER_GC_ROOT_MISC, 0);
-		notify_gc_roots (&report);
-	}
-}
-
-static void
-report_finalizer_roots_from_queue (SgenPointerQueue *queue)
-{
-	GCRootReport report;
-	size_t i;
-
-	report.count = 0;
-	for (i = 0; i < queue->next_slot; ++i) {
-		void *obj = queue->data [i];
-		if (!obj)
-			continue;
-		add_profile_gc_root (&report, obj, MONO_PROFILER_GC_ROOT_FINALIZER, 0);
-	}
-	notify_gc_roots (&report);
-}
-
-static void
-report_finalizer_roots (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue)
-{
-	report_finalizer_roots_from_queue (fin_ready_queue);
-	report_finalizer_roots_from_queue (critical_fin_queue);
-}
-
-static GCRootReport *root_report;
 
 static void
 single_arg_report_root (MonoObject **obj, void *gc_data)
 {
+	GCRootReport *report = gc_data;
 	if (*obj)
-		add_profile_gc_root (root_report, *obj, MONO_PROFILER_GC_ROOT_OTHER, 0);
+		report_gc_root (report, obj, *obj);
+}
+
+static void
+two_args_report_root (void *address, MonoObject *obj, void *gc_data)
+{
+	GCRootReport *report = gc_data;
+	if (obj)
+		report_gc_root (report, address, obj);
 }
 
 static void
@@ -1953,9 +1933,8 @@ precisely_report_roots_from (GCRootReport *report, void** start_root, void** end
 	case ROOT_DESC_BITMAP:
 		desc >>= ROOT_DESC_TYPE_SHIFT;
 		while (desc) {
-			if ((desc & 1) && *start_root) {
-				add_profile_gc_root (report, *start_root, MONO_PROFILER_GC_ROOT_OTHER, 0);
-			}
+			if ((desc & 1) && *start_root)
+				report_gc_root (report, start_root, *start_root);
 			desc >>= 1;
 			start_root++;
 		}
@@ -1969,9 +1948,8 @@ precisely_report_roots_from (GCRootReport *report, void** start_root, void** end
 			gsize bmap = *bitmap_data++;
 			void **objptr = start_run;
 			while (bmap) {
-				if ((bmap & 1) && *objptr) {
-					add_profile_gc_root (report, *objptr, MONO_PROFILER_GC_ROOT_OTHER, 0);
-				}
+				if ((bmap & 1) && *objptr)
+					report_gc_root (report, objptr, *objptr);
 				bmap >>= 1;
 				++objptr;
 			}
@@ -1984,14 +1962,17 @@ precisely_report_roots_from (GCRootReport *report, void** start_root, void** end
 
 		for (p = start_root; p < end_root; p++) {
 			if (*p)
-				add_profile_gc_root (report, *p, MONO_PROFILER_GC_ROOT_OTHER, 0);
+				report_gc_root (report, p, *p);
 		}
 		break;
 	}
 	case ROOT_DESC_USER: {
 		MonoGCRootMarkFunc marker = (MonoGCRootMarkFunc)sgen_get_user_descriptor_func (desc);
-		root_report = report;
-		marker ((MonoObject**)start_root, single_arg_report_root, NULL);
+
+		if ((void*)marker == (void*)sgen_mark_normal_gc_handles)
+			sgen_gc_handles_report_roots (two_args_report_root, report);
+		else
+			marker ((MonoObject**)start_root, single_arg_report_root, report);
 		break;
 	}
 	case ROOT_DESC_RUN_LEN:
@@ -2002,15 +1983,194 @@ precisely_report_roots_from (GCRootReport *report, void** start_root, void** end
 }
 
 static void
-report_registered_roots_by_type (int root_type)
+report_pinning_roots (GCRootReport *report, void **start, void **end)
+{
+	while (start < end) {
+		mword addr = (mword)*start;
+		addr &= ~(SGEN_ALLOC_ALIGN - 1);
+		if (addr)
+			report_gc_root (report, start, (void*)addr);
+
+		start++;
+	}
+}
+
+static SgenPointerQueue pinned_objects = SGEN_POINTER_QUEUE_INIT (INTERNAL_MEM_MOVED_OBJECT);
+static mword lower_bound, upper_bound;
+
+static GCObject*
+find_pinned_obj (char *addr)
+{
+	size_t idx = sgen_pointer_queue_search (&pinned_objects, addr);
+
+	if (idx != pinned_objects.next_slot) {
+		if (pinned_objects.data [idx] == addr)
+			return pinned_objects.data [idx];
+		if (idx == 0)
+			return NULL;
+	}
+
+	GCObject *obj = pinned_objects.data [idx - 1];
+	if (addr > (char*)obj && addr < ((char*)obj + sgen_safe_object_get_size (obj)))
+		return obj;
+	return NULL;
+}
+
+
+/*
+ * We pass @root_report_address so register are properly accounted towards their thread
+*/
+static void
+report_conservative_roots (GCRootReport *report, char *root_report_address, void **start, void **end)
+{
+	while (start < end) {
+		mword addr = (mword)*start;
+		addr &= ~(SGEN_ALLOC_ALIGN - 1);
+
+		if (addr < lower_bound || addr > upper_bound) {
+			++start;
+			continue;
+		}
+
+		GCObject *obj = find_pinned_obj ((char*)addr);
+		if (obj)
+			report_gc_root (report, root_report_address, obj);
+		start++;
+	}
+}
+
+typedef struct {
+	gboolean precise;
+	GCRootReport *report;
+	SgenThreadInfo *info;
+} ReportHandleStackRoot;
+
+static void
+report_handle_stack_root (gpointer *ptr, gpointer user_data)
+{
+	ReportHandleStackRoot *ud = user_data;
+	GCRootReport *report = ud->report;
+	gpointer addr = ud->info->client_info.info.handle_stack;
+
+	// Note: We know that *ptr != NULL.
+	if (ud->precise)
+		report_gc_root (report, addr, *ptr);
+	else
+		report_conservative_roots (report, addr, ptr, ptr + 1);
+}
+
+static void
+report_handle_stack_roots (GCRootReport *report, SgenThreadInfo *info, gboolean precise)
+{
+	ReportHandleStackRoot ud = {
+		.precise = precise,
+		.report = report,
+		.info = info,
+	};
+
+	mono_handle_stack_scan ((HandleStack *) info->client_info.info.handle_stack, report_handle_stack_root, &ud, ud.precise, FALSE);
+}
+
+static void
+report_stack_roots (void)
+{
+	GCRootReport report = {0};
+	FOREACH_THREAD (info) {
+		void *aligned_stack_start;
+
+		if (info->client_info.skip) {
+			continue;
+		} else if (info->client_info.gc_disabled) {
+			continue;
+		} else if (!mono_thread_info_is_live (info)) {
+			continue;
+		} else if (!info->client_info.stack_start) {
+			continue;
+		}
+
+		g_assert (info->client_info.stack_start);
+		g_assert (info->client_info.info.stack_end);
+
+		aligned_stack_start = (void*)(mword) ALIGN_TO ((mword)info->client_info.stack_start, SIZEOF_VOID_P);
+#ifdef HOST_WIN32
+		/* Windows uses a guard page before the committed stack memory pages to detect when the
+		   stack needs to be grown. If we suspend a thread just after a function prolog has
+		   decremented the stack pointer to point into the guard page but before the thread has
+		   been able to read or write to that page, starting the stack scan at aligned_stack_start
+		   will raise a STATUS_GUARD_PAGE_VIOLATION and the process will crash. This code uses
+		   VirtualQuery() to determine whether stack_start points into the guard page and then
+		   updates aligned_stack_start to point at the next non-guard page. */
+		MEMORY_BASIC_INFORMATION mem_info;
+		SIZE_T result = VirtualQuery (info->client_info.stack_start, &mem_info, sizeof(mem_info));
+		g_assert (result != 0);
+		if (mem_info.Protect & PAGE_GUARD) {
+			aligned_stack_start = ((char*) mem_info.BaseAddress) + mem_info.RegionSize;
+		}
+#endif
+
+		g_assert (info->client_info.suspend_done);
+
+		report_conservative_roots (&report, aligned_stack_start, (void **)aligned_stack_start, (void **)info->client_info.info.stack_end);
+		report_conservative_roots (&report, aligned_stack_start, (void**)&info->client_info.ctx, (void**)(&info->client_info.ctx + 1));
+
+		report_handle_stack_roots (&report, info, FALSE);
+		report_handle_stack_roots (&report, info, TRUE);
+	} FOREACH_THREAD_END
+
+	notify_gc_roots (&report);
+}
+
+static void
+report_pin_queue (void)
+{
+	lower_bound = SIZE_MAX;
+	upper_bound = 0;
+
+	//sort the addresses
+	sgen_pointer_queue_sort_uniq (&pinned_objects);
+
+	for (int i = 0; i < pinned_objects.next_slot; ++i) {
+		GCObject *obj = pinned_objects.data [i];
+		ssize_t size = sgen_safe_object_get_size (obj);
+
+		ssize_t addr = (ssize_t)obj;
+		lower_bound = MIN (lower_bound, addr);
+		upper_bound = MAX (upper_bound, addr + size);
+	}
+
+	report_stack_roots ();
+	sgen_pointer_queue_clear (&pinned_objects);
+}
+
+static void
+report_finalizer_roots_from_queue (SgenPointerQueue *queue, void* queue_address)
 {
 	GCRootReport report;
+	size_t i;
+
+	report.count = 0;
+	for (i = 0; i < queue->next_slot; ++i) {
+		void *obj = queue->data [i];
+		if (!obj)
+			continue;
+		report_gc_root (&report, queue_address, obj);
+	}
+	notify_gc_roots (&report);
+}
+
+static void
+report_registered_roots_by_type (int root_type)
+{
+	GCRootReport report = { 0 };
 	void **start_root;
 	RootRecord *root;
 	report.count = 0;
 	SGEN_HASH_TABLE_FOREACH (&roots_hash [root_type], void **, start_root, RootRecord *, root) {
-		SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
-		precisely_report_roots_from (&report, start_root, (void**)root->end_root, root->root_desc);
+		SGEN_LOG (6, "Profiler root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
+		if (root_type == ROOT_TYPE_PINNED)
+			report_pinning_roots (&report, start_root, (void**)root->end_root);
+		else
+			precisely_report_roots_from (&report, start_root, (void**)root->end_root, root->root_desc);
 	} SGEN_HASH_TABLE_FOREACH_END;
 	notify_gc_roots (&report);
 }
@@ -2018,52 +2178,85 @@ report_registered_roots_by_type (int root_type)
 static void
 report_registered_roots (void)
 {
-	report_registered_roots_by_type (ROOT_TYPE_NORMAL);
-	report_registered_roots_by_type (ROOT_TYPE_WBARRIER);
+	for (int i = 0; i < ROOT_TYPE_NUM; ++i)
+		report_registered_roots_by_type (i);
+}
+
+static void
+sgen_report_all_roots (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue)
+{
+	if (!MONO_PROFILER_ENABLED (gc_roots))
+		return;
+
+	report_registered_roots ();
+	report_pin_queue ();
+	report_finalizer_roots_from_queue (fin_ready_queue, SPECIAL_ADDRESS_FIN_QUEUE);
+	report_finalizer_roots_from_queue (critical_fin_queue, SPECIAL_ADDRESS_CRIT_FIN_QUEUE);
 }
 
 void
-sgen_client_collecting_minor (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue)
+sgen_client_pinning_start (void)
 {
-	if (MONO_PROFILER_ENABLED (gc_roots))
-		report_registered_roots ();
+	if (!MONO_PROFILER_ENABLED (gc_roots))
+		return;
 
-	if (MONO_PROFILER_ENABLED (gc_roots))
-		report_finalizer_roots (fin_ready_queue, critical_fin_queue);
+	sgen_pointer_queue_clear (&pinned_objects);
 }
 
-static GCRootReport major_root_report;
-static gboolean profile_roots;
+void
+sgen_client_pinning_end (void)
+{
+	if (!MONO_PROFILER_ENABLED (gc_roots))
+		return;
+}
 
 void
-sgen_client_collecting_major_1 (void)
+sgen_client_nursery_objects_pinned (void **definitely_pinned, int count)
 {
-	profile_roots = MONO_PROFILER_ENABLED (gc_roots);
-	memset (&major_root_report, 0, sizeof (GCRootReport));
+	if (!MONO_PROFILER_ENABLED (gc_roots))
+		return;
+
+	for (int i = 0; i < count; ++i)
+		sgen_pointer_queue_add (&pinned_objects, definitely_pinned [i]);
 }
 
 void
 sgen_client_pinned_los_object (GCObject *obj)
 {
-	if (profile_roots)
-		add_profile_gc_root (&major_root_report, (char*)obj, MONO_PROFILER_GC_ROOT_PINNING | MONO_PROFILER_GC_ROOT_MISC, 0);
+	if (!MONO_PROFILER_ENABLED (gc_roots))
+		return;
+
+	sgen_pointer_queue_add (&pinned_objects, obj);
 }
 
 void
-sgen_client_collecting_major_2 (void)
+sgen_client_pinned_cemented_object (GCObject *obj)
 {
-	if (profile_roots)
-		notify_gc_roots (&major_root_report);
+	if (!MONO_PROFILER_ENABLED (gc_roots))
+		return;
 
-	if (MONO_PROFILER_ENABLED (gc_roots))
-		report_registered_roots ();
+	// TODO: How do we report this in a way that makes sense?
 }
 
 void
-sgen_client_collecting_major_3 (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue)
+sgen_client_pinned_major_heap_object (GCObject *obj)
 {
-	if (MONO_PROFILER_ENABLED (gc_roots))
-		report_finalizer_roots (fin_ready_queue, critical_fin_queue);
+	if (!MONO_PROFILER_ENABLED (gc_roots))
+		return;
+
+	sgen_pointer_queue_add (&pinned_objects, obj);
+}
+
+void
+sgen_client_collecting_minor_report_roots (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue)
+{
+	sgen_report_all_roots (fin_ready_queue, critical_fin_queue);
+}
+
+void
+sgen_client_collecting_major_report_roots (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue)
+{
+	sgen_report_all_roots (fin_ready_queue, critical_fin_queue);
 }
 
 #define MOVED_OBJECTS_NUM 64
@@ -2454,12 +2647,12 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 			  beginning of the object.
 			*/
 			if (precise)
-				mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, (GcScanFunc)ctx.ops->copy_or_mark_object, ctx.queue, precise);
+				mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, (GcScanFunc)ctx.ops->copy_or_mark_object, ctx.queue, precise, TRUE);
 			else {
 				PinHandleStackInteriorPtrData ud = { .start_nursery = start_nursery,
 								     .end_nursery = end_nursery,
 				};
-				mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, pin_handle_stack_interior_ptrs, &ud, precise);
+				mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, pin_handle_stack_interior_ptrs, &ud, precise, FALSE);
 			}
 		}
 	} FOREACH_THREAD_END
@@ -2490,15 +2683,15 @@ mono_gc_set_stack_end (void *stack_end)
  */
 
 int
-mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg)
+mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg)
 {
-	return sgen_register_root (start, size, descr, descr ? ROOT_TYPE_NORMAL : ROOT_TYPE_PINNED, source, msg);
+	return sgen_register_root (start, size, descr, descr ? ROOT_TYPE_NORMAL : ROOT_TYPE_PINNED, source, key, msg);
 }
 
 int
-mono_gc_register_root_wbarrier (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg)
+mono_gc_register_root_wbarrier (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg)
 {
-	return sgen_register_root (start, size, descr, ROOT_TYPE_WBARRIER, source, msg);
+	return sgen_register_root (start, size, descr, ROOT_TYPE_WBARRIER, source, key, msg);
 }
 
 void
@@ -2532,6 +2725,8 @@ mono_gc_pthread_create (pthread_t *new_thread, const pthread_attr_t *attr, void 
 void
 sgen_client_total_allocated_heap_changed (size_t allocated_heap)
 {
+	MONO_PROFILER_RAISE (gc_resize, (allocated_heap));
+
 	mono_runtime_resource_check_limit (MONO_RESOURCE_GC_HEAP, allocated_heap);
 }
 
@@ -3109,4 +3304,34 @@ sgen_client_get_weak_bitmap (MonoVTable *vt, int *nbits)
 	return mono_class_get_weak_bitmap (klass, nbits);
 }
 
+void
+sgen_client_binary_protocol_collection_begin (int minor_gc_count, int generation)
+{
+	static gboolean pseudo_roots_registered;
+
+	MONO_GC_BEGIN (generation);
+
+	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_START, generation));
+
+	if (!pseudo_roots_registered) {
+		pseudo_roots_registered = TRUE;
+		MONO_PROFILER_RAISE (gc_root_register, (SPECIAL_ADDRESS_FIN_QUEUE, 1, MONO_ROOT_SOURCE_FINALIZER_QUEUE, NULL, "Finalizer Queue"));
+		MONO_PROFILER_RAISE (gc_root_register, (SPECIAL_ADDRESS_CRIT_FIN_QUEUE, 1, MONO_ROOT_SOURCE_FINALIZER_QUEUE, NULL, "Finalizer Queue (Critical)"));
+	}
+
+#ifndef DISABLE_PERFCOUNTERS
+	if (generation == GENERATION_NURSERY)
+		mono_atomic_inc_i32 (&mono_perfcounters->gc_collections0);
+	else
+		mono_atomic_inc_i32 (&mono_perfcounters->gc_collections1);
+#endif
+}
+
+void
+sgen_client_binary_protocol_collection_end (int minor_gc_count, int generation, long long num_objects_scanned, long long num_unique_objects_scanned)
+{
+	MONO_GC_END (generation);
+
+	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_END, generation));
+}
 #endif

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -966,7 +966,7 @@ mono_image_get_generic_param_info (MonoReflectionGenericParam *gparam, guint32 o
 	entry = g_new0 (GenericParamTableEntry, 1);
 	entry->owner = owner;
 	/* FIXME: track where gen_params should be freed and remove the GC root as well */
-	MONO_GC_REGISTER_ROOT_IF_MOVING (entry->gparam, MONO_ROOT_SOURCE_REFLECTION, "reflection generic parameter");
+	MONO_GC_REGISTER_ROOT_IF_MOVING (entry->gparam, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Generic Parameter");
 	entry->gparam = gparam;
 	
 	g_ptr_array_add (assembly->gen_params, entry);
@@ -2380,7 +2380,7 @@ mono_image_build_metadata (MonoReflectionModuleBuilder *moduleb, MonoError *erro
 	goto_if_nok (error, leave);
 
 	/* Collect all types into a list sorted by their table_idx */
-	mono_ptr_array_init (types, moduleb->num_types, MONO_ROOT_SOURCE_REFLECTION, "dynamic module types list");
+	mono_ptr_array_init (types, moduleb->num_types, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Type List");
 
 	if (moduleb->types)
 		for (i = 0; i < moduleb->num_types; ++i) {

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -319,12 +319,17 @@ selector_thread (gpointer data)
 	MonoError error;
 	MonoGHashTable *states;
 
+	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", &error);
+	mono_error_assert_ok (&error);
+	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, FALSE, TRUE, &error);
+	mono_error_assert_ok (&error);
+
 	if (mono_runtime_is_shutting_down ()) {
 		io_selector_running = FALSE;
 		return 0;
 	}
 
-	states = mono_g_hash_table_new_type (g_direct_hash, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_THREAD_POOL, "i/o thread pool states table");
+	states = mono_g_hash_table_new_type (g_direct_hash, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_THREAD_POOL, NULL, "Thread Pool I/O State Table");
 
 	while (!mono_runtime_is_shutting_down ()) {
 		gint i, j;
@@ -541,7 +546,7 @@ initialize (void)
 
 	mono_coop_mutex_init (&threadpool_io->updates_lock);
 	mono_coop_cond_init (&threadpool_io->updates_cond);
-	mono_gc_register_root ((char *)&threadpool_io->updates [0], sizeof (threadpool_io->updates), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_THREAD_POOL, "i/o thread pool updates list");
+	mono_gc_register_root ((char *)&threadpool_io->updates [0], sizeof (threadpool_io->updates), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_THREAD_POOL, NULL, "Thread Pool I/O Update List");
 
 	threadpool_io->updates_size = 0;
 

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -350,7 +350,7 @@ worker_callback (void)
 
 		domains_unlock ();
 
-		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Threadpool worker", &error);
+		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", &error);
 		mono_error_assert_ok (&error);
 		mono_thread_set_name_internal (thread, thread_name, FALSE, TRUE, &error);
 		mono_error_assert_ok (&error);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1009,11 +1009,11 @@ mono_debugger_agent_init (void)
 	/* Needed by the hash_table_new_type () call below */
 	mono_gc_base_init ();
 
-	thread_to_tls = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, "thread-to-tls table");
+	thread_to_tls = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger TLS Table");
 
-	tid_to_thread = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread table");
+	tid_to_thread = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger Thread Table");
 
-	tid_to_thread_obj = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, "tid-to-thread object table");
+	tid_to_thread_obj = mono_g_hash_table_new_type (NULL, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger Thread Object Table");
 
 	pending_assembly_loads = g_ptr_array_new ();
 	domains = g_hash_table_new (mono_aligned_addr_hash, NULL);
@@ -1956,7 +1956,7 @@ objrefs_init (void)
 {
 	objrefs = g_hash_table_new_full (NULL, NULL, NULL, free_objref);
 	obj_to_objref = g_hash_table_new (NULL, NULL);
-	suspended_objs = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, "suspended objects table");
+	suspended_objs = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger Suspended Object Table");
 }
 
 static void
@@ -3901,7 +3901,7 @@ thread_startup (MonoProfiler *prof, uintptr_t tid)
 	g_assert (!tls);
 	// FIXME: Free this somewhere
 	tls = g_new0 (DebuggerTlsData, 1);
-	MONO_GC_REGISTER_ROOT_SINGLE (tls->thread, MONO_ROOT_SOURCE_DEBUGGER, "debugger thread reference");
+	MONO_GC_REGISTER_ROOT_SINGLE (tls->thread, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger Thread Reference");
 	tls->thread = thread;
 	mono_native_tls_set_value (debugger_tls_id, tls);
 

--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -113,7 +113,7 @@ continuation_store (MonoContinuation *cont, int state, MonoException **e)
 			mono_gc_free_fixed (cont->saved_stack);
 		cont->stack_used_size = num_bytes;
 		cont->stack_alloc_size = num_bytes * 1.1;
-		cont->saved_stack = mono_gc_alloc_fixed (cont->stack_alloc_size, NULL, MONO_ROOT_SOURCE_THREADING, "saved tasklet stack");
+		cont->saved_stack = mono_gc_alloc_fixed (cont->stack_alloc_size, NULL, MONO_ROOT_SOURCE_THREADING, NULL, "Tasklet Saved Stack");
 		tasklets_unlock ();
 	}
 	memcpy (cont->saved_stack, cont->return_sp, num_bytes);

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -107,19 +107,30 @@ void sgen_client_nursery_objects_pinned (void **definitely_pinned, int count);
 /*
  * Called at a semi-random point during minor collections.  No action is necessary.
  */
-void sgen_client_collecting_minor (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue);
+void sgen_client_collecting_minor_report_roots (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue);
 
 /*
  * Called at semi-random points during major collections.  No action is necessary.
  */
-void sgen_client_collecting_major_1 (void);
-void sgen_client_collecting_major_2 (void);
-void sgen_client_collecting_major_3 (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue);
+void sgen_client_collecting_major_report_roots (SgenPointerQueue *fin_ready_queue, SgenPointerQueue *critical_fin_queue);
 
 /*
  * Called after a LOS object has been pinned.  No action is necessary.
  */
 void sgen_client_pinned_los_object (GCObject *obj);
+
+/*
+ * Called for each cemented obj
+ */
+void sgen_client_pinned_cemented_object (GCObject *obj);
+
+/*
+ * Called for each major heap obj pinned
+ */
+void sgen_client_pinned_major_heap_object (GCObject *obj);
+
+void sgen_client_pinning_start (void);
+void sgen_client_pinning_end (void);
 
 /*
  * Called for every degraded allocation.  No action is necessary.

--- a/mono/sgen/sgen-descriptor.h
+++ b/mono/sgen/sgen-descriptor.h
@@ -122,6 +122,7 @@ enum {
 };
 
 typedef void (*SgenUserMarkFunc)     (GCObject **addr, void *gc_data);
+typedef void (*SgenUserReportRootFunc)     (void *addr, GCObject *obj, void *gc_data);
 typedef void (*SgenUserRootMarkFunc) (void *addr, SgenUserMarkFunc mark_func, void *gc_data);
 
 SgenDescriptor sgen_make_user_root_descriptor (SgenUserRootMarkFunc marker);

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -394,7 +394,7 @@ enum {
 
 extern SgenHashTable roots_hash [ROOT_TYPE_NUM];
 
-int sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type, int source, const char *msg)
+int sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_type, int source, void *key, const char *msg)
 	MONO_PERMIT (need (sgen_lock_gc));
 void sgen_deregister_root (char* addr)
 	MONO_PERMIT (need (sgen_lock_gc));
@@ -1015,6 +1015,8 @@ void sgen_gchandle_iterate (GCHandleType handle_type, int max_generation, SgenGC
 	MONO_PERMIT (need (sgen_world_stopped));
 void sgen_gchandle_set_target (guint32 gchandle, GCObject *obj);
 void sgen_mark_normal_gc_handles (void *addr, SgenUserMarkFunc mark_func, void *gc_data)
+	MONO_PERMIT (need (sgen_world_stopped));
+void sgen_gc_handles_report_roots (SgenUserReportRootFunc mark_func, void *gc_data)
 	MONO_PERMIT (need (sgen_world_stopped));
 gpointer sgen_gchandle_get_metadata (guint32 gchandle);
 GCObject *sgen_gchandle_get_target (guint32 gchandle);

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -1410,6 +1410,7 @@ mark_pinned_objects_in_block (MSBlockInfo *block, size_t first_entry, size_t las
 			continue;
 		MS_MARK_OBJECT_AND_ENQUEUE (obj, sgen_obj_get_descriptor (obj), block, queue);
 		sgen_pin_stats_register_object (obj, GENERATION_OLD);
+		sgen_client_pinned_major_heap_object (obj);
 		last_index = index;
 	}
 

--- a/mono/sgen/sgen-pinning.c
+++ b/mono/sgen/sgen-pinning.c
@@ -43,6 +43,7 @@ sgen_init_pinning (void)
 {
 	memset (pin_hash_filter, 0, sizeof (pin_hash_filter));
 	pin_queue.mem_type = INTERNAL_MEM_PIN_QUEUE;
+	sgen_client_pinning_start ();
 }
 
 void
@@ -367,6 +368,7 @@ pin_from_hash (CementHashEntry *hash, gboolean has_been_reset)
 		if (has_been_reset)
 			SGEN_ASSERT (5, hash [i].count >= SGEN_CEMENT_THRESHOLD, "Cementing hash inconsistent");
 
+		sgen_client_pinned_cemented_object (hash [i].obj);
 		sgen_pin_stage_ptr (hash [i].obj);
 		binary_protocol_cement_stage (hash [i].obj);
 		/* FIXME: do pin stats if enabled */


### PR DESCRIPTION
This is rebased on master and with a few changes compared to #5710:

* `[Obsolete]` has been applied to the old roots-related stuff in `Mono.Profiler.Log`.
* Root descriptions have been cleaned up and now use Title Case.
* Roots in handle stacks are now reported (handle stacks are treated as pseudo-roots similar to the finalizer queues).
* Added `MONO_PROFILER_EVENT_5` definition to `profiler-events.h` to avoid breaking existing users.
* The `TYPE_HEAP_ROOT` event is now written as `address` followed by `object`, as opposed to the other way around.
* Fixed the decoding logic for `TYPE_HEAP_ROOT` in `mprof-report` (it handled v14 incorrectly).
* Root register/unregister events are always emitted in the log file (this is necessary to make dynamic toggling of root events work).
* The key for `static` variable roots is now the `MonoVTable` pointer.
* Added VTable load callbacks to the profiler API.
* Added VTable metadata events to the log format.
* Normalize some root key values before writing to the log file (e.g. we should write the domain ID, not the `MonoDomain` pointer).
* Use VTable pointers instead of class pointers in `TYPE_HEAP_OBJECT` and `TYPE_ALLOC`.
* Fixed `emit_ptr` in the profiler, which could write nonsense to a buffer if the first pointer written in a buffer was `NULL`.
* Added support for the `gc_resize` profiler event in SGen.