### PR TITLE
[2017-10] [System]: Ensure WebConnection calls nstream.EndWrite()

### DIFF
--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -901,13 +901,9 @@ namespace System.Net
 		internal int EndRead (HttpWebRequest request, IAsyncResult result)
 		{
 			Stream s = null;
+			Exception exception = null;
+
 			lock (this) {
-				if (request.Aborted)
-					throw new WebException ("Request aborted", WebExceptionStatus.RequestCanceled);
-				if (Data.request != request)
-					throw new ObjectDisposedException (typeof (NetworkStream).FullName);
-				if (nstream == null)
-					throw new ObjectDisposedException (typeof (NetworkStream).FullName);
 				s = nstream;
 			}
 
@@ -915,18 +911,34 @@ namespace System.Net
 			bool done = false;
 			WebAsyncResult wr = null;
 			IAsyncResult nsAsync = ((WebAsyncResult) result).InnerAsyncResult;
-			if (chunkedRead && (nsAsync is WebAsyncResult)) {
-				wr = (WebAsyncResult) nsAsync;
-				IAsyncResult inner = wr.InnerAsyncResult;
-				if (inner != null && !(inner is WebAsyncResult)) {
-					nbytes = s.EndRead (inner);
+			try {
+				if (chunkedRead && (nsAsync is WebAsyncResult)) {
+					wr = (WebAsyncResult) nsAsync;
+					IAsyncResult inner = wr.InnerAsyncResult;
+					if (inner != null && !(inner is WebAsyncResult)) {
+						nbytes = s.EndRead (inner);
+						done = nbytes == 0;
+					}
+				} else if (!(nsAsync is WebAsyncResult)) {
+					nbytes = s.EndRead (nsAsync);
+					wr = (WebAsyncResult) result;
 					done = nbytes == 0;
 				}
-			} else if (!(nsAsync is WebAsyncResult)) {
-				nbytes = s.EndRead (nsAsync);
-				wr = (WebAsyncResult) result;
-				done = nbytes == 0;
+			} catch (Exception exc) {
+				exception = exc;
 			}
+
+			lock (this) {
+				if (request.Aborted)
+					throw new WebException ("Request aborted", WebExceptionStatus.RequestCanceled);
+				if (Data.request != request)
+					throw new ObjectDisposedException (typeof (NetworkStream).FullName);
+				if (nstream == null)
+					throw new ObjectDisposedException (typeof (NetworkStream).FullName);
+			}
+
+			if (exception != null)
+				throw exception;
 
 			if (chunkedRead) {
 				try {
@@ -1029,6 +1041,24 @@ namespace System.Net
 		internal bool EndWrite (HttpWebRequest request, bool throwOnError, IAsyncResult result)
 		{
 			Stream s = null;
+			WebExceptionStatus newStatus = status;
+			bool complete;
+			Exception exception = null;
+
+			lock (this) {
+				s = nstream;
+			}
+
+			try {
+				s.EndWrite (result);
+				complete = true;
+			} catch (Exception exc) {
+				newStatus = WebExceptionStatus.SendFailure;
+				if (throwOnError && exc.InnerException != null)
+					exception = exc.InnerException;
+				complete = false;
+			}
+
 			lock (this) {
 				if (status == WebExceptionStatus.RequestCanceled)
 					return true;
@@ -1036,18 +1066,12 @@ namespace System.Net
 					throw new ObjectDisposedException (typeof (NetworkStream).FullName);
 				if (nstream == null)
 					throw new ObjectDisposedException (typeof (NetworkStream).FullName);
-				s = nstream;
 			}
 
-			try {
-				s.EndWrite (result);
-				return true;
-			} catch (Exception exc) {
-				status = WebExceptionStatus.SendFailure;
-				if (throwOnError && exc.InnerException != null)
-					throw exc.InnerException;
-				return false;
-			}
+			status = newStatus;
+			if (exception != null)
+				throw exception;
+			return complete;
 		}
 
 		internal int Read (HttpWebRequest request, byte [] buffer, int offset, int size)
@@ -1132,7 +1156,6 @@ namespace System.Net
 					try {
 						nstream.Close ();
 					} catch {}
-					nstream = null;
 				}
 
 				if (socket != null) {


### PR DESCRIPTION
Also ensure that WebConnection calls nstream.EndRead().

Fixes: <https://bugzilla.xamarin.com/show_bug.cgi?id=61002>

This bug is a regression in HTTPS web request cancellation behavior first introduced on the 2017-06 branch by https://github.com/mono/mono/commit/1b5e0f73316ee7b83c8947bc738015443fabd7af.  It is in fact resolved already for the master branch by the refactoring in https://github.com/mono/mono/pull/6125.  But since that refactoring is too large to backport and since the master branch won't be integrated into a release for a while longer, it is worth adding a separate smaller fix for the older active development branches.

This proposed fix is intentionally conservative in how it modifies `WebConnection.EndWrite()` and `WebConnection.EndRead()`.  It makes sure to keep precisely the same return values and exceptions as before.

The fix also makes a small change to the `Close()` method to avoid setting `nstream = null`.  This allows any pending `EndWrite()`, `EndRead()`, or `ReadDone()` callbacks to use the `nstream` field even after `Close()` has run.  This shouldn't cause any new garbage collection issues because the closed `WebConnection` object is not expected to live much longer than the `NetworkStream` object referenced by `nstream`.

Example of the problem for canceling `HttpClient.SendAsync()`
=============================================================

1. `WebConnectionStream.SetHeadersAsync()` calls `WebConnection.BeginWrite()`, passing in an anonymous callback method that will later call `WebConnection.EndWrite()` when the asynchronous write operation completes [\[1\]](https://github.com/mono/mono/blob/b293f453027bc075ce636988b383451e5c346347/mcs/class/System/System.Net/WebConnectionStream.cs#L664-L666).

2. When the `CancellationToken` for the call to `HttpClient.SendAsync()` is notified about the cancellation, it calls `HttpWebRequest.Abort()` [\[2\]](https://github.com/mono/mono/blob/b293f453027bc075ce636988b383451e5c346347/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs#L347), which calls `WebConnection.Abort()`, which calls `WebConnection.Close()`.

3. `WebConnection.Close()` calls `Close()` on both the `MobileAuthenticatedStream` and the network `Socket` and nulls out the `WebConnection`'s field references to those objects [\[3\]](https://github.com/mono/mono/blob/b293f453027bc075ce636988b383451e5c346347/mcs/class/System/System.Net/WebConnection.cs#L1131-L1143).  `MobileAuthenticatedStream.Close()` in turn calls `MobileAuthenticatedStream.Dispose()`, which sets the `lastException` field to an `ObjectDisposedException`.  If the asynchronous write operation from step 1 is still in progress at this point, it will throw the `ObjectDisposedException`.

4. When `MobileAuthenticatedStream.StartOperation()` throws the `ObjectDisposedException` (thus completing the running Task), the anonymous callback method from step 1 gets invoked, and it calls `WebConnection.EndWrite()`.

5. The problem is that now `WebConnection.EndWrite()` fails to call `MobileAuthenticatedStream.EndWrite()`.  There are 2 parts of the problem:

   (a) `WebConnection.EndWrite()` always returns _before_ calling `MobileAuthenticatedStream.EndWrite()` [\[4\]](https://github.com/mono/mono/blob/b293f453027bc075ce636988b383451e5c346347/mcs/class/System/System.Net/WebConnection.cs#L1033-L1034) because the call to `Abort()` at step 2 has set the request status to canceled [\[5\]](https://github.com/mono/mono/blob/b293f453027bc075ce636988b383451e5c346347/mcs/class/System/System.Net/WebConnection.cs#L1169).

   (b) Even if the cancellation status check weren't there, the attempt to call `MobileAuthenticatedStream.EndWrite()` still wouldn't work because `Close()` has set the reference to the stream to `null` at step 3.

The proposed fix addresses (a) by rearranging `WebConnection.EndWrite()` and `WebConnection.EndRead()` so that they _always_ call the corresponding `MobileAuthenticatedStream` methods.  It addresses (b) by removing the line in `Close()` that sets the `nstream` field to `null`.

How did mono/2017-06 commit 1b5e0f7 introduce this problem?
===========================================================

Commit 1b5e0f7 uses Tasks and the `TaskToApm()` helper method _correctly_, so by itself it's OK.  The problem is that the older `WebConnection` methods already had underlying limitations _before_ commit 1b5e0f7.  In the Asynchronous Programming Model, "for each call to BeginOperationName, the application should also call EndOperationName to get the results of the operation" [\[6\]](https://docs.microsoft.com/dotnet/standard/asynchronous-programming-patterns/asynchronous-programming-model-apm).  But `WebConnection` did not strictly follow this rule.  For example, `WebConnection.EndWrite()` did _not_ always call `MobileAuthenticatedStream.EndWrite()`.  This imprecise behavior worked until now because unlike unobserved exceptions in Tasks, "unobserved" exceptions in AsyncResult objects don't trigger any behaviors when the objects are finalized.  (The exceptions are just discarded.)  But now that `MobileAuthenticatedStream.BeginWrite()` uses Tasks behind the scenes, `WebConnection` needs to be stricter about following the rules.

Testing the proposed fix against old bugs from `git blame`
==========================================================

- Commit 613c2a918219

  <https://bugzilla.xamarin.com/show_bug.cgi?id=31507>

  Results: Verified still fixed.  I was able to reproduce the original behavior by intentionally removing the old fix.  I then put the old fix back, added the new proposed changes, and verified that the test case still produced the good behavior (only task cancellation messages).

- Commit 7584df6cf853

  Neither of the bugs mentioned in the commit message for 7584df6cf853 appears to be related to the `Data.request` check.  Since that check is the only part of the commit touched by the new proposed changes, neither of the bugs should be affected.  But just to be thorough, I quickly ran through the test cases associated with those bugs.

  <https://bugzilla.novell.com/show_bug.cgi?id=515931>

  Results: OK.  I tried the test case from <https://bugzilla.novell.com/show_bug.cgi?id=515097> with `AllowWriteStreamBuffering` set to `true` or `false`.  The write operation started successfully in both cases, and the call to `Abort()` was able to cancel the operation as expected.

  <https://bugzilla.novell.com/show_bug.cgi?id=510642>

  Results: OK.  The test case still produced the expected overflow exception.