### PR TITLE
[packaging] Whitelist vbc command in OSX pkg

### DIFF
--- a/packaging/MacSDK/packaging/resources/whitelist.txt
+++ b/packaging/MacSDK/packaging/resources/whitelist.txt
@@ -121,6 +121,7 @@ soapsuds
 sqlmetal
 sqlsharp
 svcutil
+vbc
 vbnc
 vbnc2
 wsdl


### PR DESCRIPTION
We added vbc in https://github.com/mono/mono/commit/8be2726e127a969cd73e4e92ed03b053f13ed5d5 but didn't whitelist it in the Mac package.