### PR TITLE
Mark mono_class_vtable and mono_class_from_typeref external only.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -189,7 +189,8 @@ create_domain_objects (MonoDomain *domain)
 	 * Initialize String.Empty. This enables the removal of
 	 * the static cctor of the String class.
 	 */
-	string_vt = mono_class_vtable (domain, mono_defaults.string_class);
+	string_vt = mono_class_vtable_full (domain, mono_defaults.string_class, &error);
+	mono_error_assert_ok (&error);
 	string_empty_fld = mono_class_get_field_from_name (mono_defaults.string_class, "Empty");
 	g_assert (string_empty_fld);
 	MonoString *empty_str = mono_string_new_checked (domain, "", &error);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -189,7 +189,7 @@ create_domain_objects (MonoDomain *domain)
 	 * Initialize String.Empty. This enables the removal of
 	 * the static cctor of the String class.
 	 */
-	string_vt = mono_class_vtable_full (domain, mono_defaults.string_class, &error);
+	string_vt = mono_class_vtable_checked (domain, mono_defaults.string_class, &error);
 	mono_error_assert_ok (&error);
 	string_empty_fld = mono_class_get_field_from_name (mono_defaults.string_class, "Empty");
 	g_assert (string_empty_fld);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1361,7 +1361,7 @@ MonoClassField*
 mono_class_get_field_from_name_full (MonoClass *klass, const char *name, MonoType *type);
 
 MonoVTable*
