### PR TITLE
Cleanup derived and expanded from PR 6247.

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -62,6 +62,7 @@ mono_ldstr_metadata_sig (MonoDomain *domain, const char* sig, MonoError *error);
 static void
 free_main_args (void);
 
+// In order to share code, error is optional.
 static char *
 mono_string_to_utf8_internal (MonoMemPool *mp, MonoImage *image, MonoString *s, MonoError *error);
 
@@ -7086,7 +7087,8 @@ mono_string_to_utf8_checked (MonoString *s, MonoError *error)
 	char *as;
 	GError *gerror = NULL;
 
-	error_init (error);
+	if (error) // In order to share code, error is optional.
+		error_init (error);
 
 	if (s == NULL)
 		return NULL;
@@ -7094,7 +7096,7 @@ mono_string_to_utf8_checked (MonoString *s, MonoError *error)
 	if (!s->length)
 		return g_strdup ("");
 
-	as = g_utf16_to_utf8 (mono_string_chars (s), s->length, NULL, &written, &gerror);
+	as = g_utf16_to_utf8 (mono_string_chars (s), s->length, NULL, &written, error ? &gerror : NULL);
 	if (gerror) {
 		mono_error_set_argument (error, "string", "%s", gerror->message);
 		g_error_free (gerror);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7058,16 +7058,7 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 char *
 mono_string_to_utf8 (MonoString *s)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
-
-	MonoError error;
-	char *result = mono_string_to_utf8_checked (s, &error);
-	
-	if (!is_ok (&error)) {
-		mono_error_cleanup (&error);
-		return NULL;
-	}
-	return result;
+	return mono_string_to_utf8_checked (s, NULL);
 }
 
 /**
@@ -7303,8 +7294,6 @@ mono_string_from_utf32_checked (mono_unichar4 *data, MonoError *error)
 static char *
 mono_string_to_utf8_internal (MonoMemPool *mp, MonoImage *image, MonoString *s, MonoError *error)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
-
 	char *r;
 	char *mp_s;
 	int len;


### PR DESCRIPTION
https://github.com/mono/mono/pull/6247/files

There is both dead and duplicated code.
The duplicated code can be cleaned up by the simple
transform of making error optional in a small number of places.
The dead code is very uninteresting and not worth carrying along.