### PR TITLE
[sdks] Add managed debugger tests to sdks

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Makefile
+++ b/mcs/class/Mono.Debugger.Soft/Makefile
@@ -22,6 +22,9 @@ TEST_HELPERS_SOURCES = \
 
 test-local: dtest-app.exe dtest-excfilter.exe
 
+dtest-app.exe: Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
+	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) -optimize- Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
+
 dtest-excfilter.exe: Test/dtest-excfilter.il
 	$(ILASM) -out:$@ /exe /debug Test/dtest-excfilter.il
 
@@ -31,9 +34,6 @@ NO_TEST=1
 check:
 
 endif
-
-dtest-app.exe: Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
-	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) -optimize- Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
 
 CLEAN_FILES = dtest-app.exe dtest-app.exe.mdb dtest-app.pdb dtest-excfilter.exe dtest-excfilter.exe.mdb dtest-excfilter.pdb
 

--- a/mcs/class/Mono.Debugger.Soft/Makefile
+++ b/mcs/class/Mono.Debugger.Soft/Makefile
@@ -16,14 +16,7 @@ VALID_TEST_PROFILE := $(filter net_4_x, $(PROFILE))
 # The test exe is not profile specific, and compiling a 2.0 will make the 4.5 tests fail
 ifdef VALID_TEST_PROFILE
 
-TEST_HELPERS_SOURCES = \
-	../test-helpers/NetworkHelpers.cs \
-	Test/TypeLoadClass.cs
-
 test-local: dtest-app.exe dtest-excfilter.exe
-
-dtest-app.exe: Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
-	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) -optimize- Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
 
 dtest-excfilter.exe: Test/dtest-excfilter.il
 	$(ILASM) -out:$@ /exe /debug Test/dtest-excfilter.il
@@ -34,6 +27,13 @@ NO_TEST=1
 check:
 
 endif
+
+TEST_HELPERS_SOURCES = \
+	../test-helpers/NetworkHelpers.cs \
+	Test/TypeLoadClass.cs
+
+dtest-app.exe: Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
+	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) -optimize- Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
 
 CLEAN_FILES = dtest-app.exe dtest-app.exe.mdb dtest-app.pdb dtest-excfilter.exe dtest-excfilter.exe.mdb dtest-excfilter.pdb
 

--- a/mcs/class/Mono.Debugger.Soft/Makefile
+++ b/mcs/class/Mono.Debugger.Soft/Makefile
@@ -22,9 +22,6 @@ TEST_HELPERS_SOURCES = \
 
 test-local: dtest-app.exe dtest-excfilter.exe
 
-dtest-app.exe: Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
-	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) -optimize- Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
-
 dtest-excfilter.exe: Test/dtest-excfilter.il
 	$(ILASM) -out:$@ /exe /debug Test/dtest-excfilter.il
 
@@ -34,6 +31,9 @@ NO_TEST=1
 check:
 
 endif
+
+dtest-app.exe: Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
+	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -out:$@ -unsafe $(PLATFORM_DEBUG_FLAGS) -optimize- Test/dtest-app.cs $(TEST_HELPERS_SOURCES)
 
 CLEAN_FILES = dtest-app.exe dtest-app.exe.mdb dtest-app.pdb dtest-excfilter.exe dtest-excfilter.exe.mdb dtest-excfilter.pdb
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -13,7 +13,9 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+#if !MOBILE
 using MonoTests.Helpers;
+#endif
 
 public class TestsBase
 {
@@ -326,7 +328,11 @@ public class Tests : TestsBase, ITest2
 			return 0;
 		}
 		if (args.Length >0 && args [0] == "threadpool-io") {
+#if !MOBILE
 			threadpool_io ();
+#else
+			throw new Exception ("Can't run threadpool-io test on mobile");
+#endif
 			return 0;
 		}
 		if (args.Length > 0 && args [0] == "attach") {
@@ -355,7 +361,9 @@ public class Tests : TestsBase, ITest2
 		threads ();
 		dynamic_methods ();
 		user ();
+#if !MOBILE
 		type_load ();
+#endif
 		regress ();
 		gc_suspend ();
 		set_ip ();
@@ -1566,6 +1574,7 @@ public class Tests : TestsBase, ITest2
 		Debugger.Log (5, Debugger.IsLogging () ? "A" : "", "B");
 	}
 
+#if !MOBILE
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void type_load () {
 		type_load_2 ();
@@ -1580,6 +1589,7 @@ public class Tests : TestsBase, ITest2
 		var c2 = new TypeLoadClass2 ();
 		c2.ToString ();
 	}
