### PR TITLE
[runtime] Fixes issue when compiling with -no_weak_imports

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2671,8 +2671,10 @@ if test x$host_win32 = xno; then
 	dnl *********************************
 	dnl *** Checks for random         ***
 	dnl *********************************
-	AC_CHECK_HEADERS(sys/random.h)
-	AC_CHECK_FUNCS(getrandom getentropy)
+	if test x$host_darwin = xno; then
+		AC_CHECK_HEADERS(sys/random.h)
+		AC_CHECK_FUNCS(getrandom getentropy)
+	fi
 else
 	dnl *********************************
 	dnl *** Checks for Windows compilation ***


### PR DESCRIPTION
It seems that when 35acde58d43305b5428d04ddc660e8348bb6fbab added getentropy support for linux, it added it for OSX as well. These functions don't work on systems which forbid weak imports, such as iOS. This broke the initial 2017-12 OSX integration. 