### PR TITLE
[metadata] Mark several functions external only

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1306,9 +1306,6 @@ mono_type_get_checked        (MonoImage *image, guint32 type_token, MonoGenericC
 gboolean
 mono_generic_class_is_generic_type_definition (MonoGenericClass *gklass);
 
-MonoMethod*
-mono_class_get_method_generic (MonoClass *klass, MonoMethod *method);
-
 MonoType*
 mono_type_get_basic_type_from_generic (MonoType *type);
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1027,9 +1027,6 @@ void
 mono_method_set_generic_container (MonoMethod *method, MonoGenericContainer* container);
 
 MonoMethod*
-mono_class_inflate_generic_method_full (MonoMethod *method, MonoClass *klass_hint, MonoGenericContext *context);
-
-MonoMethod*
 mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *klass_hint, MonoGenericContext *context, MonoError *error);
 
 MonoMethod *

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -942,7 +942,7 @@ MonoMethod*
 mono_class_get_method_by_index (MonoClass *klass, int index);
 
 MonoMethod*
-mono_class_get_inflated_method (MonoClass *klass, MonoMethod *method);
+mono_class_get_inflated_method (MonoClass *klass, MonoMethod *method, MonoError *error);
 
 MonoMethod*
 mono_class_get_vtable_entry (MonoClass *klass, int offset);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -8814,7 +8814,7 @@ mono_ldtoken (MonoImage *image, guint32 token, MonoClass **handle_class,
 {
 	ERROR_DECL (error);
 	gpointer res = mono_ldtoken_checked (image, token, handle_class, context, &error);
-	g_assert (mono_error_ok (&error));
+	mono_error_assert_ok (&error);
 	return res;
 }
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2510,15 +2510,19 @@ mono_class_get_inflated_method (MonoClass *klass, MonoMethod *method, MonoError 
 	mcount = mono_class_get_method_count (gklass);
 	for (i = 0; i < mcount; ++i) {
 		if (gklass->methods [i] == method) {
+			MonoMethod *inflated_method = NULL;
 			if (klass->methods) {
-				return klass->methods [i];
+				inflated_method = klass->methods[i];
 			} else {
-				return mono_class_inflate_generic_method_full_checked (gklass->methods [i], klass, mono_class_get_context (klass), error);
+				inflated_method = mono_class_inflate_generic_method_full_checked (gklass->methods [i], klass, mono_class_get_context (klass), error);
+				return_val_if_nok (error, NULL);
 			}
+			g_assert (inflated_method);
+			return inflated_method;
 		}
 	}
 
-	return NULL;
+	g_assert_not_reached ();
 }	
 
 /*

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -7418,7 +7418,7 @@ mono_class_get_full (MonoImage *image, guint32 type_token, MonoGenericContext *c
 	if (klass && context && mono_metadata_token_table (type_token) == MONO_TABLE_TYPESPEC)
 		klass = mono_class_inflate_generic_class_checked (klass, context, &error);
 
-	g_assert (mono_error_ok (&error)); /* FIXME deprecate this function and forbit the runtime from using it. */
+	mono_error_assert_ok (&error);
 	return klass;
 }
 
