### PR TITLE
[mini] factor out interp into a library

### DIFF
--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -280,7 +280,6 @@ DECL_OFFSET(SeqPointInfo, ss_tramp_addr)
 DECL_OFFSET(SeqPointInfo, bp_addrs)
 #endif
 
-#ifndef DISABLE_INTERPRETER
 DECL_OFFSET(InterpMethodArguments, ilen)
 DECL_OFFSET(InterpMethodArguments, iargs)
 DECL_OFFSET(InterpMethodArguments, flen)
@@ -292,7 +291,6 @@ DECL_OFFSET(CallContext, gregs)
 DECL_OFFSET(CallContext, fregs)
 DECL_OFFSET(CallContext, stack_size)
 DECL_OFFSET(CallContext, stack)
-#endif
 #endif
 
 #endif //DISABLE_JIT_OFFSETS

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -95,12 +95,12 @@ endif
 if SUPPORT_SGEN
 sgen_binaries = mono-sgen
 sgen_libraries = libmonosgen-2.0.la
-sgen_static_libraries = libmini-static.la $(sgen_static_libs)
+sgen_static_libraries = libmini-static.la $(interp_libs_static) $(sgen_static_libs)
 endif
 
 if SUPPORT_BOEHM
 boehm_libraries = libmonoboehm-2.0.la
-boehm_static_libraries = libmini-static.la $(boehm_static_libs)
+boehm_static_libraries = libmini-static.la $(interp_libs_static) $(boehm_static_libs)
 boehm_binaries  = mono-boehm
 endif
 
@@ -151,7 +151,7 @@ endif
 lib_LTLIBRARIES = $(shared_libraries)
 
 if SHARED_MONO
-mini_common_lib = libmini.la
+mini_common_lib = libmini.la $(interp_libs)
 else
 mini_common_lib = 
 endif
@@ -159,7 +159,7 @@ endif
 if DISABLE_EXECUTABLES
 noinst_LTLIBRARIES = $(mini_common_lib)
 else
-noinst_LTLIBRARIES = $(mini_common_lib) libmini-static.la
+noinst_LTLIBRARIES = $(mini_common_lib) libmini-static.la $(interp_libs_static)
 endif
 
 if LOADED_LLVM
@@ -387,10 +387,6 @@ llvm_sources = \
 endif
 endif
 
-if DISABLE_INTERPRETER
-interp_sources =	\
-	interp/interp.h
-else
 interp_sources =	\
 	interp/hacks.h		\
 	interp/interp.h	\
@@ -400,6 +396,13 @@ interp_sources =	\
 	interp/mintops.def	\
 	interp/mintops.c	\
 	interp/transform.c
+
+if DISABLE_INTERPRETER
+interp_libs =
+interp_libs_static =
+else
+interp_libs = libmono-ee-interp.la
+interp_libs_static = libmono-ee-interp-static.la
 endif
 
 if ENABLE_LLVM
@@ -485,6 +488,7 @@ common_sources = \
 	mini-profiler.c	\
 	interp-stubs.c \
 	aot-runtime.h	\
+	ee.h \
 	mini-runtime.h
 
 test_sources = 			\
@@ -642,17 +646,20 @@ libmonoldflags += $(JEMALLOC_LDFLAGS)
 mono_CFLAGS += $(JEMALLOC_CFLAGS)
 endif
 
-libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(interp_sources) $(arch_sources) $(os_sources)
+libmono_ee_interp_la_SOURCES = $(interp_sources)
+libmono_ee_interp_la_CFLAGS = $(mono_CFLAGS)
+
+libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(arch_sources) $(os_sources)
 libmini_la_CFLAGS = $(mono_CFLAGS)
 
 libmonoboehm_2_0_la_SOURCES =
 libmonoboehm_2_0_la_CFLAGS = $(mono_boehm_CFLAGS)
