### PR TITLE
[arm] replace cp15 barrier usage wih dmb instruction on armv7

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -4216,7 +4216,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 		switch (ins->opcode) {
 		case OP_MEMORY_BARRIER:
-			if (v6_supported) {
+			if (v7_supported) {
+				ARM_DMB (code, ARM_DMB_SY);
+			} else if (v6_supported) {
 				ARM_MOV_REG_IMM8 (code, ARMREG_R0, 0);
 				ARM_MCR (code, 15, 0, ARMREG_R0, 7, 10, 5);
 			}


### PR DESCRIPTION
on armv8 chips this barrier isn't implemented in hardware and must be
emulated by the kernel if it runs aarch32 code:

https://github.com/torvalds/linux/blob/c9b012e5f4a1d01dfa8abc6318211a67ba7d5db2/arch/arm64/kernel/armv8_deprecated.c#L475


/cc @directhex 