### PR TITLE
[centrinel] Suppress warning about body of mono_internal_thread_handle_ptr

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1477,7 +1477,11 @@ typedef struct {
 static inline MonoInternalThread*
 mono_internal_thread_handle_ptr (MonoInternalThreadHandle h)
 {
-	return MONO_HANDLE_RAW (h); /* Safe */
+	/* The SUPPRESS here prevents a Centrinel warning due to merely seeing this
+	 * function definition.  Callees will still get a warning unless we
+	 * attach a suppress attribute to the declaration.
+	 */
+	return MONO_HANDLE_SUPPRESS (MONO_HANDLE_RAW (h));
 }
 
 gboolean          mono_image_create_pefile (MonoReflectionModuleBuilder *module, gpointer file, MonoError *error);


### PR DESCRIPTION

Since object-internals.h is included in a ton of places, we get one Centrinel warning
about mono_internal_thread_handle_ptr per translation unit every time the
header is included which is ridiculously noisy.

This commit will suppress the warning about the body of this function.

Note that uses of the function will still get a warning since it returns a
MonoInternalThread* and we haven't yet taught Centrinel that those calls are ok since
the thread object is pinned.