### PR TITLE
Replace explicit make invocations with uses of the MAKE variable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,7 +121,7 @@ update-csproj:
 	-rm msvc/scripts/order.xml
 	-rm -rf msvc/scripts/inputs
 	-mkdir msvc/scripts/inputs
-	(cd runtime; make V=1 extra_targets=csproj-local)
+	(cd runtime; $(MAKE) V=1 extra_targets=csproj-local)
 
 package-inputs:
 	echo '<?xml version="1.0" encoding="utf-8"?>' > msvc/scripts/order.xml
@@ -150,9 +150,9 @@ update-llvm-version:
 
 
 update-solution-files:
-	make update-csproj
-	make package-inputs
-	(cd msvc/scripts; make genproj.exe; mono genproj.exe $(GENPROJ_ARGS))
+	$(MAKE) update-csproj
+	$(MAKE) package-inputs
+	(cd msvc/scripts; $(MAKE) genproj.exe; mono genproj.exe $(GENPROJ_ARGS))
 
 update-solution-files-with-tests:
-	make "GENPROJ_ARGS=2012 true true" update-solution-files
+	$(MAKE) "GENPROJ_ARGS=2012 true true" update-solution-files

--- a/mono/utils/jemalloc/Makefile.am
+++ b/mono/utils/jemalloc/Makefile.am
@@ -34,7 +34,7 @@ ASSERT_OPT=--enable-debug
 endif
 
 jemalloc:
-	make reset-jemalloc
+	$(MAKE) reset-jemalloc
 
 # Set a prefix to enable access to allocation functions with a prefix, ie so mono_jemalloc isn't named malloc by default
 # Disable zone allocator, otherwise malloc uses jemalloc for things it's not set for
@@ -42,7 +42,7 @@ jemalloc:
 jemalloc/lib/libjemalloc.a: jemalloc Makefile
 	cd jemalloc && autoconf && ./configure --with-jemalloc-prefix=mono_je --prefix=`pwd` $(ASSERT_OPT) $(JEMALLOC_AUTOCONF_FLAGS) --disable-zone-allocator EXTRA_CFLAGS="-I $(top_srcdir) $(GLIB_CFLAGS) $(CFLAGS) $(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS) " CC="$(CC)" CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS) $(JEMALLOC_CPPFLAGS) " CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)"
 
-	cd jemalloc && make build_lib_static 
+	cd jemalloc && $(MAKE) build_lib_static 
 
 all-local: jemalloc/lib/libjemalloc.a
 


### PR DESCRIPTION
This makes it possible to use remake to debug/trace these makefile targets.