### PR TITLE
Implement a couple of SocketAsyncEventArgs methods

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
@@ -249,12 +249,18 @@ namespace System.Net.Sockets
 
 		internal void FinishConnectByNameSyncFailure (Exception exception, int bytesTransferred, SocketFlags flags)
 		{
-			throw new NotImplementedException ();
+			if (current_socket != null)
+				current_socket.is_connected = false;
+			
+			Complete ();
 		}
 
 		internal void FinishOperationAsyncFailure (Exception exception, int bytesTransferred, SocketFlags flags)
 		{
-			throw new NotImplementedException ();
+			if (current_socket != null)
+				current_socket.is_connected = false;
+			
+			Complete ();
 		}
 
 		internal void FinishWrapperConnectSuccess (Socket connectSocket, int bytesTransferred, SocketFlags flags)


### PR DESCRIPTION
This does the work that currently was left as a `NotImplementedException`.

The Reference Source code does many other things that are tied up to their implementation, Mono's implementation is different enough that none of those seem to make sense.

There is one feature there that we do not handle, and it is not clear to me if we should implement it.   They support delayed Socket Disposing and a number of other features that Mono's Socket does not:

https://github.com/mono/referencesource/blob/mono/System/net/System/Net/Sockets/Socket.cs#L6151

This is an area that has been significantly been cleaned up in .NET Core and looks a lot nicer to port and reuse than what exists in Reference Source.

This should address:
* https://github.com/mono/mono/issues/6428
* https://bugzilla.xamarin.com/show_bug.cgi?id=60772
* https://github.com/kerryjiang/WebSocket4Net/issues/108

Sadly, it is not easy to write a test case for this, this relies on a network error being raised, which explains why we committed the code without this core functionality in the first place.