### PR TITLE
[exception] propagate stackoverflow exception to managed code

### DIFF
--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -80,6 +80,7 @@ struct MonoJitTlsData {
 	gpointer         stack_ovf_guard_base;
 	guint32          stack_ovf_guard_size;
 	guint            stack_ovf_valloced : 1;
+	guint            stack_ovf_pending : 1;
 	void            (*abort_func) (MonoObject *object);
 	/* Used to implement --debug=casts */
 	MonoClass       *class_cast_from, *class_cast_to;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -536,10 +536,18 @@ TESTS_CS_SRC=		\
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs
+if !HOST_WIN32
+# requires working altstack
+TESTS_CS_SRC += bug-60862.cs
+endif
 endif
 
 if X86
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs
+if !HOST_WIN32
+# requires working altstack
+TESTS_CS_SRC += bug-60862.cs
+endif
 endif
 
 TESTS_IL_SRC=			\
@@ -993,6 +1001,7 @@ DISABLED_TESTS = \
 #                exit code 0, but doesn't actually execute the test.
 # block_guard_restore_aligment_on_exit.exe: flaky (10% of the time it hangs and thus times out)
 # weak-fields.exe: https://bugzilla.xamarin.com/show_bug.cgi?id=60973
+# bug-60862.exe: missing support to map IP->method; only works on platforms with altstack support.
 INTERP_DISABLED_TESTS = \
 	$(KNOWN_FAILING_TESTS) \
 	$(INTERP_PLATFORM_DISABLED_TESTS) \
@@ -1011,6 +1020,7 @@ INTERP_DISABLED_TESTS = \
 	bug-58782-capture-and-throw.exe \
 	bug-58782-plain-throw.exe \
 	bug445361.exe \
+	bug-60862.exe \
 	calliGenericTest.exe \
 	cominterop.exe \
 	context-static.exe \

--- a/mono/tests/bug-60862.cs
+++ b/mono/tests/bug-60862.cs
@@ -1,0 +1,54 @@
+/* https://bugzilla.xamarin.com/show_bug.cgi?id=60862 */
+using System;
+using System.Threading;
+
+namespace StackOverflowTest
+{
+	class Program
+	{
+		static bool fault = false;
+		static Exception ex = null;
+
+		public static int Main(string[] args)
+		{
+			Thread t = new Thread (Run);
+			t.Start ();
+			t.Join ();
+			if (fault) {
+				if (ex == null) {
+					Console.WriteLine ("fault occured, but no exception object available");
+					return 1;
+				} else {
+					bool is_stackoverlfow = ex is StackOverflowException;
+					Console.WriteLine ("fault occured: ex = " + is_stackoverlfow);
+					return is_stackoverlfow ? 0 : 3;
+				}
+			}
+			Console.WriteLine("no fault");
+			return 2;
+		}
+
+	  static void Run()
+	  {
+		  try {
+			  Execute ();
+		  } catch(Exception e) {
+			  ex = e;
+			  fault = true;
+		  }
+	  }
+
+	  static void Execute ()
+	  {
+		  WaitOne ();
+	  }
+
+	  static bool WaitOne (bool killProcessOnInterrupt = false, bool throwOnInterrupt = false)
+	  {
+		  try {
+			  return WaitOne();
+		  } catch(ThreadInterruptedException e) { }
+		  return false;
+	  }
+  }
+}


### PR DESCRIPTION
we return the address of the StackOverflowException object in
`restore_soft_guard_pages`, so it ends up in the architecture specific
result register (e.g. %rax) where the exception handler expects it.

fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60862