### PR TITLE
Reduce use of mono_marshal_string_to_utf16 which appears no longer needed. 

### DIFF
--- a/mono/metadata/icall-windows.c
+++ b/mono/metadata/icall-windows.c
@@ -159,19 +159,15 @@ mono_icall_set_environment_variable (MonoString *name, MonoString *value)
 {
 	gunichar2 *utf16_name, *utf16_value;
 
-	utf16_name = mono_string_to_utf16 (name);
+	utf16_name = name ? mono_string_chars (name) : NULL;
 	if ((value == NULL) || (mono_string_length (value) == 0) || (mono_string_chars (value)[0] == 0)) {
 		SetEnvironmentVariable (utf16_name, NULL);
-		g_free (utf16_name);
 		return;
 	}
 
-	utf16_value = mono_string_to_utf16 (value);
+	utf16_value = mono_string_chars (value);
 
 	SetEnvironmentVariable (utf16_name, utf16_value);
-
-	g_free (utf16_name);
-	g_free (utf16_value);
 }
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)


### PR DESCRIPTION
It remains only for register_icall.

Remove casts from void* to HANDLE, as HANDLE always and forever
will also be void*.

Add comments explaining the valid use of INVALID_HANDLE_VALUE (-1).
With CreateFileMapping, for the file handle, it means to
use physical memory / pagefile.
  