### PR TITLE
[runtime] Bring jemalloc to mono

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ extra_runtime_ldflags=""
 # Hack for WASM
 # Current autotools (v1.15) doesn't have a triplet we can use for wasm so the kludge we do is to
 # work around it by using a feature flag instead
-AC_ARG_ENABLE(wasm,[  --enable-wasm	Hack to set the current runtime to target wasm], enable_wasm=$enableval)
+AC_ARG_ENABLE(wasm,[  --enable-wasm    Hack to set the current runtime to target wasm], enable_wasm=$enableval)
 
 # Thread configuration inspired by sleepycat's db
 AC_MSG_CHECKING([host platform characteristics])
@@ -912,6 +912,51 @@ if test $csc_compiler = default; then
    fi
 fi
 AC_MSG_RESULT($csc_compiler)
+
+AC_ARG_WITH(jemalloc,             [  --with-jemalloc=yes,no               If jemalloc is enabled (defaults to no)],                                     [], [with_jemalloc=no])
+AC_ARG_WITH(jemalloc-always,      [  --with-jemalloc_always=yes,no        If jemalloc is enabled and always used (defaults to yes)],                    [], [with_jemalloc_always=no])
+AC_ARG_WITH(jemalloc-assert,      [  --with-jemalloc_assert=yes,no        If jemalloc performs runtime checks for memory correctness (defaults to no)], [], [with_jemalloc_assert=no])
+
+
+if test x$target_win32 = xyes; then
+with_jemalloc=no
+with_jemalloc_assert=no
+with_jemalloc_always=no
+fi
+
+AM_CONDITIONAL(MONO_JEMALLOC_ASSERT, [test "x$with_jemalloc_assert" = "xyes"])
+if test "x$with_jemalloc_assert" = "xyes"; then
+JEMALLOC_CFLAGS+=" -DMONO_JEMALLOC_ASSERT"
+AC_DEFINE(MONO_JEMALLOC_ASSERT, 1, [Make jemalloc assert for mono])
+AC_SUBST(MONO_JEMALLOC_ASSERT, 1)
+fi
+
+AM_CONDITIONAL(MONO_JEMALLOC_DEFAULT, [test "x$with_jemalloc_always" = "xyes"])
+if test "x$with_jemalloc_always" = "xyes"; then
+with_jemalloc=yes
+JEMALLOC_CFLAGS+=" -DMONO_JEMALLOC_DEFAULT"
+AC_DEFINE(MONO_JEMALLOC_DEFAULT, 1, [Make jemalloc default for mono])
+AC_SUBST(MONO_JEMALLOC_DEFAULT, 1)
+fi
+
+AM_CONDITIONAL(MONO_JEMALLOC_ENABLED, [test "x$with_jemalloc" = "xyes"])
+if test "x$with_jemalloc" = "xyes"; then
+JEMALLOC_LDFLAGS="-L`pwd`/mono/utils/jemalloc/jemalloc/lib -ljemalloc_pic"
+JEMALLOC_CFLAGS+=" -DMONO_JEMALLOC_ENABLED -I `pwd`/mono/utils/jemalloc/jemalloc/include"
+JEMALLOC_AUTOCONF_FLAGS=" --build=$target --host=$host"
+
+if test "x$target_mach" = "xyes"; then
+	JEMALLOC_CPPFLAGS=" -stdlib=libc++ "
+fi
+
+AC_DEFINE(MONO_JEMALLOC_ENABLED, 1, [Enable jemalloc usage for mono])
+AC_SUBST(MONO_JEMALLOC_ENABLED, 1)
+
+AC_SUBST(JEMALLOC_CFLAGS)
+AC_SUBST(JEMALLOC_CPPFLAGS)
+AC_SUBST(JEMALLOC_LDFLAGS)
+AC_SUBST(JEMALLOC_AUTOCONF_FLAGS)
+fi
 
 #
 # Set the build profiles and options before things which use them
@@ -4694,6 +4739,7 @@ scripts/mono-find-requires
 mono/Makefile
 mono/btls/Makefile
 mono/utils/Makefile
