### PR TITLE
[valuetypes] use memcmp in default implementation of Equals

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -527,6 +527,7 @@ TESTS_CS_SRC=		\
 	bug-58782-plain-throw.cs \
 	bug-58782-capture-and-throw.cs \
 	recursive-struct-arrays.cs \
+	struct-explicit-layout.cs \
 	bug-59281.cs	\
 	init_array_with_lazy_type.cs \
 	weak-fields.cs \

--- a/mono/tests/struct-explicit-layout.cs
+++ b/mono/tests/struct-explicit-layout.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Test {
+	[StructLayout ( LayoutKind.Explicit )]
+	public struct ST0 {
+		[FieldOffset(0)] public short S0;
+		[FieldOffset(2)] public int I0;
+		[FieldOffset(6)] public long L0;
+		[FieldOffset(14)] public float F0;
+		[FieldOffset(18)] public double D0;
+	}
+
+	public class Test {
+		public static int Main() {
+			ST0 s0, s1;
+			s0 = s1 = new ST0();
+			return s0.Equals (s1) ? 0 : 1;
+		}
+	}
+}


### PR DESCRIPTION
some architectures (e.g. ARM) do not support reads of unaligned pointers

fixes https://github.com/mono/mono/issues/6320

that likely regresses performance, so not sure if this is a good idea.