### PR TITLE
[2017-12] [mini] isalnum() respects encoding in python3, we only want to have ASCII chars

### DIFF
--- a/mono/mini/genmdesc.py
+++ b/mono/mini/genmdesc.py
@@ -158,7 +158,7 @@ def gen_output(f, opcodes):
                 if c == "":
                     f.write (r"\x0")
                     f.write ("\" \"")
-                elif c.isalnum ():
+                elif c.isalnum () and ord (c) < 0x80:
                     f.write (c)
                 else:
                     f.write (r"\x{0:x}".format (ord (c)))


### PR DESCRIPTION
backport of https://github.com/mono/mono/pull/6199, fixes https://github.com/mono/mono/issues/6197