### PR TITLE
[mini] Allow stind.ref only on object references.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -6245,7 +6245,7 @@ emit_marshal_object (EmitMarshalContext *m, int argnum, MonoType *t,
 			pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-			mono_mb_emit_byte (mb, CEE_STIND_REF);
+			mono_mb_emit_byte (mb, CEE_STIND_I);
 			pos2 = mono_mb_emit_branch (mb, CEE_BR);
 
 			mono_mb_patch_branch (mb, pos);			
@@ -6622,7 +6622,7 @@ emit_marshal_array (EmitMarshalContext *m, int argnum, MonoType *t,
 				/* Null terminate */
 				mono_mb_emit_ldloc (mb, dest_ptr);
 				mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-				mono_mb_emit_byte (mb, CEE_STIND_REF);
+				mono_mb_emit_byte (mb, CEE_STIND_I);
 			}
 
 			mono_mb_patch_branch (mb, label1);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9530,8 +9530,13 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			MONO_ADD_INS (cfg->cbb, ins);
 
-			if (cfg->gen_write_barriers && *ip == CEE_STIND_REF && method->wrapper_type != MONO_WRAPPER_WRITE_BARRIER && !MONO_INS_IS_PCONST_NULL (sp [1]))
-				mini_emit_write_barrier (cfg, sp [0], sp [1]);
+			if (*ip == CEE_STIND_REF) {
+				/* stind.ref must only be used with object references. */
+				if (sp [1]->type != STACK_OBJ)
+					UNVERIFIED;
+				if (cfg->gen_write_barriers && method->wrapper_type != MONO_WRAPPER_WRITE_BARRIER && !MONO_INS_IS_PCONST_NULL (sp [1]))
+					mini_emit_write_barrier (cfg, sp [0], sp [1]);
+			}
 
 			inline_costs += 1;
 			++ip;


### PR DESCRIPTION
rebased https://github.com/mono/mono/pull/1630