+#endif
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void regress () {
@@ -1696,6 +1706,7 @@ public class Tests : TestsBase, ITest2
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void threadpool_bp () { }
 
+#if !MOBILE
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void threadpool_io () {
 		// Start a threadpool task that blocks on I/O.
@@ -1735,6 +1746,7 @@ public class Tests : TestsBase, ITest2
 		streamOut.Close ();
 		var bsIn = t.Result;
 	}
+#endif
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public void attach_break () {

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -266,6 +266,8 @@ public class Tests : TestsBase, ITest2
 	public static bool is_attached = Debugger.IsAttached;
 	public NestedStruct nested_struct;
 
+	static string arg;
+
 #pragma warning restore 0414
 
 	public class NestedClass {
@@ -299,6 +301,9 @@ public class Tests : TestsBase, ITest2
 	}
 
 	public static int Main (String[] args) {
+		if (args.Length == 0)
+			args = new String [] { Tests.arg };
+
 		tls_i = 42;
 
 		if (args.Length > 0 && args [0] == "suspend-test")

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -97,6 +97,7 @@ public class DebuggerTests
 #if MONODROID_TEST
 			System.Diagnostics.Process.Start("/usr/bin/make", "-C ../android dirty-run-debugger-test");
 #endif
+			var ep = new IPEndPoint (IPAddress.Any, 6100);
 			Console.WriteLine ("Listening on " + ep + "...");
 			vm = VirtualMachineManager.Listen (ep);
 		}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -2331,7 +2331,13 @@ public class DebuggerTests
 
 		Assert.AreEqual (5, (e as VMDeathEvent).ExitCode);
 
-		var p = vm.Process;
+		System.Diagnostics.Process p = null;
+
+		try {
+			p = vm.Process;
+		}
+		catch (Exception) {}
+
 		/* Could be a remote vm with no process */
 		if (p != null) {
 			p.WaitForExit ();
@@ -2355,7 +2361,13 @@ public class DebuggerTests
 		var e = GetNextEvent ();
 		Assert.IsInstanceOfType (typeof (VMDisconnectEvent), e);
 
-		var p = vm.Process;
+		System.Diagnostics.Process p = null;
+
+		try {
+			p = vm.Process;
+		}
+		catch (Exception) {}
+
 		/* Could be a remote vm with no process */
 		if (p != null) {
 			p.WaitForExit ();

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -123,6 +123,22 @@ public class DebuggerTests
 		}
 
 		load_req.Disable ();
+
+		if (args.Length == 2) {
+			var this_type = entry_point.DeclaringType;
+			var str = vm.RootDomain.CreateString (args [1]);
+			var slot = this_type.GetField ("arg");
+
+			if (slot == null)
+				throw new Exception ("Missing slot");
+
+			if (str == null)
+				throw new Exception ("Bug in createstring");
+
+			this_type.SetValue (slot, str);
+		} else if (args.Length > 2) {
+			throw new Exception (String.Format ("Fixme {0}", args [2]));
+		}
 	}
 
 	BreakpointEvent run_until (string name) {

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -39,7 +39,11 @@ public class DebuggerTests
 	}
 
 	// No other way to pass arguments to the tests ?
+#if MONODROID_TEST
+	public static bool listening = true;
+#else
 	public static bool listening = Environment.GetEnvironmentVariable ("DBG_SUSPEND") != null;
+#endif
 	public static string runtime = Environment.GetEnvironmentVariable ("DBG_RUNTIME");
 	public static string agent_args = Environment.GetEnvironmentVariable ("DBG_AGENT_ARGS");
 
@@ -90,7 +94,9 @@ public class DebuggerTests
 			var pi = CreateStartInfo (args);
 			vm = VirtualMachineManager.Launch (pi, new LaunchOptions { AgentArgs = agent_args });
 		} else {
-			var ep = new IPEndPoint (IPAddress.Any, 10000);
+#if MONODROID_TEST
+			System.Diagnostics.Process.Start("/usr/bin/make", "-C ../android dirty-run-debugger-test");
+#endif
 			Console.WriteLine ("Listening on " + ep + "...");
 			vm = VirtualMachineManager.Listen (ep);
 		}
@@ -3065,6 +3071,7 @@ public class DebuggerTests
 		vm.GetThreads ();
 	}
 
+#if !MONODROID_TEST
 	[Test]
 	public void Threads () {
 		Event e = run_until ("threads");
@@ -3090,6 +3097,7 @@ public class DebuggerTests
 		Assert.IsInstanceOfType (typeof (ThreadDeathEvent), e);
 		Assert.AreEqual (ThreadState.Stopped, e.Thread.ThreadState);
 	}
