### PR TITLE
Make mono_string_to_utf8_mp file-level static.

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1547,9 +1547,6 @@ char *
 mono_string_handle_to_utf8 (MonoStringHandle s, MonoError *error);
 
 char *
-mono_string_to_utf8_mp	(MonoMemPool *mp, MonoString *s, MonoError *error);
-
-char *
 mono_string_to_utf8_image (MonoImage *image, MonoStringHandle s, MonoError *error);
 
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -65,6 +65,9 @@ free_main_args (void);
 static char *
 mono_string_to_utf8_internal (MonoMemPool *mp, MonoImage *image, MonoString *s, MonoError *error);
 
+static char *
+mono_string_to_utf8_mp	(MonoMemPool *mp, MonoString *s, MonoError *error);
+
 static void
 array_full_copy_unchecked_size (MonoArray *src, MonoArray *dest, MonoClass *klass, uintptr_t size);
 


### PR DESCRIPTION
The only call to mono_string_to_utf8_mp is in the file that implements it -- object.c.
So remove it from any header, even an internal one, and make it static.
