### PR TITLE
Adds support for nanosecond resolution file information where available (Fixes: 6283)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2627,7 +2627,7 @@ if test x$host_win32 = xno; then
 		[#include <sys/types.h>
 		 #include <sys/vfs.h>])
 	AC_CHECK_MEMBERS(
-		[struct stat.st_atim, struct stat.st_mtim, struct stat.st_ctim],,, 
+		[struct stat.st_atim, struct stat.st_mtim, struct stat.st_atimespec, struct stat.st_ctim],,, 
 		[#include <sys/types.h>
 		 #include <sys/stat.h>
 		 #include <unistd.h>])

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3494,7 +3494,7 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 	stat->length = (stat->attributes & FILE_ATTRIBUTE_DIRECTORY) ? 0 : buf.st_size;
 
 // Multiply seconds by this
-#define SECMULT (1000*1000*10)
+#define SECMULT (1000*1000*10ULL)
 
 // Constants to convert Unix times to the API expected by .NET and Windows
 #define CONVERT_BASE  116444736000000000ULL

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3491,10 +3491,35 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 	/* fill stat block */
 
 	stat->attributes = _wapi_stat_to_file_attributes (utf8_name, &buf, &linkbuf);
-	stat->creation_time = (((guint64) (buf.st_mtime < buf.st_ctime ? buf.st_mtime : buf.st_ctime)) * 10 * 1000 * 1000) + 116444736000000000ULL;
-	stat->last_access_time = (((guint64) (buf.st_atime)) * 10 * 1000 * 1000) + 116444736000000000ULL;
-	stat->last_write_time = (((guint64) (buf.st_mtime)) * 10 * 1000 * 1000) + 116444736000000000ULL;
 	stat->length = (stat->attributes & FILE_ATTRIBUTE_DIRECTORY) ? 0 : buf.st_size;
+
+// Multiply seconds by this
+#define SECMULT (1000*1000*10)
+
+// Constants to convert Unix times to the API expected by .NET and Windows
+#define CONVERT_BASE  116444736000000000ULL
+
+#if HAVE_STRUCT_STAT_ST_ATIMESPEC
+	if (buf.st_mtimespec.tv_sec < buf.st_ctimespec.tv_sec || (buf.st_mtimespec.tv_sec == buf.st_ctimespec.tv_sec && buf.st_mtimespec.tv_nsec < buf.st_ctimespec.tv_nsec))
+		stat->creation_time = buf.st_mtimespec.tv_sec * SECMULT + (buf.st_mtimespec.tv_nsec / 100) + CONVERT_BASE;
+	else
+		stat->creation_time = buf.st_ctimespec.tv_sec * SECMULT + (buf.st_ctimespec.tv_nsec / 100) + CONVERT_BASE;
+
+	stat->last_access_time = buf.st_atimespec.tv_sec * SECMULT + (buf.st_atimespec.tv_nsec / 100) + CONVERT_BASE;
+	stat->last_write_time = buf.st_mtimespec.tv_sec * SECMULT + (buf.st_mtimespec.tv_nsec / 100) + CONVERT_BASE;
+#elif HAVE_STRUCT_STAT_ST_ATIM
+	if (buf.st_mtime < buf.st_ctime || (buf.st_mtime == buf.st_ctime && buf.st_mtim.tv_nsec < buf.st_ctim.tv_nsec))
+		stat->creation_time = buf.st_mtime * SECMULT + (buf.st_mtim.tv_nsec / 100) + CONVERT_BASE;
+	else
+		stat->creation_time = buf.st_ctime * SECMULT + (buf.st_ctim.tv_nsec / 100) + CONVERT_BASE;
+
+	stat->last_access_time = buf.st_atime * SECMULT + (buf.st_atim.tv_nsec / 100) + CONVERT_BASE;
+	stat->last_write_time = buf.st_mtime * SECMULT + (buf.st_mtim.tv_nsec / 100) + CONVERT_BASE;
+#else
+	stat->creation_time = (((guint64) (buf.st_mtime < buf.st_ctime ? buf.st_mtime : buf.st_ctime)) * 10 * 1000 * 1000) + CONVERT_BASE;
+	stat->last_access_time = (((guint64) (buf.st_atime)) * SECMULT) + CONVERT_BASE;
+	stat->last_write_time = (((guint64) (buf.st_mtime)) * SECMULT) + CONVERT_BASE;
+#endif
 
 	g_free (utf8_name);
 	return TRUE;

--- a/support/sys-stat.c
+++ b/support/sys-stat.c
@@ -51,16 +51,24 @@ Mono_Posix_FromStat (struct Mono_Posix_Stat *from, void *_to)
 	to->st_atime       = from->st_atime_;
 	to->st_mtime       = from->st_mtime_;
 	to->st_ctime       = from->st_ctime_;
-#ifdef HAVE_STRUCT_STAT_ST_ATIM
+#if HAVE_STRUCT_STAT_ST_ATIMESPEC
+	to->st_atimespec.tv_sec = from->st_atime_;
+	to->st_atimespec.tv_nsec = from->st_atime_nsec;
+	to->st_mtimespec.tv_sec = from->st_mtime_;
+	to->st_mtimespec.tv_nsec = from->st_mtime_nsec;
+	to->st_ctimespec.tv_sec = from->st_ctime_;
+	to->st_ctimespec.tv_nsec = from->st_ctime_nsec;
+#else
+#    ifdef HAVE_STRUCT_STAT_ST_ATIM
 	to->st_atim.tv_nsec = from->st_atime_nsec;
-#endif
-#ifdef HAVE_STRUCT_STAT_ST_MTIM
+#    endif
+#    ifdef HAVE_STRUCT_STAT_ST_MTIM
 	to->st_mtim.tv_nsec = from->st_mtime_nsec;
-#endif
-#ifdef HAVE_STRUCT_STAT_ST_CTIM
+#    endif
+#    ifdef HAVE_STRUCT_STAT_ST_CTIM
 	to->st_ctim.tv_nsec = from->st_ctime_nsec;
+#    endif
 #endif
-
 	return 0;
 }
 
@@ -87,16 +95,21 @@ Mono_Posix_ToStat (void *_from, struct Mono_Posix_Stat *to)
 	to->st_atime_     = from->st_atime;
 	to->st_mtime_     = from->st_mtime;
 	to->st_ctime_     = from->st_ctime;
-#ifdef HAVE_STRUCT_STAT_ST_ATIM
+#if HAVE_STRUCT_STAT_ST_ATIMESPEC
+	to->st_atime_nsec = from->st_atimespec.tv_nsec;
+	to->st_mtime_nsec = from->st_mtimespec.tv_nsec;
+	to->st_ctime_nsec = from->st_ctimespec.tv_nsec;
+#else
+#    ifdef HAVE_STRUCT_STAT_ST_ATIM
 	to->st_atime_nsec = from->st_atim.tv_nsec;
-#endif
-#ifdef HAVE_STRUCT_STAT_ST_MTIM
+#    endif
+#    ifdef HAVE_STRUCT_STAT_ST_MTIM
 	to->st_mtime_nsec = from->st_mtim.tv_nsec;
-#endif
-#ifdef HAVE_STRUCT_STAT_ST_CTIM
+#    endif
+#    ifdef HAVE_STRUCT_STAT_ST_CTIM
 	to->st_ctime_nsec = from->st_ctim.tv_nsec;
+#    endif
 #endif
-
 	return 0;
 }
 


### PR DESCRIPTION
This patch adds support to the runtime to use the nanosecond
information available on Mac and Linux on `struct stat`.
`stat.st_Xtimespec` strucutre on OSX, and `stat.st_Xtime` and
`stat.st_Xtim.tv_nsec` pair on Linux.

Additionally, this adds support in `Mono.Posix` for MacOS nanosecond stat
data, it already had Linux support before.

This is a fix for: https://github.com/mono/mono/issues/6283