### PR TITLE
[linker-analyzer] Fix error reporting

### DIFF
--- a/mcs/tools/linker-analyzer/LinkerAnalyzerCore/DependencyGraph.cs
+++ b/mcs/tools/linker-analyzer/LinkerAnalyzerCore/DependencyGraph.cs
@@ -39,14 +39,14 @@ namespace LinkerAnalyzer.Core
 		{
 			Console.WriteLine ("Loading dependency tree from: {0}", filename);
 
-			using (var fileStream = File.OpenRead (filename))
-			using (var zipStream = new GZipStream (fileStream, CompressionMode.Decompress)) {
-				try {
+			try {
+				using (var fileStream = File.OpenRead (filename))
+				using (var zipStream = new GZipStream (fileStream, CompressionMode.Decompress)) {
 					Load (zipStream);
-				} catch (Exception) {
-					Console.WriteLine ("Unable to open and read the dependecies.");
-					Environment.Exit (1);
 				}
+			} catch (Exception) {
+				Console.WriteLine ("Unable to open and read the dependecies.");
+				Environment.Exit (1);
 			}
 		}
 


### PR DESCRIPTION
Make sure we don't "crash" with an unhandled exception and instead
report a problem loading the file.