### PR TITLE
[SRE] Emit a memberref token for fields,methods of a gtd

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/ILGeneratorTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/ILGeneratorTest.cs
@@ -19,6 +19,7 @@ namespace MonoTests.System.Reflection.Emit
 	[TestFixture]
 	public class ILGeneratorTest
 	{
+		ModuleBuilder modulebuilder;
 		TypeBuilder tb;
 		ILGenerator il_gen;
 
@@ -38,8 +39,8 @@ namespace MonoTests.System.Reflection.Emit
 			AssemblyBuilder assembly = Thread.GetDomain ().DefineDynamicAssembly (
 				assemblyName, AssemblyBuilderAccess.Run);
 
-			ModuleBuilder module = assembly.DefineDynamicModule ("module1");
-			tb = module.DefineType ("T", TypeAttributes.Public);
+			modulebuilder = assembly.DefineDynamicModule ("module1");
+			tb = modulebuilder.DefineType ("T", TypeAttributes.Public);
 		}
 
 		[Test]
@@ -610,6 +611,5 @@ namespace MonoTests.System.Reflection.Emit
 			Assert.AreEqual ("1", s);
 
 		}
-
 	}
 }


### PR DESCRIPTION
This can happen when emitting code like:
```csharp
  class Foo<T> {
    T elt;
    public T getter () {
      return elt;  // ILGenerator.Emit (OpCodes.Ldfld, /*FieldBuilder of Foo::elt*/)
    };
  }
```

the old incorrect code emitted a fielddef token for `Foo::elt`, but it should be a
memberref for `Foo<!0>::elt`.

Likewise, if we have
```csharp
class Foo<T> {
  public T f () { /*...*/}
  public void g () {
    var x = f (); // ILGenerator.Emit (OpCodes.Call, /* MethodBuilder of Foo::f */)
    /*... */
  }
}
```

the old incorrect code would emit a fieldref token for `Foo::f` but it should be
a memberref for `Foo<!0>::f`

Fixes #6192 