-libmonoboehm_2_0_la_LIBADD = libmini.la $(boehm_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
+libmonoboehm_2_0_la_LIBADD = libmini.la $(interp_libs) $(boehm_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
 libmonoboehm_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags)
 
 libmonosgen_2_0_la_SOURCES =
 libmonosgen_2_0_la_CFLAGS = $(mono_sgen_CFLAGS)
-libmonosgen_2_0_la_LIBADD = libmini.la $(sgen_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
+libmonosgen_2_0_la_LIBADD = libmini.la $(interp_libs) $(sgen_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
 libmonosgen_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags)
 
 #
@@ -663,6 +670,10 @@ libmini_static_la_SOURCES = $(libmini_la_SOURCES)
 libmini_static_la_CFLAGS = $(AM_CFLAGS)
 libmini_static_la_LDFLAGS = -static
 libmini_static_la_LIBADD = $(MONO_DTRACE_OBJECT)
+
+libmono_ee_interp_static_la_SOURCES = $(libmono_ee_interp_la_SOURCES)
+libmono_ee_interp_static_la_CFLAGS = $(AM_CFLAGS)
+libmono_ee_interp_static_la_LDFLAGS = -static
 
 libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1752,14 +1752,12 @@ apply_root_domain_configuration_file_bindings (MonoDomain *domain, char *root_do
 static void
 mono_enable_interp (const char *opts)
 {
-#ifndef DISABLE_INTERPRETER
 	mono_use_interpreter = TRUE;
 	if (opts)
-		mono_interp_parse_options (opts);
-#endif
+		mono_interp_opts_string = opts;
 
 #ifdef DISABLE_INTERPRETER
-	g_warning ("Mono IL interpreter support is missing\n");
+	g_error ("Mono IL interpreter support is missing\n");
 #endif
 
 #ifdef MONO_CROSS_COMPILE
@@ -2282,7 +2280,6 @@ mono_main (int argc, char* argv[])
 	case DO_SINGLE_METHOD_REGRESSION:
 		mono_do_single_method_regression = TRUE;
 	case DO_REGRESSION:
-#ifndef DISABLE_INTERPRETER
 		if (mono_use_interpreter) {
 			if (mono_interp_regression_list (2, argc -i, argv + i)) {
 				g_print ("Regression ERRORS!\n");
@@ -2292,7 +2289,6 @@ mono_main (int argc, char* argv[])
 			// mini_cleanup (domain);
 			return 0;
 		}
-#endif
 		if (mini_regression_list (mini_verbose, argc -i, argv + i)) {
 			g_print ("Regression ERRORS!\n");
 			mini_cleanup (domain);

--- a/mono/mini/ee.h
+++ b/mono/mini/ee.h
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+#include <config.h>
+#include <mono/metadata/metadata.h>
+#include <mono/metadata/object.h>
+#include <mono/utils/mono-compiler.h>
+#include <mono/utils/mono-error.h>
+#include <mono/utils/mono-publib.h>
+#include <mono/eglib/glib.h>
+
+#ifndef __MONO_EE_H__
+#define __MONO_EE_H__
+
+#define MONO_EE_API_VERSION 0x1
+
+typedef struct _MonoInterpStackIter MonoInterpStackIter;
+
+/* Needed for stack allocation */
+struct _MonoInterpStackIter {
+	gpointer dummy [8];
+};
+
+typedef gpointer MonoInterpFrameHandle;
+
+struct _MonoEECallbacks {
+	gpointer (*create_method_pointer) (MonoMethod *method, MonoError *error);
+	MonoObject* (*runtime_invoke) (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);
+	void (*init_delegate) (MonoDelegate *del);
+	gpointer (*get_remoting_invoke) (gpointer imethod, MonoError *error);
+	gpointer (*create_trampoline) (MonoDomain *domain, MonoMethod *method, MonoError *error);
+	void (*walk_stack_with_ctx) (MonoInternalStackWalk func, MonoContext *ctx, MonoUnwindOptions options, void *user_data);
+	void (*set_resume_state) (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExceptionInfo *ei, MonoInterpFrameHandle interp_frame, gpointer handler_ip);
+	gboolean (*run_finally) (StackFrameInfo *frame, int clause_index, gpointer handler_ip);
+	gboolean (*run_filter) (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip);
+	void (*frame_iter_init) (MonoInterpStackIter *iter, gpointer interp_exit_data);
+	gboolean (*frame_iter_next) (MonoInterpStackIter *iter, StackFrameInfo *frame);
+	MonoJitInfo* (*find_jit_info) (MonoDomain *domain, MonoMethod *method);
+	void (*set_breakpoint) (MonoJitInfo *jinfo, gpointer ip);
+	void (*clear_breakpoint) (MonoJitInfo *jinfo, gpointer ip);
+	MonoJitInfo* (*frame_get_jit_info) (MonoInterpFrameHandle frame);
+	gpointer (*frame_get_ip) (MonoInterpFrameHandle frame);
+	gpointer (*frame_get_arg) (MonoInterpFrameHandle frame, int pos);
+	gpointer (*frame_get_local) (MonoInterpFrameHandle frame, int pos);
+	gpointer (*frame_get_this) (MonoInterpFrameHandle frame);
+	void (*frame_arg_to_data) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data);
+	void (*data_to_frame_arg) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data);
+	gpointer (*frame_arg_to_storage) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index);
+	MonoInterpFrameHandle (*frame_get_parent) (MonoInterpFrameHandle frame);
+	void (*start_single_stepping) (void);
+	void (*stop_single_stepping) (void);
+};
+
+typedef struct _MonoEECallbacks MonoEECallbacks;
+
+#endif /* __MONO_EE_H__ */

--- a/mono/mini/interp-stubs.c
+++ b/mono/mini/interp-stubs.c
@@ -126,14 +126,12 @@ stub_init_delegate (MonoDelegate *del)
 	g_assert_not_reached ();
 }
 
-#ifndef DISABLE_REMOTING
 static gpointer
 stub_get_remoting_invoke (gpointer imethod, MonoError *error)
 {
 	g_assert_not_reached ();
 	return NULL;
 }
-#endif
 
 static gpointer
 stub_create_trampoline (MonoDomain *domain, MonoMethod *method, MonoError *error)
@@ -151,13 +149,15 @@ stub_walk_stack_with_ctx (MonoInternalStackWalk func, MonoContext *ctx, MonoUnwi
 void
 mono_interp_stub_init (void)
 {
-	MonoInterpCallbacks c;
+	if (mini_get_interp_callbacks ()->create_method_pointer)
+		/* already initialized */
+		return;
+
+	MonoEECallbacks c;
 	c.create_method_pointer = stub_create_method_pointer;
 	c.runtime_invoke = stub_runtime_invoke;
 	c.init_delegate = stub_init_delegate;
-#ifndef DISABLE_REMOTING
 	c.get_remoting_invoke = stub_get_remoting_invoke;
-#endif
 	c.create_trampoline = stub_create_trampoline;
 	c.walk_stack_with_ctx = stub_walk_stack_with_ctx;
 	c.set_resume_state = stub_set_resume_state;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -69,6 +69,7 @@
 #include <mono/mini/aot-runtime.h>
 #include <mono/mini/jit-icalls.h>
 #include <mono/mini/debugger-agent.h>
+#include <mono/mini/ee.h>
 
 #ifdef TARGET_ARM
 #include <mono/mini/mini-arm.h>
@@ -109,6 +110,8 @@ init_frame (InterpFrame *frame, InterpFrame *parent_frame, InterpMethod *rmethod
 GSList *jit_classes;
 /* If TRUE, interpreted code will be interrupted at function entry/backward branches */
 static gboolean ss_enabled;
+
+static gboolean interp_init_done = FALSE;
 
 static char* dump_frame (InterpFrame *inv);
 static MonoArray *get_trace_ips (MonoDomain *domain, InterpFrame *top);
@@ -267,10 +270,10 @@ lookup_imethod (MonoDomain *domain, MonoMethod *method)
 	return rtm;
 }
 
-#ifndef DISABLE_REMOTING
 static gpointer
 interp_get_remoting_invoke (gpointer imethod, MonoError *error)
 {
+#ifndef DISABLE_REMOTING
 	InterpMethod *imethod_cast = (InterpMethod*) imethod;
 
 	g_assert (mono_use_interpreter);
@@ -278,8 +281,11 @@ interp_get_remoting_invoke (gpointer imethod, MonoError *error)
 	MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke (imethod_cast->method, error);
 	return_val_if_nok (error, NULL);
 	return mono_interp_get_imethod (mono_domain_get (), remoting_invoke_method, error);
-}
+#else
+	g_assert_not_reached ();
+	return NULL;
 #endif
+}
 
 InterpMethod*
 mono_interp_get_imethod (MonoDomain *domain, MonoMethod *method, MonoError *error)
@@ -5292,10 +5298,13 @@ interp_exec_method (InterpFrame *frame, ThreadContext *context)
 	interp_exec_method_full (frame, context, NULL, NULL, -1, NULL);
 }
 
-void
-mono_interp_parse_options (const char *options)
+static void
+interp_parse_options (const char *options)
 {
 	char **args, **ptr;
+
+	if (!options)
+		return;
 
 	args = g_strsplit (options, ",", -1);
 	for (ptr = args; ptr && *ptr; ptr ++) {
@@ -5531,20 +5540,23 @@ interp_stop_single_stepping (void)
 }
 
 void
-mono_interp_init ()
+mono_ee_interp_init (const char *opts)
 {
+	g_assert (mono_ee_api_version () == MONO_EE_API_VERSION);
+	g_assert (!interp_init_done);
+	interp_init_done = TRUE;
+
 	mono_native_tls_alloc (&thread_context_id, NULL);
 	set_context (NULL);
 
+	interp_parse_options (opts);
 	mono_interp_transform_init ();
 
-	MonoInterpCallbacks c;
+	MonoEECallbacks c;
 	c.create_method_pointer = interp_create_method_pointer;
 	c.runtime_invoke = interp_runtime_invoke;
 	c.init_delegate = interp_init_delegate;
-#ifndef DISABLE_REMOTING
 	c.get_remoting_invoke = interp_get_remoting_invoke;
-#endif
 	c.create_trampoline = interp_create_trampoline;
 	c.walk_stack_with_ctx = interp_walk_stack_with_ctx;
 	c.set_resume_state = interp_set_resume_state;

--- a/mono/mini/interp/interp.h
+++ b/mono/mini/interp/interp.h
@@ -28,48 +28,10 @@ struct _InterpMethodArguments {
 
 typedef struct _InterpMethodArguments InterpMethodArguments;
 
-typedef struct _MonoInterpStackIter MonoInterpStackIter;
-
-/* Needed for stack allocation */
-struct _MonoInterpStackIter {
-	gpointer dummy [8];
-};
-
-typedef gpointer MonoInterpFrameHandle;
-
-
-struct _MonoInterpCallbacks {
-	gpointer (*create_method_pointer) (MonoMethod *method, MonoError *error);
-	MonoObject* (*runtime_invoke) (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);
-	void (*init_delegate) (MonoDelegate *del);
-#ifndef DISABLE_REMOTING
-	gpointer (*get_remoting_invoke) (gpointer imethod, MonoError *error);
-#endif
-	gpointer (*create_trampoline) (MonoDomain *domain, MonoMethod *method, MonoError *error);
-	void (*walk_stack_with_ctx) (MonoInternalStackWalk func, MonoContext *ctx, MonoUnwindOptions options, void *user_data);
-	void (*set_resume_state) (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExceptionInfo *ei, MonoInterpFrameHandle interp_frame, gpointer handler_ip);
-	gboolean (*run_finally) (StackFrameInfo *frame, int clause_index, gpointer handler_ip);
-	gboolean (*run_filter) (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip);
-	void (*frame_iter_init) (MonoInterpStackIter *iter, gpointer interp_exit_data);
-	gboolean (*frame_iter_next) (MonoInterpStackIter *iter, StackFrameInfo *frame);
-	MonoJitInfo* (*find_jit_info) (MonoDomain *domain, MonoMethod *method);
-	void (*set_breakpoint) (MonoJitInfo *jinfo, gpointer ip);
-	void (*clear_breakpoint) (MonoJitInfo *jinfo, gpointer ip);
-	MonoJitInfo* (*frame_get_jit_info) (MonoInterpFrameHandle frame);
-	gpointer (*frame_get_ip) (MonoInterpFrameHandle frame);
-	gpointer (*frame_get_arg) (MonoInterpFrameHandle frame, int pos);
-	gpointer (*frame_get_local) (MonoInterpFrameHandle frame, int pos);
-	gpointer (*frame_get_this) (MonoInterpFrameHandle frame);
-	void (*frame_arg_to_data) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data);
-	void (*data_to_frame_arg) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index, gpointer data);
-	gpointer (*frame_arg_to_storage) (MonoInterpFrameHandle frame, MonoMethodSignature *sig, int index);
-	MonoInterpFrameHandle (*frame_get_parent) (MonoInterpFrameHandle frame);
-	void (*start_single_stepping) (void);
-	void (*stop_single_stepping) (void);
-};
-
-void mono_interp_parse_options (const char *options);
-
-void mono_interp_init (void);
+/* must be called either
+ *  - by mini_init ()
+ *  - xor, before mini_init () is called (embedding scenario).
+ */
+MONO_API void mono_ee_interp_init (const char *);
 
 #endif /* __MONO_MINI_INTERPRETER_H__ */

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1090,7 +1090,7 @@ void
 mono_arch_set_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
 	CallInfo *cinfo = get_call_info (NULL, sig);
-	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 
 	memset (ccontext, 0, sizeof (CallContext));
 
@@ -1159,7 +1159,7 @@ mono_arch_set_native_call_context (CallContext *ccontext, gpointer frame, MonoMe
 void
 mono_arch_get_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo;
 
 	/* No return value */

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1617,7 +1617,7 @@ void
 mono_arch_set_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
 	CallInfo *cinfo = get_call_info (NULL, sig);
-	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 
 	memset (ccontext, 0, sizeof (CallContext));
 
@@ -1678,7 +1678,7 @@ mono_arch_set_native_call_context (CallContext *ccontext, gpointer frame, MonoMe
 void
 mono_arch_get_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo;
 
 	/* No return value */

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1376,7 +1376,7 @@ void
 mono_arch_set_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
 	CallInfo *cinfo = get_call_info (NULL, sig);
-	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 
 	memset (ccontext, 0, sizeof (CallContext));
 
@@ -1445,7 +1445,7 @@ mono_arch_set_native_call_context (CallContext *ccontext, gpointer frame, MonoMe
 void
 mono_arch_get_native_call_context (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	MonoInterpCallbacks *interp_cb = mini_get_interp_callbacks ();
+	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo;
 
 	/* No return value */

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -13,6 +13,7 @@
 #define __MONO_MINI_RUNTIME_H__
 
 #include "mini.h"
+#include "ee.h"
 
 /* Per-domain information maintained by the JIT */
 typedef struct
@@ -158,12 +159,9 @@ MONO_API void        mono_set_defaults              (int verbose_level, guint32 
 MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_argv []);
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);
 
-/* actual definition in interp.h */
-typedef struct _MonoInterpCallbacks MonoInterpCallbacks;
-
 void                   mono_interp_stub_init         (void);
-void                   mini_install_interp_callbacks (MonoInterpCallbacks *cbs);
-MonoInterpCallbacks*   mini_get_interp_callbacks     (void);
+void                   mini_install_interp_callbacks (MonoEECallbacks *cbs);
+MonoEECallbacks*       mini_get_interp_callbacks     (void);
 
 MonoDomain* mini_init                      (const char *filename, const char *runtime_version);
 void        mini_cleanup                   (MonoDomain *domain);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -331,6 +331,7 @@ extern gboolean mono_do_signal_chaining;
 extern gboolean mono_do_crash_chaining;
 extern MONO_API gboolean mono_use_llvm;
 extern MONO_API gboolean mono_use_interpreter;
+extern const char* mono_interp_opts_string;
 extern gboolean mono_do_single_method_regression;
 extern guint32 mono_single_method_regression_opt;
 extern MonoMethod *mono_current_single_method;
@@ -2111,6 +2112,7 @@ void      mono_print_bb                     (MonoBasicBlock *bb, const char *msg
 void      mono_print_code                   (MonoCompile *cfg, const char *msg);
 MONO_API void      mono_print_method_from_ip         (void *ip);
 MONO_API char     *mono_pmip                         (void *ip);
+MONO_API int mono_ee_api_version (void);
 gboolean  mono_debug_count                  (void);
 MONO_LLVM_INTERNAL const char* mono_inst_name                  (int op);
 int       mono_op_to_op_imm                 (int opcode);

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -34,6 +34,13 @@ sgen_libs = \
 	$(monodir)/mono/utils/libmonoutils.la \
 	$(GLIB_LIBS) $(LIBICONV)
 
+mini_libs = \
+	$(monodir)/mono/mini/libmini.la
+
+if !DISABLE_INTERPRETER
+mini_libs += $(monodir)/mono/mini/libmono-ee-interp.la
+endif
+
 if !CROSS_COMPILE
 if !HOST_WIN32
 if SUPPORT_BOEHM
@@ -70,13 +77,13 @@ test_mono_handle_LDFLAGS = $(test_ldflags)
 
 test_mono_callspec_SOURCES = test-mono-callspec.c
 test_mono_callspec_CFLAGS = $(AM_CFLAGS)
-test_mono_callspec_LDADD = $(test_ldadd) ../mini/libmini.la $(sgen_libs)
+test_mono_callspec_LDADD = $(test_ldadd) $(mini_libs) $(sgen_libs)
 test_mono_callspec_LDFLAGS = $(test_ldflags)
 test_mono_callspec_DEPENDENCIES = callspec.exe
 
 test_mono_string_SOURCES = test-mono-string.c
 test_mono_string_CFLAGS = $(test-cflags)
-test_mono_string_LDADD = $(test_ldadd) ../mini/libmini.la $(sgen_libs)
+test_mono_string_LDADD = $(test_ldadd) $(mini_libs) $(sgen_libs)
 test_mono_string_LDFLAGS = $(test_ldflags)
 
 check_PROGRAMS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle	\


### PR DESCRIPTION
_EDIT: outdated PR message, have a look at commit messages for details._

It enables us to ship the interp as an add-on to the runtime.

Usage:

configure mono without the interpreter, such as:

```
$ ./autogen.sh --enable-minimal=interpreter ...
$ make; make install
```

run your favorite program with the interpreter and see it fail:

```
$ ./mono/mini/mono-sgen --interpreter ./mono/mini/basic.exe
Could not load symbol: dlsym(RTLD_DEFAULT, mono_ee_interp_version): symbol not found
Mono IL interpreter support is missing
```

despite `--enable-minimal=interpreter`, we can still build the interp
module:

```
% make -C mono/mini libmono-ee-interp-static.la
  CC       interp/libmono_ee_interp_static_la-interp.lo
  CC       interp/libmono_ee_interp_static_la-mintops.lo
  CC       interp/libmono_ee_interp_static_la-transform.lo
  CCLD     libmono-ee-interp-static.la
```

and now can be statically linked into `mono-sgen-with-interp`:

```
(cd mono/mini && gcc -I../.. -I../../mono/eglib -I../../mono/eglib -fvisibility=hidden -O0 -g -std=gnu99 -fno-strict-aliasing -fwrapv \
-DMONO_DLL_EXPORT -g -Wall -Wunused -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wmissing-prototypes \
-Wnested-externs -Wpointer-arith -Wno-cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes \
-Wno-format-zero-length -Qunused-arguments -Wno-unused-function -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign \
-Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array -Werror-implicit-function-declaration
-o mono-sgen-with-interp mono_sgen-main-sgen.o  -framework CoreFoundation -framework Foundation \
-force_load ./.libs/libmono-ee-interp-static.a \
./.libs/libmini-static.a ../../mono/metadata/.libs/libmonoruntimesgen-static.a \
../../mono/sgen/.libs/libmonosgen-static.a ../../mono/utils/.libs/libmonoutils.a \
../../mono/eglib/.libs/libeglib.a -lm -liconv -lpthread)
```

and now you can run it again:

```
./mono/mini/mono-sgen-with-interp --interpreter ./mono/mini/basic.exe
Cannot open assembly './mono/mini/basic.exe': No such file or directory.
* Assertion: should not be reached at tramp-amd64.c:1022

Stacktrace:

  at <unknown> <0xffffffff>
  at System.Collections.Generic.EqualityComparer`1<string>.CreateComparer () <0x00006>
  at System.Collections.Generic.EqualityComparer`1<string>.get_Default () <0x0000e>
  at System.Collections.Generic.Dictionary`2<string, System.LocalDataStoreSlot>..ctor (int,System.Collections.Generic.IEqualityComparer`1<string>) <0x0005e>
  at System.Collections.Generic.Dictionary`2<string, System.LocalDataStoreSlot>..ctor () <0x0000c>
  at System.LocalDataStoreMgr..ctor () <0x00026>
  at System.Runtime.Remoting.Contexts.Context..cctor () <0x00000>
  at (wrapper runtime-invoke) object.runtime_invoke_direct_void (object,intptr,intptr,intptr) <0x00034>

Native stacktrace:

        0   mono-sgen-with-interp               0x000000010e0ea333 mono_handle_native_crash + 291
        1   mono-sgen-with-interp               0x000000010e1eeff0 sigabrt_signal_handler + 160
        2   libsystem_platform.dylib            0x00007fff63fcef5a _sigtramp + 26
        3   ???                                 0x0000000117fc7648 0x0 + 4697388616
        4   libsystem_c.dylib                   0x00007fff63df9312 abort + 127
        5   mono-sgen-with-interp               0x000000010e4449a4 mono_log_write_logfile + 420
        6   mono-sgen-with-interp               0x000000010e43a90c structured_log_adapter + 60
        7   mono-sgen-with-interp               0x000000010e469d7d monoeg_g_logv + 109
        8   mono-sgen-with-interp               0x000000010e46a174 monoeg_assertion_message + 356
        9   mono-sgen-with-interp               0x000000010e1e8366 mono_arch_get_interp_to_native_trampoline + 38
        10  mono-sgen-with-interp               0x000000010df98b73 ves_pinvoke_method + 195
        11  mono-sgen-with-interp               0x000000010df830f5 interp_exec_method_full + 5429
        12  mono-sgen-with-interp               0x000000010df81bb2 interp_exec_method + 50
```

Now it crashes because it can't emit the required trampolines. For our use case
(iOS) we static link those trampolines as it's a non-JIT environment.

/cc @spouliot @rolfbjarne 
  