### PR TITLE
Add file missed from e0b1d6651915c395eca637ed172399354ee0fa17 to Makefile.am

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -221,6 +221,7 @@ common_sources = \
 	number-ms.c		\
 	number-ms.h		\
 	object.c	\
+	object-forward.h	\
 	object-internals.h	\
 	opcodes.c		\
 	property-bag.h	\


### PR DESCRIPTION
Fixes

```
In file included from ../../mono/metadata/metadata-internals.h:12:0,
                 from ../../mono/metadata/class-internals.h:12,
                 from ../../mono/metadata/profiler-private.h:10,
                 from mono-codeman.c:22:
../../mono/metadata/domain-internals.h:10:42: fatal error: mono/metadata/object-forward.h: No such file or directory
compilation terminated.
```

in tarball builds