+#endif
 
 	[Test]
 	public void Frame_SetValue () {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -854,18 +854,18 @@ parse_address (char *address, char **host, int *port)
 static void
 print_usage (void)
 {
-	fprintf (stderr, "Usage: mono --debugger-agent=[<option>=<value>,...] ...\n");
-	fprintf (stderr, "Available options:\n");
-	fprintf (stderr, "  transport=<transport>\t\tTransport to use for connecting to the debugger (mandatory, possible values: 'dt_socket')\n");
-	fprintf (stderr, "  address=<hostname>:<port>\tAddress to connect to (mandatory)\n");
-	fprintf (stderr, "  loglevel=<n>\t\t\tLog level (defaults to 0)\n");
-	fprintf (stderr, "  logfile=<file>\t\tFile to log to (defaults to stdout)\n");
-	fprintf (stderr, "  suspend=y/n\t\t\tWhether to suspend after startup.\n");
-	fprintf (stderr, "  timeout=<n>\t\t\tTimeout for connecting in milliseconds.\n");
-	fprintf (stderr, "  server=y/n\t\t\tWhether to listen for a client connection.\n");
-	fprintf (stderr, "  keepalive=<n>\t\t\tSend keepalive events every n milliseconds.\n");
-	fprintf (stderr, "  setpgid=y/n\t\t\tWhether to call setpid(0, 0) after startup.\n");
-	fprintf (stderr, "  help\t\t\t\tPrint this help.\n");
+	g_printerr ("Usage: mono --debugger-agent=[<option>=<value>,...] ...\n");
+	g_printerr ("Available options:\n");
+	g_printerr ("  transport=<transport>\t\tTransport to use for connecting to the debugger (mandatory, possible values: 'dt_socket')\n");
+	g_printerr ("  address=<hostname>:<port>\tAddress to connect to (mandatory)\n");
+	g_printerr ("  loglevel=<n>\t\t\tLog level (defaults to 0)\n");
+	g_printerr ("  logfile=<file>\t\tFile to log to (defaults to stdout)\n");
+	g_printerr ("  suspend=y/n\t\t\tWhether to suspend after startup.\n");
+	g_printerr ("  timeout=<n>\t\t\tTimeout for connecting in milliseconds.\n");
+	g_printerr ("  server=y/n\t\t\tWhether to listen for a client connection.\n");
+	g_printerr ("  keepalive=<n>\t\t\tSend keepalive events every n milliseconds.\n");
+	g_printerr ("  setpgid=y/n\t\t\tWhether to call setpid(0, 0) after startup.\n");
+	g_printerr ("  help\t\t\t\tPrint this help.\n");
 }
 
 static gboolean
@@ -876,7 +876,7 @@ parse_flag (const char *option, char *flag)
 	else if (!strcmp (flag, "n"))
 		return FALSE;
 	else {
-		fprintf (stderr, "debugger-agent: The valid values for the '%s' option are 'y' and 'n'.\n", option);
+		g_printerr ("debugger-agent: The valid values for the '%s' option are 'y' and 'n'.\n", option);
 		exit (1);
 		return FALSE;
 	}
@@ -891,7 +891,7 @@ mono_debugger_agent_parse_options (char *options)
 	char *extra;
 
 #ifndef MONO_ARCH_SOFT_DEBUG_SUPPORTED
-	fprintf (stderr, "--debugger-agent is not supported on this platform.\n");
+	g_printerr ("--debugger-agent is not supported on this platform.\n");
 	exit (1);
 #endif
 
@@ -962,19 +962,19 @@ mono_debugger_agent_parse_options (char *options)
 	//agent_config.log_level = 0;
 
 	if (agent_config.transport == NULL) {
-		fprintf (stderr, "debugger-agent: The 'transport' option is mandatory.\n");
+		g_printerr ("debugger-agent: The 'transport' option is mandatory.\n");
 		exit (1);
 	}
 
 	if (agent_config.address == NULL && !agent_config.server) {
-		fprintf (stderr, "debugger-agent: The 'address' option is mandatory.\n");
+		g_printerr ("debugger-agent: The 'address' option is mandatory.\n");
 		exit (1);
 	}
 
 	// FIXME:
 	if (!strcmp (agent_config.transport, "dt_socket")) {
 		if (agent_config.address && parse_address (agent_config.address, &host, &port)) {
-			fprintf (stderr, "debugger-agent: The format of the 'address' options is '<host>:<port>'\n");
+			g_printerr ("debugger-agent: The format of the 'address' options is '<host>:<port>'\n");
 			exit (1);
 		}
 	}
@@ -1033,7 +1033,7 @@ mono_debugger_agent_init (void)
 	if (agent_config.log_file) {
 		log_file = fopen (agent_config.log_file, "w+");
 		if (!log_file) {
-			fprintf (stderr, "Unable to create log file '%s': %s.\n", agent_config.log_file, strerror (errno));
+			g_printerr ("Unable to create log file '%s': %s.\n", agent_config.log_file, strerror (errno));
 			exit (1);
 		}
 	} else {
@@ -1101,7 +1101,7 @@ finish_agent_init (gboolean on_startup)
 
 		res = g_spawn_async_with_pipes (NULL, argv, NULL, (GSpawnFlags)0, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 		if (!res) {
-			fprintf (stderr, "Failed to execute '%s'.\n", agent_config.launch);
+			g_printerr ("Failed to execute '%s'.\n", agent_config.launch);
 			exit (1);
 		}
 	}
@@ -1204,7 +1204,7 @@ socket_transport_accept (int socket_fd)
 	MONO_EXIT_GC_SAFE;
 
 	if (conn_fd == -1) {
-		fprintf (stderr, "debugger-agent: Unable to listen on %d\n", socket_fd);
+		g_printerr ("debugger-agent: Unable to listen on %d\n", socket_fd);
 	} else {
 		DEBUG_PRINTF (1, "Accepted connection from client, connection fd=%d.\n", conn_fd);
 	}
@@ -1263,7 +1263,7 @@ socket_transport_connect (const char *address)
 		/* Obtain address(es) matching host/port */
 		s = mono_get_address_info (host, port, MONO_HINT_UNSPECIFIED, &result);
 		if (s != 0) {
-			fprintf (stderr, "debugger-agent: Unable to resolve %s:%d: %d\n", host, port, s); // FIXME add portable error conversion functions
+			g_printerr ("debugger-agent: Unable to resolve %s:%d: %d\n", host, port, s); // FIXME add portable error conversion functions
 			exit (1);
 		}
 	}
@@ -1281,7 +1281,7 @@ socket_transport_connect (const char *address)
 			/* This will bind the socket to a random port */
 			res = listen (sfd, 16);
 			if (res == -1) {
-				fprintf (stderr, "debugger-agent: Unable to setup listening socket: %s\n", strerror (get_last_sock_error ()));
+				g_printerr ("debugger-agent: Unable to setup listening socket: %s\n", strerror (get_last_sock_error ()));
 				exit (1);
 			}
 			listen_fd = sfd;
@@ -1347,7 +1347,7 @@ socket_transport_connect (const char *address)
 			MONO_EXIT_GC_SAFE;
 
 			if (res == 0) {
-				fprintf (stderr, "debugger-agent: Timed out waiting to connect.\n");
+				g_printerr ("debugger-agent: Timed out waiting to connect.\n");
 				exit (1);
 			}
 		}
