### PR TITLE
Don't add linker tests to tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ dist-hook:
 	rm -rf `find $(top_distdir)/external -path '*\.git'`
 	rm -f `find $(top_distdir)/external -path '*\.exe' -not -path '*/roslyn-binaries/*'`
 	rm -f `find $(top_distdir)/external -path '*\.dll' -not -path '*/binary-reference-assemblies/*' -not -path '*/roslyn-binaries/*'`
+	rm -rf "$(top_distdir)/external/linker/linker/Tests"
 
 pkgconfigdir = $(libdir)/pkgconfig
 noinst_DATA = mono-uninstalled.pc


### PR DESCRIPTION
They contain files with very long names which causes issues with `tar`:

```
tar: mono-5.11.0/external/linker/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase.cs: file name is too long (cannot be split); not dumped
tar: mono-5.11.0/external/linker/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase2.cs: file name is too long (cannot be split); not dumped
tar: mono-5.11.0/external/linker/linker/Tests/Mono.Linker.Tests.Cases/Generics/DerivedClassWithMethodOfSameNameAsBaseButDifferentNumberOfGenericParametersUnusedBaseWillGetStripped.cs: file name is too long (cannot be split); not dumped
tar: Exiting with failure status due to previous errors
```

We simply remove them from the dist directory before creating the tarball since we don't use them in the Mono build anyway.

Fixes #6349

---

Dist files in groups of 100 entries

On some distros the number of strings you can pass to execve() is limited which means you get the following error when trying to create the tarball:

```
make[5]: execvp: /bin/sh: Argument list too long
make[5]: * [../../build/rules.make:303: dist-default] Error 127
```

To solve this we split the DISTFILES variable into groups of 100 entries and invoke the shell for each group instead of adding all into the same invocation. Also removed looking for 'makefile' and 'GNUmakefile' since those don't exist in Mono and simplifies the logic.

Found during investigation of #6349
