### PR TITLE
Avoid using BSTR for conversion of a SecureString

### DIFF
--- a/mcs/class/System/ReferenceSources/SecureStringHelper.cs
+++ b/mcs/class/System/ReferenceSources/SecureStringHelper.cs
@@ -14,7 +14,18 @@ namespace System.Net
 
                 if (secureString == null || secureString.Length == 0)
                     return String.Empty;
-
+#if MONO
+                try
+                {
+                    bstr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+                    plainString = Marshal.PtrToStringUni(bstr);
+                }
+                finally
+                {
+                    if (bstr != IntPtr.Zero)
+                        Marshal.ZeroFreeGlobalAllocUnicode(bstr);
+                }
+#else
                 try
                 {
                     bstr = Marshal.SecureStringToBSTR(secureString);
@@ -25,6 +36,7 @@ namespace System.Net
                     if (bstr != IntPtr.Zero)
                         Marshal.ZeroFreeBSTR(bstr);
                 }
+#endif
                 return plainString;
             }
 


### PR DESCRIPTION
There is no need to use BSTR marshaling to convert a SecureString to a
string. On some platforms, BSTR marshaling is not implemented, but we
still want to be able to convert a SecureString to a string on those
platforms.

So instead, use Unicode string marshaling.