+mono/utils/jemalloc/Makefile
 mono/metadata/Makefile
 mono/dis/Makefile
 mono/cil/Makefile
@@ -4933,6 +4979,7 @@ echo "
 	libgdiplus:      $libgdiplus_msg
 	zlib:            $zlib_msg
 	BTLS:            $enable_btls$btls_platform_string
+	jemalloc:        $with_jemalloc (always use: $with_jemalloc_always)
 	$disabled
 "
 if test x$with_static_mono = xno -a "x$host_win32" != "xyes"; then

--- a/mono/Makefile.am
+++ b/mono/Makefile.am
@@ -34,7 +34,7 @@ monotouch-do-clean:
 	  (cd $$subdir && $(MAKE) $(AM_MAKEFLAGS) $$target); \
     done;
 else
-SUBDIRS = $(btls_dirs) eglib arch utils cil metadata $(sgen_dirs) mini dis tests unit-tests benchmark profiler
+SUBDIRS = $(btls_dirs) eglib arch utils cil metadata $(sgen_dirs) mini dis tests unit-tests benchmark profiler 
 endif
 endif
-DIST_SUBDIRS = btls eglib arch utils cil metadata $(sgen_dirs) mini dis tests unit-tests benchmark profiler
+DIST_SUBDIRS = btls eglib arch utils cil metadata $(sgen_dirs) mini dis tests unit-tests benchmark profiler 

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -67,6 +67,7 @@ AM_CFLAGS = \
 	-I$(top_srcdir) 	\
 	$(GLIB_CFLAGS)		\
 	$(LLVM_CFLAGS)		\
+	$(JEMALLOC_CFLAGS)	\
 	$(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS)
 
 AM_CXXFLAGS = $(LLVM_CXXFLAGS) $(GLIB_CFLAGS)
@@ -633,6 +634,11 @@ if HOST_DARWIN
 os_sources = $(darwin_sources) $(posix_sources)
 #monobin_platform_ldflags=-sectcreate __TEXT __info_plist $(top_srcdir)/mono/mini/Info.plist -framework CoreFoundation -framework Foundation
 monobin_platform_ldflags=-framework CoreFoundation -framework Foundation
+endif
+
+if MONO_JEMALLOC_ENABLED
+libmonoldflags += $(JEMALLOC_LDFLAGS)
+mono_CFLAGS += $(JEMALLOC_CFLAGS)
 endif
 
 libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(interp_sources) $(arch_sources) $(os_sources)

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1824,6 +1824,20 @@ mono_main (int argc, char* argv[])
 
 	if (g_hasenv ("MONO_NO_SMP"))
 		mono_set_use_smp (FALSE);