@@ -7557,7 +7557,11 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 MonoClass *
 mono_class_get (MonoImage *image, guint32 type_token)
 {
-	return mono_class_get_full (image, type_token, NULL);
+	MonoError error;
+	error_init (&error);
+	MonoClass *result = mono_class_get_checked (image, type_token, &error);
+	mono_error_assert_ok (&error);
+	return result;
 }
 
 /**

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -18,9 +18,11 @@ typedef struct _MonoClassField MonoClassField;
 typedef struct _MonoProperty MonoProperty;
 typedef struct _MonoEvent MonoEvent;
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClass *
 mono_class_get             (MonoImage *image, uint32_t type_token);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClass *
 mono_class_get_full        (MonoImage *image, uint32_t type_token, MonoGenericContext *context);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -120,6 +120,7 @@ mono_class_is_subclass_of (MonoClass *klass, MonoClass *klassc,
 MONO_API mono_bool
 mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void*
 mono_ldtoken               (MonoImage *image, uint32_t token, MonoClass **retclass, MonoGenericContext *context);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -60,6 +60,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMethod*
 mono_class_inflate_generic_method (MonoMethod *method, MonoGenericContext *context);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMethod *
 mono_get_inflated_method (MonoMethod *method);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -64,6 +64,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMethod *
 mono_get_inflated_method (MonoMethod *method);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClassField*
 mono_field_from_token      (MonoImage *image, uint32_t token, MonoClass **retklass, MonoGenericContext *context);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -56,6 +56,7 @@ mono_class_from_generic_parameter (MonoGenericParam *param, MonoImage *image, mo
 MONO_RT_EXTERNAL_ONLY MONO_API MonoType*
 mono_class_inflate_generic_type (MonoType *type, MonoGenericContext *context) /* MONO_DEPRECATED */;
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMethod*
 mono_class_inflate_generic_method (MonoMethod *method, MonoGenericContext *context);
 

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -267,7 +267,7 @@ mono_field_from_token (MonoImage *image, guint32 token, MonoClass **retklass, Mo
 {
 	ERROR_DECL (error);
 	MonoClassField *res = mono_field_from_token_checked (image, token, retklass, context, &error);
-	g_assert (mono_error_ok (&error));
+	mono_error_assert_ok (&error);
 	return res;
 }
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -4484,20 +4484,20 @@ mono_metadata_typedef_from_method (MonoImage *meta, guint32 index)
 	return loc.result + 1;
 }
 
-/*
+/**
  * mono_metadata_interfaces_from_typedef_full:
- * @meta: metadata context
- * @index: typedef token
- * @interfaces: Out parameter used to store the interface array
- * @count: Out parameter used to store the number of interfaces
- * @heap_alloc_result: if TRUE the result array will be g_malloc'd
- * @context: The generic context
+ * \param meta metadata context
+ * \param index typedef token
+ * \param interfaces Out parameter used to store the interface array
+ * \param count Out parameter used to store the number of interfaces
+ * \param heap_alloc_result if TRUE the result array will be \c g_malloc'd
+ * \param context The generic context
+ * \param error set on error
  * 
- * The array of interfaces that the @index typedef token implements is returned in
- * @interfaces. The number of elements in the array is returned in @count. 
+ * The array of interfaces that the \p index typedef token implements is returned in
+ * \p interfaces. The number of elements in the array is returned in \p count.
  *
-
- * Returns: TRUE on success, FALSE on failure.
+ * \returns \c TRUE on success, \c FALSE on failure and sets \p error.
  */
 gboolean
 mono_metadata_interfaces_from_typedef_full (MonoImage *meta, guint32 index, MonoClass ***interfaces, guint *count, gboolean heap_alloc_result, MonoGenericContext *context, MonoError *error)
@@ -4587,7 +4587,7 @@ mono_metadata_interfaces_from_typedef (MonoImage *meta, guint32 index, guint *co
 	gboolean rv;
 
 	rv = mono_metadata_interfaces_from_typedef_full (meta, index, &interfaces, count, TRUE, NULL, &error);
-	g_assert (mono_error_ok (&error)); /* FIXME dont swallow the error */
+	mono_error_assert_ok (&error);
 	if (rv)
 		return interfaces;
 	else

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2112,20 +2112,23 @@ mono_metadata_signature_size (MonoMethodSignature *sig)
 	return MONO_SIZEOF_METHOD_SIGNATURE + sig->param_count * sizeof (MonoType *);
 }
 
