### PR TITLE
Provide g_utf16_ascii_equal and g_utf16_asciiz_equal for comparing utf16 to ascii for equality.

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -245,6 +245,8 @@ gint    g_ascii_xdigit_value (gchar c);
 #define g_ascii_isalpha(c)   (isalpha (c) != 0)
 #define g_ascii_isprint(c)   (isprint (c) != 0)
 #define g_ascii_isxdigit(c)  (isxdigit (c) != 0)
+gboolean g_utf16_ascii_equal (const gunichar2 *utf16, size_t ulen, const char *ascii, size_t alen);
+gboolean g_utf16_asciiz_equal (const gunichar2 *utf16, const char *ascii);
 
 /* FIXME: g_strcasecmp supports utf8 unicode stuff */
 #ifdef _MSC_VER

--- a/mono/eglib/gstr.c
+++ b/mono/eglib/gstr.c
@@ -886,6 +886,34 @@ g_ascii_strcasecmp (const gchar *s1, const gchar *s2)
 	return (*sp1) - (*sp2);
 }
 
+gboolean
+g_utf16_ascii_equal (const gunichar2 *utf16, size_t ulen, const char *ascii, size_t alen)
+{
+	size_t i;
+	if (ulen != alen)
+		return FALSE;
+	for (i = 0; i < ulen; ++i) {
+		if (utf16[i] != ascii[i])
+			return FALSE;
+	}
+	return TRUE;
+}
+
+gboolean
+g_utf16_asciiz_equal (const gunichar2 *utf16, const char *ascii)
+// z for zero means null terminated
+{
+	while (1)
+	{
+		char a = *ascii++;
+		gunichar2 u = *utf16++;
+		if (a != u)
+			return FALSE;
+		if (a == 0)
+			return TRUE;
+	}
+}
+
 gchar *
 g_strdelimit (gchar *string, const gchar *delimiters, gchar new_delimiter)
 {


### PR DESCRIPTION
g_utf16_ascii_equal takes lengths, which are checked first
and unequal length implies unequal strings, and then no characters are looked at.

"z" for zero means nul terminated and requires scanning the string.
Still, an equality primitive is often desired vs. inverting inequality.

These can cleanup some code -- extracted from a larger not yet commited PR
that uses it.
  