### PR TITLE
Fix genproj.cs (make update-solution-files)

### DIFF
--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -756,7 +756,8 @@ class MsbuildGenerator {
 
 			sources.AppendFormat ("    <Compile Include=\"{0}\" />" + NewLine, src);
 		}
-		sources.Remove (sources.Length - 1, 1);
+		if (sources.Length > 1)
+			sources.Remove (sources.Length - 1, 1);
 
 		//if (library == "corlib-build") // otherwise, does not compile on fx_version == 4.0
 		//{


### PR DESCRIPTION
`make update-solution-files`
works but actually throws an ArgumentOutOfRangeException
and as a result - corrupted csproj
(fails on System.Runtime.CompilerServices.Unsafe - System.Runtime.CompilerServices.Unsafe.dll.sources is empty)