-/*
- * mono_metadata_parse_method_signature:
- * @m: metadata context
- * @generic_container: generics container
- * @def: the MethodDef index or 0 for Ref signatures.
- * @ptr: pointer to the signature metadata representation
- * @rptr: pointer updated to match the end of the decoded stream
+/**
+ * mono_metadata_parse_method_signature_full:
+ * \param m metadata context
+ * \param generic_container: generics container
+ * \param def the \c MethodDef index or 0 for \c Ref signatures.
+ * \param ptr pointer to the signature metadata representation
+ * \param rptr pointer updated to match the end of the decoded stream
+ * \param error set on error
  *
- * Decode a method signature stored at @ptr.
+ *
+ * Decode a method signature stored at \p ptr.
  * This is a Mono runtime internal function.
  *
  * LOCKING: Assumes the loader lock is held.
  *
- * Returns: a MonoMethodSignature describing the signature.
+ * \returns a \c MonoMethodSignature describing the signature.  On error sets
+ * \p error and returns \c NULL.
  */
 MonoMethodSignature *
 mono_metadata_parse_method_signature_full (MonoImage *m, MonoGenericContainer *container,
@@ -2240,7 +2243,7 @@ mono_metadata_parse_method_signature (MonoImage *m, int def, const char *ptr, co
 	ERROR_DECL (error);
 	MonoMethodSignature *ret;
 	ret = mono_metadata_parse_method_signature_full (m, NULL, def, ptr, rptr, &error);
-	g_assert (mono_error_ok (&error));
+	mono_error_assert_ok (&error);
 
 	return ret;
 }

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -237,6 +237,7 @@ MONO_API uint32_t mono_metadata_typedef_from_method (MonoImage *meta, uint32_t t
 MONO_API uint32_t mono_metadata_nested_in_typedef   (MonoImage *meta, uint32_t table_index);
 MONO_API uint32_t mono_metadata_nesting_typedef     (MonoImage *meta, uint32_t table_index, uint32_t start_index);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClass** mono_metadata_interfaces_from_typedef (MonoImage *meta, uint32_t table_index, unsigned int *count);
 
 MONO_API uint32_t     mono_metadata_events_from_typedef     (MonoImage *meta, uint32_t table_index, unsigned int *end_idx);

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -436,6 +436,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMethodSignature  *mono_metadata_parse_signature (MonoImage *image, 
 						     uint32_t    token);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMethodSignature  *mono_metadata_parse_method_signature (MonoImage            *m,
                                                             int                    def,
                                                             const char            *ptr,

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -413,6 +413,7 @@ MONO_API MonoType      *mono_metadata_parse_field_type  (MonoImage      *m,
 		                                short            field_flags,
 						const char      *ptr,
 						const char      **rptr);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoType      *mono_type_create_from_typespec  (MonoImage        *image, 
 					        uint32_t           type_spec);
 MONO_API void           mono_metadata_free_type         (MonoType        *type);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4161,7 +4161,8 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 				td->ip += 5;
 				if (mono_metadata_token_table (token) == MONO_TABLE_TYPESPEC && !image_is_dynamic (method->klass->image) && !generic_context) {
 					int align;
-					MonoType *type = mono_type_create_from_typespec (image, token);
+					MonoType *type = mono_type_create_from_typespec_checked (image, token, error);
+					return_if_nok (error);
 					size = mono_type_size (type, &align);
 				} else {
 					int align;

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1360,8 +1360,10 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
 			vt_slot += iface_offset;
 		}
 		m = klass->vtable [vt_slot];
-		if (cmethod->is_inflated)
-			m = mono_class_inflate_generic_method (m, mono_method_get_context (cmethod));
+		if (cmethod->is_inflated) {
+			m = mono_class_inflate_generic_method_full_checked (m, NULL, mono_method_get_context (cmethod), error);
+			return_val_if_nok (error, NULL);
+		}
 	}
 
 	if (klass->valuetype && (m->klass == mono_defaults.object_class || m->klass == mono_defaults.enum_class->parent || m->klass == mono_defaults.enum_class)) {

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -468,6 +468,7 @@ mono_method_get_declaring_generic_method (MonoMethod *method)
  * mono_class_get_method_generic:
  * @klass: a class
  * @method: a method
+ * @error: set on error
  *
  * Given a class and a generic method, which has to be of an
  * instantiation of the same class that klass is an instantiation of,
@@ -477,11 +478,12 @@ mono_method_get_declaring_generic_method (MonoMethod *method)
  * method is Gen<object>.work<int>
  *
  * returns: Gen<string>.work<int>
+ *
+ * On error sets @error and returns NULL.
  */
 MonoMethod*
-mono_class_get_method_generic (MonoClass *klass, MonoMethod *method)
+mono_class_get_method_generic (MonoClass *klass, MonoMethod *method, MonoError *error)
 {
-	ERROR_DECL (error);
 	MonoMethod *declaring, *m;
 	int i;
 
@@ -492,8 +494,8 @@ mono_class_get_method_generic (MonoClass *klass, MonoMethod *method)
 
 	m = NULL;
 	if (mono_class_is_ginst (klass)) {
-		m = mono_class_get_inflated_method (klass, declaring, &error);
-		mono_error_assert_ok (&error); /* FIXME proper error handling */
+		m = mono_class_get_inflated_method (klass, declaring, error);
+		return_val_if_nok (error, NULL);
 	}
 
 	if (!m) {
@@ -518,8 +520,8 @@ mono_class_get_method_generic (MonoClass *klass, MonoMethod *method)
 		context.class_inst = NULL;
 		context.method_inst = mono_method_get_context (method)->method_inst;
 
-		m = mono_class_inflate_generic_method_checked (m, &context, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		m = mono_class_inflate_generic_method_checked (m, &context, error);
+		return_val_if_nok (error, NULL);
 	}
 
 	return m;

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -481,6 +481,7 @@ mono_method_get_declaring_generic_method (MonoMethod *method)
 MonoMethod*
 mono_class_get_method_generic (MonoClass *klass, MonoMethod *method)
 {
+	ERROR_DECL (error);
 	MonoMethod *declaring, *m;
 	int i;
 
@@ -490,8 +491,10 @@ mono_class_get_method_generic (MonoClass *klass, MonoMethod *method)
 		declaring = method;
 
 	m = NULL;
-	if (mono_class_is_ginst (klass))
-		m = mono_class_get_inflated_method (klass, declaring);
+	if (mono_class_is_ginst (klass)) {
+		m = mono_class_get_inflated_method (klass, declaring, &error);
+		mono_error_assert_ok (&error); /* FIXME proper error handling */
+	}
 
 	if (!m) {
 		mono_class_setup_methods (klass);
@@ -510,7 +513,6 @@ mono_class_get_method_generic (MonoClass *klass, MonoMethod *method)
 	}
 
 	if (method != declaring) {
-		ERROR_DECL (error);
 		MonoGenericContext context;
 
 		context.class_inst = NULL;

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -688,7 +688,8 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
 			actual_method = mono_class_inflate_generic_method_checked (declaring, &context, error);
 			mono_error_assert_ok (error);
 		} else {
-			actual_method = mono_class_get_method_generic (klass, m);
+			actual_method = mono_class_get_method_generic (klass, m, error);
+			mono_error_assert_ok (error);
 		}
 
 		g_assert (klass);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2678,6 +2678,9 @@ mini_class_is_generic_sharable (MonoClass *klass);
 gboolean
 mini_generic_inst_is_sharable (MonoGenericInst *inst, gboolean allow_type_vars, gboolean allow_partial);
 
+MonoMethod*
+mono_class_get_method_generic (MonoClass *klass, MonoMethod *method, MonoError *error);
+
 gboolean
 mono_is_partially_sharable_inst (MonoGenericInst *inst);
 


### PR DESCRIPTION
* Marked several functions in `class.c` and `metadata.c` with `MONO_RT_EXTERNAL_ONLY` if they have `MonoError` versions that do proper error propagation instead of asserting.

* Moved `mono_class_get_method_generic` *declaration* from `metadata/` to `mini/` since it's *defintion* (and use) live in `mini`.  Also added a `MonoError*` argument and moved the assertion up to the caller.
