### PR TITLE
[amd64] Rework native entry tramp from interp

### DIFF
--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -287,6 +287,12 @@ DECL_OFFSET(InterpMethodArguments, flen)
 DECL_OFFSET(InterpMethodArguments, fargs)
 DECL_OFFSET(InterpMethodArguments, retval)
 DECL_OFFSET(InterpMethodArguments, is_float_ret)
+#if defined(TARGET_AMD64)
+DECL_OFFSET(CallContext, gregs)
+DECL_OFFSET(CallContext, fregs)
+DECL_OFFSET(CallContext, stack_size)
+DECL_OFFSET(CallContext, stack)
+#endif
 #endif
 
 #endif //DISABLE_JIT_OFFSETS

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -493,8 +493,7 @@ stackval_from_data (MonoType *type_, stackval *result, char *data, gboolean pinv
 		return;
 	}
 	default:
-		g_warning ("got type 0x%02x", type->type);
-		g_assert_not_reached ();
+		g_error ("got type 0x%02x", type->type);
 	}
 }
 
@@ -596,8 +595,61 @@ stackval_to_data (MonoType *type_, stackval *val, char *data, gboolean pinvoke)
 		return;
 	}
 	default:
-		g_warning ("got type %x", type->type);
-		g_assert_not_reached ();
+		g_error ("got type %x", type->type);
+	}
+}
+
+/*
+ * Same as stackval_to_data but return address of storage instead
+ * of copying the value.
+ */
+static gpointer
+stackval_to_data_addr (MonoType *type_, stackval *val)
+{
+	MonoType *type = mini_native_type_replace_type (type_);
+	if (type->byref)
+		return &val->data.p;
+
+	switch (type->type) {
+	case MONO_TYPE_I1:
+	case MONO_TYPE_U1:
+	case MONO_TYPE_BOOLEAN:
+	case MONO_TYPE_I2:
+	case MONO_TYPE_U2:
+	case MONO_TYPE_CHAR:
+	case MONO_TYPE_I4:
+	case MONO_TYPE_U4:
+		return &val->data.i;
+	case MONO_TYPE_I:
+	case MONO_TYPE_U:
+		return &val->data.nati;
+	case MONO_TYPE_I8:
+	case MONO_TYPE_U8:
+		return &val->data.l;
+	case MONO_TYPE_R4:
+	case MONO_TYPE_R8:
+		return &val->data.f;
+	case MONO_TYPE_STRING:
+	case MONO_TYPE_SZARRAY:
+	case MONO_TYPE_CLASS:
+	case MONO_TYPE_OBJECT:
+	case MONO_TYPE_ARRAY:
+	case MONO_TYPE_PTR:
+		return &val->data.p;
+	case MONO_TYPE_VALUETYPE:
+		if (type->data.klass->enumtype)
+			return stackval_to_data_addr (mono_class_enum_basetype (type->data.klass), val);
+		else
+			return val->data.vt;
+	case MONO_TYPE_GENERICINST: {
+		MonoClass *container_class = type->data.generic_class->container_class;
+
+		if (container_class->valuetype && !container_class->enumtype)
+			return val->data.vt;
+		return stackval_to_data_addr (&type->data.generic_class->container_class->byval_arg, val);
+	}
+	default:
+		g_error ("got type %x", type->type);
 	}
 }
 
@@ -844,6 +896,7 @@ interp_walk_stack_with_ctx (MonoInternalStackWalk func, MonoContext *ctx, MonoUn
 
 static MonoPIFunc mono_interp_enter_icall_trampoline = NULL;
 
+#ifndef MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP
 static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, InterpFrame *frame)
 {
 	InterpMethodArguments *margs = g_malloc0 (sizeof (InterpMethodArguments));
@@ -1040,6 +1093,42 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 
 	return margs;
 }
