### PR TITLE
[profiler] Fixed GCResizeEvent value overflow

### DIFF
--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -1449,7 +1449,7 @@ gc_resize (MonoProfiler *profiler, uintptr_t new_size)
 	);
 
 	emit_event (logbuffer, TYPE_GC_RESIZE | TYPE_GC);
-	emit_value (logbuffer, new_size);
+	emit_uvalue (logbuffer, new_size);
 
 	EXIT_LOG;
 }


### PR DESCRIPTION
In case application was using more than 2GB of heap memory it started reporting minus values because `emit_value` accepts `int`