@@ -1388,7 +1388,7 @@ socket_transport_connect (const char *address)
 		}
 
 		if (rp == 0) {
-			fprintf (stderr, "debugger-agent: Unable to connect to %s:%d\n", host, port);
+			g_printerr ("debugger-agent: Unable to connect to %s:%d\n", host, port);
 			exit (1);
 		}
 
@@ -1457,7 +1457,7 @@ socket_fd_transport_connect (const char *address)
 
 	res = sscanf (address, "%d", &conn_fd);
 	if (res != 1) {
-		fprintf (stderr, "debugger-agent: socket-fd transport address is invalid: '%s'\n", address);
+		g_printerr ("debugger-agent: socket-fd transport address is invalid: '%s'\n", address);
 		exit (1);
 	}
 
@@ -1527,10 +1527,10 @@ transport_init (void)
 			break;
 	}
 	if (i == ntransports) {
-		fprintf (stderr, "debugger-agent: The supported values for the 'transport' option are: ");
+		g_printerr ("debugger-agent: The supported values for the 'transport' option are: ");
 		for (i = 0; i < ntransports; ++i)
-			fprintf (stderr, "%s'%s'", i > 0 ? ", " : "", transports [i].name);
-		fprintf (stderr, "\n");
+			g_printerr ("%s'%s'", i > 0 ? ", " : "", transports [i].name);
+		g_printerr ("\n");
 		exit (1);
 	}
 	transport = &transports [i];
@@ -1593,7 +1593,7 @@ transport_handshake (void)
 	/* Read answer */
 	res = transport_recv (buf, strlen (handshake_msg));
 	if ((res != strlen (handshake_msg)) || (memcmp (buf, handshake_msg, strlen (handshake_msg)) != 0)) {
-		fprintf (stderr, "debugger-agent: DWP handshake failed.\n");
+		g_printerr ("debugger-agent: DWP handshake failed.\n");
 		return FALSE;
 	}
 
@@ -5161,7 +5161,7 @@ resume_from_signal_handler (void *sigctx, void *func)
 	// FIXME: This might not work on an altstack ?
 	tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
 	if (!tls)
