### PR TITLE
Minor cleanup split out and expanded from another larger change.

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2585,7 +2585,6 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	gpointer* key, *mp_key;
 	char *name;
 	
-	g_assert (error);
 	error_init (error);
 
 	key = create_remote_class_key (NULL, proxy_class);
@@ -6319,7 +6318,6 @@ mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *error)
 	glong items_written;
 	int len;
 
-	g_assert (error);
 	error_init (error);
 	
 	len = strlen (text);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2585,6 +2585,7 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	gpointer* key, *mp_key;
 	char *name;
 	
+	g_assert (error);
 	error_init (error);
 
 	key = create_remote_class_key (NULL, proxy_class);
@@ -6316,19 +6317,19 @@ mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *error)
 	MonoString *o = NULL;
 	guint16 *ut;
 	glong items_written;
-	int l;
+	int len;
 
+	g_assert (error);
 	error_init (error);
 	
-	l = strlen (text);
+	len = strlen (text);
 	
-	ut = g_utf8_to_utf16 (text, l, NULL, &items_written, &eg_error);
+	ut = g_utf8_to_utf16 (text, len, NULL, &items_written, &eg_error);
 	
-	if (!eg_error) {
+	if (!eg_error)
 		o = mono_string_new_utf16_checked (domain, ut, items_written, error);
-	} else {
+	else
 		mono_error_set_execution_engine (error, "String conversion error: %s", eg_error->message);
-	}
 	
 	g_free (ut);
     
@@ -7037,7 +7038,7 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 		g_error_free (gerror);
 		return NULL;
 	}
-	/* g_utf16_to_utf8  may not be able to complete the convertion (e.g. NULL values were found, #335488) */
+	/* g_utf16_to_utf8  may not be able to complete the conversion (e.g. NULL values were found, #335488) */
 	if (len2 > written) {
 		/* allocate the total length and copy the part of the string that has been converted */
 		char *as2 = (char *)g_malloc0 (len2);
@@ -7102,7 +7103,7 @@ mono_string_to_utf8_checked (MonoString *s, MonoError *error)
 		g_error_free (gerror);
 		return NULL;
 	}
-	/* g_utf16_to_utf8  may not be able to complete the convertion (e.g. NULL values were found, #335488) */
+	/* g_utf16_to_utf8  may not be able to complete the conversion (e.g. NULL values were found, #335488) */
 	if (s->length > written) {
 		/* allocate the total length and copy the part of the string that has been converted */
 		char *as2 = (char *)g_malloc0 (s->length);
@@ -7143,7 +7144,7 @@ mono_string_to_utf8_ignore (MonoString *s)
 
 	as = g_utf16_to_utf8 (mono_string_chars (s), s->length, NULL, &written, NULL);
 
-	/* g_utf16_to_utf8  may not be able to complete the convertion (e.g. NULL values were found, #335488) */
+	/* g_utf16_to_utf8  may not be able to complete the conversion (e.g. NULL values were found, #335488) */
 	if (s->length > written) {
 		/* allocate the total length and copy the part of the string that has been converted */
 		char *as2 = (char *)g_malloc0 (s->length);


### PR DESCRIPTION
 - Spelling in comment.
 - 'l' is a short identifier that looks like '1' -- use "len".
 - Remove extra braces.
 - Add some g_assert (error) before error_init (error).