+#endif
+
+static void
+interp_frame_arg_to_data (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data)
+{
+	InterpFrame *iframe = (InterpFrame*)frame;
+
+	if (index == -1)
+		stackval_to_data (sig->ret, iframe->retval, data, TRUE);
+	else
+		stackval_to_data (sig->params [index], &iframe->stack_args [index], data, TRUE);
+}
+
+static void
+interp_data_to_frame_arg (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data)
+{
+	InterpFrame *iframe = (InterpFrame*)frame;
+
+	if (index == -1)
+		stackval_from_data (sig->ret, iframe->retval, data, TRUE);
+	else
+		stackval_from_data (sig->params [index], &iframe->stack_args [index], data, TRUE);
+}
+
+static gpointer
+interp_frame_arg_to_storage (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index)
+{
+	InterpFrame *iframe = (InterpFrame*)frame;
+	MonoType *type = sig->ret;
+	stackval *val = iframe->retval;
+
+	g_assert (index == -1);
+	g_assert (type->type == MONO_TYPE_VALUETYPE);
+
+	return stackval_to_data_addr (type, val);
+}
 
 static void 
 ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr, gboolean string_ctor, ThreadContext *context)
@@ -1059,17 +1148,25 @@ ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr
 			// mono_tramp_info_register (info, NULL);
 		}
 	}
-
+#ifdef MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP
+	CallContext ccontext;
+	mono_arch_set_native_call_context (&ccontext, frame, sig);
+#else
 	InterpMethodArguments *margs = build_args_from_sig (sig, frame);
+#endif
+
 #if DEBUG_INTERP
 	g_print ("ICALL: mono_interp_enter_icall_trampoline = %p, addr = %p\n", mono_interp_enter_icall_trampoline, addr);
-	g_print ("margs(out): ilen=%d, flen=%d\n", margs->ilen, margs->flen);
 #endif
 
 	context->current_frame = frame;
 
 	interp_push_lmf (&ext, frame);
+#ifdef MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP
+	mono_interp_enter_icall_trampoline (addr, &ccontext);
+#else
 	mono_interp_enter_icall_trampoline (addr, margs);
+#endif
 	interp_pop_lmf (&ext);
 
 	if (*mono_thread_interruption_request_flag ()) {
@@ -1079,13 +1176,18 @@ ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr
 			context->search_for_handler = 1;
 		}
 	}
-	
+
+#ifdef MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP
+	if (!frame->ex)
+		mono_arch_get_native_call_context (&ccontext, frame, sig);
+#else
 	if (!frame->ex && !MONO_TYPE_ISSTRUCT (sig->ret))
 		stackval_from_data (sig->ret, frame->retval, (char*)&frame->retval->data.p, sig->pinvoke);
 
 	g_free (margs->iargs);
 	g_free (margs->fargs);
 	g_free (margs);
+#endif
 }
 
 static void
@@ -5424,6 +5526,9 @@ mono_interp_init ()
 	c.frame_get_local = interp_frame_get_local;
 	c.frame_get_this = interp_frame_get_this;
 	c.frame_get_parent = interp_frame_get_parent;
+	c.frame_arg_to_data = interp_frame_arg_to_data;
+	c.data_to_frame_arg = interp_data_to_frame_arg;
+	c.frame_arg_to_storage = interp_frame_arg_to_storage;
 	c.start_single_stepping = interp_start_single_stepping;
 	c.stop_single_stepping = interp_stop_single_stepping;
 	mini_install_interp_callbacks (&c);

--- a/mono/mini/interp/interp.h
+++ b/mono/mini/interp/interp.h
@@ -60,6 +60,9 @@ struct _MonoInterpCallbacks {
 	gpointer (*frame_get_arg) (MonoInterpFrameHandle frame, int pos);
 	gpointer (*frame_get_local) (MonoInterpFrameHandle frame, int pos);
 	gpointer (*frame_get_this) (MonoInterpFrameHandle frame);
+	void (*frame_arg_to_data) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data);
+	void (*data_to_frame_arg) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data);
+	gpointer (*frame_arg_to_storage) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index);
 	MonoInterpFrameHandle (*frame_get_parent) (MonoInterpFrameHandle frame);
 	void (*start_single_stepping) (void);
 	void (*stop_single_stepping) (void);

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -39,6 +39,10 @@
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/unlocked.h>
 
