### PR TITLE
[System.Windows.Forms] DataGridView throw exception when trying to remove a row. Fixes #15051.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -5142,12 +5142,6 @@ namespace System.Windows.Forms {
 			if (RowsLeft < 0)
 				RowsLeft = 0;
 
-			if (first_row_index > RowsLeft - 1)
-				first_row_index = RowsLeft - 1;
-
-			if (first_row_index < 0)
-				first_row_index = 0;
-
 			if (RowsLeft == 0) {
 				MoveCurrentCell (-1, -1, true, false, false, true);
 				hover_cell = null;
@@ -5164,6 +5158,12 @@ namespace System.Windows.Forms {
 				if (hover_cell != null && hover_cell.RowIndex >= e.RowIndex)
 					hover_cell = null;
 			}
+
+			if (first_row_index > RowsLeft - 1)
+				first_row_index = RowsLeft - 1;
+
+			if (first_row_index < 0)
+				first_row_index = 0;
 		}
 
 		internal void OnRowsPostRemovedInternal (DataGridViewRowsRemovedEventArgs e)

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -5154,12 +5154,13 @@ namespace System.Windows.Forms {
 			} else if (Columns.Count == 0) {
 				MoveCurrentCell (-1, -1, true, false, false, true);
 				hover_cell = null;
-			} else if (currentCell != null && currentCell.RowIndex == e.RowIndex) {
-				int nextRowIndex = e.RowIndex;
-				if (nextRowIndex >= RowsLeft)
-					nextRowIndex = RowsLeft - 1;
-				MoveCurrentCell (currentCell != null ? currentCell.ColumnIndex : 0, nextRowIndex, 
-						 true, false, false, true);
+			} else {
+				if (currentCell != null && currentCell.RowIndex >= e.RowIndex && currentCell.RowIndex < e.RowIndex + e.RowCount) {
+					int nextRowIndex = e.RowIndex + e.RowCount;
+					if (nextRowIndex >= Rows.Count)
+						nextRowIndex = e.RowIndex - 1;
+					MoveCurrentCell (currentCell.ColumnIndex, nextRowIndex, true, false, false, true);
+				}
 				if (hover_cell != null && hover_cell.RowIndex >= e.RowIndex)
 					hover_cell = null;
 			}


### PR DESCRIPTION
Method DataGridView.OnRowsPreRemovedInternal was patched. First issue fixed: proper way to move selection. Second issue fixed: first_row_index was corrupting by MoveCurrentCell call.