-mono_class_vtable_full (MonoDomain *domain, MonoClass *klass, MonoError *error);
+mono_class_vtable_checked (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
 gboolean
 mono_class_is_assignable_from_slow (MonoClass *target, MonoClass *candidate);

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -27,6 +27,7 @@ mono_class_get_full        (MonoImage *image, uint32_t type_token, MonoGenericCo
 MONO_API mono_bool
 mono_class_init            (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoVTable *
 mono_class_vtable          (MonoDomain *domain, MonoClass *klass);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -39,6 +39,7 @@ mono_class_from_name_case  (MonoImage *image, const char* name_space, const char
 MONO_API MonoMethod *
 mono_class_get_method_from_name_flags (MonoClass *klass, const char *name, int param_count, int flags);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClass * 
 mono_class_from_typeref    (MonoImage *image, uint32_t type_token);
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1763,7 +1763,7 @@ ves_icall_System_ComObject_CreateRCW (MonoReflectionType *type)
 	 * is called by the corresponding real proxy to create the real RCW.
 	 * Constructor does not need to be called. Will be called later.
 	*/
-	MonoVTable *vtable = mono_class_vtable_full (domain, klass, &error);
+	MonoVTable *vtable = mono_class_vtable_checked (domain, klass, &error);
 	if (mono_error_set_pending_exception (&error))
 		return NULL;
 	obj = mono_object_new_alloc_specific_checked (vtable, &error);

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -2238,7 +2238,11 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 				const char *nspace = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAMESPACE]);
 
 				if (!strcmp (nspace, "System") && !strcmp (name, "WeakAttribute")) {
-					MonoClass *klass = mono_class_from_typeref (image, MONO_TOKEN_TYPE_REF | nindex);
+					MonoClass *klass = mono_class_from_typeref_checked (image, MONO_TOKEN_TYPE_REF | nindex, &error);
+					if (!is_ok (&error)) {
+						mono_error_cleanup (&error);
+						return;
+					}
 					g_assert (!strcmp (klass->name, "WeakAttribute"));
 					/* Allow a testing dll as well since some profiles don't have WeakAttribute */
 					if (klass && (klass->image == mono_get_corlib () || strstr (klass->image->name, "Mono.Runtime.Testing"))) {

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1218,7 +1218,7 @@ mono_class_describe_statics (MonoClass* klass)
 	MonoClassField *field;
 	MonoClass *p;
 	const char *field_ptr;
-	MonoVTable *vtable = mono_class_vtable_full (mono_domain_get (), klass, &error);
+	MonoVTable *vtable = mono_class_vtable_checked (mono_domain_get (), klass, &error);
 	const char *addr;
 
 	if (!vtable || !is_ok (&error)) {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -979,7 +979,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunClassConstructor (Mo
 	if (mono_class_is_gtd (klass))
 		return;
 
-	vtable = mono_class_vtable_full (mono_domain_get (), klass, &error);
+	vtable = mono_class_vtable_checked (mono_domain_get (), klass, &error);
 	if (!is_ok (&error)) {
 		mono_error_set_pending_exception (&error);
 		return;
@@ -1003,7 +1003,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunModuleConstructor (M
 			return;
 		}
 		/*It's fine to raise the exception here*/
-		MonoVTable * vtable = mono_class_vtable_full (mono_domain_get (), module_klass, &error);
+		MonoVTable * vtable = mono_class_vtable_checked (mono_domain_get (), module_klass, &error);
 		if (!is_ok (&error)) {
 			mono_error_set_pending_exception (&error);
 			return;
@@ -2071,7 +2071,7 @@ ves_icall_MonoField_SetValueInternal (MonoReflectionFieldHandle field, MonoObjec
 		  (!isref && v == NULL && value_gchandle == 0));
 
 	if (type->attrs & FIELD_ATTRIBUTE_STATIC) {
-		MonoVTable *vtable = mono_class_vtable_full (MONO_HANDLE_DOMAIN (field), cf->parent, error);
+		MonoVTable *vtable = mono_class_vtable_checked (MONO_HANDLE_DOMAIN (field), cf->parent, error);
 		goto_if_nok (error, leave);
 
 		if (!vtable->initialized) {
@@ -3229,7 +3229,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 	}
 
 	if (!(m->flags & METHOD_ATTRIBUTE_STATIC)) {
-		if (!mono_class_vtable_full (mono_object_domain (method), m->klass, &error)) {
+		if (!mono_class_vtable_checked (mono_object_domain (method), m->klass, &error)) {
 			mono_error_cleanup (&error); /* FIXME does this make sense? */
 			mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_class_get_exception_for_failure (m->klass));
 			return NULL;
@@ -7035,7 +7035,7 @@ ves_icall_System_Runtime_Activation_ActivationServices_EnableProxyActivation (Mo
 	error_init (error);
 
 	MonoClass *klass = mono_class_from_mono_type (MONO_HANDLE_GETVAL (type, type));
-	MonoVTable *vtable = mono_class_vtable_full (mono_domain_get (), klass, error);
+	MonoVTable *vtable = mono_class_vtable_checked (mono_domain_get (), klass, error);
 	return_if_nok (error);
 
 	mono_vtable_set_is_remote (vtable, enable);
@@ -7071,7 +7071,7 @@ ves_icall_System_Runtime_Activation_ActivationServices_AllocateUninitializedClas
 		g_assert (klass->rank == 1);
 		return MONO_HANDLE_CAST (MonoObject, mono_array_new_handle (domain, klass->element_class, 0, error));
 	} else {
-		MonoVTable *vtable = mono_class_vtable_full (domain, klass, error);
+		MonoVTable *vtable = mono_class_vtable_checked (domain, klass, error);
 		return_val_if_nok (error, NULL_HANDLE);
 
 		/* Bypass remoting object creation check */

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -69,8 +69,8 @@ mono_mlist_alloc_checked (MonoObject *data, MonoError *error)
 	MonoMList* res;
 	if (!monolist_item_vtable) {
 		MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System", "MonoListItem");
-		monolist_item_vtable = mono_class_vtable (mono_get_root_domain (), klass);
-		g_assert (monolist_item_vtable);
+		monolist_item_vtable = mono_class_vtable_full (mono_get_root_domain (), klass, error);
+		mono_error_assert_ok  (error);
 	}
 	res = (MonoMList*)mono_object_new_specific_checked (monolist_item_vtable, error);
 	return_val_if_nok (error, NULL);

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -69,7 +69,7 @@ mono_mlist_alloc_checked (MonoObject *data, MonoError *error)
 	MonoMList* res;
 	if (!monolist_item_vtable) {
 		MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System", "MonoListItem");
-		monolist_item_vtable = mono_class_vtable_full (mono_get_root_domain (), klass, error);
+		monolist_item_vtable = mono_class_vtable_checked (mono_get_root_domain (), klass, error);
 		mono_error_assert_ok  (error);
 	}
 	res = (MonoMList*)mono_object_new_specific_checked (monolist_item_vtable, error);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -85,7 +85,7 @@
 			tmp_klass; })
 /* eclass should be a run-time constant */
 #define mono_array_new_cached(domain, eclass, size, error) ({	\
-	MonoVTable *__vtable = mono_class_vtable_full ((domain), mono_array_class_get_cached ((eclass), 1), (error)); \
+	MonoVTable *__vtable = mono_class_vtable_checked ((domain), mono_array_class_get_cached ((eclass), 1), (error)); \
 	MonoArray *__arr = NULL;					\
 	if (is_ok ((error)))						\
 		__arr = mono_array_new_specific_checked (__vtable, (size), (error)); \

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -85,15 +85,17 @@
 			tmp_klass; })
 /* eclass should be a run-time constant */
 #define mono_array_new_cached(domain, eclass, size, error) ({	\
-			MonoVTable *__vtable = mono_class_vtable ((domain), mono_array_class_get_cached ((eclass), 1));	\
-			MonoArray *__arr = mono_array_new_specific_checked (__vtable, (size), (error)); \
-			__arr; })
+	MonoVTable *__vtable = mono_class_vtable_full ((domain), mono_array_class_get_cached ((eclass), 1), (error)); \
+	MonoArray *__arr = NULL;					\
+	if (is_ok ((error)))						\
+		__arr = mono_array_new_specific_checked (__vtable, (size), (error)); \
+	__arr; })
 
 #else
 
 #define mono_class_get_field_from_name_cached(klass,name) mono_class_get_field_from_name ((klass), (name))
 #define mono_array_class_get_cached(eclass,rank) mono_array_class_get ((eclass), (rank))
-#define mono_array_new_cached(domain, eclass, size, error) mono_array_new_specific_checked (mono_class_vtable ((domain), mono_array_class_get_cached ((eclass), 1)), (size), (error))
+#define mono_array_new_cached(domain, eclass, size, error) mono_array_new_checked ((domain), (eclass), (size), (error))
 
 #endif
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2270,8 +2270,9 @@ mono_class_proxy_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mono
 
 	error_init (error);
 
-	vt = mono_class_vtable (domain, klass);
-	g_assert (vt); /*FIXME property handle failure*/
+	vt = mono_class_vtable_full (domain, klass, error);
+	if (!is_ok (error))
+		return NULL;
 	max_interface_id = vt->max_interface_id;
 	
 	/* Calculate vtable space for extra interfaces */
@@ -2699,6 +2700,7 @@ mono_remote_class_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mon
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	gpointer result = NULL;
 	error_init (error);
 
 	mono_loader_lock (); /*FIXME mono_class_from_mono_type and mono_class_proxy_vtable take it*/
@@ -2707,10 +2709,9 @@ mono_remote_class_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mon
 	if (target_domain_id != -1) {
 		if (remote_class->xdomain_vtable == NULL)
 			remote_class->xdomain_vtable = mono_class_proxy_vtable (domain, remote_class, MONO_REMOTING_TARGET_APPDOMAIN, error);
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return_val_if_nok (error, NULL);
-		return remote_class->xdomain_vtable;
+		goto_if_nok (error, leave);
+		result = remote_class->xdomain_vtable;
+		goto leave;
 	}
 	if (remote_class->default_vtable == NULL) {
 		MonoReflectionTypeHandle reftype = MONO_HANDLE_NEW (MonoReflectionType, NULL);
@@ -2719,22 +2720,28 @@ mono_remote_class_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mon
 		MonoType *type = MONO_HANDLE_GETVAL (reftype, type);
 		MonoClass *klass = mono_class_from_mono_type (type);
 #ifndef DISABLE_COM
-		if ((mono_class_is_com_object (klass) || (mono_class_get_com_object_class () && klass == mono_class_get_com_object_class ())) && !mono_vtable_is_remote (mono_class_vtable (mono_domain_get (), klass)))
+		gboolean target_is_com = FALSE;
+		if (mono_class_is_com_object (klass) || (mono_class_get_com_object_class () && klass == mono_class_get_com_object_class ())) {
+			MonoVTable *klass_vtable = mono_class_vtable_full (mono_domain_get (), klass, error);
+			goto_if_nok (error, leave);
+			if (!mono_vtable_is_remote (klass_vtable))
+				target_is_com = TRUE;
+		}
+		if (target_is_com)
 			remote_class->default_vtable = mono_class_proxy_vtable (domain, remote_class, MONO_REMOTING_TARGET_COMINTEROP, error);
 		else
 #endif
 			remote_class->default_vtable = mono_class_proxy_vtable (domain, remote_class, MONO_REMOTING_TARGET_UNKNOWN, error);
 		/* N.B. both branches of the if modify error */
-		if (!is_ok (error)) {
-			mono_domain_unlock (domain);
-			mono_loader_unlock ();
-			return NULL;
-		}
+		goto_if_nok (error, leave);
+
 	}
 	
+	result = remote_class->default_vtable;
+leave:
 	mono_domain_unlock (domain);
 	mono_loader_unlock ();
-	return remote_class->default_vtable;
+	return result;
 }
 
 /**
@@ -2875,14 +2882,14 @@ class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is_prox
 
 		/* generic methods demand invoke_with_check */
 		if (mono_method_signature (res)->generic_param_count)
-			res = mono_marshal_get_remoting_invoke_with_check (res);
+			res = mono_marshal_get_remoting_invoke_with_check (res, error);
 		else {
 #ifndef DISABLE_COM
 			if (klass == mono_class_get_com_object_class () || mono_class_is_com_object (klass))
 				res = mono_cominterop_get_invoke (res);
 			else
 #endif
-				res = mono_marshal_get_remoting_invoke (res);
+				res = mono_marshal_get_remoting_invoke (res, error);
 		}
 	} else
 #endif
@@ -5210,7 +5217,8 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			g_assert (obj); /*maybe we should raise a TLE instead?*/
 #ifndef DISABLE_REMOTING
 			if (mono_object_is_transparent_proxy (obj)) {
-				method = mono_marshal_get_remoting_invoke (method->slot == -1 ? method : method->klass->vtable [method->slot]);
+				method = mono_marshal_get_remoting_invoke (method->slot == -1 ? method : method->klass->vtable [method->slot], error);
+				return_val_if_nok (error, NULL);
 			}
 #endif
 			if (method->klass->valuetype)
@@ -5370,8 +5378,8 @@ mono_object_new_pinned (MonoDomain *domain, MonoClass *klass, MonoError *error)
 
 	error_init (error);
 
-	vtable = mono_class_vtable (domain, klass);
-	g_assert (vtable); /* FIXME don't swallow the error */
+	vtable = mono_class_vtable_full (domain, klass, error);
+	return_val_if_nok (error, NULL);
 
 	MonoObject *o = (MonoObject *)mono_gc_alloc_pinned_obj (vtable, mono_class_instance_size (klass));
 
@@ -6220,8 +6228,8 @@ mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error)
 	size = (G_STRUCT_OFFSET (MonoString, chars) + (((size_t)len + 1) * 2));
 	g_assert (size > 0);
 
-	vtable = mono_class_vtable (domain, mono_defaults.string_class);
-	g_assert (vtable);
+	vtable = mono_class_vtable_full (domain, mono_defaults.string_class, error);
+	return_val_if_nok (error, NULL);
 
 	s = (MonoString *)mono_gc_alloc_string (vtable, size, len);
 
@@ -6418,9 +6426,9 @@ mono_value_box_checked (MonoDomain *domain, MonoClass *klass, gpointer value, Mo
 	if (mono_class_is_nullable (klass))
 		return mono_nullable_box ((guint8 *)value, klass, error);
 
-	vtable = mono_class_vtable (domain, klass);
-	if (!vtable)
-		return NULL;
+	vtable = mono_class_vtable_full (domain, klass, error);
+	return_val_if_nok (error, NULL);
+
 	size = mono_class_instance_size (klass);
 	res = mono_object_new_alloc_specific_checked (vtable, error);
 	return_val_if_nok (error, NULL);
@@ -7756,7 +7764,9 @@ mono_message_invoke (MonoObject *target, MonoMethodMessage *msg,
 		object_array_klass = klass;
 	}
 
-	arr = mono_array_new_specific_checked (mono_class_vtable (domain, object_array_klass), outarg_count, error);
+	MonoVTable *vt = mono_class_vtable_full (domain, object_array_klass, error);
+	return_val_if_nok (error, NULL);
+	arr = mono_array_new_specific_checked (vt, outarg_count, error);
 	return_val_if_nok (error, NULL);
 
 	mono_gc_wbarrier_generic_store (out_args, (MonoObject*) arr);
@@ -7985,7 +7995,8 @@ mono_delegate_ctor_with_method (MonoObjectHandle this_obj, MonoObjectHandle targ
 			MONO_HANDLE_SETVAL (delegate, method_ptr, gpointer, callbacks.interp_get_remoting_invoke (addr, error));
 		} else {
 			g_assert (method);
-			method = mono_marshal_get_remoting_invoke (method);
+			method = mono_marshal_get_remoting_invoke (method, error);
+			return_val_if_nok (error, FALSE);
 			MONO_HANDLE_SETVAL (delegate, method_ptr, gpointer, mono_compile_method_checked (method, error));
 		}
 		return_val_if_nok (error, FALSE);

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -493,7 +493,7 @@ mono_marshal_get_remoting_invoke (MonoMethod *method, MonoError *error)
 	/* this seems to be the best plase to put this, as all remoting invokes seem to get filtered through here */
 #ifndef DISABLE_COM
 	if (mono_class_is_com_object (method->klass) || method->klass == mono_class_try_get_com_object_class ()) {
-		MonoVTable *vtable = mono_class_vtable_full (mono_domain_get (), method->klass, error);
+		MonoVTable *vtable = mono_class_vtable_checked (mono_domain_get (), method->klass, error);
 		return_val_if_nok (error, NULL);
 
 		if (!mono_vtable_is_remote (vtable)) {

--- a/mono/metadata/remoting.h
+++ b/mono/metadata/remoting.h
@@ -19,16 +19,16 @@ void mono_remoting_init (void);
 #ifndef DISABLE_REMOTING
 
 MonoMethod *
-mono_marshal_get_remoting_invoke (MonoMethod *method);
+mono_marshal_get_remoting_invoke (MonoMethod *method, MonoError *error);
 
 MonoMethod *
-mono_marshal_get_xappdomain_invoke (MonoMethod *method);
+mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error);
 
 MonoMethod *
-mono_marshal_get_remoting_invoke_for_target (MonoMethod *method, MonoRemotingTarget target_type);
+mono_marshal_get_remoting_invoke_for_target (MonoMethod *method, MonoRemotingTarget target_type, MonoError *error);
 
 MonoMethod *
-mono_marshal_get_remoting_invoke_with_check (MonoMethod *method);
+mono_marshal_get_remoting_invoke_with_check (MonoMethod *method, MonoError *error);
 
 MonoMethod *
 mono_marshal_get_stfld_wrapper (MonoType *type);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -502,7 +502,9 @@ get_current_thread_ptr_for_domain (MonoDomain *domain, MonoInternalThread *threa
 		g_assert (current_thread_field);
 	}
 
-	mono_class_vtable (domain, mono_defaults.thread_class);
+	MonoError thread_vt_error;
+	mono_class_vtable_full (domain, mono_defaults.thread_class, &thread_vt_error);
+	mono_error_assert_ok (&thread_vt_error);
 	mono_domain_lock (domain);
 	offset = GPOINTER_TO_UINT (g_hash_table_lookup (domain->special_static_fields, current_thread_field));
 	mono_domain_unlock (domain);
@@ -529,8 +531,8 @@ create_thread_object (MonoDomain *domain, MonoInternalThread *internal)
 	MonoVTable *vtable;
 	MonoError error;
 
-	vtable = mono_class_vtable (domain, mono_defaults.thread_class);
-	g_assert (vtable);
+	vtable = mono_class_vtable_full (domain, mono_defaults.thread_class, &error);
+	mono_error_assert_ok (&error);
 
 	thread = (MonoThread*)mono_object_new_mature (vtable, &error);
 	/* only possible failure mode is OOM, from which we don't expect to recover. */
@@ -548,7 +550,8 @@ create_internal_thread_object (void)
 	MonoInternalThread *thread;
 	MonoVTable *vt;
 
-	vt = mono_class_vtable (mono_get_root_domain (), mono_defaults.internal_thread_class);
+	vt = mono_class_vtable_full (mono_get_root_domain (), mono_defaults.internal_thread_class, &error);
+	mono_error_assert_ok (&error);
 	thread = (MonoInternalThread*) mono_object_new_mature (vt, &error);
 	/* only possible failure mode is OOM, from which we don't exect to recover */
 	mono_error_assert_ok (&error);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -503,7 +503,7 @@ get_current_thread_ptr_for_domain (MonoDomain *domain, MonoInternalThread *threa
 	}
 
 	MonoError thread_vt_error;
-	mono_class_vtable_full (domain, mono_defaults.thread_class, &thread_vt_error);
+	mono_class_vtable_checked (domain, mono_defaults.thread_class, &thread_vt_error);
 	mono_error_assert_ok (&thread_vt_error);
 	mono_domain_lock (domain);
 	offset = GPOINTER_TO_UINT (g_hash_table_lookup (domain->special_static_fields, current_thread_field));
@@ -531,7 +531,7 @@ create_thread_object (MonoDomain *domain, MonoInternalThread *internal)
 	MonoVTable *vtable;
 	MonoError error;
 
-	vtable = mono_class_vtable_full (domain, mono_defaults.thread_class, &error);
+	vtable = mono_class_vtable_checked (domain, mono_defaults.thread_class, &error);
 	mono_error_assert_ok (&error);
 
 	thread = (MonoThread*)mono_object_new_mature (vtable, &error);
@@ -550,7 +550,7 @@ create_internal_thread_object (void)
 	MonoInternalThread *thread;
 	MonoVTable *vt;
 
-	vt = mono_class_vtable_full (mono_get_root_domain (), mono_defaults.internal_thread_class, &error);
+	vt = mono_class_vtable_checked (mono_get_root_domain (), mono_defaults.internal_thread_class, &error);
 	mono_error_assert_ok (&error);
 	thread = (MonoInternalThread*) mono_object_new_mature (vt, &error);
 	/* only possible failure mode is OOM, from which we don't exect to recover */

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4372,13 +4372,13 @@ init_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *method, M
 
 	gboolean inited_ok = TRUE;
 	if (init_class) {
-		MonoVTable *vt = mono_class_vtable_full (domain, init_class, error);
+		MonoVTable *vt = mono_class_vtable_checked (domain, init_class, error);
 		if (!is_ok (error))
 			inited_ok = FALSE;
 		else
 			inited_ok = mono_runtime_class_init_full (vt, error);
 	} else if (from_plt && klass_to_run_ctor && !mono_class_is_gtd (klass_to_run_ctor)) {
-		MonoVTable *vt = mono_class_vtable_full (domain, klass_to_run_ctor, error);
+		MonoVTable *vt = mono_class_vtable_checked (domain, klass_to_run_ctor, error);
 		if (!is_ok (error))
 			inited_ok = FALSE;
 		else

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8750,7 +8750,9 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 			if (!found)
 				return ERR_INVALID_FIELDID;
 
-			vtable = mono_class_vtable (domain, f->parent);
+			vtable = mono_class_vtable_full (domain, f->parent, &error);
+			if (!is_ok (&error))
+				return ERR_INVALID_FIELDID;
 			val = (guint8 *)g_malloc (mono_class_instance_size (mono_class_from_mono_type (f->type)));
 			mono_field_static_get_value_for_thread (thread ? thread : mono_thread_internal_current (), vtable, f, val, &error);
 			if (!is_ok (&error))
@@ -8792,7 +8794,9 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 
 			// FIXME: Check for literal/const
 
-			vtable = mono_class_vtable (domain, f->parent);
+			vtable = mono_class_vtable_full (domain, f->parent, &error);
+			if (!is_ok (&error))
+				return ERR_INVALID_FIELDID;
 			val = (guint8 *)g_malloc (mono_class_instance_size (mono_class_from_mono_type (f->type)));
 			err = decode_value (f->type, domain, val, p, &p, end);
 			if (err != ERR_NONE) {
@@ -8930,7 +8934,9 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 		break;
 	}
 	case CMD_TYPE_IS_INITIALIZED: {
-		MonoVTable *vtable = mono_class_vtable (domain, klass);
+		MonoVTable *vtable = mono_class_vtable_full (domain, klass, &error);
+		if (!is_ok (&error))
+			return ERR_LOADER_ERROR;
 
 		if (vtable)
 			buffer_add_int (buf, (vtable->initialized || vtable->init_failed) ? 1 : 0);
@@ -10012,7 +10018,11 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					return ERR_INVALID_FIELDID;
 
 				g_assert (f->type->attrs & FIELD_ATTRIBUTE_STATIC);
-				vtable = mono_class_vtable (obj->vtable->domain, f->parent);
+				vtable = mono_class_vtable_full (obj->vtable->domain, f->parent, &error);
+				if (!is_ok (&error)) {
+					mono_error_cleanup (&error);
+					return ERR_INVALID_OBJECT;
+				}
 				val = (guint8 *)g_malloc (mono_class_instance_size (mono_class_from_mono_type (f->type)));
 				mono_field_static_get_value_checked (vtable, f, val, &error);
 				if (!is_ok (&error)) {
@@ -10069,7 +10079,11 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					return ERR_INVALID_FIELDID;
 
 				g_assert (f->type->attrs & FIELD_ATTRIBUTE_STATIC);
-				vtable = mono_class_vtable (obj->vtable->domain, f->parent);
+				vtable = mono_class_vtable_full (obj->vtable->domain, f->parent, &error);
+				if (!is_ok (&error)) {
+					mono_error_cleanup (&error);
+					return ERR_INVALID_FIELDID;
+				}
 
 				val = (guint8 *)g_malloc (mono_class_instance_size (mono_class_from_mono_type (f->type)));
 				err = decode_value (f->type, obj->vtable->domain, val, p, &p, end);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8750,7 +8750,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 			if (!found)
 				return ERR_INVALID_FIELDID;
 
-			vtable = mono_class_vtable_full (domain, f->parent, &error);
+			vtable = mono_class_vtable_checked (domain, f->parent, &error);
 			if (!is_ok (&error))
 				return ERR_INVALID_FIELDID;
 			val = (guint8 *)g_malloc (mono_class_instance_size (mono_class_from_mono_type (f->type)));
@@ -8794,7 +8794,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 
 			// FIXME: Check for literal/const
 
-			vtable = mono_class_vtable_full (domain, f->parent, &error);
+			vtable = mono_class_vtable_checked (domain, f->parent, &error);
 			if (!is_ok (&error))
 				return ERR_INVALID_FIELDID;
 			val = (guint8 *)g_malloc (mono_class_instance_size (mono_class_from_mono_type (f->type)));
@@ -8934,7 +8934,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 		break;
 	}
 	case CMD_TYPE_IS_INITIALIZED: {
-		MonoVTable *vtable = mono_class_vtable_full (domain, klass, &error);
+		MonoVTable *vtable = mono_class_vtable_checked (domain, klass, &error);
 		if (!is_ok (&error))
 			return ERR_LOADER_ERROR;
 
@@ -10018,7 +10018,7 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					return ERR_INVALID_FIELDID;
 
 				g_assert (f->type->attrs & FIELD_ATTRIBUTE_STATIC);
-				vtable = mono_class_vtable_full (obj->vtable->domain, f->parent, &error);
+				vtable = mono_class_vtable_checked (obj->vtable->domain, f->parent, &error);
 				if (!is_ok (&error)) {
 					mono_error_cleanup (&error);
 					return ERR_INVALID_OBJECT;
@@ -10079,7 +10079,7 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					return ERR_INVALID_FIELDID;
 
 				g_assert (f->type->attrs & FIELD_ATTRIBUTE_STATIC);
-				vtable = mono_class_vtable_full (obj->vtable->domain, f->parent, &error);
+				vtable = mono_class_vtable_checked (obj->vtable->domain, f->parent, &error);
 				if (!is_ok (&error)) {
 					mono_error_cleanup (&error);
 					return ERR_INVALID_FIELDID;

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1528,7 +1528,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 					} else {
 						MonoClass *array_class = mono_array_class_get (ins->inst_newa_class, 1);
 						MonoError vt_error;
-						MonoVTable *vtable = mono_class_vtable_full (cfg->domain, array_class, &vt_error);
+						MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, array_class, &vt_error);
 						MonoMethod *managed_alloc = mono_gc_get_managed_array_allocator (array_class);
 
 						mono_error_assert_ok (&vt_error); /*This shall not fail since we check for this condition on OP_NEWARR creation*/

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1527,10 +1527,11 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						dest->dreg = ins->dreg;
 					} else {
 						MonoClass *array_class = mono_array_class_get (ins->inst_newa_class, 1);
-						MonoVTable *vtable = mono_class_vtable (cfg->domain, array_class);
+						MonoError vt_error;
+						MonoVTable *vtable = mono_class_vtable_full (cfg->domain, array_class, &vt_error);
 						MonoMethod *managed_alloc = mono_gc_get_managed_array_allocator (array_class);
 
-						g_assert (vtable); /*This shall not fail since we check for this condition on OP_NEWARR creation*/
+						mono_error_assert_ok (&vt_error); /*This shall not fail since we check for this condition on OP_NEWARR creation*/
 						NEW_VTABLECONST (cfg, iargs [0], vtable);
 						MONO_ADD_INS (cfg->cbb, iargs [0]);
 						MONO_INST_NEW (cfg, iargs [1], OP_MOVE);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -275,7 +275,9 @@ interp_get_remoting_invoke (gpointer imethod, MonoError *error)
 
 	g_assert (mono_use_interpreter);
 
-	return mono_interp_get_imethod (mono_domain_get (), mono_marshal_get_remoting_invoke (imethod_cast->method), error);
+	MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke (imethod_cast->method, error);
+	return_val_if_nok (error, NULL);
+	return mono_interp_get_imethod (mono_domain_get (), remoting_invoke_method, error);
 }
 #endif
 
@@ -360,7 +362,9 @@ get_virtual_method (InterpMethod *imethod, MonoObject *obj)
 
 #ifndef DISABLE_REMOTING
 	if (mono_object_is_transparent_proxy (obj)) {
-		ret = mono_interp_get_imethod (domain, mono_marshal_get_remoting_invoke_with_check (m), &error);
+		MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke_with_check (m, &error);
+		mono_error_assert_ok (&error);
+		ret = mono_interp_get_imethod (domain, remoting_invoke_method, &error);
 		mono_error_assert_ok (&error);
 		return ret;
 	}
@@ -3661,7 +3665,9 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 					sp->data.p = o;
 #ifndef DISABLE_REMOTING
 					if (mono_object_is_transparent_proxy (o)) {
-						child_frame.imethod = mono_interp_get_imethod (rtm->domain, mono_marshal_get_remoting_invoke_with_check (child_frame.imethod->method), &error);
+						MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke_with_check (child_frame.imethod->method, &error);
+						mono_error_assert_ok (&error);
+						child_frame.imethod = mono_interp_get_imethod (rtm->domain, remoting_invoke_method, &error);
 						mono_error_assert_ok (&error);
 					}
 #endif

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1059,7 +1059,7 @@ no_intrinsic:
 		(target_method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) == 0 && 
 		(target_method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) == 0 &&
 		!(target_method->iflags & METHOD_IMPL_ATTRIBUTE_NOINLINING)) {
-		MonoVTable *vt = mono_class_vtable_full (domain, target_method->klass, error);
+		MonoVTable *vt = mono_class_vtable_checked (domain, target_method->klass, error);
 		return_if_nok (error);
 		int called_inited = vt->initialized;
 
@@ -4311,7 +4311,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Int
 	}
 
 	// g_printerr ("TRANSFORM(0x%016lx): begin %s::%s\n", mono_thread_current (), method->klass->name, method->name);
-	method_class_vt = mono_class_vtable_full (domain, imethod->method->klass, &error);
+	method_class_vt = mono_class_vtable_checked (domain, imethod->method->klass, &error);
 	if (!is_ok (&error))
 		return mono_error_convert_to_exception (&error);
 
@@ -4454,7 +4454,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Int
 				}
 				mono_class_init (m->klass);
 				if (!mono_class_is_interface (m->klass)) {
-					mono_class_vtable_full (domain, m->klass, &error);
+					mono_class_vtable_checked (domain, m->klass, &error);
 					if (!is_ok (&error)) {
 						g_free (is_bb_start);
 						mono_metadata_free_mh (header);

--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -324,7 +324,9 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 			NEW_AOTCONST ((cfg), (dest), MONO_PATCH_INFO_METHOD_RGCTX, (method)); \
 		} else {														\
 			MonoMethodRuntimeGenericContext *mrgctx;					\
-			mrgctx = mono_method_lookup_rgctx (mono_class_vtable ((cfg)->domain, (method)->klass), mini_method_get_context ((method))->method_inst); \
+			MonoVTable *vt = mono_class_vtable_full ((cfg)->domain, (method)->klass, &(cfg)->error); \
+			mono_error_assert_ok (&(cfg)->error);		\
+			mrgctx = mono_method_lookup_rgctx (vt, mini_method_get_context ((method))->method_inst); \
 			NEW_PCONST ((cfg), (dest), (mrgctx));						\
 		}																\
 	} while (0)

--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -324,7 +324,7 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 			NEW_AOTCONST ((cfg), (dest), MONO_PATCH_INFO_METHOD_RGCTX, (method)); \
 		} else {														\
 			MonoMethodRuntimeGenericContext *mrgctx;					\
-			MonoVTable *vt = mono_class_vtable_full ((cfg)->domain, (method)->klass, &(cfg)->error); \
+			MonoVTable *vt = mono_class_vtable_checked ((cfg)->domain, (method)->klass, &(cfg)->error); \
 			mono_error_assert_ok (&(cfg)->error);		\
 			mrgctx = mono_method_lookup_rgctx (vt, mini_method_get_context ((method))->method_inst); \
 			NEW_PCONST ((cfg), (dest), (mrgctx));						\

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -877,7 +877,7 @@ mono_class_static_field_address (MonoDomain *domain, MonoClassField *field)
 
 	mono_class_init (field->parent);
 
-	vtable = mono_class_vtable_full (domain, field->parent, &error);
+	vtable = mono_class_vtable_checked (domain, field->parent, &error);
 	if (!is_ok (&error)) {
 		mono_error_set_pending_exception (&error);
 		return NULL;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2461,9 +2461,11 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 	call = mono_emit_call_args (cfg, sig, args, FALSE, virtual_, tail, rgctx_arg ? TRUE : FALSE, need_unbox_trampoline, method);
 
 #ifndef DISABLE_REMOTING
-	if (might_be_remote)
-		call->method = mono_marshal_get_remoting_invoke_with_check (method);
-	else
+	if (might_be_remote) {
+		MonoError error;
+		call->method = mono_marshal_get_remoting_invoke_with_check (method, &error);
+		mono_error_assert_ok (&error);
+	} else
 #endif
 		call->method = method;
 	call->inst.flags |= MONO_INST_HAS_METHOD;
@@ -2514,11 +2516,13 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 			 */
 #ifndef DISABLE_REMOTING
 			if (mono_class_is_marshalbyref (method->klass) || method->klass == mono_defaults.object_class) {
+				MonoError error;
 				/* 
 				 * The check above ensures method is not gshared, this is needed since
 				 * gshared methods can't have wrappers.
 				 */
-				method = call->method = mono_marshal_get_remoting_invoke_with_check (method);
+				method = call->method = mono_marshal_get_remoting_invoke_with_check (method, &error);
+				mono_error_assert_ok (&error);
 			}
 #endif
 
@@ -3313,10 +3317,12 @@ emit_class_init (MonoCompile *cfg, MonoClass *klass)
 		vtable_arg = mini_emit_get_rgctx_klass (cfg, context_used,
 										   klass, MONO_RGCTX_INFO_VTABLE);
 	} else {
-		MonoVTable *vtable = mono_class_vtable (cfg->domain, klass);
-
-		if (!vtable)
+		MonoVTable *vtable = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+		if (!is_ok (&cfg->error)) {
+			mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 			return;
+		}
+
 		EMIT_NEW_VTABLECONST (cfg, vtable_arg, vtable);
 	}
 
@@ -3452,15 +3458,19 @@ mini_emit_check_array_type (MonoCompile *cfg, MonoInst *obj, MonoClass *array_cl
 			int vt_reg;
 			MonoVTable *vtable;
 
-			if (!(vtable = mono_class_vtable (cfg->domain, array_class)))
+			if (!(vtable = mono_class_vtable_full (cfg->domain, array_class, &cfg->error))) {
+				mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 				return;
+			}
 			vt_reg = alloc_preg (cfg);
 			MONO_EMIT_NEW_VTABLECONST (cfg, vt_reg, vtable);
 			MONO_EMIT_NEW_BIALU (cfg, OP_COMPARE, -1, vtable_reg, vt_reg);
 		} else {
 			MonoVTable *vtable;
-			if (!(vtable = mono_class_vtable (cfg->domain, array_class)))
+			if (!(vtable = mono_class_vtable_full (cfg->domain, array_class, &cfg->error))) {
+				mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 				return;
+			}
 			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, vtable);
 		}
 	}
@@ -3503,9 +3513,9 @@ handle_unbox_nullable (MonoCompile* cfg, MonoInst* val, MonoClass* klass, int co
 		g_assert (!pass_mrgctx);
 
 		if (pass_vtable) {
-			MonoVTable *vtable = mono_class_vtable (cfg->domain, method->klass);
+			MonoVTable *vtable = mono_class_vtable_full (cfg->domain, method->klass, &cfg->error);
 
-			g_assert (vtable);
+			mono_error_assert_ok (&cfg->error);
 			EMIT_NEW_VTABLECONST (cfg, rgctx_arg, vtable);
 		}
 
@@ -3701,16 +3711,14 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 		EMIT_NEW_ICONST (cfg, iargs [0], mono_metadata_token_index (klass->type_token));
 		alloc_ftn = mono_helper_newobj_mscorlib;
 	} else {
-		MonoVTable *vtable = mono_class_vtable (cfg->domain, klass);
-		MonoMethod *managed_alloc = NULL;
+		MonoVTable *vtable = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
 
-		if (!vtable) {
-			mono_cfg_set_exception (cfg, MONO_EXCEPTION_TYPE_LOAD);
-			cfg->exception_ptr = klass;
+		if (!is_ok (&cfg->error)) {
+			mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 			return NULL;
 		}
 
-		managed_alloc = mono_gc_get_managed_allocator (klass, for_box, TRUE);
+		MonoMethod *managed_alloc = mono_gc_get_managed_allocator (klass, for_box, TRUE);
 
 		if (managed_alloc) {
 			int size = mono_class_instance_size (klass);
@@ -3761,9 +3769,9 @@ handle_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used)
 			g_assert (!pass_mrgctx);
 
 			if (pass_vtable) {
-				MonoVTable *vtable = mono_class_vtable (cfg->domain, method->klass);
+				MonoVTable *vtable = mono_class_vtable_full (cfg->domain, method->klass, &cfg->error);
 
-				g_assert (vtable);
+				mono_error_assert_ok (&cfg->error);
 				EMIT_NEW_VTABLECONST (cfg, rgctx_arg, vtable);
 			}
 
@@ -4240,11 +4248,13 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 		/* The AggressiveInlining hint is a good excuse to force that cctor to run. */
 		if (method->iflags & METHOD_IMPL_ATTRIBUTE_AGGRESSIVE_INLINING) {
 			if (method->klass->has_cctor) {
-				vtable = mono_class_vtable (cfg->domain, method->klass);
-				if (!vtable)
+				MonoError error;
+				vtable = mono_class_vtable_full (cfg->domain, method->klass, &error);
+				if (!is_ok (&error)) {
+					mono_error_cleanup (&error);
 					return FALSE;
+				}
 				if (!cfg->compile_aot) {
-					MonoError error;
 					if (!mono_runtime_class_init_full (vtable, &error)) {
 						mono_error_cleanup (&error);
 						return FALSE;
@@ -4253,31 +4263,36 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 			}
 		} else if (mono_class_is_before_field_init (method->klass)) {
 			if (cfg->run_cctors && method->klass->has_cctor) {
+				MonoError error;
 				/*FIXME it would easier and lazier to just use mono_class_try_get_vtable */
 				if (!method->klass->runtime_info)
 					/* No vtable created yet */
 					return FALSE;
-				vtable = mono_class_vtable (cfg->domain, method->klass);
-				if (!vtable)
+				vtable = mono_class_vtable_full (cfg->domain, method->klass, &error);
+				if (!is_ok (&error)) {
+					mono_error_cleanup (&error);
 					return FALSE;
+				}
 				/* This makes so that inline cannot trigger */
 				/* .cctors: too many apps depend on them */
 				/* running with a specific order... */
 				if (! vtable->initialized)
 					return FALSE;
-				MonoError error;
 				if (!mono_runtime_class_init_full (vtable, &error)) {
 					mono_error_cleanup (&error);
 					return FALSE;
 				}
 			}
 		} else if (mono_class_needs_cctor_run (method->klass, NULL)) {
+			MonoError error;
 			if (!method->klass->runtime_info)
 				/* No vtable created yet */
 				return FALSE;
-			vtable = mono_class_vtable (cfg->domain, method->klass);
-			if (!vtable)
+			vtable = mono_class_vtable_full (cfg->domain, method->klass, &error);
+			if (!is_ok (&error)) {
+				mono_error_cleanup (&error);
 				return FALSE;
+			}
 			if (!vtable->initialized)
 				return FALSE;
 		}
@@ -5815,10 +5830,10 @@ mini_redirect_call (MonoCompile *cfg, MonoMethod *method,
 		/* managed string allocation support */
 		if (strcmp (method->name, "InternalAllocateStr") == 0 && !(cfg->opt & MONO_OPT_SHARED)) {
 			MonoInst *iargs [2];
-			MonoVTable *vtable = mono_class_vtable (cfg->domain, method->klass);
+			MonoVTable *vtable = mono_class_vtable_full (cfg->domain, method->klass, &cfg->error);
 			MonoMethod *managed_alloc = NULL;
 
-			g_assert (vtable); /*Should not fail since it System.String*/
+			mono_error_assert_ok (&cfg->error); /*Should not fail since it System.String*/
 #ifndef MONO_CROSS_COMPILE
 			managed_alloc = mono_gc_get_managed_allocator (method->klass, FALSE, FALSE);
 #endif
@@ -7046,7 +7061,8 @@ handle_ctor_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fs
 	if (cmethod->klass->valuetype && mono_class_generic_sharing_enabled (cmethod->klass) &&
 					mono_method_is_generic_sharable (cmethod, TRUE)) {
 		if (cmethod->is_inflated && mono_method_get_context (cmethod)->method_inst) {
-			mono_class_vtable (cfg->domain, cmethod->klass);
+			mono_class_vtable_full (cfg->domain, cmethod->klass, &cfg->error);
+			CHECK_CFG_ERROR;
 			CHECK_TYPELOAD (cmethod->klass);
 
 			vtable_arg = emit_get_rgctx_method (cfg, context_used,
@@ -7056,8 +7072,8 @@ handle_ctor_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fs
 				vtable_arg = mini_emit_get_rgctx_klass (cfg, context_used,
 												   cmethod->klass, MONO_RGCTX_INFO_VTABLE);
 			} else {
-				MonoVTable *vtable = mono_class_vtable (cfg->domain, cmethod->klass);
-
+				MonoVTable *vtable = mono_class_vtable_full (cfg->domain, cmethod->klass, &cfg->error);
+				CHECK_CFG_ERROR;
 				CHECK_TYPELOAD (cmethod->klass);
 				EMIT_NEW_VTABLECONST (cfg, vtable_arg, vtable);
 			}
@@ -7121,6 +7137,7 @@ handle_ctor_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fs
 										  callvirt_this_arg, NULL, vtable_arg);
 	}
  exception_exit:
+ mono_error_exit:
 	return;
 }
 
@@ -8639,7 +8656,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				if (context_used) {
 					vtable_arg = mini_emit_get_rgctx_klass (cfg, context_used, cmethod->klass, MONO_RGCTX_INFO_VTABLE);
 				} else {
-					MonoVTable *vtable = mono_class_vtable (cfg->domain, cmethod->klass);
+					MonoVTable *vtable = mono_class_vtable_full (cfg->domain, cmethod->klass, &cfg->error);
+					CHECK_CFG_ERROR;
 
 					CHECK_TYPELOAD (cmethod->klass);
 					EMIT_NEW_VTABLECONST (cfg, vtable_arg, vtable);
@@ -9983,7 +10001,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					MonoVTable *vtable = NULL;
 
 					if (!cfg->compile_aot)
-						vtable = mono_class_vtable (cfg->domain, cmethod->klass);
+						vtable = mono_class_vtable_full (cfg->domain, cmethod->klass, &cfg->error);
+					CHECK_CFG_ERROR;
 					CHECK_TYPELOAD (cmethod->klass);
 
 					/*
@@ -10567,7 +10586,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			 * to be called here.
 			 */
 			if (!context_used && !(cfg->opt & MONO_OPT_SHARED)) {
-				mono_class_vtable (cfg->domain, klass);
+				mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+				CHECK_CFG_ERROR;
 				CHECK_TYPELOAD (klass);
 			}
 			mono_domain_lock (cfg->domain);
@@ -10684,7 +10704,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				MonoVTable *vtable = NULL;
 
 				if (!cfg->compile_aot)
-					vtable = mono_class_vtable (cfg->domain, klass);
+					vtable = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+				CHECK_CFG_ERROR;
 				CHECK_TYPELOAD (klass);
 
 				if (!addr) {
@@ -10746,7 +10767,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				gpointer addr = NULL;
 
 				if (!context_used) {
-					vtable = mono_class_vtable (cfg->domain, klass);
+					vtable = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+					CHECK_CFG_ERROR;
 					CHECK_TYPELOAD (klass);
 				}
 				if ((ftype->attrs & FIELD_ATTRIBUTE_INIT_ONLY) && (((addr = mono_aot_readonly_field_override (field)) != NULL) ||
@@ -10922,7 +10944,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				} else {
 					/* Decompose later since it is needed by abcrem */
 					MonoClass *array_type = mono_array_class_get (klass, 1);
-					mono_class_vtable (cfg->domain, array_type);
+					mono_class_vtable_full (cfg->domain, array_type, &cfg->error);
+					CHECK_CFG_ERROR;
 					CHECK_TYPELOAD (array_type);
 
 					MONO_INST_NEW (cfg, ins, OP_NEWARR);

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -890,11 +890,8 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 
 	switch (info_type) {
 	case MONO_RGCTX_INFO_STATIC_DATA: {
-		MonoVTable *vtable = mono_class_vtable (domain, klass);
-		if (!vtable) {
-			mono_error_set_for_class_failure (error, klass);
-			return NULL;
-		}
+		MonoVTable *vtable = mono_class_vtable_full (domain, klass, error);
+		return_val_if_nok (error, NULL);
 		return mono_vtable_get_static_field_data (vtable);
 	}
 	case MONO_RGCTX_INFO_KLASS:
@@ -902,11 +899,8 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 	case MONO_RGCTX_INFO_ELEMENT_KLASS:
 		return klass->element_class;
 	case MONO_RGCTX_INFO_VTABLE: {
-		MonoVTable *vtable = mono_class_vtable (domain, klass);
-		if (!vtable) {
-			mono_error_set_for_class_failure (error, klass);
-			return NULL;
-		}
+		MonoVTable *vtable = mono_class_vtable_full (domain, klass, error);
+		return_val_if_nok (error, NULL);
 		return vtable;
 	}
 	case MONO_RGCTX_INFO_CAST_CACHE: {
@@ -1879,8 +1873,11 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 			return GUINT_TO_POINTER (MONO_GSHAREDVT_BOX_TYPE_VTYPE);
 	}
 #ifndef DISABLE_REMOTING
-	case MONO_RGCTX_INFO_REMOTING_INVOKE_WITH_CHECK:
-		return mono_compile_method_checked (mono_marshal_get_remoting_invoke_with_check ((MonoMethod *)data), error);
+	case MONO_RGCTX_INFO_REMOTING_INVOKE_WITH_CHECK: {
+		MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke_with_check ((MonoMethod *)data, error);
+		return_val_if_nok (error, NULL);
+		return mono_compile_method_checked (remoting_invoke_method, error);
+	}
 #endif
 	case MONO_RGCTX_INFO_METHOD_DELEGATE_CODE:
 		return mono_domain_alloc0 (domain, sizeof (gpointer));
@@ -1902,11 +1899,8 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		g_assert (method->method.method.is_inflated);
 		g_assert (method->context.method_inst);
 
-		vtable = mono_class_vtable (domain, method->method.method.klass);
-		if (!vtable) {
-			mono_error_set_for_class_failure (error, method->method.method.klass);
-			return NULL;
-		}
+		vtable = mono_class_vtable_full (domain, method->method.method.klass, error);
+		return_val_if_nok (error, NULL);
 
 		return mono_method_lookup_rgctx (vtable, method->context.method_inst);
 	}
@@ -3359,10 +3353,13 @@ mini_type_is_reference (MonoType *type)
 gpointer
 mini_method_get_rgctx (MonoMethod *m)
 {
-	if (mini_method_get_context (m)->method_inst)
-		return mono_method_lookup_rgctx (mono_class_vtable (mono_domain_get (), m->klass), mini_method_get_context (m)->method_inst);
-	else
-		return mono_class_vtable (mono_domain_get (), m->klass);
+	MonoError error;
+	MonoVTable *vt = mono_class_vtable_full (mono_domain_get (), m->klass, &error);
+	mono_error_assert_ok (&error);
+	if (mini_method_get_context (m)->method_inst) {
+		return mono_method_lookup_rgctx (vt, mini_method_get_context (m)->method_inst);
+	} else
+		return vt;
 }
 
 /*

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -890,7 +890,7 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 
 	switch (info_type) {
 	case MONO_RGCTX_INFO_STATIC_DATA: {
-		MonoVTable *vtable = mono_class_vtable_full (domain, klass, error);
+		MonoVTable *vtable = mono_class_vtable_checked (domain, klass, error);
 		return_val_if_nok (error, NULL);
 		return mono_vtable_get_static_field_data (vtable);
 	}
@@ -899,7 +899,7 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 	case MONO_RGCTX_INFO_ELEMENT_KLASS:
 		return klass->element_class;
 	case MONO_RGCTX_INFO_VTABLE: {
-		MonoVTable *vtable = mono_class_vtable_full (domain, klass, error);
+		MonoVTable *vtable = mono_class_vtable_checked (domain, klass, error);
 		return_val_if_nok (error, NULL);
 		return vtable;
 	}
@@ -1899,7 +1899,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		g_assert (method->method.method.is_inflated);
 		g_assert (method->context.method_inst);
 
-		vtable = mono_class_vtable_full (domain, method->method.method.klass, error);
+		vtable = mono_class_vtable_checked (domain, method->method.method.klass, error);
 		return_val_if_nok (error, NULL);
 
 		return mono_method_lookup_rgctx (vtable, method->context.method_inst);
@@ -3354,7 +3354,7 @@ gpointer
 mini_method_get_rgctx (MonoMethod *m)
 {
 	MonoError error;
-	MonoVTable *vt = mono_class_vtable_full (mono_domain_get (), m->klass, &error);
+	MonoVTable *vt = mono_class_vtable_checked (mono_domain_get (), m->klass, &error);
 	mono_error_assert_ok (&error);
 	if (mini_method_get_context (m)->method_inst) {
 		return mono_method_lookup_rgctx (vt, mini_method_get_context (m)->method_inst);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1434,7 +1434,7 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		target = GUINT_TO_POINTER ((guint32)(-((patch_info->data.klass->interface_id + 1) * SIZEOF_VOID_P)));
 		break;
 	case MONO_PATCH_INFO_VTABLE:
-		target = mono_class_vtable_full (domain, patch_info->data.klass, error);
+		target = mono_class_vtable_checked (domain, patch_info->data.klass, error);
 		mono_error_assert_ok (error);
 		break;
 	case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE: {
@@ -1447,7 +1447,7 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		break;
 	}
 	case MONO_PATCH_INFO_SFLDA: {
-		MonoVTable *vtable = mono_class_vtable_full (domain, patch_info->data.field->parent, error);
+		MonoVTable *vtable = mono_class_vtable_checked (domain, patch_info->data.field->parent, error);
 		mono_error_assert_ok (error);
 
 		if (mono_class_field_is_special_static (patch_info->data.field)) {
@@ -1556,7 +1556,7 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		target = mono_thread_interruption_request_flag ();
 		break;
 	case MONO_PATCH_INFO_METHOD_RGCTX: {
-		MonoVTable *vtable = mono_class_vtable_full (domain, patch_info->data.method->klass, error);
+		MonoVTable *vtable = mono_class_vtable_checked (domain, patch_info->data.method->klass, error);
 		mono_error_assert_ok (error);
 
 		target = mono_method_lookup_rgctx (vtable, mini_method_get_context (patch_info->data.method)->method_inst);
@@ -2053,7 +2053,7 @@ lookup_start:
 			MonoVTable *vtable;
 
 			mono_atomic_inc_i32 (&mono_jit_stats.methods_lookups);
-			vtable = mono_class_vtable_full (domain, method->klass, error);
+			vtable = mono_class_vtable_checked (domain, method->klass, error);
 			if (!is_ok (error))
 				return NULL;
 			g_assert (vtable);
@@ -2098,7 +2098,7 @@ lookup_start:
 			 * called by init_method ().
 			 */
 			if (!mono_llvm_only) {
-				vtable = mono_class_vtable_full (domain, method->klass, error);
+				vtable = mono_class_vtable_checked (domain, method->klass, error);
 				mono_error_assert_ok (error);
 				if (!mono_runtime_class_init_full (vtable, error))
 					return NULL;
@@ -2409,7 +2409,7 @@ create_runtime_invoke_info (MonoDomain *domain, MonoMethod *method, gpointer com
 		info->sig = mono_method_signature (method);
 
 	invoke = mono_marshal_get_runtime_invoke (method, FALSE);
-	info->vtable = mono_class_vtable_full (domain, method->klass, error);
+	info->vtable = mono_class_vtable_checked (domain, method->klass, error);
 	if (!mono_error_ok (error))
 		return NULL;
 	g_assert (info->vtable);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1434,8 +1434,8 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		target = GUINT_TO_POINTER ((guint32)(-((patch_info->data.klass->interface_id + 1) * SIZEOF_VOID_P)));
 		break;
 	case MONO_PATCH_INFO_VTABLE:
-		target = mono_class_vtable (domain, patch_info->data.klass);
-		g_assert (target);
+		target = mono_class_vtable_full (domain, patch_info->data.klass, error);
+		mono_error_assert_ok (error);
 		break;
 	case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE: {
 		MonoDelegateClassMethodPair *del_tramp = patch_info->data.del_tramp;
@@ -1447,7 +1447,8 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		break;
 	}
 	case MONO_PATCH_INFO_SFLDA: {
-		MonoVTable *vtable = mono_class_vtable (domain, patch_info->data.field->parent);
+		MonoVTable *vtable = mono_class_vtable_full (domain, patch_info->data.field->parent, error);
+		mono_error_assert_ok (error);
 
 		if (mono_class_field_is_special_static (patch_info->data.field)) {
 			gpointer addr = NULL;
@@ -1460,7 +1461,6 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 			return addr;
 		}
 
-		g_assert (vtable);
 		if (!vtable->initialized && !mono_class_is_before_field_init (vtable->klass) && (method && mono_class_needs_cctor_run (vtable->klass, method)))
 			/* Done by the generated code */
 			;
@@ -1556,8 +1556,8 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		target = mono_thread_interruption_request_flag ();
 		break;
 	case MONO_PATCH_INFO_METHOD_RGCTX: {
-		MonoVTable *vtable = mono_class_vtable (domain, patch_info->data.method->klass);
-		g_assert (vtable);
+		MonoVTable *vtable = mono_class_vtable_full (domain, patch_info->data.method->klass, error);
+		mono_error_assert_ok (error);
 
 		target = mono_method_lookup_rgctx (vtable, mini_method_get_context (patch_info->data.method)->method_inst);
 		break;
@@ -2098,8 +2098,8 @@ lookup_start:
 			 * called by init_method ().
 			 */
 			if (!mono_llvm_only) {
-				vtable = mono_class_vtable (domain, method->klass);
-				g_assert (vtable);
+				vtable = mono_class_vtable_full (domain, method->klass, error);
+				mono_error_assert_ok (error);
 				if (!mono_runtime_class_init_full (vtable, error))
 					return NULL;
 			}
@@ -3189,9 +3189,10 @@ mono_jit_create_remoting_trampoline (MonoDomain *domain, MonoMethod *method, Mon
 
 	if ((method->flags & METHOD_ATTRIBUTE_ABSTRACT) ||
 	    (mono_method_signature (method)->hasthis && (mono_class_is_marshalbyref (method->klass) || method->klass == mono_defaults.object_class)))
-		nm = mono_marshal_get_remoting_invoke_for_target (method, target);
+		nm = mono_marshal_get_remoting_invoke_for_target (method, target, error);
 	else
 		nm = method;
+	return_val_if_nok (error, NULL);
 	addr = (guint8 *)mono_compile_method_checked (nm, error);
 	return_val_if_nok (error, NULL);
 	return mono_get_addr_from_ftnptr (addr);
@@ -4581,7 +4582,8 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 		}
 #ifndef DISABLE_REMOTING
 		if (mono_class_is_marshalbyref (method->klass) && mono_method_signature (method)->hasthis) {
-			invoke = mono_marshal_get_remoting_invoke_with_check (method);
+			invoke = mono_marshal_get_remoting_invoke_with_check (method, &error);
+			mono_error_assert_ok (&error);
 			mono_compile_method_checked (invoke, &error);
 			mono_error_assert_ok (&error);
 		}

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4319,7 +4319,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 	if (!mono_error_ok (error))
 		return NULL;
 
-	vtable = mono_class_vtable_full (target_domain, method->klass, error);
+	vtable = mono_class_vtable_checked (target_domain, method->klass, error);
 	return_val_if_nok (error, NULL);
 
 	if (method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4319,12 +4319,8 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 	if (!mono_error_ok (error))
 		return NULL;
 
-	vtable = mono_class_vtable (target_domain, method->klass);
-	if (!vtable) {
-		g_assert (mono_class_has_failure (method->klass));
-		mono_error_set_for_class_failure (error, method->klass);
-		return NULL;
-	}
+	vtable = mono_class_vtable_full (target_domain, method->klass, error);
+	return_val_if_nok (error, NULL);
 
 	if (method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
 		if (mono_marshal_method_from_wrapper (method)) {

--- a/mono/mini/type-checking.c
+++ b/mono/mini/type-checking.c
@@ -497,7 +497,7 @@ handle_castclass (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context
 		if (!klass->rank && !cfg->compile_aot && !(cfg->opt & MONO_OPT_SHARED) && mono_class_is_sealed (klass)) {
 			/* the remoting code is broken, access the class for now */
 			if (0) { /*FIXME what exactly is broken? This change refers to r39380 from 2005 and mention some remoting fixes were due.*/
-				MonoVTable *vt = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+				MonoVTable *vt = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
 				if (!is_ok (&cfg->error)) {
 					mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 					return NULL;
@@ -695,7 +695,7 @@ handle_isinst (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context_us
 				g_assert (!context_used);
 				/* the remoting code is broken, access the class for now */
 				if (0) {/*FIXME what exactly is broken? This change refers to r39380 from 2005 and mention some remoting fixes were due.*/
-					MonoVTable *vt = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+					MonoVTable *vt = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
 					if (!is_ok (&cfg->error)) {
 						mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 						return NULL;

--- a/mono/mini/type-checking.c
+++ b/mono/mini/type-checking.c
@@ -497,10 +497,9 @@ handle_castclass (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context
 		if (!klass->rank && !cfg->compile_aot && !(cfg->opt & MONO_OPT_SHARED) && mono_class_is_sealed (klass)) {
 			/* the remoting code is broken, access the class for now */
 			if (0) { /*FIXME what exactly is broken? This change refers to r39380 from 2005 and mention some remoting fixes were due.*/
-				MonoVTable *vt = mono_class_vtable (cfg->domain, klass);
-				if (!vt) {
-					mono_cfg_set_exception (cfg, MONO_EXCEPTION_TYPE_LOAD);
-					cfg->exception_ptr = klass;
+				MonoVTable *vt = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+				if (!is_ok (&cfg->error)) {
+					mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 					return NULL;
 				}
 				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, vt);
@@ -696,10 +695,9 @@ handle_isinst (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context_us
 				g_assert (!context_used);
 				/* the remoting code is broken, access the class for now */
 				if (0) {/*FIXME what exactly is broken? This change refers to r39380 from 2005 and mention some remoting fixes were due.*/
-					MonoVTable *vt = mono_class_vtable (cfg->domain, klass);
-					if (!vt) {
-						mono_cfg_set_exception (cfg, MONO_EXCEPTION_TYPE_LOAD);
-						cfg->exception_ptr = klass;
+					MonoVTable *vt = mono_class_vtable_full (cfg->domain, klass, &cfg->error);
+					if (!is_ok (&cfg->error)) {
+						mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 						return NULL;
 					}
 					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, vt);


### PR DESCRIPTION
- Runtime should use `mono_class_vtable_checked` and `mono_class_from_typeref_checked`, respectively.
- Rename `mono_class_vtable_full` to `mono_class_vtable_checked`
- Pass a `MonoError*` argument to
  - `mono_marshal_get_remoting_invoke`
  - `mono_marshal_get_xappdomain_invoke`
  - `mono_marshal_get_remoting_invoke_for_target`
  - `mono_marshal_get_remoting_invoke_with_check`