### PR TITLE
[mini] Make sure mkbundle executables work if they are run from a path on the PATH environment variable.

### DIFF
--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -16,7 +16,9 @@
  */
 #include <config.h>
 #include <fcntl.h>
+#ifndef HOST_WIN32
 #include <dirent.h>
+#endif
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/mono-config.h>
 #include <mono/utils/mono-mmap.h>


### PR DESCRIPTION
This is a patch to enable mkbundle executable files to work when they are run from a path that is on the PATH environment variable.

Mono mini has a function probe_embedded() which looks for the program's file (using argv[0]). If the program is run from a path on the PATH environment variable then the open() fails and only a single parameter is sent to the mono_main() which in turn causes an "if" condition to print the help and exit.

This patch searches through the directories specified in the current environment's PATH variable and tries to open() then first file found.