+#ifndef DISABLE_INTERPRETER
+#include "interp/interp.h"
+#endif
+
 #include "trace.h"
 #include "ir-emit.h"
 #include "mini-amd64.h"
@@ -1080,6 +1084,136 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 	cinfo->reg_usage = gr;
 	cinfo->freg_usage = fr;
 	return cinfo;
+}
+
+void
+mono_arch_set_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
+{
+	CallInfo *cinfo = get_call_info (NULL, sig);
+	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+
+	memset (ccontext, 0, sizeof (CallContext));
+
+	ccontext->stack_size = ALIGN_TO (cinfo->stack_usage, MONO_ARCH_FRAME_ALIGNMENT);
+	if (ccontext->stack_size)
+		ccontext->stack = malloc (ccontext->stack_size);
+
+	if (sig->ret->type != MONO_TYPE_VOID) {
+		if (cinfo->ret.storage == ArgValuetypeAddrInIReg) {
+			gpointer ret_storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
+			ccontext->gregs [cinfo->ret.reg] = (mgreg_t)ret_storage;
+		}
+	}
+
+	for (int i = 0; i < sig->param_count + sig->hasthis; i++) {
+		ArgInfo *ainfo = &cinfo->args [i];
+		gpointer storage;
+		int storage_type = ainfo->storage;
+		int reg_storage = ainfo->reg;
+		switch (storage_type) {
+			case ArgInIReg: {
+				storage = &ccontext->gregs [reg_storage];
+				break;
+			}
+			case ArgInFloatSSEReg:
+			case ArgInDoubleSSEReg: {
+				storage = &ccontext->fregs [reg_storage];
+				break;
+			}
+			case ArgOnStack: {
+				storage = (char*)ccontext->stack + ainfo->offset;
+				break;
+			}
+			case ArgValuetypeInReg: {
+				storage = alloca (ainfo->nregs * sizeof (mgreg_t));
+				break;
+			}
+			default:
+				g_error ("Arg storage type not yet supported");
+		}
+		interp_cb->frame_arg_to_data ((MonoInterpFrameHandle)frame, sig, i, storage);
+		if (storage_type == ArgValuetypeInReg) {
+			/* Split up the value type into the reg pairs */
+			for (int k = 0; k < ainfo->nregs; k++) {
+				storage_type = ainfo->pair_storage [k];
+				reg_storage = ainfo->pair_regs [k];
+				switch (storage_type) {
+					case ArgInIReg:
+						ccontext->gregs [reg_storage] = *(mgreg_t*)storage;
+						break;
+					case ArgInFloatSSEReg:
+					case ArgInDoubleSSEReg:
+						ccontext->fregs [reg_storage] = *(double*)storage;
+						break;
+					default:
+						g_assert_not_reached ();
+				}
+				storage = (gpointer*)storage + 1;
+			}
+		}
+	}
+
+	g_free (cinfo);
+}
+
+void
+mono_arch_get_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
+{
+	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+	CallInfo *cinfo;
+
+	/* No return value */
+	if (sig->ret->type == MONO_TYPE_VOID)
+		return;
+
+	cinfo = get_call_info (NULL, sig);
+
+	/* The return values were stored directly at address passed in reg */
+	if (cinfo->ret.storage == ArgValuetypeAddrInIReg)
+		goto done;
+
+	ArgInfo *ainfo = &cinfo->ret;
+	gpointer storage;
+	int storage_type = ainfo->storage;
+	int reg_storage = ainfo->reg;
+	switch (storage_type) {
+		case ArgInIReg: {
+			storage = &ccontext->gregs [reg_storage];
+			break;
+		}
+		case ArgInFloatSSEReg:
+		case ArgInDoubleSSEReg: {
+			storage = &ccontext->fregs [reg_storage];
+			break;
+		}
+		case ArgValuetypeInReg: {
+			storage = alloca (ainfo->nregs * sizeof (mgreg_t));
+			mgreg_t *storage_tmp = storage;
+			/* Reconstruct the value type */
+			for (int k = 0; k < ainfo->nregs; k++) {
+				storage_type = ainfo->pair_storage [k];
+				reg_storage = ainfo->pair_regs [k];
+				switch (storage_type) {
+					case ArgInIReg:
+						*storage_tmp = ccontext->gregs [reg_storage];
+						break;
+					case ArgInFloatSSEReg:
+					case ArgInDoubleSSEReg:
+						*(double*)storage_tmp = ccontext->fregs [reg_storage];
+						break;
+					default:
+						g_assert_not_reached ();
+				}
+				storage_tmp++;
+			}
+			break;
+		}
+		default:
+			g_error ("Arg storage type not yet supported");
+	}
+	interp_cb->data_to_frame_arg ((MonoInterpFrameHandle)frame, sig, -1, storage);
+done:
+	g_free (cinfo);
 }
 
 /*

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -233,6 +233,8 @@ static AMD64_XMM_Reg_No float_return_regs [] = { AMD64_XMM0 };
 #else
 #define PARAM_REGS 6
 #define FLOAT_PARAM_REGS 8
+#define RETURN_REGS 2
+#define FLOAT_RETURN_REGS 2
 
 static const AMD64_Reg_No param_regs [] = {AMD64_RDI, AMD64_RSI, AMD64_RDX,
 					   AMD64_RCX, AMD64_R8,  AMD64_R9};
@@ -326,6 +328,15 @@ typedef struct {
 	ArgInfo args [1];
 } CallInfo;
 
+typedef struct {
+	/* General registers */
+	mgreg_t gregs [AMD64_NREG];
+	/* Floating registers */
+	double fregs [AMD64_XMM_NREG];
+	/* Stack usage, used for passing params on stack */
+	size_t stack_size;
+	gpointer *stack;
+} CallContext;
 
 #define MONO_CONTEXT_SET_LLVM_EXC_REG(ctx, exc) do { (ctx)->gregs [AMD64_RAX] = (gsize)exc; } while (0)
 #define MONO_CONTEXT_SET_LLVM_EH_SELECTOR_REG(ctx, sel) do { (ctx)->gregs [AMD64_RDX] = (gsize)(sel); } while (0)
@@ -442,6 +453,8 @@ typedef struct {
 #define MONO_ARCH_HAVE_PATCH_CODE_NEW 1
 #define MONO_ARCH_HAVE_OP_GENERIC_CLASS_INIT 1
 #define MONO_ARCH_HAVE_GENERAL_RGCTX_LAZY_FETCH_TRAMPOLINE 1
+
+#define MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP
 
 #if defined(TARGET_OSX) || defined(__linux__)
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 1

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2479,6 +2479,11 @@ guint32 mono_arch_get_plt_info_offset           (guint8 *plt_entry, mgreg_t *reg
 GSList *mono_arch_get_trampolines               (gboolean aot);
 gpointer mono_arch_get_enter_icall_trampoline   (MonoTrampInfo **info);
 
+#ifdef MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP
+void mono_arch_set_native_call_context          (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig);
+void mono_arch_get_native_call_context          (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig);
+#endif
+
 /*New interruption machinery */
 void
 mono_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data);


### PR DESCRIPTION
Add support for more complex argument passing (like structs) for pinvoke on the interpreter (on amd64). We use a single general trampoline that receives a context populated with the register values and the stack usage. We use this trampoline instead of managed wrappers per signature in order to avoid the dependency on the jit for pinvokes on full aot platforms.