### PR TITLE
Unbreak XMM register handling on platforms without MonoContextSimdReg

### DIFF
--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -363,7 +363,12 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	}
 	for (i = 0; i < AMD64_XMM_NREG; ++i)
 		if (AMD64_IS_ARGUMENT_XREG (i))
+#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || defined(HOST_WIN32)
 			amd64_movdqu_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)), i);
+#else
+			/* FIXME: Is this the appropriate type on platforms without SimdReg? */
+			amd64_movdqu_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(mgreg_t)), i);
+#endif
 
 	/* Check that the stack is aligned */
 	amd64_mov_reg_reg (code, AMD64_R11, AMD64_RSP, sizeof (mgreg_t));
@@ -540,7 +545,11 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 			amd64_mov_reg_membase (code, i, AMD64_RBP, saved_regs_offset + (i * sizeof(mgreg_t)), sizeof(mgreg_t));
 	for (i = 0; i < AMD64_XMM_NREG; ++i)
 		if (AMD64_IS_ARGUMENT_XREG (i))
+#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || defined(HOST_WIN32)
 			amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)));
+#else
+			amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(mgreg_t)));
+#endif
 
 	/* Restore stack */
 #if TARGET_WIN32

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -363,7 +363,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	}
 	for (i = 0; i < AMD64_XMM_NREG; ++i)
 		if (AMD64_IS_ARGUMENT_XREG (i))
-#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || defined(HOST_WIN32)
+#if defined(MONO_HAVE_SIMD_REG)
 			amd64_movdqu_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)), i);
 #else
 			/* FIXME: Is this the appropriate type on platforms without SimdReg? */
@@ -545,7 +545,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 			amd64_mov_reg_membase (code, i, AMD64_RBP, saved_regs_offset + (i * sizeof(mgreg_t)), sizeof(mgreg_t));
 	for (i = 0; i < AMD64_XMM_NREG; ++i)
 		if (AMD64_IS_ARGUMENT_XREG (i))
-#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || defined(HOST_WIN32)
+#if defined(MONO_HAVE_SIMD_REG)
 			amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)));
 #else
 			amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(mgreg_t)));

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -366,8 +366,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 #if defined(MONO_HAVE_SIMD_REG)
 			amd64_movdqu_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)), i);
 #else
-			/* FIXME: Is this the appropriate type on platforms without SimdReg? */
-			amd64_movdqu_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(mgreg_t)), i);
+			amd64_movsd_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(double)), i);
 #endif
 
 	/* Check that the stack is aligned */
@@ -548,7 +547,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 #if defined(MONO_HAVE_SIMD_REG)
 			amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)));
 #else
-			amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(mgreg_t)));
+			amd64_movsd_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(double)));
 #endif
 
 	/* Restore stack */

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -24,23 +24,30 @@
 
 #if defined(TARGET_X86)
 #if defined(__APPLE__)
+#define MONO_HAVE_SIMD_REG
 typedef struct __darwin_xmm_reg MonoContextSimdReg;
 #endif
 #elif defined(TARGET_AMD64)
 #if defined(__APPLE__)
+#define MONO_HAVE_SIMD_REG
 typedef struct __darwin_xmm_reg MonoContextSimdReg;
 #elif defined(__linux__) && defined(__GLIBC__)
+#define MONO_HAVE_SIMD_REG
 typedef struct _libc_xmmreg MonoContextSimdReg;
 #elif defined(HOST_WIN32)
+#define MONO_HAVE_SIMD_REG
 #include <emmintrin.h>
 typedef __m128d MonoContextSimdReg;
 #elif defined(HOST_ANDROID)
+#define MONO_HAVE_SIMD_REG
 typedef struct _libc_xmmreg MonoContextSimdReg;
 #elif defined(__linux__)
+#define MONO_HAVE_SIMD_REG
 #include <emmintrin.h>
 typedef __m128d MonoContextSimdReg;
 #endif
 #elif defined(TARGET_ARM64)
+#define MONO_HAVE_SIMD_REG
 typedef __uint128_t MonoContextSimdReg;
 #endif
 
@@ -266,7 +273,7 @@ struct sigcontext {
 
 typedef struct {
 	mgreg_t gregs [AMD64_NREG];
-#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || defined(HOST_WIN32)
+#if defined(MONO_HAVE_SIMD_REG)
 	MonoContextSimdReg fregs [AMD64_XMM_NREG];
 #else
 	double fregs [AMD64_XMM_NREG];


### PR DESCRIPTION
Platforms like Haiku (and glibc-less Linux, but that was unbroken a few weeks ago) don't have this implemented on Mono. (yet?) Restore old behaviour behind an #ifdef (same one as on mono-context.h) - perhaps it could be a nicer ifdef, but I'm keeping this consistent for now.

With this, Haiku amd64 gets to the same stage where it does on x86 - Roslyn runs, finishes, and the runtime hangs on thread suspension.