### PR TITLE
[System.Windows.Forms.Carbon] Fix non-ASCII Encoding on Window Title

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.CarbonInternal/Enums.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.CarbonInternal/Enums.cs
@@ -105,4 +105,21 @@ namespace System.Windows.Forms.CarbonInternal {
 		kMouseTrackingTimedOut = 8,
 		kMouseTrackingMouseMoved = 9
 	}
+
+	internal enum CFStringEncoding : uint {
+		kCFStringEncodingMacRoman = 0,
+		kCFStringEncodingWindowsLatin1 = 0x0500,
+		kCFStringEncodingISOLatin1 = 0x0201,
+		kCFStringEncodingNextStepLatin = 0x0B01,
+		kCFStringEncodingASCII = 0x0600,
+		kCFStringEncodingUnicode = 0x0100,
+		kCFStringEncodingUTF8 = 0x08000100,
+		kCFStringEncodingNonLossyASCII = 0x0BFF,
+		kCFStringEncodingUTF16 = 0x0100,
+		kCFStringEncodingUTF16BE = 0x10000100,
+		kCFStringEncodingUTF16LE = 0x14000100,
+		kCFStringEncodingUTF32 = 0x0c000100,
+		kCFStringEncodingUTF32BE = 0x18000100,
+		kCFStringEncodingUTF32LE = 0x1c000100
+	}
 }

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
@@ -2085,10 +2085,10 @@ namespace System.Windows.Forms {
 		internal override bool Text(IntPtr handle, string text) {
 			Hwnd hwnd = Hwnd.ObjectFromHandle (handle);
 			if (WindowMapping [hwnd.Handle] != null) {
-				SetWindowTitleWithCFString ((IntPtr)(WindowMapping [hwnd.Handle]), __CFStringMakeConstantString (text));
+				SetWindowTitleWithCFString ((IntPtr)(WindowMapping [hwnd.Handle]), CFStringCreateWithCString (IntPtr.Zero, text, Carbon.CFStringEncoding.kCFStringEncodingUTF8));
 			}
-			SetControlTitleWithCFString (hwnd.whole_window, __CFStringMakeConstantString (text));
-			SetControlTitleWithCFString (hwnd.client_window, __CFStringMakeConstantString (text));
+			SetControlTitleWithCFString (hwnd.whole_window, CFStringCreateWithCString (IntPtr.Zero, text, Carbon.CFStringEncoding.kCFStringEncodingUTF8));
+			SetControlTitleWithCFString (hwnd.client_window, CFStringCreateWithCString (IntPtr.Zero, text, Carbon.CFStringEncoding.kCFStringEncodingUTF8));
 			return true;
 		}
 		
@@ -2382,7 +2382,9 @@ namespace System.Windows.Forms {
 		extern static int SetWindowTitleWithCFString (IntPtr hWnd, IntPtr titleCFStr);
 		[DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
 		internal extern static IntPtr __CFStringMakeConstantString (string cString);
-		
+		[DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+		extern static IntPtr CFStringCreateWithCString (IntPtr allocator, string cString, Carbon.CFStringEncoding encoding);
+
 		[DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
 		internal extern static int CFRelease (IntPtr wHnd);
 		[DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]


### PR DESCRIPTION
`__CFStringMakeConstantString` couldn't make a correct `CFStringRef` if the input has non-ASCII characters inside.
For example
![p1](https://user-images.githubusercontent.com/4312700/34102814-784d25c2-e425-11e7-988d-6b3ad77bc61c.jpg)
The title of this form is incorrect.
After applying this patch.
![p2](https://user-images.githubusercontent.com/4312700/34102860-9cffc870-e425-11e7-9e94-b1fe0b24c30e.png)
It is correct.

According to [Apple's CoreFoundation/CFString.c](https://github.com/apple/swift-corelibs-foundation/blob/master/CoreFoundation/String.subproj/CFString.c), `__CFStringMakeConstantString` makes the process owns only one copy of those strings which have same content, but I think it doesn't affect most programs.