### PR TITLE
[interp] fix build when interpreter is disabled

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -39,9 +39,7 @@
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/unlocked.h>
 
-#ifndef DISABLE_INTERPRETER
 #include "interp/interp.h"
-#endif
 
 #include "trace.h"
 #include "ir-emit.h"


### PR DESCRIPTION
```
mini-amd64.c:1103:36: error: incomplete definition of type 'struct _MonoInterpCallbacks'
                        gpointer ret_storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
                                               ~~~~~~~~~^
./mini-runtime.h:162:16: note: forward declaration of 'struct _MonoInterpCallbacks'
typedef struct _MonoInterpCallbacks MonoInterpCallbacks;
               ^
mini-amd64.c:1103:61: error: use of undeclared identifier 'MonoInterpFrameHandle'
                        gpointer ret_storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
                                                                                 ^
mini-amd64.c:1134:12: error: incomplete definition of type 'struct _MonoInterpCallbacks'
                interp_cb->frame_arg_to_data ((MonoInterpFrameHandle)frame, sig, i, storage);
                ~~~~~~~~~^
./mini-runtime.h:162:16: note: forward declaration of 'struct _MonoInterpCallbacks'
typedef struct _MonoInterpCallbacks MonoInterpCallbacks;
               ^
mini-amd64.c:1134:34: error: use of undeclared identifier 'MonoInterpFrameHandle'
                interp_cb->frame_arg_to_data ((MonoInterpFrameHandle)frame, sig, i, storage);
                                               ^
mini-amd64.c:1214:11: error: incomplete definition of type 'struct _MonoInterpCallbacks'
        interp_cb->data_to_frame_arg ((MonoInterpFrameHandle)frame, sig, -1, storage);
        ~~~~~~~~~^
./mini-runtime.h:162:16: note: forward declaration of 'struct _MonoInterpCallbacks'
typedef struct _MonoInterpCallbacks MonoInterpCallbacks;
               ^
mini-amd64.c:1214:33: error: use of undeclared identifier 'MonoInterpFrameHandle'
        interp_cb->data_to_frame_arg ((MonoInterpFrameHandle)frame, sig, -1, storage);
                                       ^
```