+
+#ifdef MONO_JEMALLOC_ENABLED
+
+	gboolean use_jemalloc = FALSE;
+#ifdef MONO_JEMALLOC_DEFAULT
+	use_jemalloc = TRUE;
+#endif
+	if (!use_jemalloc)
+		use_jemalloc = g_hasenv ("MONO_USE_JEMALLOC");
+
+	if (use_jemalloc)
+		mono_init_jemalloc ();
+
+#endif
 	
 	g_log_set_always_fatal (G_LOG_LEVEL_ERROR);
 	g_log_set_fatal_mask (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -35,6 +35,7 @@
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-tls.h>
 #include <mono/utils/atomic.h>
+#include <mono/utils/mono-jemalloc.h>
 #include <mono/utils/mono-conc-hashtable.h>
 #include <mono/utils/mono-signal-handler.h>
 

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -73,6 +73,7 @@ monoutils_sources = \
 	mono-proclib.h		\
 	mono-proclib-windows-internals.h		\
 	mono-publib.c		\
+	mono-jemalloc.c		\
 	mono-string.h		\
 	mono-time.c  		\
 	mono-time.h  		\
@@ -262,13 +263,21 @@ arch_sources += mono-hwcap-cross.c
 endif
 
 libmonoutils_la_SOURCES = $(monoutils_sources) $(arch_sources)
+libmonoutils_la_CFLAGS = $(JEMALLOC_CFLAGS)
+libmonoutils_la_LDFLAGS = $(JEMALLOC_LDFLAGS)
 libmonoutilsincludedir = $(includedir)/mono-$(API_VER)/mono/utils
 
 libmonoutilsinclude_HEADERS = 	\
 	mono-logger.h		\
 	mono-error.h		\
 	mono-publib.h		\
+	mono-jemalloc.h		\
 	mono-dl-fallback.h	\
 	mono-counters.h
 
 EXTRA_DIST = mono-embed.h mono-embed.c
+
+if MONO_JEMALLOC_ENABLED
+SUBDIRS = jemalloc
+DIST_SUBDIRS = jemalloc
+endif

--- a/mono/utils/jemalloc/.gitignore
+++ b/mono/utils/jemalloc/.gitignore
@@ -1,0 +1,3 @@
+/Makefile
+/Makefile.in
+/jemalloc

--- a/mono/utils/jemalloc/Makefile.am
+++ b/mono/utils/jemalloc/Makefile.am
@@ -1,0 +1,49 @@
+#
+# Conditional submodule for jemalloc
+#
+# make reset-jemalloc will checkout a version of jemalloc which is suitable for this version of mono
+# into $top_srcdir/jemalloc/jemalloc.
+#
+
+JEMALLOC_PATH=jemalloc
+
+SUBMODULES_CONFIG_FILE = $(top_srcdir)/mono/utils/jemalloc/SUBMODULES.json
+include $(top_srcdir)/scripts/submodules/versions.mk
+
+$(eval $(call ValidateVersionTemplate,jemalloc,JEMALLOC))
+
+# Bump the given submodule to the revision given by the REV make variable
+# If COMMIT is 1, commit the change
+bump-jemalloc: __bump-version-jemalloc
+
+# Bump the given submodule to the branch given by the BRANCH/REMOTE_BRANCH make variables
+# If COMMIT is 1, commit the change
+bump-branch-jemalloc: __bump-branch-jemalloc
+
+# Bump the given submodule to its current GIT version
+# If COMMIT is 1, commit the change
+bump-current-jemalloc: __bump-current-version-jemalloc
+
+clean-local:
+	$(RM) -r $(JEMALLOC_PATH)
+
+EXTRA_DIST=SUBMODULES.json
+
+if MONO_JEMALLOC_ASSERT
+ASSERT_OPT=--enable-debug
+endif
+
+jemalloc:
+	make reset-jemalloc
+
+# Set a prefix to enable access to allocation functions with a prefix, ie so mono_jemalloc isn't named malloc by default
+# Disable zone allocator, otherwise malloc uses jemalloc for things it's not set for
+# We call autoconf ourselves so we can call configure and not autogen. Autogen script is broken, minor bash issues around quote escaping
+jemalloc/lib/libjemalloc.a: jemalloc Makefile
+	cd jemalloc && autoconf && ./configure --with-jemalloc-prefix=mono_je --prefix=`pwd` $(ASSERT_OPT) $(JEMALLOC_AUTOCONF_FLAGS) --disable-zone-allocator EXTRA_CFLAGS="-I $(top_srcdir) $(GLIB_CFLAGS) $(CFLAGS) $(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS) " CC="$(CC)" CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS) $(JEMALLOC_CPPFLAGS) " CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)"
+
+	cd jemalloc && make build_lib_static 
+
+all-local: jemalloc/lib/libjemalloc.a
+
+

--- a/mono/utils/jemalloc/SUBMODULES.json
+++ b/mono/utils/jemalloc/SUBMODULES.json
@@ -1,0 +1,10 @@
+[
+  {
+      "name": "jemalloc", 
+      "url": "git://github.com/mono/jemalloc.git",
+      "rev": "896ed3a8b3f41998d4fb4d625d30ac63ef2d51fb",
+      "remote-branch": "origin/master", 
+      "branch": "master", 
+      "directory": "jemalloc"
+  }
+]

