### PR TITLE
[interp] move up rtm assigment so it won't be NULL on potential usage

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2406,6 +2406,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 	debug_enter (frame, &tracing);
 
+	rtm = frame->imethod;
 	if (!frame->imethod->transformed) {
 #if DEBUG_INTERP
 		char *mn = mono_method_full_name (frame->imethod->method, TRUE);
@@ -2424,7 +2425,6 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 	}
 
-	rtm = frame->imethod;
 	if (!start_with_ip) {
 		frame->args = alloca (rtm->alloca_size);
 		memset (frame->args, 0, rtm->alloca_size);


### PR DESCRIPTION
`THROW_EX` expands to a potential usage of `rtm`

as reported by cppcheck (we don't store reports, thus a screenshot):
<img width="961" alt="screen shot 2018-01-03 at 23 29 27" src="https://user-images.githubusercontent.com/75403/34542714-04623574-f0de-11e7-9b96-a148dd613c5c.png">

