### PR TITLE
Split up ERROR_DECL work into easier to read history.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -174,7 +174,7 @@ mono_runtime_get_no_exec (void)
 static void
 create_domain_objects (MonoDomain *domain)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *old_domain = mono_domain_get ();
 	MonoString *arg;
 	MonoVTable *string_vt;
@@ -252,7 +252,7 @@ create_domain_objects (MonoDomain *domain)
 void
 mono_runtime_init (MonoDomain *domain, MonoThreadStartCB start_cb, MonoThreadAttachCB attach_cb)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_runtime_init_checked (domain, start_cb, attach_cb, &error);
 	mono_error_cleanup (&error);
 }
@@ -337,7 +337,7 @@ mono_context_set_default_context (MonoDomain *domain)
 static int
 mono_get_corlib_version (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoClassField *field;
 	MonoObject *value;
@@ -384,7 +384,7 @@ mono_check_corlib_version (void)
 void
 mono_context_init (MonoDomain *domain)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_context_init_checked (domain, &error);
 	mono_error_cleanup (&error);
 }
@@ -468,7 +468,7 @@ MonoDomain *
 mono_domain_create_appdomain (char *friendly_name, char *configuration_file)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_create_appdomain_checked (friendly_name, configuration_file, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_VAL (domain);
@@ -525,7 +525,7 @@ void
 mono_domain_set_config (MonoDomain *domain, const char *base_dir, const char *config_file_name)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	mono_domain_set_config_checked (domain, base_dir, config_file_name, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN ();
@@ -722,7 +722,7 @@ mono_domain_try_type_resolve (MonoDomain *domain, char *name, MonoObject *typebu
 	g_assert (domain);
 	g_assert (name || typebuilder);
 
-	MonoError error;
+	ERROR_DECL (error);
 	error_init (&error);
 
 	MonoReflectionAssembly * const ret = name
@@ -1063,7 +1063,7 @@ mono_parser = {
 void
 mono_domain_set_options_from_config (MonoDomain *domain)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gchar *config_file_name = NULL, *text = NULL, *config_file_path = NULL;
 	gsize len;
 	GMarkupParseContext *context;
@@ -1241,7 +1241,7 @@ MonoAssembly *
 mono_domain_assembly_postload_search (MonoAssemblyName *aname, MonoAssembly *requesting,
 									  gboolean refonly)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAssembly *assembly;
 	MonoDomain *domain = mono_domain_get ();
 	char *aname_str;
@@ -1306,7 +1306,7 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 	HANDLE_FUNCTION_ENTER ();
 	static MonoClassField *assembly_load_field;
 	static MonoMethod *assembly_load_method;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoClass *klass;
 	gpointer load_value;
@@ -1359,7 +1359,7 @@ leave:
 static void
 set_domain_search_path (MonoDomain *domain)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAppDomainSetup *setup;
 	gchar **tmp;
 	gchar *search_path = NULL;
@@ -1762,7 +1762,7 @@ shadow_copy_create_ini (const char *shadow, const char *filename)
 gboolean
 mono_is_shadow_copy_enabled (MonoDomain *domain, const gchar *dir_name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAppDomainSetup *setup;
 	gchar *all_dirs;
 	gchar **dir_ptr;
@@ -1836,7 +1836,7 @@ FIXME bubble up the error instead of raising it here
 char *
 mono_make_shadow_copy (const char *filename, MonoError *oerror)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gchar *sibling_source, *sibling_target;
 	gint sibling_source_len, sibling_target_len;
 	guint16 *orig, *dest;
@@ -2589,7 +2589,7 @@ deregister_reflection_info_roots (MonoDomain *domain)
 static gsize WINAPI
 unload_thread_main (void *arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	unload_data *data = (unload_data*)arg;
 	MonoDomain *domain = data->domain;
 	MonoInternalThread *internal;
@@ -2723,7 +2723,7 @@ guarded_wait (MonoThreadHandle *thread_handle, guint32 timeout, gboolean alertab
 void
 mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoThreadHandle *thread_handle;
 	MonoAppDomainState prev_state;
 	MonoMethod *method;

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1912,7 +1912,7 @@ mono_assembly_open_predicate (const char *filename, gboolean refonly,
 
 	new_fname = NULL;
 	if (!mono_assembly_is_in_gac (fname)) {
-		MonoError error;
+		ERROR_DECL (error);
 		new_fname = mono_make_shadow_copy (fname, &error);
 		if (!is_ok (&error)) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
@@ -2011,7 +2011,7 @@ free_item (gpointer val, gpointer user_data)
 void
 mono_assembly_load_friends (MonoAssembly* ass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 	MonoCustomAttrInfo* attrs;
 	GSList *list;
@@ -2269,7 +2269,7 @@ mono_assembly_load_from_predicate (MonoImage *image, const char *fname,
 	 * candidate. */
 
 	if (!refonly) {
-		MonoError refasm_error;
+		ERROR_DECL (refasm_error);
 		if (mono_assembly_has_reference_assembly_attribute (ass, &refasm_error)) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Image for assembly '%s' (%s) has ReferenceAssemblyAttribute, skipping", ass->aname.name, image->name);
 			g_free (ass);
@@ -2929,7 +2929,7 @@ probe_for_partial_name (const char *basepath, const char *fullname, MonoAssembly
 MonoAssembly*
 mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *status)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAssembly *res;
 	MonoAssemblyName *aname, base_name;
 	MonoAssemblyName mapped_aname;
@@ -3298,7 +3298,7 @@ mono_domain_parse_assembly_bindings (MonoDomain *domain, int amajor, int aminor,
 static MonoAssemblyName*
 mono_assembly_apply_binding (MonoAssemblyName *aname, MonoAssemblyName *dest_name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAssemblyBindingInfo *info, *info2;
 	MonoImage *ppimage;
 	MonoDomain *domain;
@@ -3511,7 +3511,7 @@ return_corlib_and_facades:
 static MonoAssembly*
 prevent_reference_assembly_from_running (MonoAssembly* candidate, gboolean refonly)
 {
-	MonoError refasm_error;
+	ERROR_DECL (refasm_error);
 	error_init (&refasm_error);
 	if (candidate && !refonly) {
 		/* .NET Framework seems to not check for ReferenceAssemblyAttribute on dynamic assemblies */
@@ -3863,7 +3863,7 @@ mono_assembly_close (MonoAssembly *assembly)
 MonoImage*
 mono_assembly_load_module (MonoAssembly *assembly, guint32 idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoImage *result = mono_assembly_load_module_checked (assembly, idx, &error);
 	mono_error_assert_ok (&error);
 	return result;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -267,7 +267,7 @@ mono_attach_cleanup (void)
 static int
 mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject **exc)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAssembly *agent_assembly;
 	MonoImage *image;
 	MonoMethod *method;
@@ -483,7 +483,7 @@ transport_send (int fd, guint8 *data, int len)
 static void
 transport_start_receive (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInternalThread *internal;
 
 	transport_connect ();
@@ -501,7 +501,7 @@ transport_start_receive (void)
 static gsize WINAPI
 receiver_thread (void *arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int res, content_len;
 	guint8 buffer [256];
 	guint8 *p, *p_end;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -180,7 +180,7 @@ disable_gclass_recording (gclass_record_func func, void *user_data)
 MonoClass *
 mono_class_from_typeref (MonoImage *image, guint32 type_token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass = mono_class_from_typeref_checked (image, type_token, &error);
 	g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
 	return klass;
@@ -887,7 +887,7 @@ mono_class_inflate_generic_type_with_mempool (MonoImage *image, MonoType *type, 
 MonoType*
 mono_class_inflate_generic_type (MonoType *type, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *result;
 	result = mono_class_inflate_generic_type_checked (type, context, &error);
 	mono_error_cleanup (&error);
@@ -1014,7 +1014,7 @@ mono_class_inflate_generic_method_checked (MonoMethod *method, MonoGenericContex
 MonoMethod*
 mono_class_inflate_generic_method_full (MonoMethod *method, MonoClass *klass_hint, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *res = mono_class_inflate_generic_method_full_checked (method, klass_hint, context, &error);
 	if (!mono_error_ok (&error))
 		/*FIXME do proper error handling - on this case, kill this function. */
@@ -1495,7 +1495,7 @@ static gboolean
 mono_class_set_type_load_failure_causedby_class (MonoClass *klass, const MonoClass *caused_by, const gchar* msg)
 {
 	if (mono_class_has_failure (caused_by)) {
-		MonoError cause_error;
+		ERROR_DECL (cause_error);
 		error_init (&cause_error);
 		mono_error_set_for_class_failure (&cause_error, caused_by);
 		mono_class_set_type_load_failure (klass, "%s, due to: %s", msg, mono_error_get_message (&cause_error));
@@ -1525,7 +1525,7 @@ mono_class_set_type_load_failure_causedby_class (MonoClass *klass, const MonoCla
 void
 mono_class_setup_fields (MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoImage *m = klass->image;
 	int top;
 	guint32 layout = mono_class_get_flags (klass) & TYPE_ATTRIBUTE_LAYOUT_MASK;
@@ -1868,7 +1868,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				if (field_class) {
 					mono_class_setup_fields (field_class);
 					if (mono_class_has_failure (field_class)) {
-						MonoError field_error;
+						ERROR_DECL (field_error);
 						error_init (&field_error);
 						mono_error_set_for_class_failure (&field_error, field_class);
 						mono_class_set_type_load_failure (klass, "Could not set up field '%s' due to: %s", field->name, mono_error_get_message (&field_error));
@@ -2293,7 +2293,7 @@ mono_class_setup_methods (MonoClass *klass)
 		return;
 
 	if (mono_class_is_ginst (klass)) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
 
 		mono_class_init (gklass);
@@ -2319,7 +2319,7 @@ mono_class_setup_methods (MonoClass *klass)
 			}
 		}
 	} else if (klass->rank) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *amethod;
 		MonoMethodSignature *sig;
 		int count_generic = 0, first_generic = 0;
@@ -2411,7 +2411,7 @@ mono_class_setup_methods (MonoClass *klass)
 			setup_generic_array_ifaces (klass, klass->interfaces [i], methods, first_generic + i * count_generic, cache);
 		g_hash_table_destroy (cache);
 	} else if (mono_class_has_static_metadata (klass)) {
-		MonoError error;
+		ERROR_DECL (error);
 		int first_idx = mono_class_get_first_method_idx (klass);
 
 		count = mono_class_get_method_count (klass);
@@ -2462,7 +2462,7 @@ mono_class_setup_methods (MonoClass *klass)
 MonoMethod*
 mono_class_get_method_by_index (MonoClass *klass, int index)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	MonoGenericClass *gklass = mono_class_try_get_generic_class (klass);
 	/* Avoid calling setup_methods () if possible */
@@ -2514,7 +2514,7 @@ mono_class_get_inflated_method (MonoClass *klass, MonoMethod *method)
 			if (klass->methods) {
 				return klass->methods [i];
 			} else {
-				MonoError error;
+				ERROR_DECL (error);
 				MonoMethod *result = mono_class_inflate_generic_method_full_checked (gklass->methods [i], klass, mono_class_get_context (klass), &error);
 				g_assert (mono_error_ok (&error)); /* FIXME don't swallow this error */
 				return result;
@@ -2547,7 +2547,7 @@ mono_class_get_vtable_entry (MonoClass *klass, int offset)
 	}
 
 	if (mono_class_is_ginst (klass)) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
 		mono_class_setup_vtable (gklass);
 		m = gklass->vtable [offset];
@@ -2611,7 +2611,7 @@ mono_class_setup_properties (MonoClass *klass)
 		properties = mono_class_new0 (klass, MonoProperty, ginfo->count + 1);
 
 		for (i = 0; i < ginfo->count; i++) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoProperty *prop = &properties [i];
 
 			*prop = ginfo->properties [i];
@@ -2654,7 +2654,7 @@ mono_class_setup_properties (MonoClass *klass)
 				mono_metadata_decode_row (msemt, j, cols, MONO_METHOD_SEMA_SIZE);
 
 				if (klass->image->uncompressed_metadata) {
-					MonoError error;
+					ERROR_DECL (error);
 					/* It seems like the MONO_METHOD_SEMA_METHOD column needs no remapping */
 					method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | cols [MONO_METHOD_SEMA_METHOD], klass, NULL, &error);
 					mono_error_cleanup (&error); /* FIXME don't swallow this error */
@@ -2698,7 +2698,7 @@ inflate_method_listz (MonoMethod **methods, MonoClass *klass, MonoGenericContext
 	retval = g_new0 (MonoMethod*, count + 1);
 	count = 0;
 	for (om = methods, count = 0; *om; ++om, ++count) {
-		MonoError error;
+		ERROR_DECL (error);
 		retval [count] = mono_class_inflate_generic_method_full_checked (*om, klass, context, &error);
 		g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
 	}
@@ -2739,7 +2739,7 @@ mono_class_setup_events (MonoClass *klass)
 			context = mono_class_get_context (klass);
 
 		for (i = 0; i < count; i++) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoEvent *event = &events [i];
 			MonoEvent *gevent = &ginfo->events [i];
 
@@ -2787,7 +2787,7 @@ mono_class_setup_events (MonoClass *klass)
 				mono_metadata_decode_row (msemt, j, cols, MONO_METHOD_SEMA_SIZE);
 
 				if (klass->image->uncompressed_metadata) {
-					MonoError error;
+					ERROR_DECL (error);
 					/* It seems like the MONO_METHOD_SEMA_METHOD column needs no remapping */
 					method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | cols [MONO_METHOD_SEMA_METHOD], klass, NULL, &error);
 					mono_error_cleanup (&error); /* FIXME don't swallow this error */
@@ -3065,7 +3065,7 @@ static void
 print_implemented_interfaces (MonoClass *klass)
 {
 	char *name;
-	MonoError error;
+	ERROR_DECL (error);
 	GPtrArray *ifaces = NULL;
 	int i;
 	int ancestor_level = 0;
@@ -3327,7 +3327,7 @@ mono_class_interface_match (const uint8_t *bitmap, int id)
 static int
 setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *k, *ic;
 	int i, j, num_ifaces;
 	guint32 max_iid;
@@ -3593,7 +3593,7 @@ mono_class_setup_vtable (MonoClass *klass)
 static void
 mono_class_setup_vtable_full (MonoClass *klass, GList *in_setup)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod **overrides = NULL;
 	MonoGenericContext *context;
 	guint32 type_token;
@@ -4123,7 +4123,7 @@ apply_override (MonoClass *klass, MonoMethod **vtable, MonoMethod *decl, MonoMet
 void
 mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int onum, GList *in_setup)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *k, *ic;
 	MonoMethod **vtable = NULL;
 	int i, max_vtsize = 0, cur_slot = 0;
@@ -4192,7 +4192,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 
 	/* Optimized version for generic instances */
 	if (mono_class_is_ginst (klass)) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *gklass = mono_class_get_generic_class (klass)->container_class;
 		MonoMethod **tmp;
 
@@ -4859,7 +4859,7 @@ setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **met
 	//g_print ("setting up array interface: %s\n", mono_type_get_name_full (&iface->byval_arg, 0));
 
 	for (i = 0; i < generic_array_method_num; i++) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *m = generic_array_method_info [i].array_method;
 		MonoMethod *inflated, *helper;
 
@@ -5866,7 +5866,7 @@ static void
 mono_generic_class_setup_parent (MonoClass *klass, MonoClass *gtd)
 {
 	if (gtd->parent) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoGenericClass *gclass = mono_class_get_generic_class (klass);
 
 		klass->parent = mono_class_inflate_generic_class_checked (gtd->parent, mono_generic_class_get_context (gclass), &error);
@@ -6695,7 +6695,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 
 	if (eclass->byval_arg.type == MONO_TYPE_TYPEDBYREF) {
 		/*Arrays of those two types are invalid.*/
-		MonoError prepared_error;
+		ERROR_DECL (prepared_error);
 		error_init (&prepared_error);
 		mono_error_set_invalid_program (&prepared_error, "Arrays of System.TypedReference types are invalid.");
 		mono_class_set_failure (klass, mono_error_box (&prepared_error, klass->image));
@@ -6771,7 +6771,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	klass->this_arg.byref = 1;
 
 	if (rank > 32) {
-		MonoError prepared_error;
+		ERROR_DECL (prepared_error);
 		error_init (&prepared_error);
 		name = mono_type_get_full_name (klass);
 		mono_error_set_type_load_class (&prepared_error, klass, "%s has too many dimensions.", name);
@@ -7311,7 +7311,7 @@ mono_class_name_from_token (MonoImage *image, guint32 type_token)
 	}
 
 	case MONO_TOKEN_TYPE_REF: {
-		MonoError error;
+		ERROR_DECL (error);
 		guint32 cols [MONO_TYPEREF_SIZE];
 		MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
 		guint tidx = mono_metadata_token_index (type_token);
@@ -7355,7 +7355,7 @@ mono_assembly_name_from_token (MonoImage *image, guint32 type_token)
 			return g_strdup (image->assembly_name);
 		return g_strdup_printf ("%s", image->name ? image->name : "[Could not resolve assembly name");
 	case MONO_TOKEN_TYPE_REF: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoAssemblyName aname;
 		guint32 cols [MONO_TYPEREF_SIZE];
 		MonoTableInfo  *t = &image->tables [MONO_TABLE_TYPEREF];
@@ -7411,7 +7411,7 @@ mono_assembly_name_from_token (MonoImage *image, guint32 type_token)
 MonoClass *
 mono_class_get_full (MonoImage *image, guint32 type_token, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	klass = mono_class_get_checked (image, type_token, &error);
 
@@ -7719,7 +7719,7 @@ find_nocase (gpointer key, gpointer value, gpointer user_data)
 MonoClass *
 mono_class_from_name_case (MonoImage *image, const char* name_space, const char *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *res = mono_class_from_name_case_checked (image, name_space, name, &error);
 	mono_error_cleanup (&error);
 
@@ -8018,7 +8018,7 @@ mono_class_from_name_checked (MonoImage *image, const char* name_space, const ch
 MonoClass *
 mono_class_from_name (MonoImage *image, const char* name_space, const char *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 
 	klass = mono_class_from_name_checked (image, name_space, name, &error);
@@ -8040,7 +8040,7 @@ mono_class_from_name (MonoImage *image, const char* name_space, const char *name
 MonoClass *
 mono_class_load_from_name (MonoImage *image, const char* name_space, const char *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 
 	klass = mono_class_from_name_checked (image, name_space, name, &error);
@@ -8067,7 +8067,7 @@ mono_class_load_from_name (MonoImage *image, const char* name_space, const char 
 MonoClass*
 mono_class_try_load_from_name (MonoImage *image, const char* name_space, const char *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 
 	klass = mono_class_from_name_checked (image, name_space, name, &error);
@@ -8338,7 +8338,7 @@ mono_gparam_is_assignable_from (MonoClass *target, MonoClass *candidate)
 gboolean
 mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	/*FIXME this will cause a lot of irrelevant stuff to be loaded.*/
 	if (!klass->inited)
 		mono_class_init (klass);
@@ -8517,7 +8517,7 @@ mono_class_is_variant_compatible_slow (MonoClass *klass, MonoClass *oklass)
 static gboolean
 mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 	gboolean is_variant = mono_class_has_variant_generic_params (target);
 
@@ -8662,7 +8662,7 @@ mono_class_get_cctor (MonoClass *klass)
 		return mono_class_get_inflated_method (klass, mono_class_get_cctor (mono_class_get_generic_class (klass)->container_class));
 
 	if (mono_class_get_cached_class_info (klass, &cached_info)) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *result = mono_get_method_checked (klass->image, cached_info.cctor_token, klass, NULL, &error);
 		if (!mono_error_ok (&error))
 			g_error ("Could not lookup class cctor from cached metadata due to %s", mono_error_get_message (&error));
@@ -8689,7 +8689,7 @@ mono_class_get_finalizer (MonoClass *klass)
 		return NULL;
 
 	if (mono_class_get_cached_class_info (klass, &cached_info)) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *result = mono_get_method_checked (cached_info.finalize_image, cached_info.finalize_token, NULL, NULL, &error);
 		if (!mono_error_ok (&error))
 			g_error ("Could not lookup finalizer from cached metadata due to %s", mono_error_get_message (&error));
@@ -8808,7 +8808,7 @@ gpointer
 mono_ldtoken (MonoImage *image, guint32 token, MonoClass **handle_class,
 	      MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res = mono_ldtoken_checked (image, token, handle_class, context, &error);
 	g_assert (mono_error_ok (&error));
 	return res;
@@ -9337,7 +9337,7 @@ mono_class_get_virtual_methods (MonoClass* klass, gpointer *iter)
 		}
 
 		if (i < mcount) {
-			MonoError error;
+			ERROR_DECL (error);
 			res = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | (first_idx + i + 1), klass, NULL, &error);
 			mono_error_cleanup (&error); /* FIXME don't swallow the error */
 
@@ -9445,7 +9445,7 @@ mono_class_get_events (MonoClass* klass, gpointer *iter)
 MonoClass*
 mono_class_get_interfaces (MonoClass* klass, gpointer *iter)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass** iface;
 	if (!iter)
 		return NULL;
@@ -9480,7 +9480,7 @@ mono_class_get_interfaces (MonoClass* klass, gpointer *iter)
 static void
 setup_nested_types (MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	GList *classes, *nested_classes, *l;
 	int i;
 
@@ -9617,7 +9617,7 @@ mono_field_get_name (MonoClassField *field)
 MonoType*
 mono_field_get_type (MonoClassField *field)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *type = mono_field_get_type_checked (field, &error);
 	if (!mono_error_ok (&error)) {
 		mono_trace_warning (MONO_TRACE_TYPE, "Could not load field's type due to %s", mono_error_get_message (&error));
@@ -9889,7 +9889,7 @@ find_method_in_metadata (MonoClass *klass, const char *name, int param_count, in
 	int first_idx = mono_class_get_first_method_idx (klass);
 	int mcount = mono_class_get_method_count (klass);
 	for (i = 0; i < mcount; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		guint32 cols [MONO_METHOD_SIZE];
 		MonoMethod *method;
 		MonoMethodSignature *sig;
@@ -9935,7 +9935,7 @@ find_method_in_metadata (MonoClass *klass, const char *name, int param_count, in
 MonoMethod *
 mono_class_get_method_from_name_flags (MonoClass *klass, const char *name, int param_count, int flags)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	error_init (&error);
 
 	MonoMethod * const method = mono_class_get_method_from_name_checked (klass, name, param_count, flags, &error);
@@ -10053,7 +10053,7 @@ mono_class_has_failure (const MonoClass *klass)
 gboolean
 mono_class_set_type_load_failure (MonoClass *klass, const char * fmt, ...)
 {
-	MonoError prepare_error;
+	ERROR_DECL (prepare_error);
 	va_list args;
 
 	if (mono_class_has_failure (klass))
@@ -10135,7 +10135,7 @@ mono_class_get_exception_for_failure (MonoClass *klass)
 {
 	if (!mono_class_has_failure (klass))
 		return NULL;
-	MonoError unboxed_error;
+	ERROR_DECL (unboxed_error);
 	error_init (&unboxed_error);
 	mono_error_set_for_class_failure (&unboxed_error, klass);
 	return mono_error_convert_to_exception (&unboxed_error);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -319,7 +319,7 @@ cominterop_object_is_rcw (MonoObject *obj)
 static int
 cominterop_get_com_slot_begin (MonoClass* klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo = NULL;
 	MonoInterfaceTypeAttribute* itf_attr = NULL; 
 
@@ -348,7 +348,7 @@ cominterop_get_com_slot_begin (MonoClass* klass)
 static MonoClass*
 cominterop_get_method_interface (MonoMethod* method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *ic = method->klass;
 
 	/* if method is on a class, we need to look up interface method exists on */
@@ -436,7 +436,7 @@ cominterop_mono_string_to_guid (MonoString* string, guint8 *guid);
 static gboolean
 cominterop_class_guid (MonoClass* klass, guint8* guid)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
 
 	cinfo = mono_custom_attrs_from_class_checked (klass, &error);
@@ -459,7 +459,7 @@ cominterop_class_guid (MonoClass* klass, guint8* guid)
 static gboolean
 cominterop_com_visible (MonoClass* klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
 	GPtrArray *ifaces;
 	MonoBoolean visible = 1;
@@ -498,7 +498,7 @@ cominterop_com_visible (MonoClass* klass)
 static void cominterop_set_hr_error (MonoError *oerror, int hr)
 {
 	static MonoMethod* throw_exception_for_hr = NULL;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException* ex;
 	void* params[1] = {&hr};
 
@@ -566,7 +566,7 @@ cominterop_get_interface_checked (MonoComObject* obj, MonoClass* ic, MonoError *
 static gpointer
 cominterop_get_interface (MonoComObject *obj, MonoClass *ic, gboolean throw_exception)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer itf = cominterop_get_interface_checked (obj, ic, &error);
 	if (!is_ok (&error)) {
 		if (throw_exception) {
@@ -593,7 +593,7 @@ cominterop_get_hresult_for_exception (MonoException* exc)
 static MonoReflectionType *
 cominterop_type_from_handle (MonoType *handle)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionType *ret;
 	MonoDomain *domain = mono_domain_get (); 
 	MonoClass *klass = mono_class_from_mono_type (handle);
@@ -653,7 +653,7 @@ mono_mb_emit_cominterop_get_function_pointer (MonoMethodBuilder *mb, MonoMethod 
 {
 #ifndef DISABLE_JIT
 	int slot;
-	MonoError error;
+	ERROR_DECL (error);
 	// get function pointer from 1st arg, the COM interface pointer
 	mono_mb_emit_ldarg (mb, 0);
 	slot = cominterop_get_com_slot_for_method (method, &error);
@@ -1019,7 +1019,7 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 			 * However, no interfaces are allowed to have static methods.
 			 * Thus, calling it should invariably lead to an exception.
 			 */
-			MonoError error;
+			ERROR_DECL (error);
 			error_init (&error);
 			mono_cominterop_get_interface_missing_error (&error, method);
 			mono_mb_emit_exception_for_error (mb, &error);
@@ -1592,7 +1592,7 @@ void*
 ves_icall_System_Runtime_InteropServices_Marshal_GetIUnknownForObjectInternal (MonoObject* object)
 {
 #ifndef DISABLE_COM
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (!object)
 		return NULL;
@@ -1659,7 +1659,7 @@ void*
 ves_icall_System_Runtime_InteropServices_Marshal_GetIDispatchForObjectInternal (MonoObject* object)
 {
 #ifndef DISABLE_COM
-	MonoError error;
+	ERROR_DECL (error);
 	void* idisp = cominterop_get_idispatch_for_object (object, &error);
 	mono_error_set_pending_exception (&error);
 	return idisp;
@@ -1672,7 +1672,7 @@ void*
 ves_icall_System_Runtime_InteropServices_Marshal_GetCCW (MonoObject* object, MonoReflectionType* type)
 {
 #ifndef DISABLE_COM
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass* klass = NULL;
 	void* itf = NULL;
 	g_assert (type);
@@ -1736,7 +1736,7 @@ guint32
 ves_icall_System_Runtime_InteropServices_Marshal_GetComSlotForMethodInfoInternal (MonoReflectionMethod *m)
 {
 #ifndef DISABLE_COM
-	MonoError error;
+	ERROR_DECL (error);
 	int slot = cominterop_get_com_slot_for_method (m->method, &error);
 	mono_error_assert_ok (&error);
 	return slot;
@@ -1749,7 +1749,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetComSlotForMethodInfoInternal
 MonoObject *
 ves_icall_System_ComObject_CreateRCW (MonoReflectionType *type)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoDomain *domain;
 	MonoObject *obj;
@@ -1847,7 +1847,7 @@ gpointer
 ves_icall_System_ComObject_GetInterfaceInternal (MonoComObject* obj, MonoReflectionType* type, MonoBoolean throw_exception)
 {
 #ifndef DISABLE_COM
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass = mono_type_get_class (type->type);
 	if (!mono_class_init (klass)) {
 		mono_set_pending_exception (mono_class_get_exception_for_failure (klass));
@@ -2213,7 +2213,7 @@ cominterop_get_ccw_checked (MonoObject* object, MonoClass* itf, MonoError *error
 static gpointer
 cominterop_get_ccw (MonoObject* object, MonoClass* itf)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer ccw_entry = cominterop_get_ccw_checked (object, itf, &error);
 	mono_error_set_pending_exception (&error);
 	return ccw_entry;
@@ -2519,7 +2519,7 @@ cominterop_ccw_getfreethreadedmarshaler (MonoCCW* ccw, MonoObject* object, gpoin
 static int STDCALL 
 cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* ppv)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	GPtrArray *ifaces;
 	MonoClass *itf = NULL;
 	int i;
@@ -2624,7 +2624,7 @@ cominterop_ccw_get_ids_of_names (MonoCCWInterface* ccwe, gpointer riid,
 											 guint32 lcid, gint32 *rgDispId)
 {
 	static MonoClass *ComDispIdAttribute = NULL;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo = NULL;
 	int i,ret = MONO_S_OK;
 	MonoMethod* method;
@@ -2847,7 +2847,7 @@ mono_ptr_to_bstr(gpointer ptr, int slen)
 MonoString *
 mono_string_from_bstr (gpointer bstr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -2856,7 +2856,7 @@ mono_string_from_bstr (gpointer bstr)
 MonoString *
 mono_string_from_bstr_icall (gpointer bstr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -3254,7 +3254,7 @@ mono_marshal_safe_array_get_ubound (gpointer psa, guint nDim, glong* plUbound)
 static gboolean
 mono_marshal_safearray_begin (gpointer safearray, MonoArray **result, gpointer *indices, gpointer empty, gpointer parameter, gboolean allocateNewArray)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int dim;
 	uintptr_t *sizes;
 	intptr_t *bounds;
@@ -3341,7 +3341,7 @@ mono_marshal_win_safearray_get_value (gpointer safearray, gpointer indices, gpoi
 static gpointer
 mono_marshal_safearray_get_value (gpointer safearray, gpointer indices)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer result;
 
 	int hr = mono_marshal_win_safearray_get_value (safearray, indices, &result);
@@ -3359,7 +3359,7 @@ mono_marshal_safearray_get_value (gpointer safearray, gpointer indices)
 static gpointer
 mono_marshal_safearray_get_value (gpointer safearray, gpointer indices)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer result;
 
 	if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
@@ -3380,7 +3380,7 @@ mono_marshal_safearray_get_value (gpointer safearray, gpointer indices)
 static 
 gboolean mono_marshal_safearray_next (gpointer safearray, gpointer indices)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 	int dim = mono_marshal_safearray_get_dim (safearray);
 	gboolean ret= TRUE;
@@ -3527,7 +3527,7 @@ mono_marshal_win_safearray_set_value (gpointer safearray, gpointer indices, gpoi
 static void
 mono_marshal_safearray_set_value (gpointer safearray, gpointer indices, gpointer value)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int hr = mono_marshal_win_safearray_set_value (safearray, indices, value);
 	if (hr < 0) {
 		cominterop_set_hr_error (&error, hr);
@@ -3541,7 +3541,7 @@ mono_marshal_safearray_set_value (gpointer safearray, gpointer indices, gpointer
 static void
 mono_marshal_safearray_set_value (gpointer safearray, gpointer indices, gpointer value)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
 		int hr = safe_array_put_element_ms (safearray, (glong *)indices, (void **)value);
 		if (hr < 0) {
@@ -3617,7 +3617,7 @@ mono_ptr_to_bstr (gpointer ptr, int slen)
 MonoString *
 mono_string_from_bstr (gpointer bstr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -3626,7 +3626,7 @@ mono_string_from_bstr (gpointer bstr)
 MonoString *
 mono_string_from_bstr_icall (gpointer bstr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -3691,7 +3691,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_QueryInterfaceInternal (gpointe
 MonoString *
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringBSTR (gpointer ptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_bstr_checked (ptr, &error);
 	mono_error_set_pending_exception (&error);
 	return result;

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -220,7 +220,7 @@ static void
 do_console_cancel_event (void)
 {
 	static MonoMethod *System_Console_DoConsoleCancelEventBackground_method = ((gpointer)-1);
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (mono_defaults.console_class == NULL)
 		return;
@@ -417,7 +417,7 @@ set_control_chars (MonoArray *control_chars, const guchar *cc)
 MonoBoolean
 ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardown, MonoArray **control_chars, int **size)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	int dims;
 

--- a/mono/metadata/console-win32-uwp.c
+++ b/mono/metadata/console-win32-uwp.c
@@ -16,7 +16,7 @@
 MonoBoolean
 ves_icall_System_ConsoleDriver_Isatty (HANDLE handle)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -32,7 +32,7 @@ ves_icall_System_ConsoleDriver_Isatty (HANDLE handle)
 MonoBoolean
 ves_icall_System_ConsoleDriver_SetEcho (MonoBoolean want_echo)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -48,7 +48,7 @@ ves_icall_System_ConsoleDriver_SetEcho (MonoBoolean want_echo)
 MonoBoolean
 ves_icall_System_ConsoleDriver_SetBreak (MonoBoolean want_break)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -64,7 +64,7 @@ ves_icall_System_ConsoleDriver_SetBreak (MonoBoolean want_break)
 gint32
 ves_icall_System_ConsoleDriver_InternalKeyAvailable (gint32 timeout)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -80,7 +80,7 @@ ves_icall_System_ConsoleDriver_InternalKeyAvailable (gint32 timeout)
 MonoBoolean
 ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardown, MonoArray **control_chars, int **size)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -145,7 +145,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 __int32 STDMETHODCALLTYPE _CorExeMain(void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain* domain;
 	MonoAssembly* assembly;
 	MonoImage* image;

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -176,7 +176,7 @@ find_event_index (MonoClass *klass, MonoEvent *event)
 static MonoType*
 cattr_type_from_name (char *n, MonoImage *image, gboolean is_enum, MonoError *error)
 {
-	MonoError inner_error;
+	ERROR_DECL (inner_error);
 	MonoType *t = mono_reflection_type_from_name_checked (n, image, &inner_error);
 	if (!t) {
 		mono_error_set_type_load_name (error, g_strdup(n), NULL,
@@ -1144,7 +1144,7 @@ leave:
 void
 ves_icall_System_Reflection_CustomAttributeData_ResolveArgumentsInternal (MonoReflectionMethod *ref_method, MonoReflectionAssembly *assembly, gpointer data, guint32 len, MonoArray **ctor_args, MonoArray **named_args)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	(void) reflection_resolve_custom_attribute_data (ref_method, assembly, data, len, ctor_args, named_args, &error);
 	mono_error_set_pending_exception (&error);
 }
@@ -1245,7 +1245,7 @@ mono_custom_attrs_construct_by_type (MonoCustomAttrInfo *cinfo, MonoClass *attr_
 MonoArray*
 mono_custom_attrs_construct (MonoCustomAttrInfo *cinfo)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = mono_custom_attrs_construct_by_type (cinfo, NULL, &error);
 	mono_error_assert_ok (&error); /*FIXME proper error handling*/
 
@@ -1278,7 +1278,7 @@ mono_custom_attrs_data_construct (MonoCustomAttrInfo *cinfo, MonoError *error)
 MonoCustomAttrInfo*
 mono_custom_attrs_from_index (MonoImage *image, guint32 idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *result = mono_custom_attrs_from_index_checked (image, idx, FALSE, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1368,7 +1368,7 @@ mono_custom_attrs_from_index_checked (MonoImage *image, guint32 idx, gboolean ig
 MonoCustomAttrInfo*
 mono_custom_attrs_from_method (MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo* result = mono_custom_attrs_from_method_checked  (method, &error);
 	mono_error_cleanup (&error); /* FIXME want a better API that doesn't swallow the error */
 	return result;
@@ -1409,7 +1409,7 @@ mono_custom_attrs_from_method_checked (MonoMethod *method, MonoError *error)
 MonoCustomAttrInfo*
 mono_custom_attrs_from_class (MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *result = mono_custom_attrs_from_class_checked (klass, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1446,7 +1446,7 @@ mono_custom_attrs_from_class_checked (MonoClass *klass, MonoError *error)
 MonoCustomAttrInfo*
 mono_custom_attrs_from_assembly (MonoAssembly *assembly)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *result = mono_custom_attrs_from_assembly_checked (assembly, FALSE, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1488,7 +1488,7 @@ mono_custom_attrs_from_module (MonoImage *image, MonoError *error)
 MonoCustomAttrInfo*
 mono_custom_attrs_from_property (MonoClass *klass, MonoProperty *property)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo * result = mono_custom_attrs_from_property_checked (klass, property, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1517,7 +1517,7 @@ mono_custom_attrs_from_property_checked (MonoClass *klass, MonoProperty *propert
 MonoCustomAttrInfo*
 mono_custom_attrs_from_event (MonoClass *klass, MonoEvent *event)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo * result = mono_custom_attrs_from_event_checked (klass, event, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1546,7 +1546,7 @@ mono_custom_attrs_from_event_checked (MonoClass *klass, MonoEvent *event, MonoEr
 MonoCustomAttrInfo*
 mono_custom_attrs_from_field (MonoClass *klass, MonoClassField *field)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo * result = mono_custom_attrs_from_field_checked (klass, field, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1580,7 +1580,7 @@ mono_custom_attrs_from_field_checked (MonoClass *klass, MonoClassField *field, M
 MonoCustomAttrInfo*
 mono_custom_attrs_from_param (MonoMethod *method, guint32 param)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *result = mono_custom_attrs_from_param_checked (method, param, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1688,7 +1688,7 @@ mono_custom_attrs_has_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 MonoObject*
 mono_custom_attrs_get_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *res = mono_custom_attrs_get_attr_checked (ainfo, attr_klass, &error);
 	mono_error_assert_ok (&error); /*FIXME proper error handling*/
 	return res;
@@ -1731,7 +1731,7 @@ MonoCustomAttrInfo*
 mono_reflection_get_custom_attrs_info (MonoObject *obj_raw)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	MonoCustomAttrInfo *result = mono_reflection_get_custom_attrs_info_checked (obj, &error);
 	mono_error_assert_ok (&error);
@@ -1928,7 +1928,7 @@ MonoArray*
 mono_reflection_get_custom_attrs (MonoObject *obj_raw)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	MonoArrayHandle result = mono_reflection_get_custom_attrs_by_type_handle (obj, NULL, &error);
 	mono_error_cleanup (&error);
@@ -1946,7 +1946,7 @@ MonoArray*
 mono_reflection_get_custom_attrs_data (MonoObject *obj_raw)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	MonoArrayHandle result = mono_reflection_get_custom_attrs_data_checked (obj, &error);
 	mono_error_cleanup (&error);
@@ -2160,7 +2160,7 @@ static void
 init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 {
 	MonoTableInfo *tdef;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass = NULL;
 	guint32 memberref_index = -1;
 	int first_method_idx = -1;

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -631,7 +631,7 @@ mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image)
 	mono_image_get_table_info (image, MONO_TABLE_TYPEDEF);
 	methods = mono_image_get_table_info (image, MONO_TABLE_METHOD);
 	for (i = 0; i < mono_table_info_get_rows (methods); ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		guint32 token = mono_metadata_decode_row_col (methods, i, MONO_METHOD_NAME);
 		const char *n = mono_metadata_string_heap (image, token);
 
@@ -651,7 +651,7 @@ mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image)
 static const unsigned char*
 dis_one (GString *str, MonoDisHelper *dh, MonoMethod *method, const unsigned char *ip, const unsigned char *end)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
 	const MonoOpcode *opcode;
 	guint32 label, token;
@@ -895,7 +895,7 @@ mono_method_get_name_full (MonoMethod *method, gboolean signature, gboolean ret,
 	char wrapper [64];
 	char *klass_desc;
 	char *inst_desc = NULL;
-	MonoError error;
+	ERROR_DECL (error);
 
 	const char *class_method_separator = ":";
 	const char *method_sig_space = " ";
@@ -1035,7 +1035,7 @@ print_name_space (MonoClass *klass)
 void
 mono_object_describe (MonoObject *obj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass* klass;
 	const char* sep;
 	if (!obj) {
@@ -1214,7 +1214,7 @@ mono_value_describe_fields (MonoClass* klass, const char* addr)
 void
 mono_class_describe_statics (MonoClass* klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClassField *field;
 	MonoClass *p;
 	const char *field_ptr;
@@ -1255,7 +1255,7 @@ mono_class_describe_statics (MonoClass* klass)
 void
 mono_method_print_code (MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *code;
 	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
 	if (!header) {

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -68,7 +68,7 @@ MonoException *
 mono_exception_from_name_domain (MonoDomain *domain, MonoImage *image, 
 				 const char* name_space, const char *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoObject *o;
 	MonoDomain *caller_domain = mono_domain_get ();
@@ -102,7 +102,7 @@ mono_exception_from_name_domain (MonoDomain *domain, MonoImage *image,
 MonoException *
 mono_exception_from_token (MonoImage *image, guint32 token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoObject *o;
 
@@ -179,7 +179,7 @@ MonoException *
 mono_exception_from_name_two_strings (MonoImage *image, const char *name_space,
 				      const char *name, MonoString *a1, MonoString *a2)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ret;
 
 	ret = mono_exception_from_name_two_strings_checked (image, name_space, name, a1, a2, &error);
@@ -230,7 +230,7 @@ MonoException *
 mono_exception_from_name_msg (MonoImage *image, const char *name_space,
 			      const char *name, const char *msg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ex;
 
 	ex = mono_exception_from_name (image, name_space, name);
@@ -254,7 +254,7 @@ MonoException *
 mono_exception_from_token_two_strings (MonoImage *image, guint32 token,
 									   MonoString *a1, MonoString *a2)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ret;
 	ret = mono_exception_from_token_two_strings_checked (image, token, a1, a2, &error);
 	mono_error_cleanup (&error);
@@ -434,7 +434,7 @@ mono_get_exception_array_type_mismatch ()
 MonoException *
 mono_get_exception_type_load (MonoString *class_name, char *assembly_name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *s = NULL;
 	if (assembly_name) {
 		s = mono_string_new_checked (mono_domain_get (), assembly_name, &error);
@@ -479,7 +479,7 @@ mono_get_exception_not_supported (const char *msg)
 MonoException *
 mono_get_exception_missing_method (const char *class_name, const char *member_name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *s1 = mono_string_new_checked (mono_domain_get (), class_name, &error);
 	mono_error_assert_ok (&error);
 	MonoString *s2 = mono_string_new_checked (mono_domain_get (), member_name, &error);
@@ -500,7 +500,7 @@ mono_get_exception_missing_method (const char *class_name, const char *member_na
 MonoException *
 mono_get_exception_missing_field (const char *class_name, const char *member_name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *s1 = mono_string_new_checked (mono_domain_get (), class_name, &error);
 	mono_error_assert_ok (&error);
 	MonoString *s2 = mono_string_new_checked (mono_domain_get (), member_name, &error);
@@ -526,7 +526,7 @@ mono_get_exception_argument_null (const char *arg)
 		mono_get_corlib (), "System", "ArgumentNullException");
 
 	if (arg) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoArgumentException *argex = (MonoArgumentException *)ex;
 		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, &error);
 		mono_error_assert_ok (&error);
@@ -550,7 +550,7 @@ mono_get_exception_argument (const char *arg, const char *msg)
 		mono_get_corlib (), "System", "ArgumentException", msg);
 
 	if (arg) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoArgumentException *argex = (MonoArgumentException *)ex;
 		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, &error);
 		mono_error_assert_ok (&error);
@@ -574,7 +574,7 @@ mono_get_exception_argument_out_of_range (const char *arg)
 		mono_get_corlib (), "System", "ArgumentOutOfRangeException");
 
 	if (arg) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoArgumentException *argex = (MonoArgumentException *)ex;
 		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, &error);
 		mono_error_assert_ok (&error);
@@ -616,7 +616,7 @@ mono_get_exception_io (const char *msg)
 MonoException *
 mono_get_exception_file_not_found (MonoString *fname)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ret = mono_exception_from_name_two_strings_checked (
 		mono_get_corlib (), "System.IO", "FileNotFoundException", fname, fname, &error);
 	mono_error_assert_ok (&error);
@@ -632,7 +632,7 @@ mono_get_exception_file_not_found (MonoString *fname)
 MonoException *
 mono_get_exception_file_not_found2 (const char *msg, MonoString *fname)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *s = NULL;
 	if (msg) {
 		s = mono_string_new_checked (mono_domain_get (), msg, &error);
@@ -654,7 +654,7 @@ mono_get_exception_file_not_found2 (const char *msg, MonoString *fname)
 MonoException *
 mono_get_exception_type_initialization (const gchar *type_name, MonoException *inner)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ret = mono_get_exception_type_initialization_checked (type_name, inner, &error);
 	if (!is_ok (&error)) {
 		mono_error_cleanup (&error);
@@ -757,7 +757,7 @@ mono_get_exception_bad_image_format (const char *msg)
 MonoException *
 mono_get_exception_bad_image_format2 (const char *msg, MonoString *fname)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *s = NULL;
 
 	if (msg) {
@@ -843,7 +843,7 @@ MonoException *
 mono_get_exception_reflection_type_load (MonoArray *types_raw, MonoArray *exceptions_raw)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoArray, types);
 	MONO_HANDLE_DCL (MonoArray, exceptions);
 	MonoExceptionHandle ret = mono_get_exception_reflection_type_load_checked (types, exceptions, &error);
@@ -903,7 +903,7 @@ mono_get_exception_reflection_type_load_checked (MonoArrayHandle types, MonoArra
 MonoException *
 mono_get_exception_runtime_wrapped (MonoObject *wrapped_exception)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ret = mono_get_exception_runtime_wrapped_checked (wrapped_exception, &error);
 	if (!is_ok (&error)) {
 		mono_error_cleanup (&error);
@@ -1084,7 +1084,7 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 	if (unhandled_exception_hook) {
 		unhandled_exception_hook (exc, unhandled_exception_hook_data);
 	} else {
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		MonoObject *other = NULL;
 		MonoString *str = mono_object_try_to_string (exc, &other, &inner_error);
 		char *msg = NULL;

--- a/mono/metadata/file-mmap-posix.c
+++ b/mono/metadata/file-mmap-posix.c
@@ -381,7 +381,7 @@ done:
 void *
 mono_mmap_open_file (MonoString *path, int mode, MonoString *mapName, gint64 *capacity, int access, int options, int *ioerror)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MmapHandle *handle = NULL;
 	g_assert (path || mapName);
 
@@ -429,7 +429,7 @@ mono_mmap_open_file (MonoString *path, int mode, MonoString *mapName, gint64 *ca
 void *
 mono_mmap_open_handle (void *input_fd, MonoString *mapName, gint64 *capacity, int access, int options, int *ioerror)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MmapHandle *handle;
 	if (!mapName) {
 		handle = (MmapHandle *)open_file_map (NULL, GPOINTER_TO_INT (input_fd), FILE_MODE_OPEN, capacity, access, options, ioerror);

--- a/mono/metadata/filewatcher.c
+++ b/mono/metadata/filewatcher.c
@@ -111,7 +111,7 @@ ves_icall_System_IO_FAMW_InternalFAMNextEvent (gpointer conn,
 					       gint *code,
 					       gint *reqnum)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	FAMEvent ev;
 
 	if (FAMNextEvent (conn, &ev) == 1) {
@@ -155,7 +155,7 @@ ves_icall_System_IO_InotifyWatcher_GetInotifyInstance ()
 int
 ves_icall_System_IO_InotifyWatcher_AddWatch (int fd, MonoString *name, gint32 mask)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *str, *path;
 	int retval;
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -168,7 +168,7 @@ coop_cond_timedwait_alertable (MonoCoopCond *cond, MonoCoopMutex *mutex, guint32
 void
 mono_gc_run_finalize (void *obj, void *data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *exc = NULL;
 	MonoObject *o;
 #ifndef HAVE_SGEN_GC
@@ -869,7 +869,7 @@ mono_runtime_do_background_work (void)
 static gsize WINAPI
 finalizer_thread (gpointer unused)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gboolean wait = TRUE;
 
 	MonoString *finalizer = mono_string_new_checked (mono_get_root_domain (), "Finalizer", &error);
@@ -928,7 +928,7 @@ static
 void
 mono_gc_init_finalizer_thread (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gc_thread = mono_thread_create_internal (mono_domain_get (), finalizer_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, &error);
 	mono_error_assert_ok (&error);
 }

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -180,7 +180,7 @@ Icall macros
 */
 #define SETUP_ICALL_COMMON	\
 	do { \
-		MonoError error;	\
+		ERROR_DECL (error);	\
 		MonoThreadInfo *__info = mono_thread_info_current ();	\
 		error_init (&error);	\
 

--- a/mono/metadata/icall-windows-uwp.c
+++ b/mono/metadata/icall-windows-uwp.c
@@ -31,7 +31,7 @@ mono_icall_get_windows_folder_path (int folder, MonoError *error)
 MonoArray *
 mono_icall_get_logical_drives (void)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetLogicalDriveStrings");
@@ -61,7 +61,7 @@ mono_icall_broadcast_setting_change (MonoError *error)
 guint32
 mono_icall_drive_info_get_drive_type (MonoString *root_path_name)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetDriveType");
@@ -75,7 +75,7 @@ mono_icall_drive_info_get_drive_type (MonoString *root_path_name)
 gint32
 mono_icall_wait_for_input_idle (gpointer handle, gint32 milliseconds)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("WaitForInputIdle");

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -156,7 +156,7 @@ mono_icall_get_file_path_prefix (const gchar *path)
 ICALL_EXPORT MonoObject *
 ves_icall_System_Array_GetValueImpl (MonoArray *arr, guint32 pos)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *ac;
 	gint32 esize;
 	gpointer *ea;
@@ -590,7 +590,7 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 ICALL_EXPORT MonoArray *
 ves_icall_System_Array_CreateInstanceImpl (MonoReflectionType *type, MonoArray *lengths, MonoArray *bounds)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *aklass, *klass;
 	MonoArray *array;
 	uintptr_t *sizes, i;
@@ -646,7 +646,7 @@ ves_icall_System_Array_CreateInstanceImpl (MonoReflectionType *type, MonoArray *
 ICALL_EXPORT MonoArray *
 ves_icall_System_Array_CreateInstanceImpl64 (MonoReflectionType *type, MonoArray *lengths, MonoArray *bounds)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *aklass, *klass;
 	MonoArray *array;
 	uintptr_t *sizes, i;
@@ -956,7 +956,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetObjectValue (MonoObj
 	if ((obj == NULL) || (! (obj->vtable->klass->valuetype)))
 		return obj;
 	else {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoObject *ret = mono_object_clone_checked (obj, &error);
 		mono_error_set_pending_exception (&error);
 
@@ -967,7 +967,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetObjectValue (MonoObj
 ICALL_EXPORT void
 ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunClassConstructor (MonoType *handle)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoVTable *vtable;
 
@@ -993,7 +993,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunClassConstructor (Mo
 ICALL_EXPORT void
 ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunModuleConstructor (MonoImage *image)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	mono_image_check_for_module_cctor (image);
 	if (image->has_module_cctor) {
@@ -1055,7 +1055,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_SufficientExecutionStac
 ICALL_EXPORT MonoObject *
 ves_icall_System_Object_MemberwiseClone (MonoObject *this_obj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *ret = mono_object_clone_checked (this_obj, &error);
 	mono_error_set_pending_exception (&error);
 
@@ -1065,7 +1065,7 @@ ves_icall_System_Object_MemberwiseClone (MonoObject *this_obj)
 ICALL_EXPORT gint32
 ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray **fields)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoObject **values = NULL;
 	MonoObject *o;
@@ -1131,7 +1131,7 @@ ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray 
 ICALL_EXPORT MonoBoolean
 ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoArray **fields)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoObject **values = NULL;
 	MonoObject *o;
@@ -1558,7 +1558,7 @@ ves_icall_Mono_SafeStringMarshal_GFree (void *c_str)
 ICALL_EXPORT char*
 ves_icall_Mono_SafeStringMarshal_StringToUtf8 (MonoString *s)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *res = mono_string_to_utf8_checked (s, &error);
 	mono_error_set_pending_exception (&error);
 	return res;
@@ -1963,7 +1963,7 @@ ves_icall_MonoField_GetParentType (MonoReflectionFieldHandle field, MonoBoolean 
 ICALL_EXPORT MonoObject *
 ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *obj)
 {	
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *fklass = field->klass;
 	MonoClassField *cf = field->field;
 	MonoDomain *domain = mono_object_domain (field);
@@ -2163,7 +2163,7 @@ ves_icall_MonoField_GetRawConstantValue (MonoReflectionField *rfield)
 	MonoTypeEnum def_type;
 	const char *def_value;
 	MonoType *t;
-	MonoError error;
+	ERROR_DECL (error);
 
 	mono_class_init (field->parent);
 
@@ -3245,7 +3245,7 @@ ves_icall_MonoMethod_GetGenericArguments (MonoReflectionMethodHandle ref_method,
 ICALL_EXPORT MonoObject *
 ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, MonoArray *params, MonoException **exc) 
 {
-	MonoError error;
+	ERROR_DECL (error);
 	/* 
 	 * Invoke from reflection is supposed to always be a virtual call (the API
 	 * is stupid), mono_runtime_invoke_*() calls the provided method, allowing
@@ -3488,7 +3488,7 @@ internal_execute_field_setter (MonoDomain *domain, MonoObject *this_arg, MonoArr
 ICALL_EXPORT MonoObject *
 ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, MonoArray *params, MonoArray **outArgs) 
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_object_domain (method); 
 	MonoMethod *m = method->method;
 	MonoMethodSignature *sig = mono_method_signature (m);
@@ -3607,7 +3607,7 @@ write_enum_value (char *mem, int type, guint64 value)
 ICALL_EXPORT MonoObject *
 ves_icall_System_Enum_ToObject (MonoReflectionType *enumType, guint64 value)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain; 
 	MonoClass *enumc;
 	MonoObject *res;
@@ -3645,7 +3645,7 @@ ves_icall_System_Enum_InternalHasFlag (MonoObject *a, MonoObject *b)
 ICALL_EXPORT MonoObject *
 ves_icall_System_Enum_get_value (MonoObject *eobj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *res;
 	MonoClass *enumc;
 	gpointer dst;
@@ -3673,7 +3673,7 @@ ves_icall_System_Enum_get_value (MonoObject *eobj)
 ICALL_EXPORT MonoReflectionType *
 ves_icall_System_Enum_get_underlying_type (MonoReflectionType *type)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionType *ret;
 	MonoType *etype;
 	MonoClass *klass;
@@ -4484,7 +4484,7 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHand
 	goto_if_nok (error, fail);
 
 	/*g_print ("requested type %s in %s\n", str, assembly->assembly->aname.name);*/
-	MonoError parse_error;
+	ERROR_DECL (parse_error);
 	if (!mono_reflection_parse_type_checked (str, &info, &parse_error)) {
 		g_free (str);
 		mono_reflection_free_type_info (&info);
@@ -4578,7 +4578,7 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHand
 
 	if (!type) {
 		if (throwOnError) {
-			MonoError inner_error;
+			ERROR_DECL (inner_error);
 			char *typename = mono_string_handle_to_utf8 (name, &inner_error);
 			mono_error_assert_ok (&inner_error);
 			MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
@@ -5189,7 +5189,7 @@ mono_method_get_equivalent_method (MonoMethod *method, MonoClass *klass)
 {
 	int offset = -1, i;
 	if (method->is_inflated && ((MonoMethodInflated*)method)->context.method_inst) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *result;
 		MonoMethodInflated *inflated = (MonoMethodInflated*)method;
 		//method is inflated, we should inflate it on the other class
@@ -5485,7 +5485,7 @@ image_get_type (MonoDomain *domain, MonoImage *image, MonoTableInfo *tdef, int t
 {
 	error_init (error);
 	HANDLE_FUNCTION_ENTER ();
-	MonoError klass_error;
+	ERROR_DECL (klass_error);
 	MonoClass *klass = mono_class_get_checked (image, table_idx | MONO_TOKEN_TYPE_DEF, &klass_error);
 
 	if (klass) {
@@ -5572,7 +5572,7 @@ static void
 set_class_failure_in_array (MonoArrayHandle exl, int i, MonoClass *klass)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError unboxed_error;
+	ERROR_DECL (unboxed_error);
 	error_init (&unboxed_error);
 	mono_error_set_for_class_failure (&unboxed_error, klass);
 
@@ -5809,7 +5809,7 @@ mono_memberref_is_method (MonoImage *image, guint32 token)
 		mono_metadata_decode_blob_size (sig, &sig);
 		return (*sig != 0x6);
 	} else {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *handle_class;
 
 		if (!mono_lookup_dynamic_token_class (image, token, FALSE, &handle_class, NULL, &error)) {
@@ -5882,7 +5882,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 
 	if (image_is_dynamic (image)) {
 		if ((table == MONO_TABLE_TYPEDEF) || (table == MONO_TABLE_TYPEREF)) {
-			MonoError inner_error;
+			ERROR_DECL (inner_error);
 			klass = (MonoClass *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &inner_error);
 			mono_error_cleanup (&inner_error);
 			result = klass ? &klass->byval_arg : NULL;
@@ -5890,7 +5890,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 		}
 
 		init_generic_context_from_args_handles (&context, type_args, method_args);
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		klass = (MonoClass *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, &context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		result = klass ? &klass->byval_arg : NULL;
@@ -5941,7 +5941,7 @@ module_resolve_method_token (MonoImage *image, guint32 token, MonoArrayHandle ty
 
 	if (image_is_dynamic (image)) {
 		if (table == MONO_TABLE_METHOD) {
-			MonoError inner_error;
+			ERROR_DECL (inner_error);
 			method = (MonoMethod *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &inner_error);
 			mono_error_cleanup (&inner_error);
 			goto leave;
@@ -5953,7 +5953,7 @@ module_resolve_method_token (MonoImage *image, guint32 token, MonoArrayHandle ty
 		}
 
 		init_generic_context_from_args_handles (&context, type_args, method_args);
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		method = (MonoMethod *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, &context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		goto leave;
@@ -5984,7 +5984,7 @@ ves_icall_System_Reflection_Module_ResolveMethodToken (MonoImage *image, guint32
 ICALL_EXPORT MonoString*
 ves_icall_System_Reflection_Module_ResolveStringToken (MonoImage *image, guint32 token, MonoResolveTokenError *resolve_error)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int index = mono_metadata_token_index (token);
 
 	*resolve_error = ResolveTokenError_Other;
@@ -6034,7 +6034,7 @@ module_resolve_field_token (MonoImage *image, guint32 token, MonoArrayHandle typ
 
 	if (image_is_dynamic (image)) {
 		if (table == MONO_TABLE_FIELD) {
-			MonoError inner_error;
+			ERROR_DECL (inner_error);
 			field = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &inner_error);
 			mono_error_cleanup (&inner_error);
 			goto leave;
@@ -6046,7 +6046,7 @@ module_resolve_field_token (MonoImage *image, guint32 token, MonoArrayHandle typ
 		}
 
 		init_generic_context_from_args_handles (&context, type_args, method_args);
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		field = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, &context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		goto leave;
@@ -6283,7 +6283,7 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionTypeHandle ref_
 	}
 
 	if (mono_security_core_clr_enabled ()) {
-		MonoError security_error;
+		ERROR_DECL (security_error);
 		if (!mono_security_core_clr_ensure_delegate_creation (method, &security_error)) {
 			if (throwOnBindFailure)
 				mono_error_move (error, &security_error);
@@ -6489,7 +6489,7 @@ ves_icall_Remoting_RealProxy_GetTransparentProxy (MonoObjectHandle this_obj, Mon
 ICALL_EXPORT MonoReflectionType *
 ves_icall_Remoting_RealProxy_InternalGetProxyType (MonoTransparentProxy *tp)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	g_assert (tp != NULL && mono_object_class (tp) == mono_defaults.transparent_proxy_class);
 	g_assert (tp->remote_class != NULL && tp->remote_class->proxy_class != NULL);
 	MonoReflectionType *ret = mono_type_get_object_checked (mono_object_domain (tp), &tp->remote_class->proxy_class->byval_arg, &error);
@@ -6706,7 +6706,7 @@ mono_icall_get_environment_variable_names (MonoError *error)
 ICALL_EXPORT MonoArray *
 ves_icall_System_Environment_GetEnvironmentVariableNames (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = mono_icall_get_environment_variable_names (&error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -6717,7 +6717,7 @@ static void
 mono_icall_set_environment_variable (MonoString *name, MonoString *value)
 {
 	gchar *utf8_name, *utf8_value;
-	MonoError error;
+	ERROR_DECL (error);
 
 	utf8_name = mono_string_to_utf8_checked (name, &error);	/* FIXME: this should be ascii */
 	if (mono_error_set_pending_exception (&error))
@@ -6791,7 +6791,7 @@ ves_icall_System_Environment_GetWindowsFolderPath (int folder, MonoError *error)
 static MonoArray *
 mono_icall_get_logical_drives (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gunichar2 buf [256], *ptr, *dname;
 	gunichar2 *u16;
 	guint initial_size = 127, size = 128;
@@ -6858,7 +6858,7 @@ ves_icall_System_Environment_GetLogicalDrives (void)
 ICALL_EXPORT MonoString *
 ves_icall_System_IO_DriveInfo_GetDriveFormat (MonoString *path)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gunichar2 volume_name [MAX_PATH + 1];
 	
 	if (mono_w32file_get_volume_information (mono_string_chars (path), NULL, 0, NULL, NULL, NULL, volume_name, MAX_PATH + 1) == FALSE)
@@ -7501,7 +7501,7 @@ mono_ArgIterator_IntGetNextArgType (MonoArgIterator *iter)
 ICALL_EXPORT MonoObject*
 mono_TypedReference_ToObject (MonoTypedRef* tref)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *result = NULL;
 	if (MONO_TYPE_IS_REFERENCE (tref->type)) {
 		MonoObject** objp = (MonoObject **)tref->value;
@@ -7755,7 +7755,7 @@ mono_type_from_blob_type (MonoType *type, MonoTypeEnum blob_type, MonoType *real
 ICALL_EXPORT MonoObject*
 property_info_get_default_value (MonoReflectionProperty *property)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType blob_type;
 	MonoProperty *prop = property->property;
 	MonoType *type = get_property_type (prop);

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -765,7 +765,7 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error)
 MonoImage*
 mono_image_load_module (MonoImage *image, int idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoImage *result = mono_image_load_module_checked (image, idx, &error);
 	mono_error_assert_ok (&error);
 	return result;
@@ -2499,7 +2499,7 @@ done:
 MonoImage*
 mono_image_load_file_for_image (MonoImage *image, int fileidx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoImage *result = mono_image_load_file_for_image_checked (image, fileidx, &error);
 	mono_error_assert_ok (&error);
 	return result;

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -235,7 +235,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 	 */
 	sig_type = (MonoType *)find_cached_memberref_sig (image, cols [MONO_MEMBERREF_SIGNATURE]);
 	if (!sig_type) {
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		sig_type = mono_metadata_parse_type_checked (image, NULL, 0, FALSE, ptr, &ptr, &inner_error);
 		if (sig_type == NULL) {
 			mono_error_set_field_load (error, klass, fname, "Could not parse field '%s' signature %08x due to: %s", fname, token, mono_error_get_message (&inner_error));
@@ -265,7 +265,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 MonoClassField*
 mono_field_from_token (MonoImage *image, guint32 token, MonoClass **retklass, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClassField *res = mono_field_from_token_checked (image, token, retklass, context, &error);
 	g_assert (mono_error_ok (&error));
 	return res;
@@ -285,7 +285,7 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 		MonoClass *handle_class;
 
 		*retklass = NULL;
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		result = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, TRUE, &handle_class, context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		// This checks the memberref type as well
@@ -318,7 +318,7 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 		if (retklass)
 			*retklass = k;
 		if (mono_class_has_failure (k)) {
-			MonoError causedby_error;
+			ERROR_DECL (causedby_error);
 			error_init (&causedby_error);
 			mono_error_set_for_class_failure (&causedby_error, k);
 			mono_error_set_bad_image (error, image, "Could not resolve field token 0x%08x, due to: %s", token, mono_error_get_message (&causedby_error));
@@ -649,7 +649,7 @@ fail:
 MonoMethodSignature*
 mono_method_get_signature_full (MonoMethod *method, MonoImage *image, guint32 token, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, context, &error);
 	mono_error_cleanup (&error);
 	return res;
@@ -751,7 +751,7 @@ mono_method_get_signature_checked (MonoMethod *method, MonoImage *image, guint32
 MonoMethodSignature*
 mono_method_get_signature (MonoMethod *method, MonoImage *image, guint32 token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, NULL, &error);
 	mono_error_cleanup (&error);
 	return res;
@@ -1741,7 +1741,7 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 MonoMethod *
 mono_get_method (MonoImage *image, guint32 token, MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *result = mono_get_method_checked (image, token, klass, NULL, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1754,7 +1754,7 @@ MonoMethod *
 mono_get_method_full (MonoImage *image, guint32 token, MonoClass *klass,
 		      MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *result = mono_get_method_checked (image, token, klass, context, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1928,7 +1928,7 @@ MonoMethod *
 mono_get_method_constrained (MonoImage *image, guint32 token, MonoClass *constrained_class,
 			     MonoGenericContext *context, MonoMethod **cil_method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *result = mono_get_method_constrained_checked (image, token, constrained_class, context, cil_method, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -2579,7 +2579,7 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 MonoMethodSignature*
 mono_method_signature (MonoMethod *m)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodSignature *sig;
 
 	sig = mono_method_signature_checked (m, &error);
@@ -2695,7 +2695,7 @@ mono_method_get_header_checked (MonoMethod *method, MonoError *error)
 MonoMethodHeader*
 mono_method_get_header (MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
 	mono_error_cleanup (&error);
 	return header;

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -177,7 +177,7 @@ create_names_array_idx_dynamic (const guint16 *names, int ml, MonoError *error)
 MonoBoolean
 ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData *this_obj, MonoString *name, gint32 calendar_index)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain;
 	const DateTimeFormatEntry *dfe;
 	const CultureInfoNameEntry *ne;
@@ -257,7 +257,7 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 void
 ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *this_obj, gint32 datetime_index)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain;
 	const DateTimeFormatEntry *dfe;
 
@@ -297,7 +297,7 @@ ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *t
 void
 ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInfo* number, gint32 number_index)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain;
 	const NumberFormatEntry *nfe;
 
@@ -606,7 +606,7 @@ MonoBoolean
 ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_lcid (MonoCultureInfo *this_obj,
 		gint lcid)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const CultureInfoEntry *ci;
 	
 	ci = culture_info_entry_from_lcid (lcid);
@@ -624,7 +624,7 @@ MonoBoolean
 ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (MonoCultureInfo *this_obj,
 		MonoString *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const CultureInfoNameEntry *ne;
 	char *n;
 	
@@ -666,7 +666,7 @@ MonoBoolean
 ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_lcid (MonoRegionInfo *this_obj,
 		gint lcid)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const RegionInfoEntry *ri;
 	
 	ri = region_info_entry_from_lcid (lcid);
@@ -682,7 +682,7 @@ MonoBoolean
 ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (MonoRegionInfo *this_obj,
 		MonoString *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const RegionInfoNameEntry *ne;
 	char *n;
 	
@@ -708,7 +708,7 @@ MonoArray*
 ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean neutral,
 		MonoBoolean specific, MonoBoolean installed)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *ret;
 	MonoClass *klass;
 	MonoCultureInfo *culture;
@@ -777,7 +777,7 @@ int ves_icall_System_Globalization_CompareInfo_internal_compare (MonoCompareInfo
 
 void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo *this_obj, MonoSortKey *key, MonoString *source, gint32 options)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr;
 	gint32 keylen, i;
 

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -57,7 +57,7 @@ mono_marshal_realloc_co_task_mem (gpointer ptr, size_t size)
 gpointer
 ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi (MonoString *string)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char* tres, *ret;
 	size_t len;
 	tres = mono_string_to_utf8_checked (string, &error);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -300,7 +300,7 @@ mono_object_isinst_icall (MonoObject *obj, MonoClass *klass)
 			return obj;
 	}
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *result = mono_object_isinst_checked (obj, klass, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -309,7 +309,7 @@ mono_object_isinst_icall (MonoObject *obj, MonoClass *klass)
 static MonoString*
 ves_icall_mono_string_from_utf16 (gunichar2 *data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_utf16_checked (data, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -318,7 +318,7 @@ ves_icall_mono_string_from_utf16 (gunichar2 *data)
 static char*
 ves_icall_mono_string_to_utf8 (MonoString *str)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *result = mono_string_to_utf8_checked (str, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -328,7 +328,7 @@ static MonoString*
 ves_icall_string_new_wrapper (const char *text)
 {
 	if (text) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoString *res = mono_string_new_checked (mono_domain_get (), text, &error);
 		mono_error_set_pending_exception (&error);
 		return res;
@@ -440,7 +440,7 @@ gpointer
 mono_delegate_to_ftnptr (MonoDelegate *delegate_raw)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoDelegate, delegate);
 	gpointer result = mono_delegate_handle_to_ftnptr (delegate, &error);
 	mono_error_set_pending_exception (&error);
@@ -579,7 +579,7 @@ mono_marshal_use_aot_wrappers (gboolean use)
 static void
 parse_unmanaged_function_pointer_attr (MonoClass *klass, MonoMethodPInvoke *piinfo)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
 	MonoReflectionUnmanagedFunctionPointerAttribute *attr;
 
@@ -615,7 +615,7 @@ MonoDelegate*
 mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDelegateHandle result = mono_ftnptr_to_delegate_handle (klass, ftn, &error);
 	mono_error_set_pending_exception (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -736,7 +736,7 @@ mono_delegate_free_ftnptr (MonoDelegate *delegate)
 static MonoString *
 mono_string_from_byvalstr (const char *data, int max_len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	int len = 0;
 
@@ -755,7 +755,7 @@ mono_string_from_byvalstr (const char *data, int max_len)
 static MonoString *
 mono_string_from_byvalwstr (gunichar2 *data, int max_len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *res = NULL;
 	MonoDomain *domain = mono_domain_get ();
 	int len = 0;
@@ -792,7 +792,7 @@ mono_array_to_lparray (MonoArray *array)
 
 	int i = 0;
 	MonoClass *klass;
-	MonoError error;
+	ERROR_DECL (error);
 #endif
 
 	if (!array)
@@ -929,7 +929,7 @@ mono_string_builder_new (int starting_string_length)
 	static MonoMethod *sb_ctor;
 	static void *args [1];
 
-	MonoError error;
+	ERROR_DECL (error);
 	int initial_len = starting_string_length;
 
 	if (initial_len < 0)
@@ -1059,7 +1059,7 @@ mono_string_utf16_to_builder (MonoStringBuilder *sb, gunichar2 *text)
 gchar*
 mono_string_builder_to_utf8 (MonoStringBuilder *sb)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	GError *gerror = NULL;
 	glong byte_count;
 	if (!sb)
@@ -1110,7 +1110,7 @@ mono_string_builder_to_utf8 (MonoStringBuilder *sb)
 gunichar2*
 mono_string_builder_to_utf16 (MonoStringBuilder *sb)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (!sb)
 		return NULL;
@@ -1158,7 +1158,7 @@ mono_string_builder_to_utf16 (MonoStringBuilder *sb)
 static gpointer
 mono_string_to_utf8str (MonoString *s)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *result = mono_string_to_utf8_checked (s, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1184,7 +1184,7 @@ mono_string_to_ansibstr (MonoString *string_obj)
 void
 mono_string_to_byvalstr (gpointer dst, MonoString *src, int size)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *s;
 	int len;
 
@@ -1239,7 +1239,7 @@ mono_string_to_byvalwstr (gpointer dst, MonoString *src, int size)
 static MonoString*
 mono_string_new_len_wrapper (const char *text, guint length)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_new_len_checked (mono_domain_get (), text, length, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -2015,7 +2015,7 @@ offset_of_first_nonstatic_field (MonoClass *klass)
 static gboolean
 get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
 	MonoCustomAttrEntry *attr;
 	int aindex;
@@ -2462,7 +2462,7 @@ mono_marshal_emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
 static MonoAsyncResult *
 mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMulticastDelegate *mcast_delegate;
 	MonoClass *klass;
 	MonoMethod *method;
@@ -2878,7 +2878,7 @@ mono_marshal_method_from_wrapper (MonoMethod *wrapper)
 	case MONO_WRAPPER_XDOMAIN_INVOKE:
 		m = info->d.remoting.method;
 		if (wrapper->is_inflated) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoMethod *result;
 			/*
 			 * A method cannot be inflated and a wrapper at the same time, so the wrapper info
@@ -2892,7 +2892,7 @@ mono_marshal_method_from_wrapper (MonoMethod *wrapper)
 	case MONO_WRAPPER_SYNCHRONIZED:
 		m = info->d.synchronized.method;
 		if (wrapper->is_inflated) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoMethod *result;
 			result = mono_class_inflate_generic_method_checked (m, mono_method_get_context (wrapper), &error);
 			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
@@ -2970,7 +2970,7 @@ mono_wrapper_info_create (MonoMethodBuilder *mb, WrapperSubtype subtype)
 static MonoClass*
 get_wrapper_target_class (MonoImage *image)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 
 	/*
@@ -3031,7 +3031,7 @@ check_generic_wrapper_cache (GHashTable *cache, MonoMethod *orig_method, gpointe
 	 */
 	def = mono_marshal_find_in_cache (cache, def_key);
 	if (def) {
-		MonoError error;
+		ERROR_DECL (error);
 		inst = mono_class_inflate_generic_method_checked (def, ctx, &error);
 		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 		/* Cache it */
@@ -3051,7 +3051,7 @@ check_generic_wrapper_cache (GHashTable *cache, MonoMethod *orig_method, gpointe
 static MonoMethod*
 cache_generic_wrapper (GHashTable *cache, MonoMethod *orig_method, MonoMethod *def, MonoGenericContext *ctx, gpointer key)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *inst, *res;
 
 	/*
@@ -3073,7 +3073,7 @@ cache_generic_wrapper (GHashTable *cache, MonoMethod *orig_method, MonoMethod *d
 static MonoMethod*
 check_generic_delegate_wrapper_cache (GHashTable *cache, MonoMethod *orig_method, MonoMethod *def_method, MonoGenericContext *ctx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *res;
 	MonoMethod *inst, *def;
 
@@ -3109,7 +3109,7 @@ check_generic_delegate_wrapper_cache (GHashTable *cache, MonoMethod *orig_method
 static MonoMethod*
 cache_generic_delegate_wrapper (GHashTable *cache, MonoMethod *orig_method, MonoMethod *def, MonoGenericContext *ctx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *inst, *res;
 	WrapperInfo *ginfo, *info;
 
@@ -3219,7 +3219,7 @@ mono_marshal_get_delegate_begin_invoke (MonoMethod *method)
 static MonoObject *
 mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoAsyncResult *ares;
 	MonoMethod *method = NULL;
@@ -3295,7 +3295,7 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 
 	if (exc) {
 		if (((MonoException*)exc)->stack_trace) {
-			MonoError inner_error;
+			ERROR_DECL (inner_error);
 			char *strace = mono_string_to_utf8_checked (((MonoException*)exc)->stack_trace, &inner_error);
 			if (is_ok (&inner_error)) {
 				char  *tmp;
@@ -3535,7 +3535,7 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 	if (callvirt) {
 		subtype = WRAPPER_SUBTYPE_DELEGATE_INVOKE_VIRTUAL;
 		if (target_method->is_inflated) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoType *target_type;
 
 			g_assert (method->signature->hasthis);
@@ -3784,7 +3784,7 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 	if (!ctx) {
 		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
 	} else {
-		MonoError error;
+		ERROR_DECL (error);
 		mono_mb_emit_op (mb, CEE_CALLVIRT, mono_class_inflate_generic_method_checked (method, &container->context, &error));
 		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 	}
@@ -4021,7 +4021,7 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 
 	/* to make it work with our special string constructors */
 	if (!string_dummy) {
-		MonoError error;
+		ERROR_DECL (error);
 		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, NULL, "Marshal Dummy String");
 		string_dummy = mono_string_new_checked (mono_get_root_domain (), "dummy", &error);
 		mono_error_assert_ok (&error);
@@ -4792,7 +4792,7 @@ emit_marshal_custom (EmitMarshalContext *m, int argnum, MonoType *t,
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
 	return conv_arg;
 #else
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *mtype;
 	MonoClass *mklass;
 	static MonoClass *ICustomMarshaler = NULL;
@@ -8854,7 +8854,7 @@ mono_marshal_set_callconv_from_modopt (MonoMethod *method, MonoMethodSignature *
 	/* Why is this a modopt ? */
 	if (sig->ret && sig->ret->num_mods) {
 		for (i = 0; i < sig->ret->num_mods; ++i) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoClass *cmod_class = mono_class_get_checked (method->klass->image, sig->ret->modifiers [i].token, &error);
 			g_assert (mono_error_ok (&error));
 			if ((cmod_class->image == mono_defaults.corlib) && !strcmp (cmod_class->name_space, "System.Runtime.CompilerServices")) {
@@ -8967,7 +8967,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 			gint32 call_conv;
 			gint32 charset = 0;
 			MonoBoolean set_last_error = 0;
-			MonoError error;
+			ERROR_DECL (error);
 
 			mono_reflection_create_custom_attr_data_args (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, &error);
 			g_assert (mono_error_ok (&error));
@@ -9044,7 +9044,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 gpointer
 mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *method;
 	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
@@ -9260,7 +9260,7 @@ mono_marshal_get_castclass_with_cache (void)
 static MonoObject *
 mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *isinst = mono_object_isinst_checked (obj, klass, &error);
 	if (mono_error_set_pending_exception (&error))
 		return NULL;
@@ -9529,7 +9529,7 @@ mono_marshal_get_synchronized_inner_wrapper (MonoMethod *method)
 	res = mono_mb_create (mb, sig, 0, info);
 	mono_mb_free (mb);
 	if (ctx) {
-		MonoError error;
+		ERROR_DECL (error);
 		res = mono_class_inflate_generic_method_checked (res, ctx, &error);
 		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 	}
@@ -9683,7 +9683,7 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 		mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 
 	if (ctx) {
-		MonoError error;
+		ERROR_DECL (error);
 		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, &error), NULL);
 		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 	} else {
@@ -10811,7 +10811,7 @@ mono_marshal_get_array_accessor_wrapper (MonoMethod *method)
 		mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 
 	if (ctx) {
-		MonoError error;
+		ERROR_DECL (error);
 		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, &error), NULL);
 		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 	} else {
@@ -10870,7 +10870,7 @@ mono_marshal_alloc (gsize size, MonoError *error)
 static void*
 ves_icall_marshal_alloc (gsize size)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	void *ret = mono_marshal_alloc (size, &error);
 	if (!mono_error_ok (&error)) {
 		mono_error_set_pending_exception (&error);
@@ -10927,7 +10927,7 @@ mono_marshal_string_to_utf16_copy (MonoString *s)
 	if (s == NULL) {
 		return NULL;
 	} else {
-		MonoError error;
+		ERROR_DECL (error);
 		gunichar2 *res = (gunichar2 *)mono_marshal_alloc ((mono_string_length (s) * 2) + 2, &error);
 		if (!mono_error_ok (&error)) {
 			mono_error_set_pending_exception (&error);
@@ -11051,7 +11051,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi (char *ptr, Mon
 MonoString *
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (char *ptr, gint32 len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = NULL;
 	error_init (&error);
 	if (ptr == NULL)
@@ -11065,7 +11065,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (char *ptr,
 MonoString *
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (guint16 *ptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *res = NULL;
 	MonoDomain *domain = mono_domain_get (); 
 	int len = 0;
@@ -11088,7 +11088,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (guint16 *ptr)
 MonoString *
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (guint16 *ptr, gint32 len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *res = NULL;
 	MonoDomain *domain = mono_domain_get (); 
 
@@ -11148,7 +11148,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_SizeOf (MonoReflectionTypeHandl
 void
 ves_icall_System_Runtime_InteropServices_Marshal_StructureToPtr (MonoObject *obj, gpointer dst, MonoBoolean delete_old)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *method;
 	gpointer pa [3];
 
@@ -11186,7 +11186,7 @@ void
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructure (gpointer src, MonoObject *dst)
 {
 	MonoType *t;
-	MonoError error;
+	ERROR_DECL (error);
 
 	MONO_CHECK_ARG_NULL (src,);
 	MONO_CHECK_ARG_NULL (dst,);
@@ -11213,7 +11213,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructure (gpointer src, M
 MonoObject *
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructure_type (gpointer src, MonoReflectionType *type)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	MonoDomain *domain = mono_domain_get (); 
 	MonoObject *res;
@@ -11303,7 +11303,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_OffsetOf (MonoReflectionTypeHan
 gpointer
 ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi (MonoString *string)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *ret = mono_string_to_utf8_checked (string, &error);
 	mono_error_set_pending_exception (&error);
 	return ret;
@@ -11939,7 +11939,7 @@ mono_marshal_type_size (MonoType *type, MonoMarshalSpec *mspec, guint32 *align,
 gpointer
 mono_marshal_asany (MonoObject *o, MonoMarshalNative string_encoding, int param_attrs)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *t;
 	MonoClass *klass;
 
@@ -12027,7 +12027,7 @@ mono_marshal_asany (MonoObject *o, MonoMarshalNative string_encoding, int param_
 void
 mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *t;
 	MonoClass *klass;
 

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -1783,7 +1783,7 @@ is_valid_ser_string (VerifyContext *ctx, const char **_ptr, const char *end)
 static MonoClass*
 get_enum_by_encoded_name (VerifyContext *ctx, const char **_ptr, const char *end)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *type;
 	MonoClass *klass;
 	const char *str_start = NULL;
@@ -1955,7 +1955,7 @@ handle_enum:
 static gboolean
 is_valid_cattr_content (VerifyContext *ctx, MonoMethod *ctor, const char *ptr, guint32 size)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	unsigned prolog = 0;
 	const char *end;
 	MonoMethodSignature *sig;
@@ -2405,7 +2405,7 @@ static void
 verify_typeref_table (VerifyContext *ctx)
 {
 	MonoTableInfo *table = &ctx->image->tables [MONO_TABLE_TYPEREF];
-	MonoError error;
+	ERROR_DECL (error);
 	guint32 i;
 
 	for (i = 0; i < table->rows; ++i) {
@@ -2944,7 +2944,7 @@ verify_cattr_table (VerifyContext *ctx)
 static void
 verify_cattr_table_full (VerifyContext *ctx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoTableInfo *table = &ctx->image->tables [MONO_TABLE_CUSTOMATTRIBUTE];
 	MonoMethod *ctor;
 	const char *ptr;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1451,7 +1451,7 @@ mono_metadata_parse_array_internal (MonoImage *m, MonoGenericContainer *containe
 MonoArrayType *
 mono_metadata_parse_array (MonoImage *m, const char *ptr, const char **rptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArrayType *ret = mono_metadata_parse_array_internal (m, NULL, FALSE, ptr, rptr, &error);
 	mono_error_cleanup (&error);
 
@@ -1856,7 +1856,7 @@ MonoType*
 mono_metadata_parse_type (MonoImage *m, MonoParseTypeMode mode, short opt_attrs,
 			  const char *ptr, const char **rptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType * type = mono_metadata_parse_type_internal (m, NULL, opt_attrs, FALSE, ptr, rptr, &error);
 	mono_error_cleanup (&error);
 	return type;
@@ -1938,7 +1938,7 @@ mono_metadata_get_param_attrs (MonoImage *m, int def, int param_count)
 MonoMethodSignature*
 mono_metadata_parse_signature (MonoImage *image, guint32 token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodSignature *ret;
 	ret = mono_metadata_parse_signature_checked (image, token, &error);
 	mono_error_cleanup (&error);
@@ -2237,7 +2237,7 @@ mono_metadata_parse_method_signature (MonoImage *m, int def, const char *ptr, co
 	 * Use mono_metadata_parse_method_signature_full instead.
 	 * It's ok to asser on failure as we no longer use it.
 	 */
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodSignature *ret;
 	ret = mono_metadata_parse_method_signature_full (m, NULL, def, ptr, rptr, &error);
 	g_assert (mono_error_ok (&error));
@@ -4089,7 +4089,7 @@ fail:
 MonoMethodHeader *
 mono_metadata_parse_mh (MonoImage *m, const char *ptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header = mono_metadata_parse_mh_full (m, NULL, ptr, &error);
 	mono_error_cleanup (&error);
 	return header;
@@ -4227,7 +4227,7 @@ mono_method_header_get_clauses (MonoMethodHeader *header, MonoMethod *method, gp
 MonoType *
 mono_metadata_parse_field_type (MonoImage *m, short field_flags, const char *ptr, const char **rptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType * type = mono_metadata_parse_type_internal (m, NULL, field_flags, FALSE, ptr, rptr, &error);
 	mono_error_cleanup (&error);
 	return type;
@@ -4246,7 +4246,7 @@ mono_metadata_parse_field_type (MonoImage *m, short field_flags, const char *ptr
 MonoType *
 mono_metadata_parse_param (MonoImage *m, const char *ptr, const char **rptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType * type = mono_metadata_parse_type_internal (m, NULL, 0, FALSE, ptr, rptr, &error);
 	mono_error_cleanup (&error);
 	return type;
@@ -4579,7 +4579,7 @@ mono_metadata_interfaces_from_typedef_full (MonoImage *meta, guint32 index, Mono
 MonoClass**
 mono_metadata_interfaces_from_typedef (MonoImage *meta, guint32 index, guint *count)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass **interfaces = NULL;
 	gboolean rv;
 
@@ -5844,7 +5844,7 @@ mono_metadata_implmap_from_method (MonoImage *meta, guint32 method_idx)
 MonoType *
 mono_type_create_from_typespec (MonoImage *image, guint32 type_spec)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *type = mono_type_create_from_typespec_checked (image, type_spec, &error);
 	if (!type)
 		 g_error ("Could not create typespec %x due to %s", type_spec, mono_error_get_message (&error));

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -45,7 +45,7 @@ static MonoVTable *monolist_item_vtable = NULL;
 MonoMList*
 mono_mlist_alloc (MonoObject *data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMList *result = mono_mlist_alloc_checked (data, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -171,7 +171,7 @@ mono_mlist_last (MonoMList* list)
 MonoMList*
 mono_mlist_prepend (MonoMList* list, MonoObject *data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMList *result = mono_mlist_prepend_checked (list, data, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -209,7 +209,7 @@ mono_mlist_prepend_checked (MonoMList* list, MonoObject *data, MonoError *error)
 MonoMList*
 mono_mlist_append (MonoMList* list, MonoObject *data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMList *result = mono_mlist_append_checked (list, data, &error);
 	mono_error_cleanup (&error);
 	return result;

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1318,7 +1318,7 @@ void*
 mono_perfcounter_get_impl (MonoString* category, MonoString* counter, MonoString* instance,
 		MonoString* machine, int *type, MonoBoolean *custom)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const CategoryDesc *cdesc;
 	void *result = NULL;
 	/* no support for counters on other machines */
@@ -1421,7 +1421,7 @@ mono_perfcounter_category_del (MonoString *name)
 MonoString*
 mono_perfcounter_category_help (MonoString *category, MonoString *machine)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = NULL;
 	const CategoryDesc *cdesc;
 	error_init (&error);
@@ -1489,7 +1489,7 @@ typedef struct {
 MonoBoolean
 mono_perfcounter_create (MonoString *category, MonoString *help, int type, MonoArray *items)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int result = FALSE;
 	int i, size;
 	int num_counters = mono_array_length (items);
@@ -1573,7 +1573,7 @@ failure:
 int
 mono_perfcounter_instance_exists (MonoString *instance, MonoString *category, MonoString *machine)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const CategoryDesc *cdesc;
 	SharedInstance *sinst;
 	char *name;
@@ -1604,7 +1604,7 @@ mono_perfcounter_instance_exists (MonoString *instance, MonoString *category, Mo
 MonoArray*
 mono_perfcounter_category_names (MonoString *machine)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 	MonoArray *res;
 	MonoDomain *domain = mono_domain_get ();
@@ -1646,7 +1646,7 @@ leave:
 MonoArray*
 mono_perfcounter_counter_names (MonoString *category, MonoString *machine)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 	SharedCategory *scat;
 	const CategoryDesc *cdesc;
@@ -1844,7 +1844,7 @@ get_custom_instances (MonoString *category, MonoError *error)
 MonoArray*
 mono_perfcounter_instance_names (MonoString *category, MonoString *machine)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const CategoryDesc* cat;
 	MonoArray *result = NULL;
 	if (mono_string_compare_ascii (machine, ".")) {

--- a/mono/metadata/mono-route.c
+++ b/mono/metadata/mono-route.c
@@ -23,7 +23,7 @@
 
 extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfaceProperties_ParseRouteInfo_internal(MonoString *iface, MonoArray **gw_addr_list)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	size_t needed;
 	in_addr_t in;
 	int mib[6];

--- a/mono/metadata/mono-security-windows-uwp.c
+++ b/mono/metadata/mono-security-windows-uwp.c
@@ -34,7 +34,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetCurrentToken (MonoError *
 MonoArray*
 ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetTokenInformation");
@@ -50,7 +50,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 gpointer
 ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken (gpointer token)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("DuplicateToken");
@@ -66,7 +66,7 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken (
 gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_SetCurrentToken (gpointer token)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("ImpersonateLoggedOnUser");
@@ -82,7 +82,7 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_SetCurrentToken 
 gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_RevertToSelf (void)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("RevertToSelf");
@@ -98,7 +98,7 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_RevertToSelf (vo
 gint32
 mono_security_win_get_token_name (gpointer token, gunichar2 ** uniname)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetTokenInformation");
@@ -114,7 +114,7 @@ mono_security_win_get_token_name (gpointer token, gunichar2 ** uniname)
 gboolean
 mono_security_win_is_machine_protected (gunichar2 *path)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetNamedSecurityInfo, LocalFree");
@@ -130,7 +130,7 @@ mono_security_win_is_machine_protected (gunichar2 *path)
 gboolean
 mono_security_win_is_user_protected (gunichar2 *path)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetNamedSecurityInfo, LocalFree");
@@ -146,7 +146,7 @@ mono_security_win_is_user_protected (gunichar2 *path)
 gboolean
 mono_security_win_protect_machine (gunichar2 *path)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("BuildTrusteeWithSid, SetEntriesInAcl, SetNamedSecurityInfo, LocalFree, FreeSid");
@@ -162,7 +162,7 @@ mono_security_win_protect_machine (gunichar2 *path)
 gboolean
 mono_security_win_protect_user (gunichar2 *path)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("BuildTrusteeWithSid, SetEntriesInAcl, SetNamedSecurityInfo, LocalFree");

--- a/mono/metadata/mono-security-windows.c
+++ b/mono/metadata/mono-security-windows.c
@@ -152,7 +152,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetUserToken (MonoStringHand
 MonoArray*
 ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *array = NULL;
 	MonoDomain *domain = mono_domain_get ();
 

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -329,7 +329,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetUserToken (MonoStringHand
 MonoArray*
 ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *array = NULL;
 	MonoDomain *domain = mono_domain_get ();
 
@@ -609,14 +609,14 @@ static MonoImage *system_security_assembly = NULL;
 void
 ves_icall_System_Security_SecureString_DecryptInternal (MonoArray *data, MonoObject *scope)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	invoke_protected_memory_method (data, scope, FALSE, &error);
 	mono_error_set_pending_exception (&error);
 }
 void
 ves_icall_System_Security_SecureString_EncryptInternal (MonoArray* data, MonoObject *scope)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	invoke_protected_memory_method (data, scope, TRUE, &error);
 	mono_error_set_pending_exception (&error);
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -96,7 +96,7 @@ static mono_mutex_t ldstr_section;
 void
 mono_runtime_object_init (MonoObject *this_obj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_runtime_object_init_checked (this_obj, &error);
 	mono_error_assert_ok (&error);
 }
@@ -277,7 +277,7 @@ get_type_init_exception_for_vtable (MonoVTable *vtable)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = vtable->domain;
 	MonoClass *klass = vtable->klass;
 	MonoException *ex;
@@ -318,7 +318,7 @@ void
 mono_runtime_class_init (MonoVTable *vtable)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
-	MonoError error;
+	ERROR_DECL (error);
 
 	mono_runtime_class_init_full (vtable, &error);
 	mono_error_assert_ok (&error);
@@ -663,7 +663,7 @@ mono_set_always_build_imt_trampolines (gboolean value)
 gpointer 
 mono_compile_method (MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer result = mono_compile_method_checked (method, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -1011,7 +1011,7 @@ mono_class_insecure_overlapping (MonoClass *klass)
 MonoString*
 ves_icall_string_alloc (int length)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, &error);
 	mono_error_set_pending_exception (&error);
 
@@ -1132,7 +1132,7 @@ field_is_special_static (MonoClass *fklass, MonoClassField *field)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *ainfo;
 	int i;
 	ainfo = mono_custom_attrs_from_field_checked (fklass, field, &error);
@@ -1794,7 +1794,7 @@ static MonoVTable *mono_class_create_runtime_vtable (MonoDomain *domain, MonoCla
 MonoVTable *
 mono_class_vtable (MonoDomain *domain, MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoVTable* vtable = mono_class_vtable_checked (domain, klass, &error);
 	mono_error_cleanup (&error);
 	return vtable;
@@ -2810,7 +2810,7 @@ mono_object_get_virtual_method (MonoObject *obj_raw, MonoMethod *method)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	MonoMethod *result = mono_object_handle_get_virtual_method (obj, method, &error);
 	mono_error_assert_ok (&error);
@@ -2964,7 +2964,7 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 MonoObject*
 mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *res;
 	if (exc) {
 		res = mono_runtime_try_invoke (method, obj, params, exc, &error);
@@ -3138,7 +3138,7 @@ mono_method_get_unmanaged_thunk (MonoMethod *method)
 	MONO_REQ_GC_NEUTRAL_MODE;
 	MONO_REQ_API_ENTRYPOINT;
 
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res;
 
 	g_assert (!mono_threads_is_coop_enabled ());
@@ -3394,7 +3394,7 @@ mono_field_get_value (MonoObject *obj, MonoClassField *field, void *value)
 MonoObject *
 mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObject *obj)
 {	
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject* result = mono_field_get_value_object_checked (domain, field, obj, &error);
 	mono_error_assert_ok (&error);
 	return result;
@@ -3666,7 +3666,7 @@ mono_field_static_get_value (MonoVTable *vt, MonoClassField *field, void *value)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	mono_field_static_get_value_checked (vt, field, value, &error);
 	mono_error_cleanup (&error);
 }
@@ -3717,7 +3717,7 @@ mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	do_runtime_invoke (prop->set, obj, params, exc, &error);
 	if (exc && *exc == NULL && !mono_error_ok (&error)) {
 		*exc = (MonoObject*) mono_error_convert_to_exception (&error);
@@ -3772,7 +3772,7 @@ mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *val = do_runtime_invoke (prop->get, obj, params, exc, &error);
 	if (exc && *exc == NULL && !mono_error_ok (&error)) {
 		*exc = (MonoObject*) mono_error_convert_to_exception (&error);
@@ -4008,7 +4008,7 @@ mono_runtime_delegate_invoke (MonoObject *delegate, void **params, MonoObject **
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	if (exc) {
 		MonoObject *result = mono_runtime_delegate_try_invoke (delegate, params, exc, &error);
 		if (*exc) {
@@ -4091,7 +4091,7 @@ mono_runtime_get_main_args (void)
 {
 	HANDLE_FUNCTION_ENTER ();
 	MONO_REQ_GC_UNSAFE_MODE;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArrayHandle result = MONO_HANDLE_NEW (MonoArray, NULL);
 	error_init (&error);
 	MonoArrayHandle arg_array = mono_runtime_get_main_args_handle (&error);
@@ -4202,7 +4202,7 @@ prepare_run_main (MonoMethod *method, int argc, char *argv[])
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 	MonoArray *args = NULL;
 	MonoDomain *domain = mono_domain_get ();
@@ -4309,7 +4309,7 @@ mono_runtime_run_main (MonoMethod *method, int argc, char* argv[],
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *args = prepare_run_main (method, argc, argv);
 	int res;
 	if (exc) {
@@ -4368,7 +4368,7 @@ serialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 {
 	static MonoMethod *serialize_method;
 
-	MonoError error;
+	ERROR_DECL (error);
 	void *params [1];
 	MonoObject *array;
 
@@ -4406,7 +4406,7 @@ deserialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 
 	static MonoMethod *deserialize_method;
 
-	MonoError error;
+	ERROR_DECL (error);
 	void *params [1];
 	MonoObject *result;
 
@@ -4555,7 +4555,7 @@ static void
 call_unhandled_exception_delegate (MonoDomain *domain, MonoObject *delegate, MonoObject *exc) {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *e = NULL;
 	gpointer pa [2];
 	MonoDomain *current_domain = mono_domain_get ();
@@ -4570,7 +4570,7 @@ call_unhandled_exception_delegate (MonoDomain *domain, MonoObject *delegate, Mon
 		exc = mono_object_xdomain_representation (exc, domain, &error);
 		if (!exc) {
 			if (!is_ok (&error)) {
-				MonoError inner_error;
+				ERROR_DECL (inner_error);
 				MonoException *serialization_exc = mono_error_convert_to_exception (&error);
 				exc = mono_object_xdomain_representation ((MonoObject*)serialization_exc, domain, &inner_error);
 				mono_error_assert_ok (&inner_error);
@@ -4648,7 +4648,7 @@ mono_runtime_unhandled_exception_policy_get (void) {
 void
 mono_unhandled_exception (MonoObject *exc_raw)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, exc);
 	error_init (&error);
@@ -4743,7 +4743,7 @@ mono_runtime_exec_managed_code (MonoDomain *domain,
 				MonoMainThreadFunc main_func,
 				gpointer main_args)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_thread_create_checked (domain, main_func, main_args, &error);
 	mono_error_assert_ok (&error);
 
@@ -4759,7 +4759,7 @@ prepare_thread_to_exec_main (MonoDomain *domain, MonoMethod *method)
 
 	if (!domain->entry_assembly) {
 		gchar *str;
-		MonoError error;
+		ERROR_DECL (error);
 		MonoAssembly *assembly;
 
 		assembly = method->klass->image->assembly;
@@ -4781,7 +4781,7 @@ prepare_thread_to_exec_main (MonoDomain *domain, MonoMethod *method)
 		}
 	}
 
-	MonoError cattr_error;
+	ERROR_DECL (cattr_error);
 	cinfo = mono_custom_attrs_from_method_checked (method, &cattr_error);
 	mono_error_cleanup (&cattr_error); /* FIXME warn here? */
 	if (cinfo) {
@@ -4849,7 +4849,7 @@ do_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 
 	/* FIXME: check signature of method */
 	if (mono_method_signature (method)->ret->type == MONO_TYPE_I4) {
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		MonoObject *res;
 		res = mono_runtime_try_invoke (method, NULL, pa, exc, &inner_error);
 		if (*exc == NULL && !mono_error_ok (&inner_error))
@@ -4864,7 +4864,7 @@ do_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 
 		mono_environment_exitcode_set (rval);
 	} else {
-		MonoError inner_error;
+		ERROR_DECL (inner_error);
 		mono_runtime_try_invoke (method, NULL, pa, exc, &inner_error);
 		if (*exc == NULL && !mono_error_ok (&inner_error))
 			*exc = (MonoObject*) mono_error_convert_to_exception (&inner_error);
@@ -4894,7 +4894,7 @@ do_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 int
 mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	prepare_thread_to_exec_main (mono_object_domain (args), method);
 	if (exc) {
 		int rval = do_try_exec_main (method, args, exc);
@@ -5079,7 +5079,7 @@ MonoObject*
 mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			   MonoObject **exc)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	if (exc) {
 		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, exc, &error);
 		if (*exc) {
@@ -5319,7 +5319,7 @@ mono_object_new (MonoDomain *domain, MonoClass *klass)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 
 	MonoObject * result = mono_object_new_checked (domain, klass, &error);
 
@@ -5332,7 +5332,7 @@ ves_icall_object_new (MonoDomain *domain, MonoClass *klass)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 
 	MonoObject * result = mono_object_new_checked (domain, klass, &error);
 
@@ -5403,7 +5403,7 @@ mono_object_new_pinned (MonoDomain *domain, MonoClass *klass, MonoError *error)
 MonoObject *
 mono_object_new_specific (MonoVTable *vtable)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *o = mono_object_new_specific_checked (vtable, &error);
 	mono_error_cleanup (&error);
 
@@ -5457,7 +5457,7 @@ mono_object_new_specific_checked (MonoVTable *vtable, MonoError *error)
 MonoObject *
 ves_icall_object_new_specific (MonoVTable *vtable)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *o = mono_object_new_specific_checked (vtable, &error);
 	mono_error_set_pending_exception (&error);
 
@@ -5480,7 +5480,7 @@ ves_icall_object_new_specific (MonoVTable *vtable)
 MonoObject *
 mono_object_new_alloc_specific (MonoVTable *vtable)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *o = mono_object_new_alloc_specific_checked (vtable, &error);
 	mono_error_cleanup (&error);
 
@@ -5543,7 +5543,7 @@ mono_object_new_alloc_specific_checked (MonoVTable *vtable, MonoError *error)
 MonoObject*
 mono_object_new_fast (MonoVTable *vtable)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *o = mono_object_new_fast_checked (vtable, &error);
 	mono_error_cleanup (&error);
 
@@ -5614,7 +5614,7 @@ mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, guint32 token
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *result;
 	MonoClass *klass;
 
@@ -5637,7 +5637,7 @@ mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, guint32 token
 MonoObject *
 mono_object_clone (MonoObject *obj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *o = mono_object_clone_checked (obj, &error);
 	mono_error_cleanup (&error);
 
@@ -5777,7 +5777,7 @@ mono_array_clone (MonoArray *array)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = mono_array_clone_checked (array, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -5853,7 +5853,7 @@ mono_array_calc_byte_len (MonoClass *klass, uintptr_t len, uintptr_t *res)
 MonoArray*
 mono_array_new_full (MonoDomain *domain, MonoClass *array_class, uintptr_t *lengths, intptr_t *lower_bounds)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *array = mono_array_new_full_checked (domain, array_class, lengths, lower_bounds, &error);
 	mono_error_cleanup (&error);
 
@@ -5965,7 +5965,7 @@ mono_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = mono_array_new_checked (domain, eclass, n, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -5999,7 +5999,7 @@ mono_array_new_checked (MonoDomain *domain, MonoClass *eclass, uintptr_t n, Mono
 MonoArray*
 ves_icall_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr = mono_array_new_checked (domain, eclass, n, &error);
 	mono_error_set_pending_exception (&error);
 
@@ -6016,7 +6016,7 @@ ves_icall_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n)
 MonoArray *
 mono_array_new_specific (MonoVTable *vtable, uintptr_t n)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr = mono_array_new_specific_checked (vtable, n, &error);
 	mono_error_cleanup (&error);
 
@@ -6055,7 +6055,7 @@ mono_array_new_specific_checked (MonoVTable *vtable, uintptr_t n, MonoError *err
 MonoArray*
 ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr = mono_array_new_specific_checked (vtable, n, &error);
 	mono_error_set_pending_exception (&error);
 
@@ -6098,7 +6098,7 @@ mono_string_new_utf16 (MonoDomain *domain, const guint16 *text, gint32 len)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *res = NULL;
 	res = mono_string_new_utf16_checked (domain, text, len, &error);
 	mono_error_cleanup (&error);
@@ -6189,7 +6189,7 @@ mono_string_new_utf32_checked (MonoDomain *domain, const mono_unichar4 *text, gi
 MonoString *
 mono_string_new_utf32 (MonoDomain *domain, const mono_unichar4 *text, gint32 len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_new_utf32_checked (domain, text, len, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -6204,7 +6204,7 @@ mono_string_new_utf32 (MonoDomain *domain, const mono_unichar4 *text, gint32 len
 MonoString *
 mono_string_new_size (MonoDomain *domain, gint32 len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *str = mono_string_new_size_checked (domain, len, &error);
 	mono_error_cleanup (&error);
 
@@ -6255,7 +6255,7 @@ mono_string_new_len (MonoDomain *domain, const char *text, guint length)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_new_len_checked (domain, text, length, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -6303,7 +6303,7 @@ mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length,
 MonoString*
 mono_string_new (MonoDomain *domain, const char *text)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *res = NULL;
 	res = mono_string_new_checked (domain, text, &error);
 	if (!is_ok (&error)) {
@@ -6392,7 +6392,7 @@ mono_string_new_wrapper (const char *text)
 	MonoDomain *domain = mono_domain_get ();
 
 	if (text) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoString *result = mono_string_new_checked (domain, text, &error);
 		mono_error_assert_ok (&error);
 		return result;
@@ -6410,7 +6410,7 @@ mono_string_new_wrapper (const char *text)
 MonoObject *
 mono_value_box (MonoDomain *domain, MonoClass *klass, gpointer value)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *result = mono_value_box_checked (domain, klass, value, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -6608,7 +6608,7 @@ mono_object_isinst (MonoObject *obj_raw, MonoClass *klass)
 
 	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObjectHandle result = mono_object_handle_isinst (obj, klass, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -6671,7 +6671,7 @@ mono_object_isinst_mbyref (MonoObject *obj_raw, MonoClass *klass)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	MonoObjectHandle result = mono_object_handle_isinst_mbyref (obj, klass, &error);
 	mono_error_cleanup (&error); /* FIXME better API that doesn't swallow the error */
@@ -6775,7 +6775,7 @@ mono_object_castclass_mbyref (MonoObject *obj_raw, MonoClass *klass)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	MonoObjectHandle result = MONO_HANDLE_NEW (MonoObject, NULL);
 	if (MONO_HANDLE_IS_NULL (obj))
@@ -6890,7 +6890,7 @@ mono_string_is_interned_lookup (MonoString *str, int insert, MonoError *error)
 MonoString*
 mono_string_is_interned (MonoString *o)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_is_interned_lookup (o, FALSE, &error);
 	/* This function does not fail. */
 	mono_error_assert_ok (&error);
@@ -6906,7 +6906,7 @@ mono_string_is_interned (MonoString *o)
 MonoString*
 mono_string_intern (MonoString *str)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_intern_checked (str, &error);
 	mono_error_assert_ok (&error);
 	return result;
@@ -6940,7 +6940,7 @@ mono_string_intern_checked (MonoString *str, MonoError *error)
 MonoString*
 mono_ldstr (MonoDomain *domain, MonoImage *image, guint32 idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_ldstr_checked (domain, image, idx, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -7080,7 +7080,7 @@ mono_string_to_utf8 (MonoString *s)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	char *result = mono_string_to_utf8_checked (s, &error);
 	
 	if (!is_ok (&error)) {
@@ -7239,7 +7239,7 @@ mono_string_to_utf32 (MonoString *s)
 MonoString *
 mono_string_from_utf16 (gunichar2 *data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_utf16_checked (data, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -7279,7 +7279,7 @@ mono_string_from_utf16_checked (gunichar2 *data, MonoError *error)
 MonoString *
 mono_string_from_utf32 (mono_unichar4 *data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_string_from_utf32_checked (data, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -7570,7 +7570,7 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAsyncCall *ac;
 	MonoObject *res;
 
@@ -7809,7 +7809,7 @@ prepare_to_string_method (MonoObject *obj, void **target)
 MonoString *
 mono_object_to_string (MonoObject *obj, MonoObject **exc)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *s = NULL;
 	void *target;
 	MonoMethod *method = prepare_to_string_method (obj, &target);
@@ -7887,7 +7887,7 @@ mono_print_unhandled_exception (MonoObject *exc)
 	MonoString * str;
 	char *message = (char*)"";
 	gboolean free_message = FALSE;
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (exc == (MonoObject*)mono_object_domain (exc)->out_of_memory_ex) {
 		message = g_strdup ("OutOfMemoryException");
@@ -8174,7 +8174,7 @@ mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoAr
 gpointer
 mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, gpointer *res)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer result = mono_load_remote_field_checked (this_obj, klass, field, res, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -8275,7 +8275,7 @@ mono_load_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoClas
 MonoObject *
 mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	MonoObject *result = mono_load_remote_field_new_checked (this_obj, klass, field, &error);
 	mono_error_cleanup (&error);
@@ -8334,7 +8334,7 @@ mono_load_remote_field_new_checked (MonoObject *this_obj, MonoClass *klass, Mono
 void
 mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, gpointer val)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	(void) mono_store_remote_field_checked (this_obj, klass, field, val, &error);
 	mono_error_cleanup (&error);
 }
@@ -8388,7 +8388,7 @@ mono_store_remote_field_checked (MonoObject *this_obj, MonoClass *klass, MonoCla
 void
 mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	(void) mono_store_remote_field_new_checked (this_obj, klass, field, arg, &error);
 	mono_error_cleanup (&error);
 }

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -314,7 +314,7 @@ mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, 
 
 	coverage_unlock ();
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
 	mono_error_assert_ok (&error);
 

--- a/mono/metadata/rand.c
+++ b/mono/metadata/rand.c
@@ -36,7 +36,7 @@ ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngInitialize (M
 gpointer
 ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngGetBytes (gpointer handle, MonoArray *arry)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	g_assert (arry);
 	mono_rand_try_get_bytes (&handle, mono_array_addr (arry, guchar, 0), mono_array_length (arry), &error);
 	mono_error_set_pending_exception (&error);

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -218,7 +218,7 @@ MonoReflectionAssembly*
 mono_assembly_get_object (MonoDomain *domain, MonoAssembly *assembly)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionAssemblyHandle result = mono_assembly_get_object_handle (domain, assembly, &error);
 	mono_error_cleanup (&error); /* FIXME new API that doesn't swallow the error */
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -255,7 +255,7 @@ MonoReflectionModule*
 mono_module_get_object   (MonoDomain *domain, MonoImage *image)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionModuleHandle result = mono_module_get_object_handle (domain, image, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -319,7 +319,7 @@ MonoReflectionModule*
 mono_module_file_get_object (MonoDomain *domain, MonoImage *image, int table_index)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionModuleHandle result = mono_module_file_get_object_handle (domain, image, table_index, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -425,7 +425,7 @@ mono_type_normalize (MonoType *type)
 MonoReflectionType*
 mono_type_get_object (MonoDomain *domain, MonoType *type)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionType *ret = mono_type_get_object_checked (domain, type, &error);
 	mono_error_cleanup (&error);
 
@@ -563,7 +563,7 @@ MonoReflectionMethod*
 mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refclass)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionMethodHandle ret = mono_method_get_object_handle (domain, method, refclass, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (ret);
@@ -677,7 +677,7 @@ MonoReflectionField*
 mono_field_get_object (MonoDomain *domain, MonoClass *klass, MonoClassField *field)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionFieldHandle result = mono_field_get_object_handle (domain, klass, field, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -757,7 +757,7 @@ MonoReflectionProperty*
 mono_property_get_object (MonoDomain *domain, MonoClass *klass, MonoProperty *property)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionPropertyHandle result = mono_property_get_object_handle (domain, klass, property, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -822,7 +822,7 @@ MonoReflectionEvent*
 mono_event_get_object (MonoDomain *domain, MonoClass *klass, MonoEvent *event)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionEventHandle result = mono_event_get_object_handle (domain, klass, event, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -871,7 +871,7 @@ mono_event_get_object_handle (MonoDomain *domain, MonoClass *klass, MonoEvent *e
 static MonoObjectHandle
 mono_get_reflection_missing_object (MonoDomain *domain)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	static MonoClassField *missing_value_field = NULL;
 	
 	if (!missing_value_field) {
@@ -1099,7 +1099,7 @@ MonoArray*
 mono_param_get_objects (MonoDomain *domain, MonoMethod *method)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArrayHandle result = mono_param_get_objects_internal (domain, method, NULL, &error);
 	mono_error_assert_ok (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -1165,7 +1165,7 @@ MonoReflectionMethodBody*
 mono_method_body_get_object (MonoDomain *domain, MonoMethod *method)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionMethodBodyHandle result = mono_method_body_get_object_handle (domain, method, &error);
 	mono_error_cleanup (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
@@ -1289,7 +1289,7 @@ MonoObject *
 mono_get_dbnull_object (MonoDomain *domain)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObjectHandle obj = get_dbnull_object (domain, &error);
 	mono_error_assert_ok (&error);
 	HANDLE_FUNCTION_RETURN_OBJ (obj);
@@ -1786,7 +1786,7 @@ mono_identifier_unescape_info (MonoTypeNameParse *info)
 int
 mono_reflection_parse_type (char *name, MonoTypeNameParse *info)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gboolean result = mono_reflection_parse_type_checked (name, info, &error);
 	mono_error_cleanup (&error);
 	return result ? 1 : 0;
@@ -2010,7 +2010,7 @@ leave:
  */
 MonoType*
 mono_reflection_get_type (MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve) {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *result = mono_reflection_get_type_with_rootimage (image, image, info, ignorecase, type_resolve, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -2195,7 +2195,7 @@ mono_reflection_free_type_info (MonoTypeNameParse *info)
 MonoType*
 mono_reflection_type_from_name (char *name, MonoImage *image)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	error_init (&error);
 
 	MonoType * const result = mono_reflection_type_from_name_checked (name, image, &error);
@@ -2225,7 +2225,7 @@ mono_reflection_type_from_name_checked (char *name, MonoImage *image, MonoError 
 	tmp = g_strdup (name);
 	
 	/*g_print ("requested type %s\n", str);*/
-	MonoError parse_error;
+	ERROR_DECL (parse_error);
 	if (!mono_reflection_parse_type_checked (tmp, &info, &parse_error)) {
 		mono_error_cleanup (&parse_error);
 		goto leave;
@@ -2247,7 +2247,7 @@ mono_reflection_get_token (MonoObject *obj_raw)
 {
 	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoError error;
+	ERROR_DECL (error);
 	guint32 result = mono_reflection_get_token_checked (obj, &error);
 	mono_error_assert_ok (&error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
@@ -2962,7 +2962,7 @@ mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, Mono
 	params [0] = mono_type_get_object_checked (mono_domain_get (), &oklass->byval_arg, error);
 	return_val_if_nok (error, FALSE);
 
-	MonoError inner_error;
+	ERROR_DECL (inner_error);
 	res = mono_runtime_try_invoke (method, mono_class_get_ref_info_raw (klass), params, &exc, &inner_error); /* FIXME use handles */
 
 	if (exc || !is_ok (&inner_error)) {
@@ -2982,7 +2982,7 @@ mono_reflection_type_get_type (MonoReflectionType *reftype)
 {
 	g_assert (reftype);
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *result = mono_reflection_type_get_handle (reftype, &error);
 	mono_error_assert_ok (&error);
 	return result;

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -233,7 +233,7 @@ mono_remoting_marshal_init (void)
 static MonoReflectionType *
 type_from_handle (MonoType *handle)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoReflectionType *ret;
 	MonoDomain *domain = mono_domain_get (); 
 	MonoClass *klass = mono_class_from_mono_type (handle);
@@ -373,7 +373,7 @@ mono_remoting_mb_create_and_cache (MonoMethod *key, MonoMethodBuilder *mb,
 static MonoObject *
 mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodMessage *msg;
 	MonoTransparentProxy *this_obj;
 	MonoObject *res, *exc;
@@ -555,7 +555,7 @@ mono_marshal_get_remoting_invoke (MonoMethod *method, MonoError *error)
 static void
 mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	if (src == NULL || dst == NULL) return;
 	
 	g_assert (mono_object_class (src) == mono_object_class (dst));
@@ -640,7 +640,7 @@ mono_marshal_emit_switch_domain (MonoMethodBuilder *mb)
 gpointer
 mono_compile_method_icall (MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer result = mono_compile_method_checked (method, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1314,7 +1314,7 @@ mono_marshal_get_remoting_invoke_for_target (MonoMethod *method, MonoRemotingTar
 G_GNUC_UNUSED static gpointer
 mono_marshal_load_remoting_wrapper (MonoRealProxy *rp, MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *marshal_method = NULL;
 	if (rp->target_domain_id != -1)
 		marshal_method = mono_marshal_get_xappdomain_invoke (method, &error);
@@ -2099,7 +2099,7 @@ mono_marshal_xdomain_copy_value (MonoObject* val_raw, MonoError *error)
 MonoObject *
 ves_icall_mono_marshal_xdomain_copy_value (MonoObject *val)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *result = mono_marshal_xdomain_copy_value (val, &error);
 	mono_error_set_pending_exception (&error);
 	return result;

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -54,7 +54,7 @@ mono_runtime_is_shutting_down (void)
 static void
 fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClassField *field;
 	gpointer pa [2];
 	MonoObject *delegate, *exc;

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -515,7 +515,7 @@ check_field_access (MonoMethod *caller, MonoClassField *field)
 {
 	/* if get_reflection_caller returns NULL then we assume the caller has NO privilege */
 	if (caller) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass;
 
 		/* this check can occur before the field's type is resolved (and that can fail) */
@@ -935,7 +935,7 @@ mono_security_core_clr_level_from_cinfo (MonoCustomAttrInfo *cinfo, MonoImage *i
 static MonoSecurityCoreCLRLevel
 mono_security_core_clr_class_level_no_platform_check (MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoSecurityCoreCLRLevel level = MONO_SECURITY_CORE_CLR_TRANSPARENT;
 	MonoCustomAttrInfo *cinfo = mono_custom_attrs_from_class_checked (klass, &error);
 	mono_error_cleanup (&error);
@@ -976,7 +976,7 @@ mono_security_core_clr_class_level (MonoClass *klass)
 MonoSecurityCoreCLRLevel
 mono_security_core_clr_field_level (MonoClassField *field, gboolean with_class_level)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
 	MonoSecurityCoreCLRLevel level = MONO_SECURITY_CORE_CLR_TRANSPARENT;
 
@@ -1012,7 +1012,7 @@ mono_security_core_clr_field_level (MonoClassField *field, gboolean with_class_l
 MonoSecurityCoreCLRLevel
 mono_security_core_clr_method_level (MonoMethod *method, gboolean with_class_level)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
 	MonoSecurityCoreCLRLevel level = MONO_SECURITY_CORE_CLR_TRANSPARENT;
 

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -674,7 +674,7 @@ mono_dynimage_encode_fieldref_signature (MonoDynamicImage *assembly, MonoImage *
 	if (type->num_mods) {
 		for (i = 0; i < type->num_mods; ++i) {
 			if (field_image) {
-				MonoError error;
+				ERROR_DECL (error);
 				MonoClass *klass = mono_class_get_checked (field_image, type->modifiers [i].token, &error);
 				g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -358,7 +358,7 @@ method_encode_code (MonoDynamicImage *assembly, ReflectionMethodBuilder *mb, Mon
 	} else {
 		code = mb->code;
 		if (code == NULL){
-			MonoError inner_error;
+			ERROR_DECL (inner_error);
 			char *name = mono_string_to_utf8_checked (mb->name, &inner_error);
 			if (!is_ok (&inner_error)) {
 				name = g_strdup ("");
@@ -1293,7 +1293,7 @@ mono_image_fill_export_table_from_module (MonoDomain *domain, MonoReflectionModu
 	t = &image->tables [MONO_TABLE_TYPEDEF];
 
 	for (i = 0; i < t->rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass = mono_class_get_checked (image, mono_metadata_make_token (MONO_TABLE_TYPEDEF, i + 1), &error);
 		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 
@@ -1344,7 +1344,7 @@ add_exported_type (MonoReflectionAssemblyBuilder *assemblyb, MonoDynamicImage *a
 static void
 mono_image_fill_export_table_from_type_forwarders (MonoReflectionAssemblyBuilder *assemblyb, MonoDynamicImage *assembly)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 	int i;
 
@@ -1423,7 +1423,7 @@ compare_nested (const void *a, const void *b)
 static int
 compare_genericparam (const void *a, const void *b)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const GenericParamTableEntry **a_entry = (const GenericParamTableEntry **) a;
 	const GenericParamTableEntry **b_entry = (const GenericParamTableEntry **) b;
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1288,7 +1288,7 @@ assemblybuilderaccess_can_save (guint32 access)
 void
 mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDynamicAssembly *assembly;
 	MonoDynamicImage *image;
 	MonoDomain *domain = mono_object_domain (assemblyb);
@@ -2306,7 +2306,7 @@ encode_named_val (MonoReflectionAssembly *assembly, char *buffer, char *p, char 
 MonoArray*
 mono_reflection_get_custom_attrs_blob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues) 
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = mono_reflection_get_custom_attrs_blob_checked (assembly, ctor, ctorArgs, properties, propValues, fields, fieldValues, &error);
 	mono_error_cleanup (&error);
 	return result;
@@ -3627,7 +3627,7 @@ remove_instantiations_of_and_ensure_contents (gpointer key,
 	MonoType *type = (MonoType*)key;
 	MonoClass *klass = data->klass;
 	gboolean already_failed = !is_ok (data->error);
-	MonoError lerror;
+	ERROR_DECL (lerror);
 	MonoError *error = already_failed ? &lerror : data->error;
 
 	if ((type->type == MONO_TYPE_GENERICINST) && (type->data.generic_class->container_class == klass)) {
@@ -4351,7 +4351,7 @@ ves_icall_ModuleBuilder_getMethodToken (MonoReflectionModuleBuilderHandle mb,
 void
 ves_icall_ModuleBuilder_WriteToFile (MonoReflectionModuleBuilder *mb, HANDLE file)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_image_create_pefile (mb, file, &error);
 	mono_error_set_pending_exception (&error);
 }
@@ -4359,7 +4359,7 @@ ves_icall_ModuleBuilder_WriteToFile (MonoReflectionModuleBuilder *mb, HANDLE fil
 void
 ves_icall_ModuleBuilder_build_metadata (MonoReflectionModuleBuilder *mb)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_image_build_metadata (mb, &error);
 	mono_error_set_pending_exception (&error);
 }
@@ -4385,7 +4385,7 @@ ves_icall_ModuleBuilder_GetRegisteredToken (MonoReflectionModuleBuilderHandle mb
 MonoArray*
 ves_icall_CustomAttributeBuilder_GetBlob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = mono_reflection_get_custom_attrs_blob_checked (assembly, ctor, ctorArgs, properties, propValues, fields, fieldValues, &error);
 	mono_error_set_pending_exception (&error);
 	return result;

--- a/mono/metadata/string-icalls.c
+++ b/mono/metadata/string-icalls.c
@@ -36,7 +36,7 @@ ves_icall_System_String_ctor_RedirectToCreateString (void)
 MonoString *
 ves_icall_System_String_InternalAllocateStr (gint32 length)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, &error);
 	mono_error_set_pending_exception (&error);
 
@@ -46,7 +46,7 @@ ves_icall_System_String_InternalAllocateStr (gint32 length)
 MonoString  *
 ves_icall_System_String_InternalIntern (MonoString *str)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *res;
 
 	res = mono_string_intern_checked (str, &error);

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -247,7 +247,7 @@ filter_jobs_for_domain (gpointer key, gpointer value, gpointer user_data)
 static void
 wait_callback (gint fd, gint events, gpointer user_data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (mono_runtime_is_shutting_down ())
 		return;
@@ -316,7 +316,7 @@ selector_thread_interrupt (gpointer unused)
 static gsize WINAPI
 selector_thread (gpointer data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoGHashTable *states;
 
 	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", &error);
@@ -568,7 +568,7 @@ initialize (void)
 
 	io_selector_running = TRUE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, &error))
 		g_error ("initialize: mono_thread_create_internal () failed due to %s", mono_error_get_message (&error));
 

--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -204,7 +204,7 @@ rand_create (void)
 static guint32
 rand_next (gpointer *handle, guint32 min, guint32 max)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	guint32 val;
 	mono_rand_try_get_uint32 (handle, &val, min, max, &error);
 	// FIXME handle error
@@ -508,7 +508,7 @@ worker_thread (gpointer unused)
 static gboolean
 worker_try_create (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInternalThread *thread;
 	gint64 current_ticks;
 	gint32 now;
@@ -766,7 +766,7 @@ monitor_thread (gpointer unused)
 static void
 monitor_ensure_running (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	for (;;) {
 		switch (worker.monitor_status) {
 		case MONITOR_STATUS_REQUESTED:

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -286,7 +286,7 @@ try_invoke_perform_wait_callback (MonoObject** exc, MonoError *error)
 static void
 worker_callback (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	ThreadPoolDomain *tpdomain, *previous_tpdomain;
 	ThreadPoolCounter counter;
 	MonoInternalThread *thread;
@@ -748,7 +748,7 @@ void
 ves_icall_System_Threading_ThreadPool_ReportThreadStatus (MonoBoolean is_working)
 {
 	// TODO
-	MonoError error;
+	ERROR_DECL (error);
 	mono_error_set_not_implemented (&error, "");
 	mono_error_set_pending_exception (&error);
 }
@@ -809,7 +809,7 @@ MonoBoolean G_GNUC_UNUSED
 ves_icall_System_Threading_ThreadPool_PostQueuedCompletionStatus (MonoNativeOverlapped *native_overlapped)
 {
 	/* This copy the behavior of the current Mono implementation */
-	MonoError error;
+	ERROR_DECL (error);
 	mono_error_set_not_implemented (&error, "");
 	mono_error_set_pending_exception (&error);
 	return FALSE;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -502,7 +502,7 @@ get_current_thread_ptr_for_domain (MonoDomain *domain, MonoInternalThread *threa
 		g_assert (current_thread_field);
 	}
 
-	MonoError thread_vt_error;
+	ERROR_DECL (thread_vt_error);
 	mono_class_vtable_checked (domain, mono_defaults.thread_class, &thread_vt_error);
 	mono_error_assert_ok (&thread_vt_error);
 	mono_domain_lock (domain);
@@ -529,7 +529,7 @@ create_thread_object (MonoDomain *domain, MonoInternalThread *internal)
 {
 	MonoThread *thread;
 	MonoVTable *vtable;
-	MonoError error;
+	ERROR_DECL (error);
 
 	vtable = mono_class_vtable_checked (domain, mono_defaults.thread_class, &error);
 	mono_error_assert_ok (&error);
@@ -546,7 +546,7 @@ create_thread_object (MonoDomain *domain, MonoInternalThread *internal)
 static MonoInternalThread*
 create_internal_thread_object (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInternalThread *thread;
 	MonoVTable *vt;
 
@@ -954,7 +954,7 @@ fire_attach_profiler_events (MonoNativeThreadId tid)
 
 static guint32 WINAPI start_wrapper_internal(StartInfo *start_info, gsize *stack_ptr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoThreadStart start_func;
 	void *start_func_arg;
 	gsize tid;
@@ -1277,7 +1277,7 @@ mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, Mo
 void
 mono_thread_create (MonoDomain *domain, gpointer func, gpointer arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	if (!mono_thread_create_checked (domain, func, arg, &error))
 		mono_error_cleanup (&error);
 }
@@ -1417,7 +1417,7 @@ HANDLE
 ves_icall_System_Threading_Thread_Thread_internal (MonoThread *this_obj,
 												   MonoObject *start)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInternalThread *internal;
 	gboolean res;
 
@@ -1620,7 +1620,7 @@ mono_thread_get_managed_id (MonoThread *thread)
 MonoString* 
 ves_icall_System_Threading_Thread_GetName_internal (MonoInternalThread *this_obj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString* str;
 
 	error_init (&error);
@@ -1688,7 +1688,7 @@ mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, g
 void 
 ves_icall_System_Threading_Thread_SetName_internal (MonoInternalThread *this_obj, MonoString *name)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_thread_set_name_internal (this_obj, name, TRUE, FALSE, &error);
 	mono_error_set_pending_exception (&error);
 }
@@ -1754,7 +1754,7 @@ byte_array_to_domain (MonoArray *arr, MonoDomain *domain, MonoError *error)
 MonoArray*
 ves_icall_System_Threading_Thread_ByteArrayToRootDomain (MonoArray *arr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = byte_array_to_domain (arr, mono_get_root_domain (), &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1763,7 +1763,7 @@ ves_icall_System_Threading_Thread_ByteArrayToRootDomain (MonoArray *arr)
 MonoArray*
 ves_icall_System_Threading_Thread_ByteArrayToCurrentDomain (MonoArray *arr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *result = byte_array_to_domain (arr, mono_domain_get (), &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1862,7 +1862,7 @@ ves_icall_System_Threading_Thread_Join_internal (MonoThread *this_obj, int ms)
 	MonoThreadHandle *handle = thread->handle;
 	MonoInternalThread *cur_thread = mono_thread_internal_current ();
 	gboolean ret;
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (mono_thread_current_check_pending_interrupt ())
 		return FALSE;
@@ -2389,7 +2389,7 @@ ves_icall_System_Threading_Thread_Abort (MonoInternalThread *thread, MonoObject 
 		return;
 
 	if (thread == mono_thread_internal_current ()) {
-		MonoError error;
+		ERROR_DECL (error);
 		self_abort_internal (&error);
 		mono_error_set_pending_exception (&error);
 	} else {
@@ -2469,7 +2469,7 @@ mono_thread_internal_reset_abort (MonoInternalThread *thread)
 MonoObject*
 ves_icall_System_Threading_Thread_GetAbortExceptionState (MonoThread *this_obj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInternalThread *thread = this_obj->internal_thread;
 	MonoObject *state, *deserialized = NULL;
 	MonoDomain *domain;
@@ -2636,7 +2636,7 @@ mono_thread_stop (MonoThread *thread)
 		return;
 
 	if (internal == mono_thread_internal_current ()) {
-		MonoError error;
+		ERROR_DECL (error);
 		self_abort_internal (&error);
 		/*
 		This function is part of the embeding API and has no way to return the exception
@@ -4014,7 +4014,7 @@ mono_threads_abort_appdomain_threads (MonoDomain *domain, int timeout)
 void
 mono_thread_self_abort (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	self_abort_internal (&error);
 	mono_error_set_pending_exception (&error);
 }
@@ -5235,7 +5235,7 @@ mono_thread_internal_unhandled_exception (MonoObject* exc)
 void
 ves_icall_System_Threading_Thread_GetStackTraces (MonoArray **out_threads, MonoArray **out_stack_traces)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_threads_get_thread_dump (out_threads, out_stack_traces, &error);
 	mono_error_set_pending_exception (&error);
 }

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -553,7 +553,7 @@ mono_type_is_valid_type_in_context (MonoType *type, MonoGenericContext *context)
 static MonoType*
 verifier_inflate_type (VerifyContext *ctx, MonoType *type, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *result;
 
 	result = mono_class_inflate_generic_type_checked (type, context, &error);
@@ -570,7 +570,7 @@ is only need to be done by the runtime before realizing the type.
 static gboolean
 is_valid_generic_instantiation (MonoGenericContainer *gc, MonoGenericContext *context, MonoGenericInst *ginst)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 
 	if (ginst->type_argc != gc->type_argc)
@@ -943,7 +943,7 @@ mono_method_is_valid_in_context (VerifyContext *ctx, MonoMethod *method)
 	
 static MonoClassField*
 verifier_load_field (VerifyContext *ctx, int token, MonoClass **out_klass, const char *opcode) {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClassField *field;
 	MonoClass *klass = NULL;
 
@@ -987,7 +987,7 @@ verifier_load_method (VerifyContext *ctx, int token, const char *opcode) {
 	if (ctx->method->wrapper_type != MONO_WRAPPER_NONE) {
 		method = (MonoMethod *)mono_method_get_wrapper_data (ctx->method, (guint32)token);
 	} else {
-		MonoError error;
+		ERROR_DECL (error);
 		if (!IS_METHOD_DEF_OR_REF_OR_SPEC (token) || !token_bounds_check (ctx->image, token)) {
 			ADD_VERIFY_ERROR2 (ctx, g_strdup_printf ("Invalid method token 0x%08x for %s at 0x%04x", token, opcode, ctx->ip_offset), MONO_EXCEPTION_BAD_IMAGE);
 			return NULL;
@@ -1016,7 +1016,7 @@ verifier_load_type (VerifyContext *ctx, int token, const char *opcode) {
 		MonoClass *klass = (MonoClass *)mono_method_get_wrapper_data (ctx->method, (guint32)token);
 		type = klass ? &klass->byval_arg : NULL;
 	} else {
-		MonoError error;
+		ERROR_DECL (error);
 		if (!IS_TYPE_DEF_OR_REF_OR_SPEC (token) || !token_bounds_check (ctx->image, token)) {
 			ADD_VERIFY_ERROR2 (ctx, g_strdup_printf ("Invalid type token 0x%08x at 0x%04x", token, ctx->ip_offset), MONO_EXCEPTION_BAD_IMAGE);
 			return NULL;
@@ -2091,7 +2091,7 @@ handle_enum:
 static void
 init_stack_with_value_at_exception_boundary (VerifyContext *ctx, ILCodeDesc *code, MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoType *type = mono_class_inflate_generic_type_checked (&klass->byval_arg, ctx->generic_context, &error);
 
 	if (!mono_error_ok (&error)) {
@@ -2192,7 +2192,7 @@ verifier_class_is_assignable_from (MonoClass *target, MonoClass *candidate)
 				if (verifier_inflate_and_check_compat (target, get_ireadonlycollection_class (), candidate->element_class))
 					return TRUE;
 			} else {
-				MonoError error;
+				ERROR_DECL (error);
 				int i;
 				while (candidate && candidate != mono_defaults.object_class) {
 					mono_class_setup_interfaces (candidate, &error);
@@ -3211,7 +3211,7 @@ do_ret (VerifyContext *ctx)
 static void
 do_invoke_method (VerifyContext *ctx, int method_token, gboolean virtual_)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int param_count, i;
 	MonoMethodSignature *sig;
 	ILStackDesc *value;
@@ -3699,7 +3699,7 @@ do_conversion (VerifyContext *ctx, int kind)
 static void
 do_load_token (VerifyContext *ctx, int token) 
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer handle;
 	MonoClass *handle_class;
 	if (!check_overflow (ctx))
@@ -4641,7 +4641,7 @@ do_ckfinite (VerifyContext *ctx)
 static void
 merge_stacks (VerifyContext *ctx, ILCodeDesc *from, ILCodeDesc *to, gboolean start, gboolean external) 
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i, j;
 	stack_init (ctx, to);
 
@@ -4918,7 +4918,7 @@ mono_opcode_is_prefix (int op)
 GSList*
 mono_method_verify (MonoMethod *method, int level)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	const unsigned char *ip, *code_start;
 	const unsigned char *end;
 	MonoSimpleBasicBlock *bb = NULL, *original_bb = NULL;

--- a/mono/metadata/w32file-win32-uwp.c
+++ b/mono/metadata/w32file-win32-uwp.c
@@ -117,7 +117,7 @@ mono_w32file_unlock (HANDLE handle, gint64 position, gint64 length, gint32 *erro
 HANDLE
 mono_w32file_get_console_output (void)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_OUTPUT_HANDLE)");
@@ -133,7 +133,7 @@ mono_w32file_get_console_output (void)
 HANDLE
 mono_w32file_get_console_input (void)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_INPUT_HANDLE)");
@@ -149,7 +149,7 @@ mono_w32file_get_console_input (void)
 HANDLE
 mono_w32file_get_console_error (void)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_ERROR_HANDLE)");

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -847,7 +847,7 @@ void ves_icall_System_IO_MonoIO_Unlock (HANDLE handle, gint64 position,
 gint64
 mono_filesize_from_path (MonoString *string)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	struct stat buf;
 	gint64 res;
 	char *path = mono_string_to_utf8_checked (string, &error);

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -2328,7 +2328,7 @@ ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoW32ProcessStart
 MonoArray *
 ves_icall_System_Diagnostics_Process_GetProcesses_internal (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *procs;
 	gpointer *pidarray;
 	int i, count;

--- a/mono/metadata/w32process-win32-uwp.c
+++ b/mono/metadata/w32process-win32-uwp.c
@@ -29,7 +29,7 @@ mono_process_win_enum_processes (DWORD *pids, DWORD count, DWORD *needed)
 HANDLE
 ves_icall_System_Diagnostics_Process_GetProcess_internal (guint32 pid)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("OpenProcess");
@@ -69,7 +69,7 @@ process_add_module (HANDLE process, HMODULE mod, gunichar2 *filename, gunichar2 
 MonoArray *
 ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, HANDLE process)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("EnumProcessModules, GetModuleBaseName, GetModuleFileNameEx");
@@ -85,7 +85,7 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 MonoBoolean
 ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStartInfo *proc_start_info, MonoW32ProcessInfo *process_info)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("ShellExecuteEx");
@@ -102,7 +102,7 @@ ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStar
 MonoString *
 ves_icall_System_Diagnostics_Process_ProcessName_internal (HANDLE process)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *string;
 	gunichar2 name[MAX_PATH];
 	guint32 len;
@@ -133,7 +133,7 @@ gboolean
 mono_process_create_process (MonoW32ProcessInfo *mono_process_info, MonoString *cmd, guint32 creation_flags,
 	gunichar2 *env_vars, gunichar2 *dir, STARTUPINFO *start_info, PROCESS_INFORMATION *process_info)
 {
-	MonoError	mono_error;
+	ERROR_DECL (mono_error);
 	gchar		*api_name = "";
 
 	if (mono_process_info->username) {
@@ -157,7 +157,7 @@ mono_process_create_process (MonoW32ProcessInfo *mono_process_info, MonoString *
 MonoBoolean
 mono_icall_get_process_working_set_size (gpointer handle, gsize *min, gsize *max)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetProcessWorkingSetSize");
@@ -173,7 +173,7 @@ mono_icall_get_process_working_set_size (gpointer handle, gsize *min, gsize *max
 MonoBoolean
 mono_icall_set_process_working_set_size (gpointer handle, gsize min, gsize max)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("SetProcessWorkingSetSize");
@@ -189,7 +189,7 @@ mono_icall_set_process_working_set_size (gpointer handle, gsize min, gsize max)
 gint32
 mono_icall_get_priority_class (gpointer handle)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetPriorityClass");
@@ -205,7 +205,7 @@ mono_icall_get_priority_class (gpointer handle)
 MonoBoolean
 mono_icall_set_priority_class (gpointer handle, gint32 priorityClass)
 {
-	MonoError mono_error;
+	ERROR_DECL (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("SetPriorityClass");

--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -240,7 +240,7 @@ process_get_shell_arguments (MonoW32ProcessStartInfo *proc_start_info, MonoStrin
 {
 	gchar		*spath = NULL;
 	gchar		*new_cmd, *cmd_utf8;
-	MonoError	mono_error;
+	ERROR_DECL (mono_error);
 
 	*cmd = proc_start_info->arguments;
 
@@ -358,7 +358,7 @@ mono_process_win_enum_processes (DWORD *pids, DWORD count, DWORD *needed)
 MonoArray *
 ves_icall_System_Diagnostics_Process_GetProcesses_internal (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *procs;
 	gboolean ret;
 	DWORD needed;

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -428,7 +428,7 @@ cleanup:
 void
 ves_icall_System_Diagnostics_FileVersionInfo_GetVersionInfo_internal (MonoObject *this_obj, MonoString *filename)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	stash_system_image (mono_object_class (this_obj)->image);
 
@@ -562,7 +562,7 @@ process_get_module (MonoAssembly *assembly, MonoClass *proc_class, MonoError *er
 MonoArray *
 ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, HANDLE process)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *temp_arr = NULL;
 	MonoArray *arr;
 	HMODULE mods[1024];
@@ -636,7 +636,7 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 MonoString *
 ves_icall_System_Diagnostics_Process_ProcessName_internal (HANDLE process)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *string;
 	gunichar2 name[MAX_PATH];
 	guint32 len;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -2902,7 +2902,7 @@ find_typespec_for_class (MonoAotCompile *acfg, MonoClass *klass)
 	if (!acfg->typespec_classes) {
 		acfg->typespec_classes = g_hash_table_new (NULL, NULL);
 		for (i = 0; i < len; i++) {
-			MonoError error;
+			ERROR_DECL (error);
 			int typespec = MONO_TOKEN_TYPE_SPEC | (i + 1);
 			MonoClass *klass_key = mono_class_get_and_inflate_typespec_checked (acfg->image, typespec, NULL, &error);
 			if (!is_ok (&error)) {
@@ -3954,7 +3954,7 @@ add_wrappers (MonoAotCompile *acfg)
 	 * callers.
 	 */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		gboolean skip = FALSE;
@@ -4145,7 +4145,7 @@ add_wrappers (MonoAotCompile *acfg)
 #if 0
 	/* remoting-invoke wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethodSignature *sig;
 		
 		token = MONO_TOKEN_METHOD_DEF | (i + 1);
@@ -4164,7 +4164,7 @@ add_wrappers (MonoAotCompile *acfg)
 
 	/* delegate-invoke wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass;
 		MonoCustomAttrInfo *cattr;
 		
@@ -4220,7 +4220,7 @@ add_wrappers (MonoAotCompile *acfg)
 				}
 			}
 		} else if ((acfg->opts & MONO_OPT_GSHAREDVT) && mono_class_is_gtd (klass)) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoGenericContext ctx;
 			MonoMethod *inst, *gshared;
 
@@ -4274,7 +4274,7 @@ add_wrappers (MonoAotCompile *acfg)
 
 	/* array access wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPESPEC].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass;
 		
 		token = MONO_TOKEN_TYPE_SPEC | (i + 1);
@@ -4308,7 +4308,7 @@ add_wrappers (MonoAotCompile *acfg)
 
 	/* Synchronized wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
 		report_loader_error (acfg, &error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (&error));
@@ -4317,7 +4317,7 @@ add_wrappers (MonoAotCompile *acfg)
 			if (method->is_generic) {
 				// FIXME:
 			} else if ((acfg->opts & MONO_OPT_GSHAREDVT) && mono_class_is_gtd (method->klass)) {
-				MonoError error;
+				ERROR_DECL (error);
 				MonoGenericContext ctx;
 				MonoMethod *inst, *gshared, *m;
 
@@ -4339,7 +4339,7 @@ add_wrappers (MonoAotCompile *acfg)
 
 	/* pinvoke wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 
@@ -4361,7 +4361,7 @@ add_wrappers (MonoAotCompile *acfg)
  
 	/* native-to-managed wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		MonoCustomAttrInfo *cattr;
@@ -4481,7 +4481,7 @@ add_wrappers (MonoAotCompile *acfg)
 
 	/* StructureToPtr/PtrToStructure wrappers */
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass;
 		
 		token = MONO_TOKEN_TYPE_DEF | (i + 1);
@@ -4732,7 +4732,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 		/* Add the T[]/InternalEnumerator class */
 		if (!strcmp (klass->name, "IEnumerable`1") || !strcmp (klass->name, "IEnumerator`1")) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoClass *nclass;
 
 			iter = NULL;
@@ -4760,7 +4760,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 	/* Add an instance of GenericComparer<T> which is created dynamically by Comparer<T> */
 	if (klass->image == mono_defaults.corlib && !strcmp (klass->name_space, "System.Collections.Generic") && !strcmp (klass->name, "Comparer`1")) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *tclass = mono_class_from_mono_type (mono_class_get_generic_class (klass)->context.class_inst->type_argv [0]);
 		MonoClass *icomparable, *gcomparer, *icomparable_inst;
 		MonoGenericContext ctx;
@@ -4788,7 +4788,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 	/* Add an instance of GenericEqualityComparer<T> which is created dynamically by EqualityComparer<T> */
 	if (klass->image == mono_defaults.corlib && !strcmp (klass->name_space, "System.Collections.Generic") && !strcmp (klass->name, "EqualityComparer`1")) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *tclass = mono_class_from_mono_type (mono_class_get_generic_class (klass)->context.class_inst->type_argv [0]);
 		MonoClass *iface, *gcomparer, *iface_inst;
 		MonoGenericContext ctx;
@@ -4806,7 +4806,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 		if (mono_class_is_assignable_from (iface_inst, tclass)) {
 			MonoClass *gcomparer_inst;
-			MonoError error;
+			ERROR_DECL (error);
 
 			gcomparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "GenericEqualityComparer`1");
 			gcomparer_inst = mono_class_inflate_generic_class_checked (gcomparer, &ctx, &error);
@@ -4824,7 +4824,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 		if (mono_class_is_enum (tclass)) {
 			MonoClass *enum_comparer_inst;
-			MonoError error;
+			ERROR_DECL (error);
 
 			memset (&ctx, 0, sizeof (ctx));
 			args [0] = &tclass->byval_arg;
@@ -4846,7 +4846,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 
 		if (mono_class_is_enum (tclass)) {
 			MonoClass *comparer_inst;
-			MonoError error;
+			ERROR_DECL (error);
 
 			memset (&ctx, 0, sizeof (ctx));
 			args [0] = &tclass->byval_arg;
@@ -4873,7 +4873,7 @@ add_instances_of (MonoAotCompile *acfg, MonoClass *klass, MonoType **insts, int 
 	memset (&ctx, 0, sizeof (ctx));
 
 	for (i = 0; i < ninsts; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *generic_inst;
 		args [0] = insts [i];
 		ctx.class_inst = mono_metadata_get_generic_inst (1, args);
@@ -4886,7 +4886,7 @@ add_instances_of (MonoAotCompile *acfg, MonoClass *klass, MonoType **insts, int 
 static void
 add_types_from_method_header (MonoAotCompile *acfg, MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header;
 	MonoMethodSignature *sig;
 	int j, depth;
@@ -4931,7 +4931,7 @@ add_generic_instances (MonoAotCompile *acfg)
 		return;
 
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHODSPEC].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		token = MONO_TOKEN_METHOD_SPEC | (i + 1);
 		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
 
@@ -4955,7 +4955,7 @@ add_generic_instances (MonoAotCompile *acfg)
 		 * FIXME: Handle class_inst as well.
 		 */
 		if (context && context->method_inst && context->method_inst->is_open) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoGenericContext shared_context;
 			MonoGenericInst *inst;
 			MonoType **type_argv;
@@ -5040,7 +5040,7 @@ add_generic_instances (MonoAotCompile *acfg)
 	}
 
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPESPEC].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass;
 
 		token = MONO_TOKEN_TYPE_SPEC | (i + 1);
@@ -5144,7 +5144,7 @@ add_generic_instances (MonoAotCompile *acfg)
 			get_method = mono_class_get_method_from_name (array_klass, "GetGenericValueImpl", 2);
 
 			if (get_method) {
-				MonoError error;
+				ERROR_DECL (error);
 				memset (&ctx, 0, sizeof (ctx));
 				args [0] = &mono_defaults.object_class->byval_arg;
 				ctx.method_inst = mono_metadata_get_generic_inst (1, args);
@@ -5163,7 +5163,7 @@ add_generic_instances (MonoAotCompile *acfg)
 
 			while ((m = mono_class_get_methods (interlocked_klass, &iter))) {
 				if ((!strcmp (m->name, "CompareExchange") || !strcmp (m->name, "Exchange")) && m->is_generic) {
-					MonoError error;
+					ERROR_DECL (error);
 					memset (&ctx, 0, sizeof (ctx));
 					args [0] = &mono_defaults.object_class->byval_arg;
 					ctx.method_inst = mono_metadata_get_generic_inst (1, args);
@@ -5184,7 +5184,7 @@ add_generic_instances (MonoAotCompile *acfg)
 			if (volatile_klass) {
 				while ((m = mono_class_get_methods (volatile_klass, &iter))) {
 					if ((!strcmp (m->name, "Read") || !strcmp (m->name, "Write")) && m->is_generic) {
-						MonoError error;
+						ERROR_DECL (error);
 						memset (&ctx, 0, sizeof (ctx));
 						args [0] = &mono_defaults.object_class->byval_arg;
 						ctx.method_inst = mono_metadata_get_generic_inst (1, args);
@@ -6483,7 +6483,7 @@ emit_exception_debug_info (MonoAotCompile *acfg, MonoCompile *cfg, gboolean stor
 static guint32
 emit_klass_info (MonoAotCompile *acfg, guint32 token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass = mono_class_get_checked (acfg->image, token, &error);
 	guint8 *p, *buf;
 	int i, buf_size, res;
@@ -8053,7 +8053,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	}
 	/* Make a copy of the argument/local info */
 	{
-		MonoError error;
+		ERROR_DECL (error);
 		MonoInst **args, **locals;
 		MonoMethodSignature *sig;
 		MonoMethodHeader *header;
@@ -8118,7 +8118,7 @@ compile_thread_main (gpointer user_data)
 	GPtrArray *methods = ((GPtrArray **)user_data) [1];
 	int i;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInternalThread *internal = mono_thread_internal_current ();
 	MonoString *str = mono_string_new_checked (mono_domain_get (), "AOT compiler", &error);
 	mono_error_assert_ok (&error);
@@ -9471,7 +9471,7 @@ mono_aot_get_array_helper_from_wrapper (MonoMethod *method)
 	g_free (s);
 
 	if (m->is_generic) {
-		MonoError error;
+		ERROR_DECL (error);
 		memset (&ctx, 0, sizeof (ctx));
 		args [0] = &method->klass->element_class->byval_arg;
 		ctx.method_inst = mono_metadata_get_generic_inst (1, args);
@@ -9632,7 +9632,7 @@ static void
 generate_aotid (guint8* aotid)
 {
 	gpointer rand_handle;
-	MonoError error;
+	ERROR_DECL (error);
 
 	mono_rand_open ();
 	rand_handle = mono_rand_init (NULL, 0);
@@ -9781,7 +9781,7 @@ emit_class_name_table (MonoAotCompile *acfg)
 	for (i = 0; i < table_size; ++i)
 		g_ptr_array_add (table, NULL);
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		token = MONO_TOKEN_TYPE_DEF | (i + 1);
 		klass = mono_class_get_checked (acfg->image, token, &error);
 		if (!klass) {
@@ -10911,7 +10911,7 @@ collect_methods (MonoAotCompile *acfg)
 
 	/* Collect methods */
 	for (i = 0; i < image->tables [MONO_TABLE_METHOD].rows; ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 
@@ -10960,7 +10960,7 @@ collect_methods (MonoAotCompile *acfg)
 
 	/* gsharedvt methods */
 	for (mindex = 0; mindex < image->tables [MONO_TABLE_METHOD].rows; ++mindex) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (mindex + 1);
 
@@ -11015,7 +11015,7 @@ compile_methods (MonoAotCompile *acfg)
 			methods [i] = (MonoMethod *)g_ptr_array_index (acfg->methods, i);
 		i = 0;
 		while (i < methods_len) {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoInternalThread *thread;
 
 			frag = g_ptr_array_new ();
@@ -11503,7 +11503,7 @@ resolve_ginst (GInstProfileData *inst_data)
 static void
 resolve_class (ClassProfileData *cdata)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 
 	if (!cdata->image->image)
@@ -11593,7 +11593,7 @@ resolve_profile_data (MonoAotCompile *acfg, ProfileData *data)
 		}
 		miter = NULL;
 		while ((m = mono_class_get_methods (klass, &miter))) {
-			MonoError error;
+			ERROR_DECL (error);
 
 			if (strcmp (m->name, mdata->name))
 				continue;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -607,7 +607,7 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError
 static MonoClassField*
 decode_field_info (MonoAotModule *module, guint8 *buf, guint8 **endbuf)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass = decode_klass_ref (module, buf, &buf, &error);
 	guint32 token;
 	guint8 *p = buf;
@@ -762,7 +762,7 @@ fail:
 static MonoMethodSignature*
 decode_signature_with_target (MonoAotModule *module, MonoMethodSignature *target, guint8 *buf, guint8 **endbuf)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodSignature *sig;
 	guint32 flags;
 	int i, gen_param_count = 0, param_count, call_conv;
@@ -1883,7 +1883,7 @@ init_amodule_got (MonoAotModule *amodule)
 	MonoMemPool *mp;
 	MonoJumpInfo *patches;
 	guint32 got_offsets [128];
-	MonoError error;
+	ERROR_DECL (error);
 	int i, npatches;
 
 	/* These can't be initialized in load_aot_module () */
@@ -2320,7 +2320,7 @@ if (container_assm_name && !container_amodule) {
 	 */
 	if (do_load_image) {
 		for (i = 0; i < amodule->image_table_len; ++i) {
-			MonoError error;
+			ERROR_DECL (error);
 			load_image (amodule, i, &error);
 			mono_error_cleanup (&error); /* FIXME don't swallow the error */
 		}
@@ -2407,7 +2407,7 @@ mono_aot_cleanup (void)
 static gboolean
 decode_cached_class_info (MonoAotModule *module, MonoCachedClassInfo *info, guint8 *buf, guint8 **endbuf)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	guint32 flags;
 	MethodRef ref;
 	gboolean res;
@@ -2466,7 +2466,7 @@ mono_aot_get_method_from_vt_slot (MonoDomain *domain, MonoVTable *vtable, int sl
 	MethodRef ref;
 	gboolean res;
 	gpointer addr;
-	MonoError inner_error;
+	ERROR_DECL (inner_error);
 
 	error_init (error);
 
@@ -2596,7 +2596,7 @@ mono_aot_get_class_from_name (MonoImage *image, const char *name_space, const ch
 			name_space2 = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAMESPACE]);
 
 			if (!strcmp (name, name2) && !strcmp (name_space, name_space2)) {
-				MonoError error;
+				ERROR_DECL (error);
 				amodule_unlock (amodule);
 				*klass = mono_class_get_checked (image, token, &error);
 				if (!mono_error_ok (&error))
@@ -2930,7 +2930,7 @@ decode_exception_debug_info (MonoAotModule *amodule, MonoDomain *domain,
 							 MonoMethod *method, guint8* ex_info,
 							 guint8 *code, guint32 code_len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i, buf_len, num_clauses, len;
 	MonoJitInfo *jinfo;
 	MonoJitInfoFlags flags = JIT_INFO_NONE;
@@ -3341,7 +3341,7 @@ msort_method_addresses (gpointer *array, int *indexes, int len)
 MonoJitInfo *
 mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int pos, left, right, code_len;
 	int method_index, table_len;
 	guint32 token;
@@ -3501,7 +3501,7 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 					/* Happens when a random address is passed in which matches a not-yey called wrapper encoded using its name */
 					return NULL;
 			} else {
-				MonoError error;
+				ERROR_DECL (error);
 				token = mono_metadata_make_token (MONO_TABLE_METHOD, method_index + 1);
 				method = mono_get_method_checked (image, token, NULL, NULL, &error);
 				if (!method)
@@ -3559,7 +3559,7 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 static gboolean
 decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guint8 *buf, guint8 **endbuf)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	guint8 *p = buf;
 	gpointer *table;
 	MonoImage *image;
@@ -3588,7 +3588,7 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 			if (ref.method) {
 				ji->data.method = ref.method;
 			}else {
-				MonoError error;
+				ERROR_DECL (error);
 				ji->data.method = mono_get_method_checked (ref.image, ref.token, NULL, NULL, &error);
 				if (!ji->data.method)
 					g_error ("AOT Runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
@@ -4105,7 +4105,7 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 static guint32
 find_aot_method_in_amodule (MonoAotModule *code_amodule, MonoMethod *method, guint32 hash_full)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	guint32 table_size, entry_size, hash;
 	guint32 *table, *entry;
 	guint32 index;
@@ -4400,7 +4400,7 @@ static void
 init_llvmonly_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *method, MonoClass *init_class, MonoGenericContext *context)
 {
 	gboolean res;
-	MonoError error;
+	ERROR_DECL (error);
 
 	res = init_method (amodule, method_index, method, init_class, context, &error);
 	if (!is_ok (&error)) {
@@ -4495,7 +4495,7 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 	MonoAotModule *amodule = (MonoAotModule *)klass->image->aot_module;
 	guint8 *code;
 	gboolean cache_result = FALSE;
-	MonoError inner_error;
+	ERROR_DECL (inner_error);
 
 	error_init (error);
 
@@ -5154,7 +5154,7 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 
 		for (pindex = 0; pindex < n_patches; ++pindex) {
 			MonoJumpInfo *ji = &patches [pindex];
-			MonoError error;
+			ERROR_DECL (error);
 			gpointer target;
 
 			if (amodule->got [got_slots [pindex]])

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -121,7 +121,7 @@ static void
 mono_debug_add_vg_method (MonoMethod *method, MonoDebugMethodJitInfo *jit)
 {
 #ifdef VALGRIND_ADD_LINE_INFO
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header;
 	MonoDebugMethodInfo *minfo;
 	int i;
@@ -530,7 +530,7 @@ deserialize_variable (MonoDebugVarInfo *var, guint8 *p, guint8 **endbuf)
 static MonoDebugMethodJitInfo *
 deserialize_debug_info (MonoMethod *method, guint8 *code_start, guint8 *buf, guint32 buf_len)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header;
 	gint32 offset, native_offset, prev_offset, prev_native_offset;
 	MonoDebugMethodJitInfo *jit;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1646,7 +1646,7 @@ stop_debugger_thread (void)
 static void
 start_debugger_thread (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInternalThread *thread;
 
 	thread = mono_thread_create_internal (mono_get_root_domain (), debugger_thread, NULL, MONO_THREAD_CREATE_FLAGS_DEBUGGER, &error);
@@ -3386,7 +3386,7 @@ static void
 init_jit_info_dbg_attrs (MonoJitInfo *ji)
 {
 	static MonoClass *hidden_klass, *step_through_klass, *non_user_klass;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *ainfo;
 
 	if (ji->dbg_attrs_inited)
@@ -4428,7 +4428,7 @@ set_bp_in_method (MonoDomain *domain, MonoMethod *method, MonoSeqPointInfo *seq_
 
 	code = mono_jit_find_compiled_method_with_jit_info (domain, method, &ji);
 	if (!code) {
-		MonoError oerror;
+		ERROR_DECL (oerror);
 
 		/* Might be AOTed code */
 		mono_class_init (method->klass);
@@ -4765,7 +4765,7 @@ get_this_addr (StackFrame *frame)
 static MonoMethod*
 get_set_notification_method (MonoClass* async_builder_class)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	GPtrArray* array = mono_class_get_methods_by_name (async_builder_class, "SetNotificationForWaitCompletion", 0x24, FALSE, FALSE, &error);
 	mono_error_assert_ok (&error);
 	g_assert (array->len == 1);
@@ -4777,7 +4777,7 @@ get_set_notification_method (MonoClass* async_builder_class)
 static MonoMethod*
 get_object_id_for_debugger_method (MonoClass* async_builder_class)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	GPtrArray *array = mono_class_get_methods_by_name (async_builder_class, "get_ObjectIdForDebugger", 0x24, FALSE, FALSE, &error);
 	mono_error_assert_ok (&error);
 	g_assert (array->len == 1);
@@ -4822,7 +4822,7 @@ get_this_async_id (StackFrame *frame)
 	gpointer builder;
 	MonoMethod *method;
 	MonoObject *ex;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *obj;
 	gboolean old_disable_breakpoints = FALSE;
 	DebuggerTlsData *tls;
@@ -4864,7 +4864,7 @@ set_set_notification_for_wait_completion_flag (StackFrame *frame)
 
 	void* args [1];
 	gboolean arg = TRUE;
-	MonoError error;
+	ERROR_DECL (error);
 	args [0] = &arg;
 	mono_runtime_invoke_checked (get_set_notification_method (mono_class_from_mono_type (builder_field->type)), builder, args, &error);
 	mono_error_assert_ok (&error);
@@ -4877,7 +4877,7 @@ get_notify_debugger_of_wait_completion_method (void)
 {
 	if (notify_debugger_of_wait_completion_method_cache != NULL)
 		return notify_debugger_of_wait_completion_method_cache;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass* task_class = mono_class_load_from_name (mono_defaults.corlib, "System.Threading.Tasks", "Task");
 	GPtrArray* array = mono_class_get_methods_by_name (task_class, "NotifyDebuggerOfWaitCompletion", 0x24, FALSE, FALSE, &error);
 	mono_error_assert_ok (&error);
@@ -5962,7 +5962,7 @@ ss_clear_for_assembly (SingleStepReq *req, MonoAssembly *assembly)
 void
 mono_debugger_agent_debug_log (int level, MonoString *category, MonoString *message)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int suspend_policy;
 	GSList *events;
 	EventInfo ei;
@@ -6578,7 +6578,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 			} else if (type == VALUE_TYPE_ID_NULL) {
 				*(MonoObject**)addr = NULL;
 			} else if (type == MONO_TYPE_VALUETYPE) {
-				MonoError error;
+				ERROR_DECL (error);
 				guint8 *buf2;
 				gboolean is_enum;
 				MonoClass *klass;
@@ -6633,7 +6633,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 static ErrorCode
 decode_value (MonoType *t, MonoDomain *domain, guint8 *addr, guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	ErrorCode err;
 	int type = decode_byte (buf, &buf, limit);
 
@@ -7034,7 +7034,7 @@ add_thread (gpointer key, gpointer value, gpointer user_data)
 static ErrorCode
 do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 *p, guint8 **endp)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	guint8 *end = invoke->endp;
 	MonoMethod *m;
 	int i, nargs;
@@ -7137,7 +7137,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 			if (mono_class_is_abstract (m->klass))
 				return ERR_INVALID_ARGUMENT;
 			else {
-				MonoError error;
+				ERROR_DECL (error);
 				this_arg = mono_object_new_checked (domain, m->klass, &error);
 				mono_error_assert_ok (&error);
 			}
@@ -7789,7 +7789,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_VM_GET_TYPES: {
-		MonoError error;
+		ERROR_DECL (error);
 		GHashTableIter iter;
 		MonoDomain *domain;
 		int i;
@@ -7824,7 +7824,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 				ass = (MonoAssembly *)tmp->data;
 
 				if (ass->image) {
-					MonoError probe_type_error;
+					ERROR_DECL (probe_type_error);
 					/* FIXME really okay to call while holding locks? */
 					t = mono_reflection_get_type_checked (ass->image, ass->image, &info, ignore_case, &type_resolve, &probe_type_error);
 					mono_error_cleanup (&probe_type_error); 
@@ -7863,7 +7863,7 @@ static ErrorCode
 event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 {
 	ErrorCode err;
-	MonoError error;
+	ERROR_DECL (error);
 
 	switch (command) {
 	case CMD_EVENT_REQUEST_SET: {
@@ -8150,7 +8150,7 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 	case CMD_APPDOMAIN_CREATE_STRING: {
 		char *s;
 		MonoString *o;
-		MonoError error;
+		ERROR_DECL (error);
 
 		domain = decode_domainid (p, &p, end, NULL, &err);
 		if (err != ERR_NONE)
@@ -8167,7 +8167,7 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_APPDOMAIN_CREATE_BOXED_VALUE: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass;
 		MonoDomain *domain2;
 		MonoObject *o;
@@ -8243,7 +8243,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (token == 0) {
 				buffer_add_id (buf, 0);
 			} else {
-				MonoError error;
+				ERROR_DECL (error);
 				m = mono_get_method_checked (ass->image, token, NULL, NULL, &error);
 				if (!m)
 					mono_error_cleanup (&error); /* FIXME don't swallow the error */
@@ -8257,7 +8257,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_ASSEMBLY_GET_OBJECT: {
-		MonoError error;
+		ERROR_DECL (error);
 		err = get_assembly_object_command (domain, ass, buf, &error);
 		mono_error_cleanup (&error);
 		return err;
@@ -8267,7 +8267,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_ASSEMBLY_GET_TYPE: {
-		MonoError error;
+		ERROR_DECL (error);
 		char *s = decode_string (p, &p, end);
 		gboolean ignorecase = decode_byte (p, &p, end);
 		MonoTypeNameParse info;
@@ -8411,7 +8411,7 @@ buffer_add_cattrs (Buffer *buf, MonoDomain *domain, MonoImage *image, MonoClass 
 			MonoArray *typed_args, *named_args;
 			MonoType *t;
 			CattrNamedArg *arginfo = NULL;
-			MonoError error;
+			ERROR_DECL (error);
 
 			mono_reflection_create_custom_attr_data_args (image, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, &error);
 			if (!mono_error_ok (&error)) {
@@ -8489,7 +8489,7 @@ collect_interfaces (MonoClass *klass, GHashTable *ifaces, MonoError *error)
 static ErrorCode
 type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint8 *p, guint8 *end, Buffer *buf)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *nested;
 	MonoType *type;
 	gpointer iter;
@@ -8857,7 +8857,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 	case CMD_TYPE_GET_METHODS_BY_NAME_FLAGS: {
 		char *name = decode_string (p, &p, end);
 		int i, flags = decode_int (p, &p, end);
-		MonoError error;
+		ERROR_DECL (error);
 		GPtrArray *array;
 
 		error_init (&error);
@@ -8945,7 +8945,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 		break;
 	}
 	case CMD_TYPE_CREATE_INSTANCE: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoObject *obj;
 
 		obj = mono_object_new_checked (domain, klass, &error);
@@ -8999,7 +8999,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		break;
 	}
 	case CMD_METHOD_GET_DEBUG_INFO: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoDebugMethodInfo *minfo;
 		char *source_file;
 		int i, j, n_il_offsets;
@@ -9096,7 +9096,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		break;
 	}
 	case CMD_METHOD_GET_LOCALS_INFO: {
-		MonoError error;
+		ERROR_DECL (error);
 		int i, num_locals;
 		MonoDebugLocalsInfo *locals;
 		int *locals_map = NULL;
@@ -9197,7 +9197,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 						MonoClass *klass = ((MonoMethod *) imethod)->klass;
 						/*Generic methods gets the context of the GTD.*/
 						if (mono_class_get_context (klass)) {
-							MonoError error;
+							ERROR_DECL (error);
 							result = mono_class_inflate_generic_method_full_checked (result, klass, mono_class_get_context (klass), &error);
 							g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 						}
@@ -9243,7 +9243,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		}
 		break;
 	case CMD_METHOD_GET_BODY: {
-		MonoError error;
+		ERROR_DECL (error);
 		int i;
 
 		header = mono_method_get_header_checked (method, &error);
@@ -9286,7 +9286,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		// FIXME: Generics
 		switch (mono_metadata_token_code (token)) {
 		case MONO_TOKEN_STRING: {
-			MonoError error;
+			ERROR_DECL (error);
 			MonoString *s;
 			char *s2;
 
@@ -9302,7 +9302,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 			break;
 		}
 		default: {
-			MonoError error;
+			ERROR_DECL (error);
 			gpointer val;
 			MonoClass *handle_class;
 
@@ -9350,7 +9350,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		break;
 	}
 	case CMD_METHOD_GET_CATTRS: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *attr_klass;
 		MonoCustomAttrInfo *cinfo;
 
@@ -9371,7 +9371,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		break;
 	}
 	case CMD_METHOD_MAKE_GENERIC_METHOD: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoType **type_argv;
 		int i, type_argc;
 		MonoDomain *d;
@@ -9645,7 +9645,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 	switch (command) {
 	case CMD_STACK_FRAME_GET_VALUES: {
-		MonoError error;
+		ERROR_DECL (error);
 		len = decode_int (p, &p, end);
 		header = mono_method_get_header_checked (frame->actual_method, &error);
 		mono_error_assert_ok (&error); /* FIXME report error */
@@ -9734,7 +9734,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_STACK_FRAME_SET_VALUES: {
-		MonoError error;
+		ERROR_DECL (error);
 		guint8 *val_buf;
 		MonoType *t;
 		MonoDebugVarInfo *var = NULL;
@@ -9922,7 +9922,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			buffer_add_int (buf, mono_string_length (str) * 2);
 			buffer_add_data (buf, (guint8*)mono_string_chars (str), mono_string_length (str) * 2);
 		} else {
-			MonoError error;
+			ERROR_DECL (error);
 			s = mono_string_to_utf8_checked (str, &error);
 			mono_error_assert_ok (&error);
 			buffer_add_string (buf, s);
@@ -9951,7 +9951,7 @@ string_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 static ErrorCode
 object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int objid;
 	ErrorCode err;
 	MonoObject *obj;
@@ -10390,7 +10390,7 @@ wait_for_attach (void)
 static gsize WINAPI
 debugger_thread (void *arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int res, len, id, flags, command = 0;
 	CommandSet command_set = (CommandSet)0;
 	guint8 header [HEADER_LENGTH];

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1527,7 +1527,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						dest->dreg = ins->dreg;
 					} else {
 						MonoClass *array_class = mono_array_class_get (ins->inst_newa_class, 1);
-						MonoError vt_error;
+						ERROR_DECL (vt_error);
 						MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, array_class, &vt_error);
 						MonoMethod *managed_alloc = mono_gc_get_managed_array_allocator (array_class);
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -373,7 +373,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 	if (mini_stats_fd)
 		fprintf (mini_stats_fd, "[");
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
 		if (!method) {
 			mono_error_cleanup (&error); /* FIXME don't swallow the error */
@@ -392,7 +392,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 				if (verbose >= 2)
 					g_print ("Running '%s' ...\n", method->name);
 #ifdef MONO_USE_AOT_COMPILER
-				MonoError error;
+				ERROR_DECL (error);
 				func = (TestMethod)mono_aot_get_method_checked (mono_get_root_domain (), method, &error);
 				mono_error_cleanup (&error);
 				if (!func)
@@ -472,7 +472,7 @@ mini_regression (MonoImage *image, int verbose, int *total_run)
 
 	/* load the metadata */
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
 		if (!method) {
 			mono_error_cleanup (&error);
@@ -581,7 +581,7 @@ interp_regression_step (MonoImage *image, int verbose, int *total_run, int *tota
 	g_timer_start (timer);
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		MonoObject *exc = NULL;
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethod *method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
 		if (!method) {
 			mono_error_cleanup (&error); /* FIXME don't swallow the error */
@@ -636,7 +636,7 @@ interp_regression_step (MonoImage *image, int verbose, int *total_run, int *tota
 			}
 		}
 		if (strncmp (method->name, "test_", 5) == 0 && filter) {
-			MonoError interp_error;
+			ERROR_DECL (interp_error);
 			MonoObject *exc = NULL;
 
 			result_obj = mini_get_interp_callbacks ()->runtime_invoke (method, NULL, NULL, &exc, &interp_error);
@@ -686,7 +686,7 @@ interp_regression (MonoImage *image, int verbose, int *total_run)
 
 	/* load the metadata */
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
 		if (!method) {
 			mono_error_cleanup (&error);
@@ -1014,7 +1014,7 @@ small_id_thread_func (gpointer arg)
 static void
 jit_info_table_test (MonoDomain *domain)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 
 	g_print ("testing jit_info_table\n");
@@ -1078,7 +1078,7 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 	int i, count = 0, fail_count = 0;
 
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		MonoMethodSignature *sig;
 
@@ -1139,7 +1139,7 @@ compile_all_methods_thread_main (CompileAllThreadArgs *args)
 static void
 compile_all_methods (MonoAssembly *ass, int verbose, guint32 opts, guint32 recompilation_times)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	CompileAllThreadArgs args;
 
 	args.ass = ass;
@@ -1167,7 +1167,7 @@ compile_all_methods (MonoAssembly *ass, int verbose, guint32 opts, guint32 recom
 int 
 mono_jit_exec (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[])
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoImage *image = mono_assembly_get_image (assembly);
 	MonoMethod *method;
 	guint32 entry = mono_image_get_entry_point (image);
@@ -1283,7 +1283,7 @@ static void main_thread_handler (gpointer user_data)
 static int
 load_agent (MonoDomain *domain, char *desc)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char* col = strchr (desc, ':');	
 	char *agent, *args;
 	MonoAssembly *agent_assembly;

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -1299,7 +1299,7 @@ static const guint8 *token_handler_ip;
 static char*
 token_handler (MonoDisHelper *dh, MonoMethod *method, guint32 token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *res, *desc;
 	MonoMethod *cmethod;
 	MonoClass *klass;
@@ -1327,7 +1327,7 @@ token_handler (MonoDisHelper *dh, MonoMethod *method, guint32 token)
 		if (method->wrapper_type) {
 			cmethod = (MonoMethod *)data;
 		} else {
-			MonoError error;
+			ERROR_DECL (error);
 			cmethod = mono_get_method_checked (method->klass->image, token, NULL, NULL, &error);
 			if (!cmethod)
 				g_error ("Could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
@@ -1377,7 +1377,7 @@ token_handler (MonoDisHelper *dh, MonoMethod *method, guint32 token)
 static char*
 disasm_ins (MonoMethod *method, const guchar *ip, const guint8 **endip)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *dis;
 	MonoDisHelper dh;
 	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
@@ -1496,7 +1496,7 @@ emit_line_number_info (MonoDwarfWriter *w, MonoMethod *method,
 					   guint8 *code, guint32 code_size,
 					   MonoDebugMethodJitInfo *debug_info)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	guint32 prev_line = 0;
 	guint32 prev_native_offset = 0;
 	int i, file_index, il_offset, prev_il_offset;
@@ -1755,7 +1755,7 @@ void
 mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod *method, char *start_symbol, char *end_symbol, char *linkage_name,
 							   guint8 *code, guint32 code_size, MonoInst **args, MonoInst **locals, GSList *unwind_info, MonoDebugMethodJitInfo *debug_info)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *name;
 	MonoMethodSignature *sig;
 	MonoMethodHeader *header;

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -382,7 +382,7 @@ mono_amd64_throw_exception (guint64 dummy1, guint64 dummy2, guint64 dummy3, guin
 							guint64 dummy5, guint64 dummy6,
 							MonoContext *mctx, MonoObject *exc, gboolean rethrow)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 
 	/* mctx is on the caller's stack */

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -144,7 +144,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 void
 mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 	gboolean rethrow = sp & 1;
 

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -376,7 +376,7 @@ mono_arch_exceptions_init (void)
 void
 mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 	MonoObject *exc = NULL;
 	guint32 ex_token_index, ex_token;

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -179,7 +179,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static void
 throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, gboolean rethrow)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 
 #ifdef DEBUG_EXCEPTIONS

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -324,7 +324,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 void
 mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 
 	/* adjust eip so that it point into the call instruction */

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -242,7 +242,7 @@ throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp,
 		 gulong *int_regs, gdouble *fp_regs, gint32 *acc_regs, 
 		 guint fpc, gboolean rethrow)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 	int iReg;
 

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -167,7 +167,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static void
 throw_exception (MonoObject *exc, gpointer sp, gpointer ip, gboolean rethrow)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 	static void (*restore_context) (MonoContext *);
 	gpointer *window;

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -455,7 +455,7 @@ void
 mono_x86_throw_exception (mgreg_t *regs, MonoObject *exc, 
 						  mgreg_t eip, gboolean rethrow)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoContext ctx;
 
 	ctx.esp = regs [X86_ESP];

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -237,7 +237,7 @@ static void
 ves_real_abort (int line, MonoMethod *mh,
 		const unsigned short *ip, stackval *stack, stackval *sp)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header = mono_method_get_header_checked (mh, &error);
 	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 	g_printerr ("Execution aborted in method: %s::%s\n", mh->klass->name, mh->name);
@@ -358,7 +358,7 @@ get_virtual_method (InterpMethod *imethod, MonoObject *obj)
 	MonoMethod *m = imethod->method;
 	MonoDomain *domain = imethod->domain;
 	InterpMethod *ret = NULL;
-	MonoError error;
+	ERROR_DECL (error);
 
 #ifndef DISABLE_REMOTING
 	if (mono_object_is_transparent_proxy (obj)) {
@@ -702,7 +702,7 @@ interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, gco
 static void
 fill_in_trace (MonoException *exception, InterpFrame *frame)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *stack_trace = dump_frame (frame);
 	MonoDomain *domain = frame->imethod->domain;
 	(exception)->stack_trace = mono_string_new_checked (domain, stack_trace, &error);
@@ -749,7 +749,7 @@ ves_array_create (InterpFrame *frame, MonoDomain *domain, MonoClass *klass, Mono
 	uintptr_t *lengths;
 	intptr_t *lower_bounds;
 	MonoObject *obj;
-	MonoError error;
+	ERROR_DECL (error);
 	int i;
 
 	lengths = alloca (sizeof (uintptr_t) * klass->rank * 2);
@@ -820,7 +820,7 @@ ves_array_set (InterpFrame *frame)
 		return;
 
 	if (sp [ac->rank].data.p && !mono_object_class (o)->element_class->valuetype) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoObject *isinst = mono_object_isinst_checked (sp [ac->rank].data.p, mono_object_class (o)->element_class, &error);
 		mono_error_cleanup (&error);
 		if (!isinst) {
@@ -1228,7 +1228,7 @@ ves_imethod (InterpFrame *frame, ThreadContext *context)
 	const char *name = method->name;
 	MonoObject *obj = (MonoObject*) frame->stack_args->data.p;
 	MonoObject *isinst_obj;
-	MonoError error;
+	ERROR_DECL (error);
 
 	mono_class_init (method->klass);
 
@@ -1368,7 +1368,7 @@ dump_frame (InterpFrame *inv)
 	GString *str = g_string_new ("");
 	int i;
 	char *args;
-	MonoError error;
+	ERROR_DECL (error);
 
 	for (i = 0; inv; inv = inv->parent) {
 		if (inv->imethod != NULL) {
@@ -1423,7 +1423,7 @@ get_trace_ips (MonoDomain *domain, InterpFrame *top)
 	int i;
 	MonoArray *res;
 	InterpFrame *inv;
-	MonoError error;
+	ERROR_DECL (error);
 
 	for (i = 0, inv = top; inv; inv = inv->parent)
 		if (inv->imethod != NULL)
@@ -1890,7 +1890,7 @@ do_jit_call (stackval *sp, unsigned char *vt_sp, ThreadContext *context, InterpF
 	 */
 	if (!rmethod->jit_wrapper) {
 		MonoMethod *method = rmethod->method;
-		MonoError error;
+		ERROR_DECL (error);
 
 		sig = mono_method_signature (method);
 		g_assert (sig);
@@ -2397,7 +2397,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 	int i32;
 	unsigned char *vt_sp;
 	unsigned char *locals;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *o = NULL;
 	MonoClass *c;
 #if USE_COMPUTED_GOTO

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4329,7 +4329,7 @@ mono_interp_transform_init (void)
 MonoException *
 mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, InterpFrame *frame)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	int i, align, size, offset;
 	MonoMethod *method = imethod->method;
 	MonoImage *image = method->klass->image;

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -35,7 +35,7 @@ void*
 mono_ldftn (MonoMethod *method)
 {
 	gpointer addr;
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (mono_llvm_only) {
 		// FIXME: No error handling
@@ -63,7 +63,7 @@ mono_ldftn (MonoMethod *method)
 static void*
 ldvirtfn_internal (MonoObject *obj, MonoMethod *method, gboolean gshared)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *res;
 
 	if (obj == NULL) {
@@ -109,7 +109,7 @@ mono_ldvirtfn_gshared (MonoObject *obj, MonoMethod *method)
 void
 mono_helper_stelem_ref_check (MonoArray *array, MonoObject *val)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	if (!array) {
 		mono_set_pending_exception (mono_get_exception_null_reference ());
 		return;
@@ -674,7 +674,7 @@ mono_fload_r4_arg (double val)
 MonoArray *
 mono_array_new_va (MonoMethod *cm, ...)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr;
 	MonoDomain *domain = mono_domain_get ();
 	va_list ap;
@@ -723,7 +723,7 @@ mono_array_new_va (MonoMethod *cm, ...)
 MonoArray *
 mono_array_new_1 (MonoMethod *cm, guint32 length)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr;
 	MonoDomain *domain = mono_domain_get ();
 	uintptr_t lengths [1];
@@ -758,7 +758,7 @@ mono_array_new_1 (MonoMethod *cm, guint32 length)
 MonoArray *
 mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr;
 	MonoDomain *domain = mono_domain_get ();
 	uintptr_t lengths [2];
@@ -794,7 +794,7 @@ mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2)
 MonoArray *
 mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr;
 	MonoDomain *domain = mono_domain_get ();
 	uintptr_t lengths [3];
@@ -831,7 +831,7 @@ mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 MonoArray *
 mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3, guint32 length4)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoArray *arr;
 	MonoDomain *domain = mono_domain_get ();
 	uintptr_t lengths [4];
@@ -869,7 +869,7 @@ mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 gpointer
 mono_class_static_field_address (MonoDomain *domain, MonoClassField *field)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoVTable *vtable;
 	gpointer addr;
 	
@@ -907,7 +907,7 @@ mono_class_static_field_address (MonoDomain *domain, MonoClassField *field)
 gpointer
 mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *handle_class;
 	gpointer res;
 
@@ -1095,7 +1095,7 @@ mono_lconv_to_r8_un (guint64 a)
 gpointer
 mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointer *this_arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *vmethod;
 	gpointer addr;
 	MonoGenericContext *context = mono_method_get_context (method);
@@ -1129,7 +1129,7 @@ mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointe
 MonoString*
 ves_icall_mono_ldstr (MonoDomain *domain, MonoImage *image, guint32 idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_ldstr_checked (domain, image, idx, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1138,7 +1138,7 @@ ves_icall_mono_ldstr (MonoDomain *domain, MonoImage *image, guint32 idx)
 MonoString*
 mono_helper_ldstr (MonoImage *image, guint32 idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_ldstr_checked (mono_domain_get (), image, idx, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1147,7 +1147,7 @@ mono_helper_ldstr (MonoImage *image, guint32 idx)
 MonoString*
 mono_helper_ldstr_mscorlib (guint32 idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoString *result = mono_ldstr_checked (mono_domain_get (), mono_defaults.corlib, idx, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -1156,7 +1156,7 @@ mono_helper_ldstr_mscorlib (guint32 idx)
 MonoObject*
 mono_helper_newobj_mscorlib (guint32 idx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass = mono_class_get_checked (mono_defaults.corlib, MONO_TOKEN_TYPE_DEF | idx, &error);
 
 	if (!mono_error_ok (&error)) {
@@ -1189,7 +1189,7 @@ mono_create_corlib_exception_0 (guint32 token)
 MonoException *
 mono_create_corlib_exception_1 (guint32 token, MonoString *arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ret = mono_exception_from_token_two_strings_checked (
 		mono_defaults.corlib, token, arg, NULL, &error);
 	mono_error_set_pending_exception (&error);
@@ -1199,7 +1199,7 @@ mono_create_corlib_exception_1 (guint32 token, MonoString *arg)
 MonoException *
 mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg2)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ret = mono_exception_from_token_two_strings_checked (
 		mono_defaults.corlib, token, arg1, arg2, &error);
 	mono_error_set_pending_exception (&error);
@@ -1209,7 +1209,7 @@ mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg
 MonoObject*
 mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoJitTlsData *jit_tls = NULL;
 	MonoClass *oklass;
 
@@ -1243,7 +1243,7 @@ mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass)
 MonoObject*
 mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoJitTlsData *jit_tls = NULL;
 	gpointer cached_vtable, obj_vtable;
 
@@ -1282,7 +1282,7 @@ mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *c
 MonoObject*
 mono_object_isinst_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	size_t cached_vtable, obj_vtable;
 
 	if (!obj)
@@ -1310,7 +1310,7 @@ mono_object_isinst_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cach
 gpointer
 mono_get_native_calli_wrapper (MonoImage *image, MonoMethodSignature *sig, gpointer func)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMarshalSpec **mspecs;
 	MonoMethodPInvoke piinfo;
 	MonoMethod *m;
@@ -1403,7 +1403,7 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
 MonoObject*
 mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *klass, gboolean deref_arg, gpointer *args)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject *o;
 	MonoMethod *m;
 	gpointer this_arg;
@@ -1450,7 +1450,7 @@ void
 ves_icall_runtime_class_init (MonoVTable *vtable)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
-	MonoError error;
+	ERROR_DECL (error);
 
 	mono_runtime_class_init_full (vtable, &error);
 	mono_error_set_pending_exception (&error);
@@ -1460,7 +1460,7 @@ ves_icall_runtime_class_init (MonoVTable *vtable)
 void
 mono_generic_class_init (MonoVTable *vtable)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	mono_runtime_class_init_full (vtable, &error);
 	mono_error_set_pending_exception (&error);
 }
@@ -1469,7 +1469,7 @@ void
 ves_icall_mono_delegate_ctor (MonoObject *this_obj_raw, MonoObject *target_raw, gpointer addr)
 {
 	HANDLE_FUNCTION_ENTER ();
-	MonoError error;
+	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, this_obj);
 	MONO_HANDLE_DCL (MonoObject, target);
 	mono_delegate_ctor (this_obj, target, addr, &error);
@@ -1480,7 +1480,7 @@ ves_icall_mono_delegate_ctor (MonoObject *this_obj_raw, MonoObject *target_raw, 
 gpointer
 mono_fill_class_rgctx (MonoVTable *vtable, int index)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res;
 
 	res = mono_class_fill_runtime_generic_context (vtable, index, &error);
@@ -1494,7 +1494,7 @@ mono_fill_class_rgctx (MonoVTable *vtable, int index)
 gpointer
 mono_fill_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, int index)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res;
 
 	res = mono_method_fill_runtime_generic_context (mrgctx, index, &error);
@@ -1565,7 +1565,7 @@ resolve_iface_call (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, 
 gpointer
 mono_resolve_iface_call_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res = resolve_iface_call (this_obj, imt_slot, imt_method, out_arg, TRUE, &error);
 	if (!is_ok (&error)) {
 		MonoException *ex = mono_error_convert_to_exception (&error);
@@ -1675,7 +1675,7 @@ mono_resolve_vcall_gsharedvt (MonoObject *this_obj, int slot, MonoMethod *imt_me
 {
 	g_assert (this_obj);
 
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer result = resolve_vcall (this_obj->vtable, slot, imt_method, out_arg, TRUE, &error);
 	if (!is_ok (&error)) {
 		MonoException *ex = mono_error_convert_to_exception (&error);
@@ -1696,7 +1696,7 @@ mono_resolve_generic_virtual_call (MonoVTable *vt, int slot, MonoMethod *generic
 	MonoMethod *m;
 	gpointer addr, compiled_method;
 	gboolean need_unbox_tramp = FALSE;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoGenericContext context = { NULL, NULL };
 	MonoMethod *declaring;
 	gpointer arg = NULL;
@@ -1753,7 +1753,7 @@ mono_resolve_generic_virtual_call (MonoVTable *vt, int slot, MonoMethod *generic
 MonoFtnDesc*
 mono_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMethod *generic_virtual)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *m, *variant_iface;
 	gpointer addr, aot_addr, compiled_method;
 	gboolean need_unbox_tramp = FALSE;
@@ -1804,7 +1804,7 @@ mono_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMetho
 gpointer
 mono_init_vtable_slot (MonoVTable *vtable, int slot)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer arg = NULL;
 	gpointer addr;
 	gpointer *ftnptr;
@@ -1831,7 +1831,7 @@ mono_init_vtable_slot (MonoVTable *vtable, int slot)
 void
 mono_llvmonly_init_delegate (MonoDelegate *del)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoFtnDesc *ftndesc = *(MonoFtnDesc**)del->method_code;
 
 	/*
@@ -1864,7 +1864,7 @@ mono_llvmonly_init_delegate (MonoDelegate *del)
 void
 mono_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 
 	g_assert (target);
 
@@ -1893,7 +1893,7 @@ mono_get_assembly_object (MonoImage *image)
 MonoObject*
 mono_get_method_object (MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoObject * result;
 	result = (MonoObject*)mono_method_get_object_checked (mono_domain_get (), method, method->klass, &error);
 	mono_error_set_pending_exception (&error);
@@ -1913,7 +1913,7 @@ mono_throw_method_access (MonoMethod *caller, MonoMethod *callee)
 {
 	char *caller_name = mono_method_get_reflection_name (caller);
 	char *callee_name = mono_method_get_reflection_name (callee);
-	MonoError error;
+	ERROR_DECL (error);
 
 	error_init (&error);
 	mono_error_set_generic_error (&error, "System", "MethodAccessException", "Method `%s' is inaccessible from method `%s'", callee_name, caller_name);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1582,7 +1582,7 @@ mini_emit_runtime_constant (MonoCompile *cfg, MonoJumpInfoType patch_type, gpoin
 	} else {
 		MonoJumpInfo ji;
 		gpointer target;
-		MonoError error;
+		ERROR_DECL (error);
 
 		ji.type = patch_type;
 		ji.data.target = data;
@@ -2419,7 +2419,7 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 
 #ifndef DISABLE_REMOTING
 	if (might_be_remote) {
-		MonoError error;
+		ERROR_DECL (error);
 		call->method = mono_marshal_get_remoting_invoke_with_check (method, &error);
 		mono_error_assert_ok (&error);
 	} else
@@ -2473,7 +2473,7 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 			 */
 #ifndef DISABLE_REMOTING
 			if (mono_class_is_marshalbyref (method->klass) || method->klass == mono_defaults.object_class) {
-				MonoError error;
+				ERROR_DECL (error);
 				/* 
 				 * The check above ensures method is not gshared, this is needed since
 				 * gshared methods can't have wrappers.
@@ -4205,7 +4205,7 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 		/* The AggressiveInlining hint is a good excuse to force that cctor to run. */
 		if (method->iflags & METHOD_IMPL_ATTRIBUTE_AGGRESSIVE_INLINING) {
 			if (method->klass->has_cctor) {
-				MonoError error;
+				ERROR_DECL (error);
 				vtable = mono_class_vtable_checked (cfg->domain, method->klass, &error);
 				if (!is_ok (&error)) {
 					mono_error_cleanup (&error);
@@ -4220,7 +4220,7 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 			}
 		} else if (mono_class_is_before_field_init (method->klass)) {
 			if (cfg->run_cctors && method->klass->has_cctor) {
-				MonoError error;
+				ERROR_DECL (error);
 				/*FIXME it would easier and lazier to just use mono_class_try_get_vtable */
 				if (!method->klass->runtime_info)
 					/* No vtable created yet */
@@ -4241,7 +4241,7 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 				}
 			}
 		} else if (mono_class_needs_cctor_run (method->klass, NULL)) {
-			MonoError error;
+			ERROR_DECL (error);
 			if (!method->klass->runtime_info)
 				/* No vtable created yet */
 				return FALSE;
@@ -5993,7 +5993,7 @@ static int
 inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **sp,
 	       guchar *ip, guint real_offset, gboolean inline_always)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInst *ins, *rvar = NULL;
 	MonoMethodHeader *cheader;
 	MonoBasicBlock *ebblock, *sbblock;
@@ -6356,7 +6356,7 @@ mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, Mono
 static inline MonoMethod *
 mini_get_method (MonoCompile *cfg, MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethod *method = mini_get_method_allow_open (m, token, klass, context, cfg ? &cfg->error : &error);
 
 	if (method && cfg && !cfg->gshared && mono_class_is_open_constructed_type (&method->klass->byval_arg)) {
@@ -6461,7 +6461,7 @@ initialize_array_data (MonoMethod *method, gboolean aot, unsigned char *ip, Mono
 	 * call void class [mscorlib]System.Runtime.CompilerServices.RuntimeHelpers::InitializeArray(class [mscorlib]System.Array, valuetype [mscorlib]System.RuntimeFieldHandle)
 	 */
 	if (ip [0] == CEE_DUP && ip [1] == CEE_LDTOKEN && ip [5] == 0x4 && ip [6] == CEE_CALL) {
-		MonoError error;
+		ERROR_DECL (error);
 		guint32 token = read32 (ip + 7);
 		guint32 field_token = read32 (ip + 2);
 		guint32 field_index = field_token & 0xffffff;
@@ -6532,7 +6532,7 @@ initialize_array_data (MonoMethod *method, gboolean aot, unsigned char *ip, Mono
 static void
 set_exception_type_from_invalid_il (MonoCompile *cfg, MonoMethod *method, unsigned char *ip)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *method_fname = mono_method_full_name (method, TRUE);
 	char *method_code;
 	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
@@ -6914,7 +6914,7 @@ is_exception_class (MonoClass *klass)
 static gboolean
 is_jit_optimizer_disabled (MonoMethod *m)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAssembly *ass = m->klass->image->assembly;
 	MonoCustomAttrInfo* attrs;
 	MonoClass *klass;
@@ -7173,7 +7173,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		   MonoInst *return_var, MonoInst **inline_args, 
 		   guint inline_offset, gboolean is_virtual_call)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoInst *ins, **sp, **stack_start;
 	MonoBasicBlock *tblock = NULL;
 	MonoBasicBlock *init_localsbb = NULL, *init_localsbb2 = NULL;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -854,7 +854,7 @@ get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_info)
 static MonoMethod*
 get_method_from_stack_frame (MonoJitInfo *ji, gpointer generic_info)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoGenericContext context;
 	MonoMethod *method;
 	
@@ -918,7 +918,7 @@ mono_exception_walk_trace (MonoException *ex, MonoExceptionFrameWalk func, gpoin
 MonoArray *
 ves_icall_get_trace (MonoException *exc, gint32 skip, MonoBoolean need_file_info)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoArray *res;
 	MonoArray *ta = exc->trace_ips;
@@ -1242,7 +1242,7 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 			  gint32 *iloffset, gint32 *native_offset,
 			  MonoString **file, gint32 *line, gint32 *column)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitTlsData *jit_tls = (MonoJitTlsData *)mono_tls_get_jit_tls ();
 	MonoLMF *lmf = mono_get_lmf ();
@@ -1375,7 +1375,7 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 static MonoClass*
 get_exception_catch_class (MonoJitExceptionInfo *ei, MonoJitInfo *ji, MonoContext *ctx)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *catch_class = ei->data.catch_class;
 	MonoType *inflated_type;
 	MonoGenericContext context;
@@ -1473,7 +1473,7 @@ static GENERATE_GET_CLASS_WITH_CACHE (runtime_compat_attr, "System.Runtime.Compi
 static gboolean
 wrap_non_exception_throws (MonoMethod *m)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoAssembly *ass = m->klass->image->assembly;
 	MonoCustomAttrInfo* attrs;
 	MonoClass *klass;
@@ -1570,7 +1570,7 @@ setup_stack_trace (MonoException *mono_ex, GSList *dynamic_methods, GList **trac
 {
 	if (mono_ex) {
 		*trace_ips = g_list_reverse (*trace_ips);
-		MonoError error;
+		ERROR_DECL (error);
 		MonoArray *ips_arr = mono_glist_to_array (*trace_ips, mono_defaults.int_class, &error);
 		mono_error_assert_ok (&error);
 		MONO_OBJECT_SETREF (mono_ex, trace_ips, ips_arr);
@@ -1616,7 +1616,7 @@ setup_stack_trace (MonoException *mono_ex, GSList *dynamic_methods, GList **trac
 static gboolean
 handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filter_idx, MonoJitInfo **out_ji, MonoJitInfo **out_prev_ji, MonoObject *non_exception, StackFrameInfo *catch_frame)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitInfo *ji = NULL;
 	static int (*call_filter) (MonoContext *, gpointer) = NULL;
@@ -1826,7 +1826,7 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 					}
 				}
 
-				MonoError isinst_error;
+				ERROR_DECL (isinst_error);
 				error_init (&isinst_error);
 				if (ei->flags == MONO_EXCEPTION_CLAUSE_NONE && mono_object_isinst_checked (ex_obj, catch_class, &error)) {
 					setup_stack_trace (mono_ex, dynamic_methods, &trace_ips);
@@ -1861,7 +1861,7 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 static gboolean
 mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resume, MonoJitInfo **out_ji)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitInfo *ji, *prev_ji;
 	static int (*call_filter) (MonoContext *, gpointer) = NULL;
@@ -3254,7 +3254,7 @@ throw_exception (MonoObject *ex, gboolean rethrow)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoJitTlsData *jit_tls = mono_get_jit_tls ();
 	MonoException *mono_ex;
 
@@ -3349,7 +3349,7 @@ mono_llvm_resume_exception (void)
 MonoObject *
 mono_llvm_load_exception (void)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoJitTlsData *jit_tls = mono_get_jit_tls ();
 
 	MonoException *mono_ex = (MonoException*)mono_gchandle_get_target (jit_tls->thrown_exc);
@@ -3417,7 +3417,7 @@ mono_llvm_clear_exception (void)
 gint32
 mono_llvm_match_exception (MonoJitInfo *jinfo, guint32 region_start, guint32 region_end, gpointer rgctx, MonoObject *this_obj)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoJitTlsData *jit_tls = mono_get_jit_tls ();
 	MonoObject *exc;
 	gint32 index = -1;

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -510,7 +510,7 @@ mono_class_get_method_generic (MonoClass *klass, MonoMethod *method)
 	}
 
 	if (method != declaring) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoGenericContext context;
 
 		context.class_inst = NULL;
@@ -528,7 +528,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 {
 	gpointer data = oti->data;
 	MonoRgctxInfoType info_type = oti->info_type;
-	MonoError error;
+	ERROR_DECL (error);
 
 	g_assert (data);
 
@@ -585,7 +585,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 			inflated_method = mono_method_search_in_array_class (inflated_class,
 				method->name, method->signature);
 		} else {
-			MonoError error;
+			ERROR_DECL (error);
 			inflated_method = mono_class_inflate_generic_method_checked (method, context, &error);
 			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 		}
@@ -651,7 +651,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 			inflated_method = mono_method_search_in_array_class (inflated_class,
 				method->name, method->signature);
 		} else {
-			MonoError error;
+			ERROR_DECL (error);
 			inflated_method = mono_class_inflate_generic_method_checked (method, context, &error);
 			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
 		}
@@ -670,7 +670,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 
 	case MONO_RGCTX_INFO_CLASS_FIELD:
 	case MONO_RGCTX_INFO_FIELD_OFFSET: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClassField *field = (MonoClassField *)data;
 		MonoType *inflated_type = mono_class_inflate_generic_type_checked (&field->parent->byval_arg, context, &error);
 		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
@@ -690,7 +690,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	case MONO_RGCTX_INFO_SIG_GSHAREDVT_OUT_TRAMPOLINE_CALLI: {
 		MonoMethodSignature *sig = (MonoMethodSignature *)data;
 		MonoMethodSignature *isig;
-		MonoError error;
+		ERROR_DECL (error);
 
 		isig = mono_inflate_generic_signature (sig, context, &error);
 		g_assert (mono_error_ok (&error));
@@ -702,7 +702,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 		MonoJumpInfoVirtMethod *res;
 		MonoType *t;
 		MonoDomain *domain = mono_domain_get ();
-		MonoError error;
+		ERROR_DECL (error);
 
 		// FIXME: Temporary
 		res = (MonoJumpInfoVirtMethod *)mono_domain_alloc0 (domain, sizeof (MonoJumpInfoVirtMethod));
@@ -1124,7 +1124,7 @@ get_wrapper_shared_type (MonoType *t)
 		return &mono_defaults.object_class->byval_arg;
 		//return &mono_defaults.int_class->byval_arg;
 	case MONO_TYPE_GENERICINST: {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoClass *klass;
 		MonoGenericContext ctx;
 		MonoGenericContext *orig_ctx;
@@ -1618,7 +1618,7 @@ mini_get_gsharedvt_out_sig_wrapper_signature (gboolean has_this, gboolean has_re
 gpointer
 mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSignature *normal_sig, MonoMethodSignature *gsharedvt_sig, gint32 vcall_offset, gboolean calli)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res, info;
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitDomainInfo *domain_info;
@@ -2848,7 +2848,7 @@ is_async_state_machine_class (MonoClass *klass)
 static G_GNUC_UNUSED gboolean
 is_async_method (MonoMethod *method)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoCustomAttrInfo *cattr;
 	MonoMethodSignature *sig;
 	gboolean res = FALSE;
@@ -3353,7 +3353,7 @@ mini_type_is_reference (MonoType *type)
 gpointer
 mini_method_get_rgctx (MonoMethod *m)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoVTable *vt = mono_class_vtable_checked (mono_domain_get (), m->klass, &error);
 	mono_error_assert_ok (&error);
 	if (mini_method_get_context (m)->method_inst) {
@@ -3519,7 +3519,7 @@ get_shared_type (MonoType *t, MonoType *type)
 	MonoTypeEnum ttype;
 
 	if (!type->byref && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoGenericClass *gclass = type->data.generic_class;
 		MonoGenericContext context;
 		MonoClass *k;
@@ -3602,7 +3602,7 @@ get_shared_inst (MonoGenericInst *inst, MonoGenericInst *shared_inst, MonoGeneri
 MonoMethod*
 mini_get_shared_method_full (MonoMethod *method, gboolean all_vt, gboolean is_gsharedvt)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoGenericContext shared_context;
 	MonoMethod *declaring_method, *res;
 	gboolean partial = FALSE;

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1084,7 +1084,7 @@ static gpointer
 resolve_patch (MonoCompile *cfg, MonoJumpInfoType type, gconstpointer target)
 {
 	MonoJumpInfo ji;
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res;
 
 	memset (&ji, 0, sizeof (ji));
@@ -3228,7 +3228,7 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 					g_hash_table_insert (ctx->method_to_callers, call->method, l);
 				}
 			} else {
-				MonoError error;
+				ERROR_DECL (error);
 				static int tramp_index;
 				char *name;
 
@@ -3329,7 +3329,7 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 				if (cfg->abs_patches) {
 					MonoJumpInfo *abs_ji = (MonoJumpInfo*)g_hash_table_lookup (cfg->abs_patches, call->fptr);
 					if (abs_ji) {
-						MonoError error;
+						ERROR_DECL (error);
 
 						target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, abs_ji, FALSE, &error);
 						mono_error_assert_ok (&error);
@@ -3346,7 +3346,7 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 				if (cfg->abs_patches) {
 					MonoJumpInfo *abs_ji = (MonoJumpInfo*)g_hash_table_lookup (cfg->abs_patches, call->fptr);
 					if (abs_ji) {
-						MonoError error;
+						ERROR_DECL (error);
 
 						/*
 						 * FIXME: Some trampolines might have

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -236,7 +236,7 @@ mini_profiler_context_get_argument (MonoProfilerCallContext *ctx, guint32 pos)
 gpointer
 mini_profiler_context_get_local (MonoProfilerCallContext *ctx, guint32 pos)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoMethodHeader *header = mono_method_get_header_checked (ctx->method, &error);
 	mono_error_assert_ok (&error); // Must be a valid method at this point.
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -600,7 +600,7 @@ mono_debug_count (void)
 gconstpointer
 mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *name;
 	MonoMethod *wrapper;
 	gconstpointer trampoline;
@@ -1739,7 +1739,7 @@ lookup_method (MonoDomain *domain, MonoMethod *method)
 MonoClass*
 mini_get_class (MonoMethod *method, guint32 token, MonoGenericContext *context)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoClass *klass;
 
 	if (method->wrapper_type != MONO_WRAPPER_NONE) {
@@ -3799,7 +3799,7 @@ mini_get_interp_callbacks (void)
 MonoDomain *
 mini_init (const char *filename, const char *runtime_version)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDomain *domain;
 	MonoRuntimeCallbacks callbacks;
 	MonoThreadInfoRuntimeCallbacks ticallbacks;
@@ -4552,7 +4552,7 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 		printf ("PRECOMPILE: %s.\n", mono_image_get_filename (image));
 
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
-		MonoError error;
+		ERROR_DECL (error);
 
 		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
 		if (!method) {

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -825,7 +825,7 @@ cvtMonoType(MonoTypeEnum t)
 static void
 decodeParmString (MonoString *s)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	char *str = mono_string_to_utf8_checked(s, &error);
 	if (is_ok (&error))  {
 		fprintf (trFd, "[STRING:%p:%s], ", s, str);
@@ -2609,7 +2609,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 
 		mono_call_inst_add_outarg_reg (cfg, call, dreg, ainfo->reg, TRUE);
 	} else {
-		MonoError error;
+		ERROR_DECL (error);
 		MonoMethodHeader *header;
 		int srcReg;
 

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -1569,7 +1569,7 @@ else { \
 static guint32*
 emit_call (MonoCompile *cfg, guint32 *code, guint32 patch_type, gconstpointer data)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer target;
 
 	/* FIXME: This only works if the target method is already compiled */

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -835,7 +835,7 @@ gpointer
 mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 {
 	gpointer res;
-	MonoError error;
+	ERROR_DECL (error);
 
 	MONO_REQ_GC_UNSAFE_MODE;
 
@@ -866,7 +866,7 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 	MonoVTable *vt;
 	gpointer *vtable_slot;
 	MonoMethod *m;
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer addr, res = NULL;
 
 	UnlockedIncrement (&trampoline_calls);
@@ -937,7 +937,7 @@ mono_generic_virtual_remoting_trampoline (mgreg_t *regs, guint8 *code, MonoMetho
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoError error;
+	ERROR_DECL (error);
 	MonoGenericContext context = { NULL, NULL };
 	MonoMethod *imt_method, *declaring;
 	gpointer addr;
@@ -996,7 +996,7 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
 	MonoMethod *method = NULL;
 	gpointer addr;
 	guint8 *plt_entry;
-	MonoError error;
+	ERROR_DECL (error);
 
 	UnlockedIncrement (&trampoline_calls);
 
@@ -1040,7 +1040,7 @@ mono_aot_plt_trampoline (mgreg_t *regs, guint8 *code, guint8 *aot_module,
 
 	guint32 plt_info_offset = mono_aot_get_plt_info_offset (regs, code);
 	gpointer res;
-	MonoError error;
+	ERROR_DECL (error);
 
 	UnlockedIncrement (&trampoline_calls);
 
@@ -1068,7 +1068,7 @@ mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, gu
 	gpointer arg = (gpointer)(gssize)r [MONO_ARCH_VTABLE_REG];
 	guint32 index = MONO_RGCTX_SLOT_INDEX (slot);
 	gboolean mrgctx = MONO_RGCTX_SLOT_IS_MRGCTX (slot);
-	MonoError error;
+	ERROR_DECL (error);
 	gpointer res;
 
 	UnlockedIncrement (&trampoline_calls);
@@ -1101,7 +1101,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	MonoJitInfo *ji;
 	MonoMethod *m;
 	MonoMethod *method = NULL;
-	MonoError error;
+	ERROR_DECL (error);
 	gboolean multicast, callvirt = FALSE, closed_over_null = FALSE;
 	gboolean need_rgctx_tramp = FALSE;
 	gboolean need_unbox_tramp = FALSE;
@@ -1110,7 +1110,7 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 	MonoMethod *invoke = tramp_info->invoke;
 	guint8 *impl_this = (guint8 *)tramp_info->impl_this;
 	guint8 *impl_nothis = (guint8 *)tramp_info->impl_nothis;
-	MonoError err;
+	ERROR_DECL (err);
 	MonoMethodSignature *sig;
 	gpointer addr, compiled_method;
 	gboolean is_remote = FALSE;
@@ -1540,7 +1540,7 @@ MonoDelegateTrampInfo*
 mono_create_delegate_trampoline_info (MonoDomain *domain, MonoClass *klass, MonoMethod *method)
 {
 	MonoMethod *invoke;
-	MonoError error;
+	ERROR_DECL (error);
 	MonoDelegateTrampInfo *tramp_info;
 	MonoClassMethodPair pair, *dpair;
 	guint32 code_size = 0;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3077,7 +3077,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 {
 	MonoMethodHeader *header;
 	MonoMethodSignature *sig;
-	MonoError err;
+	ERROR_DECL (err);
 	MonoCompile *cfg;
 	int i;
 	gboolean try_generic_shared, try_llvm = FALSE;

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -2038,7 +2038,7 @@ static void
 assert_handled (MonoCompile *cfg, MonoMethod *method)
 {
 	MonoCustomAttrInfo *cattr;
-	MonoError error;
+	ERROR_DECL (error);
 
 	if (cfg->verbose_level > 1) {
 		cattr = mono_custom_attrs_from_method_checked (method, &error);

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -43,6 +43,10 @@ struct _MonoErrorBoxed {
 	MonoImage *image;
 };
 
+// Initial version for easier to read history.
+#define ERROR_DECL(name) \
+	MonoError name
+
 #define error_init(error) do {	\
 	((MonoErrorInternal*)(error))->error_code = MONO_ERROR_NONE;	\
 	((MonoErrorInternal*)(error))->flags = 0;	\

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -593,7 +593,7 @@ mono_error_set_not_verifiable (MonoError *oerror, MonoMethod *method, const char
 static MonoString*
 string_new_cleanup (MonoDomain *domain, const char *text)
 {
-	MonoError ignored_err;
+	ERROR_DECL (ignored_err);
 	MonoString *result = mono_string_new_checked (domain, text, &ignored_err);
 	mono_error_cleanup (&ignored_err);
 	return result;
@@ -831,7 +831,7 @@ The error object is cleant after.
 MonoException*
 mono_error_convert_to_exception (MonoError *target_error)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	MonoException *ex;
 
 	/* Mempool stored error shouldn't be cleaned up */
@@ -842,7 +842,7 @@ mono_error_convert_to_exception (MonoError *target_error)
 
 	ex = mono_error_prepare_exception (target_error, &error);
 	if (!mono_error_ok (&error)) {
-		MonoError second_chance;
+		ERROR_DECL (second_chance);
 		/*Try to produce the exception for the second error. FIXME maybe we should log about the original one*/
 		ex = mono_error_prepare_exception (&error, &second_chance);
 


### PR DESCRIPTION
Split up ERROR_DECL work into easier to read history.
This is two uninteresting pieces but the bulk of the diff.

1. Define ERROR_DECL to an initial form, that does not initialize.
2. Replace MonoError foo; with ERROR_DECL (foo); a large noisy diff.