### PR TITLE
[utils] Include jemalloc dir in tarball build

### DIFF
--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -277,7 +277,8 @@ libmonoutilsinclude_HEADERS = 	\
 
 EXTRA_DIST = mono-embed.h mono-embed.c
 
+DIST_SUBDIRS = jemalloc
+
 if MONO_JEMALLOC_ENABLED
 SUBDIRS = jemalloc
-DIST_SUBDIRS = jemalloc
 endif


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/6343