### PR TITLE
MonoUnwrappedString is a common representation for both a MonoString* and a MonoStringHandle.

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -554,3 +554,32 @@ mono_handle_stack_is_empty (HandleStack *stack)
 {
 	return (stack->top == stack->bottom && stack->top->size == 0);
 }
+
+MonoUnwrappedString
+mono_unwrap_string_handle (MonoStringHandle s)
+{
+	MonoUnwrappedString self = { 0 };
+	if (!MONO_HANDLE_IS_NULL(s)) {
+		self.chars = mono_string_handle_pin_chars (s, &self.privat.gchandle);
+		self.length = mono_string_handle_length (s);
+	}
+	return self;
+}
+
+MonoUnwrappedString
+mono_unwrap_string (MonoString *s)
+{
+	MonoUnwrappedString self = { 0 };
+	if (s) {
+		self.chars = mono_string_chars (s);
+		self.length = s->length;
+	}
+	return self;
+}
+
+void
+mono_unwrapped_string_cleanup (MonoUnwrappedString* self)
+{
+	mono_gchandle_free (self->privat.gchandle);
+	self->privat.gchandle = 0; // allow duplicate cleanup
+}

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -547,6 +547,50 @@ mono_context_get_handle (void);
 void
 mono_context_set_handle (MonoAppContextHandle new_context);
 
+/*
+MonoUnwrappedString is a common representation for both a MonoString* and a MonoStringHandle.
+
+Usage patterns:
+1.     MonoStringHandle s;
+       MonoUnwrappedString us = { 0 };
+       ... conditional branch ...
+       us = mono_unwrap_string_handle (s);
+       us.length;
+       us.chars;
+       mono_unwrapped_string_cleanup (&us); // ok without mono_unwrap_string_handle
+
+2.     MonoStringHandle s;
+       MonoUnwrappedString us = mono_unwrap_string_handle (s);
+       us.length;
+       us.chars;
+       mono_unwrapped_string_cleanup (&us);
+
+3.     MonoString* s;
+       MonoUnwrappedString us = mono_unwrap_string (s);
+       us.length;
+       us.chars;
+       mono_unwrapped_string_cleanup (&us);
+
+4.     MonoString* s;
+       MonoUnwrappedString us = { 0 };
+       ... conditional branch ...
+       us = mono_unwrap_string (s);
+       us.length;
+       us.chars;
+       mono_unwrapped_string_cleanup (&us); // ok without mono_unwrap_string
+*/
+typedef struct MonoUnwrappedString {
+	const gunichar2 *chars;
+	size_t length;
+	struct {
+		guint gchandle;
+	} privat; // "private" but legal C++
+} MonoUnwrappedString;
+
+MonoUnwrappedString mono_unwrap_string_handle (MonoStringHandle s);
+MonoUnwrappedString mono_unwrap_string (MonoString* s);
+void mono_unwrapped_string_cleanup (MonoUnwrappedString* self);
+
 G_END_DECLS
 
 #endif /* __MONO_HANDLE_H__ */


### PR DESCRIPTION
The next best thing is loose pointer/length pair, but a pair is worth a struct.

This will assist in coop handle conversion without code duplication.
This is extracted and cleaned up from two pull requests that use it but have not yet
been commited, in an attempt to present smaller requests and get them commited.

Usage patterns:
1.     MonoStringHandle s;
       MonoUnwrappedString us = { 0 };
       ... conditional branch ...
       us = mono_unwrap_string_handle (s);
       us.length;
       us.chars;
       mono_unwrapped_string_cleanup (&us); // ok without mono_unwrap_string_handle

2.     MonoStringHandle s;
       MonoUnwrappedString us = mono_unwrap_string_handle (s);
       us.length;
       us.chars;
       mono_unwrapped_string_cleanup (&us);

3.     MonoString* s;
       MonoUnwrappedString us = mono_unwrap_string (s);
       us.length;
       us.chars;
       mono_unwrapped_string_cleanup (&us);

4.     MonoString* s;
       MonoUnwrappedString us = { 0 ];
       ... conditional branch ...
       us = mono_unwrap_string (s);
       us.length;
       us.chars;
       mono_unwrapped_string_cleanup (&us); // ok without mono_unwrap_string
  
  