### PR TITLE
Add a possibility to use empty X.509 certificates.

### DIFF
--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Helper2.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Helper2.cs
@@ -142,6 +142,9 @@ namespace System.Security.Cryptography.X509Certificates
 
 		internal static X509Certificate2Impl Import (X509Certificate cert, bool disableProvider = false)
 		{
+			if (cert.Impl == null)
+				return null;
+
 #if MONO_FEATURE_BTLS
 			if (!disableProvider) {
 				var provider = MonoTlsProviderFactory.GetProvider ();

--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
@@ -442,6 +442,12 @@ WYpnKQqsKIzlSqv9wwXs7B1iA7ZdvHk3TAnSnLP1o2H7ME05UnZPKCvraONdezon
 		}
 
 		[Test]
+		public void X509Certificate2_WhenEmptyCertificateProvided_DoesNotThrow ()
+		{
+			Assert.DoesNotThrow (() => new X509Certificate2 (new X509Certificate2 ()));
+		}
+
+		[Test]
 		public void Certificate_1_Properties ()
 		{
 			DateTime expectedNotAfter = new DateTime (629937887260000000,

--- a/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
+++ b/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
@@ -111,19 +111,15 @@ namespace System.Security.Cryptography.X509Certificates {
 
 		internal X509Certificate (X509CertificateImpl impl)
 		{
-			if (impl == null)
-				throw new ArgumentNullException ("impl");
-
 			this.impl = X509Helper.InitFromCertificate (impl);
 		}
 
-		public X509Certificate (System.Security.Cryptography.X509Certificates.X509Certificate cert) 
+		public X509Certificate (X509Certificate cert) 
 		{
 			if (cert == null)
 				throw new ArgumentNullException ("cert");
 
 			impl = X509Helper.InitFromCertificate (cert);
-			hideDates = false;
 		}
 
 		internal void ImportHandle (X509CertificateImpl impl)
@@ -134,7 +130,6 @@ namespace System.Security.Cryptography.X509Certificates {
 
 		internal X509CertificateImpl Impl {
 			get {
-				X509Helper.ThrowIfContextInvalid (impl);
 				return impl;
 			}
 		}

--- a/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Helper.cs
+++ b/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Helper.cs
@@ -136,7 +136,9 @@ namespace System.Security.Cryptography.X509Certificates
 
 		public static X509CertificateImpl InitFromCertificate (X509CertificateImpl impl)
 		{
-			ThrowIfContextInvalid (impl);
+			if (impl == null)
+				return null;
+
 			var copy = impl.Clone ();
 			if (copy != null)
 				return copy;

--- a/mcs/class/corlib/Test/System.Security.Cryptography.X509Certificates/X509CertificateTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography.X509Certificates/X509CertificateTest.cs
@@ -82,6 +82,12 @@ public void ConstructorX509CertificateNull ()
 	X509Certificate nullcopy = new X509Certificate ((X509Certificate) null);
 }
 
+[Test]
+public void X509Certificate_WhenEmptyCertificateProvided_DoesNotThrow ()
+{
+	Assert.DoesNotThrow (() => new X509Certificate (new X509Certificate ()));
+}
+
 //-->8-- NON GENERATED CODE ENDS HERE   -->8---->8---->8---->8---->8---->8--
 
 // Certificate: basic\COMMERCE.cer


### PR DESCRIPTION
Fixes #6264.

Although empty X.509 certificates (`new X509Certificate()` and `new X509Certificate2()`) don't represent valid X.509 certificates, .NET Framework still allows using them in some cases (in other cases, an exception is being thrown, since such certificates are invalid). Mono's implementation is quite different, but it follows the same idea. The only problem is that in certain cases it was too strict and wasn't allowing the usage of empty certificates where they're allowed.