### PR TITLE
[interp] on cee_ret use underlying type which handles, among other things, ref types correctly

### DIFF
--- a/mcs/tests/known-issues-interp-net_4_x
+++ b/mcs/tests/known-issues-interp-net_4_x
@@ -18,5 +18,3 @@ test-399.cs
 test-704.cs
 test-811.cs
 test-async-17.cs
-test-ref-08.cs IGNORE
-test-ref-09.cs IGNORE


### PR DESCRIPTION

while at it:
* only get `MonoClass` if really necessary.
* use helper function to print method with signature.

fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=60756