--- a/mono/utils/mono-jemalloc.c
+++ b/mono/utils/mono-jemalloc.c
@@ -1,0 +1,19 @@
+/**
+ * \file
+ *
+ * Jemalloc registration code
+ */
+
+#include <glib.h>
+#include <mono/utils/mono-jemalloc.h>
+
+#ifdef MONO_JEMALLOC_ENABLED
+
+void 
+mono_init_jemalloc (void)
+{
+	GMemVTable g_mem_vtable = { MONO_JEMALLOC_MALLOC, MONO_JEMALLOC_REALLOC, MONO_JEMALLOC_FREE, MONO_JEMALLOC_CALLOC};
+	g_mem_set_vtable (&g_mem_vtable);
+}
+
+#endif

--- a/mono/utils/mono-jemalloc.h
+++ b/mono/utils/mono-jemalloc.h
@@ -1,0 +1,36 @@
+/**
+ * \file
+ *
+ * Header for jemalloc registration code
+ */
+
+#ifndef __MONO_JEMALLOC_H__
+#define __MONO_JEMALLOC_H__
+
+#if defined(MONO_JEMALLOC_ENABLED)
+
+#include <jemalloc/jemalloc.h>
+
+/* Jemalloc can be configured in three ways.
+ * 1. You can use it with library loading hacks at run-time
+ * 2. You can use it as a global malloc replacement
+ * 3. You can use it with a prefix. If you use it with a prefix, you have to explicitly name the malloc function.
+ *
+ * In order to make this feature able to be toggled at run-time, I chose to use a prefix of mono_je. 
+ * This mapping is captured below in the header, in the spirit of "no magic constants".
+ *
+ * The place that configures jemalloc and sets this prefix is in the Makefile in
+ * mono/jemalloc/Makefile.am 
+ *
+ */
+#define MONO_JEMALLOC_MALLOC mono_jemalloc
+#define MONO_JEMALLOC_REALLOC mono_jerealloc
+#define MONO_JEMALLOC_FREE mono_jefree
+#define MONO_JEMALLOC_CALLOC mono_jecalloc
+
+void mono_init_jemalloc (void);
+
+#endif
+
+#endif
+

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -35,8 +35,8 @@ if [[ $CI_TAGS == *'retry-flaky-tests'* ]]; then
     export MONO_FLAKY_TEST_RETRIES=5
 fi
 
-if [[ ${label} == 'osx-i386' ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib --build=i386-apple-darwin11.2.0"; fi
-if [[ ${label} == 'osx-amd64' ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib "; fi
+if [[ ${label} == 'osx-i386' ]]; then CFLAGS="$CFLAGS -m32 -arch=i386"; LDFLAGS="-m32 -arch=i386"; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib --host=i386-apple-darwin11.2.0 --build=i386-apple-darwin11.2.0"; fi
+if [[ ${label} == 'osx-amd64' ]]; then CFLAGS="$CFLAGS -m64 -arch x86_64"; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib"; fi
 if [[ ${label} == 'w32' ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
 if [[ ${label} == 'w64' ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
 


### PR DESCRIPTION
Jemalloc is known to have much better performance than system memory
allocators, and is safe in concurrent/re-entrant situations.

To use, provide the following options to configure:

--with-jemalloc to enable optionally. To use at runtime,
export MONO_USE_JEMALLOC to the environment.

--with-jemalloc-always to enable and make the default

--with-jemalloc-assert to enable with assertions to catch memory
unsafety. It adds overhead, but an overhead that's much less than
valgrind or asan.

If you export
MONO_JEMALLOC_CONF="stats_print:true"

You will see detailed memory statistics for mono at exit.

Now note that jemalloc is used through an explicit registration, so
C libraries called through pinvoke calls will not use jemalloc unless
they configure themselves to do so separately.

To understand the build work, I'm statically linking jemalloc.a into
the compilation unit for mono/utils/mono-jemalloc.c, which is
responsible for registering it with mono at startup. No further
copying out of the submodule is necessary at installation time.