### PR TITLE
In MonoError, provide a uint32_t for initialization with

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6275,7 +6275,7 @@ mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod 
 	guint32 cols [MONO_METHODIMPL_SIZE];
 	MonoMethod **result;
 	
-	error_init (error)
+	error_init (error);
 
 	*overrides = NULL;
 	if (num_overrides)

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -47,10 +47,7 @@ struct _MonoErrorBoxed {
 #define ERROR_DECL(name) \
 	MonoError name
 
-#define error_init(error) do {	\
-	((MonoErrorInternal*)(error))->error_code = MONO_ERROR_NONE;	\
-	((MonoErrorInternal*)(error))->flags = 0;	\
-} while (0);
+#define error_init(error) ((void)((error)->init = 0))
 
 #define is_ok(error) ((error)->error_code == MONO_ERROR_NONE)
 

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -49,11 +49,15 @@ enum {
 };
 
 /*Keep in sync with MonoErrorInternal*/
-typedef struct _MonoError {
-	unsigned short error_code;
-    unsigned short hidden_0; /*DON'T TOUCH */
-
-	void *hidden_1 [12]; /*DON'T TOUCH */
+typedef union _MonoError {
+	// Merge two uint16 into one uint32 so it can be initialized
+	// with one instruction instead of two.
+	uint32_t init;
+	struct {
+		uint16_t error_code;
+		uint16_t private_flags; /*DON'T TOUCH */
+		void *hidden_1 [12]; /*DON'T TOUCH */
+	};
 } MonoError;
 
 /* Mempool-allocated MonoError.*/


### PR DESCRIPTION
just one instruction instead of two (at least it makes
a difference on the Apple arm32 target).

Also favor expressions over statements.
Also avoid casts where easy, to avoid passing random incorrect types.
  
  