-		fprintf (stderr, "Thread %p is not attached to the JIT.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+		g_printerr ("Thread %p is not attached to the JIT.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 	g_assert (tls);
 
 	// FIXME: MonoContext usually doesn't include the fp registers, so these are 

--- a/sdks/android/Makefile
+++ b/sdks/android/Makefile
@@ -16,6 +16,10 @@ CONFIGURATION=$(if $(filter $(RELEASE),true),release,debug)
 
 APK_DIR=apk
 
+BCL_RUNNER_EXE = $(APK_DIR)/assets/asm/main.exe
+DEBUGGER_RUNNER_EXE = $(APK_DIR)/assets/asm/dtest-app.exe
+
+
 BCL_CHECKS= \
 	corlib \
 	System \
@@ -167,7 +171,6 @@ package: $(patsubst %,$(APK_DIR)/jni/arm64-v8a/%,$(MONO_LIBS))
 package: $(patsubst %,$(APK_DIR)/jni/x86/%,$(MONO_LIBS))
 package: $(patsubst %,$(APK_DIR)/jni/x86_64/%,$(MONO_LIBS))
 package: $(APK_DIR)/assets/mconfig
-package: $(APK_DIR)/assets/asm/main.exe
 package: $(APK_DIR)/assets/asm/Mono.Android.dll
 package: $(patsubst %,$(APK_DIR)/assets/asm/%,$(BCL_LIBS))
 package: $(patsubst %,$(APK_DIR)/assets/asm/%,$(NUNIT_LIBS))
@@ -176,10 +179,37 @@ ifneq ($(MONO_WAIT_LLDB),)
 package: $(APK_DIR)/lldb-mono-0.1/xa-lldb
 endif
 
+package-bcl: package
+	rm -rf $(APK_DIR)/bin/AndroidActivity-debug.apk
+	rm -rf $(DEBUGGER_RUNNER_EXE)
+	$(MAKE) $(BCL_RUNNER_EXE)
+
+package-debugger: package
+	rm -rf $(BCL_RUNNER_EXE)
+	rm -rf $(APK_DIR)/bin/AndroidActivity-debug.apk
+	rm -rf $(APK_DIR)/assets/asm/testassembly.txt
+	$(MAKE) $(DEBUGGER_RUNNER_EXE)
+
+.PHONY: $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe
+$(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe:
+	$(MAKE) PROFILE='monodroid' -C $(TOP)/mcs/class/Mono.Debugger.Soft dtest-app.exe
+
+$(APK_DIR)/assets/asm/dtest-app.exe: $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe
+	cp $< $@
+
+make-debugger-test: package-debugger
+	cd $(APK_DIR) && RUN_WITH_MANAGED_DEBUGGER=1 MONO_DEBUGGER_TESTS=1 $(NDK_BUILD)
+	cd $(APK_DIR) && $(ANT) debug
+
+run-debugger-test: make-debugger-test
+	cd $(APK_DIR) && $(ADB) uninstall $(PACKAGE) || true
+	cd $(APK_DIR) && $(ADB) install bin/AndroidActivity-debug.apk
+	cd $(APK_DIR) && $(ADB) shell am instrument -w $(PACKAGE)/$(RUNNER)
+
 .PHONY: build-%
-build-%: package
+build-%: package-bcl
 	printf "monodroid_$*_test.dll" > $(APK_DIR)/assets/asm/testassembly.txt
-	cd $(APK_DIR) && $(NDK_BUILD)
+	cd $(APK_DIR) && MONO_BCL_TESTS=1 $(NDK_BUILD)
 	cd $(APK_DIR) && $(ANT) debug
 
 .PHONY: check-%

--- a/sdks/android/Makefile
+++ b/sdks/android/Makefile
@@ -212,10 +212,27 @@ make-debugger-test: package-debugger
 	cd $(APK_DIR) && RUN_WITH_MANAGED_DEBUGGER=1 MONO_DEBUGGER_TESTS=1 $(NDK_BUILD)
 	cd $(APK_DIR) && $(ANT) debug
 
+# fixme:
+# eventual api:
+# MONO_EXE=foo.exe make run-debug-managed-droid
+# MONO_EXE=foo.exe make run-debug-unmanaged-droid
+#
+# mono.debugger tests can just run those targets in the setup function
 run-debugger-test: make-debugger-test
 	cd $(APK_DIR) && $(ADB) uninstall $(PACKAGE) || true
 	cd $(APK_DIR) && $(ADB) install bin/AndroidActivity-debug.apk
-	cd $(APK_DIR) && $(ADB) shell am instrument -w $(PACKAGE)/$(RUNNER)
+	$(ADB) reverse tcp:6100 tcp:6100
+	cd $(APK_DIR) && $(ADB) shell am instrument $(PACKAGE)/$(RUNNER)
+
+# Skip rerunning build steps / cleanup steps
+# And run unattended
+.PHONY: dirty-run-debugger-test
+dirty-run-debugger-test:
+	$(ADB) shell am instrument $(PACKAGE)/$(RUNNER)
+
+.PHONY: run-debugger-test-cleanup
+run-debugger-test-cleanup:
+	$(ADB) reverse --remove-all
 
 .PHONY: build-%
 build-%: package-bcl

--- a/sdks/android/Makefile
+++ b/sdks/android/Makefile
@@ -18,6 +18,7 @@ APK_DIR=apk
 
 BCL_RUNNER_EXE = $(APK_DIR)/assets/asm/main.exe
 DEBUGGER_RUNNER_EXE = $(APK_DIR)/assets/asm/dtest-app.exe
+DEBUGGER_RUNNER_PDB = $(APK_DIR)/assets/asm/dtest-app.pdb
 
 
 BCL_CHECKS= \
@@ -95,6 +96,8 @@ BCL_LIBS= \
 	Mono.Data.Tds.dll \
 	Mono.Security.dll
 
+BCL_PDBS=$(patsubst %.dll,%.pdb,$(BCL_LIBS))
+
 BCL_REFERENCES=$(patsubst %,-r:$(TOP)/sdks/out/bcl/monodroid/%,$(BCL_LIBS))
 
 NUNIT_LIBS= \
@@ -155,6 +158,9 @@ $(APK_DIR)/lldb-mono-0.1/xa-lldb:
 	cd $(APK_DIR) && rm lldb-mono-0.1/xa-lldb
 	cd $(APK_DIR) && cp ../xa-lldb lldb-mono-0.1
 
+$(patsubst %,$(APK_DIR)/assets/asm/%,$(BCL_PDBS)): $(APK_DIR)/assets/asm/%: $(TOP)/sdks/out/bcl/monodroid/% | $(APK_DIR)/assets/asm
+	cp $< $@
+
 .PHONY: package
 package: $(APK_DIR)/AndroidManifest.xml
 package: $(APK_DIR)/build.xml
@@ -173,6 +179,7 @@ package: $(patsubst %,$(APK_DIR)/jni/x86_64/%,$(MONO_LIBS))
 package: $(APK_DIR)/assets/mconfig
 package: $(APK_DIR)/assets/asm/Mono.Android.dll
 package: $(patsubst %,$(APK_DIR)/assets/asm/%,$(BCL_LIBS))
+package: $(patsubst %,$(APK_DIR)/assets/asm/%,$(BCL_PDBS))
 package: $(patsubst %,$(APK_DIR)/assets/asm/%,$(NUNIT_LIBS))
 package: $(patsubst %,$(APK_DIR)/assets/asm/monodroid_%_test.dll,$(CHECKS))
 ifneq ($(MONO_WAIT_LLDB),)
@@ -189,12 +196,16 @@ package-debugger: package
 	rm -rf $(APK_DIR)/bin/AndroidActivity-debug.apk
 	rm -rf $(APK_DIR)/assets/asm/testassembly.txt
 	$(MAKE) $(DEBUGGER_RUNNER_EXE)
+	$(MAKE) $(DEBUGGER_RUNNER_PDB)
 
-.PHONY: $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe
-$(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe:
+.PHONY: $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.pdb
+$(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.pdb:
 	$(MAKE) PROFILE='monodroid' -C $(TOP)/mcs/class/Mono.Debugger.Soft dtest-app.exe
 
 $(APK_DIR)/assets/asm/dtest-app.exe: $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.exe
+	cp $< $@
+
+$(APK_DIR)/assets/asm/dtest-app.pdb: $(TOP)/mcs/class/Mono.Debugger.Soft/dtest-app.pdb
 	cp $< $@
 
 make-debugger-test: package-debugger

--- a/sdks/android/jni/Android.mk
+++ b/sdks/android/jni/Android.mk
@@ -19,9 +19,23 @@ include $(CLEAR_VARS)
 LOCAL_LDLIBS    := -llog
 LOCAL_MODULE    := runtime-bootstrap
 LOCAL_SRC_FILES := runtime-bootstrap.c
-ifneq ($(MONO_WAIT_LLDB),)
-LOCAL_CFLAGS    := -DMONO_WAIT_LLDB=1
+
+ifneq ($(MONO_BCL_TESTS),)
+LOCAL_CFLAGS    += -DMONO_BCL_TESTS=1
 endif
+
+ifneq ($(MONO_DEBUGGER_TESTS),)
+LOCAL_CFLAGS    += -DMONO_DEBUGGER_TESTS=1
+endif
+
+ifneq ($(RUN_WITH_MANAGED_DEBUGGER),)
+LOCAL_CFLAGS    += -DRUN_WITH_MANAGED_DEBUGGER=1
+endif
+
+ifneq ($(MONO_WAIT_LLDB),)
+LOCAL_CFLAGS    += -DMONO_WAIT_LLDB=1
+endif
+
 include $(BUILD_SHARED_LIBRARY)
 
 

--- a/sdks/builds/.gitignore
+++ b/sdks/builds/.gitignore
@@ -30,6 +30,8 @@ ios-simtv-*/
 ios-simwatch-*/
 wasm-interp/
 bcl/
+desktop-x86/
+desktop-x86_64/
 
 # android toolchain
 toolchains/

--- a/sdks/builds/Makefile
+++ b/sdks/builds/Makefile
@@ -62,6 +62,12 @@ ifndef DISABLE_IOS
 include ios.mk
 endif
 
+## Desktop targets
+## To run host-side tests
+ifndef DISABLE_DESKTOP
+include desktop.mk
+endif
+
 ## WASM targets
 ifndef DISABLE_WASM
 include wasm.mk

--- a/sdks/builds/bcl.mk
+++ b/sdks/builds/bcl.mk
@@ -9,7 +9,7 @@ bcl-ios_CONFIGURE_FLAGS = \
        --with-monotouch_watch=yes
 
 bcl_CONFIGURE_FLAGS = \
-       --with-profile4_x=no \
+       $(if $(DISABLE_DESKTOP),--with-profile4_x=no,--with-profile4_x=yes) \
        $(if $(DISABLE_ANDROID),,--with-monodroid=yes) \
        $(if $(DISABLE_IOS),,$(bcl-ios_CONFIGURE_FLAGS)) \
        $(if $(DISABLE_WASM),,--with-wasm=yes) \
@@ -24,7 +24,7 @@ bcl_CONFIGURE_FLAGS = \
 	cd $(TOP)/sdks/builds/bcl && $(TOP)/configure $(bcl_CONFIGURE_FLAGS)
 	touch $@
 
-$(TOP)/sdks/out/bcl/monodroid $(TOP)/sdks/out/bcl/monotouch $(TOP)/sdks/out/bcl/wasm:
+$(TOP)/sdks/out/bcl/monodroid $(TOP)/sdks/out/bcl/monotouch $(TOP)/sdks/out/bcl/wasm $(TOP)/sdks/out/bcl/net_4_x:
 	mkdir -p $@
 
 .PHONY: package-bcl
@@ -32,6 +32,7 @@ package-bcl: | $(TOP)/sdks/out/bcl/monodroid $(TOP)/sdks/out/bcl/monotouch $(TOP
 	if [ -d $(TOP)/mcs/class/lib/monodroid ]; then cp -R $(TOP)/mcs/class/lib/monodroid/* $(TOP)/sdks/out/bcl/monodroid; fi
 	if [ -d $(TOP)/mcs/class/lib/monotouch ]; then cp -R $(TOP)/mcs/class/lib/monotouch/* $(TOP)/sdks/out/bcl/monotouch; fi
 	if [ -d $(TOP)/mcs/class/lib/wasm ]; then cp -R $(TOP)/mcs/class/lib/wasm/* $(TOP)/sdks/out/bcl/wasm; fi
+	if [ -d $(TOP)/mcs/class/lib/net_4_x ]; then cp -R $(TOP)/mcs/class/lib/net_4_x/* $(TOP)/sdks/out/bcl/net_4_x; fi
 
 .PHONY: clean-bcl
 clean-bcl:

--- a/sdks/builds/bcl.mk
+++ b/sdks/builds/bcl.mk
@@ -28,7 +28,7 @@ $(TOP)/sdks/out/bcl/monodroid $(TOP)/sdks/out/bcl/monotouch $(TOP)/sdks/out/bcl/
 	mkdir -p $@
 
 .PHONY: package-bcl
-package-bcl: | $(TOP)/sdks/out/bcl/monodroid $(TOP)/sdks/out/bcl/monotouch $(TOP)/sdks/out/bcl/wasm
+package-bcl: | $(TOP)/sdks/out/bcl/net_4_x $(TOP)/sdks/out/bcl/monodroid $(TOP)/sdks/out/bcl/monotouch $(TOP)/sdks/out/bcl/wasm
 	if [ -d $(TOP)/mcs/class/lib/monodroid ]; then cp -R $(TOP)/mcs/class/lib/monodroid/* $(TOP)/sdks/out/bcl/monodroid; fi
 	if [ -d $(TOP)/mcs/class/lib/monotouch ]; then cp -R $(TOP)/mcs/class/lib/monotouch/* $(TOP)/sdks/out/bcl/monotouch; fi
 	if [ -d $(TOP)/mcs/class/lib/wasm ]; then cp -R $(TOP)/mcs/class/lib/wasm/* $(TOP)/sdks/out/bcl/wasm; fi

--- a/sdks/builds/desktop.mk
+++ b/sdks/builds/desktop.mk
@@ -1,0 +1,51 @@
+
+##
+# Parameters:
+#  $(1): arch
+#  $(2): host_triple
+#
+# Flags:
+#  desktop_$(1)_CFLAGS
+#  desktop_$(1)_CXXFLAGS
+#  desktop_$(1)_LDFLAGS
+define DesktopTemplate
+
+_desktop_$(1)_CONFIGURE_ENVIRONMENT = \
+	CFLAGS="$$(_desktop_$(1)_CFLAGS)" \
+	CXXFLAGS="$$(_desktop_$(1)_CXXFLAGS) " \
+	LDFLAGS="$$(_desktop_$(1)_LDFLAGS)" \
+	CC="cc"
+
+_desktop_$(1)_CONFIGURE_FLAGS= \
+	--host=$(2) \
+	--cache-file=$$(TOP)/sdks/builds/desktop-$(1).config.cache \
+	--prefix=$$(TOP)/sdks/out/desktop-$(1) \
+	--disable-boehm \
+	--disable-iconv \
+	--disable-mcs-build \
+	--disable-nls \
+	--enable-dynamic-btls \
+	--enable-maintainer-mode \
+	--with-sigaltstack=yes \
+	--with-tls=pthread \
+	--without-ikvm-native
+
+.PHONY: package-desktop-$(1)
+package-desktop-$(1):
+	$$(MAKE) -C $$(TOP)/sdks/builds/desktop-$(1)/mono install
+	$$(MAKE) -C $$(TOP)/sdks/builds/desktop-$(1)/support install
+
+.stamp-desktop-$(1)-configure: $$(TOP)/configure 
+	mkdir -p $$(TOP)/sdks/builds/desktop-$(1)
+	cd $$(TOP)/sdks/builds/desktop-$(1) && $$(TOP)/configure $$(_desktop_$(1)_AC_VARS) $$(_desktop_$(1)_CONFIGURE_ENVIRONMENT) $$(_desktop_$(1)_CONFIGURE_FLAGS)
+	touch $$@
+
+.PHONY: clean-desktop-$(1)
+clean-desktop-$(1):
+	rm -rf $$(TOP)/sdks/builds/toolchains/desktop-$(1) $$(TOP)/sdks/builds/desktop-$(1) $$(TOP)/sdks/builds/desktop-$(1).config.cache
+
+TARGETS += desktop-$(1)
+
+endef
+
+$(eval $(call DesktopTemplate,x86_64,x86_64-apple-darwin17.2.0))

--- a/sdks/desktop/Makefile
+++ b/sdks/desktop/Makefile
@@ -1,0 +1,15 @@
+TOP=$(realpath $(CURDIR)/../..)
+include $(TOP)/sdks/paths.mk
+
+run: $(CURDIR)/net_4_x_Mono.Debugger.Soft_test.dll $(TOP)/sdks/out/desktop-x86_64/bin/mono-sgen
+	MONO_TESTS_IN_PROGRESS="yes" MONO_PATH="$(CURDIR)/../out/bcl/net_4_x" $(TOP)/sdks/out/desktop-x86_64/bin/mono-sgen --debug $(CURDIR)/../out/bcl/net_4_x/nunit-lite-console.exe $(CURDIR)/net_4_x_Mono.Debugger.Soft_test.dll -exclude=NotOnMac,MacNotWorking,NotWorking,CAS  -format:nunit2
+
+.PHONY: $(CURDIR)/net_4_x_Mono.Debugger.Soft_test.dll
+$(CURDIR)/net_4_x_Mono.Debugger.Soft_test.dll: $(TOP)/mcs/class/lib/net_4_x/tests/net_4_x_Mono.Debugger.Soft_test.dll
+	cp $(TOP)/mcs/class/lib/net_4_x/tests/net_4_x_Mono.Debugger.Soft_test.dll $(CURDIR)/net_4_x_Mono.Debugger.Soft_test.dll
+	cp $(TOP)/mcs/class/lib/net_4_x/nunit* $(CURDIR)/../out/bcl/net_4_x
+
+.PHONY: $(TOP)/mcs/class/lib/net_4_x/tests/net_4_x_Mono.Debugger.Soft_test.dll
+$(TOP)/mcs/class/lib/net_4_x/tests/net_4_x_Mono.Debugger.Soft_test.dll:
+	$(MAKE) PROFILE='net_4_x' -C $(TOP)/mcs/class/Mono.Debugger.Soft test
+

--- a/sdks/desktop/Makefile
+++ b/sdks/desktop/Makefile
@@ -11,5 +11,5 @@ $(CURDIR)/net_4_x_Mono.Debugger.Soft_test.dll: $(TOP)/mcs/class/lib/net_4_x/test
 
 .PHONY: $(TOP)/mcs/class/lib/net_4_x/tests/net_4_x_Mono.Debugger.Soft_test.dll
 $(TOP)/mcs/class/lib/net_4_x/tests/net_4_x_Mono.Debugger.Soft_test.dll:
-	$(MAKE) PROFILE='net_4_x' -C $(TOP)/mcs/class/Mono.Debugger.Soft test
+	$(MAKE) TEST_MCS_FLAGS="-d:MONODROID_TEST" PROFILE='net_4_x' -C $(TOP)/mcs/class/Mono.Debugger.Soft test
 


### PR DESCRIPTION
This adds the Managed debugger tests to the sdks. A couple of the tests are failing, but everything related to the setup of the runtime appears to be passing. We have 5 failures right now. 

Note also that this adds support for running an arbitrary .exe if someone is willing to edit the boostrap file and indicate their class main, and pass the args themselves. They can also set the args with the managed debugger. 

This functionality is linked to https://github.com/mono/mono/pull/6310 . That PR has the lldb integration that was necessary to debug this into working. If combined with the ability to run an arbitrary .exe, it allows us to more easily take an android reproduction and run it in an sdks environment with different monos. 
