### PR TITLE
[System] Clear XDG_DATA_HOME and XDG_CONFIG_HOME in ApplicationSettingsBase tests

### DIFF
--- a/mcs/class/System/Test/System.Configuration/ApplicationSettingsBaseTest.cs
+++ b/mcs/class/System/Test/System.Configuration/ApplicationSettingsBaseTest.cs
@@ -184,6 +184,8 @@ namespace MonoTests.System.Configuration {
 		[TestFixtureTearDown]
 		public void FixtureTearDown ()
 		{
+			Environment.SetEnvironmentVariable ("XDG_DATA_HOME", null);
+			Environment.SetEnvironmentVariable ("XDG_CONFIG_HOME", null);
 			Directory.Delete (tempDir);
 		}
 


### PR DESCRIPTION
They were set in https://github.com/mono/mono/pull/6272 but since env vars are process wide we'd end up with non-existing paths once the tests are done. It is safer to unset the variables after the test.